### PR TITLE
Add a startup verbosity option to only show the splash screen

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -93,12 +93,13 @@ Il n'y a gÇnÇralement pas de gain de vitesse en augmentant cette valeur.
 .
 :CONFIG_STARTUP_VERBOSITY
 Contrìle la verbositÇ avant l'affichage du programme :
-       | êcran de dÇmarrage | êcran de bienvenue | Sorties Çcran de dÇmarrage
-high   |        oui         |        oui         |            oui
-medium |        non         |        oui         |            oui
-low    |        non         |        non         |            oui
-quiet  |        non         |        non         |            non
-auto   | 'low' si exec ou dir sont utilisÇs, sinon 'high'
+            | êcran de dÇmarrage | êcran de bienvenue | Sorties Çcran de dÇmarrage
+high        |        oui         |        oui         |            oui
+medium      |        non         |        oui         |            oui
+low         |        non         |        non         |            oui
+quiet       |        non         |        non         |            non
+splash_only |        oui         |        non         |            non
+auto        | 'low' si exec ou dir sont utilisÇs, sinon 'high'
 .
 :CONFIG_FRAMESKIP
 Nombre d'images que DOSBox saute avant d'en afficher une autre.

--- a/contrib/translations/pl/pl_PL.CP437.lng
+++ b/contrib/translations/pl/pl_PL.CP437.lng
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/contrib/translations/pl/pl_PL.lng
+++ b/contrib/translations/pl/pl_PL.lng
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/contrib/translations/ru/ru_RU.lng
+++ b/contrib/translations/ru/ru_RU.lng
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/contrib/translations/utf-8/fr/fr-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/fr/fr-0.77.0-alpha.txt
@@ -93,12 +93,13 @@ Il n'y a généralement pas de gain de vitesse en augmentant cette valeur.
 .
 :CONFIG_STARTUP_VERBOSITY
 Contrôle la verbosité avant l'affichage du programme :
-       | Écran de démarrage | Écran de bienvenue | Sorties écran de démarrage
-high   |        oui         |        oui         |            oui
-medium |        non         |        oui         |            oui
-low    |        non         |        non         |            oui
-quiet  |        non         |        non         |            non
-auto   | 'low' si exec ou dir sont utilisés, sinon 'high'
+            | Écran de démarrage | Écran de bienvenue | Sorties écran de démarrage
+high        |        oui         |        oui         |            oui
+medium      |        non         |        oui         |            oui
+low         |        non         |        non         |            oui
+quiet       |        non         |        non         |            non
+splash_only |        oui         |        non         |            non
+auto        | 'low' si exec ou dir sont utilisés, sinon 'high'
 .
 :CONFIG_FRAMESKIP
 Nombre d'images que DOSBox saute avant d'en afficher une autre.

--- a/contrib/translations/utf-8/pl/pl-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/pl/pl-0.77.0-alpha.txt
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/contrib/translations/utf-8/ru/ru-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/ru/ru-0.77.0-alpha.txt
@@ -93,12 +93,13 @@ There is generally no speed advantage when raising this value.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
-       | Show splash | Show welcome | Show early stdout
-high   |     yes     |     yes      |       yes
-medium |     no      |     yes      |       yes
-low    |     no      |     no       |       yes
-quiet  |     no      |     no       |       no
-auto   | 'low' if exec or dir is passed, otherwise 'high'
+            | Splash | Welcome | Early stdout
+high        |  yes   |   yes   |     yes
+medium      |  no    |   yes   |     yes
+low         |  no    |   no    |     yes
+quiet       |  no    |   no    |     no
+splash_only |  yes   |   no    |     no
+auto        | 'low' if exec or dir is passed, otherwise 'high'
 .
 :CONFIG_FRAMESKIP
 How many frames DOSBox skips before drawing one.

