### PR TITLE
Fix alignment of host address reads and writes

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -97,14 +97,14 @@ jobs:
         conf:
           - name: Clang
             sanitizers: USAN
-            usan:  93
+            usan:  86
             tsan:  -1
             uasan: -1
           - name: GCC
             sanitizers: TSAN UASAN
             usan:  -1
             tsan:  0  # our test does not trigger multiple threads yet
-            uasan: 80
+            uasan: 36
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,10 @@ jobs:
           CXX: ccache g++
           LD: gcc
           RANLIB: gcc-ranlib
-          FLAGS: -O3 -flto -ffunction-sections -fdata-sections -DNDEBUG -pipe
+          FLAGS: >-
+            -O3 -fstrict-aliasing -fno-signed-zeros -fno-trapping-math
+            -fassociative-math -mfpmath=sse -msse4.2 -flto -ffunction-sections
+            -fdata-sections -DNDEBUG -pipe
           LINKFLAGS: -Wl,--as-needed
         run: |
           set -x

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,11 +26,11 @@ jobs:
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 76
+            max_warnings: 57
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
-            max_warnings: 57
+            max_warnings: 38
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 58
+            max_warnings: 39
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 77
+            max_warnings: 58
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,7 +58,7 @@ jobs:
     env:
       CC: ccache clang
       CXX: ccache clang++
-      FLAGS: -O3 -DNDEBUG -pipe -march=nehalem
+      FLAGS: -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing -march=nehalem -flto=thin -pipe
     steps:
       - uses: actions/checkout@v1
       - name: Install C++ compiler and libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,19 +17,19 @@ jobs:
           - compiler: Clang
             bits: 32
             arch: i686
-            max_warnings: 28
+            max_warnings: 9
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 60
+            max_warnings: 41
           - compiler: GCC
             bits: 32
             arch: i686
-            max_warnings: 45
+            max_warnings: 26
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 77
+            max_warnings: 58
     env:
       CHERE_INVOKING:  yes
       CCACHE_DIR:      "${{ github.workspace }}/.ccache"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
         id:    cache-msys2
         with:
           path: 'C:/tools/msys64'
-          key: msys2-${{ matrix.conf.bits }}-${{ steps.get-date.outputs.date }}-3
+          key: msys2-${{ matrix.conf.bits }}-${{ steps.get-date.outputs.date }}
       - name:  Install MSYS2
         if:    steps.cache-msys2.outputs.cache-hit != 'true'
         run:   choco install msys2 --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ missing
 mkinstalldirs
 stamp-h1
 
+# autotools configuration ephemerals
+confdefs.h
+conftest.dir
+
 # Other
 compile
 build.log

