### PR TITLE
Improve the help description for the MT-32 'romdir' setting

### DIFF
--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -844,15 +844,15 @@ static Handler * make_opl_handler(const std::string &oplemu, OPL_Mode mode)
 }
 
 Module::Module(Section *configuration)
-	: Module_base(configuration),
-	  mixerObject(),
-	  mode(MODE_OPL2), // TODO this is set in Init and there's no good default
-	  reg{0}, // union
-	  ctrl{false, 0, 0xff, 0xff, false},
-	  mixerChan(nullptr),
-	  lastUsed(0),
-	  handler(nullptr),
-	  capture(nullptr)
+        : Module_base(configuration),
+          mixerObject(),
+          mode(MODE_OPL2), // TODO this is set in Init and there's no good default
+          reg{0},          // union
+          ctrl{false, 0, 0xff, 0xff, false},
+          mixerChan(nullptr),
+          lastUsed(0),
+          handler(nullptr),
+          capture(nullptr)
 {
 	Section_prop * section=static_cast<Section_prop *>(configuration);
 	Bitu base = section->Get_hex("sbbase");

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -77,10 +77,10 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");
 	str_prop->Set_help(
-	        "The directory holding the required MT-32 and/or CM-32L ROMs\n"
-	        "named as follows:\n"
-	        "  MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM files(s).\n"
-	        "  MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file(s).\n"
+	        "The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.\n"
+	        "The files must be named in capitals, as follows:\n"
+	        "  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM\n"
+	        "  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM\n"
 	        "The directory can be absolute or relative, or leave it blank to\n"
 	        "use the 'mt32-roms' directory in your DOSBox configuration\n"
 	        "directory, followed by checking other common system locations.");


### PR DESCRIPTION
Corresponding wording update for `romdir` in the MT-32 source.
Sorry for not catching this @dreamer!