### PR TITLE
Add reenigne's improved CGA composite patch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,7 +65,7 @@ jobs:
           - name: GCC, warning_level=3
             os: ubuntu-20.04
             build_flags: -Dwarning_level=3
-            max_warnings: 64
+            max_warnings: 62
 
           - name: GCC, minimum build
             os: ubuntu-20.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 179
+            max_warnings: 177
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 351
+          MAX_BUGS: 327
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 272
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1960
+            max_warnings: 1959
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/vga.h
+++ b/include/vga.h
@@ -28,18 +28,28 @@
 
 class PageHandler;
 
-
 enum VGAModes {
-	M_CGA2, M_CGA4,
-	M_EGA, M_VGA,
-	M_LIN4, M_LIN8, M_LIN15, M_LIN16, M_LIN32,
+	M_CGA2,
+	M_CGA4,
+	M_EGA,
+	M_VGA,
+	M_LIN4,
+	M_LIN8,
+	M_LIN15,
+	M_LIN16,
+	M_LIN32,
 	M_TEXT,
-	M_HERC_GFX, M_HERC_TEXT,
-	M_CGA16, M_TANDY2, M_TANDY4, M_TANDY16, M_TANDY_TEXT,
-	M_CGA2_COMPOSITE, M_CGA4_COMPOSITE, M_CGA_TEXT_COMPOSITE,
+	M_HERC_GFX,
+	M_HERC_TEXT,
+	M_TANDY2,
+	M_TANDY4,
+	M_TANDY16,
+	M_TANDY_TEXT,
+	M_CGA2_COMPOSITE,
+	M_CGA4_COMPOSITE,
+	M_CGA_TEXT_COMPOSITE,
 	M_ERROR
 };
-
 
 #define CLK_25 25175
 #define CLK_28 28322
@@ -408,7 +418,6 @@ typedef struct {
 	int ri, rq, gi, gq, bi, bq;
 	int sharpness;
 } VGA_Type;
-
 
 /* Hercules Palette function */
 void Herc_Palette(void);

--- a/include/vga.h
+++ b/include/vga.h
@@ -36,6 +36,7 @@ enum VGAModes {
 	M_TEXT,
 	M_HERC_GFX, M_HERC_TEXT,
 	M_CGA16, M_TANDY2, M_TANDY4, M_TANDY16, M_TANDY_TEXT,
+	M_CGA2_COMPOSITE, M_CGA4_COMPOSITE, M_CGA_TEXT_COMPOSITE,
 	M_ERROR
 };
 
@@ -404,6 +405,8 @@ typedef struct {
 	VGA_Changes changes;
 #endif
 	VGA_LFB lfb;
+	int ri, rq, gi, gq, bi, bq;
+	int sharpness;
 } VGA_Type;
 
 
@@ -523,7 +526,7 @@ extern Bit32u FillTable[16];
 extern Bit32u CGA_2_Table[16];
 extern Bit32u CGA_4_Table[256];
 extern Bit32u CGA_4_HiRes_Table[256];
-extern Bit32u CGA_16_Table[256];
+extern int CGA_Composite_Table[1024];
 extern Bit32u TXT_Font_Table[16];
 extern Bit32u TXT_FG_Table[16];
 extern Bit32u TXT_BG_Table[16];

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -31,7 +31,7 @@ SVGA_Driver svga;
 Bit32u CGA_2_Table[16];
 Bit32u CGA_4_Table[256];
 Bit32u CGA_4_HiRes_Table[256];
-Bit32u CGA_16_Table[256];
+int CGA_Composite_Table[1024];
 Bit32u TXT_Font_Table[16];
 Bit32u TXT_FG_Table[16];
 Bit32u TXT_BG_Table[16];

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -16,15 +16,17 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <string.h>
-#include <math.h>
 #include "dosbox.h"
-#include "video.h"
+
+#include <cstring>
+#include <cmath>
+
+#include "pic.h"
 #include "render.h"
 #include "../gui/render_scalers.h"
+#include "support.h"
 #include "vga.h"
-#include "pic.h"
+#include "video.h"
 
 //#undef C_DEBUG
 //#define C_DEBUG 1
@@ -138,8 +140,8 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 		int *ap = atemp + 1;
 		int *bp = btemp + 1;
 		for (int x = -1; x < w + 1; ++x) {
-			ap[x] = i[-4] - ((i[-2] - i[0] + i[2]) << 1) + i[4];
-			bp[x] = (i[-3] - i[-1] + i[1] - i[3]) << 1;
+			ap[x] = i[-4] - left_shift_signed(i[-2] - i[0] + i[2], 1) + i[4];
+			bp[x] = left_shift_signed(i[-3] - i[-1] + i[1] - i[3], 1);
 			++i;
 		}
 
@@ -153,7 +155,7 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 			i[1] = (i[1] << 3) - ap[1];
 			const int c = i[0] + i[0];
 			const int d = i[-1] + i[1];
-			const int y = ((c + d) << 8) + vga.sharpness * (c - d);
+			const int y = left_shift_signed(c + d, 8) + vga.sharpness * (c - d);
 			const int rr = y + vga.ri * (I) + vga.rq * (Q);
 			const int gg = y + vga.gi * (I) + vga.gq * (Q);
 			const int bb = y + vga.bi * (I) + vga.bq * (Q);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -73,22 +73,23 @@ static Bit8u * VGA_Draw_2BPPHiRes_Line(Bitu vidstart, Bitu line) {
 	return TempLine;
 }
 
