### PR TITLE
Fix regression involving international characters in batch file

### DIFF
--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -75,9 +75,6 @@ emptyline:
 	do {
 		bytes_read = 1;
 		DOS_ReadFile(file_handle, &data, &bytes_read);
-
-		// Allow the full 0-255 range to wrap into the char
-		assert(data <= UINT8_MAX);
 		val = static_cast<char>(data);
 
 		if (bytes_read > 0) {
@@ -85,9 +82,13 @@ emptyline:
 			 * Exclusion list: tab for batch files
 			 * escape for ansi
 			 * backspace for alien odyssey */
-			if (val > 31 || val == 0x1b || val == '\t' || val == 8) {
-				//Only add it if room for it (and trailing zero) in the buffer, but do the check here instead at the end
-				//So we continue reading till EOL/EOF
+
+			// negative char values are international ASCII characters
+			// above 127 that got wrapped
+			if (val < 0 || val > 31 || val == 0x1b || val == '\t' || val == 8) {
+				// Only add it if room for it (and trailing zero)
+				// in the buffer, but do the check here instead
+				// at the end So we continue reading till EOL/EOF
 				if (cmd_write - temp + 1 < CMD_MAXLINE - 1) {
 					*cmd_write++ = val;
 				}
@@ -198,10 +199,11 @@ again:
 	do {
 		bytes_read = 1;
 		DOS_ReadFile(file_handle, &data, &bytes_read);
-		assert(data <= CHAR_MAX);
 		val = static_cast<char>(data);
 		if (bytes_read > 0) {
-			if (val > 31) {
+			// negative char values are international ASCII characters
+			// above 127 that got wrapped
+			if (val < 0 || val > 31) {
 				if (cmd_write - cmd_buffer + 1 < CMD_MAXLINE - 1) {
 					*cmd_write++ = val;
 				}


### PR DESCRIPTION
This is a fixup! for commit ed1d1e19

International ascii characters fall between 127 and 255, however when cast into a `char` these "high ASCII" values wrap to the negative side of the `char`.

So this sequence failed to handle those international characters:

``` c++
val = static_cast<char>(data); // international symbols now on the negative side .. 
if (val > 31)
  ... handle the characters ... 
```

Given we do need to operate on the symbols are `char` (and store them in `char` arrays, such as `cmd_write` and `cmd_read`), the solution was to acknowledge what's happening and permit wrapped high-ASCII in these two checks.

Fixes #555