### PR TITLE
Contribute a stripped-down static Glib builder and use it for the macOS release

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,9 +79,20 @@ jobs:
             ccache-macos-release-${{ steps.prep-ccache.outputs.yesterday }}
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - name: Build FluidSynth library
+      - name: Build static Glib libraries
+        run: |
+          set -x
+          brew install meson
+          cd contrib/static-glib
+          gmake
+      - name: Build static FluidSynth library
+        env:
+          GLIB_LIBS:        ${{ github.workspace }}/contrib/static-glib/lib/libglib-2.0.a
+          GTHREAD_LIBS:     ${{ github.workspace }}/contrib/static-glib/lib/libgthread-2.0.a
+          GLIB_CFLAGS:    -I${{ github.workspace }}/contrib/static-glib/include/glib-2.0
+          GTHREAD_CFLAGS: -I${{ github.workspace }}/contrib/static-glib/include/glib-2.0
         run:  cd contrib/static-fluidsynth && gmake
-      - name: Build Opus libraries
+      - name: Build static Opus libraries
         run: |
           set -x
           cd contrib/static-opus
@@ -97,10 +108,21 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build
         env:
-          FLUIDSYNTH_CFLAGS: -I${{ github.workspace }}/contrib/static-fluidsynth/include
-          FLUIDSYNTH_LIBS: ${{ github.workspace }}/contrib/static-fluidsynth/lib/libfluidsynth.a -lm -L/usr/local/Cellar/glib/$(pkg-config --modversion glib-2.0)/lib -L/usr/local/opt/gettext/lib -lgthread-2.0 -lglib-2.0 -lintl
-          OPUSFILE_CFLAGS: -I${{ github.workspace }}/contrib/static-opus/include -I${{ github.workspace }}/contrib/static-opus/include/opus
-          OPUSFILE_LIBS: ${{ github.workspace }}/contrib/static-opus/lib/libopusfile.a ${{ github.workspace }}/contrib/static-opus/lib/libogg.a ${{ github.workspace }}/contrib/static-opus/lib/libopus.a -lm
+          FLUIDSYNTH_CFLAGS: >-
+            -I${{ github.workspace }}/contrib/static-fluidsynth/include -pthread
+            -I${{ github.workspace }}/contrib/static-glib/include/glib-2.0
+          FLUIDSYNTH_LIBS: >-
+            ${{ github.workspace }}/contrib/static-fluidsynth/lib/libfluidsynth.a
+            ${{ github.workspace }}/contrib/static-glib/lib/libgthread-2.0.a -pthread
+            ${{ github.workspace }}/contrib/static-glib/lib/libglib-2.0.a
+            /usr/local/lib/libintl.a -lm
+          OPUSFILE_CFLAGS: >-
+            -I${{ github.workspace }}/contrib/static-opus/include
+            -I${{ github.workspace }}/contrib/static-opus/include/opus
+          OPUSFILE_LIBS: >-
+            ${{ github.workspace }}/contrib/static-opus/lib/libopusfile.a
+            ${{ github.workspace }}/contrib/static-opus/lib/libogg.a
+            ${{ github.workspace }}/contrib/static-opus/lib/libopus.a -lm
         run: |
           set -x
           ./autogen.sh
@@ -133,33 +155,6 @@ jobs:
           install -m 644 "COPYING"                           "$dst/SharedSupport/COPYING"
           install -m 644 "README"                            "$dst/SharedSupport/manual.txt"
           install -m 644 "docs/README.video"                 "$dst/SharedSupport/video.txt"
