### PR TITLE
vga_attr.cpp: fix spelling, unkown => unknown

### DIFF
--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -251,7 +251,7 @@ void write_p3c0(Bitu /*port*/,Bitu val,Bitu iolen) {
 				svga.write_p3c0(attr(index), val, iolen);
 				break;
 			}
-			LOG(LOG_VGAMISC,LOG_NORMAL)("VGA:ATTR:Write to unkown Index %2X",attr(index));
+			LOG(LOG_VGAMISC,LOG_NORMAL)("VGA:ATTR:Write to unknown Index %2X",attr(index));
 			break;
 		}
 	}
@@ -279,7 +279,7 @@ Bitu read_p3c1(Bitu /*port*/,Bitu iolen) {
 	default:
 		if (svga.read_p3c1)
 			return svga.read_p3c1(attr(index), iolen);
-		LOG(LOG_VGAMISC,LOG_NORMAL)("VGA:ATTR:Read from unkown Index %2X",attr(index));
+		LOG(LOG_VGAMISC,LOG_NORMAL)("VGA:ATTR:Read from unknown Index %2X",attr(index));
 	}
 	return 0;
 }


### PR DESCRIPTION
Oddly lintian didn't find this
However it is patched in Debian's DOSBox
 https://salsa.debian.org/debian/dosbox
 with debian/patches/spelling-fixes.patch