### PR TITLE
Drop rapid-exit protection for normal-launch modes

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -31,12 +31,13 @@
 #include "setup.h"
 
 enum class Verbosity : int8_t {
-	//                  Splash | Welcome | Early Stdout |
-	Quiet = 0,      //   no    |   no    |    no        |
-	SplashOnly = 1, //   yes   |   no    |    no        |
-	Low = 2,        //   no    |   no    |    yes       |
-	Medium = 3,     //   no    |   yes   |    yes       |
-	High = 4,       //   yes   |   yes   |    yes       |
+	//                     Splash | Welcome | Early Stdout |
+	Quiet = 0,         //   no    |   no    |    no        |
+	SplashOnly = 1,    //   yes   |   no    |    no        |
+	InstantLaunch = 2, //   no    |   no    |    yes       |
+	Low = 3,           //   no    |   no    |    yes       |
+	Medium = 4,        //   no    |   yes   |    yes       |
+	High = 5,          //   yes   |   yes   |    yes       |
 };
 
 class Config {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1082,11 +1082,14 @@ Verbosity Config::GetStartupVerbosity() const
 		return Verbosity::SplashOnly;
 	if (user_choice == "quiet")
 		return Verbosity::Quiet;
-	// auto-mode
-	if (cmdline->HasDirectory() || cmdline->HasExecutableName())
-		return Verbosity::Low;
-	else
-		return Verbosity::High;
+	if (user_choice == "auto")
+		return (cmdline->HasDirectory() || cmdline->HasExecutableName())
+		               ? Verbosity::InstantLaunch
+		               : Verbosity::High;
+
+	LOG_WARNING("SETUP: Unknown verbosity mode '%s', defaulting to 'high'",
+	            user_choice.c_str());
+	return Verbosity::High;
 }
 
 bool CommandLine::FindExist(char const * const name,bool remove) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -477,11 +477,10 @@ public:
 		}
 
 		// Check for the -exit switch, which indicates they want to quit after the command has finished
-		const bool requested_exit_after_command = control->cmdline->FindExist("-exit", true);
+		const bool requested_exit_after_command = control->cmdline->FindExist("-exit");
 
 		// Check if instant-launch is active
-		const bool using_instant_launch = control->cmdline->HasExecutableName() &&
-		                                  control->GetStartupVerbosity() <= Verbosity::Low;
+		const bool using_instant_launch = control->GetStartupVerbosity() == Verbosity::InstantLaunch;
 
 		// Should we add an 'exit' call to the end of autoexec.bat?
 		const bool addexit = requested_exit_after_command || using_instant_launch;


### PR DESCRIPTION
The timeout's been lowered to 1.5 seconds too.

Nominal scenarios are:

 - for "good" launches (where the game starts up fine), the vast majority of users will spend more than 1.5 seconds "in-game" before exiting.

- for the "bad" launch scenario (where the game is missing some files, doesn't find the CDROM, isn't configured, etc..) and immediately quits back to DOS - in these scenarios, the early-exit protection will kick in so the user can what happened and try to address it.

For non-standard scenarios: users who routinely instant-launch games and then quit within 1.5 seconds: these should be extremely rate, but if this is actually common for some workflows (perhaps automation/scripting/..), then these users can either add an `-exit` command-line argument (which will force-exit no matter what) or they can adjust their primary conf to use a `startup_verbosity` other than `auto`. 