### PR TITLE
Convert mixer audio callback to SDL_QueueAudio

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -52,6 +52,13 @@ struct AudioFrame {
 	float right = 0;
 };
 
+typedef int16_t mixer_sample_t;
+
+struct MixerFrame {
+	mixer_sample_t left = 0;
+	mixer_sample_t right = 0;
+};
+
 #define MIXER_BUFSIZE (16 * 1024)
 #define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
 extern Bit8u MixTemp[MIXER_BUFSIZE];

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -597,19 +597,23 @@ void DOSBOX_Init(void) {
 	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
 	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
 
-	Pint = secprop->Add_int("rate",Property::Changeable::OnlyAtStart,44100);
+	Pint = secprop->Add_int("rate", only_at_start, 48000);
 	Pint->Set_values(rates);
 	Pint->Set_help("Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.");
 
-	const char *blocksizes[] = {
-		 "1024", "2048", "4096", "8192", "512", "256", 0};
-	Pint = secprop->Add_int("blocksize",Property::Changeable::OnlyAtStart,1024);
-	Pint->Set_values(blocksizes);
-	Pint->Set_help("Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.");
+	Pint = secprop->Add_int("blocksize", deprecated, 1024);
+	Pint->Set_help("This property is deprecated, use latency instead.");
 
-	Pint = secprop->Add_int("prebuffer",Property::Changeable::OnlyAtStart,25);
-	Pint->SetMinMax(0,100);
-	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
+	Pint = secprop->Add_int("prebuffer", deprecated, 25);
+	Pint->Set_help("This property is deprecated, use latency instead.");
+
+	Pint = secprop->Add_int("latency", only_at_start, 15);
+	Pint->SetMinMax(1, 100);
+	Pint->Set_help("Desired audio latency in milliseconds. Range is 1-100.");
+
+	Pbool = secprop->Add_bool("negotiate", only_at_start, true);
+	Pbool->Set_help("Allow system audio driver to negotiate optimal rate and latency\n"
+	                "as close to the specified values as possible.");
 
 	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init, true);
@@ -781,7 +785,7 @@ void DOSBOX_Init(void) {
 	Pstring->Set_values(tandys);
 	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
 
-	Pint = secprop->Add_int("tandyrate",Property::Changeable::WhenIdle,44100);
+	Pint = secprop->Add_int("tandyrate", Property::Changeable::WhenIdle, 44100);
 	Pint->Set_values(rates);
 	Pint->Set_help("Sample rate of the Tandy 3-Voice generation.");
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -24,10 +24,12 @@
 #include "mixer.h"
 
 #include <cstdint>
-#include <string.h>
+#include <cstring>
 #include <sys/types.h>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
+#include <array>
+#include <map>
 
 #if defined (WIN32)
 //Midi listing
@@ -52,7 +54,9 @@
 #include "programs.h"
 #include "midi.h"
 
-#define MIXER_SSIZE 4
+// The max frames allowed to send to SDL, based on
+// limits for 'rate' and 'latency' in dosbox.conf
+static constexpr int MIXER_QUEUE_MAX_FRAMES = 8192;
 
 //#define MIXER_SHIFT 14
 //#define MIXER_REMAIN ((1<<MIXER_SHIFT)-1)
@@ -75,7 +79,7 @@
 // should the envelope monitor the initial signal? (recommended > 5s)
 #define ENVELOPE_EXPIRES_AFTER_S 10u
 
-static inline int16_t MIXER_CLIP(Bits SAMP)
+static constexpr int16_t MIXER_CLIP(int32_t SAMP)
 {
 	if (SAMP < MAX_AUDIO) {
 		if (SAMP > MIN_AUDIO)
@@ -90,8 +94,6 @@ static struct {
 	Bitu pos = 0;
 	Bitu done = 0;
 	Bitu needed = 0;
-	Bitu min_needed = 0;
-	Bitu max_needed = 0;
 	// For every millisecond tick how many samples need to be generated
 	uint32_t tick_add = 0;
 	uint32_t tick_counter = 0;
@@ -99,7 +101,7 @@ static struct {
 	MixerChannel *channels = nullptr;
 	bool nosound = false;
 	uint32_t freq = 0;
-	uint16_t blocksize = 0; // matches SDL AudioSpec.samples type
+	uint8_t latency = 0;
 	// Note: As stated earlier, all sdl code shall rather be in sdlmain
 	SDL_AudioDeviceID sdldevice = {};
 } mixer;
@@ -157,16 +159,6 @@ void MIXER_DelChannel(MixerChannel* delchan) {
 		where=&chan->next;
 		chan=chan->next;
 	}
-}
-
-static void MIXER_LockAudioDevice()
-{
-	SDL_LockAudioDevice(mixer.sdldevice);
-}
-
-static void MIXER_UnlockAudioDevice()
-{
-	SDL_UnlockAudioDevice(mixer.sdldevice);
 }
 
 void MixerChannel::RegisterLevelCallBack(apply_level_callback_f cb)
@@ -242,9 +234,6 @@ void MixerChannel::Enable(const bool should_enable)
 	if (is_enabled == should_enable)
 		return;
 
-	// Lock the channel before changing states
-	MIXER_LockAudioDevice();
-
 	// Prepare the channel to accept samples
 	if (should_enable) {
 		freq_counter = 0u;
@@ -266,7 +255,6 @@ void MixerChannel::Enable(const bool should_enable)
 		next_sample[1] = 0;
 	}
 	is_enabled = should_enable;
-	MIXER_UnlockAudioDevice();
 }
 
 void MixerChannel::SetFreq(Bitu freq)
@@ -624,9 +612,7 @@ void MixerChannel::FillUp()
 	if (!is_enabled || done < mixer.done)
 		return;
 	const auto index = PIC_TickIndex();
-	MIXER_LockAudioDevice();
 	Mix((Bitu)(index * static_cast<double>(mixer.needed)));
-	MIXER_UnlockAudioDevice();
 }
 
 extern bool ticksLocked;
@@ -676,14 +662,17 @@ static void MIXER_MixData(Bitu needed) {
 	mixer.done = needed;
 }
 
+static std::array<MixerFrame, MIXER_QUEUE_MAX_FRAMES> queue_buffer;
+static void MIXER_QueueAudio(uint16_t);
+
 static void MIXER_Mix()
 {
-	MIXER_LockAudioDevice();
 	MIXER_MixData(mixer.needed);
 	mixer.tick_counter += mixer.tick_add;
 	mixer.needed+=(mixer.tick_counter >> TICK_SHIFT);
 	mixer.tick_counter &= TICK_MASK;
-	MIXER_UnlockAudioDevice();
+	assert(mixer.done <= queue_buffer.size());
+	MIXER_QueueAudio(static_cast<uint16_t>(mixer.done));
 }
 
 static void MIXER_Mix_NoSound()
@@ -707,74 +696,12 @@ static void MIXER_Mix_NoSound()
 	mixer.done=0;
 }
 
