### PR TITLE
Cleanup incorrect types used in printf-string conversions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,19 +18,19 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 55
+            max_warnings: 23
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 57
+            max_warnings: 25
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 57
+            max_warnings: 25
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
-            max_warnings: 38
+            max_warnings: 6
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 38
+            max_warnings: 6
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 57
+            max_warnings: 25
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 41
+            max_warnings: 9
           - compiler: GCC
             bits: 32
             arch: i686
@@ -29,7 +29,7 @@ jobs:
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 58
+            max_warnings: 26
     env:
       CHERE_INVOKING:  yes
       CCACHE_DIR:      "${{ github.workspace }}/.ccache"

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -115,7 +115,8 @@ void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler * handler,Bitu mask,B
 		m_mask=mask;
 		m_range=range;
 		IO_RegisterReadHandler(port,handler,mask,range);
-	} else E_Exit("IO_readHandler already installed port %x",port);
+	} else
+		E_Exit("IO_readHandler already installed port %" PRIuPTR, port);
 }
 
 void IO_ReadHandleObject::Uninstall(){
@@ -135,7 +136,8 @@ void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler * handler,Bitu mask
 		m_mask=mask;
 		m_range=range;
 		IO_RegisterWriteHandler(port,handler,mask,range);
-	} else E_Exit("IO_writeHandler already installed port %x",port);
+	} else
+		E_Exit("IO_writeHandler already installed port %" PRIuPTR, port);
 }
 
 void IO_WriteHandleObject::Uninstall() {

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -254,11 +254,16 @@ static void write_data(Bitu port,Bitu val,Bitu iolen) {
 			4		Special/Not Special nested mode 
 		*/
 		pic->auto_eoi=(val & 0x2)>0;
-		
-		LOG(LOG_PIC,LOG_NORMAL)("%d:ICW 4 %X",port==0x21 ? 0 : 1,val);
 
-		if ((val&0x01)==0) E_Exit("PIC:ICW4: %x, 8085 mode not handled",val);
-		if ((val&0x10)!=0) LOG_MSG("PIC:ICW4: %x, special fully-nested mode not handled",val);
+		LOG(LOG_PIC, LOG_NORMAL)
+		("%d:ICW 4 %" PRIuPTR, port == 0x21 ? 0 : 1, val);
+
+		if ((val & 0x01) == 0)
+			E_Exit("PIC:ICW4: %" PRIuPTR ", 8085 mode not handled", val);
+		if ((val & 0x10) != 0)
+			LOG_MSG("PIC:ICW4: %" PRIuPTR
+			        ", special fully-nested mode not handled",
+			        val);
 
 		if(pic->icw_index++ >= pic->icw_words) pic->icw_index=0;
 		break;

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -42,13 +42,14 @@ CDirectSerial::CDirectSerial (Bitu id, CommandLine* cmd)
 	std::string tmpstring;
 	if(!cmd->FindStringBegin("realport:",tmpstring,false)) return;
 
-	LOG_MSG ("Serial%d: Opening %s", COMNUMBER, tmpstring.c_str());
+	LOG_MSG("Serial%" PRIuPTR ": Opening %s", COMNUMBER, tmpstring.c_str());
 	if(!SERIAL_open(tmpstring.c_str(), &comport)) {
 		char errorbuffer[256];
 		SERIAL_getErrorString(errorbuffer, sizeof(errorbuffer));
-		LOG_MSG("Serial%d: Serial Port \"%s\" could not be opened.",
-			COMNUMBER, tmpstring.c_str());
-		LOG_MSG("%s",errorbuffer);
+		LOG_MSG("Serial%" PRIuPTR
+		        ": Serial Port \"%s\" could not be opened.",
+		        COMNUMBER, tmpstring.c_str());
+		LOG_MSG("%s", errorbuffer);
 		return;
 	}
 
@@ -273,9 +274,10 @@ void CDirectSerial::updatePortConfig (Bit16u divider, Bit8u lcr) {
 #if SERIAL_DEBUG
 		log_ser(dbg_aux,"Serial port settings not supported by host." );
 #endif
-		LOG_MSG ("Serial%d: Desired serial mode not supported (%d,%d,%c,%d)",
-			COMNUMBER, baudrate,bytelength,parity,stopbits);
-	} 
+		LOG_MSG("Serial%" PRIuPTR ": Desired serial mode not supported "
+		        "(%" PRIuPTR ",%d,%c,%d)",
+		        COMNUMBER, baudrate, bytelength, parity, stopbits);
+	}
 	CDirectSerial::setRTSDTR(getRTS(), getDTR());
 }
 
