### PR TITLE
Use more robust method to get the scripts directory

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -139,5 +139,6 @@ function parse_args() {
 	selected_type=$(lower "${selected_type}")
 }
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=scripts/automator/main.sh
-source "$(dirname "$0")/automator/main.sh"
+source "$script_dir/automator/main.sh"

--- a/scripts/list-build-dependencies.sh
+++ b/scripts/list-build-dependencies.sh
@@ -53,5 +53,6 @@ function parse_args() {
 # shellcheck disable=SC2034
 data_dir="packages"
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=scripts/automator/main.sh
-source "$(dirname "$0")/automator/main.sh"
+source "$script_dir/automator/main.sh"


### PR DESCRIPTION
A new issues/feature causing early failure in MSYS2 CI runs appears due to $(dirname $0) evaluating to the empty string.  So this PR uses a more tried-and-true mechanism to discover the script's parent directory (without relying on 'git', which is not yet in PATH at this point in the bash script sequence on the CI systems).

![Screenshot at 2020-04-21 16-42-48](https://user-images.githubusercontent.com/1557255/79925571-8cbf6f80-83ef-11ea-8ba9-6ab58f7f5e54.png)
 