### PR TITLE
Add native-aligned memory read and write functions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -61,7 +61,7 @@ jobs:
           steps.repo-meta.outputs.has-commits == 'true'
         with:
           path: 'C:/tools/msys64'
-          key: msys2-64-${{ steps.get-date.outputs.date }}-3
+          key: msys2-64-${{ steps.get-date.outputs.date }}
 
       - name:  Install MSYS2 (Windows)
         if:    >

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,7 +106,7 @@ jobs:
           LD: gcc
           RANLIB: gcc-ranlib
           FLAGS: >-
-            -O3 -fno-signed-zeros -fno-trapping-math -fassociative-math 
+            -O3 -fno-signed-zeros -fno-trapping-math -fassociative-math
             -mfpmath=sse -msse4.2 -flto -ffunction-sections -fdata-sections
             -DNDEBUG -pipe
           LINKFLAGS: -Wl,--as-needed

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,9 +106,9 @@ jobs:
           LD: gcc
           RANLIB: gcc-ranlib
           FLAGS: >-
-            -O3 -fstrict-aliasing -fno-signed-zeros -fno-trapping-math
-            -fassociative-math -mfpmath=sse -msse4.2 -flto -ffunction-sections
-            -fdata-sections -DNDEBUG -pipe
+            -O3 -fno-signed-zeros -fno-trapping-math -fassociative-math 
+            -mfpmath=sse -msse4.2 -flto -ffunction-sections -fdata-sections
+            -DNDEBUG -pipe
           LINKFLAGS: -Wl,--as-needed
         run: |
           set -x

--- a/include/mem.h
+++ b/include/mem.h
@@ -56,7 +56,7 @@ MemHandle MEM_NextHandle(MemHandle handle);
 MemHandle MEM_NextHandleAt(MemHandle handle,Bitu where);
 
 // Read and write single-byte values
-static INLINE uint8_t host_readb(const uint8_t *var)
+constexpr uint8_t host_readb(const uint8_t *var)
 {
 	return *var;
 }

--- a/include/mem.h
+++ b/include/mem.h
@@ -76,6 +76,15 @@ static INLINE uint16_t read_uint16(const uint8_t *arr)
 	return val;
 }
 
+/*  Read a uint16 from 8-bit DOS/little-endian byte-ordered memory.
+ *  Use this instead of endian branching and byte swapping, such as:
+ *  #if BIG_ENDIAN byteswap(*(uint16_t*)(arr)) #else *(uint16_t*)(arr) 
+ */
+static INLINE uint16_t host_readw(const uint8_t *arr)
+{
+	return le16_to_host(read_uint16(arr));
+}
+
 /*  Read an array-indexed uint16 from 8-bit native byte-ordered memory.
  *  Use this instead of ((uint16_t*)arr)[index]
  */
@@ -83,6 +92,11 @@ static INLINE uint16_t read_uint16_at(const uint8_t *arr, const uintptr_t index)
 {
 	return read_uint16(arr + index * sizeof(uint16_t));
 }
+
+/*  Read an array-indexed uint16 from 8-bit DOS/little-endian byte-ordered
+ *  memory. Use this instead of endian branching and byte swapping, such as:
+ *  #if BIG_ENDIAN byteswap(((uint16_t*)arr)[i]) #else ((uint16_t*)arr)[i]
+ */
 static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
 {
 	return host_readw(arr + index * sizeof(uint16_t));
@@ -94,12 +108,19 @@ static INLINE void write_uint16(uint8_t *arr, uint16_t val)
 	memcpy(arr, &val, sizeof(val));
 }
 
+// Write a uint16 to 8-bit memory using DOS/little-endian byte-ordering.
+static INLINE void host_writew(uint8_t *arr, uint16_t val)
+{
+	write_uint16(arr, host_to_le16(val));
+}
 
 // Write an array-indexed uint16 to 8-bit memory using native byte-ordering.
 static INLINE void write_uint16_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
 {
 	write_uint16(arr + index * sizeof(uint16_t), val);
 }
+
+// Write an array-indexed uint16 to 8-bit memory using DOS/little-endian byte-ordering.
 static INLINE void host_writew_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
 {
 	host_writew(arr + index * sizeof(uint16_t), val);
@@ -111,18 +132,33 @@ static INLINE void incr_uint16(uint8_t *arr, const uint16_t incr)
 	write_uint16(arr, read_uint16(arr) + incr);
 }
 
