### PR TITLE
Simplify drive_local's delete() function with actionable checks only

### DIFF
--- a/include/drives.h
+++ b/include/drives.h
@@ -78,9 +78,9 @@ public:
 	const char *GetBasedir() const { return basedir; }
 
 protected:
-	char basedir[CROSS_LEN];
+	char basedir[CROSS_LEN] = "";
 	struct {
-		char srch_dir[CROSS_LEN];
+		char srch_dir[CROSS_LEN] = "";
 	} srchInfo[MAX_OPENDIRS];
 
 private:

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -333,7 +333,10 @@ again:
  	if (~srch_attr & find_attr & (DOS_ATTR_DIRECTORY | DOS_ATTR_HIDDEN | DOS_ATTR_SYSTEM)) goto again;
 	
 	/*file is okay, setup everything to be copied in DTA Block */
-	char find_name[DOS_NAMELENGTH_ASCII];Bit16u find_date,find_time;Bit32u find_size;
+	char find_name[DOS_NAMELENGTH_ASCII] = "";
+	uint16_t find_date;
+	uint16_t find_time;
+	uint32_t find_size;
 
 	if (strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII) {
 		safe_strcpy(find_name, dir_entcopy);


### PR DESCRIPTION
A previous Coverity cleanup PR fixed all but one issue in `drive_local`.  This PR attempts to resolve that.

The delete function can either "get lucky" and delete the file straight-away, or dosbox itself might happen to be holding the file open, in which case we close it and try again. Failing those, then the file simply cannot be removed due to OS security or file-system access controls.

Extra checks to `fopen` and `stat` do nothing to alter the state of either of the above attempts, so these are eliminated.

The original code was also vulnerable to a time-of-check time-of-use vulnerability (CWE-367), which allows the underly file associated with the filename to be changed between the check (call to stat) and the use (call to unlink).