### PR TITLE
convert existing shaders to C++11 raw string syntax

### DIFF
--- a/src/gui/render_glsl.h
+++ b/src/gui/render_glsl.h
@@ -18,559 +18,569 @@
 
 #if C_OPENGL
 
-static const char advinterp2x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform sampler2D rubyTexture;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-""
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-""
-"vec3 getadvinterp2xtexel(vec2 coord) {\n"
-"	vec2 base = floor(coord/vec2(2.0))+vec2(0.5);\n"
-"	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;\n"
-"	vec3 c1 = texture2D(rubyTexture, (base-vec2(0.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c7 = texture2D(rubyTexture, (base+vec2(0.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c3 = texture2D(rubyTexture, (base-vec2(1.0,0.0))/rubyTextureSize).xyz;\n"
-"	vec3 c5 = texture2D(rubyTexture, (base+vec2(1.0,0.0))/rubyTextureSize).xyz;\n"
-""
-"	bool outer = c1 != c7 && c3 != c5;\n"
-"	bool c3c1 = outer && c3==c1;\n"
-"	bool c1c5 = outer && c1==c5;\n"
-"	bool c3c7 = outer && c3==c7;\n"
-"	bool c7c5 = outer && c7==c5;\n"
-""
-"	vec3 l00 = mix(c3,c4,c3c1?3.0/8.0:1.0);\n"
-"	vec3 l01 = mix(c5,c4,c1c5?3.0/8.0:1.0);\n"
-"	vec3 l10 = mix(c3,c4,c3c7?3.0/8.0:1.0);\n"
-"	vec3 l11 = mix(c5,c4,c7c5?3.0/8.0:1.0);\n"
-""
-"	coord = max(floor(mod(coord, 2.0)), 0.0);\n"
-"	/* 2x2 output:\n"
-"	 *    |x=0|x=1\n"
-"	 * y=0|l00|l01\n"
-"	 * y=1|l10|l11\n"
-"	 */\n"
-""
-"	return mix(mix(l00,l01,coord.x), mix(l10,l11,coord.x), coord.y);\n"
-"}\n"
-""
-"void main()\n"
-"{\n"
-"	vec2 coord = v_texCoord;\n"
-"#if defined(OPENGLNB)\n"
-"	gl_FragColor = getadvinterp2xtexel(coord);\n"
-"#else\n"
-"	coord -= 0.5;\n"
-"	vec3 c0 = getadvinterp2xtexel(coord);\n"
-"	vec3 c1 = getadvinterp2xtexel(coord+vec2(1.0,0.0));\n"
-"	vec3 c2 = getadvinterp2xtexel(coord+vec2(0.0,1.0));\n"
-"	vec3 c3 = getadvinterp2xtexel(coord+vec2(1.0));\n"
-""
-"	coord = fract(max(coord,0.0));\n"
-"	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);\n"
-"#endif\n"
-"}\n"
-"#endif";
+static const char advinterp2x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform sampler2D rubyTexture;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
 
-static const char advinterp3x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform sampler2D rubyTexture;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-""
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-""
-"vec3 getadvinterp3xtexel(vec2 coord) {\n"
-"	vec2 base = floor(coord/vec2(3.0))+vec2(0.5);\n"
-"	vec3 c0 = texture2D(rubyTexture, (base-vec2(1.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c1 = texture2D(rubyTexture, (base-vec2(0.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c2 = texture2D(rubyTexture, (base-vec2(-1.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c3 = texture2D(rubyTexture, (base-vec2(1.0,0.0))/rubyTextureSize).xyz;\n"
-"	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;\n"
-"	vec3 c5 = texture2D(rubyTexture, (base+vec2(1.0,0.0))/rubyTextureSize).xyz;\n"
-"	vec3 c6 = texture2D(rubyTexture, (base+vec2(-1.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c7 = texture2D(rubyTexture, (base+vec2(0.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c8 = texture2D(rubyTexture, (base+vec2(1.0,1.0))/rubyTextureSize).xyz;\n"
-""
-"	bool outer = c1 != c7 && c3 != c5;\n"
-""
-"	vec3 l00 = mix(c3,c4,(outer && c3==c1) ? 3.0/8.0:1.0);\n"
-"	vec3 l01 = (outer && ((c3==c1&&c4!=c2)||(c5==c1&&c4!=c0))) ? c1 : c4;\n"
-"	vec3 l02 = mix(c5,c4,(outer && c5==c1) ? 3.0/8.0:1.0);\n"
-"	vec3 l10 = (outer && ((c3==c1&&c4!=c6)||(c3==c7&&c4!=c0))) ? c3 : c4;\n"
-"	vec3 l11 = c4;\n"
-"	vec3 l12 = (outer && ((c5==c1&&c4!=c8)||(c5==c7&&c4!=c2))) ? c5 : c4;\n"
-"	vec3 l20 = mix(c3,c4,(outer && c3==c7) ? 3.0/8.0:1.0);\n"
-"	vec3 l21 = (outer && ((c3==c7&&c4!=c8)||(c5==c7&&c4!=c6))) ? c7 : c4;\n"
-"	vec3 l22 = mix(c5,c4,(outer && c5==c7) ? 3.0/8.0:1.0);\n"
-""
-"	coord = mod(coord, 3.0);\n"
-"	bvec2 l = lessThan(coord, vec2(1.0));\n"
-"	bvec2 h = greaterThanEqual(coord, vec2(2.0));\n"
-""
-"	if (h.x) {\n"
-"		l01 = l02;\n"
-"		l11 = l12;\n"
-"		l21 = l22;\n"
-"	}\n"
-"	if (h.y) {\n"
-"		l10 = l20;\n"
-"		l11 = l21;\n"
-"	}\n"
-"	if (l.x) {\n"
-"		l01 = l00;\n"
-"		l11 = l10;\n"
-"	}\n"
-"	return l.y ? l01 : l11;\n"
-"}\n"
-""
-"void main()\n"
-"{\n"
-"	vec2 coord = v_texCoord;\n"
-"#if defined(OPENGLNB)\n"
-"	gl_FragColor = getadvinterp3xtexel(coord);\n"
-"#else\n"
-"	coord -= 0.5;\n"
-"	vec3 c0 = getadvinterp3xtexel(coord);\n"
-"	vec3 c1 = getadvinterp3xtexel(coord+vec2(1.0,0.0));\n"
-"	vec3 c2 = getadvinterp3xtexel(coord+vec2(0.0,1.0));\n"
-"	vec3 c3 = getadvinterp3xtexel(coord+vec2(1.0));\n"
-""
-"	coord = fract(max(coord,0.0));\n"
-"	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);\n"
-"#endif\n"
-"}\n"
-"#endif";
+#if defined(VERTEX)
+attribute vec4 a_position;
 
