### PR TITLE
Resizable window support (part 2/2) (OpenGL only)

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -82,6 +82,13 @@ inline constexpr T1 ceil_sdivide(const T1 x, const T2 y) noexcept {
 	// https://stackoverflow.com/a/33790603
 }
 
+inline int iround(double x) {
+	assert(std::isfinite(x));
+	assert(x >= (std::numeric_limits<int>::min)());
+	assert(x <= (std::numeric_limits<int>::max)());
+	return static_cast<int>(round(x));
+}
+
 // Include a message in assert, similar to static_assert:
 #define assertm(exp, msg) assert(((void)msg, exp))
 // Use (void) to silent unused warnings.

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -681,7 +681,6 @@ finish:
 		SDL_SetWindowMinimumSize(sdl.window, w, h);
 	}
 
-	HandleVideoResize(width, height);
 	sdl.update_display_contents = true;
 	return sdl.window;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -276,6 +276,7 @@ struct SDL_Block {
 		// See FinalizeWindowState function for details.
 		bool lazy_init_window_size = false;
 		bool vsync = false;
+		bool want_resizable_window = false;
 		SCREEN_TYPES type;
 		SCREEN_TYPES want_type;
 	} desktop;
@@ -1064,7 +1065,7 @@ dosurface:
 			goto dosurface;
 		}
 		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-		SetupWindowScaled(SCREEN_OPENGL, false);
+		SetupWindowScaled(SCREEN_OPENGL, sdl.desktop.want_resizable_window);
 
 		/* We may simply use SDL_BYTESPERPIXEL
 		here rather than SDL_BITSPERPIXEL   */
@@ -1734,7 +1735,7 @@ static void OutputString(Bitu x,Bitu y,const char * text,Bit32u color,Bit32u col
 
 #include "dosbox_staging_splash.c"
 
-static SDL_Window * SetDefaultWindowMode()
+static SDL_Window *SetDefaultWindowMode()
 {
 	if (sdl.window)
 		return sdl.window;
@@ -1742,21 +1743,27 @@ static SDL_Window * SetDefaultWindowMode()
 	sdl.draw.width = splash_image.width;
 	sdl.draw.height = splash_image.height;
 
+	// TODO detect based on user settings
+	sdl.desktop.want_resizable_window = true;
+
 	if (sdl.desktop.fullscreen) {
 		sdl.desktop.lazy_init_window_size = true;
 		return SetWindowMode(sdl.desktop.want_type, sdl.desktop.full.width,
-		                     sdl.desktop.full.height, true, false);
+		                     sdl.desktop.full.height, true,
+		                     sdl.desktop.want_resizable_window);
 	}
 
 	if (sdl.desktop.window.use_original_size) {
 		sdl.desktop.lazy_init_window_size = false;
 		return SetWindowMode(sdl.desktop.want_type, sdl.draw.width,
-		                     sdl.draw.height, false, false);
+		                     sdl.draw.height, false,
+		                     sdl.desktop.want_resizable_window);
 	}
 
 	sdl.desktop.lazy_init_window_size = false;
 	return SetWindowMode(sdl.desktop.want_type, sdl.desktop.window.width,
-	                     sdl.desktop.window.height, false, false);
+	                     sdl.desktop.window.height, false,
+	                     sdl.desktop.want_resizable_window);
 }
 
 /* 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -632,10 +632,6 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 		if (resizable) {
 			SDL_AddEventWatch(watch_sdl_events, sdl.window);
 			SDL_SetWindowResizable(sdl.window, SDL_TRUE);
-			const int w = iround(sdl.draw.width * sdl.draw.scalex);
-			const int h = iround(sdl.draw.height * sdl.draw.scaley);
-			SDL_SetWindowMinimumSize(sdl.window, w, h);
-
 			sdl.desktop.window.resizable = true;
 		} else {
 			sdl.desktop.window.resizable = false;
@@ -678,6 +674,13 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 	}
 	// Maybe some requested fullscreen resolution is unsupported?
 finish:
+
+	if (sdl.desktop.window.resizable && !sdl.desktop.switching_fullscreen) {
+		const int w = iround(sdl.draw.width * sdl.draw.scalex);
+		const int h = iround(sdl.draw.height * sdl.draw.scaley);
+		SDL_SetWindowMinimumSize(sdl.window, w, h);
+	}
+
 	HandleVideoResize(width, height);
 	sdl.update_display_contents = true;
 	return sdl.window;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1898,6 +1898,36 @@ static void SetupWindowResolution(const char *val)
 	sdl.desktop.window.use_original_size = true;
 }
 
+static SDL_Rect CalculateViewport(int win_width, int win_height)
+{
+	assert(sdl.draw.width > 0);
+	assert(sdl.draw.height > 0);
+	assert(sdl.draw.scalex > 0.0);
+	assert(sdl.draw.scaley > 0.0);
+	assert(std::isfinite(sdl.draw.scalex));
+	assert(std::isfinite(sdl.draw.scaley));
+
+	const double prog_aspect_ratio = (sdl.draw.width * sdl.draw.scalex) /
+	                                 (sdl.draw.height * sdl.draw.scaley);
+	const double win_aspect_ratio = double(win_width) / double(win_height);
+
+	if (prog_aspect_ratio > win_aspect_ratio) {
+		// match window width
+		const int w = win_width;
+		const int h = iround(win_width / prog_aspect_ratio);
+		assert(win_height >= h);
+		const int y = (win_height - h) / 2;
+		return {0, y, w, h};
+	} else {
+		// match window height
+		const int w = iround(win_height * prog_aspect_ratio);
+		const int h = win_height;
+		assert(win_width >= w);
+		const int x = (win_width - w) / 2;
+		return {x, 0, w, h};
+	}
+}
+
 //extern void UI_Run(bool);
 void Restart(bool pressed);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2401,7 +2401,8 @@ void GFX_Events() {
 				 * FOCUS_GAINED event to catch window startup
 				 * and size toggles.
 				 */
