### PR TITLE
Fix environment parsing, document the feature, and remove ENVIRON* defines

### DIFF
--- a/README
+++ b/README
@@ -430,6 +430,17 @@ dosbox D:\folder\file.exe -c "MOUNT Y H:\MyFolder"
 In Windows, you can also drag directories/files onto the DOSBox executable.
 
 
+Environment variables
+---------------------
+
+Any configuration option can be overriden using an environment variable.
+Environment variables starting with prefix "DOSBOX" are processed and
+interpreted as follows: DOSBOX_SECTIONNAME_PROPERTYNAME=value
+
+For example, you can override render aspect with:
+
+  $ DOSBOX_RENDER_ASPECT=false dosbox
+
 
 =====================
 4. Internal Programs:

--- a/configure.ac
+++ b/configure.ac
@@ -145,16 +145,6 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #endif
 ])],[],[AC_DEFINE([socklen_t],[int],[Define to `int` if you don't have socklen_t])])
 
-AC_MSG_CHECKING(if environ can be included)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <unistd.h>
-#include <stdlib.h>]],[[*environ;]])],
-[AC_MSG_RESULT(yes);AC_DEFINE(ENVIRON_INCLUDED,1,[environ can be included])],AC_MSG_RESULT(no))
-
-AC_MSG_CHECKING(if environ can be linked)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[extern char ** environ;]],[[*environ;]])],
-[AC_MSG_RESULT(yes);AC_DEFINE(ENVIRON_LINKED,1,[environ can be linked])],AC_MSG_RESULT(no))
-
 AC_MSG_CHECKING([if dirent includes d_type])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #include <sys/types.h>

--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -1,5 +1,5 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
-.TH DOSBOX 1 "Jan 1, 2021"
+.TH DOSBOX 1 "Jan 17, 2021"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 dosbox \- an x86/DOS emulator with sound/graphics
@@ -351,6 +351,15 @@ increments of one) by pressing CTRL\-F8. Your CPU usage should decrease.
 Go back one step and repeat this until the game runs fast enough for you.
 Please note that this is a trade off: you lose in fluidity of video what you
 gain in speed.
+.SH ENVIRONMENT
+Any configuration option can be override using an environment variable.
+.RB "Environment variables starting with prefix " DOSBOX " are processed and
+interpreted as follows:
+.B DOSBOX_SECTIONNAME_PROPERTYNAME=value
+.PP
+.R For example, you can override render aspect this way:
+.PP
+.B $ DOSBOX_RENDER_ASPECT=false dosbox
 .SH NOTES
 .RB "While we hope that, one day, " dosbox " will run virtually all programs ever made for the PC..."
 .RB "we are not there yet. At present, " dosbox " run on a 1.7 Gigahertz PC is roughly the equivalent of a 25MHz 386 PC."

--- a/include/control.h
+++ b/include/control.h
@@ -71,9 +71,9 @@ public:
 	                                  SectionFunction func,
 	                                  bool changeable_at_runtime = false);
 
-	Section_line *AddSection_line(char const *const _name, SectionFunction func);
+	Section_line *AddSection_line(const char *section_name, SectionFunction func);
 
