### PR TITLE
Provide MT-32 ROM specifications on startup

### DIFF
--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -164,8 +164,14 @@ static bool find_and_load(const std::string &model,
 	const std::string pcm_rom = model + "_PCM.ROM";
 	for (const auto &dir : rom_dirs) {
 		if (load_rom_set(dir + ctr_rom, dir + pcm_rom, service)) {
-			LOG_MSG("MT32: Loaded %s-model ROMs from %s",
-			        model.c_str(), dir.c_str());
+			LOG_MSG("MT32: Found ROM pair in %s", dir.c_str());
+
+			mt32emu_rom_info rom_info;
+			service->getROMInfo(&rom_info);
+			LOG_MSG("MT32: Initialized %s with %s",
+			        rom_info.control_rom_description,
+			        rom_info.pcm_rom_description);
+
 			return true;
 		}
 	}


### PR DESCRIPTION
Provide the user with definitive specifications about their currently-loaded ROMs in the console log. This uses mt32emu's [`getROMInfo`](https://github.com/munt/munt/blob/master/mt32emu/src/ROMInfo.cpp) API, which uses checksums to identify ROM type, model, and version. Examples:

**MT-32 _Old_**
``` text
MT32: Found ROM pair in ./mt32-roms
MT32: Initialized MT-32 Control v1.07 with MT-32 PCM ROM
```

**MT-32 _Blue Ridge_**
``` text
MT32: Found ROM pair in ./mt32-roms
MT32: Initialized MT-32 Control BlueRidge with MT-32 PCM ROM
```

**MT-32 _New_**
``` text
MT32: Found ROM pair in ./mt32-roms
MT32: Initialized MT-32 Control v2.04 with MT-32 PCM ROM
```

**CM32L Latest revision**

``` text
MT32: Found ROM pair in ./mt32-roms
MT32: Initialized CM-32L/LAPC-I Control v1.02 with CM-32L/CM-64/LAPC-I PCM ROM
```

This is important because some games were authored against the old MT-32 control ROM, some against the newer 2.x control ROM, and others used effects only heard using a CM32L:

https://en.wikipedia.org/wiki/List_of_MT-32-compatible_computer_games#Table_of_compatible_games