-static const char advmame2x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform sampler2D rubyTexture;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-""
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-""
-"vec3 getadvmame2xtexel(vec2 coord) {\n"
-"	vec2 base = floor(coord/vec2(2.0))+vec2(0.5);\n"
-"	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;\n"
-"	vec3 c1 = texture2D(rubyTexture, (base-vec2(0.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c7 = texture2D(rubyTexture, (base+vec2(0.0,1.0))/rubyTextureSize).xyz;\n"
-"	vec3 c3 = texture2D(rubyTexture, (base-vec2(1.0,0.0))/rubyTextureSize).xyz;\n"
-"	vec3 c5 = texture2D(rubyTexture, (base+vec2(1.0,0.0))/rubyTextureSize).xyz;\n"
-""
-"	bool outer = c1 != c7 && c3 != c5;\n"
-"	bool c3c1 = outer && c3==c1;\n"
-"	bool c1c5 = outer && c1==c5;\n"
-"	bool c3c7 = outer && c3==c7;\n"
-"	bool c7c5 = outer && c7==c5;\n"
-""
-"	vec3 l00 = mix(c4,c3,c3c1?1.0:0.0);\n"
-"	vec3 l01 = mix(c4,c5,c1c5?1.0:0.0);\n"
-"	vec3 l10 = mix(c4,c3,c3c7?1.0:0.0);\n"
-"	vec3 l11 = mix(c4,c5,c7c5?1.0:0.0);\n"
-""
-"	coord = max(floor(mod(coord, 2.0)), 0.0);\n"
-"	/* 2x2 output:\n"
-"	 *    |x=0|x=1\n"
-"	 * y=0|l00|l01\n"
-"	 * y=1|l10|l11\n"
-"	 */\n"
-""
-"	return mix(mix(l00,l01,coord.x), mix(l10,l11,coord.x), coord.y);\n"
-"}\n"
-""
-"void main()\n"
-"{\n"
-"	vec2 coord = v_texCoord;\n"
-"#if defined(OPENGLNB)\n"
-"	gl_FragColor = getadvmame2xtexel(coord);\n"
-"#else\n"
-"	coord -= 0.5;\n"
-"	vec3 c0 = getadvmame2xtexel(coord);\n"
-"	vec3 c1 = getadvmame2xtexel(coord+vec2(1.0,0.0));\n"
-"	vec3 c2 = getadvmame2xtexel(coord+vec2(0.0,1.0));\n"
-"	vec3 c3 = getadvmame2xtexel(coord+vec2(1.0));\n"
-""
-"	coord = fract(max(coord,0.0));\n"
-"	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);\n"
-"#endif\n"
-"}\n"
-"#endif";
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;
+}
 
-static const char advmame3x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform sampler2D rubyTexture;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-""
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-""
-"vec3 getadvmame3xtexel(vec2 coord) {\n"
-"	vec2 base = floor(coord/vec2(3.0))+vec2(0.5);\n"
-"	coord = mod(coord, 3.0);\n"
-"	bvec2 l = lessThan(coord, vec2(1.0));\n"
-"	bvec2 h = greaterThanEqual(coord, vec2(2.0));\n"
-"	bvec2 m = equal(l,h);\n"
-""
-"	vec2 left = vec2(h.x?1.0:-1.0, 0.0);\n"
-"	vec2 up = vec2(0.0, h.y?1.0:-1.0);\n"
-"	if (l==h) left.x = 0.0; // hack for center pixel, will ensure outer==false\n"
-"	if (m.y) {\n"
-"		// swap\n"
-"		left -= up;\n"
-"		up += left;\n"
-"		left = up - left;\n"
-"	}\n"
-""
-"	vec3 c0 = texture2D(rubyTexture, (base+up+left)/rubyTextureSize).xyz;\n"
-"	vec3 c1 = texture2D(rubyTexture, (base+up)/rubyTextureSize).xyz;\n"
-"	vec3 c2 = texture2D(rubyTexture, (base+up-left)/rubyTextureSize).xyz;\n"
-"	vec3 c3 = texture2D(rubyTexture, (base+left)/rubyTextureSize).xyz;\n"
-"	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;\n"
-"	vec3 c5 = texture2D(rubyTexture, (base-left)/rubyTextureSize).xyz;\n"
-"	vec3 c7 = texture2D(rubyTexture, (base-up)/rubyTextureSize).xyz;\n"
-""
-"	bool outer = c1 != c7 && c3 != c5;\n"
-"	bool check1 = c3==c1 && (!any(m) || c4!=c2);\n"
-"	bool check2 = any(m) && c5==c1 && c4!=c0;\n"
-""
-"	return (outer && (check1 || check2)) ? c1 : c4;\n"
-"}\n"
-""
-"void main()\n"
-"{\n"
-"	vec2 coord = v_texCoord;\n"
-"#if defined(OPENGLNB)\n"
-"	gl_FragColor = getadvmame3xtexel(coord);\n"
-"#else\n"
-"	coord -= 0.5;\n"
-"	vec3 c0 = getadvmame3xtexel(coord);\n"
-"	vec3 c1 = getadvmame3xtexel(coord+vec2(1.0,0.0));\n"
-"	vec3 c2 = getadvmame3xtexel(coord+vec2(0.0,1.0));\n"
-"	vec3 c3 = getadvmame3xtexel(coord+vec2(1.0));\n"
-""
-"	coord = fract(max(coord,0.0));\n"
-"	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);\n"
-"#endif\n"
-"}\n"
-"#endif";
+#elif defined(FRAGMENT)
 
