### PR TITLE
Fix localtime_r on MSYS2

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 290
+            max_warnings: 289
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1997
+            max_warnings: 1996
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/cross.h
+++ b/include/cross.h
@@ -70,9 +70,19 @@
 #define cross_fileno(s) fileno(s)
 #endif
 
-#if defined(_MSC_VER)
+namespace cross {
+
+#if defined(WIN32)
+
 struct tm *localtime_r(const time_t *timep, struct tm *result);
+
+#else
+
+constexpr auto localtime_r = ::localtime_r;
+
 #endif
+
+} // namespace cross
 
 void CROSS_DetermineConfigPaths();
 std::string CROSS_GetPlatformConfigDir();

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -361,7 +361,7 @@ again:
 
 	find_size=(Bit32u) stat_block.st_size;
 	struct tm datetime;
-	if (localtime_r(&stat_block.st_mtime, &datetime)) {
+	if (cross::localtime_r(&stat_block.st_mtime, &datetime)) {
 		find_date = DOS_PackDate(datetime);
 		find_time = DOS_PackTime(datetime);
 	} else {
@@ -474,7 +474,7 @@ bool localDrive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	if (stat(newname,&temp_stat)!=0) return false;
 	/* Convert the stat to a FileStat */
 	struct tm datetime;
-	if (localtime_r(&temp_stat.st_mtime, &datetime)) {
+	if (cross::localtime_r(&temp_stat.st_mtime, &datetime)) {
 		stat_block->time = DOS_PackTime(datetime);
 		stat_block->date = DOS_PackDate(datetime);
 	} else {
@@ -749,7 +749,7 @@ bool localFile::UpdateDateTimeFromHost()
 		return true; // use defaults
 
 	struct tm datetime;
-	if (!localtime_r(&temp_stat.st_mtime, &datetime))
+	if (!cross::localtime_r(&temp_stat.st_mtime, &datetime))
 		return true; // use defaults
 
 	time = DOS_PackTime(datetime);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -821,7 +821,7 @@ again:
 
 	find_size=(Bit32u) stat_block.st_size;
 	struct tm datetime;
-	if (localtime_r(&stat_block.st_mtime, &datetime)) {
+	if (cross::localtime_r(&stat_block.st_mtime, &datetime)) {
 		find_date = DOS_PackDate(datetime);
 		find_time = DOS_PackTime(datetime);
 	} else {
@@ -1203,7 +1203,7 @@ bool Overlay_Drive::FileStat(const char* name, FileStat_Block * const stat_block
 	}
 	/* Convert the stat to a FileStat */
 	struct tm datetime;
-	if (localtime_r(&temp_stat.st_mtime, &datetime)) {
+	if (cross::localtime_r(&temp_stat.st_mtime, &datetime)) {
 		stat_block->time = DOS_PackTime(datetime);
 		stat_block->date = DOS_PackDate(datetime);
 	} else {

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -16,18 +16,18 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <time.h>
-#include <math.h>
-
 #include "dosbox.h"
-#include "timer.h"
-#include "pic.h"
+
+#include <cmath>
+#include <ctime>
+
+#include "bios_disk.h"
+#include "cross.h"
 #include "inout.h"
 #include "mem.h"
-#include "bios_disk.h"
+#include "pic.h"
 #include "setup.h"
-#include "cross.h" //fmod on certain platforms
+#include "timer.h"
 
 static struct {
 	Bit8u regs[0x40];
@@ -130,31 +130,28 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
 	}
 	Bitu drive_a, drive_b;
 	Bit8u hdparm;
-	time_t curtime;
-	struct tm *loctime;
-	/* Get the current time. */
-	curtime = time (NULL);
 
-	/* Convert it to local time representation. */
-	loctime = localtime (&curtime);
+	const time_t curtime = time(nullptr);
+	struct tm datetime;
+	cross::localtime_r(&curtime, &datetime);
 
 	switch (cmos.reg) {
 	case 0x00:		/* Seconds */
-		return 	MAKE_RETURN(loctime->tm_sec);
+		return MAKE_RETURN(datetime.tm_sec);
 	case 0x02:		/* Minutes */
-		return 	MAKE_RETURN(loctime->tm_min);
+		return MAKE_RETURN(datetime.tm_min);
 	case 0x04:		/* Hours */
-		return 	MAKE_RETURN(loctime->tm_hour);
+		return MAKE_RETURN(datetime.tm_hour);
 	case 0x06:		/* Day of week */
-		return 	MAKE_RETURN(loctime->tm_wday + 1);
+		return MAKE_RETURN(datetime.tm_wday + 1);
 	case 0x07:		/* Date of month */
-		return 	MAKE_RETURN(loctime->tm_mday);
+		return MAKE_RETURN(datetime.tm_mday);
 	case 0x08:		/* Month */
-		return 	MAKE_RETURN(loctime->tm_mon + 1);
+		return MAKE_RETURN(datetime.tm_mon + 1);
 	case 0x09:		/* Year */
-		return 	MAKE_RETURN(loctime->tm_year % 100);
+		return MAKE_RETURN(datetime.tm_year % 100);
 	case 0x32:		/* Century */
-		return 	MAKE_RETURN(loctime->tm_year / 100 + 19);
+		return MAKE_RETURN(datetime.tm_year / 100 + 19);
 	case 0x01:		/* Seconds Alarm */
 	case 0x03:		/* Minutes Alarm */
 	case 0x05:		/* Hours Alarm */

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -393,10 +393,14 @@ FILE *fopen_wrap(const char *path, const char *mode) {
 	return fopen(path,mode);
 }
 
-#if defined(_MSC_VER)
+namespace cross {
+
+#if defined(WIN32)
 struct tm *localtime_r(const time_t *timep, struct tm *result)
 {
 	const errno_t err = localtime_s(result, timep);
 	return (err == 0 ? result : nullptr);
 }
 #endif
+
+} // namespace cross

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1331,7 +1331,7 @@ void DOS_Shell::CMD_DATE(char * args) {
 		// synchronize date with host
 		const time_t curtime = time(nullptr);
 		struct tm datetime;
-		localtime_r(&curtime, &datetime);
+		cross::localtime_r(&curtime, &datetime);
 		reg_ah = 0x2b; // set system date
 		reg_cx = static_cast<uint16_t>(datetime.tm_year + 1900);
 		reg_dh = static_cast<uint8_t>(datetime.tm_mon + 1);
@@ -1389,7 +1389,7 @@ void DOS_Shell::CMD_TIME(char * args) {
 		// synchronize time with host
 		const time_t curtime = time(NULL);
 		struct tm datetime;
-		localtime_r(&curtime, &datetime);
+		cross::localtime_r(&curtime, &datetime);
 
 		// Original IBM PC used ~1.19MHz crystal for timer, because at
 		// 1.19MHz, 2^16 ticks is ~1 hour, making it easy to count


### PR DESCRIPTION
And convert one more use from `localtime` to `cross::localtime_r`.

MSYS2 jobs are ongoing: https://github.com/dosbox-staging/dosbox-staging/runs/1618441499