### PR TITLE
Fix timing regression and expand use of doubles for timing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Denable_debugger=normal
-            max_warnings: 78
+            max_warnings: 77
 
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
@@ -55,7 +55,7 @@ jobs:
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 114
+            max_warnings: 113
 
           - name: GCC, -network
             os: ubuntu-20.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 177
+            max_warnings: 179
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 327
+          MAX_BUGS: 317
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
             max_warnings: 272
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1902
+            max_warnings: 1896
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -156,16 +156,16 @@ void MIXER_DelChannel(MixerChannel* delchan);
  * and removes itself when destroyed. */
 class MixerObject{
 private:
-	bool installed;
-	char m_name[32];
+	bool installed = false;
+	char m_name[32] = "";
+
 public:
-	MixerObject() : installed(false) {}
 	MixerChannel* Install(MIXER_Handler handler,Bitu freq,const char * name);
 	~MixerObject();
 };
 
 /* PC Speakers functions, tightly related to the timer functions */
-void PCSPEAKER_SetCounter(Bitu cntr,Bitu mode);
-void PCSPEAKER_SetType(Bitu mode);
+void PCSPEAKER_SetCounter(uint32_t cntr, uint32_t mode);
+void PCSPEAKER_SetType(uint32_t mode);
 
 #endif

--- a/include/pic.h
+++ b/include/pic.h
@@ -19,6 +19,9 @@
 #ifndef DOSBOX_PIC_H
 #define DOSBOX_PIC_H
 
+#include <cassert>
+#include <cmath>
+#include <cstdint>
 
 /* CPU Cycle Timing */
 extern int32_t CPU_Cycles;
@@ -35,27 +38,28 @@ extern uint32_t PIC_IRQCheck;
 extern uint32_t PIC_Ticks;
 
 // The number of cycles not done yet (ND)
-static INLINE int32_t PIC_TickIndexND()
+static inline int32_t PIC_TickIndexND()
 {
 	return CPU_CycleMax - CPU_CycleLeft - CPU_Cycles;
 }
 
 // Returns the percent cycles completed within the current "millisecond tick" of
 // the CPU
-static INLINE float PIC_TickIndex()
+static inline double PIC_TickIndex()
 {
-	return static_cast<float>(PIC_TickIndexND()) /
-	       static_cast<float>(CPU_CycleMax);
+	return static_cast<double>(PIC_TickIndexND()) / static_cast<double>(CPU_CycleMax);
 }
 
-static INLINE int32_t PIC_MakeCycles(float amount)
+static inline int32_t PIC_MakeCycles(double amount)
 {
-	return static_cast<int32_t>(static_cast<float>(CPU_CycleMax) * amount);
+	const auto cycles = static_cast<double>(CPU_CycleMax) * amount;
+	assert(cycles >= INT32_MIN && cycles <= INT32_MAX);
+	return static_cast<int32_t>(cycles);
 }
 
-static INLINE float PIC_FullIndex()
+static inline double PIC_FullIndex()
 {
-	return static_cast<float>(PIC_Ticks) + PIC_TickIndex();
+	return static_cast<double>(PIC_Ticks) + PIC_TickIndex();
 }
 
 void PIC_ActivateIRQ(uint8_t irq);
@@ -65,7 +69,7 @@ void PIC_runIRQs();
 bool PIC_RunQueue();
 
 //Delay in milliseconds
-void PIC_AddEvent(PIC_EventHandler handler, float delay, uint32_t val = 0);
+void PIC_AddEvent(PIC_EventHandler handler, double delay, uint32_t val = 0);
 void PIC_RemoveEvents(PIC_EventHandler handler);
 void PIC_RemoveSpecificEvents(PIC_EventHandler handler, uint32_t val);
 

