### PR TITLE
Sync dr_mp3 with upsteam (v0.6.24)

### DIFF
--- a/src/libs/decoders/dr_mp3.h
+++ b/src/libs/decoders/dr_mp3.h
@@ -1,6 +1,6 @@
 /*
 MP3 audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_mp3 - v0.6.22 - 2020-12-02
+dr_mp3 - v0.6.24 - 2020-12-07
 
 David Reid - mackron@gmail.com
 
@@ -95,7 +95,7 @@ extern "C" {
 
 #define DRMP3_VERSION_MAJOR     0
 #define DRMP3_VERSION_MINOR     6
-#define DRMP3_VERSION_REVISION  22
+#define DRMP3_VERSION_REVISION  23
 #define DRMP3_VERSION_STRING    DRMP3_XSTRINGIFY(DRMP3_VERSION_MAJOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_MINOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_REVISION)
 
 #include <stddef.h> /* For size_t. */
@@ -2831,7 +2831,7 @@ static drmp3_bool32 drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drm
 
     /* Decode the first frame to confirm that it is indeed a valid MP3 stream. */
     if (!drmp3_decode_next_frame(pMP3)) {
-        drmp3_uninit(pMP3);
+        drmp3__free_from_callbacks(pMP3->pData, &pMP3->allocationCallbacks);    /* The call above may have allocated memory. Need to make sure it's freed before aborting. */
         return DRMP3_FALSE; /* Not a valid MP3 stream. */
     }
 
@@ -4458,6 +4458,12 @@ counts rather than sample counts.
 /*
 REVISION HISTORY
 ================
+v0.6.24 - 2020-12-07
+  - Fix a typo in version date for 0.6.23.
+
+v0.6.23 - 2020-12-03
+  - Fix an error where a file can be closed twice when initialization of the decoder fails.
+
 v0.6.22 - 2020-12-02
   - Fix an error where it's possible for a file handle to be left open when initialization of the decoder fails.
 


### PR DESCRIPTION
Fixed the one Coverity issue (https://github.com/mackron/dr_libs/issues/171) introduced during the last sync.
