### PR TITLE
Replace Cross::CreateDir with create_dir function

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -77,7 +77,6 @@ public:
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
 	static void ResolveHomedir(std::string & temp_line);
-	static void CreateDir(std::string const& temp);
 	static bool IsPathAbsolute(std::string const& in);
 };
 

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -57,8 +57,15 @@ std::string to_native_path(const std::string &path) noexcept;
  *
  * - Unix: mkdir(const char *, mode_t)
  * - Windows: _mkdir(const char *)
+ *
+ * Normal behaviour of mkdir is to fail when directory exists already,
+ * you can override this behaviour by calling:
+ *
+ *     create_dir(path, 0700, OK_IF_EXISTS)
  */
 
-int create_dir(const char *path, uint32_t mode);
+constexpr uint32_t OK_IF_EXISTS = 0x1;
+
+int create_dir(const char *path, uint32_t mode, uint32_t flags = 0x0) noexcept;
 
 #endif

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -21,6 +21,7 @@
 #ifndef DOSBOX_FS_UTILS_H
 #define DOSBOX_FS_UTILS_H
 
+#include <cinttypes>
 #include <string>
 
 /* Check if the given path corresponds to an existing file or directory.
@@ -51,5 +52,13 @@ inline bool path_exists(const std::string &path) noexcept
  */
 
 std::string to_native_path(const std::string &path) noexcept;
+
+/* Cross-platform wrapper for following functions:
+ *
+ * - Unix: mkdir(const char *, mode_t)
+ * - Windows: _mkdir(const char *)
+ */
+
+int create_dir(const char *path, uint32_t mode);
 
 #endif

--- a/include/support.h
+++ b/include/support.h
@@ -236,4 +236,17 @@ constexpr size_t static_if_array_then_zero()
 	(static_if_array_then_zero<decltype(arr)>() +                          \
 	 (sizeof(arr) / sizeof(arr[0])))
 
+// Thread-safe replacement for strerror.
+//
+// Usage:
+//     char desc[STRERR_LEN];
+//     safe_strerror(desc, errno);
+//
+#define STRERR_LEN 128
+#ifdef _MSC_VER
+#define safe_strerror(buf, err) strerror_s(buf, ARRAY_LEN(buf), err)
+#else
+#define safe_strerror(buf, err) strerror_r(err, buf, ARRAY_LEN(buf))
+#endif
+
 #endif

--- a/include/support.h
+++ b/include/support.h
@@ -238,15 +238,6 @@ constexpr size_t static_if_array_then_zero()
 
 // Thread-safe replacement for strerror.
 //
-// Usage:
-//     char desc[STRERR_LEN];
-//     safe_strerror(desc, errno);
-//
-#define STRERR_LEN 128
-#ifdef _MSC_VER
-#define safe_strerror(buf, err) strerror_s(buf, ARRAY_LEN(buf), err)
-#else
-#define safe_strerror(buf, err) strerror_r(err, buf, ARRAY_LEN(buf))
-#endif
+std::string safe_strerror(int err) noexcept;
 
 #endif

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -394,13 +394,9 @@ bool localDrive::MakeDir(char * dir) {
 	safe_strcpy(newdir, basedir);
 	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
-#if defined (WIN32)						/* MS Visual C++ */
-	int temp=mkdir(dirCache.GetExpandName(newdir));
-#else
-	int temp=mkdir(dirCache.GetExpandName(newdir),0775);
-#endif
-	if (temp==0) dirCache.CacheOut(newdir,true);
-
+	const int temp = create_dir(dirCache.GetExpandName(newdir), 0775);
+	if (temp == 0)
+		dirCache.CacheOut(newdir, true);
 	return (temp==0);// || ((temp!=0) && (errno==EEXIST));
 }
 

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -33,6 +33,8 @@
 #include <time.h>
 #include <errno.h>
 
+#include "fs_utils.h"
+
 #define OVERLAY_DIR 1
 bool logoverlay = false;
 using namespace std;
@@ -157,11 +159,7 @@ bool Overlay_Drive::MakeDir(char * dir) {
 	safe_strcpy(newdir, overlaydir);
 	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
-#if defined (WIN32)						/* MS Visual C++ */
-	int temp = mkdir(newdir);
-#else
-	int temp = mkdir(newdir,0775);
-#endif
+	const int temp = create_dir(newdir, 0775);
 	if (temp==0) {
 		char fakename[CROSS_LEN];
 		safe_strcpy(fakename, basedir);
@@ -550,12 +548,8 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 			} else {
 				//folder does not exist, make it
 				if (logoverlay) LOG_MSG("creating %s",dirnameoverlay);
-#if defined (WIN32)						/* MS Visual C++ */
-				int temp = mkdir(dirnameoverlay);
-#else
-				int temp = mkdir(dirnameoverlay,0700);
-#endif
-				if (temp != 0) return false;
+				if (create_dir(dirnameoverlay, 0700) != 0)
+					return false;
 			}
 		}
 		leaddir = leaddir + 1; //Move to next

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -19,10 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include "dosbox.h"
 
 #include <array>
