### PR TITLE
Don't use exceptions as an exit mechanism, use return-codes

### DIFF
--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -23,6 +23,12 @@
 #include "compiler.h"
 #include "types.h"
 
+// The exit_requested bool is a conditional break in the parse-loop and
+// machine-loop. Set it to true to gracefully quit in expected circumstances.
+extern bool exit_requested;
+
+// The E_Exit function throws an exception to quit. Call it in unexpected
+// circumstances.
 [[noreturn]] void E_Exit(const char *message, ...)
         GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -123,7 +123,6 @@ public:
 	uint16_t input_handle = 0;
 	BatchFile *bf = nullptr;
 	bool echo = false;
-	bool exit_flag = false;
 	bool call = false;
 };
 

--- a/include/video.h
+++ b/include/video.h
@@ -51,7 +51,11 @@ typedef void (*GFX_CallBack_t)( GFX_CallBackFunctions_t function );
 #define GFX_CAN_RANDOM  0x4000 //If the interface can also do random access surface
 #define GFX_UNITY_SCALE 0x8000 /* turn of all scaling in render.cpp */
 
-void GFX_Events(void);
+// return code of:
+// - true means event loop can keep running.
+// - false means event loop wants to quit.
+bool GFX_Events();
+
 Bitu GFX_GetBestMode(Bitu flags);
 Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);
 void GFX_SetShader(const char* src);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -38,6 +38,7 @@
 #include "timer.h"
 #include "dos_inc.h"
 #include "setup.h"
+#include "shell.h"
 #include "control.h"
 #include "cross.h"
 #include "programs.h"
@@ -152,8 +153,9 @@ static Bitu Normal_Loop(void) {
 			if (DEBUG_ExitLoop()) return 0;
 #endif
 		} else {
-			GFX_Events();
-			if (ticksRemain>0) {
+			if (!GFX_Events())
+				return 0;
+			if (ticksRemain > 0) {
 				TIMER_AddTick();
 				ticksRemain--;
 			} else {increaseticks();return 0;}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -50,6 +50,7 @@
 #include "hardware.h"
 
 Config * control;
+bool exit_requested = false;
 MachineType machine;
 SVGACards svgaCard;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -323,11 +323,12 @@ void DOSBOX_SetNormalLoop() {
 	loop=Normal_Loop;
 }
 
-void DOSBOX_RunMachine(void){
+void DOSBOX_RunMachine()
+{
 	Bitu ret;
 	do {
 		ret=(*loop)();
-	} while (!ret);
+	} while (!ret && !exit_requested);
 }
 
 static void DOSBOX_UnlockSpeed( bool pressed ) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -325,10 +325,8 @@ void DOSBOX_SetNormalLoop() {
 
 void DOSBOX_RunMachine()
 {
-	Bitu ret;
-	do {
-		ret=(*loop)();
-	} while (!ret && !exit_requested);
+	while ((*loop)() == 0 && !exit_requested)
+		;
 }
 
 static void DOSBOX_UnlockSpeed( bool pressed ) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -169,7 +169,6 @@ DOS_Shell::DOS_Shell()
           input_handle(STDIN),
           bf(nullptr),
           echo(true),
-          exit_flag(false),
           call(false)
 {}
 
@@ -379,7 +378,7 @@ void DOS_Shell::Run()
 			InputCommand(input_line);
 			ParseLine(input_line);
 		}
-	} while (!exit_flag);
+	} while (!exit_requested);
 }
 
 void DOS_Shell::SyntaxError()

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -322,7 +322,7 @@ void DOS_Shell::CMD_ECHO(char * args){
 void DOS_Shell::CMD_EXIT(char *args)
 {
 	HELP("EXIT");
-	exit_flag = true;
+	exit_requested = true;
 }
 
 void DOS_Shell::CMD_CHDIR(char * args) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -60,7 +60,7 @@ void DOS_Shell::InputCommand(char * line) {
 
 	std::list<std::string>::iterator it_history = l_history.begin(), it_completion = l_completion.begin();
 
-	while (size) {
+	while (size && !exit_requested) {
 		dos.echo=false;
 		while(!DOS_ReadFile(input_handle,&c,&n)) {
 			Bit16u dummy;


### PR DESCRIPTION
The previous code used an exception throw in the SDL event loop as a hack to quit the emulator instead of using a return code to gracefully exit.

This is wrong and harmful for a couple reasons:

1) quitting the emulator is a _normal_ action by the user. It's not an exception. C++ exceptions should be reserved for exactly that: truly exceptional scenarios.

2) Because an exception was used in normal circumstances, the main() body was wrapped in a catch-all bucket to suppress actual exceptions, which simultaneously prevented them from revealing their call histories.

This was quite easy to put into place given an existing exit-request flag already existed in the `Shell` class, and the SDL event loop already funnelled requests to a `KillSwitch()` function that perform the exception-throw.

So now the KillSwitch set an the exit-request, and we return a `bool` frrom the event loop up to the main DOSBox machine-loop, where the exit state is checked. Because the event loop spins, the last commit replaces many branch-and-conditional checks with fewer and simply checks, with no change in behaviour. 

The bulk of the lines-of-code change tally comes froms removing the `try() { .. }` block, de-indenting one tab place (.. so those appear a changed lines, but no functional changes were made).

This commit, along with the `cleanup-leaks-1` has been tested on Linux, Windows VM, macOS VM, and macOS hardware - and has fixed https://github.com/MaddTheSane/Boxer/issues/20.

Thanks to @mdmallardi for testing!