### PR TITLE
Load FluidSynth SoundFonts in the background on startup

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -579,8 +579,7 @@ void DOSBOX_Init(void) {
 	secprop=control->AddSection_prop("pci",&PCI_Init,false); //PCI bus
 #endif
 
-
-	secprop=control->AddSection_prop("mixer",&MIXER_Init);
+	secprop = control->AddEarlySectionProp("mixer", &MIXER_Init);
 	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
 	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -79,6 +79,8 @@ void FPU_Init(Section*);
 void DMA_Init(Section*);
 
 void MIXER_Init(Section*);
+void MIXER_MakeProgram(Section*);
+
 void HARDWARE_Init(Section*);
 
 #if defined(PCI_FUNCTIONALITY_ENABLED)
@@ -579,7 +581,9 @@ void DOSBOX_Init(void) {
 	secprop=control->AddSection_prop("pci",&PCI_Init,false); //PCI bus
 #endif
 
-	secprop = control->AddEarlySectionProp("mixer", &MIXER_Init);
+	(void) control->AddEarlySectionProp("mixer", &MIXER_Init);
+	secprop = control->AddSection_prop("mixer", &MIXER_MakeProgram);
+
 	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
 	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -601,7 +601,7 @@ void DOSBOX_Init(void) {
 	Pint->SetMinMax(0,100);
 	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
 
-	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
+	secprop = control->AddEarlySectionProp("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init, true);
 
 	pstring = secprop->Add_string("mididevice", when_idle, "auto");

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -891,6 +891,9 @@ void MIXER_Init(Section* sec) {
 	mixer.freq = static_cast<uint32_t>(section->Get_int("rate"));
 	mixer.blocksize = static_cast<uint16_t>(section->Get_int("blocksize"));
 
+	// Ensure external order-of-operations have taken care of our dependencies
+	assert(SDL_WasInit(SDL_INIT_AUDIO) || mixer.nosound);
+
 	/* Initialize the internal stuff */
 	mixer.channels=0;
 	mixer.pos=0;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -960,6 +960,9 @@ void MIXER_Init(Section* sec) {
 	mixer.min_needed = (mixer.freq * mixer.min_needed) / 1000;
 	mixer.max_needed = mixer.blocksize * 2 + 2 * mixer.min_needed;
 	mixer.needed = mixer.min_needed + 1;
+}
+
+void MIXER_MakeProgram(MAYBE_UNUSED Section* sec) {
 	PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart);
 }
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -1,8 +1,8 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2021  Nikos Chantziaras <realnc@gmail.com>
  *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2020  Nikos Chantziaras <realnc@gmail.com>
  *  Copyright (C) 2002-2011  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -256,9 +256,6 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 		return false;
 	}
 
-	if (!LoadSoundFont(section, fluid_synth.get()))
-		return false;
-
 	// Use a 7th-order (highest) polynomial to generate MIDI channel waveforms
 	constexpr int all_channels = -1;
 	fluid_synth_set_interp_method(fluid_synth.get(), all_channels,
@@ -285,6 +282,10 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	const auto set_mixer_level = std::bind(&MidiHandlerFluidsynth::SetMixerLevel,
 	                                       this, std::placeholders::_1);
 	mixer_channel->RegisterLevelCallBack(set_mixer_level);
+
+	if (!LoadSoundFont(section, fluid_synth.get()))
+		return false;
+
 	mixer_channel->Enable(true);
 
 	settings = std::move(fluid_settings);

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -335,6 +335,11 @@ void MidiHandlerFluidsynth::Close()
 	is_open = false;
 }
 
+MidiHandlerFluidsynth::~MidiHandlerFluidsynth()
+{
+	Close();
+}
+
 void MidiHandlerFluidsynth::PlayMsg(const uint8_t *msg)
 {
 	const int chanID = msg[0] & 0b1111;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -192,20 +192,22 @@ bool LoadSoundFont(const Section_prop *section, fluid_synth_t *synth)
 	}
 	fluid_synth_set_gain(synth, static_cast<float>(scale_by_percent) / 100.0f);
 
-	// Attempt to find the soundfont file
-	const auto soundfont = find_sf_file(std::get<std::string>(sf_spec));
+	// Attempt to find the SoundFont file
+	const auto filename = std::get<std::string>(sf_spec);
+	const auto soundfont = find_sf_file(filename);
 	if (soundfont.empty()) {
 		LOG_MSG("MIDI: FluidSynth couldn't find the '%s' SoundFont.",
-		        soundfont.c_str());
+		        filename.c_str());
 		return false;
 	}
-	// Attempt to load the soundfont file
+	// Attempt to load the SoundFont into the synthesizer
 	fluid_synth_sfload(synth, soundfont.data(), true);
 	if (fluid_synth_sfcount(synth) == 0) {
 		LOG_MSG("MIDI: FluidSynth failed loading the '%s' SoundFont.",
 		        soundfont.c_str());
 		return false;
 	}
+
 	// Let the user know that the SoundFont was loaded
 	if (scale_by_percent == 100)
 		LOG_MSG("MIDI: Loaded SoundFont '%s'", soundfont.c_str());

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -283,16 +283,21 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	                                       this, std::placeholders::_1);
 	mixer_channel->RegisterLevelCallBack(set_mixer_level);
 
-	if (!LoadSoundFont(section, fluid_synth.get()))
-		return false;
-
-	mixer_channel->Enable(true);
-
 	settings = std::move(fluid_settings);
 	synth = std::move(fluid_synth);
 	channel = std::move(mixer_channel);
 	is_open = true;
+
+	StartBackgroundLoad(section);
 	return true;
+}
+
+void MidiHandlerFluidsynth::StartBackgroundLoad(const Section_prop *section)
+{
+	assert(is_open && synth && channel);
+
+	const bool is_loaded = LoadSoundFont(section, synth.get());
+	channel->Enable(is_loaded);
 }
 
 void MidiHandlerFluidsynth::Close()

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -325,8 +325,10 @@ void MidiHandlerFluidsynth::Close()
 	if (background_loader.joinable())
 		background_loader.join();
 
