### PR TITLE
Use consistent style for key names

### DIFF
--- a/README
+++ b/README
@@ -139,7 +139,7 @@ MOUSE: The mouse doesn't work.
     Usually, DOSBox detects when a game uses mouse control. When you click on
     the screen it should get locked (confined to the DOSBox window) and work.
     With certain games, the DOSBox mouse detection doesn't work. In that case
-    you will have to lock the mouse manually by pressing CTRL-F10.
+    you will have to lock the mouse manually by pressing Ctrl+F10.
 
 
 SOUND: There is no sound.
@@ -218,7 +218,7 @@ KEYBOARD: I can't type \ or : in DOSBox.
     have a matching DOS layout representation (or it was not correctly
     detected), or the key mapping is wrong.
     Some possible fixes:
-      1. Use / instead, or ALT-58 for : and ALT-92 for \.
+      1. Use / instead, or Alt+58 for : and Alt+92 for \.
       2. Change the DOS keyboard layout (see Section 8: "Keyboard Layout").
       3. Add the commands you want to execute to the [autoexec] section
          of the DOSBox configuration file.
@@ -227,9 +227,9 @@ KEYBOARD: I can't type \ or : in DOSBox.
 
     Note that if the host layout can not be identified, or keyboardlayout is
     set to none in the DOSBox configuration file, the standard US layout is
-    used. In this configuration try the keys around "enter" for the key \
-    (backslash), and for the key : (colon) use shift and the keys between
-    "enter" and "L".
+    used. In this configuration try the keys around "Enter" for the key \
+    (backslash), and for the key : (colon) use Shift and the keys between
+    "Enter" and "L".
 
 
 KEYBOARD: The keyboard lags.
@@ -763,7 +763,7 @@ LOADFIX -f
 
 RESCAN [Drive:] [-All]
   Make DOSBox reread the directory structure. Useful if you changed something
-  on a mounted drive outside of DOSBox. (CTRL - F4 does this as well!)
+  on a mounted drive outside of DOSBox. (Ctrl+F4 does this as well!)
 
   Drive:
         Drive to refresh.
@@ -826,7 +826,7 @@ IMGMOUNT
   imagefile1 imagefile2 .. imagefileN
       Location of the image files to mount in DOSBox. Specifying a number
       of image files is only allowed for CD-ROM images.
-      The CD's can be swapped with CTRL-F4 at any time.
+      The CD's can be swapped with Ctrl+F4 at any time.
       This is required for games which use multiple CD-ROMs and require the CD
       to be switched during the gameplay at some point.
 
@@ -890,7 +890,7 @@ BOOT
   diskimg1.img diskimg2.img .. diskimgN.img
      This can be any number of floppy disk images one wants mounted after
      DOSBox boots the specified drive letter.
-     To swap between images, hit CTRL-F4 to change from the current disk
+     To swap between images, hit Ctrl+F4 to change from the current disk
      to the next disk in the list. The list will loop back from the last
      disk image to the beginning.
 
@@ -1020,7 +1020,7 @@ KEYB [keyboardlayoutcode [codepage [codepagefile]]]
          keyb pl214
     2. To load one of Russian keyboard layouts with codepage 866:
          keyb ru441 866
-       In order to type Russian characters press ALT+RIGHT-SHIFT.
+       In order to type Russian characters press Alt+Right+Shift.
     3. To load one of French keyboard layouts with codepage 850 (where the
        codepage is defined in EGACPI.DAT):
          keyb fr189 850 EGACPI.DAT
@@ -1068,21 +1068,21 @@ For more information use the /? command line switch with the programs.
 5. Special Keys:
 ================
 
-ALT-ENTER     Switch between fullscreen and window mode.
-ALT-PAUSE     Pause/Unpause emulator.
-CTRL-F1       Start the keymapper.
-CTRL-F4       Change between mounted floppy/CD images. Update directory cache
+Alt+Enter     Switch between fullscreen and window mode.
+Alt+Pause     Pause/Unpause emulator.
+Ctrl+F1       Start the keymapper.
+Ctrl+F4       Change between mounted floppy/CD images. Update directory cache
               for all drives.
-CTRL-F5       Save a screenshot. (PNG format)
-CTRL-F6       Start/Stop recording sound output to a wave file.
-CTRL-F7       Start/Stop recording video output to a zmbv file.
-CTRL-F9       Shutdown emulator.
-CTRL-F10      Capture/Release the mouse.
-CTRL-F11      Slow down emulation (Decrease DOSBox Cycles).
-CTRL-F12      Speed up emulation (Increase DOSBox Cycles)*.
-ALT-F12       Unlock speed (turbo button/fast forward)**.
-CTRL-ALT-HOME Restart DOSBox.
-F11, ALT-F11  (machine=cga) change tint in NTSC output modes***.
+Ctrl+F5       Save a screenshot. (PNG format)
+Ctrl+F6       Start/Stop recording sound output to a wave file.
+Ctrl+F7       Start/Stop recording video output to a zmbv file.
+Ctrl+F9       Shutdown emulator.
+Ctrl+F10      Capture/Release the mouse.
+Ctrl+F11      Slow down emulation (Decrease DOSBox Cycles).
+Ctrl+F12      Speed up emulation (Increase DOSBox Cycles)*.
+Alt+F12       Unlock speed (turbo button/fast forward)**.
+Ctrl+Alt+Home Restart DOSBox.
+F11, Alt+F11  (machine=cga) change tint in NTSC output modes***.
 F11           (machine=hercules) cycle through amber, green, white colouring***.
 
 *NOTE: Once you increase your DOSBox cycles beyond your computer CPU resources,
