### PR TITLE
Add new command: ls

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -276,12 +276,17 @@ static INLINE Bit16u mem_readw_inline(PhysPt address) {
 	} else return mem_unalignedreadw(address);
 }
 
-static INLINE Bit32u mem_readd_inline(PhysPt address) {
-	if ((address & 0xfff)<0xffd) {
-		HostPt tlb_addr=get_tlb_read(address);
-		if (tlb_addr) return host_readd(tlb_addr+address);
-		else return (get_tlb_readhandler(address))->readd(address);
-	} else return mem_unalignedreadd(address);
+static INLINE uint32_t mem_readd_inline(PhysPt address)
+{
+	if ((address & 0xfff) < 0xffd) {
+		HostPt tlb_addr = get_tlb_read(address);
+		if (tlb_addr)
+			return host_readd(tlb_addr + address);
+		else
+			return static_cast<uint32_t>((get_tlb_readhandler(address))->readd(address));
+	} else {
+		return mem_unalignedreadd(address);
+	}
 }
 
 static INLINE void mem_writeb_inline(PhysPt address,Bit8u val) {

--- a/include/shell.h
+++ b/include/shell.h
@@ -116,6 +116,7 @@ public:
 	void CMD_PATH(char * args);
 	void CMD_SHIFT(char * args);
 	void CMD_VER(char * args);
+	void CMD_LS(char *args);
 	/* The shell's variables */
 	Bit16u input_handle;
 	BatchFile * bf;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -80,11 +80,17 @@ bool ends_with(const std::string &suffix, const std::string &str) noexcept
 	return std::equal(sfx, sfx + n, txt, txt + n);
 }
 
-void trim(std::string &str) {
-	std::string::size_type loc = str.find_first_not_of(" \r\t\f\n");
-	if (loc != std::string::npos) str.erase(0,loc);
-	loc = str.find_last_not_of(" \r\t\f\n");
-	if (loc != std::string::npos) str.erase(loc+1);
+void trim(std::string &str)
+{
+	constexpr char whitespace[] = " \r\t\f\n";
+	const auto empty_pfx = str.find_first_not_of(whitespace);
+	if (empty_pfx == std::string::npos) {
+		str.clear(); // whole string is filled with whitespace
+		return;
+	}
+	const auto empty_sfx = str.find_last_not_of(whitespace);
+	str.erase(empty_sfx + 1);
+	str.erase(0, empty_pfx);
 }
 
 void strip_punctuation(std::string &str) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -688,6 +688,10 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_CALL_HELP","Start a batch file from within another batch file.\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP","Assign an internal directory to a drive.\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires xms=true,umb=true).\n");
+
+	MSG_Add("SHELL_CMD_LS_HELP", "List directory contents.\n");
+	MSG_Add("SHELL_CMD_LS_HELP_LONG", "ls [/?] [PATTERN]\n");
+
 	MSG_Add("SHELL_CMD_CHOICE_HELP","Waits for a keypress and sets ERRORLEVEL.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG","CHOICE [/C:choices] [/N] [/S] text\n"
 	        "  /C[:]choices  -  Specifies allowable keys.  Default is: yn.\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -691,6 +691,8 @@ void SHELL_Init() {
 
 	MSG_Add("SHELL_CMD_LS_HELP", "List directory contents.\n");
 	MSG_Add("SHELL_CMD_LS_HELP_LONG", "ls [/?] [PATTERN]\n");
+	MSG_Add("SHELL_CMD_LS_PATH_ERR",
+	        "ls: cannot access '%s': No such file or directory\n");
 
 	MSG_Add("SHELL_CMD_CHOICE_HELP","Waits for a keypress and sets ERRORLEVEL.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG","CHOICE [/C:choices] [/N] [/S] text\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -56,6 +56,7 @@ static SHELL_Cmd cmd_list[] = {
 	{ "IF",       1, &DOS_Shell::CMD_IF,       "SHELL_CMD_IF_HELP" },
 	{ "LH",       1, &DOS_Shell::CMD_LOADHIGH, "SHELL_CMD_LOADHIGH_HELP" },
 	{ "LOADHIGH", 1, &DOS_Shell::CMD_LOADHIGH, "SHELL_CMD_LOADHIGH_HELP" },
+	{ "LS",       0, &DOS_Shell::CMD_LS,       "SHELL_CMD_LS_HELP" },
 	{ "MD",       0, &DOS_Shell::CMD_MKDIR,    "SHELL_CMD_MKDIR_HELP" },
 	{ "MKDIR",    1, &DOS_Shell::CMD_MKDIR,    "SHELL_CMD_MKDIR_HELP" },
 	{ "PATH",     1, &DOS_Shell::CMD_PATH,     "SHELL_CMD_PATH_HELP" },
@@ -738,6 +739,11 @@ void DOS_Shell::CMD_DIR(char * args) {
 		show_press_any_key();
 	}
 	dos.dta(save_dta);
+}
+
+void DOS_Shell::CMD_LS(char *args)
+{
+	HELP("LS");
 }
 
 struct copysource {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -784,7 +784,13 @@ void DOS_Shell::CMD_LS(char *args)
 		}
 
 		lowcase(name);
-		WriteOut("%-16s", name.c_str());
+		const bool is_executable = ends_with(".exe", name) ||
+		                           ends_with(".bat", name) ||
+		                           ends_with(".com", name);
+		if (is_executable)
+			WriteOut("\033[32;1m%-16s\033[0m", name.c_str());
+		else
+			WriteOut("%-16s", name.c_str());
 	}
 	WriteOut("\n");
 	dos.dta(original_dta);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -770,6 +770,8 @@ void DOS_Shell::CMD_LS(char *args)
 		results.push_back(result);
 	} while ((ret = DOS_FindNext()) == true);
 