--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -2,6 +2,30 @@
     "version": 1,
     "warnings": [
         {
+            "CodeCurrent": 99146737,
+            "CodeNext": 3299936121,
+            "CodePrev": 2974951853,
+            "ErrorCode": "V570",
+            "FileName": "mem.h",
+            "Message": "The 'val' variable is assigned to itself."
+        },
+        {
+            "CodeCurrent": 99146737,
+            "CodeNext": 3299936121,
+            "CodePrev": 2974951853,
+            "ErrorCode": "V570",
+            "FileName": "mem.h",
+            "Message": "The 'val' variable is assigned to itself."
+        },
+        {
+            "CodeCurrent": 99146737,
+            "CodeNext": 3299936121,
+            "CodePrev": 2974951853,
+            "ErrorCode": "V570",
+            "FileName": "mem.h",
+            "Message": "The 'val' variable is assigned to itself."
+        },
+        {
             "CodeCurrent": 432032057,
             "CodeNext": 36027430,
             "CodePrev": 0,

--- a/include/mem.h
+++ b/include/mem.h
@@ -19,10 +19,11 @@
 #ifndef DOSBOX_MEM_H
 #define DOSBOX_MEM_H
 
-#include <cstring>
-#ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
-#endif
+
+#include <cstring>
+
+#include "types.h"
 
 #include "byteorder.h"
 
@@ -147,19 +148,19 @@ constexpr static INLINE uint64_t le_to_host(uint64_t val)
 static INLINE uint16_t host_readw(const uint8_t *arr)
 {
 	uint16_t val;
-	memcpy(reinterpret_cast<void *>(&val),
-	       reinterpret_cast<const void *>(arr), sizeof(val));
+	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
 	return le_to_host(val);
 }
+
 static INLINE void host_writew(uint8_t *arr, uint16_t val)
 {
 	// Convert the host-type value to little-endian before filling array
 	val = host_to_le(val);
-	memcpy(reinterpret_cast<void *>(arr),
-	       reinterpret_cast<const void *>(&val), sizeof(val));
+	memcpy(arr, &val, sizeof(val));
 }
-static INLINE void host_addw(uint8_t *arr, const uint16_t &incr)
+
+static INLINE void host_addw(uint8_t *arr, const uint16_t incr)
 {
 	const uint16_t val = host_readw(arr) + incr;
 	host_writew(arr, val);
@@ -169,19 +170,19 @@ static INLINE void host_addw(uint8_t *arr, const uint16_t &incr)
 static INLINE uint32_t host_readd(const uint8_t *arr)
 {
 	uint32_t val;
-	memcpy(reinterpret_cast<void *>(&val),
-	       reinterpret_cast<const void *>(arr), sizeof(val));
+	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
 	return le_to_host(val);
 }
+
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
 	// Convert the host-type value to little-endian before filling array
 	val = host_to_le(val);
-	memcpy(reinterpret_cast<void *>(arr),
-	       reinterpret_cast<const void *>(&val), sizeof(val));
+	memcpy(arr, &val, sizeof(val));
 }
-static INLINE void host_addd(uint8_t *arr, const uint32_t &incr)
+
+static INLINE void host_addd(uint8_t *arr, const uint32_t incr)
 {
 	const uint32_t val = host_readd(arr) + incr;
 	host_writed(arr, val);
@@ -191,19 +192,17 @@ static INLINE void host_addd(uint8_t *arr, const uint32_t &incr)
 static INLINE uint64_t host_readq(const uint8_t *arr)
 {
 	uint64_t val;
-	memcpy(reinterpret_cast<void *>(&val),
-	       reinterpret_cast<const void *>(arr), sizeof(val));
+	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
 	return le_to_host(val);
 }
+
 static INLINE void host_writeq(uint8_t *arr, uint64_t val)
 {
 	// Convert the host-type value to little-endian before filling array
 	val = host_to_le(val);
-	memcpy(reinterpret_cast<void *>(arr),
-	       reinterpret_cast<const void *>(&val), sizeof(val));
+	memcpy(arr, &val, sizeof(val));
 }
-
 
 static INLINE void var_write(uint8_t *var, uint8_t val)
 {

--- a/include/mem.h
+++ b/include/mem.h
@@ -71,7 +71,7 @@ static INLINE uint16_t host_readw(const uint8_t *arr)
 	uint16_t val;
 	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
-	return le_to_host16(val);
+	return le16_to_host(val);
 }
 
 // Like the above, but allows index-style access assuming a 16-bit array
@@ -104,7 +104,7 @@ static INLINE uint32_t host_readd(const uint8_t *arr)
 	uint32_t val;
 	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
-	return le_to_host32(val);
+	return le32_to_host(val);
 }
 
 // Like the above, but allows index-style access assuming a 32-bit array
@@ -137,7 +137,7 @@ static INLINE uint64_t host_readq(const uint8_t *arr)
 	uint64_t val;
 	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
-	return le_to_host64(val);
+	return le64_to_host(val);
 }
 
 static INLINE void host_writeq(uint8_t *arr, uint64_t val)

--- a/include/mem.h
+++ b/include/mem.h
@@ -19,6 +19,7 @@
 #ifndef DOSBOX_MEM_H
 #define DOSBOX_MEM_H
 
+#include <cstring>
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif
@@ -54,75 +55,160 @@ bool MEM_ReAllocatePages(MemHandle & handle,Bitu pages,bool sequence);
 MemHandle MEM_NextHandle(MemHandle handle);
 MemHandle MEM_NextHandleAt(MemHandle handle,Bitu where);
 
-/* 
-	The folowing six functions are used everywhere in the end so these should be changed for
-	Working on big or little endian machines 
-*/
-
-static INLINE Bit8u host_readb(HostPt off) {
-	return *off;
+// Read and write single-byte values
+static INLINE uint8_t host_readb(const uint8_t *var)
+{
+	return *var;
+}
+static INLINE void host_writeb(uint8_t *var, const uint8_t &val)
+{
+	*var = val;
 }
 
-static INLINE void host_writeb(HostPt off,Bit8u val) {
-	*off = val;
+// host_to_le functions allow for byte order conversion on big endian
+// architectures while respecting memory alignment on low endian.
+//
+// It is extremely unlikely that we'll ever try to compile on big endian arch
+// with a compiler missing __builtin_bswap*, so let's not overcomplicate
+// things.
+//
+// __builtin_bswap* is supported since GCC 4.3 and Clang 3.4
+
+constexpr static INLINE uint8_t host_to_le(uint8_t val) {
+	return val;
 }
 
-// use __builtin_bswap* for gcc >= 4.3
-#if defined(WORDS_BIGENDIAN) && defined(__GNUC__) && \
-	(__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+#if defined(WORDS_BIGENDIAN)
 
-static INLINE Bit16u host_readw(HostPt off) {
-	return __builtin_bswap16(*(Bit16u *)off);
-}
-static INLINE Bit32u host_readd(HostPt off) {
-	return __builtin_bswap32(*(Bit32u *)off);
-}
-static INLINE void host_writew(HostPt off, Bit16u val) {
-	*(Bit16u *)off = __builtin_bswap16(val);
-}
-static INLINE void host_writed(HostPt off, Bit32u val) {
-	*(Bit32u *)off = __builtin_bswap32(val);
+constexpr static INLINE int16_t host_to_le(int16_t val) {
+	return __builtin_bswap16(val);
 }
 
-#elif defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+constexpr static INLINE uint16_t host_to_le(uint16_t val) {
+	return __builtin_bswap16(val);
+}
 
-static INLINE Bit16u host_readw(HostPt off) {
-	return off[0] | (off[1] << 8);
+constexpr static INLINE uint32_t host_to_le(uint32_t val) {
+	return __builtin_bswap32(val);
 }
-static INLINE Bit32u host_readd(HostPt off) {
-	return off[0] | (off[1] << 8) | (off[2] << 16) | (off[3] << 24);
-}
-static INLINE void host_writew(HostPt off,Bit16u val) {
-	off[0]=(Bit8u)(val);
-	off[1]=(Bit8u)(val >> 8);
-}
-static INLINE void host_writed(HostPt off,Bit32u val) {
-	off[0]=(Bit8u)(val);
-	off[1]=(Bit8u)(val >> 8);
-	off[2]=(Bit8u)(val >> 16);
-	off[3]=(Bit8u)(val >> 24);
+
+constexpr static INLINE uint64_t host_to_le(uint64_t val)
+{
+	return __builtin_bswap64(val);
 }
 
 #else
 
-static INLINE Bit16u host_readw(HostPt off) {
-	return *(Bit16u *)off;
+constexpr static INLINE int16_t host_to_le(int16_t val) {
+	return val;
 }
-static INLINE Bit32u host_readd(HostPt off) {
-	return *(Bit32u *)off;
+
+constexpr static INLINE uint16_t host_to_le(uint16_t val) {
+	return val;
 }
-static INLINE void host_writew(HostPt off,Bit16u val) {
-	*(Bit16u *)(off)=val;
+
+constexpr static INLINE uint32_t host_to_le(uint32_t val) {
+	return val;
 }
-static INLINE void host_writed(HostPt off,Bit32u val) {
-	*(Bit32u *)(off)=val;
+
+constexpr static INLINE uint64_t host_to_le(uint64_t val)
+{
+	return val;
 }
 
 #endif
 
-static INLINE void var_write(Bit8u * var, Bit8u val) {
-	host_writeb(var, val);
+constexpr static INLINE uint8_t le_to_host(uint8_t val)
+{
+	return host_to_le(val);
 }
+
+constexpr static INLINE int16_t le_to_host(int16_t val)
+{
+	return host_to_le(val);
+}
+
+constexpr static INLINE uint16_t le_to_host(uint16_t val)
+{
+	return host_to_le(val);
+}
+
+constexpr static INLINE uint32_t le_to_host(uint32_t val)
+{
+	return host_to_le(val);
+}
+
+constexpr static INLINE uint64_t le_to_host(uint64_t val)
+{
+	return host_to_le(val);
+}
+
+// Read, write, and add using 16-bit words
+static INLINE uint16_t host_readw(const uint8_t *arr)
+{
+	uint16_t val;
+	memcpy(reinterpret_cast<void *>(&val),
+	       reinterpret_cast<const void *>(arr), sizeof(val));
+	// array sequence was DOS little-endian, so convert value to host-type
+	return le_to_host(val);
+}
+static INLINE void host_writew(uint8_t *arr, uint16_t val)
+{
+	// Convert the host-type value to little-endian before filling array
+	val = host_to_le(val);
+	memcpy(reinterpret_cast<void *>(arr),
+	       reinterpret_cast<const void *>(&val), sizeof(val));
+}
+static INLINE void host_addw(uint8_t *arr, const uint16_t &incr)
+{
+	const uint16_t val = host_readw(arr) + incr;
+	host_writew(arr, val);
+}
+
+// Read, write, and add using 32-bit double-words
+static INLINE uint32_t host_readd(const uint8_t *arr)
+{
+	uint32_t val;
+	memcpy(reinterpret_cast<void *>(&val),
+	       reinterpret_cast<const void *>(arr), sizeof(val));
+	// array sequence was DOS little-endian, so convert value to host-type
+	return le_to_host(val);
+}
+static INLINE void host_writed(uint8_t *arr, uint32_t val)
+{
+	// Convert the host-type value to little-endian before filling array
+	val = host_to_le(val);
+	memcpy(reinterpret_cast<void *>(arr),
+	       reinterpret_cast<const void *>(&val), sizeof(val));
+}
+static INLINE void host_addd(uint8_t *arr, const uint32_t &incr)
+{
+	const uint32_t val = host_readd(arr) + incr;
+	host_writed(arr, val);
+}
+
+// Read and write using 64-bit quad-words
+static INLINE uint64_t host_readq(const uint8_t *arr)
+{
+	uint64_t val;
+	memcpy(reinterpret_cast<void *>(&val),
+	       reinterpret_cast<const void *>(arr), sizeof(val));
+	// array sequence was DOS little-endian, so convert value to host-type
+	return le_to_host(val);
+}
+static INLINE void host_writeq(uint8_t *arr, uint64_t val)
+{
+	// Convert the host-type value to little-endian before filling array
+	val = host_to_le(val);
+	memcpy(reinterpret_cast<void *>(arr),
+	       reinterpret_cast<const void *>(&val), sizeof(val));
+}
+
+
+static INLINE void var_write(uint8_t *var, uint8_t val)
+{
+	host_writeb(var, val);
+}	
 
 static INLINE void var_write(Bit16u * var, Bit16u val) {
 	host_writew((HostPt)var, val);

--- a/include/mem.h
+++ b/include/mem.h
@@ -61,7 +61,7 @@ static INLINE uint8_t host_readb(const uint8_t *var)
 {
 	return *var;
 }
-static INLINE void host_writeb(uint8_t *var, const uint8_t &val)
+static INLINE void host_writeb(uint8_t *var, const uint8_t val)
 {
 	*var = val;
 }

--- a/include/mem.h
+++ b/include/mem.h
@@ -74,11 +74,22 @@ static INLINE uint16_t host_readw(const uint8_t *arr)
 	return le_to_host(val);
 }
 
+// Like the above, but allows index-style access assuming a 16-bit array
+static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
+{
+	return host_readw(arr + index * sizeof(uint16_t));
+}
+
 static INLINE void host_writew(uint8_t *arr, uint16_t val)
 {
 	// Convert the host-type value to little-endian before filling array
 	val = host_to_le(val);
 	memcpy(arr, &val, sizeof(val));
+}
+
+static INLINE void host_writew_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
+{
+	host_writew(arr + index * sizeof(uint16_t), val);
 }
 
 static INLINE void host_addw(uint8_t *arr, const uint16_t incr)
@@ -96,11 +107,22 @@ static INLINE uint32_t host_readd(const uint8_t *arr)
 	return le_to_host(val);
 }
 
+// Like the above, but allows index-style access assuming a 32-bit array
+static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
+{
+	return host_readd(arr + index * sizeof(uint32_t));
+}
+
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
 	// Convert the host-type value to little-endian before filling array
 	val = host_to_le(val);
 	memcpy(arr, &val, sizeof(val));
+}
+
+static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
+{
+	host_writed(arr + index * sizeof(uint32_t), val);
 }
 
 static INLINE void host_addd(uint8_t *arr, const uint32_t incr)

--- a/include/mem.h
+++ b/include/mem.h
@@ -24,7 +24,6 @@
 #include <cstring>
 
 #include "types.h"
-
 #include "byteorder.h"
 
 typedef Bit32u PhysPt;
@@ -64,84 +63,6 @@ static INLINE uint8_t host_readb(const uint8_t *var)
 static INLINE void host_writeb(uint8_t *var, const uint8_t val)
 {
 	*var = val;
-}
-
-// host_to_le functions allow for byte order conversion on big endian
-// architectures while respecting memory alignment on low endian.
-//
-// It is extremely unlikely that we'll ever try to compile on big endian arch
-// with a compiler missing __builtin_bswap*, so let's not overcomplicate
-// things.
-//
-// __builtin_bswap* is supported since GCC 4.3 and Clang 3.4
-
-constexpr static INLINE uint8_t host_to_le(uint8_t val) {
-	return val;
-}
-
-#if defined(WORDS_BIGENDIAN)
-
-constexpr static INLINE int16_t host_to_le(int16_t val) {
-	return __builtin_bswap16(val);
-}
-
-constexpr static INLINE uint16_t host_to_le(uint16_t val) {
-	return __builtin_bswap16(val);
-}
-
-constexpr static INLINE uint32_t host_to_le(uint32_t val) {
-	return __builtin_bswap32(val);
-}
-
-constexpr static INLINE uint64_t host_to_le(uint64_t val)
-{
-	return __builtin_bswap64(val);
-}
-
-#else
-
-constexpr static INLINE int16_t host_to_le(int16_t val) {
-	return val;
-}
-
-constexpr static INLINE uint16_t host_to_le(uint16_t val) {
-	return val;
-}
-
-constexpr static INLINE uint32_t host_to_le(uint32_t val) {
-	return val;
-}
-
-constexpr static INLINE uint64_t host_to_le(uint64_t val)
-{
-	return val;
-}
-
-#endif
-
-constexpr static INLINE uint8_t le_to_host(uint8_t val)
-{
-	return host_to_le(val);
-}
-
-constexpr static INLINE int16_t le_to_host(int16_t val)
-{
-	return host_to_le(val);
-}
-
-constexpr static INLINE uint16_t le_to_host(uint16_t val)
-{
-	return host_to_le(val);
-}
-
-constexpr static INLINE uint32_t le_to_host(uint32_t val)
-{
-	return host_to_le(val);
-}
-
-constexpr static INLINE uint64_t le_to_host(uint64_t val)
-{
-	return host_to_le(val);
 }
 
 // Read, write, and add using 16-bit words

--- a/include/mem.h
+++ b/include/mem.h
@@ -83,7 +83,7 @@ static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
 static INLINE void host_writew(uint8_t *arr, uint16_t val)
 {
 	// Convert the host-type value to little-endian before filling array
-	(val) = host_to_le16(val);
+	val = host_to_le16(val);
 	memcpy(arr, &val, sizeof(val));
 }
 
@@ -116,7 +116,7 @@ static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
 	// Convert the host-type value to little-endian before filling array
-	(val) = host_to_le32(val);
+	val = host_to_le32(val);
 	memcpy(arr, &val, sizeof(val));
 }
 
@@ -143,7 +143,7 @@ static INLINE uint64_t host_readq(const uint8_t *arr)
 static INLINE void host_writeq(uint8_t *arr, uint64_t val)
 {
 	// Convert the host-type value to little-endian before filling array
-	(val) = host_to_le64(val); 
+	val = host_to_le64(val);
 	memcpy(arr, &val, sizeof(val));
 }
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -71,7 +71,7 @@ static INLINE uint16_t host_readw(const uint8_t *arr)
 	uint16_t val;
 	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
-	return le_to_host(val);
+	return le_to_host16(val);
 }
 
 // Like the above, but allows index-style access assuming a 16-bit array
@@ -83,7 +83,7 @@ static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
 static INLINE void host_writew(uint8_t *arr, uint16_t val)
 {
 	// Convert the host-type value to little-endian before filling array
-	val = host_to_le(val);
+	(val) = host_to_le16(val);
 	memcpy(arr, &val, sizeof(val));
 }
 
@@ -104,7 +104,7 @@ static INLINE uint32_t host_readd(const uint8_t *arr)
 	uint32_t val;
 	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
-	return le_to_host(val);
+	return le_to_host32(val);
 }
 
 // Like the above, but allows index-style access assuming a 32-bit array
@@ -116,7 +116,7 @@ static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
 	// Convert the host-type value to little-endian before filling array
-	val = host_to_le(val);
+	(val) = host_to_le32(val);
 	memcpy(arr, &val, sizeof(val));
 }
 
@@ -137,13 +137,13 @@ static INLINE uint64_t host_readq(const uint8_t *arr)
 	uint64_t val;
 	memcpy(&val, arr, sizeof(val));
 	// array sequence was DOS little-endian, so convert value to host-type
-	return le_to_host(val);
+	return le_to_host64(val);
 }
 
 static INLINE void host_writeq(uint8_t *arr, uint64_t val)
 {
 	// Convert the host-type value to little-endian before filling array
-	val = host_to_le(val);
+	(val) = host_to_le64(val); 
 	memcpy(arr, &val, sizeof(val));
 }
 

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -14,14 +14,18 @@ TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno
                  -fno-strict-aliasing)
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
+
+cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
+                  -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion
+                  -Wdouble-promotion -Wformat=2 -fstrict-aliasing -Wstrict-aliasing=2)
+cxxonly_warnmore+=(-Wnon-virtual-dtor -Woverloaded-virtual)
+
 cflags_pgotrain+=("${cflags_debug[@]}" -fprofile-instr-generate
                   -fcoverage-mapping)
-cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align
-                  -Wunused -Woverloaded-virtual -Wpedantic -Wconversion
-                  -Wsign-conversion -Wdouble-promotion -Wformat=2)
-cxxonly_warnmore+=(-Wnon-virtual-dtor -Woverloaded-virtual)
+
 cflags_optinfo+=("${cflags_release[@]}" -Rpass-analysis=loop-vectorize
                  -gline-tables-only -gcolumn-info)
+
 cflags_msan=("${cflags_debug[@]}" -fsanitize-recover=all -fPIE -pie
              -fsanitize=memory -fno-omit-frame-pointer)
 cflags_usan=("${cflags_debug[@]}" -fsanitize-recover=all

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -18,17 +18,21 @@ cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing
                  -fno-signed-zeros -fno-trapping-math -fassociative-math
                  -frename-registers -ffunction-sections -fdata-sections)
-cflags_pgotrain+=("${cflags_debug[@]}" -pg -ftree-vectorize)
-cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align
-                  -Wdouble-promotion -Wduplicated-branches
-                  -Wduplicated-cond -Wextra -Wformat=2 -Wlogical-op
-                  -Wmisleading-indentation -Wnull-dereference -Wshadow
-                  -Wunused)
+
+cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
+                  -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2
+                  -Wlogical-op -Wmisleading-indentation -Wnull-dereference
+                  -Wshadow -Wunused -fstrict-aliasing -Wstrict-aliasing=2)
 cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual
                    -Wuseless-cast)
