### PR TITLE
Restore focus_ticks functionality

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -359,7 +359,7 @@ struct SDL_Block {
 	SDL_Rect updateRects[1024];
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
-	Bit32u focus_ticks;
+	int64_t focus_ticks = 0;
 #endif
 	// State of Alt keys for certain special handlings
 	SDL_EventType laltstate = SDL_KEYUP;
@@ -1467,10 +1467,14 @@ static void FocusInput()
 	// Ensure auto-cycles are enabled
 	CPU_Disable_SkipAutoAdjust();
 
+#if defined(WIN32)
+	sdl.focus_ticks = GetTicks();
+#endif
+
 	// Ensure we have input focus when in fullscreen
 	if (!sdl.desktop.fullscreen)
 		return;
-
+	
 	// Do we already have focus?
 	if (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS)
 		return;


### PR DESCRIPTION
The main branch contains WIN32-specific code to discard TAB key events right after an ALT-TAB SDL event:

```cpp
#ifdef WIN32
		case SDL_KEYDOWN:
		case SDL_KEYUP:
			// ignore event alt+tab
			if (event.key.keysym.sym == SDLK_LALT)
				sdl.laltstate = (SDL_EventType)event.key.type;
			if (event.key.keysym.sym == SDLK_RALT)
				sdl.raltstate = (SDL_EventType)event.key.type;
			if (((event.key.keysym.sym==SDLK_TAB)) && ((sdl.laltstate==SDL_KEYDOWN) || (sdl.raltstate==SDL_KEYDOWN)))
				break;
			// This can happen as well.
			if (((event.key.keysym.sym == SDLK_TAB )) && (event.key.keysym.mod & KMOD_ALT)) break;
			// Ignore tab events that arrive just after regaining
			// focus. Likely the result of Alt+Tab.
			if ((event.key.keysym.sym == SDLK_TAB) &&
			    (GetTicksSince(sdl.focus_ticks) < 2))
				break;
#endif
```
but there is currently no code that updates `sdl.focus_ticks`, and this caused an assert in `GetTicksSince` when I used tab completion for a directory at the C: prompt.

An older commit, 9ab84c503dbeb5db3b2c4f1ecd8d27f2e4500d84, has the following:

```cpp
case SDL_ACTIVEEVENT:
			if (event.active.state & SDL_APPINPUTFOCUS) {
				if (event.active.gain) {
#ifdef WIN32
					if (!sdl.desktop.fullscreen) sdl.focus_ticks = GetTicks();
#endif
```
but this logic is gone in the next commit for sdlmain.cpp, f2029d71d8d97e54358dbb0610643a879468f22a, leaving the current state.

Based on the current code structure, the best match for this updating of `focus_ticks` looked liked `FocusInput()`. I tested several applications with no asserts or other issues, with extensive Alt-Tab usage.