### PR TITLE
Squash a couple printf Bitu format warnings

### DIFF
--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -117,12 +117,14 @@ bool DOS_IOCTL(void) {
 				reg_al=0x0; //EOF or beyond
 			}
 			Files[handle]->Seek(&oldlocation, DOS_SEEK_SET); //restore filelocation
-			LOG(LOG_IOCTL,LOG_NORMAL)("06:Used Get Input Status on regular file with handle %d",handle);
+			LOG(LOG_IOCTL, LOG_NORMAL)("06:Used Get Input Status on regular file with handle %u",
+			                           static_cast<uint32_t>(handle));
 		}
 		return true;
 	case 0x07:		/* Get Output Status */
-		LOG(LOG_IOCTL,LOG_NORMAL)("07:Fakes output status is ready for handle %d",handle);
-		reg_al=0xff;
+		LOG(LOG_IOCTL, LOG_NORMAL)("07:Fakes output status is ready for handle %u",
+		                           static_cast<uint32_t>(handle));
+		reg_al = 0xff;
 		return true;
 	case 0x08:		/* Check if block device removable */
 		/* cdrom drives and drive a&b are removable */

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1648,8 +1648,9 @@ void KEYB::Run(void) {
 					WriteOut(MSG_Get("PROGRAM_KEYB_SHOWHELP"));
 					break;
 				default:
-					LOG(LOG_DOSMISC,LOG_ERROR)("KEYB:Invalid returncode %x",keyb_error);
-					break;
+				        LOG(LOG_DOSMISC, LOG_ERROR)("KEYB:Invalid returncode %x",
+				         static_cast<uint32_t>(keyb_error));
+				        break;
 			}
 		}
 	} else {


### PR DESCRIPTION
Simply cast these printf `Bitu`'s to `uint32_t` as we already know they're legally 32-bit on Win32 builds (and these aren't memory addresses). Fixes:

``` text
../src/dos/dos_ioctl.cpp:120:88: warning: format specifies type 'int' but the
argument has type 'Bitu' (aka 'unsigned long') [-Wformat]

../src/dos/dos_ioctl.cpp:124:77: warning: format specifies type 'int' but the
argument has type 'Bitu' (aka 'unsigned long') [-Wformat]

../src/dos/dos_programs.cpp:1651:62: warning: format specifies type 'unsigned
int' but the argument has type 'Bitu' (aka 'unsigned long') [-Wformat]
```