### PR TITLE
Switch to C++14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,7 +25,9 @@ ColumnLimit: 80
 # C/C++ Language specifics
 #
 Language: Cpp
-Standard: Cpp11 # in clang-format 11.x: c++11
+# in clang-format 9.x "Cpp11" covers formatting for C++11 and C++14
+# in clang-format 10.x: switch to "c++14"
+Standard: Cpp11
 
 # The extra indent or outdent of class access modifiers, e.g. public:
 #
@@ -96,8 +98,6 @@ AlwaysBreakTemplateDeclarations: Yes
 #                      "cccc";
 # shortname = "dddd"
 #             "eeee";
-#
-# TODO Test interaction with C++11 raw string literals
 #
 # AlwaysBreakBeforeMultilineStrings: true
 
@@ -229,13 +229,6 @@ SpacesInParentheses: false
 # int a[5];       NOT    int a[ 5 ];
 #
 SpacesInSquareBrackets: false
-
-# Insert a space after '{' and before '}' in struct initializers
-#
-# This is native C++11 style, but it looks very weird.
-# TODO Investigate if it has any tangible benefits.
-#
-# Cpp11BracedListStyle: false
 
 # A list of macros that should be interpreted as foreach loops instead of as
 # function calls.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,15 +93,15 @@ Do not do mass reformating or renaming of existing code.
 
 ### Language
 
-We use C-like C++11. To clarify:
+We use C-like C++14. To clarify:
 
 - Avoid designing your code in complex object-oriented style.
   This does not mean "don't use classes", it means "don't use stuff like
   multiple inheritance, overblown class hierarchies, operator overloading,
   iostreams for stdout/stderr, etc, etc".
