### PR TITLE
Update Linux snapshot builds to Ubuntu 18.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,13 +64,13 @@ jobs:
 
   build_linux_release_dynamic:
     name: Release build (dynamic)
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
     steps:
       - uses: actions/checkout@v1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
-        run:  sudo apt-get install -y tree libpng16-dev librsvg2-bin $(./scripts/list-build-dependencies.sh -m apt -c gcc)
+        run:  sudo apt-get install -y tree libpng-dev librsvg2-bin $(./scripts/list-build-dependencies.sh -m apt -c gcc)
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash
@@ -109,7 +109,10 @@ jobs:
         run: |
           set -x
           ./autogen.sh
-          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" LDFLAGS="$FLAGS $LINKFLAGS -flto=$(nproc)" --disable-screenshots
+          ./configure \
+              CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" \
+              LDFLAGS="$FLAGS $LINKFLAGS -flto=$(nproc)" \
+              --enable-png-static
           make -j "$(nproc)"
           strip src/dosbox
       - name: Package

--- a/README.md
+++ b/README.md
@@ -89,13 +89,14 @@ packages installed via your package manager.
 
     sudo dnf install SDL2 SDL2_net opusfile
 
-#### Debian, Ubuntu
+#### Debian (10 or newer), Ubuntu (18.04 LTS or newer)
 
     sudo apt install libsdl2-2.0 libsdl2-net-2.0 libopusfile0
 
 #### Arch, Manjaro
 
     sudo pacman -S sdl2 sdl2_net opusfile
+
 
 ### [Windows]
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,16 @@ Codecs supported for CD-DA emulation:
 
 Other differences:
 
-|                        | dosbox-staging                               | DOSBox SVN
-|-                       |-                                             |-
-| **Pixel-perfect mode** | Yes (`output=texturepp`)<sup>[7]</sup>       | N/A
-| **[OPL] emulators**    | compat, fast, mame, nuked<sup>[8]</sup>      | compat, fast, mame
-| **[CGA]/mono support** | Yes (`machine=cga_mono`)<sup>[9]</sup>       | Only CGA with colour
-| **[Wayland] support**  | Experimental (use `SDL_VIDEODRIVER=wayland`) | N/A
+|                          | dosbox-staging                               | DOSBox SVN
+|-                         |-                                             |-
+| **Pixel-perfect mode**   | Yes (`output=texturepp`)<sup>[7]</sup>       | N/A
+| **Resizable window**     | Experimental (`windowresolution=resizable`)  | N/A
+| **Relative window size** | N/A                                          | `windowresolution=X%`
+| **[OPL] emulators**      | compat, fast, mame, nuked<sup>[8]</sup>      | compat, fast, mame
+| **[CGA]/mono support**   | Yes (`machine=cga_mono`)<sup>[9]</sup>       | Only CGA with colour
+| **[Wayland] support**    | Experimental (use `SDL_VIDEODRIVER=wayland`) | N/A
+| **Modem phonebook file** | Yes (`phonebookfile=<name>`)                 | N/A
+| **Autotype command**     | Yes<sup>10</sup>                             | N/A
 
 [OPL]:https://en.wikipedia.org/wiki/Yamaha_YMF262
 [CGA]:https://en.wikipedia.org/wiki/Color_Graphics_Adapter
@@ -71,6 +75,7 @@ Other differences:
 [7]:https://github.com/dosbox-staging/dosbox-staging/commit/d1be65b105de714924947df4a7909e684d283385
 [8]:https://www.vogons.org/viewtopic.php?f=9&t=37782
 [9]:https://github.com/dosbox-staging/dosbox-staging/commit/ffe3c5ab7fb5e28bae78f07ea987904f391a7cf8
+[10]:https://github.com/dosbox-staging/dosbox-staging/commit/239396fec83dbba6a1eb1a0f4461f4a427d2be38
 
 ## Development snapshot builds
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Other differences:
 | **[CGA]/mono support**   | Yes (`machine=cga_mono`)<sup>[9]</sup>       | Only CGA with colour
 | **[Wayland] support**    | Experimental (use `SDL_VIDEODRIVER=wayland`) | N/A
 | **Modem phonebook file** | Yes (`phonebookfile=<name>`)                 | N/A
-| **Autotype command**     | Yes<sup>10</sup>                             | N/A
+| **Autotype command**     | Yes<sup>[10]</sup>                           | N/A
 
 [OPL]:https://en.wikipedia.org/wiki/Yamaha_YMF262
 [CGA]:https://en.wikipedia.org/wiki/Color_Graphics_Adapter

--- a/configure.ac
+++ b/configure.ac
@@ -430,15 +430,28 @@ else
   AC_MSG_RESULT(no)
 fi
 
-AH_TEMPLATE(C_SSHOT,[Define to 1 to enable screenshots, requires libpng])
-AC_ARG_ENABLE(screenshots,AC_HELP_STRING([--disable-screenshots],[Disable screenshots and movie recording]),,enable_screenshots=yes)
-AC_CHECK_HEADER(png.h,have_png_h=yes,)
-AC_CHECK_LIB(png, png_get_io_ptr, have_png_lib=yes, ,-lz)
+AH_TEMPLATE(C_SSHOT, [Define to 1 to enable screenshots, requires libpng])
+AC_ARG_ENABLE(screenshots,
+              AC_HELP_STRING([--disable-screenshots],
+                             [Disable screenshots and movie recording]),
+              enable_screenshots=no,
+              enable_screenshots=yes)
+AC_ARG_ENABLE(png_static,
+              AC_HELP_STRING([--enable-png-static],
+                             [Link libpng statically (not recommended)]),
+              enable_png_static=yes,
+              enable_png_static=no)
+AC_CHECK_HEADER(png.h, have_png_h=yes, )
+AC_CHECK_LIB(png, png_get_io_ptr, have_png_lib=yes, , -lz)
 AC_MSG_CHECKING([whether screenshots will be enabled])
 if test x$enable_screenshots = xyes; then
-    if test x$have_png_lib = xyes -a x$have_png_h = xyes ; then
-    LIBS="$LIBS -lpng -lz"
-    AC_DEFINE(C_SSHOT,1)
+  if test x$have_png_lib = xyes -a x$have_png_h = xyes ; then
+    if test x$enable_png_static = xyes ; then
+      LIBS="$LIBS -Wl,-Bstatic -lpng -Wl,-Bdynamic -lz"
+    else
+      LIBS="$LIBS -lpng -lz"
+    fi
+    AC_DEFINE(C_SSHOT, 1)
     AC_MSG_RESULT([yes])
   else
     AC_MSG_RESULT([no, can't find libpng.])


### PR DESCRIPTION
Also:

- new opt-in configure option for linking `libpng` statically
- Linux snapshots have screenshots feature re-enabled
- Small README.md updates