### PR TITLE
Move MidiHandler class to internal header in midi module

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -1,5 +1,8 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
+ *  Copyright (C) 2020-2020  The dosbox-staging team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/midi/Makefile.am
+++ b/src/midi/Makefile.am
@@ -1,5 +1,11 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LIBRARIES = libmidi.a
-libmidi_a_SOURCES = midi.cpp midi_alsa.h midi_coreaudio.h midi_coremidi.h \
-                    midi_oss.h midi_win32.h
+
+libmidi_a_SOURCES = \
+	midi.cpp \
+	midi_alsa.h \
+	midi_coreaudio.h \
+	midi_coremidi.h \
+	midi_oss.h \
+	midi_win32.h

--- a/src/midi/Makefile.am
+++ b/src/midi/Makefile.am
@@ -7,5 +7,6 @@ libmidi_a_SOURCES = \
 	midi_alsa.h \
 	midi_coreaudio.h \
 	midi_coremidi.h \
+	midi_handler.h \
 	midi_oss.h \
 	midi_win32.h

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -29,11 +29,12 @@
 #include <SDL.h>
 
 #include "cross.h"
-#include "support.h"
-#include "setup.h"
-#include "mapper.h"
-#include "pic.h"
 #include "hardware.h"
+#include "mapper.h"
+#include "midi_handler.h"
+#include "pic.h"
+#include "setup.h"
+#include "support.h"
 #include "timer.h"
 
 #define RAWBUF	1024

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -21,6 +21,8 @@
 #ifndef DOSBOX_MIDI_ALSA_H
 #define DOSBOX_MIDI_ALSA_H
 
+#include "midi_handler.h"
+
 #define ALSA_PCM_OLD_HW_PARAMS_API
 #define ALSA_PCM_OLD_SW_PARAMS_API
 #include <alsa/asoundlib.h>
@@ -87,13 +89,16 @@ public:
 	MidiHandler_alsa(const MidiHandler_alsa &) = delete; // prevent copying
 	MidiHandler_alsa &operator=(const MidiHandler_alsa &) = delete; // prevent assignment
 
-	const char* GetName(void) { return "alsa"; }
-	void PlaySysex(Bit8u * sysex,Bitu len) {
+	const char *GetName() const override { return "alsa"; }
+
+	void PlaySysex(uint8_t *sysex, size_t len) override
+	{
 		snd_seq_ev_set_sysex(&ev, len, sysex);
 		send_event(1);
 	}
 
-	void PlayMsg(Bit8u * msg) {
+	void PlayMsg(const uint8_t *msg) override
+	{
 		ev.type = SND_SEQ_EVENT_OSS;
 
 		ev.data.raw32.d[0] = msg[0];
@@ -138,14 +143,16 @@ public:
 			send_event(1);
 			break;
 		}
-	}	
+	}
 
