### PR TITLE
Use NOMINMAX to prevent std::min failing in MSVC

### DIFF
--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -68,7 +68,7 @@ void AUTOTYPE::PrintKeys()
 	// Keep track of the longest key name
 	size_t max_length = 0;
 	for (const auto &name : names)
-		max_length = (std::max)(name.length(), max_length);
+		max_length = std::max(name.length(), max_length);
 
 	// Sanity check to avoid dividing by 0
 	if (!max_length) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2515,7 +2515,7 @@ static void QueryJoysticks() {
 
 	// Check which, if any, of the first two joysticks are useable
 	bool useable[2] = {false};
-	for (int i = 0; i < (std::min)(num_joysticks, 2); ++i) {
+	for (int i = 0; i < std::min(num_joysticks, 2); ++i) {
 		SDL_Joystick *stick = SDL_JoystickOpen(i);
 		useable[i] = (SDL_JoystickNumAxes(stick) >= req_min_axis) ||
 		             (SDL_JoystickNumButtons(stick) > 0) ? true : false;

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -60,6 +60,9 @@
 /* environ can be linked */
 #define ENVIRON_LINKED 1
 
+/* Prevent <windows.h> from clobbering std::min and std::max */
+#define NOMINMAX 1
+
 /* Define to 1 if you want serial passthrough support. */
 #define C_DIRECTSERIAL 1
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -962,11 +962,10 @@ void DOS_Shell::CMD_SET(char * args) {
 				std::string temp;
 				if (GetEnvStr(p,temp)) {
 					std::string::size_type equals = temp.find('=');
-					if (equals == std::string::npos) continue;
-					const uintptr_t remaining_len = (std::min)(
-					        sizeof(parsed) -
-					                static_cast<uintptr_t>(
-					                        p_parsed - parsed),
+					if (equals == std::string::npos)
+						continue;
+					const uintptr_t remaining_len = std::min(
+					        sizeof(parsed) - static_cast<uintptr_t>(p_parsed - parsed),
 					        sizeof(parsed));
 					safe_strncpy(p_parsed,
 					             temp.substr(equals + 1).c_str(),


### PR DESCRIPTION
I restarted this job about 10 times today. MSYS2 keeps failing over and over again.