+
+cflags_pgotrain+=("${cflags_debug[@]}" -pg -ftree-vectorize)
+
 cflags_fdotrain+=("${cflags[@]}" -DNDEBUG -g1 -fno-omit-frame-pointer)
+
 cflags_optinfo+=("${cflags_release[@]}" -fopt-info-missed
                  -ftree-vectorizer-verbose=6)
+
 cflags_asan+=("${cflags_debug[@]}" -fsanitize=address)
 ldflags_asan+=(-static-libasan)
 cflags_uasan+=("${cflags_debug[@]}" -fsanitize=address,undefined

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -15,7 +15,7 @@ cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 # Note: associative-math is needed for vectorization of floating point
 #       calculations, which also relies on no-signed-zeros and
 #       no-trapping-math.
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-strict-aliasing
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing
                  -fno-signed-zeros -fno-trapping-math -fassociative-math
                  -frename-registers -ffunction-sections -fdata-sections)
 cflags_pgotrain+=("${cflags_debug[@]}" -pg -ftree-vectorize)

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -114,7 +114,7 @@ public:
 		addr&=4095;
 		if (host_readb(hostmem+addr)==(Bit8u)val) return;
 		host_writeb(hostmem+addr,val);
-		if (!*(Bit8u*)&write_map[addr]) {
+		if (!write_map[addr]) {
 			if (active_blocks) return;
 			active_count--;
 			if (!active_count) Release();
@@ -186,7 +186,7 @@ public:
 		}
 		addr&=4095;
 		if (host_readb(hostmem+addr)==(Bit8u)val) return false;
-		if (!*(Bit8u*)&write_map[addr]) {
+		if (!write_map[addr]) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -151,7 +151,7 @@ public:
 			}
 			memset(invalidation_map,0,4096);
 		}
-		(*(Bit16u*)&invalidation_map[addr])+=0x101;
+		host_addw(invalidation_map + addr, 0x101);
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -176,7 +176,7 @@ public:
 			}
 			memset(invalidation_map,0,4096);
 		}
-		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
+		host_addd(invalidation_map + addr, 0x1010101);
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -230,7 +230,7 @@ public:
 				}
 				memset(invalidation_map,0,4096);
 			}
-			(*(Bit16u*)&invalidation_map[addr])+=0x101;
+			host_addw(invalidation_map + addr, 0x101);
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -261,7 +261,7 @@ public:
 				}
 				memset(invalidation_map,0,4096);
 			}
-			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
+			host_addd(invalidation_map + addr, 0x1010101);
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -137,8 +137,10 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return;
 		host_writew(hostmem+addr,val);
