### PR TITLE
Add PIT timer control in mode 3 with a counter of 1 (Paratrooper PC speaker fix)

### DIFF
--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -221,7 +221,13 @@ static void write_latch(Bitu port,Bitu val,Bitu /*iolen*/) {
 		if (p->write_latch == 0) {
 			if (p->bcd == false) p->cntr = 0x10000;
 			else p->cntr=9999;
-		} else p->cntr = p->write_latch;
+		}
+		// square wave, count by 2
+		else if (p->write_latch == 1 && p->mode == 3)
+			// counter==1 and mode==3 makes a low frequency buzz (Paratrooper)
+			p->cntr = p->bcd ? 10000 : 0x10001;
+		else
+			p->cntr = p->write_latch;
 
 		if ((!p->new_mode) && (p->mode == 2) && (counter == 0)) {
 			// In mode 2 writing another value has no direct effect on the count


### PR DESCRIPTION
PC speaker/Timer: Mode 3 (square wave) and counter == 1 generates a low frequency buzz. Fixes Paratrooper. (Original commit message). 

Thanks to the DOSBox-X team:

- @rderooy for the information and pointer to the change
- @joncampbell123 for the fix

**Ref**: https://github.com/joncampbell123/dosbox-x/issues/1492

I believe this is quite Paratrooper-specific, although it's nice to have functionality in this "gap" if any other software happens to set this specific mode 3, counter 1 PIT state.

Here it is in action, combined with the DC-zero'ing (near the start):

![Screenshot at 2020-06-17 17-23-15](https://user-images.githubusercontent.com/1557255/84964036-ec6c8b00-b0bf-11ea-90b2-48900d2a16e5.png)

[trooper_000.flac.gz](https://github.com/dosbox-staging/dosbox-staging/files/4795642/trooper_000.flac.gz)