### PR TITLE
Auto-exit when using instant-launch

### DIFF
--- a/.github/scripts/run-sanitizers.sh
+++ b/.github/scripts/run-sanitizers.sh
@@ -38,7 +38,7 @@ export LSAN_OPTIONS="suppressions=.lsan-suppress:verbosity=0"
 # so we or-to-true to ensure our script doesn't end here.
 # We'll detect issues by analyzing logs instead.
 time xvfb-run "./${build_dir}/dosbox" \
-	-c "autotype -w 0.1 e x i t enter" \
+	-c "autotype -w 2 e x i t enter" \
 	&> "${logs}/EnterExit.log" || true
 
 # Compress the logs

--- a/README
+++ b/README
@@ -367,8 +367,16 @@ dosbox -opencaptures program
         If "NAME" is an executable it will mount the directory of "NAME"
         as the C: drive and execute "NAME".
 
+        If "NAME" in an execuatble and the startup_verbosity configurable
+        setting is "auto" (or "low" or "quiet"), then the introductory
+        splash-screen and text help banner will not be shown.  This is known
+        as instant-launch.
+
   -exit
         DOSBox will close itself when the DOS application "name" ends.
+        If the above conditions for instant-launch are true, then the -exit
+        flag is implied, and DOSBox will quit as soon as the executable
+        "NAME" terminates.
 
   -c command
         Runs the specified command before running "name". Multiple commands