-static const char rgb2x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform sampler2D rubyTexture;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-""
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 2.0;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-""
-"vec4 getRGB2xtexel(vec2 coord) {\n"
-"	vec2 mid = vec2(0.5);\n"
-"	vec4 s = texture2D(rubyTexture, (floor(coord/vec2(2.0))+mid)/rubyTextureSize);\n"
-""
-"	coord = max(floor(mod(coord, 2.0)), 0.0);\n"
-"	/* 2x2 output:\n"
-"	 *    |x=0|x=1\n"
-"	 * y=0| r | g\n"
-"	 * y=1| b |rgb\n"
-"	 */\n"
-""
-"	s.r *= 1.0 - abs(coord.x - coord.y);\n"
-"	s.g *= coord.x;\n"
-"	s.b *= coord.y;\n"
-"	return s;\n"
-"}\n"
-""
-"void main()\n"
-"{\n"
-"	vec2 coord = v_texCoord;\n"
-"#if defined(OPENGLNB)\n"
-"	gl_FragColor = getRGB2xtexel(coord);\n"
-"#else\n"
-"	coord -= 0.5;\n"
-"	vec4 c0 = getRGB2xtexel(coord);\n"
-"	vec4 c1 = getRGB2xtexel(coord+vec2(1.0,0.0));\n"
-"	vec4 c2 = getRGB2xtexel(coord+vec2(0.0,1.0));\n"
-"	vec4 c3 = getRGB2xtexel(coord+vec2(1.0));\n"
-""
-"	coord = fract(max(coord,0.0));\n"
-"	gl_FragColor = mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y);\n"
-"#endif\n"
-"}\n"
-"#endif";
+vec3 getadvinterp2xtexel(vec2 coord) {
+	vec2 base = floor(coord/vec2(2.0))+vec2(0.5);
+	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;
+	vec3 c1 = texture2D(rubyTexture, (base-vec2(0.0,1.0))/rubyTextureSize).xyz;
+	vec3 c7 = texture2D(rubyTexture, (base+vec2(0.0,1.0))/rubyTextureSize).xyz;
+	vec3 c3 = texture2D(rubyTexture, (base-vec2(1.0,0.0))/rubyTextureSize).xyz;
+	vec3 c5 = texture2D(rubyTexture, (base+vec2(1.0,0.0))/rubyTextureSize).xyz;
 
-static const char rgb3x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform sampler2D rubyTexture;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-""
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 3.0;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-""
-"vec4 getRGB3xtexel(vec2 coord) {\n"
-"	vec2 mid = vec2(0.5);\n"
-"	vec4 s = texture2D(rubyTexture, (floor(coord/vec2(3.0))+mid)/rubyTextureSize);\n"
-""
-"	coord = max(floor(mod(coord, 3.0)), 0.0);\n"
-"	/* 3x3 output:\n"
-"	 *  | l | m | h\n"
-"	 * l|rgb| g | b\n"
-"	 * m| g | r |rgb\n"
-"	 * h|rgb| b | r\n"
-"	 */\n"
-"	vec2 l = step(0.0, -coord);\n"
-"	vec2 m = vec2(1.0) - abs(coord-1.0);\n"
-"	vec2 h = step(2.0, coord);\n"
-""
-"	s.r *= l.x + m.y - 2.0*l.x*m.y + h.x*h.y;\n"
-"	s.g *= l.x + l.y*m.x + h.x*m.y;\n"
-"	s.b *= l.x*l.y + h.x + h.y - 2.0*h.x*h.y;\n"
-"	return s;\n"
-"}\n"
-""
-"void main()\n"
-"{\n"
-"	vec2 coord = v_texCoord;\n"
-"#if defined(OPENGLNB)\n"
-"	gl_FragColor = getRGB3xtexel(coord);\n"
-"#else\n"
-"	coord -= 0.5;\n"
-"	vec4 c0 = getRGB3xtexel(coord);\n"
-"	vec4 c1 = getRGB3xtexel(coord+vec2(1.0,0.0));\n"
-"	vec4 c2 = getRGB3xtexel(coord+vec2(0.0,1.0));\n"
-"	vec4 c3 = getRGB3xtexel(coord+vec2(1.0));\n"
-""
-"	coord = fract(max(coord,0.0));\n"
-"	gl_FragColor = mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y);\n"
-"#endif\n"
-"}\n"
-"#endif";
+	bool outer = c1 != c7 && c3 != c5;
+	bool c3c1 = outer && c3==c1;
+	bool c1c5 = outer && c1==c5;
+	bool c3c7 = outer && c3==c7;
+	bool c7c5 = outer && c7==c5;
 
-static const char scan2x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-"uniform sampler2D rubyTexture;\n"
-""
-"void main() {\n"
-"  vec2 prescale = vec2(2.0);\n"
-"  vec2 texel = v_texCoord;\n"
-"  vec2 texel_floored = floor(texel);\n"
-"  vec2 s = fract(texel);\n"
-"  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;\n"
-""
-"  vec2 center_dist = s - vec2(0.5);\n"
-"  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);\n"
-""
-"  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);\n"
-"  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);\n"
-"  float ss = abs(s.y*2.0-1.0);\n"
-"  p -= p*ss;\n"
-""
-"  gl_FragColor = p;\n"
-"}\n"
-"#endif";
+	vec3 l00 = mix(c3,c4,c3c1?3.0/8.0:1.0);
+	vec3 l01 = mix(c5,c4,c1c5?3.0/8.0:1.0);
+	vec3 l10 = mix(c3,c4,c3c7?3.0/8.0:1.0);
+	vec3 l11 = mix(c5,c4,c7c5?3.0/8.0:1.0);
 
-static const char scan3x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-"uniform sampler2D rubyTexture;\n"
-""
-"void main() {\n"
-"  vec2 prescale = vec2(3.0);\n"
-"  vec2 texel = v_texCoord;\n"
-"  vec2 texel_floored = floor(texel);\n"
-"  vec2 s = fract(texel);\n"
-"  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;\n"
-""
-"  vec2 center_dist = s - 0.5;\n"
-"  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);\n"
-""
-"  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);\n"
-"  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);\n"
-"  float m = s.y*6.0;\n"
-"  m -= clamp(m, 2.0, 4.0);\n"
-"  m = abs(m/2.0);\n"
-"  gl_FragColor = p - p*m;\n"
-"}\n"
-"#endif";
+	coord = max(floor(mod(coord, 2.0)), 0.0);
+	/* 2x2 output:
+	 *    |x=0|x=1
+	 * y=0|l00|l01
+	 * y=1|l10|l11
+	 */
 
-static const char tv2x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-"uniform sampler2D rubyTexture;\n"
-""
-"void main() {\n"
-"  vec2 prescale = vec2(2.0);\n"
-"  vec2 texel = v_texCoord;\n"
-"  vec2 texel_floored = floor(texel);\n"
-"  vec2 s = fract(texel);\n"
-"  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;\n"
-""
-"  vec2 center_dist = s - 0.5;\n"
-"  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);\n"
-""
-"  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);\n"
-"  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);\n"
-"  float ss = abs(s.y*2.0-1.0);\n"
-"  p -= p*ss*3.0/8.0;\n"
-""
-"  gl_FragColor = p;\n"
-"}\n"
-"#endif";
+	return mix(mix(l00,l01,coord.x), mix(l10,l11,coord.x), coord.y);
+}
 
