### PR TITLE
Remove vcpkg FluidSynth SF2 files incompatible with GitHub cache

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         id:   cache-vcpkg
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
 
       - name:  Install new packages using vcpkg
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
@@ -44,6 +44,7 @@ jobs:
           mv c:\vcpkg-bak c:\vcpkg
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
+          rm -R c:\vcpkg\buildtrees\fluidsynth\src\*.clean\sf2
 
       - name:  Integrate packages
         shell: pwsh
@@ -112,7 +113,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
 
       - name:  Integrate packages
         shell: pwsh


### PR DESCRIPTION
Vcpkg recently changed the FluidSynth package to include some SF2 files that are named so poorly that tar fails to properly write them during GitHub's cache restore process.

``` text
2021-07-17T15:56:52.7149556Z [command]C:\Windows\System32\tar.exe -z -xf D:/a/_temp/65b53710-b43f-4f41-abe8-c16174c70a30/cache.tgz -P -C D:/a/dosbox-staging/dosbox-staging
2021-07-17T15:59:10.0248287Z c:/vcpkg/buildtrees/fluidsynth/src/d2fbc413bc-822d7b6699.clean/sf2/G��VintageDreamsWaves-v2G��.sf2: Can't create '\\\\?\\c:\\vcpkg\\buildtrees\\fluidsynth\\src\\d2fbc413bc-822d7b6699.clean\\sf2\\G��VintageDreamsWaves-v2G��.sf2'
2021-07-17T15:59:12.5727181Z tar.exe: Error exit delayed from previous errors.
2021-07-17T15:59:12.6384690Z [warning]Tar failed with error: The process 'C:\Windows\System32\tar.exe' failed with exit code 1
```

This in turn causes every Windows CI workflow to not use the cache and instead install vcpkg packages from scratch, which adds roughly 30 minutes to our CI pipeline. 

This PR prunes those problematic (and unnecessary) SF2 files prior to the cache-creation step. 