### PR TITLE
Cleanup Coverity and effc++ issues in the Shell subsystem

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -451,7 +451,7 @@ public:
 		char orig[CROSS_LEN+1];
 		char cross_filesplit[2] = {CROSS_FILESPLIT , 0};
 
-		Bitu dummy = 1;
+		uint32_t dummy = 1;
 		bool command_found = false;
 		while (control->cmdline->FindCommand(dummy++,line) && !command_found) {
 			struct stat test;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -205,13 +205,13 @@ Bitu DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn,bool * append) {
 //				*lr++=0;
 //			else
 //				*lr=0;
-			t = (char*)malloc(lr-*ofn+1);
+			t = (char *)malloc(static_cast<size_t>(lr - *ofn + 1u));
 			if (t == nullptr) {
 				E_Exit("SHELL: Could not allocate %u bytes in parser",
-				       static_cast<unsigned int>(lr-*ofn+1));
+				       static_cast<unsigned int>(lr - *ofn + 1u));
 			}
 
-			safe_strncpy(t,*ofn,lr-*ofn+1);
+			safe_strncpy(t, *ofn, static_cast<size_t>(lr - *ofn + 1u));
 			*ofn=t;
 			continue;
 		case '<':
@@ -224,12 +224,12 @@ Bitu DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn,bool * append) {
 //				*lr++=0;
 //			else
 //				*lr=0;
-			t = (char*)malloc(lr-*ifn+1);
+			t = (char *)malloc(static_cast<size_t>(lr - *ifn + 1u));
 			if (t == nullptr) {
 				E_Exit("SHELL: Could not allocate %u bytes in parser",
-				       static_cast<unsigned int>(lr-*ifn+1));
+				       static_cast<unsigned int>(lr - *ifn + 1u));
 			}
-			safe_strncpy(t,*ifn,lr-*ifn+1);
+			safe_strncpy(t, *ifn, static_cast<size_t>(lr - *ifn + 1u));
 			*ifn=t;
 			continue;
 		case '|':

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -153,7 +153,11 @@ AutoexecObject::~AutoexecObject(){
 			}
 		} else it++;
 	}
