### PR TITLE
Define PI once, and use it throughout the code base

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -95,9 +95,6 @@ typedef struct FPU_rec {
 	FPU_Round	round;
 } FPU_rec;
 
-
-//get pi from a real library
-#define PI		3.14159265358979323846
 #define L2E		1.4426950408889634
 #define L2T		3.3219280948873623
 #define LN2		0.69314718055994531

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -596,7 +596,7 @@ static void FPU_FLDL2E(void){
 
 static void FPU_FLDPI(void){
 	FPU_PREP_PUSH();
-	fpu.regs[TOP].d = PI;
+	fpu.regs[TOP].d = M_PI;
 }
 
 static void FPU_FLDLG2(void){

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -35,15 +35,11 @@
 #include "dbopl.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstddef>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <type_traits>
-
-#ifndef PI
-#define PI 3.14159265358979323846
-#endif
 
 namespace DBOPL {
 
@@ -1360,7 +1356,8 @@ void InitTables( void ) {
 	//Add 0.5 for the trunc rounding of the integer cast
 	//Do a PI sinetable instead of the original 0.5 PI
 	for ( int i = 0; i < 512; i++ ) {
-		SinTable[i] = (Bit16s)( 0.5 - log10( sin( (i + 0.5) * (PI / 512.0) ) ) / log10(2.0)*256 );
+		SinTable[i] = (Bit16s)(0.5 - log10(sin((i + 0.5) * (M_PI / 512.0))) /
+		                                     log10(2.0) * 256);
 	}
 #endif
 #if ( DBOPL_WAVE == WAVE_TABLEMUL )
@@ -1374,7 +1371,8 @@ void InitTables( void ) {
 
 	//Sine Wave Base
 	for ( int i = 0; i < 512; i++ ) {
-		WaveTable[ 0x0200 + i ] = (Bit16s)(sin( (i + 0.5) * (PI / 512.0) ) * 4084);
+		WaveTable[0x0200 + i] = (Bit16s)(
+		        sin((i + 0.5) * (M_PI / 512.0)) * 4084);
 		WaveTable[ 0x0000 + i ] = -WaveTable[ 0x200 + i ];
 	}
 	//Exponential wave
@@ -1386,7 +1384,9 @@ void InitTables( void ) {
 #if ( DBOPL_WAVE == WAVE_TABLELOG )
 	//Sine Wave Base
 	for ( int i = 0; i < 512; i++ ) {
-		WaveTable[ 0x0200 + i ] = (Bit16s)( 0.5 - log10( sin( (i + 0.5) * (PI / 512.0) ) ) / log10(2.0)*256 );
+		WaveTable[0x0200 + i] = (Bit16s)(
+		        0.5 - log10(sin((i + 0.5) * (M_PI / 512.0))) /
+		                      log10(2.0) * 256);
 		WaveTable[ 0x0000 + i ] = ((Bit16s)0x8000) | WaveTable[ 0x200 + i];
 	}
 	//Exponential wave

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -3,12 +3,13 @@
 
 
 #include "dosbox.h"
+
+#include <cmath>
 #if defined(_MSC_VER) && (_MSC_VER  <= 1500) 
 #include <SDL.h>
 #else
 #include <stdint.h>
 #endif
-#include <math.h>
 #include <float.h>
 #include <stdlib.h>
 #include <memory.h>
@@ -16,10 +17,6 @@
 #if C_DEBUG
 #include <stdio.h>
 #include <stdarg.h>
-#endif
-
-#ifndef M_PI
-#define M_PI           3.14159265358979323846
 #endif
 
 typedef Bit16s stream_sample_t;

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -1353,7 +1353,8 @@ int FM_OPL::init_tables()
 	for (i=0; i<SIN_LEN; i++)
 	{
 		/* non-standard sinus */
-		m = sin(((i*2)+1) * M_PI / SIN_LEN); /* checked against the real chip */
+		m = sin(((i * 2) + 1) * M_PI / SIN_LEN); /* checked against the
+		                                          real chip */
 
 		/* we never reach zero here due to ((i*2)+1) */
 

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1218,7 +1218,8 @@ static int init_tables(void)
 	for (i=0; i<SIN_LEN; i++)
 	{
 		/* non-standard sinus */
-		m = sin(((i*2)+1) * M_PI / SIN_LEN); /* checked against the real chip */
+		m = sin(((i * 2) + 1) * M_PI / SIN_LEN); /* checked against the
+		                                          real chip */
 
 		/* we never reach zero here due to ((i*2)+1) */
 

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -24,13 +24,13 @@
  * Ken Silverman's official web site: "http://www.advsys.net/ken"
  */
 
-
-#include <math.h>
-#include <stdlib.h> // rand()
-#include <string.h> // memset()
-#include "dosbox.h"
 #include "opl.h"
 
+#include <cmath>
+#include <stdlib.h> // rand()
+#include <string.h> // memset()
+
+#include "dosbox.h"
 
 static fltype recipsamp;	// inverse of sampling rate
 static Bit16s wavtable[WAVEPREC*3];	// wave form table
@@ -566,13 +566,19 @@ void adlib_init(Bit32u samplerate) {
 
 		// create waveform tables
 		for (i=0;i<(WAVEPREC>>1);i++) {
-			wavtable[(i<<1)  +WAVEPREC]	= (Bit16s)(16384*sin((fltype)((i<<1)  )*PI*2/WAVEPREC));
-			wavtable[(i<<1)+1+WAVEPREC]	= (Bit16s)(16384*sin((fltype)((i<<1)+1)*PI*2/WAVEPREC));
-			wavtable[i]					= wavtable[(i<<1)  +WAVEPREC];
+			wavtable[(i << 1) + WAVEPREC] = (Bit16s)(
+			        16384 * sin((fltype)((i << 1)) * M_PI * 2 / WAVEPREC));
+			wavtable[(i << 1) + 1 + WAVEPREC] = (Bit16s)(
+			        16384 *
+			        sin((fltype)((i << 1) + 1) * M_PI * 2 / WAVEPREC));
+			wavtable[i] = wavtable[(i << 1) + WAVEPREC];
 			// alternative: (zero-less)
-/*			wavtable[(i<<1)  +WAVEPREC]	= (Bit16s)(16384*sin((fltype)((i<<2)+1)*PI/WAVEPREC));
-			wavtable[(i<<1)+1+WAVEPREC]	= (Bit16s)(16384*sin((fltype)((i<<2)+3)*PI/WAVEPREC));
-			wavtable[i]					= wavtable[(i<<1)-1+WAVEPREC]; */
+			/*			wavtable[(i<<1)  +WAVEPREC]	=
+			   (Bit16s)(16384*sin((fltype)((i<<2)+1)*M_PI/WAVEPREC));
+			                        wavtable[(i<<1)+1+WAVEPREC] =
+			   (Bit16s)(16384*sin((fltype)((i<<2)+3)*M_PI/WAVEPREC));
+			                        wavtable[i]
+			   = wavtable[(i<<1)-1+WAVEPREC]; */
 		}
 		for (i=0;i<(WAVEPREC>>3);i++) {
 			wavtable[i+(WAVEPREC<<1)]		= wavtable[i+(WAVEPREC>>3)]-16384;

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -60,9 +60,7 @@ typedef int8_t		Bit8s;
 
 
 #define FL05	((fltype)0.5)
-#define FL2		((fltype)2.0)
-#define PI		((fltype)3.1415926535897932384626433832795)
-
+#define FL2     ((fltype)2.0)
 
 #define FIXEDPT			0x10000		// fixed-point calculations using 16+16
 #define FIXEDPT_LFO		0x1000000	// fixed-point calculations using 8+24

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -68,3 +68,7 @@
 
 #define INLINE __forceinline
 #define DB_FASTCALL __fastcall
+
+// Enables mathematical constants under Visual Studio, such as M_PI
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+#define _USE_MATH_DEFINES


### PR DESCRIPTION
The current solution is not ideal as the #define'd value is a `double` and so will generate information-loss warnings when used in `float` calculations (without casting; which is cumbersome).

This PR will implement an elegant solution for use in all our self-managed code (ie: externally maintained 3rd party libraries will be left as is).
