### PR TITLE
Update FluidSynth wrap to use 2.2.0

### DIFF
--- a/subprojects/fluidsynth.wrap
+++ b/subprojects/fluidsynth.wrap
@@ -1,12 +1,11 @@
 [wrap-file]
-directory = fluidsynth-2.1.8
-source_url = https://github.com/FluidSynth/fluidsynth/archive/v2.1.8.tar.gz
-source_filename = fluidsynth-2.1.8.tar.gz
-source_hash = a254efceff5d99f8d658d12d25318317f37307e6df852ec9baeb7da173496967
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/fluidsynth/2.1.8/1/get_zip
-patch_filename = fluidsynth-2.1.8-1-wrap.zip
-patch_hash = 78564c496c079c598204c8a0fe3693f83abcddbd648259a0761a3c126e50e6db
+directory = fluidsynth-2.2.0
+source_url = https://github.com/FluidSynth/fluidsynth/archive/v2.2.0.tar.gz
+source_filename = fluidsynth-2.2.0.tar.gz
+source_hash = 928fb16f307507485bd1d9b010dafba8c747bce5de2ba47ab1705944c87013b6
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/fluidsynth/2.2.0/1/get_zip
+patch_filename = fluidsynth-2.2.0-1-wrap.zip
+patch_hash = 8017e749a0879df74ce8ee8316a5b8e79a79c2bf7931db25e8f40a7f3d33e9b0
 
 [provide]
 fluidsynth = fluidsynth_dep
-


### PR DESCRIPTION
FluidSynth 2.2.0 release notes - https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.0