### PR TITLE
Extend the download timeout for and cache the Clam AV database

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -51,7 +51,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
@@ -119,7 +119,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run:   echo ::set-output name=date::$(date +%Y-%W)
 
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-msys2
         if:    >
           matrix.system.name == 'Windows' &&

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,7 @@ env:
   CCACHE_DIR:      "/dev/shm/.ccache"
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
+  CLAMDB_DIR:      "/var/lib/clamav"
 
 jobs:
   build_ubuntu:
@@ -159,12 +160,29 @@ jobs:
           # Create tarball
           tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
 
+      - name:  Prepare Clam AV DB cache
+        id:    prep-clamdb
+        shell: bash
+        run: |
+          sudo mkdir -p "${CLAMDB_DIR}"
+          sudo chmod 777 "${CLAMDB_DIR}"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+      - uses:  actions/cache@v2
+        id:    cache-clamdb
+        with:
+          path: ${{ env.CLAMDB_DIR }}/*.cvd
+          key:  clamdb-linux-${{ steps.prep-clamdb.outputs.today }}-1
+          restore-keys: |
+            clamdb-linux-${{ steps.prep-clamdb.outputs.yesterday }}-1
+
       - name: Clam AV scan
         run: |
           set -x
-          sudo apt-get install clamav > /dev/null
+          sudo apt-get install clamav
           sudo systemctl stop clamav-freshclam
-          sudo freshclam --quiet && sudo freshclam
+          sudo sed -i 's/30/20000/g' /etc/clamav/freshclam.conf
+          sudo freshclam --foreground
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
 
       - name: Upload tarball

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,7 +62,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
@@ -95,7 +95,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,7 +34,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
@@ -70,7 +70,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
-      - uses:  actions/cache@v1
+      - uses:  actions/cache@v2
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ env:
   CCACHE_DIR:      "${{ github.workspace }}/.ccache"
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
+  CLAMDB_DIR:      "/usr/local/Cellar/clamav"
 
 jobs:
   build_macos:
@@ -142,14 +143,29 @@ jobs:
               -srcfolder dist \
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
 
-      - name: Clam AV scan
+      - name:  Install Clam AV
+        id:    prep-clamdb
+        shell: bash
         run: |
-          set -x
           brew install clamav > /dev/null
           clamconf=/usr/local/etc/clamav/freshclam.conf
           mv -f "$clamconf".sample "$clamconf"
           sed -ie 's/^Example/#Example/g' "$clamconf"
-          freshclam --quiet && freshclam
+          sed -ie 's/30/20000/g' "$clamconf"
+          echo "::set-output name=today::$(gdate -I)"
+          echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
+      - uses:  actions/cache@v2
+        id:    cache-clamdb
+        with:
+          path: ${{ env.CLAMDB_DIR }}/**/*.cvd
+          key:  clamdb-macos-${{ steps.prep-clamdb.outputs.today }}-2
+          restore-keys: |
+            clamdb-macos-${{ steps.prep-clamdb.outputs.yesterday }}-2
+
+      - name: Clam AV scan
+        run: |
+          set -x
+          freshclam --foreground
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
 
       - name: Upload disk image

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date -I)"
-          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+          echo "::set-output name=today::$(gdate -I)"
+          echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
       - uses:  actions/cache@v2
         id:    cache-ccache
         with:
@@ -68,8 +68,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date -I)"
-          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+          echo "::set-output name=today::$(gdate -I)"
+          echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
       - uses:  actions/cache@v2
         id:    cache-ccache
         with:

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           ./scripts/log-env.sh
           mkdir -p pvs-package
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: cache-pvs
         with:
           path: pvs-package


### PR DESCRIPTION
This PR fixes the recent problem where the Clam AV update software (`freshclam`) was timing out and restarting in and endless loop because Clam AV's database server couldn't deliver the updates fast enough.
 
It extends `freshclam`'s download cutoff from 30s to 20000s to provide enough time to download the databases if the speed averages 10 KB/s, which is conservatively below the speeds we were seeing (15 KB/s up to 50 KB/s).

It also caches and restores the data files on a daily rolling basis. The first job of the day will restore yesterday's database files and then perform an incremental update on them, which are then cached as today's results. All subsequent jobs get today's results.

![2020-07-24_09-58](https://user-images.githubusercontent.com/1557255/88416407-096a3d00-cd95-11ea-8e00-a1311144156f.png)

Two other commits included:

- All the cache@v1 API calls are bumped to @v2, which uses `zstd` for faster compression and decompression. It's backward compatible with the files produced under v1, and all CI jobs are working without issue w/ v2.
- It uses GNU date (`gdate`) under macOS, because the existing `date` command didn't understand the `-I` flag.