### PR TITLE
Apply the SoftLimiter to FluidSynth

### DIFF
--- a/include/soft_limiter.h
+++ b/include/soft_limiter.h
@@ -1,6 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2020  Kevin R Croft <krcroft@gmail.com>
  *  Copyright (C) 2020-2020  The dosbox-staging team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,52 +23,70 @@
 #define DOSBOX_SOFT_LIMITER_H
 
 /*
-Soft Limiter
-------------
-Given an input array and output array where the input can support wider values
-than the output, the limiter will detect when the input contains one or more
-values that would exceed the output's type bounds.
+Zero-Latency Soft Limiter
+-------------------------
+Given an input array of floats, the Soft Limiter scales sequences that
+exceed the bounds of a standard 16-bit signal.
 
-When detected, it scale-down the entire input set such that they fit within the
-output bounds. By scaling the entire series of values, it ensure relative
-differences are retained without distorion. (This is known as Soft Limiting,
-which is superior to Hard Limiting that truncates or clips values and causes
-distortion).
+This scale-down effect continues to be applied to subsequent sequences,
+each time with less effect (provided even greater peaks aren't detected),
+until the scale-down is complete - this period is known as 'Release' and
+prevents a discontinuous jump in subsequent waveforms after the initial
+sequence is scaled down.
 
-This scale-down-to-fit effect continues to be applied to subsequent input sets,
-each time with less effect (provided new peaks aren't detected), until the
-scale-down is complete - this period is known as 'Release'.
+Likewise, when a new large peak is detected, a polynomial is used to join
+the tail of the prior sequence with the head of the current sequence.
 
-The release duration is a function of how much we needed to scale down in the
-first place.  The larger the scale-down, the longer the release (typically
-ranging from 10's of milliseconds to low-hundreds for > 2x overages).
+Unique features:
+ - Left and right channels are independently handled
+
+ - Zero-latency: it does not require a pre-buffer or aprior knowledge to
+   perform seamless scaling both on the front-end and back-end of the signal
+
+ - Permits a pre-scaling factor be applied to the 32-bit float source samples
+   before detection and scaling (performed on-the-fly without pre-pass).
+
+ - Informs the user if the source signal was significantly under the allowed
+   bounds in which case it suggests a suitable scale-up factor, or if excessive
+   scaling was required it suggests a suitable scale-down factor.
+
+Regarding the release duration:
+
+Because audio should only be adjusted in small amounts to prevent
+discontinuities, the release duration is a function of the magnitude of the
+scale-down factor. The larger the scale-down, the more release periods are
+needed; typically ranging from 10's of milliseconds to low-hundreds for large >
+2x overages.
 
 Use:
 
-The SoftLimiter reads and writes arrays of the same length, which is
-defined during object creation as a template size. For example:
+Instantiate the Soft Limiter template object with the maximum number of frames
+you plan to pass it. Construct it with the name of the channel that's being
+operated on and prescalar frames (one frame = left and right samples) in a given
+sequence of audio. For example:
 
-  SoftLimiter<48> limiter;
+  AudioFrame prescale = {1.0f, 1.0f};
+  SoftLimiter<48> limiter("channel name", prescale);
 
 You can then repeatedly call:
-  limiter.Apply(in_samples, out_samples);
+  const auto out_array = limiter.Apply(in_array, num_frames);
 
-Where in_samples is a std::array<float, 48> and out_samples is a 
-std::array<int16_t, 48>. The limiter will either copy or limit the in_samples
-into the out_samples array.
+Where:
+ - in_array is a std::array<float, 48>
+ - num_frames is some number of frames from zero up to 48.
+ - out_array is a const reference to std::array<int16_t, 48>
 
-The PrintStats function will make mixer suggestions if the in_samples
-were (at most) 40% under the allowed bounds, in which case the recommendation
-will describe how to scale up the channel amplitude. 
+The limiter will either copy or scale-limit num_frames into the out_array.
 
-On the other hand, if the limiter found itself scaling down more than 10% of
-the inbound stream, then it will in turn recommend how to scale down the
-channel. 
+The PrintStats function will make mixer suggestions if the in_array samples were
+either significantly under or over the allowed bounds for the entire playback
+duration.
 */
 
 #include "dosbox.h"
 #include "logging.h"
 #include "mixer.h"
+#include "support.h"
 
 #include <algorithm>
 #include <array>
