### PR TITLE
Add pdcurses to the Windows list of vcpkg's in README.md

### DIFF
--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -11,6 +11,25 @@ Windows builds can be created using:
 2. Install vcpkg: <https://github.com/Microsoft/vcpkg#quick-start-windows>.
 3. Follow instructions in [README.md](/README.md).
 
+### Create a Debugger build using Visual Studio
+
+Note that the debugger imposes a significant runtime performance penalty.
+If you're not planning to use the debugger then the steps above will help
+you build a binary optimized for gaming.
+
+1. Follow the steps above to setup a working build environment.
+2. Install and integrate `pdcurses` using vcpkg:
+
+    ``` shell
+    cd \vcpkg
+    .\vcpkg install --triplet pdcurses
+    .\vcpkg integrate install
+    ```
+
+3. Edit `src\platform\visualc\config.h` and enable `C_DEBUG` and optionally
+  `C_HEAVY_DEBUG` by setting them to `1` instead of `0`.
+4. Select a **Release** build type in Visual Studio, and run the build.
+
 ## Build using MSYS2
 
 1. Install MSYS2: <https://www.msys2.org/>


### PR DESCRIPTION
This commit adds `pdcurses` to vcpkg's list in README.md given it's a dependency to build DOSBox's optional debugger.

The logic being that our vcpkg install line should provide all the dependencies needed to build the user-side features.

Given the debugger is no different than other optional user-side features (albeit a different use-case), we should therefore include it as a dependency. It's also neither risky nor resource intensive to do so.

I made the conscious decide /not/ to include the various `ncurses-devel` libs on the Linux and macOS side because we consider the debugger feature fully broken and unusable on those platforms.

Fixes #983 