### PR TITLE
Improve user option related to configuration handling

### DIFF
--- a/README
+++ b/README
@@ -297,30 +297,35 @@ See Section 13: "The configuration (options) file".
 
 To be able to use Command Line Parameters:
 (Windows)  open cmd.exe or command.com or edit the shortcut to dosbox.exe
-(Linux)    use console
-(Mac OS X) start terminal.app and navigate to:
-           /applications/dosbox.app/contents/macos/dosbox
+(Linux)    use any terminal emulator
+(macOS)    start terminal.app and navigate to:
+           /Applications/dosbox-staging.app/Contents/MacOS/dosbox
 
 The options are valid for all operating systems unless noted in the option
 description:
 
-dosbox [name] [-exit] [-c command] [-fullscreen] [-userconf]
-       [-conf congfigfilelocation] [-lang languagefilelocation]
-       [-machine machine type] [-noconsole] [-startmapper] [-noautoexec]
-       [-securemode] [-scaler scaler | -forcescaler scaler] [-version]
-       [-socket socket]
-       
-dosbox -version
-dosbox -editconf program
-dosbox -opencaptures program
-dosbox -printconf
+dosbox [-fullscreen] [-startmapper] [-noautoexec] [-securemode] [-userconf]
+       [-scaler scaler | -forcescaler scaler] [-conf congfigfile]
+       [-lang langfile] [-machine machine-type] [-socket socketnumber]
+       [-c command] [-noconsole] [-exit] [NAME]
+
+dosbox --version
+
+dosbox --printconf
+
+dosbox --editconf [editor]
+
 dosbox -eraseconf
+
 dosbox -erasemapper
 
-  name
-        If "name" is a directory it will mount that as the C: drive.
-        If "name" is an executable it will mount the directory of "name"
-        as the C: drive and execute "name".
+dosbox -opencaptures program
+
+
+  NAME
+        If "NAME" is a directory it will mount that as the C: drive.
+        If "NAME" is an executable it will mount the directory of "NAME"
+        as the C: drive and execute "NAME".
 
   -exit
         DOSBox will close itself when the DOS application "name" ends.
@@ -382,20 +387,20 @@ dosbox -erasemapper
         Similar to the -scaler parameter, but tries to force usage of
         the specified scaler even if it might not fit.
 
-  -version
-        output version information and exit. Useful for frontends.
+  --version
+        Output version information and exit. Useful for frontends.
 
-  -editconf program
-        calls program with as first parameter the configuration file.
-        You can specify this command more than once. In this case it will
-        move to second program if the first one fails to start.
+  --editconf [editor]
+        Open the default configuration file in a text editor. If no editor name
+        is given, then use the program from EDITOR environment variable,
+        otherwise DOSBox will try to guess the name.
 
   -opencaptures program
         calls program with as first parameter the location of the captures
         folder.
 
-  -printconf
-        prints the location of the default configuration file.
+  --printconf
+        Print the location of the default configuration file.
 
   -resetconf
         removes the default configuration file.
@@ -1539,6 +1544,8 @@ The default directories storing config file are:
    (Windows) C:\Users\<username>\AppData\Local\DOSBox\
    (Linux)   ~/.config/dosbox/
    (macOS)   ~/Library/Preferences/DOSBox/
+
+You can quickly find exact path by running dosbox with parameter "--printconf".
 
 Linux users:
     The configuration's parent-directory can be customized by setting

--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -10,23 +10,20 @@ dosbox \- an x86/DOS emulator with sound/graphics
 .B [\-noautoexec]
 .B [\-securemode]
 .B [\-userconf]
-.BI "[\-scaler " scaler ] 
-.BI "[\-forcescaler " scaler ]
+.BI "[\-scaler " scaler | \-forcescaler " scaler]
 .BI "[\-conf " configfile ]
 .BI "[\-lang " langfile ]
 .BI "[\-machine " machinetype ]
 .BI "[\-socket " socketnumber ]
 .BI "[\-c " command ]
 .B [\-exit]
-.B [file]
+.B [NAME]
 .LP
-.B dosbox \-version
+.B dosbox \-\-version
 .LP
-.BI "dosbox \-editconf" " program"
+.B dosbox \-\-printconf
 .LP
-.BI "dosbox \-opencaptures" " program"
-.LP
-.B dosbox \-printconf
+.BI "dosbox \-\-editconf ["editor ]
 .LP
 .B dosbox \-eraseconf
 .LP
@@ -35,11 +32,13 @@ dosbox \- an x86/DOS emulator with sound/graphics
 .B dosbox \-erasemapper
 .LP
 .B dosbox \-resetmapper
