### PR TITLE
Fix ls cmd output when emulating Hercules

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -844,6 +844,13 @@ void DOS_Shell::CMD_LS(char *args)
 
 	size_t w_count = 0;
 
+	constexpr int ansi_blue = 34;
+	constexpr int ansi_green = 32;
+	auto write_color = [&](int color, const std::string &txt, int width) {
+		const int padr = width - static_cast<int>(txt.size());
+		WriteOut("\033[%d;1m%s\033[0m%-*s", color, txt.c_str(), padr, "");
+	};
+
 	for (const auto &entry : dir_contents) {
 		std::string name = entry.name;
 		const bool is_dir = entry.attr & DOS_ATTR_DIRECTORY;
@@ -852,11 +859,11 @@ void DOS_Shell::CMD_LS(char *args)
 
 		if (is_dir) {
 			upcase(name);
-			WriteOut("\033[34;1m%-*s\033[0m", cw, name.c_str());
+			write_color(ansi_blue, name, cw);
 		} else {
 			lowcase(name);
 			if (is_executable_filename(name))
-				WriteOut("\033[32;1m%-*s\033[0m", cw, name.c_str());
+				write_color(ansi_green, name, cw);
 			else
 				WriteOut("%-*s", cw, name.c_str());
 		}


### PR DESCRIPTION
Use ANSI escape code to surround only text, excluding the padding space.
That's because when emulating Hercules (black and white), the blue
colour is turned into an underline connecting all the directories
listed.

Before:
![Screenshot from 2020-09-01 18-45-40](https://user-images.githubusercontent.com/3967/91882533-5fc77700-ec83-11ea-962c-b3c04f6f4cdd.png)

After:
![Screenshot from 2020-09-01 18-44-35](https://user-images.githubusercontent.com/3967/91882425-39a1d700-ec83-11ea-9c61-d141827275b9.png)