@@ -3061,10 +3057,8 @@ static void launchcaptures(std::string const& edit) {
 	path += file;
 
 	if (create_dir(path.c_str(), 0700, OK_IF_EXISTS) != 0) {
-		char desc[STRERR_LEN];
-		safe_strerror(desc, errno);
 		fprintf(stderr, "Can't access capture dir '%s': %s\n",
-		        path.c_str(), desc);
+		        path.c_str(), safe_strerror(errno).c_str());
 		exit(1);
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3060,21 +3060,12 @@ static void launchcaptures(std::string const& edit) {
 	Cross::CreatePlatformConfigDir(path);
 	path += file;
 
-	if (create_dir(path.c_str(), 0700) != 0) {
-		bool dir_exists = false;
-		if (errno == EEXIST) {
-			struct stat cstat;
-			if ((stat(path.c_str(), &cstat) == 0) &&
-			    (cstat.st_mode & S_IFDIR))
-				dir_exists = true;
-		}
-		if (!dir_exists) {
-			char desc[STRERR_LEN];
-			safe_strerror(desc, errno);
-			fprintf(stderr, "Can't access capture dir '%s': %s\n",
-			        path.c_str(), desc);
-			exit(1);
-		}
+	if (create_dir(path.c_str(), 0700, OK_IF_EXISTS) != 0) {
+		char desc[STRERR_LEN];
+		safe_strerror(desc, errno);
+		fprintf(stderr, "Can't access capture dir '%s': %s\n",
+		        path.c_str(), desc);
+		exit(1);
 	}
 
 	execlp(edit.c_str(),edit.c_str(),path.c_str(),(char*) 0);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3069,8 +3069,10 @@ static void launchcaptures(std::string const& edit) {
 				dir_exists = true;
 		}
 		if (!dir_exists) {
+			char desc[STRERR_LEN];
+			safe_strerror(desc, errno);
 			fprintf(stderr, "Can't access capture dir '%s': %s\n",
-			        path.c_str(), strerror(errno));
+			        path.c_str(), desc);
 			exit(1);
 		}
 	}

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -92,7 +92,7 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 	dir_information *dir = open_directory(capturedir.c_str());
 	if (!dir) {
 		// Try creating it first
-		if (create_dir(capturedir.c_str(), 0700) != 0) {
+		if (create_dir(capturedir.c_str(), 0700, OK_IF_EXISTS) != 0) {
 			char desc[STRERR_LEN];
 			safe_strerror(desc, errno);
 			LOG_MSG("ERROR: Can't create dir '%s': %s",

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -93,8 +93,10 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 	if (!dir) {
 		// Try creating it first
 		if (create_dir(capturedir.c_str(), 0700) != 0) {
+			char desc[STRERR_LEN];
+			safe_strerror(desc, errno);
 			LOG_MSG("ERROR: Can't create dir '%s': %s",
-			        capturedir.c_str(), strerror(errno));
+			        capturedir.c_str(), desc);
 		}
 
 		dir = open_directory(capturedir.c_str());

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -93,10 +93,8 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 	if (!dir) {
 		// Try creating it first
 		if (create_dir(capturedir.c_str(), 0700, OK_IF_EXISTS) != 0) {
-			char desc[STRERR_LEN];
-			safe_strerror(desc, errno);
 			LOG_MSG("ERROR: Can't create dir '%s': %s",
-			        capturedir.c_str(), desc);
+			        capturedir.c_str(), safe_strerror(errno).c_str());
 		}
 
 		dir = open_directory(capturedir.c_str());

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -177,16 +177,7 @@ void Cross::CreatePlatformConfigDir(std::string &in)
 	if (in.back() != CROSS_FILESPLIT)
 		in += CROSS_FILESPLIT;
 
-	if (create_dir(in.c_str(), 0700) != 0) {
-		// If creation failed because directory already exists, then silently
-		// return. Otherwise leave a log for user because something unexpected
-		// happened.
-		if (errno == EEXIST) {
-			struct stat cstat;
-			if ((stat(in.c_str(), &cstat) == 0) &&
-			    (cstat.st_mode & S_IFDIR))
-				return;
-		}
+	if (create_dir(in.c_str(), 0700, OK_IF_EXISTS) != 0) {
 		LOG_MSG("ERROR: Creation of config directory '%s' failed: %s",
 		        in.c_str(), safe_strerror(errno).c_str());
 	}

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -187,8 +187,10 @@ void Cross::CreatePlatformConfigDir(std::string &in)
 			    (cstat.st_mode & S_IFDIR))
 				return;
 		}
+		char desc[STRERR_LEN];
+		safe_strerror(desc, errno);
 		LOG_MSG("ERROR: Creation of config directory '%s' failed: %s",
-		        in.c_str(), strerror(errno));
+		        in.c_str(), desc);
 	}
 }
 

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -187,10 +187,8 @@ void Cross::CreatePlatformConfigDir(std::string &in)
 			    (cstat.st_mode & S_IFDIR))
 				return;
 		}
