### PR TITLE
Cleanup type-sizes in serial port classes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,19 +18,19 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 55
+            max_warnings: 23
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 57
+            max_warnings: 25
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 57
+            max_warnings: 25
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
-            max_warnings: 38
+            max_warnings: 6
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 38
+            max_warnings: 6
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 57
+            max_warnings: 25
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 498
+          MAX_BUGS: 496
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 41
+            max_warnings: 9
           - compiler: GCC
             bits: 32
             arch: i686
@@ -29,7 +29,7 @@ jobs:
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 58
+            max_warnings: 42
     env:
       CHERE_INVOKING:  yes
       CCACHE_DIR:      "${{ github.workspace }}/.ccache"

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -131,20 +131,21 @@ public:
 
 #if SERIAL_DEBUG
 	FILE * debugfp;
-	bool dbg_modemcontrol; // RTS,CTS,DTR,DSR,RI,CD
-	bool dbg_serialtraffic;
-	bool dbg_register;
-	bool dbg_interrupt;
-	bool dbg_aux;
-	void log_ser(bool active, char const* format,...);
+	bool dbg_modemcontrol = false; // RTS,CTS,DTR,DSR,RI,CD
+	bool dbg_serialtraffic = false;
+	bool dbg_register = false;
+	bool dbg_interrupt = false;
+	bool dbg_aux = false;
+	void log_ser(bool active, char const *format, ...);
 #endif
 
 	static bool getUintFromString(const char *name,
 	                              uint32_t &data,
 	                              CommandLine *cmd);
 
