### PR TITLE
Fix formatting of `mount` command (when translated)

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -514,10 +514,6 @@ Missing parameter.
 CDROMs found: %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-
-.
 :PROGRAM_MOUNT_STATUS_DRIVE
 Drive
 .

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -515,10 +515,6 @@ ParamŠtre manquant.
 CDROMs trouv‚s : %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-.
-
 :PROGRAM_MOUNT_STATUS_DRIVE
 Lecteur
 .

--- a/contrib/translations/pl/pl_PL.CP437.lng
+++ b/contrib/translations/pl/pl_PL.CP437.lng
@@ -514,10 +514,6 @@ Missing parameter.
 CDROMs found: %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-
-.
 :PROGRAM_MOUNT_STATUS_DRIVE
 Dysk
 .

--- a/contrib/translations/pl/pl_PL.lng
+++ b/contrib/translations/pl/pl_PL.lng
@@ -514,10 +514,6 @@ Missing parameter.
 CDROMs found: %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-
-.
 :PROGRAM_MOUNT_STATUS_DRIVE
 Dysk
 .

--- a/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
@@ -514,10 +514,6 @@ Missing parameter.
 CDROMs found: %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-
-.
 :PROGRAM_MOUNT_STATUS_DRIVE
 Drive
 .

--- a/contrib/translations/utf-8/fr/fr-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/fr/fr-0.77.0-alpha.txt
@@ -515,10 +515,6 @@ Paramètre manquant.
 CDROMs trouvés : %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-.
-
 :PROGRAM_MOUNT_STATUS_DRIVE
 Lecteur
 .

--- a/contrib/translations/utf-8/pl/pl-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/pl/pl-0.77.0-alpha.txt
@@ -514,10 +514,6 @@ Missing parameter.
 CDROMs found: %d
 
 .
-:PROGRAM_MOUNT_STATUS_FORMAT
-%-5s  %-58s %-12s
-
-.
 :PROGRAM_MOUNT_STATUS_DRIVE
 Dysk
 .

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -139,25 +139,25 @@ public:
 		dos.dta(dos.tables.tempdta);
 		DOS_DTA dta(dos.dta());
 
-		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_1"));
-
 		const std::string header_drive = MSG_Get("PROGRAM_MOUNT_STATUS_DRIVE");
 		const std::string header_type = MSG_Get("PROGRAM_MOUNT_STATUS_TYPE");
 		const std::string header_label = MSG_Get("PROGRAM_MOUNT_STATUS_LABEL");
 
 		const int term_width = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
-		const auto col_1_width = static_cast<int>(header_drive.size());
-		const auto col_3_width = std::max(11, static_cast<int>(header_label.size()));
-		const auto col_2_width = term_width - 3 - col_1_width - col_3_width;
+		const auto width_1 = static_cast<int>(header_drive.size());
+		const auto width_3 = std::max(11, static_cast<int>(header_label.size()));
+		const auto width_2 = term_width - 3 - width_1 - width_3;
 
 		auto print_row = [&](const std::string &txt_1,
 		                     const std::string &txt_2,
 		                     const std::string &txt_3) {
-			WriteOut("%-*s %-*s %-*s\n", col_1_width, txt_1.c_str(),
-			         col_2_width, txt_2.c_str(), col_3_width,
-			         txt_3.c_str());
+			WriteOut("%-*s %-*s %-*s\n",
+			         width_1, txt_1.c_str(),
+			         width_2, txt_2.c_str(),
+			         width_3, txt_3.c_str());
 		};
 
+		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_1"));
 		print_row(header_drive, header_type, header_label);
 
 		for (int i = 0; i < term_width; i++)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -133,12 +133,6 @@ public:
 
 	void ListMounts()
 	{
-		char name[DOS_NAMELENGTH_ASCII];Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
-		/* Command uses dta so set it to our internal dta */
-		RealPt save_dta = dos.dta();
-		dos.dta(dos.tables.tempdta);
-		DOS_DTA dta(dos.dta());
-
 		const std::string header_drive = MSG_Get("PROGRAM_MOUNT_STATUS_DRIVE");
 		const std::string header_type = MSG_Get("PROGRAM_MOUNT_STATUS_TYPE");
 		const std::string header_label = MSG_Get("PROGRAM_MOUNT_STATUS_LABEL");
@@ -159,25 +153,16 @@ public:
 
 		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_1"));
 		print_row(header_drive, header_type, header_label);
-
 		for (int i = 0; i < term_width; i++)
 			WriteOut_NoParsing("-");
 
-		for (int d = 0; d < DOS_DRIVES; d++) {
-			if (!Drives[d]) continue;
-
-			char root[7] = {static_cast<char>('A' + d),':','\\','*','.','*',0};
-			bool ret = DOS_FindFirst(root,DOS_ATTR_VOLUME);
-			if (ret) {
-				dta.GetResult(name,size,date,time,attr);
-				DOS_FindNext(); //Mark entry as invalid
-			} else {
-				name[0] = 0;
+		for (uint8_t d = 0; d < DOS_DRIVES; d++) {
+			if (Drives[d]) {
+				print_row(std::string{drive_letter(d)},
+				          Drives[d]->GetInfo(),
+				          To_Label(Drives[d]->GetLabel()));
 			}
-			print_row(std::string{root[0]}, Drives[d]->GetInfo(),
-			          To_Label(name));
 		}
-		dos.dta(save_dta);
 	}
 
 	void Run(void) {

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -73,7 +73,13 @@ checkext:
 	return true;
 }
 
-
+// TODO Right now label formatting seems to be a bit of mess, with various
+// places in code setting/expecting different format, so simple GetLabel() on
+// a drive object might not yield an expected result. Not sure how to sort it
+// out, but it will require some attention to detail.
+// Also: this function is too strict - it removes all punctuation when *some*
+// punctuation is acceptable in drive labels (e.g. '_' or '-').
+//
 std::string To_Label(const char* name) {
 	// Reformat the name per the DOS label specification:
 	// - Upper-case, up to 11 ASCII characters

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -629,8 +629,9 @@ void DOS_Shell::CMD_DIR(char * args) {
 
 	if (!optB) {
 		if (print_label) {
-			const char *label = Drives[drive_idx]->GetLabel();
-			WriteOut(MSG_Get("SHELL_CMD_DIR_VOLUME"), drive_letter, label);
+			const auto label = To_Label(Drives[drive_idx]->GetLabel());
+			WriteOut(MSG_Get("SHELL_CMD_DIR_VOLUME"), drive_letter,
+			         label.c_str());
 			p_count += 1;
 		}
 		WriteOut(MSG_Get("SHELL_CMD_DIR_INTRO"), path);


### PR DESCRIPTION
Table formatting was difficult to get right for translators - now it won't be a problem any more. Plus, some additional improvements in the same function.