### PR TITLE
Screenshot with correct aspect ratio, resolution, and shaders

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -50,11 +50,13 @@ jobs:
           - configure_flags:  --disable-opengl
           - configure_flags:  --disable-opus-cdda
           - configure_flags:  --disable-screenshots
+          - configure_flags:  --disable-sdl-image
           - configure_flags:  --disable-unaligned-memory
           - configure_flags:  --disable-fluidsynth
-          - without_packages: -x net
           - without_packages: -x curses
-          - without_packages: -x net -x curses
+          - without_packages: -x image
+          - without_packages: -x net
+          - without_packages: -x curses -x image -x net
     env:
       CHERE_INVOKING: yes
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,6 +45,8 @@ jobs:
         run:  ./scripts/log-env.sh
       - name: Build
         run:  ./scripts/build.sh --build-type Debug ${{ matrix.conf.flags }}
+      - name: Dump dynamic libraries on-start
+        run:  DYLD_PRINT_LIBRARIES=1 ./src/dosbox -c exit
       - name: Summarize warnings
         env:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
@@ -158,7 +160,7 @@ jobs:
           dep_archive="/tmp/$$-deps.tar"
           tar -cvPf "$dep_archive" "$gthread" "$glib" "$glib_cellar" "$intl" "$pcre"
           rm -f "$gthread" "$glib" "$glib_cellar" "$intl" "$pcre"
-          "$dst/MacOS/dosbox" -c exit
+          DYLD_PRINT_LIBRARIES=1 "$dst/MacOS/dosbox" -c exit
           tar -xvPf "$dep_archive" -C /
 
           # Fill README template file

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         id:   cache-vcpkg
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
 
       - name:  Install new packages using vcpkg
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,9 +131,12 @@ jobs:
           VC_REDIST_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC'
         run: |
           set -x
