### PR TITLE
Move the GUS Soft Limiter its own stand-alone class

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -64,6 +64,8 @@ public:
 	MixerChannel(MIXER_Handler _handler, Bitu _freq, const char * _name);
 	uint32_t GetSampleRate() const;
 	bool IsInterpolated() const;
+	using apply_level_callback_f = std::function<void(const AudioFrame &level)>;
+	void RegisterLevelCallBack(apply_level_callback_f cb);
 	void SetVolume(float _left, float _right);
 	void SetScale(float f);
 	void SetScale(float _left, float _right);
@@ -134,6 +136,12 @@ private:
 	uint32_t peak_amplitude = MAX_AUDIO;
 
 	uint8_t channel_map[2] = {0u, 0u}; // Output channel mapping
+
+	// The RegisterLevelCallBack() assigns this callback that can be used by
+	// the channel's source to manage the stream's level prior to mixing,
+	// in-place of scaling by volmain[]
+	apply_level_callback_f apply_level = nullptr;
+
 	bool interpolate = false;
 	bool last_samples_were_stereo = false;
 	bool last_samples_were_silence = true;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -46,8 +46,14 @@ enum MixerModes {
 	M_16M,M_16S
 };
 
-#define MIXER_BUFSIZE (16*1024)
-#define MIXER_BUFMASK (MIXER_BUFSIZE-1)
+// A simple stereo audio frame
+struct AudioFrame {
+	float left = 0;
+	float right = 0;
+};
+
+#define MIXER_BUFSIZE (16 * 1024)
+#define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
 extern Bit8u MixTemp[MIXER_BUFSIZE];
 
 #define MAX_AUDIO ((1<<(16-1))-1)

