### PR TITLE
Search for configured soundfont and MT-32 ROMs in XDG_DATA_DIRS

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 295
+            max_warnings: 296
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 2006
+            max_warnings: 2007
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/support.h
+++ b/include/support.h
@@ -194,6 +194,22 @@ void strip_punctuation(std::string &str);
 //   split("::", ':') returns {"", "", ""}
 std::vector<std::string> split(const std::string &seq, const char delim);
 
+// Split a string on whitespace, where whitespace can be any of the following:
+// ' '    (0x20)  space (SPC)
+// '\t'   (0x09)  horizontal tab (TAB)
+// '\n'   (0x0a)  newline (LF)
+// '\v'   (0x0b)  vertical tab (VT)
+// '\f'   (0x0c)  feed (FF)
+// '\r'   (0x0d)  carriage return (CR)
+// Absent string content on either side of a delimiter is omitted. For example:
+//   split("abc") returns {"abc"}
+//   split("  a   b   c  ") returns {"a", "b", "c"}
+//   split("\t \n abc \r \v def \f \v ") returns {"abc", "def"}
+//   split("a\tb\nc\vd e\rf") returns {"a", "b", "c", "d", "e", "f"}
+//   split("  ") returns {}
+//   split(" ") returns {}
+std::vector<std::string> split(const std::string &seq);
+
 bool is_executable_filename(const std::string &filename) noexcept;
 
 // Coarse but fast sine and cosine approximations. Accuracy ranges from 0.0005

--- a/include/support.h
+++ b/include/support.h
@@ -31,6 +31,7 @@
 #include <stdexcept>
 #include <string.h>
 #include <string>
+#include <vector>
 
 #include <SDL.h>
 
@@ -184,6 +185,14 @@ void trim(std::string& str);
 void upcase(std::string &str);
 void lowcase(std::string &str);
 void strip_punctuation(std::string &str);
+
+// Split a string on an arbitrary character delimiter. Absent string content on
+// either side of a delimiter is treated as an empty string. For example:
+//   split("abc:", ':') returns {"abc", ""}
+//   split(":def", ':') returns {"", "def"}
+//   split(":", ':') returns {"", ""}
+//   split("::", ':') returns {"", "", ""}
+std::vector<std::string> split(const std::string &seq, const char delim);
 
 bool is_executable_filename(const std::string &filename) noexcept;
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -25,6 +25,7 @@
 #if C_FLUIDSYNTH
 
 #include <cassert>
+#include <deque>
 #include <string>
 #include <tuple>
 
