### PR TITLE
fix high competing CPU load sluggishness

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1403,12 +1403,12 @@ static void ToggleMouseCapture(bool pressed) {
 
 static void FocusInput()
 {
+	// Ensure auto-cycles are enabled
+	CPU_Disable_SkipAutoAdjust();
+
 	// Ensure we have input focus when in fullscreen
 	if (!sdl.desktop.fullscreen)
 		return;
-
-	// Ensure auto-cycles are enabled
-	CPU_Disable_SkipAutoAdjust();
 
 	// Do we already have focus?
 	if (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS)


### PR DESCRIPTION
A competing load with high CPU usage was causing extreme sluggishness on at least Windows and macOS. To reproduce:

1. Start DOSBox with `cycles = auto` and `core = auto`
2. Start a competing load with high CPU usage in another window; it's important that DOSBox lose focus
3. Go back to DOSBox
4. Start an app that auto-switches to dynamic core and max cycles, e.g. Quake
5. Observe extremely low responsiveness in said app

The trivial code fix is self-explanatory, but `CPU_Disable_SkipAutoAdjust()` was only being called in `FocusInput()` when the DOSBox window was fullscreen. 