--- a/include/soft_limiter.h
+++ b/include/soft_limiter.h
@@ -1,0 +1,255 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_SOFT_LIMITER_H
+#define DOSBOX_SOFT_LIMITER_H
+
+/*
+Soft Limiter
+------------
+Given an input array and output array where the input can support wider values
+than the output, the limiter will detect when the input contains one or more
+values that would exceed the output's type bounds.
+
+When detected, it scale-down the entire input set such that they fit within the
+output bounds. By scaling the entire series of values, it ensure relative
+differences are retained without distorion. (This is known as Soft Limiting,
+which is superior to Hard Limiting that truncates or clips values and causes
+distortion).
+
+This scale-down-to-fit effect continues to be applied to subsequent input sets,
+each time with less effect (provided new peaks aren't detected), until the
+scale-down is complete - this period is known as 'Release'.
+
+The release duration is a function of how much we needed to scale down in the
+first place.  The larger the scale-down, the longer the release (typically
+ranging from 10's of milliseconds to low-hundreds for > 2x overages).
+
+Use:
+
+The SoftLimiter reads and writes arrays of the same length, which is
+defined during object creation as a template size. For example:
+
+  SoftLimiter<48> limiter;
+
+You can then repeatedly call:
+  limiter.Apply(in_samples, out_samples);
+
+Where in_samples is a std::array<float, 48> and out_samples is a 
+std::array<int16_t, 48>. The limiter will either copy or limit the in_samples
+into the out_samples array.
+
+The PrintStats function will make mixer suggestions if the in_samples
+were (at most) 40% under the allowed bounds, in which case the recommendation
+will describe how to scale up the channel amplitude. 
+
+On the other hand, if the limiter found itself scaling down more than 10% of
+the inbound stream, then it will in turn recommend how to scale down the
+channel. 
+*/
+
+#include "dosbox.h"
+#include "logging.h"
+#include "mixer.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <limits>
+#include <cmath>
+#include <string>
+
+template <size_t array_frames>
+class SoftLimiter {
+public:
+	SoftLimiter() = delete;
+	SoftLimiter(const std::string &name, const AudioFrame &scale);
+
+	using in_array_t = std::array<float, array_frames * 2>; // 2 for stereo
+	using out_array_t = std::array<int16_t, array_frames * 2>; // 2 for stereo
+
+	void Apply(const in_array_t &in, out_array_t &out, uint16_t frames) noexcept;
+	const AudioFrame &GetPeaks() const noexcept { return peak; }
+	void PrintStats() const;
+	void Reset() noexcept;
+
+private:
+	// Amplitude level constants
+	using out_limits = std::numeric_limits<int16_t>;
+	constexpr static float upper_bound = static_cast<float>(out_limits::max());
+	constexpr static float lower_bound = static_cast<float>(out_limits::min());
+
+	bool FindPeaks(const in_array_t &stream, uint16_t frames) noexcept;
+	void Release() noexcept;
+
+	std::string channel_name = {};
+	AudioFrame limit_scale = {1, 1}; // real-time limit applied to stream
+	AudioFrame peak = {1, 1};        // holds real-time peak amplitudes
+	const AudioFrame &prescale;      // scale before operating on the stream
+	int limited_ms = 0;              // milliseconds that needed limiting
+	int non_limited_ms = 0; // milliseconds that didn't need limiting
+};
+
+template <size_t array_frames>
+SoftLimiter<array_frames>::SoftLimiter(const std::string &name, const AudioFrame &scale)
+        : channel_name(name),
+          prescale(scale)
+{
+	static_assert(array_frames > 0, "need some quantity of frames");
+	static_assert(array_frames < 16384, "too many frames adds audible latency");
+}
+
+template <size_t array_frames>
+bool SoftLimiter<array_frames>::FindPeaks(const in_array_t &stream,
+                                          const uint16_t samples) noexcept
+{
+	auto val = stream.begin();
+	const auto val_end = stream.begin() + samples;
+	AudioFrame local_peak{};
+	while (val < val_end) {
+		// Left channel
+		local_peak.left = std::max(local_peak.left, fabsf(*val++));
+		local_peak.right = std::max(local_peak.right, fabsf(*val++));
+	}
+	peak.left = std::max(peak.left, prescale.left * local_peak.left);
+	peak.right = std::max(peak.right, prescale.right * local_peak.right);
+
+	const bool limiting_needed = (peak.left > upper_bound ||
+	                              peak.right > upper_bound);
+
+	// Calculate the percent we need to scale down each channel. In cases
+	// where one channel is less than the upper-bound, its time_ratio is limited
+	// to 1.0 to retain the original level.
+	if (limiting_needed)
+		limit_scale = {std::min(1.0f, upper_bound / peak.left),
+		               std::min(1.0f, upper_bound / peak.right)};
+
+	return limiting_needed;
+	// LOG_MSG("%s peak left = %f", channel_name.c_str(),
+	// static_cast<double>(peak.left));
+}
+
+template <size_t array_frames>
+void SoftLimiter<array_frames>::Apply(const in_array_t &in,
+                                      out_array_t &out,
+                                      const uint16_t req_frames) noexcept
+{
+	// Ensure the buffers are large enough to handle the request
+	const uint16_t samples = req_frames * 2; // left and right channels
+	assert(samples <= in.size());
+
+	const bool limiting_needed = FindPeaks(in, samples);
+
+	// get our in and out iterators
+	auto in_val = in.begin();
+	const auto in_val_end = in.begin() + samples;
+	auto out_val = out.begin();
+
+	// apply both the pre-scale and limit-scale to determine the final scale
+	const AudioFrame scale{prescale.left * limit_scale.left,
+	                       prescale.right * limit_scale.right};
+
+	// Process the signal by pre-scaling and limit-scaling
+	// Note: if limit-scaling isn't needed then its values are simply 1.0
+	while (in_val < in_val_end) {
+		*out_val++ = static_cast<int16_t>(*in_val++ * scale.left);
+		*out_val++ = static_cast<int16_t>(*in_val++ * scale.right);
+	}
+	if (limiting_needed)
+		Release();
+	else
+		non_limited_ms++;
+}
+
+template <size_t array_frames>
+void SoftLimiter<array_frames>::Release() noexcept
+{
+	++limited_ms;
+	// Decrement the peak(s) one step
+	constexpr float delta_db = 0.002709201f; // 0.0235 dB increments
+	constexpr float release_amplitude = upper_bound * delta_db;
+	if (peak.left > upper_bound)
+		peak.left -= release_amplitude;
+	if (peak.right > upper_bound)
+		peak.right -= release_amplitude;
+	// LOG_MSG("GUS: releasing peak_amplitude = %.2f | %.2f",
+	//         static_cast<double>(peak.left),
+	//         static_cast<double>(peak.right));
+}
+
+template <size_t array_frames>
+void SoftLimiter<array_frames>::PrintStats() const
+{
+	constexpr auto ms_per_minute = 1000 * 60;
+	const auto ms_total = static_cast<double>(limited_ms) + non_limited_ms;
+	const auto minutes_total = ms_total / ms_per_minute;
+
+	// Only print stats if we have more than 30 seconds of data
+	if (minutes_total < 0.5)
+		return;
+
+	// Only print levels if the peak is at-least 5% of the max
+	const auto peak_sample = std::max(peak.left, peak.right);
+	constexpr auto five_percent_of_max = upper_bound / 20;
+	if (peak_sample < five_percent_of_max)
+		return;
+
+	// It's expected and normal for multi-channel audio to periodically
+	// accumulate beyond the max, which the soft-limiter gracefully handles.
+	// More importantly, users typically care when their overall stream
+	// never achieved the maximum levels.
+	auto peak_ratio = peak_sample / upper_bound;
+	peak_ratio = std::min(peak_ratio, 1.0f);
+	LOG_MSG("%s: Peak amplitude reached %.0f%% of max",
+	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
+
+	// Make a suggestion if the peak amplitude was well below 3 dB. Note that
+	// we remove the effect of the external scale by dividing by it. This
+	// avoids making a recommendation if the user delibertely wanted quiet
+	// output (as an example).
+	const auto scale = std::max(prescale.left, prescale.right);
+	constexpr auto well_below_3db = static_cast<float>(0.6);
+	if (peak_ratio / scale < well_below_3db) {
+		const auto suggested_mix_val = 100 * scale / peak_ratio;
+		LOG_MSG("%s: If it should be louder, use: mixer %s %.0f",
+		        channel_name.c_str(), channel_name.c_str(),
+		        static_cast<double>(suggested_mix_val));
+	}
+	// Make a suggestion if more than 20% of the stream required limiting
+	const auto time_ratio = limited_ms / (ms_total + 1); // one ms avoids div-by-0
+	if (time_ratio > 0.2) {
+		const auto minutes_limited = static_cast<double>(limited_ms) / ms_per_minute;
+		const auto reduction_ratio = 1 - time_ratio / 2;
+		const auto suggested_mix_val = 100 * reduction_ratio * static_cast<double>(scale);
+		LOG_MSG("%s: %.1f%% or %.2f of %.2f minutes needed limiting, consider: mixer %s %.0f",
+		        channel_name.c_str(), 100 * time_ratio, minutes_limited,
+		        minutes_total, channel_name.c_str(), suggested_mix_val);
+	}
+}
+
+template <size_t array_frames>
+void SoftLimiter<array_frames>::Reset() noexcept
+{
+	peak = {1, 1};
+	limited_ms = 0;
+	non_limited_ms = 0;
+}
+
+#endif

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -248,6 +248,7 @@ private:
 	void RegisterIoHandlers();
 	void Reset(uint8_t state);
 	void SoftLimit(const accumulator_array_t &in, scaled_array_t &out) noexcept;
+	void SetLevelCallback(const AudioFrame &level);
 	void StopPlayback();
 	void UpdateDmaAddress(uint8_t new_address);
 	void UpdateWaveMsw(int32_t &addr) const noexcept;
@@ -275,6 +276,7 @@ private:
 	VoiceIrq voice_irq = {};
 	MixerObject mixer_channel = {};
 	AudioFrame peak = {ONE_AMP, ONE_AMP};
+	AudioFrame mixer_level = {1, 1};
 	Voice *voice = nullptr;
 	DmaChannel *dma_channel = nullptr;
 	MixerChannel *audio_channel = nullptr;
@@ -592,9 +594,13 @@ Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
 
 	RegisterIoHandlers();
 
-	// Register the Audio and DMA callbacks
+	// Register the Audio and DMA channels
 	audio_channel = mixer_channel.Install(
 		std::bind(&Gus::AudioCallback, this, std::placeholders::_1), 1, "GUS");
+	assert(audio_channel);
+	// Let the mixer command adjust the GUS's internal amplitude level's
+	const auto set_level_callback = std::bind(&Gus::SetLevelCallback, this, _1);
+	audio_channel->RegisterLevelCallBack(set_level_callback);
 
 	UpdateDmaAddress(dma);
 
@@ -617,6 +623,13 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 	}
 }
 
