### PR TITLE
Introduce layered configuration loading, by default (#670)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ TabWidth: 8
 IndentWidth: 8
 ContinuationIndentWidth: 8
 
-ColumnLimit: 110
+ColumnLimit: 80
 
 # C/C++ Language specifics
 #

--- a/README
+++ b/README
@@ -344,9 +344,10 @@ To be able to use Command Line Parameters:
 The options are valid for all operating systems unless noted in the option
 description:
 
-dosbox [-fullscreen] [-startmapper] [-noautoexec] [-securemode] [-userconf]
-       [-scaler scaler | -forcescaler scaler] [-conf congfigfile]
-       [-lang langfile] [-machine machine-type] [-socket socketnumber]
+dosbox [-fullscreen] [-startmapper] [-noautoexec] [-securemode]
+       [-noprimaryconf] [-nolocalconf] [-conf congfigfile]
+       [-scaler scaler | -forcescaler scaler] [-lang langfile]
+       [-machine machine-type] [-socket socketnumber]
        [-c command] [-noconsole] [-exit] [NAME]
 
 dosbox --version
@@ -387,15 +388,31 @@ dosbox -opencaptures program
   -fullscreen
         Starts DOSBox in fullscreen mode.
 
-  -userconf
-        Start DOSBox with the users specific configuration file. Can be used
-        together with multiple -conf parameters, but -userconf will always be
-        loaded before them.
+  -noprimaryconf, -conf, and -nolocalconf:
 
-  -conf configfilelocation
-        Start DOSBox with the options specified in "configfilelocation".
-        Multiple -conf options may be present.
-        See Section 13: "The configuration (options) file" for more details.
+        DOSBox Staging uses a layered configuration approach, as follows:
+
+        1. The primary configuration file is loaded first, which comes
+           from the operating system's user configuration directory.
+           This can be thought of as your "global" configuration file.
+
+        2. Custom configurations can be layered on next using one
+           or more -conf <filename> command-line arguments. For example:
+           dosbox -conf myshader.conf -conf myaudio.conf
+
+        3. Finally, if the local directory contains a "dosbox.conf" file,
+           these settings will be layered on last and therefore have
+           the highest precedence.
+
+        This layered approach means you can start with the most general
+        settings (from your primary conf) and increasingly fine-tune them
+        for a specific game, which may only have a couple DOS-specific
+        settings inside its own local dosbox.conf file.
+
+        The -noprimaryconf and -nolocalconf affect this behavior:
+
+        -noprimaryconf avoids loading your primary conf file.
+        -nolocalconf avoids loading the local dosbox.conf file.
 
   -lang languagefilelocation
         Start DOSBox using the language specified in "languagefilelocation".

--- a/include/control.h
+++ b/include/control.h
@@ -89,7 +89,8 @@ public:
 	void ShutDown();
 	void StartUp();
 	bool PrintConfig(const std::string &filename) const;
-	bool ParseConfigFile(char const * const configfilename);
+	bool ParseConfigFile(const std::string &type,
+	                     const std::string &configfilename);
 	void ParseEnv();
 	bool SecureMode() const { return secure_mode; }
 	void SwitchToSecureMode() { secure_mode = true; }//can't be undone

--- a/include/setup.h
+++ b/include/setup.h
@@ -426,4 +426,6 @@ public:
 	virtual bool Change_Config(Section * /*newconfig*/) { return false; }
 };
 
+void SETUP_ParseConfigFiles(const std::string &config_path);
+
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3602,69 +3602,8 @@ int sdl_main(int argc, char *argv[])
 	// Once initialized, ensure we clean up SDL for all exit conditions
 	atexit(QuitSDL);
 
