### PR TITLE
Ensure SDL2_net preceeds SDL2 in the link-order

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -492,16 +492,16 @@ if test x$enable_network = xyes ; then
       libtype="(static)"
       case "$host" in
         *-*-darwin*)
-          LIBS="$LIBS /usr/local/lib/libSDL2_net.a"
+          LIBS="/usr/local/lib/libSDL2_net.a $LIBS"
           ;;
         *)
           AC_MSG_WARN(m4_normalize([Statically linking SDL2 is unreliable.
             Please ensure that "libSDL2_net.a" is available.]))
-          LIBS="$LIBS -Wl,-Bstatic -lSDL2_net -Wl,-Bdynamic"
+          LIBS="-Wl,-Bstatic -lSDL2_net -Wl,-Bdynamic $LIBS"
           ;;
       esac
     else
-      LIBS="$LIBS -lSDL2_net"
+      LIBS="-lSDL2_net $LIBS"
     fi
     AC_DEFINE(C_MODEM,1)
     AC_DEFINE(C_IPX,1)


### PR DESCRIPTION
When configuring with `--enable-sdl-static`, some systems might fail to link due to SDL2_net not findSDL2-provided symbols: 

`libSDL2_net.a(SDLnet.o):(.text+0x4d): undefined reference to SDL_vsnprintf`

Linkers look for symbols to the right of the dependent library, so this PR moves SDL2 to the right of SDL2_net.

[:robot: **Config Heavy**](https://github.com/dosbox-staging/dosbox-staging/actions/runs/143823142) gets credit for catching this one :wink: 
