### PR TITLE
AUTHORS,THANKS: use UTF-8 encoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,7 +8,7 @@ The project is continuation of DOSBox project, authored by:
 Sjoerd v.d. Berg <harekiet>
 Peter Veenstra <qbix79>
 Ulf Wohlers <finsterr>
-Tommy Frössman <fanskapet>
+Tommy FrÃ¶ssman <fanskapet>
 Dean Beeler <canadacow>
-Sebastian Strohhäcker <c2woody>
+Sebastian StrohhÃ¤cker <c2woody>
 Ralf Grillenberger <h-a-l-9000>

--- a/THANKS
+++ b/THANKS
@@ -15,7 +15,7 @@ Jarek Burczynski for his work on an OPL3 emulator.
 Ken Silverman for his work on an OPL2 emulator.
 The Bochs and DOSemu projects which I used for information.
 FreeDOS for ideas in making my shell.
-Pierre-Yves Gérardy for hosting the old Beta Board.
+Pierre-Yves GÃ©rardy for hosting the old Beta Board.
 Colin Snover for hosting our forum.
 Mirek Luza, for his moderation of the forums.
 eL_Pusher, DosFreak and MiniMax for their moderation of Vogons forum.


### PR DESCRIPTION
Fixes lintian warnings
W: dosbox-staging: national-encoding usr/share/doc/dosbox-staging/AUTHORS
W: dosbox-staging: national-encoding usr/share/doc/dosbox-staging/THANKS

https://lintian.debian.org/tags/national-encoding.html