### PR TITLE
Compensate for sleep overhead

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -57,9 +57,14 @@ static inline int GetTicksSince(int64_t old_ticks)
 	return GetTicksDiff(now, old_ticks);
 }
 
+
+
+std::chrono::nanoseconds measure_sleep_overhead();
+
 static inline void Delay(int milliseconds)
 {
-	std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+	static const auto sleep_overhead = measure_sleep_overhead();
+	std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds) - sleep_overhead);
 }
 
 #endif

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -26,6 +26,23 @@
 #include "timer.h"
 #include "setup.h"
 
+std::chrono::nanoseconds measure_sleep_overhead() {
+	using stc = std::chrono::steady_clock;
+	auto overhead_tally = std::chrono::nanoseconds(0);
+	int passes = 0;
+	while (passes < 1000) {
+		const auto start = stc::now();
+		std::this_thread::sleep_for( std::chrono::nanoseconds(1) );
+		const auto end = stc::now();
+		assert(end >= start);
+		overhead_tally += end - start;
+		++passes;
+	}
+	const auto average_overhead = (overhead_tally / passes) - std::chrono::nanoseconds(1);
+	DEBUG_LOG_MSG("TIMER: Overhead of sleep is %0.3f ms", average_overhead.count() / 1000000.0);
+	return average_overhead;
+}
+
 static INLINE void BIN2BCD(Bit16u& val) {
 	Bit16u temp=val%10 + (((val/10)%10)<<4)+ (((val/100)%10)<<8) + (((val/1000)%10)<<12);
 	val=temp;


### PR DESCRIPTION
PR https://github.com/dosbox-staging/dosbox-staging/pull/1066 showed that DOSBox's 1-millisecond sleeps are actually more like 1.1 milliseconds (or more).

Given DOSBox wants to sleep for only 1ms but is actually sleeping for 1.1ms, it would be nice to remove 0.1ms from the sleep request, and actually sleep for 1ms. 

So to that end, this PR measures the cost of sleeping on startup and then removes that overhead cost (whatever it might be) from the Delay() function - knowing that the sleep itself will incur that overhead.  The result is that we should now be sleeping very close to the requested number of milliseconds.

This is a draft PR for now until we can add some sanity checks.  Some thoughts:

1. If a clock's overhead varies wildly, then our average might not help much. Computing the standard deviation would catch these cases, and we could simply skip in these cases. 

2. If a clock's overhead is less than 1 ms but greater than 0.5 ms then we should probably warn user and have them report it. 

3. If a clock's overhead is > 1 ms , but still has acceptable standard deviation, then we should definitely warn the user, but also set the overhead to "almost 1ms but not a full 1ms", simply because the 1ms sleep requests would transform to sleep(0), which becomes a no-op.

