### PR TITLE
[Innovation] add `chipmodel = auto` to standardize its conf setting

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
 
           - name: Clang, +debugger
             build_flags: -Denable_debugger=normal
-            max_warnings: 110
+            max_warnings: 108
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 357
+          MAX_BUGS: 351
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 272
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1968
+            max_warnings: 1967
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/libs/residfp/EnvelopeGenerator.h
+++ b/src/libs/residfp/EnvelopeGenerator.h
@@ -404,6 +404,7 @@ void EnvelopeGenerator::set_exponential_counter()
     switch (envelope_counter)
     {
     case 0xff:
+    case 0x00:
         new_exponential_counter_period = 1;
         break;
 
@@ -425,10 +426,6 @@ void EnvelopeGenerator::set_exponential_counter()
 
     case 0x06:
         new_exponential_counter_period = 30;
-        break;
-
-    case 0x00:
-        new_exponential_counter_period = 1;
         break;
     }
 }

--- a/src/libs/residfp/SID.cpp
+++ b/src/libs/residfp/SID.cpp
@@ -114,14 +114,15 @@ void SID::voiceSync(bool sync)
 
     for (int i = 0; i < 3; i++)
     {
-        const unsigned int freq = voice[i]->wave()->readFreq();
+        WaveformGenerator* const wave = voice[i]->wave();
+        const unsigned int freq = wave->readFreq();
 
-        if (voice[i]->wave()->readTest() || freq == 0 || !voice[(i + 1) % 3]->wave()->readSync())
+        if (wave->readTest() || freq == 0 || !voice[(i + 1) % 3]->wave()->readSync())
         {
             continue;
         }
 
-        const unsigned int accumulator = voice[i]->wave()->readAccumulator();
+        const unsigned int accumulator = wave->readAccumulator();
         const unsigned int thisVoiceSync = ((0x7fffff - accumulator) & 0xffffff) / freq + 1;
 
         if (thisVoiceSync < nextVoiceSync)

--- a/src/libs/residfp/WaveformCalculator.cpp
+++ b/src/libs/residfp/WaveformCalculator.cpp
@@ -66,7 +66,7 @@ const CombinedWaveformConfig config[2][4] =
  * @param waveform the waveform to emulate, 1 .. 7
  * @param accumulator the high bits of the accumulator value
  */
-short calculateCombinedWaveform(CombinedWaveformConfig config, int waveform, int accumulator)
+short calculateCombinedWaveform(const CombinedWaveformConfig& config, int waveform, int accumulator)
 {
     float o[12];
 

--- a/src/libs/residfp/WaveformGenerator.cpp
+++ b/src/libs/residfp/WaveformGenerator.cpp
@@ -367,7 +367,9 @@ void WaveformGenerator::reset()
     shift_register_reset = 0;
     shift_register = 0x7fffff;
     // when reset is released the shift register is clocked once
-    clock_shift_register((~shift_register << 17) & (1 << 22));
+    // so the lower bit is zeroed out
+    // bit0 = (bit22 | test) ^ bit17 = 1 ^ 1 = 0
+    clock_shift_register(0);
 
     shift_pipeline = 0;
 

--- a/src/libs/residfp/resample/SincResampler.cpp
+++ b/src/libs/residfp/resample/SincResampler.cpp
@@ -332,15 +332,17 @@ SincResampler::SincResampler(double clockFrequency, double samplingFrequency, do
         // Calculate the sinc tables.
         const double scale = 32768.0 * wc / cyclesPerSampleD / M_PI;
 
+        const double firN_2 = static_cast<double>(firN / 2);
+
         for (int i = 0; i < firRES; i++)
         {
-            const double jPhase = (double) i / firRES + firN / 2;
+            const double jPhase = (double) i / firRES + firN_2;
 
             for (int j = 0; j < firN; j++)
             {
                 const double x = j - jPhase;
 
-                const double xt = x / (firN / 2);
+                const double xt = x / firN_2;
                 const double kaiserXt = fabs(xt) < 1. ? I0(beta * sqrt(1. - xt * xt)) / I0beta : 0.;
 
                 const double wt = wc * x / cyclesPerSampleD;


### PR DESCRIPTION
The `auto` model setting brings the Innovation conf settings in-line with others simple audio device conf settings, like the Tandy device.

This PR also syncs a handful of PVS Studio fixes from upstream.