-		if (!*(Bit16u*)&write_map[addr]) {
-			if (active_blocks) return;
+		const uint16_t is_mapped = host_readw(write_map + addr);
+		if (!is_mapped) {
+			if (active_blocks)
+				return;
 			active_count--;
 			if (!active_count) Release();
 			return;
@@ -160,8 +162,10 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return;
 		host_writed(hostmem+addr,val);
-		if (!*(Bit32u*)&write_map[addr]) {
-			if (active_blocks) return;
+		const uint32_t is_mapped = host_readd(write_map + addr);
+		if (!is_mapped) {
+			if (active_blocks)
+				return;
 			active_count--;
 			if (!active_count) Release();
 			return;
@@ -211,7 +215,9 @@ public:
 		}
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
-		if (!*(Bit16u*)&write_map[addr]) {
+
+		const uint16_t is_mapped = host_readw(write_map + addr);
+		if (!is_mapped) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();
@@ -240,7 +246,9 @@ public:
 		}
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
-		if (!*(Bit32u*)&write_map[addr]) {
+
+		const uint32_t is_mapped = host_readd(write_map + addr);
+		if (!is_mapped) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -487,19 +487,22 @@ static INLINE void cache_addb(Bit8u val) {
 	*cache.pos++=val;
 }
 
-static INLINE void cache_addw(Bit16u val) {
-	*(Bit16u*)cache.pos=val;
-	cache.pos+=2;
+static INLINE void cache_addw(const uint16_t &val)
+{
+	host_writew(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
-static INLINE void cache_addd(Bit32u val) {
-	*(Bit32u*)cache.pos=val;
-	cache.pos+=4;
+static INLINE void cache_addd(const uint32_t &val)
+{
+	host_writed(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
-static INLINE void cache_addq(Bit64u val) {
-	*(Bit64u*)cache.pos=val;
-	cache.pos+=8;
+static INLINE void cache_addq(const uint64_t &val)
+{
+	host_writeq(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
 static void gen_return(BlockReturn retcode);

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -487,19 +487,19 @@ static INLINE void cache_addb(Bit8u val) {
 	*cache.pos++=val;
 }
 
-static INLINE void cache_addw(const uint16_t &val)
+static INLINE void cache_addw(const uint16_t val)
 {
 	host_writew(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
-static INLINE void cache_addd(const uint32_t &val)
+static INLINE void cache_addd(const uint32_t val)
 {
 	host_writed(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
-static INLINE void cache_addq(const uint64_t &val)
+static INLINE void cache_addq(const uint64_t val)
 {
 	host_writeq(cache.pos, val);
 	cache.pos += sizeof(val);

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -197,9 +197,11 @@ static INLINE void decode_increase_wmapmask(Bitu size) {
 		}
 	}
 	switch (size) {
-		case 1 : activecb->cache.wmapmask[mapidx]+=0x01; break;
-		case 2 : (*(Bit16u*)&activecb->cache.wmapmask[mapidx])+=0x0101; break;
-		case 4 : (*(Bit32u*)&activecb->cache.wmapmask[mapidx])+=0x01010101; break;
+	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
+
+	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
+
+	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
 	}
 }
 

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -198,9 +198,7 @@ static INLINE void decode_increase_wmapmask(Bitu size) {
 	}
 	switch (size) {
 	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-
 	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
-
 	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
 	}
 }

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -140,28 +140,32 @@ static Bit8u decode_fetchb(void) {
 	decode.code+=1;
 	return mem_readb(decode.code-1);
 }
-static Bit16u decode_fetchw(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4095)) {
-   		Bit16u val=decode_fetchb();
-		val|=decode_fetchb() << 8;
+static uint16_t decode_fetchw()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4095)) {
+		uint16_t val = decode_fetchb();
+		val |= decode_fetchb() << 8;
 		return val;
 	}
-	*(Bit16u *)&decode.page.wmap[decode.page.index]+=0x0101;
-	decode.code+=2;decode.page.index+=2;
-	return mem_readw(decode.code-2);
+	host_addw(decode.page.wmap + decode.page.index, 0x0101);
+	decode.code += sizeof(uint16_t);
+	decode.page.index += sizeof(uint16_t);
+	return mem_readw(decode.code - sizeof(uint16_t));
 }
-static Bit32u decode_fetchd(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4093)) {
-   		Bit32u val=decode_fetchb();
-		val|=decode_fetchb() << 8;
-		val|=decode_fetchb() << 16;
+static uint32_t decode_fetchd()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4093)) {
+		Bit32u val = decode_fetchb();
+		val |= decode_fetchb() << 8;
+		val |= decode_fetchb() << 16;
 		val|=decode_fetchb() << 24;
 		return val;
         /* Advance to the next page */
 	}
-	*(Bit32u *)&decode.page.wmap[decode.page.index]+=0x01010101;
-	decode.code+=4;decode.page.index+=4;
-	return mem_readd(decode.code-4);
+	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
+	decode.code += sizeof(uint32_t);
+	decode.page.index += sizeof(uint32_t);
+	return mem_readd(decode.code - sizeof(uint32_t));
 }
 
 #define START_WMMEM 64

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1150,8 +1150,9 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_branch_long(Bit8u * data,Bit8u * from=cache.pos) {
-	*(Bit32u*)data=(Bit32u)(from-data-4);
+static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos)
+{
+	host_writed(data, from - data - sizeof(uint32_t));
 }
 
 static Bit8u * gen_create_jump(Bit8u * to=0) {

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -272,7 +272,8 @@ public:
 static BlockReturn gen_runcodeInit(Bit8u *code);
 static BlockReturn (*gen_runcode)(Bit8u *code) = gen_runcodeInit;
 
-static BlockReturn gen_runcodeInit(Bit8u *code) {
+static BlockReturn gen_runcodeInit(uint8_t *code)
+{
 	Bit8u* oldpos = cache.pos;
 	cache.pos = &cache_code_link_blocks[128];
 	gen_runcode = (BlockReturn(*)(Bit8u*))cache.pos;
@@ -303,7 +304,7 @@ static BlockReturn gen_runcodeInit(Bit8u *code) {
 	opcode(0).setea(4,-1,0,CALLSTACK).Emit8(0x89);  // mov [rsp+8/40], eax
 	opcode(4).setrm(ARG0_REG).Emit8(0xFF);   // jmp ARG0
 
-	*(Bit32u*)diff = (Bit32u)(cache.pos - diff - 4);
+	host_writed(diff, cache.pos - diff - sizeof(uint32_t));
 	// eax = return value, ecx = flags
 	opcode(1).setea(5,-1,0,offsetof(CPU_Regs,flags)).Emit8(0x33); // xor ecx, reg_flags
 	opcode(4).setrm(1).setimm(FMASK_TEST,4).Emit8(0x81);          // and ecx,FMASK_TEST

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1155,11 +1155,12 @@ static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos)
 	host_writed(data, from - data - sizeof(uint32_t));
 }
 
-static Bit8u * gen_create_jump(Bit8u * to=0) {
+static uint8_t *gen_create_jump(uint8_t *to = 0)
+{
 	/* First free all registers */
 	cache_addb(0xe9);
-	cache_addd((Bit32u)(to-(cache.pos+4)));
-	return (cache.pos-4);
+	cache_addd(to - cache.pos - sizeof(uint32_t));
+	return cache.pos - sizeof(uint32_t);
 }
 
 #if 0

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1164,8 +1164,8 @@ static uint8_t *gen_create_jump(uint8_t *to = 0)
 }
 
 #if 0
-static void gen_fill_jump(Bit8u * data,Bit8u * to=cache.pos) {
-	*(Bit32u*)data=(Bit32u)(to-data-4);
+static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
+	host_writed(data, to - data - sizeof(uint32_t));
 }
 #endif
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -994,8 +994,8 @@ static Bit8u * gen_create_jump(Bit8u * to=0) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_jump(Bit8u * data,Bit8u * to=cache.pos) {
-	*(Bit32u*)data=(to-data-4);
+static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
+	host_writed(data, to - data - sizeof(uint32_t));
 }
 
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -983,8 +983,8 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_branch_long(Bit8u * data,Bit8u * from=cache.pos) {
-	*(Bit32u*)data=(from-data-4);
+static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos) {
+	host_writed(data, from - data - sizeof(uint32_t));
 }
 
 static Bit8u * gen_create_jump(Bit8u * to=0) {

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -171,12 +171,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-		host_writew(&invalidation_map[addr],
-			host_readw(&invalidation_map[addr])+0x101);
-#else
-		(*(Bit16u*)&invalidation_map[addr])+=0x101;
-#endif
+		host_addw(invalidation_map + addr, 0x101);
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -193,12 +188,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-		host_writed(&invalidation_map[addr],
-			host_readd(&invalidation_map[addr])+0x1010101);
-#else
-		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
-#endif
+		host_addd(invalidation_map + addr, 0x1010101);
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -240,12 +230,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-			host_writew(&invalidation_map[addr],
-				host_readw(&invalidation_map[addr])+0x101);
-#else
-			(*(Bit16u*)&invalidation_map[addr])+=0x101;
-#endif
+			host_addw(invalidation_map + addr, 0x101);
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -269,12 +254,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-			host_writed(&invalidation_map[addr],
-				host_readd(&invalidation_map[addr])+0x1010101);
-#else
-			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
-#endif
+			host_addd(invalidation_map + addr, 0x1010101);
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -513,19 +513,19 @@ static INLINE void cache_addb(Bit8u val) {
 }
 
 // place a 16bit value into the cache
-static INLINE void cache_addw(const uint16_t &val) {
+static INLINE void cache_addw(const uint16_t val) {
 	host_writew(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
 // place a 32bit value into the cache
-static INLINE void cache_addd(const uint32_t &val) {
+static INLINE void cache_addd(const uint32_t val) {
 	host_writed(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
 // place a 64bit value into the cache
-static INLINE void cache_addq(const uint64_t &val) {
+static INLINE void cache_addq(const uint64_t val) {
 	host_writeq(cache.pos, val);
 	cache.pos += sizeof(val);
 }

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -533,23 +533,22 @@ static INLINE void cache_addb(Bit8u val) {
 }
 
 // place a 16bit value into the cache
-static INLINE void cache_addw(Bit16u val) {
-	*(Bit16u*)cache.pos=val;
-	cache.pos+=2;
+static INLINE void cache_addw(const uint16_t &val) {
+	host_writew(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
 // place a 32bit value into the cache
-static INLINE void cache_addd(Bit32u val) {
-	*(Bit32u*)cache.pos=val;
-	cache.pos+=4;
+static INLINE void cache_addd(const uint32_t &val) {
+	host_writed(cache.pos, val);
+	cache.pos += sizeof(val);
 }
 
 // place a 64bit value into the cache
-static INLINE void cache_addq(Bit64u val) {
-	*(Bit64u*)cache.pos=val;
-	cache.pos+=8;
+static INLINE void cache_addq(const uint64_t &val) {
+	host_writeq(cache.pos, val);
+	cache.pos += sizeof(val);
 }
-
 
 static void dyn_return(BlockReturn retcode,bool ret_exception);
 static void dyn_run_code(void);

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -292,9 +292,14 @@ static void INLINE decode_increase_wmapmask(Bitu size) {
 	// update mask entries
 	switch (size) {
 		case 1 : activecb->cache.wmapmask[mapidx]+=0x01; break;
-		case 2 : (*(Bit16u*)&activecb->cache.wmapmask[mapidx])+=0x0101; break;
-		case 4 : (*(Bit32u*)&activecb->cache.wmapmask[mapidx])+=0x01010101; break;
-	}
+	        case 2:
+		        host_addw(activecb->cache.wmapmask + mapidx, 0x0101);
+		        break;
+
+	        case 4:
+		        host_addd(activecb->cache.wmapmask + mapidx, 0x01010101);
+		        break;
+	        }
 }
 
 // fetch a byte, val points to the code location if possible,

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -291,15 +291,10 @@ static void INLINE decode_increase_wmapmask(Bitu size) {
 	}
 	// update mask entries
 	switch (size) {
-		case 1 : activecb->cache.wmapmask[mapidx]+=0x01; break;
-	        case 2:
-		        host_addw(activecb->cache.wmapmask + mapidx, 0x0101);
-		        break;
-
-	        case 4:
-		        host_addd(activecb->cache.wmapmask + mapidx, 0x01010101);
-		        break;
-	        }
+		case 1: activecb->cache.wmapmask[mapidx]+=0x01; break;
+		case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
+		case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
+	}
 }
 
 // fetch a byte, val points to the code location if possible,

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -221,39 +221,44 @@ static void decode_advancepage(void) {
 }
 
 // fetch the next byte of the instruction stream
-static Bit8u decode_fetchb(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4096)) {
+static uint8_t decode_fetchb()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4096)) {
 		decode_advancepage();
 	}
-	decode.page.wmap[decode.page.index]+=0x01;
+	decode.page.wmap[decode.page.index] += 0x01;
 	decode.page.index++;
-	decode.code+=1;
-	return mem_readb(decode.code-1);
+	decode.code += 1;
+	return mem_readb(decode.code - 1);
 }
 // fetch the next word of the instruction stream
-static Bit16u decode_fetchw(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4095)) {
-   		Bit16u val=decode_fetchb();
-		val|=decode_fetchb() << 8;
+static uint16_t decode_fetchw()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4095)) {
+		Bit16u val = decode_fetchb();
+		val |= decode_fetchb() << 8;
 		return val;
 	}
-	*(Bit16u *)&decode.page.wmap[decode.page.index]+=0x0101;
-	decode.code+=2;decode.page.index+=2;
-	return mem_readw(decode.code-2);
+	host_addw(decode.page.wmap + decode.page.index, 0x0101);
+	decode.code += sizeof(uint16_t);
+	decode.page.index += sizeof(uint16_t);
+	return mem_readw(decode.code - sizeof(uint16_t));
 }
 // fetch the next dword of the instruction stream
-static Bit32u decode_fetchd(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4093)) {
-   		Bit32u val=decode_fetchb();
-		val|=decode_fetchb() << 8;
-		val|=decode_fetchb() << 16;
-		val|=decode_fetchb() << 24;
+static uint32_t decode_fetchd()
+{
+	if (GCC_UNLIKELY(decode.page.index >= 4093)) {
+		Bit32u val = decode_fetchb();
+		val |= decode_fetchb() << 8;
+		val |= decode_fetchb() << 16;
+		val |= decode_fetchb() << 24;
 		return val;
-        /* Advance to the next page */
+		/* Advance to the next page */
 	}
-	*(Bit32u *)&decode.page.wmap[decode.page.index]+=0x01010101;
-	decode.code+=4;decode.page.index+=4;
-	return mem_readd(decode.code-4);
+	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
+	decode.code += sizeof(uint32_t);
+	decode.page.index += sizeof(uint32_t);
+	return mem_readd(decode.code - sizeof(uint32_t));
 }
 
 #define START_WMMEM 64

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -385,7 +385,7 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 #endif
 		for (i=0;i<height;i++) {
 			void *rowPointer;
-			void *srcLine;
+			uint8_t *srcLine;
 			if (flags & CAPTURE_FLAG_DBLH)
 				srcLine=(data+(i >> 1)*pitch);
 			else
@@ -396,21 +396,21 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 				if (flags & CAPTURE_FLAG_DBLW) {
    					for (Bitu x=0;x<countWidth;x++)
 						doubleRow[x*2+0] =
-						doubleRow[x*2+1] = ((Bit8u *)srcLine)[x];
+						doubleRow[x*2+1] = srcLine[x];
 					rowPointer = doubleRow;
 				}
 				break;
 			case 15:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x=0;x<countWidth;x++) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
+					for (Bitu x = 0; x < countWidth; x++) {
+						const Bitu pixel = host_readw_at(srcLine, x);
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x03e0) * 0x21) >>  7;
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0x7c00) * 0x21) >>  12;
 					}
 				} else {
-					for (Bitu x=0;x<countWidth;x++) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
+					for (Bitu x = 0; x < countWidth; x++) {
+						const Bitu pixel = host_readw_at(srcLine, x);
 						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*3+1] = ((pixel& 0x03e0) * 0x21) >>  7;
 						doubleRow[x*3+2] = ((pixel& 0x7c00) * 0x21) >>  12;
@@ -420,15 +420,15 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 				break;
 			case 16:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x=0;x<countWidth;x++) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
+					for (Bitu x = 0; x < countWidth; x++) {
+						const Bitu pixel = host_readw_at(srcLine, x);
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >> 2;
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x07e0) * 0x41) >> 9;
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0xf800) * 0x21) >> 13;
 					}
 				} else {
-					for (Bitu x=0;x<countWidth;x++) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
+					for (Bitu x = 0; x < countWidth; x++) {
+						const Bitu pixel = host_readw_at(srcLine, x);
 						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*3+1] = ((pixel& 0x07e0) * 0x41) >>  9;
 						doubleRow[x*3+2] = ((pixel& 0xf800) * 0x21) >>  13;
@@ -439,15 +439,15 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 			case 32:
 				if (flags & CAPTURE_FLAG_DBLW) {
 					for (Bitu x=0;x<countWidth;x++) {
-						doubleRow[x*6+0] = doubleRow[x*6+3] = ((Bit8u *)srcLine)[x*4+0];
-						doubleRow[x*6+1] = doubleRow[x*6+4] = ((Bit8u *)srcLine)[x*4+1];
-						doubleRow[x*6+2] = doubleRow[x*6+5] = ((Bit8u *)srcLine)[x*4+2];
+						doubleRow[x*6+0] = doubleRow[x*6+3] = srcLine[x*4+0];
+						doubleRow[x*6+1] = doubleRow[x*6+4] = srcLine[x*4+1];
+						doubleRow[x*6+2] = doubleRow[x*6+5] = srcLine[x*4+2];
 					}
 				} else {
 					for (Bitu x=0;x<countWidth;x++) {
-						doubleRow[x*3+0] = ((Bit8u *)srcLine)[x*4+0];
-						doubleRow[x*3+1] = ((Bit8u *)srcLine)[x*4+1];
-						doubleRow[x*3+2] = ((Bit8u *)srcLine)[x*4+2];
+						doubleRow[x*3+0] = srcLine[x*4+0];
+						doubleRow[x*3+1] = srcLine[x*4+1];
+						doubleRow[x*3+2] = srcLine[x*4+2];
 					}
 				}
 				rowPointer = doubleRow;
@@ -523,7 +523,7 @@ skip_shot:
 		for (i=0;i<height;i++) {
 			void * rowPointer;
 			if (flags & CAPTURE_FLAG_DBLW) {
-				void *srcLine;
+				uint8_t *srcLine;
 				Bitu x;
 				Bitu countWidth = width >> 1;
 				if (flags & CAPTURE_FLAG_DBLH)
@@ -533,19 +533,23 @@ skip_shot:
 				switch ( bpp) {
 				case 8:
 					for (x=0;x<countWidth;x++)
-						((Bit8u *)doubleRow)[x*2+0] =
-						((Bit8u *)doubleRow)[x*2+1] = ((Bit8u *)srcLine)[x];
+						doubleRow[x*2+0] =
+						doubleRow[x*2+1] = srcLine[x];
 					break;
 				case 15:
 				case 16:
-					for (x=0;x<countWidth;x++)
-						((Bit16u *)doubleRow)[x*2+0] =
-						((Bit16u *)doubleRow)[x*2+1] = ((Bit16u *)srcLine)[x];
+					for (x = 0; x < countWidth; x++) {
+						const uint16_t pixel = host_readw_at(srcLine, x);
+						host_writew_at(doubleRow, x * 2, pixel);
+						host_writew_at(doubleRow, x * 2 + 1, pixel);
+					}
 					break;
 				case 32:
-					for (x=0;x<countWidth;x++)
-						((Bit32u *)doubleRow)[x*2+0] =
-						((Bit32u *)doubleRow)[x*2+1] = ((Bit32u *)srcLine)[x];
+					for (x = 0; x < countWidth; x++) {
+						const uint32_t pixel = host_readd_at(srcLine, x);
+						host_writed_at(doubleRow, x * 2, pixel);
+						host_writed_at(doubleRow, x * 2 + 1, pixel);
+					}
 					break;
 				}
                 rowPointer=doubleRow;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -505,8 +505,8 @@ static void MIXER_MixData(Bitu needed) {
 			const int32_t sample_2 = mixer.work[readpos][1] >> MIXER_VOLSHIFT;
 			const int16_t s1 = MIXER_CLIP(sample_1);
 			const int16_t s2 = MIXER_CLIP(sample_2);
-			convert[i][0] = host_to_le(static_cast<uint16_t>(s1));
-			convert[i][1] = host_to_le(static_cast<uint16_t>(s2));
+			convert[i][0] = host_to_le16(s1);
+			convert[i][1] = host_to_le16(s2);
 			readpos = (readpos + 1) & MIXER_BUFMASK;
 		}
 		CAPTURE_AddWave(mixer.freq, added, reinterpret_cast<int16_t*>(convert));

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -148,77 +148,90 @@ foundit:
 	switch (mblock->type) {
 	case M_LIN4:
 		pageSize = mblock->sheight * mblock->swidth/2;
-		var_write(&minfo.BytesPerScanLine,mblock->swidth/8);
-		var_write(&minfo.NumberOfPlanes,0x4);
-		var_write(&minfo.BitsPerPixel,4);
-		var_write(&minfo.MemoryModel,3);	//ega planar mode
-		modeAttributes = 0x1b;	// Color, graphics, no linear buffer
+		minfo.BytesPerScanLine = host_to_le(
+		        static_cast<uint16_t>(mblock->swidth / 8));
+		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x4));
+		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(4));
+		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(3)); // ega
+		                                                         // planar
+		                                                         // mode
+		modeAttributes = 0x1b; // Color, graphics, no linear buffer
 		break;
 	case M_LIN8:
 		pageSize = mblock->sheight * mblock->swidth;
-		var_write(&minfo.BytesPerScanLine,mblock->swidth);
-		var_write(&minfo.NumberOfPlanes,0x1);
-		var_write(&minfo.BitsPerPixel,8);
-		var_write(&minfo.MemoryModel,4);		//packed pixel
-		modeAttributes = 0x1b;	// Color, graphics
-		if (!int10.vesa_nolfb) modeAttributes |= 0x80;	// linear framebuffer
+		minfo.BytesPerScanLine = host_to_le(
+		        static_cast<uint16_t>(mblock->swidth));
+		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
+		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(8));
+		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(4)); // packed
+		                                                         // pixel
+		modeAttributes = 0x1b; // Color, graphics
+		if (!int10.vesa_nolfb)
+			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_LIN15:
 		pageSize = mblock->sheight * mblock->swidth*2;
-		var_write(&minfo.BytesPerScanLine,mblock->swidth*2);
-		var_write(&minfo.NumberOfPlanes,0x1);
-		var_write(&minfo.BitsPerPixel,15);
-		var_write(&minfo.MemoryModel,6);	//HiColour
-		var_write(&minfo.RedMaskSize,5);
-		var_write(&minfo.RedMaskPos,10);
-		var_write(&minfo.GreenMaskSize,5);
-		var_write(&minfo.GreenMaskPos,5);
-		var_write(&minfo.BlueMaskSize,5);
-		var_write(&minfo.BlueMaskPos,0);
-		var_write(&minfo.ReservedMaskSize,0x01);
-		var_write(&minfo.ReservedMaskPos,0x0f);
-		modeAttributes = 0x1b;	// Color, graphics
-		if (!int10.vesa_nolfb) modeAttributes |= 0x80;	// linear framebuffer
+		minfo.BytesPerScanLine = host_to_le(
+		        static_cast<uint16_t>(mblock->swidth * 2));
+		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
+		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(15));
+		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(6)); // HiColour
+		minfo.RedMaskSize = host_to_le(static_cast<uint8_t>(5));
+		minfo.RedMaskPos = host_to_le(static_cast<uint8_t>(10));
+		minfo.GreenMaskSize = host_to_le(static_cast<uint8_t>(5));
+		minfo.GreenMaskPos = host_to_le(static_cast<uint8_t>(5));
+		minfo.BlueMaskSize = host_to_le(static_cast<uint8_t>(5));
+		minfo.BlueMaskPos = host_to_le(static_cast<uint8_t>(0));
+		minfo.ReservedMaskSize = host_to_le(static_cast<uint8_t>(0x01));
+		minfo.ReservedMaskPos = host_to_le(static_cast<uint8_t>(0x0f));
+		modeAttributes = 0x1b; // Color, graphics
+		if (!int10.vesa_nolfb)
+			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_LIN16:
 		pageSize = mblock->sheight * mblock->swidth*2;
-		var_write(&minfo.BytesPerScanLine,mblock->swidth*2);
-		var_write(&minfo.NumberOfPlanes,0x1);
-		var_write(&minfo.BitsPerPixel,16);
-		var_write(&minfo.MemoryModel,6);	//HiColour
-		var_write(&minfo.RedMaskSize,5);
-		var_write(&minfo.RedMaskPos,11);
-		var_write(&minfo.GreenMaskSize,6);
-		var_write(&minfo.GreenMaskPos,5);
-		var_write(&minfo.BlueMaskSize,5);
-		var_write(&minfo.BlueMaskPos,0);
-		modeAttributes = 0x1b;	// Color, graphics
-		if (!int10.vesa_nolfb) modeAttributes |= 0x80;	// linear framebuffer
+		minfo.BytesPerScanLine = host_to_le(
+		        static_cast<uint16_t>(mblock->swidth * 2));
+		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
+		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(16));
+		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(6)); // HiColour
+		minfo.RedMaskSize = host_to_le(static_cast<uint8_t>(5));
+		minfo.RedMaskPos = host_to_le(static_cast<uint8_t>(11));
+		minfo.GreenMaskSize = host_to_le(static_cast<uint8_t>(6));
+		minfo.GreenMaskPos = host_to_le(static_cast<uint8_t>(5));
+		minfo.BlueMaskSize = host_to_le(static_cast<uint8_t>(5));
+		minfo.BlueMaskPos = host_to_le(static_cast<uint8_t>(0));
+		modeAttributes = 0x1b; // Color, graphics
+		if (!int10.vesa_nolfb)
+			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_LIN32:
 		pageSize = mblock->sheight * mblock->swidth*4;
