### PR TITLE
Cleanup presumptive drive_local library calls (Coverity fixes)

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -140,19 +140,23 @@ private:
 
 class localFile : public DOS_File {
 public:
-	localFile                   (const char* name, FILE * handle);
-	localFile                   (const localFile&) = delete; // prevent copying
-	localFile& operator=        (const localFile&) = delete; // prevent assignment
-	bool Read                   (Bit8u * data,Bit16u * size);
-	bool Write                  (Bit8u * data,Bit16u * size);
-	bool Seek                   (Bit32u * pos,Bit32u type);
-	bool Close                  (void);
-	Bit16u GetInformation       (void);
-	bool UpdateDateTimeFromHost (void);
-	void Flush                  (void);
-	void SetFlagReadOnlyMedium  () { read_only_medium = true; }
-	FILE * fhandle; //todo handle this properly
+	localFile(const char *name, FILE *handle);
+	localFile(const localFile &) = delete;            // prevent copying
+	localFile &operator=(const localFile &) = delete; // prevent assignment
+	bool Read(uint8_t *data, uint16_t *size);
+	bool Write(uint8_t *data, uint16_t *size);
+	bool Seek(uint32_t *pos, uint32_t type);
+	bool Close();
+	uint16_t GetInformation();
+	bool UpdateDateTimeFromHost();
+	void Flush();
+	void SetFlagReadOnlyMedium() { read_only_medium = true; }
+	FILE *fhandle = nullptr; // todo handle this properly
 private:
+	long stream_pos = 0;
+	bool ftell_and_check();
+	void fseek_and_check(int whence);
+	bool fseek_to_and_check(long pos, int whence);
 	bool read_only_medium;
 	enum { NONE,READ,WRITE } last_action;
 };

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -598,13 +598,19 @@ bool localFile::UpdateDateTimeFromHost(void) {
 	return true;
 }
 
-void localFile::Flush(void) {
-	if (last_action==WRITE) {
-		fseek(fhandle,ftell(fhandle),SEEK_SET);
-		last_action=NONE;
-	}
-}
+void localFile::Flush()
+{
+	if (last_action != WRITE)
+		return;
 
+	const auto pos = ftell(fhandle);
+	// only seek to a valid file position
+	if (pos >= 0)
+		fseek(fhandle, pos, SEEK_SET);
+
+	// Always reset the state even if the file is broken
+	last_action = NONE;
+}
 
 // ********************************************
 // CDROM DRIVE

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -219,7 +219,9 @@ bool localDrive::FileUnlink(char * name) {
 			}
 		}
 		if (!found_file) return false;
-		if (!unlink(fullname)) {
+
+		// If the file still exists then try to delete it
+		if (stat(fullname, &buffer) == 0 && unlink(fullname) == 0) {
 			dirCache.DeleteEntry(newname);
 			return true;
 		}

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -524,8 +524,15 @@ bool localFile::Write(Bit8u * data,Bit16u * size) {
 	if (*size == 0) {
 		return !ftruncate(cross_fileno(fhandle), ftell(fhandle));
 	} else {
-		*size = (Bit16u)fwrite(data, 1, *size, fhandle);
-		return true;
+		const auto requested = *size;
+		const auto actual = static_cast<uint16_t>(
+		        fwrite(data, 1, requested, fhandle));
+		if (actual != requested)
+			LOG_MSG("FS: Only wrote %u of %u requested bytes to %s",
+			        actual, requested, filename.c_str());
+
+		*size = actual; // always save the actual
+		return true; // always return true, even if partially written
 	}
 }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -730,7 +730,7 @@ cdromDrive::cdromDrive(const char _driveLetter,
 
 bool cdromDrive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 	if ((flags&0xf)==OPEN_READWRITE) {
-		flags &= ~OPEN_READWRITE;
+		flags &= ~static_cast<unsigned>(OPEN_READWRITE);
 	} else if ((flags&0xf)==OPEN_WRITE) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;


### PR DESCRIPTION
Mostly adding checks around presumptive file calls to prevent library calls from being fed garbage values.

The relatively dangerous flow is retained though; perhaps it's needed- I didn't want to change it.

This should fix nine Coverity issues.  Still some low hanging :cherries: :green_apple: left :-)

Suggest reviewing commit-by-commit.