### PR TITLE
Statically link the macos release with libPNG and SDL2_Net

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -26,8 +26,7 @@ jobs:
           - configure_flags:  --enable-alsa-midi
           - configure_flags:  --enable-png-static
           - configure_flags:  --enable-sdl-static
-          - configure_flags:  --enable-sdl-net-static
-          - configure_flags:  --enable-png-static --enable-sdl-static --enable-sdl-net-static
+          - configure_flags:  --enable-png-static --enable-sdl-static
           - configure_flags:  --disable-core-inline
           - configure_flags:  --disable-dynamic-x86
           - configure_flags:  --disable-dynrec

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -24,6 +24,10 @@ jobs:
           - configure_flags:  --enable-debug
           - configure_flags:  --enable-debug=heavy
           - configure_flags:  --enable-alsa-midi
+          - configure_flags:  --enable-png-static
+          - configure_flags:  --enable-sdl-static
+          - configure_flags:  --enable-sdl-net-static
+          - configure_flags:  --enable-png-static --enable-sdl-static --enable-sdl-net-static
           - configure_flags:  --disable-core-inline
           - configure_flags:  --disable-dynamic-x86
           - configure_flags:  --disable-dynrec

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -99,11 +99,10 @@ jobs:
         run: |
           set -x
           ./autogen.sh
-          # FIXME temporarily disable everything aside SDL2 due to linking issues
           ./configure \
+            --enable-png-static \
             --enable-sdl-static \
-            --disable-screenshots \
-            --disable-network \
+            --enable-sdl-net-static \
             CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"
           gmake -j "$(sysctl -n hw.physicalcpu)"
           strip src/dosbox

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -102,7 +102,6 @@ jobs:
           ./configure \
             --enable-png-static \
             --enable-sdl-static \
-            --enable-sdl-net-static \
             CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"
           gmake -j "$(sysctl -n hw.physicalcpu)"
           strip src/dosbox

--- a/configure.ac
+++ b/configure.ac
@@ -466,12 +466,28 @@ AC_ARG_ENABLE(network,
               AS_HELP_STRING([--disable-network],
                              [Disable networking features (modem, ipx)]),,
               enable_network=yes)
-AC_CHECK_HEADER(SDL_net.h,have_sdl_net_h=yes,)
+AC_ARG_ENABLE(sdl_net_static,
+              AC_HELP_STRING([--enable-sdl-net-static],
+                             [Link SDL2_Net statically (not recommended)]),
+              enable_sdl_net_static=yes,
+              enable_sdl_net_static=no)
+AC_CHECK_HEADER(SDL_net.h, have_sdl_net_h=yes,)
 AC_CHECK_LIB(SDL2_net, SDLNet_Init, have_sdl_net_lib=yes, , )
 AC_MSG_CHECKING([whether networking features will be enabled])
 if test x$enable_network = xyes ; then
   if test x$have_sdl_net_lib = xyes -a x$have_sdl_net_h = xyes ; then
-    LIBS="$LIBS -lSDL2_net"
+    if test x$enable_sdl_net_static = xyes ; then
+      case "$host" in
+        *-*-darwin*)
+          LIBS="$LIBS /usr/local/lib/libSDL2_net.a"
+          ;;
+        *)
+          LIBS="$LIBS -Wl,-Bstatic -lSDL2_net -Wl,-Bdynamic"
+          ;;
+      esac
+    else
+      LIBS="$LIBS -lSDL2_net"
+    fi
     AC_DEFINE(C_MODEM,1)
     AC_DEFINE(C_IPX,1)
     AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -473,22 +473,21 @@ AC_ARG_ENABLE(network,
               AS_HELP_STRING([--disable-network],
                              [Disable networking features (modem, ipx)]),,
               enable_network=yes)
-AC_ARG_ENABLE(sdl_net_static,
-              AC_HELP_STRING([--enable-sdl-net-static],
-                             [Link SDL2_Net statically (not recommended)]),
-              enable_sdl_net_static=yes,
-              enable_sdl_net_static=no)
 AC_CHECK_HEADER(SDL_net.h, have_sdl_net_h=yes,)
 AC_CHECK_LIB(SDL2_net, SDLNet_Init, have_sdl_net_lib=yes, , )
 AC_MSG_CHECKING([whether networking features will be enabled])
 if test x$enable_network = xyes ; then
   if test x$have_sdl_net_lib = xyes -a x$have_sdl_net_h = xyes ; then
-    if test x$enable_sdl_net_static = xyes ; then
+    libtype=""
+    if test x$enable_sdl_static = xyes ; then
+      libtype="(static)"
       case "$host" in
         *-*-darwin*)
           LIBS="$LIBS /usr/local/lib/libSDL2_net.a"
           ;;
         *)
