### PR TITLE
Clarify use of Meson from pip for Debian <= 10 and Ubuntu <= 20.04

### DIFF
--- a/.github/packages/ubuntu-16.04-apt.txt
+++ b/.github/packages/ubuntu-16.04-apt.txt
@@ -5,3 +5,4 @@ libopusfile-dev
 libpng-dev
 libsdl2-dev
 libsdl2-net-dev
+python3-setuptools

--- a/.github/packages/ubuntu-18.04-apt.txt
+++ b/.github/packages/ubuntu-18.04-apt.txt
@@ -5,3 +5,4 @@ libopusfile-dev
 libpng-dev
 libsdl2-dev
 libsdl2-net-dev
+python3-setuptools

--- a/.github/packages/ubuntu-20.04-apt.txt
+++ b/.github/packages/ubuntu-20.04-apt.txt
@@ -7,3 +7,4 @@ libopusfile-dev
 libpng-dev
 libsdl2-dev
 libsdl2-net-dev
+python3-setuptools

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get install $(cat .github/packages/ubuntu-20.04-apt.txt)
+          sudo pip3 install --upgrade meson ninja
 
       - name:  Install dependencies (macOS)
         if:    matrix.system.name == 'macOS'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Install dependencies (minimum set)
         if:   matrix.conf.min_dependencies
         run: |
-          sudo apt-get install -y build-essential ccache libsdl2-dev libopusfile-dev
+          sudo apt-get install -y build-essential ccache libsdl2-dev libopusfile-dev python3-setuptools
+          sudo pip3 install --upgrade meson ninja
 
       - name: Install dependencies
         if:   matrix.conf.min_dependencies != true
@@ -88,11 +89,6 @@ jobs:
           sudo apt-get install -y \
             ${{ matrix.conf.packages }} \
             $(cat ./.github/packages/${{ matrix.conf.os }}-apt.txt)
-
-      - name: Install Meson via pip3
-#        if:   matrix.conf.os != 'ubuntu-20.04'
-        run: |
-          sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
@@ -150,16 +146,11 @@ jobs:
 
       - run:  sudo apt-get update
 
-      - name: Install C++ compiler and libraries
+      - name: Install dependencies
         run: |
           sudo apt-get install -y tree \
             $(cat ./.github/packages/ubuntu-18.04-apt.txt)
-
-      - name: Install Meson via pip3
-        if:   matrix.conf.os != 'ubuntu-20.04'
-        run: |
-          sudo apt-get install python3-setuptools
-          sudo pip3 install meson ninja
+          sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
         id:    prep-ccache

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -50,6 +50,7 @@ jobs:
             set -xo pipefail
             apt-get update
             apt-get install -y $(cat ./.github/packages/ubuntu-20.04-apt.txt)
+            pip3 install --upgrade meson ninja
             ./scripts/log-env.sh
             meson build \
               -Duse_fluidsynth=false \

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -22,15 +22,12 @@ jobs:
     strategy:
       matrix:
         conf:
-          # - name: ARMv6 (Debian Buster)
-          #   arch: armv6
-          #   distro: buster
-          # - name: ARMv7 (Debian Buster)
-          #   arch: armv7
-          #   distro: buster
-          # - name: ARMv8 AArch64 (Ubuntu 18.04)
-          #   arch: aarch64
-          #   distro: ubuntu18.04
+          - name: ARMv7 (Ubuntu 20.04)
+            arch: armv7
+            distro: ubuntu20.04
+          - name: ARM64 (Ubuntu 20.04)
+            arch: aarch64
+            distro: ubuntu20.04
           - name: s390x (Ubuntu 20.04)
             arch: s390x
             distro: ubuntu20.04

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -28,17 +28,13 @@ jobs:
         if:    steps.cache-pvs.outputs.cache-hit != 'true'
         run:   wget "https://files.viva64.com/${debfile}" -O "pvs-package/pvs.deb"
 
-      - name: Install packages
+      - name: Install dependencies
         run: |
           set -xeu
           sudo apt-get install -y strace $(cat .github/packages/ubuntu-20.04-apt.txt)
+          sudo pip3 install --upgrade meson ninja
           sudo dpkg -i "pvs-package/pvs.deb"
           pvs-studio-analyzer credentials "${{ secrets.PvsStudioName }}" "${{ secrets.PvsStudioKey }}"
-
-      - name: Install Meson via pip3
-        run: |
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade meson ninja
 
       - name:  Cache subprojects
         uses:  actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -134,8 +134,19 @@ sudo dnf install ccache gcc-c++ meson alsa-lib-devel libpng-devel \
 
 ``` shell
 # Debian, Ubuntu
-sudo apt install ccache build-essential meson libasound2-dev libpng-dev \
+sudo apt install ccache build-essential libasound2-dev libpng-dev \
                  libsdl2-dev libsdl2-net-dev libopusfile-dev libfluidsynth-dev
+```
+
+## Install Meson on Debian-10 "Buster" or Ubuntu-20.04 and older
+``` shell
+sudo apt install python3-setuptools
+sudo pip3 install --upgrade meson ninja
+```
+
+## Install Meson on Debian-11 "Bullseye" or Ubuntu-21.04 and newer
+``` shell
+sudo apt install meson
 ```
 
 ``` shell


### PR DESCRIPTION
Also enables ARMv7 and ARM64 platform CI builds.

Fixes the config heavy workflow:
![2021-08-18_18-32](https://user-images.githubusercontent.com/1557255/129993902-b4b79d73-d981-4c1e-adef-f8b1fd92099e.png)

Fixes the platform workflow:
![2021-08-18_18-33](https://user-images.githubusercontent.com/1557255/129993942-60e73d80-6dea-49c5-86cb-6f138c59c345.png)
