### PR TITLE
Various updates to dosbox-staging.metainfo.xml

### DIFF
--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -63,7 +63,7 @@
     <category>Emulator</category>
   </categories>
   <releases>
-    <release version="0.76.0-alpha-git" type="development">
+    <release version="0.76.0-alpha-git" type="development" date="1970-01-01">
     </release>
     <release version="0.75.2" date="2020-10-26">
       <description>

--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -96,7 +96,7 @@
   <launchable type="desktop-id">dosbox-staging.desktop</launchable>
   <developer_name>The DOSBox Staging Team</developer_name>
   <update_contact>dreamer.tan@gmail.com</update_contact>
-  <url type="homepage">https://dosbox-staging.github.io/</url>
+  <url type="homepage">https://dosbox-staging.github.io/about/</url>
   <url type="bugtracker">https://github.com/dosbox-staging/dosbox-staging/issues</url>
   <content_rating type="oars-1.0"/>
 </component>

--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -21,7 +21,7 @@
       <li>Audio solutions: PC Speaker, Tandy Sound System, Disney Sound Source,
           Sound Blaster series, and Gravis UltraSound</li>
       <li>CDROM and CD Digital Audio with audio optionally encoded as FLAC,
-	  Opus, OGG/Vorbis, MP3 or WAV</li>
+          Opus, OGG/Vorbis, MP3 or WAV</li>
       <li>Joystick emulation working with modern game controllers</li>
       <li>Serial port emulation including IPX over UDP and Telnet over TCP/IP</li>
       <li>Hardware-accelerated video output including integer (pixel-perfect)

--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -15,8 +15,8 @@
     <p>It features:</p>
     <ul>
       <li>A built-in DOS-like console</li>
-      <li>Emulation of several PC variants: IBM PC, IBM PCjr, Tandy 1000),
-          and CPUs (286, 386, 486, and Pentium I)</li>
+      <li>Emulation of several PC variants: ( IBM PC, IBM PCjr, Tandy 1000 ),
+          and CPUs ( 286, 386, 486, and Pentium I )</li>
       <li>Graphics chipsets: Hercules, CGA, EGA, VGA, and SVGA</li>
       <li>Audio solutions: PC Speaker, Tandy Sound System, Disney Sound Source,
           Sound Blaster series, and Gravis UltraSound</li>

--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -63,7 +63,26 @@
     <category>Emulator</category>
   </categories>
   <releases>
-    <release version="0.75.1" date="2020-07-19"/>
+    <release version="0.76.0-alpha-git" type="development">
+    </release>
+    <release version="0.75.2" date="2020-10-26">
+      <description>
+        <p>dosbox-staging 0.75.2 maintenance release</p>
+      </description>
+      <url>https://dosbox-staging.github.io/v0-75-2/</url>
+    </release>
+    <release version="0.75.1" date="2020-07-19">
+      <description>
+        <p>dosbox-staging 0.75.1 bugfix release</p>
+      </description>
+      <url>https://dosbox-staging.github.io/v0-75-1/</url>
+    </release>
+    <release version="0.75.0" date="2020-05-06">
+      <description>
+        <p>dosbox-staging 0.75.0 final release</p>
+      </description>
+      <url>https://dosbox-staging.github.io/v0-75-0/</url>
+    </release>
   </releases>
   <provides>
     <binary>dosbox</binary>

--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -31,6 +31,11 @@
       DOSBox Staging is highly configurable and sufficiently-optimized to run
       any DOS game on a modern computer.
     </p>
+    <p>Relationship to DOSBox:</p>
+    <p>
+      DOSBox Staging is separate from and not supported by the SourceForge-hosted
+      DOSBox project or its development team, the DOSBox Team.
+    </p>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION

Viewing the result is a little tiresome, using the **gnome-software** package ( Debian Sid ) I can view the metainfo via the "Installed" tab ( after installing a deb packaged dosbox-staging ).

I can view in the available list ( when not installed ) if I serve via [DAK](https://wiki.debian.org/DebianRepository/Setup#dak_.28Debian_Archive_Kit.29) with DEP11 generated by [appstream-generator](https://github.com/ximion/appstream-generator) injected.

But iterations are slow.. ( have to re-package, push .deb(s) to DAK, appstream-generator , push DEP11 to DAK , apt update.. )

It is much easier to just edit
```
/usr/share/metainfo/dosbox-staging.metainfo.xml 
```
after installing the .deb
It still needs work, for instance the text does not quite flow as I believe it was intended

original
```xml
<li>Emulation of several PC variants: IBM PC, IBM PCjr, Tandy 1000),
    and CPUs (286, 386, 486, and Pentium I)</li>
```

snapshot is edited version, but the linewrap is similar
![no_line_breaks_in_list](https://user-images.githubusercontent.com/37488595/98488378-b2dc1e00-2220-11eb-9a1c-ca24ef6e49d4.png)

Sadly the appstream spec does not support nesting lists:

It would probably make sense to reword it and split the PC variants and CPU architectures out into their own list items.

I have not tried to fix the missing desktop icon here, 
![missing icon](https://user-images.githubusercontent.com/37488595/98488324-5d077600-2220-11eb-9f8e-db119a059d80.png)

I have been able to "fix" that by

- setting `<ID/>` to *dosbox-staging.desktop*
  - :+1: works
  - :-1: fails validation with  **appstreamcli** ( is-not-rdns )
  - :+1: passes validation with **appstream-util** 
- Adding `<icon type="stock">dosbox-staging</icon>`
  - :+1: works
  - :+1: [as per spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-icon)
  - :+1: passes validation with **appstreamcli**
  - :-1:  fails validation with **appstream-util**
- Adding `<icon>dosbox-staging</icon>`
  - :+1: works
  - :-1: [not to spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-icon)
  - :-1: fails validation with **appstreamcli**
  - :+1: passes validation with **appstream-util**

From what I gather the `<icon/>` shouldn't be needed, as the metainfo parser ***should*** be pulling it from the *.destop* linked via `<launchable type="desktop-id">` but with my Debian Sid's gnome-software this isn't working. It may work with a DEP11 ( or equivalent ) cache, not a route available  everywhere.

My DE is `lxqt`, so quite distant from stock Debian ( I think it defaults to gnome3 )

I think I will need to setup some VMs to get a better feel for how things look in different software centres, no point having it to look great on Debian if it looks all screwy on Fedora , although I think they both default to Gnome3. I imagine flatpak may have issues 

I will note that I do not typically use the **gnome-software center**, I only installed it to make sure the metainfo.xml was working once I had packaged it.
