### PR TITLE
Limit string concatenation to the target's length

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -705,9 +705,9 @@ public:
 							strncpy(buf,(char*)&rombuf[ct+1],clen);
 							buf[clen]=0;
 							upcase(buf);
-							strcat(cmdlist," ");
-							strcat(cmdlist,buf);
-							ct+=1+clen+3;
+							safe_strcat(cmdlist, " ");
+							safe_strcat(cmdlist, buf);
+							ct += 1 + clen + 3;
 							if (ct>sizeof(cmdlist)) break;
 							clen=rombuf[ct];
 						}
@@ -725,9 +725,9 @@ public:
 							strncpy(buf,(char*)&rombuf[ct+1],clen);
 							buf[clen]=0;
 							upcase(buf);
-							strcat(cmdlist," ");
-							strcat(cmdlist,buf);
-							ct+=1+clen;
+							safe_strcat(cmdlist, " ");
+							safe_strcat(cmdlist, buf);
+							ct += 1 + clen;
 
 							if (cart_cmd==buf) {
 								cfound_at=ct;
@@ -1060,8 +1060,8 @@ void LOADFIX::Run(void)
 				ok = cmd->FindCommand(commandNr++,temp_line);
 				if (sizeof(args) - strlen(args) - 1 < temp_line.length() + 1)
 					break;
-				strcat(args,temp_line.c_str());
-				strcat(args," ");
+				safe_strcat(args, temp_line.c_str());
+				safe_strcat(args, " ");
 			} while (ok);
 			// Use shell to start program
 			DOS_Shell shell;

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -153,7 +153,7 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
 	if (!error) {
 		if (loadImage()) {
 			safe_strcpy(info, "isoDrive ");
-			strcat(info, fileName);
+			safe_strcat(info, fileName);
 			this->driveLetter = driveLetter;
 			this->mediaid = mediaid;
 			char buffer[32] = { 0 };
@@ -162,7 +162,7 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
 
 		} else if (CDROM_Interface_Image::images[subUnit]->HasDataTrack() == false) { //Audio only cdrom
 			safe_strcpy(info, "isoDrive ");
-			strcat(info, fileName);
+			safe_strcat(info, fileName);
 			this->driveLetter = driveLetter;
 			this->mediaid = mediaid;
 			char buffer[32] = { 0 };

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -37,7 +37,7 @@ bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/)
 //TODO Maybe care for attributes but not likely
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	char* temp_name = dirCache.GetExpandName(newname); //Can only be used in till a new drive_cache action is preformed */
 	/* Test if file exists (so we need to truncate it). don't add to dirCache then */
@@ -83,7 +83,7 @@ bool localDrive::FileOpen(DOS_File** file, char * name, Bit32u flags) {
 	}
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 
@@ -173,7 +173,7 @@ FILE * localDrive::GetSystemFilePtr(char const * const name, char const * const 
 
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 
@@ -192,7 +192,7 @@ bool localDrive::GetSystemFilename(char *sysName, char const * const dosName) {
 bool localDrive::FileUnlink(char * name) {
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	char *fullname = dirCache.GetExpandName(newname);
 	if (unlink(fullname)) {
@@ -233,7 +233,7 @@ bool localDrive::FileUnlink(char * name) {
 bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	char tempDir[CROSS_LEN];
 	safe_strcpy(tempDir, basedir);
-	strcat(tempDir,_dir);
+	safe_strcat(tempDir, _dir);
 	CROSS_FILENAME(tempDir);
 
 	if (allocation.mediaid==0xF0) {
@@ -241,8 +241,9 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	}
     
 	char end[2]={CROSS_FILESPLIT,0};
-	if (tempDir[strlen(tempDir)-1]!=CROSS_FILESPLIT) strcat(tempDir,end);
-	
+	if (tempDir[strlen(tempDir) - 1] != CROSS_FILESPLIT)
+		safe_strcat(tempDir, end);
+
 	Bit16u id;
 	if (!dirCache.FindFirst(tempDir,id)) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
@@ -304,8 +305,8 @@ again:
 	if (!WildFileCmp(dir_ent,srch_pattern)) goto again;
 
 	safe_strcpy(full_name, srchInfo[id].srch_dir);
-	strcat(full_name,dir_ent);
-	
+	safe_strcat(full_name, dir_ent);
+
 	//GetExpandName might indirectly destroy dir_ent (by caching in a new directory 
 	//and due to its design dir_ent might be lost.)
 	//Copying dir_ent first
@@ -342,7 +343,7 @@ again:
 bool localDrive::GetFileAttr(char * name,Bit16u * attr) {
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 
@@ -359,7 +360,7 @@ bool localDrive::GetFileAttr(char * name,Bit16u * attr) {
 bool localDrive::MakeDir(char * dir) {
 	char newdir[CROSS_LEN];
 	safe_strcpy(newdir, basedir);
-	strcat(newdir,dir);
+	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
 #if defined (WIN32)						/* MS Visual C++ */
 	int temp=mkdir(dirCache.GetExpandName(newdir));
@@ -374,7 +375,7 @@ bool localDrive::MakeDir(char * dir) {
 bool localDrive::RemoveDir(char * dir) {
 	char newdir[CROSS_LEN];
 	safe_strcpy(newdir, basedir);
-	strcat(newdir,dir);
+	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
 	int temp=rmdir(dirCache.GetExpandName(newdir));
 	if (temp==0) dirCache.DeleteEntry(newdir,true);
@@ -384,7 +385,7 @@ bool localDrive::RemoveDir(char * dir) {
 bool localDrive::TestDir(char * dir) {
 	char newdir[CROSS_LEN];
 	safe_strcpy(newdir, basedir);
-	strcat(newdir,dir);
+	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
 	dirCache.ExpandName(newdir);
 	// Skip directory test, if "\"
@@ -402,13 +403,13 @@ bool localDrive::TestDir(char * dir) {
 bool localDrive::Rename(char * oldname,char * newname) {
 	char newold[CROSS_LEN];
 	safe_strcpy(newold, basedir);
-	strcat(newold,oldname);
+	safe_strcat(newold, oldname);
 	CROSS_FILENAME(newold);
 	dirCache.ExpandName(newold);
 	
 	char newnew[CROSS_LEN];
 	safe_strcpy(newnew, basedir);
-	strcat(newnew,newname);
+	safe_strcat(newnew, newname);
 	CROSS_FILENAME(newnew);
 	int temp=rename(newold,dirCache.GetExpandName(newnew));
 	if (temp==0) dirCache.CacheOut(newnew);
@@ -427,7 +428,7 @@ bool localDrive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,
 bool localDrive::FileExists(const char* name) {
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	struct stat temp_stat;
@@ -439,7 +440,7 @@ bool localDrive::FileExists(const char* name) {
 bool localDrive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	struct stat temp_stat;
@@ -628,7 +629,7 @@ cdromDrive::cdromDrive(const char _driveLetter,
 	// Init mscdex
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	safe_strcpy(info, "CDRom ");
-	strcat(info, startdir);
+	safe_strcat(info, startdir);
 	// Get Volume Label
 	char name[32];
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -88,14 +88,14 @@ bool Overlay_Drive::RemoveDir(char * dir) {
 		//The simple case
 		char odir[CROSS_LEN];
 		safe_strcpy(odir, overlaydir);
-		strcat(odir,dir);
+		safe_strcat(odir, dir);
 		CROSS_FILENAME(odir);
 		int temp = rmdir(odir);
 		if (temp == 0) {
 			remove_DOSdir_from_cache(dir);
 			char newdir[CROSS_LEN];
 			safe_strcpy(newdir, basedir);
-			strcat(newdir,dir);
+			safe_strcat(newdir, dir);
 			CROSS_FILENAME(newdir);
 			dirCache.DeleteEntry(newdir,true);
 			update_cache(false);
@@ -155,7 +155,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 	}
 	char newdir[CROSS_LEN];
 	safe_strcpy(newdir, overlaydir);
-	strcat(newdir,dir);
+	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
 #if defined (WIN32)						/* MS Visual C++ */
 	int temp = mkdir(newdir);
@@ -165,7 +165,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 	if (temp==0) {
 		char fakename[CROSS_LEN];
 		safe_strcpy(fakename, basedir);
-		strcat(fakename,dir);
+		safe_strcat(fakename, dir);
 		CROSS_FILENAME(fakename);
 		dirCache.AddEntryDirOverlay(fakename,true);
 		add_DOSdir_to_cache(dir);
@@ -236,7 +236,8 @@ FILE* Overlay_Drive::create_file_in_overlay(char* dos_filename, char const* mode
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, overlaydir); // TODO GOG make part of class and
 	                                  // join in
-	strcat(newname,dos_filename); //HERE we need to convert it to Linux TODO
+	safe_strcat(newname, dos_filename); // HERE we need to convert it to
+	                                    // Linux TODO
 	CROSS_FILENAME(newname);
 
 	FILE* f = fopen_wrap(newname,mode);
@@ -364,7 +365,7 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 
 				char d[CROSS_LEN];
 				safe_strcpy(d, basedir);
-				strcat(d,directoryname);
+				safe_strcat(d, directoryname);
 				CROSS_FILENAME(d);
 				//Try to find the corresponding directoryname in DOSBox.
 				if(!dirCache.GetShortName(d,dosboxdirname) ) {
@@ -421,7 +422,7 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 	//overlay file.
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, overlaydir);
-	strcat(newname,name);
+	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 
 	FILE * hand = fopen_wrap(newname,type);
@@ -475,7 +476,7 @@ bool Overlay_Drive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes
 	//create fake name for the drive cache
 	char fakename[CROSS_LEN];
 	safe_strcpy(fakename, basedir);
-	strcat(fakename,name);
+	safe_strcat(fakename, name);
 	CROSS_FILENAME(fakename);
 	dirCache.AddEntry(fakename,true); //add it.
 	add_DOSname_to_cache(name);
@@ -509,7 +510,7 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 		//Test if directory exist in base.
 		char dirnamebase[CROSS_LEN] ={0};
 		safe_strcpy(dirnamebase, basedir);
-		strcat(dirnamebase,dirname);
+		safe_strcat(dirnamebase, dirname);
 		CROSS_FILENAME(dirnamebase);
 		struct stat basetest;
 		if (stat(dirCache.GetExpandName(dirnamebase),&basetest) == 0 && basetest.st_mode & S_IFDIR) {
@@ -520,7 +521,7 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 			struct stat overlaytest;
 			char dirnameoverlay[CROSS_LEN] ={0};
 			safe_strcpy(dirnameoverlay, overlaydir);
-			strcat(dirnameoverlay,dirname);
+			safe_strcat(dirnameoverlay, dirname);
 			CROSS_FILENAME(dirnameoverlay);
 			if (stat(dirnameoverlay,&overlaytest) == 0 ) {
 				//item exist. Check if it is a folder, if not a folder =>fail!
@@ -616,11 +617,11 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 
 			char dir[CROSS_LEN];
 			safe_strcpy(dir, overlaydir);
-			strcat(dir,(*i).c_str());
+			safe_strcat(dir, (*i).c_str());
 			char dirpush[CROSS_LEN];
 			safe_strcpy(dirpush, (*i).c_str());
 			static char end[2] = {CROSS_FILESPLIT,0};
-			strcat(dirpush,end); //Linux ?
+			safe_strcat(dirpush, end); // Linux ?
 			dir_information* dirp = open_directory(dir);
 			if (dirp == NULL) continue;
 
@@ -666,7 +667,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 	for (i = DOSdirs_cache.begin(); i !=DOSdirs_cache.end(); ++i) {
 		char fakename[CROSS_LEN];
 		safe_strcpy(fakename, basedir);
-		strcat(fakename,(*i).c_str());
+		safe_strcat(fakename, (*i).c_str());
 		CROSS_FILENAME(fakename);
 		dirCache.AddEntryDirOverlay(fakename,true);
 	}
@@ -675,7 +676,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 	for (i = DOSnames_cache.begin(); i != DOSnames_cache.end(); ++i) {
 		char fakename[CROSS_LEN];
 		safe_strcpy(fakename, basedir);
-		strcat(fakename,(*i).c_str());
+		safe_strcat(fakename, (*i).c_str());
 		CROSS_FILENAME(fakename);
 		dirCache.AddEntry(fakename,true);
 	}
@@ -744,8 +745,8 @@ again:
 	if(!WildFileCmp(dir_ent,srch_pattern)) goto again;
 
 	safe_strcpy(full_name, srchInfo[id].srch_dir);
-	strcat(full_name,dir_ent);
-	
+	safe_strcat(full_name, dir_ent);
+
 	//GetExpandName might indirectly destroy dir_ent (by caching in a new directory 
 	//and due to its design dir_ent might be lost.)
 	//Copying dir_ent first
@@ -770,7 +771,7 @@ again:
 	}
 #endif
 
-	strcat(ovname,prel);
+	safe_strcat(ovname, prel);
 	bool statok = ( stat(ovname,&stat_block)==0);
 
 	if (logoverlay) LOG_MSG("listing %s",dir_entcopy);
@@ -824,13 +825,13 @@ bool Overlay_Drive::FileUnlink(char * name) {
 	if (logoverlay) LOG_MSG("calling unlink on %s",name);
 	char basename[CROSS_LEN];
 	safe_strcpy(basename, basedir);
-	strcat(basename,name);
+	safe_strcat(basename, name);
 	CROSS_FILENAME(basename);
 
 
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
-	strcat(overlayname,name);
+	safe_strcat(overlayname, name);
 	CROSS_FILENAME(overlayname);
 //	char *fullname = dirCache.GetExpandName(newname);
 	if (unlink(overlayname)) {
@@ -900,7 +901,7 @@ bool Overlay_Drive::FileUnlink(char * name) {
 bool Overlay_Drive::GetFileAttr(char * name,Bit16u * attr) {
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
-	strcat(overlayname,name);
+	safe_strcat(overlayname, name);
 	CROSS_FILENAME(overlayname);
 
 	struct stat status;
@@ -932,7 +933,7 @@ void Overlay_Drive::add_special_file_to_disk(const char* dosname, const char* op
 	std::string name = create_filename_of_special_operation(dosname, operation);
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
-	strcat(overlayname,name.c_str());
+	safe_strcat(overlayname, name.c_str());
 	CROSS_FILENAME(overlayname);
 	FILE* f = fopen_wrap(overlayname,"wb+");
 	if (!f) {
@@ -949,7 +950,7 @@ void Overlay_Drive::remove_special_file_from_disk(const char* dosname, const cha
 	std::string name = create_filename_of_special_operation(dosname,operation);
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
-	strcat(overlayname,name.c_str());
+	safe_strcat(overlayname, name.c_str());
 	CROSS_FILENAME(overlayname);
 	if(unlink(overlayname) != 0) E_Exit("Failed removal of %s",overlayname);
 }
@@ -1058,7 +1059,7 @@ bool Overlay_Drive::check_if_leading_is_deleted(const char* name){
 bool Overlay_Drive::FileExists(const char* name) {
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
-	strcat(overlayname,name);
+	safe_strcat(overlayname, name);
 	CROSS_FILENAME(overlayname);
 	struct stat temp_stat;
 	if(stat(overlayname,&temp_stat)==0 && (temp_stat.st_mode & S_IFDIR)==0) return true;
@@ -1092,12 +1093,12 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 	//First generate overlay names.
 	char overlaynameold[CROSS_LEN];
 	safe_strcpy(overlaynameold, overlaydir);
-	strcat(overlaynameold,oldname);
+	safe_strcat(overlaynameold, oldname);
 	CROSS_FILENAME(overlaynameold);
 
 	char overlaynamenew[CROSS_LEN];
 	safe_strcpy(overlaynamenew, overlaydir);
-	strcat(overlaynamenew,newname);
+	safe_strcat(overlaynamenew, newname);
 	CROSS_FILENAME(overlaynamenew);
 
 	//No need to check if the original is marked as deleted, as GetFileAttr would fail if it did.
@@ -1115,7 +1116,7 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		//File exists in the basedrive. Make a copy and mark old one as deleted.
 		char newold[CROSS_LEN];
 		safe_strcpy(newold, basedir);
-		strcat(newold,oldname);
+		safe_strcat(newold, oldname);
 		CROSS_FILENAME(newold);
 		dirCache.ExpandName(newold);
 		FILE* o = fopen_wrap(newold,"rb");
@@ -1163,7 +1164,7 @@ bool Overlay_Drive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 bool Overlay_Drive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
-	strcat(overlayname,name);
+	safe_strcat(overlayname, name);
 	CROSS_FILENAME(overlayname);
 	struct stat temp_stat;
 	if(stat(overlayname,&temp_stat) != 0) {

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -142,7 +142,8 @@ static void W32_ConfDir(std::string& in,bool create) {
 		safe_strncpy(result,windir,MAX_PATH);
 		char const* appdata = "\\Application Data";
 		size_t len = strlen(result);
-		if(len + strlen(appdata) < MAX_PATH) strcat(result,appdata);
+		if (len + strlen(appdata) < MAX_PATH)
+			safe_strcat(result, appdata);
 		if(create) mkdir(result);
 	}
 	in = result;
@@ -231,8 +232,10 @@ dir_information* open_directory(const char* dirname) {
 
 	safe_strncpy(dir.base_path,dirname,MAX_PATH);
 
-	if (dirname[len-1] == '\\') strcat(dir.base_path,"*.*");
-	else                        strcat(dir.base_path,"\\*.*");
+	if (dirname[len - 1] == '\\')
+		safe_strcat(dir.base_path, "*.*");
+	else
+		safe_strcat(dir.base_path, "\\*.*");
 
 	dir.handle = INVALID_HANDLE_VALUE;
 
@@ -314,8 +317,9 @@ bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_direc
 	buffer[0] = 0;
 	safe_strcpy(buffer, dirp->base_path);
 	size_t buflen = strlen(buffer);
-	if (buflen && buffer[buflen - 1] != CROSS_FILESPLIT ) strcat(buffer, split);
-	strcat(buffer,entry_name);
+	if (buflen && buffer[buflen - 1] != CROSS_FILESPLIT)
+		safe_strcat(buffer, split);
+	safe_strcat(buffer, entry_name);
 	struct stat status;
 
 	if (stat(buffer,&status) == 0) is_directory = (S_ISDIR(status.st_mode)>0);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -426,21 +426,21 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		//try to add .com, .exe and .bat extensions to filename
 
 		safe_strcpy(temp_name, fullname);
-		strcat(temp_name,".COM");
+		safe_strcat(temp_name, ".COM");
 		temp_fullname=Which(temp_name);
 		if (temp_fullname) { extension=".com";strcpy(fullname,temp_fullname); }
 
 		else 
 		{
 			safe_strcpy(temp_name, fullname);
-			strcat(temp_name,".EXE");
+			safe_strcat(temp_name, ".EXE");
 			temp_fullname=Which(temp_name);
 		 	if (temp_fullname) { extension=".exe";strcpy(fullname,temp_fullname);}
 
 			else 
 			{
 				safe_strcpy(temp_name, fullname);
-				strcat(temp_name,".BAT");
+				safe_strcat(temp_name, ".BAT");
 				temp_fullname=Which(temp_name);
 		 		if (temp_fullname) { extension=".bat";strcpy(fullname,temp_fullname);}
 
@@ -614,7 +614,7 @@ char * DOS_Shell::Which(char * name)
 			if(len >= (DOS_PATHLENGTH - 2)) continue;
 
 			if(path[len - 1] != '\\') {
-				strcat(path,"\\"); 
+				safe_strcat(path, "\\");
 				len++;
 			}
 


### PR DESCRIPTION
This commits covers a single class of string-cat issues, all of which involve writing an unchecked quantity of bytes into a string of a fixed length (ie: char[]).

Should knock off another round of memory handling issues flagged by Coverity:

![Screenshot at 2020-05-01 09-29-04](https://user-images.githubusercontent.com/1557255/80821766-393ae780-8b8e-11ea-8a29-ae8d471480a5.png)
