### PR TITLE
Let user opt-out of building unit tests 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
           - name: GCC 5, Ubuntu 18.04
             os: ubuntu-18.04
             packages: g++-5
-            build_flags: --native-file=.github/meson/native-gcc-5.ini --wrap-mode=nofallback -Duse_fluidsynth=false -Duse_mt32emu=false
+            build_flags: --native-file=.github/meson/native-gcc-5.ini --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_mt32emu=false
             max_warnings: 0
 
           - name: GCC, +tests
@@ -71,7 +71,7 @@ jobs:
 
           - name: GCC, minimum build
             os: ubuntu-20.04
-            build_flags: --wrap-mode=nofallback -Duse_fluidsynth=false -Duse_sdl2_net=false -Duse_opengl=false -Duse_fluidsynth=false -Duse_mt32emu=false -Duse_opusfile=false -Duse_png=false -Duse_alsa=false
+            build_flags: --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_sdl2_net=false -Duse_opengl=false -Duse_fluidsynth=false -Duse_mt32emu=false -Duse_opusfile=false -Duse_png=false -Duse_alsa=false
             min_dependencies: true
             max_warnings: -1
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -65,3 +65,8 @@ option('try_static_libs',
        choices : ['opusfile', 'png', 'sdl2', 'sdl2_net'],
        value : [],
        description : 'Attempt to statically link selected libraries.')
+
+option('unit_tests',
+       type : 'feature',
+       value : 'auto',
+       description : 'Build unit tests. Auto skips for release builds.')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,19 +1,24 @@
 # gtest dependency
 #
-# Meson will first try to find pre-installed gtest via pkg-config;
-# if this fails, it will download wrap dependency (subproject).
+# User opt-in/out, or disabled for release builds
 #
-# Users can further configure the download behaviour using:
-#
-#   meson setup --wrap-mode={nofallback,nodownload,forcefallback}
-#
-# If gtest is not available at all, unit tests will be disabled.
-#
-gtest_dep = dependency('gtest', main : true, required : false,
-                       fallback : ['gtest', 'gtest_main_dep'])
-if not gtest_dep.found()
-  message('optional gtest dependency not found, unit tests are disabled')
+if (get_option('unit_tests').disabled() or
+   (get_option('buildtype') == 'release' and get_option('unit_tests').auto()))
   gtest_dep = disabler()
+else
+  #
+  # Meson will first try to find pre-installed gtest via pkg-config;
+  # if this fails, it will download wrap dependency (subproject).
+  #
+  # Users can further configure the download behaviour using:
+  #
+  #   meson setup --wrap-mode={nofallback,nodownload,forcefallback}
+  #
+  # If gtest is not available at all, unit tests will be disabled.
+  #
+  gtest_dep = dependency('gtest', main : true,
+                         required : false,
+                         fallback : ['gtest', 'gtest_main_dep'])
 endif
 
 # unit tests with specific requirements


### PR DESCRIPTION
A feature is added to Meson allowing the user to explicitly enable or disable building of unit tests:

 - `-Dunit_tests=enabled`
 - `-Dunit_tests=disabled`

If the user doesn't specified this preference, then it defaults to `auto`-mode, which means unit tests **will be built** for all build-types except for `release`.

Configurable options list:

![2021-02-24_08-11](https://user-images.githubusercontent.com/1557255/109031296-728e9780-7679-11eb-8e84-1a12f80dec35.png)

Example configuration when testing is enabled:

![2021-02-24_08-10](https://user-images.githubusercontent.com/1557255/109031325-78847880-7679-11eb-94f9-dac0f36b7b48.png)

Example configuration when testing is disabled:

![2021-02-24_08-08](https://user-images.githubusercontent.com/1557255/109031375-86d29480-7679-11eb-9893-7f8595efa439.png)

Thank you @granminigun for this suggestion!