### PR TITLE
Use the Brew-provided FluidSynth library for MacOS debug builds and in the build notes 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
       - name: Build
-        run:  ./scripts/build.sh --build-type Debug ${{ matrix.conf.flags }} --disable-fluidsynth
+        run:  ./scripts/build.sh --build-type Debug ${{ matrix.conf.flags }}
       - name: Summarize warnings
         env:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}

--- a/README.md
+++ b/README.md
@@ -129,12 +129,8 @@ sudo pacman -S gcc automake alsa-lib libpng sdl2 sdl2_net opusfile fluidsynth
 ``` shell
 # macOS
 xcode-select --install
-brew install autogen automake libpng sdl2 sdl2_net opusfile glib
+brew install autogen automake libpng sdl2 sdl2_net opusfile fluid-synth
 ```
-*Note: FluidSynth as a library is not available on macOS via brew.
-Either use the `--disable-fluidsynth` configure flag to disable the
-feature or run `gmake` inside `contrib/static-fluid-synth` and set
-the resulting two environment variables prior to `./configure`ing.*
 
 Compilation flags suggested for local optimised builds:
 

--- a/scripts/automator/packages/manager-brew
+++ b/scripts/automator/packages/manager-brew
@@ -1,3 +1,3 @@
 # Package repo: https://formulae.brew.sh/
 delim="@"
-packages+=(ccache coreutils autogen autoconf automake make pkg-config libpng ncurses sdl2 sdl2_net opusfile glib)
+packages+=(ccache coreutils autogen autoconf automake make pkg-config libpng ncurses sdl2 sdl2_net opusfile fluid-synth)


### PR DESCRIPTION
Not much discussion for what _was_ changed, but I do want to explain why I left the snapshot builds using the static library:

Currently our snapshots are 100% stand-alone and will run out-of-the-box on any Catalina macOS system without XCode or Brew, which I feel gives the project the widest possible audience for those offering help testing.

If we switched our snapshots to use the brew library, this creates hard-coded dependencies into the `/usr/local/... */` Brew area, which requires users have both XCode and Brew installed.  To make matters worse, the Brew directories are hard-coded with version numbers, so there's an additional risk that the versions used on the CI build system differ from what the user has installed. 