### PR TITLE
Don't check for glib nor gthread headers

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Build
         env:
           FLUIDSYNTH_CFLAGS: -I${{ github.workspace }}/contrib/static-fluidsynth/include
-          FLUIDSYNTH_LIBS: ${{ github.workspace }}/contrib/static-fluidsynth/lib/libfluidsynth.a -lm
+          FLUIDSYNTH_LIBS: ${{ github.workspace }}/contrib/static-fluidsynth/lib/libfluidsynth.a -lm -L/usr/local/Cellar/glib/$(pkg-config --modversion glib-2.0)/lib -L/usr/local/opt/gettext/lib -lgthread-2.0 -lglib-2.0 -lintl
           OPUSFILE_CFLAGS: -I${{ github.workspace }}/contrib/static-opus/include -I${{ github.workspace }}/contrib/static-opus/include/opus
           OPUSFILE_LIBS: ${{ github.workspace }}/contrib/static-opus/lib/libopusfile.a ${{ github.workspace }}/contrib/static-opus/lib/libogg.a ${{ github.workspace }}/contrib/static-opus/lib/libopus.a -lm
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -514,8 +514,6 @@ AC_ARG_ENABLE(fluidsynth,
                              [Disable FluidSynth integration]))
 
 if test "${enable_fluidsynth}" != "no" ; then
-    PKG_CHECK_MODULES(GLIB,
-                      [glib-2.0 >= 2.6.5 gthread-2.0 >= 2.6.5])
     PKG_CHECK_MODULES(FLUIDSYNTH,
                       fluidsynth >= 2,
                       [LIBS="$LIBS $FLUIDSYNTH_LIBS $GLIB_LIBS"

--- a/scripts/automator/packages/manager-dnf
+++ b/scripts/automator/packages/manager-dnf
@@ -1,3 +1,3 @@
 # Package repo: https://apps.fedoraproject.org/packages/
-packages+=(ccache make cmake libpng-devel libtool ncurses-devel
-           SDL2-devel SDL2_net-devel opusfile-devel glib2-devel)
+packages+=(ccache make automake alsa-lib-devel libpng-devel SDL2-devel
+           SDL2_net-devel opusfile-devel fluidsynth-devel)


### PR DESCRIPTION
These are FluidSynth 2.x dependencies; dosbox-staging build does not
require headers for those libraries.

They are required only when doing static linking - therefore those
additional flags are added to the macOS release build only.