### PR TITLE
Cleanup MIDI area (1/2)

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -58,4 +58,7 @@ struct DB_Midi {
 
 extern DB_Midi midi;
 
+bool MIDI_Available();
+void MIDI_RawOutByte(uint8_t data);
+
 #endif

--- a/include/midi.h
+++ b/include/midi.h
@@ -64,6 +64,7 @@ struct DB_Midi {
 
 extern DB_Midi midi;
 
+void MIDI_Init(Section *sec);
 bool MIDI_Available();
 void MIDI_RawOutByte(uint8_t data);
 

--- a/include/midi.h
+++ b/include/midi.h
@@ -46,21 +46,6 @@ public:
 };
 
 #define SYSEX_SIZE 8192
-struct DB_Midi {
-	Bitu status;
-	Bitu cmd_len;
-	Bitu cmd_pos;
-	Bit8u cmd_buf[8];
-	Bit8u rt_buf[8];
-	struct {
-		Bit8u buf[SYSEX_SIZE];
-		Bitu used;
-		Bitu delay;
-		Bit32u start;
-	} sysex;
-	bool available;
-	MidiHandler * handler;
-};
 
 void MIDI_Init(Section *sec);
 bool MIDI_Available();

--- a/include/midi.h
+++ b/include/midi.h
@@ -26,7 +26,12 @@
 class MidiHandler {
 public:
 	MidiHandler();
+
+	MidiHandler(const MidiHandler &) = delete; // prevent copying
+	MidiHandler &operator=(const MidiHandler &) = delete; // prevent assignment
+
 	virtual ~MidiHandler() = default;
+
 	virtual bool Open(const char * /*conf*/) {
 		LOG_MSG("MIDI: No working MIDI device found/selected.");
 		return true;
@@ -36,7 +41,8 @@ public:
 	virtual void PlaySysex(Bit8u * /*sysex*/,Bitu /*len*/) {};
 	virtual const char * GetName(void) { return "none"; };
 	virtual void ListAll(Program * base) {};
-	MidiHandler * next;
+
+	MidiHandler *next;
 };
 
 #define SYSEX_SIZE 8192

--- a/include/midi.h
+++ b/include/midi.h
@@ -62,10 +62,9 @@ struct DB_Midi {
 	MidiHandler * handler;
 };
 
-extern DB_Midi midi;
-
 void MIDI_Init(Section *sec);
 bool MIDI_Available();
+void MIDI_ListAll(Program *output_handler);
 void MIDI_RawOutByte(uint8_t data);
 
 #endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -42,6 +42,7 @@
 #include "ints/int10.h"
 #include "render.h"
 #include "pci_bus.h"
+#include "midi.h"
 
 Config * control;
 MachineType machine;
@@ -71,7 +72,6 @@ void FPU_Init(Section*);
 void DMA_Init(Section*);
 
 void MIXER_Init(Section*);
-void MIDI_Init(Section*);
 void HARDWARE_Init(Section*);
 
 #if defined(PCI_FUNCTIONALITY_ENABLED)
@@ -568,7 +568,7 @@ void DOSBOX_Init(void) {
 	Pint->SetMinMax(0,100);
 	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
 
-	secprop=control->AddSection_prop("midi",&MIDI_Init,true);//done
+	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init,true);//done
 
 	pstring = secprop->Add_string("mpu401", when_idle, "intelligent");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -396,6 +396,7 @@ void DOSBOX_Init(void) {
 	Prop_multival_remain* Pmulti_remain;
 
 	constexpr auto always = Property::Changeable::Always;
+	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	SDLNetInited = false;
 
@@ -570,16 +571,34 @@ void DOSBOX_Init(void) {
 	secprop=control->AddSection_prop("midi",&MIDI_Init,true);//done
 	secprop->AddInitFunction(&MPU401_Init,true);//done
 
-	const char* mputypes[] = { "intelligent", "uart", "none",0};
-	// FIXME: add some way to offer the actually available choices.
-	const char *devices[] = { "default", "win32", "alsa", "oss", "coreaudio", "coremidi","none", 0};
-	Pstring = secprop->Add_string("mpu401",Property::Changeable::WhenIdle,"intelligent");
-	Pstring->Set_values(mputypes);
-	Pstring->Set_help("Type of MPU-401 to emulate.");
+	pstring = secprop->Add_string("mpu401", when_idle, "intelligent");
+	const char *mputypes[] = {"intelligent", "uart", "none", 0};
+	pstring->Set_values(mputypes);
+	pstring->Set_help("Type of MPU-401 to emulate.");
 
-	Pstring = secprop->Add_string("mididevice",Property::Changeable::WhenIdle,"default");
-	Pstring->Set_values(devices);
-	Pstring->Set_help("Device that will receive the MIDI data from MPU-401.");
+	pstring = secprop->Add_string("mididevice", when_idle, "default");
+	const char *midi_devices[] = {
+		"default",
+#if defined(MACOSX)
+#ifdef C_SUPPORTS_COREMIDI
+		"coremidi",
+#endif
+#ifdef C_SUPPORTS_COREAUDIO
+		"coreaudio",
+#endif
+#elif defined(WIN32)
+		"win32",
+#else
+		"oss",
+#endif
+#if defined(HAVE_ALSA)
+		"alsa",
+#endif
+		"none",
+		0
+	};
+	pstring->Set_values(midi_devices);
+	pstring->Set_help("Device that will receive the MIDI data from MPU-401.");
 
 	Pstring = secprop->Add_string("midiconfig",Property::Changeable::WhenIdle,"");
 	Pstring->Set_help("Special configuration options for the device driver. This is usually the id or part of the name of the device you want to use\n"

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -226,6 +226,11 @@ getdefault:
 	}
 };
 
+void MIDI_ListAll(Program *output_handler)
+{
+	if (midi.handler)
+		midi.handler->ListAll(output_handler);
+}
 
 static MIDI* test;
 void MIDI_Destroy(Section* /*sec*/){

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -61,10 +61,10 @@ Bit8u MIDI_evt_len[256] = {
 
 MidiHandler * handler_list = 0;
 
-MidiHandler::MidiHandler(){
-	next = handler_list;
+MidiHandler::MidiHandler() : next(handler_list)
+{
 	handler_list = this;
-};
+}
 
 MidiHandler Midi_none;
 

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -97,6 +97,22 @@ MidiHandler Midi_none;
 
 #endif
 
+struct DB_Midi {
+	uint8_t status;
+	size_t cmd_len;
+	size_t cmd_pos;
+	uint8_t cmd_buf[8];
+	uint8_t rt_buf[8];
+	struct {
+		uint8_t buf[SYSEX_SIZE];
+		size_t used;
+		Bitu delay;
+		uint32_t start;
+	} sysex;
+	bool available;
+	MidiHandler * handler;
+};
+
 DB_Midi midi;
 
 void MIDI_RawOutByte(uint8_t data)

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -16,16 +16,16 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <assert.h>
-#include <string.h>
-#include <stdlib.h>
+#include "midi.h"
+
+#include <cassert>
+#include <cstring>
+#include <cstdlib>
 #include <string>
 #include <algorithm>
 
 #include <SDL.h>
 
-#include "dosbox.h"
-#include "midi.h"
 #include "cross.h"
 #include "support.h"
 #include "setup.h"
@@ -99,7 +99,8 @@ MidiHandler Midi_none;
 
 DB_Midi midi;
 
-void MIDI_RawOutByte(Bit8u data) {
+void MIDI_RawOutByte(uint8_t data)
+{
 	if (midi.sysex.start) {
 		Bit32u passed_ticks = GetTicks() - midi.sysex.start;
 		if (passed_ticks < midi.sysex.delay) SDL_Delay(midi.sysex.delay - passed_ticks);
@@ -163,7 +164,8 @@ void MIDI_RawOutByte(Bit8u data) {
 	}
 }
 
-bool MIDI_Available(void)  {
+bool MIDI_Available()
+{
 	return midi.available;
 }
 

--- a/src/gui/midi_alsa.h
+++ b/src/gui/midi_alsa.h
@@ -70,7 +70,19 @@ private:
 		return true;
 	}
 public:
-	MidiHandler_alsa() : MidiHandler() {};
+	MidiHandler_alsa()
+	        : MidiHandler(),
+	          ev{},
+	          seq_handle(nullptr),
+	          seq_client(0),
+	          seq_port(0),
+	          my_client(0),
+	          my_port(0)
+	{}
+
+	MidiHandler_alsa(const MidiHandler_alsa &) = delete; // prevent copying
+	MidiHandler_alsa &operator=(const MidiHandler_alsa &) = delete; // prevent assignment
+
 	const char* GetName(void) { return "alsa"; }
 	void PlaySysex(Bit8u * sysex,Bitu len) {
 		snd_seq_ev_set_sysex(&ev, len, sysex);
@@ -194,7 +206,6 @@ public:
 		LOG_MSG("ALSA: Client initialised [%d:%d]", seq_client, seq_port);
 		return true;
 	}
-
 };
 
 MidiHandler_alsa Midi_alsa;

--- a/src/gui/midi_oss.h
+++ b/src/gui/midi_oss.h
@@ -17,15 +17,26 @@
  */
 
 #include <fcntl.h>
+
 #define SEQ_MIDIPUTC    5
 
-class MidiHandler_oss: public MidiHandler {
+class MidiHandler_oss : public MidiHandler {
 private:
-	int  device;
-	Bit8u device_num;
+	int device;
+	uint8_t device_num;
 	bool isOpen;
+
 public:
-	MidiHandler_oss() : MidiHandler(),isOpen(false) {};
+	MidiHandler_oss()
+	        : MidiHandler(),
+	          device(0),
+	          device_num(0),
+	          isOpen(false)
+	{}
+
+	MidiHandler_oss(const MidiHandler_oss &) = delete; // prevent copying
+	MidiHandler_oss &operator=(const MidiHandler_oss &) = delete; // prevent assignment
+
 	const char * GetName(void) { return "oss";};
 	bool Open(const char * conf) {
 		char devname[512];
@@ -70,7 +81,3 @@ public:
 };
 
 MidiHandler_oss Midi_oss;
-
-
-
-

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -714,10 +714,7 @@ private:
 		);
 	}
 
-	void ListMidi(){
-		if(midi.handler) midi.handler->ListAll(this);
-	};
-
+	void ListMidi() { MIDI_ListAll(this); }
 };
 
 static void MIXER_ProgramStart(Program * * make) {

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -16,7 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
@@ -24,9 +23,7 @@
 #include "setup.h"
 #include "cpu.h"
 #include "support.h"
-
-void MIDI_RawOutByte(Bit8u data);
-bool MIDI_Available(void);
+#include "midi.h"
 
 static void MPU401_Event(Bitu);
 static void MPU401_Reset(void);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -16,7 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include <iomanip>
 #include <sstream>
 #include <string.h>
@@ -30,10 +29,9 @@
 #include "setup.h"
 #include "support.h"
 #include "shell.h"
-using namespace std;
+#include "midi.h"
 
-void MIDI_RawOutByte(Bit8u data);
-bool MIDI_Available(void);
+using namespace std;
 
 #define SB_PIC_EVENTS 0
 


### PR DESCRIPTION
This is preparatory cleanup before going forward with #262; this PR is probably better reviewed commit-by-commit.

Next MIDI cleanup PR will consist of moving files around - all `midi_*` files will be moved out of `gui` code module (*why it was in GUI?!*) into a new `midi` module. This functionality is small and well contained - perfect for moving it into new module before introducing FluidSynth as new, cross-platform MIDI backend.