### PR TITLE
Cleanup remaining 8-bit type-punning alignment issues

### DIFF
--- a/include/mem.h
+++ b/include/mem.h
@@ -56,7 +56,7 @@ MemHandle MEM_NextHandle(MemHandle handle);
 MemHandle MEM_NextHandleAt(MemHandle handle,Bitu where);
 
 // Read and write single-byte values
-static INLINE uint8_t host_readb(const uint8_t *var)
+constexpr uint8_t host_readb(const uint8_t *var)
 {
 	return *var;
 }

--- a/include/mem.h
+++ b/include/mem.h
@@ -76,6 +76,15 @@ static INLINE uint16_t read_uint16(const uint8_t *arr)
 	return val;
 }
 
+/*  Read a uint16 from 8-bit DOS/little-endian byte-ordered memory.
+ *  Use this instead of endian branching and byte swapping, such as:
+ *  #if BIG_ENDIAN byteswap(*(uint16_t*)(arr)) #else *(uint16_t*)(arr) 
+ */
+static INLINE uint16_t host_readw(const uint8_t *arr)
+{
+	return le16_to_host(read_uint16(arr));
+}
+
 /*  Read an array-indexed uint16 from 8-bit native byte-ordered memory.
  *  Use this instead of ((uint16_t*)arr)[index]
  */
@@ -83,6 +92,11 @@ static INLINE uint16_t read_uint16_at(const uint8_t *arr, const uintptr_t index)
 {
 	return read_uint16(arr + index * sizeof(uint16_t));
 }
+
+/*  Read an array-indexed uint16 from 8-bit DOS/little-endian byte-ordered
+ *  memory. Use this instead of endian branching and byte swapping, such as:
+ *  #if BIG_ENDIAN byteswap(((uint16_t*)arr)[i]) #else ((uint16_t*)arr)[i]
+ */
 static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
 {
 	return host_readw(arr + index * sizeof(uint16_t));
@@ -94,12 +108,19 @@ static INLINE void write_uint16(uint8_t *arr, uint16_t val)
 	memcpy(arr, &val, sizeof(val));
 }
 
+// Write a uint16 to 8-bit memory using DOS/little-endian byte-ordering.
+static INLINE void host_writew(uint8_t *arr, uint16_t val)
+{
+	write_uint16(arr, host_to_le16(val));
+}
 
 // Write an array-indexed uint16 to 8-bit memory using native byte-ordering.
 static INLINE void write_uint16_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
 {
 	write_uint16(arr + index * sizeof(uint16_t), val);
 }
+
+// Write an array-indexed uint16 to 8-bit memory using DOS/little-endian byte-ordering.
 static INLINE void host_writew_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
 {
 	host_writew(arr + index * sizeof(uint16_t), val);
@@ -111,9 +132,11 @@ static INLINE void incr_uint16(uint8_t *arr, const uint16_t incr)
 	write_uint16(arr, read_uint16(arr) + incr);
 }
 
-// Read, write, and add using 32-bit double-words
-static INLINE uint32_t host_readd(const uint8_t *arr)
+// Increment a uint16 value held in 8-bit DOS/little-endian byte-ordered memory.
+static INLINE void host_incrw(uint8_t *arr, const uint16_t incr)
 {
+	host_writew(arr, host_readw(arr) + incr);
+}
 
 // Read a uint32 from 8-bit native byte-ordered memory.
 static INLINE uint32_t read_uint32(const uint8_t *arr)
@@ -123,13 +146,19 @@ static INLINE uint32_t read_uint32(const uint8_t *arr)
 	return val;
 }
 
+// Read a uint32 from 8-bit DOS/little-endian byte-ordered memory.
+static INLINE uint32_t host_readd(const uint8_t *arr)
+{
+	return le32_to_host(read_uint32(arr));
+}
+
 // Read an array-indexed uint32 from 8-bit native byte-ordered memory.
 static INLINE uint32_t read_uint32_at(const uint8_t *arr, const uintptr_t index)
 {
 	return read_uint32(arr + index * sizeof(uint32_t));
 }
 
-// Like the above, but allows index-style access assuming a 32-bit array
+// Read an array-indexed uint16 from 8-bit DOS/little-endian byte-ordered memory. 
 static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
 {
 	return host_readd(arr + index * sizeof(uint32_t));
@@ -140,8 +169,12 @@ static INLINE void write_uint32(uint8_t *arr, uint32_t val)
 {
 	memcpy(arr, &val, sizeof(val));
 }
+
+// Write a uint32 to 8-bit memory using DOS/little-endian byte-ordering.
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
+	write_uint32(arr, host_to_le32(val));
+}
 
 // Write an array-indexed uint32 to 8-bit memory using native byte-ordering.
 static INLINE void write_uint32_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
@@ -149,6 +182,7 @@ static INLINE void write_uint32_at(uint8_t *arr, const uintptr_t index, const ui
 	write_uint32(arr + index * sizeof(uint32_t), val);
 }
 
+// Write an array-indexed uint32 to 8-bit memory using DOS/little-endian byte-ordering.
 static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
 {
 	host_writed(arr + index * sizeof(uint32_t), val);
@@ -159,9 +193,11 @@ static INLINE void incr_uint32(uint8_t *arr, const uint32_t incr)
 {
 	write_uint32(arr, read_uint32(arr) + incr);
 }
+
+// Increment a uint32 value held in 8-bit DOS/little-endian byte-ordered memory.
+static INLINE void host_incrd(uint8_t *arr, const uint32_t incr)
 {
-	const uint32_t val = host_readd(arr) + incr;
-	host_writed(arr, val);
+	host_writed(arr, host_readd(arr) + incr);
 }
 
 // Read a uint64 from 8-bit native byte-ordered memory.

--- a/include/mem.h
+++ b/include/mem.h
@@ -66,46 +66,67 @@ static INLINE void host_writeb(uint8_t *var, const uint8_t val)
 	*var = val;
 }
 
-// Read, write, and add using 16-bit words
-static INLINE uint16_t host_readw(const uint8_t *arr)
+/*  Read a uint16 from 8-bit native byte-ordered memory. Use this
+ *  instead of *(uint16_t*)(8_bit_ptr) or *(uint16_t*)(8_bit_ptr + offset)
+ */
+static INLINE uint16_t read_uint16(const uint8_t *arr)
 {
 	uint16_t val;
 	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le16_to_host(val);
+	return val;
 }
 
-// Like the above, but allows index-style access assuming a 16-bit array
+/*  Read an array-indexed uint16 from 8-bit native byte-ordered memory.
+ *  Use this instead of ((uint16_t*)arr)[index]
+ */
+static INLINE uint16_t read_uint16_at(const uint8_t *arr, const uintptr_t index)
+{
+	return read_uint16(arr + index * sizeof(uint16_t));
+}
 static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
 {
 	return host_readw(arr + index * sizeof(uint16_t));
 }
 
-static INLINE void host_writew(uint8_t *arr, uint16_t val)
+// Write a uint16 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint16(uint8_t *arr, uint16_t val)
 {
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le16(val);
 	memcpy(arr, &val, sizeof(val));
 }
 
+
+// Write an array-indexed uint16 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint16_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
+{
+	write_uint16(arr + index * sizeof(uint16_t), val);
+}
 static INLINE void host_writew_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
 {
 	host_writew(arr + index * sizeof(uint16_t), val);
 }
 
-static INLINE void host_addw(uint8_t *arr, const uint16_t incr)
+// Increment a uint16 value held in 8-bit native byte-ordered memory.
+static INLINE void incr_uint16(uint8_t *arr, const uint16_t incr)
 {
-	const uint16_t val = host_readw(arr) + incr;
-	host_writew(arr, val);
+	write_uint16(arr, read_uint16(arr) + incr);
 }
 
 // Read, write, and add using 32-bit double-words
 static INLINE uint32_t host_readd(const uint8_t *arr)
 {
+
+// Read a uint32 from 8-bit native byte-ordered memory.
+static INLINE uint32_t read_uint32(const uint8_t *arr)
+{
 	uint32_t val;
 	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le32_to_host(val);
+	return val;
+}
+
+// Read an array-indexed uint32 from 8-bit native byte-ordered memory.
+static INLINE uint32_t read_uint32_at(const uint8_t *arr, const uintptr_t index)
+{
+	return read_uint32(arr + index * sizeof(uint32_t));
 }
 
 // Like the above, but allows index-style access assuming a 32-bit array
@@ -114,11 +135,18 @@ static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
 	return host_readd(arr + index * sizeof(uint32_t));
 }
 
+// Write a uint32 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint32(uint8_t *arr, uint32_t val)
+{
+	memcpy(arr, &val, sizeof(val));
+}
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le32(val);
-	memcpy(arr, &val, sizeof(val));
+
+// Write an array-indexed uint32 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint32_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
+{
+	write_uint32(arr + index * sizeof(uint32_t), val);
 }
 
 static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
@@ -126,25 +154,27 @@ static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uin
 	host_writed(arr + index * sizeof(uint32_t), val);
 }
 
-static INLINE void host_addd(uint8_t *arr, const uint32_t incr)
+// Increment a uint32 value held in 8-bit native byte-ordered memory.
+static INLINE void incr_uint32(uint8_t *arr, const uint32_t incr)
+{
+	write_uint32(arr, read_uint32(arr) + incr);
+}
 {
 	const uint32_t val = host_readd(arr) + incr;
 	host_writed(arr, val);
 }
 
-// Read and write using 64-bit quad-words
-static INLINE uint64_t host_readq(const uint8_t *arr)
+// Read a uint64 from 8-bit native byte-ordered memory.
+static INLINE uint64_t read_uint64(const uint8_t *arr)
 {
 	uint64_t val;
 	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le64_to_host(val);
+	return val;
 }
 
-static INLINE void host_writeq(uint8_t *arr, uint64_t val)
+// Write a uint64 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint64(uint8_t *arr, uint64_t val)
 {
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le64(val);
 	memcpy(arr, &val, sizeof(val));
 }
 

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -11,8 +11,7 @@ fi
 TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 
 # Note: no-math-errno improves optimization of C/C++ math functions
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno
-                 -fno-strict-aliasing)
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing)
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 
 cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -15,9 +15,9 @@ cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 # Note: associative-math is needed for vectorization of floating point
 #       calculations, which also relies on no-signed-zeros and
 #       no-trapping-math.
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -frename-registers
                  -fno-signed-zeros -fno-trapping-math -fassociative-math
-                 -frename-registers -ffunction-sections -fdata-sections)
+                 -ffunction-sections -fdata-sections -fno-stack-protector)
 
 cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                   -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -139,5 +139,6 @@ function parse_args() {
 	selected_type=$(lower "${selected_type}")
 }
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=scripts/automator/main.sh
-source "$(dirname "$0")/automator/main.sh"
+source "$script_dir/automator/main.sh"

--- a/scripts/list-build-dependencies.sh
+++ b/scripts/list-build-dependencies.sh
@@ -53,5 +53,6 @@ function parse_args() {
 # shellcheck disable=SC2034
 data_dir="packages"
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=scripts/automator/main.sh
-source "$(dirname "$0")/automator/main.sh"
+source "$script_dir/automator/main.sh"

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -151,7 +151,7 @@ public:
 			}
 			memset(invalidation_map,0,4096);
 		}
-		host_addw(invalidation_map + addr, 0x101);
+		incr_uint16(invalidation_map + addr, 0x101);
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -176,7 +176,7 @@ public:
 			}
 			memset(invalidation_map,0,4096);
 		}
-		host_addd(invalidation_map + addr, 0x1010101);
+		incr_uint32(invalidation_map + addr, 0x1010101);
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -230,7 +230,7 @@ public:
 				}
 				memset(invalidation_map,0,4096);
 			}
-			host_addw(invalidation_map + addr, 0x101);
+			incr_uint16(invalidation_map + addr, 0x101);
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -261,7 +261,7 @@ public:
 				}
 				memset(invalidation_map,0,4096);
 			}
-			host_addd(invalidation_map + addr, 0x1010101);
+			host_incrd(invalidation_map + addr, 0x1010101);
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -137,7 +137,7 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return;
 		host_writew(hostmem+addr,val);
