### PR TITLE
Implement instant launch!

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Other differences:
 | **[Wayland] support**    | Experimental (use `SDL_VIDEODRIVER=wayland`) | N/A
 | **Modem phonebook file** | Yes (`phonebookfile=<name>`)                 | N/A
 | **Autotype command**     | Yes<sup>[10]</sup>                           | N/A
+| **Instant Launch**       | Yes<sup>[11]</sup>                           | N/A
 
 [OPL]:https://en.wikipedia.org/wiki/Yamaha_YMF262
 [CGA]:https://en.wikipedia.org/wiki/Color_Graphics_Adapter
@@ -77,6 +78,7 @@ Other differences:
 [8]:https://www.vogons.org/viewtopic.php?f=9&t=37782
 [9]:https://github.com/dosbox-staging/dosbox-staging/commit/ffe3c5ab7fb5e28bae78f07ea987904f391a7cf8
 [10]:https://github.com/dosbox-staging/dosbox-staging/commit/239396fec83dbba6a1eb1a0f4461f4a427d2be38
+[11]:https://github.com/dosbox-staging/dosbox-staging/pull/415
 
 ## Development snapshot builds
 

--- a/include/control.h
+++ b/include/control.h
@@ -78,6 +78,7 @@ public:
 	void ParseEnv(char ** envp);
 	bool SecureMode() const { return secure_mode; }
 	void SwitchToSecureMode() { secure_mode = true; }//can't be undone
+	bool WantsBanners() const;
 };
 
 #endif

--- a/include/programs.h
+++ b/include/programs.h
@@ -54,6 +54,7 @@ public:
 	bool GetStringRemain(std::string & value);
 	int GetParameterFromList(const char* const params[], std::vector<std::string> & output);
 	void FillVector(std::vector<std::string> & vector);
+	bool HasExecutable() const;
 	unsigned int GetCount(void);
 	void Shift(unsigned int amount=1);
 	Bit16u Get_arglength();

--- a/include/support.h
+++ b/include/support.h
@@ -157,4 +157,5 @@ void strip_punctuation(std::string &str);
 bool starts_with(const std::string &prefix, const std::string &str) noexcept;
 bool ends_with(const std::string &suffix, const std::string &str) noexcept;
 
+bool is_executable(std::string filename) noexcept;
 #endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -413,15 +413,16 @@ void DOSBOX_Init(void) {
 		"vgaonly", "svga_s3", "svga_et3000", "svga_et4000",
 		"svga_paradise", "vesa_nolfb", "vesa_oldvbe", 0 };
 	secprop=control->AddSection_prop("dosbox",&DOSBOX_RealInit);
+
+	Pstring = secprop->Add_path("captures",Property::Changeable::Always,"capture");
+	Pstring->Set_help("Directory where things like wave, midi, screenshot get captured.");
+
 	Pstring = secprop->Add_path("language",Property::Changeable::Always,"");
 	Pstring->Set_help("Select another language file.");
 
 	Pstring = secprop->Add_string("machine",Property::Changeable::OnlyAtStart,"svga_s3");
 	Pstring->Set_values(machines);
 	Pstring->Set_help("The type of machine DOSBox tries to emulate.");
-
-	Pstring = secprop->Add_path("captures",Property::Changeable::Always,"capture");
-	Pstring->Set_help("Directory where things like wave, midi, screenshot get captured.");
 
 #if C_DEBUG
 	LOG_StartUp();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -445,6 +445,11 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&TIMER_Init);//done
 	secprop->AddInitFunction(&CMOS_Init);//done
 
