### PR TITLE
Implement MAYBE_UNUSED macro

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 137
+            max_warnings: 135
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
@@ -46,7 +46,7 @@ jobs:
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 188
+            max_warnings: 186
 
     steps:
       - uses: actions/checkout@v2

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -22,18 +22,35 @@
 // This header wraps compiler-specific features, so they won't need to
 // be hacked into the buildsystem.
 
-// Modern C++ compilers have better support for feature testing using GNU
-// extension __has_attribute but C++20 introduces even better alternative:
-// standard-defined __has_cpp_attribute, which will remove the need for
-// defining C_HAS_* macros on a buildsystem level (at some point).
+// Function-like macro __has_cpp_attribute was introduced in C++20, but
+// various compilers support it since C++11 as a language extension.
+// Thanks to that we can use it for testing support for both language-defined
+// and vendor-specific attributes.
+
+#ifndef __has_cpp_attribute // for compatibility with non-supporting compilers
+#define __has_cpp_attribute(x) 0
+#endif
+
+// When passing the -Wunused flag to GCC or Clang, entities that are unused by
+// the program may be diagnosed.  The MAYBE_UNUSED attribute can be used to
+// silence such diagnostics when the entity cannot be removed.
+//
+// The attribute may be applied to the declaration of a class, a typedef,
+// a variable, a function or method, a function parameter, an enumeration,
+// an enumerator, a non-static data member, or a label.
+
+#if __has_cpp_attribute(maybe_unused)
+#define MAYBE_UNUSED [[maybe_unused]]
+#elif __has_cpp_attribute(gnu::unused)
+#define MAYBE_UNUSED [[gnu::unused]]
+#else
+#define MAYBE_UNUSED
+#endif
 
 // The __attribute__ syntax is supported by GCC, Clang, and IBM compilers.
 //
-// TODO: C++11 introduced standard syntax for implementation-defined attributes,
-//       it should allow for removal of C_HAS_ATTRIBUTE from the buildsystem.
-//       However, the vast majority of GCC_ATTRIBUTEs in DOSBox code need
-//       to be reviewed, as many of them seem to be incorrectly/unnecessarily
-//       used.
+// Provided for backwards-compatibility with old code; to be gradually
+// replaced by new C++ attribute syntax.
 
 #if C_HAS_ATTRIBUTE
 #define GCC_ATTRIBUTE(x) __attribute__ ((x))

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -16,9 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "compiler.h"
 
 #define X86_INLINED_MEMACCESS
-
 
 enum REP_Type {
 	REP_NONE=0,REP_NZ,REP_Z
@@ -2023,7 +2023,8 @@ static void dyn_iret(void) {
 	dyn_closeblock();
 }
 
-static void dyn_interrupt(Bitu num) {
+MAYBE_UNUSED static void dyn_interrupt(Bitu num)
+{
 	gen_protectflags();
 	dyn_flags_gen_to_host();
 	dyn_reduce_cycles();

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -16,8 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 /*
 	The functions in this file are called almost exclusively by	decoder.h,
 	they translate an (or a set of) instruction(s) into hostspecific code
@@ -28,6 +26,8 @@
 	(see operators.h). Parameter loading and result writeback is done
 	according to the instruction.
 */
+
+#include "compiler.h"
 
 static void dyn_dop_ebgb(DualOps op) {
 	dyn_get_modrm();
@@ -1249,15 +1249,14 @@ static void dyn_iret(void) {
 	dyn_closeblock();
 }
 
-static void dyn_interrupt(Bit8u num) {
+MAYBE_UNUSED static void dyn_interrupt(Bit8u num)
+{
 	dyn_reduce_cycles();
 	dyn_set_eip_last_end(FC_RETOP);
 	gen_call_function_IIR((void*)&CPU_Interrupt,num,CPU_INT_SOFTWARE,FC_RETOP);
 	dyn_return(BR_Normal);
 	dyn_closeblock();
 }
-
-
 
 static void dyn_string(StringOps op) {
 	if (decode.rep) MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -506,7 +506,8 @@ static void KillSwitch(bool pressed) {
 	throw 1;
 }
 
-static void PauseDOSBox(bool pressed) {
+MAYBE_UNUSED static void PauseDOSBox(bool pressed)
+{
 	if (!pressed)
 		return;
 	GFX_SetTitle(-1,-1,true);


### PR DESCRIPTION
It's a way to use C++17 `[[maybe_unused]]` attribute even on compilers, that do not support C++17 yet. As it turns out, GCC supports equivalent functionality since C++11, and Clang does as well - both compilers enable it as a "language extension" turned on by default. 

Clang documentation for the attribute: https://clang.llvm.org/docs/AttributeReference.html#maybe-unused-unused

On MSVC we're already compiling with C++17 (as this is the default in VS nowadays) and that's ok.