### PR TITLE
MIDI listing improvements (part 4)

### DIFF
--- a/README
+++ b/README
@@ -795,13 +795,13 @@ MIXER
      of the volume levels.
 
   /LISTMIDI
-     List all available MIDI devices on your PC.  To select the specific device,
-     change the line 'midiconfig=' in the [midi] section of the configuration
-     file to 'midiconfig=<id>' or 'midiconfig=<substring of device name>'.
+     Lists your PC's MIDI devices. To use one, set the 'midiconfig' attribute 
+     in your configuration file to the device's numerical ID or any part of
+     its textual name. For example:
 
      Examples:
 
-     (any OS)  midiconfig = str    # matches case-insensitive substring of name
+     (any OS)  midiconfig = name   # matches any part of name, case-insensitive
      (Linux)   midiconfig = 128:0  # connects to specific port
      (Windows) midiconfig = 2      # connects to specific port
 

--- a/README
+++ b/README
@@ -795,15 +795,15 @@ MIXER
      of the volume levels.
 
   /LISTMIDI
-     In Windows lists the available midi devices on your PC. To select a device
-     other than the Windows default midi-mapper, change the line 'midiconfig='
-     in the [midi] section of the configuration file to 'midiconfig=id', where
-     'id' is the number for the device as listed by LISTMIDI. eg. midiconfig=2
+     List all available MIDI devices on your PC.  To select the specific device,
+     change the line 'midiconfig=' in the [midi] section of the configuration
+     file to 'midiconfig=<id>' or 'midiconfig=<substring of device name>'.
 
-     In Linux this option doesn't work, but you get similar results by using
-     'pmidi -l' in console. Then change the line 'midiconfig=' to
-     'midiconfig=port', where 'port' is the port for the device as listed by
-     'pmidi -l'. eg. midiconfig=128:0
+     Examples:
+
+     (any OS)  midiconfig = str    # matches case-insensitive substring of name
+     (Linux)   midiconfig = 128:0  # connects to specific port
+     (Windows) midiconfig = 2      # connects to specific port
 
 
 IMGMOUNT

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -90,9 +90,8 @@ void MidiHandler_alsa::send_event(int do_flush)
 		snd_seq_drain_output(seq_handle);
 }
 
