### PR TITLE
Rote memory leak and shutdown cleanups

### DIFF
--- a/include/serialport.h
+++ b/include/serialport.h
@@ -49,7 +49,7 @@
 #endif
 
 // Serial port interface
-
+#define SERIAL_IO_HANDLERS 8
 #define SERIAL_MAX_FIFO_SIZE 256
 /* Note: Almost all DOS-era universal asynchronous receiver-transmitter
  *       (UART)'s permitted up to a 16-byte receive and transmit
@@ -173,8 +173,8 @@ public:
 	CSerial(const uint8_t port_idx, CommandLine *cmd);
 	virtual ~CSerial();
 
-	IO_ReadHandleObject ReadHandler[8];
-	IO_WriteHandleObject WriteHandler[8];
+	IO_ReadHandleObject ReadHandler[SERIAL_IO_HANDLERS];
+	IO_WriteHandleObject WriteHandler[SERIAL_IO_HANDLERS];
 
 	float bytetime = 0.0f; // how long a byte takes to transmit/receive in
 	                       // milliseconds

--- a/include/shell.h
+++ b/include/shell.h
@@ -49,30 +49,31 @@ public:
 	virtual bool ReadLine(char * line);
 	bool Goto(char * where);
 	void Shift(void);
-	Bit16u file_handle;
-	Bit32u location;
-	bool echo;
-	DOS_Shell * shell;
-	BatchFile * prev;
-	CommandLine * cmd;
-	std::string filename;
+	uint16_t file_handle = 0;
+	uint32_t location = 0;
+	bool echo = false;
+	DOS_Shell *shell = nullptr;
+	BatchFile *prev = nullptr;
+	CommandLine *cmd = nullptr;
+	std::string filename{};
 };
 
 class AutoexecEditor;
 class DOS_Shell : public Program {
 private:
 	friend class AutoexecEditor;
-	std::list<std::string> l_history, l_completion;
+	std::list<std::string> l_history{};
+	std::list<std::string> l_completion{};
 
-	char *completion_start;
-	Bit16u completion_index;
-	
+	char *completion_start = nullptr;
+	uint16_t completion_index = 0;
+
 public:
 
 	DOS_Shell();
 	DOS_Shell(const DOS_Shell&) = delete; // prevent copy
 	DOS_Shell& operator=(const DOS_Shell&) = delete; // prevent assignment
-	void Run(void);
+	void Run() override;
 	void RunInternal(void); //for command /C
 /* A load of subfunctions */
 	void ParseLine(char * line);
@@ -118,18 +119,18 @@ public:
 	void CMD_VER(char * args);
 	void CMD_LS(char *args);
 	/* The shell's variables */
-	Bit16u input_handle;
-	BatchFile * bf;
-	bool echo;
-	bool exit_flag;
-	bool call;
+	uint16_t input_handle = 0;
+	BatchFile *bf = nullptr;
+	bool echo = false;
+	bool exit_flag = false;
+	bool call = false;
 };
 
 struct SHELL_Cmd {
-	const char * name;								/* Command name*/
-	Bit32u flags;									/* Flags about the command */
-	void (DOS_Shell::*handler)(char * args);		/* Handler for this command */
-	const char * help;								/* String with command help */
+	const char *name = nullptr;             /* Command name*/
+	uint32_t flags = 0;                     /* Flags about the command */
+	void (DOS_Shell::*handler)(char *args); /* Handler for this command */
+	const char *help = nullptr;             /* String with command help */
 };
 
 /* Object to manage lines in the autoexec.bat The lines get removed from
@@ -137,8 +138,9 @@ struct SHELL_Cmd {
  * as well if the line set a a variable */
 class AutoexecObject{
 private:
-	bool installed;
-	std::string buf;
+	bool installed = false;
+	std::string buf{};
+
 public:
 	AutoexecObject()
 		: installed(false),

--- a/include/shell.h
+++ b/include/shell.h
@@ -48,7 +48,7 @@ public:
 	virtual ~BatchFile();
 	virtual bool ReadLine(char * line);
 	bool Goto(char * where);
-	void Shift(void);
+	void Shift();
 	uint16_t file_handle = 0;
 	uint32_t location = 0;
 	bool echo = false;
@@ -74,8 +74,8 @@ public:
 	DOS_Shell(const DOS_Shell&) = delete; // prevent copy
 	DOS_Shell& operator=(const DOS_Shell&) = delete; // prevent assignment
 	void Run() override;
-	void RunInternal(void); //for command /C
-/* A load of subfunctions */
+	void RunInternal(); // for command /C
+	/* A load of subfunctions */
 	void ParseLine(char * line);
 	Bitu GetRedirection(char *s, char **ifn, char **ofn,bool * append);
 	void InputCommand(char * line);
@@ -108,7 +108,7 @@ public:
 	void CMD_REM(char * args);
 	void CMD_RENAME(char * args);
 	void CMD_CALL(char * args);
-	void SyntaxError(void);
+	void SyntaxError();
 	void CMD_PAUSE(char * args);
 	void CMD_SUBST(char* args);
 	void CMD_LOADHIGH(char* args);
@@ -150,7 +150,7 @@ public:
 	void InstallBefore(std::string const &in);
 	~AutoexecObject();
 private:
-	void CreateAutoexec(void);
+	void CreateAutoexec();
 };
 
 #endif

