### PR TITLE
Implemented long filename support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,19 +19,19 @@ jobs:
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 24
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 30
+            max_warnings: 26
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 30
+            max_warnings: 26
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 9
+            max_warnings: 10
           - name: Ubuntu, +debug
             os: ubuntu-latest
             flags: -c gcc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 24
+            max_warnings: 26
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 10
+            max_warnings: 9
           - name: Ubuntu, +debug
             os: ubuntu-latest
             flags: -c gcc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 30
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 30
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,15 +19,15 @@ jobs:
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 24
+            max_warnings: 23
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 25
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 25
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
@@ -36,17 +36,17 @@ jobs:
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 135
+            max_warnings: 134
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 26
+            max_warnings: 25
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 172
+            max_warnings: 171
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
             max_warnings: 10
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 26
+            max_warnings: 30
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 7
+            max_warnings: 10
           - name: GCC-9
             flags: -c gcc -v 9
             max_warnings: 26

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 10
+            max_warnings: 8
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 30
+            max_warnings: 26
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 8
+            max_warnings: 7
           - name: GCC-9
             flags: -c gcc -v 9
             max_warnings: 26

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
             max_warnings: 7
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 26
+            max_warnings: 25
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 408
+            max_warnings: 399
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 392
+            max_warnings: 306
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2257
+            max_warnings: 2171
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 599
+            max_warnings: 516
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2457
+            max_warnings: 2374
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 411
+            max_warnings: 408
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2269
+            max_warnings: 2266
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 399
+            max_warnings: 392
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2266
+            max_warnings: 2257
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 343
+            max_warnings: 599
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 516
+            max_warnings: 415
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2374
+            max_warnings: 2273
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 415
+            max_warnings: 411
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2273
+            max_warnings: 2269
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2208
+            max_warnings: 2457
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
           - name: MSVC 32-bit
             vs-platform: x86
             vcpkg-triplet: x86-windows
-            max_warnings: 306
+            max_warnings: 343
           - name: MSVC 64-bit
             vs-platform: x64
             vcpkg-triplet: x64-windows
-            max_warnings: 2171
+            max_warnings: 2208
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/include/cross.h
+++ b/include/cross.h
@@ -113,8 +113,8 @@ typedef struct dir_struct {
 #endif
 
 dir_information* open_directory(const char* dirname);
-bool read_directory_first(dir_information* dirp, char* entry_name, bool& is_directory);
-bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_directory);
+bool read_directory_first(dir_information* dirp, char* entry_name, char* entry_sname, bool& is_directory);
+bool read_directory_next(dir_information* dirp, char* entry_name, char* entry_sname, bool& is_directory);
 void close_directory(dir_information* dirp);
 
 FILE *fopen_wrap(const char *path, const char *mode);

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -50,6 +50,9 @@ struct DOS_Version {
 	Bit8u major,minor,revision;
 };
 
