### PR TITLE
Purge a broken VCPKG SDL2 directory that's blocking CI cache restore

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,6 +45,7 @@ jobs:
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
           rm -R c:\vcpkg\buildtrees\fluidsynth\src\*.clean\sf2
+          rm -R c:\vcpkg\buildtrees\sdl2\src\*.clean\android-project-ant
 
       - name:  Integrate packages
         shell: pwsh


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/20121 via work-around.

```text
c:/vcpkg/buildtrees/sdl2/src/ase-2.0.16-5db7014de9.clean/android-project-ant/AndroidManifest.xml:
Can't create '\\\\?\\c:\\vcpkg\\buildtrees\\sdl2\\src\\ase-2.0.16-5db70>

c:/vcpkg/buildtrees/sdl2/src/ase-2.0.16-5db7014de9.clean/android-project-ant/src: Can't
create '\\\\?\\c:\\vcpkg\\buildtrees\\sdl2\\src\\ase-2.0.16-5db7014de9.clean\\and>

tar.exe: Error exit delayed from previous errors.
```