### PR TITLE
Support versioned MT-32 models

### DIFF
--- a/README
+++ b/README
@@ -795,13 +795,13 @@ MIXER
      of the volume levels.
 
   /LISTMIDI
-     List all available MIDI devices on your PC.  To select the specific device,
-     change the line 'midiconfig=' in the [midi] section of the configuration
-     file to 'midiconfig=<id>' or 'midiconfig=<substring of device name>'.
+     Lists your PC's MIDI devices. To use one, set the 'midiconfig' attribute 
+     in your configuration file to the device's numerical ID or any part of
+     its textual name. For example:
 
      Examples:
 
-     (any OS)  midiconfig = str    # matches case-insensitive substring of name
+     (any OS)  midiconfig = name   # matches any part of name, case-insensitive
      (Linux)   midiconfig = 128:0  # connects to specific port
      (Windows) midiconfig = 2      # connects to specific port
 

--- a/README
+++ b/README
@@ -795,15 +795,15 @@ MIXER
      of the volume levels.
 
   /LISTMIDI
-     In Windows lists the available midi devices on your PC. To select a device
-     other than the Windows default midi-mapper, change the line 'midiconfig='
-     in the [midi] section of the configuration file to 'midiconfig=id', where
-     'id' is the number for the device as listed by LISTMIDI. eg. midiconfig=2
+     List all available MIDI devices on your PC.  To select the specific device,
+     change the line 'midiconfig=' in the [midi] section of the configuration
+     file to 'midiconfig=<id>' or 'midiconfig=<substring of device name>'.
 
-     In Linux this option doesn't work, but you get similar results by using
-     'pmidi -l' in console. Then change the line 'midiconfig=' to
-     'midiconfig=port', where 'port' is the port for the device as listed by
-     'pmidi -l'. eg. midiconfig=128:0
+     Examples:
+
+     (any OS)  midiconfig = str    # matches case-insensitive substring of name
+     (Linux)   midiconfig = 128:0  # connects to specific port
+     (Windows) midiconfig = 2      # connects to specific port
 
 
 IMGMOUNT

--- a/src/midi/meson.build
+++ b/src/midi/meson.build
@@ -3,6 +3,7 @@ libmidi_sources = [
   'midi_alsa.cpp',
   'midi_fluidsynth.cpp',
   'midi_mt32.cpp',
+  'midi_lasynth_model.cpp',
   'midi_oss.cpp',
 ]
 

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -90,9 +90,8 @@ void MidiHandler_alsa::send_event(int do_flush)
 		snd_seq_drain_output(seq_handle);
 }
 