-		var_write(&minfo.BytesPerScanLine,mblock->swidth*4);
-		var_write(&minfo.NumberOfPlanes,0x1);
-		var_write(&minfo.BitsPerPixel,32);
-		var_write(&minfo.MemoryModel,6);	//HiColour
-		var_write(&minfo.RedMaskSize,8);
-		var_write(&minfo.RedMaskPos,0x10);
-		var_write(&minfo.GreenMaskSize,0x8);
-		var_write(&minfo.GreenMaskPos,0x8);
-		var_write(&minfo.BlueMaskSize,0x8);
-		var_write(&minfo.BlueMaskPos,0x0);
-		var_write(&minfo.ReservedMaskSize,0x8);
-		var_write(&minfo.ReservedMaskPos,0x18);
-		modeAttributes = 0x1b;	// Color, graphics
-		if (!int10.vesa_nolfb) modeAttributes |= 0x80;	// linear framebuffer
+		minfo.BytesPerScanLine = host_to_le(
+		        static_cast<uint16_t>(mblock->swidth * 4));
+		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
+		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(32));
+		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(6)); // HiColour
+		minfo.RedMaskSize = host_to_le(static_cast<uint8_t>(8));
+		minfo.RedMaskPos = host_to_le(static_cast<uint8_t>(0x10));
+		minfo.GreenMaskSize = host_to_le(static_cast<uint8_t>(0x8));
+		minfo.GreenMaskPos = host_to_le(static_cast<uint8_t>(0x8));
+		minfo.BlueMaskSize = host_to_le(static_cast<uint8_t>(0x8));
+		minfo.BlueMaskPos = host_to_le(static_cast<uint8_t>(0x0));
+		minfo.ReservedMaskSize = host_to_le(static_cast<uint8_t>(0x8));
+		minfo.ReservedMaskPos = host_to_le(static_cast<uint8_t>(0x18));
+		modeAttributes = 0x1b; // Color, graphics
+		if (!int10.vesa_nolfb)
+			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_TEXT:
 		pageSize = 0;
