### PR TITLE
Remove typedef from SVGA_PVGA1A_DATA struct

### DIFF
--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -23,7 +23,7 @@
 #include "inout.h"
 #include "mem.h"
 
-typedef struct {
+typedef struct SVGA_PVGA1A_DATA {
 	Bitu PR0A;
 	Bitu PR0B;
 	Bitu PR1;
@@ -36,7 +36,7 @@ typedef struct {
 
 	Bitu clockFreq[4];
 	Bitu biosMode;
-} SVGA_PVGA1A_DATA;
+} ;
 
 static SVGA_PVGA1A_DATA pvga1a = { 0,0, 0,0,0,0,0, {0,0,0,0}, 0 };
 

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -23,7 +23,7 @@
 #include "inout.h"
 #include "mem.h"
 
-typedef struct SVGA_PVGA1A_DATA {
+struct SVGA_PVGA1A_DATA {
 	Bitu PR0A;
 	Bitu PR0B;
 	Bitu PR1;
@@ -36,7 +36,7 @@ typedef struct SVGA_PVGA1A_DATA {
 
 	Bitu clockFreq[4];
 	Bitu biosMode;
-} ;
+};
 
 static SVGA_PVGA1A_DATA pvga1a = { 0,0, 0,0,0,0,0, {0,0,0,0}, 0 };
 


### PR DESCRIPTION
Its previous position was blocking compilation on VS2019 Windows x64.