### PR TITLE
Fix data-races in the Soft limiter and libmt32emu

### DIFF
--- a/include/soft_limiter.h
+++ b/include/soft_limiter.h
@@ -24,6 +24,7 @@
 
 #include "dosbox.h"
 
+#include <atomic>
 #include <vector>
 #include <string>
 
@@ -150,7 +151,7 @@ private:
 
 	// Mutable members
 	std::string channel_name = {};
-	AudioFrame prescale;
+	std::atomic<AudioFrame> prescale = {};
 	AudioFrame global_peaks = {0, 0};
 	AudioFrame tail_frame = {0, 0};
 	float range_multiplier = 1.0f;

--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,7 @@ static_libs_list = get_option('try_static_libs')
 msg = 'You can disable this dependency with: -D@0@=false'
 
 optional_dep  = dependency('', required : false)
+atomic_dep    = cxx.find_library('atomic', required : false)
 opus_dep      = dependency('opusfile',
                            static : ('opusfile' in static_libs_list))
 threads_dep   = dependency('threads')
@@ -295,7 +296,7 @@ subdir('tests')
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
 executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
-           dependencies : [threads_dep, sdl2_dep] + internal_deps,
+           dependencies : [atomic_dep, threads_dep, sdl2_dep] + internal_deps,
            include_directories : incdir,
            install : true)
 

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -50,7 +50,7 @@ public:
 
 private:
 	void MixerCallBack(uint16_t requested_frames);
-	void SetMixerLevel(const AudioFrame &prescale_level) noexcept;
+	void SetMixerLevel(const AudioFrame &levels) noexcept;
 	uint16_t GetRemainingFrames();
 	void Render();
 
@@ -69,7 +69,6 @@ private:
 	RWQueue<std::vector<int16_t>> backstock{num_buffers};
 
 	std::thread renderer = {};
-	AudioFrame prescale_level = {1.0f, 1.0f};
 	SoftLimiter soft_limiter;
 
 	uint16_t last_played_frame = 0; // relative frame-offset in the play buffer

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -28,6 +28,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -72,8 +73,9 @@ private:
 	RWQueue<std::vector<int16_t>> playable{num_buffers};
 	RWQueue<std::vector<int16_t>> backstock{num_buffers};
 
-	service_t service{};
-	std::thread renderer{};
+	std::mutex service_mutex = {};
+	service_t service = {};
+	std::thread renderer = {};
 	SoftLimiter soft_limiter;
 
 	// The following two members let us determine the total number of played

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -74,7 +74,6 @@ private:
 
 	service_t service{};
 	std::thread renderer{};
-	AudioFrame limiter_ratio = {1.0f, 1.0f};
 	SoftLimiter soft_limiter;
 
 	// The following two members let us determine the total number of played

--- a/src/misc/soft_limiter.cpp
+++ b/src/misc/soft_limiter.cpp
@@ -27,6 +27,8 @@
 
 #include "support.h"
 
+constexpr static auto relaxed = std::memory_order_relaxed;
+
 constexpr static float bounds = static_cast<float>(INT16_MAX - 1);
 
 SoftLimiter::SoftLimiter(const std::string &name, const uint16_t max_frames)
