### PR TITLE
Upgrade some callback typedefs from C-style pointers to std::function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ missed.txt
 
 # Visual Studio
 .vs
+.vscode
 
 # Common editor temp/backup files
 *~

--- a/include/dma.h
+++ b/include/dma.h
@@ -20,15 +20,16 @@
 #ifndef DOSBOX_DMA_H
 #define DOSBOX_DMA_H
 
+#include <functional>
+
 enum DMAEvent {
 	DMA_REACHED_TC,
 	DMA_MASKED,
 	DMA_UNMASKED,
-//	DMA_TRANSFEREND, this shouldn't really be a ignal
 };
 
 class DmaChannel;
-typedef void (* DMA_CallBack)(DmaChannel * chan,DMAEvent event);
+using DMA_CallBack = std::function<void(DmaChannel *chan, DMAEvent event)>;
 
 class DmaChannel {
 public:
@@ -50,7 +51,8 @@ public:
 
 	DmaChannel(Bit8u num, bool dma16);
 	void DoCallBack(DMAEvent event) {
-		if (callback)	(*callback)(this,event);
+		if (callback)
+			callback(this, event);
 	}
 	void SetMask(bool _mask) {
 		masked=_mask;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -24,10 +24,17 @@
 #include "dosbox.h"
 #endif
 
+#include <functional>
+
 #include "envelope.h"
 
 typedef void (*MIXER_MixHandler)(Bit8u *sampdate, Bit32u len);
-typedef void (*MIXER_Handler)(Bitu len);
+
+// The mixer callback can accept a static function or a member function
+// using a std::bind. The callback typically requests enough frames to
+// fill one millisecond with of audio. For an audio channel running at
+// 48000 Hz, that's 48 frames.
+using MIXER_Handler = std::function<void(uint16_t frames)>;
 
 enum BlahModes {
 	MIXER_8MONO,MIXER_8STEREO,

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -778,7 +778,8 @@ static void GUS_DMA_Callback(DmaChannel * chan,DMAEvent event) {
 	chan->Register_Callback(0);
 }
 
-static void GUS_CallBack(Bitu len) {
+static void GUS_CallBack(uint16_t len)
+{
 	Bit32s buffer[MIXER_BUFSIZE][2];
 	memset(buffer, 0, len * sizeof(buffer[0]));
 
@@ -879,7 +880,7 @@ public:
 		myGUS.gRegData=0x1;
 		GUSReset();
 		myGUS.gRegData=0x0;
-		int portat = 0x200+GUS_BASE;
+		const Bitu portat = 0x200 + GUS_BASE;
 
 		// ULTRASND=Port,DMA1,DMA2,IRQ1,IRQ2
 		// [GUS port], [GUS DMA (recording)], [GUS DMA (playback)], [GUS IRQ (playback)], [GUS IRQ (MIDI)]


### PR DESCRIPTION
This gives us the option to bind a member function as a callback, letting us refactor away from the ever-present globals and static access functions, to bread-and-butter "standard" classes.

This only touches the prototypes - and does not actually change all the _users of the callback_ to using std::function (instead, simply giving us the option if we wish).  These are critical for the GUS feature branch which includes some light refactoring, but I wanted to lift them out because they are generalized and do not affect functionality.  This will also de-scope the GUS feature branch back to only touching the GUS-code.

Note that I only upgraded the callbacks needed to cleanup the GUS structure, specifically: the Mixer's callback, DMA callback, and IO handler's --- (there are still a lot more C-style callback typedef's in other areas)

Oh - I also reduced the audio callback's number of requested frames from `Bitu` to `uint16_t`, because this value at most should be around 44 or 48 (frames-per-millisecond) or less.  The audio buffers themselves are typically only a couple thousand elements, with the largest being the mixer's primary buffer which is [16384] in size.. so capping this at a uint16_t also keeps potentially crashes from reading deep into unknown memory-land... we'll only over-read by ~48,000 bytes instead of GB or TBs :-). 

@dreamer , I also wanted to upgrade `typedef void (* PIC_EventHandler)(Bitu val)` in **pic.h** to `typedef std::function<void(Bitu val)> PIC_EventHandler`, however **pic.cpp:434** `pic_event == handler` blocked this because apparently `std::function` isn't comparable.

People recommend adding some identifier tag or member that you can retrieve from the std::function object and then compare that instead (sounds ugly?) but that would have required actual code changes beyond just the interfaces; so didn't attempt it.  Mentioning it here if you've hit such problems before.