### PR TITLE
Fix APT package names and minimum OS ver

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ packages installed via your package manager.
 
     sudo dnf install SDL2 SDL2_net opusfile
 
-#### Debian (10 or newer), Ubuntu (18.04 LTS or newer)
+#### Debian (9 or newer), Ubuntu (16.04 LTS or newer)
 
-    sudo apt install libsdl2-2.0 libsdl2-net-2.0 libopusfile0
+    sudo apt install libsdl2-2.0-0 libsdl2-net-2.0-0 libopusfile0
 
 #### Arch, Manjaro
 


### PR DESCRIPTION
Correct SDL package names and widen OS coverage to Debian Sid and and Ubuntu 16.04:

libopusfile0 References:
- (Debian SID) https://packages.debian.org/sid/libs/libopusfile0
- (Debian Buster) https://packages.debian.org/buster/libs/libopusfile0
- (Ubuntu 16.04  - latest dev) https://packages.ubuntu.com/search?keywords=libopusfile0&searchon=names

SDL references:
- (Ubuntu 16.04 to latest) https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libsdl2-2.0-0&searchon=names
- (Ubuntu 16.04 to latest) https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libsdl2-net-2.0-0&searchon=names