-		var_write(&minfo.BytesPerScanLine, mblock->twidth * 2);
-		var_write(&minfo.NumberOfPlanes,0x4);
-		var_write(&minfo.BitsPerPixel,4);
-		var_write(&minfo.MemoryModel,0);	// text
-		modeAttributes = 0x0f;	//Color, text, bios output
+		minfo.BytesPerScanLine = host_to_le(
+		        static_cast<uint16_t>(mblock->twidth * 2));
+		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x4));
+		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(4));
+		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(0)); // text
+		modeAttributes = 0x0f; // Color, text, bios output
 		break;
 	default:
 		return VESA_FAIL;
@@ -236,29 +249,30 @@ foundit:
 	} else if (pageSize) {
 		pages = (vga.vmemsize / pageSize)-1;
 	}
-	var_write(&minfo.NumberOfImagePages, pages);
-	var_write(&minfo.ModeAttributes, modeAttributes);
-	var_write(&minfo.WinAAttributes, 0x7);	// Exists/readable/writable
+	minfo.NumberOfImagePages = host_to_le(static_cast<uint8_t>(pages));
+	minfo.ModeAttributes = host_to_le(static_cast<uint16_t>(modeAttributes));
+	minfo.WinAAttributes = host_to_le(static_cast<uint8_t>(0x7)); // Exists/readable/writable
 
 	if (mblock->type==M_TEXT) {
-		var_write(&minfo.WinGranularity,32);
-		var_write(&minfo.WinSize,32);
-		var_write(&minfo.WinASegment,0xb800);
-		var_write(&minfo.XResolution,mblock->twidth);
-		var_write(&minfo.YResolution,mblock->theight);
+		minfo.WinGranularity = host_to_le(static_cast<uint16_t>(32));
+		minfo.WinSize = host_to_le(static_cast<uint16_t>(32));
+		minfo.WinASegment = host_to_le(static_cast<uint16_t>(0xb800));
+		minfo.XResolution = host_to_le(static_cast<uint16_t>(mblock->twidth));
+		minfo.YResolution = host_to_le(static_cast<uint16_t>(mblock->theight));
 	} else {
-		var_write(&minfo.WinGranularity,64);
-		var_write(&minfo.WinSize,64);
-		var_write(&minfo.WinASegment,0xa000);
-		var_write(&minfo.XResolution,mblock->swidth);
-		var_write(&minfo.YResolution,mblock->sheight);
+		minfo.WinGranularity = host_to_le(static_cast<uint16_t>(64));
+		minfo.WinSize = host_to_le(static_cast<uint16_t>(64));
+		minfo.WinASegment = host_to_le(static_cast<uint16_t>(0xa000));
+		minfo.XResolution = host_to_le(static_cast<uint16_t>(mblock->swidth));
+		minfo.YResolution = host_to_le(static_cast<uint16_t>(mblock->sheight));
 	}