-				GFX_ResetScreen();
+				if (sdl.draw.callback)
+					sdl.draw.callback(GFX_CallBackRedraw);
 				GFX_UpdateMouseState();
 				continue;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1,5 +1,8 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
+ *  Copyright (C) 2019-2020  The dosbox-staging team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,7 +18,6 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -237,6 +237,9 @@ enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_HIGHEST
 };
 
+/* Alias for indicating, that new window should not be user-resizable: */
+constexpr bool FIXED_SIZE = false;
+
 struct Dimensions {
 	int width;
 	int height;
@@ -693,7 +696,8 @@ finish:
 // on Android, and a non-fullscreen window with the input dimensions otherwise.
 SDL_Window * GFX_SetSDLSurfaceWindow(Bit16u width, Bit16u height)
 {
-	return SetWindowMode(SCREEN_SURFACE, width, height, false, false);
+	constexpr bool fullscreen = false;
+	return SetWindowMode(SCREEN_SURFACE, width, height, fullscreen, FIXED_SIZE);
 }
 
 // Returns the rectangle in the current window to be used for scaling a
@@ -947,7 +951,7 @@ dosurface:
 				                           sdl.desktop.full.width,
 				                           sdl.desktop.full.height,
 				                           sdl.desktop.fullscreen,
-				                           false);
+				                           FIXED_SIZE);
 				if (sdl.window == NULL)
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
 					       sdl.desktop.full.width,
@@ -966,7 +970,7 @@ dosurface:
 				sdl.window = SetWindowMode(SCREEN_SURFACE,
 				                           width, height,
 				                           sdl.desktop.fullscreen,
-				                           false);
+				                           FIXED_SIZE);
 				if (sdl.window == NULL)
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
 					       (int)width,
@@ -978,7 +982,8 @@ dosurface:
 			sdl.clip.x = 0;
 			sdl.clip.y = 0;
 			sdl.window = SetWindowMode(SCREEN_SURFACE, width, height,
-			                           sdl.desktop.fullscreen, false);
+			                           sdl.desktop.fullscreen,
+			                           FIXED_SIZE);
 			if (sdl.window == NULL)
 				E_Exit("Could not set windowed video mode %ix%i-%i: %s",
 				       (int)width,
@@ -1038,7 +1043,8 @@ dosurface:
 			sdl.clip.y = (wndh - imgh) / 2;
 
 			sdl.window = SetWindowMode(SCREEN_TEXTURE, wndw, wndh,
-			                           sdl.desktop.fullscreen, false);
+			                           sdl.desktop.fullscreen,
+			                           FIXED_SIZE);
 		}
 		if (sdl.render_driver != "auto")
 			SDL_SetHint(SDL_HINT_RENDER_DRIVER, sdl.render_driver.c_str());
@@ -1804,20 +1810,20 @@ static SDL_Window *SetDefaultWindowMode()
 	if (sdl.desktop.fullscreen) {
 		sdl.desktop.lazy_init_window_size = true;
 		return SetWindowMode(sdl.desktop.want_type, sdl.desktop.full.width,
-		                     sdl.desktop.full.height, true,
+		                     sdl.desktop.full.height, sdl.desktop.fullscreen,
 		                     sdl.desktop.want_resizable_window);
 	}
 
 	if (sdl.desktop.window.use_original_size) {
 		sdl.desktop.lazy_init_window_size = false;
 		return SetWindowMode(sdl.desktop.want_type, sdl.draw.width,
-		                     sdl.draw.height, false,
+		                     sdl.draw.height, sdl.desktop.fullscreen,
 		                     sdl.desktop.want_resizable_window);
 	}
 
 	sdl.desktop.lazy_init_window_size = false;
 	return SetWindowMode(sdl.desktop.want_type, sdl.desktop.window.width,
-	                     sdl.desktop.window.height, false,
+	                     sdl.desktop.window.height, sdl.desktop.fullscreen,
 	                     sdl.desktop.want_resizable_window);
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -623,24 +623,22 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 			flags |= SDL_WINDOW_OPENGL;
 #endif
 
