### PR TITLE
Cleanup some warnings; October, part 1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,20 +21,20 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 43
+            max_warnings: 36
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 45
+            max_warnings: 38
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 45
+            max_warnings: 38
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 3
+            max_warnings: 2
           - name: Ubuntu, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 155
+            max_warnings: 148
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 45
+            max_warnings: 38
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 189
+            max_warnings: 182
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 43
+            max_warnings: 36
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,17 +24,17 @@ jobs:
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 38
+            max_warnings: 13
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 38
+            max_warnings: 13
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 36
+            max_warnings: 11
           - name: GCC, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 148
+            max_warnings: 123
           - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 38
+            max_warnings: 13
           - name: GCC, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 182
+            max_warnings: 157
           - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 36
+            max_warnings: 11
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,16 +21,16 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 50
+            max_warnings: 43
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 52
+            max_warnings: 45
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 52
+            max_warnings: 45
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 162
+            max_warnings: 155
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 52
+            max_warnings: 45
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 196
+            max_warnings: 189
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 50
+            max_warnings: 43
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,16 +21,16 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 51
+            max_warnings: 50
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 53
+            max_warnings: 52
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 53
+            max_warnings: 52
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 163
+            max_warnings: 162
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 53
+            max_warnings: 52
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 197
+            max_warnings: 196
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 51
+            max_warnings: 50
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,16 +21,16 @@ jobs:
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 52
+            max_warnings: 51
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 54
+            max_warnings: 53
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 54
+            max_warnings: 53
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 164
+            max_warnings: 163
           - name: Ubuntu, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 54
+            max_warnings: 53
           - name: Ubuntu, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 198
+            max_warnings: 197
           - name: Ubuntu, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 52
+            max_warnings: 51
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,47 +17,47 @@ jobs:
       max-parallel: 3
       matrix:
         conf:
-          - name: GCC, Ubuntu 16.04
-            os: ubuntu-16.04
+          - name: Clang, Ubuntu 20.04
+            os: ubuntu-20.04
+            flags: -c clang -v 10
+            max_warnings: 2
+          - name: GCC, Ubuntu 20.04
+            os: ubuntu-20.04
             flags: -c gcc
-            config_flags: --disable-fluidsynth
-            max_warnings: 36
+            max_warnings: 38
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
             max_warnings: 38
-          - name: GCC, Ubuntu 20.04
-            os: ubuntu-20.04
+          - name: GCC, Ubuntu 16.04
+            os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 38
-          - name: Clang, Ubuntu 20.04
-            os: ubuntu-20.04
-            flags: -c clang -v 10
-            max_warnings: 2
-          - name: Ubuntu, +tests
+            config_flags: --disable-fluidsynth
+            max_warnings: 36
+          - name: GCC, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
             add_packages: libgtest-dev
             flags: -c gcc
             run_tests: true
             max_warnings: -1
-          - name: Ubuntu, +debug
+          - name: GCC, +debug
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
             max_warnings: 148
-          - name: Ubuntu, +dynrec, -dyn_x86
+          - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
             max_warnings: 38
-          - name: Ubuntu, +dynrec, +debug, -dyn_x86
+          - name: GCC, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
             max_warnings: 182
-          - name: Ubuntu, -network
+          - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 1
+            max_warnings: 0
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 45
+            max_warnings: 38
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 0
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 38
+            max_warnings: 13
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 1
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 52
+            max_warnings: 45
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 1
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 54
+            max_warnings: 53
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 1
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 53
+            max_warnings: 52
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 470
+          MAX_BUGS: 471
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -905,9 +905,8 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
 		if ((device_type==0x0001) && (font_type==0x0001) && (font_codepage==codepage_id)) {
 			// valid/matching codepage found
 
-			Bit16u number_of_fonts,font_data_length;
-			number_of_fonts=host_readw(&cpi_buf[font_data_header_pt+0x02]);
-			font_data_length=host_readw(&cpi_buf[font_data_header_pt+0x04]);
+			const uint16_t number_of_fonts = host_readw(&cpi_buf[font_data_header_pt + 0x02]);
+			// const uint16_t font_data_length = host_readw(&cpi_buf[font_data_header_pt + 0x04]);
 
 			bool font_changed=false;
 			Bit32u font_data_start=font_data_header_pt+0x06;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -257,20 +257,20 @@ struct SDL_Block {
 		double scaley = 1.0;
 		double pixel_aspect = 1.0;
 		GFX_CallBack_t callback = nullptr;
-	} draw;
+	} draw = {};
 	struct {
 		struct {
 			Bit16u width = 0;
 			Bit16u height = 0;
 			bool fixed = false;
 			bool display_res = false;
-		} full;
+		} full = {};
 		struct {
 			uint16_t width = 0; // TODO convert to int
 			uint16_t height = 0; // TODO convert to int
 			bool use_original_size = true;
 			bool resizable = false;
-		} window;
+		} window = {};
 		Bit8u bpp = 0;
 		bool fullscreen = false;
 		// This flag indicates, that we are in the process of switching
