### PR TITLE
Replace the IO Handler sparse arrays with unordered maps of std::functions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,7 @@ jobs:
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 442
+            max_warnings: 439
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-latest
             flags: -c gcc
@@ -47,7 +47,7 @@ jobs:
             os: ubuntu-latest
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 476
+            max_warnings: 473
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 321
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2185
+            max_warnings: 2199
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/include/inout.h
+++ b/include/inout.h
@@ -23,8 +23,6 @@
 #include <functional>
 #include <unordered_map>
 
-#define IO_MAX (64*1024+3)
-
 #define IO_MB	0x1 // Byte (8-bit)
 #define IO_MW	0x2 // Word (16-bit)
 #define IO_MD	0x4 // DWord (32-bit)

--- a/include/inout.h
+++ b/include/inout.h
@@ -64,16 +64,12 @@ io_val_t IO_ReadD(io_port_t port);
  * The io objects will remove itself on destruction.*/
 class IO_Base{
 protected:
-	bool installed;
-	Bitu m_port, m_mask,m_range;
-public:
-	IO_Base()
-	: installed(false),
-	  m_port(0),
-	  m_mask(0),
-	  m_range(0)
-{}
+	bool installed = false;
+	io_port_t m_port = 0u;
+	Bitu m_mask = 0u;
+	Bitu m_range = 0u;
 };
