### PR TITLE
Fix compilation for devkit pro toolchain

### DIFF
--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -394,8 +394,8 @@ struct FM_OPL
 	//attotime TimerBase;         /* Timer base time (==sampling time)*/
 	device_t *device;
 
-	signed int phase_modulation;    /* phase modulation input (SLOT 2) */
-	signed int output[1];
+	int32_t phase_modulation;     /* phase modulation input (SLOT 2) */
+	int32_t output[1];
 #if BUILD_Y8950
 	int32_t output_deltat[4];     /* for Y8950 DELTA-T, chip is mono, that 4 here is just for safety */
 #endif

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -228,9 +228,9 @@ struct OPL3
 	uint32_t  pan[18*4];              /* channels output masks (0xffffffff = enable); 4 masks per one channel */
 	uint32_t  pan_ctrl_value[18];     /* output control values 1 per one channel (1 value contains 4 masks) */
 
-	signed int chanout[18];
-	signed int phase_modulation;        /* phase modulation input (SLOT 2) */
-	signed int phase_modulation2;   /* phase modulation input (SLOT 3 in 4 operator channels) */
+	int32_t chanout[18];
+	int32_t phase_modulation;         /* phase modulation input (SLOT 2) */
+	int32_t phase_modulation2;        /* phase modulation input (SLOT 3 in 4 operator channels) */
 
 	uint32_t  eg_cnt;                 /* global envelope generator counter    */
 	uint32_t  eg_timer;               /* global envelope generator counter works at frequency = chipclock/288 (288=8*36) */
@@ -1006,7 +1006,7 @@ number   number    BLK/FNUM2 FNUM    Drum  Hat   Drum  Tom  Cymbal
 static inline void chan_calc_rhythm(OPL3 *chip, OPL3_CH *CH, unsigned int noise)
 {
 	OPL3_SLOT *SLOT;
-	signed int *chanout = chip->chanout;
+	int32_t *chanout = chip->chanout;
 	signed int out;
 	unsigned int env;
 
@@ -2613,7 +2613,7 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
 {
 	int i;
 	OPL3        *chip  = (OPL3 *)_chip;
-	signed int *chanout = chip->chanout;
+	int32_t *chanout = chip->chanout;
 	uint8_t       rhythm = chip->rhythm&0x20;
 
 	OPL3SAMPLE  *ch_a = buffers[0];


### PR DESCRIPTION
It's a GCC cross-compiler targeting PPC intended for homebrew development for
various Nintendo devices (like GameCube).

Imported-from: https://www.vogons.org/viewtopic.php?p=845410#p845410