@@ -79,32 +98,79 @@ channel.
 template <size_t array_frames>
 class SoftLimiter {
 public:
-	SoftLimiter() = delete;
 	SoftLimiter(const std::string &name, const AudioFrame &scale);
 
-	using in_array_t = std::array<float, array_frames * 2>; // 2 for stereo
-	using out_array_t = std::array<int16_t, array_frames * 2>; // 2 for stereo
+	// Prevent default object construction, copy, and assignment
+	SoftLimiter() = delete;
+	SoftLimiter(const SoftLimiter<array_frames> &) = delete;
+	SoftLimiter<array_frames> &operator=(const SoftLimiter<array_frames> &) = delete;
 
-	void Apply(const in_array_t &in, out_array_t &out, uint16_t frames) noexcept;
-	const AudioFrame &GetPeaks() const noexcept { return peak; }
+	constexpr static size_t array_samples = array_frames * 2; // 2 for stereo
+	using in_array_t = std::array<float, array_samples>;
+	using out_array_t = std::array<int16_t, array_samples>;
+
+	const out_array_t &Apply(const in_array_t &in, uint16_t frames) noexcept;
+	const AudioFrame &GetPeaks() const noexcept { return global_peaks; }
 	void PrintStats() const;
 	void Reset() noexcept;
 
 private:
-	// Amplitude level constants
+	using in_array_iterator_t = typename std::array<float, array_samples>::const_iterator;
+	using out_array_iterator_t = typename std::array<int16_t, array_samples>::iterator;
 	using out_limits = std::numeric_limits<int16_t>;
-	constexpr static float upper_bound = static_cast<float>(out_limits::max());
-	constexpr static float lower_bound = static_cast<float>(out_limits::min());
 
-	bool FindPeaks(const in_array_t &stream, uint16_t frames) noexcept;
+	void FindPeaksAndZeroCrosses(const in_array_t &stream, uint16_t frames) noexcept;
+
+	void FindPeakAndCross(const in_array_iterator_t pos,
+	                      in_array_iterator_t &prev_pos,
+	                      const float prescalar,
+	                      float &local_peak,
+	                      in_array_iterator_t &precross_peak_pos,
+	                      in_array_iterator_t &zero_cross_pos,
+	                      float &global_peak) noexcept;
+
+	void LinearScale(in_array_iterator_t in_pos,
+	                 const in_array_iterator_t in_end,
+	                 out_array_iterator_t out_pos,
+	                 const float scalar) noexcept;
+
+	void PolyFit(in_array_iterator_t in_pos,
+	             const in_array_iterator_t in_end,
+	             out_array_iterator_t out_pos,
+	             const float prescalar,
+	             const float poly_a,
+	             const float poly_b) noexcept;
+
 	void Release() noexcept;
 
+	void SaveTailFrame(const uint16_t frames) noexcept;
+
+	template <size_t channel>
+	void ScaleOrCopy(const in_array_t &in,
+	                 const size_t samples,
+	                 const float prescalar,
+	                 const in_array_iterator_t precross_peak_pos,
+	                 const in_array_iterator_t zero_cross_pos,
+	                 const float global_peak,
+	                 const float tail);
+
+	// Const members
+	constexpr static size_t left = 0;
+	constexpr static size_t right = 1;
+	constexpr static float bounds = static_cast<float>(out_limits::max() - 1);
+
+	// Mutable members
+	out_array_t out{};
 	std::string channel_name = {};
-	AudioFrame limit_scale = {1, 1}; // real-time limit applied to stream
-	AudioFrame peak = {1, 1};        // holds real-time peak amplitudes
-	const AudioFrame &prescale;      // scale before operating on the stream
-	int limited_ms = 0;              // milliseconds that needed limiting
-	int non_limited_ms = 0; // milliseconds that didn't need limiting
+	const AudioFrame &prescale; // values inside struct are mutable
+	in_array_iterator_t zero_cross_left = nullptr;
+	in_array_iterator_t zero_cross_right = nullptr;
+	in_array_iterator_t precross_peak_pos_left = nullptr;
+	in_array_iterator_t precross_peak_pos_right = nullptr;
+	AudioFrame global_peaks = {0, 0};
+	AudioFrame tail_frame = {0, 0};
+	int limited_ms = 0;
+	int non_limited_ms = 0;
 };
 
 template <size_t array_frames>