+void Gus::SetLevelCallback(const AudioFrame &requested_level)
+{
+	// Allow amplitudes to scale from silent up to 20-fold
+	mixer_level.left = clamp(requested_level.left, 0.0f, 20.0f);
+	mixer_level.right = clamp(requested_level.right, 0.0f, 20.0f);
+}
+
 void Gus::AudioCallback(const uint16_t requested_frames)
 {
 	assert(requested_frames <= BUFFER_FRAMES);
@@ -631,6 +644,13 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 		v->get()->GenerateSamples(accumulator, ram, vol_scalars,
 		                          pan_scalars, requested_frames);
 		++v;
+	}
+
+	// Pre-scale the stream by the user-defined mixer level
+	auto val = accumulator.begin();
+	while (val < accumulator.end()) {
+		*val++ *= mixer_level.left;
+		*val++ *= mixer_level.right;
 	}
 
 	SoftLimit(accumulator, scaled);
@@ -814,7 +834,7 @@ void Gus::PopulateVolScalars() noexcept
 	// The last element starts at 1.0 and we divide downward to
 	// the first element that holds zero, which is directly assigned
 	// after the loop.
-	while (v > vol_scalars.begin()) {
+	while (v != vol_scalars.begin()) {
 		*(--v) = static_cast<float>(scalar);
 		scalar /= VOLUME_LEVEL_DIVISOR;
 	}
@@ -865,7 +885,7 @@ void Gus::PopulatePanScalars() noexcept
 {
 	int i = 0;
 	auto pan_scalar = pan_scalars.begin();
-	while (pan_scalar < pan_scalars.end()) {
+	while (pan_scalar != pan_scalars.end()) {
 		// Normalize absolute range [0, 15] to [-1.0, 1.0]
 		const auto norm = (i - 7.0) / (i < 7 ? 7 : 8);
 		// Convert to an angle between 0 and 90-degree, in radians
@@ -937,10 +957,10 @@ void Gus::PrintStats()
 	}
 
 	// Calculate and print info about the volume
-	const auto mixer_scalar = std::max(audio_channel->volmain[0],
-	                                   audio_channel->volmain[1]);
+	const auto scalar = std::max(mixer_level->left,
+	                             mixer_level->right);
 	const auto peak_sample = std::max(peak.left, peak.right);
-	auto peak_ratio = mixer_scalar * peak_sample / AUDIO_SAMPLE_MAX;
+	auto peak_ratio = scalar * peak_sample / AUDIO_SAMPLE_MAX;
 
 	// It's expected and normal for multi-voice audio to periodically
 	// accumulate beyond the max, which is gracefully scaled without
@@ -950,12 +970,14 @@ void Gus::PrintStats()
 	LOG_MSG("GUS: Peak amplitude reached %.0f%% of max",
 	        100 * static_cast<double>(peak_ratio));
 
-	// Make a suggestion if the peak volume was well below 3 dB
-	if (peak_ratio < 0.6f) {
+	// Make a suggestion if the peak volume was well below 3 dB, but without
+	// the influence of the mixer's scalar because the user might have
+	// deliberately set it low.
+	if (peak_ratio / scalar < 0.6f) {
 		const auto multiplier = static_cast<uint16_t>(
-		        100 * mixer_scalar / peak_ratio);
+		        100 * scalar / peak_ratio);
 		LOG_MSG("GUS: If it should be louder, %s %u",
-		        fabs(mixer_scalar - 1.0f) > 0.01f ? "adjust mixer gus to"
+		        fabs(scalar - 1.0f) > 0.01f ? "adjust mixer gus to"
 		                                          : "use: mixer gus",
 		        multiplier);
 	}

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -91,12 +91,6 @@ constexpr int16_t WAVE_WIDTH = 1 << 9; // Wave interpolation width (9 bits)
 constexpr uint8_t READ_HANDLERS = 8u;
 constexpr uint8_t WRITE_HANDLERS = 9u;
 
-// A simple stereo audio frame that's used by the Gus and Voice classes.
-struct AudioFrame {
-	float left = 0.0f;
-	float right = 0.0f;
-};
-
 // A group of parameters defining the Gus's voice IRQ control that's also shared
 // (as a reference) into each instantiated voice.
 struct VoiceIrq {

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -34,6 +34,7 @@
 #include "pic.h"
 #include "setup.h"
 #include "shell.h"
+#include "soft_limiter.h"
 
 #define LOG_GUS 0 // set to 1 for detailed logging
 
@@ -44,7 +45,6 @@
 constexpr uint8_t ADLIB_CMD_DEFAULT = 85u;
 
 // Amplitude level constants
-constexpr float ONE_AMP = 1.0f; // first amplitude value
 constexpr float AUDIO_SAMPLE_MAX = static_cast<float>(MAX_AUDIO);
 constexpr float AUDIO_SAMPLE_MIN = static_cast<float>(MIN_AUDIO);
 
@@ -253,7 +253,6 @@ private:
 	void UpdateDmaAddress(uint8_t new_address);
 	void UpdateWaveMsw(int32_t &addr) const noexcept;
 	void UpdateWaveLsw(int32_t &addr) const noexcept;
-	void UpdatePeakAmplitudes(const accumulator_array_t &stream) noexcept;
 	void WriteToPort(size_t port, size_t val, size_t iolen);
 	void WriteToRegister();
 
@@ -275,8 +274,8 @@ private:
 	// Struct and pointer members
 	VoiceIrq voice_irq = {};
 	MixerObject mixer_channel = {};
-	AudioFrame peak = {ONE_AMP, ONE_AMP};
 	AudioFrame mixer_level = {1, 1};
+	SoftLimiter<BUFFER_FRAMES> soft_limiter;
 	Voice *voice = nullptr;
 	DmaChannel *dma_channel = nullptr;
 	MixerChannel *audio_channel = nullptr;
@@ -582,7 +581,8 @@ void Voice::WriteWaveRate(uint16_t val) noexcept
 }
 
 Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
-        : port_base(port - 0x200u),
+        : soft_limiter("GUS", mixer_level),
+          port_base(port - 0x200u),
           dma2(dma),
           irq1(irq),
           irq2(irq)
@@ -646,14 +646,7 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 		++v;
 	}
 
-	// Pre-scale the stream by the user-defined mixer level
-	auto val = accumulator.begin();
-	while (val < accumulator.end()) {
-		*val++ *= mixer_level.left;
-		*val++ *= mixer_level.right;
-	}
-
-	SoftLimit(accumulator, scaled);
+	soft_limiter.Apply(accumulator, scaled, requested_frames);
 	audio_channel->AddSamples_s16(requested_frames, scaled.data());
 	CheckVoiceIrq();
 }
@@ -934,6 +927,7 @@ void Gus::PrintStats()
 	const uint32_t combined_ms = combined_8bit_ms + combined_16bit_ms;
 
 	// Is there enough information to be meaningful?
+	const auto peak = soft_limiter.GetPeaks();
 	if (combined_ms < 10000u || (peak.left + peak.right) < 10 ||
 	    !(used_8bit_voices + used_16bit_voices))
 		return;
@@ -955,32 +949,7 @@ void Gus::PrintStats()
 		        ratio_8bit, used_8bit_voices, ratio_16bit,
 		        used_16bit_voices);
 	}
