### PR TITLE
Support install target

### DIFF
--- a/.github/packages/ubuntu-18.04-apt.txt
+++ b/.github/packages/ubuntu-18.04-apt.txt
@@ -5,4 +5,3 @@ libopusfile-dev
 libpng-dev
 libsdl2-dev
 libsdl2-net-dev
-meson

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,7 +69,7 @@ jobs:
             $(cat ./.github/packages/${{ matrix.conf.os }}-apt.txt)
 
       - name: Install Meson via pip3
-        if:   matrix.conf.os == 'ubuntu-16.04'
+        if:   matrix.conf.os != 'ubuntu-20.04'
         run: |
           sudo apt-get install python3-setuptools
           sudo pip3 install meson ninja

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -31,12 +31,12 @@ jobs:
           # - name: ARMv8 AArch64 (Ubuntu 18.04)
           #   arch: aarch64
           #   distro: ubuntu18.04
-          - name: s390x (Ubuntu 18.04)
+          - name: s390x (Ubuntu 20.04)
             arch: s390x
-            distro: ubuntu18.04
-          - name: ppc64le (Ubuntu 18.04)
+            distro: ubuntu20.04
+          - name: ppc64le (Ubuntu 20.04)
             arch: ppc64le
-            distro: ubuntu18.04
+            distro: ubuntu20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
           run: |
             set -xo pipefail
             apt-get update
-            apt-get install -y $(cat ./.github/packages/ubuntu-18.04-apt.txt)
+            apt-get install -y $(cat ./.github/packages/ubuntu-20.04-apt.txt)
             ./scripts/log-env.sh
             meson build -Duse_fluidsynth=false --wrap-mode=nofallback
             ninja -C build |& tee build.log

--- a/contrib/icons/meson.build
+++ b/contrib/icons/meson.build
@@ -1,0 +1,13 @@
+icons_hicolor = data_dir / 'icons' / 'hicolor'
+
+# small pre-rendered raster icons
+#
+foreach size : ['16x16', '22x22', '24x24', '32x32']
+  install_data('small-png' / size / 'dosbox-staging.png',
+               install_dir : icons_hicolor / size / 'apps')
+endforeach
+
+# scalable vector icon
+#
+install_data('dosbox-staging.svg',
+             install_dir : icons_hicolor / 'scalable' / 'apps')

--- a/contrib/linux/meson.build
+++ b/contrib/linux/meson.build
@@ -1,0 +1,5 @@
+install_data('dosbox-staging.desktop',
+             install_dir : data_dir / 'applications')
+
+install_data('dosbox-staging.metainfo.xml',
+             install_dir : data_dir / 'metainfo')

--- a/meson.build
+++ b/meson.build
@@ -43,16 +43,17 @@ endif
 conf_data = configuration_data()
 conf_data.set('version', meson.project_version())
 
-host_os = host_machine.system()
-if host_os == 'linux'
-  conf_data.set('LINUX', 1)
-elif host_os in ['windows', 'cygwin']
-  conf_data.set('WIN32', 1)
-elif host_os == 'darwin'
-  conf_data.set('MACOSX', 1)
-elif host_os in ['freebsd', 'netbsd', 'openbsd', 'dragonfly']
-  conf_data.set('BSD', 1)
-endif
+os_family_name = {
+  'linux'     : 'LINUX',
+  'windows'   : 'WIN32',
+  'cygwin'    : 'WIN32',
+  'darwin'    : 'MACOSX',
+  'freebsd'   : 'BSD',
+  'netbsd'    : 'BSD',
+  'openbsd'   : 'BSD',
+  'dragonfly' : 'BSD',
+}.get(host_machine.system(), 'UNKNOWN_OS')
+conf_data.set(os_family_name, 1)
 
 conf_data.set10('C_MODEM', get_option('use_sdl2_net'))
 conf_data.set10('C_IPX', get_option('use_sdl2_net'))

