### PR TITLE
Cleanup CGA composite compiler warnings (2 of 2)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 272
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1965
+            max_warnings: 1960
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -183,8 +183,9 @@ static void write_lightpen(Bitu port,Bitu /*val*/,Bitu) {
 			Bitu current_scanline = (Bitu)(timeInFrame / vga.draw.delay.htotal);
 
 			vga.other.lightpen = (Bit16u)((vga.draw.address_add/2) * (current_scanline/2));
-			vga.other.lightpen += (Bit16u)((timeInLine / vga.draw.delay.hdend) *
-				((double)(vga.draw.address_add/2)));
+			vga.other.lightpen +=
+			        (Bit16u)((timeInLine / vga.draw.delay.hdend) *
+			                 ((double)(vga.draw.address_add / 2)));
 		}
 		break;
 	}
@@ -427,11 +428,17 @@ static void update_cga16_color(void) {
 			G = pow(G, gamma);
 			B = pow(B, gamma);
 
-			int r = static_cast<int>(255*pow( 1.5073*R -0.3725*G -0.0832*B, 1/gamma)); if (r<0) r=0; if (r>255) r=255;
-			int g = static_cast<int>(255*pow(-0.0275*R +0.9350*G +0.0670*B, 1/gamma)); if (g<0) g=0; if (g>255) g=255;
-			int b = static_cast<int>(255*pow(-0.0272*R -0.0401*G +1.1677*B, 1/gamma)); if (b<0) b=0; if (b>255) b=255;
+			const auto r = static_cast<uint8_t>(
+			        clamp(255 * pow(1.5073 * R - 0.3725 * G - 0.0832 * B, 1 / gamma),
+			              0.0, 255.0));
+			const auto g = static_cast<uint8_t>(
+			        clamp(255 * pow(-0.0275 * R + 0.9350 * G + 0.0670 * B, 1 / gamma),
+			              0.0, 255.0));
+			const auto b = static_cast<uint8_t>(
+			        clamp(255 * pow(-0.0272 * R - 0.0401 * G + 1.1677 * B, 1 / gamma),
+			              0.0, 255.0));
 
-			Bit8u index = bits | ((x & 1) == 0 ? 0x30 : 0x80) | ((x & 2) == 0 ? 0x40 : 0);
+			const uint8_t index = bits | ((x & 1) == 0 ? 0x30 : 0x80) | ((x & 2) == 0 ? 0x40 : 0);
 			RENDER_SetPal(index,r,g,b);
 		}
 	}

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -184,7 +184,7 @@ static void write_lightpen(Bitu port,Bitu /*val*/,Bitu) {
 
 			vga.other.lightpen = (Bit16u)((vga.draw.address_add/2) * (current_scanline/2));
 			vga.other.lightpen += (Bit16u)((timeInLine / vga.draw.delay.hdend) *
-				((float)(vga.draw.address_add/2)));
+				((double)(vga.draw.address_add/2)));
 		}
 		break;
 	}

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -460,7 +460,7 @@ static void DecreaseHue(bool pressed) {
 	LOG_MSG("Hue at %f",hue_offset); 
 }
 
