### PR TITLE
Add MSYS2 support and port "Config heavy" workflow to meson

### DIFF
--- a/.github/packages/.gitattributes
+++ b/.github/packages/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf 

--- a/.github/packages/macos-latest-brew.txt
+++ b/.github/packages/macos-latest-brew.txt
@@ -1,6 +1,7 @@
 ccache
 fluid-synth
 libpng
+meson
 opusfile
 sdl2
 sdl2_net

--- a/.github/packages/windows-latest-msys2.txt
+++ b/.github/packages/windows-latest-msys2.txt
@@ -1,0 +1,11 @@
+meson
+mingw-w64-x86_64-ccache
+mingw-w64-x86_64-fluidsynth
+mingw-w64-x86_64-gcc
+mingw-w64-x86_64-libpng
+mingw-w64-x86_64-ncurses
+mingw-w64-x86_64-opusfile
+mingw-w64-x86_64-pkg-config
+mingw-w64-x86_64-SDL2
+mingw-w64-x86_64-SDL2_net
+mingw-w64-x86_64-zlib

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -63,7 +63,7 @@ jobs:
         if:    matrix.system.name == 'Windows'
         with:
           path: 'C:/tools/msys64'
-          key: msys2-64-${{ steps.get-date.outputs.date }}-4
+          key: msys2-64-${{ steps.get-date.outputs.date }}-6
 
       - name:  Install MSYS2 (Windows)
         if:    >
@@ -77,30 +77,19 @@ jobs:
           steps.cache-msys2.outputs.cache-hit != 'true'
         shell: python scripts\msys-bash.py {0}
         run: |
-           pacman -S --noconfirm \
-             meson \
-             mingw-w64-x86_64-ccache \
-             mingw-w64-x86_64-fluidsynth \
-             mingw-w64-x86_64-gcc \
-             mingw-w64-x86_64-libpng \
-             mingw-w64-x86_64-ncurses \
-             mingw-w64-x86_64-opusfile \
-             mingw-w64-x86_64-pkg-config \
-             mingw-w64-x86_64-SDL2 \
-             mingw-w64-x86_64-SDL2_net \
-             mingw-w64-x86_64-zlib
+           pacman -S --noconfirm $(cat .github/packages/windows-latest-msys2.txt)
            .github/scripts/shrink-msys2.sh
 
       - name:  Install dependencies (Linux)
         if:    matrix.system.name == 'Linux'
         run: |
           sudo apt-get -y update
-          sudo apt-get install $(cat ./.github/packages/ubuntu-20.04-apt.txt)
+          sudo apt-get install $(cat .github/packages/ubuntu-20.04-apt.txt)
 
       - name:  Install dependencies (macOS)
         if:    matrix.system.name == 'macOS'
         run: |
-          brew install $(cat ./.github/packages/macos-latest-brew.txt)
+          brew install $(cat .github/packages/macos-latest-brew.txt)
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
         if:    matrix.system.name == 'Windows'

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -15,7 +15,7 @@ jobs:
       has-commits: ${{ steps.commit-check.outputs.has-commits }}
 
   config_all:
-    name: ${{ matrix.system.name }} ${{ matrix.conf.configure_flags }} ${{ matrix.conf.without_packages }}
+    name: ${{ matrix.system.name }} ${{ matrix.conf.configure_flags }}
     runs-on: ${{ matrix.system.os }}
     needs: repo-check
     if: needs.repo-check.outputs.has-commits == 'true'
@@ -25,41 +25,28 @@ jobs:
         system:
           - name: Windows
             os: windows-latest
-            compiler: gcc
           - name: macOS
             os: macos-latest
-            compiler: clang
-            missing_packages: --disable-fluidsynth
           - name: Linux
             os: ubuntu-20.04
-            compiler: gcc
         conf:
-          - configure_flags:  --enable-debug
-          - configure_flags:  --enable-debug=heavy
-          - configure_flags:  --enable-alsa-midi
-          - configure_flags:  --enable-png-static
-          - configure_flags:  --enable-sdl-static
-          - configure_flags:  --enable-png-static --enable-sdl-static
-          - configure_flags:  --disable-alsa-midi
-          - configure_flags:  --disable-core-inline
-          - configure_flags:  --disable-dynamic-x86
-          - configure_flags:  --disable-dynrec
-          - configure_flags:  --disable-fpu
-          - configure_flags:  --disable-fpu-x64
-          - configure_flags:  --disable-fpu-x86
-          - configure_flags:  --disable-opengl
-          - configure_flags:  --disable-opus-cdda
-          - configure_flags:  --disable-screenshots
-          - configure_flags:  --disable-unaligned-memory
-          - configure_flags:  --disable-fluidsynth
-          - configure_flags:  --disable-mt32
-          - without_packages: -x net
-          - without_packages: -x curses
-          - without_packages: -x net -x curses
+          - configure_flags:  -Duse_sdl2_net=false
+          - configure_flags:  -Duse_opengl=false         # TODO opengl is always disabled on msys2
+          - configure_flags:  -Duse_fluidsynth=false
+          - configure_flags:  -Duse_opusfile=false
+          - configure_flags:  -Duse_png=false
+          # - configure_flags:  -Denable_debugger=normal # TODO broken on msys2
+          # - configure_flags:  -Denable_debugger=heavy  # TODO broken on msys2
+          - configure_flags:  -Ddynamic_core=dyn-x86
+          - configure_flags:  -Ddynamic_core=dynrec
+          - configure_flags:  -Ddynamic_core=none
+
     env:
       CHERE_INVOKING: yes
+
     steps:
       - uses:  actions/checkout@v2
+
       - name:  Check repo for commits
         id:    repo-meta
         shell: bash
@@ -76,7 +63,7 @@ jobs:
         if:    matrix.system.name == 'Windows'
         with:
           path: 'C:/tools/msys64'
-          key: msys2-64-${{ steps.get-date.outputs.date }}-3
+          key: msys2-64-${{ steps.get-date.outputs.date }}-4
 
       - name:  Install MSYS2 (Windows)
         if:    >
@@ -90,35 +77,51 @@ jobs:
           steps.cache-msys2.outputs.cache-hit != 'true'
         shell: python scripts\msys-bash.py {0}
         run: |
-           scripts/list-build-dependencies.sh -m msys2 -c clang ${{ matrix.conf.without_packages }} | xargs pacman -S --noconfirm
+           pacman -S --noconfirm \
+             meson \
+             mingw-w64-x86_64-ccache \
+             mingw-w64-x86_64-fluidsynth \
+             mingw-w64-x86_64-gcc \
+             mingw-w64-x86_64-libpng \
+             mingw-w64-x86_64-ncurses \
+             mingw-w64-x86_64-opusfile \
+             mingw-w64-x86_64-pkg-config \
+             mingw-w64-x86_64-SDL2 \
+             mingw-w64-x86_64-SDL2_net \
+             mingw-w64-x86_64-zlib
            .github/scripts/shrink-msys2.sh
 
-      - name:  Install dependencies ${{ matrix.conf.without_packages }} (Linux)
+      - name:  Install dependencies (Linux)
         if:    matrix.system.name == 'Linux'
         run: |
           sudo apt-get -y update
-          sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c gcc ${{ matrix.conf.without_packages }})
+          sudo apt-get install $(cat ./.github/packages/ubuntu-20.04-apt.txt)
 
-      - name:  Install dependencies ${{ matrix.conf.without_packages }} (macOS)
+      - name:  Install dependencies (macOS)
         if:    matrix.system.name == 'macOS'
-        run:   brew install $(./scripts/list-build-dependencies.sh -m brew -c clang ${{ matrix.conf.without_packages }})
+        run: |
+          brew install meson $(cat ./.github/packages/macos-brew.txt)
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
         if:    matrix.system.name == 'Windows'
         shell: python scripts\msys-bash.py {0}
