### PR TITLE
Use `main` as Staging's default branch

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,7 @@ name: Coverity Scan analysis
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   COVERITY_EMAIL: ${{ secrets.CoverityEmail }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -285,14 +285,14 @@ jobs:
 
 
   # This job exists only to publish an artifact with version info when building
-  # from master branch, so snapshot build version will be visible on:
+  # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_linux_release_dynamic
     runs-on: ubuntu-18.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -324,14 +324,14 @@ jobs:
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
     
   # This job exists only to publish an artifact with version info when building
-  # from master branch, so snapshot build version will be visible on:
+  # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_macos_release
     runs-on: macos-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -241,14 +241,14 @@ jobs:
 
 
   # This job exists only to publish an artifact with version info when building
-  # from master branch, so snapshot build version will be visible on:
+  # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_windows_vs_release
     runs-on: windows-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Generate changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ These rules apply to code in `src/` and `include/` directories.
 They do not apply to code in `src/libs/` directory (libraries in there
 have their own coding conventions).
 
-Rules outlined below apply to new code landing in master branch.
+Rules outlined below apply to new code landing in the main branch.
 Do not do mass reformatting or renaming of existing code.
 
 ### Language

--- a/docs/vc_redist.txt
+++ b/docs/vc_redist.txt
@@ -12,7 +12,7 @@ Windows versions.  These files are optional - if you have them pre-installed
 as part of your Operating System, you can safely remove them from this
 software package, or build your own version of DOSBox Staging, that does
 not use these files.  You can find instructions for doing so here:
-https://github.com/dosbox-staging/dosbox-staging/blob/master/BUILD.md#windows-procedures
+https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#windows-procedures
 
 These files are covered by "MICROSOFT VISUAL STUDIO 2015 EXTENSIONS,
 VISUAL STUDIO SHELLS and C++ REDISTRIBUTABLE" license:

--- a/scripts/fetch-workflows.sh
+++ b/scripts/fetch-workflows.sh
@@ -5,13 +5,13 @@
 # Copyright (C) 2020-2021  Kevin R. Croft <krcroft@gmail.com>
 
 ##
-#  This script craws the current repo's GitHub workflow content.
+#  This script crawls the current repo's GitHub workflow content.
 #  It fetches CI records for the provided branches, or by default
-#  the latest CI runs for the master and currently-set branches.
+#  the latest CI runs for the main branch and currently-set branch.
 #
 #  The goal of this script is two fold:
 #    - Provide a mechanized an automated way to fetch CI records.
-#    - Provide a rapid way to diff bad CI runs against master.
+#    - Provide a rapid way to diff bad CI runs against the main branch.
 #
 #  This script requires a GitHub account in order to generate an
 #  auth-token. Simply run the script, it will provide instructions.
@@ -51,7 +51,7 @@ function parse_args() {
 		echo ""
 		echo " - If only BRANCH_A is provided, then just download its records"
 		echo " - If both BRANCH_A and B are provided, then fetch and diff them"
-		echo " - If neither are provided, then fetch and diff good-master vs current branch"
+		echo " - If neither are provided, then fetch and diff the main branch vs current branch"
 		echo " - 'current' can be used in-place of the repo's currently set branch name"
 		echo " - Note: BRANCH_A and B can be the same; the tool will try to diff"
 		echo "         the last *good* run versus latest run (which might differ)"
@@ -63,7 +63,7 @@ function parse_args() {
 		branches+=( "$(get_branch "$1")" )
 		branches+=( "$(get_branch "$2")" )
 	else
-		branches+=( "master" )
+		branches+=( "main" )
 		branches+=( "$(get_branch current)" )
 	fi
 }
@@ -620,7 +620,7 @@ function main() {
 					fetch_job_log "$job_id" "$log_file"
 
 					# In the event we've found a failed job, try to diff it against a prior
-					# successful master job of the equivalent workflow and job-type.
+					# successful main job of the equivalent workflow and job-type.
 					if [[ "$conclusion" == "failure"
 					&& -f "$log_file"
 					&& -f "$successful_prior_log" ]]; then

--- a/scripts/import-from-svn/import-from-svn.sh
+++ b/scripts/import-from-svn/import-from-svn.sh
@@ -110,7 +110,7 @@ import_svn_tagpaths_as_git_tags () {
 #
 cleanup () {
 	git -C "$1" checkout svn/trunk
-	git -C "$1" branch -D master
+	git -C "$1" branch -D main
 }
 
 # Set up remote repo to prepare for push

--- a/scripts/import-from-svn/import-from-svn.sh
+++ b/scripts/import-from-svn/import-from-svn.sh
@@ -8,8 +8,13 @@
 # Uses git-svn to download whole history, converts svn tag paths to git tags,
 # filters repo and removes temporary git refs.
 
-readonly svn_url=https://svn.code.sf.net/p/dosbox/code-0/dosbox
-readonly git_default_branch="main"
+set -euo pipefail
+
+readonly svn_url="https://svn.code.sf.net/p/dosbox/code-0/dosbox"
+
+readonly git_destination_repo=$(git config --get remote.origin.url)
+
+readonly git_default_branch=$(git branch -rl '*/HEAD' | rev | cut -d/ -f1 | rev)
 
 echo_err () {
 	echo "$@" 1>&2
@@ -35,19 +40,29 @@ svn_get_copied_from () {
 # Full import takes ~40 minutes
 #
 git_svn_clone_dosbox () {
-	local -r repo_name=$1
-	local -r default_branch=$2
+	local -r svn_rev_range=$1
+	local -r repo_name=$2
+	local -r default_branch=$3
 
-	git -c "init.defaultBranch=$default_branch" \
-		svn init \
-		--stdlayout \
-		"$svn_url" \
-		"$repo_name"
+	if ! git -c "init.defaultBranch=$default_branch" \
+		svn init --stdlayout "$svn_url" "$repo_name" ; then
+		echo_err "'git svn init' failed. Do you have git-svn installed?"
+		exit 1
+	fi
 
-	local -r authors_prog=$PWD/svn-authors-prog.sh
+	local -r authors_file=$PWD/svn-dosbox-authors
+	#
+	# TODO:
+	# warning: do not use --use-log-author
+	#
+	# removing From: lines from message might (will?) mess up preserving info for
+	# fast imports, as I am rebasing commits, and overwriting committer
+	#
+	# TODO: implement our own authorship filtering
+	#
 	git -C "$repo_name" svn fetch \
-		--use-log-author \
-		--authors-prog="$authors_prog"
+		--revision="$svn_rev_range" \
+		--authors-file="$authors_file"
 }
 
 # Remove UUID of SVN server to avoid issues in case SourceForge will change
@@ -58,6 +73,19 @@ git_rewrite_import_links () {
 	git -C "$repo_name" filter-branch \
 		--msg-filter 'sed "s|git-svn-id: \([^ ]*\) .*|Imported-from: \1|"' \
 		-- --all
+}
+
+git_rewrite_committers () {
+	local -r repo_name=$1
+	local -r rev_list=$2
+	# shellcheck disable=SC2016
+	# --env-filter is going to evaluate the variables
+	git -C "$repo_name" filter-branch \
+		-f --env-filter '
+			GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+			GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+		' \
+		-- "$rev_list"
 }
 
 list_svn_branch_paths () {
@@ -118,27 +146,96 @@ cleanup () {
 	git -C "$1" branch -D "$default_branch"
 }
 
-# Set up remote repo to prepare for push
+# Perform import of the whole SVN history
 #
-setup_remote () {
-	git -C "$1" remote add dosbox-staging git@github.com:dosbox-staging/dosbox-staging.git
-	git -C "$1" fetch dosbox-staging
+full_import () {
+	local -r repo=$1
+	local -r default_branch=$2
+
+	if ! git_svn_clone_dosbox "1:HEAD" "$repo" "$default_branch" ; then
+		echo_err "Preparing git-svn repo failed."
+		exit 1
+	fi
+
+	git_rewrite_import_links "$repo"
+	name_active_branches "$repo"
+	import_svn_tagpaths_as_git_tags "$repo"
+	cleanup "$repo" "$default_branch"
+}
+
+# TODO: Fast import
+#
+fast_import () {
+	local -r repo=$1
+	local -r git_repo=$2
+	local -r default_branch=$3
+
+	local -r svn_base_rev=4385
+	# commit svn_base_rev before rebase:
+	local -r git_old_base_commit=132fa665fc3b5eea11fdc2236080afa5bbadbd9d
+	# commit svn_base_rev after rebase:
+	local -r git_new_base_commit=b5c09dd8ebf69c1ccc5c3d0722c80d30a1780576
+
+	if ! git_svn_clone_dosbox "$svn_base_rev:HEAD" "$repo" "$default_branch" ; then
+		echo_err "TODO!!!" # TODO
+		exit 1
+	fi
+
+	git_rewrite_import_links "$repo"
+	name_active_branches "$repo"
+	cleanup "$repo"
+
+	git -C "$repo" remote add dosbox-staging "$git_repo"
+	git -C "$repo" fetch dosbox-staging
+	git -C "$repo" rebase \
+		--committer-date-is-author-date \
+		--onto="$git_new_base_commit" \
+		"$git_old_base_commit"
+
+	git_rewrite_committers "$repo" "$git_new_base_commit..HEAD"
+
+	echo
+	echo "Tip of svn/trunk in $repo:"
+	echo
+
+	git -C "$repo" log --oneline dosbox-staging/svn/trunk~1..svn/trunk
+
+	echo
+	echo "Inspect new commits in $repo in detail."
+	echo "If the import looks good, invoke:"
+	echo
+	echo "    $ git -C $repo push dosbox-staging svn/trunk:svn/trunk"
+	echo
+}
+
+## Confirm the remote repo to use with recommended push command
+#
+confirm_remote () {
+        local -r git_repo=$1
+        local -r default_branch=$2
+
+	echo ""
+	echo "Remote repo: $git_repo"
+	echo ""
+	echo "Default branch: $default_branch"
+	echo ""
+	read -r -p "Press Enter to continue ot Ctrl+C to abort"
 }
 
 # main
 #
 main () {
-	readonly repo=dosbox-git-svn-$(svn_get_repo_revision)
+	confirm_remote "$git_destination_repo" "$git_default_branch"
+
+	local -r repo=dosbox-git-svn-$(svn_get_repo_revision)
 	if [ -e "$repo" ] ; then
 		echo_err "Repository '$repo' exists already."
 		exit 1
 	fi
-	git_svn_clone_dosbox "$repo" "$git_default_branch"
-	git_rewrite_import_links "$repo"
-	name_active_branches "$repo"
-	import_svn_tagpaths_as_git_tags "$repo"
-	cleanup "$repo" "$git_default_branch"
-	setup_remote "$repo"
+
+	# full_import "$repo" "$git_default_branch"
+
+	fast_import "$repo" "$git_destination_repo" "$git_default_branch"
 }
 
 main "$@"

--- a/scripts/import-from-svn/import-from-svn.sh
+++ b/scripts/import-from-svn/import-from-svn.sh
@@ -233,9 +233,9 @@ main () {
 		exit 1
 	fi
 
-	# full_import "$repo" "$git_default_branch"
+	full_import "$repo" "$git_default_branch"
 
-	fast_import "$repo" "$git_destination_repo" "$git_default_branch"
+	# fast_import "$repo" "$git_destination_repo" "$git_default_branch"
 }
 
 main "$@"


### PR DESCRIPTION
Suggest reviewing commit-by-commit. 
I was able to test the import script using a local `main` branch. 

All that's left is to [select `main` as the default branch in the project settings](https://github.com/github/renaming#renaming-existing-branches).

GitHub takes care of the rest:
-    Re-targets any open pull requests
-   Updates any draft releases based on the branch
-    Moves any branch protection rules that explicitly reference the old name
-    Updates the branch used to build GitHub Pages, if applicable
-    Shows a notice to repository contributors, maintainers, and admins on the repository homepage with instructions to update local copies of the repository
-    Shows a notice to contributors who git push to the old branch
-    Redirects web requests for the old branch name to the new branch name
-    Returns a "Moved Permanently" response in API requests for the old branch name