### PR TITLE
Only initialize the joystick subsystem if configured

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3151,13 +3151,6 @@ int main(int argc, char* argv[]) {
 	// Once initialized, ensure we clean up SDL for all exit conditions
 	atexit(SDL_Quit);
 
-#ifndef DISABLE_JOYSTICK
-	//Initialise Joystick separately. This way we can warn when it fails instead
-	//of exiting the application
-	if( SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0 )
-		LOG_MSG("Failed to init joystick support");
-#endif
-
 	sdl.laltstate = SDL_KEYUP;
 	sdl.raltstate = SDL_KEYUP;
 


### PR DESCRIPTION
Draft, pending feedback from @granminigun.

Appears that baseline DOSBox always (silently) initializes SDL's joystick subsystem even if `joysticktype=none`, unless DISABLE_JOYSTICK is defined; however there's no `./configure` option that defines this - so it appears to be a manual hack.  Also, SDL itself doesn't recognize this define, so SDL will always include the joystick subsystem regardless. 

I've knocked that out, and now we only initialize SDL's joystick subsystem (and from there populate the mapper) if requested.

Fixes #294. 