### PR TITLE
Assert instead of clamping the CDOM image's track start offset

### DIFF
--- a/include/soft_limiter.h
+++ b/include/soft_limiter.h
@@ -22,10 +22,18 @@
 #ifndef DOSBOX_SOFT_LIMITER_H
 #define DOSBOX_SOFT_LIMITER_H
 
+#include <algorithm>
+#include <cinttypes>
+#include <limits>
+#include <vector>
+#include <string>
+
+#include "mixer.h"
+
 /*
 Zero-Latency Soft Limiter
 -------------------------
-Given an input array of floats, the Soft Limiter scales sequences that
+Given an input vector of floats, the Soft Limiter scales sequences that
 exceed the bounds of a standard 16-bit signal.
 
 This scale-down effect continues to be applied to subsequent sequences,
@@ -69,93 +77,79 @@ sequence of audio. For example:
   SoftLimiter<48> limiter("channel name", prescale);
 
 You can then repeatedly call:
-  const auto out_array = limiter.Apply(in_array, num_frames);
+  auto &&out = limiter.Apply(in, num_frames);
 
 Where:
- - in_array is a std::array<float, 48>
- - num_frames is some number of frames from zero up to 48.
- - out_array is a const reference to std::array<int16_t, 48>
+ - in is a std::vector<float>
+ - num_frames is some number of frames from zero up in.size()
+ - out is a a std::vector<int16_t> of samples (num_frames * 2).
 
-The limiter will either copy or scale-limit num_frames into the out_array.
+The limiter will either copy or scale-limit num_frames into the out vector.
 
-The PrintStats function will make mixer suggestions if the in_array samples were
-either significantly under or over the allowed bounds for the entire playback
-duration.
+The PrintStats function will make mixer-level suggestions if the 'in' samples
+were either significantly under or over the allowed bounds for the entire
+playback duration.
 */
 