@@ -290,8 +292,10 @@ void CDirectSerial::updateMSR () {
 
 void CDirectSerial::transmitByte (Bit8u val, bool first) {
 	if(!SERIAL_sendchar(comport, val))
-		LOG_MSG("Serial%d: COM port error: write failed!", COMNUMBER);
-	if(first) setEvent(SERIAL_THR_EVENT, bytetime/8);
+		LOG_MSG("Serial%" PRIuPTR ": COM port error: write failed!",
+		        COMNUMBER);
+	if (first)
+		setEvent(SERIAL_THR_EVENT, bytetime / 8);
 	else setEvent(SERIAL_TX_EVENT, bytetime);
 }
 

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -104,17 +104,23 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 					if (!ClientConnect(new TCPClientSocket(sock)))
 						return;
 				} else {
-					LOG_MSG("Serial%d: -socket parameter missing.",COMNUMBER);
+					LOG_MSG("Serial%" PRIuPTR
+					        ": -socket parameter "
+					        "missing.",
+					        COMNUMBER);
 					return;
 				}
 			}
 		} else {
-			LOG_MSG("Serial%d: socket inheritance not supported on this platform.",
-				COMNUMBER);
+			LOG_MSG("Serial%" PRIuPTR
+			        ": socket inheritance not supported "
+			        "on this platform.",
+			        COMNUMBER);
 			return;
 		}
 #else
