### PR TITLE
PC-Speaker [2/4] Silence DC offset using inaudible sine curves instead of a ramp

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <cassert>
-#define _USE_MATH_DEFINES // M_PI under MSVC
 #include <cmath>
 #include <cstdio>
 #include <ctype.h>

--- a/include/support.h
+++ b/include/support.h
@@ -24,10 +24,11 @@
 #include <algorithm>
 #include <cassert>
 #define _USE_MATH_DEFINES // M_PI under MSVC
-#include <math.h>
+#include <cmath>
 #include <cstdio>
 #include <ctype.h>
 #include <limits>
+#include <math.h>
 #include <stdexcept>
 #include <string.h>
 #include <string>

--- a/include/support.h
+++ b/include/support.h
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #define _USE_MATH_DEFINES // M_PI under MSVC
-#include <cmath>
+#include <math.h>
 #include <cstdio>
 #include <ctype.h>
 #include <limits>

--- a/include/support.h
+++ b/include/support.h
@@ -160,4 +160,35 @@ bool ends_with(const std::string &suffix, const std::string &str) noexcept;
 
 bool is_executable_filename(const std::string &filename) noexcept;
 
+// Coarse but fast sine and cosine approximations. Accuracy ranges from 0.0005
+// to 0.098 and speed ranges from ~3 to 5x faster than floats with cosf/sinf and
+// ~10x faster than doubles with sin/cos.
+
+// Only consider using these if the benefit of adding sine and cosine even with
+// the reduced accuracy outweighs the loss of using an outright inferior
+// technique. For example, fitting a curve using sine and cosine versus no
+// curve-fitting using linear-only interpolation.
+constexpr float coarse_sin(float x)
+{
+	constexpr int fact_3 = 1 * 2 * 3;
+	constexpr int fact_5 = fact_3 * 4 * 5;
+	constexpr int fact_7 = fact_5 * 6 * 7;
+
+	const float x_pow_2 = x * x;
+	const float x_pow_3 = x_pow_2 * x;
+	const float x_pow_5 = x_pow_3 * x_pow_2;
+	const float x_pow_7 = x_pow_5 * x_pow_2;
+
+	const float taylor_1 = x - (x_pow_3 / fact_3);
+	const float taylor_2 = taylor_1 + (x_pow_5 / fact_5);
+	const float taylor_3 = taylor_2 - (x_pow_7 / fact_7);
+
+	return taylor_3;
+}
+
+constexpr float coarse_cos(float x)
+{
+	constexpr auto half_pi = static_cast<float>(M_PI_2);
+	return coarse_sin(x + half_pi);
+}
 #endif

--- a/include/support.h
+++ b/include/support.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cassert>
+#define _USE_MATH_DEFINES // M_PI under MSVC
 #include <cmath>
 #include <cstdio>
 #include <ctype.h>

--- a/src/hardware/Makefile.am
+++ b/src/hardware/Makefile.am
@@ -17,6 +17,7 @@ libhardware_a_SOURCES = \
 	adlib.cpp \
 	cmos.cpp \
 	dbopl.cpp \
+	dc_silencer.cpp \
 	disney.cpp \
 	dma.cpp \
 	envelope.cpp \

--- a/src/hardware/dc_silencer.cpp
+++ b/src/hardware/dc_silencer.cpp
@@ -1,0 +1,75 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *  Copyright (c) 2019-2020  Kevin R Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "dc_silencer.h"
+#include "support.h"
+
+void DCSilencer::Configure(const uint32_t sequence_hz,
+                           const uint8_t silent_waves,
+                           const uint8_t silent_wave_hz)
+{
+	// N curves + a quarter-radian split into 20ms (50-Hz) worth of samples
+	assertm(silent_waves >= 2u,
+	        "The number of silencing waves should be at least two");
+	assertm(silent_wave_hz >= 20u && silent_wave_hz <= 60u,
+	        "The silent wave should be inaudible: between 20 Hz and 60 Hz");
+	assertm(sequence_hz > silent_wave_hz,
+	        "If the sequence is silent too, then you don't need the "
+	        "silencer");
+
+	// Add 90-degrees (1/4th-rad) to get from the DC-offset down to zero
+	const float waves = 0.25f + silent_waves;
+
+	// How many sample points exist to generate our waves
+	constexpr auto pi_f = static_cast<float>(M_PI);
+	const float steps = waves * sequence_hz / silent_wave_hz;
+	rad_dt = waves * 2 * pi_f / steps; // delta radian increment per step
+	vol_dt = 1 / steps; // delta volume decrement per step
+	// DEBUG_LOG_MSG("SILENCER: Using %u waves at %u-Hz across %.0f samples",
+	//               silent_waves, silent_wave_hz, steps);
+	Reset();
+}
+
+bool DCSilencer::Generate(const int16_t dc_offset, const size_t samples, int16_t *buffer)
+{
+	assertm(rad_dt > 0 && vol_dt > 0, "Configure the silencer first");
+	uint16_t i = 0;
+	while (vol_pos > 0 && i < samples) {
+		vol_pos -= vol_dt; // keep turning down the volume ..
+		rad_pos += rad_dt; // keep walking around our circle ..
+		const float sample = dc_offset * coarse_cos(rad_pos) * vol_pos;
+		buffer[i++] = static_cast<int16_t>(sample);
+	}
+	// only consider the job done when we haven't generated any samples.
+	const bool still_generating = i > 0;
+
+	// When the waves are done, fill any reamainder with silence.
+	while (i < samples)
+		buffer[i++] = 0;
+
+	return still_generating;
+}
+
+void DCSilencer::Reset()
+{
+	rad_pos = 0;
+	vol_pos = 1;
+}

