### PR TITLE
Amend DNF package dependencies per Fedora 32 Workstation needs

### DIFF
--- a/scripts/automator/packages/gcc-dnf
+++ b/scripts/automator/packages/gcc-dnf
@@ -1,0 +1,2 @@
+# DNF provides a 'default' version of gcc is available, so we avoid post-fixing the version
+compiler=(gcc g++)

--- a/scripts/automator/packages/manager-dnf
+++ b/scripts/automator/packages/manager-dnf
@@ -1,2 +1,3 @@
 # Package repo: https://apps.fedoraproject.org/packages/
-packages+=(ccache libtool ncurses-devel SDL2-devel SDL2_net-devel opusfile-devel glib2-devel)
+packages+=(ccache make cmake libpng-devel libtool ncurses-devel
+           SDL2-devel SDL2_net-devel opusfile-devel glib2-devel)


### PR DESCRIPTION
After a clean installation of Fedora 32 Workstation, I attempted to install the dosbox-staging dependencies per `./script/list-packages.sh -m dnf -c gcc`, however it came up short and I found myself having to manually install the remainder.

This commit adds those that were missing, and is now confirmed to build a full-featured dosbox-staging plus static FluidSynth 2.1.15 library.
