### PR TITLE
Fix shifting of negative 8-bit samples in `fast` OPL2 mode 

### DIFF
--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -856,7 +856,7 @@ INLINE void Channel::GeneratePercussion( Chip* chip, Bit32s* output ) {
 		Bit32u tcIndex = (1 + phaseBit) << 8;
 		sample += Op(5)->GetWave( tcIndex, tcVol );
 	}
-	sample <<= 1;
+	sample *= 2; // don't bit-shift signed values
 	if ( opl3Mode ) {
 		output[0] += sample;
 		output[1] += sample;


### PR DESCRIPTION
Reproduce with Meson configuration:

``` shell
meson setup -Dbuildtype=debugoptimized -Db_sanitize=address,undefined -Db_lundef=false -Dc_args=-fsanitize-recover=all -Dcpp_args=-fsanitize-recover=all -Ddefault_library=static -Dfluidsynth:enable-floats=true -Dfluidsynth:try-static-deps=true build/clang-both-a_u

meson compile -C build/clang-both-a_u
```

DOSBox configuration:

``` ini
[sblaster]
oplmode = opl2
oplemu = fast
```

Game: Blues Brothers

``` text
../../src/hardware/dbopl.cpp:859:9: runtime error: left shift of negative value -2436
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../src/hardware/dbopl.cpp:859:9 in 
```