+	size_t w_count = 0;
+
 	for (const auto &entry : results) {
 		std::string name = entry.name;
 		const bool is_dir = entry.attr & DOS_ATTR_DIRECTORY;
@@ -779,20 +781,22 @@ void DOS_Shell::CMD_LS(char *args)
 
 		if (is_dir) {
 			upcase(name);
-			WriteOut("\033[34;1m%-16s\033[0m", name.c_str());
-			continue;
+			WriteOut("\033[34;1m%-15s\033[0m", name.c_str());
+		} else {
+			lowcase(name);
+			const bool is_executable = ends_with(".exe", name) ||
+			                           ends_with(".bat", name) ||
+			                           ends_with(".com", name);
+			if (is_executable)
+				WriteOut("\033[32;1m%-15s\033[0m", name.c_str());
+			else
+				WriteOut("%-15s", name.c_str());
 		}
 
-		lowcase(name);
-		const bool is_executable = ends_with(".exe", name) ||
-		                           ends_with(".bat", name) ||
-		                           ends_with(".com", name);
-		if (is_executable)
-			WriteOut("\033[32;1m%-16s\033[0m", name.c_str());
-		else
-			WriteOut("%-16s", name.c_str());
+		++w_count;
+		if (w_count % 5 == 0)
+			WriteOut_NoParsing("\n");
 	}
-	WriteOut("\n");
 	dos.dta(original_dta);
 }
 


### PR DESCRIPTION
My muscle memory will not be fooled again :)

This implementation is really simple with no pretence of supporting all the options available in GNU `ls`; only listing directories, with colourised, readable output, with supporting "globbing" the same way `dir` command does.

Also, I found a tiny edge-case bug in `trim` function, that caused `DIR /W` to be broken since eadd0b0fc4163beff799340612c5b8fe20355dde (fix included).

Example:

*Output of `dir /w /p` in Windows 3.11 directory; there are just enough files to not fit on one screen and it's pretty hard to distinguish them (also, user must know about /w and /p switches).*
![Screenshot from 2020-05-22 21-15-09](https://user-images.githubusercontent.com/3967/82701934-56387700-9c71-11ea-8279-13bbb969b2f6.png)

*Output of `ls` in the same directory; there's enough screen space to spare and it's easy to find executable files:*
![Screenshot from 2020-05-22 21-12-51](https://user-images.githubusercontent.com/3967/82702082-9ac41280-9c71-11ea-8b6e-44b28b5fb384.png)
