### PR TITLE
Sort sources in hardware module

### DIFF
--- a/src/hardware/Makefile.am
+++ b/src/hardware/Makefile.am
@@ -1,13 +1,53 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
-SUBDIRS = serialport mame
+SUBDIRS = \
+	mame \
+	serialport
 
-EXTRA_DIST = opl.cpp opl.h adlib.h dbopl.h pci_devices.h
+EXTRA_DIST = \
+	adlib.h \
+	dbopl.h \
+	opl.cpp \
+	opl.h \
+	pci_devices.h
 
 noinst_LIBRARIES = libhardware.a
 
-libhardware_a_SOURCES = adlib.cpp dma.cpp gameblaster.cpp hardware.cpp iohandler.cpp joystick.cpp keyboard.cpp \
-                        memory.cpp mixer.cpp pcspeaker.cpp pci_bus.cpp pic.cpp sblaster.cpp tandy_sound.cpp timer.cpp \
-			vga.cpp vga_attr.cpp vga_crtc.cpp vga_dac.cpp vga_draw.cpp vga_gfx.cpp vga_other.cpp \
-			vga_memory.cpp vga_misc.cpp vga_seq.cpp vga_xga.cpp vga_s3.cpp vga_tseng.cpp vga_paradise.cpp \
-			cmos.cpp disney.cpp gus.cpp mpu401.cpp ipx.cpp ipxserver.cpp dbopl.cpp envelope.cpp
+libhardware_a_SOURCES = \
+	adlib.cpp \
+	cmos.cpp \
+	dbopl.cpp \
+	disney.cpp \
+	dma.cpp \
+	envelope.cpp \
+	gameblaster.cpp \
+	gus.cpp \
+	hardware.cpp \
+	iohandler.cpp \
+	ipx.cpp \
+	ipxserver.cpp \
+	joystick.cpp \
+	keyboard.cpp \
+	memory.cpp \
+	mixer.cpp \
+	mpu401.cpp \
+	pci_bus.cpp \
+	pcspeaker.cpp \
+	pic.cpp \
+	sblaster.cpp \
+	tandy_sound.cpp \
+	timer.cpp \
+	vga_attr.cpp \
+	vga.cpp \
+	vga_crtc.cpp \
+	vga_dac.cpp \
+	vga_draw.cpp \
+	vga_gfx.cpp \
+	vga_memory.cpp \
+	vga_misc.cpp \
+	vga_other.cpp \
+	vga_paradise.cpp \
+	vga_s3.cpp \
+	vga_seq.cpp \
+	vga_tseng.cpp \
+	vga_xga.cpp

--- a/src/hardware/mame/Makefile.am
+++ b/src/hardware/mame/Makefile.am
@@ -1,9 +1,16 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LIBRARIES = libmame.a
-libmame_a_SOURCES = emu.h \
-    fmopl.cpp fmopl.h \
-    saa1099.cpp saa1099.h \
-    sn76496.cpp sn76496.h \
-    ymdeltat.cpp ymdeltat.h \
-    ymf262.cpp ymf262.h
+
+libmame_a_SOURCES = \
+	emu.h \
+	fmopl.cpp \
+	fmopl.h \
+	saa1099.cpp \
+	saa1099.h \
+	sn76496.cpp \
+	sn76496.h \
+	ymdeltat.cpp \
+	ymdeltat.h \
+	ymf262.cpp \
+	ymf262.h

--- a/src/hardware/serialport/Makefile.am
+++ b/src/hardware/serialport/Makefile.am
@@ -2,8 +2,17 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LIBRARIES = libserial.a
 
-libserial_a_SOURCES =	directserial.cpp directserial.h \
-						libserial.cpp libserial.h \
-						serialdummy.cpp serialdummy.h serialport.cpp \
-						softmodem.cpp softmodem.h misc_util.cpp misc_util.h \
-						nullmodem.cpp nullmodem.h
+libserial_a_SOURCES = \
+	directserial.cpp \
+	directserial.h \
+	libserial.cpp \
+	libserial.h \
+	misc_util.cpp \
+	misc_util.h \
+	nullmodem.cpp \
+	nullmodem.h \
+	serialdummy.cpp \
+	serialdummy.h \
+	serialport.cpp \
+	softmodem.cpp \
+	softmodem.h


### PR DESCRIPTION
Some Makefile.am files have them sorted, others do not; start
unification across the project, one module at a time.

---

I consider this a pre-requisite for #480, so that review won't need to deal with retouching makefiles (which is not directly related to PC speaker).