### PR TITLE
Simplify Platform and Config-Heavy workflow gating using new CI job controls

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,9 +4,21 @@ on:
   schedule: [cron: '0 16 * * *']
 
 jobs:
+  repo-check:
+    name: Repository commit check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: commit-check
+        run: 'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
+    outputs:
+      has-commits: ${{ steps.commit-check.outputs.has-commits }}
+
   config_all:
     name: ${{ matrix.system.name }} ${{ matrix.conf.configure_flags }} ${{ matrix.conf.without_packages }}
     runs-on: ${{ matrix.system.os }}
+    needs: repo-check
+    if: needs.repo-check.outputs.has-commits == 'true'
     strategy:
       max-parallel: 8
       matrix:
@@ -44,25 +56,21 @@ jobs:
     env:
       CHERE_INVOKING: yes
     steps:
-      - uses: actions/checkout@v2
-      - name: Check repo for commits
-        id:   repo-meta
+      - uses:  actions/checkout@v2
+      - name:  Check repo for commits
+        id:    repo-meta
         shell: bash
-        run:  'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
+        run:   'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
 
       - name:  Get Date
         id:    get-date
-        if:    >
-          matrix.system.name == 'Windows' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'Windows'
         shell: bash
         run:   echo ::set-output name=date::$(date +%Y-%W)
 
       - uses:  actions/cache@v2
         id:    cache-msys2
-        if:    >
-          matrix.system.name == 'Windows' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'Windows'
         with:
           path: 'C:/tools/msys64'
           key: msys2-64-${{ steps.get-date.outputs.date }}-3
@@ -70,51 +78,39 @@ jobs:
       - name:  Install MSYS2 (Windows)
         if:    >
           matrix.system.name == 'Windows' &&
-          steps.cache-msys2.outputs.cache-hit != 'true' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+          steps.cache-msys2.outputs.cache-hit != 'true'
         run:   choco install msys2 --no-progress
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (Windows)
         if:    >
           matrix.system.name == 'Windows' &&
-          steps.cache-msys2.outputs.cache-hit != 'true' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+          steps.cache-msys2.outputs.cache-hit != 'true'
         shell: python scripts\msys-bash.py {0}
         run: |
            scripts/list-build-dependencies.sh -m msys2 -c clang ${{ matrix.conf.without_packages }} | xargs pacman -S --noconfirm
            .github/scripts/shrink-msys2.sh
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (Linux)
-        if:    >
-          matrix.system.name == 'Linux' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'Linux'
         run: |
           sudo apt-get -y update
           sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c gcc ${{ matrix.conf.without_packages }})
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (macOS)
-        if:    >
-          matrix.system.name == 'macOS' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'macOS'
         run:   brew install $(./scripts/list-build-dependencies.sh -m brew -c clang ${{ matrix.conf.without_packages }})
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
-        if:    >
-          matrix.system.name == 'Windows' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'Windows'
         shell: python scripts\msys-bash.py {0}
         run:   scripts/build.sh -c ${{ matrix.system.compiler }} -t debug --bin-path /mingw64/bin ${{ matrix.conf.configure_flags }}
 
       - name:  Build ${{ matrix.conf.configure_flags }} (macOS)
-        if:    >
-          matrix.system.name == 'macOS' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'macOS'
         run: |
           export PKG_CONFIG_PATH="/usr/local/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
           ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug ${{ matrix.conf.configure_flags }}
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Linux)
-        if:    >
-          matrix.system.name == 'Linux' &&
-          steps.repo-meta.outputs.has-commits == 'true'
+        if:    matrix.system.name == 'Linux'
         run:   ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug ${{ matrix.conf.configure_flags }}

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -4,9 +4,21 @@ on:
   schedule: [cron: '0 14 * * *']
 
 jobs:
-  build_linux_platforms:
+  repo-check:
+    name: Repository commit check
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: commit-check
+        run: 'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
+    outputs:
+      has-commits: ${{ steps.commit-check.outputs.has-commits }}
+
+  build_linux_platforms:
     name: ${{ matrix.conf.name }}
+    runs-on: ubuntu-latest
+    needs: repo-check
+    if: needs.repo-check.outputs.has-commits == 'true'
     strategy:
       matrix:
         conf:
@@ -29,13 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Check repo for commits
-        id: repo-meta
-        shell: bash
-        run:  'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
-
       - name: Inject version string
-        if: steps.repo-meta.outputs.has-commits == 'true'
         run: |
           set -x
           git fetch --prune --unshallow
@@ -45,7 +51,6 @@ jobs:
 
       - name: Build
         uses: uraimo/run-on-arch-action@master
-        if: steps.repo-meta.outputs.has-commits == 'true'
         with:
           architecture: ${{ matrix.conf.architecture }}
           distribution: ${{ matrix.conf.distribution }}
@@ -57,11 +62,9 @@ jobs:
             ./scripts/build.sh -c gcc -t release -m lto --disable-fluidsynth
 
       - name: Summarize warnings
-        if: steps.repo-meta.outputs.has-commits == 'true'
         run:  ./scripts/count-warnings.py --max-warnings -1 build.log
 
       - name: Package
-        if: steps.repo-meta.outputs.has-commits == 'true'
         run: |
           set -x
 
@@ -89,7 +92,6 @@ jobs:
           echo ::set-env name=PACKAGE::$PACKAGE
 
       - name: Clam AV scan
-        if: steps.repo-meta.outputs.has-commits == 'true'
         run: |
           set -x
           sudo apt-get install clamav > /dev/null
@@ -98,7 +100,6 @@ jobs:
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
 
       - name: Upload tarball
-        if: steps.repo-meta.outputs.has-commits == 'true'
         uses: actions/upload-artifact@v2
         # GitHub automatically zips the artifacts (there's no way to create
         # a tarball), and it removes all executable flags while zipping.


### PR DESCRIPTION
A job-level CI conditional bug reported by the dosbox-staging project has been fixed by GitHub's @ericsciple (thanks Eric!), here: https://github.com/actions/toolkit/issues/299.

Resulting in new job-level output syntax (https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs).

This allows us to control our nightly platform and config-heavy builds using a preliminary job that checks if commits have occurred, and only then carry on with the matrix jobs. 

This eliminates the excessive number of `if: ...` check that we previously needed **_in every_** step.