### PR TITLE
Make composite settings configurable (via conf file)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ TabWidth: 8
 IndentWidth: 8
 ContinuationIndentWidth: 8
 
-ColumnLimit: 80
+ColumnLimit: 110
 
 # C/C++ Language specifics
 #

--- a/include/support.h
+++ b/include/support.h
@@ -274,6 +274,22 @@ constexpr size_t static_if_array_then_zero()
 //
 std::string safe_strerror(int err) noexcept;
 
-#endif
-
 void set_thread_name(std::thread &thread, const char *name);
+
+/*
+  Returns a number wrapped between the lower and upper bounds.
+   - wrap(-1, 0, 4); // Returns 4
+   - wrap(5, 0, 4); // Returns 0
+
+  All credit to Charles Bailey, https://stackoverflow.com/a/707426
+*/
+constexpr int wrap(int val, int const lower_bound, int const upper_bound)
+{
+	const auto range_size = upper_bound - lower_bound + 1;
+	if (val < lower_bound)
+		val += range_size * ((lower_bound - val) / range_size + 1);
+
+	return lower_bound + (val - lower_bound) % range_size;
+}
+
+#endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -22,8 +22,9 @@
 #include "dosbox.h"
 
 #include "inout.h"
+#include "control.h"
 
-// Don't enable keeping changes and mapping lfb probably...
+//Don't enable keeping changes and mapping lfb probably...
 #define VGA_LFB_MAPPED
 //#define VGA_KEEP_CHANGES
 #define VGA_CHANGE_SHIFT	9
@@ -478,6 +479,7 @@ void VGA_SetupGFX(void);
 void VGA_SetupSEQ(void);
 void VGA_SetupOther(void);
 void VGA_SetupXGA(void);
+void VGA_AddCompositeSettings(Config &conf);
 
 /* Some Support Functions */
 void VGA_SetClock(Bitu which, uint32_t target);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -585,6 +585,10 @@ void DOSBOX_Init(void) {
 	                  "scan2x, scan3x, tv2x, tv3x, sharp (default).");
 #endif
 
