### PR TITLE
Scan Windows release builds with Windows Defender

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,7 +142,7 @@ jobs:
           # Create tarball
           tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
 
-      - name: AV scan
+      - name: Clam AV scan
         run: |
           set -x
           sudo apt-get install clamav > /dev/null

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -144,7 +144,7 @@ jobs:
               -srcfolder dist \
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
 
-      - name: AV scan
+      - name: Clam AV scan
         run: |
           set -x
           brew install clamav > /dev/null

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -169,6 +169,14 @@ jobs:
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
           # Create dir for zipping
           mv dest dosbox-staging-windows-${{ env.VERSION }}
+
+      - name: Windows Defender AV Scan
+        shell: powershell
+        run: |
+          Update-MpSignature
+          Start-MpScan -ScanPath "${{ github.workspace }}\dosbox-staging-windows-${{ env.VERSION }}"
+          Start-MpScan -ScanPath dosbox-staging-windows-${{ env.VERSION }}
+
       - name: Upload package
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,6 +174,7 @@ jobs:
         shell: powershell
         run: |
           Get-MpComputerStatus
+          wget "https://secure.eicar.org/eicar.com" -O "./dosbox-staging-windows-${{ env.VERSION }}/eicar.com"
           Start-MpScan -ScanPath "./dosbox-staging-windows-${{ env.VERSION }}"
           echo $?
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,8 +174,8 @@ jobs:
         shell: powershell
         run: |
           Get-MpComputerStatus
-          wget "https://secure.eicar.org/eicar.com" -O "./dosbox-staging-windows-${{ env.VERSION }}/eicar.com"
-          Start-MpScan -ScanPath "./dosbox-staging-windows-${{ env.VERSION }}"
+          Invoke-WebRequest "https://secure.eicar.org/eicar.com" -OutFile "./dosbox-staging-windows-${{ env.VERSION }}/eicar.com" -Verbose
+          Start-MpScan -ScanPath "./dosbox-staging-windows-${{ env.VERSION }}" -Verbose -ErrorAction Stop
           echo $?
 
       - name: Upload package

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -145,6 +145,17 @@ jobs:
           # TODO "Windows SmartScreen" complains about unsigned .exe during
           #      the first start of a build. Maybe self-signed certificate
           #      will make it a bit more user-friendly.
+
+      - name: Activate Windows Defender RT Monitoring
+        shell: powershell
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $false
+          Get-MpComputerStatus
+          Invoke-WebRequest "https://secure.eicar.org/eicar.com" -OutFile "./dosbox-staging-windows-${{ env.VERSION }}/eicar.com" -Verbose
+          Start-MpScan -ScanPath "./dosbox-staging-windows-${{ env.VERSION }}" -Verbose -ErrorAction Stop
+          dir "./dosbox-staging-windows-${{ env.VERSION }}/"
+          echo $?
+
       - name:  Package
         shell: bash
         run: |
@@ -169,14 +180,6 @@ jobs:
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
           # Create dir for zipping
           mv dest dosbox-staging-windows-${{ env.VERSION }}
-
-      - name: Windows Defender AV Scan
-        shell: powershell
-        run: |
-          Get-MpComputerStatus
-          Invoke-WebRequest "https://secure.eicar.org/eicar.com" -OutFile "./dosbox-staging-windows-${{ env.VERSION }}/eicar.com" -Verbose
-          Start-MpScan -ScanPath "./dosbox-staging-windows-${{ env.VERSION }}" -Verbose -ErrorAction Stop
-          echo $?
 
       - name: Upload package
         uses: actions/upload-artifact@master

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -173,9 +173,9 @@ jobs:
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
-          Update-MpSignature
-          Start-MpScan -ScanPath "${{ github.workspace }}\dosbox-staging-windows-${{ env.VERSION }}"
-          Start-MpScan -ScanPath dosbox-staging-windows-${{ env.VERSION }}
+          Get-MpComputerStatus
+          Start-MpScan -ScanPath "./dosbox-staging-windows-${{ env.VERSION }}"
+          echo $?
 
       - name: Upload package
         uses: actions/upload-artifact@master


### PR DESCRIPTION
![Screenshot at 2020-04-29 16-19-25](https://user-images.githubusercontent.com/1557255/80656120-3f698080-8a35-11ea-8d87-37395f7c6dc4.png)

I found I couldn't capture the scan output though; unfortuantely some powershell commands produce some kind "text overlay" that pops up in the GUI, then disappears when its done.  The best I could do was to dump the status pre-scan, and print the return-code post-scan. 