### PR TITLE
Add support for PPC and PPC64LE dynamic recompilers

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -16,13 +16,13 @@ jobs:
           - name: ARMv7 (Debian Buster)
             architecture: armv7
             distribution: buster
-          - name: AArch64 (Ubuntu 18.04)
+          - name: ARMv8 AArch64 (Ubuntu 18.04)
             architecture: aarch64
             distribution: ubuntu18.04
-          - name: LinuxONE (Ubuntu 18.04)
+          - name: s390x (Ubuntu 18.04)
             architecture: s390x
             distribution: ubuntu18.04
-          - name: POWER8 (Ubuntu 18.04)
+          - name: ppc64le (Ubuntu 18.04)
             architecture: ppc64le
             distribution: ubuntu18.04
     steps:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -2,6 +2,7 @@ name: Platform builds
 
 on:
   schedule: [cron: '0 14 * * *']
+  push:
 
 jobs:
   build_linux_platforms:

--- a/configure.ac
+++ b/configure.ac
@@ -284,9 +284,16 @@ case "$host_cpu" in
     c_targetcpu="x86"
     c_unalignedmemory=yes
     ;;
+   powerpc64le*)
+    AC_DEFINE(C_TARGETCPU,PPC64LE)
+    AC_DEFINE(PAGESIZE,65536,Non-4K page size; currently ppc64le only)
+    AC_MSG_RESULT(OpenPOWER)
+    c_targetcpu="ppc64le"
+    c_unalignedmemory=yes
+    ;;
    powerpc*)
     AC_DEFINE(C_TARGETCPU,POWERPC)
-    AC_MSG_RESULT(Power PC)
+    AC_MSG_RESULT(PowerPC)
     c_targetcpu="powerpc"
     c_unalignedmemory=yes
     ;;
@@ -381,8 +388,8 @@ dnl x86 only enable it if dynamic-x86 is disabled.
     else
         AC_MSG_RESULT([no, using dynamic-x86])
     fi
-  else
-    if test x$c_targetcpu = xarm ; then
+  else 
+    if test x$c_targetcpu = xarm -o x$c_targetcpu = xppc64le ; then
       AC_DEFINE(C_DYNREC,1)
       AC_MSG_RESULT(yes)
     else

--- a/configure.ac
+++ b/configure.ac
@@ -389,7 +389,7 @@ dnl x86 only enable it if dynamic-x86 is disabled.
         AC_MSG_RESULT([no, using dynamic-x86])
     fi
   else 
-    if test x$c_targetcpu = xarm -o x$c_targetcpu = xppc64le ; then
+    if test x$c_targetcpu = xarm -o x$c_targetcpu = xppc64le -o x$c_targetcpu = xpowerpc ; then
       AC_DEFINE(C_DYNREC,1)
       AC_MSG_RESULT(yes)
     else

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -155,9 +155,9 @@ static INLINE void FPU_SET_C3(Bitu C){
 	if(C) fpu.sw |= 0x4000;
 }
 
