### PR TITLE
Setup self-hosted runner for macOS arm64 builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,10 +115,7 @@ jobs:
         shell: bash
         run: |
           set -eu
-          BREW_DIR="$(brew --cache)"
-          DISCARD_DIR="${{ github.workspace }}/discard"
-          mkdir -p "$DISCARD_DIR"
-          mv -f "$BREW_DIR"/* "$DISCARD_DIR"
+          brew cleanup
           mkdir -p "$CCACHE_DIR"
           echo "::set-output name=brew_dir::$BREW_DIR"
           echo "::set-output name=ccache_dir::$CCACHE_DIR"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -103,9 +103,174 @@ jobs:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
         run:  python3 ./scripts/count-warnings.py -lf build.log
 
+  build_macos_release_arm64:
+    name: Release build (arm64)
+    runs-on: self-hosted
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    steps:
+      - uses: actions/checkout@v2
 
-  build_macos_release:
-    name: Release build
+      - name:  Prepare brew and compiler caches
+        id:    prep-caches
+        shell: bash
+        run: |
+          set -eu
+          BREW_DIR="$(brew --cache)"
+          DISCARD_DIR="${{ github.workspace }}/discard"
+          mkdir -p "$DISCARD_DIR"
+          mv -f "$BREW_DIR"/* "$DISCARD_DIR"
+          mkdir -p "$CCACHE_DIR"
+          echo "::set-output name=brew_dir::$BREW_DIR"
+          echo "::set-output name=ccache_dir::$CCACHE_DIR"
+          echo "::set-output name=today::$(date +%F)"
+
+      - uses:  actions/cache@v2
+        with:
+          path: ${{ steps.prep-caches.outputs.brew_dir }}
+          key:  brew-cache-${{ steps.prep-caches.outputs.today }}
+          restore-keys: brew-cache-
+
+      - name: Install C++ compiler and libraries
+        run: |
+          brew install librsvg tree \
+            $(cat ./.github/packages/macos-latest-brew.txt)
+
+      - uses:  actions/cache@v2
+        with:
+          path: ${{ steps.prep-caches.outputs.ccache_dir }}
+          key:  ccache-macos-release-${{ steps.prep-caches.outputs.today }}
+          restore-keys: ccache-macos-release-
+
+      - name:  Cache subprojects
+        uses:  actions/cache@v2
+        with:
+          path: subprojects/packagecache
+          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}
+
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+
+      - name: Inject version string
+        run: |
+          set -x
+          git fetch --prune --unshallow
+          export VERSION=$(git describe --abbrev=5)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Setup release build
+        run: |
+          meson setup \
+            --wrap-mode=forcefallback \
+            -Dbuildtype=release \
+            -Ddefault_library=static \
+            -Db_asneeded=true \
+            -Db_lto=true \
+            -Dtry_static_libs=opusfile,png,sdl2,sdl2_net \
+            -Dfluidsynth:enable-floats=true \
+            -Dfluidsynth:try-static-deps=true \
+            build
+
+      - name: Build
+        run:  arch -arch=arm64 ninja -C build
+
+      - name: Package
+        run: |
+          set -x
+
+          # Print shared object dependencies
+          otool -L build/dosbox
+          python3 scripts/verify-macos-dylibs.py build/dosbox
+
+          # Generate icon
+          make -C contrib/icons/ dosbox-staging.icns
+
+          dst=dist/dosbox-staging.app/Contents
+
+          # Prepare content
+          install -d "$dst/MacOS/"
+          install -d "$dst/Resources/"
+          install -d "$dst/SharedSupport/"
+
+          install        "build/dosbox"                      "$dst/MacOS/"
+          install -m 644 "contrib/macos/Info.plist.template" "$dst/Info.plist"
+          install -m 644 "contrib/macos/PkgInfo"             "$dst/PkgInfo"
+          install -m 644 "contrib/icons/dosbox-staging.icns" "$dst/Resources/"
+          install -m 644 "docs/README.template"              "$dst/SharedSupport/README"
+          install -m 644 "COPYING"                           "$dst/SharedSupport/COPYING"
+          install -m 644 "README"                            "$dst/SharedSupport/manual.txt"
+          install -m 644 "docs/README.video"                 "$dst/SharedSupport/video.txt"
+
+          # Fill README template file
+          sed -i -e "s|%VERSION%|${{ env.VERSION }}|"           "$dst/Info.plist"
+          sed -i -e "s|%GIT_COMMIT%|$GITHUB_SHA|"               "$dst/SharedSupport/README"
+          sed -i -e "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" "$dst/SharedSupport/README"
+          sed -i -e "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       "$dst/SharedSupport/README"
+
+          # Prepare translation files
+          #
+          # Note:
+          #   We conciously drop the dialect postfix because no dialects are available.
+          #   (US was the default DOS dialect and therefore is the default for 'en').
+          #   There users get the generic translation and benefit from simpler filenames.
+          #   Dialect translations will be added if/when they're available.
+          #
+          dst_lng="$dst/Resources/translations/"
+          install -d "$dst_lng"
+          install -m 644 contrib/translations/de/de_DE.lng       "$dst_lng/de.lng"
+          install -m 644 contrib/translations/en/en_US.lng       "$dst_lng/en.lng"
+          install -m 644 contrib/translations/es/es_ES.lng       "$dst_lng/es.lng"
+          install -m 644 contrib/translations/fr/fr_FR.lng       "$dst_lng/fr.lng"
+          install -m 644 contrib/translations/it/it_IT.lng       "$dst_lng/it.lng"
+          install -m 644 contrib/translations/pl/pl_PL.CP437.lng "$dst_lng/pl.cp437.lng"
+          install -m 644 contrib/translations/pl/pl_PL.lng       "$dst_lng/pl.lng"
+          install -m 644 contrib/translations/ru/ru_RU.lng       "$dst_lng/ru.lng"
+
+          ln -s /Applications dist/
+
+          codesign -s "-" dist/dosbox-staging.app --force --deep -v
+          
+          hdiutil create \
+              -volname "dosbox-staging" \
+              -srcfolder dist \
+              -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
+
+      - name: Upload disk image
+        uses: actions/upload-artifact@v2
+        # GitHub automatically zips the artifacts, and there's no option
+        # to skip it or upload a file only.
+        with:
+          name: dosbox-staging-macOS-arm64
+          path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
+
+
+  # This job exists only to publish an artifact with version info when building
+  # from master branch, so snapshot build version will be visible on:
+  # https://dosbox-staging.github.io/downloads/devel/
+  #
+  publish_additional_artifacts_arm64:
+    name: Publish additional artifacts (arm64)
+    needs: build_macos_release_arm64
+    runs-on: self-hosted
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate changelog
+        run: |
+          set +x
+          git fetch --unshallow
+          VERSION=$(git describe --abbrev=4)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          NEWEST_TAG=$(git describe --abbrev=0)
+          git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          # Keep exactly this artifact name; it's being used to propagate
+          # version info via GitHub REST API
+          name: changelog-${{ env.VERSION }}.txt
+          path: changelog-${{ env.VERSION }}.txt
+
+  build_macos_release_x86_64:
+    name: Release build (x86_64)
     runs-on: macos-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     steps:
@@ -207,55 +372,14 @@ jobs:
           sed -i -e "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" "$dst/SharedSupport/README"
           sed -i -e "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       "$dst/SharedSupport/README"
 
-          # Prepare translation files
-          #
-          # Note:
-          #   We conciously drop the dialect postfix because no dialects are available.
-          #   (US was the default DOS dialect and therefore is the default for 'en').
-          #   There users get the generic translation and benefit from simpler filenames.
-          #   Dialect translations will be added if/when they're available.
-          #
-          dst_lng="$dst/Resources/translations/"
-          install -d "$dst_lng"
-          install -m 644 contrib/translations/de/de_DE.lng       "$dst_lng/de.lng"
-          install -m 644 contrib/translations/en/en_US.lng       "$dst_lng/en.lng"
-          install -m 644 contrib/translations/es/es_ES.lng       "$dst_lng/es.lng"
-          install -m 644 contrib/translations/fr/fr_FR.lng       "$dst_lng/fr.lng"
-          install -m 644 contrib/translations/it/it_IT.lng       "$dst_lng/it.lng"
-          install -m 644 contrib/translations/pl/pl_PL.CP437.lng "$dst_lng/pl.cp437.lng"
-          install -m 644 contrib/translations/pl/pl_PL.lng       "$dst_lng/pl.lng"
-          install -m 644 contrib/translations/ru/ru_RU.lng       "$dst_lng/ru.lng"
-
           ln -s /Applications dist/
 
+          codesign -s "-" dist/dosbox-staging.app --force --deep -v
+          
           hdiutil create \
               -volname "dosbox-staging" \
               -srcfolder dist \
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
-
-      - name:  Install Clam AV
-        id:    prep-clamdb
-        shell: bash
-        run: |
-          brew install clamav > /dev/null
-          clamconf=/usr/local/etc/clamav/freshclam.conf
-          mv -f "$clamconf".sample "$clamconf"
-          sed -ie 's/^Example/#Example/g' "$clamconf"
-          sed -ie 's/30/20000/g' "$clamconf"
-          echo "::set-output name=today::$(date +%F)"
-      - uses:  actions/cache@v2
-        id:    cache-clamdb
-        with:
-          path: ${{ env.CLAMDB_DIR }}/**/*.cvd
-          key:  clamdb-macos-${{ steps.prep-clamdb.outputs.today }}
-          restore-keys: |
-            clamdb-macos-
-
-      - name: Clam AV scan
-        run: |
-          set -x
-          freshclam --foreground
-          clamscan --heuristic-scan-precedence=yes --recursive --infected dist
 
       - name: Upload disk image
         uses: actions/upload-artifact@v2
