### PR TITLE
Added stubs.cpp source to the example and fs_utils testcase builds

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,13 +27,13 @@ endif
 # - example  - has a failing testcase (on purpose)
 # - fs_utils - depends on files in: tests/files/
 #
-example = executable('example', 'example_tests.cpp',
+example = executable('example', ['example_tests.cpp', 'stubs.cpp'],
                      dependencies : [gtest_dep, sdl2_dep, libmisc_dep],
                      include_directories : incdir)
 test('gtest example', example, 
      should_fail : true)
 
-fs_utils = executable('fs_utils', 'fs_utils_tests.cpp',
+fs_utils = executable('fs_utils', ['fs_utils_tests.cpp', 'stubs.cpp'],
                       dependencies : [gtest_dep, libmisc_dep],
                       include_directories : incdir)
 test('gtest fs_utils', fs_utils,


### PR DESCRIPTION
Resolves issue when compiling with heavy debugging enabled and missing the `DEBUG_HeavyWriteLogInstruction` symbol provided in `stubs.cpp`

```
[1/5] Linking target tests/example
FAILED: tests/example 
c++  -o tests/example tests/example.p/example_tests.cpp.o tests/example.p/.._subprojects_googletest-release-1.10.0_googletest_src_gtest-all.cc.o tests/example.p/.._subprojects_googletest-release-1.10.0_googletest_src_gtest_main.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -Wl,-rpath,/usr/local/lib src/misc/libmisc.a /usr/local/lib/libSDL2.dylib
Undefined symbols for architecture x86_64:
  "DEBUG_HeavyWriteLogInstruction()", referenced from:
      E_Exit(char const*, ...) in libmisc.a(support.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[2/5] Linking target tests/fs_utils
FAILED: tests/fs_utils 
c++  -o tests/fs_utils tests/fs_utils.p/fs_utils_tests.cpp.o tests/fs_utils.p/.._subprojects_googletest-release-1.10.0_googletest_src_gtest-all.cc.o tests/fs_utils.p/.._subprojects_googletest-release-1.10.0_googletest_src_gtest_main.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -Wl,-rpath,/usr/local/lib src/misc/libmisc.a /usr/local/lib/libSDL2.dylib
Undefined symbols for architecture x86_64:
  "DEBUG_HeavyWriteLogInstruction()", referenced from:
      E_Exit(char const*, ...) in libmisc.a(support.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[3/5] Generating version.cpp with a custom command
ninja: build stopped: subcommand failed.
```