### PR TITLE
Fix vsync lag

### DIFF
--- a/include/pacer.h
+++ b/include/pacer.h
@@ -1,0 +1,62 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  Kirk Klobe <kklobe@gmail.com>
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PACER_H
+#define DOSBOX_PACER_H
+
+#include "dosbox.h"
+
+#include <string>
+
+#include "timer.h"
+
+/*
+Pacer Class
+~~~~~~~~~~~
+Pacer allows a task to run provided it completes within a specified timeout. If
+the task takes longer than the permitted time, then it skips its next turn to
+run.
+
+Usage:
+ 1. Construct using the task name and a timeout (microseconds) within which the
+task should run. For example: Pacer render_pacer("Render", 1000);
+ 2. Check if the task can be run using CanRun(), which returns a bool.
+ 3. Immediately after the task ran (or didn't), Checkpoint() the results to
+    prepare for the next pass.
+*/
+
+class Pacer {
+public:
+	Pacer(const std::string &name, const int timeout);
+	Pacer() = delete;
+
+	bool CanRun();
+	void Checkpoint();
+	void SetTimeout(const int timeout);
+
+private:
+	const std::string pacer_name{};
+	int64_t iteration_start = 0;
+	int skip_timeout = 0;
+	bool can_run = true;
+};
+
+#endif

--- a/include/timer.h
+++ b/include/timer.h
@@ -144,4 +144,5 @@ static inline bool CanDelayPrecise()
 
 	return is_precise;
 }
+
 #endif

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -3,6 +3,7 @@ libmisc_sources = [
   'fs_utils_posix.cpp',
   'fs_utils_win32.cpp',
   'messages.cpp',
+  'pacer.cpp',
   'programs.cpp',
   'rwqueue.cpp',
   'setup.cpp',

--- a/src/misc/pacer.cpp
+++ b/src/misc/pacer.cpp
@@ -1,0 +1,59 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2021  Kirk Klobe <kklobe@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "pacer.h"
+
+Pacer::Pacer(const std::string &name, const int timeout)
+        : pacer_name(name),
+          iteration_start(GetTicksUs())
+{
+	assert(pacer_name.size() > 0);
+	SetTimeout(timeout);
+}
+
+bool Pacer::CanRun()
+{
+	if (can_run)
+		iteration_start = GetTicksUs();
+	return can_run;
+}
+
+static constexpr bool log_checkpoints = false;
+
+void Pacer::Checkpoint()
+{
+	if (can_run) {
+		const auto iteration_took = GetTicksUsSince(iteration_start);
+		can_run = iteration_took < skip_timeout;
+
+		if (log_checkpoints)
+			LOG_MSG("%s took %5dus, can_run = %s", pacer_name.c_str(),
+			        iteration_took, can_run ? "true" : "false");
+	} else {
+		can_run = true;
+	}
+}
+
+void Pacer::SetTimeout(const int timeout)
+{
+	assert(timeout > 0);
+	skip_timeout = timeout;
+}

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -416,6 +416,7 @@
     <ClCompile Include="..\src\misc\cross.cpp" />
     <ClCompile Include="..\src\misc\fs_utils_win32.cpp" />
     <ClCompile Include="..\src\misc\messages.cpp" />
+    <ClCompile Include="..\src\misc\pacer.cpp" />
     <ClCompile Include="..\src\misc\programs.cpp" />
     <ClCompile Include="..\src\misc\rwqueue.cpp" />
     <ClCompile Include="..\src\misc\setup.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -478,6 +478,9 @@
     <ClCompile Include="..\src\libs\residfp\WaveformGenerator.cpp">
       <Filter>src\libs\residfp</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\misc\pacer.cpp">
+      <Filter>src\misc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\bios.h">


### PR DESCRIPTION
This is a fix for stuttering issues originally observed when vsync
appeared to be force-enabled due to an external monitor connected to a
MacBook Pro, despite the video subsystem being initialized without
vsync.

The fix sets a maximum allowable duration for the rendering calls, which
block when vsync is enabled. Each render call is timed, and if the
duration is too long, we skip the next frame.

This also restores vsync-related .conf settings.

Fixes #104