### PR TITLE
Move to GitHub's v2 checkout API

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Run shellcheck
         run:  ./scripts/verify-bash.sh
@@ -38,9 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: run_linters
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install python3-setuptools $(./scripts/list-build-dependencies.sh -m apt -c gcc)
@@ -106,9 +102,7 @@ jobs:
             tsan:  0  # our test does not trigger multiple threads yet
             uasan: 36
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         env:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -40,10 +40,7 @@ jobs:
     env:
       CHERE_INVOKING: yes
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-
+      - uses: actions/checkout@v2
       - name: Check repo for commits
         id:   repo-meta
         shell: bash

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,7 +18,7 @@ jobs:
     name: Coverity static analyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Log environment
         run:  ./scripts/log-env.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,9 +32,7 @@ jobs:
             flags: -c clang -v 8
             max_warnings: 38
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt ${{ matrix.conf.flags }})
@@ -67,7 +65,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install -y tree libpng-dev librsvg2-bin $(./scripts/list-build-dependencies.sh -m apt -c gcc)
@@ -91,6 +89,7 @@ jobs:
       - name: Inject version string
         run: |
           set -x
+          git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,9 +22,7 @@ jobs:
             flags: -c gcc -v 9
             max_warnings: 58
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries
         run:  brew install $(./scripts/list-build-dependencies.sh -m brew ${{ matrix.conf.flags}})
       - name:  Prepare compiler cache
@@ -60,7 +58,7 @@ jobs:
       CXX: ccache clang++
       FLAGS: -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing -march=nehalem -flto=thin -pipe
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries
         run:  brew install librsvg $(./scripts/list-build-dependencies.sh -m brew -c clang)
       - name:  Prepare compiler cache
@@ -90,6 +88,7 @@ jobs:
       - name: Inject version string
         run: |
           set -x
+          git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=5)
           sed -i -e "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -14,9 +14,7 @@ jobs:
     env:
       debfile: pvs-studio-7.07.37949.43-amd64.deb
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
       - run:  sudo apt-get update
       - name: Log and setup environment
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,9 +36,7 @@ jobs:
       CCACHE_MAXSIZE:  "64M"
       CCACHE_COMPRESS: "true"
     steps:
-      - uses:  actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses:  actions/checkout@v2
       - name:  Get Date
         id:    get-date
         shell: bash
@@ -98,9 +96,7 @@ jobs:
       matrix:
         type: [Debug]
     steps:
-      - uses:  actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses:  actions/checkout@v2
       - name:  Install packages
         shell: pwsh
         run: |
@@ -122,7 +118,7 @@ jobs:
     runs-on: windows-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
     steps:
-      - uses:  actions/checkout@v1
+      - uses:  actions/checkout@v2
       - name:  Install packages
         shell: pwsh
         run: |
@@ -135,6 +131,7 @@ jobs:
         shell: bash
         run: |
           set -x
+          git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
           sed -i "s|VERSION \"git\"|VERSION \"$VERSION\"|" src/platform/visualc/config.h
           echo ::set-env name=VERSION::$VERSION


### PR DESCRIPTION
v2 will:
- Checkout over SSH
- use Git's REST API, when git is version 2.18 or newer
- No longer detaches HEAD when checking out a branch
- Fetches one-commit deep by default

When building releases where we expect full history plus tags, we explicitly get them with `git fetch --prune --unshallow`.

Significantly cleans and organizes the _Action_ GUI output into expandable "chapters", with a tidy commit log presented:

![Screenshot at 2020-04-22 12-09-53](https://user-images.githubusercontent.com/1557255/80023462-6a326280-8492-11ea-8f94-cdadc239141c.png)

