### PR TITLE
Soft-limit and allow FluidSynth gain adjustment

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -63,7 +63,11 @@ extern Bit8u MixTemp[MIXER_BUFSIZE];
 class MixerChannel {
 public:
 	MixerChannel(MIXER_Handler _handler, Bitu _freq, const char * _name);
-	void SetVolume(float _left,float _right);
+
+	// Allows and external source to control the volume up-stream
+	using ApplyVolCallBack = std::function<void(const AudioFrame<float> &vol_level)>;
+	void RegisterVolCallBack(ApplyVolCallBack cb);
+	void SetVolume(float _left, float _right);
 	void SetScale(float f);
 	void SetScale(float _left, float _right);
 	void MapChannels(Bit8u _left, Bit8u _right);
@@ -133,6 +137,11 @@ private:
 	uint32_t peak_amplitude = MAX_AUDIO;
 
 	uint8_t channel_map[2] = {0u, 0u}; // Output channel mapping
+
+	// If an audio source wants to manage the volume, then this callback
+	// will called on mixer volume changes.
+	ApplyVolCallBack apply_volume_callback = nullptr;
+
 	bool interpolate = false;
 	bool last_samples_were_stereo = false;
 	bool last_samples_were_silence = true;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -46,8 +46,15 @@ enum MixerModes {
 	M_16M,M_16S
 };
 
-#define MIXER_BUFSIZE (16*1024)
-#define MIXER_BUFMASK (MIXER_BUFSIZE-1)
+// A simple stereo audio frame
+template <typename sample_t>
+struct AudioFrame {
+	sample_t left = 0;
+	sample_t right = 0;
+};
+
+#define MIXER_BUFSIZE (16 * 1024)
+#define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
 extern Bit8u MixTemp[MIXER_BUFSIZE];
 
 #define MAX_AUDIO ((1<<(16-1))-1)

--- a/include/soft_limiter.h
+++ b/include/soft_limiter.h
@@ -1,0 +1,272 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_SOFT_LIMITER_H
+#define DOSBOX_SOFT_LIMITER_H
+
+/*
+Soft Limiter
+------------
+Given an input array and output array where the input can support wider values
+than the output, the limiter will detect when the input contains one or more
+values that would exceed the output's type bounds.
+
+When detected, it scale-down the entire input set such that they fit within the
+output bounds. By scaling the entire series of values, it ensure relative
+differences are retained without distorion. (This is known as 'Soft Limiting',
+which is superior to Hard Limiting, which truncates values and causes
+distortion).
+
+This scale-down-to-fit effect continues to be applied to subsequent input sets,
+each time with less effect (provided new peaks aren't detected), until the
+scale-down is complete - this period is known as 'Release'.
+
+The release duration is a function of how much we needed to scale down in the
+first place.  The larger the scale-down, the longer the effect (typically
+ranging from 10's of milliseconds to low-hundreds for > 2x overages).
+
+Use:
+
+The SoftLimiter is a template class where:
+ - in_t is inbound sample type, which should be decimal-type (float/double/..)
+ - out_t is the outbound sample type, typically a fixed-width integer (int16_t)
+ - Static assert check that a float-type is used for in_t, and that
+   in_t has a wider-value range than out_t.
+ - array_frames is a fixed number of frames in both arrays.
+
+SoftLimiter<float, int16_t, 48> limiter;
+
+You can then repeatedly call:
+  limiter.Apply(inarray, outarray);
+
+which will either copy or limit the inarray values into outarray.
+
+The PrintStats function will make mixer suggestions if the inarray
+was 40% under the allowed bounds (recommending it be scaled up)
+or if the limiter was needed on more than 10% of the stream, in which
+case a reduction is recommended.  The PrintStats takes in "pre-scalars",
+which might have already been used on the stream, and takes these into
+account in its recommendations.
+*/
+
+#include "logging.h"
+#include "mixer.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <string>
+
+// Short-hand helpers
+#define SL_TEMPLATE_DEF                                                        \
+	template <typename in_t, typename out_t, size_t array_frames>
+#define SL_TEMPLATE_INST SoftLimiter<in_t, out_t, array_frames>
+
+SL_TEMPLATE_DEF
+class SoftLimiter {
+public:
+	SoftLimiter() = delete;
+	SoftLimiter(const std::string &name, const AudioFrame<in_t> &scale);
+
+	using in_array_t = std::array<in_t, array_frames * 2>; // 2 for stereo
+	using out_array_t = std::array<out_t, array_frames * 2>; // 2 for stereo
+
+	void Apply(in_array_t &in, out_array_t &out, uint16_t frames) noexcept;
+	const AudioFrame<in_t> &GetPeaks() const noexcept { return peak; }
+	void PrintStats(const AudioFrame<in_t> &external_scale) const;
+	void Reset() noexcept;
+
+private:
+	// Amplitude level constants
+	using out_limits = std::numeric_limits<out_t>;
+	constexpr static in_t upper_bound = static_cast<in_t>(out_limits::max());
+	constexpr static in_t lower_bound = static_cast<in_t>(out_limits::min());
+
+	constexpr void CheckTypes() const;
+	bool PrescaleAndPeak(in_array_t &stream, uint16_t frames) noexcept;
+
+	std::string channel_name = {};
+	AudioFrame<in_t> limit_scale = {1, 1}; // real-time limit applied to stream
+	AudioFrame<in_t> peak = {1, 1};   // tracks real-time peak amplitude
+	const AudioFrame<in_t> &prescale; // scale before operating on the stream
+	int limited_ms = 0;               // milliseconds that needed limiting
+	int non_limited_ms = 0; // milliseconds that didn't need limiting
+};
+
+// A simple templatized absolute-value helper function
+template <typename in_t>
+in_t absolute_value(in_t val) noexcept
+{
+	return (val > 0 ? val : val * -1);
+}
+
+SL_TEMPLATE_DEF
+SL_TEMPLATE_INST::SoftLimiter(const std::string &name, const AudioFrame<in_t> &scale)
+        : channel_name(name),
+          prescale(scale)
+{
+	CheckTypes();
+}
+
+SL_TEMPLATE_DEF
+constexpr void SL_TEMPLATE_INST::CheckTypes() const
+{
+	static_assert(std::numeric_limits<in_t>::max() >
+	                      std::numeric_limits<out_t>::max(),
+	              "in_t needs to hold larger values than out_t");
+	static_assert(!std::is_integral<in_t>::value,
+	              "out_t needs to be non-integral type, like float or double");
+}
+
+SL_TEMPLATE_DEF
+bool SL_TEMPLATE_INST::PrescaleAndPeak(in_array_t &stream, const uint16_t samples) noexcept
+{
+	auto val = stream.begin();
+	const auto val_end = stream.begin() + samples;
+	while (val < val_end) {
+		// Left channel
+		*val *= prescale.left;
+		peak.left = std::max(peak.left, absolute_value(*val));
+		++val;
+
+		// Right channel
+		*val *= prescale.right;
+		peak.right = std::max(peak.right, absolute_value(*val));
+		++val;
+	}
+	const bool limiting_needed = (peak.left > upper_bound ||
+	                              peak.right > upper_bound);
+
+	// Calculate the percent we need to scale down each channel. In cases
+	// where one channel is less than the upper-bound, its time_ratio is limited
+	// to 1.0 to retain the original level.
+	if (limiting_needed)
+		limit_scale = {std::min(in_t{1}, upper_bound / peak.left),
+		               std::min(in_t{1}, upper_bound / peak.right)};
+
+	return limiting_needed;
+	// LOG_MSG("%s peak left = %f", channel_name.c_str(),
+	// static_cast<double>(peak.left));
+}
+
+SL_TEMPLATE_DEF
+void SL_TEMPLATE_INST::Apply(in_array_t &in, out_array_t &out, const uint16_t req_frames) noexcept
+{
+	// Ensure the buffers are large enough to handle the request
+	const uint16_t samples = req_frames * 2; // left and right channels
+	assert(samples <= in.size());
+
+	// Prescale the signal and detect any new peaks
+	const bool limiting_needed = PrescaleAndPeak(in, samples);
+
+	// get our in and out iterators
+	auto in_val = in.begin();
+	const auto in_val_end = in.begin() + samples;
+	auto out_val = out.begin();
+
+	// If we don't need to limit the signal then simply copy it
+	if (!limiting_needed) {
+		while (in_val < in_val_end)
+			*out_val++ = static_cast<out_t>(*in_val++);
+		++non_limited_ms;
+		return;
+	}
+	// Otherwise we need to limit the signal
+	while (in_val < in_val_end) {
+		*out_val++ = static_cast<out_t>(*in_val++ * limit_scale.left);
+		*out_val++ = static_cast<out_t>(*in_val++ * limit_scale.right);
+	}
+	++limited_ms;
+
+	// Decrement the peak(s) one step
+	constexpr in_t delta_db = static_cast<in_t>(0.002709201); // 0.0235 dB
+	                                                          // increments
+	constexpr in_t release_amplitude = upper_bound * delta_db;
+	if (peak.left > upper_bound)
+		peak.left -= release_amplitude;
+	if (peak.right > upper_bound)
+		peak.right -= release_amplitude;
+	// LOG_MSG("GUS: releasing peak_amplitude = %.2f | %.2f",
+	//         static_cast<double>(peak.left),
+	//         static_cast<double>(peak.right));
+}
+
+SL_TEMPLATE_DEF
+void SL_TEMPLATE_INST::PrintStats(const AudioFrame<in_t> &external_scale) const
+{
+	constexpr auto ms_per_minute = 1000 * 60;
+	const auto ms_total = static_cast<double>(limited_ms) + non_limited_ms;
+	const auto minutes_total = ms_total / ms_per_minute;
+
+	// Only print stats if we have more than 30 seconds of data
+	if (minutes_total < 0.5)
+		return;
+
+	// Only print volume info the peak is at-least 5% of the max
+	const auto peak_sample = std::max(peak.left, peak.right);
+	constexpr auto five_percent_of_max = upper_bound / 20;
+	if (peak_sample < five_percent_of_max)
+		return;
+
+	// It's expected and normal for multi-channel audio to periodically
+	// accumulate beyond the max, which the soft-limiter gracefully handles.
+	// More importantly, users typically care when their overall stream
+	// never achieved the maximum levels.
+	auto peak_ratio = peak_sample / upper_bound;
+	peak_ratio = std::min(peak_ratio, static_cast<in_t>(1.0));
+	LOG_MSG("%s: Peak amplitude reached %.0f%% of max",
+	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
+
+	// Make a suggestion if the peak volume was well below 3 dB. Note that
+	// we remove the effect of the external scale by dividing by it. This
+	// avoids making a recommendation if the user delibertely wanted quiet
+	// output (as an example).
+	const auto scale = std::max(external_scale.left, external_scale.right);
+	constexpr auto well_below_3db = static_cast<in_t>(0.6);
+	if (peak_ratio / scale < well_below_3db) {
+		const auto suggested_mix_val = 100 * scale / peak_ratio;
+		LOG_MSG("%s: If it should be louder, use: mixer %s %.0f",
+		        channel_name.c_str(), channel_name.c_str(),
+		        static_cast<double>(suggested_mix_val));
+	}
+	// Make a suggestion if more than 20% of the stream required limiting
+	const auto time_ratio = limited_ms / (ms_total + 1); // one ms avoids div-by-0
+	if (time_ratio > 0.2) {
+		const auto minutes_limited = static_cast<double>(limited_ms) / ms_per_minute;
+		const auto reduction_ratio = 1 - time_ratio / 2;
+		const auto suggested_mix_val = 100 * reduction_ratio * static_cast<double>(scale);
+		LOG_MSG("%s: %.1f%% or %.2f of %.2f minutes needed limiting, consider: mixer %s %.0f",
+		        channel_name.c_str(), 100 * time_ratio, minutes_limited,
+		        minutes_total, channel_name.c_str(), suggested_mix_val);
+	}
+}
+
+SL_TEMPLATE_DEF
+void SL_TEMPLATE_INST::Reset() noexcept
+{
+	peak = {1, 1};
+	limited_ms = 0;
+	non_limited_ms = 0;
+}
+
+#undef SL_TEMPLATE_DEF
+#undef SL_TEMPLATE_INST
+
+#endif

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -34,6 +34,7 @@
 #include "pic.h"
 #include "setup.h"
 #include "shell.h"
+#include "soft_limiter.h"
 
 #define LOG_GUS 0 // set to 1 for detailed logging
 
@@ -44,7 +45,6 @@
 constexpr uint8_t ADLIB_CMD_DEFAULT = 85u;
 
 // Amplitude level constants
-constexpr float ONE_AMP = 1.0f; // first amplitude value
 constexpr float AUDIO_SAMPLE_MAX = static_cast<float>(MAX_AUDIO);
 constexpr float AUDIO_SAMPLE_MIN = static_cast<float>(MIN_AUDIO);
 
@@ -247,13 +247,11 @@ private:
 	size_t ReadFromPort(const size_t port, const size_t iolen);
 	void RegisterIoHandlers();
 	void Reset(uint8_t state);
-	void SoftLimit(const accumulator_array_t &in, scaled_array_t &out) noexcept;
 	void SetMixerVolume(const AudioFrame<float> &level);
 	void StopPlayback();
 	void UpdateDmaAddress(uint8_t new_address);
 	void UpdateWaveMsw(int32_t &addr) const noexcept;
 	void UpdateWaveLsw(int32_t &addr) const noexcept;
-	void UpdatePeakAmplitudes(const accumulator_array_t &stream) noexcept;
 	void WriteToPort(size_t port, size_t val, size_t iolen);
 	void WriteToRegister();
 
@@ -275,11 +273,11 @@ private:
 	// Struct and pointer members
 	VoiceIrq voice_irq = {};
 	MixerObject mixer_channel = {};
-	AudioFrame<float> peak = {ONE_AMP, ONE_AMP};
+	AudioFrame<float> mixer_volume = {1, 1};
+	SoftLimiter<float, int16_t, BUFFER_FRAMES> soft_limiter;
 	Voice *voice = nullptr;
 	DmaChannel *dma_channel = nullptr;
 	MixerChannel *audio_channel = nullptr;
-	AudioFrame<float> mixer_volume = {1, 1};
 	uint8_t &adlib_command_reg = adlib_commandreg;
 
 	// Port address
@@ -582,7 +580,8 @@ void Voice::WriteWaveRate(uint16_t val) noexcept
 }
 
 Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
-        : port_base(port - 0x200u),
+        : soft_limiter("GUS", mixer_volume),
+          port_base(port - 0x200u),
           dma2(dma),
           irq1(irq),
           irq2(irq)
@@ -646,14 +645,7 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 		++v;
 	}
 