@@ -72,13 +74,14 @@ void SoftLimiter::Process(const std::vector<float> &in,
 	// Given the local peaks found in each side channel, scale or copy the
 	// input array into the output array
 	constexpr int8_t left = 0;
-	ScaleOrCopy<left>(in, samples, prescale.left, precross_peak_pos_left,
-	                  zero_cross_left, global_peaks.left, tail_frame.left, out);
+	ScaleOrCopy<left>(in, samples, prescale.load(relaxed).left,
+	                  precross_peak_pos_left, zero_cross_left,
+	                  global_peaks.left, tail_frame.left, out);
 
 	constexpr int8_t right = 1;
-	ScaleOrCopy<right>(in, samples, prescale.right, precross_peak_pos_right,
-	                   zero_cross_right, global_peaks.right,
-	                   tail_frame.right, out);
+	ScaleOrCopy<right>(in, samples, prescale.load(relaxed).right,
+	                   precross_peak_pos_right, zero_cross_right,
+	                   global_peaks.right, tail_frame.right, out);
 
 	SaveTailFrame(frames, out);
 	Release();
@@ -132,11 +135,13 @@ void SoftLimiter::FindPeaksAndZeroCrosses(const std::vector<float> &in,
 	AudioFrame local_peaks = global_peaks;
 
 	while (pos != pos_end) {
-		FindPeakAndCross(in.end(), pos++, prev_pos_left, prescale.left,
-		                 local_peaks.left, precross_peak_pos_left,
-		                 zero_cross_left, global_peaks.left);
+		FindPeakAndCross(in.end(), pos++, prev_pos_left,
+		                 prescale.load(relaxed).left, local_peaks.left,
+		                 precross_peak_pos_left, zero_cross_left,
+		                 global_peaks.left);
 
-		FindPeakAndCross(in.end(), pos++, prev_pos_right, prescale.right,
+		FindPeakAndCross(in.end(), pos++, prev_pos_right,
+		                 prescale.load(relaxed).right,
 		                 local_peaks.right, precross_peak_pos_right,
 		                 zero_cross_right, global_peaks.right);
 	}
@@ -271,7 +276,8 @@ void SoftLimiter::PrintStats() const
 	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
 
 	// Inform when the stream fell short of using the full dynamic-range
-	const auto scale = std::max(prescale.left, prescale.right) / range_multiplier;
+	const auto scale = std::max(prescale.load().left, prescale.load().right) /
+	                   range_multiplier;
 	constexpr auto well_below_3db = 0.6f;
 	if (peak_ratio < well_below_3db) {
 		const auto suggested_mix_val = 100 * scale / peak_ratio;

--- a/src/misc/soft_limiter.cpp
+++ b/src/misc/soft_limiter.cpp
@@ -29,13 +29,22 @@
 
 constexpr static float bounds = static_cast<float>(INT16_MAX - 1);
 
-SoftLimiter::SoftLimiter(const std::string &name,
-                         const AudioFrame &scale,
-                         const uint16_t max_frames)
+SoftLimiter::SoftLimiter(const std::string &name, const uint16_t max_frames)
         : channel_name(name),
-          prescale(scale),
           max_samples(max_frames * 2)
-{}
+{
+	UpdateLevels({1, 1}, 1); // default to unity (ie: no) scaling
+	limited_tally = 0;
+	non_limited_tally = 0;
+}
+
+void SoftLimiter::UpdateLevels(const AudioFrame &desired_levels,
+                               const float desired_multiplier)
+{
+	range_multiplier = desired_multiplier;
+	prescale = {desired_levels.left * desired_multiplier,
+	            desired_levels.right * desired_multiplier};
+}
 
 //  Limit the input array and returned as integer array
 void SoftLimiter::Process(const std::vector<float> &in,
@@ -262,7 +271,7 @@ void SoftLimiter::PrintStats() const
 	        channel_name.c_str(), 100 * static_cast<double>(peak_ratio));
 
 	// Inform when the stream fell short of using the full dynamic-range
-	const auto scale = std::max(prescale.left, prescale.right);
+	const auto scale = std::max(prescale.left, prescale.right) / range_multiplier;
 	constexpr auto well_below_3db = 0.6f;
 	if (peak_ratio < well_below_3db) {
 		const auto suggested_mix_val = 100 * scale / peak_ratio;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -44,7 +44,7 @@ test('gtest fs_utils', fs_utils,
 #
 unit_tests = [
   {'name' : 'rwqueue',      'deps' : [libmisc_dep]},
-  {'name' : 'soft_limiter', 'deps' : [sdl2_dep, libmisc_dep]},
+  {'name' : 'soft_limiter', 'deps' : [atomic_dep, sdl2_dep, libmisc_dep]},
   {'name' : 'string_utils', 'deps' : []},
   {'name' : 'setup',        'deps' : [sdl2_dep, libmisc_dep]},
   {'name' : 'support',      'deps' : [sdl2_dep, libmisc_dep]},

--- a/tests/soft_limiter.cpp
+++ b/tests/soft_limiter.cpp
@@ -27,8 +27,7 @@ namespace {
 TEST(SoftLimiter, InboundsProcessAllFrames)
 {
 	constexpr int frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 
 	std::vector<int16_t> out(frames * 2);
@@ -40,8 +39,7 @@ TEST(SoftLimiter, InboundsProcessAllFrames)
 TEST(SoftLimiter, InboundsProcessPartialFrames)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 
 	std::vector<int16_t> out(frames * 2);
@@ -54,8 +52,7 @@ TEST(SoftLimiter, InboundsProcessPartialFrames)
 TEST(SoftLimiter, InboundsProcessTooManyFrames)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 	std::vector<int16_t> out(frames * 2);
 	EXPECT_DEBUG_DEATH({ limiter.Process(in, frames + 1, out); }, "");
@@ -64,8 +61,7 @@ TEST(SoftLimiter, InboundsProcessTooManyFrames)
 TEST(SoftLimiter, OutOfBoundsLeftChannel)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-8.1f,    32000.0f, 65535.0f,
 	                            32000.0f, 4.1f,     32000.0f};
 
@@ -78,8 +74,7 @@ TEST(SoftLimiter, OutOfBoundsLeftChannel)
 TEST(SoftLimiter, OutOfBoundsRightChannel)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{32000.0f, -3.1f,    32000.0f,
 	                            98304.1f, 32000.0f, 6.1f};
 
@@ -92,8 +87,7 @@ TEST(SoftLimiter, OutOfBoundsRightChannel)
 TEST(SoftLimiter, OutboundsBothChannelsPositive)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-8.1f,    -3.1f, 65535.0f,
 	                            98304.1f, 4.1f,  6.1f};
 
@@ -106,8 +100,7 @@ TEST(SoftLimiter, OutboundsBothChannelsPositive)
 TEST(SoftLimiter, OutboundsBothChannelsNegative)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-8.1f,     -3.1f, -65535.0f,
 	                            -98304.1f, 4.1f,  6.1f};
 
@@ -120,8 +113,7 @@ TEST(SoftLimiter, OutboundsBothChannelsNegative)
 TEST(SoftLimiter, OutboundsBothChannelsMixed)
 {
 	const auto frames = 3;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{40000.0f,  -40000.0f, 65534.0f,
 	                            -98301.0f, 40000.0f,  -40000.0f};
 
@@ -135,8 +127,7 @@ TEST(SoftLimiter, OutboundsBothChannelsMixed)
 TEST(SoftLimiter, OutboundsBigOneReleaseStep)
 {
 	const auto frames = 1;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	std::vector<float> in{-60000.0f, 80000.0f};
 	std::vector<int16_t> out(frames * 2);
 	limiter.Process(in, 1, out);
@@ -152,8 +143,7 @@ TEST(SoftLimiter, OutboundsBigOneReleaseStep)
 TEST(SoftLimiter, OutboundsBig600ReleaseSteps)
 {
 	const auto frames = 1;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	std::vector<float> in{-60000.0f, 80000.0f};
 	std::vector<int16_t> out(frames * 2);
 
@@ -169,8 +159,7 @@ TEST(SoftLimiter, OutboundsBig600ReleaseSteps)
 TEST(SoftLimiter, OutboundsSmallTwoReleaseSteps)
 {
 	const auto frames = 1;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	std::vector<float> in{-32800.0f, 32800.0f};
 	std::vector<int16_t> out(frames * 2);
 	for (int i = 0; i < 2; ++i) {
@@ -185,8 +174,7 @@ TEST(SoftLimiter, OutboundsSmallTwoReleaseSteps)
 TEST(SoftLimiter, OutboundsSmallTenReleaseSteps)
 {
 	const auto frames = 1;
-	const AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	std::vector<float> in{-32800.0f, 32800.0f};
 	std::vector<int16_t> out(frames * 2);
 
@@ -202,8 +190,7 @@ TEST(SoftLimiter, OutboundsSmallTenReleaseSteps)
 TEST(SoftLimiter, OutboundsPolyJoinPositive)
 {
 	const auto frames = 3;
-	AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 
 	const std::vector<float> first_chunk{18000, 18000, 20000,
 	                                     20000, 22000, 22000};
@@ -225,8 +212,7 @@ TEST(SoftLimiter, OutboundsPolyJoinPositive)
 TEST(SoftLimiter, OutboundsPolyJoinNegative)
 {
 	const auto frames = 3;
-	AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 
 	const std::vector<float> first_chunk{-18000, -18000, -20000,
 	                                     -20000, -22000, -22000};
@@ -248,8 +234,7 @@ TEST(SoftLimiter, OutboundsPolyJoinNegative)
 TEST(SoftLimiter, OutboundsJoinWithZeroCross)
 {
 	const auto frames = 6;
-	AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 
 	const std::vector<float> first_chunk{-5000, 1000, -3000, 1000,
 	                                     -1000, 1000, 0,     1000,
@@ -278,11 +263,10 @@ TEST(SoftLimiter, OutboundsJoinWithZeroCross)
 	EXPECT_EQ(out, expected_third);
 }
 
-TEST(SoftLimiter, PrescaleAttenuate)
+TEST(SoftLimiter, ScaleAttenuate)
 {
 	const auto frames = 1;
-	AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-30000.1f, 30000.0f};
 	std::vector<int16_t> out(frames * 2);
 	limiter.Process(in, frames, out);
@@ -291,18 +275,18 @@ TEST(SoftLimiter, PrescaleAttenuate)
 
 	// The limiter holds a reference to the prescaling struct so it can
 	// be adjusted on-the-fly via callback. We simulate this callback here.
-	prescale.left = 0.5f;
-	prescale.right = 0.1f;
+	AudioFrame levels = {0.5f, 0.1f};
+	const float range_multiplier = 1.0f;
+	limiter.UpdateLevels(levels, range_multiplier);
 	limiter.Process(in, frames, out);
 	const std::vector<int16_t> expected_scaled{-15000, 3000};
 	EXPECT_EQ(out, expected_scaled);
 }
 
-TEST(SoftLimiter, PrescaleAmplify)
+TEST(SoftLimiter, ScaleAmplify)
 {
 	const auto frames = 1;
-	AudioFrame prescale{1, 1};
-	SoftLimiter limiter("test-channel", prescale, frames);
+	SoftLimiter limiter("test-channel", frames);
 	const std::vector<float> in{-10000.1f, 10000.0f};
 	std::vector<int16_t> out(frames * 2);
 	limiter.Process(in, frames, out);
@@ -311,11 +295,28 @@ TEST(SoftLimiter, PrescaleAmplify)
 
 	// The limiter holds a reference to the prescaling struct so it can
 	// be adjusted on-the-fly via callback. We simulate this callback here.
-	prescale.left = 1.5f;
-	prescale.right = 1.1f;
+	AudioFrame levels = {1.5f, 1.1f};
+	const float range_multiplier = 1.0f;
+	limiter.UpdateLevels(levels, range_multiplier);
 	limiter.Process(in, frames, out);
 	const std::vector<int16_t> expected_scaled{-15000, 11000};
 	EXPECT_EQ(out, expected_scaled);
+}
+
+TEST(SoftLimiter, RangeMultiply)
+{
+	const auto frames = 1;
+	SoftLimiter limiter("test-channel", frames);
+
+	AudioFrame levels = {1, 1};
+	const float range_multiplier = 2;
+	limiter.UpdateLevels(levels, range_multiplier);
+
+	const std::vector<float> in{-10000.1f, 10000.0f};
+	std::vector<int16_t> out(frames * 2);
+	limiter.Process(in, frames, out);
+	const std::vector<int16_t> expected{-20000, 20000};
+	EXPECT_EQ(out, expected);
 }
 
 } // namespace


### PR DESCRIPTION
Fix threaded data-races in MT-32 reported in https://github.com/dosbox-staging/dosbox-staging/issues/921

The internals of mt32emu are not thread-safe, as flagged by the thread sanitizer when sysex and rendering calls are performed simultaneously. This is the case for both the current implementation and the original threaded-patch implementation (https://github.com/dosbox-staging/dosbox-staging/blob/4ea652555b2dafcc3d94762a20b763139209b736/src/midi/midi_mt32.cpp)

This commit makes two relatively small changes:
 - moves the mixer's channel level in the soft limiter to an internal atomic type (to avoid the need for heavier locking), and moves its control to a separate function. 
 - adds a guard-lock around the mt32emu service accesses.

I ran the same thread sanitizer tests using FluidSynth and GUS playback, and both are running clean. 

Reviewable commit by commit.

Before and after:
 - [master-tsan-mt32.txt](https://github.com/dosbox-staging/dosbox-staging/files/6055163/master-tsan-mt32.txt)
 - [pr-tsan-mt32.txt](https://github.com/dosbox-staging/dosbox-staging/files/6055164/pr-tsan-mt32.txt)

After, the only data-races flagged come from PulseAudio, dbus, and the iris video driver (see attached PR text file), which occur for all audio types:

``` text
SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x58dde) in recvmsg
SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x58dde) in recvmsg
SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) (/lib/x86_64-linux-gnu/libtsan.so.0+0x5271c) in pthread_mutex_lock
SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x3418a) in __interceptor_pthread_barrier_destroy
```