-	var_write(&minfo.WinFuncPtr,int10.rom.set_window);
-	var_write(&minfo.NumberOfBanks,0x1);
-	var_write(&minfo.Reserved_page,0x1);
-	var_write(&minfo.XCharSize,mblock->cwidth);
-	var_write(&minfo.YCharSize,mblock->cheight);
-	if (!int10.vesa_nolfb) var_write(&minfo.PhysBasePtr,S3_LFB_BASE);
+	minfo.WinFuncPtr = host_to_le(static_cast<uint32_t>(int10.rom.set_window));
+	minfo.NumberOfBanks = host_to_le(static_cast<uint8_t>(0x1));
+	minfo.Reserved_page = host_to_le(static_cast<uint8_t>(0x1));
+	minfo.XCharSize = host_to_le(static_cast<uint8_t>(mblock->cwidth));
+	minfo.YCharSize = host_to_le(static_cast<uint8_t>(mblock->cheight));
+	if (!int10.vesa_nolfb)
+		minfo.PhysBasePtr = host_to_le(static_cast<uint32_t>(S3_LFB_BASE));
 
 	MEM_BlockWrite(buf,&minfo,sizeof(MODE_INFO));
 	return VESA_SUCCESS;

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -148,89 +148,80 @@ foundit:
 	switch (mblock->type) {
 	case M_LIN4:
 		pageSize = mblock->sheight * mblock->swidth/2;
-		minfo.BytesPerScanLine = host_to_le(
-		        static_cast<uint16_t>(mblock->swidth / 8));
-		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x4));
-		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(4));
-		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(3)); // ega
-		                                                         // planar
-		                                                         // mode
+		minfo.BytesPerScanLine = host_to_le16(mblock->swidth / 8);
+		minfo.NumberOfPlanes = 0x4;
+		minfo.BitsPerPixel = 4u;
+		minfo.MemoryModel = 3u; // ega planar mode
 		modeAttributes = 0x1b; // Color, graphics, no linear buffer
 		break;
 	case M_LIN8:
 		pageSize = mblock->sheight * mblock->swidth;
-		minfo.BytesPerScanLine = host_to_le(
-		        static_cast<uint16_t>(mblock->swidth));
-		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
-		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(8));
-		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(4)); // packed
-		                                                         // pixel
+		minfo.BytesPerScanLine = host_to_le16(mblock->swidth);
+		minfo.NumberOfPlanes = 0x1;
+		minfo.BitsPerPixel = 8u;
+		minfo.MemoryModel = 4u; // packed pixel
 		modeAttributes = 0x1b; // Color, graphics
 		if (!int10.vesa_nolfb)
 			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_LIN15:
 		pageSize = mblock->sheight * mblock->swidth*2;
-		minfo.BytesPerScanLine = host_to_le(
-		        static_cast<uint16_t>(mblock->swidth * 2));
-		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
-		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(15));
-		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(6)); // HiColour
-		minfo.RedMaskSize = host_to_le(static_cast<uint8_t>(5));
-		minfo.RedMaskPos = host_to_le(static_cast<uint8_t>(10));
-		minfo.GreenMaskSize = host_to_le(static_cast<uint8_t>(5));
-		minfo.GreenMaskPos = host_to_le(static_cast<uint8_t>(5));
-		minfo.BlueMaskSize = host_to_le(static_cast<uint8_t>(5));
-		minfo.BlueMaskPos = host_to_le(static_cast<uint8_t>(0));
-		minfo.ReservedMaskSize = host_to_le(static_cast<uint8_t>(0x01));
-		minfo.ReservedMaskPos = host_to_le(static_cast<uint8_t>(0x0f));
+		minfo.BytesPerScanLine = host_to_le16(mblock->swidth * 2);
+		minfo.NumberOfPlanes = 0x1;
+		minfo.BitsPerPixel = 15u;
+		minfo.MemoryModel = 6u; // HiColour
+		minfo.RedMaskSize = 5u;
+		minfo.RedMaskPos = 10u;
+		minfo.GreenMaskSize = 5u;
+		minfo.GreenMaskPos = 5u;
+		minfo.BlueMaskSize = 5u;
+		minfo.BlueMaskPos = 0u;
+		minfo.ReservedMaskSize = 0x01;
+		minfo.ReservedMaskPos = 0x0f;
 		modeAttributes = 0x1b; // Color, graphics
 		if (!int10.vesa_nolfb)
 			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_LIN16:
 		pageSize = mblock->sheight * mblock->swidth*2;
-		minfo.BytesPerScanLine = host_to_le(
-		        static_cast<uint16_t>(mblock->swidth * 2));
-		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
-		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(16));
-		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(6)); // HiColour
-		minfo.RedMaskSize = host_to_le(static_cast<uint8_t>(5));
-		minfo.RedMaskPos = host_to_le(static_cast<uint8_t>(11));
-		minfo.GreenMaskSize = host_to_le(static_cast<uint8_t>(6));
-		minfo.GreenMaskPos = host_to_le(static_cast<uint8_t>(5));
-		minfo.BlueMaskSize = host_to_le(static_cast<uint8_t>(5));
-		minfo.BlueMaskPos = host_to_le(static_cast<uint8_t>(0));
+		minfo.BytesPerScanLine = host_to_le16(mblock->swidth * 2);
+		minfo.NumberOfPlanes = 0x1;
+		minfo.BitsPerPixel = 16u;
+		minfo.MemoryModel = 6u; // HiColour
+		minfo.RedMaskSize = 5u;
+		minfo.RedMaskPos = 11u;
+		minfo.GreenMaskSize = 6u;
+		minfo.GreenMaskPos = 5u;
+		minfo.BlueMaskSize = 5u;
+		minfo.BlueMaskPos = 0u;
 		modeAttributes = 0x1b; // Color, graphics
 		if (!int10.vesa_nolfb)
 			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_LIN32:
 		pageSize = mblock->sheight * mblock->swidth*4;
