### PR TITLE
Protect "debugger" feature through CI gating

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,6 +27,11 @@ jobs:
             os: ubuntu-18.04
             flags: -c gcc -v 9
             max_warnings: 26
+          - name: GCC-9 (Ubuntu 18.04) +debug
+            os: ubuntu-18.04
+            flags: -c gcc -v 9
+            config_flags: --enable-debug
+            max_warnings: 263
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
@@ -54,7 +59,7 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
       - name: Build
-        run:  ./scripts/build.sh --build-type Debug ${{ matrix.conf.flags }}
+        run:  ./scripts/build.sh -t Debug ${{ matrix.conf.flags }} ${{ matrix.conf.config_flags }}
       - name: Summarize warnings
         env:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -362,8 +362,9 @@ bool CSerial::CanReceiveByte() {
 void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 {
 #if SERIAL_DEBUG
-	log_ser(dbg_serialtraffic, data < 0x10 ? "\t\t\t\trx 0x%02x (%"
-	        PRIu8 "):\t\t\t\trx 0x%02x (%c)", data, data); // TODO: fix
+	log_ser(dbg_serialtraffic,
+	        data < 0x10 ? "\t\t\t\trx 0x%02x (%" PRIu8 ")" : "\t\t\t\trx 0x%02x (%c)",
+	        data, data);
 #endif
 	if (!(rxfifo->addb(data))) {
 		// Overrun error ;o


### PR DESCRIPTION
Well, if it's not being gated, then simple compilation errors might happen by a mistake.
"debug" is the largest and most intrusive opt-in feature; I guess building it on Linux only should be enough.