### PR TITLE
Replace sGet, sSave macros - part 2 - DOS_FCB, DOS_DTA, DOS_SDA classes

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -93,7 +93,7 @@ jobs:
         conf:
           - name: Clang
             sanitizers: USAN
-            usan:  61
+            usan:  55
             tsan:  -1
             uasan: -1
           - name: GCC

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,16 +21,16 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 281
+            max_warnings: 279
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 280
+            max_warnings: 278
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 280
+            max_warnings: 278
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
@@ -39,17 +39,17 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 390
+            max_warnings: 388
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 277
+            max_warnings: 275
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 424
+            max_warnings: 422
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 6
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 280
+            max_warnings: 278
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 318
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2059
+            max_warnings: 2056
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -560,29 +560,45 @@ private:
 	#endif
 };
 
-class DOS_FCB: public MemStruct {
+/* File Control Block */
+
+class DOS_FCB : public MemStruct {
 public:
-	DOS_FCB(Bit16u seg,Bit16u off,bool allow_extended=true);
+	DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended = true);
+
 	void Create(bool _extended);
-	void SetName(Bit8u _drive,char * _fname,char * _ext);
-	void SetSizeDateTime(Bit32u _size,Bit16u _date,Bit16u _time);
-	void GetSizeDateTime(Bit32u & _size,Bit16u & _date,Bit16u & _time);
+
+	bool Extended() const { return extended; }
+
+	void SetName(uint8_t drive, const char *fname, const char *ext);
 	void GetName(char * fillname);
-	void FileOpen(Bit8u _fhandle);
-	void FileClose(Bit8u & _fhandle);
-	void GetRecord(Bit16u & _cur_block,Bit8u & _cur_rec);
-	void SetRecord(Bit16u _cur_block,Bit8u _cur_rec);
-	void GetSeqData(Bit8u & _fhandle,Bit16u & _rec_size);
-	void SetSeqData(Bit8u _fhandle,Bit16u _rec_size);
-	void GetRandom(Bit32u & _random);
-	void SetRandom(Bit32u  _random);
-	Bit8u GetDrive(void);
-	bool Extended(void);
-	void GetAttr(Bit8u & attr);
-	void SetAttr(Bit8u attr);
+
+	void SetSizeDateTime(uint32_t size, uint16_t mod_date, uint16_t mod_time);
+	void GetSizeDateTime(uint32_t &size, uint16_t &mod_date, uint16_t &mod_time) const;
+
+	void FileOpen(uint8_t fhandle);
+	void FileClose(uint8_t &fhandle);
+
+	void SetRecord(uint16_t cur_block, uint8_t cur_rec);
+	void GetRecord(uint16_t &cur_block, uint8_t &cur_rec) const;
+
+	void SetSeqData(uint8_t fhandle, uint16_t rec_size);
+	void GetSeqData(uint8_t &fhandle, uint16_t &rec_size) const;
+
+	void SetRandom(uint32_t random) { SSET_DWORD(sFCB, rndm, random); }
+	uint32_t GetRandom() const { return SGET_DWORD(sFCB, rndm); }
+
+	void SetAttr(uint8_t attr);
+	void GetAttr(uint8_t &attr) const;
+
 	void SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr);
-	bool Valid(void);
-	void ClearBlockRecsize(void);
+
+	uint8_t GetDrive() const;
+
+	bool Valid() const;
+
+	void ClearBlockRecsize();
+
 private:
 	bool extended;
 	PhysPt real_pt;
@@ -596,8 +612,8 @@ private:
 		Bit16u cur_block;		/* Current Block */
 		Bit16u rec_size;		/* Logical record size */
 		Bit32u filesize;		/* File Size */
-		Bit16u date;
-		Bit16u time;
+		uint16_t date;                  // Date of last modification
+		uint16_t time;                  // Time of last modification
 		/* Reserved Block should be 8 bytes */
 		Bit8u sft_entries;
 		Bit8u share_attributes;

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -521,21 +521,35 @@ public:
 	Bit16u	seg;
 };
 
-class DOS_DTA:public MemStruct{
+/* Disk Transfer Address
+ *
+ * Some documents refer to it also as Data Transfer Address or Disk Transfer Area.
+ */
+
+class DOS_DTA : public MemStruct {
 public:
 	DOS_DTA(RealPt addr) { SetPt(addr); }
 
-	void SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * _pattern);
-	void SetResult(const char * _name,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr);
-	
-	Bit8u GetSearchDrive(void);
-	void GetSearchParams(Bit8u & _sattr,char * _spattern);
-	void GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr);
+	void SetupSearch(uint8_t drive, uint8_t attr, char *pattern);
+	uint8_t GetSearchDrive() const { return SGET_BYTE(sDTA, sdrive); }
+	void GetSearchParams(uint8_t &attr, char *pattern) const;
 
