### PR TITLE
DOS: Properly set modify time on written files

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 316
+            max_warnings: 317
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2035
+            max_warnings: 2036
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -116,6 +116,7 @@ bool DOS_FlushFile(Bit16u handle);
 bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry);
 bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry);
 bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate);
+bool DOS_SetFileDate(Bit16u entry, Bit16u ntime, Bit16u ndate);
 
 /* Routines for Drive Class */
 bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb = false);

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -64,6 +64,7 @@ public:
 	          refCtr(0),
 	          open(false),
 	          name(""),
+	          newtime(false),
 	          hdrive(0xff)
 	{}
 
@@ -102,7 +103,8 @@ public:
 	Bits refCtr;
 	bool open;
 	std::string name;
-/* Some Device Specific Stuff */
+	bool newtime;
+	/* Some Device Specific Stuff */
 private:
 	Bit8u hdrive;
 };
@@ -140,19 +142,21 @@ private:
 
 class localFile : public DOS_File {
 public:
-	localFile(const char *name, FILE *handle);
-	localFile(const localFile &) = delete;            // prevent copying
-	localFile &operator=(const localFile &) = delete; // prevent assignment
-	bool Read(uint8_t *data, uint16_t *size);
-	bool Write(uint8_t *data, uint16_t *size);
-	bool Seek(uint32_t *pos, uint32_t type);
-	bool Close();
-	uint16_t GetInformation();
-	bool UpdateDateTimeFromHost();
-	void Flush();
-	void SetFlagReadOnlyMedium() { read_only_medium = true; }
+	localFile				(const char *name, FILE *handle, const char *basedir);
+	localFile				(const localFile &) = delete;            // prevent copying
+	localFile &operator=	(const localFile &) = delete; // prevent assignment
+	bool					Read(uint8_t *data, uint16_t *size);
+	bool					Write(uint8_t *data, uint16_t *size);
+	bool					Seek(uint32_t *pos, uint32_t type);
+	bool					Close();
+	uint16_t				GetInformation();
+	bool					UpdateDateTimeFromHost();
+	void					Flush();
+	void					SetFlagReadOnlyMedium() { read_only_medium = true; }
+	const char				*GetBaseDir() const { return basedir; }
 	FILE *fhandle = nullptr; // todo handle this properly
 private:
+	const char *basedir;
 	long stream_pos = 0;
 	bool ftell_and_check();
 	void fseek_and_check(int whence);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -879,8 +879,12 @@ static Bitu DOS_21Handler(void) {
 				CALLBACK_SCF(true);
 			}
 		} else if (reg_al==0x01) {
-			LOG(LOG_DOSMISC,LOG_ERROR)("DOS:57:Set File Date Time Faked");
-			CALLBACK_SCF(false);		
+			/* FIXME: verify if AX needs to be updated here */
+			if (DOS_SetFileDate(reg_bx, reg_cx, reg_dx)) {
+				CALLBACK_SCF(false);
+			} else {
+				CALLBACK_SCF(true);
+			}
 		} else {
 			LOG(LOG_DOSMISC,LOG_ERROR)("DOS:57:Unsupported subtion %X",reg_al);
 		}

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1334,6 +1334,23 @@ bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate) {
 	return true;
 }
 
+bool DOS_SetFileDate(Bit16u entry, Bit16u ntime, Bit16u ndate) {
+	Bit32u handle = RealHandle(entry);
+	if (handle >= DOS_FILES) {
+		DOS_SetError(DOSERR_INVALID_HANDLE);
+		return false;
+	};
+	if (!Files[handle]) {
+		DOS_SetError(DOSERR_INVALID_HANDLE);
+		return false;
+	};
+	Files[handle]->time = ntime;
+	Files[handle]->date = ndate;
+	Files[handle]->newtime = true;
+
+	return true;
+}
+
 void DOS_SetupFiles (void) {
 	/* Setup the File Handles */
 	Bit32u i;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -28,6 +28,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <sys/types.h>
+#ifdef _MSC_VER
+#include <sys/utime.h>
+#else
+#include <utime.h>
+#endif
 
 #include "dos_inc.h"
 #include "dos_mscdex.h"
@@ -60,7 +66,7 @@ bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/)
    
 	if (!existing_file) dirCache.AddEntry(newname, true);
 	/* Make the 16 bit device information */
-	*file=new localFile(name,hand);
+	*file = new localFile(name, hand, basedir);
 	(*file)->flags=OPEN_READWRITE;
 
 	return true;
