### PR TITLE
Switch to unique_ptr in MT-32 and promote threaded rendering

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -34,12 +34,6 @@
 
 #include <SDL.h>
 
-// General-use unique-pointer types
-void sdl_thread_deleter(SDL_Thread *t);
-using sdl_thread_ptr_t = std::unique_ptr<SDL_Thread, decltype(&sdl_thread_deleter)>;
-using sdl_mutex_ptr_t = std::unique_ptr<SDL_mutex, decltype(&SDL_DestroyMutex)>;
-using sdl_cond_ptr_t = std::unique_ptr<SDL_cond, decltype(&SDL_DestroyCond)>;
-
 #ifdef _MSC_VER
 #define strcasecmp(a, b) _stricmp(a, b)
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)

--- a/include/support.h
+++ b/include/support.h
@@ -27,11 +27,18 @@
 #include <cstdio>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <SDL.h>
+
+// General-use unique-pointer types
+void sdl_thread_deleter(SDL_Thread *t);
+using sdl_thread_ptr_t = std::unique_ptr<SDL_Thread, decltype(&sdl_thread_deleter)>;
+using sdl_mutex_ptr_t = std::unique_ptr<SDL_mutex, decltype(&SDL_DestroyMutex)>;
+using sdl_cond_ptr_t = std::unique_ptr<SDL_cond, decltype(&SDL_DestroyCond)>;
 
 #ifdef _MSC_VER
 #define strcasecmp(a, b) _stricmp(a, b)

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -143,7 +143,7 @@ static std::deque<std::string> get_rom_dirs()
 
 static bool load_rom_set(const std::string &ctr_path,
                          const std::string &pcm_path,
-                         mt32_service_ptr_t &service)
+                         MidiHandler_mt32::service_t &service)
 {
 	const bool paths_exist = path_exists(ctr_path) && path_exists(pcm_path);
 	if (!paths_exist)
@@ -158,7 +158,7 @@ static bool load_rom_set(const std::string &ctr_path,
 
 static bool find_and_load(const std::string &model,
                           const std::deque<std::string> &rom_dirs,
-                          mt32_service_ptr_t &service)
+                          MidiHandler_mt32::service_t &service)
 {
 	const std::string ctr_rom = model + "_CONTROL.ROM";
 	const std::string pcm_rom = model + "_PCM.ROM";
@@ -231,7 +231,7 @@ static mt32emu_report_handler_i get_report_handler_interface()
 
 bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 {
-	mt32_service_ptr_t mt32_service = std::make_unique<MT32Emu::Service>();
+	service_t mt32_service = std::make_unique<MT32Emu::Service>();
 
 	// Check version
 	uint32_t version = mt32_service->getLibraryVersionInt();
@@ -281,8 +281,8 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 
 	const auto mixer_callback = std::bind(&MidiHandler_mt32::MixerCallBack,
 	                                      this, std::placeholders::_1);
-	mixer_channel_ptr_t mixer_channel(MIXER_AddChannel(mixer_callback, 0, "MT32"),
-	                                  MIXER_DelChannel);
+	channel_t mixer_channel(MIXER_AddChannel(mixer_callback, 0, "MT32"),
+	                        MIXER_DelChannel);
 	const auto sample_rate = mixer_channel->GetSampleRate();
 
 	mt32_service->setAnalogOutputMode(ANALOG_MODE);
@@ -457,6 +457,11 @@ void MidiHandler_mt32::RenderingLoop()
 			}
 		}
 	}
+}
+
+void MidiHandler_mt32::DeleteThread(SDL_Thread *t)
+{
+	SDL_WaitThread(t, nullptr);
 }
 
 static void mt32_init(MAYBE_UNUSED Section *sec)

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -330,13 +330,13 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 	service = std::move(mt32_service);
 	channel = std::move(mixer_channel);
 	channel->Enable(true);
-	open = true;
+	is_open = true;
 	return true;
 }
 
 void MidiHandler_mt32::Close()
 {
-	if (!open)
+	if (!is_open)
 		return;
 	channel->Enable(false);
 
@@ -349,7 +349,7 @@ void MidiHandler_mt32::Close()
 	framesInBufferChanged.reset();
 
 	service->closeSynth();
-	open = false;
+	is_open = false;
 }
 
 uint32_t MidiHandler_mt32::GetMidiEventTimestamp() const

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -76,7 +76,7 @@ private:
 	uint16_t framesPerAudioBuffer = 0;
 	uint16_t minimumRenderFrames = 0;
 
-	bool open = false;
+	bool is_open = false;
 	volatile bool stopProcessing = true;
 };
 

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -62,11 +62,11 @@ private:
 
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
 	mt32_service_ptr_t service{};