-#define INDEX_SHIFT_LOCAL 14
-
-static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, int len)
+static void MIXER_QueueAudio(const uint16_t len)
 {
-	memset(stream, 0, len);
-	Bitu need=(Bitu)len/MIXER_SSIZE;
-	Bit16s * output=(Bit16s *)stream;
-	Bitu reduce;
-	Bitu pos;
-	//Local resampling counter to manipulate the data when sending it off to the callback
-	Bitu index_add = (1<<INDEX_SHIFT_LOCAL);
-	Bitu index = (index_add%need)?need:0;
+	assert(len <= queue_buffer.size());
 
-	Bits sample;
-	/* Enough room in the buffer ? */
-	if (mixer.done < need) {
-//		LOG_MSG("Full underrun need %d, have %d, min %d", need, mixer.done, mixer.min_needed);
-		if((need - mixer.done) > (need >>7) ) //Max 1 percent stretch.
-			return;
-		reduce = mixer.done;
-		index_add = (reduce << INDEX_SHIFT_LOCAL) / need;
-		mixer.tick_add = calc_tickadd(mixer.freq+mixer.min_needed);
-	} else if (mixer.done < mixer.max_needed) {
-		Bitu left = mixer.done - need;
-		if (left < mixer.min_needed) {
-			if( !Mixer_irq_important() ) {
-				Bitu needed = mixer.needed - need;
-				Bitu diff = (mixer.min_needed>needed?mixer.min_needed:needed) - left;
-				mixer.tick_add = calc_tickadd(mixer.freq+(diff*3));
-				left = 0; //No stretching as we compensate with the tick_add value
-			} else {
-				left = (mixer.min_needed - left);
-				left = 1 + (2*left) / mixer.min_needed; //left=1,2,3
-			}
-//			LOG_MSG("needed underrun need %d, have %d, min %d, left %d", need, mixer.done, mixer.min_needed, left);
-			reduce = need - left;
-			index_add = (reduce << INDEX_SHIFT_LOCAL) / need;
-		} else {
-			reduce = need;
-			index_add = (1 << INDEX_SHIFT_LOCAL);
-//			LOG_MSG("regular run need %d, have %d, min %d, left %d", need, mixer.done, mixer.min_needed, left);
+	auto reduce = len;
 
-			/* Mixer tick value being updated:
-			 * 3 cases:
-			 * 1) A lot too high. >division by 5. but maxed by 2* min to prevent too fast drops.
-			 * 2) A little too high > division by 8
-			 * 3) A little to nothing above the min_needed buffer > go to default value
-			 */
-			Bitu diff = left - mixer.min_needed;
-			if(diff > (mixer.min_needed<<1)) diff = mixer.min_needed<<1;
-			if(diff > (mixer.min_needed>>1))
-				mixer.tick_add = calc_tickadd(mixer.freq-(diff/5));
-			else if (diff > (mixer.min_needed>>2))
-				mixer.tick_add = calc_tickadd(mixer.freq-(diff>>3));
-			else
-				mixer.tick_add = calc_tickadd(mixer.freq);
-		}
-	} else {
-		/* There is way too much data in the buffer */
-//		LOG_MSG("overflow run need %d, have %d, min %d", need, mixer.done, mixer.min_needed);
-		if (mixer.done > MIXER_BUFSIZE)
-			index_add = MIXER_BUFSIZE - 2*mixer.min_needed;
-		else
-			index_add = mixer.done - 2*mixer.min_needed;
-		index_add = (index_add << INDEX_SHIFT_LOCAL) / need;
-		reduce = mixer.done - 2* mixer.min_needed;
-		mixer.tick_add = calc_tickadd(mixer.freq-(mixer.min_needed/5));
-	}
 	/* Reduce done count in all channels */
 	for (MixerChannel * chan=mixer.channels;chan;chan=chan->next) {
 		if (chan->done>reduce) chan->done-=reduce;
@@ -787,39 +714,28 @@ static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, i
 
 	mixer.done -= reduce;
 	mixer.needed -= reduce;
-	pos = mixer.pos;
+	auto pos = mixer.pos;
 	mixer.pos = (mixer.pos + reduce) & MIXER_BUFMASK;
-	if(need != reduce) {
-		while (need--) {
-			Bitu i = (pos + (index >> INDEX_SHIFT_LOCAL )) & MIXER_BUFMASK;
-			index += index_add;
-			sample=mixer.work[i][0]>>MIXER_VOLSHIFT;
-			*output++=MIXER_CLIP(sample);
-			sample=mixer.work[i][1]>>MIXER_VOLSHIFT;
-			*output++=MIXER_CLIP(sample);
-		}
-		/* Clean the used buffer */
-		while (reduce--) {
-			pos &= MIXER_BUFMASK;
-			mixer.work[pos][0]=0;
-			mixer.work[pos][1]=0;
-			pos++;
-		}
-	} else {
-		while (reduce--) {
-			pos &= MIXER_BUFMASK;
-			sample=mixer.work[pos][0]>>MIXER_VOLSHIFT;
-			*output++=MIXER_CLIP(sample);
-			sample=mixer.work[pos][1]>>MIXER_VOLSHIFT;
-			*output++=MIXER_CLIP(sample);
-			mixer.work[pos][0]=0;
-			mixer.work[pos][1]=0;
-			pos++;
-		}
-	}
-}
 
-#undef INDEX_SHIFT_LOCAL
+	int idx = 0;
+
+	while (reduce--) {
+		pos &= MIXER_BUFMASK;
+		const MixerFrame frame = {
+		        MIXER_CLIP(mixer.work[pos][0] >> MIXER_VOLSHIFT),
+		        MIXER_CLIP(mixer.work[pos][1] >> MIXER_VOLSHIFT)};
+		queue_buffer[idx++] = frame;
+
+		mixer.work[pos][0] = 0;
+		mixer.work[pos][1] = 0;
+		pos++;
+	}
+
+	const uint32_t size = len * sizeof(MixerFrame);
+	const auto res = SDL_QueueAudio(mixer.sdldevice, queue_buffer.data(), size);
+	if (res != 0)
+		LOG_MSG("MIXER: SDL_QueueAudio error %s", SDL_GetError());
+}
 
 static void MIXER_Stop(MAYBE_UNUSED Section *sec)
 {}
