### PR TITLE
Add support for listing MT-32 model availability 

### DIFF
--- a/src/midi/midi_lasynth_model.cpp
+++ b/src/midi/midi_lasynth_model.cpp
@@ -123,6 +123,12 @@ const char *LASynthModel::GetVersion() const
 	return name.data() + version_pos;
 }
 
+bool LASynthModel::Matches(const std::string &model_name) const
+{
+	assert(!model_name.empty());
+	return (name.rfind(model_name, 0) == 0);
+}
+
 size_t LASynthModel::SetVersion()
 {
 	// Given the versioned name "mt32_106", version_pos would be 5

--- a/src/midi/midi_lasynth_model.h
+++ b/src/midi/midi_lasynth_model.h
@@ -64,6 +64,9 @@ public:
 	// The name "mt32" doesn't have a version, so "mt32" is returned.
 	const char *GetVersion() const;
 
+	// Returns true if the model has a matches that provided "mt32" or "cm32l".
+	bool Matches(const std::string &model_name) const;
+
 	using service_t = std::unique_ptr<MT32Emu::Service>;
 	bool InDir(const service_t &service, const std::string &dir) const;
 	bool Load(const service_t &service, const std::string &dir) const;

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -145,12 +145,11 @@ const LASynthModel mt32_old_model = {"mt32_old", // old is 1.07
                                      &mt32_ctrl_107_a, &mt32_ctrl_107_b};
 
 // In order that "model = auto" will load
-const LASynthModel *all_models[] = {&cm32l_any_model,  &cm32l_102_model,
-                                    &cm32l_100_model,  &mt32_any_model,
-                                    &mt32_new_model,   &mt32_204_model,
-                                    &mt32_old_model,   &mt32_107_model,
-                                    &mt32_bluer_model, &mt32_106_model,
-                                    &mt32_105_model,   &mt32_104_model};
+const LASynthModel *all_models[] = {
+        &cm32l_any_model, &cm32l_102_model,  &cm32l_100_model, &mt32_any_model,
+        &mt32_old_model,  &mt32_107_model,   &mt32_106_model,  &mt32_105_model,
+        &mt32_104_model,  &mt32_bluer_model, &mt32_new_model,  &mt32_204_model,
+};
 
 MidiHandler_mt32 mt32_instance;
 
@@ -163,14 +162,14 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	                        cm32l_102_model.GetName(),
 	                        cm32l_100_model.GetName(),
 	                        mt32_any_model.GetName(),
-	                        mt32_new_model.GetName(),
-	                        mt32_204_model.GetName(),
 	                        mt32_old_model.GetName(),
 	                        mt32_107_model.GetName(),
-	                        mt32_bluer_model.GetName(),
 	                        mt32_106_model.GetName(),
 	                        mt32_105_model.GetName(),
 	                        mt32_104_model.GetName(),
+	                        mt32_bluer_model.GetName(),
+	                        mt32_new_model.GetName(),
+	                        mt32_204_model.GetName(),
 	                        0};
 	auto *str_prop = sec_prop.Add_string("model", when_idle, "auto");
 	str_prop->Set_values(models);
@@ -420,10 +419,10 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 	const auto delim_width = strlen(column_delim);
 
 	const LASynthModel *models_without_aliases[] = {
-	        &cm32l_any_model,  &cm32l_102_model, &cm32l_100_model,
-	        &mt32_any_model,   &mt32_204_model,  &mt32_107_model,
-	        &mt32_bluer_model, &mt32_106_model,  &mt32_105_model,
-	        &mt32_104_model};
+	        &cm32l_any_model, &cm32l_102_model, &cm32l_100_model,
+	        &mt32_any_model,  &mt32_107_model,  &mt32_106_model,
+	        &mt32_105_model,  &mt32_104_model,  &mt32_bluer_model,
+	        &mt32_204_model};
 
 	const size_t max_dir_width = get_max_dir_width(models_without_aliases,
 	                                               indent, column_delim);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -176,7 +176,7 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	str_prop->Set_help(
 	        "Model of synthesizer to use.\n"
 	        "'auto' picks the first model with available ROMs, in order as listed.\n"
-	        "'cm32l' and 'mt32 pick the first model of their type, in the order listed.\n"
+	        "'cm32l' and 'mt32' pick the first model of their type, in the order listed.\n"
 	        "'mt32_old' and 'mt32_new' are aliases for 1.07 and 2.04, respectively.");
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -54,6 +54,7 @@ public:
 	~MidiHandler_mt32() override;
 	void Close() override;
 	const char *GetName() const override { return "mt32"; }
+	MIDI_RC ListAll(Program *caller) override;
 	bool Open(const char *conf) override;
 	void PlayMsg(const uint8_t *msg) override;
 	void PlaySysex(uint8_t *sysex, size_t len) override;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -61,6 +61,7 @@ public:
 
 private:
 	uint32_t GetMidiEventTimestamp() const;
+	service_t GetService();
 	void MixerCallBack(uint16_t len);
 	void SetMixerLevel(const AudioFrame &desired) noexcept;
 	uint16_t GetRemainingFrames();


### PR DESCRIPTION
Provides a column-formatted table for which models are (or aren't) supported in those directories that have at least one available model.  Allows the users to quickly take inventory of what they have or don't have.

![2021-04-04_11-02](https://user-images.githubusercontent.com/1557255/113517516-4b0ed280-9535-11eb-8ffc-c0a95dc370e5.png)

Because the number of models is fixed, the table shows all of them and either darkened (or lightened) depends on overall availability. 

 In the example above, we see that `mt32_106` is completely unavailable while `mt32_107` is the user's selected model.
The green highlighted 'y' additionally indicates which directory will be used during the actual loading.