### PR TITLE
Expand CI gating with Linux dynrec build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ${{ matrix.conf.os }}
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
     strategy:
+      max-parallel: 4
       matrix:
         conf:
           - name: GCC, Ubuntu 16.04
@@ -27,15 +28,21 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             max_warnings: 26
-          - name: GCC, Ubuntu 20.04, +debug
-            os: ubuntu-20.04
-            flags: -c gcc
-            config_flags: --enable-debug
-            max_warnings: 137
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
             max_warnings: 9
+          - name: Ubuntu, +debug
+            os: ubuntu-latest
+            flags: -c gcc
+            config_flags: --enable-debug
+            max_warnings: 137
+          - name: Ubuntu, -dyn_x86, +dynrec
+            os: ubuntu-latest
+            flags: -c gcc
+            config_flags: --disable-dynamic-x86
+            max_warnings: 33
+
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update


### PR DESCRIPTION
The default build configuration uses core_dyn_x86, which is separate
implementation of dynamic core optimised for x86 and x86_64
architectures.

New CI job uses core_dynrec, which is implementation primarily used on
other architectures, but it includes x86 backend as well. This gives us
some protection from accidental build problems in that area even without
cross-compiling.

Set up max 4 concurrent jobs for Linux job matrix to prevent going over
max GitHub limit. Our Linux jobs are faster than jobs on other OSes, so
it's not really a problem.

Use ubuntu-latest for jobs focusing on configuration changes and not
testing compilation on various compiler/os configurations.