### PR TITLE
Clear samples and counters when disabling the channel

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -86,7 +86,7 @@ public:
 	MixerChannel *next = nullptr;
 	const char *name = nullptr;
 	Bitu done = 0u; // Timing on how many samples have been done by the mixer
-	bool isEnabled = false;
+	bool is_enabled = false;
 
 private:
 	MixerChannel();

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -79,26 +79,29 @@ public:
 	void AddStretched(Bitu len,Bit16s * data);		//Strech block up into needed data
 
 	void FillUp(void);
-	void Enable(bool _yesno);
+	void Enable(bool should_enable);
+	void FlushSamples();
 
-	float          volmain[2];
-	MixerChannel*  next;
-	const char*    name;
-	Bitu           done;           //Timing on how many samples have been done by the mixer
-	bool           enabled;
+	float volmain[2] = {0.0f};
+	MixerChannel *next = nullptr;
+	const char *name = nullptr;
+	Bitu done = 0u; // Timing on how many samples have been done by the mixer
+	bool isEnabled = false;
 
 private:
 	MixerChannel();
-	MIXER_Handler  handler;
-	Bitu           freq_add;       //This gets added the frequency counter each mixer step
-	Bitu           freq_counter;   //When this flows over a new sample needs to be read from the device
-	Bitu           needed; 	       //Timing on how many samples were needed by the mixer
-	Bits           prev_sample[2]; //Previous and next samples
-	Bits           next_sample[2];
-	Bit32s         volmul[2];
-	float          scale[2];
-	Bit8u          channel_map[2]; //Output channel mapping
-	bool           interpolate;
+	MIXER_Handler handler = nullptr;
+	Bitu freq_add = 0u; // This gets added the frequency counter each mixer
+	                    // step
+	Bitu freq_counter = 0u; // When this flows over a new sample needs to be
+	                        // read from the device
+	Bitu needed = 0u; // Timing on how many samples were needed by the mixer
+	Bits prev_sample[2] = {0}; // Previous and next samples
+	Bits next_sample[2] = {0};
+	Bit32s volmul[2] = {0};
+	float scale[2] = {0.0f};
+	Bit8u channel_map[2] = {0u}; // Output channel mapping
+	bool interpolate = false;
 };
 
 MixerChannel * MIXER_AddChannel(MIXER_Handler handler,Bitu freq,const char * name);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -51,10 +51,10 @@ public:
 	void SetScale(float f);
 	void SetScale(float _left, float _right);
 	void MapChannels(Bit8u _left, Bit8u _right);
-	void UpdateVolume(void);
+	void UpdateVolume();
 	void SetFreq(Bitu _freq);
 	void Mix(Bitu _needed);
-	void AddSilence(void);			//Fill up until needed
+	void AddSilence();			//Fill up until needed
 
 	template<class Type,bool stereo,bool signeddata,bool nativeorder>
 	void AddSamples(Bitu len, const Type* data);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -82,7 +82,7 @@ public:
 	void Enable(bool should_enable);
 	void FlushSamples();
 
-	float volmain[2] = {0.0f};
+	float volmain[2] = {0.0f, 0.0f};
 	MixerChannel *next = nullptr;
 	const char *name = nullptr;
 	Bitu done = 0u; // Timing on how many samples have been done by the mixer
@@ -98,9 +98,9 @@ private:
 	Bitu needed = 0u; // Timing on how many samples were needed by the mixer
 	Bits prev_sample[2] = {0}; // Previous and next samples
 	Bits next_sample[2] = {0};
