### PR TITLE
Convert Linux and macOS release jobs to use Meson buildsystem

### DIFF
--- a/.github/scripts/verify-macos-dylibs.py
+++ b/.github/scripts/verify-macos-dylibs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021-2021  Patryk Obara <patryk.obara@gmail.com>
+
+# pylint: disable=invalid-name
+
+"""
+Verify if there are no problematic runtime dependencies for this macOS binary.
+"""
+
+import sys
+import subprocess
+
+
+if __name__ == '__main__':
+    result = subprocess.run(['otool', '-L', sys.argv[1]],
+                            stdout=subprocess.PIPE,
+                            check=True)
+    output = result.stdout.decode('utf-8').split('\n')
+
+    allowed_list = [
+        '/System/Library/Frameworks/AppKit.framework/',
+        '/System/Library/Frameworks/AudioToolbox.framework/',
+        '/System/Library/Frameworks/AudioUnit.framework/',
+        '/System/Library/Frameworks/Carbon.framework/',
+        '/System/Library/Frameworks/CoreAudio.framework/',
+        '/System/Library/Frameworks/CoreFoundation.framework/',
+        '/System/Library/Frameworks/CoreGraphics.framework/',
+        '/System/Library/Frameworks/CoreMIDI.framework/',
+        '/System/Library/Frameworks/CoreServices.framework/',
+        '/System/Library/Frameworks/CoreVideo.framework/',
+        '/System/Library/Frameworks/ForceFeedback.framework/',
+        '/System/Library/Frameworks/Foundation.framework/',
+        '/System/Library/Frameworks/GameController.framework/',
+        '/System/Library/Frameworks/IOKit.framework/',
+        '/System/Library/Frameworks/Metal.framework/',
+        '/System/Library/Frameworks/OpenGL.framework/',
+        '/usr/lib/',
+    ]
+
+    # skip first line (program name)
+    for desc in (line.strip() for line in output[1:]):
+        if not desc: # skip over empty string
+            continue
+        if any(desc.startswith(pfx) for pfx in allowed_list):
+            continue
+        print(f"Problematic runtime dependency: '{desc}'")
+        print("Is it installed by default on macOS system?")
+        sys.exit(1)
+
+    sys.exit(0)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,22 +126,22 @@ jobs:
     name: Release build
     runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
-    env:
-      AR: gcc-ar
-      CC: ccache gcc
-      CXX: ccache g++
-      LD: gcc
-      RANLIB: gcc-ranlib
-      FLAGS: >-
-        -O3 -fstrict-aliasing -fno-signed-zeros -fno-trapping-math
-        -fassociative-math -mfpmath=sse -msse4.2 -flto -ffunction-sections
-        -fdata-sections -DNDEBUG -pipe
-      LINKFLAGS: -Wl,--as-needed
     steps:
       - uses: actions/checkout@v2
+
       - run:  sudo apt-get update
+
       - name: Install C++ compiler and libraries
-        run:  sudo apt-get install -y tree libpng-dev librsvg2-bin $(./scripts/list-build-dependencies.sh -m apt -c gcc)
+        run: |
+          sudo apt-get install -y tree \
+            $(cat ./.github/packages/ubuntu-18.04-apt.txt)
+
+      - name: Install Meson via pip3
+        if:   matrix.conf.os != 'ubuntu-20.04'
+        run: |
+          sudo apt-get install python3-setuptools
+          sudo pip3 install meson ninja
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash
@@ -150,6 +150,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+
       - uses:  actions/cache@v2
         id:    cache-ccache
         with:
@@ -157,64 +158,47 @@ jobs:
           key:  ccache-linux-release-${{ steps.prep-ccache.outputs.today }}
           restore-keys: |
             ccache-linux-release-${{ steps.prep-ccache.outputs.yesterday }}
