### PR TITLE
DOSBox-X backport cursor range tweaks for some DOS games

### DIFF
--- a/git-commit-version.pl
+++ b/git-commit-version.pl
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use File::Basename qw<dirname>;
+
+$branch = `git branch | grep '^\*' | sed -e 's/^\* //'`; chomp $branch;
+die if $branch eq "";
+
+if (!open(S,"git --no-pager log --max-count=1 |")) { exit 1; }
+my $lcommit = "x";
+my $i,$lcdate = "unknown";
+foreach my $line (<S>) {
+	chomp $line;
+
+	if ($line =~ m/^commit +/) {
+		$lcommit = lc($');
+		$lcommit =~ s/ +$//;
+	}
+	else {
+		my @nv = split(/: +/,$line);
+		my $value = $nv[1];
+		my $name = $nv[0];
+
+		if ($name =~ m/^Date$/i) {
+			# Fri Apr 15 08:51:32 2011 -0700
+			#  0   1   2  3        4     5
+			my @b = split(/ +/,$value);
+
+			$mon = lc($b[1]);
+			$day = $b[2];
+			$time = $b[3];
+			$year = $b[4];
+			$mon = 1 if $mon eq "jan";
+			$mon = 2 if $mon eq "feb";
+			$mon = 3 if $mon eq "mar";
+			$mon = 4 if $mon eq "apr";
+			$mon = 5 if $mon eq "may";
+			$mon = 6 if $mon eq "jun";
+			$mon = 7 if $mon eq "jul";
+			$mon = 8 if $mon eq "aug";
+			$mon = 9 if $mon eq "sep";
+			$mon = 10 if $mon eq "oct";
+			$mon = 11 if $mon eq "nov";
+			$mon = 12 if $mon eq "dec";
+			$mon = $mon+0;
+			$date = sprintf("%04u%02u%02u",$year+0,$mon,$day+0);
+			$time =~ s/://g;
+			$lcdate = $date."-".$time;
+		}
+	}
+}
+close(S);
+
+print "$lcdate-$lcommit-$branch\n";
+

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -468,13 +468,15 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
 	if((fabs(yrel) > 1.0) || (mouse.senv_y < 1.0)) dy *= mouse.senv_y;
 	if (useps2callback) dy *= 2;	
 
-	mouse.mickey_x += (dx * mouse.mickeysPerPixel_x);
-	mouse.mickey_y += (dy * mouse.mickeysPerPixel_y);
-	if (mouse.mickey_x >= 32768.0) mouse.mickey_x -= 65536.0;
-	else if (mouse.mickey_x <= -32769.0) mouse.mickey_x += 65536.0;
-	if (mouse.mickey_y >= 32768.0) mouse.mickey_y -= 65536.0;
-	else if (mouse.mickey_y <= -32769.0) mouse.mickey_y += 65536.0;
 	if (emulate) {
+		/* Send relative motion only if captured, else there is no point */
+		mouse.mickey_x += (dx * mouse.mickeysPerPixel_x);
+		mouse.mickey_y += (dy * mouse.mickeysPerPixel_y);
+		if (mouse.mickey_x >= 32768.0) mouse.mickey_x -= 65536.0;
+		else if (mouse.mickey_x <= -32769.0) mouse.mickey_x += 65536.0;
+		if (mouse.mickey_y >= 32768.0) mouse.mickey_y -= 65536.0;
+		else if (mouse.mickey_y <= -32769.0) mouse.mickey_y += 65536.0;
+
 		mouse.x += dx;
 		mouse.y += dy;
 	} else {

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -854,14 +854,6 @@ static Bitu INT33_Handler(void) {
 			mouse.y = (mouse.max_y - mouse.min_y + 1)/2;*/
 			LOG(LOG_MOUSE,LOG_NORMAL)("Define Vertical range min:%d max:%d",min,max);
 
-			/* NTS: The mouse in VESA BIOS modes would ideally start with the x and y ranges
-			 *      that fit the screen, but I'm not so sure mouse drivers even pay attention
-			 *      to VESA BIOS modes so it's not certain what comes out. However some
-			 *      demoscene productions like "Aqua" will set their own mouse range and draw
-			 *      their own cursor. The menu in "Aqua" will set up 640x480 256-color mode
-			 *      and then set a mouse range of x=0-1279 and y=0-479. Using the FIRST range
-			 *      set after mode set is the only way to make sure mouse pointer integration
-			 *      tracks the guest pointer properly. */
 			if (mouse.buttons == 0) {
 				if (mouse.min_y == 0 && mouse.max_y > 0) {
 					// most games redefine the range so they can use a saner range matching the screen


### PR DESCRIPTION
This adds separate screen maximum tracking from the min/max given by the DOS game. The screen max can differ from the INT 33h max if it is close enough to the screen width/height or close enough to the screen width/height times 2.

This allows the cursor to map properly in games like Daggerfall that set the maximum about 8-10 pixels less than the screen width/height.

Some DOSBox-X conditionals, such as "first set" have been omitted from this patch since they don't seem to be necessary for this staging branch.