### PR TITLE
Disambiguate the CONFIG_ROMDIR versus its ROM files

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.

--- a/contrib/translations/pl/pl_PL.CP437.lng
+++ b/contrib/translations/pl/pl_PL.CP437.lng
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.

--- a/contrib/translations/pl/pl_PL.lng
+++ b/contrib/translations/pl/pl_PL.lng
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.

--- a/contrib/translations/ru/ru_RU.lng
+++ b/contrib/translations/ru/ru_RU.lng
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.

--- a/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.

--- a/contrib/translations/utf-8/pl/pl-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/pl/pl-0.77.0-alpha.txt
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.

--- a/contrib/translations/utf-8/ru/ru-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/ru/ru-0.77.0-alpha.txt
@@ -215,10 +215,10 @@ it's recommended to use 'mt32', while newer games typically made
 use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')
 .
 :CONFIG_ROMDIR
-The directory holding the required MT-32 and/or CM-32L ROMs
-named as follows:
-  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).
-  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).
+The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.
+The files must be named in capitals, as follows:
+  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM
+  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM
 The directory can be absolute or relative, or leave it blank to
 use the 'mt32-roms' directory in your DOSBox configuration
 directory, followed by checking other common system locations.


### PR DESCRIPTION
@IlyaIndigo, can you comment on this new wording?

(Follow up from https://github.com/dosbox-staging/dosbox-staging/issues/884#issuecomment-786744327)