### PR TITLE
Unify autoconf defines for function checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -622,9 +622,9 @@ AM_CONDITIONAL(BUILD_TESTS, test "${HAVE_GTEST}" = "yes")
 AM_CONDITIONAL(USE_GTEST_STATIC, test "${HAVE_GTEST_STATIC}" = "yes")
 
 dnl Check for mprotect. Needed for 64 bits linux
-AH_TEMPLATE(C_HAVE_MPROTECT,[Define to 1 if you have the mprotect function])
+AH_TEMPLATE(HAVE_MPROTECT,[Define to 1 if you have the mprotect function])
 AC_CHECK_HEADER([sys/mman.h], [
-AC_CHECK_FUNC([mprotect],[AC_DEFINE(C_HAVE_MPROTECT,1)])
+AC_CHECK_FUNC([mprotect],[AC_DEFINE(HAVE_MPROTECT,1)])
 ])
 
 dnl Check for realpath. Used on Linux

--- a/configure.ac
+++ b/configure.ac
@@ -185,11 +185,6 @@ typedef struct { } __attribute__((packed)) junk;]],
 OLDCFLAGS="$CFLAGS"
 CFLAGS="-Werror"
 
-AH_TEMPLATE([C_ATTRIBUTE_ALWAYS_INLINE],[Determines if the compiler supports always_inline attribute.])
-AC_MSG_CHECKING(if compiler allows __attribute__((always_inline)) )
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([ inline void __attribute__((always_inline)) test(){}
-])],[ AC_MSG_RESULT(yes);AC_DEFINE(C_ATTRIBUTE_ALWAYS_INLINE)],AC_MSG_RESULT(no))
-
 CFLAGS="$OLDCFLAGS"
 
 
@@ -712,12 +707,6 @@ AH_TOP([
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 ])
-
-AH_BOTTOM([#if C_ATTRIBUTE_ALWAYS_INLINE
-#define INLINE inline __attribute__((always_inline))
-#else
-#define INLINE inline
-#endif])
 
 AC_CONFIG_FILES([
 Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -164,12 +164,11 @@ struct dirent d_test;
 d_test.d_type = 0;
 }])],[AC_MSG_RESULT(yes);AC_DEFINE(DIRENT_HAS_D_TYPE,1,[struct dirent has d_type])],AC_MSG_RESULT(no))
 
-
-dnl Look for clock_gettime, a DB_HAVE_CLOCK_GETTIME is set when present
-AH_TEMPLATE([DB_HAVE_CLOCK_GETTIME],[Determines if the function clock_gettime is available.])
+dnl Look for clock_gettime, HAVE_CLOCK_GETTIME is set when present
+AH_TEMPLATE([HAVE_CLOCK_GETTIME],[Determines if the function clock_gettime is available.])
 AC_SEARCH_LIBS([clock_gettime], [rt] , [found_clock_gettime=yes], [found_clock_gettime=no])
 if test x$found_clock_gettime = xyes; then
-  AC_DEFINE(DB_HAVE_CLOCK_GETTIME)
+  AC_DEFINE(HAVE_CLOCK_GETTIME)
 fi
 
 dnl Checks for libraries.

--- a/configure.ac
+++ b/configure.ac
@@ -631,14 +631,14 @@ dnl Check for realpath. Used on Linux
 AC_CHECK_FUNCS([realpath])
 
 dnl Setpriority
-AH_TEMPLATE(C_SET_PRIORITY,[Define to 1 if you have setpriority support])
+AH_TEMPLATE(HAVE_SETPRIORITY,[Define to 1 if you have setpriority support])
 AC_MSG_CHECKING(for setpriority support)
 AC_LINK_IFELSE([AC_LANG_SOURCE([
 #include <sys/resource.h>
 int main(int argc,char * argv[]) {
 	return setpriority (PRIO_PROCESS, 0,PRIO_MIN+PRIO_MAX);
 };
-])],AC_MSG_RESULT(yes);AC_DEFINE(C_SET_PRIORITY,1),AC_MSG_RESULT(no))
+])],AC_MSG_RESULT(yes);AC_DEFINE(HAVE_SETPRIORITY,1),AC_MSG_RESULT(no))
 
 
 dnl Some target detection and actions for them

