### PR TITLE
Implement OpenGL pixel-perfect mode

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -357,7 +357,7 @@ static SDL_Block sdl;
 
 static bool calc_pp_scale(int width, int heigth);
 static Dimensions GetAvailableArea(int width, int height);
-static SDL_Rect calc_viewport_fit(int win_width, int win_height);
+static SDL_Rect calc_viewport(int width, int height);
 static void CleanupSDLResources();
 static void HandleVideoResize(int width, int height);
 
@@ -1275,7 +1275,7 @@ dosurface:
 			           sdl.clip.w,
 			           sdl.clip.h);
 		} else if (sdl.desktop.window.resizable) {
-			sdl.clip = calc_viewport_fit(windowWidth, windowHeight);
+			sdl.clip = calc_viewport(windowWidth, windowHeight);
 			glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
 		} else {
 			/* We don't just pass sdl.clip.y as-is, so we cover the case of non-vertical
@@ -2037,6 +2037,26 @@ static SDL_Rect calc_viewport_fit(int win_width, int win_height)
 	}
 }
 
+static SDL_Rect calc_viewport_pp(int win_width, int win_height)
+{
+	calc_pp_scale(win_width, win_height); // updates sdl.ppscale
+
+	const int w = sdl.pp_scale.x * sdl.draw.width;
+	const int h = sdl.pp_scale.y * sdl.draw.height;
+	const int x = (win_width - w) / 2;
+	const int y = (win_height - h) / 2;
+
+	return {x, y, w, h};
+}
+
+static SDL_Rect calc_viewport(int width, int height)
+{
+	if (sdl.scaling_mode == SmPerfect)
+		return calc_viewport_pp(width, height);
+	else
+		return calc_viewport_fit(width, height);
+}
+
 //extern void UI_Run(bool);
 void Restart(bool pressed);
 
@@ -2380,7 +2400,7 @@ static void HandleVideoResize(int width, int height)
 
 #if C_OPENGL
 	if (sdl.desktop.window.resizable && sdl.desktop.type == SCREEN_OPENGL) {
-		sdl.clip = calc_viewport_fit(width, height);
+		sdl.clip = calc_viewport(width, height);
 		glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
 		return;
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -129,7 +129,7 @@ typedef void (APIENTRYP PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size,
 
 /* Apple defines these functions in their GL header (as core functions)
  * so we can't use their names as function pointers. We can't link
- * directly as some platforms may not have them. So they get their own 
+ * directly as some platforms may not have them. So they get their own
  * namespace here to keep the official names but avoid collisions.
  */
 namespace gl2 {
@@ -398,7 +398,7 @@ void OPENGL_ERROR(const char* message) {
 		LOG_MSG("%X",r);
 	} while ( (r=glGetError()) != GL_NO_ERROR);
 }
-#else 
+#else
 void OPENGL_ERROR(const char*) {
 	return;
 }
@@ -1285,7 +1285,7 @@ dosurface:
 		if (sdl.opengl.texture > 0) {
 			glDeleteTextures(1,&sdl.opengl.texture);
 		}
- 		glGenTextures(1,&sdl.opengl.texture);
+		glGenTextures(1, &sdl.opengl.texture);
 		glBindTexture(GL_TEXTURE_2D,sdl.opengl.texture);
 		// No borders
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
@@ -1388,7 +1388,7 @@ void GFX_ToggleMouseCapture(void) {
 	 */
 	if (!sdl.mouse.has_focus)
 		return;
-	
+
 	assertm(sdl.mouse.control_choice != NoMouse,
 	        "SDL: Mouse capture is invalid when NoMouse is configured [Logic Bug]");
 
@@ -1396,8 +1396,9 @@ void GFX_ToggleMouseCapture(void) {
 	if (SDL_SetRelativeMouseMode(mouse_is_captured) != 0) {
 		SDL_ShowCursor(SDL_ENABLE);
 		E_Exit("SDL: failed to %s relative-mode [SDL Bug]",
-   		       mouse_is_captured ? "put the mouse in" : "take the mouse out of");
- 	}
+		       mouse_is_captured ? "put the mouse in"
+		                         : "take the mouse out of");
+	}
 	LOG_MSG("SDL: %s the mouse", mouse_is_captured ? "captured" : "released");
 }
 
