### PR TITLE
Use vectors for TLB instead of arrays

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -21,6 +21,9 @@
 
 #include "dosbox.h"
 
+#include <array>
+#include <vector>
+
 #include "mem.h"
 
 // disable this to reduce the size of the TLB
@@ -158,11 +161,11 @@ struct PagingBlock {
 	} base;
 #if defined(USE_FULL_TLB)
 	struct {
-		HostPt read[TLB_SIZE];
-		HostPt write[TLB_SIZE];
-		PageHandler * readhandler[TLB_SIZE];
-		PageHandler * writehandler[TLB_SIZE];
-		Bit32u	phys_page[TLB_SIZE];
+		std::vector<HostPt> read;
+		std::vector<HostPt> write;
+		std::vector<PageHandler *> readhandler;
+		std::vector<PageHandler *> writehandler;
+		std::vector<Bit32u> phys_page;
 	} tlb;
 #else
 	tlb_entry tlbh[TLB_SIZE];
@@ -170,9 +173,9 @@ struct PagingBlock {
 #endif
 	struct {
 		Bitu used;
-		Bit32u entries[PAGING_LINKS];
+		std::array<Bit32u, PAGING_LINKS> entries;
 	} links;
-	Bit32u		firstmb[LINK_START];
+	std::array<Bit32u, LINK_START> firstmb;
 	bool		enabled;
 };
 

--- a/include/paging.h
+++ b/include/paging.h
@@ -21,6 +21,7 @@
 
 #include "dosbox.h"
 
+#include <array>
 #include <memory>
 
 #include "mem.h"
@@ -160,11 +161,11 @@ struct PagingBlock {
 	} base;
 #if defined(USE_FULL_TLB)
 	struct {
-		std::vector<HostPt> read;
-		std::vector<HostPt> write;
-		std::vector<PageHandler *> readhandler;
-		std::vector<PageHandler *> writehandler;
-		std::vector<Bit32u> phys_page;
+		std::array<HostPt, TLB_SIZE> read;
+		std::array<HostPt, TLB_SIZE> write;
+		std::array<PageHandler *, TLB_SIZE> readhandler;
+		std::array<PageHandler *, TLB_SIZE> writehandler;
+		std::array<Bit32u, TLB_SIZE> phys_page;
 	} tlb;
 #else
 	tlb_entry tlbh[TLB_SIZE];

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -527,9 +527,9 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 
 	cache_addw(0xe8c1);		// shr eax,0x0c
 	cache_addb(0x0c);
-	cache_addw(0x048b);		// mov eax,paging.tlb.read[eax*TYPE Bit32u]
+	cache_addw(0x048b); // mov eax,paging->tlb.read[eax*TYPE Bit32u]
 	cache_addb(0x85);
-	cache_addd((Bit32u)(&paging.tlb.read[0]));
+	cache_addd((Bit32u)(&paging->tlb.read[0]));
 	cache_addw(0xc085);		// test eax,eax
 	const Bit8u* je_loc=gen_create_branch(BR_Z);
 
@@ -604,9 +604,9 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 	const Bit8u* jb_loc1=gen_create_branch(BR_NB);
 	cache_addb(0x25);       // and eax, 0x000FFFFF
 	cache_addd(0x000fffff);
-	cache_addw(0x048b);		// mov eax,paging.tlb.read[eax*TYPE Bit32u]
+	cache_addw(0x048b); // mov eax,paging->tlb.read[eax*TYPE Bit32u]
 	cache_addb(0x85);
-	cache_addd((Bit32u)(&paging.tlb.read[0]));
+	cache_addd((Bit32u)(&paging->tlb.read[0]));
 	cache_addw(0xc085);		// test eax,eax
 	const Bit8u* je_loc=gen_create_branch(BR_Z);
 