-	channel->Enable(false);
-	channel = nullptr;
+	if (channel) {
+		channel->Enable(false);
+		channel = nullptr;
+	}
 	synth = nullptr;
 	settings = nullptr;
 	is_loaded = false;

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -56,6 +56,7 @@ private:
 	static constexpr uint16_t expected_max_frames = (96000 / 1000) + 4;
 	void MixerCallBack(uint16_t len); // see: MIXER_Handler
 	void SetMixerLevel(const AudioFrame &prescale_level) noexcept;
+	void StartBackgroundLoad(const Section_prop *section);
 
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -28,6 +28,7 @@
 #if C_FLUIDSYNTH
 
 #include <memory>
+#include <thread>
 #include <fluidsynth.h>
 
 #include "mixer.h"
@@ -48,6 +49,7 @@ public:
 	void PrintStats();
 	const char *GetName() const override { return "fluidsynth"; }
 	bool Open(const char *conf) override;
+	void FinishBackgroundLoad();
 	void Close() override;
 	void PlayMsg(const uint8_t *msg) override;
 	void PlaySysex(uint8_t *sysex, size_t len) override;
@@ -63,6 +65,8 @@ private:
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
 	AudioFrame prescale_level = {1.0f, 1.0f};
 	SoftLimiter<expected_max_frames> soft_limiter;
+	std::thread background_loader{};
+	bool is_loaded = false;
 
 	bool is_open = false;
 };

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -46,6 +46,7 @@ private:
 
 public:
 	MidiHandlerFluidsynth() : soft_limiter("FSYNTH", prescale_level) {}
+	~MidiHandlerFluidsynth();
 	void PrintStats();
 	const char *GetName() const override { return "fluidsynth"; }
 	bool Open(const char *conf) override;


### PR DESCRIPTION
![2021-02-05_19-03](https://user-images.githubusercontent.com/1557255/107107600-f4ac3e80-67e6-11eb-8211-16d6ef2c570f.png)

Reviewable commit-by-commit.

Tested good and bad scenarios (ie: missing SF2), as well as trying to pull the rug on it with ungraceful exits and kills.