### PR TITLE
Introduce filesystem utilities

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -15,6 +15,7 @@ noinst_HEADERS = \
 	drives.h \
 	envelope.h \
 	fpu.h \
+	fs_utils.h \
 	hardware.h \
 	inout.h \
 	ipx.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,45 +1,45 @@
-noinst_HEADERS =  \
-bios_disk.h \
-bios.h \
-byteorder.h \
-callback.h \
-compiler.h \
-control.h \
-cpu.h \
-cross.h \
-debug.h \
-dma.h \
-dosbox.h \
-dos_inc.h \
-dos_system.h \
-drives.h \
-envelope.h \
-fpu.h \
-hardware.h \
-inout.h \
-ipx.h \
-ipxserver.h \
-joystick.h \
-keyboard.h \
-logging.h \
-mapper.h \
-mem.h \
-mem_host.h \
-mem_unaligned.h \
-midi.h \
-mixer.h \
-mouse.h \
-paging.h \
-pci_bus.h \
-pic.h \
-programs.h \
-regs.h \
-render.h \
-serialport.h \
-setup.h \
-shell.h \
-support.h \
-timer.h \
-types.h \
-vga.h \
-video.h
+noinst_HEADERS = \
+	bios.h \
+	bios_disk.h \
+	byteorder.h \
+	callback.h \
+	compiler.h \
+	control.h \
+	cpu.h \
+	cross.h \
+	debug.h \
+	dma.h \
+	dos_inc.h \
+	dos_system.h \
+	dosbox.h \
+	drives.h \
+	envelope.h \
+	fpu.h \
+	hardware.h \
+	inout.h \
+	ipx.h \
+	ipxserver.h \
+	joystick.h \
+	keyboard.h \
+	logging.h \
+	mapper.h \
+	mem.h \
+	mem_host.h \
+	mem_unaligned.h \
+	midi.h \
+	mixer.h \
+	mouse.h \
+	paging.h \
+	pci_bus.h \
+	pic.h \
+	programs.h \
+	regs.h \
+	render.h \
+	serialport.h \
+	setup.h \
+	shell.h \
+	support.h \
+	timer.h \
+	types.h \
+	vga.h \
+	video.h

--- a/include/cross.h
+++ b/include/cross.h
@@ -44,7 +44,6 @@
 #if defined (WIN32)
 #define CROSS_FILENAME(blah) 
 #define CROSS_FILESPLIT '\\'
-#define F_OK 0
 #else
 #define	CROSS_FILENAME(blah) strreplace(blah,'\\','/')
 #define CROSS_FILESPLIT '/'

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -1,0 +1,35 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_FS_UTILS_H
+#define DOSBOX_FS_UTILS_H
+
+#include <string>
+
+// Checks if the given path corresponds to an existing file or directory.
+
+bool path_exists(const char *path) noexcept;
+
+inline bool path_exists(const std::string &path) noexcept
+{
+	return path_exists(path.c_str());
+}
+
+#endif

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -19,6 +19,7 @@
 // #define DEBUG 1
 
 #include "cdrom.h"
+
 #include <cassert>
 #include <cctype>
 #include <chrono>
@@ -30,7 +31,6 @@
 #include <limits>
 #include <sstream>
 #include <vector>
-#include <sys/stat.h>
 
 #if !defined(WIN32)
 #include <libgen.h>
@@ -39,6 +39,7 @@
 #endif
 
 #include "drives.h"
+#include "fs_utils.h"
 #include "support.h"
 #include "setup.h"
 
