### PR TITLE
Allow division operations to be reassociated by the compiler

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,8 +119,8 @@ jobs:
           RANLIB: gcc-ranlib
           FLAGS: >-
             -O3 -fstrict-aliasing -fno-signed-zeros -fno-trapping-math
-            -fassociative-math -mfpmath=sse -msse4.2 -flto -ffunction-sections
-            -fdata-sections -DNDEBUG -pipe
+            -fassociative-math -freciprocal-math -mfpmath=sse -msse4.2 -flto
+            -ffunction-sections -fdata-sections -DNDEBUG -pipe
           LINKFLAGS: -Wl,--as-needed
         run: |
           set -x

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       CC: ccache clang
       CXX: ccache clang++
-      FLAGS: -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing -march=nehalem -flto=thin -pipe
+      FLAGS: -DNDEBUG -O3 -fno-math-errno -freciprocal-math -fstrict-aliasing -march=nehalem -flto=thin -pipe
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -12,7 +12,7 @@ TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 
 # Note: no-math-errno improves optimization of C/C++ math functions
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno
-                 -fno-strict-aliasing)
+                 -freciprocal-math -fno-strict-aliasing)
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 
 cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -15,8 +15,8 @@ cflags_debug+=("${cflags[@]}" -g -fstack-protector -fno-omit-frame-pointer)
 # Note: associative-math is needed for vectorization of floating point
 #       calculations, which also relies on no-signed-zeros and
 #       no-trapping-math.
-cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing
-                 -fno-signed-zeros -fno-trapping-math -fassociative-math
+cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fstrict-aliasing -fno-signed-zeros
+                 -fno-trapping-math -fassociative-math -freciprocal-math
                  -frename-registers -ffunction-sections -fdata-sections)
 
 cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion


### PR DESCRIPTION
This commit allows the compiler to use reciprocals x/y => x * 1/y when it makes sense.

Testing on x86-64, ARM-v7, and PPC 7400 platforms show that performance generally improves.

Accuracy is degraded at most by 4.665300250053405e-10 per calculation, and on some platforms there is no change in accuracy. For example on PPC, summing the result from 100,000,000 iterations produces the same decimal fraction with or without allowing reciprocals.

4.7e-10 is ~three sig-figs better than the absolute accuracy maintained by floating point calculations as it is (which is roughly 7 sig-figs). Does this matter? No. The project code has no floating point calculations where a difference of 4.6e-10 (ie: 15.72348576192 vs 15.72348576146) is going to change an end result.

For example, 16-bit audio rounds to the nearest digit.. so we could tolerate  /a lot more/ error before the rounding affects a volume level by a single digit.

Testing a variety of games and applications on x64 and Pi show no visible or audible change.