### PR TITLE
Reconcile differences between PCjr and CGA composite patches

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,7 +51,7 @@ jobs:
             arch: x86_64
             needs_deps: true
             build_flags: -Dwarning_level=3
-            max_warnings: 133
+            max_warnings: 134
 
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]

--- a/include/vga.h
+++ b/include/vga.h
@@ -48,9 +48,10 @@ enum VGAModes {
 	M_TANDY4 = 1 << 14,
 	M_TANDY16 = 1 << 15,
 	M_TANDY_TEXT = 1 << 16,
-	M_CGA2_COMPOSITE = 1 << 17,
-	M_CGA4_COMPOSITE = 1 << 18,
-	M_CGA_TEXT_COMPOSITE = 1 << 19,
+	M_CGA16 = 1 << 17,
+	M_CGA2_COMPOSITE = 1 << 18,
+	M_CGA4_COMPOSITE = 1 << 19,
+	M_CGA_TEXT_COMPOSITE = 1 << 20,
 	// bits 20 through 30 for more modes
 	M_ERROR = 1 << 31,
 };
@@ -558,6 +559,7 @@ extern Bit32u FillTable[16];
 extern Bit32u CGA_2_Table[16];
 extern Bit32u CGA_4_Table[256];
 extern Bit32u CGA_4_HiRes_Table[256];
+extern Bit32u CGA_16_Table[256];
 extern int CGA_Composite_Table[1024];
 extern Bit32u TXT_Font_Table[16];
 extern Bit32u TXT_FG_Table[16];

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -33,7 +33,7 @@ SVGA_Driver svga;
 Bit32u CGA_2_Table[16];
 Bit32u CGA_4_Table[256];
 Bit32u CGA_4_HiRes_Table[256];
-Bit32u CGA_16_Table[256];
+uint32_t CGA_16_Table[256];
 int CGA_Composite_Table[1024];
 Bit32u TXT_Font_Table[16];
 Bit32u TXT_FG_Table[16];

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -33,6 +33,7 @@ SVGA_Driver svga;
 Bit32u CGA_2_Table[16];
 Bit32u CGA_4_Table[256];
 Bit32u CGA_4_HiRes_Table[256];
+Bit32u CGA_16_Table[256];
 int CGA_Composite_Table[1024];
 Bit32u TXT_Font_Table[16];
 Bit32u TXT_FG_Table[16];

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1696,11 +1696,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_TANDY2:
 		aspect_ratio = 1.2;
-		doubleheight=true;
+		doubleheight = true;
 		VGA_DrawLine = VGA_Draw_1BPP_Line;
 
 		if (machine == MCH_PCJR) {
-			doublewidth = (vga.tandy.gfx_control & 0x8) == 0x00;
+			doublewidth = (vga.tandy.gfx_control & 0x8) == 0;
 			vga.draw.blocks = width * (doublewidth ? 4 : 8);
 			width = vga.draw.blocks * 2;
 		} else {

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -509,6 +509,7 @@ static void FinishSetMode(bool clearmem) {
 		switch (CurMode->type) {
 		case M_TANDY16:
 		case M_CGA4:
+		case M_CGA16:
 			if ((machine==MCH_PCJR) && (CurMode->mode >= 9)) {
 				// PCJR cannot access the full 32k at 0xb800
 				for (Bit16u ct=0;ct<16*1024;ct++) {
@@ -937,6 +938,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 		seq_data[2]|=0xf;				//Enable all planes for writing
 		seq_data[4]|=0xc;				//Graphics - odd/even - Chained
 		break;
+	case M_CGA16:              // only in MCH_TANDY, MCH_PCJR
 	case M_CGA2_COMPOSITE:     // only in MCH_CGA
 	case M_CGA4_COMPOSITE:     // only in MCH_CGA
 	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
@@ -1199,6 +1201,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 		if (CurMode->special & VGA_PIXEL_DOUBLE)
 			mode_control |= 0x08;
 		break;
+	case M_CGA16:              // only in MCH_TANDY, MCH_PCJR
 	case M_CGA2_COMPOSITE:     // only in MCH_CGA
 	case M_CGA4_COMPOSITE:     // only in MCH_CGA
 	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
@@ -1308,6 +1311,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 			gfx_data[0x6]|=0x0f;		//graphics mode at at 0xb800=0xbfff
 		}
 		break;
+	case M_CGA16:              // only in MCH_TANDY, MCH_PCJR
 	case M_CGA2_COMPOSITE:     // only in MCH_CGA
 	case M_CGA4_COMPOSITE:     // only in MCH_CGA
 	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
@@ -1424,6 +1428,7 @@ att_text16:
 		for (Bit8u ct=0;ct<16;ct++) att_data[ct]=ct;
 		att_data[0x10]=0x41;		//Color Graphics 8-bit
 		break;
+	case M_CGA16:              // only in MCH_TANDY, MCH_PCJR
 	case M_CGA2_COMPOSITE:     // only in MCH_CGA
 	case M_CGA4_COMPOSITE:     // only in MCH_CGA
 	case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA
@@ -1521,6 +1526,7 @@ dac_text16:
 				IO_Write(0x3c9,vga_palette[i][2]);
 			}
 			break;
+		case M_CGA16:              // only in MCH_TANDY, MCH_PCJR
 		case M_CGA2_COMPOSITE:     // only in MCH_CGA
 		case M_CGA4_COMPOSITE:     // only in MCH_CGA
 		case M_CGA_TEXT_COMPOSITE: // only in MCH_CGA

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -390,15 +390,15 @@ void INT10_SetColorSelect(Bit8u val) {
 	else if (machine == MCH_PCJR) {
 		IO_Read(VGAREG_TDY_RESET); // reset the flipflop
 		switch (CurMode->mode) {
-		case 4:
-		case 5:
+		case 4: // CGA 4-color mode
+		case 5: // Also CGA 4-color mode
 			for (Bit8u i = 0x11; i < 0x14; i++) {
 				const Bit8u t4_table[] = {0,2,4,6, 0,3,5,0xf};
 				IO_Write(VGAREG_TDY_ADDRESS, i);
 				IO_Write(VGAREG_PCJR_DATA, t4_table[(i-0x10)+(val&1? 4:0)]);
 			}
 			break;
-		case 6:
+		case 6: // CGA 2-color mode
 			IO_Write(VGAREG_TDY_ADDRESS, 0x11);
 			IO_Write(VGAREG_PCJR_DATA, val & 1 ? 0xf : 0);
 			break;


### PR DESCRIPTION
Fixes the regression with PCjr composite color due to functional overlap between the composite patches.

![2021-09-14_12-35_1](https://user-images.githubusercontent.com/1557255/133322432-6a71b487-b7a1-45a6-892f-f325fe27587f.png)
![2021-09-14_12-35](https://user-images.githubusercontent.com/1557255/133322434-359ad2a8-84d7-4138-80d4-ef793898d8af.png)
![2021-09-14_12-34](https://user-images.githubusercontent.com/1557255/133322435-929568bc-37ea-4d43-a23f-9c71f91c6b67.png)
