### PR TITLE
Clear modem phone book on serial ports shutdown

### DIFF
--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1308,6 +1308,8 @@ public:
 	}
 
 	~SERIALPORTS () {
+		MODEM_ClearPhonebook();
+
 		for (uint8_t i = 0; i < SERIAL_MAX_PORTS; ++i)
 			if (serialports[i]) {
 				delete serialports[i];

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -51,7 +51,7 @@ private:
 	std::string address;
 };
 
-static std::vector<PhonebookEntry *> phones;
+static std::vector<PhonebookEntry> phones;
 static const char phoneValidChars[] = "01234567890*=,;#+>";
 
 static bool MODEM_IsPhoneValid(const std::string &input) {
@@ -89,17 +89,21 @@ bool MODEM_ReadPhonebook(const std::string &filename) {
 
 		LOG_MSG("SERIAL: Phonebook mapped %s to address %s.", phone.c_str(),
 		        address.c_str());
-		PhonebookEntry *pbEntry = new PhonebookEntry(phone, address);
-		phones.push_back(pbEntry);
+		phones.emplace_back(phone, address);
 	}
 
 	return true;
 }
 
+void MODEM_ClearPhonebook()
+{
+	phones.clear();
+}
+
 static const char *MODEM_GetAddressFromPhone(const char *input) {
-	for (const auto entry : phones) {
-		if (entry->IsMatchingPhone(input))
-			return entry->GetAddress().c_str();
+	for (const auto &entry : phones) {
+		if (entry.IsMatchingPhone(input))
+			return entry.GetAddress().c_str();
 	}
 
 	return nullptr;

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -58,6 +58,7 @@ enum ResTypes {
 #define TEL_SERVER 1
 
 bool MODEM_ReadPhonebook(const std::string &filename);
+void MODEM_ClearPhonebook();
 
 class CFifo {
 public:


### PR DESCRIPTION
This fixes a memory leak of sorts introduced in https://github.com/dosbox-staging/dosbox-staging/pull/226.
Turns out serial ports are re-initialized every time you change any of serialX parameters at runtime and this, in turn, re-parses phone book file, potentially filling up the phones list with endless duplicate entries.