### PR TITLE
Enale math constants in support header

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -24,9 +24,11 @@
 
 #include "dosbox.h"
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <algorithm>
 #include <cassert>
-#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
Fixing a build failure in config-heavy:

![2021-08-14_10-04](https://user-images.githubusercontent.com/1557255/129455270-3546c16f-86e1-44bc-9370-8af7f0200cd9.png)
