### PR TITLE
Use regular expression to expand shell variables

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 271
+            max_warnings: 272
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1967
+            max_warnings: 1968
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iterator>
+#include <regex>
 
 #include "regs.h"
 #include "callback.h"
@@ -389,106 +390,38 @@ void DOS_Shell::InputCommand(char * line) {
 	ProcessCmdLineEnvVarStitution(line);
 }
 
-/* WARNING: Substitution is carried out in-place!
- * Buffer pointed to by "line" must be at least CMD_MAXLINE+1 bytes long! */
-void DOS_Shell::ProcessCmdLineEnvVarStitution(char *line) {
-
-	// TODO: Replace this with a regular expression
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// In the provided 'line' string, replace all instances of %variable_name%s
-	// with equally named environment "variable_name"s'values, as fetched from
-	// the GetEnvStr(variable_name, variable_string_value) function.
-
-	char temp[CMD_MAXLINE]; /* <- NTS: Currently 4096 which is very generous indeed! */
-	char* w = temp;
-	const char* wf = temp + sizeof(temp) - 1;
-	char *r=line;
-	/* initial scan: is there anything to substitute? */
-	/* if not, then return without modifying "line" */
-	while (*r != 0 && *r != '%') r++;
-	if (*r != '%') return;
-	/* if the incoming string is already too long, then that's a problem too! */
-	if (((size_t)(r+1-line)) >= CMD_MAXLINE) {
-		LOG_MSG("DOS_Shell::ProcessCmdLineEnvVarStitution WARNING incoming string to substitute is already too long!\n");
-		goto overflow;
-	}
-	/* copy the string down up to that point */
-	for (const char* c = line; c < r;) {
-		assert(w < wf);
-		*w++ = *c++;
-	}
-	/* begin substitution process */
-	while (*r != 0) {
-		if (*r == '%') {
-			r++;
-			if (*r == '%' || *r == 0) {
-				/* %% or leaving a trailing % at the end (Win95 behavior) becomes a single '%' */
-				if (w >= wf) goto overflow;
-				*w++ = '%';
-				if (*r != 0) r++;
-				else break;
-			}
-			else {
-				const char* name = r; /* store pointer, 'r' is first char of the name following '%' */
-				int spaces = 0,chars = 0;
-				if (isalpha(*r) || *r == ' ') { /* must start with a letter. space is apparently valid too. (Win95) */
-					if (*r == ' ') spaces++;
-					else if (isalpha(*r)) chars++;
-					r++;
-					while (*r != 0 && *r != '%') {
-						if (*r == ' ') spaces++;
-						else chars++;
-						r++;
-					}
-				}
-				if (*r == '%' && ((spaces > 0 && chars == 0) || (spaces == 0 && chars > 0))) {
-					std::string temp2;
-					/* valid name found. substitute */
-					*r++ = 0; /* ASCIIZ snip */
-					if (GetEnvStr(name,temp2)) {
-						size_t equ_pos = temp2.find_first_of('=');
-						if (equ_pos != std::string::npos) {
-							const char *base = temp2.c_str();
-							const char *value = base + equ_pos + 1;
-							const char *fence = base + temp2.length();
-							assert(value >= base && value <= fence);
-							size_t len = (size_t)(fence-value);
-							if ((w+len) > wf) goto overflow;
-							memcpy(w,value,len);
-							w += len;
-						}
-					}
-				}
-				else {
-					/* nope. didn't find a valid name */
-					while (*r == ' ') r++; /* skip spaces */
-					name--; /* step "name" back to cover the first '%' we found */
-					for (const char* c = name; c < r;) {
-						if (w >= wf) goto overflow;
-						*w++ = *c++;
-					}
-				}
-			}
+/* Note: Buffer pointed to by "line" must be at least CMD_MAXLINE+1 bytes long! */
+void DOS_Shell::ProcessCmdLineEnvVarStitution(char* line) {
+	constexpr char surrogate_percent = 8;
+	const static std::regex re("\\%([^%0-9][^%]*)?%");
+	std::string text = line;
+	std::smatch match;
+	/* Iterate over potential %var1%, %var2%, etc matches found in the text string */
+	while (std::regex_search(text, match, re)) {
+		std::string variable_name;
+		variable_name = match[1].str();
+		if (!variable_name.size()) {
+			/* Replace %% with the character "surrogate_percent", then (eventually) % */
+			text.replace(match[0].first, match[0].second, std::string(1, surrogate_percent));
+			continue;
+		}
+		/* Trim preceding spaces from the variable name */
+		variable_name.erase(0, variable_name.find_first_not_of(' '));
+		std::string variable_value;
+		if (variable_name.size() && GetEnvStr(variable_name.c_str(), variable_value)) {
+			const size_t equal_pos = variable_value.find_first_of('=');
+			/* Replace the original %var% with its corresponding value from the environment */
+			const std::string replacement = equal_pos != std::string::npos
+			                ? variable_value.substr(equal_pos + 1) : "";
+			text.replace(match[0].first, match[0].second, replacement);
 		}
 		else {
-			if (w >= wf) goto overflow;
-			*w++ = *r++;
+			text.replace(match[0].first, match[0].second, "");
 		}
 	}
-	/* complete the C-string */
-	assert(w <= wf);
-	*w = 0;
-	/* copy the string back over the buffer pointed to by line */
-	{
-		size_t out_len = (size_t)(w+1-temp); /* length counting the NUL too */
-		assert(out_len <= CMD_MAXLINE);
-		memcpy(line,temp,out_len);
-	}
-	/* success */
-	return;
-overflow:
-	*line = 0; /* clear string (C-string chop with NUL) */
-	WriteOut("Command input error: string expansion overflow\n");
+	std::replace(text.begin(), text.end(), surrogate_percent, '%');
+	assert(text.size() <= CMD_MAXLINE);
+	safe_strncpy(line, text.c_str(), CMD_MAXLINE);
 }
 
 std::string full_arguments = "";


### PR DESCRIPTION
This is a continuation of PR #632 and #1052, that is, to improve the code for expansions of environment variables in the DOS command line using regular expressions. The code is noticeable shorter (and also hopefully cleaner) than the previous one. There is an increase of a single warning because of the use of strcpy statement in the final line.