### PR TITLE
Small refactor in DIR command (preparation for LS command)

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -124,7 +124,7 @@ bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb = false)
 bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bit16u action, Bit16u *entry, Bit16u* status);
 bool DOS_CreateFile(char const * name,Bit16u attribute,Bit16u * entry, bool fcb = false);
 bool DOS_UnlinkFile(char const * const name);
-bool DOS_FindFirst(char *search,Bit16u attr,bool fcb_findfirst=false);
+bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst = false);
 bool DOS_FindNext(void);
 bool DOS_Canonicalize(char const * const name,char * const big);
 bool DOS_CreateTempFile(char * const name,Bit16u * entry);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -308,7 +308,8 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 	return false;
 }
 
-bool DOS_FindFirst(char * search,Bit16u attr,bool fcb_findfirst) {
+bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst)
+{
 	LOG(LOG_FILES,LOG_NORMAL)("file search attributes %X name %s",attr,search);
 	DOS_DTA dta(dos.dta());
 	Bit8u drive;char fullsearch[DOS_PATHLENGTH];


### PR DESCRIPTION
Title says it all :) DOS_* API requires search pattern to exist in a specific "format" - implementation preparing this pattern could be somewhat easily extracted from DIR implementation, so it will be reusable for future LS command.