### PR TITLE
Cleanup unbounded string copies 

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -256,7 +256,7 @@ public:
 	virtual bool FileExists(const char* name)=0;
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block)=0;
 	virtual Bit8u GetMediaByte(void)=0;
-	virtual void SetDir(const char* path) { strcpy(curdir,path); };
+	virtual void SetDir(const char *path) { safe_strcpy(curdir, path); };
 	virtual void EmptyCache(void) { dirCache.EmptyCache(); };
 	virtual bool isRemote(void)=0;
 	virtual bool isRemovable(void)=0;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -219,7 +219,7 @@ bool DOS_ChangeDir(char const * const dir) {
 	}
 	
 	if (Drives[drive]->TestDir(fulldir)) {
-		strcpy(Drives[drive]->curdir,fulldir);
+		safe_strcpy(Drives[drive]->curdir, fulldir);
 		return true;
 	} else {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
@@ -327,12 +327,12 @@ bool DOS_FindFirst(char * search,Bit16u attr,bool fcb_findfirst) {
 	char * find_last;
 	find_last=strrchr(fullsearch,'\\');
 	if (!find_last) {	/*No dir */
-		strcpy(pattern,fullsearch);
+		safe_strcpy(pattern, fullsearch);
 		dir[0]=0;
 	} else {
 		*find_last=0;
-		strcpy(pattern,find_last+1);
-		strcpy(dir,fullsearch);
+		safe_strcpy(pattern, find_last + 1);
+		safe_strcpy(dir, fullsearch);
 	}
 
 	dta.SetupSearch(drive,(Bit8u)attr,pattern);
@@ -464,7 +464,7 @@ static bool PathExists(char const * const name) {
 	const char* leading = strrchr(name,'\\');
 	if(!leading) return true;
 	char temp[CROSS_LEN];
-	strcpy(temp,name);
+	safe_strcpy(temp, name);
 	char * lead = strrchr(temp,'\\');
 	if (lead == temp) return true;
 	*lead = 0;
@@ -915,9 +915,11 @@ checkext:
 	}
 savefcb:
 	if (!hasdrive & !(parser & PARSE_DFLT_DRIVE)) fcb_name.part.drive[0] = 0;
-	if (!hasname & !(parser & PARSE_BLNK_FNAME)) strcpy(fcb_name.part.name,"        ");
-	if (!hasext & !(parser & PARSE_BLNK_FEXT)) strcpy(fcb_name.part.ext,"   ");
-	fcb.SetName(fcb_name.part.drive[0],fcb_name.part.name,fcb_name.part.ext);
+	if (!hasname & !(parser & PARSE_BLNK_FNAME))
+		safe_strcpy(fcb_name.part.name, "        ");
+	if (!hasext & !(parser & PARSE_BLNK_FEXT))
+		safe_strcpy(fcb_name.part.ext, "   ");
+	fcb.SetName(fcb_name.part.drive[0], fcb_name.part.name, fcb_name.part.ext);
 	fcb.ClearBlockRecsize(); //Undocumented bonus work.
 	*change=(Bit8u)(string-string_begin);
 	return ret;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -259,7 +259,8 @@ static Bit32u read_kcl_data(Bit8u * kcl_data, Bit32u kcl_data_size, const char* 
 Bitu keyboard_layout::read_keyboard_file(const char* keyboard_file_name, Bit32s specific_layout, Bit32s requested_codepage) {
 	this->reset();
 
-	if (specific_layout==-1) strcpy(current_keyboard_file_name, keyboard_file_name);
+	if (specific_layout == -1)
+		safe_strcpy(current_keyboard_file_name, keyboard_file_name);
 	if (!strcmp(keyboard_file_name,"none")) return KEYB_NOERROR;
 
 	static Bit8u read_buf[65535];
@@ -701,7 +702,7 @@ Bit16u keyboard_layout::extract_codepage(const char* keyboard_file_name) {
 
 Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s codepage_id) {
 	char cp_filename[512];
-	strcpy(cp_filename, codepage_file_name);
+	safe_strcpy(cp_filename, codepage_file_name);
 	if (!strcmp(cp_filename,"none")) return KEYB_NOERROR;
 
 	if (codepage_id==dos.loaded_codepage) return KEYB_NOERROR;
@@ -967,7 +968,7 @@ Bitu keyboard_layout::switch_keyboard_layout(const char* new_layout, keyboard_la
 	if (strncasecmp(new_layout,"US",2)) {
 		// switch to a foreign layout
 		char tbuf[256];
-		strcpy(tbuf, new_layout);
+		safe_strcpy(tbuf, new_layout);
 		size_t newlen=strlen(tbuf);
 
 		bool language_code_found=false;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -377,7 +377,8 @@ public:
 					}
 					//Copy current directory if not marked as deleted.
 					if (newdrive->TestDir(ldp->curdir)) {
-						strcpy(newdrive->curdir, ldp->curdir);
+						safe_strcpy(newdrive->curdir,
+						            ldp->curdir);
 					}
 
 					delete Drives[drive - 'A'];
@@ -580,11 +581,11 @@ private:
 		Section* dos_sec = control->GetSection("dos");
 		dos_sec->ExecuteDestroy(false);
 		char test[20];
-		strcpy(test,"umb=false");
+		safe_strcpy(test, "umb=false");
 		dos_sec->HandleInputline(test);
-		strcpy(test,"xms=false");
+		safe_strcpy(test, "xms=false");
 		dos_sec->HandleInputline(test);
-		strcpy(test,"ems=false");
+		safe_strcpy(test, "ems=false");
 		dos_sec->HandleInputline(test);
 		dos_sec->ExecuteInit(false);
      }
@@ -1514,10 +1515,10 @@ void KEYB::Run(void) {
 				char cp_file_name[256];
 				if (cmd->FindCommand(3,cp_string)) {
 					/* third parameter is codepage file */
-					strcpy(cp_file_name, cp_string.c_str());
+					safe_strcpy(cp_file_name, cp_string.c_str());
 				} else {
 					/* no codepage file specified, use automatic selection */
-					strcpy(cp_file_name, "auto");
+					safe_strcpy(cp_file_name, "auto");
 				}
 
 				keyb_error=DOS_LoadKeyboardLayout(temp_line.c_str(), tried_cp, cp_file_name);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -477,8 +477,10 @@ int isoDrive :: readDirEntry(isoDirEntry *de, Bit8u *data) {
 	// modify file identifier for use with dosbox
 	if ((de->length < 33 + de->fileIdentLength)) return -1;
 	if (IS_DIR(FLAGS2)) {
-		if (de->fileIdentLength == 1 && de->ident[0] == 0) strcpy((char*)de->ident, ".");
-		else if (de->fileIdentLength == 1 && de->ident[0] == 1) strcpy((char*)de->ident, "..");
+		if (de->fileIdentLength == 1 && de->ident[0] == 0)
+			strcpy(reinterpret_cast<char *>(de->ident), ".");
+		else if (de->fileIdentLength == 1 && de->ident[0] == 1)
+			strcpy(reinterpret_cast<char *>(de->ident), "..");
 		else {
 			if (de->fileIdentLength > 200) return -1;
 			de->ident[de->fileIdentLength] = 0;
@@ -498,7 +500,7 @@ int isoDrive :: readDirEntry(isoDirEntry *de, Bit8u *data) {
 	if (dotpos!=NULL) {
 		if (strlen(dotpos)>4) dotpos[4]=0;
 		if (dotpos-(char*)de->ident>8) {
-			strcpy((char*)(&de->ident[8]),dotpos);
+			strcpy(reinterpret_cast<char *>(&de->ident[8]), dotpos);
 		}
 	} else if (strlen((char*)de->ident)>8) de->ident[8]=0;
 	return de->length;

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -152,7 +152,7 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
 
 	if (!error) {
 		if (loadImage()) {
-			strcpy(info, "isoDrive ");
+			safe_strcpy(info, "isoDrive ");
 			strcat(info, fileName);
 			this->driveLetter = driveLetter;
 			this->mediaid = mediaid;
@@ -161,12 +161,12 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
 			Set_Label(buffer,discLabel,true);
 
 		} else if (CDROM_Interface_Image::images[subUnit]->HasDataTrack() == false) { //Audio only cdrom
-			strcpy(info, "isoDrive ");
+			safe_strcpy(info, "isoDrive ");
 			strcat(info, fileName);
 			this->driveLetter = driveLetter;
 			this->mediaid = mediaid;
 			char buffer[32] = { 0 };
-			strcpy(buffer, "Audio_CD");
+			safe_strcpy(buffer, "Audio_CD");
 			Set_Label(buffer,discLabel,true);
 		} else error = 6; //Corrupt image
 	}
@@ -296,7 +296,7 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 			char findName[DOS_NAMELENGTH_ASCII];		
 			findName[0] = 0;
 			if(strlen((char*)de.ident) < DOS_NAMELENGTH_ASCII) {
-				strcpy(findName, (char*)de.ident);
+				safe_strcpy(findName, (char *)de.ident);
 				upcase(findName);
 			}
 			Bit32u findSize = DATA_LENGTH(de);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -36,7 +36,7 @@
 bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/) {
 //TODO Maybe care for attributes but not likely
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	char* temp_name = dirCache.GetExpandName(newname); //Can only be used in till a new drive_cache action is preformed */
@@ -82,7 +82,7 @@ bool localDrive::FileOpen(DOS_File** file, char * name, Bit32u flags) {
 		return false;
 	}
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
@@ -172,7 +172,7 @@ bool localDrive::FileOpen(DOS_File** file, char * name, Bit32u flags) {
 FILE * localDrive::GetSystemFilePtr(char const * const name, char const * const type) {
 
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
@@ -191,7 +191,7 @@ bool localDrive::GetSystemFilename(char *sysName, char const * const dosName) {
 
 bool localDrive::FileUnlink(char * name) {
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	char *fullname = dirCache.GetExpandName(newname);
@@ -232,7 +232,7 @@ bool localDrive::FileUnlink(char * name) {
 
 bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	char tempDir[CROSS_LEN];
-	strcpy(tempDir,basedir);
+	safe_strcpy(tempDir, basedir);
 	strcat(tempDir,_dir);
 	CROSS_FILENAME(tempDir);
 
@@ -248,7 +248,7 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}
-	strcpy(srchInfo[id].srch_dir,tempDir);
+	safe_strcpy(srchInfo[id].srch_dir, tempDir);
 	dta.SetDirID(id);
 	
 	Bit8u sAttr;
@@ -303,13 +303,13 @@ again:
 	}
 	if (!WildFileCmp(dir_ent,srch_pattern)) goto again;
 
-	strcpy(full_name,srchInfo[id].srch_dir);
+	safe_strcpy(full_name, srchInfo[id].srch_dir);
 	strcat(full_name,dir_ent);
 	
 	//GetExpandName might indirectly destroy dir_ent (by caching in a new directory 
 	//and due to its design dir_ent might be lost.)
 	//Copying dir_ent first
-	strcpy(dir_entcopy,dir_ent);
+	safe_strcpy(dir_entcopy, dir_ent);
 	if (stat(dirCache.GetExpandName(full_name),&stat_block)!=0) { 
 		goto again;//No symlinks and such
 	}	
@@ -322,7 +322,7 @@ again:
 	char find_name[DOS_NAMELENGTH_ASCII];Bit16u find_date,find_time;Bit32u find_size;
 
 	if (strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII) {
-		strcpy(find_name,dir_entcopy);
+		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	} 
 
@@ -341,7 +341,7 @@ again:
 
 bool localDrive::GetFileAttr(char * name,Bit16u * attr) {
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
@@ -358,7 +358,7 @@ bool localDrive::GetFileAttr(char * name,Bit16u * attr) {
 
 bool localDrive::MakeDir(char * dir) {
 	char newdir[CROSS_LEN];
-	strcpy(newdir,basedir);
+	safe_strcpy(newdir, basedir);
 	strcat(newdir,dir);
 	CROSS_FILENAME(newdir);
 #if defined (WIN32)						/* MS Visual C++ */
@@ -373,7 +373,7 @@ bool localDrive::MakeDir(char * dir) {
 
 bool localDrive::RemoveDir(char * dir) {
 	char newdir[CROSS_LEN];
-	strcpy(newdir,basedir);
+	safe_strcpy(newdir, basedir);
 	strcat(newdir,dir);
 	CROSS_FILENAME(newdir);
 	int temp=rmdir(dirCache.GetExpandName(newdir));
@@ -383,7 +383,7 @@ bool localDrive::RemoveDir(char * dir) {
 
 bool localDrive::TestDir(char * dir) {
 	char newdir[CROSS_LEN];
-	strcpy(newdir,basedir);
+	safe_strcpy(newdir, basedir);
 	strcat(newdir,dir);
 	CROSS_FILENAME(newdir);
 	dirCache.ExpandName(newdir);
@@ -401,13 +401,13 @@ bool localDrive::TestDir(char * dir) {
 
 bool localDrive::Rename(char * oldname,char * newname) {
 	char newold[CROSS_LEN];
-	strcpy(newold,basedir);
+	safe_strcpy(newold, basedir);
 	strcat(newold,oldname);
 	CROSS_FILENAME(newold);
 	dirCache.ExpandName(newold);
 	
 	char newnew[CROSS_LEN];
-	strcpy(newnew,basedir);
+	safe_strcpy(newnew, basedir);
 	strcat(newnew,newname);
 	CROSS_FILENAME(newnew);
 	int temp=rename(newold,dirCache.GetExpandName(newnew));
@@ -426,7 +426,7 @@ bool localDrive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,
 
 bool localDrive::FileExists(const char* name) {
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
@@ -438,7 +438,7 @@ bool localDrive::FileExists(const char* name) {
 
 bool localDrive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
+	safe_strcpy(newname, basedir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
@@ -487,7 +487,7 @@ localDrive::localDrive(const char * startdir,
 	             _free_clusters,
 	             _mediaid}
 {
-	strcpy(basedir, startdir);
+	safe_strcpy(basedir, startdir);
 	sprintf(info,"local directory %s",startdir);
 	dirCache.SetBaseDir(basedir);
 }
@@ -627,7 +627,7 @@ cdromDrive::cdromDrive(const char _driveLetter,
 {
 	// Init mscdex
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
-	strcpy(info, "CDRom ");
+	safe_strcpy(info, "CDRom ");
 	strcat(info, startdir);
 	// Get Volume Label
 	char name[32];

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -87,14 +87,14 @@ bool Overlay_Drive::RemoveDir(char * dir) {
 	if (is_dir_only_in_overlay(dir)) {
 		//The simple case
 		char odir[CROSS_LEN];
-		strcpy(odir,overlaydir);
+		safe_strcpy(odir, overlaydir);
 		strcat(odir,dir);
 		CROSS_FILENAME(odir);
 		int temp = rmdir(odir);
 		if (temp == 0) {
 			remove_DOSdir_from_cache(dir);
 			char newdir[CROSS_LEN];
-			strcpy(newdir,basedir);
+			safe_strcpy(newdir, basedir);
 			strcat(newdir,dir);
 			CROSS_FILENAME(newdir);
 			dirCache.DeleteEntry(newdir,true);
@@ -154,7 +154,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 		return true;
 	}
 	char newdir[CROSS_LEN];
-	strcpy(newdir,overlaydir);
+	safe_strcpy(newdir, overlaydir);
 	strcat(newdir,dir);
 	CROSS_FILENAME(newdir);
 #if defined (WIN32)						/* MS Visual C++ */
@@ -164,7 +164,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 #endif
 	if (temp==0) {
 		char fakename[CROSS_LEN];
-		strcpy(fakename,basedir);
+		safe_strcpy(fakename, basedir);
 		strcat(fakename,dir);
 		CROSS_FILENAME(fakename);
 		dirCache.AddEntryDirOverlay(fakename,true);
@@ -180,7 +180,7 @@ bool Overlay_Drive::TestDir(char * dir) {
 
 	//Directories are stored without a trailing backslash
 	char tempdir[CROSS_LEN];
-	strcpy(tempdir,dir);
+	safe_strcpy(tempdir, dir);
 	size_t templen = strlen(dir);
 	if (templen && tempdir[templen-1] == '\\') tempdir[templen-1] = 0;
 
@@ -234,7 +234,8 @@ FILE* Overlay_Drive::create_file_in_overlay(char* dos_filename, char const* mode
 
 	if (logoverlay) LOG_MSG("create_file_in_overlay called %s %s",dos_filename,mode);
 	char newname[CROSS_LEN];
-	strcpy(newname,overlaydir); //TODO GOG make part of class and join in 
+	safe_strcpy(newname, overlaydir); // TODO GOG make part of class and
+	                                  // join in
 	strcat(newname,dos_filename); //HERE we need to convert it to Linux TODO
 	CROSS_FILENAME(newname);
 
@@ -324,7 +325,7 @@ Overlay_Drive::Overlay_Drive(const char * startdir,const char* overlay, Bit16u _
 		error = 1;
 		return;
 	}
-	strcpy(overlaydir,overlay);
+	safe_strcpy(overlaydir, overlay);
 	char dirname[CROSS_LEN] = { 0 };
 	//Determine if overlaydir is part of the startdir.
 	convert_overlay_to_DOSname_in_base(dirname);
@@ -350,7 +351,7 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 #endif
 			//Beginning is the same.
 			char t[CROSS_LEN];
-			strcpy(t,overlaydir+strlen(basedir));
+			safe_strcpy(t, overlaydir + strlen(basedir));
 
 			char* p = t;
 			char* b = t;
@@ -358,11 +359,11 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 			while ( (p =strchr(p,CROSS_FILESPLIT)) ) {
 				char directoryname[CROSS_LEN]={0};
 				char dosboxdirname[CROSS_LEN]={0};
-				strcpy(directoryname,dirname);
+				safe_strcpy(directoryname, dirname);
 				strncat(directoryname,b,p-b);
 
 				char d[CROSS_LEN];
-				strcpy(d,basedir);
+				safe_strcpy(d, basedir);
 				strcat(d,directoryname);
 				CROSS_FILENAME(d);
 				//Try to find the corresponding directoryname in DOSBox.
@@ -419,7 +420,7 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 	//if name exists, use that one instead!
 	//overlay file.
 	char newname[CROSS_LEN];
-	strcpy(newname,overlaydir);
+	safe_strcpy(newname, overlaydir);
 	strcat(newname,name);
 	CROSS_FILENAME(newname);
 
@@ -473,7 +474,7 @@ bool Overlay_Drive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes
 	*file = of;
 	//create fake name for the drive cache
 	char fakename[CROSS_LEN];
-	strcpy(fakename,basedir);
+	safe_strcpy(fakename, basedir);
 	strcat(fakename,name);
 	CROSS_FILENAME(fakename);
 	dirCache.AddEntry(fakename,true); //add it.
@@ -507,7 +508,7 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 		if (logoverlay) LOG_MSG("syncdir: %s",dirname);
 		//Test if directory exist in base.
 		char dirnamebase[CROSS_LEN] ={0};
-		strcpy(dirnamebase,basedir);
+		safe_strcpy(dirnamebase, basedir);
 		strcat(dirnamebase,dirname);
 		CROSS_FILENAME(dirnamebase);
 		struct stat basetest;
@@ -518,7 +519,7 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 
 			struct stat overlaytest;
 			char dirnameoverlay[CROSS_LEN] ={0};
-			strcpy(dirnameoverlay,overlaydir);
+			safe_strcpy(dirnameoverlay, overlaydir);
 			strcat(dirnameoverlay,dirname);
 			CROSS_FILENAME(dirnameoverlay);
 			if (stat(dirnameoverlay,&overlaytest) == 0 ) {
@@ -608,16 +609,16 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 
 #if OVERLAY_DIR
 			char tdir[CROSS_LEN];
-			strcpy(tdir,(*i).c_str());
+			safe_strcpy(tdir, (*i).c_str());
 			CROSS_DOSFILENAME(tdir);
 			bool dir_exists_in_base = localDrive::TestDir(tdir);
 #endif
 
 			char dir[CROSS_LEN];
-			strcpy(dir,overlaydir);
+			safe_strcpy(dir, overlaydir);
 			strcat(dir,(*i).c_str());
 			char dirpush[CROSS_LEN];
-			strcpy(dirpush,(*i).c_str());
+			safe_strcpy(dirpush, (*i).c_str());
 			static char end[2] = {CROSS_FILESPLIT,0};
 			strcat(dirpush,end); //Linux ?
 			dir_information* dirp = open_directory(dir);
@@ -653,7 +654,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 	if (read_directory_contents) {
 		for( i = filenames.begin(); i != filenames.end(); ++i) {
 			char dosname[CROSS_LEN];
-			strcpy(dosname,(*i).c_str());
+			safe_strcpy(dosname, (*i).c_str());
 			upcase(dosname);  //Should not be really needed, as uppercase in the overlay is a requirement...
 			CROSS_DOSFILENAME(dosname);
 			if (logoverlay) LOG_MSG("update cache add dosname %s",dosname);
@@ -664,7 +665,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 #if OVERLAY_DIR
 	for (i = DOSdirs_cache.begin(); i !=DOSdirs_cache.end(); ++i) {
 		char fakename[CROSS_LEN];
-		strcpy(fakename,basedir);
+		safe_strcpy(fakename, basedir);
 		strcat(fakename,(*i).c_str());
 		CROSS_FILENAME(fakename);
 		dirCache.AddEntryDirOverlay(fakename,true);
@@ -673,7 +674,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 
 	for (i = DOSnames_cache.begin(); i != DOSnames_cache.end(); ++i) {
 		char fakename[CROSS_LEN];
-		strcpy(fakename,basedir);
+		safe_strcpy(fakename, basedir);
 		strcat(fakename,(*i).c_str());
 		CROSS_FILENAME(fakename);
 		dirCache.AddEntry(fakename,true);
@@ -742,20 +743,20 @@ again:
 	}
 	if(!WildFileCmp(dir_ent,srch_pattern)) goto again;
 
-	strcpy(full_name,srchInfo[id].srch_dir);
+	safe_strcpy(full_name, srchInfo[id].srch_dir);
 	strcat(full_name,dir_ent);
 	
 	//GetExpandName might indirectly destroy dir_ent (by caching in a new directory 
 	//and due to its design dir_ent might be lost.)
 	//Copying dir_ent first
-	strcpy(dir_entcopy,dir_ent);
-	
+	safe_strcpy(dir_entcopy, dir_ent);
+
 	//First try overlay:
 	char ovname[CROSS_LEN];
 	char relativename[CROSS_LEN];
-	strcpy(relativename,srchInfo[id].srch_dir);
+	safe_strcpy(relativename, srchInfo[id].srch_dir);
 	//strip off basedir: //TODO cleanup
-	strcpy(ovname,overlaydir);
+	safe_strcpy(ovname, overlaydir);
 	char* prel = full_name + strlen(basedir);
 
 	
@@ -777,7 +778,7 @@ again:
 		if (logoverlay) LOG_MSG("using overlay data for %s : %s",full_name, ovname);
 	} else {
 		char preldos[CROSS_LEN];
-		strcpy(preldos,prel);
+		safe_strcpy(preldos, prel);
 		CROSS_DOSFILENAME(preldos);
 		if (is_deleted_file(preldos)) { //dir.. maybe lower or keep it as is TODO
 			if (logoverlay) LOG_MSG("skipping deleted file %s %s %s",preldos,full_name,ovname);
@@ -798,7 +799,7 @@ again:
 	char find_name[DOS_NAMELENGTH_ASCII];Bit16u find_date,find_time;Bit32u find_size;
 
 	if(strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII){
-		strcpy(find_name,dir_entcopy);
+		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	} 
 
@@ -822,13 +823,13 @@ bool Overlay_Drive::FileUnlink(char * name) {
 	Bit32u a = GetTicks();
 	if (logoverlay) LOG_MSG("calling unlink on %s",name);
 	char basename[CROSS_LEN];
-	strcpy(basename,basedir);
+	safe_strcpy(basename, basedir);
 	strcat(basename,name);
 	CROSS_FILENAME(basename);
 
 
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
+	safe_strcpy(overlayname, overlaydir);
 	strcat(overlayname,name);
 	CROSS_FILENAME(overlayname);
 //	char *fullname = dirCache.GetExpandName(newname);
@@ -898,7 +899,7 @@ bool Overlay_Drive::FileUnlink(char * name) {
 
 bool Overlay_Drive::GetFileAttr(char * name,Bit16u * attr) {
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
+	safe_strcpy(overlayname, overlaydir);
 	strcat(overlayname,name);
 	CROSS_FILENAME(overlayname);
 
@@ -930,7 +931,7 @@ void Overlay_Drive::add_deleted_file(const char* name,bool create_on_disk) {
 void Overlay_Drive::add_special_file_to_disk(const char* dosname, const char* operation) {
 	std::string name = create_filename_of_special_operation(dosname, operation);
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
+	safe_strcpy(overlayname, overlaydir);
 	strcat(overlayname,name.c_str());
 	CROSS_FILENAME(overlayname);
 	FILE* f = fopen_wrap(overlayname,"wb+");
@@ -947,7 +948,7 @@ void Overlay_Drive::add_special_file_to_disk(const char* dosname, const char* op
 void Overlay_Drive::remove_special_file_from_disk(const char* dosname, const char* operation) {
 	std::string name = create_filename_of_special_operation(dosname,operation);
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
+	safe_strcpy(overlayname, overlaydir);
 	strcat(overlayname,name.c_str());
 	CROSS_FILENAME(overlayname);
 	if(unlink(overlayname) != 0) E_Exit("Failed removal of %s",overlayname);
@@ -1056,7 +1057,7 @@ bool Overlay_Drive::check_if_leading_is_deleted(const char* name){
 
 bool Overlay_Drive::FileExists(const char* name) {
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
+	safe_strcpy(overlayname, overlaydir);
 	strcat(overlayname,name);
 	CROSS_FILENAME(overlayname);
 	struct stat temp_stat;
@@ -1090,12 +1091,12 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 	Bit32u a = GetTicks();
 	//First generate overlay names.
 	char overlaynameold[CROSS_LEN];
-	strcpy(overlaynameold,overlaydir);
+	safe_strcpy(overlaynameold, overlaydir);
 	strcat(overlaynameold,oldname);
 	CROSS_FILENAME(overlaynameold);
 
 	char overlaynamenew[CROSS_LEN];
-	strcpy(overlaynamenew,overlaydir);
+	safe_strcpy(overlaynamenew, overlaydir);
 	strcat(overlaynamenew,newname);
 	CROSS_FILENAME(overlaynamenew);
 
@@ -1113,7 +1114,7 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		Bit32u aa = GetTicks();
 		//File exists in the basedrive. Make a copy and mark old one as deleted.
 		char newold[CROSS_LEN];
-		strcpy(newold,basedir);
+		safe_strcpy(newold, basedir);
 		strcat(newold,oldname);
 		CROSS_FILENAME(newold);
 		dirCache.ExpandName(newold);
@@ -1161,7 +1162,7 @@ bool Overlay_Drive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 
 bool Overlay_Drive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
+	safe_strcpy(overlayname, overlaydir);
 	strcat(overlayname,name);
 	CROSS_FILENAME(overlayname);
 	struct stat temp_stat;

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -100,7 +100,7 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 			return 0;
 		}
 	}
-	strcpy(file_start,RunningProgram);
+	safe_strcpy(file_start, RunningProgram);
 	lowcase(file_start);
 	strcat(file_start,"_");
 	bool is_directory;

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -979,7 +979,7 @@ public:
 					WriteOut("IPX Server address not specified.\n");
 					return;
 				}
-				strcpy(strHost, temp_line.c_str());
+				safe_strcpy(strHost, temp_line.c_str());
 
 				if(!cmd->FindCommand(3, temp_line)) {
 					udpPort = 213;

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -312,7 +312,7 @@ bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_direc
 	static char buffer[2 * CROSS_LEN + 1] = { 0 };
 	static char split[2] = { CROSS_FILESPLIT , 0 };
 	buffer[0] = 0;
-	strcpy(buffer,dirp->base_path);
+	safe_strcpy(buffer, dirp->base_path);
 	size_t buflen = strlen(buffer);
 	if (buflen && buffer[buflen - 1] != CROSS_FILESPLIT ) strcat(buffer, split);
 	strcat(buffer,entry_name);

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -95,8 +95,8 @@ static void LoadMessageFile(const char * fname) {
 		/* New string name */
 		if (linein[0]==':') {
 			string[0]=0;
-			strcpy(name,linein+1);
-		/* End of string marker */
+			safe_strcpy(name, linein + 1);
+			/* End of string marker */
 		} else if (linein[0]=='.') {
 			/* Replace/Add the string to the internal languagefile */
 			/* Remove last newline (marker is \n.\n) */

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -329,7 +329,7 @@ void DOS_Shell::Run(void) {
 	char input_line[CMD_MAXLINE] = {0};
 	std::string line;
 	if (cmd->FindStringRemainBegin("/C",line)) {
-		strcpy(input_line,line.c_str());
+		safe_strcpy(input_line, line.c_str());
 		char* sep = strpbrk(input_line,"\r\n"); //GTA installer
 		if (sep) *sep = 0;
 		DOS_Shell temp;
@@ -351,7 +351,7 @@ void DOS_Shell::Run(void) {
 		if (machine == MCH_HERC) WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
 		WriteOut(MSG_Get("SHELL_STARTUP_END"));
 
-		strcpy(input_line,line.c_str());
+		safe_strcpy(input_line, line.c_str());
 		line.erase();
 		ParseLine(input_line);
 	} else {
@@ -775,7 +775,7 @@ void SHELL_Init() {
 	CommandTail tail;
 	tail.count=(Bit8u)strlen(init_line);
 	memset(&tail.buffer,0,127);
-	strcpy(tail.buffer,init_line);
+	safe_strcpy(tail.buffer, init_line);
 	MEM_BlockWrite(PhysMake(psp_seg,128),&tail,128);
 
 	/* Setup internal DOS Variables */

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -268,7 +268,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 
 		//dir_source and target are introduced for when we support multiple files being renamed.
 		char target[DOS_PATHLENGTH+CROSS_LEN + 5] = {0};
-		strcpy(target,dir_source);
+		safe_strcpy(target, dir_source);
 		strncat(target,args,CROSS_LEN);
 
 		DOS_Rename(arg1,target);
@@ -874,12 +874,12 @@ void DOS_Shell::CMD_COPY(char * args) {
 			dta.GetResult(name,size,date,time,attr);
 
 			if ((attr & DOS_ATTR_DIRECTORY) == 0) {
-				strcpy(nameSource,pathSource);
+				safe_strcpy(nameSource, pathSource);
 				strcat(nameSource,name);
 				// Open Source
 				if (DOS_OpenFile(nameSource,0,&sourceHandle)) {
 					// Create Target or open it if in concat mode
-					strcpy(nameTarget,pathTarget);
+					safe_strcpy(nameTarget, pathTarget);
 					if (nameTarget[strlen(nameTarget) - 1] == '\\') strcat(nameTarget,name);
 
 					//Special variable to ensure that copy * a_file, where a_file is not a directory concats.
@@ -1248,7 +1248,7 @@ void DOS_Shell::CMD_SUBST (char * args) {
 	char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
 	char temp_str[2] = { 0,0 };
 	try {
-		strcpy(mountstring,"MOUNT ");
+		safe_strcpy(mountstring, "MOUNT ");
 		StripSpaces(args);
 		std::string arg;
 		CommandLine command(0,args);
@@ -1275,7 +1275,7 @@ void DOS_Shell::CMD_SUBST (char * args) {
 
 		if ( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
 		char newname[CROSS_LEN];
-		strcpy(newname, ldp->getBasedir());
+		safe_strcpy(newname, ldp->getBasedir());
 		strcat(newname,fulldir);
 		CROSS_FILENAME(newname);
 		ldp->dirCache.ExpandName(newname);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -962,7 +963,14 @@ void DOS_Shell::CMD_SET(char * args) {
 				if (GetEnvStr(p,temp)) {
 					std::string::size_type equals = temp.find('=');
 					if (equals == std::string::npos) continue;
-					strcpy(p_parsed,temp.substr(equals+1).c_str());
+					const uintptr_t remaining_len = (std::min)(
+					        sizeof(parsed) -
+					                static_cast<uintptr_t>(
+					                        p_parsed - parsed),
+					        sizeof(parsed));
+					safe_strncpy(p_parsed,
+					             temp.substr(equals + 1).c_str(),
+					             remaining_len);
 					p_parsed += strlen(p_parsed);
 				}
 				p = second;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -273,8 +273,8 @@ void DOS_Shell::InputCommand(char * line) {
 							strncat(mask, "*",DOS_PATHLENGTH - 1);
 						else strncat(mask, "*.*",DOS_PATHLENGTH - 1);
 					} else {
-						strcpy(mask, "*.*");
-					}
+					        safe_strcpy(mask, "*.*");
+				        }
 
 					RealPt save_dta=dos.dta();
 					dos.dta(dos.tables.tempdta);
@@ -413,7 +413,7 @@ bool DOS_Shell::Execute(char * name,char * args) {
 	/* Check for a full name */
 	p_fullname = Which(name);
 	if (!p_fullname) return false;
-	strcpy(fullname,p_fullname);
+	safe_strcpy(fullname, p_fullname);
 	const char* extension = strrchr(fullname,'.');
 	
 	/*always disallow files without extension from being executed. */
@@ -424,22 +424,22 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		if(strlen(fullname) >( DOS_PATHLENGTH - 1) ) return false;
 		char temp_name[DOS_PATHLENGTH+4],* temp_fullname;
 		//try to add .com, .exe and .bat extensions to filename
-		
-		strcpy(temp_name,fullname);
+
+		safe_strcpy(temp_name, fullname);
 		strcat(temp_name,".COM");
 		temp_fullname=Which(temp_name);
 		if (temp_fullname) { extension=".com";strcpy(fullname,temp_fullname); }
 
 		else 
 		{
-			strcpy(temp_name,fullname);
+			safe_strcpy(temp_name, fullname);
 			strcat(temp_name,".EXE");
 			temp_fullname=Which(temp_name);
 		 	if (temp_fullname) { extension=".exe";strcpy(fullname,temp_fullname);}
 
 			else 
 			{
-				strcpy(temp_name,fullname);
+				safe_strcpy(temp_name, fullname);
 				strcat(temp_name,".BAT");
 				temp_fullname=Which(temp_name);
 		 		if (temp_fullname) { extension=".bat";strcpy(fullname,temp_fullname);}


### PR DESCRIPTION
This commits covers a single class of string-copy issues, all of which involve writing an unchecked quantity of bytes into a string of a fixed length (ie: char[]).

This should address a decent number of issues flagged by Coverity:

![Screenshot at 2020-04-29 18-25-06](https://user-images.githubusercontent.com/1557255/80662714-cf63f600-8a46-11ea-9db7-94b4c6102907.png)



