### PR TITLE
Fix a number of effc++ warnings

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -56,10 +56,16 @@ public:
 	void Get_Geometry(Bit32u * getHeads, Bit32u *getCyl, Bit32u *getSect, Bit32u *getSectSize);
 	Bit8u GetBiosType(void);
 	Bit32u getSectSize(void);
+
 	imageDisk(FILE *imgFile, const char *imgName, Bit32u imgSizeK, bool isHardDisk);
 	imageDisk(const imageDisk&) = delete; // prevent copy
 	imageDisk& operator=(const imageDisk&) = delete; // prevent assignment
-	~imageDisk() { if(diskimg != NULL) { fclose(diskimg); }	};
+
+	virtual ~imageDisk()
+	{
+		if (diskimg != nullptr)
+			fclose(diskimg);
+	}
 
 	bool hardDrive;
 	bool active;

--- a/include/dma.h
+++ b/include/dma.h
@@ -16,9 +16,12 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_DMA_H
 #define DOSBOX_DMA_H
+
+#include "dosbox.h"
+
+#include <cassert>
 
 enum DMAEvent {
 	DMA_REACHED_TC,
@@ -82,24 +85,29 @@ public:
 
 class DmaController {
 private:
-	Bit8u ctrlnum;
 	bool flipflop;
 	DmaChannel *DmaChannels[4];
 public:
 	IO_ReadHandleObject DMA_ReadHandler[0x12];
 	IO_WriteHandleObject DMA_WriteHandler[0x12];
-	DmaController(Bit8u num) {
-		flipflop = false;
-		ctrlnum = num;		/* first or second DMA controller */
-		for(Bit8u i=0;i<4;i++) {
-			DmaChannels[i] = new DmaChannel(i+ctrlnum*4,ctrlnum==1);
-		}
+
+	DmaController(uint8_t num) : flipflop(false)
+	{
+		assert(num == 0 || num == 1); // first or second DMA controller
+
+		for (uint8_t i = 0; i < 4; ++i)
+			DmaChannels[i] = new DmaChannel(i + num * 4, num == 1);
 	}
-	~DmaController(void) {
-		for(Bit8u i=0;i<4;i++) {
-			delete DmaChannels[i];
-		}
+
+	DmaController(const DmaController &) = delete; // prevent copy
+	DmaController &operator=(const DmaController &) = delete; // prevent assignment
+
+	~DmaController()
+	{
+		for (auto *dma_channel : DmaChannels)
+			delete dma_channel;
 	}
+
 	DmaChannel * GetChannel(Bit8u chan) {
 		if (chan<4) return DmaChannels[chan];
 		else return NULL;

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -292,19 +292,27 @@ public:
 
 	void	SaveVectors			(void);
 	void	RestoreVectors		(void);
-	void	SetSize				(Bit16u size)			{ sSave(sPSP,next_seg,size);		};
-	Bit16u	GetSize				(void)					{ return (Bit16u)sGet(sPSP,next_seg);		};
-	void	SetEnvironment		(Bit16u envseg)			{ sSave(sPSP,environment,envseg);	};
-	Bit16u	GetEnvironment		(void)					{ return (Bit16u)sGet(sPSP,environment);	};
-	Bit16u	GetSegment			(void)					{ return seg;						};
+
+	void SetSize(uint16_t size) { sSave(sPSP, next_seg, size); }
+	uint16_t GetSize() { return (uint16_t)sGet(sPSP, next_seg); }
+
+	void SetEnvironment(uint16_t eseg) { sSave(sPSP, environment, eseg); }
+	uint16_t GetEnvironment() { return (uint16_t)sGet(sPSP, environment); }
+
+	uint16_t GetSegment() { return seg; }
+
 	void	SetFileHandle		(Bit16u index, Bit8u handle);
 	Bit8u	GetFileHandle		(Bit16u index);
-	void	SetParent			(Bit16u parent)			{ sSave(sPSP,psp_parent,parent);	};
-	Bit16u	GetParent			(void)					{ return (Bit16u)sGet(sPSP,psp_parent);		};
-	void	SetStack			(RealPt stackpt)		{ sSave(sPSP,stack,stackpt);		};
-	RealPt	GetStack			(void)					{ return sGet(sPSP,stack);			};
-	void	SetInt22			(RealPt int22pt)		{ sSave(sPSP,int_22,int22pt);		};
-	RealPt	GetInt22			(void)					{ return sGet(sPSP,int_22);			};
+
+	void SetParent(uint16_t parent) { sSave(sPSP, psp_parent, parent); }
+	uint16_t GetParent() { return (uint16_t)sGet(sPSP, psp_parent); }
+
+	void SetStack(RealPt stackpt) { sSave(sPSP, stack, stackpt); }
+	RealPt GetStack() { return sGet(sPSP, stack); }
+
+	void SetInt22(RealPt int22pt) { sSave(sPSP, int_22, int22pt); }
+	RealPt GetInt22() { return sGet(sPSP, int_22); }
+
 	void	SetFCB1				(RealPt src);
 	void	SetFCB2				(RealPt src);
 	void	SetCommandTail		(RealPt src);	
@@ -474,10 +482,11 @@ public:
 	void GetSearchParams(Bit8u & _sattr,char * _spattern);
 	void GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr);
 
-	void	SetDirID(Bit16u entry)			{ sSave(sDTA,dirID,entry); };
-	void	SetDirIDCluster(Bit16u entry)	{ sSave(sDTA,dirCluster,entry); };
-	Bit16u	GetDirID(void)				{ return (Bit16u)sGet(sDTA,dirID); };
-	Bit16u	GetDirIDCluster(void)		{ return (Bit16u)sGet(sDTA,dirCluster); };
+	void SetDirID(uint16_t entry) { sSave(sDTA, dirID, entry); }
+	void SetDirIDCluster(uint16_t entry) { sSave(sDTA, dirCluster, entry); }
+	uint16_t GetDirID() { return (uint16_t)sGet(sDTA, dirID); }
+	uint16_t GetDirIDCluster() { return (uint16_t)sGet(sDTA, dirCluster); }
+
 private:
 	#ifdef _MSC_VER
 	#pragma pack(1)
@@ -627,12 +636,16 @@ struct DOS_Block {
 	DOS_Version version;
 	Bit16u firstMCB;
 	Bit16u errorcode;
-	Bit16u psp(){return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetPSP();};
-	void psp(Bit16u _seg){ DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetPSP(_seg);};
+
+	uint16_t psp() { return DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).GetPSP(); }
+	void psp(uint16_t seg) { DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).SetPSP(seg); }
+
 	Bit16u env;
 	RealPt cpmentry;
-	RealPt dta(){return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDTA();};
-	void dta(RealPt _dta){DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDTA(_dta);};
+
+	RealPt dta() { return DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).GetDTA(); }
+	void dta(RealPt dtap) { DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).SetDTA(dtap); }
+
 	Bit8u return_code,return_mode;
 	
 	Bit8u current_drive;

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -86,11 +86,13 @@ public:
 	virtual bool	Seek(Bit32u * pos,Bit32u type)=0;
 	virtual bool	Close()=0;
 	virtual Bit16u	GetInformation(void)=0;
-	virtual bool	IsOpen()					{ return open; };
-	virtual void	AddRef()					{ refCtr++; };
-	virtual Bits	RemoveRef()					{ return --refCtr; };
-	virtual bool	UpdateDateTimeFromHost()	{ return true; }
+
+	virtual bool IsOpen() { return open; }
+	virtual void AddRef() { refCtr++; }
+	virtual Bits RemoveRef() { return --refCtr; }
+	virtual bool UpdateDateTimeFromHost() { return true; }
 	virtual void SetFlagReadOnlyMedium() {}
+
 	void SetDrive(Bit8u drv) { hdrive=drv;}
 	Bit8u GetDrive(void) { return hdrive;}
 	Bit32u flags;
@@ -107,19 +109,23 @@ private:
 
 class DOS_Device : public DOS_File {
 public:
+	DOS_Device() : DOS_File(), devnum(0) {}
+
 	DOS_Device(const DOS_Device& orig)
 		: DOS_File(orig),
 		  devnum(orig.devnum)
 	{
 		open = true;
 	}
-	DOS_Device & operator= (const DOS_Device & orig) {
+
+	DOS_Device &operator=(const DOS_Device &orig)
+	{
 		DOS_File::operator=(orig);
-		devnum=orig.devnum;
-		open=true;
+		devnum = orig.devnum;
+		open = true;
 		return *this;
 	}
-	DOS_Device():DOS_File(),devnum(0){};
+
 	virtual bool	Read(Bit8u * data,Bit16u * size);
 	virtual bool	Write(Bit8u * data,Bit16u * size);
 	virtual bool	Seek(Bit32u * pos,Bit32u type);
@@ -166,8 +172,9 @@ public:
 	DOS_Drive_Cache& operator= (const DOS_Drive_Cache&) = delete; // prevent assignment
 	~DOS_Drive_Cache           (void);
 
-	void  SetBaseDir           (const char* path);
-	void  SetDirSort           (TDirSort sort) { sortDirType = sort; };
+	void SetBaseDir(const char *path);
+	void SetDirSort(TDirSort sort) { sortDirType = sort; }
+
 	bool  OpenDir              (const char* path, Bit16u& id);
 	bool  ReadDir              (Bit16u id, char* &result);
 
@@ -185,30 +192,32 @@ public:
 	void  DeleteEntry          (const char* path, bool ignoreLastDir = false);
 	void  EmptyCache           (void);
 
-	void  SetLabel             (const char* name,bool cdrom,bool allowupdate);
-	char* GetLabel             (void) { return label; };
+	void SetLabel(const char *name, bool cdrom, bool allowupdate);
+	const char *GetLabel() const { return label; }
 
 	class CFileInfo {
 	public:
 		CFileInfo(void)
-			: orgname{0},
-			  shortname{0},
-			  isOverlayDir(false),
-			  isDir(false),
-			  id(MAX_OPENDIRS),
-			  nextEntry(0),
-			  shortNr(0),
-			  fileList(0),
-			  longNameList(0)
+		        : orgname{0},
+		          shortname{0},
+		          isOverlayDir(false),
+		          isDir(false),
+		          id(MAX_OPENDIRS),
+		          nextEntry(0),
+		          shortNr(0),
+		          fileList(0),
+		          longNameList(0)
+		{}
+
+		virtual ~CFileInfo()
 		{
-		}
-		~CFileInfo(void) {
 			for (auto p : fileList) {
 				delete p;
 			}
 			fileList.clear();
 			longNameList.clear();
-		};
+		}
+
 		char        orgname[CROSS_LEN];
 		char        shortname[DOS_NAMELENGTH_ASCII];
 		bool        isOverlayDir;
@@ -260,7 +269,8 @@ private:
 class DOS_Drive {
 public:
 	DOS_Drive();
-	virtual ~DOS_Drive(){};
+	virtual ~DOS_Drive() = default;
+
 	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags)=0;
 	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes)=0;
 	virtual bool FileUnlink(char * _name)=0;
@@ -275,8 +285,8 @@ public:
 	virtual bool FileExists(const char* name)=0;
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block)=0;
 	virtual Bit8u GetMediaByte(void)=0;
-	virtual void SetDir(const char *path) { safe_strcpy(curdir, path); };
-	virtual void EmptyCache(void) { dirCache.EmptyCache(); };
+	virtual void SetDir(const char *path) { safe_strcpy(curdir, path); }
+	virtual void EmptyCache() { dirCache.EmptyCache(); }
 	virtual bool isRemote(void)=0;
 	virtual bool isRemovable(void)=0;
 	virtual Bits UnMount(void)=0;
@@ -285,13 +295,14 @@ public:
 
 	char curdir[DOS_PATHLENGTH];
 	char info[256];
-	/* Can be overridden for example in iso images */
-	virtual char const * GetLabel(){return dirCache.GetLabel();};
+
+	// Can be overridden for example in iso images
+	virtual const char *GetLabel() { return dirCache.GetLabel(); }
 
 	DOS_Drive_Cache dirCache;
 
 	// disk cycling functionality (request resources)
-	virtual void Activate(void) {};
+	virtual void Activate() {}
 };
 
 enum { OPEN_READ=0, OPEN_WRITE=1, OPEN_READWRITE=2, OPEN_READ_NO_MOD=4, DOS_NOT_INHERIT=128};

