### PR TITLE
Fix `joysticktype = none` mode and adjust timing calculation

### DIFF
--- a/include/joystick.h
+++ b/include/joystick.h
@@ -21,21 +21,21 @@
 
 #include "dosbox.h"
 
-void JOYSTICK_Enable(Bitu which,bool enabled);
+void JOYSTICK_Enable(uint8_t which, bool enabled);
 
-void JOYSTICK_Button(Bitu which,Bitu num,bool pressed);
+void JOYSTICK_Button(uint8_t which, int num, bool pressed);
 
-void JOYSTICK_Move_X(Bitu which,float x);
+// takes in the joystick axis absolute value from -32768 to 32767
+void JOYSTICK_Move_X(uint8_t which, int16_t x_val);
+void JOYSTICK_Move_Y(uint8_t which, int16_t y_val);
 
-void JOYSTICK_Move_Y(Bitu which,float y);
+bool JOYSTICK_IsEnabled(uint8_t which);
 
-bool JOYSTICK_IsEnabled(Bitu which);
+bool JOYSTICK_GetButton(uint8_t which, int num);
 
-bool JOYSTICK_GetButton(Bitu which, Bitu num);
-
-float JOYSTICK_GetMove_X(Bitu which);
-
-float JOYSTICK_GetMove_Y(Bitu which);
+// returns a percentage from -1.0 to +1.0 along the axis
+double JOYSTICK_GetMove_X(uint8_t which);
+double JOYSTICK_GetMove_Y(uint8_t which);
 
 void JOYSTICK_ParseConfiguredType();
 

--- a/include/joystick.h
+++ b/include/joystick.h
@@ -29,7 +29,7 @@ void JOYSTICK_Button(uint8_t which, int num, bool pressed);
 void JOYSTICK_Move_X(uint8_t which, int16_t x_val);
 void JOYSTICK_Move_Y(uint8_t which, int16_t y_val);
 
-bool JOYSTICK_IsEnabled(uint8_t which);
+bool JOYSTICK_IsAccessible(uint8_t which);
 
 bool JOYSTICK_GetButton(uint8_t which, int num);
 