--- a/meson.build
+++ b/meson.build
@@ -8,15 +8,11 @@ project('dosbox-staging', 'c', 'cpp',
 # After increasing the minimum-required meson version, make the following
 # improvements:
 #
-# - 0.47.0 - remove 'if' disabling unit tests on older meson
-# - 0.47.0 - you can use dictionaries
-# - 0.49.0 - you can use string path building using '/' operator
-# - 0.49.0 - you can use 'in' operator for arrays and dictionaries
 # - 0.51.0 - remove warning about assertions in buildtype=plain
 # - 0.56.0 - use meson.current_source_dir() in unit tests
 #
-assert(meson.version().version_compare('>= 0.45.1'),
-       'Expecting meson 0.45.1 or newer.')
+assert(meson.version().version_compare('>= 0.49.0'),
+       'Expecting meson 0.49.0 or newer.')
 
 # https://mesonbuild.com/Release-notes-for-0-51-0.html#n_debugifrelease-and-buildtypeplain-means-no-asserts
 is_plain_build = (get_option('buildtype') == 'plain')
@@ -50,11 +46,11 @@ conf_data.set('version', meson.project_version())
 host_os = host_machine.system()
 if host_os == 'linux'
   conf_data.set('LINUX', 1)
-elif host_os == 'windows' or host_os == 'cygwin'
+elif host_os in ['windows', 'cygwin']
   conf_data.set('WIN32', 1)
 elif host_os == 'darwin'
   conf_data.set('MACOSX', 1)
-elif host_os.endswith('bsd') or host_os == 'dragonfly'
+elif host_os in ['freebsd', 'netbsd', 'openbsd', 'dragonfly']
   conf_data.set('BSD', 1)
 endif
 
@@ -64,8 +60,7 @@ conf_data.set10('C_OPENGL', get_option('use_opengl'))
 conf_data.set10('C_FLUIDSYNTH', get_option('use_fluidsynth'))
 conf_data.set10('C_SSHOT', get_option('use_png'))
 conf_data.set10('C_FPU', true)
-conf_data.set10('C_FPU_X86', (host_machine.cpu_family() == 'x86_64' or
-                              host_machine.cpu_family() == 'x86'))
+conf_data.set10('C_FPU_X86', host_machine.cpu_family() in ['x86', 'x86_64'])
 
 if get_option('enable_debugger') != 'none'
   conf_data.set10('C_DEBUG', true)
@@ -109,7 +104,7 @@ if cxx.get_id() == 'msvc'
   conf_data.set('NOMINMAX', true)
 endif
 
-if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
+if host_machine.system() in ['windows', 'cygwin']
   conf_data.set('_USE_MATH_DEFINES', true)
 endif
 
@@ -118,7 +113,7 @@ if host_machine.endian() == 'big'
 endif
 
 # Non-4K memory page size is supported only for ppc64 at the moment.
-if host_machine.cpu_family() == 'ppc64' or host_machine.cpu_family() == 'ppc64le'
+if host_machine.cpu_family() in ['ppc64', 'ppc64le']
   conf_data.set('PAGESIZE', 65536)
 endif
 
@@ -228,7 +223,7 @@ endif
 
 # Windows-only dependencies
 #
-if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
+if host_machine.system() in ['windows', 'cygwin']
   winsock2_dep = cxx.find_library('ws2_32', required : true)
   winmm_dep = cxx.find_library('winmm', required : true)
 endif
@@ -273,15 +268,10 @@ configure_file(input : 'src/config.h.in', output : 'config.h',
 
 # tests
 #
-# We use dictionaries for test declarations, dictionaries were added
-# in meson 0.47.0.
-#
-if meson.version().version_compare('>= 0.47.0')
-  # Some tests use relative paths; in meson 0.56.0 this can be replaced
-  # with meson.project_source_root().
-  project_source_root = meson.current_source_dir()
-  subdir('tests')
-endif
+# Some tests use relative paths; in meson 0.56.0 this can be replaced
+# with meson.project_source_root().
+project_source_root = meson.current_source_dir()
+subdir('tests')
 
 
 # dosbox executable

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,19 @@ project('dosbox-staging', 'c', 'cpp',
         default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
         version : '0.77.0')
 
+
+# meson version check
+#
+# After increasing the minimum-required meson version, make the following
+# improvements:
+#
+# - 0.47.0 - remove 'if' disabling unit tests on older meson
+# - 0.47.0 - you can use dictionaries
+# - 0.49.0 - you can use string path building using '/' operator
+# - 0.49.0 - you can use 'in' operator for arrays and dictionaries
+# - 0.51.0 - remove warning about assertions in buildtype=plain
+# - 0.56.0 - use meson.current_source_dir() in unit tests
+#
 assert(meson.version().version_compare('>= 0.45.1'),
        'Expecting meson 0.45.1 or newer.')
 
@@ -10,6 +23,7 @@ is_plain_build = (get_option('buildtype') == 'plain')
 if meson.version().version_compare('< 0.51.0') and is_plain_build
   warning('C assertions might be enabled, use buildtype=release instead')
 endif
+
 
 # compiler flags
 #

--- a/meson.build
+++ b/meson.build
@@ -278,4 +278,19 @@ subdir('tests')
 #
 executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp'],
            dependencies : [threads_dep, sdl2_dep] + internal_deps,
-           include_directories : incdir)
+           include_directories : incdir,
+           install : true)
+
+
+# additional files for installation
+#
+data_dir     = get_option('datadir')
+licenses_dir = data_dir / 'licenses' / 'dosbox-staging'
+doc_dir      = data_dir / 'doc' / 'dosbox-staging'
+
+install_man('docs/dosbox.1')
+install_data('COPYING', install_dir : licenses_dir)
+install_data('AUTHORS', 'README', 'THANKS', install_dir : doc_dir)
+
+subdir('contrib/linux')
+subdir('contrib/icons')


### PR DESCRIPTION
Another step towards #854 :)

Support for `install` target was easier to implement using Meson's `/` operator for joining paths… but this operator is available only since 0.47.0.

The list of small papercuts resulting from supporting meson 0.45.2 (version in Ubuntu 18.04) grew too long, so I decided to raise the minimum to 0.49.0 (version in Debian Stable). This means builds on Ubuntu <= 18.04 now require installing meson via pip3 :(

Anyway, I think it was worth it. If I'll find time I will make "formal request" to Canonical to upgrade Meson version in Ubuntu 18.04, but I doubt they will do it (based on the response to my initial question).