### PR TITLE
Add unit tests for MyFifo and CFifo

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,12 +15,15 @@ endif
 
 tests_SOURCES = \
 	example.cpp \
+	cfifo.cpp \
+	myfifo.cpp \
 	fs_utils.cpp \
+	log_msg_knockout.cpp \
 	soft_limiter.cpp \
 	string_utils.cpp \
 	support.cpp
 
-tests_LDADD = ../src/misc/libmisc.a
+tests_LDADD = ../src/hardware/serialport/libserial.a ../src/misc/libmisc.a
 
 # Override automake's distclean target to prevent it recursing into
 # SUBDIRS and failing (it was already invoked in there via src/Makefile.am).

--- a/tests/cfifo.cpp
+++ b/tests/cfifo.cpp
@@ -1,0 +1,207 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "../src/hardware/serialport/softmodem.h"
+#include "log_msg_knockout.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace {
+
+TEST(CFifo, constructor_EmptyQueue)
+{
+	CFifo f(10);
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 10);
+	EXPECT_EQ(f.getb(), 0);
+}
+
+TEST(CFifo, clear_EmptyQueue)
+{
+	CFifo f(10);
+	f.clear();
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 10);
+	EXPECT_EQ(f.getb(), 0);
+}
+
+TEST(CFifo, clear_ExistingQueue)
+{
+	CFifo f(10);
+	f.addb(1);
+	f.clear(); 
+
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 10);
+	// EXPECT_EQ(f.getb(), 0); <--- should pass, but fails
+	//
+	// BUG
+	//  - getb() will now return '1'
+	//  - Inconsistent behavior versus prior inuse() == false state
+	//  - Inconsistent behavior versus prior left() == 10 state
+	//  - Inconsistent behavior versus prior clear()'ed state
+}
+
+TEST(CFifo, state_QueueExists)
+{
+	CFifo f(3);
+	f.addb(1);
+	EXPECT_TRUE(f.inuse());
+	EXPECT_EQ(f.left(), 2);
+}
+
+TEST(CFifo, state_QueueFull)
+{
+	CFifo f(3);
+
+	f.addb(1);
+	f.addb(2);
+	f.addb(3);
+
+	EXPECT_TRUE(f.inuse());
+	EXPECT_EQ(f.left(), 0);
+}
+
+TEST(CFifo, state_Empty)
+{
+	CFifo f(3);
+
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 3);
+}
+
+TEST(CFifo, getb_QueueExists)
+{
+	CFifo f(3);
+	f.addb(1);
+	const auto val = f.getb();
+
+	EXPECT_EQ(val, 1);
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 3);
+
+	f.addb(2);
+	EXPECT_TRUE(f.inuse());
+	EXPECT_EQ(f.left(), 2);
+
+	f.addb(3);
+	EXPECT_EQ(f.getb(), 2);
+	EXPECT_EQ(f.getb(), 3);
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 3);
+}
+
+TEST(CFifo, getb_QueueFull)
+{
+	CFifo f(3);
+
+	uint8_t vals[3] = {1, 2, 3};
+	f.adds(vals, 3);
+
+	auto val = f.getb();
+	EXPECT_EQ(val, 1);
+
+	EXPECT_TRUE(f.inuse());
+	EXPECT_EQ(f.left(), 1);
+
+	val = f.getb();
+	val = f.getb();
+
+	EXPECT_EQ(val, 3);
+
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 3);
+}
+
+TEST(CFifo, getb_Empty)
+{
+	CFifo f(10);
+	EXPECT_EQ(f.getb(), 0);
+	EXPECT_FALSE(f.inuse());
+	EXPECT_EQ(f.left(), 10);
+}
+
+TEST(CFifo, addb_OverFlow)
+{
+	CFifo f(3);
+	
+	f.addb(1);
+	f.addb(2);
+	f.addb(3);
+	f.addb(4); // overflows on 4th value and drops it
+	EXPECT_EQ(f.getb(), 1);
+	EXPECT_EQ(f.inuse(), 2);
+
+	EXPECT_EQ(f.getb(), 2);
+	EXPECT_EQ(f.inuse(), 1);
+
+	EXPECT_EQ(f.getb(), 3);
+	EXPECT_EQ(f.inuse(), 0);
+	EXPECT_EQ(f.left(), 3);
+
+	// EXPECT_EQ(f.getb(), 0); <-- fails, it return '1'.
+	// BUG:
+	//  - Inconsistent result versus prior cleared states.
+}
+
+TEST(CFifo, adds_OverFlow)
+{
+	CFifo f(3);
+
+	uint8_t four_vals[4] = {1, 2, 3, 4};
+	f.adds(four_vals, 4);
+
+	// Expected behavior:
+	// - should match addb_OverFlow test above
+	// - 1, 2, 3 should exist in the queue	
+	// - 4th value should overflow and should be dropped
+	
+	/*
+
+	// FAILS ALL OF THESE
+	EXPECT_EQ(f.getb(), 1);
+	EXPECT_EQ(f.inuse(), 2);
+
+	EXPECT_EQ(f.getb(), 2);
+	EXPECT_EQ(f.inuse(), 1);
+
+	EXPECT_EQ(f.getb(), 3);
+	EXPECT_EQ(f.inuse(), 0);
+
+	EXPECT_EQ(f.getb(), 0);
+	EXPECT_EQ(f.inuse(), 0);
+
+	// BUG:
+	// - Modem operations operated one byte at a time, therefore
+	//   adds() should be equivalent to sequential addb()'s. 
+	// - 'adds' drops the entire request, and return empty value
+
+	*/
+}
+
+TEST(CFifo, setSize_Nominal)
+{
+	CFifo f(10);
+	EXPECT_EQ(f.left(), 10);
+}
+
+} // namespace

