### PR TITLE
Manage the MIDI handlers and fix their startup sequence

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -596,6 +596,13 @@ void DOSBOX_Init(void) {
 	Pint->SetMinMax(0,100);
 	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
 
+// Registered MIDI handlers before running MIDI_Init(), which queries them.
+#if C_FLUIDSYNTH
+	FLUID_AddConfigSection(control); // a MIDI handler
+#endif
+#if C_MT32EMU
+	MT32_AddConfigSection(control); // a MIDI handler
+#endif
 	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init, true);
 
@@ -668,14 +675,6 @@ void DOSBOX_Init(void) {
 	const char *mputypes[] = {"intelligent", "uart", "none", 0};
 	pstring->Set_values(mputypes);
 	pstring->Set_help("Type of MPU-401 to emulate.");
-
-#if C_FLUIDSYNTH
-	FLUID_AddConfigSection(control);
-#endif
-
-#if C_MT32EMU
-	MT32_AddConfigSection(control);
-#endif
 
 #if C_DEBUG
 	secprop=control->AddSection_prop("debug",&DEBUG_Init);

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -33,8 +33,6 @@
 #include "cross.h"
 #include "fs_utils.h"
 
-MidiHandlerFluidsynth instance;
-
 static void init_fluid_dosbox_settings(Section_prop &secprop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
@@ -363,13 +361,20 @@ void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
 	}
 }
 
+static std::unique_ptr<MidiHandlerFluidsynth> fluidsynth_instance;
+
 static void fluid_destroy(MAYBE_UNUSED Section *sec)
 {
-	instance.PrintStats();
+	if (!fluidsynth_instance)
+		return;
+	
+	fluidsynth_instance->PrintStats();
+	fluidsynth_instance.reset();
 }
 
 static void fluid_init(Section *sec)
 {
+	fluidsynth_instance = std::make_unique<MidiHandlerFluidsynth>();
 	sec->AddDestroyFunction(&fluid_destroy, true);
 }
 


### PR DESCRIPTION
When I attempted to manage FluidSynth and MT32 using `std::unique_ptr`, I noticed the MIDI handler couldn't find them despite being compiled it. 
 - `MIDI: No working MIDI device found/selected.`

This is because the FluidSynth and MT32 devices were being registered after the MIDI handler, and therefore their named weren't known to the handler when it was initialized.

The first commit fixes that ordering, followed by transitioning the FS and MT32 instances to managed objects.  This allows the user to flip between devices with strong guanratees of prior MIDI cleanup (synth object, SF2/ROM memory, and even mixer channel clean up).

``` text
config -set mididevice=mt32
run gameA

config -set mididevice=fluidsynth
run gameB

config -set mididevice=none
run gameC
```

Behind the scenes, we see the construction and destruction in action:

``` text
MIXER: MT32 channel operating at 48000 Hz without resampling
MIDI: Opened device: mt32

MIXER: FSYNTH channel operating at 48000 Hz without resampling
MIDI: Using SoundFont '../midi/SGM.sf2'
MIDI: Opened device: fluidsynth

MIDI: Opened device: none
```

We can also see that their mixer channels are torn down, so avoids processing an empty feed of 88200 (or 96000) samples every second:

![2021-01-06_17-34](https://user-images.githubusercontent.com/1557255/103840459-73765600-5046-11eb-8f8f-90a3a0ea4c86.png)
