### PR TITLE
Log memory base address

### DIFF
--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -571,6 +571,9 @@ public:
 		}
 		memset((void*)MemBase, 0, memsize * 1024 * 1024);
 		memory.pages = (memsize * 1024 * 1024) / 4096;
+		LOG_MSG("MEMORY: Base address: %p", MemBase);
+		LOG_MSG("MEMORY: Using %d DOS memory pages (%u MiB)",
+		        static_cast<int>(memory.pages), memsize);
 
 		/* Allocate the data for the different page information blocks */
 		memory.phandlers = new (std::nothrow) PageHandler * [memory.pages];

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -541,12 +541,14 @@ void PreparePCJRCartRom(void) {
 
 HostPt GetMemBase(void) { return MemBase; }
 
-class MEMORY:public Module_base{
+class MEMORY : public Module_base {
 private:
-	IO_ReadHandleObject ReadHandler;
-	IO_WriteHandleObject WriteHandler;
-public:	
-	MEMORY(Section* configuration):Module_base(configuration){
+	IO_ReadHandleObject ReadHandler{};
+	IO_WriteHandleObject WriteHandler{};
+
+public:
+	MEMORY(Section *configuration) : Module_base(configuration)
+	{
 		Bitu i;
 		Section_prop * section=static_cast<Section_prop *>(configuration);
 	
@@ -608,14 +610,15 @@ public:
 		ReadHandler.Install(0x92,read_p92,IO_MB);
 		MEM_A20_Enable(false);
 	}
-	~MEMORY(){
+
+	~MEMORY()
+	{
 		delete [] MemBase;
 		delete [] memory.phandlers;
 		delete [] memory.mhandles;
 	}
-};	
+};
 
-	
 static MEMORY* test;	
 	
 static void MEM_ShutDown(Section * sec) {


### PR DESCRIPTION
Users of https://www.cheatengine.org/ engine approach us asking to make their life a bit easier. This program is a modern version of devices such as [GameBuster reviewed by LGR some time ago](https://www.youtube.com/watch?v=usaioMbE8EQ).

Bundle some effc++ warning fixes while we're at it :)

I plan to backport second commit from this review to 0.75.1 release.