### PR TITLE
Use system archiver instead of hardcoded 'ar'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADER(config.h)
 
 dnl Checks for programs.
+AM_PROG_AR
 AC_PROG_MAKE_SET
 AC_PROG_CC_C99
 AC_PROG_CPP


### PR DESCRIPTION
Currently Makefiles will have AR='ar' which does not allow different implementations like llvm-ar

This adds system ar handling via automake's AM_PROG_AR macro

Downstream bug: https://bugs.gentoo.org/738116

