### PR TITLE
Finalize dangling child classes

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -390,7 +390,7 @@ protected:
 	Bitu table_limit;
 };
 
-class GDTDescriptorTable : public DescriptorTable {
+class GDTDescriptorTable final : public DescriptorTable {
 public:
 	bool GetDescriptor(Bitu selector, Descriptor& desc) {
 		Bitu address=selector & ~7;
@@ -441,7 +441,7 @@ private:
 	Bitu ldt_value;
 };
 
-class TSS_Descriptor : public Descriptor {
+class TSS_Descriptor final : public Descriptor {
 public:
 	Bitu IsBusy(void) {
 		return saved.seg.type & 2;

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -303,7 +303,7 @@ protected:
 
 /* Program Segment Prefix */
 
-class DOS_PSP : public MemStruct {
+class DOS_PSP final : public MemStruct {
 public:
 	DOS_PSP(uint16_t segment) : seg(segment) { SetPt(seg); }
 
@@ -386,7 +386,7 @@ public:
 	static	Bit16u rootpsp;
 };
 
-class DOS_ParamBlock : public MemStruct {
+class DOS_ParamBlock final : public MemStruct {
 public:
 	DOS_ParamBlock(PhysPt addr)
 		: exec{0, 0, 0, 0, 0, 0},
@@ -421,7 +421,7 @@ public:
 	sOverlay overlay;
 };
 
-class DOS_InfoBlock : public MemStruct {
+class DOS_InfoBlock final : public MemStruct {
 public:
 	DOS_InfoBlock() : seg(0) {}
 
@@ -512,7 +512,7 @@ public:
  * Some documents refer to it also as Data Transfer Address or Disk Transfer Area.
  */
 
-class DOS_DTA : public MemStruct {
+class DOS_DTA final : public MemStruct {
 public:
 	DOS_DTA(RealPt addr) : MemStruct(addr) {}
 
@@ -562,7 +562,7 @@ private:
 
 /* File Control Block */
 
-class DOS_FCB : public MemStruct {
+class DOS_FCB final : public MemStruct {
 public:
 	DOS_FCB(uint16_t seg, uint16_t off, bool allow_extended = true);
 
@@ -633,7 +633,7 @@ private:
 
 /* Memory Control Block */
 
-class DOS_MCB : public MemStruct {
+class DOS_MCB final : public MemStruct {
 public:
 	DOS_MCB(uint16_t seg) : MemStruct(seg, 0) {}
 
@@ -665,7 +665,7 @@ private:
 	#endif
 };
 
-class DOS_SDA : public MemStruct {
+class DOS_SDA final : public MemStruct {
 public:
 	DOS_SDA(uint16_t seg, uint16_t off) : MemStruct(seg, off) {}
 

--- a/include/drives.h
+++ b/include/drives.h
@@ -153,7 +153,7 @@ struct partTable {
 #endif
 //Forward
 class imageDisk;
-class fatDrive : public DOS_Drive {
+class fatDrive final : public DOS_Drive {
 public:
 	fatDrive(const char * sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit32u startSector);
 	fatDrive(const fatDrive&) = delete; // prevent copying
@@ -216,7 +216,7 @@ private:
 	Bit32u curFatSect;
 };
 
-class cdromDrive : public localDrive
+class cdromDrive final : public localDrive
 {
 public:
 	cdromDrive(const char _driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error);
@@ -314,7 +314,7 @@ struct isoDirEntry {
 #define IS_HIDDEN(fileFlags)	(fileFlags & ISO_HIDDEN)
 #define ISO_MAX_HASH_TABLE_SIZE 	100
 
-class isoDrive : public DOS_Drive {
+class isoDrive final : public DOS_Drive {
 public:
 	isoDrive(char driveLetter, const char* device_name, Bit8u mediaid, int &error);
 	~isoDrive();
@@ -378,7 +378,7 @@ private:
 
 struct VFILE_Block;
 
-class Virtual_Drive: public DOS_Drive {
+class Virtual_Drive final : public DOS_Drive {
 public:
 	Virtual_Drive();
 	bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
@@ -406,7 +406,7 @@ private:
 	VFILE_Block * search_file;
 };
 
-class Overlay_Drive : public localDrive {
+class Overlay_Drive final : public localDrive {
 public:
 	Overlay_Drive(const char *startdir,
 	              const char *overlay,

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -463,7 +463,7 @@ const char *const serial_comname[] = {"COM1", "COM2", "COM3", "COM4"};
 
 // the COM devices
 
-class device_COM : public DOS_Device {
+class device_COM final : public DOS_Device {
 public:
 	device_COM(const device_COM &) = delete;            // prevent copying
 	device_COM &operator=(const device_COM &) = delete; // prevent assignment

--- a/include/setup.h
+++ b/include/setup.h
@@ -185,7 +185,7 @@ protected:
 	const Changeable::Value change;
 };
 
-class Prop_int : public Property {
+class Prop_int final : public Property {
 public:
 	Prop_int(const std::string &name, Changeable::Value when, int val)
 	        : Property(name, when),
@@ -221,7 +221,7 @@ private:
 	Value max_value;
 };
 
-class Prop_double:public Property {
+class Prop_double final : public Property {
 public:
 	Prop_double(std::string const & _propname, Changeable::Value when, double _value)
 		:Property(_propname,when){
@@ -231,7 +231,7 @@ public:
 	~Prop_double(){ }
 };
 
-class Prop_bool:public Property {
+class Prop_bool final : public Property {
 public:
 	Prop_bool(std::string const& _propname, Changeable::Value when, bool _value)
 		:Property(_propname,when) {
@@ -257,7 +257,7 @@ public:
 	bool CheckValue(const Value &in, bool warn) override;
 };
 
-class Prop_path : public Prop_string {
+class Prop_path final : public Prop_string {
 public:
 	Prop_path(const std::string &name, Changeable::Value when, const char *val)
 	        : Prop_string(name, when, val),
@@ -271,7 +271,7 @@ public:
 	std::string realpath;
 };
 
-class Prop_hex:public Property {
+class Prop_hex final : public Property {
 public:
 	Prop_hex(std::string const& _propname, Changeable::Value when, Hex _value)
 		:Property(_propname,when) {
@@ -328,7 +328,7 @@ public:
 class Prop_multival;
 class Prop_multival_remain;
 
-class Section_prop : public Section {
+class Section_prop final : public Section {
 private:
 	std::deque<Property *> properties = {};
 	typedef std::deque<Property*>::iterator it;
@@ -390,14 +390,14 @@ public:
 	const std::vector<Value> &GetValues() const override;
 };
 
-class Prop_multival_remain:public Prop_multival{
+class Prop_multival_remain final : public Prop_multival{
 public:
 	Prop_multival_remain(std::string const& _propname, Changeable::Value when,std::string const& sep):Prop_multival(_propname,when,sep){ }
 
 	virtual bool SetValue(std::string const& input);
 };
 
-class Section_line : public Section {
+class Section_line final : public Section {
 public:
 	Section_line(std::string const &name) : Section(name), data() {}
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -59,7 +59,7 @@ public:
 };
 
 class AutoexecEditor;
-class DOS_Shell : public Program {
+class DOS_Shell final : public Program {
 private:
 	friend class AutoexecEditor;
 	std::list<std::string> l_history{};

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2174,7 +2174,7 @@ void CPU_Reset_AutoAdjust(void) {
 	ticksScheduled = 0;
 }
 
-class CPU: public Module_base {
+class CPU final : public Module_base {
 private:
 	static bool inited;
 public:

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -112,7 +112,7 @@ static CacheBlock link_blocks[2]; // default linking (specially marked)
 
 // the CodePageHandler class provides access to the contained
 // cache blocks and intercepts writes to the code for special treatment
-class CodePageHandler : public PageHandler {
+class CodePageHandler final : public PageHandler {
 public:
 	CodePageHandler() = default;
 

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -241,7 +241,7 @@ static INLINE bool InitPage_CheckUseraccess(Bitu u1,Bitu u2) {
 }
 
 
-class InitPageHandler : public PageHandler {
+class InitPageHandler final : public PageHandler {
 public:
 	InitPageHandler() {
 		flags=PFLAG_INIT|PFLAG_NOCODE;
@@ -470,7 +470,7 @@ public:
 	}
 };
 
-class InitPageUserROHandler : public PageHandler {
+class InitPageUserROHandler final : public PageHandler {
 public:
 	InitPageUserROHandler() {
 		flags=PFLAG_INIT|PFLAG_NOCODE;
@@ -870,7 +870,7 @@ bool PAGING_Enabled(void) {
 	return paging.enabled;
 }
 
-class PAGING:public Module_base{
+class PAGING final : public Module_base{
 public:
 	PAGING(Section* configuration):Module_base(configuration){
 		/* Setup default Page Directory, force it to update */

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -78,7 +78,7 @@ char* AnalyzeInstruction(char* inst, bool saveSelector);
 Bit32u GetHexValue(char* str, char*& hex);
 
 #if 0
-class DebugPageHandler : public PageHandler {
+class DebugPageHandler final : public PageHandler {
 public:
 	Bitu readb(PhysPt /*addr*/) {
 	}
@@ -2132,7 +2132,7 @@ static void LogInstruction(uint16_t segValue, uint32_t eipValue, ofstream &out)
 
 // DEBUG.COM stuff
 
-class DEBUG : public Program {
+class DEBUG final : public Program {
 public:
 	DEBUG() : active(false) { pDebugcom = this; }
 

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -114,7 +114,7 @@ public:
 	virtual void InitNewMedia       (void) {}
 };
 
-class CDROM_Interface_Fake : public CDROM_Interface
+class CDROM_Interface_Fake final : public CDROM_Interface
 {
 public:
 	bool SetDevice          (char *) { return true; }
@@ -134,7 +134,7 @@ public:
 	bool LoadUnloadMedia    (bool /*unload*/) { return true; }
 };
 
-class CDROM_Interface_Image : public CDROM_Interface
+class CDROM_Interface_Image final : public CDROM_Interface
 {
 private:
 	// Nested Class Definitions
@@ -162,7 +162,7 @@ private:
 		const Bit16u chunkSize = 0;
 	};
 
-	class BinaryFile : public TrackFile {
+	class BinaryFile final : public TrackFile {
 	public:
 		BinaryFile      (const char *filename, bool &error);
 		~BinaryFile     ();
@@ -186,7 +186,7 @@ private:
 		std::ifstream   *file;
 	};
 
-	class AudioFile : public TrackFile {
+	class AudioFile final : public TrackFile {
 	public:
 		AudioFile       (const char *filename, bool &error);
 		~AudioFile      ();

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -24,7 +24,7 @@
 
 #define NUMBER_ANSI_DATA 10
 
-class device_CON : public DOS_Device {
+class device_CON final : public DOS_Device {
 public:
 	device_CON() { SetName("CON"); }
 

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -55,7 +55,7 @@ public:
 	virtual bool WriteToControlChannel(PhysPt /*bufptr*/,Bit16u /*size*/,Bit16u * /*retcode*/){return false;}
 };
 
-class device_LPT1 : public device_NUL {
+class device_LPT1 final : public device_NUL {
 public:
    	device_LPT1() { SetName("LPT1");}
 	Bit16u GetInformation(void) { return 0x80A0; }

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1105,7 +1105,7 @@ const char* DOS_GetLoadedLayout(void) {
 }
 
 
-class DOS_KeyboardLayout: public Module_base {
+class DOS_KeyboardLayout final : public Module_base {
 public:
 	DOS_KeyboardLayout(Section* configuration):Module_base(configuration){
 		Section_prop * section=static_cast<Section_prop *>(configuration);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -61,7 +61,7 @@ static Bitu MSCDEX_Strategy_Handler(void);
 static Bitu MSCDEX_Interrupt_Handler(void);
 static MountType MSCDEX_GetMountType(const char *path);
 
-class DOS_DeviceHeader : public MemStruct {
+class DOS_DeviceHeader final : public MemStruct {
 public:
 	DOS_DeviceHeader(PhysPt ptr) { pt = ptr; }
 
@@ -1276,7 +1276,7 @@ static bool MSCDEX_Handler(void) {
 	return true;
 }
 
-class device_MSCDEX : public DOS_Device {
+class device_MSCDEX final : public DOS_Device {
 public:
 	device_MSCDEX() { SetName("MSCD001"); }
 	bool Read (Bit8u * /*data*/,Bit16u * /*size*/) { return false;}

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -97,7 +97,7 @@ static const char *UnmountHelper(char umount)
 	return MSG_Get("PROGRAM_MOUNT_UMOUNT_SUCCESS");
 }
 
-class MOUNT : public Program {
+class MOUNT final : public Program {
 public:
 	void Move_Z(char new_z)
 	{
@@ -463,7 +463,7 @@ static void MOUNT_ProgramStart(Program * * make) {
 	*make=new MOUNT;
 }
 
-class MEM : public Program {
+class MEM final : public Program {
 public:
 	void Run(void) {
 		/* Show conventional Memory */
@@ -533,7 +533,7 @@ static void MEM_ProgramStart(Program * * make) {
 extern Bit32u floppytype;
 
 
-class BOOT : public Program {
+class BOOT final : public Program {
 private:
 
 	FILE *getFSFile_mounted(char const* filename, Bit32u *ksize, Bit32u *bsize, Bit8u *error) {
@@ -919,7 +919,7 @@ static void BOOT_ProgramStart(Program * * make) {
 }
 
 
-class LOADROM : public Program {
+class LOADROM final : public Program {
 public:
 	void Run(void) {
 		if (!(cmd->FindCommand(1, temp_line))) {
@@ -996,7 +996,7 @@ static void LOADROM_ProgramStart(Program * * make) {
 }
 
 #if C_DEBUG
-class BIOSTEST : public Program {
+class BIOSTEST final : public Program {
 public:
 	void Run(void) {
 		if (!(cmd->FindCommand(1, temp_line))) {
@@ -1056,7 +1056,7 @@ static void BIOSTEST_ProgramStart(Program * * make) {
 
 // LOADFIX
 
-class LOADFIX : public Program {
+class LOADFIX final : public Program {
 public:
 	void Run(void);
 };
@@ -1121,7 +1121,7 @@ static void LOADFIX_ProgramStart(Program * * make) {
 
 // RESCAN
 
-class RESCAN : public Program {
+class RESCAN final : public Program {
 public:
 	void Run(void);
 };
@@ -1161,7 +1161,7 @@ static void RESCAN_ProgramStart(Program * * make) {
 	*make=new RESCAN;
 }
 
-class INTRO : public Program {
+class INTRO final : public Program {
 public:
 	void DisplayMount(void) {
 		/* Basic mounting has a version for each operating system.
@@ -1215,7 +1215,7 @@ static void INTRO_ProgramStart(Program * * make) {
 	*make=new INTRO;
 }
 
-class IMGMOUNT : public Program {
+class IMGMOUNT final : public Program {
 public:
 	void Run(void) {
 		//Hack To allow long commandlines
@@ -1583,7 +1583,7 @@ Bitu DOS_SwitchKeyboardLayout(const char* new_layout, Bit32s& tried_cp);
 Bitu DOS_LoadKeyboardLayout(const char * layoutname, Bit32s codepage, const char * codepagefile);
 const char* DOS_GetLoadedLayout(void);
 
-class KEYB : public Program {
+class KEYB final : public Program {
 public:
 	void Run(void);
 };

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -38,7 +38,7 @@
 #define FAT16		   1
 #define FAT32		   2
 
-class fatFile : public DOS_File {
+class fatFile final : public DOS_File {
 public:
 	fatFile(const char* name, Bit32u startCluster, Bit32u fileLen, fatDrive *useDrive);
 	fatFile(const fatFile&) = delete; // prevent copy

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -30,7 +30,7 @@
 #define FLAGS1	((iso) ? de.fileFlags : de.timeZone)
 #define FLAGS2	((iso) ? de->fileFlags : de->timeZone)
 
-class isoFile : public DOS_File {
+class isoFile final : public DOS_File {
 public:
 	isoFile(isoDrive *drive, const char *name, FileStat_Block *stat, uint32_t offset);
 	isoFile(const isoFile &) = delete;            // prevent copying

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -192,7 +192,7 @@ bool Overlay_Drive::TestDir(char * dir) {
 	return localDrive::TestDir(dir);
 }
 
-class OverlayFile : public localFile {
+class OverlayFile final : public localFile {
 public:
 	OverlayFile(const char *name, FILE *handle, const char *basedir)
 	        : localFile(name, handle, basedir),

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -65,7 +65,7 @@ void VFILE_Remove(const char *name) {
 	}
 }
 
-class Virtual_File : public DOS_File {
+class Virtual_File final : public DOS_File {
 public:
 	Virtual_File(uint8_t *in_data, uint32_t in_size);
 

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -25,7 +25,7 @@
 
 #include <string>
 
-class AUTOTYPE : public Program {
+class AUTOTYPE final : public Program {
 public:
 	void Run();
 

--- a/src/dos/program_ls.h
+++ b/src/dos/program_ls.h
@@ -25,7 +25,7 @@
 
 #include <string>
 
-class LS : public Program {
+class LS final : public Program {
 public:
 	void Run();
 };

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -205,7 +205,7 @@ static void UI_Shutdown(GUI::ScreenSDL *screen) {
 }
 
 /* helper class for command execution */
-class VirtualBatch : public BatchFile {
+class VirtualBatch final : public BatchFile {
 protected:
 	std::istringstream lines;
 public:
@@ -234,7 +234,7 @@ static void UI_RunCommands(GUI::ScreenSDL *s, const std::string &cmds) {
 
 
 /* stringification and conversion from the c++ FAQ */
-class BadConversion : public std::runtime_error {
+class BadConversion final : public std::runtime_error {
 public: BadConversion(const std::string& s) : std::runtime_error(s) { }
 };
 
@@ -275,7 +275,7 @@ public:
 	}
 };
 
-class PropertyEditorBool : public PropertyEditor {
+class PropertyEditorBool final : public PropertyEditor {
 	GUI::Checkbox *input;
 public:
 	PropertyEditorBool(Window *parent, int x, int y, Section_prop *section, Property *prop) :
@@ -291,7 +291,7 @@ public:
 	}
 };
 
-class PropertyEditorString : public PropertyEditor {
+class PropertyEditorString final : public PropertyEditor {
 protected:
 	GUI::Input *input;
 public:
@@ -311,7 +311,7 @@ public:
 	}
 };
 
-class PropertyEditorFloat : public PropertyEditor {
+class PropertyEditorFloat final : public PropertyEditor {
 protected:
 	GUI::Input *input;
 public:
@@ -331,7 +331,7 @@ public:
 	}
 };
 
-class PropertyEditorHex : public PropertyEditor {
+class PropertyEditorHex final : public PropertyEditor {
 protected:
 	GUI::Input *input;
 public:
@@ -352,7 +352,7 @@ public:
 	}
 };
 
-class PropertyEditorInt : public PropertyEditor {
+class PropertyEditorInt final : public PropertyEditor {
 protected:
 	GUI::Input *input;
 public:
@@ -373,7 +373,7 @@ public:
 	}
 };
 
-class HelpWindow : public GUI::MessageBox {
+class HelpWindow final : public GUI::MessageBox {
 public:
 	HelpWindow(GUI::Screen *parent, int x, int y, Section *section) :
 		MessageBox(parent, x, y, 580, "", "") {
@@ -387,7 +387,7 @@ public:
 	}
 };
 
-class SectionEditor : public GUI::ToplevelWindow {
+class SectionEditor final : public GUI::ToplevelWindow {
 	Section_prop * section;
 public:
 	SectionEditor(GUI::Screen *parent, int x, int y, Section_prop *section) :
@@ -431,7 +431,7 @@ public:
 	}
 };
 
-class AutoexecEditor : public GUI::ToplevelWindow {
+class AutoexecEditor final : public GUI::ToplevelWindow {
 	Section_line * section;
 	GUI::Input *content;
 public:
@@ -467,7 +467,7 @@ public:
 	}
 };
 
-class SaveDialog : public GUI::ToplevelWindow {
+class SaveDialog final : public GUI::ToplevelWindow {
 protected:
 	GUI::Input *name;
 public:
@@ -486,7 +486,7 @@ public:
 	}
 };
 
-class SaveLangDialog : public GUI::ToplevelWindow {
+class SaveLangDialog final : public GUI::ToplevelWindow {
 protected:
 	GUI::Input *name;
 public:
@@ -505,7 +505,7 @@ public:
 	}
 };
 
-class ConfigurationWindow : public GUI::ToplevelWindow {
+class ConfigurationWindow final : public GUI::ToplevelWindow {
 public:
 	ConfigurationWindow(GUI::Screen *parent, GUI::Size x, GUI::Size y, GUI::String title) :
 		GUI::ToplevelWindow(parent, x, y, 470, 290, title) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -339,7 +339,7 @@ protected:
 class CKeyBind;
 class CKeyBindGroup;
 
-class CKeyBind : public CBind {
+class CKeyBind final : public CBind {
 public:
 	CKeyBind(CBindList *_list, SDL_Scancode _key)
 		: CBind(_list),
@@ -363,7 +363,7 @@ public:
 	SDL_Scancode key;
 };
 
-class CKeyBindGroup : public  CBindGroup {
+class CKeyBindGroup final : public  CBindGroup {
 public:
 	CKeyBindGroup(Bitu _keys)
 		: CBindGroup(),
@@ -438,7 +438,7 @@ class CJAxisBind;
 class CJButtonBind;
 class CJHatBind;
 
-class CJAxisBind : public CBind {
+class CJAxisBind final : public CBind {
 public:
 	CJAxisBind(CBindList *_list, CBindGroup *_group, int _axis, bool _positive)
 		: CBind(_list),
@@ -472,7 +472,7 @@ protected:
 	bool positive;
 };
 
-class CJButtonBind : public CBind {
+class CJButtonBind final : public CBind {
 public:
 	CJButtonBind(CBindList *_list, CBindGroup *_group, int _button)
 		: CBind(_list),
@@ -500,7 +500,7 @@ protected:
 	int button;
 };
 
-class CJHatBind : public CBind {
+class CJHatBind final : public CBind {
 public:
 	CJHatBind(CBindList *_list, CBindGroup *_group, uint8_t _hat, uint8_t _dir)
 		: CBind(_list),
@@ -890,7 +890,7 @@ protected:
 
 std::list<CStickBindGroup *> stickbindgroups;
 
-class C4AxisBindGroup : public  CStickBindGroup {
+class C4AxisBindGroup final : public  CStickBindGroup {
 public:
 	C4AxisBindGroup(Bitu _stick,Bitu _emustick) : CStickBindGroup (_stick,_emustick){
 		emulated_axes=4;
@@ -952,7 +952,7 @@ public:
 	}
 };
 
-class CFCSBindGroup : public  CStickBindGroup {
+class CFCSBindGroup final : public  CStickBindGroup {
 public:
 	CFCSBindGroup(Bitu _stick, Bitu _emustick)
 		: CStickBindGroup(_stick, _emustick)
@@ -1083,7 +1083,7 @@ private:
 	}
 };
 
-class CCHBindGroup : public CStickBindGroup {
+class CCHBindGroup final : public CStickBindGroup {
 public:
 	CCHBindGroup(Bitu _stick, Bitu _emustick)
 		: CStickBindGroup(_stick, _emustick)
@@ -1448,7 +1448,7 @@ public:
 class CEventButton;
 static CEventButton * last_clicked = NULL;
 
-class CEventButton : public CClickableTextButton {
+class CEventButton final : public CClickableTextButton {
 public:
 	CEventButton(Bitu x, Bitu y, Bitu dx, Bitu dy, const char *text, CEvent *ev)
 		: CClickableTextButton(x, y, dx, dy, text),
@@ -1471,7 +1471,7 @@ protected:
 	CEvent * event = nullptr;
 };
 
-class CCaptionButton : public CButton {
+class CCaptionButton final : public CButton {
 public:
 	CCaptionButton(Bitu _x,Bitu _y,Bitu _dx,Bitu _dy) : CButton(_x,_y,_dx,_dy){
 		caption[0]=0;
@@ -1498,7 +1498,7 @@ static void change_action_text(const char* text,Bit8u col);
 
 static void MAPPER_SaveBinds();
 
-class CBindButton : public CClickableTextButton {
+class CBindButton final : public CClickableTextButton {
 public:
 	CBindButton(Bitu _x, Bitu _y, Bitu _dx, Bitu _dy, const char * _text, BB_Types _type)
 		: CClickableTextButton(_x, _y, _dx, _dy, _text),
@@ -1543,7 +1543,7 @@ protected:
 	BB_Types type;
 };
 
-class CCheckButton : public CClickableTextButton {
+class CCheckButton final : public CClickableTextButton {
 public:
 	CCheckButton(Bitu x, Bitu y, Bitu dx, Bitu dy, const char *text, BC_Types t)
 		: CClickableTextButton(x, y, dx, dy, text),
@@ -1597,7 +1597,7 @@ protected:
 	BC_Types type;
 };
 
-class CKeyEvent : public CTriggeredEvent {
+class CKeyEvent final : public CTriggeredEvent {
 public:
 	CKeyEvent(char const * const entry, KBD_KEYS k)
 		: CTriggeredEvent(entry),
@@ -1611,7 +1611,7 @@ public:
 	KBD_KEYS key;
 };
 
-class CJAxisEvent : public CContinuousEvent {
+class CJAxisEvent final : public CContinuousEvent {
 public:
 	CJAxisEvent(char const * const entry, Bitu s, Bitu a, bool p, CJAxisEvent *op_axis)
 		: CContinuousEvent(entry),
@@ -1646,7 +1646,7 @@ protected:
 	CJAxisEvent * opposite_axis;
 };
 
-class CJButtonEvent : public CTriggeredEvent {
+class CJButtonEvent final : public CTriggeredEvent {
 public:
 	CJButtonEvent(char const * const entry, Bitu s, Bitu btn)
 		: CTriggeredEvent(entry),
@@ -1663,7 +1663,7 @@ protected:
 	Bitu stick,button;
 };
 
-class CJHatEvent : public CTriggeredEvent {
+class CJHatEvent final : public CTriggeredEvent {
 public:
 	CJHatEvent(char const * const entry, Bitu s, Bitu h, Bitu d)
 		: CTriggeredEvent(entry),
@@ -1681,7 +1681,7 @@ protected:
 	Bitu stick,hat,dir;
 };
 
-class CModEvent : public CTriggeredEvent {
+class CModEvent final : public CTriggeredEvent {
 public:
 	CModEvent(char const * const _entry, int _wmod)
 		: CTriggeredEvent(_entry),
@@ -1700,7 +1700,7 @@ protected:
 	int wmod;
 };
 
-class CHandlerEvent : public CTriggeredEvent {
+class CHandlerEvent final : public CTriggeredEvent {
 public:
 	CHandlerEvent(const char *entry,
 	              MAPPER_Handler *handle,

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -285,7 +285,7 @@ void CMOS_SetRegister(Bitu regNr, Bit8u val) {
 }
 
 
-class CMOS:public Module_base{
+class CMOS final : public Module_base{
 private:
 	IO_ReadHandleObject ReadHandler[2];
 	IO_WriteHandleObject WriteHandler[2];

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -353,7 +353,7 @@ again:
 	return done;
 }
 
-class DMA : public Module_base {
+class DMA final : public Module_base {
 public:
 	DMA(Section *configuration) : Module_base(configuration)
 	{

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -118,7 +118,7 @@ static Bitu read_cms_detect(Bitu port, Bitu /* iolen */) {
 	return retval;
 }
 
-class CMS : public Module_base {
+class CMS final : public Module_base {
 private:
 	IO_WriteHandleObject WriteHandler = {};
 	IO_WriteHandleObject DetWriteHandler = {};

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -778,7 +778,7 @@ static void CAPTURE_MidiEvent(bool pressed) {
 	}
 }
 
-class HARDWARE:public Module_base{
+class HARDWARE final : public Module_base{
 public:
 	HARDWARE(Section* configuration):Module_base(configuration){
 		Section_prop * section = static_cast<Section_prop *>(configuration);

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -584,7 +584,7 @@ io_val_t IO_ReadD(io_port_t port)
 	return retval;
 }
 
-class IO :public Module_base {
+class IO final : public Module_base {
 public:
 	IO(Section* configuration):Module_base(configuration){
 		iof_queue.used = 0;

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -850,7 +850,7 @@ void IPX_NetworkInit() {
 	return;
 }
 
-class IPXNET : public Program {
+class IPXNET final : public Program {
 public:
 	void HelpCommand(const char *helpStr) {
 		// Help on connect command
@@ -1086,7 +1086,7 @@ Bitu IPX_ESRHandler(void) {
 
 void VFILE_Remove(const char *name);
 
-class IPX : public Module_base {
+class IPX final : public Module_base {
 private:
 	CALLBACK_HandlerObject callback_ipx = {};
 	CALLBACK_HandlerObject callback_esr = {};

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -311,7 +311,7 @@ void JOYSTICK_ParseConfiguredType()
 	assert(joytype != JOY_UNSET);
 }
 
-class JOYSTICK : public Module_base {
+class JOYSTICK final : public Module_base {
 private:
 	IO_ReadHandleObject ReadHandler = {};
 	IO_WriteHandleObject WriteHandler = {};

--- a/src/hardware/mame/saa1099.h
+++ b/src/hardware/mame/saa1099.h
@@ -27,7 +27,7 @@
 
 // ======================> saa1099_device
 
-class saa1099_device : public device_t, public device_sound_interface {
+class saa1099_device final : public device_t, public device_sound_interface {
 public:
 	saa1099_device(const machine_config &mconfig,
 	               const char *tag,

--- a/src/hardware/mame/sn76496.h
+++ b/src/hardware/mame/sn76496.h
@@ -100,35 +100,35 @@ private:
 };
 
 // SN76496: Whitenoise verified, phase verified, periodic verified (by Michael Zapf)
-class sn76496_device : public sn76496_base_device
+class sn76496_device final : public sn76496_base_device
 {
 public:
 	sn76496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // U8106 not verified yet. todo: verify; (a custom marked sn76489? only used on mr. do and maybe other universal games)
-class u8106_device : public sn76496_base_device
+class u8106_device final : public sn76496_base_device
 {
 public:
 	u8106_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // Y2404 not verified yet. todo: verify; (don't be fooled by the Y, it's a TI chip, not Yamaha)
-class y2404_device : public sn76496_base_device
+class y2404_device final : public sn76496_base_device
 {
 public:
 	y2404_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // NCR8496 whitenoise verified, phase verified; verified by ValleyBell & NewRisingSun
-class sn76489_device : public sn76496_base_device
+class sn76489_device final : public sn76496_base_device
 {
 public:
 	sn76489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // PSSJ-3 whitenoise verified, phase verified; verified by ValleyBell & NewRisingSun
-class pssj3_device : public sn76496_base_device
+class pssj3_device final : public sn76496_base_device
 {
 public:
 	pssj3_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -136,42 +136,42 @@ public:
 
 
 // SN76489A: whitenoise verified, phase verified, periodic verified (by plgdavid)
-class sn76489a_device : public sn76496_base_device
+class sn76489a_device final : public sn76496_base_device
 {
 public:
 	sn76489a_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // SN76494 not verified, (according to datasheet: same as sn76489a but without the /8 divider)
-class sn76494_device : public sn76496_base_device
+class sn76494_device final : public sn76496_base_device
 {
 public:
 	sn76494_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // SN94624 whitenoise verified, phase verified, period verified; verified by PlgDavid
-class sn94624_device : public sn76496_base_device
+class sn94624_device final : public sn76496_base_device
 {
 public:
 	sn94624_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // NCR8496 not verified; info from smspower wiki and vgmpf wiki
-class ncr8496_device : public sn76496_base_device
+class ncr8496_device final : public sn76496_base_device
 {
 public:
 	ncr8496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // Verified by Justin Kerk
-class gamegear_device : public sn76496_base_device
+class gamegear_device final : public sn76496_base_device
 {
 public:
 	gamegear_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 // todo: verify; from smspower wiki, assumed to have same invert as gamegear
-class segapsg_device : public sn76496_base_device
+class segapsg_device final : public sn76496_base_device
 {
 public:
 	segapsg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -58,7 +58,7 @@ static struct MemoryBlock {
 
 HostPt MemBase;
 
-class IllegalPageHandler : public PageHandler {
+class IllegalPageHandler final : public PageHandler {
 public:
 	IllegalPageHandler() {
 		flags=PFLAG_INIT|PFLAG_NOCODE;
@@ -101,7 +101,7 @@ public:
 	}
 };
 
-class ROMPageHandler : public RAMPageHandler {
+class ROMPageHandler final : public RAMPageHandler {
 public:
 	ROMPageHandler() {
 		flags=PFLAG_READABLE|PFLAG_HASROM;
@@ -544,7 +544,7 @@ void MEM_PreparePCJRCartRom()
 
 HostPt GetMemBase(void) { return MemBase; }
 
-class MEMORY : public Module_base {
+class MEMORY final : public Module_base {
 private:
 	IO_ReadHandleObject ReadHandler{};
 	IO_WriteHandleObject WriteHandler{};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -797,7 +797,7 @@ static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, i
 static void MIXER_Stop(MAYBE_UNUSED Section *sec)
 {}
 
-class MIXER : public Program {
+class MIXER final : public Program {
 public:
 	void MakeVolume(char * scan,float & vol0,float & vol1) {
 		Bitu w=0;

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -631,7 +631,7 @@ static void MPU401_Reset(void) {
 	for (Bitu i=0;i<8;i++) {mpu.playbuf[i].type=T_OVERFLOW;mpu.playbuf[i].counter=0;}
 }
 
-class MPU401:public Module_base{
+class MPU401 final : public Module_base{
 private:
 	IO_ReadHandleObject ReadHandler[2];
 	IO_WriteHandleObject WriteHandler[2];

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1474,7 +1474,7 @@ static void NE2000_Poller(void) {
 #include <windows.h>
 #endif
 
-class NE2K: public Module_base {
+class NE2K final : public Module_base {
 private:
 	// Data
 	IO_ReadHandleObject ReadHandler8[0x20];

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -251,7 +251,7 @@ static PCI_Device* rqueued_devices[max_rqueued_devices];
 
 #include "pci_devices.h"
 
-class PCI:public Module_base{
+class PCI final : public Module_base{
 private:
 	bool initialized;
 

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -459,7 +459,7 @@ static void PCSPEAKER_CallBack(Bitu len)
 	else
 		spkr.chan->AddSamples_m16(len, buffer);
 }
-class PCSPEAKER:public Module_base {
+class PCSPEAKER final : public Module_base {
 private:
 	MixerObject MixerChan = {};
 public:

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -566,7 +566,7 @@ void TIMER_AddTick(void) {
 }
 
 /* Use full name to avoid name clash with compile option for position-independent code */
-class PIC_8259A: public Module_base {
+class PIC_8259A final : public Module_base {
 private:
 	IO_ReadHandleObject ReadHandler[4];
 	IO_WriteHandleObject WriteHandler[4];

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1645,7 +1645,7 @@ static void SBLASTER_CallBack(Bitu len) {
 	}
 }
 
-class SBLASTER: public Module_base {
+class SBLASTER final : public Module_base {
 private:
 	/* Data */
 	IO_ReadHandleObject ReadHandler[0x10];

--- a/src/hardware/serialport/directserial.h
+++ b/src/hardware/serialport/directserial.h
@@ -28,7 +28,7 @@
 
 #include "libserial.h"
 
-class CDirectSerial : public CSerial {
+class CDirectSerial final : public CSerial {
 public:
 	CDirectSerial(const CDirectSerial &) = delete; // prevent copying
 	CDirectSerial &operator=(const CDirectSerial &) = delete; // prevent

--- a/src/hardware/serialport/nullmodem.h
+++ b/src/hardware/serialport/nullmodem.h
@@ -33,7 +33,7 @@
 #define SERIAL_NULLMODEM_DTR_EVENT	SERIAL_BASE_EVENT_COUNT+3
 #define SERIAL_NULLMODEM_EVENT_COUNT	SERIAL_BASE_EVENT_COUNT+3
 
-class CNullModem : public CSerial {
+class CNullModem final : public CSerial {
 public:
 	CNullModem(const CNullModem &) = delete;            // prevent copying
 	CNullModem &operator=(const CNullModem &) = delete; // prevent assignment

--- a/src/hardware/serialport/serialdummy.h
+++ b/src/hardware/serialport/serialdummy.h
@@ -24,7 +24,7 @@
 
 //#define CHECKIT_TESTPLUG
 
-class CSerialDummy : public CSerial {
+class CSerialDummy final : public CSerial {
 public:
 	CSerialDummy(const uint8_t port_idx, CommandLine *cmd);
 	~CSerialDummy();

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1282,7 +1282,7 @@ bool CSerial::Putchar(uint8_t data, bool wait_dsr, bool wait_cts, uint32_t timeo
 	return true;
 }
 
-class SERIALPORTS:public Module_base {
+class SERIALPORTS final : public Module_base {
 public:
 	SERIALPORTS (Section * configuration):Module_base (configuration) {
 		uint16_t biosParameter[SERIAL_MAX_PORTS] = {0};

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -170,7 +170,7 @@ private:
 #define MREG_DTR_DELAY 25
 
 
-class CSerialModem : public CSerial {
+class CSerialModem final : public CSerial {
 public:
 	CSerialModem(const uint8_t port_idx, CommandLine *cmd);
 	~CSerialModem();

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -317,7 +317,7 @@ static void TandyDACUpdate(size_t requested)
 	tandy.dac.chan->AddSamples_m8(requested, buf);
 }
 
-class TANDYSOUND: public Module_base {
+class TANDYSOUND final : public Module_base {
 private:
 	IO_WriteHandleObject WriteHandler[4];
 	IO_ReadHandleObject ReadHandler[4];

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -412,7 +412,7 @@ bool TIMER_GetOutput2(void) {
 	return counter_output(2);
 }
 
-class TIMER:public Module_base{
+class TIMER final : public Module_base{
 private:
 	IO_ReadHandleObject ReadHandler[4];
 	IO_WriteHandleObject WriteHandler[4];

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -176,7 +176,7 @@ public:
 	}
 };
 
-class VGA_ChainedEGA_Handler : public PageHandler {
+class VGA_ChainedEGA_Handler final : public PageHandler {
 public:
 	Bitu readHandler(PhysPt addr) {
 		return vga.mem.linear[addr];
@@ -323,7 +323,7 @@ public:
 };
 
 //Slighly unusual version, will directly write 8,16,32 bits values
-class VGA_ChainedVGA_Handler : public PageHandler {
+class VGA_ChainedVGA_Handler final : public PageHandler {
 public:
 	VGA_ChainedVGA_Handler()  {
 		flags=PFLAG_NOCODE;
@@ -415,7 +415,7 @@ public:
 	}
 };
 
-class VGA_UnchainedVGA_Handler : public VGA_UnchainedRead_Handler {
+class VGA_UnchainedVGA_Handler final : public VGA_UnchainedRead_Handler {
 public:
 	void writeHandler( PhysPt addr, Bit8u val ) {
 		Bit32u data=ModeOperation(val);
@@ -458,7 +458,7 @@ public:
 	}
 };
 
-class VGA_TEXT_PageHandler : public PageHandler {
+class VGA_TEXT_PageHandler final : public PageHandler {
 public:
 	VGA_TEXT_PageHandler() {
 		flags=PFLAG_NOCODE;
@@ -492,7 +492,7 @@ public:
 	}
 };
 
-class VGA_Map_Handler : public PageHandler {
+class VGA_Map_Handler final : public PageHandler {
 public:
 	VGA_Map_Handler() {
 		flags=PFLAG_READABLE|PFLAG_WRITEABLE|PFLAG_NOCODE;
@@ -507,7 +507,7 @@ public:
 	}
 };
 
-class VGA_Changes_Handler : public PageHandler {
+class VGA_Changes_Handler final : public PageHandler {
 public:
 	VGA_Changes_Handler() {
 		flags=PFLAG_NOCODE;
@@ -553,7 +553,7 @@ public:
 	}
 };
 
-class VGA_LIN4_Handler : public VGA_UnchainedEGA_Handler {
+class VGA_LIN4_Handler final : public VGA_UnchainedEGA_Handler {
 public:
 	VGA_LIN4_Handler() {
 		flags=PFLAG_NOCODE;
@@ -604,7 +604,7 @@ public:
 };
 
 
-class VGA_LFBChanges_Handler : public PageHandler {
+class VGA_LFBChanges_Handler final : public PageHandler {
 public:
 	VGA_LFBChanges_Handler() {
 		flags=PFLAG_NOCODE;
@@ -644,7 +644,7 @@ public:
 	}
 };
 
-class VGA_LFB_Handler : public PageHandler {
+class VGA_LFB_Handler final : public PageHandler {
 public:
 	VGA_LFB_Handler() {
 		flags=PFLAG_READABLE|PFLAG_WRITEABLE|PFLAG_NOCODE;
@@ -661,7 +661,7 @@ public:
 extern void XGA_Write(Bitu port, Bitu val, Bitu len);
 extern Bitu XGA_Read(Bitu port, Bitu len);
 
-class VGA_MMIO_Handler : public PageHandler {
+class VGA_MMIO_Handler final : public PageHandler {
 public:
 	VGA_MMIO_Handler() {
 		flags=PFLAG_NOCODE;
@@ -693,7 +693,7 @@ public:
 	}
 };
 
-class VGA_TANDY_PageHandler : public PageHandler {
+class VGA_TANDY_PageHandler final : public PageHandler {
 public:
 	VGA_TANDY_PageHandler() {
 		flags=PFLAG_READABLE|PFLAG_WRITEABLE;
@@ -713,7 +713,7 @@ public:
 };
 
 
-class VGA_PCJR_Handler : public PageHandler {
+class VGA_PCJR_Handler final : public PageHandler {
 public:
 	VGA_PCJR_Handler() {
 		flags=PFLAG_READABLE|PFLAG_WRITEABLE;
@@ -730,7 +730,7 @@ public:
 	}
 };
 
-class VGA_HERC_Handler : public PageHandler {
+class VGA_HERC_Handler final : public PageHandler {
 public:
 	VGA_HERC_Handler() {
 		flags=PFLAG_READABLE|PFLAG_WRITEABLE;
@@ -744,7 +744,7 @@ public:
 	}
 };
 
-class VGA_Empty_Handler : public PageHandler {
+class VGA_Empty_Handler final : public PageHandler {
 public:
 	VGA_Empty_Handler() {
 		flags=PFLAG_NOCODE;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1033,7 +1033,7 @@ void BIOS_ZeroExtendedSize(bool in) {
 void BIOS_SetupKeyboard(void);
 void BIOS_SetupDisks(void);
 
-class BIOS:public Module_base{
+class BIOS final : public Module_base{
 private:
 	CALLBACK_HandlerObject callback[11];
 public:

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -102,7 +102,7 @@ static EMM_Mapping emm_segmentmappings[0x40];
 
 static Bit16u GEMMIS_seg;
 
-class device_EMM : public DOS_Device {
+class device_EMM final : public DOS_Device {
 public:
 	device_EMM(bool is_emm386_avail) : is_emm386(is_emm386_avail)
 	{
@@ -1363,7 +1363,7 @@ Bitu GetEMSType(Section_prop * section) {
 	return rtype;
 }
 
-class EMS : public Module_base {
+class EMS final : public Module_base {
 private:
 	uint16_t ems_baseseg = 0;
 	DOS_Device *emm_device = nullptr;

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -414,7 +414,7 @@ Bitu XMS_Handler(void) {
 
 Bitu GetEMSType(Section_prop * section);
 
-class XMS: public Module_base {
+class XMS final : public Module_base {
 private:
 	CALLBACK_HandlerObject callbackhandler;
 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -208,7 +208,7 @@ bool MIDI_Available()
 	return midi.available;
 }
 
-class MIDI : public Module_base {
+class MIDI final : public Module_base {
 public:
 	MIDI(Section *configuration) : Module_base(configuration)
 	{

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -33,7 +33,7 @@ struct alsa_address {
 	int port;
 };
 
-class MidiHandler_alsa : public MidiHandler {
+class MidiHandler_alsa final : public MidiHandler {
 private:
 	snd_seq_event_t ev = {};
 	snd_seq_t *seq_handle = nullptr;

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -62,7 +62,7 @@ do {                                                                \
 #   endif
 #endif
 
-class MidiHandler_coreaudio : public MidiHandler {
+class MidiHandler_coreaudio final : public MidiHandler {
 private:
 	AUGraph m_auGraph;
 	AudioUnit m_synth;

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -32,7 +32,7 @@
 
 #include "programs.h"
 
-class MidiHandler_coremidi : public MidiHandler {
+class MidiHandler_coremidi final : public MidiHandler {
 private:
 	MIDIPortRef m_port;
 	MIDIClientRef m_client;

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -24,7 +24,7 @@
 
 #include "midi_handler.h"
 
-class MidiHandler_oss : public MidiHandler {
+class MidiHandler_oss final : public MidiHandler {
 private:
 	int device = 0;
 	uint8_t device_num = 0;

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -34,7 +34,7 @@
 
 #include "programs.h"
 
-class MidiHandler_win32: public MidiHandler {
+class MidiHandler_win32 final : public MidiHandler {
 private:
 	HMIDIOUT m_out;
 	MIDIHDR m_hdr;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -314,7 +314,7 @@ bool Program::SetEnv(const char * entry,const char * new_string) {
 bool MSG_Write(const char *);
 void restart_program(std::vector<std::string> & parameters);
 
-class CONFIG : public Program {
+class CONFIG final : public Program {
 public:
 	void Run(void);
 private:

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -393,7 +393,7 @@ void DOS_Shell::SyntaxError()
 	WriteOut(MSG_Get("SHELL_SYNTAXERROR"));
 }
 
-class AUTOEXEC:public Module_base {
+class AUTOEXEC final : public Module_base {
 private:
 	AutoexecObject autoexec[17];
 	AutoexecObject autoexec_echo;


### PR DESCRIPTION
This PR adds the `final` qualifier to child classes that aren't further derived.

Benefits are discussed here: https://devblogs.microsoft.com/cppblog/the-performance-benefits-of-final-classes/

Analysis of DOSBox Staging by @LowLevelMahn shows that previously, the code looks up the derived member function using a virtual lookup table followed by calling the function:

``` asm
   mov    (%rdi),%rax
   call   *(%rax)
```

There are hundreds of derived member functions; the tally for for one of these functions (`host_readb`)  comes in at 861 calls. 

When `final` is added, the derived member function is called without using a virtual lookup table:

``` asm
call   <_ZN15CodePageHandler13GetHostReadPtEm>
```

LTO and optimizations help remove these - however this isn't always guaranteed; and perhaps even more important on marginal and resource-limited platforms. 

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/980.