--- a/include/control.h
+++ b/include/control.h
@@ -32,11 +32,11 @@
 
 enum class Verbosity : int8_t {
 	//                  Splash | Welcome | Early Stdout |
-	High = 4,       //   yes   |   yes   |    yes       |
-	Medium = 3,     //   no    |   yes   |    yes       |
-	Low = 2,        //   no    |   no    |    yes       |
+	Quiet = 0,      //   no    |   no    |    no        |
 	SplashOnly = 1, //   yes   |   no    |    no        |
-	Quiet = 0       //   no    |   no    |    no        |
+	Low = 2,        //   no    |   no    |    yes       |
+	Medium = 3,     //   no    |   yes   |    yes       |
+	High = 4,       //   yes   |   yes   |    yes       |
 };
 
 class Config {

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -25,9 +25,9 @@
 
 int sdl_main(int argc, char *argv[]);
 
-// The exit_requested bool is a conditional break in the parse-loop and
+// The shutdown_requested bool is a conditional break in the parse-loop and
 // machine-loop. Set it to true to gracefully quit in expected circumstances.
-extern bool exit_requested;
+extern bool shutdown_requested;
 
 // The E_Exit function throws an exception to quit. Call it in unexpected
 // circumstances.

--- a/include/shell.h
+++ b/include/shell.h
@@ -153,6 +153,7 @@ public:
 	{}
 	void Install(std::string const &in);
 	void InstallBefore(std::string const &in);
+	const std::string &GetLine() const { return buf; }
 	~AutoexecObject();
 private:
 	void CreateAutoexec();

--- a/include/shell.h
+++ b/include/shell.h
@@ -71,6 +71,7 @@ private:
 
 	char *completion_start = nullptr;
 	uint16_t completion_index = 0;
+	bool exit_cmd_called = false;
 
 public:
 

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -874,7 +874,7 @@ static void DrawCode(void) {
 		char* res = empty_res;
 		if (showExtend) res = AnalyzeInstruction(dline, saveSel);
 		// Spacepad it up to 28 characters
-		size_t dline_len = strlen(dline);
+		size_t dline_len = safe_strlen(dline);
 		if (dline_len < 28) memset(dline + dline_len, ' ',28 - dline_len);
 		dline[28] = 0;
 		waddstr(dbg.win_code,dline);
@@ -1606,7 +1606,7 @@ Bit32u DEBUG_CheckKeys(void) {
 	bool skipDraw = false;
 	int key=getch();
 
-	if (key >='1' && key <='5' && strlen(codeViewData.inputStr) == 0) {
+	if (key >='1' && key <='5' && safe_strlen(codeViewData.inputStr) == 0) {
 		const Bit32s v[] ={5,500,1000,5000,10000};
 
 		ret = DEBUG_Run(v[key - '1'],true);
@@ -1745,7 +1745,7 @@ Bit32u DEBUG_CheckKeys(void) {
 				}
 				safe_strcpy(codeViewData.inputStr,
 				            (--histBuffPos)->c_str());
-				codeViewData.inputPos = strlen(codeViewData.inputStr);
+				codeViewData.inputPos = safe_strlen(codeViewData.inputStr);
 				break;
 		case KEY_F(7):	// next command (f1-f4 generate rubbish at my place)
 		case KEY_F(4):	// next command
@@ -1758,7 +1758,7 @@ Bit32u DEBUG_CheckKeys(void) {
 					safe_strcpy(codeViewData.inputStr,
 					            codeViewData.suspInputStr);
 				}
-				codeViewData.inputPos = strlen(codeViewData.inputStr);
+				codeViewData.inputPos = safe_strlen(codeViewData.inputStr);
 				break;
 		case KEY_F(5):	// Run Program
 				debugging=false;
@@ -1804,7 +1804,7 @@ Bit32u DEBUG_CheckKeys(void) {
 					histBuffPos = histBuff.end();
 					ClearInputLine();
 				} else {
-					codeViewData.inputPos = strlen(codeViewData.inputStr);
+					codeViewData.inputPos = safe_strlen(codeViewData.inputStr);
 				}
 				break;
 		case KEY_BACKSPACE: //backspace (linux)
@@ -1828,7 +1828,7 @@ Bit32u DEBUG_CheckKeys(void) {
 							codeViewData.inputStr[codeViewData.inputPos++] = char(key);
 							codeViewData.inputStr[codeViewData.inputPos] = '\0';
 					} else if (!codeViewData.ovrMode) {
-						int len = (int) strlen(codeViewData.inputStr);
+						int len = (int) safe_strlen(codeViewData.inputStr);
 						if (len < MAXCMDLEN) {
 							for(len++;len>codeViewData.inputPos;len--)
 								codeViewData.inputStr[len]=codeViewData.inputStr[len-1];
@@ -2095,11 +2095,11 @@ static void LogInstruction(uint16_t segValue, uint32_t eipValue, ofstream &out)
 	if (showExtend && (cpuLogType > 0) ) {
 		res = AnalyzeInstruction(dline,false);
 		if (!res || !(*res)) res = empty;
-		Bitu reslen = strlen(res);
+		Bitu reslen = safe_strlen(res);
 		if (reslen < 22) memset(res + reslen, ' ',22 - reslen);
 		res[22] = 0;
 	}
-	Bitu len = strlen(dline);
+	Bitu len = safe_strlen(dline);
 	if (len < 30) memset(dline + len,' ',30 - len);
 	dline[30] = 0;
 
@@ -2117,7 +2117,7 @@ static void LogInstruction(uint16_t segValue, uint32_t eipValue, ofstream &out)
 			else sprintf(tmpc,"%02X ",value);
 			strcat(ibytes,tmpc);
 		}
-		len = strlen(ibytes);
+		len = safe_strlen(ibytes);
 		if (len<21) { for (Bitu i=0; i<21-len; i++) ibytes[len + i] =' '; ibytes[21]=0;} //NOTE THE BRACKETS
 		out << setw(4) << SegValue(cs) << ":" << setw(8) << reg_eip << "  " << dline << "  " << res << "  " << ibytes;
 	}
@@ -2173,7 +2173,7 @@ public:
 		args[0]	= 0;
 		bool found = cmd->FindCommand(commandNr++,temp_line);
 		while (found) {
-			if (strlen(args)+temp_line.length()+1>256) break;
+			if (safe_strlen(args)+temp_line.length()+1>256) break;
 			strcat(args,temp_line.c_str());
 			found = cmd->FindCommand(commandNr++,temp_line);
 			if (found) strcat(args," ");
@@ -2518,12 +2518,12 @@ void DEBUG_HeavyLogInstruction()
 	if (showExtend) {
 		res = AnalyzeInstruction(dline,false);
 		if (!res || !(*res)) res = empty;
-		Bitu reslen = strlen(res);
+		Bitu reslen = safe_strlen(res);
 		if (reslen < 22) memset(res + reslen, ' ',22 - reslen);
 		res[22] = 0;
 	}
 
-	Bitu len = strlen(dline);
+	Bitu len = safe_strlen(dline);
 	if (len < 30) memset(dline + len,' ',30 - len);
 	dline[30] = 0;
 

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -64,7 +64,7 @@ void DEBUG_ShowMsg(char const* format,...) {
 	buf[sizeof(buf) - 1] = '\0';
 
 	/* Add newline if not present */
-	size_t len = strlen(buf);
+	size_t len = safe_strlen(buf);
 	if(buf[len - 1] != '\n' && len + 1 < sizeof(buf) ) strcat(buf,"\n");
 
 	if (debuglog) {

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -29,6 +29,7 @@
 #include "regs.h"
 #include "serialport.h"
 #include "setup.h"
+#include "string_utils.h"
 #include "support.h"
 
 DOS_Block dos;
@@ -799,7 +800,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x47:					/* CWD Get current directory */
 		if (DOS_GetCurrentDir(reg_dl,name1)) {
-			MEM_BlockWrite(SegPhys(ds)+reg_si,name1,(Bitu)(strlen(name1)+1));	
+			MEM_BlockWrite(SegPhys(ds)+reg_si,name1,(Bitu)(safe_strlen(name1)+1));	
 			reg_ax=0x0100;
 			CALLBACK_SCF(false);
 		} else {
@@ -981,7 +982,7 @@ static Bitu DOS_21Handler(void) {
 			MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 			if (DOS_CreateTempFile(name1,&handle)) {
 				reg_ax=handle;
-				MEM_BlockWrite(SegPhys(ds)+reg_dx,name1,(Bitu)(strlen(name1)+1));
+				MEM_BlockWrite(SegPhys(ds)+reg_dx,name1,(Bitu)(safe_strlen(name1)+1));
 				CALLBACK_SCF(false);
 			} else {
 				reg_ax=dos.errorcode;
@@ -1030,7 +1031,7 @@ static Bitu DOS_21Handler(void) {
 	case 0x60:					/* Canonicalize filename or path */
 		MEM_StrCopy(SegPhys(ds)+reg_si,name1,DOSNAMEBUF);
 		if (DOS_Canonicalize(name1,name2)) {
-				MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));	
+				MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(safe_strlen(name2)+1));	
 				CALLBACK_SCF(false);
 			} else {
 				reg_ax=dos.errorcode;

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -16,17 +16,19 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "dosbox.h"
 
 #include <string.h>
 #include <ctype.h>
-#include "dosbox.h"
-#include "mem.h"
-#include "dos_inc.h"
-#include "regs.h"
+
+#include "cpu.h"
 #include "callback.h"
 #include "debug.h"
-#include "cpu.h"
+#include "dos_inc.h"
+#include "mem.h"
 #include "programs.h"
+#include "regs.h"
+#include "string_utils.h"
 
 const char * RunningProgram="DOSBOX";
 
@@ -199,7 +201,7 @@ static bool MakeEnv(char * name,Bit16u * segment) {
 	envwrite+=2;
 	char namebuf[DOS_PATHLENGTH];
 	if (DOS_Canonicalize(name,namebuf)) {
-		MEM_BlockWrite(envwrite,namebuf,(Bitu)(strlen(namebuf)+1));
+		MEM_BlockWrite(envwrite,namebuf,(Bitu)(safe_strlen(namebuf)+1));
 		return true;
 	} else return false;
 }

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -216,7 +216,7 @@ bool DOS_ChangeDir(char const * const dir) {
 		return false;
 	}
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
-	if (strlen(fulldir) && testdir[len-1]=='\\') {
+	if (safe_strlen(fulldir) && testdir[len-1]=='\\') {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1122,7 +1122,7 @@ public:
 			WORD cur_kb_subID  = 0;
 			char layoutID_string[KL_NAMELENGTH];
 			if (GetKeyboardLayoutName(layoutID_string)) {
-				if (strlen(layoutID_string) == 8) {
+				if (safe_strlen(layoutID_string) == 8) {
 					int cur_kb_layout_by_name = ConvHexWord((char*)&layoutID_string[4]);
 					layoutID_string[4] = 0;
 					int subID = ConvHexWord((char*)&layoutID_string[0]);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -34,6 +34,7 @@
 #include "support.h"
 #include "bios_disk.h"
 #include "cpu.h"
+#include "string_utils.h"
 
 #define MSCDEX_LOG LOG(LOG_MISC,LOG_ERROR)
 //#define MSCDEX_LOG
@@ -694,7 +695,7 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 	char* searchPos = searchName;
 
 	//strip of tailing . (XCOM APOCALYPSE)
-	size_t searchlen = strlen(searchName);
+	size_t searchlen = safe_strlen(searchName);
 	if (searchlen > 1 && strcmp(searchName,".."))
 		if (searchName[searchlen-1] =='.')  searchName[searchlen-1] = 0;
 
@@ -741,7 +742,7 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 			char* separator = strchr(entryName,';');
 			if (separator) *separator = 0;
 			// strip trailing period
-			size_t entrylen = strlen(entryName);
+			size_t entrylen = safe_strlen(entryName);
 			if (entrylen>0 && entryName[entrylen-1]=='.') entryName[entrylen-1] = 0;
 
 			if (strcmp(entryName,useName)==0) {

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -191,7 +191,7 @@ char* DOS_Drive_Cache::GetExpandName(const char* path) {
 	}
 
 	if (*work) {
-		size_t len = strlen(work);
+		size_t len = safe_strlen(work);
 #if defined (WIN32)
 		if((work[len-1] == CROSS_FILESPLIT ) && (len >= 2) && (work[len-2] != ':')) {
 #else
@@ -391,10 +391,10 @@ int DOS_Drive_Cache::CompareShortname(const char* compareName, const char* short
 /* the following code is replaced as it's not safe when char* is 64 bits */
 /*		Bits compareCount1	= (int)cpos - (int)shortName;
 		char* endPos		= strchr(cpos,'.');
-		Bitu numberSize		= endPos ? int(endPos)-int(cpos) : strlen(cpos);
+		Bitu numberSize		= endPos ? int(endPos)-int(cpos) : safe_strlen(cpos);
 		
 		char* lpos			= strchr(compareName,'.');
-		Bits compareCount2	= lpos ? int(lpos)-int(compareName) : strlen(compareName);
+		Bits compareCount2	= lpos ? int(lpos)-int(compareName) : safe_strlen(compareName);
 		if (compareCount2>8) compareCount2 = 8;
 
 		compareCount2 -= numberSize;
@@ -615,7 +615,7 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 
 		// Copy first letters
 		Bits tocopy = 0;
-		size_t buflen = strlen(short_nr);
+		size_t buflen = safe_strlen(short_nr);
 		if (len + buflen + 1 > 8)
 			tocopy = (Bits)(8 - buflen - 1);
 		else
@@ -633,7 +633,7 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 			// Step to last extension...
 			pos = strrchr(tmpName, '.'); // extensions are at-most 3 chars (4 with terminator)
 			// add extension
-			unsigned int remaining_space = DOS_NAMELENGTH_ASCII - strlen(info->shortname) - 1;
+			unsigned int remaining_space = DOS_NAMELENGTH_ASCII - safe_strlen(info->shortname) - 1;
 			strncat(info->shortname, pos, 4 < remaining_space ? 4 : remaining_space);
 			info->shortname[DOS_NAMELENGTH] = 0;
 		}
@@ -686,7 +686,7 @@ DOS_Drive_Cache::CFileInfo* DOS_Drive_Cache::FindDirInfo(const char* path, char*
 //	LOG_DEBUG("DIR: Find %s",path);
 
 	// Remove base dir path
-	start += strlen(basePath);
+	start += safe_strlen(basePath);
 	safe_strncpy(expandedPath, basePath, CROSS_LEN);
 
 	// hehe, baseDir should be cached in... 
@@ -773,7 +773,7 @@ bool DOS_Drive_Cache::OpenDir(CFileInfo* dir, const char* expand, Bit16u& id) {
 	safe_strcpy(expandcopy, expand);
 	// Add "/"
 	char end[2]={CROSS_FILESPLIT,0};
-	const size_t expandcopylen = strlen(expandcopy);
+	const size_t expandcopylen = safe_strlen(expandcopy);
 	if (expandcopylen > 0 && expandcopy[expandcopylen - 1] != CROSS_FILESPLIT) {
 		safe_strcat(expandcopy, end);
 	}

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -357,7 +357,7 @@ again:
 	uint16_t find_time;
 	uint32_t find_size;
 
-	if (strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII) {
+	if (safe_strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII) {
 		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	} 
@@ -420,7 +420,7 @@ bool localDrive::TestDir(char * dir) {
 	CROSS_FILENAME(newdir);
 	dirCache.ExpandName(newdir);
 	// Skip directory test, if "\"
-	size_t len = strlen(newdir);
+	size_t len = safe_strlen(newdir);
 	if (len && (newdir[len-1]!='\\')) {
 		// It has to be a directory !
 		struct stat test;

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -349,7 +349,7 @@ Overlay_Drive::Overlay_Drive(const char *startdir,
 	//Determine if overlaydir is part of the startdir.
 	convert_overlay_to_DOSname_in_base(dirname);
 
-	size_t dirlen = strlen(dirname);
+	size_t dirlen = safe_strlen(dirname);
 	if(dirlen && dirname[dirlen - 1] == '\\') dirname[dirlen - 1] = 0;
 			
 	//add_deleted_path(dirname); //update_cache will add the overlap_folder
@@ -361,7 +361,7 @@ Overlay_Drive::Overlay_Drive(const char *startdir,
 void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname ) 
 {
 	dirname[0] = 0;//ensure good return string
-	if (strlen(overlaydir) >= strlen(basedir) ) {
+	if (safe_strlen(overlaydir) >= safe_strlen(basedir) ) {
 		//Needs to be longer at least.
 #if defined (WIN32)
 		if (strncasecmp(overlaydir,basedir,strlen(basedir)) == 0) {
@@ -370,7 +370,7 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 #endif
 			//Beginning is the same.
 			char t[CROSS_LEN];
-			safe_strcpy(t, overlaydir + strlen(basedir));
+			safe_strcpy(t, overlaydir + safe_strlen(basedir));
 
 			char* p = t;
 			char* b = t;
@@ -597,11 +597,11 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 		char dir_name[CROSS_LEN];
 		bool is_directory;
 		if (read_directory_first(dirp, dir_name, is_directory)) {
-			if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(dir_name);
+			if ((safe_strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(dir_name);
 			else if (is_directory) dirnames.push_back(dir_name);
 			else filenames.push_back(dir_name);
 			while (read_directory_next(dirp, dir_name, is_directory)) {
-				if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(dir_name);
+				if ((safe_strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(dir_name);
 				else if (is_directory) dirnames.push_back(dir_name);
 				else filenames.push_back(dir_name);
 			}
@@ -647,11 +647,11 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 			char dir_name[CROSS_LEN];
 			bool is_directory; 
 			if (read_directory_first(dirp, dir_name, is_directory)) {
-				if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(string(dirpush)+dir_name);
+				if ((safe_strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(string(dirpush)+dir_name);
 				else if (is_directory) dirnames.push_back(string(dirpush)+dir_name);
 				else filenames.push_back(string(dirpush)+dir_name);
 				while (read_directory_next(dirp, dir_name, is_directory)) {
-					if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(string(dirpush)+dir_name);
+					if ((safe_strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(string(dirpush)+dir_name);
 					else if (is_directory) dirnames.push_back(string(dirpush)+dir_name);
 					else filenames.push_back(string(dirpush)+dir_name);
 				}
@@ -771,7 +771,7 @@ again:
 	safe_strcpy(relativename, srchInfo[id].srch_dir);
 	//strip off basedir: //TODO cleanup
 	safe_strcpy(ovname, overlaydir);
-	char* prel = full_name + strlen(basedir);
+	char* prel = full_name + safe_strlen(basedir);
 
 	
 
@@ -812,7 +812,7 @@ again:
 	/* file is okay, setup everything to be copied in DTA Block */
 	char find_name[DOS_NAMELENGTH_ASCII];Bit16u find_date,find_time;Bit32u find_size;
 
-	if(strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII){
+	if(safe_strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII){
 		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	} 

--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -61,7 +61,7 @@ void LOADFIX::Run(void)
 			args[0] = 0;
 			bool found = cmd->FindCommand(commandNr++,temp_line);
 			while (found) {
-				if (strlen(args)+temp_line.length()+1>256) break;
+				if (safe_strlen(args)+temp_line.length()+1>256) break;
 				safe_strcat(args, temp_line.c_str());
 				found = cmd->FindCommand(commandNr++,temp_line);
 				if (found)

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -59,7 +59,7 @@ void NE2K_Init(Section* sec);
 #endif
 
 Config * control;
-bool exit_requested = false;
+bool shutdown_requested = false;
 MachineType machine;
 SVGACards svgaCard;
 
@@ -330,7 +330,7 @@ void DOSBOX_SetNormalLoop() {
 
 void DOSBOX_RunMachine()
 {
-	while ((*loop)() == 0 && !exit_requested)
+	while ((*loop)() == 0 && !shutdown_requested)
 		;
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -533,8 +533,8 @@ static void SetIcon()
 
 static void RequestExit(bool pressed)
 {
-	exit_requested = pressed;
-	if (exit_requested)
+	shutdown_requested = pressed;
+	if (shutdown_requested)
 		DEBUG_LOG_MSG("SDL: Exit requested");
 }
 
@@ -3060,7 +3060,7 @@ bool GFX_Events()
 		default: MAPPER_CheckEvent(&event);
 		}
 	}
-	return !exit_requested;
+	return !shutdown_requested;
 }
 
 #if defined (WIN32)

--- a/src/hardware/serialport/libserial.cpp
+++ b/src/hardware/serialport/libserial.cpp
@@ -25,6 +25,8 @@
 #include <windows.h>
 #include <stdio.h>
 
+#include "string_utils.h"
+
 struct _COMPORT {
 	HANDLE porthandle;
 	bool breakstatus;
@@ -153,11 +155,11 @@ void SERIAL_getErrorString(char* buffer, size_t length) {
 	
 	// Go for length > so there will be bytes left afterwards.
 	// (which are 0 due to memset, thus the buffer is 0 terminated
-	if ( length > (sysmsg_offset + strlen((const char*)sysmessagebuffer)) ) {
+	if (length > (sysmsg_offset + strlen((const char *)sysmessagebuffer))) {
 		memcpy(buffer + sysmsg_offset, sysmessagebuffer,
-		       strlen((const char*)sysmessagebuffer));
+		       strlen((const char *)sysmessagebuffer));
 	}
-		
+
 	LocalFree(sysmessagebuffer);
 }
 
@@ -258,7 +260,7 @@ bool SERIAL_setCommParameters(COMPORT port,
 
 #if defined (LINUX) || defined (MACOSX) || defined (BSD)
 
-#include <string.h> // strlen
+#include <string.h> // safe_strlen
 #include <stdlib.h>
 
 #include <termios.h>

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -29,6 +29,7 @@
 #include "setup.h"
 #include "bios.h"					// SetComPorts(..)
 #include "callback.h"				// CALLBACK_Idle
+#include "string_utils.h"
 
 #include "serialport.h"
 #include "directserial.h"
@@ -192,7 +193,7 @@ void CSerial::log_ser(bool active, char const* format,...) {
 		vsprintf(buf+strlen(buf),format,msg);
 		va_end(msg);
 		// Add newline if not present
-		const uint32_t len = strlen(buf);
+		const uint32_t len = safe_strlen(buf);
 		if(buf[len-1]!='\n') strcat(buf,"\r\n");
 		fputs(buf,debugfp);
 	}

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -36,6 +36,7 @@
 #include "programs.h"
 #include "support.h"
 #include "../ints/int10.h"
+#include "string_utils.h"
 
 
 static constexpr int FRAMES_PER_BUFFER = 512; // synth granularity
@@ -507,7 +508,7 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program *caller)
 			if (is_directory)
 				continue;
 
-			const size_t name_len = strlen(dir_entry_name);
+			const size_t name_len = safe_strlen(dir_entry_name);
 			if (name_len < 4)
 				continue;
 			const char *ext = dir_entry_name + name_len - 4;

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -133,7 +133,7 @@ static void W32_ConfDir(std::string& in,bool create) {
 		if(!windir) windir = "c:\\windows";
 		safe_strcpy(result, windir);
 		char const* appdata = "\\Application Data";
-		size_t len = strlen(result);
+		size_t len = safe_strlen(result);
 		if (len + strlen(appdata) < MAX_PATH)
 			safe_strcat(result, appdata);
 		if (create)
@@ -326,7 +326,7 @@ bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_direc
 	static char split[2] = { CROSS_FILESPLIT , 0 };
 	buffer[0] = 0;
 	safe_strcpy(buffer, dirp->base_path);
-	size_t buflen = strlen(buffer);
+	size_t buflen = safe_strlen(buffer);
 	if (buflen && buffer[buflen - 1] != CROSS_FILESPLIT)
 		safe_strcat(buffer, split);
 	safe_strcat(buffer, entry_name);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -37,6 +37,7 @@
 #include "shell.h"
 #include "hardware.h"
 #include "mapper.h"
+#include "string_utils.h"
 
 Bitu call_program;
 
@@ -242,7 +243,7 @@ bool Program::GetEnvStr(const char *entry, std::string &result) const
 	do 	{
 		MEM_StrCopy(env_read,env_string,1024);
 		if (!env_string[0]) return false;
-		env_read += (PhysPt)(strlen(env_string)+1);
+		env_read += (PhysPt)(safe_strlen(env_string)+1);
 		char* equal = strchr(env_string,'=');
 		if (!equal) continue;
 		/* replace the = with \0 to get the length */
@@ -265,7 +266,7 @@ bool Program::GetEnvNum(Bitu num, std::string &result) const
 		MEM_StrCopy(env_read,env_string,1024);
 		if (!env_string[0]) break;
 		if (!num) { result=env_string;return true;}
-		env_read += (PhysPt)(strlen(env_string)+1);
+		env_read += (PhysPt)(safe_strlen(env_string)+1);
 		num--;
 	} while (1);
 	return false;
@@ -297,12 +298,12 @@ bool Program::SetEnv(const char * entry,const char * new_string) {
 	do 	{
 		MEM_StrCopy(env_read,env_string,1024);
 		if (!env_string[0]) break;
-		env_read += (PhysPt)(strlen(env_string)+1);
+		env_read += (PhysPt)(safe_strlen(env_string)+1);
 		if (!strchr(env_string,'=')) continue;		/* Remove corrupt entry? */
 		if ((strncasecmp(entry,env_string,strlen(entry))==0) && 
 			env_string[strlen(entry)]=='=') continue;
-		MEM_BlockWrite(env_write,env_string,(Bitu)(strlen(env_string)+1));
-		env_write += (PhysPt)(strlen(env_string)+1);
+		MEM_BlockWrite(env_write,env_string,(Bitu)(safe_strlen(env_string)+1));
+		env_write += (PhysPt)(safe_strlen(env_string)+1);
 	} while (1);
 /* TODO Maybe save the program name sometime. not really needed though */
 	/* Save the new entry */
@@ -314,8 +315,8 @@ bool Program::SetEnv(const char * entry,const char * new_string) {
 		std::string bigentry(entry);
 		for (std::string::iterator it = bigentry.begin(); it != bigentry.end(); ++it) *it = toupper(*it);
 		snprintf(env_string,1024+1,"%s=%s",bigentry.c_str(),new_string);
-		MEM_BlockWrite(env_write,env_string,(Bitu)(strlen(env_string)+1));
-		env_write += (PhysPt)(strlen(env_string)+1);
+		MEM_BlockWrite(env_write,env_string,(Bitu)(safe_strlen(env_string)+1));
+		env_write += (PhysPt)(safe_strlen(env_string)+1);
 	}
 	/* Clear out the final piece of the environment */
 	mem_writeb(env_write,0);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -153,7 +153,7 @@ bool Program::SuppressWriteOut(const char *format)
 	static bool encountered_executable = false;
 	if (encountered_executable)
 		return false;
-	if (control->GetStartupVerbosity() <= Verbosity::SplashOnly)
+	if (control->GetStartupVerbosity() >= Verbosity::SplashOnly)
 		return false;
 	if (!control->cmdline->HasExecutableName())
 		return false;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -116,7 +116,7 @@ void AutoexecObject::CreateAutoexec()
 			offset = n + 2;
 		}
 
-		auto_len = strlen(autoexec_data);
+		auto_len = safe_strlen(autoexec_data);
 		if ((auto_len+linecopy.length() + 3) > AUTOEXEC_SIZE) {
 			E_Exit("SYSTEM:Autoexec.bat file overflow");
 		}
@@ -513,7 +513,7 @@ public:
 					line = buffer;
 					if (getcwd(buffer, CROSS_LEN) == NULL)
 						continue;
-					if (strlen(buffer) + line.length() + 1 > CROSS_LEN)
+					if (safe_strlen(buffer) + line.length() + 1 > CROSS_LEN)
 						continue;
 					safe_strcat(buffer, cross_filesplit);
 					safe_strcat(buffer, line.c_str());
@@ -605,7 +605,7 @@ static Bitu INT2E_Handler()
 	if (crlf) *crlf=0;
 
 	/* Execute command */
-	if (strlen(tail.buffer)) {
+	if (safe_strlen(tail.buffer)) {
 		DOS_Shell temp;
 		temp.ParseLine(tail.buffer);
 		temp.RunInternal();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -468,8 +468,15 @@ public:
 			autoexec[i++].Install(line);
 		}
 
-		/* Check for the -exit switch which causes dosbox to when the command on the commandline has finished */
-		bool addexit = control->cmdline->FindExist("-exit",true);
+		// Check for the -exit switch, which indicates they want to quit after the command has finished
+		const bool requested_exit_after_command = control->cmdline->FindExist("-exit", true);
+
+		// Check if instant-launch is active
+		const bool using_instant_launch = control->cmdline->HasExecutableName() &&
+		                                  control->GetStartupVerbosity() <= Verbosity::Low;
+
+		// Should we add an 'exit' call to the end of autoexec.bat?
+		const bool addexit = requested_exit_after_command || using_instant_launch;
 
 		/* Check for first command being a directory or file */
 		char buffer[CROSS_LEN + 1];
@@ -731,6 +738,7 @@ void SHELL_Init() {
 	        "               E  By extension (alphabetic)  D  By date & time (oldest first)\n");
 	MSG_Add("SHELL_CMD_ECHO_HELP","Display messages and enable/disable command echoing.\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP","Exit from the shell.\n");
+	MSG_Add("SHELL_CMD_EXIT_TOO_SOON", "Preventing an early 'exit' call from terminating.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP","Show help.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP_LONG","HELP [command]\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP","Make Directory.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -314,7 +314,7 @@ void DOS_Shell::ParseLine(char * line) {
 void DOS_Shell::RunInternal()
 {
 	char input_line[CMD_MAXLINE] = {0};
-	while (bf && !exit_requested) {
+	while (bf && !shutdown_requested) {
 		if (bf->ReadLine(input_line)) {
 			if (echo) {
 				if (input_line[0] != '@') {
@@ -395,7 +395,7 @@ void DOS_Shell::Run()
 			InputCommand(input_line);
 			ParseLine(input_line);
 		}
-	} while (!exit_requested);
+	} while (!exit_cmd_called && !shutdown_requested);
 }
 
 void DOS_Shell::SyntaxError()

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -567,6 +567,11 @@ public:
 		if ( !command_found ) {
 			if ( secure ) autoexec[12].Install("z:\\config.com -securemode");
 		}
+
+		// Print the entire autoexec content, if needed:
+		// for (const auto &autoexec_line : autoexec)
+		// 	LOG_INFO("AUTOEXEC-LINE: %s", autoexec_line.GetLine().c_str());
+
 		VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data));
 	}
 };

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -494,7 +494,7 @@ public:
 			if (stat(buffer, &test)) {
 				if (getcwd(buffer, CROSS_LEN) == NULL)
 					continue;
-				if (strlen(buffer) + line.length() + 1 > CROSS_LEN)
+				if (safe_strlen(buffer) + line.length() + 1 > CROSS_LEN)
 					continue;
 				safe_strcat(buffer, cross_filesplit);
 				safe_strcat(buffer, line.c_str());

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -989,7 +989,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 			if (plus) *plus++ = 0;
 			safe_strcpy(source_x, source_p);
 			bool has_drive_spec = false;
-			size_t source_x_len = strlen(source_x);
+			size_t source_x_len = safe_strlen(source_x);
 			if (source_x_len>0) {
 				if (source_x[source_x_len-1] == ':') has_drive_spec = true;
 			}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -41,6 +41,7 @@
 #include "regs.h"
 #include "string_utils.h"
 #include "support.h"
+#include "timer.h"
 #include "../ints/int10.h"
 
 // clang-format off
@@ -352,10 +353,16 @@ void DOS_Shell::CMD_ECHO(char * args){
 	} else WriteOut("%s\r\n",args);
 }
 
+static int64_t ticks_at_program_launch = GetTicks();
 void DOS_Shell::CMD_EXIT(char *args)
 {
 	HELP("EXIT");
-	exit_requested = true;
+	if (GetTicksSince(ticks_at_program_launch) <= 1500) {
+		WriteOut(MSG_Get("SHELL_CMD_EXIT_TOO_SOON"));
+		LOG_WARNING("SHELL: Caught a very early 'exit' attempt, which means something might have failed.");
+	} else {
+		exit_requested = true;
+	}
 }
 
 void DOS_Shell::CMD_CHDIR(char * args) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -361,7 +361,7 @@ void DOS_Shell::CMD_EXIT(char *args)
 		WriteOut(MSG_Get("SHELL_CMD_EXIT_TOO_SOON"));
 		LOG_WARNING("SHELL: Caught a very early 'exit' attempt, which means something might have failed.");
 	} else {
-		exit_requested = true;
+		exit_cmd_called = true;
 	}
 }
 
@@ -1598,7 +1598,7 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	Bit16u n=1;
 	do {
 		DOS_ReadFile(STDIN, &c, &n);
-		if (exit_requested)
+		if (shutdown_requested)
 			break;
 	} while (!c || !(ptr = strchr(rem, (optS ? c : toupper(c)))));
 	c = optS ? c : (Bit8u)toupper(c);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -471,7 +471,7 @@ bool DOS_Shell::Execute(char * name,char * args) {
 	const char *extension = strrchr(fullname, '.');
 	if (!extension) {
 		// Check if the result will fit in the parameters.
-		if (strlen(fullname) > (DOS_PATHLENGTH - 1))
+		if (safe_strlen(fullname) > (DOS_PATHLENGTH - 1))
 			return false;
 
 		// Try to add .COM, .EXE and .BAT extensions to the filename
@@ -513,7 +513,8 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		block.Clear();
 		//Add a filename
 		RealPt file_name=RealMakeSeg(ss,reg_sp+0x20);
-		MEM_BlockWrite(Real2Phys(file_name),fullname,(Bitu)(strlen(fullname)+1));
+		MEM_BlockWrite(Real2Phys(file_name), fullname,
+		               (Bitu)(safe_strlen(fullname) + 1));
 
 		/* HACK: Store full commandline for mount and imgmount */
 		full_arguments.assign(line);
@@ -522,7 +523,8 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		CommandTail cmdtail;
 		cmdtail.count = 0;
 		memset(&cmdtail.buffer,0,127); //Else some part of the string is unitialized (valgrind)
-		if (strlen(line)>126) line[126]=0;
+		if (safe_strlen(line) > 126)
+			line[126] = 0;
 		cmdtail.count=(Bit8u)strlen(line);
 		memcpy(cmdtail.buffer,line,strlen(line));
 		cmdtail.buffer[strlen(line)]=0xd;
@@ -651,7 +653,7 @@ const char *DOS_Shell::Which(const char *name) const
 
 
 		/* check entry */
-		if(size_t len = strlen(path)){
+		if (size_t len = safe_strlen(path)) {
 			if(len >= (DOS_PATHLENGTH - 2)) continue;
 
 			if(path[len - 1] != '\\') {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -63,7 +63,7 @@ void DOS_Shell::InputCommand(char * line) {
 
 	std::list<std::string>::iterator it_history = l_history.begin(), it_completion = l_completion.begin();
 
-	while (size && !exit_requested) {
+	while (size && !shutdown_requested) {
 		dos.echo=false;
 		while(!DOS_ReadFile(input_handle,&c,&n)) {
 			Bit16u dummy;


### PR DESCRIPTION
If `startup_verbosity` is `auto` (or `low` or `quiet`) and an executable's passed on the command-line, then automatically "exit" when that program finishes up. This is equivalent to manually adding the `-exit` command-line flag.

This PR also updates the `README` to reflect this logic.

This PR also adds a 1.5 second "exit cool down period" as some protection against scenarios where an executable immediately fails *and* dosbox quits back to the host.  In these cases, the the user sees a brief flash - and then everything is gone, which is a bad user experience leaving them with nothing to help them diagnose the issue.  

This cool down should catch most of those scenarios.  Of course, using a higher verbosity (medium or high) will fully prevent auto-exit, likewise simply launch dosbox without instant-launch will also avoid the auto-exit. 