-// Read, write, and add using 32-bit double-words
-static INLINE uint32_t host_readd(const uint8_t *arr)
+// Increment a uint16 value held in 8-bit DOS/little-endian byte-ordered memory.
+static INLINE void host_incrw(uint8_t *arr, const uint16_t incr)
+{
+	host_writew(arr, host_readw(arr) + incr);
+}
+
+// Read a uint32 from 8-bit native byte-ordered memory.
+static INLINE uint32_t read_uint32(const uint8_t *arr)
 {
 	uint32_t val;
 	memcpy(&val, arr, sizeof(val));
+	return val;
+}
+
+// Read a uint32 from 8-bit DOS/little-endian byte-ordered memory.
+static INLINE uint32_t host_readd(const uint8_t *arr)
+{
+	return le32_to_host(read_uint32(arr));
+}
+
 // Read an array-indexed uint32 from 8-bit native byte-ordered memory.
 static INLINE uint32_t read_uint32_at(const uint8_t *arr, const uintptr_t index)
 {
 	return read_uint32(arr + index * sizeof(uint32_t));
 }
 
-// Like the above, but allows index-style access assuming a 32-bit array
+// Read an array-indexed uint16 from 8-bit DOS/little-endian byte-ordered memory. 
 static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
 {
 	return host_readd(arr + index * sizeof(uint32_t));
@@ -133,13 +169,20 @@ static INLINE void write_uint32(uint8_t *arr, uint32_t val)
 {
 	memcpy(arr, &val, sizeof(val));
 }
+
+// Write a uint32 to 8-bit memory using DOS/little-endian byte-ordering.
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le32(val);
-	memcpy(arr, &val, sizeof(val));
+	write_uint32(arr, host_to_le32(val));
 }
 
+// Write an array-indexed uint32 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint32_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
+{
+	write_uint32(arr + index * sizeof(uint32_t), val);
+}
+
+// Write an array-indexed uint32 to 8-bit memory using DOS/little-endian byte-ordering.
 static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
 {
 	host_writed(arr + index * sizeof(uint32_t), val);
@@ -150,9 +193,11 @@ static INLINE void incr_uint32(uint8_t *arr, const uint32_t incr)
 {
 	write_uint32(arr, read_uint32(arr) + incr);
 }
+
+// Increment a uint32 value held in 8-bit DOS/little-endian byte-ordered memory.
+static INLINE void host_incrd(uint8_t *arr, const uint32_t incr)
 {
-	const uint32_t val = host_readd(arr) + incr;
-	host_writed(arr, val);
+	host_writed(arr, host_readd(arr) + incr);
 }
 
 // Read a uint64 from 8-bit native byte-ordered memory.

--- a/include/mem.h
+++ b/include/mem.h
@@ -66,37 +66,49 @@ static INLINE void host_writeb(uint8_t *var, const uint8_t val)
 	*var = val;
 }
 
-// Read, write, and add using 16-bit words
-static INLINE uint16_t host_readw(const uint8_t *arr)
+/*  Read a uint16 from 8-bit native byte-ordered memory. Use this
+ *  instead of *(uint16_t*)(8_bit_ptr) or *(uint16_t*)(8_bit_ptr + offset)
+ */
+static INLINE uint16_t read_uint16(const uint8_t *arr)
 {
 	uint16_t val;
 	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le16_to_host(val);
+	return val;
 }
 
-// Like the above, but allows index-style access assuming a 16-bit array
+/*  Read an array-indexed uint16 from 8-bit native byte-ordered memory.
+ *  Use this instead of ((uint16_t*)arr)[index]
+ */
+static INLINE uint16_t read_uint16_at(const uint8_t *arr, const uintptr_t index)
+{
+	return read_uint16(arr + index * sizeof(uint16_t));
+}
 static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
 {
 	return host_readw(arr + index * sizeof(uint16_t));
 }
 
-static INLINE void host_writew(uint8_t *arr, uint16_t val)
+// Write a uint16 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint16(uint8_t *arr, uint16_t val)
 {
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le16(val);
 	memcpy(arr, &val, sizeof(val));
 }
 
+
+// Write an array-indexed uint16 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint16_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
+{
+	write_uint16(arr + index * sizeof(uint16_t), val);
+}
 static INLINE void host_writew_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
 {
 	host_writew(arr + index * sizeof(uint16_t), val);
 }
 
-static INLINE void host_addw(uint8_t *arr, const uint16_t incr)
+// Increment a uint16 value held in 8-bit native byte-ordered memory.
+static INLINE void incr_uint16(uint8_t *arr, const uint16_t incr)
 {
-	const uint16_t val = host_readw(arr) + incr;
-	host_writew(arr, val);
+	write_uint16(arr, read_uint16(arr) + incr);
 }
 
 // Read, write, and add using 32-bit double-words
@@ -104,8 +116,10 @@ static INLINE uint32_t host_readd(const uint8_t *arr)
 {
 	uint32_t val;
 	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le32_to_host(val);
+// Read an array-indexed uint32 from 8-bit native byte-ordered memory.
+static INLINE uint32_t read_uint32_at(const uint8_t *arr, const uintptr_t index)
+{
+	return read_uint32(arr + index * sizeof(uint32_t));
 }
 
 // Like the above, but allows index-style access assuming a 32-bit array
@@ -114,6 +128,11 @@ static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
 	return host_readd(arr + index * sizeof(uint32_t));
 }
 
