### PR TITLE
Make sanitizers platform-agnostic

### DIFF
--- a/scripts/automator/build/clang-darwin_x86_64
+++ b/scripts/automator/build/clang-darwin_x86_64
@@ -3,11 +3,6 @@ ld="ld"
 # OS-and-processor customizations
 cflags_release+=(-march=nehalem)
 
-# Build additions
-TYPES+=(msan usan)
-cflags_msan=("${cflags_debug[@]}" -fsanitize-recover=all -fsanitize=memory -fno-omit-frame-pointer)
-cflags_usan=("${cflags_debug[@]}" -fsanitize-recover=all -fsanitize=undefined)
-
 # Modifier additions
 MODIFIERS+=(lto)
 cflags_lto=(-flto=thin)

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -8,19 +8,24 @@ if [[ $- == *i* ]]; then
 fi
 
 # Release-type additions
-TYPES+=(release debug warnmore pgotrain optinfo)
+TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 
-# Note: -fno-math-errno allows better optimization of C/C++ math library functions
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno -fno-strict-aliasing)
-
+# Note: no-math-errno improves optimization of C/C++ math functions
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno
+                 -fno-strict-aliasing)
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
-cflags_pgotrain+=("${cflags_debug[@]}" -fprofile-instr-generate -fcoverage-mapping)
-cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
-                  -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion
-                  -Wdouble-promotion -Wformat=2)
+cflags_pgotrain+=("${cflags_debug[@]}" -fprofile-instr-generate
+                  -fcoverage-mapping)
+cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align
+                  -Wunused -Woverloaded-virtual -Wpedantic -Wconversion
+                  -Wsign-conversion -Wdouble-promotion -Wformat=2)
 cxxonly_warnmore+=(-Wnon-virtual-dtor -Woverloaded-virtual)
 cflags_optinfo+=("${cflags_release[@]}" -Rpass-analysis=loop-vectorize
                  -gline-tables-only -gcolumn-info)
+cflags_msan=("${cflags_debug[@]}" -fsanitize-recover=all
+             -fsanitize=memory -fno-omit-frame-pointer)
+cflags_usan=("${cflags_debug[@]}" -fsanitize-recover=all
+             -fsanitize=undefined)
 
 # Modifier additions
 MODIFIERS=(fdo)

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -22,7 +22,7 @@ cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align
 cxxonly_warnmore+=(-Wnon-virtual-dtor -Woverloaded-virtual)
 cflags_optinfo+=("${cflags_release[@]}" -Rpass-analysis=loop-vectorize
                  -gline-tables-only -gcolumn-info)
-cflags_msan=("${cflags_debug[@]}" -fsanitize-recover=all
+cflags_msan=("${cflags_debug[@]}" -fsanitize-recover=all -fPIE -pie
              -fsanitize=memory -fno-omit-frame-pointer)
 cflags_usan=("${cflags_debug[@]}" -fsanitize-recover=all
              -fsanitize=undefined)

--- a/scripts/automator/build/clang-linux_x86_64
+++ b/scripts/automator/build/clang-linux_x86_64
@@ -3,11 +3,6 @@ ar="llvm-ar${postfix}"
 ld="llvm-link${postfix}"
 ranlib="llvm-ranlib${postfix}"
 
-# Build additions
-TYPES+=(msan usan)
-cflags_msan=("${cflags_debug[@]}" -fsanitize-recover=all -fsanitize=memory -fno-omit-frame-pointer)
-cflags_usan=("${cflags_debug[@]}" -fsanitize-recover=all -fsanitize=undefined)
-
 # Modifier additions
 MODIFIERS+=(lto)
 cflags_lto+=(-O2 -flto=thin)

--- a/scripts/automator/build/gcc-darwin_x86_64
+++ b/scripts/automator/build/gcc-darwin_x86_64
@@ -7,13 +7,6 @@ ranlib="ranlib"
 cflags_release+=(-march=nehalem)
 cflags_optinfo+=(-march=nehalem)
 
-# Build additions
-TYPES+=(asan uasan usan tsan)
-cflags_asan=("${cflags_debug[@]}" -fsanitize=address)
-cflags_uasan=("${cflags_debug[@]}" -fsanitize=address,undefined -fsanitize-recover=signed-integer-overflow)
-cflags_usan=("${cflags_debug[@]}" -fsanitize=undefined -fsanitize-recover=signed-integer-overflow)
-cflags_tsan=("${cflags_debug[@]}" -fsanitize=thread)
-
 # Modifier additions
 MODIFIERS+=(lto)
 cflags_lto+=(-flto)

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -6,7 +6,8 @@ ld="gcc${postfix}"
 ranlib="gcc-ranlib${postfix}"
 
 # Release-type additions
-TYPES+=(release debug warnmore pgotrain fdotrain optinfo)
+TYPES+=(release debug warnmore pgotrain fdotrain optinfo
+        asan uasan usan tsan)
 
 cflags+=(-fstack-protector -fdiagnostics-color=auto)
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
@@ -17,16 +18,23 @@ cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-strict-aliasing
                  -fno-signed-zeros -fno-trapping-math -fassociative-math
                  -frename-registers -ffunction-sections -fdata-sections)
