### PR TITLE
Envelope initial channel audio to mitigate clicks and pops

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,6 +13,7 @@ dosbox.h \
 dos_inc.h \
 dos_system.h \
 drives.h \
+envelope.h \
 fpu.h \
 hardware.h \
 inout.h \

--- a/include/envelope.h
+++ b/include/envelope.h
@@ -1,0 +1,110 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *  Copyright (c) 2019-2020  Kevin R Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_ENVELOPE_H
+#define DOSBOX_ENVELOPE_H
+
+/*  Audio Envelope
+ *  --------------
+ *  This class applies a step-wise earned-volume envelope with a fixed
+ * expiration period. The envelope is "earned" in the sense that the edge is
+ * expanded when a sample meets or exceeds it. This helps minimize the
+ * impact of unnatural waveforms that can whipsaw wildly, such as those
+ * generated from digital machine noise or binary data.
+ *
+ *  Use
+ *  ---
+ *  1. Call Update(..) to provide the Envelope with information about the audio
+ *     stream: the frame rate (in Hz), peak possible sample amplitude (from zero
+ *     to 2^16 -1), the expansion phase duration in milliseconds that represents
+ *     the shortest possible time the envelope will be expanded from zero to
+ *     peak volume if the samples "earn" it (reasonable values are <30ms), and
+ *     the desired expiration period in seconds (reasonable values are <60s).
+ *
+ *  2. Call Process(..), passing it samples in their natural 16-bit signed
+ *     form. Note: when the envelope is fully expanded or has expired, this
+ *     function becomes the a null-call, eliminating further overhead.
+ *     To be clear - there are no runtime checks you need to perform to
+ *     determine if you should use the envelope or not.  It simply goes
+ *     dormant when done.
+ *
+ *  3. Call Reactivate() to perform another round of enveloping. Note that the
+ *     characteristics about the envelope provided in the Update() call are
+ *     retained and do not need to be provided after a reactivating.
+ *
+ *  By default, the evenlope does nothing; it needs to be Update()'d for it to
+ *  do work.
+ */
+
+#include <cstdint>
+#include <functional>
+
+#include "compiler.h"
+
+class Envelope {
+public:
+	Envelope(const char* name);
+
+	void Process(bool is_stereo,
+	             bool is_interpolated,
+	             intptr_t prev[],
+	             intptr_t next[]);
+
+	void Update(uint32_t frame_rate,
+	            uint32_t peak_amplitude,
+	            uint8_t expansion_phase_ms,
+	            uint8_t expire_after_seconds);
+
+	void Reactivate();
+
+private:
+	Envelope(const Envelope &) = delete;            // prevent copying
+	Envelope &operator=(const Envelope &) = delete; // prevent assignment
+
+	bool ClampSample(intptr_t &sample, intptr_t next_edge);
+
+	void Apply(bool is_stereo,
+	           bool is_interpolated,
+	           intptr_t prev[],
+	           intptr_t next[]);
+
+	void Skip(MAYBE_UNUSED bool is_stereo,
+	          MAYBE_UNUSED bool is_interpolated,
+	          MAYBE_UNUSED intptr_t prev[],
+	          MAYBE_UNUSED intptr_t next[])
+	{}
+
+	using process_f = std::function<void(Envelope &, bool, bool, intptr_t[], intptr_t[])>;
+	process_f process = &Envelope::Apply;
+
+	const char* channel_name = nullptr;
+	uint32_t expire_after_frames = 0u; // Stop enveloping when this many
+	                                   // frames have been processed.
+	uint32_t frames_done = 0u; // A tally of processed frames.
+	uint16_t edge = 0u; // The current edge of the envelope, which
+	                    // increments outward when samples press against it.
+	uint16_t edge_increment = 0u; // The amount the edge grows by once a
+	                              // sample is found to be beyond it.
+	uint16_t edge_limit = 0u; // Stop enveloping when the current edge is
+	                          // hits or exceeds this limit.
+};
+
+#endif

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -24,7 +24,9 @@
 #include "dosbox.h"
 #endif
 