-		// Using undefined position will take care of placing and restoring the
-		// window by WM.
-		const int sdl_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
-		sdl.window = SDL_CreateWindow("", sdl_pos, sdl_pos, width, height, flags);
+		// Using undefined position will take care of placing and
+		// restoring the window by WM.
+		const int pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
+		sdl.window = SDL_CreateWindow("", pos, pos, width, height, flags);
+		if (!sdl.window) {
+			LOG_MSG("SDL: %s", SDL_GetError());
+			return nullptr;
+		}
 
 #if SDL_VERSION_ATLEAST(2, 0, 5)
 		if (resizable) {
 			SDL_AddEventWatch(watch_sdl_events, sdl.window);
 			SDL_SetWindowResizable(sdl.window, SDL_TRUE);
-			sdl.desktop.window.resizable = true;
-		} else {
-			sdl.desktop.window.resizable = false;
 		}
+		sdl.desktop.window.resizable = resizable;
 #endif
-		if (!sdl.window) {
-			return sdl.window;
-		}
-
 		GFX_SetTitle(-1, -1, false); // refresh title.
 
 		if (!fullscreen) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1961,6 +1961,10 @@ static void SetupWindowResolution(const char *val)
 			sdl.desktop.window.width = w;
 			sdl.desktop.window.height = h;
 			return;
+		} else {
+			LOG_MSG("MAIN: dimensions %dx%d are out of display "
+			        "bounds (%dx%d)",
+			        w, h, bounds.w, bounds.h);
 		}
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1613,12 +1613,13 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 	case SCREEN_SURFACE:
 		if (changedLines) {
 			int y = 0;
-			Bitu index = 0, rectCount = 0;
+			size_t index = 0;
+			size_t rect_count = 0;
 			while (y < sdl.draw.height) {
 				if (!(index & 1)) {
 					y += changedLines[index];
 				} else {
-					SDL_Rect *rect = &sdl.updateRects[rectCount++];
+					SDL_Rect *rect = &sdl.updateRects[rect_count++];
 					rect->x = sdl.clip.x;
 					rect->y = sdl.clip.y + y;
 					rect->w = sdl.draw.width;
@@ -1627,8 +1628,10 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 				}
 				index++;
 			}
-			if (rectCount)
-				SDL_UpdateWindowSurfaceRects(sdl.window, sdl.updateRects, rectCount);
+			if (rect_count)
+				SDL_UpdateWindowSurfaceRects(sdl.window,
+				                             sdl.updateRects,
+				                             rect_count);
 		}
 		break;
 	}


### PR DESCRIPTION
After lots of tweaking, testing, and trying various fixes, I think this version is finally worthy of being merged :)

This is second PR towards #274, resizable support for `output=texture*` should be quite easy at this point, but I think it'll be better left for 0.7**6**.0.

In code there's nothing revolutionary - just moving some settings around and clipping at the appropriate moments - but I would love to hear about testing results. I still have few very obscure corner-cases to cover, but I think it won't be that easy for users to find (or even notice there's a bug ;) ).

This feature is introduced via new `windowresolution` options: `default` and `resizable`; explanation in the commit message here: 38585c03ecfed8bfb472aa478e8b789607a5e4e4. During development I experimented with introducing a new sdl setting for this, but it resulted in much more testing without much potential benefit to the end users.

With default dosbox-staging .conf settings, resizable window is turned on by default on Linux (because it works exactly as user would expect).

### Caveats

#### Windows and macOS

On Windows resizable window works, but window content is not being updated while user is dragging - this is essentially a problem caused by WinAPI, and is very common in gamedev (the same problem happens by default with any single-threaded SDL application, or GLFW application, etc, etc), there are several ways to work around it, but it will need to be addressed in a separate PR, post 0.75.0 release (because it might be quite difficult to fix). *This is NOT SDL2 bug* and it won't be fixed in SDL2 (it can't be), it's essentially the same problem as described [here](https://stackoverflow.com/questions/45880238/how-to-draw-while-resizing-glfw-window) or [here](https://github.com/glfw/glfw/issues/408) (there are many similar questions on SO, usually with simplistic or incomplete answers).

macOS shows exactly the same problem as resizing on Windows (except it's harder to find explanation). The only difference is: window area is being stretched during resize instead of showing graphical glitches as on Windows. It looks ugly either way, but less ugly than on Windows.

Windows and macOS users can still opt-in to resizable window by setting `windowresolution=resizable`, because despite the problems it might be more convenient  than having non-resizable window (for certain games/applications).

#### Ubuntu 16.04 LTS

Creating a resizable window is available in SDL since 2.0.0, but to make it work correctly in all our usecases I need a function introduced in SDL 2.0.5 (that's why implementation is ifdefed). Ubuntu 16.04 has SDL 2.0.3… so the feature won't be working in our snapshots :(

I think we'll need to move our snapshots to be based on 18.04 LTS (which would actually also solve the problem of `libpng` ABI compatibility), but it's a change for next PR, as I would need to test compatibilities of resulting binaries with SteamOS / Steam Runtime.

### Bonus

These changes seemingly improved behaviour with `SDL_VIDEODRIVER=wayland`; it's not ready for primetime yet, but it seems somewhat usable now :)