### PR TITLE
Add support building for Apple M1

### DIFF
--- a/scripts/automator/build/clang-darwin_arm64
+++ b/scripts/automator/build/clang-darwin_arm64
@@ -1,0 +1,8 @@
+ld="ld"
+
+# OS-and-processor customizations
+cflags_release+=(-arch arm64)
+
+# Modifier additions
+MODIFIERS+=(lto)
+cflags_lto=(-flto=thin)


### PR DESCRIPTION
Added files to support the darwin+arm64 build targets for Apple Silicon hosts.

- clang-darwin_arm64 - Set the arch flag and support lto modifier for arm64
- machine-arm64 - Stub file to suppress automator script warning.