--- a/include/render.h
+++ b/include/render.h
@@ -55,7 +55,7 @@ typedef struct {
 		unsigned bpp;
 		bool dblw,dblh;
 		double ratio;
-		float fps;
+		double fps;
 	} src;
 	struct {
 		int count;
@@ -93,8 +93,13 @@ typedef struct {
 
 extern Render_t render;
 extern ScalerLineHandler_t RENDER_DrawLine;
-void RENDER_SetSize(Bitu width, Bitu height, unsigned bpp, float fps,
-                    double ratio, bool dblw, bool dblh);
+void RENDER_SetSize(Bitu width,
+                    Bitu height,
+                    unsigned bpp,
+                    double fps,
+                    double ratio,
+                    bool dblw,
+                    bool dblh);
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
 void RENDER_SetPal(Bit8u entry,Bit8u red,Bit8u green,Bit8u blue);

--- a/include/support.h
+++ b/include/support.h
@@ -74,8 +74,9 @@ T to_finite(const std::string& input) {
 			result = static_cast<T>(interim);
 	}
 	// Capture expected exceptions stod may throw
-	catch (std::invalid_argument &e) {}
-	catch (std::out_of_range &e) {}
+	catch (MAYBE_UNUSED std::invalid_argument &e) {
+	} catch (MAYBE_UNUSED std::out_of_range &e) {
+	}
 	return result;
 }
 

--- a/include/timer.h
+++ b/include/timer.h
@@ -31,6 +31,14 @@
 
 constexpr int PIT_TICK_RATE = 1193182;
 
+// Short-hand unit conversions
+constexpr auto PIT_TICK_RATE_KHZ = static_cast<double>(PIT_TICK_RATE) / 1000.0;
+// The rate at which a repeating event occurs is the frequency, measured in Hertz.
+
+// The inverse of frequency is the time between events, called 'period'.
+// In this case, we want the period of every 1000 PIT tick events.
+constexpr auto PERIOD_OF_1K_PIT_TICKS = 1000.0 / static_cast<double>(PIT_TICK_RATE);
+
 typedef void (*TIMER_TickHandler)(void);
 
 /* Register a function that gets called every time if 1 or more ticks pass */

--- a/include/vga.h
+++ b/include/vga.h
@@ -148,17 +148,17 @@ typedef struct {
 	Bitu parts_left;
 	Bitu byte_panning_shift;
 	struct {
-		float framestart;
-		float vrstart, vrend;     // V-retrace
-		float hrstart, hrend;     // H-retrace
-		float hblkstart, hblkend; // H-blanking
-		float vblkstart, vblkend; // V-Blanking
-		float vdend, vtotal;
-		float hdend, htotal;
-		float parts;
+		double framestart;
+		double vrstart, vrend;     // V-retrace
+		double hrstart, hrend;     // H-retrace
+		double hblkstart, hblkend; // H-blanking
+		double vblkstart, vblkend; // V-Blanking
+		double vdend, vtotal;
+		double hdend, htotal;
+		double parts;
 	} delay;
 	Bitu bpp;
-	float aspect_ratio;
+	double aspect_ratio;
 	bool double_scan;
 	bool doublewidth,doubleheight;
 	Bit8u font[64*1024];

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -517,8 +517,10 @@ l_M_Ed:
 	case D_RDTSC: {
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW)
 			goto illegalopcode;
-		Bit64s tsc = (Bit64s)(PIC_FullIndex() * static_cast<float>(CPU_CycleAutoAdjust ? 70000 : CPU_CycleMax));
-		reg_edx = (Bit32u)(tsc >> 32);
+	        Bit64s tsc = (Bit64s)(PIC_FullIndex() *
+	                              static_cast<double>(
+	                                      CPU_CycleAutoAdjust ? 70000 : CPU_CycleMax));
+	        reg_edx = (Bit32u)(tsc >> 32);
 		reg_eax = (Bit32u)(tsc & 0xffffffff);
 		break;
 	}

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -230,8 +230,11 @@
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW)
 				goto illegal_opcode;
 			/* Use a fixed number when in auto cycles mode as else the reported value changes constantly */
-			Bit64s tsc = (Bit64s)(PIC_FullIndex() * static_cast<float>(CPU_CycleAutoAdjust ? 70000 : CPU_CycleMax));
-			reg_edx = (Bit32u)(tsc >> 32);
+	                Bit64s tsc = (Bit64s)(PIC_FullIndex() *
+	                                      static_cast<double>(CPU_CycleAutoAdjust
+	                                                                  ? 70000
+	                                                                  : CPU_CycleMax));
+	                reg_edx = (Bit32u)(tsc >> 32);
 			reg_eax = (Bit32u)(tsc & 0xffffffff);
 		}
 		break;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -220,12 +220,15 @@ void RENDER_EndUpdate( bool abort ) {
 			if (render.src.dblw) flags|=CAPTURE_FLAG_DBLW;
 			if (render.src.dblh) flags|=CAPTURE_FLAG_DBLH;
 		}
