### PR TITLE
Use `vcpkg` from its repository

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,11 +40,16 @@ jobs:
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          rm -R c:\vcpkg
-          mv c:\vcpkg-bak c:\vcpkg
+          c:
+          cd \
+          rm -R vcpkg
+          git clone https://github.com/Microsoft/vcpkg.git
+          cd vcpkg
+          git checkout 4b317d797e0fb3ca0cfa1b47f2c6741284fe5f5c
+          .\bootstrap-vcpkg.bat
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
-          rm -R c:\vcpkg\buildtrees\fluidsynth\src\*.clean\sf2
+          rm -R buildtrees\fluidsynth\src\*.clean\sf2
 
       - name:  Integrate packages
         shell: pwsh


### PR DESCRIPTION
Last week a bug was introduced in vcpkg that[ prevented it from building `gettext`](https://github.com/microsoft/vcpkg/issues/18270), an indirect dependency of Staging by way of `glib`, which FluidSynth depends on.

The vcpkg team is working on a PR to fix it: https://github.com/microsoft/vcpkg/pull/19361.

Because this is impacting innumerable Windows build chains, we expect the vcpkg team to merge their fix shortly.  However, because GitHub's VM team takes weekly snapshots of vcpkg, our CI workflows won't actually benefit from the gettext fix until sometime Sunday or Monday, which is when GitHub will update their VM images.

In the meantime, we can use vcpkg directly from its repository (with this PR) as soon as they merge the fix for `gettext`.

(Parking this as a draft for now)