### PR TITLE
Halt playback by stopping each channel's notes and controllers

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -30,6 +30,8 @@ class Program;
 
 extern uint8_t MIDI_evt_len[256];
 
+constexpr auto MIDI_SYSEX_SIZE = 8192;
+
 void MIDI_Init(Section *sec);
 bool MIDI_Available();
 void MIDI_ListAll(Program *output_handler);

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -104,7 +104,7 @@ struct DB_Midi {
 	uint8_t cmd_buf[8];
 	uint8_t rt_buf[8];
 	struct {
-		uint8_t buf[SYSEX_SIZE];
+		uint8_t buf[MIDI_SYSEX_SIZE];
 		size_t used;
 		uint32_t delay; // ms
 		uint32_t start; // ms
@@ -146,7 +146,8 @@ void MIDI_RawOutByte(uint8_t data)
 	/* Test for a active sysex tranfer */
 	if (midi.status==0xf0) {
 		if (!(data&0x80)) {
-			if (midi.sysex.used<(SYSEX_SIZE-1)) midi.sysex.buf[midi.sysex.used++] = data;
+			if (midi.sysex.used < (MIDI_SYSEX_SIZE - 1))
+				midi.sysex.buf[midi.sysex.used++] = data;
 			return;
 		} else {
 			midi.sysex.buf[midi.sysex.used++] = 0xf7;

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -152,8 +152,10 @@ public:
 
 	void Close() override
 	{
-		if (seq_handle)
+		if (seq_handle) {
+			HaltSequence();
 			snd_seq_close(seq_handle);
+		}
 	}
 
 	bool Open(const char *conf) override

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -194,6 +194,7 @@ public:
 	void Close() override
 	{
 		if (m_auGraph) {
+			HaltSequence();
 			AUGraphStop(m_auGraph);
 			DisposeAUGraph(m_auGraph);
 			m_auGraph = 0;

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -109,6 +109,9 @@ public:
 
 	void Close() override
 	{
+		if (m_port && m_client)
+			HaltSequence();
+
 		// Dispose the port
 		MIDIPortDispose(m_port);
 

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -140,7 +140,7 @@ public:
 	void PlaySysex(uint8_t *sysex, size_t len) override
 	{
 		// Acquire a MIDIPacketList
-		Byte packetBuf[SYSEX_SIZE*4];
+		Byte packetBuf[MIDI_SYSEX_SIZE * 4];
 		MIDIPacketList *packetList = (MIDIPacketList *)packetBuf;
 		m_pCurPacket = MIDIPacketListInit(packetList);
 		

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -45,6 +45,24 @@ public:
 
 	virtual void Close() {}
 
+	void HaltSequence()
+	{
+		uint8_t message[3] = {}; // see MIDI_evt_len for length lookup-table
+		constexpr uint8_t all_notes_off = 0x7b;
+		constexpr uint8_t all_controllers_off = 0x79;
+
+		// from the first to last channel
+		for (uint8_t channel = 0xb0; channel <= 0xbf; ++channel) {
+			message[0] = channel;
+
+			message[1] = all_notes_off;
+			PlayMsg(message);
+
+			message[1] = all_controllers_off;
+			PlayMsg(message);
+		}
+	}
+
 	virtual void PlayMsg(MAYBE_UNUSED const uint8_t *msg) {}
 
 	virtual void PlaySysex(MAYBE_UNUSED uint8_t *sysex, MAYBE_UNUSED size_t len) {}

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -26,8 +26,6 @@
 
 #include <cstdint>
 
-#define SYSEX_SIZE 8192
-
 class MidiHandler {
 public:
 	MidiHandler();

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -82,8 +82,8 @@ void MidiHandler_oss::PlayMsg(const uint8_t *msg)
 
 void MidiHandler_oss::PlaySysex(uint8_t *sysex, size_t len)
 {
-	uint8_t buf[SYSEX_SIZE * 4];
-	assert(len <= SYSEX_SIZE);
+	uint8_t buf[MIDI_SYSEX_SIZE * 4];
+	assert(len <= MIDI_SYSEX_SIZE);
 	size_t pos = 0;
 	for (size_t i = 0; i < len; i++) {
 		buf[pos++] = SEQ_MIDIPUTC;

--- a/src/midi/midi_oss.cpp
+++ b/src/midi/midi_oss.cpp
@@ -60,6 +60,9 @@ void MidiHandler_oss::Close()
 {
 	if (!is_open)
 		return;
+
+	HaltSequence();
+
 	close(device);
 	is_open = false;
 }

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -87,7 +87,10 @@ public:
 	void Close() override
 	{
 		if (!isOpen) return;
-		isOpen=false;
+
+		HaltSequence();
+
+		isOpen = false;
 		midiOutClose(m_out);
 		CloseHandle (m_event);
 	}


### PR DESCRIPTION
Fixes #913, which causes MIDI notes to continue playing when DOSBox is closed while MIDI is currently playing.

Thanks to @BPaden for reporting this and providing the MIDI message sequences to properly stop each channel's notes and controllers.

Ref: Mido - MIDI Objects for Python, https://github.com/mido/mido