### PR TITLE
Link png, opusfile, and sdl2_net statically in macOS release job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -189,6 +189,7 @@ jobs:
             -Ddefault_library=static \
             -Db_asneeded=true \
             -Db_lto=true \
+            -Dtry_static_libs=png \
             -Duse_fluidsynth=false \
             build
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,8 +132,7 @@ jobs:
             -Ddefault_library=static \
             -Db_asneeded=true \
             -Db_lto=true \
-            -Dtry_sdl2_static=true \
-            -Duse_sdl2_net=false \
+            -Dtry_static_libs=sdl2,sdl2_net \
             -Duse_fluidsynth=false \
             -Duse_opusfile=false \
             -Duse_png=false \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,10 +132,9 @@ jobs:
             -Ddefault_library=static \
             -Db_asneeded=true \
             -Db_lto=true \
-            -Dtry_static_libs=sdl2,sdl2_net \
+            -Dtry_static_libs=png,sdl2,sdl2_net \
             -Duse_fluidsynth=false \
             -Duse_opusfile=false \
-            -Duse_png=false \
             build
 
       - name: Build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,9 +132,8 @@ jobs:
             -Ddefault_library=static \
             -Db_asneeded=true \
             -Db_lto=true \
-            -Dtry_static_libs=png,sdl2,sdl2_net \
+            -Dtry_static_libs=opusfile,png,sdl2,sdl2_net \
             -Duse_fluidsynth=false \
-            -Duse_opusfile=false \
             build
 
       - name: Build

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project('dosbox-staging', 'c', 'cpp',
 # After increasing the minimum-required meson version, make the following
 # improvements:
 #
+# - 0.53.0 - use summary() to communicate setup result
 # - 0.55.0 - subproject wraps are automatically promoted to fallbacks,
 #            stop using: "fallback : ['foo', 'foo_dep']" for dependencies
 # - 0.56.0 - use meson.current_source_dir() in unit tests

--- a/meson.build
+++ b/meson.build
@@ -186,7 +186,8 @@ if get_option('use_mt32emu')
 endif
 
 if get_option('use_opusfile')
-  opus_dep = dependency('opusfile', not_found_message : msg.format('use_opusfile'))
+  opus_dep = dependency('opusfile', static : ('opusfile' in static_libs_list),
+                        not_found_message : msg.format('use_opusfile'))
 endif
 
 if get_option('use_png')

--- a/meson.build
+++ b/meson.build
@@ -142,10 +142,13 @@ endif
 
 # external dependencies
 #
+static_libs_list = get_option('try_static_libs')
+msg = 'You can disable this dependency with: -D@0@=false'
+
 optional_dep  = dependency('', required : false)
 threads_dep   = dependency('threads')
 sdl2_dep      = dependency('sdl2', version : '>= 2.0.2',
-                           static : get_option('try_sdl2_static'))
+                           static : ('sdl2' in static_libs_list))
 sdl2_net_dep  = optional_dep
 opengl_dep    = optional_dep
 fluid_dep     = optional_dep
@@ -159,10 +162,10 @@ coremidi_dep  = optional_dep # macOS-only
 winsock2_dep  = optional_dep # Windows-only
 winmm_dep     = optional_dep # Windows-only
 
-msg = 'You can disable this dependency with: -D@0@=false'
 
 if get_option('use_sdl2_net')
   sdl2_net_dep = dependency('SDL2_net', version : '>= 2.0.1',
+                            static : ('sdl2_net' in static_libs_list),
                             not_found_message : msg.format('use_sdl2_net'))
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -190,7 +190,8 @@ if get_option('use_opusfile')
 endif
 
 if get_option('use_png')
-  png_dep = dependency('libpng', not_found_message : msg.format('use_png'))
+  png_dep = dependency('libpng', static : ('png' in static_libs_list),
+                       not_found_message : msg.format('use_png'))
 endif
 
 if get_option('enable_debugger') != 'none'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -51,9 +51,17 @@ option('dynamic_core',
        value : 'auto',
        description : 'Select the dynamic core implementation.')
 
-# This is NOT guaranteed to work. Use it only as a last resort.
+# Use this option for selectively switching dependencies to look for static
+# libraries first. This behaves differently than passing
+# -Ddefault_library=static (which will turn on static linking for dependencies
+# built from wraps, but still attempt dynamic linking for system-installed
+# libraries).
 #
-option('try_sdl2_static',
-       type : 'boolean',
-       value : false,
-       description : 'Hint Meson to try linking SDL2 statically.')
+# This is NOT guaranteed to work - the end results will vary depending on your
+# OS, installed libraries, and dependencies of those libraries.
+#
+option('try_static_libs',
+       type : 'array',
+       choices : ['sdl2', 'sdl2_net'],
+       value : [],
+       description : 'Attempt to statically link selected libraries.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,6 +62,6 @@ option('dynamic_core',
 #
 option('try_static_libs',
        type : 'array',
-       choices : ['png', 'sdl2', 'sdl2_net'],
+       choices : ['opusfile', 'png', 'sdl2', 'sdl2_net'],
        value : [],
        description : 'Attempt to statically link selected libraries.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,6 +62,6 @@ option('dynamic_core',
 #
 option('try_static_libs',
        type : 'array',
-       choices : ['sdl2', 'sdl2_net'],
+       choices : ['png', 'sdl2', 'sdl2_net'],
        value : [],
        description : 'Attempt to statically link selected libraries.')


### PR DESCRIPTION
For #854. Also, link png statically on Linux (I needed to verify if this technique works - it does :) ).

Interlude from cleanup for a moment :)

@kcgen I'm not sure if we can remove it immediately, but this is a step towards making `contrib/static-opus` unnecessary :) Do we know about any environment where usage of static-opus Makefile is still necessary? If yes, then we should convert it to a wrap dependency… What do you think?

Fortunately, it seems like on macOS we don't need to do it - library provided via Homebrew links statically without a problem now :)