-static const char tv3x_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-"uniform sampler2D rubyTexture;\n"
-""
-"void main() {\n"
-"  vec2 prescale = vec2(3.0);\n"
-"  vec2 texel = v_texCoord;\n"
-"  vec2 texel_floored = floor(texel);\n"
-"  vec2 s = fract(texel);\n"
-"  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;\n"
-""
-"  vec2 center_dist = s - 0.5;\n"
-"  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);\n"
-""
-"  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);\n"
-"  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);\n"
-"  float ss = abs(s.y*2.0-1.0);\n"
-"  p -= p*ss*11.0/16.0;\n"
-""
-"  gl_FragColor = p;\n"
-"}\n"
-"#endif";
+void main()
+{
+	vec2 coord = v_texCoord;
+#if defined(OPENGLNB)
+	gl_FragColor = getadvinterp2xtexel(coord);
+#else
+	coord -= 0.5;
+	vec3 c0 = getadvinterp2xtexel(coord);
+	vec3 c1 = getadvinterp2xtexel(coord+vec2(1.0,0.0));
+	vec3 c2 = getadvinterp2xtexel(coord+vec2(0.0,1.0));
+	vec3 c3 = getadvinterp2xtexel(coord+vec2(1.0));
 
-static const char sharp_glsl[] =
-"varying vec2 v_texCoord;\n"
-"uniform vec2 rubyInputSize;\n"
-"uniform vec2 rubyOutputSize;\n"
-"uniform vec2 rubyTextureSize;\n"
-"varying vec2 prescale; // const set by vertex shader\n"
-""
-"#if defined(VERTEX)\n"
-"attribute vec4 a_position;\n"
-"void main() {\n"
-"  gl_Position = a_position;\n"
-"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;\n"
-"  prescale = ceil(rubyOutputSize / rubyInputSize);\n"
-"}\n"
-""
-"#elif defined(FRAGMENT)\n"
-"uniform sampler2D rubyTexture;\n"
-""
-"void main() {\n"
-"  const vec2 halfp = vec2(0.5);\n"
-"  vec2 texel_floored = floor(v_texCoord);\n"
-"  vec2 s = fract(v_texCoord);\n"
-"  vec2 region_range = halfp - halfp / prescale;\n"
-""
-"  vec2 center_dist = s - halfp;\n"
-"  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + halfp;\n"
-""
-"  vec2 mod_texel = min(texel_floored + f, rubyInputSize-halfp);\n"
-"  gl_FragColor = texture2D(rubyTexture, mod_texel / rubyTextureSize);\n"
-"}\n"
-"#endif";
+	coord = fract(max(coord,0.0));
+	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);
+#endif
+}
+#endif
+)GLSL";
 
