### PR TITLE
Fix spelling in src/gui/render_crt_glsl.h

### DIFF
--- a/src/gui/render_crt_glsl.h
+++ b/src/gui/render_crt_glsl.h
@@ -457,7 +457,7 @@ uniform COMPAT_PRECISION float monitor_gamma;
 	the default	hardware implementation will be used, otherwise the custom
 	implementations below will be used instead.
 
-	These custom implemenations rely on the `rubyTextureSize` uniform variable.
+	These custom implementations rely on the `rubyTextureSize` uniform variable.
 	The code could calculate the texture size from the sampler using the
 	textureSize() GLSL function, but this would require a minimum of GLSL
 	version 130, which may prevent the shader from working on older systems.


### PR DESCRIPTION
Fixes Lintian spelling-error-in-binary
  usr/bin/dosbox implemenations implementations