-	Section_prop *AddSection_prop(char const *const _name,
+	Section_prop *AddSection_prop(const char *section_name,
 	                              SectionFunction func,
 	                              bool changeable_at_runtime = false);
 

--- a/include/control.h
+++ b/include/control.h
@@ -89,7 +89,7 @@ public:
 	void StartUp();
 	bool PrintConfig(const std::string &filename) const;
 	bool ParseConfigFile(char const * const configfilename);
-	void ParseEnv(char ** envp);
+	void ParseEnv();
 	bool SecureMode() const { return secure_mode; }
 	void SwitchToSecureMode() { secure_mode = true; }//can't be undone
 	Verbosity GetStartupVerbosity() const;

--- a/include/setup.h
+++ b/include/setup.h
@@ -26,11 +26,17 @@
 
 #include <cstdio>
 #include <deque>
+#include <list>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "support.h"
+
+using parse_environ_result_t = std::list<std::tuple<std::string, std::string>>;
+
+parse_environ_result_t parse_environ(const char * const * envp) noexcept;
 
 class Hex {
 private:

--- a/include/setup.h
+++ b/include/setup.h
@@ -22,6 +22,8 @@
 #ifndef DOSBOX_SETUP_H
 #define DOSBOX_SETUP_H
 
+#include "dosbox.h"
+
 #include <cstdio>
 #include <deque>
 #include <memory>

--- a/include/setup.h
+++ b/include/setup.h
@@ -32,8 +32,6 @@
 #include <tuple>
 #include <vector>
 
-#include "support.h"
-
 using parse_environ_result_t = std::list<std::tuple<std::string, std::string>>;
 
 parse_environ_result_t parse_environ(const char * const * envp) noexcept;
@@ -146,15 +144,7 @@ public:
 
 	const std::string propname;
 
-	Property(const std::string &name, Changeable::Value when)
-		: propname(name),
-		  value(),
-		  suggested_values{},
-		  default_value(),
-		  change(when)
-	{
-		assertm(!name.empty(), "Property name can't be empty.");
-	}
+	Property(const std::string &name, Changeable::Value when);
 
 	virtual ~Property() = default;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2312,7 +2312,7 @@ static void GUI_StartUp(Section *sec)
 
 	// Apply the user's mouse settings
 	Section_prop* s = section->Get_multival("capture_mouse")->GetSection();
-	const std::string control_choice = s->Get_string("capture_mouse (first value)");
+	const std::string control_choice = s->Get_string("capture_mouse_first_value");
 	std::string mouse_control_msg;
 	if (control_choice == "onclick") {
 		sdl.mouse.control_choice = CaptureOnClick;
@@ -2329,8 +2329,9 @@ static void GUI_StartUp(Section *sec)
 	} else {
 		assert(sdl.mouse.control_choice == CaptureOnClick);
 	}
-	std:: string middle_control_msg;
-	if (std::string(s->Get_string("capture_mouse (second value)")) == "middlerelease") {
+	const std::string mclick_choice = s->Get_string("capture_mouse_second_value");
+	std::string middle_control_msg;
+	if (mclick_choice == "middlerelease") {
 		sdl.mouse.middle_will_release = true;
 		if (sdl.mouse.control_choice & (CaptureOnClick | CaptureOnStart))
 			middle_control_msg = " and middle-click will uncapture the mouse";
@@ -2834,7 +2835,7 @@ void Config_Add_SDL() {
 	Prop_int *Pint; // use pint for new properties
 	Prop_int *pint;
 	Prop_multival* Pmulti;
-	Section_prop* Psection;
+	Section_prop* psection;
 
 	constexpr auto always = Property::Changeable::Always;
 	constexpr auto deprecated = Property::Changeable::Deprecated;
@@ -2918,9 +2919,11 @@ void Config_Add_SDL() {
 	Pmulti->SetValue(mouse_control_defaults);
 
 	// Add the mouse and middle control as sub-sections
-	Psection = Pmulti->GetSection();
-	Psection->Add_string("capture_mouse (first value)", always, mouse_controls[0])->Set_values(mouse_controls);
-	Psection->Add_string("capture_mouse (second value)", always, middle_controls[0])->Set_values(middle_controls);
+	psection = Pmulti->GetSection();
+	psection->Add_string("capture_mouse_first_value", always, mouse_controls[0])
+	        ->Set_values(mouse_controls);
+	psection->Add_string("capture_mouse_second_value", always, middle_controls[0])
+	        ->Set_values(middle_controls);
 
 	// Construct and set the help block using defaults set above
 	std::string mouse_control_help(

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -180,10 +180,6 @@ PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer = NULL;
 
 #endif // C_OPENGL
 
-#if !(ENVIRON_INCLUDED)
-extern char** environ;
-#endif
-
 #ifdef WIN32
 #include <winuser.h>
 #define STDOUT_FILE "stdout.txt"
@@ -3384,9 +3380,7 @@ int main(int argc, char* argv[]) {
 			mt32_rom_dir.c_str(), safe_strerror(errno).c_str());
 #endif // C_MT32EMU
 
-#if (ENVIRON_LINKED)
-		control->ParseEnv(environ);
-#endif
+		control->ParseEnv();
 //		UI_Init();
 //		if (control->cmdline->FindExist("-startui")) UI_Run(false);
 		/* Init all the sections */

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -24,6 +24,7 @@
 
 #include "cpu.h"
 #include "setup.h"
+#include "support.h"
 #include "mapper.h"
 #include "mem.h"
 #include "dbopl.h"

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -32,6 +32,7 @@
 #include "render.h"
 #include "setup.h"
 #include "string_utils.h"
+#include "support.h"
 
 #if (C_SSHOT)
 #include <png.h>

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -21,7 +21,9 @@
 
 #include "inout.h"
 
-#include <string.h>
+#include <cassert>
+#include <limits>
+#include <cstring>
 
 #include "setup.h"
 #include "cpu.h"

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -29,6 +29,7 @@
 
 #include "midi.h"
 #include "string_utils.h"
+#include "support.h"
 
 #define SEQ_MIDIPUTC 5
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <limits>
+#include <regex>
 #include <sstream>
 
 #include "cross.h"
@@ -216,6 +217,17 @@ string Value::ToString() const {
 			break;
 	}
 	return oss.str();
+}
+
+Property::Property(const std::string &name, Changeable::Value when)
+        : propname(name),
+          value(),
+          suggested_values{},
+          default_value(),
+          change(when)
+{
+	assertm(std::regex_match(name, std::regex{"[a-zA-Z0-9_]+"}),
+	        "Only letters, digits, and underscores are allowed in property name");
 }
 
 bool Property::CheckValue(Value const& in, bool warn){
@@ -828,11 +840,13 @@ Section_prop *Config::AddEarlySectionProp(const char *name,
 	return s;
 }
 
-Section_prop *Config::AddSection_prop(char const *const name,
+Section_prop *Config::AddSection_prop(const char *section_name,
                                       SectionFunction func,
                                       bool changeable_at_runtime)
 {
-	Section_prop *s = new Section_prop(name);
+	assertm(std::regex_match(section_name, std::regex{"[a-zA-Z]+"}),
+	        "Only letters are allowed in section name");
+	Section_prop *s = new Section_prop(section_name);
 	s->AddInitFunction(func, changeable_at_runtime);
 	sectionlist.push_back(s);
 	return s;
@@ -847,9 +861,11 @@ Section_prop::~Section_prop()
 		delete (*prop);
 }
 
-Section_line *Config::AddSection_line(char const *const _name, SectionFunction func)
+Section_line *Config::AddSection_line(const char *section_name, SectionFunction func)
 {
-	Section_line* blah = new Section_line(_name);
+	assertm(std::regex_match(section_name, std::regex{"[a-zA-Z]+"}),
+	        "Only letters are allowed in section name");
+	Section_line *blah = new Section_line(section_name);
 	blah->AddInitFunction(func);
 	sectionlist.push_back(blah);
 	return blah;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -19,19 +19,18 @@
 #include "setup.h"
 
 #include <algorithm>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <string>
 
-#include "dosbox.h"
 #include "cross.h"
 #include "control.h"
 #include "string_utils.h"
-#include <fstream>
-#include <string>
-#include <sstream>
-#include <deque>
-#include <stdlib.h>
-#include <stdio.h>
-#include <limits>
-#include <limits.h>
 
 using namespace std;
 static std::string current_config_dir; // Set by parseconfigfile so Prop_path can use it to construct the realpath

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1014,23 +1014,16 @@ parse_environ_result_t parse_environ(const char * const * envp) noexcept
 	return props_to_set;
 }
 
-void Config::ParseEnv(char ** envp) {
-	for(char** env=envp; *env;env++) {
-		char copy[1024];
-		safe_strcpy(copy, *env);
-		if(strncasecmp(copy,"DOSBOX_",7))
+void Config::ParseEnv(char **envp)
+{
+	const auto env_filtered = parse_environ(envp);
+	for (const auto &set_prop_desc : env_filtered) {
+		const auto section_name = std::get<0>(set_prop_desc);
+		Section *sec = GetSection(section_name);
+		if (!sec)
 			continue;
-		char* sec_name = &copy[7];
-		if(!(*sec_name))
-			continue;
-		char* prop_name = strrchr(sec_name,'_');
-		if(!prop_name || !(*prop_name))
-			continue;
-		*prop_name++=0;
-		Section* sect = GetSection(sec_name);
-		if(!sect)
-			continue;
-		sect->HandleInputline(prop_name);
+		const auto prop_name_and_value = std::get<1>(set_prop_desc);
+		sec->HandleInputline(prop_name_and_value);
 	}
 }
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -990,10 +990,6 @@ bool Config::ParseConfigFile(char const * const configfilename) {
 	return true;
 }
 
-/*const char* Config::GetPrimaryConfigFile() {
-	return configfile.c_str();
-}*/
-
 void Config::ParseEnv(char ** envp) {
 	for(char** env=envp; *env;env++) {
 		char copy[1024];

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -20,13 +20,10 @@
 
 #include <algorithm>
 #include <climits>
-#include <cstdio>
 #include <cstdlib>
-#include <deque>
 #include <fstream>
 #include <limits>
 #include <sstream>
-#include <string>
 
 #include "cross.h"
 #include "control.h"
@@ -987,6 +984,34 @@ bool Config::ParseConfigFile(char const * const configfilename) {
 	}
 	current_config_dir.clear();//So internal changes don't use the path information
 	return true;
+}
+
+parse_environ_result_t parse_environ(const char * const * envp) noexcept
+{
+	std::list<std::tuple<std::string, std::string>> props_to_set;
+
+	// Filter envirnment variables in following format:
+	// DOSBOX_SECTIONNAME_PROPNAME=VALUE (prefix, section, and property
+	// names are case-insensitive).
+	for (const char * const *str = envp; *str; str++) {
+		const char *env_var = *str;
+		if (strncasecmp(env_var, "DOSBOX_", 7) != 0)
+			continue;
+		const std::string rest = (env_var + 7);
+		const auto section_delimiter = rest.find('_');
+		if (section_delimiter == string::npos)
+			continue;
+		const auto section_name = rest.substr(0, section_delimiter);
+		if (section_name.empty())
+			continue;
+		const auto prop_name_and_value = rest.substr(section_delimiter + 1);
+		if (prop_name_and_value.empty() || !isalpha(prop_name_and_value[0]))
+			continue;
+		props_to_set.emplace_back(std::make_tuple(section_name,
+		                                          prop_name_and_value));
+	}
+
+	return props_to_set;
 }
 
 void Config::ParseEnv(char ** envp) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,7 @@ tests_SOURCES = \
 	example.cpp \
 	fs_utils.cpp \
 	readerwritercircularbuffer.cpp \
+	setup.cpp \
 	soft_limiter.cpp \
 	string_utils.cpp \
 	support.cpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,6 +20,7 @@ tests_SOURCES = \
 	setup.cpp \
 	soft_limiter.cpp \
 	string_utils.cpp \
+	stubs.cpp \
 	support.cpp
 
 tests_LDADD = ../src/misc/libmisc.a

--- a/tests/setup.cpp
+++ b/tests/setup.cpp
@@ -1,0 +1,105 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "setup.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+// stubs
+void GFX_ShowMsg(char const *, ...) {}
+Config *control = nullptr;
+
+namespace {
+
+const parse_environ_result_t expected_empty{};
+
+TEST(ParseEnv, NoRelevantEnvVariables)
+{
+	const char *test_environ[] = {"FOO=foo", "BAR=bar", "BAZ=baz", nullptr};
+
+	EXPECT_EQ(expected_empty, parse_environ(test_environ));
+}
+
+TEST(ParseEnv, SingleValueInEnv)
+{
+	const char *test_environ[] = {
+		"SOME_NAME=value",
+		"DOSBOX_SECTIONNAME_PROPNAME=value",
+		"OTHER_NAME=other_value",
+		nullptr
+	};
+	parse_environ_result_t expected{{"SECTIONNAME", "PROPNAME=value"}};
+
+	EXPECT_EQ(expected, parse_environ(test_environ));
+}
+
+TEST(ParseEnv, PropertyOrValueCanHaveUnderscores)
+{
+	const char *test_environ[] = {
+		"DOSBOX_sec_prop_name=value",
+		"DOSBOX_sec_prop=value_name",
+		nullptr
+	};
+	parse_environ_result_t expected{{"sec", "prop_name=value"},
+	                                {"sec", "prop=value_name"}};
+
+	EXPECT_EQ(expected, parse_environ(test_environ));
+}
+
+TEST(ParseEnv, SelectVarsBasedOnPrefix)
+{
+	const char *test_environ[] = {
+		"DOSBOX_sec_prop1=value1",
+		"dosbox_sec_prop2=value2",
+		"DOSBox_sec_prop3=value3",
+		"dOsBoX_sec_prop4=value4",
+		"non_dosbox_sec_prop=val",
+		nullptr
+	};
+
+	EXPECT_EQ(4, parse_environ(test_environ).size());
+}
+
+TEST(ParseEnv, FilterOutEmptySection)
+{
+	const char *test_environ[] = {
+		"DOSBOX=value",
+		"DOSBOX_=value",
+		"DOSBOX__prop=value",
+		nullptr
+	};
+
+	EXPECT_EQ(expected_empty, parse_environ(test_environ));
+}
+
+TEST(ParseEnv, FilterOutEmptyPropname)
+{
+	const char *test_environ[] = {
+		"DOSBOX_sec=value",
+		"DOSBOX_sec_=value",
+		nullptr
+	};
+
+	EXPECT_EQ(expected_empty, parse_environ(test_environ));
+}
+
+} // namespace

--- a/tests/setup.cpp
+++ b/tests/setup.cpp
@@ -24,10 +24,6 @@
 
 #include <string>
 
-// stubs
-void GFX_ShowMsg(char const *, ...) {}
-Config *control = nullptr;
-
 namespace {
 
 const parse_environ_result_t expected_empty{};

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -1,0 +1,31 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "dosbox.h"
+
+#include "control.h"
+#include "logging.h"
+
+// This global variable should be setup/torn down per test.
+Config *control = nullptr;
+
+// During testing we never want to log to stdout/stderr, as it would
+// negatively affect test harness.
+void GFX_ShowMsg(const char *, ...) {}


### PR DESCRIPTION
Some time ago I started using .conf property names with `_` inside, to improve readability. As it turned out, it caused a regression: code iterating over the environment variables used underscores to separate section from property name, and code was buggy (it was looking for last separator) - in result it was impossible to override conf using e.g. `DOSBOX_DOSBOX_STARTUP_VERBOSITY=low`.

This PR:

- Documents the feature
- Adds tests for environment parsing
- Reimplements parsing to avoid the problems
- Adds assertions to protect us from using problematic section and property names (some additional fixes were needed)
- Fixes access to `environ` variable to avoid weird linking warning using MSVC
- Removes ENVIRON_INCLUDED and ENVIRON_LINKED defines (so we won't need to handle them via meson)

I recommend reviewing commit-by-commit.