+static const char advinterp3x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform sampler2D rubyTexture;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;
+}
+
+#elif defined(FRAGMENT)
+
+vec3 getadvinterp3xtexel(vec2 coord) {
+	vec2 base = floor(coord/vec2(3.0))+vec2(0.5);
+	vec3 c0 = texture2D(rubyTexture, (base-vec2(1.0,1.0))/rubyTextureSize).xyz;
+	vec3 c1 = texture2D(rubyTexture, (base-vec2(0.0,1.0))/rubyTextureSize).xyz;
+	vec3 c2 = texture2D(rubyTexture, (base-vec2(-1.0,1.0))/rubyTextureSize).xyz;
+	vec3 c3 = texture2D(rubyTexture, (base-vec2(1.0,0.0))/rubyTextureSize).xyz;
+	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;
+	vec3 c5 = texture2D(rubyTexture, (base+vec2(1.0,0.0))/rubyTextureSize).xyz;
+	vec3 c6 = texture2D(rubyTexture, (base+vec2(-1.0,1.0))/rubyTextureSize).xyz;
+	vec3 c7 = texture2D(rubyTexture, (base+vec2(0.0,1.0))/rubyTextureSize).xyz;
+	vec3 c8 = texture2D(rubyTexture, (base+vec2(1.0,1.0))/rubyTextureSize).xyz;
+
+	bool outer = c1 != c7 && c3 != c5;
+
+	vec3 l00 = mix(c3,c4,(outer && c3==c1) ? 3.0/8.0:1.0);
+	vec3 l01 = (outer && ((c3==c1&&c4!=c2)||(c5==c1&&c4!=c0))) ? c1 : c4;
+	vec3 l02 = mix(c5,c4,(outer && c5==c1) ? 3.0/8.0:1.0);
+	vec3 l10 = (outer && ((c3==c1&&c4!=c6)||(c3==c7&&c4!=c0))) ? c3 : c4;
+	vec3 l11 = c4;
+	vec3 l12 = (outer && ((c5==c1&&c4!=c8)||(c5==c7&&c4!=c2))) ? c5 : c4;
+	vec3 l20 = mix(c3,c4,(outer && c3==c7) ? 3.0/8.0:1.0);
+	vec3 l21 = (outer && ((c3==c7&&c4!=c8)||(c5==c7&&c4!=c6))) ? c7 : c4;
+	vec3 l22 = mix(c5,c4,(outer && c5==c7) ? 3.0/8.0:1.0);
+
+	coord = mod(coord, 3.0);
+	bvec2 l = lessThan(coord, vec2(1.0));
+	bvec2 h = greaterThanEqual(coord, vec2(2.0));
+
+	if (h.x) {
+		l01 = l02;
+		l11 = l12;
+		l21 = l22;
+	}
+	if (h.y) {
+		l10 = l20;
+		l11 = l21;
+	}
+	if (l.x) {
+		l01 = l00;
+		l11 = l10;
+	}
+	return l.y ? l01 : l11;
+}
+
+void main()
+{
+	vec2 coord = v_texCoord;
+#if defined(OPENGLNB)
+	gl_FragColor = getadvinterp3xtexel(coord);
+#else
+	coord -= 0.5;
+	vec3 c0 = getadvinterp3xtexel(coord);
+	vec3 c1 = getadvinterp3xtexel(coord+vec2(1.0,0.0));
+	vec3 c2 = getadvinterp3xtexel(coord+vec2(0.0,1.0));
+	vec3 c3 = getadvinterp3xtexel(coord+vec2(1.0));
+
+	coord = fract(max(coord,0.0));
+	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);
+#endif
+}
+#endif
+)GLSL";
+
+static const char advmame2x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform sampler2D rubyTexture;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;
+}
+
+#elif defined(FRAGMENT)
+
+vec3 getadvmame2xtexel(vec2 coord) {
+	vec2 base = floor(coord/vec2(2.0))+vec2(0.5);
+	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;
+	vec3 c1 = texture2D(rubyTexture, (base-vec2(0.0,1.0))/rubyTextureSize).xyz;
+	vec3 c7 = texture2D(rubyTexture, (base+vec2(0.0,1.0))/rubyTextureSize).xyz;
+	vec3 c3 = texture2D(rubyTexture, (base-vec2(1.0,0.0))/rubyTextureSize).xyz;
+	vec3 c5 = texture2D(rubyTexture, (base+vec2(1.0,0.0))/rubyTextureSize).xyz;
+
+	bool outer = c1 != c7 && c3 != c5;
+	bool c3c1 = outer && c3==c1;
+	bool c1c5 = outer && c1==c5;
+	bool c3c7 = outer && c3==c7;
+	bool c7c5 = outer && c7==c5;
+
+	vec3 l00 = mix(c4,c3,c3c1?1.0:0.0);
+	vec3 l01 = mix(c4,c5,c1c5?1.0:0.0);
+	vec3 l10 = mix(c4,c3,c3c7?1.0:0.0);
+	vec3 l11 = mix(c4,c5,c7c5?1.0:0.0);
+
+	coord = max(floor(mod(coord, 2.0)), 0.0);
+	/* 2x2 output:
+	 *    |x=0|x=1
+	 * y=0|l00|l01
+	 * y=1|l10|l11
+	 */
+
+	return mix(mix(l00,l01,coord.x), mix(l10,l11,coord.x), coord.y);
+}
+
+void main()
+{
+	vec2 coord = v_texCoord;
+#if defined(OPENGLNB)
+	gl_FragColor = getadvmame2xtexel(coord);
+#else
+	coord -= 0.5;
+	vec3 c0 = getadvmame2xtexel(coord);
+	vec3 c1 = getadvmame2xtexel(coord+vec2(1.0,0.0));
+	vec3 c2 = getadvmame2xtexel(coord+vec2(0.0,1.0));
+	vec3 c3 = getadvmame2xtexel(coord+vec2(1.0));
+
+	coord = fract(max(coord,0.0));
+	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);
+#endif
+}
+#endif
+)GLSL";
+
+static const char advmame3x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform sampler2D rubyTexture;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;
+}
+
+#elif defined(FRAGMENT)
+
+vec3 getadvmame3xtexel(vec2 coord) {
+	vec2 base = floor(coord/vec2(3.0))+vec2(0.5);
+	coord = mod(coord, 3.0);
+	bvec2 l = lessThan(coord, vec2(1.0));
+	bvec2 h = greaterThanEqual(coord, vec2(2.0));
+	bvec2 m = equal(l,h);
+
+	vec2 left = vec2(h.x?1.0:-1.0, 0.0);
+	vec2 up = vec2(0.0, h.y?1.0:-1.0);
+	if (l==h) left.x = 0.0; // hack for center pixel, will ensure outer==false
+	if (m.y) {
+		// swap
+		left -= up;
+		up += left;
+		left = up - left;
+	}
+
+	vec3 c0 = texture2D(rubyTexture, (base+up+left)/rubyTextureSize).xyz;
+	vec3 c1 = texture2D(rubyTexture, (base+up)/rubyTextureSize).xyz;
+	vec3 c2 = texture2D(rubyTexture, (base+up-left)/rubyTextureSize).xyz;
+	vec3 c3 = texture2D(rubyTexture, (base+left)/rubyTextureSize).xyz;
+	vec3 c4 = texture2D(rubyTexture, base/rubyTextureSize).xyz;
+	vec3 c5 = texture2D(rubyTexture, (base-left)/rubyTextureSize).xyz;
+	vec3 c7 = texture2D(rubyTexture, (base-up)/rubyTextureSize).xyz;
+
+	bool outer = c1 != c7 && c3 != c5;
+	bool check1 = c3==c1 && (!any(m) || c4!=c2);
+	bool check2 = any(m) && c5==c1 && c4!=c0;
+
+	return (outer && (check1 || check2)) ? c1 : c4;
+}
+
+void main()
+{
+	vec2 coord = v_texCoord;
+#if defined(OPENGLNB)
+	gl_FragColor = getadvmame3xtexel(coord);
+#else
+	coord -= 0.5;
+	vec3 c0 = getadvmame3xtexel(coord);
+	vec3 c1 = getadvmame3xtexel(coord+vec2(1.0,0.0));
+	vec3 c2 = getadvmame3xtexel(coord+vec2(0.0,1.0));
+	vec3 c3 = getadvmame3xtexel(coord+vec2(1.0));
+
+	coord = fract(max(coord,0.0));
+	gl_FragColor = vec4(mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y), 1.0);
+#endif
+}
+#endif
+)GLSL";
+
+static const char rgb2x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform sampler2D rubyTexture;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 2.0;
+}
+
+#elif defined(FRAGMENT)
+
+vec4 getRGB2xtexel(vec2 coord) {
+	vec2 mid = vec2(0.5);
+	vec4 s = texture2D(rubyTexture, (floor(coord/vec2(2.0))+mid)/rubyTextureSize);
+
+	coord = max(floor(mod(coord, 2.0)), 0.0);
+	/* 2x2 output:
+	 *    |x=0|x=1
+	 * y=0| r | g
+	 * y=1| b |rgb
+	 */
+
+	s.r *= 1.0 - abs(coord.x - coord.y);
+	s.g *= coord.x;
+	s.b *= coord.y;
+	return s;
+}
+
+void main()
+{
+	vec2 coord = v_texCoord;
+#if defined(OPENGLNB)
+	gl_FragColor = getRGB2xtexel(coord);
+#else
+	coord -= 0.5;
+	vec4 c0 = getRGB2xtexel(coord);
+	vec4 c1 = getRGB2xtexel(coord+vec2(1.0,0.0));
+	vec4 c2 = getRGB2xtexel(coord+vec2(0.0,1.0));
+	vec4 c3 = getRGB2xtexel(coord+vec2(1.0));
+
+	coord = fract(max(coord,0.0));
+	gl_FragColor = mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y);
+#endif
+}
+#endif
+)GLSL";
+
+static const char rgb3x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform sampler2D rubyTexture;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 3.0;
+}
+
+#elif defined(FRAGMENT)
+
+vec4 getRGB3xtexel(vec2 coord) {
+	vec2 mid = vec2(0.5);
+	vec4 s = texture2D(rubyTexture, (floor(coord/vec2(3.0))+mid)/rubyTextureSize);
+
+	coord = max(floor(mod(coord, 3.0)), 0.0);
+	/* 3x3 output:
+	 *  | l | m | h
+	 * l|rgb| g | b
+	 * m| g | r |rgb
+	 * h|rgb| b | r
+	 */
+	vec2 l = step(0.0, -coord);
+	vec2 m = vec2(1.0) - abs(coord-1.0);
+	vec2 h = step(2.0, coord);
+
+	s.r *= l.x + m.y - 2.0*l.x*m.y + h.x*h.y;
+	s.g *= l.x + l.y*m.x + h.x*m.y;
+	s.b *= l.x*l.y + h.x + h.y - 2.0*h.x*h.y;
+	return s;
+}
+
+void main()
+{
+	vec2 coord = v_texCoord;
+#if defined(OPENGLNB)
+	gl_FragColor = getRGB3xtexel(coord);
+#else
+	coord -= 0.5;
+	vec4 c0 = getRGB3xtexel(coord);
+	vec4 c1 = getRGB3xtexel(coord+vec2(1.0,0.0));
+	vec4 c2 = getRGB3xtexel(coord+vec2(0.0,1.0));
+	vec4 c3 = getRGB3xtexel(coord+vec2(1.0));
+
+	coord = fract(max(coord,0.0));
+	gl_FragColor = mix(mix(c0,c1,coord.x), mix(c2,c3,coord.x), coord.y);
+#endif
+}
+#endif
+)GLSL";
+
+static const char scan2x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+}
+
+#elif defined(FRAGMENT)
+uniform sampler2D rubyTexture;
+
+void main() {
+  vec2 prescale = vec2(2.0);
+  vec2 texel = v_texCoord;
+  vec2 texel_floored = floor(texel);
+  vec2 s = fract(texel);
+  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+
+  vec2 center_dist = s - vec2(0.5);
+  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+
+  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+  float ss = abs(s.y*2.0-1.0);
+  p -= p*ss;
+
+  gl_FragColor = p;
+}
+#endif
+)GLSL";
+
+static const char scan3x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+}
+
+#elif defined(FRAGMENT)
+uniform sampler2D rubyTexture;
+
+void main() {
+  vec2 prescale = vec2(3.0);
+  vec2 texel = v_texCoord;
+  vec2 texel_floored = floor(texel);
+  vec2 s = fract(texel);
+  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+
+  vec2 center_dist = s - 0.5;
+  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+
+  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+  float m = s.y*6.0;
+  m -= clamp(m, 2.0, 4.0);
+  m = abs(m/2.0);
+  gl_FragColor = p - p*m;
+}
+#endif
+)GLSL";
+
+static const char tv2x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+}
+
+#elif defined(FRAGMENT)
+uniform sampler2D rubyTexture;
+
+void main() {
+  vec2 prescale = vec2(2.0);
+  vec2 texel = v_texCoord;
+  vec2 texel_floored = floor(texel);
+  vec2 s = fract(texel);
+  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+
+  vec2 center_dist = s - 0.5;
+  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+
+  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+  float ss = abs(s.y*2.0-1.0);
+  p -= p*ss*3.0/8.0;
+
+  gl_FragColor = p;
+}
+#endif
+)GLSL";
+
+static const char tv3x_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+}
+
+#elif defined(FRAGMENT)
+uniform sampler2D rubyTexture;
+
+void main() {
+  vec2 prescale = vec2(3.0);
+  vec2 texel = v_texCoord;
+  vec2 texel_floored = floor(texel);
+  vec2 s = fract(texel);
+  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+
+  vec2 center_dist = s - 0.5;
+  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+
+  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+  float ss = abs(s.y*2.0-1.0);
+  p -= p*ss*11.0/16.0;
+
+  gl_FragColor = p;
+}
+#endif
+)GLSL";
+
+static const char sharp_glsl[] = R"GLSL(
+varying vec2 v_texCoord;
+uniform vec2 rubyInputSize;
+uniform vec2 rubyOutputSize;
+uniform vec2 rubyTextureSize;
+varying vec2 prescale; // const set by vertex shader
+
+#if defined(VERTEX)
+attribute vec4 a_position;
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+  prescale = ceil(rubyOutputSize / rubyInputSize);
+}
+
+#elif defined(FRAGMENT)
+uniform sampler2D rubyTexture;
+
+void main() {
+  const vec2 halfp = vec2(0.5);
+  vec2 texel_floored = floor(v_texCoord);
+  vec2 s = fract(v_texCoord);
+  vec2 region_range = halfp - halfp / prescale;
+
+  vec2 center_dist = s - halfp;
+  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + halfp;
+
+  vec2 mod_texel = min(texel_floored + f, rubyInputSize-halfp);
+  gl_FragColor = texture2D(rubyTexture, mod_texel / rubyTextureSize);
+}
+#endif
+)GLSL";
 
 #endif

