### PR TITLE
Avoid version name in default phonebook file

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -834,9 +834,8 @@ void DOSBOX_Init(void) {
 	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
 	Pmulti_remain->Set_help("see serial1");
 
-	Pstring = secprop->Add_path("phonebookfile", Property::Changeable::OnlyAtStart, "phonebook-" VERSION ".txt");
-	Pstring->Set_help("File used to map fake phone numbers to addresses.");
-
+	pstring = secprop->Add_path("phonebookfile", only_at_start, "phonebook.txt");
+	pstring->Set_help("File used to map fake phone numbers to addresses.");
 
 	/* All the DOS Related stuff, which will eventually start up in the shell */
 	secprop=control->AddSection_prop("dos",&DOS_Init,false);//done


### PR DESCRIPTION
I noticed some tutorials written by users where they just instructed other users to create file `phonebook-0.75.0.txt`… Such instruction will break with every new release, so let's not do that.

We have no plans for changing the format of this file whatsoever.