@@ -113,143 +179,266 @@ SoftLimiter<array_frames>::SoftLimiter(const std::string &name, const AudioFrame
           prescale(scale)
 {
 	static_assert(array_frames > 0, "need some quantity of frames");
-	static_assert(array_frames < 16384, "too many frames adds audible latency");
+	static_assert(array_frames < 16385, "consider using a smaller sequence");
 }
 
+// Applies the Soft Limiter to the given input sequence and returns the results
+// as a reference to a std::array of 16-bit ints the same length as the input.
 template <size_t array_frames>
-bool SoftLimiter<array_frames>::FindPeaks(const in_array_t &stream,
-                                          const uint16_t samples) noexcept
-{
-	auto val = stream.begin();
-	const auto val_end = stream.begin() + samples;
-	AudioFrame local_peak{};
-	while (val < val_end) {
-		// Left channel
-		local_peak.left = std::max(local_peak.left, fabsf(*val++));
-		local_peak.right = std::max(local_peak.right, fabsf(*val++));
-	}
-	peak.left = std::max(peak.left, prescale.left * local_peak.left);
-	peak.right = std::max(peak.right, prescale.right * local_peak.right);
-
-	const bool limiting_needed = (peak.left > upper_bound ||
-	                              peak.right > upper_bound);
-
-	// Calculate the percent we need to scale down each channel. In cases
-	// where one channel is less than the upper-bound, its time_ratio is limited
-	// to 1.0 to retain the original level.
-	if (limiting_needed)
-		limit_scale = {std::min(1.0f, upper_bound / peak.left),
-		               std::min(1.0f, upper_bound / peak.right)};
-
-	return limiting_needed;
-	// LOG_MSG("%s peak left = %f", channel_name.c_str(),
-	// static_cast<double>(peak.left));
-}
-
-template <size_t array_frames>
-void SoftLimiter<array_frames>::Apply(const in_array_t &in,
-                                      out_array_t &out,
-                                      const uint16_t req_frames) noexcept
+const typename SoftLimiter<array_frames>::out_array_t &SoftLimiter<array_frames>::Apply(
+        const in_array_t &in, const uint16_t frames) noexcept
 {
 	// Ensure the buffers are large enough to handle the request
-	const uint16_t samples = req_frames * 2; // left and right channels
+	const uint16_t samples = frames * 2; // left and right channels
 	assert(samples <= in.size());
 
-	const bool limiting_needed = FindPeaks(in, samples);
+	FindPeaksAndZeroCrosses(in, samples);
 
-	// get our in and out iterators
-	auto in_val = in.begin();
-	const auto in_val_end = in.begin() + samples;
-	auto out_val = out.begin();
+	// Given the local peaks found in each side channel, scale or copy the
+	// input array into the output array
+	ScaleOrCopy<left>(in, samples, prescale.left, precross_peak_pos_left,
+	                  zero_cross_left, global_peaks.left, tail_frame.left);
 
-	// apply both the pre-scale and limit-scale to determine the final scale
-	const AudioFrame scale{prescale.left * limit_scale.left,
-	                       prescale.right * limit_scale.right};
+	ScaleOrCopy<right>(in, samples, prescale.right, precross_peak_pos_right,
+	                   zero_cross_right, global_peaks.right, tail_frame.right);
 
-	// Process the signal by pre-scaling and limit-scaling
-	// Note: if limit-scaling isn't needed then its values are simply 1.0
-	while (in_val < in_val_end) {
-		*out_val++ = static_cast<int16_t>(*in_val++ * scale.left);
-		*out_val++ = static_cast<int16_t>(*in_val++ * scale.right);
-	}
-	if (limiting_needed)
-		Release();
-	else
-		non_limited_ms++;
+	SaveTailFrame(frames);
+	Release();
+	return out;
 }
 
+// Helper function to evaluate the existing peaks and prior values.
+// Saves new local and global peaks, and the input-array iterator of any new
+// peaks before the first zero-crossing, along with the first zero-crossing
+// position.
+template <size_t array_frames>
+void SoftLimiter<array_frames>::FindPeakAndCross(const in_array_iterator_t pos,
+                                                 in_array_iterator_t &prev_pos,
+                                                 const float prescalar,
+                                                 float &local_peak,
+                                                 in_array_iterator_t &precross_peak_pos,
+                                                 in_array_iterator_t &zero_cross_pos,
+                                                 float &global_peak) noexcept
+{
+	const auto val = fabsf(*pos) * prescalar;
+	if (val > bounds && val > local_peak) {
+		local_peak = val;
+		if (!zero_cross_pos) {
+			precross_peak_pos = pos;
+		}
+	}
+	if (val > global_peak) {
+		global_peak = val;
+	}
+	// Detect and save the first zero-crossing position (if any)
+	if (!zero_cross_pos && prev_pos && signbit(*prev_pos) != signbit(*pos)) {
+		zero_cross_pos = pos;
+	}
+	prev_pos = pos;
+}
+
+// Sequentially scans the input channels to find new peaks, their positions, and
+// the first zero crossings (saved in member variables).
+template <size_t array_frames>
+void SoftLimiter<array_frames>::FindPeaksAndZeroCrosses(const in_array_t &in,
+                                                        const uint16_t samples) noexcept
+{
+	auto pos = in.begin();
+	const auto pos_end = in.begin() + samples;
+
+	precross_peak_pos_left = nullptr;
+	precross_peak_pos_right = nullptr;
+	zero_cross_left = nullptr;
+	zero_cross_right = nullptr;
+	in_array_iterator_t prev_pos_left = nullptr;
+	in_array_iterator_t prev_pos_right = nullptr;
+	AudioFrame local_peaks = global_peaks;
+
+	while (pos != pos_end) {
+		FindPeakAndCross(pos++, prev_pos_left, prescale.left,
+		                 local_peaks.left, precross_peak_pos_left,
+		                 zero_cross_left, global_peaks.left);
+
+		FindPeakAndCross(pos++, prev_pos_right, prescale.right,
+		                 local_peaks.right, precross_peak_pos_right,
+		                 zero_cross_right, global_peaks.right);
+	}
+}
+
+// Scale or copy the given channel's samples into the output array
+template <size_t array_frames>
+template <size_t channel>
+void SoftLimiter<array_frames>::ScaleOrCopy(const in_array_t &in,
+                                            const size_t samples,
+                                            const float prescalar,
+                                            const in_array_iterator_t precross_peak_pos,
+                                            const in_array_iterator_t zero_cross_pos,
+                                            const float global_peak,
+                                            const float tail)
+{
+	assert(samples >= 2); // need at least one frame
+	auto in_start = in.begin() + channel;
+	const auto in_end = in.begin() + channel + samples;
+	auto out_start = out.begin() + channel;
+
+	// We have a new peak, so ...
+	if (precross_peak_pos) {
+		const auto tail_abs = fabsf(tail);
+		const auto prepeak_scalar = (bounds - tail_abs) /
+		                            (prescalar * fabsf(*precross_peak_pos) -
+		                             tail_abs);
+		// fit the frontside of the waveform to the tail up to the peak.
+		PolyFit(in_start, precross_peak_pos, out_start, prescalar,
+		        prepeak_scalar, tail);
+
+		// Then scale the backend of the waveform from its peak ...
+		out_start = out.begin() + (precross_peak_pos - in.begin());
+		const auto postpeak_scalar = bounds / fabsf(*precross_peak_pos);
+		// down to the zero-crossing ...
+		if (zero_cross_pos) {
+			LinearScale(precross_peak_pos, zero_cross_pos,
+			            out_start, postpeak_scalar);
+
+			// and from the zero-crossing to the end of the sequence.
+			out_start = out.begin() + (zero_cross_pos - in.begin());
+			const auto postcross_scalar = prescalar * bounds / global_peak;
+			LinearScale(zero_cross_pos, in_end, out_start,
+			            postcross_scalar);
+		}
+		// down to the end of the sequence.
+		else {
+			LinearScale(precross_peak_pos, in_end, out_start,
+			            postpeak_scalar);
+		}
+		limited_ms++;
+
+		// We have an existing peak ...
+	} else if (global_peak > bounds) {
+		// so scale the entire sequence a a ratio of the peak.
+		const auto current_scalar = prescalar * bounds / global_peak;
+		LinearScale(in_start, in_end, out_start, current_scalar);
+		limited_ms++;
+
+		// The current sequence is fully inbounds ...
+	} else {
+		// so simply prescale the entire sequence.
+		LinearScale(in_start, in_end, out_start, prescalar);
+		++non_limited_ms;
+	}
+}
+
+// Apply the polynomial coefficients to the sequence
+template <size_t array_frames>
+void SoftLimiter<array_frames>::PolyFit(in_array_iterator_t in_pos,
+                                        const in_array_iterator_t in_end,
+                                        out_array_iterator_t out_pos,
+                                        const float prescalar,
+                                        const float poly_a,
+                                        const float poly_b) noexcept
+{
+	while (in_pos != in_end) {
+		const auto fitted = poly_a * (*in_pos * prescalar - poly_b) + poly_b;
+		assert(fabsf(fitted) <= out_limits::max());
+		*out_pos = static_cast<int16_t>(fitted);
+		out_pos += 2;
+		in_pos += 2;
+	}
+}
+
+// Apply the scalar to the sequence
+template <size_t array_frames>
+void SoftLimiter<array_frames>::LinearScale(in_array_iterator_t in_pos,
+                                            const in_array_iterator_t in_end,
+                                            out_array_iterator_t out_pos,
+                                            const float scalar) noexcept
+{
+	while (in_pos != in_end) {
+		const auto scaled = (*in_pos) * scalar;
+		assert(fabsf(scaled) <= out_limits::max());
+		*out_pos = static_cast<int16_t>(scaled);
+		out_pos += 2;
+		in_pos += 2;
+	}
+}
+
+template <size_t array_frames>
+void SoftLimiter<array_frames>::SaveTailFrame(const uint16_t frames) noexcept
+{
+	const size_t i = (frames - 1) * 2;
+	tail_frame.left = static_cast<float>(out[i]);
+	tail_frame.right = static_cast<float>(out[i + 1]);
+}
+
+// If either channel was out of bounds, then decrement their peak
 template <size_t array_frames>
 void SoftLimiter<array_frames>::Release() noexcept
 {
-	++limited_ms;
 	// Decrement the peak(s) one step
 	constexpr float delta_db = 0.002709201f; // 0.0235 dB increments
-	constexpr float release_amplitude = upper_bound * delta_db;
-	if (peak.left > upper_bound)
-		peak.left -= release_amplitude;
-	if (peak.right > upper_bound)
-		peak.right -= release_amplitude;
-	// LOG_MSG("GUS: releasing peak_amplitude = %.2f | %.2f",
-	//         static_cast<double>(peak.left),
-	//         static_cast<double>(peak.right));
+	constexpr float release_amplitude = bounds * delta_db;
+	if (global_peaks.left > bounds)
+		global_peaks.left -= release_amplitude;
+	if (global_peaks.right > bounds)
+		global_peaks.right -= release_amplitude;
 }
 
+// Print helpful statistics about the signal thus-far
 template <size_t array_frames>
 void SoftLimiter<array_frames>::PrintStats() const
 {
+	// Only print information if we have more than 30 seconds of data
 	constexpr auto ms_per_minute = 1000 * 60;
 	const auto ms_total = static_cast<double>(limited_ms) + non_limited_ms;
 	const auto minutes_total = ms_total / ms_per_minute;
-
-	// Only print stats if we have more than 30 seconds of data
 	if (minutes_total < 0.5)
 		return;
 
-	// Only print levels if the peak is at-least 5% of the max
-	const auto peak_sample = std::max(peak.left, peak.right);
-	constexpr auto five_percent_of_max = upper_bound / 20;
-	if (peak_sample < five_percent_of_max)
+	// Only print information if there was atleast some amplitude
+	const auto peak_sample = std::max(global_peaks.left, global_peaks.right);
+	constexpr auto two_percent_of_max = 0.02f * bounds;
+	if (peak_sample < two_percent_of_max)
 		return;
 
-	// It's expected and normal for multi-channel audio to periodically
-	// accumulate beyond the max, which the soft-limiter gracefully handles.
-	// More importantly, users typically care when their overall stream
-	// never achieved the maximum levels.
-	auto peak_ratio = peak_sample / upper_bound;
+	// Inform the user what percent of the dynamic-range was used
+	auto peak_ratio = peak_sample / bounds;
 	peak_ratio = std::min(peak_ratio, 1.0f);
 	LOG_MSG("%s: Peak amplitude reached %.0f%% of max",
 	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
 
-	// Make a suggestion if the peak amplitude was well below 3 dB. Note that
-	// we remove the effect of the external scale by dividing by it. This
-	// avoids making a recommendation if the user delibertely wanted quiet
-	// output (as an example).
+	// Inform when the stream fell short of using the full dynamic-range
 	const auto scale = std::max(prescale.left, prescale.right);
-	constexpr auto well_below_3db = static_cast<float>(0.6);
-	if (peak_ratio / scale < well_below_3db) {
+	constexpr auto well_below_3db = 0.6f;
+	if (peak_ratio < well_below_3db) {
 		const auto suggested_mix_val = 100 * scale / peak_ratio;
 		LOG_MSG("%s: If it should be louder, use: mixer %s %.0f",
 		        channel_name.c_str(), channel_name.c_str(),
 		        static_cast<double>(suggested_mix_val));
 	}
-	// Make a suggestion if more than 20% of the stream required limiting
+	// Inform if more than 20% of the stream required limiting
 	const auto time_ratio = limited_ms / (ms_total + 1); // one ms avoids div-by-0
 	if (time_ratio > 0.2) {
 		const auto minutes_limited = static_cast<double>(limited_ms) / ms_per_minute;
-		const auto reduction_ratio = 1 - time_ratio / 2;
-		const auto suggested_mix_val = 100 * reduction_ratio * static_cast<double>(scale);
+		const auto suggested_mix_val = 100 * (1 - time_ratio) *
+		                               static_cast<double>(scale);
 		LOG_MSG("%s: %.1f%% or %.2f of %.2f minutes needed limiting, consider: mixer %s %.0f",
 		        channel_name.c_str(), 100 * time_ratio, minutes_limited,
 		        minutes_total, channel_name.c_str(), suggested_mix_val);
 	}
 }
 
+// A paused audio source should Reset() the limiter so it starts with
+// fresh peaks and a zero-tail if/when the stream is restarted.
 template <size_t array_frames>
 void SoftLimiter<array_frames>::Reset() noexcept
 {
-	peak = {1, 1};
-	limited_ms = 0;
-	non_limited_ms = 0;
+	// if the current peaks are over the upper bounds, then we simply save
+	// the upper bound because we want retain information about the peak
+	// amplitude when printing statistics.
+
+	constexpr auto upper = bounds; // (workaround to prevent link-errors)
+	global_peaks.left = std::min(global_peaks.left, upper);
+	global_peaks.right = std::min(global_peaks.right, upper);
+	tail_frame = {0, 0};
 }
 
 #endif

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -118,7 +118,6 @@ using autoexec_array_t = std::array<AutoexecObject, 2>;
 using pan_scalars_array_t = std::array<AudioFrame, PAN_POSITIONS>;
 using ram_array_t = std::array<uint8_t, RAM_SIZE>;
 using read_io_array_t = std::array<IO_ReadHandleObject, READ_HANDLERS>;
-using scaled_array_t = std::array<int16_t, BUFFER_SAMPLES>;
 using vol_scalars_array_t = std::array<float, VOLUME_LEVELS>;
 using write_io_array_t = std::array<IO_WriteHandleObject, WRITE_HANDLERS>;
 
@@ -247,7 +246,6 @@ private:
 	size_t ReadFromPort(const size_t port, const size_t iolen);
 	void RegisterIoHandlers();
 	void Reset(uint8_t state);
-	void SoftLimit(const accumulator_array_t &in, scaled_array_t &out) noexcept;
 	void SetLevelCallback(const AudioFrame &level);
 	void StopPlayback();
 	void UpdateDmaAddress(uint8_t new_address);
@@ -259,7 +257,6 @@ private:
 	// Collections
 	vol_scalars_array_t vol_scalars = {{}};
 	accumulator_array_t accumulator = {{0}};
-	scaled_array_t scaled = {{}};
 	pan_scalars_array_t pan_scalars = {{}};
 	ram_array_t ram = {{0u}};
 	read_io_array_t read_handlers = {};   // std::functions
@@ -646,8 +643,8 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 		++v;
 	}
 
-	soft_limiter.Apply(accumulator, scaled, requested_frames);
-	audio_channel->AddSamples_s16(requested_frames, scaled.data());
+	const auto &out_stream = soft_limiter.Apply(accumulator, requested_frames);
+	audio_channel->AddSamples_s16(requested_frames, out_stream.data());
 	CheckVoiceIrq();
 }
 
@@ -1102,6 +1099,8 @@ void Gus::StopPlayback()
 {
 	// Halt playback before altering the DSP state
 	audio_channel->Enable(false);
+
+	soft_limiter.Reset();
 
 	irq_enabled = false;
 	irq_status = 0;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -106,6 +106,9 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	DEBUG_LOG_MSG("MIDI: FluidSynth loaded %d SoundFont files",
 	              fluid_synth_sfcount(fluid_synth.get()));
 
+	// Uses samples' native amplitudes without suppression or amplification
+	fluid_synth_set_gain(fluid_synth.get(), 1.0);
+
 	// Apply reasonable chorus and reverb settings matching ScummVM's defaults
 	constexpr int chorus_number = 3;
 	constexpr double chorus_level = 1.2;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -103,9 +103,25 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	if (!soundfont.empty() && fluid_synth_sfcount(fluid_synth.get()) == 0) {
 		fluid_synth_sfload(fluid_synth.get(), soundfont.data(), true);
 	}
-
 	DEBUG_LOG_MSG("MIDI: FluidSynth loaded %d SoundFont files",
 	              fluid_synth_sfcount(fluid_synth.get()));
+
+	// Apply reasonable chorus and reverb settings matching ScummVM's defaults
+	constexpr int chorus_number = 3;
+	constexpr double chorus_level = 1.2;
+	constexpr double chorus_speed = 0.3;
+	constexpr double chorus_depth = 8.0;
+	fluid_synth_set_chorus_on(fluid_synth.get(), 1);
+	fluid_synth_set_chorus(fluid_synth.get(), chorus_number, chorus_level,
+	                       chorus_speed, chorus_depth, FLUID_CHORUS_MOD_SINE);
+
+	constexpr double reverb_room_size = 0.61;
+	constexpr double reverb_damping = 0.23;
+	constexpr double reverb_width = 0.76;
+	constexpr double reverb_level = 0.56;
+	fluid_synth_set_reverb_on(fluid_synth.get(), 1);
+	fluid_synth_set_reverb(fluid_synth.get(), reverb_room_size,
+	                       reverb_damping, reverb_width, reverb_level);
 
 	const auto mixer_callback = std::bind(&MidiHandlerFluidsynth::MixerCallBack,
 	                                      this, std::placeholders::_1);

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -109,6 +109,10 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	// Uses samples' native amplitudes without suppression or amplification
 	fluid_synth_set_gain(fluid_synth.get(), 1.0);
 
+	// Use a 7th-order (highest) polynomial to generate MIDI channel waveforms
+	constexpr int all_channels = -1;
+	fluid_synth_set_interp_method(fluid_synth.get(), all_channels, FLUID_INTERP_HIGHEST);
+
 	// Apply reasonable chorus and reverb settings matching ScummVM's defaults
 	constexpr int chorus_number = 3;
 	constexpr double chorus_level = 1.2;

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -31,6 +31,7 @@
 #include <fluidsynth.h>
 
 #include "mixer.h"
+#include "soft_limiter.h"
 
 class MidiHandlerFluidsynth final : public MidiHandler {
 private:
@@ -43,6 +44,8 @@ private:
 	        std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
 public:
+	MidiHandlerFluidsynth() : soft_limiter("FSYNTH", prescale_level) {}
+	void PrintStats();
 	const char *GetName() const override { return "fluidsynth"; }
 	bool Open(const char *conf) override;
 	void Close() override;
@@ -50,6 +53,7 @@ public:
 	void PlaySysex(uint8_t *sysex, size_t len) override;
 
 private:
+	static constexpr uint16_t expected_max_frames = (96000 / 1000) + 4;
 	void MixerCallBack(uint16_t len); // see: MIXER_Handler
 	void SetMixerLevel(const AudioFrame &prescale_level) noexcept;
 
@@ -57,6 +61,7 @@ private:
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
 	AudioFrame prescale_level = {1.0f, 1.0f};
+	SoftLimiter<expected_max_frames> soft_limiter;
 
 	bool is_open = false;
 };

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -50,7 +50,7 @@ public:
 	void PlaySysex(uint8_t *sysex, size_t len) override;
 
 private:
-	MidiHandlerFluidsynth() = default;
+	void MixerCallBack(uint16_t len); // see: MIXER_Handler
 
 	static MidiHandlerFluidsynth instance;
 
@@ -58,8 +58,6 @@ private:
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
 	bool is_open = false;
-
-	static void mixer_callback(uint16_t len); // see: MIXER_Handler
 };
 
 #endif // C_FLUIDSYNTH

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -51,12 +51,13 @@ public:
 
 private:
 	void MixerCallBack(uint16_t len); // see: MIXER_Handler
-
-	static MidiHandlerFluidsynth instance;
+	void SetMixerLevel(const AudioFrame &prescale_level) noexcept;
 
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
+	AudioFrame prescale_level = {1.0f, 1.0f};
+
 	bool is_open = false;
 };
 

