### PR TITLE
Add C++ Core Guidelines analysis to CI

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -171,3 +171,53 @@ jobs:
             echo
             xzcat "$UASAN_LOG" | MAX_ISSUES=${{ matrix.conf.uasan }} ./scripts/count-xsan-issues.py -
           fi
+
+  build_windows_vs_core_guidelines:
+    name: C++ Core Guidelines analysis
+    needs: run_linters
+    runs-on: windows-latest
+    steps:
+      - name:  Prepare vcpkg for cache restore
+        id:    prep-vcpkg
+        shell: pwsh
+        run: |
+          mv c:\vcpkg c:\vcpkg-bak
+          md c:\vcpkg -ea 0
+
+      - name: Restore the most recent cache of vcpkg
+        uses: actions/cache@v2
+        with:
+          path: c:\vcpkg
+          key: vcpkg-x64-
+
+      - name:  Integrate packages
+        shell: pwsh
+        run: |
+          vcpkg integrate install
+          if (-not $?) { throw "vcpkg failed to integrate packages" }
+
+      - uses:  actions/checkout@v2
+      - name:  Log environment
+        shell: pwsh
+        run:   .\scripts\log-env.ps1
+
+      - name:  Add CGL analysis to build
+        shell: bash
+        run: |
+          cd vs
+          sed -i '88i<RunCodeAnalysis>true</RunCodeAnalysis><CodeAnalysisRuleSet>MS_and_CGL_without_GSL.ruleset</CodeAnalysisRuleSet>' dosbox.vcxproj
+
+      - name:  Build
+        shell: pwsh
+        env:
+          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
+        run: |
+          cd vs
+          MSBuild -m dosbox.sln -p:Configuration=Debug -p:Platform=x64 | Tee-Object build.log
+
+      - name:  Summarize warnings
+        shell: pwsh
+        env:
+          MAX_WARNINGS: 25000
+        run: python scripts\count-warnings.py --msvc vs\build.log
+

--- a/vs/MS_and_CGL_without_GSL.ruleset
+++ b/vs/MS_and_CGL_without_GSL.ruleset
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="MS_and_CGL_without_GSL" ToolsVersion="16.0">
+  <Include Path="concurrencycheckrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckarithmeticrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckboundsrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckclassrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckconcurrencyrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckconstrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckdeclrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckenumrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckexperimentalrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckfuncrules.ruleset" Action="Default" />
+  <Include Path="cppcorechecklifetimerules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckownerpointerrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckrawpointerrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckrules.ruleset" Action="Default" />
+  <Include Path="cppcorechecksharedpointerrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckstlrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckstylerules.ruleset" Action="Default" />
+  <Include Path="cppcorechecktyperules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckuniquepointerrules.ruleset" Action="Default" />
+  <Include Path="mixedrecommendedrules.ruleset" Action="Default" />
+  <Include Path="nativerecommendedrules.ruleset" Action="Default" />
+</RuleSet>
+


### PR DESCRIPTION
This adds [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md) analysis to the CI Analysis workflow.

Here are some typical warnings:

- `C26460: The reference argument 'pathname' for function 'CDROM_Interface_Image::GetRealFileName' can be marked as const (con.3)`

- `C26496: The variable 'pos' is assigned only once, mark it as const (con.4)`

- `C26440: Function 'CDROM_Image_Destroy' can be declared 'noexcept' (f.6)`

- `C26486: Don't pass a pointer that may be invalid to a function. Parameter 0 '@track_file' in call to 'icall' may be invalid (lifetime.3)`

- `C26447: The function is declared 'noexcept' but calls function 'StopAudio()' which may throw exceptions (f.6)`

The warning number can be looked up here `https://docs.microsoft.com/en-us/cpp/code-quality/c<number>`, which sometimes contains a bit more info than the document. The trailing `(x.z)`notation refers to chapter and subsection in the guidelines document.

The goal is that this will offload some code-review burden (even before PRs get to the review phase), as these warnings  are quite thorough and catch different issues versus `effc++`, for example.

Right now the workflow isn't gated: I couldn't figure out how to get the Python issue-counter to include them despite them following the same pattern as normal VS warnings.  However, the goal will be to gate on them.

Although the full analysis tallies to over ~20k warnings, typically developers will be focusing on just a couple files they're working on - and in that case, it's quite manageable.

Here's the full-log of a run: [dosbox_staging_cpp_core_guidelines.txt.gz](https://github.com/dosbox-staging/dosbox-staging/files/5114621/dosbox_staging_cpp_core_guidelines.txt.gz)

Because the analysis requires compilation and post-binary analysis, it does take longer than a typical build (roughly 9 minutes).  Fortunately the analysis takes slightly less time than the current cache-enabled Windows workflow; so overall should not push out our CI times either. 

![2020-08-23_11-08](https://user-images.githubusercontent.com/1557255/90985459-fe8bff00-e530-11ea-84ab-84c27975828a.png)