### PR TITLE
Always support Opus CD-DA tracks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,7 +71,7 @@ jobs:
 
           - name: GCC, minimum build
             os: ubuntu-20.04
-            build_flags: --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_sdl2_net=false -Duse_opengl=false -Duse_fluidsynth=false -Duse_mt32emu=false -Duse_opusfile=false -Duse_png=false -Duse_alsa=false
+            build_flags: --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_sdl2_net=false -Duse_opengl=false -Duse_fluidsynth=false -Duse_mt32emu=false -Duse_png=false -Duse_alsa=false
             min_dependencies: true
             max_warnings: -1
 
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies (minimum set)
         if:   matrix.conf.min_dependencies
         run: |
-          sudo apt-get install -y build-essential ccache meson libsdl2-dev
+          sudo apt-get install -y build-essential ccache meson libsdl2-dev libopusfile-dev
 
       - name: Install dependencies
         if:   matrix.conf.min_dependencies != true

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,6 +2,7 @@
 
 - C/C++ compiler with support for C++14
 - SDL >= 2.0.2
+- Opusfile
 - Meson >= 0.49.0 or Visual Studio Community Edition
 - OS that is mostly POSIX-compliant or up-to-date Windows system
 

--- a/meson.build
+++ b/meson.build
@@ -147,13 +147,14 @@ static_libs_list = get_option('try_static_libs')
 msg = 'You can disable this dependency with: -D@0@=false'
 
 optional_dep  = dependency('', required : false)
+opus_dep      = dependency('opusfile',
+                           static : ('opusfile' in static_libs_list))
 threads_dep   = dependency('threads')
 sdl2_dep      = dependency('sdl2', version : '>= 2.0.2',
                            static : ('sdl2' in static_libs_list))
 sdl2_net_dep  = optional_dep
 opengl_dep    = optional_dep
 fluid_dep     = optional_dep
-opus_dep      = optional_dep
 mt32emu_dep   = optional_dep
 png_dep       = optional_dep
 curses_dep    = optional_dep # necessary for debugger builds
@@ -184,11 +185,6 @@ if get_option('use_mt32emu')
   mt32emu_dep = dependency('mt32emu', version : '>= 2.4.2',
                            fallback : ['mt32emu', 'mt32emu_dep'],
                            not_found_message : msg.format('use_mt32emu'))
-endif
-
-if get_option('use_opusfile')
-  opus_dep = dependency('opusfile', static : ('opusfile' in static_libs_list),
-                        not_found_message : msg.format('use_opusfile'))
 endif
 
 if get_option('use_png')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,11 +18,6 @@ option('use_mt32emu',
        value : true,
        description : 'Enable built-in MT-32 emulation support')
 
-option('use_opusfile',
-       type : 'boolean',
-       value : true,
-       description : 'Enable Opus codec for CD-DA emulation')
-
 option('use_png',
        type : 'boolean',
        value : true,

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -116,9 +116,6 @@
 // Define to 1 to enable ALSA MIDI support
 #mesondefine C_ALSA
 
-// Define to 1 to use Opus-encoded CD-audio tracks, requires opusfile
-#mesondefine USE_OPUS
-
 /* Compiler features and extensions
  *
  * These are defines for compiler features we can't reliably verify during

--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -55,9 +55,7 @@ typedef struct
 /* Supported decoder drivers... */
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_FLAC;
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MP3;
-#ifdef USE_OPUS
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_OPUS;
-#endif
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_VORBIS;
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_WAV;
 
@@ -65,9 +63,7 @@ static decoder_element decoders[] =
 {
     { 0, &__Sound_DecoderFunctions_FLAC },
     { 0, &__Sound_DecoderFunctions_MP3 },
-#ifdef USE_OPUS
     { 0, &__Sound_DecoderFunctions_OPUS },
-#endif
     { 0, &__Sound_DecoderFunctions_VORBIS },
     { 0, &__Sound_DecoderFunctions_WAV },
     { 0, NULL }

--- a/src/libs/decoders/meson.build
+++ b/src/libs/decoders/meson.build
@@ -2,15 +2,11 @@ libdecoders_sources = files([
   'flac.c',
   'mp3.cpp',
   'mp3_seek_table.cpp',
+  'opus.cpp',
   'SDL_sound.c',
   'vorbis.c',
   'wav.c',
 ])
-
-if get_option('use_opusfile')
-  conf_data.set('USE_OPUS', 1)
-  libdecoders_sources += ['opus.cpp']
-endif
 
 libdecoders = static_library('decoders', libdecoders_sources,
                              include_directories : incdir,

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -45,9 +45,6 @@
 /* Define to 1 to enable FluidSynth MIDI synthesizer */
 #define C_FLUIDSYNTH 1
 
-/* Define to 1 to use Opus-encoded CD-audio tracks, requires opusfile */
-#define USE_OPUS 1
-
 /* Enable the FPU module, still only for beta testing */
 #define C_FPU 1
 


### PR DESCRIPTION
Vorbis has been deprecated for years by its maintainer Xiph who recommends Opus as its successor because it provides:
 - superior audio quality at lower bit-rates
 - PCM-accurate seeking
 - very low block-level latency

One of the reasons Staging supports Opus is to allow those packaging games (like GoG) to finally get off Vorbis once and for all.

However, if Staging allows repo packagers to exclude Opus, then it makes sense to similarly not rely on Opus when packaging games.

This commit make Opus no longer optional. We know Opus is supported under all known repositories that we ever expect Staging to run on (even beyond that, we know Opus can be compiled on all platforms as well).

If the day comes when there's a system out there that /doesn't/ support Opus, then we can reconsider making it optional. But I doubt that will happen :-)