@@ -179,7 +185,7 @@ bool localDrive::FileOpen(DOS_File **file, char *name, Bit32u flags)
 #endif
 
 	if (fhandle) {
-		*file = new localFile(name, fhandle);
+		*file = new localFile(name, fhandle, basedir);
 		(*file)->flags = flags;  // for the inheritance flag and maybe check for others.
 	} else {
 		// Otherwise we really can't open the file.
@@ -669,6 +675,34 @@ bool localFile::Close() {
 		fhandle = 0;
 		open = false;
 	};
+
+	if (newtime) {
+		// backport from DOS_PackDate() and DOS_PackTime()
+		tm tim = { 0 };
+		tim.tm_sec = (time & 0x1f) * 2;
+		tim.tm_min = (time >> 5) & 0x3f;
+		tim.tm_hour = (time >> 11) & 0x1f;
+		tim.tm_mday = date & 0x1f;
+		tim.tm_mon = ((date >> 5) & 0x0f) - 1;
+		tim.tm_year = (date >> 9) + 1980 - 1900;
+		//  have the C run-time library code compute whether standard time or daylight saving time is in effect.
+		tim.tm_isdst = -1;
+		// serialize time
+		mktime(&tim);
+
+		utimbuf ftim;
+		ftim.actime = ftim.modtime = mktime(&tim);
+
+		char fullname[CROSS_LEN];
+		snprintf(fullname, sizeof(fullname), "%s%s", basedir, name.c_str());
+		CROSS_FILENAME(fullname);
+
+		// FIXME: utime is deprecated, need a modern cross-platform implementation.
+		if (utime(fullname, &ftim)) {
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -677,8 +711,9 @@ Bit16u localFile::GetInformation(void) {
 }
 	
 
-localFile::localFile(const char* _name, FILE * handle)
+localFile::localFile(const char *_name, FILE *handle, const char *_basedir)
 	: fhandle(handle),
+	  basedir(_basedir),
 	  read_only_medium(false),
 	  last_action(NONE)
 {

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -199,8 +199,8 @@ bool Overlay_Drive::TestDir(char * dir) {
 
 class OverlayFile : public localFile {
 public:
-	OverlayFile(const char *name, FILE *handle)
-	        : localFile(name, handle),
+	OverlayFile(const char *name, FILE *handle, const char *basedir)
+	        : localFile(name, handle,basedir),
 	          overlay_active(false)
 	{
 		if (logoverlay)
@@ -300,7 +300,7 @@ static OverlayFile* ccc(DOS_File* file) {
 	localFile* l = dynamic_cast<localFile*>(file);
 	if (!l) E_Exit("overlay input file is not a localFile");
 	//Create an overlayFile
-	OverlayFile* ret = new OverlayFile(l->GetName(),l->fhandle);
+	OverlayFile* ret = new OverlayFile(l->GetName(),l->fhandle,l->GetBaseDir());
 	ret->flags = l->flags;
 	ret->refCtr = l->refCtr;
 	delete l;
@@ -451,7 +451,7 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 	bool fileopened = false;
 	if (hand) {
 		if (logoverlay) LOG_MSG("overlay file opened %s",newname);
-		*file=new localFile(name,hand);
+		*file=new localFile(name,hand,overlaydir);
 		(*file)->flags=flags;
 		fileopened = true;
 	} else {
@@ -489,7 +489,7 @@ bool Overlay_Drive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes
 		if (logoverlay) LOG_MSG("File creation in overlay system failed %s",name);
 		return false;
 	}
-	*file = new localFile(name,f);
+	*file = new localFile(name,f,overlaydir);
 	(*file)->flags = OPEN_READWRITE;
 	OverlayFile* of = ccc(*file);
 	of->overlay_active = true;
@@ -497,7 +497,7 @@ bool Overlay_Drive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes
 	*file = of;
 	//create fake name for the drive cache
 	char fakename[CROSS_LEN];
-	safe_strcpy(fakename, basedir);
+	safe_strcpy(fakename, overlaydir);
 	safe_strcat(fakename, name);
 	CROSS_FILENAME(fakename);
 	dirCache.AddEntry(fakename,true); //add it.

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1055,6 +1055,14 @@ void DOS_Shell::CMD_COPY(char * args) {
 								DOS_ReadFile(sourceHandle, buffer, &toread);
 								DOS_WriteFile(targetHandle, buffer, &toread);
 							} while (toread == 0x8000);
+							if (!oldsource.concat) {
+								DOS_GetFileDate(sourceHandle,
+								                &time,
+								                &date);
+								DOS_SetFileDate(targetHandle,
+								                time,
+								                date);
+							}
 							DOS_CloseFile(sourceHandle);
 							DOS_CloseFile(targetHandle);
 							WriteOut(" %s\n",name);


### PR DESCRIPTION
* Implemented the missing part of DOS function 57h which sets modify time on a file. Previously, it was a stub.
* Made "copy" command copy over file modify time as well.

This should fix some install programs which check file modify dates.
Code mostly taken from this patch by gulikoza: https://www.vogons.org/viewtopic.php?t=22600