### PR TITLE
Add missing commit-checks in platform CI workflow

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -35,6 +35,7 @@ jobs:
         run:  'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
 
       - name: Inject version string
+        if: steps.repo-meta.outputs.has-commits == 'true'
         run: |
           set -x
           git fetch --prune --unshallow
@@ -60,6 +61,7 @@ jobs:
         run:  ./scripts/count-warnings.py --max-warnings -1 build.log
 
       - name: Package
+        if: steps.repo-meta.outputs.has-commits == 'true'
         run: |
           set -x
 
@@ -87,6 +89,7 @@ jobs:
           echo ::set-env name=PACKAGE::$PACKAGE
 
       - name: Clam AV scan
+        if: steps.repo-meta.outputs.has-commits == 'true'
         run: |
           set -x
           sudo apt-get install clamav > /dev/null
@@ -95,6 +98,7 @@ jobs:
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
 
       - name: Upload tarball
+        if: steps.repo-meta.outputs.has-commits == 'true'
         uses: actions/upload-artifact@master
         # GitHub automatically zips the artifacts (there's no way to create
         # a tarball), and it removes all executable flags while zipping.
@@ -102,4 +106,3 @@ jobs:
         with:
           name: ${{ env.PACKAGE }}
           path: ${{ env.PACKAGE }}.tar.xz
-


### PR DESCRIPTION
A couple steps in the platform CI build YAML were missing commit-checks, which this PR adds.
Now the platform CI run should pass (ie: skip) on days where we don't have commits to `master`.