### PR TITLE
Fix runs-on for macOS additional artifacts

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -376,7 +376,7 @@ jobs:
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_macos_release
-    runs-on: [macos-latest, self-hosted]
+    runs-on: macos-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `runs-on:` value for `publish_additional_artifacts` was not allowing the step to execute for macOS. It appears to be an `AND` rather than an `OR`, and our self-hosted runner isn't using `macos-latest`. Let's just let it run on the plain old GitHub `macos-latest`.