### PR TITLE
Replace logging with loguru

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
+
       - run:  sudo apt-get update
 
       - name: Install dependencies
@@ -136,6 +139,9 @@ jobs:
             max_issues: 4
     steps:
       - uses: actions/checkout@v2
+
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
 
       - run:  sudo apt-get update
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
       - run:  sudo apt-get update
       - name: Log and setup environment
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,6 +75,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
+
       - run:  sudo apt-get update
 
       - name: Install dependencies (minimum set)
@@ -143,6 +147,9 @@ jobs:
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     steps:
       - uses: actions/checkout@v2
+
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
 
       - run:  sudo apt-get update
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,6 +84,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
+
       - name:  Prepare brew and compiler caches
         if:    matrix.conf.needs_deps
         id:    prep-caches
@@ -167,6 +170,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
 
       - name:  Prepare brew and compiler caches
         if:    matrix.runner.needs_deps

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
+
       - run:  sudo apt-get update
 
       - name: Log and setup environment

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,6 +53,9 @@ jobs:
           if (-not $?) { throw "vcpkg failed to integrate packages" }
 
       - uses:  actions/checkout@v2
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
+
       - name:  Log environment
         shell: pwsh
         run:   .\scripts\log-env.ps1
@@ -122,6 +125,9 @@ jobs:
           if (-not $?) { throw "vcpkg failed to integrate packages" }
 
       - uses:  actions/checkout@v2
+      - name: Fetch submodules
+        run:  git submodule update --init --recursive
+
       - name:  Log environment
         shell: pwsh
         run:   .\scripts\log-env.ps1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/loguru"]
+	path = submodules/loguru
+	url = https://github.com/dosbox-staging/loguru

