### PR TITLE
Fix two Coverity issues in VGA draw

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1621,7 +1621,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	case M_HERC_GFX:
 		vga.draw.blocks=width*2;
 		width*=16;
-		aspect_ratio = (static_cast<double>(width) / static_cast<double>(height)) *
+		assert(width > 0);
+		assert(height > 0);
+		aspect_ratio = (static_cast<double>(width) /
+		                static_cast<double>(height)) *
 		               (3.0 / 4.0);
 		VGA_DrawLine = VGA_Draw_1BPP_Line;
 		break;


### PR DESCRIPTION
Neither are problems; however these were newly detected by Coverity, and they can be addressed easily enough.

```text
________________________________________________________________________________________________________
*** CID 333409:  Incorrect expression  (DIVIDE_BY_ZERO)
/src/hardware/vga_draw.cpp: 1617 in VGA_SetupDrawing(unsigned int)()
1611                            VGA_DrawLine=VGA_TEXT_Draw_Line;
1612                    }
1613                    break;
1614            case M_HERC_GFX:
1615                    vga.draw.blocks=width*2;
1616                    width*=16;
>>>     CID 333409:  Incorrect expression  (DIVIDE_BY_ZERO)
>>>     In expression "static_cast<float>(width) / static_cast<float>(height)", division by expression "height" which may be zero has undefined behavior.
1617                    aspect_ratio = (static_cast<float>(width) / static_cast<float>(height)) * (3.0f / 4.0f);
1618                    VGA_DrawLine = VGA_Draw_1BPP_Line;
1619                    break;
1620            case M_TANDY2:
1621                    aspect_ratio = 1.2f;
1622                    doubleheight=true;

** CID 333408:  Incorrect expression  (COPY_PASTE_ERROR)
/src/hardware/vga_draw.cpp: 1624 in VGA_SetupDrawing(unsigned int)()


________________________________________________________________________________________________________
*** CID 333408:  Incorrect expression  (COPY_PASTE_ERROR)
/src/hardware/vga_draw.cpp: 1624 in VGA_SetupDrawing(unsigned int)()
1618                    VGA_DrawLine = VGA_Draw_1BPP_Line;
1619                    break;
1620            case M_TANDY2:
1621                    aspect_ratio = 1.2f;
1622                    doubleheight=true;
1623                    if (machine==MCH_PCJR) doublewidth=(vga.tandy.gfx_control & 0x8)==0x00;
>>>     CID 333408:  Incorrect expression  (COPY_PASTE_ERROR)
>>>     "mode_control" in "vga.tandy.mode_control" looks like a copy-paste error.
1624                    else doublewidth=(vga.tandy.mode_control & 0x10)==0;
1625                    vga.draw.blocks = width * (doublewidth ? 1 : 2);
1626                    width = vga.draw.blocks * 8;
1627                    VGA_DrawLine = VGA_Draw_1BPP_Line;
1628                    break;
1629            case M_TANDY4:
```

The branch was pushed through Coverity and confirmed to fix them:

``` text
---

 Build ID: 400919
    Analysis Summary:
       New defects found: 0
       Defects eliminated: 2
```
