### PR TITLE
Change mkdir permissions to 775

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -365,7 +365,7 @@ bool localDrive::MakeDir(char * dir) {
 #if defined (WIN32)						/* MS Visual C++ */
 	int temp=mkdir(dirCache.GetExpandName(newdir));
 #else
-	int temp=mkdir(dirCache.GetExpandName(newdir),0700);
+	int temp=mkdir(dirCache.GetExpandName(newdir),0775);
 #endif
 	if (temp==0) dirCache.CacheOut(newdir,true);
 

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -160,7 +160,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 #if defined (WIN32)						/* MS Visual C++ */
 	int temp = mkdir(newdir);
 #else
-	int temp = mkdir(newdir,0700);
+	int temp = mkdir(newdir,0775);
 #endif
 	if (temp==0) {
 		char fakename[CROSS_LEN];


### PR DESCRIPTION
By default on Linux, if you create a directory, it is created with
permissions 775 (rwxrwxr-x). But for some reason if you use
DOSBox to create a directory using folder mounts it creates it
with 700 (rwx------)

On the other hand, if you create a file, it creates with the same
permissions as Linux does (664, or rw-rw-r--).

With this patch, DOSBox-staging creates dirctories with the same
permissions as Linux does