### PR TITLE
Enable MT-32 emulation feature by default (meson-only)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -69,11 +69,11 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
 
-      - name: Run scan-build
+      - run:  meson setup build
+
+      - name: Build and run scan-build
         run: |
-          # build steps
           set -x
-          meson setup build
           ninja -C build scan-build
           mv build/meson-logs/scanbuild report
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 183
+          MAX_BUGS: 187
         run: |
           # summary
           echo "Full report is included in build Artifacts"
@@ -124,7 +124,7 @@ jobs:
           # UndefinedBehaviorSanitizer at the same time.
           # See Clang manual to learn more.
           - name: Clang undefined+address sanitizer
-            build_flags: -Db_sanitize=address,undefined --native-file=.github/meson/native-clang.ini
+            build_flags: -Db_sanitize=address,undefined --native-file=.github/meson/native-clang.ini -Duse_mt32emu=false
             logs: clang-uasan-logs
             max_issues: 4
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,46 +17,56 @@ jobs:
       max-parallel: 3
       matrix:
         conf:
+
           - name: Clang, Ubuntu 20.04
             os: ubuntu-20.04
             packages: clang
             build_flags: --native-file=.github/meson/native-clang.ini
             max_warnings: 0
+
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
-            max_warnings: 0
+            max_warnings: 3
+
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
-            build_flags: -Duse_fluidsynth=false --wrap-mode=nofallback
-            max_warnings: 0
+            build_flags: -Duse_fluidsynth=false
+            max_warnings: 3
+
           - name: GCC, Ubuntu 16.04
             os: ubuntu-16.04
-            build_flags: -Duse_fluidsynth=false --wrap-mode=nofallback
+            build_flags: -Duse_fluidsynth=false -Duse_mt32emu=false --wrap-mode=nofallback
             max_warnings: 0
+
           - name: GCC, +tests
             os: ubuntu-20.04
             run_tests: true
             max_warnings: -1
+
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Denable_debugger=normal
-            max_warnings: 120
+            max_warnings: 123
+
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec
-            max_warnings: 0
+            max_warnings: 3
+
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 157
+            max_warnings: 160
+
           - name: GCC, -network
             os: ubuntu-20.04
             build_flags: -Duse_sdl2_net=false
-            max_warnings: 0
+            max_warnings: 3
+
           - name: GCC, warning_level=3
             os: ubuntu-20.04
             build_flags: -Dwarning_level=3
-            max_warnings: 113
+            max_warnings: 116
 
     steps:
       - uses: actions/checkout@v2
@@ -94,12 +104,12 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
 
+      - run:  meson setup ${{ matrix.conf.build_flags }} build
+
       - name: Build
         run: |
           set -xo pipefail
-          meson setup ${{ matrix.conf.build_flags }} build
-          cd build
-          ninja |& tee ../build.log
+          ninja -C build |& tee build.log
 
       - name: Run tests
         if:   matrix.conf.run_tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,23 +17,27 @@ jobs:
       max-parallel: 3
       matrix:
         conf:
+
           - name: Clang
             packages: meson
-            build_flags: --wrap-mode=nofallback
             max_warnings: 0
+
           - name: GCC
             packages: gcc@9
-            build_flags: --wrap-mode=nofallback --native-file=.github/meson/native-gcc-9.ini
-            max_warnings: 0
+            build_flags: --native-file=.github/meson/native-gcc-9.ini
+            max_warnings: 3
+
           - name: Clang, +tests
             run_tests: true
             max_warnings: -1
+
           - name: Clang, +debugger
-            build_flags: --wrap-mode=nofallback -Denable_debugger=normal
+            build_flags: -Denable_debugger=normal
             max_warnings: 153
+
           - name: Clang, warning_level=3
-            build_flags: --wrap-mode=nofallback -Dwarning_level=3
-            max_warnings: 167
+            build_flags: -Dwarning_level=3
+            max_warnings: 170
 
     steps:
       - uses: actions/checkout@v2
