### PR TITLE
Add listing of MT-32 models and directories

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -54,6 +54,16 @@ uint8_t drive_index(char drive);
 // Convert index (0..26) to a drive letter (uppercase).
 char drive_letter(uint8_t index);
 
+// Returns the largest size() found in the iterable items 
+template <class T>
+size_t max_size(const T &iterable)
+{
+	size_t largest = 0;
+	for (const auto &item : iterable)
+		largest = std::max(largest, item.size());
+	return largest;
+}
+
 /*
  *  Converts a string to a finite number (such as float or double).
  *  Returns the number or quiet_NaN, if it could not be parsed.

--- a/src/midi/meson.build
+++ b/src/midi/meson.build
@@ -3,6 +3,7 @@ libmidi_sources = [
   'midi_alsa.cpp',
   'midi_fluidsynth.cpp',
   'midi_mt32.cpp',
+  'midi_mt32_model.cpp',
   'midi_oss.cpp',
 ]
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -122,12 +122,20 @@ Model cm32l_1_00_model = {"cm32l_1_00",
 Model cm32l_1_02_model = {"cm32l_1_02",
                           nullptr, &cm32l_pcm_1_00_l, &cm32l_pcm_1_00_h,
                           &cm32l_ctrl_1_02_f, nullptr, nullptr};
+// Aliased models
+Model mt32_new_model = {"mt32_new", // new is 2.04
+                        &mt32_pcm_1_00_f,  &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                        &mt32_ctrl_2_04_f, nullptr,          nullptr};
+Model mt32_old_model = {"mt32_old", // old is 1.07
+                        &mt32_pcm_1_00_f, &mt32_pcm_1_00_l,  &mt32_pcm_1_00_h,
+                        nullptr,          &mt32_ctrl_1_07_a, &mt32_ctrl_1_07_b};
 
 // In order that "model = auto" will load
 const std::deque<Model *> all_models = {&cm32l_any_model,  &cm32l_1_02_model,
                                         &cm32l_1_00_model, &mt32_any_model,
-                                        &mt32_2_04_model,  &mt32_bluer_model,
-                                        &mt32_1_07_model,  &mt32_1_06_model,
+                                        &mt32_new_model,   &mt32_2_04_model,
+                                        &mt32_old_model,   &mt32_1_07_model,
+                                        &mt32_bluer_model, &mt32_1_06_model,
                                         &mt32_1_05_model,  &mt32_1_04_model};
 
 MidiHandler_mt32 mt32_instance;
@@ -141,9 +149,11 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	                        cm32l_1_02_model.Name().c_str(),
 	                        cm32l_1_00_model.Name().c_str(),
 	                        mt32_any_model.Name().c_str(),
+	                        mt32_new_model.Name().c_str(),
 	                        mt32_2_04_model.Name().c_str(),
-	                        mt32_bluer_model.Name().c_str(),
+	                        mt32_old_model.Name().c_str(),
 	                        mt32_1_07_model.Name().c_str(),
+	                        mt32_bluer_model.Name().c_str(),
 	                        mt32_1_06_model.Name().c_str(),
 	                        mt32_1_05_model.Name().c_str(),
 	                        mt32_1_04_model.Name().c_str(),
@@ -152,7 +162,8 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	str_prop->Set_values(models);
 	str_prop->Set_help(
 	        "Model of synthesizer to use.\n"
-	        "'auto' picks the first model with available ROMs, in order as listed.");
+	        "'auto' picks the first model with available ROMs, in order as listed.\n"
+	        "'mt32_old' and 'mt32_new' are aliases for 1.07 and 2.04, respectively.");
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");
 	str_prop->Set_help(
@@ -160,10 +171,10 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	        "The directory can be absolute or relative, or leave it blank to\n"
 	        "use the 'mt32-roms' directory in your DOSBox configuration\n"
 	        "directory, followed by checking other common system locations.\n"
-	        "ROM files inside the directory must be named as follows:\n"
+	        "ROM files inside this directory must be named as follows:\n"
 	        "  - MT32_CONTROL.ROM and MT32_PCM.ROM, for model 'mt32'\n"
 	        "  - CM32L_CONTROL.ROM and CM32L_PCM.ROM for model 'cm32l'\n"
-	        "  - Unzipped MAME MT-32 and CM-32L ROMs for the versioned models.\n");
+	        "  - Unzipped MAME MT-32 and CM-32L ROMs, to use the versioned models.\n");
 }
 
 #if defined(WIN32)

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -238,6 +238,38 @@ static std::deque<std::string> get_rom_dirs()
 
 #endif
 
+static std::deque<std::string> get_selected_dirs()
+{
+	Section_prop *section = static_cast<Section_prop *>(
+	        control->GetSection("mt32"));
+	assert(section);
+
+	// Get potential ROM directories from the environment
+	// and/or system
+	auto rom_dirs = get_rom_dirs();
+
+	// Get the user's configured ROM directory; otherwise
+	// use 'mt32-roms'
+	std::string selected_romdir = section->Get_string("romdir");
+	if (selected_romdir.empty()) // already trimmed
+		selected_romdir = "mt32-roms";
+	if (selected_romdir.back() != '/' && selected_romdir.back() != '\\')
+		selected_romdir += CROSS_FILESPLIT;
+
+	// Make sure we search the user's configured directory
+	// first
+	rom_dirs.emplace_front(CROSS_ResolveHome((selected_romdir)));
+	return rom_dirs;
+}
+
+static const char *get_selected_model()
+{
+	Section_prop *section = static_cast<Section_prop *>(
+	        control->GetSection("mt32"));
+	assert(section);
+	return section->Get_string("model");
+}
+
 static std::string load_model(const MidiHandler_mt32::service_t &service,
                               const std::string &selected_model,
                               const std::deque<std::string> &rom_dirs)
@@ -313,41 +345,22 @@ MidiHandler_mt32::MidiHandler_mt32()
           keep_rendering(false)
 {}
 
+MidiHandler_mt32::service_t MidiHandler_mt32::GetService()
+{
+	service_t mt32_service = std::make_unique<MT32Emu::Service>();
+	// Has libmt32emu already created a context?
+	if (!mt32_service->getContext())
+		mt32_service->createContext(get_report_handler_interface(), this);
+	return mt32_service;
+}
+
 bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
 {
 	Close();
 
-	service_t mt32_service = std::make_unique<MT32Emu::Service>();
-
-	// Check version
-	uint32_t version = mt32_service->getLibraryVersionInt();
-	if (version < 0x020100) {
-		LOG_MSG("MT32: libmt32emu version is too old: %s",
-		        mt32_service->getLibraryVersionString());
-		return false;
-	}
-
-	mt32_service->createContext(get_report_handler_interface(), this);
-
-	Section_prop *section = static_cast<Section_prop *>(
-	        control->GetSection("mt32"));
-	assert(section);
-
-	// Which Roland model does the user want?
-	const std::string selected_model = section->Get_string("model");
-
-	// Get potential ROM directories from the environment and/or system
-	auto rom_dirs = get_rom_dirs();
-
-	// Get the user's configured ROM directory; otherwise use 'mt32-roms'
-	std::string preferred_dir = section->Get_string("romdir");
-	if (preferred_dir.empty()) // already trimmed
-		preferred_dir = "mt32-roms";
-	if (preferred_dir.back() != '/' && preferred_dir.back() != '\\')
-		preferred_dir += CROSS_FILESPLIT;
-
-	// Make sure we search the user's configured directory first
-	rom_dirs.emplace_front(CROSS_ResolveHome((preferred_dir)));
+	service_t mt32_service = GetService();
+	const std::string selected_model = get_selected_model();
+	const auto rom_dirs = get_selected_dirs();
 
 	// Load the selected model and print info about it
 	const auto found_in = load_model(mt32_service, selected_model, rom_dirs);
@@ -460,8 +473,10 @@ void MidiHandler_mt32::Close()
 		renderer.join();
 
 	// Stop the synthesizer
-	if (service)
+	if (service) {
 		service->closeSynth();
+		service->freeContext();
+	}
 
 	soft_limiter.PrintStats();
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -182,6 +182,7 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 static std::deque<std::string> get_rom_dirs()
 {
 	return {
+	        "..\\mt32-roms\\",
 	        CROSS_GetPlatformConfigDir() + "mt32-roms\\",
 	        "C:\\mt32-rom-data\\",
 	};
@@ -192,6 +193,7 @@ static std::deque<std::string> get_rom_dirs()
 static std::deque<std::string> get_rom_dirs()
 {
 	return {
+	        "../mt32-roms/",
 	        CROSS_GetPlatformConfigDir() + "mt32-roms/",
 	        CROSS_ResolveHome("~/Library/Audio/Sounds/MT32-Roms/"),
 	        "/usr/local/share/mt32-rom-data/",
@@ -209,6 +211,7 @@ static std::deque<std::string> get_rom_dirs()
 	        xdg_data_home_env ? xdg_data_home_env : "~/.local/share");
 
 	std::deque<std::string> dirs = {
+	        "../mt32-roms/",
 	        xdg_data_home + "/dosbox/mt32-roms/",
 	        xdg_data_home + "/mt32-rom-data/",
 	};

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -63,23 +63,72 @@ constexpr bool USE_NICE_RAMP = true;
 constexpr bool USE_NICE_PANNING = true;
 constexpr bool USE_NICE_PARTIAL_MIXING = true;
 
-// ROMs
+constexpr auto versioned = Model::ROM_TYPE::VERSIONED;
 constexpr auto unversioned = Model::ROM_TYPE::UNVERSIONED;
-const Model::Rom mt32_pcm_any_f = {"pcm_mt32", "MT32_PCM.ROM", unversioned};
-const Model::Rom mt32_ctrl_any_f = {"ctrl_mt32", "MT32_CONTROL.ROM", unversioned};
-const Model::Rom cm32l_pcm_any_f = {"pcm_cm32l", "CM32L_PCM.ROM", unversioned};
-const Model::Rom cm32l_ctrl_any_f = {"ctrl_cm32l", "CM32L_CONTROL.ROM", unversioned};
 
-// Models (composed of ROMs)
+// Traditional ROMs
+const Model::Rom mt32_pcm_any_f =    {"pcm_mt32",          "MT32_PCM.ROM",          unversioned};
+const Model::Rom mt32_ctrl_any_f =   {"ctrl_mt32",         "MT32_CONTROL.ROM",      unversioned};
+const Model::Rom cm32l_pcm_any_f =   {"pcm_cm32l",         "CM32L_PCM.ROM",         unversioned};
+const Model::Rom cm32l_ctrl_any_f =  {"ctrl_cm32l",        "CM32L_CONTROL.ROM",     unversioned};
+// MAME ROMs (versioned)
+const Model::Rom mt32_pcm_1_00_f =   {"pcm_mt32",          "r15449121.ic37.bin",    versioned};
+const Model::Rom mt32_pcm_1_00_l =   {"pcm_mt32_l",        "r15179844.ic21.bin",    versioned};
+const Model::Rom mt32_pcm_1_00_h =   {"pcm_mt32_h",        "r15179845.ic22.bin",    versioned};
+const Model::Rom mt32_ctrl_1_04_a =  {"ctrl_mt32_1_04_a",  "mt32_1.0.4.ic27.bin",   versioned};
+const Model::Rom mt32_ctrl_1_04_b =  {"ctrl_mt32_1_04_b",  "mt32_1.0.4.ic26.bin",   versioned};
+const Model::Rom mt32_ctrl_1_05_a =  {"ctrl_mt32_1_05_a",  "mt32_1.0.5.ic27.bin",   versioned};
+const Model::Rom mt32_ctrl_1_05_b =  {"ctrl_mt32_1_05_b",  "mt32_1.0.5.ic26.bin",   versioned};
+const Model::Rom mt32_ctrl_1_06_a =  {"ctrl_mt32_1_06_a",  "mt32_1.0.6.ic27.bin",   versioned};
+const Model::Rom mt32_ctrl_1_06_b =  {"ctrl_mt32_1_06_b",  "mt32_1.0.6.ic26.bin",   versioned};
+const Model::Rom mt32_ctrl_1_07_a =  {"ctrl_mt32_1_07_a",  "mt32_1.0.7.ic27.bin",   versioned};
+const Model::Rom mt32_ctrl_1_07_b =  {"ctrl_mt32_1_07_b",  "mt32_1.0.7.ic26.bin",   versioned};
+const Model::Rom mt32_ctrl_bluer_a = {"ctrl_mt32_bluer_a", "blue_ridge__mt32a.bin", versioned};
+const Model::Rom mt32_ctrl_bluer_b = {"ctrl_mt32_bluer_b", "blue_ridge__mt32b.bin", versioned};
+const Model::Rom mt32_ctrl_2_04_f =  {"ctrl_mt32_2_04",    "mt32_2.0.4.ic28.bin",   versioned};
+const Model::Rom cm32l_ctrl_1_00_f = {"ctrl_cm32l_1_00",   "lapc-i.v1.0.0.ic3.bin", versioned};
+const Model::Rom cm32l_ctrl_1_02_f = {"ctrl_cm32l_1_02",   "cm32l_control.rom",     versioned};
+const Model::Rom cm32l_pcm_1_00_h =  {"pcm_cm32l_h",       "r15179945.ic8.bin",     versioned};
+const Model::Rom &cm32l_pcm_1_00_l = mt32_pcm_1_00_f; // CM-32L re-uses the MT-32 samples
+
+// Roland LA Models (composed of ROMs)
 Model mt32_any_model = {"mt32",                              // model
                         &mt32_pcm_any_f,  nullptr, nullptr,  // PCM ROM(s)
                         &mt32_ctrl_any_f, nullptr, nullptr}; // Control ROM(s)
+Model mt32_1_04_model = {"mt32_1_04",
+                         &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                         nullptr, &mt32_ctrl_1_04_a, &mt32_ctrl_1_04_b};
+Model mt32_1_05_model = {"mt32_1_05",
+                         &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                         nullptr, &mt32_ctrl_1_05_a, &mt32_ctrl_1_05_b};
+Model mt32_1_06_model = {"mt32_1_06",
+                         &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                         nullptr, &mt32_ctrl_1_06_a, &mt32_ctrl_1_06_b};
+Model mt32_1_07_model = {"mt32_1_07",
+                         &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                         nullptr, &mt32_ctrl_1_07_a, &mt32_ctrl_1_07_b};
+Model mt32_bluer_model = {"mt32_bluer",
+                          &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                          nullptr, &mt32_ctrl_bluer_a, &mt32_ctrl_bluer_b};
+Model mt32_2_04_model = {"mt32_2_04",
+                         &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
+                         &mt32_ctrl_2_04_f, nullptr, nullptr};
 Model cm32l_any_model = {"cm32l",
                          &cm32l_pcm_any_f,  nullptr, nullptr,
                          &cm32l_ctrl_any_f, nullptr, nullptr};
+Model cm32l_1_00_model = {"cm32l_1_00",
+                          nullptr, &cm32l_pcm_1_00_l, &cm32l_pcm_1_00_h,
+                          &cm32l_ctrl_1_00_f, nullptr, nullptr};
+Model cm32l_1_02_model = {"cm32l_1_02",
+                          nullptr, &cm32l_pcm_1_00_l, &cm32l_pcm_1_00_h,
+                          &cm32l_ctrl_1_02_f, nullptr, nullptr};
 
 // In order that "model = auto" will load
-const std::deque<Model *> all_models = {&cm32l_any_model, &mt32_any_model};
+const std::deque<Model *> all_models = {&cm32l_any_model,  &cm32l_1_02_model,
+                                        &cm32l_1_00_model, &mt32_any_model,
+                                        &mt32_2_04_model,  &mt32_bluer_model,
+                                        &mt32_1_07_model,  &mt32_1_06_model,
+                                        &mt32_1_05_model,  &mt32_1_04_model};
 
 MidiHandler_mt32 mt32_instance;
 
@@ -89,25 +138,32 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 
 	const char *models[] = {"auto",
 	                        cm32l_any_model.Name().c_str(),
+	                        cm32l_1_02_model.Name().c_str(),
+	                        cm32l_1_00_model.Name().c_str(),
 	                        mt32_any_model.Name().c_str(),
+	                        mt32_2_04_model.Name().c_str(),
+	                        mt32_bluer_model.Name().c_str(),
+	                        mt32_1_07_model.Name().c_str(),
+	                        mt32_1_06_model.Name().c_str(),
+	                        mt32_1_05_model.Name().c_str(),
+	                        mt32_1_04_model.Name().c_str(),
 	                        0};
 	auto *str_prop = sec_prop.Add_string("model", when_idle, "auto");
 	str_prop->Set_values(models);
 	str_prop->Set_help(
-	        "Model of synthesizer to use. The default (auto) prefers CM-32L\n"
-	        "if both sets of ROMs are provided. For early Sierra games and Dune 2\n"
-	        "it's recommended to use 'mt32', while newer games typically made\n"
-	        "use of the CM-32L's extra sound effects (use 'auto' or 'cm32l')");
+	        "Model of synthesizer to use.\n"
+	        "'auto' picks the first model with available ROMs, in order as listed.");
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");
 	str_prop->Set_help(
-	        "The directory containing one or both pairs of MT-32 and/or CM-32L ROMs.\n"
-	        "The files must be named in capitals, as follows:\n"
-	        "  - MT-32 ROM pair: MT32_CONTROL.ROM and MT32_PCM.ROM\n"
-	        "  - CM-32L ROM pair: CM32L_CONTROL.ROM and CM32L_PCM.ROM\n"
+	        "The directory containing ROMs for one or more models.\n"
 	        "The directory can be absolute or relative, or leave it blank to\n"
 	        "use the 'mt32-roms' directory in your DOSBox configuration\n"
-	        "directory, followed by checking other common system locations.");
+	        "directory, followed by checking other common system locations.\n"
+	        "ROM files inside the directory must be named as follows:\n"
+	        "  - MT32_CONTROL.ROM and MT32_PCM.ROM, for model 'mt32'\n"
+	        "  - CM32L_CONTROL.ROM and CM32L_PCM.ROM for model 'cm32l'\n"
+	        "  - Unzipped MAME MT-32 and CM-32L ROMs for the versioned models.\n");
 }
 
 #if defined(WIN32)

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -97,31 +97,31 @@ const Model::Rom &cm32l_pcm_1_00_l = mt32_pcm_1_00_f; // CM-32L re-uses the MT-3
 Model mt32_any_model = {"mt32",                              // model
                         &mt32_pcm_any_f,  nullptr, nullptr,  // PCM ROM(s)
                         &mt32_ctrl_any_f, nullptr, nullptr}; // Control ROM(s)
-Model mt32_1_04_model = {"mt32_1_04",
+Model mt32_104_model = {"mt32_104",
                          &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
                          nullptr, &mt32_ctrl_1_04_a, &mt32_ctrl_1_04_b};
-Model mt32_1_05_model = {"mt32_1_05",
+Model mt32_105_model = {"mt32_105",
                          &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
                          nullptr, &mt32_ctrl_1_05_a, &mt32_ctrl_1_05_b};
-Model mt32_1_06_model = {"mt32_1_06",
+Model mt32_106_model = {"mt32_106",
                          &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
                          nullptr, &mt32_ctrl_1_06_a, &mt32_ctrl_1_06_b};
-Model mt32_1_07_model = {"mt32_1_07",
+Model mt32_107_model = {"mt32_107",
                          &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
                          nullptr, &mt32_ctrl_1_07_a, &mt32_ctrl_1_07_b};
 Model mt32_bluer_model = {"mt32_bluer",
                           &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
                           nullptr, &mt32_ctrl_bluer_a, &mt32_ctrl_bluer_b};
-Model mt32_2_04_model = {"mt32_2_04",
+Model mt32_204_model = {"mt32_204",
                          &mt32_pcm_1_00_f, &mt32_pcm_1_00_l, &mt32_pcm_1_00_h,
                          &mt32_ctrl_2_04_f, nullptr, nullptr};
 Model cm32l_any_model = {"cm32l",
                          &cm32l_pcm_any_f,  nullptr, nullptr,
                          &cm32l_ctrl_any_f, nullptr, nullptr};
-Model cm32l_1_00_model = {"cm32l_1_00",
+Model cm32l_100_model = {"cm32l_100",
                           nullptr, &cm32l_pcm_1_00_l, &cm32l_pcm_1_00_h,
                           &cm32l_ctrl_1_00_f, nullptr, nullptr};
-Model cm32l_1_02_model = {"cm32l_1_02",
+Model cm32l_102_model = {"cm32l_102",
                           nullptr, &cm32l_pcm_1_00_l, &cm32l_pcm_1_00_h,
                           &cm32l_ctrl_1_02_f, nullptr, nullptr};
 // Aliased models
@@ -133,12 +133,12 @@ Model mt32_old_model = {"mt32_old", // old is 1.07
                         nullptr,          &mt32_ctrl_1_07_a, &mt32_ctrl_1_07_b};
 
 // In order that "model = auto" will load
-const std::deque<Model *> all_models = {&cm32l_any_model,  &cm32l_1_02_model,
-                                        &cm32l_1_00_model, &mt32_any_model,
-                                        &mt32_new_model,   &mt32_2_04_model,
-                                        &mt32_old_model,   &mt32_1_07_model,
-                                        &mt32_bluer_model, &mt32_1_06_model,
-                                        &mt32_1_05_model,  &mt32_1_04_model};
+const std::deque<Model *> all_models = {&cm32l_any_model,  &cm32l_102_model,
+                                        &cm32l_100_model,  &mt32_any_model,
+                                        &mt32_new_model,   &mt32_204_model,
+                                        &mt32_old_model,   &mt32_107_model,
+                                        &mt32_bluer_model, &mt32_106_model,
+                                        &mt32_105_model,   &mt32_104_model};
 
 MidiHandler_mt32 mt32_instance;
 
@@ -148,17 +148,17 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 
 	const char *models[] = {"auto",
 	                        cm32l_any_model.Name().c_str(),
-	                        cm32l_1_02_model.Name().c_str(),
-	                        cm32l_1_00_model.Name().c_str(),
+	                        cm32l_102_model.Name().c_str(),
+	                        cm32l_100_model.Name().c_str(),
 	                        mt32_any_model.Name().c_str(),
 	                        mt32_new_model.Name().c_str(),
-	                        mt32_2_04_model.Name().c_str(),
+	                        mt32_204_model.Name().c_str(),
 	                        mt32_old_model.Name().c_str(),
-	                        mt32_1_07_model.Name().c_str(),
+	                        mt32_107_model.Name().c_str(),
 	                        mt32_bluer_model.Name().c_str(),
-	                        mt32_1_06_model.Name().c_str(),
-	                        mt32_1_05_model.Name().c_str(),
-	                        mt32_1_04_model.Name().c_str(),
+	                        mt32_106_model.Name().c_str(),
+	                        mt32_105_model.Name().c_str(),
+	                        mt32_104_model.Name().c_str(),
 	                        0};
 	auto *str_prop = sec_prop.Add_string("model", when_idle, "auto");
 	str_prop->Set_values(models);

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -54,6 +54,7 @@ public:
 	~MidiHandler_mt32() override;
 	void Close() override;
 	const char *GetName() const override { return "mt32"; }
+	MIDI_RC ListAll(Program *caller) override;
 	bool Open(const char *conf) override;
 	void PlayMsg(const uint8_t *msg) override;
 	void PlaySysex(uint8_t *sysex, size_t len) override;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -61,6 +61,7 @@ public:
 
 private:
 	uint32_t GetMidiEventTimestamp() const;
+	service_t GetService();
 	void MixerCallBack(uint16_t len);
 	void SetMixerLevel(const AudioFrame &desired) noexcept;
 	uint16_t GetRemainingFrames();

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -34,13 +34,14 @@
 
 #define MT32EMU_API_TYPE 3
 #include <mt32emu/mt32emu.h>
-#if MT32EMU_VERSION_MAJOR != 2 || MT32EMU_VERSION_MINOR < 1
-#error Incompatible mt32emu library version
-#endif
 
 #include "mixer.h"
 #include "rwqueue.h"
 #include "soft_limiter.h"
+
+static_assert(MT32EMU_VERSION_MAJOR > 2 ||
+                      (MT32EMU_VERSION_MAJOR == 2 && MT32EMU_VERSION_MINOR >= 5),
+              "libmt32emu >= 2.5.0 required (using " MT32EMU_VERSION ")");
 
 class MidiHandler_mt32 final : public MidiHandler {
 private:

--- a/src/midi/midi_mt32_model.cpp
+++ b/src/midi/midi_mt32_model.cpp
@@ -1,0 +1,145 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "midi_mt32_model.h"
+
+#if C_MT32EMU
+
+#include <cassert>
+
+#include "fs_utils.h"
+
+// Construct a new model and ensure both PCM and control ROM(s) are provided
+Model::Model(const std::string &rom_name,
+             const Rom *pcm_full,
+             const Rom *pcm_a,
+             const Rom *pcm_b,
+             const Rom *ctrl_full,
+             const Rom *ctrl_a,
+             const Rom *ctrl_b)
+        : name(rom_name),
+          pcmFull(pcm_full),
+          pcmA(pcm_a),
+          pcmB(pcm_b),
+          ctrlFull(ctrl_full),
+          ctrlA(ctrl_a),
+          ctrlB(ctrl_b)
+{
+	assert(!name.empty());
+	assert(pcmFull || (pcmA && pcmB));
+	assert(ctrlFull || (ctrlA && ctrlB));
+}
+
+// Checks if its ROMs can be positively found in the provided directory
+bool Model::InDir(const service_t &service, const std::string &dir)
+{
+	assert(service);
+	if (inDir.find(dir) != inDir.end())
+		return inDir[dir];
+
+	auto find_rom = [&service, &dir](const Rom *Rom) -> bool {
+		if (!Rom)
+			return false;
+
+		const std::string rom_path = dir + Rom->filename;
+		if (!path_exists(rom_path))
+			return false;
+
+		mt32emu_rom_info info;
+		if (service->identifyROMFile(&info, rom_path.c_str(), nullptr) != MT32EMU_RC_OK)
+			return false;
+
+		if (Rom->type == ROM_TYPE::UNVERSIONED)
+			return true;
+
+		const bool found_pcm = info.pcm_rom_id && (Rom->id == info.pcm_rom_id);
+		const bool found_ctrl = info.control_rom_id && (Rom->id == info.control_rom_id);
+		return found_pcm || found_ctrl;
+	};
+
+	auto find_both = [find_rom](const Rom *rom_a, const Rom *rom_b) -> bool {
+		return find_rom(rom_a) && find_rom(rom_b);
+	};
+
+	const bool have_pcm = find_rom(pcmFull) || find_both(pcmA, pcmB);
+	const bool have_ctrl = find_rom(ctrlFull) || find_both(ctrlA, ctrlB);
+	const bool have_both = have_pcm && have_ctrl;
+	inDir[dir] = have_both;
+	return have_both;
+}
+
+// If present, loads either the full or partial ROMs from the provided directory
+bool Model::Load(const service_t &service, const std::string &dir)
+{
+	if (!service || !InDir(service, dir))
+		return false;
+
+	auto load_rom = [&service, &dir](const Rom *rom_full,
+	                                 mt32emu_return_code expected_code) -> bool {
+		if (!rom_full)
+			return false;
+		const std::string rom_path = dir + rom_full->filename;
+		const auto rcode = service->addROMFile(rom_path.c_str());
+		return rcode == expected_code;
+	};
+	auto load_both = [&service, &dir](const Rom *rom_a, const Rom *rom_b,
+	                                  mt32emu_return_code expected_code) -> bool {
+		if (!rom_a || !rom_b)
+			return false;
+		const std::string rom_a_path = dir + rom_a->filename;
+		const std::string rom_b_path = dir + rom_b->filename;
+		const auto rcode = service->mergeAndAddROMFiles(rom_a_path.c_str(),
+		                                                rom_b_path.c_str());
+		return rcode == expected_code;
+	};
+	const bool loaded_pcm = load_rom(pcmFull, MT32EMU_RC_ADDED_PCM_ROM) ||
+	                        load_both(pcmA, pcmB, MT32EMU_RC_ADDED_PCM_ROM);
+	const bool loaded_ctrl = load_rom(ctrlFull, MT32EMU_RC_ADDED_CONTROL_ROM) ||
+	                         load_both(ctrlA, ctrlB, MT32EMU_RC_ADDED_CONTROL_ROM);
+	return loaded_pcm && loaded_ctrl;
+}
+
+// Returns the model's version, which is postfixed on it's name. 
+// If a version doesn't exist, 
+const std::string &Model::Version()
+{
+	if (!version.empty())
+		return version;
+
+	const auto pos = name.find_first_of('_');
+	version = (pos == std::string::npos) ? name : name.substr(pos + 1);
+	return version;
+}
+const std::string &Model::Name() const
+{
+	return name;
+}
+
+bool Model::operator<(const Model &other) const
+{
+	return name < other.Name();
+}
+
+bool Model::operator==(const Model &other) const
+{
+	return name == other.Name();
+}
+
+#endif // C_MT32EMU

--- a/src/midi/midi_mt32_model.h
+++ b/src/midi/midi_mt32_model.h
@@ -1,0 +1,82 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_MIDI_MT32_MODEL_H
+#define DOSBOX_MIDI_MT32_MODEL_H
+
+#include "dosbox.h"
+
+#if C_MT32EMU
+
+#include <map>
+#include <memory>
+#include <string>
+
+#define MT32EMU_API_TYPE 3
+#include <mt32emu/mt32emu.h>
+
+// A Model consists of a PCM and Control ROM either in full or partial forms
+class Model {
+public:
+	enum class ROM_TYPE { UNVERSIONED, VERSIONED };
+
+	struct Rom {
+		const std::string id;
+		const std::string filename;
+		const ROM_TYPE type;
+	};
+
+	Model(const std::string &rom_name,
+	      const Rom *pcm_full,
+	      const Rom *pcm_a,
+	      const Rom *pcm_b,
+	      const Rom *ctrl_full,
+	      const Rom *ctrl_a,
+	      const Rom *ctrl_b);
+
+	bool operator<(const Model &other) const;
+	bool operator==(const Model &other) const;
+
+	const std::string &Name() const;
+	const std::string &Version();
+
+	using service_t = std::unique_ptr<MT32Emu::Service>;
+	bool InDir(const service_t &service, const std::string &dir);
+	bool Load(const service_t &service, const std::string &dir);
+
+private:
+	Model() = delete;
+	Model(Model &) = delete;
+	Model &operator=(Model &) = delete;
+
+	std::map<std::string, bool> inDir = {};
+	const std::string name = {};
+	std::string version = {};
+	const Rom *pcmFull = nullptr;
+	const Rom *pcmA = nullptr;
+	const Rom *pcmB = nullptr;
+	const Rom *ctrlFull = nullptr;
+	const Rom *ctrlA = nullptr;
+	const Rom *ctrlB = nullptr;
+};
+
+#endif // C_MT32EMU
+
+#endif


### PR DESCRIPTION
This PR simplifies the model names to use a single version value (without additional underscores), for example:

Was `model = mt32_1_05`, now `model = mt32_105`
Was `model = mt32_2_04` , now `model = mt32_204`
Was `model = cm32l_1_00`, mow `model = cm32l_100`

This allows for a compact matrix-listing (showing just the version postfix) in the `mixer /listall` routine:

![2021-04-04_11-02](https://user-images.githubusercontent.com/1557255/113517516-4b0ed280-9535-11eb-8ffc-c0a95dc370e5.png)

The alternative is a messy wrapped listing per directory, which is harder to see what you have (or don't have) in a given directory.