### PR TITLE
Hide static buffer used in E_Exit

### DIFF
--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -239,20 +239,18 @@ Bits ConvHexWord(char * word) {
 	return ret;
 }
 
-static char buf[1024];           //greater scope as else it doesn't always gets thrown right (linux/gcc2.95)
-void E_Exit(const char * format,...) {
+static char e_exit_buf[1024]; // greater scope as else it doesn't always gets
+                              // thrown right
+void E_Exit(const char *format, ...)
+{
 #if C_DEBUG && C_HEAVY_DEBUG
- 	DEBUG_HeavyWriteLogInstruction();
+	DEBUG_HeavyWriteLogInstruction();
 #endif
 	va_list msg;
-	va_start(msg,format);
-	vsnprintf(buf,sizeof(buf),format,msg);
+	va_start(msg, format);
+	vsnprintf(e_exit_buf, ARRAY_LEN(e_exit_buf), format, msg);
 	va_end(msg);
-
-	buf[sizeof(buf) - 1] = '\0';
-	//strcat(buf,"\n"); catcher should handle the end of line.. 
-
-	throw(buf);
+	throw(e_exit_buf);
 }
 
 std::string safe_strerror(int err) noexcept


### PR DESCRIPTION
This global variable is used for propagating error message on exit.
Unfortunately, name 'buf' was so generic that it was shadowed by a
number of normal local variables.

Remove pointless null-byte protection, as vsnprintf does it already.

Should fix some code readability issues pointed out by lgtm.