--- a/src/gui/render_glsl.h
+++ b/src/gui/render_glsl.h
@@ -29,8 +29,8 @@ uniform vec2 rubyTextureSize;
 attribute vec4 a_position;
 
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;
 }
 
 #elif defined(FRAGMENT)
@@ -94,8 +94,8 @@ uniform vec2 rubyTextureSize;
 attribute vec4 a_position;
 
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;
 }
 
 #elif defined(FRAGMENT)
@@ -174,8 +174,8 @@ uniform vec2 rubyTextureSize;
 attribute vec4 a_position;
 
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)*rubyInputSize;
 }
 
 #elif defined(FRAGMENT)
@@ -239,8 +239,8 @@ uniform vec2 rubyTextureSize;
 attribute vec4 a_position;
 
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize*3.0;
 }
 
 #elif defined(FRAGMENT)
@@ -307,8 +307,8 @@ uniform vec2 rubyTextureSize;
 attribute vec4 a_position;
 
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 2.0;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 2.0;
 }
 
 #elif defined(FRAGMENT)
@@ -360,8 +360,8 @@ uniform vec2 rubyTextureSize;
 attribute vec4 a_position;
 
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 3.0;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize * 3.0;
 }
 
 #elif defined(FRAGMENT)
@@ -415,29 +415,29 @@ uniform vec2 rubyTextureSize;
 #if defined(VERTEX)
 attribute vec4 a_position;
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
 }
 
 #elif defined(FRAGMENT)
 uniform sampler2D rubyTexture;
 
 void main() {
-  vec2 prescale = vec2(2.0);
-  vec2 texel = v_texCoord;
-  vec2 texel_floored = floor(texel);
-  vec2 s = fract(texel);
-  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+	vec2 prescale = vec2(2.0);
+	vec2 texel = v_texCoord;
+	vec2 texel_floored = floor(texel);
+	vec2 s = fract(texel);
+	vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
 
-  vec2 center_dist = s - vec2(0.5);
-  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+	vec2 center_dist = s - vec2(0.5);
+	vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
 
-  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
-  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
-  float ss = abs(s.y*2.0-1.0);
-  p -= p*ss;
+	vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+	vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+	float ss = abs(s.y*2.0-1.0);
+	p -= p*ss;
 
-  gl_FragColor = p;
+	gl_FragColor = p;
 }
 #endif
 )GLSL";
