### PR TITLE
Correct GUS peek/poke address registers

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1314,12 +1314,12 @@ void Gus::WriteToRegister()
 		dma_addr = register_data;
 		return;
 	case 0x43: // MSB Peek/poke DRAM position
-		dram_addr = (0xff0000 & dram_addr) |
+		dram_addr = (0xf0000 & dram_addr) |
 		            (static_cast<uint32_t>(register_data));
 		return;
 	case 0x44: // LSW Peek/poke DRAM position
-		dram_addr = (0xffff & dram_addr) |
-		            (static_cast<uint32_t>(register_data >> 8)) << 16;
+		dram_addr = (0x0ffff & dram_addr) |
+		            (static_cast<uint32_t>(register_data) & 0x0f00) << 8;
 		return;
 	case 0x45: // Timer control register.  Identical in operation to Adlib's
 		timer_ctrl = static_cast<uint8_t>(register_data >> 8);


### PR DESCRIPTION
Fixes detection of GUS with 1 MB RAM in Pleasure 'N Pain, a 1994 slideshow by by Masque.

Thank you h-a-l-9000 of the vogons.org forums.