### PR TITLE
Fix dynrec crash on x86 Windows builds

### DIFF
--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -823,7 +823,7 @@ static void cache_init(bool enable) {
 			cache_code_start_ptr = static_cast<uint8_t *>(
 			        VirtualAlloc(nullptr, cache_code_size,
 			                     MEM_COMMIT,
-			                     PAGE_READWRITE));
+			                     PAGE_EXECUTE_READWRITE));
 			if (!cache_code_start_ptr) {
 				LOG_MSG("VirtualAlloc error, using malloc");
 				cache_code_start_ptr=static_cast<uint8_t *>(malloc(cache_code_size));


### PR DESCRIPTION
Apparently VirtualAlloc requires `PAGE_EXECUTE_READWRITE` to avoid a memory access exception under x86.

With release 0.77.0 x86, any dynrec will fault, even just `core dynamic` at the prompt.

Tested with several games including Abuse as reported in #1177. Also tested x64 for completeness and found no issues.

Since this is critical, I suggest we consider a point release with this fix.

Fixes #1177