+          readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
+
+          # List vcpkg installed DLL dependencies available for packaging
+          ls -l vs/$RELEASE_DIR/*.dll
 
           # Prepare content
-          readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
           mkdir -p dest/doc
           cp vs/$RELEASE_DIR/dosbox.exe           dest/
           cp COPYING                              dest/COPYING.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           rm -R c:\vcpkg
           mv c:\vcpkg-bak c:\vcpkg
-          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net opusfile fluidsynth
+          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-image sdl2-net opusfile fluidsynth
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
 
       - name:  Integrate packages
@@ -150,6 +150,7 @@ jobs:
           cp vs/$RELEASE_DIR/ogg.dll              dest/
           cp vs/$RELEASE_DIR/opus.dll             dest/
           cp vs/$RELEASE_DIR/SDL2.dll             dest/
+          cp vs/$RELEASE_DIR/SDL2_image.dll       dest/
           cp vs/$RELEASE_DIR/SDL2_net.dll         dest/
           cp vs/$RELEASE_DIR/libpng16.dll         dest/
           cp src/libs/zmbv/$RELEASE_DIR/zlib1.dll dest/ # libpng dependency

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -160,7 +160,7 @@ jobs:
           ls -l "$VC_REDIST_PATH"
 
           # Include the necessary dlls from one of available versions
-          readonly VC_REDIST_VERSION="14.27.29016"
+          readonly VC_REDIST_VERSION="14.28.29325"
           readonly VC_REDIST_DIR="$VC_REDIST_PATH/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/Microsoft.VC142.CRT"
           cp "$VC_REDIST_DIR/msvcp140.dll"       dest/
           cp "$VC_REDIST_DIR/vcruntime140.dll"   dest/

--- a/README.md
+++ b/README.md
@@ -112,24 +112,26 @@ Install build dependencies appropriate for your OS:
 ``` shell
 # Fedora
 sudo dnf install gcc-c++ make automake alsa-lib-devel libpng-devel SDL2-devel \
-                 SDL2_net-devel opusfile-devel fluidsynth-devel
+                 SDL2_image-devel SDL2_net-devel opusfile-devel fluidsynth-devel
 ```
 
 ``` shell
 # Debian, Ubuntu
 sudo apt install build-essential automake libasound2-dev libpng-dev \
-                 libsdl2-dev libsdl2-net-dev libopusfile-dev libfluidsynth-dev
+                 libsdl2-dev libsdl2-image-dev libsdl2-net-dev libopusfile-dev \
+                 libfluidsynth-dev
 ```
 
 ``` shell
 # Arch, Manjaro
-sudo pacman -S gcc automake alsa-lib libpng sdl2 sdl2_net opusfile fluidsynth
+sudo pacman -S gcc automake alsa-lib libpng sdl2 sdl2_image sdl2_net opusfile \
+               fluidsynth
 ```
 
 ``` shell
 # macOS
 xcode-select --install
-brew install autogen automake libpng sdl2 sdl2_net opusfile fluid-synth
+brew install autogen automake libpng sdl2 sdl2_image sdl2_net opusfile fluid-synth
 ```
 
 Compilation flags suggested for local optimised builds:
@@ -155,7 +157,7 @@ and run:
 
 ``` powershell
 PS:\> .\vcpkg integrate install
-PS:\> .\vcpkg install --triplet x64-windows libpng sdl2 sdl2-net opusfile fluidsynth
+PS:\> .\vcpkg install --triplet x64-windows libpng sdl2 sdl2-image sdl2-net opusfile fluidsynth
 ```
 
 These two steps will ensure that MSVC finds and links all dependencies.

--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,41 @@ else
   AC_MSG_RESULT([no])
 fi
 
+dnl SDL2_Image Support
+dnl ------------------
+dnl
+AH_TEMPLATE(C_SDL_IMAGE, [Define to 1 to enable SDL2_Image Support])
+AC_ARG_ENABLE(sdl_image,
+              AS_HELP_STRING([--disable-sdl-image],
+                             [Disable SDL2_Image: display captures will be saved as BMP]))
+if test "${enable_sdl_image}" != "no" ; then
+    PKG_CHECK_MODULES([SDL_IMAGE],
+                      [SDL2_image],
+                      [CPPFLAGS="$CPPFLAGS $SDL_IMAGE_CFLAGS"
+                       have_sdl_image=yes], [have_sdl_image=no])
+    if test x$have_sdl_image = xyes; then
+        if test x$enable_sdl_static = xyes; then
+            case "$host" in
+            *-*-darwin*)
+                LIBS="/usr/local/lib/libjpeg.a /usr/local/lib/libtiff.a /usr/local/lib/libwebp.a /usr/local/lib/libSDL2_image.a $LIBS"
+                ;;
+            *)
+                AC_MSG_WARN(m4_normalize([Statically linking SDL2 is unreliable.
+                  Please ensure that "libSDL2_image.a" is available.]))
+                LIBS="-Wl,-Bstatic -ljpeg -ltiff -lwebp -lSDL2_image -Wl,-Bdynamic $LIBS"
+                ;;
+            esac
+        else
+            LIBS="$SDL_IMAGE_LIBS $LIBS"
+        fi
+        AC_DEFINE(C_SDL_IMAGE,1)
+    else
+        AC_DEFINE(C_SDL_IMAGE,0)
+        AC_MSG_WARN([SDL2_Image support disabled])
+    fi
+fi
+
+
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_C_BIGENDIAN

--- a/contrib/fedora/dosbox-staging.spec
+++ b/contrib/fedora/dosbox-staging.spec
@@ -15,6 +15,7 @@ BuildRequires: automake
 BuildRequires: alsa-lib-devel
 BuildRequires: libpng-devel
 BuildRequires: SDL2-devel
+BuildRequires: SDL2_image-devel
 BuildRequires: SDL2_net-devel
 BuildRequires: opusfile-devel
 BuildRequires: librsvg2-tools

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -21,6 +21,7 @@
 #define DOSBOX_HARDWARE_H
 
 #include <stdio.h>
+#include <string>
 
 class Section;
 enum OPL_Mode {
@@ -43,6 +44,7 @@ bool SB_Get_Address(Bitu& sbaddr, Bitu& sbirq, Bitu& sbdma);
 bool TS_Get_Address(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
 
 extern Bit8u adlib_commandreg;
+std::string GetCaptureName(const char *type, const char *ext);
 FILE * OpenCaptureFile(const char * type,const char * ext);
 
 void CAPTURE_AddWave(Bit32u freq, Bit32u len, Bit16s * data);

--- a/scripts/automator/packages/manager-apt
+++ b/scripts/automator/packages/manager-apt
@@ -1,2 +1,2 @@
 # Package repo: https://packages.ubuntu.com/
-packages+=(ccache libtool build-essential automake libpng-dev libsdl2-dev libsdl2-net-dev libncurses-dev libopusfile-dev libfluidsynth-dev)
+packages+=(ccache libtool build-essential automake libpng-dev libsdl2-dev libsdl2-image-dev libsdl2-net-dev libncurses-dev libopusfile-dev libfluidsynth-dev)

--- a/scripts/automator/packages/manager-brew
+++ b/scripts/automator/packages/manager-brew
@@ -1,3 +1,3 @@
 # Package repo: https://formulae.brew.sh/
 delim="@"
-packages+=(ccache coreutils autogen autoconf automake make pkg-config libpng ncurses sdl2 sdl2_net opusfile fluid-synth)
+packages+=(ccache coreutils autogen autoconf automake make pkg-config libpng ncurses sdl2 sdl2_image sdl2_net opusfile fluid-synth)

--- a/scripts/automator/packages/manager-dnf
+++ b/scripts/automator/packages/manager-dnf
@@ -1,3 +1,3 @@
 # Package repo: https://apps.fedoraproject.org/packages/
 packages+=(ccache make automake alsa-lib-devel libpng-devel SDL2-devel
-           SDL2_net-devel opusfile-devel fluidsynth-devel)
+           SDL2_image-devel SDL2_net-devel opusfile-devel fluidsynth-devel)

--- a/scripts/automator/packages/manager-haikuports
+++ b/scripts/automator/packages/manager-haikuports
@@ -2,5 +2,6 @@
 delim=""
 packages+=(ccache coreutils autoconf automake autoconf_archive
            pkgconfig libpng ncurses6_devel libsdl2_devel
-           sdl2_net_devel libogg_devel opus_devel opusfile_devel
-           gcc_syslibs_devel opus_tools fluidsynth2_devel)
+           sdl2_image_devel sdl2_net_devel libogg_devel
+           opus_devel opusfile_devel gcc_syslibs_devel
+           opus_tools fluidsynth2_devel)

--- a/scripts/automator/packages/manager-macports
+++ b/scripts/automator/packages/manager-macports
@@ -1,3 +1,3 @@
 # Package repo: https://www.macports.org/ports.php?by=name
 delim=""
-packages+=(ccache coreutils autogen autoconf automake pkgconfig libpng ncurses libsdl2 libsdl2_net opusfile fluidsynth)
+packages+=(ccache coreutils autogen autoconf automake pkgconfig libpng ncurses libsdl2 libsdl2_image libsdl2_net opusfile fluidsynth)

--- a/scripts/automator/packages/manager-msys2
+++ b/scripts/automator/packages/manager-msys2
@@ -2,6 +2,6 @@
 # MSYS2 only supports the current latest releases of Clang and GCC, so we disable version customization
 packages+=(autogen autoconf base-devel automake-wrapper binutils)
 pkg_type=$([[ "${bits}" == "64" ]] && echo "x86_64" || echo "i686")
-for pkg in ccache pkg-config libtool libpng zlib ncurses pdcurses SDL2 SDL2_net opusfile fluidsynth; do
+for pkg in ccache pkg-config libtool libpng zlib ncurses pdcurses SDL2 SDL2_image SDL2_net opusfile fluidsynth; do
 	packages+=("mingw-w64-${pkg_type}-${pkg}")
 done

--- a/scripts/automator/packages/manager-pacman
+++ b/scripts/automator/packages/manager-pacman
@@ -1,4 +1,4 @@
 # Package repo: https://www.archlinux.org/packages/
 # Arch offers 32-bit versions of SDL (but not others)
-packages+=(ccache libtool ncurses sdl2_net opusfile fluidsynth)
+packages+=(ccache libtool ncurses sdl2_image sdl2_net opusfile fluidsynth)
 [[ "${bits}" == "32" ]] && packages+=(lib32-sdl2) || packages+=(sdl2)

--- a/scripts/automator/packages/manager-vcpkg
+++ b/scripts/automator/packages/manager-vcpkg
@@ -1,2 +1,2 @@
 # Package repo: https://repology.org/projects/?inrepo=vcpkg
-packages+=(libpng pdcurses sdl2 sdl2-net opusfile fluidsynth)
+packages+=(libpng pdcurses sdl2 sdl2-image sdl2-net opusfile fluidsynth)

--- a/scripts/automator/packages/manager-zypper
+++ b/scripts/automator/packages/manager-zypper
@@ -3,7 +3,7 @@
 packages+=(ccache devel_basis xvfb libtool opusfile)
 
 if [[ "${bits}" == "32" ]]; then
-	packages+=(ncurses-devel-32bit libSDL2-devel-32bit libSDL2_net-devel-32bit)
+	packages+=(ncurses-devel-32bit libSDL2-devel-32bit libSDL2_image-devel libSDL2_net-devel-32bit)
 else
 	packages+=(ncurses-devel SDL2 SDL2_net fluidsynth-devel)
 fi

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -80,8 +80,9 @@ static struct {
 #endif
 } capture;
 
-FILE * OpenCaptureFile(const char * type,const char * ext) {
-	if(capturedir.empty()) {
+std::string GetCaptureName(const char *type, const char *ext)
+{
+	if (capturedir.empty()) {
 		LOG_MSG("Please specify a capture directory");
 		return 0;
 	}
@@ -94,8 +95,7 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 		//Try creating it first
 		Cross::CreateDir(capturedir);
 		dir=open_directory(capturedir.c_str());
-		if(!dir) {
-		
+		if (!dir) {
 			LOG_MSG("Can't open dir %s for capturing %s",capturedir.c_str(),type);
 			return 0;
 		}
@@ -121,12 +121,17 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 	char file_name[CROSS_LEN];
 	sprintf(file_name, "%s%c%s%03d%s",
 	        capturedir.c_str(), CROSS_FILESPLIT, file_start, last, ext);
-	/* Open the actual file */
-	FILE * handle=fopen(file_name,"wb");
+	return file_name;
+}
+
+FILE *OpenCaptureFile(const char *type, const char *ext)
+{
+	const auto file_name = GetCaptureName(type, ext);
+	FILE *handle = fopen(file_name.c_str(), "wb");
 	if (handle) {
-		LOG_MSG("Capturing %s to %s",type,file_name);
+		LOG_MSG("Capturing %s to %s", type, file_name.c_str());
 	} else {
-		LOG_MSG("Failed to open %s for capturing %s",file_name,type);
+		LOG_MSG("Failed to open %s for capturing %s", file_name.c_str(), type);
 	}
 	return handle;
 }

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -7,6 +7,9 @@
 /* Define to 1 to enable internal debugger, requires libcurses */
 #define C_DEBUG 0
 
