### PR TITLE
Fix always-true comparison results

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -562,6 +562,10 @@ Drive %c has successfully been removed.
 Virtual Drives can not be unMOUNTed.
 
 .
+:PROGRAM_MOUNT_DRIVEID_ERROR
+'%c' is not a valid drive identifier.
+
+.
 :PROGRAM_MOUNT_WARNING_WIN
 [31;1mMounting c:\ is NOT recommended. Please mount a (sub)directory next time.[0m
 
@@ -595,6 +599,10 @@ Something went wrong.
 .
 :PROGRAM_MOUNT_OVERLAY_STATUS
 Overlay %s on drive %c mounted.
+
+.
+:PROGRAM_MOUNT_MOVE_Z_ERROR_1
+Can't move drive Z. Drive %c is mounted already.
 
 .
 :PROGRAM_MEM_CONVEN

--- a/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
@@ -562,6 +562,10 @@ Drive %c has successfully been removed.
 Virtual Drives can not be unMOUNTed.
 
 .
+:PROGRAM_MOUNT_DRIVEID_ERROR
+'%c' is not a valid drive identifier.
+
+.
 :PROGRAM_MOUNT_WARNING_WIN
 [31;1mMounting c:\ is NOT recommended. Please mount a (sub)directory next time.[0m
 
@@ -595,6 +599,10 @@ Something went wrong.
 .
 :PROGRAM_MOUNT_OVERLAY_STATUS
 Overlay %s on drive %c mounted.
+
+.
+:PROGRAM_MOUNT_MOVE_Z_ERROR_1
+Can't move drive Z. Drive %c is mounted already.
 
 .
 :PROGRAM_MEM_CONVEN

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -101,17 +101,17 @@ class MOUNT : public Program {
 public:
 	void Move_Z(char new_z)
 	{
-		const char newz_drive = toupper(new_z);
+		const char new_drive_z = toupper(new_z);
 
-		if (newz_drive < 'A' || newz_drive > 'Z') {
-			WriteOut(MSG_Get("PROGRAM_MOUNT_DRIVEID_ERROR"), newz_drive);
+		if (new_drive_z < 'A' || new_drive_z > 'Z') {
+			WriteOut(MSG_Get("PROGRAM_MOUNT_DRIVEID_ERROR"), new_drive_z);
 			return;
 		}
 
-		const uint8_t new_idx = drive_index(newz_drive);
+		const uint8_t new_idx = drive_index(new_drive_z);
 
 		if (Drives[new_idx]) {
-			WriteOut(MSG_Get("PROGRAM_MOUNT_MOVE_Z_ERROR_1"), newz_drive);
+			WriteOut(MSG_Get("PROGRAM_MOUNT_MOVE_Z_ERROR_1"), new_drive_z);
 			return;
 		}
 
@@ -123,8 +123,7 @@ public:
 			if (!first_shell) return; //Should not be possible
 			/* Update environment */
 			std::string line = "";
-			char ppp[2] = {newz_drive,0};
-			std::string tempenv = ppp; tempenv += ":\\";
+			std::string tempenv = {new_drive_z, ':', '\\'};
 			if (first_shell->GetEnvStr("PATH",line)) {
 				std::string::size_type idx = line.find('=');
 				std::string value = line.substr(idx +1 , std::string::npos);
@@ -141,7 +140,8 @@ public:
 			/* Update batch file if running from Z: (very likely: autoexec) */
 			if (first_shell->bf) {
 				std::string &name = first_shell->bf->filename;
-				if (name.length() > 2 &&  name[0] == 'Z' && name[1] == ':') name[0] = newz_drive;
+				if (starts_with("Z:", name))
+					name[0] = new_drive_z;
 			}
 			/* Change the active drive */
 			if (DOS_GetDefaultDrive() == 25)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1134,14 +1134,11 @@ void RESCAN::Run(void)
 
 	if (cmd->FindCommand(1,temp_line)) {
 		//-A -All /A /All
-		if (temp_line.size() >= 2
-			&& (temp_line[0] == '-' ||
-			    temp_line[0] == '/')
-			&& (temp_line[1] == 'a' ||
-			    temp_line[1] == 'A') ) {
-	 		all = true;
-		}
-		else if (temp_line.size() == 2 && temp_line[1] == ':') {
+		if (temp_line.size() >= 2 &&
+		    (temp_line[0] == '-' || temp_line[0] == '/') &&
+		    (temp_line[1] == 'a' || temp_line[1] == 'A')) {
+			all = true;
+		} else if (temp_line.size() == 2 && temp_line[1] == ':') {
 			lowcase(temp_line);
 			drive  = temp_line[0] - 'a';
 		}

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -99,13 +99,26 @@ static const char *UnmountHelper(char umount)
 
 class MOUNT : public Program {
 public:
-	void Move_Z(char new_z) {
-		char newz_drive = (char) toupper(new_z);
-		int i_newz = drive_index(newz_drive);
-		if (i_newz >= 0 && i_newz < DOS_DRIVES-1 && !Drives[i_newz]) {
-			ZDRIVE_NUM = i_newz;
+	void Move_Z(char new_z)
+	{
+		const char newz_drive = toupper(new_z);
+
+		if (newz_drive < 'A' || newz_drive > 'Z') {
+			WriteOut(MSG_Get("PROGRAM_MOUNT_DRIVEID_ERROR"), newz_drive);
+			return;
+		}
+
+		const uint8_t new_idx = drive_index(newz_drive);
+
+		if (Drives[new_idx]) {
+			WriteOut(MSG_Get("PROGRAM_MOUNT_MOVE_Z_ERROR_1"), newz_drive);
+			return;
+		}
+
+		if (new_idx < DOS_DRIVES - 1) {
+			ZDRIVE_NUM = new_idx;
 			/* remap drives */
-			Drives[i_newz] = Drives[25];
+			Drives[new_idx] = Drives[25];
 			Drives[25] = 0;
 			if (!first_shell) return; //Should not be possible
 			/* Update environment */
@@ -131,7 +144,8 @@ public:
 				if (name.length() > 2 &&  name[0] == 'Z' && name[1] == ':') name[0] = newz_drive;
 			}
 			/* Change the active drive */
-			if (DOS_GetDefaultDrive() == 25) DOS_SetDrive(i_newz);
+			if (DOS_GetDefaultDrive() == 25)
+				DOS_SetDrive(new_idx);
 		}
 	}
 
@@ -1658,6 +1672,7 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_SAME_AS_BASE","The overlay directory can not be the same as underlying drive.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_GENERIC_ERROR","Something went wrong.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_STATUS","Overlay %s on drive %c mounted.\n");
+	MSG_Add("PROGRAM_MOUNT_MOVE_Z_ERROR_1", "Can't move drive Z. Drive %c is mounted already.\n");
 
 	MSG_Add("PROGRAM_MEM_CONVEN","%10d Kb free conventional memory\n");
 	MSG_Add("PROGRAM_MEM_EXTEND","%10d Kb free extended memory\n");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -58,15 +58,18 @@ Bitu DEBUG_EnableDebugger(void);
 
 static Bitu ZDRIVE_NUM = 25;
 
-static const char* UnmountHelper(char umount) {
-	int i_drive;
-	if (umount < '0' || umount > 3+'0')
-		i_drive = drive_index(umount);
-	else
-		i_drive = umount - '0';
+static const char *UnmountHelper(char umount)
+{
+	const char drive_id = toupper(umount);
+	const bool using_drive_number = (drive_id >= '0' && drive_id <= '3');
+	const bool using_drive_letter = (drive_id >= 'A' && drive_id <= 'Z');
 
-	if (i_drive >= DOS_DRIVES || i_drive < 0)
-		return MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED");
+	if (!using_drive_number && !using_drive_letter)
+		return MSG_Get("PROGRAM_MOUNT_DRIVEID_ERROR");
+
+	const uint8_t i_drive = using_drive_number ? (drive_id - '0')
+	                                           : drive_index(drive_id);
+	assert(i_drive < DOS_DRIVES);
 
 	if (i_drive < MAX_DISK_IMAGES && Drives[i_drive] == NULL && !imageDiskList[i_drive])
 		return MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED");
@@ -1645,6 +1648,7 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c isn't mounted.\n");
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL","Virtual Drives can not be unMOUNTed.\n");
+	MSG_Add("PROGRAM_MOUNT_DRIVEID_ERROR", "'%c' is not a valid drive identifier.\n");
 	MSG_Add("PROGRAM_MOUNT_WARNING_WIN","\033[31;1mMounting c:\\ is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
 	MSG_Add("PROGRAM_MOUNT_WARNING_OTHER","\033[31;1mMounting / is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
 	MSG_Add("PROGRAM_MOUNT_NO_OPTION", "Warning: Ignoring unsupported option '%s'.\n");


### PR DESCRIPTION
Should address 2 LGTM issues, but also improves input handling for `mount -u` and `mount -z` commands.