### PR TITLE
Scan Windows release packages using Microsoft Defender

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,7 +142,7 @@ jobs:
           # Create tarball
           tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
 
-      - name: AV scan
+      - name: Clam AV scan
         run: |
           set -x
           sudo apt-get install clamav > /dev/null

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -144,7 +144,7 @@ jobs:
               -srcfolder dist \
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
 
-      - name: AV scan
+      - name: Clam AV scan
         run: |
           set -x
           brew install clamav > /dev/null

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -169,6 +169,18 @@ jobs:
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
           # Create dir for zipping
           mv dest dosbox-staging-windows-${{ env.VERSION }}
+
+      - name: Windows Defender AV Scan
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dosboxDir = "${{ github.workspace }}/dosbox-staging-windows-${{ env.VERSION }}"
+          & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
+          if( $LASTEXITCODE -ne 0 ) {
+              Get-Content -Path $env:TEMP\MpCmdRun.log
+              Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
+          }
+
       - name: Upload package
         uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
This completes the push to virus scan all of our release packages (fixes #333).

Thank you @simonsan for the initial powershell help and encouragement, and to @dragonwolf83 for investigating and authoring the exact powershell calls used in this commit.

Things aren't perfect, but they're the best we can do given what we have to work with. For example:

- We cannot update the virus signatures, because [that command simply fails](https://user-images.githubusercontent.com/1557255/80660803-98d7ac80-8a41-11ea-91b3-5b75aec71fc2.png), despite being copy-and-pasted from Microsoft's documentation. 

- When queried, Windows [reports its virus signature age is 4,294,967,295 days old](https://user-images.githubusercontent.com/1557255/80661978-05a07600-8a45-11ea-95a0-cc0e254edb43.png), which, on geological time scales, predates even the Pleistocene era by 9.7 million years. 

Despite these issues, my hunch is that the signatures are current as of the date when the VM's base-image was generated; and because we're in the Holocene era of zero-day network threats, my guess is GitHub is re-generating images at least weekly if not more frequently (and sure enough, [Defender catches the EICAR dummy virus](https://user-images.githubusercontent.com/1557255/80776515-6bf5c900-8b17-11ea-9188-d5a484d49b2a.png)).

@dragonwolf83 included a comment stating _that we're not using `Start-MpScan` because it does not provide any useful output on status of scans_ (indeed!). I've noted that comment in  the commit message for future maintainers.