### PR TITLE
Check for file existence using path_exists

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 296
+            max_warnings: 295
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2015
+            max_warnings: 2014
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/cross.h
+++ b/include/cross.h
@@ -44,7 +44,6 @@
 #if defined (WIN32)
 #define CROSS_FILENAME(blah) 
 #define CROSS_FILESPLIT '\\'
-#define F_OK 0
 #else
 #define	CROSS_FILENAME(blah) strreplace(blah,'\\','/')
 #define CROSS_FILESPLIT '/'

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -19,6 +19,7 @@
 // #define DEBUG 1
 
 #include "cdrom.h"
+
 #include <cassert>
 #include <cctype>
 #include <chrono>
@@ -30,7 +31,6 @@
 #include <limits>
 #include <sstream>
 #include <vector>
-#include <sys/stat.h>
 
 #if !defined(WIN32)
 #include <libgen.h>
@@ -39,6 +39,7 @@
 #endif
 
 #include "drives.h"
+#include "fs_utils.h"
 #include "support.h"
 #include "setup.h"
 
@@ -1392,17 +1393,17 @@ bool CDROM_Interface_Image::HasDataTrack(void)
 bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 {
 	// check if file exists
-	struct stat test;
-	if (stat(filename.c_str(), &test) == 0) {
+	if (path_exists(filename)) {
 		return true;
 	}
 
 	// check if file with path relative to cue file exists
 	string tmpstr(pathname + "/" + filename);
-	if (stat(tmpstr.c_str(), &test) == 0) {
+	if (path_exists(tmpstr)) {
 		filename = tmpstr;
 		return true;
 	}
+
 	// finally check if file is in a dosbox local drive
 	char fullname[CROSS_LEN];
 	char tmp[CROSS_LEN];
@@ -1415,7 +1416,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 	localDrive *ldp = dynamic_cast<localDrive*>(Drives[drive]);
 	if (ldp) {
 		ldp->GetSystemFilename(tmp, fullname);
-		if (stat(tmp, &test) == 0) {
+		if (path_exists(tmp)) {
 			filename = tmp;
 			return true;
 		}
@@ -1433,13 +1434,13 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 		if (copy[i] == '\\') copy[i] = '/';
 	}
 
-	if (stat(copy.c_str(), &test) == 0) {
+	if (path_exists(copy)) {
 		filename = copy;
 		return true;
 	}
 
 	tmpstr = pathname + "/" + copy;
-	if (stat(tmpstr.c_str(), &test) == 0) {
+	if (path_exists(tmpstr)) {
 		filename = tmpstr;
 		return true;
 	}

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -38,6 +38,7 @@
 
 #include "dos_inc.h"
 #include "dos_mscdex.h"
+#include "fs_utils.h"
 #include "support.h"
 #include "cross.h"
 #include "inout.h"
@@ -420,8 +421,7 @@ bool localDrive::TestDir(char * dir) {
 		if (stat(newdir,&test))			return false;
 		if ((test.st_mode & S_IFDIR)==0)	return false;
 	};
-	int temp=access(newdir,F_OK);
-	return (temp==0);
+	return path_exists(newdir);
 }
 
 bool localDrive::Rename(char * oldname,char * newname) {

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -39,6 +39,7 @@
 #include <pwd.h>
 #endif
 
+#include "fs_utils.h"
 #include "support.h"
 
 static std::string GetConfigName()
@@ -85,11 +86,6 @@ static bool CreateDirectories(const std::string &path)
 	return (mkdir(path.c_str(), 0700) == 0);
 }
 
-static bool PathExists(const std::string &path)
-{
-	return (access(path.c_str(), F_OK) == 0);
-}
-
 static std::string DetermineConfigPath()
 {
 	const char *xdg_conf_home = getenv("XDG_CONFIG_HOME");
@@ -97,11 +93,11 @@ static std::string DetermineConfigPath()
 	const std::string conf_path = ResolveHome(conf_home + "/dosbox");
 	const std::string old_conf_path = ResolveHome("~/.dosbox");
 
-	if (PathExists(conf_path + "/" + GetConfigName())) {
+	if (path_exists(conf_path + "/" + GetConfigName())) {
 		return conf_path;
 	}
 
-	if (PathExists(old_conf_path + "/" + GetConfigName())) {
+	if (path_exists(old_conf_path + "/" + GetConfigName())) {
 		LOG_MSG("WARNING: Config file found in deprecated path! (~/.dosbox)\n"
 		        "Backup/remove this dir and restart to generate updated config file.\n"
 		        "---");
@@ -239,7 +235,7 @@ dir_information* open_directory(const char* dirname) {
 
 	dir.handle = INVALID_HANDLE_VALUE;
 
-	return (access(dirname,0) ? NULL : &dir);
+	return (path_exists(dirname) ? &dir : nullptr);
 }
 
 bool read_directory_first(dir_information* dirp, char* entry_name, bool& is_directory) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -25,9 +25,9 @@
 #include "callback.h"
 #include "control.h"
 #include "dosbox.h"
+#include "fs_utils.h"
 #include "regs.h"
 #include "support.h"
-
 
 Bitu call_shellstop;
 /* Larger scope so shell_del autoexec can use it to
@@ -475,7 +475,8 @@ public:
 					if(!name) continue;
 				}
 				*name++ = 0;
-				if (access(buffer,F_OK)) continue;
+				if (!path_exists(buffer))
+					continue;
 				autoexec[12].Install(std::string("MOUNT C \"") + buffer + "\"");
 				autoexec[13].Install("C:");
 				/* Save the non-modified filename (so boot and imgmount can use it (long filenames, case sensivitive)) */


### PR DESCRIPTION
Bringing back fixed version of 41d249fb4e81835114ad096992ce851c39bfdbda.

I figured out what caused the regression on Windows only;

`cross.cpp` file, in function `open_directory(const char* dirname)`, this piece of code:
```C++
return (access(dirname,0) ? NULL : &dir);
```
was replaced with buggy:

```C++
return (path_exists(dirname) ? nullptr : &dir);
```
but I haven't noticed this in testing, because `open_directory` function has 2 separate ifdefed implementations, and only Windows version used `access` function.

Fixed version in this PR:
```C++
return (path_exists(dirname) ? &dir : nullptr);
```

At some point in the future I'll move `open_directory` implementation to `fs_utils_win32.cpp` and `fs_utils_posix.cpp` and add tests, but I feel it's out of scope ATM.