### PR TITLE
Revert alignment-related commits for code that shouldn't be byte-swapped

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 492
+          MAX_BUGS: 493
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/mem.h
+++ b/include/mem.h
@@ -21,10 +21,9 @@
 
 #include "dosbox.h"
 
-#include <cstring>
-
 #include "types.h"
-#include "byteorder.h"
+#include "mem_host.h"
+#include "mem_unaligned.h"
 
 typedef Bit32u PhysPt;
 typedef Bit8u * HostPt;
@@ -54,99 +53,6 @@ bool MEM_ReAllocatePages(MemHandle & handle,Bitu pages,bool sequence);
 
 MemHandle MEM_NextHandle(MemHandle handle);
 MemHandle MEM_NextHandleAt(MemHandle handle,Bitu where);
-
-// Read and write single-byte values
-static INLINE uint8_t host_readb(const uint8_t *var)
-{
-	return *var;
-}
-
-static INLINE void host_writeb(uint8_t *var, const uint8_t val)
-{
-	*var = val;
-}
-
-// Read, write, and add using 16-bit words
-static INLINE uint16_t host_readw(const uint8_t *arr)
-{
-	uint16_t val;
-	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le16_to_host(val);
-}
-
-// Like the above, but allows index-style access assuming a 16-bit array
-static INLINE uint16_t host_readw_at(const uint8_t *arr, const uintptr_t index)
-{
-	return host_readw(arr + index * sizeof(uint16_t));
-}
-
-static INLINE void host_writew(uint8_t *arr, uint16_t val)
-{
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le16(val);
-	memcpy(arr, &val, sizeof(val));
-}
-
-static INLINE void host_writew_at(uint8_t *arr, const uintptr_t index, const uint16_t val)
-{
-	host_writew(arr + index * sizeof(uint16_t), val);
-}
-
-static INLINE void host_addw(uint8_t *arr, const uint16_t incr)
-{
-	const uint16_t val = host_readw(arr) + incr;
-	host_writew(arr, val);
-}
-
-// Read, write, and add using 32-bit double-words
-static INLINE uint32_t host_readd(const uint8_t *arr)
-{
-	uint32_t val;
-	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le32_to_host(val);
-}
-
-// Like the above, but allows index-style access assuming a 32-bit array
-static INLINE uint32_t host_readd_at(const uint8_t *arr, const uintptr_t index)
-{
-	return host_readd(arr + index * sizeof(uint32_t));
-}
-
-static INLINE void host_writed(uint8_t *arr, uint32_t val)
-{
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le32(val);
-	memcpy(arr, &val, sizeof(val));
-}
-
-static INLINE void host_writed_at(uint8_t *arr, const uintptr_t index, const uint32_t val)
-{
-	host_writed(arr + index * sizeof(uint32_t), val);
-}
-
-static INLINE void host_addd(uint8_t *arr, const uint32_t incr)
-{
-	const uint32_t val = host_readd(arr) + incr;
-	host_writed(arr, val);
-}
-
-// Read and write using 64-bit quad-words
-static INLINE uint64_t host_readq(const uint8_t *arr)
-{
-	uint64_t val;
-	memcpy(&val, arr, sizeof(val));
-	// array sequence was DOS little-endian, so convert value to host-type
-	return le64_to_host(val);
-}
-
-static INLINE void host_writeq(uint8_t *arr, uint64_t val)
-{
-	// Convert the host-type value to little-endian before filling array
-	val = host_to_le64(val);
-	memcpy(arr, &val, sizeof(val));
-}
 
 static INLINE void var_write(uint8_t *var, uint8_t val)
 {

--- a/include/mem_host.h
+++ b/include/mem_host.h
@@ -1,0 +1,125 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_MEM_HOST_H
+#define DOSBOX_MEM_HOST_H
+
+#include <cstdint>
+
+#include "byteorder.h"
+#include "mem_unaligned.h"
+
+/*  These functions read and write 16, 32, and 64 bit uint's to
+ *  and from unaligned 8-bit memory in DOS/little-endian ordering.
+ */
+
+// Read and write single-byte values
+constexpr uint8_t host_readb(const uint8_t *var)
+{
+	return *var;
+}
+
+static inline void host_writeb(uint8_t *var, const uint8_t val)
+{
+	*var = val;
+}
+
+/*  Read a 16-bit WORD from 8-bit DOS/little-endian byte-ordered memory.
+ *  Use this instead of endian branching and byte swapping, such as:
+ *  #if BIG_ENDIAN byteswap(*(uint16_t*)(arr)) #else *(uint16_t*)(arr) 
+ */
+static inline uint16_t host_readw(const uint8_t *arr)
+{
+	return le16_to_host(read_unaligned_uint16(arr));
+}
+
+/*  Read an array-indexed 16-bit WORD from 8-bit DOS/little-endian byte-ordered
+ *  memory. Use this instead of endian branching and byte swapping, such as:
+ *  #if BIG_ENDIAN byteswap(((uint16_t*)arr)[i]) #else ((uint16_t*)arr)[i]
+ */
+static inline uint16_t host_readw_at(const uint8_t *arr, const uintptr_t idx)
+{
+	return host_readw(arr + idx * sizeof(uint16_t));
+}
+
+// Write a 16-bit WORD to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writew(uint8_t *arr, uint16_t val)
+{
+	write_unaligned_uint16(arr, host_to_le16(val));
+}
+
+// Write a 16-bit array-indexed WORD to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writew_at(uint8_t *arr, const uintptr_t idx, const uint16_t val)
+{
+	host_writew(arr + idx * sizeof(uint16_t), val);
+}
+
+// Increment a 16-bit WORD held in 8-bit DOS/little-endian byte-ordered memory.
+static inline void host_incrw(uint8_t *arr, const uint16_t incr)
+{
+	host_writew(arr, host_readw(arr) + incr);
+}
+
+// Read a 32-bit DWORD from 8-bit DOS/little-endian byte-ordered memory.
+static inline uint32_t host_readd(const uint8_t *arr)
+{
+	return le32_to_host(read_unaligned_uint32(arr));
+}
+
+// Read a 32-bit array-indexed DWORD from 8-bit DOS/little-endian byte-ordered memory. 
+static inline uint32_t host_readd_at(const uint8_t *arr, const uintptr_t idx)
+{
+	return host_readd(arr + idx * sizeof(uint32_t));
+}
+
+// Write a 32-bit DWORD to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writed(uint8_t *arr, uint32_t val)
+{
+	write_unaligned_uint32(arr, host_to_le32(val));
+}
+
+// Write a 32-bit array-indexed DWORD to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writed_at(uint8_t *arr, const uintptr_t idx, const uint32_t val)
+{
+	host_writed(arr + idx * sizeof(uint32_t), val);
+}
+
+// Increment a 32-bit DWORD held in 8-bit DOS/little-endian byte-ordered memory.
+static inline void host_incrd(uint8_t *arr, const uint32_t incr)
+{
+	host_writed(arr, host_readd(arr) + incr);
+}
+
+// (Provided for backward compatibility. The goal is to migrate these calls to the more
+// inituively named incr_* functions)
+static inline void host_addw(uint8_t *arr, const uint16_t incr){ host_incrw(arr, incr); }
+static inline void host_addd(uint8_t *arr, const uint32_t incr){ host_incrd(arr, incr); }
+
+// Read and write a 64-bit Quad-WORD to 8-bit memory using DOS/little-endian byte-ordering.
+static inline uint64_t host_readq(uint8_t *arr)
+{
+    return le64_to_host(read_unaligned_uint64(arr));
+}
+
+static inline void host_writeq(uint8_t *arr, uint64_t val){
+    write_unaligned_uint64(arr, host_to_le64(val));
+}
+
+#endif

--- a/include/mem_unaligned.h
+++ b/include/mem_unaligned.h
@@ -1,0 +1,117 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_MEM_UNALIGNED_H
+#define DOSBOX_MEM_UNALIGNED_H
+
+/*  These functions read and write 16, 32, and 64 bit uint's to
+ *  and from 8-bit memory positions using defined alignment. Use
+ *  these functions instead of C-style pointer type casts to larger
+ *  types, which are not alignment-safe.
+ */
+
+#include <cstdint>
+#include <cstring>
+
+#include "byteorder.h"
+
+/*  Read a uint16 from unaligned 8-bit byte-ordered memory. Use this
+ *  instead of *(uint16_t*)(8_bit_ptr) or *(uint16_t*)(8_bit_ptr + offset)
+ */
+static inline uint16_t read_unaligned_uint16(const uint8_t *arr)
+{
+	uint16_t val;
+	memcpy(&val, arr, sizeof(val));
+	return val;
+}
+
+/*  Read an array-indexed uint16 from unaligned 8-bit byte-ordered memory.
+ *  Use this instead of ((uint16_t*)arr)[idx]
+ */
+static inline uint16_t read_unaligned_uint16_at(const uint8_t *arr, const uintptr_t idx)
+{
+	return read_unaligned_uint16(arr + idx * sizeof(uint16_t));
+}
+
+// Write a uint16 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint16(uint8_t *arr, uint16_t val)
+{
+	memcpy(arr, &val, sizeof(val));
+}
+
+// Write an array-indexed uint16 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint16_at(uint8_t *arr, const uintptr_t idx, const uint16_t val)
+{
+	write_unaligned_uint16(arr + idx * sizeof(uint16_t), val);
+}
+
+// Increment a uint16 value held in unaligned 8-bit byte-ordered memory.
+static inline void incr_unaligned_uint16(uint8_t *arr, const uint16_t incr)
+{
+	write_unaligned_uint16(arr, read_unaligned_uint16(arr) + incr);
+}
+
+// Read a uint32 from unaligned 8-bit byte-ordered memory.
+static inline uint32_t read_unaligned_uint32(const uint8_t *arr)
+{
+	uint32_t val;
+	memcpy(&val, arr, sizeof(val));
+	return val;
+}
+
+// Read an array-indexed uint32 from unaligned 8-bit byte-ordered memory.
+static inline uint32_t read_unaligned_uint32_at(const uint8_t *arr, const uintptr_t idx)
+{
+	return read_unaligned_uint32(arr + idx * sizeof(uint32_t));
+}
+
+// Write a uint32 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint32(uint8_t *arr, uint32_t val)
+{
+	memcpy(arr, &val, sizeof(val));
+}
+
+// Write an array-indexed uint32 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint32_at(uint8_t *arr, const uintptr_t idx, const uint32_t val)
+{
+	write_unaligned_uint32(arr + idx * sizeof(uint32_t), val);
+}
+
+// Increment a uint32 value held in unaligned 8-bit byte-ordered memory.
+static inline void incr_unaligned_uint32(uint8_t *arr, const uint32_t incr)
+{
+	write_unaligned_uint32(arr, read_unaligned_uint32(arr) + incr);
+}
+
+// Read a uint64 from unaligned 8-bit byte-ordered memory.
+static inline uint64_t read_unaligned_uint64(const uint8_t *arr)
+{
+	uint64_t val;
+	memcpy(&val, arr, sizeof(val));
+	return val;
+}
+
+// Write a uint64 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint64(uint8_t *arr, uint64_t val)
+{
+	memcpy(arr, &val, sizeof(val));
+}
+
+#endif

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -137,10 +137,8 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return;
 		host_writew(hostmem+addr,val);
-		const uint16_t is_mapped = host_readw(write_map + addr);
-		if (!is_mapped) {
-			if (active_blocks)
-				return;
+		if (!*(Bit16u*)&write_map[addr]) {
+			if (active_blocks) return;
 			active_count--;
 			if (!active_count) Release();
 			return;
@@ -162,10 +160,8 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return;
 		host_writed(hostmem+addr,val);
-		const uint32_t is_mapped = host_readd(write_map + addr);
-		if (!is_mapped) {
-			if (active_blocks)
-				return;
+		if (!*(Bit32u*)&write_map[addr]) {
+			if (active_blocks) return;
 			active_count--;
 			if (!active_count) Release();
 			return;
@@ -215,9 +211,7 @@ public:
 		}
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
-
-		const uint16_t is_mapped = host_readw(write_map + addr);
-		if (!is_mapped) {
+		if (!*(Bit16u*)&write_map[addr]) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();
@@ -246,9 +240,7 @@ public:
 		}
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
-
-		const uint32_t is_mapped = host_readd(write_map + addr);
-		if (!is_mapped) {
+		if (!*(Bit32u*)&write_map[addr]) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -487,22 +487,19 @@ static INLINE void cache_addb(Bit8u val) {
 	*cache.pos++=val;
 }
 
-static INLINE void cache_addw(const uint16_t val)
-{
-	host_writew(cache.pos, val);
-	cache.pos += sizeof(val);
+static INLINE void cache_addw(Bit16u val) {
+	*(Bit16u*)cache.pos=val;
+	cache.pos+=2;
 }
 
-static INLINE void cache_addd(const uint32_t val)
-{
-	host_writed(cache.pos, val);
-	cache.pos += sizeof(val);
+static INLINE void cache_addd(Bit32u val) {
+	*(Bit32u*)cache.pos=val;
+	cache.pos+=4;
 }
 
-static INLINE void cache_addq(const uint64_t val)
-{
-	host_writeq(cache.pos, val);
-	cache.pos += sizeof(val);
+static INLINE void cache_addq(Bit64u val) {
+	*(Bit64u*)cache.pos=val;
+	cache.pos+=8;
 }
 
 static void gen_return(BlockReturn retcode);

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -151,7 +151,7 @@ public:
 			}
 			memset(invalidation_map,0,4096);
 		}
-		host_addw(invalidation_map + addr, 0x101);
+		(*(Bit16u*)&invalidation_map[addr])+=0x101;
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -176,7 +176,7 @@ public:
 			}
 			memset(invalidation_map,0,4096);
 		}
-		host_addd(invalidation_map + addr, 0x1010101);
+		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -230,7 +230,7 @@ public:
 				}
 				memset(invalidation_map,0,4096);
 			}
-			host_addw(invalidation_map + addr, 0x101);
+			(*(Bit16u*)&invalidation_map[addr])+=0x101;
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -261,7 +261,7 @@ public:
 				}
 				memset(invalidation_map,0,4096);
 			}
