### PR TITLE
Add a rote-implemented blocking read-write queue

### DIFF
--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -1,0 +1,55 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_RWQUEUE_H
+#define DOSBOX_RWQUEUE_H
+
+#include "dosbox.h"
+
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+
+template <typename T>
+class RWQueue {
+private:
+	std::deque<T> queue{}; // faster than: vector, queue, and list
+	std::mutex mutex = {};
+	std::condition_variable has_room = {};
+	std::condition_variable has_items = {};
+	const size_t capacity = 0;
+
+public:
+	RWQueue() = delete;
+	RWQueue(const RWQueue<T> &other) = delete;
+	RWQueue<T> &operator=(const RWQueue<T> &other) = delete;
+
+	RWQueue(size_t queue_capacity);
+
+	bool IsEmpty();
+	size_t Size();
+	size_t MaxCapacity() const;
+
+	void Enqueue(const T &item);
+	void Enqueue(T &&item); // item will be empty (moved-out) after call
+	T Dequeue();
+};
+
+#endif

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -4,6 +4,7 @@ libmisc_sources = [
   'fs_utils_win32.cpp',
   'messages.cpp',
   'programs.cpp',
+  'rwqueue.cpp',
   'setup.cpp',
   'soft_limiter.cpp',
   'support.cpp',

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -1,0 +1,99 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "rwqueue.h"
+
+#include <cassert>
+
+template <typename T>
+RWQueue<T>::RWQueue(size_t queue_capacity) : capacity(queue_capacity)
+{
+	assert(capacity > 0);
+}
+
+template <typename T>
+size_t RWQueue<T>::Size()
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	return queue.size();
+}
+
+template <typename T>
+size_t RWQueue<T>::MaxCapacity() const
+{
+	return capacity;
+}
+
+template <typename T>
+bool RWQueue<T>::IsEmpty()
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	return !queue.size();
+}
+
+template <typename T>
+void RWQueue<T>::Enqueue(const T &item)
+{
+	// wait until the queue has room to accept the item
+	std::unique_lock<std::mutex> lock(mutex);
+	while (queue.size() >= capacity)
+		has_room.wait(lock);
+
+	// add it, and notify the next waiting thread that we've got an item
+	queue.emplace(queue.end(), item);
+	lock.unlock();
+	has_items.notify_one();
+}
+
+template <typename T>
+void RWQueue<T>::Enqueue(T &&item)
+{
+	// wait until the queue has room to accept the item
+	std::unique_lock<std::mutex> lock(mutex);
+	while (queue.size() >= capacity)
+		has_room.wait(lock);
+
+	// add it, and notify the next waiting thread that we've got an item
+	queue.emplace(queue.end(), std::move(item));
+	lock.unlock();
+	has_items.notify_one();
+}
+
+template <typename T>
+T RWQueue<T>::Dequeue()
+{
+	// wait until the queue has an item that we can get
+	std::unique_lock<std::mutex> lock(mutex);
+	while (!queue.size())
+		has_items.wait(lock);
+
+	// get it, and notify the first waiting thread that the queue has room
+	T item = std::move(queue.front());
+	queue.pop_front();
+	lock.unlock();
+	has_room.notify_one();
+	return item;
+}
+
+// Explicit template instantiations
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#include <vector>
+template class RWQueue<int>; // Unit tests
+template class RWQueue<std::vector<int16_t>>; // MT-32 and FluidSynth

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -44,6 +44,7 @@ test('gtest fs_utils', fs_utils,
 #
 unit_tests = [
   {'name' : 'readerwritercircularbuffer', 'deps' : []},
+  {'name' : 'rwqueue',                    'deps' : [libmisc_dep]},
   {'name' : 'soft_limiter',               'deps' : [sdl2_dep, libmisc_dep]},
   {'name' : 'string_utils',               'deps' : []},
   {'name' : 'setup',                      'deps' : [sdl2_dep, libmisc_dep]},

--- a/tests/rwqueue.cpp
+++ b/tests/rwqueue.cpp
@@ -1,0 +1,240 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "rwqueue.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr auto iterations = 10000;
+
+TEST(RWQueue, TrivialSerial)
+{
+	RWQueue<int> q(65);
+	for (int iteration = 0; iteration != 128;
+	     ++iteration) { // check there's no problem with mismatch
+		            // between nominal and allocated capacity
+		EXPECT_EQ(q.MaxCapacity(), 65);
+		EXPECT_EQ(q.Size(), 0);
+		EXPECT_TRUE(q.IsEmpty());
+		q.Enqueue(0);
+		EXPECT_EQ(q.MaxCapacity(), 65);
+		EXPECT_EQ(q.Size(), 1);
+		EXPECT_FALSE(q.IsEmpty());
+		for (int i = 1; i != 65; ++i)
+			q.Enqueue(std::move(i));
+		EXPECT_EQ(q.Size(), 65);
+		EXPECT_FALSE(q.IsEmpty());
+
+		// Basic dequeue
+		int item;
+		item = q.Dequeue();
+		EXPECT_EQ(item, 0);
+		for (int i = 1; i != 65; ++i) {
+			item = q.Dequeue();
+			EXPECT_EQ(item, i);
+		}
+		EXPECT_EQ(item, 64);
+		EXPECT_TRUE(q.IsEmpty());
+	}
+}
+
+TEST(RWQueue, TrivialZeroCapacity)
+{
+	// Zero capacity
+	EXPECT_DEBUG_DEATH({ RWQueue<int> q(0); }, "");
+}
+
+void rw_consume_trivial(RWQueue<int> *q, const size_t *max_depth)
+{
+	int item;
+	for (int i = 0; i != iterations; ++i) {
+		EXPECT_TRUE(q->Size() <= *max_depth);
+		item = q->Dequeue();
+		EXPECT_EQ(item, i);
+	}
+}
+
+void rw_produce_copy_trivial(RWQueue<int> *q, const size_t *max_depth)
+{
+	for (int i = 0; i != iterations; ++i) {
+		q->Enqueue(i);
+		EXPECT_TRUE(q->Size() <= *max_depth);
+	}
+}
+
+void rw_produce_move_trivial(RWQueue<int> *q, const size_t *max_depth)
+{
+	for (int i = 0; i != iterations; ++i) {
+		q->Enqueue(std::move(i));
+		EXPECT_TRUE(q->Size() <= *max_depth);
+	}
+}
+
+TEST(RWQueue, TrivialCopyAsync)
+{
+	const size_t max_depth = 8;
+	RWQueue<int> q(max_depth);
+
+	std::thread writer(rw_produce_copy_trivial, &q, &max_depth);
+	std::thread reader(rw_consume_trivial, &q, &max_depth);
+
+	writer.join();
+	reader.join();
+
+	// Make sure we've consumed all produced items and the queue is empty
+	EXPECT_EQ(q.Size(), 0);
+}
+
+TEST(RWQueue, TrivialMoveAsync)
+{
+	const size_t max_depth = 8;
+	RWQueue<int> q(max_depth);
+
+	std::thread writer(rw_produce_move_trivial, &q, &max_depth);
+	std::thread reader(rw_consume_trivial, &q, &max_depth);
+
+	writer.join();
+	reader.join();
+
+	// Make sure we've consumed all produced items and the queue is empty
+	EXPECT_EQ(q.Size(), 0);
+}
+
+
+using container_t = std::vector<int16_t>;
+
+TEST(RWQueue,ContainerSerial)
+{
+	RWQueue<container_t> q(65);
+	for (int iteration = 0; iteration != 128;
+	     ++iteration) { // check there's no problem with mismatch
+		            // between nominal and allocated capacity
+		EXPECT_EQ(q.MaxCapacity(), 65);
+		EXPECT_EQ(q.Size(), 0);
+		EXPECT_TRUE(q.IsEmpty());
+
+		container_t v(iteration + 1); 
+		v[iteration] = iteration;
+		q.Enqueue(v);
+		EXPECT_EQ(v.size(), iteration + 1); // check copy
+
+		EXPECT_EQ(q.MaxCapacity(), 65);
+		EXPECT_EQ(q.Size(), 1);
+		EXPECT_FALSE(q.IsEmpty());
+		for (int i = 1; i != 65; ++i) {
+			container_t v(i + 1); 
+			v[i] = i;
+			q.Enqueue(std::move(v));
+			EXPECT_EQ(v.size(), 0); // check move
+		}
+		EXPECT_EQ(q.Size(), 65);
+		EXPECT_FALSE(q.IsEmpty());
+
+		// Basic dequeue
+		v = q.Dequeue();
+		EXPECT_EQ(v[0], 0);
+		EXPECT_EQ(v.size(), iteration + 1);
+
+		for (int i = 1; i != 65; ++i) {
+			v = q.Dequeue();
+			EXPECT_EQ(v[i], i);
+			EXPECT_EQ(v.size(), i + 1);
+		}
+		EXPECT_EQ(v[64], 64);
+		EXPECT_EQ(v.size(), 65);
+		EXPECT_TRUE(q.IsEmpty());
+	}
+}
+
+TEST(RWQueue,ContainerZeroCapacity)
+{
+	// Zero capacity
+	EXPECT_DEBUG_DEATH({ RWQueue<container_t> q(0); }, "");
+}
+
+void rw_consume_container(RWQueue<container_t> *q, const size_t *max_depth)
+{
+	container_t v;
+	for (int i = 0; i != iterations; ++i) {
+		EXPECT_TRUE(q->Size() <= *max_depth);
+		v = q->Dequeue();
+		EXPECT_EQ(v[i], i);
+		EXPECT_EQ(v.size(), i + 1);
+	}
+}
+
+void rw_produce_copy_container(RWQueue<container_t> *q, const size_t *max_depth)
+{
+	for (int i = 0; i != iterations; ++i) {
+		container_t v(i + 1);
+		v[i] = i;
+		q->Enqueue(v);
+		EXPECT_EQ(v.size(), i + 1); // check copy
+		EXPECT_TRUE(q->Size() <= *max_depth);
+	}
+}
+
+void rw_produce_move_container(RWQueue<container_t> *q, const size_t *max_depth)
+{
+	for (int i = 0; i != iterations; ++i) {
+		container_t v(i + 1);
+		v[i] = i;
+		q->Enqueue(std::move(v));
+		EXPECT_EQ(v.size(), 0); // check move
+		EXPECT_TRUE(q->Size() <= *max_depth);
+	}
+}
+
+TEST(RWQueue,ContainerCopyAsync)
+{
+	const size_t max_depth = 8;
+	RWQueue<container_t> q(max_depth);
+
+	std::thread writer(rw_produce_copy_container, &q, &max_depth);
+	std::thread reader(rw_consume_container, &q, &max_depth);
+
+	writer.join();
+	reader.join();
+
+	// Make sure we've consumed all produced items and the queue is empty
+	EXPECT_EQ(q.Size(), 0);
+}
+
+TEST(RWQueue,ContainerMoveAsync)
+{
+	const size_t max_depth = 8;
+	RWQueue<container_t> q(max_depth);
+
+	std::thread writer(rw_produce_move_container, &q, &max_depth);
+	std::thread reader(rw_consume_container, &q, &max_depth);
+
+	writer.join();
+	reader.join();
+
+	// Make sure we've consumed all produced items and the queue is empty
+	EXPECT_EQ(q.Size(), 0);
+}
+
+} // namespace

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -365,6 +365,7 @@
     <ClCompile Include="..\src\misc\fs_utils_win32.cpp" />
     <ClCompile Include="..\src\misc\messages.cpp" />
     <ClCompile Include="..\src\misc\programs.cpp" />
+    <ClCompile Include="..\src\misc\rwqueue.cpp" />
     <ClCompile Include="..\src\misc\setup.cpp" />
     <ClCompile Include="..\src\misc\soft_limiter.cpp" />
     <ClCompile Include="..\src\misc\support.cpp" />
@@ -412,6 +413,7 @@
     <ClInclude Include="..\include\programs.h" />
     <ClInclude Include="..\include\regs.h" />
     <ClInclude Include="..\include\render.h" />
+    <ClInclude Include="..\include\rwqueue.h" />
     <ClInclude Include="..\include\serialport.h" />
     <ClInclude Include="..\include\setup.h" />
     <ClInclude Include="..\include\shell.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -364,6 +364,9 @@
     <ClCompile Include="..\src\misc\programs.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\misc\rwqueue.cpp">
+      <Filter>src\misc</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\misc\setup.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>
@@ -499,6 +502,9 @@
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\include\render.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\rwqueue.h">
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\include\serialport.h">


### PR DESCRIPTION
This is a prerequisite to transition from the Moody RW queue to our own.

Once in, next step is to use this in FluidSynth and MT-32 along with functional and performance checks.



