### PR TITLE
Add libpng-dev to the list of dependencies when using an APT repo

### DIFF
--- a/scripts/automator/packages/manager-apt
+++ b/scripts/automator/packages/manager-apt
@@ -1,2 +1,2 @@
 # Package repo: https://packages.ubuntu.com/
-packages+=(ccache libtool build-essential autotools-dev automake libsdl2-dev libsdl2-net-dev libncurses-dev libopusfile-dev libfluidsynth-dev)
+packages+=(ccache libtool build-essential autotools-dev automake libpng-dev libsdl2-dev libsdl2-net-dev libncurses-dev libopusfile-dev libfluidsynth-dev)


### PR DESCRIPTION
Hit this issue on a fresh "desktop" Ubuntu installation.  

Despite installing the list of packages per the existing script, it turns out none of these pulled in `libpng-dev` as a dependency, so I wound up having to manually install it.


