### PR TITLE
Bundle VS C++ Runtime Files in Windows package

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -127,6 +127,8 @@ jobs:
 
       - name:  Package
         shell: bash
+        env:
+          VC_REDIST_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC'
         run: |
           set -x
 
@@ -137,6 +139,7 @@ jobs:
           cp COPYING                              dest/COPYING.txt
           cp docs/README.template                 dest/README.txt
           cp docs/README.video                    dest/doc/video.txt
+          cp docs/vc_redist.txt                   dest/doc/vc_redist.txt
           cp README                               dest/doc/manual.txt
           cp vs/$RELEASE_DIR/libfluidsynth-2.dll  dest/
           cp vs/$RELEASE_DIR/glib-2.dll           dest/ # fluidsynth dependency
@@ -151,6 +154,16 @@ jobs:
           cp vs/$RELEASE_DIR/libpng16.dll         dest/
           cp src/libs/zmbv/$RELEASE_DIR/zlib1.dll dest/ # libpng dependency
           cp src/libs/zmbv/$RELEASE_DIR/zmbv.dll  dest/
+
+          # List version of available Visual C++ Redistributable files
+          ls -l "$VC_REDIST_PATH"
+
+          # Include the necessary dlls from one of available versions
+          readonly VC_REDIST_VERSION="14.27.29016"
+          readonly VC_REDIST_DIR="$VC_REDIST_PATH/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/Microsoft.VC142.CRT"
+          cp "$VC_REDIST_DIR/msvcp140.dll"       dest/
+          cp "$VC_REDIST_DIR/vcruntime140.dll"   dest/
+          cp "$VC_REDIST_DIR/vcruntime140_1.dll" dest/ || true # might be missing, depending on arch
 
           # Fill README template file
           sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README.txt

--- a/docs/vc_redist.txt
+++ b/docs/vc_redist.txt
@@ -1,0 +1,29 @@
+This package might include following files from Visual C++ Runtime:
+
+msvcp140.dll
+vcruntime140.dll
+vcruntime140_1.dll
+
+These files are NOT covered by DOSBox Staging License.
+
+These are Microsoft Windows components, usually distributed via Windows 10
+update mechanism.  We provide them for convenience of users using older
+Windows versions.  These files are optional - if you have them pre-installed
+as part of your Operating System, you can safely remove them from this
+software package, or build your own version of DOSBox Staging, that does
+not use these files.  You can find instructions for doing so here:
+https://github.com/dosbox-staging/dosbox-staging/blob/master/BUILD.md#windows-procedures
+
+These files are covered by "MICROSOFT VISUAL STUDIO 2015 EXTENSIONS,
+VISUAL STUDIO SHELLS and C++ REDISTRIBUTABLE" license:
+https://visualstudio.microsoft.com/license-terms/mt171552/
+
+They fall into Section 2.1 "Utilities", as they are listed in the list of
+components linked in that section, and are explicitly allowed to be copied
+and distributed; they were copied verbatim into this software package,
+without any modifications. See:
+https://docs.microsoft.com/en-gb/visualstudio/productinfo/2015-redistribution-vs#visual-c-runtime-files
+
+The only difference is exact path to those files, as Visual Studio 2019
+changed the location; updated paths are listed here:
+https://docs.microsoft.com/en-us/visualstudio/releases/2019/redistribution#visual-c-runtime-files


### PR DESCRIPTION
Distribute version 14.27.29016 of these files.

Windows 10 provides these files via Update mechanism, but users of
Windows 7 or Windows 8.x need to install them manually.  Also, there are
multiple reports of Windows 10 users missing them as well, so there's a
possibility that Windows 10 Update sometimes corrupts these files.

By bundling them in our zip file, we guarantee that all Windows users
can run DOSBox Staging out of the box, without the need for manually
preinstalling VS C++ Redistributable package (which requires
Administrator rights).

We are using "app-local" deployment, as described here:
https://devblogs.microsoft.com/cppblog/how-to-redistribute-the-visual-c-libraries-with-your-application/

Microsoft allows for distribution of these files, details are listed
in docs/vc_redist.txt file.

Fixes: #672