### PR TITLE
Package and use icons for Linux according to XDG spec

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
-        run:  sudo apt-get install -y tree libpng16-dev $(./scripts/list-build-dependencies.sh -m apt -c gcc)
+        run:  sudo apt-get install -y tree libpng16-dev librsvg2-bin $(./scripts/list-build-dependencies.sh -m apt -c gcc)
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash
@@ -115,6 +115,7 @@ jobs:
       - name: Package
         run: |
           set -x
+
           # Prepare content
           install -DT        src/dosbox           dest/dosbox
           install -DT -m 644 docs/README.template dest/README
@@ -122,14 +123,23 @@ jobs:
           install -DT -m 644 README               dest/doc/manual.txt
           install -DT -m 644 docs/README.video    dest/doc/video.txt
           install -DT -m 644 docs/dosbox.1        dest/man/dosbox.1
+
+          # Generate .desktop entry and icon files
+          install -DT contrib/linux/dosbox-staging.desktop dest/desktop/dosbox-staging.desktop
+          make -C contrib/icons/ hicolor
+          mkdir -p dest/icons
+          mv contrib/icons/hicolor dest/icons
+
           # Fill README template file
           sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README
           sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README
           mv dest "dosbox-staging-linux-$VERSION"
           tree --si -p "dosbox-staging-linux-$VERSION"
+
           # Create tarball
           tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
+
       - name: Upload tarball
         uses: actions/upload-artifact@master
         # GitHub automatically zips the artifacts (there's no way to create

--- a/contrib/icons/.gitignore
+++ b/contrib/icons/.gitignore
@@ -1,2 +1,3 @@
 dosbox-staging.iconset
 icon_*.png
+hicolor/

--- a/contrib/icons/Makefile
+++ b/contrib/icons/Makefile
@@ -4,6 +4,7 @@ help:
 	@echo "Re-generate icons in platform specific formats."
 	@echo
 	@echo "Available targets:"
+	@echo "  hicolor             - Freedesktop icon directory structure"
 	@echo "  dosbox-staging.ico  - Windows format"
 	@echo "  dosbox-staging.icns - macOS format"
 	@echo "  icon_<size>.png     - render icon in specific size, e.g. icon_24.png"
@@ -55,11 +56,37 @@ dosbox-staging.iconset: \
 	cp icon_512.png  $@/icon_512x512.png
 	cp icon_1024.png $@/icon_512x512@2x.png
 
+##
+# Freedesktop icons (for Linux or other OSes) often are placed in 'hicolor'
+# directory in /usr/share/icons/ or /usr/local/share/icons/.
+#
+# Users can override them by placing icons in ~/.local/share/icons/
+#
+# This is not strictly necessary (just placing scalable icon is enough,
+# but some there are some corner cases where small raster icon looks better).
+#
+hicolor: \
+		dosbox-staging.svg \
+		icon_32.png \
+		icon_24.png \
+		icon_22.png \
+		icon_16.png
+	install -DT -m 644 $<          $@/scalable/apps/dosbox-staging.svg
+	install -DT -m 644 icon_32.png $@/32x32/apps/dosbox-staging.png
+	install -DT -m 644 icon_24.png $@/24x24/apps/dosbox-staging.png
+	install -DT -m 644 icon_22.png $@/22x22/apps/dosbox-staging.png
+	install -DT -m 644 icon_16.png $@/16x16/apps/dosbox-staging.png
+
 icon_16.png: small-svg/dosbox-staging-16.svg
 	rsvg-convert -h 16 $< > $@
 
 icon_24.png: small-svg/dosbox-staging-24.svg
 	rsvg-convert -h 24 $< > $@
+
+# Some desktop environments expect 22x22 icon (e.g. KDE Plasma).
+# Rendering 24px source to 22px looks good enough.
+icon_22.png: small-svg/dosbox-staging-24.svg
+	rsvg-convert -h 22 $< > $@
 
 icon_32.png: small-svg/dosbox-staging-32.svg
 	rsvg-convert -h 32 $< > $@
@@ -84,4 +111,5 @@ icon_1024.png: dosbox-staging.svg
 
 clean:
 	rm -rf dosbox-staging.iconset
+	rm -rf hicolor
 	rm -f icon_*.png

--- a/contrib/linux/dosbox-staging.desktop
+++ b/contrib/linux/dosbox-staging.desktop
@@ -8,3 +8,4 @@ Type=Application
 Terminal=false
 Keywords=dos;gaming;game;games;emulator;
 Categories=Game;Emulator;
+StartupWMClass=dosbox-staging

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3072,11 +3072,20 @@ void Disable_OS_Scaling() {
 #endif
 }
 
+void OverrideWMClass()
+{
+#if !defined(WIN32)
+	constexpr int overwrite = 0; // don't overwrite
+	setenv("SDL_VIDEO_X11_WMCLASS", "dosbox-staging", overwrite);
+#endif
+}
+
 //extern void UI_Init(void);
 int main(int argc, char* argv[]) {
 	int rcode = 0; // assume good until proven otherwise
 	try {
 		Disable_OS_Scaling(); //Do this early on, maybe override it through some parameter.
+		OverrideWMClass(); // Before SDL2 video subsystem is initialized
 
 		CommandLine com_line(argc,argv);
 		Config myconf(&com_line);


### PR DESCRIPTION
I think this PR concludes icon rework - after this change, dosbox-staging icon will no longer conflict with upstream dosbox icon in any way (so we should never square orange box ever again), and additionally users will be able to either drop `hicolor` directory in their `~/.local/share/icons/` directory to provide low-resolution icons or override our icons with their chosen ones (e.g. as part of user icon theme - this works very well in Gnome-derived desktop environments).