-static INLINE void FPU_LOG_WARN(unsigned tree, bool ea, unsigned group, unsigned sub)
+static INLINE void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr_t sub)
 {
-	LOG(LOG_FPU, LOG_WARN)("ESC %u%s: Unhandled group %u subfunction %u",
+	LOG(LOG_FPU, LOG_WARN)("ESC %u%s: Unhandled group %" PRIuPTR " subfunction %" PRIuPTR,
 	                       tree, ea ? " EA" : "", group, sub);
 }
 

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -85,7 +85,7 @@ enum FPU_Round {
 	ROUND_Chop    = 3
 };
 
-typedef struct {
+typedef struct FPU_rec {
 	FPU_Reg		regs[9];
 	FPU_P_Reg	p_regs[9];
 	FPU_Tag		tags[9];

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -446,10 +446,10 @@ static void cache_closeblock(void) {
 	if (written>block->cache.size) {
 		if (!block->cache.next) {
 			if (written > block->cache.size + CACHE_MAXSIZE)
-				E_Exit("CacheBlock overrun 1 %" sBitfs(d),
+				E_Exit("CacheBlock overrun 1 %" PRIuPTR,
 				       written - block->cache.size);
 		} else {
-			E_Exit("CacheBlock overrun 2 written %" sBitfs(d) " size %" sBitfs(d),
+			E_Exit("CacheBlock overrun 2 written %" PRIuPTR " size %" PRIuPTR,
 			       written, block->cache.size);
 		}
 	} else {

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -155,6 +155,7 @@ static_assert(offsetof(core_dynrec_t, readdata) % sizeof(uint32_t) == 0,
 #define MIPSEL		0x03
 #define ARMV4LE		0x04
 #define ARMV7LE		0x05
+#define POWERPC		0x06
 #define ARMV8LE		0x07
 
 #if C_TARGETCPU == X86_64
@@ -165,8 +166,15 @@ static_assert(offsetof(core_dynrec_t, readdata) % sizeof(uint32_t) == 0,
 #include "core_dynrec/risc_mipsel32.h"
 #elif (C_TARGETCPU == ARMV4LE) || (C_TARGETCPU == ARMV7LE)
 #include "core_dynrec/risc_armv4le.h"
+#elif C_TARGETCPU == POWERPC
+#include "core_dynrec/risc_ppc.h"
 #elif C_TARGETCPU == ARMV8LE
 #include "core_dynrec/risc_armv8le.h"
+#endif
+
+#if !defined(WORDS_BIGENDIAN)
+#define gen_add_LE gen_add
+#define gen_mov_LE_word_to_reg gen_mov_word_to_reg
 #endif
 
 #include "core_dynrec/decoder.h"

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -157,6 +157,7 @@ static_assert(offsetof(core_dynrec_t, readdata) % sizeof(uint32_t) == 0,
 #define ARMV7LE		0x05
 #define POWERPC		0x06
 #define ARMV8LE		0x07
+#define PPC64LE		0x08
 
 #if C_TARGETCPU == X86_64
 #include "core_dynrec/risc_x64.h"
@@ -170,6 +171,8 @@ static_assert(offsetof(core_dynrec_t, readdata) % sizeof(uint32_t) == 0,
 #include "core_dynrec/risc_ppc.h"
 #elif C_TARGETCPU == ARMV8LE
 #include "core_dynrec/risc_armv8le.h"
+#elif C_TARGETCPU == PPC64LE
+#include "core_dynrec/risc_ppc64le.h"
 #endif
 
 #if !defined(WORDS_BIGENDIAN)

--- a/src/cpu/core_dynrec/Makefile.am
+++ b/src/cpu/core_dynrec/Makefile.am
@@ -3,4 +3,4 @@ noinst_HEADERS = cache.h decoder.h decoder_basic.h decoder_opcodes.h \
                  risc_armv4le.h risc_armv4le-common.h \
                  risc_armv4le-o3.h risc_armv4le-thumb.h \
                  risc_armv4le-thumb-iw.h risc_armv4le-thumb-niw.h risc_armv8le.h \
-                 risc_ppc.h
+                 risc_ppc.h risc_ppc64le.h

--- a/src/cpu/core_dynrec/Makefile.am
+++ b/src/cpu/core_dynrec/Makefile.am
@@ -2,4 +2,5 @@ noinst_HEADERS = cache.h decoder.h decoder_basic.h decoder_opcodes.h \
                  dyn_fpu.h operators.h risc_x64.h risc_x86.h risc_mipsel32.h \
                  risc_armv4le.h risc_armv4le-common.h \
                  risc_armv4le-o3.h risc_armv4le-thumb.h \
-                 risc_armv4le-thumb-iw.h risc_armv4le-thumb-niw.h risc_armv8le.h
+                 risc_armv4le-thumb-iw.h risc_armv4le-thumb-niw.h risc_armv8le.h \
+                 risc_ppc.h

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -500,8 +500,13 @@ static void cache_closeblock(void) {
 	Bitu written=(Bitu)(cache.pos-block->cache.start);
 	if (written>block->cache.size) {
 		if (!block->cache.next) {
-			if (written>block->cache.size+CACHE_MAXSIZE) E_Exit("CacheBlock overrun 1 %d",written-block->cache.size);
-		} else E_Exit("CacheBlock overrun 2 written %d size %d",written,block->cache.size);
+			if (written > block->cache.size + CACHE_MAXSIZE)
+				E_Exit("CacheBlock overrun 1 %" PRIuPTR,
+				       written - block->cache.size);
+		} else {
+			E_Exit("CacheBlock overrun 2 written %" PRIuPTR " size %" PRIuPTR,
+			       written, block->cache.size);
+		}
 	} else {
 		Bitu new_size;
 		Bitu left=block->cache.size-written;

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -145,7 +145,7 @@ public:
 		if (host_readb(hostmem+addr)==(Bit8u)val) return;
 		host_writeb(hostmem+addr,val);
 		// see if there's code where we are writing to
-		if (!host_readb(&write_map[addr])) {
+		if (!write_map[addr]) {
 			if (active_blocks) return;		// still some blocks in this page
 			active_count--;
 			if (!active_count) Release();	// delay page releasing until active_count is zero
@@ -162,7 +162,7 @@ public:
 		if (host_readw(hostmem+addr)==(Bit16u)val) return;
 		host_writew(hostmem+addr,val);
 		// see if there's code where we are writing to
-		if (!host_readw(&write_map[addr])) {
+		if (!*(Bit16u*)&write_map[addr]) {
 			if (active_blocks) return;		// still some blocks in this page
 			active_count--;
 			if (!active_count) Release();	// delay page releasing until active_count is zero
@@ -184,7 +184,7 @@ public:
 		if (host_readd(hostmem+addr)==(Bit32u)val) return;
 		host_writed(hostmem+addr,val);
 		// see if there's code where we are writing to
-		if (!host_readd(&write_map[addr])) {
+		if (!*(Bit32u*)&write_map[addr]) {
 			if (active_blocks) return;		// still some blocks in this page
 			active_count--;
 			if (!active_count) Release();	// delay page releasing until active_count is zero
@@ -229,7 +229,7 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
 		// see if there's code where we are writing to
-		if (!host_readw(&write_map[addr])) {
+		if (!*(Bit16u*)&write_map[addr]) {
 			if (!active_blocks) {
 				// no blocks left in this page, still delay the page releasing a bit
 				active_count--;
@@ -258,7 +258,7 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
 		// see if there's code where we are writing to
-		if (!host_readd(&write_map[addr])) {
+		if (!*(Bit32u*)&write_map[addr]) {
 			if (!active_blocks) {
 				// no blocks left in this page, still delay the page releasing a bit
 				active_count--;
@@ -372,11 +372,11 @@ public:
 		return 0;	// none found
 	}
 
-	HostPt GetHostReadPt(Bitu phys_page) { 
+	HostPt GetHostReadPt(Bitu phys_page) {
 		hostmem=old_pagehandler->GetHostReadPt(phys_page);
 		return hostmem;
 	}
-	HostPt GetHostWritePt(Bitu phys_page) { 
+	HostPt GetHostWritePt(Bitu phys_page) {
 		return GetHostReadPt( phys_page );
 	}
 public:
@@ -392,7 +392,7 @@ private:
 
 	Bitu active_blocks;		// the number of cache blocks in this page
 	Bitu active_count;		// delaying parameter to not immediately release a page
-	HostPt hostmem;	
+	HostPt hostmem;
 	Bitu phys_page;
 };
 
@@ -433,13 +433,13 @@ void CacheBlockDynRec::Clear(void) {
 				wherelink = &(*wherelink)->link[ind].next;
 			}
 			// now remove the link
-			if(*wherelink) 
+			if(*wherelink)
 				*wherelink = (*wherelink)->link[ind].next;
 			else {
 				LOG(LOG_CPU,LOG_ERROR)("Cache anomaly. please investigate");
 			}
 		}
-	} else 
+	} else
 		cache_addunusedblock(this);
 	if (crossblock) {
 		// clear out the crossblock (in the page before) as well
@@ -464,7 +464,7 @@ static CacheBlockDynRec * cache_openblock(void) {
 	// check for enough space in this block
 	Bitu size=block->cache.size;
 	CacheBlockDynRec * nextblock=block->cache.next;
-	if (block->page.handler) 
+	if (block->page.handler)
 		block->Clear();
 	// block size must be at least CACHE_MAXSIZE
 	while (size<CACHE_MAXSIZE) {
@@ -473,7 +473,7 @@ static CacheBlockDynRec * cache_openblock(void) {
 		// merge blocks
 		size+=nextblock->cache.size;
 		CacheBlockDynRec * tempblock=nextblock->cache.next;
-		if (nextblock->page.handler) 
+		if (nextblock->page.handler)
 			nextblock->Clear();
 		// block is free now
 		cache_addunusedblock(nextblock);
@@ -500,8 +500,8 @@ static void cache_closeblock(void) {
 	Bitu written=(Bitu)(cache.pos-block->cache.start);
 	if (written>block->cache.size) {
 		if (!block->cache.next) {
-			if (written>block->cache.size+CACHE_MAXSIZE) E_Exit("CacheBlock overrun 1 %d",written-block->cache.size);	
-		} else E_Exit("CacheBlock overrun 2 written %d size %d",written,block->cache.size);	
+			if (written>block->cache.size+CACHE_MAXSIZE) E_Exit("CacheBlock overrun 1 %d",written-block->cache.size);
+		} else E_Exit("CacheBlock overrun 2 written %d size %d",written,block->cache.size);
 	} else {
 		Bitu new_size;
 		Bitu left=block->cache.size-written;
@@ -553,12 +553,14 @@ static INLINE void cache_addq(Bit64u val) {
 
 static void dyn_return(BlockReturn retcode,bool ret_exception);
 static void dyn_run_code(void);
+static void cache_block_before_close(void);
+static void cache_block_closing(Bit8u* block_start,Bitu block_size);
 
 
 /* Define temporary pagesize so the MPROTECT case and the regular case share as much code as possible */
 #if (C_HAVE_MPROTECT)
 #define PAGESIZE_TEMP PAGESIZE
-#else 
+#else
 #define PAGESIZE_TEMP 4096
 #endif
 
@@ -614,18 +616,27 @@ static void cache_init(bool enable) {
 		}
 		// setup the default blocks for block linkage returns
 		cache.pos=&cache_code_link_blocks[0];
+		core_dynrec.runcode=(BlockReturn (*)(Bit8u*))cache.pos;
+		// can use op to PAGESIZE_TEMP-64 bytes
+		dyn_run_code();
+		cache_block_before_close();
+		cache_block_closing(cache_code_link_blocks, cache.pos-cache_code_link_blocks);
+
+		cache.pos=&cache_code_link_blocks[PAGESIZE_TEMP-64];
 		link_blocks[0].cache.start=cache.pos;
 		// link code that returns with a special return code
+		// must be less than 32 bytes
 		dyn_return(BR_Link1,false);
-		cache.pos=&cache_code_link_blocks[32];
+		cache_block_before_close();
+		cache_block_closing(link_blocks[0].cache.start, cache.pos-link_blocks[0].cache.start);
+
+		cache.pos=&cache_code_link_blocks[PAGESIZE_TEMP-32];
 		link_blocks[1].cache.start=cache.pos;
 		// link code that returns with a special return code
+		// must be less than 32 bytes
 		dyn_return(BR_Link2,false);
-
-		cache.pos=&cache_code_link_blocks[64];
-		core_dynrec.runcode=(BlockReturn (*)(Bit8u*))cache.pos;
-//		link_blocks[1].cache.start=cache.pos;
-		dyn_run_code();
+		cache_block_before_close();
+		cache_block_closing(link_blocks[1].cache.start, cache.pos-link_blocks[1].cache.start);
 
 		cache.free_pages=0;
 		cache.last_page=0;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -808,11 +808,14 @@ static void dyn_write_word(HostReg reg_addr,HostReg reg_val,bool dword) {
 	dyn_check_exception(FC_RETOP);
 }
 
-
-
 // effective address calculation helper, op2 has to be present!
 // loads op1 into ea_reg and adds the scaled op2 and the immediate to it
-static void dyn_lea_mem_mem(HostReg ea_reg,void* op1,void* op2,Bitu scale,Bits imm) {
+MAYBE_UNUSED static void dyn_lea_mem_mem(HostReg ea_reg,
+                                         void *op1,
+                                         void *op2,
+                                         Bitu scale,
+                                         Bits imm)
+{
 	if (scale || imm) {
 		if (op1!=NULL) {
 			gen_mov_word_to_reg(ea_reg,op1,true);

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -502,7 +502,6 @@ static INLINE void dyn_set_eip_end(HostReg reg,Bit32u imm=0) {
 	gen_mov_word_to_reg(reg,&reg_eip,true); //get_extend_word will mask off the upper bits
 	//gen_mov_word_to_reg(reg,&reg_eip,decode.big_op);
 	gen_add_imm(reg,(Bit32u)(decode.code-decode.code_start+imm));
-	if (!decode.big_op) gen_extend_word(false,reg);
 }
 
 
@@ -999,10 +998,10 @@ skip_extend_word:
 							// succeeded, use the pointer to avoid code invalidation
 							if (!addseg) {
 								if (!scaled_reg_used) {
-									gen_mov_word_to_reg(ea_reg,(void*)val,true);
+									gen_mov_LE_word_to_reg(ea_reg,(void*)val,true);
 								} else {
 									DYN_LEA_MEM_REG_VAL(ea_reg,NULL,scaled_reg,scale,0);
-									gen_add(ea_reg,(void*)val);
+									gen_add_LE(ea_reg,(void*)val);
 								}
 							} else {
 								if (!scaled_reg_used) {
@@ -1010,7 +1009,7 @@ skip_extend_word:
 								} else {
 									DYN_LEA_SEG_PHYS_REG_VAL(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base),scaled_reg,scale,0);
 								}
-								gen_add(ea_reg,(void*)val);
+								gen_add_LE(ea_reg,(void*)val);
 							}
 							return;
 						}
@@ -1051,10 +1050,10 @@ skip_extend_word:
 						if (!addseg) {
 							if (!scaled_reg_used) {
 								MOV_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-								gen_add(ea_reg,(void*)val);
+								gen_add_LE(ea_reg,(void*)val);
 							} else {
 								DYN_LEA_REG_VAL_REG_VAL(ea_reg,base_reg,scaled_reg,scale,0);
-								gen_add(ea_reg,(void*)val);
+								gen_add_LE(ea_reg,(void*)val);
 							}
 						} else {
 							if (!scaled_reg_used) {
@@ -1063,7 +1062,7 @@ skip_extend_word:
 								DYN_LEA_SEG_PHYS_REG_VAL(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base),scaled_reg,scale,0);
 							}
 							ADD_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-							gen_add(ea_reg,(void*)val);
+							gen_add_LE(ea_reg,(void*)val);
 						}
 						return;
 					}
@@ -1128,11 +1127,11 @@ skip_extend_word:
 				// succeeded, use the pointer to avoid code invalidation
 				if (!addseg) {
 					MOV_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-					gen_add(ea_reg,(void*)val);
+					gen_add_LE(ea_reg,(void*)val);
 				} else {
 					MOV_SEG_PHYS_TO_HOST_REG(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base));
 					ADD_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-					gen_add(ea_reg,(void*)val);
+					gen_add_LE(ea_reg,(void*)val);
 				}
 				return;
 			}

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -250,12 +250,12 @@ static void dyn_prep_word_imm(Bit8u reg) {
 	Bitu val;
 	if (decode.big_op) {
 		if (decode_fetchd_imm(val)) {
-			gen_mov_word_to_reg(FC_OP2,(void*)val,true);
+			gen_mov_LE_word_to_reg(FC_OP2,(void*)val,true);
 			return;
 		}
 	} else {
 		if (decode_fetchw_imm(val)) {
-			gen_mov_word_to_reg(FC_OP2,(void*)val,false);
+			gen_mov_LE_word_to_reg(FC_OP2,(void*)val,false);
 			return;
 		}
 	}
@@ -287,13 +287,13 @@ static void dyn_mov_word_imm(Bit8u reg) {
 	Bitu val;
 	if (decode.big_op) {
 		if (decode_fetchd_imm(val)) {
-			gen_mov_word_to_reg(FC_OP1,(void*)val,true);
+			gen_mov_LE_word_to_reg(FC_OP1,(void*)val,true);
 			MOV_REG_WORD32_FROM_HOST_REG(FC_OP1,reg);
 			return;
 		}
 	} else {
 		if (decode_fetchw_imm(val)) {
-			gen_mov_word_to_reg(FC_OP1,(void*)val,false);
+			gen_mov_LE_word_to_reg(FC_OP1,(void*)val,false);
 			MOV_REG_WORD16_FROM_HOST_REG(FC_OP1,reg);
 			return;
 		}
@@ -330,7 +330,7 @@ static void dyn_mov_byte_direct_al() {
 	if (decode.big_addr) {
 		Bitu val;
 		if (decode_fetchd_imm(val)) {
-			gen_add(FC_ADDR,(void*)val);
+			gen_add_LE(FC_ADDR,(void*)val);
 		} else {
 			gen_add_imm(FC_ADDR,(Bit32u)val);
 		}
@@ -1184,11 +1184,8 @@ static void dyn_ret_near(Bitu bytes) {
 	dyn_reduce_cycles();
 
 	if (decode.big_op) gen_call_function_raw((void*)&dynrec_pop_dword);
-	else {
-		gen_call_function_raw((void*)&dynrec_pop_word);
-		gen_extend_word(false,FC_RETOP);
-	}
-	gen_mov_word_from_reg(FC_RETOP,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),true);
+	else gen_call_function_raw((void*)&dynrec_pop_word);
+	gen_mov_word_from_reg(FC_RETOP,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),decode.big_op);
 
 	if (bytes) gen_add_direct_word(&reg_esp,bytes,true);
 	dyn_return(BR_Normal);

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1149,6 +1149,9 @@ static void dyn_loop(LoopTypes type) {
 		dyn_branchflag_to_reg(BR_Z);
 		branch1=gen_create_branch_on_nonzero(FC_RETOP,true);
 		break;
+	case LOOP_NONE:
+	case LOOP_JCXZ:
+		break;
 	}
 	switch (type) {
 	case LOOP_E:

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -365,7 +365,8 @@ static void dyn_fpu_esc2(){
 	}
 }
 
-static void dyn_fpu_esc3(){
+static void dyn_fpu_esc3()
+{
 	dyn_get_modrm();  
 //	if (decode.modrm.val >= 0xc0) { 
 	if (decode.modrm.mod == 3) {
@@ -374,7 +375,8 @@ static void dyn_fpu_esc3(){
 			switch (decode.modrm.rm) {
 			case 0x00:				//FNENI
 			case 0x01:				//FNDIS
-				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfuntion: %d",decode.modrm.rm);
+				LOG(LOG_FPU, LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %" PRIuPTR,
+				                        decode.modrm.rm);
 				break;
 			case 0x02:				//FNCLEX FCLEX
 				gen_call_function_raw((void*)&FPU_FCLEX);
@@ -387,11 +389,12 @@ static void dyn_fpu_esc3(){
 //				LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
 				break;
 			default:
-				E_Exit("ESC 3:ILLEGAL OPCODE group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+				E_Exit("ESC 3:ILLEGAL OPCODE group %" PRIuPTR " subfunction %" PRIuPTR,
+				       decode.modrm.reg, decode.modrm.rm);
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			FPU_LOG_WARN(3, false, decode.modrm.reg, decode.modrm.rm);
 			break;
 		}
 	} else {
@@ -403,7 +406,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function_RR((void*)&FPU_FLD_I32,FC_OP1,FC_OP2);
 			break;
 		case 0x01:	/* FISTTP */
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			FPU_LOG_WARN(3, true, decode.modrm.reg, decode.modrm.rm);
 			break;
 		case 0x02:	/* FIST */
 			dyn_fill_ea(FC_ADDR); 
@@ -425,7 +428,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function_raw((void*)&FPU_FPOP);
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			FPU_LOG_WARN(3, true, decode.modrm.reg, decode.modrm.rm);
 		}
 	}
 }

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -16,10 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /* ARMv4 (little endian) backend by M-HT (common data/functions) */
-
 
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -16,10 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /* ARMv4/ARMv7 (little endian) backend by M-HT (arm version) */
-
 
 // temporary registers
 #define temp1 HOST_ip

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -16,10 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
-/* ARMv4 (little endian) backend by M-HT (thumb version with data pool, requires -mthumb-interwork switch when compiling dosbox) */
-
+/* ARMv4 (little endian) backend by M-HT (thumb version with data pool)
+ *
+ * Requires -mthumb-interwork switch during compilation.
+ */
 
 // temporary "lo" registers
 #define templo1 HOST_v3

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -16,10 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /* ARMv4 (little endian) backend by M-HT (thumb version with data pool) */
-
 
 // temporary "lo" registers
 #define templo1 HOST_v3

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -16,10 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /* ARMv4 (little endian) backend by M-HT (thumb version) */
-
 
 // temporary "lo" registers
 #define templo1 HOST_v3

--- a/src/cpu/core_dynrec/risc_armv4le.h
+++ b/src/cpu/core_dynrec/risc_armv4le.h
@@ -16,8 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /* ARMv4/ARMv7 (little endian) backend (switcher) by M-HT */
 
 #include "risc_armv4le-common.h"

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -16,10 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
-/* ARMv8 (little endian, 64-bit) backend by M-HT */
-
+/* ARMv8 Aarch64 (little endian, 64-bit) backend by M-HT */
 
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -16,10 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /* MIPS32 (little endian) backend by crazyc */
-
 
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling

--- a/src/cpu/core_dynrec/risc_ppc.h
+++ b/src/cpu/core_dynrec/risc_ppc.h
@@ -1,0 +1,901 @@
+/*
+ *  Copyright (C) 2002-2019  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+// some configuring defines that specify the capabilities of this architecture
+// or aspects of the recompiling
+
+// protect FC_ADDR over function calls if necessaray
+//#define DRC_PROTECT_ADDR_REG
+
+// try to use non-flags generating functions if possible
+#define DRC_FLAGS_INVALIDATION
+// try to replace _simple functions by code
+#define DRC_FLAGS_INVALIDATION_DCODE
+
+// type with the same size as a pointer
+#define DRC_PTR_SIZE_IM Bit32u
+
+// calling convention modifier
+#define DRC_FC /* nothing */
+#define DRC_CALL_CONV /* nothing */
+
+#define DRC_USE_REGS_ADDR
+#define DRC_USE_SEGS_ADDR
+
+#if defined(_CALL_SYSV)
+// disable if your toolchain doesn't provide a _SDA_BASE_ symbol (r13 constant value)
+#define USE_SDA_BASE
+#endif
+
+// register mapping
+enum HostReg {
+	HOST_R0=0,
+	HOST_R1,
+	HOST_R2,
+	HOST_R3,
+	HOST_R4,
+	HOST_R5,
+	HOST_R6,
+	HOST_R7,
+	HOST_R8,
+	HOST_R9,
+	HOST_R10,
+	HOST_R11,
+	HOST_R12,
+	HOST_R13,
+	HOST_R14,
+	HOST_R15,
+	HOST_R16,
+	HOST_R17,
+	HOST_R18,
+	HOST_R19,
+	HOST_R20,
+	HOST_R21,
+	HOST_R22,
+	HOST_R23,
+	HOST_R24,
+	HOST_R25,
+	HOST_R26,  // generic non-volatile (used for inline adc/sbb)
+	HOST_R27,  // points to current CacheBlockDynRec (decode.block)
+	HOST_R28,  // points to fpu
+	HOST_R29,  // FC_ADDR
+	HOST_R30,  // points to Segs
+	HOST_R31,  // points to cpu_regs
+
+	HOST_NONE
+};
+
+static const HostReg RegParams[] = {
+	HOST_R3, HOST_R4, HOST_R5, HOST_R6,
+	HOST_R7, HOST_R8, HOST_R9, HOST_R10
+};
+
+#if C_FPU
+#include "fpu.h"
+extern struct FPU_rec fpu;
+#endif
+
+#if defined(USE_SDA_BASE)
+extern Bit32u _SDA_BASE_[];
+#endif
+
+// register that holds function return values
+#define FC_RETOP HOST_R3
+
+// register used for address calculations, if the ABI does not
+// state that this register is preserved across function calls
+// then define DRC_PROTECT_ADDR_REG above
+#define FC_ADDR HOST_R29
+
+// register that points to Segs[]
+#define FC_SEGS_ADDR HOST_R30
+// register that points to cpu_regs[]
+#define FC_REGS_ADDR HOST_R31
+
+// register that holds the first parameter
+#define FC_OP1 RegParams[0]
+
+// register that holds the second parameter
+#define FC_OP2 RegParams[1]
+
+// special register that holds the third parameter for _R3 calls (byte accessible)
+#define FC_OP3 RegParams[2]
+
+// register that holds byte-accessible temporary values
+#define FC_TMP_BA1 FC_OP2
+
+// register that holds byte-accessible temporary values
+#define FC_TMP_BA2 FC_OP1
+
+// temporary register for LEA
+#define TEMP_REG_DRC HOST_R10
+
+#define IMM(op, regsd, rega, imm)           (((op)<<26)|((regsd)<<21)|((rega)<<16)|             (((Bit32u)(imm))&0xFFFF))
+#define EXT(regsd, rega, regb, op, rc)      (  (31<<26)|((regsd)<<21)|((rega)<<16)|((regb)<<11)|          ((op)<<1)|(rc))
+#define RLW(op, regs, rega, sh, mb, me, rc) (((op)<<26)|((regs) <<21)|((rega)<<16)|  ((sh)<<11)|((mb)<<6)|((me)<<1)|(rc))
+
+#define IMM_OP(op, regsd, rega, imm)           cache_addd(IMM(op, regsd, rega, imm))
+#define EXT_OP(regsd, rega, regb, op, rc)      cache_addd(EXT(regsd, rega, regb, op, rc))
+#define RLW_OP(op, regs, rega, sh, mb, me, rc) cache_addd(RLW(op, regs, rega, sh, mb, me, rc))
+
+// move a full register from reg_src to reg_dst
+static void gen_mov_regs(HostReg reg_dst,HostReg reg_src)
+{
+	if (reg_dst != reg_src)
+		EXT_OP(reg_src,reg_dst,reg_src,444,0); // or dst,src,src (mr dst,src)
+}
+
+// move a 16bit constant value into dest_reg
+// the upper 16bit of the destination register may be destroyed
+static void gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm)
+{
+	IMM_OP(14, dest_reg, 0, imm); // li dest,imm
+}
+
+DRC_PTR_SIZE_IM block_ptr;
+
+// Helper for loading addresses
+static HostReg INLINE gen_addr(Bit32s &addr, HostReg dest)
+{
+	Bit32s off;
+
+	if ((Bit16s)addr == addr)
+		return HOST_R0;
+
+	off = addr - (Bit32s)&Segs;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return FC_SEGS_ADDR;
+	}
+
+	off = addr - (Bit32s)&cpu_regs;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return FC_REGS_ADDR;
+	}
+
+	off = addr - (Bit32s)block_ptr;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return HOST_R27;
+	}
+
+#if C_FPU
+	off = addr - (Bit32s)&fpu;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return HOST_R28;
+	}
+#endif
+
+#if defined(USE_SDA_BASE)
+	off = addr - (Bit32s)_SDA_BASE_;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return HOST_R13;
+	}
+#endif
+
+	IMM_OP(15, dest, 0, (addr+0x8000)>>16); // lis dest, addr@ha
+	addr = (Bit16s)addr;
+	return dest;
+}
+
+// move a 32bit constant value into dest_reg
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm)
+{
+	HostReg ld = gen_addr((Bit32s&)imm, dest_reg);
+	if (imm || ld != dest_reg)
+		IMM_OP(14, dest_reg, ld, imm);   // addi dest_reg, ldr, imm@l
+}
+
+// move a 32bit (dword==true) or 16bit (dword==false) value from memory into dest_reg
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword)
+{
+	Bit32s addr = (Bit32s)data;
+	HostReg ld = gen_addr(addr, dest_reg);
+	IMM_OP(dword ? 32:40, dest_reg, ld, addr);  // lwz/lhz dest, addr@l(ld)
+}
+
+// move a 32bit (dword==true) or 16bit (dword==false) value from host memory into dest_reg
+static void gen_mov_LE_word_to_reg(HostReg dest_reg,void* data, bool dword) {
+	Bit32u addr = (Bit32u)data;
+	gen_mov_dword_to_reg_imm(dest_reg, addr);
+	EXT_OP(dest_reg, 0, dest_reg, dword ? 534 : 790, 0); // lwbrx/lhbrx dest, 0, dest
+}
+
+// move an 8bit constant value into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function does not use FC_OP1/FC_OP2 as dest_reg as these
+// registers might not be directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+	gen_mov_word_to_reg_imm(dest_reg, imm);
+}
+
+// move an 8bit constant value into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function can use FC_OP1/FC_OP2 as dest_reg which are
+// not directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+	gen_mov_word_to_reg_imm(dest_reg, imm);
+}
+
+// move 32bit (dword==true) or 16bit (dword==false) of a register into memory
+static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword)
+{
+	Bit32s addr = (Bit32s)dest;
+	HostReg ld = gen_addr(addr, HOST_R8);
+	IMM_OP(dword ? 36 : 44, src_reg, ld, addr);  // stw/sth src,addr@l(ld)
+}
+
+// move an 8bit value from memory into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function does not use FC_OP1/FC_OP2 as dest_reg as these
+// registers might not be directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data)
+{
+	Bit32s addr = (Bit32s)data;
+	HostReg ld = gen_addr(addr, dest_reg);
+	IMM_OP(34, dest_reg, ld, addr);  // lbz dest,addr@l(ld)
+}
+
+// move an 8bit value from memory into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function can use FC_OP1/FC_OP2 as dest_reg which are
+// not directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+	gen_mov_byte_to_reg_low(dest_reg, data);
+}
+
+// move the lowest 8bit of a register into memory
+static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest)
+{
+	Bit32s addr = (Bit32s)dest;
+	HostReg ld = gen_addr(addr, HOST_R8);
+	IMM_OP(38, src_reg, ld, addr);  // stb src_reg,addr@l(ld)
+}
+
+// convert an 8bit word to a 32bit dword
+// the register is zero-extended (sign==false) or sign-extended (sign==true)
+static void gen_extend_byte(bool sign,HostReg reg)
+{
+	if (sign)
+		EXT_OP(reg, reg, 0, 954, 0); // extsb reg, src
+	else
+		RLW_OP(21, reg, reg, 0, 24, 31, 0); // rlwinm reg, src, 0, 24, 31
+}
+
+// convert a 16bit word to a 32bit dword
+// the register is zero-extended (sign==false) or sign-extended (sign==true)
+static void gen_extend_word(bool sign,HostReg reg)
+{
+	if (sign)
+		EXT_OP(reg, reg, 0, 922, 0); // extsh reg, reg
+	else
+		RLW_OP(21, reg, reg, 0, 16, 31, 0); // rlwinm reg, reg, 0, 16, 31
+}
+
+// add a 32bit value from memory to a full register
+static void gen_add(HostReg reg,void* op)
+{
+	gen_mov_word_to_reg(HOST_R8, op, true); // r8 = *(Bit32u*)op
+	EXT_OP(reg,reg,HOST_R8,266,0);          // add reg,reg,r8
+}
+
+// add a 32bit value from host memory to a full register
+static void gen_add_LE(HostReg reg,void* op)
+{
+	gen_mov_LE_word_to_reg(HOST_R8, op, true); // r8 = op[0]|(op[1]<<8)|(op[2]<<16)|(op[3]<<24);
+	EXT_OP(reg,reg,HOST_R8,266,0);       // add reg,reg,r8
+}
+
+// add a 32bit constant value to a full register
+static void gen_add_imm(HostReg reg,Bit32u imm)
+{
+	if ((Bit16s)imm != (Bit32s)imm)
+		IMM_OP(15, reg, reg, (imm+0x8000)>>16); // addis reg,reg,imm@ha
+	if ((Bit16s)imm)
+		IMM_OP(14, reg, reg, imm);              // addi reg, reg, imm@l
+}
+
+// and a 32bit constant value with a full register
+static void gen_and_imm(HostReg reg,Bit32u imm) {
+	Bits sbit,ebit,tbit,bbit,abit,i;
+
+	// sbit = number of leading 0 bits
+	// ebit = number of trailing 0 bits
+	// tbit = number of total 0 bits
+	// bbit = number of leading 1 bits
+	// abit = number of trailing 1 bits
+
+	if (imm == 0xFFFFFFFF)
+		return;
+
+	if (!imm)
+		return gen_mov_word_to_reg_imm(reg, 0);
+
+	sbit = ebit = tbit = bbit = abit = 0;
+	for (i=0; i < 32; i++)
+	{
+		if (!(imm & (1<<(31-i))))
+		{
+			abit = 0;
+			tbit++;
+			if (sbit == i)
+				sbit++;
+			ebit++;
+		}
+		else
+		{
+			ebit = 0;
+			if (bbit == i)
+				bbit++;
+			abit++;
+		}
+	}
+
+	if (sbit + ebit == tbit)
+	{
+		RLW_OP(21,reg,reg,0,sbit,31-ebit,0); // rlwinm reg,reg,0,sbit,31-ebit
+		return;
+	}
+
+	if (sbit >= 16)
+	{
+		IMM_OP(28,reg,reg,imm); // andi. reg,reg,imm
+		return;
+	}
+	if (ebit >= 16)
+	{
+		IMM_OP(29,reg,reg,imm>>16); // andis. reg,reg,(imm>>16)
+		return;
+	}
+
+	if (bbit + abit == (32 - tbit))
+	{
+		RLW_OP(21,reg,reg,0,32-abit,bbit-1,0); // rlwinm reg,reg,0,32-abit,bbit-1
+		return;
+	}
+
+	IMM_OP(28, reg, HOST_R0, imm); // andi. r0, reg, imm@l
+	IMM_OP(29, reg, reg, imm>16);  // andis. reg, reg, imm@h
+	EXT_OP(reg, reg, HOST_R0, 444, 0); // or reg, reg, r0
+}
+
+// move a 32bit constant value into memory
+static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+	gen_mov_dword_to_reg_imm(HOST_R9, imm);
+	gen_mov_word_from_reg(HOST_R9, dest, 1);
+}
+
+// move an address into memory (assumes address != NULL)
+static void INLINE gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm)
+{
+	block_ptr = 0;
+	gen_mov_dword_to_reg_imm(HOST_R27, imm);
+	// this will be used to look-up the linked blocks
+	block_ptr = imm;
+	gen_mov_word_from_reg(HOST_R27, dest, 1);
+}
+
+// add a 32bit (dword==true) or 16bit (dword==false) constant value to a 32bit memory value
+static void gen_add_direct_word(void* dest,Bit32u imm,bool dword)
+{
+	HostReg ld;
+	Bit32s addr = (Bit32s)dest;
+
+	if (!dword)
+	{
+		imm &= 0xFFFF;
+		addr += 2;
+	}
+
+	if (!imm)
+		return;
+
+	ld = gen_addr(addr, HOST_R8);
+	IMM_OP(dword ? 32 : 40, HOST_R9, ld, addr); // lwz/lhz r9, addr@l(ld)
+	if (dword && (Bit16s)imm != (Bit32s)imm)
+		IMM_OP(15, HOST_R9, HOST_R9, (imm+0x8000)>>16); // addis r9,r9,imm@ha
+	if (!dword || (Bit16s)imm)
+		IMM_OP(14, HOST_R9, HOST_R9, imm);      // addi r9,r9,imm@l
+	IMM_OP(dword ? 36 : 44, HOST_R9, ld, addr); // stw/sth r9, addr@l(ld)
+}
+
+// subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a 32-bit memory value
+static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
+	gen_add_direct_word(dest, -(Bit32s)imm, dword);
+}
+
+// effective address calculation, destination is dest_reg
+// scale_reg is scaled by scale (scale_reg*(2^scale)) and
+// added to dest_reg, then the immediate value is added
+static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm)
+{
+	if (scale)
+	{
+		RLW_OP(21, scale_reg, HOST_R8, scale, 0, 31-scale, 0); // slwi scale_reg,r8,scale
+		scale_reg = HOST_R8;
+	}
+
+	gen_add_imm(dest_reg, imm);
+	EXT_OP(dest_reg, dest_reg, scale_reg, 266, 0); // add dest,dest,scaled
+}
+
+// effective address calculation, destination is dest_reg
+// dest_reg is scaled by scale (dest_reg*(2^scale)),
+// then the immediate value is added
+static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm)
+{
+	if (scale)
+	{
+		RLW_OP(21, dest_reg, dest_reg, scale, 0, 31-scale, 0); // slwi dest,dest,scale
+	}
+
+	gen_add_imm(dest_reg, imm);
+}
+
+// helper function to choose direct or indirect call
+static int INLINE do_gen_call(void *func, Bit32u *pos, bool pad)
+{
+	Bit32s f = (Bit32s)func;
+	Bit32s off = f - (Bit32s)pos;
+
+	// relative branches are limited to +/- ~32MB
+	if (off < 0x02000000 && off >= -0x02000000)
+	{
+		pos[0] = 0x48000001 | (off & 0x03FFFFFC); // bl func
+		if (pad)
+		{
+			pos[1] = 0x4800000C;       // b 12+
+			pos[2] = pos[3] = IMM(24, 0, 0, 0); // nop
+			return 16;
+		}
+		return 4;
+	}
+
+	pos[0] = IMM(15, HOST_R8, 0, f>>16);      // lis r8,imm@h
+	pos[1] = IMM(24, HOST_R8, HOST_R8, f);    // ori r8,r8,imm@l
+	pos[2] = EXT(HOST_R8, 9, 0, 467, 0);      // mtctr r8
+	pos[3] = IMM(19, 0x14, 0, (528<<1)|1); // bctrl
+	return 16;
+}
+
+// generate a call to a parameterless function
+static void INLINE gen_call_function_raw(void * func,bool fastcall=true)
+{
+	cache.pos += do_gen_call(func, (Bit32u*)cache.pos, fastcall);
+}
+
+// generate a call to a function with paramcount parameters
+// note: the parameters are loaded in the architecture specific way
+// using the gen_load_param_ functions below
+static Bit32u INLINE gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false)
+{
+	Bit32u proc_addr=(Bit32u)cache.pos;
+	gen_call_function_raw(func,fastcall);
+	return proc_addr;
+}
+
+// load an immediate value as param'th function parameter
+static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+	gen_mov_dword_to_reg_imm(RegParams[param], imm);
+}
+
+// load an address as param'th function parameter
+static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+	gen_load_param_imm(addr, param);
+}
+
+// load a host-register as param'th function parameter
+static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+	gen_mov_regs(RegParams[param], (HostReg)reg);
+}
+
+// load a value from memory as param'th function parameter
+static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+	gen_mov_word_to_reg(RegParams[param], (void*)mem, true);
+}
+
+// jump to an address pointed at by ptr, offset is in imm
+static void gen_jmp_ptr(void * ptr,Bits imm=0) {
+	gen_mov_word_to_reg(HOST_R8,ptr,true);                // r8 = *(Bit32u*)ptr
+	if ((Bit16s)imm != (Bit32s)imm)
+		IMM_OP(15, HOST_R8, HOST_R8, (imm + 0x8000)>>16); // addis r8, r8, imm@ha
+	IMM_OP(32, HOST_R8, HOST_R8, imm);                    // lwz r8, imm@l(r8)
+	EXT_OP(HOST_R8, 9, 0, 467, 0);                        // mtctr r8
+	IMM_OP(19, 0x14, 0, 528<<1);                       // bctr
+}
+
+// short conditional jump (+-127 bytes) if register is zero
+// the destination is set by gen_fill_branch() later
+static Bit32u gen_create_branch_on_zero(HostReg reg,bool dword)
+{
+	if (!dword)
+		IMM_OP(28,reg,HOST_R0,0xFFFF); // andi. r0,reg,0xFFFF
+	else
+		IMM_OP(11, 0, reg, 0);         // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x0C, 2, 0); // bc 12,CR0[Z] (beq)
+	return ((Bit32u)cache.pos-4);
+}
+
+// short conditional jump (+-127 bytes) if register is nonzero
+// the destination is set by gen_fill_branch() later
+static Bit32u gen_create_branch_on_nonzero(HostReg reg,bool dword)
+{
+	if (!dword)
+		IMM_OP(28,reg,HOST_R0,0xFFFF); // andi. r0,reg,0xFFFF
+	else
+		IMM_OP(11, 0, reg, 0);         // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x04, 2, 0); // bc 4,CR0[Z] (bne)
+	return ((Bit32u)cache.pos-4);
+}
+
+// calculate relative offset and fill it into the location pointed to by data
+static void gen_fill_branch(DRC_PTR_SIZE_IM data)
+{
+#if C_DEBUG
+	Bits len=(Bit32u)cache.pos-data;
+	if (len<0) len=-len;
+	if (len >= 0x8000) LOG_MSG("Big jump %d",len);
+#endif
+
+	((Bit16u*)data)[1] =((Bit32u)cache.pos-data) & 0xFFFC;
+}
+
+
+// conditional jump if register is nonzero
+// for isdword==true the 32bit of the register are tested
+// for isdword==false the lowest 8bit of the register are tested
+static Bit32u gen_create_branch_long_nonzero(HostReg reg,bool dword)
+{
+	if (!dword)
+		IMM_OP(28,reg,HOST_R0,0xFF); // andi. r0,reg,0xFF
+	else
+		IMM_OP(11, 0, reg, 0);       // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x04, 2, 0); // bne
+	return ((Bit32u)cache.pos-4);
+}
+
+// compare 32bit-register against zero and jump if value less/equal than zero
+static Bit32u gen_create_branch_long_leqzero(HostReg reg)
+{
+	IMM_OP(11, 0, reg, 0); // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x04, 1, 0); // ble
+	return ((Bit32u)cache.pos-4);
+}
+
+// calculate long relative offset and fill it into the location pointed to by data
+static void gen_fill_branch_long(Bit32u data) {
+	return gen_fill_branch((DRC_PTR_SIZE_IM)data);
+}
+
+static void cache_block_closing(Bit8u* block_start,Bitu block_size)
+{
+#if defined(__GNUC__)
+	Bit8u* start = (Bit8u*)((Bit32u)block_start & -32);
+
+	while (start < block_start + block_size)
+	{
+		asm volatile("dcbst %y0\n\t icbi %y0" :: "Z"(*start));
+		start += 32;
+	}
+	asm volatile("sync\n\t isync");
+#else
+	#error "Don't know how to flush/invalidate CacheBlock with this compiler"
+#endif
+}
+
+static void cache_block_before_close(void) {}
+
+static void gen_function(void* func)
+{
+	Bit32s off = (Bit32s)func - (Bit32s)cache.pos;
+
+	// relative branches are limited to +/- 32MB
+	if (off < 0x02000000 && off >= -0x02000000) {
+		cache_addd(0x48000000 | (off & 0x03FFFFFC)); // b func
+		return;
+	}
+
+	gen_mov_dword_to_reg_imm(HOST_R8, (Bit32u)func); // r8 = func
+	EXT_OP(HOST_R8, 9, 0, 467, 0);  // mtctr r8
+	IMM_OP(19, 0x14, 0, 528<<1); // bctr
+}
+
+// gen_run_code is assumed to be called exactly once, gen_return_function() jumps back to it
+static void* epilog_addr;
+static Bit8u *getCF_glue;
+static void gen_run_code(void)
+{
+	// prolog
+	IMM_OP(37, HOST_R1, HOST_R1, -256); // stwu sp,-256(sp)
+	EXT_OP(FC_OP1, 9, 0, 467, 0); // mtctr FC_OP1
+	EXT_OP(HOST_R0, 8, 0, 339, 0); // mflr r0
+
+	IMM_OP(47, HOST_R26, HOST_R1, 128); // stmw r26, 128(sp)
+
+	IMM_OP(15, FC_SEGS_ADDR, 0, ((Bit32u)&Segs)>>16);  // lis FC_SEGS_ADDR, Segs@h
+	IMM_OP(24, FC_SEGS_ADDR, FC_SEGS_ADDR, &Segs);     // ori FC_SEGS_ADDR, FC_SEGS_ADDR, Segs@l
+
+	IMM_OP(15, FC_REGS_ADDR, 0, ((Bit32u)&cpu_regs)>>16);  // lis FC_REGS_ADDR, cpu_regs@h
+	IMM_OP(24, FC_REGS_ADDR, FC_REGS_ADDR, &cpu_regs);     // ori FC_REGS_ADDR, FC_REGS_ADDR, cpu_regs@l
+
+#if C_FPU
+	IMM_OP(15, HOST_R28, 0, ((Bit32u)&fpu)>>16);  // lis r28, fpu@h
+	IMM_OP(24, HOST_R28, HOST_R28, &fpu);         // ori r28, r28, fpu@l
+#endif
+
+	IMM_OP(36, HOST_R0, HOST_R1, 256+4); // stw r0,256+4(sp)
+	IMM_OP(19, 0x14, 0, 528<<1);     // bctr
+
+	// epilog
+	epilog_addr = cache.pos;
+	IMM_OP(32, HOST_R0, HOST_R1, 256+4); // lwz r0,256+4(sp)
+	IMM_OP(46, HOST_R26, HOST_R1, 128);   // lmw r26, 128(sp)
+	EXT_OP(HOST_R0, 8, 0, 467, 0);       // mtlr r0
+	IMM_OP(14, HOST_R1, HOST_R1, 256);   // addi sp, sp, 256
+	IMM_OP(19, 0x14, 0, 16<<1);       // blr
+
+	// trampoline to call get_CF()
+	getCF_glue = cache.pos;
+	gen_function((void*)get_CF);
+}
+
+// return from a function
+static void gen_return_function(void)
+{
+	gen_function(epilog_addr);
+}
+
+// called when a call to a function can be replaced by a
+// call to a simpler function
+static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type)
+{
+	Bit32u *op = (Bit32u*)pos;
+	Bit32u *end = op+4;
+
+	switch (flags_type) {
+#if defined(DRC_FLAGS_INVALIDATION_DCODE)
+		// try to avoid function calls but rather directly fill in code
+		case t_ADDb:
+		case t_ADDw:
+		case t_ADDd:
+			*op++ = EXT(FC_RETOP, FC_OP1, FC_OP2, 266, 0); // add FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_ORb:
+		case t_ORw:
+		case t_ORd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 444, 0); // or FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_ADCb:
+		case t_ADCw:
+		case t_ADCd:
+			op[0] = EXT(HOST_R26, FC_OP1, FC_OP2, 266, 0); // r26 = FC_OP1 + FC_OP2
+			op[1] = 0x48000001 | ((getCF_glue-(pos+4)) & 0x03FFFFFC); // bl get_CF
+			op[2] = IMM(12, HOST_R0, FC_RETOP, -1);        // addic r0, FC_RETOP, 0xFFFFFFFF (XER[CA] = !!CF)
+			op[3] = EXT(FC_RETOP, HOST_R26, 0, 202, 0);    // addze; FC_RETOP = r26 + !!CF
+			return;
+		case t_SBBb:
+		case t_SBBw:
+		case t_SBBd:
+			op[0] = EXT(HOST_R26, FC_OP2, FC_OP1, 40, 0);  // r26 = FC_OP1 - FC_OP2
+			op[1] = 0x48000001 | ((getCF_glue-(pos+4)) & 0x03FFFFFC); // bl get_CF
+			op[2] = IMM(8, HOST_R0, FC_RETOP, 0);          // subfic r0, FC_RETOP, 0 (XER[CA] = !CF)
+			op[3] = EXT(FC_RETOP, HOST_R26, 0, 234, 0);    // addme; FC_RETOP = r26 - 1 + !CF
+			return;
+		case t_ANDb:
+		case t_ANDw:
+		case t_ANDd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 28, 0); // and FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_SUBb:
+		case t_SUBw:
+		case t_SUBd:
+			*op++ = EXT(FC_RETOP, FC_OP2, FC_OP1, 40, 0); // subf FC_RETOP, FC_OP2, FC_OP1
+			break;
+		case t_XORb:
+		case t_XORw:
+		case t_XORd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 316, 0); // xor FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_CMPb:
+		case t_CMPw:
+		case t_CMPd:
+		case t_TESTb:
+		case t_TESTw:
+		case t_TESTd:
+			break;
+		case t_INCb:
+		case t_INCw:
+		case t_INCd:
+			*op++ = IMM(14, FC_RETOP, FC_OP1, 1); // addi FC_RETOP, FC_OP1, #1
+			break;
+		case t_DECb:
+		case t_DECw:
+		case t_DECd:
+			*op++ = IMM(14, FC_RETOP, FC_OP1, -1); // addi FC_RETOP, FC_OP1, #-1
+			break;
+		case t_NEGb:
+		case t_NEGw:
+		case t_NEGd:
+			*op++ = EXT(FC_RETOP, FC_OP1, 0, 104, 0); // neg FC_RETOP, FC_OP1
+			break;
+		case t_SHLb:
+		case t_SHLw:
+		case t_SHLd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 24, 0); // slw FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_SHRb:
+		case t_SHRw:
+		case t_SHRd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 536, 0); // srw FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_SARb:
+			*op++ = EXT(FC_OP1, FC_RETOP, 0, 954, 0); // extsb FC_RETOP, FC_OP1
+		case t_SARw:
+			if (flags_type == t_SARw)
+				*op++ = EXT(FC_OP1, FC_RETOP, 0, 922, 0); // extsh FC_RETOP, FC_OP1
+		case t_SARd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 792, 0); // sraw FC_RETOP, FC_OP1, FC_OP2
+			break;
+
+		case t_ROLb:
+			*op++ = RLW(20, FC_OP1, FC_OP1, 24, 0, 7, 0); // rlwimi FC_OP1, FC_OP1, 24, 0, 7
+		case t_ROLw:
+			if (flags_type == t_ROLw)
+				*op++ = RLW(20, FC_OP1, FC_OP1, 16, 0, 15, 0); // rlwimi FC_OP1, FC_OP1, 16, 0, 15
+		case t_ROLd:
+			*op++ = RLW(23, FC_OP1, FC_RETOP, FC_OP2, 0, 31, 0); // rotlw FC_RETOP, FC_OP1, FC_OP2
+			break;
+
+		case t_RORb:
+			*op++ = RLW(20, FC_OP1, FC_OP1, 8, 16, 23, 0); // rlwimi FC_OP1, FC_OP1, 8, 16, 23
+		case t_RORw:
+			if (flags_type == t_RORw)
+				*op++ = RLW(20, FC_OP1, FC_OP1, 16, 0, 15, 0); // rlwimi FC_OP1, FC_OP1, 16, 0, 15
+		case t_RORd:
+			*op++ = IMM(8, FC_OP2, FC_OP2, 32); // subfic FC_OP2, FC_OP2, 32 (FC_OP2 = 32 - FC_OP2)
+			*op++ = RLW(23, FC_OP1, FC_RETOP, FC_OP2, 0, 31, 0); // rotlw FC_RETOP, FC_OP1, FC_OP2
+			break;
+
+		case t_DSHLw: // technically not correct for FC_OP3 > 16
+			*op++ = RLW(20, FC_OP2, FC_RETOP, 16, 0, 15, 0); // rlwimi FC_RETOP, FC_OP2, 16, 0, 5
+			*op++ = RLW(23, FC_RETOP, FC_RETOP, FC_OP3, 0, 31, 0); // rotlw FC_RETOP, FC_RETOP, FC_OP3
+			break;
+		case t_DSHLd:
+			op[0] = EXT(FC_OP1, FC_RETOP, FC_OP3, 24, 0); // slw FC_RETOP, FC_OP1, FC_OP3
+			op[1] = IMM(8, FC_OP3, FC_OP3, 32); // subfic FC_OP3, FC_OP3, 32 (FC_OP3 = 32 - FC_OP3)
+			op[2] = EXT(FC_OP2, FC_OP2, FC_OP3, 536, 0); // srw FC_OP2, FC_OP2, FC_OP3
+			op[3] = EXT(FC_RETOP, FC_RETOP, FC_OP2, 444, 0); // or FC_RETOP, FC_RETOP, FC_OP2
+			return;
+		case t_DSHRw: // technically not correct for FC_OP3 > 16
+			*op++ = RLW(20, FC_OP2, FC_RETOP, 16, 0, 15, 0); // rlwimi FC_RETOP, FC_OP2, 16, 0, 5
+			*op++ = EXT(FC_RETOP, FC_RETOP, FC_OP3, 536, 0); // srw FC_RETOP, FC_RETOP, FC_OP3
+			break;
+		case t_DSHRd:
+			op[0] = EXT(FC_OP1, FC_RETOP, FC_OP3, 536, 0); // srw FC_RETOP, FC_OP1, FC_OP3
+			op[1] = IMM(8, FC_OP3, FC_OP3, 32); // subfic FC_OP3, FC_OP3, 32 (FC_OP32 = 32 - FC_OP3)
+			op[2] = EXT(FC_OP2, FC_OP2, FC_OP3, 24, 0); // slw FC_OP2, FC_OP2, FC_OP3
+			op[3] = EXT(FC_RETOP, FC_RETOP, FC_OP2, 444, 0); // or FC_RETOP, FC_RETOP, FC_OP2
+			return;
+#endif
+		default:
+			do_gen_call(fct_ptr, op, true);
+			return;
+	}
+
+	*op = 0x48000000 + 4*(end-op); // b end
+}
+
+// mov 16bit value from Segs[index] into dest_reg using FC_SEGS_ADDR (index modulo 2 must be zero)
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_seg16_to_reg(HostReg dest_reg,Bitu index) {
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&Segs + index, false);
+}
+
+// mov 32bit value from Segs[index] into dest_reg using FC_SEGS_ADDR (index modulo 4 must be zero)
+static void gen_mov_seg32_to_reg(HostReg dest_reg,Bitu index) {
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&Segs + index, true);
+}
+
+// add a 32bit value from Segs[index] to a full register using FC_SEGS_ADDR (index modulo 4 must be zero)
+static void gen_add_seg32_to_reg(HostReg reg,Bitu index) {
+	gen_add(reg, (Bit8u*)&Segs + index);
+}
+
+// mov 16bit value from cpu_regs[index] into dest_reg using FC_REGS_ADDR (index modulo 2 must be zero)
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_regval16_to_reg(HostReg dest_reg,Bitu index)
+{
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&cpu_regs + index, false);
+}
+
+// mov 32bit value from cpu_regs[index] into dest_reg using FC_REGS_ADDR (index modulo 4 must be zero)
+static void gen_mov_regval32_to_reg(HostReg dest_reg,Bitu index)
+{
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&cpu_regs + index, true);
+}
+
+// move an 8bit value from cpu_regs[index]  into dest_reg using FC_REGS_ADDR
+// the upper 24bit of the destination register can be destroyed
+// this function does not use FC_OP1/FC_OP2 as dest_reg as these
+// registers might not be directly byte-accessible on some architectures
+static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index)
+{
+	gen_mov_byte_to_reg_low(dest_reg, (Bit8u*)&cpu_regs + index);
+}
+
+// move an 8bit value from cpu_regs[index]  into dest_reg using FC_REGS_ADDR
+// the upper 24bit of the destination register can be destroyed
+// this function can use FC_OP1/FC_OP2 as dest_reg which are
+// not directly byte-accessible on some architectures
+static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+	gen_mov_byte_to_reg_low_canuseword(dest_reg, (Bit8u*)&cpu_regs + index);
+}
+
+// move 16bit of register into cpu_regs[index] using FC_REGS_ADDR (index modulo 2 must be zero)
+static void gen_mov_regval16_from_reg(HostReg src_reg,Bitu index)
+{
+	gen_mov_word_from_reg(src_reg, (Bit8u*)&cpu_regs + index, false);
+}
+
+// move 32bit of register into cpu_regs[index] using FC_REGS_ADDR (index modulo 4 must be zero)
+static void gen_mov_regval32_from_reg(HostReg src_reg,Bitu index)
+{
+	gen_mov_word_from_reg(src_reg, (Bit8u*)&cpu_regs + index, true);
+}
+
+// move the lowest 8bit of a register into cpu_regs[index] using FC_REGS_ADDR
+static void gen_mov_regbyte_from_reg_low(HostReg src_reg,Bitu index)
+{
+	gen_mov_byte_from_reg_low(src_reg, (Bit8u*)&cpu_regs + index);
+}
+
+// add a 32bit value from cpu_regs[index] to a full register using FC_REGS_ADDR (index modulo 4 must be zero)
+static void gen_add_regval32_to_reg(HostReg reg,Bitu index)
+{
+	gen_add(reg, (Bit8u*)&cpu_regs + index);
+}
+
+// move 32bit (dword==true) or 16bit (dword==false) of a register into cpu_regs[index] using FC_REGS_ADDR (if dword==true index modulo 4 must be zero) (if dword==false index modulo 2 must be zero)
+static void gen_mov_regword_from_reg(HostReg src_reg,Bitu index,bool dword) {
+	if (dword)
+		gen_mov_regval32_from_reg(src_reg, index);
+	else
+		gen_mov_regval16_from_reg(src_reg, index);
+}
+
+// move a 32bit (dword==true) or 16bit (dword==false) value from cpu_regs[index] into dest_reg using FC_REGS_ADDR (if dword==true index modulo 4 must be zero) (if dword==false index modulo 2 must be zero)
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_regword_to_reg(HostReg dest_reg,Bitu index,bool dword) {
+	if (dword)
+		gen_mov_regval32_to_reg(dest_reg, index);
+	else
+		gen_mov_regval16_to_reg(dest_reg, index);
+}