+          AC_MSG_WARN(m4_normalize([Statically linking SDL2 is unreliable.
+            Please ensure that "libSDL2_net.a" is available.]))
           LIBS="$LIBS -Wl,-Bstatic -lSDL2_net -Wl,-Bdynamic"
           ;;
       esac
@@ -497,7 +496,7 @@ if test x$enable_network = xyes ; then
     fi
     AC_DEFINE(C_MODEM,1)
     AC_DEFINE(C_IPX,1)
-    AC_MSG_RESULT([yes])
+    AC_MSG_RESULT([yes $libtype])
     case "$host_os" in haiku*)
       AC_CHECK_LIB(network, socket, [],
                    [AC_MSG_ERROR([Can't find a useable network libary])],
@@ -505,7 +504,7 @@ if test x$enable_network = xyes ; then
       ;;
     esac
   else
-    AC_MSG_WARN([Can't find SDL_net, internal modem and ipx disabled])
+    AC_MSG_WARN([Can't find SDL2_net, internal modem and ipx disabled])
   fi
 else
   AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -441,28 +441,30 @@ AC_ARG_ENABLE(png_static,
                              [Link libpng statically (not recommended)]),
               enable_png_static=yes,
               enable_png_static=no)
-AC_CHECK_HEADER(png.h, have_png_h=yes, )
-AC_CHECK_LIB(png, png_get_io_ptr, have_png_lib=yes, , -lz)
-AC_MSG_CHECKING([whether screenshots will be enabled])
-if test x$enable_screenshots = xyes; then
-  if test x$have_png_lib = xyes -a x$have_png_h = xyes ; then
-    if test x$enable_png_static = xyes ; then
+if test x"$enable_screenshots" = x"yes"; then
+    if test x"$enable_png_static" = x"yes"; then
       case "$host" in
         *-*-darwin*)
-          LIBS="$LIBS /usr/local/lib/libpng.a -lz"
+          libpng_LIBS="/usr/local/lib/libpng.a"
+          AC_MSG_NOTICE([checking for libpng... using macOS brew library])
           ;;
         *)
-          LIBS="$LIBS -Wl,-Bstatic -lpng -Wl,-Bdynamic -lz"
+          PKG_CHECK_MODULES([libpng], [libpng],
+            [libpng_LIBS="-Wl,-Bstatic $libpng_LIBS -Wl,-Bdynamic"])
           ;;
       esac
     else
-      LIBS="$LIBS -lpng -lz"
+      PKG_CHECK_MODULES([libpng], [libpng])
     fi
-    AC_DEFINE(C_SSHOT, 1)
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no, can't find libpng.])
-  fi
+    dnl If our libs are empty, then PNG wasn't found
+    if test x"$libpng_LIBS" = x""; then
+      AC_MSG_RESULT([screenshots disabled... can't find libpng!])
+    else
+      AC_DEFINE(C_SSHOT, 1)
+      LIBS="$LIBS $libpng_LIBS -lz"
+      CXXFLAGS="$CXXFLAGS $libpng_CFLAGS"
+      AC_MSG_NOTICE([screenshots enabled... using $libpng_LIBS])
+    fi
 else
   AC_MSG_RESULT([no])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -447,7 +447,14 @@ AC_MSG_CHECKING([whether screenshots will be enabled])
 if test x$enable_screenshots = xyes; then
   if test x$have_png_lib = xyes -a x$have_png_h = xyes ; then
     if test x$enable_png_static = xyes ; then
-      LIBS="$LIBS -Wl,-Bstatic -lpng -Wl,-Bdynamic -lz"
+      case "$host" in
+        *-*-darwin*)
+          LIBS="$LIBS /usr/local/lib/libpng.a -lz"
+          ;;
+        *)
+          LIBS="$LIBS -Wl,-Bstatic -lpng -Wl,-Bdynamic -lz"
+          ;;
+      esac
     else
       LIBS="$LIBS -lpng -lz"
     fi


### PR DESCRIPTION
Adds `--enable-png-static` to link PNG statically, and now `--enable-sdl-static` will also link SDL2_Net statically.

On macos:
- The `.a` libraries are assumed to be in the expected Brew-provided `/usr/local/lib/` directory.

    ``` text
     ccache clang++ -std=gnu++14  -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing -march=nehalem -flto=thin -pipe -mno-ms-bitfields    -o dosbox dosbox.o  cpu/libcpu.a debug/libdebug.a dos/libdos.a fpu/libfpu.a gui/libgui.a hardware/libhardware.a hardware/mame/libmame.a hardware/serialport/libserial.a ints/libints.a libs/decoders/libdecoders.a libs/gui_tk/libgui_tk.a libs/nuked/libnuked.a libs/ppscale/libppscale.a midi/libmidi.a misc/libmisc.a shell/libshell.a /usr/local/lib/libSDL2.a -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -framework CoreMIDI -framework CoreFoundation -framework AudioUnit -framework AudioToolbox /usr/local/lib/libpng.a -lz /usr/local/lib/libSDL2_net.a /Users/runner/runners/2.263.0/work/dosbox-staging/dosbox-staging/contrib/static-opus/lib/libopusfile.a /Users/runner/runners/2.263.0/work/dosbox-staging/dosbox-staging/contrib/static-opus/lib/libogg.a /Users/runner/runners/2.263.0/work/dosbox-staging/dosbox-staging/contrib/static-opus/lib/libopus.a -lm -framework OpenGL -framework CoreFoundation
    ```

    ``` text
    2020-06-11T15:15:07.5413610Z + otool -L src/dosbox
    2020-06-11T15:15:08.5911110Z src/dosbox:
    2020-06-11T15:15:08.5911440Z 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0,                 current version 1281.100.1)
    2020-06-11T15:15:08.5911730Z 	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
    2020-06-11T15:15:08.5911870Z 	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
    2020-06-11T15:15:08.5913150Z 	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
    2020-06-11T15:15:08.5913480Z 	/System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback (compatibility version 1.0.0, current version 1.0.2)
    2020-06-11T15:15:08.5913620Z 	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
    2020-06-11T15:15:08.5913750Z 	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (compatibility version 1.2.0, current version 1.5.0)
    2020-06-11T15:15:08.5913870Z 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
    2020-06-11T15:15:08.5914010Z 	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 162.0.0)
    2020-06-11T15:15:08.5914140Z 	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
    2020-06-11T15:15:08.5914290Z 	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore (compatibility version 1.2.0, current version 1.11.0, weak)
    2020-06-11T15:15:08.5914430Z 	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 212.5.15, weak)
    2020-06-11T15:15:08.5914560Z 	/System/Library/Frameworks/CoreMIDI.framework/Versions/A/CoreMIDI (compatibility version 1.0.0, current version 69.0.0)
    2020-06-11T15:15:08.5914700Z 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1675.129.0)
    2020-06-11T15:15:08.5914830Z 	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit (compatibility version 1.0.0, current version 1.0.0)
    2020-06-11T15:15:08.5914960Z 	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
    2020-06-11T15:15:08.5915090Z 	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
    2020-06-11T15:15:08.5915230Z 	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 902.1.0)
    2020-06-11T15:15:08.5916560Z 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1894.40.150)
    2020-06-11T15:15:08.5916830Z 	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1355.13.0)
    2020-06-11T15:15:08.5916980Z 	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1069.22.0)
    2020-06-11T15:15:08.5917120Z 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1675.129.0)
    ```

On non-macos:

- The `.a` libs may be found dynamically by your compiler if they're in its search path(s).  Alternatively, the user can specify their own directory using `LDFLAGS="-L/path/to/static/libs/"`, which is expected behavior (and works for dynamic libraries as well).

    ``` text
    g++-9 -std=gnu++14  -O3 -mtune=native -pipe -Wnon-virtual-dtor -Weffc++ -Woverloaded-virtual -Wuseless-cast -mno-ms-bitfields   -O3 -mtune=native -pipe -o dosbox dosbox.o  cpu/libcpu.a debug/libdebug.a dos/libdos.a fpu/libfpu.a gui/libgui.a hardware/libhardware.a hardware/mame/libmame.a hardware/serialport/libserial.a ints/libints.a libs/decoders/libdecoders.a libs/gui_tk/libgui_tk.a libs/nuked/libnuked.a libs/ppscale/libppscale.a midi/libmidi.a misc/libmisc.a shell/libshell.a -lasound -lm -ldl -lpthread -lSDL2 -Wl,--no-undefined -lm -ldl -lpulse-simple -lpulse -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lwayland-egl -lwayland-client -lwayland-cursor -lxkbcommon -lpthread -lrt -Wl,-Bstatic -lpng -Wl,-Bdynamic -lz -Wl,-Bstatic -lSDL2_net -Wl,-Bdynamic -lopusfile -lGL
    ```

    ``` text
    ldd src/dosbox | grep -i 'libSDL\|libpng'
    libSDL2-2.0.so.0 => /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 (0x00007f340cc65000)
    ```

This PR also adds these static flags to the Config Heavy workflow.

Fixes #416 

Thank you to @acegary for reporting and testing this PR, and to @dreamer for the suggestion to use static libraries.