### PR TITLE
Add an option for setting monochrome palette colour

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -416,6 +416,8 @@ void Herc_Palette(void);
 /* CGA Mono Palette function */
 void Mono_CGA_Palette(void);
 
+void VGA_SetMonoPalette(const char *colour);
+
 /* Functions for different resolutions */
 void VGA_SetMode(VGAModes mode);
 void VGA_DetermineMode(void);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -470,6 +470,13 @@ void DOSBOX_Init(void) {
 	                "320x200 or 640x400; where as square-pixel modes, such as 640x480\n"
 	                "and 800x600, will be displayed as-is.");
 
+	pstring = secprop->Add_string("monochrome_palette", always, "white");
+	pstring->Set_help("Select default palette for monochrome display.\n"
+	                  "Works only when emulating hercules or cga_mono.\n"
+	                  "You can also cycle through available colours using F11.");
+	const char *mono_pal[] = {"white", "paperwhite", "green", "amber", 0};
+	pstring->Set_values(mono_pal);
+
 	pmulti = secprop->Add_multi("scaler", always, " ");
 	pmulti->SetValue("none");
 	pmulti->Set_help("Scaler used to enlarge/enhance low resolution modes.\n"

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "dosbox.h"
 
 #include <sys/types.h>
 #include <assert.h>
@@ -24,7 +25,6 @@
 #include <sstream>
 #include <stdlib.h>
 
-#include "dosbox.h"
 #include "video.h"
 #include "render.h"
 #include "setup.h"
@@ -34,6 +34,7 @@
 #include "hardware.h"
 #include "support.h"
 #include "shell.h"
+#include "vga.h"
 
 #include "render_scalers.h"
 #include "render_glsl.h"
@@ -688,6 +689,7 @@ void RENDER_Init(Section * sec) {
 	render.aspect=section->Get_bool("aspect");
 	render.frameskip.max=section->Get_int("frameskip");
 	render.frameskip.count=0;
+	VGA_SetMonoPalette(section->Get_string("monochrome_palette"));
 	std::string cline;
 	std::string scaler;
 	//Check for commandline paramters and parse them through the configclass so they get checked against allowed values

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -723,6 +723,33 @@ static void write_pcjr(Bitu port,Bitu val,Bitu /*iolen*/) {
 	}
 }
 
+static int palette_num(const char *colour)
+{
+	if (strcasecmp(colour, "green") == 0)
+		return 0;
+	if (strcasecmp(colour, "amber") == 0)
+		return 1;
+	if (strcasecmp(colour, "white") == 0)
+		return 2;
+	if (strcasecmp(colour, "paperwhite") == 0)
+		return 3;
+	return 2;
+}
+
+void VGA_SetMonoPalette(const char *colour)
+{
+	if (machine == MCH_HERC) {
+		herc_pal = palette_num(colour);
+		Herc_Palette();
+		return;
+	}
+	if (machine == MCH_CGA && mono_cga) {
+		mono_cga_pal = palette_num(colour);
+		Mono_CGA_Palette();
+		return;
+	}
+}
+
 static void CycleMonoCGAPal(bool pressed) {
 	if (!pressed) return;
 	if (++mono_cga_pal>3) mono_cga_pal=0;
@@ -752,24 +779,25 @@ static void CycleHercPal(bool pressed) {
 	Herc_Palette();
 	VGA_DAC_CombineColor(1,7);
 }
-	
-void Herc_Palette(void) {	
+
+void Herc_Palette()
+{
 	switch (herc_pal) {
-	case 0:	// White
-		VGA_DAC_SetEntry(0x7,0x2a,0x2a,0x2a);
-		VGA_DAC_SetEntry(0xf,0x3f,0x3f,0x3f);
+	case 0: // Green
+		VGA_DAC_SetEntry(0x7, 0x00, 0x26, 0x00);
+		VGA_DAC_SetEntry(0xf, 0x00, 0x3f, 0x00);
 		break;
-	case 1:	// Amber
-		VGA_DAC_SetEntry(0x7,0x34,0x20,0x00);
-		VGA_DAC_SetEntry(0xf,0x3f,0x34,0x00);
+	case 1: // Amber
+		VGA_DAC_SetEntry(0x7, 0x34, 0x20, 0x00);
+		VGA_DAC_SetEntry(0xf, 0x3f, 0x34, 0x00);
 		break;
-	case 2:	// Paper-white
-		VGA_DAC_SetEntry(0x7,0x2c,0x2d,0x2c);
-		VGA_DAC_SetEntry(0xf,0x3f,0x3f,0x3b);
+	case 2: // White
+		VGA_DAC_SetEntry(0x7, 0x2a, 0x2a, 0x2a);
+		VGA_DAC_SetEntry(0xf, 0x3f, 0x3f, 0x3f);
 		break;
-	case 3:	// Green
-		VGA_DAC_SetEntry(0x7,0x00,0x26,0x00);
-		VGA_DAC_SetEntry(0xf,0x00,0x3f,0x00);
+	case 3: // Paper-white
+		VGA_DAC_SetEntry(0x7, 0x2d, 0x2e, 0x2d);
+		VGA_DAC_SetEntry(0xf, 0x3f, 0x3f, 0x3b);
 		break;
 	}
 }


### PR DESCRIPTION
To be used with machine=hercules and machine=cga_mono, as right now
users must cycle through colours every time they start dosbox.

There are two ways to use this new option: either by changing .conf
file to set the default colour, or alternatively:

  Z:\> config -set monochrome_palette green

Also, chance colours numbers in Hercules machine to match the order
used by cga_mono - this way implementation is cleaner and the behaviour
is more consistent for user.

Fixes: #602