### PR TITLE
Cleanup some effc++ warnings - September - part 2

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -54,7 +54,8 @@ public:
 	bool request;
 	DMA_CallBack callback;
 
-	DmaChannel(Bit8u num, bool dma16);
+	DmaChannel(uint8_t num, bool dma16);
+
 	void DoCallBack(DMAEvent event) {
 		if (callback)
 			callback(this, event);

--- a/include/drives.h
+++ b/include/drives.h
@@ -405,11 +405,18 @@ private:
 	VFILE_Block * search_file;
 };
 
-class Overlay_Drive: public localDrive {
+class Overlay_Drive : public localDrive {
 public:
-	Overlay_Drive(const char * startdir,const char* overlay, Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid,Bit8u &error);
+	Overlay_Drive(const char *startdir,
+	              const char *overlay,
+	              uint16_t _bytes_sector,
+	              uint8_t _sectors_cluster,
+	              uint16_t _total_clusters,
+	              uint16_t _free_clusters,
+	              uint8_t _mediaid,
+	              uint8_t &error);
 
-	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
+	virtual bool FileOpen(DOS_File **file, char *name, uint32_t flags);
 	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/);
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst);
 	virtual bool FindNext(DOS_DTA & dta);
@@ -428,14 +435,13 @@ public:
 	virtual bool MakeDir(char * dir);
 private:
 	char overlaydir[CROSS_LEN];
-	bool optimize_cache_v1;
 	bool Sync_leading_dirs(const char* dos_filename);
 	void add_DOSname_to_cache(const char* name);
 	void remove_DOSname_from_cache(const char* name);
 	void add_DOSdir_to_cache(const char* name);
 	void remove_DOSdir_from_cache(const char* name);
 	void update_cache(bool read_directory_contents = false);
-	
+
 	std::vector<std::string> deleted_files_in_base; //Set is probably better, or some other solution (involving the disk).
 	std::vector<std::string> deleted_paths_in_base; //Currently only used to hide the overlay folder.
 	std::string overlap_folder;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -58,16 +58,24 @@ static FILE* OpenDosboxFile(const char* name) {
 	return tmpfile;
 }
 
-
 class keyboard_layout {
 public:
 	keyboard_layout()
+	        : additional_planes(0),
+	          used_lock_modifiers(0x0f),
+	          diacritics_entries(0),
+	          diacritics_character(0),
+	          user_keys(0),
+	          use_foreign_layout(false),
+	          language_codes(nullptr),
+	          language_code_count(0)
 	{
 		this->reset();
-		language_codes=NULL;
-		use_foreign_layout=false;
 		sprintf(current_keyboard_file_name, "none");
 	}
+
+	keyboard_layout(const keyboard_layout &) = delete; // prevent copying
+	keyboard_layout &operator=(const keyboard_layout &) = delete; // prevent assignment
 
 	~keyboard_layout();
 
@@ -113,7 +121,6 @@ private:
 	Bitu read_keyboard_file(const char* keyboard_file_name, Bit32s specific_layout, Bit32s requested_codepage);
 	bool map_key(Bitu key, Bit16u layouted_key, bool is_command, bool is_keypair);
 };