-
-	// Calculate and print info about the volume
-	const auto scalar = std::max(mixer_level->left,
-	                             mixer_level->right);
-	const auto peak_sample = std::max(peak.left, peak.right);
-	auto peak_ratio = scalar * peak_sample / AUDIO_SAMPLE_MAX;
-
-	// It's expected and normal for multi-voice audio to periodically
-	// accumulate beyond the max, which is gracefully scaled without
-	// distortion, so there is no need to recommend that users scale-down
-	// their GUS mixer settings.
-	peak_ratio = std::min(peak_ratio, 1.0f);
-	LOG_MSG("GUS: Peak amplitude reached %.0f%% of max",
-	        100 * static_cast<double>(peak_ratio));
-
-	// Make a suggestion if the peak volume was well below 3 dB, but without
-	// the influence of the mixer's scalar because the user might have
-	// deliberately set it low.
-	if (peak_ratio / scalar < 0.6f) {
-		const auto multiplier = static_cast<uint16_t>(
-		        100 * scalar / peak_ratio);
-		LOG_MSG("GUS: If it should be louder, %s %u",
-		        fabs(scalar - 1.0f) > 0.01f ? "adjust mixer gus to"
-		                                          : "use: mixer gus",
-		        multiplier);
-	}
+	soft_limiter.PrintStats();
 }
 
 Bitu Gus::ReadFromPort(const Bitu port, const Bitu iolen)