@@ -1099,9 +1099,9 @@ F11           (machine=hercules) cycle through amber, green, white colouring***.
 These are the default keybindings. They can be changed in the keymapper
 (see Section 7: "KeyMapper").
 
-In Mac OS X you can try using cmd(applekey) together with Ctrl (and/or ) Fn,
-if the key doesn't work i.e. fn-cmd-ctrl-F1, but some keys may still need
-remapping (in Linux too).
+In macOS you can try using Cmd together with Ctrl (and/or) Fn,
+if the key doesn't work i.e. Fn+Cmd+Ctrl+F1, but some keys may still need
+remapping.
 
 Saved/recorded files can be found in:
 
@@ -1153,7 +1153,7 @@ inside DOSBox, try a different 'timed' setting in DOSBox's configuration file.
 7. KeyMapper:
 =============
 
-Start the DOSBox mapper either with CTRL-F1 (see Section 5: "Special Keys") or
+Start the DOSBox mapper either with Ctrl+F1 (see Section 5: "Special Keys") or
 -startmapper (see Section 3: "Command Line Parameters").
 You are presented with a virtual keyboard and a virtual joystick.
 
@@ -1179,7 +1179,7 @@ BIND
     joystick(s) (as reported by SDL), which is connected to the EVENT.
 mod1,2,3
     Modifiers. These are keys you need to have to be pressed while pressing
-    BIND. mod1 = CTRL and mod2 = ALT. These are generally only used when you
+    BIND. mod1 = Ctrl and mod2 = Alt. These are generally only used when you
     want to change the special keys of DOSBox.
 Add
     Add a new BIND to this EVENT. Basically add a key from your keyboard or an
@@ -1268,9 +1268,9 @@ Layout switching
 
   Some keyboard layouts (for example layout GK319 codepage 869 and layout RU441
   codepage 808) have support for dual layouts that can be accessed by pressing
-  LeftALT+RrightSHIFT for one layout and LeftALT+LeftSHIFT for the other.
+  Left Alt+Right Shift for one layout and Left Alt+Left Shift for the other.
   Some keyboard layouts (for example layout LT456 codepage 771) have support
-  for three layouts, third can be accessed by pressing LeftALT+LeftCTRL
+  for three layouts, third can be accessed by pressing Left Alt+Left Ctrl
 
 Supported external files
   The FreeDOS .kl files are supported (FreeDOS keyb2 keyboard layoutfiles) as
@@ -1462,8 +1462,8 @@ CPU Cycles (speed up/slow down)
   You can force the slow or fast behavior by setting a fixed amount of cycles
   in the DOSBox's configuration file. If you set for example cycles=10000, the
   DOSBox window will display a line "CPU speed: fixed 10000 cycles" at the top.
-  In this mode you can reduce the amount of cycles even more by hitting CTRL-F11
-  (you can go as low as you want) or raise it by hitting CTRL-F12 as much as you
+  In this mode you can reduce the amount of cycles even more by hitting Ctrl+F11
+  (you can go as low as you want) or raise it by hitting Ctrl+F12 as much as you
   want, but you will be limited by the power of one core of your computer's CPU.
   You can see how much free time your real CPU's cores have by looking at
   the Task Manager in Windows 2000/XP/Vista/7 and the System Monitor
@@ -1479,7 +1479,7 @@ CPU Cycles (speed up/slow down)
   "CPU speed: max 100% cycles" at the top then. This time you won't have to care
   how much free time your real CPU cores have, because DOSBox will always use
   100% of your real CPU's one core. In this mode you can reduce the amount
-  of your real CPU's core usage by CTRL-F11 or raise it with CTRL-F12.
+  of your real CPU's core usage by Ctrl+F11 or raise it with Ctrl+F12.
 
 CPU Core (speed up)
   On x86 architectures you can try to force the usage of a dynamically
@@ -1495,7 +1495,7 @@ Graphics emulation (speed up)
   On systems with limited CPU performance, consider binding a hotkey to the
   "Increase frameskip" action ("Inc Fskip") using the keymapper. Skipping
   frames generally frees up your CPU, providing faster emulation when using
-  max cycles or affording a greater number of fixed cycles with CTRL+F12.
+  max cycles or affording a greater number of fixed cycles with Ctrl+F12.
 
   You can repeat this until the game runs fast enough for you.
   Please note that this is a trade-off: you lose in fluidity of video what

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -1,6 +1,6 @@
 :CONFIG_FULLSCREEN
 Start DOSBox directly in fullscreen.
-Press Alt-Enter to switch back to window.
+Press Alt+Enter to switch back to window.
 .
 :CONFIG_DISPLAY
 Number of display to use; values depend on OS and user settings.
@@ -44,12 +44,12 @@ Choose a mouse control method:
                    input sent to the game.
 Choose how middle-clicks are handled (second parameter):
    middlegame:     Middle-clicks are sent to the game
-                   (Ctrl-F10 uncaptures the mouse).
+                   (Ctrl+F10 uncaptures the mouse).
    middlerelease:  Middle-clicks are used to uncapture the mouse
                    (not sent to the game). However, middle-clicks
                    will be sent to the game in fullscreen or when
                    seamless control is set.
-                   Ctrl-F10 will also uncapture the mouse.
+                   Ctrl+F10 will also uncapture the mouse.
 Defaults (if not present or incorrect): seamless middlerelease
 .
 :CONFIG_SENSITIVITY
@@ -154,7 +154,7 @@ Cycles can be set in 3 ways:
                   handle.
 .
 :CONFIG_CYCLEUP
-Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
+Number of cycles to decrease/increase with keycombos. (Ctrl+F11/Ctrl+F12)
 .
 :CONFIG_CYCLEDOWN
 Setting it lower than 100 will be a percentage.