-	bool InstallationSuccessful;// check after constructing. If
-								// something was wrong, delete it right away.
+	bool InstallationSuccessful = false; // check after constructing. If
+	                                     // something was wrong, delete it
+	                                     // right away.
 
 	/*
 	 * Communication port index is typically 0-3, but logically limited
@@ -258,8 +259,7 @@ public:
 	uint8_t PortNumber() const;
 
 private:
-
-	DOS_Device* mydosdevice;
+	DOS_Device *mydosdevice = nullptr;
 
 	// I used this spec: st16c450v420.pdf
 
@@ -278,27 +278,28 @@ private:
 	#define TIMEOUT_PRIORITY 0x10
 	#define NONE_PRIORITY 0
 
-	Bit8u waiting_interrupts;	// these are on, but maybe not enabled
+	uint8_t waiting_interrupts = 0; // these are on, but maybe not enabled
 	
 	// 16C550
 	//				read/write		name
 
-	Bit16u baud_divider;
-	#define RHR_OFFSET 0	// r Receive Holding Register, also LSB of Divisor Latch (r/w)
+	uint16_t baud_divider = 0;
 							// Data: whole byte
 	#define THR_OFFSET 0	// w Transmit Holding Register
 							// Data: whole byte
-	Bit8u IER;	//	r/w		Interrupt Enable Register, also MSB of Divisor Latch
+	uint8_t IER = 0; //	r/w		Interrupt Enable Register, also
+	                 // MSB of Divisor Latch
 	#define IER_OFFSET 1
 
-	bool irq_active;
+	bool irq_active = false;
 				
 	#define RHR_INT_Enable_MASK				0x1
 	#define THR_INT_Enable_MASK				0x2
 	#define Receive_Line_INT_Enable_MASK	0x4
 	#define Modem_Status_INT_Enable_MASK	0x8
 
-	Bit8u ISR;	//	r				Interrupt Status Register
+	uint8_t ISR = 0; //	r				Interrupt Status
+	                 // Register
 	#define ISR_OFFSET 2
 
 	#define ISR_CLEAR_VAL 0x1
@@ -308,7 +309,8 @@ private:
 	#define ISR_TX_VAL 0x2
 	#define ISR_MSR_VAL 0x0
 public:	
-	Bit8u LCR;	//	r/w				Line Control Register
+	uint8_t LCR = 0; //	r/w				Line Control
+	                 // Register
 private:
 	#define LCR_OFFSET 3
 						// bit0: word length bit0
@@ -354,7 +356,8 @@ private:
 	#define MCR_OP2_MASK 0x8
 	#define MCR_LOOPBACK_Enable_MASK 0x10
 public:	
-	Bit8u LSR;	//	r				Line Status Register
+	uint8_t LSR = 0; //	r				Line Status
+	                 // Register
 private:
 
 	#define LSR_OFFSET 5
@@ -381,14 +384,14 @@ private:
 	// Modem Status Register
 	//	r
 	#define MSR_OFFSET 6
-	bool d_cts;			// bit0: deltaCTS
-	bool d_dsr;			// bit1: deltaDSR
-	bool d_ri;			// bit2: deltaRI
-	bool d_cd;			// bit3: deltaCD
-	bool cts;			// bit4: CTS
-	bool dsr;			// bit5: DSR
-	bool ri;			// bit6: RI
-	bool cd;			// bit7: CD
+	bool d_cts = false; // bit0: deltaCTS
+	bool d_dsr = false; // bit1: deltaDSR
+	bool d_ri = false;  // bit2: deltaRI
+	bool d_cd = false;  // bit3: deltaCD
+	bool cts = false;   // bit4: CTS
+	bool dsr = false;   // bit5: DSR
+	bool ri = false;    // bit6: RI
+	bool cd = false;    // bit7: CD
 	
 	#define MSR_delta_MASK 0xf
 	#define MSR_LINE_MASK 0xf0
@@ -402,21 +405,24 @@ private:
 	#define MSR_RI_MASK 0x40
 	#define MSR_CD_MASK 0x80
 
-	Bit8u SPR;	//	r/w				Scratchpad Register
+	uint8_t SPR = 0; //	r/w				Scratchpad Register
 	#define SPR_OFFSET 7
 
-
 	// For loopback purposes...
-	Bit8u loopback_data;
-	void transmitLoopbackByte(Bit8u val, bool value);
+	uint8_t loopback_data = 0;
 
 	// 16C550 (FIFO)
 	public: // todo remove
-	MyFifo* rxfifo;
+	        MyFifo *rxfifo = nullptr;
+
 	private:
+	        MyFifo *txfifo = nullptr;
+	        MyFifo *errorfifo = nullptr;
 	        uint32_t errors_in_fifo = 0;
 	        uint32_t rx_interrupt_threshold = 0;
 	        uint32_t fifosize = 0;
+	        uint8_t FCR = 0;
+	        bool sync_guardtime = false;
 	#define FIFO_STATUS_ACTIVE 0xc0 // FIFO is active AND works ;)
 	#define FIFO_ERROR 0x80
 	#define FCR_ACTIVATE 0x01
@@ -427,9 +433,9 @@ private:
 };
 
 extern CSerial* serialports[];
-const Bit8u serial_defaultirq[] = { 4, 3, 4, 3 };
-const Bit16u serial_baseaddr[] = {0x3f8,0x2f8,0x3e8,0x2e8};
-const char* const serial_comname[]={"COM1","COM2","COM3","COM4"};
+const uint8_t serial_defaultirq[] = {4, 3, 4, 3};
+const uint16_t serial_baseaddr[] = {0x3f8, 0x2f8, 0x3e8, 0x2e8};
+const char *const serial_comname[] = {"COM1", "COM2", "COM3", "COM4"};
 
 // the COM devices
 
@@ -444,7 +450,7 @@ public:
 	bool Close();
 	Bit16u GetInformation(void);
 private:
-	CSerial* sclass;
+	CSerial *sclass = nullptr;
 };
 
 #endif

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -20,6 +20,9 @@
 #ifndef DOSBOX_SERIALPORT_H
 #define DOSBOX_SERIALPORT_H
 
+#include <algorithm>
+#include <vector>
+
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif
@@ -47,87 +50,104 @@
 #include "hardware.h"
 #endif
 
-// Serial port interface 
+// Serial port interface
+
+#define SERIAL_MAX_FIFO_SIZE 256
+/* Note: Almost all DOS-era universal asynchronous receiver-transmitter
+ *       (UART)'s permitted up to a 16-byte receive and transmit
+ *       first-in/first-out (FIFO) buffer, however some specialty
+ *       controller cards allowed up to 64-bytes and later 256-bytes.
+ */
 
 class MyFifo {
 public:
-	MyFifo(uint32_t maxsize_)
+	MyFifo(const MyFifo &) = delete;            // prevent copying
+	MyFifo &operator=(const MyFifo &) = delete; // prevent assignment
+
+	MyFifo(size_t n) : data(n, 0), maxsize(n), size(n)
 	{
-		maxsize = size = maxsize_;
+		assert(n <= SERIAL_MAX_FIFO_SIZE);
+	}
+	size_t getFree() { return size - used; }
+	bool isEmpty() { return used == 0; }
+	bool isFull() { return (size - used) == 0; }
+	size_t getUsage() { return used; }
+	void setSize(size_t n)
+	{
+		assert(n <= SERIAL_MAX_FIFO_SIZE);
+		data.resize(n);
+		size = n;
+		maxsize = n;
 		pos = used = 0;
-		data = new uint8_t[size];
 	}
-	~MyFifo() {
-		delete[] data;
-	}
-	INLINE uint32_t getFree(void) { return size - used; }
-	bool isEmpty() {
-		return used==0;
-	}
-	bool isFull() {
-		return (size-used)==0;
+	void clear() {
+		pos = used = 0;
+		if (data.size() > 0)
+			std::fill(data.begin(), data.end(), 0);
 	}
 
-	INLINE uint32_t getUsage(void) { return used; }
-	void setSize(uint32_t newsize)
+	bool addb(uint8_t val)
 	{
-		size=newsize;
-		pos=used=0;
-	}
-	void clear(void) {
-		pos=used=0;
-		data[0]=0;
-	}
-
-	bool addb(uint8_t _val)
-	{
-		uint32_t where = pos + used;
+		size_t where = pos + used;
 		if (where >= size)
 			where -= size;
-		if(used>=size) {
+		if (used >= size) {
 			// overwrite last byte
-			if(where==0) where=size-1;
+			if (where == 0)
+				where = size - 1;
 			else where--;
-			data[where]=_val;
+			assert(where < data.size());
+			data[where] = val;
 			return false;
 		}
-		data[where]=_val;
+		assert(where < data.size());
+		data[where] = val;
 		used++;
 		return true;
 	}
 	uint8_t getb()
 	{
 		if (!used) return data[pos];
-		uint32_t where = pos;
+		size_t where = pos;
 		used--;
 		if(used) pos++;
 		if (pos>=size) pos-=size;
+		assert(where < data.size());
 		return data[where];
 	}
 	uint8_t getTop()
 	{
-		uint32_t where = pos + used;
+		size_t where = pos + used;
 		if (where >= size)
 			where -= size;
-		if(used>=size) {
-			if(where==0) where=size-1;
-			else where--;
+		if (used >= size) {
+			if (where == 0)
+				where = size - 1;
+			else
+				where--;
 		}
+		assert(where < data.size());
 		return data[where];
 	}
 
-	uint8_t probeByte() { return data[pos]; }
+	uint8_t probeByte()
+	{
+		assert(pos < data.size());
+		return data[pos];
+	}
 
 private:
-	uint8_t *data = nullptr;
-	uint32_t maxsize = 0;
-	uint32_t size = 0;
-	uint32_t pos = 0;
-	uint32_t used = 0;
+	std::vector<uint8_t> data;
+	size_t maxsize = 0;
+	size_t size = 0;
+	size_t pos = 0;
+	size_t used = 0;
 };
 
 class CSerial {
 public:
+	CSerial(const CSerial &) = delete;            // prevent copying
+	CSerial &operator=(const CSerial &) = delete; // prevent assignment
 
 #if SERIAL_DEBUG
 	FILE * debugfp;
@@ -151,22 +171,22 @@ public:
 	 * Communication port index is typically 0-3, but logically limited
 	 * to the number of physical interrupts available on the system.
 	 */
-	CSerial(const uint8_t port_index_, CommandLine *cmd);
-
+	CSerial(const uint8_t port_idx, CommandLine *cmd);
 	virtual ~CSerial();
-		
+
 	IO_ReadHandleObject ReadHandler[8];
 	IO_WriteHandleObject WriteHandler[8];
 
-	float bytetime; // how long a byte takes to transmit/receive in milliseconds
+	float bytetime = 0.0f; // how long a byte takes to transmit/receive in
+	                       // milliseconds
 	void changeLineProperties();
 	const uint8_t port_index = 0;
 
-	void setEvent(Bit16u type, float duration);
-	void removeEvent(Bit16u type);
-	void handleEvent(Bit16u type);
-	virtual void handleUpperEvent(Bit16u type)=0;
-	
+	void setEvent(uint16_t type, float duration);
+	void removeEvent(uint16_t type);
+	void handleEvent(uint16_t type);
+	virtual void handleUpperEvent(uint16_t type) = 0;
+
 	// defines for event type
 #define SERIAL_TX_LOOPBACK_EVENT 0
 #define SERIAL_THR_LOOPBACK_EVENT 1
@@ -179,10 +199,12 @@ public:
 #define SERIAL_RX_TIMEOUT_EVENT 7
 
 #define	SERIAL_BASE_EVENT_COUNT 7
-#define SERIAL_MAX_PORTS 4
+#define SERIAL_MAX_PORTS        4
+// Note: The code currently only handles four ports.
+//       To allow more, add more UARTs in SERIAL_Read(...)
 
 	uint32_t irq = 0;
-	
+
 	// CSerial requests an update of the input lines
 	virtual void updateMSR()=0;
 
@@ -207,15 +229,16 @@ public:
 	virtual void setDTR(bool val)=0;
 
 	// Register access
-	void Write_THR(Bit8u data);
-	void Write_IER(Bit8u data);
-	void Write_FCR(Bit8u data);
-	void Write_LCR(Bit8u data);
-	void Write_MCR(Bit8u data);
-	// Really old hardware seems to have the delta part of this register writable
-	void Write_MSR(Bit8u data);
-	void Write_SPR(Bit8u data);
-	void Write_reserved(Bit8u data, Bit8u address);
+	void Write_THR(uint8_t data);
+	void Write_IER(uint8_t data);
+	void Write_FCR(uint8_t data);
+	void Write_LCR(uint8_t data);
+	void Write_MCR(uint8_t data);
+	// Really old hardware seems to have the delta part of this register
+	// writable
+	void Write_MSR(uint8_t data);
+	void Write_SPR(uint8_t data);
+	void Write_reserved(uint8_t data, uint8_t address);
 
 	uint32_t Read_RHR();
 	uint32_t Read_IER();
@@ -225,13 +248,13 @@ public:
 	uint32_t Read_LSR();
 	uint32_t Read_MSR();
 	uint32_t Read_SPR();
-	
+
 	// If a byte comes from loopback or prepherial, put it in here.
-	void receiveByte(Bit8u data);
-	void receiveByteEx(Bit8u data, Bit8u error);
+	void receiveByte(uint8_t data);
+	void receiveByteEx(uint8_t data, uint8_t error);
 
 	// If an error was received, put it here (in LSR register format)
-	void receiveError(Bit8u errorword);
+	void receiveError(uint8_t errorword);
 
 	// depratched
 	// connected device checks, if port can receive data:
@@ -244,19 +267,19 @@ public:
 	void ByteTransmitted();
 
 	// Transmit byte to prepherial
-	virtual void transmitByte(Bit8u val, bool first)=0;
+	virtual void transmitByte(uint8_t val, bool first) = 0;
 
 	// switch break state to the passed value
 	virtual void setBreak(bool value)=0;
 	
 	// change baudrate, number of bits, parity, word length al at once
-	virtual void updatePortConfig(Bit16u divider, Bit8u lcr)=0;
-	
+	virtual void updatePortConfig(uint16_t divider, uint8_t lcr) = 0;
+
 	void Init_Registers();
-	
+
 	bool Putchar(uint8_t data, bool wait_dtr, bool wait_rts, uint32_t timeout);
 	bool Getchar(uint8_t *data, uint8_t *lsr, bool wait_dsr, uint32_t timeout);
-	uint8_t PortNumber() const;
+	uint8_t GetPortNumber() const { return port_index + 1; }
 
 private:
 	DOS_Device *mydosdevice = nullptr;
@@ -266,114 +289,115 @@ private:
 	void ComputeInterrupts();
 	
 	// a sub-interrupt is triggered
-	void rise(Bit8u priority);
+	void rise(uint8_t priority);
 
 	// clears the pending sub-interrupt
-	void clear(Bit8u priority);
-	
-	#define ERROR_PRIORITY 4	// overrun, parity error, frame error, break
-	#define RX_PRIORITY 1		// a byte has been received
-	#define TX_PRIORITY 2		// tx buffer has become empty
-	#define MSR_PRIORITY 8		// CRS, DSR, RI, DCD change 
-	#define TIMEOUT_PRIORITY 0x10
-	#define NONE_PRIORITY 0
+	void clear(uint8_t priority);
+
+#define ERROR_PRIORITY   4    // overrun, parity error, frame error, break
+#define RX_PRIORITY      1    // a byte has been received
+#define TX_PRIORITY      2    // tx buffer has become empty
+#define MSR_PRIORITY     8    // CRS, DSR, RI, DCD change 
+#define TIMEOUT_PRIORITY 0x10
+#define NONE_PRIORITY    0
 
 	uint8_t waiting_interrupts = 0; // these are on, but maybe not enabled
-	
+
 	// 16C550
 	//				read/write		name
 
 	uint16_t baud_divider = 0;
-							// Data: whole byte
-	#define THR_OFFSET 0	// w Transmit Holding Register
-							// Data: whole byte
+#define RHR_OFFSET \
+	0 // r Receive Holding Register, also LSB of Divisor Latch (r/w)
+	  // Data: whole byte
+#define THR_OFFSET \
+	0                // w Transmit Holding Register
+	                 // Data: whole byte
 	uint8_t IER = 0; //	r/w		Interrupt Enable Register, also
 	                 // MSB of Divisor Latch
-	#define IER_OFFSET 1
+#define IER_OFFSET 1
 
 	bool irq_active = false;
-				
-	#define RHR_INT_Enable_MASK				0x1
-	#define THR_INT_Enable_MASK				0x2
-	#define Receive_Line_INT_Enable_MASK	0x4
-	#define Modem_Status_INT_Enable_MASK	0x8
+
+#define RHR_INT_Enable_MASK          0x1
+#define THR_INT_Enable_MASK          0x2
+#define Receive_Line_INT_Enable_MASK 0x4
+#define Modem_Status_INT_Enable_MASK 0x8
 
 	uint8_t ISR = 0; //	r				Interrupt Status
 	                 // Register
-	#define ISR_OFFSET 2
+#define ISR_OFFSET 2
 
-	#define ISR_CLEAR_VAL 0x1
-	#define ISR_FIFOTIMEOUT_VAL 0xc
-	#define ISR_ERROR_VAL 0x6
-	#define ISR_RX_VAL 0x4
-	#define ISR_TX_VAL 0x2
-	#define ISR_MSR_VAL 0x0
-public:	
+#define ISR_CLEAR_VAL       0x1
+#define ISR_FIFOTIMEOUT_VAL 0xc
+#define ISR_ERROR_VAL       0x6
+#define ISR_RX_VAL          0x4
+#define ISR_TX_VAL          0x2
+#define ISR_MSR_VAL         0x0
+public:
 	uint8_t LCR = 0; //	r/w				Line Control
 	                 // Register
 private:
-	#define LCR_OFFSET 3
-						// bit0: word length bit0
-						// bit1: word length bit1
-						// bit2: stop bits
-						// bit3: parity enable
-						// bit4: even parity
-						// bit5: set parity
-						// bit6: set break
-						// bit7: divisor latch enable
+#define LCR_OFFSET 3
+	// bit0: word length bit0
+	// bit1: word length bit1
+	// bit2: stop bits
+	// bit3: parity enable
+	// bit4: even parity
+	// bit5: set parity
+	// bit6: set break
+	// bit7: divisor latch enable
 
-	
-	#define	LCR_BREAK_MASK 0x40
-	#define LCR_DIVISOR_Enable_MASK 0x80
-	#define LCR_PORTCONFIG_MASK 0x3F
-	
-	#define LCR_PARITY_NONE		0x0
-	#define LCR_PARITY_ODD		0x8
-	#define LCR_PARITY_EVEN		0x18
-	#define LCR_PARITY_MARK		0x28
-	#define LCR_PARITY_SPACE	0x38
+#define LCR_BREAK_MASK          0x40
+#define LCR_DIVISOR_Enable_MASK 0x80
+#define LCR_PORTCONFIG_MASK     0x3F
 
-	#define LCR_DATABITS_5		0x0
-	#define LCR_DATABITS_6		0x1
-	#define LCR_DATABITS_7		0x2
-	#define LCR_DATABITS_8		0x3
+#define LCR_PARITY_NONE  0x0
+#define LCR_PARITY_ODD   0x8
+#define LCR_PARITY_EVEN  0x18
+#define LCR_PARITY_MARK  0x28
+#define LCR_PARITY_SPACE 0x38
 
-	#define LCR_STOPBITS_1		0x0
-	#define LCR_STOPBITS_MORE_THAN_1 0x4
+#define LCR_DATABITS_5 0x0
+#define LCR_DATABITS_6 0x1
+#define LCR_DATABITS_7 0x2
+#define LCR_DATABITS_8 0x3
 
-	// Modem Control Register
-	// r/w				
-	#define MCR_OFFSET 4
-	bool dtr;			// bit0: DTR
-	bool rts;			// bit1: RTS
-	bool op1;			// bit2: OP1
-	bool op2;			// bit3: OP2
-	bool loopback;		// bit4: loop back enable
+#define LCR_STOPBITS_1           0x0
+#define LCR_STOPBITS_MORE_THAN_1 0x4
 
-	#define MCR_DTR_MASK 0x1
-	#define MCR_RTS_MASK 0x2	
-	#define MCR_OP1_MASK 0x4	
-	#define MCR_OP2_MASK 0x8
-	#define MCR_LOOPBACK_Enable_MASK 0x10
-public:	
+// Modem Control Register
+// r/w
+#define MCR_OFFSET 4
+	bool dtr = false;      // bit0: DTR
+	bool rts = false;      // bit1: RTS
+	bool op1 = false;      // bit2: OP1
+	bool op2 = false;      // bit3: OP2
+	bool loopback = false; // bit4: loop back enable
+
+#define MCR_DTR_MASK             0x1
+#define MCR_RTS_MASK             0x2
+#define MCR_OP1_MASK             0x4
+#define MCR_OP2_MASK             0x8
+#define MCR_LOOPBACK_Enable_MASK 0x10
+public:
 	uint8_t LSR = 0; //	r				Line Status
 	                 // Register
 private:
+#define LSR_OFFSET 5
 
-	#define LSR_OFFSET 5
+#define LSR_RX_DATA_READY_MASK    0x1
+#define LSR_OVERRUN_ERROR_MASK    0x2
+#define LSR_PARITY_ERROR_MASK     0x4
+#define LSR_FRAMING_ERROR_MASK    0x8
+#define LSR_RX_BREAK_MASK         0x10
+#define LSR_TX_HOLDING_EMPTY_MASK 0x20
+#define LSR_TX_EMPTY_MASK         0x40
 
-	#define LSR_RX_DATA_READY_MASK 0x1
-	#define LSR_OVERRUN_ERROR_MASK 0x2
-	#define LSR_PARITY_ERROR_MASK 0x4
-	#define LSR_FRAMING_ERROR_MASK 0x8
-	#define LSR_RX_BREAK_MASK 0x10
-	#define LSR_TX_HOLDING_EMPTY_MASK 0x20
-	#define LSR_TX_EMPTY_MASK 0x40
-
-	#define LSR_ERROR_MASK 0x1e
+#define LSR_ERROR_MASK 0x1e
 
 	// error printing
-	bool errormsg_pending;
+	bool errormsg_pending = false;
 	uint32_t framingErrors = 0;
 	uint32_t parityErrors = 0;
 	uint32_t overrunErrors = 0;
@@ -392,24 +416,25 @@ private:
 	bool dsr = false;   // bit5: DSR
 	bool ri = false;    // bit6: RI
 	bool cd = false;    // bit7: CD
-	
-	#define MSR_delta_MASK 0xf
-	#define MSR_LINE_MASK 0xf0
 
-	#define MSR_dCTS_MASK 0x1
-	#define MSR_dDSR_MASK 0x2
-	#define MSR_dRI_MASK 0x4
-	#define MSR_dCD_MASK 0x8
-	#define MSR_CTS_MASK 0x10
-	#define MSR_DSR_MASK 0x20
-	#define MSR_RI_MASK 0x40
-	#define MSR_CD_MASK 0x80
+#define MSR_delta_MASK 0xf
+#define MSR_LINE_MASK  0xf0
+
+#define MSR_dCTS_MASK 0x1
+#define MSR_dDSR_MASK 0x2
+#define MSR_dRI_MASK  0x4
+#define MSR_dCD_MASK  0x8
+#define MSR_CTS_MASK  0x10
+#define MSR_DSR_MASK  0x20
+#define MSR_RI_MASK   0x40
+#define MSR_CD_MASK   0x80
 
 	uint8_t SPR = 0; //	r/w				Scratchpad Register
-	#define SPR_OFFSET 7
+#define SPR_OFFSET 7
 
 	// For loopback purposes...
 	uint8_t loopback_data = 0;
+	void transmitLoopbackByte(uint8_t val, bool value);
 
 	// 16C550 (FIFO)
 	public: // todo remove
@@ -423,13 +448,13 @@ private:
 	        uint32_t fifosize = 0;
 	        uint8_t FCR = 0;
 	        bool sync_guardtime = false;
-	#define FIFO_STATUS_ACTIVE 0xc0 // FIFO is active AND works ;)
-	#define FIFO_ERROR 0x80
-	#define FCR_ACTIVATE 0x01
-	#define FCR_CLEAR_RX 0x02
-	#define FCR_CLEAR_TX 0x04
-	#define FCR_OFFSET 2
-	#define FIFO_FLOWCONTROL 0x20
+#define FIFO_STATUS_ACTIVE 0xc0 // FIFO is active AND works ;)
+#define FIFO_ERROR         0x80
+#define FCR_ACTIVATE       0x01
+#define FCR_CLEAR_RX       0x02
+#define FCR_CLEAR_TX       0x04
+#define FCR_OFFSET         2
+#define FIFO_FLOWCONTROL   0x20
 };
 
 extern CSerial* serialports[];
@@ -441,14 +466,19 @@ const char *const serial_comname[] = {"COM1", "COM2", "COM3", "COM4"};
 
 class device_COM : public DOS_Device {
 public:
-	// Creates a COM device that communicates with the num-th parallel port, i.e. is LPTnum
+	device_COM(const device_COM &) = delete;            // prevent copying
+	device_COM &operator=(const device_COM &) = delete; // prevent assignment
+
+	// Creates a COM device that communicates with the num-th parallel port,
+	// i.e. is LPTnum
 	device_COM(class CSerial* sc);
 	~device_COM();
-	bool Read(Bit8u * data,Bit16u * size);
-	bool Write(Bit8u * data,Bit16u * size);
-	bool Seek(Bit32u * pos,Bit32u type);
+	bool Read(uint8_t *data, uint16_t *size);
+	bool Write(uint8_t *data, uint16_t *size);
+	bool Seek(uint32_t *pos, uint32_t type);
 	bool Close();
-	Bit16u GetInformation(void);
+	uint16_t GetInformation();
+
 private:
 	CSerial *sclass = nullptr;
 };

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -51,17 +51,16 @@
 
 class MyFifo {
 public:
-	MyFifo(Bitu maxsize_) {
-		maxsize=size=maxsize_;
-		pos=used=0;
-		data=new Bit8u[size];
+	MyFifo(uint32_t maxsize_)
+	{
+		maxsize = size = maxsize_;
+		pos = used = 0;
+		data = new uint8_t[size];
 	}
 	~MyFifo() {
 		delete[] data;
 	}
-	INLINE Bitu getFree(void) {
-		return size-used;
-	}
+	INLINE uint32_t getFree(void) { return size - used; }
 	bool isEmpty() {
 		return used==0;
 	}
@@ -69,10 +68,8 @@ public:
 		return (size-used)==0;
 	}
 
-	INLINE Bitu getUsage(void) {
-		return used;
-	}
-	void setSize(Bitu newsize)
+	INLINE uint32_t getUsage(void) { return used; }
+	void setSize(uint32_t newsize)
 	{
 		size=newsize;
 		pos=used=0;
@@ -82,9 +79,11 @@ public:
 		data[0]=0;
 	}
 
-	bool addb(Bit8u _val) {
-		Bitu where=pos+used;
-		if (where>=size) where-=size;
+	bool addb(uint8_t _val)
+	{
+		uint32_t where = pos + used;
+		if (where >= size)
+			where -= size;
 		if(used>=size) {
 			// overwrite last byte
 			if(where==0) where=size-1;
@@ -96,17 +95,20 @@ public:
 		used++;
 		return true;
 	}
-	Bit8u getb() {
+	uint8_t getb()
+	{
 		if (!used) return data[pos];
-		Bitu where=pos;
+		uint32_t where = pos;
 		used--;
 		if(used) pos++;
 		if (pos>=size) pos-=size;
 		return data[where];
 	}
-	Bit8u getTop() {
-		Bitu where=pos+used;
-		if (where>=size) where-=size;
+	uint8_t getTop()
+	{
+		uint32_t where = pos + used;
+		if (where >= size)
+			where -= size;
 		if(used>=size) {
 			if(where==0) where=size-1;
 			else where--;
@@ -114,12 +116,14 @@ public:
 		return data[where];
 	}
 
-	Bit8u probeByte() {
-		return data[pos];
-	}
+	uint8_t probeByte() { return data[pos]; }
+
 private:
-	Bit8u * data;
-	Bitu maxsize,size,pos,used;
+	uint8_t *data = nullptr;
+	uint32_t maxsize = 0;
+	uint32_t size = 0;
+	uint32_t pos = 0;
+	uint32_t used = 0;
 };
 
 class CSerial {
@@ -135,7 +139,9 @@ public:
 	void log_ser(bool active, char const* format,...);
 #endif
 
-	static bool getBituSubstring(const char* name,Bitu* data, CommandLine* cmd);
+	static bool getUintFromString(const char *name,
+	                              uint32_t &data,
+	                              CommandLine *cmd);
 
 	bool InstallationSuccessful;// check after constructing. If
 								// something was wrong, delete it right away.
@@ -174,7 +180,7 @@ public:
 #define	SERIAL_BASE_EVENT_COUNT 7
 #define SERIAL_MAX_PORTS 4
 
-	Bitu irq;
+	uint32_t irq = 0;
 	
 	// CSerial requests an update of the input lines
 	virtual void updateMSR()=0;
@@ -210,14 +216,14 @@ public:
 	void Write_SPR(Bit8u data);
 	void Write_reserved(Bit8u data, Bit8u address);
 
-	Bitu Read_RHR();
-	Bitu Read_IER();
-	Bitu Read_ISR();
-	Bitu Read_LCR();
-	Bitu Read_MCR();
-	Bitu Read_LSR();
-	Bitu Read_MSR();
-	Bitu Read_SPR();
+	uint32_t Read_RHR();
+	uint32_t Read_IER();
+	uint32_t Read_ISR();
+	uint32_t Read_LCR();
+	uint32_t Read_MCR();
+	uint32_t Read_LSR();
+	uint32_t Read_MSR();
+	uint32_t Read_SPR();
 	
 	// If a byte comes from loopback or prepherial, put it in here.
 	void receiveByte(Bit8u data);
@@ -247,8 +253,8 @@ public:
 	
 	void Init_Registers();
 	
-	bool Putchar(Bit8u data, bool wait_dtr, bool wait_rts, Bitu timeout);
-	bool Getchar(Bit8u* data, Bit8u* lsr, bool wait_dsr, Bitu timeout);
+	bool Putchar(uint8_t data, bool wait_dtr, bool wait_rts, uint32_t timeout);
+	bool Getchar(uint8_t *data, uint8_t *lsr, bool wait_dsr, uint32_t timeout);
 	uint8_t PortNumber() const;
 
 private:
@@ -365,13 +371,12 @@ private:
 
 	// error printing
 	bool errormsg_pending;
-	Bitu framingErrors;
-	Bitu parityErrors;
-	Bitu overrunErrors;
-	Bitu txOverrunErrors;
-	Bitu overrunIF0;
-	Bitu breakErrors;
-
+	uint32_t framingErrors = 0;
+	uint32_t parityErrors = 0;
+	uint32_t overrunErrors = 0;
+	uint32_t txOverrunErrors = 0;
+	uint32_t overrunIF0 = 0;
+	uint32_t breakErrors = 0;
 
 	// Modem Status Register
 	//	r
@@ -409,13 +414,9 @@ private:
 	public: // todo remove
 	MyFifo* rxfifo;
 	private:
-	MyFifo* txfifo;
-	MyFifo* errorfifo;
-	Bitu errors_in_fifo;
-	Bitu rx_interrupt_threshold;
-	Bitu fifosize;
-	Bit8u FCR;
-	bool sync_guardtime;
+	        uint32_t errors_in_fifo = 0;
+	        uint32_t rx_interrupt_threshold = 0;
+	        uint32_t fifosize = 0;
 	#define FIFO_STATUS_ACTIVE 0xc0 // FIFO is active AND works ;)
 	#define FIFO_ERROR 0x80
 	#define FCR_ACTIVATE 0x01

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -140,9 +140,12 @@ public:
 	bool InstallationSuccessful;// check after constructing. If
 								// something was wrong, delete it right away.
 
-	// Constructor takes com port number (0-3)
-	CSerial(Bitu id, CommandLine* cmd);
-	
+	/*
+	 * Communication port index is typically 0-3, but logically limited
+	 * to the number of physical interrupts available on the system.
+	 */
+	CSerial(const uint8_t port_index_, CommandLine *cmd);
+
 	virtual ~CSerial();
 		
 	IO_ReadHandleObject ReadHandler[8];
@@ -150,7 +153,7 @@ public:
 
 	float bytetime; // how long a byte takes to transmit/receive in milliseconds
 	void changeLineProperties();
-	Bitu idnumber;
+	const uint8_t port_index = 0;
 
 	void setEvent(Bit16u type, float duration);
 	void removeEvent(Bit16u type);
@@ -169,8 +172,7 @@ public:
 #define SERIAL_RX_TIMEOUT_EVENT 7
 
 #define	SERIAL_BASE_EVENT_COUNT 7
-
-#define COMNUMBER idnumber+1
+#define SERIAL_MAX_PORTS 4
 
 	Bitu irq;
 	
@@ -247,7 +249,7 @@ public:
 	
 	bool Putchar(Bit8u data, bool wait_dtr, bool wait_rts, Bitu timeout);
 	bool Getchar(Bit8u* data, Bit8u* lsr, bool wait_dsr, Bitu timeout);
-
+	uint8_t PortNumber() const;
 
 private:
 

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -115,7 +115,8 @@ void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler * handler,Bitu mask,B
 		m_mask=mask;
 		m_range=range;
 		IO_RegisterReadHandler(port,handler,mask,range);
-	} else E_Exit("IO_readHandler already installed port %x",port);
+	} else
+		E_Exit("IO_readHandler already installed port %#" PRIxPTR, port);
 }
 
 void IO_ReadHandleObject::Uninstall(){
@@ -135,7 +136,8 @@ void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler * handler,Bitu mask
 		m_mask=mask;
 		m_range=range;
 		IO_RegisterWriteHandler(port,handler,mask,range);
-	} else E_Exit("IO_writeHandler already installed port %x",port);
+	} else
+		E_Exit("IO_writeHandler already installed port %#" PRIxPTR, port);
 }
 
 void IO_WriteHandleObject::Uninstall() {
@@ -146,7 +148,7 @@ void IO_WriteHandleObject::Uninstall() {
 
 IO_WriteHandleObject::~IO_WriteHandleObject(){
 	Uninstall();
-	//LOG_MSG("FreeWritehandler called with port %X",m_port);
+	// LOG_MSG("FreeWritehandler called with port %#" PRIxPTR,m_port);
 }
 
 struct IOF_Entry {

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -198,7 +198,8 @@ static void write_command(Bitu port,Bitu val,Bitu iolen) {
 			else pic->special = false;
 			//Check if there are irqs ready to run, as the priority system has possibly been changed.
 			pic->check_for_irq();
-			LOG(LOG_PIC,LOG_NORMAL)("port %X : special mask %s",port,(pic->special)?"ON":"OFF");
+			LOG(LOG_PIC, LOG_NORMAL)("port %#" PRIxPTR " : special mask %s",
+			                         port, (pic->special) ? "ON" : "OFF");
 		}
 	} else {	// OCW2 issued
 		if (val&0x20) {		// EOI commands
@@ -235,14 +236,19 @@ static void write_data(Bitu port,Bitu val,Bitu iolen) {
 		pic->set_imr(val);
 		break;
 	case 1:                        /* icw2          */
-		LOG(LOG_PIC,LOG_NORMAL)("%d:Base vector %X",port==0x21 ? 0 : 1,val);
-		pic->vector_base = val&0xf8;
-		if(pic->icw_index++ >= pic->icw_words) pic->icw_index=0;
-		else if(pic->single) pic->icw_index=3;		/* skip ICW3 in single mode */
+		LOG(LOG_PIC, LOG_NORMAL)("%d:Base vector %#" PRIxPTR,
+		                         port == 0x21 ? 0 : 1, val);
+		pic->vector_base = val & 0xf8;
+		if (pic->icw_index++ >= pic->icw_words)
+			pic->icw_index = 0;
+		else if (pic->single)
+			pic->icw_index = 3; /* skip ICW3 in single mode */
 		break;
 	case 2:							/* icw 3 */
-		LOG(LOG_PIC,LOG_NORMAL)("%d:ICW 3 %X",port==0x21 ? 0 : 1,val);
-		if(pic->icw_index++ >= pic->icw_words) pic->icw_index=0;
+		LOG(LOG_PIC, LOG_NORMAL)("%d:ICW 3 %#" PRIxPTR,
+		                         port == 0x21 ? 0 : 1, val);
+		if (pic->icw_index++ >= pic->icw_words)
+			pic->icw_index = 0;
 		break;
 	case 3:							/* icw 4 */
 		/*
@@ -254,17 +260,20 @@ static void write_data(Bitu port,Bitu val,Bitu iolen) {
 			4		Special/Not Special nested mode 
 		*/
 		pic->auto_eoi=(val & 0x2)>0;
-		
-		LOG(LOG_PIC,LOG_NORMAL)("%d:ICW 4 %X",port==0x21 ? 0 : 1,val);
 
-		if ((val&0x01)==0) E_Exit("PIC:ICW4: %x, 8085 mode not handled",val);
-		if ((val&0x10)!=0) LOG_MSG("PIC:ICW4: %x, special fully-nested mode not handled",val);
+		LOG(LOG_PIC, LOG_NORMAL)("%d:ICW 4 %#" PRIxPTR,
+		                         port == 0x21 ? 0 : 1, val);
+
+		if ((val & 0x01) == 0)
+			E_Exit("PIC:ICW4: %#" PRIxPTR ", 8085 mode not handled", val);
+		if ((val & 0x10) != 0)
+			LOG_MSG("PIC:ICW4: %#" PRIxPTR
+			        ", special fully-nested mode not handled",
+			        val);
 
 		if(pic->icw_index++ >= pic->icw_words) pic->icw_index=0;
 		break;
-	default:
-		LOG(LOG_PIC,LOG_NORMAL)("ICW HUH? %X",val);
-		break;
+	default: LOG(LOG_PIC, LOG_NORMAL)("ICW HUH? %#" PRIxPTR, val); break;
 	}
 }
 

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -31,8 +31,9 @@
 /* This is a serial passthrough class.  Its amazingly simple to */
 /* write now that the serial ports themselves were abstracted out */
 
-CDirectSerial::CDirectSerial (Bitu id, CommandLine* cmd)
-					:CSerial (id, cmd) {
+CDirectSerial::CDirectSerial(const uint8_t port_index_, CommandLine *cmd)
+        : CSerial(port_index_, cmd)
+{
 	InstallationSuccessful = false;
 	comport = 0;
 
@@ -60,7 +61,7 @@ CDirectSerial::CDirectSerial (Bitu id, CommandLine* cmd)
 
 	// rxdelay: How many milliseconds to wait before causing an
 	// overflow when the application is unresponsive.
-	if(getBituSubstring("rxdelay:", &rx_retry_max, cmd)) {
+	if (getUintFromString("rxdelay:", rx_retry_max, cmd)) {
 		if(!(rx_retry_max<=10000)) {
 			rx_retry_max=0;
 		}
@@ -259,9 +260,7 @@ void CDirectSerial::updatePortConfig (Bit16u divider, Bit8u lcr) {
 	Bit8u bytelength = (lcr & 0x3)+5;
 
 	// baudrate
-	Bitu baudrate;
-	if(divider==0) baudrate=115200;
-	else baudrate = 115200 / divider;
+	const uint32_t baudrate = divider ? 115200 / divider : 115200;
 
 	// stopbits
 	Bit8u stopbits;

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -42,13 +42,14 @@ CDirectSerial::CDirectSerial (Bitu id, CommandLine* cmd)
 	std::string tmpstring;
 	if(!cmd->FindStringBegin("realport:",tmpstring,false)) return;
 
-	LOG_MSG ("Serial%d: Opening %s", COMNUMBER, tmpstring.c_str());
+	LOG_MSG("Serial Port %u: Opening %s", PortNumber(), tmpstring.c_str());
 	if(!SERIAL_open(tmpstring.c_str(), &comport)) {
 		char errorbuffer[256];
 		SERIAL_getErrorString(errorbuffer, sizeof(errorbuffer));
-		LOG_MSG("Serial%d: Serial Port \"%s\" could not be opened.",
-			COMNUMBER, tmpstring.c_str());
-		LOG_MSG("%s",errorbuffer);
+		LOG_MSG("Serial Port %u: Serial Port \"%s\" could not be "
+		        "opened.",
+		        PortNumber(), tmpstring.c_str());
+		LOG_MSG("%s", errorbuffer);
 		return;
 	}
 
@@ -273,9 +274,10 @@ void CDirectSerial::updatePortConfig (Bit16u divider, Bit8u lcr) {
 #if SERIAL_DEBUG
 		log_ser(dbg_aux,"Serial port settings not supported by host." );
 #endif
-		LOG_MSG ("Serial%d: Desired serial mode not supported (%d,%d,%c,%d)",
-			COMNUMBER, baudrate,bytelength,parity,stopbits);
-	} 
+		LOG_MSG("Serial Port %u: Desired serial mode not supported "
+		        "(%d,%d,%c,%d)",
+		        PortNumber(), baudrate, bytelength, parity, stopbits);
+	}
 	CDirectSerial::setRTSDTR(getRTS(), getDTR());
 }
 
@@ -290,7 +292,7 @@ void CDirectSerial::updateMSR () {
 
 void CDirectSerial::transmitByte (Bit8u val, bool first) {
 	if(!SERIAL_sendchar(comport, val))
-		LOG_MSG("Serial%d: COM port error: write failed!", COMNUMBER);
+		LOG_MSG("Serial Port %u: write failed!", PortNumber());
 	if(first) setEvent(SERIAL_THR_EVENT, bytetime/8);
 	else setEvent(SERIAL_TX_EVENT, bytetime);
 }

--- a/src/hardware/serialport/directserial.h
+++ b/src/hardware/serialport/directserial.h
@@ -46,7 +46,7 @@ public:
 	void handleUpperEvent(Bit16u type);
 
 private:
-	COMPORT comport;
+	COMPORT comport = nullptr;
 
 	uint32_t rx_state = 0;
 #define D_RX_IDLE		0
@@ -60,10 +60,9 @@ private:
 	bool doReceive();
 
 #if SERIAL_DEBUG
-	bool dbgmsg_poll_block;
-	bool dbgmsg_rx_block;
+	bool dbgmsg_poll_block = false;
+	bool dbgmsg_rx_block = false;
 #endif
-
 };
 
 #endif	// C_DIRECTSERIAL

--- a/src/hardware/serialport/directserial.h
+++ b/src/hardware/serialport/directserial.h
@@ -32,7 +32,7 @@
 
 class CDirectSerial : public CSerial {
 public:
-	CDirectSerial(Bitu id, CommandLine* cmd);
+	CDirectSerial(const uint8_t port_index_, CommandLine *cmd);
 	~CDirectSerial();
 
 	void updatePortConfig(Bit16u divider, Bit8u lcr);
@@ -48,15 +48,15 @@ public:
 private:
 	COMPORT comport;
 
-	Bitu rx_state;
+	uint32_t rx_state = 0;
 #define D_RX_IDLE		0
 #define D_RX_WAIT		1
 #define D_RX_BLOCKED	2
 #define D_RX_FASTWAIT	3
 
-	Bitu rx_retry;		// counter of retries (every millisecond)
-	Bitu rx_retry_max;	// how many POLL_EVENTS to wait before causing
-						// an overrun error.
+	uint32_t rx_retry = 0;     // counter of retries (every millisecond)
+	uint32_t rx_retry_max = 0; // how many POLL_EVENTS to wait before
+	                           // causing an overrun error.
 	bool doReceive();
 
 #if SERIAL_DEBUG

--- a/src/hardware/serialport/directserial.h
+++ b/src/hardware/serialport/directserial.h
@@ -32,18 +32,22 @@
 
 class CDirectSerial : public CSerial {
 public:
-	CDirectSerial(const uint8_t port_index_, CommandLine *cmd);
+	CDirectSerial(const CDirectSerial &) = delete; // prevent copying
+	CDirectSerial &operator=(const CDirectSerial &) = delete; // prevent
+	                                                          // assignment
+
+	CDirectSerial(const uint8_t port_idx, CommandLine *cmd);
 	~CDirectSerial();
 
-	void updatePortConfig(Bit16u divider, Bit8u lcr);
+	void updatePortConfig(uint16_t divider, uint8_t lcr);
 	void updateMSR();
-	void transmitByte(Bit8u val, bool first);
+	void transmitByte(uint8_t val, bool first);
 	void setBreak(bool value);
 	
 	void setRTSDTR(bool rts, bool dtr);
 	void setRTS(bool val);
 	void setDTR(bool val);
-	void handleUpperEvent(Bit16u type);
+	void handleUpperEvent(uint16_t type);
 
 private:
 	COMPORT comport = nullptr;

--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -148,20 +148,19 @@ bool TCPClientSocket::GetRemoteAddressString(Bit8u* buffer) {
 	return true;
 }
 
-bool TCPClientSocket::ReceiveArray(Bit8u* data, Bitu* size) {
-	if(SDLNet_CheckSockets(listensocketset,0))
+bool TCPClientSocket::ReceiveArray(uint8_t *data, uint32_t *size)
 	{
+	if (SDLNet_CheckSockets(listensocketset, 0)) {
 		Bits retval = SDLNet_TCP_Recv(mysock, data, static_cast<int>(*size));
 		if(retval<1) {
 			isopen=false;
 			*size = 0;
 			return false;
 		} else {
-			*size = static_cast<Bitu>(retval);
+			*size = static_cast<uint32_t>(retval);
 			return true;
 		}
-	}
-	else {
+	} else {
 		*size=0;
 		return true;
 	}
@@ -190,7 +189,7 @@ bool TCPClientSocket::Putchar(Bit8u data)
 	return SendArray(&data, 1);
 }
 
-bool TCPClientSocket::SendArray(Bit8u* data, Bitu bufsize)
+bool TCPClientSocket::SendArray(uint8_t *data, uint32_t bufsize)
 {
 	if (SDLNet_TCP_Send(mysock, data, static_cast<int>(bufsize))
 	    != (int)bufsize) {
@@ -225,7 +224,7 @@ void TCPClientSocket::FlushBuffer()
 	}
 }
 
-void TCPClientSocket::SetSendBufferSize(Bitu bufsize)
+void TCPClientSocket::SetSendBufferSize(uint32_t bufsize)
 {
 	// Only resize the buffer if needed
 	if (!sendbuffer || sendbuffersize != bufsize) {

--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -21,9 +21,9 @@
 #if C_MODEM
 
 #include "misc_util.h"
-Bit32u Netwrapper_GetCapabilities()
+uint32_t Netwrapper_GetCapabilities()
 {
-	Bit32u retval=0;
+	uint32_t retval = 0;
 	retval = CAPWORD;
 	return retval;
 }
@@ -43,7 +43,7 @@ TCPClientSocket::TCPClientSocket(int platformsocket)
 	// fill the SDL socket manually
 	nativetcpstruct->ready = 0;
 	nativetcpstruct->sflag = 0;
-	nativetcpstruct->channel = (SOCKET) platformsocket;
+	nativetcpstruct->channel = platformsocket;
 	sockaddr_in		sa;
 	socklen_t		sz;
 	sz=sizeof(sa);
@@ -57,10 +57,8 @@ TCPClientSocket::TCPClientSocket(int platformsocket)
 	}
 	sz=sizeof(sa);
 	if(getsockname(platformsocket, (sockaddr *)(&sa), &sz)==0) {
-		((struct _TCPsocketX*)nativetcpstruct)->
-			localAddress.host=/*ntohl(*/sa.sin_addr.s_addr;//);
-		((struct _TCPsocketX*)nativetcpstruct)->
-			localAddress.port=/*ntohs(*/sa.sin_port;//);
+		(nativetcpstruct)->localAddress.host = /*ntohl(*/ sa.sin_addr.s_addr; //);
+		(nativetcpstruct)->localAddress.port = /*ntohs(*/ sa.sin_port; //);
 	}
 	else {
 		mysock = nullptr;
@@ -97,7 +95,7 @@ TCPClientSocket::TCPClientSocket(TCPsocket source)
 	}
 }
 
-TCPClientSocket::TCPClientSocket(const char* destination, Bit16u port)
+TCPClientSocket::TCPClientSocket(const char *destination, uint16_t port)
 {
 	if (!SDLNetInited) {
 		if (SDLNet_Init() == -1) {
@@ -135,82 +133,87 @@ TCPClientSocket::~TCPClientSocket()
 	if(listensocketset) SDLNet_FreeSocketSet(listensocketset);
 }
 
-bool TCPClientSocket::GetRemoteAddressString(Bit8u* buffer) {
-	IPaddress* remote_ip;
-	Bit8u b1, b2, b3, b4;
+bool TCPClientSocket::GetRemoteAddressString(uint8_t *buffer)
+{
+	IPaddress *remote_ip;
+	uint8_t b1, b2, b3, b4;
 	remote_ip=SDLNet_TCP_GetPeerAddress(mysock);
 	if(!remote_ip) return false;
 	b4=remote_ip->host>>24;
 	b3=(remote_ip->host>>16)&0xff;
 	b2=(remote_ip->host>>8)&0xff;
 	b1=remote_ip->host&0xff;
-	sprintf((char*)buffer,"%u.%u.%u.%u",b1,b2,b3,b4);
+	sprintf((char*)buffer,"%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8,
+	        b1, b2, b3, b4);
 	return true;
 }
 
-bool TCPClientSocket::ReceiveArray(uint8_t *data, uint32_t *size)
-	{
+bool TCPClientSocket::ReceiveArray(uint8_t *data, size_t &n)
+{
+	assertm(n <= static_cast<size_t>(std::numeric_limits<int>::max()),
+	        "SDL_net can't handle more bytes at a time.");
+	assert(data);
 	if (SDLNet_CheckSockets(listensocketset, 0)) {
-		Bits retval = SDLNet_TCP_Recv(mysock, data, static_cast<int>(*size));
-		if(retval<1) {
-			isopen=false;
-			*size = 0;
+		const int result = SDLNet_TCP_Recv(mysock, data, static_cast<int>(n));
+		if(result < 1) {
+			isopen = false;
+			n = 0;
 			return false;
 		} else {
-			*size = static_cast<uint32_t>(retval);
+			n = result;
 			return true;
 		}
 	} else {
-		*size=0;
+		n = 0;
 		return true;
 	}
 }
 
-Bits TCPClientSocket::GetcharNonBlock() {
-// return:
-// -1: no data
-// -2: socket closed
-// 0..255: data
-	Bits rvalue = -1;
+SocketState TCPClientSocket::GetcharNonBlock(uint8_t &val)
+{
+	SocketState state = SocketState::Empty;
 	if(SDLNet_CheckSockets(listensocketset,0))
 	{
-		char data = 0;
-		if (SDLNet_TCP_Recv(mysock, &data, 1) != 1) {
+		if (SDLNet_TCP_Recv(mysock, &val, 1) == 1)
+			state = SocketState::Good;
+		else {
 			isopen = false;
-			rvalue = -2;
-		} else
-			rvalue = static_cast<Bits>(data);
+			state = SocketState::Closed;
+		}
 	}
-	return rvalue;
+	return state;
 }
 
-bool TCPClientSocket::Putchar(Bit8u data)
+bool TCPClientSocket::Putchar(uint8_t val)
 {
-	return SendArray(&data, 1);
+	return SendArray(&val, 1);
 }
 
-bool TCPClientSocket::SendArray(uint8_t *data, uint32_t bufsize)
+bool TCPClientSocket::SendArray(uint8_t *data, const size_t n)
 {
-	if (SDLNet_TCP_Send(mysock, data, static_cast<int>(bufsize))
-	    != (int)bufsize) {
+	assertm(n <= static_cast<size_t>(std::numeric_limits<int>::max()),
+	        "SDL_net can't handle more bytes at a time.");
+	assert(data);
+	if (SDLNet_TCP_Send(mysock, data, static_cast<int>(n))
+	    != static_cast<int>(n)) {
 		isopen = false;
 		return false;
 	}
 	return true;
 }
 
-bool TCPClientSocket::SendByteBuffered(Bit8u data)
+bool TCPClientSocket::SendByteBuffered(const uint8_t val)
 {
 	if (sendbuffersize == 0)
 		return false;
 
 	if (sendbufferindex < (sendbuffersize - 1)) {
-		sendbuffer[sendbufferindex] = data;
+		sendbuffer[sendbufferindex] = val;
 		sendbufferindex++;
 		return true;
 	}
 	// buffer is full, get rid of it
-	sendbuffer[sendbufferindex] = data;
+	sendbuffer[sendbufferindex] = val;
 	sendbufferindex = 0;
 	return SendArray(sendbuffer, sendbuffersize);
 }
@@ -224,18 +227,18 @@ void TCPClientSocket::FlushBuffer()
 	}
 }
 
-void TCPClientSocket::SetSendBufferSize(uint32_t bufsize)
+void TCPClientSocket::SetSendBufferSize(const size_t n)
 {
 	// Only resize the buffer if needed
-	if (!sendbuffer || sendbuffersize != bufsize) {
+	if (!sendbuffer || sendbuffersize != n) {
 		delete [] sendbuffer;
-		sendbuffer = new Bit8u[bufsize];
-		sendbuffersize = bufsize;
+		sendbuffer = new uint8_t[n];
+		sendbuffersize = n;
 	}
 	sendbufferindex = 0;
 }
 
-TCPServerSocket::TCPServerSocket(Bit16u port)
+TCPServerSocket::TCPServerSocket(const uint16_t port)
 {
 	isopen = false;
 	mysock = nullptr;

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -55,22 +55,28 @@
 
 #include <SDL_net.h>
 
-Bit32u Netwrapper_GetCapabilities();
+uint32_t Netwrapper_GetCapabilities();
 
 struct _TCPsocketX {
 	int ready = 0;
 #ifdef NATIVESOCKETS
 	SOCKET channel = 0;
 #endif
-	IPaddress remoteAddress;
-	IPaddress localAddress;
+	IPaddress remoteAddress = {0, 0};
+	IPaddress localAddress = {0, 0};
 	int sflag = 0;
+};
+
+enum class SocketState {
+	Good, // had data and socket is open
+	Empty, // didn't have data but socket is open
+	Closed // didn't have data and socket is closed
 };
 
 class TCPClientSocket {
 public:
 	TCPClientSocket(TCPsocket source);
-	TCPClientSocket(const char* destination, Bit16u port);
+	TCPClientSocket(const char *destination, uint16_t port);
 #ifdef NATIVESOCKETS
 	TCPClientSocket(int platformsocket);
 #endif
@@ -79,25 +85,21 @@ public:
 
 	~TCPClientSocket();
 
-	// return:
-	// -1: no data
-	// -2: socket closed
-	// >0: data char
-	Bits GetcharNonBlock();
+	SocketState GetcharNonBlock(uint8_t &val);
 
-	bool Putchar(uint8_t data);
-	bool SendArray(uint8_t *data, uint32_t bufsize);
-	bool ReceiveArray(uint8_t *data, uint32_t *size);
+	bool Putchar(uint8_t val);
+	bool SendArray(uint8_t *data, size_t n);
+	bool ReceiveArray(uint8_t *data, size_t &n);
 
 	bool isopen = false;
 
-	bool GetRemoteAddressString(Bit8u* buffer);
+	bool GetRemoteAddressString(uint8_t *buffer);
 
 	void FlushBuffer();
-	void SetSendBufferSize(uint32_t bufsize);
+	void SetSendBufferSize(size_t n);
 
 	// buffered send functions
-	bool SendByteBuffered(Bit8u data);
+	bool SendByteBuffered(uint8_t val);
 
 private:
 
@@ -109,8 +111,8 @@ private:
 	SDLNet_SocketSet listensocketset = nullptr;
 
 	// Items for send buffering
-	uint32_t sendbuffersize = 0;
-	uint32_t sendbufferindex = 0;
+	size_t sendbuffersize = 0;
+	size_t sendbufferindex = 0;
 	uint8_t *sendbuffer = nullptr;
 };
 
@@ -118,7 +120,7 @@ struct TCPServerSocket {
 	bool isopen = false;
 	TCPsocket mysock = nullptr;
 
-	TCPServerSocket(Bit16u port);
+	TCPServerSocket(uint16_t port);
 	TCPServerSocket(const TCPServerSocket&) = delete; // prevent copying
 	TCPServerSocket& operator=(const TCPServerSocket&) = delete; // prevent assignment
 

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -85,16 +85,16 @@ public:
 	// >0: data char
 	Bits GetcharNonBlock();
 
-	bool Putchar(Bit8u data);
-	bool SendArray(Bit8u* data, Bitu bufsize);
-	bool ReceiveArray(Bit8u* data, Bitu* size);
+	bool Putchar(uint8_t data);
+	bool SendArray(uint8_t *data, uint32_t bufsize);
+	bool ReceiveArray(uint8_t *data, uint32_t *size);
 
 	bool isopen = false;
 
 	bool GetRemoteAddressString(Bit8u* buffer);
 
 	void FlushBuffer();
-	void SetSendBufferSize(Bitu bufsize);
+	void SetSendBufferSize(uint32_t bufsize);
 
 	// buffered send functions
 	bool SendByteBuffered(Bit8u data);
@@ -109,9 +109,8 @@ private:
 	SDLNet_SocketSet listensocketset = nullptr;
 
 	// Items for send buffering
-	Bitu sendbuffersize = 0;
-	Bitu sendbufferindex = 0;
-	Bit8u *sendbuffer = nullptr;
+	uint32_t sendbuffersize = 0;
+	uint32_t sendbufferindex = 0;
 };
 
 struct TCPServerSocket {

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -58,13 +58,13 @@
 Bit32u Netwrapper_GetCapabilities();
 
 struct _TCPsocketX {
-	int ready;
+	int ready = 0;
 #ifdef NATIVESOCKETS
-	SOCKET channel;
+	SOCKET channel = 0;
 #endif
 	IPaddress remoteAddress;
 	IPaddress localAddress;
-	int sflag;
+	int sflag = 0;
 };
 
 class TCPClientSocket {
@@ -111,6 +111,7 @@ private:
 	// Items for send buffering
 	uint32_t sendbuffersize = 0;
 	uint32_t sendbufferindex = 0;
+	uint8_t *sendbuffer = nullptr;
 };
 
 struct TCPServerSocket {

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -25,34 +25,21 @@
 #include "serialport.h"
 #include "nullmodem.h"
 
-CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
-	Bitu temptcpport=23;
-	memset(&telClient, 0, sizeof(telClient));
-	InstallationSuccessful = false;
-	serversocket = 0;
-	clientsocket = 0;
-	serverport = 0;
-	clientport = 0;
-
-	rx_retry = 0;
+CNullModem::CNullModem(const uint8_t port_index_, CommandLine *cmd)
+        : CSerial(port_index_, cmd)
+{
+	uint32_t temptcpport = 23;
 	rx_retry_max = 20;
 	rx_state=N_RX_DISC;
 
 	tx_gather = 12;
+	uint32_t bool_temp = 0;
 	
-	dtrrespect=false;
-	tx_block=false;
-	receiveblock=false;
-	transparent=false;
-	telnet=false;
-	
-	Bitu bool_temp=0;
-
 	// usedtr: The nullmodem will
 	// 1) when it is client connect to the server not immediately but
 	//    as soon as a modem-aware application is started (DTR is switched on).
 	// 2) only receive data when DTR is on.
-	if (getBituSubstring("usedtr:", &bool_temp, cmd)) {
+	if (getUintFromString("usedtr:", bool_temp, cmd)) {
 		if (bool_temp==1) {
 			dtrrespect=true;
 			transparent=true;
@@ -60,12 +47,12 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 		}
 	}
 	// transparent: don't add additional handshake control.
-	if (getBituSubstring("transparent:", &bool_temp, cmd)) {
+	if (getUintFromString("transparent:", bool_temp, cmd)) {
 		if (bool_temp==1) transparent=true;
 		else transparent=false;
 	}
 	// telnet: interpret telnet commands.
-	if (getBituSubstring("telnet:", &bool_temp, cmd)) {
+	if (getUintFromString("telnet:", bool_temp, cmd)) {
 		if (bool_temp==1) {
 			transparent=true;
 			telnet=true;
@@ -73,26 +60,26 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 	}
 	// rxdelay: How many milliseconds to wait before causing an
 	// overflow when the application is unresponsive.
-	if (getBituSubstring("rxdelay:", &rx_retry_max, cmd)) {
+	if (getUintFromString("rxdelay:", rx_retry_max, cmd)) {
 		if (!(rx_retry_max<=10000)) {
 			rx_retry_max=50;
 		}
 	}
 	// txdelay: How many milliseconds to wait before sending data.
 	// This reduces network overhead quite a lot.
-	if (getBituSubstring("txdelay:", &tx_gather, cmd)) {
+	if (getUintFromString("txdelay:", tx_gather, cmd)) {
 		if (!(tx_gather<=500)) {
 			tx_gather=12;
 		}
 	}
 	// port is for both server and client
-	if (getBituSubstring("port:", &temptcpport, cmd)) {
+	if (getUintFromString("port:", temptcpport, cmd)) {
 		if (!(temptcpport>0&&temptcpport<65536)) {
 			temptcpport=23;
 		}
 	}
 	// socket inheritance (client-alike)
-	if (getBituSubstring("inhsocket:", &bool_temp, cmd)) {
+	if (getUintFromString("inhsocket:", bool_temp, cmd)) {
 #ifdef NATIVESOCKETS
 		if (Netwrapper_GetCapabilities()&NETWRAPPER_TCP_NATIVESOCKET) {
 			if (bool_temp==1) {

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -104,17 +104,21 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 					if (!ClientConnect(new TCPClientSocket(sock)))
 						return;
 				} else {
-					LOG_MSG("Serial%d: -socket parameter missing.",COMNUMBER);
+					LOG_MSG("Serial Port %u: -socket "
+					        "parameter missing.",
+					        PortNumber());
 					return;
 				}
 			}
 		} else {
-			LOG_MSG("Serial%d: socket inheritance not supported on this platform.",
-				COMNUMBER);
+			LOG_MSG("Serial Port %u: socket inheritance not "
+			        "supported on this platform.",
+			        PortNumber());
 			return;
 		}
 #else
-		LOG_MSG("Serial%d: socket inheritance not available.", COMNUMBER);
+		LOG_MSG("Serial Port %u: socket inheritance not available.",
+		        PortNumber());
 #endif
 	} else {
 		// normal server/client
@@ -132,7 +136,8 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 			if (dtrrespect) {
 				// we connect as soon as DTR is switched on
 				setEvent(SERIAL_NULLMODEM_DTR_EVENT, 50);
-				LOG_MSG("Serial%d: Waiting for DTR...",COMNUMBER);
+				LOG_MSG("Serial Port %u: Waiting for DTR...",
+				        PortNumber());
 			} else if (!ClientConnect(
 				new TCPClientSocket((char*)hostnamebuffer,(Bit16u)clientport)))
 				return;
@@ -189,7 +194,7 @@ bool CNullModem::ClientConnect(TCPClientSocket* newsocket) {
 	clientsocket = newsocket;
  
 	if (!clientsocket->isopen) {
-		LOG_MSG("Serial%d: Connection failed.",COMNUMBER);
+		LOG_MSG("Serial Port %u: Connection failed.", PortNumber());
 		delete clientsocket;
 		clientsocket=0;
 		setCD(false);
@@ -200,7 +205,7 @@ bool CNullModem::ClientConnect(TCPClientSocket* newsocket) {
 	// transmit the line status
 	if (!transparent) setRTSDTR(getRTS(), getDTR());
 	rx_state=N_RX_IDLE;
-	LOG_MSG("Serial%d: Connected to %s",COMNUMBER,peernamebuf);
+	LOG_MSG("Serial Port %u: Connected to %s", PortNumber(), peernamebuf);
 	setEvent(SERIAL_POLLING_EVENT, 1);
 	setCD(true);
 	return true;
@@ -210,8 +215,9 @@ bool CNullModem::ServerListen() {
 	// Start the server listen port.
 	serversocket = new TCPServerSocket(serverport);
 	if (!serversocket->isopen) return false;
-	LOG_MSG("Serial%d: Nullmodem server waiting for connection on port %d...",
-		COMNUMBER,serverport);
+	LOG_MSG("Serial Port %u: Nullmodem server waiting for connection on "
+	        "TCP port %d...",
+	        PortNumber(), serverport);
 	setEvent(SERIAL_SERVER_POLLING_EVENT, 50);
 	setCD(false);
 	return true;
@@ -224,7 +230,8 @@ bool CNullModem::ServerConnect() {
 	
 	Bit8u peeripbuf[16];
 	clientsocket->GetRemoteAddressString(peeripbuf);
-	LOG_MSG("Serial%d: A client (%s) has connected.",COMNUMBER,peeripbuf);
+	LOG_MSG("Serial Port %u: A client (%s) has connected.", PortNumber(),
+	        peeripbuf);
 #if SERIAL_DEBUG
 	log_ser(dbg_aux,"Nullmodem: A client (%s) has connected.", peeripbuf);
 #endif
@@ -246,7 +253,7 @@ void CNullModem::Disconnect() {
 	removeEvent(SERIAL_POLLING_EVENT);
 	removeEvent(SERIAL_RX_EVENT);
 	// it was disconnected; free the socket and restart the server socket
-	LOG_MSG("Serial%d: Disconnected.",COMNUMBER);
+	LOG_MSG("Serial Port %u: Disconnected.", PortNumber());
 	delete clientsocket;
 	clientsocket=0;
 	setDSR(false);
@@ -457,7 +464,9 @@ Bits CNullModem::TelnetEmulation(Bit8u data) {
 	if (telClient.inIAC) {
 		if (telClient.recCommand) {
 			if ((data != 0) && (data != 1) && (data != 3)) {
-				LOG_MSG("Serial%d: Unrecognized telnet option %d",COMNUMBER, data);
+				LOG_MSG("Serial Port %u: Unrecognized telnet "
+				        "option %d",
+				        PortNumber(), data);
 				if (telClient.command>250) {
 					/* Reject anything we don't recognize */
 					response[0]=0xff;

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -25,8 +25,9 @@
 #include "serialport.h"
 #include "nullmodem.h"
 
-CNullModem::CNullModem(const uint8_t port_index_, CommandLine *cmd)
-        : CSerial(port_index_, cmd)
+CNullModem::CNullModem(const uint8_t port_idx, CommandLine *cmd)
+        : CSerial(port_idx, cmd),
+          telClient({})
 {
 	uint32_t temptcpport = 23;
 	rx_retry_max = 20;
@@ -34,7 +35,7 @@ CNullModem::CNullModem(const uint8_t port_index_, CommandLine *cmd)
 
 	tx_gather = 12;
 	uint32_t bool_temp = 0;
-	
+
 	// usedtr: The nullmodem will
 	// 1) when it is client connect to the server not immediately but
 	//    as soon as a modem-aware application is started (DTR is switched on).
@@ -87,25 +88,27 @@ CNullModem::CNullModem(const uint8_t port_index_, CommandLine *cmd)
 				if (control->cmdline->FindInt("-socket",sock,true)) {
 					dtrrespect=false;
 					transparent=true;
-					LOG_MSG("Inheritance socket handle: %d",sock);
+					LOG_MSG("SERIAL: Port %" PRIu8 " inheritance "
+					        "socket handle: %d",
+					        GetPortNumber(), sock);
 					if (!ClientConnect(new TCPClientSocket(sock)))
 						return;
 				} else {
-					LOG_MSG("Serial Port %u: -socket "
-					        "parameter missing.",
-					        PortNumber());
+					LOG_MSG("SERIAL: Port %" PRIu8 " missing "
+					        "\"-socket\" parameter.",
+					        GetPortNumber());
 					return;
 				}
 			}
 		} else {
-			LOG_MSG("Serial Port %u: socket inheritance not "
+			LOG_MSG("SERIAL: Port %" PRIu8 " socket inheritance not "
 			        "supported on this platform.",
-			        PortNumber());
+			        GetPortNumber());
 			return;
 		}
 #else
-		LOG_MSG("Serial Port %u: socket inheritance not available.",
-		        PortNumber());
+		LOG_MSG("SERIAL: Port %" PRIu8 " socket inheritance not available.",
+		        GetPortNumber());
 #endif
 	} else {
 		// normal server/client
@@ -119,18 +122,18 @@ CNullModem::CNullModem(const uint8_t port_index_, CommandLine *cmd)
 				hostnamebuffer[sizeof(hostnamebuffer)-1]=0;
 			}
 			memcpy(hostnamebuffer,hostnamechar,hostlen);
-			clientport=(Bit16u)temptcpport;
+			clientport = (uint16_t)temptcpport;
 			if (dtrrespect) {
 				// we connect as soon as DTR is switched on
 				setEvent(SERIAL_NULLMODEM_DTR_EVENT, 50);
-				LOG_MSG("Serial Port %u: Waiting for DTR...",
-				        PortNumber());
-			} else if (!ClientConnect(
-				new TCPClientSocket((char*)hostnamebuffer,(Bit16u)clientport)))
+				LOG_MSG("SERIAL: Port %" PRIu8 " waiting for DTR ...",
+				        GetPortNumber());
+			} else if (!ClientConnect(new TCPClientSocket((char *)hostnamebuffer,
+			                                              clientport)))
 				return;
 		} else {
 			// we are a server
-			serverport = (Bit16u)temptcpport;
+			serverport = (uint16_t)temptcpport;
 			if (!ServerListen()) return;
 		}
 	}
@@ -147,41 +150,53 @@ CNullModem::~CNullModem() {
 	if (serversocket) delete serversocket;
 	if (clientsocket) delete clientsocket;
 	// remove events
-	for(Bit16u i = SERIAL_BASE_EVENT_COUNT+1;
-			i <= SERIAL_NULLMODEM_EVENT_COUNT; i++) {
+	for (uint16_t i = SERIAL_BASE_EVENT_COUNT + 1;
+	     i <= SERIAL_NULLMODEM_EVENT_COUNT; i++) {
 		removeEvent(i);
 	}
 }
 
-void CNullModem::WriteChar(Bit8u data) {
-	if (clientsocket)clientsocket->SendByteBuffered(data);
+void CNullModem::WriteChar(uint8_t data)
+{
+	if (clientsocket)
+		clientsocket->SendByteBuffered(data);
 	if (!tx_block) {
-		//LOG_MSG("setevreduct");
+		// LOG_MSG("SERIAL: Port %" PRIu8 " setevreduct", GetPortNumber());
 		setEvent(SERIAL_TX_REDUCTION, (float)tx_gather);
 		tx_block=true;
 	}
 }
 
-Bits CNullModem::readChar() {
-	Bits rxchar = clientsocket->GetcharNonBlock();
-	if (telnet && rxchar>=0) return TelnetEmulation((Bit8u)rxchar);
-	else if (rxchar==0xff && !transparent) {// escape char
-		// get the next char
-		Bits rxchar = clientsocket->GetcharNonBlock();
-		if (rxchar==0xff) return rxchar; // 0xff 0xff -> 0xff was meant
-		rxchar&0x1? setCTS(true) : setCTS(false);
-		rxchar&0x2? setDSR(true) : setDSR(false);
-		if (rxchar&0x4) receiveByteEx(0x0,0x10);
-		return -1;	// no "payload" received
-	} else return rxchar;
+SocketState CNullModem::readChar(uint8_t &val)
+{
+	SocketState state = clientsocket->GetcharNonBlock(val);
+	if (state != SocketState::Good)
+		return state;
+
+	if (telnet)
+		return TelnetEmulation(val);
+
+	if (val == 0xff && !transparent) { // escape char
+		// get the next character
+		state = clientsocket->GetcharNonBlock(val);
+		if (state != SocketState::Good || val == 0xff) // 0xff 0xff -> 0xff was meant
+			return state;
+
+		setCTS(val & 0x1);
+		setDSR(val & 0x2);
+		if (val & 0x4)
+			receiveByteEx(0x0, 0x10);
+		return SocketState::Empty; // no "payload" received
+	}
+	return SocketState::Good;
 }
 
 bool CNullModem::ClientConnect(TCPClientSocket* newsocket) {
-	Bit8u peernamebuf[16];
+	uint8_t peernamebuf[16];
 	clientsocket = newsocket;
  
 	if (!clientsocket->isopen) {
-		LOG_MSG("Serial Port %u: Connection failed.", PortNumber());
+		LOG_MSG("SERIAL: Port %" PRIu8 " connection failed.", GetPortNumber());
 		delete clientsocket;
 		clientsocket=0;
 		setCD(false);
@@ -192,7 +207,7 @@ bool CNullModem::ClientConnect(TCPClientSocket* newsocket) {
 	// transmit the line status
 	if (!transparent) setRTSDTR(getRTS(), getDTR());
 	rx_state=N_RX_IDLE;
-	LOG_MSG("Serial Port %u: Connected to %s", PortNumber(), peernamebuf);
+	LOG_MSG("SERIAL: Port %" PRIu8 " connected to %s.", GetPortNumber(), peernamebuf);
 	setEvent(SERIAL_POLLING_EVENT, 1);
 	setCD(true);
 	return true;
@@ -202,9 +217,9 @@ bool CNullModem::ServerListen() {
 	// Start the server listen port.
 	serversocket = new TCPServerSocket(serverport);
 	if (!serversocket->isopen) return false;
-	LOG_MSG("Serial Port %u: Nullmodem server waiting for connection on "
-	        "TCP port %d...",
-	        PortNumber(), serverport);
+	LOG_MSG("SERIAL: Port %" PRIu8 " nullmodem server waiting for connection on "
+	        "TCP port %" PRIu16 " ...",
+	        GetPortNumber(), serverport);
 	setEvent(SERIAL_SERVER_POLLING_EVENT, 50);
 	setCD(false);
 	return true;
@@ -214,13 +229,14 @@ bool CNullModem::ServerConnect() {
 	// check if a connection is available.
 	clientsocket=serversocket->Accept();
 	if (!clientsocket) return false;
-	
-	Bit8u peeripbuf[16];
+
+	uint8_t peeripbuf[16];
 	clientsocket->GetRemoteAddressString(peeripbuf);
-	LOG_MSG("Serial Port %u: A client (%s) has connected.", PortNumber(),
-	        peeripbuf);
+	LOG_MSG("SERIAL: Port %" PRIu8 " a client (%s) has connected.",
+	        GetPortNumber(), peeripbuf);
 #if SERIAL_DEBUG
-	log_ser(dbg_aux,"Nullmodem: A client (%s) has connected.", peeripbuf);
+	log_ser(dbg_aux, "SERIAL: Port %" PRIu8 " a client (%s) has connected.",
+	        GetPortNumber(), peeripbuf);
 #endif
 	clientsocket->SetSendBufferSize(256);
 	rx_state=N_RX_IDLE;
@@ -240,7 +256,7 @@ void CNullModem::Disconnect() {
 	removeEvent(SERIAL_POLLING_EVENT);
 	removeEvent(SERIAL_RX_EVENT);
 	// it was disconnected; free the socket and restart the server socket
-	LOG_MSG("Serial Port %u: Disconnected.", PortNumber());
+	LOG_MSG("SERIAL: Port %" PRIu8 " disconnected.", GetPortNumber());
 	delete clientsocket;
 	clientsocket=0;
 	setDSR(false);
@@ -258,24 +274,24 @@ void CNullModem::Disconnect() {
 	}
 }
 
-void CNullModem::handleUpperEvent(Bit16u type) {
-	
-	switch(type) {
-		case SERIAL_POLLING_EVENT: {
-			// periodically check if new data arrived, disconnect
-			// if required. Add it back.
-			setEvent(SERIAL_POLLING_EVENT, 1.0f);
-			// update Modem input line states
-			updateMSR();
-			switch(rx_state) {
-				case N_RX_IDLE:
-					if (CanReceiveByte()) {
-						if (doReceive()) {
-							// a byte was received
-							rx_state=N_RX_WAIT;
-							setEvent(SERIAL_RX_EVENT, bytetime*0.9f);
-						} // else still idle
-					} else {
+void CNullModem::handleUpperEvent(uint16_t type)
+{
+	switch (type) {
+	case SERIAL_POLLING_EVENT: {
+		// periodically check if new data arrived, disconnect
+		// if required. Add it back.
+		setEvent(SERIAL_POLLING_EVENT, 1.0f);
+		// update Modem input line states
+		updateMSR();
+		switch (rx_state) {
+		case N_RX_IDLE:
+			if (CanReceiveByte()) {
+				if (doReceive()) {
+					// a byte was received
+					rx_state = N_RX_WAIT;
+					setEvent(SERIAL_RX_EVENT, bytetime * 0.9f);
+				} // else still idle
+			} else {
 #if SERIAL_DEBUG
 						log_ser(dbg_aux,"Nullmodem: block on polling.");
 #endif
@@ -328,8 +344,10 @@ void CNullModem::handleUpperEvent(Bit16u type) {
 		case SERIAL_RX_EVENT: {
 			switch(rx_state) {
 				case N_RX_IDLE:
-					LOG_MSG("internal error in nullmodem");
-					break;
+			                LOG_MSG("SERIAL: Port %" PRIu8 " internal "
+			                        "error in nullmodem.",
+			                        GetPortNumber());
+			                break;
 
 				case N_RX_BLOCKED: // try to receive
 				case N_RX_WAIT:
@@ -400,44 +418,48 @@ void CNullModem::handleUpperEvent(Bit16u type) {
 		case SERIAL_NULLMODEM_DTR_EVENT: {
 			if ((!DTR_delta) && getDTR()) {
 				// DTR went positive. Try to connect.
-				if (ClientConnect(new TCPClientSocket((char*)hostnamebuffer,
-								(Bit16u)clientport)))
-					break; // no more DTR wait event when connected
-			}
-			DTR_delta = getDTR();
+			        if (ClientConnect(new TCPClientSocket((char *)hostnamebuffer,
+			                                              clientport)))
+				        break; // no more DTR wait event when
+				               // connected
+		        }
+		        DTR_delta = getDTR();
 			setEvent(SERIAL_NULLMODEM_DTR_EVENT,50);
 			break;
 		}
-	}
+	        }
 }
 
 /*****************************************************************************/
 /* updatePortConfig is called when emulated app changes the serial port     **/
 /* parameters baudrate, stopbits, number of databits, parity.               **/
 /*****************************************************************************/
-void CNullModem::updatePortConfig (Bit16u /*divider*/, Bit8u /*lcr*/) {
-	
-}
+void CNullModem::updatePortConfig(uint16_t /*divider*/, uint8_t /*lcr*/)
+{}
 
 void CNullModem::updateMSR () {
 	
 }
 
 bool CNullModem::doReceive () {
-		Bits rxchar = readChar();
-		if (rxchar>=0) {
-			receiveByteEx((Bit8u)rxchar,0);
-			return true;
-		}
-		else if (rxchar==-2) {
-			Disconnect();
-		}
-		return false;
+	uint8_t val;
+	SocketState state = readChar(val);
+	if (state == SocketState::Good) {
+		receiveByteEx(val, 0);
+		return true;
+	}
+	if (state == SocketState::Closed) {
+		Disconnect();
+	}
+	// socket was either empty or closed
+	return false;
 }
- 
-void CNullModem::transmitByte (Bit8u val, bool first) {
- 	// transmit it later in THR_Event
-	if (first) setEvent(SERIAL_THR_EVENT, bytetime/8);
+
+void CNullModem::transmitByte(uint8_t val, bool first)
+{
+	// transmit it later in THR_Event
+	if (first)
+		setEvent(SERIAL_THR_EVENT, bytetime / 8);
 	else setEvent(SERIAL_TX_EVENT, bytetime);
 
 	// disable 0xff escaping when transparent mode is enabled
@@ -446,15 +468,16 @@ void CNullModem::transmitByte (Bit8u val, bool first) {
 	WriteChar(val);
 }
 
-Bits CNullModem::TelnetEmulation(Bit8u data) {
-	Bit8u response[3];
+SocketState CNullModem::TelnetEmulation(const uint8_t data)
+{
+	uint8_t response[3];
 	if (telClient.inIAC) {
 		if (telClient.recCommand) {
 			if ((data != 0) && (data != 1) && (data != 3)) {
-				LOG_MSG("Serial Port %u: Unrecognized telnet "
-				        "option %d",
-				        PortNumber(), data);
-				if (telClient.command>250) {
+				LOG_MSG("SERIAL: Port %" PRIu8 " unrecognized telnet "
+				        "option %" PRIu8 ".",
+				        GetPortNumber(), data);
+				if (telClient.command > 250) {
 					/* Reject anything we don't recognize */
 					response[0]=0xff;
 					response[1]=252;
@@ -520,17 +543,19 @@ Bits CNullModem::TelnetEmulation(Bit8u data) {
 					}
 					break;
 				default:
-					LOG_MSG("MODEM: Telnet client sent IAC %d", telClient.command);
-					break;
+				        LOG_MSG("SERIAL: Port %" PRIu8 " telnet client "
+				                "sent IAC %" PRIu8 ".",
+				                GetPortNumber(), telClient.command);
+				        break;
 			}
 			telClient.inIAC = false;
 			telClient.recCommand = false;
-			return -1; //continue;
+			return SocketState::Empty; //continue;
 		} else {
-			if (data==249) {
+			if (data == 249) {
 				/* Go Ahead received */
 				telClient.inIAC = false;
-				return -1; //continue;
+				return SocketState::Empty; //continue;
 			}
 			telClient.command = data;
 			telClient.recCommand = true;
@@ -539,19 +564,18 @@ Bits CNullModem::TelnetEmulation(Bit8u data) {
 				/* Binary data with value of 255 */
 				telClient.inIAC = false;
 				telClient.recCommand = false;
-					return 0xff;
+				return SocketState::Good;
 			}
 		}
 	} else {
 		if (data == 0xff) {
 			telClient.inIAC = true;
-			return -1;
+			return SocketState::Empty;
 		}
-		return data;
+		return SocketState::Good;
 	}
-	return -1; // ???
+	return SocketState::Empty; // ???
 }
-	
 
 /*****************************************************************************/
 /* setBreak(val) switches break on or off                                   **/
@@ -566,13 +590,17 @@ void CNullModem::setBreak (bool /*value*/) {
 /*****************************************************************************/
 void CNullModem::setRTSDTR(bool xrts, bool xdtr) {
 	if (!transparent) {
-		Bit8u control[2];
-		control[0]=0xff;
-		control[1]=0x0;
-		if (xrts) control[1]|=1;
-		if (xdtr) control[1]|=2;
-		if (LCR&LCR_BREAK_MASK) control[1]|=4;
-		if (clientsocket) clientsocket->SendArray(control, 2);
+		uint8_t ctrl_lines[2];
+		ctrl_lines[0] = 0xff;
+		ctrl_lines[1] = 0x0;
+		if (xrts)
+			ctrl_lines[1] |= 1;
+		if (xdtr)
+			ctrl_lines[1] |= 2;
+		if (LCR & LCR_BREAK_MASK)
+			ctrl_lines[1] |= 4;
+		if (clientsocket)
+			clientsocket->SendArray(ctrl_lines, 2);
 	}
 }
 void CNullModem::setRTS(bool val) {

--- a/src/hardware/serialport/nullmodem.h
+++ b/src/hardware/serialport/nullmodem.h
@@ -35,18 +35,21 @@
 
 class CNullModem : public CSerial {
 public:
-	CNullModem(const uint8_t port_index_, CommandLine *cmd);
+	CNullModem(const CNullModem &) = delete;            // prevent copying
+	CNullModem &operator=(const CNullModem &) = delete; // prevent assignment
+
+	CNullModem(const uint8_t port_idx, CommandLine *cmd);
 	~CNullModem();
 
-	void updatePortConfig(Bit16u divider, Bit8u lcr);
+	void updatePortConfig(uint16_t divider, uint8_t lcr);
 	void updateMSR();
-	void transmitByte(Bit8u val, bool first);
+	void transmitByte(uint8_t val, bool first);
 	void setBreak(bool value);
 	
 	void setRTSDTR(bool rts, bool dtr);
 	void setRTS(bool val);
 	void setDTR(bool val);
-	void handleUpperEvent(Bit16u type);
+	void handleUpperEvent(uint16_t type);
 
 private:
 	TCPServerSocket *serversocket = nullptr;
@@ -69,15 +72,15 @@ private:
 	bool ServerListen();
 	bool ServerConnect();
     void Disconnect();
-	Bits readChar();
-	void WriteChar(Bit8u data);
+    SocketState readChar(uint8_t &val);
+    void WriteChar(uint8_t data);
 
 	bool DTR_delta = false; // with dtrrespect, we try to establish a
 	                        // connection whenever DTR switches to 1. This
 	                        // variable is used to remember the old state.
 
 	bool tx_block = false; // true while the SERIAL_TX_REDUCTION event
-						// is pending
+	                       // is pending
 
 	uint32_t rx_retry = 0; // counter of retries
 
@@ -85,21 +88,21 @@ private:
 	                           // causing a overrun error.
 
 	uint32_t tx_gather = 0; // how long to gather tx data before
-						// sending all of them [milliseconds]
+	                        // sending all of them [milliseconds]
 
 	bool dtrrespect = false; // dtr behavior - only send data to the serial
-						// port when DTR is on
+	                         // port when DTR is on
 
 	bool transparent = false; // if true, don't send 0xff 0xXX to toggle
-						// DSR/CTS.
+	                          // DSR/CTS.
 
 	bool telnet = false; // Do Telnet parsing.
 
-	// Telnet's brain
+    // Telnet's brain
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
-	Bits TelnetEmulation(Bit8u data);
+	SocketState TelnetEmulation(const uint8_t data);
 
 	// Telnet's memory
 	struct {
@@ -107,7 +110,7 @@ private:
 		bool echo[2] = {false};
 		bool supressGA[2] = {false};
 		bool timingMark[2] = {false};
-					
+
 		bool inIAC = false;
 		bool recCommand = false;
 		uint8_t command = 0;

--- a/src/hardware/serialport/nullmodem.h
+++ b/src/hardware/serialport/nullmodem.h
@@ -35,7 +35,7 @@
 
 class CNullModem : public CSerial {
 public:
-	CNullModem(Bitu id, CommandLine* cmd);
+	CNullModem(const uint8_t port_index_, CommandLine *cmd);
 	~CNullModem();
 
 	void updatePortConfig(Bit16u divider, Bit8u lcr);
@@ -58,7 +58,7 @@ private:
 
 	Bit8u hostnamebuffer[128]; // the name passed to us by the user
 
-	Bitu rx_state;
+	uint32_t rx_state = 0;
 #define N_RX_IDLE		0
 #define N_RX_WAIT		1
 #define N_RX_BLOCKED	2
@@ -80,12 +80,12 @@ private:
 	bool tx_block;		// true while the SERIAL_TX_REDUCTION event
 						// is pending
 
-	Bitu rx_retry;		// counter of retries
+	uint32_t rx_retry = 0; // counter of retries
 
-	Bitu rx_retry_max;	// how many POLL_EVENTS to wait before causing
-						// a overrun error.
+	uint32_t rx_retry_max = 0; // how many POLL_EVENTS to wait before
+	                           // causing a overrun error.
 
-	Bitu tx_gather;		// how long to gather tx data before
+	uint32_t tx_gather = 0; // how long to gather tx data before
 						// sending all of them [milliseconds]
 
 	

--- a/src/hardware/serialport/nullmodem.h
+++ b/src/hardware/serialport/nullmodem.h
@@ -49,14 +49,13 @@ public:
 	void handleUpperEvent(Bit16u type);
 
 private:
-	TCPServerSocket* serversocket;
-	TCPClientSocket* clientsocket;
+	TCPServerSocket *serversocket = nullptr;
+	TCPClientSocket *clientsocket = nullptr;
 
-	bool receiveblock;		// It's not a block of data it rather blocks
-	Bit16u serverport;		// we are a server if this is nonzero
-	Bit16u clientport;
+	uint16_t serverport = 0; // we are a server if this is nonzero
+	uint16_t clientport = 0;
 
-	Bit8u hostnamebuffer[128]; // the name passed to us by the user
+	uint8_t hostnamebuffer[128] = {0}; // the name passed to us by the user
 
 	uint32_t rx_state = 0;
 #define N_RX_IDLE		0
@@ -73,11 +72,11 @@ private:
 	Bits readChar();
 	void WriteChar(Bit8u data);
 
-	bool DTR_delta;		// with dtrrespect, we try to establish a connection
-						// whenever DTR switches to 1. This variable is
-						// used to remember the old state.
+	bool DTR_delta = false; // with dtrrespect, we try to establish a
+	                        // connection whenever DTR switches to 1. This
+	                        // variable is used to remember the old state.
 
-	bool tx_block;		// true while the SERIAL_TX_REDUCTION event
+	bool tx_block = false; // true while the SERIAL_TX_REDUCTION event
 						// is pending
 
 	uint32_t rx_retry = 0; // counter of retries
@@ -88,14 +87,13 @@ private:
 	uint32_t tx_gather = 0; // how long to gather tx data before
 						// sending all of them [milliseconds]
 
-	
-	bool dtrrespect;	// dtr behavior - only send data to the serial
+	bool dtrrespect = false; // dtr behavior - only send data to the serial
 						// port when DTR is on
 
-	bool transparent;	// if true, don't send 0xff 0xXX to toggle
+	bool transparent = false; // if true, don't send 0xff 0xXX to toggle
 						// DSR/CTS.
 
-	bool telnet;		// Do Telnet parsing.
+	bool telnet = false; // Do Telnet parsing.
 
 	// Telnet's brain
 #define TEL_CLIENT 0
@@ -105,14 +103,14 @@ private:
 
 	// Telnet's memory
 	struct {
-		bool binary[2];
-		bool echo[2];
-		bool supressGA[2];
-		bool timingMark[2];
+		bool binary[2] = {false};
+		bool echo[2] = {false};
+		bool supressGA[2] = {false};
+		bool timingMark[2] = {false};
 					
-		bool inIAC;
-		bool recCommand;
-		Bit8u command;
+		bool inIAC = false;
+		bool recCommand = false;
+		uint8_t command = 0;
 	} telClient;
 };
 

--- a/src/hardware/serialport/serialdummy.cpp
+++ b/src/hardware/serialport/serialdummy.cpp
@@ -23,8 +23,8 @@
 #include "serialdummy.h"
 #include "serialport.h"
 
-CSerialDummy::CSerialDummy(const uint8_t port_index_, CommandLine *cmd)
-        : CSerial(port_index_, cmd)
+CSerialDummy::CSerialDummy(const uint8_t port_idx, CommandLine *cmd)
+        : CSerial(port_idx, cmd)
 {
 	CSerial::Init_Registers();
 	setRI(false);
@@ -39,35 +39,42 @@ CSerialDummy::~CSerialDummy() {
 	removeEvent(SERIAL_TX_EVENT);
 }
 
-void CSerialDummy::handleUpperEvent(Bit16u type) {
-	if(type==SERIAL_TX_EVENT) {
-	//LOG_MSG("SERIAL_TX_EVENT");
+void CSerialDummy::handleUpperEvent(uint16_t type)
+{
+	if (type == SERIAL_TX_EVENT) {
+		// LOG_MSG("SERIAL: Port %" PRIu8 " TX_EVENT", GetPortNumber());
 #ifdef CHECKIT_TESTPLUG
 		receiveByte(loopbackdata);
 #endif
 		ByteTransmitted(); // tx timeout
-	}
-	else if(type==SERIAL_THR_EVENT){
-		//LOG_MSG("SERIAL_THR_EVENT");
+	} else if (type == SERIAL_THR_EVENT) {
+		//LOG_MSG("SERIAL: Port %" PRIu8 " THR_EVENT", GetPortNumber());
 		ByteTransmitting();
 		setEvent(SERIAL_TX_EVENT,bytetime);
 	}
-
 }
 
 /*****************************************************************************/
 /* updatePortConfig is called when emulated app changes the serial port     **/
 /* parameters baudrate, stopbits, number of databits, parity.               **/
 /*****************************************************************************/
-void CSerialDummy::updatePortConfig(Bit16u divider, Bit8u lcr) {
-	//LOG_MSG("Serial port at 0x%x: Port params changed: %d Baud", base,dcb.BaudRate);
+void CSerialDummy::updatePortConfig(uint16_t divider, uint8_t lcr)
+{
+	(void)divider; // unused
+	(void)lcr;     // unused
+
+	// LOG_MSG("SERIAL: Port %" PRIu8 " at UART 0x%x params changed: %"
+	//         PRIu16 " baud", GetPortNumber(), base, dcb.BaudRate);
 }
 
 void CSerialDummy::updateMSR() {
 }
-void CSerialDummy::transmitByte(Bit8u val, bool first) {
 
-	if(first) setEvent(SERIAL_THR_EVENT, bytetime/10); 
+void CSerialDummy::transmitByte(uint8_t val, bool first)
+{
+	(void)val; // unused
+	if (first)
+		setEvent(SERIAL_THR_EVENT, bytetime / 10);
 	else setEvent(SERIAL_TX_EVENT, bytetime);
 
 #ifdef CHECKIT_TESTPLUG
@@ -80,19 +87,24 @@ void CSerialDummy::transmitByte(Bit8u val, bool first) {
 /*****************************************************************************/
 
 void CSerialDummy::setBreak(bool value) {
-	//LOG_MSG("UART 0x%x: Break toggeled: %d", base, value);
+	(void)value; // unused
+	// LOG_MSG("SERIAL: Port %" PRIu8 " at UART 0x%x break "
+	//         "toggled: %d.", GetPortNumber(), base, value);
 }
 
 /*****************************************************************************/
 /* setRTSDTR sets the modem control lines                                   **/
 /*****************************************************************************/
-void CSerialDummy::setRTSDTR(bool rts, bool dtr) {
-	setRTS(rts);
-	setDTR(dtr);
+void CSerialDummy::setRTSDTR(bool rts_state, bool dtr_state)
+{
+	setRTS(rts_state);
+	setDTR(dtr_state);
 }
 void CSerialDummy::setRTS(bool val) {
 #ifdef CHECKIT_TESTPLUG
 	setCTS(val);
+#else
+	(void)val; // unused
 #endif
 }
 void CSerialDummy::setDTR(bool val) {
@@ -100,5 +112,7 @@ void CSerialDummy::setDTR(bool val) {
 	setDSR(val);
 	setRI(val);
 	setCD(val);
+#else
+	(void)val; // unused
 #endif
 }

--- a/src/hardware/serialport/serialdummy.cpp
+++ b/src/hardware/serialport/serialdummy.cpp
@@ -23,7 +23,9 @@
 #include "serialdummy.h"
 #include "serialport.h"
 
-CSerialDummy::CSerialDummy(Bitu id,	CommandLine* cmd):CSerial(id, cmd) {
+CSerialDummy::CSerialDummy(const uint8_t port_index_, CommandLine *cmd)
+        : CSerial(port_index_, cmd)
+{
 	CSerial::Init_Registers();
 	setRI(false);
 	setDSR(false);

--- a/src/hardware/serialport/serialdummy.h
+++ b/src/hardware/serialport/serialdummy.h
@@ -26,18 +26,18 @@
 
 class CSerialDummy : public CSerial {
 public:
-	CSerialDummy(const uint8_t port_index_, CommandLine *cmd);
+	CSerialDummy(const uint8_t port_idx, CommandLine *cmd);
 	~CSerialDummy();
 
 	void setRTSDTR(bool rts, bool dtr);
 	void setRTS(bool val);
 	void setDTR(bool val);
 
-	void updatePortConfig(Bit16u, Bit8u lcr);
+	void updatePortConfig(uint16_t, uint8_t lcr);
 	void updateMSR();
-	void transmitByte(Bit8u val, bool first);
+	void transmitByte(uint8_t val, bool first);
 	void setBreak(bool value);
-	void handleUpperEvent(Bit16u type);
+	void handleUpperEvent(uint16_t type);
 
 #ifdef CHECKIT_TESTPLUG
 	uint8_t loopbackdata = 0;

--- a/src/hardware/serialport/serialdummy.h
+++ b/src/hardware/serialport/serialdummy.h
@@ -40,7 +40,7 @@ public:
 	void handleUpperEvent(Bit16u type);
 
 #ifdef CHECKIT_TESTPLUG
-	Bit8u loopbackdata;
+	uint8_t loopbackdata = 0;
 #endif
 
 };

--- a/src/hardware/serialport/serialdummy.h
+++ b/src/hardware/serialport/serialdummy.h
@@ -26,7 +26,7 @@
 
 class CSerialDummy : public CSerial {
 public:
-	CSerialDummy(Bitu id, CommandLine* cmd);
+	CSerialDummy(const uint8_t port_index_, CommandLine *cmd);
 	~CSerialDummy();
 
 	void setRTSDTR(bool rts, bool dtr);

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -84,7 +84,7 @@ Bit16u device_COM::GetInformation(void) {
 
 device_COM::device_COM(class CSerial* sc) {
 	sclass = sc;
-	SetName(serial_comname[sclass->idnumber]);
+	SetName(serial_comname[sclass->port_index]);
 }
 
 device_COM::~device_COM() {
@@ -93,7 +93,7 @@ device_COM::~device_COM() {
 
 
 // COM1 - COM4 objects
-CSerial* serialports[4] ={0,0,0,0};
+CSerial *serialports[SERIAL_MAX_PORTS] = {0};
 
 static Bitu SERIAL_Read (Bitu port, Bitu iolen) {
 	Bitu i;
@@ -241,12 +241,12 @@ static void Serial_EventHandler(Bitu val) {
 }
 
 void CSerial::setEvent(Bit16u type, float duration) {
-    PIC_AddEvent(Serial_EventHandler,duration,(type<<2)|idnumber);
+	PIC_AddEvent(Serial_EventHandler, duration, (type << 2) | port_index);
 }
 
 void CSerial::removeEvent(Bit16u type) {
     // TODO
-	PIC_RemoveSpecificEvents(Serial_EventHandler,(type<<2)|idnumber);
+    PIC_RemoveSpecificEvents(Serial_EventHandler, (type << 2) | port_index);
 }
 
 void CSerial::handleEvent(Bit16u type) {
@@ -269,11 +269,13 @@ void CSerial::handleEvent(Bit16u type) {
 			break;
 		}
 		case SERIAL_ERRMSG_EVENT: {
-			LOG_MSG("Serial%d: Errors: "\
-				"Framing %d, Parity %d, Overrun RX:%d (IF0:%d), TX:%d, Break %d",
-				COMNUMBER, framingErrors, parityErrors, overrunErrors,
-				overrunIF0,txOverrunErrors, breakErrors);
-			errormsg_pending=false;
+		        LOG_MSG("Serial%u: Errors: "
+		                "Framing %d, Parity %d, Overrun RX:%d "
+		                "(IF0:%d), TX:%d, Break %d",
+		                PortNumber(), framingErrors, parityErrors,
+		                overrunErrors, overrunIF0, txOverrunErrors,
+		                breakErrors);
+		        errormsg_pending=false;
 			framingErrors=0;
 			parityErrors=0;
 			overrunErrors=0;
@@ -883,8 +885,8 @@ void CSerial::Write_SPR (Bit8u data) {
 /* Write_reserved                                                           **/
 /*****************************************************************************/
 void CSerial::Write_reserved (Bit8u data, Bit8u address) {
-	/*LOG_UART("Serial%d: Write to reserved register, value 0x%x, register %x",
-		COMNUMBER, data, address);*/
+	/*LOG_UART("Serial%u: Write to reserved register, value 0x%x, register
+	   %x", PortNumber(), data, address);*/
 }
 
 /*****************************************************************************/
@@ -1072,13 +1074,15 @@ void CSerial::Init_Registers () {
 	PIC_DeActivateIRQ(irq);
 }
 
-CSerial::CSerial(Bitu id, CommandLine* cmd) {
-	idnumber=id;
-	Bit16u base = serial_baseaddr[id];
+CSerial::CSerial(const uint8_t port_index_, CommandLine *cmd)
+        : port_index(port_index_)
+{
+	const uint16_t base = serial_baseaddr[port_index];
 
-	irq = serial_defaultirq[id];
+	irq = serial_defaultirq[port_index];
 	getBituSubstring("irq:",&irq, cmd);
-	if (irq < 2 || irq > 15) irq = serial_defaultirq[id];
+	if (irq < 2 || irq > 15)
+		irq = serial_defaultirq[port_index];
 
 #if SERIAL_DEBUG
 	dbg_serialtraffic = cmd->FindExist("dbgtr", false);
@@ -1110,8 +1114,8 @@ CSerial::CSerial(Bitu id, CommandLine* cmd) {
 		std::string cleft;
 		cmd->GetStringRemain(cleft);
 
-		log_ser(true,"Serial%d: BASE %3x, IRQ %d, initstring \"%s\"\r\n\r\n",
-			COMNUMBER,base,irq,cleft.c_str());
+		log_ser(true, "Serial Port %u: BASE %3x, IRQ %d, initstring \"%s\"\r\n\r\n",
+		        PortNumber(), base, irq, cleft.c_str());
 	}
 #endif
 	fifosize=16;
@@ -1183,6 +1187,10 @@ bool CSerial::Getchar(Bit8u* data, Bit8u* lsr, bool wait_dsr, Bitu timeout) {
 	return true;
 }
 
+uint8_t CSerial::PortNumber() const
+{
+	return port_index + 1;
+}
 
 bool CSerial::Putchar(Bit8u data, bool wait_dsr, bool wait_cts, Bitu timeout) {
 	
@@ -1221,7 +1229,7 @@ bool CSerial::Putchar(Bit8u data, bool wait_dsr, bool wait_cts, Bitu timeout) {
 class SERIALPORTS:public Module_base {
 public:
 	SERIALPORTS (Section * configuration):Module_base (configuration) {
-		Bit16u biosParameter[4] = { 0, 0, 0, 0 };
+		Bit16u biosParameter[SERIAL_MAX_PORTS] = {0};
 		Section_prop *section = static_cast <Section_prop*>(configuration);
 
 #if C_MODEM
@@ -1229,8 +1237,8 @@ public:
 		MODEM_ReadPhonebook(pbFilename->realpath);
 #endif
 
-		char s_property[] = "serialx"; 
-		for(Bitu i = 0; i < 4; i++) {
+		char s_property[] = "serialx";
+		for (uint8_t i = 0; i < SERIAL_MAX_PORTS; ++i) {
 			// get the configuration property
 			s_property[6] = '1' + i;
 			Prop_multival* p = section->Get_multival(s_property);
@@ -1271,7 +1279,7 @@ public:
 				serialports[i] = NULL;
 			} else {
 				serialports[i] = NULL;
-				LOG_MSG("Invalid type for serial%d",i+1);
+				LOG_MSG("Invalid type for serial port %u",i+1);
 			}
 			if(serialports[i]) biosParameter[i] = serial_baseaddr[i];
 		} // for 1-4
@@ -1279,7 +1287,7 @@ public:
 	}
 
 	~SERIALPORTS () {
-		for (Bitu i = 0; i < 4; i++)
+		for (uint8_t i = 0; i < SERIAL_MAX_PORTS; ++i)
 			if (serialports[i]) {
 				delete serialports[i];
 				serialports[i] = 0;

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -96,43 +96,22 @@ device_COM::~device_COM() {
 CSerial *serialports[SERIAL_MAX_PORTS] = {0};
 
 static Bitu SERIAL_Read (Bitu port, Bitu iolen) {
-	Bitu i;
-	Bitu retval;
-	Bitu index = port & 0x7;
-	switch(port&0xff8) {
-		case 0x3f8: i=0; break;
-		case 0x2f8: i=1; break;
-		case 0x3e8: i=2; break;
-		case 0x2e8: i=3; break;
+	uint32_t i;
+	uint32_t retval;
+	uint8_t offset_type = static_cast<uint8_t>(port) & 0x7;
 		default: return 0xff;
 	}
 	if(serialports[i]==0) return 0xff;
 
-	switch (index) {
-		case RHR_OFFSET:
-			retval = serialports[i]->Read_RHR();
-			break;
-		case IER_OFFSET:
-			retval = serialports[i]->Read_IER();
-			break;
-		case ISR_OFFSET:
-			retval = serialports[i]->Read_ISR();
-			break;
-		case LCR_OFFSET:
-			retval = serialports[i]->Read_LCR();
-			break;
-		case MCR_OFFSET:
-			retval = serialports[i]->Read_MCR();
-			break;
-		case LSR_OFFSET:
-			retval = serialports[i]->Read_LSR();
-			break;
-		case MSR_OFFSET:
-			retval = serialports[i]->Read_MSR();
-			break;
-		case SPR_OFFSET:
-			retval = serialports[i]->Read_SPR();
-			break;
+	switch (offset_type) {
+	case RHR_OFFSET: retval = serialports[i]->Read_RHR(); break;
+	case IER_OFFSET: retval = serialports[i]->Read_IER(); break;
+	case ISR_OFFSET: retval = serialports[i]->Read_ISR(); break;
+	case LCR_OFFSET: retval = serialports[i]->Read_LCR(); break;
+	case MCR_OFFSET: retval = serialports[i]->Read_MCR(); break;
+	case LSR_OFFSET: retval = serialports[i]->Read_LSR(); break;
+	case MSR_OFFSET: retval = serialports[i]->Read_MSR(); break;
+	case SPR_OFFSET: retval = serialports[i]->Read_SPR(); break;
 	}
 
 #if SERIAL_DEBUG
@@ -148,13 +127,8 @@ static Bitu SERIAL_Read (Bitu port, Bitu iolen) {
 	return retval;	
 }
 static void SERIAL_Write (Bitu port, Bitu val, Bitu) {
-	Bitu i;
-	Bitu index = port & 0x7;
-	switch(port&0xff8) {
-		case 0x3f8: i=0; break;
-		case 0x2f8: i=1; break;
-		case 0x3e8: i=2; break;
-		case 0x2e8: i=3; break;
+	uint32_t i;
+	const uint8_t offset_type = static_cast<uint8_t>(port) & 0x7;
 		default: return;
 	}
 	if(serialports[i]==0) return;
@@ -163,32 +137,22 @@ static void SERIAL_Write (Bitu port, Bitu val, Bitu) {
 		const char* const dbgtext[]={"THR","IER","FCR",
 			"LCR","MCR","!LSR","MSR","SPR","DLL","DLM"};
 		if(serialports[i]->dbg_register) {
-			Bitu debugindex=index;
-			if((index<2) && ((serialports[i]->LCR)&LCR_DIVISOR_Enable_MASK))
+		        uint32_t debugindex = offset_type;
+		        if ((offset_type < 2) &&
+		            ((serialports[i]->LCR) & LCR_DIVISOR_Enable_MASK))
 				debugindex += 8;
 			serialports[i]->log_ser(serialports[i]->dbg_register,
-				"write 0x%2x to %s.",val,dbgtext[debugindex]);
+		                                "write 0x%2x to %s.", val,
+		                                dbgtext[debugindex]);
 		}
 #endif
-	switch (index) {
-		case THR_OFFSET:
-			serialports[i]->Write_THR (val);
-			return;
-		case IER_OFFSET:
-			serialports[i]->Write_IER (val);
-			return;
-		case FCR_OFFSET:
-			serialports[i]->Write_FCR (val);
-			return;
-		case LCR_OFFSET:
-			serialports[i]->Write_LCR (val);
-			return;
-		case MCR_OFFSET:
-			serialports[i]->Write_MCR (val);
-			return;
-		case MSR_OFFSET:
-			serialports[i]->Write_MSR (val);
-			return;
+	        switch (offset_type) {
+	        case THR_OFFSET: serialports[i]->Write_THR(val); return;
+	        case IER_OFFSET: serialports[i]->Write_IER(val); return;
+	        case FCR_OFFSET: serialports[i]->Write_FCR(val); return;
+	        case LCR_OFFSET: serialports[i]->Write_LCR(val); return;
+	        case MCR_OFFSET: serialports[i]->Write_MCR(val); return;
+	        case MSR_OFFSET: serialports[i]->Write_MSR(val); return;
 		case SPR_OFFSET:
 			serialports[i]->Write_SPR (val);
 			return;
@@ -208,7 +172,7 @@ void CSerial::log_ser(bool active, char const* format,...) {
 		vsprintf(buf+strlen(buf),format,msg);
 		va_end(msg);
 		// Add newline if not present
-		Bitu len=strlen(buf);
+		const uint32_t len = strlen(buf);
 		if(buf[len-1]!='\n') strcat(buf,"\r\n");
 		fputs(buf,debugfp);
 	}
@@ -235,7 +199,7 @@ void CSerial::changeLineProperties() {
 }
 
 static void Serial_EventHandler(Bitu val) {
-	Bitu serclassid=val&0x3;
+	const uint32_t serclassid = val & 0x3;
 	if(serialports[serclassid]!=0)
 		serialports[serclassid]->handleEvent(val>>2);
 }
@@ -329,8 +293,7 @@ void CSerial::clear (Bit8u priority) {
 }
 
 void CSerial::ComputeInterrupts () {
-
-	Bitu val = IER & waiting_interrupts;
+	const uint32_t val = IER & waiting_interrupts;
 
 	if (val & ERROR_PRIORITY)			ISR = ISR_ERROR_VAL;
 	else if (val & TIMEOUT_PRIORITY)	ISR = ISR_FIFOTIMEOUT_VAL;
@@ -540,11 +503,12 @@ void CSerial::Write_THR (Bit8u data) {
 /*****************************************************************************/
 /* Receive Holding Register, also LSB of Divisor Latch (r/w)                **/
 /*****************************************************************************/
-Bitu CSerial::Read_RHR () {
+uint32_t CSerial::Read_RHR()
+{
 	// 0-7 received data
 	if ((LCR & LCR_DIVISOR_Enable_MASK)) return baud_divider&0xff;
 	else {
-		Bit8u data=rxfifo->getb();
+		uint8_t data = rxfifo->getb();
 		if(FCR&FCR_ACTIVATE) {
 			Bit8u error=errorfifo->getb();
 			if(error) errors_in_fifo--;
@@ -572,7 +536,8 @@ Bitu CSerial::Read_RHR () {
 /*****************************************************************************/
 // Modified by:
 // - writing to it.
-Bitu CSerial::Read_IER () {
+uint32_t CSerial::Read_IER()
+{
 	// 0	receive holding register (byte received)
 	// 1	transmit holding register (byte sent)
 	// 2	receive line status (overrun, parity error, frame error, break)
@@ -605,7 +570,8 @@ void CSerial::Write_IER (Bit8u data) {
 // modified by:
 // - incoming interrupts
 // - loopback mode
-Bitu CSerial::Read_ISR () {
+uint32_t CSerial::Read_ISR()
+{
 	// 0	0:interrupt pending 1: no interrupt
 	// 1-3	identification
 	//      011 LSR
@@ -669,7 +635,8 @@ void CSerial::Write_FCR (Bit8u data) {
 // - switch between RHR/THR and baud rate registers
 // Modified by:
 // - writing to it.
-Bitu CSerial::Read_LCR () {
+uint32_t CSerial::Read_LCR()
+{
 	// 0-1	word length
 	// 2	stop bits
 	// 3	parity enable
@@ -703,7 +670,8 @@ void CSerial::Write_LCR (Bit8u data) {
 // Set levels of RTS and DTR, as well as loopback-mode.
 // Modified by: 
 // - writing to it.
-Bitu CSerial::Read_MCR () {
+uint32_t CSerial::Read_MCR()
+{
 	// 0	-DTR
 	// 1	-RTS
 	// 2	-OP1
@@ -810,13 +778,9 @@ void CSerial::Write_MCR (Bit8u data) {
 // modified by:
 // - event from real serial port
 // - loopback
-Bitu CSerial::Read_LSR () {
-	Bitu retval = LSR & (LSR_ERROR_MASK|LSR_TX_EMPTY_MASK);
-	if(txfifo->isEmpty()) retval |= LSR_TX_HOLDING_EMPTY_MASK;
-	if(!(rxfifo->isEmpty()))retval |= LSR_RX_DATA_READY_MASK;
-	if(errors_in_fifo) retval |= FIFO_ERROR;
-	LSR &= (~LSR_ERROR_MASK);			// clear error bits on read
-	clear (ERROR_PRIORITY);
+uint32_t CSerial::Read_LSR()
+{
+	uint32_t retval = LSR & (LSR_ERROR_MASK | LSR_TX_EMPTY_MASK);
 	return retval;
 }
 
@@ -835,8 +799,7 @@ void CSerial::Write_MSR (Bit8u val) {
 // modified by:
 // - real values
 // - write operation to MCR in loopback mode
-Bitu CSerial::Read_MSR () {
-	Bit8u retval=0;
+uint32_t CSerial::Read_MSR()
 	
 	if (loopback) {
 		
@@ -873,7 +836,8 @@ Bitu CSerial::Read_MSR () {
 /* Scratchpad Register (r/w)                                                **/
 /*****************************************************************************/
 // Just a memory register. Not much to do here.
-Bitu CSerial::Read_SPR () {
+uint32_t CSerial::Read_SPR()
+{
 	return SPR;
 }
 
@@ -1080,7 +1044,7 @@ CSerial::CSerial(const uint8_t port_index_, CommandLine *cmd)
 	const uint16_t base = serial_baseaddr[port_index];
 
 	irq = serial_defaultirq[port_index];
-	getBituSubstring("irq:",&irq, cmd);
+	getUintFromString("irq:", irq, cmd);
 	if (irq < 2 || irq > 15)
 		irq = serial_defaultirq[port_index];
 
@@ -1135,29 +1099,28 @@ CSerial::CSerial(const uint8_t port_index_, CommandLine *cmd)
 	overrunIF0=0;
 	breakErrors=0;
 
-	for (Bitu i = 0; i <= 7; i++) {
+	for (uint32_t i = 0; i <= 7; i++) {
 		WriteHandler[i].Install (i + base, SERIAL_Write, IO_MB);
-		ReadHandler[i].Install (i + base, SERIAL_Read, IO_MB);
+		ReadHandler[i].Install(i + base, SERIAL_Read, IO_MB);
 	}
 }
 
-bool CSerial::getBituSubstring(const char* name,Bitu* data, CommandLine* cmd) {
+bool CSerial::getUintFromString(const char *name, uint32_t &data, CommandLine *cmd)
+{
+	bool result = false;
 	std::string tmpstring;
-	if(!(cmd->FindStringBegin(name,tmpstring,false))) return false;
-	const char* tmpchar = tmpstring.c_str();
-	unsigned int d = 0;
-	if(sscanf(tmpchar,"%u",&d) != 1) return false;
-	*data = static_cast<Bitu>(d);
-	return true;
+	if (cmd->FindStringBegin(name, tmpstring, false))
+		result = (sscanf(tmpstring.c_str(), "%u", &data) == 1);
+	return result;
 }
 
 CSerial::~CSerial(void) {
 	DOS_DelDevice(mydosdevice);
-	for(Bitu i = 0; i <= SERIAL_BASE_EVENT_COUNT; i++)
+	for (uint32_t i = 0; i <= SERIAL_BASE_EVENT_COUNT; i++)
 		removeEvent(i);
 };
-bool CSerial::Getchar(Bit8u* data, Bit8u* lsr, bool wait_dsr, Bitu timeout) {
-	double starttime=PIC_FullIndex();
+bool CSerial::Getchar(uint8_t *data, uint8_t *lsr, bool wait_dsr, uint32_t timeout)
+{
 	// wait for DSR on
 	if(wait_dsr) {
 		while((!(Read_MSR()&0x20))&&(starttime>PIC_FullIndex()-timeout))
@@ -1192,9 +1155,8 @@ uint8_t CSerial::PortNumber() const
 	return port_index + 1;
 }
 
-bool CSerial::Putchar(Bit8u data, bool wait_dsr, bool wait_cts, Bitu timeout) {
-	
-	double starttime=PIC_FullIndex();
+bool CSerial::Putchar(uint8_t data, bool wait_dsr, bool wait_cts, uint32_t timeout)
+{
 	// wait for it to become empty
 	while(!(Read_LSR()&0x20)) {
 		CALLBACK_Idle();

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -366,15 +366,15 @@ void CSerialModem::EnterIdleState(void){
 
 		serversocket.reset(new TCPServerSocket(listenport));
 		if (!serversocket->isopen) {
-			LOG_MSG("Serial%" PRIuPTR ": Modem could not open TCP port %" PRIuPTR ".",
-			        COMNUMBER,
-			        listenport);
+			LOG_MSG("Serial Port %u: Modem could not open TCP port "
+			        "%" PRIuPTR ".",
+			        PortNumber(), listenport);
 
 			serversocket.reset(nullptr);
 		} else
-			LOG_MSG("Serial%" PRIuPTR ": Modem listening on port %" PRIuPTR "...",
-			        COMNUMBER,
-			        listenport);
+			LOG_MSG("Serial Port %u: Modem listening on port "
+			        "%" PRIuPTR "...",
+			        PortNumber(), listenport);
 	}
 	waitingclientsocket.reset(nullptr);
 

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -102,8 +102,8 @@ static const char *MODEM_GetAddressFromPhone(const char *input) {
 	return nullptr;
 }
 
-CSerialModem::CSerialModem(Bitu id, CommandLine* cmd)
-	: CSerial(id, cmd),
+CSerialModem::CSerialModem(const uint8_t port_index_, CommandLine *cmd)
+        : CSerial(port_index_, cmd),
 	  rqueue(new CFifo(MODEM_BUFFER_QUEUE_SIZE)),
 	  tqueue(new CFifo(MODEM_BUFFER_QUEUE_SIZE)),
 	  cmdbuf {0},
@@ -135,7 +135,7 @@ CSerialModem::CSerialModem(Bitu id, CommandLine* cmd)
 	InstallationSuccessful=false;
 
 	// Setup the listening port, and ignore the return code as this is optional
-	(void) getBituSubstring("listenport:", &listenport, cmd);
+	(void)getUintFromString("listenport:", listenport, cmd);
 
 	// TODO: Fix dialtones if requested
 	//mhd.chan=MIXER_AddChannel((MIXER_MixHandler)this->MODEM_CallBack,8000,"MODEM");
@@ -151,7 +151,8 @@ CSerialModem::CSerialModem(Bitu id, CommandLine* cmd)
 
 CSerialModem::~CSerialModem() {
 	// remove events
-	for (Bitu i = SERIAL_BASE_EVENT_COUNT+1; i <= SERIAL_MODEM_EVENT_COUNT; i++)
+	for (uint32_t i = SERIAL_BASE_EVENT_COUNT + 1;
+	     i <= SERIAL_MODEM_EVENT_COUNT; i++)
 		removeEvent(i);
 }
 
@@ -175,7 +176,7 @@ void CSerialModem::handleUpperEvent(Bit16u type) {
 				CSerial::setCTS(false);
 			}
 		} else {
-			static Bits lcount=0;
+			static uint16_t lcount=0;
 			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: TX Buffer overflow!");
@@ -209,7 +210,8 @@ void CSerialModem::SendLine(const char *line) {
 }
 
 // only for numbers < 1000...
-void CSerialModem::SendNumber(Bitu val) {
+void CSerialModem::SendNumber(uint32_t val)
+{
 	rqueue->addb(0xd);
 	rqueue->addb(0xa);
 
@@ -225,7 +227,7 @@ void CSerialModem::SendNumber(Bitu val) {
 
 void CSerialModem::SendRes(const ResTypes response) {
 	char const * string = nullptr;
-	Bitu code = -1;
+	uint32_t code = -1;
 	switch (response) {
 		case ResOK:         code = 0; string = "OK"; break;
 		case ResCONNECT:    code = 1; string = "CONNECT 57600"; break;
@@ -242,7 +244,7 @@ void CSerialModem::SendRes(const ResTypes response) {
 		if (doresponse == 2 && (response == ResRING ||
 			response == ResCONNECT || response == ResNOCARRIER))
 			return;
-		if (numericresponse && code != static_cast<Bitu>(-1))
+		if (numericresponse && code != static_cast<uint32_t>(-1))
 			SendNumber(code);
 		else if (string != nullptr)
 			SendLine(string);
@@ -301,8 +303,9 @@ void CSerialModem::AcceptIncomingCall(void) {
 	}
 }
 
-Bitu CSerialModem::ScanNumber(char * & scan) const {
-	Bitu ret=0;
+uint32_t CSerialModem::ScanNumber(char *&scan) const
+{
+	uint32_t ret = 0;
 	while (char c = *scan) {
 		if (c >= '0' && c <= '9') {
 			ret*=10;
@@ -581,7 +584,7 @@ void CSerialModem::DoCommand() {
 			// Response options
 			// 0 = all on, 1 = all off,
 			// 2 = no ring and no connect/carrier in answermode
-			Bitu val = ScanNumber(scanbuf);
+			const uint32_t val = ScanNumber(scanbuf);
 			if (!(val > 2)) {
 				doresponse = val;
 				break;
@@ -591,7 +594,7 @@ void CSerialModem::DoCommand() {
 			}
 		}
 		case 'S': { // Registers
-			Bitu index = ScanNumber(scanbuf);
+			const uint32_t index = ScanNumber(scanbuf);
 			if (index >= SREGS) {
 				SendRes(ResERROR);
 				return; //goto ret_none;
@@ -604,7 +607,7 @@ void CSerialModem::DoCommand() {
 				scanbuf++;
 				while (scanbuf[0] == ' ')
 					scanbuf++; // skip spaces
-				Bitu val = ScanNumber(scanbuf);
+				const uint32_t val = ScanNumber(scanbuf);
 				reg[index] = val;
 				break;
 			}
@@ -620,8 +623,8 @@ void CSerialModem::DoCommand() {
 			char cmdchar = GetChar(scanbuf);
 			switch(cmdchar) {
 				case 'K': {
-					Bitu val = ScanNumber(scanbuf);
-					if(val < 5)
+				        const uint32_t val = ScanNumber(scanbuf);
+				        if (val < 5)
 						flowcontrol = val;
 					else {
 						SendRes(ResERROR);
@@ -630,8 +633,9 @@ void CSerialModem::DoCommand() {
 					break;
 				}
 				case 'D': {
-					Bitu val = ScanNumber(scanbuf);
-					if (val<4) dtrmode=val;
+				        const uint32_t val = ScanNumber(scanbuf);
+				        if (val < 4)
+					        dtrmode = val;
 					else {
 						SendRes(ResERROR);
 						return;
@@ -684,11 +688,9 @@ void CSerialModem::DoCommand() {
 	}
 }
 
-void CSerialModem::TelnetEmulation(Bit8u * data, Bitu size) {
-	Bitu i;
-	Bit8u c;
-	for (i=0; i < size; i++) {
-		c = data[i];
+void CSerialModem::TelnetEmulation(uint8_t *data, uint32_t size)
+{
+	for (uint32_t i = 0; i < size; i++) {
 		if (telClient.inIAC) {
 			if (telClient.recCommand) {
 				if ((c != 0) && (c != 1) && (c != 3)) {
@@ -786,9 +788,7 @@ void CSerialModem::TelnetEmulation(Bit8u * data, Bitu size) {
 }
 
 void CSerialModem::Timer2(void) {
-	Bitu usesize;
-	Bit8u txval;
-	Bitu txbuffersize =0;
+	uint32_t txbuffersize = 0;
 
 	// Check for eventual break command
 	if (!commandmode) {
@@ -809,7 +809,7 @@ void CSerialModem::Timer2(void) {
 	// Handle incoming data from serial port, read as much as available
 	CSerial::setCTS(true);	// buffer will get 'emptier', new data can be received
 	while (tqueue->inuse()) {
-		txval = tqueue->getb();
+		const uint8_t txval = tqueue->getb();
 		if (commandmode) {
 			if (echo) {
 				rqueue->addb(txval);
@@ -852,9 +852,7 @@ void CSerialModem::Timer2(void) {
 	}
 	// Handle incoming to the serial port
 	if (!commandmode && clientsocket && rqueue->left()) {
-		usesize = rqueue->left();
-		if (usesize > 16)
-			usesize = 16;
+		uint32_t usesize = rqueue->left() >= 16 ? 16 : rqueue->left();
 		if (!clientsocket->ReceiveArray(tmpbuf, &usesize)) {
 			SendRes(ResNOCARRIER);
 			EnterIdleState();

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -57,7 +57,8 @@ static const char phoneValidChars[] = "01234567890*=,;#+>";
 static bool MODEM_IsPhoneValid(const std::string &input) {
 	size_t found = input.find_first_not_of(phoneValidChars);
 	if (found != std::string::npos) {
-		LOG_MSG("SERIAL: Phone %s contains invalid character %c", input.c_str(), input[found]);
+		LOG_MSG("SERIAL: Phonebook %s contains invalid character %c.",
+		        input.c_str(), input[found]);
 		return false;
 	}
 
@@ -69,7 +70,7 @@ bool MODEM_ReadPhonebook(const std::string &filename) {
 	if (!loadfile)
 		return false;
 
-	LOG_MSG("SERIAL: Loading phonebook from %s", filename.c_str());
+	LOG_MSG("SERIAL: Phonebook loading from %s.", filename.c_str());
 
 	std::string linein;
 	while (std::getline(loadfile, linein)) {
@@ -77,7 +78,8 @@ bool MODEM_ReadPhonebook(const std::string &filename) {
 		std::string phone, address;
 
 		if (!(iss >> phone >> address)) {
-			LOG_MSG("SERIAL: Skipped a bad line in %s", filename.c_str());
+			LOG_MSG("SERIAL: Phonebook skipped a bad line in %s.",
+			        filename.c_str());
 			continue;
 		}
 
@@ -85,7 +87,8 @@ bool MODEM_ReadPhonebook(const std::string &filename) {
 		if (!MODEM_IsPhoneValid(phone))
 			continue;
 
-		LOG_MSG("SERIAL: Mapped phone %s to address %s", phone.c_str(), address.c_str());
+		LOG_MSG("SERIAL: Phonebook mapped %s to address %s.", phone.c_str(),
+		        address.c_str());
 		PhonebookEntry *pbEntry = new PhonebookEntry(phone, address);
 		phones.push_back(pbEntry);
 	}
@@ -102,40 +105,20 @@ static const char *MODEM_GetAddressFromPhone(const char *input) {
 	return nullptr;
 }
 
-CSerialModem::CSerialModem(const uint8_t port_index_, CommandLine *cmd)
-        : CSerial(port_index_, cmd),
-	  rqueue(new CFifo(MODEM_BUFFER_QUEUE_SIZE)),
-	  tqueue(new CFifo(MODEM_BUFFER_QUEUE_SIZE)),
-	  cmdbuf {0},
-	  commandmode(false),
-	  echo(false),
-	  oldDTRstate(false),
-	  ringing(false),
-	  numericresponse(false),
-	  // Default to direct null modem connection; Telnet mode interprets IAC codes
-	  telnetmode(false),
-	  connected(false),
-	  doresponse(0),
-	  waiting_tx_character(0),
-	  cmdpause(0),
-	  ringtimer(0),
-	  ringcount(0),
-	  plusinc(0),
-	  cmdpos(0),
-	  flowcontrol(0),
-	  tmpbuf {0},
-	  listenport(23),
-	  reg {0},
-	  serversocket(nullptr),
-	  clientsocket(nullptr),
-	  waitingclientsocket(nullptr),
-	  telClient {},
-	  dial {}
+CSerialModem::CSerialModem(const uint8_t port_idx, CommandLine *cmd)
+        : CSerial(port_idx, cmd),
+          rqueue(std::make_unique<CFifo>(MODEM_BUFFER_QUEUE_SIZE)),
+          tqueue(std::make_unique<CFifo>(MODEM_BUFFER_QUEUE_SIZE)),
+          telClient({}),
+          dial({})
 {
 	InstallationSuccessful=false;
 
-	// Setup the listening port, and ignore the return code as this is optional
-	(void)getUintFromString("listenport:", listenport, cmd);
+	// Setup the listening port
+	uint32_t val;
+	if (getUintFromString("listenport:", val, cmd))
+		listenport = val;
+	// Otherwise the default listenport will be used
 
 	// TODO: Fix dialtones if requested
 	//mhd.chan=MIXER_AddChannel((MIXER_MixHandler)this->MODEM_CallBack,8000,"MODEM");
@@ -156,14 +139,16 @@ CSerialModem::~CSerialModem() {
 		removeEvent(i);
 }
 
-void CSerialModem::handleUpperEvent(Bit16u type) {
+void CSerialModem::handleUpperEvent(uint16_t type)
+{
 	switch (type) {
 	case SERIAL_RX_EVENT: {
 		// check for bytes to be sent to port
 		if (CSerial::CanReceiveByte())
 			if (rqueue->inuse() && (CSerial::getRTS() || (flowcontrol != 3))) {
-				Bit8u rbyte = rqueue->getb();
-				//LOG_MSG("Modem: sending byte %2x back to UART3",rbyte);
+				uint8_t rbyte = rqueue->getb();
+				// LOG_MSG("SERIAL: Port %" PRIu8 " modem sending byte %2x"
+				//         " back to UART3", GetPortNumber(), rbyte);
 				CSerial::receiveByte(rbyte);
 			}
 		if(CSerial::CanReceiveByte()) setEvent(SERIAL_RX_EVENT, bytetime*0.98f);
@@ -179,7 +164,8 @@ void CSerialModem::handleUpperEvent(Bit16u type) {
 			static uint16_t lcount=0;
 			if (lcount < 1000) {
 				lcount++;
-				LOG_MSG("MODEM: TX Buffer overflow!");
+				LOG_MSG("SERIAL: Port %" PRIu8 " modem TX buffer overflow!",
+				        GetPortNumber());
 			}
 		}
 		ByteTransmitted();
@@ -204,7 +190,7 @@ void CSerialModem::handleUpperEvent(Bit16u type) {
 void CSerialModem::SendLine(const char *line) {
 	rqueue->addb(0xd);
 	rqueue->addb(0xa);
-	rqueue->adds((Bit8u *)line, strlen(line));
+	rqueue->adds((uint8_t *)line, strlen(line));
 	rqueue->addb(0xd);
 	rqueue->addb(0xa);
 }
@@ -249,15 +235,17 @@ void CSerialModem::SendRes(const ResTypes response) {
 		else if (string != nullptr)
 			SendLine(string);
 
-		//if(CSerial::CanReceiveByte())	// very fast response
+		// if(CSerial::CanReceiveByte())	// very fast response
 		//	if(rqueue->inuse() && CSerial::getRTS())
-		//	{ Bit8u rbyte =rqueue->getb();
+		//	{ uint8_t rbyte =rqueue->getb();
 		//		CSerial::receiveByte(rbyte);
-		//	LOG_MSG("Modem: sending byte %2x back to UART2",rbyte);
+		//	LOG_MSG("SERIAL: Port %" PRIu8 " modem sending byte %2x back to UART2",
+		//	        GetPortNumber(), rbyte);
 		//	}
 
 		if (string != nullptr) {
-			LOG_MSG("Modem response: %s", string);
+			LOG_MSG("SERIAL: Port %" PRIu8 " modem response: %s.",
+			        GetPortNumber(), string);
 		}
 	}
 }
@@ -269,22 +257,23 @@ bool CSerialModem::Dial(const char * host) {
 	const char *destination = buf;
 
 	// Scan host for port
-	Bit16u port;
+	uint16_t port;
 	char * hasport = strrchr(buf,':');
 	if (hasport) {
 		*hasport++ = 0;
-		port = (Bit16u)atoi(hasport);
+		port = (uint16_t)atoi(hasport);
 	}
 	else {
 		port = MODEM_DEFAULT_PORT;
 	}
 
 	// Resolve host we're gonna dial
-	LOG_MSG("Connecting to host %s port %u", destination, port);
+	LOG_MSG("SERIAL: Port %" PRIu8 " connecting to host %s port %" PRIu16
+	        ".", GetPortNumber(), destination, port);
 	clientsocket.reset(new TCPClientSocket(destination, port));
 	if (!clientsocket->isopen) {
 		clientsocket.reset(nullptr);
-		LOG_MSG("Failed to connect.");
+		LOG_MSG("SERIAL: Port %" PRIu8 " failed to connect.", GetPortNumber());
 		SendRes(ResNOCARRIER);
 		EnterIdleState();
 		return false;
@@ -294,7 +283,7 @@ bool CSerialModem::Dial(const char * host) {
 	}
 }
 
-void CSerialModem::AcceptIncomingCall(void) {
+void CSerialModem::AcceptIncomingCall() {
 	if (waitingclientsocket) {
 		clientsocket = std::move(waitingclientsocket);
 		EnterConnectedState();
@@ -352,7 +341,7 @@ void CSerialModem::Reset(){
 	telnetmode = false;
 }
 
-void CSerialModem::EnterIdleState(void){
+void CSerialModem::EnterIdleState(){
 	connected = false;
 	ringing = false;
 	dtrofftimer = -1;
@@ -369,15 +358,15 @@ void CSerialModem::EnterIdleState(void){
 
 		serversocket.reset(new TCPServerSocket(listenport));
 		if (!serversocket->isopen) {
-			LOG_MSG("Serial Port %u: Modem could not open TCP port "
-			        "%" PRIuPTR ".",
-			        PortNumber(), listenport);
+			LOG_MSG("SERIAL: Port %" PRIu8 " modem could not open TCP port "
+			        "%" PRIu16 ".",
+			        GetPortNumber(), listenport);
 
 			serversocket.reset(nullptr);
 		} else
-			LOG_MSG("Serial Port %u: Modem listening on port "
-			        "%" PRIuPTR "...",
-			        PortNumber(), listenport);
+			LOG_MSG("SERIAL: Port %" PRIu8 " modem listening on TCP port "
+			        "%" PRIu16 " ...",
+			        GetPortNumber(), listenport);
 	}
 	waitingclientsocket.reset(nullptr);
 
@@ -389,12 +378,12 @@ void CSerialModem::EnterIdleState(void){
 	tqueue->clear();
 }
 
-void CSerialModem::EnterConnectedState(void) {
+void CSerialModem::EnterConnectedState() {
 	// we don't accept further calls
 	serversocket.reset(nullptr);
 	SendRes(ResCONNECT);
 	commandmode = false;
-	memset(&telClient, 0, sizeof(telClient));
+	telClient = {}; // reset values
 	connected = true;
 	ringing = false;
 	dtrofftimer = -1;
@@ -406,7 +395,8 @@ void CSerialModem::DoCommand() {
 	cmdbuf[cmdpos] = 0;
 	cmdpos = 0;			//Reset for next command
 	upcase(cmdbuf);
-	LOG_MSG("Command sent to modem: ->%s<-\n", cmdbuf);
+	LOG_MSG("SERIAL: Port %" PRIu8 " command sent to modem: ->%s<-\n",
+	        GetPortNumber(), cmdbuf);
 	/* Check for empty line, stops dialing and autoanswer */
 	if (!cmdbuf[0]) {
 		reg[MREG_AUTOANSWER_COUNT] = 0;	// autoanswer off
@@ -437,7 +427,8 @@ void CSerialModem::DoCommand() {
 
 	char * scanbuf = &cmdbuf[2];
 	while (1) {
-		// LOG_MSG("loopstart ->%s<-",scanbuf);
+		// LOG_MSG("SERIAL: Port %" PRIu8 " loopstart ->%s<-",
+		//         GetPortNumber(), scanbuf);
 		char chr = GetChar(scanbuf);
 		switch (chr) {
 		case 'D': { // Dial
@@ -616,7 +607,10 @@ void CSerialModem::DoCommand() {
 				scanbuf++;
 				break;
 			}
-			//else LOG_MSG("print reg %d with %d",index,reg[index]);
+			// else
+				// LOG_MSG("SERIAL: Port %" PRIu8 " print reg %" PRIu32
+				//         " with %" PRIu8 ".",
+				//         GetPortNumber(), index, reg[index]);
 		}
 		break;
 		case '&': { // & escaped commands
@@ -625,34 +619,34 @@ void CSerialModem::DoCommand() {
 				case 'K': {
 				        const uint32_t val = ScanNumber(scanbuf);
 				        if (val < 5)
-						flowcontrol = val;
-					else {
-						SendRes(ResERROR);
-						return;
-					}
-					break;
-				}
-				case 'D': {
+					        flowcontrol = val;
+				        else {
+					        SendRes(ResERROR);
+					        return;
+				        }
+				        break;
+			        }
+			        case 'D': {
 				        const uint32_t val = ScanNumber(scanbuf);
 				        if (val < 4)
 					        dtrmode = val;
-					else {
-						SendRes(ResERROR);
-						return;
-					}
-					break;
-				}
-				case '\0':
-					// end of string
-					SendRes(ResERROR);
-					return;
-				default:
-					LOG_MSG("Modem: Unhandled command: &%c%" PRIuPTR,
-					        cmdchar,
-					        ScanNumber(scanbuf));
-					break;
-			}
-			break;
+				        else {
+					        SendRes(ResERROR);
+					        return;
+				        }
+				        break;
+			        }
+			        case '\0':
+				        // end of string
+				        SendRes(ResERROR);
+				        return;
+			        default:
+				        LOG_MSG("SERIAL: Port %" PRIu8 " unhandled "
+				                "modem command: &%c%" PRIu32 ".",
+				                GetPortNumber(), cmdchar, ScanNumber(scanbuf));
+				        break;
+			        }
+			        break;
 		}
 		case '\\': { // \ escaped commands
 			char cmdchar = GetChar(scanbuf);
@@ -669,20 +663,20 @@ void CSerialModem::DoCommand() {
 					SendRes(ResERROR);
 					return;
 				default:
-					LOG_MSG("Modem: Unhandled command: \\%c%" PRIuPTR,
-					        cmdchar,
-					        ScanNumber(scanbuf));
-					break;
-			}
-			break;
+				        LOG_MSG("SERIAL: Port %" PRIu8 " unhandled "
+				                "modem command: \\%c%" PRIu32 ".",
+				                GetPortNumber(), cmdchar, ScanNumber(scanbuf));
+				        break;
+			        }
+			        break;
 		}
 		case '\0':
 			SendRes(ResOK);
 			return;
 		default:
-			LOG_MSG("Modem: Unhandled command: %c%" PRIuPTR,
-			        chr,
-			        ScanNumber(scanbuf));
+			LOG_MSG("SERIAL: Port %" PRIu8 " unhandled modem command: "
+			        "%c%" PRIu32 ".",
+			        GetPortNumber(), chr, ScanNumber(scanbuf));
 			break;
 		}
 	}
@@ -691,10 +685,13 @@ void CSerialModem::DoCommand() {
 void CSerialModem::TelnetEmulation(uint8_t *data, uint32_t size)
 {
 	for (uint32_t i = 0; i < size; i++) {
+		uint8_t c = data[i];
 		if (telClient.inIAC) {
 			if (telClient.recCommand) {
 				if ((c != 0) && (c != 1) && (c != 3)) {
-					LOG_MSG("MODEM: Unrecognized option %u", c);
+					LOG_MSG("SERIAL: Port %" PRIu8 " unrecognized "
+					        "modem option %" PRIu8 ".",
+					        GetPortNumber(), c);
 					if (telClient.command > 250) {
 						/* Reject anything we don't recognize */
 						tqueue->addb(0xff);
@@ -754,7 +751,9 @@ void CSerialModem::TelnetEmulation(uint8_t *data, uint32_t size)
 					}
 					break;
 				default:
-					LOG_MSG("MODEM: Telnet client sent IAC %d", telClient.command);
+					LOG_MSG("SERIAL: Port %" PRIu8 " telnet client "
+					        "sent IAC %" PRIu8 ".",
+					        GetPortNumber(), telClient.command);
 					break;
 			}
 			telClient.inIAC = false;
@@ -777,17 +776,17 @@ void CSerialModem::TelnetEmulation(uint8_t *data, uint32_t size)
 				continue;
 			}
 		}
-	} else {
-		if (c == 0xff) {
-			telClient.inIAC = true;
-			continue;
-		}
+		} else {
+			if (c == 0xff) {
+				telClient.inIAC = true;
+				continue;
+			}
 			rqueue->addb(c);
 		}
 	}
 }
 
-void CSerialModem::Timer2(void) {
+void CSerialModem::Timer2() {
 	uint32_t txbuffersize = 0;
 
 	// Check for eventual break command
@@ -798,7 +797,9 @@ void CSerialModem::Timer2(void) {
 				plusinc = 1;
 			}
 			else if (plusinc == 4) {
-				LOG_MSG("Modem: Entering command mode(escape sequence)");
+				LOG_MSG("SERIAL: Port %" PRIu8 " modem entering "
+				        "command mode (escape sequence).",
+				        GetPortNumber());
 				commandmode = true;
 				SendRes(ResOK);
 				plusinc = 0;
@@ -813,7 +814,8 @@ void CSerialModem::Timer2(void) {
 		if (commandmode) {
 			if (echo) {
 				rqueue->addb(txval);
-				//LOG_MSG("Echo back to queue: %x",txval);
+				// LOG_MSG("SERIAL: Port %" PRIu8 " echo back to queue: %x.",
+				//         GetPortNumber(), txval);
 			}
 
 			if (txval == '\n')
@@ -852,8 +854,8 @@ void CSerialModem::Timer2(void) {
 	}
 	// Handle incoming to the serial port
 	if (!commandmode && clientsocket && rqueue->left()) {
-		uint32_t usesize = rqueue->left() >= 16 ? 16 : rqueue->left();
-		if (!clientsocket->ReceiveArray(tmpbuf, &usesize)) {
+		size_t usesize = rqueue->left() >= 16 ? 16 : rqueue->left();
+		if (!clientsocket->ReceiveArray(tmpbuf, usesize)) {
 			SendRes(ResNOCARRIER);
 			EnterIdleState();
 		} else if (usesize) {
@@ -903,24 +905,31 @@ void CSerialModem::Timer2(void) {
 			switch (dtrmode) {
 				case 0:
 					// Do nothing.
-					//LOG_MSG("Modem: Dropped DTR.");
+					//LOG_MSG("SERIAL: Port %" PRIu8 " modem dropped DTR.", GetPortNumber());
 					break;
 				case 1:
 					// Go back to command mode.
-					LOG_MSG("Modem: Entering command mode due to dropped DTR.");
-					commandmode = true;
+				        LOG_MSG("SERIAL: Port %" PRIu8 " modem "
+				                "entering command mode due to "
+				                "dropped DTR.",
+				                GetPortNumber());
+				        commandmode = true;
 					SendRes(ResOK);
 					break;
 				case 2:
 					// Hang up.
-					LOG_MSG("Modem: Hanging up due to dropped DTR.");
-					SendRes(ResNOCARRIER);
+				        LOG_MSG("SERIAL: Port %" PRIu8 " modem hanging "
+				                "up due to dropped DTR.",
+				                GetPortNumber());
+				        SendRes(ResNOCARRIER);
 					EnterIdleState();
 					break;
 				case 3:
 					// Reset.
-					LOG_MSG("Modem: Resetting due to dropped DTR.");
-					SendRes(ResNOCARRIER);
+				        LOG_MSG("SERIAL: Port %" PRIu8 " modem "
+				                "resetting due to dropped DTR.",
+				                GetPortNumber());
+				        SendRes(ResNOCARRIER);
 					Reset();
 					break;
 			}
@@ -938,22 +947,26 @@ void CSerialModem::Timer2(void) {
 void CSerialModem::RXBufferEmpty() {
 	// see if rqueue has some more bytes
 	if (rqueue->inuse() && (CSerial::getRTS() || (flowcontrol != 3))){
-		Bit8u rbyte = rqueue->getb();
-		//LOG_MSG("Modem: sending byte %2x back to UART1",rbyte);
+		uint8_t rbyte = rqueue->getb();
+		// LOG_MSG("SERIAL: Port %" PRIu8 " modem sending byte %2x back to UART1.",
+		//         GetPortNumber(), rbyte);
 		CSerial::receiveByte(rbyte);
 	}
 }
 
-void CSerialModem::transmitByte(Bit8u val, bool first) {
+void CSerialModem::transmitByte(uint8_t val, bool first)
+{
 	waiting_tx_character = val;
 	setEvent(MODEM_TX_EVENT, bytetime); // TX event
 	if (first)
 		ByteTransmitting();
-	//LOG_MSG("MODEM: Byte %x to be transmitted",val);
+	// LOG_MSG("SERIAL: Port %" PRIu8 " modem byte %x to be transmitted.",
+	// GetPortNumber(), val);
 }
 
-void CSerialModem::updatePortConfig(Bit16u, Bit8u lcr) {
-	(void) lcr; // deliberately unused but needed for API compliance
+void CSerialModem::updatePortConfig(uint16_t, uint8_t lcr)
+{
+	(void)lcr; // deliberately unused but needed for API compliance
 }
 
 void CSerialModem::updateMSR() {
@@ -964,9 +977,9 @@ void CSerialModem::setBreak(bool) {
 	// TODO: handle this
 }
 
-void CSerialModem::setRTSDTR(bool rts_, bool dtr_) {
-	(void) rts_; // deliberately unused but needed for API compliance
-	setDTR(dtr_);
+void CSerialModem::setRTSDTR(bool rts_state, bool dtr_state) {
+	(void) rts_state; // deliberately unused but needed for API compliance
+	setDTR(dtr_state);
 }
 void CSerialModem::setRTS(bool val) {
 	(void) val; // deliberately unused but but needed for API compliance
@@ -985,20 +998,21 @@ void CSerialModem::setDTR(bool val) {
 }
 /*
 void CSerialModem::updateModemControlLines() {
-	//bool txrdy=tqueue->left();
-	//if(CSerial::getRTS() && txrdy) CSerial::setCTS(true);
-	//else CSerial::setCTS(tqueue->left());
+        //bool txrdy=tqueue->left();
+        //if(CSerial::getRTS() && txrdy) CSerial::setCTS(true);
+        //else CSerial::setCTS(tqueue->left());
 
-	// If DTR goes low, hang up.
-	if(connected)
-		if(oldDTRstate)
-			if(!getDTR()) {
-				SendRes(ResNOCARRIER);
-				EnterIdleState();
-				LOG_MSG("Modem: Hang up due to dropped DTR.");
-			}
+        // If DTR goes low, hang up.
+        if(connected)
+                if(oldDTRstate)
+                        if(!getDTR()) {
+                                SendRes(ResNOCARRIER);
+                                EnterIdleState();
+                                LOG_MSG("SERIAL: Port %" PRIu8 " modem hung up due to "
+                                        "dropped DTR.", GetPortNumber());
+                        }
 
-	oldDTRstate = getDTR();
+        oldDTRstate = getDTR();
 }
 */
 

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -61,20 +61,12 @@ bool MODEM_ReadPhonebook(const std::string &filename);
 
 class CFifo {
 public:
-	CFifo(Bitu _size)
-		: data(_size),
-		  size(_size),
-		  pos(0),
-		  used(0)
-	{}
+	CFifo(uint32_t _size) : data(_size), size(_size), pos(0), used(0) {}
 
-	INLINE Bitu left(void) const {
-		return size - used;
-	}
-	INLINE Bitu inuse(void) const {
-		return used;
-	}
-	void clear(void) {
+	INLINE uint32_t left(void) const { return size - used; }
+	INLINE uint32_t inuse(void) const { return used; }
+	void clear(void)
+	{
 		used = 0;
 		pos = 0;
 	}
@@ -89,7 +81,7 @@ public:
 			return;
 		}
 		//assert(used<size);
-		Bitu where = pos + used;
+		uint32_t where = pos + used;
 		if (where >= size)
 			where -= size;
 		data[where]=_val;
@@ -97,9 +89,7 @@ public:
 		used++;
 	}
 
-	void adds(Bit8u * _str,Bitu _len) {
-		if ( (used+_len) > size) {
-			static Bits lcount=0;
+	void adds(uint8_t *_str, uint32_t _len)
 			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: FIFO Overflow! (adds len %" PRIuPTR ")",
@@ -109,7 +99,7 @@ public:
 		}
 
 		//assert((used+_len)<=size);
-		Bitu where = pos + used;
+		uint32_t where = pos + used;
 		used += _len;
 		while (_len--) {
 			if (where >= size)
@@ -128,7 +118,7 @@ public:
 			}
 			return data[pos];
 		}
-		Bitu where = pos;
+		uint32_t where = pos;
 		if (++pos >= size)
 			pos -= size;
 		used--;
@@ -136,7 +126,8 @@ public:
 		return data[where];
 	}
 
-	void gets(Bit8u * _str,Bitu _len) {
+	void gets(uint8_t *_str, uint32_t _len)
+	{
 		if (!used) {
 			static Bits lcount = 0;
 			if (lcount < 1000) {
@@ -156,10 +147,9 @@ public:
 		}
 	}
 private:
-	std::vector<Bit8u> data;
-	Bitu size;
-	Bitu pos;
-	Bitu used;
+	uint32_t size = 0;
+	uint32_t pos = 0;
+	uint32_t used = 0;
 };
 #define MREG_AUTOANSWER_COUNT 0
 #define MREG_RING_COUNT 1
@@ -173,26 +163,26 @@ private:
 
 class CSerialModem : public CSerial {
 public:
-	CSerialModem(Bitu id, CommandLine* cmd);
+	CSerialModem(const uint8_t port_index_, CommandLine *cmd);
 	~CSerialModem();
 	void Reset();
 
 	void SendLine(const char *line);
 	void SendRes(const ResTypes response);
-	void SendNumber(Bitu val);
+	void SendNumber(uint32_t val);
 
 	void EnterIdleState();
 	void EnterConnectedState();
 	bool Dial(const char *host);
 	void AcceptIncomingCall(void);
-	Bitu ScanNumber(char * & scan) const;
+	uint32_t ScanNumber(char *&scan) const;
 	char GetChar(char * & scan) const;
 
 	void DoCommand();
 
-	// void MC_Changed(Bitu new_mc);
+	// void MC_Changed(uint32_t new_mc);
 
-	void TelnetEmulation(Bit8u * data, Bitu size);
+	void TelnetEmulation(uint8_t *data, uint32_t size);
 
 	//TODO
 	void Timer2(void);
@@ -221,21 +211,19 @@ protected:
 	bool ringing;
 	bool numericresponse;   // true: send control response as number.
 	                        // false: send text (i.e. NO DIALTONE)
-	bool telnetmode;        // true: process IAC commands.
-	bool connected;
-	Bitu doresponse;
-	Bit8u waiting_tx_character;
-	Bitu cmdpause;
-	Bits ringtimer;
-	Bits ringcount;
-	Bitu plusinc;
-	Bitu cmdpos;
-	Bitu flowcontrol;
-	Bitu dtrmode;
-	Bits dtrofftimer;
-	Bit8u tmpbuf[MODEM_BUFFER_QUEUE_SIZE];
-	Bitu listenport;
-	Bit8u reg[SREGS];
+	uint32_t doresponse = 0;
+	uint8_t waiting_tx_character = 0;
+	uint32_t cmdpause = 0;
+	int32_t ringtimer = 0;
+	int32_t ringcount = 0;
+	uint32_t plusinc = 0;
+	uint32_t cmdpos = 0;
+	uint32_t flowcontrol = 0;
+	uint32_t dtrmode = 0;
+	int32_t dtrofftimer = 0;
+	uint8_t tmpbuf[MODEM_BUFFER_QUEUE_SIZE] = {0};
+	uint32_t listenport = 23; // 23 is the default telnet TCP/IP port
+	uint8_t reg[SREGS] = {0};
 	std::unique_ptr<TCPServerSocket> serversocket;
 	std::unique_ptr<TCPClientSocket> clientsocket;
 	std::unique_ptr<TCPClientSocket> waitingclientsocket;
@@ -251,10 +239,8 @@ protected:
 	} telClient;
 
 	struct {
-		bool active;
-		double f1, f2;
-		Bitu len,pos;
-		char str[256];
+		uint32_t len = 0;
+		uint32_t pos = 0;
 	} dial;
 };
 #endif

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -204,13 +204,16 @@ public:
 	std::unique_ptr<CFifo> tqueue;
 
 protected:
-	char cmdbuf[255];
-	bool commandmode;       // true: interpret input as commands
-	bool echo;              // local echo on or off
-	bool oldDTRstate;
-	bool ringing;
-	bool numericresponse;   // true: send control response as number.
+	char cmdbuf[255] = {0};
+	bool commandmode = false; // true: interpret input as commands
+	bool echo = false;        // local echo on or off
+	bool oldDTRstate = false;
+	bool ringing = false;
+	bool numericresponse = false; // true: send control response as number.
 	                        // false: send text (i.e. NO DIALTONE)
+	bool telnetmode = false; // Default to direct null modem connection;
+	                         // Telnet mode interprets IAC
+	bool connected = false;
 	uint32_t doresponse = 0;
 	uint8_t waiting_tx_character = 0;
 	uint32_t cmdpause = 0;
@@ -229,18 +232,22 @@ protected:
 	std::unique_ptr<TCPClientSocket> waitingclientsocket;
 
 	struct {
-		bool binary[2];
-		bool echo[2];
-		bool supressGA[2];
-		bool timingMark[2];
-		bool inIAC;
-		bool recCommand;
-		Bit8u command;
+		bool binary[2] = {false};
+		bool echo[2] = {false};
+		bool supressGA[2] = {false};
+		bool timingMark[2] = {false};
+		bool inIAC = false;
+		bool recCommand = false;
+		uint8_t command = 0;
 	} telClient;
 
 	struct {
+		bool active = false;
+		double f1 = 0.0f;
+		double f2 = 0.0f;
 		uint32_t len = 0;
 		uint32_t pos = 0;
+		char str[256] = {0};
 	} dial;
 };
 #endif

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -61,19 +61,20 @@ bool MODEM_ReadPhonebook(const std::string &filename);
 
 class CFifo {
 public:
-	CFifo(uint32_t _size) : data(_size), size(_size), pos(0), used(0) {}
+	CFifo(const size_t n) : data(n), size(n) {}
 
-	INLINE uint32_t left(void) const { return size - used; }
-	INLINE uint32_t inuse(void) const { return used; }
-	void clear(void)
+	uint32_t left() const { return size - used; }
+	uint32_t inuse() const { return used; }
+	void clear()
 	{
 		used = 0;
 		pos = 0;
 	}
 
-	void addb(Bit8u _val) {
-		if(used >= size) {
-			static Bits lcount = 0;
+	void addb(uint8_t val)
+	{
+		if (used >= size) {
+			static uint16_t lcount = 0;
 			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: FIFO Overflow! (addb)");
@@ -81,44 +82,48 @@ public:
 			return;
 		}
 		//assert(used<size);
-		uint32_t where = pos + used;
+		size_t where = pos + used;
 		if (where >= size)
 			where -= size;
-		data[where]=_val;
-		//LOG_MSG("+%x",_val);
+		data[where] = val;
+		//LOG_MSG("+%x", val);
 		used++;
 	}
 
-	void adds(uint8_t *_str, uint32_t _len)
+	void adds(uint8_t *str, size_t len)
+	{
+		if ((used + len) > size) {
+			static uint16_t lcount = 0;
 			if (lcount < 1000) {
 				lcount++;
-				LOG_MSG("MODEM: FIFO Overflow! (adds len %" PRIuPTR ")",
-				        _len);
+				LOG_MSG("MODEM: FIFO Overflow! (adds len %u)",
+				        static_cast<unsigned>(len));
 			}
 			return;
 		}
 
-		//assert((used+_len)<=size);
-		uint32_t where = pos + used;
-		used += _len;
-		while (_len--) {
+		//assert((used + len) <= size);
+		size_t where = pos + used;
+		used += len;
+		while (len--) {
 			if (where >= size)
 				where -= size;
-			//LOG_MSG("+'%x'",*_str);
-			data[where++] = *_str++;
+			//LOG_MSG("+'%x'", *str);
+			data[where++] = *str++;
 		}
 	}
 
-	Bit8u getb(void) {
+	uint8_t getb()
+	{
 		if (!used) {
-			static Bits lcount = 0;
+			static uint16_t lcount = 0;
 			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: FIFO UNDERFLOW! (getb)");
 			}
 			return data[pos];
 		}
-		uint32_t where = pos;
+		const size_t where = pos;
 		if (++pos >= size)
 			pos -= size;
 		used--;
@@ -126,30 +131,32 @@ public:
 		return data[where];
 	}
 
-	void gets(uint8_t *_str, uint32_t _len)
+	void gets(uint8_t *str, size_t len)
 	{
 		if (!used) {
-			static Bits lcount = 0;
+			static uint16_t lcount = 0;
 			if (lcount < 1000) {
 				lcount++;
-				LOG_MSG("MODEM: FIFO UNDERFLOW! (gets len %" PRIuPTR ")",
-				        _len);
+				LOG_MSG("MODEM: FIFO UNDERFLOW! (gets len %u)",
+				        static_cast<unsigned>(len));
 			}
 			return;
 		}
-			//assert(used>=_len);
-		used -= _len;
-		while (_len--) {
-			//LOG_MSG("-%x",data[pos]);
-			*_str++ = data[pos];
+		// assert(used >= len);
+		used -= len;
+		while (len--) {
+			//LOG_MSG("-%x", data[pos]);
+			*str++ = data[pos];
 			if (++pos >= size)
 				pos -= size;
 		}
 	}
+
 private:
-	uint32_t size = 0;
-	uint32_t pos = 0;
-	uint32_t used = 0;
+	std::vector<uint8_t> data;
+	size_t size = 0;
+	size_t pos = 0;
+	size_t used = 0;
 };
 #define MREG_AUTOANSWER_COUNT 0
 #define MREG_RING_COUNT 1
@@ -163,7 +170,7 @@ private:
 
 class CSerialModem : public CSerial {
 public:
-	CSerialModem(const uint8_t port_index_, CommandLine *cmd);
+	CSerialModem(const uint8_t port_idx, CommandLine *cmd);
 	~CSerialModem();
 	void Reset();
 
@@ -174,7 +181,7 @@ public:
 	void EnterIdleState();
 	void EnterConnectedState();
 	bool Dial(const char *host);
-	void AcceptIncomingCall(void);
+	void AcceptIncomingCall();
 	uint32_t ScanNumber(char *&scan) const;
 	char GetChar(char * & scan) const;
 
@@ -185,13 +192,13 @@ public:
 	void TelnetEmulation(uint8_t *data, uint32_t size);
 
 	//TODO
-	void Timer2(void);
-	void handleUpperEvent(Bit16u type);
+	void Timer2();
+	void handleUpperEvent(uint16_t type);
 
 	void RXBufferEmpty();
 
-	void transmitByte(Bit8u val, bool first);
-	void updatePortConfig(Bit16u divider, Bit8u lcr);
+	void transmitByte(uint8_t val, bool first);
+	void updatePortConfig(uint16_t divider, uint8_t lcr);
 	void updateMSR();
 
 	void setBreak(bool);
@@ -210,7 +217,7 @@ protected:
 	bool oldDTRstate = false;
 	bool ringing = false;
 	bool numericresponse = false; // true: send control response as number.
-	                        // false: send text (i.e. NO DIALTONE)
+	                              // false: send text (i.e. NO DIALTONE)
 	bool telnetmode = false; // Default to direct null modem connection;
 	                         // Telnet mode interprets IAC
 	bool connected = false;
@@ -225,11 +232,11 @@ protected:
 	uint32_t dtrmode = 0;
 	int32_t dtrofftimer = 0;
 	uint8_t tmpbuf[MODEM_BUFFER_QUEUE_SIZE] = {0};
-	uint32_t listenport = 23; // 23 is the default telnet TCP/IP port
+	uint16_t listenport = 23; // 23 is the default telnet TCP/IP port
 	uint8_t reg[SREGS] = {0};
-	std::unique_ptr<TCPServerSocket> serversocket;
-	std::unique_ptr<TCPClientSocket> clientsocket;
-	std::unique_ptr<TCPClientSocket> waitingclientsocket;
+	std::unique_ptr<TCPServerSocket> serversocket = nullptr;
+	std::unique_ptr<TCPClientSocket> clientsocket = nullptr;
+	std::unique_ptr<TCPClientSocket> waitingclientsocket = nullptr;
 
 	struct {
 		bool binary[2] = {false};

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -77,7 +77,8 @@ static void SN76496Write(Bitu /*port*/,Bitu data,Bitu /*iolen*/) {
 	}
 	device.write(data);
 
-//	LOG_MSG("3voice write %X at time %7.3f",data,PIC_FullIndex());
+	//	LOG_MSG("3voice write %#" PRIxPTR " at time
+	//%7.3f",data,PIC_FullIndex());
 }
 
 static void SN76496Update(Bitu length) {
@@ -227,7 +228,7 @@ static Bitu TandyDACRead(Bitu port,Bitu /*iolen*/) {
 	case 0xc7:
 		return (Bit8u)(((tandy.dac.frequency>>8)&0xf) | (tandy.dac.amplitude<<5));
 	}
-	LOG_MSG("Tandy DAC: Read from unknown %X",port);
+	LOG_MSG("Tandy DAC: Read from unknown %#" PRIxPTR, port);
 	return 0xff;
 }
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -104,9 +104,11 @@ void XGA_Write_Multifunc(Bitu val, Bitu len) {
 			xga.read_sel = dataval;
 			break;
 		default:
-			LOG_MSG("XGA: Unhandled multifunction command %x", regselect);
-			break;
-	}
+		        LOG_MSG("XGA: Unhandled multifunction command "
+		                "%#" PRIxPTR,
+		                regselect);
+		        break;
+	        }
 }
 
 Bitu XGA_Read_Multifunc() {
@@ -637,35 +639,45 @@ void XGA_DrawWait(Bitu val, Bitu len)
 							break;
 						default:
 							// Let's hope they never show up ;)
-							LOG_MSG("XGA: unsupported bpp / datawidth combination %x",
-								xga.waitcmd.buswidth);
-							break;
-					};
-					break;
-			
-				case 0x02: // Data from PIX_TRANS selects the mix
-					switch(xga.waitcmd.buswidth&0x60) {
-						case 0x0:
-							chunksize=8;
-							chunks=1;
-							break;
-						case 0x20: // 16 bit
-							chunksize=16;
-							if(len==4) chunks=2;
-							else chunks = 1;
-							break;
-						case 0x40: // 32 bit
-							chunksize=16;
-							if(len==4) chunks=2;
-							else chunks = 1;
-							break;
-						case 0x60: // undocumented guess (but works)
-							chunksize=8;
-							chunks=4;
-							break;
-					}
-					
-					for(Bitu k = 0; k < chunks; k++) { // chunks counter
+				                        LOG_MSG("XGA: "
+				                                "unsupported "
+				                                "bpp / "
+				                                "datawidth "
+				                                "combination "
+				                                "%#" PRIxPTR,
+				                                xga.waitcmd.buswidth);
+				                        break;
+			                        };
+			                        break;
+
+		                case 0x02: // Data from PIX_TRANS selects the mix
+			                switch (xga.waitcmd.buswidth & 0x60) {
+			                case 0x0:
+				                chunksize = 8;
+				                chunks = 1;
+				                break;
+			                case 0x20: // 16 bit
+				                chunksize = 16;
+				                if (len == 4)
+					                chunks = 2;
+				                else
+					                chunks = 1;
+				                break;
+			                case 0x40: // 32 bit
+				                chunksize = 16;
+				                if (len == 4)
+					                chunks = 2;
+				                else
+					                chunks = 1;
+				                break;
+			                case 0x60: // undocumented guess (but
+			                           // works)
+				                chunksize = 8;
+				                chunks = 4;
+				                break;
+			                }
+
+			                for(Bitu k = 0; k < chunks; k++) { // chunks counter
 						xga.waitcmd.newline = false;
 						for (Bitu n = 0; n < chunksize; ++n) { // pixels
 							// This formula can rule the world ;)
@@ -1154,11 +1166,13 @@ void XGA_Write(Bitu port, Bitu val, Bitu len) {
 				//LOG_MSG("XGA: Wrote to port %4x with %08x, len %x", port, val, len);
 				xga.waitcmd.newline = false;
 				XGA_DrawWait(val, len);
-				
-			}
-			else LOG_MSG("XGA: Wrote to port %x with %x, len %x", port, val, len);
-			break;
-	}
+
+		        } else
+			        LOG_MSG("XGA: Wrote to port %#" PRIxPTR
+			                " with %#" PRIxPTR ", len %#" PRIxPTR,
+			                port, val, len);
+		        break;
+	        }
 }
 
 Bitu XGA_Read(Bitu port, Bitu len) {


### PR DESCRIPTION
This PR is primarily a Bitu-abuse and warning cleanup for the serial port area.
In order, the commits do the following:
1. The max-number of serial ports is dropped from 2^64 to 256.
1. Local and member variables are capped at 32bit, instead of using Bitu.
1. Member variables are initialized in their class' declarations.
1. DOSBox-types (Bit8u, Bit16u, Bit32u) are replaced with their std C++ equivalents.
1. `printf` formatting types are fixed (including a couple remaining flagged by Coverity).
1. Remaining `effc++` warnings are fixed.
1. The CI warning counts are updated.

This is functionally equivalent, except for the fact that various counters that were previous Bitu will now be limited to 2^32 on 64-bit systems (4 billion `tx_overruns` should be enough, I think!).

![Screenshot at 2020-05-14 12-31-30](https://user-images.githubusercontent.com/1557255/81977431-dd854b00-95de-11ea-8a87-bf18579ef2c5.png)