### PR TITLE
Match IO handlers' port size to its actual size

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -133,7 +133,7 @@ bool CPU_PUSHF(Bitu use32);
 bool CPU_CLI(void);
 bool CPU_STI(void);
 
-bool CPU_IO_Exception(Bitu port,Bitu size);
+bool CPU_IO_Exception(uint16_t port,Bitu size);
 void CPU_RunException(void);
 
 void CPU_ENTER(bool use32,Bitu bytes,Bitu level);

--- a/include/inout.h
+++ b/include/inout.h
@@ -27,25 +27,25 @@
 #define IO_MD	0x4
 #define IO_MA	(IO_MB | IO_MW | IO_MD )
 
-typedef Bitu IO_ReadHandler(Bitu port,Bitu iolen);
-typedef void IO_WriteHandler(Bitu port,Bitu val,Bitu iolen);
+typedef Bitu IO_ReadHandler(uint16_t port,Bitu iolen);
+typedef void IO_WriteHandler(uint16_t port,Bitu val,Bitu iolen);
 
 extern IO_WriteHandler * io_writehandlers[3][IO_MAX];
 extern IO_ReadHandler * io_readhandlers[3][IO_MAX];
 
-void IO_RegisterReadHandler(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);
-void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range=1);
+void IO_RegisterReadHandler(uint16_t port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);
+void IO_RegisterWriteHandler(uint16_t port,IO_WriteHandler * handler,Bitu mask,Bitu range=1);
 
-void IO_FreeReadHandler(Bitu port,Bitu mask,Bitu range=1);
-void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range=1);
+void IO_FreeReadHandler(uint16_t port,Bitu mask,Bitu range=1);
+void IO_FreeWriteHandler(uint16_t port,Bitu mask,Bitu range=1);
 
-void IO_WriteB(Bitu port,Bitu val);
-void IO_WriteW(Bitu port,Bitu val);
-void IO_WriteD(Bitu port,Bitu val);
+void IO_WriteB(uint16_t port,Bitu val);
+void IO_WriteW(uint16_t port,Bitu val);
+void IO_WriteD(uint16_t port,Bitu val);
 
-Bitu IO_ReadB(Bitu port);
-Bitu IO_ReadW(Bitu port);
-Bitu IO_ReadD(Bitu port);
+Bitu IO_ReadB(uint16_t port);
+Bitu IO_ReadW(uint16_t port);
+Bitu IO_ReadD(uint16_t port);
 
 /* Classes to manage the IO objects created by the various devices.
  * The io objects will remove itself on destruction.*/
@@ -63,21 +63,21 @@ public:
 };
 class IO_ReadHandleObject: private IO_Base{
 public:
-	void Install(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);
+	void Install(uint16_t port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);
 	void Uninstall();
 	~IO_ReadHandleObject();
 };
 class IO_WriteHandleObject: private IO_Base{
 public:
-	void Install(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range=1);
+	void Install(uint16_t port,IO_WriteHandler * handler,Bitu mask,Bitu range=1);
 	void Uninstall();
 	~IO_WriteHandleObject();
 };
 
