### PR TITLE
Fix 32-bit dynamic core crashes

### DIFF
--- a/.github/packages/ubuntu-20.04-apt.txt
+++ b/.github/packages/ubuntu-20.04-apt.txt
@@ -7,4 +7,3 @@ libopusfile-dev
 libpng-dev
 libsdl2-dev
 libsdl2-net-dev
-meson

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -46,8 +46,9 @@ jobs:
       - run:  sudo apt-get update
 
       - name: Install dependencies
-        run:  sudo apt-get install clang-tools python3-bs4
-                                   $(cat .github/packages/ubuntu-20.04-apt.txt)
+        run: |
+          sudo apt-get install clang-tools python3-bs4 $(cat .github/packages/ubuntu-20.04-apt.txt)
+          sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -138,8 +139,10 @@ jobs:
 
       - run:  sudo apt-get update
 
-      - name: Install C++ compiler and libraries
-        run:  sudo apt-get install $(cat .github/packages/ubuntu-20.04-apt.txt)
+      - name: Install dependencies
+        run: |
+          sudo apt-get install $(cat .github/packages/ubuntu-20.04-apt.txt)
+          sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
         id:    prep-ccache

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install dependencies (minimum set)
         if:   matrix.conf.min_dependencies
         run: |
-          sudo apt-get install -y build-essential ccache meson libsdl2-dev libopusfile-dev
+          sudo apt-get install -y build-essential ccache libsdl2-dev libopusfile-dev
 
       - name: Install dependencies
         if:   matrix.conf.min_dependencies != true
@@ -90,10 +90,10 @@ jobs:
             $(cat ./.github/packages/${{ matrix.conf.os }}-apt.txt)
 
       - name: Install Meson via pip3
-        if:   matrix.conf.os != 'ubuntu-20.04'
+#        if:   matrix.conf.os != 'ubuntu-20.04'
         run: |
           sudo apt-get install python3-setuptools
-          sudo pip3 install meson ninja
+          sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
         id:    prep-ccache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,7 +79,7 @@ jobs:
             arch: arm64
             needs_deps: false
             build_flags: -Dwarning_level=3
-            max_warnings: 194
+            max_warnings: 196
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -35,6 +35,11 @@ jobs:
           sudo dpkg -i "pvs-package/pvs.deb"
           pvs-studio-analyzer credentials "${{ secrets.PvsStudioName }}" "${{ secrets.PvsStudioKey }}"
 
+      - name: Install Meson via pip3
+        run: |
+          sudo apt-get install python3-setuptools
+          sudo pip3 install --upgrade meson ninja
+
       - name:  Cache subprojects
         uses:  actions/cache@v2
         with:

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('dosbox-staging', 'c', 'cpp',
         version : '0.78.0',
         license : 'GPL-2.0-or-later',
         default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_staticpic=false'],
-        meson_version : '>= 0.51.0')
+        meson_version : '>= 0.54.2')
 
 # After increasing the minimum-required meson version, make the following
 # improvements:

--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,10 @@ if cc.has_function('__builtin_available')
   conf_data.set10('HAVE_BUILTIN_AVAILABLE', true)
 endif
 
+if cc.has_function('__builtin___clear_cache')
+  conf_data.set10('HAVE_BUILTIN_CLEAR_CACHE', true)
+endif
+
 if cc.has_function('mprotect', prefix : '#include <sys/mman.h>')
   conf_data.set10('HAVE_MPROTECT', true)
 endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -139,6 +139,9 @@
 // Defined if function __builtin_available is available
 #mesondefine HAVE_BUILTIN_AVAILABLE
 
+// Defined if function __builtin___clear_cache is available
+#mesondefine HAVE_BUILTIN_CLEAR_CACHE
+
 // Defined if function mprotect is available
 #mesondefine HAVE_MPROTECT
 

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2181,7 +2181,7 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 	codepage->AddCacheBlock(decode.block);
 
 	auto cache_addr = static_cast<void *>(
-	        const_cast<uint8_t *>(decode.block->cache.start - 1));
+	        const_cast<uint8_t *>(decode.block->cache.start));
 	constexpr size_t cache_bytes = CACHE_MAXSIZE;
 
 	dyn_mem_write(cache_addr, cache_bytes);

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2180,7 +2180,7 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 	decode.block->page.start=decode.page.index;
 	codepage->AddCacheBlock(decode.block);
 