-static void write_cga_color_select(Bitu val) {
+static void write_cga_color_select(uint8_t val) {
 	vga.tandy.color_select=val;
 	switch(vga.mode) {
 	case  M_TANDY4: {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 
 #include "inout.h"
@@ -38,52 +39,59 @@ static Bitu read_crtc_index_other(Bitu /*port*/,Bitu /*iolen*/) {
 	return vga.other.index;
 }
 
-static void write_crtc_data_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
+{
+	// write_crtc_data_other() only accepts 8-bit data per its IO port registration
+	auto val = static_cast<uint8_t>(data);
+
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
 		if (vga.other.htotal ^ val) VGA_StartResize();
-		vga.other.htotal=(Bit8u)val;
+		vga.other.htotal = val;
 		break;
 	case 0x01:		//Horizontal displayed chars
 		if (vga.other.hdend ^ val) VGA_StartResize();
-		vga.other.hdend=(Bit8u)val;
+		vga.other.hdend = val;
 		break;
 	case 0x02:		//Horizontal sync position
-		vga.other.hsyncp=(Bit8u)val;
+		vga.other.hsyncp = val;
 		break;
-	case 0x03:		//Horizontal sync width
-		if (machine==MCH_TANDY) vga.other.vsyncw=(Bit8u)(val >> 4);
-		else vga.other.vsyncw = 16; // The MC6845 has a fixed v-sync width of 16 lines
-		vga.other.hsyncw=(Bit8u)(val & 0xf);
+	case 0x03: // Horizontal sync width
+		if (machine == MCH_TANDY)
+			vga.other.vsyncw = val >> 4;
+		else
+			// The MC6845 has a fixed v-sync width of 16 lines
+			vga.other.vsyncw = 16;
+		vga.other.hsyncw = val & 0xf;
 		break;
-	case 0x04:		//Vertical total
+	case 0x04: // Vertical total
 		if (vga.other.vtotal ^ val) VGA_StartResize();
-		vga.other.vtotal=(Bit8u)val;
+		vga.other.vtotal = val;
 		break;
 	case 0x05:		//Vertical display adjust
 		if (vga.other.vadjust ^ val) VGA_StartResize();
-		vga.other.vadjust=(Bit8u)val;
+		vga.other.vadjust = val;
 		break;
 	case 0x06:		//Vertical rows
 		if (vga.other.vdend ^ val) VGA_StartResize();
-		vga.other.vdend=(Bit8u)val;
+		vga.other.vdend = val;
 		break;
 	case 0x07:		//Vertical sync position
-		vga.other.vsyncp=(Bit8u)val;
+		vga.other.vsyncp = val;
 		break;
 	case 0x09:		//Max scanline
 		val &= 0x1f; // VGADOC says bit 0-3 but the MC6845 datasheet says bit 0-4
  		if (vga.other.max_scanline ^ val) VGA_StartResize();
-		vga.other.max_scanline=(Bit8u)val;
+		vga.other.max_scanline = val;
 		break;
 	case 0x0A:	/* Cursor Start Register */
-		vga.other.cursor_start = (Bit8u)(val & 0x3f);
-		vga.draw.cursor.sline = (Bit8u)(val&0x1f);
+		vga.other.cursor_start = val & 0x3f;
+		vga.draw.cursor.sline = val & 0x1f;
 		vga.draw.cursor.enabled = ((val & 0x60) != 0x20);
 		break;
 	case 0x0B:	/* Cursor End Register */
-		vga.other.cursor_end = (Bit8u)(val&0x1f);
-		vga.draw.cursor.eline = (Bit8u)(val&0x1f);
+		vga.other.cursor_end = val & 0x1f;
+		vga.draw.cursor.eline = val & 0x1f;
 		break;
 	case 0x0C:	/* Start Address High Register */
 		// Bit 12 (depending on video mode) and 13 are actually masked too,
@@ -94,12 +102,12 @@ static void write_crtc_data_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
 		vga.config.display_start=(vga.config.display_start & 0xFF00) | val;
 		break;
 	case 0x0E:	/*Cursor Location High Register */
-		vga.config.cursor_start&=0x00ff;
-		vga.config.cursor_start|=((Bit8u)val) << 8;
+		vga.config.cursor_start &= 0x00ff;
+		vga.config.cursor_start |= val << 8;
 		break;
-	case 0x0F:	/* Cursor Location Low Register */
-		vga.config.cursor_start&=0xff00;
-		vga.config.cursor_start|=(Bit8u)val;
+	case 0x0F: /* Cursor Location Low Register */
+		vga.config.cursor_start &= 0xff00;
+		vga.config.cursor_start |= val;
 		break;
 	case 0x10:	/* Light Pen High */
 		vga.other.lightpen &= 0xff;
@@ -107,10 +115,10 @@ static void write_crtc_data_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
 		break;
 	case 0x11:	/* Light Pen Low */
 		vga.other.lightpen &= 0xff00;
-		vga.other.lightpen |= (Bit8u)val;
+		vga.other.lightpen |= val;
 		break;
 	default:
-		LOG(LOG_VGAMISC,LOG_NORMAL)("MC6845:Write %" sBitfs(X) " to illegal index %x",val,vga.other.index);
+		LOG(LOG_VGAMISC, LOG_NORMAL)("MC6845:Write %u to illegal index %x", val, vga.other.index);
 	}
 }
 static Bitu read_crtc_data_other(Bitu /*port*/,Bitu /*iolen*/) {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -122,7 +122,8 @@ static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
 		LOG(LOG_VGAMISC, LOG_NORMAL)("MC6845:Write %u to illegal index %x", val, vga.other.index);
 	}
 }
-static Bitu read_crtc_data_other(Bitu /*port*/,Bitu /*iolen*/) {
+static uint8_t read_crtc_data_other(Bitu /*port*/, Bitu /*iolen*/)
+{
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
 		return vga.other.htotal;
@@ -132,8 +133,10 @@ static Bitu read_crtc_data_other(Bitu /*port*/,Bitu /*iolen*/) {
 		return vga.other.hsyncp;
 	case 0x03:		//Horizontal and vertical sync width
 		if (machine==MCH_TANDY)
-			return vga.other.hsyncw | (vga.other.vsyncw << 4);
-		else return vga.other.hsyncw;
+			return static_cast<uint8_t>(vga.other.hsyncw |
+			                            (vga.other.vsyncw << 4));
+		else
+			return vga.other.hsyncw;
 	case 0x04:		//Vertical total
 		return vga.other.vtotal;
 	case 0x05:		//Vertical display adjust
@@ -149,21 +152,21 @@ static Bitu read_crtc_data_other(Bitu /*port*/,Bitu /*iolen*/) {
 	case 0x0B:	/* Cursor End Register */
 		return vga.other.cursor_end;
 	case 0x0C:	/* Start Address High Register */
-		return (Bit8u)(vga.config.display_start >> 8);
+		return static_cast<uint8_t>(vga.config.display_start >> 8);
 	case 0x0D:	/* Start Address Low Register */
-		return (Bit8u)(vga.config.display_start & 0xff);
+		return static_cast<uint8_t>(vga.config.display_start & 0xff);
 	case 0x0E:	/*Cursor Location High Register */
-		return (Bit8u)(vga.config.cursor_start >> 8);
+		return static_cast<uint8_t>(vga.config.cursor_start >> 8);
 	case 0x0F:	/* Cursor Location Low Register */
-		return (Bit8u)(vga.config.cursor_start & 0xff);
+		return static_cast<uint8_t>(vga.config.cursor_start & 0xff);
 	case 0x10:	/* Light Pen High */
-		return (Bit8u)(vga.other.lightpen >> 8);
+		return static_cast<uint8_t>(vga.other.lightpen >> 8);
 	case 0x11:	/* Light Pen Low */
-		return (Bit8u)(vga.other.lightpen & 0xff);
+		return static_cast<uint8_t>(vga.other.lightpen & 0xff);
 	default:
 		LOG(LOG_VGAMISC,LOG_NORMAL)("MC6845:Read from illegal index %x",vga.other.index);
 	}
-	return (Bitu)(~0);
+	return static_cast<uint8_t>(~0);
 }
 
 static void write_lightpen(Bitu port,Bitu /*val*/,Bitu) {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -103,7 +103,7 @@ static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
 		break;
 	case 0x0E:	/*Cursor Location High Register */
 		vga.config.cursor_start &= 0x00ff;
-		vga.config.cursor_start |= val << 8;
+		vga.config.cursor_start |= static_cast<uint16_t>(val << 8);
 		break;
 	case 0x0F: /* Cursor Location Low Register */
 		vga.config.cursor_start &= 0xff00;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -96,7 +96,8 @@ static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
 	case 0x0C:	/* Start Address High Register */
 		// Bit 12 (depending on video mode) and 13 are actually masked too,
 		// but so far no need to implement it.
-		vga.config.display_start=(vga.config.display_start & 0x00FF) | ((val&0x3F) << 8);
+		vga.config.display_start = (vga.config.display_start & 0x00FF) |
+		                           static_cast<uint16_t>((val & 0x3F) << 8);
 		break;
 	case 0x0D:	/* Start Address Low Register */
 		vga.config.display_start=(vga.config.display_start & 0xFF00) | val;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -492,10 +492,12 @@ static void write_cga_color_select(uint8_t val) {
 	}
 }
 
-static void write_cga(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_cga(Bitu port,Bitu data,Bitu /*iolen*/) {
+	// The only data written is 8-bit per write_cga's IO port registration
+	const auto val = static_cast<uint8_t>(data);
 	switch (port) {
 	case 0x3d8:
-		vga.tandy.mode_control=(Bit8u)val;
+		vga.tandy.mode_control= val;
 		vga.attr.disabled = (val&0x8)? 0: 1;
 		if (vga.tandy.mode_control & 0x2) {		// graphics mode
 			if (vga.tandy.mode_control & 0x10) {// highres mode

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -132,7 +132,12 @@ static uint8_t read_crtc_data_other(Bitu /*port*/, Bitu /*iolen*/)
 	case 0x02:		//Horizontal sync position
 		return vga.other.hsyncp;
 	case 0x03:		//Horizontal and vertical sync width
-		if (machine==MCH_TANDY)
+
+		// hsyncw and vsyncw should only be populated with their lower 4-bits
+		assert(vga.other.hsyncw >> 4 == 0);
+		assert(vga.other.vsyncw >> 4 == 0);
+
+		if (machine == MCH_TANDY)
 			return static_cast<uint8_t>(vga.other.hsyncw |
 			                            (vga.other.vsyncw << 4));
 		else

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -492,12 +492,13 @@ static void write_cga_color_select(uint8_t val) {
 	}
 }
 
-static void write_cga(Bitu port,Bitu data,Bitu /*iolen*/) {
+static void write_cga(Bitu port, Bitu data, Bitu /*iolen*/)
+{
 	// The only data written is 8-bit per write_cga's IO port registration
 	const auto val = static_cast<uint8_t>(data);
 	switch (port) {
 	case 0x3d8:
-		vga.tandy.mode_control= val;
+		vga.tandy.mode_control = val;
 		vga.attr.disabled = (val&0x8)? 0: 1;
 		if (vga.tandy.mode_control & 0x2) {		// graphics mode
 			if (vga.tandy.mode_control & 0x10) {// highres mode
@@ -714,12 +715,15 @@ static void write_tandy_reg(Bit8u val) {
 	}
 }
 
-static void write_tandy(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_tandy(Bitu port, Bitu data, Bitu /*iolen*/)
+{
+	// only is passed 8-bit data given its IO port registration
+	auto val = static_cast<uint8_t>(data);
 	switch (port) {
 	case 0x3d8:
 		val &= 0x3f; // only bits 0-6 are used
 		if (vga.tandy.mode_control ^ val) {
-			vga.tandy.mode_control=(Bit8u)val;
+			vga.tandy.mode_control = val;
 			if (val&0x8) vga.attr.disabled &= ~1;
 			else vga.attr.disabled |= 1;
 			TandyCheckLineMask();
@@ -733,15 +737,13 @@ static void write_tandy(Bitu port,Bitu val,Bitu /*iolen*/) {
 		tandy_update_palette();
 		break;
 	case 0x3da:
-		vga.tandy.reg_index=(Bit8u)val;
+		vga.tandy.reg_index = val;
 		//if (val&0x10) vga.attr.disabled |= 2;
 		//else vga.attr.disabled &= ~2;
 		break;
 //	case 0x3dd:	//Extended ram page address register:
 //		break;
-	case 0x3de:
-		write_tandy_reg((Bit8u)val);
-		break;
+	case 0x3de: write_tandy_reg(val); break;
 	case 0x3df:
 		// CRT/processor page register
 		// See the comments on the PCJr version of this register.
@@ -752,7 +754,7 @@ static void write_tandy(Bitu port,Bitu val,Bitu /*iolen*/) {
 		// backwards compatibility?), resulting in odd pages being mapped
 		// as 2x16kB. Implemeted in vga_memory.cpp Tandy handler.
 
-		vga.tandy.line_mask = (Bit8u)(val >> 6);
+		vga.tandy.line_mask = val >> 6;
 		vga.tandy.draw_bank = val & ((vga.tandy.line_mask&2) ? 0x6 : 0x7);
 		vga.tandy.mem_bank = (val >> 3) & 7;
 		TandyCheckLineMask();

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -132,14 +132,11 @@ static uint8_t read_crtc_data_other(Bitu /*port*/, Bitu /*iolen*/)
 	case 0x02:		//Horizontal sync position
 		return vga.other.hsyncp;
 	case 0x03:		//Horizontal and vertical sync width
-
 		// hsyncw and vsyncw should only be populated with their lower 4-bits
 		assert(vga.other.hsyncw >> 4 == 0);
 		assert(vga.other.vsyncw >> 4 == 0);
-
 		if (machine == MCH_TANDY)
-			return static_cast<uint8_t>(vga.other.hsyncw |
-			                            (vga.other.vsyncw << 4));
+			return static_cast<uint8_t>(vga.other.hsyncw | (vga.other.vsyncw << 4));
 		else
 			return vga.other.hsyncw;
 	case 0x04:		//Vertical total

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -897,9 +897,8 @@ void Herc_Palette()
 	}
 }
 
-static void write_hercules(Bitu port, uint8_t data, Bitu /*iolen*/)
+static void write_hercules(Bitu port, uint8_t val, Bitu /*iolen*/)
 {
-	const auto val = static_cast<uint8_t>(data);
 	switch (port) {
 	case 0x3b8: {
 		// the protected bits can always be cleared but only be set if the
@@ -930,7 +929,7 @@ static void write_hercules(Bitu port, uint8_t data, Bitu /*iolen*/)
 		}
 		vga.draw.blinking = (val&0x20)!=0;
 		vga.herc.mode_control &= 0x82;
-		vga.herc.mode_control |= static_cast<uint8_t>(val & ~0x82);
+		vga.herc.mode_control |= val & ~0x82;
 		break;
 		}
 	case 0x3bf:

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1045,13 +1045,16 @@ void VGA_SetupOther(void)
 	}
 	if (machine == MCH_HERC) {
 		Bitu base=0x3b0;
-		for (int i = 0; i < 4; ++i) {
+		for (uint8_t i = 0; i < 4; ++i) {
 			// The registers are repeated as the address is not decoded properly;
 			// The official ports are 3b4, 3b5
-			IO_RegisterWriteHandler(base+i*2,write_crtc_index_other,IO_MB);
-			IO_RegisterWriteHandler(base+i*2+1,write_crtc_data_other,IO_MB);
-			IO_RegisterReadHandler(base+i*2,read_crtc_index_other,IO_MB);
-			IO_RegisterReadHandler(base+i*2+1,read_crtc_data_other,IO_MB);
+			const auto index_port = base + i * 2;
+			IO_RegisterWriteHandler(index_port, write_crtc_index_other, IO_MB);
+			IO_RegisterReadHandler(index_port, read_crtc_index_other, IO_MB);
+
+			const auto data_port = index_port + 1;
+			IO_RegisterWriteHandler(data_port, write_crtc_data_other, IO_MB);
+			IO_RegisterReadHandler(data_port, read_crtc_data_other, IO_MB);
 		}
 		vga.herc.enable_bits=0;
 		vga.herc.mode_control=0xa; // first mode written will be text mode

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -56,7 +56,7 @@ static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
 	case 0x02:		//Horizontal sync position
 		vga.other.hsyncp = val;
 		break;
-	case 0x03: // Horizontal sync width
+	case 0x03:		//Horizontal sync width
 		if (machine == MCH_TANDY)
 			vga.other.vsyncw = val >> 4;
 		else
@@ -64,7 +64,7 @@ static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
 			vga.other.vsyncw = 16;
 		vga.other.hsyncw = val & 0xf;
 		break;
-	case 0x04: // Vertical total
+	case 0x04:		//Vertical total
 		if (vga.other.vtotal ^ val) VGA_StartResize();
 		vga.other.vtotal = val;
 		break;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -974,10 +974,9 @@ Bitu read_herc_status(Bitu /*port*/,Bitu /*iolen*/) {
 	return retval;
 }
 
-
-void VGA_SetupOther(void) {
-	Bitu i;
-	memset( &vga.tandy, 0, sizeof( vga.tandy ));
+void VGA_SetupOther(void)
+{
+	memset(&vga.tandy, 0, sizeof(vga.tandy));
 	vga.attr.disabled = 0;
 	vga.config.bytes_skip=0;
 
@@ -990,8 +989,10 @@ void VGA_SetupOther(void) {
 
 	if (machine==MCH_CGA || IS_TANDY_ARCH) {
 		extern Bit8u int10_font_08[256 * 8];
-		for (i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_08[i*8],8);
-		vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
+		for (int i = 0; i < 256; ++i) {
+			memcpy(&vga.draw.font[i * 32], &int10_font_08[i * 8], 8);
+		}
+		vga.draw.font_tables[0] = vga.draw.font_tables[1] = vga.draw.font;
 	}
 	if (machine==MCH_CGA || IS_TANDY_ARCH || machine==MCH_HERC) {
 		IO_RegisterWriteHandler(0x3db,write_lightpen,IO_MB);
@@ -999,8 +1000,10 @@ void VGA_SetupOther(void) {
 	}
 	if (machine==MCH_HERC) {
 		extern Bit8u int10_font_14[256 * 14];
-		for (i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_14[i*14],14);
-		vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
+		for (int i = 0; i < 256; ++i) {
+			memcpy(&vga.draw.font[i * 32], &int10_font_14[i * 14], 14);
+		}
+		vga.draw.font_tables[0] = vga.draw.font_tables[1] = vga.draw.font;
 		MAPPER_AddHandler(CycleHercPal, SDL_SCANCODE_F11, 0,
 		                  "hercpal", "Herc Pal");
 	}
@@ -1042,7 +1045,7 @@ void VGA_SetupOther(void) {
 	}
 	if (machine == MCH_HERC) {
 		Bitu base=0x3b0;
-		for (Bitu i = 0; i < 4; i++) {
+		for (int i = 0; i < 4; ++i) {
 			// The registers are repeated as the address is not decoded properly;
 			// The official ports are 3b4, 3b5
 			IO_RegisterWriteHandler(base+i*2,write_crtc_index_other,IO_MB);

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -895,7 +895,9 @@ void Herc_Palette()
 	}
 }
 
-static void write_hercules(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_hercules(Bitu port, uint8_t data, Bitu /*iolen*/)
+{
+	const auto val = static_cast<uint8_t>(data);
 	switch (port) {
 	case 0x3b8: {
 		// the protected bits can always be cleared but only be set if the
@@ -926,7 +928,7 @@ static void write_hercules(Bitu port,Bitu val,Bitu /*iolen*/) {
 		}
 		vga.draw.blinking = (val&0x20)!=0;
 		vga.herc.mode_control &= 0x82;
-		vga.herc.mode_control |= val & ~0x82;
+		vga.herc.mode_control |= static_cast<uint8_t>(val & ~0x82);
 		break;
 		}
 	case 0x3bf:

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -816,7 +816,7 @@ static void write_pcjr(Bitu port,Bitu val,Bitu /*iolen*/) {
 	}
 }
 
-static int palette_num(const char *colour)
+static uint8_t palette_num(const char *colour)
 {
 	if (strcasecmp(colour, "green") == 0)
 		return 0;


### PR DESCRIPTION
Fixes all warning generated in `vga_other`.

Suggest reviewing commit-by-commit.

Fixes:

![2021-07-05_14-39](https://user-images.githubusercontent.com/1557255/124521479-714a4580-dda4-11eb-9f04-caef79237d54.png)
