### PR TITLE
Cleanup some verbose warnings - September 2020

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -118,6 +118,10 @@ bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry);
 bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate);
 bool DOS_SetFileDate(uint16_t entry, uint16_t ntime, uint16_t ndate);
 
+// Date and Time Conversion
+uint16_t DOS_PackTime(uint16_t hour, uint16_t min, uint16_t sec);
+uint16_t DOS_PackDate(uint16_t year, uint16_t mon, uint16_t day);
+
 /* Routines for Drive Class */
 bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb = false);
 bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bit16u action, Bit16u *entry, Bit16u* status);
@@ -214,28 +218,6 @@ static INLINE Bit16u long2para(Bit32u size) {
 	if (size>0xFFFF0) return 0xffff;
 	if (size&0xf) return (Bit16u)((size>>4)+1);
 	else return (Bit16u)(size>>4);
-}
-
-static inline uint16_t DOS_PackTime(uint16_t hour, uint16_t min, uint16_t sec)
-{
-	const auto hour_portion = (hour & 0x1f) << 11;
-	const auto min_portion = (min & 0x3f) << 5;
-	const auto sec_portion = (sec / 2) & 0x1f;
-	const auto packed = hour_portion | min_portion | sec_portion;
-
-	assert(packed >= 0 && packed <= UINT16_MAX); // ensure rvalue won't wrap
-	return static_cast<uint16_t>(packed);
-}
-
-static inline uint16_t DOS_PackDate(uint16_t year, uint16_t mon, uint16_t day)
-{
-	const auto year_portion = ((year - 1980) & 0x7f) << 9;
-	const auto mon_portion = (mon & 0x3f) << 5;
-	const auto day_portion = day & 0x1f;
-	const auto packed = year_portion | mon_portion | day_portion;
-
-	assert(packed >= 0 && packed <= UINT16_MAX); // ensure rvalue won't wrap
-	return static_cast<uint16_t>(packed);
 }
 
 /* Dos Error Codes */

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -435,7 +435,7 @@ public:
 	void SetUMBChainState(uint8_t state) { SSET_BYTE(sDIB, chainingUMB, state); }
 	uint8_t GetUMBChainState() const { return SGET_BYTE(sDIB, chainingUMB); }
 
-	void SetStartOfUMBChain(uint16_t seg) { SSET_WORD(sDIB, startOfUMBChain, seg); }
+	void SetStartOfUMBChain(uint16_t start_seg) { SSET_WORD(sDIB, startOfUMBChain, start_seg); }
 	uint16_t GetStartOfUMBChain() const { return SGET_WORD(sDIB, startOfUMBChain); }
 
 	void SetDiskBufferHeadPt(uint32_t db) { SSET_DWORD(sDIB, diskBufferHeadPt, db); }

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -216,13 +216,26 @@ static INLINE Bit16u long2para(Bit32u size) {
 	else return (Bit16u)(size>>4);
 }
 