--- a/src/hardware/dc_silencer.h
+++ b/src/hardware/dc_silencer.h
@@ -1,0 +1,84 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *  Copyright (c) 2020-2020  Kevin R Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_DC_SILENCER_H
+#define DOSBOX_DC_SILENCER_H
+
+/*
+DC Silencer
+-----------
+From a given DC-offset value, this class generates a fading cosine wave at an
+inaudible frequency, which is suitable for eliminating a DC-offset within
+the low 100s of milliseconds, versus "stepping" the DC-offset inward, which
+produces and audible soft  zippering sound effect, unless carried out over
+several seconds.
+
+The number of waves and their frequency are configurable.
+
+If audio audio equipment were perfect, we could assume only one wave would be
+needed to take down a full DC-offset, and terminate perfectly at the centerline.
+However in practice the speaker diaphragm oscillates across the centerline and
+is dampened by the suspension material.  The literature: Langford, S. 2014.
+Digital Audio Editing. Burlington: Focal Press. pp. 47-57 mentions fade-outs can
+be performed in 500ms.  Assume we use 33 Hz inaudible waves, 500ms would require
+roughly 15 waves.
+
+Use
+---
+1. Configure() the silencer with the sample rate of the stream in need of
+   DC-fixing, the number of full silencing waves to perform, and the frequency
+   to use for those waves.  Nominal values might be 44100 Hz for the audio
+   stream, 15 silencing waves, at 33 Hz.
+
+2. Generate() when your stream in need of DC-offset correction. Pass it the
+   current DC-offset value, and the number of samples to generate into the
+   buffer.  Note that it's typically for generation to be performed over
+   many calls.  The silencer keeps track of where it is in generating waves,
+   and once done will fill the stream with silence.
+
+   It returns true while still winding down the offset, and false once the
+   signal's been populated with one full generate-round of zeros.
+
+3. Reset() when you want to prepare the silencer for another round of
+   silencing.  The silencer is reset as part of the configuration
+   step (because the paramaters of the waves is changes and mixing new
+   paramater with old setting can result in discontinuities).
+
+*/
+
+#include <cstdint>
+#include "support.h"
+
+class DCSilencer {
+public:
+	DCSilencer() = default;
+	void Configure(uint32_t sequence_hz, uint8_t full_waves, uint8_t wave_hz);
+	bool Generate(int16_t dc_offset, size_t samples, int16_t *buffer);
+	void Reset();
+
+private:
+	float rad_dt = 0.0f; // The delta radians added every sample
+	float rad_pos = 0.0f; // The current position along our waves (in radians)
+	float vol_dt = 0.0f;  // The delta volume decremented every sample
+	float vol_pos = 0.0f; // The current volume level (as a fraction of 1)
+};
+
+#endif

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -16,12 +16,14 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "support.h"
 
 #include <algorithm>
 #include <assert.h>
 #include <cctype>
-#include <ctype.h>
+#include <cmath>
 #include <cstring>
+#include <ctype.h>
 #include <functional>
 #include <stdarg.h>
 #include <stdio.h>
@@ -32,7 +34,6 @@
 #include "dosbox.h"
 #include "cross.h"
 #include "debug.h"
-#include "support.h"
 #include "video.h"
 
 std::string get_basename(const std::string& filename) {
@@ -240,3 +241,5 @@ void E_Exit(const char * format,...) {
 
 	throw(buf);
 }
+
+

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -283,6 +283,7 @@
     <ClCompile Include="..\src\gui\sdl_mapper.cpp" />
     <ClCompile Include="..\src\hardware\adlib.cpp" />
     <ClCompile Include="..\src\hardware\cmos.cpp" />
+    <ClCompile Include="..\src\hardware\dc_silencer.cpp" />
     <ClCompile Include="..\src\hardware\dbopl.cpp" />
     <ClCompile Include="..\src\hardware\disney.cpp" />
     <ClCompile Include="..\src\hardware\dma.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="..\src\hardware\cmos.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\dc_silencer.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\dbopl.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>


### PR DESCRIPTION
This PR uses inaudible sine curves to eliminate DC offset left by a PC-Speaker sample.

**[click to open fullscreen]** (:exclamation: correction: green text should say _"inaudible"_ :-))
![2020-07-03_07-45](https://user-images.githubusercontent.com/1557255/86479523-2fa23d00-bd01-11ea-8bd1-278b6f0bd801.png)

Eliminating DC offset is important in dosbox because it can 1) cause a pop when (eventually) the next sample played has a value "away" from the offset's value 2) harm accurate sound reproduction of other sound devices' audio streams by simultaneously pulling (or pushing) half the samples  either further away from the center line (becoming louder) and the other half of the samples closer to the center line (becoming quieter).

Fix 2 of 4 for issue #433, addressing _"I still hear a slight popping sound behind the engine sounds."_, as reported by @BPaden -- thank you!

Regression tests: https://github.com/dosbox-staging/dosbox-staging/issues/464#issuecomment-651904100