### PR TITLE
Fix 2 crashes in key mapper code

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -806,8 +806,12 @@ private:
 		                        button);
 	}
 
-	CBind * CreateHatBind(uint8_t hat, uint8_t value)
+	CBind *CreateHatBind(uint8_t hat, uint8_t value)
 	{
+		if (is_dummy)
+			return nullptr;
+		assert(hat_lists);
+
 		Bitu hat_dir;
 		if (value & SDL_HAT_UP)
 			hat_dir = 0;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1481,8 +1481,10 @@ public:
 			change_action_text("Press a key/joystick button or move the joystick.",CLR_RED);
 			break;
 		case BB_Del:
-			if (mapper.abindit!=mapper.aevent->bindlist.end())  {
-				delete (*mapper.abindit);
+			if (mapper.abindit != mapper.aevent->bindlist.end()) {
+				auto *active_bind = *mapper.abindit;
+				all_binds.remove(active_bind);
+				delete active_bind;
 				mapper.abindit=mapper.aevent->bindlist.erase(mapper.abindit);
 				if (mapper.abindit==mapper.aevent->bindlist.end()) 
 					mapper.abindit=mapper.aevent->bindlist.begin();


### PR DESCRIPTION
Log:
```
commit 556daf2d48147bca601066984fa842b0198a4835
Date:   Wed Jul 1 11:05:04 2020 +0200

    Fix crash after removing bind
    
    Stale pointer was stored in all_binds list.
    
    This crash was happening on exit after removal of controller actions
    bound to keyboard events.

commit b26b833301a2f5315af35bac379dd460e41e324c
Date:   Wed Jul 1 10:54:51 2020 +0200

    Fix crash with single controller connected
    
    Mapper internal state is not preserved correctly after restart - this
    indicates more issues, but this fix prevents the obvious crash.
    
    Following steps were needed to reproduce the crash:
    
    1. Bind hat events on 2 different controllers
    2. Close dosbox-staging
    3. Disconnect one controller
    4. Start dosbox-staging
    
    Fixes #405

```