-#include "dosbox.h"
-
-#include <algorithm>
-#include <array>
-#include <cassert>
-#include <limits>
-#include <cmath>
-#include <string>
-
-#include "logging.h"
-#include "mixer.h"
-#include "support.h"
-
-template <size_t array_frames>
 class SoftLimiter {
 public:
-	SoftLimiter(const std::string &name, const AudioFrame &scale);
-
 	// Prevent default object construction, copy, and assignment
 	SoftLimiter() = delete;
-	SoftLimiter(const SoftLimiter<array_frames> &) = delete;
-	SoftLimiter<array_frames> &operator=(const SoftLimiter<array_frames> &) = delete;
+	SoftLimiter(const SoftLimiter &) = delete;
+	SoftLimiter &operator=(const SoftLimiter &) = delete;
 
-	constexpr static size_t array_samples = array_frames * 2; // 2 for stereo
-	using in_array_t = std::array<float, array_samples>;
-	using out_array_t = std::array<int16_t, array_samples>;
+	SoftLimiter(const std::string &name,
+	            const AudioFrame &scale,
+	            const uint16_t max_frames);
 
-	out_array_t Apply(const in_array_t &in, uint16_t frames) noexcept;
+	using in_t = std::vector<float>;
+	using out_t = std::vector<int16_t>;
+	out_t Apply(const in_t &in, uint16_t req_frames) noexcept;
 	const AudioFrame &GetPeaks() const noexcept { return global_peaks; }
 	void PrintStats() const;
 	void Reset() noexcept;
 
 private:
-	using in_array_iterator_t = typename std::array<float, array_samples>::const_iterator;
-	using out_array_iterator_t = typename std::array<int16_t, array_samples>::iterator;
+	using in_iterator_t = typename std::vector<float>::const_iterator;
+	using out_iterator_t = typename std::vector<int16_t>::iterator;
 	using out_limits = std::numeric_limits<int16_t>;
 
-	void FindPeaksAndZeroCrosses(const in_array_t &stream, uint16_t frames) noexcept;
+	void FindPeaksAndZeroCrosses(const in_t &stream, uint16_t req_samples) noexcept;
 
-	void FindPeakAndCross(const in_array_iterator_t in_end,
-	                      const in_array_iterator_t pos,
-	                      in_array_iterator_t &prev_pos,
+	void FindPeakAndCross(const in_iterator_t in_end,
+	                      const in_iterator_t pos,
+	                      in_iterator_t &prev_pos,
 	                      const float prescalar,
 	                      float &local_peak,
-	                      in_array_iterator_t &precross_peak_pos,
-	                      in_array_iterator_t &zero_cross_pos,
+	                      in_iterator_t &precross_peak_pos,
+	                      in_iterator_t &zero_cross_pos,
 	                      float &global_peak) noexcept;
 
-	void LinearScale(in_array_iterator_t in_pos,
-	                 const in_array_iterator_t in_end,
-	                 out_array_iterator_t out_pos,
-	                 const float scalar) noexcept;
+	void LinearScale(in_iterator_t in_pos,
+	                 const in_iterator_t in_end,
+	                 out_iterator_t out_pos,
+	                 const float scalar) const noexcept;
 
-	void PolyFit(in_array_iterator_t in_pos,
-	             const in_array_iterator_t in_end,
-	             out_array_iterator_t out_pos,
+	void PolyFit(in_iterator_t in_pos,
+	             const in_iterator_t in_end,
+	             out_iterator_t out_pos,
 	             const float prescalar,
 	             const float poly_a,
-	             const float poly_b) noexcept;
+	             const float poly_b) const noexcept;
 
 	void Release() noexcept;
 
-	void SaveTailFrame(const uint16_t frames, const out_array_t &out) noexcept;
+	void SaveTailFrame(const uint16_t req_frames, const out_t &out) noexcept;
 
 	template <size_t channel>
-	void ScaleOrCopy(const in_array_t &in,
+	void ScaleOrCopy(const in_t &in,
 	                 const size_t samples,
 	                 const float prescalar,
-	                 const in_array_iterator_t precross_peak_pos,
-	                 const in_array_iterator_t zero_cross_pos,
+	                 const in_iterator_t precross_peak_pos,
+	                 const in_iterator_t zero_cross_pos,
 	                 const float global_peak,
 	                 const float tail,
-	                 out_array_t &out);
+	                 out_t &out);
 
 	// Const members
 	constexpr static size_t left = 0;
@@ -165,288 +159,15 @@ private:
 	// Mutable members
 	std::string channel_name = {};
 	const AudioFrame &prescale; // values inside struct are mutable
-	in_array_iterator_t zero_cross_left = {};
-	in_array_iterator_t zero_cross_right = {};
-	in_array_iterator_t precross_peak_pos_left = {};
-	in_array_iterator_t precross_peak_pos_right = {};
+	in_iterator_t zero_cross_left = {};
+	in_iterator_t zero_cross_right = {};
+	in_iterator_t precross_peak_pos_left = {};
+	in_iterator_t precross_peak_pos_right = {};
 	AudioFrame global_peaks = {0, 0};
 	AudioFrame tail_frame = {0, 0};
 	int limited_ms = 0;
 	int non_limited_ms = 0;
+	const uint16_t max_samples = 0;
 };
-
-template <size_t array_frames>
-SoftLimiter<array_frames>::SoftLimiter(const std::string &name, const AudioFrame &scale)
-        : channel_name(name),
-          prescale(scale)
-{
-	static_assert(array_frames > 0, "need some quantity of frames");
-	static_assert(array_frames < 16385, "consider using a smaller sequence");
-}
-
-// Applies the Soft Limiter to the given input sequence and returns the results
-// as a reference to a std::array of 16-bit ints the same length as the input.
-template <size_t array_frames>
-typename SoftLimiter<array_frames>::out_array_t SoftLimiter<array_frames>::Apply(
-        const in_array_t &in, const uint16_t frames) noexcept
-{
-	// Ensure the buffers are large enough to handle the request
-	const uint16_t samples = frames * 2; // left and right channels
-	assert(samples <= in.size());
-
-	FindPeaksAndZeroCrosses(in, samples);
-
-	// Given the local peaks found in each side channel, scale or copy the
-	// input array into the output array
-	out_array_t out;
-	ScaleOrCopy<left>(in, samples, prescale.left, precross_peak_pos_left,
-	                  zero_cross_left, global_peaks.left, tail_frame.left, out);
-
-	ScaleOrCopy<right>(in, samples, prescale.right, precross_peak_pos_right,
-	                   zero_cross_right, global_peaks.right,
-	                   tail_frame.right, out);
-
-	SaveTailFrame(frames, out);
-	Release();
-	return out;
-}
-
-// Helper function to evaluate the existing peaks and prior values.
-// Saves new local and global peaks, and the input-array iterator of any new
-// peaks before the first zero-crossing, along with the first zero-crossing
-// position.
-template <size_t array_frames>
-void SoftLimiter<array_frames>::FindPeakAndCross(const in_array_iterator_t in_end,
-                                                 const in_array_iterator_t pos,
-                                                 in_array_iterator_t &prev_pos,
-                                                 const float prescalar,
-                                                 float &local_peak,
-                                                 in_array_iterator_t &precross_peak_pos,
-                                                 in_array_iterator_t &zero_cross_pos,
-                                                 float &global_peak) noexcept
-{
-	const auto val = fabsf(*pos) * prescalar;
-	if (val > bounds && val > local_peak) {
-		local_peak = val;
-		if (zero_cross_pos == in_end) {
-			precross_peak_pos = pos;
-		}
-	}
-	if (val > global_peak) {
-		global_peak = val;
-	}
-	// Detect and save the first zero-crossing position (if any)
-	if (zero_cross_pos == in_end && prev_pos != in_end &&
-	    std::signbit(*prev_pos) != std::signbit(*pos)) {
-		zero_cross_pos = pos;
-	}
-	prev_pos = pos;
-}
-
-// Sequentially scans the input channels to find new peaks, their positions, and
-// the first zero crossings (saved in member variables).
-template <size_t array_frames>
-void SoftLimiter<array_frames>::FindPeaksAndZeroCrosses(const in_array_t &in,
-                                                        const uint16_t samples) noexcept
-{
-	auto pos = in.begin();
-	const auto pos_end = in.begin() + samples;
-
-	precross_peak_pos_left = in.end();
-	precross_peak_pos_right = in.end();
-	zero_cross_left = in.end();
-	zero_cross_right = in.end();
-	in_array_iterator_t prev_pos_left = in.end();
-	in_array_iterator_t prev_pos_right = in.end();
-	AudioFrame local_peaks = global_peaks;
-
-	while (pos != pos_end) {
-		FindPeakAndCross(in.end(), pos++, prev_pos_left, prescale.left,
-		                 local_peaks.left, precross_peak_pos_left,
-		                 zero_cross_left, global_peaks.left);
-
-		FindPeakAndCross(in.end(), pos++, prev_pos_right, prescale.right,
-		                 local_peaks.right, precross_peak_pos_right,
-		                 zero_cross_right, global_peaks.right);
-	}
-}
-
-// Scale or copy the given channel's samples into the output array
-template <size_t array_frames>
-template <size_t channel>
-void SoftLimiter<array_frames>::ScaleOrCopy(const in_array_t &in,
-                                            const size_t samples,
-                                            const float prescalar,
-                                            const in_array_iterator_t precross_peak_pos,
-                                            const in_array_iterator_t zero_cross_pos,
-                                            const float global_peak,
-                                            const float tail,
-                                            out_array_t &out)
-{
-	assert(samples >= 2); // need at least one frame
-	auto in_start = in.begin() + channel;
-	const auto in_end = in.begin() + channel + samples;
-	auto out_start = out.begin() + channel;
-
-	// We have a new peak, so ...
-	if (precross_peak_pos != in.end()) {
-		const auto tail_abs = fabsf(tail);
-		const auto prepeak_scalar = (bounds - tail_abs) /
-		                            (prescalar * fabsf(*precross_peak_pos) -
-		                             tail_abs);
-		// fit the frontside of the waveform to the tail up to the peak.
-		PolyFit(in_start, precross_peak_pos, out_start, prescalar,
-		        prepeak_scalar, tail);
-
-		// Then scale the backend of the waveform from its peak ...
-		out_start = out.begin() + (precross_peak_pos - in.begin());
-		const auto postpeak_scalar = bounds / fabsf(*precross_peak_pos);
-		// down to the zero-crossing ...
-		if (zero_cross_pos != in.end()) {
-			LinearScale(precross_peak_pos, zero_cross_pos,
-			            out_start, postpeak_scalar);
-
-			// and from the zero-crossing to the end of the sequence.
-			out_start = out.begin() + (zero_cross_pos - in.begin());
-			const auto postcross_scalar = prescalar * bounds / global_peak;
-			LinearScale(zero_cross_pos, in_end, out_start,
-			            postcross_scalar);
-		}
-		// down to the end of the sequence.
-		else {
-			LinearScale(precross_peak_pos, in_end, out_start,
-			            postpeak_scalar);
-		}
-		limited_ms++;
-
-		// We have an existing peak ...
-	} else if (global_peak > bounds) {
-		// so scale the entire sequence a a ratio of the peak.
-		const auto current_scalar = prescalar * bounds / global_peak;
-		LinearScale(in_start, in_end, out_start, current_scalar);
-		limited_ms++;
-
-		// The current sequence is fully inbounds ...
-	} else {
-		// so simply prescale the entire sequence.
-		LinearScale(in_start, in_end, out_start, prescalar);
-		++non_limited_ms;
-	}
-}
-
-// Apply the polynomial coefficients to the sequence
-template <size_t array_frames>
-void SoftLimiter<array_frames>::PolyFit(in_array_iterator_t in_pos,
-                                        const in_array_iterator_t in_end,
-                                        out_array_iterator_t out_pos,
-                                        const float prescalar,
-                                        const float poly_a,
-                                        const float poly_b) noexcept
-{
-	while (in_pos != in_end) {
-		const auto fitted = poly_a * (*in_pos * prescalar - poly_b) + poly_b;
-		assert(fabsf(fitted) <= out_limits::max());
-		*out_pos = static_cast<int16_t>(fitted);
-		out_pos += 2;
-		in_pos += 2;
-	}
-}
-
-// Apply the scalar to the sequence
-template <size_t array_frames>
-void SoftLimiter<array_frames>::LinearScale(in_array_iterator_t in_pos,
-                                            const in_array_iterator_t in_end,
-                                            out_array_iterator_t out_pos,
-                                            const float scalar) noexcept
-{
-	while (in_pos != in_end) {
-		const auto scaled = (*in_pos) * scalar;
-		assert(fabsf(scaled) <= out_limits::max());
-		*out_pos = static_cast<int16_t>(scaled);
-		out_pos += 2;
-		in_pos += 2;
-	}
-}
-
-template <size_t array_frames>
-void SoftLimiter<array_frames>::SaveTailFrame(const uint16_t frames,
-                                              const out_array_t &out) noexcept
-{
-	const size_t i = (frames - 1) * 2;
-	tail_frame.left = static_cast<float>(out[i]);
-	tail_frame.right = static_cast<float>(out[i + 1]);
-}
-
-// If either channel was out of bounds, then decrement their peak
-template <size_t array_frames>
-void SoftLimiter<array_frames>::Release() noexcept
-{
-	// Decrement the peak(s) one step
-	constexpr float delta_db = 0.002709201f; // 0.0235 dB increments
-	constexpr float release_amplitude = bounds * delta_db;
-	if (global_peaks.left > bounds)
-		global_peaks.left -= release_amplitude;
-	if (global_peaks.right > bounds)
-		global_peaks.right -= release_amplitude;
-}
-
-// Print helpful statistics about the signal thus-far
-template <size_t array_frames>
-void SoftLimiter<array_frames>::PrintStats() const
-{
-	// Only print information if we have more than 30 seconds of data
-	constexpr auto ms_per_minute = 1000 * 60;
-	const auto ms_total = static_cast<double>(limited_ms) + non_limited_ms;
-	const auto minutes_total = ms_total / ms_per_minute;
-	if (minutes_total < 0.5)
-		return;
-
-	// Only print information if there was at least some amplitude
-	const auto peak_sample = std::max(global_peaks.left, global_peaks.right);
-	constexpr auto two_percent_of_max = 0.02f * bounds;
-	if (peak_sample < two_percent_of_max)
-		return;
-
-	// Inform the user what percent of the dynamic-range was used
-	auto peak_ratio = peak_sample / bounds;
-	peak_ratio = std::min(peak_ratio, 1.0f);
-	LOG_MSG("%s: Peak amplitude reached %.0f%% of max",
-	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
-
-	// Inform when the stream fell short of using the full dynamic-range
-	const auto scale = std::max(prescale.left, prescale.right);
-	constexpr auto well_below_3db = 0.6f;
-	if (peak_ratio < well_below_3db) {
-		const auto suggested_mix_val = 100 * scale / peak_ratio;
-		LOG_MSG("%s: If it should be louder, use: mixer %s %.0f",
-		        channel_name.c_str(), channel_name.c_str(),
-		        static_cast<double>(suggested_mix_val));
-	}
-	// Inform if more than 20% of the stream required limiting
-	const auto time_ratio = limited_ms / (ms_total + 1); // one ms avoids div-by-0
-	if (time_ratio > 0.2) {
-		const auto minutes_limited = static_cast<double>(limited_ms) / ms_per_minute;
-		const auto suggested_mix_val = 100 * (1 - time_ratio) *
-		                               static_cast<double>(scale);
-		LOG_MSG("%s: %.1f%% or %.2f of %.2f minutes needed limiting, consider: mixer %s %.0f",
-		        channel_name.c_str(), 100 * time_ratio, minutes_limited,
-		        minutes_total, channel_name.c_str(), suggested_mix_val);
-	}
-}
-
-// A paused audio source should Reset() the limiter so it starts with
-// fresh peaks and a zero-tail if/when the stream is restarted.
-template <size_t array_frames>
-void SoftLimiter<array_frames>::Reset() noexcept
-{
-	// if the current peaks are over the upper bounds, then we simply save
-	// the upper bound because we want retain information about the peak
-	// amplitude when printing statistics.
-
-	constexpr auto upper = bounds; // (workaround to prevent link-errors)
-	global_peaks.left = std::min(global_peaks.left, upper);
-	global_peaks.right = std::min(global_peaks.right, upper);
-	tail_frame = {0, 0};
-}
 
 #endif

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -720,23 +720,22 @@ bool CDROM_Interface_Image::PlayAudioSector(const uint32_t start, uint32_t len)
 	if (start < track->start)
 		len -= (track->start - start);
 
-	// Seek to the calculated byte offset, bounded to the valid byte offsets
-	const uint32_t offset = (track->skip
-	                        + clamp(start - static_cast<uint32_t>(track->start),
-	                                0u, track->length - 1)
-	                        * track->sectorSize);
+	// Calculate the requested byte offset from the sector offset
+	const auto sector_offset = start - track->start;
+	const auto last_sector = track->length - 1;
+	assert(sector_offset <= last_sector);
+	const uint32_t byte_offset = (track->skip + sector_offset * track->sectorSize);
 
 	// Guard: Bail if our track could not be seeked
-	if (!track_file->seek(offset)) {
+	if (!track_file->seek(byte_offset)) {
 		LOG_MSG("CDROM: Track %d failed to seek to byte %u, so cancelling playback",
-		        track->number,
-		        offset);
+		        track->number, byte_offset);
 		StopAudio();
 		return false;
 	}
 
 	// We're performing an audio-task, so update the audio position
-	track_file->setAudioPosition(offset);
+	track_file->setAudioPosition(byte_offset);
 
 	// Get properties about the current track
 	const uint8_t track_channels = track_file->getChannels();

--- a/src/hardware/Makefile.am
+++ b/src/hardware/Makefile.am
@@ -37,6 +37,7 @@ libhardware_a_SOURCES = \
 	pcspeaker.cpp \
 	pic.cpp \
 	sblaster.cpp \
+	soft_limiter.cpp \
 	tandy_sound.cpp \
 	timer.cpp \
 	vga_attr.cpp \

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -659,8 +659,8 @@ void Gus::AudioCallback(const uint16_t requested_frames)
 			                          pan_scalars, frames, dac_enabled);
 			++v;
 		}