+
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - name: Build FluidSynth libraries
-        run: |
-          set -x
-          sudo apt-get install -y python3-setuptools cmake 
-          sudo pip3 install meson ninja
-          pushd contrib/static-glib
-          make
-          popd
-          cd contrib/static-fluidsynth
-          GLIB_LIBS="$PWD/../static-glib/lib/libglib-2.0.a" \
-          GTHREAD_LIBS="$PWD/../static-glib/lib/libgthread-2.0.a" \
-          GLIB_CFLAGS="-I$PWD/../static-glib/include/glib-2.0" \
-          GTHREAD_CFLAGS="-I$PWD/../static-glib/include/glib-2.0" \
-          make
+
       - name: Inject version string
         run: |
           set -x
           git fetch --prune --unshallow
-          export VERSION=$(git describe --abbrev=4)
-          sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
+          export VERSION=$(git describe --abbrev=5)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - name: Build
+
+      - name: Setup release build
         run: |
-          set -x
-          ./autogen.sh
-          FLUIDSYNTH_CFLAGS="\
-              -I$PWD/contrib/static-fluidsynth/include \
-              -pthread -I$PWD/contrib/static-glib/include/glib-2.0" \
-          FLUIDSYNTH_LIBS="\
-              $PWD/contrib/static-fluidsynth/lib/libfluidsynth.a \
-              $PWD/contrib/static-glib/lib/libgthread-2.0.a -pthread \
-              $PWD/contrib/static-glib/lib/libglib-2.0.a -lm" \
-          ./configure \
-              --enable-png-static \
-              CFLAGS="$FLAGS" \
-              CXXFLAGS="$FLAGS" \
-              LDFLAGS="$FLAGS $LINKFLAGS -flto=$(nproc)"
-          make -j "$(nproc)"
-          strip src/dosbox
+          meson setup \
+            -Dbuildtype=release \
+            -Ddefault_library=static \
+            -Db_asneeded=true \
+            -Db_lto=true \
+            -Duse_fluidsynth=false \
+            build
+
+      - name: Build
+        run:  ninja -C build
+
       - name: Package
         run: |
           set -x
 
+          # Print shared object dependencies
+          ldd build/dosbox
+
           # Prepare content
-          install -DT        src/dosbox           dest/dosbox
+          install -DT        build/dosbox         dest/dosbox
           install -DT -m 644 docs/README.template dest/README
           install -DT -m 644 COPYING              dest/COPYING
           install -DT -m 644 README               dest/doc/manual.txt
-          install -DT -m 644 docs/README.video    dest/doc/video.txt
           install -DT -m 644 docs/dosbox.1        dest/man/dosbox.1
 
-          # Generate .desktop entry and icon files
+          # Install .desktop entry and icon files
           install -DT contrib/linux/dosbox-staging.desktop dest/desktop/dosbox-staging.desktop
-          make -C contrib/icons/ hicolor
-          mkdir -p dest/icons
-          mv contrib/icons/hicolor dest/icons
+          DESTDIR="$PWD" make -C contrib/icons/ install datadir=dest
 
           # Fill README template file
           sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -148,6 +148,7 @@ jobs:
 
           # Print shared object dependencies
           otool -L build/dosbox
+          python3 .github/scripts/verify-macos-dylibs.py build/dosbox
 
           # Generate icon
           make -C contrib/icons/ dosbox-staging.icns

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,6 +132,7 @@ jobs:
             -Ddefault_library=static \
             -Db_asneeded=true \
             -Db_lto=true \
+            -Dtry_sdl2_static=true \
             -Duse_sdl2_net=false \
             -Duse_fluidsynth=false \
             -Duse_opusfile=false \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -89,17 +89,15 @@ jobs:
   build_macos_release:
     name: Release build
     runs-on: macos-latest
-    # Disabled pending meson static-SDL solution
-    if: false
-    # github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
-    env:
-      CC: ccache clang
-      CXX: ccache clang++
-      FLAGS: -DNDEBUG -O3 -fno-math-errno -fstrict-aliasing -march=nehalem -flto=thin -pipe
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     steps:
       - uses: actions/checkout@v2
+
       - name: Install C++ compiler and libraries
