### PR TITLE
Cleanup and add warning count to platform builds

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -7,7 +7,6 @@ jobs:
   build_linux_platforms:
     runs-on: ubuntu-latest
     name: ${{ matrix.conf.name }}
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
     strategy:
       matrix:
         conf:
@@ -27,14 +26,16 @@ jobs:
             architecture: ppc64le
             distribution: ubuntu18.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Check repo for commits
         id: repo-meta
         shell: bash
         run:  'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
 
-      - uses: uraimo/run-on-arch-action@master
+      - name: Build
+        uses: uraimo/run-on-arch-action@master
         if: steps.repo-meta.outputs.has-commits == 'true'
         with:
           architecture: ${{ matrix.conf.architecture }}
@@ -45,3 +46,6 @@ jobs:
             apt-get install -y $(./scripts/list-build-dependencies.sh -c gcc -m apt)
             ./scripts/log-env.sh
             ./scripts/build.sh -c gcc -t release
+
+      - name: Summarize warnings
+        run:  ./scripts/count-warnings.py --max-warnings -1 build.log


### PR DESCRIPTION
Snips out the unnecessary push/account check, and adds an information-only warning count. 

Also, the platform builds are working :-)

https://github.com/dosbox-staging/dosbox-staging/actions/runs/89164436