-- C++11 has rich STL library, use it (responsibly - sometimes using
+- C++14 has rich STL library, use it (responsibly - sometimes using
   C standard library makes more sense).
-- Use C++11 features like `constexpr`, `static_assert`, managed pointers,
+- Use modern C++ features like `constexpr`, `static_assert`, managed pointers,
   lambda expressions, for-each loops, etc.
 - Avoid using exceptions. C++ exceptions are trickier than you think.
   No, you won't get it right. Or person touching the code after you won't get

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ support today's systems.
 |                                | dosbox-staging              | DOSBox
 |-                               |-                            |-
 | **Version control**            | Git                         | [SVN]
-| **Language**                   | C++11                       | C++03<sup>[1]</sup>
+| **Language**                   | C++14                       | C++03<sup>[1]</sup>
 | **SDL**                        | 2.0                         | 1.2<sup>＊</sup>
 | **CI**                         | Yes                         | No
 | **Static analysis**            | Yes<sup>[2],[3],[4]</sup>   | No

--- a/configure.ac
+++ b/configure.ac
@@ -54,9 +54,9 @@ AC_CHECK_SIZEOF(unsigned long)
 AC_CHECK_SIZEOF(unsigned long long)
 AC_CHECK_SIZEOF(int *)
 
-dnl Require compiler with C++11 support.
+dnl Require compiler with C++14 support.
 dnl Allow GNU extensions to work around MinGW bugs around POSIX compatibility.
-AX_CXX_COMPILE_STDCXX_11(ext, mandatory)
+AX_CXX_COMPILE_STDCXX_14(ext, mandatory)
 
 dnl some semi complex check for sys/socket so it works on darwin as well
 AC_CHECK_HEADERS([stdlib.h sys/types.h])

--- a/include/byteorder.h
+++ b/include/byteorder.h
@@ -40,7 +40,7 @@
 
 #if !defined(_MSC_VER)
 
-/* Aside of MSVC, every C++11-capable compiler provides __builtin_bswap*
+/* Aside of MSVC, every C++14-capable compiler provides __builtin_bswap*
  * as compiler intrinsics or builtin functions.
  */
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -29,7 +29,7 @@
 
 // The __attribute__ syntax is supported by GCC, Clang, and IBM compilers.
 //
-// TODO: C++11 introduces standard syntax for implementation-defined attributes,
+// TODO: C++11 introduced standard syntax for implementation-defined attributes,
 //       it should allow for removal of C_HAS_ATTRIBUTE from the buildsystem.
 //       However, the vast majority of GCC_ATTRIBUTEs in DOSBox code need
 //       to be reviewed, as many of them seem to be incorrectly/unnecessarily

--- a/include/logging.h
+++ b/include/logging.h
@@ -94,7 +94,7 @@ void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1,
 // be redirected into internal DOSBox debugger for DOS programs (C_DEBUG feature).
 #define DEBUG_LOG_MSG(...)
 #else
-// There's no portable way to expand variadic macro using C99/C++11 (or older)
+// There's no portable way to expand variadic macro using C99/C++14 (or older)
 // alone. This language limitation got removed only with C++20 (through addition
 // of __VA_OPT__ macro).
 #ifdef _MSC_VER

--- a/include/support.h
+++ b/include/support.h
@@ -155,9 +155,7 @@ void upcase(std::string &str);
 void lowcase(std::string &str);
 void strip_punctuation(std::string &str);
 
-template<size_t N>
-bool starts_with(const char (& pfx)[N], const std::string &str) noexcept {
-	return (strncmp(pfx, str.c_str(), N) == 0);
-}
+bool starts_with(const std::string &prefix, const std::string &str) noexcept;
+bool ends_with(const std::string &suffix, const std::string &str) noexcept;
 
 #endif

--- a/m4/ax_cxx_compile_stdcxx_14.m4
+++ b/m4/ax_cxx_compile_stdcxx_14.m4
@@ -1,19 +1,19 @@
 # =============================================================================
-#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_11.html
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_14.html
 # =============================================================================
 #
 # SYNOPSIS
 #
-#   AX_CXX_COMPILE_STDCXX_11([ext|noext], [mandatory|optional])
+#   AX_CXX_COMPILE_STDCXX_14([ext|noext], [mandatory|optional])
 #
 # DESCRIPTION
 #
-#   Check for baseline language coverage in the compiler for the C++11
+#   Check for baseline language coverage in the compiler for the C++14
 #   standard; if necessary, add switches to CXX and CXXCPP to enable
 #   support.
 #
 #   This macro is a convenience alias for calling the AX_CXX_COMPILE_STDCXX
-#   macro with the version set to C++11.  The two optional arguments are
+#   macro with the version set to C++14.  The two optional arguments are
 #   forwarded literally as the second and third argument respectively.
 #   Please see the documentation for the AX_CXX_COMPILE_STDCXX macro for
 #   more information.  If you want to use this macro, you also need to
@@ -21,11 +21,6 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
-#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
-#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
-#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
-#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
 #
 #   Copying and distribution of this file, with or without modification, are
@@ -33,7 +28,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 18
+#serial 5
 
 AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
-AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [AX_CXX_COMPILE_STDCXX([11], [$1], [$2])])
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_14], [AX_CXX_COMPILE_STDCXX([14], [$1], [$2])])

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -64,6 +64,22 @@ void lowcase(std::string &str) {
 	std::transform(str.begin(), str.end(), str.begin(), tf);
 }
 
+bool starts_with(const std::string &prefix, const std::string &str) noexcept
+{
+	const size_t n = prefix.length();
+	const auto pfx = std::cbegin(prefix);
+	const auto txt = std::cbegin(str);
+	return std::equal(pfx, pfx + n, txt, txt + n);
+}
+
+bool ends_with(const std::string &suffix, const std::string &str) noexcept
+{
+	const size_t n = suffix.length();
+	const auto sfx = std::crbegin(suffix);
+	const auto txt = std::crbegin(str);
+	return std::equal(sfx, sfx + n, txt, txt + n);
+}
+
 void trim(std::string &str) {
 	std::string::size_type loc = str.find_first_not_of(" \r\t\f\n");
 	if (loc != std::string::npos) str.erase(0,loc);


### PR DESCRIPTION
C++14 introduced only a handful of changes to the language, but even those are quite handy. In this PR I bundled small code change I intended with other PR to test if C++14 works correctly (usage of `std::equal`).

This effectively moves the oldest GCC we can use from 4.9.1 to 5.<something>. 5.4 that comes with Ubuntu 16.04 by default is ok. For modern MSVC no change is needed, as MSVC does not recognize C++11 any more - we used C++14 in there already (it's the default standard).

Making it a draft only for now, as I need to test ABI compatibility on some older distros and will turn it into PR once my tests will be successful.