### PR TITLE
convert SDL to STL functions for GetTicks and Delay

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -19,12 +19,14 @@
 #ifndef DOSBOX_TIMER_H
 #define DOSBOX_TIMER_H
 
+#include <chrono>
+#include <thread>
+#include <cassert>
+#include <climits>
+
 /* underlying clock rate in HZ */
-#include <SDL.h>
 
 #define PIT_TICK_RATE 1193182
-
-#define GetTicks() SDL_GetTicks()
 
 typedef void (*TIMER_TickHandler)(void);
 
@@ -34,5 +36,30 @@ void TIMER_DelTickHandler(TIMER_TickHandler handler);
 
 /* This will add 1 milliscond to all timers */
 void TIMER_AddTick(void);
+
+static inline int64_t GetTicks(void)
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+	               std::chrono::steady_clock::now().time_since_epoch())
+	        .count();
+}
+
+static inline int GetTicksDiff(int64_t new_ticks, int64_t old_ticks)
+{
+	assert(new_ticks >= old_ticks);
+	assert((new_ticks - old_ticks) <= INT_MAX);
+	return static_cast<int>(new_ticks - old_ticks);
+}
+
+static inline int GetTicksSince(int64_t old_ticks)
+{
+	const auto now = GetTicks();
+	return GetTicksDiff(now, old_ticks);
+}
+
+static inline void Delay(int milliseconds)
+{
+	std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+}
 
 #endif

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2165,8 +2165,8 @@ void CPU_Disable_SkipAutoAdjust(void) {
 }
 
 
-extern Bit32s ticksDone;
-extern Bit32u ticksScheduled;
+extern int ticksDone;
+extern int ticksScheduled;
 
 void CPU_Reset_AutoAdjust(void) {
 	CPU_IODelayRemoved = 0;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1869,7 +1869,7 @@ Bitu DEBUG_Loop(void) {
 	Bit16u oldCS	= SegValue(cs);
 	Bit32u oldEIP	= reg_eip;
 	PIC_runIRQs();
-	SDL_Delay(1);
+	Delay(1);
 	if ((oldCS!=SegValue(cs)) || (oldEIP!=reg_eip)) {
 		CBreakpoint::AddBreakpoint(oldCS,oldEIP,true);
 		CBreakpoint::ActivateBreakpointsExceptAt(SegPhys(cs)+reg_eip);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -209,11 +209,11 @@ public:
 			if (*data == 0) {
 				if (logoverlay) LOG_MSG("OPTIMISE: truncate on switch!!!!");
 			}
-			Bit32u a = GetTicks();
+			const auto a = logoverlay ? GetTicks() : 0;
 			bool r = create_copy();
-			if (GetTicks() - a > 2) {
-				if (logoverlay) LOG_MSG("OPTIMISE: switching took %d",GetTicks() - a);
-			}
+			const auto b = logoverlay ? GetTicksSince(a) : 0;
+			if (b > 2)
+				LOG_MSG("OPTIMISE: switching took %d", b);
 			if (!r) return false;
 			overlay_active = true;
 			
@@ -555,7 +555,7 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 	return true;
 }
 void Overlay_Drive::update_cache(bool read_directory_contents) {
-	Bit32u a = GetTicks();
+	const auto a = logoverlay ? GetTicks() : 0;
 	std::vector<std::string> specials;
 	std::vector<std::string> dirnames;
 	std::vector<std::string> filenames;
@@ -733,7 +733,8 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 
 		}
 	}
-	if (logoverlay) LOG_MSG("OPTIMISE: update cache took %d",GetTicks()-a);
+	if (logoverlay)
+		LOG_MSG("OPTIMISE: update cache took %d", GetTicksSince(a));
 }
 
 bool Overlay_Drive::FindNext(DOS_DTA & dta) {
@@ -832,14 +833,14 @@ again:
 
 
 bool Overlay_Drive::FileUnlink(char * name) {
-//TODO check the basedir for file existence in order if we need to add the file to deleted file list.
-	Bit32u a = GetTicks();
-	if (logoverlay) LOG_MSG("calling unlink on %s",name);
+	// TODO check the basedir for file existence in order if we need to add the file to deleted file list.
+	const auto a = logoverlay ? GetTicks() : 0;
+	if (logoverlay)
+		LOG_MSG("calling unlink on %s", name);
 	char basename[CROSS_LEN];
 	safe_strcpy(basename, basedir);
 	safe_strcat(basename, name);
 	CROSS_FILENAME(basename);
-
 
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
@@ -919,7 +920,8 @@ bool Overlay_Drive::FileUnlink(char * name) {
 		dirCache.DeleteEntry(basename);
 
 		update_cache(false);
-		if (logoverlay) LOG_MSG("OPTIMISE: unlink took %d",GetTicks()-a);
+		if (logoverlay)
+			LOG_MSG("OPTIMISE: unlink took %d", GetTicksSince(a));
 		return true;
 	}
 }
@@ -1116,7 +1118,7 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		E_Exit("renaming directory %s to %s . Not yet supported in Overlay",oldname,newname); //TODO
 	}
 
