### PR TITLE
Cleanup Coverity issues and compiler warnings in serial port

### DIFF
--- a/include/serialport.h
+++ b/include/serialport.h
@@ -362,13 +362,7 @@ private:
 	uint8_t loopback_data = 0;
 	void transmitLoopbackByte(uint8_t val, bool value);
 
-	// 16C550 (FIFO)
-public: // todo remove
-	Fifo *rxfifo = nullptr;
-
 private:
-	Fifo *txfifo = nullptr;
-	Fifo *errorfifo = nullptr;
 	// Universal Asynchronous Receiver Transmitter (UARTs) were largely
 	// defined by their buffer sizes:
 	// - 8250, 16450, and early 16550: 1-byte buffer and are obsolete
@@ -379,6 +373,9 @@ private:
 	// - 16950: up to 512-byte buffer
 	// - Hayes ESP accelerator: 1024-byte buffer
 	const uint16_t fifo_size = 16; // emulate the 16550A
+	Fifo errorfifo;
+	Fifo rxfifo;
+	Fifo txfifo;
 	uint32_t errors_in_fifo = 0;
 	uint32_t rx_interrupt_threshold = 0;
 	uint8_t FCR = 0;

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -21,6 +21,7 @@
 #define DOSBOX_SERIALPORT_H
 
 #include <algorithm>
+#include <queue>
 #include <vector>
 
 #ifndef DOSBOX_DOSBOX_H
@@ -52,97 +53,22 @@
 
 // Serial port interface
 
