### PR TITLE
Ensure Tandy DMA partial tail-reads terminate in silence

### DIFF
--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -91,28 +91,30 @@ centerline.
 #define TDAC_DMA_BUFSIZE 1024
 
 static struct {
-	MixerChannel * chan = nullptr;
-	bool enabled;
-	Bitu last_write;
+	MixerChannel *chan = nullptr;
+	bool enabled = false;
+	Bitu last_write = 0u;
 	struct {
-		MixerChannel * chan = nullptr;
-		bool enabled;
+		MixerChannel *chan = nullptr;
+		bool enabled = false;
 		struct {
-			Bitu base;
-			Bit8u irq,dma;
+			Bitu base = 0u;
+			Bit8u irq = 0u;
+			Bit8u dma = 0u;
 		} hw;
 		struct {
-			Bitu rate;
-			Bit8u buf[TDAC_DMA_BUFSIZE];
-			DmaChannel * chan = nullptr;
-			bool transfer_done;
+			Bitu rate = 0u;
+			Bit8u buf[TDAC_DMA_BUFSIZE] = {};
+			DmaChannel *chan = nullptr;
+			bool transfer_done = false;
 		} dma;
-		Bit8u mode,control;
-		Bit16u frequency;
-		Bit8u amplitude;
-		bool irq_activated;
-	} dac;
-} tandy;
+		Bit8u mode = 0u;
+		Bit8u control = 0u;
+		Bit16u frequency = 0u;
+		Bit8u amplitude = 0u;
+		bool irq_activated = false;
+	} dac = {};
+} tandy = {};
 
 static sn76496_device device_sn76496(machine_config(), 0, 0, SOUND_CLOCK );
 static ncr8496_device device_ncr8496(machine_config(), 0, 0, SOUND_CLOCK);
@@ -136,8 +138,8 @@ static void SN76496Update(Bitu length) {
 	if (!tandy.chan)
 		return;
 
-	//Disable the channel if it's been quiet for a while
-	if ((tandy.last_write+5000)<PIC_Ticks) {
+	// Disable the channel if it's been quiet for a while
+	if ((tandy.last_write + 5000) < PIC_Ticks) {
 		tandy.enabled=false;
 		tandy.chan->Enable(false);
 		return;
@@ -213,12 +215,13 @@ static void TandyDACModeChanged()
 	}
 }
 
-static void TandyDACDMAEnabled(void) {
+static void TandyDACDMAEnabled()
+{
 	TandyDACModeChanged();
 }
 
-static void TandyDACDMADisabled(void) {
-}
+static void TandyDACDMADisabled()
+{}
 
 static void TandyDACWrite(Bitu port,Bitu data,Bitu /*iolen*/) {
 	switch (port) {
@@ -321,8 +324,12 @@ private:
 	MixerObject MixerChan;
 	MixerObject MixerChanDAC;
 public:
-	TANDYSOUND(Section* configuration):Module_base(configuration){
-		Section_prop * section=static_cast<Section_prop *>(configuration);
+	TANDYSOUND(Section *configuration)
+	        : Module_base(configuration),
+	          MixerChan(),
+	          MixerChanDAC()
+	{
+		Section_prop *section = static_cast<Section_prop *>(configuration);
 
 		bool enable_hw_tandy_dac=true;
 		Bitu sbport, sbirq, sbdma;
@@ -390,12 +397,9 @@ public:
 
 		((device_t&)device).device_start();
 		device.convert_samplerate(sample_rate);
-
 	}
 	~TANDYSOUND(){ }
 };
-
-
 
 static TANDYSOUND* test;
 


### PR DESCRIPTION
This commit eliminates unnecessary complexity and book-keeping in the Tandy DMA channel callback, and in doing so fixes dosbox-side audio quality bugs.

When the Tandy's DMA transfer span multiple reads, this PR terminates the last "tail read" sample at the zero-line instead of leaving it at a potentially non-centerline value.

**Edit:** This PR is opinionated in what counts as game audio: we consider the actual PCM DMA audio as read from the game's DMA memory as audio intended by the game authors.  We do not consider the artifact appended after playback of every DMA sequence caused by the Tandy's DMA DAC ramp function to be game audio, and thus effort and code to simulate this is not included in this PR (contrasting with the DOSBox-X project, which adds it).

Please listen to these three recordings of Price of Persia footsteps, for comparison. You will hear an artifact at the end of each footstep in SVN and -X, but not staging.  
In SVN, it's a side-effect of the AddSilence mixer function. In -X, it's a deliberate addition to model the Tandy's inelegant control of their hardware DAC. If you play the game, you will hear the glitch postfixed onto every sound-effect in SVN and X.

[prince-comparison.tar.gz](https://github.com/dosbox-staging/dosbox-staging/files/4818387/prince-comparison.tar.gz)

Regression tested with:

- AD&D Forgotten Realms II Curse of the Azure Bonds
- AD&D Forgotten Realms I Pool of Radiance
- Alley Cat
- King's Quest I (1984) Quest for the Crown
- King's Quest II Romancing the Throne
- Leisure Suit Larry I (1987) in the Land of the Lounge Lizards
- Police Quest I (1987) In Pursuit of the Death Angel
- Prince of Persia 1
- Space Quest I (1986) The Sarien Encounter
- Space Quest II Vohaul's Revenge
- Thexder I

Note that the Tandy internally operates at a lower frequency than the mixer typically operates at, therefore, single "Tandy samples" get stretched into multiple when the mixer muxes them. 

In [Tandy Cat](https://github.com/bjt42/tandycat), a souped up mod of Alley Cat :smile_cat:, we get a small click when we hit a key and terminate the intro music: 

![2020-06-23_00-33](https://user-images.githubusercontent.com/1557255/85376680-e2e28900-b4ec-11ea-8c4b-82ffb275389b.png)

Here are the samples after:

![2020-06-23_00-32](https://user-images.githubusercontent.com/1557255/85377272-b4b17900-b4ed-11ea-9752-3e143ac284a2.png)

In Prince of Persia, as we walk forward and hear his footsteps, the DMA transfer tails end in a non-zero number which produces a very tight click right at the back end of the PCM effect (I had to use headphones and turn them up).  This tight click is also post-fixed with a faint "squeak" which is due to `AddSilence()` taking the signal outward before ramping back up again to the zeroline.

It should be noted that these nearly silent audio ramps are performed after the game's DMA audio has completed playback, and are thus not part of the game author's deliberate musical or sound-effect score.  

![2020-06-23_00-37](https://user-images.githubusercontent.com/1557255/85377657-44efbe00-b4ee-11ea-8b0f-9969c8db9f72.png)

The foot steps now terminate without DC-offset nor are the their post-playback DC ramps:

![2020-06-23_00-39](https://user-images.githubusercontent.com/1557255/85378182-11616380-b4ef-11ea-805e-51398c7ede88.png)

In the other games, I couldn't hear (or see after opening the captures) any differences, which indicates they're likely well-behaved and already terminating their sequences in silence. 