### PR TITLE
Fix a boundary check when reading the GUS volume register

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Other differences:
 | **Modem phonebook file** | Yes (`phonebookfile=<name>`)                 | N/A
 | **Autotype command**     | Yes<sup>[10]</sup>                           | N/A
 | **Startup verbosity**    | Yes<sup>[11]</sup>                           | N/A
+| **GUS Enhancements**     | Yes<sup>[12]</sup>                           | N/A
 
 [OPL]:https://en.wikipedia.org/wiki/Yamaha_YMF262
 [CGA]:https://en.wikipedia.org/wiki/Color_Graphics_Adapter
@@ -81,6 +82,7 @@ Other differences:
 [9]:https://github.com/dosbox-staging/dosbox-staging/commit/ffe3c5ab7fb5e28bae78f07ea987904f391a7cf8
 [10]:https://github.com/dosbox-staging/dosbox-staging/commit/239396fec83dbba6a1eb1a0f4461f4a427d2be38
 [11]: https://github.com/dosbox-staging/dosbox-staging/pull/477
+[12]: https://github.com/dosbox-staging/dosbox-staging/wiki/Gravis-UltraSound-Enhancements
 
 ## Stable release builds
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1062,7 +1062,7 @@ uint16_t Gus::ReadFromRegister()
 	case 0x89: // Voice volume register
 	{
 		const int i = ceil_sdivide(voice->vol_ctrl.pos, VOLUME_INC_SCALAR);
-		assert(i > 0 && i < static_cast<int>(vol_scalars.size()));
+		assert(i >= 0 && i < static_cast<int>(vol_scalars.size()));
 		return static_cast<uint16_t>(i << 4);
 	}
 	case 0x8a: // Voice MSB current address register


### PR DESCRIPTION
Also adds the GUS Enhancements to README's table of changes.
GUS emulation is now re-passing the full set of regression games and programs.