### PR TITLE
Use mt32emu's floating-point synthesis

### DIFF
--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -47,8 +47,10 @@ constexpr auto DAC_MODE = MT32Emu::DACInputMode_NICE;
 constexpr auto RENDERING_TYPE = MT32Emu::RendererType_FLOAT;
 // Sample rate conversion quality: FASTEST, FAST, GOOD, BEST
 constexpr auto RATE_CONVERSION_QUALITY = MT32Emu::SamplerateConversionQuality_BEST;
-// Use improved amplitude ramp characteristics for sustaining instruments
+// Use improved behavior for volume adjustments, panning, and mixing
 constexpr bool USE_NICE_RAMP = true;
+constexpr bool USE_NICE_PANNING = true;
+constexpr bool USE_NICE_PARTIAL_MIXING = true;
 
 MidiHandler_mt32 mt32_instance;
 
@@ -305,6 +307,8 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 
 	mt32_service->setDACInputMode(DAC_MODE);
 	mt32_service->setNiceAmpRampEnabled(USE_NICE_RAMP);
+	mt32_service->setNicePanningEnabled(USE_NICE_PANNING);
+	mt32_service->setNicePartialMixingEnabled(USE_NICE_PARTIAL_MIXING); 
 
 	service = std::move(mt32_service);
 	channel = std::move(mixer_channel);


### PR DESCRIPTION
Similar to our migration to floating-point synthesis under FluidSynth, this PR migrates to floating-point synthesis under mt32emu, which has been supported for ~3 years now.

Comments in the commits. Similar to the move to the RW queue, the changes are "all-or-nothing".  

**Background**
- ![2021-02-11_08-50](https://user-images.githubusercontent.com/1557255/107669143-4a00a980-6c46-11eb-96c0-fd81ca0c54da.png)

**Audio comparison**
 - Master-branch vs PR-branch: 
[Ultima-VII-Part-2-Staging-mt32emu-int-vs-float.zip](https://github.com/dosbox-staging/dosbox-staging/files/5968423/Ultima-VII-Part-2-Staging-mt32emu-int-vs-float.zip)


**Functional testing**
- [x] Linux x86-64
- [x] Linux Aarch64 passing
- [ ] macOS
- [ ] Windows

**Benchmarks**
The rendering thread consumes more CPU time, however floating-point SIMD calls greatly help it therefore it's important to compile mt32emu with optimizations.  That said, there is still an ample amount of headroom on the Pi3 and x86-64:
- Idle % fell from 93.4% to to 91.4% on the Skylake x86-64 rendering core at 800 MHz
- Idle % fell from 29.1% to 20.2% on the Cortex-A53 Pi3 rendering core at 1200 MHz 

**Frequency analysis**

Steps: 
1. Open the two identically recorded tracks (attached above from Ultima 7 Part 2) in Audacity.
1. Press `ctrl + a` to select all (the entire sequence)
1. Click the Analysis menu items > Plot Spectrum > Blackman Window, then 16384 FFT size
1. Compare the plots.
1. Click drag to select the initial second of the tracks. Zoom into this section using `ctrl + mouse-wheel-up/down`, and drag the horizontal scroll-bar left to ensure you're at the start.
1. Compare the waveform shapes at similar high-zoom levels.
 
Results: 
 - Floating point rendering does not introduce quantization steps in the signal, which allows for more natural speaker movement on playback (given the wave-forms of real instruments are typically formed from accumulated sine waves).  
 - The spectrum plots show that floating point rendering retains between  2 to 6 dB of additional dynamic range, which equates to roughly 0.5 to 1.5 extra bits of information.

![2021-02-11_12-54](https://user-images.githubusercontent.com/1557255/107697881-a248a300-6c68-11eb-985a-75cf0e0aae1b.png)