### PR TITLE
Prevent crash on exit in Wayland

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -120,7 +120,7 @@ public:
 	Bit16u input_handle;
 	BatchFile * bf;
 	bool echo;
-	bool exit;
+	bool exit_flag;
 	bool call;
 };
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -248,7 +248,7 @@ struct Dimensions {
 };
 
 struct SDL_Block {
-	bool inited;
+	bool initialized = false;
 	bool active;							//If this isn't set don't draw
 	bool updating;
 	bool update_display_contents;
@@ -407,12 +407,10 @@ void OPENGL_ERROR(const char*) {
 #endif
 #endif
 
-static int SDL_Init_Wrapper(void)
+static void QuitSDL()
 {
-	// Don't init timers, GetTicks seems to work fine and they can use
-	// a fair amount of power (Macs again).
-	// Please report problems with audio and other things.
-	return SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO);
+	if (sdl.initialized)
+		SDL_Quit();
 }
 
 extern const char* RunningProgram;
@@ -2887,11 +2885,12 @@ static void show_warning(char const * const message) {
 	fprintf(stderr, "%s", message);
 	return;
 #else
-	if (!sdl.inited && SDL_Init(SDL_INIT_VIDEO|SDL_INIT_NOPARACHUTE) < 0) {
-		sdl.inited = true;
-		printf("%s",message);
+	if (!sdl.initialized && SDL_Init(SDL_INIT_VIDEO) < 0) {
+		sdl.initialized = true;
+		fprintf(stderr, "%s", message);
 		return;
 	}
+
 	if (!sdl.window && !GFX_SetSDLSurfaceWindow(640, 400))
 		return;
 
@@ -2982,7 +2981,7 @@ void restart_program(std::vector<std::string> & parameters) {
 	newargs[parameters.size()] = NULL;
 	MIXER_CloseAudioDevice();
 	SDL_Delay(50);
-	SDL_Quit();
+	QuitSDL();
 #if C_DEBUG
 	// shutdown curses
 	DEBUG_ShutDown(NULL);
@@ -3181,11 +3180,11 @@ int main(int argc, char* argv[]) {
 	LOG_MSG("dosbox-staging version %s", VERSION);
 	LOG_MSG("---");
 
-	if (SDL_Init_Wrapper() < 0)
+	if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO) < 0)
 		E_Exit("Can't init SDL %s", SDL_GetError());
-	sdl.inited = true;
+	sdl.initialized = true;
 	// Once initialized, ensure we clean up SDL for all exit conditions
-	atexit(SDL_Quit);
+	atexit(QuitSDL);
 
 	sdl.laltstate = SDL_KEYUP;
 	sdl.raltstate = SDL_KEYUP;
@@ -3297,9 +3296,16 @@ int main(int argc, char* argv[]) {
 		// just exit
 		rcode = 1;
 	}
+
 #if defined (WIN32)
 	sticky_keys(true); //Might not be needed if the shutdown function switches to windowed mode, but it doesn't hurt
 #endif
+
+	// We already do this at exit, but do cleanup earlier in case of normal
+	// exit; this works around problems when atexit order clashes with SDL2
+	// cleanup order. Happens with SDL_VIDEODRIVER=wayland as of SDL 2.0.12.
+	QuitSDL();
+
 	return rcode;
 }
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -157,16 +157,16 @@ AutoexecObject::~AutoexecObject(){
 }
 
 DOS_Shell::DOS_Shell()
-	: Program(),
-	  l_history{},
-	  l_completion{},
-	  completion_start(nullptr),
-	  completion_index(0),
-	  input_handle(STDIN),
-	  bf(nullptr),
-	  echo(true),
-	  exit(false),
-	  call(false)
+        : Program(),
+          l_history{},
+          l_completion{},
+          completion_start(nullptr),
+          completion_index(0),
+          input_handle(STDIN),
+          bf(nullptr),
+          echo(true),
+          exit_flag(false),
+          call(false)
 {}
 
 Bitu DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn,bool * append) {
@@ -375,7 +375,7 @@ void DOS_Shell::Run(void) {
 			InputCommand(input_line);
 			ParseLine(input_line);
 		}
-	} while (!exit);
+	} while (!exit_flag);
 }
 
 void DOS_Shell::SyntaxError(void) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -307,10 +307,10 @@ void DOS_Shell::CMD_ECHO(char * args){
 	} else WriteOut("%s\r\n",args);
 }
 
-
-void DOS_Shell::CMD_EXIT(char * args) {
+void DOS_Shell::CMD_EXIT(char *args)
+{
 	HELP("EXIT");
-	exit = true;
+	exit_flag = true;
 }
 
 void DOS_Shell::CMD_CHDIR(char * args) {


### PR DESCRIPTION
This workaround should fix #336, but we might need to have a follow up on this problem with SDL maintainers.

This commit fixes the problem *for me*, when testing in Gnome. I guess it's a good candidate for backport to release branch.