-		const auto &out_stream = soft_limiter.Apply(accumulator, frames);
-		audio_channel->AddSamples_s16(frames, out_stream.data());
+		const auto &&out = soft_limiter.Apply(accumulator, frames);
+		audio_channel->AddSamples_s16(frames, out.data());
 		CheckVoiceIrq();
 		generated_frames += frames;
 	}

--- a/src/hardware/soft_limiter.cpp
+++ b/src/hardware/soft_limiter.cpp
@@ -1,0 +1,299 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2021  Kevin R. Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "soft_limiter.h"
+
+#include <cmath>
+
+#include "support.h"
+
+SoftLimiter::SoftLimiter(const std::string &name,
+                         const AudioFrame &scale,
+                         const uint16_t max_frames)
+        : channel_name(name),
+          prescale(scale),
+          max_samples(max_frames * 2)
+{}
+
+// Applies the Soft Limiter to the given input sequence and returns the results
+// as a reference to a std::vector of 16-bit ints the same length as the input.
+typename SoftLimiter::out_t SoftLimiter::Apply(const in_t &in,
+                                               const uint16_t frames) noexcept
+{
+	// Make sure chunk sizes aren' too big or latent
+	assertm(frames > 0, "need some quantity of frames");
+	assertm(frames <= 16384, "consider using smaller sequence chunks");
+
+	// Make sure the incoming vector has at least the requested frames
+	const uint16_t samples = frames * 2; // left and right channels
+	assert(in.size() >= samples);
+
+	FindPeaksAndZeroCrosses(in, samples);
+
+	// Size our temporary output vector using the max_samples, which
+	// is typically assigned from constexpr's at compile-time. This followed
+	// by logically sizing the vector downward (if needed) based on runtime
+	// content.
+	out_t out;
+	out.reserve(max_samples);
+	assert(samples <= max_samples);
+	out.resize(samples);
+
+	// Given the local peaks found in each side channel, scale or copy the
+	// input array into the output array
+	ScaleOrCopy<left>(in, samples, prescale.left, precross_peak_pos_left,
+	                  zero_cross_left, global_peaks.left, tail_frame.left, out);
+
+	ScaleOrCopy<right>(in, samples, prescale.right, precross_peak_pos_right,
+	                   zero_cross_right, global_peaks.right,
+	                   tail_frame.right, out);
+
+	SaveTailFrame(frames, out);
+	Release();
+	return out;
+}
+
+// Helper function to evaluate the existing peaks and prior values.
+// Saves new local and global peaks, and the input-array iterator of any new
+// peaks before the first zero-crossing, along with the first zero-crossing
+// position.
+void SoftLimiter::FindPeakAndCross(const in_iterator_t in_end,
+                                   const in_iterator_t pos,
+                                   in_iterator_t &prev_pos,
+                                   const float prescalar,
+                                   float &local_peak,
+                                   in_iterator_t &precross_peak_pos,
+                                   in_iterator_t &zero_cross_pos,
+                                   float &global_peak) noexcept
+{
+	const auto val = fabsf(*pos) * prescalar;
+	if (val > bounds && val > local_peak) {
+		local_peak = val;
+		if (zero_cross_pos == in_end) {
+			precross_peak_pos = pos;
+		}
+	}
+	if (val > global_peak) {
+		global_peak = val;
+	}
+	// Detect and save the first zero-crossing position (if any)
+	if (zero_cross_pos == in_end && prev_pos != in_end &&
+	    std::signbit(*prev_pos) != std::signbit(*pos)) {
+		zero_cross_pos = pos;
+	}
+	prev_pos = pos;
+}
+
+// Sequentially scans the input channels to find new peaks, their positions, and
+// the first zero crossings (saved in member variables).
+void SoftLimiter::FindPeaksAndZeroCrosses(const in_t &in, const uint16_t samples) noexcept
+{
+	auto pos = in.begin();
+	const auto pos_end = in.begin() + samples;
+
+	precross_peak_pos_left = in.end();
+	precross_peak_pos_right = in.end();
+	zero_cross_left = in.end();
+	zero_cross_right = in.end();
+	in_iterator_t prev_pos_left = in.end();
+	in_iterator_t prev_pos_right = in.end();
+	AudioFrame local_peaks = global_peaks;
+
+	while (pos != pos_end) {
+		FindPeakAndCross(in.end(), pos++, prev_pos_left, prescale.left,
+		                 local_peaks.left, precross_peak_pos_left,
+		                 zero_cross_left, global_peaks.left);
+
+		FindPeakAndCross(in.end(), pos++, prev_pos_right, prescale.right,
+		                 local_peaks.right, precross_peak_pos_right,
+		                 zero_cross_right, global_peaks.right);
+	}
+}
+
+// Scale or copy the given channel's samples into the output array
+template <size_t channel>
+void SoftLimiter::ScaleOrCopy(const in_t &in,
+                              const size_t samples,
+                              const float prescalar,
+                              const in_iterator_t precross_peak_pos,
+                              const in_iterator_t zero_cross_pos,
+                              const float global_peak,
+                              const float tail,
+                              out_t &out)
+{
+	assert(samples >= 2); // need at least one frame
+	auto in_start = in.begin() + channel;
+	const auto in_end = in.begin() + channel + samples;
+	auto out_start = out.begin() + channel;
+
+	// We have a new peak, so ...
+	if (precross_peak_pos != in.end()) {
+		const auto tail_abs = fabsf(tail);
+		const auto prepeak_scalar = (bounds - tail_abs) /
+		                            (prescalar * fabsf(*precross_peak_pos) -
+		                             tail_abs);
+		// fit the frontside of the waveform to the tail up to the peak.
+		PolyFit(in_start, precross_peak_pos, out_start, prescalar,
+		        prepeak_scalar, tail);
+
+		// Then scale the backend of the waveform from its peak ...
+		out_start = out.begin() + (precross_peak_pos - in.begin());
+		const auto postpeak_scalar = bounds / fabsf(*precross_peak_pos);
+		// down to the zero-crossing ...
+		if (zero_cross_pos != in.end()) {
+			LinearScale(precross_peak_pos, zero_cross_pos,
+			            out_start, postpeak_scalar);
+
+			// and from the zero-crossing to the end of the sequence.
+			out_start = out.begin() + (zero_cross_pos - in.begin());
+			const auto postcross_scalar = prescalar * bounds / global_peak;
+			LinearScale(zero_cross_pos, in_end, out_start,
+			            postcross_scalar);
+		}
+		// down to the end of the sequence.
+		else {
+			LinearScale(precross_peak_pos, in_end, out_start,
+			            postpeak_scalar);
+		}
+		limited_ms++;
+
+		// We have an existing peak ...
+	} else if (global_peak > bounds) {
+		// so scale the entire sequence a a ratio of the peak.
+		const auto current_scalar = prescalar * bounds / global_peak;
+		LinearScale(in_start, in_end, out_start, current_scalar);
+		limited_ms++;
+
+		// The current sequence is fully inbounds ...
+	} else {
+		// so simply prescale the entire sequence.
+		LinearScale(in_start, in_end, out_start, prescalar);
+		++non_limited_ms;
+	}
+}
+
+// Apply the polynomial coefficients to the sequence
+void SoftLimiter::PolyFit(in_iterator_t in_pos,
+                          const in_iterator_t in_end,
+                          out_iterator_t out_pos,
+                          const float prescalar,
+                          const float poly_a,
+                          const float poly_b) const noexcept
+{
+	while (in_pos != in_end) {
+		const auto fitted = poly_a * (*in_pos * prescalar - poly_b) + poly_b;
+		assert(fabsf(fitted) <= out_limits::max());
+		*out_pos = static_cast<int16_t>(fitted);
+		out_pos += 2;
+		in_pos += 2;
+	}
+}
+
+// Apply the scalar to the sequence
+void SoftLimiter::LinearScale(in_iterator_t in_pos,
+                              const in_iterator_t in_end,
+                              out_iterator_t out_pos,
+                              const float scalar) const noexcept
+{
+	while (in_pos != in_end) {
+		const auto scaled = (*in_pos) * scalar;
+		assert(fabsf(scaled) <= out_limits::max());
+		*out_pos = static_cast<int16_t>(scaled);
+		out_pos += 2;
+		in_pos += 2;
+	}
+}
+
+void SoftLimiter::SaveTailFrame(const uint16_t frames, const out_t &out) noexcept
+{
+	const size_t i = (frames - 1) * 2;
+	tail_frame.left = static_cast<float>(out[i]);
+	tail_frame.right = static_cast<float>(out[i + 1]);
+}
+
+// If either channel was out of bounds, then decrement their peak
+void SoftLimiter::Release() noexcept
+{
+	// Decrement the peak(s) one step
+	constexpr float delta_db = 0.002709201f; // 0.0235 dB increments
+	constexpr float release_amplitude = bounds * delta_db;
+	if (global_peaks.left > bounds)
+		global_peaks.left -= release_amplitude;
+	if (global_peaks.right > bounds)
+		global_peaks.right -= release_amplitude;
+}
+
+// Print helpful statistics about the signal thus-far
+void SoftLimiter::PrintStats() const
+{
+	// Only print information if we have more than 30 seconds of data
+	constexpr auto ms_per_minute = 1000 * 60;
+	const auto ms_total = static_cast<double>(limited_ms) + non_limited_ms;
+	const auto minutes_total = ms_total / ms_per_minute;
+	if (minutes_total < 0.5)
+		return;
+
+	// Only print information if there was at least some amplitude
+	const auto peak_sample = std::max(global_peaks.left, global_peaks.right);
+	constexpr auto two_percent_of_max = 0.02f * bounds;
+	if (peak_sample < two_percent_of_max)
+		return;
+
+	// Inform the user what percent of the dynamic-range was used
+	auto peak_ratio = peak_sample / bounds;
+	peak_ratio = std::min(peak_ratio, 1.0f);
+	LOG_MSG("%s: Peak amplitude reached %.0f%% of max",
+	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
+
+	// Inform when the stream fell short of using the full dynamic-range
+	const auto scale = std::max(prescale.left, prescale.right);
+	constexpr auto well_below_3db = 0.6f;
+	if (peak_ratio < well_below_3db) {
+		const auto suggested_mix_val = 100 * scale / peak_ratio;
+		LOG_MSG("%s: If it should be louder, use: mixer %s %.0f",
+		        channel_name.c_str(), channel_name.c_str(),
+		        static_cast<double>(suggested_mix_val));
+	}
+	// Inform if more than 20% of the stream required limiting
+	const auto time_ratio = limited_ms / (ms_total + 1); // one ms avoids div-by-0
+	if (time_ratio > 0.2) {
+		const auto minutes_limited = static_cast<double>(limited_ms) / ms_per_minute;
+		const auto suggested_mix_val = 100 * (1 - time_ratio) *
+		                               static_cast<double>(scale);
+		LOG_MSG("%s: %.1f%% or %.2f of %.2f minutes needed limiting, consider: mixer %s %.0f",
+		        channel_name.c_str(), 100 * time_ratio, minutes_limited,
+		        minutes_total, channel_name.c_str(), suggested_mix_val);
+	}
+}
+
+// A paused audio source should Reset() the limiter so it starts with
+// fresh peaks and a zero-tail if/when the stream is restarted.
+void SoftLimiter::Reset() noexcept
+{
+	// if the current peaks are over the upper bounds, then we simply save
+	// the upper bound because we want retain information about the peak
+	// amplitude when printing statistics.
+
+	constexpr auto upper = bounds; // (workaround to prevent link-errors)
+	global_peaks.left = std::min(global_peaks.left, upper);
+	global_peaks.right = std::min(global_peaks.right, upper);
+	tail_frame = {0, 0};
+}

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -378,8 +378,8 @@ void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
 		const uint16_t len = std::min(frames, max_frames);
 		fluid_synth_write_float(synth.get(), len, stream.data(), 0, 2,
 		                        stream.data(), 1, 2);
-		const auto &out_stream = soft_limiter.Apply(stream, len);
-		channel->AddSamples_s16(len, out_stream.data());
+		const auto &&out = soft_limiter.Apply(stream, len);
+		channel->AddSamples_s16(len, out.data());
 		frames -= len;
 	}
 }

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -28,6 +28,7 @@
 #include <deque>
 #include <string>
 #include <tuple>
