### PR TITLE
Implement to_native_path function

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -47,6 +47,15 @@
 #define MAYBE_UNUSED
 #endif
 
+// Wrapper for C++17 [[fallthrough]] null statement. Use this to avoid implicit
+// fallthrough in switch statements (-Wimplicit-fallthrough flag).
+
+#if __has_cpp_attribute(fallthrough)
+#define FALLTHROUGH [[fallthrough]]
+#else
+#define FALLTHROUGH
+#endif
+
 // The __attribute__ syntax is supported by GCC, Clang, and IBM compilers.
 //
 // Provided for backwards-compatibility with old code; to be gradually

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -23,7 +23,8 @@
 
 #include <string>
 
-// Checks if the given path corresponds to an existing file or directory.
+/* Check if the given path corresponds to an existing file or directory.
+ */
 
 bool path_exists(const char *path) noexcept;
 
@@ -31,5 +32,24 @@ inline bool path_exists(const std::string &path) noexcept
 {
 	return path_exists(path.c_str());
 }
+
+/* Convert path (possibly in format used by different OS) to a path
+ * native for host OS.
+ *
+ * If path (after conversion) does not correspond to an existing file or
+ * directory, then an empty string is returned.
+ *
+ * On Unix-like systems:
+ * - Expand ~ and ~name to paths in appropriate home directory.
+ * - Convert Windows-style path separators to Unix-style separators.
+ * - If case-insensitive, relative path matches an existing file in the
+ *   filesystem, then return case-sensitive path to that file.
+ * - If more than one files match, return the first one (alphabetically).
+ *
+ * On Windows:
+ * - If path points to an existing file, then return the path unmodified.
+ */
+
+std::string to_native_path(const std::string &path) noexcept;
 
 #endif

--- a/include/logging.h
+++ b/include/logging.h
@@ -21,6 +21,8 @@
 
 #include <cstdio>
 
+#include "compiler.h"
+
 enum LOG_TYPES {
 	LOG_ALL,
 	LOG_VGA, LOG_VGAGFX,LOG_VGAMISC,LOG_INT10,

--- a/include/support.h
+++ b/include/support.h
@@ -176,6 +176,7 @@ char * StripWord(char *&cmd);
 bool IsHexWord(char * word);
 Bits ConvHexWord(char * word);
 
+std::string replace(const std::string &str, char old_char, char new_char) noexcept;
 void trim(std::string& str);
 void upcase(std::string &str);
 void lowcase(std::string &str);

--- a/src/misc/Makefile.am
+++ b/src/misc/Makefile.am
@@ -4,7 +4,8 @@ noinst_LIBRARIES = libmisc.a
 
 libmisc_a_SOURCES = \
 	cross.cpp \
-	fs_utils.cpp \
+	fs_utils_posix.cpp \
+	fs_utils_win32.cpp \
 	messages.cpp \
 	programs.cpp \
 	setup.cpp \

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -51,9 +51,7 @@ static std::string translate_to_glob_pattern(const std::string &path) noexcept
 		case '?':
 		case '*':
 		case '[':
-		case ']':
-			glob_pattern.push_back('\\');
-			// fall-through
+		case ']': glob_pattern.push_back('\\'); FALLTHROUGH;
 		default: glob_pattern.push_back(c); continue;
 		}
 	}

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -1,0 +1,32 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#if !defined(WIN32)
+
+#include "fs_utils.h"
+
+#include <unistd.h>
+
+bool path_exists(const char *path) noexcept
+{
+	return (access(path, F_OK) == 0);
+}
+
+#endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -18,20 +18,15 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#ifndef DOSBOX_FS_UTILS_H
-#define DOSBOX_FS_UTILS_H
+#if defined(WIN32)
 
 #include "fs_utils.h"
 
-#include <unistd.h>
+#include <io.h>
 
 bool path_exists(const char *path) noexcept
 {
-#if defined(WIN32)
-	return (access(path, 0) == 0);
-#else
-	return (access(path, F_OK) == 0);
-#endif
+	return (_access(path, 0) == 0);
 }
 
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -29,4 +29,11 @@ bool path_exists(const char *path) noexcept
 	return (_access(path, 0) == 0);
 }
 
+std::string to_native_path(const std::string &path) noexcept
+{
+	if (path_exists(path))
+		return path;
+	return "";
+}
+
 #endif

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -112,6 +112,15 @@ bool is_executable_filename(const std::string &filename) noexcept
 	return (sfx == "exe" || sfx == "bat" || sfx == "com");
 }
 
+std::string replace(const std::string &str, char old_char, char new_char) noexcept
+{
+	std::string new_str = str;
+	for (char &c : new_str)
+		if (c == old_char)
+			c = new_char;
+	return str;
+}
+
 void trim(std::string &str)
 {
 	constexpr char whitespace[] = " \r\t\f\n";

--- a/tests/fs_utils.cpp
+++ b/tests/fs_utils.cpp
@@ -53,4 +53,22 @@ TEST(PathExists, MissingPathAsString)
 	EXPECT_FALSE(path_exists("foobar"));
 }
 
+TEST(PathConversion, SimpleTest)
+{
+	constexpr auto expected_result = "tests/files/paths/empty.txt";
+	constexpr auto input = "tests\\files\\PATHS\\EMPTY.TXT";
+	ASSERT_TRUE(path_exists(expected_result));
+	EXPECT_TRUE(path_exists(to_native_path(input)));
+#if !defined(WIN32)
+	EXPECT_EQ(expected_result, to_native_path(input));
+#endif
+}
+
+TEST(PathConversion, MissingFile)
+{
+	constexpr auto nonexistent_file = "tests/files/paths/missing.txt";
+	ASSERT_FALSE(path_exists(nonexistent_file));
+	EXPECT_FALSE(path_exists(to_native_path(nonexistent_file)));
+}
+
 } // namespace

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -360,7 +360,7 @@
     <ClCompile Include="..\src\midi\midi.cpp" />
     <ClCompile Include="..\src\midi\midi_fluidsynth.cpp" />
     <ClCompile Include="..\src\misc\cross.cpp" />
-    <ClCompile Include="..\src\misc\fs_utils.cpp" />
+    <ClCompile Include="..\src\misc\fs_utils_win32.cpp" />
     <ClCompile Include="..\src\misc\messages.cpp" />
     <ClCompile Include="..\src\misc\programs.cpp" />
     <ClCompile Include="..\src\misc\setup.cpp" />


### PR DESCRIPTION
Quick summary (details are in commit messages of course)

- Correct ifdef issue in fs_utils.cpp
- Split it into two files (as practically every function in this file will have separate implementations on Windows and on POSIX)
- Implement `to_native_path` using `glob(3)` - see tests for how I plan for it to be used
- Add FALLTHROUGH macro (to be removed when we'll switch to C++17)

This function is required for implementing automatic correction of .cue files and mount/imgmount paths for #102 (I have proof of concept ready, just want to decorate it with tests).