### PR TITLE
Open the requested MIDI handler early and asynchronously [3/4]

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -164,6 +164,8 @@ public:
 	~MixerObject();
 };
 
+void MIXER_AddConfigSection(Config *conf);
+
 /* PC Speakers functions, tightly related to the timer functions */
 void PCSPEAKER_SetCounter(Bitu cntr,Bitu mode);
 void PCSPEAKER_SetType(Bitu mode);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -84,6 +84,8 @@ void FPU_Init(Section*);
 void DMA_Init(Section*);
 
 void MIXER_Init(Section*);
+void MIXER_MakeProgram(Section *);
+
 void HARDWARE_Init(Section*);
 
 #if defined(PCI_FUNCTIONALITY_ENABLED)
@@ -588,7 +590,9 @@ void DOSBOX_Init(void) {
 	secprop=control->AddSection_prop("pci",&PCI_Init,false); //PCI bus
 #endif
 
+	(void)control->AddSection_prop("mixercom", &MIXER_MakeProgram);
 	secprop = control->AddEarlySectionProp("mixer", &MIXER_Init);
+
 	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
 	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -584,7 +584,7 @@ void DOSBOX_Init(void) {
 
 	MIXER_AddConfigSection(control);
 
-	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
+	secprop = control->AddEarlySectionProp("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init, true);
 
 	pstring = secprop->Add_string("mididevice", when_idle, "auto");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -82,10 +82,6 @@ void FPU_Init(Section*);
 #endif
 
 void DMA_Init(Section*);
-
-void MIXER_Init(Section*);
-void MIXER_MakeProgram(Section *);
-
 void HARDWARE_Init(Section*);
 
 #if defined(PCI_FUNCTIONALITY_ENABLED)
@@ -419,10 +415,6 @@ void DOSBOX_Init(void) {
 
 	SDLNetInited = false;
 
-	// Some frequently used option sets
-	const char *rates[] = {"44100", "48000", "32000", "22050", "16000",
-	                       "11025", "8000",  "49716", 0};
-
 	/* Setup all the different modules making up DOSBox */
 	const char* machines[] = {
 		"hercules", "cga", "cga_mono", "tandy", "pcjr", "ega",
@@ -590,25 +582,7 @@ void DOSBOX_Init(void) {
 	secprop=control->AddSection_prop("pci",&PCI_Init,false); //PCI bus
 #endif
 
-	(void)control->AddSection_prop("mixercom", &MIXER_MakeProgram);
-	secprop = control->AddEarlySectionProp("mixer", &MIXER_Init);
-
-	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
-	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
-
-	Pint = secprop->Add_int("rate",Property::Changeable::OnlyAtStart,44100);
-	Pint->Set_values(rates);
-	Pint->Set_help("Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.");
-
-	const char *blocksizes[] = {
-		 "1024", "2048", "4096", "8192", "512", "256", 0};
-	Pint = secprop->Add_int("blocksize",Property::Changeable::OnlyAtStart,1024);
-	Pint->Set_values(blocksizes);
-	Pint->Set_help("Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.");
-
-	Pint = secprop->Add_int("prebuffer",Property::Changeable::OnlyAtStart,25);
-	Pint->SetMinMax(0,100);
-	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
+	MIXER_AddConfigSection(control);
 
 	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init, true);
@@ -777,7 +751,10 @@ void DOSBOX_Init(void) {
 	Pstring->Set_values(tandys);
 	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
 
+	// TODO: make tandy use the negotiated mixer's rate
 	Pint = secprop->Add_int("tandyrate",Property::Changeable::WhenIdle,44100);
+	const char *rates[] = {"44100", "48000", "32000", "22050", "16000",
+	                       "11025", "8000",  "49716", 0};
 	Pint->Set_values(rates);
 	Pint->Set_help("Sample rate of the Tandy 3-Voice generation.");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -588,8 +588,7 @@ void DOSBOX_Init(void) {
 	secprop=control->AddSection_prop("pci",&PCI_Init,false); //PCI bus
 #endif
 
-
-	secprop=control->AddSection_prop("mixer",&MIXER_Init);
+	secprop = control->AddEarlySectionProp("mixer", &MIXER_Init);
 	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
 	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -891,6 +891,9 @@ void MIXER_Init(Section* sec) {
 	mixer.freq = static_cast<uint32_t>(section->Get_int("rate"));
 	mixer.blocksize = static_cast<uint16_t>(section->Get_int("blocksize"));
 
+	// Ensure external order-of-operations have taken care of our dependencies
+	assert(SDL_WasInit(SDL_INIT_AUDIO) || mixer.nosound);
+
 	/* Initialize the internal stuff */
 	mixer.channels=0;
 	mixer.pos=0;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -960,7 +960,11 @@ void MIXER_Init(Section* sec) {
 	mixer.min_needed = (mixer.freq * mixer.min_needed) / 1000;
 	mixer.max_needed = mixer.blocksize * 2 + 2 * mixer.min_needed;
 	mixer.needed = mixer.min_needed + 1;
-	PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart);
+}
+
+void MIXER_MakeProgram(MAYBE_UNUSED Section *sec)
+{
+	PROGRAMS_MakeFile("MIXER.COM", MIXER_ProgramStart);
 }
 
 void MIXER_CloseAudioDevice()

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -102,19 +102,19 @@ MidiHandler_alsa Midi_alsa;
 #endif
 
 struct DB_Midi {
-	uint8_t status;
-	size_t cmd_len;
-	size_t cmd_pos;
-	uint8_t cmd_buf[8];
-	uint8_t rt_buf[8];
+	uint8_t status = 0;
+	size_t cmd_len = 0;
+	size_t cmd_pos = 0;
+	uint8_t cmd_buf[8] = {0};
+	uint8_t rt_buf[8] = {0};
 	struct {
-		uint8_t buf[MIDI_SYSEX_SIZE];
-		size_t used;
-		uint32_t delay; // ms
-		uint32_t start; // ms
-	} sysex;
-	bool available;
-	MidiHandler * handler;
+		uint8_t buf[MIDI_SYSEX_SIZE] = {};
+		size_t used = 0;
+		uint32_t delay = 0; // ms
+		uint32_t start = 0; // ms
+	} sysex{};
+	bool available = false;
+	MidiHandler *handler = nullptr;
 };
 
 DB_Midi midi;


### PR DESCRIPTION
**Motivation**
 - discussed in issue #735, items 3 and 4.

**Background**
 - The existing MIDI manager opens the requested MIDI handler with fallback to trying the default handlers (ALSA, OSS, and so on).
 - This task of opening the MIDI device needs to be finished when the emulated MPU401 asks the MIDI manager if MIDI is _**Available**_.

**Challenge**
 - We know that setting up MIDI (especially FluidSynth) is both CPU and IO intensive, often parsing several hundred MB worth of SF2 content and loading it into the synthesizer. 
 - So to eliminate as much of this time as possible, we want to start this loading as soon as possible **_and_** we want to do it in parallel with DOSBox's other startup activities.
 - We're free to run in parallel until the MPU401 asks us if we're ready.

**Approach**
- This PR leverages the new `EarlyInit` configuration sections to get MIDI's dependencies (like the SDL audio and mixer initialized) as-soon-as-possible, and from there we Init the MIDI handler early.
- We then kick off the MIDI Open() task in the background, and join (wait for the thread to finish) only when the MPU401 asks if we're available.
- It's at that point where we, if needed, can fallback to opening system MIDI devices if FluidSynth or MT32 failed to open. 

With this approach in mind, I suggest reviewing commit-by-commit. 

I've tested the following permutations successfully:
 
- mididevice = fluidsynth, that has a good config (passes) 
- mididevice = mt32, that has a good config (passes)
- mididevice = fluidsynth, that has a bad config, but midiconfig = 128:0 + Qsynth working (passes) 
- mididevice = mt32, that has a bad config, but midifconfig = 128:0 + Munt working (passes)
- mididevice = fluidsynth, that has a bad config, and midiconfig is bad. (Midi does not open, as expected) 
- mididevice = mt32, that has a bad config, but midifconfig is bad (Midi does not open, as expected)
- mididevice = auto and midiconfig = 128:0 + Qsynth working (passes) 
- mididevice = auto and midifconfig = 128:0 + Munt working (passes)