-		LOG_MSG("Serial%d: socket inheritance not available.", COMNUMBER);
+		LOG_MSG("Serial%" PRIuPTR ": socket inheritance not available.",
+		        COMNUMBER);
 #endif
 	} else {
 		// normal server/client
@@ -132,9 +138,12 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 			if (dtrrespect) {
 				// we connect as soon as DTR is switched on
 				setEvent(SERIAL_NULLMODEM_DTR_EVENT, 50);
-				LOG_MSG("Serial%d: Waiting for DTR...",COMNUMBER);
+				LOG_MSG("Serial%" PRIuPTR
+				        ": Waiting for DTR...",
+				        COMNUMBER);
 			} else if (!ClientConnect(
-				new TCPClientSocket((char*)hostnamebuffer,(Bit16u)clientport)))
+			                   new TCPClientSocket((char *)hostnamebuffer,
+			                                       (Bit16u)clientport)))
 				return;
 		} else {
 			// we are a server
@@ -189,7 +198,7 @@ bool CNullModem::ClientConnect(TCPClientSocket* newsocket) {
 	clientsocket = newsocket;
  
 	if (!clientsocket->isopen) {
-		LOG_MSG("Serial%d: Connection failed.",COMNUMBER);
+		LOG_MSG("Serial%" PRIuPTR ": Connection failed.", COMNUMBER);
 		delete clientsocket;
 		clientsocket=0;
 		setCD(false);
@@ -200,7 +209,7 @@ bool CNullModem::ClientConnect(TCPClientSocket* newsocket) {
 	// transmit the line status
 	if (!transparent) setRTSDTR(getRTS(), getDTR());
 	rx_state=N_RX_IDLE;
-	LOG_MSG("Serial%d: Connected to %s",COMNUMBER,peernamebuf);
+	LOG_MSG("Serial%" PRIuPTR ": Connected to %s", COMNUMBER, peernamebuf);
 	setEvent(SERIAL_POLLING_EVENT, 1);
 	setCD(true);
 	return true;
@@ -210,8 +219,10 @@ bool CNullModem::ServerListen() {
 	// Start the server listen port.
 	serversocket = new TCPServerSocket(serverport);
 	if (!serversocket->isopen) return false;
-	LOG_MSG("Serial%d: Nullmodem server waiting for connection on port %d...",
-		COMNUMBER,serverport);
+	LOG_MSG("Serial%" PRIuPTR
+	        ": Nullmodem server waiting for connection on port "
+	        "%d...",
+	        COMNUMBER, serverport);
 	setEvent(SERIAL_SERVER_POLLING_EVENT, 50);
 	setCD(false);
 	return true;
@@ -224,7 +235,8 @@ bool CNullModem::ServerConnect() {
 	
 	Bit8u peeripbuf[16];
 	clientsocket->GetRemoteAddressString(peeripbuf);
-	LOG_MSG("Serial%d: A client (%s) has connected.",COMNUMBER,peeripbuf);
+	LOG_MSG("Serial%" PRIuPTR ": A client (%s) has connected.", COMNUMBER,
+	        peeripbuf);
 #if SERIAL_DEBUG
 	log_ser(dbg_aux,"Nullmodem: A client (%s) has connected.", peeripbuf);
 #endif
@@ -246,7 +258,7 @@ void CNullModem::Disconnect() {
 	removeEvent(SERIAL_POLLING_EVENT);
 	removeEvent(SERIAL_RX_EVENT);
 	// it was disconnected; free the socket and restart the server socket
-	LOG_MSG("Serial%d: Disconnected.",COMNUMBER);
+	LOG_MSG("Serial%" PRIuPTR ": Disconnected.", COMNUMBER);
 	delete clientsocket;
 	clientsocket=0;
 	setDSR(false);
@@ -457,8 +469,11 @@ Bits CNullModem::TelnetEmulation(Bit8u data) {
 	if (telClient.inIAC) {
 		if (telClient.recCommand) {
 			if ((data != 0) && (data != 1) && (data != 3)) {
-				LOG_MSG("Serial%d: Unrecognized telnet option %d",COMNUMBER, data);
-				if (telClient.command>250) {
+				LOG_MSG("Serial%" PRIuPTR
+				        ": Unrecognized telnet option "
+				        "%d",
+				        COMNUMBER, data);
+				if (telClient.command > 250) {
 					/* Reject anything we don't recognize */
 					response[0]=0xff;
 					response[1]=252;

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -269,15 +269,17 @@ void CSerial::handleEvent(Bit16u type) {
 			break;
 		}
 		case SERIAL_ERRMSG_EVENT: {
-			LOG_MSG("Serial%d: Errors: "\
-				"Framing %d, Parity %d, Overrun RX:%d (IF0:%d), TX:%d, Break %d",
-				COMNUMBER, framingErrors, parityErrors, overrunErrors,
-				overrunIF0,txOverrunErrors, breakErrors);
-			errormsg_pending=false;
-			framingErrors=0;
-			parityErrors=0;
-			overrunErrors=0;
-			txOverrunErrors=0;
+		        LOG_MSG("Serial%" PRIuPTR ": Errors: "
+		                "Framing %" PRIuPTR ", Parity %" PRIuPTR
+		                ", Overrun RX:%" PRIuPTR " (IF0:%" PRIuPTR
+		                "), TX:%" PRIuPTR ", Break %" PRIuPTR,
+		                COMNUMBER, framingErrors, parityErrors, overrunErrors,
+		                overrunIF0, txOverrunErrors, breakErrors);
+		        errormsg_pending = false;
+		        framingErrors = 0;
+		        parityErrors = 0;
+		        overrunErrors = 0;
+		        txOverrunErrors=0;
 			overrunIF0=0;
 			breakErrors=0;
 			break;					  
@@ -1271,7 +1273,7 @@ public:
 				serialports[i] = NULL;
 			} else {
 				serialports[i] = NULL;
-				LOG_MSG("Invalid type for serial%d",i+1);
+				LOG_MSG("Invalid type for serial%" PRIuPTR, i + 1);
 			}
 			if(serialports[i]) biosParameter[i] = serial_baseaddr[i];
 		} // for 1-4

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -227,7 +227,7 @@ static Bitu TandyDACRead(Bitu port,Bitu /*iolen*/) {
 	case 0xc7:
 		return (Bit8u)(((tandy.dac.frequency>>8)&0xf) | (tandy.dac.amplitude<<5));
 	}
-	LOG_MSG("Tandy DAC: Read from unknown %X",port);
+	LOG_MSG("Tandy DAC: Read from unknown %" PRIuPTR, port);
 	return 0xff;
 }
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -104,9 +104,11 @@ void XGA_Write_Multifunc(Bitu val, Bitu len) {
 			xga.read_sel = dataval;
 			break;
 		default:
-			LOG_MSG("XGA: Unhandled multifunction command %x", regselect);
-			break;
-	}
+		        LOG_MSG("XGA: Unhandled multifunction command "
+		                "%" PRIuPTR,
+		                regselect);
+		        break;
+	        }
 }
 
 Bitu XGA_Read_Multifunc() {
@@ -637,13 +639,18 @@ void XGA_DrawWait(Bitu val, Bitu len)
 							break;
 						default:
 							// Let's hope they never show up ;)
-							LOG_MSG("XGA: unsupported bpp / datawidth combination %x",
-								xga.waitcmd.buswidth);
-							break;
-					};
-					break;
-			
-				case 0x02: // Data from PIX_TRANS selects the mix
+				                        LOG_MSG("XGA: "
+				                                "unsupported "
+				                                "bpp / "
+				                                "datawidth "
+				                                "combination "
+				                                "%" PRIuPTR,
+				                                xga.waitcmd.buswidth);
+				                        break;
+			                        };
+			                        break;
+
+		                case 0x02: // Data from PIX_TRANS selects the mix
 					switch(xga.waitcmd.buswidth&0x60) {
 						case 0x0:
 							chunksize=8;
@@ -1154,11 +1161,13 @@ void XGA_Write(Bitu port, Bitu val, Bitu len) {
 				//LOG_MSG("XGA: Wrote to port %4x with %08x, len %x", port, val, len);
 				xga.waitcmd.newline = false;
 				XGA_DrawWait(val, len);
-				
-			}
-			else LOG_MSG("XGA: Wrote to port %x with %x, len %x", port, val, len);
-			break;
-	}
+
+		        } else
+			        LOG_MSG("XGA: Wrote to port %" PRIuPTR
+			                " with %" PRIuPTR ", len %" PRIuPTR,
+			                port, val, len);
+		        break;
+	        }
 }
 
 Bitu XGA_Read(Bitu port, Bitu len) {


### PR DESCRIPTION
More rote-replacements, this time addressing common weakness exploitations (CWE)s flagged by Coverity.  Takes another healthy bite out of our warnings counts as well.
