### PR TITLE
Detect Code Audio, Core MIDI dependencies via Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -109,6 +109,8 @@ opus_dep      = optional_dep
 png_dep       = optional_dep
 z_dep         = optional_dep
 curses_dep    = optional_dep # necessary for debugger builds
+coreaudio_dep = optional_dep # macOS only
+coremidi_dep  = optional_dep # macOS only
 
 msg = 'You can disable this dependency with: -D@0@=false'
 
@@ -137,6 +139,28 @@ endif
 
 if get_option('enable_debugger') != 'none'
   curses_dep = dependency('ncurses') # or pdcurses on Windows
+endif
+
+# macOS-only dependencies
+#
+if host_machine.system() == 'darwin'
+  coreaudio_dep = dependency('appleframeworks',
+                             modules : ['CoreAudio', 'AudioUnit', 'AudioToolbox'],
+                             required : false)
+  if coreaudio_dep.found()
+    conf_data.set('C_SUPPORTS_COREAUDIO', 1)
+  else
+    warning('''Core Audio support disabled: compiler can't detect/use Apple Frameworks''')
+  endif
+
+  coremidi_dep = dependency('appleframeworks',
+                             modules : ['CoreMIDI', 'CoreFoundation'],
+                             required : false)
+  if coremidi_dep.found()
+    conf_data.set('C_SUPPORTS_COREMIDI', 1)
+  else
+    warning('''Core MIDI support disabled: compiler can't detect/use Apple Frameworks''')
+  endif
 endif
 
 

--- a/meson.build
+++ b/meson.build
@@ -99,48 +99,43 @@ endif
 
 # external dependencies
 #
+optional_dep  = dependency('', required : false)
+threads_dep   = dependency('threads')
+sdl2_dep      = dependency('sdl2', version : '>= 2.0.2')
+sdl2_net_dep  = optional_dep
+opengl_dep    = optional_dep
+fluid_dep     = optional_dep
+opus_dep      = optional_dep
+png_dep       = optional_dep
+z_dep         = optional_dep
+curses_dep    = optional_dep # necessary for debugger builds
+
 msg = 'You can disable this dependency with: -D@0@=false'
-dummy_dep = dependency('', required : false)
-threads_dep = dependency('threads')
-sdl2_dep = dependency('sdl2', version : '>= 2.0.2')
 
 if get_option('use_sdl2_net')
   sdl2_net_dep = dependency('SDL2_net', version : '>= 2.0.1',
                             not_found_message : msg.format('use_sdl2_net'))
-else
-  sdl2_net_dep = dummy_dep
 endif
 
 if get_option('use_opengl')
   opengl_dep = dependency('gl', not_found_message : msg.format('use_opengl'))
-else
-  opengl_dep = dummy_dep
 endif
 
 if get_option('use_fluidsynth')
   fluid_dep = dependency('fluidsynth', version : '>= 2.0.0',
                          not_found_message : msg.format('use_fluidsynth'))
-else
-  fluid_dep = dummy_dep
 endif
 
 if get_option('use_opusfile')
   opus_dep = dependency('opusfile', not_found_message : msg.format('use_opusfile'))
-else
-  opus_dep = dummy_dep
 endif
 
 if get_option('use_png')
   png_dep = dependency('libpng', not_found_message : msg.format('use_png'))
   z_dep = dependency('zlib') # libpng in Ubuntu 16.04 needs zlib linked explicitly
-else
-  png_dep = dummy_dep
-  z_dep = dummy_dep
 endif
 
-if get_option('enable_debugger') == 'none'
-  curses_dep = dummy_dep
-else
+if get_option('enable_debugger') != 'none'
   curses_dep = dependency('ncurses') # or pdcurses on Windows
 endif
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -109,6 +109,12 @@
 // Define to 1 to enable MT-32 emulator
 #define C_MT32EMU 0
 
+// Compiler supports Core Audio headers
+#mesondefine C_SUPPORTS_COREAUDIO
+
+// Compiler supports Core MIDI headers
+#mesondefine C_SUPPORTS_COREMIDI
+
 /* Compiler features and extensions
  *
  * These are defines for compiler features we can't reliably verify during

--- a/src/midi/meson.build
+++ b/src/midi/meson.build
@@ -6,7 +6,12 @@ libmidi_sources = [
 
 libmidi = static_library('midi', libmidi_sources,
                          include_directories : incdir,
-                         dependencies : [sdl2_dep, fluid_dep])
+                         dependencies : [
+                           sdl2_dep,
+                           fluid_dep,
+                           coreaudio_dep,
+                           coremidi_dep
+                         ])
 
 libmidi_dep = declare_dependency(link_with : libmidi)
 


### PR DESCRIPTION
Notably, this detection fails when using GCC (it also fails with Autoconf). I decided to delegate these dependencies to macOS only to avoid warnings on other systems.