### PR TITLE
Expand and improve `windowresolution`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 272
+            max_warnings: 270
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1967
+            max_warnings: 1965
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/README
+++ b/README
@@ -104,8 +104,9 @@ FULLSCREEN: My fullscreen is too large.
     - Apply the changes by clicking on "OK".
 
     Unfortunately, this compatibility option causes some side effects in
-    windowed mode, and in this case you will need to change the resolution
-    in the config/Options file for windowresolution (e.g. 1024x768).
+    windowed mode, and in this case you will need to change the windowresolution
+    setting in your config file to either a fixed size (e.g. 1024x768) or
+    a relative size: (e.g. small, medium, or large).
 
     Alternatively, you can disable the display scaling and or use a lower
     fullresolution value.

--- a/README.md
+++ b/README.md
@@ -75,21 +75,21 @@ Codecs supported for CD-DA emulation:
 
 Feature differences between release binaries (or unpatched sources):
 
-|                          | DOSBox Staging                               | DOSBox SVN
-|-                         |-                                             |-
-| **Pixel-perfect mode**   | Yes (`output=openglpp` or `output=texturepp`)| N/A
-| **Resizable window**     | Experimental (`windowresolution=resizable`)  | N/A
-| **Relative window size** | N/A                                          | `windowresolution=X%`
-| **[OPL] emulators**      | compat, fast, mame, nuked<sup>[8]</sup>      | compat, fast, mame
-| **[CGA]/mono support**   | Yes (`machine=cga_mono`)<sup>[9]</sup>       | Only CGA with colour
-| **[Wayland] support**    | Experimental (use `SDL_VIDEODRIVER=wayland`) | N/A
-| **Modem phonebook file** | Yes (`phonebookfile=<name>`)                 | N/A
-| **Autotype command**     | Yes<sup>[10]</sup>                           | N/A
-| **Startup verbosity**    | Yes<sup>[11]</sup>                           | N/A
-| **[GUS] enhancements**   | Yes<sup>[12]</sup>                           | N/A
-| **Raw mouse input**      | Yes (`raw_mouse_input=true`)                 | N/A
-| **[FluidSynth][FS] MIDI**| Yes<sup>[13]</sup> (FluidSynth 2.x)          | Only external synths
-| **[MT-32] emulator**     | Yes<sup>＊</sup> (libmt32emu 2.4.2)          | N/A
+| *Feature*                | *DOSBox Staging*                                     | *DOSBox SVN*
+|-                         |-                                                     |-
+| **Pixel-perfect mode**   | Yes (`output=openglpp` or `output=texturepp`)        | N/A
+| **Resizable window**     | Yes (for all `output=opengl` modes)                  | N/A
+| **Relative window size** | Yes (`windowresolution=small`, `medium`, or `large`) | `windowresolution=X%`
+| **[OPL] emulators**      | compat, fast, mame, nuked<sup>[8]</sup>              | compat, fast, mame
+| **[CGA]/mono support**   | Yes (`machine=cga_mono`)<sup>[9]</sup>               | Only CGA with colour
+| **[Wayland] support**    | Experimental (use `SDL_VIDEODRIVER=wayland`)         | N/A
+| **Modem phonebook file** | Yes (`phonebookfile=<name>`)                         | N/A
+| **Autotype command**     | Yes<sup>[10]</sup>                                   | N/A
+| **Startup verbosity**    | Yes<sup>[11]</sup>                                   | N/A
+| **[GUS] enhancements**   | Yes<sup>[12]</sup>                                   | N/A
+| **Raw mouse input**      | Yes (`raw_mouse_input=true`)                         | N/A
+| **[FluidSynth][FS] MIDI**| Yes<sup>[13]</sup> (FluidSynth 2.x)                  | Only external synths
+| **[MT-32] emulator**     | Yes<sup>＊</sup> (libmt32emu 2.4.2)                  | N/A
 
 <sup>＊- Requires original ROM files</sup>
 

--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,7 @@ atomic_dep    = cxx.find_library('atomic', required : false)
 opus_dep      = dependency('opusfile',
                            static : ('opusfile' in static_libs_list))
 threads_dep   = dependency('threads')
-sdl2_dep      = dependency('sdl2', version : '>= 2.0.2',
+sdl2_dep      = dependency('sdl2', version : '>= 2.0.5',
                            static : ('sdl2' in static_libs_list))
 sdl2_net_dep  = optional_dep
 opengl_dep    = optional_dep

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -441,7 +441,6 @@ void GFX_SetTitle(Bit32s cycles, int /*frameskip*/, bool paused)
 	SDL_SetWindowTitle(sdl.window, title);
 }
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
 /* This function is SDL_EventFilter which is being called when event is
  * pushed into the SDL event queue.
  *
@@ -473,7 +472,6 @@ static int watch_sdl_events(void *userdata, SDL_Event *e)
 	}
 	return 0;
 }
-#endif
 
 /* On macOS, as we use a nicer external icon packaged in App bundle.
  *
@@ -718,13 +716,12 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 			return nullptr;
 		}
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
 		if (resizable) {
 			SDL_AddEventWatch(watch_sdl_events, sdl.window);
 			SDL_SetWindowResizable(sdl.window, SDL_TRUE);
 		}
 		sdl.desktop.window.resizable = resizable;
-#endif
+
 		GFX_SetTitle(-1, -1, false); // refresh title.
 
 		if (!fullscreen) {
@@ -2816,7 +2813,6 @@ static bool ProcessEvents()
 				RequestExit(true);
 				break;
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
 			case SDL_WINDOWEVENT_TAKE_FOCUS:
 				// DEBUG_LOG_MSG("SDL: Window is being offered a focus");
 				// should SetWindowInputFocus() on itself or a
@@ -2827,7 +2823,7 @@ static bool ProcessEvents()
 				DEBUG_LOG_MSG("SDL: Window had a hit test that "
 				              "wasn't SDL_HITTEST_NORMAL");
 				continue;
-#endif
+
 			default: break;
 			}
 

--- a/src/platform/visualc/sdl.h
+++ b/src/platform/visualc/sdl.h
@@ -10,5 +10,5 @@
 	XSTR(SDL_MAJOR_VERSION) "." XSTR(SDL_MINOR_VERSION) "." XSTR(SDL_PATCHLEVEL)
 #endif
 
-static_assert(SDL_VERSION_ATLEAST(2, 0, 2),
-              "SDL >= 2.0.2 required (using " SDL_CONSTEXPR_VERSION ")");
+static_assert(SDL_VERSION_ATLEAST(2, 0, 5),
+              "SDL >= 2.0.5 required (using " SDL_CONSTEXPR_VERSION ")");


### PR DESCRIPTION
This PR changes `windowresolution` as follows:
 - removes `original` resolution
 - always opt-in to `resizeability` when the shader-mode permits it (Windows/macOS/Linux).
 - adds common size labels: `small`, `medium` and `large` (or s, m, l).  This is meant to be agnostic of display size or resolution. 
 - all cases, the selected window resolution is refined based on scaling mode (such as nearest neighbour or pixel-perfect) and aspect corrected, if requested. 

Previous included:
 - ~~enables high DPI handling by SDL~~ <- **removed because it's not consistent.** 
 - ~~adds `N%` percent resolution, relative to the desktop's size. For example, 50% would produce a window roughly half of the desktop's width and height.~~ <- **removed because users might not understand this and size-labels are likely good-enough.**