+/* Define to 1 to enable SDL2_Image Support */
+#define C_SDL_IMAGE 1
+
 /* Define to 1 to enable screenshots, requires libpng */
 #define C_SSHOT 1
 

--- a/src/platform/visualc/sdl_image.h
+++ b/src/platform/visualc/sdl_image.h
@@ -1,0 +1,4 @@
+// This file exists only for MSVC builds.
+// It's needed because vcpkg does not set SDL subdirectory in includes list
+// for projects that do not use cmake.
+#include <SDL2/SDL_image.h>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -102,7 +102,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;SDL2_net.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;SDL2_image.lib;SDL2_net.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -132,7 +132,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;SDL2_net.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;SDL2_image.lib;SDL2_net.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -170,7 +170,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_image.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -215,7 +215,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_image.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This captures the output exactly as configured by the user.

| Feature | Aspect-Ratio | Resolution |  Shader(s) |
| :---: | :--- | :--- | :--- |
| Exiting Screenshot |  Not correct | Not as-shown | Not as-shown | 
| PR's Screenshot |  Correct | As-shown | As-shown | 

Try it out:
 - PR-screenshot using **Ctrl + F3**
 - Original-screenshot using **Ctrl + F5**

## Comparison

I configured dosbox with:
 - Full screen
 - `aspect=true`, and
 - `crt-easymode.tweaked.glsl` shader.

