### PR TITLE
Create an OS-specific default modifier key binding for F*-hotkeys

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 318
+            max_warnings: 320
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2043
+            max_warnings: 2045
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/README
+++ b/README
@@ -1158,8 +1158,12 @@ BIND
     joystick(s) (as reported by SDL), which is connected to the EVENT.
 mod1,2,3
     Modifiers. These are keys you need to have to be pressed while pressing
-    BIND. mod1 = CTRL and mod2 = ALT. These are generally only used when you
-    want to change the special keys of DOSBox.
+    BIND.
+       mod1 = CTRL (left or right)
+       mod2 = ALT (left or right)
+       mod3 = SHIFT (left or right)
+    These are generally only used when you want to change the special keys
+    of DOSBox.
 Add
     Add a new BIND to this EVENT. Basically add a key from your keyboard or an
     event from the joystick (button press, axis/hat movement) which will

--- a/README
+++ b/README
@@ -1043,26 +1043,29 @@ For more information use the /? command line switch with the programs.
 5. Special Keys:
 ================
 
-ALT-ENTER     Switch to full screen and back.
-ALT-PAUSE     Pause emulation (hit ALT-PAUSE again to continue).
-CTRL-F1       Start the keymapper.
-CTRL-F4       Change between mounted floppy/CD images. Update directory cache 
-              for all drives.
-CTRL-ALT-F5   Start/Stop creating a movie of the screen. (avi video capturing)
-CTRL-F5       Save a screenshot. (PNG format)
-CTRL-F6       Start/Stop recording sound output to a wave file.
-CTRL-ALT-F7   Start/Stop recording of OPL commands. (DRO format)
-CTRL-ALT-F8   Start/Stop the recording of raw MIDI commands.
-CTRL-F7       Decrease frameskip.
-CTRL-F8       Increase frameskip.
-CTRL-F9       Kill DOSBox.
-CTRL-F10      Capture/Release the mouse.
-CTRL-F11      Slow down emulation (Decrease DOSBox Cycles).
-CTRL-F12      Speed up emulation (Increase DOSBox Cycles)*.
-ALT-F12       Unlock speed (turbo button/fast forward)**.
-CTRL-ALT-HOME Restart DOSBox.
-F11, ALT-F11  (machine=cga) change tint in NTSC output modes***.
-F11           (machine=hercules) cycle through amber, green, white colouring***.
+ALT-ENTER      Switch to full screen and back.
+ALT-PAUSE      Pause emulation (hit ALT-PAUSE again to continue).
+CTRL-F1        Start the keymapper.
+CTRL-F4        Change between mounted floppy/CD images. Update directory cache 
+               for all drives.
+CTRL-[MOD]-F5  Start/Stop creating a movie of the screen. (avi video capturing)
+CTRL-F5        Save a screenshot. (PNG format)
+CTRL-F6        Start/Stop recording sound output to a wave file.
+CTRL-[MOD]-F7  Start/Stop recording of OPL commands. (DRO format)
+CTRL-[MOD]-F8  Start/Stop the recording of raw MIDI commands.
+CTRL-F7        Decrease frameskip.
+CTRL-F8        Increase frameskip.
+CTRL-F9        Kill DOSBox.
+CTRL-F10       Capture/Release the mouse.
+CTRL-F11       Slow down emulation (Decrease DOSBox Cycles).
+CTRL-F12       Speed up emulation (Increase DOSBox Cycles)*.
+ALT-F12        Unlock speed (turbo button/fast forward)**.
+CTRL-ALT-HOME  Restart DOSBox.
+F11, [MOD]-F11 (machine=cga) change tint in NTSC output modes***.
+F11            (machine=hercules) cycle through amber, green, white colouring***.
+
+[MOD] is SHIFT on Linux
+[MOD] is ALT on Window, macOS, and other non-Linux OSes.
 
 *NOTE: Once you increase your DOSBox cycles beyond your computer CPU resources,
        it will produce the same effect as slowing down the emulation.

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -46,4 +46,13 @@ void MAPPER_AutoType(std::vector<std::string> &sequence,
 #define MMOD1 0x1
 #define MMOD2 0x2
 
+// Linux uses SHIFT
+#if defined(LINUX)
+#define MMOD_ALT_OR_SHIFT 0x4
+
+// Non-Linux uses ALT
+#else
+#define MMOD_ALT_OR_SHIFT 0x2
+#endif
+
 #endif

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2282,6 +2282,10 @@ static void CreateDefaultBinds() {
 	CreateStringBind(buffer);
 	sprintf(buffer, "mod_2 \"key %d\"", SDL_SCANCODE_LALT);
 	CreateStringBind(buffer);
+	sprintf(buffer, "mod_3 \"key %d\"", SDL_SCANCODE_RSHIFT);
+	CreateStringBind(buffer);
+	sprintf(buffer, "mod_3 \"key %d\"", SDL_SCANCODE_LSHIFT);
+	CreateStringBind(buffer);
 	for (CHandlerEventVector_it hit = handlergroup.begin(); hit != handlergroup.end(); ++hit) {
 		(*hit)->MakeDefaultBind(buffer);
 		CreateStringBind(buffer);

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -883,7 +883,7 @@ Module::Module(Section *configuration)
 	WriteHandler[2].Install(base+8,OPL_Write,IO_MB, 2);
 	ReadHandler[2].Install(base+8,OPL_Read,IO_MB, 1);
 
-	MAPPER_AddHandler(OPL_SaveRawEvent,MK_f7,MMOD1|MMOD2,"caprawopl","Cap OPL");
+	MAPPER_AddHandler(OPL_SaveRawEvent,MK_f7,MMOD1|MMOD_ALT_OR_SHIFT,"caprawopl","Cap OPL");
 }
 
 Module::~Module() {

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -754,10 +754,10 @@ public:
 		capturedir = proppath->realpath;
 		CaptureState = 0;
 		MAPPER_AddHandler(CAPTURE_WaveEvent,MK_f6,MMOD1,"recwave","Rec Wave");
-		MAPPER_AddHandler(CAPTURE_MidiEvent,MK_f8,MMOD1|MMOD2,"caprawmidi","Cap MIDI");
+		MAPPER_AddHandler(CAPTURE_MidiEvent,MK_f8,MMOD1|MMOD_ALT_OR_SHIFT,"caprawmidi","Cap MIDI");
 #if (C_SSHOT)
 		MAPPER_AddHandler(CAPTURE_ScreenShotEvent,MK_f5,MMOD1,"scrshot","Screenshot");
-		MAPPER_AddHandler(CAPTURE_VideoEvent,MK_f5,MMOD1|MMOD2,"video","Video");
+		MAPPER_AddHandler(CAPTURE_VideoEvent,MK_f5,MMOD1|MMOD_ALT_OR_SHIFT,"video","Video");
 #endif
 	}
 	~HARDWARE(){

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -886,7 +886,7 @@ void VGA_SetupOther(void) {
 		if(!mono_cga) {
 			MAPPER_AddHandler(IncreaseHue,MK_f11,MMOD2,"inchue","Inc Hue");
 			MAPPER_AddHandler(DecreaseHue,MK_f11,0,"dechue","Dec Hue");
-			MAPPER_AddHandler(CGAModel,MK_f11,MMOD1|MMOD2,"cgamodel","CGA Model");
+			MAPPER_AddHandler(CGAModel,MK_f11,MMOD1|MMOD_ALT_OR_SHIFT,"cgamodel","CGA Model");
 			MAPPER_AddHandler(Composite,MK_f12,0,"cgacomp","CGA Comp");
 		} else {
 			MAPPER_AddHandler(CycleMonoCGAPal,MK_f11,0,"monocgapal","Mono CGA Pal"); 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -217,7 +217,7 @@ public:
 
 		std::string fullconf=section->Get_string("midiconfig");
 		MidiHandler * handler;
-//		MAPPER_AddHandler(MIDI_SaveRawEvent,MK_f8,MMOD1|MMOD2,"caprawmidi","Cap MIDI");
+//		MAPPER_AddHandler(MIDI_SaveRawEvent,MK_f8,MMOD1|MMOD_ALT_OR_SHIFT,"caprawmidi","Cap MIDI");
 		midi.sysex.delay = 0;
 		midi.sysex.start = 0;
 		if (fullconf.find("delaysysex") != std::string::npos) {


### PR DESCRIPTION
This creates a new **_default_** modifier key binding that's OS specific: SHIFT on Linux and ALT (unchanged) on non-Linux.

This new modifier is then used in the default definitions for the following hotkeys:

- Ctrl+**[MOD]**+F5 - Start/stop zmbv movie recording
- Ctrl+**[MOD]**+F7 - Start/stop OPL commands recording
- Ctrl+**[MOD]**+F8 - Start/stop MIDI commands recording
- Ctrl+**[MOD]**+F11 - Switch CGA model

The expansion of the modifier when writing the mapper file does the right thing in that it properly expands to `mod3` on Linux and `mod2` on non-Linux OSes.

``` text
hand_capmouse "key 67 mod1" 
hand_shutdown "key 66 mod1" 
hand_fullscr "key 40 mod2" 
hand_restart "key 74 mod1 mod2" 
hand_pause "key 72 mod2" 
hand_mapper "key 58 mod1" 
hand_speedlock "key 69 mod2" 
hand_recwave "key 63 mod1" 
hand_caprawmidi "key 65 mod1 mod3" 
hand_scrshot "key 62 mod1" 
hand_video "key 62 mod1 mod3" 
hand_decfskip "key 64 mod1" 
hand_incfskip "key 65 mod1" 
hand_cycledown "key 68 mod1" 
hand_cycleup "key 69 mod1" 
hand_swapimg "key 61 mod1" 
mod_1 "key 224" "key 228" 
mod_2 "key 226" "key 230" 
mod_3 "key 225" "key 229" 
```

This means that there is no confusion of what "mod2" is:
 - mod2 is still ALT
 - mod3 is still SHIFT

Fixes #585