+#include <vector>
 
 #include "control.h"
 #include "cross.h"
@@ -176,6 +177,12 @@ static std::string find_sf_file(const std::string &name)
 		}
 	}
 	return "";
+}
+
+MidiHandlerFluidsynth::MidiHandlerFluidsynth()
+        : soft_limiter("FSYNTH", prescale_level, expected_max_frames)
+{
+	stream.resize(expected_max_frames * 2); // L & R channels
 }
 
 bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
@@ -368,19 +375,17 @@ void MidiHandlerFluidsynth::PrintStats()
 	soft_limiter.PrintStats();
 }
 
-void MidiHandlerFluidsynth::MixerCallBack(uint16_t frames)
+void MidiHandlerFluidsynth::MixerCallBack(uint16_t requested_frames)
 {
-	constexpr uint16_t max_samples = expected_max_frames * 2; // two channels per frame
-	std::array<float, max_samples> stream;
-
-	while (frames > 0) {
+	while (requested_frames > 0) {
 		constexpr uint16_t max_frames = expected_max_frames; // local copy fixes link error
-		const uint16_t len = std::min(frames, max_frames);
-		fluid_synth_write_float(synth.get(), len, stream.data(), 0, 2,
-		                        stream.data(), 1, 2);
-		const auto &&out = soft_limiter.Apply(stream, len);
-		channel->AddSamples_s16(len, out.data());
-		frames -= len;
+		const uint16_t frames = std::min(requested_frames, max_frames);
+		assert(frames <= stream.size());
+		fluid_synth_write_float(synth.get(), frames, stream.data(), 0,
+		                        2, stream.data(), 1, 2);
+		const auto &&out = soft_limiter.Apply(stream, frames);
+		channel->AddSamples_s16(frames, out.data());
+		requested_frames -= frames;
 	}
 }
 

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -28,6 +28,7 @@
 #if C_FLUIDSYNTH
 
 #include <memory>
+#include <vector>
 #include <fluidsynth.h>
 
 #include "mixer.h"
@@ -44,7 +45,7 @@ private:
 	        std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
 public:
-	MidiHandlerFluidsynth() : soft_limiter("FSYNTH", prescale_level) {}
+	MidiHandlerFluidsynth();
 	void PrintStats();
 	const char *GetName() const override { return "fluidsynth"; }
 	bool Open(const char *conf) override;
@@ -54,14 +55,15 @@ public:
 
 private:
 	static constexpr uint16_t expected_max_frames = (96000 / 1000) + 4;
-	void MixerCallBack(uint16_t len); // see: MIXER_Handler
+	void MixerCallBack(uint16_t requested_frames);
 	void SetMixerLevel(const AudioFrame &prescale_level) noexcept;
 
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	mixer_channel_ptr_t channel{nullptr, MIXER_DelChannel};
 	AudioFrame prescale_level = {1.0f, 1.0f};
-	SoftLimiter<expected_max_frames> soft_limiter;
+	SoftLimiter soft_limiter;
+	std::vector<float> stream{};
 
 	bool is_open = false;
 };

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -230,6 +230,10 @@ static mt32emu_report_handler_i get_report_handler_interface()
 	return REPORT_HANDLER_I;
 }
 
