### PR TITLE
Use main branch in import script (PR for better-import branch) [2 of 3]

### DIFF
--- a/scripts/import-from-svn/import-from-svn.sh
+++ b/scripts/import-from-svn/import-from-svn.sh
@@ -125,7 +125,7 @@ import_svn_tagpaths_as_git_tags () {
 #
 cleanup () {
 	git -C "$1" checkout svn/trunk
-	git -C "$1" branch -D master
+	git -C "$1" branch -D main
 }
 
 # Perform import of the whole SVN history


### PR DESCRIPTION
I see the part in the script where it uses your own repo (dreamer/dosbox-staging).
I wonder if we can pull the github-name for the user running the script, and swap it into that place? 
Just trying to think through how to remove the single-committer limitation.