--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -2,6 +2,30 @@
     "version": 1,
     "warnings": [
         {
+            "CodeCurrent": 88293181,
+            "CodeNext": 6447,
+            "CodePrev": 2507819856,
+            "ErrorCode": "V522",
+            "FileName": "loguru.cpp",
+            "Message": "There might be dereferencing of a potential null pointer 'with_newline'. Check lines: _, _."
+        },
+        {
+            "CodeCurrent": 647877999,
+            "CodeNext": 3897,
+            "CodePrev": 1189980955,
+            "ErrorCode": "V769",
+            "FileName": "loguru.cpp",
+            "Message": "The 'file_path' pointer in the 'file_path + _' expression could be nullptr. In such case, resulting value will be senseless and it should not be used. Check lines: _, _."
+        },
+        {
+            "CodeCurrent": 381112897,
+            "CodeNext": 1022144702,
+            "CodePrev": 0,
+            "ErrorCode": "V1051",
+            "FileName": "loguru.cpp",
+            "Message": "Consider checking for misprints. It's possible that the 'thread_id' should be checked here."
+        },
+        {
             "CodeCurrent": 0,
             "CodeNext": 0,
             "CodePrev": 0,

--- a/include/logging.h
+++ b/include/logging.h
@@ -23,6 +23,8 @@
 
 #include "compiler.h"
 
+#include "loguru.hpp"
+
 enum LOG_TYPES {
 	LOG_ALL,
 	LOG_VGA, LOG_VGAGFX,LOG_VGAMISC,LOG_INT10,
@@ -88,35 +90,22 @@ struct LOG
 }; //add missing operators to here
 	//try to avoid anything smaller than bit32...
 void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
-#define LOG_MSG GFX_ShowMsg
+
+// Keep for compatibility
+#define LOG_MSG(...)	LOG_F(INFO, __VA_ARGS__)
 
 #endif //C_DEBUG
+
+#define LOG_INFO(...)		LOG_F(INFO, __VA_ARGS__)
+#define LOG_WARNING(...)	LOG_F(WARNING, __VA_ARGS__)
+#define LOG_ERR(...)		LOG_F(ERROR, __VA_ARGS__)
 
 #ifdef NDEBUG
 // DEBUG_LOG_MSG exists only for messages useful during development, and not to
 // be redirected into internal DOSBox debugger for DOS programs (C_DEBUG feature).
 #define DEBUG_LOG_MSG(...)
 #else
-// There's no portable way to expand variadic macro using C99/C++14 (or older)
-// alone. This language limitation got removed only with C++20 (through addition
-// of __VA_OPT__ macro).
-#ifdef _MSC_VER
-#define DEBUG_LOG_MSG(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
-//                                                      ~
-// MSVC silently eliminates trailing comma if needed:   ^
-#else
-#define DEBUG_LOG_MSG(fmt, ...) fprintf(stderr, fmt "\n", ##__VA_ARGS__)
-//                                                        ~~~~~~~~~~~~~
-//                                                        ^
-// GCC and Clang provide '##' token as a language extension to explicitly remove
-// trailing comma when there's no trailing parameters.
-#endif
-// If it'll ever be necessary to support another compiler, which does not
-// support C++20 nor GNU extension nor MSVC extension, then behaviour can be
-// simulated by implementing C++ variadic template wrapped inside a macro
-// (at the cost of slowing down compilation).
-//
-// Another option it to use vsnprintf (at the cost of slowing down runtime).
+#define DEBUG_LOG_MSG(...) DLOG_F(INFO, __VA_ARGS__)
 #endif // NDEBUG
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -183,6 +183,7 @@ static_libs_list = get_option('try_static_libs')
 msg = 'You can disable this dependency with: -D@0@=false'
 
 optional_dep  = dependency('', required : false)
+dl_dep        = cc.find_library('dl', required : false)
 atomic_dep    = cxx.find_library('atomic', required : false)
 opus_dep      = dependency('opusfile',
                            static : ('opusfile' in static_libs_list))
@@ -296,12 +297,19 @@ endif
 
 # include directories
 #
-incdir = include_directories('include', '.')
+incdir = include_directories(
+           'include',
+           '.',
+           'submodules/loguru',
+         )
 
 
-# bundled dependencies
+# bundled dependencies, in dependency-order
 #
-subdir('src/libs/decoders')
+subdir('src/libs/loguru')
+libloguru_dep = declare_dependency(link_with : libloguru)
+
+subdir('src/libs/decoders') # depends on libloguru_dep
 subdir('src/libs/nuked')
 subdir('src/libs/ppscale')
 subdir('src/libs/residfp')
@@ -310,7 +318,6 @@ libdecoders_dep = declare_dependency(link_with : libdecoders)
 libnuked_dep    = declare_dependency(link_with : libnuked)
 libppscale_dep  = declare_dependency(link_with : libppscale)
 libresidfp_dep  = declare_dependency(link_with : libresidfp)
-
 
 # internal libs
 #

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1280,7 +1280,7 @@ public:
 		} */
 		if (loaded_layout->read_keyboard_file(layoutname, dos.loaded_codepage)) {
 			if (strncmp(layoutname,"auto",4)) {
-				LOG_MSG("Error loading keyboard layout %s",layoutname);
+				LOG_ERR("Error loading keyboard layout %s",layoutname);
 			}
 		} else {
 			const char* lcode = loaded_layout->main_language_code();

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -28,7 +28,11 @@ libdos_sources = files([
 
 libdos = static_library('dos', libdos_sources,
                         include_directories : incdir,
-                        dependencies : [sdl2_dep, libdecoders_dep])
+                        dependencies : [
+                          sdl2_dep,
+                          libdecoders_dep,
+                          libloguru_dep,
+                        ])
 
 libdos_dep = declare_dependency(link_with : libdos)
 

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -8,7 +8,12 @@ libgui_sources = files([
 
 libgui = static_library('gui', libgui_sources,
                         include_directories : incdir,
-                        dependencies : [ sdl2_dep, opengl_dep, libppscale_dep ])
+                        dependencies : [
+                          sdl2_dep,
+                          opengl_dep,
+                          libloguru_dep,
+                          libppscale_dep,
+                        ])
 
 libgui_dep = declare_dependency(link_with : libgui)
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2281,7 +2281,7 @@ static void CreateStringBind(char * line) {
 			goto foundevent;
 		}
 	}
-	LOG_MSG("MAPPER: Can't find key binding for %s event", eventname);
+	LOG_WARNING("MAPPER: Can't find key binding for %s event", eventname);
 	return ;
 foundevent:
 	CBind * bind = nullptr;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3469,6 +3469,18 @@ void GFX_GetSize(int &width, int &height, bool &fullscreen)
 int sdl_main(int argc, char *argv[])
 {
 	int rcode = 0; // assume good until proven otherwise
+	
+	// Setup logging right away
+	loguru::g_preamble_date    = true; // The date field
+	loguru::g_preamble_time    = true; // The time of the current day
+	loguru::g_preamble_uptime  = false; // The time since init call
+	loguru::g_preamble_thread  = false; // The logging thread
+	loguru::g_preamble_file    = false; // The file from which the log originates from
+	loguru::g_preamble_verbose = false; // The verbosity field
+	loguru::g_preamble_pipe    = true; // The pipe symbol right before the message	
+
+	loguru::init(argc, argv);
+
 	try {
 		Disable_OS_Scaling(); //Do this early on, maybe override it through some parameter.
 		OverrideWMClass(); // Before SDL2 video subsystem is initialized

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -57,14 +57,15 @@ libhardware_sources = files([
 libhardware = static_library('hardware', libhardware_sources,
                              include_directories : incdir,
                              dependencies : [
-                               libnuked_dep,
                                pcap_dep,
                                png_dep,
-                               libresidfp_dep,
                                sdl2_dep,
                                sdl2_net_dep,
                                slirp_dep,
                                winsock2_dep,
+                               libloguru_dep,
+                               libnuked_dep,
+                               libresidfp_dep,
                              ])
 
 libhardware_dep = declare_dependency(link_with : libhardware)

--- a/src/ints/meson.build
+++ b/src/ints/meson.build
@@ -19,7 +19,10 @@ libints_sources = files([
 
 libints = static_library('ints', libints_sources,
                          include_directories : incdir,
-                         dependencies : [sdl2_dep])
+                         dependencies : [
+                           sdl2_dep,
+                           libloguru_dep,
+                         ])
 
 libints_dep = declare_dependency(link_with : libints)
 

--- a/src/libs/decoders/meson.build
+++ b/src/libs/decoders/meson.build
@@ -10,4 +10,8 @@ libdecoders_sources = files([
 
 libdecoders = static_library('decoders', libdecoders_sources,
                              include_directories : incdir,
-                             dependencies : [sdl2_dep, opus_dep])
+                             dependencies : [
+                               sdl2_dep,
+                               opus_dep,
+                               libloguru_dep,
+                             ])

--- a/src/libs/loguru/meson.build
+++ b/src/libs/loguru/meson.build
@@ -1,0 +1,6 @@
+libloguru = static_library('loguru',
+                           '../../../submodules/loguru/loguru.cpp',
+                           dependencies : [
+                             threads_dep,
+                             dl_dep,
+                           ])

--- a/src/midi/meson.build
+++ b/src/midi/meson.build
@@ -16,7 +16,8 @@ libmidi = static_library('midi', libmidi_sources,
                            alsa_dep,
                            coreaudio_dep,
                            coremidi_dep,
-                           winmm_dep
+                           winmm_dep,
+                           libloguru_dep,
                          ])
 
 libmidi_dep = declare_dependency(link_with : libmidi)

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -13,7 +13,10 @@ libmisc_sources = [
 
 libmisc = static_library('misc', libmisc_sources,
                          include_directories : incdir,
-                         dependencies : sdl2_dep)
+                         dependencies : [
+                           sdl2_dep,
+                           libloguru_dep,
+                         ])
 
 libmisc_dep = declare_dependency(link_with : libmisc)
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -957,7 +957,7 @@ bool Config::ParseConfigFile(char const * const configfilename) {
 	if (!in) return false;
 	configfiles.push_back(configfilename);
 
-	LOG_MSG("CONFIG: Loading %s file %s",
+	LOG_INFO("CONFIG: Loading %s file %s",
 	        configfiles.size() == 1 ? "primary" : "additional",
 	        configfilename);
 

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -311,7 +311,7 @@ void E_Exit(const char *format, ...)
 	va_start(msg, format);
 	vsnprintf(e_exit_buf, ARRAY_LEN(e_exit_buf), format, msg);
 	va_end(msg);
-	throw(e_exit_buf);
+	ABORT_F("%s", e_exit_buf);
 }
 
 /* Overloaded function to handle different return types of POSIX and GNU

--- a/src/shell/meson.build
+++ b/src/shell/meson.build
@@ -7,7 +7,10 @@ libshell_sources = files([
 
 libshell = static_library('shell', libshell_sources,
                           include_directories : incdir,
-                          dependencies : [sdl2_dep])
+                          dependencies : [
+                            sdl2_dep,
+                            libloguru_dep,
+                          ])
 
 libshell_dep = declare_dependency(link_with : libshell)
 

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -110,6 +110,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>..\..\submodules\loguru</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -139,6 +140,7 @@ $(TargetPath)
       <ConformanceMode>Default</ConformanceMode>
       <OmitFramePointers>true</OmitFramePointers>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AdditionalIncludeDirectories>..\..\submodules\loguru</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -167,6 +169,7 @@ $(TargetPath)
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>false</OmitFramePointers>
+      <AdditionalIncludeDirectories>..\..\submodules\loguru</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -196,6 +199,7 @@ $(TargetPath)
       <OmitFramePointers>true</OmitFramePointers>
       <ConformanceMode>Default</ConformanceMode>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AdditionalIncludeDirectories>..\..\submodules\loguru</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -219,6 +223,7 @@ $(TargetPath)
     <ClCompile Include="..\..\src\misc\setup.cpp" />
     <ClCompile Include="..\..\src\misc\soft_limiter.cpp" />
     <ClCompile Include="..\..\src\misc\support.cpp" />
+    <ClCompile Include="..\..\submodules\loguru\loguru.cpp" />
     <ClCompile Include="..\fs_utils_tests.cpp" />
     <ClCompile Include="..\rwqueue_tests.cpp" />
     <ClCompile Include="..\setup_tests.cpp" />

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClCompile Include="..\..\src\misc\cross.cpp">
       <Filter>dosbox_sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\submodules\loguru\loguru.cpp">
+      <Filter>dosbox_sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\support_tests.cpp">
       <Filter>tests</Filter>
     </ClCompile>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -100,7 +100,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\submodules\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -136,7 +136,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\submodules\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -176,7 +176,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\submodules\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -224,7 +224,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\submodules\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -426,6 +426,7 @@
     <ClCompile Include="..\src\shell\shell_batch.cpp" />
     <ClCompile Include="..\src\shell\shell_cmds.cpp" />
     <ClCompile Include="..\src\shell\shell_misc.cpp" />
+    <ClCompile Include="..\submodules\loguru\loguru.cpp" />
     <ClCompile Include="..\src\platform\visualc\version.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -576,6 +577,7 @@
     <ClInclude Include="..\src\midi\midi_win32.h" />
     <ClInclude Include="..\src\platform\visualc\config.h" />
     <ClInclude Include="..\src\platform\visualc\unistd.h" />
+    <ClInclude Include="..\submodules\loguru\loguru.hpp" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\src\dosbox.ico" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\src\cpu\callback.cpp">
@@ -481,6 +481,9 @@
     <ClCompile Include="..\src\misc\pacer.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>
+    <ClCompile Include="..\submodules\loguru\loguru.cpp">
+      <Filter>submodules\loguru</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\bios.h">
@@ -914,6 +917,9 @@
     </ClInclude>
     <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x64.h">
       <Filter>src\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\submodules\loguru\loguru.hpp">
+      <Filter>submodules\loguru</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR integrates https://github.com/emilk/loguru and uses it in `LOG_MSG` and `DEBUG_LOG_MSG` for compatibility, and adds a few new macros for future work:
```cpp
#define LOG_INFO(...)		LOG_F(INFO, __VA_ARGS__)
#define LOG_WARNING(...)	LOG_F(WARNING, __VA_ARGS__)
#define LOG_ERR(...)		LOG_F(ERROR, __VA_ARGS__)
```
We've used a minimal initialization sequence in `sdlmain.cpp`:
```cpp
	// Setup logging right away
	loguru::g_preamble_date    = true; // The date field
	loguru::g_preamble_time    = true; // The time of the current day
	loguru::g_preamble_uptime  = false; // The time since init call
	loguru::g_preamble_thread  = false; // The logging thread
	loguru::g_preamble_file    = false; // The file from which the log originates from
	loguru::g_preamble_verbose = false; // The verbosity field
	loguru::g_preamble_pipe    = true; // The pipe symbol right before the message	

	loguru::init(argc, argv);
```
Here is a sample of the output:
```log
date       time         | 
2021-08-24 12:21:46.375 | arguments: /Users/xxxxxx/src/dosbox-staging/build/dosbox
2021-08-24 12:21:46.375 | Current dir: /Users/xxxxxx
2021-08-24 12:21:46.375 | stderr verbosity: 0
2021-08-24 12:21:46.375 | -----------------------------------
2021-08-24 12:21:46.377 | dosbox-staging version 0.78.0-alpha-254-g7f8e76d1+
2021-08-24 12:21:46.377 | ---
2021-08-24 12:21:46.469 | CONFIG: Loading primary file /Users/xxxxxx/Library/Preferences/DOSBox/dosbox-staging.conf
2021-08-24 12:21:46.469 | CONFIG: Unknown option log_level
2021-08-24 12:21:46.469 | DISPLAY: Disabled resizable window, only compatible with OpenGL output
2021-08-24 12:21:46.469 | DISPLAY: Initialized 1008x756 window-mode on 1920x1080 display-0
2021-08-24 12:21:46.492 | SDL: Using driver "metal" for texture renderer
2021-08-24 12:21:47.495 | SDL: Mouse will move seamlessly without being captured and middle-click will uncapture the mouse.
2021-08-24 12:21:47.508 | MEMORY: Base address: 0x141000000
2021-08-24 12:21:47.508 | MEMORY: Using 4096 DOS memory pages (16 MiB)
```
This adds some new behavior by hooking signal handlers. For example, CTRL-C from the launching console window now produces:
```log
Loguru caught a signal: SIGINT
Stack trace:
14         0x190e25430 start + 4
13         0x1006e81a4 sdl_main(int, char**) + 4332
12         0x1007802c0 SHELL_Init() + 2760
11         0x10077f660 DOS_Shell::Run() + 836
10         0x10078ad30 DOS_Shell::InputCommand(char*) + 208
9          0x10061e05c DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool) + 144
8          0x10061b134 device_CON::Read(unsigned char*, unsigned short*) + 184
7          0x1005abfa4 CALLBACK_RunRealInt(unsigned char) + 76
6          0x1005a834c DOSBOX_RunMachine() + 28
5          0x1005a8310 Normal_Loop() + 132
4          0x1005a8038 increaseticks() + 664
3          0x1005ab780 DelayPrecise(int) + 140
2          0x190da0584 std::this_thread::sleep_for(std::chrono::duration<long long, std::ratio<1l, 1000000000l> > const&) + 84
1          0x190d4c284 nanosleep + 216
0          0x190e52c44 _sigtramp + 56
2021-08-24 12:21:51.297 | Signal: SIGINT
```

Future work will use the new log levels for warnings and errors, and also provide a file logger backend, but this PR is intended to be a backwards-compatible 1-to-1 replacement.