### PR TITLE
Fix BatchFile memory leak

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -23,6 +23,7 @@
 
 #include <cctype>
 #include <list>
+#include <memory>
 #include <string>
 
 #ifndef DOSBOX_PROGRAMS_H
@@ -53,7 +54,7 @@ public:
 	uint32_t location = 0;
 	bool echo = false;
 	DOS_Shell *shell = nullptr;
-	BatchFile *prev = nullptr;
+	std::shared_ptr<BatchFile> prev = {}; // shared with Shell.bf
 	CommandLine *cmd = nullptr;
 	std::string filename{};
 };
@@ -125,7 +126,7 @@ public:
 	void CMD_LS(char *args);
 	/* The shell's variables */
 	uint16_t input_handle = 0;
-	BatchFile *bf = nullptr;
+	std::shared_ptr<BatchFile> bf = {}; // shared with BatchFile.prev
 	bool echo = false;
 	bool call = false;
 };

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -380,6 +380,8 @@ void DOS_Shell::Run()
 					}
 				}
 				ParseLine(input_line);
+			} else {
+				bf.reset();
 			}
 		} else {
 			if (echo) ShowPrompt();

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -62,8 +62,9 @@ BatchFile::BatchFile(DOS_Shell *host,
 
 BatchFile::~BatchFile() {
 	delete cmd;
-	shell->bf=prev;
-	shell->echo=echo;
+	assert(shell);
+	shell->bf = prev;
+	shell->echo = echo;
 }
 
 // TODO: Refactor this sprawling function into smaller ones without GOTOs
@@ -71,8 +72,7 @@ bool BatchFile::ReadLine(char * line) {
 	//Open the batchfile and seek to stored postion
 	if (!DOS_OpenFile(filename.c_str(),(DOS_NOT_INHERIT|OPEN_READ),&file_handle)) {
 		LOG(LOG_MISC,LOG_ERROR)("ReadLine Can't open BatchFile %s",filename.c_str());
-		delete this;
-		return false;
+		return false; // Parent deletes this BatchFile on negative return
 	}
 	DOS_SeekFile(file_handle,&(this->location),DOS_SEEK_SET);
 
@@ -113,10 +113,9 @@ emptyline:
 	} while (val != LINE_FEED && bytes_read);
 	*cmd_write=0;
 	if (!bytes_read && cmd_write == temp) {
-		//Close file and delete bat file
+		// Close the file and delete this BatchFile on return
 		DOS_CloseFile(file_handle);
-		delete this;
-		return false;
+		return false; // Parent deletes this BatchFile on negative return
 	}
 	if (!strlen(temp)) goto emptyline;
 	if (temp[0]==':') goto emptyline;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -33,8 +33,7 @@
 unsigned int result_errorcode = 0;
 
 DOS_Shell::~DOS_Shell() {
-	delete bf;
-	bf = nullptr;
+	bf.reset();
 }
 
 void DOS_Shell::ShowPrompt(void) {
@@ -495,9 +494,10 @@ bool DOS_Shell::Execute(char * name,char * args) {
 	{	/* Run the .bat file */
 		/* delete old batch file if call is not active*/
 		bool temp_echo=echo; /*keep the current echostate (as delete bf might change it )*/
-		if(bf && !call) delete bf;
-		bf=new BatchFile(this,fullname,name,line);
-		echo=temp_echo; //restore it.
+		if (bf && !call)
+			bf.reset();
+		bf = std::make_shared<BatchFile>(this, fullname, name, line);
+		echo = temp_echo; // restore it.
 	} 
 	else 
 	{	/* only .bat .exe .com extensions maybe be executed by the shell */


### PR DESCRIPTION
Fixes #1154.

### Test Procedures

1. Build with ASAN and UBSAN instrumentation (GCC or Clang):

    ``` text
    meson setup \
        -Dbuildtype=debugoptimized \
        -Db_sanitize=address,undefined \
        -Db_lundef=false \
        -Dc_args=-fsanitize-recover=all \
        -Dcpp_args=-fsanitize-recover=all \
        -Ddefault_library=static \
        -Dfluidsynth:enable-floats=true \
        -Dfluidsynth:try-static-deps=true \
        build/aubsan
    
    meson compile -C build/aubsan
    ```

1. Launch a game using a batch file.

1. While in-game, press Ctrl+F9 to exit DOSBox.

1. What to expect:
   - **main branch**: You should see the leak report, as seen in #1154.
   - **PR branch**: batch file(s) should behave as expected and exit cleanly.

Leaks will be reported for each nested call. For example, `a.bat` calls `b.bat` calls `c.bat` calls ... :

**a.bat:**
``` shell
@echo off
echo in A
call b.bat
echo done A
```

**b.bat:**
``` shell
@echo off
echo in B
call c.bat
echo done B
```

**c.bat:**
``` shell
@echo off
echo in C
# .. do something and Ctrl+F9 ..
echo done C
```
