### PR TITLE
Never resample FM/OPL music

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -56,7 +56,9 @@ extern Bit8u MixTemp[MIXER_BUFSIZE];
 class MixerChannel {
 public:
 	MixerChannel(MIXER_Handler _handler, Bitu _freq, const char * _name);
-	void SetVolume(float _left,float _right);
+	uint32_t GetSampleRate() const;
+	bool IsInterpolated() const;
+	void SetVolume(float _left, float _right);
 	void SetScale(float f);
 	void SetScale(float _left, float _right);
 	void MapChannels(Bit8u _left, Bit8u _right);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -673,15 +673,9 @@ void DOSBOX_Init(void) {
 	const char* oplemus[] = {"default", "compat", "fast", "mame", "nuked", 0};
 	Pstring = secprop->Add_string("oplemu", Property::Changeable::WhenIdle, "default");
 	Pstring->Set_values(oplemus);
-	Pstring->Set_help("Provider for the OPL emulation. 'compat' provides better quality,\n"
-	                  "'nuked' is the default and most accurate (but the most CPU-intensive).\n"
-	                  "See sblaster.oplrate as well.");
-
-	const char *oplrates[] = {"44100", "49716", "48000", "32000", "22050", "16000", "11025", "8000", 0};
-	Pint = secprop->Add_int("oplrate", Property::Changeable::WhenIdle, 44100);
-	Pint->Set_values(oplrates);
-	Pint->Set_help("Sample rate of OPL music emulation. Use 49716 for the highest\n"
-	               "quality (set the mixer.rate accordingly).");
+	Pstring->Set_help(
+	        "Provider for the OPL emulation. 'compat' provides better quality,\n"
+	        "'nuked' is the default and most accurate (but the most CPU-intensive).\n");
 
 	// Configure Gravis UltraSound emulation
 	GUS_AddConfigSection(control);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -396,9 +396,11 @@ void DOSBOX_Init(void) {
 	Prop_multival *pmulti;
 	Prop_multival_remain* Pmulti_remain;
 
+	// Specifies if and when a setting can be changed 
 	constexpr auto always = Property::Changeable::Always;
-	constexpr auto when_idle = Property::Changeable::WhenIdle;
+	constexpr auto deprecated = Property::Changeable::Deprecated;
 	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
+	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	SDLNetInited = false;
 
@@ -663,6 +665,10 @@ void DOSBOX_Init(void) {
 
 	Pbool = secprop->Add_bool("sbmixer", Property::Changeable::WhenIdle, true);
 	Pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer.");
+
+	pint = secprop->Add_int("oplrate", deprecated, false);
+	pint->Set_help("oplrate is deprecated. The OPL waveform is now sampled\n"
+	               "        at the mixer's playback rate to avoid resampling.");
 
 	const char* oplmodes[] = {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", 0};
 	Pstring = secprop->Add_string("oplmode", Property::Changeable::WhenIdle, "auto");

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -839,18 +839,15 @@ Module::Module(Section *configuration)
 {
 	Section_prop * section=static_cast<Section_prop *>(configuration);
 	Bitu base = section->Get_hex("sbbase");
-	Bitu rate = section->Get_int("oplrate");
-	//Make sure we can't select lower than 8000 to prevent fixed point issues
-	if ( rate < 8000 )
-		rate = 8000;
+
 	ctrl.mixer = section->Get_bool("sbmixer");
 
-	mixerChan = mixerObject.Install(OPL_CallBack,rate,"FM");
+	mixerChan = mixerObject.Install(OPL_CallBack, 0, "FM");
 	//Used to be 2.0, which was measured to be too high. Exact value depends on card/clone.
 	mixerChan->SetScale( 1.5f );  
 
 	handler = make_opl_handler(section->Get_string("oplemu"), oplmode);
-	handler->Init(rate);
+	handler->Init(mixerChan->GetSampleRate());
 
 	bool single = false;
 	switch ( oplmode ) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -121,6 +121,16 @@ MixerChannel * MIXER_AddChannel(MIXER_Handler handler, Bitu freq, const char * n
 	chan->MapChannels(0, 1);
 	chan->Enable(false);
 	mixer.channels=chan;
+
+	const auto mix_rate = mixer.freq;
+	const auto chan_rate = chan->GetSampleRate();
+	if (chan_rate == mix_rate)
+		LOG_MSG("MIXER: %s channel operating at %u Hz without resampling",
+		        name, chan_rate);
+	else
+		LOG_MSG("MIXER: %s channel operating at %u Hz and %s to the output rate",
+		        name, chan_rate,
+		        chan_rate > mix_rate ? "downsampling" : "upsampling");
 	return chan;
 }
 
@@ -248,6 +258,16 @@ void MixerChannel::SetFreq(Bitu freq) {
 	sample_rate = static_cast<uint32_t>(freq);
 	envelope.Update(sample_rate, peak_amplitude,
 	                ENVELOPE_MAX_EXPANSION_OVER_MS, ENVELOPE_EXPIRES_AFTER_S);
+}
+
+bool MixerChannel::IsInterpolated() const
+{
+	return interpolate;
+}
+
+uint32_t MixerChannel::GetSampleRate() const
+{
+	return sample_rate;
 }
 
 void MixerChannel::SetPeakAmplitude(const uint32_t peak)

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -252,8 +252,15 @@ void MixerChannel::Enable(const bool should_enable)
 	MIXER_UnlockAudioDevice();
 }
 
-void MixerChannel::SetFreq(Bitu freq) {
-	freq_add=(freq<<FREQ_SHIFT)/mixer.freq;
+void MixerChannel::SetFreq(Bitu freq)
+{
+	if (!freq) {
+		// If the channel rate is zero, then avoid resampling by running
+		// the channel at the same rate as the mixer
+		assert(mixer.freq > 0);
+		freq = mixer.freq;
+	}
+	freq_add = (freq << FREQ_SHIFT) / mixer.freq;
 	interpolate = (freq != mixer.freq);
 	sample_rate = static_cast<uint32_t>(freq);
 	envelope.Update(sample_rate, peak_amplitude,


### PR DESCRIPTION
This PR operates the OPL generator at the mixer's native output rate which retains more dynamic range [per analysis](https://github.com/dosbox-staging/dosbox-staging/pull/546#issuecomment-674462256) performed by @grapeli (thank you!) while avoiding:
- wasting CPU cycles by over-sampling the OPL
- wasting CPU cycles by resampling the FM channel back down in the mixer
- introducing resampling artifacts in the output stream

This came about by asking:

1. Should we run the Adlib OPL emulator at 49716 Hz and then resample back down to the mixer's output rate or, 

1. Should we run the Adlib OPL emulator at the mixer's output rate (eliminating the CPU cost of the higher OPL rate as well as the CPU cost, latency, and added arifacts of resampling).

Two recordings were taken from Blues Brothers:

1. `oplrate = 49716` Hz resampled back down to 16000 Hz.  
2. `oplrate = 16000` Hz, saved natively at 16000 Hz. 

No visual difference was seen in the wave forms (zoomed in or out in Audacity), here's the first second of audio:

![2020-08-15_12-57](https://user-images.githubusercontent.com/1557255/90320860-6622c880-def9-11ea-8e01-981aedd6110a.png)
![2020-08-15_12-58](https://user-images.githubusercontent.com/1557255/90320861-66bb5f00-def9-11ea-9ee8-b341df511005.png)

Likewise no audible difference was heard when using decent Sennheiser headphones, and repeating sections over and over.

Perhaps the first recording still contains more information? 

To answer this, FLAC compression was used to measure the information content (or entropy), which from [information theory](https://en.wikipedia.org/wiki/Entropy_(information_theory)#Data_compression) says that the entropy rate of a data source can be measured by the average number of bits per symbol needed to encode it.

FLAC was able to compress both recordings to the same reported level of compression and inspecting the actual byte-quantities in the resulting FLAC files differed by a mere 0.039%. 

[comparison.zip](https://github.com/dosbox-staging/dosbox-staging/files/5079404/comparison.zip)

So this confirms we're not losing any information by running OPL at the mixer's direct output rate, and in doing so we avoid:
- wasting CPU cycles by over-sampling the OPL
- wasting CPU cycles by resampling the FM channel back down in the mixer
- introducing resampling artifacts in the output stream