### PR TITLE
Increment the vcpkg fluidsynth DLL revision number

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -162,7 +162,7 @@ jobs:
           cp docs/README.video                    dest/doc/video.txt
           cp docs/vc_redist.txt                   dest/doc/vc_redist.txt
           cp README                               dest/doc/manual.txt
-          cp vs/$RELEASE_DIR/libfluidsynth-2.dll  dest/
+          cp vs/$RELEASE_DIR/libfluidsynth-3.dll  dest/
           cp vs/$RELEASE_DIR/glib-2.0-0.dll       dest/ # fluidsynth dependency
           cp vs/$RELEASE_DIR/intl-8.dll           dest/ # glib dependency
           cp vs/$RELEASE_DIR/pcre.dll             dest/ # glib dependency


### PR DESCRIPTION
vcpkg has incremented the FluidSynth DLL rev-number, and all Windows CI jobs have been failing.

```
2021-07-06T01:38:19.5466465Z cp: cannot stat 'vs/x64/Release/libfluidsynth-2.dll': No such file or directory
```

Will merge this update when confirmed passing.