-		minfo.BytesPerScanLine = host_to_le(
-		        static_cast<uint16_t>(mblock->swidth * 4));
-		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x1));
-		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(32));
-		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(6)); // HiColour
-		minfo.RedMaskSize = host_to_le(static_cast<uint8_t>(8));
-		minfo.RedMaskPos = host_to_le(static_cast<uint8_t>(0x10));
-		minfo.GreenMaskSize = host_to_le(static_cast<uint8_t>(0x8));
-		minfo.GreenMaskPos = host_to_le(static_cast<uint8_t>(0x8));
-		minfo.BlueMaskSize = host_to_le(static_cast<uint8_t>(0x8));
-		minfo.BlueMaskPos = host_to_le(static_cast<uint8_t>(0x0));
-		minfo.ReservedMaskSize = host_to_le(static_cast<uint8_t>(0x8));
-		minfo.ReservedMaskPos = host_to_le(static_cast<uint8_t>(0x18));
+		minfo.BytesPerScanLine = host_to_le(mblock->swidth * 4);
+		minfo.NumberOfPlanes = 0x1u;
+		minfo.BitsPerPixel = 32u;
+		minfo.MemoryModel = 6u; // HiColour
+		minfo.RedMaskSize = 8u;
+		minfo.RedMaskPos = 0x10;
+		minfo.GreenMaskSize = 0x8;
+		minfo.GreenMaskPos = 0x8;
+		minfo.BlueMaskSize = 0x8;
+		minfo.BlueMaskPos = 0x0;
+		minfo.ReservedMaskSize = 0x8;
+		minfo.ReservedMaskPos = 0x18;
 		modeAttributes = 0x1b; // Color, graphics
 		if (!int10.vesa_nolfb)
 			modeAttributes |= 0x80; // linear framebuffer
 		break;
 	case M_TEXT:
 		pageSize = 0;
-		minfo.BytesPerScanLine = host_to_le(
-		        static_cast<uint16_t>(mblock->twidth * 2));
-		minfo.NumberOfPlanes = host_to_le(static_cast<uint8_t>(0x4));
-		minfo.BitsPerPixel = host_to_le(static_cast<uint8_t>(4));
-		minfo.MemoryModel = host_to_le(static_cast<uint8_t>(0)); // text
+		minfo.BytesPerScanLine = host_to_le16(mblock->twidth * 2);
+		minfo.NumberOfPlanes = 0x4;
+		minfo.BitsPerPixel = 4u;
+		minfo.MemoryModel = 0u; // text
 		modeAttributes = 0x0f; // Color, text, bios output
 		break;
 	default:
@@ -249,30 +240,30 @@ foundit:
 	} else if (pageSize) {
 		pages = (vga.vmemsize / pageSize)-1;
 	}
-	minfo.NumberOfImagePages = host_to_le(static_cast<uint8_t>(pages));
-	minfo.ModeAttributes = host_to_le(static_cast<uint16_t>(modeAttributes));
-	minfo.WinAAttributes = host_to_le(static_cast<uint8_t>(0x7)); // Exists/readable/writable
+	minfo.NumberOfImagePages = pages;
+	minfo.ModeAttributes = host_to_le16(modeAttributes);
+	minfo.WinAAttributes = 0x7; // Exists/readable/writable
 
 	if (mblock->type==M_TEXT) {
-		minfo.WinGranularity = host_to_le(static_cast<uint16_t>(32));
-		minfo.WinSize = host_to_le(static_cast<uint16_t>(32));
-		minfo.WinASegment = host_to_le(static_cast<uint16_t>(0xb800));
-		minfo.XResolution = host_to_le(static_cast<uint16_t>(mblock->twidth));
-		minfo.YResolution = host_to_le(static_cast<uint16_t>(mblock->theight));
+		minfo.WinGranularity = host_to_le16(32);
+		minfo.WinSize = host_to_le16(32);
+		minfo.WinASegment = host_to_le16(0xb800);
+		minfo.XResolution = host_to_le16(mblock->twidth);
+		minfo.YResolution = host_to_le16(mblock->theight);
 	} else {
-		minfo.WinGranularity = host_to_le(static_cast<uint16_t>(64));
-		minfo.WinSize = host_to_le(static_cast<uint16_t>(64));
-		minfo.WinASegment = host_to_le(static_cast<uint16_t>(0xa000));
-		minfo.XResolution = host_to_le(static_cast<uint16_t>(mblock->swidth));
-		minfo.YResolution = host_to_le(static_cast<uint16_t>(mblock->sheight));
+		minfo.WinGranularity = host_to_le16(64);
+		minfo.WinSize = host_to_le16(64);
+		minfo.WinASegment = host_to_le16(0xa000);
+		minfo.XResolution = host_to_le16(mblock->swidth);
+		minfo.YResolution = host_to_le16(mblock->sheight);
 	}
-	minfo.WinFuncPtr = host_to_le(static_cast<uint32_t>(int10.rom.set_window));
-	minfo.NumberOfBanks = host_to_le(static_cast<uint8_t>(0x1));
-	minfo.Reserved_page = host_to_le(static_cast<uint8_t>(0x1));
-	minfo.XCharSize = host_to_le(static_cast<uint8_t>(mblock->cwidth));
-	minfo.YCharSize = host_to_le(static_cast<uint8_t>(mblock->cheight));
+	minfo.WinFuncPtr = host_to_le32(int10.rom.set_window);
+	minfo.NumberOfBanks = 0x1;
+	minfo.Reserved_page = 0x1;
+	minfo.XCharSize = mblock->cwidth;
+	minfo.YCharSize = mblock->cheight;
 	if (!int10.vesa_nolfb)
-		minfo.PhysBasePtr = host_to_le(static_cast<uint32_t>(S3_LFB_BASE));
+		minfo.PhysBasePtr = host_to_le32(S3_LFB_BASE);
 
 	MEM_BlockWrite(buf,&minfo,sizeof(MODE_INFO));
 	return VESA_SUCCESS;

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -200,7 +200,7 @@ foundit:
 		break;
 	case M_LIN32:
 		pageSize = mblock->sheight * mblock->swidth*4;
-		minfo.BytesPerScanLine = host_to_le(mblock->swidth * 4);
+		minfo.BytesPerScanLine = host_to_le16(mblock->swidth * 4);
 		minfo.NumberOfPlanes = 0x1u;
 		minfo.BitsPerPixel = 32u;
 		minfo.MemoryModel = 6u; // HiColour
@@ -245,14 +245,14 @@ foundit:
 	minfo.WinAAttributes = 0x7; // Exists/readable/writable
 
 	if (mblock->type==M_TEXT) {
-		minfo.WinGranularity = host_to_le16(32);
-		minfo.WinSize = host_to_le16(32);
+		minfo.WinGranularity = host_to_le16(32u);
+		minfo.WinSize = host_to_le16(32u);
 		minfo.WinASegment = host_to_le16(0xb800);
 		minfo.XResolution = host_to_le16(mblock->twidth);
 		minfo.YResolution = host_to_le16(mblock->theight);
 	} else {
-		minfo.WinGranularity = host_to_le16(64);
-		minfo.WinSize = host_to_le16(64);
+		minfo.WinGranularity = host_to_le16(64u);
+		minfo.WinSize = host_to_le16(64u);
 		minfo.WinASegment = host_to_le16(0xa000);
 		minfo.XResolution = host_to_le16(mblock->swidth);
 		minfo.YResolution = host_to_le16(mblock->sheight);


### PR DESCRIPTION
The UASAN and UBSAN analyzers report undefined behavior caused by many mis-aligned memory accesses (both reads and writes). 

For example:
- runtime error: store to misaligned address for type 'Bit16u', which requires 2 byte alignment
- runtime error: store to misaligned address for type 'Bit32u', which requires 4 byte alignment
- runtime error: store to misaligned address for type 'Bit64u', which requires 8 byte alignment
- runtime error: load of misaligned address for type 'Bit16u', which requires 2 byte alignment
- runtime error: load of misaligned address for type 'Bit32u', which requires 4 byte alignment

The `host_read*`, and `host_write*` functions currently rely on casting unaligned memory to translate from byte arrays into higher-level types (like 16and 32bit ints), however this approach is implementation specific, can cause undefined behavior, and forces the compiler to use less efficient aliasing rules.

Unaligned memory casts have historically been corrected by expanding multi-byte types into their constituents bytes, shifting them, and re-packing. They've also been solved using union objects to access the same underlying memory for each member (legal under C, but not C++). However, we use memcpy which is compact, readable, universally compatible, and compiles down efficient inline single-instructions; therefore imparting no penalty.

This PR also:
- adds `host_add*` functions (for 16 and 32bit values) that add a host-formatted value to the implied value at a memory address.
- adds handling for quad-words as well: `host_readq`, `host_writeq`, which we use in the cache, which otherwise suffers from the same alignment issues.
- compiles releases with strict-alignment, which reduces binary size by roughly 100KB and brings a small performance improvement.

[REF] https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8 for current discussion and live code-comparisons from various compilers and architectures.

[Snapshot from UASAN run]
![Screenshot at 2020-04-14 18-22-28](https://user-images.githubusercontent.com/1557255/79288964-f6ce9680-7e7c-11ea-9b2e-64c27b0ed042.png)