-	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start));
+	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start-1));
 	constexpr size_t cache_bytes = CACHE_MAXSIZE;
 
 	dyn_mem_write(cache_addr, cache_bytes);
@@ -2897,6 +2897,7 @@ finish_block:
 	decode.active_block->page.end=--decode.page.index;
 	dyn_mem_execute(cache_addr, cache_bytes);
 	dyn_cache_invalidate(cache_addr, cache_bytes);
+	assert(decode.block->cache.size <= cache_bytes);
 	//	LOG_MSG("Created block size %d start %d end
 	//%d",decode.block->cache.size,decode.block->page.start,decode.block->page.end);
 	return decode.block;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2180,7 +2180,8 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 	decode.block->page.start=decode.page.index;
 	codepage->AddCacheBlock(decode.block);
 
-	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start-1));
+	auto cache_addr = static_cast<void *>(
+	        const_cast<uint8_t *>(decode.block->cache.start - 1));
 	constexpr size_t cache_bytes = CACHE_MAXSIZE;
 
 	dyn_mem_write(cache_addr, cache_bytes);
@@ -2896,7 +2897,7 @@ finish_block:
 	/* Setup the correct end-address */
 	decode.active_block->page.end=--decode.page.index;
 	dyn_mem_execute(cache_addr, cache_bytes);
-	const size_t cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
+	const auto cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
 	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 	assert(decode.block->cache.size <= cache_bytes);
 	//	LOG_MSG("Created block size %d start %d end

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2896,7 +2896,8 @@ finish_block:
 	/* Setup the correct end-address */
 	decode.active_block->page.end=--decode.page.index;
 	dyn_mem_execute(cache_addr, cache_bytes);
-	dyn_cache_invalidate(cache_addr, cache_bytes);
+	const size_t cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
+	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 	assert(decode.block->cache.size <= cache_bytes);
 	//	LOG_MSG("Created block size %d start %d end
 	//%d",decode.block->cache.size,decode.block->page.start,decode.block->page.end);

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -342,7 +342,7 @@ static BlockReturn gen_runcodeInit(const Bit8u *code) {
 	cache_addb(0xc3);          // ret
 	
 	dyn_mem_execute(cache_addr, cache_bytes);
-	const size_t cache_flush_bytes = static_cast<size_t>(cache.pos - oldpos);
+	const auto cache_flush_bytes = static_cast<size_t>(cache.pos - oldpos);
 	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 
 	cache.pos = oldpos;
@@ -1304,7 +1304,7 @@ static void gen_dh_fpu_saveInit(void) {
 	cache_addb(0xC3); // RET
 	
 	dyn_mem_execute(cache_addr, cache_bytes);
-	const size_t cache_flush_bytes = static_cast<size_t>(cache.pos - oldpos);
+	const auto cache_flush_bytes = static_cast<size_t>(cache.pos - oldpos);
 	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 
 	cache.pos = oldpos;

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -342,7 +342,8 @@ static BlockReturn gen_runcodeInit(const Bit8u *code) {
 	cache_addb(0xc3);          // ret
 	
 	dyn_mem_execute(cache_addr, cache_bytes);
-	dyn_cache_invalidate(cache_addr, cache_bytes);
+	const size_t cache_flush_bytes = static_cast<size_t>(cache.pos - oldpos);
+	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 
 	cache.pos = oldpos;
 	return gen_runcode(code);
@@ -1303,7 +1304,8 @@ static void gen_dh_fpu_saveInit(void) {
 	cache_addb(0xC3); // RET
 	
 	dyn_mem_execute(cache_addr, cache_bytes);
-	dyn_cache_invalidate(cache_addr, cache_bytes);
+	const size_t cache_flush_bytes = static_cast<size_t>(cache.pos - oldpos);
+	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 
 	cache.pos = oldpos;
 	gen_dh_fpu_save();

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -54,7 +54,7 @@
 #include "lazyflags.h"
 #include "pic.h"
 
-#define CACHE_MAXSIZE	(4096*2)
+#define CACHE_MAXSIZE	(4096*3)
 #define CACHE_TOTAL		(1024*1024*8)
 #define CACHE_PAGES		(512)
 #define CACHE_BLOCKS	(128*1024)

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -54,7 +54,7 @@
 #include "lazyflags.h"
 #include "pic.h"
 
-#define CACHE_MAXSIZE	(4096*3)
+#define CACHE_MAXSIZE	(4096*2)
 #define CACHE_TOTAL		(1024*1024*8)
 #define CACHE_PAGES		(512)
 #define CACHE_BLOCKS	(128*1024)

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -43,7 +43,7 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 	decode.block->page.start=(Bit16u)decode.page.index;
 	codepage->AddCacheBlock(decode.block);
 
-	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start));
+	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start-1));
 	constexpr size_t cache_bytes = CACHE_MAXSIZE;
 
 	dyn_mem_write(cache_addr, cache_bytes);