--- a/include/drives.h
+++ b/include/drives.h
@@ -75,7 +75,8 @@ public:
 	virtual bool isRemote(void);
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
-	const char* getBasedir() {return basedir;};
+	const char *GetBasedir() const { return basedir; }
+
 protected:
 	char basedir[CROSS_LEN];
 	struct {
@@ -335,7 +336,7 @@ public:
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
 	bool readSector(Bit8u *buffer, Bit32u sector);
-	virtual char const* GetLabel(void) {return discLabel;};
+	virtual const char *GetLabel() { return discLabel; }
 	virtual void Activate(void);
 private:
 	int  readDirEntry(isoDirEntry *de, Bit8u *data);

--- a/include/paging.h
+++ b/include/paging.h
@@ -57,7 +57,8 @@ class PageDirectory;
 
 class PageHandler {
 public:
-	virtual ~PageHandler(void) { }
+	virtual ~PageHandler() = default;
+
 	virtual Bitu readb(PhysPt addr);
 	virtual Bitu readw(PhysPt addr);
 	virtual Bitu readd(PhysPt addr);
@@ -72,7 +73,8 @@ public:
 	virtual bool writeb_checked(PhysPt addr,Bitu val);
 	virtual bool writew_checked(PhysPt addr,Bitu val);
 	virtual bool writed_checked(PhysPt addr,Bitu val);
-	Bitu flags;
+
+	Bitu flags = 0x0;
 };
 
 /* Some other functions */

--- a/include/setup.h
+++ b/include/setup.h
@@ -240,15 +240,20 @@ public:
 	~Prop_bool(){ }
 };
 
