### PR TITLE
Look for sf2 files in standard locations

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -70,6 +70,7 @@
 #endif
 
 void CROSS_DetermineConfigPaths();
+std::string CROSS_GetPlatformConfigDir();
 
 class Cross {
 public:

--- a/include/cross.h
+++ b/include/cross.h
@@ -71,6 +71,7 @@
 
 void CROSS_DetermineConfigPaths();
 std::string CROSS_GetPlatformConfigDir();
+std::string CROSS_ResolveHome(const std::string &str);
 
 class Cross {
 public:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3230,8 +3230,9 @@ int main(int argc, char* argv[]) {
 	atexit(QuitSDL);
 
 	/* Parse configuration files */
-	std::string config_file, config_path, config_combined;
-	Cross::GetPlatformConfigDir(config_path);
+	std::string config_file, config_combined;
+
+	std::string config_path = CROSS_GetPlatformConfigDir();
 
 	//First parse -userconf
 	if(control->cmdline->FindExist("-userconf",true)){
@@ -3292,6 +3293,18 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
+#if C_OPENGL
+	const std::string glshaders_dir = config_path + "glshaders";
+	if (create_dir(glshaders_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
+		LOG_MSG("CONFIG: Can't create dir '%s': %s",
+			glshaders_dir.c_str(), safe_strerror(errno).c_str());
+#endif // C_OPENGL
+#if C_FLUIDSYNTH
+	const std::string soundfonts_dir = config_path + "soundfonts";
+	if (create_dir(soundfonts_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
+		LOG_MSG("CONFIG: Can't create dir '%s': %s",
+			soundfonts_dir.c_str(), safe_strerror(errno).c_str());
+#endif // C_FLUIDSYNTH
 
 #if (ENVIRON_LINKED)
 		control->ParseEnv(environ);

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -148,16 +148,24 @@ static void W32_ConfDir(std::string& in,bool create) {
 }
 #endif
 
-void Cross::GetPlatformConfigDir(std::string& in) {
+std::string CROSS_GetPlatformConfigDir()
+{
+	std::string conf_dir = "";
 #ifdef WIN32
-	W32_ConfDir(in,false);
-	in += "\\DOSBox";
+	W32_ConfDir(conf_dir, false);
+	conf_dir += "\\DOSBox\\";
 #else
 	assert(!cached_conf_path.empty());
-	in = cached_conf_path;
+	conf_dir = cached_conf_path;
+	if (conf_dir.back() != CROSS_FILESPLIT)
+		conf_dir += CROSS_FILESPLIT;
 #endif
-	if (in.back() != CROSS_FILESPLIT)
-		in += CROSS_FILESPLIT;
+	return conf_dir;
+}
+
+void Cross::GetPlatformConfigDir(std::string &in)
+{
+	in = CROSS_GetPlatformConfigDir();
 }
 
 void Cross::GetPlatformConfigName(std::string &in)


### PR DESCRIPTION
I think this concludes the FluidSynth features we want to be implemented for 0.76.0 (#262). More improvements will be pushed back to 0.77.0 (unless we have something critical and user-facing to address).

With this PR, soundfont is searched not only by path, but also in standard locations - notably in `/usr/share/soundfonts/`, where FluidSynth places `default.sf2` file (which is a symlink to Fluid_R3 soundfont. This way DOSBox Staging packages can use Fluid soundfont as a dependency and it will be picked automatically.

Users can also place their soundfonts in new `~/.config/dosbox/soundfonts/` directory or in use relative or absolute path (as it used to work) - so sf2 can be stored in the game directory and it will work fine as long as the current working directory is used correctly.

On macOS path `~/Library/Audio/Sounds/Banks/` is searched - it seems like it is semi-official path to store sf2 files.

On Windows path `C:\soundfonts\` is searched - it is path listed in FluidSynth documentation.