--- a/tests/soft_limiter.cpp
+++ b/tests/soft_limiter.cpp
@@ -24,142 +24,161 @@
 
 namespace {
 
-TEST(SoftLimiter, FullFrames)
+TEST(SoftLimiter, InboundsProcessAllFrames)
 {
-	const auto frames = 3;
+	constexpr int frames = 3;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
-	SoftLimiter<frames>::out_array_t out{};
 
-	limiter.Apply(in, out, frames);
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
 	const SoftLimiter<frames>::out_array_t expected{-3, -2, -1, 0, 1, 2};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, PartialFrames)
+TEST(SoftLimiter, InboundsProcessPartialFrames)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
-	SoftLimiter<frames>::out_array_t out{};
 
-	limiter.Apply(in, out, 1);
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, 1);
 	const SoftLimiter<frames>::out_array_t expected{-3, -2};
 	EXPECT_EQ(out[0], expected[0]);
 	EXPECT_EQ(out[1], expected[1]);
 }
 
-TEST(SoftLimiter, ExcessiveFrames)
+TEST(SoftLimiter, InboundsProcessTooManyFrames)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
-	SoftLimiter<frames>::out_array_t out{};
-	EXPECT_DEBUG_DEATH({ limiter.Apply(in, out, frames + 1); }, "");
+	EXPECT_DEBUG_DEATH({ limiter.Apply(in, frames + 1); }, "");
 }
 
