### PR TITLE
Rewrite starts_with function

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -40,6 +40,7 @@ noinst_HEADERS = \
 	setup.h \
 	shell.h \
 	soft_limiter.h \
+	string_utils.h \
 	support.h \
 	timer.h \
 	types.h \

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -1,0 +1,39 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_STRING_UTILS_H
+#define DOSBOX_STRING_UTILS_H
+
+#include <cstring>
+#include <string>
+
+template <size_t N>
+bool starts_with(const char (&pfx)[N], const char *str) noexcept
+{
+	return (strncmp(pfx, str, N - 1) == 0);
+}
+
+template <size_t N>
+bool starts_with(const char (&pfx)[N], const std::string &str) noexcept
+{
+	return (strncmp(pfx, str.c_str(), N - 1) == 0);
+}
+
+#endif

--- a/include/support.h
+++ b/include/support.h
@@ -185,9 +185,6 @@ void upcase(std::string &str);
 void lowcase(std::string &str);
 void strip_punctuation(std::string &str);
 
-bool starts_with(const std::string &prefix, const std::string &str) noexcept;
-bool ends_with(const std::string &suffix, const std::string &str) noexcept;
-
 bool is_executable_filename(const std::string &filename) noexcept;
 
 // Coarse but fast sine and cosine approximations. Accuracy ranges from 0.0005

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -41,6 +41,7 @@
 #include "mapper.h"
 #include "pic.h"
 #include "setup.h"
+#include "string_utils.h"
 #include "support.h"
 #include "video.h"
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -56,6 +56,7 @@
 #include "pic.h"
 #include "render.h"
 #include "setup.h"
+#include "string_utils.h"
 #include "support.h"
 #include "timer.h"
 #include "vga.h"

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -90,22 +90,6 @@ void lowcase(std::string &str) {
 	std::transform(str.begin(), str.end(), str.begin(), tf);
 }
 
-bool starts_with(const std::string &prefix, const std::string &str) noexcept
-{
-	const size_t n = prefix.length();
-	const auto pfx = std::cbegin(prefix);
-	const auto txt = std::cbegin(str);
-	return std::equal(pfx, pfx + n, txt, txt + n);
-}
-
-bool ends_with(const std::string &suffix, const std::string &str) noexcept
-{
-	const size_t n = suffix.length();
-	const auto sfx = std::crbegin(suffix);
-	const auto txt = std::crbegin(str);
-	return std::equal(sfx, sfx + n, txt, txt + n);
-}
-
 bool is_executable_filename(const std::string &filename) noexcept
 {
 	const size_t n = filename.length();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,9 +15,10 @@ endif
 
 tests_SOURCES = \
 	example.cpp \
+	fs_utils.cpp \
 	soft_limiter.cpp \
-	support.cpp \
-	fs_utils.cpp
+	string_utils.cpp \
+	support.cpp
 
 tests_LDADD = ../src/misc/libmisc.a
 

--- a/tests/string_utils.cpp
+++ b/tests/string_utils.cpp
@@ -1,0 +1,59 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "string_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace {
+
+TEST(StartsWith, Prefix)
+{
+	EXPECT_TRUE(starts_with("ab", "abcd"));
+	EXPECT_TRUE(starts_with("ab", std::string{"abcd"}));
+}
+
+TEST(StartsWith, NotPrefix)
+{
+	EXPECT_FALSE(starts_with("xy", "abcd"));
+	EXPECT_FALSE(starts_with("xy", std::string{"abcd"}));
+}
+
+TEST(StartsWith, TooLongPrefix)
+{
+	EXPECT_FALSE(starts_with("abcd", "ab"));
+	EXPECT_FALSE(starts_with("abcd", std::string{"ab"}));
+}
+
+TEST(StartsWith, EmptyPrefix)
+{
+	EXPECT_TRUE(starts_with("", "abcd"));
+	EXPECT_TRUE(starts_with("", std::string{"abcd"}));
+}
+
+TEST(StartsWith, EmptyString)
+{
+	EXPECT_FALSE(starts_with("ab", ""));
+	EXPECT_FALSE(starts_with("ab", std::string{""}));
+}
+
+} // namespace

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -412,6 +412,7 @@
     <ClInclude Include="..\include\serialport.h" />
     <ClInclude Include="..\include\setup.h" />
     <ClInclude Include="..\include\shell.h" />
+    <ClInclude Include="..\include\string_utils.h" />
     <ClInclude Include="..\include\support.h" />
     <ClInclude Include="..\include\timer.h" />
     <ClInclude Include="..\include\vga.h" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -454,9 +454,6 @@
     <ClInclude Include="..\src\dos\cdrom.h" />
     <ClInclude Include="..\src\dos\dev_con.h" />
     <ClInclude Include="..\src\dos\dos_mscdex.h" />
-    <ClInclude Include="..\src\dos\Ntddcdrm.h" />
-    <ClInclude Include="..\src\dos\Ntddscsi.h" />
-    <ClInclude Include="..\src\dos\Ntddstor.h" />
     <ClInclude Include="..\src\dos\program_autotype.h" />
     <ClInclude Include="..\src\dos\program_ls.h" />
     <ClInclude Include="..\src\fpu\fpu_instructions.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -394,6 +394,12 @@
     <ClCompile Include="..\src\midi\midi_fluidsynth.cpp">
       <Filter>src\midi</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_ls.cpp">
+      <Filter>src\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\misc\fs_utils_win32.cpp">
+      <Filter>src\misc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\bios.h">
@@ -624,15 +630,6 @@
     <ClInclude Include="..\src\dos\dos_mscdex.h">
       <Filter>src\dos</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\dos\Ntddcdrm.h">
-      <Filter>src\dos</Filter>
-    </ClInclude>
-    <ClInclude Include="..\src\dos\Ntddscsi.h">
-      <Filter>src\dos</Filter>
-    </ClInclude>
-    <ClInclude Include="..\src\dos\Ntddstor.h">
-      <Filter>src\dos</Filter>
-    </ClInclude>
     <ClInclude Include="..\src\fpu\fpu_instructions.h">
       <Filter>src\fpu</Filter>
     </ClInclude>
@@ -746,6 +743,18 @@
     </ClInclude>
     <ClInclude Include="..\include\compiler.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\fs_utils.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\string_utils.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\program_ls.h">
+      <Filter>src\dos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\gui\gui_msgs.h">
+      <Filter>src\gui</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
    Move starts_with function to a new header

    New header is introduced to gradually move our new string-related helper
    functions in there (out of support header).

    Rewrite starts_with function, as it was triggering debug assertion
    in MSVC: "Expression: cannot seek string iterator after end" (when
    calling starts_with("opengl", "auto").

    Limit starts_with interface only to our actual usecases, such as:

        starts_with("prefix", text)

    This way we can save time on calculating string length of hardcoded
    prefix.

    Drop ends_with function, as we don't use it any more - the code using it
    was refactored some time ago.

The main reason for doing this change was the debug assertion on MSVC. The secondary reason is introduction of header dedicated to implementing string-related helper functions (as support.h is a mish-mash of unrelated functionalities).