### PR TITLE
 De-`Bitu` the `PIC_`* counters and functions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Denable_debugger=normal
-            max_warnings: 80
+            max_warnings: 78
 
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
@@ -55,7 +55,7 @@ jobs:
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 116
+            max_warnings: 114
 
           - name: GCC, -network
             os: ubuntu-20.04
@@ -65,7 +65,7 @@ jobs:
           - name: GCC, warning_level=3
             os: ubuntu-20.04
             build_flags: -Dwarning_level=3
-            max_warnings: 62
+            max_warnings: 52
 
           - name: GCC, minimum build
             os: ubuntu-20.04

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 272
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1959
+            max_warnings: 1902
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/pic.h
+++ b/include/pic.h
@@ -21,43 +21,53 @@
 
 
 /* CPU Cycle Timing */
-extern Bit32s CPU_Cycles;
-extern Bit32s CPU_CycleLeft;
-extern Bit32s CPU_CycleMax;
+extern int32_t CPU_Cycles;
+extern int32_t CPU_CycleLeft;
+extern int32_t CPU_CycleMax;
 
-typedef void (PIC_EOIHandler) (void);
-typedef void (* PIC_EventHandler)(Bitu val);
+typedef void(PIC_EOIHandler)();
+typedef void (*PIC_EventHandler)(uint32_t val);
 
+extern uint32_t PIC_IRQCheck;
 
-extern Bitu PIC_IRQCheck;
-extern Bitu PIC_Ticks;
+// Elapsed milliseconds since starting DOSBox
+// Holds ~4.2 B milliseconds or ~48 days before rolling over
+extern uint32_t PIC_Ticks;
 
-static INLINE float PIC_TickIndex(void) {
-	return (CPU_CycleMax-CPU_CycleLeft-CPU_Cycles)/(float)CPU_CycleMax;
+// The number of cycles not done yet (ND)
+static INLINE int32_t PIC_TickIndexND()
+{
+	return CPU_CycleMax - CPU_CycleLeft - CPU_Cycles;
 }
 
-static INLINE Bits PIC_TickIndexND(void) {
-	return CPU_CycleMax-CPU_CycleLeft-CPU_Cycles;
+// Returns the percent cycles completed within the current "millisecond tick" of
+// the CPU
+static INLINE float PIC_TickIndex()
+{
+	return static_cast<float>(PIC_TickIndexND()) /
+	       static_cast<float>(CPU_CycleMax);
 }
 
-static INLINE Bits PIC_MakeCycles(double amount) {
-	return (Bits)(CPU_CycleMax*amount);
+static INLINE int32_t PIC_MakeCycles(float amount)
+{
+	return static_cast<int32_t>(static_cast<float>(CPU_CycleMax) * amount);
 }
 
-static INLINE double PIC_FullIndex(void) {
-	return PIC_Ticks+(double)PIC_TickIndex();
+static INLINE float PIC_FullIndex()
+{
+	return static_cast<float>(PIC_Ticks) + PIC_TickIndex();
 }
 
-void PIC_ActivateIRQ(Bitu irq);
-void PIC_DeActivateIRQ(Bitu irq);
+void PIC_ActivateIRQ(uint8_t irq);
+void PIC_DeActivateIRQ(uint8_t irq);
 
-void PIC_runIRQs(void);
-bool PIC_RunQueue(void);
+void PIC_runIRQs();
+bool PIC_RunQueue();
 
 //Delay in milliseconds
-void PIC_AddEvent(PIC_EventHandler handler,float delay,Bitu val=0);
+void PIC_AddEvent(PIC_EventHandler handler, float delay, uint32_t val = 0);
 void PIC_RemoveEvents(PIC_EventHandler handler);
-void PIC_RemoveSpecificEvents(PIC_EventHandler handler, Bitu val);
+void PIC_RemoveSpecificEvents(PIC_EventHandler handler, uint32_t val);
 
-void PIC_SetIRQMask(Bitu irq, bool masked);
+void PIC_SetIRQMask(uint32_t irq, bool masked);
 #endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -148,17 +148,17 @@ typedef struct {
 	Bitu parts_left;
 	Bitu byte_panning_shift;
 	struct {
-		double framestart;
-		double vrstart, vrend;		// V-retrace
-		double hrstart, hrend;		// H-retrace
-		double hblkstart, hblkend;	// H-blanking
-		double vblkstart, vblkend;	// V-Blanking
-		double vdend, vtotal;
-		double hdend, htotal;
-		double parts;
+		float framestart;
+		float vrstart, vrend;     // V-retrace
+		float hrstart, hrend;     // H-retrace
+		float hblkstart, hblkend; // H-blanking
+		float vblkstart, vblkend; // V-Blanking
+		float vdend, vtotal;
+		float hdend, htotal;
+		float parts;
 	} delay;
 	Bitu bpp;
-	double aspect_ratio;
+	float aspect_ratio;
 	bool double_scan;
 	bool doublewidth,doubleheight;
 	Bit8u font[64*1024];

--- a/include/vga.h
+++ b/include/vga.h
@@ -432,7 +432,7 @@ void VGA_SetMode(VGAModes mode);
 void VGA_DetermineMode(void);
 void VGA_SetupHandlers(void);
 void VGA_StartResize(Bitu delay=50);
-void VGA_SetupDrawing(Bitu val);
+void VGA_SetupDrawing(uint32_t val);
 void VGA_CheckScanLength(void);
 void VGA_ChangedBank(void);
 

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -515,14 +515,15 @@ l_M_Ed:
 		CPU_SW_Interrupt_NoIOPLCheck(1,GetIP());
 		continue;
 	case D_RDTSC: {
-		if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW) goto illegalopcode;
-		Bit64s tsc=(Bit64s)(PIC_FullIndex()*(double)(CPU_CycleAutoAdjust?70000:CPU_CycleMax));
-		reg_edx=(Bit32u)(tsc>>32);
-		reg_eax=(Bit32u)(tsc&0xffffffff);
+		if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW)
+			goto illegalopcode;
+		Bit64s tsc = (Bit64s)(PIC_FullIndex() * static_cast<float>(CPU_CycleAutoAdjust ? 70000 : CPU_CycleMax));
+		reg_edx = (Bit32u)(tsc >> 32);
+		reg_eax = (Bit32u)(tsc & 0xffffffff);
 		break;
-		}
+	}
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("LOAD:Unhandled code %d opcode %X",inst.code.load,inst.entry);
+		LOG(LOG_CPU, LOG_ERROR)("LOAD:Unhandled code %d opcode %X", inst.code.load, inst.entry);
 		goto illegalopcode;
 }
 

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -227,16 +227,18 @@
 		break;
 	CASE_0F_B(0x31)												/* RDTSC */
 		{
-			if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW) goto illegal_opcode;
+			if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW)
+				goto illegal_opcode;
 			/* Use a fixed number when in auto cycles mode as else the reported value changes constantly */
-			Bit64s tsc=(Bit64s)(PIC_FullIndex()*(double) (CPU_CycleAutoAdjust?70000:CPU_CycleMax));
-			reg_edx=(Bit32u)(tsc>>32);
-			reg_eax=(Bit32u)(tsc&0xffffffff);
+			Bit64s tsc = (Bit64s)(PIC_FullIndex() * static_cast<float>(CPU_CycleAutoAdjust ? 70000 : CPU_CycleMax));
+			reg_edx = (Bit32u)(tsc >> 32);
+			reg_eax = (Bit32u)(tsc & 0xffffffff);
 		}
 		break;
-	CASE_0F_W(0x80)												/* JO */
-		JumpCond16_w(TFLG_O);break;
-	CASE_0F_W(0x81)												/* JNO */
+	CASE_0F_W(0x80) /* JO */
+		JumpCond16_w(TFLG_O);
+		break;
+	CASE_0F_W(0x81) /* JNO */
 		JumpCond16_w(TFLG_NO);break;
 	CASE_0F_W(0x82)												/* JB */
 		JumpCond16_w(TFLG_B);break;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -208,7 +208,7 @@ static void RENDER_Halt( void ) {
 	render.active=false;
 }
 
-extern Bitu PIC_Ticks;
+extern uint32_t PIC_Ticks;
 void RENDER_EndUpdate( bool abort ) {
 	if (GCC_UNLIKELY(!render.updating))
 		return;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2798,8 +2798,9 @@ void MAPPER_LosingFocus() {
 	}
 }
 
