### PR TITLE
Convert dynamic analysis jobs to use meson and reorganize them

### DIFF
--- a/.github/scripts/build-and-run-sanitizers.sh
+++ b/.github/scripts/build-and-run-sanitizers.sh
@@ -11,26 +11,31 @@
 #   ./build-and-run-sanitizers.sh COMPILER VERSION SANITIZER [SANITIZER [...]]"
 #
 # Examples:
-#   ./build-and-run-sanitizers.sh clang 8 msan usan
-#   ./build-and-run-sanitizers.sh gcc 9 asan uasan usan tsan
+#   ./build-and-run-sanitizers.sh gcc address undefined
+#   ./build-and-run-sanitizers.sh clang thread
+#
+# SANITIZER values are the names supported by meson for b_sanitize build
+# option: "address", "thread", "undefined", "memory", "address,undefined"
 #
 set -euo pipefail
 
+# let build logs be printed to the output, we don't need them stored in artifacts
+set -x
+
 # Check the arguments
-if [[ "$#" -lt 3 ]]; then
-	echo "Usage: $0 COMPILER VERSION SANITIZER [SANITIZER [...]]"
-	exit 1
-fi
+#if [[ "$#" -lt 3 ]]; then
+#	echo "Usage: $0 COMPILER SANITIZER [SANITIZER [...]]"
+#	exit 1
+#fi
 
 # Defaults and arguments
 compiler="${1}"
-compiler_version="${2}"
 logs="${compiler}-logs"
-shift 2
+shift 1
 sanitizers=("$@")
 
 # Move to the top of our source directory
-cd "$(dirname "${0}")/../.."
+cd "$(git rev-parse --show-toplevel)"
 
 # Make a directory to hold our build and run output
 mkdir -p "${logs}"
@@ -40,18 +45,16 @@ export LSAN_OPTIONS="suppressions=.lsan-suppress:verbosity=0"
 
 for sanitizer in "${sanitizers[@]}"; do
 
-	# Build DOSBox for each sanitizer
-	time ./scripts/build.sh \
-		--compiler "${compiler}" \
-		--version-postfix "${compiler_version}" \
-		--build-type "${sanitizer}" \
-		&> "${logs}/${compiler}-${sanitizer}-compile.log"
+	# Build for each sanitizer
+	meson setup -Db_sanitize="${sanitizer}" "${sanitizer}-build"
+	ninja -C "${sanitizer}-build"
 
 	# Exercise the testcase(s) for each sanitizer
 	# Sanitizers return non-zero if one or more issues were found,
 	# so we or-to-true to ensure our script doesn't end here.
-	time xvfb-run ./src/dosbox -c "autotype -w 0.1 e x i t enter" \
-		&> "${logs}/${compiler}-${sanitizer}-EnterExit.log" || true
+	time xvfb-run "./${sanitizer}-build/dosbox" \
+		-c "autotype -w 0.1 e x i t enter" \
+		&> "${logs}/${sanitizer}-EnterExit.log" || true
 
 done
 

--- a/.github/scripts/run-sanitizers.sh
+++ b/.github/scripts/run-sanitizers.sh
@@ -8,11 +8,11 @@
 # various sanitizer-builds.
 #
 # Usage:
-#   ./build-and-run-sanitizers.sh BUILDDIR LOGDIR"
+#   ./run-sanitizers.sh BUILDDIR LOGDIR"
 #
 set -euo pipefail
 
-# let build logs be printed to the output, we don't need them stored in artifacts
+# let run logs be printed to the output, we don't need them stored in artifacts
 set -x
 
 # Check the arguments
@@ -28,7 +28,7 @@ logs="$2"
 # Move to the top of our source directory
 cd "$(git rev-parse --show-toplevel)"
 
