### PR TITLE
Ramp CD-DA volume around play, stop, and pause transitions

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -212,14 +212,18 @@ void MixerChannel::MapChannels(Bit8u _left, Bit8u _right) {
 }
 
 void MixerChannel::Enable(bool _yesno) {
-	if (_yesno==enabled) return;
-	enabled=_yesno;
+	// The channel is already in the desired stated
+	if (_yesno == enabled)
+		return;
+
+	MIXER_LockAudioDevice();
+	enabled = _yesno;
 	if (enabled) {
 		freq_counter = 0;
-		MIXER_LockAudioDevice();
-		if (done<mixer.done) done=mixer.done;
-		MIXER_UnlockAudioDevice();
+		if (done < mixer.done)
+			done = mixer.done;
 	}
+	MIXER_UnlockAudioDevice();
 }
 
 void MixerChannel::SetFreq(Bitu freq) {
@@ -461,11 +465,9 @@ void MixerChannel::AddSamples_s32_nonnative(Bitu len,const Bit32s * data) {
 }
 
 void MixerChannel::FillUp(void) {
-	MIXER_LockAudioDevice();
-	if (!enabled || done<mixer.done) {
-		MIXER_UnlockAudioDevice();
+	if (!enabled || done < mixer.done)
 		return;
-	}
+	MIXER_LockAudioDevice();
 	float index=PIC_TickIndex();
 	Mix((Bitu)(index*mixer.needed));
 	MIXER_UnlockAudioDevice();

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -472,8 +472,8 @@ void MixerChannel::AddSamples_s32_nonnative(Bitu len,const Bit32s * data) {
 void MixerChannel::FillUp(void) {
 	if (!enabled || done < mixer.done)
 		return;
+	const float index = PIC_TickIndex();
 	MIXER_LockAudioDevice();
-	float index=PIC_TickIndex();
 	Mix((Bitu)(index*mixer.needed));
 	MIXER_UnlockAudioDevice();
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -101,14 +101,14 @@ MixerChannel::MixerChannel(MIXER_Handler _handler, Bitu _freq, const char * _nam
 		volmain      {0, 0},
 		next         (nullptr),
 		name         (_name),
-		done         (0),
-		enabled      (false),
+		done         (0), // increases as samples are decoded (lock needed)
+		enabled      (false), // controls if samples are fed to mixer (lock needed)
 
 		// Private member initialization
 		handler      (_handler),
-		freq_add     (0),
-		freq_counter (0),
-		needed       (0),
+		freq_add     (0), // changes every mix step (lock needed)
+		freq_counter (0), // changes every mix step (lock needed)
+		needed       (0), // decreases as samples decoded (lock needed)
 		prev_sample  {0, 0},
 		next_sample  {0, 0},
 		volmul       {0, 0},

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -227,14 +227,11 @@ void MixerChannel::Enable(bool _yesno) {
 }
 
 void MixerChannel::SetFreq(Bitu freq) {
-	freq_add=(freq<<FREQ_SHIFT)/mixer.freq;
-
-	if (freq != mixer.freq) {
-		interpolate = true;
-	}
-	else {
-		interpolate = false;
-	}
+	MIXER_LockAudioDevice();
+	freq_add = (freq << FREQ_SHIFT) / mixer.freq;
+	// Interpolate if our frequencies differ
+	interpolate = (freq != mixer.freq);
+	MIXER_UnlockAudioDevice();
 }
 
 void MixerChannel::Mix(Bitu _needed) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -234,6 +234,7 @@ void MixerChannel::SetFreq(Bitu freq) {
 	MIXER_UnlockAudioDevice();
 }
 
+// (Mix() is locked by its caller
 void MixerChannel::Mix(Bitu _needed) {
 	needed=_needed;
 	while (enabled && needed>done) {
@@ -245,14 +246,18 @@ void MixerChannel::Mix(Bitu _needed) {
 }
 
 void MixerChannel::AddSilence(void) {
-	if (done<needed) {
-		done=needed;
-		//Make sure the next samples are zero when they get switched to prev
-		next_sample[0] = 0;
-		next_sample[1] = 0;
-		//This should trigger an instant request for new samples
-		freq_counter = FREQ_NEXT;
-	}
+	// There is no gap to fill with silence
+	if (done >= needed)
+		return;
+
+	MIXER_LockAudioDevice();
+	done = needed;
+	//Make sure the next samples are zero when they get switched to prev
+	next_sample[0] = 0;
+	next_sample[1] = 0;
+	//This should trigger an instant request for new samples
+	freq_counter = FREQ_NEXT;
+	MIXER_UnlockAudioDevice();
 }
 
 template<class Type,bool stereo,bool signeddata,bool nativeorder>

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -395,6 +395,8 @@ void MixerChannel::AddStretched(Bitu len,Bit16s * data) {
 	Bitu index = 0;
 	Bitu index_add = (len << FREQ_SHIFT)/outlen;
 	Bitu mixpos = mixer.pos + done;
+
+	MIXER_LockAudioDevice();
 	done = needed;
 	Bitu pos = 0;
 
@@ -415,6 +417,7 @@ void MixerChannel::AddStretched(Bitu len,Bit16s * data) {
 		mixer.work[mixpos][1] += sample * volmul[1];
 		mixpos++;
 	}
+	MIXER_UnlockAudioDevice();
 }
 
 void MixerChannel::AddSamples_m8(Bitu len, const Bit8u * data) {


### PR DESCRIPTION
This commit adds a short volume ramp at the front and back of CD-DA start and stop events in order to silence any instantaneous dicontinuous transition (going from a 0-sample up to a full-magnitude sample, or vice-versa) which typically causes a harsh click or pop.

The volume transition only spans a 15-ms period, which is extremely quick in human-terms; it's roughly the duration of one video frame. The goal is only to catch problems around the control-changes (start/stop/pause/unpause), as opposed to fixing actual clicks in the audio data itself.

Notes about the change: 

- in the prior code, the CDROM's Pause() and Stop() functions were responsible for stopping the CDROM's mixer channel. In this commit, these functions now simply request a particular ramp type (from a set of enums), and the actual transition and channel-halting is carried out inside the callback over a series of mixer playback requests, each time scaling the channel's volume higher or lower as needed.

- The ramping is done by re-purposing the relatively unused but existing SetScale(float) function available in the mixer channel (this is different than the per-channel mixer volumes, which are held in a separate volmain[] pair).

- Some games are sophisticated enough to perform their own ramping around start and stop events, which they perform by adjust the TCtrl struct. When this happens, we relenquish volume control and let the game take charge. This is also necessary for games that adjust
volumes and channel mappings to achieve 'mono-over-stereo-output' effects, such as A Crown of Swords.