--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,7 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 void blah(){
 struct dirent d_test;
 d_test.d_type = 0;
-}])],[AC_MSG_RESULT(yes);AC_DEFINE(DIRENT_HAS_D_TYPE,1,[struct dirent has d_type])],AC_MSG_RESULT(no))
+}])],[AC_MSG_RESULT(yes);AC_DEFINE(HAVE_STRUCT_DIRENT_D_TYPE,1,[struct dirent has d_type])],AC_MSG_RESULT(no))
 
 dnl Look for clock_gettime, HAVE_CLOCK_GETTIME is set when present
 AH_TEMPLATE([HAVE_CLOCK_GETTIME],[Determines if the function clock_gettime is available.])

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -33,6 +33,14 @@
 #define __has_cpp_attribute(x) 0
 #endif
 
+// Function-like macro __has_attribute was introduced in GCC 5.x and Clang,
+// alongside __has_cpp_attribute, and with the same logic.
+// See: https://clang.llvm.org/docs/LanguageExtensions.html#has-attribute
+
+#ifndef __has_attribute // for compatibility with non-supporting compilers
+#define __has_attribute(x) 0
+#endif
+
 // When passing the -Wunused flag to GCC or Clang, entities that are unused by
 // the program may be diagnosed.  The MAYBE_UNUSED attribute can be used to
 // silence such diagnostics when the entity cannot be removed.
@@ -67,6 +75,32 @@
 #define GCC_ATTRIBUTE(x) __attribute__ ((x))
 #else
 #define GCC_ATTRIBUTE(x) /* attribute not supported */
+#endif
+
+// Wrapper for various compiler extensions for inlining aggresively.
+//
+// There is NO way to truly FORCE compiler to do inlining, therefore all these
+// methods are only strong hints, usually non-preferrable over simple
+// 'inline' keyword.
+//
+// Normal C++ 'inline' is indicator that there might be more than one
+// definition for the function (as long as all definitions are the same).
+// It's used to define functions in C++ headers. Compiler will automatically
+// try to inline (embed compiled code without function call) any function
+// defined in a header.
+//
+// For details about GCC/Clang always_inline, see:
+// https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
+//
+// For details about MSVC __forceinline, see:
+// https://docs.microsoft.com/en-us/cpp/cpp/inline-functions-cpp#inline-__inline-and-__forceinline
+
+#if __has_attribute(always_inline)
+#define INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define INLINE __forceinline
+#else
+#define INLINE inline
 #endif
 
 // GCC_LIKELY macro is incorrectly named, because other compilers support

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -33,14 +33,16 @@
 #include <winbase.h>
 #endif
 
-#if (C_HAVE_MPROTECT)
+#if defined(HAVE_MPROTECT)
 #include <sys/mman.h>
 
 #include <limits.h>
+
 #ifndef PAGESIZE
 #define PAGESIZE 4096
 #endif
-#endif /* C_HAVE_MPROTECT */
+
+#endif // HAVE_MPROTECT
 
 #include "callback.h"
 #include "regs.h"

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -33,14 +33,16 @@
 #include <winbase.h>
 #endif
 
-#if (C_HAVE_MPROTECT)
+#if defined(HAVE_MPROTECT)
 #include <sys/mman.h>
 
 #include <limits.h>
+
 #ifndef PAGESIZE
 #define PAGESIZE 4096
 #endif
-#endif /* C_HAVE_MPROTECT */
+
+#endif // HAVE_MPROTECT
 
 #include "callback.h"
 #include "regs.h"

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -655,7 +655,7 @@ static void cache_block_closing(uint8_t *block_start, Bitu block_size);
 #endif
 
 /* Define temporary pagesize so the MPROTECT case and the regular case share as much code as possible */
-#if (C_HAVE_MPROTECT)
+#if defined(HAVE_MPROTECT)
 #define PAGESIZE_TEMP PAGESIZE
 #else
 #define PAGESIZE_TEMP 4096
@@ -708,7 +708,7 @@ static void cache_init(bool enable) {
 			cache_code_link_blocks=cache_code;
 			cache_code += PAGESIZE_TEMP;
 
-#if (C_HAVE_MPROTECT)
+#if defined(HAVE_MPROTECT)
 			if(mprotect(cache_code_link_blocks,CACHE_TOTAL+CACHE_MAXSIZE+PAGESIZE_TEMP,PROT_WRITE|PROT_READ|PROT_EXEC))
 				LOG_MSG("Setting execute permission on the code cache has failed");
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -190,9 +190,10 @@ extern char** environ;
 #define STDERR_FILE "stderr.txt"
 #endif
 
-#if C_SET_PRIORITY
+#if defined(HAVE_SETPRIORITY)
 #include <sys/resource.h>
-#define PRIO_TOTAL (PRIO_MAX-PRIO_MIN)
+
+#define PRIO_TOTAL (PRIO_MAX - PRIO_MIN)
 #endif
 
 SDL_bool mouse_is_captured = SDL_FALSE; // global for mapper
@@ -1726,9 +1727,10 @@ static void GUI_ShutDown(Section *)
 	CleanupSDLResources();
 }
 
