### PR TITLE
WIP Autoexec tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -287,21 +287,22 @@ configure_file(input : 'src/config.h.in', output : 'config.h',
                configuration : conf_data)
 
 
+# dosbox executable
+#
+version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
+dosbox_bin = executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
+                        dependencies : [threads_dep, sdl2_dep] + internal_deps,
+                        include_directories : incdir,
+                        install : true)
+
+
 # tests
 #
 # Some tests use relative paths; in meson 0.56.0 this can be replaced
 # with meson.project_source_root().
+#
 project_source_root = meson.current_source_dir()
 subdir('tests')
-
-
-# dosbox executable
-#
-version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
-executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
-           dependencies : [threads_dep, sdl2_dep] + internal_deps,
-           include_directories : incdir,
-           install : true)
 
 
 # additional files for installation

--- a/tests/autoexec_test.py
+++ b/tests/autoexec_test.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021-2021  The DOSBox Staging Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+""" backend for performing autoexec-based dosbox tests.
+
+Collection of functions that can be used for performing automatic autoexec
+testing of DOSBox Staging emulator.
+
+"""
+
+from itertools import zip_longest
+from typing import Iterator
+import os
+import pathlib
+import subprocess
+import sys
+
+DOSBOX_TEST_ENV = {
+    'XDG_CONFIG_HOME': 'xdg-config-home-test',
+    'SDL_VIDEODRIVER': 'dummy',
+    'DOSBOX_DOSBOX_STARTUP_VERBOSITY': 'low',
+    'DOSBOX_MIXER_NOSOUND': 'true',
+    'DOSBOX_MIDI_MIDIDEVICE': 'none',
+}
+
+def get_test_name() -> str:
+    r""" get_test_name() -> str
+
+    Obtain test name based on current test script filename.
+
+    Example: t1234_test_name.py -> t1234_test_name
+
+    """
+    exe_path = pathlib.Path(sys.argv[0])
+    return exe_path.stem
+
+
+def get_test_num() -> str:
+    r""" get_test_num() -> str
+
+    Obtain test number id based on current test script filename.
+
+    Example: t1234_test_name.py -> t1234
+
+    """
+    exe_path = pathlib.Path(sys.argv[0])
+    return exe_path.stem.split('_')[0]
+
+
+def _sanitize_file_lines(dos_output_file: str) -> Iterator[str]:
+    for line in open(dos_output_file, 'r').readlines():
+        yield line[:-1]  # strip newline char
+    # end with empty line to make it easier to compare with
+    # multiline string split by newline char
+    yield ''
+
+
+def run_autoexec_test(conf_txt: str, expected_output: str) -> None:
+    r""" run_autoexec_test(conf_txt: str, expected_output: str)
+
+    Start dosbox binary (passed through the first script argument) using test
+    environment (see DOSBOX_TEST_ENV) and generated .conf file.
+
+    conf_txt parameter should contain text to be injected into the .conf file
+    (notably, including an autoexec section ending with 'exit' command).
+
+    You can use {out} in conf_txt as placeholder for file used to store
+    output redirected from DOS commands/programs.  After dosbox exits,
+    the text redirected to {out} is compared line-by-line to text passed
+    through expected_output parameter.
+
+    This function always ends with an exit, with one of following codes:
+
+    0 - test passed
+    1 - dosbox process exited with non-zero return code
+    2 - expected output is different than text stored in {out} file
+
+    """
+    dosbox_bin = sys.argv[1]
+    test_name = get_test_name()
+    test_conf = test_name + '.conf'
+    out_file = get_test_num() + '.txt'
+
+    print('---')
+    print('running test', test_name)
+    print('in', os.getcwd())
+
+    with open(test_conf, 'w') as conf_file:
+        conf_file.write(conf_txt.format(out = out_file))
+
+    result = subprocess.run([dosbox_bin, '-conf', test_conf],
+                            env = DOSBOX_TEST_ENV,
+                            check = True)
+    print('---')
+    print(f'dosbox stopped with error code: {result.returncode}')
+    if result.returncode != 0:
+        sys.exit(1) # test failed - unexpected error code
+
+    out_file_name = out_file.upper()
+    out_lines = _sanitize_file_lines(out_file_name)
+    exp_lines = expected_output.split('\n')
+    line_no = 0
+    for out_line, exp_line in zip_longest(out_lines, exp_lines, fillvalue='<missing line>'):
+        line_no += 1
+        if exp_line != out_line:
+            print(f'unexpected DOS shell output in line {out_file_name}:{line_no}')
+            print(f'expecting: "{exp_line}"')
+            print(f'found:     "{out_line}"')
+            sys.exit(2) # test failed - unexpected DOS shell output
+
+    sys.exit(0)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,14 +30,14 @@ endif
 example = executable('example', 'example.cpp',
                      dependencies : [gtest_dep, sdl2_dep, libmisc_dep],
                      include_directories : incdir)
-test('gtest example', example, 
-     should_fail : true)
+test('gtest example', example,
+     suite : 'ut', should_fail : true)
 
 fs_utils = executable('fs_utils', 'fs_utils.cpp',
                       dependencies : [gtest_dep, libmisc_dep],
                       include_directories : incdir)
 test('gtest fs_utils', fs_utils,
-     workdir : project_source_root, is_parallel : false)
+     suite : 'ut', workdir : project_source_root, is_parallel : false)
 
 
 # other unit tests
@@ -56,5 +56,22 @@ foreach ut : unit_tests
   exe = executable(name, [name + '.cpp', 'stubs.cpp'],
                    dependencies : [gtest_dep] + ut.get('deps'),
                    include_directories : incdir)
