### PR TITLE
Log display properties consistently

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -816,6 +816,11 @@ finish:
 		SDL_SetWindowMinimumSize(sdl.window, w, h);
 	}
 
+	if (sdl.draw.has_changed)
+		log_display_properties(sdl.draw.width, sdl.draw.height,
+		                       sdl.draw.pixel_aspect, sdl.scaling_mode,
+		                       sdl.pp_scale, fullscreen, width, height);
+
 	sdl.update_display_contents = true;
 	return sdl.window;
 }
@@ -854,19 +859,10 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 	}
 	assert(w > 0 && h > 0);
 
-	const int previous_imgw = sdl.pp_scale.x * sdl.draw.width;
-	const int previous_imgh = sdl.pp_scale.y * sdl.draw.height;
-
 	sdl.pp_scale = calc_pp_scale(w, h);
 
 	const int imgw = sdl.pp_scale.x * sdl.draw.width;
 	const int imgh = sdl.pp_scale.y * sdl.draw.height;
-
-	if (previous_imgw != imgw || previous_imgh != imgh)
-		LOG_MSG("MAIN: Scaling source %dx%d (PAR %#.3g) by %dx%d -> %dx%d (PAR %#.3g)",
-		        sdl.draw.width, sdl.draw.height, sdl.draw.pixel_aspect,
-		        sdl.pp_scale.x, sdl.pp_scale.y, imgw, imgh,
-		        static_cast<double>(sdl.pp_scale.y) / sdl.pp_scale.x);
 
 	const int wndw = (sdl.desktop.fullscreen ? w : imgw);
 	const int wndh = (sdl.desktop.fullscreen ? h : imgh);
@@ -1054,15 +1050,6 @@ Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags,
 	sdl.draw.scaley = scaley;
 	sdl.draw.pixel_aspect = pixel_aspect;
 	sdl.draw.callback = callback;
-
-	const bool double_h = (flags & GFX_DBL_H) > 0;
-	const bool double_w = (flags & GFX_DBL_W) > 0;
-
-	if (sdl.draw.has_changed)
-		LOG_MSG("DISPLAY: Source resolution changed to %dx%d,%s%s (PAR %#.2f)",
-		        sdl.draw.width, sdl.draw.height,
-		        (double_w ? " double-width," : ""),
-		        (double_h ? " double-height," : ""), pixel_aspect);
 
 	switch (sdl.desktop.want_type) {
 dosurface:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1176,7 +1176,14 @@ dosurface:
 			case 32: retFlags = GFX_CAN_32; break;
 		}
 		retFlags |= GFX_SCALING;
-		LOG_MSG("SDL: Using driver \"%s\" for texture renderer", rinfo.name);
+
+		// Log changes to the rendering driver
+		static std::string render_driver = {};
+		if (render_driver != rinfo.name) {
+			LOG_MSG("SDL: Using driver \"%s\" for texture renderer", rinfo.name);
+			render_driver = rinfo.name;
+		}
+		
 		if (rinfo.flags & SDL_RENDERER_ACCELERATED)
 			retFlags |= GFX_HARDWARE;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -728,7 +728,7 @@ static void log_display_properties(const int in_x,
 		return "Unknown mode!";
 	};
 
-	LOG_MSG("MAIN: %s scaling source %dx%d (PAR %#.3g) by %.1fx%.1f -> %dx%d (PAR %#.3g)",
+	LOG_MSG("DISPLAY: %s scaling source %dx%d (PAR %#.3g) by %.1fx%.1f -> %dx%d (PAR %#.3g)",
 	        describe_scaling_mode(), in_x, in_y, in_par, scale_x, scale_y,
 	        out_x, out_y, out_par);
 }
