### PR TITLE
Add effc++ and extra-semi warnings to the CI gating

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,15 +19,15 @@ jobs:
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 24
+            max_warnings: 330
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 329
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 26
+            max_warnings: 329
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
@@ -36,17 +36,17 @@ jobs:
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 134
+            max_warnings: 442
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 26
+            max_warnings: 326
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 171
+            max_warnings: 476
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 9
+            max_warnings: 50
           - name: Ubuntu, +debug
             os: ubuntu-latest
             flags: -c gcc

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 7
+            max_warnings: 44
           - name: GCC-9
             flags: -c gcc -v 9
             max_warnings: 329

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
             max_warnings: 7
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 26
+            max_warnings: 329
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 486
+          MAX_BUGS: 485
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -11,7 +11,7 @@ fi
 TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 
 cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
-cxxonly_debug+=("${cxxonly[@]}" -Weffc++)
+cxxonly_debug+=("${cxxonly[@]}" -Weffc++ -Wextra-semi)
 
 # Note: no-math-errno improves optimization of C/C++ math functions
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -10,15 +10,17 @@ fi
 # Release-type additions
 TYPES+=(release debug warnmore pgotrain optinfo msan usan)
 
+cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
+cxxonly_debug+=("${cxxonly[@]}" -Weffc++)
+
 # Note: no-math-errno improves optimization of C/C++ math functions
 cflags_release+=("${cflags[@]}" -DNDEBUG -O3 -fno-math-errno
                  -fno-strict-aliasing)
-cflags_debug+=("${cflags[@]}" -g -fno-omit-frame-pointer)
 
 cflags_warnmore+=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
                   -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion
                   -Wdouble-promotion -Wformat=2 -fstrict-aliasing -Wstrict-aliasing=2)
-cxxonly_warnmore+=(-Wnon-virtual-dtor -Woverloaded-virtual)
+cxxonly_warnmore+=("${cxxonly_debug[@]}" -Wnon-virtual-dtor -Woverloaded-virtual)
 
 cflags_pgotrain+=("${cflags_debug[@]}" -fprofile-instr-generate
                   -fcoverage-mapping)

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -10,7 +10,9 @@ TYPES+=(release debug warnmore pgotrain fdotrain optinfo
         asan uasan usan tsan)
 
 cflags+=(-fdiagnostics-color=auto)
+
 cflags_debug+=("${cflags[@]}" -g -fstack-protector -fno-omit-frame-pointer)
+cxxonly_debug+=("${cxxonly[@]}" -Weffc++)
 
 # Note: associative-math is needed for vectorization of floating point
 #       calculations, which also relies on no-signed-zeros and
@@ -24,7 +26,7 @@ cflags_warnmore+=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                   -Wlogical-op -Wmisleading-indentation -Wnull-dereference
                   -Wshadow -Wunused -fstrict-aliasing -Wstrict-aliasing=2
                   -Wextra-semi)
-cxxonly_warnmore+=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual
+cxxonly_warnmore+=("${cxxonly_debug[@]}" -Wnon-virtual-dtor -Woverloaded-virtual
                    -Wuseless-cast)
 
 cflags_pgotrain+=("${cflags_debug[@]}" -pg -ftree-vectorize)


### PR DESCRIPTION
Motivations for both changes are explained in detail in the commit messages.

It took us a while to clean up the codebase to the level when this is workable in CI; new contributors won't be bitten by effc++ warning appearing after including a random header file. I think most of the remaining fixes will happen during normal development from now on, but few of effc++ warnings I looked up were quite nasty (e.g. the ones in OPL code - there are ~50 warnings in there, and cleanup won't be trivial).

Clang is bad at detecting effc++ warnings (all the warnings it uses are fixed in our code already); GCC 5.4 does not support extra-semi unfortunately, but as it turns out Clang does it better than GCC in general - and we only need it enabled in one of the compilers to be part of the CI :)