-TEST(SoftLimiter, PositiveOverrun)
+TEST(SoftLimiter, OutOfBoundsLeftChannel)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{-8.1f,    32000.0f, 65535.0f,
+	                                         32000.0f, 4.1f,     32000.0f};
+
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
+	const SoftLimiter<frames>::out_array_t expected{-4,    32000, 32766,
+	                                                32000, 2,     32000};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, OutOfBoundsRightChannel)
+{
+	const auto frames = 3;
+	const AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+	const SoftLimiter<frames>::in_array_t in{32000.0f, -3.1f,    32000.0f,
+	                                         98304.1f, 32000.0f, 6.1f};
+
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
+	const SoftLimiter<frames>::out_array_t expected{32000, -1,    32000,
+	                                                32765, 32000, 2};
+	EXPECT_EQ(out, expected);
+}
+
+TEST(SoftLimiter, OutboundsBothChannelsPositive)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	const SoftLimiter<frames>::in_array_t in{-8.1f,    -3.1f, 65535.0f,
 	                                         98304.1f, 4.1f,  6.1f};
-	SoftLimiter<frames>::out_array_t out{};
 
-	limiter.Apply(in, out, frames);
-	const SoftLimiter<frames>::out_array_t expected{-4,    -1, 32767,
-	                                                32767, 2,  2};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
+	const SoftLimiter<frames>::out_array_t expected{-4,    -1, 32766,
+	                                                32765, 2,  2};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, NegativeOverrun)
+TEST(SoftLimiter, OutboundsBothChannelsNegative)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	const SoftLimiter<frames>::in_array_t in{-8.1f,     -3.1f, -65535.0f,
 	                                         -98304.1f, 4.1f,  6.1f};
