### PR TITLE
Prevent shell from injecting spurious newlines

### DIFF
--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -149,7 +149,9 @@ bool Program::SuppressWriteOut(const char *format)
 	return true;
 }
 
-static char last_written_character = 0; // For 0xA to OxD 0xA expansion (\n to \r\n)
+// For "\n" to "\r\n" expansion (0xA to OxD 0xA) in WriteOut* functions
+static char last_written_character = '\n';
+
 void Program::WriteOut(const char *format, ...)
 {
 	if (SuppressWriteOut(format))
@@ -157,7 +159,7 @@ void Program::WriteOut(const char *format, ...)
 
 	char buf[2048];
 	va_list msg;
-	
+
 	va_start(msg,format);
 	vsnprintf(buf,2047,format,msg);
 	va_end(msg);
@@ -173,7 +175,7 @@ void Program::WriteOut(const char *format, ...)
 		DOS_WriteFile(STDOUT,&out,&s);
 	}
 	dos.internal_output=false;
-	
+
 //	DOS_WriteFile(STDOUT,(Bit8u *)buf,&size);
 }
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -371,10 +371,9 @@ void DOS_Shell::Run(void) {
 						ShowPrompt();
 						WriteOut_NoParsing(input_line);
 						WriteOut_NoParsing("\n");
-					};
-				};
+					}
+				}
 				ParseLine(input_line);
-				if (echo) WriteOut("\n");
 			}
 		} else {
 			if (echo) ShowPrompt();
@@ -656,8 +655,7 @@ void SHELL_Init() {
 	        "\xC8\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
 	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
 	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBC\033[0m\n"
-	        //"\n" //Breaks the startup message if you type a mount and a drive change.
-	);
+	        "\n");
 	MSG_Add("SHELL_STARTUP_SUB","\033[32;1mdosbox-staging %s\033[0m\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays/changes the current directory.\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG","CHDIR [drive:][path]\n"


### PR DESCRIPTION
Start interactive shell in a state as if newline was just written, thus
preventing first prompt from injecting newline (which is a workaround
for executables not printing newline).

Do not print additional newline after each line parsed in shell when
parsing bat files. This prevents spurious newlines from being inserted
in numerous usecases, such as:

- parsing lines (also the ones starting with '@') from autoexec section
- parsing SBLASTER line injected when SoundBlaster emulation is enabled
- parsing ordinary .bat files

After this change, behaviour of dosbox-staging shell matches the
behaviour of FreeDOS. It's also quite pleasant to get clean, empty
terminal on start when using dosbox.startup_verbosity = low.

Add one more newline after initial banner (to match old behaviour when
the newline was injected in the result of SBLASTER autoexec line) and
remove FUD comment.