### PR TITLE
Add GitHub Annotations feature to verify-bash.sh

### DIFF
--- a/scripts/verify-bash.sh
+++ b/scripts/verify-bash.sh
@@ -22,4 +22,21 @@ main () {
 	list_bash_files | xargs -L 1000 shellcheck --color "$@"
 }
 
-main "$@"
+Anotate_github () {
+	jq -r -j \
+		'.comments[]
+		 |"::error"
+		 ," file=",.file
+		 ,",line=",.line
+		 ,"::SC",.code,": ",.message
+		 ,"\n"
+		' | grep "" || return 0 && return 123
+# return 123 same as xargs return code would be
+}
+
+if [[ -z $GITHUB_ACTOR ]]
+then
+	main "$@"
+else
+	Anotate_github < <( main --format=json1 "$@" )
+fi


### PR DESCRIPTION
This adds Annotations to the Job run's Summary and
in-line Annotations in the "Files Changed" tab

When env. var. GITHUB_ACTOR is present:

SHELLCHECK(1)'s json1 output format is used, JQ(1) then outputs the GitHub API command:

    ::error file=<filename>,line=<line no>::<msg>

A simple GREP(1) is used to flip the return code, i.e. "0" if no errors found and "123" when they are. "123" is to keep in sync with the scripts normal, from XARGS(1) return code.

All of SHELLCHECK(1)'s severity levels:

    error, warning, info, style

Are reported as "error" for GitHub's API, regardless of the severity (.comments[].level)