### PR TITLE
Reorganize and update documentation in mem_* headers

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -23,6 +23,7 @@ keyboard.h \
 logging.h \
 mapper.h \
 mem.h \
+mem_unaligned.h \
 midi.h \
 mixer.h \
 mouse.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -23,6 +23,7 @@ keyboard.h \
 logging.h \
 mapper.h \
 mem.h \
+mem_host.h \
 mem_unaligned.h \
 midi.h \
 mixer.h \

--- a/include/mem_host.h
+++ b/include/mem_host.h
@@ -10,7 +10,7 @@
  *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License along
@@ -21,105 +21,214 @@
 #ifndef DOSBOX_MEM_HOST_H
 #define DOSBOX_MEM_HOST_H
 
+/* These functions read and write fixed-width unsigned integers to/from
+ * byte-arrays using DOS/little-endian byte ordering.
+ *
+ * Values returned or passed to these functions are expected to be integers
+ * using native endianess representation for the host machine.
+ *
+ * They are safe to use even when byte-array address is not aligned according
+ * to desired integer width.
+ */
+
 #include <cstdint>
 
 #include "byteorder.h"
 #include "mem_unaligned.h"
 
-/*  These functions read and write 16, 32, and 64 bit uint's to
- *  and from unaligned 8-bit memory in DOS/little-endian ordering.
+/* Use host_read* functions to replace endian branching and byte swapping code,
+ * such as:
+ *
+ *   #ifdef WORDS_BIGENDIAN
+ *   auto x = byteswap(*(uint16_t*)(arr));
+ *   #else
+ *   auto x = *(uint16_t*)(arr);
+ *   #endif
  */
 
-// Read and write single-byte values
-constexpr uint8_t host_readb(const uint8_t *var)
+// Read a single-byte value; provided for backwards-compatibility only.
+constexpr uint8_t host_readb(const uint8_t *arr) noexcept
 {
-	return *var;
+	return *arr;
 }
 
-static inline void host_writeb(uint8_t *var, const uint8_t val)
-{
-	*var = val;
-}
-
-/*  Read a 16-bit WORD from 8-bit DOS/little-endian byte-ordered memory.
- *  Use this instead of endian branching and byte swapping, such as:
- *  #if BIG_ENDIAN byteswap(*(uint16_t*)(arr)) #else *(uint16_t*)(arr) 
- */
-static inline uint16_t host_readw(const uint8_t *arr)
+// Read a 16-bit word from 8-bit DOS/little-endian byte-ordered memory.
+static inline uint16_t host_readw(const uint8_t *arr) noexcept
 {
 	return le16_to_host(read_unaligned_uint16(arr));
 }
 
-/*  Read an array-indexed 16-bit WORD from 8-bit DOS/little-endian byte-ordered
- *  memory. Use this instead of endian branching and byte swapping, such as:
- *  #if BIG_ENDIAN byteswap(((uint16_t*)arr)[i]) #else ((uint16_t*)arr)[i]
- */
-static inline uint16_t host_readw_at(const uint8_t *arr, const uintptr_t idx)
-{
-	return host_readw(arr + idx * sizeof(uint16_t));
-}
-
-// Write a 16-bit WORD to 8-bit memory using DOS/little-endian byte-ordering.
-static inline void host_writew(uint8_t *arr, uint16_t val)
-{
-	write_unaligned_uint16(arr, host_to_le16(val));
-}
-
-// Write a 16-bit array-indexed WORD to 8-bit memory using DOS/little-endian byte-ordering.
-static inline void host_writew_at(uint8_t *arr, const uintptr_t idx, const uint16_t val)
-{
-	host_writew(arr + idx * sizeof(uint16_t), val);
-}
-
-// Increment a 16-bit WORD held in 8-bit DOS/little-endian byte-ordered memory.
-static inline void host_incrw(uint8_t *arr, const uint16_t incr)
-{
-	host_writew(arr, host_readw(arr) + incr);
-}
-
-// Read a 32-bit DWORD from 8-bit DOS/little-endian byte-ordered memory.
-static inline uint32_t host_readd(const uint8_t *arr)
+// Read a 32-bit double-word from 8-bit DOS/little-endian byte-ordered memory.
+static inline uint32_t host_readd(const uint8_t *arr) noexcept
 {
 	return le32_to_host(read_unaligned_uint32(arr));
 }
 
