### PR TITLE
Fix alignment for host address reads and writes

### DIFF
--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -14,11 +14,15 @@ TYPES+=(release debug warnmore pgotrain optinfo)
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno -fno-strict-aliasing)
 
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
+
 cflags_pgotrain+=("${cflags_debug[@]}" -fprofile-instr-generate -fcoverage-mapping)
+
 cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
                   -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion
-                  -Wdouble-promotion -Wformat=2)
+                  -Wdouble-promotion -Wformat=2 -fstrict-aliasing -Wstrict-aliasing=2)
+
 cxxonly_warnmore+=(-Wnon-virtual-dtor -Woverloaded-virtual)
+
 cflags_optinfo+=("${cflags_release[@]}" -Rpass-analysis=loop-vectorize
                  -gline-tables-only -gcolumn-info)
 

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -19,10 +19,12 @@ cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-strict-aliasing
                  -frename-registers -ffunction-sections -fdata-sections)
 
 cflags_pgotrain+=("${cflags_debug[@]}" -pg -ftree-vectorize)
+
 cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                   -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2
                   -Wlogical-op -Wmisleading-indentation -Wnull-dereference
-                  -Wshadow -Wunused)
+                  -Wshadow -Wunused -fstrict-aliasing -Wstrict-aliasing=2)
+
 cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual -Wuseless-cast)
 cflags_fdotrain+=("${cflags[@]}" -DNDEBUG -g1 -fno-omit-frame-pointer)
 cflags_optinfo+=("${cflags_release[@]}" -fopt-info-missed

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -137,8 +137,10 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return;
 		host_writew(hostmem+addr,val);
-		if (!*(Bit16u*)&write_map[addr]) {
-			if (active_blocks) return;
+		const uint16_t is_active = host_readw(write_map + addr);
+		if (!is_active) {
+			if (active_blocks)
+				return;
 			active_count--;
 			if (!active_count) Release();
 			return;
@@ -160,8 +162,10 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return;
 		host_writed(hostmem+addr,val);
-		if (!*(Bit32u*)&write_map[addr]) {
-			if (active_blocks) return;
+		const uint32_t is_active = host_readd(write_map + addr);
+		if (!is_active) {
+			if (active_blocks)
+				return;
 			active_count--;
 			if (!active_count) Release();
 			return;
@@ -211,7 +215,9 @@ public:
 		}
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
-		if (!*(Bit16u*)&write_map[addr]) {
+
+		const uint16_t is_active = host_readw(write_map + addr);
+		if (!is_active) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();
@@ -240,7 +246,9 @@ public:
 		}
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
-		if (!*(Bit32u*)&write_map[addr]) {
+
+		const uint32_t is_active = host_readd(write_map + addr);
+		if (!is_active) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();
@@ -479,19 +487,22 @@ static INLINE void cache_addb(Bit8u val) {
 	*cache.pos++=val;
 }
 
-static INLINE void cache_addw(Bit16u val) {
-	*(Bit16u*)cache.pos=val;
-	cache.pos+=2;
+static INLINE void cache_addw(const uint16_t &val)
+{
+	host_writew(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
-static INLINE void cache_addd(Bit32u val) {
-	*(Bit32u*)cache.pos=val;
-	cache.pos+=4;
+static INLINE void cache_addd(const uint32_t &val)
+{
+	host_writed(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
-static INLINE void cache_addq(Bit64u val) {
-	*(Bit64u*)cache.pos=val;
-	cache.pos+=8;
+static INLINE void cache_addq(uint64_t val)
+{
+	host_writeq(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
 static void gen_return(BlockReturn retcode);

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -140,28 +140,32 @@ static Bit8u decode_fetchb(void) {
 	decode.code+=1;
 	return mem_readb(decode.code-1);
 }
-static Bit16u decode_fetchw(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4095)) {
-   		Bit16u val=decode_fetchb();
-		val|=decode_fetchb() << 8;
+static uint16_t decode_fetchw()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4095)) {
+		uint16_t val = decode_fetchb();
+		val |= decode_fetchb() << 8;
 		return val;
 	}
-	*(Bit16u *)&decode.page.wmap[decode.page.index]+=0x0101;
-	decode.code+=2;decode.page.index+=2;
-	return mem_readw(decode.code-2);
+	host_addw(decode.page.wmap + decode.page.index, 0x0101);
+	decode.code += sizeof(uint16_t);
+	decode.page.index += sizeof(uint16_t);
+	return mem_readw(decode.code - sizeof(uint16_t));
 }
-static Bit32u decode_fetchd(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4093)) {
-   		Bit32u val=decode_fetchb();
-		val|=decode_fetchb() << 8;
-		val|=decode_fetchb() << 16;
+static uint32_t decode_fetchd()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4093)) {
+		Bit32u val = decode_fetchb();
+		val |= decode_fetchb() << 8;
+		val |= decode_fetchb() << 16;
 		val|=decode_fetchb() << 24;
 		return val;
         /* Advance to the next page */
 	}
-	*(Bit32u *)&decode.page.wmap[decode.page.index]+=0x01010101;
-	decode.code+=4;decode.page.index+=4;
-	return mem_readd(decode.code-4);
+	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
+	decode.code += sizeof(uint32_t);
+	decode.page.index += sizeof(uint32_t);
+	return mem_readd(decode.code - sizeof(uint32_t));
 }
 
 #define START_WMMEM 64
@@ -193,9 +197,11 @@ static INLINE void decode_increase_wmapmask(Bitu size) {
 		}
 	}
 	switch (size) {
-		case 1 : activecb->cache.wmapmask[mapidx]+=0x01; break;
-		case 2 : (*(Bit16u*)&activecb->cache.wmapmask[mapidx])+=0x0101; break;
-		case 4 : (*(Bit32u*)&activecb->cache.wmapmask[mapidx])+=0x01010101; break;
+	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
+
+	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
+
+	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
 	}
 }
 

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -272,7 +272,8 @@ public:
 static BlockReturn gen_runcodeInit(Bit8u *code);
 static BlockReturn (*gen_runcode)(Bit8u *code) = gen_runcodeInit;
 
-static BlockReturn gen_runcodeInit(Bit8u *code) {
+static BlockReturn gen_runcodeInit(uint8_t *code)
+{
 	Bit8u* oldpos = cache.pos;
 	cache.pos = &cache_code_link_blocks[128];
 	gen_runcode = (BlockReturn(*)(Bit8u*))cache.pos;
@@ -303,7 +304,7 @@ static BlockReturn gen_runcodeInit(Bit8u *code) {
 	opcode(0).setea(4,-1,0,CALLSTACK).Emit8(0x89);  // mov [rsp+8/40], eax
 	opcode(4).setrm(ARG0_REG).Emit8(0xFF);   // jmp ARG0
 
-	*(Bit32u*)diff = (Bit32u)(cache.pos - diff - 4);
+	host_writed(diff, cache.pos - diff - sizeof(uint32_t));
 	// eax = return value, ecx = flags
 	opcode(1).setea(5,-1,0,offsetof(CPU_Regs,flags)).Emit8(0x33); // xor ecx, reg_flags
 	opcode(4).setrm(1).setimm(FMASK_TEST,4).Emit8(0x81);          // and ecx,FMASK_TEST
@@ -1149,20 +1150,22 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_branch_long(Bit8u * data,Bit8u * from=cache.pos) {
-	*(Bit32u*)data=(Bit32u)(from-data-4);
+static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos)
+{
+	host_writed(data, from - data - sizeof(uint32_t));
 }
 
-static Bit8u * gen_create_jump(Bit8u * to=0) {
+static uint8_t *gen_create_jump(uint8_t *to = 0)
+{
 	/* First free all registers */
 	cache_addb(0xe9);
-	cache_addd((Bit32u)(to-(cache.pos+4)));
-	return (cache.pos-4);
+	cache_addd(static_cast<uint32_t>(to - cache.pos + sizeof(uint32_t)));
+	return cache.pos - sizeof(uint32_t);
 }
 
 #if 0
-static void gen_fill_jump(Bit8u * data,Bit8u * to=cache.pos) {
-	*(Bit32u*)data=(Bit32u)(to-data-4);
+static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
+	host_writed(data, static_cast<uint32_t>(to - data - sizeof(uint32_t)));
 }
 #endif
 

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -171,12 +171,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-		host_writew(&invalidation_map[addr],
-			host_readw(&invalidation_map[addr])+0x101);
-#else
-		(*(Bit16u*)&invalidation_map[addr])+=0x101;
-#endif
+		host_addw(invalidation_map + addr, 0x101);
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -193,12 +188,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-		host_writed(&invalidation_map[addr],
-			host_readd(&invalidation_map[addr])+0x1010101);
-#else
-		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
-#endif
+		host_addd(invalidation_map + addr, 0x1010101);
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -240,12 +230,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-			host_writew(&invalidation_map[addr],
-				host_readw(&invalidation_map[addr])+0x101);
-#else
-			(*(Bit16u*)&invalidation_map[addr])+=0x101;
-#endif
+			host_addw(invalidation_map + addr, 0x101);
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -269,12 +254,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-			host_writed(&invalidation_map[addr],
-				host_readd(&invalidation_map[addr])+0x1010101);
-#else
-			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
-#endif
+			host_addd(invalidation_map + addr, 0x1010101);
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -534,22 +514,21 @@ static INLINE void cache_addb(Bit8u val) {
 
 // place a 16bit value into the cache
 static INLINE void cache_addw(Bit16u val) {
-	*(Bit16u*)cache.pos=val;
-	cache.pos+=2;
+	host_writew(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
 // place a 32bit value into the cache
 static INLINE void cache_addd(Bit32u val) {
-	*(Bit32u*)cache.pos=val;
-	cache.pos+=4;
+	host_writed(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
 // place a 64bit value into the cache
 static INLINE void cache_addq(Bit64u val) {
-	*(Bit64u*)cache.pos=val;
-	cache.pos+=8;
+	host_writeq(cache.pos, val);
+	cache.pos += sizeof(val);
 }
-
 
 static void dyn_return(BlockReturn retcode,bool ret_exception);
 static void dyn_run_code(void);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -627,3 +627,32 @@ void MEM_Init(Section * sec) {
 	test = new MEMORY(sec);
 	sec->AddDestroyFunction(&MEM_ShutDown);
 }
+
+void host_addw(uint8_t *arr, uint16_t incr)
+{
+	const uint16_t val = host_readw(arr) + incr;
+	host_writew(arr, val);
+}
+
+void host_addd(uint8_t *arr, uint32_t incr)
+{
+	const uint32_t val = host_readd(arr) + incr;
+	host_writed(arr, val);
+}
+
+// Read and write using 64-bit quad-words
+uint64_t host_readq(const uint8_t *arr)
+{
+	uint64_t val;
+	memcpy(reinterpret_cast<void *>(&val),
+	       reinterpret_cast<const void *>(arr), sizeof(val));
+	// array sequence was DOS little-endian, so convert value to host-type
+	return le_to_host(val);
+}
+void host_writeq(uint8_t *arr, uint64_t val)
+{
+	// Convert the host-type value to little-endian before filling array
+	val = host_to_le(val);
+	memcpy(reinterpret_cast<void *>(arr),
+	       reinterpret_cast<const void *>(&val), sizeof(val));
+}


### PR DESCRIPTION
The UASAN and UBSAN analyzers report undefined behavior caused by many mis-aligned memory accesses (both reads and writes). For example:

- runtime error: store to misaligned address for type 'Bit16u', which requires 2 byte alignment

- runtime error: store to misaligned address for type 'Bit32u', which requires 4 byte alignment

- runtime error: store to misaligned address for type 'Bit64u', which requires 8 byte alignment

- runtime error: load of misaligned address for type 'Bit16u', which requires 2 byte alignment

- runtime error: load of misaligned address for type 'Bit32u', which requires 4 byte alignment

This commit fixes the underly host_read*, and host_write* functions by replacing its broken aliasing-based type punning with the with the safe-and-fast memcpy calls. These are typically compiled down to a single-instruction and therefore impart no penalty while avoiding the complexity of unrolled byte-shifting.

It adds a new function type that adds a value to a host-addressed value, and adds handling of quad-words (host_readq, host_writeq).

It then makes uses of these safe functions at various other points in the cache and CPU emulation code previously also flagged as having alignment issue.

[REF] https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8 for current discussion and live code-comparisons from various compilers and architectures.