-
-          # Inventory the brew dependencies residing in /usr/local
-          gthread="/usr/local/opt/glib/lib/libgthread-2.0.0.dylib"
-          glib="/usr/local/opt/glib/lib/libglib-2.0.0.dylib"
-          glib_version="$(pkg-config --modversion glib-2.0)"
-          glib_cellar="/usr/local/Cellar/glib/${glib_version}_1/lib/libglib-2.0.0.dylib"
-          intl="/usr/local/opt/gettext/lib/libintl.8.dylib"
-          pcre="/usr/local/opt/pcre/lib/libpcre.1.dylib"
-
-          # Bundle brew dependencies along-side the dosbox executable
-          install -m 644 "$gthread" "$dst/MacOS/"
-          install -m 644 "$glib"    "$dst/MacOS/"
-          install -m 644 "$intl"    "$dst/MacOS/"
-          install -m 644 "$pcre"    "$dst/MacOS/"
-          install_name_tool -change "$glib_cellar" "@executable_path/${glib##*/}"    "$dst/MacOS/${gthread##*/}"
-          install_name_tool -change "$intl"        "@executable_path/${intl##*/}"    "$dst/MacOS/${glib##*/}"
-          install_name_tool -change "$pcre"        "@executable_path/${pcre##*/}"    "$dst/MacOS/${glib##*/}"
-          install_name_tool -change "$gthread"     "@executable_path/${gthread##*/}" "$dst/MacOS/dosbox"
-          install_name_tool -change "$glib"        "@executable_path/${glib##*/}"    "$dst/MacOS/dosbox"
-          install_name_tool -change "$intl"        "@executable_path/${intl##*/}"    "$dst/MacOS/dosbox"
-
-          # Perform a stand-alone execution test with /usr/local dependencies temporarily removed
-          dep_archive="/tmp/$$-deps.tar"
-          tar -cvPf "$dep_archive" "$gthread" "$glib" "$glib_cellar" "$intl" "$pcre"
-          rm -f "$gthread" "$glib" "$glib_cellar" "$intl" "$pcre"
-          "$dst/MacOS/dosbox" -c exit
-          tar -xvPf "$dep_archive" -C /
 
           # Fill README template file
           sed -i -e "s|%VERSION%|${{ env.VERSION }}|"           "$dst/Info.plist"

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -10,6 +10,8 @@ itself.
   and .icns formats; read icons.md file for details
 - **static-fluidsynth**: Compiles a static FluidSynth library that can
   be used by `./configure` in the absense of `pkg-config`
+- **static-glib**: Compiles a static Glib library that can be used by
+ `./configure` in the absense of `pkg-config`
 - **static-opus**: Compiles a static Opusfile library that can be used
   by `./configure` in the absense of `pkg-config`
 - **macos**: Files required for creating macOS App bundle

--- a/contrib/static-glib/.gitignore
+++ b/contrib/static-glib/.gitignore
@@ -1,0 +1,6 @@
+bin
+include
+lib*
+glib
+glib.tar.gz
+share

--- a/contrib/static-glib/Makefile
+++ b/contrib/static-glib/Makefile
@@ -3,6 +3,7 @@
 #  -------------------------------------------
 GLIB_ARCHIVE = glib.tar.gz
 GLIB_URL = https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.0/glib-2.67.0.tar.gz
+GLIB_SHA256 = a6df47c78dc8793dac80edecd9602c53a517ec2d30e9f7832a25eb554fa5ddb6
 
 ##
 #  Common commands and arguments
@@ -52,6 +53,10 @@ define download
 	   )
 endef
 
+define checksum
+	echo $(SUM) $(FILENAME) | sha256sum --check
+endef
+
 ##
 #  GLib Library
 #  ------------
@@ -62,6 +67,9 @@ glib: lib/libglib-2.0.a
 $(GLIB_ARCHIVE):
 	$(eval URL := $(GLIB_URL))
 	@$(download)
+	$(eval SUM := $(GLIB_SHA256))
+	$(eval FILENAME := $(GLIB_ARCHIVE))
+	@$(checksum)
 
 glib/build: $(GLIB_ARCHIVE)
 	@test -f $@ \

