### PR TITLE
Override SDL2 disabling the screensaver

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2149,6 +2149,8 @@ static void GUI_StartUp(Section * sec) {
 		sdl.desktop.want_type=SCREEN_SURFACE;//SHOULDN'T BE POSSIBLE anymore
 	}
 
+	SDL_EnableScreenSaver();
+
 	sdl.texture.texture = 0;
 	sdl.texture.pixelFormat = 0;
 	sdl.render_driver = section->Get_string("texture_renderer");


### PR DESCRIPTION
> Disabling screensaver prevents inactive display from going to sleep
> on macOS and Gnome.  It has also some other bad side effects (screen is
> not disabled even when user explicitly locks the machine on macOS).
> 
> Some users might still want to suppress screensaver (e.g. when using
> CRTs in retro-machines, in gaming cabinets, or when opting-in to
> screensaver e.g. in emulated Norton Commander or Windows 3.x); those
> users can still suppress the screensaver using SDL_VIDEO_ALLOW_SCREENSAVER
> environment variable.
> 
> For example on Linux:
> 
>     $ SDL_VIDEO_ALLOW_SCREENSAVER=0 dosbox
> 
> See: https://wiki.libsdl.org/FAQUsingSDL
> 
> Fixes: #630