-        run: >
-          scripts/build.sh -c ${{ matrix.system.compiler }} -t debug --bin-path /mingw64/bin
-          ${{ matrix.conf.configure_flags }} ${{ matrix.system.missing_packages }}
+        run: |
+          export PATH="/mingw64/bin:$PATH"
+          meson setup --wrap-mode=nofallback -Duse_opengl=false \
+            ${{ matrix.conf.configure_flags }} build
+          cat build/meson-logs/meson-log.txt
+          ninja -C build
 
       - name:  Build ${{ matrix.conf.configure_flags }} (macOS)
         if:    matrix.system.name == 'macOS'
-        run: >
-          export PKG_CONFIG_PATH="/usr/local/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH" &&
-          ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug
-          ${{ matrix.conf.configure_flags }} ${{ matrix.system.missing_packages }}
+        run: |
+          meson setup --wrap-mode=nofallback \
+            ${{ matrix.conf.configure_flags }} build
+          ninja -C build
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Linux)
         if:    matrix.system.name == 'Linux'
-        run: >
-          ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug
-          ${{ matrix.conf.configure_flags }} ${{ matrix.system.missing_packages }}
+        run: |
+          meson setup --wrap-mode=nofallback \
+            ${{ matrix.conf.configure_flags }} build
+          ninja -C build

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -100,7 +100,7 @@ jobs:
       - name:  Install dependencies (macOS)
         if:    matrix.system.name == 'macOS'
         run: |
-          brew install meson $(cat ./.github/packages/macos-brew.txt)
+          brew install $(cat ./.github/packages/macos-latest-brew.txt)
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
         if:    matrix.system.name == 'Windows'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,19 +22,16 @@ jobs:
             build_flags: --wrap-mode=nofallback
             max_warnings: 0
           - name: GCC
-            packages: meson gcc@9
+            packages: gcc@9
             build_flags: --wrap-mode=nofallback --native-file=.github/meson/native-gcc-9.ini
             max_warnings: 0
           - name: Clang, +tests
-            packages: meson
             run_tests: true
             max_warnings: -1
           - name: Clang, +debugger
-            packages: meson
             build_flags: --wrap-mode=nofallback -Denable_debugger=normal
             max_warnings: 154
           - name: Clang, warning_level=3
-            packages: meson
             build_flags: --wrap-mode=nofallback -Dwarning_level=3
             max_warnings: 179
 
@@ -45,7 +42,7 @@ jobs:
         run: |
           brew install \
             ${{ matrix.conf.packages }} \
-            $(cat ./.github/packages/macos-brew.txt)
+            $(cat ./.github/packages/macos-latest-brew.txt)
 
       - name:  Prepare compiler cache
         id:    prep-ccache

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,10 @@ if cxx.get_id() == 'msvc'
   conf_data.set('NOMINMAX', true)
 endif
 
+if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
+  conf_data.set('_USE_MATH_DEFINES', true)
+endif
+
 if host_machine.endian() == 'big'
   conf_data.set('WORDS_BIGENDIAN', 1)
 endif

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,8 @@ curses_dep    = optional_dep # necessary for debugger builds
 alsa_dep      = optional_dep # Linux-only
 coreaudio_dep = optional_dep # macOS-only
 coremidi_dep  = optional_dep # macOS-only
+winsock2_dep  = optional_dep # Windows-only
+winmm_dep     = optional_dep # Windows-only
 
 msg = 'You can disable this dependency with: -D@0@=false'
 
@@ -202,6 +204,13 @@ endif
 if host_machine.system() == 'linux'
   alsa_dep = dependency('alsa')
   conf_data.set('C_ALSA', 1)
+endif
+
+# Windows-only dependencies
+#
+if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
+  winsock2_dep = cxx.find_library('ws2_32', required : true)
+  winmm_dep = cxx.find_library('winmm', required : true)
 endif
 
 

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,12 @@ foreach header : ['pwd.h', 'strings.h', 'netinet/in.h', 'sys/socket.h']
   endif
 endforeach
 
+# Header windows.h defines old min/max macros, that conflict with C++11
+# std::min/std::max.  Defining NOMINMAX prevents these macros from appearing.
+if cxx.get_id() == 'msvc'
+  conf_data.set('NOMINMAX', true)
+endif
+
 if host_machine.endian() == 'big'
   conf_data.set('WORDS_BIGENDIAN', 1)
 endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -164,4 +164,10 @@
 // Non-4K page size (only on selected architectures)
 #mesondefine PAGESIZE
 
