### PR TITLE
Deprecate master & slave adjectives

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,7 @@ name: Coverity Scan analysis
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   COVERITY_EMAIL: ${{ secrets.CoverityEmail }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -273,14 +273,14 @@ jobs:
 
 
   # This job exists only to publish an artifact with version info when building
-  # from master branch, so snapshot build version will be visible on:
+  # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_linux_release_dynamic
     runs-on: ubuntu-18.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -248,14 +248,14 @@ jobs:
 
 
   # This job exists only to publish an artifact with version info when building
-  # from master branch, so snapshot build version will be visible on:
+  # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_macos_release
     runs-on: macos-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -213,14 +213,14 @@ jobs:
 
 
   # This job exists only to publish an artifact with version info when building
-  # from master branch, so snapshot build version will be visible on:
+  # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_windows_vs_release
     runs-on: windows-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ These rules apply to code in `src/` and `include/` directories.
 They do not apply to code in `src/libs/` directory (libraries in there
 have their own coding conventions).
 
-Rules outlined below apply to new code landing in master branch.
+Rules outlined below apply to new code landing in the main branch.
 Do not do mass reformatting or renaming of existing code.
 
 ### Language

--- a/README
+++ b/README
@@ -888,9 +888,9 @@ IMGMOUNT
         none: DOSBox will make no attempt to read the file system on the disk.
               This is useful if you need to format it or if you want to boot
               the disk using the BOOT command. When using the "none"
-              filesystem, you must specify the drive number (2 or 3,
-              where 2 = master, 3 = slave) rather than a drive letter.
-              For example, to mount a 70MB image as the slave drive device,
+              filesystem, you must specify the drive number: 2 or 3, where
+              two is primary and three is secondary, rather than a drive letter.
+              For example, to mount a 70MB image as the secondary drive device,
               you would type (without the quotes):
                 "imgmount 3 d:\test.img -size 512,63,16,142 -fs none"
                 Compare this with a mount to be able to access the drive
@@ -936,8 +936,8 @@ BOOT
   [-l driveletter]
      This parameter allows you to specify the drive to boot from.
      The default is the A drive, the floppy drive. You can also boot
-     a hard drive image mounted as master by specifying "-l C"
-     without the quotes, or the drive as slave by specifying "-l D"
+     a hard drive image mounted as primary by specifying "-l C"
+     without the quotes, or the drive as secondary by specifying "-l D"
 
    cart.jrc (PCjr only)
      When emulation of a PCjr is enabled, cartridges can be loaded with

--- a/README
+++ b/README
@@ -821,7 +821,7 @@ MIXER
   mixer channel left:right [/NOSHOW] [/LISTMIDI]
 
   channel
-     Can be one of the following: MASTER, DISNEY, SPKR, GUS, SB, FM [, CDAUDIO].
+     Can be one of the following: BASELINE, DISNEY, SPKR, GUS, SB, FM [, CDAUDIO].
      CDAUDIO is only available if a CD-ROM interface with volume control is
      enabled (CD image).
 

--- a/docs/vc_redist.txt
+++ b/docs/vc_redist.txt
@@ -12,7 +12,7 @@ Windows versions.  These files are optional - if you have them pre-installed
 as part of your Operating System, you can safely remove them from this
 software package, or build your own version of DOSBox Staging, that does
 not use these files.  You can find instructions for doing so here:
-https://github.com/dosbox-staging/dosbox-staging/blob/master/BUILD.md#windows-procedures
+https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#windows-procedures
 
 These files are covered by "MICROSOFT VISUAL STUDIO 2015 EXTENSIONS,
 VISUAL STUDIO SHELLS and C++ REDISTRIBUTABLE" license:

--- a/scripts/fetch-workflows.sh
+++ b/scripts/fetch-workflows.sh
@@ -5,13 +5,13 @@
 # Copyright (C) 2020-2021  Kevin R. Croft <krcroft@gmail.com>
 
 ##
-#  This script craws the current repo's GitHub workflow content.
+#  This script crawls the current repo's GitHub workflow content.
 #  It fetches CI records for the provided branches, or by default
-#  the latest CI runs for the master and currently-set branches.
+#  the latest CI runs for the main branch and currently-set branch.
 #
 #  The goal of this script is two fold:
 #    - Provide a mechanized an automated way to fetch CI records.
-#    - Provide a rapid way to diff bad CI runs against master.
+#    - Provide a rapid way to diff bad CI runs against the main branch.
 #
 #  This script requires a GitHub account in order to generate an
 #  auth-token. Simply run the script, it will provide instructions.
@@ -51,7 +51,7 @@ function parse_args() {
 		echo ""
 		echo " - If only BRANCH_A is provided, then just download its records"
 		echo " - If both BRANCH_A and B are provided, then fetch and diff them"
-		echo " - If neither are provided, then fetch and diff good-master vs current branch"
+		echo " - If neither are provided, then fetch and diff the main branch vs current branch"
 		echo " - 'current' can be used in-place of the repo's currently set branch name"
 		echo " - Note: BRANCH_A and B can be the same; the tool will try to diff"
 		echo "         the last *good* run versus latest run (which might differ)"
@@ -63,7 +63,7 @@ function parse_args() {
 		branches+=( "$(get_branch "$1")" )
 		branches+=( "$(get_branch "$2")" )
 	else
-		branches+=( "master" )
+		branches+=( "main" )
 		branches+=( "$(get_branch current)" )
 	fi
 }
@@ -620,7 +620,7 @@ function main() {
 					fetch_job_log "$job_id" "$log_file"
 
 					# In the event we've found a failed job, try to diff it against a prior
-					# successful master job of the equivalent workflow and job-type.
+					# successful main job of the equivalent workflow and job-type.
 					if [[ "$conclusion" == "failure"
 					&& -f "$log_file"
 					&& -f "$successful_prior_log" ]]; then

--- a/scripts/import-from-svn/import-from-svn.sh
+++ b/scripts/import-from-svn/import-from-svn.sh
@@ -110,7 +110,7 @@ import_svn_tagpaths_as_git_tags () {
 #
 cleanup () {
 	git -C "$1" checkout svn/trunk
-	git -C "$1" branch -D master
+	git -C "$1" branch -D main
 }
 
 # Set up remote repo to prepare for push

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -203,7 +203,7 @@ void DmaController::WriteControllerReg(Bitu reg,Bitu val,Bitu /*len*/) {
 	case 0xc:		/* Clear Flip/Flip */
 		flipflop=false;
 		break;
-	case 0xd:		/* Master Clear/Reset */
+	case 0xd: /* Clear/Reset all channels */
 		for (Bit8u ct=0;ct<4;ct++) {
 			chan=GetChannel(ct);
 			chan->SetMask(true);

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -30,7 +30,9 @@
 #include "mame/emu.h"
 #include "mame/saa1099.h"
 
-#define MASTER_CLOCK 7159090
+// GameBlaster runs at half of ISA's clock speed (14318180 / 2)
+constexpr uint32_t GAMEBLASTER_CLOCK_HZ = 7159090;
+
 
 //My mixer channel
 static MixerChannel * cms_chan;
@@ -146,11 +148,9 @@ public:
 
 		lastWriteTicks = PIC_Ticks;
 
-		const uint32_t clock = 7159090; // 14318180 isa clock / 2
-
 		machine_config config;
-		device[0] = new saa1099_device(config, "", 0, clock);
-		device[1] = new saa1099_device(config, "", 0, clock);
+		device[0] = new saa1099_device(config, "", 0, GAMEBLASTER_CLOCK_HZ);
+		device[1] = new saa1099_device(config, "", 0, GAMEBLASTER_CLOCK_HZ);
 
 		device[0]->device_start();
 		device[1]->device_start();

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -388,7 +388,7 @@ struct FM_OPL
 	uint8_t statusmask;               /* status mask                  */
 	uint8_t mode;                     /* Reg.08 : CSM,notesel,etc.    */
 
-	uint32_t clock;                   /* master clock  (Hz)           */
+	uint32_t clock;                   /* OPL chip clock speed (Hz)    */
 	uint32_t rate;                    /* sampling rate (Hz)           */
 	double freqbase;                /* frequency base               */
 	//attotime TimerBase;         /* Timer base time (==sampling time)*/

--- a/src/hardware/mame/saa1099.h
+++ b/src/hardware/mame/saa1099.h
@@ -91,7 +91,7 @@ private:
 	saa1099_channel m_channels[6];    /* channels */
 	saa1099_noise m_noise[2];         /* noise generators */
 	double m_sample_rate;
-	int m_master_clock;
+	int m_baseline_clock;
 };
 
 DECLARE_DEVICE_TYPE(SAA1099, saa1099_device)

--- a/src/hardware/mame/ymdeltat.cpp
+++ b/src/hardware/mame/ymdeltat.cpp
@@ -132,10 +132,12 @@ uint8_t YM_DELTAT::ADPCM_Read()
 			if (status_reset_handler && status_change_BRDY_bit)
 				(status_reset_handler)(status_change_which_chip, status_change_BRDY_bit);
 
-			/* setup a timer that will callback us in 10 master clock cycles for Y8950
-			* in the callback set the BRDY flag to 1 , which means we have another data ready.
-			* For now, we don't really do this; we simply reset and set the flag in zero time, so that the IRQ will work.
-			*/
+			/* setup a timer that will callback us in 10 YMF chip
+			 * clock cycles for Y8950 in the callback set the BRDY
+			 * flag to 1 , which means we have another data ready.
+			 * For now, we don't really do this; we simply reset and
+			 * set the flag in zero time, so that the IRQ will work.
+			 */
 			/* set BRDY bit in status register */
 			if (status_set_handler && status_change_BRDY_bit)
 				(status_set_handler)(status_change_which_chip, status_change_BRDY_bit);
@@ -348,10 +350,13 @@ value:   START, REC, MEMDAT, REPEAT, SPOFF, x,x,RESET   meaning:
 				if (status_reset_handler && status_change_BRDY_bit)
 					(status_reset_handler)(status_change_which_chip, status_change_BRDY_bit);
 
-				/* setup a timer that will callback us in 10 master clock cycles for Y8950
-				* in the callback set the BRDY flag to 1 , which means we have written the data.
-				* For now, we don't really do this; we simply reset and set the flag in zero time, so that the IRQ will work.
-				*/
+				/* setup a timer that will callback us in 10 YMF
+				 * chip clock cycles for Y8950 in the callback
+				 * set the BRDY flag to 1 , which means we have
+				 * written the data. For now, we don't really do
+				 * this; we simply reset and set the flag in
+				 * zero time, so that the IRQ will work.
+				 */
 				/* set BRDY bit in status register */
 				if (status_set_handler && status_change_BRDY_bit)
 					(status_set_handler)(status_change_which_chip, status_change_BRDY_bit);

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -276,8 +276,8 @@ struct OPL3
 	OPL3_UPDATEHANDLER UpdateHandler;
 	device_t *UpdateParam;
 
-	uint8_t type;                     /* chip type                    */
-	int clock;                      /* master clock  (Hz)           */
+	uint8_t type;                   /* chip type                    */
+	int clock;                      /* YMF chip clock speed (Hz)    */
 	int rate;                       /* sampling rate (Hz)           */
 	double freqbase;                /* frequency base               */
 	//attotime TimerBase;         /* Timer base time (==sampling time)*/

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -81,12 +81,15 @@ static void write_pci(Bitu port,Bitu val,Bitu iolen) {
 		LOG(LOG_PCI,LOG_NORMAL)("  Write to device %x register %x (function %x) (:=%x)",devnum,regnum,fctnum,val);
 
 		if (devnum>=pci_devices_installed) return;
-		PCI_Device* masterdev=pci_devices[devnum];
-		if (masterdev==NULL) return;
-		if (fctnum>masterdev->NumSubdevices()) return;
+		PCI_Device *selected_device = pci_devices[devnum];
+		if (selected_device == nullptr)
+			return;
+		if (fctnum > selected_device->NumSubdevices())
+			return;
 
-		PCI_Device* dev=masterdev->GetSubdevice(fctnum);
-		if (dev==NULL) return;
+		PCI_Device *dev = selected_device->GetSubdevice(fctnum);
+		if (dev == nullptr)
+			return;
 
 		// write data to PCI device/configuration
 		switch (iolen) {
@@ -151,13 +154,15 @@ static Bitu read_pci(Bitu port,Bitu iolen) {
 		LOG(LOG_PCI,LOG_NORMAL)("  Read from device %x register %x (function %x); addr %x",
 			devnum,regnum,fctnum,pci_caddress);
 
-		PCI_Device* masterdev=pci_devices[devnum];
-		if (masterdev==NULL) return 0xffffffff;
-		if (fctnum>masterdev->NumSubdevices()) return 0xffffffff;
+		PCI_Device *selected_device = pci_devices[devnum];
+		if (selected_device == nullptr)
+			return 0xffffffff;
+		if (fctnum > selected_device->NumSubdevices())
+			return 0xffffffff;
 
-		PCI_Device* dev=masterdev->GetSubdevice(fctnum);
+		PCI_Device *dev = selected_device->GetSubdevice(fctnum);
 
-		if (dev!=NULL) {
+		if (dev != nullptr) {
 			switch (iolen) {
 				case 1:
 					{

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1150,9 +1150,9 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 			}
 		}
 
-		/* Check for 8 for 9 character clock mode */
+		/* Check for 8 for 9 character clock modes */
 		if (vga.seq.clocking_mode & 1 ) clock/=8; else clock/=9;
-		/* Check for pixel doubling, master clock/2 */
+		/* Check for pixel doubling, clock/2 */
 		if (vga.seq.clocking_mode & 0x8) {
 			htotal*=2;
 		}

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -502,7 +502,7 @@ Bitu SVGA_S3_GetClock(void) {
 		clock = 28322000;
 	else
 		clock=1000*S3_CLOCK(vga.s3.clk[clock].m,vga.s3.clk[clock].n,vga.s3.clk[clock].r);
-	/* Check for dual transfer, master clock/2 */
+	/* Check for dual transfer, clock/2 */
 	if (vga.s3.pll.cmd & 0x10) clock/=2;
 	return clock;
 }

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1002,9 +1002,9 @@ static Bitu INT67_Handler(void) {
 				}
 				break;
 			case 0x0a:		/* VCPI Get PIC Vector Mappings */
-				reg_bx=vcpi.pic1_remapping;		// master PIC
-				reg_cx=vcpi.pic2_remapping;		// slave PIC
-				reg_ah=EMM_NO_ERROR;
+				reg_bx = vcpi.pic1_remapping; // primary PIC
+				reg_cx = vcpi.pic2_remapping; // secondary PIC
+				reg_ah = EMM_NO_ERROR;
 				break;
 			case 0x0b:		/* VCPI Set PIC Vector Mappings */
 				reg_flags&=(~FLAG_IF);
@@ -1276,8 +1276,8 @@ static void SetupVCPI() {
 
 	vcpi.enabled=true;
 
-	vcpi.pic1_remapping=0x08;	// master PIC base
-	vcpi.pic2_remapping=0x70;	// slave PIC base
+	vcpi.pic1_remapping = 0x08; // primary PIC base
+	vcpi.pic2_remapping = 0x70; // secondary PIC base
 
 	vcpi.private_area=emm_handles[vcpi.ems_handle].mem<<12;
 


### PR DESCRIPTION
This branch, [plus this PR](https://github.com/dosbox-staging/dosbox-staging/pull/1113) completes the repo-side work to deprecate the use of master & slave adjectives in the documentation, sources, and our default branch name.

### User-visible changes

Use of the baseline mixer volume:

![2021-07-04_10-57](https://user-images.githubusercontent.com/1557255/124395063-e9d2d880-dcb6-11eb-8745-fd3e50b32bd4.png)

The baseline volume is described in README as well.

### Remaining instances

 - In proper nouns ( Covox Voice Master, Sega Master System)
 - Deprecated translations (`contrib/old-translations/*`)
 - 3rd party repositories
 - 3rd party library code (stb_vorbis)

### GitHub-side steps

All that's left is to [select `main` as the default branch in the project settings](https://github.com/github/renaming#renaming-existing-branches).

GitHub takes care of the rest:
-    Re-targets any open pull requests
-   Updates any draft releases based on the branch
-    Moves any branch protection rules that explicitly reference the old name
-    Updates the branch used to build GitHub Pages, if applicable
-    Shows a notice to repository contributors, maintainers, and admins on the repository homepage with instructions to update local copies of the repository
-    Shows a notice to contributors who git push to the old branch
-    Redirects web requests for the old branch name to the new branch name
-    Returns a "Moved Permanently" response in API requests for the old branch name
