### PR TITLE
Fix test crash when using GLIBCXX_ASSERTIONS

### DIFF
--- a/tests/soft_limiter_tests.cpp
+++ b/tests/soft_limiter_tests.cpp
@@ -55,7 +55,11 @@ TEST(SoftLimiter, InboundsProcessTooManyFrames)
 	SoftLimiter limiter("test-channel");
 	const std::vector<float> in{-3, -2, -1, 0, 1, 2};
 	std::vector<int16_t> out(frames * 2);
+#ifdef _GLIBCXX_ASSERTIONS
+	EXPECT_DEATH({ limiter.Process(in, frames + 1, out); }, "");
+#else
 	EXPECT_DEBUG_DEATH({ limiter.Process(in, frames + 1, out); }, "");
+#endif
 }
 
 TEST(SoftLimiter, OutOfBoundsLeftChannel)


### PR DESCRIPTION
Test case SoftLimiter.InboundsProcessTooManyFrames
tested that for certain invalid usage
that leads to an out-of-bound read from a container,
the debug build crashes because an assertion fails.
For release builds, the same test case expected no crash.
However, GLIBCXX_ASSERTIONS are used for release builds also,
so enabling them led the release build to crash
which the test case did not expect.

Fixed by conditionalizing the test
based on presence of GLIBCXX_ASSERTIONS.

Fixes #1085.