### PR TITLE
Work around MSYS2/MinGW build issues

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -21,6 +21,8 @@
 #ifndef DOSBOX_FS_UTILS_H
 #define DOSBOX_FS_UTILS_H
 
+#include "config.h"
+
 #include <cinttypes>
 #include <string>
 

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -136,7 +136,7 @@ static void W32_ConfDir(std::string& in,bool create) {
 		if (len + strlen(appdata) < MAX_PATH)
 			safe_strcat(result, appdata);
 		if (create)
-			_mkdir(result);
+			mkdir(result);
 	}
 	in = result;
 }

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -24,6 +24,7 @@
 
 #include <direct.h>
 #include <io.h>
+#include <sys/stat.h>
 
 #include "compiler.h"
 
@@ -41,11 +42,11 @@ std::string to_native_path(const std::string &path) noexcept
 
 int create_dir(const char *path, MAYBE_UNUSED uint32_t mode, uint32_t flags) noexcept
 {
-	const int err = _mkdir(path);
+	const int err = mkdir(path);
 	if ((errno == EEXIST) && (flags & OK_IF_EXISTS)) {
 		struct _stat pstat;
 		if ((_stat(path, &pstat) == 0) &&
-		    ((pstat.st_mode & S_IFMT) == S_IFDIR))
+		    ((pstat.st_mode & _S_IFMT) == _S_IFDIR))
 			return 0;
 	}
 	return err;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -256,7 +256,7 @@ void E_Exit(const char *format, ...)
 std::string safe_strerror(int err) noexcept
 {
 	char buf[128];
-#if defined(_MSC_VER)
+#if defined(WIN32)
 	// C11 version; unavailable in C++14 in general.
 	strerror_s(buf, ARRAY_LEN(buf), err);
 	return buf;


### PR DESCRIPTION
Most of these problems are results of MinGW not being able to decide if
it is POSIX or ISO compliant or not.

Replace non-POSIX but ISO-compliant _mkdir(const char*) function (which
works in MSVC, but does not work in MinGW) with non-POSIX and non-ISO
mkdir(const char*) function (because it works in MinGW, but only
generates a warning in MSVC).

Add config.h before any use of mkdir, as that's where we disable MSVC
warnings urging us to use ISO versions of POSIX functions (with '_'
prefix).

Use ISO _S_IFDIR, _S_IFMT and include sys/stat.h as otherwise MinGW
can't find POSIX S_IFDIR, S_IFMT.

Change ifdef to use C11, non-POSIX strerror_s in MinGW, because
GNU-provided, POSIX-like strerror_r is not available (which is weird,
because C99 stuff generally does not work in MinGW so why C11 stuff
works suddenly?).

Fixes: #753