### PR TITLE
Cleanup serial port area (2/2)

### DIFF
--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -165,23 +165,19 @@ bool TCPClientSocket::ReceiveArray(uint8_t *data, uint32_t *size)
 	}
 }
 
-int16_t TCPClientSocket::GetcharNonBlock()
+SocketState TCPClientSocket::GetcharNonBlock(uint8_t &val)
 {
-	// return:
-	// -1: no data
-	// -2: socket closed
-	// 0..255: data
-	int16_t rvalue = -1;
+	SocketState state = SocketState::Empty;
 	if(SDLNet_CheckSockets(listensocketset,0))
 	{
-		char data = 0;
-		if (SDLNet_TCP_Recv(mysock, &data, 1) != 1) {
+		if (SDLNet_TCP_Recv(mysock, &val, 1) == 1)
+			state = SocketState::Good;
+		else {
 			isopen = false;
-			rvalue = -2;
-		} else
-			rvalue = static_cast<int16_t>(data);
+			state = SocketState::Closed;
+		}
 	}
-	return rvalue;
+	return state;
 }
 
 bool TCPClientSocket::Putchar(uint8_t data)

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -67,6 +67,12 @@ struct _TCPsocketX {
 	int sflag = 0;
 };
 
+enum class SocketState {
+	Good, // had data and socket is open
+	Empty, // didn't have data but socket is open
+	Closed // didn't have data and socket is closed
+};
+
 class TCPClientSocket {
 public:
 	TCPClientSocket(TCPsocket source);
@@ -79,11 +85,7 @@ public:
 
 	~TCPClientSocket();
 
-	// return:
-	// -1: no data
-	// -2: socket closed
-	// >0: data char
-	int16_t GetcharNonBlock();
+	SocketState GetcharNonBlock(uint8_t &val);
 
 	bool Putchar(uint8_t data);
 	bool SendArray(uint8_t *data, uint32_t bufsize);

--- a/src/hardware/serialport/nullmodem.h
+++ b/src/hardware/serialport/nullmodem.h
@@ -72,7 +72,7 @@ private:
 	bool ServerListen();
 	bool ServerConnect();
     void Disconnect();
-    int16_t readChar();
+    SocketState readChar(uint8_t &val);
     void WriteChar(uint8_t data);
 
     bool DTR_delta = false; // with dtrrespect, we try to establish a
@@ -102,7 +102,7 @@ private:
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
-	Bits TelnetEmulation(uint8_t data);
+	SocketState TelnetEmulation(const uint8_t data);
 
 	// Telnet's memory
 	struct {


### PR DESCRIPTION
This PR de-tangles the return status from data in the `readChar`, `TelnetEmulation`, and `GetcharNonBlock` functions, which previous operated on whopping 64-bit signed types and mixed both data and status into a single return value.

Finally, we can _"do what these functions say they do"_ and operate on a single bonafide character (as a `uint8_t`), and return a separate enumerated socket state.