-		const uint16_t is_mapped = host_readw(write_map + addr);
+		const uint16_t is_mapped = read_uint16(write_map + addr);
 		if (!is_mapped) {
 			if (active_blocks)
 				return;
@@ -162,7 +162,7 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return;
 		host_writed(hostmem+addr,val);
-		const uint32_t is_mapped = host_readd(write_map + addr);
+		const uint32_t is_mapped = read_uint32(write_map + addr);
 		if (!is_mapped) {
 			if (active_blocks)
 				return;
@@ -216,7 +216,7 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
 
-		const uint16_t is_mapped = host_readw(write_map + addr);
+		const uint16_t is_mapped = read_uint16(write_map + addr);
 		if (!is_mapped) {
 			if (!active_blocks) {
 				active_count--;
@@ -247,7 +247,7 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
 
-		const uint32_t is_mapped = host_readd(write_map + addr);
+		const uint32_t is_mapped = read_uint32(write_map + addr);
 		if (!is_mapped) {
 			if (!active_blocks) {
 				active_count--;
@@ -489,19 +489,19 @@ static INLINE void cache_addb(Bit8u val) {
 
 static INLINE void cache_addw(const uint16_t val)
 {
-	host_writew(cache.pos, val);
+	write_uint16(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
 static INLINE void cache_addd(const uint32_t val)
 {
-	host_writed(cache.pos, val);
+	write_uint32(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
 static INLINE void cache_addq(const uint64_t val)
 {
-	host_writeq(cache.pos, val);
+	write_uint64(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -148,7 +148,7 @@ static uint16_t decode_fetchw()
 		val |= decode_fetchb() << 8;
 		return val;
 	}
-	host_addw(decode.page.wmap + decode.page.index, 0x0101);
+	incr_uint16(decode.page.wmap + decode.page.index, 0x0101);
 	decode.code += sizeof(uint16_t);
 	decode.page.index += sizeof(uint16_t);
 	return mem_readw(decode.code - sizeof(uint16_t));
@@ -164,7 +164,7 @@ static uint32_t decode_fetchd()
 		return val;
         /* Advance to the next page */
 	}
-	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
+	incr_uint32(decode.page.wmap + decode.page.index, 0x01010101);
 	decode.code += sizeof(uint32_t);
 	decode.page.index += sizeof(uint32_t);
 	return mem_readd(decode.code - sizeof(uint32_t));
@@ -200,8 +200,8 @@ static INLINE void decode_increase_wmapmask(Bitu size) {
 	}
 	switch (size) {
 	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
-	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
+	case 2: incr_uint16(activecb->cache.wmapmask + mapidx, 0x0101); break;
+	case 4: incr_uint32(activecb->cache.wmapmask + mapidx, 0x01010101); break;
 	}
 }
 

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -304,7 +304,7 @@ static BlockReturn gen_runcodeInit(uint8_t *code)
 	opcode(0).setea(4,-1,0,CALLSTACK).Emit8(0x89);  // mov [rsp+8/40], eax
 	opcode(4).setrm(ARG0_REG).Emit8(0xFF);   // jmp ARG0
 
-	host_writed(diff, cache.pos - diff - sizeof(uint32_t));
+	write_uint32(diff, cache.pos - diff - sizeof(uint32_t));
 	// eax = return value, ecx = flags
 	opcode(1).setea(5,-1,0,offsetof(CPU_Regs,flags)).Emit8(0x33); // xor ecx, reg_flags
 	opcode(4).setrm(1).setimm(FMASK_TEST,4).Emit8(0x81);          // and ecx,FMASK_TEST
@@ -1152,7 +1152,7 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 
 static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos)
 {
-	host_writed(data, from - data - sizeof(uint32_t));
+	write_uint32(data, from - data - sizeof(uint32_t));
 }
 
 static uint8_t *gen_create_jump(uint8_t *to = 0)
@@ -1165,7 +1165,7 @@ static uint8_t *gen_create_jump(uint8_t *to = 0)
 
 #if 0
 static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
-	host_writed(data, to - data - sizeof(uint32_t));
+	write_uint32(data, to - data - sizeof(uint32_t));
 }
 #endif
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -984,7 +984,7 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 }
 
 static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos) {
-	host_writed(data, from - data - sizeof(uint32_t));
+	write_uint32(data, from - data - sizeof(uint32_t));
 }
 
 static Bit8u * gen_create_jump(Bit8u * to=0) {
@@ -995,7 +995,7 @@ static Bit8u * gen_create_jump(Bit8u * to=0) {
 }
 
 static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
-	host_writed(data, to - data - sizeof(uint32_t));
+	write_uint32(data, to - data - sizeof(uint32_t));
 }
 
 

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -171,7 +171,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-		host_addw(invalidation_map + addr, 0x101);
+		host_incrw(invalidation_map + addr, 0x101);
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -188,7 +188,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-		host_addd(invalidation_map + addr, 0x1010101);
+		host_incrd(invalidation_map + addr, 0x1010101);
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -230,7 +230,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-			host_addw(invalidation_map + addr, 0x101);
+			host_incrw(invalidation_map + addr, 0x101);
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -254,7 +254,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-			host_addd(invalidation_map + addr, 0x1010101);
+			host_incrd(invalidation_map + addr, 0x1010101);
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -514,19 +514,19 @@ static INLINE void cache_addb(Bit8u val) {
 
 // place a 16bit value into the cache
 static INLINE void cache_addw(const uint16_t val) {
-	host_writew(cache.pos, val);
+	write_uint16(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
 // place a 32bit value into the cache
 static INLINE void cache_addd(const uint32_t val) {
-	host_writed(cache.pos, val);
+	write_uint32(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 
 // place a 64bit value into the cache
 static INLINE void cache_addq(const uint64_t val) {
-	host_writeq(cache.pos, val);
+	write_uint64(cache.pos, val);
 	cache.pos += sizeof(val);
 }
 

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -240,7 +240,7 @@ static uint16_t decode_fetchw()
 		val |= decode_fetchb() << 8;
 		return val;
 	}
-	host_addw(decode.page.wmap + decode.page.index, 0x0101);
+	incr_uint16(decode.page.wmap + decode.page.index, 0x0101);
 	decode.code += sizeof(uint16_t);
 	decode.page.index += sizeof(uint16_t);
 	return mem_readw(decode.code - sizeof(uint16_t));
@@ -257,7 +257,7 @@ static uint32_t decode_fetchd()
 		return val;
 		/* Advance to the next page */
 	}
-	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
+	incr_uint32(decode.page.wmap + decode.page.index, 0x01010101);
 	decode.code += sizeof(uint32_t);
 	decode.page.index += sizeof(uint32_t);
 	return mem_readd(decode.code - sizeof(uint32_t));
@@ -294,8 +294,8 @@ static void INLINE decode_increase_wmapmask(Bitu size) {
 	// update mask entries
 	switch (size) {
 	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
-	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
+	case 2: incr_uint16(activecb->cache.wmapmask + mapidx, 0x0101); break;
+	case 4: incr_uint32(activecb->cache.wmapmask + mapidx, 0x01010101); break;
 	}
 }
 

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -938,13 +938,20 @@ static void gen_run_code(void) {
 		cache.pos = cache.pos + (32 - (((Bitu)cache.pos) & 0x1f));
 	}
 
-	write_uint32(pos1, LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)));      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
+	write_uint32(pos1, LDR_IMM(FC_SEGS_ADDR, HOST_pc,
+	                           cache.pos - (pos1 + 8))); // ldr FC_SEGS_ADDR,
+	                                                     // [pc, #(&Segs)]
 	cache_addd((Bit32u)&Segs);      // address of "Segs"
 
-	write_uint32(pos2, LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)));      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
+	write_uint32(pos2, LDR_IMM(FC_REGS_ADDR, HOST_pc,
+	                           cache.pos - (pos2 + 8))); // ldr FC_REGS_ADDR,
+	                                                     // [pc, #(&cpu_regs)]
 	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
 
-	write_uint32(pos3, LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)));      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
+	write_uint32(pos3, LDR_IMM(readdata_addr, HOST_pc,
+	                           cache.pos - (pos3 + 8))); // ldr readdata_addr,
+	                                                     // [pc,
+	                                                     // #(&core_dynrec.readdata)]
 	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
@@ -970,51 +977,56 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, ADD_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// add FC_RETOP, a1, a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ADD_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              HOST_a2, 0)); // add FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, ORR_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// orr FC_RETOP, a1, a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ORR_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              HOST_a2, 0)); // orr FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, AND_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// and FC_RETOP, a1, a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, AND_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              HOST_a2, 0)); // and FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, SUB_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// sub FC_RETOP, a1, a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, SUB_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              HOST_a2, 0)); // sub FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_XORb:
 		case t_XORw:
 		case t_XORd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, EOR_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// eor FC_RETOP, a1, a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, EOR_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              HOST_a2, 0)); // eor FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_CMPb:
@@ -1023,183 +1035,325 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, NOP);				// nop
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, NOP); // nop
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, ADD_IMM(FC_RETOP, HOST_a1, 1, 0));	// add FC_RETOP, a1, #1
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ADD_IMM(FC_RETOP, HOST_a1, 1, 0)); // add FC_RETOP, a1, #1
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, SUB_IMM(FC_RETOP, HOST_a1, 1, 0));	// sub FC_RETOP, a1, #1
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, SUB_IMM(FC_RETOP, HOST_a1, 1, 0)); // sub FC_RETOP, a1, #1
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_SHLb:
 		case t_SHLw:
 		case t_SHLd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, MOV_REG_LSL_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsl a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, MOV_REG_LSL_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // lsl a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
-		case t_SHRb:
-			write_uint32(pos, NOP);					// nop
+	        case t_SHRb: write_uint32(pos, NOP); // nop
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos + 4, BFC(HOST_a1, 8, 24));	// bfc a1, 8, 24
-			write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsr a2
+		        write_uint32(pos + 4, BFC(HOST_a1, 8, 24)); // bfc a1,
+		                                                    // 8, 24
+		        write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // lsr a2
 #else
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, AND_IMM(FC_RETOP, HOST_a1, 0xff, 0));				// and FC_RETOP, a1, #0xff
-			write_uint32(pos + 12, MOV_REG_LSR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, lsr a2
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, AND_IMM(FC_RETOP, HOST_a1, 0xff,
+		                                      0)); // and FC_RETOP, a1,
+		                                           // #0xff
+		        write_uint32(pos + 12, MOV_REG_LSR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // lsr a2
 #endif
-			break;
-		case t_SHRw:
-			write_uint32(pos, NOP);					// nop
+		        break;
+	        case t_SHRw: write_uint32(pos, NOP); // nop
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos + 4, BFC(HOST_a1, 16, 16));	// bfc a1, 16, 16
-			write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsr a2
+		        write_uint32(pos + 4, BFC(HOST_a1, 16, 16)); // bfc a1,
+		                                                     // 16, 16
+		        write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // lsr a2
 #else
-			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));			// mov FC_RETOP, a1, lsl #16
-			write_uint32(pos + 8, MOV_REG_LSR_IMM(FC_RETOP, FC_RETOP, 16));			// mov FC_RETOP, FC_RETOP, lsr #16
-			write_uint32(pos + 12, MOV_REG_LSR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, lsr a2
+		        write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              16)); // mov
+		                                                    // FC_RETOP,
+		                                                    // a1, lsl #16
+		        write_uint32(pos + 8, MOV_REG_LSR_IMM(FC_RETOP, FC_RETOP,
+		                                              16)); // mov
+		                                                    // FC_RETOP,
+		                                                    // FC_RETOP,
+		                                                    // lsr #16
+		        write_uint32(pos + 12, MOV_REG_LSR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // lsr a2
 #endif
-			break;
+		        break;
 		case t_SHRd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsr a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // lsr a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
-		case t_SARb:
-			write_uint32(pos, NOP);					// nop
+	        case t_SARb: write_uint32(pos, NOP); // nop
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos + 4, SXTB(FC_RETOP, HOST_a1, 0));					// sxtb FC_RETOP, a1
-			write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
+		        write_uint32(pos + 4, SXTB(FC_RETOP, HOST_a1, 0)); // sxtb
+		                                                           // FC_RETOP,
+		                                                           // a1
+		        write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // FC_RETOP,
+		                                                         // asr a2
 #else
-			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 24));			// mov FC_RETOP, a1, lsl #24
-			write_uint32(pos + 8, MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP, 24));			// mov FC_RETOP, FC_RETOP, asr #24
-			write_uint32(pos + 12, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
+		        write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              24)); // mov
+		                                                    // FC_RETOP,
+		                                                    // a1, lsl #24
+		        write_uint32(pos + 8, MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP,
+		                                              24)); // mov
+		                                                    // FC_RETOP,
+		                                                    // FC_RETOP,
+		                                                    // asr #24
+		        write_uint32(pos + 12, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // asr a2
 #endif
-			break;
-		case t_SARw:
-			write_uint32(pos, NOP);					// nop
+		        break;
+	        case t_SARw: write_uint32(pos, NOP); // nop
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos + 4, SXTH(FC_RETOP, HOST_a1, 0));					// sxth FC_RETOP, a1
-			write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
+		        write_uint32(pos + 4, SXTH(FC_RETOP, HOST_a1, 0)); // sxth
+		                                                           // FC_RETOP,
+		                                                           // a1
+		        write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // FC_RETOP,
+		                                                         // asr a2
 #else
-			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));			// mov FC_RETOP, a1, lsl #16
-			write_uint32(pos + 8, MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP, 16));			// mov FC_RETOP, FC_RETOP, asr #16
-			write_uint32(pos + 12, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
+		        write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              16)); // mov
+		                                                    // FC_RETOP,
+		                                                    // a1, lsl #16
+		        write_uint32(pos + 8, MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP,
+		                                              16)); // mov
+		                                                    // FC_RETOP,
+		                                                    // FC_RETOP,
+		                                                    // asr #16
+		        write_uint32(pos + 12, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // asr a2
 #endif
-			break;
+		        break;
 		case t_SARd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, asr a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // asr a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_RORb:
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos, BFI(HOST_a1, HOST_a1, 8, 8));						// bfi a1, a1, 8, 8
-			write_uint32(pos + 4, BFI(HOST_a1, HOST_a1, 16, 16));				// bfi a1, a1, 16, 16
-			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
+		        write_uint32(pos, BFI(HOST_a1, HOST_a1, 8, 8)); // bfi
+		                                                        // a1,
+		                                                        // a1, 8, 8
+		        write_uint32(pos + 4, BFI(HOST_a1, HOST_a1, 16, 16)); // bfi a1, a1, 16, 16
+		        write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // ror a2
 #else
-			write_uint32(pos, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 24));					// mov FC_RETOP, a1, lsl #24
-			write_uint32(pos + 4, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 8));		// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #8
-			write_uint32(pos + 8, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16));	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
-			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2));		// mov FC_RETOP, FC_RETOP, ror a2
+		        write_uint32(pos, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                          24)); // mov FC_RETOP,
+		                                                // a1, lsl #24
+		        write_uint32(pos + 4,
+		                     ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP,
+		                                     8)); // orr FC_RETOP,
+		                                          // FC_RETOP, FC_RETOP,
+		                                          // lsr #8
+		        write_uint32(pos + 8,
+		                     ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP,
+		                                     16)); // orr FC_RETOP,
+		                                           // FC_RETOP,
+		                                           // FC_RETOP, lsr #16
+		        write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // ror a2
 #endif
-			break;
-		case t_RORw:
-			write_uint32(pos, NOP);					// nop
+		        break;
+	        case t_RORw: write_uint32(pos, NOP); // nop
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos + 4, BFI(HOST_a1, HOST_a1, 16, 16));				// bfi a1, a1, 16, 16
-			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
+		        write_uint32(pos + 4, BFI(HOST_a1, HOST_a1, 16, 16)); // bfi a1, a1, 16, 16
+		        write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // ror a2
 #else
-			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));				// mov FC_RETOP, a1, lsl #16
-			write_uint32(pos + 8, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16));	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
-			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2));		// mov FC_RETOP, FC_RETOP, ror a2
+		        write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                              16)); // mov
+		                                                    // FC_RETOP,
+		                                                    // a1, lsl #16
+		        write_uint32(pos + 8,
+		                     ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP,
+		                                     16)); // orr FC_RETOP,
+		                                           // FC_RETOP,
+		                                           // FC_RETOP, lsr #16
+		        write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // ror a2
 #endif
-			break;
+		        break;
 		case t_RORd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // ror a2
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		case t_ROLw:
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos, BFI(HOST_a1, HOST_a1, 16, 16));					// bfi a1, a1, 16, 16
-			write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0));				// rsb a2, a2, #32
-			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
+		        write_uint32(pos, BFI(HOST_a1, HOST_a1, 16, 16)); // bfi
+		                                                          // a1,
+		                                                          // a1,
+		                                                          // 16, 16
+		        write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0)); // rsb a2, a2, #32
+		        write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // ror a2
 #else
-			write_uint32(pos, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));					// mov FC_RETOP, a1, lsl #16
-			write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0));						// rsb a2, a2, #32
-			write_uint32(pos + 8, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16));	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
-			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2));		// mov FC_RETOP, FC_RETOP, ror a2
+		        write_uint32(pos, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1,
+		                                          16)); // mov FC_RETOP,
+		                                                // a1, lsl #16
+		        write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0)); // rsb a2, a2, #32
+		        write_uint32(pos + 8,
+		                     ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP,
+		                                     16)); // orr FC_RETOP,
+		                                           // FC_RETOP,
+		                                           // FC_RETOP, lsr #16
+		        write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // FC_RETOP,
+		                                                          // ror a2
 #endif
-			break;
-		case t_ROLd:
-			write_uint32(pos, NOP);					// nop
+		        break;
+	        case t_ROLd: write_uint32(pos, NOP); // nop
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0));				// rsb a2, a2, #32
-			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
+		        write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0)); // rsb a2, a2, #32
+		        write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1,
+		                                              HOST_a2)); // mov
+		                                                         // FC_RETOP,
+		                                                         // a1,
+		                                                         // ror a2
 #else
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, RSB_IMM(HOST_a2, HOST_a2, 32, 0));				// rsb a2, a2, #32
-			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, RSB_IMM(HOST_a2, HOST_a2, 32, 0)); // rsb a2, a2, #32
+		        write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, HOST_a1,
+		                                               HOST_a2)); // mov
+		                                                          // FC_RETOP,
+		                                                          // a1,
+		                                                          // ror a2
 #endif
-			break;
+		        break;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			write_uint32(pos, NOP);					// nop
-			write_uint32(pos + 4, NOP);				// nop
-			write_uint32(pos + 8, RSB_IMM(FC_RETOP, HOST_a1, 0, 0));	// rsb FC_RETOP, a1, #0
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, RSB_IMM(FC_RETOP, HOST_a1, 0, 0)); // rsb FC_RETOP, a1, #0
 #if C_TARGETCPU != ARMV7LE
-			write_uint32(pos + 12, NOP);				// nop
+		        write_uint32(pos + 12, NOP); // nop
 #endif
 			break;
 		default:
 #if C_TARGETCPU == ARMV7LE
