### PR TITLE
PC-Speaker [4/4] Adjust the default pcrate for authentic game accuracy

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -388,6 +388,7 @@ static void DOSBOX_RealInit(Section * sec) {
 void DOSBOX_Init(void) {
 	Section_prop * secprop;
 	Prop_int* Pint;
+	Prop_int *pint = nullptr;
 	Prop_hex* Phex;
 	Prop_string* Pstring; // use pstring when touching properties
 	Prop_string *pstring;
@@ -705,9 +706,20 @@ void DOSBOX_Init(void) {
 	Pbool = secprop->Add_bool("pcspeaker",Property::Changeable::WhenIdle,true);
 	Pbool->Set_help("Enable PC-Speaker emulation.");
 
-	Pint = secprop->Add_int("pcrate",Property::Changeable::WhenIdle,44100);
-	Pint->Set_values(rates);
-	Pint->Set_help("Sample rate of the PC-Speaker sound generation.");
+	// Basis for the default PC-Speaker sample generation rate:
+	//   "With the PC speaker, typically a 6-bit DAC with a maximum value of
+	//   63
+	//    is used at a sample rate of 18,939.4 Hz."
+	// PC Speaker. (2020, June 8). In Wikipedia. Retrieved from
+	// https://en.wikipedia.org/w/index.php?title=PC_speaker&oldid=961464485
+	//
+	// As this is the frequency range that game authors in the 1980s would
+	// have worked with when tuning their game audio, we therefore use this
+	// same value given it's the most likely to produce audio as intended by
+	// the authors.
+	pint = secprop->Add_int("pcrate", when_idle, 18939);
+	pint->SetMinMax(8000, 48000);
+	pint->Set_help("Sample rate of the PC-Speaker sound generation.");
 
 	secprop->AddInitFunction(&TANDYSOUND_Init,true);//done
 	const char* tandys[] = { "auto", "on", "off", 0};


### PR DESCRIPTION
The internal speaker and PC clock timer in circa '80s and early '90s generated an output sample rate of 18,939.4 Hz. 

Reference: PC Speaker (2020, June 8). In Wikipedia. Retrieved from https://en.wikipedia.org/w/index.php?title=PC_speaker&oldid=961464485

The benefit of using this lower, realistic rate is that it acts as a low-pass-filter to eliminate higher-order harmonics and aliasing effect causes by square-wave and PWM wave approximations:

**Before: dosbox current 44100 Hz default** [:speaker: Original/SVN @ 44.1KHz ](https://drive.google.com/file/d/1ZQeScipdLnZrq7kXbw4zOhZBfnpNSQJi/view?usp=sharing)
Square edges produce artificial high frequencies.
![2020-07-03_08-04](https://user-images.githubusercontent.com/1557255/86482605-24521000-bd07-11ea-8982-4f0b29c9e4f8.png)

**After: new PR 18939 Hz default** [:speaker: Staging @  18.9 KHz ](https://drive.google.com/file/d/1VHvzIWLgY036vjz_FJX7u9wvavY8PMVO/view?usp=sharing)
Lesser-squared edges producer fewer artifacts and a smoother curve approximation.
![2020-07-03_08-05](https://user-images.githubusercontent.com/1557255/86482879-ad694700-bd07-11ea-9a40-efb785abef76.png)

This realistic rate produces a frequency range that game authors in the 1980s would have worked with when tuning their game audio. Therefore, it's the most likely to produce audio as intended by the authors.

(The previous permitted pcrate values from 8 KHz to 48 KHz are still available, and now includes any value in between. This flexibility lets the user adjust the rate slightly to eliminate harmonics, if needed).

Fix 4 of 4 for issue #433, addressing why the audio sounds notably different between recordings, as reported by @BPaden -- thank you!