### PR TITLE
Cleanup autoconf checks/defines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,7 +215,7 @@ AC_HELP_STRING([--enable-alsa-midi],[compile with alsa midi support (default yes
 esac],
 [alsa_midi=true])
 if test x$alsa_midi = xtrue ; then
-  AM_PATH_ALSA(0.9.0, AC_DEFINE(HAVE_ALSA,1,[Define to 1 to use ALSA for MIDI]) , : )
+  AM_PATH_ALSA(0.9.0, AC_DEFINE(C_ALSA,1,[Define to 1 to enable ALSA MIDI support]) , : )
   CXXFLAGS="$CXXFLAGS $ALSA_CFLAGS"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -191,8 +191,7 @@ case "$host" in
    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
    #include <CoreMIDI/MIDIServices.h>
    int blah() { return 0; }
-   ]])], [AC_MSG_RESULT(yes);LIBS="$LIBS -framework CoreMIDI -framework CoreFoundation";AC_DEFINE([C_SUPPORTS_COREMIDI], [],
-   [Compiler supports Core MIDI headers])],
+   ]])], [AC_MSG_RESULT(yes);LIBS="$LIBS -framework CoreMIDI -framework CoreFoundation";AC_DEFINE(C_COREMIDI,1,[Compiler supports Core MIDI headers])],
    AC_MSG_RESULT(no);AC_MSG_WARN([Compiler can't compile Apple headers. CoreMIDI functionality disabled. Please use the Apple compiler!]))
 
    AC_MSG_CHECKING(if compiler supports Apple's Core Audio headers)
@@ -200,8 +199,7 @@ case "$host" in
    #include <AudioToolbox/AUGraph.h>
    #include <CoreServices/CoreServices.h>
    int blah() { return 0; }
-   ]])], [AC_MSG_RESULT(yes);LIBS="$LIBS -framework AudioUnit -framework AudioToolbox";AC_DEFINE([C_SUPPORTS_COREAUDIO], [],
-   [Compiler supports Core Audio headers])],
+   ]])], [AC_MSG_RESULT(yes);LIBS="$LIBS -framework AudioUnit -framework AudioToolbox";AC_DEFINE(C_COREAUDIO,1,[Compiler supports Core Audio headers])],
    AC_MSG_RESULT(no);AC_MSG_WARN([Compiler can't compile Apple headers. CoreAudio functionality disabled. Please use the Apple compiler!]))
    ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -158,14 +158,6 @@ fi
 
 dnl Checks for libraries.
 
-#Check if the compiler support attributes
-AH_TEMPLATE([C_HAS_ATTRIBUTE],[Determines if the compiler supports attributes for structures.])
-AC_MSG_CHECKING(if compiler allows __attribute__)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-typedef struct { } __attribute__((packed)) junk;]],
-[[ ]])],[ AC_MSG_RESULT(yes);AC_DEFINE(C_HAS_ATTRIBUTE)],AC_MSG_RESULT(no))
-
-
 #Check if the compiler supports certain attributes
 OLDCFLAGS="$CFLAGS"
 CFLAGS="-Werror"

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -37,8 +37,11 @@
 // alongside __has_cpp_attribute, and with the same logic.
 // See: https://clang.llvm.org/docs/LanguageExtensions.html#has-attribute
 
-#ifndef __has_attribute // for compatibility with non-supporting compilers
-#define __has_attribute(x) 0
+#ifdef __has_attribute
+#define C_HAS_ATTRIBUTE 1
+#else
+#define C_HAS_ATTRIBUTE 0
+#define __has_attribute(x) 0 // for compatibility with non-supporting compilers
 #endif
 
 // When passing the -Wunused flag to GCC or Clang, entities that are unused by

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -605,10 +605,10 @@ void DOSBOX_Init(void) {
 	const char *midi_devices[] = {
 		"auto",
 #if defined(MACOSX)
-#ifdef C_SUPPORTS_COREMIDI
+#if C_COREMIDI
 		"coremidi",
 #endif
-#ifdef C_SUPPORTS_COREAUDIO
+#if C_COREAUDIO
 		"coreaudio",
 #endif
 #elif defined(WIN32)
@@ -652,7 +652,7 @@ void DOSBOX_Init(void) {
 	        "- This option has no effect when using the built-in synthesizers\n"
 	        "  (mididevice = fluidsynth or mt32).\n"
 #endif
-#ifdef C_SUPPORTS_COREAUDIO
+#if C_COREAUDIO
 	        "- When using CoreAudio, you can specify a soundfont here.\n"
 #endif
 #if C_ALSA

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -616,7 +616,7 @@ void DOSBOX_Init(void) {
 #else
 		"oss",
 #endif
-#if defined(HAVE_ALSA)
+#if C_ALSA
 		"alsa",
 #endif
 #if C_FLUIDSYNTH
@@ -655,7 +655,7 @@ void DOSBOX_Init(void) {
 #ifdef C_SUPPORTS_COREAUDIO
 	        "- When using CoreAudio, you can specify a soundfont here.\n"
 #endif
-#if defined(HAVE_ALSA)
+#if C_ALSA
 	        "- When using ALSA, use Linux command 'aconnect -l' to list open\n"
 	        "  MIDI ports, and select one (for example 'midiconfig=14:0'\n"
 	        "  for sequencer client 14, port 0).\n"

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -80,15 +80,10 @@ MidiHandler Midi_none;
 
 #if defined(MACOSX)
 
-#if defined(C_SUPPORTS_COREMIDI)
 #include "midi_coremidi.h"
-#endif
-
-#if defined(C_SUPPORTS_COREAUDIO)
 #include "midi_coreaudio.h"
-#endif
 
-#elif defined (WIN32)
+#elif defined(WIN32)
 
 #include "midi_win32.h"
 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -100,11 +100,7 @@ MidiHandler_oss Midi_oss;
 
 #endif
 
-#if defined (HAVE_ALSA)
-
 #include "midi_alsa.h"
-
-#endif
 
 struct DB_Midi {
 	uint8_t status;

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -24,6 +24,8 @@
 
 #include "midi_handler.h"
 
+#if C_ALSA
+
 #define ALSA_PCM_OLD_HW_PARAMS_API
 #define ALSA_PCM_OLD_SW_PARAMS_API
 #include <alsa/asoundlib.h>
@@ -223,5 +225,7 @@ public:
 };
 
 MidiHandler_alsa Midi_alsa;
+
+#endif // C_ALSA
 
 #endif

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -24,6 +24,8 @@
 
 #include "midi_handler.h"
 
+#if C_COREAUDIO
+
 #include <AudioToolbox/AUGraph.h>
 #include <CoreServices/CoreServices.h>
 
@@ -212,5 +214,7 @@ public:
 #undef RequireNoErr
 
 MidiHandler_coreaudio Midi_coreaudio;
+
+#endif // C_COREAUDIO
 
 #endif

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -24,6 +24,8 @@
 
 #include "midi_handler.h"
 
+#if C_COREMIDI
+
 #include <CoreMIDI/MIDIServices.h>
 #include <sstream>
 #include <string>
@@ -167,5 +169,7 @@ public:
 };
 
 MidiHandler_coremidi Midi_coremidi;
+
+#endif // C_COREMIDI
 
 #endif


### PR DESCRIPTION
Cleanup for meson migration. After these are done, the last remaining define to port will be `C_HAS_BUILTIN_EXPECT`. Unfortunately it will require a meson compilation check - modern compilers have `__has_builtin(__builtin_expect)`, but it's broken prior to Clang 10 / unavailable prior to GCC 10.