-static void SetPriority(PRIORITY_LEVELS level) {
-
-#if C_SET_PRIORITY
+static void SetPriority(PRIORITY_LEVELS level)
+{
+	// TODO replace platform-specific API with SDL_SetThreadPriority
+#if defined(HAVE_SETPRIORITY)
 // Do nothing if priorties are not the same and not root, else the highest
 // priority can not be set as users can only lower priority (not restore it)
 
@@ -1754,7 +1756,7 @@ static void SetPriority(PRIORITY_LEVELS level) {
 	case PRIORITY_LEVEL_HIGHEST:
 		SetPriorityClass(GetCurrentProcess(),HIGH_PRIORITY_CLASS);
 		break;
-#elif C_SET_PRIORITY
+#elif defined(HAVE_SETPRIORITY)
 /* Linux use group as dosbox has mulitple threads under linux */
 	case PRIORITY_LEVEL_PAUSE:	// if DOSBox is paused, assume idle priority
 	case PRIORITY_LEVEL_LOWEST:

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -33,7 +33,7 @@
 #include "serialport.h"
 #include <time.h>
 
-#if defined(DB_HAVE_CLOCK_GETTIME) && ! defined(WIN32)
+#if defined(HAVE_CLOCK_GETTIME) && !defined(WIN32)
 //time.h is already included
 #else
 #include <sys/timeb.h>
@@ -494,10 +494,12 @@ static Bitu INT11_Handler(void) {
 
 static void BIOS_HostTimeSync() {
 	Bit32u milli = 0;
-#if defined(DB_HAVE_CLOCK_GETTIME) && ! defined(WIN32)
+	// TODO investigate if clock_gettime and ftime can be replaced
+	// by using C++11 chrono
+#if defined(HAVE_CLOCK_GETTIME) && !defined(WIN32)
 	struct timespec tp;
 	clock_gettime(CLOCK_REALTIME,&tp);
-	
+
 	struct tm *loctime;
 	loctime = localtime(&tp.tv_sec);
 	milli = (Bit32u) (tp.tv_nsec / 1000000);
@@ -505,7 +507,7 @@ static void BIOS_HostTimeSync() {
 	/* Setup time and date */
 	struct timeb timebuffer;
 	ftime(&timebuffer);
-	
+
 	struct tm *loctime;
 	loctime = localtime (&timebuffer.time);
 	milli = (Bit32u) timebuffer.millitm;

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -305,17 +305,22 @@ bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_direc
 //	safe_strncpy(entry_name,dentry->d_name,(FILENAME_MAX<MAX_PATH)?FILENAME_MAX:MAX_PATH);	// [include stdio.h], maybe pathconf()
 	safe_strncpy(entry_name,dentry->d_name,CROSS_LEN);
 
-#ifdef DIRENT_HAS_D_TYPE
-	if(dentry->d_type == DT_DIR) {
+	// TODO check if this check can be replaced with glibc-defined
+	// _DIRENT_HAVE_D_TYPE. Non-GNU systems (BSD) provide d_type field as
+	// well, but do they provide define?
+	// Alternatively, maybe we can replace whole directory listing with
+	// C++17 std::filesystem::directory_iterator.
+#ifdef HAVE_STRUCT_DIRENT_D_TYPE
+	if (dentry->d_type == DT_DIR) {
 		is_directory = true;
 		return true;
-	} else if(dentry->d_type == DT_REG) {
+	} else if (dentry->d_type == DT_REG) {
 		is_directory = false;
 		return true;
 	}
 #endif
 
-	//Maybe only for DT_UNKNOWN if DIRENT_HAD_D_TYPE..
+	// Maybe only for DT_UNKNOWN if HAVE_STRUCT_DIRENT_D_TYPE
 	static char buffer[2 * CROSS_LEN + 1] = { 0 };
 	static char split[2] = { CROSS_FILESPLIT , 0 };
 	buffer[0] = 0;

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -69,8 +69,6 @@
 /* Define to 1 if you want serial passthrough support. */
 #define C_DIRECTSERIAL 1
 
-#define INLINE __forceinline
-
 // Enables mathematical constants under Visual Studio, such as M_PI
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
 #define _USE_MATH_DEFINES


### PR DESCRIPTION
Several different define name variants are replaced with defines using `HAVE_*` format.

Replace `C_ATTRIBUTE_ALWAYS_INLINE` with preprocessor checks in `compiler.h`.

Prerequisite for #822 (but this PR is for master branch).