-			write_uint32(pos, MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) & 0xffff));      // movw temp1, #(fct_ptr & 0xffff)
-			write_uint32(pos + 4, MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >> 16));      // movt temp1, #(fct_ptr >> 16)
+		        write_uint32(pos,
+		                     MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) &
+		                                         0xffff)); // movw temp1,
+		                                                   // #(fct_ptr
+		                                                   // & 0xffff)
+		        write_uint32(pos + 4,
+		                     MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >>
+		                                         16)); // movt temp1,
+		                                               // #(fct_ptr >> 16)
 #else
-			write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr));		// simple_func
+		        write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr)); // simple_func
 #endif
 			break;
 
 	}
 #else
 #if C_TARGETCPU == ARMV7LE
-	write_uint32(pos, MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) & 0xffff));      // movw temp1, #(fct_ptr & 0xffff)
-	write_uint32(pos + 4, MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >> 16));      // movt temp1, #(fct_ptr >> 16)
+	write_uint32(pos, MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) &
+	                                      0xffff)); // movw temp1, #(fct_ptr
+	                                                // & 0xffff)
+	write_uint32(pos + 4, MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >>
+	                                          16)); // movt temp1, #(fct_ptr
+	                                                // >> 16)
 #else
-	write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr));		// simple_func
+	write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr)); // simple_func
 #endif
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -920,7 +920,7 @@ static void gen_run_code(void) {
 
 	cache_addd( BX(HOST_r0) );			// bx r0
 #else
-	Bit8u *pos1, *pos2, *pos3;
+	uint8_t *pos1, *pos2, *pos3;
 
 	cache_addd(0xe92d4df0);			// stmfd sp!, {v1-v5,v7,v8,lr}
 
@@ -938,13 +938,13 @@ static void gen_run_code(void) {
 		cache.pos = cache.pos + (32 - (((Bitu)cache.pos) & 0x1f));
 	}
 
-	*(Bit32u*)pos1 = LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8));      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
+	write_uint32(pos1, LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)));      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
 	cache_addd((Bit32u)&Segs);      // address of "Segs"
 
-	*(Bit32u*)pos2 = LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8));      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
+	write_uint32(pos2, LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)));      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
 	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
 
-	*(Bit32u*)pos3 = LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8));      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
+	write_uint32(pos3, LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)));      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
 	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
@@ -970,51 +970,51 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ADD_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0);	// add FC_RETOP, a1, a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, ADD_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// add FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ORR_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0);	// orr FC_RETOP, a1, a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, ORR_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// orr FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=AND_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0);	// and FC_RETOP, a1, a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, AND_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// and FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=SUB_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0);	// sub FC_RETOP, a1, a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, SUB_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// sub FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_XORb:
 		case t_XORw:
 		case t_XORd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=EOR_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0);	// eor FC_RETOP, a1, a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, EOR_REG_LSL_IMM(FC_RETOP, HOST_a1, HOST_a2, 0));	// eor FC_RETOP, a1, a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_CMPb:
@@ -1023,183 +1023,183 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=NOP;				// nop
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, NOP);				// nop
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ADD_IMM(FC_RETOP, HOST_a1, 1, 0);	// add FC_RETOP, a1, #1
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, ADD_IMM(FC_RETOP, HOST_a1, 1, 0));	// add FC_RETOP, a1, #1
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=SUB_IMM(FC_RETOP, HOST_a1, 1, 0);	// sub FC_RETOP, a1, #1
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, SUB_IMM(FC_RETOP, HOST_a1, 1, 0));	// sub FC_RETOP, a1, #1
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_SHLb:
 		case t_SHLw:
 		case t_SHLd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=MOV_REG_LSL_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, lsl a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, MOV_REG_LSL_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsl a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_SHRb:
-			*(Bit32u*)pos=NOP;					// nop
+			write_uint32(pos, NOP);					// nop
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)(pos+4)=BFC(HOST_a1, 8, 24);	// bfc a1, 8, 24
-			*(Bit32u*)(pos+8)=MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, lsr a2
+			write_uint32(pos + 4, BFC(HOST_a1, 8, 24));	// bfc a1, 8, 24
+			write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsr a2
 #else
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=AND_IMM(FC_RETOP, HOST_a1, 0xff, 0);				// and FC_RETOP, a1, #0xff
-			*(Bit32u*)(pos+12)=MOV_REG_LSR_REG(FC_RETOP, FC_RETOP, HOST_a2);	// mov FC_RETOP, FC_RETOP, lsr a2
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, AND_IMM(FC_RETOP, HOST_a1, 0xff, 0));				// and FC_RETOP, a1, #0xff
+			write_uint32(pos + 12, MOV_REG_LSR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, lsr a2
 #endif
 			break;
 		case t_SHRw:
-			*(Bit32u*)pos=NOP;					// nop
+			write_uint32(pos, NOP);					// nop
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)(pos+4)=BFC(HOST_a1, 16, 16);	// bfc a1, 16, 16
-			*(Bit32u*)(pos+8)=MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, lsr a2
+			write_uint32(pos + 4, BFC(HOST_a1, 16, 16));	// bfc a1, 16, 16
+			write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsr a2
 #else
-			*(Bit32u*)(pos+4)=MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16);			// mov FC_RETOP, a1, lsl #16
-			*(Bit32u*)(pos+8)=MOV_REG_LSR_IMM(FC_RETOP, FC_RETOP, 16);			// mov FC_RETOP, FC_RETOP, lsr #16
-			*(Bit32u*)(pos+12)=MOV_REG_LSR_REG(FC_RETOP, FC_RETOP, HOST_a2);	// mov FC_RETOP, FC_RETOP, lsr a2
+			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));			// mov FC_RETOP, a1, lsl #16
+			write_uint32(pos + 8, MOV_REG_LSR_IMM(FC_RETOP, FC_RETOP, 16));			// mov FC_RETOP, FC_RETOP, lsr #16
+			write_uint32(pos + 12, MOV_REG_LSR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, lsr a2
 #endif
 			break;
 		case t_SHRd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, lsr a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, MOV_REG_LSR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, lsr a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_SARb:
-			*(Bit32u*)pos=NOP;					// nop
+			write_uint32(pos, NOP);					// nop
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)(pos+4)=SXTB(FC_RETOP, HOST_a1, 0);					// sxtb FC_RETOP, a1
-			*(Bit32u*)(pos+8)=MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2);	// mov FC_RETOP, FC_RETOP, asr a2
+			write_uint32(pos + 4, SXTB(FC_RETOP, HOST_a1, 0));					// sxtb FC_RETOP, a1
+			write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
 #else
-			*(Bit32u*)(pos+4)=MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 24);			// mov FC_RETOP, a1, lsl #24
-			*(Bit32u*)(pos+8)=MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP, 24);			// mov FC_RETOP, FC_RETOP, asr #24
-			*(Bit32u*)(pos+12)=MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2);	// mov FC_RETOP, FC_RETOP, asr a2
+			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 24));			// mov FC_RETOP, a1, lsl #24
+			write_uint32(pos + 8, MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP, 24));			// mov FC_RETOP, FC_RETOP, asr #24
+			write_uint32(pos + 12, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
 #endif
 			break;
 		case t_SARw:
-			*(Bit32u*)pos=NOP;					// nop
+			write_uint32(pos, NOP);					// nop
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)(pos+4)=SXTH(FC_RETOP, HOST_a1, 0);					// sxth FC_RETOP, a1
-			*(Bit32u*)(pos+8)=MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2);	// mov FC_RETOP, FC_RETOP, asr a2
+			write_uint32(pos + 4, SXTH(FC_RETOP, HOST_a1, 0));					// sxth FC_RETOP, a1
+			write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
 #else
-			*(Bit32u*)(pos+4)=MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16);			// mov FC_RETOP, a1, lsl #16
-			*(Bit32u*)(pos+8)=MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP, 16);			// mov FC_RETOP, FC_RETOP, asr #16
-			*(Bit32u*)(pos+12)=MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2);	// mov FC_RETOP, FC_RETOP, asr a2
+			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));			// mov FC_RETOP, a1, lsl #16
+			write_uint32(pos + 8, MOV_REG_ASR_IMM(FC_RETOP, FC_RETOP, 16));			// mov FC_RETOP, FC_RETOP, asr #16
+			write_uint32(pos + 12, MOV_REG_ASR_REG(FC_RETOP, FC_RETOP, HOST_a2));	// mov FC_RETOP, FC_RETOP, asr a2
 #endif
 			break;
 		case t_SARd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=MOV_REG_ASR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, asr a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, MOV_REG_ASR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, asr a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_RORb:
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)pos=BFI(HOST_a1, HOST_a1, 8, 8);						// bfi a1, a1, 8, 8
-			*(Bit32u*)(pos+4)=BFI(HOST_a1, HOST_a1, 16, 16);				// bfi a1, a1, 16, 16
-			*(Bit32u*)(pos+8)=MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, ror a2
+			write_uint32(pos, BFI(HOST_a1, HOST_a1, 8, 8));						// bfi a1, a1, 8, 8
+			write_uint32(pos + 4, BFI(HOST_a1, HOST_a1, 16, 16));				// bfi a1, a1, 16, 16
+			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
 #else
-			*(Bit32u*)pos=MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 24);					// mov FC_RETOP, a1, lsl #24
-			*(Bit32u*)(pos+4)=ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 8);		// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #8
-			*(Bit32u*)(pos+8)=ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16);	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
-			*(Bit32u*)(pos+12)=MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2);		// mov FC_RETOP, FC_RETOP, ror a2
+			write_uint32(pos, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 24));					// mov FC_RETOP, a1, lsl #24
+			write_uint32(pos + 4, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 8));		// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #8
+			write_uint32(pos + 8, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16));	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
+			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2));		// mov FC_RETOP, FC_RETOP, ror a2
 #endif
 			break;
 		case t_RORw:
-			*(Bit32u*)pos=NOP;					// nop
+			write_uint32(pos, NOP);					// nop
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)(pos+4)=BFI(HOST_a1, HOST_a1, 16, 16);				// bfi a1, a1, 16, 16
-			*(Bit32u*)(pos+8)=MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, ror a2
+			write_uint32(pos + 4, BFI(HOST_a1, HOST_a1, 16, 16));				// bfi a1, a1, 16, 16
+			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
 #else
-			*(Bit32u*)(pos+4)=MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16);				// mov FC_RETOP, a1, lsl #16
-			*(Bit32u*)(pos+8)=ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16);	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
-			*(Bit32u*)(pos+12)=MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2);		// mov FC_RETOP, FC_RETOP, ror a2
+			write_uint32(pos + 4, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));				// mov FC_RETOP, a1, lsl #16
+			write_uint32(pos + 8, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16));	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
+			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2));		// mov FC_RETOP, FC_RETOP, ror a2
 #endif
 			break;
 		case t_RORd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, ror a2
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		case t_ROLw:
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)pos=BFI(HOST_a1, HOST_a1, 16, 16);					// bfi a1, a1, 16, 16
-			*(Bit32u*)(pos+4)=RSB_IMM(HOST_a2, HOST_a2, 32, 0);				// rsb a2, a2, #32
-			*(Bit32u*)(pos+8)=MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, ror a2
+			write_uint32(pos, BFI(HOST_a1, HOST_a1, 16, 16));					// bfi a1, a1, 16, 16
+			write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0));				// rsb a2, a2, #32
+			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
 #else
-			*(Bit32u*)pos=MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16);					// mov FC_RETOP, a1, lsl #16
-			*(Bit32u*)(pos+4)=RSB_IMM(HOST_a2, HOST_a2, 32, 0);						// rsb a2, a2, #32
-			*(Bit32u*)(pos+8)=ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16);	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
-			*(Bit32u*)(pos+12)=MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2);		// mov FC_RETOP, FC_RETOP, ror a2
+			write_uint32(pos, MOV_REG_LSL_IMM(FC_RETOP, HOST_a1, 16));					// mov FC_RETOP, a1, lsl #16
+			write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0));						// rsb a2, a2, #32
+			write_uint32(pos + 8, ORR_REG_LSR_IMM(FC_RETOP, FC_RETOP, FC_RETOP, 16));	// orr FC_RETOP, FC_RETOP, FC_RETOP, lsr #16
+			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, FC_RETOP, HOST_a2));		// mov FC_RETOP, FC_RETOP, ror a2
 #endif
 			break;
 		case t_ROLd:
-			*(Bit32u*)pos=NOP;					// nop
+			write_uint32(pos, NOP);					// nop
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)(pos+4)=RSB_IMM(HOST_a2, HOST_a2, 32, 0);				// rsb a2, a2, #32
-			*(Bit32u*)(pos+8)=MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, ror a2
+			write_uint32(pos + 4, RSB_IMM(HOST_a2, HOST_a2, 32, 0));				// rsb a2, a2, #32
+			write_uint32(pos + 8, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
 #else
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=RSB_IMM(HOST_a2, HOST_a2, 32, 0);				// rsb a2, a2, #32
-			*(Bit32u*)(pos+12)=MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2);	// mov FC_RETOP, a1, ror a2
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, RSB_IMM(HOST_a2, HOST_a2, 32, 0));				// rsb a2, a2, #32
+			write_uint32(pos + 12, MOV_REG_ROR_REG(FC_RETOP, HOST_a1, HOST_a2));	// mov FC_RETOP, a1, ror a2
 #endif
 			break;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=RSB_IMM(FC_RETOP, HOST_a1, 0, 0);	// rsb FC_RETOP, a1, #0
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, RSB_IMM(FC_RETOP, HOST_a1, 0, 0));	// rsb FC_RETOP, a1, #0
 #if C_TARGETCPU != ARMV7LE
-			*(Bit32u*)(pos+12)=NOP;				// nop
+			write_uint32(pos + 12, NOP);				// nop
 #endif
 			break;
 		default:
 #if C_TARGETCPU == ARMV7LE
-			*(Bit32u*)pos=MOVW(temp1, ((Bit32u)fct_ptr) & 0xffff);      // movw temp1, #(fct_ptr & 0xffff)
-			*(Bit32u*)(pos+4)=MOVT(temp1, ((Bit32u)fct_ptr) >> 16);      // movt temp1, #(fct_ptr >> 16)
+			write_uint32(pos, MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) & 0xffff));      // movw temp1, #(fct_ptr & 0xffff)
+			write_uint32(pos + 4, MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >> 16));      // movt temp1, #(fct_ptr >> 16)
 #else
-			*(Bit32u*)(pos+12)=(Bit32u)fct_ptr;		// simple_func
+			write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr));		// simple_func
 #endif
 			break;
 
 	}
 #else
 #if C_TARGETCPU == ARMV7LE
-	*(Bit32u*)pos=MOVW(temp1, ((Bit32u)fct_ptr) & 0xffff);      // movw temp1, #(fct_ptr & 0xffff)
-	*(Bit32u*)(pos+4)=MOVT(temp1, ((Bit32u)fct_ptr) >> 16);      // movt temp1, #(fct_ptr >> 16)
+	write_uint32(pos, MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) & 0xffff));      // movw temp1, #(fct_ptr & 0xffff)
+	write_uint32(pos + 4, MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >> 16));      // movt temp1, #(fct_ptr >> 16)
 #else
-	*(Bit32u*)(pos+12)=(Bit32u)fct_ptr;		// simple_func
+	write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr));		// simple_func
 #endif
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -1329,31 +1329,33 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			break;
 		default:
 #if C_TARGETCPU == ARMV7LE
-		        write_uint32(pos,
-		                     MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) &
-		                                         0xffff)); // movw temp1,
-		                                                   // #(fct_ptr
-		                                                   // & 0xffff)
+		        write_uint32(pos, MOVW(temp1,
+		                               (reinterpret_cast<uint32_t>(fct_ptr)) &
+		                                       0xffff)); // movw temp1,
+		                                                 // #(fct_ptr
+		                                                 // & 0xffff)
 		        write_uint32(pos + 4,
-		                     MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >>
-		                                         16)); // movt temp1,
-		                                               // #(fct_ptr >> 16)
+		                     MOVT(temp1,
+		                          (reinterpret_cast<uint32_t>(fct_ptr)) >>
+		                                  16)); // movt temp1,
+		                                        // #(fct_ptr >> 16)
 #else