@@ -451,29 +451,29 @@ uniform vec2 rubyTextureSize;
 #if defined(VERTEX)
 attribute vec4 a_position;
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
 }
 
 #elif defined(FRAGMENT)
 uniform sampler2D rubyTexture;
 
 void main() {
-  vec2 prescale = vec2(3.0);
-  vec2 texel = v_texCoord;
-  vec2 texel_floored = floor(texel);
-  vec2 s = fract(texel);
-  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+	vec2 prescale = vec2(3.0);
+	vec2 texel = v_texCoord;
+	vec2 texel_floored = floor(texel);
+	vec2 s = fract(texel);
+	vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
 
-  vec2 center_dist = s - 0.5;
-  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+	vec2 center_dist = s - 0.5;
+	vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
 
-  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
-  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
-  float m = s.y*6.0;
-  m -= clamp(m, 2.0, 4.0);
-  m = abs(m/2.0);
-  gl_FragColor = p - p*m;
+	vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+	vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+	float m = s.y*6.0;
+	m -= clamp(m, 2.0, 4.0);
+	m = abs(m/2.0);
+	gl_FragColor = p - p*m;
 }
 #endif
 )GLSL";
@@ -487,29 +487,29 @@ uniform vec2 rubyTextureSize;
 #if defined(VERTEX)
 attribute vec4 a_position;
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
 }
 
 #elif defined(FRAGMENT)
 uniform sampler2D rubyTexture;
 
 void main() {
-  vec2 prescale = vec2(2.0);
-  vec2 texel = v_texCoord;
-  vec2 texel_floored = floor(texel);
-  vec2 s = fract(texel);
-  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+	vec2 prescale = vec2(2.0);
+	vec2 texel = v_texCoord;
+	vec2 texel_floored = floor(texel);
+	vec2 s = fract(texel);
+	vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
 
-  vec2 center_dist = s - 0.5;
-  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+	vec2 center_dist = s - 0.5;
+	vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
 
-  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
-  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
-  float ss = abs(s.y*2.0-1.0);
-  p -= p*ss*3.0/8.0;
+	vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+	vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+	float ss = abs(s.y*2.0-1.0);
+	p -= p*ss*3.0/8.0;
 
-  gl_FragColor = p;
+	gl_FragColor = p;
 }
 #endif
 )GLSL";