@@ -622,6 +622,8 @@ finish_block:
 	dyn_mem_execute(cache_addr, cache_bytes);
 	dyn_cache_invalidate(cache_addr, cache_bytes);
 
+	assert(decode.block->cache.size <= cache_bytes);
+	
 //	LOG_MSG("Created block size %d start %d end %d",decode.block->cache.size,decode.block->page.start,decode.block->page.end);
 
 	return decode.block;

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -613,18 +613,17 @@ illegalopcode:
 	dyn_reduce_cycles();
 	dyn_return(BR_Opcode);	// tell the core what happened
 	dyn_closeblock();
+
 	goto finish_block;
 finish_block:
-
 	// setup the correct end-address
 	decode.page.index--;
 	decode.active_block->page.end=(Bit16u)decode.page.index;
 	dyn_mem_execute(cache_addr, cache_bytes);
-	dyn_cache_invalidate(cache_addr, cache_bytes);
-
+	const size_t cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
+	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 	assert(decode.block->cache.size <= cache_bytes);
-	
-//	LOG_MSG("Created block size %d start %d end %d",decode.block->cache.size,decode.block->page.start,decode.block->page.end);
-
+	//	LOG_MSG("Created block size %d start %d end
+	//%d",decode.block->cache.size,decode.block->page.start,decode.block->page.end);
 	return decode.block;
 }

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -44,7 +44,7 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 	codepage->AddCacheBlock(decode.block);
 
 	auto cache_addr = static_cast<void *>(
-	        const_cast<uint8_t *>(decode.block->cache.start - 1));
+	        const_cast<uint8_t *>(decode.block->cache.start));
 	constexpr size_t cache_bytes = CACHE_MAXSIZE;
 
 	dyn_mem_write(cache_addr, cache_bytes);

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -43,7 +43,8 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 	decode.block->page.start=(Bit16u)decode.page.index;
 	codepage->AddCacheBlock(decode.block);
 
-	auto cache_addr = static_cast<void *>(const_cast<uint8_t *>(decode.block->cache.start-1));
+	auto cache_addr = static_cast<void *>(
+	        const_cast<uint8_t *>(decode.block->cache.start - 1));
 	constexpr size_t cache_bytes = CACHE_MAXSIZE;
 
 	dyn_mem_write(cache_addr, cache_bytes);
@@ -620,7 +621,7 @@ finish_block:
 	decode.page.index--;
 	decode.active_block->page.end=(Bit16u)decode.page.index;
 	dyn_mem_execute(cache_addr, cache_bytes);
-	const size_t cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
+	const auto cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
 	dyn_cache_invalidate(cache_addr, cache_flush_bytes);
 	assert(decode.block->cache.size <= cache_bytes);
 	//	LOG_MSG("Created block size %d start %d end

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -80,28 +80,4 @@ typedef Bit8u HostReg;
 #define HOST_lr HOST_r14
 #define HOST_pc HOST_r15
 
-
-static void cache_block_closing(const Bit8u* block_start,Bitu block_size) {
-#if (__ARM_EABI__)
-	//flush cache - eabi
-	register unsigned long _beg __asm ("a1") = (unsigned long)(block_start);				// block start
-	register unsigned long _end __asm ("a2") = (unsigned long)(block_start+block_size);		// block end
-	register unsigned long _flg __asm ("a3") = 0;
-	register unsigned long _par __asm ("r7") = 0xf0002;										// sys_cacheflush
-	__asm __volatile ("swi 0x0"
-		: // no outputs
-		: "r" (_beg), "r" (_end), "r" (_flg), "r" (_par)
-		);
-#else
-// GP2X BEGIN
-	//flush cache - old abi
-	register unsigned long _beg __asm ("a1") = (unsigned long)(block_start);				// block start
-	register unsigned long _end __asm ("a2") = (unsigned long)(block_start+block_size);		// block end
-	register unsigned long _flg __asm ("a3") = 0;
-	__asm __volatile ("swi 0x9f0002		@ sys_cacheflush"
-		: // no outputs
-		: "r" (_beg), "r" (_end), "r" (_flg)
-		);
-// GP2X END
-#endif
-}
+static void cache_block_closing(const Bit8u *block_start, Bitu block_size) { }

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -1133,10 +1133,8 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 }
 #endif
 
