### PR TITLE
Improve listing of available MIDI devices/user options (part 2)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 267
+            max_warnings: 268
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1969
+            max_warnings: 1970
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -34,6 +34,7 @@
 #include "mapper.h"
 #include "midi_handler.h"
 #include "pic.h"
+#include "programs.h"
 #include "setup.h"
 #include "support.h"
 #include "timer.h"
@@ -285,10 +286,23 @@ getdefault:
 	}
 };
 
-void MIDI_ListAll(Program *output_handler)
+void MIDI_ListAll(Program *caller)
 {
-	if (midi.handler)
-		midi.handler->ListAll(output_handler);
+	for (auto *handler = handler_list; handler; handler = handler->next) {
+		const std::string name = handler->GetName();
+		if (name == "none")
+			continue;
+
+		caller->WriteOut("%s:\n", name.c_str());
+
+		const auto err = handler->ListAll(caller);
+		if (err == MIDI_RC::ERR_DEVICE_NOT_CONFIGURED)
+			caller->WriteOut("  device not configured\n");
+		if (err == MIDI_RC::ERR_DEVICE_LIST_NOT_SUPPORTED)
+			caller->WriteOut("  listing not supported\n");
+
+		caller->WriteOut("\n"); // additional newline to separate devices
+	}
 }
 
 static MIDI* test;

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -42,7 +42,7 @@ void for_each_alsa_seq_port(port_action_t action)
 	// We can't reuse the sequencer from midi handler, as the function might
 	// be called before that sequencer is created.
 	snd_seq_t *seq = nullptr;
-	if (snd_seq_open(&seq, "hw", SND_SEQ_OPEN_OUTPUT, 0) != 0) {
+	if (snd_seq_open(&seq, "default", SND_SEQ_OPEN_OUTPUT, 0) != 0) {
 		LOG_MSG("ALSA: Error: Can't open MIDI sequencer");
 		return;
 	}
@@ -195,7 +195,7 @@ bool MidiHandler_alsa::Open(const char *conf)
 		return false;
 	}
 
-	if (snd_seq_open(&seq_handle, "hw", SND_SEQ_OPEN_OUTPUT, 0) != 0) {
+	if (snd_seq_open(&seq_handle, "default", SND_SEQ_OPEN_OUTPUT, 0) != 0) {
 		LOG_MSG("ALSA: Can't open sequencer");
 		return false;
 	}

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -54,6 +54,7 @@ public:
 	void Close() override;
 	void PlayMsg(const uint8_t *msg) override;
 	void PlaySysex(uint8_t *sysex, size_t len) override;
+	MIDI_RC ListAll(Program *caller) override;
 };
 
 #endif // C_ALSA

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -26,9 +26,6 @@
 
 #if C_ALSA
 
-// TODO Old ALSA API is unsafe; switch to new API.
-#define ALSA_PCM_OLD_HW_PARAMS_API
-#define ALSA_PCM_OLD_SW_PARAMS_API
 #include <alsa/asoundlib.h>
 
 class MidiHandler_alsa : public MidiHandler {

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -154,7 +154,7 @@ public:
 		MIDISend(m_port,m_endpoint,packetList);
 	}
 
-	void ListAll(Program *base) override
+	MIDI_RC ListAll(Program *caller) override
 	{
 		Bitu numDests = MIDIGetNumberOfDestinations();
 		for(Bitu i = 0; i < numDests; i++){
@@ -163,11 +163,14 @@ public:
 			CFStringRef midiname = 0;
 			if(MIDIObjectGetStringProperty(dest, kMIDIPropertyDisplayName, &midiname) == noErr) {
 				const char * s = CFStringGetCStringPtr(midiname, kCFStringEncodingMacRoman);
-				if (s) base->WriteOut("%02d\t%s\n",i,s);
+				if (s) {
+					caller->WriteOut("  %02d - %s\n", i, s);
+				}
 			}
 			//This is for EndPoints created by us.
 			//MIDIEndpointDispose(dest);
 		}
+		return MIDI_RC::OK;
 	}
 };
 

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -47,6 +47,7 @@ public:
 	void Close() override;
 	void PlayMsg(const uint8_t *msg) override;
 	void PlaySysex(uint8_t *sysex, size_t len) override;
+	MIDI_RC ListAll(Program *caller) override;
 
 private:
 	void MixerCallBack(uint16_t requested_frames);

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -26,6 +26,12 @@
 
 #include <cstdint>
 
+enum class MIDI_RC : int {
+	OK = 0,
+	ERR_DEVICE_NOT_CONFIGURED = -1,
+	ERR_DEVICE_LIST_NOT_SUPPORTED = -2,
+};
+
 class MidiHandler {
 public:
 	MidiHandler();
@@ -67,7 +73,10 @@ public:
 
 	virtual void PlaySysex(MAYBE_UNUSED uint8_t *sysex, MAYBE_UNUSED size_t len) {}
 
-	virtual void ListAll(MAYBE_UNUSED Program *base) {}
+	virtual MIDI_RC ListAll(Program *)
+	{
+		return MIDI_RC::ERR_DEVICE_LIST_NOT_SUPPORTED;
+	}
 
 	MidiHandler *next;
 };

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -123,14 +123,15 @@ public:
 		}
 	}
 
-	void ListAll(Program *base) override
+	MIDI_RC ListAll(Program *caller) override
 	{
 		unsigned int total = midiOutGetNumDevs();
 		for(unsigned int i = 0;i < total;i++) {
 			MIDIOUTCAPS mididev;
 			midiOutGetDevCaps(i, &mididev, sizeof(MIDIOUTCAPS));
-			base->WriteOut("%2d\t \"%s\"\n",i,mididev.szPname);
+			caller->WriteOut("  %2d - \"%s\"\n", i, mididev.szPname);
 		}
+		return MIDI_RC::OK;
 	}
 };
 


### PR DESCRIPTION
The work is not finished yet, but it's a significant improvement to what was before.

MIDI port listing happens when user runs: `mixer /listmidi`.

With previous implementation it worked only on Windows and macOS, and only if default MIDI backed was selected. With new implementation, `/listmidi` will show all available user options.

- FluidSynth - list all found SoundFont files (I think future PR will improve it a little bit). Some formatting is performed to make sure description fits into a single line (as path might be quite long).
- ALSA - list all MIDI sequencer ports (In future PR I'll add filtering of ports, so we display only the usable ones). No additional formatting is done, as sequencer names and port names tend to be brief and fit into 80 columns nicely.
- Windows/macOS backends - stays as it is except formatting is slightly adjusted (and function interface changed).

@kcgen  I am not going to implement MT-32 listing support - feel free to give it a try after this PR will be merged.