@@ -912,7 +828,6 @@ MixerObject::~MixerObject(){
 	MIXER_DelChannel(MIXER_FindChannel(m_name));
 }
 
-
 void MIXER_Init(Section* sec) {
 	sec->AddDestroyFunction(&MIXER_Stop);
 
@@ -921,7 +836,9 @@ void MIXER_Init(Section* sec) {
 
 	mixer.nosound=section->Get_bool("nosound");
 	mixer.freq = static_cast<uint32_t>(section->Get_int("rate"));
-	mixer.blocksize = static_cast<uint16_t>(section->Get_int("blocksize"));
+	mixer.latency = static_cast<uint8_t>(section->Get_int("latency"));
+	assert(mixer.latency <= 100);
+	const bool negotiate = section->Get_bool("negotiate");
 
 	/* Initialize the internal stuff */
 	mixer.channels=0;
@@ -931,6 +848,9 @@ void MIXER_Init(Section* sec) {
 	mixer.mastervol[0]=1.0f;
 	mixer.mastervol[1]=1.0f;
 
+	/* Calculate blocksize from requested latency to nearest power of 2 */
+	auto blocksize = static_cast<uint16_t>(mixer.freq * mixer.latency / 1000);
+
 	/* Start the Mixer using SDL Sound at 22 khz */
 	SDL_AudioSpec spec;
 	SDL_AudioSpec obtained;
@@ -938,16 +858,26 @@ void MIXER_Init(Section* sec) {
 	spec.freq = static_cast<int>(mixer.freq);
 	spec.format=AUDIO_S16SYS;
 	spec.channels=2;
-	spec.callback=MIXER_CallBack;
+	spec.callback = nullptr;
 	spec.userdata = nullptr;
-	spec.samples = mixer.blocksize;
+	spec.samples = blocksize;
+
+	int sdl_allow_flags = 0;
+
+	if (negotiate) {
+		sdl_allow_flags |= SDL_AUDIO_ALLOW_FREQUENCY_CHANGE;
+#if defined(SDL_AUDIO_ALLOW_SAMPLES_CHANGE)
+		sdl_allow_flags |= SDL_AUDIO_ALLOW_SAMPLES_CHANGE;
+#endif
+	}
 
 	mixer.tick_counter=0;
 	if (mixer.nosound) {
 		LOG_MSG("MIXER: No Sound Mode Selected.");
 		mixer.tick_add=calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix_NoSound);
-	} else if ((mixer.sdldevice = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE)) ==0 ) {
+	} else if ((mixer.sdldevice = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained,
+	                                                  sdl_allow_flags)) == 0) {
 		mixer.nosound = true;
 		LOG_MSG("MIXER: Can't open audio: %s , running in nosound mode.",SDL_GetError());
 		mixer.tick_add=calc_tickadd(mixer.freq);
@@ -970,26 +900,25 @@ void MIXER_Init(Section* sec) {
 
 		// Does SDL want a different blocksize?
 		const auto obtained_blocksize = obtained.samples;
-		if (obtained_blocksize != mixer.blocksize) {
+		if (obtained_blocksize != blocksize) {
 			LOG_MSG("MIXER: SDL changed the blocksize from %u to %u frames",
-			        mixer.blocksize, obtained_blocksize);
-			mixer.blocksize = obtained_blocksize;
+			        blocksize, obtained_blocksize);
+			blocksize = obtained_blocksize;
 		}
 		mixer.tick_add = calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix);
 		SDL_PauseAudioDevice(mixer.sdldevice, 0);
 
-		LOG_MSG("MIXER: Negotiated %u-channel %u-Hz audio in %u-frame blocks",
-		        obtained.channels, mixer.freq, mixer.blocksize);
+		const auto latency = blocksize / (mixer.freq / 1000);
+		LOG_MSG("MIXER: Negotiated %u-channel %u-Hz %ums-latency audio in %u-frame blocks",
+		        obtained.channels, mixer.freq, latency, blocksize);
 	}
 
 	//1000 = 8 *125
 	mixer.tick_counter = (mixer.freq%125)?TICK_NEXT:0;
-	const auto requested_prebuffer = section->Get_int("prebuffer");
-	mixer.min_needed = static_cast<uint16_t>(clamp(requested_prebuffer, 0, 100));
-	mixer.min_needed = (mixer.freq * mixer.min_needed) / 1000;
-	mixer.max_needed = mixer.blocksize * 2 + 2 * mixer.min_needed;
-	mixer.needed = mixer.min_needed + 1;
+
+	// calculate here in case SDL changed the freq
+	mixer.needed = mixer.freq / 1000;
 
 	// Initialize the 8-bit to 16-bit lookup table
 	fill_8to16_lut();


### PR DESCRIPTION
SDL 2.0.4 added a [push API](https://wiki.libsdl.org/SDL_QueueAudio) for audio in addition to the existing callback method.

This PR implements the new API, which takes direct control over filling the audio buffer in `MIXER_Mix()`.

It also deprecates `blocksize` and `prebuffer` config options in favor of a more direct `latency` setting, which is used along with `rate` to calculate the `samples` parameter for SDL to approximate the desired latency. We use the flag `SDL_AUDIO_ALLOW_SAMPLES_CHANGE` to let SDL negotiate the best setting with the audio subsystem. This can be controlled with the new `negotiate` config boolean option, which defaults to `true`.

The default value for `latency` is 15, based on empirical testing and giving a safety buffer over the rendering time per frame of ~14ms.

Anecdotal feedback from Scanno indicates that this change removes all stuttering from Mortal Kombat 2. I have tested over a dozen titles and have had no issues with latencies as low as 1.

Hopefully we can identify other titles that have a history of problematic audio and see if this change helps them as well.