### PR TITLE
Fix warnings in SVGA_S3_ReadSEQ

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,16 +20,16 @@ jobs:
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c clang -v 10
-            max_warnings: 2
+            max_warnings: 0
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             flags: -c gcc
-            max_warnings: 2
+            max_warnings: 0
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             flags: -c gcc
             config_flags: --disable-fluidsynth
-            max_warnings: 2
+            max_warnings: 0
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
             flags: -c gcc
@@ -46,22 +46,22 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 109
+            max_warnings: 107
           - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86
-            max_warnings: 2
+            max_warnings: 0
           - name: GCC, +dynrec, +debug, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 146
+            max_warnings: 144
           - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-network
-            max_warnings: 2
+            max_warnings: 0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -138,7 +138,7 @@ jobs:
           gthread="/usr/local/opt/glib/lib/libgthread-2.0.0.dylib"
           glib="/usr/local/opt/glib/lib/libglib-2.0.0.dylib"
           glib_version="$(pkg-config --modversion glib-2.0)"
-          glib_cellar="/usr/local/Cellar/glib/$glib_version/lib/libglib-2.0.0.dylib"
+          glib_cellar="/usr/local/Cellar/glib/${glib_version}_1/lib/libglib-2.0.0.dylib"
           intl="/usr/local/opt/gettext/lib/libintl.8.dylib"
           pcre="/usr/local/opt/pcre/lib/libpcre.1.dylib"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             max_warnings: 0
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 2
+            max_warnings: 0
     steps:
       - uses: actions/checkout@v2
       - name: Install C++ compiler and libraries

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -446,15 +446,15 @@ void SVGA_S3_WriteSEQ(Bitu reg,Bitu val,Bitu iolen) {
 		vga.s3.pll.lock=val;
 		break;
 	case 0x10:		/* Memory PLL Data Low */
-		vga.s3.mclk.n=val & 0x1f;
-		vga.s3.mclk.r=val >> 5;
+		vga.s3.mclk.n = (val & 0b000'11111);
+		vga.s3.mclk.r = (val & 0b111'00000) >> 5;
 		break;
 	case 0x11:		/* Memory PLL Data High */
 		vga.s3.mclk.m=val & 0x7f;
 		break;
 	case 0x12:		/* Video PLL Data Low */
-		vga.s3.clk[3].n=val & 0x1f;
-		vga.s3.clk[3].r=val >> 5;
+		vga.s3.clk[3].n = (val & 0b000'11111);
+		vga.s3.clk[3].r = (val & 0b111'00000) >> 5;
 		break;
 	case 0x13:		/* Video PLL Data High */
 		vga.s3.clk[3].m=val & 0x7f;
@@ -479,11 +479,11 @@ Bitu SVGA_S3_ReadSEQ(Bitu reg,Bitu iolen) {
 	case 0x08:		/* PLL Unlock */
 		return vga.s3.pll.lock;
 	case 0x10:		/* Memory PLL Data Low */
-		return vga.s3.mclk.n || (vga.s3.mclk.r << 5);
+		return (vga.s3.mclk.r << 5) | vga.s3.mclk.n;
 	case 0x11:		/* Memory PLL Data High */
 		return vga.s3.mclk.m;
 	case 0x12:		/* Video PLL Data Low */
-		return vga.s3.clk[3].n || (vga.s3.clk[3].r << 5);
+		return (vga.s3.clk[3].r << 5) | vga.s3.clk[3].n;
 	case 0x13:		/* Video Data High */
 		return vga.s3.clk[3].m;
 	case 0x15:


### PR DESCRIPTION
GCC warns us about these lines:

vga_s3.cpp:482:42: warning: converting the result of '<<' to a boolean;
did you mean '(vga.s3.mclk.r << 5) != 0'? [-Wint-in-bool-context]

In this case the answer is: no, we want to use bit-or instead of
logical-or instead.

Code in SVGA_S3_WriteSEQ is an I/O callback called with iolen == 1, and
value passed via val is originally uint8_t.

The 8-bit value is then split into 5-bit value stored in byte n, and
3-bit value stored in byte r.

Therefore we can conclude SVGA_S3_ReadSEQ is supposed to recombine those
two bytes back into a single value, and not merely return 1 if any bits
were set.