-bool MidiHandler_alsa::parse_addr(const char *arg, int *client, int *port)
+static bool parse_addr(const std::string &in, int *client, int *port)
 {
-	std::string in(arg);
 	if (in.empty())
 		return false;
 
@@ -191,7 +190,7 @@ static bool port_name_matches(const std::string &pattern,
 	if (pattern.empty())
 		return true;
 
-	char port_name[40];
+	char port_name[80];
 	safe_sprintf(port_name, "%s - %s", snd_seq_client_info_get_name(client_info),
 	             snd_seq_port_info_get_name(port_info));
 
@@ -254,20 +253,19 @@ static alsa_address find_seq_input_port(const std::string &pattern)
 
 bool MidiHandler_alsa::Open(const char *conf)
 {
+	assert(conf != nullptr);
 	seq = {-1, -1};
-
-	char var[40];
 
 	DEBUG_LOG_MSG("ALSA: Attempting connection to: '%s'", conf);
 
 	// Try to use port specified in config; if port is not configured,
 	// then attempt to connect to the newest capable port.
 	//
-	safe_strcpy(var, conf);
-	const bool use_specific_addr = parse_addr(var, &seq.client, &seq.port);
+	const std::string conf_str = conf;
+	const bool use_specific_addr = parse_addr(conf_str, &seq.client, &seq.port);
 
 	if (!use_specific_addr) {
-		const auto found_addr = find_seq_input_port(var);
+		const auto found_addr = find_seq_input_port(conf_str);
 		if (found_addr.client > 0) {
 			seq = found_addr;
 		}

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -235,12 +235,16 @@ static alsa_address find_seq_input_port(const std::string &pattern)
 	                                             auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
 		const auto caps = snd_seq_port_info_get_capability(port_info);
-		const auto client_type = snd_seq_client_info_get_type(client_info);
-
-		const bool is_user_client = (client_type == SND_SEQ_USER_CLIENT);
 		const bool is_new_client = (addr->client != seq_addr.client);
-		const bool match = port_name_matches(pattern, client_info, port_info);
-		const bool is_candidate = (pattern.empty() ? is_user_client : match);
+
+		bool is_candidate = false;
+		if (pattern.empty())
+			is_candidate = (snd_seq_client_info_get_type(client_info) ==
+			                SND_SEQ_USER_CLIENT);
+		else
+			is_candidate = port_name_matches(pattern, client_info,
+			                                 port_info);
+
 		if (is_new_client && is_candidate && port_is_writable(caps)) {
 			seq_addr.client = addr->client;
 			seq_addr.port = addr->port;

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -24,9 +24,11 @@
 #if C_ALSA
 
 #include <cassert>
-#include <string>
-#include <sstream>
+#include <cstring>
 #include <functional>
+#include <regex>
+#include <sstream>
+#include <string>
 
 #include "logging.h"
 #include "programs.h"
@@ -182,18 +184,33 @@ void MidiHandler_alsa::Close()
 	}
 }
 
-static alsa_address find_seq_input_port()
+static bool port_name_matches(const std::string &pattern,
+                              snd_seq_client_info_t *client_info,
+                              snd_seq_port_info_t *port_info)
+{
+	if (pattern.empty())
+		return true;
+
+	char port_name[40];
+	safe_sprintf(port_name, "%s - %s", snd_seq_client_info_get_name(client_info),
+	             snd_seq_port_info_get_name(port_info));
+
+	return (strcasestr(port_name, pattern.c_str()) != nullptr);
+}
+
+static alsa_address find_seq_input_port(const std::string &pattern)
 {
 	alsa_address seq_addr = {-1, -1};
 
 	// Modern sequencers like FluidSynth indicate that they
 	// are capable of generating sound.
 	//
-	auto find_synth_port = [&seq_addr](MAYBE_UNUSED auto *client_info,
-	                                   auto *port_info) {
+	auto find_synth_port = [&pattern, &seq_addr](auto *client_info,
+	                                             auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
 		const auto port_type = snd_seq_port_info_get_type(port_info);
-		if (port_type & SND_SEQ_PORT_TYPE_SYNTHESIZER) {
+		const bool match = port_name_matches(pattern, client_info, port_info);
+		if (match && (port_type & SND_SEQ_PORT_TYPE_SYNTHESIZER)) {
 			seq_addr.client = addr->client;
 			seq_addr.port = addr->port;
 		}
@@ -215,14 +232,17 @@ static alsa_address find_seq_input_port()
 	// but only first two ones generate sound (even though all 4
 	// ones are marked as writable).
 	//
-	auto find_input_port = [&seq_addr](auto *client_info, auto *port_info) {
+	auto find_input_port = [&pattern, &seq_addr](auto *client_info,
+	                                             auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
 		const auto caps = snd_seq_port_info_get_capability(port_info);
 		const auto client_type = snd_seq_client_info_get_type(client_info);
 
 		const bool is_user_client = (client_type == SND_SEQ_USER_CLIENT);
 		const bool is_new_client = (addr->client != seq_addr.client);
-		if (is_new_client && is_user_client && port_is_writable(caps)) {
+		const bool match = port_name_matches(pattern, client_info, port_info);
+		const bool is_candidate = (pattern.empty() ? is_user_client : match);
+		if (is_new_client && is_candidate && port_is_writable(caps)) {
 			seq_addr.client = addr->client;
 			seq_addr.port = addr->port;
 		}
@@ -236,21 +256,18 @@ bool MidiHandler_alsa::Open(const char *conf)
 {
 	seq = {-1, -1};
 
-	char var[10];
+	char var[40];
 
 	DEBUG_LOG_MSG("ALSA: Attempting connection to: '%s'", conf);
 
 	// Try to use port specified in config; if port is not configured,
 	// then attempt to connect to the newest capable port.
 	//
-	if (!is_empty(conf)) {
-		safe_strcpy(var, conf);
-		if (!parse_addr(var, &seq.client, &seq.port)) {
-			LOG_MSG("ALSA: Invalid alsa port %s", var);
-			return false;
-		}
-	} else {
-		const auto found_addr = find_seq_input_port();
+	safe_strcpy(var, conf);
+	const bool use_specific_addr = parse_addr(var, &seq.client, &seq.port);
+
+	if (!use_specific_addr) {
+		const auto found_addr = find_seq_input_port(var);
 		if (found_addr.client > 0) {
 			seq = found_addr;
 		}

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -41,7 +41,6 @@ private:
 	int output_port = 0;
 
 	void send_event(int do_flush);
-	bool parse_addr(const char *arg, int *client, int *port);
 
 public:
 	MidiHandler_alsa() : MidiHandler() {}

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -63,6 +63,7 @@ private:
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 	channel_t channel{nullptr, MIXER_DelChannel};
+	std::string selected_font = "";
 
 	std::vector<int16_t> play_buffer = {};
 	static constexpr auto num_buffers = 8;


### PR DESCRIPTION
- Highlight selected soundfont the same way ALSA ports are highlighted
- Select ALSA port by matching substring, the same way it works on Windows
- Update documentation in README file