-	/* Parse configuration files */
-	std::string config_file, config_combined;
-
-	std::string config_path = CROSS_GetPlatformConfigDir();
-
-	//First parse -userconf
-	if(control->cmdline->FindExist("-userconf",true)){
-		config_file.clear();
-		Cross::GetPlatformConfigDir(config_path);
-		Cross::GetPlatformConfigName(config_file);
-		config_combined = config_path + config_file;
-		control->ParseConfigFile(config_combined.c_str());
-		if(!control->configfiles.size()) {
-			//Try to create the userlevel configfile.
-			config_file.clear();
-			Cross::CreatePlatformConfigDir(config_path);
-			Cross::GetPlatformConfigName(config_file);
-			config_combined = config_path + config_file;
-			if (control->PrintConfig(config_combined)) {
-				LOG_MSG("CONFIG: Generating default configuration\n"
-					"CONFIG: Writing it to %s",
-					config_combined.c_str());
-				// Load them as well. Makes relative paths much easier
-				control->ParseConfigFile(config_combined.c_str());
-			}
-		}
-	}
-
-	//Second parse -conf switches
-	while(control->cmdline->FindString("-conf",config_file,true)) {
-		if (!control->ParseConfigFile(config_file.c_str())) {
-			// try to load it from the user directory
-			if (!control->ParseConfigFile((config_path + config_file).c_str())) {
-				LOG_MSG("CONFIG: Can't open specified config file: %s",config_file.c_str());
-			}
-		}
-	}
-	// if none found => parse localdir conf
-	if(!control->configfiles.size()) control->ParseConfigFile("dosbox.conf");
-
-	// if none found => parse userlevel conf
-	if(!control->configfiles.size()) {
-		config_file.clear();
-		Cross::GetPlatformConfigName(config_file);
-		control->ParseConfigFile((config_path + config_file).c_str());
-	}
-
-	if(!control->configfiles.size()) {
-		//Try to create the userlevel configfile.
-		config_file.clear();
-		Cross::CreatePlatformConfigDir(config_path);
-		Cross::GetPlatformConfigName(config_file);
-		config_combined = config_path + config_file;
-		if (control->PrintConfig(config_combined)) {
-			LOG_MSG("CONFIG: Generating default configuration\n"
-				"CONFIG: Writing it to %s",
-				config_combined.c_str());
-			// Load them as well. Makes relative paths much easier
-			control->ParseConfigFile(config_combined.c_str());
-		} else {
-			LOG_MSG("CONFIG: Using default settings. Create a configfile to change them");
-		}
-	}
+	const auto config_path = CROSS_GetPlatformConfigDir();
+	SETUP_ParseConfigFiles(config_path);
 
 #if C_OPENGL
 	const std::string glshaders_dir = config_path + "glshaders";

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -951,15 +951,12 @@ Section *Config::GetSectionFromProperty(const char *prop) const
 	return nullptr;
 }
 
-bool Config::ParseConfigFile(char const * const configfilename) {
-	//static bool first_configfile = true;
+bool Config::ParseConfigFile(const std::string &type, const std::string &configfilename)
+{
+	// static bool first_configfile = true;
 	ifstream in(configfilename);
 	if (!in) return false;
 	configfiles.push_back(configfilename);
-
-	LOG_INFO("CONFIG: Loading %s file %s",
-	        configfiles.size() == 1 ? "primary" : "additional",
-	        configfilename);
 
 	//Get directory from configfilename, used with relative paths.
 	current_config_dir=configfilename;
@@ -1005,6 +1002,9 @@ bool Config::ParseConfigFile(char const * const configfilename) {
 		}
 	}
 	current_config_dir.clear();//So internal changes don't use the path information
+
+	LOG_INFO("CONFIG: Loaded %s conf file %s", type.c_str(), configfilename.c_str());
+
 	return true;
 }
 


### PR DESCRIPTION
This PR introduces a layered configuration approach, by default.

1. **First**, the primary configuration file is loaded, which comes from the operating system's user configuration directory. 
    This can be thought of as your "global" configuration file.
           
2. **Second**, custom configurations can be layered on using one or more `-conf <filename>`command-line arguments. For example: `dosbox -conf myshader.conf -conf myaudio.conf`

3. **Third**, if the local directory contains a "dosbox.conf" file, these settings are layered on last and therefore have the highest precedence.

This layered approach means you can start with the most general setting (from your primary conf) and increasingly fine-tune them for a specific game, which may only have a couple DOS-specific settings inside it's own local dosbox.conf file.

A couple new command-line arguments, `-noprimaryconf` and `-nolocalconf`  affect this behavior: 
 - `-noprimaryconf` avoids loading this user's primary conf file.
 - `-nolocalconf` avoids loading the local dosbox.conf file.

These are discussed in the `README` text.

## Examples

**`dosbox`, by default**

``` text
2021-09-19 14:33:45.584 | CONFIG: Loaded primary conf file ~/.config/dosbox/dosbox-staging.conf
2021-09-19 14:33:45.584 | CONFIG: Loaded local conf file dosbox.conf
```

**`dosbox -conf intermediate-1.conf -conf intermediate-2.conf`**

``` text
2021-09-19 14:33:45.584 | CONFIG: Loaded primary conf file ~/.config/dosbox/dosbox-staging.conf
2021-09-19 14:33:45.584 | CONFIG: Loaded custom conf file intermediate-1.conf
2021-09-19 14:33:45.584 | CONFIG: Loaded custom conf file intermediate-2.conf
2021-09-19 14:33:45.584 | CONFIG: Loaded local conf file dosbox.conf
```

Fixes #670.