### PR TITLE
Return error code when handling DOS function 57h

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -872,17 +872,18 @@ static Bitu DOS_21Handler(void) {
 		}
 		break;		
 	case 0x57:					/* Get/Set File's Date and Time */
-		if (reg_al==0x00) {
-			if (DOS_GetFileDate(reg_bx,&reg_cx,&reg_dx)) {
+		if (reg_al == 0x00) {
+			if (DOS_GetFileDate(reg_bx, &reg_cx, &reg_dx)) {
 				CALLBACK_SCF(false);
 			} else {
+				reg_ax = dos.errorcode;
 				CALLBACK_SCF(true);
 			}
-		} else if (reg_al==0x01) {
-			/* FIXME: verify if AX needs to be updated here */
+		} else if (reg_al == 0x01) {
 			if (DOS_SetFileDate(reg_bx, reg_cx, reg_dx)) {
 				CALLBACK_SCF(false);
 			} else {
+				reg_ax = dos.errorcode;
 				CALLBACK_SCF(true);
 			}
 		} else {


### PR DESCRIPTION
Both functions 5700h (Get file time/date) and 5701h (Set file time/date)
return error code in register AX.

See:
https://dos4gw.org/DOS_Fn_5700H_Query_File_Time_Date
https://dos4gw.org/DOS_Fn_5701H_Set_File_Time_Date
http://spike.scu.edu.au/~barry/interrupts.html#ah57