### PR TITLE
Mass-replace safe_strncpy with safe_strcpy

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 317
+            max_warnings: 298
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2036
+            max_warnings: 2017
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -246,8 +246,14 @@ bool GetDescriptorInfo(char* selname, char* out1, char* out2)
 class CDebugVar
 {
 public:
-	CDebugVar(char* _name, PhysPt _adr) { adr=_adr; safe_strncpy(name,_name,16); hasvalue = false; value = 0; };
-	
+	CDebugVar(const char *vname, PhysPt address)
+	        : adr(address),
+	          hasvalue(false),
+	          value(0)
+	{
+		safe_strcpy(name, vname);
+	}
+
 	char*  GetName (void)                 { return name; };
 	PhysPt GetAdr  (void)                 { return adr; };
 	void   SetValue(bool has, Bit16u val) { hasvalue = has; value=val; };
@@ -1704,19 +1710,23 @@ Bit32u DEBUG_CheckKeys(void) {
 				if (histBuffPos == histBuff.begin()) break;
 				if (histBuffPos == histBuff.end()) {
 					// copy inputStr to suspInputStr so we can restore it
-					safe_strncpy(codeViewData.suspInputStr, codeViewData.inputStr, sizeof(codeViewData.suspInputStr));
+					safe_strcpy(codeViewData.suspInputStr,
+					            codeViewData.inputStr);
 				}
-				safe_strncpy(codeViewData.inputStr,(*--histBuffPos).c_str(),sizeof(codeViewData.inputStr));
+				safe_strcpy(codeViewData.inputStr,
+				            (--histBuffPos)->c_str());
 				codeViewData.inputPos = strlen(codeViewData.inputStr);
 				break;
 		case KEY_F(7):	// next command (f1-f4 generate rubbish at my place)
 		case KEY_F(4):	// next command
 				if (histBuffPos == histBuff.end()) break;
 				if (++histBuffPos != histBuff.end()) {
-					safe_strncpy(codeViewData.inputStr,(*histBuffPos).c_str(),sizeof(codeViewData.inputStr));
+					safe_strcpy(codeViewData.inputStr,
+					            histBuffPos->c_str());
 				} else {
 					// copy suspInputStr back into inputStr
-					safe_strncpy(codeViewData.inputStr, codeViewData.suspInputStr, sizeof(codeViewData.inputStr));
+					safe_strcpy(codeViewData.inputStr,
+					            codeViewData.suspInputStr);
 				}
 				codeViewData.inputPos = strlen(codeViewData.inputStr);
 				break; 
@@ -2141,7 +2151,7 @@ public:
 		if (!cmd->FindCommand(commandNr++,temp_line)) return;
 		// Get filename
 		char filename[128];
-		safe_strncpy(filename,temp_line.c_str(),128);
+		safe_strcpy(filename, temp_line.c_str());
 		// Setup commandline
 		char args[256+1];
 		args[0]	= 0;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -217,7 +217,7 @@ static void LOG_Init(Section * sec) {
 	sect->AddDestroyFunction(&LOG_Destroy);
 	char buf[64];
 	for (Bitu i = LOG_ALL + 1;i < LOG_MAX;i++) { //Skip LOG_ALL, it is always enabled
-		safe_strncpy(buf,loggrp[i].front,sizeof(buf));
+		safe_strcpy(buf, loggrp[i].front);
 		lowcase(buf);
 		loggrp[i].enabled=sect->Get_bool(buf);
 	}
@@ -262,7 +262,7 @@ void LOG_StartUp(void) {
 	Pstring->Set_help("file where the log messages will be saved to");
 	char buf[64];
 	for (Bitu i = LOG_ALL + 1;i < LOG_MAX;i++) {
-		safe_strncpy(buf,loggrp[i].front, sizeof(buf));
+		safe_strcpy(buf, loggrp[i].front);
 		lowcase(buf);
 		Prop_bool* Pbool = sect->Add_bool(buf,Property::Changeable::Always,true);
 		Pbool->Set_help("Enable/Disable logging of this type.");

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1176,7 +1176,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 	bool success;
 	bool canAddTrack = false;
 	char tmp[MAX_FILENAME_LENGTH];  // dirname can change its argument
-	safe_strncpy(tmp, cuefile, MAX_FILENAME_LENGTH);
+	safe_strcpy(tmp, cuefile);
 	string pathname(dirname(tmp));
 	ifstream in;
 	in.open(cuefile, ios::in);
@@ -1406,7 +1406,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 	// finally check if file is in a dosbox local drive
 	char fullname[CROSS_LEN];
 	char tmp[CROSS_LEN];
-	safe_strncpy(tmp, filename.c_str(), CROSS_LEN);
+	safe_strcpy(tmp, filename.c_str());
 	Bit8u drive;
 	if (!DOS_MakeName(tmp, fullname, &drive)) {
 		return false;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1057,7 +1057,7 @@ void LOADFIX::Run(void)
 		if (cmd->FindCommand(commandNr++,temp_line)) {
 			// get Filename
 			char filename[128];
-			safe_strncpy(filename,temp_line.c_str(),128);
+			safe_strcpy(filename, temp_line.c_str());
 			// Setup commandline
 			char args[256+1];
 			args[0] = 0;
@@ -1294,7 +1294,7 @@ public:
 					// convert dosbox filename to system filename
 					char fullname[CROSS_LEN];
 					char tmp[CROSS_LEN];
-					safe_strncpy(tmp, temp_line.c_str(), CROSS_LEN);
+					safe_strcpy(tmp, temp_line.c_str());
 
 					Bit8u dummy;
 					if (!DOS_MakeName(tmp, fullname, &dummy) || strncmp(Drives[dummy]->GetInfo(),"local directory",15)) {

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -565,14 +565,10 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 	Bits	len			= 0;
 	bool	createShort = false;
 
-	char tmpNameBuffer[CROSS_LEN];
-
-	char* tmpName = tmpNameBuffer;
-
 	// Remove Spaces
-	// avoid using safe_strncpy to prevent GCC warning about truncation on an incomplete copy
-	strncpy(tmpName, info->orgname, CROSS_LEN);
-	tmpName[CROSS_LEN - 1] = '\0'; // zero-terminate even if the source wasn't
+	char tmpNameBuffer[CROSS_LEN];
+	safe_strcpy(tmpNameBuffer, info->orgname);
+	char* tmpName = tmpNameBuffer;
 	upcase(tmpName);
 	createShort = RemoveSpaces(tmpName);
 
@@ -665,7 +661,7 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 			curDir->longNameList.push_back(info);
 		}
 	} else {
-		safe_strncpy(info->shortname, tmpName, DOS_NAMELENGTH_ASCII);
+		safe_strcpy(info->shortname, tmpName);
 	}
 	RemoveTrailingDot(info->shortname);
 }

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -157,7 +157,7 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
 	memset(sectorHashEntries, 0, sizeof(sectorHashEntries));
 	memset(&rootEntry, 0, sizeof(isoDirEntry));
 
-	safe_strncpy(this->fileName, fileName, CROSS_LEN);
+	safe_strcpy(this->fileName, fileName);
 	error = UpdateMscdex(driveLetter, fileName, subUnit);
 
 	if (!error) {
@@ -191,7 +191,7 @@ int isoDrive::UpdateMscdex(char drive_letter, const char *path, uint8_t &sub_uni
 		CDROM_Interface_Image *oldCdrom = CDROM_Interface_Image::images[sub_unit];
 		CDROM_Interface *cdrom = new CDROM_Interface_Image(sub_unit);
 		char pathCopy[CROSS_LEN];
-		safe_strncpy(pathCopy, path, CROSS_LEN);
+		safe_strcpy(pathCopy, path);
 		if (!cdrom->SetDevice(pathCopy)) {
 			CDROM_Interface_Image::images[sub_unit] = oldCdrom;
 			delete cdrom;
@@ -544,7 +544,7 @@ bool isoDrive :: lookup(isoDirEntry *de, const char *path) {
 	if (!strcmp(path, "")) return true;
 
 	char isoPath[ISO_MAXPATHNAME];
-	safe_strncpy(isoPath, path, ISO_MAXPATHNAME);
+	safe_strcpy(isoPath, path);
 	strreplace(isoPath, '\\', '/');
 
 	// iterate over all path elements (name), and search each of them in the current de

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -113,10 +113,9 @@ static CBindList holdlist;
 
 class CEvent {
 public:
-	CEvent(char const * const _entry)
-		: bindlist{}
+	CEvent(const char *ev_entry) : bindlist{}
 	{
-		safe_strncpy(entry, _entry, sizeof(entry));
+		safe_strcpy(entry, ev_entry);
 		events.push_back(this);
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2081,7 +2081,7 @@ static void GUI_StartUp(Section * sec) {
 	sdl.desktop.full.height = 0;
 	if(fullresolution && *fullresolution) {
 		char res[100];
-		safe_strncpy( res, fullresolution, sizeof( res ));
+		safe_strcpy(res, fullresolution);
 		fullresolution = lowcase (res);//so x and X are allowed
 		if (strcmp(fullresolution,"original")) {
 			sdl.desktop.full.fixed = true;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -850,7 +850,7 @@ static void MIXER_ProgramStart(Program * * make) {
 MixerChannel* MixerObject::Install(MIXER_Handler handler,Bitu freq,const char * name){
 	if(!installed) {
 		if(strlen(name) > 31) E_Exit("Too long mixer channel name");
-		safe_strncpy(m_name,name,32);
+		safe_strcpy(m_name, name);
 		installed = true;
 		return MIXER_AddChannel(handler,freq,name);
 	} else {

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -215,7 +215,7 @@ imageDisk::imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, 
 {
 	fseek(diskimg,0,SEEK_SET);
 	memset(diskname,0,512);
-	safe_strncpy(diskname, img_name, sizeof(diskname));
+	safe_strcpy(diskname, img_name);
 	if (!is_hdd) {
 		Bit8u i=0;
 		bool founddisk = false;

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -159,7 +159,7 @@ public:
 
 		// try to use port specified in config file
 		if (conf && conf[0]) {
-			safe_strncpy(var, conf, 10);
+			safe_strcpy(var, conf);
 			if (!parse_addr(var, &seq_client, &seq_port)) {
 				LOG_MSG("ALSA: Invalid alsa port %s", var);
 				return false;

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -49,7 +49,8 @@ public:
 	bool Open(const char *conf) override
 	{
 		char devname[512];
-		if (conf && conf[0]) safe_strncpy(devname,conf,512);
+		if (conf && conf[0])
+			safe_strcpy(devname, conf);
 		else strcpy(devname,"/dev/sequencer");
 		char * devfind=(strrchr(devname,','));
 		if (devfind) {

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -139,7 +139,7 @@ static void W32_ConfDir(std::string& in,bool create) {
 	if(!r || result[0] == 0) {
 		char const * windir = getenv("windir");
 		if(!windir) windir = "c:\\windows";
-		safe_strncpy(result,windir,MAX_PATH);
+		safe_strcpy(result, windir);
 		char const* appdata = "\\Application Data";
 		size_t len = strlen(result);
 		if (len + strlen(appdata) < MAX_PATH)
@@ -282,7 +282,7 @@ void close_directory(dir_information* dirp) {
 dir_information* open_directory(const char* dirname) {
 	static dir_information dir;
 	dir.dir=opendir(dirname);
-	safe_strncpy(dir.base_path,dirname,CROSS_LEN);
+	safe_strcpy(dir.base_path, dirname);
 	return dir.dir?&dir:NULL;
 }
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -751,7 +751,7 @@ bool Config::PrintConfig(const std::string &filename) const
 
 	for (const_it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel){
 		/* Print out the Section header */
-		safe_strncpy(temp,(*tel)->GetName(),sizeof(temp));
+		safe_strcpy(temp, (*tel)->GetName());
 		lowcase(temp);
 		fprintf(outfile,"[%s]\n",temp);
 
@@ -972,7 +972,7 @@ bool Config::ParseConfigFile(char const * const configfilename) {
 void Config::ParseEnv(char ** envp) {
 	for(char** env=envp; *env;env++) {
 		char copy[1024];
-		safe_strncpy(copy,*env,1024);
+		safe_strcpy(copy, *env);
 		if(strncasecmp(copy,"DOSBOX_",7))
 			continue;
 		char* sec_name = &copy[7];

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -261,7 +261,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 
 		char dir_source[DOS_PATHLENGTH + 4] = {0}; //not sure if drive portion is included in pathlength
 		//Copy first and then modify, makes GCC happy
-		safe_strncpy(dir_source,arg1,DOS_PATHLENGTH + 4);
+		safe_strcpy(dir_source, arg1);
 		char* dummy = strrchr(dir_source,'\\');
 		if (!dummy) { //Possible due to length
 			WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
@@ -292,7 +292,7 @@ void DOS_Shell::CMD_ECHO(char * args){
 	}
 	char buffer[512];
 	char* pbuffer = buffer;
-	safe_strncpy(buffer,args,512);
+	safe_strcpy(buffer, args);
 	StripSpaces(pbuffer);
 	if (strcasecmp(pbuffer,"OFF") == 0) {
 		echo=false;
@@ -931,7 +931,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 				plus = strchr(source_p,'+');
 			}
 			if (plus) *plus++ = 0;
-			safe_strncpy(source_x,source_p,CROSS_LEN);
+			safe_strcpy(source_x, source_p);
 			bool has_drive_spec = false;
 			size_t source_x_len = strlen(source_x);
 			if (source_x_len>0) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -263,7 +263,7 @@ void DOS_Shell::InputCommand(char * line) {
 							//Beep;
 							break;
 						}
-						safe_strncpy(mask, p_completion_start,DOS_PATHLENGTH);
+						safe_strcpy(mask, p_completion_start);
 						char* dot_pos=strrchr(mask,'.');
 						char* bs_pos=strrchr(mask,'\\');
 						char* fs_pos=strrchr(mask,'/');
@@ -391,10 +391,8 @@ bool DOS_Shell::Execute(char * name,char * args) {
 			line[0]=' ';line[1]=0;
 			strncat(line,args,CMD_MAXLINE-2);
 			line[CMD_MAXLINE-1]=0;
-		}
-		else
-		{
-			safe_strncpy(line,args,CMD_MAXLINE);
+		} else {
+			safe_strcpy(line, args);
 		}
 	}else{
 		line[0]=0;


### PR DESCRIPTION
Macro safe_strncpy(dst, src, size) is not really "safe", because it is
supposed to be used with size being available space in dst (that's how
strncpy works), but users sometimes pass length of src in there (which
leads to macro overwriting last character in string with terminating
null byte). In result, user needs to remember to add 1 to size (and it's
unclear when this is intentional and when it's not).

On the other hand, when buffer size is known at compilation time, then
we can safely pass it to safe_strcpy(char (&dst)[N], const char *src)
and let C++ type system fill-in dst buffer size for us (ensuring no
buffer overflow, and that terminating 0-byte will always be there).

Convert following trivial cases:

         char foo[N];
    -    safe_strncpy(foo, bar, N);
    +    safe_strcpy(foo, bar);

         char foo[N];
    -    safe_strncpy(foo, bar, sizeof(foo));
    +    safe_strcpy(foo, bar);

After this change there are still 26 uses of safe_strncpy left - those
cannot be easily replaced with safe_strcpy or it's unclear if
overwriting of the last character in those is intentional or not.