### PR TITLE
Fix Opus mounting on Windows and add some size checks

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -464,9 +464,10 @@ int CDROM_Interface_Image::AudioFile::getLength()
 		 *  Sound_GetDuration returns milliseconds but getLength()
 		 *  needs to return bytes, so we covert using PCM bytes/s
 		 */
-		length_redbook_bytes = static_cast<int>(
-		        static_cast<float>(Sound_GetDuration(sample)) *
-		        REDBOOK_PCM_BYTES_PER_MS);
+		const auto track_ms = Sound_GetDuration(sample);
+		const auto track_bytes = static_cast<float>(track_ms) * REDBOOK_PCM_BYTES_PER_MS;
+		assert(track_bytes < static_cast<float>(INT32_MAX));
+		length_redbook_bytes = static_cast<int32_t>(track_bytes);
 	}
 	assertm(length_redbook_bytes >= 0,
 	        "Track length could not be determined");

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -49,8 +49,8 @@
 #include "SDL_sound_internal.h"
 
 // Opus's internal sampling rates to which all encoded streams get resampled
-#define OPUS_SAMPLE_RATE        48000u
-#define OPUS_SAMPLE_RATE_PER_MS    48u
+constexpr auto OPUS_FRAMES_PER_S = 48000;
+constexpr auto OPUS_FRAMES_PER_MS = 48;
 
 static int32_t opus_init(void)
 {
@@ -272,7 +272,7 @@ static int32_t opus_open(Sound_Sample * sample, const char * ext)
     output_opus_info(of, oh);
 
     // Populate track properties
-    sample->actual.rate = OPUS_SAMPLE_RATE;
+    sample->actual.rate = OPUS_FRAMES_PER_S;
     sample->actual.channels = static_cast<Uint8>(oh->channel_count);
     sample->flags = op_seekable(of) ? SOUND_SAMPLEFLAG_CANSEEK: 0;
     sample->actual.format = AUDIO_S16SYS;
@@ -284,7 +284,7 @@ static int32_t opus_open(Sound_Sample * sample, const char * ext)
         internal->total_time = -1;
         return 0; // couldn't determine length; something's wrong!
     }
-    constexpr int64_t frames_per_ms = OPUS_SAMPLE_RATE_PER_MS;
+    constexpr int64_t frames_per_ms = OPUS_FRAMES_PER_MS;
     const int64_t track_ms = ceil_sdivide(pcm_frames, frames_per_ms);
 
     assertm(track_ms <= INT32_MAX, "OPUS: Irack exceeds 2^31 ms (596 hrs)");
@@ -366,7 +366,7 @@ static int32_t opus_seek(Sound_Sample * sample, const uint32_t ms)
 #endif
 
     // convert the desired ms offset into OPUS PCM samples
-    const ogg_int64_t desired_pcm = ms * OPUS_SAMPLE_RATE_PER_MS;
+    const ogg_int64_t desired_pcm = ms * OPUS_FRAMES_PER_MS;
     rcode = op_pcm_seek(of, desired_pcm);
 
     if (rcode != 0) {

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -39,6 +39,7 @@
 #include "config.h"
 
 #include <cassert>
+#include <cinttypes>
 #include <opusfile.h>
 #include <SDL.h>
 
@@ -141,11 +142,10 @@ static int32_t RWops_opus_seek(void * stream, const opus_int64 offset, const int
             "OPUS: The position from where to seek is invalid");
 
     const int64_t offset_after_seek = SDL_RWseek(static_cast<SDL_RWops*>(stream),
-                                                 static_cast<int32_t>(offset),
-                                                 whence);
+                                                 offset, whence);
     SNDDBG(("Opus ops seek:          "
-            "{requested offset: %ld, seeked offset: %ld}\n",
-            offset, offset_after_seek));
+            "requested: %" PRId64 " and got: %" PRId64 "\n",
+            static_cast<int64_t>(offset), offset_after_seek));
     return (offset_after_seek != -1 ? 0 : -1);
 } /* RWops_opus_seek */
 

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -399,7 +399,8 @@ extern const Sound_DecoderFunctions __Sound_DecoderFunctions_OPUS =
     {
         extensions_opus,
         "Ogg Opus audio using libopusfile",
-        "The DOSBox Staging Team"
+        "The DOSBox Staging Team",
+        "https://dosbox-staging.github.io/",
     },
 
     opus_init,   /*   init() method */

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -177,8 +177,7 @@ static opus_int64 RWops_opus_tell(void * stream)
     assertm(stream, "OPUS: Input is not initialized");
 
     const int64_t current_offset = SDL_RWtell(static_cast<SDL_RWops*>(stream));
-    SNDDBG(("Opus ops tell:          "
-            "%ld\n", current_offset));
+    SNDDBG(("Opus ops tell:          % " PRId64 "\n",current_offset));
     return current_offset;
 } /* RWops_opus_tell */
 

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -42,6 +42,9 @@
 /* Define to 1 to enable FluidSynth MIDI synthesizer */
 #define C_FLUIDSYNTH 1
 
+/* Define to 1 to use Opus-encoded CD-audio tracks, requires opusfile */
+#define USE_OPUS 1
+
 /* Enable the FPU module, still only for beta testing */
 #define C_FPU 1
 


### PR DESCRIPTION
Fixes #849 

Although only the first commit is needed (yes, Opus was simply de-activated!), the remaining commits:
 - cleanup the warnings in the Opus decoders verbose mode (which activates the `SNDDBG` calls)
 - ensure the tracks' reported size can be safely down-cast (in DEBUG builds) to meet the API types
 - These were critical to let the build pass the CI warning limits so I could test the Windows release build on hardware and Wine

CI release build was confirmed working on Windows (wine64, VirtualBox, and hardware), as well as on Linux x86 and ARM.