-	// Pre-scale the stream by the user's mixer scalar
-	auto val = accumulator.begin();
-	while (val < accumulator.end()) {
-		*val++ *= mixer_volume.left;
-		*val++ *= mixer_volume.right;
-	}
-
-	SoftLimit(accumulator, scaled);
+	soft_limiter.Apply(accumulator, scaled, requested_frames);
 	audio_channel->AddSamples_s16(requested_frames, scaled.data());
 	CheckVoiceIrq();
 }
@@ -934,6 +926,7 @@ void Gus::PrintStats()
 	const uint32_t combined_ms = combined_8bit_ms + combined_16bit_ms;
 
 	// Is there enough information to be meaningful?
+	const auto peak = soft_limiter.GetPeaks();
 	if (combined_ms < 10000u || (peak.left + peak.right) < 10 ||
 	    !(used_8bit_voices + used_16bit_voices))
 		return;
@@ -955,30 +948,7 @@ void Gus::PrintStats()
 		        ratio_8bit, used_8bit_voices, ratio_16bit,
 		        used_16bit_voices);
 	}
-
-	// Calculate and print info about the volume
-	const auto mixer_scalar = std::max(audio_channel->volmain[0],
-	                                   audio_channel->volmain[1]);
-	const auto peak_sample = std::max(peak.left, peak.right);
-	auto peak_ratio = mixer_scalar * peak_sample / AUDIO_SAMPLE_MAX;
-
-	// It's expected and normal for multi-voice audio to periodically
-	// accumulate beyond the max, which is gracefully scaled without
-	// distortion, so there is no need to recommend that users scale-down
-	// their GUS mixer settings.
-	peak_ratio = std::min(peak_ratio, 1.0f);
-	LOG_MSG("GUS: Peak amplitude reached %.0f%% of max",
-	        100 * static_cast<double>(peak_ratio));
-
-	// Make a suggestion if the peak volume was well below 3 dB
-	if (peak_ratio < 0.6f) {
-		const auto multiplier = static_cast<uint16_t>(
-		        100 * mixer_scalar / peak_ratio);
-		LOG_MSG("GUS: If it should be louder, %s %u",
-		        fabs(mixer_scalar - 1.0f) > 0.01f ? "adjust mixer gus to"
-		                                          : "use: mixer gus",
-		        multiplier);
-	}
+	soft_limiter.PrintStats(mixer_volume);
 }
 
 Bitu Gus::ReadFromPort(const Bitu port, const Bitu iolen)