-		        write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr)); // simple_func
+		        write_uint32(pos + 12,
+		                     reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 #endif
 			break;
 
 	}
 #else
 #if C_TARGETCPU == ARMV7LE
-	write_uint32(pos, MOVW(temp1, (static_cast<uint32_t>(fct_ptr)) &
+	write_uint32(pos, MOVW(temp1, (reinterpret_cast<uint32_t>(fct_ptr)) &
 	                                      0xffff)); // movw temp1, #(fct_ptr
 	                                                // & 0xffff)
-	write_uint32(pos + 4, MOVT(temp1, (static_cast<uint32_t>(fct_ptr)) >>
+	write_uint32(pos + 4, MOVT(temp1, (reinterpret_cast<uint32_t>(fct_ptr)) >>
 	                                          16)); // movt temp1, #(fct_ptr
 	                                                // >> 16)
 #else
-	write_uint32(pos + 12, static_cast<uint32_t>(fct_ptr)); // simple_func
+	write_uint32(pos + 12, reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 #endif
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -340,7 +340,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 
 		cache_checkinstr(4);
 
-		diff = imm - ((Bit32u)cache.pos+4);
+		diff = imm - ((Bit32u)cache.pos + 4);
 
 		if ((diff < 1024) && ((imm & 0x03) == 0)) {
 			if (((Bit32u)cache.pos & 0x03) == 0) {
@@ -353,7 +353,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 			Bit8u *datapos;
 
 			datapos = cache_reservedata();
-			*(Bit32u*)datapos=imm;
+			write_uint32(datapos, imm);
 
 			if (((Bit32u)cache.pos & 0x03) == 0) {
 				cache_addw( LDR_PC_IMM(dest_reg, datapos - (cache.pos + 4)) );      // ldr dest_reg, [pc, datapos]
@@ -822,11 +822,12 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 }
 
 // helper function for gen_call_function_raw and gen_call_function_setup
-static void gen_call_function_helper(void * func) {
+static void gen_call_function_helper(void *func)
+{
 	Bit8u *datapos;
 
 	datapos = cache_reservedata();
-	*(Bit32u*)datapos=(Bit32u)func;
+	write_uint32(datapos, static_cast<uint32_t>(func));
 
 	if (((Bit32u)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
@@ -1054,13 +1055,24 @@ static void gen_run_code(void) {
 		cache.pos = cache.pos + (32 - (((Bitu)cache.pos) & 0x1f));
 	}
 
-	*(Bit32u*)pos1 = ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8));      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
+	write_uint32(pos1, ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc,
+	                               cache.pos - (pos1 + 8))); // ldr
+	                                                         // FC_SEGS_ADDR,
+	                                                         // [pc, #(&Segs)]
 	cache_addd((Bit32u)&Segs);      // address of "Segs"
 
-	*(Bit32u*)pos2 = ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8));      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
+	write_uint32(pos2, ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc,
+	                               cache.pos - (pos2 + 8))); // ldr
+	                                                         // FC_REGS_ADDR,
+	                                                         // [pc,
+	                                                         // #(&cpu_regs)]
 	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
 
-	*(Bit32u*)pos3 = ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8));      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
+	write_uint32(pos3, ARM_LDR_IMM(readdata_addr, HOST_pc,
+	                               cache.pos - (pos3 + 8))); // ldr
+	                                                         // readdata_addr,
+	                                                         // [pc,
+	                                                         // #(&core_dynrec.readdata)]
 	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
@@ -1088,12 +1100,14 @@ static void INLINE gen_create_branch_short(void * func) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
-	if ((*(Bit16u*)pos & 0xf000) == 0xe000) {
-		if ((*(Bit16u*)pos & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
-			(*(Bit16u*)pos & 0x0fff) < 0x0800)
-		{
-			pos = (Bit8u *) ( ( ( (Bit32u)(*(Bit16u*)pos & 0x0fff) ) << 1 ) + ((Bit32u)pos + 4) );
+static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
+{
+	if ((read_uint16(pos) & 0xf000) == 0xe000) {
+		if ((read_uint16(pos) & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
+		    (read_uint16(pos) & 0x0fff) < 0x0800) {
+			pos = static_cast<uint8_t *>(
+			        ((static_cast<uint32_t>(read_uint16(pos)) & 0x0fff)
+			         << 1) + (static_cast<uint32_t>(pos) + 4));
 		}
 	}
 
@@ -1105,32 +1119,44 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			case t_ADDb:
 			case t_ADDw:
 			case t_ADDd:
-				*(Bit16u*)pos=ADD_REG(HOST_a1, HOST_a1, HOST_a2);	// add a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, ADD_REG(HOST_a1, HOST_a1,
+				                          HOST_a2)); // add a1,
+				                                     // a1, a2
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_ORb:
 			case t_ORw:
 			case t_ORd:
-				*(Bit16u*)pos=ORR(HOST_a1, HOST_a2);				// orr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, ORR(HOST_a1, HOST_a2)); // orr
+				                                          // a1, a2
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_ANDb:
 			case t_ANDw:
 			case t_ANDd:
-				*(Bit16u*)pos=AND(HOST_a1, HOST_a2);				// and a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, AND(HOST_a1, HOST_a2)); // and
+				                                          // a1, a2
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_SUBb:
 			case t_SUBw:
 			case t_SUBd:
-				*(Bit16u*)pos=SUB_REG(HOST_a1, HOST_a1, HOST_a2);	// sub a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, SUB_REG(HOST_a1, HOST_a1,
+				                          HOST_a2)); // sub a1,
+				                                     // a1, a2
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_XORb:
 			case t_XORw:
 			case t_XORd:
-				*(Bit16u*)pos=EOR(HOST_a1, HOST_a2);				// eor a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, EOR(HOST_a1, HOST_a2)); // eor
+				                                          // a1, a2
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_CMPb:
 			case t_CMPw:
@@ -1138,110 +1164,115 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			case t_TESTb:
 			case t_TESTw:
 			case t_TESTd:
-				*(Bit16u*)pos=B_FWD(8);								// b after_call (pc+8)
+				write_uint16(pos, B_FWD(8)); // b after_call (pc+8)
 				break;
 			case t_INCb:
 			case t_INCw:
 			case t_INCd:
-				*(Bit16u*)pos=ADD_IMM3(HOST_a1, HOST_a1, 1);		// add a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, ADD_IMM3(HOST_a1, HOST_a1, 1)); // add a1, a1, #1
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_DECb:
 			case t_DECw:
 			case t_DECd:
-				*(Bit16u*)pos=SUB_IMM3(HOST_a1, HOST_a1, 1);		// sub a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, SUB_IMM3(HOST_a1, HOST_a1, 1)); // sub a1, a1, #1
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_SHLb:
 			case t_SHLw:
 			case t_SHLd:
-				*(Bit16u*)pos=LSL_REG(HOST_a1, HOST_a2);			// lsl a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, LSL_REG(HOST_a1, HOST_a2)); // lsl a1, a2
+				write_uint16(pos + 2, B_FWD(6)); // b after_call
+				                                 // (pc+6)
 				break;
 			case t_SHRb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=LSR_IMM(HOST_a1, HOST_a1, 24);	// lsr a1, a1, #24
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(Bit16u*)(pos+10)=NOP;								// nop
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, LSR_IMM(HOST_a1, HOST_a1, 24));	// lsr a1, a1, #24
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, LSR_REG(HOST_a1, HOST_a2));		// lsr a1, a2
+				write_uint16(pos + 10, NOP;								// nop
 				break;
 			case t_SHRw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=LSR_IMM(HOST_a1, HOST_a1, 16);	// lsr a1, a1, #16
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(Bit16u*)(pos+10)=NOP;								// nop
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, LSR_IMM(HOST_a1, HOST_a1, 16));	// lsr a1, a1, #16
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, LSR_REG(HOST_a1, HOST_a2));		// lsr a1, a2
+				write_uint16(pos + 10, NOP;								// nop
 				break;
 			case t_SHRd:
-				*(Bit16u*)pos=LSR_REG(HOST_a1, HOST_a2);			// lsr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, LSR_REG(HOST_a1, HOST_a2));			// lsr a1, a2
+				write_uint16(pos + 2, B_FWD(6));							// b after_call (pc+6)
 				break;
 			case t_SARb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=ASR_IMM(HOST_a1, HOST_a1, 24);	// asr a1, a1, #24
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(Bit16u*)(pos+10)=NOP;								// nop
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24));		// lsl a1, a1, #24
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, ASR_IMM(HOST_a1, HOST_a1, 24));	// asr a1, a1, #24
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, ASR_REG(HOST_a1, HOST_a2));		// asr a1, a2
+				write_uint16(pos + 10, NOP;								// nop
 				break;
 			case t_SARw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=ASR_IMM(HOST_a1, HOST_a1, 16);	// asr a1, a1, #16
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(Bit16u*)(pos+10)=NOP;								// nop
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, ASR_IMM(HOST_a1, HOST_a1, 16));	// asr a1, a1, #16
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, ASR_REG(HOST_a1, HOST_a2));		// asr a1, a2
+				write_uint16(pos + 10, NOP;								// nop
 				break;
 			case t_SARd:
-				*(Bit16u*)pos=ASR_REG(HOST_a1, HOST_a2);			// asr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, ASR_REG(HOST_a1, HOST_a2));			// asr a1, a2
+				write_uint16(pos + 2, B_FWD(6));							// b after_call (pc+6)
 				break;
 			case t_RORb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(Bit16u*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+6)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24));		// lsl a1, a1, #24
+				write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1, 8));		// lsr templo1, a1, #8
+				write_uint16(pos + 4, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 6, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 8, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_RORw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+4)=NOP;								// nop
-				*(Bit16u*)(pos+6)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+8)=NOP;								// nop
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 4, NOP;								// nop
+				write_uint16(pos + 6, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 8, NOP;								// nop
+				write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_RORd:
-				*(Bit16u*)pos=ROR_REG(HOST_a1, HOST_a2);			// ror a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, ROR_REG(HOST_a1, HOST_a2));			// ror a1, a2
+				write_uint16(pos + 2, B_FWD(6));							// b after_call (pc+6)
 				break;
 			case t_ROLw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(Bit16u*)(pos+4)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NEG(HOST_a2, HOST_a2));			// neg a2, a2
+				write_uint16(pos + 4, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 6, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 8, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_ROLd:
-				*(Bit16u*)pos=NEG(HOST_a2, HOST_a2);				// neg a2, a2
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+10)=NOP;								// nop
+				write_uint16(pos, NEG(HOST_a2, HOST_a2));				// neg a2, a2
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
+				write_uint16(pos + 10, NOP;								// nop
 				break;
 			case t_NEGb:
 			case t_NEGw:
 			case t_NEGd:
-				*(Bit16u*)pos=NEG(HOST_a1, HOST_a1);				// neg a1, a1
-				*(Bit16u*)(pos+2)=B_FWD(6);							// b after_call (pc+6)
+				write_uint16(pos, NEG(HOST_a1, HOST_a1));				// neg a1, a1
+				write_uint16(pos + 2, B_FWD(6));							// b after_call (pc+6)
 				break;
 			default:
-				*(Bit32u*)( ( ((Bit32u) (*pos)) << 2 ) + ((Bit32u)pos + 4) ) = (Bit32u)fct_ptr;		// simple_func
+				write_uint32((static_cast<uint32_t>(*pos) << 2) +
+					     (static_cast<uint32_t>(pos) + 4),
+					     static_cast<uint32_t>(ct_ptr)); // simple_func
 				break;
 		}
 	}
@@ -1252,32 +1283,44 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			case t_ADDb:
 			case t_ADDw:
 			case t_ADDd:
-				*(Bit16u*)pos=ADD_REG(HOST_a1, HOST_a1, HOST_a2);	// add a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, ADD_REG(HOST_a1, HOST_a1,
+				                          HOST_a2)); // add a1,
+				                                     // a1, a2
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_ORb:
 			case t_ORw:
 			case t_ORd:
-				*(Bit16u*)pos=ORR(HOST_a1, HOST_a2);				// orr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, ORR(HOST_a1, HOST_a2)); // orr
+				                                          // a1, a2
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_ANDb:
 			case t_ANDw:
 			case t_ANDd:
-				*(Bit16u*)pos=AND(HOST_a1, HOST_a2);				// and a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, AND(HOST_a1, HOST_a2)); // and
+				                                          // a1, a2
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_SUBb:
 			case t_SUBw:
 			case t_SUBd:
-				*(Bit16u*)pos=SUB_REG(HOST_a1, HOST_a1, HOST_a2);	// sub a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, SUB_REG(HOST_a1, HOST_a1,
+				                          HOST_a2)); // sub a1,
+				                                     // a1, a2
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_XORb:
 			case t_XORw:
 			case t_XORd:
-				*(Bit16u*)pos=EOR(HOST_a1, HOST_a2);				// eor a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, EOR(HOST_a1, HOST_a2)); // eor
+				                                          // a1, a2
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_CMPb:
 			case t_CMPw:
@@ -1285,88 +1328,93 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			case t_TESTb:
 			case t_TESTw:
 			case t_TESTd:
-				*(Bit16u*)pos=B_FWD(6);								// b after_call (pc+6)
+				write_uint16(pos, B_FWD(6)); // b after_call (pc+6)
 				break;
 			case t_INCb:
 			case t_INCw:
 			case t_INCd:
-				*(Bit16u*)pos=ADD_IMM3(HOST_a1, HOST_a1, 1);		// add a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, ADD_IMM3(HOST_a1, HOST_a1, 1)); // add a1, a1, #1
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_DECb:
 			case t_DECw:
 			case t_DECd:
-				*(Bit16u*)pos=SUB_IMM3(HOST_a1, HOST_a1, 1);		// sub a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, SUB_IMM3(HOST_a1, HOST_a1, 1)); // sub a1, a1, #1
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_SHLb:
 			case t_SHLw:
 			case t_SHLd:
-				*(Bit16u*)pos=LSL_REG(HOST_a1, HOST_a2);			// lsl a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, LSL_REG(HOST_a1, HOST_a2)); // lsl a1, a2
+				write_uint16(pos + 2, B_FWD(4)); // b after_call
+				                                 // (pc+4)
 				break;
 			case t_SHRb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=LSR_IMM(HOST_a1, HOST_a1, 24);	// lsr a1, a1, #24
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, LSR_IMM(HOST_a1, HOST_a1, 24));	// lsr a1, a1, #24
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, LSR_REG(HOST_a1, HOST_a2));		// lsr a1, a2
 				break;
 			case t_SHRw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=LSR_IMM(HOST_a1, HOST_a1, 16);	// lsr a1, a1, #16
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, LSR_IMM(HOST_a1, HOST_a1, 16));	// lsr a1, a1, #16
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, LSR_REG(HOST_a1, HOST_a2));		// lsr a1, a2
 				break;
 			case t_SHRd:
-				*(Bit16u*)pos=LSR_REG(HOST_a1, HOST_a2);			// lsr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, LSR_REG(HOST_a1, HOST_a2));			// lsr a1, a2
+				write_uint16(pos + 2, B_FWD(4));							// b after_call (pc+4)
 				break;
 			case t_SARb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=ASR_IMM(HOST_a1, HOST_a1, 24);	// asr a1, a1, #24
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24));		// lsl a1, a1, #24
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, ASR_IMM(HOST_a1, HOST_a1, 24));	// asr a1, a1, #24
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, ASR_REG(HOST_a1, HOST_a2));		// asr a1, a2
 				break;
 			case t_SARw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=ASR_IMM(HOST_a1, HOST_a1, 16);	// asr a1, a1, #16
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, ASR_IMM(HOST_a1, HOST_a1, 16));	// asr a1, a1, #16
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, ASR_REG(HOST_a1, HOST_a2));		// asr a1, a2
 				break;
 			case t_SARd:
