### PR TITLE
Improve usability of keymapper GUI

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -51,13 +51,13 @@ jobs:
           reportdir="pvs-report/pvs-report-${stamp}"
           mkdir -p "${reportdir}"
           pvs-studio-analyzer analyze -a 63 -s .pvs-suppress -o "${log}" -j "$(nproc)"
-          plog-converter -a "${general_criteria}" -d V1042 -t fullhtml -p dosbox-staging \
+          plog-converter -a "${general_criteria}" -d V1042,V826 -t fullhtml -p dosbox-staging \
           -v "${GITHUB_SHA:0:8}" -o "${reportdir}" "${log}"
           mv "${reportdir}/fullhtml" "${reportdir}/general"
-          plog-converter -a "${mirsa_criteria}" -d V1042 -t fullhtml -p dosbox-staging \
+          plog-converter -a "${mirsa_criteria}" -d V1042,V826 -t fullhtml -p dosbox-staging \
           -v "${GITHUB_SHA:0:8}" -o "${reportdir}" "${log}"
           mv "${reportdir}/fullhtml" "${reportdir}/mirsa"
-          plog-converter -a "${general_criteria}" -d V1042 -t csv -o pvs-report.csv "${log}"
+          plog-converter -a "${general_criteria}" -d V1042,V826 -t csv -o pvs-report.csv "${log}"
           cp -l pvs-report.csv "${reportdir}/general/"
           pvs-studio-analyzer suppress -a "${general_criteria}" \
           -o "${reportdir}/general/supressible-list.json" "${log}"
@@ -68,7 +68,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 469
+          MAX_BUGS: 464
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 296
+            max_warnings: 295
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2019
+            max_warnings: 2018
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -346,10 +346,9 @@ public:
 	std::string GetBindName() const override
 	{
 		if (key == SDL_SCANCODE_RETURN)
-			return "Enter";
-		char buf[20];
-		snprintf(buf, sizeof(buf), "Key %s", SDL_GetScancodeName(key));
-		return buf;
+			return "Enter"; // instead of "Return"
+		else
+			return SDL_GetScancodeName(key);
 	}
 
 	void ConfigName(char *buf) override
@@ -1776,21 +1775,21 @@ static std::string humanize_mod_name(const CBindList &binds, const std::string &
 
 	const auto binds_num = binds.size();
 
-	// We have a single bind, be specific - e.g. "Right Ctrl"
+	// We have a single bind, just use it
 	if (binds_num == 1)
-		return trim_pfx("Key ", binds.front()->GetBindName());
+		return binds.front()->GetBindName();
 
-	// Avoid prefix, e.g. "Key Left Alt" and "Key Right Alt" -> "Alt"
+	// Avoid prefix, e.g. "Left Alt" and "Right Alt" -> "Alt"
 	if (binds_num == 2) {
 		const std::string new_pfx = (fallback.empty() ? "" : fallback + ": ");
 		const std::string name_1 = binds.front()->GetBindName();
 		const std::string name_2 = binds.back()->GetBindName();
-		std::string trimmed_1 = trim_pfx("Key Right ", name_1);
-		std::string trimmed_2 = trim_pfx("Key Left ", name_2);
+		std::string trimmed_1 = trim_pfx("Right ", name_1);
+		std::string trimmed_2 = trim_pfx("Left ", name_2);
 		if (trimmed_1 == trimmed_2)
 			return new_pfx + trimmed_1;
-		trimmed_1 = trim_pfx("Key Left ", name_1);
-		trimmed_2 = trim_pfx("Key Right ", name_2);
+		trimmed_1 = trim_pfx("Left ", name_1);
+		trimmed_2 = trim_pfx("Right ", name_2);
 		if (trimmed_1 == trimmed_2)
 			return new_pfx + trimmed_1;
 	}
@@ -1858,8 +1857,6 @@ static void SetActiveBind(CBind *new_active_bind)
 		}
 
 		// Format "Bind: " description
