### PR TITLE
 Add fixed-width IO handler interfaces

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,22 +20,22 @@ jobs:
             os: ubuntu-20.04
             packages: clang
             build_flags: --native-file=.github/meson/native-clang.ini
-            max_warnings: 0
+            max_warnings: 20
 
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
-            max_warnings: 0
+            max_warnings: 70
 
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             build_flags: -Duse_fluidsynth=false
-            max_warnings: 0
+            max_warnings: 66
 
           - name: GCC 5, Ubuntu 18.04
             os: ubuntu-18.04
             packages: g++-5
             build_flags: --native-file=.github/meson/native-gcc-5.ini --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_mt32emu=false
-            max_warnings: 0
+            max_warnings: 42
 
           - name: GCC, +tests
             os: ubuntu-20.04
@@ -50,7 +50,7 @@ jobs:
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec
-            max_warnings: 0
+            max_warnings: 70
 
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
@@ -60,7 +60,7 @@ jobs:
           - name: GCC, -network
             os: ubuntu-20.04
             build_flags: -Duse_sdl2_net=false
-            max_warnings: 0
+            max_warnings: 70
 
           - name: GCC, warning_level=3
             os: ubuntu-20.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Denable_debugger=normal
-            max_warnings: 56
+            max_warnings: 126
 
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
@@ -55,7 +55,7 @@ jobs:
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 92
+            max_warnings: 162
 
           - name: GCC, -network
             os: ubuntu-20.04
@@ -65,7 +65,7 @@ jobs:
           - name: GCC, warning_level=3
             os: ubuntu-20.04
             build_flags: -Dwarning_level=3
-            max_warnings: 51
+            max_warnings: 121
 
           - name: GCC, minimum build
             os: ubuntu-20.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86_64
             needs_deps: true
             packages: meson
-            max_warnings: 0
+            max_warnings: 20
 
           - name: GCC 11
             host: macos-latest
@@ -30,7 +30,7 @@ jobs:
             needs_deps: true
             packages: gcc@11
             build_flags: --native-file=.github/meson/native-gcc-11.ini
-            max_warnings: 0
+            max_warnings: 70
 
           - name: Clang, +tests
             host: macos-latest
@@ -58,7 +58,7 @@ jobs:
             arch: arm64
             needs_deps: false
             packages: meson
-            max_warnings: 0
+            max_warnings: 20
 
           - name: Clang, +tests
             host: [self-hosted, macOS, arm64, debug-builds]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,14 +44,14 @@ jobs:
             arch: x86_64
             needs_deps: true
             build_flags: -Denable_debugger=normal
-            max_warnings: 84
+            max_warnings: 104
 
           - name: Clang, warning_level=3
             host: macos-latest
             arch: x86_64
             needs_deps: true
             build_flags: -Dwarning_level=3
-            max_warnings: 173
+            max_warnings: 193
 
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]
@@ -72,14 +72,14 @@ jobs:
             arch: arm64
             needs_deps: false
             build_flags: -Denable_debugger=normal
-            max_warnings: 121
+            max_warnings: 141
 
           - name: Clang, warning_level=3
             host: [self-hosted, macOS, arm64, debug-builds]
             arch: arm64
             needs_deps: false
             build_flags: -Dwarning_level=3
-            max_warnings: 189
+            max_warnings: 209
 
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 297
+            max_warnings: 296
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1845
+            max_warnings: 1859
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 275
+            max_warnings: 297
           - name: MSVC 64-bit
             arch: x64
             max_warnings: 1845

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,8 +44,8 @@ jobs:
           mv c:\vcpkg-bak c:\vcpkg
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
-          rm -R c:\vcpkg\buildtrees\fluidsynth\src\*.clean\sf2
-          rm -R c:\vcpkg\buildtrees\sdl2\src\*.clean\android-project-ant
+          rm -R c:\vcpkg\buildtrees
+          rm -R c:\vcpkg\packages
 
       - name:  Integrate packages
         shell: pwsh

--- a/include/inout.h
+++ b/include/inout.h
@@ -25,14 +25,15 @@
 #include "dosbox.h"
 
 #include <functional>
-#include <unordered_map>
 
+// To be removed after deprecating the Bitu IO sized handlers and API
 #define IO_MB	0x1 // Byte (8-bit)
 #define IO_MW	0x2 // Word (16-bit)
 #define IO_MD	0x4 // DWord (32-bit)
 #define IO_MA	(IO_MB | IO_MW | IO_MD ) // All three
 #define IO_SIZES 3 // byte, word, and dword
 
+// To be removed after deprecating the Bitu IO sized handlers and API
 // Existing type sizes
 using io_port_t = Bitu;
 using io_val_t = Bitu;
@@ -41,19 +42,23 @@ using io_val_t = Bitu;
 using io_port_t_proposed = uint16_t; // DOS only supports 16-bit port addresses
 using io_val_t_proposed = uint32_t; // Handling exists up to a dword (or less)
 
+// To be removed after deprecating the Bitu IO sized handlers and API
 using IO_ReadHandler = std::function<Bitu(io_port_t port, Bitu iolen)>;
 using IO_WriteHandler = std::function<void(io_port_t port, io_val_t val, Bitu iolen)>;
 
-extern std::unordered_map<io_port_t, IO_WriteHandler> io_writehandlers[IO_SIZES];
-extern std::unordered_map<io_port_t, IO_ReadHandler> io_readhandlers[IO_SIZES];
-
+// To be removed after deprecating the Bitu IO sized handlers and API
 void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
