### PR TITLE
Fix a CD-DA roll-over bug when calculating PCM frames

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -763,16 +763,10 @@ bool CDROM_Interface_Image::PlayAudioSector(const uint32_t start, uint32_t len)
 		player.addFrames = track_channels ==  2  ? &MixerChannel::AddSamples_s16_nonnative \
 		                                         : &MixerChannel::AddSamples_m16_nonnative;
 	}
-
-	/**
-	 *  Convert Redbook frames (len) to Track PCM frames, rounding up to whole
-	 *  integer frames. Note: the intermediate numerator in the calculation
-	 *  below can overflow uint32_t, so the variable types used must stay
-	 *  64-bit.
-	 */
 	player.playedTrackFrames = 0;
-	player.totalTrackFrames = ceil_udivide(track_rate * player.totalRedbookFrames,
-	                                      REDBOOK_FRAMES_PER_SECOND);
+	// Convert requested RedBook frames into PCM frames
+	player.totalTrackFrames = player.totalRedbookFrames *
+	                          (track_rate / REDBOOK_FRAMES_PER_SECOND);
 
 #ifdef DEBUG
 	if (start < track->start) {


### PR DESCRIPTION
In some cases the numerator in the PCM frame calculation can exceed a `uin32_t` causing it to roll-over. 
This small change pre-divides the PCM rate by the Redbook rate, preventing the subsequent multiplication from ever getting close to limit of a `uint32_t`.

This fixes a regression when playing Descent 2 with a bin/cue pair: after starting the first level the CD-DA only plays for 40 seconds. This is because the game requests playback of track 2, but requests a duration significantly exceeding the actual track's length (which is legal).  This commit fixes the PCM frame calculation and thus the music continues to play into subsequent tracks as expected.

This regression does not occur when using ripped audio tracks (flac/opus).


