### PR TITLE
Adjust our build docs and config defaults to better accomodate Pi2/3/4 users

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -188,6 +188,9 @@ installed and the license agreed to:
 - GCC (specific version, ie: 10): `./scripts/build.sh -c gcc -v 10 -t release -m
   lto`
 
+  :warning: Raspberry Pi 4 users should avoid link-time-optimized builds for
+  now. Simply drop the `-m lto` in your build line.
+
 1. To build a debug binary, use `-t debug` in place of `-t release -m lto`.
 
 ## Haiku Procedures

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -9,8 +9,8 @@ ranlib="gcc-ranlib${postfix}"
 TYPES+=(release debug warnmore pgotrain fdotrain optinfo
         asan uasan usan tsan)
 
-cflags+=(-fstack-protector -fdiagnostics-color=auto)
-cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
+cflags+=(-fdiagnostics-color=auto)
+cflags_debug+=("${cflags[@]}" -g -fstack-protector -fno-omit-frame-pointer)
 
 # Note: associative-math is needed for vectorization of floating point
 #       calculations, which also relies on no-signed-zeros and


### PR DESCRIPTION
This was a rather complex situation involving link-time-optimization negatively interacting with the new PPC dynrec code specifically on the Pi4 (which works fine on the Pi3!).

As we don't have hardware to dig into it, I think the best approach is to deprecate LTO for the Pi4, and report the circumstance and backtrace to jmarsh on vogons:
 
``` text
(gdb) bt
#0  0x0001c8f4 in gen_mov_dword_to_reg_imm(unsigned char, unsigned int) [clone .constprop.448] ()
#1  0x0025b9a8 in cache_init(bool) [clone .lto_priv.613] ()
#2  0x0002e348 in CPU::Change_Config(Section*) [clone .constprop.435] ()
#3  0x002ba180 in CPU::CPU(Section*) ()
#4  0x002ba220 in CPU_Init(Section*) ()
#5  0x0001a34c in main ()
(gdb) 
```

When things break with LTO, the immediate reaction is to blame LTO; however [the problem often lies in the project's code](https://mcuoneclipse.com/2018/05/31/gnu-link-time-optimization-finds-non-matching-declarations/), as LTO gets a more extensive look at all the functions, variables, and branches globally - so if there are mixed definitions of things, those can cause problems.  

This is only a draft PR for now to let us discuss how to tie up this issue.  The changes suggested in this PR are:

1.  In the LTO section of README.md we specifically warn about use with the Pi4. 

1. Stop mentioning `-m lto` throughout BUILD.md in the general build instructions, leaving its use for more intrepid users or developers.

1. Moves the `-fstack-protector` instrumentation flag over to the debug set.  This is just a small general adjustment; we don't want extra memory instrumentation in our release builds.

1. Tailors three config defaults for ARM platforms, giving Pi users a sane defaults out of the box -- which is a persistent pre-requisite concern whenever an issue regarding the Pi is reported.