+
+// To be removed after deprecating the Bitu IO sized handlers and API
 void IO_RegisterWriteHandler(io_port_t port,
                              IO_WriteHandler handler,
                              Bitu mask,
                              Bitu range = 1);
 
+// To be removed after deprecating the Bitu IO sized handlers and API
 void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range = 1);
+
+// To be removed after deprecating the Bitu IO sized handlers and API
 void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range = 1);
 
 void IO_WriteB(io_port_t port, io_val_t val);
@@ -64,25 +69,71 @@ io_val_t IO_ReadB(io_port_t port);
 io_val_t IO_ReadW(io_port_t port);
 io_val_t IO_ReadD(io_port_t port);
 
+// type-sized IO handler API
+enum class io_width_t : uint8_t {
+	byte = sizeof(uint8_t),
+	word = sizeof(uint16_t),
+	dword = sizeof(uint32_t),
+};
+constexpr int io_widths = 3; // byte, word, and dword
+
+using io_read_f = std::function<uint32_t(io_port_t_proposed port, io_width_t width)>;
+using io_write_f = std::function<void(io_port_t_proposed port, io_val_t val, io_width_t width)>;
+
+void IO_RegisterReadHandler(io_port_t_proposed port,
+                            io_read_f handler,
+                            io_width_t max_width,
+                            io_port_t_proposed range = 1);
+
+void IO_RegisterWriteHandler(io_port_t_proposed port,
+                             io_write_f handler,
+                             io_width_t max_width,
+                             io_port_t_proposed range = 1);
+
+void IO_FreeReadHandler(io_port_t_proposed port,
+                        io_width_t max_width,
+                        io_port_t_proposed range = 1);
+
+void IO_FreeWriteHandler(io_port_t_proposed port,
+                         io_width_t max_width,
+                         io_port_t_proposed range = 1);
+
 /* Classes to manage the IO objects created by the various devices.
  * The io objects will remove itself on destruction.*/
 class IO_Base{
 protected:
 	bool installed = false;
 	io_port_t m_port = 0u;
+
+	// To be removed after deprecating the Bitu IO sized handlers and API
 	Bitu m_mask = 0u;
-	Bitu m_range = 0u;
+	io_width_t m_width = io_width_t::byte;
+	io_port_t m_range = 0u;
 };
 
 class IO_ReadHandleObject: private IO_Base{
 public:
+	// To be removed after deprecating the Bitu IO sized handlers and API
 	void Install(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range = 1);
+
+	void Install(io_port_t_proposed port,
+	             io_read_f handler,
+	             io_width_t max_width,
+	             io_port_t_proposed range = 1);
+
 	void Uninstall();
 	~IO_ReadHandleObject();
 };
 class IO_WriteHandleObject: private IO_Base{
 public:
+	// To be removed after deprecating the Bitu IO sized handlers and API
 	void Install(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range = 1);
+
+	void Install(io_port_t_proposed port,
+	             io_write_f handler,
+	             io_width_t max_width,
+	             io_port_t_proposed range = 1);
+
 	void Uninstall();
 	~IO_WriteHandleObject();
 };
@@ -91,7 +142,9 @@ static INLINE void IO_Write(io_port_t port, Bit8u val)
 {
 	IO_WriteB(port,val);
 }
+
 static INLINE Bit8u IO_Read(io_port_t port){
+	// cast to be dropped after deprecating the Bitu IO handler API
 	return (Bit8u)IO_ReadB(port);
 }
 

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -31,7 +31,7 @@
 #include "../src/cpu/lazyflags.h"
 #include "callback.h"
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 extern std::unordered_map<io_port_t, IO_WriteHandler> io_writehandlers[IO_SIZES];
 extern std::unordered_map<io_port_t, IO_ReadHandler> io_readhandlers[IO_SIZES];
 void port_within_proposed(io_port_t port);