@@ -675,9 +675,9 @@ static void dyn_write_byte(DynReg * addr,DynReg * val,bool high,bool release=fal
 	GenReg * genreg=FindDynReg(val);
 	cache_addw(0xe9c1);		// shr ecx,0x0c
 	cache_addb(0x0c);
-	cache_addw(0x0c8b);		// mov ecx,paging.tlb.write[ecx*TYPE Bit32u]
+	cache_addw(0x0c8b); // mov ecx,paging->tlb.write[ecx*TYPE Bit32u]
 	cache_addb(0x8d);
-	cache_addd((Bit32u)(&paging.tlb.write[0]));
+	cache_addd((Bit32u)(&paging->tlb.write[0]));
 	cache_addw(0xc985);		// test ecx,ecx
 	const Bit8u* je_loc=gen_create_branch(BR_Z);
 
@@ -719,9 +719,9 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 	const Bit8u* jb_loc1=gen_create_branch(BR_NB);
 	cache_addw(0xe181);     // and ecx, 0x000FFFFF
 	cache_addd(0x000fffff);
-	cache_addw(0x0c8b);		// mov ecx,paging.tlb.write[ecx*TYPE Bit32u]
+	cache_addw(0x0c8b); // mov ecx,paging->tlb.write[ecx*TYPE Bit32u]
 	cache_addb(0x8d);
-	cache_addd((Bit32u)(&paging.tlb.write[0]));
+	cache_addd((Bit32u)(&paging->tlb.write[0]));
 	cache_addw(0xc985);		// test ecx,ecx
 	const Bit8u* je_loc=gen_create_branch(BR_Z);
 
@@ -803,8 +803,11 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 	}
 
 	opcode(5).setrm(tmp).setimm(12,1).Emit8(0xC1); // shr tmpd,12
-	// mov tmp, [8*tmp+paging.tlb.read(rbp)]
-	opcode(tmp).set64().setea(5,tmp,3,(Bits)paging.tlb.read-(Bits)&cpu_regs).Emit8(0x8B);
+	// mov tmp, [8*tmp+paging->tlb.read(rbp)]
+	opcode(tmp)
+	        .set64()
+	        .setea(5, tmp, 3, (Bits)paging->tlb.read - (Bits)&cpu_regs)
+	        .Emit8(0x8B);
 	opcode(tmp).set64().setrm(tmp).Emit8(0x85); // test tmp,tmp
 	const Bit8u *nomap=gen_create_branch(BR_Z);
 	//mov dst, [tmp+src]
@@ -849,8 +852,11 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 
 	opcode(tmp).setrm(gensrc->index).Emit8(0x8B); // mov tmp, src
 	opcode(5).setrm(tmp).setimm(12,1).Emit8(0xC1); // shr tmp,12
-	// mov tmp, [8*tmp+paging.tlb.read(rbp)]
-	opcode(tmp).set64().setea(5,tmp,3,(Bits)paging.tlb.read-(Bits)&cpu_regs).Emit8(0x8B);
+	// mov tmp, [8*tmp+paging->tlb.read(rbp)]
+	opcode(tmp)
+	        .set64()
+	        .setea(5, tmp, 3, (Bits)paging->tlb.read - (Bits)&cpu_regs)
+	        .Emit8(0x8B);
 	opcode(tmp).set64().setrm(tmp).Emit8(0x85); // test tmp,tmp
 	const Bit8u *nomap=gen_create_branch(BR_Z);
 
@@ -906,8 +912,11 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 	}
 
 	opcode(5).setrm(tmp).setimm(12,1).Emit8(0xC1); // shr tmpd,12
-	// mov tmp, [8*tmp+paging.tlb.write(rbp)]
-	opcode(tmp).set64().setea(5,tmp,3,(Bits)paging.tlb.write-(Bits)&cpu_regs).Emit8(0x8B);
+	// mov tmp, [8*tmp+paging->tlb.write(rbp)]
+	opcode(tmp)
+	        .set64()
+	        .setea(5, tmp, 3, (Bits)paging->tlb.write - (Bits)&cpu_regs)
+	        .Emit8(0x8B);
 	opcode(tmp).set64().setrm(tmp).Emit8(0x85); // test tmp,tmp
 	const Bit8u *nomap=gen_create_branch(BR_Z);
 	//mov [tmp+src], dst
@@ -947,8 +956,11 @@ static void dyn_write_byte(DynReg * addr,DynReg * val,bool high,bool release=fal
 
 	opcode(tmp).setrm(gendst->index).Emit8(0x8B); // mov tmpd, dst
 	opcode(5).setrm(tmp).setimm(12,1).Emit8(0xC1); // shr tmpd,12
-	// mov tmp, [8*tmp+paging.tlb.write(rbp)]
-	opcode(tmp).set64().setea(5,tmp,3,(Bits)paging.tlb.write-(Bits)&cpu_regs).Emit8(0x8B);
+	// mov tmp, [8*tmp+paging->tlb.write(rbp)]
+	opcode(tmp)
+	        .set64()
+	        .setea(5, tmp, 3, (Bits)paging->tlb.write - (Bits)&cpu_regs)
+	        .Emit8(0x8B);
 	opcode(tmp).set64().setrm(tmp).Emit8(0x85); // test tmp,tmp
 	const Bit8u *nomap=gen_create_branch(BR_Z);
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1602,15 +1602,12 @@ void CPU_SET_CRX(Bitu cr,Bitu value) {
 			}
 			break;
 		}