-				*(Bit16u*)pos=ASR_REG(HOST_a1, HOST_a2);			// asr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, ASR_REG(HOST_a1, HOST_a2));			// asr a1, a2
+				write_uint16(pos + 2, B_FWD(4));							// b after_call (pc+4)
 				break;
 			case t_RORw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+4)=NOP;								// nop
-				*(Bit16u*)(pos+6)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+8)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 4, NOP;								// nop
+				write_uint16(pos + 6, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 8, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_RORd:
-				*(Bit16u*)pos=ROR_REG(HOST_a1, HOST_a2);			// ror a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, ROR_REG(HOST_a1, HOST_a2));			// ror a1, a2
+				write_uint16(pos + 2, B_FWD(4));							// b after_call (pc+4)
 				break;
 			case t_ROLd:
-				*(Bit16u*)pos=NEG(HOST_a2, HOST_a2);				// neg a2, a2
-				*(Bit16u*)(pos+2)=NOP;								// nop
-				*(Bit16u*)(pos+4)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+6)=NOP;								// nop
-				*(Bit16u*)(pos+8)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				write_uint16(pos, NEG(HOST_a2, HOST_a2));				// neg a2, a2
+				write_uint16(pos + 2, NOP;								// nop
+				write_uint16(pos + 4, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 6, NOP;								// nop
+				write_uint16(pos + 8, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_NEGb:
 			case t_NEGw:
 			case t_NEGd:
-				*(Bit16u*)pos=NEG(HOST_a1, HOST_a1);				// neg a1, a1
-				*(Bit16u*)(pos+2)=B_FWD(4);							// b after_call (pc+4)
+				write_uint16(pos, NEG(HOST_a1, HOST_a1));				// neg a1, a1
+				write_uint16(pos + 2, B_FWD(4));							// b after_call (pc+4)
 				break;
 			default:
-				*(Bit32u*)( ( ((Bit32u) (*pos)) << 2 ) + ((Bit32u)pos + 2) ) = (Bit32u)fct_ptr;		// simple_func
+				write_uint32((static_cast<uint32_t>(*pos) << 2) +
+				     (static_cast<uint32_t>(pos) + 2),
+				      static_cast<uint32_t>(fct_ptr)); // simple_func
 				break;
 		}
 
@@ -1374,11 +1422,13 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 #else
 	if (((Bit32u)pos & 0x03) == 0)
 	{
-		*(Bit32u*)( ( ((Bit32u) (*pos)) << 2 ) + ((Bit32u)pos + 4) ) = (Bit32u)fct_ptr;		// simple_func
-	}
-	else
-	{
-		*(Bit32u*)( ( ((Bit32u) (*pos)) << 2 ) + ((Bit32u)pos + 2) ) = (Bit32u)fct_ptr;		// simple_func
+		write_uint32((static_cast<uint32_t>(*pos) << 2) +
+		             (static_cast<uint32_t>(pos) + 4),
+		             static_cast<uint32_t>(fct_ptr)); // simple_func
+	} else {
+		write_uint32((static_cast<uint32_t>(*pos) << 2) +
+		             (static_cast<uint32_t>(pos) + 2),
+		             static_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -1414,7 +1414,7 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 			default:
 				write_uint32((static_cast<uint32_t>(*pos) << 2) +
 				     (static_cast<uint32_t>(pos) + 2),
-				      static_cast<uint32_t>(fct_ptr)); // simple_func
+				      reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 				break;
 		}
 
@@ -1423,12 +1423,12 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 	if (((Bit32u)pos & 0x03) == 0)
 	{
 		write_uint32((static_cast<uint32_t>(*pos) << 2) +
-		             (static_cast<uint32_t>(pos) + 4),
-		             static_cast<uint32_t>(fct_ptr)); // simple_func
+		                     (static_cast<uint32_t>(pos) + 4),
+		             reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 	} else {
 		write_uint32((static_cast<uint32_t>(*pos) << 2) +
-		             (static_cast<uint32_t>(pos) + 2),
-		             static_cast<uint32_t>(fct_ptr)); // simple_func
+		                     (static_cast<uint32_t>(pos) + 2),
+		             reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -1295,7 +1295,7 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 			default:
 				write_uint32((static_cast<uint32_t>(*pos) << 2) + 
 				             (static_cast<uint32_t>(pos) + 4),
-				             static_cast<uint32_t>(fct_ptr)); // simple_func
+				             reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 				break;
 		}
 	}
@@ -1482,7 +1482,7 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 			default:
 				write_uint32((static_cast<uint32_t>(*pos) << 2) + 
 				             (static_cast<uint32_t>(pos) + 2),
-				             static_cast<uint32_t>(fct_ptr)); // simple_func
+				             reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 				break;
 		}
 
@@ -1492,11 +1492,11 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 	{
 		write_uint32((static_cast<uint32_t>(*pos) << 2) +
 		                     (static_cast<uint32_t>(pos) + 4),
-		             static_cast<uint32_t>(fct_ptr)); // simple_func
+		             reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 	} else {
 		write_uint32((static_cast<uint32_t>(*pos) << 2) +
 		                     (static_cast<uint32_t>(pos) + 2),
-		             static_cast<uint32_t>(fct_ptr)); // simple_func
+		             reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -1105,7 +1105,7 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 				write_uint16(pos + 2, B_FWD(14));						// b after_call (pc+14)
 				break;
 			default:
-				write_uint32(pos + 8, static_cast<uint32_t>(fct_ptr));		// simple_func
+				write_uint32(pos + 8, reinterpret_cast<uint32_t>(fct_ptr));		// simple_func
 				break;
 		}
 	}
@@ -1297,7 +1297,7 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 				write_uint16(pos + 2, B_FWD(16));						// b after_call (pc+16)
 				break;
 			default:
-				write_uint32(pos + 10, static_cast<uint32_t>(fct_ptr));		// simple_func
+				write_uint32(pos + 10, reinterpret_cast<uint32_t>(fct_ptr));		// simple_func
 				break;
 		}
 
@@ -1305,11 +1305,11 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 #else
 	if (((Bit32u)pos & 0x03) == 0)
 	{
-		write_uint32(pos + 8, static_cast<uint32_t>(fct_ptr)); // simple_func
+		write_uint32(pos + 8, reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 	else
 	{
-		write_uint32(pos + 10, static_cast<uint32_t>(fct_ptr)); // simple_func
+		write_uint32(pos + 10, reinterpret_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -879,13 +879,24 @@ static void gen_run_code(void) {
 		cache.pos = cache.pos + (32 - (((Bitu)cache.pos) & 0x1f));
 	}
 
-	*(Bit32u*)pos1 = ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8));      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
+	write_uint32(pos1, ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc,
+	                               cache.pos - (pos1 + 8))); // ldr
+	                                                         // FC_SEGS_ADDR,
+	                                                         // [pc, #(&Segs)]
 	cache_addd((Bit32u)&Segs);      // address of "Segs"
 
-	*(Bit32u*)pos2 = ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8));      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
+	write_uint32(pos2, ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc,
+	                               cache.pos - (pos2 + 8))); // ldr
+	                                                         // FC_REGS_ADDR,
+	                                                         // [pc,
+	                                                         // #(&cpu_regs)]
 	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
 
-	*(Bit32u*)pos3 = ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8));      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
+	write_uint32(pos3, ARM_LDR_IMM(readdata_addr, HOST_pc,
+	                               cache.pos - (pos3 + 8))); // ldr
+	                                                         // readdata_addr,
+	                                                         // [pc,
+	                                                         // #(&core_dynrec.readdata)]
 	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
@@ -913,146 +924,188 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			case t_ADDb:
 			case t_ADDw:
 			case t_ADDd:
-				*(Bit16u*)pos=ADD_REG(HOST_a1, HOST_a1, HOST_a2);	// add a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_ORb:
+			        write_uint16(pos, ADD_REG(HOST_a1, HOST_a1,
+			                                  HOST_a2);) // add a1,
+			                                             // a1, a2
+			                write_uint16(pos + 2, B_FWD(14)); // b
+			                                                  // after_call
+			                                                  // (pc+14)
+			        break;
+		        case t_ORb:
 			case t_ORw:
 			case t_ORd:
-				*(Bit16u*)pos=ORR(HOST_a1, HOST_a2);				// orr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_ANDb:
+			        write_uint16(pos, ORR(HOST_a1, HOST_a2)); // orr
+			                                                  // a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_ANDb:
 			case t_ANDw:
 			case t_ANDd:
-				*(Bit16u*)pos=AND(HOST_a1, HOST_a2);				// and a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_SUBb:
+			        write_uint16(pos, AND(HOST_a1, HOST_a2)); // and
+			                                                  // a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_SUBb:
 			case t_SUBw:
 			case t_SUBd:
-				*(Bit16u*)pos=SUB_REG(HOST_a1, HOST_a1, HOST_a2);	// sub a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_XORb:
+			        write_uint16(pos, SUB_REG(HOST_a1, HOST_a1,
+			                                  HOST_a2)); // sub a1,
+			                                             // a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_XORb:
 			case t_XORw:
 			case t_XORd:
-				*(Bit16u*)pos=EOR(HOST_a1, HOST_a2);				// eor a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_CMPb:
+			        write_uint16(pos, EOR(HOST_a1, HOST_a2)); // eor
+			                                                  // a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_CMPb:
 			case t_CMPw:
 			case t_CMPd:
 			case t_TESTb:
 			case t_TESTw:
 			case t_TESTd:
-				*(Bit16u*)pos=B_FWD(16);							// b after_call (pc+16)
-				break;
+			        write_uint16(pos, B_FWD(16)); // b after_call
+			                                      // (pc+16)
+			        break;
 			case t_INCb:
 			case t_INCw:
 			case t_INCd:
-				*(Bit16u*)pos=ADD_IMM3(HOST_a1, HOST_a1, 1);		// add a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_DECb:
+			        write_uint16(pos, ADD_IMM3(HOST_a1, HOST_a1, 1)); // add a1, a1, #1
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_DECb:
 			case t_DECw:
 			case t_DECd:
-				*(Bit16u*)pos=SUB_IMM3(HOST_a1, HOST_a1, 1);		// sub a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_SHLb:
+			        write_uint16(pos, SUB_IMM3(HOST_a1, HOST_a1, 1)); // sub a1, a1, #1
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_SHLb:
 			case t_SHLw:
 			case t_SHLd:
-				*(Bit16u*)pos=LSL_REG(HOST_a1, HOST_a2);			// lsl a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_SHRb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 24);	// lsr a1, a1, #24
-				*(Bit16u*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(10);						// b after_call (pc+10)
-				break;
-			case t_SHRw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 16);	// lsr a1, a1, #16
-				*(Bit16u*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(10);						// b after_call (pc+10)
-				break;
-			case t_SHRd:
-				*(Bit16u*)pos=LSR_REG(HOST_a1, HOST_a2);			// lsr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_SARb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 24);	// asr a1, a1, #24
-				*(Bit16u*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(10);						// b after_call (pc+10)
-				break;
-			case t_SARw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 16);	// asr a1, a1, #16
-				*(Bit16u*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(10);						// b after_call (pc+10)
-				break;
-			case t_SARd:
-				*(Bit16u*)pos=ASR_REG(HOST_a1, HOST_a2);			// asr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_RORb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(Bit16u*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+6)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+12)=B_FWD(4);						// b after_call (pc+4)
-				break;
-			case t_RORw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+6)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+8)=B_FWD(8);							// b after_call (pc+8)
-				break;
-			case t_RORd:
-				*(Bit16u*)pos=ROR_REG(HOST_a1, HOST_a2);			// ror a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
-				break;
-			case t_ROLb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(Bit16u*)(pos+4)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(Bit16u*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=NOP;								// nop
-				*(Bit16u*)(pos+12)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+14)=NOP;								// nop
-				*(Bit16u*)(pos+16)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+18)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+			        write_uint16(pos, LSL_REG(HOST_a1, HOST_a2)); // lsl a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_SHRb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, LSR_IMM(HOST_a1, HOST_a1,
+			                                      24)); // lsr a1,
+			                                            // a1, #24
+			        write_uint16(pos + 4, LSR_REG(HOST_a1, HOST_a2)); // lsr a1, a2
+			        write_uint16(pos + 6, B_FWD(10)); // b after_call
+			                                          // (pc+10)
+			        break;
+		        case t_SHRw:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16)); // lsl a1, a1, #16
+			        write_uint16(pos + 2, LSR_IMM(HOST_a1, HOST_a1,
+			                                      16)); // lsr a1,
+			                                            // a1, #16
+			        write_uint16(pos + 4, LSR_REG(HOST_a1, HOST_a2)); // lsr a1, a2
+			        write_uint16(pos + 6, B_FWD(10)); // b after_call
+			                                          // (pc+10)
+			        break;
+		        case t_SHRd:
+			        write_uint16(pos, LSR_REG(HOST_a1, HOST_a2)); // lsr a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_SARb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, ASR_IMM(HOST_a1, HOST_a1,
+			                                      24)); // asr a1,
+			                                            // a1, #24
+			        write_uint16(pos + 4, ASR_REG(HOST_a1, HOST_a2)); // asr a1, a2
+			        write_uint16(pos + 6, B_FWD(10)); // b after_call
+			                                          // (pc+10)
+			        break;
+		        case t_SARw:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16)); // lsl a1, a1, #16
+			        write_uint16(pos + 2, ASR_IMM(HOST_a1, HOST_a1,
+			                                      16)); // asr a1,
+			                                            // a1, #16
+			        write_uint16(pos + 4, ASR_REG(HOST_a1, HOST_a2)); // asr a1, a2
+			        write_uint16(pos + 6, B_FWD(10)); // b after_call
+			                                          // (pc+10)
+			        break;
+		        case t_SARd:
+			        write_uint16(pos, ASR_REG(HOST_a1, HOST_a2)); // asr a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_RORb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1,
+			                                      8)); // lsr templo1,
+			                                           // a1, #8
+			        write_uint16(pos + 4, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 6, LSR_IMM(templo1, HOST_a1,
+			                                      16)); // lsr templo1,
+			                                            // a1, #16
+			        write_uint16(pos + 8, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2)); // ror a1, a2
+			        write_uint16(pos + 12, B_FWD(4)); // b after_call
+			                                          // (pc+4)
+			        break;
+		        case t_RORw:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16)); // lsl a1, a1, #16
+			        write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1,
+			                                      16)); // lsr templo1,
+			                                            // a1, #16
+			        write_uint16(pos + 4, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 6, ROR_REG(HOST_a1, HOST_a2)); // ror a1, a2
+			        write_uint16(pos + 8, B_FWD(8)); // b after_call
+			                                         // (pc+8)
+			        break;
+		        case t_RORd:
+			        write_uint16(pos, ROR_REG(HOST_a1, HOST_a2)); // ror a1, a2
+			        write_uint16(pos + 2, B_FWD(14)); // b after_call
+			                                          // (pc+14)
+			        break;
+		        case t_ROLb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, NEG(HOST_a2, HOST_a2)); // neg a2, a2
+			        write_uint16(pos + 4, LSR_IMM(templo1, HOST_a1,
+			                                      8)); // lsr templo1,
+			                                           // a1, #8
+			        write_uint16(pos + 6, ADD_IMM8(HOST_a2, 32)); // add a2, #32
+			        write_uint16(pos + 8, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 10, NOP;								// nop
+				write_uint16(pos + 12, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 14, NOP;								// nop
+				write_uint16(pos + 16, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 18, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_ROLw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(Bit16u*)(pos+4)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+12)=B_FWD(4);						// b after_call (pc+4)
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NEG(HOST_a2, HOST_a2));			// neg a2, a2
+				write_uint16(pos + 4, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 6, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 8, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
+				write_uint16(pos + 12, B_FWD(4));						// b after_call (pc+4)
 				break;
 			case t_ROLd:
-				*(Bit16u*)pos=NEG(HOST_a2, HOST_a2);				// neg a2, a2
-				*(Bit16u*)(pos+2)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+4)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(10);						// b after_call (pc+10)
+				write_uint16(pos, NEG(HOST_a2, HOST_a2));				// neg a2, a2
+				write_uint16(pos + 2, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 4, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
+				write_uint16(pos + 6, B_FWD(10));						// b after_call (pc+10)
 				break;
 			case t_NEGb:
 			case t_NEGw:
 			case t_NEGd:
-				*(Bit16u*)pos=NEG(HOST_a1, HOST_a1);				// neg a1, a1
-				*(Bit16u*)(pos+2)=B_FWD(14);						// b after_call (pc+14)
+				write_uint16(pos, NEG(HOST_a1, HOST_a1));				// neg a1, a1
+				write_uint16(pos + 2, B_FWD(14));						// b after_call (pc+14)
 				break;
 			default:
-				*(Bit32u*)(pos+8)=(Bit32u)fct_ptr;		// simple_func
+				write_uint32(pos + 8, static_cast<uint32_t>(fct_ptr));		// simple_func
 				break;
 		}
 	}
