### PR TITLE
Specify encoding on-open in Python scripts

### DIFF
--- a/scripts/count-clang-bugs.py
+++ b/scripts/count-clang-bugs.py
@@ -42,7 +42,7 @@ def summary_values(summary_table):
 
 
 def read_soup(index_html):
-    with open(index_html) as index:
+    with open(index_html, encoding='utf-8') as index:
         soup = BeautifulSoup(index, 'html5lib')
         tables = soup.find_all('table')
         summary = tables[1]

--- a/scripts/count-pvs-bugs.py
+++ b/scripts/count-pvs-bugs.py
@@ -31,7 +31,7 @@ def parse_issues(filename):
     """
     cwd = os.getcwd()
     issues = collections.defaultdict(int)
-    with open(filename) as csvfile:
+    with open(filename, encoding='utf-8') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             sourcefile = os.path.realpath(row['FilePath'])

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -112,7 +112,7 @@ def get_input_lines(name):
     if not os.path.isfile(name):
         print('{}: no such file.'.format(name))
         sys.exit(2)
-    with open(name, 'r') as logs:
+    with open(name, 'r', encoding='utf-8') as logs:
         return logs.readlines()
 
 

--- a/scripts/count-xsan-issues.py
+++ b/scripts/count-xsan-issues.py
@@ -82,7 +82,7 @@ def get_input_lines(name):
     if not os.path.isfile(name):
         print('{}: no such file.'.format(name))
         sys.exit(2)
-    with open(name, 'r') as logs:
+    with open(name, 'r', encoding='utf-8') as logs:
         return logs.readlines()
 
 


### PR DESCRIPTION
Fix a new warning flagged by the new pyLint version:

![2021-08-20_16-47](https://user-images.githubusercontent.com/1557255/130303350-3f0ac3f9-594a-449b-b7e7-3acc92414a82.png)