-	void Close(void) {
+	void Close() override
+	{
 		if (seq_handle)
 			snd_seq_close(seq_handle);
 	}
 
-	bool Open(const char * conf) {
+	bool Open(const char *conf) override
+	{
 		char var[10];
 		unsigned int caps;
 		bool defaultport = true; //try 17:0. Seems to be default nowadays

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -16,6 +18,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifndef DOSBOX_MIDI_ALSA_H
+#define DOSBOX_MIDI_ALSA_H
 
 #define ALSA_PCM_OLD_HW_PARAMS_API
 #define ALSA_PCM_OLD_SW_PARAMS_API
@@ -209,3 +213,5 @@ public:
 };
 
 MidiHandler_alsa Midi_alsa;
+
+#endif

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -21,6 +21,8 @@
 #ifndef DOSBOX_MIDI_COREAUDIO_H
 #define DOSBOX_MIDI_COREAUDIO_H
 
+#include "midi_handler.h"
+
 #include <AudioToolbox/AUGraph.h>
 #include <CoreServices/CoreServices.h>
 
@@ -64,8 +66,11 @@ private:
         const char *soundfont;
 public:
 	MidiHandler_coreaudio() : m_auGraph(0), m_synth(0) {}
-	const char * GetName(void) { return "coreaudio"; }
-	bool Open(const char * conf) {
+
+	const char *GetName() const override { return "coreaudio"; }
+
+	bool Open(const char *conf) override
+	{
 		OSStatus err = 0;
 
 		if (m_auGraph)
@@ -177,7 +182,8 @@ public:
 		return false;
 	}
 
-	void Close(void) {
+	void Close() override
+	{
 		if (m_auGraph) {
 			AUGraphStop(m_auGraph);
 			DisposeAUGraph(m_auGraph);
@@ -185,11 +191,13 @@ public:
 		}
 	}
 
-	void PlayMsg(Bit8u * msg) {
+	void PlayMsg(const uint8_t *msg) override
+	{
 		MusicDeviceMIDIEvent(m_synth, msg[0], msg[1], msg[2], 0);
-	}	
+	}
 
-	void PlaySysex(Bit8u * sysex, Bitu len) {
+	void PlaySysex(uint8_t *sysex, size_t len) override
+	{
 		MusicDeviceSysEx(m_synth, sysex, len);
 	}
 };

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -63,9 +63,15 @@ class MidiHandler_coreaudio : public MidiHandler {
 private:
 	AUGraph m_auGraph;
 	AudioUnit m_synth;
-        const char *soundfont;
+	const char *soundfont;
+
 public:
-	MidiHandler_coreaudio() : m_auGraph(0), m_synth(0) {}
+	MidiHandler_coreaudio()
+	        : MidiHandler(),
+	          m_auGraph(0),
+	          m_synth(0),
+	          soundfont(nullptr)
+	{}
 
 	const char *GetName() const override { return "coreaudio"; }
 

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -16,6 +18,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifndef DOSBOX_MIDI_COREAUDIO_H
+#define DOSBOX_MIDI_COREAUDIO_H
 
 #include <AudioToolbox/AUGraph.h>
 #include <CoreServices/CoreServices.h>
@@ -193,3 +197,5 @@ public:
 #undef RequireNoErr
 
 MidiHandler_coreaudio Midi_coreaudio;
+
+#endif

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -1,4 +1,9 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2002-2020  The DOSBox Team
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
@@ -13,6 +18,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
+#ifndef DOSBOX_MIDI_COREMIDI_H
+#define DOSBOX_MIDI_COREMIDI_H
 
 #include <CoreMIDI/MIDIServices.h>
 #include <sstream>
@@ -136,9 +144,9 @@ public:
 			//This is for EndPoints created by us.
 			//MIDIEndpointDispose(dest);
 		}
-
 	}
 };
 
 MidiHandler_coremidi Midi_coremidi;
 
+#endif

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -35,9 +35,16 @@ private:
 	MIDIPortRef m_port;
 	MIDIClientRef m_client;
 	MIDIEndpointRef m_endpoint;
-	MIDIPacket* m_pCurPacket;
+	MIDIPacket *m_pCurPacket;
+
 public:
-	MidiHandler_coremidi() { m_pCurPacket = 0; }
+	MidiHandler_coremidi()
+	        : MidiHandler(),
+	          m_port(0),
+	          m_client(0),
+	          m_endpoint(0),
+	          m_pCurPacket(nullptr)
+	{}
 
 	const char *GetName() const override { return "coremidi"; }
 

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -22,9 +22,13 @@
 #ifndef DOSBOX_MIDI_COREMIDI_H
 #define DOSBOX_MIDI_COREMIDI_H
 
+#include "midi_handler.h"
+
 #include <CoreMIDI/MIDIServices.h>
 #include <sstream>
 #include <string>
+
+#include "programs.h"
 
 class MidiHandler_coremidi : public MidiHandler {
 private:
@@ -33,9 +37,12 @@ private:
 	MIDIEndpointRef m_endpoint;
 	MIDIPacket* m_pCurPacket;
 public:
-	MidiHandler_coremidi()  {m_pCurPacket = 0;}
-	const char * GetName(void) { return "coremidi"; }
-	bool Open(const char * conf) {	
+	MidiHandler_coremidi() { m_pCurPacket = 0; }
+
+	const char *GetName() const override { return "coremidi"; }
+
+	bool Open(const char *conf) override
+	{
 		// Get the MIDIEndPoint
 		m_endpoint = 0;
 		Bitu numDests = MIDIGetNumberOfDestinations();
@@ -90,8 +97,9 @@ public:
 		
 		return true;
 	}
-	
-	void Close(void) {
+
+	void Close() override
+	{
 		// Dispose the port
 		MIDIPortDispose(m_port);
 
@@ -102,8 +110,9 @@ public:
 		// Not, as it is for Endpoints created by us
 //		MIDIEndpointDispose(m_endpoint);
 	}
-	
-	void PlayMsg(Bit8u * msg) {
+
+	void PlayMsg(const uint8_t *msg) override
+	{
 		// Acquire a MIDIPacketList
 		Byte packetBuf[128];
 		MIDIPacketList *packetList = (MIDIPacketList *)packetBuf;
@@ -118,8 +127,9 @@ public:
 		// Send the MIDIPacketList
 		MIDISend(m_port,m_endpoint,packetList);
 	}
-	
-	void PlaySysex(Bit8u * sysex, Bitu len) {
+
+	void PlaySysex(uint8_t *sysex, size_t len) override
+	{
 		// Acquire a MIDIPacketList
 		Byte packetBuf[SYSEX_SIZE*4];
 		MIDIPacketList *packetList = (MIDIPacketList *)packetBuf;
@@ -131,7 +141,9 @@ public:
 		// Send the MIDIPacketList
 		MIDISend(m_port,m_endpoint,packetList);
 	}
-	void ListAll(Program* base) {
+
+	void ListAll(Program *base) override
+	{
 		Bitu numDests = MIDIGetNumberOfDestinations();
 		for(Bitu i = 0; i < numDests; i++){
 			MIDIEndpointRef dest = MIDIGetDestination(i);

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -19,16 +19,41 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#ifndef DOSBOX_MIDI_H
-#define DOSBOX_MIDI_H
+#ifndef DOSBOX_MIDI_HANDLER_H
+#define DOSBOX_MIDI_HANDLER_H
 
-#include "dosbox.h"
+#include "midi.h"
 
-class Program;
+#include <cstdint>
 
-void MIDI_Init(Section *sec);
-bool MIDI_Available();
-void MIDI_ListAll(Program *output_handler);
-void MIDI_RawOutByte(uint8_t data);
+#define SYSEX_SIZE 8192
+
+class MidiHandler {
+public:
+	MidiHandler();
+
+	MidiHandler(const MidiHandler &) = delete;            // prevent copying
+	MidiHandler &operator=(const MidiHandler &) = delete; // prevent assignment
+
+	virtual ~MidiHandler() = default;
+
+	virtual const char *GetName() const { return "none"; }
+
+	virtual bool Open(MAYBE_UNUSED const char *conf)
+	{
+		LOG_MSG("MIDI: No working MIDI device found/selected.");
+		return true;
+	}
+
+	virtual void Close() {}
+
+	virtual void PlayMsg(MAYBE_UNUSED const uint8_t *msg) {}
+
+	virtual void PlaySysex(MAYBE_UNUSED uint8_t *sysex, MAYBE_UNUSED size_t len) {}
+
+	virtual void ListAll(MAYBE_UNUSED Program *base) {}
+
+	MidiHandler *next;
+};
 
 #endif

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -15,6 +17,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
+#ifndef DOSBOX_MIDI_OSS_H
+#define DOSBOX_MIDI_OSS_H
 
 #include <fcntl.h>
 
@@ -76,8 +81,10 @@ public:
 			buf[pos++] = device_num;
 			buf[pos++] = 0;
 		}
-		write(device,buf,pos);	
+		write(device, buf, pos);
 	}
 };
 
 MidiHandler_oss Midi_oss;
+
+#endif

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -21,6 +21,8 @@
 #ifndef DOSBOX_MIDI_OSS_H
 #define DOSBOX_MIDI_OSS_H
 
+#include "midi_handler.h"
+
 #include <fcntl.h>
 
 #define SEQ_MIDIPUTC    5
@@ -42,8 +44,10 @@ public:
 	MidiHandler_oss(const MidiHandler_oss &) = delete; // prevent copying
 	MidiHandler_oss &operator=(const MidiHandler_oss &) = delete; // prevent assignment
 
-	const char * GetName(void) { return "oss";};
-	bool Open(const char * conf) {
+	const char *GetName() const override { return "oss"; }
+
+	bool Open(const char *conf) override
+	{
 		char devname[512];
 		if (conf && conf[0]) safe_strncpy(devname,conf,512);
 		else strcpy(devname,"/dev/sequencer");
@@ -56,12 +60,16 @@ public:
 		device=open(devname, O_WRONLY, 0);
 		if (device<0) return false;
 		return true;
-	};
-	void Close(void) {
+	}
+
+	void Close() override
+	{
 		if (!isOpen) return;
 		if (device>0) close(device);
-	};
-	void PlayMsg(Bit8u * msg) {
+	}
+
+	void PlayMsg(const uint8_t *msg) override
+	{
 		Bit8u buf[128];Bitu pos=0;
 		Bitu len=MIDI_evt_len[*msg];
 		for (;len>0;len--) {
@@ -72,8 +80,10 @@ public:
 			msg++;
 		}
 		write(device,buf,pos);
-	};
-	void PlaySysex(Bit8u * sysex,Bitu len) {
+	}
+
+	void PlaySysex(uint8_t *sysex, size_t len) override
+	{
 		Bit8u buf[SYSEX_SIZE*4];Bitu pos=0;
 		for (;len>0;len--) {
 			buf[pos++] = SEQ_MIDIPUTC;

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -21,6 +21,8 @@
 #ifndef DOSBOX_MIDI_WIN32_H
 #define DOSBOX_MIDI_WIN32_H
 
+#include "midi_handler.h"
+
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -29,6 +31,8 @@
 #include <string>
 #include <sstream>
 
+#include "programs.h"
+
 class MidiHandler_win32: public MidiHandler {
 private:
 	HMIDIOUT m_out;
@@ -36,9 +40,12 @@ private:
 	HANDLE m_event;
 	bool isOpen;
 public:
-	MidiHandler_win32() : MidiHandler(),isOpen(false) {};
-	const char * GetName(void) { return "win32";};
-	bool Open(const char * conf) {
+	MidiHandler_win32() : MidiHandler(), isOpen(false) {}
+
+	const char *GetName() const override { return "win32"; }
+
+	bool Open(const char *conf) override
+	{
 		if (isOpen) return false;
 		m_event = CreateEvent (NULL, true, true, NULL);
 		MMRESULT res = MMSYSERR_NOERROR;
@@ -74,18 +81,23 @@ public:
 		if (res != MMSYSERR_NOERROR) return false;
 		isOpen=true;
 		return true;
-	};
+	}
 
-	void Close(void) {
+	void Close() override
+	{
 		if (!isOpen) return;
 		isOpen=false;
 		midiOutClose(m_out);
 		CloseHandle (m_event);
-	};
-	void PlayMsg(Bit8u * msg) {
-		midiOutShortMsg(m_out, *(Bit32u*)msg);
-	};
-	void PlaySysex(Bit8u * sysex,Bitu len) {
+	}
+
+	void PlayMsg(const uint8_t *msg) override
+	{
+		midiOutShortMsg(m_out, read_unaligned_uint32(msg));
+	}
+
+	void PlaySysex(uint8_t *sysex, size_t len) override
+	{
 		if (WaitForSingleObject (m_event, 2000) == WAIT_TIMEOUT) {
 			LOG(LOG_MISC,LOG_ERROR)("Can't send midi message");
 			return;
@@ -106,7 +118,9 @@ public:
 			return;
 		}
 	}
-	void ListAll(Program* base) {
+
+	void ListAll(Program *base) override
+	{
 		unsigned int total = midiOutGetNumDevs();
 		for(unsigned int i = 0;i < total;i++) {
 			MIDIOUTCAPS mididev;

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -16,6 +18,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifndef DOSBOX_MIDI_WIN32_H
+#define DOSBOX_MIDI_WIN32_H
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -114,4 +118,4 @@ public:
 
 MidiHandler_win32 Midi_win32;
 
-
+#endif


### PR DESCRIPTION
Mostly a cleanup, fixing several warnings and tidying-up interface.

This is final cleanup PR in preparation for #262.