### PR TITLE
MIDI OSS cleanup

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -28,6 +28,8 @@
 
 class Program;
 
+extern uint8_t MIDI_evt_len[256];
+
 void MIDI_Init(Section *sec);
 bool MIDI_Available();
 void MIDI_ListAll(Program *output_handler);

--- a/src/midi/Makefile.am
+++ b/src/midi/Makefile.am
@@ -12,5 +12,6 @@ libmidi_a_SOURCES = \
 	midi_handler.h \
 	midi_mt32.cpp \
 	midi_mt32.h \
+	midi_oss.cpp \
 	midi_oss.h \
 	midi_win32.h

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -40,7 +40,7 @@
 
 #define RAWBUF	1024
 
-Bit8u MIDI_evt_len[256] = {
+uint8_t MIDI_evt_len[256] = {
   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,  // 0x00
   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,  // 0x10
   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,  // 0x20
@@ -95,6 +95,8 @@ MidiHandler Midi_none;
 #else
 
 #include "midi_oss.h"
+
+MidiHandler_oss Midi_oss;
 
 #endif
 

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -34,11 +34,8 @@
 bool MidiHandler_oss::Open(const char *conf)
 {
 	char devname[512];
-	if (conf && conf[0])
-		safe_strcpy(devname, conf);
-	else
-		strcpy(devname, "/dev/sequencer");
-	char *devfind = (strrchr(devname, ','));
+	safe_strcpy(devname, (is_empty(conf) ? "/dev/sequencer" : conf));
+	char *devfind = strrchr(devname, ',');
 	if (devfind) {
 		*devfind++ = '\0';
 		device_num = atoi(devfind);

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -20,6 +20,7 @@
 
 #include "midi_oss.h"
 
+#include <cassert>
 #include <cstdlib>
 #include <cstring>
 
@@ -64,9 +65,10 @@ void MidiHandler_oss::Close()
 
 void MidiHandler_oss::PlayMsg(const uint8_t *msg)
 {
-	uint8_t buf[128];
-	size_t pos = 0;
 	const uint8_t len = MIDI_evt_len[*msg];
+	uint8_t buf[128];
+	assert(len * 4 <= sizeof(buf));
+	size_t pos = 0;
 	for (uint8_t i = 0; i < len; i++) {
 		buf[pos++] = SEQ_MIDIPUTC;
 		buf[pos++] = *msg;
@@ -80,6 +82,7 @@ void MidiHandler_oss::PlayMsg(const uint8_t *msg)
 void MidiHandler_oss::PlaySysex(uint8_t *sysex, size_t len)
 {
 	uint8_t buf[SYSEX_SIZE * 4];
+	assert(len <= SYSEX_SIZE);
 	size_t pos = 0;
 	for (size_t i = 0; i < len; i++) {
 		buf[pos++] = SEQ_MIDIPUTC;

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -1,0 +1,90 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "midi_oss.h"
+
+#include <cstdlib>
+#include <cstring>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "midi.h"
+#include "support.h"
+
+#define SEQ_MIDIPUTC 5
+
+bool MidiHandler_oss::Open(const char *conf)
+{
+	char devname[512];
+	if (conf && conf[0])
+		safe_strcpy(devname, conf);
+	else
+		strcpy(devname, "/dev/sequencer");
+	char *devfind = (strrchr(devname, ','));
+	if (devfind) {
+		*devfind++ = '\0';
+		device_num = atoi(devfind);
+	} else {
+		device_num = 0;
+	}
+	if (is_open)
+		return false;
+	device = open(devname, O_WRONLY, 0);
+	if (device < 0)
+		return false;
+	return true;
+}
+
+void MidiHandler_oss::Close()
+{
+	if (!is_open)
+		return;
+	if (device > 0)
+		close(device);
+}
+
+void MidiHandler_oss::PlayMsg(const uint8_t *msg)
+{
+	uint8_t buf[128];
+	size_t pos = 0;
+	const uint8_t len = MIDI_evt_len[*msg];
+	for (uint8_t i = 0; i < len; i++) {
+		buf[pos++] = SEQ_MIDIPUTC;
+		buf[pos++] = *msg;
+		buf[pos++] = device_num;
+		buf[pos++] = 0;
+		msg++;
+	}
+	write(device, buf, pos);
+}
+
+void MidiHandler_oss::PlaySysex(uint8_t *sysex, size_t len)
+{
+	uint8_t buf[SYSEX_SIZE * 4];
+	size_t pos = 0;
+	for (size_t i = 0; i < len; i++) {
+		buf[pos++] = SEQ_MIDIPUTC;
+		buf[pos++] = *sysex++;
+		buf[pos++] = device_num;
+		buf[pos++] = 0;
+	}
+	write(device, buf, pos);
+}

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -33,12 +33,13 @@
 
 MidiHandler_oss::~MidiHandler_oss()
 {
-	if (device > 0)
+	if (is_open)
 		close(device);
 }
 
 bool MidiHandler_oss::Open(const char *conf)
 {
+	Close();
 	char devname[512];
 	safe_strcpy(devname, (is_empty(conf) ? "/dev/sequencer" : conf));
 	char *devfind = strrchr(devname, ',');
@@ -48,20 +49,17 @@ bool MidiHandler_oss::Open(const char *conf)
 	} else {
 		device_num = 0;
 	}
-	if (is_open)
-		return false;
 	device = open(devname, O_WRONLY, 0);
-	if (device < 0)
-		return false;
-	return true;
+	is_open = (device >= 0);
+	return is_open;
 }
 
 void MidiHandler_oss::Close()
 {
 	if (!is_open)
 		return;
-	if (device > 0)
-		close(device);
+	close(device);
+	is_open = false;
 }
 
 void MidiHandler_oss::PlayMsg(const uint8_t *msg)

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -31,6 +31,12 @@
 
 #define SEQ_MIDIPUTC 5
 
+MidiHandler_oss::~MidiHandler_oss()
+{
+	if (device > 0)
+		close(device);
+}
+
 bool MidiHandler_oss::Open(const char *conf)
 {
 	char devname[512];

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -36,6 +36,8 @@ public:
 	MidiHandler_oss(const MidiHandler_oss &) = delete; // prevent copying
 	MidiHandler_oss &operator=(const MidiHandler_oss &) = delete; // prevent assignment
 
+	~MidiHandler_oss() override;
+
 	const char *GetName() const override { return "oss"; }
 
 	bool Open(const char *conf) override;

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -24,79 +24,27 @@
 
 #include "midi_handler.h"
 
-#include <fcntl.h>
-
-#define SEQ_MIDIPUTC    5
-
 class MidiHandler_oss : public MidiHandler {
 private:
-	int device;
-	uint8_t device_num;
-	bool isOpen;
+	int device = 0;
+	uint8_t device_num = 0;
+	bool is_open = false;
 
 public:
-	MidiHandler_oss()
-	        : MidiHandler(),
-	          device(0),
-	          device_num(0),
-	          isOpen(false)
-	{}
+	MidiHandler_oss() : MidiHandler() {}
 
 	MidiHandler_oss(const MidiHandler_oss &) = delete; // prevent copying
 	MidiHandler_oss &operator=(const MidiHandler_oss &) = delete; // prevent assignment
 
 	const char *GetName() const override { return "oss"; }
 
-	bool Open(const char *conf) override
-	{
-		char devname[512];
-		if (conf && conf[0])
-			safe_strcpy(devname, conf);
-		else strcpy(devname,"/dev/sequencer");
-		char * devfind=(strrchr(devname,','));
-		if (devfind) {
-			*devfind++=0;
-			device_num=atoi(devfind);
-		} else device_num=0;
-		if (isOpen) return false;
-		device=open(devname, O_WRONLY, 0);
-		if (device<0) return false;
-		return true;
-	}
+	bool Open(const char *conf) override;
 
-	void Close() override
-	{
-		if (!isOpen) return;
-		if (device>0) close(device);
-	}
+	void Close() override;
 
-	void PlayMsg(const uint8_t *msg) override
-	{
-		Bit8u buf[128];Bitu pos=0;
-		Bitu len=MIDI_evt_len[*msg];
-		for (;len>0;len--) {
-			buf[pos++] = SEQ_MIDIPUTC;
-			buf[pos++] = *msg;
-			buf[pos++] = device_num;
-			buf[pos++] = 0;
-			msg++;
-		}
-		write(device,buf,pos);
-	}
+	void PlayMsg(const uint8_t *msg) override;
 
-	void PlaySysex(uint8_t *sysex, size_t len) override
-	{
-		Bit8u buf[SYSEX_SIZE*4];Bitu pos=0;
-		for (;len>0;len--) {
-			buf[pos++] = SEQ_MIDIPUTC;
-			buf[pos++] = *sysex++;
-			buf[pos++] = device_num;
-			buf[pos++] = 0;
-		}
-		write(device, buf, pos);
-	}
+	void PlaySysex(uint8_t *sysex, size_t len) override;
 };
-
-MidiHandler_oss Midi_oss;
 
 #endif


### PR DESCRIPTION
Initially I only wanted to fix https://lgtm.com/projects/g/dosbox-staging/dosbox-staging/snapshot/04a5404246e0a5aee1d63563c3d494e5deade8ea/files/src/midi/midi_oss.h?sort=name&dir=ASC&mode=heatmap#xcc9bc9b8d33d1695:1
but I noticed this code is untouched since ~2007 and obviously buggy, so I decided to do more thorough cleanup (since after retouching, it will likely not be changed for a long time again).

The first commit moves the implementation from header-only to a cpp file, later commits fix several issues in the code (explained in commit messages).

OSS API does not work on Linux any more (and I don't feel like installing some old compatibility kernel modules to test it - I trust it is implemented correctly (it seems like it is based on OSSv4.x code examples). We cannot/should not remove this MIDI backend, because it's the primary one for BSDs. Fortunately, the behaviour can be tested by redirecting OSS writes to an ordinary file (it must exist before starting emulator).