@@ -1063,147 +1116,188 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			case t_ADDb:
 			case t_ADDw:
 			case t_ADDd:
-				*(Bit16u*)pos=ADD_REG(HOST_a1, HOST_a1, HOST_a2);	// add a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_ORb:
+			        write_uint16(pos, ADD_REG(HOST_a1, HOST_a1,
+			                                  HOST_a2)); // add a1,
+			                                             // a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_ORb:
 			case t_ORw:
 			case t_ORd:
-				*(Bit16u*)pos=ORR(HOST_a1, HOST_a2);				// orr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_ANDb:
+			        write_uint16(pos, ORR(HOST_a1, HOST_a2)); // orr
+			                                                  // a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_ANDb:
 			case t_ANDw:
 			case t_ANDd:
-				*(Bit16u*)pos=AND(HOST_a1, HOST_a2);				// and a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_SUBb:
+			        write_uint16(pos, AND(HOST_a1, HOST_a2)); // and
+			                                                  // a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_SUBb:
 			case t_SUBw:
 			case t_SUBd:
-				*(Bit16u*)pos=SUB_REG(HOST_a1, HOST_a1, HOST_a2);	// sub a1, a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_XORb:
+			        write_uint16(pos, SUB_REG(HOST_a1, HOST_a1,
+			                                  HOST_a2)); // sub a1,
+			                                             // a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_XORb:
 			case t_XORw:
 			case t_XORd:
-				*(Bit16u*)pos=EOR(HOST_a1, HOST_a2);				// eor a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_CMPb:
+			        write_uint16(pos, EOR(HOST_a1, HOST_a2)); // eor
+			                                                  // a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_CMPb:
 			case t_CMPw:
 			case t_CMPd:
 			case t_TESTb:
 			case t_TESTw:
 			case t_TESTd:
-				*(Bit16u*)pos=B_FWD(18);							// b after_call (pc+18)
-				break;
+			        write_uint16(pos, B_FWD(18)); // b after_call
+			                                      // (pc+18)
+			        break;
 			case t_INCb:
 			case t_INCw:
 			case t_INCd:
-				*(Bit16u*)pos=ADD_IMM3(HOST_a1, HOST_a1, 1);		// add a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_DECb:
+			        write_uint16(pos, ADD_IMM3(HOST_a1, HOST_a1, 1)); // add a1, a1, #1
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_DECb:
 			case t_DECw:
 			case t_DECd:
-				*(Bit16u*)pos=SUB_IMM3(HOST_a1, HOST_a1, 1);		// sub a1, a1, #1
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_SHLb:
+			        write_uint16(pos, SUB_IMM3(HOST_a1, HOST_a1, 1)); // sub a1, a1, #1
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_SHLb:
 			case t_SHLw:
 			case t_SHLd:
-				*(Bit16u*)pos=LSL_REG(HOST_a1, HOST_a2);			// lsl a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_SHRb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 24);	// lsr a1, a1, #24
-				*(Bit16u*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(12);						// b after_call (pc+12)
-				break;
-			case t_SHRw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 16);	// lsr a1, a1, #16
-				*(Bit16u*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(12);						// b after_call (pc+12)
-				break;
-			case t_SHRd:
-				*(Bit16u*)pos=LSR_REG(HOST_a1, HOST_a2);			// lsr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_SARb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 24);	// asr a1, a1, #24
-				*(Bit16u*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(12);						// b after_call (pc+12)
-				break;
-			case t_SARw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 16);	// asr a1, a1, #16
-				*(Bit16u*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(12);						// b after_call (pc+12)
-				break;
-			case t_SARd:
-				*(Bit16u*)pos=ASR_REG(HOST_a1, HOST_a2);			// asr a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_RORb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(Bit16u*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+6)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+12)=B_FWD(6);						// b after_call (pc+6)
-				break;
-			case t_RORw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+6)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+8)=B_FWD(10);						// b after_call (pc+10)
-				break;
-			case t_RORd:
-				*(Bit16u*)pos=ROR_REG(HOST_a1, HOST_a2);			// ror a1, a2
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
-				break;
-			case t_ROLb:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(Bit16u*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(Bit16u*)(pos+4)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(Bit16u*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=NOP;								// nop
-				*(Bit16u*)(pos+12)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+14)=NOP;								// nop
-				*(Bit16u*)(pos+16)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+18)=NOP;								// nop
-				*(Bit16u*)(pos+20)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+			        write_uint16(pos, LSL_REG(HOST_a1, HOST_a2)); // lsl a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_SHRb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, LSR_IMM(HOST_a1, HOST_a1,
+			                                      24)); // lsr a1,
+			                                            // a1, #24
+			        write_uint16(pos + 4, LSR_REG(HOST_a1, HOST_a2)); // lsr a1, a2
+			        write_uint16(pos + 6, B_FWD(12)); // b after_call
+			                                          // (pc+12)
+			        break;
+		        case t_SHRw:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16)); // lsl a1, a1, #16
+			        write_uint16(pos + 2, LSR_IMM(HOST_a1, HOST_a1,
+			                                      16)); // lsr a1,
+			                                            // a1, #16
+			        write_uint16(pos + 4, LSR_REG(HOST_a1, HOST_a2)); // lsr a1, a2
+			        write_uint16(pos + 6, B_FWD(12)); // b after_call
+			                                          // (pc+12)
+			        break;
+		        case t_SHRd:
+			        write_uint16(pos, LSR_REG(HOST_a1, HOST_a2)); // lsr a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_SARb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, ASR_IMM(HOST_a1, HOST_a1,
+			                                      24)); // asr a1,
+			                                            // a1, #24
+			        write_uint16(pos + 4, ASR_REG(HOST_a1, HOST_a2)); // asr a1, a2
+			        write_uint16(pos + 6, B_FWD(12)); // b after_call
+			                                          // (pc+12)
+			        break;
+		        case t_SARw:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16)); // lsl a1, a1, #16
+			        write_uint16(pos + 2, ASR_IMM(HOST_a1, HOST_a1,
+			                                      16)); // asr a1,
+			                                            // a1, #16
+			        write_uint16(pos + 4, ASR_REG(HOST_a1, HOST_a2)); // asr a1, a2
+			        write_uint16(pos + 6, B_FWD(12)); // b after_call
+			                                          // (pc+12)
+			        break;
+		        case t_SARd:
+			        write_uint16(pos, ASR_REG(HOST_a1, HOST_a2)); // asr a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_RORb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1,
+			                                      8)); // lsr templo1,
+			                                           // a1, #8
+			        write_uint16(pos + 4, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 6, LSR_IMM(templo1, HOST_a1,
+			                                      16)); // lsr templo1,
+			                                            // a1, #16
+			        write_uint16(pos + 8, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2)); // ror a1, a2
+			        write_uint16(pos + 12, B_FWD(6)); // b after_call
+			                                          // (pc+6)
+			        break;
+		        case t_RORw:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16)); // lsl a1, a1, #16
+			        write_uint16(pos + 2, LSR_IMM(templo1, HOST_a1,
+			                                      16)); // lsr templo1,
+			                                            // a1, #16
+			        write_uint16(pos + 4, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 6, ROR_REG(HOST_a1, HOST_a2)); // ror a1, a2
+			        write_uint16(pos + 8, B_FWD(10)); // b after_call
+			                                          // (pc+10)
+			        break;
+		        case t_RORd:
+			        write_uint16(pos, ROR_REG(HOST_a1, HOST_a2)); // ror a1, a2
+			        write_uint16(pos + 2, B_FWD(16)); // b after_call
+			                                          // (pc+16)
+			        break;
+		        case t_ROLb:
+			        write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 24)); // lsl a1, a1, #24
+			        write_uint16(pos + 2, NEG(HOST_a2, HOST_a2)); // neg a2, a2
+			        write_uint16(pos + 4, LSR_IMM(templo1, HOST_a1,
+			                                      8)); // lsr templo1,
+			                                           // a1, #8
+			        write_uint16(pos + 6, ADD_IMM8(HOST_a2, 32)); // add a2, #32
+			        write_uint16(pos + 8, ORR(HOST_a1, templo1)); // orr a1, templo1
+			        write_uint16(pos + 10, NOP;								// nop
+				write_uint16(pos + 12, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 14, NOP;								// nop
+				write_uint16(pos + 16, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 18, NOP;								// nop
+				write_uint16(pos + 20, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
 				break;
 			case t_ROLw:
-				*(Bit16u*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(Bit16u*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(Bit16u*)(pos+4)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(Bit16u*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(Bit16u*)(pos+10)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+12)=B_FWD(6);						// b after_call (pc+6)
+				write_uint16(pos, LSL_IMM(HOST_a1, HOST_a1, 16));		// lsl a1, a1, #16
+				write_uint16(pos + 2, NEG(HOST_a2, HOST_a2));			// neg a2, a2
+				write_uint16(pos + 4, LSR_IMM(templo1, HOST_a1, 16));	// lsr templo1, a1, #16
+				write_uint16(pos + 6, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 8, ORR(HOST_a1, templo1));			// orr a1, templo1
+				write_uint16(pos + 10, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
+				write_uint16(pos + 12, B_FWD(6));						// b after_call (pc+6)
 				break;
 			case t_ROLd:
-				*(Bit16u*)pos=NEG(HOST_a2, HOST_a2);				// neg a2, a2
-				*(Bit16u*)(pos+2)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(Bit16u*)(pos+4)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(Bit16u*)(pos+6)=B_FWD(12);						// b after_call (pc+12)
+				write_uint16(pos, NEG(HOST_a2, HOST_a2));				// neg a2, a2
+				write_uint16(pos + 2, ADD_IMM8(HOST_a2, 32));			// add a2, #32
+				write_uint16(pos + 4, ROR_REG(HOST_a1, HOST_a2));		// ror a1, a2
+				write_uint16(pos + 6, B_FWD(12));						// b after_call (pc+12)
 				break;
 			case t_NEGb:
 			case t_NEGw:
 			case t_NEGd:
-				*(Bit16u*)pos=NEG(HOST_a1, HOST_a1);				// neg a1, a1
-				*(Bit16u*)(pos+2)=B_FWD(16);						// b after_call (pc+16)
+				write_uint16(pos, NEG(HOST_a1, HOST_a1));				// neg a1, a1
+				write_uint16(pos + 2, B_FWD(16));						// b after_call (pc+16)
 				break;
 			default:
-				*(Bit32u*)(pos+10)=(Bit32u)fct_ptr;		// simple_func
+				write_uint32(pos + 10, static_cast<uint32_t>(fct_ptr));		// simple_func
 				break;
 		}
 
@@ -1211,11 +1305,11 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 #else
 	if (((Bit32u)pos & 0x03) == 0)
 	{
-		*(Bit32u*)(pos+8)=(Bit32u)fct_ptr;		// simple_func
+		write_uint32(pos + 8, static_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 	else
 	{
-		*(Bit32u*)(pos+10)=(Bit32u)fct_ptr;		// simple_func
+		write_uint32(pos + 10, static_cast<uint32_t>(fct_ptr)); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -1150,25 +1150,25 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 			write_uint32(pos + 16, LSRV64(FC_RETOP, HOST_x0, HOST_x2));				// lsrv FC_RETOP, x0, x2
 			break;
 		default:
-			write_uint32(pos, MOVZ64(temp1, (static_cast<uint64_t>(fct_ptr)) & 0xffff, 0));                 // movz temp1, #(fct_ptr & 0xffff)
-			write_uint32(pos + 4, MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 16) & 0xffff, 16));    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-			write_uint32(pos + 8, MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 32) & 0xffff, 32));    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-			write_uint32(pos + 12, MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 48) & 0xffff, 48));   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+			write_uint32(pos, MOVZ64(temp1, (reinterpret_cast<uint64_t>(fct_ptr)) & 0xffff, 0));                 // movz temp1, #(fct_ptr & 0xffff)
+			write_uint32(pos + 4, MOVK64(temp1, ((reinterpret_cast<uint64_t>(fct_ptr)) >> 16) & 0xffff, 16));    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
+			write_uint32(pos + 8, MOVK64(temp1, ((reinterpret_cast<uint64_t>(fct_ptr)) >> 32) & 0xffff, 32));    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
+			write_uint32(pos + 12, MOVK64(temp1, ((reinterpret_cast<uint64_t>(fct_ptr)) >> 48) & 0xffff, 48));   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
 			break;
 	}
 #else
-	write_uint32(pos, MOVZ64(temp1, (static_cast<uint64_t>(fct_ptr)) & 0xffff,
+	write_uint32(pos, MOVZ64(temp1, (reinterpret_cast<uint64_t>(fct_ptr)) & 0xffff,
 	                         0)); // movz temp1, #(fct_ptr & 0xffff)
 	write_uint32(pos + 4,
-	             MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 16) & 0xffff,
+	             MOVK64(temp1, ((reinterpret_cast<uint64_t>(fct_ptr)) >> 16) & 0xffff,
 	                    16)); // movk temp1, #((fct_ptr >> 16) & 0xffff),
 	                          // lsl #16
 	write_uint32(pos + 8,
-	             MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 32) & 0xffff,
+	             MOVK64(temp1, ((reinterpret_cast<uint64_t>(fct_ptr)) >> 32) & 0xffff,
 	                    32)); // movk temp1, #((fct_ptr >> 32) & 0xffff),
 	                          // lsl #32
 	write_uint32(pos + 12,
-	             MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 48) & 0xffff,
+	             MOVK64(temp1, ((reinterpret_cast<uint64_t>(fct_ptr)) >> 48) & 0xffff,
 	                    48)); // movk temp1, #((fct_ptr >> 48) & 0xffff),
 	                          // lsl #48
 #endif

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -24,7 +24,7 @@
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling
 
-// protect FC_ADDR over function calls if necessaray
+// protect FC_ADDR over function calls if necessary
 // #define DRC_PROTECT_ADDR_REG
 
 // try to use non-flags generating functions if possible
@@ -924,214 +924,253 @@ static void gen_return_function(void) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
+{
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ADD_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// add FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_ORb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ADD_REG_LSL_IMM(FC_RETOP, HOST_w0,
+		                                              HOST_w1, 0)); // add FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_ORb:
 		case t_ORw:
 		case t_ORd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ORR_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// orr FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_ANDb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ORR_REG_LSL_IMM(FC_RETOP, HOST_w0,
