### PR TITLE
Use std::string for name in DOS_File class

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -21,6 +21,7 @@
 
 #include "dosbox.h"
 
+#include <string>
 #include <vector>
 
 #include "cross.h"
@@ -55,19 +56,37 @@ class DOS_DTA;
 
 class DOS_File {
 public:
-	DOS_File():flags(0),time(0),date(0),attr(0),refCtr(0),open(false),name(0),hdrive(0xff) { };
-	DOS_File(const DOS_File& orig);
-	DOS_File & operator= (const DOS_File & orig);
-	virtual	~DOS_File(){if(name) delete [] name;};
+	DOS_File()
+	        : flags(0),
+	          time(0),
+	          date(0),
+	          attr(0),
+	          refCtr(0),
+	          open(false),
+	          name(""),
+	          hdrive(0xff)
+	{}
+
+	DOS_File(const DOS_File &orig) = default;
+	DOS_File &operator=(const DOS_File &orig);
+
+	virtual ~DOS_File() = default;
+
+	const char *GetName() const { return name.c_str(); }
+
+	void SetName(const char *str) { name = str; }
+
+	bool IsName(const char *str) const
+	{
+		return !name.empty() && (strcasecmp(name.c_str(), str) == 0);
+	}
+
 	virtual bool	Read(Bit8u * data,Bit16u * size)=0;
 	virtual bool	Write(Bit8u * data,Bit16u * size)=0;
 	virtual bool	Seek(Bit32u * pos,Bit32u type)=0;
 	virtual bool	Close()=0;
 	virtual Bit16u	GetInformation(void)=0;
-	virtual void	SetName(const char* _name)	{ if (name) delete[] name; name = new char[strlen(_name)+1]; strcpy(name,_name); }
-	virtual char*	GetName(void)				{ return name; };
 	virtual bool	IsOpen()					{ return open; };
-	virtual bool	IsName(const char* _name)	{ if (!name) return false; return strcasecmp(name,_name)==0; };
 	virtual void	AddRef()					{ refCtr++; };
 	virtual Bits	RemoveRef()					{ return --refCtr; };
 	virtual bool	UpdateDateTimeFromHost()	{ return true; }
@@ -80,7 +99,7 @@ public:
 	Bit16u attr;
 	Bits refCtr;
 	bool open;
-	char* name;
+	std::string name;
 /* Some Device Specific Stuff */
 private:
 	Bit8u hdrive;

--- a/include/drives.h
+++ b/include/drives.h
@@ -419,7 +419,8 @@ public:
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block);
 	virtual void EmptyCache(void);
 
-	FILE* create_file_in_overlay(char* dos_filename, char const* mode);
+	FILE *create_file_in_overlay(const char *dos_filename, char const *mode);
+
 	virtual Bits UnMount(void);
 	virtual bool TestDir(char * dir);
 	virtual bool RemoveDir(char * dir);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -93,20 +93,6 @@ bool DOS_Device::WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcod
 	return Devices[devnum]->WriteToControlChannel(bufptr,size,retcode);
 }
 
-DOS_File::DOS_File(const DOS_File& orig) {
-	flags=orig.flags;
-	time=orig.time;
-	date=orig.date;
-	attr=orig.attr;
-	refCtr=orig.refCtr;
-	open=orig.open;
-	hdrive=orig.hdrive;
-	name=0;
-	if(orig.name) {
-		name=new char [strlen(orig.name) + 1];strcpy(name,orig.name);
-	}
-}
-
 DOS_File & DOS_File::operator= (const DOS_File & orig) {
 	flags=orig.flags;
 	time=orig.time;
@@ -115,12 +101,7 @@ DOS_File & DOS_File::operator= (const DOS_File & orig) {
 	refCtr=orig.refCtr;
 	open=orig.open;
 	hdrive=orig.hdrive;
-	if(name) {
-		delete [] name; name=0;
-	}
-	if(orig.name) {
-		name=new char [strlen(orig.name) + 1];strcpy(name,orig.name);
-	}
+	name = orig.name;
 	return *this;
 }
 
@@ -151,7 +132,8 @@ Bit8u DOS_FindDevice(char const * name) {
 	/* loop through devices */
 	for(Bit8u index = 0;index < DOS_DEVICES;index++) {
 		if (Devices[index]) {
-			if (WildFileCmp(name_part,Devices[index]->name)) return index;
+			if (WildFileCmp(name_part, Devices[index]->GetName()))
+				return index;
 		}
 	}
 	return DOS_DEVICES;
@@ -175,7 +157,7 @@ void DOS_DelDevice(DOS_Device * dev) {
 // We will destroy the device if we find it in our list.
 // TODO:The file table is not checked to see the device is opened somewhere!
 	for (Bitu i = 0; i <DOS_DEVICES;i++) {
-		if(Devices[i] && !strcasecmp(Devices[i]->name,dev->name)){
+		if (Devices[i] && !strcasecmp(Devices[i]->GetName(), dev->GetName())) {
 			delete Devices[i];
 			Devices[i] = 0;
 			return;

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -58,7 +58,6 @@ isoFile::isoFile(isoDrive *drive, const char *name, FileStat_Block *stat, Bit32u
 	fileEnd = fileBegin + stat->size;
 	cachedSector = -1;
 	open = true;
-	this->name = NULL;
 	SetName(name);
 }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -579,7 +579,6 @@ localFile::localFile(const char* _name, FILE * handle)
 
 	attr=DOS_ATTR_ARCHIVE;
 
-	name=0;
 	SetName(_name);
 }
 

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -230,8 +230,8 @@ public:
 //Create leading directories of a file being overlayed if they exist in the original (localDrive).
 //This function is used to create copies of existing files, so all leading directories exist in the original.
 
-FILE* Overlay_Drive::create_file_in_overlay(char* dos_filename, char const* mode) {
-
+FILE *Overlay_Drive::create_file_in_overlay(const char *dos_filename, char const *mode)
+{
 	if (logoverlay) LOG_MSG("create_file_in_overlay called %s %s",dos_filename,mode);
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, overlaydir); // TODO GOG make part of class and
@@ -242,7 +242,8 @@ FILE* Overlay_Drive::create_file_in_overlay(char* dos_filename, char const* mode
 
 	FILE* f = fopen_wrap(newname,mode);
 	//Check if a directories are part of the name:
-	char* dir = strrchr(dos_filename,'\\');
+	const char *dir = strrchr(dos_filename, '\\');
+
 	if (!f && dir && *dir) {
 		if (logoverlay) LOG_MSG("Overlay: warning creating a file inside a directory %s",dos_filename);
 		//ensure they exist, else make them in the overlay if they exist in the original....


### PR DESCRIPTION
Remove 'virtual' specifier, as name-related methods do not need to be
virtual AND inheriting classes call them from their constructors
(virtual call mechanism is disabled in C++ constructors, so let's be
explicit about it).

Make some of methods const methods (when applicable).

Field 'name' is public, and other interfaces (needlessly) depended on
name being non-const, so some adjustments in other classes were
necessary.

Aside of cleaning up and simplifying the code, this change prevents MSVC
from reporting the same warning about unsafe strcpy multiple times,
whenever this header was transitively included (thus affecting unrelated
pull requests).