-typedef void (*MIXER_MixHandler)(Bit8u * sampdate,Bit32u len);
+#include "envelope.h"
+
+typedef void (*MIXER_MixHandler)(Bit8u *sampdate, Bit32u len);
 typedef void (*MIXER_Handler)(Bitu len);
 
 enum BlahModes {
@@ -91,6 +93,7 @@ public:
 
 private:
 	MixerChannel();
+	Envelope envelope;
 	MIXER_Handler handler = nullptr;
 	Bitu freq_add = 0u; // This gets added the frequency counter each mixer
 	                    // step

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -53,6 +53,7 @@ public:
 	void MapChannels(Bit8u _left, Bit8u _right);
 	void UpdateVolume();
 	void SetFreq(Bitu _freq);
+	void SetPeakAmplitude(uint32_t peak);
 	void Mix(Bitu _needed);
 	void AddSilence(); // Fill up until needed
 
@@ -104,6 +105,12 @@ private:
 	uint32_t sample_rate = 0u;
 	int32_t volmul[2] = {0};
 	float scale[2] = {0.0f, 0.0f};
+
+	// Defines the peak sample amplitude we can expect in this channel.
+	// Default to signed 16bit max, however channel's that know their own
+	// peak, like the PCSpeaker, should update it with: SetPeakAmplitude()
+	uint32_t peak_amplitude = MAX_AUDIO;
+
 	uint8_t channel_map[2] = {0u, 0u}; // Output channel mapping
 	bool interpolate = false;
 	bool last_samples_were_stereo = false;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -129,7 +129,7 @@ private:
 	bool installed;
 	char m_name[32];
 public:
-	MixerObject():installed(false){};
+	MixerObject() : installed(false) {}
 	MixerChannel* Install(MIXER_Handler handler,Bitu freq,const char * name);
 	~MixerObject();
 };

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -101,6 +101,7 @@ private:
 	// Simple way to lower the impact of DC offset. if MIXER_UPRAMP_STEPS is >0.
 	// Still work in progress and thus disabled for now.
 	Bits offset[2] = {0};
+	uint32_t sample_rate = 0u;
 	int32_t volmul[2] = {0};
 	float scale[2] = {0.0f, 0.0f};
 	uint8_t channel_map[2] = {0u, 0u}; // Output channel mapping

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -81,7 +81,7 @@ public:
 	
 	void AddStretched(Bitu len,Bit16s * data);		//Strech block up into needed data
 
-	void FillUp(void);
+	void FillUp();
 	void Enable(bool should_enable);
 	void FlushSamples();
 
@@ -92,7 +92,11 @@ public:
 	bool is_enabled = false;
 
 private:
-	MixerChannel();
+	// prevent default construction, copying, and assignment
+	MixerChannel() = delete;
+	MixerChannel(const MixerChannel &) = delete;
+	MixerChannel &operator=(const MixerChannel &) = delete;
+
 	Envelope envelope;
 	MIXER_Handler handler = nullptr;
 	Bitu freq_add = 0u; // This gets added the frequency counter each mixer
@@ -136,7 +140,6 @@ public:
 	MixerChannel* Install(MIXER_Handler handler,Bitu freq,const char * name);
 	~MixerObject();
 };
-
 
 /* PC Speakers functions, tightly related to the timer functions */
 void PCSPEAKER_SetCounter(Bitu cntr,Bitu mode);

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -22,7 +22,8 @@ cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing
 cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                   -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2
                   -Wlogical-op -Wmisleading-indentation -Wnull-dereference
-                  -Wshadow -Wunused -fstrict-aliasing -Wstrict-aliasing=2)
+                  -Wshadow -Wunused -fstrict-aliasing -Wstrict-aliasing=2
+                  -Wextra-semi)
 cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual
                    -Wuseless-cast)
 

