### PR TITLE
Resizable window support (part 1/2+) - necessary fixes+cleanup

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -18,6 +18,9 @@
 
 #ifndef DOSBOX_LOGGING_H
 #define DOSBOX_LOGGING_H
+
+#include <cstdio>
+
 enum LOG_TYPES {
 	LOG_ALL,
 	LOG_VGA, LOG_VGAGFX,LOG_VGAMISC,LOG_INT10,
@@ -86,5 +89,14 @@ void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1,
 
 #endif //C_DEBUG
 
+#ifdef DEBUG
+#define DEBUG_LOG_MSG(...)                                                     \
+	do {                                                                   \
+		fprintf(stderr, __VA_ARGS__);                                  \
+		fprintf(stderr, "\n");                                         \
+	} while (0);
+#else
+#define DEBUG_LOG_MSG(...)
+#endif
 
 #endif //DOSBOX_LOGGING_H

--- a/include/logging.h
+++ b/include/logging.h
@@ -89,14 +89,31 @@ void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1,
 
 #endif //C_DEBUG
 
-#ifdef DEBUG
-#define DEBUG_LOG_MSG(...)                                                     \
-	do {                                                                   \
-		fprintf(stderr, __VA_ARGS__);                                  \
-		fprintf(stderr, "\n");                                         \
-	} while (0);
-#else
+#ifdef NDEBUG
+// DEBUG_LOG_MSG exists only for messages useful during development, and not to
+// be redirected into internal DOSBox debugger for DOS programs (C_DEBUG feature).
 #define DEBUG_LOG_MSG(...)
+#else
+// There's no portable way to expand variadic macro using C99/C++11 (or older)
+// alone. This language limitation got removed only with C++20 (through addition
+// of __VA_OPT__ macro).
+#ifdef _MSC_VER
+#define DEBUG_LOG_MSG(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
+//                                                      ~
+// MSVC silently eliminates trailing comma if needed:   ^
+#else
+#define DEBUG_LOG_MSG(fmt, ...) fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+//                                                        ~~~~~~~~~~~~~
+//                                                        ^
+// GCC and Clang provide '##' token as a language extension to explicitly remove
+// trailing comma when there's no trailing parameters.
 #endif
+// If it'll ever be necessary to support another compiler, which does not
+// support C++20 nor GNU extension nor MSVC extension, then behaviour can be
+// simulated by implementing C++ variadic template wrapped inside a macro
+// (at the cost of slowing down compilation).
+//
+// Another option it to use vsnprintf (at the cost of slowing down runtime).
+#endif // NDEBUG
 
-#endif //DOSBOX_LOGGING_H
+#endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -387,13 +387,15 @@ static void DOSBOX_RealInit(Section * sec) {
 
 void DOSBOX_Init(void) {
 	Section_prop * secprop;
-	Section_line * secline;
 	Prop_int* Pint;
 	Prop_hex* Phex;
-	Prop_string* Pstring;
+	Prop_string* Pstring; // use pstring when touching properties
+	Prop_string *pstring;
 	Prop_bool* Pbool;
-	Prop_multival* Pmulti;
+	Prop_multival *pmulti;
 	Prop_multival_remain* Pmulti_remain;
+
+	constexpr auto always = Property::Changeable::Always;
 
 	SDLNetInited = false;
 
@@ -454,9 +456,9 @@ void DOSBOX_Init(void) {
 	                "320x200 or 640x400; where as square-pixel modes, such as 640x480\n"
 	                "and 800x600, will be displayed as-is.");
 
-	Pmulti = secprop->Add_multi("scaler", Property::Changeable::Always, " ");
-	Pmulti->SetValue("normal2x");
-	Pmulti->Set_help("Scaler used to enlarge/enhance low resolution modes.\n"
+	pmulti = secprop->Add_multi("scaler", always, " ");
+	pmulti->SetValue("none");
+	pmulti->Set_help("Scaler used to enlarge/enhance low resolution modes.\n"
 	                 "If 'forced' is appended, then the scaler will be used even if\n"
 	                 "the result might not be desired.\n"
 	                 "Note that some scalers may use black borders to fit the image\n"
@@ -464,7 +466,7 @@ void DOSBOX_Init(void) {
 	                 "undesirable, try either a different scaler or enabling\n"
 	                 "fullresolution output.");
 
-	Pstring = Pmulti->GetSection()->Add_string("type",Property::Changeable::Always,"normal2x");
+	pstring = pmulti->GetSection()->Add_string("type", always, "none");
 
 	const char *scalers[] = {
 		"none", "normal2x", "normal3x",
@@ -475,11 +477,12 @@ void DOSBOX_Init(void) {
 		"tv2x", "tv3x", "rgb2x", "rgb3x", "scan2x", "scan3x",
 #endif
 		0 };
-	Pstring->Set_values(scalers);
+	pstring->Set_values(scalers);
 
-	const char* force[] = { "", "forced", 0 };
-	Pstring = Pmulti->GetSection()->Add_string("force",Property::Changeable::Always,"");
-	Pstring->Set_values(force);
+	const char *force[] = {"", "forced", 0};
+	pstring = pmulti->GetSection()->Add_string("force", always, "");
+	pstring->Set_values(force);
+
 #if C_OPENGL
 	Pstring = secprop->Add_path("glshader", Property::Changeable::Always, "sharp");
 	Pstring->Set_help("Path to GLSL shader source to use with OpenGL output (\"none\" to disable).\n"
@@ -806,7 +809,7 @@ void DOSBOX_Init(void) {
 //	secprop->AddInitFunction(&CREDITS_Init);
 
 	//TODO ?
-	secline=control->AddSection_line("autoexec",&AUTOEXEC_Init);
+	control->AddSection_line("autoexec", &AUTOEXEC_Init);
 	MSG_Add("AUTOEXEC_CONFIGFILE_HELP",
 		"Lines in this section will be run at startup.\n"
 		"You can put your MOUNT lines here.\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2434,8 +2434,8 @@ void Config_Add_SDL() {
 	Pstring->Set_help("What resolution to use for fullscreen: 'original', 'desktop'\n"
 	                  "or a fixed size (e.g. 1024x768).");
 
-	Pstring = sdl_sec->Add_string("windowresolution", always, "original");
-	Pstring->Set_help("Scale the window to this size. Value 'original' will resize\n"
+	pstring = sdl_sec->Add_string("windowresolution", on_start, "original");
+	pstring->Set_help("Scale the window to this size. Value 'original' will resize\n"
 	                  "window to the resolution picked by the emulated program.\n"
 	                  "Not supported when 'output' is set to 'surface'.");
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2163,7 +2163,7 @@ bool GFX_IsFullscreen(void) {
 #define DB_POLLSKIP 1
 #endif
 
-void GFX_HandleVideoResize(int width, int height)
+static void HandleVideoResize(int width, int height)
 {
 	/* Maybe a screen rotation has just occurred, so we simply resize.
 	There may be a different cause for a forced resized, though.    */
@@ -2224,8 +2224,9 @@ void GFX_Events() {
 					GFX_ResetScreen();
 					continue;
 				case SDL_WINDOWEVENT_RESIZED:
-					GFX_HandleVideoResize(event.window.data1, event.window.data2);
-					continue;
+				        HandleVideoResize(event.window.data1,
+				                          event.window.data2);
+				        continue;
 				/*
 				 *  EXPOSED indicates that the window needs to be redrawn.
 				 *  Note that on Windows/Linux-X11/Wayland/macOS, the EXPOSED event

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2408,7 +2408,8 @@ void Config_Add_SDL() {
 	Section_prop * sdl_sec=control->AddSection_prop("sdl",&GUI_StartUp);
 	sdl_sec->AddInitFunction(&MAPPER_StartUp);
 	Prop_bool* Pbool;
-	Prop_string* Pstring;
+	Prop_string *Pstring; // use pstring for new properties
+	Prop_string *pstring;
 	Prop_int *Pint; // use pint for new properties
 	Prop_int *pint;
 	Prop_multival* Pmulti;
@@ -2535,8 +2536,9 @@ void Config_Add_SDL() {
 	Pstring = Pmulti->GetSection()->Add_string("inactive",Property::Changeable::Always,"normal");
 	Pstring->Set_values(inactt);
 
-	Pstring = sdl_sec->Add_path("mapperfile",Property::Changeable::Always,MAPPERFILE);
-	Pstring->Set_help("File used to load/save the key/event mappings from. Resetmapper only works with the default value.");
+	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
+	pstring->Set_help("File used to load/save the key/event mappings from.\n"
+	                  "Resetmapper only works with the default value.");
 }
 
 static void show_warning(char const * const message) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2359,11 +2359,13 @@ void GFX_Events() {
 				DEBUG_LOG_MSG("SDL: Window has been hidden");
 				continue;
 
+#if 0 // ifdefed out only because it's too noisy
 			case SDL_WINDOWEVENT_MOVED:
 				DEBUG_LOG_MSG("SDL: Window has been moved to %d, %d",
 				              event.window.data1,
 				              event.window.data2);
 				continue;
+#endif
 
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
 				DEBUG_LOG_MSG("SDL: The window size has changed");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -264,6 +264,15 @@ struct SDL_Block {
 		} window;
 		Bit8u bpp = 0;
 		bool fullscreen = false;
+		// This flag indicates, that we are in the process of switching
+		// between fullscreen or window (as oppososed to changing
+		// rendering size due to rotating screen, emulation state, or
+		// user resizing the window).
+		bool switching_fullscreen = false;
+		// Lazy window size init triggers updating window size and
+		// position when leaving fullscreen for the first time.
+		// See FinalizeWindowState function for details.
+		bool lazy_init_window_size = false;
 		bool vsync = false;
 		SCREEN_TYPES type;
 		SCREEN_TYPES want_type;
@@ -551,12 +560,7 @@ static SDL_Window * GFX_SetSDLWindowMode(Bit16u width, Bit16u height, bool fulls
 		return sdl.window;
 	}
 
-	const bool first_window = !sdl.window;
-
-	/* If we change screen type, recreate the window. Furthermore, if
-	 * it is our very first time then we simply create a new window.
-	 */
-	if (first_window || (lastType != screenType)) {
+	if (!sdl.window || (lastType != screenType)) {
 
 		lastType = screenType;
 
@@ -584,26 +588,6 @@ static SDL_Window * GFX_SetSDLWindowMode(Bit16u width, Bit16u height, bool fulls
 			return sdl.window;
 		}
 
-#if defined (WIN32)
-		// Force window position when going straight to fullscreen.
-		// Otherwise, SDL will reset window position to 0,0 when
-		// switching to a window for the first time. This is happening
-		// on every OS, but only on Windows it's a really big problem
-		// (because window decorations are rendered off-screen).
-		//
-		// To work around this problem, center the window manually based on
-		// the original drawing size, and not window size.
-		//
-		// On Linux this workaround breaks window position on
-		// multi-monitor setups, so let's use it on Windows only.
-
-		if (first_window && fullscreen) {
-			const int x = (sdl.desktop.full.width - sdl.draw.width) / 2;
-			const int y = (sdl.desktop.full.height - sdl.draw.height) / 2;
-			SDL_SetWindowPosition(sdl.window, x, y);
-		}
-#endif
-
 		GFX_SetTitle(-1, -1, false); // refresh title.
 
 		if (!fullscreen) {
@@ -624,7 +608,15 @@ static SDL_Window * GFX_SetSDLWindowMode(Bit16u width, Bit16u height, bool fulls
 		SDL_SetWindowFullscreen(sdl.window,
 		                        sdl.desktop.full.display_res ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN);
 	} else {
-		SDL_SetWindowSize(sdl.window, width, height);
+		// If you feel inclined to remove this SDL_SetWindowSize call
+		// (or further modify when it is being invoked), then make sure
+		// window size is updated AND content is correctly clipped when
+		// emulated program changes resolution with various
+		// windowresolution settings (!).
+		if (sdl.desktop.window.use_original_size &&
+		    !sdl.desktop.switching_fullscreen)
+			SDL_SetWindowSize(sdl.window, width, height);
+
 		SDL_SetWindowFullscreen(sdl.window, 0);
 	}
 	// Maybe some requested fullscreen resolution is unsupported?
@@ -1409,7 +1401,9 @@ void sticky_keys(bool restore){
 }
 #endif
 
-void GFX_SwitchFullScreen(void) {
+void GFX_SwitchFullScreen()
+{
+	sdl.desktop.switching_fullscreen = true;
 #if defined (WIN32)
 	// We are about to switch to the opposite of our current mode
 	// (ie: opposite of whatever sdl.desktop.fullscreen holds).
@@ -1419,6 +1413,7 @@ void GFX_SwitchFullScreen(void) {
 #endif
 	sdl.desktop.fullscreen = !sdl.desktop.fullscreen;
  	GFX_ResetScreen();
+	sdl.desktop.switching_fullscreen = false;
 }
 
 static void SwitchFullScreen(bool pressed)
@@ -1744,19 +1739,22 @@ static SDL_Window * SetDefaultWindowMode()
 	sdl.draw.height = splash_image.height;
 
 	if (sdl.desktop.fullscreen) {
+		sdl.desktop.lazy_init_window_size = true;
 		return GFX_SetSDLWindowMode(sdl.desktop.full.width,
 		                            sdl.desktop.full.height,
-		                            sdl.desktop.fullscreen,
+		                            true,
 		                            sdl.desktop.want_type);
 	}
 
 	if (sdl.desktop.window.use_original_size) {
+		sdl.desktop.lazy_init_window_size = false;
 		return GFX_SetSDLWindowMode(sdl.draw.width,
 		                            sdl.draw.height,
 		                            false,
 		                            sdl.desktop.want_type);
 	}
 
+	sdl.desktop.lazy_init_window_size = false;
 	return GFX_SetSDLWindowMode(sdl.desktop.window.width,
 	                            sdl.desktop.window.height,
 	                            false,
@@ -2212,6 +2210,57 @@ static void HandleVideoResize(int width, int height)
 	sdl.resizing_window = false;
 }
 
+/* This function is triggered after window is shown to fixup sdl.window
+ * properties in predictable manner on all platforms.
+ *
+ * In specific usecases, certain sdl.window properties might be left unitialized
+ * when starting in fullscreen, which might trigger severe problems for end
+ * users (e.g. placing window partially off-screen, or using fullscreen
+ * resolution for window size).
+ */
+static void FinalizeWindowState()
+{
+	assert(sdl.window);
+
+	if (!sdl.desktop.lazy_init_window_size)
+		return;
+
+	// Don't change window position or size when state changed to
+	// fullscreen.
+	if (sdl.desktop.fullscreen)
+		return;
+
+	// Once window is fixed up once, OS or Window Manager will deal with it
+	// on future expose events.
+	sdl.desktop.lazy_init_window_size = false;
+
+	int w, h;
+	if (sdl.desktop.window.use_original_size) {
+		w = sdl.draw.width * sdl.draw.scalex;
+		h = sdl.draw.height * sdl.draw.scaley;
+	} else {
+		w = sdl.desktop.window.width;
+		h = sdl.desktop.window.height;
+	}
+	SDL_SetWindowSize(sdl.window, w, h);
+
+	// Force window position when dosbox is configured to start in
+	// fullscreen.  Otherwise SDL will reset window position to 0,0 when
+	// switching to a window for the first time. This is happening on every
+	// OS, but only on Windows it's a really big problem (because window
+	// decorations are rendered off-screen).
+	//
+	// To work around this problem, tell SDL to center the window on current
+	// screen (we want center, as undefined position could still result in
+	// placing part of the window off-screen).
+	const int pos = SDL_WINDOWPOS_CENTERED_DISPLAY(sdl.display_number);
+	SDL_SetWindowPosition(sdl.window, pos, pos);
+
+	// In some cases (not always), leaving fullscreen breaks window content,
+	// screen reset restores rendering to the working state.
+	GFX_ResetScreen();
+}
+
 void GFX_Events() {
 	//Don't poll too often. This can be heavy on the OS, especially Macs.
 	//In idle mode 3000-4000 polls are done per second without this check.
@@ -2269,8 +2318,7 @@ void GFX_Events() {
 				 * FOCUS_GAINED event to catch window startup
 				 * and size toggles.
 				 */
-				if (sdl.draw.callback)
-					sdl.draw.callback(GFX_CallBackRedraw);
+				GFX_ResetScreen();
 				GFX_UpdateMouseState();
 				continue;
 
@@ -2322,6 +2370,7 @@ void GFX_Events() {
 				// The window size has changed either as a
 				// result of an API call or through the system
 				// or user changing the window size.
+				FinalizeWindowState();
 				continue;
 
 			case SDL_WINDOWEVENT_MINIMIZED:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2238,48 +2238,119 @@ void GFX_Events() {
 		switch (event.type) {
 		case SDL_WINDOWEVENT:
 			switch (event.window.event) {
-				case SDL_WINDOWEVENT_RESTORED:
-					/* We may need to re-create a texture
-					 * and more on Android. Another case:
-					 * Update surface while using X11.
-					 */
-					GFX_ResetScreen();
-					continue;
-				case SDL_WINDOWEVENT_RESIZED:
-				        HandleVideoResize(event.window.data1,
-				                          event.window.data2);
-				        continue;
-				/*
-				 *  EXPOSED indicates that the window needs to be redrawn.
-				 *  Note that on Windows/Linux-X11/Wayland/macOS, the EXPOSED event
-				 *  is fired after toggling between full vs windowed modes. However this is
-				 *  never fired on the Raspberry Pi (when rendering to the Framebuffer);
-				 *  therefore we rely on the FOCUS_GAINED event to catch window startup
-				 *  and size toggles.
-				 */ 
-				case SDL_WINDOWEVENT_EXPOSED:
-					if (sdl.draw.callback)
-						sdl.draw.callback(GFX_CallBackRedraw);
-					GFX_UpdateMouseState();
-					continue;
-				case SDL_WINDOWEVENT_FOCUS_GAINED:
-					SetPriority(sdl.priority.focus);
-					CPU_Disable_SkipAutoAdjust();
-					GFX_UpdateMouseState();
-					break;
-				case SDL_WINDOWEVENT_FOCUS_LOST:
+			case SDL_WINDOWEVENT_RESTORED:
+				DEBUG_LOG_MSG("SDL: Window has been restored");
+				/* We may need to re-create a texture
+				 * and more on Android. Another case:
+				 * Update surface while using X11.
+				 */
+				GFX_ResetScreen();
+				continue;
+
+			case SDL_WINDOWEVENT_RESIZED:
+				DEBUG_LOG_MSG("SDL: Window has been resized to %dx%d",
+				              event.window.data1,
+				              event.window.data2);
+				HandleVideoResize(event.window.data1,
+				                  event.window.data2);
+				continue;
+
+			case SDL_WINDOWEVENT_EXPOSED:
+				DEBUG_LOG_MSG("SDL: Window has been exposed "
+				              "and should be redrawn");
+				/* FIXME: below is not consistently true :(
+				 * seems incorrect on KDE and sometimes on MATE
+				 *
+				 * Note that on Windows/Linux-X11/Wayland/macOS,
+				 * event is fired after toggling between full vs
+				 * windowed modes. However this is never fired
+				 * on the Raspberry Pi (when rendering to the
+				 * Framebuffer); therefore we rely on the
+				 * FOCUS_GAINED event to catch window startup
+				 * and size toggles.
+				 */
+				if (sdl.draw.callback)
+					sdl.draw.callback(GFX_CallBackRedraw);
+				GFX_UpdateMouseState();
+				continue;
+
+			case SDL_WINDOWEVENT_FOCUS_GAINED:
+				DEBUG_LOG_MSG("SDL: Window has gained keyboard focus");
+				SetPriority(sdl.priority.focus);
+				CPU_Disable_SkipAutoAdjust();
+				GFX_UpdateMouseState();
+				continue;
+
+			case SDL_WINDOWEVENT_FOCUS_LOST:
+				DEBUG_LOG_MSG("SDL: Window has lost keyboard focus");
 #ifdef WIN32
-					if (sdl.desktop.fullscreen) {
-						VGA_KillDrawing();
-						GFX_ForceFullscreenExit();
-					}
+				if (sdl.desktop.fullscreen) {
+					VGA_KillDrawing();
+					GFX_ForceFullscreenExit();
+				}
 #endif
-					SetPriority(sdl.priority.nofocus);
-					GFX_LosingFocus();
-					CPU_Enable_SkipAutoAdjust();
-					sdl.mouse.has_focus = false;
-					break;
-				default: ;
+				SetPriority(sdl.priority.nofocus);
+				GFX_LosingFocus();
+				CPU_Enable_SkipAutoAdjust();
+				sdl.mouse.has_focus = false;
+				break;
+
+			case SDL_WINDOWEVENT_ENTER:
+				DEBUG_LOG_MSG("SDL: Window has gained mouse focus");
+				continue;
+
+			case SDL_WINDOWEVENT_LEAVE:
+				DEBUG_LOG_MSG("SDL: Window has lost mouse focus");
+				continue;
+
+			case SDL_WINDOWEVENT_SHOWN:
+				DEBUG_LOG_MSG("SDL: Window has been shown");
+				continue;
+
+			case SDL_WINDOWEVENT_HIDDEN:
+				DEBUG_LOG_MSG("SDL: Window has been hidden");
+				continue;
+
+			case SDL_WINDOWEVENT_MOVED:
+				DEBUG_LOG_MSG("SDL: Window has been moved to %d, %d",
+				              event.window.data1,
+				              event.window.data2);
+				continue;
+
+			case SDL_WINDOWEVENT_SIZE_CHANGED:
+				DEBUG_LOG_MSG("SDL: The window size has changed");
+				// The window size has changed either as a
+				// result of an API call or through the system
+				// or user changing the window size.
+				continue;
+
+			case SDL_WINDOWEVENT_MINIMIZED:
+				DEBUG_LOG_MSG("SDL: Window has been minimized");
+				break;
+
+			case SDL_WINDOWEVENT_MAXIMIZED:
+				DEBUG_LOG_MSG("SDL: Window has been maximized");
+				continue;
+
+			case SDL_WINDOWEVENT_CLOSE:
+				DEBUG_LOG_MSG("SDL: The window manager "
+				              "requests that the window be "
+				              "closed");
+				continue;
+
+#if SDL_VERSION_ATLEAST(2, 0, 5)
+			case SDL_WINDOWEVENT_TAKE_FOCUS:
+				DEBUG_LOG_MSG("SDL: Window is being offered a focus");
+				// should SetWindowInputFocus() on itself or a
+				// subwindow, or ignore
+				continue;
+
+			case SDL_WINDOWEVENT_HIT_TEST:
+				DEBUG_LOG_MSG("SDL: Window had a hit test that "
+				              "wasn't SDL_HITTEST_NORMAL");
+				continue;
+#endif
+			default: break;
 			}
 
 			/* Non-focus priority is set to pause; check to see if we've lost window or input focus
@@ -2334,7 +2405,8 @@ void GFX_Events() {
 					}
 				}
 			}
-			break;
+			break; // end of SDL_WINDOWEVENT
+
 		case SDL_MOUSEMOTION:
 			HandleMouseMotion(&event.motion);
 			break;


### PR DESCRIPTION
This is part of ongoing work towards #274 - it does not have resizable part yet, just fixes to state of sdl.window post-initialization (which is a prerequisite), and some other fixes.

I modernized the part of code handling `windowresoltion=<size>`, but I decided not to re-implement `windowresolution=X%` - after testing and trying it a little bit, I decided it's too disruptive (also, the correct implementation needs access to [`SDL_GetDisplayUsableBounds`](https://wiki.libsdl.org/SDL_GetDisplayUsableBounds), which is unavailable in SDL 2.0.2 distributed by Ubuntu 16.04 LTS… There's also a question of how to interpret it (50% should be 50% of usable screen estate or 50% of original window size? should we support values above 100%? how exactly (by changing window size or doing something special on HiDPI displays)?). It also somewhat conflicts with resizable window implementation :(

Second interesting change in here is logging of SDL window events (only for debug builds). SDL2 introduced a number of events, that were not used until now - 2 interesting ones are [`SDL_WINDOWEVENT_ENTER`, and `SDL_WINDOWEVENT_LEAVE`](https://wiki.libsdl.org/SDL_WindowEvent) for detecting when mouse cursor enters and leaves the application window (I am just logging them right now, nothing more).

I verified this implementation on a number of configurations, situation considerably improved (especially on Linux); more testing will be appreciated. During testing I finally managed to reproduce transparent splash screen bug (only in KDE Plasma with X11 and output=texture).

I think the scope of testing explains why this is so annoying to work with…

Legend:
- `ok` - generally behaves ok, but there are small errors not preventing comfortable use
- `OK` - works perfect in every way (previously all of these were `ok`)
- `err` - it's still buggy
- `BUG1` - error when setting custom nonnative resolution, happens on macOS and Wayland, might be impossible to fix (I don't know for sure yet)

```
    Tested on (OS / GPU / WM / Display server)
    
    Each test with 2 configs: fullscreen=true/false, testing going in/out fullscreen,
    in textmodes/graphic modes, switching between text modes and graphic modes
    (there were tiny bugs in all of these use-cases)
    
    output=opengl fullresolution=desktop windowresolution=original
    
      - Linux       / Intel / Gnome    / X11      - OK
      - Linux       / Intel / Cinnamon / X11      - OK
      - Linux       / Intel / Plasma   / X11      - OK
      - Linux       / Intel / MATE     / X11      - OK
      - Linux       / AMD   / Gnome    / X11      - OK
      - Linux       / AMD   / Gnome    / XWayland - OK
      - Linux       / AMD   / Gnome    / Wayland  - err (no regressions, fullscreen ok)
      - Windows 10  / AMD                         - ok* (excessive trashing when switching)
      - macOS 10.14 / VM                          - ok* (excessive trashing when switching)
    
    output=opengl fullresolution=<non-native> windowresolution=original
    
      - Linux       / Intel / Gnome    / X11      - OK
      - Linux       / Intel / Cinnamon / X11      - OK
      - Linux       / Intel / Plasma   / X11      - ok* (splash screen off-screen when fullscreen=true, rest ok)
      - Linux       / Intel / MATE     / X11      - OK
      - Linux       / AMD   / Gnome    / X11      - OK
      - Linux       / AMD   / Gnome    / XWayland - ok* (fake weird fullscreen)
      - Linux       / AMD   / Gnome    / Wayland  - err (no regressions, BUG1)
      - Windows 10  / AMD                         - ok* (excessive trashing when switching)
      - macOS 10.14 / VM                          - err (no regressions, BUG1)
    
    output=opengl fullresolution=desktop windowresolution=<custom>
    
      - Linux       / Intel / Gnome    / X11      - OK
      - Linux       / Intel / Cinnamon / X11      - OK
      - Linux       / Intel / Plasma   / X11      - OK
      - Linux       / Intel / MATE     / X11      - OK
      - Linux       / AMD   / Gnome    / X11      - OK
      - Linux       / AMD   / Gnome    / XWayland - OK
      - Linux       / AMD   / Gnome    / Wayland  - err (no regressions)
      - Windows 10  / AMD                         - ok* (excessive trashing when switching)
    
    output=texture fullresolution=desktop  windowresolution=original
    
      - Linux       / Intel / Gnome    / X11      - OK
      - Linux       / Intel / Cinnamon / X11      - OK
      - Linux       / Intel / Plasma   / X11      - ok* (transparent/invisible splash screen)
      - Linux       / Intel / MATE     / X11      - OK
      - Linux       / AMD   / Gnome    / X11      - OK
      - Linux       / AMD   / Gnome    / XWayland - OK
      - Linux       / AMD   / Gnome    / Wayland  - err (no regressions)
      - Windows 10  / AMD                         - OK
      - macOS 10.14 / VM                          - err (no regressions, depending on renderer)
    
    output=texture fullresolution=<non-native> windowresolution=original
    
      - Linux       / Intel / Gnome    / X11      - OK
      - Linux       / Intel / Cinnamon / X11      - OK
      - Linux       / Intel / Plasma   / X11      - ok* (transparent/invisible splash screen)
      - Linux       / Intel / MATE     / X11      - OK
      - Linux       / AMD   / Gnome    / X11      - OK
      - Linux       / AMD   / Gnome    / XWayland - ok* (fake weird fullscreen)
      - Linux       / AMD   / Gnome    / Wayland  - err (no regressions, BUG1)
      - Windows 10  / AMD                         - OK
    
    output=texture fullresolution=desktop  windowresolution=<custom>
    
      - Linux       / Intel / Gnome    / X11      - OK
      - Linux       / Intel / Cinnamon / X11      - OK
      - Linux       / Intel / Plasma   / X11      - ok* (transparent/invisible splash screen)
      - Linux       / Intel / MATE     / X11      - OK
      - Linux       / AMD   / Gnome    / X11      - OK
      - Linux       / AMD   / Gnome    / XWayland - OK
      - Linux       / AMD   / Gnome    / Wayland  - err (no regressions)
      - Windows 10  / AMD                         - OK
```