@@ -523,29 +523,29 @@ uniform vec2 rubyTextureSize;
 #if defined(VERTEX)
 attribute vec4 a_position;
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
 }
 
 #elif defined(FRAGMENT)
 uniform sampler2D rubyTexture;
 
 void main() {
-  vec2 prescale = vec2(3.0);
-  vec2 texel = v_texCoord;
-  vec2 texel_floored = floor(texel);
-  vec2 s = fract(texel);
-  vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
+	vec2 prescale = vec2(3.0);
+	vec2 texel = v_texCoord;
+	vec2 texel_floored = floor(texel);
+	vec2 s = fract(texel);
+	vec2 region_range = vec2(0.5) - vec2(0.5) / prescale;
 
-  vec2 center_dist = s - 0.5;
-  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
+	vec2 center_dist = s - 0.5;
+	vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + vec2(0.5);
 
-  vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
-  vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
-  float ss = abs(s.y*2.0-1.0);
-  p -= p*ss*11.0/16.0;
+	vec2 mod_texel = min(texel_floored + f, rubyInputSize-0.5);
+	vec4 p = texture2D(rubyTexture, mod_texel/rubyTextureSize);
+	float ss = abs(s.y*2.0-1.0);
+	p -= p*ss*11.0/16.0;
 
-  gl_FragColor = p;
+	gl_FragColor = p;
 }
 #endif
 )GLSL";
@@ -560,25 +560,25 @@ varying vec2 prescale; // const set by vertex shader
 #if defined(VERTEX)
 attribute vec4 a_position;
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
-  prescale = ceil(rubyOutputSize / rubyInputSize);
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
+	prescale = ceil(rubyOutputSize / rubyInputSize);
 }
 
 #elif defined(FRAGMENT)
 uniform sampler2D rubyTexture;
 
 void main() {
-  const vec2 halfp = vec2(0.5);
-  vec2 texel_floored = floor(v_texCoord);
-  vec2 s = fract(v_texCoord);
-  vec2 region_range = halfp - halfp / prescale;
+	const vec2 halfp = vec2(0.5);
+	vec2 texel_floored = floor(v_texCoord);
+	vec2 s = fract(v_texCoord);
+	vec2 region_range = halfp - halfp / prescale;
 
-  vec2 center_dist = s - halfp;
-  vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + halfp;
+	vec2 center_dist = s - halfp;
+	vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + halfp;
 
-  vec2 mod_texel = min(texel_floored + f, rubyInputSize-halfp);
-  gl_FragColor = texture2D(rubyTexture, mod_texel / rubyTextureSize);
+	vec2 mod_texel = min(texel_floored + f, rubyInputSize-halfp);
+	gl_FragColor = texture2D(rubyTexture, mod_texel / rubyTextureSize);
 }
 #endif
 )GLSL";

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -373,22 +373,23 @@ Read AUTHORS file for more details.
 )";
 
 #if C_OPENGL
-static char const shader_src_default[] =
-	"varying vec2 v_texCoord;\n"
-	"#if defined(VERTEX)\n"
-	"uniform vec2 rubyTextureSize;\n"
-	"uniform vec2 rubyInputSize;\n"
-	"attribute vec4 a_position;\n"
-	"void main() {\n"
-	"  gl_Position = a_position;\n"
-	"  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize/rubyTextureSize;\n"
-	"}\n"
-	"#elif defined(FRAGMENT)\n"
-	"uniform sampler2D rubyTexture;\n\n"
-	"void main() {\n"
-	"  gl_FragColor = texture2D(rubyTexture, v_texCoord);\n"
-	"}\n"
-	"#endif\n";
+static char const shader_src_default[] = R"GLSL(
+varying vec2 v_texCoord;
+#if defined(VERTEX)
+uniform vec2 rubyTextureSize;
+uniform vec2 rubyInputSize;
+attribute vec4 a_position;
+void main() {
+  gl_Position = a_position;
+  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize/rubyTextureSize;
+}
+#elif defined(FRAGMENT)
+uniform sampler2D rubyTexture;
+void main() {
+  gl_FragColor = texture2D(rubyTexture, v_texCoord);
+}
+#endif
+)GLSL";
 
 #ifdef DB_OPENGL_ERROR
 void OPENGL_ERROR(const char* message) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -380,13 +380,13 @@ uniform vec2 rubyTextureSize;
 uniform vec2 rubyInputSize;
 attribute vec4 a_position;
 void main() {
-  gl_Position = a_position;
-  v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize/rubyTextureSize;
+	gl_Position = a_position;
+	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize/rubyTextureSize;
 }
 #elif defined(FRAGMENT)
 uniform sampler2D rubyTexture;
 void main() {
-  gl_FragColor = texture2D(rubyTexture, v_texCoord);
+	gl_FragColor = texture2D(rubyTexture, v_texCoord);
 }
 #endif
 )GLSL";


### PR DESCRIPTION
Pull request to address @dreamer's comment regarding converting existing shaders to C++11 raw string syntax: https://github.com/dosbox-staging/dosbox-staging/issues/301#issuecomment-616873811. I have used a deliminator of `GLSL` for the strings.