-static Bit8u byte_clamp(int v) {
+static Bit8u byte_clamp(int v)
+{
 	v >>= 13;
 	return v < 0 ? 0 : (v > 255 ? 255 : v);
 }
 
-static int temp[SCALER_MAXWIDTH + 10]={0};
-static int atemp[SCALER_MAXWIDTH + 2]={0};
-static int btemp[SCALER_MAXWIDTH + 2]={0};
+static int temp[SCALER_MAXWIDTH + 10] = {0};
+static int atemp[SCALER_MAXWIDTH + 2] = {0};
+static int btemp[SCALER_MAXWIDTH + 2] = {0};
 
-static Bit8u * Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
+static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 {
-	int w = blocks*4;
+	int w = blocks * 4;
 
 	if (doublewidth) {
-		Bit8u * source = TempLine + w - 1;
-		Bit8u * dest = TempLine + w*2 - 2;
+		Bit8u *source = TempLine + w - 1;
+		Bit8u *dest = TempLine + w * 2 - 2;
 		for (int x = 0; x < w; ++x) {
 			*dest = *source;
 			*(dest + 1) = *source;
@@ -123,37 +124,36 @@ static Bit8u * Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 	Bit8u* rgbi = TempLine;
 	int* b = &CGA_Composite_Table[border*68];
 	for (int x = 0; x < 4; ++x)
-		OUT(b[(x+3)&3]);
-	OUT(CGA_Composite_Table[(border<<6) | ((*rgbi)<<2) | 3]);
-	for (int x = 0; x < w-1; ++x) {
-		OUT(CGA_Composite_Table[(rgbi[0]<<6) | (rgbi[1]<<2) | (x&3)]);
+		OUT(b[(x + 3) & 3]);
+	OUT(CGA_Composite_Table[(border << 6) | ((*rgbi) << 2) | 3]);
+	for (int x = 0; x < w - 1; ++x) {
+		OUT(CGA_Composite_Table[(rgbi[0] << 6) | (rgbi[1] << 2) | (x & 3)]);
 		++rgbi;
 	}
-	OUT(CGA_Composite_Table[((*rgbi)<<6) | (border<<2) | 3]);
+	OUT(CGA_Composite_Table[((*rgbi) << 6) | (border << 2) | 3]);
 	for (int x = 0; x < 5; ++x)
-		OUT(b[x&3]);
+		OUT(b[x & 3]);
 
 	if ((vga.tandy.mode_control & 4) != 0) {
 		// Decode
-		int* i = temp + 5;
-		Bit32u* srgb = (Bit32u *)TempLine;
-		for (Bit32u x = 0; x < blocks*4; ++x) {
-			int c = (i[0]+i[0])<<3;
-			int d = (i[-1]+i[1])<<3;
-			int y = ((c+d)<<8) + vga.sharpness*(c-d);
+		int *i = temp + 5;
+		Bit32u *srgb = (Bit32u *)TempLine;
+		for (Bit32u x = 0; x < blocks * 4; ++x) {
+			int c = (i[0] + i[0]) << 3;
+			int d = (i[-1] + i[1]) << 3;
+			int y = ((c + d) << 8) + vga.sharpness * (c - d);
 			++i;
-			*srgb = byte_clamp(y)*0x10101;
+			*srgb = byte_clamp(y) * 0x10101;
 			++srgb;
 		}
-	}
-	else {
+	} else {
 		// Store chroma
-		int* i = temp + 4;
-		int* ap = atemp + 1;
-		int* bp = btemp + 1;
+		int *i = temp + 4;
+		int *ap = atemp + 1;
+		int *bp = btemp + 1;
 		for (int x = -1; x < w + 1; ++x) {
-			ap[x] = i[-4]-((i[-2]-i[0]+i[2])<<1)+i[4];
-			bp[x] = (i[-3]-i[-1]+i[1]-i[3])<<1;
+			ap[x] = i[-4] - ((i[-2] - i[0] + i[2]) << 1) + i[4];
+			bp[x] = (i[-3] - i[-1] + i[1] - i[3]) << 1;
 			++i;
 		}
 
@@ -175,19 +175,23 @@ static Bit8u * Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 	return TempLine;
 }
 
-static Bit8u * VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line);
+static Bit8u *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line);
 
-static Bit8u * VGA_CGA_TEXT_Composite_Draw_Line(Bitu vidstart, Bitu line) {
+static Bit8u *VGA_CGA_TEXT_Composite_Draw_Line(Bitu vidstart, Bitu line)
+{
 	VGA_TEXT_Draw_Line(vidstart, line);
-	return Composite_Process(vga.tandy.color_select & 0x0f, vga.draw.blocks*2, (vga.tandy.mode_control & 0x1)==0);
+	return Composite_Process(vga.tandy.color_select & 0x0f, vga.draw.blocks * 2,
+	                         (vga.tandy.mode_control & 0x1) == 0);
 }
 
-static Bit8u * VGA_Draw_CGA2_Composite_Line(Bitu vidstart, Bitu line) {
+static Bit8u *VGA_Draw_CGA2_Composite_Line(Bitu vidstart, Bitu line)
+{
 	VGA_Draw_1BPP_Line(vidstart, line);
-	return Composite_Process(0, vga.draw.blocks*2, false);
+	return Composite_Process(0, vga.draw.blocks * 2, false);
 }
 
-static Bit8u * VGA_Draw_CGA4_Composite_Line(Bitu vidstart, Bitu line) {
+static Bit8u *VGA_Draw_CGA4_Composite_Line(Bitu vidstart, Bitu line)
+{
 	VGA_Draw_2BPP_Line(vidstart, line);
 	return Composite_Process(vga.tandy.color_select & 0x0f, vga.draw.blocks, true);
 }
@@ -1008,13 +1012,13 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
 			|| !vga.draw.blinking) ? true:false;
 		break;
 	case M_HERC_GFX:
-	case M_CGA4:case M_CGA2:
-		vga.draw.address=(vga.draw.address*2)&0x1fff;
-		break;
-	case M_CGA2_COMPOSITE:case M_CGA4_COMPOSITE:
-	case M_TANDY2:case M_TANDY4:case M_TANDY16:
-		vga.draw.address *= 2;
-		break;
+	case M_CGA2:
+	case M_CGA4: vga.draw.address = (vga.draw.address * 2) & 0x1fff; break;
+	case M_CGA2_COMPOSITE:
+	case M_CGA4_COMPOSITE:
+	case M_TANDY2:
+	case M_TANDY4:
+	case M_TANDY16: vga.draw.address *= 2; break;
 	default:
 		break;
 	}
@@ -1076,17 +1080,11 @@ void VGA_CheckScanLength(void) {
 		vga.draw.address_add=vga.config.scan_len*4;
 		break;
 	case M_CGA2:
-	case M_CGA4:
-		vga.draw.address_add=80;
-		return;
+	case M_CGA4: vga.draw.address_add = 80; break;
 	case M_TANDY2:
-	case M_CGA2_COMPOSITE:
-		vga.draw.address_add=vga.draw.blocks;
-		break;
+	case M_CGA2_COMPOSITE: vga.draw.address_add = vga.draw.blocks; break;
 	case M_TANDY4:
-	case M_CGA4_COMPOSITE:
-		vga.draw.address_add=vga.draw.blocks;
-		break;
+	case M_CGA4_COMPOSITE: vga.draw.address_add = vga.draw.blocks; break;
 	case M_TANDY16:
 		vga.draw.address_add=vga.draw.blocks;
 		break;
@@ -1443,9 +1441,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 	case M_LIN32:
 	case M_CGA2_COMPOSITE:
 	case M_CGA4_COMPOSITE:
-	case M_CGA_TEXT_COMPOSITE:
-		bpp = 32;
-		break;
+	case M_CGA_TEXT_COMPOSITE: bpp = 32; break;
 	default:
 		bpp = 8;
 		break;
@@ -1520,14 +1516,14 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		doubleheight=true;
 		vga.draw.blocks=width*2;
 		width<<=4;
-		VGA_DrawLine=VGA_Draw_CGA2_Composite_Line;
+		VGA_DrawLine = VGA_Draw_CGA2_Composite_Line;
 		break;
 	case M_CGA4_COMPOSITE:
-		aspect_ratio=1.2;
-		doubleheight=true;
-		vga.draw.blocks=width*2;
-		width<<=4;
-		VGA_DrawLine=VGA_Draw_CGA4_Composite_Line;
+		aspect_ratio = 1.2;
+		doubleheight = true;
+		vga.draw.blocks = width * 2;
+		width <<= 4;
+		VGA_DrawLine = VGA_Draw_CGA4_Composite_Line;
 		break;
 	case M_CGA4:
 		doublewidth=true;
@@ -1574,9 +1570,9 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		doubleheight=true;
 		if (machine==MCH_PCJR) doublewidth=(vga.tandy.gfx_control & 0x8)==0x00;
 		else doublewidth=(vga.tandy.mode_control & 0x10)==0;
-		vga.draw.blocks=width * (doublewidth ? 1:2);
-		width=vga.draw.blocks*8;
-		VGA_DrawLine=VGA_Draw_1BPP_Line;
+		vga.draw.blocks = width * (doublewidth ? 1 : 2);
+		width = vga.draw.blocks * 8;
+		VGA_DrawLine = VGA_Draw_1BPP_Line;
 		break;
 	case M_TANDY4:
 		aspect_ratio=1.2;
@@ -1619,11 +1615,11 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		VGA_DrawLine=VGA_TEXT_Draw_Line;
 		break;
 	case M_CGA_TEXT_COMPOSITE:
-		aspect_ratio=1.2;
-		doubleheight=true;
-		vga.draw.blocks=width;
-		width<<=(((vga.tandy.mode_control & 0x1)!=0) ? 3 : 4);
-		VGA_DrawLine=VGA_CGA_TEXT_Composite_Draw_Line;
+		aspect_ratio = 1.2;
+		doubleheight = true;
+		vga.draw.blocks = width;
+		width <<= (((vga.tandy.mode_control & 0x1) != 0) ? 3 : 4);
+		VGA_DrawLine = VGA_CGA_TEXT_Composite_Draw_Line;
 		break;
 	case M_HERC_TEXT:
 		aspect_ratio=((double)480)/((double)350);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1317,9 +1317,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 	LOG(LOG_VGA,LOG_NORMAL)("v total %d end %d blank (%d/%d) retrace (%d/%d)",
 		vtotal, vdend, vbstart, vbend, vrstart, vrend );
 #endif
-	if (!htotal) return;
-	if (!vtotal) return;
-	
+
 	// The screen refresh frequency
 	fps=(double)clock/(vtotal*htotal);
 	// Horizontal total (that's how long a line takes with whistles and bells)

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <cmath>
 
+#include "mem_unaligned.h"
 #include "pic.h"
 #include "render.h"
 #include "../gui/render_scalers.h"
@@ -37,15 +38,16 @@
 typedef Bit8u * (* VGA_Line_Handler)(Bitu vidstart, Bitu line);
 
 static VGA_Line_Handler VGA_DrawLine;
-static Bit8u TempLine[SCALER_MAXWIDTH * 4];
+static uint8_t TempLine[SCALER_MAXWIDTH * 4];
 
 static Bit8u * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {
 	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
-	Bit32u *draw = (Bit32u *)TempLine;
+
+	uint16_t i = 0;
 	for (Bitu x=vga.draw.blocks;x>0;x--, vidstart++) {
 		Bitu val = base[(vidstart & (8 * 1024 -1))];
-		*draw++=CGA_2_Table[val >> 4];
-		*draw++=CGA_2_Table[val & 0xf];
+		write_unaligned_uint32_at(TempLine, i++, CGA_2_Table[val >> 4]);
+		write_unaligned_uint32_at(TempLine, i++, CGA_2_Table[val & 0xf]);
 	}
 	return TempLine;
 }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -783,11 +783,10 @@ static void VGA_DrawSingleLine(Bitu /*blah*/) {
 		}
 		if (vga.draw.bpp==8) {
 			memset(TempLine, bg_color_index, sizeof(TempLine));
-		} else if (vga.draw.bpp==16) {
-			Bit16u* wptr = (Bit16u*) TempLine;
+		} else if (vga.draw.bpp == 16) {
 			Bit16u value = vga.dac.xlat16[bg_color_index];
 			for (Bitu i = 0; i < sizeof(TempLine)/2; i++) {
-				wptr[i] = value;
+				write_unaligned_uint16_at(TempLine, i, value);
 			}
 		}
 		RENDER_DrawLine(TempLine);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1115,8 +1115,6 @@ void VGA_CheckScanLength(void) {
 		break;
 	case M_TANDY_TEXT:
 	case M_CGA_TEXT_COMPOSITE:
-		vga.draw.address_add=vga.draw.blocks*2;
-		break;
 	case M_HERC_TEXT:
 		vga.draw.address_add=vga.draw.blocks*2;
 		break;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1517,7 +1517,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		width<<=3;
 		VGA_DrawLine=VGA_Draw_Linear_Line;
 		vga.draw.linear_base = vga.fastmem;
-		vga.draw.linear_mask = (vga.vmemwrap<<1) - 1;
+		vga.draw.linear_mask = (static_cast<uint64_t>(vga.vmemwrap) << 1) - 1;
 		break;
 	case M_EGA:
 		doublewidth=(vga.seq.clocking_mode & 0x8) > 0;
@@ -1530,7 +1530,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		} else VGA_DrawLine=VGA_Draw_Linear_Line;
 
 		vga.draw.linear_base = vga.fastmem;
-		vga.draw.linear_mask = (vga.vmemwrap<<1) - 1;
+		vga.draw.linear_mask = (static_cast<uint64_t>(vga.vmemwrap) << 1) - 1;
 		break;
 	case M_CGA2_COMPOSITE:
 		aspect_ratio=1.2;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1655,7 +1655,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 	VGA_CheckScanLength();
 	if (vga.draw.double_scan) {
 		if (IS_VGA_ARCH) { 
-			vga.draw.vblank_skip /= 2;
+			vblank_skip /= 2;
 			height/=2;
 		}
 		doubleheight=true;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -297,7 +297,6 @@ static Bit8u * VGA_Draw_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 static Bit8u * VGA_Draw_Xlat16_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 	Bitu offset = vidstart & vga.draw.linear_mask;
 	Bit8u *ret = &vga.draw.linear_base[offset];
-	Bit16u* temps = (Bit16u*) TempLine;
 
 	// see VGA_Draw_Linear_Line
 	if (GCC_UNLIKELY((vga.draw.line_length + offset)& ~vga.draw.linear_mask)) {
@@ -309,15 +308,18 @@ static Bit8u * VGA_Draw_Xlat16_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 		
 		// unwrapped chunk: to top of memory block
 		for(Bitu i = 0; i < unwrapped_len; i++)
-			temps[i]=vga.dac.xlat16[ret[i]];
-		
+			write_unaligned_uint16_at(TempLine, i,
+			                          vga.dac.xlat16[ret[i]]);
+
 		// wrapped chunk: from base of memory block
 		for(Bitu i = 0; i < wrapped_len; i++)
-			temps[i + unwrapped_len]=vga.dac.xlat16[vga.draw.linear_base[i]];
+			write_unaligned_uint16_at(TempLine, i + unwrapped_len,
+			                          vga.dac.xlat16[vga.draw.linear_base[i]]);
 
 	} else {
 		for(Bitu i = 0; i < vga.draw.line_length; i++) {
-			temps[i]=vga.dac.xlat16[ret[i]];
+			write_unaligned_uint16_at(TempLine, i,
+			                          vga.dac.xlat16[ret[i]]);
 		}
 	}
 	return TempLine;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -500,7 +500,7 @@ static bool SkipCursor(Bitu vidstart, Bitu line)
 static Bit32u FontMask[2]={0xffffffff,0x0};
 static uint8_t *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line)
 {
-	Bit32u * draw=(Bit32u *)TempLine;
+	uint16_t i = 0;
 	const Bit8u* vidmem = VGA_Text_Memwrap(vidstart);
 	for (Bitu cx=0;cx<vga.draw.blocks;cx++) {
 		Bitu chr=vidmem[cx*2];
@@ -510,14 +510,14 @@ static uint8_t *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line)
 		Bit32u mask2=TXT_Font_Table[font&0xf] & FontMask[col >> 7];
 		Bit32u fg=TXT_FG_Table[col&0xf];
 		Bit32u bg=TXT_BG_Table[col>>4];
-		*draw++=(fg&mask1) | (bg&~mask1);
-		*draw++=(fg&mask2) | (bg&~mask2);
+		write_unaligned_uint32_at(TempLine, i++, (fg & mask1) | (bg & ~mask1));
+		write_unaligned_uint32_at(TempLine, i++, (fg & mask2) | (bg & ~mask2));
 	}
 	if (SkipCursor(vidstart, line))
 		return TempLine;
 	const Bitu font_addr = (vga.draw.cursor.address - vidstart) >> 1;
 	if (font_addr < vga.draw.blocks) {
-		draw=(Bit32u *)&TempLine[font_addr*8];
+		Bit32u *draw = (Bit32u *)&TempLine[font_addr * 8];
 		Bit32u att=TXT_FG_Table[vga.tandy.draw_base[vga.draw.cursor.address+1]&0xf];
 		*draw++=att;*draw++=att;
 	}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -54,11 +54,12 @@ static Bit8u * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {
 
 static Bit8u * VGA_Draw_2BPP_Line(Bitu vidstart, Bitu line) {
 	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
-	Bit32u * draw=(Bit32u *)TempLine;
-	for (Bitu x=0;x<vga.draw.blocks;x++) {
+
+	uint16_t i = 0;
+	for (Bitu x = 0; x < vga.draw.blocks; x++) {
 		Bitu val = base[vidstart & vga.tandy.addr_mask];
 		vidstart++;
-		*draw++=CGA_4_Table[val];
+		write_unaligned_uint32_at(TempLine, i++, CGA_4_Table[val]);
 	}
 	return TempLine;
 }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -66,14 +66,17 @@ static Bit8u * VGA_Draw_2BPP_Line(Bitu vidstart, Bitu line) {
 
 static Bit8u * VGA_Draw_2BPPHiRes_Line(Bitu vidstart, Bitu line) {
 	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
-	Bit32u * draw=(Bit32u *)TempLine;
-	for (Bitu x=0;x<vga.draw.blocks;x++) {
+
+	uint16_t i = 0;
+	for (Bitu x = 0; x < vga.draw.blocks; x++) {
 		Bitu val1 = base[vidstart & vga.tandy.addr_mask];
 		++vidstart;
 		Bitu val2 = base[vidstart & vga.tandy.addr_mask];
 		++vidstart;
-		*draw++=CGA_4_HiRes_Table[(val1>>4)|(val2&0xf0)];
-		*draw++=CGA_4_HiRes_Table[(val1&0x0f)|((val2&0x0f)<<4)];
+		write_unaligned_uint32_at(TempLine, i++,
+		                          CGA_4_HiRes_Table[(val1 >> 4) | (val2 & 0xf0)]);
+		write_unaligned_uint32_at( TempLine, i++,
+		                          CGA_4_HiRes_Table[(val1 & 0x0f) | ((val2 & 0x0f) << 4)]);
 	}
 	return TempLine;
 }

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -618,13 +618,10 @@ static void Composite(bool pressed) {
 	if (++cga_comp>2) cga_comp=0;
 	LOG_MSG("Composite output: %s",(cga_comp==0)?"auto":((cga_comp==1)?"on":"off"));
 	// switch RGB and Composite if in graphics mode
-	if (vga.tandy.mode_control & 0x2) {
-		if (machine == MCH_PCJR) {
-			PCJr_FindMode();
-		} else {
-			write_cga(0x3d8, vga.tandy.mode_control, 1);
-		}
-	}
+	if (vga.tandy.mode_control & 0x2 && machine == MCH_PCJR)
+		PCJr_FindMode();
+	else
+		write_cga(0x3d8, vga.tandy.mode_control, 1);
 }
 
 static void tandy_update_palette() {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -713,13 +713,14 @@ static void PCJr_FindMode()
 			/* bit3 of mode control 2 signals 2 colour graphics mode */
 			if (cga_comp == 1 ||
 			    (cga_comp == 0 && !(vga.tandy.mode_control & 0x4))) {
-				VGA_SetMode(M_CGA16);
+				VGA_SetMode(M_CGA2_COMPOSITE);
 			} else {
 				VGA_SetMode(M_TANDY2);
 			}
 		} else {
 			/* otherwise some 4-colour graphics mode */
-			const auto new_mode = (cga_comp == 1) ? M_CGA16 : M_TANDY4;
+			const auto new_mode = (cga_comp == 1) ? M_CGA4_COMPOSITE
+			                                      : M_TANDY4;
 			if (vga.mode == M_TANDY16) {
 				VGA_SetModeNow(new_mode);
 			} else {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -240,11 +240,6 @@ static Bit8u mono_cga_palettes[8][16][3] =
 	},
 };
 
-static Bit8u byte_clamp(int v)
-{
-	return v < 0 ? 0 : (v > 255 ? 255 : v);
-}
-
 static void update_cga16_color(void) {
 	// New algorithm by reenigne
 	// Works in all CGA modes/color settings and can simulate older and

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -199,12 +199,12 @@ static void write_lightpen(Bitu port, uint8_t /*val*/, Bitu)
 	}
 }
 
-static double brightness = 0;
-static double contrast = 100;
-static double saturation = 100;
-static double sharpness = 0;
-static double hue_offset = 0;
-static Bit8u cga_comp = 0;
+static int16_t brightness = 0;
+static int16_t contrast = 100;
+static int16_t saturation = 100;
+static int16_t sharpness = 0;
+static int16_t hue_offset = 0;
+static uint8_t cga_comp = 0;
 static bool new_cga = 0;
 
 static Bit8u herc_pal = 0;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -491,26 +491,22 @@ static void CycleWhichControl(bool pressed)
 		return;
 	which_control = (which_control + 1) % 6;
 	LogControlValue();
- }
- 
+}
 
+/*
 static void DecreaseWhichControl(bool pressed) {
- 	if (!pressed)
- 		return;
+        if (!pressed)
+                return;
+        which_control = (which_control + 5)%6;
+        LogControlValue();
+ } */
 
-
-
-	which_control = (which_control + 5)%6;
-	LogControlValue();
- }
- 
-
-static void write_cga_color_select(uint8_t val) {
+static void write_cga_color_select(uint8_t val)
+{
 	vga.tandy.color_select=val;
 	switch(vga.mode) {
-
-	case  M_TANDY4:
-	case  M_CGA4_COMPOSITE: {
+	case M_TANDY4:
+	case M_CGA4_COMPOSITE: {
 		Bit8u base = (val & 0x10) ? 0x08 : 0;
 		Bit8u bg = val & 0xf;
 		if (vga.tandy.mode_control & 0x4)	// cyan red white
@@ -549,15 +545,16 @@ static void write_cga(Bitu port, Bitu data, Bitu /*iolen*/)
 			if (vga.tandy.mode_control & 0x10) {// highres mode
 				if (cga_comp==1 || ((cga_comp==0 && !(val&0x4)) && !mono_cga)) {	// composite display
 
-					VGA_SetMode(M_CGA2_COMPOSITE); // composite ntsc 640x200 16 color mode
+					// composite ntsc 640x200 16 color mode
+					VGA_SetMode(M_CGA2_COMPOSITE);
 					update_cga16_color();
 				} else {
 					VGA_SetMode(M_TANDY2);
 				}
 			} else {							// lowres mode
 				if (cga_comp==1) {				// composite display
-
-					VGA_SetMode(M_CGA4_COMPOSITE); // composite ntsc 640x200 16 color mode
+					// composite ntsc 640x200 16 color mode
+					VGA_SetMode(M_CGA4_COMPOSITE);
 					update_cga16_color();
 				} else {
 					VGA_SetMode(M_TANDY4);
@@ -566,11 +563,11 @@ static void write_cga(Bitu port, Bitu data, Bitu /*iolen*/)
 
 			write_cga_color_select(vga.tandy.color_select);
 		} else {
-			if (cga_comp==1) {				// composite display
+			if (cga_comp == 1) { // composite display
 				VGA_SetMode(M_CGA_TEXT_COMPOSITE);
 				update_cga16_color();
 			} else {
-			VGA_SetMode(M_TANDY_TEXT);
+				VGA_SetMode(M_TANDY_TEXT);
 			}
 		}
 		VGA_SetBlinking(val & 0x20);
@@ -1055,9 +1052,12 @@ void VGA_SetupOther(void)
 		IO_RegisterWriteHandler(0x3d8,write_cga,IO_MB);
 		IO_RegisterWriteHandler(0x3d9,write_cga,IO_MB);
 		if (!mono_cga) {
-		MAPPER_AddHandler(IncreaseWhichControl,SDL_SCANCODE_F10,0, "select","Sel Ctl");
-		MAPPER_AddHandler(DecreaseControlValue,SDL_SCANCODE_F11,MMOD2,"decval","Dec Val");
-		MAPPER_AddHandler(IncreaseControlValue,SDL_SCANCODE_F11,0,"incval","Inc Val");
+			MAPPER_AddHandler(CycleWhichControl, SDL_SCANCODE_F10,
+			                  0, "select", "Sel Ctl");
+			MAPPER_AddHandler(DecreaseControlValue, SDL_SCANCODE_F11,
+			                  MMOD2, "decval", "Dec Val");
+			MAPPER_AddHandler(IncreaseControlValue, SDL_SCANCODE_F11,
+			                  0, "incval", "Inc Val");
 			MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0,
 			                  "cgacomp", "CGA Comp");
 		} else {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1110,9 +1110,14 @@ void VGA_SetupOther(void)
 		write_pcjr( 0x3df, 0x7 | (0x7 << 3), 0 );
 		IO_RegisterWriteHandler(0x3da,write_pcjr,IO_MB);
 		IO_RegisterWriteHandler(0x3df,write_pcjr,IO_MB);
-		MAPPER_AddHandler(IncreaseHue, SDL_SCANCODE_F11, MMOD2, "inchue", "Inc Hue");
-		MAPPER_AddHandler(DecreaseHue, SDL_SCANCODE_F11, 0, "dechue", "Dec Hue");
-		MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0, "cgacomp", "CGA Comp");
+		MAPPER_AddHandler(CycleWhichControl, SDL_SCANCODE_F10, 0,
+		                  "select", "Sel Ctl");
+		MAPPER_AddHandler(DecreaseControlValue, SDL_SCANCODE_F11, MMOD2,
+		                  "decval", "Dec Val");
+		MAPPER_AddHandler(IncreaseControlValue, SDL_SCANCODE_F11, 0,
+		                  "incval", "Inc Val");
+		MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0, "cgacomp",
+		                  "CGA Comp");
 	}
 	if (machine == MCH_HERC) {
 		Bitu base=0x3b0;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -623,9 +623,11 @@ static void tandy_update_palette() {
 		// PCJr
 		switch (vga.mode) {
 		case M_TANDY2:
+		case M_CGA2_COMPOSITE:
 			VGA_SetCGA2Table(vga.attr.palette[0],vga.attr.palette[1]);
 			break;
 		case M_TANDY4:
+		case M_CGA4_COMPOSITE:
 			VGA_SetCGA4Table(
 				vga.attr.palette[0], vga.attr.palette[1],
 				vga.attr.palette[2], vga.attr.palette[3]);
@@ -1071,6 +1073,9 @@ void VGA_SetupOther(void)
 		IO_RegisterWriteHandler(0x3df,write_tandy,IO_MB);
 	}
 	if (machine==MCH_PCJR) {
+		// Start the PCjr composite huge almost 1/3rd into the CGA hue
+		hue_offset = 100;
+
 		//write_pcjr will setup base address
 		write_pcjr( 0x3df, 0x7 | (0x7 << 3), 0 );
 		IO_RegisterWriteHandler(0x3da,write_pcjr,IO_MB);

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -31,18 +31,21 @@
 #include "support.h"
 #include "vga.h"
 
-static void write_crtc_index_other(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
-	vga.other.index=(Bit8u)val;
+static void write_crtc_index_other(Bitu /*port*/, uint8_t val, Bitu /*iolen*/)
+{
+	// only receives 8-bit data per its IO port registration
+	vga.other.index = val;
 }
 
-static Bitu read_crtc_index_other(Bitu /*port*/,Bitu /*iolen*/) {
+static uint8_t read_crtc_index_other(Bitu /*port*/, uint8_t /*iolen*/)
+{
+	// only returns 8-bit data per its IO port registration
 	return vga.other.index;
 }
 
-static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
+static void write_crtc_data_other(Bitu /*port*/, uint8_t val, Bitu /*iolen*/)
 {
-	// write_crtc_data_other() only accepts 8-bit data per its IO port registration
-	auto val = static_cast<uint8_t>(data);
+	// only receives 8-bit data per its IO port registration
 
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
@@ -122,8 +125,9 @@ static void write_crtc_data_other(Bitu /*port*/, Bitu data, Bitu /*iolen*/)
 		LOG(LOG_VGAMISC, LOG_NORMAL)("MC6845:Write %u to illegal index %x", val, vga.other.index);
 	}
 }
-static uint8_t read_crtc_data_other(Bitu /*port*/, Bitu /*iolen*/)
+static uint8_t read_crtc_data_other(Bitu /*port*/, uint8_t /*iolen*/)
 {
+	// only returns 8-bit data per its IO port registration
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
 		return vga.other.htotal;
@@ -171,7 +175,9 @@ static uint8_t read_crtc_data_other(Bitu /*port*/, Bitu /*iolen*/)
 	return static_cast<uint8_t>(~0);
 }
 
-static void write_lightpen(Bitu port,Bitu /*val*/,Bitu) {
+static void write_lightpen(Bitu port, uint8_t /*val*/, Bitu)
+{
+	// only receives 8-bit data per its IO port registration
 	switch (port) {
 	case 0x3db:	// Clear lightpen latch
 		vga.other.lightpen_triggered = false;
@@ -498,6 +504,7 @@ static void DecreaseWhichControl(bool pressed) {
 
 static void write_cga_color_select(uint8_t val)
 {
+	// only receives 8-bit data per its IO port registration
 	vga.tandy.color_select=val;
 	switch(vga.mode) {
 	case M_TANDY4:
@@ -528,10 +535,9 @@ static void write_cga_color_select(uint8_t val)
 	}
 }
 
-static void write_cga(Bitu port, Bitu data, Bitu /*iolen*/)
+static void write_cga(Bitu port, uint8_t val, Bitu /*iolen*/)
 {
-	// The only data written is 8-bit per write_cga's IO port registration
-	const auto val = static_cast<uint8_t>(data);
+	// only receives 8-bit data per its IO port registration
 	switch (port) {
 	case 0x3d8:
 		vga.tandy.mode_control = val;
@@ -712,7 +718,9 @@ static void TandyCheckLineMask(void ) {
 	}
 }
 
-static void write_tandy_reg(Bit8u val) {
+static void write_tandy_reg(uint8_t val)
+{
+	// only receives 8-bit data per its IO port registration
 	switch (vga.tandy.reg_index) {
 	case 0x0:
 		if (machine==MCH_PCJR) {
@@ -754,10 +762,9 @@ static void write_tandy_reg(Bit8u val) {
 	}
 }
 
-static void write_tandy(Bitu port, Bitu data, Bitu /*iolen*/)
+static void write_tandy(Bitu port, uint8_t val, Bitu /*iolen*/)
 {
-	// only is passed 8-bit data given its IO port registration
-	auto val = static_cast<uint8_t>(data);
+	// only receives 8-bit data per its IO port registration
 	switch (port) {
 	case 0x3d8:
 		val &= 0x3f; // only bits 0-6 are used
@@ -802,12 +809,15 @@ static void write_tandy(Bitu port, Bitu data, Bitu /*iolen*/)
 	}
 }
 
-static void write_pcjr(Bitu port,Bitu val,Bitu /*iolen*/) {
+static void write_pcjr(Bitu port, uint8_t val, Bitu /*iolen*/)
+{
+	// only receives 8-bit data per its IO port registration
 	switch (port) {
 	case 0x3da:
-		if (vga.tandy.pcjr_flipflop) write_tandy_reg((Bit8u)val);
+		if (vga.tandy.pcjr_flipflop)
+			write_tandy_reg(val);
 		else {
-			vga.tandy.reg_index=(Bit8u)val;
+			vga.tandy.reg_index = val;
 			if (vga.tandy.reg_index & 0x10)
 				vga.attr.disabled |= 2;
 			else vga.attr.disabled &= ~2;
@@ -844,7 +854,7 @@ static void write_pcjr(Bitu port,Bitu val,Bitu /*iolen*/) {
 		//    CRTC RA1. This results in the 4-bank mode.
 		//    PG1-2 in effect. 32k range.
 
-		vga.tandy.line_mask = (Bit8u)(val >> 6);
+		vga.tandy.line_mask = val >> 6;
 		vga.tandy.draw_bank = val & ((vga.tandy.line_mask&2) ? 0x6 : 0x7);
 		vga.tandy.mem_bank = (val >> 3) & 7;
 		vga.tandy.draw_base = &MemBase[vga.tandy.draw_bank * 16 * 1024];
@@ -980,12 +990,10 @@ static void write_hercules(Bitu port, uint8_t val, Bitu /*iolen*/)
 	}
 }
 
-/* static Bitu read_hercules(Bitu port,Bitu iolen) {
-	LOG_MSG("read from Herc port %x",port);
-	return 0;
-} */
+uint8_t read_herc_status(Bitu /*port*/, uint8_t /*iolen*/)
+{
+	// only returns 8-bit data per its IO port registration
 
-Bitu read_herc_status(Bitu /*port*/,Bitu /*iolen*/) {
 	// 3BAh (R):  Status Register
 	// bit   0  Horizontal sync
 	//       1  Light pen status (only some cards)
@@ -1090,15 +1098,15 @@ void VGA_SetupOther(void)
 		                  "CGA Comp");
 	}
 	if (machine == MCH_HERC) {
-		Bitu base=0x3b0;
+		constexpr uint16_t base = 0x3b0;
 		for (uint8_t i = 0; i < 4; ++i) {
 			// The registers are repeated as the address is not decoded properly;
 			// The official ports are 3b4, 3b5
-			const auto index_port = base + i * 2;
+			const auto index_port = base + i * 2u;
 			IO_RegisterWriteHandler(index_port, write_crtc_index_other, IO_MB);
 			IO_RegisterReadHandler(index_port, read_crtc_index_other, IO_MB);
 
-			const auto data_port = index_port + 1;
+			const auto data_port = index_port + 1u;
 			IO_RegisterWriteHandler(data_port, write_crtc_data_other, IO_MB);
 			IO_RegisterReadHandler(data_port, read_crtc_data_other, IO_MB);
 		}
@@ -1109,12 +1117,12 @@ void VGA_SetupOther(void)
 		IO_RegisterWriteHandler(0x3bf,write_hercules,IO_MB);
 		IO_RegisterReadHandler(0x3ba,read_herc_status,IO_MB);
 	} else if (!IS_EGAVGA_ARCH) {
-		Bitu base=0x3d0;
-		for (Bitu port_ct=0; port_ct<4; port_ct++) {
-			IO_RegisterWriteHandler(base+port_ct*2,write_crtc_index_other,IO_MB);
-			IO_RegisterWriteHandler(base+port_ct*2+1,write_crtc_data_other,IO_MB);
-			IO_RegisterReadHandler(base+port_ct*2,read_crtc_index_other,IO_MB);
-			IO_RegisterReadHandler(base+port_ct*2+1,read_crtc_data_other,IO_MB);
+		constexpr uint16_t base = 0x3d0;
+		for (uint8_t port_ct = 0; port_ct < 4; port_ct++) {
+			IO_RegisterWriteHandler(base + port_ct * 2, write_crtc_index_other, IO_MB);
+			IO_RegisterWriteHandler(base + port_ct * 2 + 1, write_crtc_data_other, IO_MB);
+			IO_RegisterReadHandler(base + port_ct * 2, read_crtc_index_other, IO_MB);
+			IO_RegisterReadHandler(base + port_ct * 2 + 1, read_crtc_data_other, IO_MB);
 		}
 	}
 }

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -587,14 +587,14 @@ static void write_cga_color_select(uint8_t val)
 	switch(vga.mode) {
 	case M_TANDY4:
 	case M_CGA4_COMPOSITE: {
-		Bit8u base = (val & 0x10) ? 0x08 : 0;
-		Bit8u bg = val & 0xf;
-		if (vga.tandy.mode_control & 0x4)	// cyan red white
-			VGA_SetCGA4Table(bg, 3+base, 4+base, 7+base);
-		else if (val & 0x20)				// cyan magenta white
-			VGA_SetCGA4Table(bg, 3+base, 5+base, 7+base);
-		else								// green red brown
-			VGA_SetCGA4Table(bg, 2+base, 4+base, 6+base);
+		uint8_t base = (val & 0x10) ? 0x08 : 0;
+		uint8_t bg = val & 0xf;
+		if (vga.tandy.mode_control & 0x4) // cyan red white
+			VGA_SetCGA4Table(bg, 3 + base, 4 + base, 7 + base);
+		else if (val & 0x20) // cyan magenta white
+			VGA_SetCGA4Table(bg, 3 + base, 5 + base, 7 + base);
+		else // green red brown
+			VGA_SetCGA4Table(bg, 2 + base, 4 + base, 6 + base);
 		vga.tandy.border_color = bg;
 		vga.attr.overscan_color = bg;
 		break;
@@ -685,11 +685,13 @@ static void tandy_update_palette() {
 					vga.attr.palette[0], vga.attr.palette[1],
 					vga.attr.palette[2], vga.attr.palette[3]);
 			} else {
-				Bit8u color_set = 0;
-				Bit8u r_mask = 0xf;
-				if (vga.tandy.color_select & 0x10) color_set |= 8; // intensity
-				if (vga.tandy.color_select & 0x20) color_set |= 1; // Cyan Mag. White
-				if (vga.tandy.mode_control & 0x04) {			// Cyan Red White
+				uint8_t color_set = 0;
+				uint8_t r_mask = 0xf;
+				if (vga.tandy.color_select & 0x10)
+					color_set |= 8; // intensity
+				if (vga.tandy.color_select & 0x20)
+					color_set |= 1; // Cyan Mag. White
+				if (vga.tandy.mode_control & 0x04) { // Cyan Red White
 					color_set |= 1;
 					r_mask &= ~1;
 				}
@@ -754,11 +756,13 @@ static void PCJr_FindMode()
 	is_composite_new_era = true;
 	if (vga.tandy.mode_control & 0x2) {
 		if (vga.tandy.mode_control & 0x10) {
-			/* bit4 of mode control 1 signals 16 colour graphics mode */
-			if (vga.mode==M_TANDY4) VGA_SetModeNow(M_TANDY16); // TODO lowres mode only
-			else VGA_SetMode(M_TANDY16);
+			// bit4 of mode control 1 signals 16 colour graphics mode
+			if (vga.mode == M_TANDY4)
+				VGA_SetModeNow(M_TANDY16); // TODO lowres mode only
+			else
+				VGA_SetMode(M_TANDY16);
 		} else if (vga.tandy.gfx_control & 0x08) {
-			/* bit3 of mode control 2 signals 2 colour graphics mode */
+			// bit3 of mode control 2 signals 2 colour graphics mode
 			if (cga_comp == 1 ||
 			    (cga_comp == 0 && !(vga.tandy.mode_control & 0x4))) {
 				VGA_SetMode(M_CGA2_COMPOSITE);
@@ -766,7 +770,7 @@ static void PCJr_FindMode()
 				VGA_SetMode(M_TANDY2);
 			}
 		} else {
-			/* otherwise some 4-colour graphics mode */
+			// otherwise some 4-colour graphics mode
 			const auto new_mode = (cga_comp == 1) ? M_CGA4_COMPOSITE
 			                                      : M_TANDY4;
 			if (vga.mode == M_TANDY16) {
@@ -982,14 +986,15 @@ static void CycleMonoCGABright(bool pressed) {
 	Mono_CGA_Palette();
 }
 
-void Mono_CGA_Palette(void) {
-	for (Bit8u ct=0;ct<16;ct++) {
-		VGA_DAC_SetEntry(ct,
-						 mono_cga_palettes[2*mono_cga_pal+mono_cga_bright][ct][0],
-						 mono_cga_palettes[2*mono_cga_pal+mono_cga_bright][ct][1],
-						 mono_cga_palettes[2*mono_cga_pal+mono_cga_bright][ct][2]
-		);
-		VGA_DAC_CombineColor(ct,ct);
+void Mono_CGA_Palette()
+{
+	for (uint8_t ct = 0; ct < 16; ++ct) {
+		VGA_DAC_SetEntry(
+		        ct,
+		        mono_cga_palettes[2 * mono_cga_pal + mono_cga_bright][ct][0],
+		        mono_cga_palettes[2 * mono_cga_pal + mono_cga_bright][ct][1],
+		        mono_cga_palettes[2 * mono_cga_pal + mono_cga_bright][ct][2]);
+		VGA_DAC_CombineColor(ct, ct);
 	}
 }
 
@@ -1083,10 +1088,11 @@ uint8_t read_herc_status(Bitu /*port*/, uint8_t /*iolen*/)
 	//       7  Vertical sync inverted
 
 	double timeInFrame = PIC_FullIndex()-vga.draw.delay.framestart;
-	Bit8u retval=0x72; // Hercules ident; from a working card (Winbond W86855AF)
-					// Another known working card has 0x76 ("KeysoGood", full-length)
-	if (timeInFrame < vga.draw.delay.vrstart ||
-		timeInFrame > vga.draw.delay.vrend) retval |= 0x80;
+	uint8_t retval = 0x72; // Hercules ident; from a working card (Winbond
+	                       // W86855AF) Another known working card has 0x76
+	                       // ("KeysoGood", full-length)
+	if (timeInFrame < vga.draw.delay.vrstart || timeInFrame > vga.draw.delay.vrend)
+		retval |= 0x80;
 
 	double timeInLine=fmod(timeInFrame,vga.draw.delay.htotal);
 	if (timeInLine >= vga.draw.delay.hrstart &&
@@ -1098,7 +1104,7 @@ uint8_t read_herc_status(Bitu /*port*/, uint8_t /*iolen*/)
 	return retval;
 }
 
-void VGA_SetupOther(void)
+void VGA_SetupOther()
 {
 	memset(&vga.tandy, 0, sizeof(vga.tandy));
 	vga.attr.disabled = 0;
@@ -1112,7 +1118,7 @@ void VGA_SetupOther(void)
 	vga.tandy.line_shift = 13;
 
 	if (machine==MCH_CGA || IS_TANDY_ARCH) {
-		extern Bit8u int10_font_08[256 * 8];
+		extern uint8_t int10_font_08[256 * 8];
 		for (int i = 0; i < 256; ++i) {
 			memcpy(&vga.draw.font[i * 32], &int10_font_08[i * 8], 8);
 		}
@@ -1123,7 +1129,7 @@ void VGA_SetupOther(void)
 		IO_RegisterWriteHandler(0x3dc,write_lightpen,IO_MB);
 	}
 	if (machine==MCH_HERC) {
-		extern Bit8u int10_font_14[256 * 14];
+		extern uint8_t int10_font_14[256 * 14];
 		for (int i = 0; i < 256; ++i) {
 			memcpy(&vga.draw.font[i * 32], &int10_font_14[i * 14], 14);
 		}
@@ -1196,7 +1202,7 @@ void VGA_SetupOther(void)
 		IO_RegisterReadHandler(0x3ba,read_herc_status,IO_MB);
 	} else if (!IS_EGAVGA_ARCH) {
 		constexpr uint16_t base = 0x3d0;
-		for (uint8_t port_ct = 0; port_ct < 4; port_ct++) {
+		for (uint8_t port_ct = 0; port_ct < 4; ++port_ct) {
 			IO_RegisterWriteHandler(base + port_ct * 2, write_crtc_index_other, IO_MB);
 			IO_RegisterWriteHandler(base + port_ct * 2 + 1, write_crtc_data_other, IO_MB);
 			IO_RegisterReadHandler(base + port_ct * 2, read_crtc_index_other, IO_MB);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -478,7 +478,9 @@ static void FinishSetMode(bool clearmem) {
 		case M_TANDY2:
 		case M_TANDY4:
 		case M_HERC_GFX:
-		case M_CGA16:
+		case M_CGA2_COMPOSITE:
+		case M_CGA4_COMPOSITE:
+		case M_CGA_TEXT_COMPOSITE:
 			/* Hack we just access the memory directly */
 			memset(vga.mem.linear,0,vga.vmemsize);
 			memset(vga.fastmem, 0, vga.vmemsize<<1);
@@ -861,8 +863,10 @@ bool INT10_SetVideoMode(Bit16u mode)
 		seq_data[2]|=0xf;				//Enable all planes for writing
 		seq_data[4]|=0xc;				//Graphics - odd/even - Chained
 		break;
-	case M_CGA16:      // only in MCH_CGA
-	case M_TANDY2:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
+	case M_CGA2_COMPOSITE:     // only in MCH_CGA
+	case M_CGA4_COMPOSITE:     // only in MCH_CGA
+	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
+	case M_TANDY2:             // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY4:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY16:    // only in MCH_TANDY, MCH_PCJR
 	case M_TANDY_TEXT: // only in MCH_CGA, MCH_TANDY
@@ -1102,8 +1106,10 @@ bool INT10_SetVideoMode(Bit16u mode)
 		if (CurMode->special & _VGA_PIXEL_DOUBLE)
 			mode_control |= 0x08;
 		break;
-	case M_CGA16:      // only in MCH_CGA
-	case M_TANDY2:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
+	case M_CGA2_COMPOSITE:     // only in MCH_CGA
+	case M_CGA4_COMPOSITE:     // only in MCH_CGA
+	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
+	case M_TANDY2:             // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY4:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY16:    // only in MCH_TANDY, MCH_PCJR
 	case M_TANDY_TEXT: // only in MCH_CGA, MCH_TANDY
@@ -1190,8 +1196,10 @@ bool INT10_SetVideoMode(Bit16u mode)
 			gfx_data[0x6]|=0x0f;		//graphics mode at at 0xb800=0xbfff
 		}
 		break;
-	case M_CGA16:      // only in MCH_CGA
-	case M_TANDY2:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
+	case M_CGA2_COMPOSITE:     // only in MCH_CGA
+	case M_CGA4_COMPOSITE:     // only in MCH_CGA
+	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
+	case M_TANDY2:             // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY4:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY16:    // only in MCH_TANDY, MCH_PCJR
 	case M_TANDY_TEXT: // only in MCH_CGA, MCH_TANDY
@@ -1303,8 +1311,10 @@ att_text16:
 		for (Bit8u ct=0;ct<16;ct++) att_data[ct]=ct;
 		att_data[0x10]=0x41;		//Color Graphics 8-bit
 		break;
-	case M_CGA16:      // only in MCH_CGA
-	case M_TANDY2:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
+	case M_CGA2_COMPOSITE:     // only in MCH_CGA
+	case M_CGA4_COMPOSITE:     // only in MCH_CGA
+	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
+	case M_TANDY2:             // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	case M_TANDY4:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 	// case M_TANDY16:    // only in MCH_TANDY, MCH_PCJR
 	case M_TANDY_TEXT: // only in MCH_CGA, MCH_TANDY
@@ -1397,7 +1407,9 @@ dac_text16:
 				IO_Write(0x3c9,vga_palette[i][2]);
 			}
 			break;
-		case M_CGA16:      // only in MCH_CGA
+		case M_CGA2_COMPOSITE:     // only in MCH_CGA
+		case M_CGA4_COMPOSITE:     // only in MCH_CGA
+		case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
 		case M_TANDY2:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 		case M_TANDY4:     // only in MCH_CGA, MCH_TANDY, MCH_PCJR
 		// case M_TANDY16:    // only in MCH_TANDY, MCH_PCJR

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -652,7 +652,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_STARTUP_CGA",
 	        "\xBA DOSBox supports Composite CGA mode.                                \xBA\n"
 	        "\xBA Use \033[31mF12\033[37m to set composite output ON, OFF, or AUTO (default).        \xBA\n"
-	        "\xBA \033[31m(%s+)F11\033[37m changes hue; \033[31m%s+%s+F11\033[37m selects early/late CGA model.%s  \xBA\n"
+	        "\xBA \033[31mF10\033[37m selects the CGA settings to change and \033[31m(%s+)F11\033[37m changes it.   \xBA\n"
 	        "\xBA                                                                    \xBA\n");
 	MSG_Add("SHELL_STARTUP_CGA_MONO",
 	        "\xBA Use \033[31mF11\033[37m to cycle through green, amber, white and paper-white mode, \xBA\n"


### PR DESCRIPTION
This combines reenigne's CGA composite patch, kindly maintained by VileRancour, with NewRisingSun's already merged PCjr composite patch. 

PCjr composite now uses these improvements too:  colors, hue, contrast, brightness, and sharpness. 

This is currently a draft for functional testing and early preview. Feedback on the merge or testing results is very welcome. 

To get this merged will we still need to apply the usual Staging adjustments with a couple more commits; but those should be mostly topical.

After this PR, we can add conf setting for composite , because manually "turning the dials" every game launch is tedious, and we want preservationists to lock-in these preferences that best suit each game (ie: grass is green, sky is blue, etc..). 