### PR TITLE
Permit use of C++17

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Denable_debugger=normal
-            max_warnings: 17
+            max_warnings: 0
 
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
@@ -55,7 +55,7 @@ jobs:
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 53
+            max_warnings: 0
 
           - name: GCC, -network
             os: ubuntu-20.04
@@ -66,7 +66,7 @@ jobs:
             os: ubuntu-20.04
             build_flags: --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_sdl2_net=false -Duse_opengl=false -Duse_fluidsynth=false -Duse_mt32emu=false -Duse_png=false -Duse_alsa=false
             min_dependencies: true
-            max_warnings: -1
+            max_warnings: 0
 
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -109,9 +109,9 @@ jobs:
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.today }}
+          key:  ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.today }}-1
           restore-keys: |
-            ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}
+            ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}-1
 
       - name:  Cache subprojects
         uses:  actions/cache@v2
@@ -172,9 +172,9 @@ jobs:
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-linux-release-${{ steps.prep-ccache.outputs.today }}
+          key:  ccache-linux-release-${{ steps.prep-ccache.outputs.today }}-1
           restore-keys: |
-            ccache-linux-release-${{ steps.prep-ccache.outputs.yesterday }}
+            ccache-linux-release-${{ steps.prep-ccache.outputs.yesterday }}-1
 
       - name:  Cache subprojects
         uses:  actions/cache@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,11 +62,6 @@ jobs:
             build_flags: -Duse_sdl2_net=false
             max_warnings: 0
 
-          - name: GCC, warning_level=3
-            os: ubuntu-20.04
-            build_flags: -Dwarning_level=3
-            max_warnings: 44
-
           - name: GCC, minimum build
             os: ubuntu-20.04
             build_flags: --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_sdl2_net=false -Duse_opengl=false -Duse_fluidsynth=false -Duse_mt32emu=false -Duse_png=false -Duse_alsa=false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,13 +46,6 @@ jobs:
             build_flags: -Denable_debugger=normal
             max_warnings: 17
 
-          - name: Clang, warning_level=3
-            host: macos-latest
-            arch: x86_64
-            needs_deps: true
-            build_flags: -Dwarning_level=3
-            max_warnings: 134
-
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]
             arch: arm64

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -86,7 +86,7 @@ jobs:
         if:    matrix.conf.needs_deps
         with:
           path: ${{ steps.prep-caches.outputs.brew_dir }}
-          key:  brew-cache-${{ matrix.conf.arch }}-${{ steps.prep-caches.outputs.today }}
+          key:  brew-cache-${{ matrix.conf.arch }}-${{ steps.prep-caches.outputs.today }}-1
           restore-keys: brew-cache-${{ matrix.conf.arch }}-
 
       - name: Install C++ compiler and libraries
@@ -100,7 +100,7 @@ jobs:
         if:    matrix.conf.needs_deps
         with:
           path: ${{ steps.prep-caches.outputs.ccache_dir }}
-          key:  ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-${{ steps.prep-caches.outputs.today }}
+          key:  ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-${{ steps.prep-caches.outputs.today }}-1
           restore-keys: |
             ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-
             ccache-macos-debug-
@@ -185,7 +185,7 @@ jobs:
         if:    matrix.runner.needs_deps
         with:
           path: ${{ steps.prep-caches.outputs.ccache_dir }}
-          key:  ccache-macos-release-${{ matrix.runner.arch }}-${{ steps.prep-caches.outputs.today }}
+          key:  ccache-macos-release-${{ matrix.runner.arch }}-${{ steps.prep-caches.outputs.today }}-1
           restore-keys: ccache-macos-release-${{ matrix.runner.arch }}-
 
       - name:  Cache subprojects

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
             arch: x86_64
             needs_deps: true
             build_flags: -Denable_debugger=normal
-            max_warnings: 17
+            max_warnings: 0
 
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 266
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1670
+            max_warnings: 1633
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
 ## Minimum build requirements
 
-- C/C++ compiler with support for C++14
+- C/C++ compiler with support for C++17
 - SDL >= 2.0.5
 - Opusfile
 - Meson >= 0.49.0 or Visual Studio Community Edition

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,10 +1,10 @@
 ## Minimum build requirements
 
-- C/C++ compiler with support for C++17
-- SDL >= 2.0.5
-- Opusfile
-- Meson >= 0.49.0 or Visual Studio Community Edition
-- OS that is mostly POSIX-compliant or up-to-date Windows system
+  - C/C++ compiler with support for C++17
+  - SDL >= 2.0.5
+  - Opusfile
+  - Meson >= 0.49.0 or Visual Studio Community Edition
+  - OS that is mostly POSIX-compliant or up-to-date Windows system
 
 All other dependencies are optional and can be disabled while configuring the
 build (in `meson setup` step).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,13 @@ Do not do mass reformatting or renaming of existing code.
 
 ### Language
 
-We use C-like C++14. To clarify:
+We use C-like C++17. To clarify:
 
 - Avoid designing your code in complex object-oriented style.
   This does not mean "don't use classes", it means "don't use stuff like
   multiple inheritance, overblown class hierarchies, operator overloading,
   iostreams for stdout/stderr, etc, etc".
