### PR TITLE
Use action upload-artifact@v2 and upload changelog as a build artifact

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Analyze
         run:  analyze-build -v -o report --html-title="dosbox-staging (${GITHUB_SHA:0:8})"
       - name: Upload report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: clang-analysis-report
           path: report
@@ -138,7 +138,7 @@ jobs:
             $VERSION_${{ matrix.conf.name }} \
             ${{ matrix.conf.sanitizers }}
       - name: Upload logs
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.conf.name }}-sanitizer-logs
           path: ${{ matrix.conf.name }}-logs

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -167,7 +167,7 @@ jobs:
           sudo freshclam --quiet && sudo freshclam
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
       - name: Upload tarball
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         # GitHub automatically zips the artifacts (there's no way to create
         # a tarball), and it removes all executable flags while zipping.
         # Letting it zip a tarball preserves flags in the compressed files.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,6 +166,7 @@ jobs:
           sudo systemctl stop clamav-freshclam
           sudo freshclam --quiet && sudo freshclam
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
+
       - name: Upload tarball
         uses: actions/upload-artifact@v2
         # GitHub automatically zips the artifacts (there's no way to create
@@ -174,3 +175,26 @@ jobs:
         with:
           name: dosbox-staging-linux-x86_64
           path: dosbox-staging-linux-${{ env.VERSION }}.tar.xz
+
+
+  publish_additional_artifacts:
+    name: Publish additional artifacts
+    needs: build_linux_release_dynamic
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate changelog
+        run: |
+          set +x
+          git fetch --unshallow
+          VERSION=$(git describe --abbrev=4)
+          echo ::set-env name=VERSION::$VERSION
+          NEWEST_TAG=$(git describe --abbrev=0)
+          git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          # Keep exactly this artifact name; it's being used to propagate
+          # version info via GitHub REST API
+          name: changelog-${{ env.VERSION }}.txt
+          path: changelog-${{ env.VERSION }}.txt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -152,7 +152,7 @@ jobs:
           freshclam --quiet && freshclam
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
       - name: Upload disk image
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         # GitHub automatically zips the artifacts, and there's no option
         # to skip it or upload a file only.
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -151,6 +151,7 @@ jobs:
           sed -ie 's/^Example/#Example/g' "$clamconf"
           freshclam --quiet && freshclam
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
+
       - name: Upload disk image
         uses: actions/upload-artifact@v2
         # GitHub automatically zips the artifacts, and there's no option
@@ -158,3 +159,26 @@ jobs:
         with:
           name: dosbox-staging-macOS-x86_64
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
+
+
+  publish_additional_artifacts:
+    name: Publish additional artifacts
+    needs: build_macos_release
+    runs-on: macos-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate changelog
+        run: |
+          set +x
+          git fetch --unshallow
+          VERSION=$(git describe --abbrev=4)
+          echo ::set-env name=VERSION::$VERSION
+          NEWEST_TAG=$(git describe --abbrev=0)
+          git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          # Keep exactly this artifact name; it's being used to propagate
+          # version info via GitHub REST API
+          name: changelog-${{ env.VERSION }}.txt
+          path: changelog-${{ env.VERSION }}.txt

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload tarball
         if: steps.repo-meta.outputs.has-commits == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         # GitHub automatically zips the artifacts (there's no way to create
         # a tarball), and it removes all executable flags while zipping.
         # Letting it zip a tarball preserves flags in the compressed files.

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -62,7 +62,7 @@ jobs:
           pvs-studio-analyzer suppress -a "${general_criteria}" \
           -o "${reportdir}/general/supressible-list.json" "${log}"
       - name: Upload report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: pvs-analysis-report
           path: pvs-report

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,3 +123,27 @@ jobs:
         with:
           name: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
           path: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
+
+
+  publish_additional_artifacts:
+    name: Publish additional artifacts
+    needs: build_windows_vs_release
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate changelog
+        shell: bash
+        run: |
+          set +x
+          git fetch --unshallow
+          VERSION=$(git describe --abbrev=4)
+          echo ::set-env name=VERSION::$VERSION
+          NEWEST_TAG=$(git describe --abbrev=0)
+          git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          # Keep exactly this artifact name; it's being used to propagate
+          # version info via GitHub REST API
+          name: changelog-${{ env.VERSION }}.txt
+          path: changelog-${{ env.VERSION }}.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -119,7 +119,7 @@ jobs:
           }
 
       - name: Upload package
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
           path: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}


### PR DESCRIPTION
See details in the first commit message for assessment why we still can't use features stabilized in upload-artifact@v2 ; we'll need to wait for GitHub to fix UI to avoid the zip files.

For reference, see: https://github.com/actions/upload-artifact/issues/41

The second commit introduces uploading of automatically-generated changelog as our build artifact (the text file is still zipped, and we can't work around it). But the content of the text file does not really matter - real motivation for this change is to provide a build artifact, that includes `git describe` information in the name; this way we can use GitHub REST API to propagate information about builds. This is being used in https://github.com/dosbox-staging/dosbox-staging.github.io/pull/4 to present version info next to download links.