-        run:  brew install librsvg $(./scripts/list-build-dependencies.sh -m brew -c clang)
+        run: |
+          brew install librsvg tree \
+            $(cat ./.github/packages/macos-latest-brew.txt)
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash
@@ -108,6 +106,7 @@ jobs:
           echo "::set-output name=dir::$CCACHE_DIR"
           echo "::set-output name=today::$(gdate -I)"
           echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
+
       - uses:  actions/cache@v2
         id:    cache-ccache
         with:
@@ -115,65 +114,39 @@ jobs:
           key:  ccache-macos-release-${{ steps.prep-ccache.outputs.today }}
           restore-keys: |
             ccache-macos-release-${{ steps.prep-ccache.outputs.yesterday }}
+
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - name: Build static Glib libraries
-        run: |
-          set -x
-          brew install meson
-          cd contrib/static-glib
-          gmake
-      - name: Build static FluidSynth library
-        env:
-          GLIB_LIBS:        ${{ github.workspace }}/contrib/static-glib/lib/libglib-2.0.a
-          GTHREAD_LIBS:     ${{ github.workspace }}/contrib/static-glib/lib/libgthread-2.0.a
-          GLIB_CFLAGS:    -I${{ github.workspace }}/contrib/static-glib/include/glib-2.0
-          GTHREAD_CFLAGS: -I${{ github.workspace }}/contrib/static-glib/include/glib-2.0
-        run:  cd contrib/static-fluidsynth && gmake
-      - name: Build static Opus libraries
-        run: |
-          set -x
-          cd contrib/static-opus
-          export CFLAGS="$FLAGS"
-          export CXXFLAGS="$FLAGS"
-          gmake -j "$(sysctl -n hw.physicalcpu)"
+
       - name: Inject version string
         run: |
           set -x
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=5)
-          sed -i -e "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - name: Build
-        env:
-          FLUIDSYNTH_CFLAGS: >-
-            -I${{ github.workspace }}/contrib/static-fluidsynth/include -pthread
-            -I${{ github.workspace }}/contrib/static-glib/include/glib-2.0
-          FLUIDSYNTH_LIBS: >-
-            ${{ github.workspace }}/contrib/static-fluidsynth/lib/libfluidsynth.a
-            ${{ github.workspace }}/contrib/static-glib/lib/libgthread-2.0.a -pthread
-            ${{ github.workspace }}/contrib/static-glib/lib/libglib-2.0.a
-            /usr/local/lib/libintl.a -lm
-          OPUSFILE_CFLAGS: >-
-            -I${{ github.workspace }}/contrib/static-opus/include
-            -I${{ github.workspace }}/contrib/static-opus/include/opus
-          OPUSFILE_LIBS: >-
-            ${{ github.workspace }}/contrib/static-opus/lib/libopusfile.a
-            ${{ github.workspace }}/contrib/static-opus/lib/libogg.a
-            ${{ github.workspace }}/contrib/static-opus/lib/libopus.a -lm
+
+      - name: Setup release build
         run: |
-          set -x
-          ./autogen.sh
-          ./configure \
-            --enable-png-static \
-            --enable-sdl-static \
-            CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"
-          gmake -j "$(sysctl -n hw.physicalcpu)"
-          strip src/dosbox
-          otool -L src/dosbox
+          meson setup \
+            -Dbuildtype=release \
+            -Ddefault_library=static \
+            -Db_asneeded=true \
+            -Db_lto=true \
+            -Duse_sdl2_net=false \
+            -Duse_fluidsynth=false \
+            -Duse_opusfile=false \
+            -Duse_png=false \
+            build
+
+      - name: Build
+        run:  ninja -C build
+
       - name: Package
         run: |
           set -x
+
+          # Print shared object dependencies
+          otool -L build/dosbox
 
           # Generate icon
           make -C contrib/icons/ dosbox-staging.icns
@@ -185,7 +158,7 @@ jobs:
           install -d "$dst/Resources/"
           install -d "$dst/SharedSupport/"
 
