### PR TITLE
Make the PC Speaker's DC-offset correction optional

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -712,9 +712,17 @@ void DOSBOX_Init(void) {
 	pint->SetMinMax(8000, 48000);
 	pint->Set_help("Sample rate of the PC-Speaker sound generation.");
 
-	secprop->AddInitFunction(&TANDYSOUND_Init,true);//done
-	const char* tandys[] = { "auto", "on", "off", 0};
-	Pstring = secprop->Add_string("tandy",Property::Changeable::WhenIdle,"auto");
+	const char *pc_zero_offset_opts[] = {"auto", "true", "false", 0};
+	pstring = secprop->Add_string("pc_zero_offset", when_idle, pc_zero_offset_opts[0]);
+	pstring->Set_values(pc_zero_offset_opts);
+	pstring->Set_help(
+	        "Neutralizes and prevents the PC speaker's DC-offset from harming other sources.\n"
+	        "'auto' enables this for non-Windows systems and disables it on Windows.\n"
+	        "If your OS performs its own DC-offset correction, then set this to 'false'.");
+
+	secprop->AddInitFunction(&TANDYSOUND_Init, true);
+	const char *tandys[] = {"auto", "on", "off", 0};
+	Pstring = secprop->Add_string("tandy", when_idle, "auto");
 	Pstring->Set_values(tandys);
 	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
 

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -87,6 +87,7 @@ static struct {
 	int16_t last_played_sample = 0;
 	uint16_t prev_pos = 0u;
 	uint8_t idle_countdown = 0u;
+	bool neutralize_dc_offset = true;
 } spkr;
 
 static bool SpeakerExists()
@@ -448,7 +449,12 @@ static void PCSPEAKER_CallBack(Bitu len)
 		spkr.prev_pos = pos;
 		*stream++=(Bit16s)(value/sample_add);
 	}
-	PlayOrFadeout(pos, len, reinterpret_cast<int16_t *>(MixTemp));
+
+	int16_t *buffer = reinterpret_cast<int16_t *>(MixTemp);
+	if (spkr.neutralize_dc_offset)
+		PlayOrFadeout(pos, len, buffer);
+	else
+		spkr.chan->AddSamples_m16(len, buffer);
 }
 class PCSPEAKER:public Module_base {
 private:
@@ -460,6 +466,16 @@ public:
 		if (!section->Get_bool("pcspeaker"))
 			return;
 		spkr.rate = std::max(section->Get_int("pcrate"), 8000);
+
+		std::string dc_offset_pref = section->Get_string("pc_zero_offset");
+		if (dc_offset_pref == "auto")
+#if !defined(WIN32)
+			spkr.neutralize_dc_offset = true;
+#else
+			spkr.neutralize_dc_offset = false;
+#endif
+		else
+			spkr.neutralize_dc_offset = (dc_offset_pref == "true");
 
 		spkr.dc_silencer.Configure(static_cast<uint32_t>(spkr.rate),
 		                           DC_SILENCER_WAVES, DC_SILENCER_WAVE_HZ);


### PR DESCRIPTION
In addition to some RealTek audio manager drivers, Windows 10 appears to have also started performing its own mandatory audio post processing, including a poor(*) form of DC-offset correction.

Thanks to @OpenRift412 for reporting this in https://github.com/dosbox-staging/dosbox-staging/issues/619, and to @NicknineTheEagle for confirming and testing various work-arounds. 

(*) The Window 10 post-processor introduces a lagging positive bias in the signal, which influence any subsequent signal, as flagged by audacity users who say their wavforms _"go astray"_: 

![Tape Hiss Macro View](https://user-images.githubusercontent.com/1557255/94344225-a2eede80-ffd2-11ea-8abc-934d90362bfe.PNG)
![Tape Hiss Micro- View- +10db](https://user-images.githubusercontent.com/1557255/94344226-a3877500-ffd2-11ea-9434-b6cfd7a7e886.PNG)

In our case, the DC silencer's waveform goes from being neutrally-offset around zero to instead being positively offset (as seen the right-hand-side of the image below), resulting in becoming audible instead of silent:

![2020-09-25_18-13](https://user-images.githubusercontent.com/1557255/94344203-8b175a80-ffd2-11ea-84e6-65d413bc8bcf.png)

Because this occurs downstream from dosbox, we have no way of either detecting it at runtime or compensating for it; therefore we instead provide an option to disable DC-offset correction.

Fixes #619 

@OpenRift412 and @NicknineTheEagle -- can you test this branch?
In your `dosbox.conf`, add `neutralize_dc_offset = false` under your `[speaker]` section.