@@ -265,14 +389,13 @@ jobs:
           name: dosbox-staging-macOS-x86_64
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
 
-
   # This job exists only to publish an artifact with version info when building
   # from master branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/
   #
-  publish_additional_artifacts:
-    name: Publish additional artifacts
-    needs: build_macos_release
+  publish_additional_artifacts_x64_64:
+    name: Publish additional artifacts (x86_64)
+    needs: build_macos_release_x86_64
     runs-on: macos-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,6 +115,7 @@ jobs:
         shell: bash
         run: |
           set -eu
+          BREW_DIR="$(brew --cache)"
           brew cleanup
           mkdir -p "$CCACHE_DIR"
           echo "::set-output name=brew_dir::$BREW_DIR"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -162,9 +162,9 @@ jobs:
           meson setup \
             --wrap-mode=forcefallback \
             -Dbuildtype=release \
+            -Doptimization=s \
             -Ddefault_library=static \
             -Db_asneeded=true \
-            -Db_lto=true \
             -Dtry_static_libs=opusfile,png,sdl2,sdl2_net \
             -Dfluidsynth:enable-floats=true \
             -Dfluidsynth:try-static-deps=true \

--- a/scripts/verify-macos-dylibs.py
+++ b/scripts/verify-macos-dylibs.py
@@ -28,6 +28,7 @@ if __name__ == '__main__':
         '/System/Library/Frameworks/CoreAudio.framework/',
         '/System/Library/Frameworks/CoreFoundation.framework/',
         '/System/Library/Frameworks/CoreGraphics.framework/',
+        '/System/Library/Frameworks/CoreHaptics.framework/',
         '/System/Library/Frameworks/CoreMIDI.framework/',
         '/System/Library/Frameworks/CoreServices.framework/',
         '/System/Library/Frameworks/CoreVideo.framework/',


### PR DESCRIPTION
Add an arm64 build to the macOS workflow using a self-hosted runner.

I removed ClamAV from the arm64 runner since I have realtime MalwareBytes on my machine.

I also added `CoreHaptics` to the whitelist and forced a `codesign` for both x64 and arm64, since arm64 binaries require a valid signature, and we might as well do it right for x64 also.