### PR TITLE
allow /path/to/dest/hicolor with contrib/icons

### DIFF
--- a/contrib/icons/Makefile
+++ b/contrib/icons/Makefile
@@ -77,7 +77,10 @@ dosbox-staging.iconset: \
 # This is not strictly necessary (just placing scalable icon is enough,
 # but some there are some corner cases where small raster icon looks better).
 #
-hicolor: \
+
+hicolor: \ hicolor
+
+%hicolor: \
 		dosbox-staging.svg \
 		icon_32.png \
 		icon_24.png \


### PR DESCRIPTION
This simplifies installation of hicolor icons

Instead of variants such as:

  mkdir -p /path/to/dest
  make -C contrib/icons hicolor
  mv contrib/icons/hicolor /path/to/dest/

The %hicolor: allows directly installing to dest.

  make -C contrib/icons /path/to/dest/hicolor

Legacy behaviour is preserved via:

  hicolor: \ hicolor
escaped space is enough to satisfy the %hicolor
pattern and word splitting occurs normally.

please note, spaces in path are not supported.