@@ -64,10 +68,11 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
 
+      - run:  meson setup ${{ matrix.conf.build_flags }} build
+
       - name: Build
         run: |
           set -xo pipefail
-          meson setup ${{ matrix.conf.build_flags }} build
           meson compile -C build 2>&1 | tee build.log
 
       - name: Run tests

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -59,7 +59,10 @@ jobs:
             apt-get update
             apt-get install -y $(cat ./.github/packages/ubuntu-20.04-apt.txt)
             ./scripts/log-env.sh
-            meson build -Duse_fluidsynth=false --wrap-mode=nofallback
+            meson build \
+              -Duse_fluidsynth=false \
+              -Duse_mt32emu=false \
+              --wrap-mode=nofallback
             ninja -C build |& tee build.log
 
 

--- a/meson.build
+++ b/meson.build
@@ -31,9 +31,9 @@ endif
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 
-add_global_arguments('-Weffc++', language : 'cpp')
+add_project_arguments('-Weffc++', language : 'cpp')
 if cxx.has_argument('-Wextra-semi')
-    add_global_arguments('-Wextra-semi', language : 'cpp')
+    add_project_arguments('-Wextra-semi', language : 'cpp')
 endif
 
 

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ project('dosbox-staging', 'c', 'cpp',
 # improvements:
 #
 # - 0.51.0 - remove warning about assertions in buildtype=plain
+# - 0.55.0 - subproject wraps are automatically promoted to fallbacks,
+#            stop using: "fallback : ['foo', 'foo_dep']" for dependencies
 # - 0.56.0 - use meson.current_source_dir() in unit tests
 #
 assert(meson.version().version_compare('>= 0.49.0'),
@@ -59,6 +61,7 @@ conf_data.set10('C_MODEM', get_option('use_sdl2_net'))
 conf_data.set10('C_IPX', get_option('use_sdl2_net'))
 conf_data.set10('C_OPENGL', get_option('use_opengl'))
 conf_data.set10('C_FLUIDSYNTH', get_option('use_fluidsynth'))
+conf_data.set10('C_MT32EMU', get_option('use_mt32emu'))
 conf_data.set10('C_SSHOT', get_option('use_png'))
 conf_data.set10('C_FPU', true)
 conf_data.set10('C_FPU_X86', host_machine.cpu_family() in ['x86', 'x86_64'])
@@ -155,6 +158,7 @@ sdl2_net_dep  = optional_dep
 opengl_dep    = optional_dep
 fluid_dep     = optional_dep
 opus_dep      = optional_dep
+mt32emu_dep   = optional_dep
 png_dep       = optional_dep
 z_dep         = optional_dep
 curses_dep    = optional_dep # necessary for debugger builds
@@ -178,6 +182,13 @@ endif
 if get_option('use_fluidsynth')
   fluid_dep = dependency('fluidsynth', version : '>= 2.0.0',
                          not_found_message : msg.format('use_fluidsynth'))
+endif
+
+if get_option('use_mt32emu')
+  # TODO version 2.5.0 will install mt32emu.pc file; upgrade when released
+  mt32emu_dep = dependency('mt32emu', version : '>= 2.4.2',
+                           fallback : ['mt32emu', 'mt32emu_dep'],
+                           not_found_message : msg.format('use_mt32emu'))
 endif
 
 if get_option('use_opusfile')

--- a/meson.build
+++ b/meson.build
@@ -228,7 +228,9 @@ endif
 
 # Linux-only dependencies
 #
-if host_machine.system() == 'linux'
+using_linux = (host_machine.system() == 'linux')
+force_alsa  = (get_option('use_alsa') == 'true')
+if force_alsa or (using_linux and get_option('use_alsa') == 'auto')
   alsa_dep = dependency('alsa')
   conf_data.set('C_ALSA', 1)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,11 @@ option('use_fluidsynth',
        value : true,
        description : 'Enable built-in MIDI support via FluidSynth')
 
+option('use_mt32emu',
+       type : 'boolean',
+       value : true,
+       description : 'Enable built-in MT-32 emulation support')
+
 option('use_opusfile',
        type : 'boolean',
        value : true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,6 +28,17 @@ option('use_png',
        value : true,
        description : 'Enable saving screenshots in .png format')
 
+# This option exists only for rare situations when Linux developer cannot
+# install ALSA library headers on their machine.
+#
+# 'auto' translates to 'true' on Linux systems and 'false' everywhere else.
+#
+option('use_alsa',
+       type : 'combo',
+       choices : ['auto', 'true', 'false'],
+       value : 'auto',
+       description : 'Enable ALSA MIDI support')
+
 option('enable_debugger',
        type : 'combo',
        choices : ['normal', 'heavy', 'none'],

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -105,7 +105,7 @@
 #mesondefine C_HEAVY_DEBUG
 
 // Define to 1 to enable MT-32 emulator
-#define C_MT32EMU 0
+#mesondefine C_MT32EMU
 
 // Compiler supports Core Audio headers
 #mesondefine C_COREAUDIO

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -113,6 +113,9 @@
 // Compiler supports Core MIDI headers
 #mesondefine C_COREMIDI
 
+// Define to 1 to enable ALSA MIDI support
+#mesondefine C_ALSA
+
 /* Compiler features and extensions
  *
  * These are defines for compiler features we can't reliably verify during

--- a/src/midi/meson.build
+++ b/src/midi/meson.build
@@ -1,6 +1,7 @@
 libmidi_sources = [
   'midi.cpp',
   'midi_fluidsynth.cpp',
+  'midi_mt32.cpp',
   'midi_oss.cpp',
 ]
 
@@ -9,6 +10,7 @@ libmidi = static_library('midi', libmidi_sources,
                          dependencies : [
                            sdl2_dep,
                            fluid_dep,
+                           mt32emu_dep,
                            alsa_dep,
                            coreaudio_dep,
                            coremidi_dep,

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,2 +1,3 @@
 googletest-release-*
+munt-libmt32emu*
 packagecache

--- a/subprojects/mt32emu.wrap
+++ b/subprojects/mt32emu.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = munt-libmt32emu_2_4_2
+source_url = https://github.com/munt/munt/archive/libmt32emu_2_4_2.tar.gz
+source_filename = libmt32emu_2_4_2.tar.gz
+source_hash = 5ba49f416dc1a076ea73e2b0136ec076b0d86537b47125c104e1e8c3716efb3c
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/mt32emu/2.4.2/1/get_zip
+patch_filename = mt32emu-2.4.2-1-wrap.zip
+patch_hash = 1f4271adc5efd05b347462681120a4603e2ba62e2086000ea829abbfc76b1098
+
+[provide]
+mt32emu = mt32emu_dep
+


### PR DESCRIPTION
Another step towards  #854 - however in this case we are actually pulling ahead of `master` branch, because MT-32 will stay disabled by default on master.

*Only a draft because we're using WIP meson wrap for now. Once the wrap will be accepted in WrapDB, I'll turn this draft into a review.*

This is the first time we have the feature enabled on CI - and we immediately see some interesting things:

- We get 3 new effc++ warnings (Munt project is very strict about the clean builds, but they don't track effc++ warnings - we'll need to fix these 3 warnings upstream).
- We have some new static analysis issues detected by Clang static analyzer (!!!) - I haven't looked in the details yet, though.
- Clang dynamic analyzer fails to compile with the feature enabled for some reason - I simply disabled the feature there (to be fixed, but it's not a deal breaker to me). GCC dynamic analyzer job passed without a problem.

(I don't intend to fix these issues in this PR - I consider them out of scope for Meson migration).

@kcgen Can you test if MT-32 feature works well for you on this branch?