+typedef unsigned char       UINT8;
+typedef unsigned short      UINT16;
+typedef unsigned int        UINT32;
 
 #ifdef _MSC_VER
 #pragma pack (1)

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -61,7 +61,7 @@ enum SVGACards {
 
 extern SVGACards svgaCard;
 extern MachineType machine;
-extern bool SDLNetInited;
+extern bool SDLNetInited, uselfn;
 extern bool mono_cga;
 
 #define IS_TANDY_ARCH ((machine==MCH_TANDY) || (machine==MCH_PCJR))

--- a/include/shell.h
+++ b/include/shell.h
@@ -87,7 +87,7 @@ public:
 	bool CheckConfig(char* cmd_in,char*line);
 
 	/* Some internal used functions */
-	const char *Which(const char *name) const;
+	const char *Which(char *name) const;
 
 	/* Commands */
 	void CMD_HELP(char * args);

--- a/include/support.h
+++ b/include/support.h
@@ -141,7 +141,7 @@ char *rtrim(char *str);
 char *trim(char * str);
 char * upcase(char * str);
 char * lowcase(char * str);
-
+char * StripArg(char *&cmd);
 bool ScanCMDBool(char * cmd,char const * const check);
 char * ScanCMDRemain(char * cmd);
 char * StripWord(char *&cmd);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -18,6 +18,9 @@
  *  Wengier: LFN support
  */
 
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+# define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1197,7 +1197,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 
 	case 0x71:					/* Unknown probably 4dos detection */
-		printf("DOS:MS-DOS 7.x long file name support call %2X\n",reg_al);
+		printf("DOS:MS-DOS 7+ long file name support call %2X\n",reg_al);
 		if (!uselfn) {
 				reg_ax=0x7100;
 				CALLBACK_SCF(true); //Check this! What needs this ? See default case

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -14,6 +14,8 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  Wengier: LFN support
  */
 
 
@@ -29,9 +31,16 @@
 #include "setup.h"
 #include "support.h"
 #include "serialport.h"
+#include "drives.h"
+#include "shell.h"
+#include "time.h"
 
 DOS_Block dos;
 DOS_InfoBlock dos_infoblock;
+int enablelfn=-1;
+bool uselfn;
+extern bool force_sfn;
+extern int lfn_filefind_handle;
 
 #define DOS_COPYBUFSIZE 0x10000
 Bit8u dos_copybuf[DOS_COPYBUFSIZE];
@@ -102,6 +111,38 @@ static inline void overhead() {
 	return;
 }
 #endif
+
+void DOS_Int21_7139(char *name1, const char *name2);
+void DOS_Int21_713a(char *name1, const char *name2);
+void DOS_Int21_713b(char *name1, const char *name2);
+void DOS_Int21_7141(char *name1, const char *name2);
+void DOS_Int21_7143(char *name1, const char *name2);
+void DOS_Int21_7147(char *name1, const char *name2);
+void DOS_Int21_714e(char *name1, char *name2);
+void DOS_Int21_714f(const char *name1, const char *name2);
+void DOS_Int21_7156(char *name1, char *name2);
+void DOS_Int21_7160(char *name1, char *name2);
+void DOS_Int21_716c(char *name1, const char *name2);
+void DOS_Int21_71a0(char *name1, char *name2);
+void DOS_Int21_71a1(const char *name1, const char *name2);
+void DOS_Int21_71a6(const char *name1, const char *name2);
+void DOS_Int21_71a7(const char *name1, const char *name2);
+void DOS_Int21_71a8(char* name1, const char* name2);
+void DOS_Int21_71aa(char* name1, const char* name2);
+
+typedef struct {
+	UINT16 size_of_structure;
+	UINT16 structure_version;
+	UINT32 sectors_per_cluster;
+	UINT32 bytes_per_sector;
+	UINT32 available_clusters_on_drive;
+	UINT32 total_clusters_on_drive;
+	UINT32 available_sectors_on_drive;
+	UINT32 total_sectors_on_drive;
+	UINT32 available_allocation_units;
+	UINT32 total_allocation_units;
+	UINT8 reserved[8];
+} ext_space_info_t;
 
 #define DOSNAMEBUF 256
 static Bitu DOS_21Handler(void) {
@@ -585,6 +626,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x39:		/* MKDIR Create directory */
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+		force_sfn = true;
 		if (DOS_MakeDir(name1)) {
 			reg_ax=0x05;	/* ax destroyed */
 			CALLBACK_SCF(false);
@@ -592,9 +634,11 @@ static Bitu DOS_21Handler(void) {
 			reg_ax=dos.errorcode;
 			CALLBACK_SCF(true);
 		}
+		force_sfn = false;
 		break;
 	case 0x3a:		/* RMDIR Remove directory */
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+		force_sfn = true;
 		if  (DOS_RemoveDir(name1)) {
 			reg_ax=0x05;	/* ax destroyed */
 			CALLBACK_SCF(false);
@@ -603,6 +647,7 @@ static Bitu DOS_21Handler(void) {
 			CALLBACK_SCF(true);
 			LOG(LOG_MISC,LOG_NORMAL)("Remove dir failed on %s with error %X",name1,dos.errorcode);
 		}
+		force_sfn = false;
 		break;
 	case 0x3b:		/* CHDIR Set current directory */
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
@@ -615,6 +660,7 @@ static Bitu DOS_21Handler(void) {
 		}
 		break;
 	case 0x3c:		/* CREATE Create of truncate file */
+		force_sfn = true;
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 		if (DOS_CreateFile(name1,reg_cx,&reg_ax)) {
 			CALLBACK_SCF(false);
@@ -622,16 +668,28 @@ static Bitu DOS_21Handler(void) {
 			reg_ax=dos.errorcode;
 			CALLBACK_SCF(true);
 		}
+		force_sfn = false;
 		break;
 	case 0x3d:		/* OPEN Open existing file */
+	{
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+		force_sfn = true;
+		Bit8u oldal=reg_al;
 		if (DOS_OpenFile(name1,reg_al,&reg_ax)) {
+			force_sfn = false;
 			CALLBACK_SCF(false);
 		} else {
+			force_sfn = false;
+			if (uselfn&&DOS_OpenFile(name1,oldal,&reg_ax)) {
+				CALLBACK_SCF(false);
+				break;
+			}
 			reg_ax=dos.errorcode;
 			CALLBACK_SCF(true);
 		}
+		force_sfn = false;
 		break;
+	}
 	case 0x3e:		/* CLOSE Close file */
 		if (DOS_CloseFile(reg_bx)) {
 //			reg_al=0x01;	/* al destroyed. Refcount */
@@ -673,12 +731,14 @@ static Bitu DOS_21Handler(void) {
 		};
 	case 0x41:					/* UNLINK Delete file */
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+		force_sfn = true;
 		if (DOS_UnlinkFile(name1)) {
 			CALLBACK_SCF(false);
 		} else {
 			reg_ax=dos.errorcode;
 			CALLBACK_SCF(true);
 		}
+		force_sfn = false;
 		break;
 	case 0x42:					/* LSEEK Set current file position */
 		{
@@ -752,7 +812,7 @@ static Bitu DOS_21Handler(void) {
 		}
 		break;
 	case 0x47:					/* CWD Get current directory */
-		if (DOS_GetCurrentDir(reg_dl,name1)) {
+		if (DOS_GetCurrentDir(reg_dl,name1,false)) {
 			MEM_BlockWrite(SegPhys(ds)+reg_si,name1,(Bitu)(strlen(name1)+1));	
 			reg_ax=0x0100;
 			CALLBACK_SCF(false);
@@ -862,6 +922,7 @@ static Bitu DOS_21Handler(void) {
 		reg_al=0xf0;	/* al destroyed */
 		break;
 	case 0x56:					/* RENAME Rename file */
+		force_sfn = true;
 		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 		MEM_StrCopy(SegPhys(es)+reg_di,name2,DOSNAMEBUF);
 		if (DOS_Rename(name1,name2)) {
@@ -870,6 +931,7 @@ static Bitu DOS_21Handler(void) {
 			reg_ax=dos.errorcode;
 			CALLBACK_SCF(true);
 		}
+		force_sfn = false;
 		break;		
 	case 0x57:					/* Get/Set File's Date and Time */
 		if (reg_al==0x00) {
@@ -1136,11 +1198,115 @@ static Bitu DOS_21Handler(void) {
 		break;
 
 	case 0x71:					/* Unknown probably 4dos detection */
-		reg_ax=0x7100;
-		CALLBACK_SCF(true); //Check this! What needs this ? See default case
-		LOG(LOG_DOSMISC,LOG_NORMAL)("DOS:Windows long file name support call %2X",reg_al);
+		printf("DOS:Windows long file name support call %2X\n",reg_al);
+		if (!uselfn) {
+				reg_ax=0x7100;
+				CALLBACK_SCF(true); //Check this! What needs this ? See default case
+				break;
+		}
+		switch(reg_al) {
+			case 0x39:              /* LFN MKDIR */
+					DOS_Int21_7139(name1, name2);
+					break;
+			case 0x3a:              /* LFN RMDIR */
+					DOS_Int21_713a(name1, name2);
+					break;
+			case 0x3b:              /* LFN CHDIR */
+					DOS_Int21_713b(name1, name2);
+					break;
+			case 0x41:              /* LFN UNLINK */
+					DOS_Int21_7141(name1, name2);
+					break;
+			case 0x43:              /* LFN ATTR */
+					DOS_Int21_7143(name1, name2);
+					break;
+			case 0x47:              /* LFN PWD */
+					DOS_Int21_7147(name1, name2);
+					break;
+			case 0x4e:              /* LFN FindFirst */
+					DOS_Int21_714e(name1, name2);
+					break;
+			case 0x4f:              /* LFN FindNext */
+					DOS_Int21_714f(name1, name2);
+					break;
+			case 0x56:              /* LFN Rename */
+					DOS_Int21_7156(name1, name2);
+					break;
+			case 0x60:              /* LFN GetName */
+					DOS_Int21_7160(name1, name2);
+					break;
+			case 0x6c:              /* LFN Create */
+					DOS_Int21_716c(name1, name2);
+					break;
+			case 0xa0:              /* LFN VolInfo */
+					DOS_Int21_71a0(name1, name2);
+					break;
+			case 0xa1:              /* LFN FileClose */
+					DOS_Int21_71a1(name1, name2);
+					break;
+			case 0xa6:              /* LFN GetFileInfoByHandle */
+					DOS_Int21_71a6(name1, name2);
+					break;
+			case 0xa7:              /* LFN TimeConv */
+					DOS_Int21_71a7(name1, name2);
+					break;
+			case 0xa8:              /* LFN GenSFN */
+					DOS_Int21_71a8(name1, name2);
+					break;
+			case 0xaa:              /* LFN Subst */
+					DOS_Int21_71aa(name1, name2);
+					break;
+			case 0xa9:              /* LFN Server Create */
+					reg_ax=0x7100; // not implemented yet
+			default:
+					reg_ax=0x7100;
+					CALLBACK_SCF(true); //Check this! What needs this ? See default case
+		}
 		break;
 
+	case 0x73:
+		if (dos.version.major < 7) {
+			CALLBACK_SCF(true);
+			reg_ax=0x7300;
+		} else if (reg_al==3) {
+			MEM_StrCopy(SegPhys(ds)+reg_dx,name1,reg_cx);
+			if (name1[1]==':'&&name1[2]=='\\')
+				reg_dl=name1[0]-'A'+1;
+			else {
+				reg_ax=0xffff;
+				CALLBACK_SCF(true);
+				break;
+			}
+			Bit16u bytes_per_sector,total_clusters,free_clusters;
+			Bit8u sectors_per_cluster;
+			if (DOS_GetFreeDiskSpace(reg_dl,&bytes_per_sector,&sectors_per_cluster,&total_clusters,&free_clusters)) {
+				ext_space_info_t *info = new ext_space_info_t;
+				info->size_of_structure = sizeof(ext_space_info_t);
+				info->structure_version = 0;
+				info->sectors_per_cluster = sectors_per_cluster;
+				info->bytes_per_sector = bytes_per_sector;
+				info->available_clusters_on_drive = free_clusters;
+				info->total_clusters_on_drive = total_clusters;
+				info->available_sectors_on_drive = sectors_per_cluster * free_clusters;
+				info->total_sectors_on_drive = sectors_per_cluster * total_clusters;
+				info->available_allocation_units = free_clusters;
+				info->total_allocation_units = total_clusters;
+				MEM_BlockWrite(SegPhys(es)+reg_di,info,sizeof(ext_space_info_t));
+				delete(info);
+				reg_ax=0;
+				CALLBACK_SCF(false);
+				}
+			else
+				{
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+				}
+			break;
+		} else {
+			CALLBACK_SCF(true);
+			reg_ax=0x7300;
+			break;
+		}
 	case 0xE0:
 	case 0x18:	            	/* NULL Function for CP/M compatibility or Extended rename FCB */
 	case 0x1d:	            	/* NULL Function for CP/M compatibility or Extended rename FCB */
@@ -1158,6 +1324,618 @@ static Bitu DOS_21Handler(void) {
 	return CBRET_NONE;
 }
 
+void DOS_Int21_7139(char *name1, const char *name2) {
+    (void)name2;
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if (DOS_MakeDir(name1)) {
+				reg_ax=0;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_713a(char *name1, const char *name2) {
+    (void)name2;
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if  (DOS_RemoveDir(name1)) {
+				reg_ax=0;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+				LOG(LOG_MISC,LOG_NORMAL)("Remove dir failed on %s with error %X",name1,dos.errorcode);
+		}
+}
+
+void DOS_Int21_713b(char *name1, const char *name2) {
+    (void)name2;
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if  (DOS_ChangeDir(name1)) {
+				reg_ax=0;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_7141(char *name1, const char *name2) {
+    (void)name2;
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if (DOS_UnlinkFile(name1)) {
+				reg_ax=0;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_7143(char *name1, const char *name2) {
+    (void)name2;
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		switch (reg_bl) {
+				case 0x00:                              /* Get */
+				{
+					Bit16u attr_val=reg_cx;
+					if (DOS_GetFileAttr(name1,&attr_val)) {
+							reg_cx=attr_val;
+							reg_ax=0;
+							CALLBACK_SCF(false);
+					} else {
+							CALLBACK_SCF(true);
+							reg_ax=dos.errorcode;
+					}
+					break;
+				};
+				case 0x01:                              /* Set */
+					if (DOS_SetFileAttr(name1,reg_cx)) {
+							reg_ax=0;
+							CALLBACK_SCF(false);
+					} else {
+							CALLBACK_SCF(true);
+							reg_ax=dos.errorcode;
+					}
+					break;
+				case 0x02:				/* Get compressed file size */
+				{
+					reg_ax=0;
+					reg_dx=0;
+					unsigned long size = DOS_GetCompressedFileSize(name1);
+					if (size != (unsigned long)(-1l)) {
+#if defined (WIN32)
+						reg_ax = LOWORD(size);
+						reg_dx = HIWORD(size);
+#endif
+						CALLBACK_SCF(false);
+					} else {
+						CALLBACK_SCF(true);
+						reg_ax=dos.errorcode;
+					}
+					break;
+				}
+				case 0x03:
+				case 0x05:
+				case 0x07:
+				{
+#if defined (WIN32) && !defined(HX_DOS)
+					HANDLE hFile = DOS_CreateOpenFile(name1);
+					if (hFile != INVALID_HANDLE_VALUE) {
+						time_t clock = time(NULL), ttime;
+						struct tm *t = localtime(&clock);
+						FILETIME time;
+						t->tm_isdst = -1;
+						t->tm_sec  = (((int)reg_cx) << 1) & 0x3e;
+						t->tm_min  = (((int)reg_cx) >> 5) & 0x3f;
+						t->tm_hour = (((int)reg_cx) >> 11) & 0x1f;
+						t->tm_mday = (int)(reg_di) & 0x1f;
+						t->tm_mon  = ((int)(reg_di >> 5) & 0x0f) - 1;
+						t->tm_year = ((int)(reg_di >> 9) & 0x7f) + 80;
+						ttime=mktime(t);
+						LONGLONG ll = Int32x32To64(ttime, 10000000) + 116444736000000000 + (reg_bl==0x07?reg_si*100000:0);
+						time.dwLowDateTime = (DWORD) ll;
+						time.dwHighDateTime = (DWORD) (ll >> 32);
+						if (!SetFileTime(hFile, reg_bl==0x07?&time:NULL,reg_bl==0x05?&time:NULL,reg_bl==0x03?&time:NULL)) {
+							CloseHandle(hFile);
+							CALLBACK_SCF(true);
+							reg_ax=dos.errorcode;
+							break;
+						}
+						CloseHandle(hFile);
+						reg_ax=0;
+						CALLBACK_SCF(false);
+					} else
+#endif
+					{
+						CALLBACK_SCF(true);
+						reg_ax=dos.errorcode;
+					}
+					break;
+				}
+				case 0x04:
+				case 0x06:
+				case 0x08:
+#if !defined(HX_DOS)
+					struct stat status;
+					if (DOS_GetFileAttrEx(name1, &status)) {
+						const struct tm * ltime;
+						time_t ttime=reg_bl==0x04?status.st_mtime:reg_bl==0x06?status.st_atime:status.st_ctime;
+						if ((ltime=localtime(&ttime))!=0) {
+							reg_cx=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
+							reg_di=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
+						}
+						if (reg_bl==0x08)
+							reg_si = 0;
+						reg_ax=0;
+						CALLBACK_SCF(false);
+					} else
+#endif
+					{
+						CALLBACK_SCF(true);
+						reg_ax=dos.errorcode;
+					}
+					break;
+				default:
+						E_Exit("DOS:Illegal LFN Attr call %2X",reg_bl);
+		}
+}
+
+void DOS_Int21_7147(char *name1, const char *name2) {
+    (void)name2;
+		DOS_PSP psp(dos.psp());
+		psp.StoreCommandTail();
+		if (DOS_GetCurrentDir(reg_dl,name1,true)) {
+				MEM_BlockWrite(SegPhys(ds)+reg_si,name1,(Bitu)(strlen(name1)+1));
+				psp.RestoreCommandTail();
+				reg_ax=0;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_714e(char *name1, char *name2) {
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if (!DOS_GetSFNPath(name1,name2,false)) {
+			reg_ax=dos.errorcode;
+			CALLBACK_SCF(true);
+			return;
+		}
+		Bit16u entry;
+		Bit8u i,handle=(Bit8u)DOS_FILES;
+		for (i=1;i<DOS_FILES;i++) {
+			if (!Files[i]) {
+				handle=i;
+				break;
+			}
+		}
+		if (handle==DOS_FILES) {
+			reg_ax=DOSERR_TOO_MANY_OPEN_FILES;
+			CALLBACK_SCF(true);
+			return;
+		}
+		if (strlen(name2)>2&&name2[strlen(name2)-2]=='\\'&&name2[strlen(name2)-1]=='*')
+			strcat(name2, ".*");
+		lfn_filefind_handle=handle;
+		bool b=DOS_FindFirst(name2,reg_cx,false);
+		lfn_filefind_handle=LFN_FILEFIND_NONE;
+		int error=dos.errorcode;
+		Bit16u attribute = 0;
+		if (!b&&!(strlen(name2)==3&&*(name2+1)==':'&&*(name2+2)=='\\')&&DOS_GetFileAttr(name2, &attribute) && (attribute&DOS_ATTR_DIRECTORY)) {
+			strcat(name2,"\\*.*");
+			lfn_filefind_handle=handle;
+			b=DOS_FindFirst(name2,reg_cx,false);
+			lfn_filefind_handle=LFN_FILEFIND_NONE;
+			error=dos.errorcode;
+		}
+		if (b) {
+				DOS_PSP psp(dos.psp());
+				entry = psp.FindFreeFileEntry();
+				if (entry==0xff) {
+					reg_ax=DOSERR_TOO_MANY_OPEN_FILES;
+					CALLBACK_SCF(true);
+					return;
+				}
+				if (handle>=DOS_DEVICES||!Devices[handle])
+					{
+					int m=0;
+					for (int i=1;i<DOS_DEVICES;i++)
+						if (Devices[i]) m=i;
+					Files[handle]=new DOS_Device(*Devices[m]);
+					}
+				else
+					Files[handle]=new DOS_Device(*Devices[handle]);
+				Files[handle]->AddRef();
+				psp.SetFileHandle(entry,handle);
+				reg_ax=handle;
+				DOS_DTA dta(dos.dta());
+				char finddata[CROSS_LEN];
+				int c=0;
+				MEM_BlockWrite(SegPhys(es)+reg_di,finddata,dta.GetFindData((int)reg_si,finddata,&c));
+				reg_cx=c;
+				CALLBACK_SCF(false);
+		} else {
+				dos.errorcode=error;
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_714f(const char *name1, const char *name2) {
+    (void)name1;
+    (void)name2;
+		Bit8u handle=(Bit8u)reg_bx;
+		if (!handle || handle>=DOS_FILES || !Files[handle]) {
+			reg_ax=DOSERR_INVALID_HANDLE;
+			CALLBACK_SCF(true);
+			return;
+		}
+		lfn_filefind_handle=handle;
+		if (DOS_FindNext()) {
+				DOS_DTA dta(dos.dta());
+				char finddata[CROSS_LEN];
+				int c=0;
+				MEM_BlockWrite(SegPhys(es)+reg_di,finddata,dta.GetFindData((int)reg_si,finddata,&c));
+				reg_cx=c;
+				CALLBACK_SCF(false);
+				reg_ax=0x4f00+handle;
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+		lfn_filefind_handle=LFN_FILEFIND_NONE;
+}
+
+void DOS_Int21_7156(char *name1, char *name2) {
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		MEM_StrCopy(SegPhys(es)+reg_di,name2+1,DOSNAMEBUF);
+		*name2='\"';
+		p=name2+strlen(name2);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if (DOS_Rename(name1,name2)) {
+				reg_ax=0;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_7160(char *name1, char *name2) {
+		MEM_StrCopy(SegPhys(ds)+reg_si,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if (DOS_Canonicalize(name1,name2)) {
+				strcpy(name1,"\"");
+				strcat(name1,name2);
+				strcat(name1,"\"");
+				switch(reg_cl)          {
+						case 0:         // Canonoical path name
+								strcpy(name2,name1);
+								MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
+								reg_ax=0;
+								CALLBACK_SCF(false);
+								break;
+						case 1:         // SFN path name
+								if (DOS_GetSFNPath(name1,name2,false)) {
+									MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
+									reg_ax=0;
+									CALLBACK_SCF(false);
+								} else {
+									reg_ax=2;
+									CALLBACK_SCF(true);
+								}
+								break;
+						case 2:         // LFN path name
+								if (DOS_GetSFNPath(name1,name2,true)) {
+									MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
+									reg_ax=0;
+									CALLBACK_SCF(false);
+								} else {
+									reg_ax=2;
+									CALLBACK_SCF(true);
+								}
+								break;
+						default:
+								E_Exit("DOS:Illegal LFN GetName call %2X",reg_cl);
+				}
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_716c(char *name1, const char *name2) {
+    (void)name2;
+		MEM_StrCopy(SegPhys(ds)+reg_si,name1+1,DOSNAMEBUF);
+		*name1='\"';
+		char *p=name1+strlen(name1);
+		while (*p==' '||*p==0) p--;
+		*(p+1)='\"';
+		*(p+2)=0;
+		if (DOS_OpenFileExtended(name1,reg_bx,reg_cx,reg_dx,&reg_ax,&reg_cx)) {
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_71a0(char *name1, char *name2) {
+		MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+		if (DOS_Canonicalize(name1,name2)) {
+				if (reg_cx > 3)
+						MEM_BlockWrite(SegPhys(es)+reg_di,"FAT",4);
+				reg_ax=0;
+				reg_bx=0x4006;
+				reg_cx=0xff;
+				reg_dx=0x104;
+				CALLBACK_SCF(false);
+		} else {
+				reg_ax=dos.errorcode;
+				CALLBACK_SCF(true);
+		}
+}
+
+void DOS_Int21_71a1(const char *name1, const char *name2) {
+    (void)name1;
+    (void)name2;
+		Bit8u handle=(Bit8u)reg_bx;
+		if (!handle || handle>=DOS_FILES || !Files[handle]) {
+			reg_ax=DOSERR_INVALID_HANDLE;
+			CALLBACK_SCF(true);
+			return;
+		}
+		DOS_PSP psp(dos.psp());
+		Bit16u entry=psp.FindEntryByHandle(handle);
+		if (entry>0&&entry!=0xff) psp.SetFileHandle(entry,0xff);
+		if (entry>0&&Files[handle]->RemoveRef()<=0) {
+			delete Files[handle];
+			Files[handle]=0;
+		}
+		reg_ax=0;
+		CALLBACK_SCF(false);
+}
+
+void DOS_Int21_71a6(const char *name1, const char *name2) {
+    (void)name1;
+    (void)name2;
+	char buf[64];
+	unsigned long serial_number=0x1234,st=0,cdate=0,ctime=0,adate=0,atime=0,mdate=0,mtime=0;
+	Bit8u entry=(Bit8u)reg_bx, handle;
+	if (entry>=DOS_FILES) {
+		reg_ax=DOSERR_INVALID_HANDLE;
+		CALLBACK_SCF(true);
+		return;
+	}
+	DOS_PSP psp(dos.psp());
+	for (unsigned int i=0;i<=DOS_FILES;i++)
+		if (Files[i] && psp.FindEntryByHandle(i)==entry)
+			handle=i;
+	if (handle < DOS_FILES && Files[handle] && Files[handle]->name!="") {
+		struct stat status;
+		if (DOS_GetFileAttrEx(Files[handle]->name.c_str(), &status, Files[handle]->GetDrive())) {
+#if !defined(HX_DOS)
+			time_t ttime;
+			const struct tm * ltime;
+			ttime=status.st_ctime;
+			if ((ltime=localtime(&ttime))!=0) {
+				ctime=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
+				cdate=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
+			}
+			ttime=status.st_atime;
+			if ((ltime=localtime(&ttime))!=0) {
+				atime=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
+				adate=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
+			}
+			ttime=status.st_mtime;
+			if ((ltime=localtime(&ttime))!=0) {
+				mtime=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
+				mdate=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
+			}
+#endif
+			sprintf(buf,"%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s",(char*)&st,(char*)&ctime,(char*)&cdate,(char*)&atime,(char*)&adate,(char*)&mtime,(char*)&mdate,(char*)&serial_number,(char*)&st,(char*)&st,(char*)&st,(char*)&st,(char*)&handle);
+			for (int i=32;i<36;i++) buf[i]=0;
+			buf[36]=(char)((Bit32u)status.st_size%256);
+			buf[37]=(char)(((Bit32u)status.st_size%65536)/256);
+			buf[38]=(char)(((Bit32u)status.st_size%16777216)/65536);
+			buf[39]=(char)((Bit32u)status.st_size/16777216);
+			buf[40]=(char)status.st_nlink;
+			for (int i=41;i<47;i++) buf[i]=0;
+			buf[52]=0;
+			MEM_BlockWrite(SegPhys(ds)+reg_dx,buf,53);
+			reg_ax=0;
+			CALLBACK_SCF(false);
+		} else {
+			reg_ax=dos.errorcode;
+			CALLBACK_SCF(true);
+		}
+	} else {
+		reg_ax=dos.errorcode;
+		CALLBACK_SCF(true);
+	}
+}
+
+void DOS_Int21_71a7(const char *name1, const char *name2) {
+    (void)name1;
+    (void)name2;
+	switch (reg_bl) {
+			case 0x00:
+					reg_cl=mem_readb(SegPhys(ds)+reg_si);	//not yet a proper implementation,
+					reg_ch=mem_readb(SegPhys(ds)+reg_si+1);	//but MS-DOS 7 and 4DOS DIR should
+					reg_dl=mem_readb(SegPhys(ds)+reg_si+4);	//show date/time correctly now
+					reg_dh=mem_readb(SegPhys(ds)+reg_si+5);
+					reg_bh=0;
+					reg_ax=0;
+					CALLBACK_SCF(false);
+					break;
+			case 0x01:
+					mem_writeb(SegPhys(es)+reg_di,reg_cl);
+					mem_writeb(SegPhys(es)+reg_di+1,reg_ch);
+					mem_writeb(SegPhys(es)+reg_di+4,reg_dl);
+					mem_writeb(SegPhys(es)+reg_di+5,reg_dh);
+					reg_ax=0;
+					CALLBACK_SCF(false);
+					break;
+			default:
+					E_Exit("DOS:Illegal LFN TimeConv call %2X",reg_bl);
+	}
+}
+
+void DOS_Int21_71a8(char* name1, const char* name2) {
+    (void)name2;
+	if (reg_dh == 0 || reg_dh == 1) {
+			MEM_StrCopy(SegPhys(ds)+reg_si,name1,DOSNAMEBUF);
+			int i,j=0,o=0;
+            char c[13];
+            const char* s = strrchr(name1, '.');
+			for (i=0;i<8;j++) {
+					if (name1[j] == 0 || s-name1 <= j) break;
+					if (name1[j] == '.') continue;
+					c[o++] = toupper(name1[j]);
+					i++;
+			}
+			if (s != NULL) {
+					s++;
+					if (s != 0 && reg_dh == 1) c[o++] = '.';
+					for (i=0;i<3;i++) {
+							if (*(s+i) == 0) break;
+							c[o++] = toupper(*(s+i));
+					}
+			}
+			assert(o <= 12);
+			c[o] = 0;
+			MEM_BlockWrite(SegPhys(es)+reg_di,c,strlen(c)+1);
+			reg_ax=0;
+			CALLBACK_SCF(false);
+	} else {
+			reg_ax=1;
+			CALLBACK_SCF(true);
+	}
+}
+
+void DOS_Int21_71aa(char* name1, const char* name2) {
+    (void)name2;
+	if (reg_bh<3 && (reg_bl<1 || reg_bl>26)) {
+			reg_ax = DOSERR_INVALID_DRIVE;
+			CALLBACK_SCF(true);
+			return;
+	}
+	switch (reg_bh) {
+		case 0:
+		{
+			Bit8u drive=reg_bl-1;
+			if (drive==DOS_GetDefaultDrive() || Drives[drive] || drive==25) {
+				reg_ax = DOSERR_INVALID_DRIVE;
+				CALLBACK_SCF(true);
+			} else {
+				MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+				char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
+				strcpy(mountstring,"MOUNT ");
+				char temp_str[3] = { 0,0,0 };
+				temp_str[0]=(char)('A'+reg_bl-1);
+				temp_str[1]=' ';
+				strcat(mountstring,temp_str);
+				strcat(mountstring,name1);
+				strcat(mountstring," >nul");
+				DOS_Shell temp;
+				temp.ParseLine(mountstring);
+				if (Drives[drive]) {
+					reg_ax=0;
+					CALLBACK_SCF(false);
+				} else {
+					reg_ax=DOSERR_PATH_NOT_FOUND;
+					CALLBACK_SCF(true);
+				}
+			}
+			break;
+		}
+		case 1:
+		{
+			Bit8u drive=reg_bl-1;
+			if (drive==DOS_GetDefaultDrive() || !Drives[drive] || drive==25) {
+				reg_ax = DOSERR_INVALID_DRIVE;
+				CALLBACK_SCF(true);
+			} else {
+				char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
+				strcpy(mountstring,"MOUNT -u ");
+				char temp_str[2] = { 0,0 };
+				temp_str[0]=(char)('A'+reg_bl-1);
+				strcat(mountstring,temp_str);
+				strcat(mountstring," >nul");
+				DOS_Shell temp;
+				temp.ParseLine(mountstring);
+				if (!Drives[drive]) {
+					reg_ax =0;
+					CALLBACK_SCF(false);
+				} else {
+					reg_ax=5;
+					CALLBACK_SCF(true);
+				}
+			}
+			break;
+		}
+		case 2:
+		{
+			Bit8u drive=reg_bl>0?reg_bl-1:DOS_GetDefaultDrive();
+			if (Drives[drive]&&!strncmp(Drives[drive]->GetInfo(),"local directory ",16)) {
+				strcpy(name1,Drives[drive]->GetInfo()+16);
+				MEM_BlockWrite(SegPhys(ds)+reg_dx,name1,(Bitu)(strlen(name1)+1));
+				reg_ax=0;
+				CALLBACK_SCF(false);
+			} else {
+				reg_ax=3;
+				CALLBACK_SCF(true);
+			}
+			break;
+		}
+		default:
+			E_Exit("DOS:Illegal LFN Subst call %2X",reg_bh);
+	}
+}
 
 static Bitu DOS_20Handler(void) {
 	reg_ah=0x00;
@@ -1255,6 +2033,28 @@ public:
 		dos.version.minor=0;
 		dos.direct_output=false;
 		dos.internal_output=false;
+
+		const Section_prop* section = static_cast<Section_prop*>(configuration);
+		if (!strcmp(section->Get_string("lfn"), "true")) enablelfn=1;
+		else if (!strcmp(section->Get_string("lfn"), "false")) enablelfn=0;
+		else if (!strcmp(section->Get_string("lfn"), "autostart")) enablelfn=-2;
+		else enablelfn=-1;
+
+		std::string ver = section->Get_string("ver");
+		if (!ver.empty()) {
+			const char *s = ver.c_str();
+
+			if (isdigit(*s)) {
+				dos.version.minor=0;
+				dos.version.major=(int)strtoul(s,(char**)(&s),10);
+				if (*s == '.' || *s == ' ') {
+					s++;
+					if (isdigit(*s))
+						dos.version.minor=(*(s-1)=='.'&&strlen(s)==1?10:1)*(int)strtoul(s,(char**)(&s),10);
+				}
+			}
+		}
+		uselfn = enablelfn==1 || ((enablelfn == -1 || enablelfn == -2) && dos.version.major>6);
 	}
 	~DOS(){
 		for (Bit16u i=0;i<DOS_DRIVES;i++) delete Drives[i];

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1870,13 +1870,13 @@ void DOS_Int21_71aa(char* name1, const char* name2) {
 			} else {
 				MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 				char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-				strcpy(mountstring,"MOUNT ");
+				safe_strcpy(mountstring,"MOUNT ");
 				char temp_str[3] = { 0,0,0 };
 				temp_str[0]=(char)('A'+reg_bl-1);
 				temp_str[1]=' ';
-				strcat(mountstring,temp_str);
-				strcat(mountstring,name1);
-				strcat(mountstring," >nul");
+				safe_strcat(mountstring,temp_str);
+				safe_strcat(mountstring,name1);
+				safe_strcat(mountstring," >nul");
 				DOS_Shell temp;
 				temp.ParseLine(mountstring);
 				if (Drives[drive]) {
@@ -1897,11 +1897,11 @@ void DOS_Int21_71aa(char* name1, const char* name2) {
 				CALLBACK_SCF(true);
 			} else {
 				char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-				strcpy(mountstring,"MOUNT -u ");
+				safe_strcpy(mountstring,"MOUNT -u ");
 				char temp_str[2] = { 0,0 };
 				temp_str[0]=(char)('A'+reg_bl-1);
-				strcat(mountstring,temp_str);
-				strcat(mountstring," >nul");
+				safe_strcat(mountstring,temp_str);
+				safe_strcat(mountstring," >nul");
 				DOS_Shell temp;
 				temp.ParseLine(mountstring);
 				if (!Drives[drive]) {

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -18,10 +18,6 @@
  *  Wengier: LFN support
  */
 
-#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
-# define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1197,7 +1197,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 
 	case 0x71:					/* Unknown probably 4dos detection */
-		printf("DOS:Windows long file name support call %2X\n",reg_al);
+		printf("DOS:MS-DOS 7.x long file name support call %2X\n",reg_al);
 		if (!uselfn) {
 				reg_ax=0x7100;
 				CALLBACK_SCF(true); //Check this! What needs this ? See default case
@@ -1256,7 +1256,7 @@ static Bitu DOS_21Handler(void) {
 					DOS_Int21_71aa(name1, name2);
 					break;
 			case 0xa9:              /* LFN Server Create */
-					reg_ax=0x7100; // not implemented yet
+					reg_ax=0x7100; // unimplemented (not very useful)
 			default:
 					reg_ax=0x7100;
 					CALLBACK_SCF(true); //Check this! What needs this ? See default case

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1445,7 +1445,7 @@ void DOS_Int21_7143(char *name1, const char *name2) {
 				case 0x05:
 				case 0x07:
 				{
-#if defined (WIN32) && !defined(HX_DOS)
+#if defined (WIN32)
 					HANDLE hFile = DOS_CreateOpenFile(name1);
 					if (hFile != INVALID_HANDLE_VALUE) {
 						time_t clock = time(NULL), ttime;
@@ -1482,7 +1482,6 @@ void DOS_Int21_7143(char *name1, const char *name2) {
 				case 0x04:
 				case 0x06:
 				case 0x08:
-#if !defined(HX_DOS)
 					struct stat status;
 					if (DOS_GetFileAttrEx(name1, &status)) {
 						const struct tm * ltime;
@@ -1496,7 +1495,6 @@ void DOS_Int21_7143(char *name1, const char *name2) {
 						reg_ax=0;
 						CALLBACK_SCF(false);
 					} else
-#endif
 					{
 						CALLBACK_SCF(true);
 						reg_ax=dos.errorcode;
@@ -1758,7 +1756,6 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
 	if (handle < DOS_FILES && Files[handle] && Files[handle]->name!="") {
 		struct stat status;
 		if (DOS_GetFileAttrEx(Files[handle]->name.c_str(), &status, Files[handle]->GetDrive())) {
-#if !defined(HX_DOS)
 			time_t ttime;
 			const struct tm * ltime;
 			ttime=status.st_ctime;
@@ -1776,7 +1773,6 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
 				mtime=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
 				mdate=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
 			}
-#endif
 			sprintf(buf,"%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s",(char*)&st,(char*)&ctime,(char*)&cdate,(char*)&atime,(char*)&adate,(char*)&mtime,(char*)&mdate,(char*)&serial_number,(char*)&st,(char*)&st,(char*)&st,(char*)&st,(char*)&handle);
 			for (int i=32;i<36;i++) buf[i]=0;
 			buf[36]=(char)((Bit32u)status.st_size%256);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -18,7 +18,6 @@
  *  Wengier: LFN support
  */
 
-
 #include <string.h>
 #include <stdlib.h>
 #include "dosbox.h"
@@ -352,7 +351,6 @@ bool DOS_PSP::SetNumFiles(Bit16u fileNum) {
 	return true;
 }
 
-
 void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
 	unsigned int i;
 
@@ -399,7 +397,6 @@ void DOS_DTA::SetResult(const char * _name,const char * _lname,Bit32u _size,Bit1
 		sSave(sDTA,attr,_attr);
 	}
 }
-
 
 void DOS_DTA::GetResult(char * _name,char * _lname,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr) {
 	strcpy(_lname,fd.lname);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -388,8 +388,8 @@ void DOS_DTA::SetResult(const char * _name,const char * _lname,Bit32u _size,Bit1
 	fd.mdate=_date;
 	fd.mtime=_time;
 	fd.attr=_attr;
-	strcpy(fd.lname,_lname);
-	strcpy(fd.sname,_name);
+	safe_strcpy(fd.lname,_lname);
+	safe_strcpy(fd.sname,_name);
 	if (!strcmp(fd.lname,fd.sname)) fd.sname[0]=0;
 	if (lfn_filefind_handle>=LFN_FILEFIND_MAX) {
 		MEM_BlockWrite(pt+offsetof(sDTA,name),(void *)_name,strlen(_name)+1);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -14,6 +14,8 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  Wengier: LFN support
  */
 
 
@@ -23,7 +25,24 @@
 #include "mem.h"
 #include "dos_inc.h"
 #include "support.h"
+#include "drives.h"
 
+#define CTBUF 127
+Bit8u sdriv[260], sattr[260], fattr;
+char sname[260][LFN_NAMELENGTH+1],storect[CTBUF];
+extern int lfn_filefind_handle;
+
+struct finddata {
+       Bit8u attr;
+       Bit8u fres1[19];
+       Bit32u mtime;
+       Bit32u mdate;
+       Bit32u hsize;
+       Bit32u size;
+       Bit8u fres2[8];
+       char lname[260];
+       char sname[14];
+} fd;
 
 void DOS_ParamBlock::Clear(void) {
 	memset(&exec,0,sizeof(exec));
@@ -288,11 +307,21 @@ void DOS_PSP::RestoreVectors(void) {
 
 void DOS_PSP::SetCommandTail(RealPt src) {
 	if (src) {	// valid source
-		MEM_BlockCopy(pt+offsetof(sPSP,cmdtail),Real2Phys(src),128);
+		MEM_BlockCopy(pt+offsetof(sPSP,cmdtail),Real2Phys(src),CTBUF+1);
 	} else {	// empty
 		sSave(sPSP,cmdtail.count,0x00);
 		mem_writeb(pt+offsetof(sPSP,cmdtail.buffer),0x0d);
 	};
+}
+
+void DOS_PSP::StoreCommandTail() {
+	int len=(int)mem_strlen(pt+offsetof(sPSP,cmdtail.buffer));
+	MEM_StrCopy(pt+offsetof(sPSP,cmdtail.buffer),storect,len>CTBUF?CTBUF:len);
+}
+
+void DOS_PSP::RestoreCommandTail() {
+	mem_writeb(pt+offsetof(sPSP,cmdtail.count),strlen(storect)>0?(Bit8u)(strlen(storect)-1):0);
+	MEM_BlockWrite(pt+offsetof(sPSP,cmdtail.buffer),storect,strlen(storect));
 }
 
 void DOS_PSP::SetFCB1(RealPt src) {
@@ -325,54 +354,107 @@ bool DOS_PSP::SetNumFiles(Bit16u fileNum) {
 
 
 void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
+	unsigned int i;
+
+	if (lfn_filefind_handle<LFN_FILEFIND_NONE) {
+		sdriv[lfn_filefind_handle]=_sdrive;
+		sattr[lfn_filefind_handle]=_sattr;
+		for (i=0;i<LFN_NAMELENGTH;i++) {
+			if (pattern[i]==0) break;
+				sname[lfn_filefind_handle][i]=pattern[i];
+		}
+		while (i<=LFN_NAMELENGTH) sname[lfn_filefind_handle][i++]=0;
+	}
+    for (i=0;i<11;i++) mem_writeb(pt+offsetof(sDTA,spname)+i,0);
+
 	sSave(sDTA,sdrive,_sdrive);
 	sSave(sDTA,sattr,_sattr);
-	/* Fill with spaces */
-	Bitu i;
-	for (i=0;i<11;i++) mem_writeb(pt+offsetof(sDTA,sname)+i,' ');
-	char * find_ext;
-	find_ext=strchr(pattern,'.');
-	if (find_ext) {
-		Bitu size=(Bitu)(find_ext-pattern);
+    const char* find_ext;
+    find_ext=strchr(pattern,'.');
+    if (find_ext) {
+        Bitu size=(Bitu)(find_ext-pattern);
 		if (size>8) size=8;
-		MEM_BlockWrite(pt+offsetof(sDTA,sname),pattern,size);
-		find_ext++;
-		MEM_BlockWrite(pt+offsetof(sDTA,sext),find_ext,(strlen(find_ext)>3) ? 3 : (Bitu)strlen(find_ext));
+			MEM_BlockWrite(pt+offsetof(sDTA,spname),pattern,size);
+			find_ext++;
+			MEM_BlockWrite(pt+offsetof(sDTA,spext),find_ext,(strlen(find_ext)>3) ? 3 : (Bitu)strlen(find_ext));
 	} else {
-		MEM_BlockWrite(pt+offsetof(sDTA,sname),pattern,(strlen(pattern) > 8) ? 8 : (Bitu)strlen(pattern));
+		MEM_BlockWrite(pt+offsetof(sDTA,spname),pattern,(strlen(pattern) > 8) ? 8 : (Bitu)strlen(pattern));
 	}
 }
 
-void DOS_DTA::SetResult(const char * _name,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr) {
-	MEM_BlockWrite(pt+offsetof(sDTA,name),(void *)_name,strlen(_name)+1);
-	sSave(sDTA,size,_size);
-	sSave(sDTA,date,_date);
-	sSave(sDTA,time,_time);
-	sSave(sDTA,attr,_attr);
+void DOS_DTA::SetResult(const char * _name,const char * _lname,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr) {
+	fd.hsize=0;
+	fd.size=_size;
+	fd.mdate=_date;
+	fd.mtime=_time;
+	fd.attr=_attr;
+	strcpy(fd.lname,_lname);
+	strcpy(fd.sname,_name);
+	if (!strcmp(fd.lname,fd.sname)) fd.sname[0]=0;
+	if (lfn_filefind_handle>=LFN_FILEFIND_MAX) {
+		MEM_BlockWrite(pt+offsetof(sDTA,name),(void *)_name,strlen(_name)+1);
+		sSave(sDTA,size,_size);
+		sSave(sDTA,date,_date);
+		sSave(sDTA,time,_time);
+		sSave(sDTA,attr,_attr);
+	}
 }
 
 
-void DOS_DTA::GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr) {
-	MEM_BlockRead(pt+offsetof(sDTA,name),_name,DOS_NAMELENGTH_ASCII);
-	_size=sGet(sDTA,size);
-	_date=(Bit16u)sGet(sDTA,date);
-	_time=(Bit16u)sGet(sDTA,time);
-	_attr=(Bit8u)sGet(sDTA,attr);
+void DOS_DTA::GetResult(char * _name,char * _lname,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr) {
+	strcpy(_lname,fd.lname);
+	if (fd.sname[0]!=0) strcpy(_name,fd.sname);
+	else if (strlen(fd.lname)<DOS_NAMELENGTH_ASCII) strcpy(_name,fd.lname);
+	_size = fd.size;
+	_date = fd.mdate;
+	_time = fd.mtime;
+	_attr = fd.attr;
+	if (lfn_filefind_handle>=LFN_FILEFIND_MAX) {
+		MEM_BlockRead(pt+offsetof(sDTA,name),_name,DOS_NAMELENGTH_ASCII);
+		_size=sGet(sDTA,size);
+		_date=(Bit16u)sGet(sDTA,date);
+		_time=(Bit16u)sGet(sDTA,time);
+		_attr=(Bit8u)sGet(sDTA,attr);
+	}
+}
+
+int DOS_DTA::GetFindData(int fmt, char * fdstr, int *c) {
+	if (fmt==1)
+		sprintf(fdstr,"%-1s%-19s%-2s%-2s%-4s%-4s%-4s%-8s%-260s%-14s",(char*)&fd.attr,(char*)&fd.fres1,(char*)&fd.mtime,(char*)&fd.mdate,(char*)&fd.mtime,(char*)&fd.hsize,(char*)&fd.size,(char*)&fd.fres2,(char*)&fd.lname,(char*)&fd.sname);
+	else
+		sprintf(fdstr,"%-1s%-19s%-4s%-4s%-4s%-4s%-8s%-260s%-14s",(char*)&fd.attr,(char*)&fd.fres1,(char*)&fd.mtime,(char*)&fd.mdate,(char*)&fd.hsize,(char*)&fd.size,(char*)&fd.fres2,(char*)&fd.lname,(char*)&fd.sname);
+	for (int i=0;i<4;i++) fdstr[28+i]=0;
+    fdstr[32]=(char)fd.size%256;
+    fdstr[33]=(char)((fd.size%65536)/256);
+    fdstr[34]=(char)((fd.size%16777216)/65536);
+    fdstr[35]=(char)(fd.size/16777216);
+    fdstr[44+strlen(fd.lname)]=0;
+    fdstr[304+strlen(fd.sname)]=0;
+	if (!strcmp(fd.sname,"?")&&strlen(fd.lname))
+		*c=2;
+	else
+		*c=!strchr(fd.sname,'?')&&strchr(fd.lname,'?')?1:0;
+    return (sizeof(fd));
 }
 
 Bit8u DOS_DTA::GetSearchDrive(void) {
-	return (Bit8u)sGet(sDTA,sdrive);
+	return lfn_filefind_handle>=LFN_FILEFIND_MAX?(Bit8u)sGet(sDTA,sdrive):sdriv[lfn_filefind_handle];
 }
 
-void DOS_DTA::GetSearchParams(Bit8u & attr,char * pattern) {
-	attr=(Bit8u)sGet(sDTA,sattr);
-	char temp[11];
-	MEM_BlockRead(pt+offsetof(sDTA,sname),temp,11);
-	memcpy(pattern,temp,8);
-	pattern[8]='.';
-	memcpy(&pattern[9],&temp[8],3);
-	pattern[12]=0;
-
+void DOS_DTA::GetSearchParams(Bit8u & attr,char * pattern, bool lfn) {
+    if (lfn&&lfn_filefind_handle<LFN_FILEFIND_NONE) {
+		attr=sattr[lfn_filefind_handle];
+        memcpy(pattern,sname[lfn_filefind_handle],LFN_NAMELENGTH);
+        pattern[LFN_NAMELENGTH]=0;
+    } else {
+		attr=(Bit8u)sGet(sDTA,sattr);
+        char temp[11];
+        MEM_BlockRead(pt+offsetof(sDTA,spname),temp,11);
+        for (int i=0;i<13;i++) pattern[i]=0;
+            memcpy(pattern,temp,8);
+            pattern[strlen(pattern)]='.';
+            memcpy(&pattern[strlen(pattern)],&temp[8],3);
+    }
 }
 
 DOS_FCB::DOS_FCB(Bit16u seg,Bit16u off,bool allow_extended) { 

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -107,7 +107,7 @@ DOS_File & DOS_File::operator= (const DOS_File & orig) {
 
 Bit8u DOS_FindDevice(char const * name) {
 	/* should only check for the names before the dot and spacepadded */
-	char fullname[DOS_PATHLENGTH];Bit8u drive;
+	char fullname[LFN_NAMELENGTH+2];Bit8u drive;
 //	if(!name || !(*name)) return DOS_DEVICES; //important, but makename does it
 	if (!DOS_MakeName(name,fullname,&drive)) return DOS_DEVICES;
 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -305,7 +305,7 @@ bool DOS_GetCurrentDir(Bit8u drive,char * const buffer, bool LFN) {
 	}
 
 	if (LFN && uselfn) {
-        char cdir[LFN_NAMELENGTH+2],ldir[LFN_NAMELENGTH+2];
+        char cdir[LFN_NAMELENGTH+6],ldir[LFN_NAMELENGTH+2];
 
 		if (strchr(Drives[drive]->curdir,' '))
 			sprintf(cdir,"\"%c:\\%s\"",drive+'A',Drives[drive]->curdir);
@@ -383,7 +383,7 @@ bool DOS_RemoveDir(char const * const dir) {
 	char currdir[DOS_PATHLENGTH]= { 0 }, lcurrdir[LFN_NAMELENGTH+2]= { 0 };
     DOS_GetCurrentDir(drive + 1 ,currdir, false);
     DOS_GetCurrentDir(drive + 1 ,lcurrdir, true);
-    if(strcasecmp(currdir,fulldir) == 0 || uselfn && strcasecmp(lcurrdir,fulldir) == 0) {
+    if(strcasecmp(currdir,fulldir) == 0 || (uselfn && strcasecmp(lcurrdir,fulldir) == 0)) {
 		DOS_SetError(DOSERR_REMOVE_CURRENT_DIRECTORY);
 		return false;
 	}
@@ -479,7 +479,7 @@ bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst)
 bool DOS_FindNext(void) {
 	DOS_DTA dta(dos.dta());
 	Bit8u i = dta.GetSearchDrive();
-	if(uselfn && i >= DOS_DRIVES || !Drives[i]) i=sdrive;
+	if((uselfn && i >= DOS_DRIVES) || !Drives[i]) i=sdrive;
 	if(i >= DOS_DRIVES || !Drives[i]) {
 		/* Corrupt search. */
 		LOG(LOG_FILES,LOG_ERROR)("Corrupt search!!!!");

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -68,7 +68,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 		return false;
 	}
 	char names[LFN_NAMELENGTH];
-	strcpy(names,name);
+	safe_strcpy(names,name);
 	char * name_int = names;
 	if (strlen(names)==14 && name_int[1]==':' && name_int[2]!='\\' && name_int[9]==' ' && name_int[10]=='.') {
 		for (unsigned int i=0;i<strlen(names);i++)
@@ -237,7 +237,7 @@ bool DOS_GetSFNPath(char const * const path,char * SFNPath,bool LFN) {
     Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
     if (!DOS_MakeName(path,fulldir,&drive)) return false;
     sprintf(SFNPath,"%c:\\",drive+'A');
-    strcpy(LFNPath,SFNPath);
+    safe_strcpy(LFNPath,SFNPath);
     p = fulldir;
     if (*p==0) return true;
 	RealPt save_dta=dos.dta();
@@ -258,9 +258,9 @@ bool DOS_GetSFNPath(char const * const path,char * SFNPath,bool LFN) {
 				lfn_filefind_handle=fbak;
 				dta.GetResult(name,lname,size,date,time,attr);
 				strcat(SFNPath,name);
-				strcat(LFNPath,lname);
+				safe_strcat(LFNPath,lname);
 				strcat(SFNPath,"\\");
-				strcat(LFNPath,"\\");
+				safe_strcat(LFNPath,"\\");
 			}
 			else {
 				lfn_filefind_handle=fbak;
@@ -269,9 +269,9 @@ bool DOS_GetSFNPath(char const * const path,char * SFNPath,bool LFN) {
 			}
 		} else {
 			strcat(SFNPath,p);
-			strcat(LFNPath,p);
+			safe_strcat(LFNPath,p);
 			strcat(SFNPath,"\\");
-			strcat(LFNPath,"\\");
+			safe_strcat(LFNPath,"\\");
 			*s = '\\';
 			p = s + 1;
 			break;
@@ -283,10 +283,10 @@ bool DOS_GetSFNPath(char const * const path,char * SFNPath,bool LFN) {
 		if (!strrchr(p,'*')&&!strrchr(p,'?')&&DOS_FindFirst(pdir,0xffff & ~DOS_ATTR_VOLUME,false)) {
 			dta.GetResult(name,lname,size,date,time,attr);
 			strcat(SFNPath,name);
-			strcat(LFNPath,lname);
+			safe_strcat(LFNPath,lname);
 		} else {
 			strcat(SFNPath,p);
-			strcat(LFNPath,p);
+			safe_strcat(LFNPath,p);
 		}
 		lfn_filefind_handle=fbak;
     }
@@ -778,15 +778,15 @@ bool DOS_UnlinkFile(char const * const name) {
 			return false;
 		}
 		if (!strchr(name,'\"')||!DOS_GetSFNPath(("\""+std::string(fullname)+"\"").c_str(), fname, false))
-			strcpy(fname, fullname);
+			safe_strcpy(fname, fullname);
 		char * find_last=strrchr(fname,'\\');
 		if (!find_last) {
 			dir[0]=0;
-			strcpy(pattern, fname);
+			safe_strcpy(pattern, fname);
 		} else {
 			*find_last=0;
-			strcpy(dir,fname);
-			strcpy(pattern, find_last+1);
+			safe_strcpy(dir,fname);
+			safe_strcpy(pattern, find_last+1);
 		}
 		int k=0;
 		for (int i=0;i<(int)strlen(pattern);i++)
@@ -798,9 +798,9 @@ bool DOS_UnlinkFile(char const * const name) {
 		DOS_DTA dta(dos.dta());
 		std::vector<std::string> cdirs;
 		cdirs.clear();
-		strcpy(spath, dir);
-		if (!DOS_GetSFNPath(dir, spath, false)) strcpy(spath, dir);
-		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+		safe_strcpy(spath, dir);
+		if (!DOS_GetSFNPath(dir, spath, false)) safe_strcpy(spath, dir);
+		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') safe_strcat(spath, "\\");
 		std::string pfull=std::string(spath)+std::string(pattern);
 		int fbak=lfn_filefind_handle;
 		lfn_filefind_handle=LFN_FILEFIND_INTERNAL;
@@ -810,9 +810,9 @@ bool DOS_UnlinkFile(char const * const name) {
 			Bit16u find_date,find_time;Bit32u find_size;Bit8u find_attr;
 			dta.GetResult(find_name,lfind_name,find_size,find_date,find_time,find_attr);
 			if (!(find_attr & DOS_ATTR_DIRECTORY)&&strlen(find_name)&&!strchr(find_name, '*')&&!strchr(find_name, '?')) {
-				strcpy(temp, dir);
-				if (strlen(temp)&&temp[strlen(temp)-1]!='\\') strcat(temp, "\\");
-				strcat(temp, find_name);
+				safe_strcpy(temp, dir);
+				if (strlen(temp)&&temp[strlen(temp)-1]!='\\') safe_strcat(temp, "\\");
+				safe_strcat(temp, find_name);
 				cdirs.push_back(std::string(temp));
 			}
 		} while ((ret=DOS_FindNext())==true);
@@ -853,7 +853,7 @@ bool DOS_GetFileAttrEx(char const* const name, struct stat *status, Bit8u hdrive
 	Bit8u drive;
 	bool usehdrive=hdrive>=0&&hdrive<DOS_FILES;
 	if (usehdrive)
-		strcpy(fullname,name);
+		safe_strcpy(fullname,name);
 	else if (!DOS_MakeName(name, fullname, &drive))
 		return false;
 	return Drives[usehdrive?hdrive:drive]->GetFileAttrEx(fullname, status);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -99,7 +99,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 		return false; 
 	}
 	r=0;w=0;
-	while ((r<(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) && name_int[r]!=0) {
+	while ((r<(Bitu)(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) && name_int[r]!=0) {
 		c=name_int[r++];
 		if (c=='/') c='\\';
 		else if (c=='"') {q++;continue;}
@@ -112,7 +112,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 		upname[w++]=c;
 	}
 	while (r>0 && name_int[r-1]==' ') r--;
-	if (r>=(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) { DOS_SetError(DOSERR_PATH_NOT_FOUND);return false; }
+	if (r>=(Bitu)(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) { DOS_SetError(DOSERR_PATH_NOT_FOUND);return false; }
 	upname[w]=0;
 
 	/* Now parse the new file name to make the final filename */
@@ -216,7 +216,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 				}
 			}
 
-			if (strlen(fullname)+strlen(tempdir)>=(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) {
+			if (strlen(fullname)+strlen(tempdir)>=(unsigned int)(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) {
 				DOS_SetError(DOSERR_PATH_NOT_FOUND);return false;
 			}
 		   

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -18,10 +18,6 @@
  *  Wengier: LFN support
  */
 
-#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
-# define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -18,6 +18,10 @@
  *  Wengier: LFN support
  */
 
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+# define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -897,9 +897,9 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
 		if ((device_type==0x0001) && (font_type==0x0001) && (font_codepage==codepage_id)) {
 			// valid/matching codepage found
 
-			Bit16u number_of_fonts,font_data_length;
+			Bit16u number_of_fonts;//,font_data_length;
 			number_of_fonts=host_readw(&cpi_buf[font_data_header_pt+0x02]);
-			font_data_length=host_readw(&cpi_buf[font_data_header_pt+0x04]);
+			//font_data_length=host_readw(&cpi_buf[font_data_header_pt+0x04]);
 
 			bool font_changed=false;
 			Bit32u font_data_start=font_data_header_pt+0x06;

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -186,7 +186,6 @@ static bool DOS_MultiplexFunctions(void) {
 		char psp_name[9];
 		DOS_MCB psp_mcb(dos.psp()-1);
 		psp_mcb.GetFileName(psp_name);
-		printf("psp_name %s reg_sp %X mem_readw(SegPhys(ss)+reg_sp) %X\n", psp_name, reg_sp, mem_readw(SegPhys(ss)+reg_sp));
 		// Report Windows version 4.0 (95) to NESTICLE x.xx so that it uses LFN when available
 		if (uselfn && (!strcmp(psp_name, "NESTICLE") || (reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F))) {
 			reg_ax = 0;

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -188,7 +188,7 @@ static bool DOS_MultiplexFunctions(void) {
 		psp_mcb.GetFileName(psp_name);
 		printf("psp_name %s reg_sp %X mem_readw(SegPhys(ss)+reg_sp) %X\n", psp_name, reg_sp, mem_readw(SegPhys(ss)+reg_sp));
 		// Report Windows version 4.0 (95) to NESTICLE x.xx so that it uses LFN when available
-		if (uselfn && (!strcmp(psp_name, "NESTICLE") || reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F)) {
+		if (uselfn && (!strcmp(psp_name, "NESTICLE") || (reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F))) {
 			reg_ax = 0;
 			reg_bx = 0x400;
 			reg_cx = 2;

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -181,6 +181,21 @@ static bool DOS_MultiplexFunctions(void) {
 		}
 		else if (reg_bx == 0x18) return true;	// idle callout
 		else return false;
+	case 0x160A:
+	{
+		char psp_name[9];
+		DOS_MCB psp_mcb(dos.psp()-1);
+		psp_mcb.GetFileName(psp_name);
+		printf("psp_name %s reg_sp %X mem_readw(SegPhys(ss)+reg_sp) %X\n", psp_name, reg_sp, mem_readw(SegPhys(ss)+reg_sp));
+		// Report Windows version 4.0 (95) to NESTICLE x.xx so that it uses LFN when available
+		if (uselfn && (!strcmp(psp_name, "NESTICLE") || reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F)) {
+			reg_ax = 0;
+			reg_bx = 0x400;
+			reg_cx = 2;
+			return true;
+		}
+		return false;
+	}
 	case 0x1680:	/*  RELEASE CURRENT VIRTUAL MACHINE TIME-SLICE */
 		//TODO Maybe do some idling but could screw up other systems :)
 		return true; //So no warning in the debugger anymore
@@ -196,6 +211,11 @@ static bool DOS_MultiplexFunctions(void) {
 		SegSet16(es,0xffff);
 		reg_di=0xffff;
 		return true;
+	case 0x4a33:	/* Check MS-DOS Version 7 */
+		if (dos.version.major > 6) {
+			reg_ax=0;
+			return true;
+		}
 	}
 
 	return false;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -703,7 +703,7 @@ public:
 					char buf[257];
 					if (cart_cmd=="?") {
 						while (clen!=0) {
-							strncpy(buf,(char*)&rombuf[ct+1],clen);
+							safe_strncpy(buf,(char*)&rombuf[ct+1],clen);
 							buf[clen]=0;
 							upcase(buf);
 							safe_strcat(cmdlist, " ");
@@ -723,7 +723,7 @@ public:
 						return;
 					} else {
 						while (clen!=0) {
-							strncpy(buf,(char*)&rombuf[ct+1],clen);
+							safe_strncpy(buf,(char*)&rombuf[ct+1],clen);
 							buf[clen]=0;
 							upcase(buf);
 							safe_strcat(cmdlist, " ");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -127,7 +127,8 @@ public:
 		}
 	}
 	void ListMounts(void) {
-		char name[DOS_NAMELENGTH_ASCII];Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
+		char name[DOS_NAMELENGTH_ASCII],lname[LFN_NAMELENGTH];
+        Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
 		/* Command uses dta so set it to our internal dta */
 		RealPt save_dta = dos.dta();
 		dos.dta(dos.tables.tempdta);
@@ -143,7 +144,7 @@ public:
 			char root[7] = {static_cast<char>('A' + d),':','\\','*','.','*',0};
 			bool ret = DOS_FindFirst(root,DOS_ATTR_VOLUME);
 			if (ret) {
-				dta.GetResult(name,size,date,time,attr);
+				dta.GetResult(name,lname,size,date,time,attr);
 				DOS_FindNext(); //Mark entry as invalid
 			} else {
 				name[0] = 0;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -703,7 +703,7 @@ public:
 					char buf[257];
 					if (cart_cmd=="?") {
 						while (clen!=0) {
-							safe_strncpy(buf,(char*)&rombuf[ct+1],clen);
+							strncpy(buf,(char*)&rombuf[ct+1],clen);
 							buf[clen]=0;
 							upcase(buf);
 							safe_strcat(cmdlist, " ");
@@ -723,7 +723,7 @@ public:
 						return;
 					} else {
 						while (clen!=0) {
-							safe_strncpy(buf,(char*)&rombuf[ct+1],clen);
+							strncpy(buf,(char*)&rombuf[ct+1],clen);
 							buf[clen]=0;
 							upcase(buf);
 							safe_strcat(cmdlist, " ");

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -262,9 +262,9 @@ void DOS_Drive_Cache::AddEntryDirOverlay(const char* path, char *sfile, bool che
 
 	char sname[CROSS_LEN], *p=strrchr(sfile, '\\');
 	if (p!=NULL)
-		strcpy(sname, p+1);
+		safe_strcpy(sname, p+1);
 	else
-		strcpy(sname, sfile);
+		safe_strcpy(sname, sfile);
 	if (pos && dir) {
 		safe_strcpy(file, pos + 1);
 		// Check if directory already exists, then don't add new entry...
@@ -841,7 +841,7 @@ char* DOS_Drive_Cache::CreateEntry(CFileInfo* dir, const char* name, const char*
 		dir->fileList.push_back(info);
 	}
 	static char sgenname[DOS_NAMELENGTH+1];
-	strcpy(sgenname, info->shortname);
+	safe_strcpy(sgenname, info->shortname);
 	return sgenname;
 }
 

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -533,8 +533,6 @@ Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName, const size
 	// Remove dot, if no extension...
 	RemoveTrailingDot(shortName);
 	// Search long name and return array number of element
-	Bits low	= 0;
-	Bits high	= (Bits)(filelist_size-1);
 	Bits res;
 	if (strlen(shortName))
 		for (Bitu i=0; i<filelist_size; i++) {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -88,7 +88,7 @@ char sfn[DOS_NAMELENGTH_ASCII];
 /* Generate 8.3 names from LFNs, with tilde usage (from ~1 to ~9999). */
 char* fatDrive::Generate_SFN(const char *path, const char *name) {
 	if (!filename_not_8x3(name)) {
-		strcpy(sfn, name);
+		safe_strcpy(sfn, name);
 		upcase(sfn);
 		return sfn;
 	}
@@ -98,7 +98,7 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 		strncpy(lfn, name, LFN_NAMELENGTH);
 		lfn[LFN_NAMELENGTH]=0;
 	} else
-		strcpy(lfn, name);
+		safe_strcpy(lfn, name);
 	if (!strlen(lfn)) return NULL;
 	direntry fileEntry = {};
 	Bit32u dirClust, subEntry;
@@ -161,8 +161,8 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 			}
 			sfn[i++]=0;
 		}
-		strcpy(fullname, path);
-		strcat(fullname, sfn);
+		safe_strcpy(fullname, path);
+		safe_strcat(fullname, sfn);
 		if(!getFileDirEntry(fullname, &fileEntry, &dirClust, &subEntry,/*dirOk*/true)) return sfn;
 		k++;
 	}
@@ -1166,7 +1166,7 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, Bit16u attributes) {
 
 			if (lfn != NULL) {
 				lfn++; /* step past '\' */
-				strcpy(path, name);
+				safe_strcpy(path, name);
 				*(strrchr(path,'\\')+1)=0;
 			} else {
 				lfn = name; /* no path elements */
@@ -1792,7 +1792,7 @@ bool fatDrive::MakeDir(char *dir) {
 
 		if (lfn != NULL) {
 			lfn++; /* step past '\' */
-			strcpy(path, dir);
+			safe_strcpy(path, dir);
 			*(strrchr(path,'\\')+1)=0;
 		} else {
 			lfn = dir; /* no path elements */
@@ -1936,7 +1936,7 @@ bool fatDrive::Rename(char * oldname, char * newname) {
 
 		if (lfn != NULL) {
 			lfn++; /* step past '\' */
-			strcpy(path, newname);
+			safe_strcpy(path, newname);
 			*(strrchr(path,'\\')+1)=0;
 		} else {
 			lfn = newname; /* no path elements */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -95,7 +95,7 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 	char lfn[LFN_NAMELENGTH+1], fullname[DOS_PATHLENGTH+DOS_NAMELENGTH_ASCII], *n;
 	if (name==NULL||!*name) return NULL;
 	if (strlen(name)>LFN_NAMELENGTH) {
-		strncpy(lfn, name, LFN_NAMELENGTH);
+		safe_strncpy(lfn, name, LFN_NAMELENGTH);
 		lfn[LFN_NAMELENGTH]=0;
 	} else
 		safe_strcpy(lfn, name);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -298,7 +298,7 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 		if (IS_HIDDEN(FLAGS1)) findAttr |= DOS_ATTR_HIDDEN;
 
 		if (strcmp((char*)de.ident,(char*)fullname))
-			strcpy(lfindName,fullname);
+			safe_strcpy(lfindName,fullname);
 		else
 			GetLongName((char*)de.ident,lfindName);
 
@@ -523,7 +523,7 @@ int isoDrive :: readDirEntry(isoDirEntry *de, Bit8u *data) {
 			if (de->ident[tmp - 1] == '.') de->ident[tmp - 1] = 0;
 		}
 	}
-	strcpy((char*)fullname,(char*)de->ident);
+	safe_strcpy(fullname,(char*)de->ident);
 	char* dotpos = strchr((char*)de->ident, '.');
 	if (dotpos!=NULL) {
 		if (strlen(dotpos)>4) dotpos[4]=0;

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -575,7 +575,7 @@ bool isoDrive :: lookup(isoDirEntry *de, const char *path) {
 			int dirIterator = GetDirIterator(de);
 			while (!found && GetNextDirEntry(dirIterator, de)) {
 				GetLongName((char*)de->ident,longname);
-				if (!IS_ASSOC(FLAGS2) && (0 == strncasecmp((char*) de->ident, name, ISO_MAX_FILENAME_LENGTH)) ||0 == strncasecmp((char*) longname, name, ISO_MAXPATHNAME)) {
+				if ((!IS_ASSOC(FLAGS2) && (0 == strncasecmp((char*) de->ident, name, ISO_MAX_FILENAME_LENGTH))) ||0 == strncasecmp((char*) longname, name, ISO_MAXPATHNAME)) {
 					found = true;
 				}
 			}

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -306,7 +306,6 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 			&& !(~attr & findAttr & (DOS_ATTR_DIRECTORY | DOS_ATTR_HIDDEN | DOS_ATTR_SYSTEM))) {
 			
 			/* file is okay, setup everything to be copied in DTA Block */
-			char findName[DOS_NAMELENGTH_ASCII];		
 			findName[0] = 0;
 			if(strlen((char*)de.ident) < DOS_NAMELENGTH_ASCII) {
 				safe_strcpy(findName, (char *)de.ident);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -443,10 +443,13 @@ bool localDrive::MakeDir(char * dir) {
 	safe_strcpy(newdir, basedir);
 	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
-#if defined (WIN32)						/* MS Visual C++ */
-	int temp=mkdir(dirCache.GetExpandName(newdir));
+	int temp=-1;
+#if defined(_MSC_VER)					/* MS Visual C++ */
+	temp=_mkdir(dirCache.GetExpandName(newdir));
+#elif defined (WIN32)
+	temp=mkdir(dirCache.GetExpandName(newdir));
 #else
-	int temp=mkdir(dirCache.GetExpandName(newdir),0775);
+	temp=mkdir(dirCache.GetExpandName(newdir),0775);
 #endif
 	if (temp==0) dirCache.CacheOut(newdir,true);
 
@@ -458,7 +461,12 @@ bool localDrive::RemoveDir(char * dir) {
 	safe_strcpy(newdir, basedir);
 	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
-	int temp=rmdir(dirCache.GetExpandName(newdir));
+	int temp=-1;
+#if defined(_MSC_VER)
+	temp=_rmdir(dirCache.GetExpandName(newdir));
+#else
+	temp=rmdir(dirCache.GetExpandName(newdir));
+#endif
 	if (temp==0) dirCache.DeleteEntry(newdir,true);
 	return (temp==0);
 }

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -348,7 +348,7 @@ again:
 		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	}
-	strcpy(lfind_name,ldir_entcopy);
+	safe_strcpy(lfind_name,ldir_entcopy);
     lfind_name[LFN_NAMELENGTH]=0;
 
 	find_size=(Bit32u) stat_block.st_size;
@@ -383,8 +383,8 @@ bool localDrive::GetFileAttr(char * name,Bit16u * attr) {
 
 bool localDrive::GetFileAttrEx(char* name, struct stat *status) {
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
-	strcat(newname,name);
+	safe_strcpy(newname,basedir);
+	safe_strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	return !stat(newname,status);
@@ -395,8 +395,8 @@ unsigned long localDrive::GetCompressedSize(char* name) {
 	return 0;
 #else
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
-	strcat(newname,name);
+	safe_strcpy(newname,basedir);
+	safe_strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	DWORD size = GetCompressedFileSize(newname, NULL);
@@ -418,8 +418,8 @@ unsigned long localDrive::GetCompressedSize(char* name) {
 #if defined (WIN32)
 HANDLE localDrive::CreateOpenFile(const char* name) {
 	char newname[CROSS_LEN];
-	strcpy(newname,basedir);
-	strcat(newname,name);
+	safe_strcpy(newname,basedir);
+	safe_strcat(newname,name);
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	HANDLE handle=CreateFile(newname, FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -201,7 +201,11 @@ bool localDrive::FileUnlink(char * name) {
 	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 	char *fullname = dirCache.GetExpandName(newname);
+#if defined(_MSC_VER)						/* MS Visual C++ */
+	if (_unlink(fullname)) {
+#else
 	if (unlink(fullname)) {
+#endif
 		//Unlink failed for some reason try finding it.
 		struct stat buffer;
 		if (stat(fullname,&buffer)) return false; // File not found.
@@ -225,7 +229,11 @@ bool localDrive::FileUnlink(char * name) {
 			}
 		}
 		if (!found_file) return false;
+#if defined(_MSC_VER)
+		if (!_unlink(fullname)) {
+#else
 		if (!unlink(fullname)) {
+#endif
 			dirCache.DeleteEntry(newname);
 			return true;
 		}

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1203,7 +1203,7 @@ bool Overlay_Drive::is_deleted_file(const char* name) {
 
 void Overlay_Drive::add_DOSdir_to_cache(const char* name, const char *sname) {
 	if (!name || !*name ) return; //Skip empty file.
-	LOG_MSG("Adding name to overlay_only_dir_cache %s",name);
+	if (logoverlay) LOG_MSG("Adding name to overlay_only_dir_cache %s",name);
 	if (!is_dir_only_in_overlay(name)) {
 		DOSdirs_cache.push_back(name);
 		DOSdirs_cache.push_back(sname);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -51,8 +51,8 @@ using namespace std;
 
 char* GetCrossedName(const char *basedir, const char *dir) {
 	static char crossname[CROSS_LEN];
-	strcpy(crossname, basedir);
-	strcat(crossname, dir);
+	safe_strcpy(crossname, basedir);
+	safe_strcat(crossname, dir);
 	CROSS_FILENAME(crossname);
 	return crossname;
 }
@@ -163,20 +163,20 @@ bool Overlay_Drive::MakeDir(char * dir) {
 		return true;
 	}
 	char newdir[CROSS_LEN],sdir[CROSS_LEN];
-	strcpy(sdir,dir);
+	safe_strcpy(sdir,dir);
 	char *p=strrchr(sdir,'\\');
 	if (p!=NULL) {
 		*p=0;
 		char *temp_name=dirCache.GetExpandName(GetCrossedName(basedir,sdir));
 		if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-			strcpy(newdir,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
-			strcat(newdir,"\\");
-			strcat(newdir,p+1);
-			strcpy(sdir,newdir);
+			safe_strcpy(newdir,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+			safe_strcat(newdir,"\\");
+			safe_strcat(newdir,p+1);
+			safe_strcpy(sdir,newdir);
 		}
 	}
-	strcpy(newdir,overlaydir);
-	strcat(newdir,sdir);
+	safe_strcpy(newdir,overlaydir);
+	safe_strcat(newdir,sdir);
 	CROSS_FILENAME(newdir);
 #if defined (WIN32)						/* MS Visual C++ */
 	int temp = mkdir(newdir);
@@ -188,7 +188,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 		safe_strcpy(fakename, basedir);
 		safe_strcat(fakename, dir);
 		CROSS_FILENAME(fakename);
-		strcpy(sdir, dir);
+		safe_strcpy(sdir, dir);
 		upcase(sdir);
 		dirCache.AddEntryDirOverlay(fakename,sdir,true);
 		add_DOSdir_to_cache(dir,sdir);
@@ -275,7 +275,7 @@ FILE *Overlay_Drive::create_file_in_overlay(const char *dos_filename, char const
 		Sync_leading_dirs(dos_filename);
 		//try again
 		char temp_name[CROSS_LEN],tmp[CROSS_LEN];
-		strcpy(tmp, dos_filename);
+		safe_strcpy(tmp, dos_filename);
 		char *p=strrchr(tmp, '\\');
 		assert(p!=NULL);
 		*p=0;
@@ -283,21 +283,21 @@ FILE *Overlay_Drive::create_file_in_overlay(const char *dos_filename, char const
 		for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it != DOSdirs_cache.end(); it+=2)
 			if ((*(it+1)).length()&&!strcasecmp((*(it+1)).c_str(), tmp)) {
 				found=true;
-				strcpy(tmp, (*it).c_str());
+				safe_strcpy(tmp, (*it).c_str());
 				break;
 			}
 		if (found) {
-			strcpy(temp_name,overlaydir);
-			strcat(temp_name,tmp);
-			strcat(temp_name,dir);
+			safe_strcpy(temp_name,overlaydir);
+			safe_strcat(temp_name,tmp);
+			safe_strcat(temp_name,dir);
 			CROSS_FILENAME(temp_name);
 			f = fopen_wrap(temp_name,mode);
 		}
 		if (!f) {
-			strcpy(temp_name,dirCache.GetExpandName(GetCrossedName(basedir,dos_filename)));
+			safe_strcpy(temp_name,dirCache.GetExpandName(GetCrossedName(basedir,dos_filename)));
 			if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-				strcpy(newname,overlaydir);
-				strcat(newname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+				safe_strcpy(newname,overlaydir);
+				safe_strcat(newname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
 				CROSS_FILENAME(newname);
 			}
 			f = fopen_wrap(newname,mode);
@@ -483,8 +483,8 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 		char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
 		if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 			temp_name+=strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0);
-			strcpy(newname,overlaydir);
-			strcat(newname,temp_name);
+			safe_strcpy(newname,overlaydir);
+			safe_strcat(newname,temp_name);
 			CROSS_FILENAME(newname);
 			hand = fopen_wrap(newname,type);
 		}
@@ -590,8 +590,8 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 			char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,dirname));
 			if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 				temp_name+=strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0);
-				strcpy(dirnameoverlay,overlaydir);
-				strcat(dirnameoverlay,temp_name);
+				safe_strcpy(dirnameoverlay,overlaydir);
+				safe_strcat(dirnameoverlay,temp_name);
 				CROSS_FILENAME(dirnameoverlay);
 			}
 			if (stat(dirnameoverlay,&overlaytest) == 0 ) {
@@ -660,7 +660,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 			else if (is_directory) {
 				dirnames.push_back(dir_name);
 				if (!strlen(dir_sname)) {
-					strcpy(dir_sname, dir_name);
+					safe_strcpy(dir_sname, dir_name);
 					upcase(dir_sname);
 				}
 				dirnames.push_back(dir_sname);
@@ -670,7 +670,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 				else if (is_directory) {
 					dirnames.push_back(dir_name);
 					if (!strlen(dir_sname)) {
-						strcpy(dir_sname, dir_name);
+						safe_strcpy(dir_sname, dir_name);
 						upcase(dir_sname);
 					}
 					dirnames.push_back(dir_sname);
@@ -719,7 +719,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 			//Good directory, add to DOSdirs_cache if not existing in localDrive. tested earlier to prevent problems with opendir
 			if (!dir_exists_in_base) {
 				if (!strlen(sdir)) {
-					strcpy(sdir, tdir);
+					safe_strcpy(sdir, tdir);
 					upcase(sdir);
 				}
 				add_DOSdir_to_cache(tdir,sdir);
@@ -735,7 +735,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 				else if (is_directory) {
 					dirnames.push_back(string(dirpush)+dir_name);
 					if (!strlen(dir_sname)) {
-						strcpy(dir_sname, dir_name);
+						safe_strcpy(dir_sname, dir_name);
 						upcase(dir_sname);
 					}
 					dirnames.push_back(string(dirspush)+dir_sname);
@@ -745,7 +745,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 					else if (is_directory) {
 						dirnames.push_back(string(dirpush)+dir_name);
 						if (!strlen(dir_sname)) {
-							strcpy(dir_sname, dir_name);
+							safe_strcpy(dir_sname, dir_name);
 							upcase(dir_sname);
 						}
 						dirnames.push_back(string(dirspush)+dir_sname);
@@ -773,25 +773,25 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 #if OVERLAY_DIR
 	for (i = DOSdirs_cache.begin(); i !=DOSdirs_cache.end(); i+=2) {
 		char fakename[CROSS_LEN],sdir[CROSS_LEN],tmp[CROSS_LEN],*p;
-		strcpy(fakename,basedir);
-		strcat(fakename,(*i).c_str());
+		safe_strcpy(fakename,basedir);
+		safe_strcat(fakename,(*i).c_str());
 		CROSS_FILENAME(fakename);
-		strcpy(sdir,(*(i+1)).c_str());
+		safe_strcpy(sdir,(*(i+1)).c_str());
 		dirCache.AddEntryDirOverlay(fakename,sdir,true);
 		if (strlen(sdir)) {
-			strcpy(tmp,(*(i+1)).c_str());
+			safe_strcpy(tmp,(*(i+1)).c_str());
 			p=strrchr(tmp, '\\');
 			if (p==NULL) *(i+1)=std::string(sdir);
 			else {
 				*p=0;
 				for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it<i && it != DOSdirs_cache.end(); it+=2) {
 					if (!strcasecmp((*it).c_str(), tmp)) {
-						strcpy(tmp, (*(it+1)).c_str());
+						safe_strcpy(tmp, (*(it+1)).c_str());
 						break;
 					}
 				}
-				strcat(tmp,"\\");
-				strcat(tmp,sdir);
+				safe_strcat(tmp,"\\");
+				safe_strcat(tmp,sdir);
 				*(i+1)=std::string(tmp);
 			}
 		}
@@ -939,7 +939,7 @@ again:
 		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	}
-	strcpy(lfind_name,ldir_entcopy);
+	safe_strcpy(lfind_name,ldir_entcopy);
     lfind_name[LFN_NAMELENGTH]=0;
 
 	find_size=(Bit32u) stat_block.st_size;
@@ -980,8 +980,8 @@ bool Overlay_Drive::FileUnlink(char * name) {
 		if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 			char overtmpname[CROSS_LEN];
 			temp_name+=strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0);
-			strcpy(overtmpname,overlaydir);
-			strcat(overtmpname,temp_name);
+			safe_strcpy(overtmpname,overlaydir);
+			safe_strcat(overtmpname,temp_name);
 			CROSS_FILENAME(overtmpname);
 			if (unlink(overtmpname)==0) removed=true;
 		}
@@ -1056,7 +1056,7 @@ bool Overlay_Drive::GetFileAttr(char * name,Bit16u * attr) {
 	safe_strcat(overlayname,name);
 	CROSS_FILENAME(overlayname);
 	char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
-	strcpy(tmp, name);
+	safe_strcpy(tmp, name);
 	char *q=strrchr(tmp, '\\');
 	if (q!=NULL) *(q+1)=0;
 	else *tmp=0;
@@ -1137,9 +1137,9 @@ bool Overlay_Drive::is_dir_only_in_overlay(const char* name) {
 	if (DOSdirs_cache.empty()) return false;
 	char fname[CROSS_LEN];
 	char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
-	strcpy(fname, "");
+	safe_strcpy(fname, "");
 	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-		strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		safe_strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
 		CROSS_DOSFILENAME(fname);
 	}
 	for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it != DOSdirs_cache.end(); it+=2) {
@@ -1169,9 +1169,9 @@ void Overlay_Drive::add_DOSdir_to_cache(const char* name, const char *sname) {
 void Overlay_Drive::remove_DOSdir_from_cache(const char* name) {
 	char fname[CROSS_LEN];
 	char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
-	strcpy(fname, "");
+	safe_strcpy(fname, "");
 	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-		strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		safe_strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
 		CROSS_DOSFILENAME(fname);
 	}
 	for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it != DOSdirs_cache.end(); it+=2) {
@@ -1241,15 +1241,15 @@ bool Overlay_Drive::check_if_leading_is_deleted(const char* name){
 
 bool Overlay_Drive::FileExists(const char* name) {
 	char overlayname[CROSS_LEN];
-	strcpy(overlayname,overlaydir);
-	strcat(overlayname,name);
+	safe_strcpy(overlayname,overlaydir);
+	safe_strcat(overlayname,name);
 	CROSS_FILENAME(overlayname);
 	struct stat tempstat;
 	if (stat(overlayname,&tempstat)==0 && (tempstat.st_mode & S_IFDIR)==0) return true;
 	char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
 	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-		strcpy(overlayname,overlaydir);
-		strcat(overlayname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		safe_strcpy(overlayname,overlaydir);
+		safe_strcat(overlayname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
 		CROSS_FILENAME(overlayname);
 		if(stat(overlayname,&tempstat)==0 && (tempstat.st_mode & S_IFDIR)==0) return true;
 	}
@@ -1283,31 +1283,31 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		}
 #endif
 		char overlaynameold[CROSS_LEN];
-		strcpy(overlaynameold,overlaydir);
-		strcat(overlaynameold,oldname);
+		safe_strcpy(overlaynameold,overlaydir);
+		safe_strcat(overlaynameold,oldname);
 		CROSS_FILENAME(overlaynameold);
 
 		char overlaynamenew[CROSS_LEN];
-		strcpy(overlaynamenew,overlaydir);
-		strcat(overlaynamenew,newname);
+		safe_strcpy(overlaynamenew,overlaydir);
+		safe_strcat(overlaynamenew,newname);
 		CROSS_FILENAME(overlaynamenew);
 
 		if (stat(overlaynameold,&tempstat)) {
 			char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,oldname));
 			if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 				temp_name+=strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0);
-				strcpy(overlaynameold,GetCrossedName(overlaydir,temp_name));
+				safe_strcpy(overlaynameold,GetCrossedName(overlaydir,temp_name));
 			}
-			strcpy(tmp,newname);
+			safe_strcpy(tmp,newname);
 			char *p=strrchr(tmp,'\\'), ndir[CROSS_LEN];
 			if (p!=NULL) {
 				*p=0;
 				temp_name=dirCache.GetExpandName(GetCrossedName(basedir,tmp));
 				if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-					strcpy(ndir,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
-					strcat(ndir,"\\");
-					strcat(ndir,p+1);
-					strcpy(overlaynamenew,GetCrossedName(overlaydir,ndir));
+					safe_strcpy(ndir,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+					safe_strcat(ndir,"\\");
+					safe_strcat(ndir,p+1);
+					safe_strcpy(overlaynamenew,GetCrossedName(overlaydir,ndir));
 				}
 			}
 		}
@@ -1338,18 +1338,18 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,oldname));
 		if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 			temp_name+=strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0);
-			strcpy(overlaynameold,GetCrossedName(overlaydir,temp_name));
+			safe_strcpy(overlaynameold,GetCrossedName(overlaydir,temp_name));
 		}
-		strcpy(tmp,newname);
+		safe_strcpy(tmp,newname);
 		char *p=strrchr(tmp,'\\'), ndir[CROSS_LEN];
 		if (p!=NULL) {
 			*p=0;
 			temp_name=dirCache.GetExpandName(GetCrossedName(basedir,tmp));
 			if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
-				strcpy(ndir,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
-				strcat(ndir,"\\");
-				strcat(ndir,p+1);
-				strcpy(overlaynamenew,GetCrossedName(overlaydir,ndir));
+				safe_strcpy(ndir,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+				safe_strcat(ndir,"\\");
+				safe_strcat(ndir,p+1);
+				safe_strcpy(overlaynamenew,GetCrossedName(overlaydir,ndir));
 			}
 		}
 	}
@@ -1412,8 +1412,8 @@ bool Overlay_Drive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 
 	if (*_dir) {
 		char newname[CROSS_LEN], tmp[CROSS_LEN];
-		strcpy(newname,overlaydir);
-		strcat(newname,_dir);
+		safe_strcpy(newname,overlaydir);
+		safe_strcat(newname,_dir);
 		CROSS_FILENAME(newname);
 		struct stat temp_stat;
 		if (stat(newname,&temp_stat)) {
@@ -1422,12 +1422,12 @@ bool Overlay_Drive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 				temp_name+=strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0);
 				return localDrive::FindFirst(temp_name,dta,fcb_findfirst);
 			}
-			strcpy(tmp, _dir);
+			safe_strcpy(tmp, _dir);
 			bool found=false;
 			for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it != DOSdirs_cache.end(); it+=2) {
 				if ((*(it+1)).length()&&!strcasecmp((*(it+1)).c_str(), tmp)) {
 					found=true;
-					strcpy(tmp, (*it).c_str());
+					safe_strcpy(tmp, (*it).c_str());
 					break;
 				}
 			}

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1009,11 +1009,20 @@ bool Overlay_Drive::FileUnlink(char * name) {
 			safe_strcpy(overtmpname,overlaydir);
 			safe_strcat(overtmpname,temp_name);
 			CROSS_FILENAME(overtmpname);
-			if (unlink(overtmpname)==0) removed=true;
+#if defined(_MSC_VER)						/* MS Visual C++ */
+			if (_unlink(overtmpname)==0)
+#else
+			if (unlink(overtmpname)==0)
+#endif
+				 removed=true;
 		}
 	}
 
+#if defined(_MSC_VER)
+	if (!removed&&_unlink(overlayname)) {
+#else
 	if (!removed&&unlink(overlayname)) {
+#endif
 		//Unlink failed for some reason try finding it.
 		if(stat(overlayname,&buffer)) {
 			//file not found in overlay, check the basedrive
@@ -1048,7 +1057,11 @@ bool Overlay_Drive::FileUnlink(char * name) {
 			}
 		}
 		if(!found_file) return false;
+#if defined(_MSC_VER)
+		if (_unlink(overlayname) == 0) { //Overlay file removed
+#else
 		if (unlink(overlayname) == 0) { //Overlay file removed
+#endif
 			//Mark basefile as deleted if it exists:
 			if (localDrive::FileExists(name)) add_deleted_file(name,true);
 			remove_DOSname_from_cache(name); //Should be an else ? although better safe than sorry.
@@ -1145,7 +1158,12 @@ void Overlay_Drive::remove_special_file_from_disk(const char* dosname, const cha
 	safe_strcpy(overlayname, overlaydir);
 	safe_strcat(overlayname, name.c_str());
 	CROSS_FILENAME(overlayname);
-	if(unlink(overlayname) != 0) E_Exit("Failed removal of %s",overlayname);
+#if defined(_MSC_VER)
+	if(_unlink(overlayname) != 0)
+#else
+	if(unlink(overlayname) != 0)
+#endif
+		E_Exit("Failed removal of %s",overlayname);
 }
 
 std::string Overlay_Drive::create_filename_of_special_operation(const char* dosname, const char* operation) {

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1232,7 +1232,7 @@ bool Overlay_Drive::check_if_leading_is_deleted(const char* name){
 	const char* dname = strrchr(name,'\\');
 	if (dname != NULL) {
 		char dirname[CROSS_LEN];
-		strncpy(dirname,name,dname - name);
+		safe_strncpy(dirname,name,dname - name);
 		dirname[dname - name] = 0;
 		if (is_deleted_path(dirname)) return true;
 	}

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "drives.h"
-
 #include "support.h"
 
 bool wild_match(char *haystack, char *needle) {

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -156,8 +156,8 @@ bool LWildFileCmp(const char * file, const char * wild)
     }
     upcase(file_name);upcase(file_ext);
     char nwild[LFN_NAMELENGTH+2];
-    strcpy(nwild,wild);
-    if (strrchr(nwild,'*')&&strrchr(nwild,'.')==NULL) strcat(nwild,".*");
+    safe_strcpy(nwild,wild);
+    if (strrchr(nwild,'*')&&strrchr(nwild,'.')==NULL) safe_strcat(nwild,".*");
     find_ext=strrchr(nwild,'.');
     if (find_ext) {
             Bitu size=(Bitu)(find_ext-nwild);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -405,7 +405,7 @@ void DOSBOX_Init(void) {
 	const char *iosgus[] = { "240", "220", "260", "280", "2a0", "2c0", "2e0", "300", 0 };
 	const char *irqsgus[] = { "5", "3", "7", "9", "10", "11", "12", 0 };
 	const char *dmasgus[] = { "3", "0", "1", "5", "6", "7", 0 };
-
+	const char *lfn_settings[] = { "true", "false", "auto", "autostart", 0};
 
 	/* Setup all the different modules making up DOSBox */
 	const char* machines[] = {
@@ -811,6 +811,18 @@ void DOSBOX_Init(void) {
 
 	Pbool = secprop->Add_bool("umb",Property::Changeable::WhenIdle,true);
 	Pbool->Set_help("Enable UMB support.");
+
+    Pstring = secprop->Add_string("ver",Property::Changeable::WhenIdle,"");
+    Pstring->Set_help("Set DOS version (5.0 by default). Specify as major.minor format.\n"
+			"A single number is treated as the major version.\n"
+			"Common settings are 3.3, 5.0, 6.22, and 7.1.\n"
+            "Long filename (LFN) support will be enabled with a\n"
+			"reported DOS version of 7.0 or higher with \"lfn=auto\" (default).\n");
+
+    Pstring = secprop->Add_string("lfn",Property::Changeable::WhenIdle,"auto");
+    Pstring->Set_values(lfn_settings);
+    Pstring->Set_help("Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.\n"
+                      "If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.");
 
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init,true);
 	Pstring = secprop->Add_string("keyboardlayout",Property::Changeable::WhenIdle, "auto");

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -104,10 +104,10 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 	lowcase(file_start);
 	strcat(file_start,"_");
 	bool is_directory;
-	char tempname[CROSS_LEN];
-	bool testRead = read_directory_first(dir, tempname, is_directory );
+	char tempname[CROSS_LEN], sname[15];
+	bool testRead = read_directory_first(dir, tempname, sname, is_directory );
 	int last = 0;
-	for ( ; testRead; testRead = read_directory_next(dir, tempname, is_directory) ) {
+	for ( ; testRead; testRead = read_directory_next(dir, tempname, sname, is_directory) ) {
 		char * test=strstr(tempname,ext);
 		if (!test || strlen(test)!=strlen(ext)) 
 			continue;

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -207,34 +207,6 @@ void Cross::CreateDir(std::string const& in) {
 #endif
 }
 
-/* does the filename fit the 8.3 format? */
-static bool is_filename_8by3w(const char* fname) {
-    int i;
-
-    /* Is the first part 8 chars or less? */
-    i=0;
-    while (*fname != 0 && *fname != '.') {
-		if (*fname<=32||*fname==127||*fname=='"'||*fname=='+'||*fname=='='||*fname==','||*fname==';'||*fname==':'||*fname=='<'||*fname=='>'||*fname=='|'||*fname=='?'||*fname=='*') return false;
-		fname++; i++;
-	}
-    if (i > 8) return false;
-
-    if (*fname == '.') fname++;
-
-    /* Is the second part 3 chars or less? A second '.' also makes it a LFN */
-    i=0;
-    while (*fname != 0 && *fname != '.') {
-		if (*fname<=32||*fname==127||*fname=='"'||*fname=='+'||*fname=='='||*fname==','||*fname==';'||*fname==':'||*fname=='<'||*fname=='>'||*fname=='|'||*fname=='?'||*fname=='*') return false;
-		fname++; i++;
-	}
-    if (i > 3) return false;
-
-    /* if there is anything beyond this point, it's an LFN */
-    if (*fname != 0) return false;
-
-    return true;
-}
-
 bool Cross::IsPathAbsolute(std::string const& in) {
 	// Absolute paths
 #if defined (WIN32)
@@ -268,6 +240,34 @@ dir_information* open_directory(const char* dirname) {
 	dir.handle = INVALID_HANDLE_VALUE;
 
 	return (access(dirname,0) ? NULL : &dir);
+}
+
+/* does the filename fit the 8.3 format? */
+static bool is_filename_8by3w(const char* fname) {
+    int i;
+
+    /* Is the first part 8 chars or less? */
+    i=0;
+    while (*fname != 0 && *fname != '.') {
+		if (*fname<=32||*fname==127||*fname=='"'||*fname=='+'||*fname=='='||*fname==','||*fname==';'||*fname==':'||*fname=='<'||*fname=='>'||*fname=='|'||*fname=='?'||*fname=='*') return false;
+		fname++; i++;
+	}
+    if (i > 8) return false;
+
+    if (*fname == '.') fname++;
+
+    /* Is the second part 3 chars or less? A second '.' also makes it a LFN */
+    i=0;
+    while (*fname != 0 && *fname != '.') {
+		if (*fname<=32||*fname==127||*fname=='"'||*fname=='+'||*fname=='='||*fname==','||*fname==';'||*fname==':'||*fname=='<'||*fname=='>'||*fname=='|'||*fname=='?'||*fname=='*') return false;
+		fname++; i++;
+	}
+    if (i > 3) return false;
+
+    /* if there is anything beyond this point, it's an LFN */
+    if (*fname != 0) return false;
+
+    return true;
 }
 
 bool read_directory_first(dir_information* dirp, char* entry_name, char* entry_sname, bool& is_directory) {

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -322,12 +322,12 @@ dir_information* open_directory(const char* dirname) {
 	return dir.dir?&dir:NULL;
 }
 
-bool read_directory_first(dir_information* dirp, char* entry_name, bool& is_directory) {
+bool read_directory_first(dir_information* dirp, char* entry_name, char* entry_sname, bool& is_directory) {
 	if (!dirp) return false;
 	return read_directory_next(dirp,entry_name,entry_sname,is_directory);
 }
 
-bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_directory) {
+bool read_directory_next(dir_information* dirp, char* entry_name, char* entry_sname, bool& is_directory) {
 	if (!dirp) return false;
 	struct dirent* dentry = readdir(dirp->dir);
 	if (dentry==NULL) {

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -127,7 +127,7 @@ char *ltrim(char *str) {
 char *rtrim(char *str) {
 	char *p;
 	p = strchr(str, '\0');
-	while (--p >= str && isspace(*reinterpret_cast<unsigned char*>(p))) {};
+	while (--p >= str && *reinterpret_cast<unsigned char*>(p) != '\f' && isspace(*reinterpret_cast<unsigned char*>(p))) {};
 	p[1] = '\0';
 	return str;
 }
@@ -189,6 +189,23 @@ char * StripWord(char *&line) {
 	char * begin=scan;
 	for (char c = *scan ;(c = *scan);scan++) {
 		if (isspace(*reinterpret_cast<unsigned char*>(&c))) {
+			*scan++=0;
+			break;
+		}
+	}
+	line=scan;
+	return begin;
+}
+
+char * StripArg(char *&line) {
+       char * scan=line;
+       int q=0;
+       scan=ltrim(scan);
+       char * begin=scan;
+       for (char c = *scan ;(c = *scan);scan++) {
+               if (*scan=='"') {
+                       q++;
+               } else if (q/2*2==q && isspace(*reinterpret_cast<unsigned char*>(&c))) {
 			*scan++=0;
 			break;
 		}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -666,7 +666,25 @@ void SHELL_Init() {
 	        "Type CD drive: to display the current directory in the specified drive.\n"
 	        "Type CD without parameters to display the current drive and directory.\n");
 	MSG_Add("SHELL_CMD_CLS_HELP","Clear screen.\n");
-	MSG_Add("SHELL_CMD_DIR_HELP","Directory View.\n");
+	MSG_Add("SHELL_CMD_DIR_HELP","Displays a list of files and subdirectories in a directory.\n");
+	MSG_Add("SHELL_CMD_DIR_HELP_LONG","DIR [drive:][path][filename] [/[W|B]] [/S] [/P] [/A[D|H|S|R|A]] [/O[N|E|G|S|D]]\n\n"
+		   "  [drive:][path][filename]\n"
+		   "              Specifies drive, directory, and/or files to list.\n"
+		   "  /W          Uses wide list format.\n"
+		   "  /B          Uses bare format (no heading information or summary).\n"
+		   "  /S          Displays files in specified directory and all subdirectories.\n"
+		   "  /P          Pauses after each screenful of information.\n"
+		   "  /A          Displays files with specified attributes.\n"
+		   "  attributes   D  Directories                R  Read-only files\n"
+		   "               H  Hidden files               A  Files ready for archiving\n"
+		   "               S  System files               -  Prefix meaning not\n"
+		   "  /O          List by files in sorted order.\n"
+		   "  sortorder    N  By name (alphabetic)       S  By size (smallest first)\n"
+		   "               E  By extension (alphabetic)  D  By date & time (earlist first)\n"
+		   "               G  Group directories first    -  Prefix to reverse order\n\n"
+		   "Switches may be preset in the DIRCMD environment variable.  Override\n"
+		   "preset switches by prefixing any switch with - (hyphen)--for example, /-W.\n"
+		   );
 	MSG_Add("SHELL_CMD_ECHO_HELP","Display messages and enable/disable command echoing.\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP","Exit from the shell.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP","Show help.\n");
@@ -685,18 +703,22 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_REM_HELP","Add comments in a batch file.\n");
 	MSG_Add("SHELL_CMD_REM_HELP_LONG","REM [comment]\n");
 	MSG_Add("SHELL_CMD_NO_WILD","This is a simple version of the command, no wildcards allowed!\n");
-	MSG_Add("SHELL_CMD_RENAME_HELP","Renames one or more files.\n");
-	MSG_Add("SHELL_CMD_RENAME_HELP_LONG","RENAME [drive:][path]filename1 filename2.\n"
-	        "REN [drive:][path]filename1 filename2.\n\n"
-	        "Note that you can not specify a new drive or path for your destination file.\n");
+	MSG_Add("SHELL_CMD_RENAME_HELP","Renames a file/directory or files.\n");
+	MSG_Add("SHELL_CMD_RENAME_HELP_LONG","RENAME [drive:][path][directoryname1 | filename1] [directoryname2 | filename2]\n"
+	        "REN [drive:][path][directoryname1 | filename1] [directoryname2 | filename2]\n\n"
+	        "Note that you can not specify a new drive or path for your destination.\n");
 	MSG_Add("SHELL_CMD_DELETE_HELP","Removes one or more files.\n");
 	MSG_Add("SHELL_CMD_COPY_HELP","Copy files.\n");
 	MSG_Add("SHELL_CMD_CALL_HELP","Start a batch file from within another batch file.\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP","Assign an internal directory to a drive.\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires xms=true,umb=true).\n");
 
-	MSG_Add("SHELL_CMD_LS_HELP", "List directory contents.\n");
-	MSG_Add("SHELL_CMD_LS_HELP_LONG", "ls [/?] [PATTERN]\n");
+	MSG_Add("SHELL_CMD_LS_HELP", "Lists directory contents.\n");
+	MSG_Add("SHELL_CMD_LS_HELP_LONG", "LS [drive:][path][filename] [/A] [/L] [/P] [/Z]\n\n"
+	        "  /A\tLists hidden and system files also.\n"
+	        "  /L\tLists names one per line.\n"
+		    "  /P\tPauses after each screenful of information.\n"
+			"  /Z\tDisplays short names even if LFN support is available.\n");
 	MSG_Add("SHELL_CMD_LS_PATH_ERR",
 	        "ls: cannot access '%s': No such file or directory\n");
 
@@ -709,7 +731,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_ATTRIB_HELP","Does nothing. Provided for compatibility.\n");
 	MSG_Add("SHELL_CMD_PATH_HELP","Provided for compatibility.\n");
 	MSG_Add("SHELL_CMD_VER_HELP","View and set the reported DOS version.\n");
-	MSG_Add("SHELL_CMD_VER_VER","DOSBox version %s. Reported DOS version %d.%02d.\n");
+	MSG_Add("SHELL_CMD_VER_VER","dosbox-staging version %s. Reported DOS version %d.%02d.\n");
 
 	/* Regular startup */
 	call_shellstop=CALLBACK_Allocate();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -708,7 +708,24 @@ void SHELL_Init() {
 	        "REN [drive:][path][directoryname1 | filename1] [directoryname2 | filename2]\n\n"
 	        "Note that you can not specify a new drive or path for your destination.\n");
 	MSG_Add("SHELL_CMD_DELETE_HELP","Removes one or more files.\n");
+	MSG_Add("SHELL_CMD_DELETE_HELP_LONG","DEL [/P] [/Q] names\n"
+		   "ERASE [/P] [/Q] names\n\n"
+		   "  names\t\tSpecifies a list of one or more files or directories.\n"
+		   "\t\tWildcards may be used to delete multiple files. If a\n"
+		   "\t\tdirectory is specified, all files within the directory\n"
+		   "\t\twill be deleted.\n"
+		   "  /P\t\tPrompts for confirmation before deleting one or more files.\n"
+		   "  /Q\t\tQuiet mode, do not ask if ok to delete on global wildcard\n");
 	MSG_Add("SHELL_CMD_COPY_HELP","Copy files.\n");
+	MSG_Add("SHELL_CMD_COPY_HELP_LONG","COPY [/Y | /-Y] source [+source [+ ...]] [destination]\n\n"
+		   "  source\tSpecifies the file or files to be copied.\n"
+		   "  destination\tSpecifies the directory and/or filename for the new file(s).\n"
+		   "  /Y\t\tSuppresses prompting to confirm you want to overwrite an\n\t\texisting destination file.\n"
+		   "  /-Y\t\tCauses prompting to confirm you want to overwrite an\n\t\texisting destination file.\n\n"
+		   "The switch /Y may be preset in the COPYCMD environment variable.\n"
+		   "This may be overridden with /-Y on the command line.\n\n"
+		   "To append files, specify a single file for destination, but multiple files\n"
+		   "for source (using wildcards or file1+file2+file3 format).\n");
 	MSG_Add("SHELL_CMD_CALL_HELP","Start a batch file from within another batch file.\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP","Assign an internal directory to a drive.\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires xms=true,umb=true).\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -736,8 +736,6 @@ void SHELL_Init() {
 	        "  /L\tLists names one per line.\n"
 		    "  /P\tPauses after each screenful of information.\n"
 			"  /Z\tDisplays short names even if LFN support is available.\n");
-	MSG_Add("SHELL_CMD_LS_PATH_ERR",
-	        "ls: cannot access '%s': No such file or directory\n");
 
 	MSG_Add("SHELL_CMD_CHOICE_HELP","Waits for a keypress and sets ERRORLEVEL.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG","CHOICE [/C:choices] [/N] [/S] text\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -519,7 +519,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 				if (dot2==NULL) {
 					star=strchr(arg2,'*');
 					if (strchr(arg2,'?')) {
-						for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
+						for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
 							if (*(arg2+i)=='?'&&i<strlen(name))
 								*(arg2+i)=name[i];
 						}
@@ -543,7 +543,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					*dot2='.';
 					star=strchr(tname2,'*');
 					if (strchr(tname2,'?')) {
-						for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
+						for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
 							if (*(tname2+i)=='?'&&i<strlen(tname1))
 								*(tname2+i)=tname1[i];
 						}
@@ -560,7 +560,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 						safe_strcpy(text2, dot2+1);
 						star=strchr(text2,'*');
 						if (strchr(text2,'?')) {
-							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+							for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='?'&&i<strlen(text1))
 									*(text2+i)=text1[i];
 							}
@@ -574,7 +574,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					} else {
 						safe_strcpy(text2, dot2+1);
 						if (strchr(text2,'?')||strchr(text2,'*')) {
-							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+							for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='*') {
 									*(text2+i)=0;
 									break;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -525,7 +525,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 						}
 					}
 					if (star) {
-						if (star-arg2<(unsigned int)strlen(name))
+						if ((unsigned int)(star-arg2)<strlen(name))
 							strcpy(star, name+(star-arg2));
 						else
 							*star=0;
@@ -549,7 +549,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 						}
 					}
 					if (star) {
-						if (star-tname2<(unsigned int)strlen(tname1))
+						if ((unsigned int)(star-tname2)<strlen(tname1))
 							strcpy(star, tname1+(star-tname2));
 						else
 							*star=0;
@@ -566,7 +566,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 							}
 						}
 						if (star) {
-							if (star-text2<(unsigned int)strlen(text1))
+							if ((unsigned int)(star-text2)<strlen(text1))
 								strcpy(star, text1+(star-text2));
 							else
 								*star=0;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -785,6 +785,7 @@ struct DtaResult {
 
 };
 
+/* Unused function
 static std::string to_search_pattern(const char *arg)
 {
 	std::string pattern = arg;
@@ -822,6 +823,7 @@ static std::string to_search_pattern(const char *arg)
 
 	return pattern;
 }
+*/
 
 Bit32u byte_count,file_count,dir_count;
 Bitu p_count;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -18,6 +18,10 @@
  *  Wengier: LFN support
  */
 
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+# define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "shell.h"
 
 #include <algorithm>

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -14,6 +14,8 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  Wengier: LFN support
  */
 
 #include "shell.h"
@@ -35,6 +37,10 @@
 #include "support.h"
 #include "control.h"
 #include "paging.h"
+#include "drives.h"
+#include "../src/ints/int10.h"
+
+extern int enablelfn, lfn_filefind_handle;
 
 // clang-format off
 static SHELL_Cmd cmd_list[] = {
@@ -134,11 +140,11 @@ void DOS_Shell::DoCommand(char * line) {
 	line=trim(line);
 	char cmd_buffer[CMD_MAXLINE];
 	char * cmd_write=cmd_buffer;
+	int q=0;
 	while (*line) {
-		if (*line == 32) break;
-		if (*line == '/') break;
-		if (*line == '\t') break;
-		if (*line == '=') break;
+        if (strchr("/\t", *line) || (q / 2 * 2 == q && strchr(" =", *line)))
+			break;
+		if (*line == '"') q++;
 //		if (*line == ':') break; //This breaks drive switching as that is handled at a later stage.
 		if ((*line == '.') ||(*line == '\\')) {  //allow stuff like cd.. and dir.exe cd\kees
 			*cmd_write=0;
@@ -165,7 +171,20 @@ void DOS_Shell::DoCommand(char * line) {
 		cmd_index++;
 	}
 /* This isn't an internal command execute it */
-	if (Execute(cmd_buffer,line)) return;
+	char ldir[CROSS_LEN], *p=ldir;
+	if (strchr(cmd_buffer,'\"')&&DOS_GetSFNPath(cmd_buffer,ldir,false)) {
+		if (!strchr(cmd_buffer, '\\') && strrchr(ldir, '\\'))
+			p=strrchr(ldir, '\\')+1;
+		if (uselfn&&strchr(p, ' ')&&!DOS_FileExists(("\""+std::string(p)+"\"").c_str())) {
+			bool append=false;
+			if (DOS_FileExists(("\""+std::string(p)+".COM\"").c_str())) {append=true;strcat(p, ".COM");}
+			else if (DOS_FileExists(("\""+std::string(p)+".EXE\"").c_str())) {append=true;strcat(p, ".EXE");}
+			else if (DOS_FileExists(("\""+std::string(p)+".BAT\"").c_str())) {append=true;strcat(p, ".BAT");}
+			if (append&&DOS_GetSFNPath(("\""+std::string(p)+"\"").c_str(), cmd_buffer,false)) if(Execute(cmd_buffer,line)) return;
+		}
+		if(Execute(p,line)) return;
+	} else
+		if (Execute(cmd_buffer,line)) return;
 	if (CheckConfig(cmd_buffer,line)) return;
 	WriteOut(MSG_Get("SHELL_EXECUTE_ILLEGAL_COMMAND"),cmd_buffer);
 }
@@ -188,43 +207,179 @@ void DOS_Shell::CMD_CLS(char * args) {
 
 void DOS_Shell::CMD_DELETE(char * args) {
 	HELP("DELETE");
-	/* Command uses dta so set it to our internal dta */
-	RealPt save_dta=dos.dta();
-	dos.dta(dos.tables.tempdta);
+	bool optP=ScanCMDBool(args,"P");
+	bool optF=ScanCMDBool(args,"F");
+	bool optQ=ScanCMDBool(args,"Q");
 
 	char * rem=ScanCMDRemain(args);
 	if (rem) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
 		return;
 	}
-	/* If delete accept switches mind the space infront of them. See the dir /p code */
+	if (!*args) {
+		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
+		return;
+	}
 
-	char full[DOS_PATHLENGTH];
+	StripSpaces(args);
+	args=trim(args);
+
+	/* Command uses dta so set it to our internal dta */
+	//DOS_DTA dta(dos.dta());
+	RealPt save_dta=dos.dta();
+	dos.dta(dos.tables.tempdta);
+	DOS_DTA dta(dos.dta());
+	/* If delete accept switches mind the space in front of them. See the dir /p code */
+
+	char full[LFN_NAMELENGTH+2],sfull[LFN_NAMELENGTH+2];
 	char buffer[CROSS_LEN];
+    char name[DOS_NAMELENGTH_ASCII],lname[LFN_NAMELENGTH+1];
+    Bit32u size;Bit16u time,date;Bit8u attr;
 	args = ExpandDot(args,buffer, CROSS_LEN);
 	StripSpaces(args);
-	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));return; }
-//TODO Maybe support confirmation for *.* like dos does.
-	bool res=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME);
+	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));dos.dta(save_dta);return; }
+	if (strlen(args)&&args[strlen(args)-1]!='\\') {
+		Bit16u fattr;
+		if (strcmp(args,"*.*")&&DOS_GetFileAttr(args, &fattr) && (fattr&DOS_ATTR_DIRECTORY))
+			strcat(args, "\\");
+	}
+	if (strlen(args)&&args[strlen(args)-1]=='\\') strcat(args, "*.*");
+	else if (!strcmp(args,".")||(strlen(args)>1&&(args[strlen(args)-2]==':'||args[strlen(args)-2]=='\\')&&args[strlen(args)-1]=='.')) {
+		args[strlen(args)-1]='*';
+		strcat(args, ".*");
+	} else if (uselfn&&strchr(args, '*')) {
+		char * find_last;
+		find_last=strrchr(args,'\\');
+		if (find_last==NULL) find_last=args;
+		else find_last++;
+		if (strlen(find_last)>0&&args[strlen(args)-1]=='*'&&strchr(find_last, '.')==NULL) strcat(args, ".*");
+	}
+	if (!strcmp(args,"*.*")||(strlen(args)>3&&(!strcmp(args+strlen(args)-4, "\\*.*") || !strcmp(args+strlen(args)-4, ":*.*")))) {
+		if (!optQ) {
+first_1:
+			WriteOut(MSG_Get("SHELL_CMD_DEL_SURE"));
+first_2:
+			Bit8u c;Bit16u n=1;
+			DOS_ReadFile (STDIN,&c,&n);
+			do switch (c) {
+			case 'n':			case 'N':
+			{
+				DOS_WriteFile (STDOUT,&c, &n);
+				DOS_ReadFile (STDIN,&c,&n);
+				do switch (c) {
+					case 0xD: WriteOut("\n");dos.dta(save_dta);return;
+					case 0x03: WriteOut("^C\n");dos.dta(save_dta);return;
+					case 0x08: WriteOut("\b \b"); goto first_2;
+				} while (DOS_ReadFile (STDIN,&c,&n));
+			}
+			case 'y':			case 'Y':
+			{
+				DOS_WriteFile (STDOUT,&c, &n);
+				DOS_ReadFile (STDIN,&c,&n);
+				do switch (c) {
+					case 0xD: WriteOut("\n"); goto continue_1;
+					case 0x03: WriteOut("^C\n");dos.dta(save_dta);return;
+					case 0x08: WriteOut("\b \b"); goto first_2;
+				} while (DOS_ReadFile (STDIN,&c,&n));
+			}
+			case 0xD: WriteOut("\n"); goto first_1;
+			case 0x03: WriteOut("^C\n");dos.dta(save_dta);return;
+			case '\t':
+			case 0x08:
+				goto first_2;
+			default:
+			{
+				DOS_WriteFile (STDOUT,&c, &n);
+				DOS_ReadFile (STDIN,&c,&n);
+				do switch (c) {
+					case 0xD: WriteOut("\n"); goto first_1;
+					case 0x03: WriteOut("^C\n");dos.dta(save_dta);return;
+					case 0x08: WriteOut("\b \b"); goto first_2;
+				} while (DOS_ReadFile (STDIN,&c,&n));
+				goto first_2;
+			}
+		} while (DOS_ReadFile (STDIN,&c,&n));
+	}
+}
+
+continue_1:
+	/* Command uses dta so set it to our internal dta */
+	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));dos.dta(save_dta);return; }
+	char path[LFN_NAMELENGTH+2], spath[LFN_NAMELENGTH+2], pattern[LFN_NAMELENGTH+2], *r=strrchr(full, '\\');
+	if (r!=NULL) {
+		*r=0;
+		strcpy(path, full);
+		strcat(path, "\\");
+		strcpy(pattern, r+1);
+		*r='\\';
+	} else {
+		strcpy(path, "");
+		strcpy(pattern, full);
+	}
+	int k=0;
+	for (int i=0;i<(int)strlen(pattern);i++)
+		if (pattern[i]!='\"')
+			pattern[k++]=pattern[i];
+	pattern[k]=0;
+	strcpy(spath, path);
+	if (strchr(args,'\"')||uselfn) {
+		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
+		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+	}
+	std::string pfull=std::string(spath)+std::string(pattern);
+	int fbak=lfn_filefind_handle;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+    bool res=DOS_FindFirst((char *)((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 	if (!res) {
+		lfn_filefind_handle=fbak;
 		WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),args);
 		dos.dta(save_dta);
 		return;
 	}
+	lfn_filefind_handle=fbak;
 	//end can't be 0, but if it is we'll get a nice crash, who cares :)
+	strcpy(sfull,full);
 	char * end=strrchr(full,'\\')+1;*end=0;
-	char name[DOS_NAMELENGTH_ASCII];Bit32u size;Bit16u time,date;Bit8u attr;
-	DOS_DTA dta(dos.dta());
+	char * lend=strrchr(sfull,'\\')+1;*lend=0;
+	dta=dos.dta();
+	bool exist=false;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 	while (res) {
-		dta.GetResult(name,size,date,time,attr);
-		if (!(attr & (DOS_ATTR_DIRECTORY|DOS_ATTR_READ_ONLY))) {
+		dta.GetResult(name,lname,size,date,time,attr);
+		if (!optF && (attr & DOS_ATTR_READ_ONLY) && !(attr & DOS_ATTR_DIRECTORY)) {
+			exist=true;
 			strcpy(end,name);
-			if (!DOS_UnlinkFile(full)) WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),full);
+			strcpy(lend,lname);
+			WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
+		} else if (!(attr & DOS_ATTR_DIRECTORY)) {
+			exist=true;
+			strcpy(end,name);
+			strcpy(lend,lname);
+			if (optP) {
+				WriteOut("Delete %s (Y/N)?", uselfn?sfull:full);
+				Bit8u c;
+				Bit16u n=1;
+				DOS_ReadFile (STDIN,&c,&n);
+				if (c==3) {WriteOut("^C\r\n");break;}
+				c = c=='y'||c=='Y' ? 'Y':'N';
+				WriteOut("%c\r\n", c);
+				if (c=='N') {lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;res = DOS_FindNext();continue;}
+			}
+			if (strlen(full)) {
+				std::string pfull=(uselfn||strchr(full, ' ')?(full[0]!='"'?"\"":""):"")+std::string(full)+(uselfn||strchr(full, ' ')?(full[strlen(full)-1]!='"'?"\"":""):"");
+				bool reset=false;
+				if (optF && (attr & DOS_ATTR_READ_ONLY)&&DOS_SetFileAttr(pfull.c_str(), attr & ~DOS_ATTR_READ_ONLY)) reset=true;
+				if (!DOS_UnlinkFile(pfull.c_str())) {
+					if (optF&&reset) DOS_SetFileAttr(pfull.c_str(), attr);
+					WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
+				}
+			} else WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
 		}
 		res=DOS_FindNext();
 	}
-	dos.dta(save_dta);
-}
+	lfn_filefind_handle=fbak;
+	if (!exist) WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),args);
+	dos.dta(save_dta);}
 
 void DOS_Shell::CMD_HELP(char * args){
 	HELP("HELP");
@@ -242,45 +397,223 @@ void DOS_Shell::CMD_HELP(char * args){
 	}
 }
 
+static void removeChar(char *str, char c) {
+    char *src, *dst;
+    for (src = dst = str; *src != '\0'; src++) {
+        *dst = *src;
+        if (*dst != c) dst++;
+    }
+    *dst = '\0';
+}
+
 void DOS_Shell::CMD_RENAME(char * args){
 	HELP("RENAME");
 	StripSpaces(args);
+	char * rem=ScanCMDRemain(args);
+	if (rem) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
+		return;
+	}
 	if (!*args) {SyntaxError();return;}
-	if ((strchr(args,'*')!=NULL) || (strchr(args,'?')!=NULL) ) { WriteOut(MSG_Get("SHELL_CMD_NO_WILD"));return;}
-	char * arg1=StripWord(args);
+	char * arg1=StripArg(args);
 	StripSpaces(args);
 	if (!*args) {SyntaxError();return;}
+	char * arg2=StripArg(args);
+	StripSpaces(args);
+	if (*args) {SyntaxError();return;}
 	char* slash = strrchr(arg1,'\\');
+	Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
+	char name[DOS_NAMELENGTH_ASCII], lname[LFN_NAMELENGTH+1], tname1[LFN_NAMELENGTH+1], tname2[LFN_NAMELENGTH+1], text1[LFN_NAMELENGTH+1], text2[LFN_NAMELENGTH+1], tfull[CROSS_LEN+2];
+	//dir_source and target are introduced for when we support multiple files being renamed.
+	char sargs[CROSS_LEN], targs[CROSS_LEN], dir_source[CROSS_LEN + 4] = {0}, dir_target[CROSS_LEN + 4] = {0}, target[CROSS_LEN + 4] = {0}; //not sure if drive portion is included in pathlength
+
+	if (!slash) slash = strrchr(arg1,':');
 	if (slash) {
 		/* If directory specified (crystal caves installer)
 		 * rename from c:\X : rename c:\abc.exe abc.shr.
 		 * File must appear in C:\
 		 * Ren X:\A\B C => ren X:\A\B X:\A\C */
-
-		char dir_source[DOS_PATHLENGTH + 4] = {0}; //not sure if drive portion is included in pathlength
+ 
 		//Copy first and then modify, makes GCC happy
-		safe_strncpy(dir_source,arg1,DOS_PATHLENGTH + 4);
+		safe_strncpy(dir_source,arg1,(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH) + 4);
 		char* dummy = strrchr(dir_source,'\\');
+		if (!dummy) dummy = strrchr(dir_source,':');
 		if (!dummy) { //Possible due to length
 			WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
 			return;
 		}
 		dummy++;
 		*dummy = 0;
-
-		//Maybe check args for directory, as I think that isn't allowed
-
-		//dir_source and target are introduced for when we support multiple files being renamed.
-		char target[DOS_PATHLENGTH+CROSS_LEN + 5] = {0};
-		safe_strcpy(target, dir_source);
-		strncat(target,args,CROSS_LEN);
-
-		DOS_Rename(arg1,target);
-
+		if (strchr(arg2,'\\')||strchr(arg2,':')) {
+			safe_strncpy(dir_target,arg2,(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH) + 4);
+			dummy = strrchr(dir_target,'\\');
+			if (!dummy) dummy = strrchr(dir_target,':');
+			if (dummy) {
+				dummy++;
+				*dummy = 0;
+				if (strcasecmp(dir_source, dir_target)) {
+					WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+					return;
+				}
+			}
+			arg2=strrchr(arg2,strrchr(arg2,'\\')?'\\':':')+1;
+		}
+		if (strlen(dummy)&&dummy[strlen(dummy)-1]==':')
+			strcat(dummy, ".\\");
 	} else {
-		DOS_Rename(arg1,args);
+		if (strchr(arg2,'\\')||strchr(arg2,':')) {SyntaxError();return;};
+		strcpy(dir_source, ".\\");
 	}
-}
+
+	strcpy(target,arg2);
+
+	char path[LFN_NAMELENGTH+2], spath[LFN_NAMELENGTH+2], pattern[LFN_NAMELENGTH+2], full[LFN_NAMELENGTH+2], *r;
+	if (!DOS_Canonicalize(arg1,full)) return;
+	r=strrchr(full, '\\');
+	if (r!=NULL) {
+		*r=0;
+		strcpy(path, full);
+		strcat(path, "\\");
+		strcpy(pattern, r+1);
+		*r='\\';
+	} else {
+		strcpy(path, "");
+		strcpy(pattern, full);
+	}
+	int k=0;
+	for (int i=0;i<(int)strlen(pattern);i++)
+		if (pattern[i]!='\"')
+			pattern[k++]=pattern[i];
+	pattern[k]=0;
+	strcpy(spath, path);
+	if (strchr(arg1,'\"')||uselfn) {
+		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
+		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+	}
+	RealPt save_dta=dos.dta();
+	dos.dta(dos.tables.tempdta);
+	DOS_DTA dta(dos.dta());
+	std::string pfull=std::string(spath)+std::string(pattern);
+	int fbak=lfn_filefind_handle;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+	if (!DOS_FindFirst((char *)((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(), strchr(arg1,'*')!=NULL || strchr(arg1,'?')!=NULL ? 0xffff & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY : 0xffff & ~DOS_ATTR_VOLUME)) {
+		lfn_filefind_handle=fbak;
+		WriteOut(MSG_Get("SHELL_CMD_RENAME_ERROR"),arg1);
+	} else {
+		std::vector<std::string> sources;
+		sources.clear();
+
+		do {    /* File name and extension */
+			dta.GetResult(name,lname,size,date,time,attr);
+			lfn_filefind_handle=fbak;
+
+			if(!(attr&DOS_ATTR_DIRECTORY && (!strcmp(name, ".") || !strcmp(name, "..")))) {
+				strcpy(dir_target, target);
+				removeChar(dir_target, '\"');
+				arg2=dir_target;
+				strcpy(sargs, dir_source);
+				if (uselfn) removeChar(sargs, '\"');
+				strcat(sargs, uselfn?lname:name);
+				if (uselfn&&strchr(arg2,'*')&&!strchr(arg2,'.')) strcat(arg2, ".*");
+				char *dot1=strrchr(uselfn?lname:name,'.'), *dot2=strrchr(arg2,'.'), *star;
+				if (dot2==NULL) {
+					star=strchr(arg2,'*');
+					if (strchr(arg2,'?')) {
+						for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
+							if (*(arg2+i)=='?'&&i<strlen(name))
+								*(arg2+i)=name[i];
+						}
+					}
+					if (star) {
+						if (star-arg2<(unsigned int)strlen(name))
+							strcpy(star, name+(star-arg2));
+						else
+							*star=0;
+					}
+					removeChar(arg2, '?');
+				} else {
+					if (dot1) {
+						*dot1=0;
+						strcpy(tname1, uselfn?lname:name);
+						*dot1='.';
+					} else
+						strcpy(tname1, uselfn?lname:name);
+					*dot2=0;
+					strcpy(tname2, arg2);
+					*dot2='.';
+					star=strchr(tname2,'*');
+					if (strchr(tname2,'?')) {
+						for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
+							if (*(tname2+i)=='?'&&i<strlen(tname1))
+								*(tname2+i)=tname1[i];
+						}
+					}
+					if (star) {
+						if (star-tname2<(unsigned int)strlen(tname1))
+							strcpy(star, tname1+(star-tname2));
+						else
+							*star=0;
+					}
+					removeChar(tname2, '?');
+					if (dot1) {
+						strcpy(text1, dot1+1);
+						strcpy(text2, dot2+1);
+						star=strchr(text2,'*');
+						if (strchr(text2,'?')) {
+							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+								if (*(text2+i)=='?'&&i<strlen(text1))
+									*(text2+i)=text1[i];
+							}
+						}
+						if (star) {
+							if (star-text2<(unsigned int)strlen(text1))
+								strcpy(star, text1+(star-text2));
+							else
+								*star=0;
+						}
+					} else {
+						strcpy(text2, dot2+1);
+						if (strchr(text2,'?')||strchr(text2,'*')) {
+							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+								if (*(text2+i)=='*') {
+									*(text2+i)=0;
+									break;
+								}
+							}
+						}
+					}
+					removeChar(text2, '?');
+					strcpy(tfull, tname2);
+					strcat(tfull, ".");
+					strcat(tfull, text2);
+					arg2=tfull;
+				}
+				strcpy(targs, dir_source);
+				if (uselfn) removeChar(targs, '\"');
+				strcat(targs, arg2);
+				sources.push_back(uselfn?((sargs[0]!='"'?"\"":"")+std::string(sargs)+(sargs[strlen(sargs)-1]!='"'?"\"":"")).c_str():sargs);
+				sources.push_back(uselfn?((targs[0]!='"'?"\"":"")+std::string(targs)+(targs[strlen(targs)-1]!='"'?"\"":"")).c_str():targs);
+				sources.push_back(strlen(sargs)>2&&sargs[0]=='.'&&sargs[1]=='\\'?sargs+2:sargs);
+			}
+			lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+		} while ( DOS_FindNext() );
+		lfn_filefind_handle=fbak;
+		if (sources.empty()) WriteOut(MSG_Get("SHELL_CMD_RENAME_ERROR"),arg1);
+		else {
+			for (std::vector<std::string>::iterator source = sources.begin(); source != sources.end(); ++source) {
+				char *oname=(char *)source->c_str();
+				source++;
+				if (source==sources.end()) break;
+				char *nname=(char *)source->c_str();
+				source++;
+				if (source==sources.end()||oname==NULL||nname==NULL) break;
+				char *fname=(char *)source->c_str();
+				if (!DOS_Rename(oname,nname)&&fname!=NULL)
+					WriteOut(MSG_Get("SHELL_CMD_RENAME_ERROR"),fname);
+			}
+		}
+	}
+	dos.dta(save_dta);}
 
 void DOS_Shell::CMD_ECHO(char * args){
 	if (!*args) {
@@ -319,15 +652,20 @@ void DOS_Shell::CMD_EXIT(char *args)
 void DOS_Shell::CMD_CHDIR(char * args) {
 	HELP("CHDIR");
 	StripSpaces(args);
+	char sargs[CROSS_LEN];
+	if (*args && !DOS_GetSFNPath(args,sargs,false)) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		return;
+	}
 	Bit8u drive = DOS_GetDefaultDrive()+'A';
-	char dir[DOS_PATHLENGTH];
+	char dir[LFN_NAMELENGTH+2];
 	if (!*args) {
-		DOS_GetCurrentDir(0,dir);
+		DOS_GetCurrentDir(0,dir,true);
 		WriteOut("%c:\\%s\n",drive,dir);
 	} else if (strlen(args) == 2 && args[1] == ':') {
 		Bit8u targetdrive = (args[0] | 0x20) - 'a' + 1;
 		unsigned char targetdisplay = *reinterpret_cast<unsigned char*>(&args[0]);
-		if (!DOS_GetCurrentDir(targetdrive,dir)) {
+		if (!DOS_GetCurrentDir(targetdrive,dir,true)) {
 			if (drive == 'Z') {
 				WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),toupper(targetdisplay));
 			} else {
@@ -338,7 +676,7 @@ void DOS_Shell::CMD_CHDIR(char * args) {
 		WriteOut("%c:\\%s\n",toupper(targetdisplay),dir);
 		if (drive == 'Z')
 			WriteOut(MSG_Get("SHELL_CMD_CHDIR_HINT"),toupper(targetdisplay));
-	} else 	if (!DOS_ChangeDir(args)) {
+	} else 	if (!DOS_ChangeDir(sargs)) {
 		/* Changedir failed. Check if the filename is longer then 8 and/or contains spaces */
 
 		std::string temps(args),slashpart;
@@ -357,7 +695,7 @@ void DOS_Shell::CMD_CHDIR(char * args) {
 			if (temps.size() >6) temps.erase(6);
 			temps += "~1";
 			WriteOut(MSG_Get("SHELL_CMD_CHDIR_HINT_2"),temps.insert(0,slashpart).c_str());
-		} else if (temps.size()>8) {
+		} else if (!uselfn && temps.size()>8) {
 			temps.erase(6);
 			temps += "~1";
 			WriteOut(MSG_Get("SHELL_CMD_CHDIR_HINT_2"),temps.insert(0,slashpart).c_str());
@@ -423,11 +761,14 @@ static void FormatNumber(Bit32u num,char * buf) {
 
 struct DtaResult {
 	char name[DOS_NAMELENGTH_ASCII];
+	char lname[LFN_NAMELENGTH+1];
 	Bit32u size;
 	Bit16u date;
 	Bit16u time;
 	Bit8u attr;
 
+	static bool groupDef(const DtaResult &lhs, const DtaResult &rhs) { return (lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY)?true:((((lhs.attr & DOS_ATTR_DIRECTORY) && (rhs.attr & DOS_ATTR_DIRECTORY)) || (!(lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY))) && strcmp(lhs.name, rhs.name) < 0); }
+	static bool groupDirs(const DtaResult &lhs, const DtaResult &rhs) { return (lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY); }
 	static bool compareName(const DtaResult &lhs, const DtaResult &rhs) { return strcmp(lhs.name, rhs.name) < 0; }
 	static bool compareExt(const DtaResult &lhs, const DtaResult &rhs) { return strcmp(lhs.getExtension(), rhs.getExtension()) < 0; }
 	static bool compareSize(const DtaResult &lhs, const DtaResult &rhs) { return lhs.size < rhs.size; }
@@ -482,248 +823,424 @@ static std::string to_search_pattern(const char *arg)
 	return pattern;
 }
 
+Bit32u byte_count,file_count,dir_count;
+Bitu p_count;
+std::vector<std::string> dirs, adirs;
+
+static size_t GetPauseCount() {
+	Bit8u page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+	return (CURSOR_POS_ROW(page) > 2u) ? (CURSOR_POS_ROW(page) - 2u) : 22u; /* <- FIXME: Please clarify this logic */
+}
+
+static bool dirPaused(DOS_Shell * shell, Bitu w_size, bool optP, bool optW) {
+	p_count+=optW?5:1;
+	if (optP && p_count%(GetPauseCount()*w_size)<1) {
+		shell->WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
+		Bit8u c;Bit16u n=1;
+		DOS_ReadFile(STDIN,&c,&n);
+		if (c==3) {shell->WriteOut("^C\r\n");return false;}
+		if (c==0) DOS_ReadFile(STDIN,&c,&n); // read extended key
+	}
+	return true;
+}
+
+static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat, Bitu w_size, bool optW, bool optZ, bool optS, bool optP, bool optB, bool optA, bool optAD, bool optAminusD, bool optAS, bool optAminusS, bool optAH, bool optAminusH, bool optAR, bool optAminusR, bool optAA, bool optAminusA, bool optO, bool optOG, bool optON, bool optOD, bool optOE, bool optOS, bool reverseSort) {
+	char path[LFN_NAMELENGTH+2];
+	char sargs[CROSS_LEN], largs[CROSS_LEN];
+
+	/* Make a full path in the args */
+	if (!DOS_Canonicalize(args,path)) {
+		shell->WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		return true;
+	}
+	*(strrchr(path,'\\')+1)=0;
+	if (!DOS_GetSFNPath(path,sargs,false)) {
+		shell->WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		return true;
+	}
+    if (!optB&&!optS) {
+		shell->WriteOut(MSG_Get("SHELL_CMD_DIR_INTRO"),uselfn&&!optZ&&DOS_GetSFNPath(path,largs,true)?largs:sargs);
+		if (optP) {
+			p_count+=optW?10:2;
+			if (p_count%(GetPauseCount()*w_size)<2) {
+				shell->WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
+				Bit8u c;Bit16u n=1;
+				DOS_ReadFile(STDIN,&c,&n);
+				if (c==3) {shell->WriteOut("^C\r\n");return false;}
+				if (c==0) DOS_ReadFile(STDIN,&c,&n); // read extended key
+			}
+		}
+	}
+    if (*(sargs+strlen(sargs)-1) != '\\') strcat(sargs,"\\");
+
+	Bit32u cbyte_count=0,cfile_count=0,w_count=0;
+	int fbak=lfn_filefind_handle;
+	lfn_filefind_handle=uselfn&&!optZ?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+	bool ret=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME), found=true, first=true;
+	lfn_filefind_handle=fbak;
+	if (ret) {
+		std::vector<DtaResult> results;
+
+		lfn_filefind_handle=uselfn&&!optZ?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+		do {    /* File name and extension */
+			DtaResult result;
+			dta.GetResult(result.name,result.lname,result.size,result.date,result.time,result.attr);
+
+			/* Skip non-directories if option AD is present, or skip dirs in case of A-D */
+			if(optAD && !(result.attr&DOS_ATTR_DIRECTORY) ) continue;
+			else if(optAminusD && (result.attr&DOS_ATTR_DIRECTORY) ) continue;
+			else if(optAS && !(result.attr&DOS_ATTR_SYSTEM) ) continue;
+			else if(optAminusS && (result.attr&DOS_ATTR_SYSTEM) ) continue;
+			else if(optAH && !(result.attr&DOS_ATTR_HIDDEN) ) continue;
+			else if(optAminusH && (result.attr&DOS_ATTR_HIDDEN) ) continue;
+			else if(optAR && !(result.attr&DOS_ATTR_READ_ONLY) ) continue;
+			else if(optAminusR && (result.attr&DOS_ATTR_READ_ONLY) ) continue;
+			else if(optAA && !(result.attr&DOS_ATTR_ARCHIVE) ) continue;
+			else if(optAminusA && (result.attr&DOS_ATTR_ARCHIVE) ) continue;
+			else if(!(optA||optAD||optAminusD||optAS||optAminusS||optAH||optAminusH||optAR||optAminusR||optAA||optAminusA) && (result.attr&DOS_ATTR_SYSTEM || result.attr&DOS_ATTR_HIDDEN) && strcmp(result.name, "..") ) continue;
+
+			results.push_back(result);
+
+		} while ( (ret=DOS_FindNext()) );
+		lfn_filefind_handle=fbak;
+
+		if (optON) {
+			// Sort by name
+			std::sort(results.begin(), results.end(), DtaResult::compareName);
+		} else if (optOE) {
+			// Sort by extension
+			std::sort(results.begin(), results.end(), DtaResult::compareExt);
+		} else if (optOD) {
+			// Sort by date
+			std::sort(results.begin(), results.end(), DtaResult::compareDate);
+		} else if (optOS) {
+			// Sort by size
+			std::sort(results.begin(), results.end(), DtaResult::compareSize);
+		} else if (optOG) {
+			// Directories first, then files
+			std::sort(results.begin(), results.end(), DtaResult::groupDirs);
+		} else if (optO) {
+			// Directories first, then files, both sort by name
+			std::sort(results.begin(), results.end(), DtaResult::groupDef);
+		}
+		if (reverseSort) {
+			std::reverse(results.begin(), results.end());
+		}
+
+		for (std::vector<DtaResult>::iterator iter = results.begin(); iter != results.end(); ++iter) {
+
+			char * name = iter->name;
+			char *lname = iter->lname;
+			Bit32u size = iter->size;
+			Bit16u date = iter->date;
+			Bit16u time = iter->time;
+			Bit8u attr = iter->attr;
+
+			/* output the file */
+			if (optB) {
+				// this overrides pretty much everything
+				if (strcmp(".",uselfn&&!optZ?lname:name) && strcmp("..",uselfn&&!optZ?lname:name)) {
+					shell->WriteOut("%s\n",uselfn&&!optZ?lname:name);
+				}
+			} else {
+				if (first&&optS) {
+					first=false;
+					shell->WriteOut("\n");
+					shell->WriteOut(MSG_Get("SHELL_CMD_DIR_INTRO"),uselfn&&!optZ&&DOS_GetSFNPath(path,largs,true)?largs:sargs);
+					if (optP) {
+						p_count+=optW?15:3;
+						if (optS&&p_count%(GetPauseCount()*w_size)<3) {
+							shell->WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
+							Bit8u c;Bit16u n=1;
+							DOS_ReadFile(STDIN,&c,&n);
+							if (c==3) {shell->WriteOut("^C\r\n");return false;}
+							if (c==0) DOS_ReadFile(STDIN,&c,&n); // read extended key
+						}
+					}
+				}
+				char * ext = empty_string;
+				if (!optW && (name[0] != '.')) {
+					ext = strrchr(name, '.');
+					if (!ext) ext = empty_string;
+					else *ext++ = 0;
+				}
+				Bit8u day	= (Bit8u)(date & 0x001f);
+				Bit8u month	= (Bit8u)((date >> 5) & 0x000f);
+				Bit16u year = (Bit16u)((date >> 9) + 1980);
+				Bit8u hour	= (Bit8u)((time >> 5 ) >> 6);
+				Bit8u minute = (Bit8u)((time >> 5) & 0x003f);
+
+				if (attr & DOS_ATTR_DIRECTORY) {
+					if (optW) {
+						shell->WriteOut("[%s]",name);
+						size_t namelen = strlen(name);
+						if (namelen <= 14) {
+							for (size_t i=14-namelen;i>0;i--) shell->WriteOut(" ");
+						}
+					} else {
+						shell->WriteOut("%-8s %-3s   %-16s %02d-%02d-%04d %2d:%02d %s\n",name,ext,"<DIR>",day,month,year,hour,minute,uselfn&&!optZ?lname:"");
+					}
+					dir_count++;
+				} else {
+					if (optW) {
+						shell->WriteOut("%-16s",name);
+					} else {
+						FormatNumber(size,numformat);
+						shell->WriteOut("%-8s %-3s   %16s %02d-%02d-%04d %2d:%02d %s\n",name,ext,numformat,day,month,year,hour,minute,uselfn&&!optZ?lname:"");
+					}
+					if (optS) {
+						cfile_count++;
+						cbyte_count+=size;
+					}
+					file_count++;
+					byte_count+=size;
+				}
+				if (optW) w_count++;
+			}
+			if (optP && !(++p_count%(GetPauseCount()*w_size))) {
+				if (optW&&w_count%5) {shell->WriteOut("\n");w_count=0;}
+				shell->WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
+				Bit8u c;Bit16u n=1;
+				DOS_ReadFile(STDIN,&c,&n);
+				if (c==3) {shell->WriteOut("^C\r\n");return false;}
+				if (c==0) DOS_ReadFile(STDIN,&c,&n); // read extended key
+			}
+		}
+
+		if (!results.size())
+			found=false;
+		else if (optW&&w_count%5)
+			shell->WriteOut("\n");
+	} else
+		found=false;
+	if (!found&&!optB&&!optS) {
+		shell->WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),args);
+		if (!dirPaused(shell, w_size, optP, optW)) return false;
+	}
+	if (optS) {
+		size_t len=strlen(sargs);
+		strcat(sargs, "*.*");
+		bool ret=DOS_FindFirst(sargs,0xffff & ~DOS_ATTR_VOLUME);
+		*(sargs+len)=0;
+		if (ret) {
+			std::vector<std::string> cdirs;
+			cdirs.clear();
+			do {    /* File name and extension */
+				DtaResult result;
+				dta.GetResult(result.name,result.lname,result.size,result.date,result.time,result.attr);
+
+				if(result.attr&DOS_ATTR_DIRECTORY && strcmp(result.name, ".")&&strcmp(result.name, "..")) {
+					strcat(sargs, result.name);
+					strcat(sargs, "\\");
+					char *fname = strrchr(args, '\\');
+					if (fname==NULL) fname=args;
+					else fname++;
+					strcat(sargs, fname);
+					cdirs.push_back((sargs[0]!='"'&&sargs[strlen(sargs)-1]=='"'?"\"":"")+std::string(sargs));
+					*(sargs+len)=0;
+				}
+			} while ( (ret=DOS_FindNext()) );
+			dirs.insert(dirs.begin()+1, cdirs.begin(), cdirs.end());
+		}
+		if (found&&!optB) {
+			FormatNumber(cbyte_count,numformat);
+			shell->WriteOut(MSG_Get("SHELL_CMD_DIR_BYTES_USED"),cfile_count,numformat);
+			if (!dirPaused(shell, w_size, optP, optW)) return false;
+		}
+	}
+	return true;
+}
+
 void DOS_Shell::CMD_DIR(char * args) {
 	HELP("DIR");
 	char numformat[16];
+	char path[LFN_NAMELENGTH+2];
+	char sargs[CROSS_LEN];
 
 	std::string line;
-	if (GetEnvStr("DIRCMD",line)){
+	if(GetEnvStr("DIRCMD",line)){
 		std::string::size_type idx = line.find('=');
 		std::string value=line.substr(idx +1 , std::string::npos);
 		line = std::string(args) + " " + value;
 		args=const_cast<char*>(line.c_str());
 	}
 
+	ScanCMDBool(args,"4"); /* /4 ignored (default) */
 	bool optW=ScanCMDBool(args,"W");
-	ScanCMDBool(args,"S");
 	bool optP=ScanCMDBool(args,"P");
-	if (ScanCMDBool(args,"WP") || ScanCMDBool(args,"PW")) {
-		optW=optP=true;
-	}
+	if (ScanCMDBool(args,"WP") || ScanCMDBool(args,"PW")) optW=optP=true;
+	if (ScanCMDBool(args,"-W")) optW=false;
+	if (ScanCMDBool(args,"-P")) optP=false;
+	bool optZ=ScanCMDBool(args,"Z");
+	if (ScanCMDBool(args,"-Z")) optZ=false;
+	bool optS=ScanCMDBool(args,"S");
+	if (ScanCMDBool(args,"-S")) optS=false;
 	bool optB=ScanCMDBool(args,"B");
-	bool optAD=ScanCMDBool(args,"AD");
+	if (ScanCMDBool(args,"-B")) optB=false;
+	bool optA=ScanCMDBool(args,"A");
+	bool optAD=ScanCMDBool(args,"AD")||ScanCMDBool(args,"A:D");
 	bool optAminusD=ScanCMDBool(args,"A-D");
+	bool optAS=ScanCMDBool(args,"AS")||ScanCMDBool(args,"A:S");
+	bool optAminusS=ScanCMDBool(args,"A-S");
+	bool optAH=ScanCMDBool(args,"AH")||ScanCMDBool(args,"A:H");
+	bool optAminusH=ScanCMDBool(args,"A-H");
+	bool optAR=ScanCMDBool(args,"AR")||ScanCMDBool(args,"A:R");
+	bool optAminusR=ScanCMDBool(args,"A-R");
+	bool optAA=ScanCMDBool(args,"AA")||ScanCMDBool(args,"A:A");
+	bool optAminusA=ScanCMDBool(args,"A-A");
+	if (ScanCMDBool(args,"-A")) {
+		optA = false;
+		optAD = false;
+		optAminusD = false;
+		optAS = false;
+		optAminusS = false;
+		optAH = false;
+		optAminusH = false;
+		optAR = false;
+		optAminusR = false;
+		optAA = false;
+		optAminusA = false;
+	}
 	// Sorting flags
 	bool reverseSort = false;
-	bool optON=ScanCMDBool(args,"ON");
+	bool optON=ScanCMDBool(args,"ON")||ScanCMDBool(args,"O:N");
 	if (ScanCMDBool(args,"O-N")) {
 		optON = true;
 		reverseSort = true;
 	}
-	bool optOD=ScanCMDBool(args,"OD");
+	bool optOD=ScanCMDBool(args,"OD")||ScanCMDBool(args,"O:D");
 	if (ScanCMDBool(args,"O-D")) {
 		optOD = true;
 		reverseSort = true;
 	}
-	bool optOE=ScanCMDBool(args,"OE");
+	bool optOE=ScanCMDBool(args,"OE")||ScanCMDBool(args,"O:E");
 	if (ScanCMDBool(args,"O-E")) {
 		optOE = true;
 		reverseSort = true;
 	}
-	bool optOS=ScanCMDBool(args,"OS");
+	bool optOS=ScanCMDBool(args,"OS")||ScanCMDBool(args,"O:S");
 	if (ScanCMDBool(args,"O-S")) {
 		optOS = true;
 		reverseSort = true;
+	}
+	bool optOG=ScanCMDBool(args,"OG")||ScanCMDBool(args,"O:G");
+	if (ScanCMDBool(args,"O-G")) {
+		optOG = true;
+		reverseSort = true;
+	}
+	bool optO=ScanCMDBool(args,"O");
+	if (ScanCMDBool(args,"OGN")) optO=true;
+	if (ScanCMDBool(args,"-O")) {
+		optO = false;
+		optOG = false;
+		optON = false;
+		optOD = false;
+		optOE = false;
+		optOS = false;
+		reverseSort = false;
 	}
 	char * rem=ScanCMDRemain(args);
 	if (rem) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
 		return;
 	}
+	byte_count=0;file_count=0;dir_count=0;p_count=0;
+	Bitu w_size = optW?5:1;
 
-	const std::string pattern = to_search_pattern(args);
+	char buffer[CROSS_LEN];
+	args = trim(args);
+	size_t argLen = strlen(args);
+	if (argLen == 0) {
+		strcpy(args,"*.*"); //no arguments.
+	} else {
+		switch (args[argLen-1])
+		{
+		case '\\':	// handle \, C:\, etc.
+		case ':' :	// handle C:, etc.
+			strcat(args,"*.*");
+			break;
+		default:
+			break;
+		}
+	}
+	args = ExpandDot(args,buffer,CROSS_LEN);
 
-	/* Make a full path in the args */
-	char path[DOS_PATHLENGTH];
-	if (!DOS_Canonicalize(pattern.c_str(), path)) {
+	if (DOS_FindDevice(args) != DOS_DEVICES) {
+		WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),args);
+		return;
+	}
+	if (!strrchr(args,'*') && !strrchr(args,'?')) {
+		Bit16u attribute=0;
+		if(!DOS_GetSFNPath(args,sargs,false)) {
+			WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+			return;
+		}
+		if(DOS_GetFileAttr(sargs,&attribute) && (attribute&DOS_ATTR_DIRECTORY) ) {
+			DOS_FindFirst(sargs,0xffff & ~DOS_ATTR_VOLUME);
+			DOS_DTA dta(dos.dta());
+			strcpy(args,sargs);
+			strcat(args,"\\*.*");	// if no wildcard and a directory, get its files
+		}
+	}
+	if (!DOS_GetSFNPath(args,sargs,false)) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
 		return;
 	}
+	if (!(uselfn&&!optZ&&strchr(sargs,'*'))&&!strrchr(sargs,'.'))
+		strcat(sargs,".*");	// if no extension, get them all
+    sprintf(args,"\"%s\"",sargs);
 
-	// DIR cmd in DOS and cmd.exe format 'Directory of <path>'
-	// accordingly:
-	// - only directory part of pattern passed as an argument
-	// - do not append '\' to the directory name
-	// - for root directories/drives: append '\' to the name
-	char *last_dir_sep = strrchr(path, '\\');
-	if (last_dir_sep == path + 2)
-		*(last_dir_sep + 1) = '\0';
-	else
-		*last_dir_sep = '\0';
+	/* Make a full path in the args */
+	if (!DOS_Canonicalize(args,path)) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		return;
+	}
+	*(strrchr(path,'\\')+1)=0;
+	if (!DOS_GetSFNPath(path,sargs,true)) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		return;
+	}
+    if (*(sargs+strlen(sargs)-1) != '\\') strcat(sargs,"\\");
 
 	const char drive_letter = path[0];
 	const size_t drive_idx = drive_letter - 'A';
 	const bool print_label = (drive_letter >= 'A') && Drives[drive_idx];
-	unsigned p_count = 0; // line counter for 'pause' command
-
-	if (!optB) {
+    if (!optB) {
 		if (print_label) {
 			const char *label = Drives[drive_idx]->GetLabel();
 			WriteOut(MSG_Get("SHELL_CMD_DIR_VOLUME"), drive_letter, label);
 			p_count += 1;
 		}
-		WriteOut(MSG_Get("SHELL_CMD_DIR_INTRO"), path);
-		WriteOut_NoParsing("\n");
-		p_count += 2;
+		if (optP) p_count+=optW?15:3;
 	}
-
-	// Helper function to handle 'Press any key to continue' message
-	// regardless of specific formatting below.
-	// Call it whenever a newline gets printed.
-	//
-	// TODO: DIR code assumes, that terminal size is 80x25
-	auto show_press_any_key = [&]() {
-		p_count += 1;
-		if (optP && (p_count % 24) == 0)
-			CMD_PAUSE(empty_string);
-	};
-
-	const bool is_root = strnlen(path, sizeof(path)) == 3;
 
 	/* Command uses dta so set it to our internal dta */
 	RealPt save_dta=dos.dta();
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
-
-	bool ret = DOS_FindFirst(pattern.c_str(), 0xffff & ~DOS_ATTR_VOLUME);
-	if (!ret) {
-		if (!optB)
-			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),
-			         pattern.c_str());
-		dos.dta(save_dta);
-		return;
+	dirs.clear();
+	dirs.push_back(std::string(args));
+	while (!dirs.empty()) {
+		if (!doDir(this, (char *)dirs.begin()->c_str(), dta, numformat, w_size, optW, optZ, optS, optP, optB, optA, optAD, optAminusD, optAS, optAminusS, optAH, optAminusH, optAR, optAminusR, optAA, optAminusA, optO, optOG, optON, optOD, optOE, optOS, reverseSort)) {dos.dta(save_dta);return;}
+		dirs.erase(dirs.begin());
 	}
-
-	std::vector<DtaResult> results;
-	// TODO OS should be asked for a number of files and appropriate
-	// vector capacity should be set
-
-	do {    /* File name and extension */
-		DtaResult result;
-		dta.GetResult(result.name,result.size,result.date,result.time,result.attr);
-
-		/* Skip non-directories if option AD is present, or skip dirs in case of A-D */
-		if (optAD && !(result.attr&DOS_ATTR_DIRECTORY) ) continue;
-		else if (optAminusD && (result.attr&DOS_ATTR_DIRECTORY) ) continue;
-
-		results.push_back(result);
-
-	} while ( (ret=DOS_FindNext()) );
-
-	if (optON) {
-		// Sort by name
-		std::sort(results.begin(), results.end(), DtaResult::compareName);
-	} else if (optOE) {
-		// Sort by extension
-		std::sort(results.begin(), results.end(), DtaResult::compareExt);
-	} else if (optOD) {
-		// Sort by date
-		std::sort(results.begin(), results.end(), DtaResult::compareDate);
-	} else if (optOS) {
-		// Sort by size
-		std::sort(results.begin(), results.end(), DtaResult::compareSize);
-	}
-	if (reverseSort) {
-		std::reverse(results.begin(), results.end());
-	}
-
-	uint32_t byte_count = 0;
-	uint32_t file_count = 0;
-	uint32_t dir_count = 0;
-	unsigned w_count = 0;
-
-	for (auto &entry : results) {
-
-		char *name = entry.name;
-		const uint32_t size = entry.size;
-		const uint16_t date = entry.date;
-		const uint16_t time = entry.time;
-		const bool is_dir = entry.attr & DOS_ATTR_DIRECTORY;
-
-		// Skip listing . and .. from toplevel directory, to simulate
-		// DIR output correctly.
-		// Bare format never lists .. nor . as directories.
-		if (is_root || optB) {
-			if (strcmp(".", name) == 0 || strcmp("..", name) == 0)
-				continue;
-		}
-
-		if (is_dir) {
-			dir_count += 1;
-		} else {
-			file_count += 1;
-			byte_count += size;
-		}
-
-		// 'Bare' format: just the name, one per line, nothing else
-		//
-		if (optB) {
-			WriteOut("%s\n", name);
-			show_press_any_key();
-			continue;
-		}
-
-		// 'Wide list' format: using several columns
-		//
-		if (optW) {
-			if (is_dir) {
-				const int length = static_cast<int>(strlen(name));
-				WriteOut("[%s]%*s", name, (14 - length), "");
-			} else {
-				WriteOut("%-16s", name);
-			}
-			w_count += 1;
-			if ((w_count % 5) == 0)
-				show_press_any_key();
-			continue;
-		}
-
-		// default format: one detailed entry per line
-		//
-		const auto year   = static_cast<uint16_t>((date >> 9) + 1980);
-		const auto month  = static_cast<uint8_t>((date >> 5) & 0x000f);
-		const auto day    = static_cast<uint8_t>(date & 0x001f);
-		const auto hour   = static_cast<uint8_t>((time >> 5) >> 6);
-		const auto minute = static_cast<uint8_t>((time >> 5) & 0x003f);
-
-		char *ext = empty_string;
-		if ((name[0] != '.')) {
-			ext = strrchr(name, '.');
-			if (ext) {
-				*ext = '\0';
-				ext++;
-			} else {
-				// prevent (null) from appearing
-				ext = empty_string;
-			}
-		}
-
-		if (is_dir) {
-			WriteOut("%-8s %-3s   %-16s %02d-%02d-%04d %2d:%02d\n",
-			         name, ext, "<DIR>", day, month, year, hour, minute);
-		} else {
-			FormatNumber(size, numformat);
-			WriteOut("%-8s %-3s   %16s %02d-%02d-%04d %2d:%02d\n",
-			         name, ext, numformat, day, month, year, hour, minute);
-		}
-		show_press_any_key();
-	}
-
-	// Additional newline in case last line in 'Wide list` format was
-	// not wrapped automatically.
-	if (optW && (w_count % 5)) {
-		WriteOut("\n");
-		show_press_any_key();
-	}
-
-	// Show the summary of results
 	if (!optB) {
-		FormatNumber(byte_count, numformat);
-		WriteOut(MSG_Get("SHELL_CMD_DIR_BYTES_USED"), file_count, numformat);
-		show_press_any_key();
-
-		Bit8u drive = dta.GetSearchDrive();
-		Bitu free_space = 1024 * 1024 * 100;
+		if (optS) {
+			WriteOut("\n");
+			if (!dirPaused(this, w_size, optP, optW)) {dos.dta(save_dta);return;}
+			if (!file_count&&!dir_count)
+				WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),args);
+			else
+				WriteOut(MSG_Get("SHELL_CMD_DIR_FILES_LISTED"));
+			if (!dirPaused(this, w_size, optP, optW)) {dos.dta(save_dta);return;}
+		}
+		/* Show the summary of results */
+		FormatNumber(byte_count,numformat);
+		WriteOut(MSG_Get("SHELL_CMD_DIR_BYTES_USED"),file_count,numformat);
+		if (!dirPaused(this, w_size, optP, optW)) {dos.dta(save_dta);return;}
+		Bit8u drive=dta.GetSearchDrive();
+		//TODO Free Space
+		Bitu free_space=1024u*1024u*100u;
 		if (Drives[drive]) {
 			Bit16u bytes_sector;
 			Bit8u  sectors_cluster;
@@ -735,9 +1252,9 @@ void DOS_Shell::CMD_DIR(char * args) {
 			                              &free_clusters);
 			free_space = bytes_sector * sectors_cluster * free_clusters;
 		}
-		FormatNumber(free_space, numformat);
-		WriteOut(MSG_Get("SHELL_CMD_DIR_BYTES_FREE"), dir_count, numformat);
-		show_press_any_key();
+		FormatNumber(free_space,numformat);
+		WriteOut(MSG_Get("SHELL_CMD_DIR_BYTES_FREE"),dir_count,numformat);
+		if (!dirPaused(this, w_size, optP, optW)) {dos.dta(save_dta);return;}
 	}
 	dos.dta(save_dta);
 }
@@ -745,16 +1262,68 @@ void DOS_Shell::CMD_DIR(char * args) {
 void DOS_Shell::CMD_LS(char *args)
 {
 	HELP("LS");
+	bool optA=ScanCMDBool(args,"A");
+	bool optL=ScanCMDBool(args,"L");
+	bool optP=ScanCMDBool(args,"P");
+	bool optZ=ScanCMDBool(args,"Z");
+	char * rem=ScanCMDRemain(args);
+	if (rem) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
+		return;
+	}
 
-	const RealPt original_dta = dos.dta();
+	RealPt save_dta=dos.dta();
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
 
-	const std::string pattern = to_search_pattern(args);
-	bool ret = DOS_FindFirst(pattern.c_str(), 0xffff & ~DOS_ATTR_VOLUME);
+	std::string pattern = args;
+	trim(pattern);
+
+	const char last_char = (pattern.length() > 0 ? pattern.back() : '\0');
+	switch (last_char) {
+		case '\0': // No arguments, search for all.
+			pattern = "*.*";
+			break;
+		case '\\': // Handle \, C:\, etc.
+		case ':':  // Handle C:, etc.
+			pattern += "*.*";
+			break;
+		default: break;
+	}
+
+	// Handle patterns starting with a dot.
+	char buffer[CROSS_LEN];
+	pattern = ExpandDot((char *)pattern.c_str(), buffer, sizeof(buffer));
+
+	// When there's no wildcard and target is a directory then search files
+	// inside the directory.
+	const char *p = pattern.c_str();
+	if (!strrchr(p, '*') && !strrchr(p, '?')) {
+		uint16_t attr = 0;
+		if (DOS_GetFileAttr(p, &attr) && (attr & DOS_ATTR_DIRECTORY))
+			pattern += "\\*.*";
+	}
+
+	// If no extension, list all files.
+	// This makes patterns like foo* work.
+	if (!strrchr(pattern.c_str(), '.'))
+		pattern += ".*";
+
+	char spattern[CROSS_LEN];
+	if (!DOS_GetSFNPath(pattern.c_str(),spattern,false)) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		return;
+	}
+	int fbak=lfn_filefind_handle;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+	bool ret = DOS_FindFirst((char *)((uselfn?"\"":"")+std::string(spattern)+(uselfn?"\"":"")).c_str(), 0xffff & ~DOS_ATTR_VOLUME);
 	if (!ret) {
-		WriteOut(MSG_Get("SHELL_CMD_LS_PATH_ERR"), trim(args));
-		dos.dta(original_dta);
+		lfn_filefind_handle=fbak;
+		if (trim(args))
+			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"), trim(args));
+		else
+			WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+		dos.dta(save_dta);
 		return;
 	}
 
@@ -765,39 +1334,69 @@ void DOS_Shell::CMD_LS(char *args)
 
 	do {
 		DtaResult result;
-		dta.GetResult(result.name, result.size, result.date,
-		              result.time, result.attr);
+		dta.GetResult(result.name, result.lname, result.size, result.date, result.time, result.attr);
 		results.push_back(result);
 	} while ((ret = DOS_FindNext()) == true);
+	lfn_filefind_handle=fbak;
 
-	size_t w_count = 0;
+	size_t w_count, p_count, col;
+	unsigned int max[10], total, tcols=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+	if (!tcols) tcols=80;
+
+	for (col=10; col>0; col--) {
+		for (int i=0; i<10; i++) max[i]=2;
+		if (optL) col=1;
+		if (col==1) break;
+		w_count=0;
+		for (const auto &entry : results) {
+			std::string name = uselfn&&!optZ?entry.lname:entry.name;
+			if (name == "." || name == "..") continue;
+			if (!optA && (entry.attr&DOS_ATTR_SYSTEM || entry.attr&DOS_ATTR_HIDDEN)) continue;
+			if (name.size()+2>max[w_count%col]) max[w_count%col]=(unsigned int)(name.size()+2);
+			++w_count;
+		}
+		total=0;
+		for (size_t i=0; i<col; i++) total+=max[i];
+		if (total<tcols) break;
+	}
+
+	w_count = 0, p_count = 0;
 
 	for (const auto &entry : results) {
-		std::string name = entry.name;
-		const bool is_dir = entry.attr & DOS_ATTR_DIRECTORY;
-
-		if (name == "." || name == "..")
-			continue;
-
-		if (is_dir) {
-			upcase(name);
-			WriteOut("\033[34;1m%-15s\033[0m", name.c_str());
+		std::string name = uselfn&&!optZ?entry.lname:entry.name;
+		if (name == "." || name == "..") continue;
+		if (!optA && (entry.attr&DOS_ATTR_SYSTEM || entry.attr&DOS_ATTR_HIDDEN)) continue;
+		if (entry.attr & DOS_ATTR_DIRECTORY) {
+			if (!uselfn||optZ) upcase(name);
+			if (col==1) {
+				WriteOut("\033[34;1m%s\033[0m\n", name.c_str());
+				p_count++;
+			} else
+				WriteOut("\033[34;1m%-*s\033[0m", max[w_count % col], name.c_str());
 		} else {
-			lowcase(name);
-			const bool is_executable = ends_with(".exe", name) ||
-			                           ends_with(".bat", name) ||
-			                           ends_with(".com", name);
-			if (is_executable)
-				WriteOut("\033[32;1m%-15s\033[0m", name.c_str());
-			else
-				WriteOut("%-15s", name.c_str());
+			if (!uselfn||optZ) lowcase(name);
+			const bool is_executable = name.length()>4 && (!strcasecmp(name.substr(name.length()-4).c_str(), ".exe") || !strcasecmp(name.substr(name.length()-4).c_str(), ".com") || !strcasecmp(name.substr(name.length()-4).c_str(), ".bat"));
+			if (col==1) {
+				WriteOut(is_executable?"\033[32;1m%s\033[0m\n":"%s\n", name.c_str());
+				p_count++;
+			} else
+				WriteOut(is_executable?"\033[32;1m%-*s\033[0m":"%-*s", max[w_count % col], name.c_str());
 		}
-
-		++w_count;
-		if (w_count % 5 == 0)
-			WriteOut_NoParsing("\n");
+		if (col>1) {
+			++w_count;
+			if (w_count % col == 0) {p_count++;WriteOut_NoParsing("\n");}
+		}
+		if (optP&&p_count>=GetPauseCount()) {
+			WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
+			Bit8u c;Bit16u n=1;
+			DOS_ReadFile(STDIN,&c,&n);
+			if (c==3) {WriteOut("^C\r\n");dos.dta(save_dta);return;}
+			if (c==0) DOS_ReadFile(STDIN,&c,&n); // read extended key
+			p_count=0;
+		}
 	}
-	dos.dta(original_dta);
+	if (col>1&&w_count%col) WriteOut_NoParsing("\n");
+	dos.dta(save_dta);
 }
 
 struct copysource {
@@ -810,22 +1409,29 @@ struct copysource {
 
 
 void DOS_Shell::CMD_COPY(char * args) {
-	HELP("COPY");
-	static char defaulttarget[] = ".";
+	static std::string defaulttarget = ".";
 	StripSpaces(args);
 	/* Command uses dta so set it to our internal dta */
 	RealPt save_dta=dos.dta();
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
 	Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
-	char name[DOS_NAMELENGTH_ASCII];
+	char name[DOS_NAMELENGTH_ASCII], lname[LFN_NAMELENGTH+1];
 	std::vector<copysource> sources;
 	// ignore /b and /t switches: always copy binary
-	while (ScanCMDBool(args,"B")) ;
-	while (ScanCMDBool(args,"T")) ; //Shouldn't this be A ?
-	while (ScanCMDBool(args,"A")) ;
-	ScanCMDBool(args,"Y");
-	ScanCMDBool(args,"-Y");
+	while(ScanCMDBool(args,"B")) ;
+	while(ScanCMDBool(args,"T")) ; //Shouldn't this be A ?
+	while(ScanCMDBool(args,"A")) ;
+	bool optY=ScanCMDBool(args,"Y");
+	std::string line;
+	if(GetEnvStr("COPYCMD",line)){
+		std::string::size_type idx = line.find('=');
+		std::string value=line.substr(idx +1 , std::string::npos);
+		char copycmd[CROSS_LEN];
+		strcpy(copycmd, value.c_str());
+		if (ScanCMDBool(copycmd, "Y") && !ScanCMDBool(copycmd, "-Y")) optY = true;
+	}
+	if (ScanCMDBool(args,"-Y")) optY=false;
 	ScanCMDBool(args,"V");
 
 	char * rem=ScanCMDRemain(args);
@@ -837,34 +1443,62 @@ void DOS_Shell::CMD_COPY(char * args) {
 	// Gather all sources (extension to copy more then 1 file specified at command line)
 	// Concatenating files go as follows: All parts except for the last bear the concat flag.
 	// This construction allows them to be counted (only the non concat set)
+	char q[]="\"";
 	char* source_p = NULL;
 	char source_x[DOS_PATHLENGTH+CROSS_LEN];
-	while ( (source_p = StripWord(args)) && *source_p ) {
+	while ( (source_p = StripArg(args)) && *source_p ) {
 		do {
 			char* plus = strchr(source_p,'+');
 			// If StripWord() previously cut at a space before a plus then
 			// set concatenate flag on last source and remove leading plus.
 			if (plus == source_p && sources.size()) {
-				sources[sources.size() - 1].concat = true;
+				sources[sources.size()-1].concat = true;
 				// If spaces also followed plus then item is only a plus.
-				if (strlen(++source_p) == 0) break;
+				if (strlen(++source_p)==0) break;
 				plus = strchr(source_p,'+');
 			}
-			if (plus) *plus++ = 0;
+			if (plus) {
+				char *c=source_p+strlen(source_p)-1;
+				if (*source_p=='"'&&*c=='"') {
+					*c=0;
+					if (strchr(source_p+1,'"'))
+						*plus++ = 0;
+					else
+						plus=NULL;
+					*c='"';
+				} else
+					*plus++ = 0;
+			}
 			safe_strncpy(source_x,source_p,CROSS_LEN);
 			bool has_drive_spec = false;
 			size_t source_x_len = strlen(source_x);
 			if (source_x_len>0) {
-				if (source_x[source_x_len-1] == ':') has_drive_spec = true;
-			}
-			if (!has_drive_spec  && !strpbrk(source_p,"*?") ) { //doubt that fu*\*.* is valid
-				if (DOS_FindFirst(source_p,0xffff & ~DOS_ATTR_VOLUME)) {
-					dta.GetResult(name,size,date,time,attr);
-					if (attr & DOS_ATTR_DIRECTORY)
-						strcat(source_x,"\\*.*");
+				if (source_x[source_x_len-1]==':') has_drive_spec = true;
+				else if (uselfn&&strchr(source_x, '*')) {
+					char * find_last;
+					find_last=strrchr(source_x,'\\');
+					if (find_last==NULL) find_last=source_x;
+					else find_last++;
+					if (strlen(find_last)>0&&source_x[source_x_len-1]=='*'&&strchr(find_last, '.')==NULL) strcat(source_x, ".*");
 				}
 			}
-			sources.push_back(copysource(source_x,(plus)?true:false));
+			if (!has_drive_spec  && !strpbrk(source_p,"*?") ) { //doubt that fu*\*.* is valid
+                char spath[DOS_PATHLENGTH+2];
+                if (DOS_GetSFNPath(source_p,spath,false)) {
+					bool root=false;
+					if (strlen(spath)==3&&spath[1]==':'&&spath[2]=='\\') {
+						root=true;
+						strcat(spath, "*.*");
+					}
+					if (DOS_FindFirst(spath,0xffff & ~DOS_ATTR_VOLUME)) {
+                    dta.GetResult(name,lname,size,date,time,attr);
+					if (attr & DOS_ATTR_DIRECTORY || root)
+						strcat(source_x,"\\*.*");
+					}
+				}
+			}
+            std::string source_xString = std::string(source_x);
+			sources.push_back(copysource(source_xString,(plus)?true:false));
 			source_p = plus;
 		} while (source_p && *source_p);
 	}
@@ -873,7 +1507,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
 		dos.dta(save_dta);
 		return;
-	};
+	}
 
 	copysource target;
 	// If more then one object exists and last target is not part of a
@@ -888,27 +1522,29 @@ void DOS_Shell::CMD_COPY(char * args) {
 	copysource oldsource;
 	copysource source;
 	Bit32u count = 0;
-	while (sources.size()) {
+	while(sources.size()) {
 		/* Get next source item and keep track of old source for concat start end */
 		oldsource = source;
 		source = sources[0];
 		sources.erase(sources.begin());
 
 		//Skip first file if doing a+b+c. Set target to first file
-		if (!oldsource.concat && source.concat && target.concat) {
+		if(!oldsource.concat && source.concat && target.concat) {
 			target = source;
 			continue;
 		}
 
 		/* Make a full path in the args */
-		char pathSource[DOS_PATHLENGTH];
-		char pathTarget[DOS_PATHLENGTH];
+		char pathSourcePre[LFN_NAMELENGTH], pathSource[LFN_NAMELENGTH+2];
+		char pathTarget[LFN_NAMELENGTH+2];
 
-		if (!DOS_Canonicalize(const_cast<char*>(source.filename.c_str()),pathSource)) {
+		if (!DOS_Canonicalize(const_cast<char*>(source.filename.c_str()),pathSourcePre)) {
 			WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
 			dos.dta(save_dta);
 			return;
 		}
+		strcpy(pathSource,pathSourcePre);
+		if (uselfn) sprintf(pathSource,"\"%s\"",pathSourcePre);
 		// cut search pattern
 		char* pos = strrchr(pathSource,'\\');
 		if (pos) *(pos+1) = 0;
@@ -919,13 +1555,13 @@ void DOS_Shell::CMD_COPY(char * args) {
 			return;
 		}
 		char* temp = strstr(pathTarget,"*.*");
-		if (temp) *temp = 0;//strip off *.* from target
+		if(temp && (temp == pathTarget || temp[-1] == '\\')) *temp = 0;//strip off *.* from target
 
 		// add '\\' if target is a directory
 		bool target_is_file = true;
-		if (pathTarget[strlen(pathTarget) - 1]!='\\') {
+		if (pathTarget[strlen(pathTarget)-1]!='\\') {
 			if (DOS_FindFirst(pathTarget,0xffff & ~DOS_ATTR_VOLUME)) {
-				dta.GetResult(name,size,date,time,attr);
+				dta.GetResult(name,lname,size,date,time,attr);
 				if (attr & DOS_ATTR_DIRECTORY) {
 					strcat(pathTarget,"\\");
 					target_is_file = false;
@@ -934,37 +1570,139 @@ void DOS_Shell::CMD_COPY(char * args) {
 		} else target_is_file = false;
 
 		//Find first sourcefile
-		bool ret = DOS_FindFirst(const_cast<char*>(source.filename.c_str()),0xffff & ~DOS_ATTR_VOLUME);
+		char sPath[LFN_NAMELENGTH+2];
+		bool ret=DOS_GetSFNPath(source.filename.c_str(),sPath,false) && DOS_FindFirst((char *)((strchr(sPath, ' ')&&sPath[0]!='"'&&sPath[0]!='"'?"\"":"")+std::string(sPath)+(strchr(sPath, ' ')&&sPath[strlen(sPath)-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 		if (!ret) {
 			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),const_cast<char*>(source.filename.c_str()));
 			dos.dta(save_dta);
 			return;
 		}
 
-		Bit16u sourceHandle,targetHandle;
-		char nameTarget[DOS_PATHLENGTH];
-		char nameSource[DOS_PATHLENGTH];
+		Bit16u sourceHandle,targetHandle = 0;
+		char nameTarget[LFN_NAMELENGTH];
+		char nameSource[LFN_NAMELENGTH], nametmp[DOS_PATHLENGTH+2];
 
-		bool second_file_of_current_source = false;
+		// Cache so we don't have to recalculate
+		size_t pathTargetLen = strlen(pathTarget);
+
+		// See if we have to substitute filename or extension
+		char *ext = 0;
+		size_t replacementOffset = 0;
+		if (pathTarget[pathTargetLen-1]!='\\') {
+				// only if it's not a directory
+			ext = strchr(pathTarget, '.');
+			if (ext > pathTarget) { // no possible substitution
+				if (ext[-1] == '*') {
+					// we substitute extension, save it, hide the name
+					ext[-1] = 0;
+					assert(ext > pathTarget + 1); // pathTarget is fully qualified
+					if (ext[-2] != '\\') {
+						// there is something before the asterisk
+						// save the offset in the source names
+
+						replacementOffset = source.filename.find('*');
+						size_t lastSlash = source.filename.rfind('\\');
+						if (std::string::npos == lastSlash)
+							lastSlash = 0;
+						else
+							lastSlash++;
+						if (std::string::npos == replacementOffset
+							  || replacementOffset < lastSlash) {
+							// no asterisk found or in wrong place, error
+							WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+							dos.dta(save_dta);
+							return;
+						}
+						replacementOffset -= lastSlash;
+//						WriteOut("[II] replacement offset is %d\n", replacementOffset);
+					}
+				}
+				if (ext[1] == '*') {
+					// we substitute name, clear the extension
+					*ext = 0;
+				} else if (ext[-1]) {
+					// we don't substitute anything, clear up
+					ext = 0;
+				}
+			}
+		}
+
+		bool echo=dos.echo, second_file_of_current_source = false;
 		while (ret) {
-			dta.GetResult(name,size,date,time,attr);
+			dta.GetResult(name,lname,size,date,time,attr);
 
-			if ((attr & DOS_ATTR_DIRECTORY) == 0) {
-				safe_strcpy(nameSource, pathSource);
+			if ((attr & DOS_ATTR_DIRECTORY)==0) {
+                Bit16u ftime,fdate;
+
+				strcpy(nameSource,pathSource);
 				strcat(nameSource,name);
+
 				// Open Source
 				if (DOS_OpenFile(nameSource,0,&sourceHandle)) {
+                    // record the file date/time
+                    bool ftdvalid = DOS_GetFileDate(sourceHandle, &ftime, &fdate);
+                    if (!ftdvalid) LOG_MSG("WARNING: COPY cannot obtain file date/time");
+
 					// Create Target or open it if in concat mode
-					safe_strcpy(nameTarget, pathTarget);
-					if (nameTarget[strlen(nameTarget) - 1] == '\\') strcat(nameTarget,name);
+					strcpy(nameTarget,q);
+                    strcat(nameTarget,pathTarget);
+
+					if (ext) { // substitute parts if necessary
+						if (!ext[-1]) { // substitute extension
+							strcat(nameTarget, (uselfn?lname:name) + replacementOffset);
+							char *p=strchr(nameTarget, '.');
+							strcpy(p==NULL?nameTarget+strlen(nameTarget):p, ext);
+						}
+						if (ext[1] == '*') { // substitute name (so just add the extension)
+							strcat(nameTarget, strchr(uselfn?lname:name, '.'));
+						}
+					}
+
+                    if (nameTarget[strlen(nameTarget)-1]=='\\') strcat(nameTarget,uselfn?lname:name);
+                    strcat(nameTarget,q);
 
 					//Special variable to ensure that copy * a_file, where a_file is not a directory concats.
-					bool special = second_file_of_current_source && target_is_file;
+					bool special = second_file_of_current_source && target_is_file && strchr(target.filename.c_str(), '*')==NULL;
 					second_file_of_current_source = true;
 					if (special) oldsource.concat = true;
+					if (*nameSource&&*nameTarget) {
+						strcpy(nametmp, nameSource[0]!='\"'&&nameTarget[0]=='\"'?"\"":"");
+						strcat(nametmp, nameSource);
+						strcat(nametmp, nameSource[strlen(nameSource)-1]!='\"'&&nameTarget[strlen(nameTarget)-1]=='\"'?"\"":"");
+					} else
+						strcpy(nametmp, nameSource);
+					if (!oldsource.concat && (!strcasecmp(nameSource, nameTarget) || !strcasecmp(nametmp, nameTarget)))
+						{
+						WriteOut("File cannot be copied onto itself\r\n");
+						dos.dta(save_dta);
+						DOS_CloseFile(sourceHandle);
+						if (targetHandle)
+							DOS_CloseFile(targetHandle);
+						return;
+						}
+					Bit16u fattr;
+					bool exist = DOS_GetFileAttr(nameTarget, &fattr);
+					if (!(attr & DOS_ATTR_DIRECTORY) && DOS_FindDevice(nameTarget) == DOS_DEVICES) {
+						if (exist && !optY && !oldsource.concat) {
+							dos.echo=false;
+							WriteOut(MSG_Get("SHELL_CMD_COPY_CONFIRM"), nameTarget);
+							Bit8u c;
+							Bit16u n=1;
+							while (true)
+								{
+								DOS_ReadFile (STDIN,&c,&n);
+								if (c==3) {WriteOut("^C\r\n");dos.dta(save_dta);DOS_CloseFile(sourceHandle);dos.echo=echo;return;}
+								if (c=='y'||c=='Y') {WriteOut("Y\r\n", c);break;}
+								if (c=='n'||c=='N') {WriteOut("N\r\n", c);break;}
+								if (c=='a'||c=='A') {WriteOut("A\r\n", c);optY=true;break;}
+								}
+							if (c=='n'||c=='N') {DOS_CloseFile(sourceHandle);ret = DOS_FindNext();continue;}
+						}
+					}
 					//Don't create a new file when in concat mode
 					if (oldsource.concat || DOS_CreateFile(nameTarget,0,&targetHandle)) {
 						Bit32u dummy=0;
+
 						//In concat mode. Open the target and seek to the eof
 						if (!oldsource.concat || (DOS_OpenFile(nameTarget,OPEN_READWRITE,&targetHandle) &&
 					        	                  DOS_SeekFile(targetHandle,&dummy,DOS_SEEK_END))) {
@@ -972,14 +1710,49 @@ void DOS_Shell::CMD_COPY(char * args) {
 							static Bit8u buffer[0x8000]; // static, otherwise stack overflow possible.
 							bool	failed = false;
 							Bit16u	toread = 0x8000;
+							bool iscon=DOS_FindDevice(name)==DOS_FindDevice("con");
+							if (iscon) dos.echo=true;
+							bool cont;
 							do {
-								failed |= DOS_ReadFile(sourceHandle,buffer,&toread);
-								failed |= DOS_WriteFile(targetHandle,buffer,&toread);
-							} while (toread == 0x8000);
-							failed |= DOS_CloseFile(sourceHandle);
-							failed |= DOS_CloseFile(targetHandle);
-							WriteOut(" %s\n",name);
-							if (!source.concat && !special) count++; //Only count concat files once
+								if (!DOS_ReadFile(sourceHandle,buffer,&toread)) failed=true;
+								if (iscon)
+									{
+									if (dos.errorcode==77)
+										{
+										WriteOut("^C\r\n");
+										dos.dta(save_dta);
+										DOS_CloseFile(sourceHandle);
+										DOS_CloseFile(targetHandle);
+										if (!exist) DOS_UnlinkFile(nameTarget);
+										dos.echo=echo;
+										return;
+										}
+									cont=true;
+									for (int i=0;i<toread;i++)
+										if (buffer[i]==26)
+											{
+											toread=i;
+											cont=false;
+											break;
+											}
+									if (!DOS_WriteFile(targetHandle,buffer,&toread)) failed=true;
+									if (cont) toread=0x8000;
+									}
+								else
+									{
+									if (!DOS_WriteFile(targetHandle,buffer,&toread)) failed=true;
+									cont=toread == 0x8000;
+									}
+							} while (cont);
+							if (!DOS_CloseFile(sourceHandle)) failed=true;
+							if (!DOS_CloseFile(targetHandle)) failed=true;
+							if (failed)
+                                WriteOut(MSG_Get("SHELL_CMD_COPY_ERROR"),uselfn?lname:name);
+                            else if (strcmp(name,lname)&&uselfn)
+                                WriteOut(" %s [%s]\n",lname,name);
+                            else
+                                WriteOut(" %s\n",uselfn?lname:name);
+							if(!source.concat && !special) count++; //Only count concat files once
 						} else {
 							DOS_CloseFile(sourceHandle);
 							WriteOut(MSG_Get("SHELL_CMD_COPY_FAILURE"),const_cast<char*>(target.filename.c_str()));
@@ -989,15 +1762,17 @@ void DOS_Shell::CMD_COPY(char * args) {
 						WriteOut(MSG_Get("SHELL_CMD_COPY_FAILURE"),const_cast<char*>(target.filename.c_str()));
 					}
 				} else WriteOut(MSG_Get("SHELL_CMD_COPY_FAILURE"),const_cast<char*>(source.filename.c_str()));
-			};
+			}
 			//On to the next file if the previous one wasn't a device
 			if ((attr&DOS_ATTR_DEVICE) == 0) ret = DOS_FindNext();
 			else ret = false;
-		};
+		}
 	}
 
 	WriteOut(MSG_Get("SHELL_CMD_COPY_SUCCESS"),count);
 	dos.dta(save_dta);
+	dos.echo=echo;
+	Drives[DOS_GetDefaultDrive()]->EmptyCache();
 }
 
 void DOS_Shell::CMD_SET(char * args) {
@@ -1093,21 +1868,48 @@ void DOS_Shell::CMD_IF(char * args) {
 		return;
 	}
 
-	if (strncasecmp(args,"EXIST ",6) == 0) {
+	if(strncasecmp(args,"EXIST ",6) == 0) {
 		args += 6; //Skip text
 		StripSpaces(args);
-		char* word = StripWord(args);
+		char* word = StripArg(args);
 		if (!*word) {
 			WriteOut(MSG_Get("SHELL_CMD_IF_EXIST_MISSING_FILENAME"));
 			return;
 		}
 
 		{	/* DOS_FindFirst uses dta so set it to our internal dta */
+			char spath[LFN_NAMELENGTH+2], path[LFN_NAMELENGTH+2], pattern[LFN_NAMELENGTH+2], full[LFN_NAMELENGTH+2], *r;
+			if (!DOS_Canonicalize(word,full)) return;
+			r=strrchr(full, '\\');
+			if (r!=NULL) {
+				*r=0;
+				strcpy(path, full);
+				strcat(path, "\\");
+				strcpy(pattern, r+1);
+				*r='\\';
+			} else {
+				strcpy(path, "");
+				strcpy(pattern, full);
+			}
+			int k=0;
+			for (int i=0;i<(int)strlen(pattern);i++)
+				if (pattern[i]!='\"')
+					pattern[k++]=pattern[i];
+			pattern[k]=0;
+			strcpy(spath, path);
+			if (strchr(word,'\"')||uselfn) {
+				if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
+				if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+			}
 			RealPt save_dta=dos.dta();
 			dos.dta(dos.tables.tempdta);
-			bool ret=DOS_FindFirst(word,0xffff & ~DOS_ATTR_VOLUME);
+			int fbak=lfn_filefind_handle;
+			lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+			std::string sfull=std::string(spath)+std::string(pattern);
+			bool ret=DOS_FindFirst((char *)((uselfn&&sfull.length()&&sfull[0]!='"'?"\"":"")+sfull+(uselfn&&sfull.length()&&sfull[sfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~(DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY));
+			lfn_filefind_handle=fbak;
 			dos.dta(save_dta);
-			if (ret == (!has_not)) DoCommand(args);
+			if (ret==(!has_not)) DoCommand(args);
 		}
 		return;
 	}
@@ -1182,19 +1984,24 @@ void DOS_Shell::CMD_TYPE(char * args) {
 	Bit16u handle;
 	char * word;
 nextfile:
-	word=StripWord(args);
+	word=StripArg(args);
 	if (!DOS_OpenFile(word,0,&handle)) {
 		WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),word);
 		return;
 	}
-	Bit16u n;Bit8u c;
-	do {
-		n=1;
+	Bit8u c;Bit16u n=1;
+	bool iscon=DOS_FindDevice(word)==DOS_FindDevice("con");
+	while (n) {
 		DOS_ReadFile(handle,&c,&n);
-		if (c == 0x1a) break; // stop at EOF
+		if (n==0 || c==0x1a) break; // stop at EOF
+		if (iscon) {
+			if (c==3) {WriteOut("^C\r\n");break;}
+			else if (c==13) WriteOut("\r\n");
+		}
 		DOS_WriteFile(STDOUT,&c,&n);
-	} while (n);
+	}
 	DOS_CloseFile(handle);
+	WriteOut("\r\n");
 	if (*args) goto nextfile;
 }
 
@@ -1321,7 +2128,7 @@ void DOS_Shell::CMD_TIME(char * args) {
 	}
 };
 
-void DOS_Shell::CMD_SUBST (char * args) {
+void DOS_Shell::CMD_SUBST(char * args) {
 /* If more that one type can be substed think of something else
  * E.g. make basedir member dos_drive instead of localdrive
  */
@@ -1352,7 +2159,7 @@ void DOS_Shell::CMD_SUBST (char * args) {
 		strcat(mountstring,temp_str);
 		strcat(mountstring," ");
 
-   		Bit8u drive;char fulldir[DOS_PATHLENGTH];
+		Bit8u drive;char fulldir[LFN_NAMELENGTH+2];
 		if (!DOS_MakeName(const_cast<char*>(arg.c_str()),fulldir,&drive)) throw 0;
 
 		if ( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
@@ -1486,7 +2293,7 @@ void DOS_Shell::CMD_VER(char *args) {
 	HELP("VER");
 	if (args && strlen(args)) {
 		char* word = StripWord(args);
-		if (strcasecmp(word,"set")) return;
+		if(strcasecmp(word,"set")) return;
 		word = StripWord(args);
 		if (!*args && !*word) { //Reset
 			dos.version.major = 5;
@@ -1494,10 +2301,11 @@ void DOS_Shell::CMD_VER(char *args) {
 		} else if (*args == 0 && *word && (strchr(word,'.') != 0)) { //Allow: ver set 5.1
 			const char * p = strchr(word,'.');
 			dos.version.major = (Bit8u)(atoi(word));
-			dos.version.minor = (Bit8u)(atoi(p+1));
+			dos.version.minor = (Bit8u)(strlen(p+1)==1&&*(p+1)>'0'&&*(p+1)<='9'?atoi(p+1)*10:atoi(p+1));
 		} else { //Official syntax: ver set 5 2
 			dos.version.major = (Bit8u)(atoi(word));
 			dos.version.minor = (Bit8u)(atoi(args));
 		}
+		if (enablelfn != -2) uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
 	} else WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,dos.version.major,dos.version.minor);
 }

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -212,7 +212,6 @@ void DOS_Shell::CMD_CLS(char * args) {
 void DOS_Shell::CMD_DELETE(char * args) {
 	HELP("DELETE");
 	bool optP=ScanCMDBool(args,"P");
-	bool optF=ScanCMDBool(args,"F");
 	bool optQ=ScanCMDBool(args,"Q");
 
 	char * rem=ScanCMDRemain(args);
@@ -350,7 +349,7 @@ continue_1:
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 	while (res) {
 		dta.GetResult(name,lname,size,date,time,attr);
-		if (!optF && (attr & DOS_ATTR_READ_ONLY) && !(attr & DOS_ATTR_DIRECTORY)) {
+		if ((attr & DOS_ATTR_READ_ONLY) && !(attr & DOS_ATTR_DIRECTORY)) {
 			exist=true;
 			strcpy(end,name);
 			strcpy(lend,lname);
@@ -371,12 +370,7 @@ continue_1:
 			}
 			if (strlen(full)) {
 				std::string pfull=(uselfn||strchr(full, ' ')?(full[0]!='"'?"\"":""):"")+std::string(full)+(uselfn||strchr(full, ' ')?(full[strlen(full)-1]!='"'?"\"":""):"");
-				bool reset=false;
-				if (optF && (attr & DOS_ATTR_READ_ONLY)&&DOS_SetFileAttr(pfull.c_str(), attr & ~DOS_ATTR_READ_ONLY)) reset=true;
-				if (!DOS_UnlinkFile(pfull.c_str())) {
-					if (optF&&reset) DOS_SetFileAttr(pfull.c_str(), attr);
-					WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
-				}
+				if (!DOS_UnlinkFile(pfull.c_str())) WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
 			} else WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
 		}
 		res=DOS_FindNext();
@@ -1414,6 +1408,7 @@ struct copysource {
 
 
 void DOS_Shell::CMD_COPY(char * args) {
+	HELP("COPY");
 	static std::string defaulttarget = ".";
 	StripSpaces(args);
 	/* Command uses dta so set it to our internal dta */

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -519,7 +519,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 				if (dot2==NULL) {
 					star=strchr(arg2,'*');
 					if (strchr(arg2,'?')) {
-						for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
+						for (unsigned int i=0; i<(unsigned int)(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
 							if (*(arg2+i)=='?'&&i<strlen(name))
 								*(arg2+i)=name[i];
 						}
@@ -543,7 +543,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					*dot2='.';
 					star=strchr(tname2,'*');
 					if (strchr(tname2,'?')) {
-						for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
+						for (unsigned int i=0; i<(unsigned int)(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
 							if (*(tname2+i)=='?'&&i<strlen(tname1))
 								*(tname2+i)=tname1[i];
 						}
@@ -560,7 +560,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 						safe_strcpy(text2, dot2+1);
 						star=strchr(text2,'*');
 						if (strchr(text2,'?')) {
-							for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+							for (unsigned int i=0; i<(unsigned int)(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='?'&&i<strlen(text1))
 									*(text2+i)=text1[i];
 							}
@@ -574,7 +574,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					} else {
 						safe_strcpy(text2, dot2+1);
 						if (strchr(text2,'?')||strchr(text2,'*')) {
-							for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+							for (unsigned int i=0; i<(unsigned int)(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='*') {
 									*(text2+i)=0;
 									break;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -834,8 +834,7 @@ Bitu p_count;
 std::vector<std::string> dirs, adirs;
 
 static size_t GetPauseCount() {
-	Bit8u page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	return (CURSOR_POS_ROW(page) > 2u) ? (CURSOR_POS_ROW(page) - 2u) : 22u; /* <- FIXME: Please clarify this logic */
+	return (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) > 2u) ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) - 2u) : 22u;
 }
 
 static bool dirPaused(DOS_Shell * shell, Bitu w_size, bool optP, bool optW) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -308,23 +308,23 @@ continue_1:
 	char path[LFN_NAMELENGTH+2], spath[LFN_NAMELENGTH+2], pattern[LFN_NAMELENGTH+2], *r=strrchr(full, '\\');
 	if (r!=NULL) {
 		*r=0;
-		strcpy(path, full);
-		strcat(path, "\\");
-		strcpy(pattern, r+1);
+		safe_strcpy(path, full);
+		safe_strcat(path, "\\");
+		safe_strcpy(pattern, r+1);
 		*r='\\';
 	} else {
-		strcpy(path, "");
-		strcpy(pattern, full);
+		safe_strcpy(path, "");
+		safe_strcpy(pattern, full);
 	}
 	int k=0;
 	for (int i=0;i<(int)strlen(pattern);i++)
 		if (pattern[i]!='\"')
 			pattern[k++]=pattern[i];
 	pattern[k]=0;
-	strcpy(spath, path);
+	safe_strcpy(spath, path);
 	if (strchr(args,'\"')||uselfn) {
-		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
-		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) safe_strcpy(spath, path);
+		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') safe_strcat(spath, "\\");
 	}
 	std::string pfull=std::string(spath)+std::string(pattern);
 	int fbak=lfn_filefind_handle;
@@ -338,7 +338,7 @@ continue_1:
 	}
 	lfn_filefind_handle=fbak;
 	//end can't be 0, but if it is we'll get a nice crash, who cares :)
-	strcpy(sfull,full);
+	safe_strcpy(sfull,full);
 	char * end=strrchr(full,'\\')+1;*end=0;
 	char * lend=strrchr(sfull,'\\')+1;*lend=0;
 	dta=dos.dta();
@@ -462,33 +462,33 @@ void DOS_Shell::CMD_RENAME(char * args){
 			strcat(dummy, ".\\");
 	} else {
 		if (strchr(arg2,'\\')||strchr(arg2,':')) {SyntaxError();return;};
-		strcpy(dir_source, ".\\");
+		safe_strcpy(dir_source, ".\\");
 	}
 
-	strcpy(target,arg2);
+	safe_strcpy(target,arg2);
 
 	char path[LFN_NAMELENGTH+2], spath[LFN_NAMELENGTH+2], pattern[LFN_NAMELENGTH+2], full[LFN_NAMELENGTH+2], *r;
 	if (!DOS_Canonicalize(arg1,full)) return;
 	r=strrchr(full, '\\');
 	if (r!=NULL) {
 		*r=0;
-		strcpy(path, full);
-		strcat(path, "\\");
-		strcpy(pattern, r+1);
+		safe_strcpy(path, full);
+		safe_strcat(path, "\\");
+		safe_strcpy(pattern, r+1);
 		*r='\\';
 	} else {
-		strcpy(path, "");
-		strcpy(pattern, full);
+		safe_strcpy(path, "");
+		safe_strcpy(pattern, full);
 	}
 	int k=0;
 	for (int i=0;i<(int)strlen(pattern);i++)
 		if (pattern[i]!='\"')
 			pattern[k++]=pattern[i];
 	pattern[k]=0;
-	strcpy(spath, path);
+	safe_strcpy(spath, path);
 	if (strchr(arg1,'\"')||uselfn) {
-		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
-		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) safe_strcpy(spath, path);
+		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') safe_strcat(spath, "\\");
 	}
 	RealPt save_dta=dos.dta();
 	dos.dta(dos.tables.tempdta);
@@ -508,12 +508,12 @@ void DOS_Shell::CMD_RENAME(char * args){
 			lfn_filefind_handle=fbak;
 
 			if(!(attr&DOS_ATTR_DIRECTORY && (!strcmp(name, ".") || !strcmp(name, "..")))) {
-				strcpy(dir_target, target);
+				safe_strcpy(dir_target, target);
 				removeChar(dir_target, '\"');
 				arg2=dir_target;
-				strcpy(sargs, dir_source);
+				safe_strcpy(sargs, dir_source);
 				if (uselfn) removeChar(sargs, '\"');
-				strcat(sargs, uselfn?lname:name);
+				safe_strcat(sargs, uselfn?lname:name);
 				if (uselfn&&strchr(arg2,'*')&&!strchr(arg2,'.')) strcat(arg2, ".*");
 				char *dot1=strrchr(uselfn?lname:name,'.'), *dot2=strrchr(arg2,'.'), *star;
 				if (dot2==NULL) {
@@ -534,12 +534,12 @@ void DOS_Shell::CMD_RENAME(char * args){
 				} else {
 					if (dot1) {
 						*dot1=0;
-						strcpy(tname1, uselfn?lname:name);
+						safe_strcpy(tname1, uselfn?lname:name);
 						*dot1='.';
 					} else
-						strcpy(tname1, uselfn?lname:name);
+						safe_strcpy(tname1, uselfn?lname:name);
 					*dot2=0;
-					strcpy(tname2, arg2);
+					safe_strcpy(tname2, arg2);
 					*dot2='.';
 					star=strchr(tname2,'*');
 					if (strchr(tname2,'?')) {
@@ -556,8 +556,8 @@ void DOS_Shell::CMD_RENAME(char * args){
 					}
 					removeChar(tname2, '?');
 					if (dot1) {
-						strcpy(text1, dot1+1);
-						strcpy(text2, dot2+1);
+						safe_strcpy(text1, dot1+1);
+						safe_strcpy(text2, dot2+1);
 						star=strchr(text2,'*');
 						if (strchr(text2,'?')) {
 							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
@@ -572,7 +572,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 								*star=0;
 						}
 					} else {
-						strcpy(text2, dot2+1);
+						safe_strcpy(text2, dot2+1);
 						if (strchr(text2,'?')||strchr(text2,'*')) {
 							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='*') {
@@ -583,14 +583,14 @@ void DOS_Shell::CMD_RENAME(char * args){
 						}
 					}
 					removeChar(text2, '?');
-					strcpy(tfull, tname2);
-					strcat(tfull, ".");
-					strcat(tfull, text2);
+					safe_strcpy(tfull, tname2);
+					safe_strcat(tfull, ".");
+					safe_strcat(tfull, text2);
 					arg2=tfull;
 				}
-				strcpy(targs, dir_source);
+				safe_strcpy(targs, dir_source);
 				if (uselfn) removeChar(targs, '\"');
-				strcat(targs, arg2);
+				safe_strcat(targs, arg2);
 				sources.push_back(uselfn?((sargs[0]!='"'?"\"":"")+std::string(sargs)+(sargs[strlen(sargs)-1]!='"'?"\"":"")).c_str():sargs);
 				sources.push_back(uselfn?((targs[0]!='"'?"\"":"")+std::string(targs)+(targs[strlen(targs)-1]!='"'?"\"":"")).c_str():targs);
 				sources.push_back(strlen(sargs)>2&&sargs[0]=='.'&&sargs[1]=='\\'?sargs+2:sargs);
@@ -873,7 +873,7 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 			}
 		}
 	}
-    if (*(sargs+strlen(sargs)-1) != '\\') strcat(sargs,"\\");
+    if (*(sargs+strlen(sargs)-1) != '\\') safe_strcat(sargs,"\\");
 
 	Bit32u cbyte_count=0,cfile_count=0,w_count=0;
 	int fbak=lfn_filefind_handle;
@@ -1021,7 +1021,7 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 	}
 	if (optS) {
 		size_t len=strlen(sargs);
-		strcat(sargs, "*.*");
+		safe_strcat(sargs, "*.*");
 		bool ret=DOS_FindFirst(sargs,0xffff & ~DOS_ATTR_VOLUME);
 		*(sargs+len)=0;
 		if (ret) {
@@ -1032,12 +1032,12 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 				dta.GetResult(result.name,result.lname,result.size,result.date,result.time,result.attr);
 
 				if(result.attr&DOS_ATTR_DIRECTORY && strcmp(result.name, ".")&&strcmp(result.name, "..")) {
-					strcat(sargs, result.name);
-					strcat(sargs, "\\");
+					safe_strcat(sargs, result.name);
+					safe_strcat(sargs, "\\");
 					char *fname = strrchr(args, '\\');
 					if (fname==NULL) fname=args;
 					else fname++;
-					strcat(sargs, fname);
+					safe_strcat(sargs, fname);
 					cdirs.push_back((sargs[0]!='"'&&sargs[strlen(sargs)-1]=='"'?"\"":"")+std::string(sargs));
 					*(sargs+len)=0;
 				}
@@ -1189,7 +1189,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 		return;
 	}
 	if (!(uselfn&&!optZ&&strchr(sargs,'*'))&&!strrchr(sargs,'.'))
-		strcat(sargs,".*");	// if no extension, get them all
+		safe_strcat(sargs,".*");	// if no extension, get them all
     sprintf(args,"\"%s\"",sargs);
 
 	/* Make a full path in the args */
@@ -1202,7 +1202,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
 		return;
 	}
-    if (*(sargs+strlen(sargs)-1) != '\\') strcat(sargs,"\\");
+    if (*(sargs+strlen(sargs)-1) != '\\') safe_strcat(sargs,"\\");
 
 	const char drive_letter = path[0];
 	const size_t drive_idx = drive_letter - 'A';
@@ -1430,7 +1430,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 		std::string::size_type idx = line.find('=');
 		std::string value=line.substr(idx +1 , std::string::npos);
 		char copycmd[CROSS_LEN];
-		strcpy(copycmd, value.c_str());
+		safe_strcpy(copycmd, value.c_str());
 		if (ScanCMDBool(copycmd, "Y") && !ScanCMDBool(copycmd, "-Y")) optY = true;
 	}
 	if (ScanCMDBool(args,"-Y")) optY=false;
@@ -1481,7 +1481,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 					find_last=strrchr(source_x,'\\');
 					if (find_last==NULL) find_last=source_x;
 					else find_last++;
-					if (strlen(find_last)>0&&source_x[source_x_len-1]=='*'&&strchr(find_last, '.')==NULL) strcat(source_x, ".*");
+					if (strlen(find_last)>0&&source_x[source_x_len-1]=='*'&&strchr(find_last, '.')==NULL) safe_strcat(source_x, ".*");
 				}
 			}
 			if (!has_drive_spec  && !strpbrk(source_p,"*?") ) { //doubt that fu*\*.* is valid
@@ -1490,12 +1490,12 @@ void DOS_Shell::CMD_COPY(char * args) {
 					bool root=false;
 					if (strlen(spath)==3&&spath[1]==':'&&spath[2]=='\\') {
 						root=true;
-						strcat(spath, "*.*");
+						safe_strcat(spath, "*.*");
 					}
 					if (DOS_FindFirst(spath,0xffff & ~DOS_ATTR_VOLUME)) {
                     dta.GetResult(name,lname,size,date,time,attr);
 					if (attr & DOS_ATTR_DIRECTORY || root)
-						strcat(source_x,"\\*.*");
+						safe_strcat(source_x,"\\*.*");
 					}
 				}
 			}
@@ -1545,7 +1545,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 			dos.dta(save_dta);
 			return;
 		}
-		strcpy(pathSource,pathSourcePre);
+		safe_strcpy(pathSource,pathSourcePre);
 		if (uselfn) sprintf(pathSource,"\"%s\"",pathSourcePre);
 		// cut search pattern
 		char* pos = strrchr(pathSource,'\\');
@@ -1565,7 +1565,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 			if (DOS_FindFirst(pathTarget,0xffff & ~DOS_ATTR_VOLUME)) {
 				dta.GetResult(name,lname,size,date,time,attr);
 				if (attr & DOS_ATTR_DIRECTORY) {
-					strcat(pathTarget,"\\");
+					safe_strcat(pathTarget,"\\");
 					target_is_file = false;
 				}
 			}
@@ -1636,8 +1636,8 @@ void DOS_Shell::CMD_COPY(char * args) {
 			if ((attr & DOS_ATTR_DIRECTORY)==0) {
                 Bit16u ftime,fdate;
 
-				strcpy(nameSource,pathSource);
-				strcat(nameSource,name);
+				safe_strcpy(nameSource,pathSource);
+				safe_strcat(nameSource,name);
 
 				// Open Source
 				if (DOS_OpenFile(nameSource,0,&sourceHandle)) {
@@ -1646,33 +1646,33 @@ void DOS_Shell::CMD_COPY(char * args) {
                     if (!ftdvalid) LOG_MSG("WARNING: COPY cannot obtain file date/time");
 
 					// Create Target or open it if in concat mode
-					strcpy(nameTarget,q);
-                    strcat(nameTarget,pathTarget);
+					safe_strcpy(nameTarget,q);
+					safe_strcat(nameTarget,pathTarget);
 
 					if (ext) { // substitute parts if necessary
 						if (!ext[-1]) { // substitute extension
-							strcat(nameTarget, (uselfn?lname:name) + replacementOffset);
+							safe_strcat(nameTarget, (uselfn?lname:name) + replacementOffset);
 							char *p=strchr(nameTarget, '.');
 							strcpy(p==NULL?nameTarget+strlen(nameTarget):p, ext);
 						}
 						if (ext[1] == '*') { // substitute name (so just add the extension)
-							strcat(nameTarget, strchr(uselfn?lname:name, '.'));
+							safe_strcat(nameTarget, strchr(uselfn?lname:name, '.'));
 						}
 					}
 
-                    if (nameTarget[strlen(nameTarget)-1]=='\\') strcat(nameTarget,uselfn?lname:name);
-                    strcat(nameTarget,q);
+                    if (nameTarget[strlen(nameTarget)-1]=='\\') safe_strcat(nameTarget,uselfn?lname:name);
+                    safe_strcat(nameTarget,q);
 
 					//Special variable to ensure that copy * a_file, where a_file is not a directory concats.
 					bool special = second_file_of_current_source && target_is_file && strchr(target.filename.c_str(), '*')==NULL;
 					second_file_of_current_source = true;
 					if (special) oldsource.concat = true;
 					if (*nameSource&&*nameTarget) {
-						strcpy(nametmp, nameSource[0]!='\"'&&nameTarget[0]=='\"'?"\"":"");
-						strcat(nametmp, nameSource);
-						strcat(nametmp, nameSource[strlen(nameSource)-1]!='\"'&&nameTarget[strlen(nameTarget)-1]=='\"'?"\"":"");
+						safe_strcpy(nametmp, nameSource[0]!='\"'&&nameTarget[0]=='\"'?"\"":"");
+						safe_strcat(nametmp, nameSource);
+						safe_strcat(nametmp, nameSource[strlen(nameSource)-1]!='\"'&&nameTarget[strlen(nameTarget)-1]=='\"'?"\"":"");
 					} else
-						strcpy(nametmp, nameSource);
+						safe_strcpy(nametmp, nameSource);
 					if (!oldsource.concat && (!strcasecmp(nameSource, nameTarget) || !strcasecmp(nametmp, nameTarget)))
 						{
 						WriteOut("File cannot be copied onto itself\r\n");
@@ -1885,23 +1885,23 @@ void DOS_Shell::CMD_IF(char * args) {
 			r=strrchr(full, '\\');
 			if (r!=NULL) {
 				*r=0;
-				strcpy(path, full);
-				strcat(path, "\\");
-				strcpy(pattern, r+1);
+				safe_strcpy(path, full);
+				safe_strcat(path, "\\");
+				safe_strcpy(pattern, r+1);
 				*r='\\';
 			} else {
-				strcpy(path, "");
-				strcpy(pattern, full);
+				safe_strcpy(path, "");
+				safe_strcpy(pattern, full);
 			}
 			int k=0;
 			for (int i=0;i<(int)strlen(pattern);i++)
 				if (pattern[i]!='\"')
 					pattern[k++]=pattern[i];
 			pattern[k]=0;
-			strcpy(spath, path);
+			safe_strcpy(spath, path);
 			if (strchr(word,'\"')||uselfn) {
-				if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
-				if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+				if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) safe_strcpy(spath, path);
+				if (!strlen(spath)||spath[strlen(spath)-1]!='\\') safe_strcat(spath, "\\");
 			}
 			RealPt save_dta=dos.dta();
 			dos.dta(dos.tables.tempdta);
@@ -2152,14 +2152,14 @@ void DOS_Shell::CMD_SUBST(char * args) {
 		command.FindCommand(2,arg);
 		if ((arg == "/D") || (arg == "/d")) {
 			if (!Drives[temp_str[0]-'A'] ) throw 1; //targetdrive not in use
-			strcat(mountstring,"-u ");
-			strcat(mountstring,temp_str);
+			safe_strcat(mountstring,"-u ");
+			safe_strcat(mountstring,temp_str);
 			this->ParseLine(mountstring);
 			return;
 		}
 		if (Drives[temp_str[0]-'A'] ) throw 0; //targetdrive in use
-		strcat(mountstring,temp_str);
-		strcat(mountstring," ");
+		safe_strcat(mountstring,temp_str);
+		safe_strcat(mountstring," ");
 
 		Bit8u drive;char fulldir[LFN_NAMELENGTH+2];
 		if (!DOS_MakeName(const_cast<char*>(arg.c_str()),fulldir,&drive)) throw 0;
@@ -2167,12 +2167,12 @@ void DOS_Shell::CMD_SUBST(char * args) {
 		if ( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
 		char newname[CROSS_LEN];
 		safe_strcpy(newname, ldp->getBasedir());
-		strcat(newname,fulldir);
+		safe_strcat(newname,fulldir);
 		CROSS_FILENAME(newname);
 		ldp->dirCache.ExpandName(newname);
-		strcat(mountstring,"\"");
-		strcat(mountstring, newname);
-		strcat(mountstring,"\"");
+		safe_strcat(mountstring,"\"");
+		safe_strcat(mountstring, newname);
+		safe_strcat(mountstring,"\"");
 		this->ParseLine(mountstring);
 	}
 	catch(int a){

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -447,7 +447,7 @@ bool DOS_Shell::Execute(char * name,char * args) {
 	if(strlen(args)!= 0){
 		if(*args != ' '){ //put a space in front
 			line[0]=' ';line[1]=0;
-			strncat(line,args,CMD_MAXLINE-2);
+			safe_strncat(line,args,CMD_MAXLINE-2);
 			line[CMD_MAXLINE-1]=0;
 		}
 		else

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -347,7 +347,7 @@ void DOS_Shell::InputCommand(char * line) {
 						if ((strchr(uselfn?lname:name,' ')!=NULL&&q/2*2==q)||r)
 							sprintf(qlname,q/2*2!=q?"%s\"":"\"%s\"",uselfn?lname:name);
 						else
-							strcpy(qlname,uselfn?lname:name);
+							safe_strcpy(qlname,uselfn?lname:name);
 						// add result to completion list
 
 						if (strcmp(name, ".") && strcmp(name, "..")) {
@@ -669,7 +669,7 @@ const char *DOS_Shell::Which(char *name) const
 			if (uselfn&&len>3) {
 				if (path[len - 1]=='\\') path[len - 1]=0;
 				if (DOS_GetSFNPath(("\""+std::string(path)+"\"").c_str(), s_ret, false))
-					strcpy(path, s_ret);
+					safe_strcpy(path, s_ret);
 				len = strlen(path);
 			}
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -14,6 +14,8 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  Wengier: LFN support
  */
 
 #include "shell.h"

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -292,7 +292,7 @@ void DOS_Shell::InputCommand(char * line) {
 					// build the completion list
 					char mask[LFN_NAMELENGTH+2] = {0}, smask[LFN_NAMELENGTH] = {0};
 					if (p_completion_start) {
-						if (strlen(p_completion_start) + 3 >= (uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) {
+						if (strlen(p_completion_start) + 3 >= (unsigned int)(uselfn?LFN_NAMELENGTH:DOS_PATHLENGTH)) {
 							//Beep;
 							break;
 						}

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -447,7 +447,7 @@ bool DOS_Shell::Execute(char * name,char * args) {
 	if(strlen(args)!= 0){
 		if(*args != ' '){ //put a space in front
 			line[0]=' ';line[1]=0;
-			safe_strncat(line,args,CMD_MAXLINE-2);
+			strncat(line,args,CMD_MAXLINE-2);
 			line[CMD_MAXLINE-1]=0;
 		}
 		else


### PR DESCRIPTION
This pull request adds full long filename support for DOSBox-staging, including LFN support on mounted local drives, overlay drives and FAT drives, as in DOSBox-X. Among them, LFN on FAT drives was a joint effort of @joncampbell123 and myself - it was to a large extent implemented by @joncampbell123 thanks to his great knowledge on FAT filesystem.

A description of long filename support is available from this page in this GitHub site: https://github.com/dosbox-staging/dosbox-staging/commit/093ef992fa2310d74e9e517bd72ab440453f9e7e

By default, this feature is enabled when the reported DOS version is 7.0 or higher (e.g. "ver=7.0" in dosbox.conf or "VER SET 7.0" in the shell) with the default "lfn=auto" setting, but by setting "lfn=true" it will enable the feature regardless of the reported DOS version. On the other hand, the setting "lfn=false" will disable the feature regardless of the reported DOS version. When the feature is enabled, DOS programs that support this feature will use it whenever possible, instead of sticking with 8.3 names. There is a long list of DOS software supporting this feature (see https://individual.utoronto.ca/wengier/doslfns.htm for an incomplete list).

Since I don't play DOS games a lot, at this time I am only aware of the following DOS gaming software which make use of long filename support in DOSBox-staging with this feature enabled:

ZSNES
SNEESE
NESTICLE
RockNES
FakeNES
ESNES
NO$GBA
NO$GMB

All of the above have been tested and confirmed to work in DOSBox-staging with this feature enabled. In such case, long file names will be shown for directories and names of the game ROMs, instead of something like ``PROGRA~1`` and ``SOMEGA~1.ROM``. I am very positive there are more DOS gaming software (especially game emulators for DOS) that will work with this feature, but I have not tried myself yet.

Additional features such as clipboard support will be submitted in separate pull requests later.