-	void SetDirID(uint16_t entry) { sSave(sDTA, dirID, entry); }
-	void SetDirIDCluster(uint16_t entry) { sSave(sDTA, dirCluster, entry); }
-	uint16_t GetDirID() { return (uint16_t)sGet(sDTA, dirID); }
-	uint16_t GetDirIDCluster() { return (uint16_t)sGet(sDTA, dirCluster); }
+	void SetResult(const char *name,
+	               uint32_t size,
+	               uint16_t date,
+	               uint16_t time,
+	               uint8_t attr);
+	void GetResult(char *name,
+	               uint32_t &size,
+	               uint16_t &date,
+	               uint16_t &time,
+	               uint8_t &attr) const;
+
+	void SetDirID(uint16_t id) { SSET_WORD(sDTA, dirID, id); }
+	uint16_t GetDirID() const { return SGET_WORD(sDTA, dirID); }
+
+	void SetDirIDCluster(uint16_t cl) { SSET_WORD(sDTA, dirCluster, cl); }
+	uint16_t GetDirIDCluster() const { return SGET_WORD(sDTA, dirCluster); }
 
 private:
 	#ifdef _MSC_VER
@@ -543,7 +557,7 @@ private:
 	#endif
 	struct sDTA {
 		Bit8u sdrive;						/* The Drive the search is taking place */
-		Bit8u sname[8];						/* The Search pattern for the filename */		
+		Bit8u sname[8];						/* The Search pattern for the filename */
 		Bit8u sext[3];						/* The Search pattern for the extenstion */
 		Bit8u sattr;						/* The Attributes that need to be found */
 		Bit16u dirID;						/* custom: dir-search ID for multiple searches at the same time */
@@ -618,7 +632,7 @@ private:
 		Bit8u sft_entries;
 		Bit8u share_attributes;
 		Bit8u extra_info;
-		/* Maybe swap file_handle and sft_entries now that fcbs 
+		/* Maybe swap file_handle and sft_entries now that fcbs
 		 * aren't stored in the psp filetable anymore */
 		Bit8u file_handle;
 		Bit8u reserved[4];

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -675,15 +675,18 @@ private:
 class DOS_SDA : public MemStruct {
 public:
 	DOS_SDA(Bit16u _seg,Bit16u _offs) { SetPt(_seg,_offs); }
-	void Init();   
-	void SetDrive(Bit8u _drive) { sSave(sSDA,current_drive, _drive); }
-	void SetDTA(Bit32u _dta) { sSave(sSDA,current_dta, _dta); }
-	void SetPSP(Bit16u _psp) { sSave(sSDA,current_psp, _psp); }
-	Bit8u GetDrive(void) { return (Bit8u)sGet(sSDA,current_drive); }
-	Bit16u GetPSP(void) { return (Bit16u)sGet(sSDA,current_psp); }
-	Bit32u GetDTA(void) { return (Bit32u)sGet(sSDA,current_dta); }
-	
-	
+
+	void Init();
+
+	void SetDrive(uint8_t drive) { SSET_BYTE(sSDA, current_drive, drive); }
+	uint8_t GetDrive() const { return SGET_BYTE(sSDA, current_drive); }
+
+	void SetDTA(uint32_t dta) { SSET_DWORD(sSDA, current_dta, dta); }
+	uint32_t GetDTA() const { return SGET_DWORD(sSDA, current_dta); }
+
+	void SetPSP(uint16_t psp) { SSET_WORD(sSDA, current_psp, psp); }
+	uint16_t GetPSP() const { return SGET_WORD(sSDA, current_psp); }
+
 private:
 	#ifdef _MSC_VER
 	#pragma pack (1)
@@ -727,7 +730,7 @@ struct DOS_Block {
 	void dta(RealPt dtap) { DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).SetDTA(dtap); }
 
 	Bit8u return_code,return_mode;
-	
+
 	Bit8u current_drive;
 	bool verify;
 	bool breakcheck;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -568,8 +568,10 @@ void DOS_FCB::SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr) {
 	mem_writeb(pt + 0x0c,attr);
 }
 
-void DOS_SDA::Init() {
+void DOS_SDA::Init()
+{
 	/* Clear */
-	for(Bitu i=0;i<sizeof(sSDA);i++) mem_writeb(pt+i,0x00);
-	sSave(sSDA,drive_crit_error,0xff);   
+	for (size_t i = 0; i < sizeof(sSDA); ++i)
+		mem_writeb(pt + i, 0x00);
+	SSET_BYTE(sSDA, drive_crit_error, uint8_t(0xff));
 }

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -364,10 +364,10 @@ bool DOS_PSP::SetNumFiles(uint16_t file_num)
 	return true;
 }
 
-
-void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
-	sSave(sDTA,sdrive,_sdrive);
-	sSave(sDTA,sattr,_sattr);
+void DOS_DTA::SetupSearch(uint8_t drive, uint8_t attr, char *pattern)
+{
+	SSET_BYTE(sDTA, sdrive, drive);
+	SSET_BYTE(sDTA, sattr, attr);
 	/* Fill with spaces */
 	Bitu i;
 	for (i=0;i<11;i++) mem_writeb(pt+offsetof(sDTA,sname)+i,' ');
@@ -384,36 +384,42 @@ void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
 	}
 }
 