+	// Add the [composite] conf block after [render]
+	assert(control);
+	VGA_AddCompositeSettings(*control);
+
 	secprop=control->AddSection_prop("cpu",&CPU_Init,true);//done
 	const char* cores[] = { "auto",
 #if (C_DYNAMIC_X86) || (C_DYNREC)

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -154,23 +154,23 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 
 	// Simulate CGA composite output
 	int *o = temp;
-	auto OUT = [&](const int v) {
-		*o = (v);
+	auto push_pixel = [&o](const int v) {
+		*o = v;
 		++o;
 	};
 
 	Bit8u *rgbi = TempLine;
 	int *b = &CGA_Composite_Table[border * 68];
 	for (int x = 0; x < 4; ++x)
-		OUT(b[(x + 3) & 3]);
-	OUT(CGA_Composite_Table[(border << 6) | ((*rgbi) << 2) | 3]);
+		push_pixel(b[(x + 3) & 3]);
+	push_pixel(CGA_Composite_Table[(border << 6) | ((*rgbi) << 2) | 3]);
 	for (int x = 0; x < w - 1; ++x) {
-		OUT(CGA_Composite_Table[(rgbi[0] << 6) | (rgbi[1] << 2) | (x & 3)]);
+		push_pixel(CGA_Composite_Table[(rgbi[0] << 6) | (rgbi[1] << 2) | (x & 3)]);
 		++rgbi;
 	}
-	OUT(CGA_Composite_Table[((*rgbi) << 6) | (border << 2) | 3]);
+	push_pixel(CGA_Composite_Table[((*rgbi) << 6) | (border << 2) | 3]);
 	for (int x = 0; x < 5; ++x)
-		OUT(b[x & 3]);
+		push_pixel(b[x & 3]);
 
 	if ((vga.tandy.mode_control & 4) != 0) {
 		// Decode

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1136,14 +1136,31 @@ static void TANDY_FindMode()
 			} else VGA_SetMode(M_TANDY16);
 		}
 		else if (vga.tandy.gfx_control & 0x08) {
-			VGA_SetMode(M_TANDY4);
-		}
-		else if (vga.tandy.mode_control & 0x10)
-			VGA_SetMode(M_TANDY2);
-		else {
-			if (vga.mode==M_TANDY16) {
-				VGA_SetModeNow(M_TANDY4);
-			} else VGA_SetMode(M_TANDY4);
+			if (cga_comp == COMPOSITE_STATE::ON) {
+				// composite ntsc 640x200 16 color mode
+				VGA_SetMode(M_CGA4_COMPOSITE);
+				update_cga16_color();
+			} else {
+				VGA_SetMode(M_TANDY4);
+			}
+		} else if (vga.tandy.mode_control & 0x10) {
+			if (cga_comp == COMPOSITE_STATE::ON) {
+				// composite ntsc 640x200 16 color mode
+				VGA_SetMode(M_CGA2_COMPOSITE);
+				update_cga16_color();
+			} else {
+				VGA_SetMode(M_TANDY2);
+			}
+		} else {
+			// otherwise some 4-colour graphics mode
+			const auto new_mode = (cga_comp == COMPOSITE_STATE::ON)
+			                              ? M_CGA4_COMPOSITE
+			                              : M_TANDY4;
+			if (vga.mode == M_TANDY16) {
+				VGA_SetModeNow(new_mode);
+			} else {
+				VGA_SetMode(new_mode);
+			}
 		}
 		tandy_update_palette();
 	} else {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1264,6 +1264,9 @@ static void write_tandy(io_port_t port, uint8_t val, io_width_t)
 	case 0x3d9:
 		vga.tandy.color_select=val;
 		tandy_update_palette();
+		// Re-apply the composite mode after updating the palette
+		if (cga_comp == COMPOSITE_STATE::ON)
+			apply_composite_state();
 		break;
 	case 0x3da:
 		vga.tandy.reg_index = val;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1022,9 +1022,15 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 static void PCJr_FindMode();
 
 static void Composite(bool pressed) {
-	if (!pressed) return;
-	if (++cga_comp>2) cga_comp=0;
-	LOG_MSG("Composite output: %s",(cga_comp==0)?"auto":((cga_comp==1)?"on":"off"));
+	if (!pressed)
+		return;
+
+	if (++cga_comp > 2)
+		cga_comp = 0;
+
+	LOG_MSG("COMPOSITE: State is %s", cga_comp == 0   ? "auto"
+	                                  : cga_comp == 1 ? "on"
+	                                                  : "off");
 	// switch RGB and Composite if in graphics mode
 	if (vga.tandy.mode_control & 0x2) {
 		if (machine == MCH_PCJR) {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1194,9 +1194,9 @@ static void PCJr_FindMode()
 			} else {
 				VGA_SetMode(new_mode);
 			}
-			if (cga_comp == COMPOSITE_STATE::ON) {
-				update_cga16_color();
-			}
+		}
+		if (vga.mode == M_CGA16) {
+			update_cga16_color_pcjr();
 		}
 		tandy_update_palette();
 	} else {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -599,15 +599,16 @@ static void update_cga16_color()
 	                           ? new_cga_v(chroma_multiplexer[255], i3, i3, i3, i3)
 	                           : chroma_multiplexer[255] + i3;
 
-	const auto mode_contrast = 2.56f * contrast / (max_v - min_v);
+	const auto mode_contrast = 2.56f * static_cast<float>(contrast) / (max_v - min_v);
 
-	const auto mode_brightness = brightness * 5 - 256 * min_v / (max_v - min_v);
+	const auto mode_brightness = static_cast<float>(brightness) * 5 - 256 * min_v / (max_v - min_v);
 
 	const bool in_tandy_text_mode = (vga.mode == M_CGA_TEXT_COMPOSITE) &&
 	                                (vga.tandy.mode_control & 1);
 	const auto mode_hue = in_tandy_text_mode ? 14.0f : 4.0f;
 
-	const auto mode_saturation = saturation * (is_composite_new_era ? 5.8f : 2.9f) / 100;
+	const auto mode_saturation = static_cast<float>(saturation) *
+	                             (is_composite_new_era ? 5.8f : 2.9f) / 100;
 
 	// Update the Composite CGA palette
 	const bool in_tandy_mode_4 = vga.tandy.mode_control & 4;
@@ -647,7 +648,7 @@ static void update_cga16_color()
 	const auto q = static_cast<float>(CGA_Composite_Table[6 * 68 + 1] -
 	                                  CGA_Composite_Table[6 * 68 + 3]);
 
-	const auto a = tau * (33 + 90 + hue_offset + mode_hue) / 360.0f;
+	const auto a = tau * (33 + 90 + static_cast<float>(hue) + mode_hue) / 360.0f;
 	const auto c = cosf(a);
 	const auto s = sinf(a);
 

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -203,7 +203,6 @@ static void write_lightpen(io_port_t port, uint8_t /*val*/, io_width_t)
 constexpr int16_t hue_min = 0;
 constexpr int16_t hue_mid = 0;
 constexpr int16_t hue_max = 360;
-constexpr int16_t hue_pcjr_rotation = 100;
 static int hue = hue_mid;
 
 constexpr int16_t saturation_min = 0;
@@ -715,7 +714,6 @@ static void set_hue_from_percent(int percent)
 
 	percent -= percent_mid;                // switch to zero-based
 	hue = percent * hue_max / percent_max; // to 360 degrees
-	hue += (machine == MCH_PCJR ? hue_pcjr_rotation : 0);
 	hue = wrap(hue, hue_min, hue_max); // stay in-bounds
 
 	assert(hue >= hue_min && hue <= hue_max);
@@ -726,8 +724,7 @@ static int get_percent_from_hue()
 {
 	assert(hue >= hue_min && hue <= hue_max);
 
-	const auto adjustment = (machine == MCH_PCJR ? hue_pcjr_rotation : 0);
-	auto percent = (hue - adjustment) * percent_max / hue_max;
+	auto percent = hue * percent_max / hue_max;
 	percent = wrap(percent + percent_mid, percent_min, percent_max);
 	assert(percent >= percent_min && percent <= percent_max);
 	return percent;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1528,16 +1528,7 @@ void VGA_SetupOther()
 	if (machine==MCH_CGA) {
 		IO_RegisterWriteHandler(0x3d8, write_cga, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3d9, write_cga, io_width_t::byte);
-		if (!mono_cga) {
-			MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10,
-			                  0, "select", "Sel Knob");
-			MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11,
-			                  0, "incval", "Inc Knob");
-			MAPPER_AddHandler(turn_crt_knob_negative, SDL_SCANCODE_F11,
-			                  MMOD2, "decval", "Dec Knob");
-			MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0,
-			                  "cgacomp", "CGA Comp");
-		} else {
+		if (mono_cga) {
 			MAPPER_AddHandler(CycleMonoCGAPal, SDL_SCANCODE_F11, 0,
 			                  "monocgapal", "Mono CGA Pal");
 			MAPPER_AddHandler(CycleMonoCGABright, SDL_SCANCODE_F11, MMOD2,
@@ -1557,10 +1548,18 @@ void VGA_SetupOther()
 		write_pcjr(0x3df, 0x7 | (0x7 << 3), io_width_t::byte);
 		IO_RegisterWriteHandler(0x3da, write_pcjr, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3df, write_pcjr, io_width_t::byte);
-		MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10, 0, "select", "Sel Knob");
-		MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11, 0, "incval", "Inc Knob");
-		MAPPER_AddHandler(turn_crt_knob_negative, SDL_SCANCODE_F11, MMOD2, "decval", "Dec Knob");
-		MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0, "cgacomp", "CGA Comp");
+	}
+	// Add composite hotkeys for CGA, Tandy, and PCjr
+	if ((machine == MCH_CGA && !mono_cga) || machine == MCH_TANDY ||
+	    machine == MCH_PCJR) {
+		MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10, 0,
+		                  "select", "Sel Knob");
+		MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11, 0,
+		                  "incval", "Inc Knob");
+		MAPPER_AddHandler(turn_crt_knob_negative, SDL_SCANCODE_F11,
+		                  MMOD2, "decval", "Dec Knob");
+		MAPPER_AddHandler(Composite, SDL_SCANCODE_F12, 0, "cgacomp",
+		                  "CGA Comp");
 	}
 	if (machine == MCH_HERC) {
 		constexpr uint16_t base = 0x3b0;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -226,7 +226,12 @@ constexpr int16_t convergence_mid = 0;
 constexpr int16_t convergence_max = 256;
 static int convergence = convergence_mid;
 
-static uint8_t cga_comp = 0;
+enum class COMPOSITE_STATE : uint8_t {
+	AUTO = 0,
+	ON,
+	OFF,
+};
+static COMPOSITE_STATE cga_comp = COMPOSITE_STATE::AUTO;
 static bool is_composite_new_era = false;
 
 // PCjr composite-specific
@@ -976,7 +981,10 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 		vga.attr.disabled = (val&0x8)? 0: 1;
 		if (vga.tandy.mode_control & 0x2) {		// graphics mode
 			if (vga.tandy.mode_control & 0x10) {// highres mode
-				if (cga_comp==1 || ((cga_comp==0 && !(val&0x4)) && !mono_cga)) {	// composite display
+				if (cga_comp == COMPOSITE_STATE::ON ||
+				    ((cga_comp == COMPOSITE_STATE::AUTO &&
+				      !(val & 0x4)) &&
+				     !mono_cga)) {
 
 					// composite ntsc 640x200 16 color mode
 					if (machine == MCH_PCJR) {
@@ -989,7 +997,7 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 					VGA_SetMode(M_TANDY2);
 				}
 			} else {							// lowres mode
-				if (cga_comp==1) {				// composite display
+				if (cga_comp == COMPOSITE_STATE::ON) {
 					// composite ntsc 640x200 16 color mode
 					if (machine == MCH_PCJR) {
 						VGA_SetMode(M_CGA16);
@@ -1004,7 +1012,7 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 
 			write_cga_color_select(vga.tandy.color_select);
 		} else {
-			if (cga_comp == 1) { // composite display
+			if (cga_comp == COMPOSITE_STATE::ON) { // composite display
 				VGA_SetMode(M_CGA_TEXT_COMPOSITE);
 				update_cga16_color();
 			} else {
@@ -1025,12 +1033,17 @@ static void Composite(bool pressed) {
 	if (!pressed)
 		return;
 
-	if (++cga_comp > 2)
-		cga_comp = 0;
+	// Step through the composite modes
+	if (cga_comp == COMPOSITE_STATE::AUTO)
+		cga_comp = COMPOSITE_STATE::ON;
+	else if (cga_comp == COMPOSITE_STATE::ON)
+		cga_comp = COMPOSITE_STATE::OFF;
+	else
+		cga_comp = COMPOSITE_STATE::AUTO;
 
-	LOG_MSG("COMPOSITE: State is %s", cga_comp == 0   ? "auto"
-	                                  : cga_comp == 1 ? "on"
-	                                                  : "off");
+	LOG_MSG("COMPOSITE: State is %s", cga_comp == COMPOSITE_STATE::AUTO ? "auto"
+	                                  : cga_comp == COMPOSITE_STATE::ON ? "on"
+	                                                                    : "off");
 	// switch RGB and Composite if in graphics mode
 	if (vga.tandy.mode_control & 0x2) {
 		if (machine == MCH_PCJR) {
@@ -1138,15 +1151,16 @@ static void PCJr_FindMode()
 				VGA_SetMode(M_TANDY16);
 		} else if (vga.tandy.gfx_control & 0x08) {
 			// bit3 of mode control 2 signals 2 colour graphics mode
-			if (cga_comp == 1 ||
-			    (cga_comp == 0 && !(vga.tandy.mode_control & 0x4))) {
+			if (cga_comp == COMPOSITE_STATE::ON ||
+			    (cga_comp == COMPOSITE_STATE::AUTO &&
+			     !(vga.tandy.mode_control & 0x4))) {
 				VGA_SetMode(M_CGA16);
 			} else {
 				VGA_SetMode(M_TANDY2);
 			}
 		} else {
 			// otherwise some 4-colour graphics mode
-			const auto new_mode = (cga_comp == 1) ? M_CGA16 : M_TANDY4;
+			const auto new_mode = (cga_comp == COMPOSITE_STATE::ON) ? M_CGA16 : M_TANDY4;
 			if (vga.mode == M_TANDY16) {
 				VGA_SetModeNow(new_mode);
 			} else {
@@ -1583,7 +1597,9 @@ static void composite_init(Section *sec)
 	const auto conf = static_cast<Section_prop *>(sec);
 	assert(conf);
 	const std::string state = conf->Get_string("composite");
-	cga_comp = (state == "auto" ? 0 : state == "on" ? 1 : 2);
+	cga_comp = (state == "auto" ? COMPOSITE_STATE::AUTO
+	            : state == "on" ? COMPOSITE_STATE::ON
+	                            : COMPOSITE_STATE::OFF);
 
 	const auto era_choice = std::string(conf->Get_string("era"));
 	is_composite_new_era = era_choice == "new" ||

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1106,11 +1106,9 @@ static void tandy_update_palette() {
 		// PCJr
 		switch (vga.mode) {
 		case M_TANDY2:
-		case M_CGA2_COMPOSITE:
 			VGA_SetCGA2Table(vga.attr.palette[0],vga.attr.palette[1]);
 			break;
 		case M_TANDY4:
-		case M_CGA4_COMPOSITE:
 			VGA_SetCGA4Table(
 				vga.attr.palette[0], vga.attr.palette[1],
 				vga.attr.palette[2], vga.attr.palette[3]);
@@ -1195,6 +1193,9 @@ static void PCJr_FindMode()
 				VGA_SetModeNow(new_mode);
 			} else {
 				VGA_SetMode(new_mode);
+			}
+			if (cga_comp == COMPOSITE_STATE::ON) {
+				update_cga16_color();
 			}
 		}
 		tandy_update_palette();

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1029,7 +1029,27 @@ static void write_cga(io_port_t port, uint8_t val, io_width_t)
 
 static void PCJr_FindMode();
 
-static void Composite(bool pressed) {
+static void apply_composite_state()
+{
+	// switch RGB and Composite if in graphics mode
+	if (vga.tandy.mode_control & 0x2 && machine == MCH_PCJR)
+		PCJr_FindMode();
+	else
+		write_cga(0x3d8, vga.tandy.mode_control, io_width_t::byte);
+
+/* 	if (vga.tandy.mode_control & 0x2) {
+		if (machine == MCH_PCJR) {
+			PCJr_FindMode();
+		} else {
+			write_cga(0x3d8, vga.tandy.mode_control, io_width_t::byte);
+		}
+	}
+ */
+
+}
+
+static void Composite(bool pressed)
+{
 	if (!pressed)
 		return;
 
@@ -1044,14 +1064,7 @@ static void Composite(bool pressed) {
 	LOG_MSG("COMPOSITE: State is %s", cga_comp == COMPOSITE_STATE::AUTO ? "auto"
 	                                  : cga_comp == COMPOSITE_STATE::ON ? "on"
 	                                                                    : "off");
-	// switch RGB and Composite if in graphics mode
-	if (vga.tandy.mode_control & 0x2) {
-		if (machine == MCH_PCJR) {
-			PCJr_FindMode();
-		} else {
-			write_cga(0x3d8, vga.tandy.mode_control, io_width_t::byte);
-		}
-	}
+	apply_composite_state();
 }
 
 static void tandy_update_palette() {


### PR DESCRIPTION
```ini

[composite]
#   composite: Enable composite mode on start. 'auto' lets the program decide.
#              Note: For the adjustments below, use the composite hotkeys to fine-tune them,
#              then read the new settings from your console and enter them here.
#              Possible values: auto, on, off.
#         era: Era of composite technology. When 'auto', PCjr is 'new' and others are 'old'.
#              Possible values: auto, old, new.
#         hue: Appearance of RGB palette. For example, adjust until sky is blue.
#  saturation: Intensity of colors, from washed out to vivid.
#    contrast: Ratio between the dark and light area.
#  brightness: Luminosity of the image, from dark to light.
# convergence: Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only)

composite   = auto
era         = auto
hue         = 0
saturation  = 100
contrast    = 100
brightness  = 0
convergence = 0
```

Some nice features:
 - when using the hotkeys, the settings will wrap when they hit their positive or negative limit, like a real CRT knob.
 - when entering values here
 - `convergence` isn't supported in PCjr mode - and this hotkey setting is skipped
