### PR TITLE
Fix a bunch of -Wswitch warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,20 +21,20 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 61
+            max_warnings: 59
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 63
+            max_warnings: 61
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 63
+            max_warnings: 61
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 8
+            max_warnings: 7
           - name: Ubuntu, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 173
+            max_warnings: 171
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 63
+            max_warnings: 61
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 210
+            max_warnings: 208
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 61
+            max_warnings: 59
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,20 +21,20 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 59
+            max_warnings: 57
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 61
+            max_warnings: 59
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 61
+            max_warnings: 59
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 7
+            max_warnings: 6
           - name: Ubuntu, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 171
+            max_warnings: 169
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 61
+            max_warnings: 59
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 208
+            max_warnings: 206
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 59
+            max_warnings: 57
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,20 +21,20 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 53
+            max_warnings: 52
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 55
+            max_warnings: 54
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 55
+            max_warnings: 54
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 4
+            max_warnings: 3
           - name: Ubuntu, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 165
+            max_warnings: 164
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 55
+            max_warnings: 54
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 202
+            max_warnings: 201
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 53
+            max_warnings: 52
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,7 +94,7 @@ jobs:
         if:   matrix.conf.run_tests != true
         env:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
-        run:  ./scripts/count-warnings.py build.log
+        run:  ./scripts/count-warnings.py -f build.log
 
   build_linux_release_dynamic:
     name: Release build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,20 +21,20 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 55
+            max_warnings: 53
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 57
+            max_warnings: 55
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 57
+            max_warnings: 55
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 5
+            max_warnings: 4
           - name: Ubuntu, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 167
+            max_warnings: 165
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 57
+            max_warnings: 55
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 204
+            max_warnings: 202
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 55
+            max_warnings: 53
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,20 +21,20 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 57
+            max_warnings: 55
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 59
+            max_warnings: 57
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 59
+            max_warnings: 57
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 6
+            max_warnings: 5
           - name: Ubuntu, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 169
+            max_warnings: 167
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 59
+            max_warnings: 57
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 206
+            max_warnings: 204
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 57
+            max_warnings: 55
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 4
+            max_warnings: 3
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 59
+            max_warnings: 57
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 5
+            max_warnings: 4
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 61
+            max_warnings: 59
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 6
+            max_warnings: 5
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 63
+            max_warnings: 61
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 3
+            max_warnings: 2
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 57
+            max_warnings: 55
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 2
+            max_warnings: 1
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 55
+            max_warnings: 54
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Summarize warnings
         env:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
-        run:  python3 ./scripts/count-warnings.py build.log
+        run:  python3 ./scripts/count-warnings.py -f build.log
 
   build_macos_release:
     name: Release build

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 471
+          MAX_BUGS: 470
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 475
+          MAX_BUGS: 474
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 473
+          MAX_BUGS: 472
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 472
+          MAX_BUGS: 471
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 474
+          MAX_BUGS: 473
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -187,7 +187,7 @@ void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu
 void INT10_ReloadFont(void);
 
 /* Palette Group */
-void INT10_SetBackgroundBorder(Bit8u val);
+void INT10_SetBackgroundBorder(uint8_t val);
 void INT10_SetColorSelect(Bit8u val);
 void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val);
 void INT10_SetOverscanBorderColor(uint8_t val);

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -190,7 +190,7 @@ void INT10_ReloadFont(void);
 void INT10_SetBackgroundBorder(Bit8u val);
 void INT10_SetColorSelect(Bit8u val);
 void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val);
-void INT10_SetOverscanBorderColor(Bit8u val);
+void INT10_SetOverscanBorderColor(uint8_t val);
 void INT10_SetAllPaletteRegisters(PhysPt data);
 void INT10_ToggleBlinkingBit(Bit8u state);
 void INT10_GetSinglePaletteRegister(Bit8u reg,Bit8u * val);

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -189,7 +189,7 @@ void INT10_ReloadFont(void);
 /* Palette Group */
 void INT10_SetBackgroundBorder(Bit8u val);
 void INT10_SetColorSelect(Bit8u val);
-void INT10_SetSinglePaletteRegister(Bit8u reg,Bit8u val);
+void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val);
 void INT10_SetOverscanBorderColor(Bit8u val);
 void INT10_SetAllPaletteRegisters(PhysPt data);
 void INT10_ToggleBlinkingBit(Bit8u state);

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -175,7 +175,7 @@ void INT10_SetCursorPos(Bit8u row,Bit8u col,Bit8u page);
 void INT10_TeletypeOutput(Bit8u chr,Bit8u attr);
 void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr);
 void INT10_ReadCharAttr(Bit16u * result,Bit8u page);
-void INT10_WriteChar(Bit8u chr,Bit8u attr,Bit8u page,Bit16u count,bool showattr);
+void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bool showattr);
 void INT10_WriteString(Bit8u row,Bit8u col,Bit8u flag,Bit8u attr,PhysPt string,Bit16u count,Bit8u page);
 
 /* Graphics Stuff */

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -587,7 +587,8 @@ void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit8u chr,Bit8u attr,bool useatt
 	}
 }
 