-		const std::string bind_name = new_active_bind->GetBindName();
-		const char *key_desc = bind_name.c_str();
 		const auto mods = new_active_bind->mods;
 		bind_but.bind_title->Change(
 		        "Bind %zu/%zu: %s%s%s%s", active_bind_pos + 1,
@@ -1867,7 +1864,7 @@ static void SetActiveBind(CBind *new_active_bind)
 		        (mods & BMOD_Mod1 ? mod_1_desc.c_str() : ""),
 		        (mods & BMOD_Mod2 ? mod_2_desc.c_str() : ""),
 		        (mods & BMOD_Mod3 ? mod_3_desc.c_str() : ""),
-		        (starts_with("Key ", key_desc) ? key_desc + 4 : key_desc));
+		        new_active_bind->GetBindName().c_str());
 		bind_but.bind_title->SetColor(CLR_GREEN);
 
 		bind_but.bind_title->Enable(true);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -283,7 +283,7 @@ public:
 		}
 	}
 	virtual void ConfigName(char * buf)=0;
-	virtual void BindName(char * buf)=0;
+	virtual void BindName(char * buf)=0; // TODO make const?
 
 	Bitu mods = 0;
 	Bitu flags = 0;
@@ -1399,11 +1399,13 @@ public:
 		if (!enabled)
 			return;
 		CButton::Draw();
-		DrawText(x + 2, y + 2, text, color);
+		DrawText(x + 2, y + 2, text.c_str(), color);
 	}
 
+	void SetText(const std::string &txt) { text = txt; }
+
 protected:
-	const char *text = nullptr;
+	std::string text;
 };
 
 class CClickableTextButton : public CTextButton {
@@ -1757,6 +1759,7 @@ static void change_action_text(const char* text,Bit8u col) {
 
 static void SetActiveBind(CBind * _bind) {
 	mapper.abind=_bind;
+
 	if (_bind) {
 		bind_but.bind_title->Enable(true);
 		char buf[256];_bind->BindName(buf);
@@ -1775,6 +1778,30 @@ static void SetActiveBind(CBind * _bind) {
 		bind_but.mod2->Enable(false);
 		bind_but.mod3->Enable(false);
 		bind_but.hold->Enable(false);
+		return;
+	}
+
+	char buf[20];
+	auto set_btn_name = [&](CCheckButton *btn, std::string name, const CEvent *event) {
+		if (event->GetName() != name)
+			return false;
+		auto *bind = event->bindlist.front();
+		if (!bind) {
+			btn->Enable(false);
+			return false;
+		}
+		bind->BindName(buf); // GetBindName
+		btn->SetText(buf);
+		return true;
+	};
+
+	for (auto &event : events) {
+		if (set_btn_name(bind_but.mod1, "mod_1", event))
+			continue;
+		if (set_btn_name(bind_but.mod2, "mod_2", event))
+			continue;
+		if (set_btn_name(bind_but.mod3, "mod_3", event))
+			continue;
 	}
 }
 
@@ -2130,10 +2157,10 @@ static void CreateLayout() {
 
 	/* Create binding support buttons */
 
-	bind_but.mod1=new CCheckButton(20,410,60,20, "mod1",BC_Mod1);
-	bind_but.mod2=new CCheckButton(20,432,60,20, "mod2",BC_Mod2);
-	bind_but.mod3=new CCheckButton(20,454,60,20, "mod3",BC_Mod3);
-	bind_but.hold=new CCheckButton(100,410,60,20,"hold",BC_Hold);
+	bind_but.mod1 = new CCheckButton(20, 410, 110, 20, "Mod1", BC_Mod1);
+	bind_but.mod2 = new CCheckButton(20, 432, 110, 20, "Mod2", BC_Mod2);
+	bind_but.mod3 = new CCheckButton(20, 454, 110, 20, "Mod3", BC_Mod3);
+	bind_but.hold = new CCheckButton(150, 410, 60, 20, "Hold", BC_Hold);
 
 	bind_but.next=new CBindButton(250,400,50,20,"Next",BB_Next);
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1795,11 +1795,9 @@ static std::string humanize_key_name(const CBindList &binds, const std::string &
 	return fallback;
 }
 
-static void SetActiveBind(CBind *new_active_bind)
+static void update_active_bind_ui()
 {
-	mapper.abind = new_active_bind;
-
-	if (new_active_bind == nullptr) {
+	if (mapper.abind == nullptr) {
 		bind_but.bind_title->Enable(false);
 		bind_but.del->Enable(false);
 		bind_but.next->Enable(false);
@@ -1810,7 +1808,8 @@ static void SetActiveBind(CBind *new_active_bind)
 		return;
 	}
 
-	// Count number of bindings for active event and pos of current bind
+	// Count number of bindings for active event and the number (pos)
+	// of active bind
 	size_t active_event_binds_num = 0;
 	size_t active_bind_pos = 0;
 	if (mapper.aevent) {
@@ -1859,19 +1858,25 @@ static void SetActiveBind(CBind *new_active_bind)
 	}
 
 	// Format "Bind: " description
-	const auto mods = new_active_bind->mods;
+	const auto mods = mapper.abind->mods;
 	bind_but.bind_title->Change("Bind %zu/%zu: %s%s%s%s",
 	                            active_bind_pos + 1, active_event_binds_num,
 	                            (mods & BMOD_Mod1 ? mod_1_desc.c_str() : ""),
 	                            (mods & BMOD_Mod2 ? mod_2_desc.c_str() : ""),
 	                            (mods & BMOD_Mod3 ? mod_3_desc.c_str() : ""),
-	                            new_active_bind->GetBindName().c_str());
+	                            mapper.abind->GetBindName().c_str());
 
 	bind_but.bind_title->SetColor(CLR_GREEN);
 	bind_but.bind_title->Enable(true);
 	bind_but.del->Enable(true);
 	bind_but.next->Enable(active_event_binds_num > 1);
 	bind_but.hold->Enable(true);
+}
+
+static void SetActiveBind(CBind *new_active_bind)
+{
+	mapper.abind = new_active_bind;
+	update_active_bind_ui();
 }
 
 static void SetActiveEvent(CEvent * event) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1883,7 +1883,7 @@ static void SetActiveEvent(CEvent * event) {
 	mapper.aevent=event;
 	mapper.redraw=true;
 	mapper.addbind=false;
-	bind_but.event_title->Change("EVENT:%s",event ? event->GetName(): "none");
+	bind_but.event_title->Change("   Event: %s", event ? event->GetName() : "none");
 	if (!event) {
 		change_action_text("Select an event to change.",CLR_WHITE);
 		bind_but.add->Enable(false);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -344,7 +344,10 @@ public:
 
 	void BindName(char *buf)
 	{
-		sprintf(buf, "Key %s", SDL_GetScancodeName(key));
+		if (key == SDL_SCANCODE_RETURN)
+			strcpy(buf, "Enter");
+		else
+			sprintf(buf, "Key %s", SDL_GetScancodeName(key));
 	}
 
 	void ConfigName(char *buf)
@@ -1889,7 +1892,8 @@ static void SetActiveEvent(CEvent * event) {
 		bind_but.add->Enable(false);
 		SetActiveBind(0);
 	} else {
-		change_action_text("Select a different event or hit the Add/Del/Next buttons.",CLR_WHITE);
+		change_action_text("Modify the bindings for this event or select a different event.",
+		                   CLR_WHITE);
 		mapper.abindit=event->bindlist.begin();
 		if (mapper.abindit!=event->bindlist.end()) {
 			SetActiveBind(*(mapper.abindit));
@@ -2236,10 +2240,9 @@ static void CreateLayout() {
 	bind_but.mod3 = new CCheckButton(20, 454, 110, 20, "Mod3", BC_Mod3);
 	bind_but.hold = new CCheckButton(150, 410, 60, 20, "Hold", BC_Hold);
 
-	bind_but.next=new CBindButton(250,400,50,20,"Next",BB_Next);
-
-	bind_but.add=new CBindButton(250,380,50,20,"Add",BB_Add);
-	bind_but.del=new CBindButton(300,380,50,20,"Del",BB_Del);
+	bind_but.add = new CBindButton(250, 380, 100, 20, "Add bind", BB_Add);
+	bind_but.del = new CBindButton(250, 400, 100, 20, "Remove bind", BB_Del);
+	bind_but.next = new CBindButton(250, 420, 100, 20, "Next bind", BB_Next);
 
 	bind_but.save=new CBindButton(400,450,50,20,"Save",BB_Save);
 	bind_but.exit=new CBindButton(450,450,50,20,"Exit",BB_Exit);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2224,7 +2224,7 @@ static void CreateLayout() {
 //	new CTextButton(PX(6),0,124,20,"Keyboard Layout");
 //	new CTextButton(PX(17),0,124,20,"Joystick Layout");
 
-	bind_but.action=new CCaptionButton(180,350,0,0);
+	bind_but.action = new CCaptionButton(0, 335, 0, 0);
 
 	bind_but.event_title=new CCaptionButton(0,350,0,0);
 	bind_but.bind_title=new CCaptionButton(0,365,0,0);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1812,8 +1812,15 @@ static void SetActiveBind(CBind *new_active_bind)
 		bind_but.bind_title->Enable(true);
 		char buf[256];
 		new_active_bind->BindName(buf);
-		bind_but.bind_title->Change("Bind %zu/%zu: %s", active_bind_pos + 1,
-		                            active_event_binds_num, buf);
+		const auto mods = new_active_bind->mods;
+		bind_but.bind_title->Change("Bind %zu/%zu: %s%s%s%s",
+		                            active_bind_pos + 1,
+		                            active_event_binds_num,
+		                            (mods & BMOD_Mod1 ? "Mod1 + " : ""),
+		                            (mods & BMOD_Mod2 ? "Mod2 + " : ""),
+		                            (mods & BMOD_Mod3 ? "Mod3 + " : ""),
+		                            buf);
+
 		bind_but.del->Enable(true);
 		bind_but.next->Enable(true);
 		bind_but.mod1->Enable(true);
@@ -2529,6 +2536,8 @@ void BIND_MappingEvents() {
 					break;
 				}
 			}
+			SetActiveBind(mapper.abind); // force redraw key binding
+			                             // description
 			break;
 		case SDL_WINDOWEVENT:
 			/* The resize event MAY arrive e.g. when the mapper is

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1799,9 +1799,18 @@ static std::string humanize_mod_name(const CBindList &binds, const std::string &
 
 static void SetActiveBind(CBind *new_active_bind)
 {
-	using namespace std::string_literals;
-
 	mapper.abind = new_active_bind;
+
+	if (new_active_bind == nullptr) {
+		bind_but.bind_title->Enable(false);
+		bind_but.del->Enable(false);
+		bind_but.next->Enable(false);
+		bind_but.mod1->Enable(false);
+		bind_but.mod2->Enable(false);
+		bind_but.mod3->Enable(false);
+		bind_but.hold->Enable(false);
+		return;
+	}
 
 	// Count number of bindings for active event and pos of current bind
 	size_t active_event_binds_num = 0;
@@ -1816,8 +1825,8 @@ static void SetActiveBind(CBind *new_active_bind)
 		}
 	}
 
-	auto set_btn_name = [&](CCheckButton *btn, std::string label,
-	                        const CEvent *event) {
+	auto set_btn_name = [](CCheckButton *btn, const std::string &label,
+	                       const CEvent *event) {
 		assert(btn);
 		assert(event);
 		if (event->bindlist.empty()) {
@@ -1828,58 +1837,48 @@ static void SetActiveBind(CBind *new_active_bind)
 		}
 	};
 
-	if (new_active_bind) {
+	std::string mod_1_desc = "";
+	std::string mod_2_desc = "";
+	std::string mod_3_desc = "";
 
-		std::string mod_1_desc = "";
-		std::string mod_2_desc = "";
-		std::string mod_3_desc = "";
+	// Correlate mod events to key names and button labels
+	for (auto &event : events) {
+		using namespace std::string_literals;
 
-		// Correlate mod events to key names and button labels
-		for (auto &event : events) {
-			if (event->GetName() == "mod_1"s) {
-				set_btn_name(bind_but.mod1, "Mod1", event);
-				mod_1_desc = humanize_mod_name(event->bindlist, "");
-				mod_1_desc += " + ";
-				continue;
-			}
-			if (event->GetName() == "mod_2"s) {
-				set_btn_name(bind_but.mod2, "Mod2", event);
-				mod_2_desc = humanize_mod_name(event->bindlist, "");
-				mod_2_desc += " + ";
-				continue;
-			}
-			if (event->GetName() == "mod_3"s) {
-				set_btn_name(bind_but.mod3, "Mod3", event);
-				mod_3_desc = humanize_mod_name(event->bindlist, "");
-				mod_3_desc += " + ";
-				continue;
-			}
+		if (event->GetName() == "mod_1"s) {
+			set_btn_name(bind_but.mod1, "Mod1", event);
+			mod_1_desc = humanize_mod_name(event->bindlist, "");
+			mod_1_desc += " + ";
+			continue;
 		}
-
-		// Format "Bind: " description
-		const auto mods = new_active_bind->mods;
-		bind_but.bind_title->Change(
-		        "Bind %zu/%zu: %s%s%s%s", active_bind_pos + 1,
-		        active_event_binds_num,
-		        (mods & BMOD_Mod1 ? mod_1_desc.c_str() : ""),
-		        (mods & BMOD_Mod2 ? mod_2_desc.c_str() : ""),
-		        (mods & BMOD_Mod3 ? mod_3_desc.c_str() : ""),
-		        new_active_bind->GetBindName().c_str());
-		bind_but.bind_title->SetColor(CLR_GREEN);
-
-		bind_but.bind_title->Enable(true);
-		bind_but.del->Enable(true);
-		bind_but.next->Enable(active_event_binds_num > 1);
-		bind_but.hold->Enable(true);
-	} else {
-		bind_but.bind_title->Enable(false);
-		bind_but.del->Enable(false);
-		bind_but.next->Enable(false);
-		bind_but.mod1->Enable(false);
-		bind_but.mod2->Enable(false);
-		bind_but.mod3->Enable(false);
-		bind_but.hold->Enable(false);
+		if (event->GetName() == "mod_2"s) {
+			set_btn_name(bind_but.mod2, "Mod2", event);
+			mod_2_desc = humanize_mod_name(event->bindlist, "");
+			mod_2_desc += " + ";
+			continue;
+		}
+		if (event->GetName() == "mod_3"s) {
+			set_btn_name(bind_but.mod3, "Mod3", event);
+			mod_3_desc = humanize_mod_name(event->bindlist, "");
+			mod_3_desc += " + ";
+			continue;
+		}
 	}
+
+	// Format "Bind: " description
+	const auto mods = new_active_bind->mods;
+	bind_but.bind_title->Change("Bind %zu/%zu: %s%s%s%s",
+	                            active_bind_pos + 1, active_event_binds_num,
+	                            (mods & BMOD_Mod1 ? mod_1_desc.c_str() : ""),
+	                            (mods & BMOD_Mod2 ? mod_2_desc.c_str() : ""),
+	                            (mods & BMOD_Mod3 ? mod_3_desc.c_str() : ""),
+	                            new_active_bind->GetBindName().c_str());
+
+	bind_but.bind_title->SetColor(CLR_GREEN);
+	bind_but.bind_title->Enable(true);
+	bind_but.del->Enable(true);
+	bind_but.next->Enable(active_event_binds_num > 1);
+	bind_but.hold->Enable(true);
 }
 
 static void SetActiveEvent(CEvent * event) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1792,13 +1792,28 @@ static std::string humanize_mod_name(const CBindList &binds, const std::string &
 	}
 }
 
-static void SetActiveBind(CBind * _bind) {
-	mapper.abind=_bind;
+static void SetActiveBind(CBind *new_active_bind)
+{
+	mapper.abind = new_active_bind;
 
-	if (_bind) {
+	size_t active_event_binds_num = 0;
+	size_t active_bind_pos = 0;
+	if (mapper.aevent) {
+		const auto &bindlist = mapper.aevent->bindlist;
+		active_event_binds_num = bindlist.size();
+		for (const auto *bind : bindlist) {
+			if (bind == mapper.abind)
+				break;
+			active_bind_pos += 1;
+		}
+	}
+
+	if (new_active_bind) {
 		bind_but.bind_title->Enable(true);
-		char buf[256];_bind->BindName(buf);
-		bind_but.bind_title->Change("BIND:%s",buf);
+		char buf[256];
+		new_active_bind->BindName(buf);
+		bind_but.bind_title->Change("Bind %zu/%zu: %s", active_bind_pos + 1,
+		                            active_event_binds_num, buf);
 		bind_but.del->Enable(true);
 		bind_but.next->Enable(true);
 		bind_but.mod1->Enable(true);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1798,6 +1798,7 @@ static void SetActiveBind(CBind *new_active_bind)
 
 	mapper.abind = new_active_bind;
 
+	// Count number of bindings for active event and pos of current bind
 	size_t active_event_binds_num = 0;
 	size_t active_bind_pos = 0;
 	if (mapper.aevent) {
@@ -1865,7 +1866,7 @@ static void SetActiveBind(CBind *new_active_bind)
 
 		bind_but.bind_title->Enable(true);
 		bind_but.del->Enable(true);
-		bind_but.next->Enable(true);
+		bind_but.next->Enable(active_event_binds_num > 1);
 		bind_but.hold->Enable(true);
 	} else {
 		bind_but.bind_title->Enable(false);


### PR DESCRIPTION
This is a prerequisite towards fixing #585 (because once we'll remove some rarely used shortcuts, a usable interface for changing the key bindings is required for users who might want one of the features back).

When working on this I discovered #696  - but it's not a regression, it seems like a bug existing in SVN for more than 10 years…

While working on this, I added a small refactorization for sdl_mapper CBind class.

In this case, I think a picture presentation of changes will do nicely ;)

## Before
![Screenshot from 2020-11-02 14-12-15](https://user-images.githubusercontent.com/3967/97871938-818dba80-1d15-11eb-98e9-e4a650603c5f.png)

## After
![Screenshot from 2020-11-02 14-11-51](https://user-images.githubusercontent.com/3967/97871969-8d797c80-1d15-11eb-9536-9c5bd6a0cf5c.png)

- Number of binds for selected events is displayed (button "Next bind" appears only if there is more than one bind)
- Full key combination is displayed instead of single key, e.g. "Ctrl + Alt + F5" instead of only "Key F5" + mod buttons
- Mod buttons are labelled the same way as Mod actions (to make them easier to correlate), and display labels, e.g. ("Left Shift"); when both left and right shifts are associated with mod, the label says simply "Shift" (same for Alt and Ctrl).
- Selected key binding is highlighted in green - to make it easier to correlate with selected action
- Buttons and labels are slightly moved around (moving them around more might give better UI still, but it's out of scope for now)

