### PR TITLE
Add composite video mode settings to conf file

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -274,6 +274,22 @@ constexpr size_t static_if_array_then_zero()
 //
 std::string safe_strerror(int err) noexcept;
 
-#endif
-
 void set_thread_name(std::thread &thread, const char *name);
+
+/*
+  Returns a number wrapped between the lower and upper bounds.
+   - wrap(-1, 0, 4); // Returns 4
+   - wrap(5, 0, 4); // Returns 0
+
+  All credit to Charles Bailey, https://stackoverflow.com/a/707426
+*/
+constexpr int wrap(int val, int const lower_bound, int const upper_bound)
+{
+	const auto range_size = upper_bound - lower_bound + 1;
+	if (val < lower_bound)
+		val += range_size * ((lower_bound - val) / range_size + 1);
+
+	return lower_bound + (val - lower_bound) % range_size;
+}
+
+#endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -22,8 +22,9 @@
 #include "dosbox.h"
 
 #include "inout.h"
+#include "control.h"
 
-// Don't enable keeping changes and mapping lfb probably...
+//Don't enable keeping changes and mapping lfb probably...
 #define VGA_LFB_MAPPED
 //#define VGA_KEEP_CHANGES
 #define VGA_CHANGE_SHIFT	9
@@ -477,6 +478,7 @@ void VGA_SetupGFX(void);
 void VGA_SetupSEQ(void);
 void VGA_SetupOther(void);
 void VGA_SetupXGA(void);
+void VGA_AddCompositeSettings(Config &conf);
 
 /* Some Support Functions */
 void VGA_SetClock(Bitu which, uint32_t target);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -585,6 +585,10 @@ void DOSBOX_Init(void) {
 	                  "scan2x, scan3x, tv2x, tv3x, sharp (default).");
 #endif
 
