### PR TITLE
Add a delay between AUTOTYPE key down and up events

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1260,7 +1260,9 @@ class Typer {
 					for (auto &event : *m_events) {
 						if (bind_name == event->GetName()) {
 							found = true;
-							MAPPER_TriggerEvent(event, true);
+							event->Active(true);
+							std::this_thread::sleep_for(std::chrono::milliseconds(50));
+							event->Active(false);
 							break;
 						}
 					}


### PR DESCRIPTION
Fixes games that don't currently respond well to AUTOTYPE, such as Astérix & Obelix, Crusader: No Remorse, and KGB Conspiracy.

Thank you @maxigaz for reported the issue with detailed reproduction steps and @Wengier for the fix.

Tested with KGB Conspiracy configured w/ sound-blaster output, per @grapeli's recommended 26,800 cycles and similar scancode timings.  Thanks @grapeli.  

`autotype -w 2.8 -p 0.8 esc , enter , , , enter enter`

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/940