### PR TITLE
Fix spelling errors flagged by Debian's Lintian tool

### DIFF
--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -194,8 +194,8 @@ which is located on the local filesystem. Not a mounted drive in
 .TP
 .B \-securemode
 .RB "Switches " dosbox " to a more secure mode. In this mode the"
-.RI "internal commands " MOUNT ", " IMGMOUNT " and " BOOT " won\'t work."
-It\'s not possible
+.RI "internal commands " MOUNT ", " IMGMOUNT " and " BOOT " won't work."
+It's not possible
 either to create a new configfile or languagefile in this mode.
 (Warning you can only undo this mode by restarting
 .BR dosbox .)

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -116,8 +116,7 @@ Bit32u get_CF(void) {
 	case t_TESTw:
 	case t_TESTd:
 		return false;	/* Set to false */
-	case t_DIV:
-		return false;	/* Unkown */
+	case t_DIV: return false; /* Unknown */
 	default:
 		LOG(LOG_CPU,LOG_ERROR)("get_CF Unknown %d",lflags.type);
 	}
@@ -198,8 +197,7 @@ Bit32u get_AF(void) {
 	case t_DSHRw:
 	case t_DSHRd:
 	case t_DIV:
-	case t_MUL:
-		return false;			          /* Unkown */
+	case t_MUL: return false; /* Unknown */
 	default:
 		LOG(LOG_CPU,LOG_ERROR)("get_AF Unknown %d",lflags.type);
 	}
@@ -267,8 +265,7 @@ Bit32u get_ZF(void) {
 	case t_NEGd:
 		return (lf_resd==0);
 	case t_DIV:
-	case t_MUL:
-		return false;		/* Unkown */
+	case t_MUL: return false; /* Unknown */
 	default:
 		LOG(LOG_CPU,LOG_ERROR)("get_ZF Unknown %d",lflags.type);
 	}
@@ -335,10 +332,8 @@ Bit32u get_SF(void) {
 	case t_NEGd:
 		return	(lf_resd&0x80000000);
 	case t_DIV:
-	case t_MUL:
-		return false;	/* Unkown */
-	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_SF Unkown %d",lflags.type);
+	case t_MUL: return false; /* Unknown */
+	default: LOG(LOG_CPU, LOG_ERROR)("get_SF Unknown %d", lflags.type);
 	}
 	return false;
 
@@ -423,10 +418,8 @@ Bit32u get_OF(void) {
 	case t_SARw:
 	case t_SARd:
 		return false;			/* Return false */
-	case t_DIV:
-		return false;		/* Unkown */
-	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_OF Unkown %d",lflags.type);
+	case t_DIV: return false;               /* Unknown */
+	default: LOG(LOG_CPU, LOG_ERROR)("get_OF Unknown %d", lflags.type);
 	}
 	return false;
 }

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -946,7 +946,7 @@ static Bitu DOS_21Handler(void) {
 			reg_bh=0;	//Unspecified error class
 		}
 		reg_bl=1;	//Retry retry retry
-		reg_ch=0;	//Unkown error locus
+		reg_ch = 0;     // Unknown error locus
 		break;
 	case 0x5a:					/* Create temporary file */
 		{

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -308,7 +308,7 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 		break;
 	case MountType::DIRECTORY:
 		LOG(LOG_MISC,LOG_NORMAL)("MSCDEX: Mounting directory as cdrom: %s", physicalPath);
-		LOG(LOG_MISC,LOG_NORMAL)("MSCDEX: You wont have full MSCDEX support!");
+		LOG(LOG_MISC, LOG_NORMAL)("MSCDEX: You won't have full MSCDEX support!");
 		cdrom[numDrives] = new CDROM_Interface_Fake;
 		result = 5;
 		break;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -584,7 +584,7 @@ Bit32u fatDrive::getAbsoluteSectFromChain(Bit32u startClustNum, Bit32u logicalSe
 			//LOG_MSG("End of cluster chain reached before end of logical sector seek!");
 			if (skipClust == 1 && fattype == FAT12) {
 				//break;
-				LOG(LOG_DOSMISC,LOG_ERROR)("End of cluster chain reached, but maybe good afterall ?");
+				LOG(LOG_DOSMISC, LOG_ERROR)("End of cluster chain reached, but maybe good after all ?");
 			}
 			return 0;
 		}

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -126,8 +126,8 @@ static void write_p60(Bitu port,Bitu val,Bitu iolen) {
 			KEYBOARD_AddBuffer(0xfa);	/* Acknowledge */
 			break;
 		case 0xf4:	/* Enable keyboard,clear buffer, start scanning */
-			LOG(LOG_KEYBOARD,LOG_NORMAL)("Clear buffer,enable Scaning");
-			KEYBOARD_AddBuffer(0xfa);	/* Acknowledge */
+			LOG(LOG_KEYBOARD, LOG_NORMAL)("Clear buffer,enable Scanning");
+			KEYBOARD_AddBuffer(0xfa); /* Acknowledge */
 			keyb.scanning=true;
 			break;
 		case 0xf5:	 /* Reset keyboard and disable scanning */

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -163,7 +163,7 @@ emptyline:
 			} else {
 				/* Not a command line number has to be an environment */
 				char * first = strchr(cmd_read,'%');
-				/* No env afterall. Ignore a single % */
+				/* No env after all. Ignore a single % */
 				if (!first) {/* *cmd_write++ = '%';*/continue;}
 				*first++ = 0;
 				std::string env;


### PR DESCRIPTION
fixes unhappy lintian
```
I: dosbox-staging-debug: spelling-error-in-binary usr/bin/dosbox-debug Scaning Scanning
I: dosbox-staging-debug: spelling-error-in-binary usr/bin/dosbox-debug Unkown Unknown
I: dosbox-staging-debug: spelling-error-in-binary usr/bin/dosbox-debug afterall after all
I: dosbox-staging-debug: spelling-error-in-binary usr/bin/dosbox-debug wont won't
```

Signed-off-by: David Heidelberg <david@ixit.cz>