+.LP
+.BI "dosbox \-opencaptures" " program"
 .SH DESCRIPTION
 This manual page briefly documents
-.BR "dosbox" ", an x86/DOS emulator."
+.BR "dosbox-staging" ", an x86/DOS emulator."
 .LP
-.RB "The optional " file " argument should be a DOS executable or a"
+.RB "The optional " NAME " argument should be a DOS executable or a"
 directory. If it is a dos executable (.com .exe .bat) the program will 
 run automatically. If it is a directory, a DOS session will run with 
 the directory mounted as C:\\.
@@ -106,19 +105,19 @@ an Internal Program, a DOS command or an executable on a mounted drive.
 .B "\-exit "
 .BR "dosbox" " will close itself when the DOS program specified by "file " ends."
 .TP
-.B \-version
+.B \-\-version
 Output version information and exit. Useful for frontends.
 .TP
-.BI \-editconf " program"
-.RI calls " program" " with as first parameter the configuration file."
-You can specify this command more than once. In this case it will
-.RI " move to second " program " if the first one fails to start."
+.BI "\-\-editconf ["editor ]
+.R Open the default configuration file in a text editor. If no editor name
+is given, then use the program from EDITOR environment variable,
+otherwise DOSBox will try to guess the name.
 .TP
 .BI \-opencaptures " program"
 .RI "calls " program " with as  first parameter the location of the captures folder."
 .TP
-.B \-printconf
-prints the location of the default configuration file.
+.B \-\-printconf
+Prints the location of the default configuration file.
 .TP
 .B \-eraseconf, \-resetconf
 removes the default configuration file.

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3012,20 +3012,22 @@ static void launchcaptures(std::string const& edit) {
 	exit(1);
 }
 
-static void printconfiglocation() {
-	std::string path,file;
+static int PrintConfigLocation()
+{
+	std::string path, file;
 	Cross::CreatePlatformConfigDir(path);
 	Cross::GetPlatformConfigName(file);
 	path += file;
 
-	FILE* f = fopen(path.c_str(),"r");
+	FILE *f = fopen(path.c_str(), "r");
 	if (!f && !control->PrintConfig(path)) {
-		printf("tried creating %s. but failed", path.c_str());
-		exit(1);
+		fprintf(stderr, "Tried creating '%s', but failed.\n", path.c_str());
+		return 1;
 	}
-	if(f) fclose(f);
-	printf("%s\n",path.c_str());
-	exit(0);
+	if (f)
+		fclose(f);
+	printf("%s\n", path.c_str());
+	return 0;
 }
 
 static void eraseconfigfile() {
@@ -3135,8 +3137,11 @@ int main(int argc, char* argv[]) {
 			return 0;
 		}
 
-		if (control->cmdline->FindExist("-printconf"))
-			printconfiglocation();
+		if (control->cmdline->FindExist("--printconf") ||
+		    control->cmdline->FindExist("-printconf")) {
+			const int err = PrintConfigLocation();
+			return err;
+		}
 
 #if C_DEBUG
 		DEBUG_SetupConsole();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3089,6 +3089,8 @@ int main(int argc, char* argv[]) {
 		Disable_OS_Scaling(); //Do this early on, maybe override it through some parameter.
 		OverrideWMClass(); // Before SDL2 video subsystem is initialized
 
+		CROSS_DetermineConfigPaths();
+
 		CommandLine com_line(argc,argv);
 		Config myconf(&com_line);
 		control=&myconf;
@@ -3155,8 +3157,6 @@ int main(int argc, char* argv[]) {
 
 	sdl.laltstate = SDL_KEYUP;
 	sdl.raltstate = SDL_KEYUP;
-
-	CROSS_DetermineConfigPaths();
 
 	/* Parse configuration files */
 	std::string config_file, config_path, config_combined;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3158,8 +3158,8 @@ int main(int argc, char* argv[]) {
 		}
 #endif  //defined(WIN32) && !(C_DEBUG)
 
-		if (control->cmdline->FindExist("-version") ||
-		    control->cmdline->FindExist("--version")) {
+		if (control->cmdline->FindExist("--version") ||
+		    control->cmdline->FindExist("-version")) {
 			printf(version_msg, VERSION);
 			return 0;
 		}


### PR DESCRIPTION
- Fix `--printconf` which I accidentally broke during the transition to XDG
- Fix `--editconf` to behave like a sane option
- Fix #311 (also regressed with XDG) - this fix qualifies for backporting to the release branch
- Improve documentation around these options

Details in specific commit messages.