### PR TITLE
Rename pc_zero_offset to zero_offset

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -714,9 +714,9 @@ void DOSBOX_Init(void) {
 	pint->SetMinMax(8000, 48000);
 	pint->Set_help("Sample rate of the PC-Speaker sound generation.");
 
-	const char *pc_zero_offset_opts[] = {"auto", "true", "false", 0};
-	pstring = secprop->Add_string("pc_zero_offset", when_idle, pc_zero_offset_opts[0]);
-	pstring->Set_values(pc_zero_offset_opts);
+	const char *zero_offset_opts[] = {"auto", "true", "false", 0};
+	pstring = secprop->Add_string("zero_offset", when_idle, zero_offset_opts[0]);
+	pstring->Set_values(zero_offset_opts);
 	pstring->Set_help(
 	        "Neutralizes and prevents the PC speaker's DC-offset from harming other sources.\n"
 	        "'auto' enables this for non-Windows systems and disables it on Windows.\n"

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -467,7 +467,7 @@ public:
 			return;
 		spkr.rate = std::max(section->Get_int("pcrate"), 8000);
 
-		std::string dc_offset_pref = section->Get_string("pc_zero_offset");
+		std::string dc_offset_pref = section->Get_string("zero_offset");
 		if (dc_offset_pref == "auto")
 #if !defined(WIN32)
 			spkr.neutralize_dc_offset = true;


### PR DESCRIPTION
I found the the option somewhat miss-titled because the feature involves _DC offset_ correction, however it involves the PC speaker. Is it PC offset or DC offset, I wondered?

I opted to simplify it to "zero_offset" given the variable already exists under the `[speaker]` category.  This takes up less width too. 

``` ini
[speaker]
#   pcspeaker: Enable PC-Speaker emulation.
#      pcrate: Sample rate of the PC-Speaker sound generation.
# zero_offset: Neutralizes and prevents the PC speaker's DC-offset from harming other sources.
#              'auto' enables this for non-Windows systems and disables it on Windows.
#              If your OS performs its own DC-offset correction, then set this to 'false'.
#              Possible values: auto, true, false.
#       tandy: Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.
#              Possible values: auto, on, off.
#   tandyrate: Sample rate of the Tandy 3-Voice generation.
#              Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
#      disney: Enable Disney Sound Source emulation. (Covox Voice Master and Speech Thing compatible).

pcspeaker   = true
pcrate      = 18939
zero_offset = auto
```