@@ -1392,17 +1393,17 @@ bool CDROM_Interface_Image::HasDataTrack(void)
 bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 {
 	// check if file exists
-	struct stat test;
-	if (stat(filename.c_str(), &test) == 0) {
+	if (path_exists(filename)) {
 		return true;
 	}
 
 	// check if file with path relative to cue file exists
 	string tmpstr(pathname + "/" + filename);
-	if (stat(tmpstr.c_str(), &test) == 0) {
+	if (path_exists(tmpstr)) {
 		filename = tmpstr;
 		return true;
 	}
+
 	// finally check if file is in a dosbox local drive
 	char fullname[CROSS_LEN];
 	char tmp[CROSS_LEN];
@@ -1415,7 +1416,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 	localDrive *ldp = dynamic_cast<localDrive*>(Drives[drive]);
 	if (ldp) {
 		ldp->GetSystemFilename(tmp, fullname);
-		if (stat(tmp, &test) == 0) {
+		if (path_exists(tmp)) {
 			filename = tmp;
 			return true;
 		}
@@ -1433,13 +1434,13 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 		if (copy[i] == '\\') copy[i] = '/';
 	}
 
-	if (stat(copy.c_str(), &test) == 0) {
+	if (path_exists(copy)) {
 		filename = copy;
 		return true;
 	}
 
 	tmpstr = pathname + "/" + copy;
-	if (stat(tmpstr.c_str(), &test) == 0) {
+	if (path_exists(tmpstr)) {
 		filename = tmpstr;
 		return true;
 	}

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -38,6 +38,7 @@
 
 #include "dos_inc.h"
 #include "dos_mscdex.h"
+#include "fs_utils.h"
 #include "support.h"
 #include "cross.h"
 #include "inout.h"
@@ -420,8 +421,7 @@ bool localDrive::TestDir(char * dir) {
 		if (stat(newdir,&test))			return false;
 		if ((test.st_mode & S_IFDIR)==0)	return false;
 	};
-	int temp=access(newdir,F_OK);
-	return (temp==0);
+	return path_exists(newdir);
 }
 
 bool localDrive::Rename(char * oldname,char * newname) {

--- a/src/misc/Makefile.am
+++ b/src/misc/Makefile.am
@@ -1,4 +1,11 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LIBRARIES = libmisc.a
-libmisc_a_SOURCES = cross.cpp messages.cpp programs.cpp setup.cpp support.cpp
+
+libmisc_a_SOURCES = \
+	cross.cpp \
+	fs_utils.cpp \
+	messages.cpp \
+	programs.cpp \
+	setup.cpp \
+	support.cpp

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -39,6 +39,7 @@
 #include <pwd.h>
 #endif
 
+#include "fs_utils.h"
 #include "support.h"
 
 static std::string GetConfigName()
@@ -85,11 +86,6 @@ static bool CreateDirectories(const std::string &path)
 	return (mkdir(path.c_str(), 0700) == 0);
 }
 
-static bool PathExists(const std::string &path)
-{
-	return (access(path.c_str(), F_OK) == 0);
-}
-
 static std::string DetermineConfigPath()
 {
 	const char *xdg_conf_home = getenv("XDG_CONFIG_HOME");
@@ -97,11 +93,11 @@ static std::string DetermineConfigPath()
 	const std::string conf_path = ResolveHome(conf_home + "/dosbox");
 	const std::string old_conf_path = ResolveHome("~/.dosbox");
 
-	if (PathExists(conf_path + "/" + GetConfigName())) {
+	if (path_exists(conf_path + "/" + GetConfigName())) {
 		return conf_path;
 	}
 
-	if (PathExists(old_conf_path + "/" + GetConfigName())) {
+	if (path_exists(old_conf_path + "/" + GetConfigName())) {
 		LOG_MSG("WARNING: Config file found in deprecated path! (~/.dosbox)\n"
 		        "Backup/remove this dir and restart to generate updated config file.\n"
 		        "---");
@@ -239,7 +235,7 @@ dir_information* open_directory(const char* dirname) {
 
 	dir.handle = INVALID_HANDLE_VALUE;
 
-	return (access(dirname,0) ? NULL : &dir);
+	return (path_exists(dirname) ? nullptr : &dir);
 }
 
 bool read_directory_first(dir_information* dirp, char* entry_name, bool& is_directory) {

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -1,0 +1,37 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_FS_UTILS_H
+#define DOSBOX_FS_UTILS_H
+
+#include "fs_utils.h"
+
+#include <unistd.h>
+
+bool path_exists(const char *path) noexcept
+{
+#if defined(WIN32)
+	return (access(path, 0) == 0);
+#else
+	return (access(path, F_OK) == 0);
+#endif
+}
+
+#endif

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -25,9 +25,9 @@
 #include "callback.h"
 #include "control.h"
 #include "dosbox.h"
+#include "fs_utils.h"
 #include "regs.h"
 #include "support.h"
-
 
 Bitu call_shellstop;
 /* Larger scope so shell_del autoexec can use it to
@@ -475,7 +475,8 @@ public:
 					if(!name) continue;
 				}
 				*name++ = 0;
-				if (access(buffer,F_OK)) continue;
+				if (path_exists(buffer))
+					continue;
 				autoexec[12].Install(std::string("MOUNT C \"") + buffer + "\"");
 				autoexec[13].Install("C:");
 				/* Save the non-modified filename (so boot and imgmount can use it (long filenames, case sensivitive)) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,7 +16,8 @@ endif
 tests_SOURCES = \
 	example.cpp \
 	soft_limiter.cpp \
-	support.cpp
+	support.cpp \
+	fs_utils.cpp
 
 tests_LDADD = ../src/misc/libmisc.a
 

--- a/tests/fs_utils.cpp
+++ b/tests/fs_utils.cpp
@@ -1,0 +1,56 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "fs_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace {
+
+TEST(PathExists, DirExists)
+{
+	EXPECT_TRUE(path_exists("tests"));
+}
+
+TEST(PathExists, FileExists)
+{
+	EXPECT_TRUE(path_exists("tests/fs_utils.cpp"));
+}
+
+TEST(PathExists, MissingPath)
+{
+	EXPECT_FALSE(path_exists("foobar"));
+}
+
+TEST(PathExists, ExistingPathAsString)
+{
+	const std::string path = "tests/fs_utils.cpp";
+	EXPECT_TRUE(path_exists(path));
+}
+
+TEST(PathExists, MissingPathAsString)
+{
+	const std::string path = "barbaz";
+	EXPECT_FALSE(path_exists("foobar"));
+}
+
+} // namespace

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -360,6 +360,7 @@
     <ClCompile Include="..\src\midi\midi.cpp" />
     <ClCompile Include="..\src\midi\midi_fluidsynth.cpp" />
     <ClCompile Include="..\src\misc\cross.cpp" />
+    <ClCompile Include="..\src\misc\fs_utils.cpp" />
     <ClCompile Include="..\src\misc\messages.cpp" />
     <ClCompile Include="..\src\misc\programs.cpp" />
     <ClCompile Include="..\src\misc\setup.cpp" />
@@ -389,6 +390,7 @@
     <ClInclude Include="..\include\drives.h" />
     <ClInclude Include="..\include\envelope.h" />
     <ClInclude Include="..\include\fpu.h" />
+    <ClInclude Include="..\include\fs_utils.h" />
     <ClInclude Include="..\include\hardware.h" />
     <ClInclude Include="..\include\inout.h" />
     <ClInclude Include="..\include\joystick.h" />


### PR DESCRIPTION
I want to have a new file for functions related to OS paths and filesystem access.

Theoretically, we could wait for `std::filesystem` in C++17… but once I looked through the interfaces, some of them are less convenient than using C functions.

Upstream placed some filesystem related functions in `std/misc/cross.cpp`, which is somewhat misleading.

This is prerequisite for several other tasks, such as:

#102 and adding better SF2 file lookup for #539 