### PR TITLE
Use better algorithm for displaying columns in LS command

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -862,13 +862,16 @@ void DOS_Shell::CMD_LS(char *args)
 }
 
 struct copysource {
-	std::string filename;
-	bool concat;
-	copysource(std::string filein,bool concatin):
-		filename(filein),concat(concatin){ };
-	copysource():filename(""),concat(false){ };
-};
+	std::string filename = "";
+	bool concat = false;
 
+	copysource() = default;
+
+	copysource(const std::string &file, bool cat)
+	        : filename(file),
+	          concat(cat)
+	{}
+};
 
 void DOS_Shell::CMD_COPY(char * args) {
 	HELP("COPY");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -834,26 +834,29 @@ void DOS_Shell::CMD_LS(char *args)
 	const int column_sep = 2; // chars separating columns
 	const auto word_widths = to_name_lengths(results, column_sep);
 	const auto column_widths = calc_column_widths(word_widths, column_sep + 1);
+	const size_t cols = column_widths.size();
 
 	size_t w_count = 0;
 
 	for (const auto &entry : results) {
 		std::string name = entry.name;
 		const bool is_dir = entry.attr & DOS_ATTR_DIRECTORY;
+		const size_t col = w_count % cols;
+		const int cw = column_widths[col];
 
 		if (is_dir) {
 			upcase(name);
-			WriteOut("\033[34;1m%-15s\033[0m", name.c_str());
+			WriteOut("\033[34;1m%-*s\033[0m", cw, name.c_str());
 		} else {
 			lowcase(name);
 			if (is_executable_filename(name))
-				WriteOut("\033[32;1m%-15s\033[0m", name.c_str());
+				WriteOut("\033[32;1m%-*s\033[0m", cw, name.c_str());
 			else
-				WriteOut("%-15s", name.c_str());
+				WriteOut("%-*s", cw, name.c_str());
 		}
 
 		++w_count;
-		if (w_count % 5 == 0)
+		if (w_count % cols == 0)
 			WriteOut_NoParsing("\n");
 	}
 	dos.dta(original_dta);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -744,6 +744,8 @@ void DOS_Shell::CMD_DIR(char * args) {
 
 void DOS_Shell::CMD_LS(char *args)
 {
+	using namespace std::string_literals;
+
 	HELP("LS");
 
 	const RealPt original_dta = dos.dta();
@@ -767,6 +769,8 @@ void DOS_Shell::CMD_LS(char *args)
 		DtaResult result;
 		dta.GetResult(result.name, result.size, result.date,
 		              result.time, result.attr);
+		if (result.name == "."s || result.name == ".."s)
+			continue;
 		results.push_back(result);
 	} while ((ret = DOS_FindNext()) == true);
 
@@ -775,9 +779,6 @@ void DOS_Shell::CMD_LS(char *args)
 	for (const auto &entry : results) {
 		std::string name = entry.name;
 		const bool is_dir = entry.attr & DOS_ATTR_DIRECTORY;
-
-		if (name == "." || name == "..")
-			continue;
 
 		if (is_dir) {
 			upcase(name);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -482,6 +482,19 @@ static std::string to_search_pattern(const char *arg)
 	return pattern;
 }
 
+// Map a vector of dir contents to a vector of word widths.
+static std::vector<int> to_name_lengths(const std::vector<DtaResult> &dir_contents,
+                                        int padding)
+{
+	std::vector<int> ret;
+	ret.reserve(dir_contents.size());
+	for (const auto &entry : dir_contents) {
+		const int len = static_cast<int>(strlen(entry.name));
+		ret.push_back(len + padding);
+	}
+	return ret;
+}
+
 void DOS_Shell::CMD_DIR(char * args) {
 	HELP("DIR");
 	char numformat[16];
@@ -773,6 +786,9 @@ void DOS_Shell::CMD_LS(char *args)
 			continue;
 		results.push_back(result);
 	} while ((ret = DOS_FindNext()) == true);
+
+	const int column_sep = 2; // chars separating columns
+	const auto word_widths = to_name_lengths(results, column_sep);
 
 	size_t w_count = 0;
 


### PR DESCRIPTION
This change was suggested by @Wengier in #476 (specifically here: https://github.com/dosbox-staging/dosbox-staging/blob/ww/dirls/src/shell/shell_cmds.cpp#L954); I modified this algorithm and split it out of LS command into a separate function. Some changes as compared to the original:

- Split out of LS, generalize, and put into separate functions (thus we'll be able to use it for improving `dir /w` later on)
- Preprocess entries to pre-calculate widths instead of creating *O(NxM)* temporary std::string objects (N - columns, M - words)
- The algorithm now bails out early as soon as column number is detected to be too high - it does not reduce the pessimistic case (still *O(NxM)*), but *average* case is now closer to *O(N+M)* - thus allowing us to consider more columns than 10.
- Use an actual max number of columns that fit into the terminal size - original 10 columns was not enough when directory is filled with files using very short names

I strongly recommend reviewing commit-by commit (commit messages include additional implementation deliberations).

@Wengier I stripped this functionality out of your review to showcase the size and scope of a single PR. Please review it and look at how I split commits and organized code. If you're the author of an original algorithm for column detection I'll happily add you as a co-author in f50f1db. And of course I'll be happy to hear your thoughts about new implementation :)

@kcgen Please make sure the algorithm is clear - I hope I picked the good naming and organized the code clearly; I am not sure about naming of lambda expression `too_many_columns` (and not sure if maybe changing the values returned by this lambda). 

I tested new algorithm with textutils to see if it behaves correctly in 132-column modes and it seemed to work fine.

During implementation I noticed interesting difference in our `ls` implementation compared to GNU `ls` (unix ls orders files by columns instead of rows, which makes more sense).
