### PR TITLE
Backport fourth batch of 0.78-alpha fixes to 0.77.x

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
           - name: Clang, warning_level=3
             build_flags: -Dwarning_level=3
-            max_warnings: 179
+            max_warnings: 180
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -7,7 +7,7 @@ jobs:
     name: PVS-Studio static analyzer
     runs-on: ubuntu-20.04
     env:
-      debfile: pvs-studio-7.13.48133.129-amd64.deb
+      debfile: pvs-studio-7.14.50353.142-amd64.deb
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Install build dependencies appropriate for your OS:
 ``` shell
 # Fedora
 sudo dnf install ccache gcc-c++ meson alsa-lib-devel libpng-devel \
-                 SDL2-devel SDL2_net-devel opusfile-devel fluidsynth-devel
+                 SDL2-devel SDL2_net-devel opusfile-devel fluidsynth-devel \
+                 mt32emu-devel
 ```
 
 ``` shell

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('dosbox-staging', 'c', 'cpp',
         version : '0.77.0',
         license : 'GPL-2.0-or-later',
-        default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
+        default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_staticpic=false'],
         meson_version : '>= 0.51.0')
 
 # After increasing the minimum-required meson version, make the following

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -823,7 +823,7 @@ static void cache_init(bool enable) {
 			cache_code_start_ptr = static_cast<uint8_t *>(
 			        VirtualAlloc(nullptr, cache_code_size,
 			                     MEM_COMMIT,
-			                     PAGE_READWRITE));
+			                     PAGE_EXECUTE_READWRITE));
 			if (!cache_code_start_ptr) {
 				LOG_MSG("VirtualAlloc error, using malloc");
 				cache_code_start_ptr=static_cast<uint8_t *>(malloc(cache_code_size));

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2687,9 +2687,9 @@ bool GFX_Events()
 	// Macs, with this code,  max 250 polls per second. (non-macs unused
 	// default max 500). Currently not implemented for all platforms, given
 	// the ALT-TAB stuff for WIN32.
-	static int last_check = 0;
-	int current_check = GetTicks();
-	if (current_check - last_check <= DB_POLLSKIP)
+	static auto last_check = GetTicks();
+	auto current_check = GetTicks();
+	if (GetTicksDiff(current_check, last_check) <= DB_POLLSKIP)
 		return true;
 	last_check = current_check;
 #endif
@@ -2697,10 +2697,10 @@ bool GFX_Events()
 	SDL_Event event;
 #if defined (REDUCE_JOYSTICK_POLLING)
 	if (MAPPER_IsUsingJoysticks()) {
-		static int poll_delay = 0;
-		int time = GetTicks();
-		if (time - poll_delay > 20) {
-			poll_delay = time;
+		static auto last_check_joystick = GetTicks();
+		auto current_check_joystick = GetTicks();
+		if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
+			last_check_joystick = current_check_joystick;
 			SDL_JoystickUpdate();
 			MAPPER_UpdateJoysticks();
 		}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -356,7 +356,7 @@ struct SDL_Block {
 	SDL_Rect updateRects[1024];
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
-	Bit32u focus_ticks;
+	int64_t focus_ticks = 0;
 #endif
 	// State of Alt keys for certain special handlings
 	SDL_EventType laltstate = SDL_KEYUP;
@@ -1415,10 +1415,14 @@ static void FocusInput()
 	// Ensure auto-cycles are enabled
 	CPU_Disable_SkipAutoAdjust();
 
+#if defined(WIN32)
+	sdl.focus_ticks = GetTicks();
+#endif
+
 	// Ensure we have input focus when in fullscreen
 	if (!sdl.desktop.fullscreen)
 		return;
-
+	
 	// Do we already have focus?
 	if (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS)
 		return;

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -450,16 +450,6 @@ void SVGA_Setup_TsengET4K(void) {
 		vga.vmemsize = 512*1024;
 	else
 		vga.vmemsize = 1024*1024;
-
-	// Tseng ROM signature
-	PhysPt rom_base=PhysMake(0xc000,0);
-	phys_writeb(rom_base+0x0075,' ');
-	phys_writeb(rom_base+0x0076,'T');
-	phys_writeb(rom_base+0x0077,'s');
-	phys_writeb(rom_base+0x0078,'e');
-	phys_writeb(rom_base+0x0079,'n');
-	phys_writeb(rom_base+0x007a,'g');
-	phys_writeb(rom_base+0x007b,' ');
 }
 
 
@@ -702,7 +692,7 @@ void FinishSetMode_ET3K(Bitu crtc_base, VGA_ModeExtraData* modeData) {
 	IO_Write(crtc_base,0x25);IO_Write(crtc_base+1,et4k_ver_overflow);
 
 	// Clear remaining ext CRTC registers
-	for (Bitu i=0x16; i<=0x21; i++) {
+	for (Bitu i=0x1b; i<=0x21; i++) {
 		IO_Write(crtc_base,i);
 		IO_Write(crtc_base+1,0);
 	}

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -841,6 +841,10 @@ static Bitu INT33_Handler(void) {
 		}
 		DrawCursor();
 		break;
+	case 0x27:	/* Get Screen/Cursor Masks and Mickey Counts */
+		reg_ax=mouse.textAndMask;
+		reg_bx=mouse.textXorMask;
+		/* FALLTHROUGH */
 	case 0x0b:	/* Read Motion Data */
 		reg_cx=static_cast<Bit16s>(mouse.mickey_x);
 		reg_dx=static_cast<Bit16s>(mouse.mickey_y);

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -844,7 +844,7 @@ static Bitu INT33_Handler(void) {
 	case 0x27:	/* Get Screen/Cursor Masks and Mickey Counts */
 		reg_ax=mouse.textAndMask;
 		reg_bx=mouse.textXorMask;
-		/* FALLTHROUGH */
+		FALLTHROUGH;
 	case 0x0b:	/* Read Motion Data */
 		reg_cx=static_cast<Bit16s>(mouse.mickey_x);
 		reg_dx=static_cast<Bit16s>(mouse.mickey_y);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,13 +27,13 @@ endif
 # - example  - has a failing testcase (on purpose)
 # - fs_utils - depends on files in: tests/files/
 #
-example = executable('example', 'example_tests.cpp',
+example = executable('example', ['example_tests.cpp', 'stubs.cpp'],
                      dependencies : [gtest_dep, sdl2_dep, libmisc_dep],
                      include_directories : incdir)
 test('gtest example', example, 
      should_fail : true)
 
-fs_utils = executable('fs_utils', 'fs_utils_tests.cpp',
+fs_utils = executable('fs_utils', ['fs_utils_tests.cpp', 'stubs.cpp'],
                       dependencies : [gtest_dep, libmisc_dep],
                       include_directories : incdir)
 test('gtest fs_utils', fs_utils,


### PR DESCRIPTION
 - Apply SVN r4460 and 4461 fixes
 - Update PVS studio (keep GitHub workflows running on 0.77.x)
 - Update MT-32 Fedora deps
 - Fix Alt-Tab event focus for Windows
 - Fix dynrec win32 crash
 - Fix -fPIC performance regression (meson default setting)
 - Fix heavy-debugger missing symbols when compiling unit tests
 - Fix ~monthly potential integer tick-rollover in GFX Events

Thanks to all authors for testing and contributing these!