### PR TITLE
Support case-insensitive paths for mount, imgmount, and in .cue files

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -49,6 +49,9 @@ char int_to_char(int val);
 // through to 26 for drive Z.
 uint8_t drive_index(char drive);
 
+// Convert index (0..26) to a drive letter (uppercase).
+char drive_letter(uint8_t index);
+
 /*
  *  Converts a string to a finite number (such as float or double).
  *  Returns the number or quiet_NaN, if it could not be parsed.

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1180,7 +1180,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 	safe_strcpy(tmp, cuefile);
 	string pathname(dirname(tmp));
 	ifstream in;
-	in.open(cuefile, ios::in);
+	in.open(to_native_path(cuefile), ios::in);
 	if (in.fail()) {
 		return false;
 	}
@@ -1397,8 +1397,13 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 		return true;
 	}
 
-	// check if file with path relative to cue file exists
-	string tmpstr(pathname + "/" + filename);
+	// Check if file with path relative to cue file exists.
+	// Consider the possibility that the filename has a windows directory
+	// seperator or case-insensitive path (inside the CUE file) which is common
+	// for some commercial rereleases of DOS games using DOSBox.
+	const std::string cue_file_entry = (pathname + CROSS_FILESPLIT + filename);
+	const std::string tmpstr = to_native_path(cue_file_entry);
+
 	if (path_exists(tmpstr)) {
 		filename = tmpstr;
 		return true;
@@ -1422,29 +1427,6 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 		}
 	}
 
-#if !defined (WIN32)
-	/**
-	 *  Consider the possibility that the filename has a windows directory
-	 *  seperator (inside the CUE file) which is common for some commercial
-	 *  rereleases of DOS games using DOSBox
-	 */
-	string copy = filename;
-	size_t l = copy.size();
-	for (size_t i = 0; i < l;i++) {
-		if (copy[i] == '\\') copy[i] = '/';
-	}
-
-	if (path_exists(copy)) {
-		filename = copy;
-		return true;
-	}
-
-	tmpstr = pathname + "/" + copy;
-	if (path_exists(tmpstr)) {
-		filename = tmpstr;
-		return true;
-	}
-#endif
 	return false;
 }
 

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -40,8 +40,8 @@
 
 #include "drives.h"
 #include "fs_utils.h"
-#include "support.h"
 #include "setup.h"
+#include "support.h"
 
 using namespace std;
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1346,7 +1346,7 @@ public:
 					}
 
 					LOG_MSG("IMGMOUNT: Path '%s' found on virtual drive %c:",
-					        fullname, 'A' + dummy);
+					        fullname, drive_letter(dummy));
 				}
 			}
 			if (S_ISDIR(test.st_mode)) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -25,21 +25,21 @@
 #include <string>
 #include <vector>
 
-#include "support.h"
-#include "drives.h"
-#include "cross.h"
-#include "regs.h"
+#include "bios_disk.h"
+#include "bios.h"
 #include "callback.h"
 #include "cdrom.h"
-#include "dos_system.h"
-#include "bios.h"
-#include "bios_disk.h"
-#include "setup.h"
 #include "control.h"
-#include "inout.h"
+#include "cross.h"
 #include "dma.h"
-#include "shell.h"
+#include "dos_system.h"
+#include "drives.h"
+#include "inout.h"
 #include "program_autotype.h"
+#include "regs.h"
+#include "setup.h"
+#include "shell.h"
+#include "support.h"
 
 #if defined(WIN32)
 #ifndef S_ISDIR

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -54,6 +54,12 @@ uint8_t drive_index(char drive)
 	return static_cast<uint8_t>(drive_letter - 'A');
 }
 
+char drive_letter(uint8_t index)
+{
+	assert(index <= 26);
+	return 'A' + index;
+}
+
 std::string get_basename(const std::string &filename)
 {
 	// Guard against corner cases: '', '/', '\', 'a'


### PR DESCRIPTION
This takes care of 2/3 tasks in #102. I wanted to include a change for `mount` command as well but turns out it supports some undocumented features (I need to look into that and start documenting them).

I tested this on Linux with:

- Mortal Kombat 3 (GOG) - GOG released the game only for Windows partly because of this issue
- Redneck Rampage (GOG) - same story
- Heroes of Might and Magic II (GOG) - same story
- Carmageddon (Steam) - also part of the reason for release being Windows-only

And I know several other releases that have the same problem.

*Fix works only for `imgmount` for now, so while testing `mount` command still needs to be manually adjusted.*

*edit* 3/3 :)

Fixes: #102 