### PR TITLE
Port defines required for dynamic recompiler to Meson

### DIFF
--- a/.github/packages/ubuntu-16.04-apt.txt
+++ b/.github/packages/ubuntu-16.04-apt.txt
@@ -1,7 +1,6 @@
 build-essential
 ccache
 libasound2-dev
-libfluidsynth-dev
 libopusfile-dev
 libpng-dev
 libsdl2-dev

--- a/.github/packages/ubuntu-18.04-apt.txt
+++ b/.github/packages/ubuntu-18.04-apt.txt
@@ -1,0 +1,8 @@
+build-essential
+ccache
+libasound2-dev
+libopusfile-dev
+libpng-dev
+libsdl2-dev
+libsdl2-net-dev
+meson

--- a/.github/packages/ubuntu-20.04-apt.txt
+++ b/.github/packages/ubuntu-20.04-apt.txt
@@ -1,0 +1,10 @@
+build-essential
+ccache
+libasound2-dev
+libfluidsynth-dev
+libgtest-dev
+libopusfile-dev
+libpng-dev
+libsdl2-dev
+libsdl2-net-dev
+meson

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,50 +19,42 @@ jobs:
         conf:
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
-            packages: meson clang
+            packages: clang
             build_flags: --native-file=.github/meson/native-clang.ini
             max_warnings: 0
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
-            packages: meson
             max_warnings: 0
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
-            packages: meson
-            build_flags: -Duse_fluidsynth=false
+            build_flags: -Duse_fluidsynth=false --wrap-mode=nofallback
             max_warnings: 0
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
-            build_flags: -Duse_fluidsynth=false
+            build_flags: -Duse_fluidsynth=false --wrap-mode=nofallback
             max_warnings: 0
           - name: GCC, +tests
             os: ubuntu-20.04
-            packages: meson libgtest-dev
             run_tests: true
             max_warnings: -1
           - name: GCC, +debugger
             os: ubuntu-20.04
-            packages: meson
             build_flags: -Denable_debugger=normal
             max_warnings: 132
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
-            packages: meson
             build_flags: -Ddynamic_core=dynrec
             max_warnings: 0
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
-            packages: meson
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
             max_warnings: 144
           - name: GCC, -network
             os: ubuntu-20.04
-            packages: meson
             build_flags: -Duse_sdl2_net=false
             max_warnings: 0
           - name: GCC, warning_level=3
             os: ubuntu-20.04
-            packages: meson
             build_flags: -Dwarning_level=3
             max_warnings: 236
 
@@ -74,13 +66,10 @@ jobs:
         run: |
           sudo apt-get install -y \
             ${{ matrix.conf.packages }} \
-            $(cat ./.github/packages/ubuntu-apt.txt)
+            $(cat ./.github/packages/${{ matrix.conf.os }}-apt.txt)
 
-      # We want to use meson provided via apt whenever possible, but
-      # Ubuntu 16.04 has very old version (and is close to EOL).
-      # We need meson 0.45.1 or newer.
       - name: Install Meson via pip3
-        if:   contains(matrix.conf.packages, 'meson') == false
+        if:   matrix.conf.os == 'ubuntu-16.04'
         run: |
           sudo apt-get install python3-setuptools
           sudo pip3 install meson ninja

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,21 +37,24 @@ jobs:
             max_warnings: 0
           - name: GCC, +tests
             os: ubuntu-20.04
-            packages: libgtest-dev
+            packages: meson libgtest-dev
             run_tests: true
             max_warnings: -1
-          - name: GCC, +debug
+          - name: GCC, +debugger
             os: ubuntu-20.04
+            packages: meson
             build_flags: -Denable_debugger=normal
             max_warnings: 132
