### PR TITLE
(Draft) Fix all remaining undefined-behaviour violations

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -93,7 +93,7 @@ jobs:
         conf:
           - name: Clang
             sanitizers: USAN
-            usan:  13
+            usan:  0  # cleared out all issues so far
             tsan:  -1
             uasan: -1
           - name: GCC

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -93,7 +93,7 @@ jobs:
         conf:
           - name: Clang
             sanitizers: USAN
-            usan:  25
+            usan:  13
             tsan:  -1
             uasan: -1
           - name: GCC

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -93,7 +93,7 @@ jobs:
         conf:
           - name: Clang
             sanitizers: USAN
-            usan:  86
+            usan:  25
             tsan:  -1
             uasan: -1
           - name: GCC

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 319
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2171
+            max_warnings: 2061
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 319
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2054
+            max_warnings: 2051
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 319
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2061
+            max_warnings: 2054
     steps:
       - uses:  actions/checkout@v2
       - name:  Install packages

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -301,6 +301,8 @@ constexpr PhysPt assert_macro_args_ok()
 #define SGET_DWORD(s, f)                                                       \
 	mem_readd(VERIFY_SGET_ARGS(4, s, f) + pt + offsetof(s, f))
 
+/* Program Segment Prefix
+ */
 class DOS_PSP : public MemStruct {
 public:
 	DOS_PSP(uint16_t segment) : MemStruct(segment), seg(segment) {}
@@ -494,6 +496,8 @@ public:
 	Bit16u	seg;
 };
 
+/* Disk/Data Transfer Address
+ */
 class DOS_DTA : public MemStruct {
 public:
 	DOS_DTA(RealPt addr) : MemStruct(addr) {}
@@ -542,6 +546,8 @@ private:
 	#endif
 };
 
+/* File Control Block
+ */
 class DOS_FCB: public MemStruct {
 public:
 	DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended = true);
@@ -601,6 +607,8 @@ private:
 	#endif
 };
 
+/* Memory Control Block
+ */
 class DOS_MCB : public MemStruct {
 public:
 	DOS_MCB(uint16_t seg) : MemStruct(seg, 0) {}

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -338,32 +338,29 @@ public:
 	void	SaveVectors			(void);
 	void	RestoreVectors		(void);
 
-	void SetSize(uint16_t size) { sSave(sPSP, next_seg, size); }
-	uint16_t GetSize() { return (uint16_t)sGet(sPSP, next_seg); }
-
-	void SetEnvironment(uint16_t eseg) { sSave(sPSP, environment, eseg); }
-	uint16_t GetEnvironment() { return (uint16_t)sGet(sPSP, environment); }
-
 	uint16_t GetSegment() { return seg; }
 
 	void	SetFileHandle		(Bit16u index, Bit8u handle);
 	Bit8u	GetFileHandle		(Bit16u index);
-
-	void SetParent(uint16_t parent) { sSave(sPSP, psp_parent, parent); }
-	uint16_t GetParent() { return (uint16_t)sGet(sPSP, psp_parent); }
-
-	void SetStack(RealPt stackpt) { sSave(sPSP, stack, stackpt); }
-	RealPt GetStack() { return sGet(sPSP, stack); }
-
-	void SetInt22(RealPt int22pt) { sSave(sPSP, int_22, int22pt); }
-	RealPt GetInt22() { return sGet(sPSP, int_22); }
 
 	void	SetFCB1				(RealPt src);
 	void	SetFCB2				(RealPt src);
 	void	SetCommandTail		(RealPt src);	
 	bool	SetNumFiles			(Bit16u fileNum);
 	Bit16u	FindEntryByHandle	(Bit8u handle);
-			
+
+	void SetSize(uint16_t size) { SSET_WORD(sPSP, next_seg, size); }
+	void SetInt22(RealPt int22pt) { SSET_DWORD(sPSP, int_22, int22pt); }
+	void SetParent(uint16_t parent) { SSET_WORD(sPSP, psp_parent, parent); }
+	void SetEnvironment(uint16_t env) { SSET_WORD(sPSP, environment, env); }
+	void SetStack(RealPt stackpt) { SSET_DWORD(sPSP, stack, stackpt); }
+
+	uint16_t GetSize() const { return SGET_WORD(sPSP, next_seg); }
+	RealPt GetInt22() const { return SGET_DWORD(sPSP, int_22); }
+	uint16_t GetParent() const { return SGET_WORD(sPSP, psp_parent); }
+	uint16_t GetEnvironment() const { return SGET_WORD(sPSP, environment); }
+	RealPt GetStack() const { return SGET_DWORD(sPSP, stack); }
+
 private:
 	#ifdef _MSC_VER
 	#pragma pack(1)
@@ -412,9 +409,11 @@ public:
 	{
 		pt = addr;
 	}
-	void Clear(void);
-	void LoadData(void);
-	void SaveData(void);		/* Save it as an exec block */
+
+	void Clear();
+	void LoadData();
+	void SaveData(); // Save it as an exec block
+
 	#ifdef _MSC_VER
 	#pragma pack (1)
 	#endif
@@ -437,30 +436,34 @@ public:
 	sOverlay overlay;
 };
 
