### PR TITLE
Replace ConvDecWord function with atoi/atol

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -145,9 +145,8 @@ char * lowcase(char * str);
 bool ScanCMDBool(char * cmd,char const * const check);
 char * ScanCMDRemain(char * cmd);
 char * StripWord(char *&cmd);
-bool IsDecWord(char * word);
+
 bool IsHexWord(char * word);
-Bits ConvDecWord(char * word);
 Bits ConvHexWord(char * word);
 
 void trim(std::string& str);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -26,6 +26,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <list>
 #include <thread>
@@ -381,8 +382,7 @@ public:
 		if (strncasecmp(buf, configname, strlen(configname)))
 			return nullptr;
 		StripWord(buf);
-		char *num = StripWord(buf);
-		long code = ConvDecWord(num);
+		long code = atol(StripWord(buf));
 		assert(code > 0);
 		return CreateKeyBind((SDL_Scancode)code);
 	}
@@ -619,17 +619,15 @@ public:
 		char *type = StripWord(buf);
 		CBind *bind = nullptr;
 		if (!strcasecmp(type,"axis")) {
-			// TODO ConvDecWord returns Bits… (signed), but it was stored in unsigned
-			// seems like this could be safely replaced with std::atoi
-			int ax = ConvDecWord(StripWord(buf));
-			int pos = ConvDecWord(StripWord(buf));
+			int ax = atoi(StripWord(buf));
+			int pos = atoi(StripWord(buf));
 			bind = CreateAxisBind(ax, pos > 0); // TODO double check, previously it was != 0
 		} else if (!strcasecmp(type, "button")) {
-			int but = ConvDecWord(StripWord(buf));
+			int but = atoi(StripWord(buf));
 			bind = CreateButtonBind(but);
 		} else if (!strcasecmp(type, "hat")) {
-			uint8_t hat = static_cast<uint8_t>(ConvDecWord(StripWord(buf)));
-			uint8_t dir = static_cast<uint8_t>(ConvDecWord(StripWord(buf)));
+			uint8_t hat = static_cast<uint8_t>(atoi(StripWord(buf)));
+			uint8_t dir = static_cast<uint8_t>(atoi(StripWord(buf)));
 			bind = CreateHatBind(hat, dir);
 		}
 		return bind;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -197,21 +197,6 @@ char * StripWord(char *&line) {
 	return begin;
 }
 
-Bits ConvDecWord(char * word) {
-	bool negative=false;Bitu ret=0;
-	if (*word=='-') {
-		negative=true;
-		word++;
-	}
-	while (char c=*word) {
-		ret*=10;
-		ret+=c-'0';
-		word++;
-	}
-	if (negative) return 0-ret;
-	else return ret;
-}
-
 Bits ConvHexWord(char * word) {
 	Bitu ret=0;
 	while (char c=toupper(*reinterpret_cast<unsigned char*>(word))) {


### PR DESCRIPTION
This function was buggy (couldn't handle leading +, was converting
non-digit characters) version of atoi/atol/atoll (which are already
more popular throughout dosbox codebase than ConvDecWord ever was).

Remove empty declaration of function IsDecWord.