-		float fps = render.src.fps;
+		auto fps = render.src.fps;
 		pitch = render.scale.cachePitch;
-		if (render.frameskip.max)
-			fps /= 1+render.frameskip.max;
-		CAPTURE_AddImage( render.src.width, render.src.height, render.src.bpp, pitch,
-			flags, fps, (Bit8u *)&scalerSourceCache, (Bit8u*)&render.pal.rgb );
+		if (render.frameskip.max) {
+			const double fps_skip = 1 + render.frameskip.max;
+			fps /= fps_skip;
+		}
+		CAPTURE_AddImage(render.src.width, render.src.height, render.src.bpp,
+		                 pitch, flags, fps, (Bit8u *)&scalerSourceCache,
+		                 (Bit8u *)&render.pal.rgb);
 	}
 	if ( render.scale.outWrite ) {
 		GFX_EndUpdate( abort? NULL : Scaler_ChangedLines );
@@ -558,8 +561,13 @@ static void RENDER_CallBack( GFX_CallBackFunctions_t function ) {
 	}
 }
 
-void RENDER_SetSize(Bitu width, Bitu height, unsigned bpp, float fps,
-                    double ratio, bool dblw, bool dblh)
+void RENDER_SetSize(Bitu width,
+                    Bitu height,
+                    unsigned bpp,
+                    double fps,
+                    double ratio,
+                    bool dblw,
+                    bool dblh)
 {
 	RENDER_Halt( );
 	if (!width || !height || width > SCALER_MAXWIDTH || height > SCALER_MAXHEIGHT) {

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -903,12 +903,10 @@ Module::Module(Section *configuration)
 }
 
 Module::~Module() {
-	if ( capture ) {
-		delete capture;
-	}
-	if ( handler ) {
-		delete handler;
-	}
+	delete capture;
+	capture = nullptr;
+	delete handler;
+	handler = nullptr;
 }
 
 //Initialize static members

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -33,13 +33,13 @@ namespace Adlib {
 
 class Timer {
 	//Rounded down start time
-	float start;
+	double start;
 	//Time when you overflow
-	float trigger;
+	double trigger;
 	//Clock interval
-	float clockInterval;
+	double clockInterval;
 	//cycle interval
-	float counterInterval;
+	double counterInterval;
 	uint8_t counter;
 	bool enabled;
 	bool overflow;
@@ -47,10 +47,10 @@ class Timer {
 
 public:
 	Timer(int16_t micros)
-	        : start(0.0f),
-	          trigger(0.0f),
-	          clockInterval(micros * 0.001f), // interval in milliseconds
-	          counterInterval(0.0f),
+	        : start(0.0),
+	          trigger(0.0),
+	          clockInterval(micros * 0.001), // interval in milliseconds
+	          counterInterval(0.0),
 	          counter(0),
 	          enabled(false),
 	          overflow(false),
@@ -61,13 +61,13 @@ public:
 
 	//Update returns with true if overflow
 	//Properly syncs up the start/end to current time and changing intervals
-	bool Update(const float time)
+	bool Update(const double time)
 	{
 		if (enabled && (time >= trigger)) {
 			// How far into the next cycle
-			const float deltaTime = time - trigger;
+			const double deltaTime = time - trigger;
 			// Sync start to last cycle
-			const auto counterMod = fmodf(deltaTime, counterInterval);
+			const auto counterMod = fmod(deltaTime, counterInterval);
 			start = time - counterMod;
 			trigger = start + counterInterval;
 			//Only set the overflow flag when not masked
@@ -99,14 +99,14 @@ public:
 		enabled = false;
 	}
 
-	void Start(const float time)
+	void Start(const double time)
 	{
 		// Only properly start when not running before
 		if (!enabled) {
 			enabled = true;
 			overflow = false;
 			//Sync start to the last clock interval
-			const auto clockMod = fmodf(time, clockInterval);
+			const auto clockMod = fmod(time, clockInterval);
 			start = time - clockMod;
 			//Overflow trigger
 			trigger = start + counterInterval;

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -37,13 +37,13 @@ static struct {
 	struct {
 		bool enabled;
 		Bit8u div;
-		float delay;
+		double delay;
 		bool acknowledged;
 	} timer;
 	struct {
-		float timer;
-		float ended;
-		float alarm;
+		double timer;
+		double ended;
+		double alarm;
 	} last;
 	bool update_ended;
 } cmos;
@@ -63,12 +63,12 @@ static void cmos_timerevent(uint32_t /*val*/)
 static void cmos_checktimer(void) {
 	PIC_RemoveEvents(cmos_timerevent);
 	if (cmos.timer.div<=2) cmos.timer.div+=7;
-	cmos.timer.delay=(1000.0f/(32768.0f / (1 << (cmos.timer.div - 1))));
+	cmos.timer.delay = (1000.0 / (32768.0 / (1 << (cmos.timer.div - 1))));
 	if (!cmos.timer.div || !cmos.timer.enabled) return;
 	LOG(LOG_PIT,LOG_NORMAL)("RTC Timer at %.2f hz",1000.0/cmos.timer.delay);
 //	PIC_AddEvent(cmos_timerevent,cmos.timer.delay);
 	/* A rtc is always running */
-	const auto remd = fmodf(PIC_FullIndex(), cmos.timer.delay);
+	const auto remd = fmod(PIC_FullIndex(), cmos.timer.delay);
 	// Should be more like a real pc. Check
 	PIC_AddEvent(cmos_timerevent, cmos.timer.delay - remd);
 	// Status reg A reading with this (and with other delays actually)

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -37,8 +37,8 @@ enum DISNEY_STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 struct dac_channel {
 	uint8_t buffer[BUFFER_SAMPLES] = {};
 	uint8_t used = 0; // current data buffer level
-	float speedcheck_sum = 0;
-	float speedcheck_last = 0;
+	double speedcheck_sum = 0.0;
+	double speedcheck_last = 0.0;
 	bool speedcheck_failed = false;
 	bool speedcheck_init = false;
 };
@@ -368,8 +368,8 @@ static void DISNEY_CallBack(uint16_t len) {
 	}
 	if (disney.last_used+100<PIC_Ticks) {
 		// disable sound output
-		PIC_AddEvent(DISNEY_disable,0.0001f);	// I think we shouldn't delete the 
-												// mixer while we are inside it
+		PIC_AddEvent(DISNEY_disable, 0.0001); // I think we shouldn't delete the
+		                                      // mixer while we are inside it
 	}
 }
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -53,7 +53,7 @@ constexpr uint32_t RAM_SIZE = 1024 * 1024;        // 1 MiB
 constexpr uint32_t BYTES_PER_DMA_XFER = 8 * 1024;         // 8 KiB per transfer
 constexpr uint32_t ISA_BUS_THROUGHPUT = 32 * 1024 * 1024; // 32 MiB/s
 constexpr uint16_t DMA_TRANSFERS_PER_S = ISA_BUS_THROUGHPUT / BYTES_PER_DMA_XFER;
-constexpr float MS_PER_DMA_XFER = 1000.0f / DMA_TRANSFERS_PER_S;
+constexpr double MS_PER_DMA_XFER = 1000.0 / DMA_TRANSFERS_PER_S;
 
 // Voice-channel and state related constants
 constexpr uint8_t MAX_VOICES = 32u;
@@ -73,8 +73,8 @@ constexpr uint8_t PAN_DEFAULT_POSITION = 7u;
 constexpr uint8_t PAN_POSITIONS = 16u;  // 0: -45-deg, 7: centre, 15: +45-deg
 
 // Timer delay constants
-constexpr float TIMER_1_DEFAULT_DELAY = 0.080f;
-constexpr float TIMER_2_DEFAULT_DELAY = 0.320f;
+constexpr double TIMER_1_DEFAULT_DELAY = 0.080;
+constexpr double TIMER_2_DEFAULT_DELAY = 0.320;
 
 // Volume scaling and dampening constants
 constexpr auto DELTA_DB = 0.002709201;     // 0.0235 dB increments
@@ -209,7 +209,7 @@ public:
 	void PrintStats();
 
 	struct Timer {
-		float delay = 0.0f;
+		double delay = 0.0;
 		uint8_t value = 0xff;
 		bool has_expired = true;
 		bool is_counting_down = false;
@@ -415,7 +415,7 @@ float Voice::GetSample(const ram_array_t &ram) noexcept
 		const auto next_addr = addr + 1;
 		const float next_sample = Is8Bit() ? Read8BitSample(ram, next_addr)
 		                                   : Read16BitSample(ram, next_addr);
-		constexpr float WAVE_WIDTH_INV = 1.0f / WAVE_WIDTH;
+		constexpr float WAVE_WIDTH_INV = 1.0 / WAVE_WIDTH;
 		sample += (next_sample - sample) *
 		          static_cast<float>(fraction) * WAVE_WIDTH_INV;
 	}
@@ -848,7 +848,7 @@ void Gus::PopulateVolScalars() noexcept
 		*(--volume) = static_cast<float>(scalar);
 		scalar /= VOLUME_LEVEL_DIVISOR;
 	}
-	vol_scalars.front() = 0.0f;
+	vol_scalars.front() = 0.0;
 }
 
 /*

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -26,7 +26,7 @@
 #include "timer.h"
 
 #define KEYBUFSIZE 32
-#define KEYDELAY 0.300f			//Considering 20-30 khz serial clock and 11 bits/char
+#define KEYDELAY   0.300 // Considering 20-30 khz serial clock and 11 bits/char
 
 enum KeyCommands {
 	CMD_NONE,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -623,9 +623,9 @@ void MixerChannel::FillUp()
 {
 	if (!is_enabled || done < mixer.done)
 		return;
-	float index = PIC_TickIndex();
+	const auto index = PIC_TickIndex();
 	MIXER_LockAudioDevice();
-	Mix((Bitu)(index * mixer.needed));
+	Mix((Bitu)(index * static_cast<double>(mixer.needed)));
 	MIXER_UnlockAudioDevice();
 }
 

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -79,7 +79,7 @@ static struct {
 	uint32_t min_tr = 0u;
 	uint32_t used = 0u;
 	double pit_last = 0.0;
-	double pit_max = (1000.0 / PIT_TICK_RATE) * 1320.0;
+	double pit_max = PERIOD_OF_1K_PIT_TICKS * 1320.0;
 	double pit_half = pit_max / 2.0;
 	double pit_new_max = pit_max;
 	double pit_new_half = pit_half;
@@ -286,8 +286,8 @@ void PCSPEAKER_SetCounter(uint32_t cntr, uint32_t mode)
 		spkr.pit_index=0;
 		spkr.pit_last = AMPLITUDE_NEGATIVE;
 		AddDelayEntry(newindex, spkr.pit_last);
-		spkr.pit_half = (1000.0 / PIT_TICK_RATE) * 1;
-		spkr.pit_max = (1000.0 / PIT_TICK_RATE) * cntr;
+		spkr.pit_half = PERIOD_OF_1K_PIT_TICKS * 1;
+		spkr.pit_max = PERIOD_OF_1K_PIT_TICKS * cntr;
 		break;
 	case 3:		/* Square wave generator */
 		if (cntr==0 || cntr<spkr.min_tr) {
@@ -296,14 +296,14 @@ void PCSPEAKER_SetCounter(uint32_t cntr, uint32_t mode)
 			spkr.pit_mode=0;
 			return;
 		}
-		spkr.pit_new_max = (1000.0 / PIT_TICK_RATE) * cntr;
+		spkr.pit_new_max = PERIOD_OF_1K_PIT_TICKS * cntr;
 		spkr.pit_new_half=spkr.pit_new_max/2;
 		break;
 	case 4:		/* Software triggered strobe */
 		spkr.pit_last = AMPLITUDE_POSITIVE;
 		AddDelayEntry(newindex,spkr.pit_last);
 		spkr.pit_index=0;
-		spkr.pit_max = (1000.0 / PIT_TICK_RATE) * cntr;
+		spkr.pit_max = PERIOD_OF_1K_PIT_TICKS * cntr;
 		break;
 	default:
 #if C_DEBUG

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -228,7 +228,7 @@ static void Serial_EventHandler(uint32_t val)
 
 void CSerial::setEvent(uint16_t type, float duration)
 {
-	PIC_AddEvent(Serial_EventHandler, duration,
+	PIC_AddEvent(Serial_EventHandler, static_cast<double>(duration),
 	             static_cast<Bitu>((type << 2) | port_index));
 }
 
@@ -1210,7 +1210,7 @@ CSerial::~CSerial() {
 	}
 }
 
-static bool idle(const float start, const uint32_t timeout)
+static bool idle(const double start, const uint32_t timeout)
 {
 	CALLBACK_Idle();
 	return PIC_FullIndex() - start > timeout;
@@ -1358,7 +1358,7 @@ public:
 	}
 };
 
-static SERIALPORTS *testSerialPortsBaseclass;
+static SERIALPORTS *testSerialPortsBaseclass = nullptr;
 
 void SERIAL_Destroy(Section *sec)
 {
@@ -1368,8 +1368,7 @@ void SERIAL_Destroy(Section *sec)
 }
 
 void SERIAL_Init (Section * sec) {
-	// should never happen
-	if (testSerialPortsBaseclass) delete testSerialPortsBaseclass;
+	delete testSerialPortsBaseclass;
 	testSerialPortsBaseclass = new SERIALPORTS (sec);
 	sec->AddDestroyFunction (&SERIAL_Destroy, true);
 }

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -827,11 +827,11 @@ void CSerialModem::Timer2() {
 	// Check for eventual break command
 	if (!commandmode) {
 		cmdpause++;
-		if (cmdpause > (20 * reg[MREG_GUARD_TIME])) {
+		const auto guard_threashold = static_cast<uint32_t>(20 * reg[MREG_GUARD_TIME]);
+		if (cmdpause > guard_threashold) {
 			if (plusinc == 0) {
 				plusinc = 1;
-			}
-			else if (plusinc == 4) {
+			} else if (plusinc == 4) {
 				LOG_MSG("SERIAL: Port %" PRIu8 " modem entering "
 				        "command mode (escape sequence).",
 				        GetPortNumber());

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -257,8 +257,8 @@ protected:
 
 	struct {
 		bool active = false;
-		double f1 = 0.0f;
-		double f2 = 0.0f;
+		double f1 = 0.0;
+		double f2 = 0.0;
 		uint32_t len = 0;
 		uint32_t pos = 0;
 		char str[256] = {0};

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -93,7 +93,8 @@ void VGA_StartResize(Bitu delay /*=50*/) {
 		if (vga.mode==M_ERROR) delay = 5;
 		/* Start a resize after delay (default 50 ms) */
 		if (delay==0) VGA_SetupDrawing(0);
-		else PIC_AddEvent(VGA_SetupDrawing,(float)delay);
+		else
+			PIC_AddEvent(VGA_SetupDrawing, (double)delay);
 	}
 }
 

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -46,7 +46,7 @@ Bitu vga_read_p3da(Bitu /*port*/,Bitu /*iolen*/) {
 	if (timeInFrame >= vga.draw.delay.vdend) {
 		retval |= 1;
 	} else {
-		const auto timeInLine = fmodf(timeInFrame, vga.draw.delay.htotal);
+		const auto timeInLine = fmod(timeInFrame, vga.draw.delay.htotal);
 		if (timeInLine >= vga.draw.delay.hblkstart && 
 			timeInLine <= vga.draw.delay.hblkend) {
 			retval |= 1;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -187,13 +187,13 @@ static void write_lightpen(Bitu port, uint8_t /*val*/, Bitu)
 			vga.other.lightpen_triggered = true; // TODO: this shows at port 3ba/3da bit 1
 
 			const auto timeInFrame = PIC_FullIndex() - vga.draw.delay.framestart;
-			const auto timeInLine = fmodf(timeInFrame, vga.draw.delay.htotal);
+			const auto timeInLine = fmod(timeInFrame, vga.draw.delay.htotal);
 			Bitu current_scanline = (Bitu)(timeInFrame / vga.draw.delay.htotal);
 
 			vga.other.lightpen = (Bit16u)((vga.draw.address_add/2) * (current_scanline/2));
-			vga.other.lightpen +=
-			        static_cast<uint16_t>((timeInLine / vga.draw.delay.hdend) *
-			                 (static_cast<float>(vga.draw.address_add / 2)));
+			vga.other.lightpen += static_cast<uint16_t>(
+			        (timeInLine / vga.draw.delay.hdend) *
+			        (static_cast<double>(vga.draw.address_add / 2)));
 		}
 		break;
 	}
@@ -1094,7 +1094,7 @@ uint8_t read_herc_status(Bitu /*port*/, uint8_t /*iolen*/)
 	if (timeInFrame < vga.draw.delay.vrstart || timeInFrame > vga.draw.delay.vrend)
 		retval |= 0x80;
 
-	const auto timeInLine = fmodf(timeInFrame, vga.draw.delay.htotal);
+	const auto timeInLine = fmod(timeInFrame, vga.draw.delay.htotal);
 	if (timeInLine >= vga.draw.delay.hrstart &&
 		timeInLine <= vga.draw.delay.hrend) retval |= 0x1;
 

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -449,7 +449,7 @@ void SVGA_Setup_TsengET4K(void) {
 	else if (vga.vmemsize < 1024*1024)
 		vga.vmemsize = 512*1024;
 	else
-		vga.vmemsize = 1024*1024;
+		vga.vmemsize = 1024 * 1024;
 }
 
 
@@ -692,7 +692,7 @@ void FinishSetMode_ET3K(Bitu crtc_base, VGA_ModeExtraData* modeData) {
 	IO_Write(crtc_base,0x25);IO_Write(crtc_base+1,et4k_ver_overflow);
 
 	// Clear remaining ext CRTC registers
-	for (Bitu i=0x1b; i<=0x21; i++) {
+	for (Bitu i = 0x1b; i <= 0x21; i++) {
 		IO_Write(crtc_base,i);
 		IO_Write(crtc_base+1,0);
 	}

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1062,13 +1062,14 @@ static Bitu Default_IRQ_Handler()
 
 static Bitu Reboot_Handler(void) {
 	// switch to text mode, notify user (let's hope INT10 still works)
-	const char* const text = "\n\n   Reboot requested, quitting now.";
 	reg_ax = 0;
 	CALLBACK_RunRealInt(0x10);
 	reg_ah = 0xe;
 	reg_bx = 0;
-	for(Bitu i = 0; i < strlen(text);i++) {
-		reg_al = text[i];
+
+	constexpr char text[] = "\n\n   Reboot requested, quitting now.";
+	for (const auto c : text) {
+		reg_al = static_cast<uint8_t>(c);
 		CALLBACK_RunRealInt(0x10);
 	}
 	LOG_MSG(text);
@@ -1227,19 +1228,21 @@ public:
 		else phys_writeb(0xffffe,0xfc);	/* PC */
 
 		// System BIOS identification
-		const char* const b_type =
-			"IBM COMPATIBLE 486 BIOS COPYRIGHT The DOSBox Team.";
-		for(Bitu i = 0; i < strlen(b_type); i++) phys_writeb(0xfe00e + i,b_type[i]);
-		
+		uint16_t i = 0;
+		for (const auto c : "IBM COMPATIBLE 486 BIOS COPYRIGHT The DOSBox Team.")
+			phys_writeb(0xfe00e + i++, static_cast<uint8_t>(c));
+
 		// System BIOS version
-		const char* const b_vers =
-			"DOSBox FakeBIOS v1.0";
-		for(Bitu i = 0; i < strlen(b_vers); i++) phys_writeb(0xfe061+i,b_vers[i]);
+		i = 0;
+		for (const auto c : "DOSBox FakeBIOS v1.0")
+			phys_writeb(0xfe061 + i++, static_cast<uint8_t>(c));
 
 		// write system BIOS date
-		const char* const b_date = "01/01/92";
-		for(Bitu i = 0; i < strlen(b_date); i++) phys_writeb(0xffff5+i,b_date[i]);
-		phys_writeb(0xfffff,0x55); // signature
+		i = 0;
+		for (const auto c : "01/01/92")
+			phys_writeb(0xffff5 + i++, static_cast<uint8_t>(c));
+
+		phys_writeb(0xfffff, 0x55); // signature
 
 		tandy_sb.port=0;
 		tandy_dac.port=0;
@@ -1280,7 +1283,9 @@ public:
 
 				RealPt current_irq=RealGetVec(tandy_irq_vector);
 				real_writed(0x40,0xd6,current_irq);
-				for (Bit16u i=0; i<0x10; i++) phys_writeb(PhysMake(0xf000,0xa084+i),0x80);
+				for (i = 0; i < 0x10; i++)
+					phys_writeb(PhysMake(0xf000, 0xa084 + i),
+					            0x80);
 			} else real_writeb(0x40,0xd4,0x00);
 		}
 	

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -553,7 +553,9 @@ static Bitu INT8_Handler(void) {
 			check = false;
 			time_t curtime;struct tm *loctime;
 			curtime = time (NULL);loctime = localtime (&curtime);
-			Bit32u ticksnu = (Bit32u)((loctime->tm_hour*3600+loctime->tm_min*60+loctime->tm_sec)*(float)PIT_TICK_RATE/65536.0);
+			Bit32u ticksnu = (Bit32u)((loctime->tm_hour * 3600 +
+			                           loctime->tm_min * 60 + loctime->tm_sec) *
+			                          (double)PIT_TICK_RATE / 65536.0);
 			Bit32s bios = value;Bit32s tn = ticksnu;
 			Bit32s diff = tn - bios;
 			if(diff>0) {
@@ -603,7 +605,7 @@ static Bitu INT17_Handler(void) {
 
 static bool INT14_Wait(Bit16u port, Bit8u mask, Bit8u timeout, Bit8u* retval) {
 	const auto starttime = PIC_FullIndex();
-	const auto timeout_f = timeout * 1000.0f;
+	const auto timeout_f = timeout * 1000.0;
 	while (((*retval = IO_ReadB(port)) & mask) != mask) {
 		if (starttime < (PIC_FullIndex() - timeout_f)) {
 			return false;
@@ -870,10 +872,8 @@ static Bitu INT15_Handler(void) {
 			}
 			Bit32u count=(reg_cx<<16)|reg_dx;
 		        const auto timeout = PIC_FullIndex() +
-		                             static_cast<float>(count) / 1000.0f +
-		                             1.0f;
-		        mem_writed(BIOS_WAIT_FLAG_POINTER,
-		                   RealMake(0, BIOS_WAIT_FLAG_TEMP));
+		                             static_cast<double>(count) / 1000.0 + 1.0;
+		        mem_writed(BIOS_WAIT_FLAG_POINTER, RealMake(0, BIOS_WAIT_FLAG_TEMP));
 		        mem_writed(BIOS_WAIT_FLAG_COUNT, count);
 		        mem_writeb(BIOS_WAIT_FLAG_ACTIVE, 1);
 		        /* Unmask IRQ 8 if masked */
@@ -1073,7 +1073,7 @@ static Bitu Reboot_Handler(void) {
 	}
 	LOG_MSG(text);
 	const auto start = PIC_FullIndex();
-	while ((PIC_FullIndex() - start) < 3000.0f)
+	while ((PIC_FullIndex() - start) < 3000.0)
 		CALLBACK_Idle();
 	throw 1;
 	return CBRET_NONE;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1323,10 +1323,16 @@ CommandLine::CommandLine(int argc, char const *const argv[])
 
 Bit16u CommandLine::Get_arglength() {
 	if (cmds.empty()) return 0;
-	Bit16u i=1;
-	for(cmd_it it = cmds.begin();it != cmds.end(); ++it)
-		i+=(*it).size() + 1;
-	return --i;
+
+	size_t total_length = 0;
+	for (const auto &cmd : cmds)
+		total_length += cmd.size() + 1;
+
+	if (total_length > UINT16_MAX) {
+		LOG_MSG("SETUP: Command line length too long, truncating");
+		total_length = UINT16_MAX;
+	}
+	return static_cast<uint16_t>(total_length);
 }
 
 CommandLine::CommandLine(const char *name, const char *cmdline)


### PR DESCRIPTION
This PR uses `double`s in place of `float`s for all timer and `PIC_` timer interfaces. Users of these API's are also updated to use doubles.

**Background**
- Previously the timer used a mix of floats and Bitu's, which recently was augmented with a very accurate 1ms timer that internally used `double` precision values to represent microseconds.  I later expanded the use of floats across all of the timing code, which caused a timing-accuracy regression in the accurate 1ms timer.

Thanks to @GranMinigun for detecting this timing issue and thanks to @kklobe for quickly isolating the issue.

**Notes for reviewers** 
 - This is a rote 1:1 replacement, with the priority placed on ensuring easy "eyeball" review.
 - There are no behavioral / functional changes, besides what double offers over float.
 - Feel free to review all of the changes at once (no value in commit-by-commit).
 - I've broken the commits up per-module, to ensure easy bisecting if there are further issues.
 - I've inspected all of the calls, and it's all just standard FPU math equations. 
 - There are no risky uses like casting a double to a pointer and then memsetting or dynamic casting to other types.
 
**Tests completed**
 - I tested this with EVGA, CGA, Composite, and several VGA+SVGA video modes, all audio devices (PC, GUS, SB, Tandy, SSI, MIDI, and PS/1), real and protected modes, and the normal and dynamic cores.  