### PR TITLE
Render resolution restriction and window improvements

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -456,15 +456,14 @@ void DOSBOX_Init(void) {
 	                          "vesa_oldvbe",   0};
 
 	secprop = control->AddSection_prop("dosbox", &DOSBOX_RealInit);
-	pstring = secprop->Add_path("language", Property::Changeable::Always, "");
+	pstring = secprop->Add_path("language", always, "");
 	pstring->Set_help("Select another language file.");
 
-	pstring = secprop->Add_string("machine", Property::Changeable::OnlyAtStart,
-	                              "svga_s3");
+	pstring = secprop->Add_string("machine", only_at_start, "svga_s3");
 	pstring->Set_values(machines);
 	pstring->Set_help("The type of machine DOSBox tries to emulate.");
-	pstring = secprop->Add_path("captures", Property::Changeable::Always,
-	                            "capture");
+
+	pstring = secprop->Add_path("captures", always, "capture");
 	pstring->Set_help(
 	        "Directory where things like wave, midi, screenshot get captured.");
 
@@ -476,7 +475,7 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&PAGING_Init);//done
 	secprop->AddInitFunction(&MEM_Init);//done
 	secprop->AddInitFunction(&HARDWARE_Init);//done
-	pint = secprop->Add_int("memsize", Property::Changeable::WhenIdle, 16);
+	pint = secprop->Add_int("memsize", when_idle, 16);
 	pint->SetMinMax(1, 63);
 	pint->Set_help(
 	        "Amount of memory DOSBox has in megabytes.\n"
@@ -527,11 +526,11 @@ void DOSBOX_Init(void) {
 	        "auto        | 'low' if exec or dir is passed, otherwise 'high'");
 
 	secprop = control->AddSection_prop("render", &RENDER_Init, true);
-	pint = secprop->Add_int("frameskip", Property::Changeable::Always, 0);
+	pint = secprop->Add_int("frameskip", always, 0);
 	pint->SetMinMax(0, 10);
 	pint->Set_help("How many frames DOSBox skips before drawing one.");
 
-	Pbool = secprop->Add_bool("aspect", Property::Changeable::Always, true);
+	Pbool = secprop->Add_bool("aspect", always, true);
 	Pbool->Set_help("Scales the vertical resolution to produce a 4:3 display aspect\n"
 	                "ratio, matching that of the original standard-definition monitors\n"
 	                "for which the majority of DOS games were designed. This setting\n"
@@ -601,18 +600,18 @@ void DOSBOX_Init(void) {
 		"dynamic",
 #endif
 		"normal", "simple",0 };
-	Pstring = secprop->Add_string("core",Property::Changeable::WhenIdle,"auto");
+	Pstring = secprop->Add_string("core", when_idle, "auto");
 	Pstring->Set_values(cores);
 	Pstring->Set_help("CPU Core used in emulation. auto will switch to dynamic if available and\n"
 		"appropriate.");
 
 	const char* cputype_values[] = { "auto", "386", "386_slow", "486_slow", "pentium_slow", "386_prefetch", 0};
-	Pstring = secprop->Add_string("cputype",Property::Changeable::Always,"auto");
+	Pstring = secprop->Add_string("cputype", always, "auto");
 	Pstring->Set_values(cputype_values);
 	Pstring->Set_help("CPU Type used in emulation. auto is the fastest choice.");
 
 
-	Pmulti_remain = secprop->Add_multiremain("cycles",Property::Changeable::Always," ");
+	Pmulti_remain = secprop->Add_multiremain("cycles", always, " ");
 	Pmulti_remain->Set_help(
 		"Number of instructions DOSBox tries to emulate each millisecond.\n"
 		"Setting this value too high results in sound dropouts and lags.\n"
@@ -625,18 +624,18 @@ void DOSBOX_Init(void) {
 		"                  handle.");
 
 	const char* cyclest[] = { "auto","fixed","max","%u",0 };
-	Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::Always,"auto");
+	Pstring = Pmulti_remain->GetSection()->Add_string("type", always, "auto");
 	Pmulti_remain->SetValue("auto");
 	Pstring->Set_values(cyclest);
 
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::Always,"");
+	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", always, "");
 
-	Pint = secprop->Add_int("cycleup",Property::Changeable::Always,10);
+	Pint = secprop->Add_int("cycleup", always, 10);
 	Pint->SetMinMax(1,1000000);
 	Pint->Set_help("Number of cycles added or subtracted with speed control hotkeys.\n"
 	               "Run INTRO and see Special Keys for list of hotkeys.");
 
-	Pint = secprop->Add_int("cycledown",Property::Changeable::Always,20);
+	Pint = secprop->Add_int("cycledown", always, 20);
 	Pint->SetMinMax(1,1000000);
 	Pint->Set_help("Setting it lower than 100 will be a percentage.");
 
@@ -654,7 +653,7 @@ void DOSBOX_Init(void) {
 
 
 	secprop=control->AddSection_prop("mixer",&MIXER_Init);
-	Pbool = secprop->Add_bool("nosound",Property::Changeable::OnlyAtStart,false);
+	Pbool = secprop->Add_bool("nosound", only_at_start, false);
 	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
 
 	Pint = secprop->Add_int("rate", only_at_start, 48000);
@@ -763,30 +762,30 @@ void DOSBOX_Init(void) {
 	secprop = control->AddSection_prop("sblaster", &SBLASTER_Init, true);
 
 	const char* sbtypes[] = {"sb1", "sb2", "sbpro1", "sbpro2", "sb16", "gb", "none", 0};
-	Pstring = secprop->Add_string("sbtype", Property::Changeable::WhenIdle, "sb16");
+	Pstring = secprop->Add_string("sbtype", when_idle, "sb16");
 	Pstring->Set_values(sbtypes);
 	Pstring->Set_help("Type of Sound Blaster to emulate. 'gb' is Game Blaster.");
 
 	const char *ios[] = {"220", "240", "260", "280", "2a0", "2c0", "2e0", "300", 0};
-	Phex = secprop->Add_hex("sbbase", Property::Changeable::WhenIdle, 0x220);
+	Phex = secprop->Add_hex("sbbase", when_idle, 0x220);
 	Phex->Set_values(ios);
 	Phex->Set_help("The IO address of the Sound Blaster.");
 
 	const char *irqssb[] = {"7", "5", "3", "9", "10", "11", "12", 0};
-	Pint = secprop->Add_int("irq", Property::Changeable::WhenIdle, 7);
+	Pint = secprop->Add_int("irq", when_idle, 7);
 	Pint->Set_values(irqssb);
 	Pint->Set_help("The IRQ number of the Sound Blaster.");
 
 	const char *dmassb[] = {"1", "5", "0", "3", "6", "7", 0};
-	Pint = secprop->Add_int("dma", Property::Changeable::WhenIdle, 1);
+	Pint = secprop->Add_int("dma", when_idle, 1);
 	Pint->Set_values(dmassb);
 	Pint->Set_help("The DMA number of the Sound Blaster.");
 
-	Pint = secprop->Add_int("hdma", Property::Changeable::WhenIdle, 5);
+	Pint = secprop->Add_int("hdma", when_idle, 5);
 	Pint->Set_values(dmassb);
 	Pint->Set_help("The High DMA number of the Sound Blaster.");
 
-	Pbool = secprop->Add_bool("sbmixer", Property::Changeable::WhenIdle, true);
+	Pbool = secprop->Add_bool("sbmixer", when_idle, true);
 	Pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer.");
 
 	pint = secprop->Add_int("oplrate", deprecated, false);
@@ -794,13 +793,13 @@ void DOSBOX_Init(void) {
 	               "        at the mixer's playback rate to avoid resampling.");
 
 	const char* oplmodes[] = {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", 0};
-	Pstring = secprop->Add_string("oplmode", Property::Changeable::WhenIdle, "auto");
+	Pstring = secprop->Add_string("oplmode", when_idle, "auto");
 	Pstring->Set_values(oplmodes);
 	Pstring->Set_help("Type of OPL emulation. On 'auto' the mode is determined by 'sbtype'.\n"
 	                  "All OPL modes are AdLib-compatible, except for 'cms'.");
 
 	const char* oplemus[] = {"default", "compat", "fast", "mame", "nuked", 0};
-	Pstring = secprop->Add_string("oplemu", Property::Changeable::WhenIdle, "default");
+	Pstring = secprop->Add_string("oplemu", when_idle, "default");
 	Pstring->Set_values(oplemus);
 	Pstring->Set_help(
 	        "Provider for the OPL emulation. 'compat' provides better quality,\n"
@@ -813,7 +812,7 @@ void DOSBOX_Init(void) {
 	INNOVATION_AddConfigSection(control);
 
 	secprop = control->AddSection_prop("speaker",&PCSPEAKER_Init,true);//done
-	Pbool = secprop->Add_bool("pcspeaker",Property::Changeable::WhenIdle,true);
+	Pbool = secprop->Add_bool("pcspeaker", when_idle, true);
 	Pbool->Set_help("Enable PC-Speaker emulation.");
 
 	// Basis for the default PC-Speaker sample generation rate:
@@ -845,13 +844,13 @@ void DOSBOX_Init(void) {
 	Pstring->Set_values(tandys);
 	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
 
-	Pint = secprop->Add_int("tandyrate", Property::Changeable::WhenIdle, 44100);
+	Pint = secprop->Add_int("tandyrate", when_idle, 44100);
 	Pint->Set_values(rates);
 	Pint->Set_help("Sample rate of the Tandy 3-Voice generation.");
 
 	secprop->AddInitFunction(&DISNEY_Init,true);//done
 
-	Pbool = secprop->Add_bool("disney",Property::Changeable::WhenIdle,true);
+	Pbool = secprop->Add_bool("disney", when_idle, true);
 	Pbool->Set_help("Enable Disney Sound Source emulation. (Covox Voice Master and Speech Thing compatible).");
 
 	// IBM PS/1 Audio emulation
@@ -865,8 +864,7 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&JOYSTICK_Init,true);
 	const char *joytypes[] = {"auto", "2axis", "4axis",    "4axis_2", "fcs",
 	                          "ch",   "none",  "disabled", 0};
-	Pstring = secprop->Add_string("joysticktype",
-	                              Property::Changeable::WhenIdle, "auto");
+	Pstring = secprop->Add_string("joysticktype", when_idle, "auto");
 	Pstring->Set_values(joytypes);
 	Pstring->Set_help(
 	        "Type of joystick to emulate: auto (default),\n"
@@ -880,23 +878,23 @@ void DOSBOX_Init(void) {
 	        "disabled: Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
 	        "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
 
-	Pbool = secprop->Add_bool("timed",Property::Changeable::WhenIdle,true);
+	Pbool = secprop->Add_bool("timed", when_idle, true);
 	Pbool->Set_help("enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).");
 
-	Pbool = secprop->Add_bool("autofire",Property::Changeable::WhenIdle,false);
+	Pbool = secprop->Add_bool("autofire", when_idle, false);
 	Pbool->Set_help("continuously fires as long as you keep the button pressed.");
 
-	Pbool = secprop->Add_bool("swap34",Property::Changeable::WhenIdle,false);
+	Pbool = secprop->Add_bool("swap34", when_idle, false);
 	Pbool->Set_help("swap the 3rd and the 4th axis. Can be useful for certain joysticks.");
 
-	Pbool = secprop->Add_bool("buttonwrap",Property::Changeable::WhenIdle,false);
+	Pbool = secprop->Add_bool("buttonwrap", when_idle, false);
 	Pbool->Set_help("enable button wrapping at the number of emulated buttons.");
 
-	Pbool = secprop->Add_bool("circularinput",Property::Changeable::WhenIdle,false);
+	Pbool = secprop->Add_bool("circularinput", when_idle, false);
 	Pbool->Set_help("enable translation of circular input to square output.\n"
 	                "Try enabling this if your left analog stick can only move in a circle.");
 
-	Pint = secprop->Add_int("deadzone",Property::Changeable::WhenIdle,10);
+	Pint = secprop->Add_int("deadzone", when_idle, 10);
 	Pint->SetMinMax(0,100);
 	Pint->Set_help("the percentage of motion to ignore. 100 turns the stick into a digital one.");
 
@@ -904,11 +902,11 @@ void DOSBOX_Init(void) {
 	const char* serials[] = { "dummy", "disabled", "modem", "nullmodem",
 	                          "directserial",0 };
 
-	Pmulti_remain = secprop->Add_multiremain("serial1",Property::Changeable::WhenIdle," ");
-	Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"dummy");
+	Pmulti_remain = secprop->Add_multiremain("serial1", when_idle, " ");
+	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
 	Pmulti_remain->SetValue("dummy");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help(
 		"set type of device connected to com port.\n"
 		"Can be disabled, dummy, modem, nullmodem, directserial.\n"
@@ -921,25 +919,25 @@ void DOSBOX_Init(void) {
 		"               transparent, port, inhsocket (all optional).\n"
 		"Example: serial1=modem listenport:5000");
 
-	Pmulti_remain = secprop->Add_multiremain("serial2",Property::Changeable::WhenIdle," ");
-	Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"dummy");
+	Pmulti_remain = secprop->Add_multiremain("serial2", when_idle, " ");
+	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
 	Pmulti_remain->SetValue("dummy");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help("see serial1");
 
-	Pmulti_remain = secprop->Add_multiremain("serial3",Property::Changeable::WhenIdle," ");
-	Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"disabled");
+	Pmulti_remain = secprop->Add_multiremain("serial3", when_idle, " ");
+	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	Pmulti_remain->SetValue("disabled");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help("see serial1");
 
-	Pmulti_remain = secprop->Add_multiremain("serial4",Property::Changeable::WhenIdle," ");
-	Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"disabled");
+	Pmulti_remain = secprop->Add_multiremain("serial4", when_idle, " ");
+	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	Pmulti_remain->SetValue("disabled");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help("see serial1");
 
 	pstring = secprop->Add_path("phonebookfile", only_at_start, "phonebook.txt");
@@ -948,19 +946,19 @@ void DOSBOX_Init(void) {
 	/* All the DOS Related stuff, which will eventually start up in the shell */
 	secprop=control->AddSection_prop("dos",&DOS_Init,false);//done
 	secprop->AddInitFunction(&XMS_Init,true);//done
-	Pbool = secprop->Add_bool("xms",Property::Changeable::WhenIdle,true);
+	Pbool = secprop->Add_bool("xms", when_idle, true);
 	Pbool->Set_help("Enable XMS support.");
 
 	secprop->AddInitFunction(&EMS_Init,true);//done
 	const char* ems_settings[] = { "true", "emsboard", "emm386", "false", 0};
-	Pstring = secprop->Add_string("ems",Property::Changeable::WhenIdle,"true");
+	Pstring = secprop->Add_string("ems", when_idle, "true");
 	Pstring->Set_values(ems_settings);
 	Pstring->Set_help("Enable EMS support. The default (=true) provides the best\n"
 		"compatibility but certain applications may run better with\n"
 		"other choices, or require EMS support to be disabled (=false)\n"
 		"to work at all.");
 
-	Pbool = secprop->Add_bool("umb",Property::Changeable::WhenIdle,true);
+	Pbool = secprop->Add_bool("umb", when_idle, true);
 	Pbool->Set_help("Enable UMB support.");
 
 	pstring = secprop->Add_string("ver", when_idle, "5.0");
@@ -969,7 +967,7 @@ void DOSBOX_Init(void) {
 	                  "Common settings are 3.3, 5.0, 6.22, and 7.1.");
 
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init,true);
-	Pstring = secprop->Add_string("keyboardlayout",Property::Changeable::WhenIdle, "auto");
+	Pstring = secprop->Add_string("keyboardlayout", when_idle,  "auto");
 	Pstring->Set_help("Language code of the keyboard layout (or none).");
 
 	// Mscdex
@@ -978,7 +976,7 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&CDROM_Image_Init);
 #if C_IPX
 	secprop=control->AddSection_prop("ipx",&IPX_Init,true);
-	Pbool = secprop->Add_bool("ipx",Property::Changeable::WhenIdle, false);
+	Pbool = secprop->Add_bool("ipx", when_idle,  false);
 	Pbool->Set_help("Enable ipx over UDP/IP emulation.");
 #endif
 
@@ -997,23 +995,23 @@ void DOSBOX_Init(void) {
 
 	);
 
-	Pbool = secprop->Add_bool("ne2000", Property::Changeable::WhenIdle, true);
+	Pbool = secprop->Add_bool("ne2000", when_idle,  true);
 	Pbool->Set_help("Enable Ethernet passthrough. Requires [Win]Pcap.");
 
-	Phex = secprop->Add_hex("nicbase", Property::Changeable::WhenIdle, 0x300);
+	Phex = secprop->Add_hex("nicbase", when_idle,  0x300);
 	Phex->Set_help("The base address of the NE2000 board.");
 
-	Pint = secprop->Add_int("nicirq", Property::Changeable::WhenIdle, 3);
+	Pint = secprop->Add_int("nicirq", when_idle,  3);
 	Pint->Set_help("The interrupt it uses. Note serial2 uses IRQ3 as default.");
 
-	Pstring = secprop->Add_string("macaddr", Property::Changeable::WhenIdle,"AC:DE:48:88:99:AA");
+	Pstring = secprop->Add_string("macaddr", when_idle, "AC:DE:48:88:99:AA");
 	Pstring->Set_help("The physical address the emulator will use on your network.\n"
 		"If you have multiple DOSBoxes running on your network,\n"
 		"this has to be changed for each. AC:DE:48 is an address range reserved for\n"
 		"private use, so modify the last three number blocks.\n"
 		"I.e. AC:DE:48:88:99:AB.");
 
-	Pstring = secprop->Add_string("realnic", Property::Changeable::WhenIdle,"list");
+	Pstring = secprop->Add_string("realnic", when_idle, "list");
 	Pstring->Set_help("Specifies which of your network interfaces is used.\n"
 		"Write \'list\' here to see the list of devices in the\n"
 		"Status Window. Then make your choice and put either the\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -584,6 +584,13 @@ void DOSBOX_Init(void) {
 	                  "scan2x, scan3x, tv2x, tv3x, sharp (default).");
 #endif
 
+	pstring = secprop->Add_path("maxresolution", always, "auto");
+	pstring->Set_help(
+	        "Optionally restricts the viewport resolution within the window/screen:\n"
+	        "  auto:      The viewport fills the window/screen (default).\n"
+	        "  <custom>:  Set max viewport resolution in W,H format.\n"
+	        "             For example: 960,720");
+
 	// Add the [composite] conf block after [render]
 	assert(control);
 	VGA_AddCompositeSettings(*control);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -283,6 +283,7 @@ struct SDL_Block {
 			uint16_t width = 0; // TODO convert to int
 			uint16_t height = 0; // TODO convert to int
 			bool resizable = false;
+			bool show_decorations = true;
 		} window = {};
 		struct {
 			int width = 0;
@@ -773,6 +774,9 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 		if (screen_type == SCREEN_OPENGL)
 			flags |= SDL_WINDOW_OPENGL;
 #endif
+		if (!sdl.desktop.window.show_decorations) {
+			flags |= SDL_WINDOW_BORDERLESS;
+		}
 
 		// Using undefined position will take care of placing and
 		// restoring the window by WM.
@@ -2483,6 +2487,8 @@ static void GUI_StartUp(Section *sec)
 	        control->GetSection("render"));
 	assert(render_section);
 
+	sdl.desktop.window.show_decorations = section->Get_bool("windowdecorations");
+
 	setup_window_sizes_from_conf(section->Get_string("windowresolution"),
 	                             sdl.scaling_mode,
 	                             render_section->Get_bool("aspect"));
@@ -3149,6 +3155,9 @@ void Config_Add_SDL() {
 	        "  <custom>:  Scale the window to the given dimensions in\n"
 	        "             WxH format. For example: 1024x768.\n"
 	        "             Scaling is not performed for output=surface.");
+
+	Pbool = sdl_sec->Add_bool("windowdecorations", always, true);
+	Pbool->Set_help("Controls whether to display window decorations in windowed mode.");
 
 	Pbool = sdl_sec->Add_bool("vsync", on_start, false);
 	Pbool->Set_help(

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2056,19 +2056,6 @@ static void DisplaySplash(int time_ms)
 	Delay(time_ms);
 }
 
-/* For some preference values, we can safely remove comment after # character
- */
-static std::string NormalizeConfValue(const char *val)
-{
-	std::string pref = val;
-	const auto comment_pos = pref.find('#');
-	if (comment_pos != std::string::npos)
-		pref.erase(comment_pos);
-	trim(pref);
-	lowcase(pref);
-	return pref;
-}
-
 MAYBE_UNUSED static std::string get_glshader_value()
 {
 #if C_OPENGL
@@ -2391,9 +2378,9 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 
 	// Get the coarse resolution from the users setting, and adjust
 	// refined scaling mode if an exact resolution is desired.
+	const std::string pref = windowresolution_val;
 	SDL_Point coarse_size = FALLBACK_WINDOW_DIMENSIONS;
 
-	const std::string pref = NormalizeConfValue(windowresolution_val);
 	const auto window_resolution_specified = pref.find('x') != std::string::npos;
 	if (window_resolution_specified) {
 		coarse_size = window_bounds_from_resolution(pref, desktop);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -361,6 +361,8 @@ struct SDL_Block {
 	} mouse = {};
 	SDL_Point pp_scale = {1, 1};
 	SDL_Rect updateRects[1024];
+	bool restrict_resolution = false;
+	SDL_Point max_resolution = {-1, -1};
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
 	int64_t focus_ticks = 0;
@@ -372,6 +374,7 @@ struct SDL_Block {
 
 static SDL_Block sdl;
 
+static SDL_Point restrict_viewport_resolution(int width, int height);
 static SDL_Point calc_pp_scale(int width, int heigth);
 static SDL_Rect calc_viewport(int width, int height);
 
@@ -884,9 +887,7 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 {
 	assert(sdl.window);
 
-	int w = 0;
-	int h = 0;
-
+	int w, h;
 	if (sdl.desktop.fullscreen) {
 		SDL_GetWindowSize(sdl.window, &w, &h);
 	} else {
@@ -895,83 +896,84 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 	}
 	assert(w > 0 && h > 0);
 
-	sdl.pp_scale = calc_pp_scale(w, h);
+	const auto render_resolution = restrict_viewport_resolution(w, h);
 
-	const int imgw = sdl.pp_scale.x * sdl.draw.width;
-	const int imgh = sdl.pp_scale.y * sdl.draw.height;
+	sdl.pp_scale = calc_pp_scale(render_resolution.x, render_resolution.y);
 
-	const int wndw = (sdl.desktop.fullscreen ? w : imgw);
-	const int wndh = (sdl.desktop.fullscreen ? h : imgh);
+	const int img_width = sdl.pp_scale.x * sdl.draw.width;
+	const int img_height = sdl.pp_scale.y * sdl.draw.height;
 
-	sdl.clip.w = imgw;
-	sdl.clip.h = imgh;
-	sdl.clip.x = (wndw - imgw) / 2;
-	sdl.clip.y = (wndh - imgh) / 2;
+	int win_width, win_height;
+	if (sdl.restrict_resolution) {
+		win_width = w;
+		win_height = h;
+	} else {
+		win_width = (sdl.desktop.fullscreen ? w : img_width);
+		win_height = (sdl.desktop.fullscreen ? h : img_height);
+	}
 
-	sdl.window = SetWindowMode(screen_type, wndw, wndh,
+	sdl.clip.w = img_width;
+	sdl.clip.h = img_height;
+	sdl.clip.x = (win_width - img_width) / 2;
+	sdl.clip.y = (win_height - img_height) / 2;
+
+	sdl.window = SetWindowMode(screen_type, win_width, win_height,
 	                           sdl.desktop.fullscreen, resizable);
 	return sdl.window;
 }
+
+
+static SDL_Point restrict_viewport_resolution(int width, int height)
+{
+	int w, h;
+	if (sdl.restrict_resolution) {
+		w = std::min(width, sdl.max_resolution.x);
+		h = std::min(height, sdl.max_resolution.y);
+	} else {
+		w = width;
+		h = height;
+	}
+	return {w, h};
+}
+
+static SDL_Rect calc_viewport_fit(int win_width, int win_height);
 
 static SDL_Window *SetupWindowScaled(SCREEN_TYPES screen_type, bool resizable)
 {
 	if (sdl.scaling_mode == SCALING_MODE::PERFECT)
 		return setup_window_pp(screen_type, resizable);
 
-	Bit16u fixedWidth;
-	Bit16u fixedHeight;
-
+	int w, h;
 	if (sdl.desktop.fullscreen) {
-		fixedWidth = sdl.desktop.full.fixed ? sdl.desktop.full.width : 0;
-		fixedHeight = sdl.desktop.full.fixed ? sdl.desktop.full.height : 0;
+		w = sdl.desktop.full.fixed ? sdl.desktop.full.width : 0;
+		h = sdl.desktop.full.fixed ? sdl.desktop.full.height : 0;
 	} else {
-		fixedWidth = sdl.desktop.window.width;
-		fixedHeight = sdl.desktop.window.height;
+		w = sdl.desktop.window.width;
+		h = sdl.desktop.window.height;
 	}
 
-	if (fixedWidth && fixedHeight) {
-		double ratio_w=(double)fixedWidth/(sdl.draw.width*sdl.draw.scalex);
-		double ratio_h=(double)fixedHeight/(sdl.draw.height*sdl.draw.scaley);
-		if ( ratio_w < ratio_h) {
-			sdl.clip.w = fixedWidth;
-			sdl.clip.h = (Bit16u)(sdl.draw.height * sdl.draw.scaley*ratio_w + 0.1); //possible rounding issues
-		} else {
-			/*
-			 * The 0.4 is there to correct for rounding issues.
-			 * (partly caused by the rounding issues fix in RENDER_SetSize)
-			 */
-			sdl.clip.w=(Bit16u)(sdl.draw.width*sdl.draw.scalex*ratio_h + 0.4);
-			sdl.clip.h = fixedHeight;
-		}
+	if (w > 0 && h > 0) {
+		sdl.clip = calc_viewport_fit(w, h);
+		sdl.window = SetWindowMode(screen_type, w, h,
+		                           sdl.desktop.fullscreen, resizable);
 
-		if (sdl.desktop.fullscreen) {
-			sdl.window = SetWindowMode(screen_type, fixedWidth,
-			                           fixedHeight, sdl.desktop.fullscreen,
-			                           resizable);
-		} else {
-			sdl.window = SetWindowMode(screen_type, sdl.clip.w,
-			                           sdl.clip.h, sdl.desktop.fullscreen,
-			                           resizable);
+		const auto is_window_fullscreen = SDL_GetWindowFlags(sdl.window) &
+		                                  SDL_WINDOW_FULLSCREEN;
+		if (sdl.window && is_window_fullscreen) {
+			int win_width;
+			SDL_GetWindowSize(sdl.window, &win_width, NULL);
+			sdl.clip.x = (win_width - sdl.clip.w) / 2;
+			sdl.clip.y = (h - sdl.clip.h) / 2;
 		}
-
-		if (sdl.window && SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_FULLSCREEN) {
-			int windowWidth;
-			SDL_GetWindowSize(sdl.window, &windowWidth, NULL);
-			sdl.clip.x = (Sint16)((windowWidth - sdl.clip.w) / 2);
-			sdl.clip.y = (Sint16)((fixedHeight - sdl.clip.h) / 2);
-		} else {
-			sdl.clip.x = 0;
-			sdl.clip.y = 0;
-		}
-
 		return sdl.window;
 
 	} else {
-		sdl.clip.x = 0;
-		sdl.clip.y = 0;
-		sdl.clip.w = iround(sdl.draw.width * sdl.draw.scalex);
-		sdl.clip.h = iround(sdl.draw.height * sdl.draw.scaley);
-		sdl.window = SetWindowMode(screen_type, sdl.clip.w, sdl.clip.h,
+		const auto win_width = iround(sdl.draw.width * sdl.draw.scalex);
+		const auto win_height = iround(sdl.draw.height * sdl.draw.scaley);
+
+		sdl.clip = calc_viewport_fit(win_width, win_height);
+
+		sdl.window = SetWindowMode(screen_type, win_width, win_height,
 		                           sdl.desktop.fullscreen, resizable);
 		return sdl.window;
 	}
@@ -1366,14 +1368,14 @@ dosurface:
 
 		int windowWidth, windowHeight;
 		SDL_GetWindowSize(sdl.window, &windowWidth, &windowHeight);
+
 		if (sdl.clip.x == 0 && sdl.clip.y == 0 &&
 		    sdl.desktop.fullscreen &&
 		    !sdl.desktop.full.fixed &&
 		    (sdl.clip.w != windowWidth || sdl.clip.h != windowHeight)) {
 			// LOG_MSG("attempting to fix the centering to %d %d %d %d",(windowWidth-sdl.clip.w)/2,(windowHeight-sdl.clip.h)/2,sdl.clip.w,sdl.clip.h);
-			glViewport((windowWidth - sdl.clip.w) / 2,
-			           (windowHeight - sdl.clip.h) / 2, sdl.clip.w,
-			           sdl.clip.h);
+			sdl.clip = calc_viewport(windowWidth, windowHeight);
+			glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
 		} else if (sdl.desktop.window.resizable) {
 			sdl.clip = calc_viewport(windowWidth, windowHeight);
 			glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
@@ -1381,6 +1383,7 @@ dosurface:
 			/* We don't just pass sdl.clip.y as-is, so we cover the case of non-vertical
 			 * centering on Android (in order to leave room for the on-screen keyboard)
 			 */
+			sdl.clip = calc_viewport(windowWidth, windowHeight);
 			glViewport(sdl.clip.x,
 			           windowHeight - (sdl.clip.y + sdl.clip.h),
 			           sdl.clip.w,
@@ -2078,8 +2081,6 @@ MAYBE_UNUSED static std::string get_glshader_value()
 #endif // C_OPENGL
 }
 
-
-
 static bool detect_resizable_window()
 {
 #if C_OPENGL
@@ -2099,6 +2100,15 @@ static bool detect_resizable_window()
 #else
 	return false;
 #endif // C_OPENGL
+}
+
+static bool wants_stretched_pixels()
+{
+	const auto render_section = static_cast<Section_prop *>(
+	        control->GetSection("render"));
+	assert(render_section);
+
+	return render_section->Get_bool("aspect");
 }
 
 static SDL_Point remove_stretched_aspect(const SDL_Point &size)
@@ -2123,10 +2133,12 @@ static SDL_Point refine_window_size(const SDL_Point &size,
 		if (window_aspect > game_aspect) {
 			const int x = ceil_sdivide(size.y * game_ratios.x, game_ratios.y);
 			return {x, size.y};
+		} else {
+			// screen is narrower than the game, so constrain vertical
+			const int y = ceil_sdivide(size.x * game_ratios.y,
+			                           game_ratios.x);
+			return {size.x, y};
 		}
-		// screen is narrower than the game, so constrain vertical
-		const int y = ceil_sdivide(size.x * game_ratios.y, game_ratios.x);
-		return {size.x, y};
 	}
 	case (SCALING_MODE::NEAREST): {
 		constexpr SDL_Point resolutions[] = {
@@ -2229,6 +2241,13 @@ static SDL_Point window_bounds_from_label(const std::string &pref,
 	return {w, h};
 }
 
+static SDL_Point clamp_to_minimum_window_dimensions(SDL_Point size)
+{
+	const auto w = std::max(size.x, FALLBACK_WINDOW_DIMENSIONS.x);
+	const auto h = std::max(size.y, FALLBACK_WINDOW_DIMENSIONS.y);
+	return {w, h};
+}
+
 static SDL_Rect get_desktop_resolution()
 {
 	SDL_Rect desktop;
@@ -2237,6 +2256,62 @@ static SDL_Rect get_desktop_resolution()
 	assert(desktop.w >= FALLBACK_WINDOW_DIMENSIONS.x);
 	assert(desktop.h >= FALLBACK_WINDOW_DIMENSIONS.y);
 	return desktop;
+}
+
+// Takes in:
+//  - The 'maxresolution' config value: 'auto', 'W,H', or an invalid setting.
+//
+// Except for SURFACE and TEXTURE rendering, the function populates the following struct members:
+//  - 'sdl.desktop.restrict_resolution', true if resolution restriction is enabled.
+//  - 'sdl.desktop.max_resolution', with the refined size.
+
+static void setup_resolution_restriction_from_conf(const std::string &max_resolution_val)
+{
+	sdl.restrict_resolution = false;
+	sdl.max_resolution = {-1, -1};
+
+	// TODO: Deprecate SURFACE output and remove this.
+	if (sdl.desktop.want_type == SCREEN_SURFACE)
+		return;
+
+	if (max_resolution_val == "auto")
+		return;
+
+	const auto desktop = get_desktop_resolution();
+	int w, h;
+	auto was_parsed = sscanf(max_resolution_val.c_str(), "%dx%d", &w, &h) == 2;
+	if (!was_parsed) {
+		LOG_MSG("DISPLAY: Requested maxresolution '%s' is invalid, resolution restriction is disabled",
+		        max_resolution_val.c_str());
+		return;
+	}
+
+	const bool is_out_of_bounds = w <= 0 || w > desktop.w || h <= 0 ||
+	                              h > desktop.h;
+	if (is_out_of_bounds) {
+		LOG_MSG("DISPLAY: Requested maxresolution '%dx%d' is outside the bounds of the desktop '%dx%d', "
+		        "resolution restriction is disabled",
+		        w, h, desktop.w, desktop.h);
+		return;
+	}
+
+	auto coarse_size = clamp_to_minimum_window_dimensions({w, h});
+
+	SDL_Point refined_size;
+	if (sdl.scaling_mode == SCALING_MODE::PERFECT) {
+		// Keep requested maxresolution in pixel-perfect modes; refining it
+		// would be too counterintuitive
+		refined_size = coarse_size;
+	} else {
+		refined_size = refine_window_size(coarse_size, sdl.scaling_mode,
+		                                  wants_stretched_pixels());
+	}
+
+	sdl.restrict_resolution = true;
+	sdl.max_resolution = refined_size;
+
+	LOG_MSG("DISPLAY: Render resolution restricted to %dx%d (refined from %dx%d)",
+			refined_size.x, refined_size.y, w, h);
 }
 
 static void setup_initial_window_position_from_conf(const std::string &windowposition_val)
@@ -2304,12 +2379,7 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 	// Can the window be resized?
 	sdl.desktop.want_resizable_window = detect_resizable_window();
 
-	// Get the total desktop resolution
-	SDL_Rect desktop;
-	assert(sdl.display_number >= 0);
-	SDL_GetDisplayBounds(sdl.display_number, &desktop);
-	assert(desktop.w >= FALLBACK_WINDOW_DIMENSIONS.x);
-	assert(desktop.h >= FALLBACK_WINDOW_DIMENSIONS.y);
+	const auto desktop = get_desktop_resolution();
 
 	// The refined scaling mode tell the refiner how it should adjust
 	// the coarse-resolution.
@@ -2321,9 +2391,11 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 
 	// Get the coarse resolution from the users setting, and adjust
 	// refined scaling mode if an exact resolution is desired.
-	const std::string pref = NormalizeConfValue(windowresolution_val);
 	SDL_Point coarse_size = FALLBACK_WINDOW_DIMENSIONS;
-	if (pref.find('x') != std::string::npos) {
+
+	const std::string pref = NormalizeConfValue(windowresolution_val);
+	const auto window_resolution_specified = pref.find('x') != std::string::npos;
+	if (window_resolution_specified) {
 		coarse_size = window_bounds_from_resolution(pref, desktop);
 		refined_scaling_mode = drop_nearest();
 	} else {
@@ -2335,9 +2407,16 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 	// Save the coarse bounds in the SDL struct for future sizing events
 	sdl.desktop.requested_window_bounds = {coarse_size.x, coarse_size.y};
 
-	// Refine the coarse resolution and save it in the SDL struct
-	const auto refined_size = refine_window_size(coarse_size, refined_scaling_mode,
-	                                             wants_stretched_pixels);
+	// Refine the coarse resolution and save it in the SDL struct.
+	auto refined_size = coarse_size;
+	if (window_resolution_specified && sdl.restrict_resolution) {
+		// If viewport resolution restriction is enabled, the refinement is
+		// applied to the restricted resolution instead of the the window dimensions.
+		refined_size = clamp_to_minimum_window_dimensions(coarse_size);
+	} else {
+		refined_size = refine_window_size(coarse_size, refined_scaling_mode,
+		                                  wants_stretched_pixels);
+	}
 	assert(refined_size.x <= UINT16_MAX && refined_size.y <= UINT16_MAX);
 	sdl.desktop.window.width = static_cast<uint16_t>(refined_size.x);
 	sdl.desktop.window.height = static_cast<uint16_t>(refined_size.y);
@@ -2357,30 +2436,33 @@ static SDL_Rect calc_viewport_fit(int win_width, int win_height)
 	assert(std::isfinite(sdl.draw.scalex));
 	assert(std::isfinite(sdl.draw.scaley));
 
-	const double prog_aspect_ratio = (sdl.draw.width * sdl.draw.scalex) /
-	                                 (sdl.draw.height * sdl.draw.scaley);
+	const double prog_aspect_ratio = (sdl.draw.width * sdl.draw.scalex) / (sdl.draw.height * sdl.draw.scaley);
 	const double win_aspect_ratio = double(win_width) / double(win_height);
 
+	const auto render_resolution = restrict_viewport_resolution(win_width, win_height);
+
+	int w, h;
 	if (prog_aspect_ratio > win_aspect_ratio) {
-		// match window width
-		const int w = win_width;
-		const int h = iround(win_width / prog_aspect_ratio);
-		assert(win_height >= h);
-		const int y = (win_height - h) / 2;
-		return {0, y, w, h};
+		w = render_resolution.x;
+		h = iround(w / prog_aspect_ratio);
 	} else {
-		// match window height
-		const int w = iround(win_height * prog_aspect_ratio);
-		const int h = win_height;
-		assert(win_width >= w);
-		const int x = (win_width - w) / 2;
-		return {x, 0, w, h};
+		h = render_resolution.y;
+		w = iround(h * prog_aspect_ratio);
 	}
+	assert(win_width >= w);
+	assert(win_height >= h);
+
+	const int x = (win_width - w) / 2;
+	const int y = (win_height - h) / 2;
+
+	return {x, y, w, h};
 }
 
 static SDL_Rect calc_viewport_pp(int win_width, int win_height)
 {
-	sdl.pp_scale = calc_pp_scale(win_width, win_height);
+	const auto render_resolution = restrict_viewport_resolution(win_width, win_height);
+	
+	sdl.pp_scale = calc_pp_scale(render_resolution.x, render_resolution.y);
 
 	const int w = sdl.pp_scale.x * sdl.draw.width;
 	const int h = sdl.pp_scale.y * sdl.draw.height;
@@ -2543,13 +2625,16 @@ static void GUI_StartUp(Section *sec)
 	        control->GetSection("render"));
 	assert(render_section);
 
+	setup_resolution_restriction_from_conf(
+	        render_section->Get_string("maxresolution"));
+
 	sdl.desktop.window.show_decorations = section->Get_bool("windowdecorations");
 
 	setup_initial_window_position_from_conf(section->Get_string("windowposition"));
 
 	setup_window_sizes_from_conf(section->Get_string("windowresolution"),
 	                             sdl.scaling_mode,
-	                             render_section->Get_bool("aspect"));
+	                             wants_stretched_pixels());
 
 #if C_OPENGL
 	if (sdl.desktop.want_type == SCREEN_OPENGL) { /* OPENGL is requested */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3316,9 +3316,9 @@ void Config_Add_SDL() {
 	  0 };
 
 #if C_OPENGL
-	Pstring = sdl_sec->Add_string("output", Property::Changeable::Always, "opengl");
+	Pstring = sdl_sec->Add_string("output", always, "opengl");
 #else
-	Pstring = sdl_sec->Add_string("output", Property::Changeable::Always, "texture");
+	Pstring = sdl_sec->Add_string("output", always, "texture");
 #endif
 	Pstring->Set_help("What video system to use for output.");
 	Pstring->Set_values(outputs);
@@ -3366,12 +3366,12 @@ void Config_Add_SDL() {
 	mouse_control_help += mouse_control_defaults;
 	Pmulti->Set_help(mouse_control_help);
 
-	Pmulti = sdl_sec->Add_multi("sensitivity",Property::Changeable::Always, ",");
+	Pmulti = sdl_sec->Add_multi("sensitivity", always, ",");
 	Pmulti->Set_help("Mouse sensitivity. The optional second parameter specifies vertical sensitivity (e.g. 100,-50).");
 	Pmulti->SetValue("100");
-	Pint = Pmulti->GetSection()->Add_int("xsens",Property::Changeable::Always,100);
+	Pint = Pmulti->GetSection()->Add_int("xsens", always,100);
 	Pint->SetMinMax(-1000,1000);
-	Pint = Pmulti->GetSection()->Add_int("ysens",Property::Changeable::Always,100);
+	Pint = Pmulti->GetSection()->Add_int("ysens", always,100);
 	Pint->SetMinMax(-1000,1000);
 
 	pbool = sdl_sec->Add_bool("raw_mouse_input", on_start, false);
@@ -3380,10 +3380,10 @@ void Config_Add_SDL() {
 	        "acceleration and sensitivity settings. This works in\n"
 	        "fullscreen or when the mouse is captured in window mode.");
 
-	Pbool = sdl_sec->Add_bool("waitonerror",Property::Changeable::Always, true);
+	Pbool = sdl_sec->Add_bool("waitonerror", always, true);
 	Pbool->Set_help("Wait before closing the console if dosbox has an error.");
 
-	Pmulti = sdl_sec->Add_multi("priority", Property::Changeable::Always, ",");
+	Pmulti = sdl_sec->Add_multi("priority", always, ",");
 	Pmulti->SetValue("auto,auto");
 	Pmulti->Set_help(
 	        "Priority levels for dosbox. Second entry behind the comma is for when dosbox is not focused/minimized.\n"
@@ -3391,16 +3391,12 @@ void Config_Add_SDL() {
 
 	const char *actt[] = {"auto",   "lowest",  "lower", "normal",
 	                      "higher", "highest", "pause", 0};
-	Pstring = Pmulti->GetSection()->Add_string("active",
-	                                           Property::Changeable::Always,
-	                                           "higher");
+	Pstring = Pmulti->GetSection()->Add_string("active", always, "higher");
 	Pstring->Set_values(actt);
 
 	const char *inactt[] = {"auto",   "lowest",  "lower", "normal",
 	                        "higher", "highest", "pause", 0};
-	Pstring = Pmulti->GetSection()->Add_string("inactive",
-	                                           Property::Changeable::Always,
-	                                           "normal");
+	Pstring = Pmulti->GetSection()->Add_string("inactive", always, "normal");
 	Pstring->Set_values(inactt);
 
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1431,7 +1431,7 @@ dosurface:
 			// Set shader variables
 			glUniform2f(sdl.opengl.ruby.texture_size, (float)texsize, (float)texsize);
 			glUniform2f(sdl.opengl.ruby.input_size, (float)width, (float)height);
-			glUniform2f(sdl.opengl.ruby.output_size, sdl.clip.w, sdl.clip.h);
+			glUniform2f(sdl.opengl.ruby.output_size, (GLfloat)sdl.clip.w, (GLfloat)sdl.clip.h);
 			// The following uniform is *not* set right now
 			sdl.opengl.actual_frame_count = 0;
 		} else {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -284,6 +284,8 @@ struct SDL_Block {
 			uint16_t height = 0; // TODO convert to int
 			bool resizable = false;
 			bool show_decorations = true;
+			int initial_x_pos = -1;
+			int initial_y_pos = -1;
 		} window = {};
 		struct {
 			int width = 0;
@@ -744,6 +746,19 @@ static void log_display_properties(const int in_x,
 	        out_x, out_y, out_par);
 }
 
+static SDL_Point get_initial_window_position_or_default(int default_val)
+{
+	int x, y;
+	if (sdl.desktop.window.initial_x_pos >= 0 &&
+	    sdl.desktop.window.initial_y_pos >= 0) {
+		x = sdl.desktop.window.initial_x_pos;
+		y = sdl.desktop.window.initial_y_pos;
+	} else {
+		x = y = default_val;
+	}
+	return {x, y};
+}
+
 static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
                                  int width,
                                  int height,
@@ -780,8 +795,9 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 
 		// Using undefined position will take care of placing and
 		// restoring the window by WM.
-		const int pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
-		sdl.window = SDL_CreateWindow("", pos, pos, width, height, flags);
+		const auto default_val = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
+		const auto pos = get_initial_window_position_or_default(default_val);
+		sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
 		if (!sdl.window) {
 			LOG_MSG("SDL: %s", SDL_GetError());
 			return nullptr;
@@ -2213,6 +2229,46 @@ static SDL_Point window_bounds_from_label(const std::string &pref,
 	return {w, h};
 }
 
+static SDL_Rect get_desktop_resolution()
+{
+	SDL_Rect desktop;
+	assert(sdl.display_number >= 0);
+	SDL_GetDisplayBounds(sdl.display_number, &desktop);
+	assert(desktop.w >= FALLBACK_WINDOW_DIMENSIONS.x);
+	assert(desktop.h >= FALLBACK_WINDOW_DIMENSIONS.y);
+	return desktop;
+}
+
+static void setup_initial_window_position_from_conf(const std::string &windowposition_val)
+{
+	sdl.desktop.window.initial_x_pos = -1;
+	sdl.desktop.window.initial_y_pos = -1;
+
+	if (windowposition_val == "auto")
+		return;
+
+	int x, y;
+	const auto was_parsed = sscanf(windowposition_val.c_str(), "%d,%d", &x, &y) == 2;
+	if (!was_parsed) {
+		LOG_MSG("DISPLAY: Requested windowposition '%s' is invalid, using 'auto' instead",
+		        windowposition_val.c_str());
+		return;
+	}
+
+	const auto desktop = get_desktop_resolution();	
+	const bool is_out_of_bounds = x <= 0 || x > desktop.w || y <= 0 ||
+	                              y > desktop.h;
+	if (is_out_of_bounds) {
+		LOG_MSG("DISPLAY: Requested window position '%d,%d' is outside the bounds of the desktop '%dx%d', "
+		        "using 'auto' instead",
+		        x, y, desktop.w, desktop.h);
+		return;
+	}
+
+	sdl.desktop.window.initial_x_pos = x;
+	sdl.desktop.window.initial_y_pos = y;
+}
+
 // Takes in:
 //  - The user's windowresolution: default, WxH, small, medium, large,
 //    desktop, or an invalid setting.
@@ -2488,6 +2544,8 @@ static void GUI_StartUp(Section *sec)
 	assert(render_section);
 
 	sdl.desktop.window.show_decorations = section->Get_bool("windowdecorations");
+
+	setup_initial_window_position_from_conf(section->Get_string("windowposition"));
 
 	setup_window_sizes_from_conf(section->Get_string("windowresolution"),
 	                             sdl.scaling_mode,
@@ -2790,12 +2848,9 @@ static void FinalizeWindowState()
 	// switching to a window for the first time. This is happening on every
 	// OS, but only on Windows it's a really big problem (because window
 	// decorations are rendered off-screen).
-	//
-	// To work around this problem, tell SDL to center the window on current
-	// screen (we want center, as undefined position could still result in
-	// placing part of the window off-screen).
-	const int pos = SDL_WINDOWPOS_CENTERED_DISPLAY(sdl.display_number);
-	SDL_SetWindowPosition(sdl.window, pos, pos);
+	const auto default_val = SDL_WINDOWPOS_CENTERED_DISPLAY(sdl.display_number);
+	const auto pos = get_initial_window_position_or_default(default_val);
+	SDL_SetWindowPosition(sdl.window, pos.x, pos.y);
 
 	// In some cases (not always), leaving fullscreen breaks window content,
 	// screen reset restores rendering to the working state.
@@ -3155,6 +3210,13 @@ void Config_Add_SDL() {
 	        "  <custom>:  Scale the window to the given dimensions in\n"
 	        "             WxH format. For example: 1024x768.\n"
 	        "             Scaling is not performed for output=surface.");
+
+	pstring = sdl_sec->Add_string("windowposition", always, "auto");
+	pstring->Set_help(
+	        "Set initial window position when running in windowed mode:\n"
+	        "  auto:      Let the window manager decide the position.\n"
+	        "  <custom>:  Set window position in X,Y format. For example: 250,100\n"
+	        "             0,0 is the top-left corner of the screen.\n");
 
 	Pbool = sdl_sec->Add_bool("windowdecorations", always, true);
 	Pbool->Set_help("Controls whether to display window decorations in windowed mode.");


### PR DESCRIPTION
I almost raised three separate PRs for this, but then decided to just do it in one because it's easier to explain why I need these features through a few examples that show how they can be used together. In any case, there are separate commits for the three features.

This is my first PR so please let me know if I missed something :) 

# Motivation

## Case 1

I like to play 320x200 games in fullscreen on my 24" 1920x1080 monitor with the **draw area restricted to a 960x720 rectangle** at the center of screen. That closely matches the size of a typical 14" VGA display from a normal viewing distance. 

![space-quest-3](https://user-images.githubusercontent.com/698770/133879064-c48973e1-d157-45bb-8da1-31dc9a8f7422.png)

This is how I always play low-resolution games in ScummVM and WinUAE; I find anything larger just too big, the pixels are so huge -- that's not how those games looked on a 14" monitor back in the day!

Right now, I could use windowed mode with the default `sharp` shader and set the window resolution to 960x720, but I find the window decorations and the desktop very immersion-breaking when playing a game.

## Case 2

When I play old grid-based RPGs, I like to have the emulator window on the left side of the screen, and my own dungeon mapper program on the right side.  For maximum immersion, I hide the taskbar and disable the window decorations on both windows. Then I can comfortably Alt-Tab between the two windows when playing the game.

![eye-of-the-beholder-no-titlebar](https://user-images.githubusercontent.com/698770/133879068-d76ecc6f-b0b4-4708-973d-e7fcce89085a.png)

All this can be easily done in WinUAE. To replicate it in DOSBox, we need the same **draw area restriction** mechanism from _Case 1_.  We also need the ability to **set the exact window size** and **window position** from the config (without any window size refinement), and an option to **hide all window decorations**.

# Solution

It's perhaps a bit involved to explain the solution in detail, but it's really intuitive and straighforward to use, as evidenced by the config examples further down. I've spend a considerable time to make this **100% backward compatible at default settings** and logical, but if you can think of some further improvements, I'm happy to hear them :) 

1. Introduce new `maxresolution` param (in `render` section) to provide support for restricting the actual drawing area to a smaller rectangle than the full size of the window/screen. Possible values are `auto` or `WxH`.

- `auto` is the current behaviour with no changes to anything whatsoever (the drawing area always fills the screen/window). This is the default to ensure 100% backward compatibility.

- If the max resolution is specified in `WxH` format, no window size refinement is performed (except for ensuring a minimum window size of 640x480). Instead, the refinement is applied to the `maxresolution` rectangle. The resulting draw area is always centered to the window/screen.

2. Introduce new `windowposition` param (in `sdl` section) to set the initial window position.  Possible values are `X,Y`, where `X` and `Y` are the desired window coordinates, or `auto`, which is the current behaviour (leave it to the OS). Defaults to `auto` for backward compatibility.

3. Introduce new `windowdecoration` param (in `sdl` section) to show/hide the window decorations. Defaults to `true` for backward compatibility.

## Config examples

This is how the config would look like for case 1:

```
[sdl]
fullscreen = true

[render]
maxresolution = 960x720
```

And for case 2:

```
[sdl]
windowresolution = 1060x1080
windowposition = 0,0
windowdecoration = false

[render]
maxresolution = 960x720
```

# Notes

- I've tested it on Windows 10 with all sorts of permutations (start in fullscreen, start in windowed, switch between the two, games that change resolutions, different shaders, etc)
- Only `opengl` is supported currently. Support could (and should) be added for `texture` output as well. I might do that later, or someone else can pick it up, but I just wanted to show this to you guys first, I've spent enough time on it already.
- `surface` output changes the window size when the games change the resolution, so conceptually is a bit at odds with the `maxresolution` option. But honestly, I don't care, as my understanding is that `surface` is planned to be removed soon (rightly so).
- I've done some cleanup in separate commits, if you don't like them, I can delete them.


