### PR TITLE
(draft) Take control of vcpkg and cache its results

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,16 +17,45 @@ jobs:
             arch: x64
             max_warnings: -1
     steps:
-      - uses:  actions/checkout@v2
-      - name:  Install packages
+      - name:  Prepare and generate vcpkg cache key
+        id:    prep-vcpkg
+        shell: bash
+        run: |
+          rm -rf /mnt/c/vcpkg/*
+          echo "::set-output name=year_and_week::$(date '+%Y%W')"
+
+      - name: Cache vcpkg
+        uses: actions/cache@v2
+        id:   cache-vcpkg
+        with:
+          path: c:\vcpkg
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
+
+      - name:  Install vcpkg and packages
+        if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          vcpkg install --triplet ${{ matrix.conf.arch }}-windows sdl2 sdl2-net opusfile
-          if (-not $?) { throw "vcpkg install failed" }
+          choco uninstall cmake.install --all-versions
+          if (-not $?) { throw "chocolatey failed to uninstall CMake" }
+          rm -r -fo c:\vcpkg
+          git clone --depth 1 https://github.com/microsoft/vcpkg c:/vcpkg
+          if (-not $?) { throw "git failed to clone the vcpkg repository" }
+          c:\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+          if (-not $?) { throw "vcpkg's bootstrap script failed" }
+          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net opusfile
+          if (-not $?) { throw "vcpkg failed to install library dependencies" }
+
+      - name:  Integrate packages
+        shell: pwsh
+        run: |
           vcpkg integrate install
+          if (-not $?) { throw "vcpkg failed to integrate packages" }
+
+      - uses:  actions/checkout@v2
       - name:  Log environment
         shell: pwsh
         run:   .\scripts\log-env.ps1
+
       - name:  Build
         shell: pwsh
         env:
@@ -43,6 +72,7 @@ jobs:
 
   build_windows_vs_release:
     name: ${{ matrix.conf.name }}
+    needs: build_windows_vs
     runs-on: windows-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     strategy:
@@ -55,16 +85,30 @@ jobs:
             arch: x64
             vs-release-dirname: x64
     steps:
-      - uses:  actions/checkout@v2
-      - name:  Install packages
+      - name:  Prepare vcpkg for cache restore
+        id:    prep-vcpkg
+        shell: pwsh
+        run:   rm -r -fo c:\vcpkg\*
+
+      - name: Cache vcpkg
+        uses: actions/cache@v2
+        id:   cache-vcpkg
+        with:
+          path: c:\vcpkg
+          # Use the latest cache
+          key: vcpkg-${{ matrix.conf.arch }}-
+
+      - name:  Integrate packages
         shell: pwsh
         run: |
-          vcpkg install --triplet ${{ matrix.conf.arch }}-windows sdl2 sdl2-net opusfile
-          if (-not $?) { throw "vcpkg install failed" }
           vcpkg integrate install
+          if (-not $?) { throw "vcpkg failed to integrate packages" }
+
+      - uses:  actions/checkout@v2
       - name:  Log environment
         shell: pwsh
         run:   .\scripts\log-env.ps1
+
       - name:  Inject version string
         shell: bash
         run: |
@@ -73,6 +117,7 @@ jobs:
           export VERSION=$(git describe --abbrev=4)
           sed -i "s|VERSION \"git\"|VERSION \"$VERSION\"|" src/platform/visualc/config.h
           echo ::set-env name=VERSION::$VERSION
+
       - name:  Build
         shell: pwsh
         env:
@@ -80,6 +125,7 @@ jobs:
         run: |
           cd vs
           MSBuild -m dosbox.sln -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
+
       - name:  Package
         shell: bash
         run: |


### PR DESCRIPTION
Heading into day 10 with broken Windows CI due to vcpkg blindly using the host's cmake instead of its internal proven-tested version.  

To make matters worse, the Microsoft team lead for that project admits not having CI gating in place and has also dismissed the recommendation to only use the host's cmake if its version is equal to or less than the internal tested version; meaning the same factors that lead this this bug are not mitigated.

So I'm not happy about Vcpkg's "solution" (ie: do nothing to prevent this again) and I'm not happy with the attention this has gotten. Issue reports from countless projects continue to pour into vxpkg's issue tracker today. 

This PR takes control of vxpkg on the VM by 1) removing cmake from the host 2) upgrading the host-installed vcpkg, and 3) caching the results on a weekly basis, cutting CI times almost in half. 
