### PR TITLE
Fix for MacOS event loop

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2766,9 +2766,9 @@ bool GFX_Events()
 	// Macs, with this code,  max 250 polls per second. (non-macs unused
 	// default max 500). Currently not implemented for all platforms, given
 	// the ALT-TAB stuff for WIN32.
-	static int last_check = 0;
-	int current_check = GetTicks();
-	if (current_check - last_check <= DB_POLLSKIP)
+	static auto last_check = GetTicks();
+	auto current_check = GetTicks();
+	if (GetTicksDiff(current_check, last_check) <= DB_POLLSKIP)
 		return true;
 	last_check = current_check;
 #endif
@@ -2776,10 +2776,10 @@ bool GFX_Events()
 	SDL_Event event;
 #if defined (REDUCE_JOYSTICK_POLLING)
 	if (MAPPER_IsUsingJoysticks()) {
-		static int poll_delay = 0;
-		int time = GetTicks();
-		if (time - poll_delay > 20) {
-			poll_delay = time;
+		static auto last_check_joystick = GetTicks();
+		auto current_check_joystick = GetTicks();
+		if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
+			last_check_joystick = current_check_joystick;
 			SDL_JoystickUpdate();
 			MAPPER_UpdateJoysticks();
 		}


### PR DESCRIPTION
Fix for non functioning MacOS event loop due to integer overflow from `GetTicks()`

The updated `GetTicks` function returns a 64-bit integer for the milliseconds since epoch which was overflowing the 32-bit int value used in the MacOS-only poll-limiting code. For the present time, it is resulting in a negative number which causes the comparison with `last_check` to always return true and bypass all SDL event processing. This results in the system hanging once the SDL window is shown as no events ever get processed.