### PR TITLE
Add handling for Early Init Config sections

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -43,7 +43,6 @@ public:
 	CommandLine * cmdline;
 private:
 	std::deque<Section*> sectionlist;
-	typedef std::deque<Section*>::iterator it;
 	typedef std::deque<Section*>::const_iterator const_it;
 	void (* _start_function)(void);
 	bool secure_mode; //Sandbox mode
@@ -79,7 +78,9 @@ public:
 	                              SectionFunction func,
 	                              bool changeable_at_runtime = false);
 
-	Section *GetSection(int index);
+	auto begin() { return sectionlist.begin(); }
+	auto end() { return sectionlist.end(); }
+
 	Section *GetSection(std::string const &_sectionname) const;
 	Section* GetSectionFromProperty(char const * const prop) const;
 

--- a/include/control.h
+++ b/include/control.h
@@ -43,7 +43,6 @@ public:
 	CommandLine * cmdline;
 private:
 	std::deque<Section*> sectionlist;
-	typedef std::deque<Section*>::const_iterator const_it;
 	void (* _start_function)(void);
 	bool secure_mode; //Sandbox mode
 public:
@@ -81,8 +80,8 @@ public:
 	auto begin() { return sectionlist.begin(); }
 	auto end() { return sectionlist.end(); }
 
-	Section *GetSection(std::string const &_sectionname) const;
-	Section* GetSectionFromProperty(char const * const prop) const;
+	Section *GetSection(const std::string &section_name) const;
+	Section *GetSectionFromProperty(const char *prop) const;
 
 	void SetStartUp(void (*_function)(void));
 	void Init() const;

--- a/include/control.h
+++ b/include/control.h
@@ -44,7 +44,6 @@ public:
 private:
 	std::deque<Section*> sectionlist;
 	typedef std::deque<Section*>::iterator it;
-	typedef std::deque<Section*>::reverse_iterator reverse_it;
 	typedef std::deque<Section*>::const_iterator const_it;
 	void (* _start_function)(void);
 	bool secure_mode; //Sandbox mode

--- a/include/control.h
+++ b/include/control.h
@@ -22,7 +22,7 @@
 #include "dosbox.h"
 
 #include <cassert>
-#include <list>
+#include <deque>
 #include <string>
 #include <vector>
 
@@ -41,11 +41,11 @@ class Config {
 public:
 	CommandLine * cmdline;
 private:
-	std::list<Section*> sectionlist;
-	typedef std::list<Section*>::iterator it;
-	typedef std::list<Section*>::reverse_iterator reverse_it;
-	typedef std::list<Section*>::const_iterator const_it;
-	typedef std::list<Section*>::const_reverse_iterator const_reverse_it;
+	std::deque<Section*> sectionlist;
+	typedef std::deque<Section*>::iterator it;
+	typedef std::deque<Section*>::reverse_iterator reverse_it;
+	typedef std::deque<Section*>::const_iterator const_it;
+	typedef std::deque<Section*>::const_reverse_iterator const_reverse_it;
 	void (* _start_function)(void);
 	bool secure_mode; //Sandbox mode
 public:

--- a/include/control.h
+++ b/include/control.h
@@ -46,7 +46,6 @@ private:
 	typedef std::deque<Section*>::iterator it;
 	typedef std::deque<Section*>::reverse_iterator reverse_it;
 	typedef std::deque<Section*>::const_iterator const_it;
-	typedef std::deque<Section*>::const_reverse_iterator const_reverse_it;
 	void (* _start_function)(void);
 	bool secure_mode; //Sandbox mode
 public:

--- a/include/control.h
+++ b/include/control.h
@@ -70,10 +70,12 @@ public:
 
 	~Config();
 
-	Section_line * AddSection_line(char const * const _name,void (*_initfunction)(Section*));
-	Section_prop * AddSection_prop(char const * const _name,void (*_initfunction)(Section*),bool canchange=false);
-	
-	Section* GetSection(int index);
+	Section_line *AddSection_line(char const *const _name, SectionFunction func);
+
+	Section_prop *AddSection_prop(char const *const _name,
+	                              SectionFunction func,
+	                              bool canchange = false);
+	Section *GetSection(int index);
 	Section* GetSection(std::string const&_sectionname) const;
 	Section* GetSectionFromProperty(char const * const prop) const;
 

--- a/include/control.h
+++ b/include/control.h
@@ -23,6 +23,7 @@
 
 #include <cassert>
 #include <deque>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -70,17 +71,22 @@ public:
 
 	~Config();
 
+	Section_prop *AddEarlySectionProp(const char *name,
+	                                  SectionFunction func,
+	                                  bool changeable_at_runtime = false);
+
 	Section_line *AddSection_line(char const *const _name, SectionFunction func);
 
 	Section_prop *AddSection_prop(char const *const _name,
 	                              SectionFunction func,
-	                              bool canchange = false);
+	                              bool changeable_at_runtime = false);
+
 	Section *GetSection(int index);