@@ -1407,7 +1408,7 @@ static void ToggleMouseCapture(bool pressed) {
 	GFX_ToggleMouseCapture();
 }
 
-/*  
+/*
  *  Assesses the following:
  *   - current window size (full or not),
  *   - mouse capture state, (yes or no).
@@ -1495,7 +1496,7 @@ void GFX_SwitchFullScreen()
 	sticky_keys(sdl.desktop.fullscreen);
 #endif
 	sdl.desktop.fullscreen = !sdl.desktop.fullscreen;
- 	GFX_ResetScreen();
+	GFX_ResetScreen();
 	sdl.desktop.switching_fullscreen = false;
 }
 
@@ -1510,8 +1511,8 @@ static void SwitchFullScreen(bool pressed)
 // can be achieved via GFX_SetSize call), and specifically - properly initialized
 // output-specific bits (sdl.surface, sdl.texture, sdl.opengl.framebuf, or
 // sdl.openg.pixel_buffer_object fields).
-// 
-// If everything is prepared correctly, this function returns true, assigns 
+//
+// If everything is prepared correctly, this function returns true, assigns
 // 'pixels' output parameter to to a buffer (with format specified via earlier
 // GFX_SetSize call), and assigns 'pitch' to a number of bytes used for a single
 // pixels row in 'pixels' buffer.
@@ -1855,7 +1856,7 @@ static SDL_Window *SetDefaultWindowMode()
 	                     sdl.desktop.want_resizable_window);
 }
 
-/* 
+/*
  * Please leave the Splash screen stuff in working order.
  * We spend a lot of time making DOSBox.
  */