-			host_addd(invalidation_map + addr, 0x1010101);
+			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -140,34 +140,28 @@ static Bit8u decode_fetchb(void) {
 	decode.code+=1;
 	return mem_readb(decode.code-1);
 }
-
-static uint16_t decode_fetchw()
-{
-	if (GCC_UNLIKELY(decode.page.index >= 4095)) {
-		uint16_t val = decode_fetchb();
-		val |= decode_fetchb() << 8;
+static Bit16u decode_fetchw(void) {
+	if (GCC_UNLIKELY(decode.page.index>=4095)) {
+   		Bit16u val=decode_fetchb();
+		val|=decode_fetchb() << 8;
 		return val;
 	}
-	host_addw(decode.page.wmap + decode.page.index, 0x0101);
-	decode.code += sizeof(uint16_t);
-	decode.page.index += sizeof(uint16_t);
-	return mem_readw(decode.code - sizeof(uint16_t));
+	*(Bit16u *)&decode.page.wmap[decode.page.index]+=0x0101;
+	decode.code+=2;decode.page.index+=2;
+	return mem_readw(decode.code-2);
 }
-
-static uint32_t decode_fetchd()
-{
-	if (GCC_UNLIKELY(decode.page.index >= 4093)) {
-		Bit32u val = decode_fetchb();
-		val |= decode_fetchb() << 8;
-		val |= decode_fetchb() << 16;
+static Bit32u decode_fetchd(void) {
+	if (GCC_UNLIKELY(decode.page.index>=4093)) {
+   		Bit32u val=decode_fetchb();
+		val|=decode_fetchb() << 8;
+		val|=decode_fetchb() << 16;
 		val|=decode_fetchb() << 24;
 		return val;
         /* Advance to the next page */
 	}
-	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
-	decode.code += sizeof(uint32_t);
-	decode.page.index += sizeof(uint32_t);
-	return mem_readd(decode.code - sizeof(uint32_t));
+	*(Bit32u *)&decode.page.wmap[decode.page.index]+=0x01010101;
+	decode.code+=4;decode.page.index+=4;
+	return mem_readd(decode.code-4);
 }
 
 #define START_WMMEM 64

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -199,9 +199,9 @@ static INLINE void decode_increase_wmapmask(Bitu size) {
 		}
 	}
 	switch (size) {
-	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
-	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
+		case 1 : activecb->cache.wmapmask[mapidx]+=0x01; break;
+		case 2 : (*(Bit16u*)&activecb->cache.wmapmask[mapidx])+=0x0101; break;
+		case 4 : (*(Bit32u*)&activecb->cache.wmapmask[mapidx])+=0x01010101; break;
 	}
 }
 

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1167,8 +1167,8 @@ static uint8_t *gen_create_jump(uint8_t *to = 0)
 }
 
 #if 0
-static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
-	host_writed(data, to - data - sizeof(uint32_t));
+static void gen_fill_jump(Bit8u * data,Bit8u * to=cache.pos) {
+	*(Bit32u*)data=(Bit32u)(to-data-4);
 }
 #endif
 

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -272,8 +272,7 @@ public:
 static BlockReturn gen_runcodeInit(Bit8u *code);
 static BlockReturn (*gen_runcode)(Bit8u *code) = gen_runcodeInit;
 
-static BlockReturn gen_runcodeInit(uint8_t *code)
-{
+static BlockReturn gen_runcodeInit(Bit8u *code) {
 	Bit8u* oldpos = cache.pos;
 	cache.pos = &cache_code_link_blocks[128];
 	gen_runcode = (BlockReturn(*)(Bit8u*))cache.pos;
@@ -304,7 +303,7 @@ static BlockReturn gen_runcodeInit(uint8_t *code)
 	opcode(0).setea(4,-1,0,CALLSTACK).Emit8(0x89);  // mov [rsp+8/40], eax
 	opcode(4).setrm(ARG0_REG).Emit8(0xFF);   // jmp ARG0
 
-	host_writed(diff, cache.pos - diff - sizeof(uint32_t));
+	*(Bit32u*)diff = (Bit32u)(cache.pos - diff - 4);
 	// eax = return value, ecx = flags
 	opcode(1).setea(5,-1,0,offsetof(CPU_Regs,flags)).Emit8(0x33); // xor ecx, reg_flags
 	opcode(4).setrm(1).setimm(FMASK_TEST,4).Emit8(0x81);          // and ecx,FMASK_TEST

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1153,9 +1153,8 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos)
-{
-	host_writed(data, from - data - sizeof(uint32_t));
+static void gen_fill_branch_long(Bit8u * data,Bit8u * from=cache.pos) {
+	*(Bit32u*)data=(Bit32u)(from-data-4);
 }
 
 static uint8_t *gen_create_jump(uint8_t *to = 0)

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -989,8 +989,8 @@ static Bit8u * gen_create_branch_long(BranchTypes type) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_branch_long(uint8_t *data, uint8_t *from = cache.pos) {
-	host_writed(data, from - data - sizeof(uint32_t));
+static void gen_fill_branch_long(Bit8u * data,Bit8u * from=cache.pos) {
+	*(Bit32u*)data=(from-data-4);
 }
 
 static Bit8u * gen_create_jump(Bit8u * to=0) {

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -1000,8 +1000,8 @@ static Bit8u * gen_create_jump(Bit8u * to=0) {
 	return (cache.pos-4);
 }
 
-static void gen_fill_jump(uint8_t *data, uint8_t *to = cache.pos) {
-	host_writed(data, to - data - sizeof(uint32_t));
+static void gen_fill_jump(Bit8u * data,Bit8u * to=cache.pos) {
+	*(Bit32u*)data=(to-data-4);
 }
 
 

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -171,7 +171,12 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-		host_addw(invalidation_map + addr, 0x101);
+#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+		host_writew(&invalidation_map[addr],
+			host_readw(&invalidation_map[addr])+0x101);
+#else
+		(*(Bit16u*)&invalidation_map[addr])+=0x101;
+#endif
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -188,7 +193,12 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-		host_addd(invalidation_map + addr, 0x1010101);
+#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+		host_writed(&invalidation_map[addr],
+			host_readd(&invalidation_map[addr])+0x1010101);
+#else
+		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
+#endif
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
@@ -230,7 +240,12 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-			host_addw(invalidation_map + addr, 0x101);
+#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+			host_writew(&invalidation_map[addr],
+				host_readw(&invalidation_map[addr])+0x101);
+#else
+			(*(Bit16u*)&invalidation_map[addr])+=0x101;
+#endif
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -254,7 +269,12 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-			host_addd(invalidation_map + addr, 0x1010101);
+#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+			host_writed(&invalidation_map[addr],
+				host_readd(&invalidation_map[addr])+0x1010101);
+#else
+			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
+#endif
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -533,22 +533,23 @@ static INLINE void cache_addb(Bit8u val) {
 }
 
 // place a 16bit value into the cache
-static INLINE void cache_addw(const uint16_t val) {
-	host_writew(cache.pos, val);
-	cache.pos += sizeof(val);
+static INLINE void cache_addw(Bit16u val) {
+	*(Bit16u*)cache.pos=val;
+	cache.pos+=2;
 }
 
 // place a 32bit value into the cache
-static INLINE void cache_addd(const uint32_t val) {
-	host_writed(cache.pos, val);
-	cache.pos += sizeof(val);
+static INLINE void cache_addd(Bit32u val) {
+	*(Bit32u*)cache.pos=val;
+	cache.pos+=4;
 }
 
 // place a 64bit value into the cache
-static INLINE void cache_addq(const uint64_t val) {
-	host_writeq(cache.pos, val);
-	cache.pos += sizeof(val);
+static INLINE void cache_addq(Bit64u val) {
+	*(Bit64u*)cache.pos=val;
+	cache.pos+=8;
 }
+
 
 static void dyn_return(BlockReturn retcode,bool ret_exception);
 static void dyn_run_code(void);

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -221,46 +221,39 @@ static void decode_advancepage(void) {
 }
 
 // fetch the next byte of the instruction stream
-static uint8_t decode_fetchb()
-{
-	if (GCC_UNLIKELY(decode.page.index >= 4096)) {
+static Bit8u decode_fetchb(void) {
+	if (GCC_UNLIKELY(decode.page.index>=4096)) {
 		decode_advancepage();
 	}
-	decode.page.wmap[decode.page.index] += 0x01;
+	decode.page.wmap[decode.page.index]+=0x01;
 	decode.page.index++;
-	decode.code += 1;
-	return mem_readb(decode.code - 1);
+	decode.code+=1;
+	return mem_readb(decode.code-1);
 }
-
 // fetch the next word of the instruction stream
-static uint16_t decode_fetchw()
-{
-	if (GCC_UNLIKELY(decode.page.index >= 4095)) {
-		Bit16u val = decode_fetchb();
-		val |= decode_fetchb() << 8;
+static Bit16u decode_fetchw(void) {
+	if (GCC_UNLIKELY(decode.page.index>=4095)) {
+   		Bit16u val=decode_fetchb();
+		val|=decode_fetchb() << 8;
 		return val;
 	}
-	host_addw(decode.page.wmap + decode.page.index, 0x0101);
-	decode.code += sizeof(uint16_t);
-	decode.page.index += sizeof(uint16_t);
-	return mem_readw(decode.code - sizeof(uint16_t));
+	*(Bit16u *)&decode.page.wmap[decode.page.index]+=0x0101;
+	decode.code+=2;decode.page.index+=2;
+	return mem_readw(decode.code-2);
 }
-
 // fetch the next dword of the instruction stream
-static uint32_t decode_fetchd()
-{
-	if (GCC_UNLIKELY(decode.page.index >= 4093)) {
-		Bit32u val = decode_fetchb();
-		val |= decode_fetchb() << 8;
-		val |= decode_fetchb() << 16;
-		val |= decode_fetchb() << 24;
+static Bit32u decode_fetchd(void) {
+	if (GCC_UNLIKELY(decode.page.index>=4093)) {
+   		Bit32u val=decode_fetchb();
+		val|=decode_fetchb() << 8;
+		val|=decode_fetchb() << 16;
+		val|=decode_fetchb() << 24;
 		return val;
-		/* Advance to the next page */
+        /* Advance to the next page */
 	}
-	host_addd(decode.page.wmap + decode.page.index, 0x01010101);
-	decode.code += sizeof(uint32_t);
-	decode.page.index += sizeof(uint32_t);
-	return mem_readd(decode.code - sizeof(uint32_t));
+	*(Bit32u *)&decode.page.wmap[decode.page.index]+=0x01010101;
+	decode.code+=4;decode.page.index+=4;
+	return mem_readd(decode.code-4);
 }
 
 #define START_WMMEM 64

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -293,9 +293,9 @@ static void INLINE decode_increase_wmapmask(Bitu size) {
 	}
 	// update mask entries
 	switch (size) {
-	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: host_addw(activecb->cache.wmapmask + mapidx, 0x0101); break;
-	case 4: host_addd(activecb->cache.wmapmask + mapidx, 0x01010101); break;
+		case 1 : activecb->cache.wmapmask[mapidx]+=0x01; break;
+		case 2 : (*(Bit16u*)&activecb->cache.wmapmask[mapidx])+=0x0101; break;
+		case 4 : (*(Bit32u*)&activecb->cache.wmapmask[mapidx])+=0x01010101; break;
 	}
 }
 

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -381,7 +381,7 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 		png_write_info(png_ptr, info_ptr);
 		for (i=0;i<height;i++) {
 			void *rowPointer;
-			uint8_t *srcLine;
+			void *srcLine;
 			if (flags & CAPTURE_FLAG_DBLH)
 				srcLine=(data+(i >> 1)*pitch);
 			else
@@ -392,21 +392,21 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 				if (flags & CAPTURE_FLAG_DBLW) {
    					for (Bitu x=0;x<countWidth;x++)
 						doubleRow[x*2+0] =
-						doubleRow[x*2+1] = srcLine[x];
+						doubleRow[x*2+1] = ((Bit8u *)srcLine)[x];
 					rowPointer = doubleRow;
 				}
 				break;
 			case 15:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x = 0; x < countWidth; x++) {
-						const Bitu pixel = host_readw_at(srcLine, x);
+					for (Bitu x=0;x<countWidth;x++) {
+						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x03e0) * 0x21) >>  7;
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0x7c00) * 0x21) >>  12;
 					}
 				} else {
-					for (Bitu x = 0; x < countWidth; x++) {
-						const Bitu pixel = host_readw_at(srcLine, x);
+					for (Bitu x=0;x<countWidth;x++) {
+						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*3+1] = ((pixel& 0x03e0) * 0x21) >>  7;
 						doubleRow[x*3+2] = ((pixel& 0x7c00) * 0x21) >>  12;
@@ -416,15 +416,15 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 				break;
 			case 16:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x = 0; x < countWidth; x++) {
-						const Bitu pixel = host_readw_at(srcLine, x);
+					for (Bitu x=0;x<countWidth;x++) {
+						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >> 2;
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x07e0) * 0x41) >> 9;
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0xf800) * 0x21) >> 13;
 					}
 				} else {
-					for (Bitu x = 0; x < countWidth; x++) {
-						const Bitu pixel = host_readw_at(srcLine, x);
+					for (Bitu x=0;x<countWidth;x++) {
+						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*3+1] = ((pixel& 0x07e0) * 0x41) >>  9;
 						doubleRow[x*3+2] = ((pixel& 0xf800) * 0x21) >>  13;
@@ -435,15 +435,15 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 			case 32:
 				if (flags & CAPTURE_FLAG_DBLW) {
 					for (Bitu x=0;x<countWidth;x++) {
-						doubleRow[x*6+0] = doubleRow[x*6+3] = srcLine[x*4+0];
-						doubleRow[x*6+1] = doubleRow[x*6+4] = srcLine[x*4+1];
-						doubleRow[x*6+2] = doubleRow[x*6+5] = srcLine[x*4+2];
+						doubleRow[x*6+0] = doubleRow[x*6+3] = ((Bit8u *)srcLine)[x*4+0];
+						doubleRow[x*6+1] = doubleRow[x*6+4] = ((Bit8u *)srcLine)[x*4+1];
+						doubleRow[x*6+2] = doubleRow[x*6+5] = ((Bit8u *)srcLine)[x*4+2];
 					}
 				} else {
 					for (Bitu x=0;x<countWidth;x++) {
-						doubleRow[x*3+0] = srcLine[x*4+0];
-						doubleRow[x*3+1] = srcLine[x*4+1];
-						doubleRow[x*3+2] = srcLine[x*4+2];
+						doubleRow[x*3+0] = ((Bit8u *)srcLine)[x*4+0];
+						doubleRow[x*3+1] = ((Bit8u *)srcLine)[x*4+1];
+						doubleRow[x*3+2] = ((Bit8u *)srcLine)[x*4+2];
 					}
 				}
 				rowPointer = doubleRow;
@@ -519,7 +519,7 @@ skip_shot:
 		for (i=0;i<height;i++) {
 			void * rowPointer;
 			if (flags & CAPTURE_FLAG_DBLW) {
-				uint8_t *srcLine;
+				void *srcLine;
 				Bitu x;
 				Bitu countWidth = width >> 1;
 				if (flags & CAPTURE_FLAG_DBLH)
@@ -529,23 +529,19 @@ skip_shot:
 				switch ( bpp) {
 				case 8:
 					for (x=0;x<countWidth;x++)
-						doubleRow[x*2+0] =
-						doubleRow[x*2+1] = srcLine[x];
+						((Bit8u *)doubleRow)[x*2+0] =
+						((Bit8u *)doubleRow)[x*2+1] = ((Bit8u *)srcLine)[x];
 					break;
 				case 15:
 				case 16:
-					for (x = 0; x < countWidth; x++) {
-						const uint16_t pixel = host_readw_at(srcLine, x);
-						host_writew_at(doubleRow, x * 2, pixel);
-						host_writew_at(doubleRow, x * 2 + 1, pixel);
-					}
+					for (x=0;x<countWidth;x++)
+						((Bit16u *)doubleRow)[x*2+0] =
+						((Bit16u *)doubleRow)[x*2+1] = ((Bit16u *)srcLine)[x];
 					break;
 				case 32:
-					for (x = 0; x < countWidth; x++) {
-						const uint32_t pixel = host_readd_at(srcLine, x);
-						host_writed_at(doubleRow, x * 2, pixel);
-						host_writed_at(doubleRow, x * 2 + 1, pixel);
-					}
+					for (x=0;x<countWidth;x++)
+						((Bit32u *)doubleRow)[x*2+0] =
+						((Bit32u *)doubleRow)[x*2+1] = ((Bit32u *)srcLine)[x];
 					break;
 				}
                 rowPointer=doubleRow;


### PR DESCRIPTION
The goal of PR 282 was to correct the alignment issues in the memory read and write `host_()` functions. These function also happen to perform byte-swapping to and from little-endian.

Although the above was correct, PR 282 included commits that incorrectly applied these now-alignment-safe `host_()` functions to code that previously didn't didn't need the byte-swapping (ie: code that didn't call or use the `host_()` functions), and instead they only needed alignment correction.

I've flagged each incorrect application of the `host_()` functions to code that didn't previous use it, here: 
 - https://github.com/dosbox-staging/dosbox-staging/pull/282/files

This PR:
 1. **Reverts** the subset of PR-282 commits that incorrectly applied the `host_()` functions in places that did not previous use them.  This fixes the byte-swapping regression under PPC dynrec, but re-introduced the alignment problem.
 2. **Proposes** a suite of new memory function that are alignment-safe functions but _don't_ perform byte-swapping.  These are exclusively contained in the [`mem_native.h`](https://github.com/dosbox-staging/dosbox-staging/pull/429/files#diff-df06ddb429831543fba214abaf650cfa) header, and we can use this PR to choose better names for them.

Once we've nailed down names, we can apply these new non-swapping functions to the reverted code (likely in a follow-up PR).