### PR TITLE
Add an option for unblocking the OS screensaver

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2141,6 +2141,12 @@ static void GUI_StartUp(Section *sec)
 		sdl.desktop.want_type=SCREEN_SURFACE;//SHOULDN'T BE POSSIBLE anymore
 	}
 
+	const std::string screensaver = section->Get_string("screensaver");
+	if (screensaver == "allow")
+		SDL_EnableScreenSaver();
+	if (screensaver == "block")
+		SDL_DisableScreenSaver();
+
 	sdl.texture.texture = 0;
 	sdl.texture.pixelFormat = 0;
 	sdl.render_driver = section->Get_string("texture_renderer");
@@ -2905,6 +2911,14 @@ void Config_Add_SDL() {
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
 	pstring->Set_help("File used to load/save the key/event mappings from.\n"
 	                  "Resetmapper only works with the default value.");
+
+	pstring = sdl_sec->Add_string("screensaver", on_start, "auto");
+	pstring->Set_help(
+	        "Use 'allow' or 'block' to override the SDL_VIDEO_ALLOW_SCREENSAVER\n"
+	        "environment variable (which usually blocks the OS screensaver\n"
+	        "while the emulator is running).");
+	const char *ssopts[] = {"auto", "allow", "block", 0};
+	pstring->Set_values(ssopts);
 }
 
 static void show_warning(char const * const message) {


### PR DESCRIPTION
Applications emulated via DOSBox Staging are usually games - for this
usecase user is usually watching something for an extended period of
time or using joystick input which generally does not prevent the
screensaver from kicking in.

Other usecases where screensaver should be disabled are for example:
when using CRTs in retro-machines, in gaming cabinets, or when opting-in
to screensaver in DOS file managers or GUI frontends
(e.g. Norton Commander or Windows 3.x)

However, blocking screensaver prevents inactive display from going to
sleep (tested on macOS and Gnome).  It has also some other bad side
effects (screen is not disabled even when user explicitly locks the
machine on macOS). Users relying on those usecases can now set:

    [sdl]
    screensaver = allow

Or keep this value in default ('auto') and override the behaviour using
SDL environment variable:

    $ SDL_VIDEO_ALLOW_SCREENSAVER=1 dosbox

Users beware: testing on Windows 10 indicated, that system can go
unstable when allowing screensaver while using fullscreen with custom
resolution on multi-display setup. We were unable to reproduce the same
issues on Linux (Gnome).

See: https://wiki.libsdl.org/FAQUsingSDL

Fixes: #630