### PR TITLE
Make startup verbosity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Other differences:
 | **[Wayland] support**    | Experimental (use `SDL_VIDEODRIVER=wayland`) | N/A
 | **Modem phonebook file** | Yes (`phonebookfile=<name>`)                 | N/A
 | **Autotype command**     | Yes<sup>[10]</sup>                           | N/A
+| **Startup verbosity**    | Yes<sup>[11]</sup>                           | N/A
 
 [OPL]:https://en.wikipedia.org/wiki/Yamaha_YMF262
 [CGA]:https://en.wikipedia.org/wiki/Color_Graphics_Adapter
@@ -77,6 +78,7 @@ Other differences:
 [8]:https://www.vogons.org/viewtopic.php?f=9&t=37782
 [9]:https://github.com/dosbox-staging/dosbox-staging/commit/ffe3c5ab7fb5e28bae78f07ea987904f391a7cf8
 [10]:https://github.com/dosbox-staging/dosbox-staging/commit/239396fec83dbba6a1eb1a0f4461f4a427d2be38
+[11]: https://github.com/dosbox-staging/dosbox-staging/pull/477
 
 ## Development snapshot builds
 

--- a/include/control.h
+++ b/include/control.h
@@ -29,7 +29,15 @@
 #include "programs.h"
 #include "setup.h"
 
-class Config{
+enum class Verbosity : int8_t {
+	//             Show Splash | Show Welcome | Show Early Stdout |
+	High = 3,   //     yes     |     yes      |       yes         |
+	Medium = 2, //     no      |     yes      |       yes         |
+	Low = 1,    //     no      |     no       |       yes         |
+	Quiet = 0   //     no      |     no       |       no          |
+};
+
+class Config {
 public:
 	CommandLine * cmdline;
 private:
@@ -78,6 +86,7 @@ public:
 	void ParseEnv(char ** envp);
 	bool SecureMode() const { return secure_mode; }
 	void SwitchToSecureMode() { secure_mode = true; }//can't be undone
+	Verbosity GetStartupVerbosity() const;
 };
 
 #endif

--- a/include/programs.h
+++ b/include/programs.h
@@ -86,6 +86,7 @@ public:
 	bool SetEnv(const char * entry,const char * new_string);
 	void WriteOut(const char *format, ...);	// printf to DOS stdout
 	void WriteOut_NoParsing(const char *str); // write string to DOS stdout
+	bool SuppressWriteOut(const char *format); // prevent writing to DOS stdout
 	void InjectMissingNewline();
 	void ChangeToLongCmd();
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -54,6 +54,8 @@ public:
 	bool GetStringRemain(std::string & value);
 	int GetParameterFromList(const char* const params[], std::vector<std::string> & output);
 	void FillVector(std::vector<std::string> & vector);
+	bool HasDirectory() const;
+	bool HasExecutableName() const;
 	unsigned int GetCount(void);
 	void Shift(unsigned int amount=1);
 	Bit16u Get_arglength();

--- a/include/support.h
+++ b/include/support.h
@@ -157,4 +157,6 @@ void strip_punctuation(std::string &str);
 bool starts_with(const std::string &prefix, const std::string &str) noexcept;
 bool ends_with(const std::string &suffix, const std::string &str) noexcept;
 
+bool is_executable_filename(const std::string &filename) noexcept;
+
 #endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -397,6 +397,7 @@ void DOSBOX_Init(void) {
 
 	constexpr auto always = Property::Changeable::Always;
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
+	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
 
 	SDLNetInited = false;
 
@@ -443,6 +444,18 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&PROGRAMS_Init);
 	secprop->AddInitFunction(&TIMER_Init);//done
 	secprop->AddInitFunction(&CMOS_Init);//done
