### PR TITLE
Fix missing include

### DIFF
--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -26,6 +26,7 @@
 
 #if C_NE2000
 
+#include <cstdarg>
 #include <cstdio>
 #include <cstring>
 


### PR DESCRIPTION
Fixes FTBFS only seen when using meson arguments `-Duse_pcap=true`

GCC 10.3.0
Linux x86_64