### PR TITLE
Cache the Coverity install package

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,10 +8,13 @@ on:
 env:
   COVERITY_EMAIL: ${{ secrets.CoverityEmail }}
   COVERITY_TOKEN: ${{ secrets.CoverityToken }}
+  BASE_DIR: "/dev/shm"
+  PACKAGE: "/dev/shm/coverity-package/coverity.tar.zst"
+  PACKAGE_DIR: "/dev/shm/coverity-package"
   # Latest package: https://scan.coverity.com/download
   PACKAGE_VERSION: "2019.03"
-  TARBALL_SHA256: "0bec2d12e7fca3fe4b6df843d9584e2a58e273970a8549c100541f86dbc0da4e"
   TARBALL_GDRIVE_ID: ${{ secrets.GoogleDriveId }}
+  TARBALL_SHA256: "0bec2d12e7fca3fe4b6df843d9584e2a58e273970a8549c100541f86dbc0da4e"
 
 jobs:
   coverity_scan:
@@ -20,19 +23,30 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update
-      - name: Log environment
-        run:  ./scripts/log-env.sh
+      - name: Log and setup environment
+        run: |
+          ./scripts/log-env.sh
+          mkdir -p "${PACKAGE_DIR}"
 
       - name: Install C++ compiler and dependencies
         run: |
           sudo apt-get install zstd python3-setuptools $(./scripts/list-build-dependencies.sh -m apt -c gcc)
           sudo pip3 install gdown
 
-      - name: Fetch the Coverity instrumenteur
+      - name: Prepare the Coverity package cache
+        uses: actions/cache@v2
+        id: cache-coverity
+        with:
+          path: ${{ env.PACKAGE_DIR }}
+          key: coverity-${{ env.PACKAGE_VERSION }}
+      - name:  Fetch the Coverity package
+        if:    steps.cache-coverity.outputs.cache-hit != 'true'
+        run:   gdown --id "${TARBALL_GDRIVE_ID}" -O "${PACKAGE}"
+
+      - name: Install the Coverity package
         run: |
           set -xeuo pipefail
-          gdown --id "${TARBALL_GDRIVE_ID}" -O - \
-          | tee >(tar -I zstd -C /dev/shm -x) \
+          tee >(tar -I zstd -C "${BASE_DIR}" -x) < "${PACKAGE}" \
           | sha256sum -c <(echo "${TARBALL_SHA256} -" )
 
       - name: Build and instrument the project
@@ -43,7 +57,7 @@ jobs:
           export CFLAGS="-g -Og"
           export CXXFLAGS="${CFLAGS}"
           ./configure
-          PATH="/dev/shm/cov-analysis-linux64-${PACKAGE_VERSION}/bin:${PATH}"
+          PATH="${BASE_DIR}/cov-analysis-linux64-${PACKAGE_VERSION}/bin:${PATH}"
           cov-build --dir cov-int make -j "$(nproc)"
           tar -cvaf package.tar.gz cov-int
 


### PR DESCRIPTION
This should work around any intermittent fetch issues from Google Drive, which we use to host the Coverity package. 
This PR also requires an updated `TARBALL_GDRIVE_ID` that's been sent via email.
The package is the same; Google just bumped their token size. The SHA256 checksum, included in YAML for anyone to see and check, remains the same.