-static void cache_block_closing(const Bit8u* block_start,Bitu block_size) {
-	//flush cache - GCC/LLVM builtin
-	__builtin___clear_cache((char *)block_start, (char *)(block_start+block_size));
-}
+static void cache_block_closing(MAYBE_UNUSED const Bit8u *block_start,
+                                MAYBE_UNUSED Bitu block_size) { }
 
 static void cache_block_before_close(void) { }
 

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -783,15 +783,17 @@ static inline void dyn_mem_write(MAYBE_UNUSED void *ptr, MAYBE_UNUSED size_t siz
 
 static inline void dyn_cache_invalidate(MAYBE_UNUSED void *ptr, MAYBE_UNUSED size_t size)
 {
-#if defined(HAVE_SYS_ICACHE_INVALIDATE)
+#if defined(HAVE_BUILTIN_CLEAR_CACHE)
+	__builtin___clear_cache(static_cast<char *>(ptr), reinterpret_cast<char *>(reinterpret_cast<uintptr_t>(ptr) + size));		
+#elif defined(HAVE_SYS_ICACHE_INVALIDATE)
 #if defined(HAVE_BUILTIN_AVAILABLE)
 	if (__builtin_available(macOS 11.0, *))
 #endif	
 		sys_icache_invalidate(ptr, size);
-#elif defined(__GNUC__)
-	__builtin___clear_cache(static_cast<char *>(ptr), reinterpret_cast<char *>(reinterpret_cast<uintptr_t>(ptr) + size));		
 #elif defined(WIN32)
 	FlushInstructionCache(GetCurrentProcess(), ptr, size);
+#else
+	#error "Don't know how to clear the cache on this platform"
 #endif
 }
 

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -822,8 +822,8 @@ static void cache_init(bool enable) {
 #if defined (WIN32)
 			cache_code_start_ptr = static_cast<uint8_t *>(
 			        VirtualAlloc(nullptr, cache_code_size,
-			                     MEM_COMMIT,
-			                     PAGE_EXECUTE_READWRITE));
+			                     MEM_RESERVE | MEM_COMMIT,
+			                     PAGE_READWRITE));
 			if (!cache_code_start_ptr) {
 				LOG_MSG("VirtualAlloc error, using malloc");
 				cache_code_start_ptr=static_cast<uint8_t *>(malloc(cache_code_size));

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -784,7 +784,9 @@ static inline void dyn_mem_write(MAYBE_UNUSED void *ptr, MAYBE_UNUSED size_t siz
 static inline void dyn_cache_invalidate(MAYBE_UNUSED void *ptr, MAYBE_UNUSED size_t size)
 {
 #if defined(HAVE_BUILTIN_CLEAR_CACHE)
-	__builtin___clear_cache(static_cast<char *>(ptr), reinterpret_cast<char *>(reinterpret_cast<uintptr_t>(ptr) + size));		
+	__builtin___clear_cache(static_cast<char *>(ptr),
+	                        reinterpret_cast<char *>(
+	                                reinterpret_cast<uintptr_t>(ptr) + size));
 #elif defined(HAVE_SYS_ICACHE_INVALIDATE)
 #if defined(HAVE_BUILTIN_AVAILABLE)
 	if (__builtin_available(macOS 11.0, *))


### PR DESCRIPTION
This fixes segfaults for 32-bit builds on x86 and ARM platforms running dynamic core. The root cause was not entirely clear, since 64-bit builds have no issues, but the behavior suggests that the memory range that gets toggled between write and execute permissions during codegen was somehow incomplete. The system would segfault after a codegen when reading memory that didn't seem to belong to codegen. Simply subtracting 1 from the start of the cache block's start address and increasing the size of the toggled memory space was sufficient.

I also took the opportunity to simplify and genericize the cache invalidation logic, as there was redundant cache clearing code for several platforms via the `cache_block_closing` function using inline assembly. This includes creating a Meson-level define for `__builtin___clear_cache` and preferring to use that, only falling back to OS-specific calls for Windows and macOS if it's unavailable. Compiling will also now error out if there is no suitable cache invalidation function available.

I've prepared this as four distinct commits for each piece of functionality, due to the low-level nature of the changes, for bisecting purposes.

Fixes #1196