### PR TITLE
Fixup macOS CI caches

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -55,6 +55,7 @@ jobs:
           echo "::set-output name=brew_dir::$BREW_DIR"
           echo "::set-output name=ccache_dir::$CCACHE_DIR"
           echo "::set-output name=today::$(date +%F)"
+          echo "::set-output name=name_hash::$(echo '${{ matrix.conf.name }}' | shasum | cut -b-8)"
 
       - uses:  actions/cache@v2
         with:
@@ -71,8 +72,10 @@ jobs:
       - uses:  actions/cache@v2
         with:
           path: ${{ steps.prep-caches.outputs.ccache_dir }}
-          key:  ccache-macos-debug-${{ steps.prep-caches.outputs.today }}
-          restore-keys: ccache-macos-debug-
+          key:  ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-${{ steps.prep-caches.outputs.today }}
+          restore-keys: |
+            ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-
+            ccache-macos-debug-
 
       - name: Log environment
         run:  ./scripts/log-env.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,28 +42,37 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name:  Prepare brew and compiler caches
+        id:    prep-caches
+        shell: bash
+        run: |
+          set -eu
+          BREW_DIR="$(brew --cache)"
+          DISCARD_DIR="${{ github.workspace }}/discard"
+          mkdir -p "$DISCARD_DIR"
+          mv -f "$BREW_DIR"/* "$DISCARD_DIR"
+          mkdir -p "$CCACHE_DIR"
+          echo "::set-output name=brew_dir::$BREW_DIR"
+          echo "::set-output name=ccache_dir::$CCACHE_DIR"
+          echo "::set-output name=today::$(date +%F)"
+
+      - uses:  actions/cache@v2
+        with:
+          path: ${{ steps.prep-caches.outputs.brew_dir }}
+          key:  brew-cache-${{ steps.prep-caches.outputs.today }}
+          restore-keys: brew-cache-
+
       - name: Install C++ compiler and libraries
         run: |
           brew install \
             ${{ matrix.conf.packages }} \
             $(cat ./.github/packages/macos-latest-brew.txt)
 
-      - name:  Prepare compiler cache
-        id:    prep-ccache
-        shell: bash
-        run: |
-          mkdir -p "${CCACHE_DIR}"
-          echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(gdate -I)"
-          echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
-
       - uses:  actions/cache@v2
-        id:    cache-ccache
         with:
-          path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.today }}
-          restore-keys: |
-            ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.yesterday }}
+          path: ${{ steps.prep-caches.outputs.ccache_dir }}
+          key:  ccache-macos-debug-${{ steps.prep-caches.outputs.today }}
+          restore-keys: ccache-macos-debug-
 
       - name: Log environment
         run:  ./scripts/log-env.sh
@@ -93,27 +102,36 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name:  Prepare brew and compiler caches
+        id:    prep-caches
+        shell: bash
+        run: |
+          set -eu
+          BREW_DIR="$(brew --cache)"
+          DISCARD_DIR="${{ github.workspace }}/discard"
+          mkdir -p "$DISCARD_DIR"
+          mv -f "$BREW_DIR"/* "$DISCARD_DIR"
+          mkdir -p "$CCACHE_DIR"
+          echo "::set-output name=brew_dir::$BREW_DIR"
+          echo "::set-output name=ccache_dir::$CCACHE_DIR"
+          echo "::set-output name=today::$(date +%F)"
+
+      - uses:  actions/cache@v2
+        with:
+          path: ${{ steps.prep-caches.outputs.brew_dir }}
+          key:  brew-cache-${{ steps.prep-caches.outputs.today }}
+          restore-keys: brew-cache-
+
       - name: Install C++ compiler and libraries
         run: |
           brew install librsvg tree \
             $(cat ./.github/packages/macos-latest-brew.txt)
 
-      - name:  Prepare compiler cache
-        id:    prep-ccache
-        shell: bash
-        run: |
-          mkdir -p "${CCACHE_DIR}"
-          echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(gdate -I)"
-          echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
-
       - uses:  actions/cache@v2
-        id:    cache-ccache
         with:
-          path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-macos-release-${{ steps.prep-ccache.outputs.today }}
-          restore-keys: |
-            ccache-macos-release-${{ steps.prep-ccache.outputs.yesterday }}
+          path: ${{ steps.prep-caches.outputs.ccache_dir }}
+          key:  ccache-macos-release-${{ steps.prep-caches.outputs.today }}
+          restore-keys: ccache-macos-release-
 
       - name: Log environment
         run:  ./scripts/log-env.sh
@@ -188,15 +206,14 @@ jobs:
           mv -f "$clamconf".sample "$clamconf"
           sed -ie 's/^Example/#Example/g' "$clamconf"
           sed -ie 's/30/20000/g' "$clamconf"
-          echo "::set-output name=today::$(gdate -I)"
-          echo "::set-output name=yesterday::$(gdate --date=yesterday -I)"
+          echo "::set-output name=today::$(date +%F)"
       - uses:  actions/cache@v2
         id:    cache-clamdb
         with:
           path: ${{ env.CLAMDB_DIR }}/**/*.cvd
-          key:  clamdb-macos-${{ steps.prep-clamdb.outputs.today }}-2
+          key:  clamdb-macos-${{ steps.prep-clamdb.outputs.today }}
           restore-keys: |
-            clamdb-macos-${{ steps.prep-clamdb.outputs.yesterday }}-2
+            clamdb-macos-
 
       - name: Clam AV scan
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: macos-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     strategy:
-      max-parallel: 3
       matrix:
         conf:
 


### PR DESCRIPTION
This PR:
 - Adds caching of brew tarballs
 - Fixes caching of ccache records
 - Resets the ClamDB caching postfix
 - Replaces calls to `gdate` (GNU date) with `date`; as at some point I guess gdate was pulled from the GitHub VMs.

We know caching was "working right", in the sense that nothing should ever rely on caching.  Instead, these caches incrementally broke down as we evolved the build system and as the CI system evolved underneath us - meanwhile performance incrementally degraded, but not so much that it caught our attention.

# Dependency install, before and after

Also note in the top-left corner the "succeeded" duration for the entire workflow (not just the install step).

| Type | Screenshot |
| --- | --- |
| Before | ![2021-03-08_08-31](https://user-images.githubusercontent.com/1557255/110350593-bb830c00-7fe8-11eb-92ac-6abeb337e017.png) |
| After | ![2021-03-08_07-49](https://user-images.githubusercontent.com/1557255/110348987-161b6880-7fe7-11eb-9632-75be07d62e70.png) |

# Meson setup & compile, before and after

| Type | Screenshot |
| --- | --- |
| Before | ![2021-03-07_16-10_1](https://user-images.githubusercontent.com/1557255/110344603-81167080-7fe2-11eb-84b7-97ee6f84aa1e.png) |
| Before | ![2021-03-07_16-10_2](https://user-images.githubusercontent.com/1557255/110344604-81167080-7fe2-11eb-9e92-fdf5cbaa75b6.png) |
| After | ![2021-03-07_16-07](https://user-images.githubusercontent.com/1557255/110344590-7f4cad00-7fe2-11eb-84a7-bca324451a74.png) |
| After | ![2021-03-07_16-07_1](https://user-images.githubusercontent.com/1557255/110344599-807dda00-7fe2-11eb-9922-853961ed40c8.png) |