-          install        "src/dosbox"                        "$dst/MacOS/"
+          install        "build/dosbox"                      "$dst/MacOS/"
           install -m 644 "contrib/macos/Info.plist.template" "$dst/Info.plist"
           install -m 644 "contrib/macos/PkgInfo"             "$dst/PkgInfo"
           install -m 644 "contrib/icons/dosbox-staging.icns" "$dst/Resources/"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,7 +114,7 @@ jobs:
           set -x
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=4)
-          sed -i "s|VERSION \"git\"|VERSION \"$VERSION\"|" src/platform/visualc/config.h
+          sed -i "s|DOSBOX_DETAILED_VERSION \"git\"|DOSBOX_DETAILED_VERSION \"$VERSION\"|" src/platform/visualc/config.h
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name:  Build

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,14 +2,18 @@ extraction:
   cpp:
     prepare:
       packages:
+      - "libasound2-dev"
+      - "libopusfile-dev"
       - "libpng-dev"
       - "libsdl2-dev"
       - "libsdl2-net-dev"
-      - "libopusfile-dev"
+      - "meson"
     configure:
       command:
-      - "./autogen.sh"
-      - "./configure --disable-fluidsynth"
+      - meson setup -Duse_fluidsynth=false -Duse_mt32emu=false build
+    index:
+      build_command:
+        - ninja -C build
   python:
     python_setup:
       version: 3

--- a/docs/README.template
+++ b/docs/README.template
@@ -2,7 +2,7 @@ This is the development snapshot build of dosbox-staging project.
 
 Please report any bugs or issues to: https://github.com/%GITHUB_REPO%
 
-You can find detailed instructions on using DOSBox in file: docs/manual.txt
+You can find detailed instructions on using DOSBox in file: doc/manual.txt
 
 branch: %GIT_BRANCH%
 commit: %GIT_COMMIT%

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -41,6 +41,8 @@ class Section;
 
 typedef Bitu (LoopHandler)(void);
 
+const char *DOSBOX_GetDetailedVersion() noexcept;
+
 void DOSBOX_RunMachine();
 void DOSBOX_SetLoop(LoopHandler * handler);
 void DOSBOX_SetNormalLoop();

--- a/meson.build
+++ b/meson.build
@@ -290,7 +290,8 @@ subdir('tests')
 
 # dosbox executable
 #
-executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp'],
+version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
+executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
            dependencies : [threads_dep, sdl2_dep] + internal_deps,
            include_directories : incdir,
            install : true)

--- a/meson.build
+++ b/meson.build
@@ -153,7 +153,8 @@ endif
 #
 optional_dep  = dependency('', required : false)
 threads_dep   = dependency('threads')
-sdl2_dep      = dependency('sdl2', version : '>= 2.0.2')
+sdl2_dep      = dependency('sdl2', version : '>= 2.0.2',
+                           static : get_option('try_sdl2_static'))
 sdl2_net_dep  = optional_dep
 opengl_dep    = optional_dep
 fluid_dep     = optional_dep

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,3 +50,10 @@ option('dynamic_core',
        choices : ['auto', 'dyn-x86', 'dynrec', 'none'],
        value : 'auto',
        description : 'Select the dynamic core implementation.')
+
+# This is NOT guaranteed to work. Use it only as a last resort.
+#
+option('try_sdl2_static',
+       type : 'boolean',
+       value : false,
+       description : 'Hint Meson to try linking SDL2 statically.')

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -23,13 +23,13 @@
 
 constexpr char version_msg[] =
         R"(dosbox (dosbox-staging), version %s
-Copyright (C) 2020-2021  The DOSBox Staging Team.
-License GPLv2+: GNU GPL version 2 or later
-<https://www.gnu.org/licenses/gpl-2.0.html>
 
