### PR TITLE
Prevent PVS license state from impacting CI results

### DIFF
--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -2,6 +2,14 @@
     "version": 1,
     "warnings": [
         {
+            "CodeCurrent": 0,
+            "CodeNext": 0,
+            "CodePrev": 0,
+            "ErrorCode": "Renew",
+            "FileName": " ",
+            "Message": "Your license will expire in _ days. Click 'Renew' to learn more or contact us at support@viva_.com."
+        },
+        {
             "CodeCurrent": 99146737,
             "CodeNext": 3299936121,
             "CodePrev": 2974951853,


### PR DESCRIPTION
When this occurs, the added warning causes CI to fail due to the increase number of warnings, which acts as a false-positive because it doesn't involve our code.

False positives should be suppressed if possible, and in this case license renewal should be handled separately and not influence CI run results.