+	sdl_thread_ptr_t thread{nullptr, &sdl_thread_deleter};
+	sdl_mutex_ptr_t lock{nullptr, &SDL_DestroyMutex};
+	sdl_cond_ptr_t framesInBufferChanged{nullptr, &SDL_DestroyCond};
 
 	// TODO: replace pointers with std::unique_ptr
-	SDL_Thread *thread = nullptr;
-	SDL_mutex *lock = nullptr;
-	SDL_cond *framesInBufferChanged = nullptr;
 	int16_t *audioBuffer = nullptr;
 
 	// Ongoing state-tracking

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -38,6 +38,8 @@
 
 #include "mixer.h"
 
+using mt32_service_ptr_t = std::unique_ptr<MT32Emu::Service>;
+
 class MidiHandler_mt32 final : public MidiHandler {
 private:
 	using mixer_channel_ptr_t =
@@ -59,9 +61,9 @@ private:
 	void RenderingLoop();
 
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
+	mt32_service_ptr_t service{};
 
 	// TODO: replace pointers with std::unique_ptr
-	MT32Emu::Service *service = nullptr;
 	SDL_Thread *thread = nullptr;
 	SDL_mutex *lock = nullptr;
 	SDL_cond *framesInBufferChanged = nullptr;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -26,6 +26,8 @@
 
 #if C_MT32EMU
 
+#include <memory>
+
 #define MT32EMU_API_TYPE 3
 #include <mt32emu/mt32emu.h>
 #if MT32EMU_VERSION_MAJOR != 2 || MT32EMU_VERSION_MINOR < 1
@@ -37,6 +39,10 @@
 #include "mixer.h"
 
 class MidiHandler_mt32 final : public MidiHandler {
+private:
+	using mixer_channel_ptr_t =
+	        std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
+
 public:
 	~MidiHandler_mt32();
 
@@ -52,8 +58,9 @@ private:
 	static int ProcessingThread(void *data);
 	void RenderingLoop();
 
+	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
+
 	// TODO: replace pointers with std::unique_ptr
-	MixerChannel *chan = nullptr;
 	MT32Emu::Service *service = nullptr;
 	SDL_Thread *thread = nullptr;
 	SDL_mutex *lock = nullptr;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -65,9 +65,7 @@ private:
 	sdl_thread_ptr_t thread{nullptr, &sdl_thread_deleter};
 	sdl_mutex_ptr_t lock{nullptr, &SDL_DestroyMutex};
 	sdl_cond_ptr_t framesInBufferChanged{nullptr, &SDL_DestroyCond};
-
-	// TODO: replace pointers with std::unique_ptr
-	int16_t *audioBuffer = nullptr;
+	std::vector<int16_t> audioBuffer = {};
 
 	// Ongoing state-tracking
 	volatile uint32_t playedBuffers = 0;
@@ -75,7 +73,6 @@ private:
 	volatile uint16_t playPos = 0;
 
 	// Buffer properties
-	uint16_t audioBufferSize = 0;
 	uint16_t framesPerAudioBuffer = 0;
 	uint16_t minimumRenderFrames = 0;
 

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -234,6 +234,11 @@ char * lowcase(char * str) {
 	return str;
 }
 
+void sdl_thread_deleter(SDL_Thread *t)
+{
+	SDL_WaitThread(t, nullptr);
+}
+
 bool ScanCMDBool(char * cmd, char const * const check)
 {
 	if (cmd == nullptr)

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -234,11 +234,6 @@ char * lowcase(char * str) {
 	return str;
 }
 
-void sdl_thread_deleter(SDL_Thread *t)
-{
-	SDL_WaitThread(t, nullptr);
-}
-
 bool ScanCMDBool(char * cmd, char const * const check)
 {
 	if (cmd == nullptr)


### PR DESCRIPTION
Round 3 for MT-32! 

This moves its implementation to using modern C++ constructs similar to FluidSynth.

Dynamically-allocated resources are RAII managed with unique_ptr and vector.

The threaded code path is now the only path.  

_Justification_: even on single-CPU core systems, it makes more sense to render MT-32 frames in parallel using _any_ spare CPU cycles than to have those cycles go to waste and instead wait for the 1ms callback "tick" to perform the entire batch of MT-32 rendering on-the-spot.  In the latter case, we incur the full latency impact and thus significantly increase the odds of playback skipping when CPU performance is limited.

On a minor note, this PR somehow made VisualStudio report another `vnsprintf` warning from `support.h`, despite none of the commits in this PR performing string-related calls or using any `support.h` functions.   

Was ... 
``` text
  C4996 : 275
  C4244 : 14
  C4101 : 2
  C4309 : 1
  C4305 : 1
  C4267 : 1
  C4018 : 1
```

Now ...

``` text
  C4996 : 276
  C4244 : 14
  C4101 : 2
  C4309 : 1
  C4305 : 1
  C4267 : 1
  C4018 : 1
```