### PR TITLE
Update list of zypper packages

### DIFF
--- a/scripts/automator/packages/manager-zypper
+++ b/scripts/automator/packages/manager-zypper
@@ -1,9 +1,10 @@
 # Package repo: https://pkgs.org/
 # openSUSE offers 32-bit versions of SDL and SDL_net (but not others)
-packages+=(ccache devel_basis xvfb libtool opusfile)
+packages+=(ccache libpng16-devel patterns-devel-base-devel_basis
+           libtool opusfile-devel fluidsynth-devel libmt32emu-devel)
 
 if [[ "${bits}" == "32" ]]; then
 	packages+=(ncurses-devel-32bit libSDL2-devel-32bit libSDL2_net-devel-32bit)
 else
-	packages+=(ncurses-devel SDL2 SDL2_net fluidsynth-devel)
+	packages+=(ncurses-devel libSDL2-devel libSDL2_net-devel)
 fi


### PR DESCRIPTION
Updated and tested against the [current OpenSuse HCL](https://en.opensuse.org/HCL:Raspberry_Pi3).

