### PR TITLE
Clean up remaining extra-semi warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 28
+            max_warnings: 8
           - name: Ubuntu, +debug
             os: ubuntu-latest
             flags: -c gcc

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 26
+            max_warnings: 6
           - name: GCC-9
             flags: -c gcc -v 9
             max_warnings: 311

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -256,12 +256,13 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 	// helper class to auto-save DH_FPU state on function exit
 	class auto_dh_fpu {
 	public:
-		~auto_dh_fpu(void) {
+		~auto_dh_fpu()
+		{
 #if defined(X86_DYNFPU_DH_ENABLED)
 			if (dyn_dh_fpu.state_used)
 				gen_dh_fpu_save();
 #endif
-		};
+		}
 	};
 	auto_dh_fpu fpu_saver;
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2215,7 +2215,11 @@ public:
 		Change_Config(configuration);	
 		CPU_JMP(false,0,0,0);					//Setup the first cpu core
 	}
-	bool Change_Config(Section* newconfig){
+
+	~CPU() override = default;
+
+	bool Change_Config(Section *newconfig) override
+	{
 		Section_prop * section=static_cast<Section_prop *>(newconfig);
 		CPU_AutoDetermineMode=CPU_AUTODETERMINE_NONE;
 		//CPU_CycleLeft=0;//needed ?
@@ -2385,9 +2389,8 @@ public:
 		else GFX_SetTitle(CPU_CycleMax,-1,false);
 		return true;
 	}
-	~CPU(){ /* empty */};
 };