-- C++14 has rich STL library, use it (responsibly - sometimes using
+- C++17 has rich STL library, use it (responsibly - sometimes using
   C standard library makes more sense).
 - Use modern C++ features like `constexpr`, `static_assert`, managed pointers,
   lambda expressions, for-each loops, etc.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ support today's systems.
 |                                | DOSBox Staging                | DOSBox
 |-                               |-                              |-
 | **Version control**            | Git                           | [SVN]
-| **Language**                   | C++14                         | C++03<sup>[1]</sup>
+| **Language**                   | C++17                         | C++03<sup>[1]</sup>
 | **SDL**                        | >= 2.0.5                      | 1.2<sup>＊</sup>
 | **Buildsystem**                | Meson or Visual Studio 2019   | Autotools or Visual Studio 2003
 | **CI**                         | Yes                           | No

--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ git submodule update --init
 git pull --recurse-submodules
 ```
 
+We recommend applying this Git (2.15+) configuration to ensure
+project submodules are kept in-sync whenever you `git pull`:
+
+``` shell
+git config --global submodule.recurse true
+```
+
+
 ## Build instructions
 
 Read [BUILD.md] for the comprehensive compilation guide.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('dosbox-staging', 'c', 'cpp',
         version : '0.78.0',
         license : 'GPL-2.0-or-later',
-        default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_staticpic=false'],
+        default_options : ['cpp_std=c++17', 'b_ndebug=if-release', 'b_staticpic=false'],
         meson_version : '>= 0.54.2')
 
 # After increasing the minimum-required meson version, make the following

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('dosbox-staging', 'c', 'cpp',
         version : '0.78.0',
         license : 'GPL-2.0-or-later',
-        default_options : ['cpp_std=c++17', 'b_ndebug=if-release', 'b_staticpic=false'],
+        default_options : ['cpp_std=c++17', 'warning_level=3', 'b_ndebug=if-release', 'b_staticpic=false'],
         meson_version : '>= 0.54.2')
 
 # After increasing the minimum-required meson version, make the following
@@ -14,9 +14,6 @@ project('dosbox-staging', 'c', 'cpp',
 
 
 # compiler flags
-#
-# Warnings enabled below are our baseline; use '-Dwarning_level=3' to
-# turn on more.  The default level is 1 (meson turns on -Wall).
 #
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -299,7 +299,7 @@ static INLINE void dyn_set_eip_end(void) {
 	gen_dop_word_imm(DOP_ADD,cpu.code.big,DREG(EIP),decode.code-decode.code_start);
 }
 
-static INLINE void dyn_set_eip_end(DynReg * endreg) {
+static INLINE void dyn_set_eip_end(MAYBE_UNUSED DynReg * endreg) {
 	gen_protectflags();
 	if (cpu.code.big) gen_dop_word(DOP_MOV,true,DREG(TMPW),DREG(EIP));
 	else gen_extend_word(false,DREG(TMPW),DREG(EIP));

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -133,6 +133,7 @@ private:
 					}
 				} else if ((modrm&7)!=4 || (sib&7)!=5)
 					break;
+				FALLTHROUGH;
 			case 2:	cache_addd((Bit32u)offset); break;
 			case 1: cache_addb((Bit8u)offset); break;
 			}
@@ -553,7 +554,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 		op.setreg(idx,di1);
 		tmp = 0x8A; // mov r8, []
 		break;
-	case 2: op.setword(); // mov r16, []
+	case 2: op.setword(); FALLTHROUGH; // mov r16, []
 	case 4: op.setreg(idx);
 		tmp = 0x8B; // mov r32, []
 		break;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -1248,7 +1248,7 @@ static void InvalidateFlagsPartially(void* current_simple_function,const Bit8u* 
 }
 
 // the current function needs the condition flags thus reset the queue
-static void AcquireFlags(Bitu flags_mask) {
+static void AcquireFlags(MAYBE_UNUSED Bitu flags_mask) {
 #ifdef DRC_FLAGS_INVALIDATION
 	mf_functions_num=0;
 #endif

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -248,7 +248,7 @@ static void dyn_dop_byte_imm_mem(DualOps op,Bit8u reg,Bit8u idx) {
 	if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,reg,idx);
 }
 
-static void dyn_prep_word_imm(Bit8u reg) {
+static void dyn_prep_word_imm(MAYBE_UNUSED Bit8u reg) {
 	Bitu val;
 	if (decode.big_op) {
 		if (decode_fetchd_imm(val)) {

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -180,7 +180,7 @@ static void dyn_fpu_esc1(){
 				break;
 			case 0x02:       /* UNKNOWN */
 			case 0x03:       /* ILLEGAL */
-				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",decode.modrm.reg,decode.modrm.rm);
+				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg), static_cast<uint32_t>(decode.modrm.rm));
 				break;
 			case 0x04:       /* FTST */
 				gen_call_function_raw((void*)&FPU_FTST);
@@ -190,7 +190,7 @@ static void dyn_fpu_esc1(){
 				break;
 			case 0x06:       /* FTSTP (cyrix)*/
 			case 0x07:       /* UNKNOWN */
-				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",decode.modrm.reg,decode.modrm.rm);
+				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 				break;
 			}
 			break;
@@ -218,7 +218,7 @@ static void dyn_fpu_esc1(){
 				gen_call_function_raw((void*)&FPU_FLDZ);
 				break;
 			case 0x07:       /* ILLEGAL */
-				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",decode.modrm.reg,decode.modrm.rm);
+				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 				break;
 			}
 			break;
@@ -249,7 +249,7 @@ static void dyn_fpu_esc1(){
 				gen_call_function_raw((void*)&FPU_FINCSTP);
 				break;
 			default:
-				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",decode.modrm.reg,decode.modrm.rm);
+				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 				break;
 			}
 			break;
@@ -280,12 +280,12 @@ static void dyn_fpu_esc1(){
 				gen_call_function_raw((void*)&FPU_FCOS);
 				break;
 			default:
-				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",decode.modrm.reg,decode.modrm.rm);
+				LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 				break;
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		}
 	} else {
@@ -297,7 +297,7 @@ static void dyn_fpu_esc1(){
 			gen_call_function_RR((void*)&FPU_FLD_F32,FC_OP1,FC_OP2);
 			break;
 		case 0x01: /* UNKNOWN */
-			LOG(LOG_FPU,LOG_WARN)("ESC EA 1:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC EA 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		case 0x02: /* FST float*/
 			dyn_fill_ea(FC_ADDR);
@@ -325,7 +325,7 @@ static void dyn_fpu_esc1(){
 			gen_call_function_R((void *)&FPU_FNSTCW,FC_ADDR);
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC EA 1:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC EA 1:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		}
 	}
@@ -348,12 +348,12 @@ static void dyn_fpu_esc2(){
 				gen_call_function_raw((void *)&FPU_FPOP);
 				break;
 			default:
-				LOG(LOG_FPU,LOG_WARN)("ESC 2:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm); 
+				LOG(LOG_FPU,LOG_WARN)("ESC 2:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 				break;
 			}
 			break;
 		default:
-	   		LOG(LOG_FPU,LOG_WARN)("ESC 2:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 2:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		}
 	} else {
@@ -508,7 +508,7 @@ static void dyn_fpu_esc5(){
 			gen_call_function_raw((void*)&FPU_FPOP);
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 5:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 5:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
         }
 	} else {
@@ -520,7 +520,7 @@ static void dyn_fpu_esc5(){
 			gen_call_function_RR((void*)&FPU_FLD_F64,FC_OP1,FC_OP2);
 			break;
 		case 0x01:  /* FISTTP longint*/
-			LOG(LOG_FPU,LOG_WARN)("ESC 5 EA:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 5 EA:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		case 0x02:   /* FST double real*/
 			dyn_fill_ea(FC_ADDR); 
@@ -547,7 +547,7 @@ static void dyn_fpu_esc5(){
 			gen_call_function_RR((void*)&mem_writew,FC_OP1,FC_OP2);
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 5 EA:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 5 EA:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 		}
 	}
 }
@@ -571,7 +571,7 @@ static void dyn_fpu_esc6(){
 			break;	/* TODO IS THIS ALLRIGHT ????????? */
 		case 0x03:  /*FCOMPP*/
 			if(decode.modrm.rm != 1) {
-				LOG(LOG_FPU,LOG_WARN)("ESC 6:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+				LOG(LOG_FPU,LOG_WARN)("ESC 6:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 				return;
 			}
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
@@ -638,12 +638,12 @@ static void dyn_fpu_esc7(){
 					MOV_REG_WORD16_FROM_HOST_REG(FC_OP1,DRC_REG_EAX);
 					break;
 				default:
-					LOG(LOG_FPU,LOG_WARN)("ESC 7:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+					LOG(LOG_FPU,LOG_WARN)("ESC 7:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 					break;
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 7:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 7:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		}
 	} else {
@@ -655,7 +655,7 @@ static void dyn_fpu_esc7(){
 			gen_call_function_RR((void*)&FPU_FLD_I16,FC_OP1,FC_OP2);
 			break;
 		case 0x01:
-			LOG(LOG_FPU,LOG_WARN)("ESC 7 EA:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 7 EA:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		case 0x02:   /* FIST Bit16s */
 			dyn_fill_ea(FC_ADDR); 
@@ -689,7 +689,7 @@ static void dyn_fpu_esc7(){
 			gen_call_function_raw((void*)&FPU_FPOP);
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 7 EA:Unhandled group %d subfunction %d",decode.modrm.reg,decode.modrm.rm);
+			LOG(LOG_FPU,LOG_WARN)("ESC 7 EA:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
 		}
 	}

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -85,7 +85,7 @@ static void DRC_CALL_CONV dynrec_cmp_byte(Bit8u op1,Bit8u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_cmp_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_byte_simple(Bit8u op1,Bit8u op2) {
+static void DRC_CALL_CONV dynrec_cmp_byte_simple(MAYBE_UNUSED Bit8u op1,MAYBE_UNUSED Bit8u op2) {
 }
 
 static Bit8u DRC_CALL_CONV dynrec_xor_byte(Bit8u op1,Bit8u op2) DRC_FC;
@@ -139,7 +139,7 @@ static void DRC_CALL_CONV dynrec_test_byte(Bit8u op1,Bit8u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_test_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_byte_simple(Bit8u op1,Bit8u op2) {
+static void DRC_CALL_CONV dynrec_test_byte_simple(MAYBE_UNUSED Bit8u op1,MAYBE_UNUSED Bit8u op2) {
 }
 
 static Bit16u DRC_CALL_CONV dynrec_add_word(Bit16u op1,Bit16u op2) DRC_FC;
@@ -209,7 +209,7 @@ static void DRC_CALL_CONV dynrec_cmp_word(Bit16u op1,Bit16u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_cmp_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_word_simple(Bit16u op1,Bit16u op2) {
+static void DRC_CALL_CONV dynrec_cmp_word_simple(MAYBE_UNUSED Bit16u op1, MAYBE_UNUSED Bit16u op2) {
 }
 
 static Bit16u DRC_CALL_CONV dynrec_xor_word(Bit16u op1,Bit16u op2) DRC_FC;
@@ -263,7 +263,7 @@ static void DRC_CALL_CONV dynrec_test_word(Bit16u op1,Bit16u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_test_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_word_simple(Bit16u op1,Bit16u op2) {
+static void DRC_CALL_CONV dynrec_test_word_simple(MAYBE_UNUSED Bit16u op1, MAYBE_UNUSED Bit16u op2) {
 }
 
 static Bit32u DRC_CALL_CONV dynrec_add_dword(Bit32u op1,Bit32u op2) DRC_FC;
@@ -333,7 +333,7 @@ static void DRC_CALL_CONV dynrec_cmp_dword(Bit32u op1,Bit32u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_cmp_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_dword_simple(Bit32u op1,Bit32u op2) {
+static void DRC_CALL_CONV dynrec_cmp_dword_simple(MAYBE_UNUSED Bit32u op1, MAYBE_UNUSED Bit32u op2) {
 }
 
 static Bit32u DRC_CALL_CONV dynrec_xor_dword(Bit32u op1,Bit32u op2) DRC_FC;
@@ -387,7 +387,7 @@ static void DRC_CALL_CONV dynrec_test_dword(Bit32u op1,Bit32u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_test_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_dword_simple(Bit32u op1,Bit32u op2) {
+static void DRC_CALL_CONV dynrec_test_dword_simple(MAYBE_UNUSED Bit32u op1, MAYBE_UNUSED Bit32u op2) {
 }
 
 

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -80,4 +80,4 @@ typedef Bit8u HostReg;
 #define HOST_lr HOST_r14
 #define HOST_pc HOST_r15
 
-static void cache_block_closing(const Bit8u *block_start, Bitu block_size) { }
+static void cache_block_closing(MAYBE_UNUSED const Bit8u *block_start, MAYBE_UNUSED Bitu block_size) { }

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -371,7 +371,7 @@ static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
 }
 
 // helper function for gen_mov_word_to_reg
-static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,HostReg data_reg) {
+static void gen_mov_word_to_reg_helper(HostReg dest_reg, MAYBE_UNUSED void* data,bool dword,HostReg data_reg) {
 	// alignment....
 	if (dword) {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
@@ -475,7 +475,7 @@ static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
 }
 
 // helper function for gen_mov_word_from_reg
-static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, HostReg data_reg) {
+static void gen_mov_word_from_reg_helper(HostReg src_reg, MAYBE_UNUSED void* dest,bool dword, HostReg data_reg) {
 	// alignment....
 	if (dword) {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
@@ -554,7 +554,7 @@ static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u
 }
 
 // move the lowest 8bit of a register into memory
-static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
+MAYBE_UNUSED static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
 		gen_mov_dword_to_reg_imm(temp1, (Bit32u)dest);
 		cache_addd( STRB_IMM(src_reg, temp1, 0) );      // strb src_reg, [temp1]
@@ -692,7 +692,7 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-static void gen_add_direct_byte(void* dest,Bit8s imm) {
+MAYBE_UNUSED static void gen_add_direct_byte(void* dest,Bit8s imm) {
 	gen_add_direct_word(dest, (Bit32s)imm, 1);
 }
 
@@ -739,7 +739,7 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-static void gen_sub_direct_byte(void* dest,Bit8s imm) {
+MAYBE_UNUSED static void gen_sub_direct_byte(void* dest,Bit8s imm) {
 	gen_sub_direct_word(dest, (Bit32s)imm, 1);
 }
 
@@ -778,7 +778,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bitu paramcount, MAYBE_UNUSED bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -812,8 +812,6 @@ static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
 
 // jump to an address pointed at by ptr, offset is in imm
 static void gen_jmp_ptr(void * ptr,Bits imm=0) {
-	Bit32u scale;
-
 	gen_mov_word_to_reg(temp3, ptr, 1);
 
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -447,7 +447,7 @@ static void gen_mov_qword_to_reg_imm(HostReg dest_reg,Bit64u imm) {
 }
 
 // helper function for gen_mov_word_to_reg
-static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,HostReg data_reg) {
+static void gen_mov_word_to_reg_helper(HostReg dest_reg, MAYBE_UNUSED void* data,bool dword,HostReg data_reg) {
 	if (dword) {
 		cache_addd( LDR_IMM(dest_reg, data_reg, 0) );       // ldr dest_reg, [data_reg]
 	} else {
@@ -523,7 +523,7 @@ static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
 }
 
 // helper function for gen_mov_word_from_reg
-static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, HostReg data_reg) {
+static void gen_mov_word_from_reg_helper(HostReg src_reg, MAYBE_UNUSED void* dest,bool dword, HostReg data_reg) {
 	if (dword) {
 		cache_addd( STR_IMM(src_reg, data_reg, 0) );        // str src_reg, [data_reg]
 	} else {
@@ -762,7 +762,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bitu paramcount, MAYBE_UNUSED bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -380,7 +380,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bitu paramcount, MAYBE_UNUSED bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -693,6 +693,6 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 }
 #endif
 
-static void cache_block_closing(const Bit8u* block_start,Bitu block_size) { }
+static void cache_block_closing(MAYBE_UNUSED const Bit8u* block_start, MAYBE_UNUSED Bitu block_size) { }
 
 static void cache_block_before_close(void) { }

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -213,7 +213,7 @@ l_M_Ed:
 		case 0:
 			break;
 		default:
-			LOG(LOG_CPU,LOG_ERROR)("MODRM:Unhandled load %d entry %x",inst.code.extra,inst.entry);
+			LOG(LOG_CPU,LOG_ERROR)("MODRM:Unhandled load %d entry %x",inst.code.extra,static_cast<uint32_t>(inst.entry));
 			break;
 		}
 		break;
@@ -526,7 +526,7 @@ l_M_Ed:
 		break;
 	}
 	default:
-		LOG(LOG_CPU, LOG_ERROR)("LOAD:Unhandled code %d opcode %X", inst.code.load, inst.entry);
+		LOG(LOG_CPU, LOG_ERROR)("LOAD:Unhandled code %d opcode %X", inst.code.load, static_cast<uint32_t>(inst.entry));
 		goto illegalopcode;
 }
 

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -417,7 +417,7 @@ switch (inst.code.op) {
 			CPU_VERW(inst_op1_d);
 			goto nextopcode;		/* Else value will saved */
 		default:
-			LOG(LOG_CPU,LOG_ERROR)("Group 6 Illegal subfunction %X",inst.rm_index);
+			LOG(LOG_CPU,LOG_ERROR)("Group 6 Illegal subfunction %X", static_cast<uint32_t>(inst.rm_index));
 			goto illegalopcode;
 		}
 		break;
@@ -453,7 +453,7 @@ switch (inst.code.op) {
 			PAGING_ClearTLB();
 			goto nextopcode;
 		default:
-			LOG(LOG_CPU,LOG_ERROR)("Group 7 Illegal subfunction %X",inst.rm_index);
+			LOG(LOG_CPU,LOG_ERROR)("Group 7 Illegal subfunction %X", static_cast<uint32_t>(inst.rm_index));
 			goto illegalopcode;
 		}
 		break;
@@ -662,6 +662,6 @@ switch (inst.code.op) {
 	case 0:
 		break;
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("OP:Unhandled code %d entry %X",inst.code.op,inst.entry);
+		LOG(LOG_CPU,LOG_ERROR)("OP:Unhandled code %d entry %X",inst.code.op,static_cast<uint32_t>(inst.entry));
 		
 }

--- a/src/cpu/core_full/save.h
+++ b/src/cpu/core_full/save.h
@@ -117,5 +117,5 @@ switch (inst.code.save) {
 	case 0:
 		break;
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("SAVE:Unhandled code %d entry %X",inst.code.save,inst.entry);
+		LOG(LOG_CPU,LOG_ERROR)("SAVE:Unhandled code %d entry %X",inst.code.save,static_cast<uint32_t>(inst.entry));
 }

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -241,7 +241,9 @@
 		}
 		break;
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("Unhandled string %d entry %X",inst.code.op,inst.entry);
+		LOG(LOG_CPU, LOG_ERROR)
+		("Unhandled string %d entry %X", inst.code.op,
+		 static_cast<uint32_t>(inst.entry));
 	}
 	/* Clean up after certain amount of instructions */
 	reg_esi&=(~add_mask);

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -153,7 +153,7 @@
 			Bitu which=(rm >> 3) & 7;
 			if (rm < 0xc0 ) {
 				rm |= 0xc0;
-				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,CR%u with non-register",which);
+				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,CR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
 			Bit32u crx_value;
@@ -167,7 +167,7 @@
 			Bitu which=(rm >> 3) & 7;
 			if (rm < 0xc0 ) {
 				rm |= 0xc0;
-				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,DR%u with non-register",which);
+				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,DR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
 			Bit32u drx_value;
@@ -181,7 +181,7 @@
 			Bitu which=(rm >> 3) & 7;
 			if (rm < 0xc0 ) {
 				rm |= 0xc0;
-				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,CR%u with non-register",which);
+				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,CR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
 			if (CPU_WRITE_CRX(which,*eard)) RUNEXCEPTION();
@@ -193,7 +193,7 @@
 			Bitu which=(rm >> 3) & 7;
 			if (rm < 0xc0 ) {
 				rm |= 0xc0;
-				LOG(LOG_CPU,LOG_ERROR)("MOV DR%u,XXX with non-register",which);
+				LOG(LOG_CPU,LOG_ERROR)("MOV DR%u,XXX with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
 			if (CPU_WRITE_DRX(which,*eard)) RUNEXCEPTION();
@@ -205,7 +205,7 @@
 			Bitu which=(rm >> 3) & 7;
 			if (rm < 0xc0 ) {
 				rm |= 0xc0;
-				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,TR%u with non-register",which);
+				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,TR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
 			Bit32u trx_value;
@@ -219,7 +219,7 @@
 			Bitu which=(rm >> 3) & 7;
 			if (rm < 0xc0 ) {
 				rm |= 0xc0;
-				LOG(LOG_CPU,LOG_ERROR)("MOV TR%u,XXX with non-register",which);
+				LOG(LOG_CPU,LOG_ERROR)("MOV TR%u,XXX with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
 			if (CPU_WRITE_TRX(which,*eard)) RUNEXCEPTION();

--- a/src/cpu/core_normal/prefix_66.h
+++ b/src/cpu/core_normal/prefix_66.h
@@ -712,7 +712,7 @@
 				else {GetEAa;Push_32(LoadMd(eaa));}
 				break;
 			default:
-				LOG(LOG_CPU,LOG_ERROR)("CPU:66:GRP5:Illegal call %2X",which);
+				LOG(LOG_CPU,LOG_ERROR)("CPU:66:GRP5:Illegal call %2X",static_cast<uint32_t>(which));
 				goto illegal_opcode;
 			}
 			break;

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -56,7 +56,7 @@
 				}
 				break;
 			default:
-				LOG(LOG_CPU,LOG_ERROR)("GRP6:Illegal call %2X",which);
+				LOG(LOG_CPU,LOG_ERROR)("GRP6:Illegal call %2X",static_cast<uint32_t>(which));
 				goto illegal_opcode;
 			}
 		}
@@ -111,7 +111,7 @@
 					if (CPU_LMSW(*eard)) RUNEXCEPTION();
 					break;
 				default:
-					LOG(LOG_CPU,LOG_ERROR)("Illegal group 7 RM subfunction %d",which);
+					LOG(LOG_CPU,LOG_ERROR)("Illegal group 7 RM subfunction %d",static_cast<int>(which));
 					goto illegal_opcode;
 					break;
 				}

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -511,6 +511,7 @@
 			switch (which) {
 			case 0x02:					/* MOV SS,Ew */
 				CPU_Cycles++; //Always do another instruction
+				FALLTHROUGH;
 			case 0x00:					/* MOV ES,Ew */
 			case 0x03:					/* MOV DS,Ew */
 			case 0x05:					/* MOV GS,Ew */
@@ -1166,7 +1167,7 @@
 				else {GetEAa;Push_16(LoadMw(eaa));}
 				break;
 			default:
-				LOG(LOG_CPU,LOG_ERROR)("CPU:GRP5:Illegal Call %2X",which);
+				LOG(LOG_CPU,LOG_ERROR)("CPU:GRP5:Illegal Call %2X",static_cast<uint32_t>(which));
 				goto illegal_opcode;
 			}
 			break;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -708,6 +708,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bitu oldeip) {
 					} 
 					if (cs_dpl!=cpu.cpl)
 						E_Exit("Non-conforming intra privilege INT with DPL!=CPL");
+					FALLTHROUGH;
 				case DESC_CODE_N_C_A:	case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:	case DESC_CODE_R_C_NA:
 					/* Prepare stack for gate to same priviledge */
@@ -1258,6 +1259,7 @@ call_code:
 						break;		
 					} else if (n_cs_dpl > cpu.cpl)
 						E_Exit("CALL:GATE:CS DPL>CPL");		// or #GP(sel)
+					FALLTHROUGH;
 				case DESC_CODE_N_C_A:case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:case DESC_CODE_R_C_NA:
 					// zrdx extender
@@ -1309,7 +1311,7 @@ call_code:
 }
 
 
-void CPU_RET(bool use32,Bitu bytes,Bitu oldeip) {
+void CPU_RET(bool use32,Bitu bytes, MAYBE_UNUSED Bitu oldeip) {
 	if (!cpu.pmode || (reg_flags & FLAG_VM)) {
 		Bitu new_ip,new_cs;
 		if (!use32) {
@@ -1787,6 +1789,7 @@ void CPU_LAR(Bitu selector,Bitu & ar) {
 				case DESC_CODE_R_NC_A:		case DESC_CODE_R_NC_NA:
 					if (desc.DPL()<cpu.cpl || desc.DPL()<rpl)
 						break;
+					FALLTHROUGH;
 
 				case DESC_CODE_N_C_A:	case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:	case DESC_CODE_R_C_NA:
@@ -1824,7 +1827,7 @@ void CPU_LSL(Bitu selector,Bitu & limit) {
 				case DESC_CODE_R_NC_A:		case DESC_CODE_R_NC_NA:
 					if (desc.DPL()<cpu.cpl || desc.DPL()<rpl)
 						break;
-
+					FALLTHROUGH;
 				case DESC_CODE_N_C_A:	case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:	case DESC_CODE_R_C_NA:
 					limit=desc.GetLimit();
@@ -2417,7 +2420,7 @@ public:
 
 static CPU * test;
 
-void CPU_ShutDown(Section* sec) {
+void CPU_ShutDown(MAYBE_UNUSED Section* sec) {
 #if (C_DYNAMIC_X86)
 	CPU_Core_Dyn_X86_Cache_Close();
 #elif (C_DYNREC)

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -521,7 +521,7 @@ public:
 		}
 		return true;
 	}
-	void InitPage(Bitu lin_addr,Bitu val) {
+	void InitPage(Bitu lin_addr, MAYBE_UNUSED Bitu val) {
 		Bitu lin_page=lin_addr >> 12;
 		Bitu phys_page;
 		if (paging.enabled) {
@@ -552,7 +552,7 @@ public:
 			PAGING_LinkPage(lin_page,phys_page);
 		}
 	}
-	Bitu InitPageCheckOnly(Bitu lin_addr,Bitu val) {
+	Bitu InitPageCheckOnly(Bitu lin_addr, MAYBE_UNUSED Bitu val) {
 		Bitu lin_page=lin_addr >> 12;
 		if (paging.enabled) {
 			if (!USERWRITE_PROHIBITED) return 2;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -522,7 +522,7 @@ bool CBreakpoint::CheckBreakpoint(Bitu seg, Bitu off)
 	return false;
 }
 
-bool CBreakpoint::CheckIntBreakpoint(PhysPt adr, Bit8u intNr, Bit16u ahValue, Bit16u alValue)
+bool CBreakpoint::CheckIntBreakpoint(MAYBE_UNUSED PhysPt adr, Bit8u intNr, Bit16u ahValue, Bit16u alValue)
 // Checks if interrupt breakpoint is valid and should stop execution
 {
 	if (BPoints.empty()) return false;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -282,7 +282,7 @@ void DBGUI_StartUp(void) {
 	nodelay(dbg.win_main,true);
 	keypad(dbg.win_main,true);
 	#ifndef WIN32
-	printf("\e[8;50;80t");
+	printf("\033[8;50;80t");
 	fflush(NULL);
 	resizeterm(50,80);
 	touchwin(dbg.win_main);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -648,11 +648,12 @@ void GFX_ForceFullscreenExit()
 	GFX_ResetScreen();
 }
 
-static int int_log2 (int val) {
-    int log = 0;
-    while ((val >>= 1) != 0)
-	log++;
-    return log;
+MAYBE_UNUSED static int int_log2(int val)
+{
+	int log = 0;
+	while ((val >>= 1) != 0)
+		log++;
+	return log;
 }
 
 // This is a hack to prevent SDL2 from re-creating window internally. Prevents
@@ -1044,8 +1045,11 @@ static SDL_Point calc_pp_scale(int avw, int avh)
 		return {1, 1};
 }
 
-Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags,
-                 double scalex, double scaley,
+Bitu GFX_SetSize(Bitu width,
+                 Bitu height,
+                 MAYBE_UNUSED Bitu flags,
+                 double scalex,
+                 double scaley,
                  GFX_CallBack_t callback,
                  double pixel_aspect)
 {
@@ -1450,7 +1454,8 @@ dosurface:
 	return retFlags;
 }
 
-void GFX_SetShader(const char* src) {
+void GFX_SetShader(MAYBE_UNUSED const char *src)
+{
 #if C_OPENGL
 	if (!sdl.opengl.use_shader || src == sdl.opengl.shader_src)
 		return;
@@ -1681,7 +1686,7 @@ void GFX_EndUpdate(const Bit16u *changedLines)
 #endif
 	if ((!using_opengl || !RENDER_GetForceUpdate()) && !sdl.updating)
 		return;
-	bool actually_updating = sdl.updating;
+	MAYBE_UNUSED bool actually_updating = sdl.updating;
 	sdl.updating = false;
 	switch (sdl.desktop.type) {
 	case SCREEN_TEXTURE: {
@@ -2041,7 +2046,7 @@ static std::string NormalizeConfValue(const char *val)
 	return pref;
 }
 
-static std::string get_glshader_value()
+MAYBE_UNUSED static std::string get_glshader_value()
 {
 #if C_OPENGL
 	assert(control);
@@ -2325,7 +2330,7 @@ static SDL_Rect calc_viewport_pp(int win_width, int win_height)
 	return {x, y, w, h};
 }
 
-static SDL_Rect calc_viewport(int width, int height)
+MAYBE_UNUSED static SDL_Rect calc_viewport(int width, int height)
 {
 	if (sdl.scaling_mode == SCALING_MODE::PERFECT)
 		return calc_viewport_pp(width, height);
@@ -3039,6 +3044,7 @@ bool GFX_Events()
 			if ((event.key.keysym.sym == SDLK_TAB) &&
 			    (GetTicksSince(sdl.focus_ticks) < 2))
 				break;
+			FALLTHROUGH;
 #endif
 #if defined (MACOSX)
 		case SDL_KEYDOWN:
@@ -3049,6 +3055,7 @@ bool GFX_Events()
 				RequestExit(true);
 				break;
 			}
+			FALLTHROUGH;
 #endif
 		default: MAPPER_CheckEvent(&event);
 		}

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -171,6 +171,6 @@ static CMS* test;
 void CMS_Init(Section* sec) {
 	test = new CMS(sec);
 }
-void CMS_ShutDown(Section* sec) {
+void CMS_ShutDown(MAYBE_UNUSED Section* sec) {
 	delete test;	       
 }

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -333,7 +333,15 @@ void CAPTURE_VideoStop() {
 #endif
 }
 
-void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags, float fps, Bit8u * data, Bit8u * pal) {
+void CAPTURE_AddImage(MAYBE_UNUSED Bitu width,
+                      MAYBE_UNUSED Bitu height,
+                      MAYBE_UNUSED Bitu bpp,
+                      MAYBE_UNUSED Bitu pitch,
+                      MAYBE_UNUSED Bitu flags,
+                      MAYBE_UNUSED float fps,
+                      MAYBE_UNUSED Bit8u *data,
+                      MAYBE_UNUSED Bit8u *pal)
+{
 #if (C_SSHOT)
 	Bitu i;
 	Bit8u doubleRow[SCALER_MAXWIDTH*4];
@@ -640,7 +648,6 @@ skip_video:
 	return;
 }
 
-
 #if (C_SSHOT)
 static void CAPTURE_ScreenShotEvent(bool pressed) {
 	if (!pressed)
@@ -842,7 +849,7 @@ public:
 
 static HARDWARE *hardware_module;
 
-void HARDWARE_Destroy(Section *sec)
+void HARDWARE_Destroy(MAYBE_UNUSED Section *sec)
 {
 	delete hardware_module;
 }

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -399,16 +399,18 @@ public:
 	{
 		size_t total_bytes = 0u;
 		for (uint8_t i = 0; i < io_widths; ++i) {
-			const size_t readers = io_read_handlers[i].size();
-			const size_t writers = io_write_handlers[i].size();
-			DEBUG_LOG_MSG("IOBUS: Releasing %lu read and %lu write %d-bit port handlers", readers,
-			              writers, 8 << i);
+			const auto readers = io_read_handlers[i].size();
+			const auto writers = io_write_handlers[i].size();
+			DEBUG_LOG_MSG("IOBUS: Releasing %d read and %d write %d-bit port handlers",
+			              static_cast<int>(readers), static_cast<int>(writers), 8 << i);
+
 			total_bytes += readers * sizeof(io_read_f) + sizeof(io_read_handlers[i]);
 			total_bytes += writers * sizeof(io_write_f) + sizeof(io_write_handlers[i]);
 			io_read_handlers[i].clear();
 			io_write_handlers[i].clear();
 		}
-		DEBUG_LOG_MSG("IOBUS: Handlers consumed %lu total bytes", total_bytes);
+		DEBUG_LOG_MSG("IOBUS: Handlers consumed %d total bytes",
+		              static_cast<int>(total_bytes));
 	}
 };
 

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1194,7 +1194,7 @@ public:
 
 static IPX* test;
 
-void IPX_ShutDown(Section* sec) {
+void IPX_ShutDown(MAYBE_UNUSED Section* sec) {
 	delete test;    
 }
 

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -54,7 +54,7 @@ struct machine_config;
 #define DECLARE_READ8_MEMBER(name)      u8     name( int, int)
 #define DECLARE_WRITE8_MEMBER(name)     void   name( int, int, u8 data)
 #define READ8_MEMBER(name)              u8     name( int, int)
-#define WRITE8_MEMBER(name)				void   name( int offset, int space, u8 data)
+#define WRITE8_MEMBER(name)				void   name(MAYBE_UNUSED int offset, MAYBE_UNUSED int space, MAYBE_UNUSED u8 data)
 
 #define DECLARE_DEVICE_TYPE(Type, Class) \
 		extern const device_type Type; \
@@ -71,13 +71,13 @@ public:
 
 	sound_stream temp;
 
-	device_sound_interface(const machine_config &mconfig, device_t &_device)
+	device_sound_interface(MAYBE_UNUSED const machine_config &mconfig, MAYBE_UNUSED device_t &_device)
 	        : temp()
 	{}
 
 	virtual ~device_sound_interface() = default;
 
-	sound_stream *stream_alloc(int whatever, int channels, int size)
+	sound_stream *stream_alloc(MAYBE_UNUSED int whatever, MAYBE_UNUSED int channels, MAYBE_UNUSED int size)
 	{
 		return &temp;
 	}
@@ -91,7 +91,7 @@ public:
 struct attotime {
 	int whatever;
 
-	static attotime from_hz(int hz) {
+	static attotime from_hz(MAYBE_UNUSED int hz) {
 		return attotime();
 	}
 };
@@ -120,7 +120,7 @@ public:
 		return clockRate;
 	}
 
-	void logerror(const char* format, ...) {
+	void logerror(MAYBE_UNUSED const char* format, ...) {
 #if C_DEBUG
 		char buf[512*2];
 		va_list msg;
@@ -138,10 +138,10 @@ public:
 	virtual void device_start() {
 	}
 
-	void save_item(int wtf, int blah= 0) {
+	void save_item(int, MAYBE_UNUSED int blah= 0) {
 	}
 
-	device_t(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 _clock) : clockRate( _clock ) {
+	device_t(MAYBE_UNUSED const machine_config &mconfig, MAYBE_UNUSED device_type type, MAYBE_UNUSED const char *tag, MAYBE_UNUSED device_t *owner, u32 _clock) : clockRate( _clock ) {
 	}
 
 	virtual ~device_t() {

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -71,7 +71,7 @@ public:
 
 	sound_stream temp;
 
-	device_sound_interface(MAYBE_UNUSED const machine_config &mconfig, MAYBE_UNUSED device_t &_device)
+	device_sound_interface(const machine_config & /* mconfig */, MAYBE_UNUSED device_t &_device)
 	        : temp()
 	{}
 
@@ -141,7 +141,7 @@ public:
 	void save_item(int, MAYBE_UNUSED int blah= 0) {
 	}
 
-	device_t(MAYBE_UNUSED const machine_config &mconfig, MAYBE_UNUSED device_type type, MAYBE_UNUSED const char *tag, MAYBE_UNUSED device_t *owner, u32 _clock) : clockRate( _clock ) {
+	device_t(const machine_config & /* mconfig */, MAYBE_UNUSED device_type type, MAYBE_UNUSED const char *tag, MAYBE_UNUSED device_t *owner, u32 _clock) : clockRate( _clock ) {
 	}
 
 	virtual ~device_t() {

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -930,7 +930,7 @@ struct FM_OPL
 
 
 	/* lock/unlock for common table */
-	static int LockTable(device_t *device)
+	static int LockTable(MAYBE_UNUSED device_t *device)
 	{
 		num_lock++;
 		if(num_lock>1) return 0;

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -393,7 +393,7 @@ void sn76496_base_device::countdown_cycles()
 	}
 }
 
-void sn76496_base_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
+void sn76496_base_device::sound_stream_update(MAYBE_UNUSED sound_stream &stream, MAYBE_UNUSED stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
 	int i;
 	stream_sample_t *lbuffer = outputs[0];

--- a/src/hardware/mame/ymdeltat.cpp
+++ b/src/hardware/mame/ymdeltat.cpp
@@ -460,7 +460,7 @@ void YM_DELTAT::postload(uint8_t *regs)
 		now_data = *(memory + (now_addr >> 1));
 
 }
-void YM_DELTAT::savestate(device_t *device)
+void YM_DELTAT::savestate(MAYBE_UNUSED device_t *device)
 {
 #ifdef MAME_EMU_SAVE_H
 	YM_DELTAT *const DELTAT = this; // makes the save name sensible

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1633,7 +1633,7 @@ static inline void set_sl_rr(OPL3 *chip,int slot,int v)
 }
 
 
-static void update_channels(OPL3 *chip, OPL3_CH *CH)
+static void update_channels(MAYBE_UNUSED OPL3 *chip, OPL3_CH *CH)
 {
 	/* update channel passed as a parameter and a channel at CH+=3; */
 	if (CH->extended)
@@ -2442,7 +2442,7 @@ static int OPL3TimerOver(OPL3 *chip,int c)
 	return chip->status>>7;
 }
 
-static void OPL3_save_state(OPL3 *chip, device_t *device) {
+static void OPL3_save_state(MAYBE_UNUSED OPL3 *chip, MAYBE_UNUSED device_t *device) {
 #if 0 
 	for (int ch=0; ch<18; ch++) {
 		OPL3_CH *channel = &chip->P_CH[ch];

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -915,7 +915,7 @@ uint8_t adlib_reg_read(io_port_t port) {
 #endif
 }
 
-void adlib_write_index(io_port_t port, uint8_t val) {
+void adlib_write_index(MAYBE_UNUSED io_port_t port, uint8_t val) {
 	opl_index = val;
 #if defined(OPLTYPE_IS_OPL3)
 	if ((port&3)!=0) {

--- a/src/libs/decoders/stb_vorbis.h
+++ b/src/libs/decoders/stb_vorbis.h
@@ -1856,7 +1856,9 @@ static int codebook_decode_start(vorb *f, Codebook *c)
       error(f, VORBIS_invalid_stream);
    else {
       DECODE_VQ(z,f,c);
-      if (c->sparse) assert(z < c->sorted_entries);
+      if (c->sparse) {
+         assert(z < c->sorted_entries);
+      }
       if (z < 0) {  // check for EOP
          if (!f->bytes_in_seg)
             if (f->last_seg)
@@ -3214,8 +3216,9 @@ static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, in
       goto retry;
    }
 
-   if (f->alloc.alloc_buffer)
+   if (f->alloc.alloc_buffer) {
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   }
 
    i = get_bits(f, ilog(f->mode_count-1));
    if (i == EOP) return FALSE;
@@ -3363,8 +3366,9 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    CHECK(f);
    // at this point we've decoded all floors
 
-   if (f->alloc.alloc_buffer)
+   if (f->alloc.alloc_buffer) {
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   }
 
    // re-enable coupled channels if necessary
    memcpy(really_zero_channel, zero_channel, sizeof(really_zero_channel[0]) * f->channels);
@@ -3396,8 +3400,9 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
       decode_residue(f, residue_buffers, ch, n2, r, do_not_decode);
    }
 
-   if (f->alloc.alloc_buffer)
+   if (f->alloc.alloc_buffer) {
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   }
    CHECK(f);
 
 // INVERSE COUPLING
@@ -3512,8 +3517,9 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    if (f->current_loc_valid)
       f->current_loc += (right_start - left_start);
 
-   if (f->alloc.alloc_buffer)
+   if (f->alloc.alloc_buffer) {
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   }
    *len = right_end;  // ignore samples after the window goes to 0
    CHECK(f);
 

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -97,8 +97,11 @@ emptyline:
 			 * international ASCII characters that are wrapped when
 			 * char is a signed type
 			 */
-			if (val < 0 || val > UNIT_SEPARATOR ||
-			    val == BACKSPACE || val == ESC || val == TAB) {
+			if (
+#if (CHAR_MIN < 0) // char is signed
+			    val < 0 ||
+#endif
+			    val > UNIT_SEPARATOR || val == BACKSPACE || val == ESC || val == TAB) {
 				// Only add it if room for it (and trailing zero)
 				// in the buffer, but do the check here instead
 				// at the end So we continue reading till EOL/EOF
@@ -157,7 +160,9 @@ emptyline:
 				next -= '0';
 				if (cmd->GetCount()<(unsigned int)next) continue;
 				std::string word;
+#if (CHAR_MIN < 0) // char is signed
 				assert(next >= 0);
+#endif
 				if (!cmd->FindCommand(static_cast<unsigned>(next), word))
 					continue;
 				append_cmd_write(word.c_str());
@@ -236,7 +241,12 @@ again:
 			// Note: the negative allowance permits high
 			// international ASCII characters that are wrapped when
 			// char is a signed type
-			if (val < 0 || val > UNIT_SEPARATOR) {
+
+			if (
+#if (CHAR_MIN < 0) // char is signed
+			    val < 0 ||
+#endif
+			    val > UNIT_SEPARATOR) {
 				if (cmd_write - cmd_buffer + 1 < CMD_MAXLINE - 1) {
 					*cmd_write++ = val;
 				}

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -39,7 +39,7 @@ const char *MSG_Get(char const *)
 }
 
 #if C_DEBUG
-void LOG::operator()(char const *buf, ...)
+void LOG::operator()(MAYBE_UNUSED char const *buf, ...)
 {
 	(void)d_type;     // Deliberately unused.
 	(void)d_severity; // Deliberately unused.

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -104,7 +104,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -131,7 +131,7 @@ $(TargetPath)
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -162,7 +162,7 @@ $(TargetPath)
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -190,7 +190,7 @@ $(TargetPath)
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FloatingPointModel>Fast</FloatingPointModel>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -112,7 +112,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <FloatingPointExceptions>true</FloatingPointExceptions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <MinimalRebuild>false</MinimalRebuild>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -150,7 +150,7 @@
       <OmitFramePointers>false</OmitFramePointers>
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <MinimalRebuild>false</MinimalRebuild>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
@@ -191,7 +191,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FloatingPointModel>Fast</FloatingPointModel>
       <FloatingPointExceptions>false</FloatingPointExceptions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>
@@ -239,7 +239,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FloatingPointModel>Fast</FloatingPointModel>
       <FloatingPointExceptions>false</FloatingPointExceptions>
-      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>


### PR DESCRIPTION
As of July 2021, all non-EOL supported platforms have a C++17-compliant compiler available (be it gcc, clang, or visual studio). 

This makes available improved language features such as string slicing (thanks for mentioning this @dreamer!) And the portable std::filesystem functions and classes. 