-	Section* GetSection(std::string const&_sectionname) const;
+	Section *GetSection(std::string const &_sectionname) const;
 	Section* GetSectionFromProperty(char const * const prop) const;
 
 	void SetStartUp(void (*_function)(void));
-	void Init();
+	void Init() const;
 	void ShutDown();
 	void StartUp();
 	bool PrintConfig(const std::string &filename) const;

--- a/include/setup.h
+++ b/include/setup.h
@@ -290,14 +290,15 @@ typedef void (*SectionFunction)(Section *);
 class Section {
 private:
 	/* Wrapper class around startup and shutdown functions. the variable
-	 * canchange indicates it can be called on configuration changes */
+	 * changeable_at_runtime indicates it can be called on configuration
+	 * changes */
 	struct Function_wrapper {
 		SectionFunction function;
-		bool canchange;
+		bool changeable_at_runtime;
 
 		Function_wrapper(SectionFunction const fn, bool ch)
 		        : function(fn),
-		          canchange(ch)
+		          changeable_at_runtime(ch)
 		{}
 	};
 
@@ -310,9 +311,11 @@ public:
 
 	virtual ~Section() = default; // Children must call executedestroy!
 
-	void AddEarlyInitFunction(SectionFunction func, bool canchange = false);
-	void AddInitFunction(SectionFunction func, bool canchange = false);
-	void AddDestroyFunction(SectionFunction func, bool canchange = false);
+	void AddEarlyInitFunction(SectionFunction func,
+	                          bool changeable_at_runtime = false);
+	void AddInitFunction(SectionFunction func, bool changeable_at_runtime = false);
+	void AddDestroyFunction(SectionFunction func,
+	                        bool changeable_at_runtime = false);
 
 	void ExecuteEarlyInit(bool initall = true);
 	void ExecuteInit(bool initall=true);

--- a/include/setup.h
+++ b/include/setup.h
@@ -23,7 +23,7 @@
 #define DOSBOX_SETUP_H
 
 #include <cstdio>
-#include <list>
+#include <deque>
 #include <memory>
 #include <string>
 #include <vector>
@@ -301,8 +301,8 @@ private:
 		{}
 	};
 
-	std::list<Function_wrapper> initfunctions = {};
-	std::list<Function_wrapper> destroyfunctions = {};
+	std::deque<Function_wrapper> initfunctions = {};
+	std::deque<Function_wrapper> destroyfunctions = {};
 	std::string sectionname;
 public:
 	Section(const std::string &name) : sectionname(name) {}
@@ -325,9 +325,9 @@ class Prop_multival_remain;
 
 class Section_prop : public Section {
 private:
-	std::list<Property *> properties = {};
-	typedef std::list<Property*>::iterator it;
-	typedef std::list<Property*>::const_iterator const_it;
+	std::deque<Property *> properties = {};
+	typedef std::deque<Property*>::iterator it;
+	typedef std::deque<Property*>::const_iterator const_it;
 
 public:
 	Section_prop(const std::string &name) : Section(name) {}

--- a/include/setup.h
+++ b/include/setup.h
@@ -301,6 +301,7 @@ private:
 		{}
 	};
 
