### PR TITLE
Fix CPUID for emulated Pentium and 486

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2003,15 +2003,28 @@ bool CPU_CPUID(void) {
 	case 1: // Get processor type/family/model/stepping and feature flags
 		if ((CPU_ArchitectureType == CPU_ARCHTYPE_486NEWSLOW) ||
 		    (CPU_ArchitectureType == CPU_ARCHTYPE_MIXED)) {
+#if (C_FPU)
 			reg_eax = 0x402; // Intel 486DX
-			reg_ebx = 0;     // Not supported
-			reg_ecx = 0;     // No features
 			reg_edx = 0x1;   // FPU
-		} else if (CPU_ArchitectureType == CPU_ARCHTYPE_PENTIUMSLOW) {
-			reg_eax = 0x517; // Intel Pentium P5 60/66 MHz D1-step
+#else
+			reg_eax = 0x422; // Intel 486SX
+			reg_edx = 0x0;   // no FPU
+#endif
 			reg_ebx = 0;     // Not supported
 			reg_ecx = 0;     // No features
-			reg_edx = 0x11;  // FPU+TimeStamp/RDTSC
+		} else if (CPU_ArchitectureType == CPU_ARCHTYPE_PENTIUMSLOW) {
+#if (C_FPU)
+			reg_eax = 0x517; // Intel Pentium P5 60/66 MHz D1-step
+			reg_edx = 0x11;  // FPU + Time Stamp Counter (RDTSC)
+#else
+			// All Pentiums had FPU built-in, so when FPU is
+			// disabled, we pretend to have early Pentium model with
+			// FDIV bug present.
+			reg_eax = 0x513; // Intel Pentium P5 60/66 MHz B1-step
+			reg_edx = 0x10;  // Time Stamp Counter (RDTSC)
+#endif
+			reg_ebx = 0;     // Not supported
+			reg_ecx = 0;     // No features
 		} else {
 			return false;
 		}

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2000,18 +2000,18 @@ bool CPU_CPUID(void) {
 		reg_edx='i' | ('n' << 8) | ('e' << 16) | ('I'<< 24); 
 		reg_ecx='n' | ('t' << 8) | ('e' << 16) | ('l'<< 24); 
 		break;
-	case 1:	/* get processor type/family/model/stepping and feature flags */
-		if ((CPU_ArchitectureType==CPU_ARCHTYPE_486NEWSLOW) ||
-			(CPU_ArchitectureType==CPU_ARCHTYPE_MIXED)) {
-			reg_eax=0x402;		/* intel 486dx */
-			reg_ebx=0;			/* Not Supported */
-			reg_ecx=0;			/* No features */
-			reg_edx=0x00000001;	/* FPU */
-		} else if (CPU_ArchitectureType==CPU_ARCHTYPE_PENTIUMSLOW) {
-			reg_eax=0x513;		/* intel pentium */
-			reg_ebx=0;			/* Not Supported */
-			reg_ecx=0;			/* No features */
-			reg_edx=0x00000011;	/* FPU+TimeStamp/RDTSC */
+	case 1: // Get processor type/family/model/stepping and feature flags
+		if ((CPU_ArchitectureType == CPU_ARCHTYPE_486NEWSLOW) ||
+		    (CPU_ArchitectureType == CPU_ARCHTYPE_MIXED)) {
+			reg_eax = 0x402; // Intel 486DX
+			reg_ebx = 0;     // Not supported
+			reg_ecx = 0;     // No features
+			reg_edx = 0x1;   // FPU
+		} else if (CPU_ArchitectureType == CPU_ARCHTYPE_PENTIUMSLOW) {
+			reg_eax = 0x513; // Intel Pentium
+			reg_ebx = 0;     // Not supported
+			reg_ecx = 0;     // No features
+			reg_edx = 0x11;  // FPU+TimeStamp/RDTSC
 		} else {
 			return false;
 		}

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2008,7 +2008,7 @@ bool CPU_CPUID(void) {
 			reg_ecx = 0;     // No features
 			reg_edx = 0x1;   // FPU
 		} else if (CPU_ArchitectureType == CPU_ARCHTYPE_PENTIUMSLOW) {
-			reg_eax = 0x513; // Intel Pentium
+			reg_eax = 0x517; // Intel Pentium P5 60/66 MHz D1-step
 			reg_ebx = 0;     // Not supported
 			reg_ecx = 0;     // No features
 			reg_edx = 0x11;  // FPU+TimeStamp/RDTSC


### PR DESCRIPTION
I imported fix by @rderooy, decorated the commit message with excellent description he provided for https://sourceforge.net/p/dosbox/bugs/541/ :) Then implemented similar fix for 486; code looks a little bit different than in DOSBox-X, because we allow disabling FPU only at compile time (as does upstream).

Fixes: #690 