### PR TITLE
Add debugger feature to meson buildsystem

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,10 +41,10 @@ jobs:
           #   config_flags: --enable-tests
           #   run_tests: true
           #   max_warnings: -1
-          # - name: GCC, +debug
-          #   os: ubuntu-20.04
-          #   config_flags: --enable-debug
-          #   max_warnings: 107
+          - name: GCC, +debug
+            os: ubuntu-20.04
+            build_flags: -Denable_debugger=normal
+            max_warnings: 132
           # - name: GCC, +dynrec, -dyn_x86
           #   os: ubuntu-20.04
           #   config_flags: --disable-dynamic-x86

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: macos-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     strategy:
+      max-parallel: 3
       matrix:
         conf:
           - name: Clang
@@ -23,6 +24,10 @@ jobs:
             packages: meson gcc@9
             build_flags: --native-file=.github/meson/native-gcc-9.ini
             max_warnings: 0
+          - name: Clang, +debug
+            packages: meson
+            build_flags: -Denable_debugger=normal
+            max_warnings: 165
           - name: Clang, warning_level=3
             packages: meson
             build_flags: -Dwarning_level=3

--- a/INSTALL
+++ b/INSTALL
@@ -1,15 +1,5 @@
 TODO: Add these two dependencies to meson.build and remove the file
 
-Curses (optional)
-    If you want to enable the debugger you need a curses library.
-    On Linux, install ncurses-devel via your distro package manager.
-    On macOS, install ncurses via brew or macports.
-    On Windows, install pdcurses at https://pdcurses.org/, or ncurses
-    via package-manager such as pacman within an MSYS2 environment.
-    Licenses:
-      ncurses - MIT License
-      pdcurses - Public Domain
-
 alsa-lib (mandatory, Linux only)
     For ALSA audio support under linux.
     See https://www.alsa-project.org/

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,14 @@ if cc.has_member('struct dirent', 'd_type', prefix : '#include<dirent.h>')
   conf_data.set('DIRENT_HAS_D_TYPE', true)
 endif
 
+if get_option('enable_debugger') != 'none'
+  conf_data.set10('C_DEBUG', true)
+endif
+
+if get_option('enable_debugger') == 'heavy'
+  conf_data.set10('C_HEAVY_DEBUG', true)
+endif
+
 configure_file(input : 'src/config.h.in', output : 'config.h',
                configuration : conf_data)
 
@@ -78,6 +86,12 @@ if get_option('use_png')
 else
   png_dep = dummy_dep
   z_dep = dummy_dep
+endif
+
+if get_option('enable_debugger') == 'none'
+  curses_dep = dummy_dep
+else
+  curses_dep = dependency('ncurses') # or pdcurses on Windows
 endif
 
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,3 +22,9 @@ option('use_png',
        type : 'boolean',
        value : true,
        description : 'Enable saving screenshots in .png format')
+
+option('enable_debugger',
+       type : 'combo',
+       choices : ['normal', 'heavy', 'none'],
+       value : 'none',
+       description : 'Build emulator with internal debugger feature.')

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -79,9 +79,16 @@
 // Define to 1 to enable screenshots in .png format
 #mesondefine C_SSHOT
 
+// Define to 1 to enable internal debugger (using ncurses or pdcurses)
+#mesondefine C_DEBUG
+
+// Define to 1 to enable heavy debugging (requires C_DEBUG)
+#mesondefine C_HEAVY_DEBUG
+
 /* Compiler features and extensions
  *
- * These are defines for compiler features we can't reliably verify
+ * These are defines for compiler features we can't reliably verify during
+ * compilation time.
  */
 
 // TODO generate ; support for __attribute__ syntax

--- a/src/debug/meson.build
+++ b/src/debug/meson.build
@@ -6,7 +6,8 @@ libdebug_sources = files([
 ])
 
 libdebug = static_library('debug', libdebug_sources,
-                          include_directories : incdir)
+                          include_directories : incdir,
+                          dependencies: [sdl2_dep, curses_dep])
 
 libdebug_dep = declare_dependency(link_with : libdebug)
 


### PR DESCRIPTION
Raise warning limit on Linux, as GCC understands -Wextra-semi now.
Add build with debugger enabled on macOS to cover the code with Clang.