### PR TITLE
Fix a static analysis warning and improve move-scemantics

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -659,8 +659,8 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 			                          pan_scalars, frames, dac_enabled);
 			++v;
 		}
-		const auto &out_stream = soft_limiter.Apply(accumulator, frames);
-		audio_channel->AddSamples_s16(frames, out_stream.data());
+		const auto &&out = soft_limiter.Apply(accumulator, frames);
+		audio_channel->AddSamples_s16(frames, out.data());
 		CheckVoiceIrq();
 		generated_frames += frames;
 	}

--- a/src/libs/rwqueue/readerwritercircularbuffer.h
+++ b/src/libs/rwqueue/readerwritercircularbuffer.h
@@ -261,7 +261,7 @@ private:
 		std::size_t i = nextItem++;
 		T& element = reinterpret_cast<T*>(data)[i & mask];
 		item = std::move(element);
-		element.~T();
+		// element.~T();
 		slots->signal();
 	}
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -378,8 +378,8 @@ void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
 		const uint16_t len = std::min(frames, max_frames);
 		fluid_synth_write_float(synth.get(), len, stream.data(), 0, 2,
 		                        stream.data(), 1, 2);
-		const auto &out_stream = soft_limiter.Apply(stream, len);
-		channel->AddSamples_s16(len, out_stream.data());
+		const auto &&out = soft_limiter.Apply(stream, len);
+		channel->AddSamples_s16(len, out.data());
 		frames -= len;
 	}
 }

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -440,7 +440,7 @@ void MidiHandler_mt32::Render()
 	render_buffer_t buf;
 	while (keep_rendering) {
 		service->renderFloat(buf.data(), FRAMES_PER_BUFFER);
-		const auto &out = soft_limiter.Apply(buf, FRAMES_PER_BUFFER);
+		auto &&out = soft_limiter.Apply(buf, FRAMES_PER_BUFFER);
 		ring.wait_enqueue(out);
 	}
 }


### PR DESCRIPTION
This commit implements a one-line-fix to address the destruct-after-move warning reported here:
https://github.com/dosbox-staging/dosbox-staging/pull/887 and tracking in upstream here: https://github.com/dosbox-staging/dosbox-staging/issues/889

Related to `std::move`, this also include a commit that uses a simple rvalue for Soft Limiter's `std::array` return type (instead of a const-ref to a permanent member variable).  This change allow the return values to be moved into the ring queue (instead of copied), and later move it out as well, ensuring end-to-end move semantics.