### PR TITLE
Avoid dropping the last character when appending shell commands

### DIFF
--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -123,9 +123,9 @@ emptyline:
 	// Finally it moves the cmd_write pointer ahead by the length copied.
 	auto append_cmd_write = [&cmd_write, &line](const char *src) {
 		const auto src_len = strlen(src);
-		const auto req_len = cmd_write - line + static_cast<int>(src_len);
-		if (req_len < CMD_MAXLINE - 1) {
-			safe_strncpy(cmd_write, src, src_len);
+		const auto req_len = cmd_write - line + static_cast<int>(src_len) + 1;
+		if (src_len && req_len < CMD_MAXLINE) {
+			safe_strncpy(cmd_write, src, req_len);
 			cmd_write += src_len;
 		}
 	};


### PR DESCRIPTION
Fixes #623 

**Tests:**
- Pre-expansion
- Post-expansion
- Multi-char expansion
- With and without trailing backslash
- Single character variables

``` ini
[autoexec]
mount c .
set PATH=%PATH%;C:\
PATH
set PATH=%PATH%;A;B;D
PATH
set PATH=%PATH%;E:
PATH
set PATH=F:\;%PATH%;G:\
PATH
```

**Produces:**

![2020-09-25_17-18](https://user-images.githubusercontent.com/1557255/94325422-210ba080-ff53-11ea-982a-4ef21fac8924.png)

Tested countless other typical commands (both inside `[autoexec]` and entered at runtime), including: `mount`, `imgmount`, `cd`, `echo`, `@echo off`, `autotype`, `exit`, batch execution w/ `choice.exe` and `goto` statements -- all without  regressions.

@NicknineTheEagle, can you give this a whirl?