### PR TITLE
Add information-only thread naming

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 139
+            max_warnings: 141
 
     steps:
       - uses: actions/checkout@v2

--- a/include/support.h
+++ b/include/support.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -229,3 +230,5 @@ constexpr size_t static_if_array_then_zero()
 std::string safe_strerror(int err) noexcept;
 
 #endif
+
+void set_thread_name(std::thread &thread, const char *name);

--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,11 @@ if cc.has_function('mprotect', prefix : '#include <sys/mman.h>')
   conf_data.set10('HAVE_MPROTECT', true)
 endif
 
+if cxx.has_function('pthread_setname_np', prefix : '#include <pthread.h>',
+                    dependencies : dependency('threads'))
+  conf_data.set10('HAVE_PTHREAD_SETNAME_NP', true)
+endif
+
 if cc.has_function('realpath', prefix : '#include <stdlib.h>')
   conf_data.set10('HAVE_REALPATH', true)
 endif
@@ -251,7 +256,6 @@ if host_machine.system() in ['windows', 'cygwin']
   winsock2_dep = cxx.find_library('ws2_32', required : true)
   winmm_dep = cxx.find_library('winmm', required : true)
 endif
-
 
 # include directories
 #

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -139,6 +139,9 @@
 // Defined if function mprotect is available
 #mesondefine HAVE_MPROTECT
 
+// Defined if function pthread_setname_np is available
+#mesondefine HAVE_PTHREAD_SETNAME_NP
+
 // Defined if function realpath is available
 #mesondefine HAVE_REALPATH
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1228,6 +1228,7 @@ class Typer {
 			m_pace_ms = pace_ms;
 			m_stop_requested = false;
 			m_instance = std::thread(&Typer::Callback, this);
+			set_thread_name(m_instance, "dosbox:autotype");
 		}
 		void Wait() {
 			if (m_instance.joinable())
@@ -1237,6 +1238,7 @@ class Typer {
 			m_stop_requested = true;
 			Wait();
 		}
+
 	private:
 		void Callback() {
 		        // quit before our initial wait time

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -33,6 +33,7 @@
 #include "cross.h"
 #include "fs_utils.h"
 #include "mixer.h"
+#include "support.h"
 
 static constexpr int FRAMES_PER_BUFFER = 512; // synth granularity
 
@@ -298,6 +299,7 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	keep_rendering = true;
 	const auto render = std::bind(&MidiHandlerFluidsynth::Render, this);
 	renderer = std::thread(render);
+	set_thread_name(renderer, "dosbox:fsynth");
 	play_buffer = playable.Dequeue(); // populate the first play buffer
 
 	// Start playback

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -37,6 +37,7 @@
 #include "midi.h"
 #include "mixer.h"
 #include "string_utils.h"
+#include "support.h"
 
 // mt32emu Settings
 // ----------------
@@ -331,6 +332,7 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 	keep_rendering = true;
 	const auto render = std::bind(&MidiHandler_mt32::Render, this);
 	renderer = std::thread(render);
+	set_thread_name(renderer, "dosbox:mt32");
 	play_buffer = playable.Dequeue(); // populate the first play buffer
 
 	// Start playback

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -331,3 +331,12 @@ std::string safe_strerror(int err) noexcept
 	return buf;
 #endif
 }
+
+void set_thread_name(MAYBE_UNUSED std::thread& thread, MAYBE_UNUSED const char *name)
+{
+#if defined(HAVE_PTHREAD_SETNAME_NP) && defined(_GNU_SOURCE)
+	assert(strlen(name) < 16);
+	pthread_t handle = thread.native_handle();
+	pthread_setname_np(handle, name);
+#endif
+}


### PR DESCRIPTION

The autotype, and MT-32 and FluidSynth rendering threads are named.

For example:

![2021-01-30_13-23](https://user-images.githubusercontent.com/1557255/106368510-d504aa00-62fe-11eb-8e08-ab29f424b620.png)

To test this, start autotype for a long enough sequence that your process monitor (htop, top, task manager) can pick it up.

Note that the autotype thread will disappear from the list once autotyping is complete.