+		                                              HOST_w1, 0)); // orr FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=AND_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// and FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SUBb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, AND_REG_LSL_IMM(FC_RETOP, HOST_w0,
+		                                              HOST_w1, 0)); // and FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=SUB_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// sub FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_XORb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, SUB_REG_LSL_IMM(FC_RETOP, HOST_w0,
+		                                              HOST_w1, 0)); // sub FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_XORb:
 		case t_XORw:
 		case t_XORd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=EOR_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// eor FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_CMPb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, EOR_REG_LSL_IMM(FC_RETOP, HOST_w0,
+		                                              HOST_w1, 0)); // eor FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_CMPb:
 		case t_CMPw:
 		case t_CMPd:
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=NOP;				// nop
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_INCb:
+		        write_uint32(pos, NOP);      // nop
+		        write_uint32(pos + 4, NOP);  // nop
+		        write_uint32(pos + 8, NOP);  // nop
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ADD_IMM(FC_RETOP, HOST_w0, 1, 0);	// add FC_RETOP, w0, #1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_DECb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ADD_IMM(FC_RETOP, HOST_w0, 1, 0)); // add FC_RETOP, w0, #1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=SUB_IMM(FC_RETOP, HOST_w0, 1, 0);	// sub FC_RETOP, w0, #1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SHLb:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, SUB_IMM(FC_RETOP, HOST_w0, 1, 0)); // sub FC_RETOP, w0, #1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SHLb:
 		case t_SHLw:
 		case t_SHLd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=LSLV(FC_RETOP, HOST_w0, HOST_w1);	// lslv FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SHRb:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=UXTB(FC_RETOP, HOST_w0);				// uxtb FC_RETOP, w0
-			*(Bit32u*)(pos+8)=NOP;				// nop
-			*(Bit32u*)(pos+12)=LSRV(FC_RETOP, FC_RETOP, HOST_w1);	// lsrv FC_RETOP, FC_RETOP, w1
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SHRw:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=UXTH(FC_RETOP, HOST_w0);				// uxth FC_RETOP, w0
-			*(Bit32u*)(pos+8)=NOP;				// nop
-			*(Bit32u*)(pos+12)=LSRV(FC_RETOP, FC_RETOP, HOST_w1);	// lsrv FC_RETOP, FC_RETOP, w1
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SHRd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=LSRV(FC_RETOP, HOST_w0, HOST_w1);	// lsrv FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SARb:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=SXTB(FC_RETOP, HOST_w0);				// sxtb FC_RETOP, w0
-			*(Bit32u*)(pos+8)=NOP;				// nop
-			*(Bit32u*)(pos+12)=ASRV(FC_RETOP, FC_RETOP, HOST_w1);	// asrv FC_RETOP, FC_RETOP, w1
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SARw:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=SXTH(FC_RETOP, HOST_w0);				// sxth FC_RETOP, w0
-			*(Bit32u*)(pos+8)=NOP;				// nop
-			*(Bit32u*)(pos+12)=ASRV(FC_RETOP, FC_RETOP, HOST_w1);	// asrv FC_RETOP, FC_RETOP, w1
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_SARd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=ASRV(FC_RETOP, HOST_w0, HOST_w1);	// asrv FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
-			break;
-		case t_RORb:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=BFI(HOST_w0, HOST_w0, 8, 8);			// bfi w0, w0, 8, 8
-			*(Bit32u*)(pos+8)=BFI(HOST_w0, HOST_w0, 16, 16);		// bfi w0, w0, 16, 16
-			*(Bit32u*)(pos+12)=RORV(FC_RETOP, HOST_w0, HOST_w1);	// rorv FC_RETOP, w0, w1
-			*(Bit32u*)(pos+16)=NOP;				// nop
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, LSLV(FC_RETOP, HOST_w0, HOST_w1)); // lslv FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SHRb:
+		        write_uint32(pos, NOP);                         // nop
+		        write_uint32(pos + 4, UXTB(FC_RETOP, HOST_w0)); // uxtb
+		                                                        // FC_RETOP,
+		                                                        // w0
+		        write_uint32(pos + 8, NOP); // nop
+		        write_uint32(pos + 12,
+		                     LSRV(FC_RETOP, FC_RETOP, HOST_w1)); // lsrv
+		                                                         // FC_RETOP,
+		                                                         // FC_RETOP,
+		                                                         // w1
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SHRw:
+		        write_uint32(pos, NOP);                         // nop
+		        write_uint32(pos + 4, UXTH(FC_RETOP, HOST_w0)); // uxth
+		                                                        // FC_RETOP,
+		                                                        // w0
+		        write_uint32(pos + 8, NOP); // nop
+		        write_uint32(pos + 12,
+		                     LSRV(FC_RETOP, FC_RETOP, HOST_w1)); // lsrv
+		                                                         // FC_RETOP,
+		                                                         // FC_RETOP,
+		                                                         // w1
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SHRd:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, LSRV(FC_RETOP, HOST_w0, HOST_w1)); // lsrv FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SARb:
+		        write_uint32(pos, NOP);                         // nop
+		        write_uint32(pos + 4, SXTB(FC_RETOP, HOST_w0)); // sxtb
+		                                                        // FC_RETOP,
+		                                                        // w0
+		        write_uint32(pos + 8, NOP); // nop
+		        write_uint32(pos + 12,
+		                     ASRV(FC_RETOP, FC_RETOP, HOST_w1)); // asrv
+		                                                         // FC_RETOP,
+		                                                         // FC_RETOP,
+		                                                         // w1
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SARw:
+		        write_uint32(pos, NOP);                         // nop
+		        write_uint32(pos + 4, SXTH(FC_RETOP, HOST_w0)); // sxth
+		                                                        // FC_RETOP,
+		                                                        // w0
+		        write_uint32(pos + 8, NOP); // nop
+		        write_uint32(pos + 12,
+		                     ASRV(FC_RETOP, FC_RETOP, HOST_w1)); // asrv
+		                                                         // FC_RETOP,
+		                                                         // FC_RETOP,
+		                                                         // w1
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_SARd:
+		        write_uint32(pos, NOP);     // nop
+		        write_uint32(pos + 4, NOP); // nop
+		        write_uint32(pos + 8, ASRV(FC_RETOP, HOST_w0, HOST_w1)); // asrv FC_RETOP, w0, w1
+		        write_uint32(pos + 12, NOP); // nop
+		        write_uint32(pos + 16, NOP); // nop
+		        break;
+	        case t_RORb:
+		        write_uint32(pos, NOP); // nop
+		        write_uint32(pos + 4, BFI(HOST_w0, HOST_w0, 8, 8);			// bfi w0, w0, 8, 8
+			write_uint32(pos + 8, BFI(HOST_w0, HOST_w0, 16, 16);		// bfi w0, w0, 16, 16
+			write_uint32(pos + 12, RORV(FC_RETOP, HOST_w0, HOST_w1));	// rorv FC_RETOP, w0, w1
+			write_uint32(pos + 16, NOP);				// nop
 			break;
 		case t_RORw:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=BFI(HOST_w0, HOST_w0, 16, 16);		// bfi w0, w0, 16, 16
-			*(Bit32u*)(pos+8)=NOP;				// nop
-			*(Bit32u*)(pos+12)=RORV(FC_RETOP, HOST_w0, HOST_w1);	// rorv FC_RETOP, w0, w1
-			*(Bit32u*)(pos+16)=NOP;				// nop
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, BFI(HOST_w0, HOST_w0, 16, 16);		// bfi w0, w0, 16, 16
+			write_uint32(pos + 8, NOP);				// nop
+			write_uint32(pos + 12, RORV(FC_RETOP, HOST_w0, HOST_w1));	// rorv FC_RETOP, w0, w1
+			write_uint32(pos + 16, NOP);				// nop
 			break;
 		case t_RORd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=RORV(FC_RETOP, HOST_w0, HOST_w1);	// rorv FC_RETOP, w0, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, RORV(FC_RETOP, HOST_w0, HOST_w1));	// rorv FC_RETOP, w0, w1
+			write_uint32(pos + 12, NOP);				// nop
+			write_uint32(pos + 16, NOP);				// nop
 			break;
 		case t_ROLb:
-			*(Bit32u*)pos=MOVZ(HOST_w2, 32, 0);									// movz w2, #32
-			*(Bit32u*)(pos+4)=BFI(HOST_w0, HOST_w0, 8, 8);						// bfi w0, w0, 8, 8
-			*(Bit32u*)(pos+8)=SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0);	// sub w2, w2, w1
-			*(Bit32u*)(pos+12)=BFI(HOST_w0, HOST_w0, 16, 16);					// bfi w0, w0, 16, 16
-			*(Bit32u*)(pos+16)=RORV(FC_RETOP, HOST_w0, HOST_w2);				// rorv FC_RETOP, w0, w2
+			write_uint32(pos, MOVZ(HOST_w2, 32, 0));									// movz w2, #32
+			write_uint32(pos + 4, BFI(HOST_w0, HOST_w0, 8, 8));						// bfi w0, w0, 8, 8
+			write_uint32(pos + 8, SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0));	// sub w2, w2, w1
+			write_uint32(pos + 12, BFI(HOST_w0, HOST_w0, 16, 16));					// bfi w0, w0, 16, 16
+			write_uint32(pos + 16, RORV(FC_RETOP, HOST_w0, HOST_w2));				// rorv FC_RETOP, w0, w2
 			break;
 		case t_ROLw:
-			*(Bit32u*)pos=MOVZ(HOST_w2, 32, 0);									// movz w2, #32
-			*(Bit32u*)(pos+4)=BFI(HOST_w0, HOST_w0, 16, 16);					// bfi w0, w0, 16, 16
-			*(Bit32u*)(pos+8)=SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0);	// sub w2, w2, w1
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=RORV(FC_RETOP, HOST_w0, HOST_w2);				// rorv FC_RETOP, w0, w2
+			write_uint32(pos, MOVZ(HOST_w2, 32, 0));									// movz w2, #32
+			write_uint32(pos + 4, BFI(HOST_w0, HOST_w0, 16, 16));					// bfi w0, w0, 16, 16
+			write_uint32(pos + 8, SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0));	// sub w2, w2, w1
+			write_uint32(pos + 12, NOP);				// nop
+			write_uint32(pos + 16, RORV(FC_RETOP, HOST_w0, HOST_w2));				// rorv FC_RETOP, w0, w2
 			break;
 		case t_ROLd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=MOVZ(HOST_w2, 32, 0);								// movz w2, #32
-			*(Bit32u*)(pos+8)=SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0);	// sub w2, w2, w1
-			*(Bit32u*)(pos+12)=RORV(FC_RETOP, HOST_w0, HOST_w2);				// rorv FC_RETOP, w0, w2
-			*(Bit32u*)(pos+16)=NOP;				// nop
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, MOVZ(HOST_w2, 32, 0));								// movz w2, #32
+			write_uint32(pos + 8, SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0));	// sub w2, w2, w1
+			write_uint32(pos + 12, RORV(FC_RETOP, HOST_w0, HOST_w2));				// rorv FC_RETOP, w0, w2
+			write_uint32(pos + 16, NOP);				// nop
 			break;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			*(Bit32u*)pos=NOP;					// nop
-			*(Bit32u*)(pos+4)=NOP;				// nop
-			*(Bit32u*)(pos+8)=SUB_REG_LSL_IMM(FC_RETOP, HOST_wzr, HOST_w0, 0);	// sub FC_RETOP, wzr, w0
-			*(Bit32u*)(pos+12)=NOP;				// nop
-			*(Bit32u*)(pos+16)=NOP;				// nop
+			write_uint32(pos, NOP);					// nop
+			write_uint32(pos + 4, NOP);				// nop
+			write_uint32(pos + 8, SUB_REG_LSL_IMM(FC_RETOP, HOST_wzr, HOST_w0, 0));	// sub FC_RETOP, wzr, w0
+			write_uint32(pos + 12, NOP);				// nop
+			write_uint32(pos + 16, NOP);				// nop
 			break;
 		case t_DSHLd:
-			*(Bit32u*)pos=MOVZ64(HOST_x3, 0x1f, 0);								// movz x3, #0x1f
-			*(Bit32u*)(pos+4)=BFI64(HOST_x1, HOST_x0, 32, 32);					// bfi x1, x0, 32, 32
-			*(Bit32u*)(pos+8)=AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0);	// and x2, x2, x3
-			*(Bit32u*)(pos+12)=LSLV64(FC_RETOP, HOST_x1, HOST_x2);				// lslv FC_RETOP, x1, x2
-			*(Bit32u*)(pos+16)=LSR64_IMM(FC_RETOP, FC_RETOP, 32);				// lsr FC_RETOP, FC_RETOP, #32
+			write_uint32(pos, MOVZ64(HOST_x3, 0x1f, 0));								// movz x3, #0x1f
+			write_uint32(pos + 4, BFI64(HOST_x1, HOST_x0, 32, 32));					// bfi x1, x0, 32, 32
+			write_uint32(pos + 8, AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0));	// and x2, x2, x3
+			write_uint32(pos + 12, LSLV64(FC_RETOP, HOST_x1, HOST_x2));				// lslv FC_RETOP, x1, x2
+			write_uint32(pos + 16, LSR64_IMM(FC_RETOP, FC_RETOP, 32));				// lsr FC_RETOP, FC_RETOP, #32
 			break;
 		case t_DSHRd:
-			*(Bit32u*)pos=MOVZ64(HOST_x3, 0x1f, 0);								// movz x3, #0x1f
-			*(Bit32u*)(pos+4)=BFI64(HOST_x0, HOST_x1, 32, 32);					// bfi x0, x1, 32, 32
-			*(Bit32u*)(pos+8)=AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0);	// and x2, x2, x3
-			*(Bit32u*)(pos+12)=NOP;												// nop
-			*(Bit32u*)(pos+16)=LSRV64(FC_RETOP, HOST_x0, HOST_x2);				// lsrv FC_RETOP, x0, x2
+			write_uint32(pos, MOVZ64(HOST_x3, 0x1f, 0));								// movz x3, #0x1f
+			write_uint32(pos + 4, BFI64(HOST_x0, HOST_x1, 32, 32));					// bfi x0, x1, 32, 32
+			write_uint32(pos + 8, AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0));	// and x2, x2, x3
+			write_uint32(pos + 12, NOP);												// nop
+			write_uint32(pos + 16, LSRV64(FC_RETOP, HOST_x0, HOST_x2));				// lsrv FC_RETOP, x0, x2
 			break;
 		default:
-			*(Bit32u*)pos=MOVZ64(temp1, ((Bit64u)fct_ptr) & 0xffff, 0);                 // movz temp1, #(fct_ptr & 0xffff)
-			*(Bit32u*)(pos+4)=MOVK64(temp1, (((Bit64u)fct_ptr) >> 16) & 0xffff, 16);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-			*(Bit32u*)(pos+8)=MOVK64(temp1, (((Bit64u)fct_ptr) >> 32) & 0xffff, 32);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-			*(Bit32u*)(pos+12)=MOVK64(temp1, (((Bit64u)fct_ptr) >> 48) & 0xffff, 48);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+			write_uint32(pos, MOVZ64(temp1, (static_cast<uint64_t>(fct_ptr)) & 0xffff, 0));                 // movz temp1, #(fct_ptr & 0xffff)
+			write_uint32(pos + 4, MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 16) & 0xffff, 16));    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
+			write_uint32(pos + 8, MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 32) & 0xffff, 32));    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
+			write_uint32(pos + 12, MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 48) & 0xffff, 48));   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
 			break;
