### PR TITLE
Update GCC UASAN allowed warnings limits

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -105,7 +105,7 @@ jobs:
             sanitizers: TSAN UASAN
             usan:  -1
             tsan:  0  # our test does not trigger multiple threads yet
-            uasan: 14
+            uasan: 15
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update


### PR DESCRIPTION
This bump is needed because the latest GCC and/or USAN output includes a new heading line, which is picked up by the warning counter.

The actual leaks detected has not changed, if a comparison is made against a current `master` build.

Both report: `SUMMARY: AddressSanitizer: 17426 byte(s) leaked in 104 allocation(s).`