### PR TITLE
Fix boot failure from Drive C

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1413,7 +1413,8 @@ public:
 
 			if (paths.size() == 1) {
 				auto *newdrive = static_cast<fatDrive*>(imgDisks[0]);
-				if ('A' <= drive && drive <= 'D' && !(newdrive->loadedDisk->hardDrive)) {
+				if (('A' <= drive && drive <= 'B' && !(newdrive->loadedDisk->hardDrive)) ||
+				    ('C' <= drive && drive <= 'D' && newdrive->loadedDisk->hardDrive)) {
 					const size_t idx = drive_index(drive);
 					imageDiskList[idx] = newdrive->loadedDisk;
 					updateDPT();


### PR DESCRIPTION
I decided to take a look at the the issue of boot failure from Drive C, as reported in Issue #522. It turns out to be a relatively simple bug, which is fixed in this pull request.