### PR TITLE
Use overloaded function to handle different strerror_r variants (by @joshuakraemer)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,7 +67,7 @@ jobs:
           - name: GCC, warning_level=3
             os: ubuntu-20.04
             build_flags: -Dwarning_level=3
-            max_warnings: 68
+            max_warnings: 64
 
           - name: GCC, minimum build
             os: ubuntu-20.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 145
+            max_warnings: 146
 
     steps:
       - uses: actions/checkout@v2

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -315,13 +315,13 @@ void E_Exit(const char *format, ...)
 
 /* Overloaded function to handle different return types of POSIX and GNU
  * strerror_r variants */
-static const char *strerror_result(int retval, const char *buf)
+MAYBE_UNUSED static const char *strerror_result(int retval, const char *err_str)
 {
-	return retval == 0 ? buf : nullptr;
+	return retval == 0 ? err_str : nullptr;
 }
-static const char *strerror_result(const char *retval, const char *buf)
+MAYBE_UNUSED static const char *strerror_result(const char *err_str, MAYBE_UNUSED const char *buf)
 {
-	return retval;
+	return err_str;
 }
 
 std::string safe_strerror(int err) noexcept

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -153,7 +153,7 @@ std::vector<std::string> split(const std::string &seq, const char delim)
 }
 
 std::vector<std::string> split(const std::string &seq)
-{	
+{
 	std::vector<std::string> words;
 	if (seq.empty())
 		return words;
@@ -193,7 +193,7 @@ void strip_punctuation(std::string &str) {
 		str.end());
 }
 
-/* 
+/*
 	Ripped some source from freedos for this one.
 
 */
@@ -210,7 +210,7 @@ void strreplace(char * str,char o,char n) {
 		str++;
 	}
 }
-char *ltrim(char *str) { 
+char *ltrim(char *str) {
 	while (*str && isspace(*reinterpret_cast<unsigned char*>(str))) str++;
 	return str;
 }
@@ -263,7 +263,7 @@ char * ScanCMDRemain(char * cmd) {
 		while ( *scan && !isspace(*reinterpret_cast<unsigned char*>(scan)) ) scan++;
 		*scan=0;
 		return found;
-	} else return 0; 
+	} else return 0;
 }
 
 char * StripWord(char *&line) {
@@ -313,6 +313,17 @@ void E_Exit(const char *format, ...)
 	throw(e_exit_buf);
 }
 
+/* Overloaded function to handle different return types of POSIX and GNU
+ * strerror_r variants */
+static const char *strerror_result(int retval, const char *buf)
+{
+	return retval == 0 ? buf : nullptr;
+}
+static const char *strerror_result(const char *retval, const char *buf)
+{
+	return retval;
+}
+
 std::string safe_strerror(int err) noexcept
 {
 	char buf[128];
@@ -320,15 +331,8 @@ std::string safe_strerror(int err) noexcept
 	// C11 version; unavailable in C++14 in general.
 	strerror_s(buf, ARRAY_LEN(buf), err);
 	return buf;
-#elif defined(_GNU_SOURCE)
-	// GNU has POSIX-incompatible version, which fills the buffer
-	// only when unknown error is passed, otherwise it returns
-	// the internal glibc buffer.
-	return strerror_r(err, buf, ARRAY_LEN(buf));
 #else
-	// POSIX version
-	strerror_r(err, buf, ARRAY_LEN(buf));
-	return buf;
+	return strerror_result(strerror_r(err, buf, ARRAY_LEN(buf)), buf);
 #endif
 }
 


### PR DESCRIPTION
Closes: #1047.

Thank you, @joshuakraemer, for reporting and implementing this!

(temporary local PR to drive the change through CI)