### PR TITLE
Contribute a static FluidSynth build script and use it for macOS snapshots

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,6 +79,8 @@ jobs:
             ccache-macos-release-${{ steps.prep-ccache.outputs.yesterday }}
       - name: Log environment
         run:  ./scripts/log-env.sh
+      - name: Build FluidSynth library
+        run:  cd contrib/static-fluidsynth && gmake
       - name: Build Opus libraries
         run: |
           set -x
@@ -95,6 +97,8 @@ jobs:
           echo ::set-env name=VERSION::$VERSION
       - name: Build
         env:
+          FLUIDSYNTH_CFLAGS: -I${{ github.workspace }}/contrib/static-fluidsynth/include
+          FLUIDSYNTH_LIBS: ${{ github.workspace }}/contrib/static-fluidsynth/lib/libfluidsynth.a -lm
           OPUSFILE_CFLAGS: -I${{ github.workspace }}/contrib/static-opus/include -I${{ github.workspace }}/contrib/static-opus/include/opus
           OPUSFILE_LIBS: ${{ github.workspace }}/contrib/static-opus/lib/libopusfile.a ${{ github.workspace }}/contrib/static-opus/lib/libogg.a ${{ github.workspace }}/contrib/static-opus/lib/libopus.a -lm
         run: |
@@ -103,7 +107,6 @@ jobs:
           ./configure \
             --enable-png-static \
             --enable-sdl-static \
-            --disable-fluidsynth \
             CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"
           gmake -j "$(sysctl -n hw.physicalcpu)"
           strip src/dosbox
@@ -115,7 +118,7 @@ jobs:
           # Generate icon
           make -C contrib/icons/ dosbox-staging.icns
 
-          dst=dist/dosbox-staging.app/Contents/
+          dst=dist/dosbox-staging.app/Contents
 
           # Prepare content
           install -d "$dst/MacOS/"
@@ -130,6 +133,32 @@ jobs:
           install -m 644 "COPYING"                           "$dst/SharedSupport/COPYING"
           install -m 644 "README"                            "$dst/SharedSupport/manual.txt"
           install -m 644 "docs/README.video"                 "$dst/SharedSupport/video.txt"
+
+          # Inventory the brew dependencies residing in /usr/local
+          gthread="/usr/local/opt/glib/lib/libgthread-2.0.0.dylib"
+          glib="/usr/local/opt/glib/lib/libglib-2.0.0.dylib"
+          glib_cellar="/usr/local/Cellar/glib/2.66.0/lib/libglib-2.0.0.dylib"
+          intl="/usr/local/opt/gettext/lib/libintl.8.dylib"
+          pcre="/usr/local/opt/pcre/lib/libpcre.1.dylib"
+
+          # Bundle brew dependencies along-side the dosbox executable
+          install -m 644 "$gthread" "$dst/MacOS/"
+          install -m 644 "$glib"    "$dst/MacOS/"
+          install -m 644 "$intl"    "$dst/MacOS/"
+          install -m 644 "$pcre"    "$dst/MacOS/"
+          install_name_tool -change "$glib_cellar" "@executable_path/${glib##*/}"    "$dst/MacOS/${gthread##*/}"
+          install_name_tool -change "$intl"        "@executable_path/${intl##*/}"    "$dst/MacOS/${glib##*/}"
+          install_name_tool -change "$pcre"        "@executable_path/${pcre##*/}"    "$dst/MacOS/${glib##*/}"
+          install_name_tool -change "$gthread"     "@executable_path/${gthread##*/}" "$dst/MacOS/dosbox"
+          install_name_tool -change "$glib"        "@executable_path/${glib##*/}"    "$dst/MacOS/dosbox"
+          install_name_tool -change "$intl"        "@executable_path/${intl##*/}"    "$dst/MacOS/dosbox"
+
+          # Perform a stand-alone execution test with /usr/local dependencies temporarily removed
+          dep_archive="/tmp/$$-deps.tar"
+          tar -cvPf "$dep_archive" "$gthread" "$glib" "$glib_cellar" "$intl" "$pcre"
+          rm -f "$gthread" "$glib" "$glib_cellar" "$intl" "$pcre"
+          "$dst/MacOS/dosbox" -c exit
+          tar -xvPf "$dep_archive" -C /
 
           # Fill README template file
           sed -i -e "s|%VERSION%|${{ env.VERSION }}|"           "$dst/Info.plist"