@@ -104,7 +105,7 @@ std::tuple<std::string, int> parse_sf_pref(const std::string &line,
 
 #if defined(WIN32)
 
-static std::vector<std::string> get_data_dirs()
+static std::deque<std::string> get_data_dirs()
 {
 	return {
 	        CROSS_GetPlatformConfigDir() + "soundfonts\\",
@@ -114,7 +115,7 @@ static std::vector<std::string> get_data_dirs()
 
 #elif defined(MACOSX)
 
-static std::vector<std::string> get_data_dirs()
+static std::deque<std::string> get_data_dirs()
 {
 	return {
 	        CROSS_GetPlatformConfigDir() + "soundfonts/",
@@ -126,21 +127,38 @@ static std::vector<std::string> get_data_dirs()
 
 #else
 
-static std::vector<std::string> get_data_dirs()
+static std::deque<std::string> get_data_dirs()
 {
+	// First priority is $XDG_DATA_HOME
 	const char *xdg_data_home_env = getenv("XDG_DATA_HOME");
 	const auto xdg_data_home = CROSS_ResolveHome(
 	        xdg_data_home_env ? xdg_data_home_env : "~/.local/share");
 
-	return {
-	        CROSS_GetPlatformConfigDir() + "soundfonts/",
+	std::deque<std::string> dirs = {
+	        xdg_data_home + "/dosbox/soundfonts/",
 	        xdg_data_home + "/soundfonts/",
 	        xdg_data_home + "/sounds/sf2/",
-	        "/usr/local/share/soundfonts/",
-	        "/usr/local/share/sounds/sf2/",
-	        "/usr/share/soundfonts/",
-	        "/usr/share/sounds/sf2/",
 	};
+
+	// Second priority are the $XDG_DATA_DIRS
+	const char *xdg_data_dirs_env = getenv("XDG_DATA_DIRS");
+	if (!xdg_data_dirs_env)
+		xdg_data_dirs_env = "/usr/local/share:/usr/share";
+
+	for (auto xdg_data_dir : split(xdg_data_dirs_env, ':')) {
+		trim(xdg_data_dir);
+		if (xdg_data_dir.empty()) {
+			continue;
+		}
+		const auto resolved_dir = CROSS_ResolveHome(xdg_data_dir);
+		dirs.emplace_back(resolved_dir + "/soundfonts/");
+		dirs.emplace_back(resolved_dir + "/sounds/sf2/");
+	}
+
+	// Third priority is $XDG_CONF_HOME, for convenience
+	dirs.emplace_back(CROSS_GetPlatformConfigDir() + "soundfonts/");
+
+	return dirs;
 }
 
 #endif
@@ -152,6 +170,7 @@ static std::string find_sf_file(const std::string &name)
 		return sf_path;
 	for (const auto &dir : get_data_dirs()) {
 		for (const auto &sf : {dir + name, dir + name + ".sf2"}) {
+			// DEBUG_LOG_MSG("MIDI: FluidSynth checking if '%s' exists", sf.c_str());
 			if (path_exists(sf))
 				return sf;
 		}

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -124,6 +124,33 @@ void trim(std::string &str)
 	str.erase(0, empty_pfx);
 }
 
+std::vector<std::string> split(const std::string &seq, const char delim)
+{
+	std::vector<std::string> words;
+	if (seq.empty())
+		return words;
+
+	// count delimeters to reserve space in our vector of words
+	const size_t n = 1u + std::count(seq.begin(), seq.end(), delim);
+	words.reserve(n);
+
+	std::string::size_type head = 0;
+	while (head != std::string::npos) {
+		const auto tail = seq.find_first_of(delim, head);
+		const auto word_len = tail - head;
+		words.emplace_back(seq.substr(head, word_len));
+		if (tail == std::string::npos) {
+			break;
+		}
+		head += word_len + 1;
+	}
+
+	// did we reserve the exact space needed?
+	assert(n == words.size());
+
+	return words;
+}
+
 void strip_punctuation(std::string &str) {
 	str.erase(
 		std::remove_if(

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -151,6 +151,38 @@ std::vector<std::string> split(const std::string &seq, const char delim)
 	return words;
 }
 
+std::vector<std::string> split(const std::string &seq)
+{	
+	std::vector<std::string> words;
+	if (seq.empty())
+		return words;
+
+	constexpr auto whitespace = " \f\n\r\t\v";
+
+	// count words to reserve space in our vector
+	size_t n = 0;
+	auto head = seq.find_first_not_of(whitespace, 0);
+	while (head != std::string::npos) {
+		const auto tail = seq.find_first_of(whitespace, head);
+		head = seq.find_first_not_of(whitespace, tail);
+		++n;
+	}
+	words.reserve(n);
+
+	// populate the vector with the words
+	head = seq.find_first_not_of(whitespace, 0);
+	while (head != std::string::npos) {
+		const auto tail = seq.find_first_of(whitespace, head);
+		words.emplace_back(seq.substr(head, tail - head));
+		head = seq.find_first_not_of(whitespace, tail);
+	}
+
+	// did we reserve the exact space needed?
+	assert(n == words.size());
+
+	return words;
+}
+
 void strip_punctuation(std::string &str) {
 	str.erase(
 		std::remove_if(

--- a/tests/support.cpp
+++ b/tests/support.cpp
@@ -82,4 +82,87 @@ TEST(DriveIndex, DriveZ)
 	EXPECT_EQ(25, drive_index('Z'));
 }
 
+TEST(Support_split_delim, NoBoundingDelims)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split("a:/b:/c/d:/e/f/", ':'), expected);
+	EXPECT_EQ(split("a /b /c/d /e/f/", ' '), expected);
+	EXPECT_EQ(split("abc", 'x'), std::vector<std::string>{"abc"});
+}
+
+TEST(Support_split_delim, DelimAtStartNotEnd)
+{
+	const std::vector<std::string> expected({"", "a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split(":a:/b:/c/d:/e/f/", ':'), expected);
+	EXPECT_EQ(split(" a /b /c/d /e/f/", ' '), expected);
+}
+
+TEST(Support_split_delim, DelimAtEndNotStart)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/", ""});
+	EXPECT_EQ(split("a:/b:/c/d:/e/f/:", ':'), expected);
+	EXPECT_EQ(split("a /b /c/d /e/f/ ", ' '), expected);
+}
+
+TEST(Support_split_delim, DelimsAtBoth)
+{
+	const std::vector<std::string> expected({"", "a", "/b", "/c/d", "/e/f/", ""});
+	EXPECT_EQ(split(":a:/b:/c/d:/e/f/:", ':'), expected);
+	EXPECT_EQ(split(" a /b /c/d /e/f/ ", ' '), expected);
+}
+
+TEST(Support_split_delim, MultiInternalDelims)
+{
+	const std::vector<std::string> expected(
+	        {"a", "/b", "", "/c/d", "", "", "/e/f/"});
+	EXPECT_EQ(split("a:/b::/c/d:::/e/f/", ':'), expected);
+	EXPECT_EQ(split("a /b  /c/d   /e/f/", ' '), expected);
+}
+
+TEST(Support_split_delim, MultiBoundingDelims)
+{
+	const std::vector<std::string> expected(
+	        {"", "", "a", "/b", "/c/d", "/e/f/", "", "", ""});
+	EXPECT_EQ(split("::a:/b:/c/d:/e/f/:::", ':'), expected);
+	EXPECT_EQ(split("  a /b /c/d /e/f/   ", ' '), expected);
+}
+
+TEST(Support_split_delim, MixedDelims)
+{
+	const std::vector<std::string> expected(
+	        {"", "", "a", "/b", "", "/c/d", "/e/f/"});
+	EXPECT_EQ(split("::a:/b::/c/d:/e/f/", ':'), expected);
+	EXPECT_EQ(split("  a /b  /c/d /e/f/", ' '), expected);
+}
+
+TEST(Support_split_delim, Empty)
+{
+	const std::vector<std::string> empty;
+	const std::vector<std::string> two({"", ""});
+	const std::vector<std::string> three({"", "", ""});
+
+	EXPECT_EQ(split("", ':'), empty);
+	EXPECT_EQ(split(":", ':'), two);
+	EXPECT_EQ(split("::", ':'), three);
+	EXPECT_EQ(split("", ' '), empty);
+	EXPECT_EQ(split(" ", ' '), two);
+	EXPECT_EQ(split("  ", ' '), three);
+}
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split("::::a:/b::::/c/d:/e/f/", ':'), expected);
+	EXPECT_EQ(split("a /b  /c/d   /e/f/    ", ' '), expected);
+}
+
+TEST(Support_split, Empty)
+{
+	const std::vector<std::string> expected;
+	EXPECT_EQ(split("", ':'), expected);
+	EXPECT_EQ(split(":", ':'), expected);
+	EXPECT_EQ(split("::", ':'), expected);
+	EXPECT_EQ(split(" ", ' '), expected);
+	EXPECT_EQ(split("  ", ' '), expected);
+	EXPECT_EQ(split("   ", ' '), expected);
+}
+
 } // namespace

--- a/tests/support.cpp
+++ b/tests/support.cpp
@@ -148,21 +148,57 @@ TEST(Support_split_delim, Empty)
 	EXPECT_EQ(split(" ", ' '), two);
 	EXPECT_EQ(split("  ", ' '), three);
 }
+ 
+TEST(Support_split, NoBoundingWhitespace)
 {
 	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
-	EXPECT_EQ(split("::::a:/b::::/c/d:/e/f/", ':'), expected);
-	EXPECT_EQ(split("a /b  /c/d   /e/f/    ", ' '), expected);
+	EXPECT_EQ(split("a /b /c/d /e/f/"), expected);
+	EXPECT_EQ(split("abc"), std::vector<std::string>{"abc"});
+}
+TEST(Support_split, WhitespaceAtStartNotEnd)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split(" a /b /c/d /e/f/"), expected);
+}
+
+TEST(Support_split, WhitespaceAtEndNotStart)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split("a /b /c/d /e/f/ "), expected);
+}
+
+TEST(Support_split, WhitespaceAtBoth)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split(" a /b /c/d /e/f/ "), expected);
+}
+
+TEST(Support_split, MultiInternalWhitespace)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split("a /b  /c/d   /e/f/"), expected);
+}
+
+TEST(Support_split, MultiBoundingWhitespace)
+{
+	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
+	EXPECT_EQ(split("  a /b /c/d /e/f/   "), expected);
+}
+
+TEST(Support_split, MixedWhitespace)
+{
+	const std::vector<std::string> expected({"a", "b", "c"});
+	EXPECT_EQ(split("\t\na\f\vb\rc"), expected);
+	EXPECT_EQ(split("a\tb\f\vc"), expected);
+	EXPECT_EQ(split(" a \n \v \r b \f \r c "), expected);
 }
 
 TEST(Support_split, Empty)
 {
-	const std::vector<std::string> expected;
-	EXPECT_EQ(split("", ':'), expected);
-	EXPECT_EQ(split(":", ':'), expected);
-	EXPECT_EQ(split("::", ':'), expected);
-	EXPECT_EQ(split(" ", ' '), expected);
-	EXPECT_EQ(split("  ", ' '), expected);
-	EXPECT_EQ(split("   ", ' '), expected);
+	const std::vector<std::string> empty;
+	EXPECT_EQ(split(""), empty);
+	EXPECT_EQ(split(" "), empty);
+	EXPECT_EQ(split("   "), empty);
 }
 
 } // namespace


### PR DESCRIPTION
Also includes searching `XDG_DATA_HOME/dosbox/{soundfont,mt32-roms}` subdirectories.

The commit messages include a real-world example of directories and paths opened in priority order.

Note: this PR doesn't create a `dosbox/*` directory tree under `XDG_DATA_HOME/` to reduce proliferation of empty directories.

Fixes #780 ; thank you @bmunger for catching this!