### PR TITLE
Add yield() to spinlock

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -121,7 +121,9 @@ static inline void DelayPrecise(const int milliseconds)
     // spin lock
     const auto spin_start = GetTicksUs();
 	const int spin_remain = static_cast<int>(seconds * 1e6);
-    while (GetTicksUsSince(spin_start) <= spin_remain);
+	do {
+		std::this_thread::yield();
+	} while (GetTicksUsSince(spin_start) <= spin_remain);
 }
 
 static inline bool CanDelayPrecise()


### PR DESCRIPTION
A fair amount of time is spent in the spinlock on systems that use DelayPrecise, so add the `yield` hint for systems that can take advantage of it. Example: https://en.cppreference.com/w/cpp/thread/yield.

The `yield` was causing problems on Win32, so I had removed it initially, but after adding `CanDelayPrecise()`, which effectively bypasses Win32, we can add it back in and test.

This probably won't make much difference for manycore systems, but since spinlocking is relatively evil to begin with, the `yield` makes it more well-behaved citizen, especially on lower-core systems.

I tested the number of loop iterations in the spinlock (M1 MacBook):

```
without yield():
spinlock loop iterations: 862
spinlock loop iterations: 6233
spinlock loop iterations: 872
spinlock loop iterations: 1386
spinlock loop iterations: 3868
spinlock loop iterations: 586
spinlock loop iterations: 467
spinlock loop iterations: 5286
spinlock loop iterations: 1158
spinlock loop iterations: 4391


with yield():
spinlock loop iterations: 866
spinlock loop iterations: 881
spinlock loop iterations: 984
spinlock loop iterations: 872
spinlock loop iterations: 876
spinlock loop iterations: 798
spinlock loop iterations: 924
spinlock loop iterations: 862
spinlock loop iterations: 904
spinlock loop iterations: 803
```
