### PR TITLE
Replace set-env with new mechanism for updating CI env

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -128,7 +128,7 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build
         env:
           AR: gcc-ar
@@ -227,7 +227,7 @@ jobs:
           set +x
           git fetch --unshallow
           VERSION=$(git describe --abbrev=4)
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,7 +94,7 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=5)
           sed -i -e "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build
         env:
           FLUIDSYNTH_CFLAGS: -I${{ github.workspace }}/contrib/static-fluidsynth/include
@@ -219,7 +219,7 @@ jobs:
           set +x
           git fetch --unshallow
           VERSION=$(git describe --abbrev=4)
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -47,7 +47,7 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Build
         uses: uraimo/run-on-arch-action@master
@@ -89,7 +89,7 @@ jobs:
 
           # Create tarball
           tar -cJf "$PACKAGE.tar.xz" "$PACKAGE"
-          echo ::set-env name=PACKAGE::$PACKAGE
+          echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
 
       - name: Clam AV scan
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,7 +118,7 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
           sed -i "s|VERSION \"git\"|VERSION \"$VERSION\"|" src/platform/visualc/config.h
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name:  Build
         shell: pwsh
@@ -194,7 +194,7 @@ jobs:
           set +x
           git fetch --unshallow
           VERSION=$(git describe --abbrev=4)
-          echo ::set-env name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
See:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/