+MidiHandler_mt32::MidiHandler_mt32()
+        : soft_limiter("MT32", limiter_ratio, FRAMES_PER_BUFFER)
+{}
+
 bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 {
 	Close();
@@ -317,6 +321,7 @@ bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 	keep_rendering = true;
 	const auto render = std::bind(&MidiHandler_mt32::Render, this);
 	renderer = std::thread(render);
+	ring.wait_dequeue(play_buffer); // populate the first play buffer
 
 	// Start playback
 	channel->Enable(true);
@@ -360,9 +365,8 @@ void MidiHandler_mt32::Close()
 
 	// Stop rendering and drain the ring
 	keep_rendering = false;
-	limited_buffer_t discard_buffer;
 	while (ring.size_approx())
-		ring.wait_dequeue(discard_buffer);
+		ring.wait_dequeue(play_buffer);
 
 	// Wait for the rendering thread to finish
 	if (renderer.joinable())
@@ -408,7 +412,7 @@ void MidiHandler_mt32::MixerCallBack(uint16_t requested_frames)
 	while (requested_frames) {
 		const auto frames_to_be_played = std::min(GetRemainingFrames(),
 		                                          requested_frames);
-		const auto sample_offset_in_buffer = buffer.data() +
+		const auto sample_offset_in_buffer = play_buffer.data() +
 		                                     last_played_frame * 2;
 		channel->AddSamples_s16(frames_to_be_played, sample_offset_in_buffer);
 		requested_frames -= frames_to_be_played;
@@ -417,19 +421,21 @@ void MidiHandler_mt32::MixerCallBack(uint16_t requested_frames)
 }
 
 // GetRemainingFrames() gives us the number of unplayed (ie: remaining) frames
-// left in the current buffer. If it's run out, then we pop a new "full" buffer
-// out of the ring. If the ring doesn't have a buffer to offer, then we (block)
-// and wait until the ring gives us one.
+// left in the current play buffer. If it's run out, then we pop a new "full"
+// play buffer out of the ring. If the ring doesn't have a buffer to offer, then
+// we (block) and wait until the ring gives us one.
 uint16_t MidiHandler_mt32::GetRemainingFrames()
 {
-	// the current buffer has some frames still left to play, so return those
+	// the current play buffer has some frames still left to play
 	if (last_played_frame < FRAMES_PER_BUFFER)
 		return FRAMES_PER_BUFFER - last_played_frame;
 
 	// Otherwise move the next fully rendered buffer out of the ring
-	ring.wait_dequeue(buffer);
+	ring.wait_dequeue(play_buffer);
 	total_buffers_played++;
 	last_played_frame = 0;
+
+	assert(play_buffer.size() == SAMPLES_PER_BUFFER);
 	return FRAMES_PER_BUFFER;
 }
 
@@ -437,11 +443,13 @@ uint16_t MidiHandler_mt32::GetRemainingFrames()
 // released in the ring allowing MT-32 to renderer the next "full buffer".
 void MidiHandler_mt32::Render()
 {
-	render_buffer_t buf;
+	render_buffer_t render_buffer;
+	render_buffer.resize(SAMPLES_PER_BUFFER);
+
 	while (keep_rendering) {
-		service->renderFloat(buf.data(), FRAMES_PER_BUFFER);
-		auto &&out = soft_limiter.Apply(buf, FRAMES_PER_BUFFER);
-		ring.wait_enqueue(out);
+		service->renderFloat(render_buffer.data(), FRAMES_PER_BUFFER);
+		auto &&out = soft_limiter.Apply(render_buffer, FRAMES_PER_BUFFER);
+		ring.wait_enqueue(out); // moved into the queue
 	}
 }
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -440,7 +440,7 @@ void MidiHandler_mt32::Render()
 	render_buffer_t buf;
 	while (keep_rendering) {
 		service->renderFloat(buf.data(), FRAMES_PER_BUFFER);
-		const auto &out = soft_limiter.Apply(buf, FRAMES_PER_BUFFER);
+		auto &&out = soft_limiter.Apply(buf, FRAMES_PER_BUFFER);
 		ring.wait_enqueue(out);
 	}
 }

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -26,9 +26,9 @@
 
 #if C_MT32EMU
 
