### PR TITLE
Reimplement CLS command

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -662,7 +662,9 @@ void SHELL_Init() {
 	        "  ..   Specifies that you want to change to the parent directory.\n\n"
 	        "Type CD drive: to display the current directory in the specified drive.\n"
 	        "Type CD without parameters to display the current drive and directory.\n");
-	MSG_Add("SHELL_CMD_CLS_HELP","Clear screen.\n");
+
+	MSG_Add("SHELL_CMD_CLS_HELP", "Clear the screen.\n");
+
 	MSG_Add("SHELL_CMD_DIR_HELP",
 	        "Displays a list of files and subdirectories in a directory.\n");
 	MSG_Add("SHELL_CMD_DIR_HELP_LONG",

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -182,10 +182,13 @@ void DOS_Shell::DoCommand(char * line) {
 		return; \
 	}
 
-void DOS_Shell::CMD_CLS(char * args) {
+void DOS_Shell::CMD_CLS(char *args)
+{
 	HELP("CLS");
-	reg_ax=0x0003;
-	CALLBACK_RunRealInt(0x10);
+	const auto rows = real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS);
+	const auto cols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+	INT10_ScrollWindow(0, 0, rows, static_cast<uint8_t>(cols), -rows, 0x7, 0xff);
+	INT10_SetCursorPos(0, 0, 0);
 }
 
 void DOS_Shell::CMD_DELETE(char * args) {


### PR DESCRIPTION
Scroll content using text window size with the same size as terminal
size, followed by resetting the cursor position to first row and column.
Now CLS command works exactly the same way as it did in DOS.

Previous CLS implementation was working by resetting terminal mode to
80x25 - which was a problem if user wanted to use console with different
size (e.g. 80x50).