- **Existing screenshot** `Ctrl + F5`:

    ![dosbox_001](https://user-images.githubusercontent.com/1557255/99862978-db351800-2b50-11eb-9362-8017182ab490.png)

- **PR screenshot** `Ctrl + F3` (click to view up-close):

    ![dosbox_000](https://user-images.githubusercontent.com/1557255/99862979-dc664500-2b50-11eb-9a97-636211992161.png)

## Key Points

### 3rd Party Capturing is Post-Processed

External 3rd party tools _can_ perform screen grabs in the same way that 3rd party tools can record audio, however in both cases what's recorded is post-drivers and post-OS manipulation, including possible OS/driver bugs or quirks.

Being able to capture our final output handed over to the OS has proven invaluable in differentiating our own audio issues versus those caused by the OS/drivers (such as Windows applying a half-baked DC offset correction, or various audio issues on Linux as we've periodically hit).  This will let us differentiate our own rendered output versus video driver post-processing effects such as integer filtering, [Gaussian filtering](https://github.com/joncampbell123/dosbox-x/issues/1732#issuecomment-659575223), sharpening, or colour-modifying settings.

### Follows the existing Screenshot process

Screenshots are written using the same mechanism at the existing screenshot feature. Files pile up in the configured `capture` directory, named after the DOS program.

### Fallback to Bitmap capture

This PR includes a one-line fallback to save the image to BMP in the event SDL2_Image is unavailable.

### Uses SDL_Image

I originally didn't want to use SDL_Image as a knee-jerk reaction to avoiding dependencies.  

However, we're already using SDL2 and SDL2_net, and SDL_Image is _"the-SDL-way"_ to save an `SDL_Surface` to image in one function call.  It doesn't get easier. 

SDL2_Image is well maintained with latest commits only a couple weeks old. If DOSBox had transitioned to SDL_Image when available, then the various libpng version and linking issues would have been abstracted away.

### What do we do with the existing screenshot feature and libpng?

I would suggest:

 1. This PR take over as the "real" screenshot (F5 + MMOD1)
 2. Existing screenshot be renamed to "raw" screenshot (F5 + MMOD2)
 3. Existing screenshot using the same SDL2_Image write call (with BMP-fallback)
 4. Deprecate libpng as a dependency.

Or other alternatives?