### PR TITLE
Inform the user when skipping junk characters

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -565,7 +565,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
 	MSG_Add("SHELL_CMD_ECHO_OFF","ECHO is off.\n");
 	MSG_Add("SHELL_ILLEGAL_CONTROL_CHARACTER",
-	        "Unexpected control character: Dec %03u and Hex 0x%02X.\n");
+	        "Unexpected control character: Dec %03u and Hex %#04x.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH","Illegal switch: %s.\n");
 	MSG_Add("SHELL_MISSING_PARAMETER","Required parameter missing.\n");
 	MSG_Add("SHELL_CMD_CHDIR_ERROR","Unable to change to: %s.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -564,6 +564,8 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type \033[33;1mhelp /all\033[0m .\nA short list of the most often used commands:\n");
 	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
 	MSG_Add("SHELL_CMD_ECHO_OFF","ECHO is off.\n");
+	MSG_Add("SHELL_ILLEGAL_CONTROL_CHARACTER",
+	        "Unexpected control character: Dec %03u and Hex 0x%02X.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH","Illegal switch: %s.\n");
 	MSG_Add("SHELL_MISSING_PARAMETER","Required parameter missing.\n");
 	MSG_Add("SHELL_CMD_CHDIR_ERROR","Unable to change to: %s.\n");

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -78,8 +78,10 @@ emptyline:
 				//So we continue reading till EOL/EOF
 				if (((cmd_write - temp) + 1) < (CMD_MAXLINE - 1))
 					*cmd_write++ = c;
-			} else if (c != 10 && c != 13)
-				shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
+			} else {
+				if (c != '\n' && c != '\r')
+					shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
+			}
 		}
 	} while (c!='\n' && n);
 	*cmd_write=0;
@@ -182,8 +184,10 @@ again:
 			if (c>31) {
 				if (((cmd_write - cmd_buffer) + 1) < (CMD_MAXLINE - 1))
 					*cmd_write++ = c;
-			} else if (c != 10 && c != 13)
-				shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
+			} else {
+				if (c != '\n' && c != '\r')
+					shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
+			}
 		}
 	} while (c!='\n' && n);
 	*cmd_write++ = 0;

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -78,7 +78,8 @@ emptyline:
 				//So we continue reading till EOL/EOF
 				if (((cmd_write - temp) + 1) < (CMD_MAXLINE - 1))
 					*cmd_write++ = c;
-			}
+			} else if (c != 10 && c != 13)
+				shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
 		}
 	} while (c!='\n' && n);
 	*cmd_write=0;
@@ -181,7 +182,8 @@ again:
 			if (c>31) {
 				if (((cmd_write - cmd_buffer) + 1) < (CMD_MAXLINE - 1))
 					*cmd_write++ = c;
-			}
+			} else if (c != 10 && c != 13)
+				shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
 		}
 	} while (c!='\n' && n);
 	*cmd_write++ = 0;


### PR DESCRIPTION
When the current batch file parser encounters an illegal control character, it silently skips it and does not append it to command string that it's building up.

For users, these control characters and not only invisible in many text editors, but dosbox also furthers their invisibly by skipping them (which also consequently may alter the expected behavior the batch file). 

This PR simply informs the user when it hits these junk characters  without changing the actual behavior of the parsing. 

Here's an example of ten junk characters injected into a longer 30+ character command:

![Screenshot at 2020-06-07 19-09-00](https://user-images.githubusercontent.com/1557255/83986761-ce01d500-a8f2-11ea-8dc1-28e0188334a4.png)
 
The 10 junk control characters actually aren't printed or visible in the command; but at least we're now informed they exist. 

Fixes #231 (yes, maybe we can be more aggressive and actually change the parsing behavior.. but for now, I think this messaging would have been helpful to the user and prevented 231 from occurring).