### PR TITLE
Avoid strict-aliasing warnings in dynrec

### DIFF
--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -697,7 +697,8 @@ bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) DRC_FC;
 bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) {
 	HostPt tlb_addr=get_tlb_read(address);
 	if (tlb_addr) {
-		*((Bit8u*)(&core_dynrec.readdata))=host_readb(tlb_addr+address);
+		const uint8_t byte = host_readb(tlb_addr + address);
+		memcpy(&core_dynrec.readdata, &byte, sizeof(byte));
 		return false;
 	} else {
 		return get_tlb_readhandler(address)->readb_checked(address, (Bit8u*)(&core_dynrec.readdata));
@@ -709,7 +710,8 @@ bool DRC_CALL_CONV mem_readw_checked_drc(PhysPt address) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) {
-			*((Bit16u*)(&core_dynrec.readdata))=host_readw(tlb_addr+address);
+			const uint16_t word = host_readw(tlb_addr + address);
+			memcpy(&core_dynrec.readdata, &word, sizeof(word));
 			return false;
 		} else return get_tlb_readhandler(address)->readw_checked(address, (Bit16u*)(&core_dynrec.readdata));
 	} else return mem_unalignedreadw_checked(address, ((Bit16u*)(&core_dynrec.readdata)));
@@ -720,7 +722,8 @@ bool DRC_CALL_CONV mem_readd_checked_drc(PhysPt address) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) {
-			*((Bit32u*)(&core_dynrec.readdata))=host_readd(tlb_addr+address);
+			const uint32_t dword = host_readd(tlb_addr + address);
+			memcpy(&core_dynrec.readdata, &dword, sizeof(dword));
 			return false;
 		} else return get_tlb_readhandler(address)->readd_checked(address, (Bit32u*)(&core_dynrec.readdata));
 	} else return mem_unalignedreadd_checked(address, ((Bit32u*)(&core_dynrec.readdata)));

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -693,8 +693,6 @@ static void dyn_check_exception(HostReg reg) {
 	used_save_info_dynrec++;
 }
 
-
-
 bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) DRC_FC;
 bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) {
 	HostPt tlb_addr=get_tlb_read(address);
@@ -704,15 +702,6 @@ bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) {
 	} else {
 		return get_tlb_readhandler(address)->readb_checked(address, (Bit8u*)(&core_dynrec.readdata));
 	}
-}
-
-bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address,Bit8u val) DRC_FC;
-bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address,Bit8u val) {
-	HostPt tlb_addr=get_tlb_write(address);
-	if (tlb_addr) {
-		host_writeb(tlb_addr+address,val);
-		return false;
-	} else return get_tlb_writehandler(address)->writeb_checked(address,val);
 }
 
 bool DRC_CALL_CONV mem_readw_checked_drc(PhysPt address) DRC_FC;
@@ -735,6 +724,18 @@ bool DRC_CALL_CONV mem_readd_checked_drc(PhysPt address) {
 			return false;
 		} else return get_tlb_readhandler(address)->readd_checked(address, (Bit32u*)(&core_dynrec.readdata));
 	} else return mem_unalignedreadd_checked(address, ((Bit32u*)(&core_dynrec.readdata)));
+}
+
+bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, Bit8u val) DRC_FC;
+bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, Bit8u val)
+{
+	HostPt tlb_addr = get_tlb_write(address);
+	if (tlb_addr) {
+		host_writeb(tlb_addr + address, val);
+		return false;
+	} else {
+		return get_tlb_writehandler(address)->writeb_checked(address, val);
+	}
 }
 
 bool DRC_CALL_CONV mem_writew_checked_drc(PhysPt address,Bit16u val) DRC_FC;


### PR DESCRIPTION
(long explanation in 2nd commit)

Turns out the same warning noticed on ppc64le happens on every architecture, as long as dynrec is turned on and -fstrict-aliasing is passed to gcc.

@kcgen previously, in discussion in #439 you suggested using assignment instead of memcpy - in general it's a good suggestion that would simplify the code in there, but it changes the behaviour.

Before this PR, this type-punning resulted in overwriting only 2 bytes in Bitu field `core_dynrec`
```C++
*((Bit16u*)(&core_dynrec.readdata))=host_readw(tlb_addr+address);
```
Change introduced in here preserves this side effect (only 2 bytes are overwritten):
```C++
const uint16_t word = host_readw(tlb_addr + address);
memcpy(&core_dynrec.readdata, &word, sizeof(word));
```
If we changed it this way instead:
```C++
core_dynrec.readdata = host_readw(tlb_addr + address);
```
Then all 8 bytes would be overwritten.

I don't know if it's safe to overwrite all bytes of this temporary variable in this case, therefore I opted to preserve the original code behaviour.