-#include <array>
 #include <memory>
 #include <thread>
+#include <vector>
 
 #define MT32EMU_API_TYPE 3
 #include <mt32emu/mt32emu.h>
@@ -45,16 +45,16 @@ private:
 	static constexpr int FRAMES_PER_BUFFER = 1024; // synth granularity
 	static constexpr int SAMPLES_PER_BUFFER = FRAMES_PER_BUFFER * 2; // L & R
 
-	using render_buffer_t = std::array<float, SAMPLES_PER_BUFFER>;
-	using limited_buffer_t = std::array<int16_t, SAMPLES_PER_BUFFER>;
-	using ring_t = moodycamel::BlockingReaderWriterCircularBuffer<limited_buffer_t>;
+	using render_buffer_t = std::vector<float>;
+	using play_buffer_t = std::vector<int16_t>;
+	using ring_t = moodycamel::BlockingReaderWriterCircularBuffer<play_buffer_t>;
 	using channel_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 	using conditional_t = moodycamel::weak_atomic<bool>;
 
 public:
 	using service_t = std::unique_ptr<MT32Emu::Service>;
 
-	MidiHandler_mt32() : soft_limiter("MT32", limiter_ratio) {}
+	MidiHandler_mt32();
 	~MidiHandler_mt32() override;
 	void Close() override;
 	const char *GetName() const override { return "mt32"; }
@@ -71,18 +71,18 @@ private:
 
 	// Managed objects
 	channel_t channel{nullptr, MIXER_DelChannel};
-	limited_buffer_t buffer{};
+	play_buffer_t play_buffer{};
 	ring_t ring{4}; // Handle up to four buffers in the ring
 	service_t service{};
 	std::thread renderer{};
 	AudioFrame limiter_ratio = {1.0f, 1.0f};
-	SoftLimiter<FRAMES_PER_BUFFER> soft_limiter;
+	SoftLimiter soft_limiter;
 
 	// The following two members let us determine the total number of played
 	// frames, which is used by GetMidiEventTimestamp() to calculate a total
 	// time offset.
 	uint32_t total_buffers_played = 0;
-	uint16_t last_played_frame = 0; // relative frame-offset in the buffer
+	uint16_t last_played_frame = 0; // relative frame-offset in the play buffer
 
 	conditional_t keep_rendering = false;
 	bool is_open = false;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,7 @@ tests_SOURCES = \
 	stubs.cpp \
 	support.cpp
 
-tests_LDADD = ../src/misc/libmisc.a
+tests_LDADD = ../src/hardware/libhardware.a ../src/misc/libmisc.a
 
 # Override automake's distclean target to prevent it recursing into
 # SUBDIRS and failing (it was already invoked in there via src/Makefile.am).

--- a/tests/soft_limiter.cpp
+++ b/tests/soft_limiter.cpp
@@ -28,11 +28,11 @@ TEST(SoftLimiter, InboundsProcessAllFrames)
 {
 	constexpr int frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-3, -2, -1, 0, 1, 2};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected{-3, -2, -1, 0, 1, 2};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected{-3, -2, -1, 0, 1, 2};
 	EXPECT_EQ(out, expected);
 }
 
@@ -40,11 +40,11 @@ TEST(SoftLimiter, InboundsProcessPartialFrames)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-3, -2, -1, 0, 1, 2};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, 1);
-	const SoftLimiter<frames>::out_array_t expected{-3, -2};
+	SoftLimiter::out_t out = limiter.Apply(in, 1);
+	const SoftLimiter::out_t expected{-3, -2};
 	EXPECT_EQ(out[0], expected[0]);
 	EXPECT_EQ(out[1], expected[1]);
 }
@@ -53,8 +53,8 @@ TEST(SoftLimiter, InboundsProcessTooManyFrames)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-3, -2, -1, 0, 1, 2};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-3, -2, -1, 0, 1, 2};
 	EXPECT_DEBUG_DEATH({ limiter.Apply(in, frames + 1); }, "");
 }
 
