### PR TITLE
Cleanup CPU dynrec cache (part 3)

### DIFF
--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -186,7 +186,7 @@ CacheBlockDynRec * LinkBlocks(BlockReturn ret) {
 	CacheBlockDynRec * block=NULL;
 	// the last instruction was a control flow modifying instruction
 	Bitu temp_ip=SegPhys(cs)+reg_eip;
-	CodePageHandlerDynRec * temp_handler=(CodePageHandlerDynRec *)get_tlb_readhandler(temp_ip);
+	CodePageHandler *temp_handler = (CodePageHandler *)get_tlb_readhandler(temp_ip);
 	if (temp_handler->flags & (cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16)) {
 		// see if the target is an already translated block
 		block=temp_handler->FindCacheBlock(temp_ip & 4095);
@@ -218,7 +218,7 @@ Bits CPU_Core_Dynrec_Run(void) {
 			return debugCallback;
 #endif
 
-		CodePageHandlerDynRec * chandler=0;
+		CodePageHandler *chandler = 0;
 		// see if the current page is present and contains code
 		if (GCC_UNLIKELY(MakeCodePage(ip_point,chandler))) {
 			// page not present, throw the exception

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -182,8 +182,9 @@ static_assert(offsetof(core_dynrec_t, readdata) % sizeof(uint32_t) == 0,
 
 #include "core_dynrec/decoder.h"
 
-CacheBlockDynRec * LinkBlocks(BlockReturn ret) {
-	CacheBlockDynRec * block=NULL;
+CacheBlock *LinkBlocks(BlockReturn ret)
+{
+	CacheBlock *block = NULL;
 	// the last instruction was a control flow modifying instruction
 	Bitu temp_ip=SegPhys(cs)+reg_eip;
 	CodePageHandler *temp_handler = (CodePageHandler *)get_tlb_readhandler(temp_ip);
@@ -230,7 +231,7 @@ Bits CPU_Core_Dynrec_Run(void) {
 		if (GCC_UNLIKELY(!chandler)) return CPU_Core_Normal_Run();
 
 		// find correct Dynamic Block to run
-		CacheBlockDynRec * block=chandler->FindCacheBlock(ip_point&4095);
+		CacheBlock *block = chandler->FindCacheBlock(ip_point & 4095);
 		if (!block) {
 			// no block found, thus translate the instruction stream
 			// unless the instruction is known to be modified

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -22,7 +22,7 @@
 #include "mem_unaligned.h"
 #include "types.h"
 
-class CodePageHandlerDynRec;	// forward
+class CodePageHandler; // forward
 
 // basic cache block representation
 class CacheBlockDynRec {
@@ -38,7 +38,7 @@ public:
 	}
 	struct {
 		Bit16u start,end;		// where in the page is the original code
-		CodePageHandlerDynRec * handler;			// page containing this code
+		CodePageHandler *handler;       // page containing this code
 	} page;
 	struct {
 		Bit8u * start;			// where in the cache are we
@@ -70,9 +70,9 @@ static struct {
 		CacheBlockDynRec * running;		// the last block that was entered for execution
 	} block;
 	Bit8u * pos;		// position in the cache block
-	CodePageHandlerDynRec * free_pages;		// pointer to the free list
-	CodePageHandlerDynRec * used_pages;		// pointer to the list of used pages
-	CodePageHandlerDynRec * last_page;		// the last used page
+	CodePageHandler *free_pages; // pointer to the free list
+	CodePageHandler *used_pages; // pointer to the list of used pages
+	CodePageHandler *last_page;  // the last used page
 } cache;
 
 // cache memory pointers, to be malloc'd later
@@ -83,11 +83,11 @@ static uint8_t *cache_code_link_blocks = nullptr;
 static CacheBlockDynRec *cache_blocks = nullptr;
 static CacheBlockDynRec link_blocks[2];		// default linking (specially marked)
 
-// the CodePageHandlerDynRec class provides access to the contained
+// the CodePageHandler class provides access to the contained
 // cache blocks and intercepts writes to the code for special treatment
-class CodePageHandlerDynRec : public PageHandler {
+class CodePageHandler : public PageHandler {
 public:
-	CodePageHandlerDynRec() : invalidation_map(nullptr) {}
+	CodePageHandler() : invalidation_map(nullptr) {}
 
 	void SetupAt(Bitu _phys_page,PageHandler * _old_pagehandler) {
 		// initialize this codepage handler
@@ -400,7 +400,7 @@ public:
 	// the write map, there are write_map[i] cache blocks that cover the byte at address i
 	Bit8u write_map[4096];
 	Bit8u * invalidation_map;
-	CodePageHandlerDynRec * next, * prev;	// page linking
+	CodePageHandler *next, *prev; // page linking
 private:
 	PageHandler * old_pagehandler;
 
@@ -666,7 +666,7 @@ static void cache_init(bool enable) {
 		cache.used_pages=0;
 		// setup the code pages
 		for (i=0;i<CACHE_PAGES;i++) {
-			CodePageHandlerDynRec * newpage=new CodePageHandlerDynRec();
+			CodePageHandler *newpage = new CodePageHandler();
 			newpage->next=cache.free_pages;
 			cache.free_pages=newpage;
 		}

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -31,7 +31,10 @@
 	instruction is encountered.
 */
 
-static CacheBlockDynRec * CreateCacheBlock(CodePageHandlerDynRec * codepage,PhysPt start,Bitu max_opcodes) {
+static CacheBlockDynRec *CreateCacheBlock(CodePageHandler *codepage,
+                                          PhysPt start,
+                                          Bitu max_opcodes)
+{
 	// initialize a load of variables
 	decode.code_start=start;
 	decode.code=start;

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -31,9 +31,7 @@
 	instruction is encountered.
 */
 
-static CacheBlockDynRec *CreateCacheBlock(CodePageHandler *codepage,
-                                          PhysPt start,
-                                          Bitu max_opcodes)
+static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bitu max_opcodes)
 {
 	// initialize a load of variables
 	decode.code_start=start;
@@ -594,7 +592,7 @@ restart_prefix:
 	// link to next block because the maximum number of opcodes has been reached
 	dyn_set_eip_end();
 	dyn_reduce_cycles();
-	gen_jmp_ptr(&decode.block->link[0].to,offsetof(CacheBlockDynRec,cache.start));
+	gen_jmp_ptr(&decode.block->link[0].to, offsetof(CacheBlock, cache.start));
 	dyn_closeblock();
     goto finish_block;
 core_close_block:

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -111,7 +111,7 @@ static struct DynDecode {
 
 	// the active page (containing the current byte of the instruction stream)
 	struct {
-		CodePageHandlerDynRec * code;
+		CodePageHandler *code;
 		Bitu index;		// index to the current byte of the instruction stream
 		Bit8u * wmap;	// write map that indicates code presence for every byte of this page
 		Bit8u * invmap;	// invalidation map
@@ -127,8 +127,8 @@ static struct DynDecode {
 	} modrm;
 } decode;
 
-
-static bool MakeCodePage(Bitu lin_addr,CodePageHandlerDynRec * &cph) {
+static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
+{
 	Bit8u rdval;
 	const Bitu cflag = cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16;
 	//Ensure page contains memory:
@@ -137,7 +137,7 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandlerDynRec * &cph) {
 	PageHandler * handler=get_tlb_readhandler(lin_addr);
 	if (handler->flags & PFLAG_HASCODE) {
 		// this is a codepage handler, make sure it matches current code size
-		cph=(CodePageHandlerDynRec *)handler;
+		cph = (CodePageHandler *)handler;
 		if (handler->flags & cflag) return false;
 		// wrong code size/stale dynamic code, drop it
 		cph->ClearRelease();
@@ -149,7 +149,7 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandlerDynRec * &cph) {
 		if (PAGING_ForcePageInit(lin_addr)) {
 			handler=get_tlb_readhandler(lin_addr);
 			if (handler->flags & PFLAG_HASCODE) {
-				cph=(CodePageHandlerDynRec *)handler;
+				cph = (CodePageHandler *)handler;
 				if (handler->flags & cflag) return false;
 				cph->ClearRelease();
 				cph=0;
@@ -183,7 +183,7 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandlerDynRec * &cph) {
 			}
 		}
 	}
-	CodePageHandlerDynRec * cpagehandler=cache.free_pages;
+	CodePageHandler *cpagehandler = cache.free_pages;
 	cache.free_pages=cache.free_pages->next;
 
 	// adjust previous and next page pointer

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -105,9 +105,9 @@ static struct DynDecode {
 	Bit8u seg_prefix;		// segment prefix (if seg_prefix_used==true)
 
 	// block that contains the first instruction translated
-	CacheBlockDynRec * block;
+	CacheBlock *block;
 	// block that contains the current byte of the instruction stream
-	CacheBlockDynRec * active_block;
+	CacheBlock *active_block;
 
 	// the active page (containing the current byte of the instruction stream)
 	struct {
@@ -209,7 +209,7 @@ static void decode_advancepage(void) {
 	Bitu faddr=decode.page.first << 12;
 	mem_readb(faddr);
 	MakeCodePage(faddr,decode.page.code);
-	CacheBlockDynRec * newblock=cache_getblock();
+	CacheBlock *newblock = cache_getblock();
 	decode.active_block->crossblock=newblock;
 	newblock->crossblock=decode.active_block;
 	decode.active_block=newblock;
@@ -262,7 +262,7 @@ static Bit32u decode_fetchd(void) {
 // codefetch functions
 static void INLINE decode_increase_wmapmask(Bitu size) {
 	Bitu mapidx;
-	CacheBlockDynRec* activecb=decode.active_block; 
+	CacheBlock *activecb = decode.active_block;
 	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
 		// no mask memory yet allocated, start with a small buffer
 		activecb->cache.wmapmask=(Bit8u*)malloc(START_WMMEM);

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1097,7 +1097,7 @@ static void dyn_sahf(void) {
 static void dyn_exit_link(Bits eip_change) {
 	gen_add_direct_word(&reg_eip,(decode.code-decode.code_start)+eip_change,decode.big_op);
 	dyn_reduce_cycles();
-	gen_jmp_ptr(&decode.block->link[0].to,offsetof(CacheBlockDynRec,cache.start));
+	gen_jmp_ptr(&decode.block->link[0].to, offsetof(CacheBlock, cache.start));
 	dyn_closeblock();
 }
 
@@ -1111,13 +1111,13 @@ static void dyn_branched_exit(BranchTypes btype,Bit32s eip_add) {
 
  	// Branch not taken
 	gen_add_direct_word(&reg_eip,eip_base,decode.big_op);
- 	gen_jmp_ptr(&decode.block->link[0].to,offsetof(CacheBlockDynRec,cache.start));
- 	gen_fill_branch(data);
+	gen_jmp_ptr(&decode.block->link[0].to, offsetof(CacheBlock, cache.start));
+	gen_fill_branch(data);
 
  	// Branch taken
 	gen_add_direct_word(&reg_eip,eip_base+eip_add,decode.big_op);
- 	gen_jmp_ptr(&decode.block->link[1].to,offsetof(CacheBlockDynRec,cache.start));
- 	dyn_closeblock();
+	gen_jmp_ptr(&decode.block->link[1].to, offsetof(CacheBlock, cache.start));
+	dyn_closeblock();
 }
 
 /*
@@ -1168,7 +1168,7 @@ static void dyn_loop(LoopTypes type) {
 		break;
 	}
 	gen_add_direct_word(&reg_eip,eip_base+eip_add,true);
-	gen_jmp_ptr(&decode.block->link[0].to,offsetof(CacheBlockDynRec,cache.start));
+	gen_jmp_ptr(&decode.block->link[0].to, offsetof(CacheBlock, cache.start));
 	if (branch1) {
 		gen_fill_branch(branch1);
 		MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
@@ -1178,7 +1178,7 @@ static void dyn_loop(LoopTypes type) {
 	// Branch taken
 	gen_fill_branch(branch2);
 	gen_add_direct_word(&reg_eip,eip_base,decode.big_op);
-	gen_jmp_ptr(&decode.block->link[1].to,offsetof(CacheBlockDynRec,cache.start));
+	gen_jmp_ptr(&decode.block->link[1].to, offsetof(CacheBlock, cache.start));
 	dyn_closeblock();
 }
 
@@ -1207,7 +1207,7 @@ static void dyn_call_near_imm(void) {
 	gen_mov_word_from_reg(FC_OP1,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),decode.big_op);
 
 	dyn_reduce_cycles();
-	gen_jmp_ptr(&decode.block->link[0].to,offsetof(CacheBlockDynRec,cache.start));
+	gen_jmp_ptr(&decode.block->link[0].to, offsetof(CacheBlock, cache.start));
 	dyn_closeblock();
 }
 

--- a/src/cpu/core_dynrec/risc_ppc.h
+++ b/src/cpu/core_dynrec/risc_ppc.h
@@ -46,7 +46,7 @@
 
 // register mapping
 enum HostReg {
-	HOST_R0=0,
+	HOST_R0 = 0,
 	HOST_R1,
 	HOST_R2,
 	HOST_R3,
@@ -73,7 +73,7 @@ enum HostReg {
 	HOST_R24,
 	HOST_R25,
 	HOST_R26,  // generic non-volatile (used for inline adc/sbb)
-	HOST_R27,  // points to current CacheBlockDynRec (decode.block)
+	HOST_R27,  // points to current CacheBlock (decode.block)
 	HOST_R28,  // points to fpu
 	HOST_R29,  // FC_ADDR
 	HOST_R30,  // points to Segs

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -72,7 +72,7 @@ enum HostReg {
 	HOST_R24,
 	HOST_R25,
 	HOST_R26, // generic non-volatile (used for inline adc/sbb)
-	HOST_R27, // points to current CacheBlockDynRec (decode.block)
+	HOST_R27, // points to current CacheBlock (decode.block)
 	HOST_R28, // points to fpu
 	HOST_R29, // FC_ADDR
 	HOST_R30, // points to Segs


### PR DESCRIPTION
At this point, the biggest difference between `cache.h` file from `core_dyn_x86` and `core_dynrec` is name of classes introduced by these headers.

`core_dyn_x86/cache.h` has `CodePageHandler` and `CacheBlock`.

When (many years ago) someone copied implementation to create `core_dynrec/cache.h`, these names in copied header were renamed to `CodePageHandlerDynRec` and `CacheBlockDynRec`.

There are tiny differences in implementation still (will be removed in the next PR), but during compilation time either one or another implementation is used - never both at the same time; so there's no point in having separate names.

This is a stepping stone towards having a single cache.h file for both implementations.