+	// Add the [composite] conf block after [render]
+	assert(control);
+	VGA_AddCompositeSettings(*control);
+
 	secprop=control->AddSection_prop("cpu",&CPU_Init,true);//done
 	const char* cores[] = { "auto",
 #if (C_DYNAMIC_X86) || (C_DYNREC)

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -111,23 +111,23 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 
 	// Simulate CGA composite output
 	int *o = temp;
-	auto OUT = [&](const int v) {
-		*o = (v);
+	auto push_pixel = [&o](const int v) {
+		*o = v;
 		++o;
 	};
 
 	Bit8u *rgbi = TempLine;
 	int *b = &CGA_Composite_Table[border * 68];
 	for (int x = 0; x < 4; ++x)
-		OUT(b[(x + 3) & 3]);
-	OUT(CGA_Composite_Table[(border << 6) | ((*rgbi) << 2) | 3]);
+		push_pixel(b[(x + 3) & 3]);
+	push_pixel(CGA_Composite_Table[(border << 6) | ((*rgbi) << 2) | 3]);
 	for (int x = 0; x < w - 1; ++x) {
-		OUT(CGA_Composite_Table[(rgbi[0] << 6) | (rgbi[1] << 2) | (x & 3)]);
+		push_pixel(CGA_Composite_Table[(rgbi[0] << 6) | (rgbi[1] << 2) | (x & 3)]);
 		++rgbi;
 	}
-	OUT(CGA_Composite_Table[((*rgbi) << 6) | (border << 2) | 3]);
+	push_pixel(CGA_Composite_Table[((*rgbi) << 6) | (border << 2) | 3]);
 	for (int x = 0; x < 5; ++x)
-		OUT(b[x & 3]);
+		push_pixel(b[x & 3]);
 
 	if ((vga.tandy.mode_control & 4) != 0) {
 		// Decode

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -428,15 +428,16 @@ static void update_cga16_color()
 	                           ? new_cga_v(chroma_multiplexer[255], i3, i3, i3, i3)
 	                           : chroma_multiplexer[255] + i3;
 
-	const auto mode_contrast = 2.56f * contrast / (max_v - min_v);
+	const auto mode_contrast = 2.56f * static_cast<float>(contrast) / (max_v - min_v);
 
-	const auto mode_brightness = brightness * 5 - 256 * min_v / (max_v - min_v);
+	const auto mode_brightness = static_cast<float>(brightness) * 5 - 256 * min_v / (max_v - min_v);
 
 	const bool in_tandy_text_mode = (vga.mode == M_CGA_TEXT_COMPOSITE) &&
 	                                (vga.tandy.mode_control & 1);
 	const auto mode_hue = in_tandy_text_mode ? 14.0f : 4.0f;
 
-	const auto mode_saturation = saturation * (is_composite_new_era ? 5.8f : 2.9f) / 100;
+	const auto mode_saturation = static_cast<float>(saturation) *
+	                             (is_composite_new_era ? 5.8f : 2.9f) / 100;
 
 	// Update the Composite CGA palette
 	const bool in_tandy_mode_4 = vga.tandy.mode_control & 4;
@@ -476,7 +477,7 @@ static void update_cga16_color()
 	const auto q = static_cast<float>(CGA_Composite_Table[6 * 68 + 1] -
 	                                  CGA_Composite_Table[6 * 68 + 3]);
 
-	const auto a = tau * (33 + 90 + hue_offset + mode_hue) / 360.0f;
+	const auto a = tau * (33 + 90 + static_cast<float>(hue) + mode_hue) / 360.0f;
 	const auto c = cosf(a);
 	const auto s = sinf(a);
 

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "control.h"
 #include "inout.h"
 #include "mapper.h"
 #include "mem.h"
@@ -199,11 +200,32 @@ static void write_lightpen(io_port_t port, uint8_t /*val*/, io_width_t)
 	}
 }
 
-static int16_t brightness = 0;
-static int16_t contrast = 100;
-static int16_t saturation = 100;
-static int16_t sharpness = 0;
-static int16_t hue_offset = 0;
+constexpr int16_t hue_min = 0;
+constexpr int16_t hue_mid = 0;
+constexpr int16_t hue_max = 360;
+constexpr int16_t hue_pcjr_rotation = 100;
+static int hue = hue_mid;
+
+constexpr int16_t saturation_min = 0;
+constexpr int16_t saturation_mid = 100;
+constexpr int16_t saturation_max = 400;
+static int saturation = saturation_mid;
+
+constexpr int16_t contrast_min = 0;
+constexpr int16_t contrast_mid = 100;
+constexpr int16_t contrast_max = 256;
+static int contrast = contrast_mid;
+
+constexpr int16_t brightness_min = -50;
+constexpr int16_t brightness_mid = 0;
+constexpr int16_t brightness_max = 50;
+static int brightness = brightness_mid;
+
+constexpr int16_t convergence_min = -256;
+constexpr int16_t convergence_mid = 0;
+constexpr int16_t convergence_max = 256;
+static int convergence = convergence_mid;
+
 static uint8_t cga_comp = 0;
 static bool is_composite_new_era = false;
 
@@ -501,7 +523,152 @@ static void update_cga16_color()
 	vga.gq = static_cast<int>(-gi * iq_adjust_q + gq * iq_adjust_i);
 	vga.bi = static_cast<int>(bi * iq_adjust_i + bq * iq_adjust_q);
 	vga.bq = static_cast<int>(-bi * iq_adjust_q + bq * iq_adjust_i);
-	vga.sharpness = sharpness * 256 / 100;
+	vga.sharpness = convergence * 256 / 100;
+}
+
+constexpr int16_t percent_min = 0;
+constexpr int16_t percent_mid = 50;
+constexpr int16_t percent_max = 100;
+
+// Takes in a percent from 0 to 100% and maps that to 360 degree hue space.
+// The default percent is 50% "mid-point", which maps to 0 degrees.
+// PCjr is always rotated ahead by 100 degrees.
+static void set_hue_from_percent(int percent)
+{
+	assert(percent >= percent_min && percent <= percent_max);
+
+	percent -= percent_mid;                // switch to zero-based
+	hue = percent * hue_max / percent_max; // to 360 degrees
+	hue += (machine == MCH_PCJR ? hue_pcjr_rotation : 0);
+	hue = wrap(hue, hue_min, hue_max); // stay in-bounds
+
+	assert(hue >= hue_min && hue <= hue_max);
+}
+
+// Returns the percent from hue, based on the above relationship.
+static int get_percent_from_hue()
+{
+	assert(hue >= hue_min && hue <= hue_max);
+
+	const auto adjustment = (machine == MCH_PCJR ? hue_pcjr_rotation : 0);
+	auto percent = (hue - adjustment) * percent_max / hue_max;
+	percent = wrap(percent + percent_mid, percent_min, percent_max);
+	assert(percent >= percent_min && percent <= percent_max);
+	return percent;
+}
+
+// Takes in a percent from 0 to 100% and maps that to saturation from 0 to 400.
+// The default percent is 50% "mid-point", which maps to a saturation of 100.
+static void set_saturation_from_percent(int percent)
+{
+	assert(percent >= percent_min && percent <= percent_max);
+
+	// percentages 50% and above map to maginitudes from 100 to 400:
+	if (percent >= percent_mid)
+		saturation = saturation_mid + (percent - percent_mid) *
+		                                      (saturation_max - saturation_mid) / percent_mid;
+	// Below 50% maps to maginitudes from 0 to 99:
+	else
+		saturation = percent * saturation_mid / percent_mid;
+
+	assert(saturation >= saturation_min && saturation <= saturation_max);
+}
+
+// Returns the percent from saturation, based on the above relationship.
+static int get_percent_from_saturation()
+{
+	assert(saturation >= saturation_min && saturation <= saturation_max);
+
+	// saturations 100 and above map to percentages from 50 to 100:
+	auto percent = 0;
+	if (saturation >= saturation_mid)
+		percent = percent_mid + (saturation - saturation_mid) * percent_mid /
+		                                (saturation_max - saturation_mid);
+	// Below 100 saturation maps to percentages from 0 to 49:
+	else
+		percent = saturation * percent_mid / saturation_mid;
+
+	assert(percent >= percent_min && percent <= percent_max);
+	return percent;
+}
+
+// Takes in a percent from 0 to 100% and maps that to contrast from 15 to 500.
+// The default percent is 50% "mid-point", which maps to a contrast of 100.
+static void set_contrast_from_percent(int percent)
+{
+	assert(percent >= percent_min && percent <= percent_max);
+
+	// percentages 50% and above map to maginitudes from 100 to 500:
+	if (percent >= percent_mid)
+		contrast = contrast_mid +
+		           (percent - percent_mid) * (contrast_max - contrast_mid) / percent_mid;
+	// Below 50% maps to maginitudes from 15 to 99:
+	else
+		contrast = contrast_min + percent * (contrast_mid - contrast_min) / percent_mid;
+
+	assert(contrast >= contrast_min && contrast <= contrast_max);
+}
+
+// Returns the percent from contrast, based on the above relationship.
+static int get_percent_from_contrast()
+{
+	assert(contrast >= contrast_min && contrast <= contrast_max);
+
+	// contrasts 100 to 500 map to percentages from 50 to 100:
+	auto percent = 0;
+	if (contrast >= contrast_mid)
+		percent = percent_mid +
+		          (contrast - contrast_mid) * percent_mid / (contrast_max - contrast_mid);
+	// Below 100 contrast maps to percentages from 0 to 49:
+	else
+		percent = (contrast - contrast_min) * percent_mid / (contrast_mid - contrast_min);
+
+	assert(percent >= percent_min && percent <= percent_max);
+	return percent;
+}
+
+// Takes in a percent from 0 to 100% and maps that to brightness from -50 to +50
+// The default percent is 50% "mid-point", which maps to a brightness of 0.
+static void set_brightness_from_percent(int percent)
+{
+	assert(percent >= percent_min && percent <= percent_max);
+
+	brightness = percent - percent_mid;
+
+	assert(brightness >= brightness_min && brightness <= brightness_max);
+}
+
+// Returns the percent from brightness, based on the above relationship.
+static int get_percent_from_brightness()
+{
+	assert(brightness >= brightness_min && brightness <= brightness_max);
+
+	const auto percent = brightness + percent_mid;
+
+	assert(percent >= percent_min && percent <= percent_max);
+	return percent;
+}
+
+// Takes in a percent from 0 to 100% and maps that to convergence from -256 to 256
+// The default percent is 50% "mid-point", which maps to a convergence of 0.
+static void set_convergence_from_percent(int percent)
+{
+	assert(percent >= percent_min && percent <= percent_max);
+
+	percent -= percent_mid; // convert from 50% mid-point to zero-based
+	convergence = percent * convergence_max / percent_mid; // to degrees
+	assert(convergence >= convergence_min && convergence <= convergence_max);
+}
+
+// Returns the percent from convergence, based on the above relationship.
+static int get_percent_from_convergence()
+{
+	assert(convergence >= convergence_min && convergence <= convergence_max);
+
+	const auto percent = percent_mid + convergence * percent_mid / convergence_max;
+
+	assert(percent >= percent_min && percent <= percent_max);
+	return percent;
 }
 
 enum CRT_KNOB : uint8_t {
@@ -510,7 +677,7 @@ enum CRT_KNOB : uint8_t {
 	SATURATION,
 	CONTRAST,
 	BRIGHTNESS,
-	SHARPNESS,
+	CONVERGENCE,
 	ENUM_END
 };
 static auto crt_knob = CRT_KNOB::ERA;
@@ -523,19 +690,23 @@ static void log_crt_knob_value()
 		        is_composite_new_era ? "New" : "Old");
 		break;
 	case CRT_KNOB::HUE:
-		LOG_MSG("COMPOSITE: Hue is %d", hue_offset);
+		LOG_MSG("COMPOSITE: Hue is %d%%", get_percent_from_hue());
 		break;
 	case CRT_KNOB::SATURATION:
-		LOG_MSG("COMPOSITE: Saturation at %d", saturation);
+		LOG_MSG("COMPOSITE: Saturation is %d%%",
+		        get_percent_from_saturation());
 		break;
 	case CRT_KNOB::CONTRAST:
-		LOG_MSG("COMPOSITE: Contrast at %d", contrast);
+		LOG_MSG("COMPOSITE: Contrast is %d%%",
+		        get_percent_from_contrast());
 		break;
 	case CRT_KNOB::BRIGHTNESS:
-		LOG_MSG("COMPOSITE: Brightness at %d", brightness);
+		LOG_MSG("COMPOSITE: Brightness is %d%%",
+		        get_percent_from_brightness());
 		break;
-	case CRT_KNOB::SHARPNESS:
-		LOG_MSG("COMPOSITE: Sharpness at %d", sharpness);
+	case CRT_KNOB::CONVERGENCE:
+		LOG_MSG("COMPOSITE: Convergence is %d%%",
+		        get_percent_from_convergence());
 		break;
 	case CRT_KNOB::ENUM_END:
 		assertm(false, "Should not reach CRT knob end marker");