-	Bit32u a = GetTicks();
+	const auto a = logoverlay ? GetTicks() : 0;
 	//First generate overlay names.
 	char overlaynameold[CROSS_LEN];
 	safe_strcpy(overlaynameold, overlaydir);
@@ -1139,7 +1141,7 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		//TODO CHECK if base has a file with same oldname!!!!! if it does mark it as deleted!!
 		if (localDrive::FileExists(oldname)) add_deleted_file(oldname,true);
 	} else {
-		Bit32u aa = GetTicks();
+		const auto aa = logoverlay ? GetTicks() : 0;
 		//File exists in the basedrive. Make a copy and mark old one as deleted.
 		char newold[CROSS_LEN];
 		safe_strcpy(newold, basedir);
@@ -1159,8 +1161,9 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		//Mark old file as deleted
 		add_deleted_file(oldname,true);
 		temp =0; //success
-		if (logoverlay) LOG_MSG("OPTIMISE: update rename with copy took %d",GetTicks()-aa);
-
+		if (logoverlay)
+			LOG_MSG("OPTIMISE: update rename with copy took %d",
+			        GetTicksSince(aa));
 	}
 	if (temp ==0) {
 		//handle the drive_cache (a bit better)
@@ -1168,8 +1171,8 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		if (is_deleted_file(newname)) remove_deleted_file(newname,true);
 		dirCache.EmptyCache();
 		update_cache(true);
-		if (logoverlay) LOG_MSG("OPTIMISE: rename took %d",GetTicks()-a);
-
+		if (logoverlay)
+			LOG_MSG("OPTIMISE: rename took %d", GetTicksSince(a));
 	}
 	return (temp==0);
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -46,6 +46,7 @@
 #include "setup.h"
 #include "string_utils.h"
 #include "support.h"
+#include "timer.h"
 #include "video.h"
 
 /* Mouse related */
@@ -2826,7 +2827,7 @@ void MAPPER_DisplayUI() {
 			SDL_UpdateWindowSurface(mapper.window);
 		}
 		BIND_MappingEvents();
-		SDL_Delay(1);
+		Delay(1);
 	}
 	/* ONE SHOULD NOT FORGET TO DO THIS!
 	Unless a memory leak is desired... */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -507,7 +507,7 @@ MAYBE_UNUSED static void PauseDOSBox(bool pressed)
 
 	GFX_SetTitle(-1,-1,true);
 	bool paused = true;