+
 class IO_ReadHandleObject: private IO_Base{
 public:
 	void Install(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);

--- a/include/inout.h
+++ b/include/inout.h
@@ -21,6 +21,7 @@
 #define DOSBOX_INOUT_H
 
 #include <functional>
+#include <unordered_map>
 
 #define IO_MAX (64*1024+3)
 
@@ -41,8 +42,8 @@ using io_val_t_proposed = uint32_t; // Handling exists up to a dword (or less)
 using IO_ReadHandler = std::function<Bitu(io_port_t port, Bitu iolen)>;
 using IO_WriteHandler = std::function<void(io_port_t port, io_val_t val, Bitu iolen)>;
 
-extern IO_WriteHandler io_writehandlers[IO_SIZES][IO_MAX];
-extern IO_ReadHandler io_readhandlers[IO_SIZES][IO_MAX];
+extern std::unordered_map<io_port_t, IO_WriteHandler> io_writehandlers[IO_SIZES];
+extern std::unordered_map<io_port_t, IO_ReadHandler> io_readhandlers[IO_SIZES];
 
 void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
 void IO_RegisterWriteHandler(io_port_t port,

--- a/include/inout.h
+++ b/include/inout.h
@@ -30,28 +30,31 @@
 #define IO_MA	(IO_MB | IO_MW | IO_MD ) // All three
 #define IO_SIZES 3 // byte, word, and dword
 
-using IO_ReadHandler = std::function<Bitu(Bitu port, Bitu iolen)>;
-using IO_WriteHandler = std::function<void(Bitu port, Bitu val, Bitu iolen)>;
+using io_port_t = Bitu;
+using io_val_t = Bitu;
+
+using IO_ReadHandler = std::function<Bitu(io_port_t port, Bitu iolen)>;
+using IO_WriteHandler = std::function<void(io_port_t port, io_val_t val, Bitu iolen)>;
 
 extern IO_WriteHandler io_writehandlers[IO_SIZES][IO_MAX];
 extern IO_ReadHandler io_readhandlers[IO_SIZES][IO_MAX];
 
-void IO_RegisterReadHandler(Bitu port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
-void IO_RegisterWriteHandler(Bitu port,
+void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
+void IO_RegisterWriteHandler(io_port_t port,
                              IO_WriteHandler handler,
                              Bitu mask,
                              Bitu range = 1);
 
-void IO_FreeReadHandler(Bitu port,Bitu mask,Bitu range=1);
-void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range=1);
+void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range = 1);
+void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range = 1);
 
-void IO_WriteB(Bitu port,Bitu val);
-void IO_WriteW(Bitu port,Bitu val);
-void IO_WriteD(Bitu port,Bitu val);
+void IO_WriteB(io_port_t port, io_val_t val);
+void IO_WriteW(io_port_t port, io_val_t val);
+void IO_WriteD(io_port_t port, io_val_t val);
 
-Bitu IO_ReadB(Bitu port);
-Bitu IO_ReadW(Bitu port);
-Bitu IO_ReadD(Bitu port);
+io_val_t IO_ReadB(io_port_t port);
+io_val_t IO_ReadW(io_port_t port);
+io_val_t IO_ReadD(io_port_t port);
 
 /* Classes to manage the IO objects created by the various devices.
  * The io objects will remove itself on destruction.*/
@@ -69,21 +72,22 @@ public:
 };
 class IO_ReadHandleObject: private IO_Base{
 public:
-	void Install(Bitu port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
+	void Install(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
 	void Uninstall();
 	~IO_ReadHandleObject();
 };
 class IO_WriteHandleObject: private IO_Base{
 public:
-	void Install(Bitu port, IO_WriteHandler handler, Bitu mask, Bitu range = 1);
+	void Install(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range = 1);
 	void Uninstall();
 	~IO_WriteHandleObject();
 };
 
-static INLINE void IO_Write(Bitu port,Bit8u val) {
+static INLINE void IO_Write(io_port_t port, Bit8u val)
+{
 	IO_WriteB(port,val);
 }
-static INLINE Bit8u IO_Read(Bitu port){
+static INLINE Bit8u IO_Read(io_port_t port){
 	return (Bit8u)IO_ReadB(port);
 }
 

--- a/include/inout.h
+++ b/include/inout.h
@@ -30,8 +30,13 @@
 #define IO_MA	(IO_MB | IO_MW | IO_MD ) // All three
 #define IO_SIZES 3 // byte, word, and dword
 
+// Existing type sizes
 using io_port_t = Bitu;
 using io_val_t = Bitu;
+
+// Proposed type types
+using io_port_t_proposed = uint16_t; // DOS only supports 16-bit port addresses
+using io_val_t_proposed = uint32_t; // Handling exists up to a dword (or less)
 
 using IO_ReadHandler = std::function<Bitu(io_port_t port, Bitu iolen)>;
 using IO_WriteHandler = std::function<void(io_port_t port, io_val_t val, Bitu iolen)>;

--- a/include/inout.h
+++ b/include/inout.h
@@ -24,19 +24,23 @@
 
 #define IO_MAX (64*1024+3)
 
-#define IO_MB	0x1
-#define IO_MW	0x2
-#define IO_MD	0x4
-#define IO_MA	(IO_MB | IO_MW | IO_MD )
+#define IO_MB	0x1 // Byte (8-bit)
+#define IO_MW	0x2 // Word (16-bit)
+#define IO_MD	0x4 // DWord (32-bit)
+#define IO_MA	(IO_MB | IO_MW | IO_MD ) // All three
+#define IO_SIZES 3 // byte, word, and dword
 
 using IO_ReadHandler = std::function<Bitu(Bitu port, Bitu iolen)>;
 using IO_WriteHandler = std::function<void(Bitu port, Bitu val, Bitu iolen)>;
 
-extern IO_WriteHandler io_writehandlers[3][IO_MAX];
-extern IO_ReadHandler io_readhandlers[3][IO_MAX];
+extern IO_WriteHandler io_writehandlers[IO_SIZES][IO_MAX];
+extern IO_ReadHandler io_readhandlers[IO_SIZES][IO_MAX];
 
-void IO_RegisterReadHandler(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range=1);
-void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range=1);
+void IO_RegisterReadHandler(Bitu port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
+void IO_RegisterWriteHandler(Bitu port,
+                             IO_WriteHandler handler,
+                             Bitu mask,
+                             Bitu range = 1);
 
 void IO_FreeReadHandler(Bitu port,Bitu mask,Bitu range=1);
 void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range=1);
@@ -65,13 +69,13 @@ public:
 };
 class IO_ReadHandleObject: private IO_Base{
 public:
-	void Install(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range=1);
+	void Install(Bitu port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
 	void Uninstall();
 	~IO_ReadHandleObject();
 };
 class IO_WriteHandleObject: private IO_Base{
 public:
-	void Install(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range=1);
+	void Install(Bitu port, IO_WriteHandler handler, Bitu mask, Bitu range = 1);
 	void Uninstall();
 	~IO_WriteHandleObject();
 };

--- a/include/inout.h
+++ b/include/inout.h
@@ -20,6 +20,8 @@
 #ifndef DOSBOX_INOUT_H
 #define DOSBOX_INOUT_H
 
+#include <functional>
+
 #define IO_MAX (64*1024+3)
 
 #define IO_MB	0x1
@@ -27,14 +29,14 @@
 #define IO_MD	0x4
 #define IO_MA	(IO_MB | IO_MW | IO_MD )
 
-typedef Bitu IO_ReadHandler(Bitu port,Bitu iolen);
-typedef void IO_WriteHandler(Bitu port,Bitu val,Bitu iolen);
+using IO_ReadHandler = std::function<Bitu(Bitu port, Bitu iolen)>;
+using IO_WriteHandler = std::function<void(Bitu port, Bitu val, Bitu iolen)>;
 
-extern IO_WriteHandler * io_writehandlers[3][IO_MAX];
-extern IO_ReadHandler * io_readhandlers[3][IO_MAX];
+extern IO_WriteHandler io_writehandlers[3][IO_MAX];
+extern IO_ReadHandler io_readhandlers[3][IO_MAX];
 
-void IO_RegisterReadHandler(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);
-void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range=1);
+void IO_RegisterReadHandler(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range=1);
+void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range=1);
 
 void IO_FreeReadHandler(Bitu port,Bitu mask,Bitu range=1);
 void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range=1);
