### PR TITLE
Include FluidSynth's dependencies when using the static library

### DIFF
--- a/contrib/static-fluidsynth/Makefile
+++ b/contrib/static-fluidsynth/Makefile
@@ -108,14 +108,17 @@ lib/libfluidsynth.a: fluidsynth/build/Makefile
 	&& ar -qc ../../lib/libfluidsynth.a src/CMakeFiles/libfluidsynth-OBJ.dir/*/*.o \
 	&& ranlib ../../lib/libfluidsynth.a
 
+
 define FLUIDSYNTH_EXPORTS
 
 Export the following to configure dosbox-staging without pkg-config
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export FLUIDSYNTH_CFLAGS="-I$(CURDIR)/include"
-export FLUIDSYNTH_LIBS="$(CURDIR)/lib/libfluidsynth.a -lm"
+export FLUIDSYNTH_CFLAGS="-I$(CURDIR)/include $(GLIB_CFLAGS)"
+export FLUIDSYNTH_LIBS="$(CURDIR)/lib/libfluidsynth.a $(GLIB_LIBS) -lm"
 endef
 
+GLIB_LIBS = $(shell pkg-config --libs gthread-2.0 glib-2.0)
+GLIB_CFLAGS = $(shell pkg-config --cflags gthread-2.0 glib-2.0)
 .PHONY: fluidsynth-message
 fluidsynth-message: lib/libfluidsynth.a
 	$(info $(FLUIDSYNTH_EXPORTS))


### PR DESCRIPTION
When using the static-fluidsynth makefile, this commit ensures the resulting `export` variables include both of FluidSynth's Glib library dependencies.

Previously these Glib dependencies were included in our CFLAGS and LIBS by way of our own `configure.ac` that checked for glib-2.0 and gthread-2.0, however we've since removed those.

This fixes link errors on those systems that depend on the static library, such as the raspberry pi.  This change is now scoped to exactly where it's needed: in the contrib `makefile`, instead of impacting our top-level `configure.ac`.