### PR TITLE
Fix unused variable warnings (SoftLimiter and Envelope)

### DIFF
--- a/include/envelope.h
+++ b/include/envelope.h
@@ -95,7 +95,7 @@ private:
 	using process_f = std::function<void(Envelope &, bool, bool, intptr_t[], intptr_t[])>;
 	process_f process = &Envelope::Apply;
 
-	const char* channel_name = nullptr;
+	const char *channel_name = nullptr;
 	uint32_t expire_after_frames = 0u; // Stop enveloping when this many
 	                                   // frames have been processed.
 	uint32_t frames_done = 0u; // A tally of processed frames.

--- a/include/soft_limiter.h
+++ b/include/soft_limiter.h
@@ -69,14 +69,11 @@ needed; typically ranging from 10's of milliseconds to low-hundreds for large >
 Use:
 
 Instantiate the Soft Limiter object with the name of the channel that's
-being operated on and the maximum number of frames you intend to pass into
-the limiter in any given pass.
-
-For example:
-  SoftLimiter limiter("channel name", max_frames);
+being operated on, for example:
+  SoftLimiter limiter("channel name");
 
 You can then repeatedly call:
-  auto out = limiter.Process(in, num_frames);
+  limiter.Process(in, num_frames, out);
 
 Where:
  - 'in' is a std::vector<float>
@@ -102,7 +99,7 @@ public:
 	SoftLimiter(const SoftLimiter &) = delete;
 	SoftLimiter &operator=(const SoftLimiter &) = delete;
 
-	SoftLimiter(const std::string &name, uint16_t max_frames);
+	SoftLimiter(const std::string &name);
 
 	void Process(const std::vector<float> &in,
 	             uint16_t req_frames,
@@ -157,7 +154,6 @@ private:
 	float range_multiplier = 1.0f;
 	int limited_tally = 0;
 	int non_limited_tally = 0;
-	const uint16_t max_samples = 0;
 };
 
 #endif

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -23,9 +23,8 @@
 
 #include "support.h"
 
-Envelope::Envelope(const char* name) :
-channel_name(name) {
-}
+Envelope::Envelope(const char *name) : channel_name(name)
+{}
 
 void Envelope::Reactivate()
 {
@@ -104,6 +103,7 @@ void Envelope::Apply(const bool is_stereo,
 	// Should we deactivate the envelope?
 	if (++frames_done > expire_after_frames || edge >= edge_limit) {
 		process = &Envelope::Skip;
+		(void)channel_name; // MAYBE_UNUSED in release builds
 		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %u",
 		              channel_name, frames_done, edge);
 	}

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -45,10 +45,6 @@
 // AdLib emulation state constant
 constexpr uint8_t ADLIB_CMD_DEFAULT = 85u;
 
-// Amplitude level constants
-constexpr float AUDIO_SAMPLE_MAX = static_cast<float>(MAX_AUDIO);
-constexpr float AUDIO_SAMPLE_MIN = static_cast<float>(MIN_AUDIO);
-
 // Buffer and memory constants
 constexpr int BUFFER_FRAMES = 48;
 constexpr uint32_t RAM_SIZE = 1024 * 1024;        // 1 MiB
@@ -423,7 +419,8 @@ float Voice::GetSample(const ram_array_t &ram) noexcept
 		sample += (next_sample - sample) *
 		          static_cast<float>(fraction) * WAVE_WIDTH_INV;
 	}
-	assert(sample >= AUDIO_SAMPLE_MIN && sample <= AUDIO_SAMPLE_MAX);
+	assert(sample >= static_cast<float>(MIN_AUDIO) &&
+	       sample <= static_cast<float>(MAX_AUDIO));
 	return sample;
 }
 
@@ -586,7 +583,7 @@ void Voice::WriteWaveRate(uint16_t val) noexcept
 Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
         : render_buffer(BUFFER_FRAMES * 2), // 2 samples/frame, L & R channels
           play_buffer(BUFFER_FRAMES * 2),   // 2 samples/frame, L & R channels