-// Read a 32-bit array-indexed DWORD from 8-bit DOS/little-endian byte-ordered memory. 
-static inline uint32_t host_readd_at(const uint8_t *arr, const uintptr_t idx)
+// Read a 64-bit quad-word from 8-bit DOS/little-endian byte-ordered memory.
+static inline uint64_t host_readq(const uint8_t *arr) noexcept
+{
+	return le64_to_host(read_unaligned_uint64(arr));
+}
+
+/* Use host_read*_at functions to replace endian branching and byte swapping
+ * code such as:
+ *
+ *   #ifdef WORDS_BIGENDIAN
+ *   auto x = byteswap(((uint16_t*)arr)[idx]);
+ *   #else
+ *   auto x = ((uint16_t*)arr)[idx];
+ *   #endif
+ */
+
+// Read an array-indexed 16-bit word from 8-bit DOS/little-endian byte-ordered
+// memory.
+static inline uint16_t host_readw_at(const uint8_t *arr, const uintptr_t idx) noexcept
+{
+	return host_readw(arr + idx * sizeof(uint16_t));
+}
+
+// Read an array-indexed 32-bit double-word from 8-bit DOS/little-endian
+// byte-ordered memory.
+static inline uint32_t host_readd_at(const uint8_t *arr, const uintptr_t idx) noexcept
 {
 	return host_readd(arr + idx * sizeof(uint32_t));
 }
 
-// Write a 32-bit DWORD to 8-bit memory using DOS/little-endian byte-ordering.
-static inline void host_writed(uint8_t *arr, uint32_t val)
+// Read an array-indexed 64-bit quad-word from 8-bit DOS/little-endian
+// byte-ordered memory.
+static inline uint64_t host_readq_at(const uint8_t *arr, const uintptr_t idx) noexcept
+{
+	return host_readq(arr + idx * sizeof(uint64_t));
+}
+
+/* Use host_write* functions to replace endian branching and byte swapping
+ * code such as:
+ *
+ *   #ifdef WORDS_BIGENDIAN
+ *   *(uint16_t*)arr = byteswap((uint16_t)val);
+ *   #else
+ *   *(uint16_t*)arr = (uint16_t)val;
+ *   #endif
+ */
+
+// Write a single-byte value; provided for backwards-compatibility only.
+static inline void host_writeb(uint8_t *arr, const uint8_t val) noexcept
+{
+	*arr = val;
+}
+
+// Write a 16-bit word to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writew(uint8_t *arr, const uint16_t val) noexcept
+{
+	write_unaligned_uint16(arr, host_to_le16(val));
+}
+
+// Write a 32-bit double-word to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writed(uint8_t *arr, const uint32_t val) noexcept
 {
 	write_unaligned_uint32(arr, host_to_le32(val));
 }
 
-// Write a 32-bit array-indexed DWORD to 8-bit memory using DOS/little-endian byte-ordering.
-static inline void host_writed_at(uint8_t *arr, const uintptr_t idx, const uint32_t val)
+// Write a 64-bit quad-word to 8-bit memory using DOS/little-endian byte-ordering.
+static inline void host_writeq(uint8_t *arr, const uint64_t val) noexcept
+{
+	write_unaligned_uint64(arr, host_to_le64(val));
+}
+
+/* Use host_write*_at functions to replace endian branching and byte swapping
+ * code such as:
+ *
+ *   #ifdef WORDS_BIGENDIAN
+ *   ((uint16_t*)arr)[idx] = byteswap((uint16_t)val);
+ *   #else
+ *   ((uint16_t*)arr)[idx] = (uint16_t)val;
+ *   #endif
+ */
+
+// Write a 16-bit array-indexed word to 8-bit memory using DOS/little-endian
+// byte-ordering.
+static inline void host_writew_at(uint8_t *arr,
+                                  const uintptr_t idx,
+                                  const uint16_t val) noexcept
+{
+	host_writew(arr + idx * sizeof(uint16_t), val);
+}
+
+// Write a 32-bit array-indexed double-word to 8-bit memory using
+// DOS/little-endian byte-ordering.
+static inline void host_writed_at(uint8_t *arr,
+                                  const uintptr_t idx,
+                                  const uint32_t val) noexcept
 {
 	host_writed(arr + idx * sizeof(uint32_t), val);
 }
 
