### PR TITLE
Let users set build variables with a copy-and-paste export line

### DIFF
--- a/scripts/automator/build/os-defaults
+++ b/scripts/automator/build/os-defaults
@@ -9,10 +9,13 @@ function pre_build() {
 	cd ../..
 	underline "Environment"
 	echo "[$(${CC} --version | head -1)]"
+	export_names=()
 	for v in "${VARIABLES[@]}"; do
 		vupper=$(upper "${v}")
 		echo "${vupper}=\"$(eval echo \$"${vupper}")\""
+		export_names+=($vupper)
 	done
+	echo "export ${export_names[@]}" CXXFLAGS=\"\${CFLAGS} \${CXXONLY}\"
 	underline "Launching"
 }
 


### PR DESCRIPTION
During the startup of the existing build script, it displays the environment variables to be used during the 'configure' and 'make' phases.

This commit adds an `export` line (see last line in the text-block below) to let users easily copy and paste that block of variables into their own shell, so they can user those settings when building other programs.

``` text
./scripts/build.sh -c clang -v 10 -t warnmore

Compiling a warnmore build using clang-10 on Linux-x86_64
=========================================================

Environment
-----------
[Ubuntu clang version 10.0.1-+rc4-1~oibaf~f]
AR="llvm-ar-10"
CC="ccache clang-10"
CXX="ccache clang++-10"
LD="llvm-link-10"
RANLIB="llvm-ranlib-10"
CFLAGS="-Wall -pipe -fpch-preprocess -g -fno-omit-frame-pointer -Wextra -Wshadow \
        -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wformat=2 \
        -Wsign-conversion -Wdouble-promotion -fstrict-aliasing -Wstrict-aliasing=2"
CXXONLY="-Weffc++ -Wextra-semi -Wnon-virtual-dtor -Woverloaded-virtual"
LDFLAGS=""
LIBS=""
export AR CC CXX LD RANLIB CFLAGS CXXONLY LDFLAGS LIBS CXXFLAGS="${CFLAGS} ${CXXONLY}"

```