-
 cflags_pgotrain+=("${cflags_debug[@]}" -pg -ftree-vectorize)
-cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
-                  -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2
-                  -Wlogical-op -Wmisleading-indentation -Wnull-dereference
-                  -Wshadow -Wunused)
-cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual -Wuseless-cast)
+cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align
+                  -Wdouble-promotion -Wduplicated-branches
+                  -Wduplicated-cond -Wextra -Wformat=2 -Wlogical-op
+                  -Wmisleading-indentation -Wnull-dereference -Wshadow
+                  -Wunused)
+cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual
+                   -Wuseless-cast)
 cflags_fdotrain+=("${cflags[@]}" -DNDEBUG -g1 -fno-omit-frame-pointer)
 cflags_optinfo+=("${cflags_release[@]}" -fopt-info-missed
                  -ftree-vectorizer-verbose=6)
+cflags_asan+=("${cflags_debug[@]}" -fsanitize=address)
+cflags_uasan+=("${cflags_debug[@]}" -fsanitize=address,undefined
+              -fsanitize-recover=signed-integer-overflow)
+cflags_usan+=("${cflags_debug[@]}" -fsanitize=undefined
+              -fsanitize-recover=signed-integer-overflow)
+cflags_tsan+=("${cflags_debug[@]}" -fsanitize=thread)
 
 # Modifier additions
 MODIFIERS=(fdo)

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -30,8 +30,10 @@ cflags_fdotrain+=("${cflags[@]}" -DNDEBUG -g1 -fno-omit-frame-pointer)
 cflags_optinfo+=("${cflags_release[@]}" -fopt-info-missed
                  -ftree-vectorizer-verbose=6)
 cflags_asan+=("${cflags_debug[@]}" -fsanitize=address)
+ldflags_asan+=(-static-libasan)
 cflags_uasan+=("${cflags_debug[@]}" -fsanitize=address,undefined
               -fsanitize-recover=signed-integer-overflow)
+ldflags_uasan+=(-static-libasan)
 cflags_usan+=("${cflags_debug[@]}" -fsanitize=undefined
               -fsanitize-recover=signed-integer-overflow)
 cflags_tsan+=("${cflags_debug[@]}" -fsanitize=thread)

--- a/scripts/automator/build/gcc-linux_x86_64
+++ b/scripts/automator/build/gcc-linux_x86_64
@@ -6,13 +6,6 @@ x86_math=(-mfpmath=sse -msse4.2)
 cflags_release+=("${x86_math[@]}")
 cflags_optinfo+=("${x86_math[@]}")
 
-# Build additions
-TYPES+=(asan uasan usan tsan)
-cflags_asan=("${cflags_debug[@]}" -fsanitize=address)
-cflags_uasan=("${cflags_debug[@]}" -fsanitize=address,undefined -fsanitize-recover=signed-integer-overflow)
-cflags_usan=("${cflags_debug[@]}" -fsanitize=undefined -fsanitize-recover=signed-integer-overflow)
-cflags_tsan=("${cflags_debug[@]}" -fsanitize=thread)
-
 # Modifier additions
 MODIFIERS+=(lto)
 cflags_lto+=(-flto)


### PR DESCRIPTION
This PR moves the sanitizers to Clang's and GCC's default settings, which allows any platform to build (or at least attempt to build) with the sanitizers.

This change comes from the fact that Clang and GCC continue adding supported platforms, and they are likely to support more platforms than we are to.

References
- https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#supported-platforms
- https://github.com/google/sanitizers/wiki/AddressSanitizer

PR also enables memory counting instrumentation `-fPIE -pie` to Clang's MSAN build, per the documentation: https://github.com/google/sanitizers/wiki/MemorySanitizer