--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ sudo pacman -S gcc automake alsa-lib libpng sdl2 sdl2_net opusfile fluidsynth
 ``` shell
 # macOS
 xcode-select --install
-brew install autogen automake libpng sdl2 sdl2_net opusfile
+brew install autogen automake libpng sdl2 sdl2_net opusfile glib
 ```
 *Note: FluidSynth as a library is not available on macOS via brew.
-Use `--disable-fluidsynth` configure flag to disable the feature.*
+Either use the `--disable-fluidsynth` configure flag to disable the
+feature or run `gmake` inside `contrib/static-fluid-synth` and set
+the resulting two environment variables prior to `./configure`ing.*
 
 Compilation flags suggested for local optimised builds:
 

--- a/configure.ac
+++ b/configure.ac
@@ -514,21 +514,14 @@ AC_ARG_ENABLE(fluidsynth,
                              [Disable FluidSynth integration]))
 
 if test "${enable_fluidsynth}" != "no" ; then
-    AC_MSG_CHECKING(for FluidSynth >= 2.0.0)
-    AC_COMPILE_IFELSE(
-        [AC_LANG_SOURCE([
-            #include <fluidsynth.h>
-            static_assert(FLUIDSYNTH_VERSION_MAJOR >= 2, "");
-        ])],
-        [AC_MSG_RESULT(yes); USE_FLUIDSYNTH=yes],
-        [AC_MSG_RESULT(no);
-         AC_MSG_NOTICE(You can turn it off with --disable-fluidsynth);
-         AC_MSG_ERROR(FluidSynth >= 2.0.0 not found)])
-fi
-
-if test "${USE_FLUIDSYNTH}" = "yes" ; then
+    PKG_CHECK_MODULES(GLIB,
+                      [glib-2.0 >= 2.6.5 gthread-2.0 >= 2.6.5])
+    PKG_CHECK_MODULES(FLUIDSYNTH,
+                      fluidsynth >= 2,
+                      [LIBS="$LIBS $FLUIDSYNTH_LIBS $GLIB_LIBS"
+                       CPPFLAGS="$CPPFLAGS $FLUIDSYNTH_CFLAGS"
+                       USE_FLUIDSYNTH="yes"])
     AC_DEFINE(C_FLUIDSYNTH,1)
-    LIBS="$LIBS -lfluidsynth"
 else
     AC_DEFINE(C_FLUIDSYNTH,0)
     AC_MSG_WARN([FluidSynth integration disabled])

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -8,6 +8,8 @@ itself.
 
 - **icons**: Vector graphics and makefiles to re-create icons in .ico
   and .icns formats; read icons.md file for details
+- **static-fluidsynth**: Compiles a static FluidSynth library that can
+  be used by `./configure` in the absense of `pkg-config`
 - **static-opus**: Compiles a static Opusfile library that can be used
   by `./configure` in the absense of `pkg-config`
 - **macos**: Files required for creating macOS App bundle

--- a/contrib/static-fluidsynth/.gitignore
+++ b/contrib/static-fluidsynth/.gitignore
@@ -1,0 +1,6 @@
+include
+lib*
+fluidsynth
+fluidsynth-master.tar.gz
+share
+

