### PR TITLE
Improve use of GCC sanitizers in CI runs

### DIFF
--- a/.github/scripts/build-and-run-sanitizers.sh
+++ b/.github/scripts/build-and-run-sanitizers.sh
@@ -35,6 +35,9 @@ cd "$(dirname "${0}")/../.."
 # Make a directory to hold our build and run output
 mkdir -p "${logs}"
 
+# SAN-specific environment variables
+export LSAN_OPTIONS="suppressions=.lsan-suppress:verbosity=0"
+
 for sanitizer in "${sanitizers[@]}"; do
 
 	# Build DOSBox for each sanitizer
@@ -47,7 +50,7 @@ for sanitizer in "${sanitizers[@]}"; do
 	# Exercise the testcase(s) for each sanitizer
 	# Sanitizers return non-zero if one or more issues were found,
 	# so we or-to-true to ensure our script doesn't end here.
-	time xvfb-run ./src/dosbox -c exit \
+	time xvfb-run ./src/dosbox -c "autotype -w 0.1 e x i t enter" \
 		&> "${logs}/${compiler}-${sanitizer}-EnterExit.log" || true
 
 done

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -99,12 +99,11 @@ jobs:
           - name: Clang
             sanitizers: USAN
             usan:  0  # cleared out in our existing tests
-            tsan:  -1
             uasan: -1
           - name: GCC
-            sanitizers: TSAN UASAN
+            # TSAN excluded, harness segfaults inside virual-X11 environment
+            sanitizers: UASAN
             usan:  -1
-            tsan:  0  # our test does not trigger multiple threads yet
             uasan: 15
     steps:
       - uses: actions/checkout@v2
@@ -150,7 +149,6 @@ jobs:
       - name: Summarize issues
         env:
           USAN_LOG:  ${{ matrix.conf.name }}-logs/${{ matrix.conf.name }}-USAN-EnterExit.log.xz
-          TSAN_LOG:  ${{ matrix.conf.name }}-logs/${{ matrix.conf.name }}-TSAN-EnterExit.log.xz
           UASAN_LOG: ${{ matrix.conf.name }}-logs/${{ matrix.conf.name }}-UASAN-EnterExit.log.xz
         run: |
           # summary
@@ -163,12 +161,6 @@ jobs:
             echo_bold "Undefined Behaviour sanitizer:"
             echo
             xzcat "$USAN_LOG" | MAX_ISSUES=${{ matrix.conf.usan }} ./scripts/count-xsan-issues.py -
-          fi
-
-          if [[ -f "$TSAN_LOG" ]] ; then
-            echo_bold "Thread sanitizer:"
-            echo
-            xzcat "$TSAN_LOG" | MAX_ISSUES=${{ matrix.conf.tsan }} ./scripts/count-xsan-issues.py -
           fi
 
           if [[ -f "$UASAN_LOG" ]] ; then

--- a/.lsan-suppress
+++ b/.lsan-suppress
@@ -1,0 +1,2 @@
+leak:/usr/lib/x86_64-linux-gnu/dri
+leak:/lib/x86_64-linux-gnu


### PR DESCRIPTION
Previously leaks reported from system libraries could pollute our results and add to the leak tally.  We're not in the business of fixing system libraries, so the best option we have is to suppress these.

The first commit also does a better job at letting DOSBox actually come to life before exiting. This is done using AUTOTYPE instead of the `-c exit` command (which quit before allowing a full startup).

The second commit remove the thread sanitizer, but only for CI runs.  Unfortunately getting meaningful results from it within a GUI-less CI environment is currently not possible.  Perhaps we will have better luck running it on macOS or Windows, as those VM's have more realistic GUI heads (despite being VMs) versus Ubuntu where we rely on the virtual frame-buffer.

See further explanation in the second commit message.