### PR TITLE
Add lib iphlpapi for static SDL builds under Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -592,6 +592,9 @@ case "$host" in
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32 and Posix).])
        if test x$have_sdl_net_lib = xyes -a x$have_sdl_net_h = xyes ; then
          LIBS="$LIBS -lws2_32"
+         if test x$enable_sdl_static = xyes ; then
+           LIBS="$LIBS -liphlpapi"
+         fi
        fi
        ;;
     *-*-darwin*)


### PR DESCRIPTION
A previous PR solved the link order problem between SDL2 and SDL2_net, however Config Heavy then revealed a new missing symbol: 

``` text
libSDL2_net.a(SDLnet.o):(.text+0x2d6): undefined reference to `GetAdaptersInfo'
```

This PR includes `-liphlpapi` specifically for Windows static SDL builds including network support, which provides this symbol. Tested working:

https://github.com/dosbox-staging/dosbox-staging/actions/runs/166580675

This iphlpapi library is pretty long-lived in terms of providing this symbol, as similar missing `GetAdapters*` symbols go back to the Windows 2000 days, and involve the same approach.

I wonder if our fully-static 32-bit builds (under MinGW) will let people use staging on older Windows system, say Windows 7, maybe even XP?