### PR TITLE
Create program stub for LS command

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 294
+            max_warnings: 295
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2017
+            max_warnings: 2018
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/dos/Makefile.am
+++ b/src/dos/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LIBRARIES = libdos.a
-EXTRA_DIST = dos_codepages.h dos_keyboard_layout_data.h
+
 libdos_a_SOURCES = \
 	cdrom.cpp \
 	cdrom.h \
@@ -28,4 +28,8 @@ libdos_a_SOURCES = \
 	drive_virtual.cpp \
 	drives.cpp \
 	program_autotype.cpp \
-	program_autotype.h
+	program_autotype.h \
+	program_ls.cpp \
+	program_ls.h
+
+EXTRA_DIST = dos_codepages.h dos_keyboard_layout_data.h

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1895,19 +1895,17 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_KEYB_LAYOUTNOTFOUND","No layout in %s for codepage %i\n");
 	MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
 
-	/*regular setup*/
 	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
-	PROGRAMS_MakeFile("MOUNT.COM",MOUNT_ProgramStart);
-	PROGRAMS_MakeFile("MEM.COM",MEM_ProgramStart);
-	PROGRAMS_MakeFile("LOADFIX.COM",LOADFIX_ProgramStart);
-	PROGRAMS_MakeFile("RESCAN.COM",RESCAN_ProgramStart);
-	PROGRAMS_MakeFile("INTRO.COM",INTRO_ProgramStart);
-	PROGRAMS_MakeFile("BOOT.COM",BOOT_ProgramStart);
 #if C_DEBUG
 	PROGRAMS_MakeFile("BIOSTEST.COM", BIOSTEST_ProgramStart);
 #endif
-	PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
+	PROGRAMS_MakeFile("BOOT.COM", BOOT_ProgramStart);
 	PROGRAMS_MakeFile("IMGMOUNT.COM", IMGMOUNT_ProgramStart);
+	PROGRAMS_MakeFile("INTRO.COM", INTRO_ProgramStart);
 	PROGRAMS_MakeFile("KEYB.COM", KEYB_ProgramStart);
-
+	PROGRAMS_MakeFile("LOADFIX.COM", LOADFIX_ProgramStart);
+	PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
+	PROGRAMS_MakeFile("MEM.COM", MEM_ProgramStart);
+	PROGRAMS_MakeFile("MOUNT.COM", MOUNT_ProgramStart);
+	PROGRAMS_MakeFile("RESCAN.COM", RESCAN_ProgramStart);
 }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -37,6 +37,7 @@
 #include "fs_utils.h"
 #include "inout.h"
 #include "program_autotype.h"
+#include "program_ls.h"
 #include "regs.h"
 #include "setup.h"
 #include "shell.h"
@@ -1905,6 +1906,7 @@ void DOS_SetupPrograms(void) {
 	PROGRAMS_MakeFile("KEYB.COM", KEYB_ProgramStart);
 	PROGRAMS_MakeFile("LOADFIX.COM", LOADFIX_ProgramStart);
 	PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
+	PROGRAMS_MakeFile("LS.COM", LS_ProgramStart);
 	PROGRAMS_MakeFile("MEM.COM", MEM_ProgramStart);
 	PROGRAMS_MakeFile("MOUNT.COM", MOUNT_ProgramStart);
 	PROGRAMS_MakeFile("RESCAN.COM", RESCAN_ProgramStart);

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "program_ls.h"
+
+#include <string>
+
+#include "shell.h"
+#include "support.h"
+
+void LS::Run()
+{
+	std::string tmp = "";
+	cmd->GetStringRemain(tmp);
+	char args[CMD_MAXLINE];
+	safe_strcpy(args, tmp.c_str());
+	first_shell->CMD_LS(args);
+}
+
+void LS_ProgramStart(Program **make)
+{
+	*make = new LS;
+}

--- a/src/dos/program_ls.h
+++ b/src/dos/program_ls.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PROGRAM_LS_H
+#define DOSBOX_PROGRAM_LS_H
+
+#include <string>
+
+#include "programs.h"
+
+class LS : public Program {
+public:
+	void Run();
+};
+
+void LS_ProgramStart(Program **make);
+
+#endif

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -58,7 +58,6 @@ static SHELL_Cmd cmd_list[] = {
 	{ "IF",       1, &DOS_Shell::CMD_IF,       "SHELL_CMD_IF_HELP" },
 	{ "LH",       1, &DOS_Shell::CMD_LOADHIGH, "SHELL_CMD_LOADHIGH_HELP" },
 	{ "LOADHIGH", 1, &DOS_Shell::CMD_LOADHIGH, "SHELL_CMD_LOADHIGH_HELP" },
-	{ "LS",       0, &DOS_Shell::CMD_LS,       "SHELL_CMD_LS_HELP" },
 	{ "MD",       0, &DOS_Shell::CMD_MKDIR,    "SHELL_CMD_MKDIR_HELP" },
 	{ "MKDIR",    1, &DOS_Shell::CMD_MKDIR,    "SHELL_CMD_MKDIR_HELP" },
 	{ "PATH",     1, &DOS_Shell::CMD_PATH,     "SHELL_CMD_PATH_HELP" },

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -275,6 +275,7 @@
     <ClCompile Include="..\src\dos\drive_overlay.cpp" />
     <ClCompile Include="..\src\dos\drive_virtual.cpp" />
     <ClCompile Include="..\src\dos\program_autotype.cpp" />
+    <ClCompile Include="..\src\dos\program_ls.cpp" />
     <ClCompile Include="..\src\fpu\fpu.cpp" />
     <ClCompile Include="..\src\gui\render.cpp" />
     <ClCompile Include="..\src\gui\render_scalers.cpp" />
@@ -456,6 +457,7 @@
     <ClInclude Include="..\src\dos\Ntddscsi.h" />
     <ClInclude Include="..\src\dos\Ntddstor.h" />
     <ClInclude Include="..\src\dos\program_autotype.h" />
+    <ClInclude Include="..\src\dos\program_ls.h" />
     <ClInclude Include="..\src\fpu\fpu_instructions.h" />
     <ClInclude Include="..\src\fpu\fpu_instructions_x86.h" />
     <ClInclude Include="..\src\gui\gui_msgs.h" />


### PR DESCRIPTION
```
    Add LS program stub to replace LS command
    
    Making LS a program prevents the problem with invoking programs called
    ls.com or ls.exe - one game, that has such executable name is
    Links LS 1997.
    
    This change introduces a small "regression" - command parameters cannot
    be passed without space, as for DOS intenal commands, e.g.:
    
      dir.txt - equivalent of dir *.txt (usually used for e.g. dir/w)
      ls.txt - does not work any more - but works exactly like GNU ls, the
               first parameter is passed after a space.
    
    The stub invokes existing LS command implementation (as LS shares some
    code with DIR command).  When shared code will be made
    public/non-static, the rest of LS command implementation will be moved
    to a new program file.
```
Fixes: #504