### PR TITLE
Simplify and fix a regression in the PC speaker fade logic

### DIFF
--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -30,7 +30,6 @@
 #define SPKR_POSITIVE_VOLTAGE 5000.0f
 #define SPKR_NEUTRAL_VOLTAGE  0.0f
 #define SPKR_NEGATIVE_VOLTAGE -SPKR_POSITIVE_VOLTAGE
-#define SPKR_FADE_PEAK_STEP 100
 #define SPKR_SPEED (SPKR_POSITIVE_VOLTAGE * 2.0f / 0.070f)
 
 enum SPKR_MODES {
@@ -59,7 +58,7 @@ static struct {
 	float volwant = 0.0f;
 	float volcur = 0.0f;
 	float last_index = 0.0f;
-	uint8_t fade_step = 0u;
+	uint8_t idle_countdown = 0u;
 } spkr;
 
 static bool SpeakerExists()
@@ -230,7 +229,7 @@ void PCSPEAKER_SetCounter(Bitu cntr, Bitu mode)
 // otherwise returns the fallback if the speaker is active.
 static float NeutralOr(float fallback)
 {
-	return !spkr.fade_step ? SPKR_NEUTRAL_VOLTAGE : fallback;
+	return !spkr.idle_countdown ? SPKR_NEUTRAL_VOLTAGE : fallback;
 }
 
 // Returns, in order of preference:
@@ -275,34 +274,34 @@ void PCSPEAKER_SetType(Bitu mode)
 	spkr.chan->Enable(true);
 }
 
-// Produces a volume scaler along a smooth 50-step cosine ramp,
-// where step 50 is maximum (100%) volume and step 0 is the
-// least volume (0%), with a cosine-curve in between.
-static float GetFadeScalar(const size_t step)
-{
-	static constexpr std::array<float, 51> cos_scalars = {
-	        1.0f,    0.9990f, 0.9961f, 0.9911f, 0.9843f, 0.9755f, 0.9649f,
-	        0.9524f, 0.9382f, 0.9222f, 0.9045f, 0.8853f, 0.8645f, 0.8423f,
-	        0.8187f, 0.7939f, 0.7679f, 0.7409f, 0.7129f, 0.6841f, 0.6545f,
-	        0.6243f, 0.5937f, 0.5627f, 0.5314f, 0.5000f, 0.4686f, 0.4373f,
-	        0.4063f, 0.3757f, 0.3455f, 0.3159f, 0.2871f, 0.2591f, 0.2321f,
-	        0.2061f, 0.1813f, 0.1577f, 0.1355f, 0.1147f, 0.0955f, 0.0778f,
-	        0.0618f, 0.0476f, 0.0351f, 0.0245f, 0.0157f, 0.0089f, 0.0039f,
-	        0.0010f, 0.0000f};
-	constexpr size_t last = cos_scalars.size() - 1u;
-	return cos_scalars[last - std::min(last, step)];
-}
-
-// When the speaker has been idle (as determined if num_actions is non-zero)
-// we step the volume down by one notch on the ramp. This continues over
-// 100 ms period, however if the speaker is used at any point then the
-// ramp is reset back to original volume.
+// Once the speaker is idle (as defined when num_actions is empty),
+// give it a short grace-time before ramping the volume down.
+// By keeping this idle-phase relatively short, we reduce the chance
+// PC-Speaker's DC-offset can influence other channels (such as the
+// Sound blaster or GUS).  Counts are in milliseconds.
 static void FadeVolume(uint16_t num_actions)
 {
-	spkr.fade_step = num_actions ? SPKR_FADE_PEAK_STEP : spkr.fade_step - 1;
-	spkr.volwant *= GetFadeScalar(spkr.fade_step);
-	if (!spkr.fade_step && SpeakerExists())
+	constexpr uint8_t grace_start = 50u;
+	constexpr uint8_t grace_end = 15u;
+	assert(grace_start >= grace_end);
+	static_assert(grace_end > 0, "algorithm depends on non-zero grace_end value");
+
+	// If the speaker was used then reset our countdown.
+	if (num_actions) {
+		spkr.idle_countdown = grace_start;
+		return;
+	}
+	// If the count is lower than the idle period, then ramp down the volume.
+	if (spkr.idle_countdown && spkr.idle_countdown < grace_end) {
+		spkr.volwant = spkr.volwant * spkr.idle_countdown / grace_end;
+		spkr.idle_countdown--;
+	}
+	// If we've ramped to zero, then shutdown the channel. This function
+	// will not be called again until the channel's re-enabled through
+	// the PWM or PIT functions.
+	if (!spkr.idle_countdown && SpeakerExists()) {
 		spkr.chan->Enable(false);
+	}
 }
 
 static void PCSPEAKER_CallBack(Bitu len)


### PR DESCRIPTION
This commit:
- Fixes a potential negative rollover in the fade count-down.
- replaces the cosine table with simpler floating-point division.
- Reworks the fade logic with clearer names.

Thank you @BPaden for the report and very careful listening!

Fixes #453 