@@ -217,7 +217,7 @@ void IO_WriteB(io_port_t port, io_val_t val)
 	else {
 		IO_USEC_write_delay();
 
-		// To-be-removed when Bitu-based IO handler API is deprecated:
+		// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 		WritePort(IO_MB, port, val);
 
 		// Assert and cast will be removed after deprecating Bitu API
@@ -265,7 +265,7 @@ void IO_WriteW(io_port_t port, io_val_t val)
 	else {
 		IO_USEC_write_delay();
 
-		// To-be-removed when Bitu-based IO handler API is deprecated:
+		// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 		WritePort(IO_MW, port, val);
 
 		// Assert and cast will be removed after deprecating Bitu API
@@ -310,7 +310,7 @@ void IO_WriteD(io_port_t port, io_val_t val)
 		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
 		cpudecoder=old_cpudecoder;
 	} else {
-		// To-be-removed when Bitu-based IO handler API is deprecated:
+		// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 		WritePort(IO_MD, port, val);
 
 		// Assert and cast will be removed after deprecating Bitu API
@@ -358,10 +358,11 @@ io_val_t IO_ReadB(io_port_t port)
 	else {
 		IO_USEC_read_delay();
 
-		// To-be-removed when Bitu-based IO handler API is deprecated:
+		// [deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 		if (io_readhandlers[0].find(port) != io_readhandlers[0].end()) {
 			retval = ReadPort(IO_MB, port);
 		} else {
+			// Assert and cast will be removed after deprecating Bitu API
 			assert(port <= UINT16_MAX);
 			retval = read_byte_from_port(static_cast<uint16_t>(port));
 		}
@@ -406,10 +407,11 @@ io_val_t IO_ReadW(io_port_t port)
 	else {
 		IO_USEC_read_delay();
 		
-		// To-be-removed when Bitu-based IO handler API is deprecated:
+		// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 		if (io_readhandlers[1].find(port) != io_readhandlers[1].end()) {
 			retval = ReadPort(IO_MW, port);
 		} else {
+			// Assert and cast will be removed after deprecating Bitu API
 			assert(port <= UINT16_MAX);
 			retval = read_word_from_port(static_cast<uint16_t>(port));
 		}
@@ -452,10 +454,11 @@ io_val_t IO_ReadD(io_port_t port)
 		cpudecoder=old_cpudecoder;
 	} else {
 
-		// To-be-removed when Bitu-based IO handler API is deprecated:
+		// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 		if (io_readhandlers[2].find(port) != io_readhandlers[2].end()) {
 			retval = ReadPort(IO_MD, port);
 		} else {
+			// Assert and cast will be removed after deprecating Bitu API
 			assert(port <= UINT16_MAX);
 			retval = read_dword_from_port(static_cast<uint16_t>(port));
 		}

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -259,15 +259,17 @@ constexpr int32_t IODELAY_WRITE_MICROSk = static_cast<int32_t>(
         1024 / IODELAY_WRITE_MICROS);
 
 inline void IO_USEC_read_delay() {
-	Bits delaycyc = CPU_CycleMax/IODELAY_READ_MICROSk;
-	if(GCC_UNLIKELY(delaycyc > CPU_Cycles)) delaycyc = CPU_Cycles;
+	auto delaycyc = CPU_CycleMax / IODELAY_READ_MICROSk;
+	if (GCC_UNLIKELY(delaycyc > CPU_Cycles))
+		delaycyc = CPU_Cycles;
 	CPU_Cycles -= delaycyc;
 	CPU_IODelayRemoved += delaycyc;
 }
 
 inline void IO_USEC_write_delay() {
-	Bits delaycyc = CPU_CycleMax/IODELAY_WRITE_MICROSk;
-	if(GCC_UNLIKELY(delaycyc > CPU_Cycles)) delaycyc = CPU_Cycles;
+	auto delaycyc = CPU_CycleMax / IODELAY_WRITE_MICROSk;
+	if (GCC_UNLIKELY(delaycyc > CPU_Cycles))
+		delaycyc = CPU_Cycles;
 	CPU_Cycles -= delaycyc;
 	CPU_IODelayRemoved += delaycyc;
 }

--- a/src/hardware/iohandler_containers.cpp
+++ b/src/hardware/iohandler_containers.cpp
@@ -1,0 +1,418 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "dosbox.h"
+
+#include <cassert>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <unordered_map>
+
+#include "inout.h"
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+std::unordered_map<io_port_t, IO_WriteHandler> io_writehandlers[IO_SIZES] = {};
+std::unordered_map<io_port_t, IO_ReadHandler> io_readhandlers[IO_SIZES] = {};
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void port_within_proposed(io_port_t port) {
+	assert(port < std::numeric_limits<io_port_t_proposed>::max());
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void val_within_proposed(io_val_t val) {
+	assert(val <= std::numeric_limits<io_val_t_proposed>::max());
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+static io_val_t ReadBlocked(io_port_t /*port*/, Bitu /*iolen*/)
+{
+	return static_cast<io_val_t>(~0);
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+static void WriteBlocked(io_port_t /*port*/, io_val_t /*val*/, Bitu /*iolen*/)
+{}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+static io_val_t ReadDefault(io_port_t port, Bitu iolen);
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen);
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+// The ReadPort and WritePort functions lookup and call the handler
+// at the desired port. If the port hasn't been assigned (and the
+// lookup is empty), then the default handler is assigned and called.
+io_val_t ReadPort(uint8_t req_bytes, io_port_t port)
+{
+	// Convert bytes to handler map index MB.0x1->0, MW.0x2->1, and MD.0x4->2
+	const uint8_t idx = req_bytes >> 1;
+	return io_readhandlers[idx].emplace(port, ReadDefault).first->second(port, req_bytes);
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void WritePort(uint8_t put_bytes, io_port_t port, io_val_t val)
+{
+	// Convert bytes to handler map index MB.0x1->0, MW.0x2->1, and MD.0x4->2
+	const uint8_t idx = put_bytes >> 1;
+
+	 // Convert bytes into a cut-off mask: 1->0xff, 2->0xffff, 4->0xffffff
+	const auto mask = (1ul << (put_bytes * 8)) - 1;
+	io_writehandlers[idx]
+	        .emplace(port, WriteDefault)
+	        .first->second(port, val & mask, put_bytes);
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+static io_val_t ReadDefault(io_port_t port, Bitu iolen)
+{
+	port_within_proposed(port);
+
+	switch (iolen) {
+	case 1:
+		LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected read from %04xh; blocking",
+		                      static_cast<uint32_t>(port));
+		io_readhandlers[0][port] = ReadBlocked;
+		return 0xff;
+	case 2: return ReadPort(IO_MB, port) | (ReadPort(IO_MB, port + 1) << 8);
+	case 4: return ReadPort(IO_MW, port) | (ReadPort(IO_MW, port + 2) << 16);
+	}
+	return 0;
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen)
+{
+	port_within_proposed(port);
+	val_within_proposed(val);
+
+	switch (iolen) {
+	case 1:
+		LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected write of %u to %04xh; blocking",
+		                      static_cast<uint32_t>(val),
+		                      static_cast<uint32_t>(port));
+		io_writehandlers[0][port] = WriteBlocked;
+		break;
+	case 2:
+		WritePort(IO_MB, port, val);
+		WritePort(IO_MB, port + 1, val >> 8);
+		break;
+	case 4:
+		WritePort(IO_MW, port, val);
+		WritePort(IO_MW, port + 2, val >> 16);
+		break;
+	}
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range)
+{
+	port_within_proposed(port);
+
+	while (range--) {
+		if (mask&IO_MB) io_readhandlers[0][port]=handler;
+		if (mask&IO_MW) io_readhandlers[1][port]=handler;
+		if (mask&IO_MD) io_readhandlers[2][port]=handler;
+		port++;
+	}
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void IO_RegisterWriteHandler(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range)
+{
+	port_within_proposed(port);
+
+	while (range--) {
+		if (mask&IO_MB) io_writehandlers[0][port]=handler;
+		if (mask&IO_MW) io_writehandlers[1][port]=handler;
+		if (mask&IO_MD) io_writehandlers[2][port]=handler;
+		port++;
+	}
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range)
+{
+	port_within_proposed(port);
+
+	while (range--) {
+		if (mask & IO_MB)
+			io_readhandlers[0].erase(port);
+		if (mask & IO_MW)
+			io_readhandlers[1].erase(port);
+		if (mask & IO_MD)
+			io_readhandlers[2].erase(port);
+		port++;
+	}
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range)
+{
+	port_within_proposed(port);
+
+	while (range--) {
+		if (mask & IO_MB)
+			io_writehandlers[0].erase(port);
+		if (mask & IO_MW)
+			io_writehandlers[1].erase(port);
+		if (mask & IO_MD)
+			io_writehandlers[2].erase(port);
+		port++;
+	}
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void IO_ReadHandleObject::Install(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range)
+{
+	port_within_proposed(port);
+
+	if(!installed) {
+		installed=true;
+		m_port=port;
+		m_mask=mask;
+		m_range=range;
+		IO_RegisterReadHandler(port,handler,mask,range);
+	} else
+		E_Exit("IO_readHandler already installed port %#" PRIxPTR, port);
+}
+
+void IO_ReadHandleObject::Uninstall(){
+	if(!installed) return;
+	IO_FreeReadHandler(m_port,m_mask,m_range); // to be removed
+	// casts will be removed after deprecating Bitu handlers
+	IO_FreeReadHandler(static_cast<io_port_t_proposed>(m_port), m_width,
+	                   static_cast<io_port_t_proposed>(m_range));
+	installed = false;
+}
+
+IO_ReadHandleObject::~IO_ReadHandleObject(){
+	Uninstall();
+}
+
+// To-be-removed when Bitu-based IO handler API is deprecated:
+void IO_WriteHandleObject::Install(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range)
+{
+	port_within_proposed(port);
+
+	if(!installed) {
+		installed=true;
+		m_port=port;
+		m_mask=mask;
+		m_range=range;
+		IO_RegisterWriteHandler(port,handler,mask,range);
+	} else
+		E_Exit("IO_writeHandler already installed port %#" PRIxPTR, port);
+}
+
+void IO_WriteHandleObject::Uninstall() {
+	if(!installed) return;
+	IO_FreeWriteHandler(m_port,m_mask,m_range); // to be removed
+	// casts will be removed after deprecating Bitu handlers
+	IO_FreeWriteHandler(static_cast<io_port_t_proposed>(m_port), m_width,
+	                    static_cast<io_port_t_proposed>(m_range));
+	installed = false;
+}
+
+IO_WriteHandleObject::~IO_WriteHandleObject(){
+	Uninstall();
+	// LOG_MSG("IOBUS: FreeWritehandler called with port %04x",
+	// static_cast<uint32_t>(m_port));
+}
+
+
+// type-sized IO handlers
+std::unordered_map<io_port_t_proposed, io_read_f> io_read_handlers[io_widths] = {};
+constexpr auto &io_read_byte_handler = io_read_handlers[0];
+constexpr auto &io_read_word_handler = io_read_handlers[1];
+constexpr auto &io_read_dword_handler = io_read_handlers[2];
+
+std::unordered_map<io_port_t_proposed, io_write_f> io_write_handlers[io_widths] = {};
+constexpr auto &io_write_byte_handler = io_write_handlers[0];
+constexpr auto &io_write_word_handler = io_write_handlers[1];
+constexpr auto &io_write_dword_handler = io_write_handlers[2];
+
+// type-sized IO handler API
+static uint8_t no_read(const io_port_t_proposed port)
+{
+	LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected read from %04xh; blocking", port);
+	return 0xff;
+}
+
+uint8_t read_byte_from_port(const io_port_t_proposed port)
+{
+	const auto reader = io_read_byte_handler.find(port);
+	const io_val_t_proposed value = reader != io_read_byte_handler.end()
+	                           ? reader->second(port, io_width_t::byte)
+	                           : no_read(port);
+	assert(value <= UINT8_MAX);
+	return static_cast<uint8_t>(value);
+}
+
+uint16_t read_word_from_port(const io_port_t_proposed port)
+{
+	const auto reader = io_read_word_handler.find(port);
+	const auto value = reader != io_read_word_handler.end()
+	                           ? reader->second(port, io_width_t::word)
+	                           : static_cast<io_val_t_proposed>(
+	                                     read_byte_from_port(port) |
+	                                     (read_byte_from_port(port + 1) << 8));
+	assert(value <= UINT16_MAX);
+	return static_cast<uint16_t>(value);
+}
+
+uint32_t read_dword_from_port(const io_port_t_proposed port)
+{
+	const auto reader = io_read_dword_handler.find(port);
+	const auto value = reader != io_read_dword_handler.end()
+	                           ? reader->second(port, io_width_t::dword)
+	                           : static_cast<io_val_t_proposed>(
+	                                     read_word_from_port(port) |
+	                                     (read_word_from_port(port + 2) << 16));
+	assert(value <= UINT32_MAX);
+	return static_cast<uint32_t>(value);
+}
+
+static void no_write(const io_port_t_proposed port, const uint8_t val)
+{
+	LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected write of %u to %04xh; blocking", val, port);
+}
+
+void write_byte_to_port(const io_port_t_proposed port, const uint8_t val)
+{
+	const auto writer = io_write_byte_handler.find(port);
+	if (writer != io_write_byte_handler.end())
+		writer->second(port, val, io_width_t::byte);
+	else
+		no_write(port, val);
+}
+
+void write_word_to_port(const io_port_t_proposed port, const uint16_t val)
+{
+	const auto writer = io_write_word_handler.find(port);
+	if (writer != io_write_word_handler.end()) {
+		writer->second(port, val, io_width_t::word);
+	} else {
+		write_byte_to_port(port, val & 0xff);
+		write_byte_to_port(port + 1, val >> 8);
+	}
+}
+
+void write_dword_to_port(const io_port_t_proposed port, const uint32_t val)
+{
+	const auto writer = io_write_dword_handler.find(port);
+	if (writer != io_write_dword_handler.end()) {
+		writer->second(port, val, io_width_t::dword);
+	} else {
+		write_word_to_port(port, val & 0xffff);
+		write_word_to_port(port + 2, val >> 16);
+	}
+}
+
+void IO_RegisterReadHandler(io_port_t_proposed port,
+                            const io_read_f handler,
+                            const io_width_t max_width,
+                            io_port_t_proposed range)
+{
+	while (range--) {
+		io_read_byte_handler[port] = handler;
+		if (max_width == io_width_t::word || max_width == io_width_t::dword)
+			io_read_word_handler[port] = handler;
+		if (max_width == io_width_t::dword)
+			io_read_dword_handler[port] = handler;
+		++port;
+	}
+}
+
+void IO_RegisterWriteHandler(io_port_t_proposed port,
+                             const io_write_f handler,
+                             const io_width_t max_width,
+                             io_port_t_proposed range)
+{
+	while (range--) {
+		io_write_byte_handler[port] = handler;
+		if (max_width == io_width_t::word || max_width == io_width_t::dword)
+			io_write_word_handler[port] = handler;
+		if (max_width == io_width_t::dword)
+			io_write_dword_handler[port] = handler;
+		++port;
+	}
+}
+
+void IO_FreeReadHandler(io_port_t_proposed port,
+                        const io_width_t max_width,
+                        io_port_t_proposed range)
+{
+	while (range--) {
+		io_read_byte_handler.erase(port);
+		if (max_width == io_width_t::word || max_width == io_width_t::dword)
+			io_read_word_handler.erase(port);
+		if (max_width == io_width_t::dword)
+			io_read_dword_handler.erase(port);
+		++port;
+	}
+}
+
+void IO_FreeWriteHandler(io_port_t_proposed port,
+                         const io_width_t width,
+                         io_port_t_proposed range)
+{
+	while (range--) {
+		io_write_byte_handler.erase(port);
+		if (width == io_width_t::word || width == io_width_t::dword)
+			io_write_word_handler.erase(port);
+		if (width == io_width_t::dword)
+			io_write_dword_handler.erase(port);
+		++port;
+	}
+}
+
+void IO_ReadHandleObject::Install(const io_port_t_proposed port,
+                                  const io_read_f handler,
+                                  const io_width_t max_width,
+                                  const io_port_t_proposed range)
+{
+	if (!installed) {
+		installed = true;
+		m_port = port;
+		m_width = max_width;
+		m_range = range;
+		IO_RegisterReadHandler(port, handler, max_width, range);
+	} else
+		E_Exit("io_read_f already installed port %u", port);
+}
+
+void IO_WriteHandleObject::Install(const io_port_t_proposed port,
+                                   const io_write_f handler,
+                                   const io_width_t max_width,
+                                   const io_port_t_proposed range)
+{
+	if (!installed) {
+		installed = true;
+		m_port = port;
+		m_width = max_width;
+		m_range = range;
+		IO_RegisterWriteHandler(port, handler, max_width, range);
+	} else
+		E_Exit("io_write_f already installed port %u", port);
+}

--- a/src/hardware/iohandler_containers.cpp
+++ b/src/hardware/iohandler_containers.cpp
@@ -29,40 +29,40 @@
 
 #include "inout.h"
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 std::unordered_map<io_port_t, IO_WriteHandler> io_writehandlers[IO_SIZES] = {};
 std::unordered_map<io_port_t, IO_ReadHandler> io_readhandlers[IO_SIZES] = {};
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void port_within_proposed(io_port_t port) {
 	assert(port < std::numeric_limits<io_port_t_proposed>::max());
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void val_within_proposed(io_val_t val) {
 	assert(val <= std::numeric_limits<io_val_t_proposed>::max());
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 static io_val_t ReadBlocked(io_port_t /*port*/, Bitu /*iolen*/)
 {
 	return static_cast<io_val_t>(~0);
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 static void WriteBlocked(io_port_t /*port*/, io_val_t /*val*/, Bitu /*iolen*/)
 {}
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 static io_val_t ReadDefault(io_port_t port, Bitu iolen);
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen);
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
 // The ReadPort and WritePort functions lookup and call the handler
 // at the desired port. If the port hasn't been assigned (and the
 // lookup is empty), then the default handler is assigned and called.
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 io_val_t ReadPort(uint8_t req_bytes, io_port_t port)
 {
 	// Convert bytes to handler map index MB.0x1->0, MW.0x2->1, and MD.0x4->2
@@ -70,7 +70,7 @@ io_val_t ReadPort(uint8_t req_bytes, io_port_t port)
 	return io_readhandlers[idx].emplace(port, ReadDefault).first->second(port, req_bytes);
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void WritePort(uint8_t put_bytes, io_port_t port, io_val_t val)
 {
 	// Convert bytes to handler map index MB.0x1->0, MW.0x2->1, and MD.0x4->2
@@ -83,7 +83,7 @@ void WritePort(uint8_t put_bytes, io_port_t port, io_val_t val)
 	        .first->second(port, val & mask, put_bytes);
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 static io_val_t ReadDefault(io_port_t port, Bitu iolen)
 {
 	port_within_proposed(port);
@@ -100,7 +100,7 @@ static io_val_t ReadDefault(io_port_t port, Bitu iolen)
 	return 0;
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen)
 {
 	port_within_proposed(port);
@@ -124,7 +124,7 @@ static void WriteDefault(io_port_t port, io_val_t val, Bitu iolen)
 	}
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range)
 {
 	port_within_proposed(port);
@@ -137,7 +137,7 @@ void IO_RegisterReadHandler(io_port_t port, IO_ReadHandler handler, Bitu mask, B
 	}
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void IO_RegisterWriteHandler(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range)
 {
 	port_within_proposed(port);
@@ -150,7 +150,7 @@ void IO_RegisterWriteHandler(io_port_t port, IO_WriteHandler handler, Bitu mask,
 	}
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range)
 {
 	port_within_proposed(port);
@@ -166,7 +166,7 @@ void IO_FreeReadHandler(io_port_t port, Bitu mask, Bitu range)
 	}
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range)
 {
 	port_within_proposed(port);
@@ -182,7 +182,7 @@ void IO_FreeWriteHandler(io_port_t port, Bitu mask, Bitu range)
 	}
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void IO_ReadHandleObject::Install(io_port_t port, IO_ReadHandler handler, Bitu mask, Bitu range)
 {
 	port_within_proposed(port);
@@ -199,7 +199,10 @@ void IO_ReadHandleObject::Install(io_port_t port, IO_ReadHandler handler, Bitu m
 
 void IO_ReadHandleObject::Uninstall(){
 	if(!installed) return;
-	IO_FreeReadHandler(m_port,m_mask,m_range); // to be removed
+
+	// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
+	IO_FreeReadHandler(m_port,m_mask,m_range);
+
 	// casts will be removed after deprecating Bitu handlers
 	IO_FreeReadHandler(static_cast<io_port_t_proposed>(m_port), m_width,
 	                   static_cast<io_port_t_proposed>(m_range));
@@ -210,7 +213,7 @@ IO_ReadHandleObject::~IO_ReadHandleObject(){
 	Uninstall();
 }
 
-// To-be-removed when Bitu-based IO handler API is deprecated:
+[[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
 void IO_WriteHandleObject::Install(io_port_t port, IO_WriteHandler handler, Bitu mask, Bitu range)
 {
 	port_within_proposed(port);
@@ -227,7 +230,9 @@ void IO_WriteHandleObject::Install(io_port_t port, IO_WriteHandler handler, Bitu
 
 void IO_WriteHandleObject::Uninstall() {
 	if(!installed) return;
-	IO_FreeWriteHandler(m_port,m_mask,m_range); // to be removed
+	// [[deprecated ("Bitu-based IO-handler: to be replace with type-sized IO-handler")]]
+	IO_FreeWriteHandler(m_port,m_mask,m_range);
+
 	// casts will be removed after deprecating Bitu handlers
 	IO_FreeWriteHandler(static_cast<io_port_t_proposed>(m_port), m_width,
 	                    static_cast<io_port_t_proposed>(m_range));

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -11,6 +11,7 @@ libhardware_sources = files([
   'hardware.cpp',
   'innovation.cpp',
   'iohandler.cpp',
+  'iohandler_containers.cpp',
   'ipx.cpp',
   'ipxserver.cpp',
   'joystick.cpp',

--- a/tests/iohandler_containers_tests.cpp
+++ b/tests/iohandler_containers_tests.cpp
@@ -1,0 +1,253 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "../src/hardware/iohandler_containers.cpp"
+
+#include <cassert>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+// Constants for all tests
+// ~~~~~~~~~~~~~~~~~~~~~~~
+constexpr uint16_t value_step_size = 4;
+constexpr uint16_t port_step_size = 256;
+constexpr uint16_t byte_port_start = 4;
+constexpr uint16_t word_port_start = byte_port_start * 2;
+constexpr uint16_t dword_port_start = word_port_start * 2;
+
+// Byte IO handler functions (Bitu and sized)
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+static uint8_t byte_val_new = 0;
+static uint8_t read_byte_new(io_port_t_proposed, io_width_t)
+{
+	return byte_val_new;
+}
+static void write_byte_new(io_port_t_proposed, uint8_t val, io_width_t)
+{
+	byte_val_new = val;
+}
+
+static Bitu byte_val_baseline = 0;
+static Bitu read_byte_baseline(Bitu /*port*/, Bitu /*iolen*/)
+{
+	return byte_val_baseline;
+}
+static void write_byte_baseline(Bitu /*port*/, Bitu val, Bitu /*iolen*/)
+{
+	byte_val_baseline = val;
+}
+
+// Word IO handler functions (Bitu and sized)
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+static uint16_t word_val_new = 0;
+static uint16_t read_word_new(io_port_t_proposed, io_width_t)
+{
+	return word_val_new;
+}
+static void write_word_new(io_port_t_proposed, uint16_t val, io_width_t)
+{
+	word_val_new = val;
+}
+
+static Bitu word_val_baseline = 0;
+static Bitu read_word_baseline(Bitu /*port*/, Bitu /*iolen*/)
+{
+	return word_val_baseline;
+}
+static void write_word_baseline(Bitu /*port*/, Bitu val, Bitu /*iolen*/)
+{
+	word_val_baseline = val;
+}
+
+// Dword IO handler functions (Bitu and sized)
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+static uint32_t dword_val_new = 0;
+static uint32_t read_dword_new(io_port_t_proposed, io_width_t)
+{
+	return dword_val_new;
+}
+static void write_dword_new(io_port_t_proposed, uint32_t val, io_width_t)
+{
+	dword_val_new = val;
+}
+
+static Bitu dword_val_baseline = 0;
+static Bitu read_dword_baseline(Bitu /*port*/, Bitu /*iolen*/)
+{
+	return dword_val_baseline;
+}
+static void write_dword_baseline(Bitu /*port*/, Bitu val, Bitu /*iolen*/)
+{
+	dword_val_baseline = val;
+}
+
+namespace {
+
+TEST(iohandler_containers, valid_bytes)
+{
+	for (uint32_t p = byte_port_start; p <= UINT16_MAX; p += port_step_size) {
+		const auto port = static_cast<uint16_t>(p);
+
+		IO_RegisterWriteHandler(port, write_byte_baseline, IO_MB);
+		IO_RegisterReadHandler(port, read_byte_baseline, IO_MB);
+
+		IO_RegisterWriteHandler(port, write_byte_new, io_width_t::byte);
+		IO_RegisterReadHandler(port, read_byte_new, io_width_t::byte);
+
+		for (uint16_t v = 0; v <= UINT8_MAX; v += value_step_size) {
+			const auto value = static_cast<uint8_t>(v);
+
+			WritePort(IO_MB, port, value);
+			EXPECT_EQ(v, ReadPort(IO_MB, p));
+
+			write_byte_to_port(port, value);
+			EXPECT_EQ(v, read_byte_from_port(port));
+		}
+	}
+}
+
+TEST(iohandler_containers, valid_words)
+{
+	for (uint32_t p = word_port_start; p <= UINT16_MAX; p += port_step_size) {
+		const auto port = static_cast<uint16_t>(p);
+
+		IO_RegisterWriteHandler(port, write_word_baseline, IO_MW);
+		IO_RegisterReadHandler(port, read_word_baseline, IO_MW);
+
+		IO_RegisterWriteHandler(port, write_word_new, io_width_t::word);
+		IO_RegisterReadHandler(port, read_word_new, io_width_t::word);
+
+		for (uint32_t v = 0; v <= UINT16_MAX; v += (value_step_size << 8)) {
+			const auto value = static_cast<uint16_t>(v);
+
+			WritePort(IO_MW, port, value);
+			EXPECT_EQ(v, ReadPort(IO_MW, p));
+
+			write_word_to_port(port, value);
+			EXPECT_EQ(v, read_word_from_port(port));
+		}
+	}
+}
+
+TEST(iohandler_containers, valid_dwords)
+{
+	for (uint32_t p = dword_port_start; p <= UINT16_MAX; p += port_step_size) {
+		const auto port = static_cast<uint16_t>(p);
+
+		IO_RegisterWriteHandler(port, write_dword_baseline, IO_MD);
+		IO_RegisterReadHandler(port, read_dword_baseline, IO_MD);
+
+		IO_RegisterWriteHandler(port, write_dword_new, io_width_t::dword);
+		IO_RegisterReadHandler(port, read_dword_new, io_width_t::dword);
+
+		for (uint64_t v = 0; v <= UINT32_MAX; v += (value_step_size << 20)) {
+			const auto value = static_cast<uint32_t>(v);
+
+			WritePort(IO_MD, port, value);
+			EXPECT_EQ(v, ReadPort(IO_MD, p));
+
+			write_dword_to_port(port, value);
+			EXPECT_EQ(v, read_dword_from_port(port));
+		}
+	}
+}
+
+TEST(iohandler_containers, empty_reads)
+{
+	constexpr uint16_t unregistered = 0;
+	EXPECT_EQ(ReadPort(IO_MB, unregistered), read_byte_from_port(unregistered));
+
+	const auto baseline_word = ReadPort(IO_MW, unregistered);
+	EXPECT_EQ(baseline_word, static_cast<Bitu>(-1));
+	EXPECT_EQ(static_cast<uint16_t>(baseline_word),
+	          read_word_from_port(unregistered));
+
+	const auto baseline_dword = ReadPort(IO_MD, unregistered);
+	EXPECT_EQ(baseline_dword, static_cast<Bitu>(-1));
+	EXPECT_EQ(static_cast<uint32_t>(baseline_word),
+	          read_dword_from_port(unregistered));
+}
+
+TEST(iohandler_containers, empty_writes)
+{
+	constexpr uint16_t unregistered = 0;
+	WritePort(IO_MB, unregistered, 0);
+	write_byte_to_port(unregistered, 0);
+}
+
+TEST(iohandler_containers, adjacent_word_read)
+{
+	constexpr uint8_t val = 0x1;
+
+	write_byte_to_port(byte_port_start, val);
+
+	auto expected = val | 0xff << 8;
+	EXPECT_EQ(read_word_from_port(byte_port_start), expected);
+
+	expected = 0xff | val << 8;
+	EXPECT_EQ(read_word_from_port(byte_port_start - 1), expected);
+
+	expected = val | 0xff << 8 | 0xff << 16 | 0xff << 24;
+	EXPECT_EQ(read_dword_from_port(byte_port_start), expected);
+
+	expected = 0xff | val << 8 | 0xff << 16 | 0xff << 24;
+	EXPECT_EQ(read_dword_from_port(byte_port_start - 1), expected);
+
+	expected = 0xff | 0xff << 8 | val << 16 | 0xff << 24;
+	EXPECT_EQ(read_dword_from_port(byte_port_start - 2), expected);
+
+	expected = 0xff | 0xff << 8 | 0xff << 16 | val << 24;
+	EXPECT_EQ(read_dword_from_port(byte_port_start - 3), expected);
+}
+
+TEST(iohandler_containers, adjacent_dword_read)
+{
+	constexpr uint16_t val = 0x1;
+
+	write_word_to_port(word_port_start, val);
+
+	auto expected = val | 0xffff << 16;
+	EXPECT_EQ(read_dword_from_port(word_port_start), expected);
+
+	expected = 0xffff | val << 16;
+	EXPECT_EQ(read_dword_from_port(word_port_start - 2), expected);
+}
+
+TEST(iohandler_containers, adjacent_word_write)
+{
+	constexpr uint16_t val = 2 << 8;
+
+	write_word_to_port(byte_port_start - 1, val);
+
+	EXPECT_EQ(read_byte_from_port(byte_port_start), val >> 8);
+}
+
+TEST(iohandler_containers, adjacent_dword_write)
+{
+	constexpr uint32_t val = 2 << 16;
+
+	write_dword_to_port(word_port_start - 2, val);
+
+	EXPECT_EQ(read_word_from_port(word_port_start), val >> 16);
+}
+
+} // namespace

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -43,11 +43,12 @@ test('gtest fs_utils', fs_utils,
 # other unit tests
 #
 unit_tests = [
-  {'name' : 'rwqueue',      'deps' : [libmisc_dep]},
-  {'name' : 'soft_limiter', 'deps' : [atomic_dep, sdl2_dep, libmisc_dep]},
-  {'name' : 'string_utils', 'deps' : []},
-  {'name' : 'setup',        'deps' : [sdl2_dep, libmisc_dep]},
-  {'name' : 'support',      'deps' : [sdl2_dep, libmisc_dep]},
+  {'name' : 'iohandler_containers', 'deps' : [libmisc_dep]},
+  {'name' : 'rwqueue',              'deps' : [libmisc_dep]},
+  {'name' : 'soft_limiter',         'deps' : [atomic_dep, sdl2_dep, libmisc_dep]},
+  {'name' : 'string_utils',         'deps' : []},
+  {'name' : 'setup',                'deps' : [sdl2_dep, libmisc_dep]},
+  {'name' : 'support',              'deps' : [sdl2_dep, libmisc_dep]},
 ]
 
 foreach ut : unit_tests

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -38,3 +38,10 @@ const char *MSG_Get(char const *)
 	return nullptr;
 }
 
+#if C_DEBUG
+void LOG::operator()(char const *buf, ...)
+{
+	(void)d_type;     // Deliberately unused.
+	(void)d_severity; // Deliberately unused.
+}
+#endif

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -338,6 +338,7 @@
     <ClCompile Include="..\src\hardware\hardware.cpp" />
     <ClCompile Include="..\src\hardware\innovation.cpp" />
     <ClCompile Include="..\src\hardware\iohandler.cpp" />
+    <ClCompile Include="..\src\hardware\iohandler_containers.cpp" />
     <ClCompile Include="..\src\hardware\ipx.cpp" />
     <ClCompile Include="..\src\hardware\ipxserver.cpp" />
     <ClCompile Include="..\src\hardware\joystick.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -163,6 +163,9 @@
     <ClCompile Include="..\src\hardware\iohandler.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\iohandler_containers.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\ipx.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>


### PR DESCRIPTION
Currently the IO port handler interfaces traffic all arguments as the one-size-fits-all `Bitu` type. This includes inbound write values (as `Bitu`), outbound read values (as `Bitu`), port address numbers (as `Bitu`), and other arguments. 

When DOSBox originated on Windows XP, `Bitu` was a 32-bit type: but today it's a 64-bit integer type on modern architectures.  DOS only performs fixed-size transactions of either byte, word, or dword sizes -- none of which are 64-bits. The ports themselves only span the 16-bit range up to 65535. 

So what's currently happening? The `Bitu` port numbers and data values must be cast into the properly-sized variables or registers on the receiving side: be they 8-bit, 16-bit, or 32-bit-wide types.  We have warnings about loss of precision (squeezing a 64-bit variable into smaller-sized variable). 

This PR adds three fixed-width IO handlers to let us migrate away from this "everything `Bitu` approach: To be clear - this is simply about the type-sizes; the interface names are kept the same - as we're only trying to achieve stronger type-sizing.

This PR doesn't actually use these new handlers - it simply adds them along-side the existing ones so we can begin the transition in subsequent PRs, one-by-one, and in small, easily bisect-able commits (if needed).

It also adds unit tests proving proper operation.  