### PR TITLE
Minor cleanup and fix race condition in Disney

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,7 +46,7 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --enable-debug
-            max_warnings: 101
+            max_warnings: 95
           - name: GCC, +dynrec, -dyn_x86
             os: ubuntu-20.04
             flags: -c gcc
@@ -56,7 +56,7 @@ jobs:
             os: ubuntu-20.04
             flags: -c gcc
             config_flags: --disable-dynamic-x86 --enable-debug
-            max_warnings: 138
+            max_warnings: 132
           - name: GCC, -network
             os: ubuntu-20.04
             flags: -c gcc

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 269
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1975
+            max_warnings: 1969
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -366,7 +366,13 @@ static void DISNEY_CallBack(Bitu len) {
 	}
 }
 
-static void DISNEY_ShutDown(Section* sec){
+static void DISNEY_ShutDown(Section *sec)
+{
+	DEBUG_LOG_MSG("DISNEY: Shutting down");
+
+	// Remove interrupt events
+	PIC_RemoveEvents(DISNEY_disable);
+
 	// Stop the game from accessing the IO ports
 	disney.read_handler.Uninstall();
 	disney.write_handler.Uninstall();

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -269,9 +269,10 @@ static void disney_write(Bitu port, Bitu data, MAYBE_UNUSED Bitu iolen)
 	}
 }
 