-void DOS_DTA::SetResult(const char * _name,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr) {
-	MEM_BlockWrite(pt+offsetof(sDTA,name),(void *)_name,strlen(_name)+1);
-	sSave(sDTA,size,_size);
-	sSave(sDTA,date,_date);
-	sSave(sDTA,time,_time);
-	sSave(sDTA,attr,_attr);
+void DOS_DTA::SetResult(const char *found_name,
+                        uint32_t found_size,
+                        uint16_t found_date,
+                        uint16_t found_time,
+                        uint8_t found_attr)
+{
+	MEM_BlockWrite(pt + offsetof(sDTA, name), found_name, strlen(found_name) + 1);
+	SSET_DWORD(sDTA, size, found_size);
+	SSET_WORD(sDTA, date, found_date);
+	SSET_WORD(sDTA, time, found_time);
+	SSET_BYTE(sDTA, attr, found_attr);
 }
 
-
-void DOS_DTA::GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr) {
-	MEM_BlockRead(pt+offsetof(sDTA,name),_name,DOS_NAMELENGTH_ASCII);
-	_size=sGet(sDTA,size);
-	_date=(Bit16u)sGet(sDTA,date);
-	_time=(Bit16u)sGet(sDTA,time);
-	_attr=(Bit8u)sGet(sDTA,attr);
+void DOS_DTA::GetResult(char *found_name,
+                        uint32_t &found_size,
+                        uint16_t &found_date,
+                        uint16_t &found_time,
+                        uint8_t &found_attr) const
+{
+	constexpr auto name_offset = offsetof(sDTA, name);
+	MEM_BlockRead(pt + name_offset, found_name, DOS_NAMELENGTH_ASCII);
+	found_size = SGET_DWORD(sDTA, size);
+	found_date = SGET_WORD(sDTA, date);
+	found_time = SGET_WORD(sDTA, time);
+	found_attr = SGET_BYTE(sDTA, attr);
 }
 
-Bit8u DOS_DTA::GetSearchDrive(void) {
-	return (Bit8u)sGet(sDTA,sdrive);
-}
-
-void DOS_DTA::GetSearchParams(Bit8u & attr,char * pattern) {
-	attr=(Bit8u)sGet(sDTA,sattr);
+void DOS_DTA::GetSearchParams(uint8_t &attr, char *pattern) const
+{
+	attr = SGET_BYTE(sDTA, sattr);
 	char temp[11];
 	MEM_BlockRead(pt+offsetof(sDTA,sname),temp,11);
 	memcpy(pattern,temp,8);
 	pattern[8]='.';
 	memcpy(&pattern[9],&temp[8],3);
 	pattern[12]=0;
-
 }
 
 DOS_FCB::DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended)

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1153,14 +1153,13 @@ Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
  * Random block read updates these fields to reflect the state after the read!
  */
 	DOS_FCB fcb(seg,offset);
-	Bit32u random;
 	Bit16u old_block=0;
 	Bit8u old_rec=0;
 	Bit8u error=0;
 	Bit16u count;
 
 	/* Set the correct record from the random data */
-	fcb.GetRandom(random);
+	const uint32_t random = fcb.GetRandom();
 	fcb.SetRecord((Bit16u)(random / 128),(Bit8u)(random & 127));
 	if (restore) fcb.GetRecord(old_block,old_rec);//store this for after the read.
 	// Read records
@@ -1181,14 +1180,13 @@ Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
 Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
 /* see FCB_RandomRead */
 	DOS_FCB fcb(seg,offset);
-	Bit32u random;
 	Bit16u old_block=0;
 	Bit8u old_rec=0;
 	Bit8u error=0;
 	Bit16u count;
 
 	/* Set the correct record from the random data */
-	fcb.GetRandom(random);
+	const uint32_t random = fcb.GetRandom();
 	fcb.SetRecord((Bit16u)(random / 128),(Bit8u)(random & 127));
 	if (restore) fcb.GetRecord(old_block,old_rec);
 	if (*numRec > 0) {


### PR DESCRIPTION
Continuation of #558 and #550.