-
 	}
 #else
-	*(Bit32u*)pos=MOVZ64(temp1, ((Bit64u)fct_ptr) & 0xffff, 0);                 // movz temp1, #(fct_ptr & 0xffff)
-	*(Bit32u*)(pos+4)=MOVK64(temp1, (((Bit64u)fct_ptr) >> 16) & 0xffff, 16);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-	*(Bit32u*)(pos+8)=MOVK64(temp1, (((Bit64u)fct_ptr) >> 32) & 0xffff, 32);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-	*(Bit32u*)(pos+12)=MOVK64(temp1, (((Bit64u)fct_ptr) >> 48) & 0xffff, 48);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+	write_uint32(pos, MOVZ64(temp1, (static_cast<uint64_t>(fct_ptr)) & 0xffff,
+	                         0)); // movz temp1, #(fct_ptr & 0xffff)
+	write_uint32(pos + 4,
+	             MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 16) & 0xffff,
+	                    16)); // movk temp1, #((fct_ptr >> 16) & 0xffff),
+	                          // lsl #16
+	write_uint32(pos + 8,
+	             MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 32) & 0xffff,
+	                    32)); // movk temp1, #((fct_ptr >> 32) & 0xffff),
+	                          // lsl #32
+	write_uint32(pos + 12,
+	             MOVK64(temp1, ((static_cast<uint64_t>(fct_ptr)) >> 48) & 0xffff,
+	                    48)); // movk temp1, #((fct_ptr >> 48) & 0xffff),
+	                          // lsl #48
 #endif
 }
 #endif

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -570,82 +570,86 @@ static void gen_return_function(void) {
 #ifdef DRC_FLAGS_INVALIDATION
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
+{
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-			*(Bit32u*)pos=0x00851021;					// addu $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00851021); // addu $v0, $a0, $a1
+		        break;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
-			*(Bit32u*)pos=0x00851025;					// or $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00851025); // or $v0, $a0, $a1
+		        break;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-			*(Bit32u*)pos=0x00851024;					// and $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00851024); // and $v0, $a0, $a1
+		        break;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-			*(Bit32u*)pos=0x00851023;					// subu $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00851023); // subu $v0, $a0, $a1
+		        break;
 		case t_XORb:
 		case t_XORw:
 		case t_XORd:
-			*(Bit32u*)pos=0x00851026;					// xor $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00851026); // xor $v0, $a0, $a1
+		        break;
 		case t_CMPb:
 		case t_CMPw:
 		case t_CMPd:
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(Bit32u*)pos=0;							// nop
-			break;
+		        write_uint32(pos, 0); // nop
+		        break;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			*(Bit32u*)pos=0x24820001;					// addiu $v0, $a0, 1
-			break;
+		        write_uint32(pos, 0x24820001); // addiu $v0, $a0, 1
+		        break;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			*(Bit32u*)pos=0x2482ffff;					// addiu $v0, $a0, -1
-			break;
+		        write_uint32(pos, 0x2482ffff); // addiu $v0, $a0, -1
+		        break;
 		case t_SHLb:
 		case t_SHLw:
 		case t_SHLd:
-			*(Bit32u*)pos=0x00a41004;					// sllv $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00a41004); // sllv $v0, $a0, $a1
+		        break;
 		case t_SHRb:
 		case t_SHRw:
 		case t_SHRd:
-			*(Bit32u*)pos=0x00a41006;					// srlv $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00a41006); // srlv $v0, $a0, $a1
+		        break;
 		case t_SARd:
-			*(Bit32u*)pos=0x00a41007;					// srav $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00a41007); // srav $v0, $a0, $a1
+		        break;
 #if (_MIPS_ISA==MIPS32R2) || defined(PSP)
 		case t_RORd:
-			*(Bit32u*)pos=0x00a41046;					// rotr $v0, $a0, $a1
-			break;
+		        write_uint32(pos, 0x00a41046); // rotr $v0, $a0, $a1
+		        break;
 #endif
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			*(Bit32u*)pos=0x00041023;					// subu $v0, $0, $a0
-			break;
+		        write_uint32(pos, 0x00041023); // subu $v0, $0, $a0
+		        break;
 		default:
-			*(Bit32u*)pos=0x0c000000+((((Bit32u)fct_ptr)>>2)&0x3ffffff);		// jal simple_func
-			break;
+		        write_uint32(pos,
+		                     0x0c000000 +
+		                             (((static_cast<uint32_t>(fct_ptr)) >> 2) &
+		                              0x3ffffff)); // jal simple_func
+		        break;
 	}
 #else
-	*(Bit32u*)pos=0x0c000000+(((Bit32u)fct_ptr)>>2)&0x3ffffff);		// jal simple_func
+	write_uint32(pos, 0x0c000000+((static_cast<uint32_t>(fct_ptr)) >> 2) & 0x3ffffff));		// jal simple_func
 #endif
 }
 #endif

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -644,12 +644,12 @@ static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
 		default:
 		        write_uint32(pos,
 		                     0x0c000000 +
-		                             (((static_cast<uint32_t>(fct_ptr)) >> 2) &
+		                             (((reinterpret_cast<uint32_t>(fct_ptr)) >> 2) &
 		                              0x3ffffff)); // jal simple_func
 		        break;
 	}
 #else
-	write_uint32(pos, 0x0c000000+((static_cast<uint32_t>(fct_ptr)) >> 2) & 0x3ffffff));		// jal simple_func
+	write_uint32(pos, 0x0c000000+((reinterpret_cast<uint32_t>(fct_ptr)) >> 2) & 0x3ffffff));		// jal simple_func
 #endif
 }
 #endif

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -629,41 +629,46 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_ADDw:
 		case t_ADDd:
 			// mov eax,FC_OP1; add eax,FC_OP2
-			*(Bit32u*)(pos+0)=0xc001c089+(FC_OP1<<11)+(FC_OP2<<27);
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc001c089 + (FC_OP1 << 11) +
+			                                   (FC_OP2 << 27));
+			write_uint32(pos + 4, 0x909006eb); // skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
 			// mov eax,FC_OP1; or eax,FC_OP2
-			*(Bit32u*)(pos+0)=0xc009c089+(FC_OP1<<11)+(FC_OP2<<27);
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc009c089 + (FC_OP1 << 11) +
+			                                   (FC_OP2 << 27));
+			write_uint32(pos + 4, 0x909006eb); // skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
 			// mov eax,FC_OP1; and eax,FC_OP2
-			*(Bit32u*)(pos+0)=0xc021c089+(FC_OP1<<11)+(FC_OP2<<27);
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc021c089 + (FC_OP1 << 11) +
+			                                   (FC_OP2 << 27));
+			write_uint32(pos + 4, 0x909006eb); // skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
 			// mov eax,FC_OP1; sub eax,FC_OP2
-			*(Bit32u*)(pos+0)=0xc029c089+(FC_OP1<<11)+(FC_OP2<<27);
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc029c089 + (FC_OP1 << 11) +
+			                                   (FC_OP2 << 27));
+			write_uint32(pos + 4, 0x909006eb); // skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
-		case t_XORb:
+	    case t_XORb:
 		case t_XORw:
 		case t_XORd:
 			// mov eax,FC_OP1; xor eax,FC_OP2
-			*(Bit32u*)(pos+0)=0xc031c089+(FC_OP1<<11)+(FC_OP2<<27);
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc031c089 + (FC_OP1 << 11) +
+			                                   (FC_OP2 << 27));
+			write_uint32(pos + 4, 0x909006eb); // skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
 		case t_CMPb:
 		case t_CMPw:
@@ -671,34 +676,35 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(Bit32u*)(pos+0)=0x90900aeb;	// skip
-			*(Bit32u*)(pos+4)=0x90909090;
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0x90900aeb); // skip
+			write_uint32(pos + 4, 0x90909090);
+			write_uint32(pos + 8, 0x90909090);
 			return;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			*(Bit32u*)(pos+0)=0xc0ffc089+(FC_OP1<<11); // mov eax,ecx; inc eax
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc0ffc089+(FC_OP1<<11); // mov eax,ecx; inc eax
+			write_uint32(pos + 4, 0x909006eb;	// skip
+			write_uint32(pos + 8, 0x90909090;
 			return;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			*(Bit32u*)(pos+0)=0xc8ffc089+(FC_OP1<<11); // mov eax, FC_OP1; dec eax
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xc8ffc089+(FC_OP1<<11)); // mov eax, FC_OP1; dec eax
+			write_uint32(pos + 4, 0x909006eb);	// skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			*(Bit32u*)(pos+0)=0xd8f7c089+(FC_OP1<<11); // mov eax, FC_OP1; neg eax
-			*(Bit32u*)(pos+4)=0x909006eb;	// skip
-			*(Bit32u*)(pos+8)=0x90909090;
+			write_uint32(pos + 0, 0xd8f7c089+(FC_OP1<<11)); // mov eax, FC_OP1; neg eax
+			write_uint32(pos + 4, 0x909006eb);	// skip
+			write_uint32(pos + 8, 0x90909090);
 			return;
 	}
 #endif
-	*(Bit64u*)(pos+2)=(Bit64u)fct_ptr;		// fill function pointer
+	write_uint64(pos + 2, static_cast<uint64_t>(fct_ptr)); // fill function
+	                                                       // pointer
 }
 #endif
 

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -703,8 +703,9 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 			return;
 	}
 #endif
-	write_uint64(pos + 2, static_cast<uint64_t>(fct_ptr)); // fill function
-	                                                       // pointer
+	write_uint64(pos + 2, reinterpret_cast<uint64_t>(fct_ptr)); // fill
+	                                                            // function
+	                                                            // pointer
 }
 #endif
 

--- a/src/cpu/core_dynrec/risc_x86.h
+++ b/src/cpu/core_dynrec/risc_x86.h
@@ -440,39 +440,40 @@ static void gen_return_function(void) {
 #ifdef DRC_FLAGS_INVALIDATION
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(uint8_t *pos, void *fct_ptr, Bitu flags_type)
+{
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-			*(Bit32u*)pos=0xc203c18b;	// mov eax,ecx; add eax,edx
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0xc203c18b); // mov eax,ecx; add eax,edx
+		        *(pos+4)=0x90;
 			break;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
-			*(Bit32u*)pos=0xc20bc18b;	// mov eax,ecx; or eax,edx
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0xc20bc18b); // mov eax,ecx; or eax,edx
+		        *(pos+4)=0x90;
 			break;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-			*(Bit32u*)pos=0xc223c18b;	// mov eax,ecx; and eax,edx
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0xc223c18b); // mov eax,ecx; and eax,edx
+		        *(pos+4)=0x90;
 			break;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-			*(Bit32u*)pos=0xc22bc18b;	// mov eax,ecx; sub eax,edx
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0xc22bc18b); // mov eax,ecx; sub eax,edx
+		        *(pos+4)=0x90;
 			break;
 		case t_XORb:
 		case t_XORw:
 		case t_XORd:
-			*(Bit32u*)pos=0xc233c18b;	// mov eax,ecx; xor eax,edx
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0xc233c18b); // mov eax,ecx; xor eax,edx
+		        *(pos+4)=0x90;
 			break;
 		case t_CMPb:
 		case t_CMPw:
@@ -480,33 +481,40 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(Bit32u*)pos=0x909003eb;	// skip
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0x909003eb); // skip
+		        *(pos+4)=0x90;
 			break;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			*(Bit32u*)pos=0x9040c18b;	// mov eax,ecx; inc eax
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0x9040c18b); // mov eax,ecx; inc eax
+		        *(pos+4)=0x90;
 			break;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			*(Bit32u*)pos=0x9048c18b;	// mov eax,ecx; dec eax
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0x9048c18b); // mov eax,ecx; dec eax
+		        *(pos+4)=0x90;
 			break;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			*(Bit32u*)pos=0xd8f7c18b;	// mov eax,ecx; neg eax
-			*(pos+4)=0x90;
+		        write_uint32(pos, 0xd8f7c18b); // mov eax,ecx; neg eax
+		        *(pos+4)=0x90;
 			break;
 		default:
-			*(Bit32u*)(pos+1)=(Bit32u)((Bit8u*)fct_ptr - (pos+1+4));	// fill function pointer
-			break;
+		        write_uint32(pos + 1,
+		                     static_cast<uint32_t>(
+		                             static_cast<uint8_t *>(fct_ptr) -
+		                             (pos + 1 + 4))); // fill function
+		                                              // pointer
+		        break;
 	}
 #else
-	*(Bit32u*)(pos+1)=(Bit32u)((Bit8u*)fct_ptr - (pos+1+4));	// fill function pointer
+	write_uint32(pos + 1, static_cast<uint32_t>(static_cast<uint8_t *>(fct_ptr) -
+	                                            (pos + 1 + 4))); // fill
+	                                                             // function
+	                                                             // pointer
 #endif
 }
 #endif

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -539,16 +539,16 @@ skip_shot:
 				case 15:
 				case 16:
 					for (x = 0; x < countWidth; x++) {
-						const uint16_t pixel = host_readw_at(srcLine, x);
-						host_writew_at(doubleRow, x * 2, pixel);
-						host_writew_at(doubleRow, x * 2 + 1, pixel);
+						const uint16_t pixel = read_uint16_at(srcLine, x);
+						write_uint16_at(doubleRow, x * 2, pixel);
+						write_uint16_at(doubleRow, x * 2 + 1, pixel);
 					}
 					break;
 				case 32:
 					for (x = 0; x < countWidth; x++) {
-						const uint32_t pixel = host_readd_at(srcLine, x);
-						host_writed_at(doubleRow, x * 2, pixel);
-						host_writed_at(doubleRow, x * 2 + 1, pixel);
+						const uint32_t pixel = read_uint32_at(srcLine, x);
+						write_uint32_at(doubleRow, x * 2, pixel);
+						write_uint32_at(doubleRow, x * 2 + 1, pixel);
 					}
 					break;
 				}


### PR DESCRIPTION
In the prior alignment PR, we replaced unaligned reads and writes with the now-aligned `host_*` calls.  The host_* functions make sure that the result is always little-endian, or "DOS-endian", which let us collapse code like:
```
#if BIG_ENDIAN
    host_writew(data, val); 
#else
    *(Bit16u*)data = val;
#endif
```

However for unaligned accesses that don't differentiate between big vs little endian, such as `    *(Bit32u*)data = val`, it turns out we don't need the endian-swapping help of the `host_*` functions, because these values can be read and written in native byte-ordering (even when  on a big-endian host); the prior PR still worked fine on big-endian though because both the reads and writes were being equally swapped..  so the end result was the same number.

So this PR back-tracks on these specific calls where we can use native byte-ordering, and we do this by introducing aligned native `read_uint16`, `write_uint16`, ... functions.

I also clarified the comments on the affected functions in `mem.h`, so it's more obvious when you would use the native vs. host functions. 

This PR also bites off the remaining chunk of platform-specific alignment issues.  For example, the Raspberry Pi's ARM cores (dynrec vs normal) were riddled, as are the MIPS cores. 

All of the commits have gone through the clang-formatter; it really helped tighten up white-space in trailing comments, and did a good job wrapping the longer lines (although this makes side-by-side visual comparison a bit harder). 

For reviewing the 'Revert' commits, I suggest opening side-by-side windows of the prior PR vs. this PR, and going file-by-file. This will let you see the original `*(Bit32u*)data =` type calls, where we now use the native aligned functions.

There are still two alignment issue reported during the build, which involve non-8-bit values.  Because they're not 8-bit, I couldn't mechanically treat these like the rest of the fixes; so will have to be done carefully in a separate PR.

I broke out each platform in separate commits, just to make bisecting (if needed) easier.

In addition to x86, I spent several hours testing on the Pi and PowerPC, and it's running without issues.