-		char desc[STRERR_LEN];
-		safe_strerror(desc, errno);
 		LOG_MSG("ERROR: Creation of config directory '%s' failed: %s",
-		        in.c_str(), desc);
+		        in.c_str(), safe_strerror(errno).c_str());
 	}
 }
 

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -24,6 +24,8 @@
 
 #include <cctype>
 #include <glob.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "logging.h"
@@ -93,6 +95,12 @@ std::string to_native_path(const std::string &path) noexcept
 	const std::string ret = pglob.gl_pathv[0];
 	globfree(&pglob);
 	return ret;
+}
+
+int create_dir(const char *path, uint32_t mode)
+{
+	static_assert(sizeof(uint32_t) >= sizeof(mode_t), "");
+	return mkdir(path, mode);
 }
 
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -39,9 +39,16 @@ std::string to_native_path(const std::string &path) noexcept
 	return "";
 }
 
-int create_dir(const char *path, MAYBE_UNUSED uint32_t mode)
+int create_dir(const char *path, MAYBE_UNUSED uint32_t mode, uint32_t flags) noexcept
 {
-	return _mkdir(path);
+	const int err = _mkdir(path);
+	if ((errno == EEXIST) && (flags & OK_IF_EXISTS)) {
+		struct _stat pstat;
+		if ((_stat(path, &pstat) == 0) &&
+		    ((pstat.st_mode & S_IFMT) == S_IFDIR))
+			return 0;
+	}
+	return err;
 }
 
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -22,7 +22,10 @@
 
 #include "fs_utils.h"
 
+#include <direct.h>
 #include <io.h>
+
+#include "compiler.h"
 
 bool path_exists(const char *path) noexcept
 {
@@ -34,6 +37,11 @@ std::string to_native_path(const std::string &path) noexcept
 	if (path_exists(path))
 		return path;
 	return "";
+}
+
+int create_dir(const char *path, MAYBE_UNUSED uint32_t mode)
+{
+	return _mkdir(path);
 }
 
 #endif

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -254,3 +254,22 @@ void E_Exit(const char * format,...) {
 
 	throw(buf);
 }
+
+std::string safe_strerror(int err) noexcept
+{
+	char buf[128];
+#if defined(_MSC_VER)
+	// C11 version; unavailable in C++14 in general.
+	strerror_s(buf, ARRAY_LEN(buf), err);
+	return buf;
+#elif defined(_GNU_SOURCE)
+	// GNU has POSIX-incompatible version, which fills the buffer
+	// only when unknown error is passed, otherwise it returns
+	// the internal glibc buffer.
+	return strerror_r(err, buf, ARRAY_LEN(buf));
+#else
+	// POSIX version
+	strerror_r(err, buf, ARRAY_LEN(buf));
+	return buf;
+#endif
+}

--- a/tests/fs_utils.cpp
+++ b/tests/fs_utils.cpp
@@ -90,11 +90,27 @@ TEST_F(CreateDirTest, CreateDir)
 	EXPECT_EQ(errno, EEXIST);
 }
 
+TEST_F(CreateDirTest, CreateDirWithoutFail)
+{
+	ASSERT_FALSE(path_exists(TEST_DIR));
+	EXPECT_EQ(create_dir(TEST_DIR, 0700, OK_IF_EXISTS), 0);
+	EXPECT_TRUE(path_exists(TEST_DIR));
+	EXPECT_EQ(create_dir(TEST_DIR, 0700, OK_IF_EXISTS), 0);
+}
+
 TEST_F(CreateDirTest, FailDueToFileExisting)
 {
 	constexpr char path[] = "tests/files/paths/empty.txt";
 	ASSERT_TRUE(path_exists(path));
 	EXPECT_EQ(create_dir(path, 0700), -1);
+	EXPECT_EQ(errno, EEXIST);
+}
+
+TEST_F(CreateDirTest, FailDueToFileExisting2)
+{
+	constexpr char path[] = "tests/files/paths/empty.txt";
+	ASSERT_TRUE(path_exists(path));
+	EXPECT_EQ(create_dir(path, 0700, OK_IF_EXISTS), -1);
 	EXPECT_EQ(errno, EEXIST);
 }
 


### PR DESCRIPTION
```
    New create_dir function behaves exactly like mkdir, so it can be used
    for replacing all mkdir usage as well (which means removal of ifdefs, as
    Unix mkdir is different than Windows mkdir/_mkdir).
    
    This change requires adding some additional checks in code that was
    missing it (where Cross::CreateDir was being used) - this code generated
    warnings in static analyzer tools. This change allows us to provide
    better logs or error messages to users.
```

This is a cleanup required before implementing the last feature for FluidSynth we want to support for 0.76.0 (searching sf2 files in existing directories). It's required so we could provide `soundfonts` dir behaving the same way as `glshaders` behaves right now.