### PR TITLE
Environment variable expansion in DOS shell

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -80,6 +80,7 @@ public:
 	void ParseLine(char * line);
 	Bitu GetRedirection(char *s, char **ifn, char **ofn,bool * append);
 	void InputCommand(char * line);
+	void ProcessCmdLineEnvVarStitution(char *line);
 	void ShowPrompt();
 	void DoCommand(char * cmd);
 	bool Execute(char * name,char * args);


### PR DESCRIPTION
As suggested in Issue #628, environment variable expansion does not work in dosbox-staging's DOS shell. It however does work in DOSBox-X's DOS shell, so I have ported the code from DOSBox-X (the original code was not written by me). Tested the code in dosbox-staging and seems to work.