-class Prop_string:public Property{
+class Prop_string : public Property {
 public:
-	Prop_string(std::string const& _propname, Changeable::Value when, char const * const _value)
-		:Property(_propname,when) {
-		default_value = value = _value;
+	Prop_string(const std::string &name, Changeable::Value when, const char *val)
+	        : Property(name, when)
+	{
+		default_value = val;
+		value = val;
 	}
-	bool SetValue(std::string const& in);
-	virtual bool CheckValue(Value const& in, bool warn);
-	~Prop_string(){ }
+
+	~Prop_string() override = default;
+
+	bool SetValue(const std::string &in) override;
+
+	bool CheckValue(const Value &in, bool warn) override;
 };
 
 class Prop_path : public Prop_string {
@@ -256,10 +261,7 @@ public:
 	Prop_path(const std::string &name, Changeable::Value when, const char *val)
 	        : Prop_string(name, when, val),
 	          realpath(val)
-	{
-		default_value = val;
-		value = val;
-	}
+	{}
 
 	~Prop_path() override = default;
 

--- a/include/setup.h
+++ b/include/setup.h
@@ -250,16 +250,22 @@ public:
 	virtual bool CheckValue(Value const& in, bool warn);
 	~Prop_string(){ }
 };
-class Prop_path:public Prop_string{
+
+class Prop_path : public Prop_string {
 public:
-	std::string realpath;
-	Prop_path(std::string const& _propname, Changeable::Value when, char const * const _value)
-		:Prop_string(_propname,when,_value) {
-		default_value = value = _value;
-		realpath = _value;
+	Prop_path(const std::string &name, Changeable::Value when, const char *val)
+	        : Prop_string(name, when, val),
+	          realpath(val)
+	{
+		default_value = val;
+		value = val;
 	}
-	bool SetValue(std::string const& in);
-	~Prop_path(){ }
+
+	~Prop_path() override = default;
+
+	bool SetValue(const std::string &in) override;
+
+	std::string realpath;
 };
 
 class Prop_hex:public Property {

--- a/include/support.h
+++ b/include/support.h
@@ -191,4 +191,22 @@ constexpr float coarse_cos(float x)
 	constexpr auto half_pi = static_cast<float>(M_PI_2);
 	return coarse_sin(x + half_pi);
 }
+
+// Use ARRAY_LEN macro to safely calculate number of elements in a C-array.
+// This macro can be used in a constant expressions, even if array is a
+// non-static class member:
+//
+//   constexpr auto n = ARRAY_LEN(my_array);
+//
+template <typename T>
+constexpr size_t static_if_array_then_zero()
+{
+	static_assert(std::is_array<T>::value, "not an array type");
+	return 0;
+}
+
+#define ARRAY_LEN(arr)                                                         \
+	(static_if_array_then_zero<decltype(arr)>() +                          \
+	 (sizeof(arr) / sizeof(arr[0])));
+
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -364,7 +364,7 @@ public:
 						WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE"));
 						return;
 					}
-					std::string base = ldp->getBasedir();
+					std::string base = ldp->GetBasedir();
 					Bit8u o_error = 0;
 					newdrive = new Overlay_Drive(base.c_str(),temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,o_error);
 					//Erase old drive on success

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -346,15 +346,17 @@ again:
 	return done;
 }
 
-class DMA:public Module_base{
+class DMA : public Module_base {
 public:
-	DMA(Section* configuration):Module_base(configuration){
-		Bitu i;
+	DMA(Section *configuration) : Module_base(configuration)
+	{
 		DmaControllers[0] = new DmaController(0);
-		if (IS_EGAVGA_ARCH) DmaControllers[1] = new DmaController(1);
-		else DmaControllers[1] = NULL;
-	
-		for (i=0;i<0x10;i++) {
+		if (IS_EGAVGA_ARCH)
+			DmaControllers[1] = new DmaController(1);
+		else
+			DmaControllers[1] = nullptr;
+
+		for (Bitu i = 0; i < 0x10; i++) {
 			Bitu mask=IO_MB;
 			if (i<8) mask|=IO_MW;
 			/* install handler for first DMA controller ports */

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -43,25 +43,29 @@ struct machine_config;
 #define DEFINE_DEVICE_TYPE(Type, Class, ShortName, FullName)		\
 	const device_type Type = 0;
 
-
 class device_sound_interface {
-public:			
+public:
 	struct sound_stream {
-		void update() {
-		}
+		void update() {}
 	};
+
 	sound_stream temp;
 
-	sound_stream* stream_alloc(int whatever, int channels, int size) {
+	device_sound_interface(const machine_config &mconfig, device_t &_device)
+	        : temp()
+	{}
+
+	virtual ~device_sound_interface() = default;
+
+	sound_stream *stream_alloc(int whatever, int channels, int size)
+	{
 		return &temp;
-	};
-	
-
-	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) = 0;
-
-	device_sound_interface(const machine_config &mconfig, device_t& _device) {
 	}
 
+	virtual void sound_stream_update(sound_stream &stream,
+	                                 stream_sample_t **inputs,
+	                                 stream_sample_t **outputs,
+	                                 int samples) = 0;
 };
 
 struct attotime {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1353,7 +1353,7 @@ void DOS_Shell::CMD_SUBST (char * args) {
 
 		if ( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
 		char newname[CROSS_LEN];
-		safe_strcpy(newname, ldp->getBasedir());
+		safe_strcpy(newname, ldp->GetBasedir());
 		strcat(newname,fulldir);
 		CROSS_FILENAME(newname);
 		ldp->dirCache.ExpandName(newname);


### PR DESCRIPTION
Also, clean out many -Wextra-semi warnings.

@kcgen after this PR, I think we'll be finally ready to enable -Weffc++ and -Wextra-semi for our debug builds. This PR cleans almost all effc++ warnings in header files, so it will be very unlikely to introduce new warning just by placing including a new header in a cpp file. I think I'll have some problems with adding -Wextra-semi to build script though (this warning flag is not available for Ubuntu 16.04).