+	const char* banner_choices[] = { "yes", "no", "auto", 0};
+	Pstring = secprop->Add_string("show_banners", Property::Changeable::OnlyAtStart, "yes");
+	Pstring->Set_values(banner_choices);
+	Pstring->Set_help("Show splash and console banners on startup.");
+
 	secprop=control->AddSection_prop("render",&RENDER_Init,true);
 	Pint = secprop->Add_int("frameskip",Property::Changeable::Always,0);
 	Pint->SetMinMax(0,10);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2229,7 +2229,7 @@ static void GUI_StartUp(Section * sec) {
 
 	const bool tiny_fullresolution = splash_image.width > sdl.desktop.full.width ||
 	                                 splash_image.height > sdl.desktop.full.height;
-	if (!(sdl.desktop.fullscreen && tiny_fullresolution)) {
+	if (control->WantsBanners() && !(sdl.desktop.fullscreen && tiny_fullresolution)) {
 		GFX_Start();
 		DisplaySplash(1000);
 		GFX_Stop();

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1024,6 +1024,14 @@ bool CommandLine::FindCommand(unsigned int which,std::string & value) {
 	return true;
 }
 
+bool CommandLine::HasExecutable() const
+{
+	for (const auto& arg : cmds)
+		if (is_executable(arg))
+			return true;
+	return false;
+}
+
 bool CommandLine::FindEntry(char const * const name,cmd_it & it,bool neednext) {
 	for (it = cmds.begin(); it != cmds.end(); ++it) {
 		if (!strcasecmp((*it).c_str(),name)) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -981,6 +981,22 @@ void Config::StartUp()
 	(*_start_function)();
 }
 
+bool Config::WantsBanners() const
+{
+	const Section* s = GetSection("dosbox");
+	assert(s);
+	const std::string user_choice = s->GetPropValue("show_banners");
+
+	bool wants_banners;
+	if (user_choice == "yes")
+		wants_banners = true;
+	else if (user_choice == "no")
+		wants_banners = false;
+	else // auto-mode
+		wants_banners = !cmdline->HasExecutable();
+	return wants_banners;
+}
+
 bool CommandLine::FindExist(char const * const name,bool remove) {
 	cmd_it it;
 	if (!(FindEntry(name,it,false))) return false;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -80,6 +80,14 @@ bool ends_with(const std::string &suffix, const std::string &str) noexcept
 	return std::equal(sfx, sfx + n, txt, txt + n);
 }
 
+bool is_executable(std::string filename) noexcept
+{	
+	lowcase(filename);
+	return ends_with(".exe", filename) ||
+	       ends_with(".bat", filename) ||
+	       ends_with(".com", filename);
+}
+
 void trim(std::string &str)
 {
 	constexpr char whitespace[] = " \r\t\f\n";

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -340,17 +340,18 @@ void DOS_Shell::Run(void) {
 	}
 	/* Start a normal shell and check for a first command init */
 	if (cmd->FindString("/INIT",line,true)) {
-		WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"),VERSION);
+		if (control->WantsBanners()) {
+			WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"),VERSION);
 #if C_DEBUG
-		WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"));
+			WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"));
 #endif
-		if (machine == MCH_CGA) {
-			if (mono_cga) WriteOut(MSG_Get("SHELL_STARTUP_CGA_MONO"));
-			else WriteOut(MSG_Get("SHELL_STARTUP_CGA"));
+			if (machine == MCH_CGA) {
+				if (mono_cga) WriteOut(MSG_Get("SHELL_STARTUP_CGA_MONO"));
+				else WriteOut(MSG_Get("SHELL_STARTUP_CGA"));
+			}
+			if (machine == MCH_HERC) WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
+			WriteOut(MSG_Get("SHELL_STARTUP_END"));
 		}
-		if (machine == MCH_HERC) WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
-		WriteOut(MSG_Get("SHELL_STARTUP_END"));
-
 		safe_strcpy(input_line, line.c_str());
 		line.erase();
 		ParseLine(input_line);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -784,10 +784,7 @@ void DOS_Shell::CMD_LS(char *args)
 			WriteOut("\033[34;1m%-15s\033[0m", name.c_str());
 		} else {
 			lowcase(name);
-			const bool is_executable = ends_with(".exe", name) ||
-			                           ends_with(".bat", name) ||
-			                           ends_with(".com", name);
-			if (is_executable)
+			if (is_executable(name))
 				WriteOut("\033[32;1m%-15s\033[0m", name.c_str());
 			else
 				WriteOut("%-15s", name.c_str());

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -293,13 +293,11 @@ void DOS_Shell::InputCommand(char * line) {
 						dta.GetResult(name,sz,date,time,att);
 						// add result to completion list
 
-						char *ext;	// file extension
 						if (strcmp(name, ".") && strcmp(name, "..")) {
 							if (dir_only) { //Handle the dir only case different (line starts with cd)
 								if(att & DOS_ATTR_DIRECTORY) l_completion.push_back(name);
 							} else {
-								ext = strrchr(name, '.');
-								if (ext && (strcmp(ext, ".BAT") == 0 || strcmp(ext, ".COM") == 0 || strcmp(ext, ".EXE") == 0))
+								if (is_executable(std::string(name)))
 									// we add executables to the a seperate list and place that list infront of the normal files
 									executable.push_front(name);
 								else


### PR DESCRIPTION
This adds a new `show_banners` configurable item to the `[dosbox]` configuration section, with values as follows:
- `on`: always shows the banners
- `off`: never shows the banners
- `auto`: skips the banners if an executable provided to dosbox, otherwise shows the banners.

Fixes #139.

Suggested review order is commit-by-commit.

PS- it's pretty amazing how quick games come to life, especially if you try an older  real-mode game. Also fewer SDL mode changes flipping around.