-          # - name: GCC, +dynrec, -dyn_x86
-          #   os: ubuntu-20.04
-          #   config_flags: --disable-dynamic-x86
-          #   max_warnings: 0
-          # - name: GCC, +dynrec, +debug, -dyn_x86
-          #   os: ubuntu-20.04
-          #   config_flags: --disable-dynamic-x86 --enable-debug
-          #   max_warnings: 144
+          - name: GCC, -dyn-x86
+            os: ubuntu-20.04
+            packages: meson
+            build_flags: -Ddynamic_core=dynrec
+            max_warnings: 0
+          - name: GCC, -dyn-x86, +debugger
+            os: ubuntu-20.04
+            packages: meson
+            build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
+            max_warnings: 144
           - name: GCC, -network
             os: ubuntu-20.04
             packages: meson

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,7 +48,7 @@ jobs:
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 144
+            max_warnings: 169
           - name: GCC, -network
             os: ubuntu-20.04
             build_flags: -Duse_sdl2_net=false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,7 @@ jobs:
             packages: meson
             run_tests: true
             max_warnings: -1
-          - name: Clang, +debug
+          - name: Clang, +debugger
             packages: meson
             build_flags: --wrap-mode=nofallback -Denable_debugger=normal
             max_warnings: 165

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,7 +1,7 @@
 name: Platform builds
 
-on:
-  schedule: [cron: '0 14 * * *']
+on: [push]
+        #  schedule: [cron: '0 14 * * *']
 
 jobs:
   repo-check:
@@ -22,21 +22,21 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: ARMv6 (Debian Buster)
-            architecture: armv6
-            distribution: buster
-          - name: ARMv7 (Debian Buster)
-            architecture: armv7
-            distribution: buster
-          - name: ARMv8 AArch64 (Ubuntu 18.04)
-            architecture: aarch64
-            distribution: ubuntu18.04
+          # - name: ARMv6 (Debian Buster)
+          #   arch: armv6
+          #   distro: buster
+          # - name: ARMv7 (Debian Buster)
+          #   arch: armv7
+          #   distro: buster
+          # - name: ARMv8 AArch64 (Ubuntu 18.04)
+          #   arch: aarch64
+          #   distro: ubuntu18.04
           - name: s390x (Ubuntu 18.04)
-            architecture: s390x
-            distribution: ubuntu18.04
+            arch: s390x
+            distro: ubuntu18.04
           - name: ppc64le (Ubuntu 18.04)
-            architecture: ppc64le
-            distribution: ubuntu18.04
+            arch: ppc64le
+            distro: ubuntu18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,14 +52,16 @@ jobs:
       - name: Build
         uses: uraimo/run-on-arch-action@master
         with:
-          architecture: ${{ matrix.conf.architecture }}
-          distribution: ${{ matrix.conf.distribution }}
+          arch:   ${{ matrix.conf.arch }}
+          distro: ${{ matrix.conf.distro }}
           run: |
-            set -x
+            set -xo pipefail
             apt-get update
-            apt-get install -y libpng-dev $(./scripts/list-build-dependencies.sh -c gcc -m apt)
+            apt-get install -y $(cat ./.github/packages/ubuntu-18.04-apt.txt)
             ./scripts/log-env.sh
-            ./scripts/build.sh -c gcc -t release -m lto --disable-fluidsynth
+            meson build -Duse_fluidsynth=false --wrap-mode=nofallback
+            ninja -C build |& tee build.log
+
 
       - name: Summarize warnings
         run:  ./scripts/count-warnings.py --max-warnings -1 build.log
@@ -69,7 +71,7 @@ jobs:
           set -x
 
           # Prepare content
-          install -DT        src/dosbox           dest/dosbox
+          install -DT        build/dosbox         dest/dosbox
           install -DT -m 644 docs/README.template dest/README
           install -DT -m 644 COPYING              dest/COPYING
           install -DT -m 644 README               dest/doc/manual.txt

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,9 @@ endif
 
 # gather data for config file
 #
+# Actual config.h file will be generated after all interpreting build files 
+# for all subdirs.
+#
 conf_data = configuration_data()
 conf_data.set('version', meson.project_version())
 conf_data.set10('C_MODEM', get_option('use_sdl2_net'))
@@ -28,6 +31,9 @@ conf_data.set10('C_IPX', get_option('use_sdl2_net'))
 conf_data.set10('C_OPENGL', get_option('use_opengl'))
 conf_data.set10('C_FLUIDSYNTH', get_option('use_fluidsynth'))
 conf_data.set10('C_SSHOT', get_option('use_png'))
