### PR TITLE
Append "(debug build)" to the title bar text

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -419,15 +419,22 @@ bool startup_state_capslock=false;
 void GFX_SetTitle(Bit32s cycles, int /*frameskip*/, bool paused)
 {
 	char title[200] = {0};
+
+#if !defined(NDEBUG)
+	const char* build_type = " (debug build)";
+#else
+	const char* build_type = "";
+#endif
+
 	static Bit32s internal_cycles = 0;
 	if (cycles != -1)
 		internal_cycles = cycles;
 
 	const char *msg = CPU_CycleAutoAdjust
-	                          ? "%8s - max %d%% - dosbox-staging%s"
-	                          : "%8s - %d cycles/ms - dosbox-staging%s";
+	                          ? "%8s - max %d%% - dosbox-staging%s%s"
+	                          : "%8s - %d cycles/ms - dosbox-staging%s%s";
 	snprintf(title, sizeof(title), msg, RunningProgram, internal_cycles,
-	         paused ? " (PAUSED)" : "");
+	         build_type, paused ? " (PAUSED)" : "");
 	SDL_SetWindowTitle(sdl.window, title);
 }
 


### PR DESCRIPTION
When NDEBUG is not defined the title bar shows:
` "<cycles> - dosbox-staging (debug build)"`
Otherwise the debug indicator is not appended:
` "<cycles> - dosbox-staging"`

![2020-10-04_09-56](https://user-images.githubusercontent.com/1557255/95021884-9bf64a80-0628-11eb-92c2-77305b15dcb9.png)

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/643.