### PR TITLE
Eliminate temporary pointers in the IO R+W calls

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 48
+            max_warnings: 34
           - name: Ubuntu, +debug
             os: ubuntu-latest
             flags: -c gcc

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 42
+            max_warnings: 32
           - name: GCC-9
             flags: -c gcc -v 9
             max_warnings: 329


### PR DESCRIPTION
Also drops two unused static IO delay functions that have since been replaced.

We'll see if Coverity is happier with these :-)
