### PR TITLE
Backport disabling of OpenMP when building FluidSynth statically (#867)

### DIFF
--- a/contrib/static-fluidsynth/Makefile
+++ b/contrib/static-fluidsynth/Makefile
@@ -75,6 +75,7 @@ fluidsynth/build/Makefile: fluidsynth/build
 	-DBUILD_SHARED_LIBS=0 \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="$(DIR)" \
+	-DOpenMP_gomp_LIBRARY="" \
 	-DLIB_SUFFIX="" \
 	-Denable-alsa=0 \
 	-Denable-aufile=0 \
@@ -85,6 +86,9 @@ fluidsynth/build/Makefile: fluidsynth/build
 	-Denable-floats=1 \
 	-Denable-ipv6=0 \
 	-Denable-jack=0 \
+	-Denable-ladspa=0 \
+	-Denable-lash=0 \
+	-Denable-libinstpatch=0 \
 	-Denable-libsndfile=0 \
 	-Denable-midishare=0 \
 	-Denable-network=0 \
@@ -93,6 +97,8 @@ fluidsynth/build/Makefile: fluidsynth/build
 	-Denable-pulseaudio=0 \
 	-Denable-readline=0 \
 	-Denable-sdl2=0 \
+	-Denable-systemd=0 \
+	-Denable-wasapi=0 \
 	-Denable-waveout=0 \
 	-Denable-winmidi=0 \
 	..


### PR DESCRIPTION
Will merge to 0.76.x when CI passes.