### PR TITLE
[FIXUP] Remove a pointer check when the Tandy DAC mode is changed

### DIFF
--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -178,7 +178,7 @@ static void TandyDAC_DMA_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 
 static void TandyDACModeChanged()
 {
-	if (!tandy.dac.chan || !tandy.dac.dma.chan) {
+	if (!tandy.dac.chan) {
 		DEBUG_LOG_MSG("TANDY: Skipping mode change until the DAC is "
 		              "initialized");
 		return;


### PR DESCRIPTION
The original check was introduced to prevent 4D-Sports Boxing from crashing (without impact to all subsequent tested Tandy games) - however this caused a regression in Prince of Persia, which was not part of the test set. It was only discovered after testing.

This issue appear non-trivial after some work to fix it, therefore this commit simply removes this check to allow 4D Sports Boxing to again crash in favour of allowing Prince of Persia to work.