@@ -549,14 +720,20 @@ static void turn_crt_knob(bool pressed, const int amount)
 		return;
 	switch (crt_knob) {
 	case CRT_KNOB::ERA: is_composite_new_era = !is_composite_new_era; break;
-	case CRT_KNOB::HUE: hue_offset = (hue_offset + amount) % 360; break;
-	case CRT_KNOB::SATURATION: saturation += amount; break;
-	case CRT_KNOB::CONTRAST: contrast += amount; break;
-	case CRT_KNOB::BRIGHTNESS: brightness += amount; break;
-	case CRT_KNOB::SHARPNESS: sharpness += amount; break;
-	case CRT_KNOB::ENUM_END:
-		assertm(false, "Should not reach CRT knob end marker");
+	case CRT_KNOB::HUE: hue = wrap(hue + amount, hue_min, hue_max); break;
+	case CRT_KNOB::SATURATION:
+		saturation = wrap(saturation + amount, saturation_min, saturation_max);
 		break;
+	case CRT_KNOB::CONTRAST:
+		contrast = wrap(contrast + amount, contrast_min, contrast_max);
+		break;
+	case CRT_KNOB::BRIGHTNESS:
+		brightness = wrap(brightness + amount, brightness_min, brightness_max);
+		break;
+	case CRT_KNOB::CONVERGENCE:
+		convergence = wrap(convergence + amount, convergence_min, convergence_max);
+		break;
+	case CRT_KNOB::ENUM_END: assertm(false, "Should not reach CRT knob end marker"); break;
 	}
 	update_cga16_color();
 	log_crt_knob_value();