--- a/contrib/static-fluidsynth/Makefile
+++ b/contrib/static-fluidsynth/Makefile
@@ -1,0 +1,124 @@
+##
+#  Fetch the latest dependencies from upstream
+#  -------------------------------------------
+FLUIDSYNTH_ARCHIVE = fluidsynth-master.tar.gz
+FLUIDSYNTH_URL = https://github.com/FluidSynth/fluidsynth/archive/master.tar.gz
+
+##
+#  Common commands and arguments
+#  -----------------------------
+THREADS = $(shell nproc || echo 4)
+CURL_FLAGS = --progress-bar
+CURL = curl --location $(CURL_FLAGS)
+WGET_FLAGS = --no-verbose --progress=bar
+WGET = wget --no-clobber $(WGET_FLAGS)
+EXTRACT = tar --strip 1 -zxof
+DIR := ${CURDIR}
+
+##
+#  Everything-targets
+#  ------------------
+.PHONY: all clean distclean
+all: fluidsynth
+clean: fluidsynth/clean
+distclean:
+	rm -rf bin fluidsynth include lib* share *.gz
+
+##
+#  Re-useable download function that tries curl, then wget, and then
+#  prompts the user to manually download the files.  Note that if
+#  one download fails then we assume they all will and therefore
+#  give the user the full list up-front.
+#
+define download
+	echo "Downloading $(URL) to ./$@"                                        \
+	&& $(CURL) "$(URL)" -o "$@"                                              \
+	|| $(WGET) "$(URL)" -O "$@"                                              \
+	|| ( rm -f "$@"                                                          \
+	     && echo ""                                                          \
+	     && echo "DOWNLOAD FAILURE"                                          \
+	     && echo "~~~~~~~~~~~~~~~~"                                          \
+	     && echo "Please manually download the following, then re-run make:" \
+	     && echo "  - $(FLUIDSYNTH_URL) to ./$(FLUIDSYNTH_ARCHIVE)"          \
+	     && echo ""                                                          \
+	     && echo "Alternatively, you can use your own curl or wget"          \
+	     && echo "arguments by passing CURL_FLAGS=\"--my-args\" and"         \
+	     && echo "WGET_FLAGS=\"--my-flags\" to the make command."            \
+	     && echo ""                                                          \
+	     && echo "For example, disable certificate checking:"                \
+	     && echo "    make CURL_FLAGS=\"-k\""                                \
+	     && echo "    make WGET_FLAGS=\"--no-check-certificate\""            \
+	     && echo ""                                                          \
+	   )
+endef
+
+##
+#  FluidSynth Library
+#  -------------------
+fluidsynth: fluidsynth-message
+
+fluidsynth: lib/libfluidsynth.a
+
+$(FLUIDSYNTH_ARCHIVE):
+	$(eval URL := $(FLUIDSYNTH_URL))
+	@$(download)
+
+fluidsynth/build: $(FLUIDSYNTH_ARCHIVE)
+	@test -f $@ \
+	|| (mkdir -p fluidsynth/build \
+	&& $(EXTRACT) $(FLUIDSYNTH_ARCHIVE) -C fluidsynth)
+
+fluidsynth/build/Makefile: fluidsynth/build
+	cd fluidsynth \
+	&& cd build \
+	&& cmake \
+	-DBUILD_SHARED_LIBS=0 \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX="$(DIR)" \
+	-DLIB_SUFFIX="" \
+	-Denable-alsa=0 \
+	-Denable-aufile=0 \
+	-Denable-coreaudio=0 \
+	-Denable-coremidi=0 \
+	-Denable-dbus=0 \
+	-Denable-dsound=0 \
+	-Denable-floats=1 \
+	-Denable-ipv6=0 \
+	-Denable-jack=0 \
+	-Denable-libsndfile=0 \
+	-Denable-midishare=0 \
+	-Denable-network=0 \
+	-Denable-oss=0 \
+	-Denable-portaudio=0 \
+	-Denable-pulseaudio=0 \
+	-Denable-readline=0 \
+	-Denable-sdl2=0 \
+	-Denable-waveout=0 \
+	-Denable-winmidi=0 \
+	..
+
+lib/libfluidsynth.a: fluidsynth/build/Makefile
+	cd fluidsynth/build \
+	&& $(MAKE) -j$(THREADS) \
+	&& $(MAKE) check \
+	&& mkdir -p ../../include/ ../../lib \
+	&& cp -rv ../include/* ../../include/ \
+	&& cp -rv include/* ../../include/ \
+	&& rm -f ../../lib/libfluidsynth.a \
+	&& ar -qc ../../lib/libfluidsynth.a src/CMakeFiles/libfluidsynth-OBJ.dir/*/*.o \
+	&& ranlib ../../lib/libfluidsynth.a
+
+define FLUIDSYNTH_EXPORTS
+
+Export the following to configure dosbox-staging without pkg-config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export FLUIDSYNTH_CFLAGS="-I$(CURDIR)/include"
+export FLUIDSYNTH_LIBS="$(CURDIR)/lib/libfluidsynth.a -lm"
+endef
+
+.PHONY: fluidsynth-message
+fluidsynth-message: lib/libfluidsynth.a
+	$(info $(FLUIDSYNTH_EXPORTS))
+
+fluidsynth/clean:
+	rm -rf fluidsynth/build