-	Bit32s volmul[2] = {0};
-	float scale[2] = {0.0f};
-	Bit8u channel_map[2] = {0u}; // Output channel mapping
+	int32_t volmul[2] = {0};
+	float scale[2] = {0.0f, 0.0f};
+	uint8_t channel_map[2] = {0u, 0u}; // Output channel mapping
 	bool interpolate = false;
 };
 

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -594,7 +594,7 @@ void Module::PortWrite( Bitu port, Bitu val, Bitu iolen ) {
 	//Keep track of last write time
 	lastUsed = PIC_Ticks;
 	//Maybe only enable with a keyon?
-	if (!mixerChan->isEnabled) {
+	if (!mixerChan->is_enabled) {
 		mixerChan->Enable(true);
 	}
 	if ( port&1 ) {

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -594,7 +594,7 @@ void Module::PortWrite( Bitu port, Bitu val, Bitu iolen ) {
 	//Keep track of last write time
 	lastUsed = PIC_Ticks;
 	//Maybe only enable with a keyon?
-	if ( !mixerChan->enabled ) {
+	if (!mixerChan->isEnabled) {
 		mixerChan->Enable(true);
 	}
 	if ( port&1 ) {

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -40,7 +40,8 @@ static Bit32u cmsBase;
 static saa1099_device* device[2];
 
 static void write_cms(Bitu port, Bitu val, Bitu /* iolen */) {
-	if(cms_chan && (!cms_chan->enabled)) cms_chan->Enable(true);
+	if (cms_chan && (!cms_chan->isEnabled))
+		cms_chan->Enable(true);
 	lastWriteTicks = PIC_Ticks;
 	switch ( port - cmsBase ) {
 	case 1:

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -40,7 +40,7 @@ static Bit32u cmsBase;
 static saa1099_device* device[2];
 
 static void write_cms(Bitu port, Bitu val, Bitu /* iolen */) {
-	if (cms_chan && (!cms_chan->isEnabled))
+	if (cms_chan && (!cms_chan->is_enabled))
 		cms_chan->Enable(true);
 	lastWriteTicks = PIC_Ticks;
 	switch ( port - cmsBase ) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -198,7 +198,7 @@ void MixerChannel::MapChannels(Bit8u _left, Bit8u _right) {
 void MixerChannel::Enable(const bool should_enable)
 {
 	// Is the channel already in the desired state?
-	if (isEnabled == should_enable)
+	if (is_enabled == should_enable)
 		return;
 
 	// Lock the channel before changing states
@@ -224,7 +224,7 @@ void MixerChannel::Enable(const bool should_enable)
 		next_sample[0] = 0;
 		next_sample[1] = 0;
 	}
-	isEnabled = should_enable;
+	is_enabled = should_enable;
 	MIXER_UnlockAudioDevice();
 }
 
@@ -235,7 +235,7 @@ void MixerChannel::SetFreq(Bitu freq) {
 
 void MixerChannel::Mix(Bitu _needed) {
 	needed=_needed;
-	while (isEnabled && needed > done) {
+	while (is_enabled && needed > done) {
 		Bitu left = (needed - done);
 		left *= freq_add;
 		left  = (left >> FREQ_SHIFT) + ((left & FREQ_MASK)!=0);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -136,15 +136,15 @@ void MIXER_DelChannel(MixerChannel* delchan) {
 	}
 }
 
-static void MIXER_LockAudioDevice(void) {
+static void MIXER_LockAudioDevice() {
 	SDL_LockAudioDevice(mixer.sdldevice);
 }
 
-static void MIXER_UnlockAudioDevice(void) {
+static void MIXER_UnlockAudioDevice() {
 	SDL_UnlockAudioDevice(mixer.sdldevice);
 }
 
-void MixerChannel::UpdateVolume(void) {
+void MixerChannel::UpdateVolume() {
 	volmul[0]=(Bits)((1 << MIXER_VOLSHIFT)*scale[0]*volmain[0]*mixer.mastervol[0]);
 	volmul[1]=(Bits)((1 << MIXER_VOLSHIFT)*scale[1]*volmain[1]*mixer.mastervol[1]);
 }
@@ -243,7 +243,7 @@ void MixerChannel::Mix(Bitu _needed) {
 	}
 }
 
-void MixerChannel::AddSilence(void) {
+void MixerChannel::AddSilence() {
 	if (done<needed) {
 		done=needed;
 		//Make sure the next samples are zero when they get switched to prev
@@ -460,8 +460,8 @@ void MixerChannel::AddSamples_s32_nonnative(Bitu len,const Bit32s * data) {
 	AddSamples<Bit32s,true,true,false>(len,data);
 }
 
-void MixerChannel::FillUp(void) {
-	if (!isEnabled || done < mixer.done)
+void MixerChannel::FillUp() {
+	if (!is_enabled || done < mixer.done)
 		return;
 	float index=PIC_TickIndex();
 	MIXER_LockAudioDevice();
@@ -470,7 +470,7 @@ void MixerChannel::FillUp(void) {
 }
 
 extern bool ticksLocked;
-static inline bool Mixer_irq_important(void) {
+static inline bool Mixer_irq_important() {
 	/* In some states correct timing of the irqs is more important then
 	 * non stuttering audo */
 	return (ticksLocked || (CaptureState & (CAPTURE_WAVE|CAPTURE_VIDEO)));
@@ -515,7 +515,7 @@ static void MIXER_MixData(Bitu needed) {
 	mixer.done = needed;
 }
 
-static void MIXER_Mix(void) {
+static void MIXER_Mix() {
 	MIXER_LockAudioDevice();
 	MIXER_MixData(mixer.needed);
 	mixer.tick_counter += mixer.tick_add;
@@ -524,7 +524,7 @@ static void MIXER_Mix(void) {
 	MIXER_UnlockAudioDevice();
 }
 
-static void MIXER_Mix_NoSound(void) {
+static void MIXER_Mix_NoSound() {
 	MIXER_MixData(mixer.needed);
 	/* Clear piece we've just generated */
 	for (Bitu i=0;i<mixer.needed;i++) {
@@ -682,7 +682,7 @@ public:
 		if (!w) vol1=vol0;
 	}
 
-	void Run(void) {
+	void Run() {
 		if(cmd->FindExist("/LISTMIDI")) {
 			ListMidi();
 			return;
@@ -792,7 +792,7 @@ void MIXER_Init(Section* sec) {
 	PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart);
 }
 
-void MIXER_CloseAudioDevice(void) {
+void MIXER_CloseAudioDevice() {
 	if (!mixer.nosound) {
 		if (mixer.sdldevice != 0) {
 			SDL_CloseAudioDevice(mixer.sdldevice);


### PR DESCRIPTION
Fixes [#401](https://github.com/dosbox-staging/dosbox-staging/issues/401) when a channel is resumed: if there were samples left in the channel when it was previously disabled, then those samples would be played first when the channel is resumed at some later point. This fix zeroes the channel's decode counters and sample values so the channel starts clean when it's re-enabled.

Test results based on actual sample inspection and audible testing. Thank you @flashmasta for reporting, testing, and providing recordings of this issue!
   
This commit also:
- Renames the mixer's "enabled" state value to the more boolean-friendly "isEnabled"
- Performs member initialization in the class definition (instead of constructor), and
- Simplifies logic in a couple functions

(Unfortunately these minor updates use the `isEnabled` state values, which was one of the first changes I made, so I could not split these into separate commits without breaking compile-ability).