### PR TITLE
PC-Speaker [1/4] Always use negative amplitude for PIT-OFF requests

### DIFF
--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -258,7 +258,7 @@ void PCSPEAKER_SetType(Bitu mode)
 		break;
 	case 1:
 		spkr.mode=SPKR_PIT_OFF;
-		AddDelayEntry(newindex, NeutralLastPitOr(SPKR_NEGATIVE_VOLTAGE));
+		AddDelayEntry(newindex, NeutralOr(SPKR_NEGATIVE_VOLTAGE));
 		break;
 	case 2:
 		spkr.mode=SPKR_ON;


### PR DESCRIPTION
This change no longer allows the "PIT OFF" request to potentially start with the prior PIT value and instead always uses negative amplitude.

Fix 1 of 4 for issue #433, addressing _"The engine noise that plays during a race just sounds like intermittent pops and static in dosbox-staging."_, as reported by @BPaden -- thank you!

Regression tests: https://github.com/dosbox-staging/dosbox-staging/issues/464#issuecomment-651904100