+	std::deque<Function_wrapper> early_init_functions = {};
 	std::deque<Function_wrapper> initfunctions = {};
 	std::deque<Function_wrapper> destroyfunctions = {};
 	std::string sectionname;
@@ -309,8 +310,11 @@ public:
 
 	virtual ~Section() = default; // Children must call executedestroy!
 
+	void AddEarlyInitFunction(SectionFunction func, bool canchange = false);
 	void AddInitFunction(SectionFunction func, bool canchange = false);
 	void AddDestroyFunction(SectionFunction func, bool canchange = false);
+
+	void ExecuteEarlyInit(bool initall = true);
 	void ExecuteInit(bool initall=true);
 	void ExecuteDestroy(bool destroyall=true);
 	const char* GetName() const {return sectionname.c_str();}

--- a/include/setup.h
+++ b/include/setup.h
@@ -285,10 +285,10 @@ public:
 
 #define NO_SUCH_PROPERTY "PROP_NOT_EXIST"
 
+typedef void (*SectionFunction)(Section *);
+
 class Section {
 private:
-	typedef void (*SectionFunction)(Section*);
-
 	/* Wrapper class around startup and shutdown functions. the variable
 	 * canchange indicates it can be called on configuration changes */
 	struct Function_wrapper {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -453,10 +453,7 @@ void CONFIG::Run(void) {
 				if (!strcasecmp("sections",pvars[0].c_str())) {
 					// list the sections
 					WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_SECTLIST"));
-					Bitu i = 0;
-					while (true) {
-						Section* sec = control->GetSection(i++);
-						if (!sec) break;
+					for (const Section *sec : *control) {
 						WriteOut("%s\n",sec->GetName());
 					}
 					return;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -27,7 +27,7 @@
 #include <fstream>
 #include <string>
 #include <sstream>
-#include <list>
+#include <deque>
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits>
@@ -863,14 +863,14 @@ void Section::AddDestroyFunction(SectionFunction func, bool canchange)
 }
 
 void Section::ExecuteInit(bool initall) {
-	typedef std::list<Function_wrapper>::iterator func_it;
+	typedef std::deque<Function_wrapper>::iterator func_it;
 	for (func_it tel = initfunctions.begin(); tel != initfunctions.end(); ++tel) {
 		if (initall || (*tel).canchange) (*tel).function(this);
 	}
 }
 
 void Section::ExecuteDestroy(bool destroyall) {
-	typedef std::list<Function_wrapper>::iterator func_it;
+	typedef std::deque<Function_wrapper>::iterator func_it;
 	for (func_it tel = destroyfunctions.begin(); tel != destroyfunctions.end(); ) {
 		if (destroyall || (*tel).canchange) {
 			(*tel).function(this);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -822,9 +822,12 @@ bool Config::PrintConfig(const std::string &filename) const
 	return true;
 }
 
-Section_prop* Config::AddSection_prop(char const * const _name,void (*_initfunction)(Section*),bool canchange) {
-	Section_prop* blah = new Section_prop(_name);
-	blah->AddInitFunction(_initfunction,canchange);
+Section_prop *Config::AddSection_prop(char const *const _name,
+                                      SectionFunction func,
+                                      bool canchange)
+{
+	Section_prop *blah = new Section_prop(_name);
+	blah->AddInitFunction(func, canchange);
 	sectionlist.push_back(blah);
 	return blah;
 }
@@ -838,13 +841,13 @@ Section_prop::~Section_prop()
 		delete (*prop);
 }
 
-Section_line* Config::AddSection_line(char const * const _name,void (*_initfunction)(Section*)) {
+Section_line *Config::AddSection_line(char const *const _name, SectionFunction func)
+{
 	Section_line* blah = new Section_line(_name);
-	blah->AddInitFunction(_initfunction);
+	blah->AddInitFunction(func);
 	sectionlist.push_back(blah);
 	return blah;
 }
-
 
 void Config::Init() {
 	for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); ++tel) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -853,6 +853,10 @@ void Config::Init() {
 	for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); ++tel) {
 		(*tel)->ExecuteInit();
 	}
+
+void Section::AddEarlyInitFunction(SectionFunction func, bool canchange)
+{
+	early_init_functions.emplace_back(func, canchange);
 }
 
 void Section::AddInitFunction(SectionFunction func, bool canchange)
@@ -863,6 +867,13 @@ void Section::AddInitFunction(SectionFunction func, bool canchange)
 void Section::AddDestroyFunction(SectionFunction func, bool canchange)
 {
 	destroyfunctions.emplace_front(func, canchange);
+}
+
+void Section::ExecuteEarlyInit(bool init_all)
+{
+	for (const auto &fn : early_init_functions)
+		if (init_all || fn.canchange)
+			fn.function(this);
 }
 
 void Section::ExecuteInit(bool initall) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -749,7 +749,7 @@ bool Config::PrintConfig(const std::string &filename) const
 	fprintf(outfile, MSG_Get("CONFIGFILE_INTRO"), VERSION);
 	fprintf(outfile, "\n");
 
-	for (const_it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel){
+	for (auto tel = sectionlist.cbegin(); tel != sectionlist.cend(); ++tel) {
 		/* Print out the Section header */
 		safe_strcpy(temp, (*tel)->GetName());
 		lowcase(temp);
@@ -915,18 +915,22 @@ Config::~Config()
 		delete (*cnt);
 }
 
-Section* Config::GetSection(string const& _sectionname) const {
-	for (const_it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel){
-		if (!strcasecmp((*tel)->GetName(),_sectionname.c_str())) return (*tel);
+Section *Config::GetSection(const std::string &section_name) const
+{
+	for (auto *el : sectionlist) {
+		if (!strcasecmp(el->GetName(), section_name.c_str()))
+			return el;
 	}
-	return NULL;
+	return nullptr;
 }
 
-Section* Config::GetSectionFromProperty(char const * const prop) const {
-   	for (const_it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel){
-		if ((*tel)->GetPropValue(prop) != NO_SUCH_PROPERTY) return (*tel);
+Section *Config::GetSectionFromProperty(const char *prop) const
+{
+	for (auto *el : sectionlist) {
+		if (el->GetPropValue(prop) != NO_SUCH_PROPERTY)
+			return el;
 	}
-	return NULL;
+	return nullptr;
 }
 
 bool Config::ParseConfigFile(char const * const configfilename) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -915,13 +915,6 @@ Config::~Config()
 		delete (*cnt);
 }
 
-Section* Config::GetSection(int index) {
-	for (it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel){
-		if (!index--) return (*tel);
-	}
-	return NULL;
-}
-
 Section* Config::GetSection(string const& _sectionname) const {
 	for (const_it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel){
 		if (!strcasecmp((*tel)->GetName(),_sectionname.c_str())) return (*tel);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -909,12 +909,10 @@ void Section::ExecuteDestroy(bool destroyall) {
 	}
 }
 
-Config::~Config() {
-	reverse_it cnt = sectionlist.rbegin();
-	while (cnt != sectionlist.rend()) {
+Config::~Config()
+{
+	for (auto cnt = sectionlist.rbegin(); cnt != sectionlist.rend(); ++cnt)
 		delete (*cnt);
-		cnt++;
-	}
 }
 
 Section* Config::GetSection(int index) {


### PR DESCRIPTION
The **Section** class currently has `Init` and `Destroy` function lists. On startup, DOSBox preps and parses the config file, gathers the user settings, and then executes all the registered `Init` functions.

This PR adds an `Early Init` category that's performed serially before `Init`, the latter which includes heavy tasks like SDL creating the graphical frame, setting up the rendering backend and audio, as well as showing the splash screen. 

**Context:** this somewhat abstract PR gives us a simple and generalized design to do any kind of work prior to the heavier startup routines and splash wait-period. 

Our most immediate need is initiating the soundfont loading once the config file has been parsed (and in parallel to the start up activities),  which could have been solved with some uglier hacks, but this is more elegant and usable for any other similar needs.