### PR TITLE
Fix a minor leak in the paging module

### DIFF
--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 
 #include "mem.h"
 #include "regs.h"
@@ -882,10 +883,11 @@ public:
 		}
 		pf_queue.used=0;
 	}
-	~PAGING(){}
 };
 
-static PAGING* test;
-void PAGING_Init(Section * sec) {
-	test = new PAGING(sec);
+static std::unique_ptr<PAGING> paging_instance = nullptr;
+
+void PAGING_Init(Section *sec)
+{
+	paging_instance = std::make_unique<PAGING>(sec);
 }


### PR DESCRIPTION
Reproduce by building the latest source as follows:

**macOS**

Use the command-line `leaks` tool after building the binary with `meson setup build-debug -Doptimization=0 -Dbuildtype=debug`

**Linux**

``` shell
CC="ccache gcc" CXX="ccache g++" \
meson setup -Dbuildtype=debug -Db_sanitize=address,undefined \
    -Doptimization=0 -Db_lundef=false -Dc_args=-fsanitize-recover=all \
    -Dcpp_args=-fsanitize-recover=all -Ddefault_library=static \
    -Dfluidsynth:enable-floats=true -Dfluidsynth:try-static-deps=true \
    build/gcc-ausan

meson compile -C build/gcc-ausan
```

Run Quake, then exit from its menu back to the command line, and then close the program.

![2021-08-07_19-21](https://user-images.githubusercontent.com/1557255/128619071-2e2796c1-7b85-499b-8218-3810f4847429.png)

Rebuild this PR branch `kc/paging-leak-1` with the same settings. It should exit clean.