-	
+
 static CPU * test;
 
 void CPU_ShutDown(Section* sec) {

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -35,7 +35,8 @@ DOS_Device * Devices[DOS_DEVICES];
 
 class device_NUL : public DOS_Device {
 public:
-	device_NUL() { SetName("NUL"); };
+	device_NUL() { SetName("NUL"); }
+
 	virtual bool Read(Bit8u * data,Bit16u * size) {
 		*size = 0; //Return success and no data read. 
 		LOG(LOG_IOCTL,LOG_NORMAL)("%s:READ",GetName());

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -61,12 +61,13 @@ static FILE* OpenDosboxFile(const char* name) {
 
 class keyboard_layout {
 public:
-	keyboard_layout() {
+	keyboard_layout()
+	{
 		this->reset();
 		language_codes=NULL;
 		use_foreign_layout=false;
 		sprintf(current_keyboard_file_name, "none");
-	};
+	}
 
 	~keyboard_layout();
 

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -63,16 +63,51 @@ static MountType MSCDEX_GetMountType(const char *path);
 class DOS_DeviceHeader : public MemStruct {
 public:
 	DOS_DeviceHeader(PhysPt ptr) { pt = ptr; }
-	
-	void	SetNextDeviceHeader	(RealPt ptr)	{ sSave(sDeviceHeader,nextDeviceHeader,ptr);	};
-	RealPt	GetNextDeviceHeader	(void)			{ return sGet(sDeviceHeader,nextDeviceHeader);	};
-	void	SetAttribute		(Bit16u atr)	{ sSave(sDeviceHeader,devAttributes,atr);		};
-	void	SetDriveLetter		(Bit8u letter)	{ sSave(sDeviceHeader,driveLetter,letter);		};
-	void	SetNumSubUnits		(Bit8u num)		{ sSave(sDeviceHeader,numSubUnits,num);			};
-	Bit8u	GetNumSubUnits		(void)			{ return sGet(sDeviceHeader,numSubUnits);		};
-	void	SetName				(char const* _name)	{ MEM_BlockWrite(pt+offsetof(sDeviceHeader,name),_name,8); };
-	void	SetInterrupt		(Bit16u ofs)	{ sSave(sDeviceHeader,interrupt,ofs);			};
-	void	SetStrategy			(Bit16u ofs)	{ sSave(sDeviceHeader,strategy,ofs);			};
+
+	void SetNextDeviceHeader(RealPt ptr)
+	{
+		sSave(sDeviceHeader, nextDeviceHeader, ptr);
+	}
+
+	RealPt GetNextDeviceHeader()
+	{
+		return sGet(sDeviceHeader, nextDeviceHeader);
+	}
+
+	void SetAttribute(uint16_t atr)
+	{
+		sSave(sDeviceHeader, devAttributes, atr);
+	}
+
+	void SetDriveLetter(uint8_t letter)
+	{
+		sSave(sDeviceHeader, driveLetter, letter);
+	}
+
+	void SetNumSubUnits(uint8_t num)
+	{
+		sSave(sDeviceHeader, numSubUnits, num);
+	}
+
+	uint8_t GetNumSubUnits()
+	{
+		return sGet(sDeviceHeader, numSubUnits);
+	}
+
+	void SetName(const char *new_name)
+	{
+		MEM_BlockWrite(pt + offsetof(sDeviceHeader, name), new_name, 8);
+	}
+
+	void SetInterrupt(uint16_t ofs)
+	{
+		sSave(sDeviceHeader, interrupt, ofs);
+	}
+
+	void SetStrategy(uint16_t offset)
+	{
+		sSave(sDeviceHeader, strategy, offset);
+	}
 
 public:
 	#ifdef _MSC_VER

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -387,10 +387,13 @@ public:
 		return CreateKeyBind((SDL_Scancode)code);
 	}
 
-	CBind * CreateEventBind(SDL_Event * event) {
-		if (event->type!=SDL_KEYDOWN) return 0;
+	CBind *CreateEventBind(SDL_Event *event)
+	{
+		if (event->type != SDL_KEYDOWN)
+			return nullptr;
 		return CreateKeyBind(event->key.keysym.scancode);
-	};
+	}
+
 	bool CheckEvent(SDL_Event * event) {
 		if (event->type!=SDL_KEYDOWN && event->type!=SDL_KEYUP) return false;
 		uintptr_t key = static_cast<uintptr_t>(event->key.keysym.scancode);
@@ -1683,9 +1686,7 @@ public:
 	CHandlerEvent(const CHandlerEvent&) = delete; // prevent copy
 	CHandlerEvent& operator=(const CHandlerEvent&) = delete; // prevent assignment
 
-	void Active(bool yesno) {
-		(*handler)(yesno);
-	};
+	void Active(bool yesno) { (*handler)(yesno); }
 
 	const char * ButtonName()
 	{

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -719,9 +719,7 @@ void Module::Init( Mode m ) {
 	}
 }
 
-}; //namespace
-
-
+} // namespace Adlib
 
 static Adlib::Module* module = 0;
 
@@ -900,8 +898,7 @@ Module::~Module() {
 //Initialize static members
 OPL_Mode Module::oplmode=OPL_none;
 
-};	//Adlib Namespace
-
+} // namespace Adlib
 
 void OPL_Init(Section* sec,OPL_Mode oplmode) {
 	Adlib::Module::oplmode = oplmode;

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -631,7 +631,7 @@ Channel::Channel() {
 	feedback = 31;
 	fourMask = 0;
 	synthHandler = &Channel::BlockTemplate< sm2FM >;
-};
+}
 
 void Channel::SetChanData( const Chip* chip, Bit32u data ) {
 	Bit32u change = chanData ^ data;
@@ -1533,5 +1533,4 @@ void Handler::Init( Bitu rate ) {
 	chip.Setup( rate );
 }
 
-
-};		//Namespace DBOPL
+} // namespace DBOPL

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -255,5 +255,4 @@ struct Handler : public Adlib::Handler {
 	virtual void Init( Bitu rate );
 };
 
-
-};		//Namespace
+} // namespace DBOPL


### PR DESCRIPTION
This PR removes all extra-semi warnings reported by our current gating CI.

*There are more warnings lurking in internal debugger(s) implementation, but we'll deal with them when appropriate (once Ubuntu 16.04 will reach EOL, which will allow us to enable -Wextra-semi in GCC builds across the board) - I don't want to deal with that right now, because debugger implementation(s) have lots of additional, more important warnings already - fixing them without gating in place is rather pointless, and implementing redundant gating is a hassle.*