### PR TITLE
Add 64-bit release Windows builds to CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,19 +11,17 @@ jobs:
       matrix:
         conf:
           - name: MSVC 32-bit
-            vs-platform: x86
-            vcpkg-triplet: x86-windows
+            arch: x86
             max_warnings: 343
           - name: MSVC 64-bit
-            vs-platform: x64
-            vcpkg-triplet: x64-windows
+            arch: x64
             max_warnings: 2208
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages
         shell: pwsh
         run: |
-          vcpkg install --triplet ${{ matrix.conf.vcpkg-triplet }} libpng sdl2 sdl2-net opusfile
+          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net opusfile
           vcpkg integrate install
       - name:  Log environment
         shell: pwsh
@@ -34,7 +32,7 @@ jobs:
           PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd vs
-          MSBuild -m dosbox.sln -p:Configuration=Debug -p:Platform=${{ matrix.conf.vs-platform }} | Tee-Object build.log
+          MSBuild -m dosbox.sln -p:Configuration=Debug -p:Platform=${{ matrix.conf.arch }} | Tee-Object build.log
       - name:  Summarize warnings
         shell: pwsh
         env:
@@ -50,19 +48,17 @@ jobs:
       matrix:
         conf:
           - name: Release build (32-bit)
-            vcpkg-triplet: x86-windows
-            vs-platform: x86
+            arch: x86
             vs-release-dirname: Win32
           - name: Release build (64-bit)
-            vcpkg-triplet: x64-windows
-            vs-platform: x64
+            arch: x64
             vs-release-dirname: x64
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages
         shell: pwsh
         run: |
-          vcpkg install --triplet ${{ matrix.conf.vcpkg-triplet }} libpng sdl2 sdl2-net opusfile
+          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net opusfile
           vcpkg integrate install
       - name:  Log environment
         shell: pwsh
@@ -81,7 +77,7 @@ jobs:
           PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd vs
-          MSBuild -m dosbox.sln -p:Configuration=Release -p:Platform=${{ matrix.conf.vs-platform }}
+          MSBuild -m dosbox.sln -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
       - name:  Package
         shell: bash
         run: |
@@ -109,13 +105,13 @@ jobs:
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
 
           # Create dir for zipping
-          mv dest dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}
+          mv dest dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
 
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}"
+          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}"
           & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
           if( $LASTEXITCODE -ne 0 ) {
               Get-Content -Path $env:TEMP\MpCmdRun.log
@@ -125,5 +121,5 @@ jobs:
       - name: Upload package
         uses: actions/upload-artifact@master
         with:
-          name: dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}
-          path: dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}
+          name: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          path: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,15 +43,26 @@ jobs:
 
 
   build_windows_vs_release:
-    name: Release build (32-bit)
+    name: ${{ matrix.conf.name }}
     runs-on: windows-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    strategy:
+      matrix:
+        conf:
+          - name: Release build (32-bit)
+            vcpkg-triplet: x86-windows
+            vs-platform: x86
+            vs-release-dirname: Win32
+          - name: Release build (64-bit)
+            vcpkg-triplet: x64-windows
+            vs-platform: x64
+            vs-release-dirname: x64
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages
         shell: pwsh
         run: |
-          vcpkg install libpng sdl2 sdl2-net opusfile
+          vcpkg install --triplet ${{ matrix.conf.vcpkg-triplet }} libpng sdl2 sdl2-net opusfile
           vcpkg integrate install
       - name:  Log environment
         shell: pwsh
@@ -70,37 +81,41 @@ jobs:
           PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd vs
-          MSBuild -m dosbox.sln -p:Configuration=Release -p:Platform=x86
+          MSBuild -m dosbox.sln -p:Configuration=Release -p:Platform=${{ matrix.conf.vs-platform }}
       - name:  Package
         shell: bash
         run: |
           set -x
+
           # Prepare content
+          readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
           mkdir -p dest/doc
-          cp vs/Win32/Release/dosbox.exe           dest/
-          cp COPYING                               dest/COPYING.txt
-          cp docs/README.template                  dest/README.txt
-          cp docs/README.video                     dest/doc/video.txt
-          cp README                                dest/doc/manual.txt
-          cp vs/Win32/Release/libpng16.dll         dest/
-          cp vs/Win32/Release/ogg.dll              dest/
-          cp vs/Win32/Release/opus.dll             dest/
-          cp vs/Win32/Release/SDL2.dll             dest/
-          cp vs/Win32/Release/SDL2_net.dll         dest/
-          cp src/libs/zmbv/Win32/Release/zlib1.dll dest/
-          cp src/libs/zmbv/Win32/Release/zmbv.dll  dest/
+          cp vs/$RELEASE_DIR/dosbox.exe           dest/
+          cp COPYING                              dest/COPYING.txt
+          cp docs/README.template                 dest/README.txt
+          cp docs/README.video                    dest/doc/video.txt
+          cp README                               dest/doc/manual.txt
+          cp vs/$RELEASE_DIR/libpng16.dll         dest/
+          cp vs/$RELEASE_DIR/ogg.dll              dest/
+          cp vs/$RELEASE_DIR/opus.dll             dest/
+          cp vs/$RELEASE_DIR/SDL2.dll             dest/
+          cp vs/$RELEASE_DIR/SDL2_net.dll         dest/
+          cp src/libs/zmbv/$RELEASE_DIR/zlib1.dll dest/
+          cp src/libs/zmbv/$RELEASE_DIR/zmbv.dll  dest/
+
           # Fill README template file
           sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README.txt
           sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README.txt
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
+
           # Create dir for zipping
-          mv dest dosbox-staging-windows-x86-${{ env.VERSION }}
+          mv dest dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}
 
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-x86-${{ env.VERSION }}"
+          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}"
           & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
           if( $LASTEXITCODE -ne 0 ) {
               Get-Content -Path $env:TEMP\MpCmdRun.log
@@ -110,5 +125,5 @@ jobs:
       - name: Upload package
         uses: actions/upload-artifact@master
         with:
-          name: dosbox-staging-windows-x86-${{ env.VERSION }}
-          path: dosbox-staging-windows-x86-${{ env.VERSION }}
+          name: dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}
+          path: dosbox-staging-windows-${{ matrix.conf.vs-platform }}-${{ env.VERSION }}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ packages installed via your package manager.
 
 ### [Windows]
 
+Our Windows snapshots include both 32-bit (x86) and 64-bit (x64) builds.
+
 A dosbox.exe file in a snapshot package is not signed, therefore Windows 10
 might prevent the program from starting.
 
@@ -114,8 +116,6 @@ unrecognised app from starting", you have two options to dismiss it:
 
 1) Click "More info", and button "Run anyway" will appear.
 2) Right-click on dosbox.exe, select: Properties → General → Security → Unblock
-
-Windows packages are built for "x86" architecture (in practice it means i686).
 
 ### [macOS]
 


### PR DESCRIPTION
Our debug builds are a little bit tested now and generally do not cause any surprising issues.

I don't have access to Windows 10 at the moment; tested using wine-staging 5.10 on Fedora 32. 32-bit bulds and 64-bit builds behave exactly the same as far as I can tell.

This change will be backported to 0.75.x branch so we could provide 64-bit builds for 0.75.1 release.