### PR TITLE
Allow GCC's LTO on all platforms

### DIFF
--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -43,7 +43,10 @@ cflags_usan+=("${cflags_debug[@]}" -fsanitize=undefined
 cflags_tsan+=("${cflags_debug[@]}" -fsanitize=thread)
 
 # Modifier additions
-MODIFIERS=(fdo)
+MODIFIERS=(lto fdo)
 # Override the prior optimization flag because O2 does better w/ feedback 
 cflags_fdo+=("-O2 -ftree-vectorize
               -fauto-profile=${FDO_FILE:-${repo_root}/current.afdo}")
+
+cflags_lto+=(-flto)
+ldflags_lto+=("${cflags[@]}" "-flto=$(( $(nproc) + 2 ))")

--- a/scripts/automator/build/gcc-linux_x86_64
+++ b/scripts/automator/build/gcc-linux_x86_64
@@ -5,8 +5,3 @@ ldflags+=(-Wl,--as-needed)
 x86_math=(-mfpmath=sse -msse4.2)
 cflags_release+=("${x86_math[@]}")
 cflags_optinfo+=("${x86_math[@]}")
-
-# Modifier additions
-MODIFIERS+=(lto)
-cflags_lto+=(-flto)
-ldflags_lto+=("${cflags[@]}" "-flto=$(( $(nproc) + 2 ))")


### PR DESCRIPTION
In earlier versions of GCC (4, 5) LTO could be flaky especially on other platforms; therefore we previously allowed it on a platform-by-platform basis.

Given the popularity of ARM boards and excellent maintainership by distros like debian, raspbian, Ubuntu; plus the Linux kernel, many of these system are using up-to-date userspace tools including  recent GCC versions.  Given this, the time has come to allow LTO builds across the board, and if they fail on some corner-case platform - then so-be-it; at least users can try it. 