--- a/scripts/automator/packages/manager-brew
+++ b/scripts/automator/packages/manager-brew
@@ -1,3 +1,3 @@
 # Package repo: https://formulae.brew.sh/
 delim="@"
-packages+=(ccache coreutils autogen autoconf automake make pkg-config libpng ncurses sdl2 sdl2_net opusfile)
+packages+=(ccache coreutils autogen autoconf automake make pkg-config libpng ncurses sdl2 sdl2_net opusfile glib)

--- a/scripts/automator/packages/manager-dnf
+++ b/scripts/automator/packages/manager-dnf
@@ -1,2 +1,2 @@
 # Package repo: https://apps.fedoraproject.org/packages/
-packages+=(ccache libtool ncurses-devel SDL2-devel SDL2_net-devel opusfile-devel)
+packages+=(ccache libtool ncurses-devel SDL2-devel SDL2_net-devel opusfile-devel glib2-devel)

--- a/scripts/automator/packages/manager-macports
+++ b/scripts/automator/packages/manager-macports
@@ -1,3 +1,3 @@
 # Package repo: https://www.macports.org/ports.php?by=name
 delim=""
-packages+=(ccache coreutils autogen autoconf automake pkgconfig libpng ncurses libsdl2 libsdl2_net opusfile)
+packages+=(ccache coreutils autogen autoconf automake pkgconfig libpng ncurses libsdl2 libsdl2_net opusfile fluidsynth)

--- a/scripts/automator/packages/manager-vcpkg
+++ b/scripts/automator/packages/manager-vcpkg
@@ -1,2 +1,2 @@
 # Package repo: https://repology.org/projects/?inrepo=vcpkg
-packages+=(libpng pdcurses sdl2 sdl2-net opusfile)
+packages+=(libpng pdcurses sdl2 sdl2-net opusfile fluidsynth)


### PR DESCRIPTION
This PR does the following ...

## 1. Uses `pkg-config` to find FluidSynth in configure

In doing so, we can now provide our own package similar to Opus.

### Scenario 1 -- FluidSynth doesn't exist

``` text
checking for FLUIDSYNTH... no
configure: error: Package requirements (fluidsynth >= 2) were not met:

No package 'fluidsynth' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables FLUIDSYNTH_CFLAGS
and FLUIDSYNTH_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```

### Scenario 2 -- FluidSynth disabled with `--disable-fluidsynth`

``` text
configure: WARNING: FluidSynth integration disabled
```

### Scenario 3 -- FluidSynth present

``` text
checking for libpng... yes
configure: screenshots enabled... using -lpng16 -lz
checking for OPUSFILE... yes
checking for GLIB... yes
checking for FLUIDSYNTH... yes
checking for main in -lGL... yes
checking for main in -lopengl32... no
```

## 2. Contributes a static FluidSynth builder, exactly like Opus

Users no longer have to wait around for their distro repository to carry a half-recent FluidSynth 2.x library. For example, users of Raspberry Pi (Raspbian), Debian, and macOS (brew).  Perhaps even Fedora < 31 / CentOS / RHEL users.

It builds an optimized release build of the latest static FluidSynth with all unnecessary dependencies eliminated:

``` text
Audio / MIDI driver support:
  ALSA:                  no
  CoreAudio:             no
  CoreMIDI:              no
  DSound:                no
  JACK:                  no
  MidiShare:             no
  Oboe:                  no
  OpenSLES:              no
  OS/2 DART:             no
  OSS:                   no
  PortAudio:             no
  PulseAudio:            no
  SDL2:                  no
  WaveOut:               no
  WinMidi:               no

Support for SF3 files:   no (libsndfile not found)
Support for DLS files:   no (libinstpatch not found)

Audio to file rendering: no
  libsndfile:            no (RAW PCM rendering only)

Miscellaneous support:
  D-Bus:                 no
  LADSPA support:        no
  LASH support:          no
  NETWORK Support:       no
    IPV6 Support:        no
  Readline:              no
  systemd:               no

Developer nerds info:
  Samples type:          float
  Multithread rendering: yes
  OpenMP 4.0:            yes
  Profiling:             no
  Debug Build:           no
  Trap on FPE (debug):   no
  Check FPE (debug):     no
  UBSan (debug):         no
```
Because we're interfacing with the library and it's DOSBox that manages the samples, we don't need any of its network, recording, or service hooks.

Also, because it builds the latest code with optimizations, unit tests are run as well (and are gated):

``` text
Test project /usr/src/dosbox-staging/contrib/static-fluidsynth/fluidsynth/build/test
      Start  1: test_sample_cache
 1/17 Test  #1: test_sample_cache ................   Passed    0.02 sec
      Start  2: test_sfont_loading
 2/17 Test  #2: test_sfont_loading ...............   Passed    0.02 sec
      Start  3: test_sample_rate_change
 3/17 Test  #3: test_sample_rate_change ..........   Passed    0.01 sec
      Start  4: test_preset_sample_loading
 4/17 Test  #4: test_preset_sample_loading .......   Passed    0.02 sec
      Start  5: test_bug_635
 5/17 Test  #5: test_bug_635 .....................   Passed    0.03 sec
      Start  6: test_pointer_alignment
 6/17 Test  #6: test_pointer_alignment ...........   Passed    0.07 sec
      Start  7: test_seqbind_unregister
 7/17 Test  #7: test_seqbind_unregister ..........   Passed    0.01 sec
      Start  8: test_synth_chorus_reverb
 8/17 Test  #8: test_synth_chorus_reverb .........   Passed    0.01 sec
      Start  9: test_snprintf
 9/17 Test  #9: test_snprintf ....................   Passed    0.00 sec
      Start 10: test_synth_process
10/17 Test #10: test_synth_process ...............   Passed    0.00 sec
      Start 11: test_ct2hz
11/17 Test #11: test_ct2hz .......................   Passed    0.00 sec
      Start 12: test_sample_validate
12/17 Test #12: test_sample_validate .............   Passed    0.00 sec
      Start 13: test_seq_event_queue_sort
13/17 Test #13: test_seq_event_queue_sort ........   Passed    0.07 sec
      Start 14: test_seq_scale
14/17 Test #14: test_seq_scale ...................   Passed    0.01 sec
      Start 15: test_seq_evt_order
15/17 Test #15: test_seq_evt_order ...............   Passed    0.00 sec
      Start 16: test_seq_event_queue_remove
16/17 Test #16: test_seq_event_queue_remove ......   Passed    0.11 sec
      Start 17: test_jack_obtaining_synth
17/17 Test #17: test_jack_obtaining_synth ........   Passed    0.00 sec
```

User gets a copy & paste export block, just like Opus:

``` text
Export the following to configure dosbox-staging without pkg-config
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
export FLUIDSYNTH_CFLAGS="-I/usr/src/dosbox-staging/contrib/static-fluidsynth/include"
export FLUIDSYNTH_LIBS="/usr/src/dosbox-staging/contrib/static-fluidsynth/lib/libfluidsynth.a -lm"
```

## 3. Statically links FluidSynth into the macOS snapshots

![2020-10-01_16-27](https://user-images.githubusercontent.com/1557255/94873088-1b0a3980-0403-11eb-90a0-69d1f5d18354.png)

Includes a runtime test to ensure the binary is truly stand-alone:

![2020-10-01_16-27_1](https://user-images.githubusercontent.com/1557255/94873090-1ba2d000-0403-11eb-9c65-5c0385108887.png)
