### PR TITLE
Don't warn about POSIX function names in MSVC

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 343
+            max_warnings: 321
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2208
+            max_warnings: 2185
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -72,3 +72,9 @@
 // Enables mathematical constants under Visual Studio, such as M_PI
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
 #define _USE_MATH_DEFINES
+
+// MSVC issues pedantic warnings on POSIX functions; for portability we don't
+// want to deal with these warnings, as the only way to avoid them is using
+// Microsoft-specific names and functions instead of POSIX conformant ones.
+// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019#posix-function-names
+#define _CRT_NONSTDC_NO_WARNINGS


### PR DESCRIPTION
MSVC issues pedantic warnings on POSIX functions; for portability, we don't want to deal with these warnings, as the only way to avoid them is using Microsoft-specific names and functions instead of POSIX conformant ones.

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019#posix-function-names