@@ -1151,43 +1121,6 @@ void Gus::StopPlayback()
 	PIC_RemoveEvents(GUS_TimerEvent);
 }
 
-void Gus::SoftLimit(const accumulator_array_t &in, scaled_array_t &out) noexcept
-{
-	UpdatePeakAmplitudes(in);
-
-	// get our in and out iterators
-	auto in_v = in.begin();
-	auto out_v = out.begin();
-
-	// If our peaks are under the max, then there's no overage - so copy
-	if (peak.left < AUDIO_SAMPLE_MAX && peak.right < AUDIO_SAMPLE_MAX) {
-		while (in_v < in.end() && out_v < out.end()) {
-			*out_v++ = static_cast<int16_t>(*in_v++);
-		}
-		return;
-	}
-	// Calculate the percent we need to scale down the volume index
-	// position.  In cases where one side is less than the max, it's ratio
-	// is limited to 1.0.
-	const float left_scalar = std::min(ONE_AMP, AUDIO_SAMPLE_MAX / peak.left);
-	const float right_scalar = std::min(ONE_AMP, AUDIO_SAMPLE_MAX / peak.right);
-
-	while (in_v < in.end() && out_v < out.end()) {
-		*out_v++ = static_cast<int16_t>(*in_v++ * left_scalar);
-		*out_v++ = static_cast<int16_t>(*in_v++ * right_scalar);
-	}
-
-	constexpr float SOFT_LIMIT_RELEASE_INC = AUDIO_SAMPLE_MAX *
-                                         static_cast<float>(DELTA_DB);
-	if (peak.left > AUDIO_SAMPLE_MAX)
-		peak.left -= SOFT_LIMIT_RELEASE_INC;
-	if (peak.right > AUDIO_SAMPLE_MAX)
-		peak.right -= SOFT_LIMIT_RELEASE_INC;
-	// LOG_MSG("GUS: releasing peak_amplitude = %.2f | %.2f",
-	//         static_cast<double>(peak.left),
-	//         static_cast<double>(peak.right));
-}
-
 static void GUS_TimerEvent(Bitu t)
 {
 	if (gus->CheckTimer(t)) {
@@ -1302,15 +1235,6 @@ void Gus::WriteToPort(Bitu port, Bitu val, Bitu iolen)
 		LOG_MSG("GUS: Write to port 0x%x with value %x", port, val);
 #endif
 		break;
-	}
-}
-
-void Gus::UpdatePeakAmplitudes(const accumulator_array_t &stream) noexcept
-{
-	auto v = stream.begin();
-	while (v < stream.end()) {
-		peak.left = std::max(peak.left, fabsf(*v++));
-		peak.right = std::max(peak.right, fabsf(*v++));
 	}
 }
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -91,12 +91,6 @@ constexpr int16_t WAVE_WIDTH = 1 << 9; // Wave interpolation width (9 bits)
 constexpr uint8_t READ_HANDLERS = 8u;
 constexpr uint8_t WRITE_HANDLERS = 9u;
 