-bool MidiHandler_alsa::parse_addr(const char *arg, int *client, int *port)
+static bool parse_addr(const std::string &in, int *client, int *port)
 {
-	std::string in(arg);
 	if (in.empty())
 		return false;
 
@@ -191,7 +190,7 @@ static bool port_name_matches(const std::string &pattern,
 	if (pattern.empty())
 		return true;
 
-	char port_name[40];
+	char port_name[80];
 	safe_sprintf(port_name, "%s - %s", snd_seq_client_info_get_name(client_info),
 	             snd_seq_port_info_get_name(port_info));
 
@@ -254,20 +253,19 @@ static alsa_address find_seq_input_port(const std::string &pattern)
 
 bool MidiHandler_alsa::Open(const char *conf)
 {
+	assert(conf != nullptr);
 	seq = {-1, -1};
-
-	char var[40];
 
 	DEBUG_LOG_MSG("ALSA: Attempting connection to: '%s'", conf);
 
 	// Try to use port specified in config; if port is not configured,
 	// then attempt to connect to the newest capable port.
 	//
-	safe_strcpy(var, conf);
-	const bool use_specific_addr = parse_addr(var, &seq.client, &seq.port);
+	const std::string conf_str = conf;
+	const bool use_specific_addr = parse_addr(conf_str, &seq.client, &seq.port);
 
 	if (!use_specific_addr) {
-		const auto found_addr = find_seq_input_port(var);
+		const auto found_addr = find_seq_input_port(conf_str);
 		if (found_addr.client > 0) {
 			seq = found_addr;
 		}

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -235,12 +235,16 @@ static alsa_address find_seq_input_port(const std::string &pattern)
 	                                             auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
 		const auto caps = snd_seq_port_info_get_capability(port_info);
-		const auto client_type = snd_seq_client_info_get_type(client_info);
-
-		const bool is_user_client = (client_type == SND_SEQ_USER_CLIENT);
 		const bool is_new_client = (addr->client != seq_addr.client);
-		const bool match = port_name_matches(pattern, client_info, port_info);
-		const bool is_candidate = (pattern.empty() ? is_user_client : match);
+
+		bool is_candidate = false;
+		if (pattern.empty())
+			is_candidate = (snd_seq_client_info_get_type(client_info) ==
+			                SND_SEQ_USER_CLIENT);
+		else
+			is_candidate = port_name_matches(pattern, client_info,
+			                                 port_info);
+
 		if (is_new_client && is_candidate && port_is_writable(caps)) {
 			seq_addr.client = addr->client;
 			seq_addr.port = addr->port;

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -24,9 +24,11 @@
 #if C_ALSA
 
 #include <cassert>
-#include <string>
-#include <sstream>
+#include <cstring>
 #include <functional>
+#include <regex>
+#include <sstream>
+#include <string>
 
 #include "logging.h"
 #include "programs.h"
@@ -182,18 +184,33 @@ void MidiHandler_alsa::Close()
 	}
 }
 
-static alsa_address find_seq_input_port()
+static bool port_name_matches(const std::string &pattern,
+                              snd_seq_client_info_t *client_info,
+                              snd_seq_port_info_t *port_info)
+{
+	if (pattern.empty())
+		return true;
+
+	char port_name[40];
+	safe_sprintf(port_name, "%s - %s", snd_seq_client_info_get_name(client_info),
+	             snd_seq_port_info_get_name(port_info));
+
+	return (strcasestr(port_name, pattern.c_str()) != nullptr);
+}
+
+static alsa_address find_seq_input_port(const std::string &pattern)
 {
 	alsa_address seq_addr = {-1, -1};
 
 	// Modern sequencers like FluidSynth indicate that they
 	// are capable of generating sound.
 	//
-	auto find_synth_port = [&seq_addr](MAYBE_UNUSED auto *client_info,
-	                                   auto *port_info) {
+	auto find_synth_port = [&pattern, &seq_addr](auto *client_info,
+	                                             auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
 		const auto port_type = snd_seq_port_info_get_type(port_info);
-		if (port_type & SND_SEQ_PORT_TYPE_SYNTHESIZER) {
+		const bool match = port_name_matches(pattern, client_info, port_info);
+		if (match && (port_type & SND_SEQ_PORT_TYPE_SYNTHESIZER)) {
 			seq_addr.client = addr->client;
 			seq_addr.port = addr->port;
 		}
@@ -215,14 +232,17 @@ static alsa_address find_seq_input_port()
 	// but only first two ones generate sound (even though all 4
 	// ones are marked as writable).
 	//
-	auto find_input_port = [&seq_addr](auto *client_info, auto *port_info) {
+	auto find_input_port = [&pattern, &seq_addr](auto *client_info,
+	                                             auto *port_info) {
 		const auto *addr = snd_seq_port_info_get_addr(port_info);
 		const auto caps = snd_seq_port_info_get_capability(port_info);
 		const auto client_type = snd_seq_client_info_get_type(client_info);
 
 		const bool is_user_client = (client_type == SND_SEQ_USER_CLIENT);
 		const bool is_new_client = (addr->client != seq_addr.client);
-		if (is_new_client && is_user_client && port_is_writable(caps)) {
+		const bool match = port_name_matches(pattern, client_info, port_info);
+		const bool is_candidate = (pattern.empty() ? is_user_client : match);
+		if (is_new_client && is_candidate && port_is_writable(caps)) {
 			seq_addr.client = addr->client;
 			seq_addr.port = addr->port;
 		}
@@ -236,21 +256,18 @@ bool MidiHandler_alsa::Open(const char *conf)
 {
 	seq = {-1, -1};
 
-	char var[10];
+	char var[40];
 
 	DEBUG_LOG_MSG("ALSA: Attempting connection to: '%s'", conf);
 
 	// Try to use port specified in config; if port is not configured,
 	// then attempt to connect to the newest capable port.
 	//
-	if (!is_empty(conf)) {
-		safe_strcpy(var, conf);
-		if (!parse_addr(var, &seq.client, &seq.port)) {
-			LOG_MSG("ALSA: Invalid alsa port %s", var);
-			return false;
-		}
-	} else {
-		const auto found_addr = find_seq_input_port();
+	safe_strcpy(var, conf);
+	const bool use_specific_addr = parse_addr(var, &seq.client, &seq.port);
+
+	if (!use_specific_addr) {
+		const auto found_addr = find_seq_input_port(var);
 		if (found_addr.client > 0) {
 			seq = found_addr;
 		}

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -41,7 +41,6 @@ private:
 	int output_port = 0;
 
 	void send_event(int do_flush);
-	bool parse_addr(const char *arg, int *client, int *port);
 
 public:
 	MidiHandler_alsa() : MidiHandler() {}

--- a/src/midi/midi_lasynth_model.cpp
+++ b/src/midi/midi_lasynth_model.cpp
@@ -1,0 +1,136 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "midi_lasynth_model.h"
+
+#if C_MT32EMU
+
+#include <cassert>
+
+#include "fs_utils.h"
+
+// Construct a new model and ensure both PCM and control ROM(s) are provided
+LASynthModel::LASynthModel(const std::string &rom_name,
+                           const Rom *pcm_rom_full,
+                           const Rom *pcm_rom_l,
+                           const Rom *pcm_rom_h,
+                           const Rom *ctrl_rom_full,
+                           const Rom *ctrl_rom_1,
+                           const Rom *ctrl_rom_2)
+        : name(rom_name),
+          version_pos(SetVersion()),
+          pcm_full(pcm_rom_full),
+          pcm_l(pcm_rom_l),
+          pcm_h(pcm_rom_h),
+          ctrl_full(ctrl_rom_full),
+          ctrl_a(ctrl_rom_1),
+          ctrl_b(ctrl_rom_2)
+{
+	assert(!name.empty());
+	assert(version_pos != std::string::npos);
+	assert(pcm_full || (pcm_l && pcm_h));
+	assert(ctrl_full || (ctrl_a && ctrl_b));
+}
+
+// Checks if its ROMs can be positively found in the provided directory
+bool LASynthModel::InDir(const service_t &service, const std::string &dir) const
+{
+	assert(service);
+
+	auto find_rom = [&service, &dir](const Rom *rom) -> bool {
+		if (!rom)
+			return false;
+
+		const std::string rom_path = dir + rom->filename;
+		if (!path_exists(rom_path))
+			return false;
+
+		mt32emu_rom_info info;
+		if (service->identifyROMFile(&info, rom_path.c_str(), nullptr) != MT32EMU_RC_OK)
+			return false;
+
+		if (rom->type == ROM_TYPE::UNVERSIONED)
+			return true;
+
+		const bool found_pcm = info.pcm_rom_id &&
+		                       (rom->id == info.pcm_rom_id);
+		const bool found_ctrl = info.control_rom_id &&
+		                        (rom->id == info.control_rom_id);
+		return found_pcm || found_ctrl;
+	};
+
+	const bool have_pcm = find_rom(pcm_full) ||
+	                      (find_rom(pcm_l) && find_rom(pcm_h));
+	const bool have_ctrl = find_rom(ctrl_full) ||
+	                       (find_rom(ctrl_a) && find_rom(ctrl_b));
+	return have_pcm && have_ctrl;
+}
+
+// If present, loads either the full or partial ROMs from the provided directory
+bool LASynthModel::Load(const service_t &service, const std::string &dir) const
+{
+	if (!service || !InDir(service, dir))
+		return false;
+
+	auto load_rom = [&service, &dir](const Rom *rom_full,
+	                                 mt32emu_return_code expected_code) -> bool {
+		if (!rom_full)
+			return false;
+		const std::string rom_path = dir + rom_full->filename;
+		const auto rcode = service->addROMFile(rom_path.c_str());
+		return rcode == expected_code;
+	};
+
+	auto load_both = [&service, &dir](const Rom *rom_1, const Rom *rom_2,
+	                                  mt32emu_return_code expected_code) -> bool {
+		if (!rom_1 || !rom_2)
+			return false;
+		const std::string rom_1_path = dir + rom_1->filename;
+		const std::string rom_2_path = dir + rom_2->filename;
+		const auto rcode = service->mergeAndAddROMFiles(rom_1_path.c_str(),
+		                                                rom_2_path.c_str());
+		return rcode == expected_code;
+	};
+
+	const bool loaded_pcm = load_rom(pcm_full, MT32EMU_RC_ADDED_PCM_ROM) ||
+	                        load_both(pcm_l, pcm_h, MT32EMU_RC_ADDED_PCM_ROM);
+	const bool loaded_ctrl = load_rom(ctrl_full, MT32EMU_RC_ADDED_CONTROL_ROM) ||
+	                         load_both(ctrl_a, ctrl_b,
+	                                   MT32EMU_RC_ADDED_CONTROL_ROM);
+	return loaded_pcm && loaded_ctrl;
+}
+
+const char *LASynthModel::GetVersion() const
+{
+	assert(version_pos != std::string::npos);
+	return name.data() + version_pos;
+}
+
+size_t LASynthModel::SetVersion()
+{
+	// Given the versioned name "mt32_106", version_pos would be 5
+	// Given the unversioned name "cm32l", version_pos would be 0
+	// (if the underscore isn't found, find_first_of returns -1)
+	const auto pos = name.find_first_of('_') + 1;
+	assert(pos < name.size());
+	return pos;
+}
+
+#endif // C_MT32EMU

--- a/src/midi/midi_lasynth_model.h
+++ b/src/midi/midi_lasynth_model.h
@@ -1,0 +1,90 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_MIDI_LA_SYNTH_MODEL_H
+#define DOSBOX_MIDI_LA_SYNTH_MODEL_H
+
+#include "dosbox.h"
+
+#if C_MT32EMU
+
+#include <memory>
+#include <string>
+
+#define MT32EMU_API_TYPE 3
+#include <mt32emu/mt32emu.h>
+
+// An LA Synth Model consists of PCM and Control ROMs either in full or partial
+// form.
+class LASynthModel {
+public:
+	enum class ROM_TYPE { UNVERSIONED, VERSIONED };
+
+	struct Rom {
+		const std::string id;
+		const std::string filename;
+		const ROM_TYPE type;
+	};
+
+	LASynthModel(const std::string &rom_name,
+	             const Rom *pcm_rom_full,
+	             const Rom *pcm_rom_l,
+	             const Rom *pcm_rom_h,
+	             const Rom *ctrl_rom_full,
+	             const Rom *ctrl_rom_a,
+	             const Rom *ctrl_rom_b);
+
+	LASynthModel() = delete;
+	LASynthModel(LASynthModel &) = delete;
+	LASynthModel &operator=(LASynthModel &) = delete;
+
+	const char *GetName() const { return name.c_str(); }
+
+	// The version may be postfixed onto the model's name using an
+	// underscore. If the model is unversioned, then the name is returned.
+	// The name "mt32_107" returns version "107".
+	// The name "mt32_bluer" returns version "bluer".
+	// The name "mt32" doesn't have a version, so "mt32" is returned.
+	const char *GetVersion() const;
+
+	using service_t = std::unique_ptr<MT32Emu::Service>;
+	bool InDir(const service_t &service, const std::string &dir) const;
+	bool Load(const service_t &service, const std::string &dir) const;
+
+private:
+	size_t SetVersion();
+
+	const std::string name = {};
+	const size_t version_pos = std::string::npos;
+
+	// PCM ROMs. Partials are in low-high form
+	const Rom *pcm_full = nullptr;
+	const Rom *pcm_l = nullptr;
+	const Rom *pcm_h = nullptr;
+
+	// Control ROMs. Partials are in a-b form
+	const Rom *ctrl_full = nullptr;
+	const Rom *ctrl_a = nullptr;
+	const Rom *ctrl_b = nullptr;
+};
+
+#endif // C_MT32EMU
+
+#endif

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -34,13 +34,14 @@
 
 #define MT32EMU_API_TYPE 3
 #include <mt32emu/mt32emu.h>
-#if MT32EMU_VERSION_MAJOR != 2 || MT32EMU_VERSION_MINOR < 1
-#error Incompatible mt32emu library version
-#endif
 
 #include "mixer.h"
 #include "rwqueue.h"
 #include "soft_limiter.h"
+
+static_assert(MT32EMU_VERSION_MAJOR > 2 ||
+                      (MT32EMU_VERSION_MAJOR == 2 && MT32EMU_VERSION_MINOR >= 5),
+              "libmt32emu >= 2.5.0 required (using " MT32EMU_VERSION ")");
 
 class MidiHandler_mt32 final : public MidiHandler {
 private:


### PR DESCRIPTION
Currently, Staging supports unversioned ROMs using a single fixed filename (such as `MT32_CONTROL.ROM` and `MT32_PCM.ROM`), which can be error prone and ambiguous for those who want to use specific versions of ROMs in their games collection. 

`libmt32emu` version 2.5.0 supports loading the consistently-named MAME MT-32 and CM-32L sets, which this PR maps to the following additional `model = ` names:

| Model | `model = ...` | Control ROMs |
| --- | --- | --- |
| CM-32L/LAPC-I v1.02 | cm32l_102 | cm32l_control.rom |
| CM-32L/LAPC-I  1.00 | cm32l_100 | lapc-i.v1.0.0.ic3.bin |
| MT-32 v2.04 | mt32_204 / mt32_new | mt32_2.0.4.ic28.bin |
| MT-32 v1.07 | mt32_107 / mt32_old | mt32_1.0.7.ic26.bin, mt32_1.0.7.ic27.bin |
| MT-32 BlueRidge | mt32_bluer | blue_ridge__mt32a.bin, blue_ridge__mt32b.bin |
| MT-32 v1.06 | mt32_106 | mt32_1.0.6.ic26.bin, mt32_1.0.6.ic27.bin |
| MT-32 v1.05 | mt32_105 | mt32_1.0.5.ic26.bin, mt32_1.0.5.ic27.bin |
| MT-32 v1.04 | mt32_104 | mt32_1.0.4.ic26.bin, mt32_1.0.4.ic27.bin |

Because each ROM filename is unique and versioned, users will be able to have all their Roland ROMs in a single directory, and then set `model = ` accordingly in the games' conf files.

This is in addition to the existing unversioned models:
 - `mt32`
 - `cm32l`

**What checks ensure the "right" ROMs are loaded?**

1. A file is considered a candidate if its name matches
2. It's then passed into `libmt32emu` checksum tester. If a hash-match was found, a text identifier is returned. 
3. The text identifier is matched against its _expected_ identifier.
4. The above process is repeated for all ROM parts making up model. A model can have up to four bitwise parts.
5. When all parts have been identified they then loaded. 
6. Once loaded, we check the return codes to ensure a complete PCM ROM and Control ROM are present before proceeding.