-	SoftLimiter<frames>::out_array_t out{};
 
-	limiter.Apply(in, out, frames);
-	const SoftLimiter<frames>::out_array_t expected{-4,     -1, -32767,
-	                                                -32767, 2,  2};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
+	const SoftLimiter<frames>::out_array_t expected{-4,     -1, -32766,
+	                                                -32765, 2,  2};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, MixedOverrun)
+TEST(SoftLimiter, OutboundsBothChannelsMixed)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{40000.1f, -40000.1f,
+	const SoftLimiter<frames>::in_array_t in{40000.0f, -40000.0f,
 	                                         65534.0f, -98301.0f,
-	                                         40000.1f, -40000.1f};
-	SoftLimiter<frames>::out_array_t out{};
+	                                         40000.0f, -40000.0f};
 
-	limiter.Apply(in, out, frames);
-	const SoftLimiter<frames>::out_array_t expected{20000,  -13333, 32767,
-	                                                -32767, 20000,  -13333};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
+	const SoftLimiter<frames>::out_array_t expected{19999,  -13332, 32766,
+	                                                -32766, 19999,  -13332};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, BigScaleOneRelease)
+TEST(SoftLimiter, OutboundsBigOneReleaseStep)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	SoftLimiter<frames>::in_array_t in{-60000.0f, 80000.0f};
-	SoftLimiter<frames>::out_array_t out{};
-	limiter.Apply(in, out, 1);
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, 1);
 
 	in[0] = static_cast<float>(out[0]);
 	in[1] = static_cast<float>(out[1]);
