### PR TITLE
Make FluidSynth's chorus and reverb setting configurable

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -102,4 +102,6 @@ bool starts_with(const char (&pfx)[N], const std::string &str) noexcept
 
 bool ends_with(const std::string &str, const std::string &suffix) noexcept;
 
+bool find_in_case_insensitive(const std::string &needle, const std::string &haystack);
+
 #endif

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -187,15 +187,14 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	        "'mt32_old' and 'mt32_new' are aliases for 1.07 and 2.04, respectively.");
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");
-	str_prop->Set_help(
-	        "The directory containing ROMs for one or more models.\n"
-	        "The directory can be absolute or relative, or leave it blank to\n"
-	        "use the 'mt32-roms' directory in your DOSBox configuration\n"
-	        "directory. Other common system locations will be checked as well.\n"
-	        "ROM files inside this directory may include any of the following:\n"
-	        "  - MT32_CONTROL.ROM and MT32_PCM.ROM, for the 'mt32' model.\n"
-	        "  - CM32L_CONTROL.ROM and CM32L_PCM.ROM, for the 'cm32l' model.\n"
-	        "  - Unzipped MAME MT-32 and CM-32L ROMs, for the versioned models.\n");
+	str_prop->Set_help("The directory containing ROMs for one or more models.\n"
+	                   "The directory can be absolute or relative, or leave it blank to\n"
+	                   "use the 'mt32-roms' directory in your DOSBox configuration\n"
+	                   "directory. Other common system locations will be checked as well.\n"
+	                   "ROM files inside this directory may include any of the following:\n"
+	                   "  - MT32_CONTROL.ROM and MT32_PCM.ROM, for the 'mt32' model.\n"
+	                   "  - CM32L_CONTROL.ROM and CM32L_PCM.ROM, for the 'cm32l' model.\n"
+	                   "  - Unzipped MAME MT-32 and CM-32L ROMs, for the versioned models.");
 }
 
 #if defined(WIN32)

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -351,3 +351,15 @@ bool ends_with(const std::string &str, const std::string &suffix) noexcept
 	return (str.size() >= suffix.size() &&
 	        str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);
 }
+
+// Search for the needle in the haystack, case insensitive.
+bool find_in_case_insensitive(const std::string &needle, const std::string &haystack)
+{
+	const auto it = std::search(haystack.begin(), haystack.end(),
+	                            needle.begin(), needle.end(),
+	                            [](char ch1, char ch2) {
+		                            return std::toupper(ch1) ==
+		                                   std::toupper(ch2);
+	                            });
+	return (it != haystack.end());
+}


### PR DESCRIPTION
```ini
[fluidsynth]
# soundfont: Path to a SoundFont file in .sf2 format. You can use an
#            absolute or relative path, or the name of an .sf2 inside
#            the 'soundfonts' directory within your DOSBox configuration
#            directory.
#            An optional percentage will scale the SoundFont's volume.
#            For example: 'soundfont.sf2 50' will attenuate it by 50 percent.
#            The scaling percentage can range from 1 to 500.
#    chorus: FluidSynth's chorus: 'auto', 'on', 'off', or custom values.
#            When using custom values:
#              All five must be provided in-order and space-separated.
#              They are: voice-count level speed depth modulation-wave, where:
#              - voice-count is an integer from 0 to 99.
#              - level is a decimal from 0.0 to 10.0
#              - speed is a decimal, measured in Hz, from 0.1 to 5.0
#              - depth is a decimal from 0.0 to 21.0
#              - modulation-wave is either 'sine' or 'triangle'
#              For example: chorus = 3 1.2 0.3 8.0 sine
#    reverb: FluidSynth's reverb: 'auto', 'on', 'off', or custom values.
#            When using custom values:
#              All four must be provided in-order and space-separated.
#              They are: room-size damping width level, where:
#              - room-size is a decimal from 0.0 to 1.0
#              - damping is a decimal from 0.0 to 1.0
#              - width is a decimal from 0.0 to 100.0
#              - level is a decimal from 0.0 to 1.0
#              For example: reverb = 0.61 0.23 0.76 0.56

soundfont = default.sf2
chorus    = auto
reverb    = auto
```
