### PR TITLE
fix slow dynamic core 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 175
+            max_warnings: 179
 
     steps:
       - uses: actions/checkout@v2

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -288,9 +288,7 @@ restart_core:
 	CacheBlock * block=chandler->FindCacheBlock(ip_point&4095);
 	if (!block) {
 		if (!chandler->invalidation_map || (chandler->invalidation_map[ip_point&4095]<4)) {
-			dyn_mem_write();
 			block=CreateCacheBlock(chandler,ip_point,32);
-			dyn_mem_execute();
 		} else {
 			Bit32s old_cycles=CPU_Cycles;
 			CPU_Cycles=1;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -58,10 +58,7 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandler * &cph) {
 	PageHandler * handler=get_tlb_readhandler(lin_addr);
 	if (handler->flags & PFLAG_HASCODE) {
 		cph=( CodePageHandler *)handler;
-		if (handler->flags & cflag) return false;
-		cph->ClearRelease();
-		cph=0;
-		handler=get_tlb_readhandler(lin_addr);
+		return false;
 	}
 	if (handler->flags & PFLAG_NOCODE) {
 		if (PAGING_ForcePageInit(lin_addr)) {

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -238,10 +238,7 @@ Bits CPU_Core_Dynrec_Run(void) {
 			// unless the instruction is known to be modified
 			if (!chandler->invalidation_map || (chandler->invalidation_map[ip_point&4095]<4)) {
 				// translate up to 32 instructions
-				dyn_mem_write();
 				block=CreateCacheBlock(chandler,ip_point,32);
-				dyn_mem_execute();
-				dyn_cache_invalidate(static_cast<void*>(const_cast<uint8_t*>(block->cache.start)), block->cache.size);
 			} else {
 				// let the normal core handle this instruction to avoid zero-sized blocks
 				Bitu old_cycles=CPU_Cycles;

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -43,6 +43,11 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 	decode.block->page.start=(Bit16u)decode.page.index;
 	codepage->AddCacheBlock(decode.block);
 
+	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start));
+	constexpr size_t cache_bytes = CACHE_MAXSIZE;
+
+	dyn_mem_write(cache_addr, cache_bytes);
+
 	InitFlagsOptimization();
 
 	// every codeblock that is run sets cache.block.running to itself
@@ -610,6 +615,9 @@ finish_block:
 	// setup the correct end-address
 	decode.page.index--;
 	decode.active_block->page.end=(Bit16u)decode.page.index;
+	dyn_mem_execute(cache_addr, cache_bytes);
+	dyn_cache_invalidate(cache_addr, cache_bytes);
+
 //	LOG_MSG("Created block size %d start %d end %d",decode.block->cache.size,decode.block->page.start,decode.block->page.end);
 
 	return decode.block;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -138,12 +138,7 @@ static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
 	if (handler->flags & PFLAG_HASCODE) {
 		// this is a codepage handler, make sure it matches current code size
 		cph = (CodePageHandler *)handler;
-		if (handler->flags & cflag) return false;
-		// wrong code size/stale dynamic code, drop it
-		cph->ClearRelease();
-		cph=0;
-		// handler was changed, refresh
-		handler=get_tlb_readhandler(lin_addr);
+		return false;
 	}
 	if (handler->flags & PFLAG_NOCODE) {
 		if (PAGING_ForcePageInit(lin_addr)) {


### PR DESCRIPTION
Dynamic core was very slow on several titles that had very heavy codegen, since the entire cache region was being toggled for each cache block gen. This commit greatly improves performance by only toggling the access for CACHE_MAXSIZE bytes, instead of the entire CACHE_TOTAL range.