### PR TITLE
Cleanup divide-by-zero cases in pixel-perfect

### DIFF
--- a/src/libs/ppscale/ppscale.c
+++ b/src/libs/ppscale/ppscale.c
@@ -52,23 +52,24 @@ int pp_getscale /* calculate integer scales for pixel-perfect magnification */
 	errmin = -1; /* this value marks the first iteration */
 	while( 1 )
 	{
-		// Handle unstable calculation: parrat = (double)syc / sxc / par
-		if (syc == 0) // numerator is zero, so result will be zero
+		/* Handle unstable calculation: parrat = (double)syc / sxc / par  */
+		if (syc == 0) /* numerator is zero, so result will be zero */
 			parrat = 0;
-		else if (sxc == 0) // numerator is not zero but denominator is zero, so will result in 'inf'
+		else if (sxc == 0) /* numerator is not zero but denominator is zero, so will result in 'inf' */
 			parrat = (double)INFINITY;
-		else // otherwise attempt the calculation
+		else /* otherwise attempt the calculation */
 			parrat = (double)syc / sxc / par;
 
 		/* calculate aspect-ratio error: */
 		if( parrat > 1.0 )
 			errpar = parrat;
-		else if (fabs(parrat) > DBL_EPSILON) // denominator is valid, so allow the division
+		else if (fabs(parrat) > DBL_EPSILON) /* denominator is valid, so allow the division */
 			errpar = 1.0 / parrat;
-		else // otherwise parrat is near zero so will result in 'inf'
+		else /* otherwise parrat is near zero so will result in 'inf' */
 			errpar = (double)INFINITY;
 
-		if(sym && sxm && syc == 0 && sxc == 0) // denominators are both zero so will result in 'inf'
+		/* Handle unstable calculation: srat = min( (double)sym/syc, (double)sxm/sxc ) */
+		if (sym && sxm && syc == 0 && sxc == 0) /* denominators are both zero so will result in 'inf' */
 			srat = (double)INFINITY;
 		else // otherwise one will be valid, so attempt the comparison
 			srat = min( (double)sym/syc, (double)sxm/sxc );

--- a/src/libs/ppscale/ppscale.c
+++ b/src/libs/ppscale/ppscale.c
@@ -32,7 +32,7 @@ int pp_getscale /* calculate integer scales for pixel-perfect magnification */
 	double parnorm = 0;              /* target PAR "normalised" to exceed 1.0  */
 	double srat = 0;                 /* ratio of maximum size to current       */
 
-	if /* sanity checks: */
+	if /* check for invalid inputs: */
 	(	win <= 0    || hin <= 0    ||
 		win >  wout || hin >  hout ||
 		par <= 0.0  || parweight <= 0 ||
@@ -69,9 +69,13 @@ int pp_getscale /* calculate integer scales for pixel-perfect magnification */
 			errpar = (double)INFINITY;
 
 		/* Handle unstable calculation: srat = min( (double)sym/syc, (double)sxm/sxc ) */
-		if (sym && sxm && syc == 0 && sxc == 0) /* denominators are both zero so will result in 'inf' */
-			srat = (double)INFINITY;
-		else // otherwise one will be valid, so attempt the comparison
+		if (syc == 0 && sxc == 0) /* denominators are both zero so will result in 'inf' */
+			srat = (double)INFINITY; /* numerator always positive, so negative 'inf' is not possible */
+		else if (syc == 0) /* left-hand-size 'inf', so use right-hand-side */
+			srat = (double)sxm / sxc;
+		else if (sxc == 0) /* right-hand-size 'inf', so use left-hand-side */
+			srat = (double)sym / syc;
+		else /* if none of the above, attempt the calculation */
 			srat = min( (double)sym/syc, (double)sxm/sxc );
 
 		/* calculate size error: */

--- a/src/libs/ppscale/ppscale.c
+++ b/src/libs/ppscale/ppscale.c
@@ -57,9 +57,9 @@ int pp_getscale /* calculate integer scales for pixel-perfect magnification */
 	while( 1 )
 	{
 		/* Handle unstable calculation: parrat = (double)syc / sxc / par  */
-		if (syc == 0) /* numerator is zero, so result will be zero */
+		if( syc == 0 ) /* numerator is zero, so result will be zero */
 			parrat = 0;
-		else if (sxc == 0) /* numerator is not zero but denominator is zero, so will result in 'inf' */
+		else if( sxc == 0 ) /* numerator is not zero but denominator is zero, so will result in 'inf' */
 			parrat = (double)INFINITY;
 		else /* otherwise attempt the calculation */
 			parrat = (double)syc / sxc / par;
@@ -67,17 +67,17 @@ int pp_getscale /* calculate integer scales for pixel-perfect magnification */
 		/* calculate aspect-ratio error: */
 		if( parrat > 1.0 )
 			errpar = parrat;
-		else if (fabs(parrat) > DBL_EPSILON) /* denominator is valid, so allow the division */
+		else if( fabs(parrat) > DBL_EPSILON ) /* denominator is valid, so allow the division */
 			errpar = 1.0 / parrat;
 		else /* otherwise parrat is near zero so will result in 'inf' */
 			errpar = (double)INFINITY;
 
 		/* Handle unstable calculation: srat = min( (double)sym/syc, (double)sxm/sxc ) */
-		if (syc == 0 && sxc == 0) /* denominators are both zero so will result in 'inf' */
+		if( syc == 0 && sxc == 0 ) /* denominators are both zero so will result in 'inf' */
 			srat = (double)INFINITY; /* numerator always positive, so negative 'inf' is not possible */
-		else if (syc == 0) /* left-hand-size 'inf', so use right-hand-side */
+		else if( syc == 0 ) /* left-hand-size 'inf', so use right-hand-side */
 			srat = (double)sxm / sxc;
-		else if (sxc == 0) /* right-hand-size 'inf', so use left-hand-side */
+		else if( sxc == 0 ) /* right-hand-size 'inf', so use left-hand-side */
 			srat = (double)sym / syc;
 		else /* if none of the above, attempt the calculation */
 			srat = min( (double)sym/syc, (double)sxm/sxc );
@@ -90,7 +90,7 @@ int pp_getscale /* calculate integer scales for pixel-perfect magnification */
 		err = errpar * errsize; /* total error */
 
 		/* check for a new optimum or if errmin is -1: */
-		if(err < errmin || fabs(errmin + 1) < DBL_EPSILON)
+		if( err < errmin || fabs(errmin + 1) < DBL_EPSILON )
 		{
 			*sx    = sxc;
 			*sy    = syc;


### PR DESCRIPTION
Pixel-perfect typically performs math that results in `NaN` and `Inf`. 

A prior commit attempted to address these by assigning default values and applying some protection against divide-by-zero, however even with these Coverity still caught two corner-cases where divide-by-zero can occur:

``` text
2 new defect(s) introduced to dosbox-staging found with Coverity Scan.


New defect(s) Reported-by: Coverity Scan
Showing 2 of 2 defect(s)


** CID 332470:  Incorrect expression  (DIVIDE_BY_ZERO)
/src/libs/ppscale/ppscale.c: 74 in pp_getscale()


________________________________________________________________________________________________________
*** CID 332470:  Incorrect expression  (DIVIDE_BY_ZERO)
/src/libs/ppscale/ppscale.c: 74 in pp_getscale()
68              else // otherwise parrat is near zero so will result in 'inf'
69                      errpar = (double)INFINITY;
70     
71              if(sym && sxm && syc == 0 && sxc == 0) // denominators are both zero so will result in 'inf'
72                      srat = (double)INFINITY;
73              else // otherwise one will be valid, so attempt the comparison
>>>     CID 332470:  Incorrect expression  (DIVIDE_BY_ZERO)
>>>     In expression "(double)sym / syc", division by expression "syc" which may be zero has undefined behavior.
74                      srat = min( (double)sym/syc, (double)sxm/sxc );
75     
76              /* calculate size error: */
77              /* if PAR is exact, exclude size error from the fitness function: */
78              if( exactpar ) errsize = 1.0;
79              else           errsize = pow( srat, parweight );

** CID 332469:    (DIVIDE_BY_ZERO)
/src/libs/ppscale/ppscale.c: 74 in pp_getscale()
/src/libs/ppscale/ppscale.c: 74 in pp_getscale()


________________________________________________________________________________________________________
*** CID 332469:    (DIVIDE_BY_ZERO)
/src/libs/ppscale/ppscale.c: 74 in pp_getscale()
68              else // otherwise parrat is near zero so will result in 'inf'
69                      errpar = (double)INFINITY;
70     
71              if(sym && sxm && syc == 0 && sxc == 0) // denominators are both zero so will result in 'inf'
72                      srat = (double)INFINITY;
73              else // otherwise one will be valid, so attempt the comparison
>>>     CID 332469:    (DIVIDE_BY_ZERO)
>>>     In expression "(double)sxm / sxc", division by expression "sxc" which may be zero has undefined behavior.
74                      srat = min( (double)sym/syc, (double)sxm/sxc );
75     
76              /* calculate size error: */
77              /* if PAR is exact, exclude size error from the fitness function: */
78              if( exactpar ) errsize = 1.0;
79              else           errsize = pow( srat, parweight );
/src/libs/ppscale/ppscale.c: 74 in pp_getscale()
68              else // otherwise parrat is near zero so will result in 'inf'
69                      errpar = (double)INFINITY;
70     
71              if(sym && sxm && syc == 0 && sxc == 0) // denominators are both zero so will result in 'inf'
72                      srat = (double)INFINITY;
73              else // otherwise one will be valid, so attempt the comparison
>>>     CID 332469:    (DIVIDE_BY_ZERO)
>>>     In expression "(double)sxm / sxc", division by expression "sxc" which may be zero has undefined behavior.
74                      srat = min( (double)sym/syc, (double)sxm/sxc );
75     
76              /* calculate size error: */
77              /* if PAR is exact, exclude size error from the fitness function: */
78              if( exactpar ) errsize = 1.0;
79              else           errsize = pow( srat, parweight );

```
 
This PR fixes these with more checks, and improves the order of events and adds the use of const variables.

```
    Analysis Summary:
       New defects found: 0
       Defects eliminated: 2
```