@@ -754,7 +931,6 @@ static void TANDY_FindMode()
 
 static void PCJr_FindMode()
 {
-	is_composite_new_era = true;
 	if (vga.tandy.mode_control & 0x2) {
 		if (vga.tandy.mode_control & 0x10) {
 			// bit4 of mode control 1 signals 16 colour graphics mode
@@ -1167,7 +1343,7 @@ void VGA_SetupOther()
 	}
 	if (machine==MCH_PCJR) {
 		// Start the PCjr composite huge almost 1/3rd into the CGA hue
-		hue_offset = 100;
+		hue = hue_pcjr_rotation;
 
 		//write_pcjr will setup base address
 		write_pcjr(0x3df, 0x7 | (0x7 << 3), io_width_t::byte);
@@ -1206,4 +1382,78 @@ void VGA_SetupOther()
 			IO_RegisterReadHandler(base + port_ct * 2 + 1, read_crtc_data_other, io_width_t::byte);
 		}
 	}
+}
+static void composite_init(Section *sec)
+{
+	assert(sec);
+	const auto conf = static_cast<Section_prop *>(sec);
+	assert(conf);
+	const std::string state = conf->Get_string("composite");
+	cga_comp = (state == "auto" ? 0 : state == "on" ? 1 : 2);
+
+	const auto era_choice = std::string(conf->Get_string("era"));
+	is_composite_new_era = era_choice == "new" ||
+	                       (machine == MCH_PCJR && era_choice == "auto");
+
+	set_hue_from_percent(conf->Get_int("hue"));
+	set_saturation_from_percent(conf->Get_int("saturation"));
+	set_contrast_from_percent(conf->Get_int("contrast"));
+	set_brightness_from_percent(conf->Get_int("brightness"));
+	set_convergence_from_percent(conf->Get_int("convergence"));
+
+	if (cga_comp == COMPOSITE_STATE::ON) {
+		LOG_MSG("COMPOSITE: %s-era enabled with hue %d%%, saturation %d%%,"
+		        " contrast %d%%, brightness %d%%, and convergence %d%%",
+		        is_composite_new_era ? "New" : "Old",
+		        get_percent_from_hue(), get_percent_from_saturation(),
+		        get_percent_from_contrast(), get_percent_from_brightness(),
+		        get_percent_from_convergence());
+	}
+}
+
+static void composite_settings(Section_prop &secprop)
+{
+	constexpr auto when_idle = Property::Changeable::WhenIdle;
+
+	const char *states[] = {"auto", "on", "off", 0};
+	auto str_prop = secprop.Add_string("composite", when_idle, "auto");
+	str_prop->Set_values(states);
+	str_prop->Set_help("Enable composite mode on start. 'auto' lets the program decide.");
+
+	const char *eras[] = {"auto", "old", "new", 0};
+	str_prop = secprop.Add_string("era", when_idle, "auto");
+	str_prop->Set_values(eras);
+	str_prop->Set_help(
+	        "Era of composite technology. When 'auto', PCjr is 'new' and others are 'old'.");
+
+	auto int_prop = secprop.Add_int("hue", when_idle, 50);
+	int_prop->SetMinMax(percent_min, percent_max);
+	int_prop->Set_help(
+	        "Appearance of RGB palette. For example, adjust until sky is blue. 0-100%, default is 50%.");
+
+	int_prop = secprop.Add_int("saturation", when_idle, 50);
+	int_prop->SetMinMax(percent_min, percent_max);
+	int_prop->Set_help(
+	        "Intensity of colors, from vivid to washed out. 0-100%, default is 50%.");
+
+	int_prop = secprop.Add_int("contrast", when_idle, 50);
+	int_prop->SetMinMax(percent_min, percent_max);
+	int_prop->Set_help("Ratio between the light and dark. 0-100%, default is 50%.");
+
+	int_prop = secprop.Add_int("brightness", when_idle, 50);
+	int_prop->SetMinMax(percent_min, percent_max);
+	int_prop->Set_help(
+	        "Luminosity of the image, from overall light to dark. 0-100%, default is 50%.");
+
+	int_prop = secprop.Add_int("convergence", when_idle, 50);
+	int_prop->SetMinMax(percent_min, percent_max);
+	int_prop->Set_help(
+	        "Convergence of subpixel elements, from focused to deconverged. 0-100%, default is 50%.");
+}
+
+void VGA_AddCompositeSettings(Config &conf)
+{
+	auto sec = conf.AddSection_prop("composite", &composite_init, true);
+	assert(sec);
+	composite_settings(*sec);
 }

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -845,7 +845,17 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 
 static void PCJr_FindMode();
 
