### PR TITLE
Selectively suppress initial Sound Blaster DMA transfer

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -249,7 +249,8 @@ static const char * CardType()
 	return types[type_id];
 }
 static void DSP_ChangeMode(DSP_MODES mode);
-static void CheckDMAEnd();
+
+static void DMA_Flush_Remaining();
 static void END_DMA_Event(Bitu);
 static void DMA_Silent_Event(Bitu val);
 static void GenerateDMASound(Bitu size);
@@ -261,7 +262,7 @@ static void DSP_SetSpeaker(bool how) {
 	sb.chan->Enable(how);
 	if (sb.speaker) {
 		PIC_RemoveEvents(DMA_Silent_Event);
-		CheckDMAEnd();
+		DMA_Flush_Remaining();
 	} else {
 		
 	}
@@ -327,7 +328,7 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 		if (sb.mode==MODE_DMA_MASKED && sb.dma.mode!=DSP_DMA_NONE) {
 			DSP_ChangeMode(MODE_DMA);
 //			sb.mode=MODE_DMA;
-			CheckDMAEnd();
+			DMA_Flush_Remaining();
 			LOG(LOG_SB,LOG_NORMAL)("DMA unmasked,starting output, auto %d block %d",chan->autoinit,chan->basecnt);
 		}
 	}
@@ -629,7 +630,7 @@ static void END_DMA_Event(Bitu val) {
 	GenerateDMASound(val);
 }
 
