### PR TITLE
Fix copyright attributions in the CD-DA backend

### DIFF
--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -9,7 +9,7 @@
  *    - Elimination of intermediate buffers, allowing direct decoding
  *    - Moved from sample-based logic to frame-based (channel-agnostic)
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *

--- a/src/libs/decoders/SDL_sound.h
+++ b/src/libs/decoders/SDL_sound.h
@@ -22,7 +22,7 @@
  *   - .OPUS (Ogg Opus support via the Opusfile and SpeexDSP libraries)
  *   - .FLAC (Free Lossless Audio Codec support via the dr_flac single-header decoder)
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *

--- a/src/libs/decoders/SDL_sound_internal.h
+++ b/src/libs/decoders/SDL_sound_internal.h
@@ -4,7 +4,7 @@
  *  Internal function/structure declaration. Do NOT include in your
  *  application.
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *

--- a/src/libs/decoders/flac.c
+++ b/src/libs/decoders/flac.c
@@ -160,7 +160,7 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_FLAC =
     {
         extensions_flac,
         "Free Lossless Audio Codec (FLAC)",
-        "The DOSBox Team"
+        "The dosbox-staging team"
     },
 
     FLAC_init,       /*   init() method */

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -168,7 +168,7 @@ extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MP3 = {
     {
         extensions_mp3,
         "MPEG-1 Audio Layer I-III",
-        "The DOSBox Team"
+        "The dosbox-staging team"
     },
 
     MP3_init,       /*   init() method */

--- a/src/libs/decoders/mp3_seek_table.cpp
+++ b/src/libs/decoders/mp3_seek_table.cpp
@@ -55,7 +55,7 @@
  *   - archive:  https://github.com/voidah/archive, by Arthur Ouellet
  *   - xxHash:   http://cyan4973.github.io/xxHash, by Yann Collet
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/libs/decoders/mp3_seek_table.h
+++ b/src/libs/decoders/mp3_seek_table.h
@@ -9,7 +9,7 @@
  *   - archive: https://github.com/voidah/archive, by Arthur Ouellet
  *   - xxHash: http://cyan4973.github.io/xxHash, by Yann Collet
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -12,7 +12,7 @@
  *    - Ogg Opus:  https://www.opus-codec.org/docs
  *    - OpusFile:  https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/index.html
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -397,7 +397,7 @@ extern const Sound_DecoderFunctions __Sound_DecoderFunctions_OPUS =
     {
         extensions_opus,
         "Ogg Opus audio using libopusfile",
-        "The DOSBox Team"
+        "The dosbox-staging team"
     },
 
     opus_init,   /*   init() method */

--- a/src/libs/decoders/vorbis.c
+++ b/src/libs/decoders/vorbis.c
@@ -5,7 +5,7 @@
  *   - STB: https://github.com/nothings/stb (source)
  *   - STB: https://twitter.com/nothings (website/author info)
  *
- *  Copyright (C) 2018-2020  The DOSBox Team
+ *  Copyright (C) 2018-2020  The dosbox-staging team
  *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -210,7 +210,7 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_VORBIS =
     {
         extensions_vorbis,
         "Ogg Vorbis audio",
-        "The DOSBox Team"
+        "The dosbox-staging team"
     },
 
     VORBIS_init,       /*   init() method */

--- a/src/libs/decoders/wav.c
+++ b/src/libs/decoders/wav.c
@@ -6,7 +6,7 @@
  *   - dr_libs: https://github.com/mackron/dr_libs (source)
  *   - dr_wav: http://mackron.github.io/dr_wav.html (website)
  *
- *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2020       The dosbox-staging team
  *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
  *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
@@ -167,7 +167,7 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_WAV =
     {
         extensions_wav,
         "WAV Audio Codec",
-        "The DOSBox Team"
+        "The dosbox-staging team"
     },
 
     WAV_init,       /*   init() method */


### PR DESCRIPTION
Prior to the creation of the dosbox-staging project, I had ascribed copyright of the added CD-DA backend source files to The DOSBox Team in anticipation of it being merged into their project.

This has not come to fruition as The DOSBox Team has not accepted this work. Likewise, I am not member of The DOSBox Team and thus have no authority to claim this work as theirs.

To avoid misrepresenting the source of this work, this PR corrects the Copyright attribution in these files.