### PR TITLE
[GUS Enh 3/x] Retain the fractional interwave-portion of GUS samples

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -159,4 +159,13 @@ bool ends_with(const std::string &suffix, const std::string &str) noexcept;
 
 bool is_executable_filename(const std::string &filename) noexcept;
 
+template <typename FromT, typename ToT, typename AsT>
+constexpr AsT scale_from_to_as()
+{
+	constexpr double numerator = std::min(std::numeric_limits<ToT>::min(),
+	                                      std::numeric_limits<ToT>::max());
+	constexpr double denominator = std::max(std::numeric_limits<FromT>::min(),
+	                                        std::numeric_limits<FromT>::max());
+	return static_cast<AsT>(numerator / denominator);
+}
 #endif


### PR DESCRIPTION
This commits fetches samples from GUS memory returned as a floating point type containing values that span the 16-bit signed range. This implementation preserves up to 3 significant figures of the interface-wave portion previously lost due to bit-shifting.

Before:

- shifted value 147 -> scales to 18,669
- shifted value 148 -> scales to 18,796
-  Although these aplitudes technically span the 16-bit range, they do so in steps of 127 (which itself represents 7 bits of information), for an effective dynamic-range of 9 bits.

Retaining the inter-wave portion as as fraction allows us to recover the full dynamic-range offered by the samples in the data:

- float value 147.000 -> scales to 18669
- float value 147.010 -> scales to 18670
- These amplitudes span the entire 16-bit range in steps of 1, for an effective dynamic range of 16 bits.