+// Write a uint32 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint32(uint8_t *arr, uint32_t val)
+{
+	memcpy(arr, &val, sizeof(val));
+}
 static INLINE void host_writed(uint8_t *arr, uint32_t val)
 {
 	// Convert the host-type value to little-endian before filling array
@@ -126,25 +145,27 @@ static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uin
 	host_writed(arr + index * sizeof(uint32_t), val);
 }
 
-static INLINE void host_addd(uint8_t *arr, const uint32_t incr)
+// Increment a uint32 value held in 8-bit native byte-ordered memory.
+static INLINE void incr_uint32(uint8_t *arr, const uint32_t incr)
+{
+	write_uint32(arr, read_uint32(arr) + incr);
+}
 {
 	const uint32_t val = host_readd(arr) + incr;
 	host_writed(arr, val);
 }
 
-// Read and write using 64-bit quad-words
-static INLINE uint64_t host_readq(const uint8_t *arr)
+// Read a uint64 from 8-bit native byte-ordered memory.
+static INLINE uint64_t read_uint64(const uint8_t *arr)
 {
 	uint64_t val;
 	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le64_to_host(val);
+	return val;
 }
 
-static INLINE void host_writeq(uint8_t *arr, uint64_t val)
+// Write a uint64 to 8-bit memory using native byte-ordering.
+static INLINE void write_uint64(uint8_t *arr, uint64_t val)
 {
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le64(val);
 	memcpy(arr, &val, sizeof(val));
 }
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -200,6 +200,10 @@ static INLINE void host_incrd(uint8_t *arr, const uint32_t incr)
 	host_writed(arr, host_readd(arr) + incr);
 }
 
+// (Temporary, to-be-removed in next PRs when code moves to incr_* functions)
+static INLINE void host_addw(uint8_t *arr, const uint16_t incr){ host_incrw(arr, incr); }
+static INLINE void host_addd(uint8_t *arr, const uint32_t incr){ host_incrd(arr, incr); }
+
 // Read a uint64 from 8-bit native byte-ordered memory.
 static INLINE uint64_t read_uint64(const uint8_t *arr)
 {
@@ -213,6 +217,10 @@ static INLINE void write_uint64(uint8_t *arr, uint64_t val)
 {
 	memcpy(arr, &val, sizeof(val));
 }
+
+// (Temporary, to-be-removed in next PRs when code moves to read/write_* functions)
+static INLINE uint64_t host_readq(uint8_t *arr){ return le64_to_host(read_uint64(arr)); }
+static INLINE void host_writeq(uint8_t *arr, uint64_t val){ write_uint64(arr, host_to_le64(val)); }
 
 static INLINE void var_write(uint8_t *var, uint8_t val)
 {

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -11,8 +11,7 @@ fi
 TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 
 # Note: no-math-errno improves optimization of C/C++ math functions
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno
-                 -fno-strict-aliasing)
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing)
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 
 cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused

--- a/scripts/automator/build/compiler-defaults
+++ b/scripts/automator/build/compiler-defaults
@@ -5,7 +5,7 @@ cc=""
 cxx=""
 ld=""
 ranlib=""
-cflags+=(-Wall -pipe)
+cflags+=(-Wall -Wstrict-aliasing=2 -pipe)
 cxxonly+=("")
 ldflags+=("")
 libs+=("")

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -15,7 +15,7 @@ cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 # Note: associative-math is needed for vectorization of floating point
 #       calculations, which also relies on no-signed-zeros and
 #       no-trapping-math.
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -frename-registers
                  -fno-signed-zeros -fno-trapping-math -fassociative-math
                  -frename-registers -ffunction-sections -fdata-sections)
 

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -17,7 +17,7 @@ cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 #       no-trapping-math.
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -frename-registers
                  -fno-signed-zeros -fno-trapping-math -fassociative-math
-                 -frename-registers -ffunction-sections -fdata-sections)
+                 -ffunction-sections -fdata-sections -fno-stack-protector)
 
 cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                   -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -22,7 +22,7 @@ cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -frename-registers
 cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                   -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2
                   -Wlogical-op -Wmisleading-indentation -Wnull-dereference
-                  -Wshadow -Wunused -fstrict-aliasing -Wstrict-aliasing=2)
+                  -Wshadow -Wunused)
 cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual
                    -Wuseless-cast)
 


### PR DESCRIPTION
Also improves comments on the `host_*` functions and cleans up the alignment flags in CI and build script (strict-aliasing is assumed for optimized builds under gcc, but not assumed under Clang).

Test results comparing original DOSBox memory access methods (which rely on undefined behavior), vs aligned and swapping `host_*`, vs aligned native `read_*` and `write_*` to follow.