### PR TITLE
Drop unused coarse cosine and sine functions

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -24,11 +24,9 @@
 
 #include "dosbox.h"
 
-#define _USE_MATH_DEFINES
-#include <cmath>
-
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -236,37 +234,6 @@ std::vector<std::string> split(const std::string &seq);
 
 bool is_executable_filename(const std::string &filename) noexcept;
 
-// Coarse but fast sine and cosine approximations. Accuracy ranges from 0.0005
-// to 0.098 and speed ranges from ~3 to 5x faster than floats with cosf/sinf and
-// ~10x faster than doubles with sin/cos.
-
-// Only consider using these if the benefit of adding sine and cosine even with
-// the reduced accuracy outweighs the loss of using an outright inferior
-// technique. For example, fitting a curve using sine and cosine versus no
-// curve-fitting using linear-only interpolation.
-constexpr float coarse_sin(float x)
-{
-	constexpr int fact_3 = 1 * 2 * 3;
-	constexpr int fact_5 = fact_3 * 4 * 5;
-	constexpr int fact_7 = fact_5 * 6 * 7;
-
-	const float x_pow_2 = x * x;
-	const float x_pow_3 = x_pow_2 * x;
-	const float x_pow_5 = x_pow_3 * x_pow_2;
-	const float x_pow_7 = x_pow_5 * x_pow_2;
-
-	const float taylor_1 = x - (x_pow_3 / fact_3);
-	const float taylor_2 = taylor_1 + (x_pow_5 / fact_5);
-	const float taylor_3 = taylor_2 - (x_pow_7 / fact_7);
-
-	return taylor_3;
-}
-
-constexpr float coarse_cos(float x)
-{
-	constexpr auto half_pi = static_cast<float>(M_PI_2);
-	return coarse_sin(x + half_pi);
-}
 
 // Use ARRAY_LEN macro to safely calculate number of elements in a C-array.
 // This macro can be used in a constant expressions, even if array is a


### PR DESCRIPTION
Fixes a recent msys2 build issue reported by @ajaja; thank you for the report and test confirmation!

> There is an error now with msys2/clang64:

``` text
[115/179] Compiling C++ object src/hardware/libhardware.a.p/timer.cpp.obj
FAILED: src/hardware/libhardware.a.p/timer.cpp.obj
"clang++" "-Isrc/hardware/libhardware.a.p" "-Isrc/hardware" "-I../src/hardware" "-I../include" "-I." "-I.." "-IZ:/msys64/clang64/include/libpng16" "-IZ:/msys64/clang64/include" "-IZ:/msys64/clang64/include/SDL2" "-fcolor-diagnostics" "-DNDEBUG" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wnon-virtual-dtor" "-std=c++14" "-O3" "-Weffc++" "-Wextra-semi" "-O3" "-O3" "-Dmain=SDL_main" -MD -MQ src/hardware/libhardware.a.p/timer.cpp.obj -MF "src/hardware/libhardware.a.p/timer.cpp.obj.d" -o src/hardware/libhardware.a.p/timer.cpp.obj "-c" ../src/hardware/timer.cpp
In file included from ../src/hardware/timer.cpp:28:
../include/support.h:267:46: error: use of undeclared identifier 'M_PI_2'
        constexpr auto half_pi = static_cast<float>(M_PI_2);
                                                    ^
../include/support.h:267:17: warning: uninitialized variable in a constexpr function is a C++20 extension [-Wc++20-extensions]
        constexpr auto half_pi = static_cast<float>(M_PI_2);
```
