### PR TITLE
Manage FluidSynth rendering and playback using the RW queue [2/4]

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -82,7 +82,7 @@ jobs:
           path: report
       - name: Summarize report
         env:
-          MAX_BUGS: 183
+          MAX_BUGS: 184
         run: |
           # summary
           echo "Full report is included in build Artifacts"

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -240,11 +240,8 @@ bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
 	// Let the user know that the SoundFont was loaded
 	if (scale_by_percent == 100)
 		LOG_MSG("MIDI: Using SoundFont '%s'", soundfont.c_str());
-	else if (scale_by_percent > 100)
-		LOG_MSG("MIDI: Using SoundFont '%s' with levels amplified by %d%%",
-		        soundfont.c_str(), scale_by_percent);
 	else
-		LOG_MSG("MIDI: Using SoundFont '%s' with levels attenuated by %d%%",
+		LOG_MSG("MIDI: Using SoundFont '%s' with voices scaled by %d%%",
 		        soundfont.c_str(), scale_by_percent);
 
 	constexpr int fx_group = -1; // applies setting to all groups

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -1,8 +1,8 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2021  Nikos Chantziaras <realnc@gmail.com>
  *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2020  Nikos Chantziaras <realnc@gmail.com>
  *  Copyright (C) 2002-2011  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -1,8 +1,8 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2021  Nikos Chantziaras <realnc@gmail.com>
  *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2020  Nikos Chantziaras <realnc@gmail.com>
  *  Copyright (C) 2002-2011  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Code is exactly as we arranged for MT-32 and in a similar all-or-nothing commit (there was no way I could implement it in parts). This PR plus the background-SoundFont-loading PR will close #735.

### Background

Prior to this commit, DOSBox's interaction with FluidSynth was not threaded. FluidSynth _does use threads internally_, and it maintains a 64-byte rendering buffer sufficient to hold 1.3 ms worth audio (assuming a 48 KHz playback rate). Therefore, playback in DOSBox could  block for as much time is needed to render the requested number of frames, assuming FluidSynth's internal thread could not maintain a near-perfect realtime rate. Blocking will occur if the sysex passage requires greater-than-realtime rendering time across a period of greater than 1.3 ms.

Fortunately on modern hardware DOSBox usually has time to spare within its 1-ms tick loop, so some (sub-millisecond) blocking can be tolerated without consequence. However, rendering that takes more than a half-milliseond or more will typically generate an audio gap.

### Summary

This commit moves the FluidSynth rendering task into a thread and uses back-pressure from the RW queue to pace the rendering and consuming threads as follows:

1. Playback waits until a rendered buffer is available before passing the samples onto the mixer.

2. Rendering waits until space is available in the queue before rendering another full buffer.

To determine the total number of frames to manage in the queue, we use FluidSynth's own default audio driver settings (period sizes and period duration) to rendering up to 4096 frames in advance (~5 video frames at 60 FPS), which are divided into eight buffers of 512-frames each. To word this another way: we now have identical latency as FluidSynth's application does. (This also matches mt32emu's recommended sizes as well). 

Rendering is now performed in efficient large chunks instead of on-demand or in per-millisecond quantities. The RW queue also performs std::move() operations on the rendered buffers to ensure no copies are created.

### Testing

 - [x] Linux x86-64 HW
 - [x] Linux ARM HW
 - [x] Windows 10 (VM & HW)
 - [X] macOS  

### Performance

Two minutes of performance metrics (call-stack-sampling) were collected using this command:

 `dosbox xwin.bat & sudo perf record -p $! -g -- sleep 120`

These were converted to FlameGraphs (in SVG format) [:chart: midi-flamegraphs.zip](https://github.com/dosbox-staging/dosbox-staging/files/5975123/midi-flamegraphs.zip)

I've circles the FluidSynth call stacks.

- Before:
    ![2021-02-12_20-19](https://user-images.githubusercontent.com/1557255/107841439-b4f9cf80-6d6f-11eb-8fb1-753673f2be6d.png)

- After:
    ![2021-02-12_20-17](https://user-images.githubusercontent.com/1557255/107841438-b4613900-6d6f-11eb-9506-3d27513f80d3.png)

[Brendan Gregg explains](http://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html):
> _"The x-axis spans the sample population. It does not show the passing of time from left to right, as most graphs do. The left to right ordering has no meaning (it's sorted alphabetically to maximize frame merging)."_
>
> _"The width of the box shows the total time it was on-CPU or part of an ancestry that was on-CPU (based on sample count). **Functions with wide boxes may consume more CPU per execution than those with narrow boxes, or, they may simply be called more often.** The call count is not shown (or known via sampling)."_

Last emphasis is mine. Because the width of the FluidSynth call stacks are more narrow in the PR graph, my guess is we're seeing the effect of making fewer calls into the rendering functions, given we're now requesting FluidSynth render 512 instead of ~45 (or 48) frames per-call.