### PR TITLE
Process SDL's event queue no faster than the host's framerate

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -54,7 +54,7 @@ typedef void (*GFX_CallBack_t)( GFX_CallBackFunctions_t function );
 // return code of:
 // - true means event loop can keep running.
 // - false means event loop wants to quit.
-bool GFX_Events();
+bool GFX_MaybeProcessEvents();
 
 Bitu GFX_GetBestMode(Bitu flags);
 Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);

--- a/include/video.h
+++ b/include/video.h
@@ -21,8 +21,6 @@
 
 #include "types.h"
 
-#define REDUCE_JOYSTICK_POLLING
-
 typedef enum {
 	GFX_CallBackReset,
 	GFX_CallBackStop,
@@ -73,8 +71,6 @@ void GFX_EndUpdate( const Bit16u *changedLines );
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus(void);
 
-#if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);
-#endif
 
 #endif

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1864,7 +1864,7 @@ Bit32u DEBUG_CheckKeys(void) {
 
 Bitu DEBUG_Loop(void) {
 //TODO Disable sound
-	GFX_Events();
+	GFX_MaybeProcessEvents();
 	// Interrupt started ? - then skip it
 	Bit16u oldCS	= SegValue(cs);
 	Bit32u oldEIP	= reg_eip;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -140,10 +140,10 @@ Bit32s ticksDone;
 Bit32u ticksScheduled;
 bool ticksLocked;
 void increaseticks();
-
 bool mono_cga=false;
 
-static Bitu Normal_Loop(void) {
+static Bitu Normal_Loop()
+{
 	Bits ret;
 	while (1) {
 		if (PIC_RunQueue()) {
@@ -158,12 +158,16 @@ static Bitu Normal_Loop(void) {
 			if (DEBUG_ExitLoop()) return 0;
 #endif
 		} else {
-			if (!GFX_Events())
+			if (!GFX_MaybeProcessEvents()) {
 				return 0;
+			}
 			if (ticksRemain > 0) {
 				TIMER_AddTick();
 				ticksRemain--;
-			} else {increaseticks();return 0;}
+			} else {
+				increaseticks();
+				return 0;
+			}
 		}
 	}
 }

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -654,10 +654,8 @@ public:
 
 			if (event->jaxis.which != stick)
 				return 0;
-#if defined(REDUCE_JOYSTICK_POLLING)
 			if (axis_id >= axes)
 				return nullptr;
-#endif
 			if (abs(axis_position) < 25000)
 				return 0;
 
@@ -669,11 +667,8 @@ public:
 		} else if (event->type == SDL_JOYBUTTONDOWN) {
 			if (event->jbutton.which != stick)
 				return 0;
-#if defined (REDUCE_JOYSTICK_POLLING)
 			return CreateButtonBind(event->jbutton.button%button_wrap);
-#else
-			return CreateButtonBind(event->jbutton.button);
-#endif
+
 		} else if (event->type==SDL_JOYHATMOTION) {
 			if (event->jhat.which!=stick) return 0;
 			if (event->jhat.value==0) return 0;
@@ -2711,14 +2706,9 @@ static void CreateBindGroups() {
 
 	assert(joytype != JOY_UNSET);
 	if (joytype != JOY_NONE) {
-#if defined (REDUCE_JOYSTICK_POLLING)
 		// direct access to the SDL joystick, thus removed from the event handling
 		if (mapper.sticks.num) SDL_JoystickEventState(SDL_DISABLE);
-#else
-		// enable joystick event handling
-		if (mapper.sticks.num) SDL_JoystickEventState(SDL_ENABLE);
-		else return;
-#endif
+
 		// Free up our previously assigned joystick slot before assinging below
 		if (mapper.sticks.stick[mapper.sticks.num_groups]) {
 			delete mapper.sticks.stick[mapper.sticks.num_groups];
@@ -2763,14 +2753,12 @@ bool MAPPER_IsUsingJoysticks() {
 	return (mapper.sticks.num > 0);
 }
 
-#if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks() {
 	for (Bitu i=0; i<mapper.sticks.num_groups; i++) {
 		assert(mapper.sticks.stick[i]);
 		mapper.sticks.stick[i]->UpdateJoystick();
 	}
 }
-#endif
 
 void MAPPER_LosingFocus() {
 	for (CEventVector_it evit = events.begin(); evit != events.end(); ++evit) {
@@ -2828,9 +2816,8 @@ void MAPPER_DisplayUI() {
 	mapper.exit = false;
 	mapper.redraw=true;
 	SetActiveEvent(0);
-#if defined (REDUCE_JOYSTICK_POLLING)
 	SDL_JoystickEventState(SDL_ENABLE);
-#endif
+
 	while (!mapper.exit) {
 		if (mapper.redraw) {
 			mapper.redraw = false;
@@ -2846,9 +2833,8 @@ void MAPPER_DisplayUI() {
 	SDL_FreeSurface(mapper.draw_surface);
 	SDL_FreeSurface(mapper.draw_surface_nonpaletted);
 	SDL_FreePalette(sdl2_map_pal_ptr);
-#if defined (REDUCE_JOYSTICK_POLLING)
 	SDL_JoystickEventState(SDL_DISABLE);
-#endif
+
 	if (mousetoggle)
 		GFX_ToggleMouseCapture();
 	SDL_ShowCursor(cursor);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2457,13 +2457,6 @@ bool GFX_IsFullscreen(void) {
 	return sdl.desktop.fullscreen;
 }
 
-#if defined(MACOSX)
-#define DB_POLLSKIP 3
-#else
-//Not used yet, see comment below
-#define DB_POLLSKIP 1
-#endif
-
 static void HandleVideoResize(int width, int height)
 {
 	/* Maybe a screen rotation has just occurred, so we simply resize.
@@ -2553,31 +2546,11 @@ static void FinalizeWindowState()
 
 static bool ProcessEvents()
 {
-#if defined(MACOSX)
-	// Don't poll too often. This can be heavy on the OS, especially Macs.
-	// In idle mode 3000-4000 polls are done per second without this check.
-	// Macs, with this code,  max 250 polls per second. (non-macs unused
-	// default max 500). Currently not implemented for all platforms, given
-	// the ALT-TAB stuff for WIN32.
-	static int last_check = 0;
-	int current_check = GetTicks();
-	if (current_check - last_check <= DB_POLLSKIP)
-		return true;
-	last_check = current_check;
-#endif
-
 	SDL_Event event;
-#if defined (REDUCE_JOYSTICK_POLLING)
 	if (MAPPER_IsUsingJoysticks()) {
-		static int poll_delay = 0;
-		int time = GetTicks();
-		if (time - poll_delay > 20) {
-			poll_delay = time;
-			SDL_JoystickUpdate();
-			MAPPER_UpdateJoysticks();
-		}
+		SDL_JoystickUpdate();
+		MAPPER_UpdateJoysticks();
 	}
-#endif
 	while (SDL_PollEvent(&event)) {
 		switch (event.type) {
 		case SDL_WINDOWEVENT:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <cassert>
 #include <cerrno>
+#include <chrono>
 #include <cstdlib>
 #include <string.h>
 #include <stdio.h>
@@ -592,14 +593,30 @@ check_surface:
 	return flags;
 }
 
+// The frame-period holds the current duration for which a single host
+// video-frame is displayed. This is kept up-to-date when the video mode is set.
+// A sane starting value is used, which is based on a 60-Hz monitor.
+auto frame_period = std::chrono::nanoseconds(1000000000 / 60);
+static void UpdateFramePeriod()
+{
+	assert(sdl.window);
+	SDL_DisplayMode display_mode;
+	SDL_GetWindowDisplayMode(sdl.window, &display_mode);
+	const int refresh_rate = display_mode.refresh_rate > 0
+	                                 ? display_mode.refresh_rate
+	                                 : 60;
+	frame_period = std::chrono::nanoseconds(1000000000 / refresh_rate);
+}
 
 void GFX_ResetScreen(void) {
 	GFX_Stop();
 	if (sdl.draw.callback)
 		(sdl.draw.callback)( GFX_CallBackReset );
 	GFX_Start();
+	UpdateFramePeriod();
 	CPU_Reset_AutoAdjust();
 }
+
 
 void GFX_ForceFullscreenExit()
 {
@@ -2534,7 +2551,7 @@ static void FinalizeWindowState()
 	GFX_ResetScreen();
 }
 
-bool GFX_Events()
+static bool ProcessEvents()
 {
 #if defined(MACOSX)
 	// Don't poll too often. This can be heavy on the OS, especially Macs.
@@ -2783,8 +2800,42 @@ bool GFX_Events()
 	return !exit_requested;
 }
 
-#if defined (WIN32)
-static BOOL WINAPI ConsoleEventHandler(DWORD event) {
+// This function processes events just prior to the next frame period. The host
+// processing lag is measured and accounted for in the next pass.
+
+// Some modern (and very fast) systems experience unknown lag; in many cases
+// this is caused by host-event polling. Comment-in the REPORT_EVENT_LAG define
+// to have this function report excessive host lag. Typically process should be
+// well under 1 millisecond, however some hosts report lag in the tens to
+// hundereds of milliseconds.
+
+// #define REPORT_EVENT_LAG
+bool GFX_MaybeProcessEvents()
+{
+	static auto next_render_at = std::chrono::steady_clock::now() + frame_period;
+	const auto checked_at = std::chrono::steady_clock::now();
+	if (checked_at < next_render_at)
+		return true;
+
+	const bool process_result = ProcessEvents();
+	const auto rendered_at = std::chrono::steady_clock::now();
+	const auto host_lag = rendered_at - checked_at;
+	next_render_at = rendered_at + frame_period - host_lag;
+
+#if defined(REPORT_EVENT_LAG)
+	if (host_lag > std::chrono::milliseconds(3)) {
+		const auto host_lag_us =
+		        std::chrono::duration_cast<std::chrono::microseconds>(host_lag)
+		                .count();
+		LOG_MSG("SDL: Host polling took %.2f ms", host_lag_us / 1000.0);
+	}
+#endif
+	return process_result;
+}
+
+#if defined(WIN32)
+static BOOL WINAPI ConsoleEventHandler(DWORD event)
+{
 	switch (event) {
 	case CTRL_SHUTDOWN_EVENT:
 	case CTRL_LOGOFF_EVENT:
@@ -2798,7 +2849,6 @@ static BOOL WINAPI ConsoleEventHandler(DWORD event) {
 	}
 }
 #endif
-
 
 /* static variable to show wether there is not a valid stdout.
  * Fixes some bugs when -noconsole is used in a read only directory */


### PR DESCRIPTION
The previous code queried SDL's event queue 1000 times (or more) per second, which unnecessarily wastes CPU time. SDL maintainer Sam Lantinga recommends that SDL's event queue be pumped at the host's framerate [1]. 

This PR guarantees that the SDL event queue is processed within the frame-period:
 - Lag caused by the hosts is accounted for in the elapsed time.
 - By combining the above items, we can achieve RetroArch's "frame-delay" on the fly.

Even at the extremes, there is no risk of dropping events, for example: consider a slow 24 Hz display paired with an 8000-Hz mouse [2][3].  The display has a frame-time of 41.6 ms (1000 ms / 24 Hz) and the mouse can produce up to 8000 events/s or 333 events within a frame period (8000 Hz / 24 Hz = 333 events).  Given SDL2's  event queue can hold up to 65535 events [4], there is no risk of the queue overflowing within the display's frame period.

What happens when the host's lag to query events is greater than frame-period? In that case, the criteria to pump the event queue will _always_ trigger, in which case the behaviour matches the original code. 

[1] http://forums.libsdl.org/viewtopic.php?p=11582#11582
[2] https://www.youtube.com/watch?v=gOQNRvJbpmk
[3] https://www.razer.com/gaming/mice/razer-viper-8khz
[4] https://github.com/libsdl-org/SDL/blob/1cfbe664f5c0685d34be8b8bfdc1e45adb2932d2/src/events/SDL_events.c#L38
