### PR TITLE
New VER function to set reported DOS version (used by VER command and VER config option)

### DIFF
--- a/README
+++ b/README
@@ -565,11 +565,16 @@ MEM
 
 
 VER
+VER set version_number
 VER set major_version [minor_version]
   Display the current DOSBox version and reported DOS version
   (parameterless usage).
   Change the reported DOS version with the "set" parameter,
-  for example: "VER set 6 22" to have DOSBox report DOS 6.22 as version number.
+  either with a version number, or in "major_version [minor_version]" format.
+  For example: "VER set 7.1" to have DOSBox report DOS 7.1 as version number.
+  Alternatively, "VER set 6 22" lets DOSBox report DOS 6.22 as version number.
+  You can also set the DOS version via the "ver=" setting in the [dos] section
+  of the DOSBox configuration file so that DOSBox will activate it at start.
 
 
 CONFIG -writeconf filelocation

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -200,6 +200,8 @@ void DOS_KeyboardLayout_Init(Section* sec);
 
 bool DOS_LayoutKey(Bitu key, Bit8u flags1, Bit8u flags2, Bit8u flags3);
 
+DOS_Version DOS_ParseVersion(const char *word, const char *args);
+
 enum {
 	KEYB_NOERROR=0,
 	KEYB_FILENOTFOUND,

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1204,6 +1204,48 @@ static Bitu DOS_26Handler(void) {
     return CBRET_NONE;
 }
 
+DOS_Version DOS_ParseVersion(const char *word, const char *args)
+{
+	DOS_Version new_version;
+	assert(word != NULL && args != NULL);
+	if (!*args && !*word) { // Reset
+		new_version.major = 5;
+		new_version.minor = 0;
+	} else if (*args == 0 && *word && (strchr(word, '.') != 0)) {
+		// Allow usual syntax: ver set 7.1
+		const char *p = strchr(word, '.');
+		p++;
+		int minor = -1;
+		if (isdigit(*p)) {
+			int len = strlen(p);
+			// Get the first 2 characters as minor version if there are more
+			minor = atoi(len > 2 ? std::string(p).substr(0, 2).c_str() : p);
+			// If .1 as the minor version, regard it as .10
+			if (len == 1) minor *= 10;
+		}
+		// Return 0.0 for invalid DOS version
+		if (!isdigit(*word) || atoi(word) < 0 || atoi(word) > 30 || minor < 0 || (!atoi(word) && !minor)) {
+			 return {0, 0, 0};
+		} else {
+			new_version.major = static_cast<uint8_t>(atoi(word));
+			new_version.minor = static_cast<uint8_t>(minor);
+		}
+	} else { // Official DOSBox syntax: ver set 6 2
+		// If only an integer like 7, regard it as 7.0, or take args as minor version
+		int minor = *args ? (isdigit(*args) ? atoi(args) : -1) : 0;
+		// Get the first 2 digits of if there are more in the number
+		while (minor > 99)
+			minor /= 10;
+		// Return 0.0 for invalid DOS version
+		if (!isdigit(*word) || atoi(word) < 0 || atoi(word) > 30 || minor < 0 || (!atoi(word) && !minor)) {
+			 return {0, 0, 0};
+		} else {
+			new_version.major = static_cast<uint8_t>(atoi(word));
+			new_version.minor = static_cast<uint8_t>(minor);
+		}
+	}
+	return new_version;
+}
 
 class DOS:public Module_base{
 private:
@@ -1250,11 +1292,18 @@ public:
 		DOS_SetupMisc();							/* Some additional dos interrupts */
 		DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(25); /* Else the next call gives a warning. */
 		DOS_SetDefaultDrive(25);
-	
+
 		dos.version.major=5;
 		dos.version.minor=0;
 		dos.direct_output=false;
 		dos.internal_output=false;
+
+		const Section_prop* section = static_cast<Section_prop*>(configuration);
+		char *args = const_cast<char *>(section->Get_string("ver"));
+		const char* word = StripWord(args);
+		const auto new_version = DOS_ParseVersion(word, args);
+		if (new_version.major || new_version.minor)
+			dos.version = new_version;
 	}
 	~DOS(){
 		for (Bit16u i=0;i<DOS_DRIVES;i++) delete Drives[i];

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -837,6 +837,11 @@ void DOSBOX_Init(void) {
 	Pbool = secprop->Add_bool("umb",Property::Changeable::WhenIdle,true);
 	Pbool->Set_help("Enable UMB support.");
 
+	pstring = secprop->Add_string("ver", when_idle, "5.0");
+	pstring->Set_help("Set DOS version (5.0 by default). Specify as major.minor format.\n"
+	                  "A single number is treated as the major version.\n"
+	                  "Common settings are 3.3, 5.0, 6.22, and 7.1.");
+
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init,true);
 	Pstring = secprop->Add_string("keyboardlayout",Property::Changeable::WhenIdle, "auto");
 	Pstring->Set_help("Language code of the keyboard layout (or none).");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -727,8 +727,12 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_PATH_HELP","Provided for compatibility.\n");
 
 	MSG_Add("SHELL_CMD_VER_HELP", "View or set the reported DOS version.\n");
+	MSG_Add("SHELL_CMD_VER_HELP_LONG", "VER\n"
+	        "VER SET version_number\n"
+	        "VER SET major_version [minor_version]\n");
 	MSG_Add("SHELL_CMD_VER_VER",
 	        "dosbox-staging version %s. Reported DOS version %d.%02d.\n");
+	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
 
 	/* Regular startup */
 	call_shellstop=CALLBACK_Allocate();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1552,22 +1552,20 @@ void DOS_Shell::CMD_PATH(char *args){
 	}
 }
 
-void DOS_Shell::CMD_VER(char *args) {
+void DOS_Shell::CMD_VER(char *args)
+{
 	HELP("VER");
 	if (args && strlen(args)) {
-		char* word = StripWord(args);
-		if (strcasecmp(word,"set")) return;
+		char *word = StripWord(args);
+		if (strcasecmp(word, "set"))
+			return;
 		word = StripWord(args);
-		if (!*args && !*word) { //Reset
-			dos.version.major = 5;
-			dos.version.minor = 0;
-		} else if (*args == 0 && *word && (strchr(word,'.') != 0)) { //Allow: ver set 5.1
-			const char * p = strchr(word,'.');
-			dos.version.major = (Bit8u)(atoi(word));
-			dos.version.minor = (Bit8u)(atoi(p+1));
-		} else { //Official syntax: ver set 5 2
-			dos.version.major = (Bit8u)(atoi(word));
-			dos.version.minor = (Bit8u)(atoi(args));
-		}
-	} else WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,dos.version.major,dos.version.minor);
+		const auto new_version = DOS_ParseVersion(word, args);
+		if (new_version.major || new_version.minor)
+			dos.version = new_version;
+		else
+			WriteOut(MSG_Get("SHELL_CMD_VER_INVALID"));
+	} else
+		WriteOut(MSG_Get("SHELL_CMD_VER_VER"), VERSION,
+		         dos.version.major, dos.version.minor);
 }


### PR DESCRIPTION
Pull request #476 included a new function to set the reported DOS version which is to be shared by both the VER command and the new "ver" config option (in "dos" section). In order to make the PR smaller and focused I have made this a separate PR.

Also, as mentioned in that PR there is an improvement to the VER function regarding the DOS version handling, which is already implemented in DOSBox-X. For example, the command ``VER SET 7.1`` sets the emulated DOS version as 7.1 (7.10), whereas ``VER SET 7 1`` sets the emulated DOS version as 7.01 (as done in upstream DOSBox), because most users apparently expect ``VER SET 7.1``  to set the emulated DOS version as 7.1 instead of 7.01.