### PR TITLE
Add fluidsynth meson wrap fallback

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -202,7 +202,8 @@ jobs:
             -Db_asneeded=true \
             -Db_lto=true \
             -Dtry_static_libs=png \
-            -Duse_fluidsynth=false \
+            -Dfluidsynth:enable-floats=true \
+            -Dfluidsynth:try-static-deps=true \
             build
 
       - name: Build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -161,12 +161,14 @@ jobs:
       - name: Setup release build
         run: |
           meson setup \
+            --wrap-mode=forcefallback \
             -Dbuildtype=release \
             -Ddefault_library=static \
             -Db_asneeded=true \
             -Db_lto=true \
             -Dtry_static_libs=opusfile,png,sdl2,sdl2_net \
-            -Duse_fluidsynth=false \
+            -Dfluidsynth:enable-floats=true \
+            -Dfluidsynth:try-static-deps=true \
             build
 
       - name: Build

--- a/meson.build
+++ b/meson.build
@@ -2,12 +2,14 @@ project('dosbox-staging', 'c', 'cpp',
         version : '0.77.0',
         license : 'GPL-2.0-or-later',
         default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
-        meson_version : '>= 0.51.0')
+        meson_version : '>= 0.53.0')
+
+summary('Build type',     get_option('buildtype'), section : 'Build Summary')
+summary('Install prefix', get_option('prefix'),    section : 'Build Summary')
 
 # After increasing the minimum-required meson version, make the following
 # improvements:
 #
-# - 0.53.0 - use summary() to communicate setup result
 # - 0.55.0 - subproject wraps are automatically promoted to fallbacks,
 #            stop using: "fallback : ['foo', 'foo_dep']" for dependencies
 # - 0.56.0 - use meson.current_source_dir() in unit tests