-	this->CreateAutoexec();
+	try {
+		this->CreateAutoexec();
+	} catch (const char *errmsg) {
+		LOG_MSG("SHELL: failed creating autoexec object because %s", errmsg);
+	}
 }
 
 DOS_Shell::DOS_Shell()

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -113,9 +113,9 @@ emptyline:
 			if (cmd_read[0] == '0') {  /* Handle %0 */
 				const char *file_name = cmd->GetFileName();
 				cmd_read++;
-				size_t name_len = strlen(file_name);
+				const auto name_len = static_cast<int>(strlen(file_name));
 				if (((cmd_write - line) + name_len) < (CMD_MAXLINE - 1)) {
-					strcpy(cmd_write,file_name);
+					strcpy(cmd_write, file_name);
 					cmd_write += name_len;
 				}
 				continue;
@@ -127,8 +127,9 @@ emptyline:
 				next -= '0';
 				if (cmd->GetCount()<(unsigned int)next) continue;
 				std::string word;
-				if (!cmd->FindCommand(next,word)) continue;
-				size_t name_len = strlen(word.c_str());
+				if (!cmd->FindCommand(static_cast<unsigned>(next), word))
+					continue;
+				const auto name_len = static_cast<int>(strlen(word.c_str()));
 				if (((cmd_write - line) + name_len) < (CMD_MAXLINE - 1)) {
 					strcpy(cmd_write,word.c_str());
 					cmd_write += name_len;
@@ -145,7 +146,7 @@ emptyline:
 					const char* equals = strchr(env.c_str(),'=');
 					if (!equals) continue;
 					equals++;
-					size_t name_len = strlen(equals);
+					const auto name_len = static_cast<int>(strlen(equals));
 					if (((cmd_write - line) + name_len) < (CMD_MAXLINE - 1)) {
 						strcpy(cmd_write,equals);
 						cmd_write += name_len;

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -81,7 +81,7 @@ emptyline:
 				//Only add it if room for it (and trailing zero) in the buffer, but do the check here instead at the end
 				//So we continue reading till EOL/EOF
 				if (((cmd_write - temp) + 1) < (CMD_MAXLINE - 1))
-					*cmd_write++ = c;
+					*cmd_write++ = static_cast<char>(c);
 			} else {
 				if (c != '\n' && c != '\r')
 					shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
@@ -187,7 +187,7 @@ again:
 		if (n>0) {
 			if (c>31) {
 				if (((cmd_write - cmd_buffer) + 1) < (CMD_MAXLINE - 1))
-					*cmd_write++ = c;
+					*cmd_write++ = static_cast<char>(c);
 			} else {
 				if (c != '\n' && c != '\r')
 					shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -36,12 +36,16 @@ BatchFile::BatchFile(DOS_Shell *host,
 	  filename("")
 {
 	char totalname[DOS_PATHLENGTH+4];
-	DOS_Canonicalize(resolved_name,totalname); // Get fullname including drive specificiation
+
+	// Get fullname including drive specification
+	if (!DOS_Canonicalize(resolved_name, totalname))
+		E_Exit("SHELL: Can't determine path to batch file %s", resolved_name);
+
 	filename = totalname;
 	// Test if file is openable
 	if (!DOS_OpenFile(totalname,(DOS_NOT_INHERIT|OPEN_READ),&file_handle)) {
 		//TODO Come up with something better
-		E_Exit("SHELL:Can't open BatchFile %s",totalname);
+		E_Exit("SHELL:Can't open batch file %s", totalname);
 	}
 	DOS_CloseFile(file_handle);
 }
@@ -55,7 +59,7 @@ BatchFile::~BatchFile() {
 bool BatchFile::ReadLine(char * line) {
 	//Open the batchfile and seek to stored postion
 	if (!DOS_OpenFile(filename.c_str(),(DOS_NOT_INHERIT|OPEN_READ),&file_handle)) {
-		LOG(LOG_MISC,LOG_ERROR)("ReadLine Can't open BatchFile %s",filename.c_str());
+		LOG(LOG_MISC, LOG_ERROR)("ReadLine Can't open batch file %s", filename.c_str());
 		delete this;
 		return false;
 	}
@@ -165,7 +169,7 @@ emptyline:
 bool BatchFile::Goto(char * where) {
 	//Open bat file and search for the where string
 	if (!DOS_OpenFile(filename.c_str(),(DOS_NOT_INHERIT|OPEN_READ),&file_handle)) {
-		LOG(LOG_MISC,LOG_ERROR)("SHELL:Goto Can't open BatchFile %s",filename.c_str());
+		LOG(LOG_MISC, LOG_ERROR)("SHELL:Goto Can't open batch file %s", filename.c_str());
 		delete this;
 		return false;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -326,8 +326,8 @@ void DOS_Shell::CMD_CHDIR(char * args) {
 		DOS_GetCurrentDir(0,dir);
 		WriteOut("%c:\\%s\n",drive,dir);
 	} else if (strlen(args) == 2 && args[1] == ':') {
-		Bit8u targetdrive = (args[0] | 0x20) - 'a' + 1;
-		unsigned char targetdisplay = *reinterpret_cast<unsigned char*>(&args[0]);
+		const auto targetdrive = static_cast<uint8_t>((args[0] | 0x20) - 'a' + 1);
+		auto targetdisplay = *reinterpret_cast<unsigned char *>(&args[0]);
 		if (!DOS_GetCurrentDir(targetdrive,dir)) {
 			if (drive == 'Z') {
 				WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),toupper(targetdisplay));
@@ -1498,8 +1498,12 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	if (!rem || !*rem) rem = defchoice; /* No choices specified use YN */
 	ptr = rem;
 	Bit8u c;
-	if (!optS) while ((c = *ptr)) *ptr++ = (char)toupper(c); /* When in no case-sensitive mode. make everything upcase */
-	if (args && *args ) {
+
+	// Convert everything to uppercase if not case-sensitive
+	if (!optS)
+		while ((c = static_cast<uint8_t>(*ptr)))
+			*ptr++ = static_cast<char>(toupper(c)); 
+	if (args && *args) {
 		StripSpaces(args);
 		size_t argslen = strlen(args);
 		if (argslen > 1 && args[0] == '"' && args[argslen-1] == '"') {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -503,11 +503,12 @@ static std::vector<int> calc_column_widths(const std::vector<int> &word_widths,
 
 	// Actual terminal width (number of text columns) using current text
 	// mode; in practice it's either 40, 80, or 132.
-	const int term_width = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+	const auto term_width = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
 
 	// Use term_width-1 because we never want to print line up to the actual
 	// limit; this would cause unnecessary line wrapping
-	const size_t max_columns = (term_width - 1) / min_col_width;
+	const auto max_columns = (term_width - 1u) /
+	                         static_cast<unsigned>(min_col_width);
 	std::vector<int> col_widths(max_columns);
 
 	// This function returns true when column number is too high to fit
@@ -518,7 +519,7 @@ static std::vector<int> calc_column_widths(const std::vector<int> &word_widths,
 		if (coln <= 1)
 			return false;
 		int max_line_width = 0; // tally of the longest line
-		int c = 0;              // current columnt
+		size_t c = 0;           // current columnt
 		for (const int width : word_widths) {
 			const int old_col_width = col_widths[c];
 			const int new_col_width = std::max(old_col_width, width);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -552,7 +552,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 	}
 
 	bool optW=ScanCMDBool(args,"W");
-	ScanCMDBool(args,"S");
+	static_cast<void>(ScanCMDBool(args, "S"));
 	bool optP=ScanCMDBool(args,"P");
 	if (ScanCMDBool(args,"WP") || ScanCMDBool(args,"PW")) {
 		optW=optP=true;
@@ -895,9 +895,9 @@ void DOS_Shell::CMD_COPY(char * args) {
 	while (ScanCMDBool(args,"B")) ;
 	while (ScanCMDBool(args,"T")) ; //Shouldn't this be A ?
 	while (ScanCMDBool(args,"A")) ;
-	ScanCMDBool(args,"Y");
-	ScanCMDBool(args,"-Y");
-	ScanCMDBool(args,"V");
+	static_cast<void>(ScanCMDBool(args, "Y"));
+	static_cast<void>(ScanCMDBool(args, "-Y"));
+	static_cast<void>(ScanCMDBool(args, "V"));
 
 	char * rem=ScanCMDRemain(args);
 	if (rem) {
@@ -1407,10 +1407,10 @@ void DOS_Shell::CMD_SUBST (char * args) {
 
 		if (command.GetCount() != 2) throw 0 ;
 
-		command.FindCommand(1,arg);
+		static_cast<void>(command.FindCommand(1, arg));
 		if ( (arg.size() > 1) && arg[1] !=':')  throw(0);
 		temp_str[0]=(char)toupper(args[0]);
-		command.FindCommand(2,arg);
+		static_cast<void>(command.FindCommand(2, arg));
 		if ((arg == "/D") || (arg == "/d")) {
 			if (!Drives[temp_str[0]-'A'] ) throw 1; //targetdrive not in use
 			strcat(mountstring,"-u ");
@@ -1476,8 +1476,9 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	if (args) {
 		optN = ScanCMDBool(args,"N");
 		optS = ScanCMDBool(args,"S"); //Case-sensitive matching
-		ScanCMDBool(args,"T"); //Default Choice after timeout
-		char *last = strchr(args,0);
+		static_cast<void>(ScanCMDBool(args, "T")); // Default Choice
+		                                           // after timeout
+		char *last = strchr(args, 0);
 		StripSpaces(args);
 		rem = ScanCMDRemain(args);
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -78,7 +78,7 @@ void DOS_Shell::InputCommand(char * line) {
 					if (it_history != l_history.end() && it_history->length() > str_len) {
 						const char *reader = &(it_history->c_str())[str_len];
 						while ((c = *reader++)) {
-							line[str_index ++] = c;
+							line[str_index++] = static_cast<char>(c);
 							DOS_WriteFile(STDOUT,&c,&n);
 						}
 						str_len = str_index = (Bitu)it_history->length();
@@ -354,7 +354,7 @@ void DOS_Shell::InputCommand(char * line) {
 				size--;
 			};
 		   
-			line[str_index]=c;
+			line[str_index] = static_cast<char>(c);
 			str_index ++;
 			if (str_index > str_len){ 
 				line[str_index] = '\0';

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -77,11 +77,12 @@ void DOS_Shell::InputCommand(char * line) {
 					it_history = l_history.begin();
 					if (it_history != l_history.end() && it_history->length() > str_len) {
 						const char *reader = &(it_history->c_str())[str_len];
-						while ((c = *reader++)) {
+						while ((c = static_cast<uint8_t>(*reader++))) {
 							line[str_index++] = static_cast<char>(c);
-							DOS_WriteFile(STDOUT,&c,&n);
+							DOS_WriteFile(STDOUT, &c, &n);
 						}
-						str_len = str_index = (Bitu)it_history->length();
+						str_len = it_history->length();
+						str_index = it_history->length();
 						size = CMD_MAXLINE - str_index - 2;
 						line[str_len] = 0;
 					}
@@ -96,7 +97,7 @@ void DOS_Shell::InputCommand(char * line) {
 
 				case 0x4D:	/* RIGHT */
 					if (str_index < str_len) {
-						outc(line[str_index++]);
+						outc(static_cast<uint8_t>(line[str_index++]));
 					}
 					break;
 
@@ -109,11 +110,11 @@ void DOS_Shell::InputCommand(char * line) {
 
 				case 0x4F:	/* END */
 					while (str_index < str_len) {
-						outc(line[str_index++]);
-					}
-					break;
+					        outc(static_cast<uint8_t>(line[str_index++]));
+				        }
+				        break;
 
-				case 0x48:	/* UP */
+			        case 0x48:	/* UP */
 					if (l_history.empty() || it_history == l_history.end()) break;
 
 					// store current command in history if we are at beginning
@@ -211,8 +212,8 @@ void DOS_Shell::InputCommand(char * line) {
 					line[--str_len]=0;
 					str_index --;
 					/* Go back to redraw */
-					for (Bit16u i=str_index; i < str_len; i++)
-						outc(line[i]);
+					for (auto i = str_index; i < str_len; ++i)
+						outc(static_cast<uint8_t>(line[i]));
 				} else {
 					line[--str_index] = '\0';
 					str_len--;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -205,7 +205,7 @@ void DOS_Shell::InputCommand(char * line) {
 		case 0x08:				/* BackSpace */
 			if (str_index) {
 				outc(8);
-				Bit32u str_remain=str_len - str_index;
+				auto str_remain = str_len - str_index;
 				size++;
 				if (str_remain) {
 					memmove(&line[str_index-1],&line[str_index],str_remain);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -44,11 +44,13 @@ static void outc(Bit8u c) {
 }
 
 void DOS_Shell::InputCommand(char * line) {
-	Bitu size=CMD_MAXLINE-2; //lastcharacter+0
-	Bit8u c;Bit16u n=1;
-	Bitu str_len=0;Bitu str_index=0;
-	Bit16u len=0;
-	bool current_hist=false; // current command stored in history?
+	size_t size = CMD_MAXLINE - 2; //lastcharacter+0
+	uint8_t c;
+	uint16_t n = 1;
+	size_t str_len = 0;
+	size_t str_index = 0;
+	uint16_t len = 0;
+	bool current_hist = false; // current command stored in history?
 
 	line[0] = '\0';
 


### PR DESCRIPTION
Tentatively will address the 11 Coverity issues flagged in the Shell subsystem. 

Suggest reviewing commit by commit.
- Most of the changes merely switch from implicitly casts to explicit, when no other options are available.
- When possible, I adjust the type to better fit so fewer casts are needed.
- Some types are/were originally small because they're passed into functions that require them to be small (ie: `&uint16_t, &uint8_t), but the values they hold are the results from some math operations - so instead of just "casting away the warning", I check the math first with an assert to be sure we're not rolling over.

Tested as much as I could (batch files, command line tests, etc).