@@ -1130,7 +1130,7 @@ dosurface:
 
 	case SCREEN_TEXTURE: {
 		if (!SetupWindowScaled(SCREEN_TEXTURE, false)) {
-			LOG_MSG("MAIN: Can't initialise 'texture' window");
+			LOG_MSG("DISPLAY: Can't initialise 'texture' window");
 			E_Exit("Creating window failed");
 		}
 
@@ -2015,14 +2015,14 @@ static bool detect_resizable_window()
 {
 #if C_OPENGL
 	if (sdl.desktop.want_type != SCREEN_OPENGL) {
-		LOG_MSG("MAIN: Disabled resizable window, only compatible with OpenGL output");
+		LOG_MSG("DISPLAY: Disabled resizable window, only compatible with OpenGL output");
 		return false;
 	}
 
 	const std::string sname = get_glshader_value();
 
 	if (sname != "sharp" && sname != "none" && sname != "default") {
-		LOG_MSG("MAIN: Disabled resizable window, only compatible with 'sharp' and 'none' glshaders");
+		LOG_MSG("DISPLAY: Disabled resizable window, only compatible with 'sharp' and 'none' glshaders");
 		return false;
 	}
 
@@ -2125,15 +2125,16 @@ static SDL_Point window_bounds_from_resolution(const std::string &pref,
 
 	const bool is_out_of_bounds = (w > desktop.w || h > desktop.h);
 	if (was_parsed && is_out_of_bounds)
-		LOG_MSG("MAIN: Requested windowresolution '%dx%d' is larger than the desktop '%dx%d'",
+		LOG_MSG("DISPLAY: Requested windowresolution '%dx%d' is larger than the desktop '%dx%d'",
 		        w, h, desktop.w, desktop.h);
 
 	const bool is_valid = (w > 0 && h > 0);
 	if (was_parsed && is_valid)
 		return {w, h};
 
-	LOG_MSG("MAIN: Requested windowresolution '%s' is not valid, falling back to '%dx%d' instead",
-	        pref.c_str(), FALLBACK_WINDOW_DIMENSIONS.x, FALLBACK_WINDOW_DIMENSIONS.y);
+	LOG_MSG("DISPLAY: Requested windowresolution '%s' is not valid, falling back to '%dx%d' instead",
+	        pref.c_str(), FALLBACK_WINDOW_DIMENSIONS.x,
+	        FALLBACK_WINDOW_DIMENSIONS.y);
 
 	return FALLBACK_WINDOW_DIMENSIONS;
 }
@@ -2151,7 +2152,7 @@ static SDL_Point window_bounds_from_label(const std::string &pref,
 	else if (pref == "desktop")
 		percent = 100;
 	else
-		LOG_MSG("MAIN: Requested windowresolution '%s' is invalid, using 'default' instead",
+		LOG_MSG("DISPLAY: Requested windowresolution '%s' is invalid, using 'default' instead",
 		        pref.c_str());
 
 	const int w = ceil_sdivide(desktop.w * percent, 100);
@@ -2233,7 +2234,7 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 	sdl.desktop.window.height = static_cast<uint16_t>(refined_size.y);
 
 	// Let the user know the resulting window properties
-	LOG_MSG("MAIN: Initialized %dx%d window-mode on %dx%d display-%d",
+	LOG_MSG("DISPLAY: Initialized %dx%d window-mode on %dx%d display-%d",
 	        refined_size.x, refined_size.y, desktop.w, desktop.h,
 	        sdl.display_number);
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2233,20 +2233,9 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 	sdl.desktop.window.height = static_cast<uint16_t>(refined_size.y);
 
 	// Let the user know the resulting window properties
-	if (scaling_mode == SCALING_MODE::NONE)
-		LOG_MSG("MAIN: Sized window on display-%d to %dx%d with %s pixels",
-		        sdl.display_number, refined_size.x, refined_size.y,
-		        wants_stretched_pixels ? "stretched" : "square");
-
-	else if (scaling_mode == SCALING_MODE::NEAREST)
-		LOG_MSG("MAIN: Sized window on display-%d to %dx%d with nearest-neighbour scaling and %s pixels",
-		        sdl.display_number, refined_size.x, refined_size.y,
-		        wants_stretched_pixels ? "stretched" : "square");
-
-	else if (scaling_mode == SCALING_MODE::PERFECT)
-		LOG_MSG("MAIN: Sized window on display-%d to %dx%d with pixel-perfect scaling and %s pixels",
-		        sdl.display_number, refined_size.x, refined_size.y,
-		        wants_stretched_pixels ? "stretched" : "square");
+	LOG_MSG("MAIN: Initialized %dx%d window-mode on %dx%d display-%d",
+	        refined_size.x, refined_size.y, desktop.w, desktop.h,
+	        sdl.display_number);
 }
 
 static SDL_Rect calc_viewport_fit(int win_width, int win_height)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -267,6 +267,7 @@ struct SDL_Block {
 		int height = 0;
 		double scalex = 1.0;
 		double scaley = 1.0;
+		bool has_changed = false;
 		double pixel_aspect = 1.0;
 		GFX_CallBack_t callback = nullptr;
 	} draw = {};
@@ -985,11 +986,11 @@ Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags,
 	if (sdl.updating)
 		GFX_EndUpdate( 0 );
 
-	const bool is_changed = (sdl.draw.width != static_cast<int>(width) ||
-	                         sdl.draw.height != static_cast<int>(height) ||
-	                         sdl.draw.scalex != scalex ||
-	                         sdl.draw.scaley != scaley ||
-	                         sdl.draw.pixel_aspect != pixel_aspect);
+	sdl.draw.has_changed = (sdl.draw.width != static_cast<int>(width) ||
+	                        sdl.draw.height != static_cast<int>(height) ||
+	                        sdl.draw.scalex != scalex ||
+	                        sdl.draw.scaley != scaley ||
+	                        sdl.draw.pixel_aspect != pixel_aspect);
 
 	sdl.draw.width = static_cast<int>(width);
 	sdl.draw.height = static_cast<int>(height);
@@ -1001,7 +1002,7 @@ Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags,
 	const bool double_h = (flags & GFX_DBL_H) > 0;
 	const bool double_w = (flags & GFX_DBL_W) > 0;
 
-	if (is_changed)
+	if (sdl.draw.has_changed)
 		LOG_MSG("DISPLAY: Source resolution changed to %dx%d,%s%s (PAR %#.2f)",
 		        sdl.draw.width, sdl.draw.height,
 		        (double_w ? " double-width," : ""),


### PR DESCRIPTION
The PR cleans up repetition and inconsistencies when logging display resolution details.

Previously:
 - we were only shown scaling details when using pixel perfect
 - log messages were repeated with the same resolution details

This PR:
 - shows scaling details for every scaling mode (not just pixel-perfect)
 - uses a consistent format from one function
 - only shows changes, avoiding repetitive log pollution

Suggest reviewing commit-by-commit.

This PR is a continuation of `kc/dont-adjust-WxH-1` branch, so should be merged after it.

Example output:

### Bilinear scaling
``` text
--
DISPLAY: Initialized 2016x1512 window-mode on 3840x2160 display-0
...
DISPLAY: Bilinear scaling source 640x400 (PAR 1.20) by 3.1x3.8 -> 2016x1512 (PAR 1.20)
...
DISPLAY: Bilinear scaling source 320x200 (PAR 1.20) by 6.3x7.6 -> 2016x1512 (PAR 1.20)
```

### Nearest-neighbour scaling
``` text
DISPLAY: Initialized 1280x960 window-mode on 3840x2160 display-0
...
DISPLAY: Nearest-neighbour scaling source 640x400 (PAR 1.20) by 2.0x2.4 -> 1280x960 (PAR 1.20)
...
DISPLAY: Nearest-neighbour scaling source 320x200 (PAR 1.20) by 4.0x4.8 -> 1280x960 (PAR 1.20)
```

### Pixel-perfect scaling
``` text
DISPLAY: Initialized 1920x1400 window-mode on 3840x2160 display-0
...
DISPLAY: Pixel-perfect scaling source 640x200 (PAR 2.40) by 3.0x7.0 -> 1920x1400 (PAR 2.33)
...
DISPLAY: Pixel-perfect scaling source 320x200 (PAR 1.20) by 6.0x7.0 -> 1920x1400 (PAR 1.17)
```