@@ -1154,43 +1123,6 @@ void Gus::StopPlayback()
 	PIC_RemoveEvents(GUS_TimerEvent);
 }
 
-void Gus::SoftLimit(const accumulator_array_t &in, scaled_array_t &out) noexcept
-{
-	UpdatePeakAmplitudes(in);
-
-	// get our in and out iterators
-	auto in_v = in.begin();
-	auto out_v = out.begin();
-
-	// If our peaks are under the max, then there's no overage - so copy
-	if (peak.left < AUDIO_SAMPLE_MAX && peak.right < AUDIO_SAMPLE_MAX) {
-		while (in_v < in.end() && out_v < out.end()) {
-			*out_v++ = static_cast<int16_t>(*in_v++);
-		}
-		return;
-	}
-	// Calculate the percent we need to scale down the volume index
-	// position.  In cases where one side is less than the max, it's ratio
-	// is limited to 1.0.
-	const float left_scalar = std::min(ONE_AMP, AUDIO_SAMPLE_MAX / peak.left);
-	const float right_scalar = std::min(ONE_AMP, AUDIO_SAMPLE_MAX / peak.right);
-
-	while (in_v < in.end() && out_v < out.end()) {
-		*out_v++ = static_cast<int16_t>(*in_v++ * left_scalar);
-		*out_v++ = static_cast<int16_t>(*in_v++ * right_scalar);
-	}
-
-	constexpr float SOFT_LIMIT_RELEASE_INC = AUDIO_SAMPLE_MAX *
-                                         static_cast<float>(DELTA_DB);
-	if (peak.left > AUDIO_SAMPLE_MAX)
-		peak.left -= SOFT_LIMIT_RELEASE_INC;
-	if (peak.right > AUDIO_SAMPLE_MAX)
-		peak.right -= SOFT_LIMIT_RELEASE_INC;
-	// LOG_MSG("GUS: releasing peak_amplitude = %.2f | %.2f",
-	//         static_cast<double>(peak.left),
-	//         static_cast<double>(peak.right));
-}
-
 static void GUS_TimerEvent(Bitu t)
 {
 	if (gus->CheckTimer(t)) {
@@ -1306,15 +1238,6 @@ void Gus::WriteToPort(Bitu port, Bitu val, Bitu iolen)
 		        static_cast<uint16_t>(port), static_cast<uint32_t>(val));
 #endif
 		break;
-	}
-}
-
-void Gus::UpdatePeakAmplitudes(const accumulator_array_t &stream) noexcept
-{
-	auto v = stream.begin();
-	while (v < stream.end()) {
-		peak.left = std::max(peak.left, fabsf(*v++));
-		peak.right = std::max(peak.right, fabsf(*v++));
 	}
 }
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -819,7 +819,10 @@ public:
 		MixerChannel * chan = mixer.channels;
 		while (chan) {
 			if (cmd->FindString(chan->name,temp_line,false)) {
-				MakeVolume((char *)temp_line.c_str(),chan->volmain[0],chan->volmain[1]);
+				float left_vol = 0;
+				float right_vol = 0;
+				MakeVolume(&temp_line[0], left_vol, right_vol);
+				chan->SetVolume(left_vol, right_vol);
 			}
 			chan->UpdateVolume();
 			chan = chan->next;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,7 @@ endif
 
 tests_SOURCES = \
 	example.cpp \
+	soft_limiter.cpp \
 	support.cpp
 
 tests_LDADD = ../src/misc/libmisc.a

--- a/tests/soft_limiter.cpp
+++ b/tests/soft_limiter.cpp
@@ -1,0 +1,221 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "soft_limiter.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(SoftLimiter, FullFrames)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected{-3, -2, -1, 0, 1, 2};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, PartialFrames)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, 1);
+	const SoftLimiter<frames>::out_array_t expected{-3, -2};
+	EXPECT_EQ(out[0], expected[0]);
+	EXPECT_EQ(out[1], expected[1]);
+}
+
+TEST(SoftLimiter, ExcessiveFrames)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
+	SoftLimiter<frames>::out_array_t out{};
+	EXPECT_DEBUG_DEATH({ limiter.Apply(in, out, frames + 1); }, "");
+}
+
+TEST(SoftLimiter, PositiveOverrun)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{-8.1f,    -3.1f, 65535.0f,
+	                                         98304.1f, 4.1f,  6.1f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected{-4,    -1, 32767,
+	                                                32767, 2,  2};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, NegativeOverrun)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{-8.1f,     -3.1f, -65535.0f,
+	                                         -98304.1f, 4.1f,  6.1f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected{-4,     -1, -32767,
+	                                                -32767, 2,  2};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, MixedOverrun)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{40000.1f, -40000.1f,
+	                                         65534.0f, -98301.0f,
+	                                         40000.1f, -40000.1f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected{20000,  -13333, 32767,
+	                                                -32767, 20000,  -13333};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, BigScaleOneRelease)
+{
+	const auto frames = 1;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter<frames>::in_array_t in{-60000.0f, 80000.0f};
+	SoftLimiter<frames>::out_array_t out{};
+	limiter.Apply(in, out, 1);
+
+	in[0] = static_cast<float>(out[0]);
+	in[1] = static_cast<float>(out[1]);
+	limiter.Apply(in, out, frames);
+
+	const SoftLimiter<frames>::out_array_t expected{-17920, 13435};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, BigScaleSixHundredReleases)
+{
+	const auto frames = 1;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter<frames>::in_array_t in{-60000.0f, 80000.0f};
+	SoftLimiter<frames>::out_array_t out{};
+	limiter.Apply(in, out, 1);
+
+	for (int i = 0; i < 600; ++i) {
+		limiter.Apply(in, out, frames);
+		in[0] = -32767;
+		in[1] = 32768;
+	}
+	const SoftLimiter<frames>::out_array_t expected{-32767, 32767};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, SmallScaleTwoReleases)
+{
+	const auto frames = 1;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter<frames>::in_array_t in{-32800.0f, 32800.0f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	for (int i = 0; i < 2; ++i) {
+		limiter.Apply(in, out, frames);
+		in[0] = -32767;
+		in[1] = 32767;
+	}
+	const SoftLimiter<frames>::out_array_t expected{-32734, 32734};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, SmallScaleTenReleases)
+{
+	const auto frames = 1;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter<frames>::in_array_t in{-32800.0f, 32800.0f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	for (int i = 0; i < 10; ++i) {
+		limiter.Apply(in, out, frames);
+		in[0] = -32767;
+		in[1] = 32768;
+	}
+	const SoftLimiter<frames>::out_array_t expected{-32767, 32767};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, AdjustPrescaleDown)
+{
+	const auto frames = 1;
+	AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter<frames>::in_array_t in{-30000.1f, 30000.0f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected_first{-30000, 30000};
+	EXPECT_EQ(out, expected_first);
+
+	// The limiter holds a reference to the prescaling struct so it can
+	// be adjusted on-the-fly via callback. We simulate this callback here.
+	prescale.left = 0.5f;
+	prescale.right = 0.1f;
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected_scaled{-15000, 3000};
+	EXPECT_EQ(out, expected_scaled);
+}
+
+TEST(SoftLimiter, AdjustPrescaleUp)
+{
+	const auto frames = 1;
+	AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter<frames>::in_array_t in{-10000.1f, 10000.0f};
+	SoftLimiter<frames>::out_array_t out{};
+
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected_first{-10000, 10000};
+	EXPECT_EQ(out, expected_first);
+
+	// The limiter holds a reference to the prescaling struct so it can
+	// be adjusted on-the-fly via callback. We simulate this callback here.
+	prescale.left = 1.5f;
+	prescale.right = 1.1f;
+	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::out_array_t expected_scaled{-15000, 11000};
+	EXPECT_EQ(out, expected_scaled);
+}
+
+} // namespace


### PR DESCRIPTION
This PR makes a handful of relatively small changes to move the GUS's Soft Limiter into its own class.

The Soft Limiter is an audio processor that was added as an enhancement to the GUS emulation class. The Soft Limiter operates on audio signals in a generic sense without doing anything GUS-specific, and therefore makes sense to move it to its own class (similar to the DC Silencer).

From an architectural perspective, this dis-entangles its various time and amplitude state-tracking variables and functions from the GUS code, making that code simpler.

Suggest this PR be reviewed commit by commit.