-# Make a directory to hold our build and run output
+# Make a directory to hold our run output
 mkdir -p "${logs}"
 
 # SAN-specific environment variables

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -92,6 +92,7 @@ jobs:
           echo
           ./scripts/count-clang-bugs.py report/*/index.html
 
+
   dynamic_matrix:
     name: ${{ matrix.conf.name }} dynamic sanitizers
     needs: run_linters
@@ -99,25 +100,18 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: Clang
-            sanitizers: USAN
-            usan:  0  # cleared out in our existing tests
-            uasan: -1
           - name: GCC
-            # TSAN excluded, harness segfaults inside virual-X11 environment
-            sanitizers: UASAN
-            usan:  -1
-            uasan: 4
+            max-undefined-issues: 0 # undefined behaviour
+            max-address-issues:   0 # address sanitizer
+
     steps:
       - uses: actions/checkout@v2
+
       - run:  sudo apt-get update
+
       - name: Install C++ compiler and libraries
-        env:
-          VERSION_GCC: 9
-          VERSION_Clang: 8
-        run:  >
-          sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt
-          -c ${{ matrix.conf.name }} -v $VERSION_${{ matrix.conf.name }})
+        run:  sudo apt-get install $(cat .github/packages/ubuntu-20.04-apt.txt)
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash
@@ -126,6 +120,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+
       - uses:  actions/cache@v2
         id:    cache-ccache
         with:
@@ -133,26 +128,24 @@ jobs:
           key:  ccache-sanitizers-${{ matrix.conf.name }}-${{ steps.prep-ccache.outputs.today }}
           restore-keys: |
             ccache-sanitizers-${{ matrix.conf.name }}-${{ steps.prep-ccache.outputs.yesterday }}
+
       - name: Log environment
         run:  ./scripts/log-env.sh
+
       - name: Build and run sanitizers
-        env:
-          VERSION_GCC: 9
-          VERSION_Clang: 8
-        run: |
-          ./.github/scripts/build-and-run-sanitizers.sh \
-            ${{ matrix.conf.name }} \
-            $VERSION_${{ matrix.conf.name }} \
-            ${{ matrix.conf.sanitizers }}
+        run: ./.github/scripts/build-and-run-sanitizers.sh ${{ matrix.conf.name }}
+                                                           undefined address
+
       - name: Upload logs
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.conf.name }}-sanitizer-logs
           path: ${{ matrix.conf.name }}-logs
+
       - name: Summarize issues
         env:
-          USAN_LOG:  ${{ matrix.conf.name }}-logs/${{ matrix.conf.name }}-USAN-EnterExit.log.xz
-          UASAN_LOG: ${{ matrix.conf.name }}-logs/${{ matrix.conf.name }}-UASAN-EnterExit.log.xz
+          USAN_LOG:  ${{ matrix.conf.name }}-logs/undefined-EnterExit.log.xz
+          ASAN_LOG:  ${{ matrix.conf.name }}-logs/address-EnterExit.log.xz
         run: |
           # summary
 
@@ -163,11 +156,17 @@ jobs:
           if [[ -f "$USAN_LOG" ]] ; then
             echo_bold "Undefined Behaviour sanitizer:"
             echo
-            xzcat "$USAN_LOG" | MAX_ISSUES=${{ matrix.conf.usan }} ./scripts/count-xsan-issues.py -
+            xzcat "$USAN_LOG" | MAX_ISSUES=${{ matrix.conf.max-undefined-issues }} ./scripts/count-xsan-issues.py -
+          else
+            echo "No UB sanitizer logs found."
+            echo
           fi
 
-          if [[ -f "$UASAN_LOG" ]] ; then
-            echo_bold "Undefined Behaviour + Address sanitizers:"
+          if [[ -f "$ASAN_LOG" ]] ; then
+            echo_bold "Address sanitizer:"
             echo
-            xzcat "$UASAN_LOG" | MAX_ISSUES=${{ matrix.conf.uasan }} ./scripts/count-xsan-issues.py -
+            xzcat "$ASAN_LOG" | MAX_ISSUES=${{ matrix.conf.max-address-issues}} ./scripts/count-xsan-issues.py -
+          else
+            echo "No address sanitizer logs found."
+            echo
           fi

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -159,7 +159,7 @@ jobs:
       - run:  ninja -C build
 
       - name: Run sanitizer test cases
-        run:  ./.github/scripts/build-and-run-sanitizers.sh build sanitizer-logs
+        run:  ./.github/scripts/run-sanitizers.sh build sanitizer-logs
 
       - name: Upload logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -94,16 +94,39 @@ jobs:
 
 
   dynamic_matrix:
-    name: ${{ matrix.conf.name }} dynamic sanitizers
+    name: ${{ matrix.conf.name }}
     needs: run_linters
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         conf:
-          - name: GCC
-            max-undefined-issues: 0 # undefined behaviour
-            max-address-issues:   0 # address sanitizer
+          # AddressSanitizer is a fast memory error detector. Memory access
+          # instructions are instrumented to detect out-of-bounds and
+          # use-after-free bugs.
+          # See GCC manual to learn more.
+          - name: GCC address sanitizer
+            build_flags: -Db_sanitize=address
+            logs: gcc-asan-logs
+            max_issues: 0
 
+          # UndefinedBehaviorSanitizer is a fast undefined behavior detector.
+          # Various computations are instrumented to detect undefined behavior
+          # at runtime, such as shift operation correctness, integer division by
+          # zero, null-pointer dereference, signed integer overflow,
+          # dereferencing memory with wrong alignment, and more.
+          # See GCC manual to learn more.
+          - name: GCC undefined sanitizer
+            build_flags: -Db_sanitize=undefined
+            logs: gcc-usan-logs
+            max_issues: 0
+
+          # Clang allows enabling both AddressSanitizer and
+          # UndefinedBehaviorSanitizer at the same time.
+          # See Clang manual to learn more.
+          - name: Clang undefined+address sanitizer
+            build_flags: -Db_sanitize=address,undefined --native-file=.github/meson/native-clang.ini
+            logs: clang-uasan-logs
+            max_issues: 4
     steps:
       - uses: actions/checkout@v2
 
@@ -125,48 +148,26 @@ jobs:
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-sanitizers-${{ matrix.conf.name }}-${{ steps.prep-ccache.outputs.today }}
-          restore-keys: |
-            ccache-sanitizers-${{ matrix.conf.name }}-${{ steps.prep-ccache.outputs.yesterday }}
+          key:          ccache-sanitizers-${{ steps.prep-ccache.outputs.today }}
+          restore-keys: ccache-sanitizers-${{ steps.prep-ccache.outputs.yesterday }}
 
       - name: Log environment
         run:  ./scripts/log-env.sh
 
-      - name: Build and run sanitizers
-        run: ./.github/scripts/build-and-run-sanitizers.sh ${{ matrix.conf.name }}
-                                                           undefined address
+      - run:  meson setup ${{ matrix.conf.build_flags }} build
+
+      - run:  ninja -C build
+
+      - name: Run sanitizer test cases
+        run:  ./.github/scripts/build-and-run-sanitizers.sh build sanitizer-logs
 
       - name: Upload logs
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.conf.name }}-sanitizer-logs
-          path: ${{ matrix.conf.name }}-logs
+          name: ${{ matrix.conf.logs }}
+          path: sanitizer-logs
 
       - name: Summarize issues
-        env:
-          USAN_LOG:  ${{ matrix.conf.name }}-logs/undefined-EnterExit.log.xz
-          ASAN_LOG:  ${{ matrix.conf.name }}-logs/address-EnterExit.log.xz
-        run: |
-          # summary
-
-          echo_bold () {
-            echo -e "\\033[1m$*\\033[0m"
-          }
-
-          if [[ -f "$USAN_LOG" ]] ; then
-            echo_bold "Undefined Behaviour sanitizer:"
-            echo
-            xzcat "$USAN_LOG" | MAX_ISSUES=${{ matrix.conf.max-undefined-issues }} ./scripts/count-xsan-issues.py -
-          else
-            echo "No UB sanitizer logs found."
-            echo
-          fi
-
-          if [[ -f "$ASAN_LOG" ]] ; then
-            echo_bold "Address sanitizer:"
-            echo
-            xzcat "$ASAN_LOG" | MAX_ISSUES=${{ matrix.conf.max-address-issues}} ./scripts/count-xsan-issues.py -
-          else
-            echo "No address sanitizer logs found."
-            echo
-          fi
+        run: >
+          xzcat sanitizer-logs/EnterExit.log.xz |
+          MAX_ISSUES=${{ matrix.conf.max_issues }} ./scripts/count-xsan-issues.py -


### PR DESCRIPTION
Another step towards #854 :)

GitHub mis-detects rename of build-and-run-sanitizers.sh script as remove and add (but Git shows it properly in git-log).

As of 0.56.0, Meson supports following sanitizer options: `none`, `address`, `thread`, `undefined`, `memory`, `address,undefined`. Although we'll need to test each one with both GCC and Clang to see how it works (I tried using `address,undefined` with GCC, but it turned on only `address` sanitizer).

Adding new sanitizer runs to the CI is out of scope for now, I think.