### PR TITLE
Query glib's version when packaging the macOS snapshot

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -137,7 +137,8 @@ jobs:
           # Inventory the brew dependencies residing in /usr/local
           gthread="/usr/local/opt/glib/lib/libgthread-2.0.0.dylib"
           glib="/usr/local/opt/glib/lib/libglib-2.0.0.dylib"
-          glib_cellar="/usr/local/Cellar/glib/2.66.1/lib/libglib-2.0.0.dylib"
+          glib_version="$(pkg-config --modversion glib-2.0)"
+          glib_cellar="/usr/local/Cellar/glib/$glib_version/lib/libglib-2.0.0.dylib"
           intl="/usr/local/opt/gettext/lib/libintl.8.dylib"
           pcre="/usr/local/opt/pcre/lib/libpcre.1.dylib"
 


### PR DESCRIPTION
GitHub's VMs are currently flip-flopping between glib-2.0 versions 2.66.0 and 2.66.1.

![2020-10-20_09-59](https://user-images.githubusercontent.com/1557255/96619426-09f27100-12bb-11eb-8749-f5c2af009572.png)

This PR queries for the version, so should address this issue going forward:

![2020-10-20_09-57](https://user-images.githubusercontent.com/1557255/96619143-a7997080-12ba-11eb-955b-33d2e1f4560a.png)