-          soft_limiter("GUS", BUFFER_FRAMES),
+          soft_limiter("GUS"),
           port_base(port - 0x200u),
           dma2(dma),
           irq1(irq),

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -177,7 +177,7 @@ static std::string find_sf_file(const std::string &name)
 }
 
 MidiHandlerFluidsynth::MidiHandlerFluidsynth()
-        : soft_limiter("FSYNTH", FRAMES_PER_BUFFER),
+        : soft_limiter("FSYNTH"),
           keep_rendering(false)
 {}
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -241,7 +241,7 @@ static mt32emu_report_handler_i get_report_handler_interface()
 }
 
 MidiHandler_mt32::MidiHandler_mt32()
-        : soft_limiter("MT32", FRAMES_PER_BUFFER),
+        : soft_limiter("MT32"),
           keep_rendering(false)
 {}
 

--- a/src/misc/soft_limiter.cpp
+++ b/src/misc/soft_limiter.cpp
@@ -31,9 +31,8 @@ constexpr static auto relaxed = std::memory_order_relaxed;
 
 constexpr static float bounds = static_cast<float>(INT16_MAX - 1);
 
-SoftLimiter::SoftLimiter(const std::string &name, const uint16_t max_frames)
-        : channel_name(name),
-          max_samples(max_frames * 2)
+SoftLimiter::SoftLimiter(const std::string &name)
+        : channel_name(name)
 {
 	UpdateLevels({1, 1}, 1); // default to unity (ie: no) scaling
 	limited_tally = 0;
@@ -53,15 +52,14 @@ void SoftLimiter::Process(const std::vector<float> &in,
                           const uint16_t frames,
                           std::vector<int16_t> &out) noexcept
 {
-	// Make sure chunk sizes aren' too big or latent
+	// Make sure chunk sizes aren't too big or latent
 	assertm(frames > 0, "need some quantity of frames");
 	assertm(frames <= 16384, "consider using smaller sequence chunks");
 
 	// Make sure the incoming vector has at least the requested frames
 	const uint16_t samples = frames * 2; // left and right channels
-	assert(samples <= max_samples);
 	assert(in.size() >= samples);
-	assert(out.size() >= frames);
+	assert(out.size() >= samples);
 
 	auto precross_peak_pos_left = in.end();
 	auto precross_peak_pos_right = in.end();

--- a/tests/soft_limiter.cpp
+++ b/tests/soft_limiter.cpp
@@ -27,7 +27,7 @@ namespace {
 TEST(SoftLimiter, InboundsProcessAllFrames)
 {
 	constexpr int frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 
 	std::vector<int16_t> out(frames * 2);
@@ -39,7 +39,7 @@ TEST(SoftLimiter, InboundsProcessAllFrames)
 TEST(SoftLimiter, InboundsProcessPartialFrames)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 
 	std::vector<int16_t> out(frames * 2);
@@ -52,7 +52,7 @@ TEST(SoftLimiter, InboundsProcessPartialFrames)
 TEST(SoftLimiter, InboundsProcessTooManyFrames)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 	std::vector<int16_t> out(frames * 2);
 	EXPECT_DEBUG_DEATH({ limiter.Process(in, frames + 1, out); }, "");
@@ -61,7 +61,7 @@ TEST(SoftLimiter, InboundsProcessTooManyFrames)
 TEST(SoftLimiter, OutOfBoundsLeftChannel)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-8.1f,    32000.0f, 65535.0f,
 	                            32000.0f, 4.1f,     32000.0f};
 
@@ -74,7 +74,7 @@ TEST(SoftLimiter, OutOfBoundsLeftChannel)
 TEST(SoftLimiter, OutOfBoundsRightChannel)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{32000.0f, -3.1f,    32000.0f,
 	                            98304.1f, 32000.0f, 6.1f};
 
@@ -87,7 +87,7 @@ TEST(SoftLimiter, OutOfBoundsRightChannel)
 TEST(SoftLimiter, OutboundsBothChannelsPositive)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-8.1f,    -3.1f, 65535.0f,
 	                            98304.1f, 4.1f,  6.1f};
 
@@ -100,7 +100,7 @@ TEST(SoftLimiter, OutboundsBothChannelsPositive)
 TEST(SoftLimiter, OutboundsBothChannelsNegative)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-8.1f,     -3.1f, -65535.0f,
 	                            -98304.1f, 4.1f,  6.1f};
 
@@ -113,7 +113,7 @@ TEST(SoftLimiter, OutboundsBothChannelsNegative)
 TEST(SoftLimiter, OutboundsBothChannelsMixed)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{40000.0f,  -40000.0f, 65534.0f,
 	                            -98301.0f, 40000.0f,  -40000.0f};
 
@@ -127,7 +127,7 @@ TEST(SoftLimiter, OutboundsBothChannelsMixed)
 TEST(SoftLimiter, OutboundsBigOneReleaseStep)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	std::vector<float> in{-60000.0f, 80000.0f};
 	std::vector<int16_t> out(frames * 2);
 	limiter.Process(in, 1, out);
@@ -143,7 +143,7 @@ TEST(SoftLimiter, OutboundsBigOneReleaseStep)
 TEST(SoftLimiter, OutboundsBig600ReleaseSteps)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	std::vector<float> in{-60000.0f, 80000.0f};
 	std::vector<int16_t> out(frames * 2);
 
@@ -159,7 +159,7 @@ TEST(SoftLimiter, OutboundsBig600ReleaseSteps)
 TEST(SoftLimiter, OutboundsSmallTwoReleaseSteps)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	std::vector<float> in{-32800.0f, 32800.0f};
 	std::vector<int16_t> out(frames * 2);
 	for (int i = 0; i < 2; ++i) {
@@ -174,7 +174,7 @@ TEST(SoftLimiter, OutboundsSmallTwoReleaseSteps)
 TEST(SoftLimiter, OutboundsSmallTenReleaseSteps)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	std::vector<float> in{-32800.0f, 32800.0f};
 	std::vector<int16_t> out(frames * 2);
 
@@ -190,7 +190,7 @@ TEST(SoftLimiter, OutboundsSmallTenReleaseSteps)
 TEST(SoftLimiter, OutboundsPolyJoinPositive)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 
 	const std::vector<float> first_chunk{18000, 18000, 20000,
 	                                     20000, 22000, 22000};
@@ -212,7 +212,7 @@ TEST(SoftLimiter, OutboundsPolyJoinPositive)
 TEST(SoftLimiter, OutboundsPolyJoinNegative)
 {
 	const auto frames = 3;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 
 	const std::vector<float> first_chunk{-18000, -18000, -20000,
 	                                     -20000, -22000, -22000};
@@ -234,7 +234,7 @@ TEST(SoftLimiter, OutboundsPolyJoinNegative)
 TEST(SoftLimiter, OutboundsJoinWithZeroCross)
 {
 	const auto frames = 6;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 
 	const std::vector<float> first_chunk{-5000, 1000, -3000, 1000,
 	                                     -1000, 1000, 0,     1000,
@@ -266,7 +266,7 @@ TEST(SoftLimiter, OutboundsJoinWithZeroCross)
 TEST(SoftLimiter, ScaleAttenuate)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-30000.1f, 30000.0f};
 	std::vector<int16_t> out(frames * 2);
 	limiter.Process(in, frames, out);
@@ -286,7 +286,7 @@ TEST(SoftLimiter, ScaleAttenuate)
 TEST(SoftLimiter, ScaleAmplify)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-10000.1f, 10000.0f};
 	std::vector<int16_t> out(frames * 2);
 	limiter.Process(in, frames, out);
@@ -306,7 +306,7 @@ TEST(SoftLimiter, ScaleAmplify)
 TEST(SoftLimiter, RangeMultiply)
 {
 	const auto frames = 1;
-	SoftLimiter limiter("test-channel", frames);
+	SoftLimiter limiter("test-channel");
 
 	AudioFrame levels = {1, 1};
 	const float range_multiplier = 2;


### PR DESCRIPTION
Noticed in Clang release builds, such as here: https://github.com/dosbox-staging/dosbox-staging/issues/952#issuecomment-803615015
