### PR TITLE
Replace sGet, sSave macros - part 1 - DOS_PSP class

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -93,7 +93,7 @@ jobs:
         conf:
           - name: Clang
             sanitizers: USAN
-            usan:  86
+            usan:  61
             tsan:  -1
             uasan: -1
           - name: GCC

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 478
+          MAX_BUGS: 479
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 316
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2170
+            max_warnings: 2058
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -321,7 +321,9 @@ protected:
 	PhysPt pt;
 };
 
-class DOS_PSP :public MemStruct {
+/* Program Segment Prefix */
+
+class DOS_PSP : public MemStruct {
 public:
 	DOS_PSP(Bit16u segment)
 		: seg(0)
@@ -329,40 +331,44 @@ public:
 		SetPt(segment);
 		seg = segment;
 	}
-	void	MakeNew				(Bit16u memSize);
-	void	CopyFileTable		(DOS_PSP* srcpsp,bool createchildpsp);
-	Bit16u	FindFreeFileEntry	(void);
-	void	CloseFiles			(void);
 
-	void	SaveVectors			(void);
-	void	RestoreVectors		(void);
+	void MakeNew(uint16_t mem_size);
 
-	void SetSize(uint16_t size) { sSave(sPSP, next_seg, size); }
-	uint16_t GetSize() { return (uint16_t)sGet(sPSP, next_seg); }
+	void CopyFileTable(DOS_PSP *srcpsp, bool createchildpsp);
 
-	void SetEnvironment(uint16_t eseg) { sSave(sPSP, environment, eseg); }
-	uint16_t GetEnvironment() { return (uint16_t)sGet(sPSP, environment); }
+	void CloseFiles();
 
-	uint16_t GetSegment() { return seg; }
+	uint16_t GetSegment() const { return seg; }
 
-	void	SetFileHandle		(Bit16u index, Bit8u handle);
-	Bit8u	GetFileHandle		(Bit16u index);
+	void SaveVectors();
+	void RestoreVectors();
 
-	void SetParent(uint16_t parent) { sSave(sPSP, psp_parent, parent); }
-	uint16_t GetParent() { return (uint16_t)sGet(sPSP, psp_parent); }
+	void SetFileHandle(uint16_t index, uint8_t handle);
+	uint8_t GetFileHandle(uint16_t index) const;
 
-	void SetStack(RealPt stackpt) { sSave(sPSP, stack, stackpt); }
-	RealPt GetStack() { return sGet(sPSP, stack); }
+	uint16_t FindFreeFileEntry() const;
+	uint16_t FindEntryByHandle(uint8_t handle) const;
 
-	void SetInt22(RealPt int22pt) { sSave(sPSP, int_22, int22pt); }
-	RealPt GetInt22() { return sGet(sPSP, int_22); }
+	void SetSize(uint16_t size) { SSET_WORD(sPSP, next_seg, size); }
+	uint16_t GetSize() const { return SGET_WORD(sPSP, next_seg); }
 
-	void	SetFCB1				(RealPt src);
-	void	SetFCB2				(RealPt src);
-	void	SetCommandTail		(RealPt src);	
-	bool	SetNumFiles			(Bit16u fileNum);
-	Bit16u	FindEntryByHandle	(Bit8u handle);
-			
+	void SetInt22(RealPt int22pt) { SSET_DWORD(sPSP, int_22, int22pt); }
+	RealPt GetInt22() const { return SGET_DWORD(sPSP, int_22); }
+
+	void SetParent(uint16_t parent) { SSET_WORD(sPSP, psp_parent, parent); }
+	uint16_t GetParent() const { return SGET_WORD(sPSP, psp_parent); }
+
+	void SetEnvironment(uint16_t env) { SSET_WORD(sPSP, environment, env); }
+	uint16_t GetEnvironment() const { return SGET_WORD(sPSP, environment); }
+
+	void SetStack(RealPt stackpt) { SSET_DWORD(sPSP, stack, stackpt); }
+	RealPt GetStack() const { return SGET_DWORD(sPSP, stack); }
+
+	bool SetNumFiles(uint16_t file_num);
+	void SetFCB1(RealPt src);
+	void SetFCB2(RealPt src);
+	void SetCommandTail(RealPt src);
+
 private:
 	#ifdef _MSC_VER
 	#pragma pack(1)

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -328,8 +328,31 @@ bool DOS_PSP::SetNumFiles(uint16_t file_num)
 		const RealPt data = RealMake(DOS_GetMemory(para), 0);
 		SSET_DWORD(sPSP, file_table, data);
 		SSET_WORD(sPSP, max_files, file_num);
-		for (uint16_t i = 0; i < 20; i++)
-			SetFileHandle(i, sGet(sPSP, files[i])); // FIXME! 'i' is unusable in constexpr!!
+
+		// enumerating 20 constexpr integers manually is easier and
+		// faster than actually using std::integer_sequence...
+		// (second parameter to SGET_BYTE must be constexpr)
+		SetFileHandle(0, SGET_BYTE(sPSP, files[0]));
+		SetFileHandle(1, SGET_BYTE(sPSP, files[1]));
+		SetFileHandle(2, SGET_BYTE(sPSP, files[2]));
+		SetFileHandle(3, SGET_BYTE(sPSP, files[3]));
+		SetFileHandle(4, SGET_BYTE(sPSP, files[4]));
+		SetFileHandle(5, SGET_BYTE(sPSP, files[5]));
+		SetFileHandle(6, SGET_BYTE(sPSP, files[6]));
+		SetFileHandle(7, SGET_BYTE(sPSP, files[7]));
+		SetFileHandle(8, SGET_BYTE(sPSP, files[8]));
+		SetFileHandle(9, SGET_BYTE(sPSP, files[9]));
+		SetFileHandle(10, SGET_BYTE(sPSP, files[10]));
+		SetFileHandle(11, SGET_BYTE(sPSP, files[11]));
+		SetFileHandle(12, SGET_BYTE(sPSP, files[12]));
+		SetFileHandle(13, SGET_BYTE(sPSP, files[13]));
+		SetFileHandle(14, SGET_BYTE(sPSP, files[14]));
+		SetFileHandle(15, SGET_BYTE(sPSP, files[15]));
+		SetFileHandle(16, SGET_BYTE(sPSP, files[16]));
+		SetFileHandle(17, SGET_BYTE(sPSP, files[17]));
+		SetFileHandle(18, SGET_BYTE(sPSP, files[18]));
+		SetFileHandle(19, SGET_BYTE(sPSP, files[19]));
+
 		for (uint16_t i = 20; i < file_num; i++)
 			SetFileHandle(i, 0xFF);
 	} else {

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -224,6 +224,9 @@ void DOS_PSP::SetFileHandle(uint16_t index, uint8_t handle)
 	if (index < SGET_WORD(sPSP, max_files)) {
 		const PhysPt files = Real2Phys(SGET_DWORD(sPSP, file_table));
 		mem_writeb(files + index, handle);
+	} else {
+		DEBUG_LOG_MSG("DOS: Prevented buffer overflow on write to PSP file_table[%u]",
+		              index);
 	}
 }
 


### PR DESCRIPTION
See #550 for an explanation for this change.

I decided to split it into several smaller PRs (one PR per converted class). This should make it easier to review and, if it'll end up regressing anything, to make the bisects more meaningful.