### PR TITLE
CPU cache area cleanup (part 1)

### DIFF
--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -280,12 +280,13 @@ public:
 	void DelCacheBlock(CacheBlock * block) {
 		active_blocks--;
 		active_count=16;
-		CacheBlock * * where=&hash_map[block->hash.index];
-		while (*where!=block) {
-			where=&((*where)->hash.next);
-			//Will crash if a block isn't found, which should never happen.
+		CacheBlock **where = &hash_map[block->hash.index];
+		while (*where != block) {
+			where = &((*where)->hash.next);
+			// Will crash if a block isn't found, which should never
+			// happen.
 		}
-		*where=block->hash.next;
+		*where = block->hash.next;
 		if (GCC_UNLIKELY(block->cache.wmapmask!=NULL)) {
 			for (Bitu i=block->page.start;i<block->cache.maskstart;i++) {
 				if (write_map[i]) write_map[i]--;
@@ -355,10 +356,11 @@ private:
 	Bitu phys_page;
 };
 
-
-static INLINE void cache_addunsedblock(CacheBlock * block) {
-	block->cache.next=cache.block.free;
-	cache.block.free=block;
+static inline void cache_add_unused_block(CacheBlock *block)
+{
+	// block has become unused, add it to the freelist
+	block->cache.next = cache.block.free;
+	cache.block.free = block;
 }
 
 static CacheBlock * cache_getblock(void) {
@@ -391,8 +393,9 @@ void CacheBlock::Clear(void) {
 			else
 				LOG(LOG_CPU,LOG_ERROR)("Cache anomaly. please investigate");
 		}
-	} else 
-		cache_addunsedblock(this);
+	} else {
+		cache_add_unused_block(this);
+	}
 	if (crossblock) {
 		crossblock->crossblock=0;
 		crossblock->Clear();
@@ -423,7 +426,7 @@ static CacheBlock * cache_openblock(void) {
 		CacheBlock * tempblock=nextblock->cache.next;
 		if (nextblock->page.handler) 
 			nextblock->Clear();
-		cache_addunsedblock(nextblock);
+		cache_add_unused_block(nextblock);
 		nextblock=tempblock;
 	}
 skipresize:

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "types.h"
 
 class CacheBlock {
 public:
@@ -63,6 +64,12 @@ static struct {
 	CodePageHandler * last_page;
 } cache;
 
+// cache memory pointers, to be malloc'd later
+static uint8_t *cache_code_start_ptr = nullptr;
+static uint8_t *cache_code = nullptr;
+static uint8_t *cache_code_link_blocks = nullptr;
+
+static CacheBlock *cache_blocks = nullptr;
 static CacheBlock link_blocks[2];
 
 class CodePageHandler : public PageHandler {
@@ -498,11 +505,6 @@ static INLINE void cache_addq(Bit64u val) {
 }
 
 static void gen_return(BlockReturn retcode);
-
-static Bit8u * cache_code_start_ptr=NULL;
-static Bit8u * cache_code=NULL;
-static Bit8u * cache_code_link_blocks=NULL;
-static CacheBlock * cache_blocks=NULL;
 
 /* Define temporary pagesize so the MPROTECT case and the regular case share as much code as possible */
 #if (C_HAVE_MPROTECT)

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "mem_unaligned.h"
 #include "types.h"
 
 class CodePageHandlerDynRec;	// forward
@@ -161,7 +162,7 @@ public:
 		if (host_readw(hostmem+addr)==(Bit16u)val) return;
 		host_writew(hostmem+addr,val);
 		// see if there's code where we are writing to
-		if (!*(Bit16u*)&write_map[addr]) {
+		if (!read_unaligned_uint16(&write_map[addr])) {
 			if (active_blocks) return;		// still some blocks in this page
 			active_count--;
 			if (!active_count) Release();	// delay page releasing until active_count is zero
@@ -170,12 +171,7 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-		host_writew(&invalidation_map[addr],
-			host_readw(&invalidation_map[addr])+0x101);
-#else
-		(*(Bit16u*)&invalidation_map[addr])+=0x101;
-#endif
+		host_addw(&invalidation_map[addr], 0x0101);
 		InvalidateRange(addr,addr+1);
 	}
 	void writed(PhysPt addr,Bitu val){
@@ -183,7 +179,7 @@ public:
 		if (host_readd(hostmem+addr)==(Bit32u)val) return;
 		host_writed(hostmem+addr,val);
 		// see if there's code where we are writing to
-		if (!*(Bit32u*)&write_map[addr]) {
+		if (!read_unaligned_uint32(&write_map[addr])) {
 			if (active_blocks) return;		// still some blocks in this page
 			active_count--;
 			if (!active_count) Release();	// delay page releasing until active_count is zero
@@ -192,19 +188,14 @@ public:
 			invalidation_map=(Bit8u*)malloc(4096);
 			memset(invalidation_map,0,4096);
 		}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-		host_writed(&invalidation_map[addr],
-			host_readd(&invalidation_map[addr])+0x1010101);
-#else
-		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
-#endif
+		host_addd(&invalidation_map[addr], 0x01010101);
 		InvalidateRange(addr,addr+3);
 	}
 	bool writeb_checked(PhysPt addr,Bitu val) {
 		addr&=4095;
 		if (host_readb(hostmem+addr)==(Bit8u)val) return false;
 		// see if there's code where we are writing to
-		if (!host_readb(&write_map[addr])) {
+		if (!write_map[addr]) {
 			if (!active_blocks) {
 				// no blocks left in this page, still delay the page releasing a bit
 				active_count--;
@@ -228,7 +219,7 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
 		// see if there's code where we are writing to
-		if (!*(Bit16u*)&write_map[addr]) {
+		if (!read_unaligned_uint16(&write_map[addr])) {
 			if (!active_blocks) {
 				// no blocks left in this page, still delay the page releasing a bit
 				active_count--;
@@ -239,12 +230,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-			host_writew(&invalidation_map[addr],
-				host_readw(&invalidation_map[addr])+0x101);
-#else
-			(*(Bit16u*)&invalidation_map[addr])+=0x101;
-#endif
+			host_addw(&invalidation_map[addr], 0x0101);
 			if (InvalidateRange(addr,addr+1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
@@ -257,7 +243,7 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
 		// see if there's code where we are writing to
-		if (!*(Bit32u*)&write_map[addr]) {
+		if (!read_unaligned_uint32(&write_map[addr])) {
 			if (!active_blocks) {
 				// no blocks left in this page, still delay the page releasing a bit
 				active_count--;
@@ -268,12 +254,7 @@ public:
 				invalidation_map=(Bit8u*)malloc(4096);
 				memset(invalidation_map,0,4096);
 			}
-#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
-			host_writed(&invalidation_map[addr],
-				host_readd(&invalidation_map[addr])+0x1010101);
-#else
-			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
-#endif
+			host_addd(&invalidation_map[addr], 0x01010101);
 			if (InvalidateRange(addr,addr+3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "types.h"
 
 class CodePageHandlerDynRec;	// forward
 
@@ -70,15 +71,13 @@ static struct {
 	CodePageHandlerDynRec * last_page;		// the last used page
 } cache;
 
-
 // cache memory pointers, to be malloc'd later
-static Bit8u * cache_code_start_ptr=NULL;
-static Bit8u * cache_code=NULL;
-static Bit8u * cache_code_link_blocks=NULL;
+static uint8_t *cache_code_start_ptr = nullptr;
+static uint8_t *cache_code = nullptr;
+static uint8_t *cache_code_link_blocks = nullptr;
 
-static CacheBlockDynRec * cache_blocks=NULL;
+static CacheBlockDynRec *cache_blocks = nullptr;
 static CacheBlockDynRec link_blocks[2];		// default linking (specially marked)
-
 
 // the CodePageHandlerDynRec class provides access to the contained
 // cache blocks and intercepts writes to the code for special treatment

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -305,12 +305,13 @@ public:
 	void DelCacheBlock(CacheBlockDynRec * block) {
 		active_blocks--;
 		active_count=16;
-		CacheBlockDynRec * * bwhere=&hash_map[block->hash.index];
-		while (*bwhere!=block) {
-			bwhere=&((*bwhere)->hash.next);
-			//Will crash if a block isn't found, which should never happen.
+		CacheBlockDynRec **where = &hash_map[block->hash.index];
+		while (*where != block) {
+			where = &((*where)->hash.next);
+			// Will crash if a block isn't found, which should never
+			// happen.
 		}
-		*bwhere=block->hash.next;
+		*where = block->hash.next;
 
 		// remove the cleared block from the write map
 		if (GCC_UNLIKELY(block->cache.wmapmask!=NULL)) {
@@ -396,11 +397,11 @@ private:
 	Bitu phys_page;
 };
 
-
-static INLINE void cache_addunusedblock(CacheBlockDynRec * block) {
+static inline void cache_add_unused_block(CacheBlockDynRec *block)
+{
 	// block has become unused, add it to the freelist
-	block->cache.next=cache.block.free;
-	cache.block.free=block;
+	block->cache.next = cache.block.free;
+	cache.block.free = block;
 }
 
 static CacheBlockDynRec * cache_getblock(void) {
@@ -439,8 +440,9 @@ void CacheBlockDynRec::Clear(void) {
 				LOG(LOG_CPU,LOG_ERROR)("Cache anomaly. please investigate");
 			}
 		}
-	} else
-		cache_addunusedblock(this);
+	} else {
+		cache_add_unused_block(this);
+	}
 	if (crossblock) {
 		// clear out the crossblock (in the page before) as well
 		crossblock->crossblock=0;
@@ -476,7 +478,7 @@ static CacheBlockDynRec * cache_openblock(void) {
 		if (nextblock->page.handler)
 			nextblock->Clear();
 		// block is free now
-		cache_addunusedblock(nextblock);
+		cache_add_unused_block(nextblock);
 		nextblock=tempblock;
 	}
 skipresize:


### PR DESCRIPTION
These changes are designed to remove pointless implementation differences between cache.h files in core_dynrec and core_dyn_x86; this will allow us to (eventually) replace these files with a single shared copy (which is a prerequisite for working on memory protection stuff).

After these changes, the bulk of differences between cache.h files boil down to pointless changes in class names, plenty of comments (dynrec has comments, dyn_x86 is missing them). However, there are still few lines with real differences between both dynrec implementations.

@kcgen Be very careful with reviewing these changes; I recommend going one-by-one.