### PR TITLE
Don't upload logs unnecessarily

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -259,11 +259,15 @@ jobs:
           path: dosbox-staging-linux-${{ env.VERSION }}.tar.xz
 
 
+  # This job exists only to publish an artifact with version info when building
+  # from master branch, so snapshot build version will be visible on:
+  # https://dosbox-staging.github.io/downloads/devel/
+  #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_linux_release_dynamic
     runs-on: ubuntu-18.04
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -233,11 +233,15 @@ jobs:
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
 
 
+  # This job exists only to publish an artifact with version info when building
+  # from master branch, so snapshot build version will be visible on:
+  # https://dosbox-staging.github.io/downloads/devel/
+  #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_macos_release
     runs-on: macos-latest
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -191,11 +191,15 @@ jobs:
           path: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
 
 
+  # This job exists only to publish an artifact with version info when building
+  # from master branch, so snapshot build version will be visible on:
+  # https://dosbox-staging.github.io/downloads/devel/
+  #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_windows_vs_release
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog


### PR DESCRIPTION
We want to trigger "Publish additional artifacts" job only when new
changes were pushed to master branch. Triggering this job in other
situations wastes ~50s per workflow.