--- a/include/control.h
+++ b/include/control.h
@@ -31,11 +31,12 @@
 #include "setup.h"
 
 enum class Verbosity : int8_t {
-	//             Show Splash | Show Welcome | Show Early Stdout |
-	High = 3,   //     yes     |     yes      |       yes         |
-	Medium = 2, //     no      |     yes      |       yes         |
-	Low = 1,    //     no      |     no       |       yes         |
-	Quiet = 0   //     no      |     no       |       no          |
+	//                  Splash | Welcome | Early Stdout |
+	High = 4,       //   yes   |   yes   |    yes       |
+	Medium = 3,     //   no    |   yes   |    yes       |
+	Low = 2,        //   no    |   no    |    yes       |
+	SplashOnly = 1, //   yes   |   no    |    no        |
+	Quiet = 0       //   no    |   no    |    no        |
 };
 
 class Config {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -453,17 +453,21 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&TIMER_Init);//done
 	secprop->AddInitFunction(&CMOS_Init);//done
 
-	const char *verbosity_choices[] = {"high",   "medium", "low",
-	                                   "quiet", "auto",   0};
+	const char *verbosity_choices[] = {"high",  "medium",
+	                                   "low",   "splash_only",
+	                                   "quiet", "auto",
+	                                   0};
 	Pstring = secprop->Add_string("startup_verbosity", only_at_start, "high");
 	Pstring->Set_values(verbosity_choices);
-	Pstring->Set_help("Controls verbosity prior to displaying the program:\n"
-	"       | Show splash | Show welcome | Show early stdout\n"
-	"high   |     yes     |     yes      |       yes\n"
-	"medium |     no      |     yes      |       yes\n"
-	"low    |     no      |     no       |       yes\n"
-	"quiet  |     no      |     no       |       no\n"
-	"auto   | 'low' if exec or dir is passed, otherwise 'high'");
+	Pstring->Set_help(
+	        "Controls verbosity prior to displaying the program:\n"
+	        "Verbosity   | Splash | Welcome | Early stdout\n"
+	        "high        |  yes   |   yes   |    yes\n"
+	        "medium      |  no    |   yes   |    yes\n"
+	        "low         |  no    |   no    |    yes\n"
+	        "quiet       |  no    |   no    |    no\n"
+	        "splash_only |  yes   |   no    |    no\n"
+	        "auto        | 'low' if exec or dir is passed, otherwise 'high'");
 
 	secprop=control->AddSection_prop("render",&RENDER_Init,true);
 	Pint = secprop->Add_int("frameskip",Property::Changeable::Always,0);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2306,7 +2306,8 @@ static void GUI_StartUp(Section *sec)
 
 	const bool tiny_fullresolution = splash_image.width > sdl.desktop.full.width ||
 	                                 splash_image.height > sdl.desktop.full.height;
-	if (control->GetStartupVerbosity() == Verbosity::High &&
+	if ((control->GetStartupVerbosity() == Verbosity::High ||
+	     control->GetStartupVerbosity() == Verbosity::SplashOnly) &&
 	    !(sdl.desktop.fullscreen && tiny_fullresolution)) {
 		GFX_Start();
 		DisplaySplash(1000);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -142,7 +142,7 @@ bool Program::SuppressWriteOut(const char *format)
 	static bool encountered_executable = false;
 	if (encountered_executable)
 		return false;
-	if (control->GetStartupVerbosity() > Verbosity::Quiet)
+	if (control->GetStartupVerbosity() <= Verbosity::SplashOnly)
 		return false;
 	if (!control->cmdline->HasExecutableName())
 		return false;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1076,6 +1076,8 @@ Verbosity Config::GetStartupVerbosity() const
 		return Verbosity::Medium;
 	if (user_choice == "low")
 		return Verbosity::Low;
+	if (user_choice == "splash_only")
+		return Verbosity::SplashOnly;
 	if (user_choice == "quiet")
 		return Verbosity::Quiet;
 	// auto-mode


### PR DESCRIPTION
The new `startup_verbosity` value is `splash_only`, and as indicated only shows the splash screen.

The welcome banner and early DOSBox-internal  standard output is suppressed.

Thank you @gumispl for this suggestion!