-void INT10_WriteChar(Bit8u chr,Bit8u attr,Bit8u page,Bit16u count,bool showattr) {
+void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bool showattr)
+{
 	Bit8u pospage=page;
 	if (CurMode->type!=M_TEXT) {
 		showattr=true; //Use attr in graphics mode always
@@ -608,6 +609,9 @@ void INT10_WriteChar(Bit8u chr,Bit8u attr,Bit8u page,Bit16u count,bool showattr)
 			case MCH_PCJR:
 				page=0;
 				pospage=0;
+				break;
+			case MCH_HERC:
+			case MCH_TANDY:
 				break;
 		}
 	}

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -90,7 +90,8 @@ void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val)
 	}
 }
 
-void INT10_SetOverscanBorderColor(Bit8u val) {
+void INT10_SetOverscanBorderColor(uint8_t val)
+{
 	switch (machine) {
 	case TANDY_ARCH_CASE:
 		IO_Read(VGAREG_TDY_RESET);
@@ -102,6 +103,9 @@ void INT10_SetOverscanBorderColor(Bit8u val) {
 		IO_Write(VGAREG_ACTL_ADDRESS,0x11);
 		IO_Write(VGAREG_ACTL_WRITE_DATA,val);
 		IO_Write(VGAREG_ACTL_ADDRESS,32);		//Enable output and protect palette
+		break;
+	case MCH_HERC:
+	case MCH_CGA:
 		break;
 	}
 }

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -33,7 +33,8 @@ static INLINE void WriteTandyACTL(Bit8u creg,Bit8u val) {
 	else IO_Write(VGAREG_PCJR_DATA,val);
 }
 
-void INT10_SetSinglePaletteRegister(Bit8u reg,Bit8u val) {
+void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val)
+{
 	switch (machine) {
 	case MCH_PCJR:
 		reg&=0xf;
@@ -63,7 +64,7 @@ void INT10_SetSinglePaletteRegister(Bit8u reg,Bit8u val) {
 					if (color_select& 0x20) reg++; // Cyan Magenta White
 				}
 				WriteTandyACTL(reg+0x10,val);
-			} 
+			}
 			// 4-color high resolution mode 0x0a isn't handled specially
 			else WriteTandyACTL(reg+0x10,val);
 			break;
@@ -83,9 +84,11 @@ void INT10_SetSinglePaletteRegister(Bit8u reg,Bit8u val) {
 		}
 		IO_Write(VGAREG_ACTL_ADDRESS,32);		//Enable output and protect palette
 		break;
+	case MCH_HERC:
+	case MCH_CGA:
+		break;
 	}
 }
-
 
 void INT10_SetOverscanBorderColor(Bit8u val) {
 	switch (machine) {

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -110,7 +110,8 @@ void INT10_SetOverscanBorderColor(uint8_t val)
 	}
 }
 
-void INT10_SetAllPaletteRegisters(PhysPt data) {
+void INT10_SetAllPaletteRegisters(PhysPt data)
+{
 	switch (machine) {
 	case TANDY_ARCH_CASE:
 		IO_Read(VGAREG_TDY_RESET);
@@ -134,6 +135,9 @@ void INT10_SetAllPaletteRegisters(PhysPt data) {
 		IO_Write(VGAREG_ACTL_ADDRESS,0x11);
 		IO_Write(VGAREG_ACTL_WRITE_DATA,mem_readb(data));
 		IO_Write(VGAREG_ACTL_ADDRESS,32);		//Enable output and protect palette
+		break;
+	case MCH_HERC:
+	case MCH_CGA:
 		break;
 	}
 }

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -316,11 +316,12 @@ void INT10_GetPelMask(Bit8u & mask) {
 	mask=IO_Read(VGAREG_PEL_MASK);
 }
 
-void INT10_SetBackgroundBorder(Bit8u val) {
+void INT10_SetBackgroundBorder(uint8_t val)
+{
 	Bit8u color_select=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
 	color_select=(color_select & 0xe0) | (val & 0x1f);
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL,color_select);
-	
+
 	switch (machine) {
 	case MCH_CGA:
 		// only write the color select register
@@ -337,7 +338,7 @@ void INT10_SetBackgroundBorder(Bit8u val) {
 			IO_Write(0x3d9, color_select);
 			break;
 		case 0x07: // Tandy monochrome not implemented
-			break; 
+			break;
 		case 0x08:
 		case 0x09: // 16-color: write to color select, border and pal. index 0
 			INT10_SetOverscanBorderColor(val);
@@ -374,6 +375,8 @@ void INT10_SetBackgroundBorder(Bit8u val) {
 		INT10_SetSinglePaletteRegister( 2, val );
 		val+=2;
 		INT10_SetSinglePaletteRegister( 3, val );
+		break;
+	case MCH_HERC:
 		break;
 	}
 }


### PR DESCRIPTION
All are fixed the same way (by simply doing nothing for missing enum values), but every commit explains why it's ok to ignore the handling for those specific cases.