### PR TITLE
Set more exact error codes when unlinking

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -648,13 +648,21 @@ bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bi
 }
 
 bool DOS_UnlinkFile(char const * const name) {
-	char fullname[DOS_PATHLENGTH];Bit8u drive;
-	// An existing device returns an access denied error
+	char fullname[DOS_PATHLENGTH];
+	uint8_t drive;
+
+	// An non-existing device returns an access denied error
 	if (DOS_FindDevice(name) != DOS_DEVICES) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
-	if (!DOS_MakeName(name,fullname,&drive)) return false;
+
+	// If a proper DOS path cannot be constructed ...
+	if (!DOS_MakeName(name, fullname, &drive)) {
+		DOS_SetError(DOSERR_PATH_NOT_FOUND);
+		return false;
+	}
+
 	return Drives[drive]->FileUnlink(fullname);
 }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -221,7 +221,8 @@ bool localDrive::FileUnlink(char * name) {
 	if (!FileExists(name)) {
 		DEBUG_LOG_MSG("FS: Skipping removal of %s because it doesn't exist",
 		              name);
-		return true;
+		DOS_SetError(DOSERR_FILE_NOT_FOUND);
+		return false;
 	}
 
 	char newname[CROSS_LEN];


### PR DESCRIPTION
A couple small refinements on the prior Unlink regression PR:

1. If a **file** is already absent when requested for deletion, we now set the **file**-not-found code. 

2. If a **path** or path-to-a-file cannot be constructed when requested for deletion, we now set the **path**-not-found code.

Both changes are confirmed working in GameWizard (as well everything else I've thrown at it).