### PR TITLE
Include SDL2's Controller API, database, and initial detection 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -215,6 +215,8 @@ jobs:
           install -DT -m 644 COPYING              dest/COPYING
           install -DT -m 644 README               dest/doc/manual.txt
           install -DT -m 644 docs/dosbox.1        dest/man/dosbox.1
+          install -DT -m 644 submodules/SDL_GameControllerDB/gamecontrollerdb.txt \
+                                                  dest/gamecontrollerdb.txt
 
           # Install .desktop entry and icon files
           install -DT contrib/linux/dosbox-staging.desktop dest/desktop/dosbox-staging.desktop

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -275,6 +275,9 @@ jobs:
           install -m 644 "README"                            "$dst/SharedSupport/manual.txt"
           install -m 644 "docs/README.video"                 "$dst/SharedSupport/video.txt"
 
+          install -m 644 "submodules/SDL_GameControllerDB/gamecontrollerdb.txt" \
+                                                             "$dst/Resources/gamecontrollerdb.txt"
+
           # Fill README template file
           sed -i -e "s|%VERSION%|${{ env.VERSION }}|"           "$dst/Info.plist"
           sed -i -e "s|%GIT_COMMIT%|$GITHUB_SHA|"               "$dst/SharedSupport/README"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -185,6 +185,7 @@ jobs:
           cp vs/$RELEASE_DIR/libpng16.dll         dest/
           cp src/libs/zmbv/$RELEASE_DIR/zlib1.dll dest/ # libpng dependency
           cp src/libs/zmbv/$RELEASE_DIR/zmbv.dll  dest/
+          cp submodules/SDL_GameControllerDB/gamecontrollerdb.txt dest/
 
           # Prepare translation files
           #

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "submodules/loguru"]
 	path = submodules/loguru
 	url = https://github.com/dosbox-staging/loguru
+
+[submodule "submodules/SDL_GameControllerDB"]
+	path = submodules/SDL_GameControllerDB
+	url = https://github.com/gabomdq/SDL_GameControllerDB

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3596,7 +3596,7 @@ int sdl_main(int argc, char *argv[])
 	LOG_MSG("dosbox-staging version %s", DOSBOX_GetDetailedVersion());
 	LOG_MSG("---");
 
-	if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO) < 0)
+	if (SDL_Init(SDL_INIT_EVERYTHING) < 0)
 		E_Exit("Can't init SDL %s", SDL_GetError());
 	sdl.initialized = true;
 	// Once initialized, ensure we clean up SDL for all exit conditions

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3260,6 +3260,14 @@ void Config_Add_SDL() {
 	                                           "normal");
 	Pstring->Set_values(inactt);
 
+	pstring = sdl_sec->Add_string("controllerdb", always, "auto");
+	pstring->Set_help(
+	        "Path to a 3rd party SDL controller database file.\n"
+	        "The default is 'auto', which loads 'gamecontrollerdb.txt' if found locally or in the the config path.\n"
+	        "If 'auto' doesn't find the file, it uses SDL's internal controller mappings.\n"
+	        "Note: 'gamecontrollerdb.txt' is bundled with the binary package or can be downloaded here:\n"
+	        "      https://github.com/gabomdq/SDL_GameControllerDB/archive/refs/heads/master.zip\n");
+
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
 	pstring->Set_help("File used to load/save the key/event mappings from.\n"
 	                  "Resetmapper only works with the default value.");

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -24,6 +24,7 @@
 
 #include "control.h"
 #include "inout.h"
+#include "fs_utils.h"
 #include "pic.h"
 #include "support.h"
 

--- a/submodules/readme.txt
+++ b/submodules/readme.txt
@@ -1,0 +1,4 @@
+Populate your submodule directories with:
+
+   git submodule update --init --recursive
+


### PR DESCRIPTION
A very small PR that:
 - Initializes the controller subsystem
 - Bundles the expanded controller database from the SDL_GameControllerDB project
 - Informs the user if their controller is indeed supported (or not) in the database

Introduces a new setting:

```ini
[sdl]
controllerdb = auto # or custom 3rd party database
```

Why this is valuable?  

Modern gamers typically have game controllers. 

SDL2 attempts to map all supported game controllers to a vendor-agnostic layout:
 - D-pad
 - Left stick
 - Right stick
 - trigger/shoulder buttons
 - four buttons

These controls are given standardized names, ie: dpad-left, right-trigger, and so on - that we can catch as events.   This will give users a workable out-of-the-box experience.  It might be their exactly preference, but it will get them off the ground, and they can map any customizations from there.

Longer term, the goal will be to add support for controllers, their events, and mapping of these generic 'controller' events in a very separate chunk of code, as the current joystick-focused code works well for users with flight sticks and such. We don't want to impact that code or add further complexity to it.  