### PR TITLE
Finishing touches on MT-32 light cleanup

### DIFF
--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -397,25 +397,26 @@ void MidiHandler_mt32::MixerCallBack(uint16_t frames)
 				return;
 		}
 		uint16_t cur_render_pos = renderPos;
-		uint16_t playPosSnap = playPos;
-		const uint16_t samplesReady = (cur_render_pos < playPosSnap)
-		                                      ? audioBufferSize - playPosSnap
-		                                      : cur_render_pos - playPosSnap;
+		uint16_t cur_play_pos = playPos;
+		const uint16_t samplesReady = (cur_render_pos < cur_play_pos)
+		                                      ? audioBufferSize - cur_play_pos
+		                                      : cur_render_pos - cur_play_pos;
 		if (frames > (samplesReady / CH_PER_FRAME)) {
 			assert(samplesReady <= UINT16_MAX);
 			frames = samplesReady / CH_PER_FRAME;
 		}
-		chan->AddSamples_s16(frames, audioBuffer + playPosSnap);
-		playPosSnap += (frames * CH_PER_FRAME);
-		while (audioBufferSize <= playPosSnap) {
-			playPosSnap -= audioBufferSize;
+		chan->AddSamples_s16(frames, audioBuffer + cur_play_pos);
+		cur_play_pos += (frames * CH_PER_FRAME);
+		while (audioBufferSize <= cur_play_pos) {
+			cur_play_pos -= audioBufferSize;
 			playedBuffers++;
 		}
-		playPos = playPosSnap;
+		playPos = cur_play_pos;
 		cur_render_pos = renderPos;
-		const uint16_t samplesFree = (cur_render_pos < playPosSnap)
-		                                     ? playPosSnap - cur_render_pos
-		                                     : audioBufferSize + playPosSnap -
+		const uint16_t samplesFree = (cur_render_pos < cur_play_pos)
+		                                     ? cur_play_pos - cur_render_pos
+		                                     : audioBufferSize +
+		                                               cur_play_pos -
 		                                               cur_render_pos;
 		if (minimumRenderFrames <= (samplesFree / CH_PER_FRAME)) {
 			SDL_LockMutex(lock);
@@ -433,18 +434,18 @@ void MidiHandler_mt32::RenderingLoop()
 {
 	while (!stopProcessing) {
 		const uint16_t cur_render_pos = renderPos;
-		const uint16_t playPosSnap = playPos;
+		const uint16_t cur_play_pos = playPos;
 		uint16_t samplesToRender = 0;
-		if (cur_render_pos < playPosSnap) {
-			samplesToRender = playPosSnap - cur_render_pos - CH_PER_FRAME;
+		if (cur_render_pos < cur_play_pos) {
+			samplesToRender = cur_play_pos - cur_render_pos - CH_PER_FRAME;
 		} else {
 			samplesToRender = audioBufferSize - cur_render_pos;
-			if (playPosSnap == 0)
+			if (cur_play_pos == 0)
 				samplesToRender -= CH_PER_FRAME;
 		}
 		uint16_t framesToRender = samplesToRender / CH_PER_FRAME;
 		if ((framesToRender == 0) || ((framesToRender < minimumRenderFrames) &&
-		                              (cur_render_pos < playPosSnap))) {
+		                              (cur_render_pos < cur_play_pos))) {
 			SDL_LockMutex(lock);
 			SDL_CondWait(framesInBufferChanged, lock);
 			SDL_UnlockMutex(lock);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -435,15 +435,17 @@ void MidiHandler_mt32::RenderingLoop()
 	while (!stopProcessing) {
 		const uint16_t cur_render_pos = renderPos;
 		const uint16_t cur_play_pos = playPos;
-		uint16_t samplesToRender = 0;
+		uint16_t samples_to_render = 0;
 		if (cur_render_pos < cur_play_pos) {
-			samplesToRender = cur_play_pos - cur_render_pos - CH_PER_FRAME;
+			samples_to_render = cur_play_pos - cur_render_pos -
+			                    CH_PER_FRAME;
 		} else {
-			samplesToRender = audioBufferSize - cur_render_pos;
-			if (cur_play_pos == 0)
-				samplesToRender -= CH_PER_FRAME;
+			samples_to_render = audioBufferSize - cur_render_pos;
+			if (cur_play_pos == 0) {
+				samples_to_render -= CH_PER_FRAME;
+			}
 		}
-		uint16_t framesToRender = samplesToRender / CH_PER_FRAME;
+		uint16_t framesToRender = samples_to_render / CH_PER_FRAME;
 		if ((framesToRender == 0) || ((framesToRender < minimumRenderFrames) &&
 		                              (cur_render_pos < cur_play_pos))) {
 			SDL_LockMutex(lock);
@@ -452,7 +454,7 @@ void MidiHandler_mt32::RenderingLoop()
 		} else {
 			service->renderBit16s(audioBuffer + cur_render_pos,
 			                      framesToRender);
-			renderPos = (cur_render_pos + samplesToRender) %
+			renderPos = (cur_render_pos + samples_to_render) %
 			            audioBufferSize;
 			if (cur_render_pos == playPos) {
 				SDL_LockMutex(lock);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -445,15 +445,16 @@ void MidiHandler_mt32::RenderingLoop()
 				samples_to_render -= CH_PER_FRAME;
 			}
 		}
-		uint16_t framesToRender = samples_to_render / CH_PER_FRAME;
-		if ((framesToRender == 0) || ((framesToRender < minimumRenderFrames) &&
-		                              (cur_render_pos < cur_play_pos))) {
+		uint16_t frames_to_render = samples_to_render / CH_PER_FRAME;
+		if ((frames_to_render == 0) ||
+		    ((frames_to_render < minimumRenderFrames) &&
+		     (cur_render_pos < cur_play_pos))) {
 			SDL_LockMutex(lock);
 			SDL_CondWait(framesInBufferChanged, lock);
 			SDL_UnlockMutex(lock);
 		} else {
 			service->renderBit16s(audioBuffer + cur_render_pos,
-			                      framesToRender);
+			                      frames_to_render);
 			renderPos = (cur_render_pos + samples_to_render) %
 			            audioBufferSize;
 			if (cur_render_pos == playPos) {

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -446,9 +446,8 @@ void MidiHandler_mt32::RenderingLoop()
 			}
 		}
 		uint16_t frames_to_render = samples_to_render / CH_PER_FRAME;
-		if ((frames_to_render == 0) ||
-		    ((frames_to_render < minimumRenderFrames) &&
-		     (cur_render_pos < cur_play_pos))) {
+		if (frames_to_render == 0 || (frames_to_render < minimumRenderFrames &&
+		                              cur_render_pos < cur_play_pos)) {
 			SDL_LockMutex(lock);
 			SDL_CondWait(framesInBufferChanged, lock);
 			SDL_UnlockMutex(lock);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -234,7 +234,6 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 	}
 
 	service->createContext(get_report_handler_interface(), this);
-	mt32emu_return_code rc;
 
 	Section_prop *section = static_cast<Section_prop *>(
 	        control->GetSection("mt32"));
@@ -278,7 +277,8 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 	service->setStereoOutputSampleRate(sample_rate);
 	service->setSamplerateConversionQuality(RATE_CONVERSION_QUALITY);
 
-	if (MT32EMU_RC_OK != (rc = service->openSynth())) {
+	const auto rc = service->openSynth();
+	if (rc != MT32EMU_RC_OK) {
 		delete service;
 		service = nullptr;
 		MIXER_DelChannel(chan);
@@ -316,8 +316,8 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 		framesInBufferChanged = SDL_CreateCond();
 		thread = SDL_CreateThread(ProcessingThread, "mt32emu", nullptr);
 	}
-	chan->Enable(true);
 
+	chan->Enable(true);
 	open = true;
 	return true;
 }

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -396,11 +396,11 @@ void MidiHandler_mt32::MixerCallBack(uint16_t frames)
 			if (stopProcessing)
 				return;
 		}
-		uint16_t renderPosSnap = renderPos;
+		uint16_t cur_render_pos = renderPos;
 		uint16_t playPosSnap = playPos;
-		const uint16_t samplesReady = (renderPosSnap < playPosSnap)
+		const uint16_t samplesReady = (cur_render_pos < playPosSnap)
 		                                      ? audioBufferSize - playPosSnap
-		                                      : renderPosSnap - playPosSnap;
+		                                      : cur_render_pos - playPosSnap;
 		if (frames > (samplesReady / CH_PER_FRAME)) {
 			assert(samplesReady <= UINT16_MAX);
 			frames = samplesReady / CH_PER_FRAME;
@@ -412,10 +412,11 @@ void MidiHandler_mt32::MixerCallBack(uint16_t frames)
 			playedBuffers++;
 		}
 		playPos = playPosSnap;
-		renderPosSnap = renderPos;
-		const uint16_t samplesFree = (renderPosSnap < playPosSnap)
-		                                     ? playPosSnap - renderPosSnap
-		                                     : audioBufferSize + playPosSnap - renderPosSnap;
+		cur_render_pos = renderPos;
+		const uint16_t samplesFree = (cur_render_pos < playPosSnap)
+		                                     ? playPosSnap - cur_render_pos
+		                                     : audioBufferSize + playPosSnap -
+		                                               cur_render_pos;
 		if (minimumRenderFrames <= (samplesFree / CH_PER_FRAME)) {
 			SDL_LockMutex(lock);
 			SDL_CondSignal(framesInBufferChanged);
@@ -431,27 +432,28 @@ void MidiHandler_mt32::MixerCallBack(uint16_t frames)
 void MidiHandler_mt32::RenderingLoop()
 {
 	while (!stopProcessing) {
-		const uint16_t renderPosSnap = renderPos;
+		const uint16_t cur_render_pos = renderPos;
 		const uint16_t playPosSnap = playPos;
 		uint16_t samplesToRender = 0;
-		if (renderPosSnap < playPosSnap) {
-			samplesToRender = playPosSnap - renderPosSnap - CH_PER_FRAME;
+		if (cur_render_pos < playPosSnap) {
+			samplesToRender = playPosSnap - cur_render_pos - CH_PER_FRAME;
 		} else {
-			samplesToRender = audioBufferSize - renderPosSnap;
+			samplesToRender = audioBufferSize - cur_render_pos;
 			if (playPosSnap == 0)
 				samplesToRender -= CH_PER_FRAME;
 		}
 		uint16_t framesToRender = samplesToRender / CH_PER_FRAME;
 		if ((framesToRender == 0) || ((framesToRender < minimumRenderFrames) &&
-		                              (renderPosSnap < playPosSnap))) {
+		                              (cur_render_pos < playPosSnap))) {
 			SDL_LockMutex(lock);
 			SDL_CondWait(framesInBufferChanged, lock);
 			SDL_UnlockMutex(lock);
 		} else {
-			service->renderBit16s(audioBuffer + renderPosSnap,
+			service->renderBit16s(audioBuffer + cur_render_pos,
 			                      framesToRender);
-			renderPos = (renderPosSnap + samplesToRender) % audioBufferSize;
-			if (renderPosSnap == playPos) {
+			renderPos = (cur_render_pos + samplesToRender) %
+			            audioBufferSize;
+			if (cur_render_pos == playPos) {
 				SDL_LockMutex(lock);
 				SDL_CondSignal(framesInBufferChanged);
 				SDL_UnlockMutex(lock);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -386,7 +386,7 @@ MidiHandler_mt32::~MidiHandler_mt32()
 	Close();
 }
 
-void MidiHandler_mt32::MixerCallBack(uint16_t len)
+void MidiHandler_mt32::MixerCallBack(uint16_t frames)
 {
 	if (USE_THREADED_RENDERING) {
 		while (renderPos == playPos) {
@@ -401,12 +401,12 @@ void MidiHandler_mt32::MixerCallBack(uint16_t len)
 		const uint16_t samplesReady = (renderPosSnap < playPosSnap)
 		                                      ? audioBufferSize - playPosSnap
 		                                      : renderPosSnap - playPosSnap;
-		if (len > (samplesReady / CH_PER_FRAME)) {
+		if (frames > (samplesReady / CH_PER_FRAME)) {
 			assert(samplesReady <= UINT16_MAX);
-			len = samplesReady / CH_PER_FRAME;
+			frames = samplesReady / CH_PER_FRAME;
 		}
-		chan->AddSamples_s16(len, audioBuffer + playPosSnap);
-		playPosSnap += (len * CH_PER_FRAME);
+		chan->AddSamples_s16(frames, audioBuffer + playPosSnap);
+		playPosSnap += (frames * CH_PER_FRAME);
 		while (audioBufferSize <= playPosSnap) {
 			playPosSnap -= audioBufferSize;
 			playedBuffers++;
@@ -423,8 +423,8 @@ void MidiHandler_mt32::MixerCallBack(uint16_t len)
 		}
 	} else {
 		auto buffer = reinterpret_cast<int16_t *>(MixTemp);
-		service->renderBit16s(buffer, len);
-		chan->AddSamples_s16(len, buffer);
+		service->renderBit16s(buffer, frames);
+		chan->AddSamples_s16(frames, buffer);
 	}
 }
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -174,9 +174,9 @@ static mt32emu_report_handler_i get_report_handler_interface()
 		                       const char *fmt,
 		                       va_list list)
 		{
-			char s[1024];
-			safe_sprintf(s, fmt, list);
-			DEBUG_LOG_MSG("MT32: %s", s);
+			char msg[1024];
+			safe_sprintf(msg, fmt, list);
+			DEBUG_LOG_MSG("MT32: %s", msg);
 		}
 
 		static void onErrorControlROM(void *)


### PR DESCRIPTION
A very small set of non-functional changes:
 - Renamed local variables per camel_case
 - Renamed local `SomethingSnap` variables as `cur_something`, to indicate the "current" state of something.

Should be quick to review commit-by-commit.

Positive and negative tests passes.