### PR TITLE
Assert instead of clamping the CDOM image's track start offset

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -720,23 +720,22 @@ bool CDROM_Interface_Image::PlayAudioSector(const uint32_t start, uint32_t len)
 	if (start < track->start)
 		len -= (track->start - start);
 
-	// Seek to the calculated byte offset, bounded to the valid byte offsets
-	const uint32_t offset = (track->skip
-	                        + clamp(start - static_cast<uint32_t>(track->start),
-	                                0u, track->length - 1)
-	                        * track->sectorSize);
+	// Calculate the requested byte offset from the sector offset
+	const auto sector_offset = start - track->start;
+	const auto last_sector = track->length - 1;
+	assert(sector_offset <= last_sector);
+	const uint32_t byte_offset = track->skip + sector_offset * track->sectorSize;
 
 	// Guard: Bail if our track could not be seeked
-	if (!track_file->seek(offset)) {
+	if (!track_file->seek(byte_offset)) {
 		LOG_MSG("CDROM: Track %d failed to seek to byte %u, so cancelling playback",
-		        track->number,
-		        offset);
+		        track->number, byte_offset);
 		StopAudio();
 		return false;
 	}
 
 	// We're performing an audio-task, so update the audio position
-	track_file->setAudioPosition(offset);
+	track_file->setAudioPosition(byte_offset);
 
 	// Get properties about the current track
 	const uint8_t track_channels = track_file->getChannels();


### PR DESCRIPTION
Clang v13 error'ed out on this `clamp` call when building the code-base as if it were C++17.
This prompted a review of this code resulting in this small logic improvement.
Tested working with several codecs and titles.