### PR TITLE
Virus-scan Linux and macOS releases

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,7 +91,6 @@ jobs:
           set -x
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
-          git fetch --depth 1
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION
       - name: Build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,6 +91,7 @@ jobs:
           set -x
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
+          git fetch --depth 1
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION
       - name: Build
@@ -142,6 +143,13 @@ jobs:
           # Create tarball
           tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
 
+      - name: AV scan
+        run: |
+          set -x
+          sudo apt-get install clamav > /dev/null
+          sudo systemctl stop clamav-freshclam
+          sudo freshclam --quiet && sudo freshclam
+          clamscan --heuristic-scan-precedence=yes --recursive --infected .
       - name: Upload tarball
         uses: actions/upload-artifact@master
         # GitHub automatically zips the artifacts (there's no way to create

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -144,6 +144,15 @@ jobs:
               -srcfolder dist \
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
 
+      - name: AV scan
+        run: |
+          set -x
+          brew install clamav > /dev/null
+          clamconf=/usr/local/etc/clamav/freshclam.conf
+          mv -f "$clamconf".sample "$clamconf"
+          sed -ie 's/^Example/#Example/g' "$clamconf"
+          freshclam --quiet && freshclam
+          clamscan --heuristic-scan-precedence=yes --recursive --infected .
       - name: Upload disk image
         uses: actions/upload-artifact@master
         # GitHub automatically zips the artifacts, and there's no option


### PR DESCRIPTION
This scans the repo and all as-built assets (including the tarball) just prior to uploading the Linux and macOS release packages.

(Background comment) originally I had this in the `analysis.yml` workflow; but that only got us part of the way; what if our build system pulls in threats or puts together a trojan from benign smaller pieces that previously passed the scan.  The safest approach is to not trust any build steps, and thus scan the very end results.  So I moved it just before the package is uploaded.
(ClamAV also scans inside compressed archives, so we have full coverage).