--- a/contrib/static-glib/Makefile
+++ b/contrib/static-glib/Makefile
@@ -1,0 +1,115 @@
+##
+#  Fetch the latest dependencies from upstream
+#  -------------------------------------------
+GLIB_ARCHIVE = glib.tar.gz
+GLIB_URL = https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.0/glib-2.67.0.tar.gz
+
+##
+#  Common commands and arguments
+#  -----------------------------
+THREADS = $(shell nproc || echo 4)
+CURL_FLAGS = --progress-bar
+CURL = curl --location $(CURL_FLAGS)
+WGET_FLAGS = --no-verbose --progress=bar
+WGET = wget --no-clobber $(WGET_FLAGS)
+EXTRACT = tar --strip 1 -zxof
+DIR := ${CURDIR}
+
+##
+#  Everything-targets
+#  ------------------
+.PHONY: all clean distclean
+all: glib
+clean: glib/clean
+distclean:
+	rm -rf bin glib include lib* share *.xz
+
+##
+#  Re-useable download function that tries curl, then wget, and then
+#  prompts the user to manually download the files.  Note that if
+#  one download fails then we assume they all will and therefore
+#  give the user the full list up-front.
+#
+define download
+	echo "Downloading $(URL) to ./$@"                                        \
+	&& $(CURL) "$(URL)" -o "$@"                                              \
+	|| $(WGET) "$(URL)" -O "$@"                                              \
+	|| ( rm -f "$@"                                                          \
+	     && echo ""                                                          \
+	     && echo "DOWNLOAD FAILURE"                                          \
+	     && echo "~~~~~~~~~~~~~~~~"                                          \
+	     && echo "Please manually download the following, then re-run make:" \
+	     && echo "  - $(GLIB_URL) to ./$(GLIB_ARCHIVE)"                      \
+	     && echo ""                                                          \
+	     && echo "Alternatively, you can use your own curl or wget"          \
+	     && echo "arguments by passing CURL_FLAGS=\"--my-args\" and"         \
+	     && echo "WGET_FLAGS=\"--my-flags\" to the make command."            \
+	     && echo ""                                                          \
+	     && echo "For example, disable certificate checking:"                \
+	     && echo "    make CURL_FLAGS=\"-k\""                                \
+	     && echo "    make WGET_FLAGS=\"--no-check-certificate\""            \
+	     && echo ""                                                          \
+	   )
+endef
+
+##
+#  GLib Library
+#  ------------
+glib: glib-message
+
+glib: lib/libglib-2.0.a
+
+$(GLIB_ARCHIVE):
+	$(eval URL := $(GLIB_URL))
+	@$(download)
+
+glib/build: $(GLIB_ARCHIVE)
+	@test -f $@ \
+	|| (mkdir -p glib/build \
+	&& $(EXTRACT) $(GLIB_ARCHIVE) -C glib)
+
+glib/build/build.ninja: glib/build
+	cd glib \
+	&& cd build \
+	&& meson \
+	--auto-features=disabled \
+	--buildtype=release \
+	--default-library=static \
+	--prefix="$(DIR)" \
+	--strip \
+	-Dbsymbolic_functions=false \
+	-Dfam=false \
+	-Dglib_assert=false \
+	-Dinstalled_tests=false \
+	-Dinternal_pcre=true \
+	-Dlibmount=disabled \
+	-Dman=false \
+	-Dnls=disabled \
+	-Dselinux=disabled \
+	-Dxattr=false \
+	..
+
+lib/libglib-2.0.a: glib/build/build.ninja
+	cd glib/build \
+	&& strings config.h \
+	&& ninja \
+	&& ninja install \
+	&& cd "$(DIR)"/lib \
+	&& ln -sf */* .
+
+define GLIB_EXPORTS
+
+Export the following to configure dosbox-staging without pkg-config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export GLIB_CFLAGS="-I$(CURDIR)/include/glib-2.0"
+export GLIB_LIBS="$(CURDIR)/lib/libglib-2.0.a"
+export GTHREAD_CFLAGS="-I$(CURDIR)/include/glib-2.0"
+export GTHREAD_LIBS="$(CURDIR)/lib/libgthread-2.0.a"
+endef
+
+.PHONY: glib-message
+glib-message: lib/libglib-2.0.a
+	$(info $(GLIB_EXPORTS))
+
+glib/clean:
+	rm -rf glib/build


### PR DESCRIPTION
We hit a couple runtime regressions on macOS suspected to be caused by subtle runtime library differences between the CI environment and users' environments (All running macOS v15, however these are build/patch-level differences). 

Reporting and testing by @rhys073, @grounded0, and @warpdesign. Thank you!

This PR contributes a static GLib library builder (a dependency of FluidSynth), specifically building an optimized and fully stripped-down library to free it from all dynamic dependencies such as RegEX, FAM, libMount, .. and other runtime bloat.

We then link the macOS runtime with this library, which eliminates  a tangle of dynlib packaging steps. 

Building GLib adds up to five minutes to the macOS release CI job, however this is currently due to a cold ccache archive generated earlier today. `meson` is picking up our ccache environment, so starting tomorrow all subsequent builds will get the cache and this should fly through.

Fixes #709, #742, and #747.

Opted to use GLib's current stable release (2.67.0) instead of pulling their latest source given they don't hard-gate their CI:

![2020-12-04_10-07](https://user-images.githubusercontent.com/1557255/101198674-af1d9a80-3618-11eb-875d-ee5a17e0b347.png)
 