### PR TITLE
Skip removal of already absent files

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -218,6 +218,12 @@ bool localDrive::GetSystemFilename(char *sysName, char const * const dosName) {
 
 // Attempt to delete the file name from our local drive mount
 bool localDrive::FileUnlink(char * name) {
+	if (!FileExists(name)) {
+		DEBUG_LOG_MSG("FS: Skipping removal of %s because it doesn't exist",
+		              name);
+		return true;
+	}
+
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
 	safe_strcat(newname, name);


### PR DESCRIPTION
Fixes a regression caught in GameWizard 32 Pro 3.0a when it tries to delete temporary files, which may not exist (GW.SC1 and GW.SCH), prior to performing a memory scan.

```
FS: Skipping removal of GW\GW.SC1 because it doesn't exist
FS: Skipping removal of GW\GW.SCH because it doesn't exist
```

![2020-11-15_08-48_1](https://user-images.githubusercontent.com/1557255/99191130-81cb8400-271f-11eb-8296-e70fb50aa179.png)

Fixes #683.