### PR TITLE
Allow joystick event mapping when `joysticktype = none`

### DIFF
--- a/README
+++ b/README
@@ -277,12 +277,14 @@ KEYBOARD: The keyboard lags.
 
 
 CONTROL: The character/cursor/mouse pointer always moves into one direction!
-    See if it still happens if you disable the joystick emulation,
-    set joysticktype=none in the [joystick] section of your DOSBox
-    configuration file. Maybe also try unplugging any joystick/gamepad.
-    If you want to use the joystick in the game, try setting timed=false
-    and be sure to calibrate the joystick (both in your OS as well as
-    in the game or the game's setup program).
+    See if it still happens if you disable the joystick emulation:
+    First try setting joysticktype=none or joysticktype=disabled in
+    the [joystick] section of your DOSBox configuration file.
+    Also try unplugging any joysticks or gamepads.
+
+    If you want to use the joystick in the game, try setting
+    timed=false and be sure to calibrate the joystick (both in your OS
+    as well as in the game or the game's setup program).
 
 
 SPEED: The game/application runs much too slow/too fast!

--- a/include/joystick.h
+++ b/include/joystick.h
@@ -41,7 +41,8 @@ void JOYSTICK_ParseConfiguredType();
 
 enum JoystickType {
 	JOY_UNSET,
-	JOY_NONE,
+	JOY_DISABLED, // joystick subsystem is fully disabled (won't even query)
+	JOY_NONE,     // joystick subsystem will be available for mapping only
 	JOY_AUTO,
 	JOY_2AXIS,
 	JOY_4AXIS,

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -803,18 +803,22 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&INT10_Init);
 	secprop->AddInitFunction(&MOUSE_Init); //Must be after int10 as it uses CurMode
 	secprop->AddInitFunction(&JOYSTICK_Init,true);
-	const char* joytypes[] = { "auto", "2axis", "4axis", "4axis_2", "fcs", "ch", "none",0};
-	Pstring = secprop->Add_string("joysticktype",Property::Changeable::WhenIdle,"auto");
+	const char *joytypes[] = {"auto", "2axis", "4axis",    "4axis_2", "fcs",
+	                          "ch",   "none",  "disabled", 0};
+	Pstring = secprop->Add_string("joysticktype",
+	                              Property::Changeable::WhenIdle, "auto");
 	Pstring->Set_values(joytypes);
 	Pstring->Set_help(
-		"Type of joystick to emulate: auto (default),\n"
-		"none (disables joystick emulation),\n"
-		"2axis (supports two joysticks),\n"
-		"4axis (supports one joystick, first joystick used),\n"
-		"4axis_2 (supports one joystick, second joystick used),\n"
-		"fcs (Thrustmaster), ch (CH Flightstick).\n"
-		"auto chooses emulation depending on real joystick(s).\n"
-		"(Remember to reset DOSBox's mapperfile if you saved it earlier)");
+	        "Type of joystick to emulate: auto (default),\n"
+	        "auto    : Detect and use any joystick(s), if possible.,\n"
+	        "2axis   : Support up to two joysticks.\n"
+	        "4axis   : Support the first joystick only.\n"
+	        "4axis_2 : support the second joystick only.\n"
+	        "fcs     : support a Thrustmaster-type joystick.\n"
+	        "ch      : support a CH Flightstick-type joystick.\n"
+	        "none    : Prevent DOS from seeing the joystick(s), but enable them for mapping.\n"
+	        "disabled: Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
+	        "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
 
 	Pbool = secprop->Add_bool("timed",Property::Changeable::WhenIdle,true);
 	Pbool->Set_help("enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).");


### PR DESCRIPTION
Fixes #1111.

This reverts the behaviour of `joysticktype = none` to allow mapping of joystick events, while the joystick itself will be invisible to DOS programs/games.

This PR also adds `joysticktype = disabled`, which fully disables joysticks in both SDL and DOS, and prevents SDL itself from using and polling for joystick events. 

These are useful when you don't want the DOS game to detect joysticks, especially for those games that insist on making use of a joystick when its detected. 

The second setting is useful when the hosts's joystick system is laggy (which might cause game stuttering or slowdown) or otherwise buggy or unwanted.