-#define SERIAL_MAX_FIFO_SIZE 256
-/* Note: Almost all DOS-era universal asynchronous receiver-transmitter
- *       (UART)'s permitted up to a 16-byte receive and transmit
- *       first-in/first-out (FIFO) buffer, however some specialty
- *       controller cards allowed up to 64-bytes and later 256-bytes.
- */
-
-class MyFifo {
+class Fifo {
 public:
-	MyFifo(const MyFifo &) = delete;            // prevent copying
-	MyFifo &operator=(const MyFifo &) = delete; // prevent assignment
-
-	MyFifo(size_t n) : data(n, 0), maxsize(n), size(n)
-	{
-		assert(n <= SERIAL_MAX_FIFO_SIZE);
-	}
-	size_t getFree() { return size - used; }
-	bool isEmpty() { return used == 0; }
-	bool isFull() { return (size - used) == 0; }
-	size_t getUsage() { return used; }
-	void setSize(size_t n)
-	{
-		assert(n <= SERIAL_MAX_FIFO_SIZE);
-		data.resize(n);
-		size = n;
-		maxsize = n;
-		pos = used = 0;
-	}
-	void clear() {
-		pos = used = 0;
-		if (data.size() > 0)
-			std::fill(data.begin(), data.end(), 0);
-	}
-
-	bool addb(uint8_t val)
-	{
-		size_t where = pos + used;
-		if (where >= size)
-			where -= size;
-		if (used >= size) {
-			// overwrite last byte
-			if (where == 0)
-				where = size - 1;
-			else where--;
-			assert(where < data.size());
-			data[where] = val;
-			return false;
-		}
-		assert(where < data.size());
-		data[where] = val;
-		used++;
-		return true;
-	}
-	uint8_t getb()
-	{
-		if (!used)
-			return data[pos];
-		size_t where = pos;
-		used--;
-		if(used) pos++;
-		if (pos>=size) pos-=size;
-		assert(where < data.size());
-		return data[where];
-	}
-	uint8_t getTop()
-	{
-		size_t where = pos + used;
-		if (where >= size)
-			where -= size;
-		if (used >= size) {
-			if (where == 0)
-				where = size - 1;
-			else
-				where--;
-		}
-		assert(where < data.size());
-		return data[where];
-	}
-
-	uint8_t probeByte()
-	{
-		assert(pos < data.size());
-		return data[pos];
-	}
+	Fifo(const size_t n);
+	uint8_t back() const noexcept;
+	void clear() noexcept;
+	uint8_t front() const noexcept;
+	bool isEmpty() const noexcept;
+	bool isFull() const noexcept;
+	size_t numQueued() const noexcept;
+	uint8_t pop() noexcept;
+	bool push(const uint8_t val) noexcept;
+	void setSize(const size_t n) noexcept;
 
 private:
-	std::vector<uint8_t> data;
-	size_t maxsize = 0;
-	size_t size = 0;
-	size_t pos = 0;
-	size_t used = 0;
+	std::queue<uint8_t> q;
+	size_t slots = 0;
 };
 
 class CSerial {
@@ -438,14 +364,23 @@ private:
 
 	// 16C550 (FIFO)
 public: // todo remove
-	MyFifo *rxfifo = nullptr;
+	Fifo *rxfifo = nullptr;
 
 private:
-	MyFifo *txfifo = nullptr;
-	MyFifo *errorfifo = nullptr;
+	Fifo *txfifo = nullptr;
+	Fifo *errorfifo = nullptr;
+	// Universal Asynchronous Receiver Transmitter (UARTs) were largely
+	// defined by their buffer sizes:
+	// - 8250, 16450, and early 16550: 1-byte buffer and are obsolete
+	// - 16550A and 16C552: 16-byte buffer
+	// - 16650: 32-byte buffer
+	// - 16750: 64-byte buffer
+	// - 16850 and 16C850: 128-byte buffer
+	// - 16950: up to 512-byte buffer
+	// - Hayes ESP accelerator: 1024-byte buffer
+	const uint16_t fifo_size = 16; // emulate the 16550A
 	uint32_t errors_in_fifo = 0;
 	uint32_t rx_interrupt_threshold = 0;
-	uint32_t fifosize = 0;
 	uint8_t FCR = 0;
 	bool sync_guardtime = false;
 

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -372,7 +372,7 @@ private:
 	// - 16850 and 16C850: 128-byte buffer
 	// - 16950: up to 512-byte buffer
 	// - Hayes ESP accelerator: 1024-byte buffer
-	const uint16_t fifo_size = 16; // emulate the 16550A
+	const uint16_t fifo_size = 1024; // emulate the Hayes ESP
 	Fifo errorfifo;
 	Fifo rxfifo;
 	Fifo txfifo;

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -93,7 +93,69 @@ device_COM::device_COM(class CSerial* sc) {
 device_COM::~device_COM() {
 }
 
+Fifo::Fifo(const size_t n) : q()
+{
+	setSize(n);
+}
 
+bool Fifo::push(const uint8_t val) noexcept
+{
+	if (numQueued() < slots) {
+		q.push(val);
+		return true;
+	}
+	// The FIFO's full. Real hardware favoured keeping the new data
+	// versus old by replacing the back of the FIFO with the newer
+	// data.
+	q.back() = val;
+	LOG_MSG("SERIAL: %lu-byte Rx FIFO is full. Data loss has occurred", slots);
+	return false;
+}
+
+void Fifo::clear() noexcept
+{
+	q = std::queue<uint8_t>();
+}
+
+uint8_t Fifo::pop() noexcept
+{
+	if (isEmpty())
+		return 0;
+	const auto val = q.front();
+	q.pop();
+	return val;
+}
+
+uint8_t Fifo::back() const noexcept
+{
+	return isEmpty() ? 0 : q.back();
+}
+
+size_t Fifo::numQueued() const noexcept
+{
+	return q.size();
+}
+
+bool Fifo::isEmpty() const noexcept
+{
+	return q.empty();
+}
+
+bool Fifo::isFull() const noexcept
+{
+	return q.size() >= slots;
+}
+
+uint8_t Fifo::front() const noexcept
+{
+	return isEmpty() ? 0 : q.front();
+}
+
+void Fifo::setSize(const size_t n) noexcept
+{
+	slots = n;
+	clear();
+}
 
 // COM1 - COM4 objects
 CSerial *serialports[SERIAL_MAX_PORTS] = {nullptr};
@@ -253,7 +315,7 @@ void CSerial::handleEvent(uint16_t type)
 		break;
 
 	case SERIAL_THR_LOOPBACK_EVENT:
-		loopback_data = txfifo->probeByte();
+		loopback_data = txfifo->front();
 		ByteTransmitting();
 		setEvent(SERIAL_TX_LOOPBACK_EVENT, bytetime);
 		break;
@@ -370,13 +432,15 @@ void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 	        data < 0x10 ? "\t\t\t\trx 0x%02x (%" PRIu8 ")" : "\t\t\t\trx 0x%02x (%c)",
 	        data, data);
 #endif
-	if (!(rxfifo->addb(data))) {
+	if (!(rxfifo->push(data))) {
 		// Overrun error ;o
 		error |= LSR_OVERRUN_ERROR_MASK;
 	}
 	removeEvent(SERIAL_RX_TIMEOUT_EVENT);
-	if(rxfifo->getUsage()==rx_interrupt_threshold) rise (RX_PRIORITY);
-	else setEvent(SERIAL_RX_TIMEOUT_EVENT,bytetime*4.0f);
+	if (rxfifo->numQueued() == rx_interrupt_threshold)
+		rise(RX_PRIORITY);
+	else
+		setEvent(SERIAL_RX_TIMEOUT_EVENT, bytetime * 4.0f);
 
 	if(error) {
 		// A lot of UART chips generate a framing error too when receiving break
@@ -390,14 +454,14 @@ void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 			// error and FIFO active
 			if(!errorfifo->isFull()) {
 				errors_in_fifo++;
-				errorfifo->addb(error);
+				errorfifo->push(error);
 			}
 			else {
-				uint8_t toperror = errorfifo->getTop();
+				uint8_t toperror = errorfifo->back();
 				if(!toperror) errors_in_fifo++;
-				errorfifo->addb(error|toperror);
+				errorfifo->push(error | toperror);
 			}
-			if(errorfifo->probeByte()) {
+			if (errorfifo->front()) {
 				// the next byte in the error fifo has an error
 				rise (ERROR_PRIORITY);
 				LSR |= error;
@@ -431,7 +495,7 @@ void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 	} else {
 		// no error
 		if(FCR&FCR_ACTIVATE) {
-			errorfifo->addb(error);
+			errorfifo->push(error);
 		}
 	}
 }
@@ -452,7 +516,7 @@ void CSerial::ByteTransmitting() {
 		//	LOG_MSG("SERIAL: Port %" PRIu8 " FIFO empty when it should not",
 		//	        GetPortNumber());
 		sync_guardtime=false;
-		txfifo->getb();
+		txfifo->pop();
 	}
 	// else
 	// 	LOG_MSG("SERIAL: Port %" PRIu8 " byte transmitting.",
@@ -460,14 +524,13 @@ void CSerial::ByteTransmitting() {
 	if(txfifo->isEmpty())rise (TX_PRIORITY);
 }
 
-
 /*****************************************************************************/
 /* ByteTransmitted: When a byte was sent, notify here.                      **/
 /*****************************************************************************/
 void CSerial::ByteTransmitted () {
 	if(!txfifo->isEmpty()) {
 		// there is more data
-		uint8_t data = txfifo->getb();
+		uint8_t data = txfifo->pop();
 #if SERIAL_DEBUG
 		log_ser(dbg_serialtraffic,data<0x10?
 			"\t\t\t\t\ttx 0x%02x (%" PRIu8 ") (from buffer)":
@@ -503,30 +566,35 @@ void CSerial::Write_THR(uint8_t data)
 
 		if((LSR & LSR_TX_EMPTY_MASK))
 		{	// we were idle before
-			// LOG_MSG("SERIAL: Port %" PRIu8 " starting new transmit cycle", GetPortNumber());
-			// if(sync_guardtime) LOG_MSG("SERIAL: Port %" PRIu8 " internal error 1", GetPortNumber());
-			// if(!(LSR & LSR_TX_EMPTY_MASK)) LOG_MSG("SERIAL: Port %" PRIu8 " internal error 2", GetPortNumber());
-			// if(txfifo->getUsage()) LOG_MSG("SERIAL: Port %" PRIu8 " internal error 3", GetPortNumber());
-			
+			// LOG_MSG("SERIAL: Port %" PRIu8 " starting new
+			// transmit cycle", GetPortNumber()); if(sync_guardtime)
+			// LOG_MSG("SERIAL: Port %" PRIu8 " internal error 1",
+			// GetPortNumber()); if(!(LSR & LSR_TX_EMPTY_MASK))
+			// LOG_MSG("SERIAL: Port %" PRIu8 " internal error 2",
+			// GetPortNumber()); if(txfifo->numQueued())
+			// LOG_MSG("SERIAL: Port %" PRIu8 " internal error 3",
+			// GetPortNumber());
+
 			// need "warming up" time
 			sync_guardtime=true;
 			// block the fifo so it returns THR full (or not in case of FIFO on)
-			txfifo->addb(data); 
+			txfifo->push(data);
 			// transmit shift register is busy
 			LSR &= (~LSR_TX_EMPTY_MASK);
 			if(loopback) setEvent(SERIAL_THR_LOOPBACK_EVENT, bytetime/10);
 			else {
 #if SERIAL_DEBUG
-				log_ser(dbg_serialtraffic, data < 0x10 ?
-				        "\t\t\t\t\ttx 0x%02x (%" PRIu8 ") [FIFO=%2zu]":
-				        "\t\t\t\t\ttx 0x%02x (%c) [FIFO=%2zu]",
-				        data, data, txfifo->getUsage());
+				log_ser(dbg_serialtraffic,
+				        data < 0x10 ? "\t\t\t\t\ttx 0x%02x (%" PRIu8
+				                      ") [FIFO=%2zu]"
+				                    : "\t\t\t\t\ttx 0x%02x (%c) [FIFO=%2zu]",
+				        data, data, txfifo->numQueued());
 #endif
 				transmitByte (data,true);
 			}
 		} else {
 			//  shift register is transmitting
-			if(!txfifo->addb(data)) {
+			if (!txfifo->push(data)) {
 				// TX overflow
 #if SERIAL_DEBUG
 				log_ser(dbg_serialtraffic,"tx overflow");
@@ -549,13 +617,13 @@ uint32_t CSerial::Read_RHR()
 	// 0-7 received data
 	if ((LCR & LCR_DIVISOR_Enable_MASK)) return baud_divider&0xff;
 	else {
-		uint8_t data = rxfifo->getb();
+		uint8_t data = rxfifo->pop();
 		if(FCR&FCR_ACTIVATE) {
-			uint8_t error = errorfifo->getb();
+			uint8_t error = errorfifo->pop();
 			if(error) errors_in_fifo--;
 			// new error
 			if(!rxfifo->isEmpty()) {
-				error=errorfifo->probeByte();
+				error = errorfifo->front();
 				if(error) {
 					LSR |= error;
 					rise(ERROR_PRIORITY);
@@ -565,7 +633,8 @@ uint32_t CSerial::Read_RHR()
 		// Reading RHR resets the FIFO timeout
 		clear (TIMEOUT_PRIORITY);
 		// RX int. is cleared if the buffer holds less data than the threshold
-		if(rxfifo->getUsage()<rx_interrupt_threshold)clear(RX_PRIORITY);
+		if (rxfifo->numQueued() < rx_interrupt_threshold)
+			clear(RX_PRIORITY);
 		removeEvent(SERIAL_RX_TIMEOUT_EVENT);
 		if(!rxfifo->isEmpty()) setEvent(SERIAL_RX_TIMEOUT_EVENT,bytetime*4.0f);
 		return data;
@@ -641,9 +710,11 @@ void CSerial::Write_FCR(uint8_t data)
 	if (BIT_CHANGE_H(FCR, data, FCR_ACTIVATE)) {
 		// FIFO was switched on
 		errors_in_fifo=0; // should already be 0
-		errorfifo->setSize(fifosize);
-		rxfifo->setSize(fifosize);
-		txfifo->setSize(fifosize);
+		errorfifo->setSize(fifo_size);
+		rxfifo->setSize(fifo_size);
+		txfifo->setSize(fifo_size);
+		DEBUG_LOG_MSG("SERIAL: Port %" PRIu8 " %u-byte FIFO enabled",
+		              GetPortNumber(), fifo_size);
 	} else if (BIT_CHANGE_L(FCR, data, FCR_ACTIVATE)) {
 		// FIFO was switched off
 		errors_in_fifo=0;
@@ -651,6 +722,8 @@ void CSerial::Write_FCR(uint8_t data)
 		rxfifo->setSize(1);
 		txfifo->setSize(1);
 		rx_interrupt_threshold=1;
+		DEBUG_LOG_MSG("SERIAL: Port %" PRIu8 " FIFO disabled",
+		              GetPortNumber());
 	}
 	FCR=data&0xCF;
 	if(FCR&FCR_CLEAR_RX) {
@@ -666,6 +739,9 @@ void CSerial::Write_FCR(uint8_t data)
 			case 2: rx_interrupt_threshold=8; break;
 			case 3: rx_interrupt_threshold=14; break;
 		}
+		DEBUG_LOG_MSG("SERIAL: Port %" PRIu8
+		              " FIFO interrupting every %u bytes",
+		              GetPortNumber(), rx_interrupt_threshold);
 	}
 }
 
@@ -1157,11 +1233,9 @@ CSerial::CSerial(const uint8_t port_idx, CommandLine *cmd)
 		        GetPortNumber(), base, irq, cleft.c_str());
 	}
 #endif
-	fifosize=16;
-
-	errorfifo = new MyFifo(fifosize);
-	rxfifo = new MyFifo(fifosize);
-	txfifo = new MyFifo(fifosize);
+	errorfifo = new Fifo(fifo_size);
+	rxfifo = new Fifo(fifo_size);
+	txfifo = new Fifo(fifo_size);
 
 	mydosdevice=new device_COM(this);
 	DOS_AddDevice(mydosdevice);

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -315,7 +315,7 @@ void CSerial::handleEvent(uint16_t type)
 		break;
 
 	case SERIAL_THR_LOOPBACK_EVENT:
-		loopback_data = txfifo->front();
+		loopback_data = txfifo.front();
 		ByteTransmitting();
 		setEvent(SERIAL_TX_LOOPBACK_EVENT, bytetime);
 		break;
@@ -419,7 +419,7 @@ void CSerial::ComputeInterrupts () {
 /* Can a byte be received?                                                  **/
 /*****************************************************************************/
 bool CSerial::CanReceiveByte() {
-	return !rxfifo->isFull();
+	return !rxfifo.isFull();
 }
 
 /*****************************************************************************/
@@ -432,12 +432,12 @@ void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 	        data < 0x10 ? "\t\t\t\trx 0x%02x (%" PRIu8 ")" : "\t\t\t\trx 0x%02x (%c)",
 	        data, data);
 #endif
-	if (!(rxfifo->push(data))) {
+	if (!(rxfifo.push(data))) {
 		// Overrun error ;o
 		error |= LSR_OVERRUN_ERROR_MASK;
 	}
 	removeEvent(SERIAL_RX_TIMEOUT_EVENT);
-	if (rxfifo->numQueued() == rx_interrupt_threshold)
+	if (rxfifo.numQueued() == rx_interrupt_threshold)
 		rise(RX_PRIORITY);
 	else
 		setEvent(SERIAL_RX_TIMEOUT_EVENT, bytetime * 4.0f);
@@ -452,16 +452,15 @@ void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 #endif
 		if(FCR&FCR_ACTIVATE) {
 			// error and FIFO active
-			if(!errorfifo->isFull()) {
+			if (!errorfifo.isFull()) {
 				errors_in_fifo++;
-				errorfifo->push(error);
-			}
-			else {
-				uint8_t toperror = errorfifo->back();
+				errorfifo.push(error);
+			} else {
+				uint8_t toperror = errorfifo.back();
 				if(!toperror) errors_in_fifo++;
-				errorfifo->push(error | toperror);
+				errorfifo.push(error | toperror);
 			}
-			if (errorfifo->front()) {
+			if (errorfifo.front()) {
 				// the next byte in the error fifo has an error
 				rise (ERROR_PRIORITY);
 				LSR |= error;
@@ -495,7 +494,7 @@ void CSerial::receiveByteEx(uint8_t data, uint8_t error)
 	} else {
 		// no error
 		if(FCR&FCR_ACTIVATE) {
-			errorfifo->push(error);
+			errorfifo.push(error);
 		}
 	}
 }
@@ -510,27 +509,29 @@ void CSerial::receiveByte(uint8_t data)
 /*****************************************************************************/
 void CSerial::ByteTransmitting() {
 	if(sync_guardtime) {
-		// LOG_MSG("SERIAL: Port %" PRIu8 " byte transmitting after guard.",
+		// LOG_MSG("SERIAL: Port %" PRIu8 " byte transmitting after
+		// guard.",
 		//         GetPortNumber());
-		// if(txfifo->isEmpty())
-		//	LOG_MSG("SERIAL: Port %" PRIu8 " FIFO empty when it should not",
-		//	        GetPortNumber());
+		// if(txfifo.isEmpty())
+		//	LOG_MSG("SERIAL: Port %" PRIu8 " FIFO empty when it
+		//should not", 	        GetPortNumber());
 		sync_guardtime=false;
-		txfifo->pop();
+		txfifo.pop();
 	}
 	// else
 	// 	LOG_MSG("SERIAL: Port %" PRIu8 " byte transmitting.",
 	// 	        GetPortNumber());
-	if(txfifo->isEmpty())rise (TX_PRIORITY);
+	if (txfifo.isEmpty())
+		rise(TX_PRIORITY);
 }
 
 /*****************************************************************************/
 /* ByteTransmitted: When a byte was sent, notify here.                      **/
 /*****************************************************************************/
 void CSerial::ByteTransmitted () {
-	if(!txfifo->isEmpty()) {
+	if (!txfifo.isEmpty()) {
 		// there is more data
-		uint8_t data = txfifo->pop();
+		uint8_t data = txfifo.pop();
 #if SERIAL_DEBUG
 		log_ser(dbg_serialtraffic,data<0x10?
 			"\t\t\t\t\ttx 0x%02x (%" PRIu8 ") (from buffer)":
@@ -538,7 +539,8 @@ void CSerial::ByteTransmitted () {
 #endif
 		if (loopback) setEvent(SERIAL_TX_LOOPBACK_EVENT, bytetime);
 		else transmitByte(data,false);
-		if(txfifo->isEmpty())rise (TX_PRIORITY);
+		if (txfifo.isEmpty())
+			rise(TX_PRIORITY);
 
 	} else {
 #if SERIAL_DEBUG
@@ -571,14 +573,14 @@ void CSerial::Write_THR(uint8_t data)
 			// LOG_MSG("SERIAL: Port %" PRIu8 " internal error 1",
 			// GetPortNumber()); if(!(LSR & LSR_TX_EMPTY_MASK))
 			// LOG_MSG("SERIAL: Port %" PRIu8 " internal error 2",
-			// GetPortNumber()); if(txfifo->numQueued())
+			// GetPortNumber()); if(txfifo.numQueued())
 			// LOG_MSG("SERIAL: Port %" PRIu8 " internal error 3",
 			// GetPortNumber());
 
 			// need "warming up" time
 			sync_guardtime=true;
 			// block the fifo so it returns THR full (or not in case of FIFO on)
-			txfifo->push(data);
+			txfifo.push(data);
 			// transmit shift register is busy
 			LSR &= (~LSR_TX_EMPTY_MASK);
 			if(loopback) setEvent(SERIAL_THR_LOOPBACK_EVENT, bytetime/10);
@@ -588,13 +590,13 @@ void CSerial::Write_THR(uint8_t data)
 				        data < 0x10 ? "\t\t\t\t\ttx 0x%02x (%" PRIu8
 				                      ") [FIFO=%2zu]"
 				                    : "\t\t\t\t\ttx 0x%02x (%c) [FIFO=%2zu]",
-				        data, data, txfifo->numQueued());
+				        data, data, txfifo.numQueued());
 #endif
 				transmitByte (data,true);
 			}
 		} else {
 			//  shift register is transmitting
-			if (!txfifo->push(data)) {
+			if (!txfifo.push(data)) {
 				// TX overflow
 #if SERIAL_DEBUG
 				log_ser(dbg_serialtraffic,"tx overflow");
@@ -617,14 +619,14 @@ uint32_t CSerial::Read_RHR()
 	// 0-7 received data
 	if ((LCR & LCR_DIVISOR_Enable_MASK)) return baud_divider&0xff;
 	else {
-		uint8_t data = rxfifo->pop();
+		uint8_t data = rxfifo.pop();
 		if(FCR&FCR_ACTIVATE) {
-			uint8_t error = errorfifo->pop();
+			uint8_t error = errorfifo.pop();
 			if(error) errors_in_fifo--;
 			// new error
-			if(!rxfifo->isEmpty()) {
-				error = errorfifo->front();
-				if(error) {
+			if (!rxfifo.isEmpty()) {
+				error = errorfifo.front();
+				if (error) {
 					LSR |= error;
 					rise(ERROR_PRIORITY);
 				}
@@ -633,10 +635,11 @@ uint32_t CSerial::Read_RHR()
 		// Reading RHR resets the FIFO timeout
 		clear (TIMEOUT_PRIORITY);
 		// RX int. is cleared if the buffer holds less data than the threshold
-		if (rxfifo->numQueued() < rx_interrupt_threshold)
+		if (rxfifo.numQueued() < rx_interrupt_threshold)
 			clear(RX_PRIORITY);
 		removeEvent(SERIAL_RX_TIMEOUT_EVENT);
-		if(!rxfifo->isEmpty()) setEvent(SERIAL_RX_TIMEOUT_EVENT,bytetime*4.0f);
+		if (!rxfifo.isEmpty())
+			setEvent(SERIAL_RX_TIMEOUT_EVENT, bytetime * 4.0f);
 		return data;
 	}
 }
@@ -666,7 +669,7 @@ void CSerial::Write_IER(uint8_t data)
 		changeLineProperties();
 	} else {
 		// Retrigger TX interrupt
-		if (txfifo->isEmpty()&& (data&TX_PRIORITY))
+		if (txfifo.isEmpty() && (data & TX_PRIORITY))
 			waiting_interrupts |= TX_PRIORITY;
 		
 		IER = data&0xF;
@@ -710,28 +713,29 @@ void CSerial::Write_FCR(uint8_t data)
 	if (BIT_CHANGE_H(FCR, data, FCR_ACTIVATE)) {
 		// FIFO was switched on
 		errors_in_fifo=0; // should already be 0
-		errorfifo->setSize(fifo_size);
-		rxfifo->setSize(fifo_size);
-		txfifo->setSize(fifo_size);
+		errorfifo.setSize(fifo_size);
+		rxfifo.setSize(fifo_size);
+		txfifo.setSize(fifo_size);
 		DEBUG_LOG_MSG("SERIAL: Port %" PRIu8 " %u-byte FIFO enabled",
 		              GetPortNumber(), fifo_size);
 	} else if (BIT_CHANGE_L(FCR, data, FCR_ACTIVATE)) {
 		// FIFO was switched off
 		errors_in_fifo=0;
-		errorfifo->setSize(1);
-		rxfifo->setSize(1);
-		txfifo->setSize(1);
-		rx_interrupt_threshold=1;
+		errorfifo.setSize(1);
+		rxfifo.setSize(1);
+		txfifo.setSize(1);
+		rx_interrupt_threshold = 1;
 		DEBUG_LOG_MSG("SERIAL: Port %" PRIu8 " FIFO disabled",
 		              GetPortNumber());
 	}
 	FCR=data&0xCF;
 	if(FCR&FCR_CLEAR_RX) {
 		errors_in_fifo=0;
-		errorfifo->clear();
-		rxfifo->clear();
+		errorfifo.clear();
+		rxfifo.clear();
 	}
-	if(FCR&FCR_CLEAR_TX) txfifo->clear();
+	if (FCR & FCR_CLEAR_TX)
+		txfifo.clear();
 	if(FCR&FCR_ACTIVATE) {
 		switch(FCR>>6) {
 			case 0: rx_interrupt_threshold=1; break;
@@ -906,9 +910,9 @@ void CSerial::Write_MCR(uint8_t data)
 uint32_t CSerial::Read_LSR()
 {
 	uint32_t retval = LSR & (LSR_ERROR_MASK | LSR_TX_EMPTY_MASK);
-	if (txfifo->isEmpty())
+	if (txfifo.isEmpty())
 		retval |= LSR_TX_HOLDING_EMPTY_MASK;
-	if (!(rxfifo->isEmpty()))
+	if (!(rxfifo.isEmpty()))
 		retval |= LSR_RX_DATA_READY_MASK;
 	if (errors_in_fifo)
 		retval |= FIFO_ERROR;
@@ -1187,7 +1191,10 @@ void CSerial::Init_Registers () {
 }
 
 CSerial::CSerial(const uint8_t port_idx, CommandLine *cmd)
-        : port_index(port_idx)
+        : port_index(port_idx),
+          errorfifo(fifo_size),
+          rxfifo(fifo_size),
+          txfifo(fifo_size)
 {
 	const uint16_t base = serial_baseaddr[port_index];
 
@@ -1233,10 +1240,6 @@ CSerial::CSerial(const uint8_t port_idx, CommandLine *cmd)
 		        GetPortNumber(), base, irq, cleft.c_str());
 	}
 #endif
-	errorfifo = new Fifo(fifo_size);
-	rxfifo = new Fifo(fifo_size);
-	txfifo = new Fifo(fifo_size);
-
 	mydosdevice=new device_COM(this);
 	DOS_AddDevice(mydosdevice);
 


### PR DESCRIPTION
Reviewable commit by commit.

Functionally identical, except for one boolean fix in the serial wait DSR and CTS loop, which previously blocked the subsequent two if/else branches from ever running (002302c).

Serialport now builds clean in Clang v11 with warnmore.

It turned out there were easy opportunities to improve the readability, as previous authors were using hardcoded hex instead of nicely name definitions provided in the header.

The `ubuntu-latest` bit us in the linters workflow; moved to 20.04 and added a check for the `ruby` version, just to show what the OS is using. 