+conf_data.set10('C_FPU', true)
+conf_data.set10('C_FPU_X86', (host_machine.cpu_family() == 'x86_64' or
+                              host_machine.cpu_family() == 'x86'))
 
 if cc.has_function('clock_gettime', prefix : '#include <time.h>')
   conf_data.set('DB_HAVE_CLOCK_GETTIME', true)
@@ -45,79 +51,9 @@ if get_option('enable_debugger') == 'heavy'
   conf_data.set10('C_HEAVY_DEBUG', true)
 endif
 
-# prepare configuration for dynrec core
-#
-# host_machine is a machine we're building for; meson reference:
-# https://mesonbuild.com/Reference-manual.html#host_machine-object
-# https://mesonbuild.com/Reference-tables.html#cpu-families
-#
-# In code we have code paths for two additional architectures:
-#
-# - ARMV4LE - autoconf used to set it when "armv6l" was reported, presumably
-#   it covers everything up to ARMv7.  Notably, Raspberry Pi 1 is using ARMv6.
-#   This arch was marked as NOT handling unaligned memory.
-# - MIPSEL - which used to be called MIPSEL32, and seems to be never hooked
-#   into the autoconf buildsystem (but it was used by several DOSBox ports)
-#
-selected_core = get_option('dynamic_core')
-host_cpu = host_machine.cpu_family()
-conf_data.set('C_TARGETCPU', 'UNKNOWN')
-cpu_handles_unaligned_memory = false
-
-core_selection = [
-  # cpu         selected_core       dynrec_define     C_TARGETCPU
-  [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86',  'X86_64'    ],
-  [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86',  'X86'       ],
-  [ 'x86_64',  ['dynrec'],          'C_DYNREC',       'X86_64'    ],
-  [ 'x86',     ['dynrec'],          'C_DYNREC',       'X86'       ],
-  [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',       'ARMV8LE'   ],
-  [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',       'ARMV7LE'   ],
-  [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',       'PPC64LE'   ], # stable name
-  [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',       'PPC64LE'   ], # unstable name
-  [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',       'POWERPC'   ],
-]
-
-foreach line : core_selection 
-  cpu = line[0]
-  opts_for_arch = line[1]
-  dynrec_define = line[2]
-  target_cpu = line[3]
-
-  if (host_cpu == cpu) and opts_for_arch.contains(selected_core)
-    conf_data.set('C_TARGETCPU', target_cpu)
-    conf_data.set(dynrec_define, 1)
-    cpu_handles_unaligned_memory = true
-  endif
-endforeach
-
-conf_data.set10('C_UNALIGNED_MEMORY', cpu_handles_unaligned_memory)
-
-target_cpu = conf_data.get('C_TARGETCPU')
-if conf_data.has('C_DYNAMIC_X86')
-  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) for ' + target_cpu)
-elif conf_data.has('C_DYNREC')
-  message('Building dynamic core (dynrec) for ' + target_cpu)
-else
-  warning('Building without dynamic core support')
-endif
-
 if host_machine.endian() == 'big'
   conf_data.set('WORDS_BIGENDIAN', 1)
-  message('Building for big-endian architecture')
-else
-  message('Building for little-endian architecture')
 endif
-
-# It might be a good idea to disable C_FPU when porting dynamic core to
-# a new hardware architecture.
-conf_data.set10('C_FPU', true)
-conf_data.set10('C_FPU_X86', (host_cpu == 'x86' or host_cpu == 'x86_64'))
-
-
-# generate config.h
-#
-configure_file(input : 'src/config.h.in', output : 'config.h',
-               configuration : conf_data)
 
 
 # external dependencies
@@ -197,6 +133,12 @@ subdir('src/ints')
 subdir('src/midi')
 subdir('src/misc')
 subdir('src/shell')
+
+
+# generate config.h
+#
+configure_file(input : 'src/config.h.in', output : 'config.h',
+               configuration : conf_data)
 
 
 # tests

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ if cxx.has_argument('-Wextra-semi')
 endif
 
 
-# config file
+# gather data for config file
 #
 conf_data = configuration_data()
 conf_data.set('version', meson.project_version())
@@ -45,6 +45,63 @@ if get_option('enable_debugger') == 'heavy'
   conf_data.set10('C_HEAVY_DEBUG', true)
 endif
 
+# prepare configuration for dynrec core
+#
+# host_machine is a machine we're building for
+#
+# In code we have code paths for two additional architectures:
+#
+# - ARMV4LE - autoconf used to set it when "armv6l" was reported, presumably
+#   it covers everything up to ARMv7.  Notably, Raspberry Pi 1 is using ARMv6.
+#   This arch was marked as NOT handling unaligned memory.
+# - MIPSEL - which used to be called MIPSEL32, and seems to be never hooked
+#   into the autoconf buildsystem (but it was used by several DOSBox ports)
+#
+selected_core = get_option('dynamic_core')
+host_cpu = host_machine.cpu_family()
+conf_data.set('C_TARGETCPU', 'UNKNOWN')
+cpu_handles_unaligned_memory = false
+
+core_selection = [
+  # cpu         selected_core       dynrec_define     C_TARGETCPU
+  [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86',  'X86_64'    ],
+  [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86',  'X86'       ],
+  [ 'x86_64',  ['dynrec'],          'C_DYNREC',       'X86_64'    ],
+  [ 'x86',     ['dynrec'],          'C_DYNREC',       'X86'       ],
+  [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',       'ARMV8LE'   ],
+  [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',       'ARMV7LE'   ],
+  [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',       'PPC64LE'   ], # stable name
+  [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',       'PPC64LE'   ], # unstable name
+  [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',       'POWERPC'   ],
+]
+
+foreach line : core_selection 
+  cpu = line[0]
+  opts_for_arch = line[1]
+  dynrec_define = line[2]
+  target_cpu = line[3]
+
+  if (host_cpu == cpu) and opts_for_arch.contains(selected_core)
+    conf_data.set('C_TARGETCPU', target_cpu)
+    conf_data.set(dynrec_define, 1)
+    cpu_handles_unaligned_memory = true
+  endif
+endforeach
+
+conf_data.set10('C_UNALIGNED_MEMORY', cpu_handles_unaligned_memory)
+
+target_cpu = conf_data.get('C_TARGETCPU')
+if conf_data.has('C_DYNAMIC_X86')
+  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) for ' + target_cpu)
+elif conf_data.has('C_DYNREC')
+  message('Building dynamic core (dynrec) for ' + target_cpu)
+else
+  warning('Building without dynamic core support')
+endif
+
+
+# generate config.h
+#
 configure_file(input : 'src/config.h.in', output : 'config.h',
                configuration : conf_data)
 

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,9 @@ endif
 
 # prepare configuration for dynrec core
 #
-# host_machine is a machine we're building for
+# host_machine is a machine we're building for; meson reference:
+# https://mesonbuild.com/Reference-manual.html#host_machine-object
+# https://mesonbuild.com/Reference-tables.html#cpu-families
 #
 # In code we have code paths for two additional architectures:
 #
@@ -97,6 +99,13 @@ elif conf_data.has('C_DYNREC')
   message('Building dynamic core (dynrec) for ' + target_cpu)
 else
   warning('Building without dynamic core support')
+endif
+
+if host_machine.endian() == 'big'
+  conf_data.set('WORDS_BIGENDIAN', 1)
+  message('Building for big-endian architecture')
+else
+  message('Building for little-endian architecture')
 endif
 
 

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,10 @@ if cc.has_function('clock_gettime', prefix : '#include <time.h>')
   conf_data.set('DB_HAVE_CLOCK_GETTIME', true)
 endif
 
+if cc.has_function('mprotect', prefix : '#include <sys/mman.h>')
+  conf_data.set('C_HAVE_MPROTECT', 1)
+endif
+
 if cc.has_member('struct dirent', 'd_type', prefix : '#include<dirent.h>')
   conf_data.set('DIRENT_HAS_D_TYPE', true)
 endif

--- a/meson.build
+++ b/meson.build
@@ -108,6 +108,11 @@ else
   message('Building for little-endian architecture')
 endif
 
+# It might be a good idea to disable C_FPU when porting dynamic core to
+# a new hardware architecture.
+conf_data.set10('C_FPU', true)
+conf_data.set10('C_FPU_X86', (host_cpu == 'x86' or host_cpu == 'x86_64'))
+
 
 # generate config.h
 #

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,11 @@ if host_machine.endian() == 'big'
   conf_data.set('WORDS_BIGENDIAN', 1)
 endif
 
+# Non-4K memory page size is supported only for ppc64 at the moment.
+if host_machine.cpu_family() == 'ppc64' or host_machine.cpu_family() == 'ppc64le'
+  conf_data.set('PAGESIZE', 65536)
+endif
+
 
 # external dependencies
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,3 +28,9 @@ option('enable_debugger',
        choices : ['normal', 'heavy', 'none'],
        value : 'none',
        description : 'Build emulator with internal debugger feature.')
+
+option('dynamic_core',
+       type : 'combo',
+       choices : ['auto', 'dyn-x86', 'dynrec', 'none'],
+       value : 'auto',
+       description : 'Select the dynamic core implementation.')

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -105,7 +105,8 @@
 // TODO: move this to compiler.h MSVC: #define INLINE __forceinline
 #define INLINE inline __attribute__((always_inline))
 
-/* Quirks and toggles for standard headers, libraries, and other stuff
+/* Quirks and toggles for standard headers, libraries, hardware-related
+ * defines, etc.
  *
  * Sometimes available functions, structs, or struct fields differ slightly
  * between operating systems.
@@ -123,5 +124,8 @@
 
 // Define to 1 when host/target processor uses big endian byte ordering
 #mesondefine WORDS_BIGENDIAN
+
+// Non-4K page size (only on selected architectures)
+#mesondefine PAGESIZE
 
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -105,7 +105,7 @@
 // TODO: move this to compiler.h MSVC: #define INLINE __forceinline
 #define INLINE inline __attribute__((always_inline))
 
-/* Quirks and toggles for standard headers and libraries
+/* Quirks and toggles for standard headers, libraries, and other stuff
  *
  * Sometimes available functions, structs, or struct fields differ slightly
  * between operating systems.
@@ -120,5 +120,8 @@
 
 // TODO: generate; Define to 1 if you have the mprotect function
 #define C_HAVE_MPROTECT 1
+
+// Define to 1 when host/target processor uses big endian byte ordering
+#mesondefine WORDS_BIGENDIAN
 
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -35,20 +35,25 @@
  * These defines are mostly relevant to modules src/cpu/ and src/fpu/
  */
 
-// TODO The type of cpu this target has
-#define C_TARGETCPU X86_64
+// The type of cpu this target has
+#mesondefine C_TARGETCPU
 
-// TODO Define to 1 if target CPU supports unaligned memory access
-#define C_UNALIGNED_MEMORY 1
+// Define to 1 if target CPU supports unaligned memory access
+#mesondefine C_UNALIGNED_MEMORY
 
-// TODO Define to 1 to use x86/x64 dynamic cpu core
-#define C_DYNAMIC_X86 1
+// Define to 1 to use x86/x86_64 dynamic cpu core
+// Can not be used together with C_DYNREC
+#mesondefine C_DYNAMIC_X86
+
+// Define to 1 to use recompiling cpu core
+// Can not be used together with C_DYNAMIC_X86
+#mesondefine C_DYNREC
 
 // TODO Define to 1 to enable floating point emulation
 #define C_FPU 1
 
 // TODO Define to 1 to use a x86/x64 assembly fpu core
-#define C_FPU_X86 1
+#define C_FPU_X86 0
 
 // TODO Define to 1 to use inlined memory functions in cpu core
 #define C_CORE_INLINE 1

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2020  The dosbox-staging team
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -119,8 +119,8 @@
 // Some OSes do not implement it (e.g. Haiku)
 #mesondefine DIRENT_HAS_D_TYPE
 
-// TODO: generate; Define to 1 if you have the mprotect function
-#define C_HAVE_MPROTECT 1
+// Define to 1 when you have the mprotect function
+#mesondefine C_HAVE_MPROTECT
 
 // Define to 1 when host/target processor uses big endian byte ordering
 #mesondefine WORDS_BIGENDIAN

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -49,11 +49,11 @@
 // Can not be used together with C_DYNAMIC_X86
 #mesondefine C_DYNREC
 
-// TODO Define to 1 to enable floating point emulation
-#define C_FPU 1
+// Define to 1 to enable floating point emulation
+#mesondefine C_FPU
 
-// TODO Define to 1 to use a x86/x64 assembly fpu core
-#define C_FPU_X86 0
+// Define to 1 to use  fpu core implemented in x86 assembler
+#mesondefine C_FPU_X86
 
 // TODO Define to 1 to use inlined memory functions in cpu core
 #define C_CORE_INLINE 1

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -4,28 +4,22 @@
 # https://mesonbuild.com/Reference-manual.html#host_machine-object
 # https://mesonbuild.com/Reference-tables.html#cpu-families
 #
-# In code we have code paths for two additional architectures:
-#
-# - ARMV4LE - autoconf used to set it when "armv6l" was reported, presumably
-#   it covers everything up to ARMv7.  Notably, Raspberry Pi 1 is using ARMv6.
-#   This arch was marked as NOT handling unaligned memory.
-# - MIPSEL - which used to be called MIPSEL32, and seems to be never hooked
-#   into the autoconf buildsystem (but it was used by several DOSBox ports)
-#
 conf_data.set('C_TARGETCPU', 'UNKNOWN')
 conf_data.set('C_UNALIGNED_MEMORY', 0)
 
 core_selection = [
-  # cpu_family selected_core        dynrec_define    target     unaligned_mem
+#   cpu_family selected_core        dynrec_define    target     unaligned_mem
   [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64',  1 ],
   [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86',     1 ],
   [ 'x86_64',  ['dynrec'],          'C_DYNREC',      'X86_64',  1 ],
   [ 'x86',     ['dynrec'],          'C_DYNREC',      'X86',     1 ],
   [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1 ],
   [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1 ],
+# [  ???       ['auto', 'dynrec'],  'C_DYNREC',      'ARMV4LE', 0 ], # ARMv6 or older (?)
   [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1 ],
   [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1 ], # for meson < 0.50
   [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1 ],
+# [ 'mips',    ['auto', 'dynrec'],  'C_DYNREC',      'MIPSEL',  ? ], # disabled in old buildsystem, but code is still there
 ]
 
 selected_core = get_option('dynamic_core')

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -1,3 +1,63 @@
+# prepare configuration for dynrec core
+#
+# host_machine is a machine we're building for; meson reference:
+# https://mesonbuild.com/Reference-manual.html#host_machine-object
+# https://mesonbuild.com/Reference-tables.html#cpu-families
+#
+# In code we have code paths for two additional architectures:
+#
+# - ARMV4LE - autoconf used to set it when "armv6l" was reported, presumably
+#   it covers everything up to ARMv7.  Notably, Raspberry Pi 1 is using ARMv6.
+#   This arch was marked as NOT handling unaligned memory.
+# - MIPSEL - which used to be called MIPSEL32, and seems to be never hooked
+#   into the autoconf buildsystem (but it was used by several DOSBox ports)
+#
+selected_core = get_option('dynamic_core')
+conf_data.set('C_TARGETCPU', 'UNKNOWN')
+cpu_handles_unaligned_memory = false
+
+core_selection = [
+  # cpu_family selected_core        dynrec_define    target_cpu
+  [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64'    ],
+  [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86'       ],
+  [ 'x86_64',  ['dynrec'],          'C_DYNREC',      'X86_64'    ],
+  [ 'x86',     ['dynrec'],          'C_DYNREC',      'X86'       ],
+  [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE'   ],
+  [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE'   ],
+  [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE'   ],
+  [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE'   ], # for meson < 0.50
+  [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC'   ],
+]
+
+foreach line : core_selection 
+  cpu = line[0]
+  opts_for_arch = line[1]
+  dynrec_define = line[2]
+  target_cpu = line[3]
+
+  if (host_machine.cpu_family() == cpu) and opts_for_arch.contains(selected_core)
+    conf_data.set('C_TARGETCPU', target_cpu)
+    conf_data.set(dynrec_define, 1)
+    cpu_handles_unaligned_memory = true
+  endif
+endforeach
+
+conf_data.set10('C_UNALIGNED_MEMORY', cpu_handles_unaligned_memory)
+
+target_cpu = conf_data.get('C_TARGETCPU')
+if conf_data.has('C_DYNAMIC_X86')
+  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) for ' + target_cpu)
+elif conf_data.has('C_DYNREC')
+  message('Building dynamic core (dynrec) for ' + target_cpu)
+else
+  warning('Building without dynamic core support')
+endif
+
+message('Building for @0@-endian architecture'.format(host_machine.endian()))
+
+
+# cpu module sources
+#
 libcpu_sources = files([
   'callback.cpp',
   'core_normal.cpp',

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -12,37 +12,36 @@
 # - MIPSEL - which used to be called MIPSEL32, and seems to be never hooked
 #   into the autoconf buildsystem (but it was used by several DOSBox ports)
 #
-selected_core = get_option('dynamic_core')
 conf_data.set('C_TARGETCPU', 'UNKNOWN')
-cpu_handles_unaligned_memory = false
+conf_data.set('C_UNALIGNED_MEMORY', 0)
 
 core_selection = [
-  # cpu_family selected_core        dynrec_define    target_cpu
-  [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64'    ],
-  [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86'       ],
-  [ 'x86_64',  ['dynrec'],          'C_DYNREC',      'X86_64'    ],
-  [ 'x86',     ['dynrec'],          'C_DYNREC',      'X86'       ],
-  [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE'   ],
-  [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE'   ],
-  [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE'   ],
-  [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE'   ], # for meson < 0.50
-  [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC'   ],
+  # cpu_family selected_core        dynrec_define    target     unaligned_mem
+  [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64',  1 ],
+  [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86',     1 ],
+  [ 'x86_64',  ['dynrec'],          'C_DYNREC',      'X86_64',  1 ],
+  [ 'x86',     ['dynrec'],          'C_DYNREC',      'X86',     1 ],
+  [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1 ],
+  [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1 ],
+  [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1 ],
+  [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1 ], # for meson < 0.50
+  [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1 ],
 ]
 
+selected_core = get_option('dynamic_core')
+
 foreach line : core_selection 
-  cpu = line[0]
+  cpu_family    = line[0]
   opts_for_arch = line[1]
   dynrec_define = line[2]
-  target_cpu = line[3]
-
-  if (host_machine.cpu_family() == cpu) and opts_for_arch.contains(selected_core)
+  target_cpu    = line[3]
+  unaligned_mem = line[4]
+  if (host_machine.cpu_family() == cpu_family) and opts_for_arch.contains(selected_core)
     conf_data.set('C_TARGETCPU', target_cpu)
+    conf_data.set('C_UNALIGNED_MEMORY', unaligned_mem)
     conf_data.set(dynrec_define, 1)
-    cpu_handles_unaligned_memory = true
   endif
 endforeach
-
-conf_data.set10('C_UNALIGNED_MEMORY', cpu_handles_unaligned_memory)
 
 target_cpu = conf_data.get('C_TARGETCPU')
 if conf_data.has('C_DYNAMIC_X86')

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -37,11 +37,12 @@ foreach line : core_selection
   endif
 endforeach
 
-target_cpu = conf_data.get('C_TARGETCPU')
 if conf_data.has('C_DYNAMIC_X86')
-  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) for ' + target_cpu)
+  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) ' +
+          'for ' + conf_data.get('C_TARGETCPU'))
 elif conf_data.has('C_DYNREC')
-  message('Building dynamic core (dynrec) for ' + target_cpu)
+  message('Building dynamic core (dynrec) ' +
+          'for ' + conf_data.get('C_TARGETCPU'))
 else
   warning('Building without dynamic core support')
 endif


### PR DESCRIPTION
I was testing platform builds - s390x and PPC64LE build fine, but ARM builds fail for some reason I do not understand yet… I don't know if it was autoconf doing something special or build.sh script.