### PR TITLE
Fix performance regression with meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('dosbox-staging', 'c', 'cpp',
         version : '0.78.0',
         license : 'GPL-2.0-or-later',
-        default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
+        default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_staticpic=false'],
         meson_version : '>= 0.51.0')
 
 # After increasing the minimum-required meson version, make the following


### PR DESCRIPTION
The meson build system adds -fPIC during compile, which has a negative performance impact. Adding this flags tells meson not to add this flag.

Resolves https://github.com/dosbox-staging/dosbox-staging/issues/1174

Further info:
https://github.com/mesonbuild/meson/issues/9080