@@ -63,13 +65,13 @@ public:
 };
 class IO_ReadHandleObject: private IO_Base{
 public:
-	void Install(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);
+	void Install(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range=1);
 	void Uninstall();
 	~IO_ReadHandleObject();
 };
 class IO_WriteHandleObject: private IO_Base{
 public:
-	void Install(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range=1);
+	void Install(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range=1);
 	void Uninstall();
 	~IO_WriteHandleObject();
 };

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -515,7 +515,18 @@ public:
 	}
 	~IO()
 	{
-		//Same as the constructor ?
+		uint32_t total_bytes = 0u;
+		for (uint8_t i = 0; i < 3; ++i) {
+			const int readers = IO_MAX;
+			const int writers = IO_MAX;
+			DEBUG_LOG_MSG("IOBUS: Releasing %d read and %d write %d-bit port handlers",
+			              readers, writers, 8 << i);
+			total_bytes += readers * sizeof(void*);
+			total_bytes += writers * sizeof(void*);
+		}
+		DEBUG_LOG_MSG("IOBUS: Handlers consumed %u total bytes", total_bytes);
+		IO_FreeReadHandler(0, IO_MA, IO_MAX);
+		IO_FreeWriteHandler(0, IO_MA, IO_MAX);
 	}
 };
 

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -27,8 +27,8 @@
 
 //#define ENABLE_PORTLOG
 