-  test('gtest ' + name, exe)
+  test('gtest ' + name, exe, suite : 'ut')
+endforeach
+
+
+# autoexec tests
+#
+autoexec_tests = [
+  {'name' : 't1000_cmd_echo'},
+  {'name' : 't1001_cmd_date'},
+]
+
+foreach at : autoexec_tests
+  name = at.get('name')
+  exe = find_program(name + '.py')
+  test(name, exe, args : [dosbox_bin.full_path()],
+       suite : 'at',
+       depends : dosbox_bin,
+       protocol : 'exitcode')
 endforeach

--- a/tests/t1000_cmd_echo.py
+++ b/tests/t1000_cmd_echo.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021-2021  The DOSBox Staging Team
+
+"""
+Test echo command.
+
+MS-DOS echo behaves very differently and unfriendly compared to UNIX echo,
+but we need to support these for backwards-compatibility.
+
+"""
+
+import autoexec_test as at
+
+CMD_ECHO_TESTS = '''
+[autoexec]
+mount C .
+C:
+
+# Output text, no spaces around.
+#
+echo foo > {out}
+
+# (MS-DOS behaviour) DOS echo does not support quoting
+#
+echo 'bar' >> {out}
+echo "bar" >> {out}
+echo ''    >> {out}
+echo ""    >> {out}
+
+# Output text, surprisingly with spaces.
+# TODO check - MS-DOS was really this stupid?
+#
+echo    baz >> {out}
+
+# (MS-DOS behaviour) Test if echo off/on changes echo status.
+#
+echo OFF >> {out}
+echo     >> {out}
+echo ON  >> {out}
+echo     >> {out}
+echo off >> {out}
+echo     >> {out}
+echo on  >> {out}
+echo     >> {out}
+
+# (MS-DOS behaviour) Echo the text "ON" or "OFF" instead of turning the
+# command printing on or off (as in previous test).
+# This can be done using . or / instead of space.
+#
+echo.ON  >> {out}
+echo.OFF >> {out}
+echo/ON  >> {out}
+echo/OFF >> {out}
+echo     >> {out}
+
+# (MS-DOS behaviour) ... but slash after space is part of the message.
+#
+echo .    >> {out}
+echo /    >> {out}
+echo .msg >> {out}
+echo /msg >> {out}
+
+# (MS-DOS behaviour) dot and slash can be used to echo an empty line,
+#
+echo. >> {out}
+echo/ >> {out}
+
+echo bye! >> {out}
+
+exit
+'''
+
+EXPECTED_OUT = '''foo
+'bar'
+"bar"
+''
+""
+   baz
+ECHO is off.
+ECHO is on.
+ECHO is off.
+ECHO is on.
+ON
+OFF
+ON
+OFF
+ECHO is on.
+.
+/
+.msg
+/msg
+
+
+bye!
+'''
+
+at.run_autoexec_test(CMD_ECHO_TESTS, EXPECTED_OUT)

--- a/tests/t1001_cmd_date.py
+++ b/tests/t1001_cmd_date.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021-2021  The DOSBox Staging Team
+
+"""
+Test if setting date works and if leap year calculation is correct.
+"""
+
+import autoexec_test as at
+
+CMD_DATE_TESTS = '''
+[autoexec]
+mount C .
+C:
+
+echo.> {out}
+echo testing date output >> {out}
+date 12-31-1999
+date >> {out}
+
+echo.>> {out}
+echo testing err on non-leap year >> {out}
+date 02-29-2001
+date >> {out}
+
+echo.>> {out}
+echo testing success on leap year >> {out}
+date 02-29-2004
+date >> {out}
+
+echo.>> {out}
+echo testing success on leap year 2000 >> {out}
+date 02-29-2000
+date >> {out}
+
+rem echo.>> {out}
+rem echo testing err on leap year 2100 >> {out}
+rem date 02-29-2100
+rem date >> {out}
+
+echo.>> {out}
+echo testing success on year 2038 problem >> {out}
+date 01-20-2038
+date >> {out}
+
+exit
+'''
+
+EXPECTED_OUT = '''
+testing date output
+Current date: Fri 12/31/1999
+Type 'date MM-DD-YYYY' to change.
+
+testing err on non-leap year
+Current date: Fri 12/31/1999
+Type 'date MM-DD-YYYY' to change.
+
+testing success on leap year
+Current date: Sun 02/29/2004
+Type 'date MM-DD-YYYY' to change.
+
+testing success on leap year 2000
+Current date: Tue 02/29/2000
+Type 'date MM-DD-YYYY' to change.
+
+testing success on year 2038 problem
+Current date: Wed 01/20/2038
+Type 'date MM-DD-YYYY' to change.
+'''
+
+at.run_autoexec_test(CMD_DATE_TESTS, EXPECTED_OUT)


### PR DESCRIPTION
@kcgen This is a prototype for new category of tests. I had no better idea for naming them than "autoexec tests" (ATs) (to differentiate from unit tests / UTs). Maybe you'll get a better naming idea ;)

They are somewhat similar to tests we store in other repo, but here we'll be able to run them on CI (!) and easily generate coverage report via Meson.

The goal is to have easy way to test interaction with shell to quickly write wide-reaching test suite. These tests cannot be as precise as UTs, but are much easier and quicker to write.

While writing this I had few other ideas about improvements for this type of testing, but I want to start with something rather simple (I hope this is simple). What do you think? Maybe try to write a new test file (`t1002_cmd_type.py` ?) to see if this is easy enough.