### PR TITLE
Add risc_x64.h to VS2019 solution

### DIFF
--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -487,6 +487,7 @@
     <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu.h" />
     <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu_dh.h" />
     <ClInclude Include="..\src\cpu\core_dyn_x86\helpers.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x64.h" />
     <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x86.h" />
     <ClInclude Include="..\src\cpu\core_dyn_x86\string.h" />
     <ClInclude Include="..\src\cpu\core_full\ea_lookup.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -912,6 +912,9 @@
     <ClInclude Include="..\src\libs\residfp\WaveformGenerator.h">
       <Filter>src\libs\residfp</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x64.h">
+      <Filter>src\cpu\core_dyn_x86</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\winres.rc">


### PR DESCRIPTION
There are no code changes here, only the addition of the file `risc_x64.h` to the Visual Studio solution for editing convenience.