### PR TITLE
Fix a couple warnings in shell and cleanup drive index conversion

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -39,6 +39,11 @@
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
+// Some C functions operate on characters but return integers,
+// such as 'toupper'. This function asserts that a given int
+// is in-range of a char and returns it as such.
+char int_to_char(int val);
+
 /*
  *  Converts a string to a finite number (such as float or double).
  *  Returns the number or quiet_NaN, if it could not be parsed.

--- a/include/support.h
+++ b/include/support.h
@@ -44,6 +44,11 @@
 // is in-range of a char and returns it as such.
 char int_to_char(int val);
 
+// Given a case-insensitive drive letter (a/A .. z/Z),
+// returns a zero-based index starting at 0 for drive A
+// through to 26 for drive Z.
+uint8_t drive_index(char drive);
+
 /*
  *  Converts a string to a finite number (such as float or double).
  *  Returns the number or quiet_NaN, if it could not be parsed.

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -16,11 +16,11 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <string.h>
-#include <stdlib.h>
-#include <time.h>
+#include <climits>
 #include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #include "dosbox.h"
 #include "bios.h"
@@ -808,6 +808,7 @@ static bool isvalid(const char in){
 #define PARSE_RET_WILD          1
 #define PARSE_RET_BADDRIVE      0xff
 
+// TODO: Refactor and document this function until it's understandable
 Bit8u FCB_Parsename(Bit16u seg,Bit16u offset,Bit8u parser ,char *string, Bit8u *change) {
 	char * string_begin=string;
 	Bit8u ret=0;
@@ -838,8 +839,11 @@ Bit8u FCB_Parsename(Bit16u seg,Bit16u offset,Bit8u parser ,char *string, Bit8u *
 #endif
 	/* Get the old information from the previous fcb */
 	fcb.GetName(fcb_name.full);
-	fcb_name.part.drive[0]-='A'-1;fcb_name.part.drive[1]=0;
-	fcb_name.part.name[8]=0;fcb_name.part.ext[3]=0;
+	auto drive_idx = drive_index(fcb_name.part.drive[0]) + 1;
+	fcb_name.part.drive[0] = int_to_char(drive_idx);
+	fcb_name.part.drive[1] = 0;
+	fcb_name.part.name[8] = 0;
+	fcb_name.part.ext[3] = 0;
 	/* strip leading spaces */
 	while((*string==' ')||(*string=='\t')) string++;
 
@@ -859,11 +863,15 @@ Bit8u FCB_Parsename(Bit16u seg,Bit16u offset,Bit8u parser ,char *string, Bit8u *
 		if (!isvalid(toupper(d))) {string += 2; goto savefcb;} //TODO check (for ret value)
 		fcb_name.part.drive[0]=0;
 		hasdrive=true;
-		if (isalpha(d) && Drives[toupper(d)-'A']) { //Floppies under dos always exist, but don't bother with that at this level
-			; //THIS* was here
-		} else ret=0xff;
-		fcb_name.part.drive[0]=DOS_ToUpper(string[0])-'A'+1; //Always do THIS* and continue parsing, just return the right code
-		string+=2;
+
+		// Floppies under dos always exist, but don't bother with that at this level
+		assert(d <= CHAR_MAX); // drive letters are strictly "low" ASCII a/A to z/Z
+		if (!(isalpha(d) && Drives[drive_index(static_cast<char>(d))])) {
+			ret = 0xff;
+		}
+		// Always do THIS* and continue parsing, just return the right code
+		fcb_name.part.drive[0] = DOS_ToUpper(string[0]) - 'A' + 1;
+		string += 2;
 	}
 
 	/* Check for extension only file names */

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1308,21 +1308,25 @@ bool device_MSCDEX::WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * ret
 	return false;
 }
 
+// TODO: this functions modifies physicalPath despite several callers passing it
+// a const char*. Figure out if a copy can suffice or if the it really should
+// change it upstream (in which case we should drop const and fix the callers).
 int MSCDEX_AddDrive(char driveLetter, const char* physicalPath, Bit8u& subUnit)
 {
-	int result = mscdex->AddDrive(driveLetter-'A',(char*)physicalPath,subUnit);
+	int result = mscdex->AddDrive(drive_index(driveLetter),
+	                              const_cast<char*>(physicalPath), subUnit);
 	return result;
 }
 
 int MSCDEX_RemoveDrive(char driveLetter)
 {
 	if(!mscdex) return 0;
-	return mscdex->RemoveDrive(driveLetter-'A');
+	return mscdex->RemoveDrive(drive_index(driveLetter));
 }
 
 bool MSCDEX_HasDrive(char driveLetter)
 {
-	return mscdex->HasDrive(driveLetter-'A');
+	return mscdex->HasDrive(drive_index(driveLetter));
 }
 
 void MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, Bit8u subUnit)