-// Increment a 32-bit DWORD held in 8-bit DOS/little-endian byte-ordered memory.
-static inline void host_incrd(uint8_t *arr, const uint32_t incr)
+// Write a 64-bit array-indexed quad-word to 8-bit memory using
+// DOS/little-endian byte-ordering.
+static inline void host_writeq_at(uint8_t *arr,
+                                  const uintptr_t idx,
+                                  const uint64_t val) noexcept
 {
-	host_writed(arr, host_readd(arr) + incr);
+	host_writeq(arr + idx * sizeof(uint64_t), val);
 }
 
-// (Provided for backward compatibility. The goal is to migrate these calls to the more
-// inituively named incr_* functions)
-static inline void host_addw(uint8_t *arr, const uint16_t incr){ host_incrw(arr, incr); }
-static inline void host_addd(uint8_t *arr, const uint32_t incr){ host_incrd(arr, incr); }
+/* Use host_add* functions to replace endian branching and byte swapping
+ * code such as:
+ *
+ *   #ifdef WORDS_BIGENDIAN
+ *   *(uint16_t*)arr += byteswap((uint16_t)val);
+ *   #else
+ *   *(uint16_t*)arr += val;
+ *   #endif
+ */
 
-// Read and write a 64-bit Quad-WORD to 8-bit memory using DOS/little-endian byte-ordering.
-static inline uint64_t host_readq(uint8_t *arr)
+// Add to a 16-bit word stored in 8-bit DOS/little-endian byte-ordered memory.
+static inline void host_addw(uint8_t *arr, const uint16_t val) noexcept
 {
-    return le64_to_host(read_unaligned_uint64(arr));
+	host_writew(arr, host_readw(arr) + val);
 }
 