@@ -62,13 +62,12 @@ TEST(SoftLimiter, OutOfBoundsLeftChannel)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-8.1f,    32000.0f, 65535.0f,
-	                                         32000.0f, 4.1f,     32000.0f};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-8.1f,    32000.0f, 65535.0f,
+	                           32000.0f, 4.1f,     32000.0f};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected{-4,    32000, 32766,
-	                                                32000, 2,     32000};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected{-4, 32000, 32766, 32000, 2, 32000};
 	EXPECT_EQ(out, expected);
 }
 
@@ -76,13 +75,12 @@ TEST(SoftLimiter, OutOfBoundsRightChannel)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{32000.0f, -3.1f,    32000.0f,
-	                                         98304.1f, 32000.0f, 6.1f};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{32000.0f, -3.1f,    32000.0f,
+	                           98304.1f, 32000.0f, 6.1f};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected{32000, -1,    32000,
-	                                                32765, 32000, 2};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected{32000, -1, 32000, 32765, 32000, 2};
 	EXPECT_EQ(out, expected);
 }
 
@@ -90,13 +88,12 @@ TEST(SoftLimiter, OutboundsBothChannelsPositive)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-8.1f,    -3.1f, 65535.0f,
-	                                         98304.1f, 4.1f,  6.1f};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-8.1f,    -3.1f, 65535.0f,
+	                           98304.1f, 4.1f,  6.1f};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected{-4,    -1, 32766,
-	                                                32765, 2,  2};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected{-4, -1, 32766, 32765, 2, 2};
 	EXPECT_EQ(out, expected);
 }
 
@@ -104,13 +101,12 @@ TEST(SoftLimiter, OutboundsBothChannelsNegative)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-8.1f,     -3.1f, -65535.0f,
-	                                         -98304.1f, 4.1f,  6.1f};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-8.1f,     -3.1f, -65535.0f,
+	                           -98304.1f, 4.1f,  6.1f};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected{-4,     -1, -32766,
-	                                                -32765, 2,  2};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected{-4, -1, -32766, -32765, 2, 2};
 	EXPECT_EQ(out, expected);
 }
 
@@ -118,14 +114,13 @@ TEST(SoftLimiter, OutboundsBothChannelsMixed)
 {
 	const auto frames = 3;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{40000.0f, -40000.0f,
-	                                         65534.0f, -98301.0f,
-	                                         40000.0f, -40000.0f};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{40000.0f,  -40000.0f, 65534.0f,
+	                           -98301.0f, 40000.0f,  -40000.0f};
 
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected{19999,  -13332, 32766,
-	                                                -32766, 19999,  -13332};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected{19999,  -13332, 32766,
+	                                  -32766, 19999,  -13332};
 	EXPECT_EQ(out, expected);
 }
 
@@ -133,15 +128,15 @@ TEST(SoftLimiter, OutboundsBigOneReleaseStep)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	SoftLimiter<frames>::in_array_t in{-60000.0f, 80000.0f};
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, 1);
+	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter::in_t in{-60000.0f, 80000.0f};
+	SoftLimiter::out_t out = limiter.Apply(in, 1);
 
 	in[0] = static_cast<float>(out[0]);
 	in[1] = static_cast<float>(out[1]);
 	out = limiter.Apply(in, frames);
 
-	const SoftLimiter<frames>::out_array_t expected{-17920, 13434};
+	const SoftLimiter::out_t expected{-17920, 13434};
 	EXPECT_EQ(out, expected);
 }
 
@@ -149,16 +144,16 @@ TEST(SoftLimiter, OutboundsBig600ReleaseSteps)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	SoftLimiter<frames>::in_array_t in{-60000.0f, 80000.0f};
-	SoftLimiter<frames>::out_array_t out;
+	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter::in_t in{-60000.0f, 80000.0f};
+	SoftLimiter::out_t out;
 
 	for (int i = 0; i < 600; ++i) {
 		out = limiter.Apply(in, frames);
 		in[0] = -32767;
 		in[1] = 32768;
 	}
-	const SoftLimiter<frames>::out_array_t expected{-32766, 32766};
+	const SoftLimiter::out_t expected{-32766, 32766};
 	EXPECT_EQ(out, expected);
 }
 
@@ -166,15 +161,15 @@ TEST(SoftLimiter, OutboundsSmallTwoReleaseSteps)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	SoftLimiter<frames>::in_array_t in{-32800.0f, 32800.0f};
-	SoftLimiter<frames>::out_array_t out;
+	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter::in_t in{-32800.0f, 32800.0f};
+	SoftLimiter::out_t out;
 	for (int i = 0; i < 2; ++i) {
 		out = limiter.Apply(in, frames);
 		in[0] = -32767;
 		in[1] = 32767;
 	}
-	const SoftLimiter<frames>::out_array_t expected{-32766, 32766};
+	const SoftLimiter::out_t expected{-32766, 32766};
 	EXPECT_EQ(out, expected);
 }
 
@@ -182,16 +177,16 @@ TEST(SoftLimiter, OutboundsSmallTenReleaseSteps)
 {
 	const auto frames = 1;
 	const AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	SoftLimiter<frames>::in_array_t in{-32800.0f, 32800.0f};
-	SoftLimiter<frames>::out_array_t out{};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter::in_t in{-32800.0f, 32800.0f};
+	SoftLimiter::out_t out{};
 
 	for (int i = 0; i < 10; ++i) {
 		out = limiter.Apply(in, frames);
 		in[0] = -32767;
 		in[1] = 32768;
 	}
-	const SoftLimiter<frames>::out_array_t expected{-32766, 32766};
+	const SoftLimiter::out_t expected{-32766, 32766};
 	EXPECT_EQ(out, expected);
 }
 
@@ -199,23 +194,21 @@ TEST(SoftLimiter, OutboundsPolyJoinPositive)
 {
 	const auto frames = 3;
 	AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter limiter("test-channel", prescale, frames);
 
-	const SoftLimiter<frames>::in_array_t first_chunk{18000, 18000, 20000,
-	                                                  20000, 22000, 22000};
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(first_chunk, frames);
-	const SoftLimiter<frames>::out_array_t expected_first{18000, 18000,
-	                                                      20000, 20000,
-	                                                      22000, 22000};
+	const SoftLimiter::in_t first_chunk{18000, 18000, 20000,
+	                                    20000, 22000, 22000};
+	SoftLimiter::out_t out = limiter.Apply(first_chunk, frames);
+	const SoftLimiter::out_t expected_first{18000, 18000, 20000,
+	                                        20000, 22000, 22000};
 	EXPECT_EQ(out, expected_first);
 
-	const SoftLimiter<frames>::in_array_t second_chunk{30000, 30000, 60000,
-	                                                   60000, 30000, 30000};
+	const SoftLimiter::in_t second_chunk{30000, 30000, 60000,
+	                                     60000, 30000, 30000};
 	out = limiter.Apply(second_chunk, frames);
 
-	const SoftLimiter<frames>::out_array_t expected_second{24266, 24266,
-	                                                       32766, 32766,
-	                                                       16383, 16383};
+	const SoftLimiter::out_t expected_second{24266, 24266, 32766,
+	                                         32766, 16383, 16383};
 	EXPECT_EQ(out, expected_second);
 }
 