@@ -286,7 +286,7 @@ struct SDL_Block {
 		bool want_resizable_window = false;
 		SCREEN_TYPES type;
 		SCREEN_TYPES want_type;
-	} desktop;
+	} desktop = {};
 #if C_OPENGL
 	struct {
 		SDL_GLContext context;
@@ -308,17 +308,17 @@ struct SDL_Block {
 			GLint input_size;
 			GLint output_size;
 			GLint frame_count;
-		} ruby;
+		} ruby = {};
 		GLuint actual_frame_count;
 		GLfloat vertex_data[2*3];
-	} opengl;
+	} opengl = {};
 #endif // C_OPENGL
 	struct {
 		PRIORITY_LEVELS focus;
 		PRIORITY_LEVELS nofocus;
-	} priority;
-	SDL_Rect clip;
-	SDL_Surface *surface;
+	} priority = {};
+	SDL_Rect clip = {0, 0, 0, 0};
+	SDL_Surface *surface = nullptr;
 	SDL_Window *window = nullptr;
 	SDL_Renderer *renderer = nullptr;
 	std::string render_driver = "";
@@ -327,7 +327,7 @@ struct SDL_Block {
 		SDL_Surface *input_surface = nullptr;
 		SDL_Texture *texture = nullptr;
 		SDL_PixelFormat *pixelFormat = nullptr;
-	} texture;
+	} texture = {};
 	struct {
 		int xsensitivity = 0;
 		int ysensitivity = 0;
@@ -335,7 +335,7 @@ struct SDL_Block {
 		MouseControlType control_choice = Seamless;
 		bool middle_will_release = true;
 		bool has_focus = false;
-	} mouse;
+	} mouse = {};
 	SDL_Point pp_scale = {1, 1};
 	SDL_Rect updateRects[1024];
 #if defined (WIN32)

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -432,13 +432,10 @@ void sn76496_base_device::sound_stream_update(sound_stream &stream, stream_sampl
 				// if noisemode is 1, both taps are enabled
 				// if noisemode is 0, the lower tap, whitenoisetap2, is held at 0
 				// The != was a bit-XOR (^) before
-				if (((m_RNG & m_whitenoise_tap1)!=0) != (((m_RNG & m_whitenoise_tap2)!=(m_ncr_style_psg?m_whitenoise_tap2:0)) && in_noise_mode()))
-				{
+				if (((m_RNG & m_whitenoise_tap1) != 0) != ((static_cast<int32_t>(m_RNG & m_whitenoise_tap2) != (m_ncr_style_psg ? m_whitenoise_tap2 : 0)) && in_noise_mode())) {
 					m_RNG >>= 1;
 					m_RNG |= m_feedback_mask;
-				}
-				else
-				{
+				} else {
 					m_RNG >>= 1;
 				}
 				m_output[3] = m_RNG & 1;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -459,21 +459,33 @@ static void FinishSetMode(bool clearmem) {
 				real_writew( 0xb800,ct*2,0x0000);
 			}
 			break;
+		case M_HERC_TEXT:
+		case M_TANDY_TEXT:
 		case M_TEXT: {
+			// TODO Hercules had 32KiB compared to CGA/MDA 16KiB,
+			// but does it matter in here?
 			Bit16u seg = (CurMode->mode==7)?0xb000:0xb800;
 			for (Bit16u ct=0;ct<16*1024;ct++) real_writew(seg,ct*2,0x0720);
 			break;
 		}
-		case M_EGA:	
+		case M_EGA:
 		case M_VGA:
 		case M_LIN8:
 		case M_LIN4:
 		case M_LIN15:
 		case M_LIN16:
 		case M_LIN32:
+		case M_TANDY2:
+		case M_TANDY4:
+		case M_HERC_GFX:
+		case M_CGA16:
 			/* Hack we just access the memory directly */
 			memset(vga.mem.linear,0,vga.vmemsize);
 			memset(vga.fastmem, 0, vga.vmemsize<<1);
+			break;
+		case M_ERROR:
+			assert(false);
+			break;
 		}
 	}
 	/* Setup the BIOS */


### PR DESCRIPTION
Initial commits silence some trivial/annoying warnings.

5992abc4d0e0a74cf4e62e28e0ed6a68d959fc9f - this one is non-trivial; I hope it makes sense.

And one commit for reorganising Linux jobs order/naming a little bit.