--- a/tests/log_msg_knockout.cpp
+++ b/tests/log_msg_knockout.cpp
@@ -1,0 +1,24 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "log_msg_knockout.h"
+
+void GFX_ShowMsg(char const *, ...)
+{}

--- a/tests/log_msg_knockout.h
+++ b/tests/log_msg_knockout.h
@@ -1,0 +1,27 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef TESTS_LOG_MSG_KNOCKOUT_H
+#define TESTS_LOG_MSG_KNOCKOUT_H
+
+// Prevent LOG_MSG from depending on sdlmain.cpp
+void GFX_ShowMsg(char const *, ...);
+
+#endif

--- a/tests/myfifo.cpp
+++ b/tests/myfifo.cpp
@@ -1,0 +1,242 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2020  The dosbox-staging team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "serialport.h"
+#include "log_msg_knockout.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace {
+
+TEST(MyFifo, getTop_Empty)
+{
+	MyFifo f(3);
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getTop(), 0);
+}
+
+
+TEST(MyFifo, clear_Nominal)
+{
+	MyFifo f(10);
+	f.addb(1);
+	f.clear();
+
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getTop(), 0);
+	EXPECT_EQ(f.probeByte(), 0);
+	EXPECT_EQ(f.probeByte(), 0);
+	EXPECT_EQ(f.getb(), 0);
+}
+
+TEST(MyFifo, getTop_QueueExists)
+{
+	MyFifo f(3);
+
+	f.addb(1);
+	f.addb(2);
+	f.addb(3);
+	EXPECT_EQ(f.getTop(), 3);
+	// '3' is the back of the queue and this passes
+
+	// Drain the queue
+	f.getb();
+	f.getb();
+	f.getb();
+
+	// Confirm queue is empty:
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());	
+	EXPECT_TRUE(f.isEmpty());
+
+	// EXPECT_EQ(f.getTop(), 0); <-- should match EmptyQueue state
+	// BUG
+	//  - Inconsistent results. Queue is empty, but results now
+	//    depending on prior states.
+
+	f.addb(4);
+	f.addb(5);
+	// EXPECT_EQ(f.getTop(), 5); 
+	// '5' is the back of the queue, but this fails.
+	// BUG
+	//  - Inconsistent behavior because getTop() will now return '2'
+	//  - '2' in this case is at the front of the queue and the oldest
+	//    item in the queue (which doesn't match prior behavior).
+}
+
+TEST(MyFifo, probeByte_QueueExists)
+{
+	MyFifo f(10);
+
+	f.addb(1);
+	EXPECT_EQ(f.probeByte(), 1);
+
+	f.addb(2);
+
+	f.addb(3);
+	EXPECT_EQ(f.probeByte(), 1);
+}
+
+TEST(MyFifo, probeByte_Empty)
+{
+	MyFifo f(10);
+	EXPECT_EQ(f.probeByte(), 0);
+}
+
+TEST(MyFifo, state_QueueExists)
+{
+	MyFifo f(3);
+	f.addb(1);
+	EXPECT_FALSE(f.isEmpty());
+	EXPECT_TRUE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getFree(), 2);
+	EXPECT_EQ(f.getUsage(), 1);
+}
+
+TEST(MyFifo, state_QueueFull)
+{
+	MyFifo f(3);
+
+	f.addb(1);
+	f.addb(2);
+	f.addb(3);
+
+	EXPECT_FALSE(f.isEmpty());
+	EXPECT_TRUE(f.getUsage());
+	EXPECT_TRUE(f.isFull());
+	EXPECT_EQ(f.getFree(), 0);
+	EXPECT_EQ(f.getUsage(), 3);
+}
+
+TEST(MyFifo, state_Empty)
+{
+	MyFifo f(3);
+
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getFree(), 3);
+	EXPECT_EQ(f.getUsage(), 0);
+}
+
+TEST(MyFifo, getb_QueueExists)
+{
+	MyFifo f(3);
+	f.addb(1);
+	const auto val = f.getb();
+
+	EXPECT_EQ(val, 1);
+
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getFree(), 3);
+	EXPECT_EQ(f.getUsage(), 0);
+}
+
+TEST(MyFifo, getb_QueueFull)
+{
+	MyFifo f(3);
+
+	const uint8_t vals[3] = {1, 2, 3};
+	f.addb(1);
+	f.addb(2);
+	f.addb(3);
+
+	auto val = f.getb();
+	EXPECT_EQ(val, 1);
+
+	EXPECT_FALSE(f.isEmpty());
+	EXPECT_TRUE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getFree(), 1);
+	EXPECT_EQ(f.getUsage(), 2);
+
+	val = f.getb();
+	val = f.getb();
+	EXPECT_EQ(val, 3);
+
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getFree(), 3);
+	EXPECT_EQ(f.getUsage(), 0);
+
+	val = f.getb();
+	// EXPECT_EQ(val, 0); <-- fails, it return '1'.
+	// BUG:
+	//  - Inconsistent result versus prior cleared states.
+}
+
+TEST(MyFifo, getb_Empty)
+{
+	MyFifo f(10);
+	EXPECT_EQ(f.getb(), 0);
+	EXPECT_TRUE(f.isEmpty());
+	EXPECT_FALSE(f.getUsage());
+	EXPECT_FALSE(f.isFull());
+	EXPECT_EQ(f.getFree(), 10);
+	EXPECT_EQ(f.getUsage(), 0);
+}
+
+TEST(MyFifo, addb_OverFlow)
+{
+	MyFifo f(3);
+
+	const uint8_t four_vals[4] = {1, 2, 3, 4};
+
+	f.addb(1);
+	f.addb(2);
+	f.addb(3);
+	f.addb(4);  // overflows on 4th value and drops it
+
+	EXPECT_EQ(f.probeByte(), 1);
+	EXPECT_FALSE(f.isEmpty());
+	EXPECT_TRUE(f.isFull());
+}
+
+TEST(MyFifo, setSize_Nominal)
+{
+	MyFifo f(0);
+	EXPECT_EQ(f.getFree(), 0);
+	EXPECT_EQ(f.getUsage(), 0);
+
+	f.setSize(1);
+	EXPECT_EQ(f.getFree(), 1);
+	EXPECT_EQ(f.getUsage(), 0);
+}
+
+TEST(MyFifo, setSize_TooMany)
+{
+	MyFifo f(0);
+	f.setSize(16);
+	EXPECT_EQ(f.getFree(), 16);
+	EXPECT_EQ(f.getUsage(), 0);
+}
+
+} // namespace


### PR DESCRIPTION
The tests revealed inconsistent (but likely inconsequential) behaviour in both Fifo classes.

A more serious issue was discovered in `MyFifo`, which may explain why the soft-modem's author wrote `CFifo` and used that instead.