--- a/src/hardware/Makefile.am
+++ b/src/hardware/Makefile.am
@@ -10,4 +10,4 @@ libhardware_a_SOURCES = adlib.cpp dma.cpp gameblaster.cpp hardware.cpp iohandler
                         memory.cpp mixer.cpp pcspeaker.cpp pci_bus.cpp pic.cpp sblaster.cpp tandy_sound.cpp timer.cpp \
 			vga.cpp vga_attr.cpp vga_crtc.cpp vga_dac.cpp vga_draw.cpp vga_gfx.cpp vga_other.cpp \
 			vga_memory.cpp vga_misc.cpp vga_seq.cpp vga_xga.cpp vga_s3.cpp vga_tseng.cpp vga_paradise.cpp \
-			cmos.cpp disney.cpp gus.cpp mpu401.cpp ipx.cpp ipxserver.cpp dbopl.cpp
+			cmos.cpp disney.cpp gus.cpp mpu401.cpp ipx.cpp ipxserver.cpp dbopl.cpp envelope.cpp

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -1,0 +1,110 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *  Copyright (c) 2019-2020  Kevin R Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "envelope.h"
+
+#include "support.h"
+
+Envelope::Envelope(const char* name) :
+channel_name(name) {
+}
+
+void Envelope::Reactivate()
+{
+	edge = 0u;
+	frames_done = 0u;
+	process = &Envelope::Apply;
+}
+
+void Envelope::Update(const uint32_t frame_rate,
+                      const uint32_t peak_amplitude,
+                      const uint8_t expansion_phase_ms,
+                      const uint8_t expire_after_seconds)
+{
+	if (!frame_rate || !peak_amplitude || !expansion_phase_ms)
+		return;
+
+	// How many frames should we inspect before expiring?
+	expire_after_frames = expire_after_seconds * frame_rate;
+	assert(expire_after_frames > 0);
+
+	// The furtherest allowed edge is the peak sample amplitude.
+	edge_limit = peak_amplitude;
+
+	// Permit the envelop to achieve peak volume within the expansion_phase
+	// (in ms) if the samples happen to constantly press on the edges.
+	const uint32_t expansion_phase_frames = ceil_udivide(frame_rate * expansion_phase_ms,
+	                                                     1000u);
+
+	// Calculate how much the envelope's edge will grow after a frame
+	// presses against it.
+	assert(expansion_phase_frames);
+	edge_increment = ceil_udivide(peak_amplitude, expansion_phase_frames);
+	
+	// DEBUG_LOG_MSG("ENVELOPE: %s grows by %-3u to %-5u across %-3u frames (%u ms)",
+	//               channel_name, edge_increment, edge_limit, expansion_phase_frames,
+	//               expansion_phase_ms);
+}
+
+bool Envelope::ClampSample(intptr_t &sample, const intptr_t lip)
+{
+	if (abs(sample) > edge) {
+		sample = clamp(sample, -lip, lip);
+		return true;
+	}
+	return false;
+}
+
+void Envelope::Process(const bool is_stereo,
+                       const bool is_interpolated,
+                       intptr_t prev[],
+                       intptr_t next[])
+{
+	process(*this, is_stereo, is_interpolated, prev, next);
+}
+
+void Envelope::Apply(const bool is_stereo,
+                     const bool is_interpolated,
+                     intptr_t prev[],
+                     intptr_t next[])
+{
+	// Only start the envelope once our samples have actual values
+	if (prev[0] == 0 && frames_done == 0u)
+		return;
+
+	// beyond the edge is the lip. Do any samples walk out onto the lip?
+	const intptr_t lip = edge + edge_increment;
+	const bool on_lip = (ClampSample(prev[0], lip)) || (is_stereo &&
+	                     ClampSample(prev[1], lip)) || (is_interpolated &&
+	                     (ClampSample(next[0], lip) || (is_stereo &&
+	                      ClampSample(next[1], lip))));
+
+	// If any of the samples are out on the lip, then march the edge forward
+	if (on_lip)
+		edge += edge_increment;
+
+	// Should we deactivate the envelope?
+	if (++frames_done > expire_after_frames || edge >= edge_limit) {
+		process = &Envelope::Skip;
+		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %u",
+		              channel_name, frames_done, edge);
+	}
+}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -99,7 +99,9 @@ Bit8u MixTemp[MIXER_BUFSIZE];
 MixerChannel::MixerChannel(MIXER_Handler _handler, Bitu _freq, const char *_name)
         : name(_name),
           handler(_handler)
