### PR TITLE
Use the project's new repo URL

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -271,6 +271,6 @@ PenaltyReturnTypeOnItsOwnLine: 200
 # "include" directives, but there are still edge cases, so we still need to
 # rely on developers doing this manually.
 #
-# See https://github.com/dreamer/dosbox-staging/issues/196 for details.
+# See https://github.com/dosbox-staging/dosbox-staging/issues/196 for details.
 #
 SortIncludes: false

--- a/BUILD.md
+++ b/BUILD.md
@@ -83,7 +83,7 @@ notes below.
 ### Clone and Build a Windows Binary
 
 1. Clone and enter the repository's directory:
-   1. `git clone https://github.com/dreamer/dosbox-staging.git`
+   1. `git clone https://github.com/dosbox-staging/dosbox-staging.git`
    1. `cd dosbox-staging`
 
    Be sure to run all subsequent steps below while inside the repo's directory.
@@ -124,7 +124,7 @@ installed and the license agreed to:
 1. Update it with: `brew update`
 1. Install git with: `brew install git`
 1. Clone the repository: `git clone
-   https://github.com/dreamer/dosbox-staging.git`
+   https://github.com/dosbox-staging/dosbox-staging.git`
 1. Change directories into the repo: `cd dosbox-staging`
 1. Install dependencies:
   
@@ -146,7 +146,7 @@ installed and the license agreed to:
    sudo port -q selfupdate
    ```
 1. Clone the repository: `git clone
-   https://github.com/dreamer/dosbox-staging.git`
+   https://github.com/dosbox-staging/dosbox-staging.git`
 1. Change directories into the repo: `cd dosbox-staging`
 1. Install depedencies:
 
@@ -169,7 +169,7 @@ installed and the license agreed to:
 
 1. Install git: `sudo apt install -y git`
 1. Clone the repository: `git clone
-   https://github.com/dreamer/dosbox-staging.git`
+   https://github.com/dosbox-staging/dosbox-staging.git`
 1. Change directories into the repo: `cd dosbox-staging`
 1. (🏁 first-time-only) Install dependencies based on your package manager.
    In this example, we use Ubuntu 20.04:
@@ -195,7 +195,7 @@ installed and the license agreed to:
 ### Install Dependencies under Haiku
 
 1. Clone the repository: `git clone
-   https://github.com/dreamer/dosbox-staging.git`
+   https://github.com/dosbox-staging/dosbox-staging.git`
 1. Change directories into the repo: `cd dosbox-staging`
 1. (🏁 first-time-only) Install dependencies:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ There's plenty of tasks to work on all around, here are some ideas:
 - Test with your DOS games.
 - Package dosbox-staging for your OS.
 - Improve documentation (in the repo, or in the
-  [project wiki](https://github.com/dreamer/dosbox-staging/wiki)).
+  [project wiki](https://github.com/dosbox-staging/dosbox-staging/wiki)).
 - Promote the project in gaming communities :)
 - Provide translations (!)
 - Look at warning in code (build with `-Wall -Weffc++` to see the long list
@@ -49,14 +49,14 @@ There's plenty of tasks to work on all around, here are some ideas:
   See artifacts/reports in: [Clang][code-analysis], [Coverity][coverity],
   [PVS][pvs]
 - Look at our groomed list of features we want implemented in the
-  [Backlog](https://github.com/dreamer/dosbox-staging/projects/3) - if the issue
-  is not assigned to anyone, then it's for the pickings! Leave a comment saying
-  that you're working on it.
+  [Backlog](https://github.com/dosbox-staging/dosbox-staging/projects/3) - if
+  the issue is not assigned to anyone, then it's for the pickings! Leave a
+  comment saying that you're working on it.
 - Find next release project in our
-  [projects list ](https://github.com/dreamer/dosbox-staging/projects)
+  [projects list ](https://github.com/dosbox-staging/dosbox-staging/projects)
   and pick one of tasks in "To do" column.
 - Peruse through the list of
-  [open bug reports](https://github.com/dreamer/dosbox-staging/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+  [open bug reports](https://github.com/dosbox-staging/dosbox-staging/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
   and try to reproduce or fix them.
 
 Or just send us a Pull Request with your improvement

--- a/scripts/import-from-svn/import-from-svn.sh
+++ b/scripts/import-from-svn/import-from-svn.sh
@@ -115,7 +115,7 @@ cleanup () {
 # Set up remote repo to prepare for push
 #
 setup_remote () {
-	git -C "$1" remote add dosbox-staging git@github.com:dreamer/dosbox-staging.git
+	git -C "$1" remote add dosbox-staging git@github.com:dosbox-staging/dosbox-staging.git
 	git -C "$1" fetch dosbox-staging
 }
 


### PR DESCRIPTION
Just a simple replacement to use `github.com/dosbox-staging/dosbox-staging` instead of the prior URL.