### PR TITLE
Fallback to sinf/cosf for now

### DIFF
--- a/src/hardware/dc_silencer.cpp
+++ b/src/hardware/dc_silencer.cpp
@@ -55,7 +55,7 @@ bool DCSilencer::Generate(const int16_t dc_offset, const size_t samples, int16_t
 	while (vol_pos > 0 && i < samples) {
 		vol_pos -= vol_dt; // keep turning down the volume ..
 		rad_pos += rad_dt; // keep walking around our circle ..
-		const float sample = dc_offset * coarse_cos(rad_pos) * vol_pos;
+		const float sample = dc_offset * cosf(rad_pos) * vol_pos;
 		buffer[i++] = static_cast<int16_t>(sample);
 	}
 	// only consider the job done when we haven't generated any samples.


### PR DESCRIPTION
I got too caught up in performance comparisons and neglected to actually inspect the values beyond a cursory check! 

The `coarse_cos` Taylor function is generating smooth trig curves, but looks like it's inverted:

![2020-07-14_11-40](https://user-images.githubusercontent.com/1557255/87464303-bd1a4280-c5c7-11ea-99ee-a34517446344.png)

This PR is a quick-fix that swaps in `cosf`, which works as expected (actual result from this build):

![2020-07-14_11-44](https://user-images.githubusercontent.com/1557255/87464304-bdb2d900-c5c7-11ea-9463-d3f49adb5f59.png)

We'll switch back to Taylor, or a better approach soon enough! Sorry for not catching this before the merge @dreamer !