### PR TITLE
Move safe_strcpy and safe_strcat to string_utils

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 287
+            max_warnings: 269
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1993
+            max_warnings: 1975
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -293,7 +293,7 @@ public:
 	virtual bool FileExists(const char* name)=0;
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block)=0;
 	virtual Bit8u GetMediaByte(void)=0;
-	virtual void SetDir(const char *path) { safe_strcpy(curdir, path); }
+	virtual void SetDir(const char *path);
 	virtual void EmptyCache() { dirCache.EmptyCache(); }
 	virtual bool isRemote(void)=0;
 	virtual bool isRemovable(void)=0;

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -16,9 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_HARDWARE_H
 #define DOSBOX_HARDWARE_H
+
+#include "dosbox.h"
 
 #include <stdio.h>
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -21,12 +21,51 @@
 #ifndef DOSBOX_STRING_UTILS_H
 #define DOSBOX_STRING_UTILS_H
 
+#include "dosbox.h"
+
+#include <cassert>
 #include <cstdarg>
 #include <cstring>
 #include <string>
 
-#include "support.h"
+/* Copy a string into C array
+ *
+ * This function copies string pointed by src to a fixed-size buffer dst.
+ * At most N bytes from src are copied, where N is size of dst. If exactly
+ * N bytes are copied, then terminating null byte is put into dst, thus
+ * buffer overrun is prevented.
+ *
+ * Function returns pointer to buffer to be compatible with strcpy.
+ *
+ * This is a safer drop-in replacement for strcpy function (when used to fill
+ * buffers, whose size is known at compilation time), however some caveats
+ * still apply:
+ *
+ * - src cannot be null, otherwise the behaviour is undefined
+ * - dst and src strings must not overlap, otherwise the behaviour is undefined
+ * - src string must be null-terminated, otherwise the behaviour is undefined
+ *
+ * Usage:
+ *
+ *     char buffer[2];
+ *     safe_strcpy(buffer, "abc");
+ *     // buffer is filled with "a"
+ */
+template <size_t N>
+char *safe_strcpy(char (&dst)[N], const char *src) noexcept
+{
+	assert(src != nullptr);
+	assert(src < &dst[0] || src > &dst[N - 1]);
+	snprintf(dst, N, "%s", src);
+	return &dst[0];
+}
 
+template <size_t N>
+char *safe_strcat(char (&dst)[N], const char *src) noexcept
+{
+	strncat(dst, src, N - strnlen(dst, N) - 1);
+	return &dst[0];
+}
 
 template <size_t N>
 int safe_sprintf(char (&dst)[N], const char *fmt, ...)

