### PR TITLE
Cleanup some warnings; October part 3

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -77,7 +77,7 @@ jobs:
           path: report
       - name: Summarize report
         env:
-          MAX_BUGS: 194
+          MAX_BUGS: 192
         run: |
           # summary
           echo "Full report is included in build Artifacts"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,17 +24,17 @@ jobs:
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 8
+            max_warnings: 7
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 8
+            max_warnings: 7
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 6
+            max_warnings: 5
           - name: GCC, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 115
+            max_warnings: 114
           - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 8
+            max_warnings: 7
           - name: GCC, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 152
+            max_warnings: 151
           - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 8
+            max_warnings: 7
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,17 +24,17 @@ jobs:
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 7
+            max_warnings: 2
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 7
+            max_warnings: 2
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 5
+            max_warnings: 0
           - name: GCC, +tests
             os: ubuntu-20.04
             config_flags: --enable-tests
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 114
+            max_warnings: 109
           - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 7
+            max_warnings: 2
           - name: GCC, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 151
+            max_warnings: 146
           - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 7
+            max_warnings: 2
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 0
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 7
+            max_warnings: 2
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 0
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 8
+            max_warnings: 7
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1265,8 +1265,8 @@ class Typer {
 				std::this_thread::sleep_for(std::chrono::milliseconds(m_pace_ms));
 			}
 		}
-		std::thread              m_instance;
-		std::vector<std::string> m_sequence;
+		std::thread m_instance = {};
+		std::vector<std::string> m_sequence = {};
 		std::vector<CEvent*>     *m_events = nullptr;
 		uint32_t                 m_wait_ms = 0;
 		uint32_t                 m_pace_ms = 0;
@@ -1280,18 +1280,18 @@ static struct CMapper {
 	SDL_Surface *surface = nullptr;
 	SDL_Surface *draw_surface = nullptr;
 	bool exit = false;
-	CEvent *aevent = nullptr; // Active Event
-	CBind *abind = nullptr; // Active Bind
-	CBindList_it abindit; //Location of active bind in list
+	CEvent *aevent = nullptr;  // Active Event
+	CBind *abind = nullptr;    // Active Bind
+	CBindList_it abindit = {}; // Location of active bind in list
 	bool redraw = false;
 	bool addbind = false;
 	Bitu mods = 0;
 	struct {
-		CStickBindGroup * stick[MAXSTICKS] = {nullptr};
+		CStickBindGroup *stick[MAXSTICKS] = {nullptr};
 		unsigned int num = 0;
 		unsigned int num_groups = 0;
-	} sticks;
-	Typer typist;
+	} sticks = {};
+	Typer typist = {};
 	std::string filename = "";
 } mapper;
 

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -437,15 +437,15 @@ static Bit8u EMM_SavePageMap(Bit16u handle) {
 }
 
 static Bit8u EMM_RestoreMappingTable(void) {
-	Bit8u result;
 	/* Move through the mappings table and setup mapping accordingly */
 	for (Bitu i=0;i<0x40;i++) {
 		/* Skip the pageframe */
 		if ((i>=EMM_PAGEFRAME/0x400) && (i<(EMM_PAGEFRAME/0x400)+EMM_MAX_PHYS)) continue;
-		result=EMM_MapSegment(i<<10,emm_segmentmappings[i].handle,emm_segmentmappings[i].page);
+		EMM_MapSegment(i << 10, emm_segmentmappings[i].handle,
+		               emm_segmentmappings[i].page);
 	}
 	for (Bitu i=0;i<EMM_MAX_PHYS;i++) {
-		result=EMM_MapPage(i,emm_mappings[i].handle,emm_mappings[i].page);
+		EMM_MapPage(i, emm_mappings[i].handle, emm_mappings[i].page);
 	}
 	return EMM_NO_ERROR;
 }
@@ -1364,12 +1364,8 @@ Bitu GetEMSType(Section_prop * section) {
 
 class EMS : public Module_base {
 private:
+	uint16_t ems_baseseg = 0;
 	DOS_Device *emm_device = nullptr;
-
-	/* location in protected unfreeable memory where the ems name and callback are
-	 * stored  32 bytes.*/
-	static Bit16u ems_baseseg;
-
 	RealPt old67_pointer = 0;
 	CALLBACK_HandlerObject call_vdma;
 	CALLBACK_HandlerObject call_vcpi;
@@ -1403,7 +1399,7 @@ public:
 		}
 		BIOS_ZeroExtendedSize(true);
 
-		if (!ems_baseseg) ems_baseseg=DOS_GetMemory(2);	//We have 32 bytes
+		ems_baseseg = DOS_GetMemory(2); // We have 32 bytes
 
 		/* Add a little hack so it appears that there is an actual ems device installed */
 		char const *emsname = "EMMXXXX0";
@@ -1539,6 +1535,3 @@ void EMS_Init(Section* sec) {
 	test = new EMS(sec);
 	sec->AddDestroyFunction(&EMS_ShutDown,true);
 }
-
-//Initialize static members
-Bit16u EMS::ems_baseseg = 0;


### PR DESCRIPTION
Turns out long-standing EMS warning was fixed already in DOSBox-X, so I imported their fix.

I am fairly certain the last two remaining warnings indicate a bug in svga_s3 implementation.