@@ -743,18 +743,18 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 These are the default keybindings.
 They can be changed in the [33mkeymapper[0m.
 
-[33;1mALT-ENTER[0m   : Switch between fullscreen and window mode.
-[33;1mALT-PAUSE[0m   : Pause/Unpause emulator.
-[33;1mCTRL-F1[0m     : Start the [33mkeymapper[0m.
-[33;1mCTRL-F4[0m     : Swap mounted disk image, update directory cache for all drives.
-[33;1mCTRL-F5[0m     : Save a screenshot.
-[33;1mCTRL-F6[0m     : Start/Stop recording sound output to a wave file.
-[33;1mCTRL-F7[0m     : Start/Stop recording video output to a zmbv file.
-[33;1mCTRL-F9[0m     : Shutdown emulator.
-[33;1mCTRL-F10[0m    : Capture/Release the mouse.
-[33;1mCTRL-F11[0m    : Slow down emulation.
-[33;1mCTRL-F12[0m    : Speed up emulation.
-[33;1mALT-F12[0m     : Unlock speed (turbo button/fast forward).
+[33;1mAlt+Enter[0m  Switch between fullscreen and window mode.
+[33;1mAlt+Pause[0m  Pause/Unpause emulator.
+[33;1mCtrl+F1[0m    Start the [33mkeymapper[0m.
+[33;1mCtrl+F4[0m    Swap mounted disk image, update directory cache for all drives.
+[33;1mCtrl+F5[0m    Save a screenshot.
+[33;1mCtrl+F6[0m    Start/Stop recording sound output to a wave file.
+[33;1mCtrl+F7[0m    Start/Stop recording video output to a zmbv file.
+[33;1mCtrl+F9[0m    Shutdown emulator.
+[33;1mCtrl+F10[0m   Capture/Release the mouse.
+[33;1mCtrl+F11[0m   Slow down emulation.
+[33;1mCtrl+F12[0m   Speed up emulation.
+[33;1mAlt+F12[0m    Unlock speed (turbo button/fast forward).
 
 .
 :PROGRAM_BOOT_NOT_EXIST
@@ -773,7 +773,7 @@ Image file is read-only! Might create problems.
 This command boots DOSBox from either a floppy or hard disk image.
 
 For this command, one can specify a succession of floppy disks swappable
-by pressing Ctrl-F4, and -l specifies the mounted drive to boot from.  If
+by pressing Ctrl+F4, and -l specifies the mounted drive to boot from.  If
 no drive letter is specified, this defaults to booting from the A drive.
 The only bootable drive letters are A, C, and D.  For booting from a hard
 drive (C or D), the image should have already been mounted using the
@@ -1191,8 +1191,8 @@ It's only possible to use SUBST on Local drives
 º For a short introduction for new users type: [33mINTRO[37m                 º
 º For supported shell commands type: [33mHELP[37m                            º
 º                                                                    º
-º To adjust the emulated CPU speed, use [31mctrl-F11[37m and [31mctrl-F12[37m.       º
-º To activate the keymapper [31mctrl-F1[37m.                                 º
+º To adjust the emulated CPU speed, use [31mCtrl+F11[37m and [31mCtrl+F12[37m.       º
+º To activate the keymapper [31mCtrl+F1[37m.                                 º
 º For more information read the [36mREADME[37m file in the DOSBox directory. º
 º                                                                    º
 
@@ -1200,13 +1200,13 @@ It's only possible to use SUBST on Local drives
 :SHELL_STARTUP_CGA
 º DOSBox supports Composite CGA mode.                                º
 º Use [31mF12[37m to set composite output ON, OFF, or AUTO (default).        º
-º [31m(Alt-)F11[37m changes hue; [31mctrl-alt-F11[37m selects early/late CGA model.  º
+º [31m(Alt+)F11[37m changes hue; [31mCtrl+Alt+F11[37m selects early/late CGA model.  º
 º                                                                    º
 
 .
 :SHELL_STARTUP_CGA_MONO
 º Use [31mF11[37m to cycle through green, amber, white and paper-white mode, º
-º and [31mAlt-F11[37m to change contrast/brightness settings.                º
+º and [31mAlt+F11[37m to change contrast/brightness settings.                º
 
 .
 :SHELL_STARTUP_HERC
@@ -1215,7 +1215,7 @@ It's only possible to use SUBST on Local drives
 
 .
 :SHELL_STARTUP_DEBUG
-º Press [31malt-Pause[37m to enter the debugger or start the exe with [33mDEBUG[37m. º
+º Press [31mAlt+Pause[37m to enter the debugger or start the exe with [33mDEBUG[37m. º
 º                                                                    º
 
 .

--- a/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
+++ b/contrib/translations/utf-8/en/en-0.77.0-alpha.txt
@@ -1,6 +1,6 @@
 :CONFIG_FULLSCREEN
 Start DOSBox directly in fullscreen.
-Press Alt-Enter to switch back to window.
+Press Alt+Enter to switch back to window.
 .
 :CONFIG_DISPLAY
 Number of display to use; values depend on OS and user settings.
@@ -44,12 +44,12 @@ Choose a mouse control method:
                    input sent to the game.
 Choose how middle-clicks are handled (second parameter):
    middlegame:     Middle-clicks are sent to the game
-                   (Ctrl-F10 uncaptures the mouse).
+                   (Ctrl+F10 uncaptures the mouse).
    middlerelease:  Middle-clicks are used to uncapture the mouse
                    (not sent to the game). However, middle-clicks
                    will be sent to the game in fullscreen or when
                    seamless control is set.
-                   Ctrl-F10 will also uncapture the mouse.
+                   Ctrl+F10 will also uncapture the mouse.
 Defaults (if not present or incorrect): seamless middlerelease
 .
 :CONFIG_SENSITIVITY
@@ -154,7 +154,7 @@ Cycles can be set in 3 ways:
                   handle.
 .
 :CONFIG_CYCLEUP
-Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
+Number of cycles to decrease/increase with keycombos. (Ctrl+F11/Ctrl+F12)
 .
 :CONFIG_CYCLEDOWN
 Setting it lower than 100 will be a percentage.
@@ -743,18 +743,18 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 These are the default keybindings.
 They can be changed in the [33mkeymapper[0m.
 
-[33;1mALT-ENTER[0m   : Switch between fullscreen and window mode.
-[33;1mALT-PAUSE[0m   : Pause/Unpause emulator.
-[33;1mCTRL-F1[0m     : Start the [33mkeymapper[0m.
-[33;1mCTRL-F4[0m     : Swap mounted disk image, update directory cache for all drives.
-[33;1mCTRL-F5[0m     : Save a screenshot.
-[33;1mCTRL-F6[0m     : Start/Stop recording sound output to a wave file.
-[33;1mCTRL-F7[0m     : Start/Stop recording video output to a zmbv file.
-[33;1mCTRL-F9[0m     : Shutdown emulator.
-[33;1mCTRL-F10[0m    : Capture/Release the mouse.
-[33;1mCTRL-F11[0m    : Slow down emulation.
-[33;1mCTRL-F12[0m    : Speed up emulation.
-[33;1mALT-F12[0m     : Unlock speed (turbo button/fast forward).
+[33;1mAlt+Enter[0m  Switch between fullscreen and window mode.
+[33;1mAlt+Pause[0m  Pause/Unpause emulator.
+[33;1mCtrl+F1[0m    Start the [33mkeymapper[0m.
+[33;1mCtrl+F4[0m    Swap mounted disk image, update directory cache for all drives.
+[33;1mCtrl+F5[0m    Save a screenshot.
+[33;1mCtrl+F6[0m    Start/Stop recording sound output to a wave file.
+[33;1mCtrl+F7[0m    Start/Stop recording video output to a zmbv file.
+[33;1mCtrl+F9[0m    Shutdown emulator.
+[33;1mCtrl+F10[0m   Capture/Release the mouse.
+[33;1mCtrl+F11[0m   Slow down emulation.
+[33;1mCtrl+F12[0m   Speed up emulation.
+[33;1mAlt+F12[0m    Unlock speed (turbo button/fast forward).
 
 .
 :PROGRAM_BOOT_NOT_EXIST
@@ -773,7 +773,7 @@ Image file is read-only! Might create problems.
 This command boots DOSBox from either a floppy or hard disk image.
 
 For this command, one can specify a succession of floppy disks swappable
-by pressing Ctrl-F4, and -l specifies the mounted drive to boot from.  If
+by pressing Ctrl+F4, and -l specifies the mounted drive to boot from.  If
 no drive letter is specified, this defaults to booting from the A drive.
 The only bootable drive letters are A, C, and D.  For booting from a hard
 drive (C or D), the image should have already been mounted using the
@@ -1191,8 +1191,8 @@ It's only possible to use SUBST on Local drives
 ║ For a short introduction for new users type: [33mINTRO[37m                 ║
 ║ For supported shell commands type: [33mHELP[37m                            ║
 ║                                                                    ║
-║ To adjust the emulated CPU speed, use [31mctrl-F11[37m and [31mctrl-F12[37m.       ║
-║ To activate the keymapper [31mctrl-F1[37m.                                 ║
+║ To adjust the emulated CPU speed, use [31mCtrl+F11[37m and [31mCtrl+F12[37m.       ║
+║ To activate the keymapper [31mCtrl+F1[37m.                                 ║
 ║ For more information read the [36mREADME[37m file in the DOSBox directory. ║
 ║                                                                    ║
 
@@ -1200,13 +1200,13 @@ It's only possible to use SUBST on Local drives
 :SHELL_STARTUP_CGA
 ║ DOSBox supports Composite CGA mode.                                ║
 ║ Use [31mF12[37m to set composite output ON, OFF, or AUTO (default).        ║
-║ [31m(Alt-)F11[37m changes hue; [31mctrl-alt-F11[37m selects early/late CGA model.  ║
+║ [31m(Alt+)F11[37m changes hue; [31mCtrl+Alt+F11[37m selects early/late CGA model.  ║
 ║                                                                    ║
 
 .
 :SHELL_STARTUP_CGA_MONO
 ║ Use [31mF11[37m to cycle through green, amber, white and paper-white mode, ║
-║ and [31mAlt-F11[37m to change contrast/brightness settings.                ║
+║ and [31mAlt+F11[37m to change contrast/brightness settings.                ║
 
 .
 :SHELL_STARTUP_HERC
@@ -1215,7 +1215,7 @@ It's only possible to use SUBST on Local drives
 
 .
 :SHELL_STARTUP_DEBUG
-║ Press [31malt-Pause[37m to enter the debugger or start the exe with [33mDEBUG[37m. ║
+║ Press [31mAlt+Pause[37m to enter the debugger or start the exe with [33mDEBUG[37m. ║
 ║                                                                    ║
 
 .

--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -268,7 +268,7 @@ Frees all memory eaten up by loadfix.
 .B RESCAN [\-All] [Drive:]
 .LP
 .RB "Make " dosbox " reread the directory structure. Useful if you changed
-.RB "something on a mounted drive outside " dosbox ".(CTRL\-F4 does"
+.RB "something on a mounted drive outside " dosbox ". (Ctrl+F4 does"
 this as well!)
 .RS
 .TP
@@ -324,30 +324,30 @@ in the current directory
 new default config file if it does not exist yet.
 .SH "SPECIAL KEYS"
 .TP 12m
-.IP ALT\-ENTER
+.IP Alt+Enter
 Switch between fullscreen and window mode.
-.IP ALT\-PAUSE
+.IP Alt+Pause
 Pause/Unpause emulator.
-.IP CTRL\-F1
+.IP Ctrl+F1
 Start the keymapper.
-.IP CTRL\-F4
-Swap mounted disk\(hyimage (Only used with imgmount). Update directory cache
-for all drives!
-.IP CTRL\-F5
+.IP Ctrl+F4
+Swap mounted disk\(hyimage (only used with imgmount). Update directory cache
+for all drives.
+.IP Ctrl+F5
 Save a screenshot.(png)
-.IP CTRL\-F6
+.IP Ctrl+F6
 Start/Stop recording sound output to a wave file.
-.IP CTRL\-F7
+.IP Ctrl+F7
 Start/Stop recording video output to a zmbv file.
-.IP CTRL\-F9
+.IP Ctrl+F9
 Kill dosbox.
-.IP CTRL\-F10
+.IP Ctrl+F10
 Capture/Release the mouse.
-.IP CTRL\-F11
+.IP Ctrl+F11
 Slow down emulation (Increase dosbox Cycles).
-.IP CTRL\-F12
+.IP Ctrl+F12
 Speed up emulation (Decrease dosbox Cycles).
-.IP ALT\-F12
+.IP Alt+F12
 Unlock speed (turbo button).
 .PP
 These are the default keybindings. They can be changed in the keymapper.
@@ -368,7 +368,7 @@ them to run fast though!! Be sure to read the next section on how to speed
 it up somewhat.
 .SS "To run resource\-demanding games"
 .BR dosbox " emulates the CPU, the sound and graphic cards, and some other"
-.RB " stuff, all at the same time. You can overclock " dosbox " by using CTRL\-F12, but"
+.RB " stuff, all at the same time. You can overclock " dosbox " by using Ctrl+F12, but"
 you'll be limited by the power of your actual CPU. You can see how much free
 time your true CPU has by various utils (top).  Once 100% of your real CPU time is
 .RB "used there is no further way to speed up " dosbox " unless you reduce the load"
@@ -378,11 +378,11 @@ So:
 .PP
 .RB "Close every program but " dosbox .
 .PP
-.RB "Overclock  " dosbox " until 100% of your CPU is used.(CTRL\-F12)" 
+.RB "Overclock  " dosbox " until 100% of your CPU is used. (Ctrl+F12)"
 .PP
 .RB "Since VGA emulation is the most demanding part of " dosbox " in terms of actual"
 CPU usage, we'll start here. Increase the number of frames skipped (in
-increments of one) by pressing CTRL\-F8. Your CPU usage should decrease.
+increments of one) by pressing Ctrl+F8. Your CPU usage should decrease.
 Go back one step and repeat this until the game runs fast enough for you.
 Please note that this is a trade off: you lose in fluidity of video what you
 gain in speed.

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -369,7 +369,7 @@ Bitu keyboard_layout::read_keyboard_file(const char* keyboard_file_name, Bit32s 
 	for (Bit16u cplane=0; cplane<additional_planes; cplane++) {
 		Bit16u plane_flags;
 
-		// get required-flags (shift/alt/ctrl-states etc.)
+		// get required-flags (Shift/Alt/Ctrl states, etc.)
 		plane_flags=host_readw(&read_buf[read_buf_pos]);
 		read_buf_pos+=2;
 		current_layout_planes[cplane].required_flags=plane_flags;
@@ -1049,12 +1049,14 @@ const char* keyboard_layout::main_language_code() {
 
 static keyboard_layout* loaded_layout=NULL;
 
-// CTRL-ALT-F2 switches between foreign and US-layout using this function
-/* static void switch_keyboard_layout(bool pressed) {
+#if 0
+// Ctrl+Alt+F2 switches between foreign and US-layout using this function
+static void switch_keyboard_layout(bool pressed) {
 	if (!pressed)
 		return;
 	if (loaded_layout) loaded_layout->switch_foreign_layout();
-} */
+}
+#endif
 
 // called by int9-handler
 bool DOS_LayoutKey(Bitu key, Bit8u flags1, Bit8u flags2, Bit8u flags3) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1759,30 +1759,31 @@ void DOS_SetupPrograms(void) {
 		"\n"
 		"\033[34;1mimgmount D C:\\cd.iso -t cdrom\033[0m\n"
 		);
+
 	MSG_Add("PROGRAM_INTRO_SPECIAL",
-		"\033[2J\033[32;1mSpecial keys:\033[0m\n"
-		"These are the default keybindings.\n"
-		"They can be changed in the \033[33mkeymapper\033[0m.\n"
-		"\n"
-		"\033[33;1mALT-ENTER\033[0m   : Switch between fullscreen and window mode.\n"
-		"\033[33;1mALT-PAUSE\033[0m   : Pause/Unpause emulator.\n"
-		"\033[33;1mCTRL-F1\033[0m     : Start the \033[33mkeymapper\033[0m.\n"
-		"\033[33;1mCTRL-F4\033[0m     : Swap mounted disk image, update directory cache for all drives.\n"
-		"\033[33;1mCTRL-F5\033[0m     : Save a screenshot.\n"
-		"\033[33;1mCTRL-F6\033[0m     : Start/Stop recording sound output to a wave file.\n"
-		"\033[33;1mCTRL-F7\033[0m     : Start/Stop recording video output to a zmbv file.\n"
-		"\033[33;1mCTRL-F9\033[0m     : Shutdown emulator.\n"
-		"\033[33;1mCTRL-F10\033[0m    : Capture/Release the mouse.\n"
-		"\033[33;1mCTRL-F11\033[0m    : Slow down emulation.\n"
-		"\033[33;1mCTRL-F12\033[0m    : Speed up emulation.\n"
-		"\033[33;1mALT-F12\033[0m     : Unlock speed (turbo button/fast forward).\n"
-		);
+	        "\033[2J\033[32;1mSpecial keys:\033[0m\n"
+	        "These are the default keybindings.\n"
+	        "They can be changed in the \033[33mkeymapper\033[0m.\n"
+	        "\n"
+	        "\033[33;1mAlt+Enter\033[0m  Switch between fullscreen and window mode.\n"
+	        "\033[33;1mAlt+Pause\033[0m  Pause/Unpause emulator.\n"
+	        "\033[33;1mCtrl+F1\033[0m    Start the \033[33mkeymapper\033[0m.\n"
+	        "\033[33;1mCtrl+F4\033[0m    Swap mounted disk image, update directory cache for all drives.\n"
+	        "\033[33;1mCtrl+F5\033[0m    Save a screenshot.\n"
+	        "\033[33;1mCtrl+F6\033[0m    Start/Stop recording sound output to a wave file.\n"
+	        "\033[33;1mCtrl+F7\033[0m    Start/Stop recording video output to a zmbv file.\n"
+	        "\033[33;1mCtrl+F9\033[0m    Shutdown emulator.\n"
+	        "\033[33;1mCtrl+F10\033[0m   Capture/Release the mouse.\n"
+	        "\033[33;1mCtrl+F11\033[0m   Slow down emulation.\n"
+	        "\033[33;1mCtrl+F12\033[0m   Speed up emulation.\n"
+	        "\033[33;1mAlt+F12\033[0m    Unlock speed (turbo button/fast forward).\n");
+
 	MSG_Add("PROGRAM_BOOT_NOT_EXIST","Bootdisk file does not exist.  Failing.\n");
 	MSG_Add("PROGRAM_BOOT_NOT_OPEN","Cannot open bootdisk file.  Failing.\n");
 	MSG_Add("PROGRAM_BOOT_WRITE_PROTECTED","Image file is read-only! Might create problems.\n");
 	MSG_Add("PROGRAM_BOOT_PRINT_ERROR","This command boots DOSBox from either a floppy or hard disk image.\n\n"
 		"For this command, one can specify a succession of floppy disks swappable\n"
-		"by pressing Ctrl-F4, and -l specifies the mounted drive to boot from.  If\n"
+		"by pressing Ctrl+F4, and -l specifies the mounted drive to boot from.  If\n"
 		"no drive letter is specified, this defaults to booting from the A drive.\n"
 		"The only bootable drive letters are A, C, and D.  For booting from a hard\n"
 		"drive (C or D), the image should have already been mounted using the\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -570,7 +570,7 @@ void DOSBOX_Init(void) {
 
 	Pint = secprop->Add_int("cycleup",Property::Changeable::Always,10);
 	Pint->SetMinMax(1,1000000);
-	Pint->Set_help("Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)");
+	Pint->Set_help("Number of cycles to decrease/increase with keycombos. (Ctrl+F11/Ctrl+F12)");
 
 	Pint = secprop->Add_int("cycledown",Property::Changeable::Always,20);
 	Pint->SetMinMax(1,1000000);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -339,10 +339,10 @@ struct SDL_Block {
 	SDL_Point pp_scale = {1, 1};
 	SDL_Rect updateRects[1024];
 #if defined (WIN32)
-	// Time when sdl regains focus (alt-tab) in windowed mode
+	// Time when sdl regains focus (Alt+Tab) in windowed mode
 	Bit32u focus_ticks;
 #endif
-	// state of alt-keys for certain special handlings
+	// State of Alt keys for certain special handlings
 	SDL_EventType laltstate = SDL_KEYUP;
 	SDL_EventType raltstate = SDL_KEYUP;
 };
@@ -2692,7 +2692,7 @@ bool GFX_Events()
 				if ((event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) || (event.window.event == SDL_WINDOWEVENT_MINIMIZED)) {
 					/* Window has lost focus, pause the emulator.
 					 * This is similar to what PauseDOSBox() does, but the exit criteria is different.
-					 * Instead of waiting for the user to hit Alt-Break, we wait for the window to
+					 * Instead of waiting for the user to hit Alt+Break, we wait for the window to
 					 * regain window or input focus.
 					 */
 					bool paused = true;
@@ -2762,7 +2762,8 @@ bool GFX_Events()
 				break;
 			// This can happen as well.
 			if (((event.key.keysym.sym == SDLK_TAB )) && (event.key.keysym.mod & KMOD_ALT)) break;
-			// ignore tab events that arrive just after regaining focus. (likely the result of alt-tab)
+			// Ignore tab events that arrive just after regaining
+			// focus. Likely the result of Alt+Tab.
 			if ((event.key.keysym.sym == SDLK_TAB) && (GetTicks() - sdl.focus_ticks < 2)) break;
 #endif
 #if defined (MACOSX)
@@ -2847,7 +2848,7 @@ void Config_Add_SDL() {
 
 	Pbool = sdl_sec->Add_bool("fullscreen", always, false);
 	Pbool->Set_help("Start DOSBox directly in fullscreen.\n"
-	                "Press Alt-Enter to switch back to window.");
+	                "Press Alt+Enter to switch back to window.");
 
 	pint = sdl_sec->Add_int("display", on_start, 0);
 	pint->Set_help("Number of display to use; values depend on OS and user "
@@ -2942,12 +2943,12 @@ void Config_Add_SDL() {
 		"                   input sent to the game.\n"
 		"Choose how middle-clicks are handled (second parameter):\n"
 		"   middlegame:     Middle-clicks are sent to the game\n"
-		"                   (Ctrl-F10 uncaptures the mouse).\n"
+		"                   (Ctrl+F10 uncaptures the mouse).\n"
 		"   middlerelease:  Middle-clicks are used to uncapture the mouse\n"
 		"                   (not sent to the game). However, middle-clicks\n"
 		"                   will be sent to the game in fullscreen or when\n"
 		"                   seamless control is set.\n"
-		"                   Ctrl-F10 will also uncapture the mouse.\n"
+		"                   Ctrl+F10 will also uncapture the mouse.\n"
 		"Defaults (if not present or incorrect): ");
 	mouse_control_help += mouse_control_defaults;
 	Pmulti->Set_help(mouse_control_help);

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -304,9 +304,9 @@ static Bitu IRQ1_Handler(void) {
 			flags3 &=~0x01;
 			mem_writeb(BIOS_KEYBOARD_FLAGS3,flags3);
 			if (flags2&1) {
-				/* ctrl-pause (break), special handling needed:
+				/* Ctrl+Pause (Break), special handling needed:
 				   add zero to the keyboard buffer, call int 0x1b which
-				   sets ctrl-c flag which calls int 0x23 in certain dos
+				   sets Ctrl+C flag which calls int 0x23 in certain dos
 				   input/output functions;    not handled */
 			} else if ((flags2&8)==0) {
 				/* normal pause key, enter loop */

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -625,41 +625,39 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST failed. You either made an error in your commandline or the target drive is already used.\nIt's only possible to use SUBST on Local drives");
 
 	MSG_Add("SHELL_STARTUP_BEGIN",
-		"\033[44;1m\xC9\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-		"\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-		"\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\n"
-		"\xBA \033[32mWelcome to DOSBox Staging %-40s\033[37m \xBA\n"
-		"\xBA                                                                    \xBA\n"
-//		"\xBA DOSBox runs real and protected mode games.                         \xBA\n"
-		"\xBA For a short introduction for new users type: \033[33mINTRO\033[37m                 \xBA\n"
-		"\xBA For supported shell commands type: \033[33mHELP\033[37m                            \xBA\n"
-		"\xBA                                                                    \xBA\n"
-		"\xBA To adjust the emulated CPU speed, use \033[31mctrl-F11\033[37m and \033[31mctrl-F12\033[37m.       \xBA\n"
-		"\xBA To activate the keymapper \033[31mctrl-F1\033[37m.                                 \xBA\n"
-		"\xBA For more information read the \033[36mREADME\033[37m file in the DOSBox directory. \xBA\n"
-		"\xBA                                                                    \xBA\n"
-	);
-	MSG_Add("SHELL_STARTUP_CGA","\xBA DOSBox supports Composite CGA mode.                                \xBA\n"
+	        "\033[44;1m\xC9\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\n"
+	        "\xBA \033[32mWelcome to DOSBox Staging %-40s\033[37m \xBA\n"
+	        "\xBA                                                                    \xBA\n"
+	        "\xBA For a short introduction for new users type: \033[33mINTRO\033[37m                 \xBA\n"
+	        "\xBA For supported shell commands type: \033[33mHELP\033[37m                            \xBA\n"
+	        "\xBA                                                                    \xBA\n"
+	        "\xBA To adjust the emulated CPU speed, use \033[31mCtrl+F11\033[37m and \033[31mCtrl+F12\033[37m.       \xBA\n"
+	        "\xBA To activate the keymapper \033[31mCtrl+F1\033[37m.                                 \xBA\n"
+	        "\xBA For more information read the \033[36mREADME\033[37m file in the DOSBox directory. \xBA\n"
+	        "\xBA                                                                    \xBA\n");
+	MSG_Add("SHELL_STARTUP_CGA",
+	        "\xBA DOSBox supports Composite CGA mode.                                \xBA\n"
 	        "\xBA Use \033[31mF12\033[37m to set composite output ON, OFF, or AUTO (default).        \xBA\n"
-	        "\xBA \033[31m(Alt-)F11\033[37m changes hue; \033[31mctrl-alt-F11\033[37m selects early/late CGA model.  \xBA\n"
-	        "\xBA                                                                    \xBA\n"
-	);
-	MSG_Add("SHELL_STARTUP_CGA_MONO","\xBA Use \033[31mF11\033[37m to cycle through green, amber, white and paper-white mode, \xBA\n"
-	        "\xBA and \033[31mAlt-F11\033[37m to change contrast/brightness settings.                \xBA\n"
-	);
-	MSG_Add("SHELL_STARTUP_HERC","\xBA Use \033[31mF11\033[37m to cycle through white, amber, and green monochrome color. \xBA\n"
-	        "\xBA                                                                    \xBA\n"
-	);
+	        "\xBA \033[31m(Alt+)F11\033[37m changes hue; \033[31mCtrl+Alt+F11\033[37m selects early/late CGA model.  \xBA\n"
+	        "\xBA                                                                    \xBA\n");
+	MSG_Add("SHELL_STARTUP_CGA_MONO",
+	        "\xBA Use \033[31mF11\033[37m to cycle through green, amber, white and paper-white mode, \xBA\n"
+	        "\xBA and \033[31mAlt+F11\033[37m to change contrast/brightness settings.                \xBA\n");
+	MSG_Add("SHELL_STARTUP_HERC",
+	        "\xBA Use \033[31mF11\033[37m to cycle through white, amber, and green monochrome color. \xBA\n"
+	        "\xBA                                                                    \xBA\n");
 	MSG_Add("SHELL_STARTUP_DEBUG",
-	        "\xBA Press \033[31malt-Pause\033[37m to enter the debugger or start the exe with \033[33mDEBUG\033[37m. \xBA\n"
-	        "\xBA                                                                    \xBA\n"
-	);
+	        "\xBA Press \033[31mAlt+Pause\033[37m to enter the debugger or start the exe with \033[33mDEBUG\033[37m. \xBA\n"
+	        "\xBA                                                                    \xBA\n");
 	MSG_Add("SHELL_STARTUP_END",
 	        "\xBA \033[33mhttps://dosbox-staging.github.io\033[37m                                   \xBA\n"
 	        "\xC8\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
 	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
 	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBC\033[0m\n"
 	        "\n");
+
 	MSG_Add("SHELL_STARTUP_SUB","\033[32;1mdosbox-staging %s\033[0m\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays/changes the current directory.\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG","CHDIR [drive:][path]\n"

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -73,12 +73,12 @@ void DOS_Shell::InputCommand(char * line) {
 			continue;
 		}
 		switch (c) {
-		case 0x00:				/* Extended Keys */
+		case 0x00: /* Extended Keys */
 			{
 				DOS_ReadFile(input_handle,&c,&n);
 				switch (c) {
 
-				case 0x3d:		/* F3 */
+				case 0x3d: /* F3 */
 					if (!l_history.size()) break;
 					it_history = l_history.begin();
 					if (it_history != l_history.end() && it_history->length() > str_len) {
@@ -93,33 +93,33 @@ void DOS_Shell::InputCommand(char * line) {
 					}
 					break;
 
-				case 0x4B:	/* LEFT */
+				case 0x4B: /* Left */
 					if (str_index) {
 						outc(8);
 						str_index --;
 					}
 					break;
 
-				case 0x4D:	/* RIGHT */
+				case 0x4D: /* Right */
 					if (str_index < str_len) {
 						outc(line[str_index++]);
 					}
 					break;
 
-				case 0x47:	/* HOME */
+				case 0x47: /* Home */
 					while (str_index) {
 						outc(8);
 						str_index--;
 					}
 					break;
 
-				case 0x4F:	/* END */
+				case 0x4F: /* End */
 					while (str_index < str_len) {
 						outc(line[str_index++]);
 					}
 					break;
 
-				case 0x48:	/* UP */
+				case 0x48: /* Up */
 					if (l_history.empty() || it_history == l_history.end()) break;
 
 					// store current command in history if we are at beginning
@@ -140,7 +140,7 @@ void DOS_Shell::InputCommand(char * line) {
 					it_history ++;
 					break;
 
-				case 0x50:	/* DOWN */
+				case 0x50: /* Down */
 					if (l_history.empty() || it_history == l_history.begin()) break;
 
 					// not very nice but works ..
@@ -169,7 +169,7 @@ void DOS_Shell::InputCommand(char * line) {
 					it_history ++;
 
 					break;
-				case 0x53:/* DELETE */
+				case 0x53: /* Delete */
 					{
 						if(str_index>=str_len) break;
 						auto text_len = static_cast<uint16_t>(str_len - str_index - 1);
@@ -184,7 +184,7 @@ void DOS_Shell::InputCommand(char * line) {
 						size++;
 					}
 					break;
-				case 15:		/* Shift-Tab */
+				case 15: /* Shift+Tab */
 					if (l_completion.size()) {
 						if (it_completion == l_completion.begin()) it_completion = l_completion.end (); 
 						it_completion--;
@@ -207,7 +207,7 @@ void DOS_Shell::InputCommand(char * line) {
 				}
 			};
 			break;
-		case 0x08:				/* BackSpace */
+		case 0x08: /* Backspace */
 			if (str_index) {
 				outc(8);
 				size_t str_remain = str_len - str_index;
@@ -229,10 +229,10 @@ void DOS_Shell::InputCommand(char * line) {
 			}
 			if (l_completion.size()) l_completion.clear();
 			break;
-		case 0x0a:				/* New Line not handled */
+		case 0x0a: /* New Line not handled */
 			/* Don't care */
 			break;
-		case 0x0d:				/* Return */
+		case 0x0d: /* Return */
 			outc('\r');
 			outc('\n');
 			size=0;			//Kill the while loop
@@ -333,7 +333,7 @@ void DOS_Shell::InputCommand(char * line) {
 				}
 			}
 			break;
-		case 0x1b:   /* ESC */
+		case 0x1b: /* Esc */
 			//write a backslash and return to the next line
 			outc('\\');
 			outc('\r');
@@ -359,7 +359,7 @@ void DOS_Shell::InputCommand(char * line) {
 				line[++str_len]=0;//new end (as the internal buffer moved one place to the right
 				size--;
 			};
-		   
+
 			line[str_index]=c;
 			str_index ++;
 			if (str_index > str_len){ 


### PR DESCRIPTION
From the first commit in this PR:
```
Various places in code used mix of uppercase and lowercase typography
for describing key combinations. Replace all those style with consistent
convention:
    
- Key names are always capitalized: Alt, Ctrl, Shift, Cmd, …
- Key combinations are connected with '+': Alt+F1
```

@IlyaIndigo and @Draky50110 already updated respective translations to follow this format for #884.

I made one additional change to translation: removed colons in: https://github.com/dosbox-staging/dosbox-staging/compare/po/ctrl-alt-1?expand=1#diff-ef6e47f1631ad068f6126125b8fae9c87ea14b627838ce316bd9957b2f43b8eeR746 (this makes this intro page a bit cleaner; similar listings of key combinations in README and man page do not have such colons).

@kcgen I hope I catched all strings that needed conversion, but I might've missed something - double checking will be appreciated!