--- a/include/support.h
+++ b/include/support.h
@@ -111,44 +111,7 @@ inline int iround(double x) {
 // Use (void) to silent unused warnings.
 // https://en.cppreference.com/w/cpp/error/assert
 
-/* Copy a string into C array
- *
- * This function copies string pointed by src to a fixed-size buffer dst.
- * At most N bytes from src are copied, where N is size of dst. If exactly
- * N bytes are copied, then terminating null byte is put into dst, thus
- * buffer overrun is prevented.
- *
- * Function returns pointer to buffer to be compatible with strcpy.
- *
- * This is a safer drop-in replacement for strcpy function (when used to fill
- * buffers, whose size is known at compilation time), however some caveats
- * still apply:
- *
- * - src cannot be null, otherwise the behaviour is undefined
- * - dst and src strings must not overlap, otherwise the behaviour is undefined
- * - src string must be null-terminated, otherwise the behaviour is undefined
- *
- * Usage:
- *
- *     char buffer[2];
- *     safe_strcpy(buffer, "abc");
- *     // buffer is filled with "a"
- */
-template <size_t N>
-char *safe_strcpy(char (&dst)[N], const char *src) noexcept
-{
-	assert(src != nullptr);
-	assert(src < &dst[0] || src > &dst[N - 1]);
-	snprintf(dst, N, "%s", src);
-	return &dst[0];
-}
-
-template<size_t N>
-char * safe_strcat(char (& dst)[N], const char * src) noexcept {
-	strncat(dst, src, N - strnlen(dst, N) - 1);
-	return & dst[0];
-}
-
+// TODO review all remaining uses of this macro
 #define safe_strncpy(a,b,n) do { strncpy((a),(b),(n)-1); (a)[(n)-1] = 0; } while (0)
 
 #ifdef HAVE_STRINGS_H

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -42,6 +42,7 @@ using namespace std;
 #include "mixer.h"
 #include "timer.h"
 #include "paging.h"
+#include "string_utils.h"
 #include "support.h"
 #include "shell.h"
 #include "programs.h"

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "cross.h"
+#include "string_utils.h"
 #include "support.h"
 #include "regs.h"
 #include "debug.h"

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -44,6 +44,7 @@
 #include "drives.h"
 #include "fs_utils.h"
 #include "setup.h"
+#include "string_utils.h"
 #include "support.h"
 
 using namespace std;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -29,6 +29,8 @@
 #include "dos_inc.h"
 #include "drives.h"
 #include "cross.h"
+#include "string_utils.h"
+#include "support.h"
 
 #define DOS_FILESTART 4
 

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -22,6 +22,7 @@
 #include "bios_disk.h"
 #include "setup.h"
 #include "support.h"
+#include "string_utils.h"
 #include "../ints/int10.h"
 #include "regs.h"
 #include "callback.h"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -43,6 +43,7 @@
 #include "setup.h"
 #include "shell.h"
 #include "support.h"
+#include "string_utils.h"
 #include "../ints/int10.h"
 
 #if defined(WIN32)

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -26,6 +26,7 @@
 #include "cross.h"
 #include "dos_inc.h"
 #include "drives.h"
+#include "string_utils.h"
 #include "support.h"
 
 int fileInfoCounter = 0;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -23,11 +23,12 @@
 #include <string.h>
 #include <time.h>
 
-#include "dos_inc.h"
-#include "support.h"
-#include "cross.h"
-#include "bios.h"
 #include "bios_disk.h"
+#include "bios.h"
+#include "cross.h"
+#include "dos_inc.h"
+#include "string_utils.h"
+#include "support.h"
 
 #define IMGTYPE_FLOPPY 0
 #define IMGTYPE_ISO    1

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -24,6 +24,7 @@
 #include "cdrom.h"
 #include "dos_mscdex.h"
 #include "dos_system.h"
+#include "string_utils.h"
 #include "support.h"
 
 #define FLAGS1	((iso) ? de.fileFlags : de.timeZone)

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -42,7 +42,7 @@
 #include "dos_inc.h"
 #include "dos_mscdex.h"
 #include "fs_utils.h"
-#include "support.h"
+#include "string_utils.h"
 #include "cross.h"
 #include "inout.h"
 

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -27,7 +27,7 @@
 #include <errno.h>
 
 #include "dos_inc.h"
-#include "support.h"
+#include "string_utils.h"
 #include "cross.h"
 #include "inout.h"
 #include "timer.h"

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -18,7 +18,7 @@
 
 #include "drives.h"
 
-#include "support.h"
+#include "string_utils.h"
 
 bool WildFileCmp(const char *file, const char *wild)
 {
@@ -127,6 +127,11 @@ DOS_Drive::DOS_Drive()
 {
 	curdir[0] = '\0';
 	info[0] = '\0';
+}
+
+void DOS_Drive::SetDir(const char *path)
+{
+	safe_strcpy(curdir, path);
 }
 
 // static members variables

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -23,7 +23,7 @@
 #include <string>
 
 #include "shell.h"
-#include "support.h"
+#include "string_utils.h"
 
 void LS::Run()
 {

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -16,21 +16,22 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "hardware.h"
+
 #include <cerrno>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "cross.h"
 #include "dosbox.h"
-#include "hardware.h"
-#include "setup.h"
-#include "support.h"
-#include "mem.h"
+#include "fs_utils.h"
 #include "mapper.h"
+#include "mem.h"
 #include "pic.h"
 #include "render.h"
-#include "cross.h"
-#include "fs_utils.h"
+#include "setup.h"
+#include "string_utils.h"
 
 #if (C_SSHOT)
 #include <png.h>

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -26,7 +26,7 @@
 #include <time.h>
 #include <stdio.h>
 #include "cross.h"
-#include "support.h"
+#include "string_utils.h"
 #include "cpu.h"
 #include "regs.h"
 #include "inout.h"

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -45,7 +45,7 @@
 #include "timer.h"
 #include "setup.h"
 #include "cross.h"
-#include "support.h"
+#include "string_utils.h"
 #include "mapper.h"
 #include "hardware.h"
 #include "programs.h"

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -27,7 +27,7 @@
 #include <fstream>
 #include <sstream>
 
-#include "support.h"
+#include "string_utils.h"
 #include "serialport.h"
 #include "softmodem.h"
 #include "misc_util.h"

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -29,6 +29,7 @@
 #include "dos_inc.h" /* for Drives[] */
 #include "drives.h"
 #include "mapper.h"
+#include "string_utils.h"
 
 diskGeo DiskGeometryList[] = {
 	{ 160,  8, 1, 40, 0},

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -32,6 +32,8 @@
 #include <sstream>
 #define ADDR_DELIM	".:"
 
+#include "string_utils.h"
+
 #if ((SND_LIB_MINOR >= 6) && (SND_LIB_MAJOR == 0)) || (SND_LIB_MAJOR >= 1)
 #define snd_seq_flush_output(x) snd_seq_drain_output(x)
 #define snd_seq_set_client_group(x,name)	/*nop */

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -28,7 +28,7 @@
 #include <unistd.h>
 
 #include "midi.h"
-#include "support.h"
+#include "string_utils.h"
 
 #define SEQ_MIDIPUTC 5
 

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #include "fs_utils.h"
+#include "string_utils.h"
 #include "support.h"
 
 static std::string GetConfigName()

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -22,7 +22,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "cross.h"
-#include "support.h"
+#include "string_utils.h"
 #include "setup.h"
 #include "control.h"
 #include <list>

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -23,7 +23,7 @@
 #include "dosbox.h"
 #include "cross.h"
 #include "control.h"
-#include "support.h"
+#include "string_utils.h"
 #include <fstream>
 #include <string>
 #include <sstream>

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -28,7 +28,7 @@
 #include "dosbox.h"
 #include "fs_utils.h"
 #include "regs.h"
-#include "support.h"
+#include "string_utils.h"
 
 Bitu call_shellstop;
 /* Larger scope so shell_del autoexec can use it to

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -26,7 +26,7 @@
 
 #include "regs.h"
 #include "callback.h"
-#include "support.h"
+#include "string_utils.h"
 
 DOS_Shell::~DOS_Shell() {
 	delete bf;

--- a/tests/support.cpp
+++ b/tests/support.cpp
@@ -26,50 +26,6 @@
 
 namespace {
 
-TEST(SafeStrcpy, SimpleCopy)
-{
-	char buffer[10] = "";
-	char *ret_value = safe_strcpy(buffer, "abc");
-	EXPECT_EQ(ret_value, &buffer[0]);
-	EXPECT_STREQ("abc", buffer);
-}
-
-TEST(SafeStrcpy, CopyFromNonArray)
-{
-	char buffer[10] = "";
-	std::string str = "abc";
-	EXPECT_STREQ("abc", safe_strcpy(buffer, str.c_str()));
-}
-
-TEST(SafeStrcpy, EmptyStringOverwrites)
-{
-	char buffer[4] = "abc";
-	EXPECT_STREQ("", safe_strcpy(buffer, ""));
-}
-
-TEST(SafeStrcpy, StringLongerThanBuffer)
-{
-	char buffer[5] = "";
-	char long_input[] = "1234567890";
-	ASSERT_LT(ARRAY_LEN(buffer), strlen(long_input));
-	EXPECT_STREQ("1234", safe_strcpy(buffer, long_input));
-}
-
-TEST(SafeStrcpyDeathTest, PassNull)
-{
-	char buf[] = "12345678";
-	EXPECT_DEBUG_DEATH({ safe_strcpy(buf, nullptr); }, "");
-}
-
-TEST(SafeStrcpyDeathTest, ProtectFromCopyingOverlappingString)
-{
-	char buf[] = "12345678";
-	char *overlapping = &buf[2];
-	ASSERT_LE(buf, overlapping);
-	ASSERT_LE(overlapping, buf + ARRAY_LEN(buf));
-	EXPECT_DEBUG_DEATH({ safe_strcpy(buf, overlapping); }, "");
-}
-
 TEST(DriveIndex, DriveA)
 {
 	EXPECT_EQ(0, drive_index('a'));


### PR DESCRIPTION
These functions fit better into more specialized header rather than
generic "support".

It also prevents a number of false-positive warnings when compiling with
MSVC compiler (because MSVC generates warning per included header, with
different message each time - so it cannot be easily filtered-out after
compilation).