### PR TITLE
Check if exit was requested in CHOICE's Read() loop

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1563,9 +1563,11 @@ void DOS_Shell::CMD_CHOICE(char * args){
 
 	Bit16u n=1;
 	do {
-		DOS_ReadFile (STDIN,&c,&n);
-	} while (!c || !(ptr = strchr(rem,(optS?c:toupper(c)))));
-	c = optS?c:(Bit8u)toupper(c);
+		DOS_ReadFile(STDIN, &c, &n);
+		if (exit_requested)
+			break;
+	} while (!c || !(ptr = strchr(rem, (optS ? c : toupper(c)))));
+	c = optS ? c : (Bit8u)toupper(c);
 	DOS_WriteFile(STDOUT, &c, &n);
 	WriteOut_NoParsing("\n");
 	dos.return_code = (Bit8u)(ptr-rem+1);


### PR DESCRIPTION
Unlike other DOS file `Read()` or `Write()` calls that run until they succeed or fail, the `CHOICE` command depends on user-input.  Without input, CHOICE will `Read()` in an endless loop on the `CON` file. _(Note that this is DOSBox's internal implementation of CHOICE, not a separate program, which is not affected by this)_.

`CHOICE` was therefore able to stay in its while loop and never return back to the top-level DOS normal loop where we check the `exit_requested` state (ie: Ctrl + F9).

Reproduction steps:
 1. Run `CHOICE` at the DOS prompt
 2. Ignore the `[Y/N]` prompt (this is the endless `Read()` loop)
 3. Press Ctrl + F9 to try to quit