-void MAPPER_RunEvent(Bitu /*val*/) {
-	KEYBOARD_ClrBuffer();	//Clear buffer
+void MAPPER_RunEvent(uint32_t /*val*/)
+{
+	KEYBOARD_ClrBuffer();           // Clear buffer
 	GFX_LosingFocus();		//Release any keys pressed (buffer gets filled again).
 	MAPPER_DisplayUI();
 }

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -407,7 +407,7 @@ public:
 			if ( (*cache)[ regFull ] == val )
 				return true;
 			/* Check how much time has passed */
-			Bitu passed = PIC_Ticks - lastTicks;
+			uint32_t passed = PIC_Ticks - lastTicks;
 			lastTicks = PIC_Ticks;
 			header.milliseconds += passed;
 

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -33,13 +33,13 @@ namespace Adlib {
 
 class Timer {
 	//Rounded down start time
-	double start;
+	float start;
 	//Time when you overflow
-	double trigger;
+	float trigger;
 	//Clock interval
-	double clockInterval;
+	float clockInterval;
 	//cycle interval
-	double counterInterval;
+	float counterInterval;
 	uint8_t counter;
 	bool enabled;
 	bool overflow;
@@ -47,10 +47,10 @@ class Timer {
 
 public:
 	Timer(int16_t micros)
-	        : start(0.0),
-	          trigger(0.0),
-	          clockInterval(micros * 0.001), // interval in milliseconds
-	          counterInterval(0),
+	        : start(0.0f),
+	          trigger(0.0f),
+	          clockInterval(micros * 0.001f), // interval in milliseconds
+	          counterInterval(0.0f),
 	          counter(0),
 	          enabled(false),
 	          overflow(false),
@@ -61,12 +61,13 @@ public:
 
 	//Update returns with true if overflow
 	//Properly syncs up the start/end to current time and changing intervals
-	bool Update( double time ) {
-		if (enabled && (time >= trigger) ) {
-			//How far into the next cycle
-			const double deltaTime = time - trigger;
-			//Sync start to last cycle
-			const double counterMod = fmod(deltaTime, counterInterval);
+	bool Update(const float time)
+	{
+		if (enabled && (time >= trigger)) {
+			// How far into the next cycle
+			const float deltaTime = time - trigger;
+			// Sync start to last cycle
+			const auto counterMod = fmodf(deltaTime, counterInterval);
 			start = time - counterMod;
 			trigger = start + counterInterval;
 			//Only set the overflow flag when not masked
@@ -98,13 +99,14 @@ public:
 		enabled = false;
 	}
 
-	void Start( const double time ) {
-		//Only properly start when not running before
+	void Start(const float time)
+	{
+		// Only properly start when not running before
 		if (!enabled) {
 			enabled = true;
 			overflow = false;
 			//Sync start to the last clock interval
-			const double clockMod = fmod(time, clockInterval);
+			const auto clockMod = fmodf(time, clockInterval);
 			start = time - clockMod;
 			//Overflow trigger
 			trigger = start + counterInterval;
@@ -134,13 +136,13 @@ typedef enum {
 class Handler {
 public:
 	//Write an address to a chip, returns the address the chip sets
-	virtual Bit32u WriteAddr( Bit32u port, Bit8u val ) = 0;
+	virtual Bit32u WriteAddr(uint16_t port, Bit8u val) = 0;
 	//Write to a specific register in the chip
 	virtual void WriteReg( Bit32u addr, Bit8u val ) = 0;
 	//Generate a certain amount of samples
-	virtual void Generate( MixerChannel* chan, Bitu samples ) = 0;
+	virtual void Generate(MixerChannel *chan, uint16_t samples) = 0;
 	//Initialize at a specific sample rate and mode
-	virtual void Init( Bitu rate ) = 0;
+	virtual void Init(uint32_t rate) = 0;
 	virtual ~Handler() = default;
 };
 
@@ -172,7 +174,8 @@ class Module: public Module_base {
 	void CacheWrite( Bit32u reg, Bit8u val );
 	void DualWrite( Bit8u index, Bit8u reg, Bit8u val );
 	void CtrlWrite( Bit8u val );
-	Bitu CtrlRead( void );
+	uint8_t CtrlRead(void);
+
 public:
 	static OPL_Mode oplmode;
 	MixerChannel* mixerChan;
@@ -184,9 +187,9 @@ public:
 	Chip	chip[2];
 
 	//Handle port writes
-	void PortWrite( Bitu port, Bitu val, Bitu iolen );
-	Bitu PortRead( Bitu port, Bitu iolen );
-	void Init( Mode m );
+	void PortWrite(uint16_t port, uint8_t val, Bitu iolen);
+	uint8_t PortRead(uint16_t port, Bitu iolen);
+	void Init(Mode m);
 
 	Module(Section *configuration);
 	~Module() override;

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -41,14 +41,15 @@ static struct {
 		bool acknowledged;
 	} timer;
 	struct {
-		double timer;
-		double ended;
-		double alarm;
+		float timer;
+		float ended;
+		float alarm;
 	} last;
 	bool update_ended;
 } cmos;
 
-static void cmos_timerevent(Bitu /*val*/) {
+static void cmos_timerevent(uint32_t /*val*/)
+{
 	if (cmos.timer.acknowledged) {
 		cmos.timer.acknowledged = false;
 		PIC_ActivateIRQ(8);
@@ -67,9 +68,10 @@ static void cmos_checktimer(void) {
 	LOG(LOG_PIT,LOG_NORMAL)("RTC Timer at %.2f hz",1000.0/cmos.timer.delay);
 //	PIC_AddEvent(cmos_timerevent,cmos.timer.delay);
 	/* A rtc is always running */
-	double remd=fmod(PIC_FullIndex(),(double)cmos.timer.delay);
-	PIC_AddEvent(cmos_timerevent,(float)((double)cmos.timer.delay-remd)); //Should be more like a real pc. Check
-//	status reg A reading with this (and with other delays actually)
+	const auto remd = fmodf(PIC_FullIndex(), cmos.timer.delay);
+	// Should be more like a real pc. Check
+	PIC_AddEvent(cmos_timerevent, cmos.timer.delay - remd);
+	// Status reg A reading with this (and with other delays actually)
 }
 
 void cmos_selreg(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
@@ -172,7 +174,7 @@ static Bitu cmos_readreg(Bitu /*port*/,Bitu /*iolen*/) {
 		} else {
 			/* Give correct values at certain times */
 			Bit8u val=0;
-			double index=PIC_FullIndex();
+			const auto index = PIC_FullIndex();
 			if (index>=(cmos.last.timer+cmos.timer.delay)) {
 				cmos.last.timer=index;
 				val|=0x40;

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -40,7 +40,9 @@ typedef Bits (*WaveHandler)(Bitu i, Bitu volume);
 #endif
 
 typedef Bits ( DBOPL::Operator::*VolumeHandler) ( );
-typedef Channel* ( DBOPL::Channel::*SynthHandler) ( Chip* chip, Bit32u samples, Bit32s* output );
+typedef Channel *(DBOPL::Channel::*SynthHandler)(Chip *chip,
+                                                 uint16_t samples,
+                                                 Bit32s *output);
 
 //Different synth modes that can generate blocks of data
 typedef enum {
@@ -186,8 +188,8 @@ struct Channel {
 	void GeneratePercussion( Chip* chip, Bit32s* output );
 
 	//Generate blocks of data in specific modes
-	template<SynthMode mode>
-	Channel* BlockTemplate( Chip* chip, Bit32u samples, Bit32s* output );
+	template <SynthMode mode>
+	Channel *BlockTemplate(Chip *chip, uint16_t samples, Bit32s *output);
 	Channel();
 };
 
@@ -226,20 +228,20 @@ struct Chip {
 	int8_t opl3Active = 0; // 0 or -1 when enabled
 
 	//Return the maximum amount of samples before and LFO change
-	Bit32u ForwardLFO( Bit32u samples );
+	Bit32u ForwardLFO(uint16_t samples);
 	Bit32u ForwardNoise();
 
 	void WriteBD( Bit8u val );
 	void WriteReg(Bit32u reg, Bit8u val );
 
-	Bit32u WriteAddr( Bit32u port, Bit8u val );
+	Bit32u WriteAddr(uint16_t port, Bit8u val);
 
-	void GenerateBlock2( Bitu samples, Bit32s* output );
-	void GenerateBlock3( Bitu samples, Bit32s* output );
+	void GenerateBlock2(uint16_t samples, Bit32s *output);
+	void GenerateBlock3(uint16_t samples, Bit32s *output);
 
 	//Update the synth handlers in all channels
 	void UpdateSynths();
-	void Generate( Bit32u samples );
+	void Generate(uint16_t samples);
 	void Setup( Bit32u r );
 
 	Chip() = default; // can't be placed on top because of offset math
@@ -247,10 +249,10 @@ struct Chip {
 
 struct Handler : public Adlib::Handler {
 	DBOPL::Chip chip = {};
-	virtual Bit32u WriteAddr( Bit32u port, Bit8u val );
+	virtual Bit32u WriteAddr(uint16_t port, Bit8u val);
 	virtual void WriteReg( Bit32u addr, Bit8u val );
-	virtual void Generate( MixerChannel* chan, Bitu samples );
-	virtual void Init( Bitu rate );
+	virtual void Generate(MixerChannel *chan, uint16_t samples);
+	virtual void Init(uint32_t rate);
 };
 
 } // namespace DBOPL

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -37,8 +37,8 @@ enum DISNEY_STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 struct dac_channel {
 	uint8_t buffer[BUFFER_SAMPLES] = {};
 	uint8_t used = 0; // current data buffer level
-	double speedcheck_sum = 0;
-	double speedcheck_last = 0;
+	float speedcheck_sum = 0;
+	float speedcheck_last = 0;
 	bool speedcheck_failed = false;
 	bool speedcheck_init = false;
 };
@@ -74,7 +74,8 @@ struct Disney {
 
 static Disney disney;
 
-static void DISNEY_disable(Bitu) {
+static void DISNEY_disable(uint32_t)
+{
 	if (disney.chan) {
 		disney.chan->AddSilence();
 		disney.chan->Enable(false);
@@ -153,18 +154,18 @@ static void DISNEY_analyze(Bitu channel){
 		}
 		case DISNEY_STATE::ANALYZING:
 		{
-			const double current = PIC_FullIndex();
-			dac_channel* cch = &disney.da[channel];
+		        const auto current = PIC_FullIndex();
+		        dac_channel *cch = &disney.da[channel];
 
-			if (!cch->speedcheck_init) {
-				cch->speedcheck_init = true;
-				cch->speedcheck_last = current;
-				break;
-			}
-			cch->speedcheck_sum += current - cch->speedcheck_last;
-			//LOG_MSG("t=%f",current - cch->speedcheck_last);
+		        if (!cch->speedcheck_init) {
+			        cch->speedcheck_init = true;
+			        cch->speedcheck_last = current;
+			        break;
+		        }
+		        cch->speedcheck_sum += current - cch->speedcheck_last;
+		        // LOG_MSG("t=%f",current - cch->speedcheck_last);
 
-			// sanity checks (printer...)
+		        // sanity checks (printer...)
 			if ((current - cch-> speedcheck_last) < 0.01 ||
 				(current - cch-> speedcheck_last) > 2)
 				cch->speedcheck_failed = true;
@@ -214,7 +215,7 @@ static void disney_write(Bitu port, Bitu data, MAYBE_UNUSED Bitu iolen)
 		break;
 	}
 	case 1:		/* Status Port */
-		LOG(LOG_MISC,LOG_NORMAL)("DISNEY:Status write %" sBitfs(X),val);
+		LOG(LOG_MISC, LOG_NORMAL)("DISNEY:Status write %u", val);
 		break;
 	case 2:		/* Control Port */
 		if ((disney.control & 0x2) && !(val & 0x2)) {

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -184,8 +184,8 @@ private:
 	uint8_t pan_position = PAN_DEFAULT_POSITION;
 };
 
-static void GUS_TimerEvent(Bitu t);
-static void GUS_DMA_Event(Bitu val);
+static void GUS_TimerEvent(uint32_t t);
+static void GUS_DMA_Event(uint32_t val);
 
 using voice_array_t = std::array<std::unique_ptr<Voice>, MAX_VOICES>;
 
@@ -797,7 +797,7 @@ bool Gus::IsDmaXfer16Bit() noexcept
 	return (dma_ctrl & 0x4) && (dma1 >= 4);
 }
 
-static void GUS_DMA_Event(Bitu)
+static void GUS_DMA_Event(uint32_t)
 {
 	if (gus->PerformDmaTransfer())
 		PIC_AddEvent(GUS_DMA_Event, MS_PER_DMA_XFER);
@@ -1160,7 +1160,7 @@ void Gus::StopPlayback()
 	is_running = false;
 }
 
-static void GUS_TimerEvent(Bitu t)
+static void GUS_TimerEvent(uint32_t t)
 {
 	if (gus->CheckTimer(t)) {
 		const auto &timer = t == 0 ? gus->timer_one : gus->timer_two;

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -346,7 +346,7 @@ static bool IPX_Multiplex(void) {
 	return true;
 }
 
-static void IPX_AES_EventHandler(Bitu param)
+static void IPX_AES_EventHandler(uint32_t param)
 {
 	ECBClass* tmpECB = ECBList;
 	ECBClass* tmp2ECB;
@@ -442,12 +442,13 @@ static void handleIpxRequest(void) {
 				tmp2ECB=tmpECB->nextECB;
 				if(tmpECB->ECBAddr == ecbaddress) {
 					if(tmpECB->getInUseFlag()==USEFLAG_AESCOUNT)
-						PIC_RemoveSpecificEvents(IPX_AES_EventHandler,(Bitu)ecbaddress);
-					tmpECB->setInUseFlag(USEFLAG_AVAILABLE);
-					tmpECB->setCompletionFlag(COMP_CANCELLED);
-					delete tmpECB;
-					reg_al=0;	// Success
-					LOG_IPX("IPX: ECB canceled.");
+					        PIC_RemoveSpecificEvents(IPX_AES_EventHandler,
+					                                 ecbaddress);
+				        tmpECB->setInUseFlag(USEFLAG_AVAILABLE);
+				        tmpECB->setCompletionFlag(COMP_CANCELLED);
+				        delete tmpECB;
+				        reg_al = 0; // Success
+				        LOG_IPX("IPX: ECB canceled.");
 					return;
 				}
 				tmpECB=tmp2ECB;

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -59,7 +59,8 @@ static void KEYBOARD_SetPort60(Bit8u val) {
 	else PIC_ActivateIRQ(1);
 }
 
-static void KEYBOARD_TransferBuffer(Bitu /*val*/) {
+static void KEYBOARD_TransferBuffer(uint32_t /*val*/)
+{
 	keyb.scheduled = false;
 	if (!keyb.used) {
 		LOG(LOG_KEYBOARD,LOG_NORMAL)("Transfer started with empty buffer");
@@ -69,7 +70,6 @@ static void KEYBOARD_TransferBuffer(Bitu /*val*/) {
 	if (++keyb.pos >= KEYBUFSIZE) keyb.pos -= KEYBUFSIZE;
 	keyb.used--;
 }
-
 
 void KEYBOARD_ClrBuffer(void) {
 	keyb.used=0;

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -27,10 +27,10 @@
 #include "support.h"
 #include "midi.h"
 
-static void MPU401_Event(Bitu);
+static void MPU401_Event(uint32_t);
 static void MPU401_Reset(void);
-static void MPU401_ResetDone(Bitu);
-static void MPU401_EOIHandler(Bitu val=0);
+static void MPU401_ResetDone(uint32_t);
+static void MPU401_EOIHandler(uint32_t val = 0);
 static void MPU401_EOIHandlerDispatch(void);
 
 #define MPU401_VERSION	0x15
@@ -532,9 +532,10 @@ static void UpdateConductor(void) {
 	mpu.state.req_mask|=(1<<9);
 }
 
-static void MPU401_Event(Bitu /*val*/) {
-
-	if (mpu.mode == M_UART) return;
+static void MPU401_Event(uint32_t /*val*/)
+{
+	if (mpu.mode == M_UART)
+		return;
 
 	if (mpu.state.irq_pending) goto next_event;
 	if (mpu.state.playing) {
@@ -561,7 +562,6 @@ next_event:
 	PIC_AddEvent(MPU401_Event,MPU401_TIMECONSTANT/(mpu.clock.tempo*mpu.clock.timebase));
 }
 
-
 static void MPU401_EOIHandlerDispatch(void) {
 	if (mpu.state.send_now) {
 		mpu.state.eoi_scheduled=true;
@@ -571,8 +571,9 @@ static void MPU401_EOIHandlerDispatch(void) {
 }
 
 //Updates counters and requests new data on "End of Input"
-static void MPU401_EOIHandler(Bitu /*val*/) {
-	mpu.state.eoi_scheduled=false;
+static void MPU401_EOIHandler(uint32_t /*val*/)
+{
+	mpu.state.eoi_scheduled = false;
 	if (mpu.state.send_now) {
 		mpu.state.send_now=false;
 		if (mpu.state.cond_req) UpdateConductor();
@@ -590,8 +591,9 @@ static void MPU401_EOIHandler(Bitu /*val*/) {
 	} while ((i++)<16);
 }
 
-static void MPU401_ResetDone(Bitu) {
-	mpu.state.reset=false;
+static void MPU401_ResetDone(uint32_t)
+{
+	mpu.state.reset = false;
 	if (mpu.state.cmd_pending) {
 		MPU401_WriteCommand(0x331,mpu.state.cmd_pending-1,1);
 		mpu.state.cmd_pending=0;

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -44,7 +44,7 @@
 
 // Handle to WinPCap device
 pcap_t *adhandle = 0;
-static void NE2000_TX_Event(Bitu val);
+static void NE2000_TX_Event(uint32_t val);
 
 #ifdef WIN32
 // DLL loading
@@ -1451,8 +1451,8 @@ void bx_ne2k_c::init()
   reset(BX_RESET_HARDWARE);
 }
 
-static void NE2000_TX_Event(Bitu val) {
-    (void)val;//UNUSED
+static void NE2000_TX_Event(MAYBE_UNUSED uint32_t val)
+{
 	theNE2kDevice->tx_timer();
 }
 

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -217,7 +217,8 @@ void CSerial::changeLineProperties() {
 	updatePortConfig (baud_divider, LCR);
 }
 
-static void Serial_EventHandler(Bitu val) {
+static void Serial_EventHandler(uint32_t val)
+{
 	const uint32_t serclassid = val & 0x3;
 	if (serialports[serclassid] != 0) {
 		const auto event_type = static_cast<uint16_t>(val >> 2);
@@ -1209,7 +1210,7 @@ CSerial::~CSerial() {
 	}
 }
 
-static bool idle(const double start, const uint32_t timeout)
+static bool idle(const float start, const uint32_t timeout)
 {
 	CALLBACK_Idle();
 	return PIC_FullIndex() - start > timeout;
@@ -1217,7 +1218,7 @@ static bool idle(const double start, const uint32_t timeout)
 
 bool CSerial::Getchar(uint8_t *data, uint8_t *lsr, bool wait_dsr, uint32_t timeout)
 {
-	const double starttime = PIC_FullIndex();
+	const auto starttime = PIC_FullIndex();
 	bool timed_out = false;
 
 	// Wait until we're ready to receive (or we've timed out)
@@ -1255,7 +1256,7 @@ receiver:
 */
 bool CSerial::Putchar(uint8_t data, bool wait_dsr, bool wait_cts, uint32_t timeout)
 {
-	const double start_time = PIC_FullIndex();
+	const auto start_time = PIC_FullIndex();
 	bool timed_out = false;
 
 	// Wait until our transfer queue is empty (or we've timed out)

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -65,7 +65,8 @@ static Bit8u latched_timerstatus;
 // reprogrammed.
 static bool latched_timerstatus_locked;
 
-static void PIT0_Event(Bitu /*val*/) {
+static void PIT0_Event(uint32_t /*val*/)
+{
 	PIC_ActivateIRQ(0);
 	if (pit[0].mode != 0) {
 		pit[0].start += pit[0].delay;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -745,7 +745,8 @@ static void VGA_ProcessSplit() {
 }
 
 static Bit8u bg_color_index = 0; // screen-off black index
-static void VGA_DrawSingleLine(Bitu /*blah*/) {
+static void VGA_DrawSingleLine(uint32_t /*blah*/)
+{
 	if (GCC_UNLIKELY(vga.attr.disabled)) {
 		switch(machine) {
 		case MCH_PCJR:
@@ -815,7 +816,8 @@ static void VGA_DrawSingleLine(Bitu /*blah*/) {
 	} else RENDER_EndUpdate(false);
 }
 
-static void VGA_DrawEGASingleLine(Bitu /*blah*/) {
+static void VGA_DrawEGASingleLine(uint32_t /*blah*/)
+{
 	if (GCC_UNLIKELY(vga.attr.disabled)) {
 		memset(TempLine, 0, sizeof(TempLine));
 		RENDER_DrawLine(TempLine);
@@ -838,7 +840,8 @@ static void VGA_DrawEGASingleLine(Bitu /*blah*/) {
 	} else RENDER_EndUpdate(false);
 }
 
-static void VGA_DrawPart(Bitu lines) {
+static void VGA_DrawPart(uint32_t lines)
+{
 	while (lines--) {
 		Bit8u * data=VGA_DrawLine( vga.draw.address, vga.draw.address_line );
 		RENDER_DrawLine(data);
@@ -909,28 +912,35 @@ static void INLINE VGA_ChangesStart( void ) {
 }
 #endif
 
-static void VGA_VertInterrupt(Bitu /*val*/) {
-	if ((!vga.draw.vret_triggered) && ((vga.crtc.vertical_retrace_end&0x30)==0x10)) {
+static void VGA_VertInterrupt(uint32_t /*val*/)
+{
+	if ((!vga.draw.vret_triggered) &&
+	    ((vga.crtc.vertical_retrace_end & 0x30) == 0x10)) {
 		vga.draw.vret_triggered=true;
 		if (GCC_UNLIKELY(machine==MCH_EGA)) PIC_ActivateIRQ(9);
 	}
 }
 
-static void VGA_Other_VertInterrupt(Bitu val) {
-	if (val) PIC_ActivateIRQ(5);
+static void VGA_Other_VertInterrupt(uint32_t val)
+{
+	if (val)
+		PIC_ActivateIRQ(5);
 	else PIC_DeActivateIRQ(5);
 }
 
-static void VGA_DisplayStartLatch(Bitu /*val*/) {
-	vga.config.real_start=vga.config.display_start & (vga.vmemwrap-1);
+static void VGA_DisplayStartLatch(uint32_t /*val*/)
+{
+	vga.config.real_start = vga.config.display_start & (vga.vmemwrap - 1);
 	vga.draw.bytes_skip = vga.config.bytes_skip;
 }
- 
-static void VGA_PanningLatch(Bitu /*val*/) {
+
+static void VGA_PanningLatch(uint32_t /*val*/)
+{
 	vga.draw.panning = vga.config.pel_panning;
 }
 
-static void VGA_VerticalTimer(Bitu /*val*/) {
+static void VGA_VerticalTimer(uint32_t /*val*/)
+{
 	vga.draw.delay.framestart = PIC_FullIndex();
 	PIC_AddEvent( VGA_VerticalTimer, (float)vga.draw.delay.vtotal );
 	
@@ -1160,8 +1170,9 @@ void VGA_ActivateHardwareCursor(void) {
 	}
 }
 
-void VGA_SetupDrawing(Bitu /*val*/) {
-	if (vga.mode==M_ERROR) {
+void VGA_SetupDrawing(uint32_t /*val*/)
+{
+	if (vga.mode == M_ERROR) {
 		PIC_RemoveEvents(VGA_VerticalTimer);
 		PIC_RemoveEvents(VGA_PanningLatch);
 		PIC_RemoveEvents(VGA_DisplayStartLatch);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -942,15 +942,15 @@ static void VGA_PanningLatch(uint32_t /*val*/)
 static void VGA_VerticalTimer(uint32_t /*val*/)
 {
 	vga.draw.delay.framestart = PIC_FullIndex();
-	PIC_AddEvent( VGA_VerticalTimer, (float)vga.draw.delay.vtotal );
-	
+	PIC_AddEvent(VGA_VerticalTimer, vga.draw.delay.vtotal);
+
 	switch(machine) {
 	case MCH_PCJR:
 	case MCH_TANDY:
 		// PCJr: Vsync is directly connected to the IRQ controller
 		// Some earlier Tandy models are said to have a vsync interrupt too
-		PIC_AddEvent(VGA_Other_VertInterrupt, (float)vga.draw.delay.vrstart, 1);
-		PIC_AddEvent(VGA_Other_VertInterrupt, (float)vga.draw.delay.vrend, 0);
+		PIC_AddEvent(VGA_Other_VertInterrupt, vga.draw.delay.vrstart, 1);
+		PIC_AddEvent(VGA_Other_VertInterrupt, vga.draw.delay.vrend, 0);
 		// fall-through
 	case MCH_CGA:
 	case MCH_HERC:
@@ -959,16 +959,17 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 		VGA_DisplayStartLatch(0);
 		break;
 	case MCH_VGA:
-		PIC_AddEvent(VGA_DisplayStartLatch, (float)vga.draw.delay.vrstart);
-		PIC_AddEvent(VGA_PanningLatch, (float)vga.draw.delay.vrend);
+		PIC_AddEvent(VGA_DisplayStartLatch, vga.draw.delay.vrstart);
+		PIC_AddEvent(VGA_PanningLatch, vga.draw.delay.vrend);
 		// EGA: 82c435 datasheet: interrupt happens at display end
-		// VGA: checked with scope; however disabled by default by jumper on VGA boards
-		// add a little amount of time to make sure the last drawpart has already fired
-		PIC_AddEvent(VGA_VertInterrupt,(float)(vga.draw.delay.vdend + 0.005));
+		// VGA: checked with scope; however disabled by default by
+		// jumper on VGA boards add a little amount of time to make sure
+		// the last drawpart has already fired
+		PIC_AddEvent(VGA_VertInterrupt, vga.draw.delay.vdend + 0.005f);
 		break;
 	case MCH_EGA:
-		PIC_AddEvent(VGA_DisplayStartLatch, (float)vga.draw.delay.vrend);
-		PIC_AddEvent(VGA_VertInterrupt,(float)(vga.draw.delay.vdend + 0.005));
+		PIC_AddEvent(VGA_DisplayStartLatch, vga.draw.delay.vrend);
+		PIC_AddEvent(VGA_VertInterrupt, vga.draw.delay.vdend + 0.005f);
 		break;
 	default:
 		E_Exit("This new machine needs implementation in VGA_VerticalTimer too.");
@@ -1074,37 +1075,39 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 #endif
 
 	// check if some lines at the top off the screen are blanked
-	float draw_skip = 0.0;
+	float draw_skip = 0.0f;
 	if (GCC_UNLIKELY(vga.draw.vblank_skip)) {
-		draw_skip = (float)(vga.draw.delay.htotal * vga.draw.vblank_skip);
-		vga.draw.address += vga.draw.address_add * (vga.draw.vblank_skip/(vga.draw.address_line_total));
+		draw_skip = vga.draw.delay.htotal * static_cast<float>(vga.draw.vblank_skip);
+		vga.draw.address += vga.draw.address_add * vga.draw.vblank_skip / vga.draw.address_line_total;
 	}
 
 	// add the draw event
 	switch (vga.draw.mode) {
 	case PART:
 		if (GCC_UNLIKELY(vga.draw.parts_left)) {
-			LOG(LOG_VGAMISC,LOG_NORMAL)( "Parts left: %d", vga.draw.parts_left );
+			LOG(LOG_VGAMISC, LOG_NORMAL)("Parts left: %d", static_cast<double>(vga.draw.parts_left));
 			PIC_RemoveEvents(VGA_DrawPart);
 			RENDER_EndUpdate(true);
 		}
 		vga.draw.lines_done = 0;
 		vga.draw.parts_left = vga.draw.parts_total;
-		PIC_AddEvent(VGA_DrawPart,(float)vga.draw.delay.parts + draw_skip,vga.draw.parts_lines);
+		PIC_AddEvent(VGA_DrawPart, vga.draw.delay.parts + draw_skip, static_cast<uint32_t>(vga.draw.parts_lines));
 		break;
 	case DRAWLINE:
 	case EGALINE:
 		if (GCC_UNLIKELY(vga.draw.lines_done < vga.draw.lines_total)) {
-			LOG(LOG_VGAMISC,LOG_NORMAL)( "Lines left: %d", 
-				vga.draw.lines_total-vga.draw.lines_done);
-			if (vga.draw.mode==EGALINE) PIC_RemoveEvents(VGA_DrawEGASingleLine);
-			else PIC_RemoveEvents(VGA_DrawSingleLine);
+			LOG(LOG_VGAMISC, LOG_NORMAL)("Lines left: %d", static_cast<double>(vga.draw.lines_total - vga.draw.lines_done));
+			if (vga.draw.mode == EGALINE)
+				PIC_RemoveEvents(VGA_DrawEGASingleLine);
+			else
+				PIC_RemoveEvents(VGA_DrawSingleLine);
 			RENDER_EndUpdate(true);
 		}
 		vga.draw.lines_done = 0;
 		if (vga.draw.mode==EGALINE)
-			PIC_AddEvent(VGA_DrawEGASingleLine,(float)(vga.draw.delay.htotal/4.0 + draw_skip));
-		else PIC_AddEvent(VGA_DrawSingleLine,(float)(vga.draw.delay.htotal/4.0 + draw_skip));
+			PIC_AddEvent(VGA_DrawEGASingleLine, vga.draw.delay.htotal / 4.0f + draw_skip);
+		else
+			PIC_AddEvent(VGA_DrawSingleLine, vga.draw.delay.htotal / 4.0f + draw_skip);
 		break;
 	}
 }
@@ -1201,7 +1204,8 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	}
 	
 	/* Calculate the FPS for this screen */
-	double fps; Bitu clock;
+	float fps;
+	uint32_t clock;
 	Bitu htotal, hdend, hbstart, hbend, hrstart, hrend;
 	Bitu vtotal, vdend, vbstart, vbend, vrstart, vrend;
 	Bitu vblank_skip;
@@ -1331,7 +1335,8 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			clock = 14318180;
 			break;
 		}
-		vga.draw.delay.hdend = hdend*1000.0/clock; //in milliseconds
+		// in milliseconds
+		vga.draw.delay.hdend = static_cast<float>(hdend) * 1000.0f / static_cast<float>(clock);
 	}
 #if C_DEBUG
 	LOG(LOG_VGA,LOG_NORMAL)("h total %d end %d blank (%d/%d) retrace (%d/%d)",
@@ -1341,21 +1346,23 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 #endif
 
 	// The screen refresh frequency
-	fps=(double)clock/(vtotal*htotal);
+	fps = static_cast<float>(clock) / static_cast<float>(vtotal * htotal);
+
+	const auto f_clock = static_cast<float>(clock);
 	// Horizontal total (that's how long a line takes with whistles and bells)
-	vga.draw.delay.htotal = htotal*1000.0/clock; //in milliseconds
+	vga.draw.delay.htotal = static_cast<float>(htotal) * 1000.0f / f_clock; // in milliseconds
 	// Start and End of horizontal blanking
-	vga.draw.delay.hblkstart = hbstart*1000.0/clock; //in milliseconds
-	vga.draw.delay.hblkend = hbend*1000.0/clock; 
+	vga.draw.delay.hblkstart = static_cast<float>(hbstart) * 1000.0f / f_clock; // in milliseconds
+	vga.draw.delay.hblkend = static_cast<float>(hbend) * 1000.0f / f_clock;
 	// Start and End of horizontal retrace
-	vga.draw.delay.hrstart = hrstart*1000.0/clock;
-	vga.draw.delay.hrend = hrend*1000.0/clock;
+	vga.draw.delay.hrstart = static_cast<float>(hrstart) * 1000.0f / f_clock;
+	vga.draw.delay.hrend = static_cast<float>(hrend) * 1000.0f / f_clock;
 	// Start and End of vertical blanking
-	vga.draw.delay.vblkstart = vbstart * vga.draw.delay.htotal;
-	vga.draw.delay.vblkend = vbend * vga.draw.delay.htotal;
+	vga.draw.delay.vblkstart = static_cast<float>(vbstart) * vga.draw.delay.htotal;
+	vga.draw.delay.vblkend = static_cast<float>(vbend) * vga.draw.delay.htotal;
 	// Start and End of vertical retrace pulse
-	vga.draw.delay.vrstart = vrstart * vga.draw.delay.htotal;
-	vga.draw.delay.vrend = vrend * vga.draw.delay.htotal;
+	vga.draw.delay.vrstart = static_cast<float>(vrstart) * vga.draw.delay.htotal;
+	vga.draw.delay.vrend = static_cast<float>(vrend) * vga.draw.delay.htotal;
 
 	// Vertical blanking tricks
 	vblank_skip = 0;
@@ -1373,15 +1380,15 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 				if (vbstart < vdend) {
 					vdend = vbstart;
 				}
-				LOG(LOG_VGA,LOG_WARN)("Blanking wrap to line %d", vblank_skip);
-			} else if (vbstart<=1) {
+				LOG(LOG_VGA, LOG_WARN)("Blanking wrap to line %d", static_cast<double>(vblank_skip));
+			} else if (vbstart <= 1) {
 				// blanking is used to cut lines at the start of the screen
 				vblank_skip = vbend;
-				LOG(LOG_VGA,LOG_WARN)("Upper %d lines of the screen blanked", vblank_skip);
+				LOG(LOG_VGA, LOG_WARN)("Upper %d lines of the screen blanked", static_cast<double>(vblank_skip));
 			} else if (vbstart < vdend) {
 				if (vbend < vdend) {
 					// the game wants a black bar somewhere on the screen
-					LOG(LOG_VGA,LOG_WARN)("Unsupported blanking: line %d-%d",vbstart,vbend);
+					LOG(LOG_VGA, LOG_WARN)("Unsupported blanking: line %d-%d", static_cast<double>(vbstart), static_cast<double>(vbend));
 				} else {
 					// blanking is used to cut off some lines from the bottom
 					vdend = vbstart;
@@ -1391,7 +1398,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		}
 	}
 	// Display end
-	vga.draw.delay.vdend = vdend * vga.draw.delay.htotal;
+	vga.draw.delay.vdend = static_cast<float>(vdend) * vga.draw.delay.htotal;
 
 	// EGA frequency dependent monitor palette
 	if (machine == MCH_EGA) {
@@ -1428,39 +1435,41 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	//Base pixel width around 100 clocks horizontal
 	//For 9 pixel text modes this should be changed, but we don't support that anyway :)
 	//Seems regular vga only listens to the 9 char pixel mode with character mode enabled
-	double pwidth = (machine==MCH_EGA) ? (114.0 / htotal) : (100.0 / htotal);
-	//Base pixel height around vertical totals of modes that have 100 clocks horizontal
-	//Different sync values gives different scaling of the whole vertical range
-	//VGA monitor just seems to thighten or widen the whole vertical range
-	double pheight;
-	double target_total = (machine==MCH_EGA) ? 262.0 : 449.0;
+	const auto pwidth = (machine == MCH_EGA ? 114.0f : 100.0f) / static_cast<float>(htotal);
+	// Base pixel height around vertical totals of modes that have 100
+	// clocks horizontal Different sync values gives different scaling of
+	// the whole vertical range VGA monitor just seems to thighten or widen
+	// the whole vertical range
+	float pheight;
+	float target_total = (machine == MCH_EGA) ? 262.0f : 449.0f;
 	Bitu sync = vga.misc_output >> 6;
+	const auto f_vtotal = static_cast<float>(vtotal);
 	switch ( sync ) {
 	case 0:		// This is not defined in vga specs,
 				// Kiet, seems to be slightly less than 350 on my monitor
 		//340 line mode, filled with 449 total
-		pheight = (480.0 / 340.0) * ( target_total / vtotal );
+		pheight = (480.0f / 340.0f) * (target_total / f_vtotal);
 		break;
 	case 1:		//400 line mode, filled with 449 total
-		pheight = (480.0 / 400.0) * ( target_total / vtotal );
+		pheight = (480.0f / 400.0f) * (target_total / f_vtotal);
 		break;
 	case 2:		//350 line mode, filled with 449 total
 		//This mode seems to get regular 640x400 timing and goes for a loong retrace
 		//Depends on the monitor to stretch the screen
-		pheight = (480.0 / 350.0) * ( target_total / vtotal );
+		pheight = (480.0f / 350.0f) * (target_total / f_vtotal);
 		break;
 	case 3:		//480 line mode, filled with 525 total
 	default:
 		//Allow 527 total ModeX to have exact 1:1 aspect
-		target_total = (vga.mode==M_VGA && vtotal==527) ? 527.0 : 525.0;
-		pheight = (480.0 / 480.0) * ( target_total / vtotal );
+		target_total = (vga.mode == M_VGA && f_vtotal == 527) ? 527.0f : 525.0f;
+		pheight = (480.0f / 480.0f) * (target_total / f_vtotal);
 		break;
 	}
 
-	double aspect_ratio = pheight / pwidth;
+	float aspect_ratio = pheight / pwidth;
 
-	vga.draw.delay.parts = vga.draw.delay.vdend/vga.draw.parts_total;
-	vga.draw.resizing=false;
+	vga.draw.delay.parts = vga.draw.delay.vdend / static_cast<float>(vga.draw.parts_total);
+	vga.draw.resizing = false;
 	vga.draw.vret_triggered=false;
 
 	//Check to prevent useless black areas
@@ -1514,7 +1523,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
  			doublewidth = true;
 			if (vga.mode == M_LIN32) {
 				// vesa modes 10f/190/191/192
-				aspect_ratio *= 2.0;
+				aspect_ratio *= 2.0f;
 			}
 		}
 		/* Use HW mouse cursor drawer if enabled */
@@ -1528,7 +1537,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			doublewidth = true;
 		else {
 			// vesa modes 165/175
-			aspect_ratio /= 2.0;
+			aspect_ratio /= 2.0f;
 		}
 		/* Use HW mouse cursor drawer if enabled */
 		VGA_ActivateHardwareCursor();
@@ -1555,14 +1564,14 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		vga.draw.linear_mask = (static_cast<uint64_t>(vga.vmemwrap) << 1) - 1;
 		break;
 	case M_CGA2_COMPOSITE:
-		aspect_ratio=1.2;
+		aspect_ratio = 1.2f;
 		doubleheight=true;
 		vga.draw.blocks=width*2;
 		width<<=4;
 		VGA_DrawLine = VGA_Draw_CGA2_Composite_Line;
 		break;
 	case M_CGA4_COMPOSITE:
-		aspect_ratio = 1.2;
+		aspect_ratio = 1.2f;
 		doubleheight = true;
 		vga.draw.blocks = width * 2;
 		width <<= 4;
@@ -1591,7 +1600,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			} else {
 				vga.draw.char9dot = true;
 				width*=9;
-				aspect_ratio*=1.125;
+				aspect_ratio *= 1.125f;
 			}
 			VGA_DrawLine=VGA_TEXT_Xlat16_Draw_Line;
 			bpp = 16;
@@ -1605,11 +1614,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	case M_HERC_GFX:
 		vga.draw.blocks=width*2;
 		width*=16;
-		aspect_ratio=((double)width/(double)height)*(3.0/4.0);
-		VGA_DrawLine=VGA_Draw_1BPP_Line;
+		aspect_ratio = (static_cast<float>(width) / static_cast<float>(height)) * (3.0f / 4.0f);
+		VGA_DrawLine = VGA_Draw_1BPP_Line;
 		break;
 	case M_TANDY2:
-		aspect_ratio=1.2;
+		aspect_ratio = 1.2f;
 		doubleheight=true;
 		if (machine==MCH_PCJR) doublewidth=(vga.tandy.gfx_control & 0x8)==0x00;
 		else doublewidth=(vga.tandy.mode_control & 0x10)==0;
@@ -1618,7 +1627,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		VGA_DrawLine = VGA_Draw_1BPP_Line;
 		break;
 	case M_TANDY4:
-		aspect_ratio=1.2;
+		aspect_ratio = 1.2f;
 		doubleheight=true;
 		if (machine==MCH_TANDY) doublewidth=(vga.tandy.mode_control & 0x10)==0;
 		else doublewidth=(vga.tandy.mode_control & 0x01)==0x00;
@@ -1630,7 +1639,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		else VGA_DrawLine=VGA_Draw_2BPP_Line;
 		break;
 	case M_TANDY16:
-		aspect_ratio=1.2;
+		aspect_ratio = 1.2f;
 		doubleheight=true;
 		vga.draw.blocks=width*2;
 		if (vga.tandy.mode_control & 0x1) {
@@ -1651,21 +1660,21 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		break;
 	case M_TANDY_TEXT:
 		doublewidth=(vga.tandy.mode_control & 0x1)==0;
-		aspect_ratio=1.2;
+		aspect_ratio = 1.2f;
 		doubleheight=true;
 		vga.draw.blocks=width;
 		width<<=3;
 		VGA_DrawLine=VGA_TEXT_Draw_Line;
 		break;
 	case M_CGA_TEXT_COMPOSITE:
-		aspect_ratio = 1.2;
+		aspect_ratio = 1.2f;
 		doubleheight = true;
 		vga.draw.blocks = width;
 		width <<= (((vga.tandy.mode_control & 0x1) != 0) ? 3 : 4);
 		VGA_DrawLine = VGA_CGA_TEXT_Composite_Draw_Line;
 		break;
 	case M_HERC_TEXT:
-		aspect_ratio=((double)480)/((double)350);
+		aspect_ratio = 480.0f / 350.0f;
 		vga.draw.blocks=width;
 		width<<=3;
 		VGA_DrawLine=VGA_TEXT_Herc_Draw_Line;
@@ -1705,15 +1714,15 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	   Cheap hack to just make all > 640x480 modes have square pixels
 	*/
 	if ( width >= 640 && height >= 480 ) {
-		aspect_ratio = 1.0;//((float)width / (float)height) * ( 3.0 / 4.0);
+		aspect_ratio = 1.0f;
 	}
 //	LOG_MSG("ht %d vt %d ratio %f", htotal, vtotal, aspect_ratio );
 
 	bool fps_changed = false;
 	// need to change the vertical timing?
-	if (fabs(vga.draw.delay.vtotal - 1000.0 / fps) > 0.0001) {
+	if (fabsf(vga.draw.delay.vtotal - 1000.0f / fps) > 0.0001f) {
 		fps_changed = true;
-		vga.draw.delay.vtotal = 1000.0 / fps;
+		vga.draw.delay.vtotal = 1000.0f / fps;
 		VGA_KillDrawing();
 		PIC_RemoveEvents(VGA_Other_VertInterrupt);
 		PIC_RemoveEvents(VGA_VerticalTimer);
@@ -1723,24 +1732,24 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	}
 
 #if C_DEBUG
-	LOG(LOG_VGA,LOG_NORMAL)("h total %2.5f (%3.2fkHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
-		vga.draw.delay.htotal,(1.0/vga.draw.delay.htotal),
-		vga.draw.delay.hblkstart,vga.draw.delay.hblkend,
-		vga.draw.delay.hrstart,vga.draw.delay.hrend);
-	LOG(LOG_VGA,LOG_NORMAL)("v total %2.5f (%3.2fHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
-		vga.draw.delay.vtotal,(1000.0/vga.draw.delay.vtotal),
-		vga.draw.delay.vblkstart,vga.draw.delay.vblkend,
-		vga.draw.delay.vrstart,vga.draw.delay.vrend);
+	LOG(LOG_VGA, LOG_NORMAL)
+	("h total %2.5f (%3.2fkHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
+	 vga.draw.delay.htotal, (1.0f / vga.draw.delay.htotal),
+	 vga.draw.delay.hblkstart, vga.draw.delay.hblkend,
+	 vga.draw.delay.hrstart, vga.draw.delay.hrend);
+	LOG(LOG_VGA, LOG_NORMAL)
+	("v total %2.5f (%3.2fHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
+	 vga.draw.delay.vtotal, (1000.0f / vga.draw.delay.vtotal),
+	 vga.draw.delay.vblkstart, vga.draw.delay.vblkend,
+	 vga.draw.delay.vrstart, vga.draw.delay.vrend);
 #endif
 
 	// need to resize the output window?
-	if ((width != vga.draw.width) ||
-		(height != vga.draw.height) ||
-		(vga.draw.doublewidth != doublewidth) ||
-		(vga.draw.doubleheight != doubleheight) ||
-		(fabs(aspect_ratio - vga.draw.aspect_ratio) > 0.0001) ||
-		(vga.draw.bpp != bpp) || fps_changed) {
-
+	if ((width != vga.draw.width) || (height != vga.draw.height) ||
+	    (vga.draw.doublewidth != doublewidth) ||
+	    (vga.draw.doubleheight != doubleheight) ||
+	    (fabsf(aspect_ratio - vga.draw.aspect_ratio) > 0.0001f) ||
+	    (vga.draw.bpp != bpp) || fps_changed) {
 		VGA_KillDrawing();
 
 		vga.draw.width = width;
@@ -1752,12 +1761,14 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		if (doubleheight) vga.draw.lines_scaled=2;
 		else vga.draw.lines_scaled=1;
 #if C_DEBUG
-		LOG(LOG_VGA,LOG_NORMAL)("Width %d, Height %d, fps %f",width,height,fps);
-		LOG(LOG_VGA,LOG_NORMAL)("%s width, %s height aspect %f",
-			doublewidth ? "double":"normal",doubleheight ? "double":"normal",aspect_ratio);
+		LOG(LOG_VGA, LOG_NORMAL)("Width %d, Height %d, fps %f", width, height, static_cast<double>(fps));
+		LOG(LOG_VGA, LOG_NORMAL)("%s width, %s height aspect %f", 
+		                         doublewidth ? "double" : "normal", doubleheight ? "double" : "normal",
+		                         static_cast<double>(aspect_ratio));
 #endif
 		if (!vga.draw.vga_override)
-			RENDER_SetSize(width, height, bpp, (float)fps, aspect_ratio,
+			RENDER_SetSize(width, height, bpp, fps,
+			               static_cast<double>(aspect_ratio),
 			               doublewidth, doubleheight);
 	}
 }

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -31,7 +31,7 @@ Bitu vga_read_p3d5(Bitu port,Bitu iolen);
 
 Bitu vga_read_p3da(Bitu /*port*/,Bitu /*iolen*/) {
 	Bit8u retval=4;	// bit 2 set, needed by Blues Brothers
-	double timeInFrame = PIC_FullIndex()-vga.draw.delay.framestart;
+	const auto timeInFrame = PIC_FullIndex() - vga.draw.delay.framestart;
 
 	vga.internal.attrindex=false;
 	vga.tandy.pcjr_flipflop=false;
@@ -46,7 +46,7 @@ Bitu vga_read_p3da(Bitu /*port*/,Bitu /*iolen*/) {
 	if (timeInFrame >= vga.draw.delay.vdend) {
 		retval |= 1;
 	} else {
-		double timeInLine=fmod(timeInFrame,vga.draw.delay.htotal);
+		const auto timeInLine = fmodf(timeInFrame, vga.draw.delay.htotal);
 		if (timeInLine >= vga.draw.delay.hblkstart && 
 			timeInLine <= vga.draw.delay.hblkend) {
 			retval |= 1;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -186,14 +186,14 @@ static void write_lightpen(Bitu port, uint8_t /*val*/, Bitu)
 		if (!vga.other.lightpen_triggered) {
 			vga.other.lightpen_triggered = true; // TODO: this shows at port 3ba/3da bit 1
 
-			double timeInFrame = PIC_FullIndex()-vga.draw.delay.framestart;
-			double timeInLine = fmod(timeInFrame,vga.draw.delay.htotal);
+			const auto timeInFrame = PIC_FullIndex() - vga.draw.delay.framestart;
+			const auto timeInLine = fmodf(timeInFrame, vga.draw.delay.htotal);
 			Bitu current_scanline = (Bitu)(timeInFrame / vga.draw.delay.htotal);
 
 			vga.other.lightpen = (Bit16u)((vga.draw.address_add/2) * (current_scanline/2));
 			vga.other.lightpen +=
-			        (Bit16u)((timeInLine / vga.draw.delay.hdend) *
-			                 ((double)(vga.draw.address_add / 2)));
+			        static_cast<uint16_t>((timeInLine / vga.draw.delay.hdend) *
+			                 (static_cast<float>(vga.draw.address_add / 2)));
 		}
 		break;
 	}
@@ -1087,14 +1087,14 @@ uint8_t read_herc_status(Bitu /*port*/, uint8_t /*iolen*/)
 	//			111: Unknown clone
 	//       7  Vertical sync inverted
 
-	double timeInFrame = PIC_FullIndex()-vga.draw.delay.framestart;
+	const auto timeInFrame = PIC_FullIndex() - vga.draw.delay.framestart;
 	uint8_t retval = 0x72; // Hercules ident; from a working card (Winbond
 	                       // W86855AF) Another known working card has 0x76
 	                       // ("KeysoGood", full-length)
 	if (timeInFrame < vga.draw.delay.vrstart || timeInFrame > vga.draw.delay.vrend)
 		retval |= 0x80;
 
-	double timeInLine=fmod(timeInFrame,vga.draw.delay.htotal);
+	const auto timeInLine = fmodf(timeInFrame, vga.draw.delay.htotal);
 	if (timeInLine >= vga.draw.delay.hrstart &&
 		timeInLine <= vga.draw.delay.hrend) retval |= 0x1;
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -174,10 +174,10 @@ static void Tandy_SetupTransfer(PhysPt bufpt,bool isplayback) {
 	IO_Write(tandy_dma*2,(Bit8u)(bufpt&0xff));
 	IO_Write(tandy_dma*2,(Bit8u)((bufpt>>8)&0xff));
 	switch (tandy_dma) {
-		case 0: IO_Write(0x87,bufpage); break;
-		case 1: IO_Write(0x83,bufpage); break;
-		case 2: IO_Write(0x81,bufpage); break;
-		case 3: IO_Write(0x82,bufpage); break;
+	case 0: IO_Write(0x87, bufpage); break;
+	case 1: IO_Write(0x83, bufpage); break;
+	case 2: IO_Write(0x81, bufpage); break;
+	case 3: IO_Write(0x82, bufpage); break;
 	}
 	real_writeb(0x40,0xd4,bufpage);
 
@@ -270,7 +270,7 @@ static Bitu IRQ_TandyDAC(void) {
 static void TandyDAC_Handler(Bit8u tfunction) {
 	if ((!tandy_sb.port) && (!tandy_dac.port)) return;
 	switch (tfunction) {
-	case 0x81:	/* Tandy sound system check */
+	case 0x81: /* Tandy sound system check */
 		if (tandy_dac.port) {
 			reg_ax=tandy_dac.port;
 		} else {
@@ -315,15 +315,15 @@ static void TandyDAC_Handler(Bit8u tfunction) {
 
 static Bitu INT1A_Handler(void) {
 	switch (reg_ah) {
-	case 0x00:	/* Get System time */
-		{
-			Bit32u ticks=mem_readd(BIOS_TIMER);
-			reg_al=mem_readb(BIOS_24_HOURS_FLAG);
-			mem_writeb(BIOS_24_HOURS_FLAG,0); // reset the "flag"
-			reg_cx=(Bit16u)(ticks >> 16);
-			reg_dx=(Bit16u)(ticks & 0xffff);
-			break;
-		}
+	case 0x00: /* Get System time */
+	{
+		Bit32u ticks = mem_readd(BIOS_TIMER);
+		reg_al = mem_readb(BIOS_24_HOURS_FLAG);
+		mem_writeb(BIOS_24_HOURS_FLAG, 0); // reset the "flag"
+		reg_cx = (Bit16u)(ticks >> 16);
+		reg_dx = (Bit16u)(ticks & 0xffff);
+		break;
+	}
 	case 0x01:	/* Set System time */
 		mem_writed(BIOS_TIMER,(reg_cx<<16)|reg_dx);
 		break;
@@ -362,45 +362,49 @@ static Bitu INT1A_Handler(void) {
 		LOG(LOG_BIOS,LOG_WARN)("INT1A:PCI bios call %2X",reg_al);
 #if defined(PCI_FUNCTIONALITY_ENABLED)
 		switch (reg_al) {
-			case 0x01:	// installation check
-				if (PCI_IsInitialized()) {
-					reg_ah=0x00;
-					reg_al=0x01;	// cfg space mechanism 1 supported
-					reg_bx=0x0210;	// ver 2.10
-					reg_cx=0x0000;	// only one PCI bus
-					reg_edx=0x20494350;
-					reg_edi=PCI_GetPModeInterface();
-					CALLBACK_SCF(false);
-				} else {
-					CALLBACK_SCF(true);
-				}
-				break;
-			case 0x02: {	// find device
-				Bitu devnr=0;
-				Bitu count=0x100;
-				Bit32u devicetag=(reg_cx<<16)|reg_dx;
-				Bits found=-1;
-				for (Bitu i=0; i<=count; i++) {
-					IO_WriteD(0xcf8,0x80000000|(i<<8));	// query unique device/subdevice entries
-					if (IO_ReadD(0xcfc)==devicetag) {
-						if (devnr==reg_si) {
-							found=i;
-							break;
-						} else {
-							// device found, but not the SIth device
-							devnr++;
-						}
+		case 0x01: // installation check
+			if (PCI_IsInitialized()) {
+				reg_ah = 0x00;
+				reg_al = 0x01; // cfg space mechanism 1 supported
+				reg_bx = 0x0210; // ver 2.10
+				reg_cx = 0x0000; // only one PCI bus
+				reg_edx = 0x20494350;
+				reg_edi = PCI_GetPModeInterface();
+				CALLBACK_SCF(false);
+			} else {
+				CALLBACK_SCF(true);
+			}
+			break;
+		case 0x02: { // find device
+			Bitu devnr = 0;
+			Bitu count = 0x100;
+			Bit32u devicetag = (reg_cx << 16) | reg_dx;
+			Bits found = -1;
+			for (Bitu i = 0; i <= count; i++) {
+				IO_WriteD(0xcf8, 0x80000000 | (i << 8)); // query
+				                                         // unique
+				                                         // device/subdevice
+				                                         // entries
+				if (IO_ReadD(0xcfc) == devicetag) {
+					if (devnr == reg_si) {
+						found = i;
+						break;
+					} else {
+						// device found, but not the
+						// SIth device
+						devnr++;
 					}
 				}
-				if (found>=0) {
-					reg_ah=0x00;
-					reg_bh=0x00;	// bus 0
-					reg_bl=(Bit8u)(found&0xff);
-					CALLBACK_SCF(false);
-				} else {
-					reg_ah=0x86;	// device not found
-					CALLBACK_SCF(true);
-				}
+			}
+			if (found >= 0) {
+				reg_ah = 0x00;
+				reg_bh = 0x00; // bus 0
+				reg_bl = (Bit8u)(found & 0xff);
+				CALLBACK_SCF(false);
+			} else {
+				reg_ah = 0x86; // device not found
+				CALLBACK_SCF(true);
+			}
 				}
 				break;
 			case 0x03: {	// find device by class code
@@ -469,7 +473,7 @@ static Bitu INT1A_Handler(void) {
 					reg_ax,reg_bx,reg_cx,reg_dx);
 				CALLBACK_SCF(true);
 				break;
-		}
+		        }
 #else
 		CALLBACK_SCF(true);
 #endif
@@ -584,8 +588,8 @@ static Bitu INT12_Handler(void) {
 
 static Bitu INT17_Handler(void) {
 	LOG(LOG_BIOS,LOG_NORMAL)("INT17:Function %X",reg_ah);
-	switch(reg_ah) {
-	case 0x00:		/* PRINTER: Write Character */
+	switch (reg_ah) {
+	case 0x00:              /* PRINTER: Write Character */
 		reg_ah=1;	/* Report a timeout */
 		break;
 	case 0x01:		/* PRINTER: Initialize port */
@@ -622,8 +626,8 @@ static Bitu INT14_Handler(void) {
 		LOG(LOG_BIOS,LOG_NORMAL)("BIOS INT14: port %d does not exist.",reg_dx);
 		return CBRET_NONE;
 	}
-	switch (reg_ah)	{
-	case 0x00:	{
+	switch (reg_ah) {
+	case 0x00: {
 		// Initialize port
 		// Parameters:				Return:
 		// AL: port parameters		AL: modem status
@@ -714,7 +718,6 @@ static Bitu INT14_Handler(void) {
 		reg_al=(Bit8u)(IO_ReadB(port+6)&0xff);
 		CALLBACK_SCF(false);
 		break;
-
 	}
 	return CBRET_NONE;
 }
@@ -722,7 +725,7 @@ static Bitu INT14_Handler(void) {
 static Bitu INT15_Handler(void) {
 	static Bit16u biosConfigSeg=0;
 	switch (reg_ah) {
-	case 0x24:		//A20 stuff
+	case 0x24: // A20 stuff
 		switch (reg_al) {
 		case 0:	//Disable a20
 			MEM_A20_Enable(false);
@@ -940,7 +943,7 @@ static Bitu INT15_Handler(void) {
 		break;
 	case 0xc2:	/* BIOS PS2 Pointing Device Support */
 		switch (reg_al) {
-		case 0x00:		// enable/disable
+		case 0x00:                      // enable/disable
 			if (reg_bh==0) {	// disable
 				Mouse_SetPS2State(false);
 				reg_ah=0;

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -195,7 +195,8 @@ Bitu PS2_Handler(void) {
 #define MOUSE_MIDDLE_RELEASED 64
 #define MOUSE_DELAY 5.0
 
-void MOUSE_Limit_Events(Bitu /*val*/) {
+void MOUSE_Limit_Events(uint32_t /*val*/)
+{
 	mouse.timer_in_progress = false;
 	if (mouse.events) {
 		mouse.timer_in_progress = true;


### PR DESCRIPTION
`Bitu` is an architecture-specific type that's sized large enough to store a pointer, which on 32-bit systems is a 32-bit type and similarly is a 64-bit type on 64-bit systems. `Bitu` is perfect for storing memory addresses as integers, and converting to an from emulated pointers to host-pointers.

`Bitu` became heavily used throughout the the code to store more than pointers and addresses.  It's used to hold counters, data values, bit fields, and so on. This is despite the fact that DOS isn't a 64-bit OS, and its data-types and interfaces were never 64-bits in size. Likewise, devices that are emulated also didn't use internal 64-bit counters/bit-fields/ and so on.

Why do we care?

This isn't much of a problem when compiling on 32-bit platforms (the default build target for DOSBox upstream), because these `Bitu`s become `uint32_t`s.  So passing a `Bitu` into a function's explicit `uint32_t` argument is no problem.

However, on 64-bit systems, these `Bitu`s balloon to 64-bits, and therefore compilers like MSVC report loss of precision or truncation when passing them into 32-bit arguments or assigning them into 32-bit types. Evidence of this can be seen in the Windows warnings counts: The 272 warning on 32-bit, which swells to over 1,000 on 64-bit.

Is changing this risky?

Fortunately we have proof from 32-bit platforms these `Bitu` values never need to store content greater than 32-bits - otherwise those builds would fail.

So provided we don't touch the code that operates on memory addresses, we already know that these general counters and data types can be safely set to uint32_t.