### PR TITLE
Simplify and clarify FPU decimation loop

### DIFF
--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -297,6 +297,8 @@ static void FPU_FBST(PhysPt addr) {
 		return;
 	}
 
+	static_assert(sizeof(long long int) == sizeof(uint64_t),
+	              "long long int needs to match uint64_t in size");
 	//numbers from back to front
 	for(Bitu i=0;i<9;i++){
 		const lldiv_t div10 = lldiv(rndint, 10);

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -299,11 +299,12 @@ static void FPU_FBST(PhysPt addr) {
 
 	//numbers from back to front
 	for(Bitu i=0;i<9;i++){
-		Bit64u temp = rndint / 10;
-		Bit8u p = static_cast<Bit8u>(rndint % 10);
-		rndint = temp / 10;
-		p |= (static_cast<Bit8u>(temp % 10)) << 4;
-		mem_writeb(addr++,p);
+		const lldiv_t div10 = lldiv(rndint, 10);
+		const lldiv_t div100 = lldiv(div10.quot, 10);
+		const uint8_t p = static_cast<uint8_t>(div10.rem) |
+		                  (static_cast<uint8_t>(div100.rem) << 4);
+		mem_writeb(addr++, p);
+		rndint = div100.quot;
 	}
 	// flags? C1 should indicate if value was rounded up
 }


### PR DESCRIPTION
Replaces the four integer operations with two calls to std::div, which lets the compiler optimize the resulting assembly calls from:

## Original integer calls

**uint64_t temp = rndint / 10;**
``` asm
        mov     rax, QWORD PTR [rbp-8]
        movabs  rdx, -3689348814741910323
        mul     rdx
        mov     rax, rdx
        shr     rax, 3
        mov     QWORD PTR [rbp-16], rax
```

**uint8_t p = static_cast<uint8_t>(rndint % 10);**
``` asm
        mov     rcx, QWORD PTR [rbp-8]
        movabs  rdx, -3689348814741910323
        mov     rax, rcx
        mul     rdx
        shr     rdx, 3
        mov     rax, rdx
        sal     rax, 2
        add     rax, rdx
        add     rax, rax
        sub     rcx, rax
        mov     rdx, rcx
        mov     BYTE PTR [rbp-17], dl
```

**rndint = temp / 10;**
``` asm
        mov     rax, QWORD PTR [rbp-16]
        movabs  rdx, -3689348814741910323
        mul     rdx
        mov     rax, rdx
        shr     rax, 3
        mov     QWORD PTR [rbp-8], rax
```

**p |= (static_cast<uint8_t>(temp % 10)) << 4;**
``` asm
        mov     rcx, QWORD PTR [rbp-16]
        movabs  rdx, -3689348814741910323
        mov     rax, rcx
        mul     rdx
        shr     rdx, 3
        mov     rax, rdx
        sal     rax, 2
        add     rax, rdx
        add     rax, rax
        sub     rcx, rax
        mov     rdx, rcx
        mov     eax, edx
        movzx   eax, al
        sal     eax, 4
        mov     edx, eax
        movzx   eax, BYTE PTR [rbp-17]
        or      eax, edx
        mov     BYTE PTR [rbp-17], al
```

## standard library calls to DIV

**const lldiv_t div10 = lldiv(rndint, 10);**
``` asm
        mov     rax, QWORD PTR [rbp-8]
        mov     esi, 10
        mov     rdi, rax
        call    lldiv
        mov     QWORD PTR [rbp-48], rax
        mov     QWORD PTR [rbp-40], rdx
```

**const lldiv_t div100 = lldiv(div10.quot, 10);**
``` asm
        mov     rax, QWORD PTR [rbp-48]
        mov     esi, 10
        mov     rdi, rax
        call    lldiv
        mov     QWORD PTR [rbp-64], rax
        mov     QWORD PTR [rbp-56], rdx
```

**p = static_cast<uint8_t>(div10.rem) | (static_cast<uint8_t>(div100.rem) << 4);**

``` asm
        mov     rax, QWORD PTR [rbp-40]
        mov     edx, eax
        mov     rax, QWORD PTR [rbp-56]
        movzx   eax, al
        sal     eax, 4
        or      eax, edx
        mov     BYTE PTR [rbp-17], al
```

**rndint = div100.quot;**
``` asm
        mov     rax, QWORD PTR [rbp-64]
        mov     QWORD PTR [rbp-8], rax
```

## References
  - Assembly comparison: https://godbolt.org/z/Tx5zYc
  - Runtime comparison: https://onlinegdb.com/HyZTi5vSD