### PR TITLE
Add Linux x86_64, +dynrec, +debug gating to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,11 +37,16 @@ jobs:
             flags: -c gcc
             config_flags: --enable-debug
             max_warnings: 137
-          - name: Ubuntu, -dyn_x86, +dynrec
+          - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86
             max_warnings: 33
+          - name: Ubuntu, +dynrec, +debug, -dyn_x86
+            os: ubuntu-latest
+            flags: -c gcc
+            config_flags: --disable-dynamic-x86 --enable-debug
+            max_warnings: 188
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This configuration catches many warnings in code enabled only for
internal DOSBox debugger when running on non-x86 architectures.