@@ -1332,7 +1336,7 @@ void MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, Bit8u subUnit)
 
 Bit8u MSCDEX_GetSubUnit(char driveLetter)
 {
-	return mscdex->GetSubUnit(driveLetter-'A');
+	return mscdex->GetSubUnit(drive_index(driveLetter));
 }
 
 bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -259,7 +259,7 @@ public:
 			// get the drive letter
 			cmd->FindCommand(1,temp_line);
 			if ((temp_line.size() > 2) || ((temp_line.size() > 1) && (temp_line[1]!=':'))) goto showusage;
-			int i_drive = toupper(temp_line[0]);
+			const int i_drive = toupper(temp_line[0]);
 
 			if (!isalpha(i_drive)) {
 				goto showusage;
@@ -267,7 +267,7 @@ public:
 			if ((i_drive - 'A') >= DOS_DRIVES || (i_drive - 'A') < 0 ) {
 				goto showusage;
 			}
-			drive = static_cast<char>(i_drive);
+			drive = int_to_char(i_drive);
 			if (type == "overlay") {
 				//Ensure that the base drive exists:
 				if (!Drives[drive_index(drive)]) {
@@ -1257,12 +1257,13 @@ public:
 				WriteOut_NoParsing(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_DRIVE"));
 				return;
 			}
-			int i_drive = toupper(temp_line[0]);
-			if (!isalpha(i_drive) || (i_drive - 'A') >= DOS_DRIVES || (i_drive - 'A') <0) {
+			const int i_drive = toupper(temp_line[0]);
+			if (!isalpha(i_drive) || (i_drive - 'A') >= DOS_DRIVES ||
+			    (i_drive - 'A') < 0) {
 				WriteOut_NoParsing(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_DRIVE"));
 				return;
 			}
-			drive = static_cast<char>(i_drive);
+			drive = int_to_char(i_drive);
 		} else if (fstype=="none") {
 			cmd->FindCommand(1,temp_line);
 			if ((temp_line.size() > 1) || (!isdigit(temp_line[0]))) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -617,7 +617,7 @@ public:
 		Bit32u floppysize=0;
 		Bit32u rombytesize_1=0;
 		Bit32u rombytesize_2=0;
-		Bit8u drive = 'A';
+		char drive = 'A';
 		std::string cart_cmd="";
 
 		if (!cmd->GetCount()) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -261,10 +261,7 @@ public:
 			if ((temp_line.size() > 2) || ((temp_line.size() > 1) && (temp_line[1]!=':'))) goto showusage;
 			const int i_drive = toupper(temp_line[0]);
 
-			if (!isalpha(i_drive)) {
-				goto showusage;
-			}
-			if ((i_drive - 'A') >= DOS_DRIVES || (i_drive - 'A') < 0 ) {
+			if (i_drive < 'A' || i_drive > 'Z') {
 				goto showusage;
 			}
 			drive = int_to_char(i_drive);
@@ -1258,8 +1255,7 @@ public:
 				return;
 			}
 			const int i_drive = toupper(temp_line[0]);
-			if (!isalpha(i_drive) || (i_drive - 'A') >= DOS_DRIVES ||
-			    (i_drive - 'A') < 0) {
+			if (i_drive < 'A' || i_drive > 'Z') {
 				WriteOut_NoParsing(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_DRIVE"));
 				return;
 			}

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <cctype>
+#include <climits>
 #include <cmath>
 #include <cstring>
 #include <ctype.h>
@@ -36,7 +37,17 @@
 #include "debug.h"
 #include "video.h"
 
-std::string get_basename(const std::string& filename) {
+char int_to_char(int val)
+{
+	// To handle inbound values cast from unsigned chars, permit a slightly
+	// wider range to avoid triggering the assert when processing international
+	// ASCII values between 128 and 255.
+	assert(val >= CHAR_MIN && val <= UCHAR_MAX);
+	return static_cast<char>(val);
+}
+
+std::string get_basename(const std::string &filename)
+{
 	// Guard against corner cases: '', '/', '\', 'a'
 	if (filename.length() <= 1)
 		return filename;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -46,6 +46,14 @@ char int_to_char(int val)
 	return static_cast<char>(val);
 }
 
+uint8_t drive_index(char drive)
+{
+	const auto drive_letter = int_to_char(toupper(drive));
+	// Confirm the provided drive is valid
+	assert(drive_letter >= 'A' && drive_letter <= 'Z');
+	return static_cast<uint8_t>(drive_letter - 'A');
+}
+
 std::string get_basename(const std::string &filename)
 {
 	// Guard against corner cases: '', '/', '\', 'a'

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -16,15 +16,16 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "shell.h"
 
-#include <stdlib.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include "callback.h"
+#include "control.h"
 #include "dosbox.h"
 #include "regs.h"
-#include "control.h"
-#include "shell.h"
-#include "callback.h"
 #include "support.h"
 
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -447,9 +447,10 @@ public:
 		char orig[CROSS_LEN+1];
 		char cross_filesplit[2] = {CROSS_FILESPLIT , 0};
 
-		Bitu dummy = 1;
+		unsigned int command_index = 1;
 		bool command_found = false;
-		while (control->cmdline->FindCommand(dummy++,line) && !command_found) {
+		while (control->cmdline->FindCommand(command_index++, line) &&
+		       !command_found) {
 			struct stat test;
 			if (line.length() > CROSS_LEN) continue;
 			safe_strcpy(buffer, line.c_str());

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -609,7 +609,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 		*last_dir_sep = '\0';
 
 	const char drive_letter = path[0];
-	const size_t drive_idx = drive_letter - 'A';
+	const auto drive_idx = drive_index(drive_letter);
 	const bool print_label = (drive_letter >= 'A') && Drives[drive_idx];
 	unsigned p_count = 0; // line counter for 'pause' command
 
@@ -1411,16 +1411,19 @@ void DOS_Shell::CMD_SUBST (char * args) {
 		if ( (arg.size() > 1) && arg[1] !=':')  throw(0);
 		temp_str[0]=(char)toupper(args[0]);
 		command.FindCommand(2,arg);
+		const auto drive_idx = drive_index(temp_str[0]);
 		if ((arg == "/D") || (arg == "/d")) {
-			if (!Drives[temp_str[0]-'A'] ) throw 1; //targetdrive not in use
-			strcat(mountstring,"-u ");
-			strcat(mountstring,temp_str);
+			if (!Drives[drive_idx])
+				throw 1; // targetdrive not in use
+			strcat(mountstring, "-u ");
+			strcat(mountstring, temp_str);
 			this->ParseLine(mountstring);
 			return;
 		}
-		if (Drives[temp_str[0]-'A'] ) throw 0; //targetdrive in use
-		strcat(mountstring,temp_str);
-		strcat(mountstring," ");
+		if (Drives[drive_idx])
+			throw 0; // targetdrive in use
+		strcat(mountstring, temp_str);
+		strcat(mountstring, " ");
 
    		Bit8u drive;char fulldir[DOS_PATHLENGTH];
 		if (!DOS_MakeName(const_cast<char*>(arg.c_str()),fulldir,&drive)) throw 0;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -403,8 +403,10 @@ bool DOS_Shell::Execute(char * name,char * args) {
 	/* check for a drive change */
 	if (((strcmp(name + 1, ":") == 0) || (strcmp(name + 1, ":\\") == 0)) && isalpha(*name))
 	{
-		if (!DOS_SetDrive(toupper(name[0])-'A')) {
-			WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),toupper(name[0]));
+		const auto drive_idx = drive_index(name[0]);
+		if (!DOS_SetDrive(drive_idx)) {
+			WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),
+			         toupper(name[0]));
 		}
 		return true;
 	}


### PR DESCRIPTION
Decided to cut this off when I noticed the drive index changes where piling up; so kept it to a manageable amount.

Suggest reviewing commit by commit.  

When I mention warning fixes, I build with `./scripts/build.sh -c clang -v 10 -t warnmore`, which seems to catch more than our worst-case in CI; do you have clang v10 locally?

The drive cleanup was an excellent suggestion, and was relatively straightforward too. I just scoped this to strict replacements to avoid regressions (but using fine-grained commits if we need to bisect). 