-
 
 keyboard_layout::~keyboard_layout() {
 	if (language_codes) {

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -307,9 +307,27 @@ static OverlayFile* ccc(DOS_File* file) {
 	return ret;
 }
 
-Overlay_Drive::Overlay_Drive(const char * startdir,const char* overlay, Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid,Bit8u &error)
-:localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid),special_prefix("DBOVERLAY") {
-	optimize_cache_v1 = true; //Try to not reread overlay files on deletes. Ideally drive_cache should be improved to handle deletes properly.
+Overlay_Drive::Overlay_Drive(const char *startdir,
+                             const char *overlay,
+                             uint16_t _bytes_sector,
+                             uint8_t _sectors_cluster,
+                             uint16_t _total_clusters,
+                             uint16_t _free_clusters,
+                             uint8_t _mediaid,
+                             uint8_t &error)
+        : localDrive(startdir,
+                     _bytes_sector,
+                     _sectors_cluster,
+                     _total_clusters,
+                     _free_clusters,
+                     _mediaid),
+          deleted_files_in_base{},
+          deleted_paths_in_base{},
+          overlap_folder(),
+          DOSnames_cache{},
+          DOSdirs_cache{},
+          special_prefix("DBOVERLAY")
+{
 	//Currently this flag does nothing, as the current behavior is to not reread due to caching everything.
 #if defined (WIN32)	
 	if (strcasecmp(startdir,overlay) == 0) {

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -197,13 +197,16 @@ bool Overlay_Drive::TestDir(char * dir) {
 	return localDrive::TestDir(dir);
 }
 
-
-class OverlayFile: public localFile {
+class OverlayFile : public localFile {
 public:
-	OverlayFile(const char* name, FILE * handle):localFile(name,handle){
-		overlay_active = false;
-		if (logoverlay) LOG_MSG("constructing OverlayFile: %s",name);
+	OverlayFile(const char *name, FILE *handle)
+	        : localFile(name, handle),
+	          overlay_active(false)
+	{
+		if (logoverlay)
+			LOG_MSG("constructing OverlayFile: %s", name);
 	}
+
 	bool Write(Bit8u * data,Bit16u * size) {
 		Bit32u f = flags&0xf;
 		if (!overlay_active && (f == OPEN_READWRITE || f == OPEN_WRITE)) {

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -632,21 +632,17 @@ Operator::Operator() {
 	releaseAdd = 0;
 }
 
-/*
-	Channel
-*/
-
-Channel::Channel() {
-	old[0] = old[1] = 0;
-	chanData = 0;
-	regB0 = 0;
-	regC0 = 0;
-	maskLeft = -1;
-	maskRight = -1;
-	feedback = 31;
-	fourMask = 0;
-	synthHandler = &Channel::BlockTemplate< sm2FM >;
-}
+Channel::Channel()
+        : synthHandler(&Channel::BlockTemplate<sm2FM>),
+          chanData(0),
+          old{0, 0},
+          feedback(31),
+          regB0(0),
+          regC0(0),
+          fourMask(0),
+          maskLeft(-1),
+          maskRight(-1)
+{}
 
 void Channel::SetChanData( const Chip* chip, Bit32u data ) {
 	Bit32u change = chanData ^ data;

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -980,18 +980,6 @@ Channel* Channel::BlockTemplate( Chip* chip, Bit32u samples, Bit32s* output ) {
 	return 0;
 }
 
-/*
-	Chip
-*/
-
-Chip::Chip() {
-	reg08 = 0;
-	reg04 = 0;
-	regBD = 0;
-	reg104 = 0;
-	opl3Active = 0;
-}
-
 INLINE Bit32u Chip::ForwardNoise() {
 	noiseCounter += noiseAdd;
 	Bitu count = noiseCounter >> LFO_SH;

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -246,7 +246,7 @@ struct Chip {
 };
 
 struct Handler : public Adlib::Handler {
-	DBOPL::Chip chip;
+	DBOPL::Chip chip = {};
 	virtual Bit32u WriteAddr( Bit32u port, Bit8u val );
 	virtual void WriteReg( Bit32u addr, Bit8u val );
 	virtual void Generate( MixerChannel* chan, Bitu samples );

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -192,40 +192,38 @@ struct Channel {
 };
 
 struct Chip {
-	//18 channels with 2 operators each. Leave on top of struct for simpler pointer math.
+	// 18 channels with 2 operators each.
+	// Leave on top of struct for simpler pointer math.
 	Channel chan[18];
 
-	//This is used as the base counter for vibrato and tremolo
-	Bit32u lfoCounter;
-	Bit32u lfoAdd;
-	
+	// This is used as the base counter for vibrato and tremolo
+	uint32_t lfoCounter = 0;
+	uint32_t lfoAdd = 0;
 
-	Bit32u noiseCounter;
-	Bit32u noiseAdd;
-	Bit32u noiseValue;
+	uint32_t noiseCounter = 0;
+	uint32_t noiseAdd = 0;
+	uint32_t noiseValue = 0;
 
-	//Frequency scales for the different multiplications
-	Bit32u freqMul[16];
-	//Rates for decay and release for rate of this chip
-	Bit32u linearRates[76];
-	//Best match attack rates for the rate of this chip
-	Bit32u attackRates[76];
+	// Frequency scales for the different multiplications
+	uint32_t freqMul[16];
+	// Rates for decay and release for rate of this chip
+	uint32_t linearRates[76];
+	// Best match attack rates for the rate of this chip
+	uint32_t attackRates[76];
 
-	Bit8u reg104;
-	Bit8u reg08;
-	Bit8u reg04;
-	Bit8u regBD;
-	Bit8u vibratoIndex;
-	Bit8u tremoloIndex;
-	Bit8s vibratoSign;
-	Bit8u vibratoShift;
-	Bit8u tremoloValue;
-	Bit8u vibratoStrength;
-	Bit8u tremoloStrength;
-	//Mask for allowed wave forms
-	Bit8u waveFormMask;
-	//0 or -1 when enabled
-	Bit8s opl3Active;
+	uint8_t reg104 = 0;
+	uint8_t reg08 = 0;
+	uint8_t reg04 = 0;
+	uint8_t regBD = 0;
+	uint8_t vibratoIndex = 0;
+	uint8_t tremoloIndex = 0;
+	int8_t vibratoSign = 0;
+	uint8_t vibratoShift = 0;
+	uint8_t tremoloValue = 0;
+	uint8_t vibratoStrength = 0;
+	uint8_t tremoloStrength = 0;
+	uint8_t waveFormMask = 0x0; // Mask for allowed wave forms
+	int8_t opl3Active = 0; // 0 or -1 when enabled
 
 	//Return the maximum amount of samples before and LFO change
 	Bit32u ForwardLFO( Bit32u samples );
@@ -244,7 +242,7 @@ struct Chip {
 	void Generate( Bit32u samples );
 	void Setup( Bit32u r );
 
-	Chip();
+	Chip() = default; // can't be placed on top because of offset math
 };
 
 struct Handler : public Adlib::Handler {

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -264,22 +264,27 @@ Bitu DmaController::ReadControllerReg(Bitu reg,Bitu /*len*/) {
 	return 0xffffffff;
 }
 
-DmaChannel::DmaChannel(Bit8u num, bool dma16) {
-	masked = true;
-	callback = NULL;
-	if(num == 4) return;
+DmaChannel::DmaChannel(uint8_t num, bool dma16)
+        : pagebase(0),
+          baseaddr(0),
+          curraddr(0),
+          basecnt(0),
+          currcnt(0),
+          channum(0),
+          pagenum(0),
+          DMA16(0x0),
+          increment(false),
+          autoinit(false),
+          masked(true),
+          tcount(false),
+          request(false),
+          callback(nullptr)
+{
+	if (num == 4)
+		return;
 	channum = num;
 	DMA16 = dma16 ? 0x1 : 0x0;
-	pagenum = 0;
-	pagebase = 0;
-	baseaddr = 0;
-	curraddr = 0;
-	basecnt = 0;
-	currcnt = 0;
 	increment = true;
-	autoinit = false;
-	tcount = false;
-	request = false;
 }
 
 Bitu DmaChannel::Read(Bitu want, Bit8u * buffer) {

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -138,23 +138,27 @@ static const uint8_t envelope[8][64] = {
 
 #define FILL_ARRAY( _FILL_ ) memset( _FILL_, 0, sizeof( _FILL_ ) )
 
-saa1099_device::saa1099_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, SAA1099, tag, owner, clock)
-	, device_sound_interface(mconfig, *this)
-	, m_stream(0)
+saa1099_device::saa1099_device(const machine_config &mconfig,
+                               const char *tag,
+                               device_t *owner,
+                               uint32_t clock)
+        : device_t(mconfig, SAA1099, tag, owner, clock),
+          device_sound_interface(mconfig, *this),
+          m_stream(0),
 #if 0
-	, m_noise_params{ 0, 0 }
-	, m_env_enable{ 0, 0 }
-	, m_env_reverse_right{ 0, 0 }
-	, m_env_mode{ 0, 0 }
-	, m_env_bits{ 0, 0 }
-	, m_env_clock{ 0, 0 }
-	, m_env_step{ 0, 0 }
+          m_noise_params{ 0, 0 },
+          m_env_enable{ 0, 0 },
+          m_env_reverse_right{ 0, 0 },
+          m_env_mode{ 0, 0 },
+          m_env_bits{ 0, 0 },
+          m_env_clock{ 0, 0 },
+          m_env_step{ 0, 0 },
 #endif
-	, m_all_ch_enable(0)
-	, m_sync_state(0)
-	, m_selected_reg(0)
-	, m_sample_rate(0.0)
+          m_all_ch_enable(0),
+          m_sync_state(0),
+          m_selected_reg(0),
+          m_sample_rate(0.0),
+          m_master_clock(0)
 {
 	FILL_ARRAY( m_noise_params );
 	FILL_ARRAY( m_env_enable );
@@ -163,7 +167,6 @@ saa1099_device::saa1099_device(const machine_config &mconfig, const char *tag, d
 	FILL_ARRAY( m_env_bits );
 	FILL_ARRAY( m_env_clock );
 	FILL_ARRAY( m_env_step );
-	
 }
 
 

--- a/src/hardware/mame/saa1099.h
+++ b/src/hardware/mame/saa1099.h
@@ -23,23 +23,6 @@
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-//Container class for int that just initalizes to 0
-class NullInt {
-    int value;
-public:
-    operator int& () {
-	return value;
-    }
-    
-    int& operator= ( int set ) {
-	value = set;
-	return value;
-    }
-    
-    NullInt( int set = 0 ) : value( set ) {
-    }
-};
-
 // ======================> saa1099_device
 
 class saa1099_device : public device_t,

--- a/src/hardware/mame/saa1099.h
+++ b/src/hardware/mame/saa1099.h
@@ -7,7 +7,7 @@
 #ifndef MAME_SOUND_SAA1099_H
 #define MAME_SOUND_SAA1099_H
 
-#pragma once
+#include "emu.h"
 
 //**************************************************************************
 //  INTERFACE CONFIGURATION MACROS
@@ -25,11 +25,15 @@
 
 // ======================> saa1099_device
 
-class saa1099_device : public device_t,
-						public device_sound_interface
-{
+class saa1099_device : public device_t, public device_sound_interface {
 public:
-	saa1099_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	saa1099_device(const machine_config &mconfig,
+	               const char *tag,
+	               device_t *owner,
+	               uint32_t clock);
+
+	saa1099_device(const saa1099_device &) = delete; // prevent copying
+	saa1099_device &operator=(const saa1099_device &) = delete; // prevent assignment
 
 	DECLARE_WRITE8_MEMBER( control_w );
 	DECLARE_WRITE8_MEMBER( data_w );
@@ -44,44 +48,34 @@ public:
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples);
 
 private:
-	struct saa1099_channel
-	{
-		saa1099_channel() {
-		    //Quite hacky, but let's see how it goes
-		    memset( this, 0, sizeof( *this ) );
-		}
+	struct saa1099_channel {
+		saa1099_channel() = default;
 
-		int frequency    ;   /* frequency (0x00..0xff) */
-		int freq_enable  ;   /* frequency enable */
-		int noise_enable ;   /* noise enable */
-		int octave       ;   /* octave (0x00..0x07) */
-		int amplitude[2];       /* amplitude (0x00..0x0f) */
-		int envelope[2];        /* envelope (0x00..0x0f or 0x10 == off) */
+		int frequency = 0;         // frequency (0x00..0xff)
+		int freq_enable = 0;       // frequency enable
+		int noise_enable = 0;      // noise enable
+		int octave = 0;            // octave (0x00..0x07)
+		int amplitude[2] = {0, 0}; // amplitude (0x00..0x0f)
+		int envelope[2] = {0, 0};  // envelope (0x00..0x0f or 0x10 == off)
 
 		/* vars to simulate the square wave */
-		double counter ;
-		double freq ;
-		int level ;
-		
+		double counter = 0;
+		double freq = 0;
+		int level = 0;
 	};
 
-	struct saa1099_noise
-	{
-		saa1099_noise() { 
-		    counter = 0;
-		    freq = 0;
-		    level = 0xFFFFFFFF;
-		}
+	struct saa1099_noise {
+		saa1099_noise() = default;
 
 		/* vars to simulate the noise generator output */
-		double counter;
-		double freq;
-		uint32_t level;         /* noise polynomial shifter */
+		double counter = 0;
+		double freq = 0;
+		uint32_t level = 0xFFFFFFFF; // noise polynomial shifter
 	};
 
 	void envelope_w(int ch);
 
-	sound_stream *m_stream;          /* our stream */
+	sound_stream *m_stream;           /* our stream */
 	int m_noise_params[2];            /* noise generators parameters */
 	int m_env_enable[2];              /* envelope generators enable */
 	int m_env_reverse_right[2];       /* envelope reversed for right channel */

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -143,34 +143,39 @@
 //When you go over this create sample
 #define RATE_MAX ( 1 << 30)
 
-sn76496_base_device::sn76496_base_device(
-		const machine_config &mconfig,
-		device_type type,
-		const char *tag,
-		int feedbackmask,
-		int noisetap1,
-		int noisetap2,
-		bool negate,
-		bool stereo,
-		int clockdivider,
-		bool ncr,
-		bool sega,
-		device_t *owner,
-		uint32_t clock)
-	: device_t(mconfig, type, tag, owner, clock)
-	, device_sound_interface(mconfig, *this)
-//	, m_ready_handler(*this)
-	, m_feedback_mask(feedbackmask)
-	, m_whitenoise_tap1(noisetap1)
-	, m_whitenoise_tap2(noisetap2)
-	, m_negate(negate)
-	, m_stereo(stereo)
-	, m_clock_divider(clockdivider)
-	, m_ncr_style_psg(ncr)
-	, m_sega_style_psg(sega)
-{
-}
-
+sn76496_base_device::sn76496_base_device(const machine_config &mconfig,
+                                         device_type type,
+                                         const char *tag,
+                                         int feedbackmask,
+                                         int noisetap1,
+                                         int noisetap2,
+                                         bool negate,
+                                         bool stereo,
+                                         int clockdivider,
+                                         bool ncr,
+                                         bool sega,
+                                         device_t *owner,
+                                         uint32_t clock)
+        : device_t(mconfig, type, tag, owner, clock),
+          device_sound_interface(mconfig, *this),
+          m_ready_state(false),
+          m_feedback_mask(feedbackmask),
+          m_whitenoise_tap1(noisetap1),
+          m_whitenoise_tap2(noisetap2),
+          m_negate(negate),
+          m_stereo(stereo),
+          m_clock_divider(clockdivider),
+          m_ncr_style_psg(ncr),
+          m_sega_style_psg(sega),
+          m_last_register(0),
+          m_RNG(0),
+          m_current_clock(0),
+          m_stereo_mask(0x0),
+          m_cycles_to_ready(0),
+          sample_rate(0),
+          rate_add(0),
+          rate_counter(0)
+{}
 
 sn76496_device::sn76496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: sn76496_base_device(mconfig, SN76496, tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -759,21 +759,21 @@ public:
 };
 
 static struct vg {
-	VGA_Map_Handler				map;
-	VGA_Changes_Handler			changes;
-	VGA_TEXT_PageHandler		text;
-	VGA_TANDY_PageHandler		tandy;
-	VGA_ChainedEGA_Handler		cega;
-	VGA_ChainedVGA_Handler		cvga;
-	VGA_UnchainedEGA_Handler	uega;
-	VGA_UnchainedVGA_Handler	uvga;
-	VGA_PCJR_Handler			pcjr;
-	VGA_HERC_Handler			herc;
-	VGA_LIN4_Handler			lin4;
-	VGA_LFB_Handler				lfb;
-	VGA_LFBChanges_Handler		lfbchanges;
-	VGA_MMIO_Handler			mmio;
-	VGA_Empty_Handler			empty;
+	VGA_Map_Handler map = {};
+	VGA_Changes_Handler changes = {};
+	VGA_TEXT_PageHandler text = {};
+	VGA_TANDY_PageHandler tandy = {};
+	VGA_ChainedEGA_Handler cega = {};
+	VGA_ChainedVGA_Handler cvga = {};
+	VGA_UnchainedEGA_Handler uega = {};
+	VGA_UnchainedVGA_Handler uvga = {};
+	VGA_PCJR_Handler pcjr = {};
+	VGA_HERC_Handler herc = {};
+	VGA_LIN4_Handler lin4 = {};
+	VGA_LFB_Handler lfb = {};
+	VGA_LFBChanges_Handler lfbchanges = {};
+	VGA_MMIO_Handler mmio = {};
+	VGA_Empty_Handler empty = {};
 } vgaph;
 
 void VGA_ChangedBank(void) {

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -536,12 +536,27 @@ void VideoCodec::FreeBuffers(void) {
 	}
 }
 
-
-VideoCodec::VideoCodec() {
+VideoCodec::VideoCodec()
+        : compress{},
+          VectorCount(0),
+          oldframe(nullptr),
+          newframe(nullptr),
+          buf1(nullptr),
+          buf2(nullptr),
+          work(nullptr),
+          bufsize(0),
+          blockcount(0),
+          blocks(nullptr),
+          workUsed(0),
+          workPos(0),
+          palsize(0),
+          height(0),
+          width(0),
+          pitch(0),
+          format(ZMBV_FORMAT_NONE),
+          pixelsize(0),
+          zstream{}
+{
 	CreateVectorTable();
-	blocks = 0;
-	buf1 = 0;
-	buf2 = 0;
-	work = 0;
-	memset( &zstream, 0, sizeof(zstream));
+	memset(&zstream, 0, sizeof(zstream));
 }


### PR DESCRIPTION
Another boring review. This one clears out all *trivial* effc++ warnings, that were remaining (and brings us below 100 warnings with our current default set! :) ).

All remaining effc++ warnings are non-trivial or with an elevated risk of regressions - we'll need to fix those with extra care.