@@ -2334,8 +2335,8 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button) {
 		        || !mouse_is_captured)) {
 
 			GFX_ToggleMouseCapture();
- 			break;	// Don't pass click to mouse handler
- 		}
+			break; // Don't pass click to mouse handler
+		}
 		switch (button->button) {
 		case SDL_BUTTON_LEFT:
 			Mouse_ButtonPressed(0);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -355,7 +355,7 @@ struct SDL_Block {
 
 static SDL_Block sdl;
 
-static SDL_Rect CalculateViewport(int win_width, int win_height);
+static SDL_Rect calc_viewport_fit(int win_width, int win_height);
 static void CleanupSDLResources();
 static void HandleVideoResize(int width, int height);
 
@@ -1293,7 +1293,7 @@ dosurface:
 			           sdl.clip.w,
 			           sdl.clip.h);
 		} else if (sdl.desktop.window.resizable) {
-			sdl.clip = CalculateViewport(windowWidth, windowHeight);
+			sdl.clip = calc_viewport_fit(windowWidth, windowHeight);
 			glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
 		} else {
 			/* We don't just pass sdl.clip.y as-is, so we cover the case of non-vertical
@@ -2025,7 +2025,7 @@ static void SetupWindowResolution(const char *val)
 	sdl.desktop.window.use_original_size = true;
 }
 
-static SDL_Rect CalculateViewport(int win_width, int win_height)
+static SDL_Rect calc_viewport_fit(int win_width, int win_height)
 {
 	assert(sdl.draw.width > 0);
 	assert(sdl.draw.height > 0);
@@ -2398,7 +2398,7 @@ static void HandleVideoResize(int width, int height)
 
 #if C_OPENGL
 	if (sdl.desktop.window.resizable && sdl.desktop.type == SCREEN_OPENGL) {
-		sdl.clip = CalculateViewport(width, height);
+		sdl.clip = calc_viewport_fit(width, height);
 		glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
 		return;
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2156,6 +2156,10 @@ static void GUI_StartUp(Section * sec) {
 		sdl.desktop.want_type=SCREEN_OPENGL;
 		sdl.scaling_mode = SmNearest;
 		sdl.opengl.bilinear = false;
+	} else if (output == "openglpp") {
+		sdl.desktop.want_type = SCREEN_OPENGL;
+		sdl.scaling_mode = SmPerfect;
+		sdl.opengl.bilinear = false;
 #endif
 	} else {
 		LOG_MSG("SDL: Unsupported output device %s, switching back to surface",output.c_str());
@@ -2812,6 +2816,7 @@ void Config_Add_SDL() {
 #if C_OPENGL
 		"opengl",
 		"openglnb",
+		"openglpp",
 #endif
 		0
 	};

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2824,10 +2824,10 @@ void Config_Add_SDL() {
 	Pstring->Set_help("What video system to use for output.");
 	Pstring->Set_values(outputs);
 
-	Pstring = sdl_sec->Add_string("texture_renderer", always, "auto");
-	Pstring->Set_help("Choose a renderer driver if output=texture or texturenb.\n"
-	                  "Use output=auto for an automatic choice.");
-	Pstring->Set_values(Get_SDL_TextureRenderers());
+	pstring = sdl_sec->Add_string("texture_renderer", always, "auto");
+	pstring->Set_help("Choose a renderer driver when using a texture output mode.\n"
+	                  "Use texture_renderer=auto for an automatic choice.");
+	pstring->Set_values(Get_SDL_TextureRenderers());
 
 	// Define mouse control settings
 	Pmulti = sdl_sec->Add_multi("capture_mouse", always, " ");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2484,16 +2484,17 @@ void GFX_Events() {
 				continue;
 
 			case SDL_WINDOWEVENT_RESIZED:
-				DEBUG_LOG_MSG("SDL: Window has been resized to %dx%d",
-				              event.window.data1,
-				              event.window.data2);
+				// DEBUG_LOG_MSG("SDL: Window has been resized to %dx%d",
+				//               event.window.data1,
+				//               event.window.data2);
 				HandleVideoResize(event.window.data1,
 				                  event.window.data2);
 				continue;
 
 			case SDL_WINDOWEVENT_EXPOSED:
-				DEBUG_LOG_MSG("SDL: Window has been exposed "
-				              "and should be redrawn");
+				// DEBUG_LOG_MSG("SDL: Window has been exposed "
+				//               "and should be redrawn");
+
 				/* FIXME: below is not consistently true :(
 				 * seems incorrect on KDE and sometimes on MATE
 				 *
@@ -2532,11 +2533,11 @@ void GFX_Events() {
 				break;
 
 			case SDL_WINDOWEVENT_ENTER:
-				DEBUG_LOG_MSG("SDL: Window has gained mouse focus");
+				// DEBUG_LOG_MSG("SDL: Window has gained mouse focus");
 				continue;
 
 			case SDL_WINDOWEVENT_LEAVE:
-				DEBUG_LOG_MSG("SDL: Window has lost mouse focus");
+				// DEBUG_LOG_MSG("SDL: Window has lost mouse focus");
 				continue;
 
 			case SDL_WINDOWEVENT_SHOWN:
@@ -2556,7 +2557,8 @@ void GFX_Events() {
 #endif
 
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
-				DEBUG_LOG_MSG("SDL: The window size has changed");
+				// DEBUG_LOG_MSG("SDL: The window size has changed");
+
 				// The window size has changed either as a
 				// result of an API call or through the system
 				// or user changing the window size.
@@ -2579,7 +2581,7 @@ void GFX_Events() {
 
 #if SDL_VERSION_ATLEAST(2, 0, 5)
 			case SDL_WINDOWEVENT_TAKE_FOCUS:
-				DEBUG_LOG_MSG("SDL: Window is being offered a focus");
+				// DEBUG_LOG_MSG("SDL: Window is being offered a focus");
 				// should SetWindowInputFocus() on itself or a
 				// subwindow, or ignore
 				continue;


### PR DESCRIPTION
One benefit of having this mode alongside `texturepp` is having a pixel-perfect mode, that allows for a resizable window.

`openglpp` name is only temporary, before stable release we'll hide it (and support it as deprecated option, since people might have it in their .con files from ECE).