### PR TITLE
Avoid double-free if MP3 fails to open

### DIFF
--- a/src/libs/decoders/mp3_seek_table.h
+++ b/src/libs/decoders/mp3_seek_table.h
@@ -55,8 +55,8 @@ struct drmp3_seek_point_serial {
 //   - a pointer to the working dr_mp3 instance
 //   - a template vector of seek_points (the serializeable form)
 struct mp3_t {
-    drmp3* p_dr;    // the actual drmp3 instance we open, read, and seek within
-    std::vector<drmp3_seek_point_serial> seek_points_vector;
+    drmp3* p_dr = nullptr;    // the actual drmp3 instance we open, read, and seek within
+    std::vector<drmp3_seek_point_serial> seek_points_vector = {};
 };
 
 uint64_t populate_seek_points(struct SDL_RWops* const context,


### PR DESCRIPTION
This PR addresses the `use after free` error flagged by Coverity.

- Restructures the MP3 opening function to be a bit more linear and readable.

- No longer uses SDL's alloc and free calls, instead uses new and delete, as well as taking advantage of C++14's explicit specification regarding deleting `nullptr`, which now says nothing is done.

- (minor) Initializes the `mp3_t` struct members to quiet effc++ warnings.