+
+	const char *verbosity_choices[] = {"high",   "medium", "low",
+	                                   "quiet", "auto",   0};
+	Pstring = secprop->Add_string("startup_verbosity", only_at_start, "high");
+	Pstring->Set_values(verbosity_choices);
+	Pstring->Set_help("Controls verbosity prior to displaying the program:\n"
+	"       | Show splash | Show welcome | Show early stdout\n"
+	"high   |     yes     |     yes      |       yes\n"
+	"medium |     no      |     yes      |       yes\n"
+	"low    |     no      |     no       |       yes\n"
+	"quiet  |     no      |     no       |       no\n"
+	"auto   | 'low' if exec or dir is passed, otherwise 'high'");
 
 	secprop=control->AddSection_prop("render",&RENDER_Init,true);
 	Pint = secprop->Add_int("frameskip",Property::Changeable::Always,0);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2229,7 +2229,8 @@ static void GUI_StartUp(Section * sec) {
 
 	const bool tiny_fullresolution = splash_image.width > sdl.desktop.full.width ||
 	                                 splash_image.height > sdl.desktop.full.height;
-	if (!(sdl.desktop.fullscreen && tiny_fullresolution)) {
+	if (control->GetStartupVerbosity() == Verbosity::High &&
+	    !(sdl.desktop.fullscreen && tiny_fullresolution)) {
 		GFX_Start();
 		DisplaySplash(1000);
 		GFX_Stop();

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1024,6 +1024,15 @@ bool CommandLine::FindCommand(unsigned int which,std::string & value) {
 	return true;
 }
 
+// Was a directory provided on the command line?
+bool CommandLine::HasDirectory() const
+{
+	for (const auto& arg : cmds)
+		if (open_directory(arg.c_str()))
+			return true;
+	return false;
+}
+
 // Was an executable filename provided on the command line?
 bool CommandLine::HasExecutableName() const
 {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -981,6 +981,27 @@ void Config::StartUp()
 	(*_start_function)();
 }
 
+Verbosity Config::GetStartupVerbosity() const
+{
+	const Section* s = GetSection("dosbox");
+	assert(s);
+	const std::string user_choice = s->GetPropValue("startup_verbosity");
+
+	if (user_choice == "high")
+		return Verbosity::High;
+	if (user_choice == "medium")
+		return Verbosity::Medium;
+	if (user_choice == "low")
+		return Verbosity::Low;
+	if (user_choice == "quiet")
+		return Verbosity::Quiet;
+	// auto-mode
+	if (cmdline->HasDirectory() || cmdline->HasExecutableName())
+		return Verbosity::Low;
+	else
+		return Verbosity::High;
+}
+
 bool CommandLine::FindExist(char const * const name,bool remove) {
 	cmd_it it;
 	if (!(FindEntry(name,it,false))) return false;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1024,6 +1024,15 @@ bool CommandLine::FindCommand(unsigned int which,std::string & value) {
 	return true;
 }
 
+// Was an executable filename provided on the command line?
+bool CommandLine::HasExecutableName() const
+{
+	for (const auto& arg : cmds)
+		if (is_executable_filename(arg))
+			return true;
+	return false;
+}
+
 bool CommandLine::FindEntry(char const * const name,cmd_it & it,bool neednext) {
 	for (it = cmds.begin(); it != cmds.end(); ++it) {
 		if (!strcasecmp((*it).c_str(),name)) {

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -80,6 +80,18 @@ bool ends_with(const std::string &suffix, const std::string &str) noexcept
 	return std::equal(sfx, sfx + n, txt, txt + n);
 }
 
+bool is_executable_filename(const std::string &filename) noexcept
+{
+	const size_t n = filename.length();
+	if (n < 4)
+		return false;
+	if (filename[n - 4] != '.')
+		return false;
+	std::string sfx = filename.substr(n - 3);
+	lowcase(sfx);
+	return (sfx == "exe" || sfx == "bat" || sfx == "com");
+}
+
 void trim(std::string &str)
 {
 	constexpr char whitespace[] = " \r\t\f\n";

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -340,17 +340,23 @@ void DOS_Shell::Run(void) {
 	}
 	/* Start a normal shell and check for a first command init */
 	if (cmd->FindString("/INIT",line,true)) {
-		WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"),VERSION);
+		const bool wants_welcome_banner = control->GetStartupVerbosity() >=
+		                                  Verbosity::Medium;
+		if (wants_welcome_banner) {
+			WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"), VERSION);
 #if C_DEBUG
-		WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"));
+			WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"));
 #endif
-		if (machine == MCH_CGA) {
-			if (mono_cga) WriteOut(MSG_Get("SHELL_STARTUP_CGA_MONO"));
-			else WriteOut(MSG_Get("SHELL_STARTUP_CGA"));
+			if (machine == MCH_CGA) {
+				if (mono_cga)
+					WriteOut(MSG_Get("SHELL_STARTUP_CGA_MONO"));
+				else
+					WriteOut(MSG_Get("SHELL_STARTUP_CGA"));
+			}
+			if (machine == MCH_HERC)
+				WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
+			WriteOut(MSG_Get("SHELL_STARTUP_END"));
 		}
-		if (machine == MCH_HERC) WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
-		WriteOut(MSG_Get("SHELL_STARTUP_END"));
-
 		safe_strcpy(input_line, line.c_str());
 		line.erase();
 		ParseLine(input_line);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -784,10 +784,7 @@ void DOS_Shell::CMD_LS(char *args)
 			WriteOut("\033[34;1m%-15s\033[0m", name.c_str());
 		} else {
 			lowcase(name);
-			const bool is_executable = ends_with(".exe", name) ||
-			                           ends_with(".bat", name) ||
-			                           ends_with(".com", name);
-			if (is_executable)
+			if (is_executable_filename(name))
 				WriteOut("\033[32;1m%-15s\033[0m", name.c_str());
 			else
 				WriteOut("%-15s", name.c_str());

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -293,14 +293,13 @@ void DOS_Shell::InputCommand(char * line) {
 						dta.GetResult(name,sz,date,time,att);
 						// add result to completion list
 
-						char *ext;	// file extension
 						if (strcmp(name, ".") && strcmp(name, "..")) {
 							if (dir_only) { //Handle the dir only case different (line starts with cd)
 								if(att & DOS_ATTR_DIRECTORY) l_completion.push_back(name);
 							} else {
-								ext = strrchr(name, '.');
-								if (ext && (strcmp(ext, ".BAT") == 0 || strcmp(ext, ".COM") == 0 || strcmp(ext, ".EXE") == 0))
-									// we add executables to the a seperate list and place that list infront of the normal files
+							        if (is_executable_filename(name))
+								        // Prepend executables to a separate list
+								        // and place that list ahead of normal files.
 									executable.push_front(name);
 								else
 									l_completion.push_back(name);


### PR DESCRIPTION
This is a rework of the prior instant launch PR, which was somewhat narrow in its focus.

This PR transforms that into the general concept of **Startup Verbosity**. 

| Level | Show Splash Window | Show Welcome Banner | Show pre-executable stdout |  Program Display |
| :---: | :---: | :---: | :---: | :---: |
| High | yes | yes | yes | yes |
| Medium | no | yes | yes | yes |
| Low | no | no | yes | yes |
| Silent | no | no | no | yes |

Graphically, this corresponds to:

| Level | Show Splash Window | Show Welcome Banner | Show pre-executable stdout |  Program Display |
| :---: | :---: | :---: | :---: | :---: |
| High | ![2020-07-01_21-06](https://user-images.githubusercontent.com/1557255/86315555-3fc1fb80-bbdf-11ea-8e8d-b58518eed405.png) | ![2020-07-01_21-07](https://user-images.githubusercontent.com/1557255/86315556-405a9200-bbdf-11ea-803e-5889b165dcfd.png) | ![2020-07-01_21-18](https://user-images.githubusercontent.com/1557255/86316012-8ebc6080-bbe0-11ea-946e-7fd17755a0ce.png) |  ![2020-07-01_21-08](https://user-images.githubusercontent.com/1557255/86315559-40f32880-bbdf-11ea-9623-7eededf7e073.png) |
| Medium | no | ![2020-07-01_21-07](https://user-images.githubusercontent.com/1557255/86315556-405a9200-bbdf-11ea-803e-5889b165dcfd.png)  | ![2020-07-01_21-18](https://user-images.githubusercontent.com/1557255/86316012-8ebc6080-bbe0-11ea-946e-7fd17755a0ce.png) | ![2020-07-01_21-08](https://user-images.githubusercontent.com/1557255/86315559-40f32880-bbdf-11ea-9623-7eededf7e073.png) |
| Low | no | no | ![2020-07-01_21-18](https://user-images.githubusercontent.com/1557255/86316012-8ebc6080-bbe0-11ea-946e-7fd17755a0ce.png) | ![2020-07-01_21-08](https://user-images.githubusercontent.com/1557255/86315559-40f32880-bbdf-11ea-9623-7eededf7e073.png) |
| Silent | no | no | no | ![2020-07-01_21-08](https://user-images.githubusercontent.com/1557255/86315559-40f32880-bbdf-11ea-9623-7eededf7e073.png) |

#### 'high' startup verbosity is default

This guarantees the existing verbose behavior is retained for new users, while allowing experienced users to dial back the verbosity if they wish. 

#### 'auto' startup verbosity is available

**auto** is also available, which is equivalent to "high" if dosbox was not passed an executable, and "low" if it was.

#### What is pre-executable stdout?

This is non-executable stdout constructed by dosbox prior to launching an executable or batch-file.

For example, even when you give dosbox a straight executable to launch, ie: `dosbox duke1/dn1.exe`, it still generates the following stdout which requires setting a graphical text mode window:

![2020-07-01_21-18](https://user-images.githubusercontent.com/1557255/86316012-8ebc6080-bbe0-11ea-946e-7fd17755a0ce.png)

If verbosity is set to silent, then this output suppressed prior to the first executable.

#### How are batch files handled with 'silent'  startup verbosity?

Any output generate by a batch file will be shown.

As described above, dosbox's stdout is suppressed prior to the first executable statement, after which stdout is re-enabled.  Batch files are executable, so it's up to the batch file if it generates output (or not). 

To make batch execution silent, ensure the first line in the batch file is: `@echo off`, which instructs DOS not to print each line in the file. 

Inside a batch file, you can similarly hide a programs text output by redirecting it's output, for example: `noisy\game.exe > NUL`, which silences its text output.

**dosbox.conf**

![2020-07-01_21-23](https://user-images.githubusercontent.com/1557255/86316323-4ea9ad80-bbe1-11ea-82a3-f06b9bed51bf.png)
