### PR TITLE
Sync Nuked with upstream

### DIFF
--- a/src/libs/nuked/opl3.c
+++ b/src/libs/nuked/opl3.c
@@ -475,7 +475,7 @@ static void OPL3_EnvelopeCalc(opl3_slot *slot)
         }
         else if (slot->key && shift > 0 && rate_hi != 0x0f)
         {
-            eg_inc = ((~slot->eg_rout) << shift) >> 4;
+            eg_inc = ~slot->eg_rout >> (4 - shift);
         }
         break;
     case envelope_gen_num_decay:


### PR DESCRIPTION
Fix left-shift of negative value in Nuked (https://github.com/nukeykt/Nuked-OPL3/issues/7)

Confirmed fixed. Tested:
- Blues Bros
- Kult
- Adventures of Moktar
- Lord of the Realm
- Super Cauldron
- Wolf 3D

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/937.