### PR TITLE
Fixup trailing string cutoff in FluidSynth

### DIFF
--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -465,13 +465,9 @@ std::string format_sf2_line(const std::string &path, const std::string &name)
 
 	// The description was too long and got trimmed; place three dots in
 	// the end to make it clear to the user.
-	assert(line.size() > 4);
-	auto it = line.end();
-	assert(*it == '\0');
-	*(--it) = '\n';
-	*(--it) = '.';
-	*(--it) = '.';
-	*(--it) = '.';
+	const std::string cutoff = "...\n";
+	assert(line.size() > cutoff.size());
+	line.replace(line.end() - cutoff.size(), line.end(), cutoff);
 	return line;
 }
 


### PR DESCRIPTION
(Fixes minor issue noted here: https://github.com/dosbox-staging/dosbox-staging/pull/949/files#r598362505)

Sorry for not catching this in the review @dreamer!