-static Bitu disney_read(Bitu port,Bitu iolen) {
-	Bitu retval;
-	switch (port-DISNEY_BASE) {
+static Bitu disney_read(Bitu port, MAYBE_UNUSED Bitu iolen)
+{
+	uint8_t retval;
+	switch (port - DISNEY_BASE) {
 	case 0:		/* Data Port */
 //		LOG(LOG_MISC,LOG_NORMAL)("DISNEY:Read from data port");
 		return disney.data;

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -34,14 +34,14 @@ constexpr uint8_t DISNEY_INIT_STATUS = 0x84;
 
 enum STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 
-typedef struct _dac_channel {
-	uint8_t buffer[BUFFER_SAMPLES];
-	uint8_t used; // current data buffer level
-	double speedcheck_sum;
-	double speedcheck_last;
-	bool speedcheck_failed;
-	bool speedcheck_init;
-} dac_channel;
+struct dac_channel {
+	uint8_t buffer[BUFFER_SAMPLES] = {};
+	uint8_t used = 0; // current data buffer level
+	double speedcheck_sum = 0;
+	double speedcheck_last = 0;
+	bool speedcheck_failed = false;
+	bool speedcheck_init = false;
+};
 
 using mixer_channel_ptr_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
@@ -50,22 +50,22 @@ struct Disney {
 	IO_WriteHandleObject write_handler{};
 
 	// parallel port stuff
-	uint8_t data;
+	uint8_t data = 0;
 	uint8_t status = DISNEY_INIT_STATUS;
-	uint8_t control;
+	uint8_t control = 0;
 	// the D/A channels
-	dac_channel da[2];
+	dac_channel da[2] = {};
 
-	Bitu last_used;
+	Bitu last_used = 0;
 	mixer_channel_ptr_t chan{nullptr, MIXER_DelChannel};
-	bool stereo;
+	bool stereo = false;
 	// which channel do we use for mono output?
 	// and the channel used for stereo
-	dac_channel* leader;
-	
+	dac_channel* leader = nullptr;
+
 	STATE state = STATE::IDLE;
-	Bitu interface_det;
-	Bitu interface_det_ext;
+	Bitu interface_det = 0;
+	Bitu interface_det_ext = 0;
 };
 
 static Disney disney;

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -16,9 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "dosbox.h"
 
 #include <string.h>
-#include "dosbox.h"
+
 #include "inout.h"
 #include "mixer.h"
 #include "pic.h"

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -131,9 +131,6 @@ static void DISNEY_analyze(Bitu channel){
 
 		case STATE::FINISHED: 
 		{
-			// detect stereo: if we have about the same data amount in both channels
-			Bits st_diff = disney.da[0].used - disney.da[1].used;
-			
 			// find leader channel (the one with higher rate) [this good for the stereo case?]
 			if(disney.da[0].used > disney.da[1].used) {
 				//disney.monochannel=0;
@@ -143,9 +140,11 @@ static void DISNEY_analyze(Bitu channel){
 				disney.leader = &disney.da[1];
 			}
 			
-			if((st_diff < 5) && (st_diff > -5)) disney.stereo = true;
-			else disney.stereo = false;
-
+			// Stereo-mode if both DACs are similarly filled
+			const auto st_diff = abs(disney.da[0].used -
+			                         disney.da[1].used);
+			disney.stereo = (st_diff < 5);
+			
 			// Run with the greater DAC frequency
 			const auto max_freq = std::max(calc_frequency(disney.da[0]),
 			                               calc_frequency(disney.da[1]));

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -321,7 +321,7 @@ static void DISNEY_CallBack(uint16_t len) {
 		else disney.chan->AddSamples_m8(len,disney.leader->buffer);
 
 		// put the rest back to start
-		for(int i = 0; i < 2; i++) {
+		for (uint8_t i = 0; i < 2; ++i) {
 			// TODO for mono only one
 			memmove(disney.da[i].buffer, &disney.da[i].buffer[len],
 			        BUFFER_SAMPLES /*real_used*/ - len);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -61,7 +61,7 @@ struct Disney {
 	bool stereo = false;
 	// which channel do we use for mono output?
 	// and the channel used for stereo
-	dac_channel* leader = nullptr;
+	dac_channel *leader = nullptr;
 
 	STATE state = STATE::IDLE;
 	Bitu interface_det = 0;
@@ -132,15 +132,11 @@ static void DISNEY_analyze(Bitu channel){
 
 		case STATE::FINISHED: 
 		{
-			// find leader channel (the one with higher rate) [this good for the stereo case?]
-			if(disney.da[0].used > disney.da[1].used) {
-				//disney.monochannel=0;
-				disney.leader = &disney.da[0];
-			} else {
-				//disney.monochannel=1;
-				disney.leader = &disney.da[1];
-			}
-			
+			// The leading channel has the most populated samples
+			disney.leader = disney.da[0].used > disney.da[1].used
+			                        ? &disney.da[0]
+			                        : &disney.da[1];
+
 			// Stereo-mode if both DACs are similarly filled
 			const auto st_diff = abs(disney.da[0].used -
 			                         disney.da[1].used);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -24,9 +24,9 @@
 #include "pic.h"
 #include "setup.h"
 
-#define DISNEY_BASE 0x0378
-
-#define DISNEY_SIZE 128
+// Disney Sound Source Constants
+constexpr uint16_t DISNEY_BASE = 0x0378;
+constexpr uint8_t DISNEY_SIZE = 128;
 
 enum STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -374,7 +374,7 @@ static void DISNEY_CallBack(uint16_t len) {
 	}
 }
 
-static void DISNEY_ShutDown(Section *sec)
+static void DISNEY_ShutDown(MAYBE_UNUSED Section *sec)
 {
 	DEBUG_LOG_MSG("DISNEY: Shutting down");
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -98,6 +98,19 @@ static void DISNEY_enable(uint32_t freq)
 	disney.state = STATE::RUNNING;
 }
 
+// Calculate the frequency from DAC samples and speed parameters
+// The maximum possible frequency return is 127000 Hz, which
+// occurs when all 128 samples are used and the speedcheck_sum
+// has accumulated only one single tick.
+static uint32_t calc_frequency(const dac_channel &dac)
+{
+	if (dac.used <= 1)
+		return 0;
+	const uint32_t k_samples = 1000 * (dac.used - 1);
+	const auto frequency = k_samples / dac.speedcheck_sum;
+	return static_cast<uint32_t>(frequency);
+}
+
 static void DISNEY_analyze(Bitu channel){
 	switch(disney.state) {
 		case STATE::RUNNING: // should not get here

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -30,6 +30,7 @@
 // Disney Sound Source Constants
 constexpr uint16_t DISNEY_BASE = 0x0378;
 constexpr uint8_t BUFFER_SAMPLES = 128;
+constexpr uint8_t DISNEY_INIT_STATUS = 0x84;
 
 enum STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 
@@ -50,7 +51,7 @@ struct Disney {
 
 	// parallel port stuff
 	uint8_t data;
-	uint8_t status;
+	uint8_t status = DISNEY_INIT_STATUS;
 	uint8_t control;
 	// the D/A channels
 	dac_channel da[2];
@@ -413,7 +414,7 @@ void DISNEY_Init(Section* sec) {
 	disney.read_handler.Install(DISNEY_BASE, disney_read, IO_MB, 3);
 
 	// Initialize the Disney states
-	disney.status = 0x84;
+	disney.status = DISNEY_INIT_STATUS;
 	disney.control = 0;
 	disney.last_used = 0;
 	DISNEY_disable(0);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -33,7 +33,7 @@ enum STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 
 typedef struct _dac_channel {
 	uint8_t buffer[BUFFER_SAMPLES];
-	Bitu used;					// current data buffer level
+	uint8_t used; // current data buffer level
 	double speedcheck_sum;
 	double speedcheck_last;
 	bool speedcheck_failed;
@@ -281,9 +281,10 @@ static Bitu disney_read(Bitu port,Bitu iolen) {
 	return 0xff;
 }
 
-static void DISNEY_PlayStereo(Bitu len, uint8_t* l, uint8_t* r) {
+static void DISNEY_PlayStereo(Bitu len, uint8_t *l, uint8_t *r)
+{
 	static uint8_t stereodata[BUFFER_SAMPLES * 2];
-	for(Bitu i = 0; i < len; i++) {
+	for (Bitu i = 0; i < len; i++) {
 		stereodata[i*2] = l[i];
 		stereodata[i*2+1] = r[i];
 	}
@@ -317,7 +318,7 @@ static void DISNEY_CallBack(Bitu len) {
 		if(disney.stereo) {
 			uint8_t gapfiller0 = 128;
 			uint8_t gapfiller1 = 128;
-			if(real_used) {
+			if (real_used) {
 				gapfiller0 = disney.da[0].buffer[real_used-1];
 				gapfiller1 = disney.da[1].buffer[real_used-1];
 			};
@@ -331,7 +332,7 @@ static void DISNEY_CallBack(Bitu len) {
 			len -= real_used;
 
 		} else { // mono
-			uint8_t gapfiller = 128; //Keep the middle
+			uint8_t gapfiller = 128; // Keep the middle
 			if(real_used) {
 				// fix for some stupid game; it outputs 0 at the end of the stream
 				// causing a click. So if we have at least two bytes availible in the

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -32,7 +32,7 @@ constexpr uint8_t BUFFER_SAMPLES = 128;
 enum STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 
 typedef struct _dac_channel {
-	Bit8u buffer[BUFFER_SAMPLES];
+	uint8_t buffer[BUFFER_SAMPLES];
 	Bitu used;					// current data buffer level
 	double speedcheck_sum;
 	double speedcheck_last;
@@ -42,9 +42,9 @@ typedef struct _dac_channel {
 
 static struct {
 	// parallel port stuff
-	Bit8u data;
-	Bit8u status;
-	Bit8u control;
+	uint8_t data;
+	uint8_t status;
+	uint8_t control;
 	// the D/A channels
 	dac_channel da[2];
 
@@ -281,8 +281,8 @@ static Bitu disney_read(Bitu port,Bitu iolen) {
 	return 0xff;
 }
 
-static void DISNEY_PlayStereo(Bitu len, Bit8u* l, Bit8u* r) {
-	static Bit8u stereodata[BUFFER_SAMPLES * 2];
+static void DISNEY_PlayStereo(Bitu len, uint8_t* l, uint8_t* r) {
+	static uint8_t stereodata[BUFFER_SAMPLES * 2];
 	for(Bitu i = 0; i < len; i++) {
 		stereodata[i*2] = l[i];
 		stereodata[i*2+1] = r[i];
@@ -315,8 +315,8 @@ static void DISNEY_CallBack(Bitu len) {
 	// TODO: len > DISNEY
 	} else { // not enough data
 		if(disney.stereo) {
-			Bit8u gapfiller0 = 128;
-			Bit8u gapfiller1 = 128;
+			uint8_t gapfiller0 = 128;
+			uint8_t gapfiller1 = 128;
 			if(real_used) {
 				gapfiller0 = disney.da[0].buffer[real_used-1];
 				gapfiller1 = disney.da[1].buffer[real_used-1];
@@ -331,7 +331,7 @@ static void DISNEY_CallBack(Bitu len) {
 			len -= real_used;
 
 		} else { // mono
-			Bit8u gapfiller = 128; //Keep the middle
+			uint8_t gapfiller = 128; //Keep the middle
 			if(real_used) {
 				// fix for some stupid game; it outputs 0 at the end of the stream
 				// causing a click. So if we have at least two bytes availible in the

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -150,7 +150,7 @@ static void DISNEY_analyze(Bitu channel){
 		}
 		case STATE::ANALYZING:
 		{
-			double current = PIC_FullIndex();
+			const double current = PIC_FullIndex();
 			dac_channel* cch = &disney.da[channel];
 
 			if(!cch->speedcheck_init) {

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -373,11 +373,8 @@ public:
 		Section_prop * section=static_cast<Section_prop *>(configuration);
 		if(!section->Get_bool("disney")) return;
 
-		disney.status=0x84;
-		disney.control=0;
-		disney.last_used=0;
 
-		DISNEY_disable(0);
+		
 	}
 
 	~DISNEY() { DISNEY_disable(0); }
@@ -396,6 +393,7 @@ static void DISNEY_ShutDown(Section* sec){
 		disney.chan.reset();
 	}
 
+	DISNEY_disable(0);
 	delete test;
 }
 
@@ -411,6 +409,12 @@ void DISNEY_Init(Section* sec) {
 	// Register port handlers for 8-bit IO
 	disney.write_handler.Install(DISNEY_BASE, disney_write, IO_MB, 3);
 	disney.read_handler.Install(DISNEY_BASE, disney_read, IO_MB, 3);
+
+	// Initialize the Disney states
+	disney.status = 0x84;
+	disney.control = 0;
+	disney.last_used = 0;
+	DISNEY_disable(0);
 
 	sec->AddDestroyFunction(&DISNEY_ShutDown, true);
 }

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -76,20 +76,20 @@ static void DISNEY_disable(Bitu) {
 	disney.stereo = false;
 }
 
-static void DISNEY_enable(Bitu freq) {
-	if(freq < 500 || freq > 100000) {
+static void DISNEY_enable(uint32_t freq)
+{
+	if (freq < 500 || freq > 100000) {
 		// try again..
 		disney.state = STATE::IDLE;
-		return;	
-	} else {
-#if 0
-		if(disney.stereo) LOG(LOG_MISC,LOG_NORMAL)("disney enable %d Hz, stereo",freq);
-		else LOG(LOG_MISC,LOG_NORMAL)("disney enable %d Hz, mono",freq);
-#endif
-		disney.chan->SetFreq(freq);
-		disney.chan->Enable(true);
-		disney.state = STATE::RUNNING;
+		return;
 	}
+#if 0
+	LOG(LOG_MISC,LOG_NORMAL)("DISNEY: enabled at %d Hz in %s", freq,
+	                         disney.stereo ? "stereo" : "mono");
+#endif
+	disney.chan->SetFreq(freq);
+	disney.chan->Enable(true);
+	disney.state = STATE::RUNNING;
 }
 
 static void DISNEY_analyze(Bitu channel){

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -64,8 +64,8 @@ struct Disney {
 	dac_channel *leader = nullptr;
 
 	STATE state = STATE::IDLE;
-	Bitu interface_det = 0;
-	Bitu interface_det_ext = 0;
+	uint32_t interface_det = 0;
+	uint32_t interface_det_ext = 0;
 };
 
 static Disney disney;

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -366,22 +366,6 @@ static void DISNEY_CallBack(Bitu len) {
 	}
 }
 
-class DISNEY : public Module_base {
-public:
-	DISNEY(Section *configuration) : Module_base(configuration)
-	{
-		Section_prop * section=static_cast<Section_prop *>(configuration);
-		if(!section->Get_bool("disney")) return;
-
-
-		
-	}
-
-	~DISNEY() { DISNEY_disable(0); }
-};
-
-static DISNEY* test;
-
 static void DISNEY_ShutDown(Section* sec){
 	// Stop the game from accessing the IO ports
 	disney.read_handler.Uninstall();
@@ -394,11 +378,13 @@ static void DISNEY_ShutDown(Section* sec){
 	}
 
 	DISNEY_disable(0);
-	delete test;
 }
 
 void DISNEY_Init(Section* sec) {
-	test = new DISNEY(sec);
+	Section_prop *section = static_cast<Section_prop *>(sec);
+	assert(section);
+	if (!section->Get_bool("disney"))
+		return;
 
 	// Setup the mixer callback
 	disney.chan = mixer_channel_ptr_t(MIXER_AddChannel(DISNEY_CallBack,

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -67,8 +67,6 @@ static struct {
 	Bitu interface_det_ext;
 } disney;
 
-static void DISNEY_CallBack(Bitu len);
-
 static void DISNEY_disable(Bitu) {
 	if (disney.chan) {
 		disney.chan->AddSilence();
@@ -297,17 +295,17 @@ static Bitu disney_read(Bitu port, MAYBE_UNUSED Bitu iolen)
 	return 0xff;
 }
 
-static void DISNEY_PlayStereo(Bitu len, uint8_t *l, uint8_t *r)
+static void DISNEY_PlayStereo(uint16_t len, const uint8_t *l, const uint8_t *r)
 {
 	static uint8_t stereodata[BUFFER_SAMPLES * 2];
-	for (Bitu i = 0; i < len; i++) {
+	for (uint16_t i = 0; i < len; ++i) {
 		stereodata[i*2] = l[i];
 		stereodata[i*2+1] = r[i];
 	}
 	disney.chan->AddSamples_s8(len,stereodata);
 }
 
-static void DISNEY_CallBack(Bitu len) {
+static void DISNEY_CallBack(uint16_t len) {
 	if (!len || !disney.chan)
 		return;
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -146,19 +146,10 @@ static void DISNEY_analyze(Bitu channel){
 			if((st_diff < 5) && (st_diff > -5)) disney.stereo = true;
 			else disney.stereo = false;
 
-			// calculate rate for both channels
-			Bitu ch_speed[2];
-
-			for(Bitu i = 0; i < 2; i++) {
-				if(disney.da[i].used > 1) { // avoid dividing by zero
-					ch_speed[i] = (Bitu)(1.0/((disney.da[i].speedcheck_sum/1000.0) /
-					(float)(((float)disney.da[i].used)-1.0))); // -1.75
-				} else ch_speed[i] = 0;
-			}
-			
-			// choose the larger value
-			DISNEY_enable(ch_speed[0] > ch_speed[1]?
-				ch_speed[0]:ch_speed[1]); // TODO
+			// Run with the greater DAC frequency
+			const auto max_freq = std::max(calc_frequency(disney.da[0]),
+			                               calc_frequency(disney.da[1]));
+			DISNEY_enable(max_freq);
 			break;
 		}
 		case STATE::ANALYZING:

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -185,8 +185,14 @@ static void DISNEY_analyze(Bitu channel){
 	}
 }
 
-static void disney_write(Bitu port,Bitu val,Bitu iolen) {
-	//LOG_MSG("write disney time %f addr%x val %x",PIC_FullIndex(),port,val);
+static void disney_write(Bitu port, Bitu data, MAYBE_UNUSED Bitu iolen)
+{
+	// Convert the IO data into a single byte-value, as Disney only
+	// operates on 8-bit values (IO ports also registered as IO_MB)
+	assert(data < UINT8_MAX);
+	const auto val = static_cast<uint8_t>(data);
+
+	// LOG_MSG("write disney time %f addr%x val %x",PIC_FullIndex(),port,val);
 	disney.last_used=PIC_Ticks;
 	switch (port-DISNEY_BASE) {
 	case 0:		/* Data Port */

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -44,7 +44,7 @@ typedef struct _dac_channel {
 
 using mixer_channel_ptr_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
-static struct {
+struct Disney {
 	IO_ReadHandleObject read_handler{};
 	IO_WriteHandleObject write_handler{};
 
@@ -65,7 +65,9 @@ static struct {
 	STATE state = STATE::IDLE;
 	Bitu interface_det;
 	Bitu interface_det_ext;
-} disney;
+};
+
+static Disney disney;
 
 static void DISNEY_disable(Bitu) {
 	if (disney.chan) {


### PR DESCRIPTION
Round 2, this time reviewable commit-by-commit.  
All magic values left-as-is.

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/816

Tested with King's Quest 6 (sound effects), and Bard's Lore 2, which plays a random music track at the initial party setup screen.

The notable change in the PR cleans up the mixer channel, IO handlers, and PIC interrupt call in the destroy function.

This allows the DSS to be toggled off an on repeatedly, with full cleanup and re-creation of resources:

![2021-01-11_23-16](https://user-images.githubusercontent.com/1557255/104282136-6e107580-5463-11eb-9c8f-370e3af2dc12.png)

Some very minor code cleanup was also performed:
 -  Compiler warnings
 -  Some Bitu's were moved to lesser types when safe and provable (noted in the comments/commits)
 - Moved one frequency calculation to a function for better readability