-	case 2:
-		paging.cr2=value;
-		break;
-	case 3:
-		PAGING_SetDirBase(value);
-		break;
-	default:
-		LOG(LOG_CPU,LOG_ERROR)("Unhandled MOV CR%d,%X",cr,value);
-		break;
+	        case 2: paging->cr2 = value; break;
+	        case 3: PAGING_SetDirBase(value); break;
+	        default:
+		        LOG(LOG_CPU, LOG_ERROR)
+		        ("Unhandled MOV CR%d,%X", cr, value);
+		        break;
 	}
 }
 
@@ -1631,8 +1628,7 @@ Bitu CPU_GET_CRX(Bitu cr) {
 		if (CPU_ArchitectureType>=CPU_ARCHTYPE_PENTIUMSLOW) return cpu.cr0;
 		else if (CPU_ArchitectureType>=CPU_ARCHTYPE_486OLDSLOW) return (cpu.cr0 & 0xe005003f);
 		else return (cpu.cr0 | 0x7ffffff0);
-	case 2:
-		return paging.cr2;
+	case 2: return paging->cr2;
 	case 3:
 		return PAGING_GetDirBase() & 0xfffff000;
 	default:

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -646,10 +646,11 @@ bool PAGING_ForcePageInit(Bitu lin_addr) {
 #if defined(USE_FULL_TLB)
 void PAGING_InitTLB(void) {
 	for (Bitu i=0;i<TLB_SIZE;i++) {
-		paging.tlb.read[i]=0;
-		paging.tlb.write[i]=0;
-		paging.tlb.readhandler[i]=&init_page_handler;
-		paging.tlb.writehandler[i]=&init_page_handler;
+		paging.tlb.read.push_back(0);
+		paging.tlb.write.push_back(0);
+		paging.tlb.readhandler.push_back(&init_page_handler);
+		paging.tlb.writehandler.push_back(&init_page_handler);
+		paging.tlb.phys_page.push_back(0);
 	}
 	paging.links.used=0;
 }

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -37,7 +37,8 @@ static void UpdateEMSMapping(void) {
 	/* if EMS is not present, this will result in a 1:1 mapping */
 	Bitu i;
 	for (i=0;i<0x10;i++) {
-		ems_board_mapping[EMM_PAGEFRAME4K+i]=paging.firstmb[EMM_PAGEFRAME4K+i];
+		ems_board_mapping[EMM_PAGEFRAME4K + i] =
+		        paging->firstmb[EMM_PAGEFRAME4K + i];
 	}
 }
 
@@ -55,9 +56,11 @@ static void DMA_BlockRead(PhysPt spage,PhysPt offset,void * data,Bitu size,Bit8u
 		offset &= dma_wrap;
 		Bitu page = highpart_addr_page+(offset >> 12);
 		/* care for EMS pageframe etc. */
-		if (page < EMM_PAGEFRAME4K) page = paging.firstmb[page];
+		if (page < EMM_PAGEFRAME4K)
+			page = paging->firstmb[page];
 		else if (page < EMM_PAGEFRAME4K+0x10) page = ems_board_mapping[page];
-		else if (page < LINK_START) page = paging.firstmb[page];
+		else if (page < LINK_START)
+			page = paging->firstmb[page];
 		*write++=phys_readb(page*4096 + (offset & 4095));
 	}
 }
@@ -76,9 +79,11 @@ static void DMA_BlockWrite(PhysPt spage,PhysPt offset,void * data,Bitu size,Bit8
 		offset &= dma_wrap;
 		Bitu page = highpart_addr_page+(offset >> 12);
 		/* care for EMS pageframe etc. */
-		if (page < EMM_PAGEFRAME4K) page = paging.firstmb[page];
+		if (page < EMM_PAGEFRAME4K)
+			page = paging->firstmb[page];
 		else if (page < EMM_PAGEFRAME4K+0x10) page = ems_board_mapping[page];
-		else if (page < LINK_START) page = paging.firstmb[page];
+		else if (page < LINK_START)
+			page = paging->firstmb[page];
 		phys_writeb(page*4096 + (offset & 4095), *read++);
 	}
 }


### PR DESCRIPTION
Allocating `PagingBlock paging` on the heap allows GCC 11 to compile `paging.cpp` for arm64. The large static arrays were causing compilation errors such as `error: addend too big for relocation`.

A quick performance test using Quake timedemo and TOPBENCH with `cycles=max` and `core=dynamic` were equivalent to `master`.