-// A simple stereo audio frame that's used by the Gus and Voice classes.
-struct AudioFrame {
-	float left = 0.0f;
-	float right = 0.0f;
-};
-
 // A group of parameters defining the Gus's voice IRQ control that's also shared
 // (as a reference) into each instantiated voice.
 struct VoiceIrq {
@@ -121,7 +115,7 @@ struct VoiceCtrl {
 using accumulator_array_t = std::array<float, BUFFER_SAMPLES>;
 using address_array_t = std::array<uint8_t, DMA_IRQ_ADDRESSES>;
 using autoexec_array_t = std::array<AutoexecObject, 2>;
-using pan_scalars_array_t = std::array<AudioFrame, PAN_POSITIONS>;
+using pan_scalars_array_t = std::array<AudioFrame<float>, PAN_POSITIONS>;
 using ram_array_t = std::array<uint8_t, RAM_SIZE>;
 using read_io_array_t = std::array<IO_ReadHandleObject, READ_HANDLERS>;
 using scaled_array_t = std::array<int16_t, BUFFER_SAMPLES>;
@@ -280,7 +274,7 @@ private:
 	// Struct and pointer members
 	VoiceIrq voice_irq = {};
 	MixerObject mixer_channel = {};
-	AudioFrame peak = {ONE_AMP, ONE_AMP};
+	AudioFrame<float> peak = {ONE_AMP, ONE_AMP};
 	Voice *voice = nullptr;
 	DmaChannel *dma_channel = nullptr;
 	MixerChannel *audio_channel = nullptr;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -789,7 +789,10 @@ public:
 		MixerChannel * chan = mixer.channels;
 		while (chan) {
 			if (cmd->FindString(chan->name,temp_line,false)) {
-				MakeVolume((char *)temp_line.c_str(),chan->volmain[0],chan->volmain[1]);
+				float left_vol = 0;
+				float right_vol = 0;
+				MakeVolume((char *)temp_line.c_str(), left_vol, right_vol);
+				chan->SetVolume(left_vol, right_vol);
 			}
 			chan->UpdateVolume();
 			chan = chan->next;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -99,6 +99,7 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 
 	const int cpu_cores = section->Get_int("synth_threads");
 	fluid_settings_setint(fluid_settings.get(), "synth.cpu-cores", cpu_cores);
+	fluid_settings_setstr(fluid_settings.get(), "audio.sample-format", "float");
 
 	fsynth_ptr_t fluid_synth(new_fluid_synth(fluid_settings.get()),
 	                         delete_fluid_synth);
@@ -192,13 +193,17 @@ void MidiHandlerFluidsynth::PlaySysex(uint8_t *sysex, size_t len)
 
 void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
 {
-	constexpr uint16_t expected_max_frames = (96000 / 1000) + 4;
-	int16_t data[expected_max_frames * 2]; // two channels per frame
+	constexpr uint16_t max_samples = expected_max_frames * 2; // two channels per frame
+	std::array<float, max_samples> accumulator = {{0}};
+	std::array<int16_t, max_samples> scaled = {{0}};
+
 	while (frames > 0) {
-		const uint16_t len = std::min(frames, expected_max_frames);
-		fluid_synth_write_s16(synth.get(), len, data, 0, 2,
-		                      data, 1, 2);
-		channel->AddSamples_s16(len, data);
+		constexpr uint16_t max_frames = expected_max_frames; // local copy fixes link error
+		const uint16_t len = std::min(frames, max_frames);
+		fluid_synth_write_float(synth.get(), len, accumulator.data(), 0,
+		                        2, accumulator.data(), 1, 2);
+		soft_limiter.Apply(accumulator, scaled, len);
+		channel->AddSamples_s16(len, scaled.data());
 		frames -= len;
 	}
 }

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -191,6 +191,11 @@ void MidiHandlerFluidsynth::PlaySysex(uint8_t *sysex, size_t len)
 	fluid_synth_sysex(synth.get(), data, n, nullptr, nullptr, nullptr, false);
 }
 
+void MidiHandlerFluidsynth::PrintStats()
+{
+	soft_limiter.PrintStats(mixer_volume);
+}
+
 void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
 {
 	constexpr uint16_t max_samples = expected_max_frames * 2; // two channels per frame
@@ -209,7 +214,9 @@ void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
 }
 
 static void fluid_destroy(MAYBE_UNUSED Section *sec)
-{}
+{
+	instance.PrintStats();
+}
 
 static void fluid_init(Section *sec)
 {

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -50,7 +50,7 @@ public:
 	void PlaySysex(uint8_t *sysex, size_t len) override;
 
 private:
-	MidiHandlerFluidsynth() = default;
+	void MixerCallBack(uint16_t len); // see: MIXER_Handler
 
 	static MidiHandlerFluidsynth instance;
 
@@ -58,8 +58,6 @@ private:
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
 	bool is_open = false;
-
-	static void mixer_callback(uint16_t len); // see: MIXER_Handler
 };
 
 #endif // C_FLUIDSYNTH

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -31,6 +31,7 @@
 #include <fluidsynth.h>
 
 #include "mixer.h"
+#include "soft_limiter.h"
 
 class MidiHandlerFluidsynth final : public MidiHandler {
 private:
@@ -43,6 +44,8 @@ private:
 	        std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
 public:
+	MidiHandlerFluidsynth() : soft_limiter("FSYNTH", prescale_volume) {}
+	void PrintStats();
 	const char *GetName() const override { return "fluidsynth"; }
 	bool Open(const char *conf) override;
 	void Close() override;
@@ -50,6 +53,7 @@ public:
 	void PlaySysex(uint8_t *sysex, size_t len) override;
 
 private:
+	static constexpr uint16_t expected_max_frames = (96000 / 1000) + 4;
 	void MixerCallBack(uint16_t len); // see: MIXER_Handler
 	void SetMixerVolume(const AudioFrame<float> &prescale_volume) noexcept;
 
@@ -60,6 +64,7 @@ private:
 	// Volume scalars - see SetMixerVolume implementation
 	AudioFrame<float> mixer_volume = {1.0f, 1.0f};
 	AudioFrame<float> prescale_volume = {1.0f, 1.0f};
+	SoftLimiter<float, int16_t, expected_max_frames> soft_limiter;
 
 	bool is_open = false;
 };

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -51,12 +51,16 @@ public:
 
 private:
 	void MixerCallBack(uint16_t len); // see: MIXER_Handler
-
-	static MidiHandlerFluidsynth instance;
+	void SetMixerVolume(const AudioFrame<float> &prescale_volume) noexcept;
 
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
+
+	// Volume scalars - see SetMixerVolume implementation
+	AudioFrame<float> mixer_volume = {1.0f, 1.0f};
+	AudioFrame<float> prescale_volume = {1.0f, 1.0f};
+
 	bool is_open = false;
 };
 


### PR DESCRIPTION
This PR fixes https://github.com/dosbox-staging/dosbox-staging/issues/572 by leveraging the GUS's Soft Limiter, which operates on floating-point samples.

To implement this change, this PR lifts out the GUS's Soft Limiter into its own class (which then is used by the GUS and FluidSynth classes), and reads floating point samples from FluidSynth, a pre-requisite of the Soft Limiter.

This PR also allows Fluidsynth's gain to be adjusted via `mixer FSYNTH <value>`, without any risk of clipping or wrapping (like we see occurring in #572 when FluidSynth is left to its own devices operating on 16bit integers). 

The combination of the above two changes allows for full volume, distortion-free MIDI music.

When dosbox is shutdown, the Soft Limiter **generates helpful information** about the channels it was managing (just like it behaved for the GUS), so this way users will see if the FSYNTH stream hit 100%, and any suggestions regarding mixer settings.

Here are some visual and audio comparisons:
1. If the game provides an in-game volume slider, the music was set to 100%
1. The high-quality **SGM-v2.01-Sal-Guit-Bass-V1.3.sf2** sound font was used.
1. Only the dosbox binary was changed between recordings; everything else was left as-is.

## Aces of the Deep

Very heavy strings and horns; you can hear the Cello and Double-bass strings "thwacking" as they're plucked, in rich detail.

Before: https://drive.google.com/file/d/10R-Scbm7xhlhmje2S0KykT7aFFegnD7V/view?usp=sharing (bottom image)
After: https://drive.google.com/file/d/1VOjjCG0F11DYxDnYarftL9V9r5WrVHQw/view?usp=sharing

![aod](https://user-images.githubusercontent.com/1557255/91237564-d5fe3380-e6ef-11ea-9f07-35aa508afb19.png)

## Descent

Mostly synthetic sounds.

Before: https://drive.google.com/file/d/12rw0zAZtmxD8_u5EreYWGKnUO_UQ74oS/view?usp=sharing (bottom image)
After: https://drive.google.com/file/d/19X5RA51PzdiFWwrv1FnMWDW066Xq7KZx/view?usp=sharing

![descent](https://user-images.githubusercontent.com/1557255/91237567-d5fe3380-e6ef-11ea-8d99-275aec61b1be.png)

## Doom

Ripping guitar line.

Before: https://drive.google.com/file/d/1VWIAlhtnqVdGt2mIlcWwN2LVy8PuG0PS/view?usp=sharing  (bottom image)
After: https://drive.google.com/file/d/1qPN1cCqDZaz1KSmIJc05grUc_-yiDfYD/view?usp=sharing

![2020-08-25_16-05](https://user-images.githubusercontent.com/1557255/91237560-d4cd0680-e6ef-11ea-80c4-c1402c15a1f3.png)

## Space Quest V

Sierra's mountain theme followed by SQ5's intro sequence. 

Before: https://drive.google.com/file/d/1LKL9GOyl5DP5tAWPUe1vxNqoyg6zgVr_/view?usp=sharing  (bottom image)
After: https://drive.google.com/file/d/1XzeHD9WMvN_VSweaKAsXeqK5457FHx2-/view?usp=sharing

![2020-08-25_16-06](https://user-images.githubusercontent.com/1557255/91237562-d5659d00-e6ef-11ea-941d-8a8d99a6d6b5.png)

## Star Wars X-Wing

Triumphant violin and brass line.

Before: https://drive.google.com/file/d/1bjNusf0dxjX2_qWgyoyJRFrrLhr37nhg/view?usp=sharing  (bottom image)
After: https://drive.google.com/file/d/1-ZHQO9YDssBBSlxAaFhztkEt85P4VlaY/view?usp=sharing

![2020-08-25_16-08](https://user-images.githubusercontent.com/1557255/91237563-d5659d00-e6ef-11ea-80ae-a2cc2e4cc148.png)

## X-COM II - Terror from the Deep

Ominous vibrating tuba during the intro scenes.

Before: https://drive.google.com/file/d/1RnUp9tmA9LpA5XckVaTRN2oGWV3lSnsD/view?usp=sharing  (bottom image)
After: https://drive.google.com/file/d/1lF-wBrisa_Eq6oEIdfKelrXrgB_CqB_I/view?usp=sharing

![xcom2](https://user-images.githubusercontent.com/1557255/91237568-d696ca00-e6ef-11ea-8228-7cdfceb9220b.png)
