### PR TITLE
Add support for binding more controller axes

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -552,20 +552,8 @@ public:
 		// initialize binding lists and position data
 		pos_axis_lists = new CBindList[MAXAXIS];
 		neg_axis_lists = new CBindList[MAXAXIS];
-		button_lists=new CBindList[MAXBUTTON];
-		hat_lists=new CBindList[4];
-
-		for (int i = 0; i < MAXBUTTON; i++) {
-			button_autofire[i]=0;
-			old_button_state[i]=0;
-		}
-		for (int i = 0; i < 16; i++)
-			old_hat_state[i] = 0;
-
-		for (int i = 0; i < MAXAXIS; i++) {
-			old_pos_axis_state[i] = false;
-			old_neg_axis_state[i] = false;
-		}
+		button_lists = new CBindList[MAXBUTTON];
+		hat_lists = new CBindList[4];
 
 		// initialize emulated joystick state
 		emulated_axes=2;
@@ -781,7 +769,8 @@ public:
 			}
 		}
 		for (int i = 0; i < hats; i++) {
-			Uint8 chat_state = SDL_JoystickGetHat(sdl_joystick, i);
+			assert(i < MAXHAT);
+			const uint8_t chat_state = SDL_JoystickGetHat(sdl_joystick, i);
 
 			/* activate binding if hat state has changed */
 			if ((chat_state & SDL_HAT_UP) != (old_hat_state[i] & SDL_HAT_UP)) {
@@ -800,7 +789,7 @@ public:
 				if (chat_state & SDL_HAT_LEFT) ActivateBindList(&hat_lists[(i<<2)+3],32767,true);
 				else DeactivateBindList(&hat_lists[(i<<2)+3],true);
 			}
-			old_hat_state[i]=chat_state;
+			old_hat_state[i] = chat_state;
 		}
 	}
 
@@ -875,13 +864,14 @@ protected:
 	Bitu emustick;
 	SDL_Joystick *sdl_joystick = nullptr;
 	char configname[10];
-	Bitu button_autofire[MAXBUTTON];
-	bool old_button_state[MAXBUTTON];
-	bool old_pos_axis_state[MAXAXIS];
-	bool old_neg_axis_state[MAXAXIS];
-	Uint8 old_hat_state[16];
+	unsigned button_autofire[MAXBUTTON] = {};
+	bool old_button_state[MAXBUTTON] = {};
+	bool old_pos_axis_state[MAXAXIS] = {};
+	bool old_neg_axis_state[MAXAXIS] = {};
+	uint8_t old_hat_state[MAXHAT] = {};
 	bool is_dummy;
 };
+
 std::list<CStickBindGroup *> stickbindgroups;
 
 class C4AxisBindGroup : public  CStickBindGroup {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -573,16 +573,10 @@ public:
 		axes = SDL_JoystickNumAxes(sdl_joystick); // TODO returns -1 on error
 		if (axes > MAXAXIS)
 			axes = MAXAXIS;
-		axes_cap = emulated_axes;
-		if (axes_cap > axes)
-			axes_cap = axes;
 
 		hats = SDL_JoystickNumHats(sdl_joystick); // TODO returns -1 on error
 		if (hats > MAXHAT)
 			hats = MAXHAT;
-		hats_cap = emulated_hats;
-		if (hats_cap > hats)
-			hats_cap=hats;
 
 		buttons = SDL_JoystickNumButtons(sdl_joystick); // TODO returns -1 on error
 		button_wrap = buttons;
@@ -851,14 +845,12 @@ protected:
 	CBindList *button_lists = nullptr;
 	CBindList *hat_lists = nullptr;
 	int axes = 0;
-	int axes_cap = 0;
 	int emulated_axes = 0;
 	int buttons = 0;
 	int button_cap = 0;
 	int button_wrap = 0;
 	int emulated_buttons = 0;
 	int hats = 0;
-	int hats_cap = 0;
 	int emulated_hats = 0;
 	int stick;
 	Bitu emustick;
@@ -880,12 +872,6 @@ public:
 		emulated_axes=4;
 		emulated_buttons=4;
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
-
-		axes_cap=emulated_axes;
-		if (axes_cap>axes) axes_cap=axes;
-		hats_cap=emulated_hats;
-		if (hats_cap>hats) hats_cap=hats;
-
 		JOYSTICK_Enable(1,true);
 	}
 
@@ -951,12 +937,6 @@ public:
 		emulated_buttons=4;
 		emulated_hats=1;
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
-
-		axes_cap=emulated_axes;
-		if (axes_cap>axes) axes_cap=axes;
-		hats_cap=emulated_hats;
-		if (hats_cap>hats) hats_cap=hats;
-
 		JOYSTICK_Enable(1,true);
 		JOYSTICK_Move_Y(1,1.0);
 	}
@@ -1088,12 +1068,6 @@ public:
 		emulated_buttons=6;
 		emulated_hats=1;
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
-
-		axes_cap=emulated_axes;
-		if (axes_cap>axes) axes_cap=axes;
-		hats_cap=emulated_hats;
-		if (hats_cap>hats) hats_cap=hats;
-
 		JOYSTICK_Enable(1,true);
 	}
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -567,16 +567,15 @@ public:
 			return;
 		}
 
-		// FIXME: when errors from SDL won't be treated as big numbers,
-		// perhaps we won't need to set those ''max_caps''
+		const int sdl_axes = SDL_JoystickNumAxes(sdl_joystick);
+		if (sdl_axes < 0)
+			LOG_MSG("SDL: Can't detect axes; %s", SDL_GetError());
+		axes = clamp(sdl_axes, 0, MAXAXIS);
 
-		axes = SDL_JoystickNumAxes(sdl_joystick); // TODO returns -1 on error
-		if (axes > MAXAXIS)
-			axes = MAXAXIS;
-
-		hats = SDL_JoystickNumHats(sdl_joystick); // TODO returns -1 on error
-		if (hats > MAXHAT)
-			hats = MAXHAT;
+		const int sdl_hats = SDL_JoystickNumHats(sdl_joystick);
+		if (sdl_hats < 0)
+			LOG_MSG("SDL: Can't detect hats; %s", SDL_GetError());
+		hats = clamp(sdl_hats, 0, MAXHAT);
 
 		buttons = SDL_JoystickNumButtons(sdl_joystick); // TODO returns -1 on error
 		button_wrap = buttons;


### PR DESCRIPTION
This PR consists of import of a patch from ECE, that allows for binding additional axis on modern controllers and subsequent small cleanup in surrounding code.

Some more testing will be in order. I think this will change qualifies for backporting to 0.75.1 (probably the last bugfix for that version).