### PR TITLE
Don't underflow when removing trailing spaces

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1094,7 +1094,11 @@ bool fatDrive::FindFirst(char *_dir, DOS_DTA &dta,bool /*fcb_findfirst*/) {
 }
 
 char* removeTrailingSpaces(char* str, const size_t max_len) {
-	char* end = str + strnlen(str, max_len);
+	const auto str_len = strnlen(str, max_len);
+	if (str_len == 0)
+		return str;
+
+	char* end = str + str_len;
 	while((*--end == ' ') && (end > str)) {
 		/* do nothing; break on while criteria */
 	}


### PR DESCRIPTION
While mounting FAT images, the `removeTrailingSpaces` function underflows its `str` pointer argument when processing zero-length strings while iterating to find the first file.

Fixes #1008.

Regression tested and working.