### PR TITLE
Use the PS/1 2011's BIOS identifiers when PS/1 Audio is enabled

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 174
+            max_warnings: 175
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 271
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1967
+            max_warnings: 1968
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -40,6 +40,7 @@ void CMS_Init(Section* sec);
 void OPL_ShutDown(Section* sec);
 void CMS_ShutDown(Section* sec);
 
+bool PS1AUDIO_IsEnabled();
 bool SB_Get_Address(Bitu& sbaddr, Bitu& sbirq, Bitu& sbdma);
 bool TS_Get_Address(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
 

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -427,11 +427,17 @@ static void PS1AUDIO_ShutDown(MAYBE_UNUSED Section *sec)
 	ps1_synth.reset();
 }
 
-void PS1AUDIO_Init(Section *sec)
+bool PS1AUDIO_IsEnabled()
 {
-	assert(sec);
-	Section_prop *section = static_cast<Section_prop *>(sec);
-	if (!section->Get_bool("ps1audio"))
+	const auto section = control->GetSection("speaker");
+	assert(section);
+	const auto properties = static_cast<Section_prop *>(section);
+	return properties->Get_bool("ps1audio");
+}
+
+void PS1AUDIO_Init(MAYBE_UNUSED Section *sec)
+{
+	if (!PS1AUDIO_IsEnabled())
 		return;
 
 	ps1_dac = std::make_unique<Ps1Dac>();

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -398,7 +398,13 @@ void Ps1Synth::WriteSoundGeneratorPort205(MAYBE_UNUSED uint16_t port, uint8_t da
 void Ps1Synth::Update(uint16_t samples)
 {
 	assert(samples <= max_samples_expected);
-	int16_t *buffer_head[1] = {buffer[0]};
+
+	// sound_stream_update's API requires an array of two pointers that
+	// point to either the mono array head or left and right heads. In this
+	// case, we're using a mono array but we still want to comply with the
+	// API, so we give it a valid two-element pointer array.
+	int16_t *buffer_head[] = {buffer[0], buffer[0]}; 
+
 	device_sound_interface::sound_stream ss;
 	static_cast<device_sound_interface &>(device).sound_stream_update(
 	        ss, nullptr, buffer_head, samples);


### PR DESCRIPTION
Prior to this PR, the ps1audio implementation worked, but some installers (like Sierra's) wouldn't acknowledge the presence of the card. Note the lack of a tick-box:

![2021-06-05_11-45](https://user-images.githubusercontent.com/1557255/120906386-de37b780-c60d-11eb-88ea-85a6ccf1f8e6.png)

This is because the installer also performs a machine-check in the BIOS, to see if it's a "real" first-model IBM PS/1 2011.  Fortunately the installer still lets you select it by acknowledging the pop-up:

![2021-06-05_11-46](https://user-images.githubusercontent.com/1557255/120906481-9d8c6e00-c60e-11eb-956f-40ee38863497.png)

After this PR, Sierra's installer finally believes the PS/1 device is available fom the get-go (provided `ps1audio = ..` is enabled in the conf file):

![2021-06-05_11-47](https://user-images.githubusercontent.com/1557255/120906496-bbf26980-c60e-11eb-9b84-98cd4f84647d.png)