-static inline void host_writeq(uint8_t *arr, uint64_t val){
-    write_unaligned_uint64(arr, host_to_le64(val));
+// Add to a 32-bit double-word stored in 8-bit DOS/little-endian byte-ordered
+// memory.
+static inline void host_addd(uint8_t *arr, const uint32_t val) noexcept
+{
+	host_writed(arr, host_readd(arr) + val);
+}
+
+// Add to a 64-bit quad-word stored in 8-bit DOS/little-endian byte-ordered memory.
+static inline void host_addq(uint8_t *arr, const uint64_t val) noexcept
+{
+	host_writeq(arr, host_readq(arr) + val);
+}
+
+/* Use host_inc* functions to replace endian branching and byte swapping
+ * code such as:
+ *
+ *   #ifdef WORDS_BIGENDIAN
+ *   *(uint16_t*)arr += byteswap((uint16_t)1);
+ *   #else
+ *   *(uint16_t*)arr += 1;
+ *   #endif
+ */
+
+// Increment a 16-bit word stored in 8-bit DOS/little-endian byte-ordered memory.
+static inline void host_incw(uint8_t *arr) noexcept
+{
+	host_writew(arr, host_readw(arr) + 1);
+}
+
+// Increment a 32-bit double-word stored in 8-bit DOS/little-endian byte-ordered
+// memory.
+static inline void host_incd(uint8_t *arr) noexcept
+{
+	host_writed(arr, host_readd(arr) + 1);
+}
+
+// Increment a 64-bit quad-word stored in 8-bit DOS/little-endian byte-ordered
+// memory.
+static inline void host_incq(uint8_t *arr) noexcept
+{
+	host_writeq(arr, host_readq(arr) + 1);
 }
 
 #endif

--- a/include/mem_unaligned.h
+++ b/include/mem_unaligned.h
@@ -10,7 +10,7 @@
  *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License along
@@ -21,97 +21,188 @@
 #ifndef DOSBOX_MEM_UNALIGNED_H
 #define DOSBOX_MEM_UNALIGNED_H
 
-/*  These functions read and write 16, 32, and 64 bit uint's to
- *  and from 8-bit memory positions using defined alignment. Use
- *  these functions instead of C-style pointer type casts to larger
- *  types, which are not alignment-safe.
+/* These functions read and write fixed-size unsigned integers to/from
+ * byte-buffers, regardless of memory alignment requirements.
+ *
+ * Use these functions instead of C-style pointer type casts to larger
+ * types (which are not alignment-safe).
+ *
+ * These functions use memcpy to signal intent to the compiler; all modern
+ * compilers recognize this and generate well-optimized, safe, inlined
+ * instructions (and not a function call). Bad compilers will generate memcpy
+ * call (which will be slower, but still safe).
+ *
+ * Examples used in comments throughout this file are NOT alignment safe - they
+ * exist only for illustrative purposes; they will work on x86 architecture in
+ * practice, but depend on undefined behaviour, might generate slow code or
+ * outright crash when targetting different architectures.
  */
 
 #include <cstdint>
 #include <cstring>
 
 #include "byteorder.h"
+#include "compiler.h"
 
-/*  Read a uint16 from unaligned 8-bit byte-ordered memory. Use this
- *  instead of *(uint16_t*)(8_bit_ptr) or *(uint16_t*)(8_bit_ptr + offset)
+/* Use read_unaligned_* functions instead constructs like:
+ *
+ *   *(uint16_t*)(pointer_to_uint8)
+ *
+ * or
+ *
+ *   *(uint16_t*)(pointer_to_uint8 + offset)
  */
-static inline uint16_t read_unaligned_uint16(const uint8_t *arr)
+
+// Read a uint16 from unaligned 8-bit byte-ordered memory.
+static inline uint16_t read_unaligned_uint16(const uint8_t *arr) noexcept
 {
 	uint16_t val;
 	memcpy(&val, arr, sizeof(val));
 	return val;
 }
 
-/*  Read an array-indexed uint16 from unaligned 8-bit byte-ordered memory.
- *  Use this instead of ((uint16_t*)arr)[idx]
- */
-static inline uint16_t read_unaligned_uint16_at(const uint8_t *arr, const uintptr_t idx)
-{
-	return read_unaligned_uint16(arr + idx * sizeof(uint16_t));
-}
-
-// Write a uint16 to unaligned 8-bit memory using byte-ordering.
-static inline void write_unaligned_uint16(uint8_t *arr, uint16_t val)
-{
-	memcpy(arr, &val, sizeof(val));
-}
-
-// Write an array-indexed uint16 to unaligned 8-bit memory using byte-ordering.
-static inline void write_unaligned_uint16_at(uint8_t *arr, const uintptr_t idx, const uint16_t val)
-{
-	write_unaligned_uint16(arr + idx * sizeof(uint16_t), val);
-}
-
-// Increment a uint16 value held in unaligned 8-bit byte-ordered memory.
-static inline void incr_unaligned_uint16(uint8_t *arr, const uint16_t incr)
-{
-	write_unaligned_uint16(arr, read_unaligned_uint16(arr) + incr);
-}
-
 // Read a uint32 from unaligned 8-bit byte-ordered memory.
-static inline uint32_t read_unaligned_uint32(const uint8_t *arr)
+static inline uint32_t read_unaligned_uint32(const uint8_t *arr) noexcept
 {
 	uint32_t val;
 	memcpy(&val, arr, sizeof(val));
 	return val;
 }
 
-// Read an array-indexed uint32 from unaligned 8-bit byte-ordered memory.
-static inline uint32_t read_unaligned_uint32_at(const uint8_t *arr, const uintptr_t idx)
-{
-	return read_unaligned_uint32(arr + idx * sizeof(uint32_t));
-}
-
-// Write a uint32 to unaligned 8-bit memory using byte-ordering.
-static inline void write_unaligned_uint32(uint8_t *arr, uint32_t val)
-{
-	memcpy(arr, &val, sizeof(val));
-}
-
-// Write an array-indexed uint32 to unaligned 8-bit memory using byte-ordering.
-static inline void write_unaligned_uint32_at(uint8_t *arr, const uintptr_t idx, const uint32_t val)
-{
-	write_unaligned_uint32(arr + idx * sizeof(uint32_t), val);
-}
-
-// Increment a uint32 value held in unaligned 8-bit byte-ordered memory.
-static inline void incr_unaligned_uint32(uint8_t *arr, const uint32_t incr)
-{
-	write_unaligned_uint32(arr, read_unaligned_uint32(arr) + incr);
-}
-
 // Read a uint64 from unaligned 8-bit byte-ordered memory.
-static inline uint64_t read_unaligned_uint64(const uint8_t *arr)
+static inline uint64_t read_unaligned_uint64(const uint8_t *arr) noexcept
 {
 	uint64_t val;
 	memcpy(&val, arr, sizeof(val));
 	return val;
 }
 
-// Write a uint64 to unaligned 8-bit memory using byte-ordering.
-static inline void write_unaligned_uint64(uint8_t *arr, uint64_t val)
+/* Use read_unaligned_*_at functions instead constructs like:
+ *
+ *   ((uint16_t*)pointer_to_uint8)[idx]
+ */
+
+// Read an array-indexed uint16 from unaligned 8-bit byte-ordered memory.
+static inline uint16_t read_unaligned_uint16_at(const uint8_t *arr,
+                                                const uintptr_t idx) noexcept
+{
+	return read_unaligned_uint16(arr + idx * sizeof(uint16_t));
+}
+
+// Read an array-indexed uint32 from unaligned 8-bit byte-ordered memory.
+static inline uint32_t read_unaligned_uint32_at(const uint8_t *arr,
+                                                const uintptr_t idx) noexcept
+{
+	return read_unaligned_uint32(arr + idx * sizeof(uint32_t));
+}
+
+// Read an array-indexed uint64 from unaligned 8-bit byte-ordered memory.
+static inline uint64_t read_unaligned_uint64_at(const uint8_t *arr,
+                                                const uintptr_t idx) noexcept
+{
+	return read_unaligned_uint64(arr + idx * sizeof(uint64_t));
+}
+
+/* Use write_unaligned_* functions instead constructs like:
+ *
+ *   *((uint16_t*)pointer_to_uint8) = val;
+ *
+ * or
+ *
+ *   ((uint16_t*)pointer_to_uint8)[0] = val;
+ */
+
+// Write a uint16 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint16(uint8_t *arr, const uint16_t val) noexcept
 {
 	memcpy(arr, &val, sizeof(val));
+}
+
+// Write a uint32 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint32(uint8_t *arr, const uint32_t val) noexcept
+{
+	memcpy(arr, &val, sizeof(val));
+}
+
+// Write a uint64 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint64(uint8_t *arr, const uint64_t val) noexcept
+{
+	memcpy(arr, &val, sizeof(val));
+}
+
+/* Use write_unaligned_*_at functions instead constructs like:
+ *
+ *   ((uint16_t*)pointer_to_uint8)[idx] = val;
+ */
+
+// Write an array-indexed uint16 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint16_at(uint8_t *arr,
+                                             const uintptr_t idx,
+                                             const uint16_t val) noexcept
+{
+	write_unaligned_uint16(arr + idx * sizeof(uint16_t), val);
+}
+
+// Write an array-indexed uint32 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint32_at(uint8_t *arr,
+                                             const uintptr_t idx,
+                                             const uint32_t val) noexcept
+{
+	write_unaligned_uint32(arr + idx * sizeof(uint32_t), val);
+}
+
+// Write an array-indexed uint64 to unaligned 8-bit memory using byte-ordering.
+static inline void write_unaligned_uint64_at(uint8_t *arr,
+                                             const uintptr_t idx,
+                                             const uint64_t val) noexcept
+{
+	write_unaligned_uint64(arr + idx * sizeof(uint64_t), val);
+}
+
+/* Use add_to_unaligned_* functions instead of constructs like:
+ *
+ *   ((uint16_t*)pointer_to_uint8)[0] += val;
+ */
+
+// Add to an uint16 value held in unaligned 8-bit byte-ordered memory.
+static inline void add_to_unaligned_uint16(uint8_t *arr, const uint16_t val) noexcept
+{
+	write_unaligned_uint16(arr, read_unaligned_uint16(arr) + val);
+}
+
+// Add to an uint32 value held in unaligned 8-bit byte-ordered memory.
+static inline void add_to_unaligned_uint32(uint8_t *arr, const uint32_t val) noexcept
+{
+	write_unaligned_uint32(arr, read_unaligned_uint32(arr) + val);
+}
+
+// Add to an uint64 value held in unaligned 8-bit byte-ordered memory.
+static inline void add_to_unaligned_uint64(uint8_t *arr, const uint64_t val) noexcept
+{
+	write_unaligned_uint64(arr, read_unaligned_uint64(arr) + val);
+}
+
+/* Use inc_unaligned_* functions instead constructs like:
+ *
+ *   ((uint16_t*)pointer_to_uint8)[0] += 1;
+ */
+
+// Increment an uint16 value held in unaligned 8-bit byte-ordered memory.
+static inline void inc_unaligned_uint16(uint8_t *arr) noexcept
+{
+	write_unaligned_uint16(arr, read_unaligned_uint16(arr) + 1);
+}
+
+// Increment an uint32 value held in unaligned 8-bit byte-ordered memory.
+static inline void inc_unaligned_uint32(uint8_t *arr) noexcept
+{
+	write_unaligned_uint32(arr, read_unaligned_uint32(arr) + 1);
+}
+
+// Increment an uint64 value held in unaligned 8-bit byte-ordered memory.
+static inline void inc_unaligned_uint64(uint8_t *arr) noexcept
+{
+	write_unaligned_uint64(arr, read_unaligned_uint64(arr) + 1);
 }
 
 #endif

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -392,6 +392,7 @@
     <ClInclude Include="..\include\keyboard.h" />
     <ClInclude Include="..\include\logging.h" />
     <ClInclude Include="..\include\mem.h" />
