### PR TITLE
Resume using GitHub's built-in `vcpkg` instead of work-around from repo

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         id:   cache-vcpkg
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
 
       - name:  Install new packages using vcpkg
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
 
       - name:  Integrate packages
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,16 +40,11 @@ jobs:
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          c:
-          cd \
-          rm -R vcpkg
-          git clone https://github.com/Microsoft/vcpkg.git
-          cd vcpkg
-          git checkout 4b317d797e0fb3ca0cfa1b47f2c6741284fe5f5c
-          .\bootstrap-vcpkg.bat
+          rm -R c:\vcpkg
+          mv c:\vcpkg-bak c:\vcpkg
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
-          rm -R buildtrees\fluidsynth\src\*.clean\sf2
+          rm -R c:\vcpkg\buildtrees\fluidsynth\src\*.clean\sf2
 
       - name:  Integrate packages
         shell: pwsh


### PR DESCRIPTION
A couple weeks ago GitHub's built-in vcpkg was in a broken state, which consequently broke our Windows CI workflow.  Staging implemented a work-around to replace it with a prior known-good version. The PR will rollback our work around (when we confirm vcpkg is working properly again).