-{}
+{
+	(void)_freq; // unused, but required for API compliance
+}
 
 MixerChannel * MIXER_AddChannel(MIXER_Handler handler, Bitu freq, const char * name) {
 	MixerChannel * chan=new MixerChannel(handler, freq, name);
@@ -620,6 +622,7 @@ static void MIXER_Mix_NoSound()
 }
 
 static void SDLCALL MIXER_CallBack(void * userdata, Uint8 *stream, int len) {
+	(void)userdata; // unused, but required for API compliance
 	memset(stream, 0, len);
 	Bitu need=(Bitu)len/MIXER_SSIZE;
 	Bit16s * output=(Bit16s *)stream;
@@ -728,6 +731,7 @@ static void SDLCALL MIXER_CallBack(void * userdata, Uint8 *stream, int len) {
 }
 
 static void MIXER_Stop(Section* sec) {
+	(void)sec; // unused, but required for API compliance
 }
 
 class MIXER : public Program {
@@ -746,7 +750,8 @@ public:
 				++scan;continue;
 			}
 			if (!db) val/=100;
-			else val=powf(10.0f,(float)val/20.0f);
+			else
+				val = powf(10.0f, val / 20.0f);
 			if (val<0) val=1.0f;
 			if (!w) {
 				vol0=val;
@@ -783,10 +788,11 @@ public:
 
 private:
 	void ShowVolume(const char * name,float vol0,float vol1) {
-		WriteOut("%-8s %3.0f:%-3.0f  %+3.2f:%-+3.2f \n",name,
-			vol0*100,vol1*100,
-			20*log(vol0)/log(10.0f),20*log(vol1)/log(10.0f)
-		);
+		WriteOut("%-8s %3.0f:%-3.0f  %+3.2f:%-+3.2f \n", name,
+		         static_cast<double>(vol0 * 100),
+		         static_cast<double>(vol1 * 100),
+		         static_cast<double>(20 * log(vol0) / log(10.0f)),
+		         static_cast<double>(20 * log(vol1) / log(10.0f)));
 	}
 
 	void ListMidi() { MIDI_ListAll(this); }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -104,13 +104,13 @@ static struct {
 
 Bit8u MixTemp[MIXER_BUFSIZE];
 
-MixerChannel::MixerChannel(MIXER_Handler _handler, Bitu _freq, const char *_name)
+MixerChannel::MixerChannel(MIXER_Handler _handler,
+                           MAYBE_UNUSED Bitu _freq,
+                           const char *_name)
         : name(_name),
           envelope(name),
           handler(_handler)
-{
-	(void)_freq; // unused, but required for API compliance
-}
+{}
 
 MixerChannel * MIXER_AddChannel(MIXER_Handler handler, Bitu freq, const char * name) {
 	MixerChannel * chan=new MixerChannel(handler, freq, name);
@@ -637,8 +637,8 @@ static void MIXER_Mix_NoSound()
 	mixer.done=0;
 }
 
-static void SDLCALL MIXER_CallBack(void * userdata, Uint8 *stream, int len) {
-	(void)userdata; // unused, but required for API compliance
+static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, int len)
+{
 	memset(stream, 0, len);
 	Bitu need=(Bitu)len/MIXER_SSIZE;
 	Bit16s * output=(Bit16s *)stream;
@@ -746,9 +746,8 @@ static void SDLCALL MIXER_CallBack(void * userdata, Uint8 *stream, int len) {
 	}
 }
 
-static void MIXER_Stop(Section* sec) {
-	(void)sec; // unused, but required for API compliance
-}
+static void MIXER_Stop(MAYBE_UNUSED Section *sec)
+{}
 
 class MIXER : public Program {
 public:

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -234,6 +234,7 @@ void MixerChannel::Enable(const bool should_enable)
 void MixerChannel::SetFreq(Bitu freq) {
 	freq_add=(freq<<FREQ_SHIFT)/mixer.freq;
 	interpolate = (freq != mixer.freq);
+	sample_rate = static_cast<uint32_t>(freq);
 }
 
 void MixerChannel::Mix(Bitu _needed) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -237,6 +237,12 @@ void MixerChannel::SetFreq(Bitu freq) {
 	sample_rate = static_cast<uint32_t>(freq);
 }
 
+void MixerChannel::SetPeakAmplitude(const uint32_t peak)
+{
+	peak_amplitude = peak;
+	envelope.Update(sample_rate, peak_amplitude);
+}
+
 void MixerChannel::Mix(Bitu _needed) {
 	needed=_needed;
 	while (is_enabled && needed > done) {

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -379,6 +379,7 @@ public:
 		spkr.min_tr = (PIT_TICK_RATE + spkr.rate / 2 - 1) / (spkr.rate / 2);
 		/* Register the sound channel */
 		spkr.chan = MixerChan.Install(&PCSPEAKER_CallBack, spkr.rate, "SPKR");
+		spkr.chan->SetPeakAmplitude(static_cast<uint32_t>(SPKR_POSITIVE_VOLTAGE));
 	}
 	~PCSPEAKER(){
 		Section_prop * section=static_cast<Section_prop *>(m_configuration);

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -288,6 +288,7 @@
     <ClCompile Include="..\src\hardware\dbopl.cpp" />
     <ClCompile Include="..\src\hardware\disney.cpp" />
     <ClCompile Include="..\src\hardware\dma.cpp" />
+    <ClCompile Include="..\src\hardware\envelope.cpp" />
     <ClCompile Include="..\src\hardware\gameblaster.cpp" />
     <ClCompile Include="..\src\hardware\gus.cpp" />
     <ClCompile Include="..\src\hardware\hardware.cpp" />
@@ -385,6 +386,7 @@
     <ClInclude Include="..\include\dos_inc.h" />
     <ClInclude Include="..\include\dos_system.h" />
     <ClInclude Include="..\include\drives.h" />
+    <ClInclude Include="..\include\envelope.h" />
     <ClInclude Include="..\include\fpu.h" />
     <ClInclude Include="..\include\hardware.h" />
     <ClInclude Include="..\include\inout.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -142,6 +142,9 @@
     <ClCompile Include="..\src\hardware\dma.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\envelope.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\gameblaster.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
@@ -424,6 +427,9 @@
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\include\drives.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\envelope.h">
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\include\fpu.h">


### PR DESCRIPTION
This PR envelopes each channel's initial audio samples permitting the maximum allowed volume to rapidly expand from zero to max-amplitude within a period as short as 15ms. 

The goal is to catch misbehaving "audio" samples such as binary data, digital machine noise, or brick-wall DC-offsets from causing clicks or pops within the split-second of initial audio.  Its secondary goal is not (or minimally) impacting the volume of "organic" or natural waveforms, which (if recorded properly) start at zero and ramp up and down along sine/cosine curves.

This was implemented in a very efficient manner:
1. The envelope parameters are pre-computed once when the channel is configured
2. The envelope itself consists of a minimal set of integer comparisons
3. Once the envelope has been fully expanded or expired, it's replaced with a no-op function so completely gets out of the way.

An example can be seen here, up very close so we can see individual samples.  This channel wants to starts straight into playing a square wave; we see the the envelope controls the volume on the first ~hundred samples - and by the time the second square wave is generate the envelope is out of the picture (and peak volume is permitted).

![Screenshot at 2020-06-05 20-15-27](https://user-images.githubusercontent.com/1557255/83934958-76842d80-a769-11ea-96fa-a003c20b9f71.png)
  
Here's an example with well-behaved audio.  

![Screenshot at 2020-06-05 20-25-03](https://user-images.githubusercontent.com/1557255/83935099-0f677880-a76b-11ea-8be5-8e9deee627c4.png)

The vertical highlighted sliver represents the enveloped region where the game, if it wanted to, could have ramped the volume all the way to the edges; however we see the audio isn't even close to that.. the game developer has faded in the audio on a far greater time scale, and at volumes not even close to peak.

So in this example, the envelope isn't even used; and infact, that's exactly what we want.  The envelope is the worst-case fallback.