-static void Composite(bool pressed) {
+static void apply_composite_state()
+{
+	// switch RGB and Composite if in graphics mode
+	if (vga.tandy.mode_control & 0x2 && machine == MCH_PCJR)
+		PCJr_FindMode();
+	else
+		write_cga(0x3d8, vga.tandy.mode_control, io_width_t::byte);
+}
+
+static void Composite(bool pressed)
+{
 	if (!pressed)
 		return;
 
@@ -860,11 +870,7 @@ static void Composite(bool pressed) {
 	LOG_MSG("COMPOSITE: State is %s", cga_comp == COMPOSITE_STATE::AUTO ? "auto"
 	                                  : cga_comp == COMPOSITE_STATE::ON ? "on"
 	                                                                    : "off");
-	// switch RGB and Composite if in graphics mode
-	if (vga.tandy.mode_control & 0x2 && machine == MCH_PCJR)
-		PCJr_FindMode();
-	else
-		write_cga(0x3d8, vga.tandy.mode_control, io_width_t::byte);
+	apply_composite_state();
 }
 
 static void tandy_update_palette() {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1067,6 +1067,9 @@ static void write_tandy(io_port_t port, uint8_t val, io_width_t)
 	case 0x3d9:
 		vga.tandy.color_select=val;
 		tandy_update_palette();
+		// Re-apply the composite mode after updating the palette
+		if (cga_comp == COMPOSITE_STATE::ON)
+			apply_composite_state();
 		break;
 	case 0x3da:
 		vga.tandy.reg_index = val;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -912,11 +912,9 @@ static void tandy_update_palette() {
 		// PCJr
 		switch (vga.mode) {
 		case M_TANDY2:
-		case M_CGA2_COMPOSITE:
 			VGA_SetCGA2Table(vga.attr.palette[0],vga.attr.palette[1]);
 			break;
 		case M_TANDY4:
-		case M_CGA4_COMPOSITE:
 			VGA_SetCGA4Table(
 				vga.attr.palette[0], vga.attr.palette[1],
 				vga.attr.palette[2], vga.attr.palette[3]);
@@ -986,6 +984,8 @@ static void PCJr_FindMode()
 			    (cga_comp == COMPOSITE_STATE::AUTO &&
 			     !(vga.tandy.mode_control & 0x4))) {
 				VGA_SetMode(M_CGA2_COMPOSITE);
+				update_cga16_color();
+
 			} else {
 				VGA_SetMode(M_TANDY2);
 			}
@@ -998,6 +998,9 @@ static void PCJr_FindMode()
 				VGA_SetModeNow(new_mode);
 			} else {
 				VGA_SetMode(new_mode);
+			}
+			if (cga_comp == COMPOSITE_STATE::ON) {
+				update_cga16_color();
 			}
 		}
 		tandy_update_palette();

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -838,9 +838,15 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 static void PCJr_FindMode();
 
 static void Composite(bool pressed) {
-	if (!pressed) return;
-	if (++cga_comp>2) cga_comp=0;
-	LOG_MSG("Composite output: %s",(cga_comp==0)?"auto":((cga_comp==1)?"on":"off"));
+	if (!pressed)
+		return;
+
+	if (++cga_comp > 2)
+		cga_comp = 0;
+
+	LOG_MSG("COMPOSITE: State is %s", cga_comp == 0   ? "auto"
+	                                  : cga_comp == 1 ? "on"
+	                                                  : "off");
 	// switch RGB and Composite if in graphics mode
 	if (vga.tandy.mode_control & 0x2 && machine == MCH_PCJR)
 		PCJr_FindMode();

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1338,16 +1338,7 @@ void VGA_SetupOther()
 	if (machine==MCH_CGA) {
 		IO_RegisterWriteHandler(0x3d8, write_cga, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3d9, write_cga, io_width_t::byte);
-		if (!mono_cga) {
-			MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10,
-			                  0, "select", "Sel Knob");
-			MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11,
-			                  0, "incval", "Inc Knob");
-			MAPPER_AddHandler(turn_crt_knob_negative, SDL_SCANCODE_F11,
-			                  MMOD2, "decval", "Dec Knob");
-			MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0,
-			                  "cgacomp", "CGA Comp");
-		} else {
+		if (mono_cga) {
 			MAPPER_AddHandler(CycleMonoCGAPal, SDL_SCANCODE_F11, 0,
 			                  "monocgapal", "Mono CGA Pal");
 			MAPPER_AddHandler(CycleMonoCGABright, SDL_SCANCODE_F11, MMOD2,
@@ -1370,10 +1361,18 @@ void VGA_SetupOther()
 		write_pcjr(0x3df, 0x7 | (0x7 << 3), io_width_t::byte);
 		IO_RegisterWriteHandler(0x3da, write_pcjr, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3df, write_pcjr, io_width_t::byte);
-		MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10, 0, "select", "Sel Knob");
-		MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11, 0, "incval", "Inc Knob");
-		MAPPER_AddHandler(turn_crt_knob_negative, SDL_SCANCODE_F11, MMOD2, "decval", "Dec Knob");
-		MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0, "cgacomp", "CGA Comp");
+	}
+	// Add composite hotkeys for CGA, Tandy, and PCjr
+	if ((machine == MCH_CGA && !mono_cga) || machine == MCH_TANDY ||
+	    machine == MCH_PCJR) {
+		MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10, 0,
+		                  "select", "Sel Knob");
+		MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11, 0,
+		                  "incval", "Inc Knob");
+		MAPPER_AddHandler(turn_crt_knob_negative, SDL_SCANCODE_F11,
+		                  MMOD2, "decval", "Dec Knob");
+		MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0, "cgacomp",
+		                  "CGA Comp");
 	}
 	if (machine == MCH_HERC) {
 		constexpr uint16_t base = 0x3b0;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -939,14 +939,31 @@ static void TANDY_FindMode()
 			} else VGA_SetMode(M_TANDY16);
 		}
 		else if (vga.tandy.gfx_control & 0x08) {
-			VGA_SetMode(M_TANDY4);
-		}
-		else if (vga.tandy.mode_control & 0x10)
-			VGA_SetMode(M_TANDY2);
-		else {
-			if (vga.mode==M_TANDY16) {
-				VGA_SetModeNow(M_TANDY4);
-			} else VGA_SetMode(M_TANDY4);
+			if (cga_comp == COMPOSITE_STATE::ON) {
+				// composite ntsc 640x200 16 color mode
+				VGA_SetMode(M_CGA4_COMPOSITE);
+				update_cga16_color();
+			} else {
+				VGA_SetMode(M_TANDY4);
+			}
+		} else if (vga.tandy.mode_control & 0x10) {
+			if (cga_comp == COMPOSITE_STATE::ON) {
+				// composite ntsc 640x200 16 color mode
+				VGA_SetMode(M_CGA2_COMPOSITE);
+				update_cga16_color();
+			} else {
+				VGA_SetMode(M_TANDY2);
+			}
+		} else {
+			// otherwise some 4-colour graphics mode
+			const auto new_mode = (cga_comp == COMPOSITE_STATE::ON)
+			                              ? M_CGA4_COMPOSITE
+			                              : M_TANDY4;
+			if (vga.mode == M_TANDY16) {
+				VGA_SetModeNow(new_mode);
+			} else {
+				VGA_SetMode(new_mode);
+			}
 		}
 		tandy_update_palette();
 	} else {


### PR DESCRIPTION
This adds a `[composite]` block in the conf file having values:
```
[composite]
#   composite: Enable composite mode on start. 'auto' lets the program decide.
#              Possible values: auto, on, off.
#         era: Era of composite technology: 'new' is more vivid than 'old'.
#              Possible values: old, new.
#         hue: Appearance of RGB palette. For example, adjust until sky is blue. 0-100%, default is 50%.
#  saturation: Intensity of colors, from vivid to washed out. 0-100%, default is 50%.
#    contrast: Ratio between the light and dark. 0-100%, default is 50%.
#  brightness: Luminosity of the image, from overall light to dark. 0-100%, default is 50%.
# convergence: Convergence of subpixel elements, from focused to deconverged. 0-100%, default is 50%.

composite   = auto
era         = old
hue         = 50
saturation  = 50
contrast    = 50
brightness  = 50
convergence = 50

```

The main work in this PR is retaining the original composite values (so the math stays the same) and converting them into easy to manage knob ranges, with the defaults always "in the middle" at the 50% mark.  

Like actual CRT knobs, they can be turned down to 0% and up to 100%, as well as forced beyond to wrap around (rotating past 100% pops the setting back around to 0%). 

Using the composite hotkeys show the same knob percentages used in the conf file. 

We expect users to 'dial in' their preferred settings, read the setting from the console, and the assign it in the conf file. For example:

![2021-08-20_16-36](https://user-images.githubusercontent.com/1557255/130302846-2798e7da-d391-4a6b-b6c3-272982e55192.png)

I pressed F10 to select `Hue`, then F11 to adjust the hue to shown color.  I can then set `hue = 89` in the game's conf file to always get the same appearance on load.
