### PR TITLE
Delay for precise number of milliseconds on supported systems

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -84,6 +84,11 @@ static inline void Delay(int milliseconds)
 	std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }
 
+static inline void DelayUs(int microseconds)
+{
+	std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
+}
+
 static inline void DelayPrecise(int milliseconds)
 {
     static double estimate = precise_delay_default_estimate;
@@ -95,7 +100,7 @@ static inline void DelayPrecise(int milliseconds)
 
     while (seconds > estimate) {
         const auto start = GetTicksUs();
-        std::this_thread::sleep_for(std::chrono::microseconds(precise_delay_interval_us));
+        DelayUs(precise_delay_interval_us);
         const double observed = GetTicksUsSince(start) / 1e6;
         seconds -= observed;
 
@@ -111,11 +116,6 @@ static inline void DelayPrecise(int milliseconds)
     const auto spin_start = GetTicksUs();
 	const int spin_remain = static_cast<int>(seconds * 1e6);
     while (GetTicksUsSince(spin_start) <= spin_remain);
-}
-
-static inline void DelayUs(int microseconds)
-{
-	std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
 }
 
 static inline bool CanDelayPrecise(void)

--- a/include/timer.h
+++ b/include/timer.h
@@ -75,7 +75,7 @@ static inline int GetTicksUsSince(int64_t old_ticks)
 }
 
 static constexpr int precise_delay_interval_us = 100;
-static constexpr int precise_delay_tolerance_us = precise_delay_interval_us / 2;
+static constexpr int precise_delay_tolerance_us = precise_delay_interval_us; 
 static constexpr double precise_delay_default_estimate = 5e-4;
 static constexpr double precise_delay_default_mean = 5e-4;
 

--- a/include/timer.h
+++ b/include/timer.h
@@ -76,8 +76,8 @@ static inline int GetTicksUsSince(int64_t old_ticks)
 
 static constexpr int precise_delay_interval_us = 100;
 static constexpr int precise_delay_tolerance_us = precise_delay_interval_us; 
-static constexpr double precise_delay_default_estimate = 5e-4;
-static constexpr double precise_delay_default_mean = 5e-4;
+static constexpr double precise_delay_default_estimate = 5e-5;
+static constexpr double precise_delay_default_mean = 5e-5;
 
 static inline void Delay(int milliseconds)
 {

--- a/include/timer.h
+++ b/include/timer.h
@@ -20,6 +20,7 @@
 #define DOSBOX_TIMER_H
 
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 
 #include <chrono>
@@ -108,7 +109,7 @@ static inline void DelayPrecise(int milliseconds)
         const double delta = observed - mean;
         mean += delta / count;
         m2   += delta * (observed - mean);
-        const double stddev = sqrt(m2 / (count - 1));
+        const double stddev = std::sqrt(m2 / (count - 1));
         estimate = mean + stddev;
     }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -194,7 +194,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	if (ticksNew <= ticksLast) { //lower should not be possible, only equal.
 		ticksAdded = 0;
 
-		if (!CPU_CycleAutoAdjust || CPU_SkipCycleAutoAdjust || !use_delay_precise || sleep1count < 3) {
+		if (!CPU_CycleAutoAdjust || CPU_SkipCycleAutoAdjust || sleep1count < 3) {
 			use_delay_precise ? DelayPrecise(1) : Delay(1);
 		} else {
 			/* Certain configurations always give an exact sleepingtime of 1, this causes problems due to the fact that

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -135,7 +135,7 @@ static LoopHandler * loop;
 
 bool SDLNetInited;
 
-static bool can_delay_precise = false;
+static bool use_delay_precise = false;
 static int ticksRemain;
 static int64_t ticksLast;
 static int ticksAdded;
@@ -194,8 +194,8 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	if (ticksNew <= ticksLast) { //lower should not be possible, only equal.
 		ticksAdded = 0;
 
-		if (!CPU_CycleAutoAdjust || CPU_SkipCycleAutoAdjust || !can_delay_precise || sleep1count < 3) {
-			can_delay_precise ? DelayPrecise(1) : Delay(1);
+		if (!CPU_CycleAutoAdjust || CPU_SkipCycleAutoAdjust || !use_delay_precise || sleep1count < 3) {
+			use_delay_precise ? DelayPrecise(1) : Delay(1);
 		} else {
 			/* Certain configurations always give an exact sleepingtime of 1, this causes problems due to the fact that
 			   dosbox keeps track of full blocks.
@@ -204,7 +204,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 			static const Bit32u sleeppattern[] = { 2, 2, 3, 2, 2, 4, 2 };
 			static Bit32u sleepindex = 0;
 			if (ticksDone != lastsleepDone) sleepindex = 0;
-			can_delay_precise ? DelayPrecise(sleeppattern[sleepindex++]) : Delay(sleeppattern[sleepindex++]);
+			use_delay_precise ? DelayPrecise(sleeppattern[sleepindex++]) : Delay(sleeppattern[sleepindex++]);
 			sleepindex %= sizeof(sleeppattern) / sizeof(sleeppattern[0]);
 		}
 		auto timeslept = GetTicksSince(ticksNew);
@@ -362,7 +362,7 @@ static void DOSBOX_RealInit(Section * sec) {
 	Section_prop * section=static_cast<Section_prop *>(sec);
 	/* Initialize some dosbox internals */
 
-	can_delay_precise = CanDelayPrecise();
+	use_delay_precise = CanDelayPrecise();
 
 	ticksRemain=0;
 	ticksLast=GetTicks();


### PR DESCRIPTION
This branch provides a precise number-of-milliseconds delay function on supported systems, which increased framerates 5-7% when `core=dynamic` and `cycles=max` on Linux and macOS.

My Windows system showed no improvement, even when creating WIN32-specific sub-millisecond delay logic, and resulted in higher CPU usage, so a more generic, cross-platform test for sub-millisecond delay precision was added, resulting in Windows using the old code path.

In addition, macOS showed a surprising 50% reduction in CPU usage on an M1 MacBook Pro.

![CleanShot 2021-06-18 at 14 59 21@2x](https://user-images.githubusercontent.com/541026/122611690-5effa600-d047-11eb-9abe-e3ca3a0c4cae.png)

![CleanShot 2021-06-18 at 15 00 08@2x](https://user-images.githubusercontent.com/541026/122611710-645cf080-d047-11eb-9414-354b7238261e.png)

<img width="385" alt="CleanShot 2021-06-18 at 15 02 15@2x" src="https://user-images.githubusercontent.com/541026/122611726-68890e00-d047-11eb-8b8d-6958d5426b0f.png">

<img width="385" alt="CleanShot 2021-06-18 at 15 03 18@2x" src="https://user-images.githubusercontent.com/541026/122611738-6cb52b80-d047-11eb-88d3-ae18c455c05e.png">


