### PR TITLE
Don't explicitly disable Microsoft bitfields for autotools builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,21 +205,6 @@ int x=10;if( __builtin_expect ((x==1),0) ) ;
 #switch language back
 AC_LANG_POP(C++)
 
-dnl test if compiler supports -mno-ms-bitfields as it is bugged
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
-BACKUP_CFLAGS="$CFLAGS"
-CFLAGS="-mno-ms-bitfields"
-AC_MSG_CHECKING(if compiler supports -mno-ms-bitfields)
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([
-void blah(){
-;
-}
-])],[
-AC_MSG_RESULT([yes])
-CXXFLAGS="$CXXFLAGS -mno-ms-bitfields"
-],[AC_MSG_RESULT([no])])
-CFLAGS="$BACKUP_CFLAGS"
-
 dnl When on macOS, enable support for Apple's Core MIDI and/or Core Audio if our compiler can #include their headers
 case "$host" in
   *-*-darwin*)


### PR DESCRIPTION
Stop `configure.ac` from trying to include the `-mno-ms-bitfields` flag in `CFLAGS` and `CXXFLAGS`.  There simply is no need to differentiate bit-field types (`-mms-bitfields` vs `-mno-ms-bitfields`) on any platform.

For example, on all supported platforms including Windows, one can build dosbox using GCC and override the `CFLAGS="-g"` or `CFLAGS="-O3"` without the need to worry about bitfield formats.

This fixes the unknown flag error reported on some platforms.