### PR TITLE
Add a placeholder program (#1258)

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -32,6 +32,7 @@
 #include "program_ls.h"
 #include "program_mem.h"
 #include "program_mount.h"
+#include "program_placeholder.h"
 #include "program_rescan.h"
 
 #if C_DEBUG
@@ -40,7 +41,10 @@
 
 extern Bit32u floppytype;
 
-void DOS_SetupPrograms(void) {
+#define WIKI_URL "https://github.com/dosbox-staging/dosbox-staging/wiki"
+
+void DOS_SetupPrograms(void)
+{
 	/*Add Messages */
 
 	MSG_Add("PROGRAM_MOUNT_CDROMS_FOUND","CDROMs found: %d\n");
@@ -93,17 +97,16 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_RESCAN_SUCCESS","Drive cache cleared.\n");
 
 	MSG_Add("PROGRAM_INTRO",
-		"\033[2J\033[32;1mWelcome to DOSBox Staging\033[0m, an x86 emulator with sound and graphics.\n"
-		"DOSBox creates a shell for you which looks like old plain DOS.\n"
-		"\n"
-		"For information about basic mount type \033[34;1mintro mount\033[0m\n"
-		"For information about CD-ROM support type \033[34;1mintro cdrom\033[0m\n"
-		"For information about special keys type \033[34;1mintro special\033[0m\n"
-		"For more imformation, visit DOSBox Staging wiki:\033[34;1m\n"
-		"https://github.com/dosbox-staging/dosbox-staging/wiki\033[0m\n"
-		"\n"
-		"\033[31;1mDOSBox will stop/exit without a warning if an error occurred!\033[0m\n"
-		);
+	        "\033[2J\033[32;1mWelcome to DOSBox Staging\033[0m, an x86 emulator with sound and graphics.\n"
+	        "DOSBox creates a shell for you which looks like old plain DOS.\n"
+	        "\n"
+	        "For information about basic mount type \033[34;1mintro mount\033[0m\n"
+	        "For information about CD-ROM support type \033[34;1mintro cdrom\033[0m\n"
+	        "For information about special keys type \033[34;1mintro special\033[0m\n"
+	        "For more imformation, visit DOSBox Staging wiki:\033[34;1m\n" WIKI_URL
+	        "\033[0m\n"
+	        "\n"
+	        "\033[31;1mDOSBox will stop/exit without a warning if an error occurred!\033[0m\n");
 	MSG_Add("PROGRAM_INTRO_MOUNT_START",
 		"\033[2J\033[32;1mHere are some commands to get you started:\033[0m\n"
 		"Before you can use the files located on your own filesystem,\n"
@@ -342,12 +345,23 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_KEYB_LAYOUTNOTFOUND","No layout in %s for codepage %i\n");
 	MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
 
+	MSG_Add("PROGRAM_PLACEHOLDER_CONSOLE_MESSAGE",
+	        "%s is only a placeholder.\n"
+	        "Install a 3rd-party replacement first in your PATH.\n");
+	MSG_Add("PROGRAM_PLACEHOLDER_LOG_MESSAGE_1", "This program is a placeholder");
+	MSG_Add("PROGRAM_PLACEHOLDER_LOG_MESSAGE_2", "Please visit the following wiki article for help:");
+
+	MSG_Add("WIKI_URL", WIKI_URL);
+
 	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
 #if C_DEBUG
 	PROGRAMS_MakeFile("BIOSTEST.COM", BIOSTEST_ProgramStart);
 #endif
 	PROGRAMS_MakeFile("BOOT.COM", BOOT_ProgramStart);
 	PROGRAMS_MakeFile("CHOICE.COM", CHOICE_ProgramStart);
+#if !(C_DEBUG)
+	PROGRAMS_MakeFile("DEBUG.COM", PLACEHOLDER_ProgramStart);
+#endif
 	PROGRAMS_MakeFile("HELP.COM", HELP_ProgramStart);
 	PROGRAMS_MakeFile("IMGMOUNT.COM", IMGMOUNT_ProgramStart);
 	PROGRAMS_MakeFile("INTRO.COM", INTRO_ProgramStart);

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -34,6 +34,7 @@ libdos_sources = files([
   'program_mem.cpp',
   'program_mount_common.cpp',
   'program_mount.cpp',
+  'program_placeholder.cpp',
   'program_rescan.cpp',
 ])
 

--- a/src/dos/program_placeholder.cpp
+++ b/src/dos/program_placeholder.cpp
@@ -1,0 +1,44 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "program_placeholder.h"
+
+#include "shell.h"
+
+extern unsigned int result_errorcode;
+
+void PLACEHOLDER::Run()
+{
+	const auto command = cmd->GetFileName();
+
+	LOG_WARNING("%s: %s", command, MSG_Get("PROGRAM_PLACEHOLDER_LOG_MESSAGE_1"));
+	LOG_WARNING("%s: %s", command, MSG_Get("PROGRAM_PLACEHOLDER_LOG_MESSAGE_2"));
+	LOG_WARNING("%s: %s/%s", command, MSG_Get("WIKI_URL"), "Add-Utilities");
+
+	WriteOut(MSG_Get("PROGRAM_PLACEHOLDER_CONSOLE_MESSAGE"), command);
+
+	first_shell->CMD_PAUSE(nullptr);
+	result_errorcode = dos.return_code;
+}
+
+void PLACEHOLDER_ProgramStart(Program **make)
+{
+	*make = new PLACEHOLDER;
+}

--- a/src/dos/program_placeholder.h
+++ b/src/dos/program_placeholder.h
@@ -1,0 +1,33 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PROGRAM_PLACEHOLDER_H
+#define DOSBOX_PROGRAM_PLACEHOLDER_H
+
+#include "programs.h"
+
+class PLACEHOLDER final : public Program {
+public:
+	void Run();
+};
+
+void PLACEHOLDER_ProgramStart(Program **make);
+
+#endif

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -801,8 +801,10 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_LS_PATH_ERR",
 	        "ls: cannot access '%s': No such file or directory\n");
 
-	MSG_Add("SHELL_CMD_CHOICE_HELP","Waits for a keypress and sets ERRORLEVEL.\n");
-	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG","CHOICE [/C:choices] [/N] [/S] text\n"
+	MSG_Add("SHELL_CMD_CHOICE_HELP",
+	        "Waits for a keypress and sets ERRORLEVEL.\n");
+	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG",
+	        "CHOICE [/C:choices] [/N] [/S] text\n"
 	        "  /C[:]choices  -  Specifies allowable keys.  Default is: yn.\n"
 	        "  /N  -  Do not display the choices at end of prompt.\n"
 	        "  /S  -  Enables case-sensitive choices to be selected.\n"

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -319,6 +319,7 @@
     <ClCompile Include="..\src\dos\program_mem.cpp" />
     <ClCompile Include="..\src\dos\program_mount_common.cpp" />
     <ClCompile Include="..\src\dos\program_mount.cpp" />
+    <ClCompile Include="..\src\dos\program_placeholder.cpp" />
     <ClCompile Include="..\src\dos\program_rescan.cpp" />
     <ClCompile Include="..\src\fpu\fpu.cpp" />
     <ClCompile Include="..\src\gui\render.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -424,6 +424,9 @@
     <ClCompile Include="..\src\dos\program_ls.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_placeholder.cpp">
+      <Filter>src\dos</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\misc\fs_utils_win32.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>


### PR DESCRIPTION
Can be used as many times as needed to inform users that a 3rd party program should be acquired and installed.

Any number of programs can be added in `dos_programs`:

``` c++
PROGRAMS_MakeFile("FAVORITE.COM", PLACEHOLDER_ProgramStart);
PROGRAMS_MakeFile("OTHRPROG.COM", PLACEHOLDER_ProgramStart);
PROGRAMS_MakeFile("POPULAR.COM", PLACEHOLDER_ProgramStart);
```

And so on.

Calling the placeholder will pause execution and produce a helpful message both on the DOS console and in the log output:

![2021-09-23_09-19](https://user-images.githubusercontent.com/1557255/134549736-09e80ff1-f60c-4309-bcee-1e7452fe3e8d.png)

Fixes (#1258)

Thank you @Burrito78 for this suggestion!