### PR TITLE
ALSA MIDI improvements: list filtering, autoconnect (part 3)

### DIFF
--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -302,9 +302,15 @@ MIDI_RC MidiHandler_alsa::ListAll(Program *caller)
 {
 	auto print_port = [caller](auto *client_info, auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
-		caller->WriteOut("  %3d:%d - %s - %s\n", addr->client, addr->port,
-		                 snd_seq_client_info_get_name(client_info),
-		                 snd_seq_port_info_get_name(port_info));
+		const unsigned int type = snd_seq_port_info_get_type(port_info);
+		const unsigned int caps = snd_seq_port_info_get_capability(port_info);
+
+		if ((type & SND_SEQ_PORT_TYPE_SYNTHESIZER) || port_is_writable(caps)) {
+			caller->WriteOut("  %3d:%d - %s - %s\n", addr->client,
+			                 addr->port,
+			                 snd_seq_client_info_get_name(client_info),
+			                 snd_seq_port_info_get_name(port_info));
+		}
 	};
 	for_each_alsa_seq_port(print_port);
 	return MIDI_RC::OK;

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -209,16 +209,16 @@ bool MidiHandler_alsa::Open(const char *conf)
 	}
 
 	if (seq_client != SND_SEQ_ADDRESS_SUBSCRIBERS) {
-		if (snd_seq_connect_to(seq_handle, my_port, seq_client, seq_port) < 0) {
-			snd_seq_close(seq_handle);
-			LOG_MSG("ALSA: Can't connect to MIDI port %d:%d",
-			        seq_client, seq_port);
-			return false;
+		if (snd_seq_connect_to(seq_handle, my_port, seq_client,
+		                       seq_port) == 0) {
+			LOG_MSG("ALSA: Connected to port %d:%d", seq_client, seq_port);
+			return true;
 		}
 	}
 
-	LOG_MSG("ALSA: Connected to port %d:%d", seq_client, seq_port);
-	return true;
+	snd_seq_close(seq_handle);
+	LOG_MSG("ALSA: Can't connect to MIDI port %d:%d", seq_client, seq_port);
+	return false;
 }
 
 MIDI_RC MidiHandler_alsa::ListAll(Program *caller)

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -290,7 +290,13 @@ bool MidiHandler_alsa::Open(const char *conf)
 	if (seq_client != SND_SEQ_ADDRESS_SUBSCRIBERS) {
 		if (snd_seq_connect_to(seq_handle, my_port, seq_client,
 		                       seq_port) == 0) {
-			LOG_MSG("ALSA: Connected to MIDI port %d:%d", seq_client, seq_port);
+			snd_seq_client_info_t *info = nullptr;
+			snd_seq_client_info_malloc(&info);
+			assert(info);
+			snd_seq_get_any_client_info(seq_handle, seq_client, info);
+			LOG_MSG("ALSA: Connected to MIDI port %d:%d - %s", seq_client,
+			        seq_port, snd_seq_client_info_get_name(info));
+			snd_seq_client_info_free(info);
 			return true;
 		}
 	}

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -180,6 +180,8 @@ void MidiHandler_alsa::PlayMsg(const uint8_t *msg)
 
 void MidiHandler_alsa::Close()
 {
+	seq_client = 0;
+	seq_port = 0;
 	if (seq_handle) {
 		HaltSequence();
 		snd_seq_close(seq_handle);

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -177,7 +177,6 @@ void MidiHandler_alsa::Close()
 bool MidiHandler_alsa::Open(const char *conf)
 {
 	char var[10];
-	unsigned int caps;
 
 	// try to use port specified in config file
 	if (!is_empty(conf)) {
@@ -194,13 +193,14 @@ bool MidiHandler_alsa::Open(const char *conf)
 	}
 
 	my_client = snd_seq_client_id(seq_handle);
-	snd_seq_set_client_name(seq_handle, "DOSBOX");
+	snd_seq_set_client_name(seq_handle, "DOSBox Staging");
 
-	caps = SND_SEQ_PORT_CAP_READ;
+	unsigned int caps = SND_SEQ_PORT_CAP_READ;
 	if (seq_client == SND_SEQ_ADDRESS_SUBSCRIBERS)
 		caps = ~SND_SEQ_PORT_CAP_SUBS_READ;
 
-	my_port = snd_seq_create_simple_port(seq_handle, "DOSBOX", caps,
+	my_port = snd_seq_create_simple_port(seq_handle,
+	                                     "Virtual MPU-401 output", caps,
 	                                     SND_SEQ_PORT_TYPE_MIDI_GENERIC | SND_SEQ_PORT_TYPE_APPLICATION);
 	if (my_port < 0) {
 		snd_seq_close(seq_handle);

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -28,14 +28,17 @@
 
 #include <alsa/asoundlib.h>
 
+struct alsa_address {
+	int client;
+	int port;
+};
+
 class MidiHandler_alsa : public MidiHandler {
 private:
 	snd_seq_event_t ev = {};
 	snd_seq_t *seq_handle = nullptr;
-	int seq_client = 0;
-	int seq_port = 0;
-	int my_client = 0;
-	int my_port = 0;
+	alsa_address seq = {-1, -1}; // address of input port we're connected to
+	int output_port = 0;
 
 	void send_event(int do_flush);
 	bool parse_addr(const char *arg, int *client, int *port);


### PR DESCRIPTION
Follow up to #949 - I recommend reviewing commits one-by-one.

- Filter input ports shown in `mixer /listmidi` to show only the usable ones
- Auto-connect to available ALSA port if user didn't pick a specific one (tested on external FluidSynth and TiMidity++, should work for hardware MIDI and soundcards as well)

Further improvements to MIDI listing in upcoming part 4.