+/* Windows-related defines
+ */
+
+// Prevent <windows.h> from clobbering std::min and std::max
+#mesondefine NOMINMAX
+
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -170,4 +170,8 @@
 // Prevent <windows.h> from clobbering std::min and std::max
 #mesondefine NOMINMAX
 
+// Enables mathematical constants (such as M_PI) in Windows math.h header
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+#mesondefine _USE_MATH_DEFINES
+
 #endif

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -56,6 +56,7 @@ libhardware = static_library('hardware', libhardware_sources,
                              dependencies : [
                                sdl2_dep,
                                sdl2_net_dep,
+                               winsock2_dep,
                                png_dep,
                                z_dep,
                                libnuked_dep

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,11 @@
 
 #include "dosbox.h"
 
+// When compiling for Windows, SDL converts function 'main' to 'WinMain' and
+// performs some additional initialization.
+//
+#include <SDL.h>
+
 int main(int argc, char *argv[])
 {
 	return sdl_main(argc, argv);

--- a/src/midi/meson.build
+++ b/src/midi/meson.build
@@ -11,7 +11,8 @@ libmidi = static_library('midi', libmidi_sources,
                            fluid_dep,
                            alsa_dep,
                            coreaudio_dep,
-                           coremidi_dep
+                           coremidi_dep,
+                           winmm_dep
                          ])
 
 libmidi_dep = declare_dependency(link_with : libmidi)


### PR DESCRIPTION
I recommend reviewing commit-by-commit.

Regarding "Config heavy" workflow: it includes fewer configurations now, and some configurations are disabled for now:

- `--enable-debug` -> now `-Denable_debugger=normal` - disabled for now because `curses`/`ncurses`/`ncursesw`/`pdcurses` dependency does not work in msys2 with meson - Meson is able to detect it, but ninja fails during linking.
  *I suspect a bug in MSYS2  `mingw-w64-x86_64-ncurses` package - requires investigation, but I would rather fix the issue at the origin rather than deploy msys2-only workaround in our buildsystem*.
- `--enable-debug-heavy` -> now `-Denable_debugger=heavy` - same as above, plus we might have a bug in unit tests preventing the build from succeeding (TBI).
- `--enable-alsa-midi` -> testing this option made no sense on Windows or macOS; ALSA is now mandatory dependency, but only when compiling on Linux (just like there were no separate flags to disable Windows and macOS-specific MIDI backends in autoconf)
- `--enable-png-static`, `--enable-sdl-static` - not supported via Meson yet. **It seems like currently these options are broken in MSYS2 on master** (we get false-positive successful CI build on MSYS2 + Autoconf).
-  `--disable-core-inline`, `--disable-dynamic-x86`, `--disable-dynrec`, `--disable-fpu`, `--disable-fpu-x64`, `--disable-fpu-x86`, `--disable-unaligned-memory` - these 7 flags (2^7 combinations!) got replaced by: `-Ddynamic_core={dyn-x86, dynrec, none}` (3 combinations). Rest of logic is implemented in Meson, so users don't need to correlate these (undocumented) flags manually.
-  `--disable-opengl` - pointless on MSYS2 because **every MSYS2 build on master has OpenGL silently disabled**. I consider this a bug that slipped in. Not sure how to correctly build on MSYS2 with OpenGL support ATM.
- `--disable-opus-cdda` -> `-Duse_opusfile=false` - works OK on MSYS2, macOS, and Linux
- `--disable-fluidsynth` -> `-Duse_fluidsynth=false` - works OK on MSYS2, macOS, and Linux (worth noting: FluidSynth lib is now correctly picked on macOS by default!)
- `--disable-screenshots` -> `-Duse_png=false` - works OK on MSYS2, macOS, and Linux
- `--disable-mt32` -> ??? - MT32 dependency to be added to Meson in future PR, I think?