--- a/src/cpu/core_dynrec/risc_ppc.h
+++ b/src/cpu/core_dynrec/risc_ppc.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+/* PowerPC (big endian, 32-bit) backend */
+
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling
 

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -16,28 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#if(0)
-// Only needed when linting standalone with cpp
-typedef char Bit8s;
-typedef unsigned char Bit8u;
-typedef short Bit16s;
-typedef unsigned short Bit16u;
-typedef long Bit32s;
-typedef unsigned long Bit32u;
-typedef long long Bit64s;
-typedef unsigned long long Bit64u;
-typedef Bit32s Bits;
-typedef Bit32u Bitu;
-#define cache_addd(x) x
-#define INLINE inline
-Bit32u Segs[16];
-Bit32u cpu_regs[16];
-struct cachetype {
-    Bit8u *pos;
-} cache;
-Bit8u *get_CF;
-#endif
-
 // debugging
 #define DEBUG_ME 0
 #define __ASSERT(x,...) \

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -1,0 +1,1152 @@
+/*
+ *  Copyright (C) 2002-2019  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#if(0)
+// Only needed when linting standalone with cpp
+typedef char Bit8s;
+typedef unsigned char Bit8u;
+typedef short Bit16s;
+typedef unsigned short Bit16u;
+typedef long Bit32s;
+typedef unsigned long Bit32u;
+typedef long long Bit64s;
+typedef unsigned long long Bit64u;
+typedef Bit32s Bits;
+typedef Bit32u Bitu;
+#define cache_addd(x) x
+#define INLINE inline
+Bit32u Segs[16];
+Bit32u cpu_regs[16];
+struct cachetype {
+    Bit8u *pos;
+} cache;
+Bit8u *get_CF;
+#endif
+
+// debugging
+#define DEBUG_ME 0
+#define __ASSERT(x,...) \
+    { if(!(x)) { fprintf(stderr, "ASSERT:" __VA_ARGS__); asm("trap\n"); } }
+
+// some configuring defines that specify the capabilities of this architecture
+// or aspects of the recompiling
+
+// protect FC_ADDR over function calls if necessaray
+//#define DRC_PROTECT_ADDR_REG
+
+// try to use non-flags generating functions if possible
+#define DRC_FLAGS_INVALIDATION
+// try to replace _simple functions by code
+#define DRC_FLAGS_INVALIDATION_DCODE
+
+// type with the same size as a pointer
+#define DRC_PTR_SIZE_IM Bit64u
+
+// calling convention modifier
+#define DRC_FC /* nothing */
+#define DRC_CALL_CONV /* nothing */
+
+#define DRC_USE_REGS_ADDR
+#define DRC_USE_SEGS_ADDR
+
+// register mapping
+enum HostReg {
+	HOST_R0=0,
+	HOST_R1,
+	HOST_R2,
+	HOST_R3,
+	HOST_R4,
+	HOST_R5,
+	HOST_R6,
+	HOST_R7,
+	HOST_R8,
+	HOST_R9,
+	HOST_R10,
+	HOST_R11,
+	HOST_R12,  // end of volatile registers. use for CTR calls
+	HOST_R13,
+	HOST_R14,
+	HOST_R15,
+	HOST_R16,
+	HOST_R17,
+	HOST_R18,
+	HOST_R19,
+	HOST_R20,
+	HOST_R21,
+	HOST_R22,
+	HOST_R23,
+	HOST_R24,
+	HOST_R25,
+	HOST_R26,  // generic non-volatile (used for inline adc/sbb)
+	HOST_R27,  // points to current CacheBlockDynRec (decode.block)
+	HOST_R28,  // points to fpu
+	HOST_R29,  // FC_ADDR
+	HOST_R30,  // points to Segs
+	HOST_R31,  // points to cpu_regs
+
+	HOST_NONE
+};
+
+static const HostReg RegParams[] = {
+	HOST_R3, HOST_R4, HOST_R5, HOST_R6,
+	HOST_R7, HOST_R8, HOST_R9, HOST_R10
+};
+
+#if C_FPU
+#include "fpu.h"
+extern FPU_rec fpu;
+#endif
+
+// register that holds function return values
+#define FC_RETOP HOST_R3
+
+// register used for address calculations, if the ABI does not
+// state that this register is preserved across function calls
+// then define DRC_PROTECT_ADDR_REG above
+#define FC_ADDR HOST_R29
+
+// register that points to Segs[]
+#define FC_SEGS_ADDR HOST_R30
+// register that points to cpu_regs[]
+#define FC_REGS_ADDR HOST_R31
+
+// register that holds the first parameter
+#define FC_OP1 RegParams[0]
+
+// register that holds the second parameter
+#define FC_OP2 RegParams[1]
+
+// special register that holds the third parameter for _R3 calls (byte accessible)
+#define FC_OP3 RegParams[2]
+
+// register that holds byte-accessible temporary values
+#define FC_TMP_BA1 FC_OP2
+
+// register that holds byte-accessible temporary values
+#define FC_TMP_BA2 FC_OP1
+
+// temporary register for LEA
+#define TEMP_REG_DRC HOST_R10
+
+// op comes right out of the PowerISA 3.0 documentation
+#define IMM(op, regsd, rega, imm)            (Bit32u)(((op)<<26)|((regsd)<<21)|((rega)<<16)|             (((Bit64u)(imm))&0xFFFF))
+#define DSF(op, regs, rega, ds, bb)          (Bit32u)(((op)<<26)|((regs) <<21)|((rega)<<16)|             (((Bit64u)(ds))&0xFFFC)|(bb))
+#define EXT(regsd, rega, regb, op, rc)       (Bit32u)(  (31<<26)|((regsd)<<21)|((rega)<<16)| ((regb)<<11)|                       ((op)<<1)              |(rc))
+#define RLW(op, regs, rega, sh, mb, me, rc)  (Bit32u)(((op)<<26)|((regs) <<21)|((rega)<<16)|   ((sh)<<11)|((mb   )<<6)|((me)<<1)                        |(rc))
+#define RLD(op, regs, rega, sh, mx, opb, rc) (Bit32u)(((op)<<26)|((regs) <<21)|((rega)<<16)|((sh&31)<<11)|((mx&31)<<6)|(mx&32)  |((opb)<<2)|((sh&32)>>4)|(rc))
+
+#define IMM_OP(op, regsd, rega, imm)                cache_addd(IMM(op, regsd, rega, imm))
+#define DSF_OP(op, regs, rega, ds, bb)              cache_addd(DSF(op, regs, rega, ds, bb))
+#define EXT_OP(regsd, rega, regb, op, rc)           cache_addd(EXT(regsd, rega, regb, op, rc))
+#define RLW_OP(op, regs, rega, sh, mb, me, rc)      cache_addd(RLW(op, regs, rega, sh, mb, me, rc))
+#define RLD_OP(op, regs, rega, sh, mx, opb, rc)     cache_addd(RLD(op, regs, rega, sh, mx, opb, rc))
+
+#define NOP                                         IMM(24, 0, 0, 0) // or 0,0,0
+#define NOP_OP()                                    cache_addd(NOP)
+#define TRAP()                                      cache_addd(EXT(31, 0, 0, 4, 0)) // tw 31,0,0 
+
+// move a full register from reg_src to reg_dst
+// truncate to 32-bits (matches x86_64, which uses 32-bit mov)
+static void gen_mov_regs(HostReg reg_dst,HostReg reg_src)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+// rld* etc. are backwards: rS is first in the encoding
+// always move, even if reg_src == reg_dst, because we may need truncation
+	RLD_OP(30, reg_src, reg_dst, 0, 32, 0, 0); // clrldi dst, src, 32
+}
+
+// move a 16bit constant value into dest_reg
+// the upper 16bit of the destination register may be destroyed
+static void gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	IMM_OP(14, dest_reg, 0, imm); // li dest,imm
+}
+
+DRC_PTR_SIZE_IM block_ptr;
+
+// Helper for loading addresses
+// Emits relevant code to load the upper 48 bits if needed
+static HostReg INLINE gen_addr(Bit64s &addr, HostReg dest)
+{
+	Bit64s off;
+
+	if ((Bit16s)addr == addr)
+		return HOST_R0; // lower to immediate
+
+	off = addr - (Bit64s)&Segs;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return FC_SEGS_ADDR;
+	}
+
+	off = addr - (Bit64s)&cpu_regs;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return FC_REGS_ADDR;
+	}
+
+	off = addr - (Bit64s)block_ptr;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return HOST_R27;
+	}
+
+#if C_FPU
+	off = addr - (Bit64s)&fpu;
+	if ((Bit16s)off == off)
+	{
+		addr = off;
+		return HOST_R28;
+	}
+#endif
+
+	if (addr & 0xffffffff00000000) {
+		IMM_OP(15, dest, 0,    (addr & 0xffff000000000000)>>48); // lis dest, upper
+		if (addr & 0x0000ffff00000000)
+			IMM_OP(24, dest, dest, (addr & 0x0000ffff00000000)>>32); // ori dest, dest, ...
+		RLD_OP(30, dest, dest, 32, 31, 1, 0); // rldicr dest, dest, 32, 31
+		if (addr & 0x00000000ffff0000)
+			IMM_OP(25, dest, dest, (addr & 0x00000000ffff0000)>>16); // oris dest, dest, ...
+	} else
+		IMM_OP(15, dest, 0,    (addr & 0x00000000ffff0000)>>16); // lis dest, lower
+	// watch unexpected sign extension with following instructions
+	if (addr & 0x8000) {
+		// make the displacement in the following instruction 0 for safety
+		IMM_OP(24, dest, dest, (addr & 0x000000000000ffff)    );
+		addr = 0;
+	} else
+		addr = (Bit16s)addr;
+	return dest;
+}
+
+// move a 64bit constant value into dest_reg
+static void gen_mov_qword_to_reg_imm(HostReg dest_reg,Bit64u imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (imm & 0xffffffff00000000) {
+		IMM_OP(15, dest_reg, 0,        (imm & 0xffff000000000000)>>48); // lis dest, upper
+		if (imm & 0x0000ffff00000000)
+			IMM_OP(24, dest_reg, dest_reg, (imm & 0x0000ffff00000000)>>32); // ori dest, dest, ...
+		RLD_OP(30, dest_reg, dest_reg, 32, 31, 1, 0); // rldicr dest, dest, 32, 31
+		if (imm & 0x00000000ffff0000)
+			IMM_OP(25, dest_reg, dest_reg, (imm & 0x00000000ffff0000)>>16); // oris dest, dest, ...
+	} else
+		IMM_OP(15, dest_reg, 0,            (imm & 0x00000000ffff0000)>>16);  // lis dest, lower
+	if (imm & 0xffff)
+		IMM_OP(24, dest_reg, dest_reg,     (imm & 0x000000000000ffff)    ); // ori dest, dest, ...
+}
+
+// move a 32bit constant value into dest_reg
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if ((Bit16s)imm != imm) {
+		IMM_OP(15,         dest_reg, 0,        (imm & 0xffff0000)>>16); // lis
+		if (imm & 0x0000ffff)
+			IMM_OP(24,     dest_reg, dest_reg, (imm & 0x0000ffff)    ); // ori
+	} else {
+		IMM_OP(14,         dest_reg, 0,        imm); // li
+	}
+}
+
+// move a 32bit (dword==true) or 16bit (dword==false) value from memory into dest_reg
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit64s addr = (Bit64s)data;
+	HostReg ld = gen_addr(addr, dest_reg);
+	IMM_OP(dword ? 32:40, dest_reg, ld, addr);  // lwz/lhz dest, addr@l(ld)
+}
+
+// move an 8bit constant value into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function does not use FC_OP1/FC_OP2 as dest_reg as these
+// registers might not be directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg_imm(dest_reg, imm);
+}
+
+// move an 8bit constant value into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function can use FC_OP1/FC_OP2 as dest_reg which are
+// not directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg_imm(dest_reg, imm);
+}
+
+// move 32bit (dword==true) or 16bit (dword==false) of a register into memory
+static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit64s addr = (Bit64s)dest;
+	HostReg ld = gen_addr(addr, HOST_R8);
+	IMM_OP(dword ? 36 : 44, src_reg, ld, addr);  // stw/sth src,addr@l(ld)
+}
+
+// move an 8bit value from memory into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function does not use FC_OP1/FC_OP2 as dest_reg as these
+// registers might not be directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit64s addr = (Bit64s)data;
+	HostReg ld = gen_addr(addr, dest_reg);
+	IMM_OP(34, dest_reg, ld, addr);  // lbz dest,addr@l(ld)
+}
+
+// move an 8bit value from memory into dest_reg
+// the upper 24bit of the destination register can be destroyed
+// this function can use FC_OP1/FC_OP2 as dest_reg which are
+// not directly byte-accessible on some architectures
+static void gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_byte_to_reg_low(dest_reg, data);
+}
+
+// move the lowest 8bit of a register into memory
+static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit64s addr = (Bit64s)dest;
+	HostReg ld = gen_addr(addr, HOST_R8);
+	IMM_OP(38, src_reg, ld, addr);  // stb src_reg,addr@l(ld)
+}
+
+// convert an 8bit word to a 32bit dword
+// the register is zero-extended (sign==false) or sign-extended (sign==true)
+static void gen_extend_byte(bool sign,HostReg reg)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (sign)
+		EXT_OP(reg, reg, 0, 954, 0); // extsb reg, src
+	else
+		RLW_OP(21, reg, reg, 0, 24, 31, 0); // rlwinm reg, src, 0, 24, 31
+}
+
+// convert a 16bit word to a 32bit dword
+// the register is zero-extended (sign==false) or sign-extended (sign==true)
+static void gen_extend_word(bool sign,HostReg reg)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (sign)
+		EXT_OP(reg, reg, 0, 922, 0); // extsh reg, reg
+	else
+		RLW_OP(21, reg, reg, 0, 16, 31, 0); // rlwinm reg, reg, 0, 16, 31
+}
+
+// add a 32bit value from memory to a full register
+static void gen_add(HostReg reg,void* op)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg(HOST_R8, op, true); // r8 = *(Bit32u*)op
+	EXT_OP(reg,reg,HOST_R8,266,0);          // add reg,reg,r8
+}
+
+// add a 32bit constant value to a full register
+static void gen_add_imm(HostReg reg,Bit32u imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+    if (!imm) return;
+	if ((Bit16s)imm != (Bit32s)imm)
+		IMM_OP(15, reg, reg, (imm+0x8000)>>16); // addis reg,reg,imm@ha
+	if ((Bit16s)imm)
+		IMM_OP(14, reg, reg, imm);              // addi reg, reg, imm@l
+}
+
+// and a 32bit constant value with a full register
+static void gen_and_imm(HostReg reg,Bit32u imm) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bits sbit,ebit,tbit,bbit,abit,i;
+
+	// sbit = number of leading 0 bits
+	// ebit = number of trailing 0 bits
+	// tbit = number of total 0 bits
+	// bbit = number of leading 1 bits
+	// abit = number of trailing 1 bits
+
+	if (imm == 0xFFFFFFFF)
+		return;
+
+	if (!imm)
+		return gen_mov_word_to_reg_imm(reg, 0);
+
+	sbit = ebit = tbit = bbit = abit = 0;
+	for (i=0; i < 32; i++)
+	{
+		if (!(imm & (1<<(31-i))))
+		{
+			abit = 0;
+			tbit++;
+			if (sbit == i)
+				sbit++;
+			ebit++;
+		}
+		else
+		{
+			ebit = 0;
+			if (bbit == i)
+				bbit++;
+			abit++;
+		}
+	}
+
+	if (sbit + ebit == tbit)
+	{
+		RLW_OP(21,reg,reg,0,sbit,31-ebit,0); // rlwinm reg,reg,0,sbit,31-ebit
+		return;
+	}
+
+	if (sbit >= 16)
+	{
+		IMM_OP(28,reg,reg,imm); // andi. reg,reg,imm
+		return;
+	}
+	if (ebit >= 16)
+	{
+		IMM_OP(29,reg,reg,imm>>16); // andis. reg,reg,(imm>>16)
+		return;
+	}
+
+	if (bbit + abit == (32 - tbit))
+	{
+		RLW_OP(21,reg,reg,0,32-abit,bbit-1,0); // rlwinm reg,reg,0,32-abit,bbit-1
+		return;
+	}
+
+	IMM_OP(28, reg, HOST_R0, imm); // andi. r0, reg, imm@l
+	IMM_OP(29, reg, reg, imm>16);  // andis. reg, reg, imm@h
+	EXT_OP(reg, reg, HOST_R0, 444, 0); // or reg, reg, r0
+}
+
+// move a 32bit constant value into memory
+static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_dword_to_reg_imm(HOST_R9, imm);
+	gen_mov_word_from_reg(HOST_R9, dest, 1);
+}
+
+// move an address into memory (assumes address != NULL)
+static void INLINE gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	block_ptr = 0;
+	gen_mov_qword_to_reg_imm(HOST_R27, imm);
+	// this will be used to look-up the linked blocks
+	block_ptr = imm;
+	// "gen_mov_qword_from_reg(HOST_R27, dest, 1);"
+	Bit64s addr = (Bit64s)dest;
+	HostReg ld = gen_addr(addr, HOST_R8);
+	DSF_OP(62, HOST_R27, ld, addr, 0); // std r27, addr@l(ld)
+}
+
+// add a 32bit (dword==true) or 16bit (dword==false) constant value to a 32bit memory value
+static void gen_add_direct_word(void* dest,Bit32u imm,bool dword)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	HostReg ld;
+	Bit64s addr = (Bit64s)dest;
+
+	if (!dword)
+	{
+		imm &= 0xFFFF;
+		//addr += 2; // ENDIAN!!!
+	}
+
+	if (!imm)
+		return;
+
+	ld = gen_addr(addr, HOST_R8);
+	IMM_OP(dword ? 32 : 40, HOST_R9, ld, addr); // lwz/lhz r9, addr@l(ld)
+	if (dword && (Bit16s)imm != (Bit32s)imm)
+		IMM_OP(15, HOST_R9, HOST_R9, (imm+0x8000)>>16); // addis r9,r9,imm@ha
+	if (!dword || (Bit16s)imm)
+		IMM_OP(14, HOST_R9, HOST_R9, imm);      // addi r9,r9,imm@l
+	IMM_OP(dword ? 36 : 44, HOST_R9, ld, addr); // stw/sth r9, addr@l(ld)
+}
+
+// subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a 32-bit memory value
+static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_add_direct_word(dest, -(Bit32s)imm, dword);
+}
+
+// effective address calculation, destination is dest_reg
+// scale_reg is scaled by scale (scale_reg*(2^scale)) and
+// added to dest_reg, then the immediate value is added
+static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (scale)
+	{
+		RLW_OP(21, scale_reg, HOST_R8, scale, 0, 31-scale, 0); // slwi scale_reg,r8,scale
+		scale_reg = HOST_R8;
+	}
+
+	gen_add_imm(dest_reg, imm);
+	EXT_OP(dest_reg, dest_reg, scale_reg, 266, 0); // add dest,dest,scaled
+}
+
+// effective address calculation, destination is dest_reg
+// dest_reg is scaled by scale (dest_reg*(2^scale)),
+// then the immediate value is added
+static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (scale)
+	{
+		RLW_OP(21, dest_reg, dest_reg, scale, 0, 31-scale, 0); // slwi dest,dest,scale
+	}
+
+	gen_add_imm(dest_reg, imm);
+}
+
+// helper function to choose direct or indirect call
+static int INLINE do_gen_call(void *func, Bit64u *npos, bool pad)
+{
+	Bit64s f = (Bit64s)func;
+	Bit64s off = f - (Bit64s)npos;
+	Bit32u *pos = (Bit32u *)npos;
+
+	// the length of this branch stanza must match the assumptions in
+	// gen_fill_function_ptr
+
+	// relative branches are limited to +/- ~32MB
+	if (off < 0x02000000 && off >= -0x02000000)
+	{
+		pos[0] = 0x48000001 | (off & 0x03FFFFFC); // bl func // "lis"
+		if (pad)
+		{
+			// keep this patchable
+			pos[1] = NOP; // nop "ori"
+			pos[2] = NOP; // nop "rldicr"
+			pos[3] = NOP; // nop "oris"
+			pos[4] = NOP; // nop "ori"
+			pos[5] = NOP; // nop "mtctr"
+			pos[6] = NOP; // nop "bctrl"
+			return 28;
+		}
+		return 4;
+	}
+
+	// for ppc64le ELF ABI, use r12 to branch
+	pos[0] = IMM(15, HOST_R12, 0,        (f & 0xffff000000000000)>>48); // lis
+	pos[1] = IMM(24, HOST_R12, HOST_R12, (f & 0x0000ffff00000000)>>32); // ori
+	pos[2] = RLD(30, HOST_R12, HOST_R12, 32, 31, 1, 0); // rldicr
+	pos[3] = IMM(25, HOST_R12, HOST_R12, (f & 0x00000000ffff0000)>>16); // oris
+	pos[4] = IMM(24, HOST_R12, HOST_R12, (f & 0x000000000000ffff)    ); // ori
+	pos[5] = EXT(HOST_R12, 9, 0, 467, 0);      // mtctr r12
+	pos[6] = IMM(19, 0x14, 0, (528<<1)|1); // bctrl
+	return 28;
+}
+
+// generate a call to a parameterless function
+static void INLINE gen_call_function_raw(void * func,bool fastcall=true)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	cache.pos += do_gen_call(func, (Bit64u*)cache.pos, fastcall);
+}
+
+// generate a call to a function with paramcount parameters
+// note: the parameters are loaded in the architecture specific way
+// using the gen_load_param_ functions below
+static Bit64u INLINE gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit64u proc_addr=(Bit64u)cache.pos;
+	gen_call_function_raw(func,fastcall);
+	return proc_addr;
+}
+
+// load an immediate value as param'th function parameter
+// these are 32-bit (see risc_x64.h)
+static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_dword_to_reg_imm(RegParams[param], imm);
+}
+
+// load an address as param'th function parameter
+// 32-bit
+static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_load_param_imm(addr, param);
+}
+
+// load a host-register as param'th function parameter
+// 32-bit
+static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_regs(RegParams[param], (HostReg)reg);
+}
+
+// load a value from memory as param'th function parameter
+// 32-bit
+static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg(RegParams[param], (void*)mem, true);
+}
+
+// jump to an address pointed at by ptr, offset is in imm
+// use r12 for ppc64le ABI compatibility
+static void gen_jmp_ptr(void * ptr,Bits imm=0) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	// "gen_mov_qword_to_reg"
+	gen_mov_qword_to_reg_imm(HOST_R12,(Bit64u)ptr);         // r12 = *(Bit64u*)ptr
+	DSF_OP(58, HOST_R12, HOST_R12, 0, 0);
+
+	if ((Bit16s)imm != (Bit32s)imm) {
+		// XXX: this is not tested. I've left it as a quasi-assertion.
+		fprintf(stderr, "large gen_jmp_ptr offset\n");
+		__asm__("trap\n");
+		IMM_OP(15, HOST_R12, HOST_R12, (imm + 0x8000)>>16); // addis r12, r12, imm@ha
+	}
+	DSF_OP(58, HOST_R12, HOST_R12, (Bit16s)imm, 0);                 // ld r12, imm@l(r12)
+	EXT_OP(HOST_R12, 9, 0, 467, 0);                         // mtctr r12
+	IMM_OP(19, 0x14, 0, 528<<1);                            // bctr
+}
+
+// short conditional jump (+-127 bytes) if register is zero
+// the destination is set by gen_fill_branch() later
+static Bit64u gen_create_branch_on_zero(HostReg reg,bool dword)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (!dword)
+		IMM_OP(28,reg,HOST_R0,0xFFFF); // andi. r0,reg,0xFFFF
+	else
+		IMM_OP(11, 0, reg, 0);         // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x0C, 2, 0); // bc 12,CR0[Z] (beq)
+	return ((Bit64u)cache.pos-4);
+}
+
+// short conditional jump (+-127 bytes) if register is nonzero
+// the destination is set by gen_fill_branch() later
+static Bit64u gen_create_branch_on_nonzero(HostReg reg,bool dword)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (!dword)
+		IMM_OP(28,reg,HOST_R0,0xFFFF); // andi. r0,reg,0xFFFF
+	else
+		IMM_OP(11, 0, reg, 0);         // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x04, 2, 0); // bc 4,CR0[Z] (bne)
+	return ((Bit64u)cache.pos-4);
+}
+
+// calculate relative offset and fill it into the location pointed to by data
+static void gen_fill_branch(DRC_PTR_SIZE_IM data)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+#if C_DEBUG
+	Bits len=(Bit64u)cache.pos-data;
+	if (len<0) len=-len;
+	if (len >= 0x8000) LOG_MSG("Big jump %d",len);
+#endif
+
+	// XXX: assert???
+	((Bit16u*)data)[0] =((Bit64u)cache.pos-data) & 0xFFFC; // ENDIAN!!!
+}
+
+
+// conditional jump if register is nonzero
+// for isdword==true the 32bit of the register are tested
+// for isdword==false the lowest 8bit of the register are tested
+static Bit64u gen_create_branch_long_nonzero(HostReg reg,bool dword)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (!dword)
+		IMM_OP(28,reg,HOST_R0,0xFF); // andi. r0,reg,0xFF
+	else
+		IMM_OP(11, 0, reg, 0);       // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x04, 2, 0); // bne
+	return ((Bit64u)cache.pos-4);
+}
+
+// compare 32bit-register against zero and jump if value less/equal than zero
+static Bit64u gen_create_branch_long_leqzero(HostReg reg)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	IMM_OP(11, 0, reg, 0); // cmpwi cr0, reg, 0
+
+	IMM_OP(16, 0x04, 1, 0); // ble
+	return ((Bit64u)cache.pos-4);
+}
+
+// calculate long relative offset and fill it into the location pointed to by data
+static void gen_fill_branch_long(Bit64u data) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	return gen_fill_branch((DRC_PTR_SIZE_IM)data);
+}
+
+static void cache_block_closing(Bit8u* block_start,Bitu block_size)
+{
+	// in the Linux kernel i-cache and d-cache are flushed separately
+	// there's probably a good reason for this ...
+	Bit8u* dstart = (Bit8u*)((Bit64u)block_start & -128);
+	Bit8u* istart = dstart;
+
+	while (dstart < block_start + block_size)
+	{
+		asm volatile("dcbf %y0" :: "Z"(*dstart));
+		// cache line size for POWER8 and POWER9 is 128 bytes
+		dstart += 128;
+	}
+	asm volatile("sync");
+
+	while (istart < block_start + block_size)
+	{
+		asm volatile("icbi %y0" :: "Z"(*istart));
+		istart += 128;
+	}
+	asm volatile("isync");
+}
+
+static void cache_block_before_close(void) {}
+
+static void gen_function(void* func)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit64s off = (Bit64s)func - (Bit64s)cache.pos;
+
+	// relative branches are limited to +/- 32MB
+	if (off < 0x02000000 && off >= -0x02000000) {
+		cache_addd(0x48000000 | (off & 0x03FFFFFC)); // b func
+		return;
+	}
+
+	gen_mov_qword_to_reg_imm(HOST_R12, (Bit64u)func); // r12 = func
+	EXT_OP(HOST_R12, 9, 0, 467, 0);  // mtctr r12
+	IMM_OP(19, 0x14, 0, 528<<1); // bctr
+}
+
+// gen_run_code is assumed to be called exactly once, gen_return_function() jumps back to it
+static void* epilog_addr;
+static Bit8u *getCF_glue;
+static void gen_run_code(void)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	// prolog
+	DSF_OP(62, HOST_R1, HOST_R1, -256, 1); // stdu sp,-256(sp)
+	EXT_OP(FC_OP1, 9, 0, 467, 0); // mtctr FC_OP1
+	EXT_OP(HOST_R0, 8, 0, 339, 0); // mflr r0
+	// we don't clobber any CR fields we need to restore, so no need to save
+
+	// put at the very end of the stack frame, since we have no floats
+	// to save
+	DSF_OP(62, HOST_R26, HOST_R1, 208+0 , 0); // std r26, 208(sp)
+	DSF_OP(62, HOST_R27, HOST_R1, 208+8 , 0); // std r27, 216(sp)
+	DSF_OP(62, HOST_R28, HOST_R1, 208+16, 0); // :
+	DSF_OP(62, HOST_R29, HOST_R1, 208+24, 0); // :
+	DSF_OP(62, HOST_R30, HOST_R1, 208+32, 0); // :
+	DSF_OP(62, HOST_R31, HOST_R1, 208+40, 0); // std r31, 248(sp)
+
+#if C_FPU
+	gen_mov_qword_to_reg_imm(HOST_R28, ((Bit64u)&fpu));
+#endif
+	gen_mov_qword_to_reg_imm(FC_SEGS_ADDR, ((Bit64u)&Segs));
+	gen_mov_qword_to_reg_imm(FC_REGS_ADDR, ((Bit64u)&cpu_regs));
+	DSF_OP(62, HOST_R0,  HOST_R1, 256+16, 0); // std r0,256+16(sp)
+	//TRAP();
+	IMM_OP(19, 0x14, 0, 528<<1);     // bctr
+
+	// epilog
+	epilog_addr = cache.pos;
+	//TRAP();
+	DSF_OP(58, HOST_R0, HOST_R1, 256+16, 0);  // ld r0,256+16(sp)
+	EXT_OP(HOST_R0, 8, 0, 467, 0);            // mtlr r0
+	DSF_OP(58, HOST_R31, HOST_R1, 208+40, 0); // ld r31, 248(sp)
+	DSF_OP(58, HOST_R30, HOST_R1, 208+32, 0); // etc.
+	DSF_OP(58, HOST_R29, HOST_R1, 208+24, 0);
+	DSF_OP(58, HOST_R28, HOST_R1, 208+16, 0);
+	DSF_OP(58, HOST_R27, HOST_R1, 208+8 , 0);
+	DSF_OP(58, HOST_R26, HOST_R1, 208+0 , 0);
+
+	IMM_OP(14, HOST_R1, HOST_R1, 256);   // addi sp, sp, 256
+	IMM_OP(19, 0x14, 0, 16<<1);          // blr
+
+	// trampoline to call get_CF()
+	getCF_glue = cache.pos;
+	gen_function((void*)get_CF);
+}
+
+// return from a function
+static void gen_return_function(void)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_function(epilog_addr);
+}
+
+// called when a call to a function can be replaced by a
+// call to a simpler function
+// these must equal the length of a branch stanza (see
+// do_gen_call)
+static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	Bit32u *op = (Bit32u*)pos;
+
+    // blank the entire old stanza
+    op[1] = NOP;
+    op[2] = NOP;
+    op[3] = NOP;
+    op[4] = NOP;
+    op[5] = NOP;
+    op[6] = NOP;
+
+	switch (flags_type) {
+#if defined(DRC_FLAGS_INVALIDATION_DCODE)
+		// try to avoid function calls but rather directly fill in code
+		case t_ADDb:
+		case t_ADDw:
+		case t_ADDd:
+			*op++ = EXT(FC_RETOP, FC_OP1, FC_OP2, 266, 0); // add FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_ORb:
+		case t_ORw:
+		case t_ORd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 444, 0); // or FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_ADCb:
+		case t_ADCw:
+		case t_ADCd:
+			op[0] = EXT(HOST_R26, FC_OP1, FC_OP2, 266, 0); // r26 = FC_OP1 + FC_OP2
+			op[1] = 0x48000001 | ((getCF_glue-(pos+4)) & 0x03FFFFFC); // bl get_CF
+			op[2] = IMM(12, HOST_R0, FC_RETOP, -1);        // addic r0, FC_RETOP, 0xFFFFFFFF (XER[CA] = !!CF)
+			op[3] = EXT(FC_RETOP, HOST_R26, 0, 202, 0);    // addze; FC_RETOP = r26 + !!CF
+			return;
+		case t_SBBb:
+		case t_SBBw:
+		case t_SBBd:
+			op[0] = EXT(HOST_R26, FC_OP2, FC_OP1, 40, 0);  // r26 = FC_OP1 - FC_OP2
+			op[1] = 0x48000001 | ((getCF_glue-(pos+4)) & 0x03FFFFFC); // bl get_CF
+			op[2] = IMM(8, HOST_R0, FC_RETOP, 0);          // subfic r0, FC_RETOP, 0 (XER[CA] = !CF)
+			op[3] = EXT(FC_RETOP, HOST_R26, 0, 234, 0);    // addme; FC_RETOP = r26 - 1 + !CF
+			return;
+		case t_ANDb:
+		case t_ANDw:
+		case t_ANDd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 28, 0); // and FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_SUBb:
+		case t_SUBw:
+		case t_SUBd:
+			*op++ = EXT(FC_RETOP, FC_OP2, FC_OP1, 40, 0); // subf FC_RETOP, FC_OP2, FC_OP1
+			break;
+		case t_XORb:
+		case t_XORw:
+		case t_XORd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 316, 0); // xor FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_CMPb:
+		case t_CMPw:
+		case t_CMPd:
+		case t_TESTb:
+		case t_TESTw:
+		case t_TESTd:
+			break;
+		case t_INCb:
+		case t_INCw:
+		case t_INCd:
+			*op++ = IMM(14, FC_RETOP, FC_OP1, 1); // addi FC_RETOP, FC_OP1, #1
+			break;
+		case t_DECb:
+		case t_DECw:
+		case t_DECd:
+			*op++ = IMM(14, FC_RETOP, FC_OP1, -1); // addi FC_RETOP, FC_OP1, #-1
+			break;
+		case t_NEGb:
+		case t_NEGw:
+		case t_NEGd:
+			*op++ = EXT(FC_RETOP, FC_OP1, 0, 104, 0); // neg FC_RETOP, FC_OP1
+			break;
+		case t_SHLb:
+		case t_SHLw:
+		case t_SHLd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 24, 0); // slw FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_SHRb:
+		case t_SHRw:
+		case t_SHRd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 536, 0); // srw FC_RETOP, FC_OP1, FC_OP2
+			break;
+		case t_SARb:
+			*op++ = EXT(FC_OP1, FC_RETOP, 0, 954, 0); // extsb FC_RETOP, FC_OP1
+		case t_SARw:
+			if (flags_type == t_SARw)
+				*op++ = EXT(FC_OP1, FC_RETOP, 0, 922, 0); // extsh FC_RETOP, FC_OP1
+		case t_SARd:
+			*op++ = EXT(FC_OP1, FC_RETOP, FC_OP2, 792, 0); // sraw FC_RETOP, FC_OP1, FC_OP2
+			break;
+
+		case t_ROLb:
+			*op++ = RLW(20, FC_OP1, FC_OP1, 24, 0, 7, 0); // rlwimi FC_OP1, FC_OP1, 24, 0, 7
+		case t_ROLw:
+			if (flags_type == t_ROLw)
+				*op++ = RLW(20, FC_OP1, FC_OP1, 16, 0, 15, 0); // rlwimi FC_OP1, FC_OP1, 16, 0, 15
+		case t_ROLd:
+			*op++ = RLW(23, FC_OP1, FC_RETOP, FC_OP2, 0, 31, 0); // rotlw FC_RETOP, FC_OP1, FC_OP2
+			break;
+
+		case t_RORb:
+			*op++ = RLW(20, FC_OP1, FC_OP1, 8, 16, 23, 0); // rlwimi FC_OP1, FC_OP1, 8, 16, 23
+		case t_RORw:
+			if (flags_type == t_RORw)
+				*op++ = RLW(20, FC_OP1, FC_OP1, 16, 0, 15, 0); // rlwimi FC_OP1, FC_OP1, 16, 0, 15
+		case t_RORd:
+			*op++ = IMM(8, FC_OP2, FC_OP2, 32); // subfic FC_OP2, FC_OP2, 32 (FC_OP2 = 32 - FC_OP2)
+			*op++ = RLW(23, FC_OP1, FC_RETOP, FC_OP2, 0, 31, 0); // rotlw FC_RETOP, FC_OP1, FC_OP2
+			break;
+
+		case t_DSHLw: // technically not correct for FC_OP3 > 16
+			*op++ = RLW(20, FC_OP2, FC_RETOP, 16, 0, 15, 0); // rlwimi FC_RETOP, FC_OP2, 16, 0, 5
+			*op++ = RLW(23, FC_RETOP, FC_RETOP, FC_OP3, 0, 31, 0); // rotlw FC_RETOP, FC_RETOP, FC_OP3
+			break;
+		case t_DSHLd:
+			op[0] = EXT(FC_OP1, FC_RETOP, FC_OP3, 24, 0); // slw FC_RETOP, FC_OP1, FC_OP3
+			op[1] = IMM(8, FC_OP3, FC_OP3, 32); // subfic FC_OP3, FC_OP3, 32 (FC_OP3 = 32 - FC_OP3)
+			op[2] = EXT(FC_OP2, FC_OP2, FC_OP3, 536, 0); // srw FC_OP2, FC_OP2, FC_OP3
+			op[3] = EXT(FC_RETOP, FC_RETOP, FC_OP2, 444, 0); // or FC_RETOP, FC_RETOP, FC_OP2
+			return;
+		case t_DSHRw: // technically not correct for FC_OP3 > 16
+			*op++ = RLW(20, FC_OP2, FC_RETOP, 16, 0, 15, 0); // rlwimi FC_RETOP, FC_OP2, 16, 0, 5
+			*op++ = EXT(FC_RETOP, FC_RETOP, FC_OP3, 536, 0); // srw FC_RETOP, FC_RETOP, FC_OP3
+			break;
+		case t_DSHRd:
+			op[0] = EXT(FC_OP1, FC_RETOP, FC_OP3, 536, 0); // srw FC_RETOP, FC_OP1, FC_OP3
+			op[1] = IMM(8, FC_OP3, FC_OP3, 32); // subfic FC_OP3, FC_OP3, 32 (FC_OP32 = 32 - FC_OP3)
+			op[2] = EXT(FC_OP2, FC_OP2, FC_OP3, 24, 0); // slw FC_OP2, FC_OP2, FC_OP3
+			op[3] = EXT(FC_RETOP, FC_RETOP, FC_OP2, 444, 0); // or FC_RETOP, FC_RETOP, FC_OP2
+			return;
+#endif
+		default:
+			do_gen_call(fct_ptr, (Bit64u*)op, true);
+			return;
+	}
+}
+
+// mov 16bit value from Segs[index] into dest_reg using FC_SEGS_ADDR (index modulo 2 must be zero)
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_seg16_to_reg(HostReg dest_reg,Bitu index) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&Segs + index, false);
+}
+
+// mov 32bit value from Segs[index] into dest_reg using FC_SEGS_ADDR (index modulo 4 must be zero)
+static void gen_mov_seg32_to_reg(HostReg dest_reg,Bitu index) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&Segs + index, true);
+}
+
+// add a 32bit value from Segs[index] to a full register using FC_SEGS_ADDR (index modulo 4 must be zero)
+static void gen_add_seg32_to_reg(HostReg reg,Bitu index) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_add(reg, (Bit8u*)&Segs + index);
+}
+
+// mov 16bit value from cpu_regs[index] into dest_reg using FC_REGS_ADDR (index modulo 2 must be zero)
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_regval16_to_reg(HostReg dest_reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&cpu_regs + index, false);
+}
+
+// mov 32bit value from cpu_regs[index] into dest_reg using FC_REGS_ADDR (index modulo 4 must be zero)
+static void gen_mov_regval32_to_reg(HostReg dest_reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_to_reg(dest_reg, (Bit8u*)&cpu_regs + index, true);
+}
+
+// move an 8bit value from cpu_regs[index]  into dest_reg using FC_REGS_ADDR
+// the upper 24bit of the destination register can be destroyed
+// this function does not use FC_OP1/FC_OP2 as dest_reg as these
+// registers might not be directly byte-accessible on some architectures
+static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_byte_to_reg_low(dest_reg, (Bit8u*)&cpu_regs + index);
+}
+
+// move an 8bit value from cpu_regs[index]  into dest_reg using FC_REGS_ADDR
+// the upper 24bit of the destination register can be destroyed
+// this function can use FC_OP1/FC_OP2 as dest_reg which are
+// not directly byte-accessible on some architectures
+static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_byte_to_reg_low_canuseword(dest_reg, (Bit8u*)&cpu_regs + index);
+}
+
+// move 16bit of register into cpu_regs[index] using FC_REGS_ADDR (index modulo 2 must be zero)
+static void gen_mov_regval16_from_reg(HostReg src_reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_from_reg(src_reg, (Bit8u*)&cpu_regs + index, false);
+}
+
+// move 32bit of register into cpu_regs[index] using FC_REGS_ADDR (index modulo 4 must be zero)
+static void gen_mov_regval32_from_reg(HostReg src_reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_word_from_reg(src_reg, (Bit8u*)&cpu_regs + index, true);
+}
+
+// move the lowest 8bit of a register into cpu_regs[index] using FC_REGS_ADDR
+static void gen_mov_regbyte_from_reg_low(HostReg src_reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_mov_byte_from_reg_low(src_reg, (Bit8u*)&cpu_regs + index);
+}
+
+// add a 32bit value from cpu_regs[index] to a full register using FC_REGS_ADDR (index modulo 4 must be zero)
+static void gen_add_regval32_to_reg(HostReg reg,Bitu index)
+{
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	gen_add(reg, (Bit8u*)&cpu_regs + index);
+}
+
+// move 32bit (dword==true) or 16bit (dword==false) of a register into cpu_regs[index] using FC_REGS_ADDR (if dword==true index modulo 4 must be zero) (if dword==false index modulo 2 must be zero)
+static void gen_mov_regword_from_reg(HostReg src_reg,Bitu index,bool dword) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (dword)
+		gen_mov_regval32_from_reg(src_reg, index);
+	else
+		gen_mov_regval16_from_reg(src_reg, index);
+}
+
+// move a 32bit (dword==true) or 16bit (dword==false) value from cpu_regs[index] into dest_reg using FC_REGS_ADDR (if dword==true index modulo 4 must be zero) (if dword==false index modulo 2 must be zero)
+// 16bit moves may destroy the upper 16bit of the destination register
+static void gen_mov_regword_to_reg(HostReg dest_reg,Bitu index,bool dword) {
+#if DEBUG_ME
+fprintf(stderr, "ppc64le: %s\n", __FUNCTION__);
+#endif
+	if (dword)
+		gen_mov_regval32_to_reg(dest_reg, index);
+	else
+		gen_mov_regval16_to_reg(dest_reg, index);
+}

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -585,7 +585,7 @@ static void gen_jmp_ptr(void *ptr, Bits imm = 0)
 	DSF_OP(58, HOST_R12, HOST_R12, 0, 0);
 
 	if ((Bit16s)imm != (Bit32s)imm) {
-		// XXX: this is not tested. I've left it as a quasi-assertion.
+		// FIXME: this is not tested. I've left it as a quasi-assertion.
 		fprintf(stderr, "large gen_jmp_ptr offset\n");
 		__asm__("trap\n");
 		IMM_OP(15, HOST_R12, HOST_R12, (imm + 0x8000)>>16); // addis r12, r12, imm@ha
@@ -630,7 +630,7 @@ static void gen_fill_branch(DRC_PTR_SIZE_IM data)
 	if (len >= 0x8000) LOG_MSG("Big jump %d",len);
 #endif
 
-	// XXX: assert???
+	// FIXME: assert???
 	((Bit16u*)data)[0] =((Bit64u)cache.pos-data) & 0xFFFC; // ENDIAN!!!
 }
 

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+/* PPC64LE/OpenPOWER (little endian) backend */
+
 // debugging
 #define DEBUG_ME 0
 #define __ASSERT(x,...) \

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -235,9 +235,9 @@ static void gen_mov_qword_to_reg_imm(HostReg dest_reg, Bit64u imm)
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg, Bit32u imm)
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg, uint32_t imm)
 {
-	if ((Bit16s)imm != imm) {
+	if (static_cast<int16_t>(imm) != static_cast<int32_t>(imm)) {
 		IMM_OP(15, dest_reg, 0, (imm & 0xffff0000) >> 16); // lis
 		if (imm & 0x0000ffff)
 			IMM_OP(24, dest_reg, dest_reg, (imm & 0x0000ffff)); // ori

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -45,7 +45,7 @@
 
 // register mapping
 enum HostReg {
-	HOST_R0=0,
+	HOST_R0 = 0,
 	HOST_R1,
 	HOST_R2,
 	HOST_R3,
@@ -57,7 +57,7 @@ enum HostReg {
 	HOST_R9,
 	HOST_R10,
 	HOST_R11,
-	HOST_R12,  // end of volatile registers. use for CTR calls
+	HOST_R12, // end of volatile registers. use for CTR calls
 	HOST_R13,
 	HOST_R14,
 	HOST_R15,
@@ -71,12 +71,12 @@ enum HostReg {
 	HOST_R23,
 	HOST_R24,
 	HOST_R25,
-	HOST_R26,  // generic non-volatile (used for inline adc/sbb)
-	HOST_R27,  // points to current CacheBlockDynRec (decode.block)
-	HOST_R28,  // points to fpu
-	HOST_R29,  // FC_ADDR
-	HOST_R30,  // points to Segs
-	HOST_R31,  // points to cpu_regs
+	HOST_R26, // generic non-volatile (used for inline adc/sbb)
+	HOST_R27, // points to current CacheBlockDynRec (decode.block)
+	HOST_R28, // points to fpu
+	HOST_R29, // FC_ADDR
+	HOST_R30, // points to Segs
+	HOST_R31, // points to cpu_regs
 
 	HOST_NONE
 };
@@ -197,21 +197,23 @@ static HostReg INLINE gen_addr(Bit64s &addr, HostReg dest)
 #endif
 
 	if (addr & 0xffffffff00000000) {
-		IMM_OP(15, dest, 0,    (addr & 0xffff000000000000)>>48); // lis dest, upper
+		IMM_OP(15, dest, 0, (addr & 0xffff000000000000) >> 48); // lis dest, upper
 		if (addr & 0x0000ffff00000000)
-			IMM_OP(24, dest, dest, (addr & 0x0000ffff00000000)>>32); // ori dest, dest, ...
+			IMM_OP(24, dest, dest, (addr & 0x0000ffff00000000) >> 32); // ori dest, dest, ...
 		RLD_OP(30, dest, dest, 32, 31, 1, 0); // rldicr dest, dest, 32, 31
 		if (addr & 0x00000000ffff0000)
-			IMM_OP(25, dest, dest, (addr & 0x00000000ffff0000)>>16); // oris dest, dest, ...
-	} else
-		IMM_OP(15, dest, 0,    (addr & 0x00000000ffff0000)>>16); // lis dest, lower
+			IMM_OP(25, dest, dest, (addr & 0x00000000ffff0000) >> 16); // oris dest, dest, ...
+	} else {
+		IMM_OP(15, dest, 0, (addr & 0x00000000ffff0000) >> 16); // lis dest, lower
+	}
 	// watch unexpected sign extension with following instructions
 	if (addr & 0x8000) {
 		// make the displacement in the following instruction 0 for safety
-		IMM_OP(24, dest, dest, (addr & 0x000000000000ffff)    );
+		IMM_OP(24, dest, dest, (addr & 0x000000000000ffff));
 		addr = 0;
-	} else
+	} else {
 		addr = (Bit16s)addr;
+	}
 	return dest;
 }
 
@@ -219,27 +221,28 @@ static HostReg INLINE gen_addr(Bit64s &addr, HostReg dest)
 static void gen_mov_qword_to_reg_imm(HostReg dest_reg, Bit64u imm)
 {
 	if (imm & 0xffffffff00000000) {
-		IMM_OP(15, dest_reg, 0,        (imm & 0xffff000000000000)>>48); // lis dest, upper
+		IMM_OP(15, dest_reg, 0, (imm & 0xffff000000000000) >> 48); // lis dest, upper
 		if (imm & 0x0000ffff00000000)
-			IMM_OP(24, dest_reg, dest_reg, (imm & 0x0000ffff00000000)>>32); // ori dest, dest, ...
+			IMM_OP(24, dest_reg, dest_reg, (imm & 0x0000ffff00000000) >> 32); // ori dest, dest, ...
 		RLD_OP(30, dest_reg, dest_reg, 32, 31, 1, 0); // rldicr dest, dest, 32, 31
 		if (imm & 0x00000000ffff0000)
-			IMM_OP(25, dest_reg, dest_reg, (imm & 0x00000000ffff0000)>>16); // oris dest, dest, ...
-	} else
-		IMM_OP(15, dest_reg, 0,            (imm & 0x00000000ffff0000)>>16);  // lis dest, lower
+			IMM_OP(25, dest_reg, dest_reg, (imm & 0x00000000ffff0000) >> 16); // oris dest, dest, ...
+	} else {
+		IMM_OP(15, dest_reg, 0, (imm & 0x00000000ffff0000) >> 16); // lis dest, lower
+	}
 	if (imm & 0xffff)
-		IMM_OP(24, dest_reg, dest_reg,     (imm & 0x000000000000ffff)    ); // ori dest, dest, ...
+		IMM_OP(24, dest_reg, dest_reg, (imm & 0x000000000000ffff)); // ori dest, dest, ...
 }
 
 // move a 32bit constant value into dest_reg
 static void gen_mov_dword_to_reg_imm(HostReg dest_reg, Bit32u imm)
 {
 	if ((Bit16s)imm != imm) {
-		IMM_OP(15,         dest_reg, 0,        (imm & 0xffff0000)>>16); // lis
+		IMM_OP(15, dest_reg, 0, (imm & 0xffff0000) >> 16); // lis
 		if (imm & 0x0000ffff)
-			IMM_OP(24,     dest_reg, dest_reg, (imm & 0x0000ffff)    ); // ori
+			IMM_OP(24, dest_reg, dest_reg, (imm & 0x0000ffff)); // ori
 	} else {
-		IMM_OP(14,         dest_reg, 0,        imm); // li
+		IMM_OP(14, dest_reg, 0, imm); // li
 	}
 }
 
@@ -764,13 +767,13 @@ static void gen_fill_function_ptr(Bit8u *pos, void *fct_ptr, Bitu flags_type)
 {
 	Bit32u *op = (Bit32u*)pos;
 
-    // blank the entire old stanza
-    op[1] = NOP;
-    op[2] = NOP;
-    op[3] = NOP;
-    op[4] = NOP;
-    op[5] = NOP;
-    op[6] = NOP;
+	// blank the entire old stanza
+	op[1] = NOP;
+	op[2] = NOP;
+	op[3] = NOP;
+	op[4] = NOP;
+	op[5] = NOP;
+	op[6] = NOP;
 
 	switch (flags_type) {
 #if defined(DRC_FLAGS_INVALIDATION_DCODE)

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+/* x86_64/x64/AMD64 (little endian) backend */
 
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling

--- a/src/cpu/core_dynrec/risc_x86.h
+++ b/src/cpu/core_dynrec/risc_x86.h
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+/* x86_64/AMD64 (little endian, 32-bit) backend */
 
 // some configuring defines that specify the capabilities of this architecture
 // or aspects of the recompiling


### PR DESCRIPTION
This PR takes over from #427 

Same initial work from jmarsh + other patches, that were posted in Vogons thread to bring PPC64LE online + tiny change to enable dynrec on PPC by default.