### PR TITLE
PC-Speaker [3/4] Differentiate and adjust pulse-wave and square-wave volumes on-the-fly

### DIFF
--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -61,6 +61,7 @@ static struct {
 	float volcur = 0.0f;
 	float last_index = 0.0f;
 	int16_t last_played_sample = 0;
+	uint16_t prev_pos = 0u;
 	uint8_t idle_countdown = 0u;
 } spkr;
 
@@ -364,6 +365,7 @@ static void PCSPEAKER_CallBack(Bitu len)
 				}
 			}
 		}
+		spkr.prev_pos = pos;
 		*stream++=(Bit16s)(value/sample_add);
 	}
 	PlayOrFadeout(pos, len, reinterpret_cast<int16_t *>(MixTemp));


### PR DESCRIPTION
PC-Speaker audio comes in two forms: PWM or "approximated curves" generated by manipulating the timer, and pure square waves.

dosbox's PC-Speaker has a single amplitude range to work within, and thus the amplitude used for both curves is the same. Unfortunately for users, square waves carry significantly more power than the approximated curves resulting in powerful "beeps and boops" compared to relatively quiet sounding PWM  "music and voice", such as RealAudio.

This PR adds a simple state-machine that inspects the current and previous speaker modes and amplitudes to determine if an inbound amplitude should be given the full PWM amplitude or attenuated if it's part of a square wave.

Fix 3 of 4 for issue #433, addressing _"I do appreciate any attempt to prevent dos games from blowing out my eardrums."_, as reported by @BPaden -- thank you!

Follow up listening tests after this PR by @BPaden: _"The countdown timer and engine noise seemed noticeably less obnoxious on the ears."_, and _"The volume adjustments are definitely a clear improvement."_

Regression tests: https://github.com/dosbox-staging/dosbox-staging/issues/464#issuecomment-651904100