``` text
2020-07-24T13:32:23.5285639Z ##[group]Run gdown --id "${TARBALL_GDRIVE_ID}" -O "${PACKAGE}"
2020-07-24T13:32:23.5285889Z [36;1mgdown --id "${TARBALL_GDRIVE_ID}" -O "${PACKAGE}"[0m
2020-07-24T13:32:23.5326921Z shell: /bin/bash -e {0}
2020-07-24T13:32:23.5327078Z env:
2020-07-24T13:32:25.1465294Z Downloading...
2020-07-24T13:32:25.1465742Z From: https://drive.google.com/uc?id=***
2020-07-24T13:32:25.1466639Z To: /dev/shm/coverity-package/coverity.tar.zst
2020-07-24T13:32:25.1466744Z 
2020-07-24T13:32:25.2471920Z 0.00B [00:00, ?B/s]
2020-07-24T13:32:25.6155083Z 14.7MB [00:00, 146MB/s]
2020-07-24T13:32:25.7163961Z 34.1MB [00:00, 95.4MB/s]
2020-07-24T13:32:25.8982535Z 57.7MB [00:00, 116MB/s] 
2020-07-24T13:32:25.9895503Z 68.2MB [00:00, 89.0MB/s]
2020-07-24T13:32:25.9991124Z 89.2MB [00:00, 106MB/s] 

2020-07-24T13:32:26.0337096Z ##[group]Run set -xeuo pipefail
2020-07-24T13:32:26.0337450Z [36;1mset -xeuo pipefail[0m
2020-07-24T13:32:26.0337612Z [36;1mtee >(tar -I zstd -C "${BASE_DIR}" -x) < "${PACKAGE}" \[0m
2020-07-24T13:32:26.0337800Z [36;1m| sha256sum -c <(echo "${TARBALL_SHA256} -" )[0m
2020-07-24T13:32:26.0380602Z shell: /bin/bash -e {0}
2020-07-24T13:32:26.0532575Z + tee /dev/fd/63
2020-07-24T13:32:26.0543819Z + sha256sum -c /dev/fd/63
2020-07-24T13:32:26.0572563Z ++ echo '0bec2d12e7fca3fe4b6df843d9584e2a58e273970a8549c100541f86dbc0da4e -'
2020-07-24T13:32:26.0578192Z ++ tar -I zstd -C /dev/shm -x
2020-07-24T13:32:27.9456351Z -: OK

2020-07-24T13:35:33.5435841Z ##[endgroup]
2020-07-24T13:35:33.5603094Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
2020-07-24T13:35:33.5606329Z                                  Dload  Upload   Total   Spent    Left  Speed
2020-07-24T13:35:33.5606687Z 
2020-07-24T13:35:34.6163977Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
2020-07-24T13:35:35.6018312Z   8 29.3M    0     0    8 2608k      0  2469k  0:00:12  0:00:01  0:00:11 2469k
2020-07-24T13:35:36.5530213Z  25 29.3M    0     0   25 7552k      0  3700k  0:00:08  0:00:02  0:00:06 3700k
2020-07-24T13:35:38.1563137Z  40 29.3M    0     0   40 11.9M      0  4085k  0:00:07  0:00:02  0:00:05 4084k
2020-07-24T13:35:38.5632084Z  48 29.3M    0     0   48 14.0M      0  3140k  0:00:09  0:00:04  0:00:05 3140k
2020-07-24T13:35:40.3937925Z  68 29.3M    0     0   68 20.0M      0  4099k  0:00:07  0:00:05  0:00:02 4099k
2020-07-24T13:35:40.5797149Z  80 29.3M    0     0   80 23.6M      0  3542k  0:00:08  0:00:06  0:00:02 3738k
2020-07-24T13:35:41.5709458Z  96 29.3M    0     0   96 28.1M      0  4112k  0:00:07  0:00:07 --:--:-- 4281k
2020-07-24T13:35:42.5722058Z 100 29.3M    0     0  100 29.3M      0  3748k  0:00:08  0:00:08 --:--:-- 3548k
2020-07-24T13:35:43.3828511Z 100 29.3M    0     0  100 29.3M      0  3331k  0:00:09  0:00:09 --:--:-- 3531k
2020-07-24T13:35:43.3828942Z 100 29.3M  100    30  100 29.3M      3  3057k  0:00:10  0:00:09  0:00:01 1975k

2020-07-24T13:35:43.3829353Z Build successfully submitted.
2020-07-24T13:35:43.3888081Z Post job cleanup.
2020-07-24T13:35:43.5237391Z [command]/bin/tar -cz -f /home/runner/work/_temp/0484afa6-d65e-4b53-bb35-d69ad5c49e3b/cache.tgz -C /dev/shm/coverity-package .
2020-07-24T13:36:00.3554461Z Cache saved successfully
```

Fixes #517.