### PR TITLE
Use the platform-specific fluidsynth package when building under MSYS2

### DIFF
--- a/scripts/automator/packages/manager-msys2
+++ b/scripts/automator/packages/manager-msys2
@@ -1,7 +1,7 @@
 # Package repo: https://packages.msys2.org/base
 # MSYS2 only supports the current latest releases of Clang and GCC, so we disable version customization
-packages+=(autogen autoconf base-devel automake-wrapper binutils fluidsynth)
+packages+=(autogen autoconf base-devel automake-wrapper binutils)
 pkg_type=$([[ "${bits}" == "64" ]] && echo "x86_64" || echo "i686")
-for pkg in ccache pkg-config libtool libpng zlib ncurses pdcurses SDL2 SDL2_net opusfile; do
+for pkg in ccache pkg-config libtool libpng zlib ncurses pdcurses SDL2 SDL2_net opusfile fluidsynth; do
 	packages+=("mingw-w64-${pkg_type}-${pkg}")
 done


### PR DESCRIPTION
Config heavy caught an issue building with FluidSynth under MSYS2:

![2020-08-17_09-25](https://user-images.githubusercontent.com/1557255/90419604-aace7100-e06b-11ea-8164-f46fe4d9eaa6.png)


This PR makes a small fix to use the platform-specific `mingw-w64-i686-fluidsynth` and `mingw-w64-x86_64-fluidsynth` packages instead of just `fluidsynth`.

![2020-08-17_09-21](https://user-images.githubusercontent.com/1557255/90419339-49a69d80-e06b-11ea-86be-71d334bd0ade.png)
