### PR TITLE
Fix the LGTM-flagged multiplication overflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -104,7 +104,7 @@ jobs:
             # TSAN excluded, harness segfaults inside virual-X11 environment
             sanitizers: UASAN
             usan:  -1
-            uasan: 15
+            uasan: 4
     steps:
       - uses: actions/checkout@v2
       - run:  sudo apt-get update

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,7 +46,7 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 107
+            max_warnings: 101
           - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
@@ -56,7 +56,7 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 144
+            max_warnings: 138
           - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1278,10 +1278,15 @@ dosurface:
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
 
-		Bit8u* emptytex = new Bit8u[texsize * texsize * 4];
-		memset((void*) emptytex, 0, texsize * texsize * 4);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, texsize, texsize, 0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, (const GLvoid*)emptytex);
-		delete [] emptytex;
+		const auto texture_area_bytes = static_cast<size_t>(texsize) *
+		                                texsize * MAX_BYTES_PER_PIXEL;
+		uint8_t *emptytex = new uint8_t[texture_area_bytes];
+		assert(emptytex);
+
+		memset(emptytex, 0, texture_area_bytes);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, texsize, texsize, 0,
+		             GL_BGRA_EXT, GL_UNSIGNED_BYTE, emptytex);
+		delete[] emptytex;
 
 		glClearColor (0.0f, 0.0f, 0.0f, 1.0f);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -194,6 +194,9 @@ PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer = NULL;
 
 SDL_bool mouse_is_captured = SDL_FALSE; // global for mapper
 
+// SDL allows pixels sizes (color-depth) from 1 to 4 bytes
+constexpr uint8_t MAX_BYTES_PER_PIXEL = 4;
+
 // Masks to be passed when creating SDL_Surface.
 // Remove ifndef if they'll be needed for MacOS X builds.
 #ifndef MACOSX

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <cassert>
 #include <zlib.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -324,10 +325,12 @@ int VideoCodec::FinishCompressFrame( void ) {
 		int i;
 		/* Add the full frame data */
 		unsigned char * readFrame = newframe + pixelsize*(MAX_VECTOR+MAX_VECTOR*pitch);	
-		for (i=0;i<height;i++) {
-			memcpy(&work[workUsed], readFrame, width*pixelsize);
-			readFrame += pitch*pixelsize;
-			workUsed += width*pixelsize;
+		const int line_width = width * pixelsize;
+		assert(line_width > 0);
+		for (i = 0; i < height; ++i) {
+			memcpy(&work[workUsed], readFrame, line_width);
+			readFrame += pitch * pixelsize;
+			workUsed += line_width;
 		}
 	} else {
 		/* Add the delta frame data */
@@ -437,11 +440,14 @@ bool VideoCodec::DecompressFrame(void * framedata, int size) {
 		}
 		newframe = buf1;
 		oldframe = buf2;
+
 		unsigned char * writeframe = newframe + pixelsize*(MAX_VECTOR+MAX_VECTOR*pitch);	
-		for (i=0;i<height;i++) {
-			memcpy(writeframe,&work[workPos],width*pixelsize);
-			writeframe+=pitch*pixelsize;
-			workPos+=width*pixelsize;
+		const int line_width = width * pixelsize;
+		assert(line_width > 0);
+		for (i = 0; i < height; ++i) {
+			memcpy(writeframe, &work[workPos], line_width);
+			writeframe += pitch * pixelsize;
+			workPos += line_width;
 		}
 	} else {
 		data = oldframe;

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -16,14 +16,13 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <cassert>
-#include <zlib.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-
 #include "zmbv.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #define DBZV_VERSION_HIGH 0
 #define DBZV_VERSION_LOW 1

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -16,6 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifndef DOSBOX_ZMBV_H
+#define DOSBOX_ZMBV_H
+
 #ifndef DOSBOX_DOSBOX_H
 #ifdef _MSC_VER
 #define INLINE __forceinline
@@ -23,6 +26,8 @@
 #define INLINE inline
 #endif
 #endif
+
+#include <zlib.h>
 
 #define CODEC_4CC "ZMBV"
 
@@ -116,3 +121,6 @@ public:
 	bool DecompressFrame(void * framedata, int size);
 	void Output_UpsideDown_24(void * output);
 };
+
+#endif
+


### PR DESCRIPTION
The first potential overflow is in a size calculation to clear the OpenGL texture buffer:

![Screenshot_20210117-233647_Brave](https://user-images.githubusercontent.com/1557255/104885570-15d2eb00-591d-11eb-96ee-e3bf9684f233.jpg)

 I opted to keep all the types as-is and correct the overflow by lifting the multiplication into a new variable whose name documents the calculation.  Also expanded the use of a magic number to a `constexpr`, which can (in a later PR) cleanup many more uses throughout `sdlmain`.

The second pair of overflows occurred in the zmbv codec:

![Screenshot_20210117-233700_Brave](https://user-images.githubusercontent.com/1557255/104885883-a14c7c00-591d-11eb-955d-e5be4b5f45b2.jpg)

Fixing them.involved using `uint16_t`s to hold the resolution parameters, which are neatly bounded by the DOS maximum VESA spec (1600 x 1200 at 24-bit).    

The alternative was ratcheting these up to `size_t`s, however because the majority of zmbv types are `int`, this causes a cascade od knock-on overflows when the size_t's interact with the other ints. The second negative with this approach is that size_t doesn't reflect the logical content they would hold.

Commits can be reviewed one by one.