### PR TITLE
Update mt32emu wrap dependency to 2.5.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,12 +26,12 @@ jobs:
 
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
-            max_warnings: 3
+            max_warnings: 0
 
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             build_flags: -Duse_fluidsynth=false
-            max_warnings: 3
+            max_warnings: 0
 
           - name: GCC 5, Ubuntu 18.04
             os: ubuntu-18.04
@@ -47,27 +47,27 @@ jobs:
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Denable_debugger=normal
-            max_warnings: 83
+            max_warnings: 80
 
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec
-            max_warnings: 3
+            max_warnings: 0
 
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 119
+            max_warnings: 116
 
           - name: GCC, -network
             os: ubuntu-20.04
             build_flags: -Duse_sdl2_net=false
-            max_warnings: 3
+            max_warnings: 0
 
           - name: GCC, warning_level=3
             os: ubuntu-20.04
             build_flags: -Dwarning_level=3
-            max_warnings: 73
+            max_warnings: 70
 
           - name: GCC, minimum build
             os: ubuntu-20.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
           - name: GCC
             packages: gcc@9
             build_flags: --native-file=.github/meson/native-gcc-9.ini
-            max_warnings: 3
+            max_warnings: 0
 
           - name: Clang, +tests
             run_tests: true

--- a/meson.build
+++ b/meson.build
@@ -197,8 +197,7 @@ if get_option('use_fluidsynth')
 endif
 
 if get_option('use_mt32emu')
-  # TODO version 2.5.0 will install mt32emu.pc file; upgrade when released
-  mt32emu_dep = dependency('mt32emu', version : '>= 2.4.2',
+  mt32emu_dep = dependency('mt32emu', version : '>= 2.5.0',
                            fallback : ['mt32emu', 'mt32emu_dep'],
                            not_found_message : msg.format('use_mt32emu'))
 endif

--- a/subprojects/mt32emu.wrap
+++ b/subprojects/mt32emu.wrap
@@ -1,11 +1,11 @@
 [wrap-file]
-directory = munt-libmt32emu_2_4_2
-source_url = https://github.com/munt/munt/archive/libmt32emu_2_4_2.tar.gz
-source_filename = libmt32emu_2_4_2.tar.gz
-source_hash = 5ba49f416dc1a076ea73e2b0136ec076b0d86537b47125c104e1e8c3716efb3c
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/mt32emu/2.4.2/2/get_zip
-patch_filename = mt32emu-2.4.2-2-wrap.zip
-patch_hash = 5cd83c0d093834afe67c768bd85261c0d3c876f5066fc11223556358cce41283
+directory = munt-libmt32emu_2_5_0
+source_url = https://github.com/munt/munt/archive/libmt32emu_2_5_0.tar.gz
+source_filename = libmt32emu_2_5_0.tar.gz
+source_hash = eb43864c002acedc42b304e1500f682c871ef8dabd8b5cbe492ec314a226f231
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/mt32emu/2.5.0/1/get_zip
+patch_filename = mt32emu-2.5.0-1-wrap.zip
+patch_hash = c41bf6e09a912a08a4b340a706230ad80fb31a7b96af0532201579ec88b0ae48
 
 [provide]
 mt32emu = mt32emu_dep


### PR DESCRIPTION
In preparation for new wrap release: https://github.com/mesonbuild/mt32emu/pull/5

@kcgen can you check if this new version works correctly with your new changes?