### PR TITLE
Adjust the `format-commit` script to work natively on macOS

### DIFF
--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -50,8 +50,8 @@ main () {
 }
 
 handle_dependencies () {
-	assert_min_version git 1007010 "Use git in version 1.7.10 or newer."
-	assert_min_version clang-format 9000000 "Use clang-format in version 9.0.0 or newer."
+	assert_min_version git 1007010 "Use git version 1.7.10 or newer."
+	assert_min_version clang-format 9000000 "Use clang-format version 9.0.0 or newer."
 }
 
 assert_min_version () {

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -84,7 +84,7 @@ format () {
 }
 
 assert_empty_diff () {
-	if [ -n "$(git_diff HEAD)" ] ; then
+	if [[ -n "$(git_diff HEAD)" ]] ; then
 		git_diff HEAD
 		echo
 		echo "clang-format formatted some code for you."
@@ -95,7 +95,7 @@ assert_empty_diff () {
 }
 
 show_tip () {
-	if [ -n "$(git_diff HEAD)" ] ; then
+	if [[ -n "$(git_diff HEAD)" ]] ; then
 		echo
 		echo "clang-format formatted some code for you."
 		echo


### PR DESCRIPTION
This makes a small adjustment replacing `xargs` (which was used to strip carriage returns from a piped string) for a bash-array, and takes care to use only bash-3.x syntax.