-static void CheckDMAEnd(void) {
+static void DMA_Flush_Remaining() {
 	if (!sb.dma.left) return;
 	if (!sb.speaker && sb.type!=SBT_16) {
 		Bitu bigger=(sb.dma.left > sb.dma.min) ? sb.dma.min : sb.dma.left;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -257,17 +257,20 @@ static void DMA_Play_Samples(Bitu size);
 typedef void (*dma_process_f)(Bitu);
 static dma_process_f DMA_Process_Samples;
 
-static void DSP_SetSpeaker(bool how) {
-	if (sb.speaker==how) return;
-	sb.speaker=how;
-	if (sb.type==SBT_16) return;
-	sb.chan->Enable(how);
+static void DSP_SetSpeaker(bool requested_state) {
+	// Speaker-output is already in the requested state
+	if (sb.speaker == requested_state)
+		return;
+
+	// Otherwise change state per the request.
+	sb.speaker = requested_state;
+	sb.chan->Enable(requested_state);
 	if (sb.speaker) {
 		PIC_RemoveEvents(DMA_Suppress_Samples);
 		DMA_Flush_Remaining();
-	} else {
-		
 	}
+	LOG_MSG("%s: Speaker-output has been toggled %s",
+	        CardType(), requested_state ? "on" : "off");
 }
 
 static void InitializeSpeakerState() {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -60,7 +60,17 @@ using namespace std;
 #define SB_SH_MASK	((1 << SB_SH)-1)
 
 enum {DSP_S_RESET,DSP_S_RESET_WAIT,DSP_S_NORMAL,DSP_S_HIGHSPEED};
-enum SB_TYPES {SBT_NONE=0,SBT_1=1,SBT_PRO1=2,SBT_2=3,SBT_PRO2=4,SBT_16=6,SBT_GB=7};
+
+enum SB_TYPES {
+	SBT_NONE = 0,
+	SBT_1    = 1,
+	SBT_PRO1 = 2,
+	SBT_2    = 3,
+	SBT_PRO2 = 4,
+	SBT_16   = 6,
+	SBT_GB   = 7
+};
+
 enum SB_IRQS {SB_IRQ_8,SB_IRQ_16,SB_IRQ_MPU};
 
 enum DSP_MODES {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -251,6 +251,7 @@ static const char * CardType()
 static void DSP_ChangeMode(DSP_MODES mode);
 
 static void DMA_Flush_Remaining();
+static void DMA_Suppress_Init(Bitu size);
 static void DMA_Suppress_Samples(Bitu size);
 static void DMA_Play_Samples(Bitu size);
 typedef void (*dma_process_f)(Bitu);
@@ -585,6 +586,17 @@ static void DMA_Play_Samples(Bitu size) {
 
 		}
 	}
+}
+
+static void DMA_Suppress_Init(Bitu size) {
+ 	// Only suppress the first dword-transfer or less
+ 	if (size <= sizeof(uint32_t) || !sb.speaker) {
+		Suppress_DMA_Transfer(size);
+		LOG_MSG("%s: Suppressed initial %" PRIuPTR "-byte DMA transfer",
+		        CardType(), size);
+	 } else
+		DMA_Play_Samples(size);
+	DMA_Process_Samples = &DMA_Play_Samples;
 }
 
 static void DMA_Suppress_Samples(Bitu size) {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -828,6 +828,9 @@ static void DSP_DoReset(Bit8u val) {
 	if (((val&1)!=0) && (sb.dsp.state!=DSP_S_RESET)) {
 //TODO Get out of highspeed mode
 		LOG_MSG("%s: DSP reset requested", CardType());
+		// Halt the channel so we're silent acoss reset events.
+		// Channel is re-enabled (if SB16) or via control by the game (non-SB16).
+		sb.chan->Enable(false);
 		DSP_Reset();
 		sb.dsp.state=DSP_S_RESET;
 	} else if (((val&1)==0) && (sb.dsp.state==DSP_S_RESET)) {	// reset off

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -253,7 +253,7 @@ static void DSP_ChangeMode(DSP_MODES mode);
 static void DMA_Flush_Remaining();
 static void END_DMA_Event(Bitu);
 static void DMA_Silent_Event(Bitu val);
-static void GenerateDMASound(Bitu size);
+static void DMA_Process_Samples(Bitu size);
 
 static void DSP_SetSpeaker(bool how) {
 	if (sb.speaker==how) return;
@@ -316,9 +316,9 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 			min_size *= 2;
 			if (sb.dma.left > min_size) {
 				if (s > (sb.dma.left - min_size)) s = sb.dma.left - min_size;
-				//This will trigger a irq, see GenerateDMASound, so lets not do that
+				//This will trigger an irq, see DMA_Process_Samples, so lets not do that
 				if (!sb.dma.autoinit && sb.dma.left <= sb.dma.min) s = 0;
-				if (s) GenerateDMASound(s);
+				if (s) DMA_Process_Samples(s);
 			}
 			sb.mode = MODE_DMA_MASKED;
 //			DSP_ChangeMode(MODE_DMA_MASKED);
@@ -437,7 +437,7 @@ INLINE Bit8u decode_ADPCM_3_sample(Bit8u sample,Bit8u & reference,Bits& scale) {
 	return reference;
 }
 
-static void GenerateDMASound(Bitu size) {
+static void DMA_Process_Samples(Bitu size) {
 	Bitu read=0;Bitu done=0;Bitu i=0;
 	last_dma_callback = PIC_FullIndex();
 
@@ -627,7 +627,7 @@ static void DMA_Silent_Event(Bitu val) {
 }
 
 static void END_DMA_Event(Bitu val) {
-	GenerateDMASound(val);
+	DMA_Process_Samples(val);
 }
 
 static void DMA_Flush_Remaining() {
@@ -1602,7 +1602,7 @@ static void SBLASTER_CallBack(Bitu len) {
 		if (len&SB_SH_MASK) len+=1 << SB_SH;
 		len>>=SB_SH;
 		if (len>sb.dma.left) len=sb.dma.left;
-		GenerateDMASound(len);
+		DMA_Process_Samples(len);
 		break;
 	}
 }

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -252,7 +252,9 @@ static void DSP_ChangeMode(DSP_MODES mode);
 
 static void DMA_Flush_Remaining();
 static void DMA_Suppress_Samples(Bitu size);
-static void DMA_Process_Samples(Bitu size);
+static void DMA_Play_Samples(Bitu size);
+typedef void (*dma_process_f)(Bitu);
+static dma_process_f DMA_Process_Samples = &DMA_Play_Samples;
 
 static void DSP_SetSpeaker(bool how) {
 	if (sb.speaker==how) return;
@@ -315,7 +317,7 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 			min_size *= 2;
 			if (sb.dma.left > min_size) {
 				if (s > (sb.dma.left - min_size)) s = sb.dma.left - min_size;
-				//This will trigger an irq, see DMA_Process_Samples, so lets not do that
+				//This will trigger an irq, see DMA_Play_Samples, so lets not do that
 				if (!sb.dma.autoinit && sb.dma.left <= sb.dma.min) s = 0;
 				if (s) DMA_Process_Samples(s);
 			}
@@ -436,7 +438,7 @@ INLINE Bit8u decode_ADPCM_3_sample(Bit8u sample,Bit8u & reference,Bits& scale) {
 	return reference;
 }
 
-static void DMA_Process_Samples(Bitu size) {
+static void DMA_Play_Samples(Bitu size) {
 	Bitu read=0;Bitu done=0;Bitu i=0;
 	last_dma_callback = PIC_FullIndex();
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <array>
 #include <iomanip>
 #include <sstream>
 #include <string.h>
@@ -236,6 +237,17 @@ static int E2_incr_table[4][9] = {
 #define min(a,b) ((a)<(b)?(a):(b))
 #endif
 
+static const char * CardType()
+{
+	constexpr std::array<const char *, 8> types = {"NONE",   "SB1",
+	                                               "SBPRO1", "SB2",
+	                                               "SBPRO2", "UNASSIGNED",
+	                                               "SB16",   "GB"};
+	const size_t type_id = static_cast<size_t>(sb.type);
+	assertm(type_id != 5 && type_id < types.size(),
+	        "sb.type does not match a known Sound Blaster type ID");
+	return types[type_id];
+}
 static void DSP_ChangeMode(DSP_MODES mode);
 static void CheckDMAEnd();
 static void END_DMA_Event(Bitu);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -547,7 +547,7 @@ static void DMA_Process_Samples(Bitu size) {
 		if (sb.dma.mode==DSP_DMA_16_ALIASED) read=read<<1;
 		break;
 	default:
-		LOG_MSG("Unhandled dma mode %d",sb.dma.mode);
+		LOG_MSG("%s: Unhandled dma mode %d", CardType(), sb.dma.mode);
 		sb.mode=MODE_NONE;
 		return;
 	}
@@ -632,8 +632,12 @@ static void DMA_Flush_Remaining() {
 		Bitu bigger=(sb.dma.left > sb.dma.min) ? sb.dma.min : sb.dma.left;
 		float delay=(bigger*1000.0f)/sb.dma.rate;
 		PIC_AddEvent(DMA_Suppress_Samples, delay,bigger);
+		LOG(LOG_SB,LOG_NORMAL)("%s: Silent DMA Transfer scheduling IRQ in %.3f milliseconds",
+		                       CardType(), delay);
 	} else if (sb.dma.left<sb.dma.min) {
 		float delay=(sb.dma.left*1000.0f)/sb.dma.rate;
+		LOG(LOG_SB,LOG_NORMAL)("%s: Short transfer scheduling IRQ in %.3f milliseconds",
+		                       CardType(), delay);	
 		PIC_AddEvent(DMA_Process_Samples,delay,sb.dma.left);
 	}
 }
@@ -813,6 +817,7 @@ static void DSP_Reset(void) {
 static void DSP_DoReset(Bit8u val) {
 	if (((val&1)!=0) && (sb.dsp.state!=DSP_S_RESET)) {
 //TODO Get out of highspeed mode
+		LOG_MSG("%s: DSP reset requested", CardType());
 		DSP_Reset();
 		sb.dsp.state=DSP_S_RESET;
 	} else if (((val&1)==0) && (sb.dsp.state==DSP_S_RESET)) {	// reset off

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -587,24 +587,6 @@ static void DMA_Play_Samples(Bitu size) {
 	}
 }
 
-/* old version...
-static void GenerateDACSound(Bitu len) {
-	if (!sb.dac.used) {
-		sb.mode=MODE_NONE;
-		return;
-	}
-	Bitu dac_add=(sb.dac.used<<16)/len;
-	Bitu dac_pos=0;
-	Bit16s * out=(Bit16s *)MixTemp;
-	for (Bitu i=len;i;i--) {
-		*out++=sb.dac.data[0+(dac_pos>>16)];
-		dac_pos+=dac_add;
-	}
-	sb.dac.used=0;
-	sb.chan->AddSamples_m16(len,(Bit16s *)MixTemp);
-}
-*/
-
 static void DMA_Suppress_Samples(Bitu size) {
 	if (sb.dma.left < size)
 		size = sb.dma.left;
@@ -989,7 +971,6 @@ static void DSP_DoCommand(void) {
 	case 0xc8:	case 0xc9:	case 0xca:	case 0xcb:  case 0xcc:	case 0xcd:	case 0xce:	case 0xcf:
 		DSP_SB16_ONLY;
 		/* Generic 8/16 bit DMA */
-//		DSP_SetSpeaker(true);		//SB16 always has speaker enabled
 		sb.dma.sign=(sb.dsp.in.data[0] & 0x10) > 0;
 		DSP_PrepareDMA_New((sb.dsp.cmd & 0x10) ? DSP_DMA_16 : DSP_DMA_8,
 			1+sb.dsp.in.data[1]+(sb.dsp.in.data[2] << 8),

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -250,37 +250,38 @@ static const char * CardType()
 }
 static void DSP_ChangeMode(DSP_MODES mode);
 
-static void DMA_Flush_Remaining();
-static void DMA_Suppress_Init(Bitu size);
-static void DMA_Suppress_Samples(Bitu size);
-static void DMA_Play_Samples(Bitu size);
-typedef void (*dma_process_f)(Bitu);
-static dma_process_f DMA_Process_Samples;
+static void Flush_Remaining_DMA_Transfer();
+static void Suppress_Initial_DMA_Transfer(Bitu size);
+static void Suppress_DMA_Transfer(Bitu size);
+static void Play_DMA_Transfer(Bitu size);
+typedef void (*process_dma_f)(Bitu);
+static process_dma_f Process_DMA_Transfer;
 
 static void DSP_SetSpeaker(bool requested_state) {
 	// Speaker-output is already in the requested state
 	if (sb.speaker == requested_state)
 		return;
 
-	// Otherwise change state per the request.
-	sb.speaker = requested_state;
-	sb.chan->Enable(requested_state);
-	if (sb.speaker) {
-		PIC_RemoveEvents(DMA_Suppress_Samples);
-		DMA_Flush_Remaining();
+	// If the speaker's being turned on, then flush old
+	// content before releasing the channel for playback.
+	if (requested_state) {
+		PIC_RemoveEvents(Suppress_DMA_Transfer);
+		Flush_Remaining_DMA_Transfer();
 	}
+	sb.chan->Enable(requested_state);
+	sb.speaker = requested_state;
 	LOG_MSG("%s: Speaker-output has been toggled %s",
 	        CardType(), requested_state ? "on" : "off");
 }
 
 static void InitializeSpeakerState() {
-		// Real SBPro2 hardware starts with the card's speaker-output disabled 
-		sb.speaker = false;
-		// For SB16, the output channel starts active however subsequent
-		// requests to disable the speaker will be honored (see: SetSpeaker).
-		sb.chan->Enable(sb.type == SBT_16);
-		// Suppress the first small DMA transfer to avoid hearing it.
-		DMA_Process_Samples = &DMA_Suppress_Init;
+	// Real SBPro2 hardware starts with the card's speaker-output disabled 
+	sb.speaker = false;
+	// For SB16, the output channel starts active however subsequent
+	// requests to disable the speaker will be honored (see: SetSpeaker).
+	sb.chan->Enable(sb.type == SBT_16);
+	// Suppress the first small DMA transfer to avoid hearing it.
+	Process_DMA_Transfer = &Suppress_Initial_DMA_Transfer;
 }
 
 static INLINE void SB_RaiseIRQ(SB_IRQS type) {
@@ -331,9 +332,9 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 			min_size *= 2;
 			if (sb.dma.left > min_size) {
 				if (s > (sb.dma.left - min_size)) s = sb.dma.left - min_size;
-				//This will trigger an irq, see DMA_Play_Samples, so lets not do that
+				//This will trigger an irq, see Play_DMA_Transfer, so lets not do that
 				if (!sb.dma.autoinit && sb.dma.left <= sb.dma.min) s = 0;
-				if (s) DMA_Process_Samples(s);
+				if (s) Process_DMA_Transfer(s);
 			}
 			sb.mode = MODE_DMA_MASKED;
 //			DSP_ChangeMode(MODE_DMA_MASKED);
@@ -343,7 +344,7 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 		if (sb.mode==MODE_DMA_MASKED && sb.dma.mode!=DSP_DMA_NONE) {
 			DSP_ChangeMode(MODE_DMA);
 //			sb.mode=MODE_DMA;
-			DMA_Flush_Remaining();
+			Flush_Remaining_DMA_Transfer();
 			LOG(LOG_SB,LOG_NORMAL)("DMA unmasked,starting output, auto %d block %d",chan->autoinit,chan->basecnt);
 		}
 	}
@@ -452,7 +453,7 @@ INLINE Bit8u decode_ADPCM_3_sample(Bit8u sample,Bit8u & reference,Bits& scale) {
 	return reference;
 }
 
-static void DMA_Play_Samples(Bitu size) {
+static void Play_DMA_Transfer(Bitu size) {
 	Bitu read=0;Bitu done=0;Bitu i=0;
 	last_dma_callback = PIC_FullIndex();
 
@@ -570,7 +571,7 @@ static void DMA_Play_Samples(Bitu size) {
 	//Check how many bytes were actually read
 	sb.dma.left-=read;
 	if (!sb.dma.left) {
-		PIC_RemoveEvents(DMA_Process_Samples);
+		PIC_RemoveEvents(Process_DMA_Transfer);
 		if (sb.dma.mode >= DSP_DMA_16) 
 			SB_RaiseIRQ(SB_IRQ_16);
 		else 
@@ -601,18 +602,18 @@ static void DMA_Play_Samples(Bitu size) {
 	}
 }
 
-static void DMA_Suppress_Init(Bitu size) {
+static void Suppress_Initial_DMA_Transfer(Bitu size) {
  	// Only suppress the first dword-transfer or less
  	if (size <= sizeof(uint32_t) || !sb.speaker) {
 		Suppress_DMA_Transfer(size);
 		LOG_MSG("%s: Suppressed initial %" PRIuPTR "-byte DMA transfer",
 		        CardType(), size);
 	 } else
-		DMA_Play_Samples(size);
-	DMA_Process_Samples = &DMA_Play_Samples;
+		Play_DMA_Transfer(size);
+	Process_DMA_Transfer = &Play_DMA_Transfer;
 }
 
-static void DMA_Suppress_Samples(Bitu size) {
+static void Suppress_DMA_Transfer(Bitu size) {
 	if (sb.dma.left < size)
 		size = sb.dma.left;
 	const Bitu read = sb.dma.chan->Read(size, sb.dma.buf.b8);
@@ -631,23 +632,23 @@ static void DMA_Suppress_Samples(Bitu size) {
 	if (sb.dma.left) {
 		Bitu bigger=(sb.dma.left > sb.dma.min) ? sb.dma.min : sb.dma.left;
 		float delay=(bigger*1000.0f)/sb.dma.rate;
-		PIC_AddEvent(DMA_Suppress_Samples, delay,bigger);
+		PIC_AddEvent(Suppress_DMA_Transfer, delay,bigger);
 	}
 }
 
-static void DMA_Flush_Remaining() {
+static void Flush_Remaining_DMA_Transfer() {
 	if (!sb.dma.left) return;
 	if (!sb.speaker && sb.type!=SBT_16) {
 		Bitu bigger=(sb.dma.left > sb.dma.min) ? sb.dma.min : sb.dma.left;
 		float delay=(bigger*1000.0f)/sb.dma.rate;
-		PIC_AddEvent(DMA_Suppress_Samples, delay,bigger);
+		PIC_AddEvent(Suppress_DMA_Transfer, delay,bigger);
 		LOG(LOG_SB,LOG_NORMAL)("%s: Silent DMA Transfer scheduling IRQ in %.3f milliseconds",
 		                       CardType(), delay);
 	} else if (sb.dma.left<sb.dma.min) {
 		float delay=(sb.dma.left*1000.0f)/sb.dma.rate;
 		LOG(LOG_SB,LOG_NORMAL)("%s: Short transfer scheduling IRQ in %.3f milliseconds",
 		                       CardType(), delay);	
-		PIC_AddEvent(DMA_Process_Samples,delay,sb.dma.left);
+		PIC_AddEvent(Process_DMA_Transfer,delay,sb.dma.left);
 	}
 }
 
@@ -706,7 +707,7 @@ static void DSP_DoDMATransfer(const DMA_MODES mode, Bitu freq, bool autoinit, bo
 	sb.dma.min=(sb.dma.rate*3)/1000;
 	sb.chan->SetFreq(freq);
 
-	PIC_RemoveEvents(DMA_Process_Samples);
+	PIC_RemoveEvents(Process_DMA_Transfer);
 	//Set to be masked, the dma call can change this again.
 	sb.mode = MODE_DMA_MASKED;
 	sb.dma.chan->Register_Callback(DSP_DMA_CallBack);
@@ -821,7 +822,7 @@ static void DSP_Reset(void) {
 	sb.irq.pending_16bit=false;
 	sb.chan->SetFreq(22050);
 	InitializeSpeakerState();
-	PIC_RemoveEvents(DMA_Process_Samples);
+	PIC_RemoveEvents(Process_DMA_Transfer);
 }
 
 static void DSP_DoReset(Bit8u val) {
@@ -1017,7 +1018,7 @@ static void DSP_DoCommand(void) {
 			// possibly different code here that does not switch to MODE_DMA_PAUSE
 		}
 		sb.mode=MODE_DMA_PAUSE;
-		PIC_RemoveEvents(DMA_Process_Samples);
+		PIC_RemoveEvents(Process_DMA_Transfer);
 		break;
 	case 0xd1:	/* Enable Speaker */
 		DSP_SetSpeaker(true);
@@ -1612,7 +1613,7 @@ static void SBLASTER_CallBack(Bitu len) {
 		if (len&SB_SH_MASK) len+=1 << SB_SH;
 		len>>=SB_SH;
 		if (len>sb.dma.left) len=sb.dma.left;
-		DMA_Process_Samples(len);
+		Process_DMA_Transfer(len);
 		break;
 	}
 }


### PR DESCRIPTION
Many games use a small DMA transfer as part of their Sound Blaster detection and initialization routine.  Because the content in this initial DMA transfer is often garbage and/or discontinuous, this leads to a "pop" while the game is starting up (credit: ripsaw8080, thank you!).

This PR suppresses this initial DMA transfer after a `DSP_Reset` cycle if:
- the transfer is a DWORD or less, or
- the SB's onboard speaker-output is disabled

This PR is a quality of life improvement because these initial pops can be jarring and lead to hearing damage at high volumes, especially for those using high-SnR earbud headphone. It's also a bug-fix because this "audio" is not game content, and instead is the result of poor documentation and hardware design by Creative Labs. See the before-and-after comparison images in the follow-up comment for just a small sampling of games affected by this.

**Notes**: the suppressed transfer is processed but without being played, so all aspects of the card state appear normal. If the suppression criteria isn't met then the behavior matches that prior to the PR. At no point is the audio content itself or channel volume altered.

After testing hundreds of titles, this corrects a significant number of games without adversely affecting those where the criteria is not met. I should warn that even with this, not all games games are fixed: some apply a constant DC-offset as part of their audio track (which pops on playback), others can pop even without using the Sound Blaster, and others pop without using DMA transfers.

**PR review:** Suggest reviewing commit-by-commit; I tried hard to layer these in a nice sequence that builds up to the functional change.