--- a/include/shell.h
+++ b/include/shell.h
@@ -71,6 +71,7 @@ private:
 public:
 
 	DOS_Shell();
+	~DOS_Shell() override;
 	DOS_Shell(const DOS_Shell&) = delete; // prevent copy
 	DOS_Shell& operator=(const DOS_Shell&) = delete; // prevent assignment
 	void Run() override;

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -18,6 +18,7 @@
 
 
 #include <stdlib.h>
+#include <string>
 #include <string.h>
 
 #include "dosbox.h"
@@ -31,7 +32,7 @@
 */
 
 CallBack_Handler CallBack_Handlers[CB_MAX];
-char* CallBack_Description[CB_MAX];
+std::string CallBack_Description[CB_MAX];
 
 static Bitu call_stop,call_idle,call_default;
 Bitu call_priv_io;
@@ -130,15 +131,14 @@ void CALLBACK_SIF(bool val) {
 
 void CALLBACK_SetDescription(Bitu nr, const char* descr) {
 	if (descr) {
-		CallBack_Description[nr] = new char[strlen(descr)+1];
-		strcpy(CallBack_Description[nr],descr);
+		CallBack_Description[nr] = descr;
 	} else
-		CallBack_Description[nr] = 0;
+		CallBack_Description[nr].clear();
 }
 
 const char* CALLBACK_GetDescription(Bitu nr) {
 	if (nr>=CB_MAX) return 0;
-	return CallBack_Description[nr];
+	return CallBack_Description[nr].c_str();
 }
 
 Bitu CALLBACK_SetupExtra(Bitu callback, Bitu type, PhysPt physAddress, bool use_cb=true) {
@@ -572,8 +572,10 @@ void CALLBACK_HandlerObject::Uninstall(){
 	} else if(m_type == CALLBACK_HandlerObject::NONE){
 		//Do nothing. Merely DeAllocate the callback
 	} else E_Exit("what kind of callback is this!");
-	if(CallBack_Description[m_callback]) delete [] CallBack_Description[m_callback];
-	CallBack_Description[m_callback] = 0;
+	
+	if(!CallBack_Description[m_callback].empty())
+		CallBack_Description[m_callback].clear();
+
 	CALLBACK_DeAllocate(m_callback);
 	installed=false;
 }

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -649,8 +649,9 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 		for (auto &val : accumulator)
 			val = 0;
 
-		const uint16_t frames = std::min(BUFFER_FRAMES,
-		                                 requested_frames - generated_frames);
+		const uint16_t frames = static_cast<uint16_t>(
+		        std::min(BUFFER_FRAMES, requested_frames - generated_frames));
+
 		auto v = voices.begin();
 		const auto v_end = v + active_voices;
 		while (v < v_end && *v) {

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1174,7 +1174,7 @@ CSerial::CSerial(const uint8_t port_idx, CommandLine *cmd)
 	overrunIF0=0;
 	breakErrors=0;
 
-	for (uint32_t i = 0; i <= 7; i++) {
+	for (uint32_t i = 0; i < SERIAL_IO_HANDLERS; ++i) {
 		WriteHandler[i].Install (i + base, SERIAL_Write, IO_MB);
 		ReadHandler[i].Install(i + base, SERIAL_Read, IO_MB);
 	}
@@ -1193,6 +1193,20 @@ CSerial::~CSerial() {
 	DOS_DelDevice(mydosdevice);
 	for (uint16_t i = 0; i <= SERIAL_BASE_EVENT_COUNT; i++)
 		removeEvent(i);
+
+	// Free the fifos and devices
+	delete(errorfifo);
+	errorfifo = nullptr;
+	delete(rxfifo);
+	rxfifo = nullptr;
+	delete(txfifo);
+	txfifo = nullptr;
+
+	// Uninstall the IO handlers
+	for (uint32_t i = 0; i < SERIAL_IO_HANDLERS; ++i) {
+		WriteHandler[i].Uninstall();
+		ReadHandler[i].Uninstall();
+	}
 }
 
 static bool idle(const double start, const uint32_t timeout)

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -21,6 +21,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <memory>
 
 #include "callback.h"
 #include "control.h"
@@ -518,11 +519,11 @@ public:
 	}
 };
 
-static AUTOEXEC *autoexec_module;
+static std::unique_ptr<AUTOEXEC> autoexec_module{};
 
 void AUTOEXEC_Init(Section *sec)
 {
-	autoexec_module = new AUTOEXEC(sec);
+	autoexec_module = std::make_unique<AUTOEXEC>(sec);
 }
 
 static Bitu INT2E_Handler()

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -34,7 +34,8 @@ Bitu call_shellstop;
  * remove things from the environment */
 DOS_Shell *first_shell = nullptr;
 
-static Bitu shellstop_handler(void) {
+static Bitu shellstop_handler()
+{
 	return CBRET_STOP;
 }
 
@@ -90,7 +91,8 @@ void AutoexecObject::InstallBefore(const std::string &in) {
 	this->CreateAutoexec();
 }
 
-void AutoexecObject::CreateAutoexec(void) {
+void AutoexecObject::CreateAutoexec()
+{
 	/* Remove old autoexec.bat if the shell exists */
 	if(first_shell)	VFILE_Remove("AUTOEXEC.BAT");
 
@@ -302,9 +304,8 @@ void DOS_Shell::ParseLine(char * line) {
 	}
 }
 
-
-
-void DOS_Shell::RunInternal(void) {
+void DOS_Shell::RunInternal()
+{
 	char input_line[CMD_MAXLINE] = {0};
 	while (bf) {
 		if (bf->ReadLine(input_line)) {
@@ -321,7 +322,8 @@ void DOS_Shell::RunInternal(void) {
 	}
 }
 
-void DOS_Shell::Run(void) {
+void DOS_Shell::Run()
+{
 	char input_line[CMD_MAXLINE] = {0};
 	std::string line;
 	if (cmd->FindStringRemainBegin("/C",line)) {
@@ -379,7 +381,8 @@ void DOS_Shell::Run(void) {
 	} while (!exit_flag);
 }
 
-void DOS_Shell::SyntaxError(void) {
+void DOS_Shell::SyntaxError()
+{
 	WriteOut(MSG_Get("SHELL_SYNTAXERROR"));
 }
 
@@ -522,7 +525,8 @@ void AUTOEXEC_Init(Section *sec)
 	autoexec_module = new AUTOEXEC(sec);
 }
 
-static Bitu INT2E_Handler(void) {
+static Bitu INT2E_Handler()
+{
 	/* Save return address and current process */
 	RealPt save_ret=real_readd(SegValue(ss),reg_sp);
 	Bit16u save_psp=dos.psp();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -32,7 +32,7 @@
 Bitu call_shellstop;
 /* Larger scope so shell_del autoexec can use it to
  * remove things from the environment */
-DOS_Shell * first_shell = 0;
+DOS_Shell *first_shell = nullptr;
 
 static Bitu shellstop_handler(void) {
 	return CBRET_STOP;
@@ -826,5 +826,5 @@ void SHELL_Init() {
 	SHELL_ProgramStart_First_shell(&first_shell);
 	first_shell->Run();
 	delete first_shell;
-	first_shell = 0;//Make clear that it shouldn't be used anymore
+	first_shell = nullptr; // Make clear that it shouldn't be used anymore
 }

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -278,6 +278,7 @@ again:
 	return false;
 }
 
-void BatchFile::Shift(void) {
+void BatchFile::Shift()
+{
 	cmd->Shift(1);
 }

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -28,6 +28,11 @@
 #include "callback.h"
 #include "support.h"
 
+DOS_Shell::~DOS_Shell() {
+	delete bf;
+	bf = nullptr;
+}
+
 void DOS_Shell::ShowPrompt(void) {
 	Bit8u drive=DOS_GetDefaultDrive()+'A';
 	char dir[DOS_PATHLENGTH];


### PR DESCRIPTION
Fixes #812, as well as leaks reported from the shell.

After this, the only leaks reported come from system libraries.

Test with:

1. Build: `./scripts/build.sh -c gcc -t uasan`
2. Launch: `./src/dosbox`
3. Run a game then exit