-IO_WriteHandler * io_writehandlers[3][IO_MAX];
-IO_ReadHandler * io_readhandlers[3][IO_MAX];
+IO_WriteHandler io_writehandlers[3][IO_MAX];
+IO_ReadHandler io_readhandlers[3][IO_MAX];
 
 static Bitu IO_ReadBlocked(Bitu /*port*/,Bitu /*iolen*/) {
 	return ~0;
@@ -72,7 +72,7 @@ void IO_WriteDefault(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-void IO_RegisterReadHandler(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range) {
+void IO_RegisterReadHandler(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range) {
 	while (range--) {
 		if (mask&IO_MB) io_readhandlers[0][port]=handler;
 		if (mask&IO_MW) io_readhandlers[1][port]=handler;
@@ -81,7 +81,7 @@ void IO_RegisterReadHandler(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu ra
 	}
 }
 
-void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range) {
+void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range) {
 	while (range--) {
 		if (mask&IO_MB) io_writehandlers[0][port]=handler;
 		if (mask&IO_MW) io_writehandlers[1][port]=handler;
@@ -108,7 +108,7 @@ void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range) {
 	}
 }
 
-void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range) {
+void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range) {
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -129,7 +129,7 @@ IO_ReadHandleObject::~IO_ReadHandleObject(){
 	Uninstall();
 }
 
-void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler * handler,Bitu mask,Bitu range) {
+void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range) {
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -521,8 +521,8 @@ public:
 			const int writers = IO_MAX;
 			DEBUG_LOG_MSG("IOBUS: Releasing %d read and %d write %d-bit port handlers",
 			              readers, writers, 8 << i);
-			total_bytes += readers * sizeof(void*);
-			total_bytes += writers * sizeof(void*);
+			total_bytes += readers * sizeof(IO_ReadHandler);
+			total_bytes += writers * sizeof(IO_WriteHandler);
 		}
 		DEBUG_LOG_MSG("IOBUS: Handlers consumed %u total bytes", total_bytes);
 		IO_FreeReadHandler(0, IO_MA, IO_MAX);

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -27,8 +27,8 @@
 
 //#define ENABLE_PORTLOG
 
-IO_WriteHandler io_writehandlers[3][IO_MAX];
-IO_ReadHandler io_readhandlers[3][IO_MAX];
+IO_WriteHandler io_writehandlers[IO_SIZES][IO_MAX];
+IO_ReadHandler io_readhandlers[IO_SIZES][IO_MAX];
 
 static Bitu IO_ReadBlocked(Bitu /*port*/,Bitu /*iolen*/) {
 	return ~0;
@@ -72,7 +72,8 @@ void IO_WriteDefault(Bitu port,Bitu val,Bitu iolen) {
 	}
 }
 
-void IO_RegisterReadHandler(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range) {
+void IO_RegisterReadHandler(Bitu port, IO_ReadHandler handler, Bitu mask, Bitu range)
+{
 	while (range--) {
 		if (mask&IO_MB) io_readhandlers[0][port]=handler;
 		if (mask&IO_MW) io_readhandlers[1][port]=handler;
@@ -81,7 +82,8 @@ void IO_RegisterReadHandler(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu rang
 	}
 }
 
-void IO_RegisterWriteHandler(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range) {
+void IO_RegisterWriteHandler(Bitu port, IO_WriteHandler handler, Bitu mask, Bitu range)
+{
 	while (range--) {
 		if (mask&IO_MB) io_writehandlers[0][port]=handler;
 		if (mask&IO_MW) io_writehandlers[1][port]=handler;
@@ -108,7 +110,8 @@ void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range) {
 	}
 }
 
-void IO_ReadHandleObject::Install(Bitu port,IO_ReadHandler handler,Bitu mask,Bitu range) {
+void IO_ReadHandleObject::Install(Bitu port, IO_ReadHandler handler, Bitu mask, Bitu range)
+{
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -129,7 +132,8 @@ IO_ReadHandleObject::~IO_ReadHandleObject(){
 	Uninstall();
 }
 
-void IO_WriteHandleObject::Install(Bitu port,IO_WriteHandler handler,Bitu mask,Bitu range) {
+void IO_WriteHandleObject::Install(Bitu port, IO_WriteHandler handler, Bitu mask, Bitu range)
+{
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -516,7 +520,7 @@ public:
 	~IO()
 	{
 		uint32_t total_bytes = 0u;
-		for (uint8_t i = 0; i < 3; ++i) {
+		for (uint8_t i = 0; i < IO_SIZES; ++i) {
 			const int readers = IO_MAX;
 			const int writers = IO_MAX;
 			DEBUG_LOG_MSG("IOBUS: Releasing %d read and %d write %d-bit port handlers",

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -30,6 +30,14 @@
 IO_WriteHandler io_writehandlers[IO_SIZES][IO_MAX];
 IO_ReadHandler io_readhandlers[IO_SIZES][IO_MAX];
 
+void port_within_proposed(io_port_t port) {
+	assert(port < std::numeric_limits<io_port_t_proposed>::max());
+}
+
+void val_within_proposed(io_val_t val) {
+	assert(val <= std::numeric_limits<io_val_t_proposed>::max());
+}
+
 static io_val_t ReadBlocked(io_port_t /*port*/, Bitu /*iolen*/)
 {
 	return ~0;
@@ -40,6 +48,8 @@ static void WriteBlocked(io_port_t /*port*/, io_val_t /*val*/, Bitu /*iolen*/)
 
 static io_val_t ReadDefault(io_port_t port, Bitu iolen)
 {
+	port_within_proposed(port);
+
 	switch (iolen) {
 	case 1:
 		LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected read from %04xh; blocking",
@@ -60,6 +70,9 @@ static io_val_t ReadDefault(io_port_t port, Bitu iolen)
 
 static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen)
 {
+	port_within_proposed(port);
+	val_within_proposed(val);
+
 	switch (iolen) {
 	case 1:
 		LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected write of %u to %04xh; blocking",
@@ -80,6 +93,8 @@ static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen)
 
 void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range)
 {
+	port_within_proposed(port);
+
 	while (range--) {
 		if (mask&IO_MB) io_readhandlers[0][port]=handler;
 		if (mask&IO_MW) io_readhandlers[1][port]=handler;
@@ -90,6 +105,8 @@ void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, B
 
 void IO_RegisterWriteHandler(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range)
 {
+	port_within_proposed(port);
+
 	while (range--) {
 		if (mask&IO_MB) io_writehandlers[0][port]=handler;
 		if (mask&IO_MW) io_writehandlers[1][port]=handler;
@@ -100,6 +117,8 @@ void IO_RegisterWriteHandler(io_port_t port, IO_WriteHandler handler, Bitu mask,
 
 void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range)
 {
+	port_within_proposed(port);
+
 	while (range--) {
 		if (mask&IO_MB) io_readhandlers[0][port] = ReadDefault;
 		if (mask&IO_MW) io_readhandlers[1][port] = ReadDefault;
@@ -110,6 +129,8 @@ void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range)
 
 void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range)
 {
+	port_within_proposed(port);
+
 	while (range--) {
 		if (mask&IO_MB) io_writehandlers[0][port] = WriteDefault;
 		if (mask&IO_MW) io_writehandlers[1][port] = WriteDefault;
@@ -120,6 +141,8 @@ void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range)
 
 void IO_ReadHandleObject::Install(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range)
 {
+	port_within_proposed(port);
+
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -142,6 +165,8 @@ IO_ReadHandleObject::~IO_ReadHandleObject(){
 
 void IO_WriteHandleObject::Install(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range)
 {
+	port_within_proposed(port);
+
 	if(!installed) {
 		installed=true;
 		m_port=port;
@@ -239,6 +264,9 @@ static Bit8u crtc_index = 0;
 const char* const len_type[] = {" 8","16","32"};
 void log_io(Bitu width, bool write, io_port_t port, io_val_t val)
 {
+	port_within_proposed(port);
+	val_within_proposed(val);
+
 	switch(width) {
 	case 0:
 		val&=0xff;
@@ -302,6 +330,9 @@ void log_io(Bitu width, bool write, io_port_t port, io_val_t val)
 
 void IO_WriteB(io_port_t port, io_val_t val)
 {
+	port_within_proposed(port);
+	val_within_proposed(val);
+
 	log_io(0, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
 		LazyFlags old_lflags;
@@ -339,6 +370,9 @@ void IO_WriteB(io_port_t port, io_val_t val)
 
 void IO_WriteW(io_port_t port, io_val_t val)
 {
+	port_within_proposed(port);
+	val_within_proposed(val);
+
 	log_io(1, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
 		LazyFlags old_lflags;
@@ -376,6 +410,9 @@ void IO_WriteW(io_port_t port, io_val_t val)
 
 void IO_WriteD(io_port_t port, io_val_t val)
 {
+	port_within_proposed(port);
+	val_within_proposed(val);
+
 	log_io(2, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
 		LazyFlags old_lflags;
@@ -410,6 +447,8 @@ void IO_WriteD(io_port_t port, io_val_t val)
 
 io_val_t IO_ReadB(io_port_t port)
 {
+	port_within_proposed(port);
+
 	io_val_t retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
 		LazyFlags old_lflags;
@@ -450,6 +489,8 @@ io_val_t IO_ReadB(io_port_t port)
 
 io_val_t IO_ReadW(io_port_t port)
 {
+	port_within_proposed(port);
+
 	io_val_t retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
 		LazyFlags old_lflags;
@@ -489,6 +530,8 @@ io_val_t IO_ReadW(io_port_t port)
 
 io_val_t IO_ReadD(io_port_t port)
 {
+	port_within_proposed(port);
+
 	io_val_t retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
 		LazyFlags old_lflags;


### PR DESCRIPTION
This PR replaces the six hard-coded very sparse arrays of C function pointers with unordered maps of C++11 `std::functions`. 

The latter point (using `std::function`) was the primary motivation, as these are compatible with raw pointers and additionally allows regular class member functions to be used as callbacks, unlike raw pointers that require callbacks to be static functions accessing global variables - both of which constrain class design and add code smells.

In doing so, we also realized size and speed improvements. 

- Block Started by Symbol size (BSS), which tallies static variable sizes, is reduced by 3 MB (or 3145536 bytes)
- The six IO handlers now weight in at anywhere from 8KB to 14KB combined - enough to sit in most processors' L1 data-cache
- Startup time is reduced by up to 30%, which shows just how heavy these IO handler arrays were (runtime performance after startup is unaffected).

**Before:**

``` text
Diagnostic:
IOBUS: Releasing 65539 read and 65539 write 8-bit port handlers
IOBUS: Releasing 65539 read and 65539 write 16-bit port handlers
IOBUS: Releasing 65539 read and 65539 write 32-bit port handlers
IOBUS: Handlers consumed 3145872 total bytes

size src/dosbox:
text     data    bss       dec       hex      filename
3885170  202112  48813344  52900626  3273312  src/dosbox

Start and quit 0.220 s
```

**After:**

``` text
Diagnostic:
IOBUS: Releasing 136 read and 130 write 8-bit port handlers
IOBUS: Releasing 50 read and 52 write 16-bit port handlers
IOBUS: Releasing 33 read and 35 write 32-bit port handlers
IOBUS: Handlers consumed 14288 total bytes

size src/dosbox:
text     data    bss       dec       hex      filename
3910444  202216  45667808  49780468  2f796f4  src/dosbox

Startup and quit: 0.145 s
```

Some test runs produce even fewer handlers, I guess if fewer subsystems were needed:

``` text
IOBUS: Releasing 58 read and 50 write 8-bit port handlers
IOBUS: Releasing 33 read and 38 write 16-bit port handlers
IOBUS: Releasing 33 read and 35 write 32-bit port handlers
IOBUS: Handlers consumed 8240 total bytes
```