-static INLINE void IO_Write(Bitu port,Bit8u val) {
+static INLINE void IO_Write(uint16_t port,Bit8u val) {
 	IO_WriteB(port,val);
 }
-static INLINE Bit8u IO_Read(Bitu port){
+static INLINE Bit8u IO_Read(uint16_t port){
 	return (Bit8u)IO_ReadB(port);
 }
 

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2579,12 +2579,12 @@ restart_prefix:
 		case 0xe3:dyn_loop(LOOP_JCXZ);goto finish_block;
 		//IN AL/AX,imm
 		case 0xe4: {
-			Bitu port=decode_fetchb();
+			Bit8u port=decode_fetchb();
 			dyn_add_iocheck_var(port,1);
 			gen_call_function((void*)&IO_ReadB,"%Id%Rl",port,DREG(EAX));
 			} break;
 		case 0xe5: {
-			Bitu port=decode_fetchb();
+			Bit8u port=decode_fetchb();
 			dyn_add_iocheck_var(port,decode.big_op?4:2);
 			if (decode.big_op) {
                 gen_call_function((void*)&IO_ReadD,"%Id%Rd",port,DREG(EAX));
@@ -2594,12 +2594,12 @@ restart_prefix:
 			} break;
 		//OUT imm,AL
 		case 0xe6: {
-			Bitu port=decode_fetchb();
+			Bit8u port=decode_fetchb();
 			dyn_add_iocheck_var(port,1);
 			gen_call_function((void*)&IO_WriteB,"%Id%Dl",port,DREG(EAX));
 			} break;
 		case 0xe7: {
-			Bitu port=decode_fetchb();
+			Bit8u port=decode_fetchb();
 			dyn_add_iocheck_var(port,decode.big_op?4:2);
 			if (decode.big_op) {
                 gen_call_function((void*)&IO_WriteD,"%Id%Dd",port,DREG(EAX));

--- a/src/cpu/core_normal/prefix_66.h
+++ b/src/cpu/core_normal/prefix_66.h
@@ -554,14 +554,14 @@
 		break;
 	CASE_D(0xe5)												/* IN EAX,Ib */
 		{
-			Bitu port=Fetchb();
+			uint16_t port=Fetchb();
 			if (CPU_IO_Exception(port,4)) RUNEXCEPTION();
 			reg_eax=IO_ReadD(port);
 			break;
 		}
 	CASE_D(0xe7)												/* OUT Ib,EAX */
 		{
-			Bitu port=Fetchb();
+			uint16_t port=Fetchb();
 			if (CPU_IO_Exception(port,4)) RUNEXCEPTION();
 			IO_WriteD(port,reg_eax);
 			break;

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -870,28 +870,28 @@
 		break;
 	CASE_B(0xe4)												/* IN AL,Ib */
 		{	
-			Bitu port=Fetchb();
+			uint16_t port=Fetchb();
 			if (CPU_IO_Exception(port,1)) RUNEXCEPTION();
 			reg_al=IO_ReadB(port);
 			break;
 		}
 	CASE_W(0xe5)												/* IN AX,Ib */
 		{	
-			Bitu port=Fetchb();
+			uint16_t port=Fetchb();
 			if (CPU_IO_Exception(port,2)) RUNEXCEPTION();
 			reg_ax=IO_ReadW(port);
 			break;
 		}
 	CASE_B(0xe6)												/* OUT Ib,AL */
 		{
-			Bitu port=Fetchb();
+			uint16_t port=Fetchb();
 			if (CPU_IO_Exception(port,1)) RUNEXCEPTION();
 			IO_WriteB(port,reg_al);
 			break;
 		}		
 	CASE_W(0xe7)												/* OUT Ib,AX */
 		{
-			Bitu port=Fetchb();
+			uint16_t port=Fetchb();
 			if (CPU_IO_Exception(port,2)) RUNEXCEPTION();
 			IO_WriteW(port,reg_ax);
 			break;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -520,7 +520,7 @@ doconforming:
 	return true;
 }
 
-bool CPU_IO_Exception(Bitu port,Bitu size) {
+bool CPU_IO_Exception(uint16_t port,Bitu size) {
 	if (cpu.pmode && ((GETFLAG_IOPL<cpu.cpl) || GETFLAG(VM))) {
 		cpu.mpl=0;
 		if (!cpu_tss.is386) goto doexception;

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -590,7 +590,7 @@ Bitu Module::CtrlRead( void ) {
 }
 
 
-void Module::PortWrite( Bitu port, Bitu val, Bitu iolen ) {
+void Module::PortWrite( uint16_t port, Bitu val, Bitu iolen ) {
 	//Keep track of last write time
 	lastUsed = PIC_Ticks;
 	//Maybe only enable with a keyon?
@@ -665,7 +665,7 @@ void Module::PortWrite( Bitu port, Bitu val, Bitu iolen ) {
 }
 
 
-Bitu Module::PortRead( Bitu port, Bitu iolen ) {
+Bitu Module::PortRead( uint16_t port, Bitu iolen ) {
 	switch ( mode ) {
 	case MODE_OPL2:
 		//We allocated 4 ports, so just return -1 for the higher ones
@@ -736,11 +736,11 @@ static void OPL_CallBack(Bitu len) {
 	}
 }
 
-static Bitu OPL_Read(Bitu port,Bitu iolen) {
+static Bitu OPL_Read(uint16_t port,Bitu iolen) {
 	return module->PortRead( port, iolen );
 }
 
-void OPL_Write(Bitu port,Bitu val,Bitu iolen) {
+void OPL_Write(uint16_t port,Bitu val,Bitu iolen) {
 	module->PortWrite( port, val, iolen );
 }
 
@@ -840,7 +840,7 @@ Module::Module(Section *configuration)
 	  capture(nullptr)
 {
 	Section_prop * section=static_cast<Section_prop *>(configuration);
-	Bitu base = section->Get_hex("sbbase");
+	uint16_t base = section->Get_hex("sbbase");
 	Bitu rate = section->Get_int("oplrate");
 	//Make sure we can't select lower than 8000 to prevent fixed point issues
 	if ( rate < 8000 )

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -146,8 +146,8 @@ public:
 	Chip	chip[2];
 
 	//Handle port writes
-	void PortWrite( Bitu port, Bitu val, Bitu iolen );
-	Bitu PortRead( Bitu port, Bitu iolen );
+	void PortWrite( uint16_t port, Bitu val, Bitu iolen );
+	Bitu PortRead( uint16_t port, Bitu iolen );
 	void Init( Mode m );
 
 	Module(Section *configuration);

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -72,12 +72,12 @@ static void cmos_checktimer(void) {
 //	status reg A reading with this (and with other delays actually)
 }
 
-void cmos_selreg(Bitu port,Bitu val,Bitu iolen) {
+void cmos_selreg(uint16_t port,Bitu val,Bitu iolen) {
 	cmos.reg=val & 0x3f;
 	cmos.nmi=(val & 0x80)>0;
 }
 
-static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
+static void cmos_writereg(uint16_t port,Bitu val,Bitu iolen) {
 	switch (cmos.reg) {
 	case 0x00:		/* Seconds */
 	case 0x02:		/* Minutes */
@@ -123,7 +123,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
 #define MAKE_RETURN(_VAL) (cmos.bcd ? ((((_VAL) / 10) << 4) | ((_VAL) % 10)) : (_VAL));
 
-static Bitu cmos_readreg(Bitu port,Bitu iolen) {
+static Bitu cmos_readreg(uint16_t port,Bitu iolen) {
 	if (cmos.reg>0x3f) {
 		LOG(LOG_BIOS,LOG_ERROR)("CMOS:Read from illegal register %x",cmos.reg);
 		return 0xff;

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -176,7 +176,7 @@ static void DISNEY_analyze(Bitu channel){
 	}
 }
 
-static void disney_write(Bitu port,Bitu val,Bitu iolen) {
+static void disney_write(uint16_t port,Bitu val,Bitu iolen) {
 	//LOG_MSG("write disney time %f addr%x val %x",PIC_FullIndex(),port,val);
 	disney.last_used=PIC_Ticks;
 	switch (port-DISNEY_BASE) {
@@ -254,7 +254,7 @@ static void disney_write(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-static Bitu disney_read(Bitu port,Bitu iolen) {
+static Bitu disney_read(uint16_t port,Bitu iolen) {
 	Bitu retval;
 	switch (port-DISNEY_BASE) {
 	case 0:		/* Data Port */

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -35,7 +35,7 @@ static Bit32u dma_wrapping = 0xffff;
 
 static void UpdateEMSMapping(void) {
 	/* if EMS is not present, this will result in a 1:1 mapping */
-	Bitu i;
+	uint16_t i;
 	for (i=0;i<0x10;i++) {
 		ems_board_mapping[EMM_PAGEFRAME4K+i]=paging.firstmb[EMM_PAGEFRAME4K+i];
 	}
@@ -108,7 +108,7 @@ bool SecondDMAControllerAvailable(void) {
 	else return false;
 }
 
-static void DMA_Write_Port(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void DMA_Write_Port(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	//LOG(LOG_DMACONTROL,LOG_ERROR)("Write %" sBitfs(X) " %" sBitfs(X),port,val);
 	if (port<0x10) {
 		/* write to the first DMA controller (channels 0-3) */
@@ -131,7 +131,7 @@ static void DMA_Write_Port(Bitu port,Bitu val,Bitu /*iolen*/) {
 	}
 }
 
-static Bitu DMA_Read_Port(Bitu port,Bitu iolen) {
+static Bitu DMA_Read_Port(uint16_t port,Bitu iolen) {
 	//LOG(LOG_DMACONTROL,LOG_ERROR)("Read %" sBitfs(X),port);
 	if (port<0x10) {
 		/* read from the first DMA controller (channels 0-3) */
@@ -349,7 +349,7 @@ again:
 class DMA:public Module_base{
 public:
 	DMA(Section* configuration):Module_base(configuration){
-		Bitu i;
+		uint16_t i;
 		DmaControllers[0] = new DmaController(0);
 		if (IS_EGAVGA_ARCH) DmaControllers[1] = new DmaController(1);
 		else DmaControllers[1] = NULL;
@@ -403,7 +403,7 @@ void DMA_Init(Section* sec) {
 	DMA_SetWrapping(0xffff);
 	test = new DMA(sec);
 	sec->AddDestroyFunction(&DMA_Destroy);
-	Bitu i;
+	uint16_t i;
 	for (i=0;i<LINK_START;i++) {
 		ems_board_mapping[i]=i;
 	}

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -39,7 +39,7 @@ static Bit32u lastWriteTicks;
 static Bit32u cmsBase;
 static saa1099_device* device[2];
 
-static void write_cms(Bitu port, Bitu val, Bitu /* iolen */) {
+static void write_cms(uint16_t port, Bitu val, Bitu /* iolen */) {
 	if (cms_chan && (!cms_chan->is_enabled))
 		cms_chan->Enable(true);
 	lastWriteTicks = PIC_Ticks;
@@ -95,7 +95,7 @@ static void CMS_CallBack(Bitu len) {
 // The Gameblaster detection
 static Bit8u cms_detect_register = 0xff;
 
-static void write_cms_detect(Bitu port, Bitu val, Bitu /* iolen */) {
+static void write_cms_detect(uint16_t port, Bitu val, Bitu /* iolen */) {
 	switch ( port - cmsBase ) {
 	case 0x6:
 	case 0x7:
@@ -104,7 +104,7 @@ static void write_cms_detect(Bitu port, Bitu val, Bitu /* iolen */) {
 	}
 }
 
-static Bitu read_cms_detect(Bitu port, Bitu /* iolen */) {
+static Bitu read_cms_detect(uint16_t port, Bitu /* iolen */) {
 	Bit8u retval = 0xff;
 	switch ( port - cmsBase ) {
 	case 0x4:

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -90,7 +90,7 @@ struct GFGus {
 		float delay;
 	} timers[2];
 	Bit32u rate;
-	Bitu portbase;
+	uint16_t portbase;
 	Bit8u dma1;
 	Bit8u dma2;
 
@@ -619,7 +619,7 @@ static void ExecuteGlobRegister(void) {
 }
 
 
-static Bitu read_gus(Bitu port,Bitu iolen) {
+static Bitu read_gus(uint16_t port,Bitu iolen) {
 //	LOG_MSG("read from gus port %x",port);
 	switch(port - GUS_BASE) {
 	case 0x206:
@@ -661,7 +661,7 @@ static Bitu read_gus(Bitu port,Bitu iolen) {
 }
 
 
-static void write_gus(Bitu port,Bitu val,Bitu iolen) {
+static void write_gus(uint16_t port,Bitu val,Bitu iolen) {
 //	LOG_MSG("Write gus port %x val %x",port,val);
 	switch(port - GUS_BASE) {
 	case 0x200:

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -30,14 +30,14 @@
 IO_WriteHandler * io_writehandlers[3][IO_MAX];
 IO_ReadHandler * io_readhandlers[3][IO_MAX];
 
-static Bitu IO_ReadBlocked(Bitu /*port*/,Bitu /*iolen*/) {
+static Bitu IO_ReadBlocked(uint16_t port,Bitu /*iolen*/) {
 	return ~0;
 }
 
-static void IO_WriteBlocked(Bitu /*port*/,Bitu /*val*/,Bitu /*iolen*/) {
+static void IO_WriteBlocked(uint16_t port,Bitu /*val*/,Bitu /*iolen*/) {
 }
 
-static Bitu IO_ReadDefault(Bitu port,Bitu iolen) {
+static Bitu IO_ReadDefault(uint16_t port,Bitu iolen) {
 	switch (iolen) {
 	case 1:
 		LOG(LOG_IO,LOG_WARN)("Read from port %04X",port);
@@ -55,7 +55,7 @@ static Bitu IO_ReadDefault(Bitu port,Bitu iolen) {
 	return 0;
 }
 
-void IO_WriteDefault(Bitu port,Bitu val,Bitu iolen) {
+void IO_WriteDefault(uint16_t port,Bitu val,Bitu iolen) {
 	switch (iolen) {
 	case 1:
 		LOG(LOG_IO,LOG_WARN)("Writing %02X to port %04X",val,port);
@@ -72,7 +72,7 @@ void IO_WriteDefault(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-void IO_RegisterReadHandler(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range) {
+void IO_RegisterReadHandler(uint16_t port,IO_ReadHandler * handler,Bitu mask,Bitu range) {
 	while (range--) {
 		if (mask&IO_MB) io_readhandlers[0][port]=handler;
 		if (mask&IO_MW) io_readhandlers[1][port]=handler;
@@ -81,7 +81,7 @@ void IO_RegisterReadHandler(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu ra
 	}
 }
 
-void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range) {
+void IO_RegisterWriteHandler(uint16_t port,IO_WriteHandler * handler,Bitu mask,Bitu range) {
 	while (range--) {
 		if (mask&IO_MB) io_writehandlers[0][port]=handler;
 		if (mask&IO_MW) io_writehandlers[1][port]=handler;
@@ -90,7 +90,7 @@ void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu 
 	}
 }
 
-void IO_FreeReadHandler(Bitu port,Bitu mask,Bitu range) {
+void IO_FreeReadHandler(uint16_t port,Bitu mask,Bitu range) {
 	while (range--) {
 		if (mask&IO_MB) io_readhandlers[0][port]=IO_ReadDefault;
 		if (mask&IO_MW) io_readhandlers[1][port]=IO_ReadDefault;
@@ -99,7 +99,7 @@ void IO_FreeReadHandler(Bitu port,Bitu mask,Bitu range) {
 	}
 }
 
-void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range) {
+void IO_FreeWriteHandler(uint16_t port,Bitu mask,Bitu range) {
 	while (range--) {
 		if (mask&IO_MB) io_writehandlers[0][port]=IO_WriteDefault;
 		if (mask&IO_MW) io_writehandlers[1][port]=IO_WriteDefault;
@@ -108,7 +108,7 @@ void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range) {
 	}
 }
 
-void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range) {
+void IO_ReadHandleObject::Install(uint16_t port,IO_ReadHandler * handler,Bitu mask,Bitu range) {
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -116,7 +116,7 @@ void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler * handler,Bitu mask,B
 		m_range=range;
 		IO_RegisterReadHandler(port,handler,mask,range);
 	} else
-		E_Exit("IO_readHandler already installed port %#" PRIxPTR, port);
+		E_Exit("IO_readHandler already installed port %#" PRIx16, port);
 }
 
 void IO_ReadHandleObject::Uninstall(){
@@ -129,7 +129,7 @@ IO_ReadHandleObject::~IO_ReadHandleObject(){
 	Uninstall();
 }
 
-void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range) {
+void IO_WriteHandleObject::Install(uint16_t port,IO_WriteHandler * handler,Bitu mask,Bitu range) {
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -137,7 +137,7 @@ void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler * handler,Bitu mask
 		m_range=range;
 		IO_RegisterWriteHandler(port,handler,mask,range);
 	} else
-		E_Exit("IO_writeHandler already installed port %#" PRIxPTR, port);
+		E_Exit("IO_writeHandler already installed port %#" PRIx16, port);
 }
 
 void IO_WriteHandleObject::Uninstall() {
@@ -148,7 +148,7 @@ void IO_WriteHandleObject::Uninstall() {
 
 IO_WriteHandleObject::~IO_WriteHandleObject(){
 	Uninstall();
-	// LOG_MSG("FreeWritehandler called with port %#" PRIxPTR,m_port);
+	// LOG_MSG("FreeWritehandler called with port %#" PRIx16,m_port);
 }
 
 struct IOF_Entry {
@@ -225,7 +225,7 @@ inline void IO_USEC_write_delay() {
 #ifdef ENABLE_PORTLOG
 static Bit8u crtc_index = 0;
 const char* const len_type[] = {" 8","16","32"};
-void log_io(Bitu width, bool write, Bitu port, Bitu val) {
+void log_io(Bitu width, bool write, uint16_t port, Bitu val) {
 	switch(width) {
 	case 0:
 		val&=0xff;
@@ -288,7 +288,7 @@ void log_io(Bitu width, bool write, Bitu port, Bitu val) {
 #endif
 
 
-void IO_WriteB(Bitu port,Bitu val) {
+void IO_WriteB(uint16_t port,Bitu val) {
 	log_io(0, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
 		LazyFlags old_lflags;
@@ -324,7 +324,7 @@ void IO_WriteB(Bitu port,Bitu val) {
 	}
 }
 
-void IO_WriteW(Bitu port,Bitu val) {
+void IO_WriteW(uint16_t port,Bitu val) {
 	log_io(1, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
 		LazyFlags old_lflags;
@@ -360,7 +360,7 @@ void IO_WriteW(Bitu port,Bitu val) {
 	}
 }
 
-void IO_WriteD(Bitu port,Bitu val) {
+void IO_WriteD(uint16_t port,Bitu val) {
 	log_io(2, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
 		LazyFlags old_lflags;
@@ -393,7 +393,7 @@ void IO_WriteD(Bitu port,Bitu val) {
 	else io_writehandlers[2][port](port,val,4);
 }
 
-Bitu IO_ReadB(Bitu port) {
+Bitu IO_ReadB(uint16_t port) {
 	Bitu retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
 		LazyFlags old_lflags;
@@ -432,7 +432,7 @@ Bitu IO_ReadB(Bitu port) {
 	return retval;
 }
 
-Bitu IO_ReadW(Bitu port) {
+Bitu IO_ReadW(uint16_t port) {
 	Bitu retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
 		LazyFlags old_lflags;
@@ -470,7 +470,7 @@ Bitu IO_ReadW(Bitu port) {
 	return retval;
 }
 
-Bitu IO_ReadD(Bitu port) {
+Bitu IO_ReadD(uint16_t port) {
 	Bitu retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
 		LazyFlags old_lflags;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -144,7 +144,7 @@ bool button_wrapping_enabled = true;
 
 extern bool autofire; //sdl_mapper.cpp
 
-static Bitu read_p201(Bitu port,Bitu iolen) {
+static Bitu read_p201(uint16_t port,Bitu iolen) {
 	/* Reset Joystick to 0 after TIMEOUT ms */
 	if(write_active && ((PIC_Ticks - last_write) > TIMEOUT)) {
 		write_active = false;
@@ -180,7 +180,7 @@ static Bitu read_p201(Bitu port,Bitu iolen) {
 	return ret;
 }
 
-static Bitu read_p201_timed(Bitu port,Bitu iolen) {
+static Bitu read_p201_timed(uint16_t port,Bitu iolen) {
 	Bit8u ret=0xff;
 	double currentTick = PIC_FullIndex();
 	if( stick[0].enabled ){
@@ -203,7 +203,7 @@ static Bitu read_p201_timed(Bitu port,Bitu iolen) {
 	return ret;
 }
 
-static void write_p201(Bitu port,Bitu val,Bitu iolen) {
+static void write_p201(uint16_t port,Bitu val,Bitu iolen) {
 	/* Store writetime index */
 	write_active = true;
 	last_write = PIC_Ticks;
@@ -218,7 +218,7 @@ static void write_p201(Bitu port,Bitu val,Bitu iolen) {
 	}
 
 }
-static void write_p201_timed(Bitu port,Bitu val,Bitu iolen) {
+static void write_p201_timed(uint16_t port,Bitu val,Bitu iolen) {
 	// Axes take time = 24.2 microseconds + ( 0.011 microsecons/ohm * resistance )
 	// to reset to 0
 	// Pre-calculate the time at which each axis hits 0 here

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -95,7 +95,7 @@ static void KEYBOARD_AddBuffer(Bit8u data) {
 }
 
 
-static Bitu read_p60(Bitu port,Bitu iolen) {
+static Bitu read_p60(uint16_t port,Bitu iolen) {
 	keyb.p60changed=false;
 	if (!keyb.scheduled && keyb.used) {
 		keyb.scheduled=true;
@@ -104,7 +104,7 @@ static Bitu read_p60(Bitu port,Bitu iolen) {
 	return keyb.p60data;
 }	
 
-static void write_p60(Bitu port,Bitu val,Bitu iolen) {
+static void write_p60(uint16_t port,Bitu val,Bitu iolen) {
 	switch (keyb.command) {
 	case CMD_NONE:	/* None */
 		/* No active command this would normally get sent to the keyboard then */
@@ -172,7 +172,7 @@ static void write_p60(Bitu port,Bitu val,Bitu iolen) {
 
 extern bool TIMER_GetOutput2(void);
 static Bit8u port_61_data = 0;
-static Bitu read_p61(Bitu port,Bitu iolen) {
+static Bitu read_p61(uint16_t port,Bitu iolen) {
 	if (TIMER_GetOutput2()) port_61_data|=0x20;
 	else					port_61_data&=~0x20;
 	port_61_data^=0x10;
@@ -180,7 +180,7 @@ static Bitu read_p61(Bitu port,Bitu iolen) {
 }
 
 extern void TIMER_SetGate2(bool);
-static void write_p61(Bitu port,Bitu val,Bitu iolen) {
+static void write_p61(uint16_t port,Bitu val,Bitu iolen) {
 	if ((port_61_data ^ val) & 3) {
 		if((port_61_data ^ val) & 1) TIMER_SetGate2(val&0x1);
 		PCSPEAKER_SetType(val & 3);
@@ -188,13 +188,13 @@ static void write_p61(Bitu port,Bitu val,Bitu iolen) {
 	port_61_data = val;
 }
 
-static Bitu read_p62(Bitu port,Bitu iolen) {
+static Bitu read_p62(uint16_t port,Bitu iolen) {
 	Bit8u ret=~0x20;
 	if (TIMER_GetOutput2()) ret|=0x20;
 	return ret;
 }
 
-static void write_p64(Bitu port,Bitu val,Bitu iolen) {
+static void write_p64(uint16_t port,Bitu val,Bitu iolen) {
 	switch (val) {
 	case 0xae:		/* Activate keyboard */
 		keyb.active=true;
@@ -220,7 +220,7 @@ static void write_p64(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-static Bitu read_p64(Bitu port,Bitu iolen) {
+static Bitu read_p64(uint16_t port,Bitu iolen) {
 	Bit8u status= 0x1c | (keyb.p60changed? 0x1 : 0x0);
 	return status;
 }

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -514,14 +514,14 @@ void mem_writed(PhysPt address,Bit32u val) {
 	mem_writed_inline(address,val);
 }
 
-static void write_p92(Bitu port,Bitu val,Bitu iolen) {	
+static void write_p92(uint16_t port,Bitu val,Bitu iolen) {	
 	// Bit 0 = system reset (switch back to real mode)
 	if (val&1) E_Exit("XMS: CPU reset via port 0x92 not supported.");
 	memory.a20.controlport = val & ~2;
 	MEM_A20_Enable((val & 2)>0);
 }
 
-static Bitu read_p92(Bitu port,Bitu iolen) {
+static Bitu read_p92(uint16_t port,Bitu iolen) {
 	return memory.a20.controlport | (memory.a20.enabled ? 0x02 : 0);
 }
 

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -40,7 +40,7 @@ static void MPU401_EOIHandlerDispatch(void);
 enum MpuMode { M_UART,M_INTELLIGENT };
 enum MpuDataType {T_OVERFLOW,T_MARK,T_MIDI_SYS,T_MIDI_NORM,T_COMMAND};
 
-static void MPU401_WriteData(Bitu port,Bitu val,Bitu iolen);
+static void MPU401_WriteData(uint16_t port,Bitu val,Bitu iolen);
 
 /* Messages sent to MPU-401 from host */
 #define MSG_EOX	                        0xf7
@@ -111,14 +111,14 @@ static void ClrQueue(void) {
 	mpu.queue_pos=0;
 }
 
-static Bitu MPU401_ReadStatus(Bitu port,Bitu iolen) {
+static Bitu MPU401_ReadStatus(uint16_t port,Bitu iolen) {
 	Bit8u ret=0x3f;	/* Bits 6 and 7 clear */
 	if (mpu.state.cmd_pending) ret|=0x40;
 	if (!mpu.queue_used) ret|=0x80;
 	return ret;
 }
 
-static void MPU401_WriteCommand(Bitu port,Bitu val,Bitu iolen) {
+static void MPU401_WriteCommand(uint16_t port,Bitu val,Bitu iolen) {
 	if (mpu.mode==M_UART && val!=0xff) return;
 	if (mpu.state.reset) {
 		if (mpu.state.cmd_pending || val!=0xff) {
@@ -267,7 +267,7 @@ static void MPU401_WriteCommand(Bitu port,Bitu val,Bitu iolen) {
 	QueueByte(MSG_MPU_ACK);
 }
 
-static Bitu MPU401_ReadData(Bitu port,Bitu iolen) {
+static Bitu MPU401_ReadData(uint16_t port,Bitu iolen) {
 	Bit8u ret=MSG_MPU_ACK;
 	if (mpu.queue_used) {
 		if (mpu.queue_pos>=MPU401_QUEUE) mpu.queue_pos-=MPU401_QUEUE;
@@ -300,7 +300,7 @@ static Bitu MPU401_ReadData(Bitu port,Bitu iolen) {
 	return ret;
 }
 
-static void MPU401_WriteData(Bitu port,Bitu val,Bitu iolen) {
+static void MPU401_WriteData(uint16_t port,Bitu val,Bitu iolen) {
 	if (mpu.mode==M_UART) {MIDI_RawOutByte(val);return;}
 	switch (mpu.state.command_byte) {	/* 0xe# command data */
 		case 0x00:

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -893,7 +893,7 @@ void adlib_write(Bitu idx, Bit8u val) {
 }
 
 
-Bitu adlib_reg_read(Bitu port) {
+Bitu adlib_reg_read(uint16_t port) {
 #if defined(OPLTYPE_IS_OPL3)
 	// opl3-detection routines require ret&6 to be zero
 	if ((port&1)==0) {
@@ -909,7 +909,7 @@ Bitu adlib_reg_read(Bitu port) {
 #endif
 }
 
-void adlib_write_index(Bitu port, Bit8u val) {
+void adlib_write_index(uint16_t port, Bit8u val) {
 	opl_index = val;
 #if defined(OPLTYPE_IS_OPL3)
 	if ((port&3)!=0) {

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -195,7 +195,7 @@ void adlib_init(Bit32u samplerate);
 void adlib_write(Bitu idx, Bit8u val);
 void adlib_getsample(Bit16s* sndptr, Bits numsamples);
 
-Bitu adlib_reg_read(Bitu port);
-void adlib_write_index(Bitu port, Bit8u val);
+Bitu adlib_reg_read(uint16_t port);
+void adlib_write_index(uint16_t port, Bit8u val);
 
 static Bit32u generator_add;	// should be a chip parameter

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -44,7 +44,7 @@ static PCI_Device* pci_devices[PCI_MAX_PCIDEVICES];		// registered PCI devices
 // 10- 8 - subfunction number	(0x00000700)
 //  7- 2 - config register #	(0x000000fc)
 
-static void write_pci_addr(Bitu port,Bitu val,Bitu iolen) {
+static void write_pci_addr(uint16_t port,Bitu val,Bitu iolen) {
 	LOG(LOG_PCI,LOG_NORMAL)("Write PCI address :=%x",val);
 	pci_caddress=val;
 }
@@ -70,7 +70,7 @@ static void write_pci_register(PCI_Device* dev,Bit8u regnum,Bit8u value) {
 		pci_cfg_data[dev->PCIId()][dev->PCISubfunction()][regnum]=(Bit8u)(parsed_register&0xff);
 }
 
-static void write_pci(Bitu port,Bitu val,Bitu iolen) {
+static void write_pci(uint16_t port,Bitu val,Bitu iolen) {
 	LOG(LOG_PCI,LOG_NORMAL)("Write PCI data :=%x (len %d)",port,val,iolen);
 
 	// check for enabled/bus 0
@@ -102,7 +102,7 @@ static void write_pci(Bitu port,Bitu val,Bitu iolen) {
 }
 
 
-static Bitu read_pci_addr(Bitu port,Bitu iolen) {
+static Bitu read_pci_addr(uint16_t port,Bitu iolen) {
 	LOG(LOG_PCI,LOG_NORMAL)("Read PCI address -> %x",pci_caddress);
 	return pci_caddress;
 }
@@ -140,7 +140,7 @@ static Bit8u read_pci_register(PCI_Device* dev,Bit8u regnum) {
 	return 0xff;
 }
 
-static Bitu read_pci(Bitu port,Bitu iolen) {
+static Bitu read_pci(uint16_t port,Bitu iolen) {
 	LOG(LOG_PCI,LOG_NORMAL)("Read PCI data -> %x",pci_caddress);
 
 	if ((pci_caddress & 0x80ff0000) == 0x80000000) {

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -177,7 +177,7 @@ static struct {
 	PICEntry * next_entry;
 } pic_queue;
 
-static void write_command(Bitu port,Bitu val,Bitu iolen) {
+static void write_command(uint16_t port,Bitu val,Bitu iolen) {
 	PIC_Controller * pic=&pics[port==0x20 ? 0 : 1];
 
 	if (GCC_UNLIKELY(val&0x10)) {		// ICW1 issued
@@ -229,7 +229,7 @@ static void write_command(Bitu port,Bitu val,Bitu iolen) {
 	}	// end OCW2
 }
 
-static void write_data(Bitu port,Bitu val,Bitu iolen) {
+static void write_data(uint16_t port,Bitu val,Bitu iolen) {
 	PIC_Controller * pic=&pics[port==0x21 ? 0 : 1];
 	switch(pic->icw_index) {
 	case 0:                        /* mask register */
@@ -278,7 +278,7 @@ static void write_data(Bitu port,Bitu val,Bitu iolen) {
 }
 
 
-static Bitu read_command(Bitu port,Bitu iolen) {
+static Bitu read_command(uint16_t port,Bitu iolen) {
 	PIC_Controller * pic=&pics[port==0x20 ? 0 : 1];
 	if (pic->request_issr){
 		return pic->isr;
@@ -288,7 +288,7 @@ static Bitu read_command(Bitu port,Bitu iolen) {
 }
 
 
-static Bitu read_data(Bitu port,Bitu iolen) {
+static Bitu read_data(uint16_t port,Bitu iolen) {
 	PIC_Controller * pic=&pics[port==0x21 ? 0 : 1];
 	return pic->imr;
 }

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -144,7 +144,7 @@ struct SB_INFO {
 		bool haveref;
 	} adpcm;
 	struct {
-		Bitu base;
+		uint16_t base;
 		Bitu irq;
 		Bit8u dma8,dma16;
 	} hw;
@@ -1480,7 +1480,7 @@ static Bit8u CTMIXER_Read(void) {
 }
 
 
-static Bitu read_sb(Bitu port,Bitu /*iolen*/) {
+static Bitu read_sb(uint16_t port,Bitu /*iolen*/) {
 	switch (port-sb.hw.base) {
 	case MIXER_INDEX:
 		return sb.mixer.index;
@@ -1519,7 +1519,7 @@ static Bitu read_sb(Bitu port,Bitu /*iolen*/) {
 	return 0xff;
 }
 
-static void write_sb(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_sb(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	Bit8u val8=(Bit8u)(val&0xff);
 	switch (port-sb.hw.base) {
 	case DSP_RESET:
@@ -1540,7 +1540,7 @@ static void write_sb(Bitu port,Bitu val,Bitu /*iolen*/) {
 	}
 }
 
-static void adlib_gusforward(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+static void adlib_gusforward(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	adlib_commandreg=(Bit8u)(val&0xff);
 }
 

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -97,7 +97,7 @@ device_COM::~device_COM() {
 // COM1 - COM4 objects
 CSerial *serialports[SERIAL_MAX_PORTS] = {nullptr};
 
-static Bitu SERIAL_Read (Bitu port, Bitu iolen) {
+static Bitu SERIAL_Read (uint16_t port, Bitu iolen) {
 	(void)iolen; // unused, but required for API compliance
 	uint32_t i = 0;
 	uint32_t retval = 0;
@@ -137,7 +137,7 @@ static Bitu SERIAL_Read (Bitu port, Bitu iolen) {
 #endif
 	return static_cast<Bitu>(retval);
 }
-static void SERIAL_Write (Bitu port, Bitu val, Bitu) {
+static void SERIAL_Write (uint16_t port, Bitu val, Bitu) {
 	uint32_t i;
 	const uint8_t offset_type = static_cast<uint8_t>(port) & 0x7;
 	switch(port&0xff8) {
@@ -1159,7 +1159,7 @@ CSerial::CSerial(const uint8_t port_idx, CommandLine *cmd)
 	overrunIF0=0;
 	breakErrors=0;
 
-	for (uint32_t i = 0; i <= 7; i++) {
+	for (uint16_t i = 0; i <= 7; i++) {
 		WriteHandler[i].Install (i + base, SERIAL_Write, IO_MB);
 		ReadHandler[i].Install(i + base, SERIAL_Read, IO_MB);
 	}

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -69,7 +69,7 @@ static ncr8496_device device_ncr8496(machine_config(), 0, 0, SOUND_CLOCK);
 static sn76496_base_device* activeDevice = &device_ncr8496;
 #define device (*activeDevice)
 
-static void SN76496Write(Bitu /*port*/,Bitu data,Bitu /*iolen*/) {
+static void SN76496Write(uint16_t port,Bitu data,Bitu /*iolen*/) {
 	tandy.last_write=PIC_Ticks;
 	if (!tandy.enabled) {
 		tandy.chan->Enable(true);
@@ -159,7 +159,7 @@ static void TandyDACDMAEnabled(void) {
 static void TandyDACDMADisabled(void) {
 }
 
-static void TandyDACWrite(Bitu port,Bitu data,Bitu /*iolen*/) {
+static void TandyDACWrite(uint16_t port,Bitu data,Bitu /*iolen*/) {
 	switch (port) {
 	case 0xc4: {
 		Bitu oldmode = tandy.dac.mode;
@@ -219,7 +219,7 @@ static void TandyDACWrite(Bitu port,Bitu data,Bitu /*iolen*/) {
 	}
 }
 
-static Bitu TandyDACRead(Bitu port,Bitu /*iolen*/) {
+static Bitu TandyDACRead(uint16_t port,Bitu /*iolen*/) {
 	switch (port) {
 	case 0xc4:
 		return (tandy.dac.mode&0x77) | (tandy.dac.irq_activated ? 0x08 : 0x00);
@@ -228,7 +228,7 @@ static Bitu TandyDACRead(Bitu port,Bitu /*iolen*/) {
 	case 0xc7:
 		return (Bit8u)(((tandy.dac.frequency>>8)&0xf) | (tandy.dac.amplitude<<5));
 	}
-	LOG_MSG("Tandy DAC: Read from unknown %#" PRIxPTR, port);
+	LOG_MSG("Tandy DAC: Read from unknown %#" PRIx16, port);
 	return 0xff;
 }
 

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -194,7 +194,7 @@ static void counter_latch(Bitu counter) {
 }
 
 
-static void write_latch(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_latch(uint16_t port,Bitu val,Bitu /*iolen*/) {
 //LOG(LOG_PIT,LOG_ERROR)("port %X write:%X state:%X",port,val,pit[port-0x40].write_state);
 	Bitu counter=port-0x40;
 	PIT_Block * p=&pit[counter];
@@ -252,7 +252,7 @@ static void write_latch(Bitu port,Bitu val,Bitu /*iolen*/) {
     }
 }
 
-static Bitu read_latch(Bitu port,Bitu /*iolen*/) {
+static Bitu read_latch(uint16_t port,Bitu /*iolen*/) {
 //LOG(LOG_PIT,LOG_ERROR)("port read %X",port);
 	Bit32u counter=port-0x40;
 	Bit8u ret=0;
@@ -293,7 +293,7 @@ static Bitu read_latch(Bitu port,Bitu /*iolen*/) {
 	return ret;
 }
 
-static void write_p43(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+static void write_p43(uint16_t port,Bitu val,Bitu /*iolen*/) {
 //LOG(LOG_PIT,LOG_ERROR)("port 43 %X",val);
 	Bitu latch=(val >> 6) & 0x03;
 	switch (latch) {

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -90,14 +90,14 @@ void VGA_ATTR_SetPalette(Bit8u index, Bit8u val) {
 	VGA_DAC_CombineColor(index,val);
 }
 
-Bitu read_p3c0(Bitu /*port*/,Bitu /*iolen*/) {
+Bitu read_p3c0(uint16_t port,Bitu /*iolen*/) {
 	// Wcharts, Win 3.11 & 95 SVGA
 	Bitu retval = attr(index) & 0x1f;
 	if (!(attr(disabled) & 0x1)) retval |= 0x20;
 	return retval;
 }
  
-void write_p3c0(Bitu /*port*/,Bitu val,Bitu iolen) {
+void write_p3c0(uint16_t port,Bitu val,Bitu iolen) {
 	if (!vga.internal.attrindex) {
 		attr(index)=val & 0x1F;
 		vga.internal.attrindex=true;
@@ -257,7 +257,7 @@ void write_p3c0(Bitu /*port*/,Bitu val,Bitu iolen) {
 	}
 }
 
-Bitu read_p3c1(Bitu /*port*/,Bitu iolen) {
+Bitu read_p3c1(uint16_t port,Bitu iolen) {
 //	vga.internal.attrindex=false;
 	switch (attr(index)) {
 			/* Palette */

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -32,18 +32,18 @@
 void VGA_MapMMIO(void);
 void VGA_UnmapMMIO(void);
 
-void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen);
+void vga_write_p3d5(uint16_t port,Bitu val,Bitu iolen);
 Bitu DEBUG_EnableDebugger(void);
 
-void vga_write_p3d4(Bitu port,Bitu val,Bitu iolen) {
+void vga_write_p3d4(uint16_t port,Bitu val,Bitu iolen) {
 	crtc(index)=val;
 }
 
-Bitu vga_read_p3d4(Bitu port,Bitu iolen) {
+Bitu vga_read_p3d4(uint16_t port,Bitu iolen) {
 	return crtc(index);
 }
 
-void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen) {
+void vga_write_p3d5(uint16_t port,Bitu val,Bitu iolen) {
 //	if (crtc(index)>0x18) LOG_MSG("VGA CRCT write %X to reg %X",val,crtc(index));
 	switch(crtc(index)) {
 	case 0x00:	/* Horizontal Total Register */
@@ -367,7 +367,7 @@ void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-Bitu vga_read_p3d5(Bitu port,Bitu iolen) {
+Bitu vga_read_p3d5(uint16_t port,Bitu iolen) {
 //	LOG_MSG("VGA CRCT read from reg %X",crtc(index));
 	switch(crtc(index)) {
 	case 0x00:	/* Horizontal Total Register */

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -66,7 +66,7 @@ static void VGA_DAC_UpdateColor( Bitu index ) {
 	VGA_DAC_SendColor( index, maskIndex );
 }
 
-static void write_p3c6(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3c6(uint16_t port,Bitu val,Bitu iolen) {
 	if ( vga.dac.pel_mask != val ) {
 		LOG(LOG_VGAMISC,LOG_NORMAL)("VGA:DCA:Pel Mask set to %X", val);
 		vga.dac.pel_mask = val;
@@ -76,35 +76,35 @@ static void write_p3c6(Bitu port,Bitu val,Bitu iolen) {
 }
 
 
-static Bitu read_p3c6(Bitu port,Bitu iolen) {
+static Bitu read_p3c6(uint16_t port,Bitu iolen) {
 	return vga.dac.pel_mask;
 }
 
 
-static void write_p3c7(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3c7(uint16_t port,Bitu val,Bitu iolen) {
 	vga.dac.read_index=val;
 	vga.dac.pel_index=0;
 	vga.dac.state=DAC_READ;
 	vga.dac.write_index= val + 1;
 }
 
-static Bitu read_p3c7(Bitu port,Bitu iolen) {
+static Bitu read_p3c7(uint16_t port,Bitu iolen) {
 	if (vga.dac.state==DAC_READ) return 0x3;
 	else return 0x0;
 }
 
-static void write_p3c8(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3c8(uint16_t port,Bitu val,Bitu iolen) {
 	vga.dac.write_index=val;
 	vga.dac.pel_index=0;
 	vga.dac.state=DAC_WRITE;
 	vga.dac.read_index= val - 1;
 }
 
-static Bitu read_p3c8(Bitu port, Bitu iolen){
+static Bitu read_p3c8(uint16_t port, Bitu iolen){
 	return vga.dac.write_index;
 }
 
-static void write_p3c9(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3c9(uint16_t port,Bitu val,Bitu iolen) {
 	val&=0x3f;
 	switch (vga.dac.pel_index) {
 	case 0:
@@ -148,7 +148,7 @@ static void write_p3c9(Bitu port,Bitu val,Bitu iolen) {
 	};
 }
 
-static Bitu read_p3c9(Bitu port,Bitu iolen) {
+static Bitu read_p3c9(uint16_t port,Bitu iolen) {
 	Bit8u ret;
 	switch (vga.dac.pel_index) {
 	case 0:

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -24,15 +24,15 @@
 #define gfx(blah) vga.gfx.blah
 static bool index9warned=false;
 
-static void write_p3ce(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3ce(uint16_t port,Bitu val,Bitu iolen) {
 	gfx(index)=val & 0x0f;
 }
 
-static Bitu read_p3ce(Bitu port,Bitu iolen) {
+static Bitu read_p3ce(uint16_t port,Bitu iolen) {
 	return gfx(index);
 }
 
-static void write_p3cf(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3cf(uint16_t port,Bitu val,Bitu iolen) {
 	switch (gfx(index)) {
 	case 0:	/* Set/Reset Register */
 		gfx(set_reset)=val & 0x0f;
@@ -190,7 +190,7 @@ static void write_p3cf(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-static Bitu read_p3cf(Bitu port,Bitu iolen) {
+static Bitu read_p3cf(uint16_t port,Bitu iolen) {
 	switch (gfx(index)) {
 	case 0:	/* Set/Reset Register */
 		return gfx(set_reset);

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -658,8 +658,8 @@ public:
 	}
 };
 
-extern void XGA_Write(Bitu port, Bitu val, Bitu len);
-extern Bitu XGA_Read(Bitu port, Bitu len);
+extern void XGA_Write(uint16_t port, Bitu val, Bitu len);
+extern Bitu XGA_Read(uint16_t port, Bitu len);
 
 class VGA_MMIO_Handler : public PageHandler {
 public:
@@ -667,28 +667,28 @@ public:
 		flags=PFLAG_NOCODE;
 	}
 	void writeb(PhysPt addr,Bitu val) {
-		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
+		uint16_t port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		XGA_Write(port, val, 1);
 	}
 	void writew(PhysPt addr,Bitu val) {
-		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
+		uint16_t port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		XGA_Write(port, val, 2);
 	}
 	void writed(PhysPt addr,Bitu val) {
-		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
+		uint16_t port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		XGA_Write(port, val, 4);
 	}
 
 	Bitu readb(PhysPt addr) {
-		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
+		uint16_t port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		return XGA_Read(port, 1);
 	}
 	Bitu readw(PhysPt addr) {
-		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
+		uint16_t port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		return XGA_Read(port, 2);
 	}
 	Bitu readd(PhysPt addr) {
-		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
+		uint16_t port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		return XGA_Read(port, 4);
 	}
 };

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -24,12 +24,12 @@
 #include <math.h>
 
 
-void vga_write_p3d4(Bitu port,Bitu val,Bitu iolen);
-Bitu vga_read_p3d4(Bitu port,Bitu iolen);
-void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen);
-Bitu vga_read_p3d5(Bitu port,Bitu iolen);
+void vga_write_p3d4(uint16_t port,Bitu val,Bitu iolen);
+Bitu vga_read_p3d4(uint16_t port,Bitu iolen);
+void vga_write_p3d5(uint16_t port,Bitu val,Bitu iolen);
+Bitu vga_read_p3d5(uint16_t port,Bitu iolen);
 
-Bitu vga_read_p3da(Bitu port,Bitu iolen) {
+Bitu vga_read_p3da(uint16_t port,Bitu iolen) {
 	Bit8u retval=4;	// bit 2 set, needed by Blues Brothers
 	double timeInFrame = PIC_FullIndex()-vga.draw.delay.framestart;
 
@@ -55,7 +55,7 @@ Bitu vga_read_p3da(Bitu port,Bitu iolen) {
 	return retval;
 }
 
-static void write_p3c2(Bitu port,Bitu val,Bitu iolen) {
+static void write_p3c2(uint16_t port,Bitu val,Bitu iolen) {
 	vga.misc_output=val;
 
 	Bitu base=(val & 0x1) ? 0x3d0 : 0x3b0;
@@ -91,20 +91,20 @@ static void write_p3c2(Bitu port,Bitu val,Bitu iolen) {
 }
 
 
-static Bitu read_p3cc(Bitu port,Bitu iolen) {
+static Bitu read_p3cc(uint16_t port,Bitu iolen) {
 	return vga.misc_output;
 }
 
 // VGA feature control register
-static Bitu read_p3ca(Bitu port,Bitu iolen) {
+static Bitu read_p3ca(uint16_t port,Bitu iolen) {
 	return 0;
 }
 
-static Bitu read_p3c8(Bitu port,Bitu iolen) {
+static Bitu read_p3c8(uint16_t port,Bitu iolen) {
 	return 0x10;
 }
 
-static Bitu read_p3c2(Bitu port,Bitu iolen) {
+static Bitu read_p3c2(uint16_t port,Bitu iolen) {
 	Bit8u retval=0;
 
 	if (machine==MCH_EGA) retval = 0x0F;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -27,15 +27,15 @@
 #include "render.h"
 #include "mapper.h"
 
-static void write_crtc_index_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+static void write_crtc_index_other(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	vga.other.index=(Bit8u)val;
 }
 
-static Bitu read_crtc_index_other(Bitu /*port*/,Bitu /*iolen*/) {
+static Bitu read_crtc_index_other(uint16_t port,Bitu /*iolen*/) {
 	return vga.other.index;
 }
 
-static void write_crtc_data_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+static void write_crtc_data_other(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
 		if (vga.other.htotal ^ val) VGA_StartResize();
@@ -110,7 +110,7 @@ static void write_crtc_data_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
 		LOG(LOG_VGAMISC,LOG_NORMAL)("MC6845:Write %X to illegal index %x",val,vga.other.index);
 	}
 }
-static Bitu read_crtc_data_other(Bitu /*port*/,Bitu /*iolen*/) {
+static Bitu read_crtc_data_other(uint16_t port,Bitu /*iolen*/) {
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
 		return vga.other.htotal;
@@ -154,7 +154,7 @@ static Bitu read_crtc_data_other(Bitu /*port*/,Bitu /*iolen*/) {
 	return (Bitu)(~0);
 }
 
-static void write_lightpen(Bitu port,Bitu val,Bitu) {
+static void write_lightpen(uint16_t port,Bitu val,Bitu) {
 	switch (port) {
 	case 0x3db:	// Clear lightpen latch
 		vga.other.lightpen_triggered = false;
@@ -423,7 +423,7 @@ static void write_cga_color_select(Bitu val) {
 	}
 }
 
-static void write_cga(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_cga(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	switch (port) {
 	case 0x3d8:
 		vga.tandy.mode_control=(Bit8u)val;
@@ -623,7 +623,7 @@ static void write_tandy_reg(Bit8u val) {
 	}
 }
 
-static void write_tandy(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_tandy(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	switch (port) {
 	case 0x3d8:
 		val &= 0x3f; // only bits 0-6 are used
@@ -670,7 +670,7 @@ static void write_tandy(Bitu port,Bitu val,Bitu /*iolen*/) {
 	}
 }
 
-static void write_pcjr(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_pcjr(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	switch (port) {
 	case 0x3da:
 		if (vga.tandy.pcjr_flipflop) write_tandy_reg((Bit8u)val);
@@ -774,7 +774,7 @@ void Herc_Palette(void) {
 	}
 }
 
-static void write_hercules(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_hercules(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	switch (port) {
 	case 0x3b8: {
 		// the protected bits can always be cleared but only be set if the 
@@ -819,12 +819,12 @@ static void write_hercules(Bitu port,Bitu val,Bitu /*iolen*/) {
 	}
 }
 
-/* static Bitu read_hercules(Bitu port,Bitu iolen) {
+/* static Bitu read_hercules(uint16_t port,Bitu iolen) {
 	LOG_MSG("read from Herc port %x",port);
 	return 0;
 } */
 
-Bitu read_herc_status(Bitu /*port*/,Bitu /*iolen*/) {
+Bitu read_herc_status(uint16_t port,Bitu /*iolen*/) {
 	// 3BAh (R):  Status Register
 	// bit   0  Horizontal sync
 	//       1  Light pen status (only some cards)
@@ -925,7 +925,7 @@ void VGA_SetupOther(void) {
 		IO_RegisterReadHandler(0x3ba,read_herc_status,IO_MB);
 	} else if (!IS_EGAVGA_ARCH) {
 		Bitu base=0x3d0;
-		for (Bitu port_ct=0; port_ct<4; port_ct++) {
+		for (uint16_t port_ct=0; port_ct<4; port_ct++) {
 			IO_RegisterWriteHandler(base+port_ct*2,write_crtc_index_other,IO_MB);
 			IO_RegisterWriteHandler(base+port_ct*2+1,write_crtc_data_other,IO_MB);
 			IO_RegisterReadHandler(base+port_ct*2,read_crtc_index_other,IO_MB);

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -23,15 +23,15 @@
 
 #define seq(blah) vga.seq.blah
 
-Bitu read_p3c4(Bitu /*port*/,Bitu /*iolen*/) {
+Bitu read_p3c4(uint16_t port,Bitu /*iolen*/) {
 	return seq(index);
 }
 
-void write_p3c4(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+void write_p3c4(uint16_t port,Bitu val,Bitu /*iolen*/) {
 	seq(index)=val;
 }
 
-void write_p3c5(Bitu /*port*/,Bitu val,Bitu iolen) {
+void write_p3c5(uint16_t port,Bitu val,Bitu iolen) {
 //	LOG_MSG("SEQ WRITE reg %X val %X",seq(index),val);
 	switch(seq(index)) {
 	case 0:		/* Reset */
@@ -120,7 +120,7 @@ void write_p3c5(Bitu /*port*/,Bitu val,Bitu iolen) {
 }
 
 
-Bitu read_p3c5(Bitu /*port*/,Bitu iolen) {
+Bitu read_p3c5(uint16_t port,Bitu iolen) {
 //	LOG_MSG("VGA:SEQ:Read from index %2X",seq(index));
 	switch(seq(index)) {
 	case 0:			/* Reset */

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -233,13 +233,13 @@ Bitu read_p3c5_et4k(Bitu reg,Bitu iolen) {
 bit 0-3  64k Write bank number (0..15)
     4-7  64k Read bank number (0..15)
 */
-void write_p3cd_et4k(Bitu port,Bitu val,Bitu iolen) {
+void write_p3cd_et4k(uint16_t port,Bitu val,Bitu iolen) {
    vga.svga.bank_write = val & 0x0f;
    vga.svga.bank_read = (val>>4) & 0x0f;
    VGA_SetupHandlers();
 }
 
-Bitu read_p3cd_et4k(Bitu port,Bitu iolen) {
+Bitu read_p3cd_et4k(uint16_t port,Bitu iolen) {
    return (vga.svga.bank_read<<4)|vga.svga.bank_write;
 }
 
@@ -629,14 +629,14 @@ bit 0-2  64k Write bank number
            2  1M linear memory
 NOTES: 1M linear memory is not supported
 */
-void write_p3cd_et3k(Bitu port,Bitu val,Bitu iolen) {
+void write_p3cd_et3k(uint16_t port,Bitu val,Bitu iolen) {
 	vga.svga.bank_write = val & 0x07;
 	vga.svga.bank_read = (val>>3) & 0x07;
 	vga.svga.bank_size = (val&0x40)?64*1024:128*1024;
 	VGA_SetupHandlers();
 }
 
-Bitu read_p3cd_et3k(Bitu port,Bitu iolen) {
+Bitu read_p3cd_et3k(uint16_t port,Bitu iolen) {
 	return (vga.svga.bank_read<<3)|vga.svga.bank_write|((vga.svga.bank_size==128*1024)?0:0x40);
 }
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1010,15 +1010,15 @@ Bitu XGA_GetDualReg(Bit32u reg) {
 	return 0;
 }
 
-extern Bitu vga_read_p3da(Bitu port,Bitu iolen);
+extern Bitu vga_read_p3da(uint16_t port,Bitu iolen);
 
-extern void vga_write_p3d4(Bitu port,Bitu val,Bitu iolen);
-extern Bitu vga_read_p3d4(Bitu port,Bitu iolen);
+extern void vga_write_p3d4(uint16_t port,Bitu val,Bitu iolen);
+extern Bitu vga_read_p3d4(uint16_t port,Bitu iolen);
 
-extern void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen);
-extern Bitu vga_read_p3d5(Bitu port,Bitu iolen);
+extern void vga_write_p3d5(uint16_t port,Bitu val,Bitu iolen);
+extern Bitu vga_read_p3d5(uint16_t port,Bitu iolen);
 
-void XGA_Write(Bitu port, Bitu val, Bitu len) {
+void XGA_Write(uint16_t port, Bitu val, Bitu len) {
 //	LOG_MSG("XGA: Write to port %x, val %8x, len %x", port,val, len);
 
 	switch(port) {
@@ -1168,14 +1168,14 @@ void XGA_Write(Bitu port, Bitu val, Bitu len) {
 				XGA_DrawWait(val, len);
 
 		        } else
-			        LOG_MSG("XGA: Wrote to port %#" PRIxPTR
+			        LOG_MSG("XGA: Wrote to port %#" PRIx16
 			                " with %#" PRIxPTR ", len %#" PRIxPTR,
 			                port, val, len);
 		        break;
 	        }
 }
 
-Bitu XGA_Read(Bitu port, Bitu len) {
+Bitu XGA_Read(uint16_t port, Bitu len) {
 	switch(port) {
 		case 0x8118:
 		case 0x9ae8:


### PR DESCRIPTION
This PR reduces the IO hander type's **port** size from `Bitu` to 16-bits.  

IO handers are function pointers that are stored in six arrays (three IO-writer arrays of 64k elements, and three IO-reader arrays of 64k elements), queried every 1ms of emulation time for input and/or output. The port value is an offset into these handler arrays.

In real-world use cases, typically there are on the order of ~100s IO handers registered at any time (Tandy writer, Sound blaster writer, CD-DA callback writer, serial ports reading and writing, and so on). The port value does not exceed a couple thousand (and logically, if it ever did exceed 16-bits it would overflow the handler arrays).

Besides reducing the carrying weight by 6-bytes across 6 * 64k elements, this allows compilers to more readily bundle the port into SIMD operations.  For example, NEON instructions allow packing 4 x 16-bit values together; where as the port's prior 64-bit weight excluded it from NEON all together.

No formatting has been applied. 

This change can be programmatically applied to the code using:

- Definition change:

  ``` shell
  git grep -l 'Bitu [/\*]*port[\*/]*' | xargs sed -i 's|Bitu [/\*]*port[/\*]*|uint16_t port|g'
  sed -i 's/uint16 port=decode_fetchb/Bit8u port=decode_fetchb/g' src/cpu/core_dyn_x86/decoder.h  # revert four changes accidentally having similar pattern but not related
  ```

- Argument-size change in DMA, AdLib, Sound Blaster, and Serial Port classes:

  ``` shell
  cd src/hardware
  sed -i 's/Bitu i;/uint16_t i;/g' dma.cpp
  sed -i 's/Bitu base/uint16_t base/g' adlib.cpp sblaster.cpp 
  sed -i 's/for (uint32_t i = 0; i <= 7;/for (uint16_t i = 0; i <= 7;/' serialport/serialport.cpp 
  ```

- Printf-format change (also inside `src/hardware`):

  ``` shell
  sed -i 's/port %#" PRIxPTR/port %#" PRIx16/g; s/xPTR, port/x16, port/g' iohandler.cpp tandy_sound.cpp vga_xga.cpp
  ```