@@ -40,15 +40,16 @@ double JOYSTICK_GetMove_Y(uint8_t which);
 void JOYSTICK_ParseConfiguredType();
 
 enum JoystickType {
-	JOY_UNSET,
-	JOY_DISABLED, // joystick subsystem is fully disabled (won't even query)
-	JOY_NONE,     // joystick subsystem will be available for mapping only
-	JOY_AUTO,
-	JOY_2AXIS,
-	JOY_4AXIS,
-	JOY_4AXIS_2,
-	JOY_FCS,
-	JOY_CH
+	JOY_UNSET = 1 << 0,
+	JOY_NONE_FOUND = 1 << 1,       // Not a conf option; only set during auto-setup
+	JOY_DISABLED = 1 << 2,         // SDL's joystick subsystem left uninitialized
+	JOY_ONLY_FOR_MAPPING = 1 << 3, // Hidden from DOS, but still mappable
+	JOY_AUTO = 1 << 4,             // Specific type is determined during auto-setup
+	JOY_2AXIS = 1 << 5,
+	JOY_4AXIS = 1 << 6,
+	JOY_4AXIS_2 = 1 << 7,
+	JOY_FCS = 1 << 8,
+	JOY_CH = 1 << 9,
 };
 
 extern JoystickType joytype;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -856,19 +856,19 @@ void DOSBOX_Init(void) {
 	secprop->AddInitFunction(&MOUSE_Init); //Must be after int10 as it uses CurMode
 	secprop->AddInitFunction(&JOYSTICK_Init,true);
 	const char *joytypes[] = {"auto", "2axis", "4axis",    "4axis_2", "fcs",
-	                          "ch",   "none",  "disabled", 0};
+	                          "ch",   "hidden",  "disabled", 0};
 	Pstring = secprop->Add_string("joysticktype", when_idle, "auto");
 	Pstring->Set_values(joytypes);
 	Pstring->Set_help(
 	        "Type of joystick to emulate: auto (default),\n"
-	        "auto    : Detect and use any joystick(s), if possible.,\n"
-	        "2axis   : Support up to two joysticks.\n"
-	        "4axis   : Support the first joystick only.\n"
-	        "4axis_2 : support the second joystick only.\n"
-	        "fcs     : support a Thrustmaster-type joystick.\n"
-	        "ch      : support a CH Flightstick-type joystick.\n"
-	        "none    : Prevent DOS from seeing the joystick(s), but enable them for mapping.\n"
-	        "disabled: Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
+	        "auto     : Detect and use any joystick(s), if possible.,\n"
+	        "2axis    : Support up to two joysticks.\n"
+	        "4axis    : Support the first joystick only.\n"
+	        "4axis_2  : Support the second joystick only.\n"
+	        "fcs      : Support a Thrustmaster-type joystick.\n"
+	        "ch       : Support a CH Flightstick-type joystick.\n"
+	        "hidden   : Prevent DOS from seeing the joystick(s), but enable them for mapping.\n"
+	        "disabled : Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
 	        "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
 
 	Pbool = secprop->Add_bool("timed", when_idle, true);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -554,11 +554,12 @@ bool autofire = false;
 
 class CStickBindGroup : public CBindGroup {
 public:
-	CStickBindGroup(int _stick, Bitu _emustick, bool _dummy=false)
-		: CBindGroup(),
-		  stick(_stick), // the number of the physical device (SDL numbering)
-		  emustick(_emustick), // the number of the emulated device
-		  is_dummy(_dummy)
+	CStickBindGroup(int _stick, uint8_t _emustick, bool _dummy = false)
+	        : CBindGroup(),
+	          stick(_stick),       // the number of the physical device (SDL
+	                               // numbering)
+	          emustick(_emustick), // the number of the emulated device
+	          is_dummy(_dummy)
 	{
 		sprintf(configname, "stick_%u", static_cast<unsigned>(emustick));
 		if (is_dummy)
@@ -835,7 +836,7 @@ private:
 			return nullptr;
 		assert(hat_lists);
 
-		Bitu hat_dir;
+		uint8_t hat_dir;
 		if (value & SDL_HAT_UP)
 			hat_dir = 0;
 		else if (value & SDL_HAT_RIGHT)
@@ -877,7 +878,7 @@ protected:
 	int hats = 0;
 	int emulated_hats = 0;
 	int stick;
-	Bitu emustick;
+	uint8_t emustick;
 	SDL_Joystick *sdl_joystick = nullptr;
 	char configname[10];
 	unsigned button_autofire[MAXBUTTON] = {};
@@ -892,11 +893,13 @@ std::list<CStickBindGroup *> stickbindgroups;
 
 class C4AxisBindGroup final : public  CStickBindGroup {
 public:
-	C4AxisBindGroup(Bitu _stick,Bitu _emustick) : CStickBindGroup (_stick,_emustick){
-		emulated_axes=4;
-		emulated_buttons=4;
-		if (button_wrapping_enabled) button_wrap=emulated_buttons;
-		JOYSTICK_Enable(1,true);
+	C4AxisBindGroup(uint8_t _stick, uint8_t _emustick) : CStickBindGroup(_stick, _emustick)
+	{
+		emulated_axes = 4;
+		emulated_buttons = 4;
+		if (button_wrapping_enabled)
+			button_wrap = emulated_buttons;
+		JOYSTICK_Enable(1, true);
 	}
 
 	bool CheckEvent(SDL_Event * event) {
@@ -937,7 +940,7 @@ public:
 			if (virtual_joysticks[0].button_pressed[i])
 				button_pressed[i % button_wrap]=true;
 		}
-		for (int i = 0; i < emulated_buttons; i++) {
+		for (uint8_t i = 0; i < emulated_buttons; ++i) {
 			if (autofire && (button_pressed[i]))
 				JOYSTICK_Button(i>>1,i&1,(++button_autofire[i])&1);
 			else
@@ -953,15 +956,14 @@ public:
 
 class CFCSBindGroup final : public  CStickBindGroup {
 public:
-	CFCSBindGroup(Bitu _stick, Bitu _emustick)
-		: CStickBindGroup(_stick, _emustick)
+	CFCSBindGroup(uint8_t _stick, uint8_t _emustick) : CStickBindGroup(_stick, _emustick)
 	{
 		emulated_axes=4;
 		emulated_buttons=4;
 		emulated_hats=1;
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
 		JOYSTICK_Enable(1,true);
-		JOYSTICK_Move_Y(1,1.0);
+		JOYSTICK_Move_Y(1, INT16_MAX);
 	}
 
 	bool CheckEvent(SDL_Event * event) {
@@ -1005,13 +1007,13 @@ public:
 		ActivateJoystickBoundEvents();
 
 		bool button_pressed[MAXBUTTON];
-		for (int i = 0; i < MAXBUTTON; i++)
+		for (uint8_t i = 0; i < MAXBUTTON; i++)
 			button_pressed[i] = false;
-		for (int i = 0; i < MAX_VJOY_BUTTONS; i++) {
+		for (uint8_t i = 0; i < MAX_VJOY_BUTTONS; i++) {
 			if (virtual_joysticks[0].button_pressed[i])
 				button_pressed[i % button_wrap]=true;
 		}
-		for (int i = 0; i < emulated_buttons; i++) {
+		for (uint8_t i = 0; i < emulated_buttons; i++) {
 			if (autofire && (button_pressed[i]))
 				JOYSTICK_Button(i>>1,i&1,(++button_autofire[i])&1);
 			else
@@ -1081,8 +1083,7 @@ private:
 
 class CCHBindGroup final : public CStickBindGroup {
 public:
-	CCHBindGroup(Bitu _stick, Bitu _emustick)
-		: CStickBindGroup(_stick, _emustick)
+	CCHBindGroup(uint8_t _stick, uint8_t _emustick) : CStickBindGroup(_stick, _emustick)
 	{
 		emulated_axes=4;
 		emulated_buttons=6;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -685,31 +685,30 @@ public:
 
 	virtual bool CheckEvent(SDL_Event * event) {
 		SDL_JoyAxisEvent * jaxis = NULL;
-		SDL_JoyButtonEvent * jbutton = NULL;
-		Bitu but = 0;
+		SDL_JoyButtonEvent *jbutton = NULL;
 
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
 				if(jaxis->which == stick) {
 					if(jaxis->axis == 0)
-						JOYSTICK_Move_X(emustick,(float)(jaxis->value/32768.0));
-					else if(jaxis->axis == 1)
-						JOYSTICK_Move_Y(emustick,(float)(jaxis->value/32768.0));
+						JOYSTICK_Move_X(emustick, jaxis->value);
+					else if (jaxis->axis == 1)
+						JOYSTICK_Move_Y(emustick, jaxis->value);
 				}
 				break;
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
 				jbutton = &event->jbutton;
 				bool state;
-				state=jbutton->type==SDL_JOYBUTTONDOWN;
-				but = jbutton->button % emulated_buttons;
+				state = jbutton->type == SDL_JOYBUTTONDOWN;
+				const auto but = check_cast<uint8_t>(jbutton->button % emulated_buttons);
 				if (jbutton->which == stick) {
-					JOYSTICK_Button(emustick,but,state);
+					JOYSTICK_Button(emustick, but, state);
 				}
 				break;
-		}
-		return false;
+			}
+			return false;
 	}
 
 	virtual void UpdateJoystick() {
@@ -730,8 +729,8 @@ public:
 				JOYSTICK_Button(emustick,i,button_pressed[i]);
 		}
 
-		JOYSTICK_Move_X(emustick,((float)virtual_joysticks[emustick].axis_pos[0])/32768.0f);
-		JOYSTICK_Move_Y(emustick,((float)virtual_joysticks[emustick].axis_pos[1])/32768.0f);
+		JOYSTICK_Move_X(emustick, virtual_joysticks[emustick].axis_pos[0]);
+		JOYSTICK_Move_Y(emustick, virtual_joysticks[emustick].axis_pos[1]);
 	}
 
 	void ActivateJoystickBoundEvents() {
@@ -902,27 +901,26 @@ public:
 
 	bool CheckEvent(SDL_Event * event) {
 		SDL_JoyAxisEvent * jaxis = NULL;
-		SDL_JoyButtonEvent * jbutton = NULL;
-		Bitu but = 0;
+		SDL_JoyButtonEvent *jbutton = NULL;
 
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
 				if(jaxis->which == stick && jaxis->axis < 4) {
 					if(jaxis->axis & 1)
-						JOYSTICK_Move_Y(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
+						JOYSTICK_Move_Y(jaxis->axis >> 1 & 1, jaxis->value);
 					else
-						JOYSTICK_Move_X(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
-				}
-				break;
+						JOYSTICK_Move_X(jaxis->axis >> 1 & 1, jaxis->value);
+		        }
+		        break;
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
 				jbutton = &event->jbutton;
 				bool state;
-				state=jbutton->type==SDL_JOYBUTTONDOWN;
-				but = jbutton->button % emulated_buttons;
+				state = jbutton->type == SDL_JOYBUTTONDOWN;
+				const auto but = check_cast<uint8_t>(jbutton->button % emulated_buttons);
 				if (jbutton->which == stick) {
-					JOYSTICK_Button((but >> 1),(but & 1),state);
+					JOYSTICK_Button((but >> 1), (but & 1), state);
 				}
 				break;
 		}
@@ -946,10 +944,10 @@ public:
 				JOYSTICK_Button(i>>1,i&1,button_pressed[i]);
 		}
 
-		JOYSTICK_Move_X(0,((float)virtual_joysticks[0].axis_pos[0])/32768.0f);
-		JOYSTICK_Move_Y(0,((float)virtual_joysticks[0].axis_pos[1])/32768.0f);
-		JOYSTICK_Move_X(1,((float)virtual_joysticks[0].axis_pos[2])/32768.0f);
-		JOYSTICK_Move_Y(1,((float)virtual_joysticks[0].axis_pos[3])/32768.0f);
+		JOYSTICK_Move_X(0, virtual_joysticks[0].axis_pos[0]);
+		JOYSTICK_Move_Y(0, virtual_joysticks[0].axis_pos[1]);
+		JOYSTICK_Move_X(1, virtual_joysticks[0].axis_pos[2]);
+		JOYSTICK_Move_Y(1, virtual_joysticks[0].axis_pos[3]);
 	}
 };
 
@@ -969,33 +967,33 @@ public:
 	bool CheckEvent(SDL_Event * event) {
 		SDL_JoyAxisEvent * jaxis = NULL;
 		SDL_JoyButtonEvent * jbutton = NULL;
-		SDL_JoyHatEvent * jhat = NULL;
-		Bitu but = 0;
+		SDL_JoyHatEvent *jhat = NULL;
 
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
 				if(jaxis->which == stick) {
 					if(jaxis->axis == 0)
-						JOYSTICK_Move_X(0,(float)(jaxis->value/32768.0));
-					else if(jaxis->axis == 1)
-						JOYSTICK_Move_Y(0,(float)(jaxis->value/32768.0));
-					else if(jaxis->axis == 2)
-						JOYSTICK_Move_X(1,(float)(jaxis->value/32768.0));
+						JOYSTICK_Move_X(0, jaxis->value);
+					else if (jaxis->axis == 1)
+						JOYSTICK_Move_Y(0, jaxis->value);
+					else if (jaxis->axis == 2)
+						JOYSTICK_Move_X(1, jaxis->value);
 				}
 				break;
 			case SDL_JOYHATMOTION:
 				jhat = &event->jhat;
-				if(jhat->which == stick) DecodeHatPosition(jhat->value);
+				if (jhat->which == stick)
+					DecodeHatPosition(jhat->value);
 				break;
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
 				jbutton = &event->jbutton;
-				bool state;
-				state=jbutton->type==SDL_JOYBUTTONDOWN;
-				but = jbutton->button % emulated_buttons;
+			bool state;
+			state=jbutton->type==SDL_JOYBUTTONDOWN;
+				const auto but = check_cast<uint8_t>(jbutton->button % emulated_buttons);
 				if (jbutton->which == stick) {
-						JOYSTICK_Button((but >> 1),(but & 1),state);
+					JOYSTICK_Button((but >> 1), (but & 1), state);
 				}
 				break;
 		}
@@ -1020,9 +1018,9 @@ public:
 				JOYSTICK_Button(i>>1,i&1,button_pressed[i]);
 		}
 
-		JOYSTICK_Move_X(0,((float)virtual_joysticks[0].axis_pos[0])/32768.0f);
-		JOYSTICK_Move_Y(0,((float)virtual_joysticks[0].axis_pos[1])/32768.0f);
-		JOYSTICK_Move_X(1,((float)virtual_joysticks[0].axis_pos[2])/32768.0f);
+		JOYSTICK_Move_X(0, virtual_joysticks[0].axis_pos[0]);
+		JOYSTICK_Move_Y(0, virtual_joysticks[0].axis_pos[1]);
+		JOYSTICK_Move_X(1, virtual_joysticks[0].axis_pos[2]);
 
 		Uint8 hat_pos=0;
 		if (virtual_joysticks[0].hat_pressed[0]) hat_pos|=SDL_HAT_UP;
@@ -1040,46 +1038,43 @@ private:
 	uint8_t old_hat_position = 0;
 
 	void DecodeHatPosition(Uint8 hat_pos) {
-		switch(hat_pos) {
-			case SDL_HAT_CENTERED:
-				JOYSTICK_Move_Y(1,1.0);
-				break;
-			case SDL_HAT_UP:
-				JOYSTICK_Move_Y(1,-1.0);
-				break;
-			case SDL_HAT_RIGHT:
-				JOYSTICK_Move_Y(1,-0.5);
-				break;
-			case SDL_HAT_DOWN:
-				JOYSTICK_Move_Y(1,0.0);
-				break;
-			case SDL_HAT_LEFT:
-				JOYSTICK_Move_Y(1,0.5);
-				break;
-			case SDL_HAT_LEFTUP:
-				if(JOYSTICK_GetMove_Y(1) < 0)
-					JOYSTICK_Move_Y(1,0.5);
-				else
-					JOYSTICK_Move_Y(1,-1.0);
-				break;
-			case SDL_HAT_RIGHTUP:
-				if(JOYSTICK_GetMove_Y(1) < -0.7)
-					JOYSTICK_Move_Y(1,-0.5);
-				else
-					JOYSTICK_Move_Y(1,-1.0);
-				break;
-			case SDL_HAT_RIGHTDOWN:
-				if(JOYSTICK_GetMove_Y(1) < -0.2)
-					JOYSTICK_Move_Y(1,0.0);
-				else
-					JOYSTICK_Move_Y(1,-0.5);
-				break;
-			case SDL_HAT_LEFTDOWN:
-				if(JOYSTICK_GetMove_Y(1) > 0.2)
-					JOYSTICK_Move_Y(1,0.0);
-				else
-					JOYSTICK_Move_Y(1,0.5);
-				break;
+		// Common joystick positions
+		constexpr int16_t joy_centered = 0;
+		constexpr int16_t joy_full_negative = INT16_MIN;
+		constexpr int16_t joy_full_positive = INT16_MAX;
+		constexpr int16_t joy_50pct_negative = static_cast<int16_t>(INT16_MIN / 2);
+		constexpr int16_t joy_50pct_positive = static_cast<int16_t>(INT16_MAX / 2);
+
+		switch (hat_pos) {
+		case SDL_HAT_CENTERED: JOYSTICK_Move_Y(1, joy_full_positive); break;
+		case SDL_HAT_UP: JOYSTICK_Move_Y(1, joy_full_negative); break;
+		case SDL_HAT_RIGHT: JOYSTICK_Move_Y(1, joy_50pct_negative); break;
+		case SDL_HAT_DOWN: JOYSTICK_Move_Y(1, joy_centered); break;
+		case SDL_HAT_LEFT: JOYSTICK_Move_Y(1, joy_50pct_positive); break;
+		case SDL_HAT_LEFTUP:
+			if (JOYSTICK_GetMove_Y(1) < 0)
+				JOYSTICK_Move_Y(1, joy_50pct_positive);
+			else
+				JOYSTICK_Move_Y(1, joy_full_negative);
+			break;
+		case SDL_HAT_RIGHTUP:
+			if (JOYSTICK_GetMove_Y(1) < -0.7)
+				JOYSTICK_Move_Y(1, joy_50pct_negative);
+			else
+				JOYSTICK_Move_Y(1, joy_full_negative);
+			break;
+		case SDL_HAT_RIGHTDOWN:
+			if (JOYSTICK_GetMove_Y(1) < -0.2)
+				JOYSTICK_Move_Y(1, joy_centered);
+			else
+				JOYSTICK_Move_Y(1, joy_50pct_negative);
+			break;
+		case SDL_HAT_LEFTDOWN:
+			if (JOYSTICK_GetMove_Y(1) > 0.2)
+				JOYSTICK_Move_Y(1, joy_centered);
+			else
+				JOYSTICK_Move_Y(1, joy_50pct_positive);
+			break;
 		}
 	}
 };
@@ -1109,17 +1104,17 @@ public:
 				jaxis = &event->jaxis;
 				if(jaxis->which == stick && jaxis->axis < 4) {
 					if(jaxis->axis & 1)
-						JOYSTICK_Move_Y(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
+						JOYSTICK_Move_Y(jaxis->axis >> 1 & 1, jaxis->value);
 					else
-						JOYSTICK_Move_X(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
+						JOYSTICK_Move_X(jaxis->axis >> 1 & 1, jaxis->value);
 				}
 				break;
 			case SDL_JOYHATMOTION:
 				jhat = &event->jhat;
-				if(jhat->which == stick && jhat->hat < 2) {
-					if(jhat->value == SDL_HAT_CENTERED)
-						button_state&=~hat_magic[jhat->hat][0];
-					if(jhat->value & SDL_HAT_UP)
+				if (jhat->which == stick && jhat->hat < 2) {
+					if (jhat->value == SDL_HAT_CENTERED)
+						button_state &= ~hat_magic[jhat->hat][0];
+					if (jhat->value & SDL_HAT_UP)
 						button_state|=hat_magic[jhat->hat][1];
 					if(jhat->value & SDL_HAT_RIGHT)
 						button_state|=hat_magic[jhat->hat][2];
@@ -1161,10 +1156,10 @@ public:
 		/* query SDL joystick and activate bindings */
 		ActivateJoystickBoundEvents();
 
-		JOYSTICK_Move_X(0,((float)virtual_joysticks[0].axis_pos[0])/32768.0f);
-		JOYSTICK_Move_Y(0,((float)virtual_joysticks[0].axis_pos[1])/32768.0f);
-		JOYSTICK_Move_X(1,((float)virtual_joysticks[0].axis_pos[2])/32768.0f);
-		JOYSTICK_Move_Y(1,((float)virtual_joysticks[0].axis_pos[3])/32768.0f);
+		JOYSTICK_Move_X(0, virtual_joysticks[0].axis_pos[0]);
+		JOYSTICK_Move_Y(0, virtual_joysticks[0].axis_pos[1]);
+		JOYSTICK_Move_X(1, virtual_joysticks[0].axis_pos[2]);
+		JOYSTICK_Move_Y(1, virtual_joysticks[0].axis_pos[3]);
 
 		Bitu bt_state=15;
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -723,7 +723,7 @@ public:
 			if (virtual_joysticks[emustick].button_pressed[i])
 				button_pressed[i % button_wrap]=true;
 		}
-		for (int i = 0; i < emulated_buttons; i++) {
+		for (uint8_t i = 0; i < emulated_buttons; i++) {
 			if (autofire && (button_pressed[i]))
 				JOYSTICK_Button(emustick,i,(++button_autofire[i])&1);
 			else
@@ -874,7 +874,7 @@ protected:
 	int buttons = 0;
 	int button_cap = 0;
 	int button_wrap = 0;
-	int emulated_buttons = 0;
+	uint8_t emulated_buttons = 0;
 	int hats = 0;
 	int emulated_hats = 0;
 	int stick;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -233,12 +233,16 @@ static void write_p201(io_port_t, io_val_t, io_width_t)
 	last_write = PIC_Ticks;
 	if (stick[0].enabled) {
 		stick[0].transform_input();
-		stick[0].xcount=(Bitu)((stick[0].xfinal*RANGE)+RANGE);
-		stick[0].ycount=(Bitu)((stick[0].yfinal*RANGE)+RANGE);
+		stick[0].xcount = check_cast<uint32_t>(
+		        static_cast<int64_t>(stick[0].xfinal * RANGE + RANGE));
+		stick[0].ycount = check_cast<uint32_t>(
+		        static_cast<int64_t>(stick[0].yfinal * RANGE + RANGE));
 	}
 	if (stick[1].enabled) {
-		stick[1].xcount=(Bitu)(((swap34? stick[1].ypos : stick[1].xpos)*RANGE)+RANGE);
-		stick[1].ycount=(Bitu)(((swap34? stick[1].xpos : stick[1].ypos)*RANGE)+RANGE);
+		stick[1].xcount = check_cast<uint32_t>(static_cast<int64_t>(
+		        (swap34 ? stick[1].ypos : stick[1].xpos) * RANGE + RANGE));
+		stick[1].ycount = check_cast<uint32_t>(static_cast<int64_t>(
+		        (swap34 ? stick[1].xpos : stick[1].ypos) * RANGE + RANGE));
 	}
 }
 static void write_p201_timed(io_port_t, io_val_t, io_width_t)

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -158,7 +158,7 @@ struct JoyStick {
 JoystickType joytype = JOY_UNSET;
 static JoyStick stick[2];
 
-static Bitu last_write = 0;
+static uint32_t last_write = 0;
 static bool write_active = false;
 static bool swap34 = false;
 bool button_wrapping_enabled = true;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -60,12 +60,18 @@ struct JoyStick {
 	}
 
 	void fake_digital() {
-		if (xpos > 0.5f) xfinal = 1.0f;
-		else if (xpos < -0.5f) xfinal = -1.0f;
-		else xfinal = 0.0f;
-		if (ypos > 0.5f) yfinal = 1.0f;
-		else if (ypos < -0.5f) yfinal = -1.0f;
-		else yfinal = 0.0f;
+		if (xpos > 0.5)
+			xfinal = 1.0;
+		else if (xpos < -0.5)
+			xfinal = -1.0;
+		else
+			xfinal = 0.0;
+		if (ypos > 0.5)
+			yfinal = 1.0;
+		else if (ypos < -0.5)
+			yfinal = -1.0;
+		else
+			yfinal = 0.0;
 	}
 
 	void transform_circular(){

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -275,49 +275,83 @@ static void write_p201_timed(io_port_t, io_val_t, io_width_t)
 	}
 }
 
-void JOYSTICK_Enable(Bitu which,bool enabled) {
-	if (which<2) stick[which].enabled = enabled;
+void JOYSTICK_Enable(uint8_t which, bool enabled)
+{
+	if (which < 2)
+		stick[which].enabled = enabled;
 }
 
-void JOYSTICK_Button(Bitu which,Bitu num,bool pressed) {
-	if ((which<2) && (num<2)) stick[which].button[num] = pressed;
+void JOYSTICK_Button(uint8_t which, int num, bool pressed)
+{
+	if ((which < 2) && (num < 2))
+		stick[which].button[num] = pressed;
 }
 
-void JOYSTICK_Move_X(Bitu which,float x) {
-	if (which > 1) return;
-	if (stick[which].xpos == x) return;
+constexpr double position_to_percent(int16_t val)
+{
+	// SDL's joystick axis value ranges from -32768 to 32767
+	return val / (val > 0 ? 32767.0 : 32768.0);
+}
+
+void JOYSTICK_Move_X(uint8_t which, int16_t x_val)
+{
+	if (which > 1)
+		return;
+
+	const auto x = position_to_percent(x_val);
+	if (stick[which].xpos == x)
+		return;
 	stick[which].xpos = x;
 	stick[which].transformed = false;
 //	if( which == 0 || joytype != JOY_FCS)  
-//		stick[which].applied_conversion; //todo 
+//		stick[which].applied_conversion; //todo
 }
 
-void JOYSTICK_Move_Y(Bitu which,float y) {
-	if (which > 1) return;
-	if (stick[which].ypos == y) return;
+void JOYSTICK_Move_Y(uint8_t which, int16_t y_val)
+{
+	if (which > 1)
+		return;
+
+	const auto y = position_to_percent(y_val);
+	if (stick[which].ypos == y)
+		return;
 	stick[which].ypos = y;
 	stick[which].transformed = false;
 }
 
-bool JOYSTICK_IsEnabled(Bitu which) {
-	if (which<2) return stick[which].enabled;
+bool JOYSTICK_IsEnabled(uint8_t which)
+{
+	if (which < 2)
+		return stick[which].enabled;
 	return false;
 }
 
-bool JOYSTICK_GetButton(Bitu which, Bitu num) {
-	if ((which<2) && (num<2)) return stick[which].button[num];
+bool JOYSTICK_GetButton(uint8_t which, int num)
+{
+	if ((which < 2) && (num < 2))
+		return stick[which].button[num];
 	return false;
 }
 
-float JOYSTICK_GetMove_X(Bitu which) {
-	if (which > 1) return 0.0f;
-	if (which == 0) { stick[0].transform_input(); return stick[0].xfinal;}
+double JOYSTICK_GetMove_X(uint8_t which)
+{
+	if (which > 1)
+		return 0.0;
+	if (which == 0) {
+		stick[0].transform_input();
+		return stick[0].xfinal;
+	}
 	return stick[1].xpos;
 }
 
-float JOYSTICK_GetMove_Y(Bitu which) {
-	if (which > 1) return 0.0f;
-	if (which == 0) { stick[0].transform_input(); return stick[0].yfinal;}
+double JOYSTICK_GetMove_Y(uint8_t which)
+{
+	if (which > 1)
+		return 0.0;
+	if (which == 0) {
+		stick[0].transform_input();
+		return stick[0].yfinal;
+	}
 	return stick[1].ypos;
 }
 

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -32,8 +32,8 @@
 //Set to true, to enable automated switching back to square on circle mode if the inputs are outside the cirle.
 #define SUPPORT_MAP_AUTO 0
 
-#define RANGE 64
-#define TIMEOUT 10
+constexpr int RANGE = 64;
+constexpr int TIMEOUT = 10;
 
 struct JoyStick {
 	enum {JOYMAP_SQUARE,JOYMAP_CIRCLE,JOYMAP_INBETWEEN} mapstate;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -51,8 +51,8 @@ struct JoyStick {
 	double xfinal = 0.0;
 	double yfinal = 0.0; // position returned to the game for stick 0
 
-	uint32_t xcount = 0;
-	uint32_t ycount = 0;
+	uint8_t xcount = 0;
+	uint8_t ycount = 0;
 
 	int deadzone = 0; // Deadzone (value between 0 and 100) interpreted as percentage
 	enum MovementType mapstate = JOYMAP_SQUARE;
@@ -232,18 +232,23 @@ static void write_p201(io_port_t, io_val_t, io_width_t)
 	/* Store writetime index */
 	write_active = true;
 	last_write = PIC_Ticks;
+
+	auto percent_to_count = [](auto percent) -> uint8_t {
+		const auto scaled = static_cast<int>(round(percent * RANGE));
+		const auto shifted = check_cast<uint8_t>(scaled + RANGE);
+		return shifted;
+	};
+
 	if (stick[0].enabled) {
 		stick[0].transform_input();
-		stick[0].xcount = check_cast<uint32_t>(
-		        static_cast<int64_t>(stick[0].xfinal * RANGE + RANGE));
-		stick[0].ycount = check_cast<uint32_t>(
-		        static_cast<int64_t>(stick[0].yfinal * RANGE + RANGE));
+		stick[0].xcount = percent_to_count(stick[0].xfinal);
+		stick[0].ycount = percent_to_count(stick[0].yfinal);
 	}
 	if (stick[1].enabled) {
-		stick[1].xcount = check_cast<uint32_t>(static_cast<int64_t>(
-		        (swap34 ? stick[1].ypos : stick[1].xpos) * RANGE + RANGE));
-		stick[1].ycount = check_cast<uint32_t>(static_cast<int64_t>(
-		        (swap34 ? stick[1].xpos : stick[1].ypos) * RANGE + RANGE));
+		stick[1].xcount = percent_to_count(swap34 ? stick[1].ypos
+		                                          : stick[1].xpos);
+		stick[1].ycount = percent_to_count(swap34 ? stick[1].xpos
+		                                          : stick[1].ypos);
 	}
 }
 static void write_p201_timed(io_port_t, io_val_t, io_width_t)

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -421,9 +421,10 @@ public:
 		stick[1].ypos = 0.0;
 		stick[0].transformed = false;
 
-		// Does the user want joysticks to be available for mapping, but hidden in DOS?
-		// Then we switch it to auto, but skip setting up the joystick handlers to
-		// prevent DOS programs from seeing the joystick.
+		// Does the user want joysticks to be available for mapping, but
+		// hidden in DOS? Then we switch it to auto, but skip setting up
+		// the joystick handlers to prevent DOS programs from seeing the
+		// joystick.
 		if (joytype == JOY_NONE) {
 			joytype = JOY_AUTO;
 			return;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -302,14 +302,15 @@ static void write_p201_timed(io_port_t, io_val_t, io_width_t)
 
 void JOYSTICK_Enable(uint8_t which, bool enabled)
 {
-	if (which < 2)
-		stick[which].enabled = enabled;
+	assert(which < 2);
+	stick[which].enabled = enabled;
 }
 
 void JOYSTICK_Button(uint8_t which, int num, bool pressed)
 {
-	if ((which < 2) && (num < 2))
-		stick[which].button[num] = pressed;
+	assert(which < 2);
+	assert(num < 2);
+	stick[which].button[num] = pressed;
 }
 
 constexpr double position_to_percent(int16_t val)
@@ -320,8 +321,7 @@ constexpr double position_to_percent(int16_t val)
 
 void JOYSTICK_Move_X(uint8_t which, int16_t x_val)
 {
-	if (which > 1)
-		return;
+	assert(which < 2);
 
 	const auto x = position_to_percent(x_val);
 	if (stick[which].xpos == x)
@@ -334,9 +334,7 @@ void JOYSTICK_Move_X(uint8_t which, int16_t x_val)
 
 void JOYSTICK_Move_Y(uint8_t which, int16_t y_val)
 {
-	if (which > 1)
-		return;
-
+	assert(which < 2);
 	const auto y = position_to_percent(y_val);
 	if (stick[which].ypos == y)
 		return;
@@ -347,21 +345,20 @@ void JOYSTICK_Move_Y(uint8_t which, int16_t y_val)
 bool JOYSTICK_IsAccessible(uint8_t which)
 {
 	assert(which < 2);
-	const auto& s = stick[which];
+	const auto &s = stick[which];
 	return s.is_visible_to_dos && s.enabled;
 }
 
 bool JOYSTICK_GetButton(uint8_t which, int num)
 {
-	if ((which < 2) && (num < 2))
-		return stick[which].button[num];
-	return false;
+	assert(which < 2);
+	assert(num < 2);
+	return stick[which].button[num];
 }
 
 double JOYSTICK_GetMove_X(uint8_t which)
 {
-	if (which > 1)
-		return 0.0;
+	assert(which < 2);
 	if (which == 0) {
 		stick[0].transform_input();
 		return stick[0].xfinal;
@@ -371,8 +368,7 @@ double JOYSTICK_GetMove_X(uint8_t which)
 
 double JOYSTICK_GetMove_Y(uint8_t which)
 {
-	if (which > 1)
-		return 0.0;
+	assert(which < 2);
 	if (which == 0) {
 		stick[0].transform_input();
 		return stick[0].yfinal;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -35,8 +35,13 @@
 constexpr int RANGE = 64;
 constexpr int TIMEOUT = 10;
 
+enum MovementType {
+	JOYMAP_SQUARE,
+	JOYMAP_CIRCLE,
+	JOYMAP_INBETWEEN,
+};
+
 struct JoyStick {
-	enum {JOYMAP_SQUARE,JOYMAP_CIRCLE,JOYMAP_INBETWEEN} mapstate;
 	double xpos = 0.0;
 	double ypos = 0.0; // position as set by SDL
 
@@ -363,9 +368,8 @@ public:
 		button_wrapping_enabled = section->Get_bool("buttonwrap");
 		stick[0].deadzone = section->Get_int("deadzone");
 		swap34 = section->Get_bool("swap34");
-		stick[0].mapstate = section->Get_bool("circularinput")
-		                            ? JoyStick::JOYMAP_CIRCLE
-		                            : JoyStick::JOYMAP_SQUARE;
+		stick[0].mapstate = section->Get_bool("circularinput") ? MovementType::JOYMAP_CIRCLE
+		                                                       : MovementType::JOYMAP_SQUARE;
 
 		// Set initial time and position states
 		const auto ticks = PIC_FullIndex();

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -832,7 +832,7 @@ static Bitu INT15_Handler(void) {
 	case 0x84:	/* BIOS - JOYSTICK SUPPORT (XT after 11/8/82,AT,XT286,PS) */
 		if (reg_dx == 0x0000) {
 			// Get Joystick button status
-			if (JOYSTICK_IsEnabled(0) || JOYSTICK_IsEnabled(1)) {
+			if (JOYSTICK_IsAccessible(0) || JOYSTICK_IsAccessible(1)) {
 				reg_al = IO_ReadB(0x201)&0xf0;
 				CALLBACK_SCF(false);
 			} else {
@@ -841,10 +841,10 @@ static Bitu INT15_Handler(void) {
 				CALLBACK_SCF(true);
 			}
 		} else if (reg_dx == 0x0001) {
-			if (JOYSTICK_IsEnabled(0)) {
+			if (JOYSTICK_IsAccessible(0)) {
 				reg_ax = (Bit16u)(JOYSTICK_GetMove_X(0)*127+128);
 				reg_bx = (Bit16u)(JOYSTICK_GetMove_Y(0)*127+128);
-				if(JOYSTICK_IsEnabled(1)) {
+				if(JOYSTICK_IsAccessible(1)) {
 					reg_cx = (Bit16u)(JOYSTICK_GetMove_X(1)*127+128);
 					reg_dx = (Bit16u)(JOYSTICK_GetMove_Y(1)*127+128);
 				}
@@ -852,7 +852,7 @@ static Bitu INT15_Handler(void) {
 					reg_cx = reg_dx = 0;
 				}
 				CALLBACK_SCF(false);
-			} else if (JOYSTICK_IsEnabled(1)) {
+			} else if (JOYSTICK_IsAccessible(1)) {
 				reg_ax = reg_bx = 0;
 				reg_cx = (Bit16u)(JOYSTICK_GetMove_X(1)*127+128);
 				reg_dx = (Bit16u)(JOYSTICK_GetMove_Y(1)*127+128);


### PR DESCRIPTION
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/1241

`joysticktype = disabled: should report the joystick subsystem is left uninitialized:
``` text
2021-09-27 23:26:59.066 | MAPPER: joystick subsystem disabled
```

`joysticktype = none`: should detect and allow mapping of joystick events to keyboard events, however the joystick will be invisible to DOS programs.  This is useful to prevent some games from auto-using the joystick or beginning a calibration phase on startup when you'd rather use the keyboard/mouse.

`joysticktype = auto`: should behave equal to the existing latest sources.

The timing calculation has been adjusted. 

For example, the baseline numbers produce the following "centred" position in `joycheck` and extents from -99% to +139%
Please download - [joyutils.zip](https://github.com/dosbox-staging/dosbox-staging/files/7241582/joyutils.zip)

![2021-09-27_23-30](https://user-images.githubusercontent.com/1557255/135034970-08e4807b-929e-407e-bf41-d96e3961cfc8.png)

The new timing produces the following centred position and extents from -100% to +99/100%.
![2021-09-27_23-22](https://user-images.githubusercontent.com/1557255/135034210-8c80a04b-7276-426e-a493-0d89b4685114.png)

In theory good calibration will make these differences moot, but perhaps it will help some games.  
I'm also curious if others (with different joysticks) see the same results in joycheck, or if it's just a one-off case with my own joystick.