-This is free software, and you are welcome to change and redistribute it
-under certain conditions; please read the COPYING file thoroughly before
-doing so.  There is NO WARRANTY, to the extent permitted by law.
+Copyright (C) 2020-2021  The DOSBox Staging Team
+License: GNU GPL-2.0-or-later <https://www.gnu.org/licenses/gpl-2.0.html>
+
+This is free software, and you are welcome to change and redistribute it under
+certain conditions; please read the COPYING file thoroughly before doing so.
+There is NO WARRANTY, to the extent permitted by law.
 )";
 
 constexpr char help_msg[] =

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3278,7 +3278,7 @@ int sdl_main(int argc, char *argv[])
 		if (control->cmdline->FindExist("--version") ||
 		    control->cmdline->FindExist("-version") ||
 		    control->cmdline->FindExist("-v")) {
-			printf(version_msg, VERSION);
+			printf(version_msg, DOSBOX_GetDetailedVersion());
 			return 0;
 		}
 
@@ -3303,7 +3303,7 @@ int sdl_main(int argc, char *argv[])
 	SetConsoleCtrlHandler((PHANDLER_ROUTINE) ConsoleEventHandler,TRUE);
 #endif
 
-	LOG_MSG("dosbox-staging version %s", VERSION);
+	LOG_MSG("dosbox-staging version %s", DOSBOX_GetDetailedVersion());
 	LOG_MSG("---");
 
 	if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO) < 0)

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -391,7 +391,8 @@ void CONFIG::Run(void) {
 			Bitu size = control->configfiles.size();
 			std::string config_path;
 			Cross::GetPlatformConfigDir(config_path);
-			WriteOut(MSG_Get("PROGRAM_CONFIG_CONFDIR"), VERSION,config_path.c_str());
+			WriteOut(MSG_Get("PROGRAM_CONFIG_CONFDIR"), VERSION,
+			         config_path.c_str());
 			if (size==0) WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
 			else {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_PRIMARY_CONF"),control->configfiles.front().c_str());
@@ -861,8 +862,9 @@ void PROGRAMS_Init(Section* /*sec*/) {
 	MSG_Add("PROGRAM_CONFIG_NOCONFIGFILE","No config file loaded!\n");
 	MSG_Add("PROGRAM_CONFIG_PRIMARY_CONF","Primary config file: \n%s\n");
 	MSG_Add("PROGRAM_CONFIG_ADDITIONAL_CONF","Additional config files:\n");
-	MSG_Add("PROGRAM_CONFIG_CONFDIR","DOSBox %s configuration directory: \n%s\n\n");
-	
+	MSG_Add("PROGRAM_CONFIG_CONFDIR",
+	        "DOSBox Staging %s configuration directory: \n%s\n\n");
+
 	// writeconf
 	MSG_Add("PROGRAM_CONFIG_FILE_ERROR","\nCan't open file %s\n");
 	MSG_Add("PROGRAM_CONFIG_FILE_WHICH", "Writing config file %s\n");

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -2,7 +2,10 @@
 #define CONF_BRAND "staging-git"
 
 /* Version number of package */
-#define VERSION "git"
+#define VERSION "0.77.0"
+
+/* This macro is going to be overriden via CI */
+#define DOSBOX_DETAILED_VERSION "git"
 
 /* Define to 1 to enable internal debugger, requires libcurses */
 #define C_DEBUG 0

--- a/src/platform/visualc/version.cpp
+++ b/src/platform/visualc/version.cpp
@@ -1,0 +1,31 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "dosbox.h"
+
+const char *DOSBOX_GetDetailedVersion() noexcept
+{
+	static const char version[] = DOSBOX_DETAILED_VERSION;
+	// Git tag names start with a letter v (by convention).
+	if (version[0] == 'v')
+		return version + 1;
+	else
+		return version;
+}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -341,7 +341,8 @@ void DOS_Shell::Run()
 		const bool wants_welcome_banner = control->GetStartupVerbosity() >=
 		                                  Verbosity::Medium;
 		if (wants_welcome_banner) {
-			WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"), VERSION);
+			WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"),
+			         DOSBOX_GetDetailedVersion());
 #if C_DEBUG
 			WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"));
 #endif
@@ -359,7 +360,7 @@ void DOS_Shell::Run()
 		line.erase();
 		ParseLine(input_line);
 	} else {
-		WriteOut(MSG_Get("SHELL_STARTUP_SUB"),VERSION);
+		WriteOut(MSG_Get("SHELL_STARTUP_SUB"), DOSBOX_GetDetailedVersion());
 	}
 	do {
 		if (bf){
@@ -746,8 +747,8 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  \033[32;1mver\033[0m \033[37;1mset\033[0m \033[36;1m6.22\033[0m\n"
 	        "  \033[32;1mver\033[0m \033[37;1mset\033[0m \033[36;1m7 10\033[0m\n");
-	MSG_Add("SHELL_CMD_VER_VER",
-	        "DOSBox Staging version %s. Reported DOS version %d.%02d.\n");
+	MSG_Add("SHELL_CMD_VER_VER", "DOSBox Staging version %s\n"
+	                             "DOS version %d.%02d\n");
 	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
 
 	/* Regular startup */

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1608,7 +1608,8 @@ void DOS_Shell::CMD_VER(char *args)
 			dos.version.minor = new_version.minor;
 		} else
 			WriteOut(MSG_Get("SHELL_CMD_VER_INVALID"));
-	} else
-		WriteOut(MSG_Get("SHELL_CMD_VER_VER"), VERSION,
+	} else {
+		WriteOut(MSG_Get("SHELL_CMD_VER_VER"), DOSBOX_GetDetailedVersion(),
 		         dos.version.major, dos.version.minor);
+	}
 }

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,0 +1,31 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "dosbox.h"
+
+const char *DOSBOX_GetDetailedVersion() noexcept
+{
+	static const char version[] = "@VCS_TAG@";
+	// Git tag names start with a letter v (by convention).
+	if (version[0] == 'v')
+		return version + 1;
+	else
+		return version;
+}

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -371,6 +371,7 @@
     <ClCompile Include="..\src\shell\shell_batch.cpp" />
     <ClCompile Include="..\src\shell\shell_cmds.cpp" />
     <ClCompile Include="..\src\shell\shell_misc.cpp" />
+    <ClCompile Include="..\src\platform\visualc\version.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\winres.rc" />


### PR DESCRIPTION
Next important step towards #854. I recommend doing the review commit-by-commit:

- Linux release job switched to Meson:
  Pro: finally…
  Pro: cleaner, faster
  Pro: mt32emu linked statically
  Pro: removed overwriting of version string in configure.ac
  Con: linking FluidSynth statically unavailable for now - the feature is disabled
- macOS release job switched to Meson:
  Pro: finally… it works again! We'll be able to fix #837 
  Pro: cleaner, faster
  Pro: mt32emu linked statically
  Pro: removed overwriting of version string in configure.ac
  Con: basically all dependencies that required static linking are disabled for now
- Git tag description for DOSBox Staging version
  Pro: Fixes: #543
  Con: **After this change, Autoconf buildsystem is no longer usable (!!!)**
  We need this change to complete the transition of release jobs, otherwise we would need to overwrite `meson.build` on CI the same way we were overwriting `configure.ac`. *Read commit description carefully, please.*
- Link SDL2 statically for macOS
  Pro: just look at this commit - it's sooo much simpler than hacks we had in Autoconf :D 
  Con: does not work on Linux, we have no *guarantee* that it will work (hence why option is called **try**_sdl2_static. Personally, I don't think this is a big deal - we instruct Linux users to install SDL2 anyway.

So, this PR is mixed bag of pros and cons, but in total I think it's more positive than negative. One important consideration: after we'll merge this - there's no going back - Autoconf buildsystem will be unusable (on `meson` branch) and all our scripts and documentation referring to old buildsystem are going to fail (so next PR will probably remove of a lot of stuff…).

I think we need serious user testing with this PR. Just before this I discovered we had Opus dependency disabled by mistake (I made a quickfix on `meson` branch directly).

Next steps after this PR will be:

- cleanup
- enabling static linking for dependencies, one-by-one (I tried already and static linking of `libpng` will be as easy as SDL2 :) ).