-	limiter.Apply(in, out, frames);
+	out = limiter.Apply(in, frames);
 
-	const SoftLimiter<frames>::out_array_t expected{-17920, 13435};
+	const SoftLimiter<frames>::out_array_t expected{-17920, 13434};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, BigScaleSixHundredReleases)
+TEST(SoftLimiter, OutboundsBig600ReleaseSteps)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	SoftLimiter<frames>::in_array_t in{-60000.0f, 80000.0f};
-	SoftLimiter<frames>::out_array_t out{};
-	limiter.Apply(in, out, 1);
+	SoftLimiter<frames>::out_array_t out;
 
 	for (int i = 0; i < 600; ++i) {
-		limiter.Apply(in, out, frames);
+		out = limiter.Apply(in, frames);
 		in[0] = -32767;
 		in[1] = 32768;
 	}
-	const SoftLimiter<frames>::out_array_t expected{-32767, 32767};
+	const SoftLimiter<frames>::out_array_t expected{-32766, 32766};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, SmallScaleTwoReleases)
+TEST(SoftLimiter, OutboundsSmallTwoReleaseSteps)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
 	SoftLimiter<frames>::in_array_t in{-32800.0f, 32800.0f};
-	SoftLimiter<frames>::out_array_t out{};
-
+	SoftLimiter<frames>::out_array_t out;
 	for (int i = 0; i < 2; ++i) {
-		limiter.Apply(in, out, frames);
+		out = limiter.Apply(in, frames);
 		in[0] = -32767;
 		in[1] = 32767;
 	}
-	const SoftLimiter<frames>::out_array_t expected{-32734, 32734};
+	const SoftLimiter<frames>::out_array_t expected{-32766, 32766};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, SmallScaleTenReleases)
+TEST(SoftLimiter, OutboundsSmallTenReleaseSteps)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
@@ -168,23 +187,104 @@ TEST(SoftLimiter, SmallScaleTenReleases)
 	SoftLimiter<frames>::out_array_t out{};
 
 	for (int i = 0; i < 10; ++i) {
-		limiter.Apply(in, out, frames);
+		out = limiter.Apply(in, frames);
 		in[0] = -32767;
 		in[1] = 32768;
 	}
-	const SoftLimiter<frames>::out_array_t expected{-32767, 32767};
+	const SoftLimiter<frames>::out_array_t expected{-32766, 32766};
 	EXPECT_EQ(out, expected);
 }
 