+    <ClInclude Include="..\include\mem_host.h" />
     <ClInclude Include="..\include\mem_unaligned.h" />
     <ClInclude Include="..\include\midi.h" />
     <ClInclude Include="..\include\mixer.h" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -392,6 +392,7 @@
     <ClInclude Include="..\include\keyboard.h" />
     <ClInclude Include="..\include\logging.h" />
     <ClInclude Include="..\include\mem.h" />
+    <ClInclude Include="..\include\mem_unaligned.h" />
     <ClInclude Include="..\include\midi.h" />
     <ClInclude Include="..\include\mixer.h" />
     <ClInclude Include="..\include\mouse.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -447,6 +447,9 @@
     <ClInclude Include="..\include\mem.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\mem_unaligned.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\midi.h">
       <Filter>include</Filter>
     </ClInclude>

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -447,6 +447,9 @@
     <ClInclude Include="..\include\mem.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\mem_host.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\mem_unaligned.h">
       <Filter>include</Filter>
     </ClInclude>


### PR DESCRIPTION
This is WIP, I still have few changes to make.

@kcgen please double-check if I updated documentation correctly (or if I haven't introduced any problems).

In the meantime, I would like to discuss naming of functions `host_incr*` and `incr_unaligned_*` - each time I read them I am confused and need to remind myself, that those functions exist to add values.

I think the names picked by upstream (e.g. `host_addw`) are better - these functions are almost exclusively used in the context of CPU emulation, thus resemble naming of assembler instructions: `add` and `inc` (in this context, `inc` increases by 1, and does not add a number).

Therefore I think the renaming of these functions would be beneficial:

- `host_incrw` -> `host_addw` (like it was before)
- `incr_unaligned_uint16` -> `add_to_unaligned_uint16`

And, optionally, adding new family of functions:

- `void host_incw(uint8_t *arr)` - increment (by 1) 16-bit LE word pointed by arr
- `void inc_unaligned_int16(uint8_t *arr)` - increment (by 1) 16-bit word pointed by arr

This might actually lead to compilers giving us slightly better code for cases, where previously we would call `incr_unaligned_uint16(ptr, 1)`.