-class DOS_InfoBlock:public MemStruct {
+class DOS_InfoBlock : public MemStruct {
 public:
-	DOS_InfoBlock()
-		: seg(0)
-	{}
+	DOS_InfoBlock() : seg(0) {}
+
 	void SetLocation(Bit16u  seg);
-	void SetFirstMCB(Bit16u _first_mcb);
-	void SetBuffers(Bit16u x,Bit16u y);
-	void SetCurDirStruct(Bit32u _curdirstruct);
-	void SetFCBTable(Bit32u _fcbtable);
+	void SetBuffers(uint16_t x, uint16_t y);
+
 	void SetDeviceChainStart(Bit32u _devchain);
 	void SetDiskBufferHeadPt(Bit32u _dbheadpt);
-	void SetStartOfUMBChain(Bit16u _umbstartseg);
-	void SetUMBChainState(Bit8u _umbchaining);
 	void SetBlockDevices(Bit8u _count);
-	Bit16u	GetStartOfUMBChain(void);
+
 	Bit8u	GetUMBChainState(void);
 	RealPt	GetPointer(void);
-	Bit32u GetDeviceChain(void);
 
-	#ifdef _MSC_VER
+	void SetFirstMCB(uint16_t mcb) { SSET_WORD(sDIB, firstMCB, mcb); }
+	void SetCurDirStruct(uint32_t cds) { SSET_DWORD(sDIB, curDirStructure, cds); }
+	void SetFCBTable(uint32_t tab) { SSET_DWORD(sDIB, fcbTable, tab); }
+	void SetUMBChainState(uint8_t state) { SSET_BYTE(sDIB, chainingUMB, state); }
+	void SetStartOfUMBChain(uint16_t seg) { SSET_WORD(sDIB, startOfUMBChain, seg); }
+
+	uint32_t GetDeviceChain() const { return SGET_DWORD(sDIB, nulNextDriver); }
+	uint16_t GetStartOfUMBChain() const { return SGET_WORD(sDIB, startOfUMBChain); }
+
+
+#ifdef _MSC_VER
 	#pragma pack(1)
 	#endif
-	struct sDIB {		
+	struct sDIB {
 		Bit8u	unknown1[4];
 		Bit16u	magicWord;			// -0x22 needs to be 1
 		Bit8u	unknown2[8];
@@ -527,10 +530,11 @@ public:
 	void GetSearchParams(Bit8u & _sattr,char * _spattern);
 	void GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr);
 
-	void SetDirID(uint16_t entry) { sSave(sDTA, dirID, entry); }
-	void SetDirIDCluster(uint16_t entry) { sSave(sDTA, dirCluster, entry); }
-	uint16_t GetDirID() { return (uint16_t)sGet(sDTA, dirID); }
-	uint16_t GetDirIDCluster() { return (uint16_t)sGet(sDTA, dirCluster); }
+	void SetDirID(uint16_t id) { SSET_WORD(sDTA, dirID, id); }
+	void SetDirIDCluster(uint16_t cl) { SSET_WORD(sDTA, dirCluster, cl); }
+
+	uint16_t GetDirID() const { return SGET_WORD(sDTA, dirID); }
+	uint16_t GetDirIDCluster() const { return SGET_WORD(sDTA, dirCluster); }
 
 private:
 	#ifdef _MSC_VER
@@ -613,14 +617,18 @@ private:
 class DOS_MCB : public MemStruct{
 public:
 	DOS_MCB(Bit16u seg) { SetPt(seg); }
+
 	void SetFileName(char const * const _name) { MEM_BlockWrite(pt+offsetof(sMCB,filename),_name,8); }
 	void GetFileName(char * const _name) { MEM_BlockRead(pt+offsetof(sMCB,filename),_name,8);_name[8]=0;}
-	void SetType(Bit8u _type) { sSave(sMCB,type,_type);}
-	void SetSize(Bit16u _size) { sSave(sMCB,size,_size);}
-	void SetPSPSeg(Bit16u _pspseg) { sSave(sMCB,psp_segment,_pspseg);}
-	Bit8u GetType(void) { return (Bit8u)sGet(sMCB,type);}
-	Bit16u GetSize(void) { return (Bit16u)sGet(sMCB,size);}
-	Bit16u GetPSPSeg(void) { return (Bit16u)sGet(sMCB,psp_segment);}
+
+	void SetType(uint8_t type) { SSET_BYTE(sMCB, type, type); }
+	void SetSize(uint16_t size) { SSET_WORD(sMCB, size, size); }
+	void SetPSPSeg(uint16_t psp) { SSET_WORD(sMCB, psp_segment, psp); }
+
+	uint8_t GetType() const { return SGET_BYTE(sMCB, type); }
+	uint16_t GetSize() const { return SGET_WORD(sMCB, size); }
+	uint16_t GetPSPSeg() const { return SGET_WORD(sMCB, psp_segment); }
+
 private:
 	#ifdef _MSC_VER
 	#pragma pack (1)
@@ -640,15 +648,16 @@ private:
 class DOS_SDA : public MemStruct {
 public:
 	DOS_SDA(Bit16u _seg,Bit16u _offs) { SetPt(_seg,_offs); }
-	void Init();   
-	void SetDrive(Bit8u _drive) { sSave(sSDA,current_drive, _drive); }
-	void SetDTA(Bit32u _dta) { sSave(sSDA,current_dta, _dta); }
-	void SetPSP(Bit16u _psp) { sSave(sSDA,current_psp, _psp); }
-	Bit8u GetDrive(void) { return (Bit8u)sGet(sSDA,current_drive); }
-	Bit16u GetPSP(void) { return (Bit16u)sGet(sSDA,current_psp); }
-	Bit32u GetDTA(void) { return (Bit32u)sGet(sSDA,current_dta); }
-	
-	
+	void Init();
+
+	void SetDTA(uint32_t dta) { SSET_DWORD(sSDA, current_dta, dta); }
+	void SetPSP(uint16_t psp) { SSET_WORD(sSDA, current_psp, psp); }
+	void SetDrive(uint8_t drive) { SSET_BYTE(sSDA, current_drive, drive); }
+
+	uint32_t GetDTA() const { return SGET_DWORD(sSDA, current_dta); }
+	uint16_t GetPSP() const { return SGET_WORD(sSDA, current_psp); }
+	uint8_t GetDrive() const { return SGET_BYTE(sSDA, current_drive); }
+
 private:
 	#ifdef _MSC_VER
 	#pragma pack (1)

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -341,7 +341,7 @@ public:
 	uint16_t GetSegment() { return seg; }
 
 	void	SetFileHandle		(Bit16u index, Bit8u handle);
-	Bit8u	GetFileHandle		(Bit16u index);
+	uint8_t GetFileHandle(uint16_t index);
 
 	void	SetFCB1				(RealPt src);
 	void	SetFCB2				(RealPt src);
@@ -440,25 +440,26 @@ class DOS_InfoBlock : public MemStruct {
 public:
 	DOS_InfoBlock() : seg(0) {}
 
-	void SetLocation(Bit16u  seg);
+	void SetLocation(uint16_t segment);
 	void SetBuffers(uint16_t x, uint16_t y);
 
-	void SetDeviceChainStart(Bit32u _devchain);
-	void SetDiskBufferHeadPt(Bit32u _dbheadpt);
-	void SetBlockDevices(Bit8u _count);
+	RealPt GetPointer() const
+	{
+		return RealMake(seg, offsetof(sDIB, firstDPB));
+	}
 
-	Bit8u	GetUMBChainState(void);
-	RealPt	GetPointer(void);
-
+	void SetDiskBufferHeadPt(uint32_t db) { SSET_DWORD(sDIB, diskBufferHeadPt, db); }
 	void SetFirstMCB(uint16_t mcb) { SSET_WORD(sDIB, firstMCB, mcb); }
 	void SetCurDirStruct(uint32_t cds) { SSET_DWORD(sDIB, curDirStructure, cds); }
 	void SetFCBTable(uint32_t tab) { SSET_DWORD(sDIB, fcbTable, tab); }
+	void SetBlockDevices(uint8_t num) { SSET_BYTE(sDIB, blockDevices, num); }
+	void SetDeviceChainStart(uint32_t chain) { SSET_DWORD(sDIB, nulNextDriver, chain); }
 	void SetUMBChainState(uint8_t state) { SSET_BYTE(sDIB, chainingUMB, state); }
 	void SetStartOfUMBChain(uint16_t seg) { SSET_WORD(sDIB, startOfUMBChain, seg); }
 
 	uint32_t GetDeviceChain() const { return SGET_DWORD(sDIB, nulNextDriver); }
+	uint8_t GetUMBChainState() const { return SGET_BYTE(sDIB, chainingUMB); }
 	uint16_t GetStartOfUMBChain() const { return SGET_WORD(sDIB, startOfUMBChain); }
-
 
 #ifdef _MSC_VER
 	#pragma pack(1)

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -277,7 +277,7 @@ protected:
  * pointer.
  *
  * Example usage:
- * 
+ *
  *   SSET_WORD(dos-structure-name, field-name, value);
  *   uint16_t x = SGET_WORD(dos-structure-name, field-name);
  *

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -247,21 +247,8 @@ static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
 #define DOSERR_NO_MORE_FILES 18
 #define DOSERR_FILE_ALREADY_EXISTS 80
 
-
-/* Remains some classes used to access certain things */
-#define sOffset(s,m) ((char*)&(((s*)NULL)->m)-(char*)NULL)
-#define sGet(s,m) GetIt(sizeof(((s *)&pt)->m),(PhysPt)sOffset(s,m))
-
 class MemStruct {
 public:
-	Bitu GetIt(Bitu size,PhysPt addr) {
-		switch (size) {
-		case 1:return mem_readb(pt+addr);
-		case 2:return mem_readw(pt+addr);
-		case 4:return mem_readd(pt+addr);
-		}
-		return 0;
-	}
 	void SetPt(Bit16u seg) { pt=PhysMake(seg,0);}
 	void SetPt(Bit16u seg,Bit16u off) { pt=PhysMake(seg,off);}
 	void SetPt(RealPt addr) { pt=Real2Phys(addr);}
@@ -280,9 +267,6 @@ protected:
  *
  *   SSET_WORD(dos-structure-name, field-name, value);
  *   uint16_t x = SGET_WORD(dos-structure-name, field-name);
- *
- * FIXME: Use these macros to replace all usage of sGet macro,
- *        so MemStruct::GetIt method could be removed.
  */
 template <size_t N, typename S, typename T1, typename T2 = T1>
 constexpr PhysPt assert_macro_args_ok()

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -331,20 +331,19 @@ public:
 		seg = segment;
 	}
 
-	void	MakeNew				(Bit16u memSize);
-	void	CopyFileTable		(DOS_PSP* srcpsp,bool createchildpsp);
-	Bit16u	FindFreeFileEntry	(void);
-	void	CloseFiles			(void);
+	void MakeNew(uint16_t mem_size);
+	void CopyFileTable(DOS_PSP *srcpsp, bool createchildpsp);
+	void CloseFiles();
 
-	void	SaveVectors			(void);
-	void	RestoreVectors		(void);
+	void SaveVectors();
+	void RestoreVectors();
 
 	uint16_t GetSegment() const { return seg; }
 
 	void SetFileHandle(uint16_t index, uint8_t handle);
 	uint8_t GetFileHandle(uint16_t index) const;
-
-	uint16_t FindEntryByHandle(uint8_t handle);
+	uint16_t FindFreeFileEntry() const;
+	uint16_t FindEntryByHandle(uint8_t handle) const;
 
 	void SetSize(uint16_t size) { SSET_WORD(sPSP, next_seg, size); }
 	void SetInt22(RealPt int22pt) { SSET_DWORD(sPSP, int_22, int22pt); }
@@ -521,20 +520,25 @@ public:
 	Bit16u	seg;
 };
 
-class DOS_DTA:public MemStruct{
+class DOS_DTA : public MemStruct {
 public:
 	DOS_DTA(RealPt addr) { SetPt(addr); }
 
 	void SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * _pattern);
 	void SetResult(const char * _name,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr);
-	
-	Bit8u GetSearchDrive(void);
-	void GetSearchParams(Bit8u & _sattr,char * _spattern);
-	void GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr);
+
+	void GetSearchParams(uint8_t &attr, char *pattern) const;
+
+	void GetResult(char *name,
+	               uint32_t &size,
+	               uint16_t &date,
+	               uint16_t &time,
+	               uint8_t &attr) const;
 
 	void SetDirID(uint16_t id) { SSET_WORD(sDTA, dirID, id); }
 	void SetDirIDCluster(uint16_t cl) { SSET_WORD(sDTA, dirCluster, cl); }
 
+	uint8_t GetSearchDrive() const { return SGET_BYTE(sDTA, sdrive); }
 	uint16_t GetDirID() const { return SGET_WORD(sDTA, dirID); }
 	uint16_t GetDirIDCluster() const { return SGET_WORD(sDTA, dirCluster); }
 
@@ -563,7 +567,8 @@ private:
 
 class DOS_FCB: public MemStruct {
 public:
-	DOS_FCB(Bit16u seg,Bit16u off,bool allow_extended=true);
+	DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended = true);
+
 	void Create(bool _extended);
 	void SetName(Bit8u _drive,char * _fname,char * _ext);
 	void SetSizeDateTime(Bit32u _size,Bit16u _date,Bit16u _time);
@@ -703,7 +708,7 @@ struct DOS_Block {
 	void dta(RealPt dtap) { DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).SetDTA(dtap); }
 
 	Bit8u return_code,return_mode;
-	
+
 	Bit8u current_drive;
 	bool verify;
 	bool breakcheck;

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -16,18 +16,16 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_DOS_INC_H
 #define DOSBOX_DOS_INC_H
 
-#ifndef DOSBOX_DOS_SYSTEM_H
-#include "dos_system.h"
-#endif
-#ifndef DOSBOX_MEM_H
-#include "mem.h"
-#endif
+#include "dosbox.h"
 
-#include <stddef.h> //for offsetof
+#include <cstddef>
+#include <type_traits>
+
+#include "dos_system.h"
+#include "mem.h"
 
 #ifdef _MSC_VER
 #pragma pack (1)
@@ -278,6 +276,51 @@ public:
 protected:
 	PhysPt pt;
 };
+
+/* Macros SSET_* and SGET_* are used to safely access fields in memory-mapped
+ * DOS structures represented via classes inheriting from MemStruct class.
+ *
+ * All of these macros depend on 'pt' base pointer from MemStruct base class;
+ * all DOS-specific fields are accessed by reading memory relative to that
+ * pointer.
+ *
+ * Example usage:
+ * 
+ *   SSET_WORD(dos-structure-name, field-name, value);
+ *   uint16_t x = SGET_WORD(dos-structure-name, field-name);
+ *
+ * FIXME: Use these macros to replace all usage of sGet and sSave macros,
+ *        so MemStruct::GetIt and MemStruct::SaveIt methods could be removed.
+ */
+template <size_t N, typename S, typename T1, typename T2 = T1>
+constexpr PhysPt assert_macro_args_ok()
+{
+	static_assert(sizeof(T1) == N, "Requested struct field has unexpected size");
+	static_assert(sizeof(T2) == N, "Type used to save value has unexpected size");
+	static_assert(std::is_standard_layout<S>::value,
+	              "Struct needs to have standard layout for offsetof calculation");
+	// returning 0, so compiler can optimize-out no-op "0 +" expression
+	return 0;
+}
+
+#define VERIFY_SSET_ARGS(n, s, f, v)                                           \
+	assert_macro_args_ok<n, s, decltype(s::f), decltype(v)>()
+#define VERIFY_SGET_ARGS(n, s, f)                                              \
+	assert_macro_args_ok<n, s, decltype(s::f)>()
+
+#define SSET_BYTE(s, f, v)                                                     \
+	mem_writeb(VERIFY_SSET_ARGS(1, s, f, v) + pt + offsetof(s, f), v)
+#define SSET_WORD(s, f, v)                                                     \
+	mem_writew(VERIFY_SSET_ARGS(2, s, f, v) + pt + offsetof(s, f), v)
+#define SSET_DWORD(s, f, v)                                                    \
+	mem_writed(VERIFY_SSET_ARGS(4, s, f, v) + pt + offsetof(s, f), v)
+
+#define SGET_BYTE(s, f)                                                        \
+	mem_readb(VERIFY_SGET_ARGS(1, s, f) + pt + offsetof(s, f))
+#define SGET_WORD(s, f)                                                        \
+	mem_readw(VERIFY_SGET_ARGS(2, s, f) + pt + offsetof(s, f))
+#define SGET_DWORD(s, f)                                                       \
+	mem_readd(VERIFY_SGET_ARGS(4, s, f) + pt + offsetof(s, f))
 
 class DOS_PSP :public MemStruct {
 public:

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -249,11 +249,14 @@ static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
 
 class MemStruct {
 public:
-	void SetPt(Bit16u seg) { pt=PhysMake(seg,0);}
-	void SetPt(Bit16u seg,Bit16u off) { pt=PhysMake(seg,off);}
-	void SetPt(RealPt addr) { pt=Real2Phys(addr);}
+	MemStruct() = default;
+	MemStruct(uint16_t seg, uint16_t off) : pt(PhysMake(seg, off)) {}
+	MemStruct(RealPt addr) : pt(Real2Phys(addr)) {}
+
+	void SetPt(uint16_t seg) { pt = PhysMake(seg, 0); }
+
 protected:
-	PhysPt pt;
+	PhysPt pt = 0;
 };
 
 /* Macros SSET_* and SGET_* are used to safely access fields in memory-mapped
@@ -298,14 +301,9 @@ constexpr PhysPt assert_macro_args_ok()
 #define SGET_DWORD(s, f)                                                       \
 	mem_readd(VERIFY_SGET_ARGS(4, s, f) + pt + offsetof(s, f))
 
-class DOS_PSP :public MemStruct {
+class DOS_PSP : public MemStruct {
 public:
-	DOS_PSP(Bit16u segment)
-		: seg(0)
-	{
-		SetPt(segment);
-		seg = segment;
-	}
+	DOS_PSP(uint16_t segment) : MemStruct(segment), seg(segment) {}
 
 	void MakeNew(uint16_t mem_size);
 	void CopyFileTable(DOS_PSP *srcpsp, bool createchildpsp);
@@ -377,7 +375,7 @@ public:
 	static	Bit16u rootpsp;
 };
 
-class DOS_ParamBlock:public MemStruct {
+class DOS_ParamBlock : public MemStruct {
 public:
 	DOS_ParamBlock(PhysPt addr)
 		: exec{0, 0, 0, 0, 0, 0},
@@ -498,7 +496,7 @@ public:
 
 class DOS_DTA : public MemStruct {
 public:
-	DOS_DTA(RealPt addr) { SetPt(addr); }
+	DOS_DTA(RealPt addr) : MemStruct(addr) {}
 
 	void SetupSearch(uint8_t drive, uint8_t attr, char *pattern);
 	void GetSearchParams(uint8_t &attr, char *pattern) const;
@@ -603,9 +601,9 @@ private:
 	#endif
 };
 
-class DOS_MCB : public MemStruct{
+class DOS_MCB : public MemStruct {
 public:
-	DOS_MCB(Bit16u seg) { SetPt(seg); }
+	DOS_MCB(uint16_t seg) : MemStruct(seg, 0) {}
 
 	void SetFileName(char const * const _name) { MEM_BlockWrite(pt+offsetof(sMCB,filename),_name,8); }
 	void GetFileName(char * const _name) { MEM_BlockRead(pt+offsetof(sMCB,filename),_name,8);_name[8]=0;}
@@ -636,7 +634,8 @@ private:
 
 class DOS_SDA : public MemStruct {
 public:
-	DOS_SDA(Bit16u _seg,Bit16u _offs) { SetPt(_seg,_offs); }
+	DOS_SDA(uint16_t seg, uint16_t off) : MemStruct(seg, off) {}
+
 	void Init();
 
 	void SetDTA(uint32_t dta) { SSET_DWORD(sSDA, current_dta, dta); }

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -330,6 +330,7 @@ public:
 		SetPt(segment);
 		seg = segment;
 	}
+
 	void	MakeNew				(Bit16u memSize);
 	void	CopyFileTable		(DOS_PSP* srcpsp,bool createchildpsp);
 	Bit16u	FindFreeFileEntry	(void);
@@ -338,22 +339,22 @@ public:
 	void	SaveVectors			(void);
 	void	RestoreVectors		(void);
 
-	uint16_t GetSegment() { return seg; }
+	uint16_t GetSegment() const { return seg; }
 
-	void	SetFileHandle		(Bit16u index, Bit8u handle);
-	uint8_t GetFileHandle(uint16_t index);
+	void SetFileHandle(uint16_t index, uint8_t handle);
+	uint8_t GetFileHandle(uint16_t index) const;
 
-	void	SetFCB1				(RealPt src);
-	void	SetFCB2				(RealPt src);
-	void	SetCommandTail		(RealPt src);	
-	bool	SetNumFiles			(Bit16u fileNum);
-	Bit16u	FindEntryByHandle	(Bit8u handle);
+	uint16_t FindEntryByHandle(uint8_t handle);
 
 	void SetSize(uint16_t size) { SSET_WORD(sPSP, next_seg, size); }
 	void SetInt22(RealPt int22pt) { SSET_DWORD(sPSP, int_22, int22pt); }
 	void SetParent(uint16_t parent) { SSET_WORD(sPSP, psp_parent, parent); }
 	void SetEnvironment(uint16_t env) { SSET_WORD(sPSP, environment, env); }
 	void SetStack(RealPt stackpt) { SSET_DWORD(sPSP, stack, stackpt); }
+	bool SetNumFiles(uint16_t file_num);
+	void SetFCB1(RealPt src);
+	void SetFCB2(RealPt src);
+	void SetCommandTail(RealPt src);
 
 	uint16_t GetSize() const { return SGET_WORD(sPSP, next_seg); }
 	RealPt GetInt22() const { return SGET_DWORD(sPSP, int_22); }

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -251,7 +251,6 @@ static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
 /* Remains some classes used to access certain things */
 #define sOffset(s,m) ((char*)&(((s*)NULL)->m)-(char*)NULL)
 #define sGet(s,m) GetIt(sizeof(((s *)&pt)->m),(PhysPt)sOffset(s,m))
-#define sSave(s,m,val) SaveIt(sizeof(((s *)&pt)->m),(PhysPt)sOffset(s,m),val)
 
 class MemStruct {
 public:
@@ -262,13 +261,6 @@ public:
 		case 4:return mem_readd(pt+addr);
 		}
 		return 0;
-	}
-	void SaveIt(Bitu size,PhysPt addr,Bitu val) {
-		switch (size) {
-		case 1:mem_writeb(pt+addr,(Bit8u)val);break;
-		case 2:mem_writew(pt+addr,(Bit16u)val);break;
-		case 4:mem_writed(pt+addr,(Bit32u)val);break;
-		}
 	}
 	void SetPt(Bit16u seg) { pt=PhysMake(seg,0);}
 	void SetPt(Bit16u seg,Bit16u off) { pt=PhysMake(seg,off);}
@@ -289,8 +281,8 @@ protected:
  *   SSET_WORD(dos-structure-name, field-name, value);
  *   uint16_t x = SGET_WORD(dos-structure-name, field-name);
  *
- * FIXME: Use these macros to replace all usage of sGet and sSave macros,
- *        so MemStruct::GetIt and MemStruct::SaveIt methods could be removed.
+ * FIXME: Use these macros to replace all usage of sGet macro,
+ *        so MemStruct::GetIt method could be removed.
  */
 template <size_t N, typename S, typename T1, typename T2 = T1>
 constexpr PhysPt assert_macro_args_ok()

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -524,11 +524,14 @@ class DOS_DTA : public MemStruct {
 public:
 	DOS_DTA(RealPt addr) { SetPt(addr); }
 
-	void SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * _pattern);
-	void SetResult(const char * _name,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr);
-
+	void SetupSearch(uint8_t drive, uint8_t attr, char *pattern);
 	void GetSearchParams(uint8_t &attr, char *pattern) const;
 
+	void SetResult(const char *_name,
+	               uint32_t size,
+	               uint16_t date,
+	               uint16_t time,
+	               uint8_t attr);
 	void GetResult(char *name,
 	               uint32_t &size,
 	               uint16_t &date,
@@ -570,25 +573,28 @@ public:
 	DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended = true);
 
 	void Create(bool _extended);
-	void SetName(Bit8u _drive,char * _fname,char * _ext);
-	void SetSizeDateTime(Bit32u _size,Bit16u _date,Bit16u _time);
-	void GetSizeDateTime(Bit32u & _size,Bit16u & _date,Bit16u & _time);
+	void SetName(uint8_t drive, const char *fname, const char *ext);
 	void GetName(char * fillname);
-	void FileOpen(Bit8u _fhandle);
-	void FileClose(Bit8u & _fhandle);
-	void GetRecord(Bit16u & _cur_block,Bit8u & _cur_rec);
-	void SetRecord(Bit16u _cur_block,Bit8u _cur_rec);
-	void GetSeqData(Bit8u & _fhandle,Bit16u & _rec_size);
-	void SetSeqData(Bit8u _fhandle,Bit16u _rec_size);
-	void GetRandom(Bit32u & _random);
-	void SetRandom(Bit32u  _random);
-	Bit8u GetDrive(void);
-	bool Extended(void);
+	void FileOpen(uint8_t fhandle);
+	void FileClose(uint8_t &fhandle);
+	bool Extended() const { return extended; }
 	void GetAttr(Bit8u & attr);
 	void SetAttr(Bit8u attr);
 	void SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr);
-	bool Valid(void);
+	bool Valid() const;
 	void ClearBlockRecsize(void);
+
+	void SetRecord(uint16_t cur_block, uint8_t cur_rec);
+	void SetSizeDateTime(uint32_t size, uint16_t date, uint16_t time);
+	void SetSeqData(uint8_t fhandle, uint16_t rec_size);
+	void SetRandom(uint32_t random) { SSET_DWORD(sFCB, rndm, random); }
+
+	uint8_t GetDrive() const;
+	void GetRecord(uint16_t &cur_block, uint8_t &cur_rec) const;
+	void GetSizeDateTime(uint32_t &size, uint16_t &date, uint16_t &time) const;
+	void GetSeqData(uint8_t &fhandle, uint16_t &rec_size) const;
+	uint32_t GetRandom() const { return SGET_DWORD(sFCB, rndm); }
+
 private:
 	bool extended;
 	PhysPt real_pt;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -124,8 +124,6 @@ void DOS_InfoBlock::SetBuffers(uint16_t x, uint16_t y)
 	SSET_WORD(sDIB, buffers_y, y);
 }
 
-/* program Segment prefix */
-
 Bit16u DOS_PSP::rootpsp = 0;
 
 void DOS_PSP::MakeNew(uint16_t mem_size)

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -24,32 +24,33 @@
 #include "dos_inc.h"
 #include "support.h"
 
-
-void DOS_ParamBlock::Clear(void) {
-	memset(&exec,0,sizeof(exec));
-	memset(&overlay,0,sizeof(overlay));
+void DOS_ParamBlock::Clear()
+{
+	memset(&exec, 0, sizeof(exec));
+	memset(&overlay, 0, sizeof(overlay));
 }
 
-void DOS_ParamBlock::LoadData(void) {
-	exec.envseg=(Bit16u)sGet(sExec,envseg);
-	exec.cmdtail=sGet(sExec,cmdtail);
-	exec.fcb1=sGet(sExec,fcb1);
-	exec.fcb2=sGet(sExec,fcb2);
-	exec.initsssp=sGet(sExec,initsssp);
-	exec.initcsip=sGet(sExec,initcsip);
-	overlay.loadseg=(Bit16u)sGet(sOverlay,loadseg);
-	overlay.relocation=(Bit16u)sGet(sOverlay,relocation);
+void DOS_ParamBlock::LoadData()
+{
+	exec.envseg = SGET_WORD(sExec, envseg);
+	exec.cmdtail = SGET_DWORD(sExec, cmdtail);
+	exec.fcb1 = SGET_DWORD(sExec, fcb1);
+	exec.fcb2 = SGET_DWORD(sExec, fcb2);
+	exec.initsssp = SGET_DWORD(sExec, initsssp);
+	exec.initcsip = SGET_DWORD(sExec, initcsip);
+	overlay.loadseg = SGET_WORD(sOverlay, loadseg);
+	overlay.relocation = SGET_WORD(sOverlay, relocation);
 }
 
-void DOS_ParamBlock::SaveData(void) {
-	sSave(sExec,envseg,exec.envseg);
-	sSave(sExec,cmdtail,exec.cmdtail);
-	sSave(sExec,fcb1,exec.fcb1);
-	sSave(sExec,fcb2,exec.fcb2);
-	sSave(sExec,initsssp,exec.initsssp);
-	sSave(sExec,initcsip,exec.initcsip);
+void DOS_ParamBlock::SaveData()
+{
+	SSET_WORD(sExec,envseg,exec.envseg);
+	SSET_DWORD(sExec,cmdtail,exec.cmdtail);
+	SSET_DWORD(sExec,fcb1,exec.fcb1);
+	SSET_DWORD(sExec,fcb2,exec.fcb2);
+	SSET_DWORD(sExec,initsssp,exec.initsssp);
+	SSET_DWORD(sExec,initcsip,exec.initcsip);
 }
-
 
 void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	seg = segment;
@@ -58,79 +59,67 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	for(Bitu i=0;i<sizeof(sDIB);i++) mem_writeb(pt+i,0xff);
 	for(Bitu i=0;i<14;i++) mem_writeb(pt+i,0);
 
-	sSave(sDIB,regCXfrom5e,(Bit16u)0);
-	sSave(sDIB,countLRUcache,(Bit16u)0);
-	sSave(sDIB,countLRUopens,(Bit16u)0);
+	SSET_WORD(sDIB, regCXfrom5e, uint16_t(0));
+	SSET_WORD(sDIB, countLRUcache, uint16_t(0));
+	SSET_WORD(sDIB, countLRUopens, uint16_t(0));
+	SSET_WORD(sDIB, protFCBs, uint16_t(0));
+	SSET_WORD(sDIB, specialCodeSeg, uint16_t(0));
+	SSET_BYTE(sDIB, joindedDrives, uint8_t(0));
+	SSET_BYTE(sDIB, lastdrive, uint8_t(0x01)); // increase this if you add drives to cds-chain
+	SSET_DWORD(sDIB, diskInfoBuffer,
+	           RealMake(segment, offsetof(sDIB, diskBufferHeadPt)));
+	SSET_DWORD(sDIB, setverPtr, uint32_t(0));
+	SSET_WORD(sDIB, a20FixOfs, uint16_t(0));
+	SSET_WORD(sDIB, pspLastIfHMA, uint16_t(0));
+	SSET_BYTE(sDIB, blockDevices, uint8_t(0));
+	SSET_BYTE(sDIB, bootDrive, uint8_t(0));
+	SSET_BYTE(sDIB, useDwordMov, uint8_t(1));
+	SSET_WORD(sDIB, extendedSize,
+	          static_cast<uint16_t>(MEM_TotalPages() * 4 - 1024));
+	SSET_WORD(sDIB, magicWord, uint16_t(0x0001)); // dos5+
+	SSET_WORD(sDIB, sharingCount, uint16_t(0));
+	SSET_WORD(sDIB, sharingDelay, uint16_t(0));
+	SSET_WORD(sDIB, ptrCONinput, uint16_t(0)); // no unread input available
+	SSET_WORD(sDIB, maxSectorLength, uint16_t(0x200));
+	SSET_WORD(sDIB, dirtyDiskBuffers, uint16_t(0));
+	SSET_DWORD(sDIB, lookaheadBufPt, uint32_t(0));
+	SSET_WORD(sDIB, lookaheadBufNumber, uint16_t(0));
+	SSET_BYTE(sDIB, bufferLocation, uint8_t(0)); // buffer in base memory,
+	                                             // no workspace
+	SSET_DWORD(sDIB, workspaceBuffer, uint32_t(0));
+	SSET_WORD(sDIB, minMemForExec, uint16_t(0));
+	SSET_WORD(sDIB, memAllocScanStart, uint16_t(DOS_MEM_START));
+	SSET_WORD(sDIB, startOfUMBChain, uint16_t(0xffff));
+	SSET_BYTE(sDIB, chainingUMB, uint8_t(0));
+	SSET_DWORD(sDIB, nulNextDriver, uint32_t(0xffffffff));
+	SSET_WORD(sDIB, nulAttributes, uint16_t(0x8004));
+	SSET_DWORD(sDIB, nulStrategy, uint32_t(0x00000000));
+	SSET_BYTE(sDIB, nulString[0], uint8_t(0x4e));
+	SSET_BYTE(sDIB, nulString[1], uint8_t(0x55));
+	SSET_BYTE(sDIB, nulString[2], uint8_t(0x4c));
+	SSET_BYTE(sDIB, nulString[3], uint8_t(0x20));
+	SSET_BYTE(sDIB, nulString[4], uint8_t(0x20));
+	SSET_BYTE(sDIB, nulString[5], uint8_t(0x20));
+	SSET_BYTE(sDIB, nulString[6], uint8_t(0x20));
+	SSET_BYTE(sDIB, nulString[7], uint8_t(0x20));
 
-	sSave(sDIB,protFCBs,(Bit16u)0);
-	sSave(sDIB,specialCodeSeg,(Bit16u)0);
-	sSave(sDIB,joindedDrives,(Bit8u)0);
-	sSave(sDIB,lastdrive,(Bit8u)0x01);//increase this if you add drives to cds-chain
-
-	sSave(sDIB,diskInfoBuffer,RealMake(segment,offsetof(sDIB,diskBufferHeadPt)));
-	sSave(sDIB,setverPtr,(Bit32u)0);
-
-	sSave(sDIB,a20FixOfs,(Bit16u)0);
-	sSave(sDIB,pspLastIfHMA,(Bit16u)0);
-	sSave(sDIB,blockDevices,(Bit8u)0);
-	
-	sSave(sDIB,bootDrive,(Bit8u)0);
-	sSave(sDIB,useDwordMov,(Bit8u)1);
-	sSave(sDIB,extendedSize,(Bit16u)(MEM_TotalPages()*4-1024));
-	sSave(sDIB,magicWord,(Bit16u)0x0001);		// dos5+
-
-	sSave(sDIB,sharingCount,(Bit16u)0);
-	sSave(sDIB,sharingDelay,(Bit16u)0);
-	sSave(sDIB,ptrCONinput,(Bit16u)0);			// no unread input available
-	sSave(sDIB,maxSectorLength,(Bit16u)0x200);
-
-	sSave(sDIB,dirtyDiskBuffers,(Bit16u)0);
-	sSave(sDIB,lookaheadBufPt,(Bit32u)0);
-	sSave(sDIB,lookaheadBufNumber,(Bit16u)0);
-	sSave(sDIB,bufferLocation,(Bit8u)0);		// buffer in base memory, no workspace
-	sSave(sDIB,workspaceBuffer,(Bit32u)0);
-
-	sSave(sDIB,minMemForExec,(Bit16u)0);
-	sSave(sDIB,memAllocScanStart,(Bit16u)DOS_MEM_START);
-	sSave(sDIB,startOfUMBChain,(Bit16u)0xffff);
-	sSave(sDIB,chainingUMB,(Bit8u)0);
-
-	sSave(sDIB,nulNextDriver,(Bit32u)0xffffffff);
-	sSave(sDIB,nulAttributes,(Bit16u)0x8004);
-	sSave(sDIB,nulStrategy,(Bit32u)0x00000000);
-	sSave(sDIB,nulString[0],(Bit8u)0x4e);
-	sSave(sDIB,nulString[1],(Bit8u)0x55);
-	sSave(sDIB,nulString[2],(Bit8u)0x4c);
-	sSave(sDIB,nulString[3],(Bit8u)0x20);
-	sSave(sDIB,nulString[4],(Bit8u)0x20);
-	sSave(sDIB,nulString[5],(Bit8u)0x20);
-	sSave(sDIB,nulString[6],(Bit8u)0x20);
-	sSave(sDIB,nulString[7],(Bit8u)0x20);
-
-	/* Create a fake SFT, so programs think there are 100 file handles */
-	Bit16u sftOffset=offsetof(sDIB,firstFileTable)+0xa2;
-	sSave(sDIB,firstFileTable,RealMake(segment,sftOffset));
-	real_writed(segment,sftOffset+0x00,RealMake(segment+0x26,0));	//Next File Table
-	real_writew(segment,sftOffset+0x04,100);		//File Table supports 100 files
-	real_writed(segment+0x26,0x00,0xffffffff);		//Last File Table
-	real_writew(segment+0x26,0x04,100);				//File Table supports 100 files
+	// Create a fake SFT, so programs think there are 100 file handles
+	const uint16_t sft_offset = offsetof(sDIB, firstFileTable) + 0xa2;
+	SSET_DWORD(sDIB, firstFileTable, RealMake(segment, sft_offset));
+	// Next File Table
+	real_writed(segment, sft_offset + 0x00, RealMake(segment + 0x26, 0));
+	// File Table supports 100 files
+	real_writew(segment, sft_offset + 0x04, 100);
+	// Last File Table
+	real_writed(segment + 0x26, 0x00, 0xffffffff);
+	// File Table supports 100 files
+	real_writew(segment + 0x26, 0x04, 100);
 }
 
-void DOS_InfoBlock::SetFirstMCB(Bit16u _firstmcb) {
-	sSave(sDIB,firstMCB,_firstmcb); //c2woody
-}
-
-void DOS_InfoBlock::SetBuffers(Bit16u x,Bit16u y) {
-	sSave(sDIB,buffers_x,x);
-	sSave(sDIB,buffers_y,y);
-}
-
-void DOS_InfoBlock::SetCurDirStruct(Bit32u _curdirstruct) {
-	sSave(sDIB,curDirStructure,_curdirstruct);
-}
-
-void DOS_InfoBlock::SetFCBTable(Bit32u _fcbtable) {
-	sSave(sDIB,fcbTable,_fcbtable);
+void DOS_InfoBlock::SetBuffers(uint16_t x, uint16_t y)
+{
+	SSET_WORD(sDIB, buffers_x, x);
+	SSET_WORD(sDIB, buffers_y, y);
 }
 
 void DOS_InfoBlock::SetDeviceChainStart(Bit32u _devchain) {
@@ -141,20 +130,8 @@ void DOS_InfoBlock::SetDiskBufferHeadPt(Bit32u _dbheadpt) {
 	sSave(sDIB,diskBufferHeadPt,_dbheadpt);
 }
 
-Bit16u DOS_InfoBlock::GetStartOfUMBChain(void) {
-	return (Bit16u)sGet(sDIB,startOfUMBChain);
-}
-
-void DOS_InfoBlock::SetStartOfUMBChain(Bit16u _umbstartseg) {
-	sSave(sDIB,startOfUMBChain,_umbstartseg);
-}
-
 Bit8u DOS_InfoBlock::GetUMBChainState(void) {
 	return (Bit8u)sGet(sDIB,chainingUMB);
-}
-
-void DOS_InfoBlock::SetUMBChainState(Bit8u _umbchaining) {
-	sSave(sDIB,chainingUMB,_umbchaining);
 }
 
 void DOS_InfoBlock::SetBlockDevices(Bit8u _count) {
@@ -164,11 +141,6 @@ void DOS_InfoBlock::SetBlockDevices(Bit8u _count) {
 RealPt DOS_InfoBlock::GetPointer(void) {
 	return RealMake(seg,offsetof(sDIB,firstDPB));
 }
-
-Bit32u DOS_InfoBlock::GetDeviceChain(void) {
-	return sGet(sDIB,nulNextDriver);
-}
-
 
 /* program Segment prefix */
 
@@ -184,7 +156,7 @@ void DOS_PSP::MakeNew(Bit16u mem_size) {
 	sSave(sPSP,next_seg,seg+mem_size);
 	/* far call opcode */
 	sSave(sPSP,far_call,0xea);
-	// far call to interrupt 0x21 - faked for bill & ted 
+	// far call to interrupt 0x21 - faked for bill & ted
 	// lets hope nobody really uses this address
 	sSave(sPSP,cpm_entry,RealMake(0xDEAD,0xFFFF));
 	/* Standard blocks,int 20  and int21 retf */

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -343,7 +343,7 @@ void DOS_DTA::GetResult(char *name,
 
 void DOS_DTA::GetSearchParams(uint8_t &attr, char *pattern) const
 {
-	attr = SGET_BYTE(sDTA, attr);
+	attr = SGET_BYTE(sDTA, sattr);
 	char temp[11];
 	MEM_BlockRead(pt+offsetof(sDTA,sname),temp,11);
 	memcpy(pattern,temp,8);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -376,8 +376,8 @@ void DOS_DTA::GetSearchParams(uint8_t &attr, char *pattern) const
 }
 
 DOS_FCB::DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended)
+        : MemStruct(seg, off)
 {
-	SetPt(seg, off);
 	real_pt=pt;
 	extended=false;
 	if (allow_extended) {

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -52,9 +52,11 @@ void DOS_ParamBlock::SaveData()
 	SSET_DWORD(sExec,initcsip,exec.initcsip);
 }
 
-void DOS_InfoBlock::SetLocation(Bit16u segment) {
+void DOS_InfoBlock::SetLocation(uint16_t segment)
+{
 	seg = segment;
-	pt=PhysMake(seg,0);
+	pt = PhysMake(seg, 0);
+
 	/* Clear the initial Block */
 	for(Bitu i=0;i<sizeof(sDIB);i++) mem_writeb(pt+i,0xff);
 	for(Bitu i=0;i<14;i++) mem_writeb(pt+i,0);
@@ -122,26 +124,6 @@ void DOS_InfoBlock::SetBuffers(uint16_t x, uint16_t y)
 	SSET_WORD(sDIB, buffers_y, y);
 }
 
-void DOS_InfoBlock::SetDeviceChainStart(Bit32u _devchain) {
-	sSave(sDIB,nulNextDriver,_devchain);
-}
-
-void DOS_InfoBlock::SetDiskBufferHeadPt(Bit32u _dbheadpt) {
-	sSave(sDIB,diskBufferHeadPt,_dbheadpt);
-}
-
-Bit8u DOS_InfoBlock::GetUMBChainState(void) {
-	return (Bit8u)sGet(sDIB,chainingUMB);
-}
-
-void DOS_InfoBlock::SetBlockDevices(Bit8u _count) {
-	sSave(sDIB,blockDevices,_count);
-}
-
-RealPt DOS_InfoBlock::GetPointer(void) {
-	return RealMake(seg,offsetof(sDIB,firstDPB));
-}
-
 /* program Segment prefix */
 
 Bit16u DOS_PSP::rootpsp = 0;
@@ -185,10 +167,12 @@ void DOS_PSP::MakeNew(Bit16u mem_size) {
 	if (rootpsp==0) rootpsp = seg;
 }
 
-Bit8u DOS_PSP::GetFileHandle(Bit16u index) {
-	if (index>=sGet(sPSP,max_files)) return 0xff;
-	PhysPt files=Real2Phys(sGet(sPSP,file_table));
-	return mem_readb(files+index);
+uint8_t DOS_PSP::GetFileHandle(uint16_t index)
+{
+	if (index >= SGET_WORD(sPSP, max_files))
+		return 0xff;
+	PhysPt files = Real2Phys(SGET_DWORD(sPSP, file_table));
+	return mem_readb(files + index);
 }
 
 void DOS_PSP::SetFileHandle(Bit16u index, Bit8u handle) {

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -284,8 +284,31 @@ bool DOS_PSP::SetNumFiles(uint16_t file_num)
 		RealPt data = RealMake(DOS_GetMemory(para), 0);
 		SSET_DWORD(sPSP, file_table, data);
 		SSET_WORD(sPSP, max_files, file_num);
-		for (uint16_t i = 0; i < 20; i++)
-			SetFileHandle(i, sGet(sPSP, files[i])); // FIXME! 'i' is unusable in constexpr!!
+
+		// enumerating 20 constexpr integers manually is easier and
+		// faster than actually using std::integer_sequence...
+		// (second parameter to SGET_BYTE must be constexpr)
+		SetFileHandle(0, SGET_BYTE(sPSP, files[0]));
+		SetFileHandle(1, SGET_BYTE(sPSP, files[1]));
+		SetFileHandle(2, SGET_BYTE(sPSP, files[2]));
+		SetFileHandle(3, SGET_BYTE(sPSP, files[3]));
+		SetFileHandle(4, SGET_BYTE(sPSP, files[4]));
+		SetFileHandle(5, SGET_BYTE(sPSP, files[5]));
+		SetFileHandle(6, SGET_BYTE(sPSP, files[6]));
+		SetFileHandle(7, SGET_BYTE(sPSP, files[7]));
+		SetFileHandle(8, SGET_BYTE(sPSP, files[8]));
+		SetFileHandle(9, SGET_BYTE(sPSP, files[9]));
+		SetFileHandle(10, SGET_BYTE(sPSP, files[10]));
+		SetFileHandle(11, SGET_BYTE(sPSP, files[11]));
+		SetFileHandle(12, SGET_BYTE(sPSP, files[12]));
+		SetFileHandle(13, SGET_BYTE(sPSP, files[13]));
+		SetFileHandle(14, SGET_BYTE(sPSP, files[14]));
+		SetFileHandle(15, SGET_BYTE(sPSP, files[15]));
+		SetFileHandle(16, SGET_BYTE(sPSP, files[16]));
+		SetFileHandle(17, SGET_BYTE(sPSP, files[17]));
+		SetFileHandle(18, SGET_BYTE(sPSP, files[18]));
+		SetFileHandle(19, SGET_BYTE(sPSP, files[19]));
+
 		for (uint16_t i = 20; i < file_num; i++)
 			SetFileHandle(i, 0xFF);
 	} else {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1145,14 +1145,13 @@ Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
  * Random block read updates these fields to reflect the state after the read!
  */
 	DOS_FCB fcb(seg,offset);
-	Bit32u random;
 	Bit16u old_block=0;
 	Bit8u old_rec=0;
 	Bit8u error=0;
 	Bit16u count;
 
 	/* Set the correct record from the random data */
-	fcb.GetRandom(random);
+	const uint32_t random = fcb.GetRandom();
 	fcb.SetRecord((Bit16u)(random / 128),(Bit8u)(random & 127));
 	if (restore) fcb.GetRecord(old_block,old_rec);//store this for after the read.
 	// Read records
@@ -1173,14 +1172,13 @@ Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
 Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
 /* see FCB_RandomRead */
 	DOS_FCB fcb(seg,offset);
-	Bit32u random;
 	Bit16u old_block=0;
 	Bit8u old_rec=0;
 	Bit8u error=0;
 	Bit16u count;
 
 	/* Set the correct record from the random data */
-	fcb.GetRandom(random);
+	const uint32_t random = fcb.GetRandom();
 	fcb.SetRecord((Bit16u)(random / 128),(Bit8u)(random & 127));
 	if (restore) fcb.GetRecord(old_block,old_rec);
 	if (*numRec > 0) {

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -66,7 +66,7 @@ public:
 
 	void SetNextDeviceHeader(RealPt ptr)
 	{
-		sSave(sDeviceHeader, nextDeviceHeader, ptr);
+		SSET_DWORD(sDeviceHeader, nextDeviceHeader, ptr);
 	}
 
 	RealPt GetNextDeviceHeader() const
@@ -76,17 +76,17 @@ public:
 
 	void SetAttribute(uint16_t atr)
 	{
-		sSave(sDeviceHeader, devAttributes, atr);
+		SSET_WORD(sDeviceHeader, devAttributes, atr);
 	}
 
 	void SetDriveLetter(uint8_t letter)
 	{
-		sSave(sDeviceHeader, driveLetter, letter);
+		SSET_BYTE(sDeviceHeader, driveLetter, letter);
 	}
 
 	void SetNumSubUnits(uint8_t num)
 	{
-		sSave(sDeviceHeader, numSubUnits, num);
+		SSET_BYTE(sDeviceHeader, numSubUnits, num);
 	}
 
 	uint8_t GetNumSubUnits() const
@@ -101,12 +101,12 @@ public:
 
 	void SetInterrupt(uint16_t ofs)
 	{
-		sSave(sDeviceHeader, interrupt, ofs);
+		SSET_WORD(sDeviceHeader, interrupt, ofs);
 	}
 
 	void SetStrategy(uint16_t offset)
 	{
-		sSave(sDeviceHeader, strategy, offset);
+		SSET_WORD(sDeviceHeader, strategy, offset);
 	}
 
 public:

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -69,9 +69,9 @@ public:
 		sSave(sDeviceHeader, nextDeviceHeader, ptr);
 	}
 
-	RealPt GetNextDeviceHeader()
+	RealPt GetNextDeviceHeader() const
 	{
-		return sGet(sDeviceHeader, nextDeviceHeader);
+		return SGET_DWORD(sDeviceHeader, nextDeviceHeader);
 	}
 
 	void SetAttribute(uint16_t atr)
@@ -89,9 +89,9 @@ public:
 		sSave(sDeviceHeader, numSubUnits, num);
 	}
 
-	uint8_t GetNumSubUnits()
+	uint8_t GetNumSubUnits() const
 	{
-		return sGet(sDeviceHeader, numSubUnits);
+		return SGET_BYTE(sDeviceHeader, numSubUnits);
 	}
 
 	void SetName(const char *new_name)


### PR DESCRIPTION
This is only a WIP draft. `dos_inc.h` header uses problematic macros: `sGet` and `sSave` - they depend on UB for calculation of field offsets. Additionally, they provide kind of "dynamic" dispatch, that we really don't need. This PR implements replacements for those macros (replacing "dynamic"-like dispatch to `mem_read*`/`mem_write*` functions with a static dispatch verified at compile time.

In the process, this provides tiny performance improvement (accessing DOS structures in emulated memory does not require going through switch statement nor packaging bytes/words/double-words to Bitu and then back) and cleaner code (explicit casting of values obtained from sGet is no longer needed).

Unfortunately, it means, that many lines of code were touched, so this PR will be a rather big one :(