--- a/meson.build
+++ b/meson.build
@@ -192,6 +192,7 @@ endif
 
 if get_option('use_fluidsynth')
   fluid_dep = dependency('fluidsynth', version : '>= 2.0.0',
+                         fallback : ['fluidsynth', 'fluidsynth_dep'],
                          not_found_message : msg.format('use_fluidsynth'))
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,36 +1,22 @@
-option('use_sdl2_net',
-       type : 'boolean',
-       value : true,
+option('use_sdl2_net', type : 'boolean', value : true,
        description : 'Enable networking features via SDL2_net (modem, ipx)')
 
-option('use_opengl',
-       type : 'boolean',
-       value : true,
+option('use_opengl', type : 'boolean', value : true,
        description : 'Enable OpenGL support')
 
-option('use_fluidsynth',
-       type : 'boolean',
-       value : true,
+option('use_fluidsynth', type : 'boolean', value : true,
        description : 'Enable built-in MIDI support via FluidSynth')
 
-option('use_mt32emu',
-       type : 'boolean',
-       value : true,
+option('use_mt32emu', type : 'boolean', value : true,
        description : 'Enable built-in MT-32 emulation support')
 
-option('use_png',
-       type : 'boolean',
-       value : true,
+option('use_png', type : 'boolean', value : true,
        description : 'Enable saving screenshots in .png format')
 
-option('use_pcap',
-       type : 'boolean',
-       value : false,
+option('use_pcap', type : 'boolean', value : false,
        description : 'Enable ethernet support (NE2000 emulator) using libpcap')
 
-option('use_slirp',
-       type : 'boolean',
-       value : false,
+option('use_slirp', type : 'boolean', value : false,
        description : 'Enable ethernet support (NE2000 emulator) using libslirp')
 
 # This option exists only for rare situations when Linux developer cannot
@@ -38,22 +24,16 @@ option('use_slirp',
 #
 # 'auto' translates to 'true' on Linux systems and 'false' everywhere else.
 #
-option('use_alsa',
-       type : 'combo',
-       choices : ['auto', 'true', 'false'],
-       value : 'auto',
+option('use_alsa', type : 'combo',
+       choices : ['auto', 'true', 'false'], value : 'auto',
        description : 'Enable ALSA MIDI support')
 
-option('enable_debugger',
-       type : 'combo',
-       choices : ['normal', 'heavy', 'none'],
-       value : 'none',
+option('enable_debugger', type : 'combo',
+       choices : ['normal', 'heavy', 'none'], value : 'none',
        description : 'Build emulator with internal debugger feature.')
 
-option('dynamic_core',
-       type : 'combo',
-       choices : ['auto', 'dyn-x86', 'dynrec', 'none'],
-       value : 'auto',
+option('dynamic_core', type : 'combo',
+       choices : ['auto', 'dyn-x86', 'dynrec', 'none'], value : 'auto',
        description : 'Select the dynamic core implementation.')
 
 # Use this option for selectively switching dependencies to look for static
@@ -65,13 +45,9 @@ option('dynamic_core',
 # This is NOT guaranteed to work - the end results will vary depending on your
 # OS, installed libraries, and dependencies of those libraries.
 #
-option('try_static_libs',
-       type : 'array',
-       choices : ['opusfile', 'png', 'sdl2', 'sdl2_net'],
-       value : [],
+option('try_static_libs', type : 'array',
+       choices : ['opusfile', 'png', 'sdl2', 'sdl2_net'], value : [],
        description : 'Attempt to statically link selected libraries.')
 
-option('unit_tests',
-       type : 'feature',
-       value : 'auto',
+option('unit_tests', type : 'feature', value : 'auto',
        description : 'Build unit tests. Auto skips for release builds.')

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -38,13 +38,18 @@ foreach line : core_selection
 endforeach
 
 if conf_data.has('C_DYNAMIC_X86')
-  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) ' +
-          'for ' + conf_data.get('C_TARGETCPU'))
+  message('Building x86/x86_64-optimized dynamic core (dyn-x86) for ' +
+          conf_data.get('C_TARGETCPU'))
+  summary('Dynamic core', 'dyn-x86 (optimized for x86/x86_64)',
+          section : 'Emulator Features')
 elif conf_data.has('C_DYNREC')
-  message('Building dynamic core (dynrec) ' +
-          'for ' + conf_data.get('C_TARGETCPU'))
+  message('Building generic dynamic core (dynrec) for ' +
+          conf_data.get('C_TARGETCPU'))
+  summary('Dynamic core', 'dynrec (generic for ' + host_machine.cpu_family() + ')',
+          section : 'Emulator Features')
 else
   warning('Building without dynamic core support')
+  summary('Dynamic core', 'disabled', section : 'Emulator Features')
 endif
 
 message('Building for @0@-endian architecture'.format(host_machine.endian()))

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,3 +1,4 @@
 googletest-release-*
 munt-libmt32emu*
+fluidsynth-*
 packagecache

--- a/subprojects/fluidsynth.wrap
+++ b/subprojects/fluidsynth.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = fluidsynth-2.1.7
+source_url = https://github.com/FluidSynth/fluidsynth/archive/v2.1.7.tar.gz
+source_filename = fluidsynth-2.1.7.tar.gz
+source_hash = 365a1c0982efcaff724a7b05d26ce1db76bc7435aa4c239df61cbc87f04b6c90
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/fluidsynth/2.1.7/1/get_zip
+patch_filename = fluidsynth-2.1.7-1-wrap.zip
+patch_hash = aaaf2f70dfc0a4803cdd9ebc56b36dd66eb3ab990ef9f433052bb52c1e71ee6e
+
+[provide]
+fluidsynth = fluidsynth_dep
+


### PR DESCRIPTION
This way we can have clean Meson build with FluidSynth lib linked statically - which is relevant for macOS release builds, our Linux release builds, and platforms that do not have FluidSynth available yet (such as Raspberry Pi OS).

Draft only, because wrap is not in WrapDB yet: https://github.com/mesonbuild/fluidsynth/pull/2