### PR TITLE
Include FluidSynth statically in the Linux release and test binary 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,6 +100,17 @@ jobs:
     name: Release build
     runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    env:
+      AR: gcc-ar
+      CC: ccache gcc
+      CXX: ccache g++
+      LD: gcc
+      RANLIB: gcc-ranlib
+      FLAGS: >-
+        -O3 -fstrict-aliasing -fno-signed-zeros -fno-trapping-math
+        -fassociative-math -mfpmath=sse -msse4.2 -flto -ffunction-sections
+        -fdata-sections -DNDEBUG -pipe
+      LINKFLAGS: -Wl,--as-needed
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update
@@ -130,17 +141,6 @@ jobs:
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build
-        env:
-          AR: gcc-ar
-          CC: ccache gcc
-          CXX: ccache g++
-          LD: gcc
-          RANLIB: gcc-ranlib
-          FLAGS: >-
-            -O3 -fstrict-aliasing -fno-signed-zeros -fno-trapping-math
-            -fassociative-math -mfpmath=sse -msse4.2 -flto -ffunction-sections
-            -fdata-sections -DNDEBUG -pipe
-          LINKFLAGS: -Wl,--as-needed
         run: |
           set -x
           ./autogen.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -133,6 +133,20 @@ jobs:
             ccache-linux-release-${{ steps.prep-ccache.outputs.yesterday }}
       - name: Log environment
         run:  ./scripts/log-env.sh
+      - name: Build FluidSynth libraries
+        run: |
+          set -x
+          sudo apt-get install -y python3-setuptools cmake 
+          sudo pip3 install meson ninja
+          pushd contrib/static-glib
+          make
+          popd
+          cd contrib/static-fluidsynth
+          GLIB_LIBS="$PWD/../static-glib/lib/libglib-2.0.a" \
+          GTHREAD_LIBS="$PWD/../static-glib/lib/libgthread-2.0.a" \
+          GLIB_CFLAGS="-I$PWD/../static-glib/include/glib-2.0" \
+          GTHREAD_CFLAGS="-I$PWD/../static-glib/include/glib-2.0" \
+          make
       - name: Inject version string
         run: |
           set -x
@@ -144,9 +158,15 @@ jobs:
         run: |
           set -x
           ./autogen.sh
+          FLUIDSYNTH_CFLAGS="\
+              -I$PWD/contrib/static-fluidsynth/include \
+              -pthread -I$PWD/contrib/static-glib/include/glib-2.0" \
+          FLUIDSYNTH_LIBS="\
+              $PWD/contrib/static-fluidsynth/lib/libfluidsynth.a \
+              $PWD/contrib/static-glib/lib/libgthread-2.0.a -pthread \
+              $PWD/contrib/static-glib/lib/libglib-2.0.a -lm" \
           ./configure \
               --enable-png-static \
-              --disable-fluidsynth \
               CFLAGS="$FLAGS" \
               CXXFLAGS="$FLAGS" \
               LDFLAGS="$FLAGS $LINKFLAGS -flto=$(nproc)"


### PR DESCRIPTION
Current popular Linux distributions do not provide FluidSynth 2.x in their repositories, as follows:

 - All Ubuntu versions before 20.04
 - All Fedora  versions before 33
 - All Debians (period)
 - All Mint versions

Although package maintainers of DOSBox Staging should (or can) bundle FluidSynth, the project itself is not a repo/package maintainer and therefore we only provide tarball binary releases.

To ensure we provide a feature-complete no-fuss out-of-the-box experience for Linux users in the same manner we do for Windows and macOS users, we therefore will include FluidSynth in our tarball binary.

The static Glib + FluidSynth static builders eliminates all up-stream dependencies and extraneous features, and threfore this is a highly stripped down and stand-alone inclusion.

This feature will be deprecated and revert to a dynamically linked FluidSynth 2.x library (similar to how we handle Opus) when the above repositories begin shipping FluidSynth 2.x libraries.

Fixed #752