-	SDL_Delay(500);
+	Delay(500);
 	SDL_Event event;
 	while (SDL_PollEvent(&event)) {
 		// flush event queue.
@@ -1876,7 +1876,7 @@ static SDL_Window *SetDefaultWindowMode()
  * Please leave the Splash screen stuff in working order.
  * We spend a lot of time making DOSBox.
  */
-static void DisplaySplash(uint32_t time_ms)
+static void DisplaySplash(int time_ms)
 {
 	assert(sdl.window);
 
@@ -1924,7 +1924,7 @@ static void DisplaySplash(uint32_t time_ms)
 
 	const uint16_t lines[2] = {0, src_h}; // output=surface won't work otherwise
 	GFX_EndUpdate(lines);
-	SDL_Delay(time_ms);
+	Delay(time_ms);
 }
 
 /* For some preference values, we can safely remove comment after # character
@@ -2722,7 +2722,7 @@ static bool ProcessEvents()
 
 					GFX_SetTitle(-1,-1,true);
 					KEYBOARD_ClrBuffer();
-//					SDL_Delay(500);
+//					Delay(500);
 //					while (SDL_PollEvent(&ev)) {
 						// flush event queue.
 //					}
@@ -2786,7 +2786,9 @@ static bool ProcessEvents()
 			if (((event.key.keysym.sym == SDLK_TAB )) && (event.key.keysym.mod & KMOD_ALT)) break;
 			// Ignore tab events that arrive just after regaining
 			// focus. Likely the result of Alt+Tab.
-			if ((event.key.keysym.sym == SDLK_TAB) && (GetTicks() - sdl.focus_ticks < 2)) break;
+			if ((event.key.keysym.sym == SDLK_TAB) &&
+			    (GetTicksSince(sdl.focus_ticks) < 2))
+				break;
 #endif
 #if defined (MACOSX)
 		case SDL_KEYDOWN:
@@ -3096,7 +3098,7 @@ static void show_warning(char const * const message) {
 
 	SDL_BlitSurface(splash_surf, NULL, sdl.surface, NULL);
 	SDL_UpdateWindowSurface(sdl.window);
-	SDL_Delay(12000);
+	Delay(12000);
 #endif // WIN32
 }
 
@@ -3158,7 +3160,7 @@ void restart_program(std::vector<std::string> & parameters) {
 	for(Bitu i = 0; i < parameters.size(); i++) newargs[i] = (char*)parameters[i].c_str();
 	newargs[parameters.size()] = NULL;
 	MIXER_CloseAudioDevice();
-	SDL_Delay(50);
+	Delay(50);
 	QuitSDL();
 #if C_DEBUG
 	// shutdown curses

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -797,11 +797,11 @@ bool ConnectToServer(char const *strAddr) {
 			} else {
 				// Wait for return packet from server.
 				// This will contain our IPX address and port num
-				Bit32u ticks, elapsed;
-				ticks = GetTicks();
+				Bit32u elapsed;
+				const auto ticks = GetTicks();
 
 				while(true) {
-					elapsed = GetTicks() - ticks;
+					elapsed = GetTicksSince(ticks);
 					if(elapsed > 5000) {
 						LOG_MSG("Timeout connecting to server at %s", strAddr);
 						SDLNet_UDP_Close(ipxClientSocket);
@@ -1034,7 +1034,6 @@ public:
 			}
 
 			if(strcasecmp("ping", temp_line.c_str()) == 0) {
-				Bit32u ticks;
 				IPXHeader pingHead;
 
 				if(!incomingPacket.connected) {
@@ -1044,11 +1043,15 @@ public:
 				TIMER_DelTickHandler(&IPX_ClientLoop);
 				WriteOut("Sending broadcast ping:\n\n");
 				pingSend();
-				ticks = GetTicks();
-				while((GetTicks() - ticks) < 1500) {
+				const auto ticks = GetTicks();
+				while ((GetTicksSince(ticks)) < 1500) {
 					CALLBACK_Idle();
 					if(pingCheck(&pingHead)) {
-						WriteOut("Response from %d.%d.%d.%d, port %d time=%dms\n", CONVIP(pingHead.src.addr.byIP.host), SDLNet_Read16(&pingHead.src.addr.byIP.port), GetTicks() - ticks);
+						WriteOut(
+						        "Response from %d.%d.%d.%d, port %d time=%dms\n",
+						        CONVIP(pingHead.src.addr.byIP.host),
+						        SDLNet_Read16(&pingHead.src.addr.byIP.port),
+						        GetTicksSince(ticks));
 					}
 				}
 				TIMER_AddTickHandler(&IPX_ClientLoop);

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -185,7 +185,7 @@ void CSerial::log_ser(bool active, char const* format,...) {
 		// copied from DEBUG_SHOWMSG
 		char buf[512];
 		buf[0]=0;
-		sprintf(buf,"%12.3f [% 7u] ",PIC_FullIndex(), SDL_GetTicks());
+		sprintf(buf, "%12.3f [% 7lld] ", PIC_FullIndex(), GetTicks());
 		va_list msg;
 		va_start(msg,format);
 		vsprintf(buf+strlen(buf),format,msg);

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -111,8 +111,8 @@ struct DB_Midi {
 	struct {
 		uint8_t buf[MIDI_SYSEX_SIZE];
 		size_t used;
-		uint32_t delay; // ms
-		uint32_t start; // ms
+		int delay; // ms
+		int64_t start;  // ms
 	} sysex;
 	bool available;
 	MidiHandler * handler;
@@ -127,19 +127,19 @@ DB_Midi midi;
  * Explanation for this formula can be found in discussion under patch
  * that introduced it: https://sourceforge.net/p/dosbox/patches/241/
  */
-uint32_t delay_in_ms(size_t sysex_bytes_num)
+int delay_in_ms(size_t sysex_bytes_num)
 {
 	constexpr double midi_baud_rate = 3.125; // bytes per ms
 	const auto delay = (sysex_bytes_num * 1.25) / midi_baud_rate;
-	return static_cast<uint32_t>(delay) + 2;
+	return static_cast<int>(delay) + 2;
 }
 
 void MIDI_RawOutByte(uint8_t data)
 {
 	if (midi.sysex.start) {
-		const uint32_t passed_ticks = GetTicks() - midi.sysex.start;
+		const auto passed_ticks = GetTicksSince(midi.sysex.start);
 		if (passed_ticks < midi.sysex.delay)
-			SDL_Delay(midi.sysex.delay - passed_ticks);
+			Delay(midi.sysex.delay - passed_ticks);
 	}
 
 	/* Test for a realtime MIDI message */


### PR DESCRIPTION
This PR modernizes the use of `GetTicks()` and `SDL_Delay()` to standard C++11 library functions.

The main side-effect is that `GetTicks()` now returns an `int64_t`, since it calculates number of milliseconds since the UNIX epoch. This is fine, since all uses are only for tick deltas. A small benefit is that the tick value won't wrap anytime soon.

I've tested several titles on macOS and Windows and look forward to hearing feedback from *nix-land.

The Delay change gives comparable results. This is from the `increaseticks` function:
```
sleep_for:
actual sleep time: 1140.167000
actual sleep time: 1138.584000
actual sleep time: 1138.541000
actual sleep time: 1144.375000
actual sleep time: 1139.833000
actual sleep time: 1138.459000
actual sleep time: 1138.875000
actual sleep time: 1138.791000
actual sleep time: 1143.709000
actual sleep time: 1139.209000

SDL_Delay:
actual sleep time: 1140.208000
actual sleep time: 1139.791000
actual sleep time: 1137.209000
actual sleep time: 1138.709000
actual sleep time: 1139.875000
actual sleep time: 1141.750000
actual sleep time: 1139.042000
actual sleep time: 1141.417000
actual sleep time: 1142.000000
actual sleep time: 1137.750000
```