-TEST(SoftLimiter, AdjustPrescaleDown)
+TEST(SoftLimiter, OutboundsPolyJoinPositive)
+{
+	const auto frames = 3;
+	AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+
+	const SoftLimiter<frames>::in_array_t first_chunk{18000, 18000, 20000,
+	                                                  20000, 22000, 22000};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(first_chunk, frames);
+	const SoftLimiter<frames>::out_array_t expected_first{18000, 18000,
+	                                                      20000, 20000,
+	                                                      22000, 22000};
+	EXPECT_EQ(out, expected_first);
+
+	const SoftLimiter<frames>::in_array_t second_chunk{30000, 30000, 60000,
+	                                                   60000, 30000, 30000};
+	out = limiter.Apply(second_chunk, frames);
+
+	const SoftLimiter<frames>::out_array_t expected_second{24266, 24266,
+	                                                       32766, 32766,
+	                                                       16383, 16383};
+	EXPECT_EQ(out, expected_second);
+}
+
+TEST(SoftLimiter, OutboundsPolyJoinNegative)
+{
+	const auto frames = 3;
+	AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+
+	const SoftLimiter<frames>::in_array_t first_chunk{-18000, -18000,
+	                                                  -20000, -20000,
+	                                                  -22000, -22000};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(first_chunk, frames);
+	const SoftLimiter<frames>::out_array_t expected_first{-18000, -18000,
+	                                                      -20000, -20000,
+	                                                      -22000, -22000};
+	EXPECT_EQ(out, expected_first);
+
+	const SoftLimiter<frames>::in_array_t second_chunk{-30000, -30000,
+	                                                   -60000, -60000,
+	                                                   -30000, -30000};
+	out = limiter.Apply(second_chunk, frames);
+
+	const SoftLimiter<frames>::out_array_t expected_second{-24266, -24266,
+	                                                       -32766, -32766,
+	                                                       -16383, -16383};
+	EXPECT_EQ(out, expected_second);
+}
+
+TEST(SoftLimiter, OutboundsJoinWithZeroCross)
+{
+	const auto frames = 6;
+	AudioFrame prescale{1, 1};
+	SoftLimiter<frames> limiter("test-channel", prescale);
+
+	const SoftLimiter<frames>::in_array_t first_chunk{-5000, 1000,  -3000,
+	                                                  1000,  -1000, 1000,
+	                                                  0,     1000,  3000,
+	                                                  1000,  5000,  1000};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(first_chunk, frames);
+
+	const SoftLimiter<frames>::in_array_t second_chunk{
+	        15000, 1000, 25000,  1000, 32000,  1000,
+	        0,     1000, -15000, 1000, -40000, 1000};
+	out = limiter.Apply(second_chunk, frames);
+
+	const SoftLimiter<frames>::out_array_t expected_second{
+	        12287, 1000, 20478,  1000, 26212,  1000,
+	        0,     1000, -12287, 1000, -32765, 1000};
+	EXPECT_EQ(out, expected_second);
+
+	const SoftLimiter<frames>::in_array_t third_chunk{
+	        -25000, 1000, -15000, 1000, -10000, 1000,
+	        -5000,  1000, 0,      1000, 3000,   1000};
+	out = limiter.Apply(third_chunk, frames);
+
+	const SoftLimiter<frames>::out_array_t expected_third{
+	        -20524, 1000, -12314, 1000, -8209, 1000,
+	        -4104,  1000, 0,      1000, 2462,  1000};
+	EXPECT_EQ(out, expected_third);
+}
+
+TEST(SoftLimiter, PrescaleAttenuate)
 {
 	const auto frames = 1;
 	AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
-	SoftLimiter<frames>::in_array_t in{-30000.1f, 30000.0f};
-	SoftLimiter<frames>::out_array_t out{};
-
-	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::in_array_t in{-30000.1f, 30000.0f};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
 	const SoftLimiter<frames>::out_array_t expected_first{-30000, 30000};
 	EXPECT_EQ(out, expected_first);
 
@@ -192,20 +292,18 @@ TEST(SoftLimiter, AdjustPrescaleDown)
 	// be adjusted on-the-fly via callback. We simulate this callback here.
 	prescale.left = 0.5f;
 	prescale.right = 0.1f;
-	limiter.Apply(in, out, frames);
+	out = limiter.Apply(in, frames);
 	const SoftLimiter<frames>::out_array_t expected_scaled{-15000, 3000};
 	EXPECT_EQ(out, expected_scaled);
 }
 
-TEST(SoftLimiter, AdjustPrescaleUp)
+TEST(SoftLimiter, PrescaleAmplify)
 {
 	const auto frames = 1;
 	AudioFrame prescale{1, 1};
 	SoftLimiter<frames> limiter("test-channel", prescale);
-	SoftLimiter<frames>::in_array_t in{-10000.1f, 10000.0f};
-	SoftLimiter<frames>::out_array_t out{};
-
-	limiter.Apply(in, out, frames);
+	const SoftLimiter<frames>::in_array_t in{-10000.1f, 10000.0f};
+	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
 	const SoftLimiter<frames>::out_array_t expected_first{-10000, 10000};
 	EXPECT_EQ(out, expected_first);
 
@@ -213,7 +311,7 @@ TEST(SoftLimiter, AdjustPrescaleUp)
 	// be adjusted on-the-fly via callback. We simulate this callback here.
 	prescale.left = 1.5f;
 	prescale.right = 1.1f;
-	limiter.Apply(in, out, frames);
+	out = limiter.Apply(in, frames);
 	const SoftLimiter<frames>::out_array_t expected_scaled{-15000, 11000};
 	EXPECT_EQ(out, expected_scaled);
 }


### PR DESCRIPTION
To do this:
 - FluidSynth is switched to generating 32-bit floating-point samples
 - FluidSynth is operated using native MIDI sample amplitudes (without suppression or magnification)
 - Channel output level `"mixer fsynth <percent>"` commands pass the users desired level via callback to FluidSynth's SoftLimiter, which pre-scales the signal and avoids clipping when done downstream in dosbox's mixer

A couple other minor changes are introduced:
 - Using FluidSynth chorus and reverb setting refined by the ScummVM project (credit and references in the commit)
 - Using FluidSynth's 7th-order polynomial when generating waveforms

Should conclude:
 - Improves https://github.com/dosbox-staging/dosbox-staging/issues/262
 - Fixes https://github.com/dosbox-staging/dosbox-staging/issues/572