### PR TITLE
Minor CI updates

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -12,7 +12,7 @@ jobs:
     name: PVS-Studio static analyzer
     runs-on: ubuntu-latest
     env:
-      debfile: pvs-studio-7.07.37949.43-amd64.deb
+      debfile: pvs-studio-7.07.38234.46-amd64.deb
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -139,6 +139,6 @@ function parse_args() {
 	selected_type=$(lower "${selected_type}")
 }
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+script_dir="$(cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 # shellcheck source=scripts/automator/main.sh
 source "$script_dir/automator/main.sh"

--- a/scripts/list-build-dependencies.sh
+++ b/scripts/list-build-dependencies.sh
@@ -53,6 +53,6 @@ function parse_args() {
 # shellcheck disable=SC2034
 data_dir="packages"
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+script_dir="$(cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 # shellcheck source=scripts/automator/main.sh
 source "$script_dir/automator/main.sh"


### PR DESCRIPTION
Noticed win32 builds are still periodically failing with an incorrect path for the launching script.  This new change uses a simpler mechanism to discover the script's path (ideally we would use `git` but under msys, git isn't even in our path). 

CI passed without any restarts needed, so hopefully this one is a winner.

PVS also updated their deb package, so this PR syncs up with that.