@@ -223,25 +216,21 @@ TEST(SoftLimiter, OutboundsPolyJoinNegative)
 {
 	const auto frames = 3;
 	AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter limiter("test-channel", prescale, frames);
 
-	const SoftLimiter<frames>::in_array_t first_chunk{-18000, -18000,
-	                                                  -20000, -20000,
-	                                                  -22000, -22000};
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(first_chunk, frames);
-	const SoftLimiter<frames>::out_array_t expected_first{-18000, -18000,
-	                                                      -20000, -20000,
-	                                                      -22000, -22000};
+	const SoftLimiter::in_t first_chunk{-18000, -18000, -20000,
+	                                    -20000, -22000, -22000};
+	SoftLimiter::out_t out = limiter.Apply(first_chunk, frames);
+	const SoftLimiter::out_t expected_first{-18000, -18000, -20000,
+	                                        -20000, -22000, -22000};
 	EXPECT_EQ(out, expected_first);
 
-	const SoftLimiter<frames>::in_array_t second_chunk{-30000, -30000,
-	                                                   -60000, -60000,
-	                                                   -30000, -30000};
+	const SoftLimiter::in_t second_chunk{-30000, -30000, -60000,
+	                                     -60000, -30000, -30000};
 	out = limiter.Apply(second_chunk, frames);
 
-	const SoftLimiter<frames>::out_array_t expected_second{-24266, -24266,
-	                                                       -32766, -32766,
-	                                                       -16383, -16383};
+	const SoftLimiter::out_t expected_second{-24266, -24266, -32766,
+	                                         -32766, -16383, -16383};
 	EXPECT_EQ(out, expected_second);
 }
 
@@ -249,32 +238,31 @@ TEST(SoftLimiter, OutboundsJoinWithZeroCross)
 {
 	const auto frames = 6;
 	AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
+	SoftLimiter limiter("test-channel", prescale, frames);
 
-	const SoftLimiter<frames>::in_array_t first_chunk{-5000, 1000,  -3000,
-	                                                  1000,  -1000, 1000,
-	                                                  0,     1000,  3000,
-	                                                  1000,  5000,  1000};
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(first_chunk, frames);
+	const SoftLimiter::in_t first_chunk{-5000, 1000, -3000, 1000,
+	                                    -1000, 1000, 0,     1000,
+	                                    3000,  1000, 5000,  1000};
+	SoftLimiter::out_t out = limiter.Apply(first_chunk, frames);
 
-	const SoftLimiter<frames>::in_array_t second_chunk{
-	        15000, 1000, 25000,  1000, 32000,  1000,
-	        0,     1000, -15000, 1000, -40000, 1000};
+	const SoftLimiter::in_t second_chunk{15000,  1000, 25000,  1000,
+	                                     32000,  1000, 0,      1000,
+	                                     -15000, 1000, -40000, 1000};
 	out = limiter.Apply(second_chunk, frames);
 
-	const SoftLimiter<frames>::out_array_t expected_second{
-	        12287, 1000, 20478,  1000, 26212,  1000,
-	        0,     1000, -12287, 1000, -32765, 1000};
+	const SoftLimiter::out_t expected_second{12287,  1000, 20478,  1000,
+	                                         26212,  1000, 0,      1000,
+	                                         -12287, 1000, -32765, 1000};
 	EXPECT_EQ(out, expected_second);
 
-	const SoftLimiter<frames>::in_array_t third_chunk{
-	        -25000, 1000, -15000, 1000, -10000, 1000,
-	        -5000,  1000, 0,      1000, 3000,   1000};
+	const SoftLimiter::in_t third_chunk{-25000, 1000, -15000, 1000,
+	                                    -10000, 1000, -5000,  1000,
+	                                    0,      1000, 3000,   1000};
 	out = limiter.Apply(third_chunk, frames);
 
-	const SoftLimiter<frames>::out_array_t expected_third{
-	        -20524, 1000, -12314, 1000, -8209, 1000,
-	        -4104,  1000, 0,      1000, 2462,  1000};
+	const SoftLimiter::out_t expected_third{-20524, 1000, -12314, 1000,
+	                                        -8209,  1000, -4104,  1000,
+	                                        0,      1000, 2462,   1000};
 	EXPECT_EQ(out, expected_third);
 }
 
@@ -282,10 +270,10 @@ TEST(SoftLimiter, PrescaleAttenuate)
 {
 	const auto frames = 1;
 	AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-30000.1f, 30000.0f};
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected_first{-30000, 30000};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-30000.1f, 30000.0f};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected_first{-30000, 30000};
 	EXPECT_EQ(out, expected_first);
 
 	// The limiter holds a reference to the prescaling struct so it can
@@ -293,7 +281,7 @@ TEST(SoftLimiter, PrescaleAttenuate)
 	prescale.left = 0.5f;
 	prescale.right = 0.1f;
 	out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected_scaled{-15000, 3000};
+	const SoftLimiter::out_t expected_scaled{-15000, 3000};
 	EXPECT_EQ(out, expected_scaled);
 }
 
@@ -301,10 +289,10 @@ TEST(SoftLimiter, PrescaleAmplify)
 {
 	const auto frames = 1;
 	AudioFrame prescale{1, 1};
-	SoftLimiter<frames> limiter("test-channel", prescale);
-	const SoftLimiter<frames>::in_array_t in{-10000.1f, 10000.0f};
-	SoftLimiter<frames>::out_array_t out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected_first{-10000, 10000};
+	SoftLimiter limiter("test-channel", prescale, frames);
+	const SoftLimiter::in_t in{-10000.1f, 10000.0f};
+	SoftLimiter::out_t out = limiter.Apply(in, frames);
+	const SoftLimiter::out_t expected_first{-10000, 10000};
 	EXPECT_EQ(out, expected_first);
 
 	// The limiter holds a reference to the prescaling struct so it can
@@ -312,7 +300,7 @@ TEST(SoftLimiter, PrescaleAmplify)
 	prescale.left = 1.5f;
 	prescale.right = 1.1f;
 	out = limiter.Apply(in, frames);
-	const SoftLimiter<frames>::out_array_t expected_scaled{-15000, 11000};
+	const SoftLimiter::out_t expected_scaled{-15000, 11000};
 	EXPECT_EQ(out, expected_scaled);
 }
 

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -316,6 +316,7 @@
     <ClCompile Include="..\src\hardware\serialport\serialdummy.cpp" />
     <ClCompile Include="..\src\hardware\serialport\serialport.cpp" />
     <ClCompile Include="..\src\hardware\serialport\softmodem.cpp" />
+    <ClCompile Include="..\src\hardware\soft_limiter.cpp" />
     <ClCompile Include="..\src\hardware\tandy_sound.cpp" />
     <ClCompile Include="..\src\hardware\timer.cpp" />
     <ClCompile Include="..\src\hardware\vga.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -229,6 +229,9 @@
     <ClCompile Include="..\src\hardware\serialport\softmodem.cpp">
       <Filter>src\hardware\serialport</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\soft_limiter.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\tandy_sound.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>


### PR DESCRIPTION
Clang v13 error'ed out on this `clamp` call when building the code-base as if it were C++17.
This prompted a review of this code resulting in this small logic improvement.
Tested working with several codecs and titles.