+static inline uint16_t DOS_PackTime(uint16_t hour, uint16_t min, uint16_t sec)
+{
+	const auto hour_portion = (hour & 0x1f) << 11;
+	const auto min_portion = (min & 0x3f) << 5;
+	const auto sec_portion = (sec / 2) & 0x1f;
+	const auto packed = hour_portion | min_portion | sec_portion;
 
-static INLINE Bit16u DOS_PackTime(Bit16u hour,Bit16u min,Bit16u sec) {
-	return (hour&0x1f)<<11 | (min&0x3f) << 5 | ((sec/2)&0x1f);
+	assert(packed >= 0 && packed <= UINT16_MAX); // ensure rvalue won't wrap
+	return static_cast<uint16_t>(packed);
 }
 
-static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
-	return ((year-1980)&0x7f)<<9 | (mon&0x3f) << 5 | (day&0x1f);
+static inline uint16_t DOS_PackDate(uint16_t year, uint16_t mon, uint16_t day)
+{
+	const auto year_portion = ((year - 1980) & 0x7f) << 9;
+	const auto mon_portion = (mon & 0x3f) << 5;
+	const auto day_portion = day & 0x1f;
+	const auto packed = year_portion | mon_portion | day_portion;
+
+	assert(packed >= 0 && packed <= UINT16_MAX); // ensure rvalue won't wrap
+	return static_cast<uint16_t>(packed);
 }
 
 /* Dos Error Codes */

--- a/include/mem.h
+++ b/include/mem.h
@@ -29,7 +29,7 @@ typedef uint32_t PhysPt;
 typedef uint8_t * HostPt;
 typedef uint32_t RealPt;
 
-typedef Bit32s MemHandle;
+typedef int32_t MemHandle;
 
 #define MEM_PAGESIZE 4096
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -26,7 +26,7 @@
 #include "mem_unaligned.h"
 
 typedef uint32_t PhysPt;
-typedef Bit8u * HostPt;
+typedef uint8_t * HostPt;
 typedef uint32_t RealPt;
 
 typedef Bit32s MemHandle;
@@ -77,15 +77,15 @@ static inline uint32_t var_read(uint32_t * var) {
 
 /* The Folowing six functions are slower but they recognize the paged memory system */
 
-Bit8u  mem_readb(PhysPt pt);
+uint8_t  mem_readb(PhysPt pt);
 uint16_t mem_readw(PhysPt pt);
 uint32_t mem_readd(PhysPt pt);
 
-void mem_writeb(PhysPt pt,Bit8u val);
+void mem_writeb(PhysPt pt,uint8_t val);
 void mem_writew(PhysPt pt,uint16_t val);
 void mem_writed(PhysPt pt,uint32_t val);
 
-static inline void phys_writeb(PhysPt addr,Bit8u val) {
+static inline void phys_writeb(PhysPt addr,uint8_t val) {
 	host_writeb(MemBase+addr,val);
 }
 static inline void phys_writew(PhysPt addr,uint16_t val){
@@ -95,7 +95,7 @@ static inline void phys_writed(PhysPt addr,uint32_t val){
 	host_writed(MemBase+addr,val);
 }
 
-static inline Bit8u phys_readb(PhysPt addr) {
+static inline uint8_t phys_readb(PhysPt addr) {
 	return host_readb(MemBase+addr);
 }
 static inline uint16_t phys_readw(PhysPt addr){
@@ -118,7 +118,7 @@ void mem_strcpy(PhysPt dest,PhysPt src);
 
 /* The folowing functions are all shortcuts to the above functions using physical addressing */
 
-static inline Bit8u real_readb(uint16_t seg,uint16_t off) {
+static inline uint8_t real_readb(uint16_t seg,uint16_t off) {
 	return mem_readb((seg<<4)+off);
 }
 static inline uint16_t real_readw(uint16_t seg,uint16_t off) {
@@ -128,7 +128,7 @@ static inline uint32_t real_readd(uint16_t seg,uint16_t off) {
 	return mem_readd((seg<<4)+off);
 }
 
-static inline void real_writeb(uint16_t seg,uint16_t off,Bit8u val) {
+static inline void real_writeb(uint16_t seg,uint16_t off,uint8_t val) {
 	mem_writeb(((seg<<4)+off),val);
 }
 static inline void real_writew(uint16_t seg,uint16_t off,uint16_t val) {
@@ -159,16 +159,16 @@ static inline RealPt RealMake(uint16_t seg,uint16_t off) {
 	return (seg<<16)+off;
 }
 
-static inline void RealSetVec(Bit8u vec,RealPt pt) {
+static inline void RealSetVec(uint8_t vec,RealPt pt) {
 	mem_writed(vec<<2,pt);
 }
 
-static inline void RealSetVec(Bit8u vec,RealPt pt,RealPt &old) {
+static inline void RealSetVec(uint8_t vec,RealPt pt,RealPt &old) {
 	old = mem_readd(vec<<2);
 	mem_writed(vec<<2,pt);
 }
 
-static inline RealPt RealGetVec(Bit8u vec) {
+static inline RealPt RealGetVec(uint8_t vec) {
 	return mem_readd(vec<<2);
 }	
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -25,9 +25,9 @@
 #include "mem_host.h"
 #include "mem_unaligned.h"
 
-typedef Bit32u PhysPt;
+typedef uint32_t PhysPt;
 typedef Bit8u * HostPt;
-typedef Bit32u RealPt;
+typedef uint32_t RealPt;
 
 typedef Bit32s MemHandle;
 
@@ -63,7 +63,7 @@ static inline void var_write(uint16_t * var, uint16_t val) {
 	host_writew((HostPt)var, val);
 }
 
-static inline void var_write(Bit32u * var, Bit32u val) {
+static inline void var_write(uint32_t * var, uint32_t val) {
 	host_writed((HostPt)var, val);
 }
 
@@ -71,7 +71,7 @@ static inline uint16_t var_read(uint16_t * var) {
 	return host_readw((HostPt)var);
 }
 
-static inline Bit32u var_read(Bit32u * var) {
+static inline uint32_t var_read(uint32_t * var) {
 	return host_readd((HostPt)var);
 }
 
@@ -79,11 +79,11 @@ static inline Bit32u var_read(Bit32u * var) {
 
 Bit8u  mem_readb(PhysPt pt);
 uint16_t mem_readw(PhysPt pt);
-Bit32u mem_readd(PhysPt pt);
+uint32_t mem_readd(PhysPt pt);
 
 void mem_writeb(PhysPt pt,Bit8u val);
 void mem_writew(PhysPt pt,uint16_t val);
-void mem_writed(PhysPt pt,Bit32u val);
+void mem_writed(PhysPt pt,uint32_t val);
 
 static inline void phys_writeb(PhysPt addr,Bit8u val) {
 	host_writeb(MemBase+addr,val);
@@ -91,7 +91,7 @@ static inline void phys_writeb(PhysPt addr,Bit8u val) {
 static inline void phys_writew(PhysPt addr,uint16_t val){
 	host_writew(MemBase+addr,val);
 }
-static inline void phys_writed(PhysPt addr,Bit32u val){
+static inline void phys_writed(PhysPt addr,uint32_t val){
 	host_writed(MemBase+addr,val);
 }
 
@@ -101,7 +101,7 @@ static inline Bit8u phys_readb(PhysPt addr) {
 static inline uint16_t phys_readw(PhysPt addr){
 	return host_readw(MemBase+addr);
 }
-static inline Bit32u phys_readd(PhysPt addr){
+static inline uint32_t phys_readd(PhysPt addr){
 	return host_readd(MemBase+addr);
 }
 
@@ -124,7 +124,7 @@ static inline Bit8u real_readb(uint16_t seg,uint16_t off) {
 static inline uint16_t real_readw(uint16_t seg,uint16_t off) {
 	return mem_readw((seg<<4)+off);
 }
-static inline Bit32u real_readd(uint16_t seg,uint16_t off) {
+static inline uint32_t real_readd(uint16_t seg,uint16_t off) {
 	return mem_readd((seg<<4)+off);
 }
 
@@ -134,7 +134,7 @@ static inline void real_writeb(uint16_t seg,uint16_t off,Bit8u val) {
 static inline void real_writew(uint16_t seg,uint16_t off,uint16_t val) {
 	mem_writew(((seg<<4)+off),val);
 }
-static inline void real_writed(uint16_t seg,uint16_t off,Bit32u val) {
+static inline void real_writed(uint16_t seg,uint16_t off,uint32_t val) {
 	mem_writed(((seg<<4)+off),val);
 }
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -54,24 +54,24 @@ bool MEM_ReAllocatePages(MemHandle & handle,Bitu pages,bool sequence);
 MemHandle MEM_NextHandle(MemHandle handle);
 MemHandle MEM_NextHandleAt(MemHandle handle,Bitu where);
 
-static INLINE void var_write(uint8_t *var, uint8_t val)
+static inline void var_write(uint8_t *var, uint8_t val)
 {
 	host_writeb(var, val);
 }
 
-static INLINE void var_write(Bit16u * var, Bit16u val) {
+static inline void var_write(Bit16u * var, Bit16u val) {
 	host_writew((HostPt)var, val);
 }
 
-static INLINE void var_write(Bit32u * var, Bit32u val) {
+static inline void var_write(Bit32u * var, Bit32u val) {
 	host_writed((HostPt)var, val);
 }
 
-static INLINE Bit16u var_read(Bit16u * var) {
+static inline Bit16u var_read(Bit16u * var) {
 	return host_readw((HostPt)var);
 }
 
-static INLINE Bit32u var_read(Bit32u * var) {
+static inline Bit32u var_read(Bit32u * var) {
 	return host_readd((HostPt)var);
 }
 
@@ -85,23 +85,23 @@ void mem_writeb(PhysPt pt,Bit8u val);
 void mem_writew(PhysPt pt,Bit16u val);
 void mem_writed(PhysPt pt,Bit32u val);
 
-static INLINE void phys_writeb(PhysPt addr,Bit8u val) {
+static inline void phys_writeb(PhysPt addr,Bit8u val) {
 	host_writeb(MemBase+addr,val);
 }
-static INLINE void phys_writew(PhysPt addr,Bit16u val){
+static inline void phys_writew(PhysPt addr,Bit16u val){
 	host_writew(MemBase+addr,val);
 }
-static INLINE void phys_writed(PhysPt addr,Bit32u val){
+static inline void phys_writed(PhysPt addr,Bit32u val){
 	host_writed(MemBase+addr,val);
 }
 
-static INLINE Bit8u phys_readb(PhysPt addr) {
+static inline Bit8u phys_readb(PhysPt addr) {
 	return host_readb(MemBase+addr);
 }
-static INLINE Bit16u phys_readw(PhysPt addr){
+static inline Bit16u phys_readw(PhysPt addr){
 	return host_readw(MemBase+addr);
 }
-static INLINE Bit32u phys_readd(PhysPt addr){
+static inline Bit32u phys_readd(PhysPt addr){
 	return host_readd(MemBase+addr);
 }
 
@@ -118,57 +118,57 @@ void mem_strcpy(PhysPt dest,PhysPt src);
 
 /* The folowing functions are all shortcuts to the above functions using physical addressing */
 
-static INLINE Bit8u real_readb(Bit16u seg,Bit16u off) {
+static inline Bit8u real_readb(Bit16u seg,Bit16u off) {
 	return mem_readb((seg<<4)+off);
 }
-static INLINE Bit16u real_readw(Bit16u seg,Bit16u off) {
+static inline Bit16u real_readw(Bit16u seg,Bit16u off) {
 	return mem_readw((seg<<4)+off);
 }
-static INLINE Bit32u real_readd(Bit16u seg,Bit16u off) {
+static inline Bit32u real_readd(Bit16u seg,Bit16u off) {
 	return mem_readd((seg<<4)+off);
 }
 
-static INLINE void real_writeb(Bit16u seg,Bit16u off,Bit8u val) {
+static inline void real_writeb(Bit16u seg,Bit16u off,Bit8u val) {
 	mem_writeb(((seg<<4)+off),val);
 }
-static INLINE void real_writew(Bit16u seg,Bit16u off,Bit16u val) {
+static inline void real_writew(Bit16u seg,Bit16u off,Bit16u val) {
 	mem_writew(((seg<<4)+off),val);
 }
-static INLINE void real_writed(Bit16u seg,Bit16u off,Bit32u val) {
+static inline void real_writed(Bit16u seg,Bit16u off,Bit32u val) {
 	mem_writed(((seg<<4)+off),val);
 }
 
 
-static INLINE Bit16u RealSeg(RealPt pt) {
+static inline Bit16u RealSeg(RealPt pt) {
 	return (Bit16u)(pt>>16);
 }
 
-static INLINE Bit16u RealOff(RealPt pt) {
+static inline Bit16u RealOff(RealPt pt) {
 	return (Bit16u)(pt&0xffff);
 }
 
-static INLINE PhysPt Real2Phys(RealPt pt) {
+static inline PhysPt Real2Phys(RealPt pt) {
 	return (RealSeg(pt)<<4) +RealOff(pt);
 }
 
-static INLINE PhysPt PhysMake(Bit16u seg,Bit16u off) {
+static inline PhysPt PhysMake(Bit16u seg,Bit16u off) {
 	return (seg<<4)+off;
 }
 
-static INLINE RealPt RealMake(Bit16u seg,Bit16u off) {
+static inline RealPt RealMake(Bit16u seg,Bit16u off) {
 	return (seg<<16)+off;
 }
 
-static INLINE void RealSetVec(Bit8u vec,RealPt pt) {
+static inline void RealSetVec(Bit8u vec,RealPt pt) {
 	mem_writed(vec<<2,pt);
 }
 
-static INLINE void RealSetVec(Bit8u vec,RealPt pt,RealPt &old) {
+static inline void RealSetVec(Bit8u vec,RealPt pt,RealPt &old) {
 	old = mem_readd(vec<<2);
 	mem_writed(vec<<2,pt);
 }
 
-static INLINE RealPt RealGetVec(Bit8u vec) {
+static inline RealPt RealGetVec(Bit8u vec) {
 	return mem_readd(vec<<2);
 }	
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -26,7 +26,7 @@
 #include "mem_unaligned.h"
 
 typedef uint32_t PhysPt;
-typedef uint8_t * HostPt;
+typedef uint8_t *HostPt;
 typedef uint32_t RealPt;
 
 typedef int32_t MemHandle;
@@ -41,136 +41,162 @@ void MEM_A20_Enable(bool enable);
 
 /* Memory management / EMS mapping */
 HostPt MEM_GetBlockPage(void);
-Bitu MEM_FreeTotal(void);			//Free 4 kb pages
-Bitu MEM_FreeLargest(void);			//Largest free 4 kb pages block
-Bitu MEM_TotalPages(void);			//Total amount of 4 kb pages
+Bitu MEM_FreeTotal(void);                  // Free 4 kb pages
+Bitu MEM_FreeLargest(void);                // Largest free 4 kb pages block
+Bitu MEM_TotalPages(void);                 // Total amount of 4 kb pages
 Bitu MEM_AllocatedPages(MemHandle handle); // amount of allocated pages of handle
-MemHandle MEM_AllocatePages(Bitu pages,bool sequence);
+MemHandle MEM_AllocatePages(Bitu pages, bool sequence);
 MemHandle MEM_GetNextFreePage(void);
 PhysPt MEM_AllocatePage(void);
 void MEM_ReleasePages(MemHandle handle);
-bool MEM_ReAllocatePages(MemHandle & handle,Bitu pages,bool sequence);
+bool MEM_ReAllocatePages(MemHandle &handle, Bitu pages, bool sequence);
 
 MemHandle MEM_NextHandle(MemHandle handle);
-MemHandle MEM_NextHandleAt(MemHandle handle,Bitu where);
+MemHandle MEM_NextHandleAt(MemHandle handle, Bitu where);
 
 static inline void var_write(uint8_t *var, uint8_t val)
 {
 	host_writeb(var, val);
 }
 
-static inline void var_write(uint16_t * var, uint16_t val) {
+static inline void var_write(uint16_t *var, uint16_t val)
+{
 	host_writew((HostPt)var, val);
 }
 
-static inline void var_write(uint32_t * var, uint32_t val) {
+static inline void var_write(uint32_t *var, uint32_t val)
+{
 	host_writed((HostPt)var, val);
 }
 
-static inline uint16_t var_read(uint16_t * var) {
+static inline uint16_t var_read(uint16_t *var)
+{
 	return host_readw((HostPt)var);
 }
 
-static inline uint32_t var_read(uint32_t * var) {
+static inline uint32_t var_read(uint32_t *var)
+{
 	return host_readd((HostPt)var);
 }
 
-/* The Folowing six functions are slower but they recognize the paged memory system */
+/* The Folowing six functions are slower but they recognize the paged memory
+ * system */
 
-uint8_t  mem_readb(PhysPt pt);
+uint8_t mem_readb(PhysPt pt);
 uint16_t mem_readw(PhysPt pt);
 uint32_t mem_readd(PhysPt pt);
 
-void mem_writeb(PhysPt pt,uint8_t val);
-void mem_writew(PhysPt pt,uint16_t val);
-void mem_writed(PhysPt pt,uint32_t val);
+void mem_writeb(PhysPt pt, uint8_t val);
+void mem_writew(PhysPt pt, uint16_t val);
+void mem_writed(PhysPt pt, uint32_t val);
 
-static inline void phys_writeb(PhysPt addr,uint8_t val) {
-	host_writeb(MemBase+addr,val);
+static inline void phys_writeb(PhysPt addr, uint8_t val)
+{
+	host_writeb(MemBase + addr, val);
 }
-static inline void phys_writew(PhysPt addr,uint16_t val){
-	host_writew(MemBase+addr,val);
+static inline void phys_writew(PhysPt addr, uint16_t val)
+{
+	host_writew(MemBase + addr, val);
 }
-static inline void phys_writed(PhysPt addr,uint32_t val){
-	host_writed(MemBase+addr,val);
+static inline void phys_writed(PhysPt addr, uint32_t val)
+{
+	host_writed(MemBase + addr, val);
 }
 
-static inline uint8_t phys_readb(PhysPt addr) {
-	return host_readb(MemBase+addr);
+static inline uint8_t phys_readb(PhysPt addr)
+{
+	return host_readb(MemBase + addr);
 }
-static inline uint16_t phys_readw(PhysPt addr){
-	return host_readw(MemBase+addr);
+static inline uint16_t phys_readw(PhysPt addr)
+{
+	return host_readw(MemBase + addr);
 }
-static inline uint32_t phys_readd(PhysPt addr){
-	return host_readd(MemBase+addr);
+static inline uint32_t phys_readd(PhysPt addr)
+{
+	return host_readd(MemBase + addr);
 }
 
 /* These don't check for alignment, better be sure it's correct */
 
-void MEM_BlockWrite(PhysPt pt,void const * const data,Bitu size);
-void MEM_BlockRead(PhysPt pt,void * data,Bitu size);
-void MEM_BlockCopy(PhysPt dest,PhysPt src,Bitu size);
-void MEM_StrCopy(PhysPt pt,char * data,Bitu size);
+void MEM_BlockWrite(PhysPt pt, const void *data, Bitu size);
+void MEM_BlockRead(PhysPt pt, void *data, Bitu size);
+void MEM_BlockCopy(PhysPt dest, PhysPt src, Bitu size);
+void MEM_StrCopy(PhysPt pt, char *data, Bitu size);
 
-void mem_memcpy(PhysPt dest,PhysPt src,Bitu size);
+void mem_memcpy(PhysPt dest, PhysPt src, Bitu size);
 Bitu mem_strlen(PhysPt pt);
-void mem_strcpy(PhysPt dest,PhysPt src);
+void mem_strcpy(PhysPt dest, PhysPt src);
 
-/* The folowing functions are all shortcuts to the above functions using physical addressing */
+/* The folowing functions are all shortcuts to the above functions using
+ * physical addressing */
 
-static inline uint8_t real_readb(uint16_t seg,uint16_t off) {
-	return mem_readb((seg<<4)+off);
+static inline uint8_t real_readb(uint16_t seg, uint16_t off)
+{
+	return mem_readb((seg << 4) + off);
 }
-static inline uint16_t real_readw(uint16_t seg,uint16_t off) {
-	return mem_readw((seg<<4)+off);
+static inline uint16_t real_readw(uint16_t seg, uint16_t off)
+{
+	return mem_readw((seg << 4) + off);
 }
-static inline uint32_t real_readd(uint16_t seg,uint16_t off) {
-	return mem_readd((seg<<4)+off);
-}
-
-static inline void real_writeb(uint16_t seg,uint16_t off,uint8_t val) {
-	mem_writeb(((seg<<4)+off),val);
-}
-static inline void real_writew(uint16_t seg,uint16_t off,uint16_t val) {
-	mem_writew(((seg<<4)+off),val);
-}
-static inline void real_writed(uint16_t seg,uint16_t off,uint32_t val) {
-	mem_writed(((seg<<4)+off),val);
+static inline uint32_t real_readd(uint16_t seg, uint16_t off)
+{
+	return mem_readd((seg << 4) + off);
 }
 
-
-static inline uint16_t RealSeg(RealPt pt) {
-	return (uint16_t)(pt>>16);
+static inline void real_writeb(uint16_t seg, uint16_t off, uint8_t val)
+{
+	mem_writeb(((seg << 4) + off), val);
+}
+static inline void real_writew(uint16_t seg, uint16_t off, uint16_t val)
+{
+	mem_writew(((seg << 4) + off), val);
+}
+static inline void real_writed(uint16_t seg, uint16_t off, uint32_t val)
+{
+	mem_writed(((seg << 4) + off), val);
 }
 
-static inline uint16_t RealOff(RealPt pt) {
-	return (uint16_t)(pt&0xffff);
+static inline uint16_t RealSeg(RealPt pt)
+{
+	return pt >> 16;
 }
 
-static inline PhysPt Real2Phys(RealPt pt) {
-	return (RealSeg(pt)<<4) +RealOff(pt);
+static inline uint16_t RealOff(RealPt pt)
+{
+	return static_cast<uint16_t>(pt & 0xffff);
 }
 
-static inline PhysPt PhysMake(uint16_t seg,uint16_t off) {
-	return (seg<<4)+off;
+static inline PhysPt Real2Phys(RealPt pt)
+{
+	return (RealSeg(pt) << 4) + RealOff(pt);
 }
 
-static inline RealPt RealMake(uint16_t seg,uint16_t off) {
-	return (seg<<16)+off;
+static inline PhysPt PhysMake(uint16_t seg, uint16_t off)
+{
+	return (seg << 4) + off;
 }
 
-static inline void RealSetVec(uint8_t vec,RealPt pt) {
-	mem_writed(vec<<2,pt);
+static inline RealPt RealMake(uint16_t seg, uint16_t off)
+{
+	return (seg << 16) + off;
 }
 
-static inline void RealSetVec(uint8_t vec,RealPt pt,RealPt &old) {
-	old = mem_readd(vec<<2);
-	mem_writed(vec<<2,pt);
+static inline void RealSetVec(uint8_t vec, RealPt pt)
+{
+	mem_writed(vec << 2, pt);
 }
 
-static inline RealPt RealGetVec(uint8_t vec) {
-	return mem_readd(vec<<2);
-}	
+// TODO: consider dropping this function. The three places where it's called all
+// ignore the 3rd updated parameter.
+static inline void RealSetVec(uint8_t vec, RealPt pt, RealPt &old)
+{
+	old = mem_readd(vec << 2);
+	mem_writed(vec << 2, pt);
+}
+
+static inline RealPt RealGetVec(uint8_t vec)
+{
+	return mem_readd(vec << 2);
+}
 
 #endif
-

--- a/include/mem.h
+++ b/include/mem.h
@@ -59,7 +59,7 @@ static inline void var_write(uint8_t *var, uint8_t val)
 	host_writeb(var, val);
 }
 
-static inline void var_write(Bit16u * var, Bit16u val) {
+static inline void var_write(uint16_t * var, uint16_t val) {
 	host_writew((HostPt)var, val);
 }
 
@@ -67,7 +67,7 @@ static inline void var_write(Bit32u * var, Bit32u val) {
 	host_writed((HostPt)var, val);
 }
 
-static inline Bit16u var_read(Bit16u * var) {
+static inline uint16_t var_read(uint16_t * var) {
 	return host_readw((HostPt)var);
 }
 
@@ -78,17 +78,17 @@ static inline Bit32u var_read(Bit32u * var) {
 /* The Folowing six functions are slower but they recognize the paged memory system */
 
 Bit8u  mem_readb(PhysPt pt);
-Bit16u mem_readw(PhysPt pt);
+uint16_t mem_readw(PhysPt pt);
 Bit32u mem_readd(PhysPt pt);
 
 void mem_writeb(PhysPt pt,Bit8u val);
-void mem_writew(PhysPt pt,Bit16u val);
+void mem_writew(PhysPt pt,uint16_t val);
 void mem_writed(PhysPt pt,Bit32u val);
 
 static inline void phys_writeb(PhysPt addr,Bit8u val) {
 	host_writeb(MemBase+addr,val);
 }
-static inline void phys_writew(PhysPt addr,Bit16u val){
+static inline void phys_writew(PhysPt addr,uint16_t val){
 	host_writew(MemBase+addr,val);
 }
 static inline void phys_writed(PhysPt addr,Bit32u val){
@@ -98,7 +98,7 @@ static inline void phys_writed(PhysPt addr,Bit32u val){
 static inline Bit8u phys_readb(PhysPt addr) {
 	return host_readb(MemBase+addr);
 }
-static inline Bit16u phys_readw(PhysPt addr){
+static inline uint16_t phys_readw(PhysPt addr){
 	return host_readw(MemBase+addr);
 }
 static inline Bit32u phys_readd(PhysPt addr){
@@ -118,44 +118,44 @@ void mem_strcpy(PhysPt dest,PhysPt src);
 
 /* The folowing functions are all shortcuts to the above functions using physical addressing */
 
-static inline Bit8u real_readb(Bit16u seg,Bit16u off) {
+static inline Bit8u real_readb(uint16_t seg,uint16_t off) {
 	return mem_readb((seg<<4)+off);
 }
-static inline Bit16u real_readw(Bit16u seg,Bit16u off) {
+static inline uint16_t real_readw(uint16_t seg,uint16_t off) {
 	return mem_readw((seg<<4)+off);
 }
-static inline Bit32u real_readd(Bit16u seg,Bit16u off) {
+static inline Bit32u real_readd(uint16_t seg,uint16_t off) {
 	return mem_readd((seg<<4)+off);
 }
 
-static inline void real_writeb(Bit16u seg,Bit16u off,Bit8u val) {
+static inline void real_writeb(uint16_t seg,uint16_t off,Bit8u val) {
 	mem_writeb(((seg<<4)+off),val);
 }
-static inline void real_writew(Bit16u seg,Bit16u off,Bit16u val) {
+static inline void real_writew(uint16_t seg,uint16_t off,uint16_t val) {
 	mem_writew(((seg<<4)+off),val);
 }
-static inline void real_writed(Bit16u seg,Bit16u off,Bit32u val) {
+static inline void real_writed(uint16_t seg,uint16_t off,Bit32u val) {
 	mem_writed(((seg<<4)+off),val);
 }
 
 
-static inline Bit16u RealSeg(RealPt pt) {
-	return (Bit16u)(pt>>16);
+static inline uint16_t RealSeg(RealPt pt) {
+	return (uint16_t)(pt>>16);
 }
 
-static inline Bit16u RealOff(RealPt pt) {
-	return (Bit16u)(pt&0xffff);
+static inline uint16_t RealOff(RealPt pt) {
+	return (uint16_t)(pt&0xffff);
 }
 
 static inline PhysPt Real2Phys(RealPt pt) {
 	return (RealSeg(pt)<<4) +RealOff(pt);
 }
 
-static inline PhysPt PhysMake(Bit16u seg,Bit16u off) {
+static inline PhysPt PhysMake(uint16_t seg,uint16_t off) {
 	return (seg<<4)+off;
 }
 
-static inline RealPt RealMake(Bit16u seg,Bit16u off) {
+static inline RealPt RealMake(uint16_t seg,uint16_t off) {
 	return (seg<<16)+off;
 }
 

--- a/include/mem.h
+++ b/include/mem.h
@@ -132,28 +132,34 @@ void mem_strcpy(PhysPt dest, PhysPt src);
 
 static inline uint8_t real_readb(uint16_t seg, uint16_t off)
 {
-	return mem_readb((seg << 4) + off);
+	const auto base = static_cast<uint32_t>(seg << 4);
+	return mem_readb(base + off);
 }
 static inline uint16_t real_readw(uint16_t seg, uint16_t off)
 {
-	return mem_readw((seg << 4) + off);
+	const auto base = static_cast<uint32_t>(seg << 4);
+	return mem_readw(base + off);
 }
 static inline uint32_t real_readd(uint16_t seg, uint16_t off)
 {
-	return mem_readd((seg << 4) + off);
+	const auto base = static_cast<uint32_t>(seg << 4);
+	return mem_readd(base + off);
 }
 
 static inline void real_writeb(uint16_t seg, uint16_t off, uint8_t val)
 {
-	mem_writeb(((seg << 4) + off), val);
+	const auto base = static_cast<uint32_t>(seg << 4);
+	mem_writeb(base + off, val);
 }
 static inline void real_writew(uint16_t seg, uint16_t off, uint16_t val)
 {
-	mem_writew(((seg << 4) + off), val);
+	const auto base = static_cast<uint32_t>(seg << 4);
+	mem_writew(base + off, val);
 }
 static inline void real_writed(uint16_t seg, uint16_t off, uint32_t val)
 {
-	mem_writed(((seg << 4) + off), val);
+	const auto base = static_cast<uint32_t>(seg << 4);
+	mem_writed(base + off, val);
 }
 
 static inline uint16_t RealSeg(RealPt pt)
@@ -168,35 +174,41 @@ static inline uint16_t RealOff(RealPt pt)
 
 static inline PhysPt Real2Phys(RealPt pt)
 {
-	return (RealSeg(pt) << 4) + RealOff(pt);
+	const auto base = static_cast<uint32_t>(RealSeg(pt) << 4);
+	return base + RealOff(pt);
 }
 
 static inline PhysPt PhysMake(uint16_t seg, uint16_t off)
 {
-	return (seg << 4) + off;
+	const auto base = static_cast<uint32_t>(seg << 4);
+	return base + off;
 }
 
 static inline RealPt RealMake(uint16_t seg, uint16_t off)
 {
-	return (seg << 16) + off;
+	const auto base = static_cast<uint32_t>(seg << 16);
+	return base + off;
 }
 
 static inline void RealSetVec(uint8_t vec, RealPt pt)
 {
-	mem_writed(vec << 2, pt);
+	const auto target = static_cast<uint16_t>(vec << 2);
+	mem_writed(target, pt);
 }
 
 // TODO: consider dropping this function. The three places where it's called all
 // ignore the 3rd updated parameter.
 static inline void RealSetVec(uint8_t vec, RealPt pt, RealPt &old)
 {
-	old = mem_readd(vec << 2);
-	mem_writed(vec << 2, pt);
+	const auto target = static_cast<uint16_t>(vec << 2);
+	old = mem_readd(target);
+	mem_writed(target, pt);
 }
 
 static inline RealPt RealGetVec(uint8_t vec)
 {
-	return mem_readd(vec << 2);
+	const auto target = static_cast<uint16_t>(vec << 2);
+	return mem_readd(target);
 }
 
 #endif

--- a/include/mem.h
+++ b/include/mem.h
@@ -34,20 +34,20 @@ typedef int32_t MemHandle;
 #define MEM_PAGESIZE 4096
 
 extern HostPt MemBase;
-HostPt GetMemBase(void);
+HostPt GetMemBase();
 
-bool MEM_A20_Enabled(void);
+bool MEM_A20_Enabled();
 void MEM_A20_Enable(bool enable);
 
 /* Memory management / EMS mapping */
-HostPt MEM_GetBlockPage(void);
-Bitu MEM_FreeTotal(void);                  // Free 4 kb pages
-Bitu MEM_FreeLargest(void);                // Largest free 4 kb pages block
-Bitu MEM_TotalPages(void);                 // Total amount of 4 kb pages
+HostPt MEM_GetBlockPage();
+Bitu MEM_FreeTotal();                      // Free 4 KiB pages
+Bitu MEM_FreeLargest();                    // Largest free 4 KiB pages block
+Bitu MEM_TotalPages();                     // Total amount of 4 KiB pages
 Bitu MEM_AllocatedPages(MemHandle handle); // amount of allocated pages of handle
 MemHandle MEM_AllocatePages(Bitu pages, bool sequence);
-MemHandle MEM_GetNextFreePage(void);
-PhysPt MEM_AllocatePage(void);
+MemHandle MEM_GetNextFreePage();
+PhysPt MEM_AllocatePage();
 void MEM_ReleasePages(MemHandle handle);
 bool MEM_ReAllocatePages(MemHandle &handle, Bitu pages, bool sequence);
 

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -203,7 +203,7 @@ private:
 		int             getLength();
 		// This is a no-op because we track the audio position in all
 		// areas of this class.
-		void setAudioPosition(uint32_t pos) {}
+		void setAudioPosition(MAYBE_UNUSED uint32_t pos) {}
 	private:
 		Sound_Sample *sample = nullptr;
 	};

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -44,7 +44,26 @@ const Bit8u DOS_DATE_months[] = {
 	0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
 };
 
-static void DOS_AddDays(Bitu days) {
+uint16_t DOS_PackTime(uint16_t hour, uint16_t min, uint16_t sec)
+{
+	const auto h_bits = 0b1111100000000000 & (hour << 11);
+	const auto m_bits = 0b0000011111100000 & (min << 5);
+	const auto s_bits = 0b0000000000011111 & (sec / 2);
+	const auto packed = h_bits | m_bits | s_bits;
+	return static_cast<uint16_t>(packed);
+}
+
+uint16_t DOS_PackDate(uint16_t year, uint16_t mon, uint16_t day)
+{
+	const auto y_bits = 0b1111111000000000 & ((year - 1980) << 9);
+	const auto m_bits = 0b0000000111100000 & (mon << 5);
+	const auto d_bits = 0b0000000000011111 & day;
+	const auto packed = y_bits | m_bits | d_bits;
+	return static_cast<uint16_t>(packed);
+}
+
+static void DOS_AddDays(Bitu days)
+{
 	dos.date.day += days;
 	Bit8u monthlimit = DOS_DATE_months[dos.date.month];
 


### PR DESCRIPTION
These warnings are generated with clang++ 11 under the `warnmore` build type. I've listed them in the commits; suggest reviewing one by one.

_(Background: I wanted to work on `cdrom_image.cpp`, however these warnings cluttered the output, so I'd like to clear them out before moving on.)_

**Unit tests:**

I added unit tests (`tests/mem.cpp`) corresponding to handful of memory read/write changes in `mem.h`, which I've included in this PR.  

However, I wasn't able to include `mem.cpp` in tests's `Makefile.am` because getting it linked without missing symbols rippled into including all of dosbox's `.a` files (which was fine and somewhat expected), however at that point I had conflicting `main` functions (also expected), so I added `#if !defined(TEST)` around the `main(...)` function in sdlmain.cpp and then included a step to recompile it inside tests's Makefile.am, but that resulted in missing a bunch of callback symbols - so at that point, I gave up :-), and looking for help/suggestions in how to get this working.