### PR TITLE
Fix audio issues introduced with push API

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -24,6 +24,7 @@
 
 #include "dosbox.h"
 
+#include <atomic>
 #include <functional>
 
 #include "envelope.h"
@@ -105,7 +106,7 @@ public:
 	float volmain[2] = {0.0f, 0.0f};
 	MixerChannel *next = nullptr;
 	const char *name = nullptr;
-	Bitu done = 0u; // Timing on how many samples have been done by the mixer
+	std::atomic<Bitu> done; // Timing on how many samples have been done by the mixer
 	bool is_enabled = false;
 
 private:

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -52,13 +52,6 @@ struct AudioFrame {
 	float right = 0;
 };
 
-typedef int16_t mixer_sample_t;
-
-struct MixerFrame {
-	mixer_sample_t left = 0;
-	mixer_sample_t right = 0;
-};
-
 #define MIXER_BUFSIZE (16 * 1024)
 #define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
 extern Bit8u MixTemp[MIXER_BUFSIZE];

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -653,18 +653,18 @@ void DOSBOX_Init(void) {
 	Pint->Set_values(rates);
 	Pint->Set_help("Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.");
 
-	Pint = secprop->Add_int("blocksize", deprecated, 1024);
-	Pint->Set_help("This property is deprecated, use latency instead.");
+	const char *blocksizes[] = {
+		 "1024", "2048", "4096", "8192", "512", "256", "128", 0};
+	Pint = secprop->Add_int("blocksize", only_at_start, 512);
+	Pint->Set_values(blocksizes);
+	Pint->Set_help("Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.");
 
-	Pint = secprop->Add_int("prebuffer", deprecated, 25);
-	Pint->Set_help("This property is deprecated, use latency instead.");
-
-	Pint = secprop->Add_int("latency", only_at_start, 15);
-	Pint->SetMinMax(1, 100);
-	Pint->Set_help("Desired audio latency in milliseconds. Range is 1-100.");
+	Pint = secprop->Add_int("prebuffer",only_at_start,20);
+	Pint->SetMinMax(0,100);
+	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
 
 	Pbool = secprop->Add_bool("negotiate", only_at_start, true);
-	Pbool->Set_help("Allow system audio driver to negotiate optimal rate and latency\n"
+	Pbool->Set_help("Allow system audio driver to negotiate optimal rate and blocksize\n"
 	                "as close to the specified values as possible.");
 
 	secprop = control->AddSection_prop("midi", &MIDI_Init, true);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -24,12 +24,10 @@
 #include "mixer.h"
 
 #include <cstdint>
-#include <cstring>
+#include <string.h>
 #include <sys/types.h>
-#include <cmath>
+#include <math.h>
 #include <algorithm>
-#include <array>
-#include <map>
 
 #if defined (WIN32)
 //Midi listing
@@ -54,9 +52,7 @@
 #include "programs.h"
 #include "midi.h"
 
-// The max frames allowed to send to SDL, based on
-// limits for 'rate' and 'latency' in dosbox.conf
-static constexpr int MIXER_QUEUE_MAX_FRAMES = 8192;
+#define MIXER_SSIZE 4
 
 //#define MIXER_SHIFT 14
 //#define MIXER_REMAIN ((1<<MIXER_SHIFT)-1)
@@ -79,11 +75,11 @@ static constexpr int MIXER_QUEUE_MAX_FRAMES = 8192;
 // should the envelope monitor the initial signal? (recommended > 5s)
 #define ENVELOPE_EXPIRES_AFTER_S 10u
 
-static constexpr int16_t MIXER_CLIP(int32_t SAMP)
+static constexpr int16_t MIXER_CLIP(Bits SAMP)
 {
 	if (SAMP < MAX_AUDIO) {
 		if (SAMP > MIN_AUDIO)
-			return SAMP;
+			return static_cast<int16_t>(SAMP);
 		else return MIN_AUDIO;
 	} else return MAX_AUDIO;
 }
@@ -91,9 +87,11 @@ static constexpr int16_t MIXER_CLIP(int32_t SAMP)
 static struct {
 	int32_t work[MIXER_BUFSIZE][2] = {{0}};
 	//Write/Read pointers for the buffer
-	Bitu pos = 0;
-	Bitu done = 0;
-	Bitu needed = 0;
+	Bit32u pos = 0;
+	Bit32u done = 0;
+	Bit32u needed = 0;
+	Bit32u min_needed = 0;
+	Bit32u max_needed = 0;
 	// For every millisecond tick how many samples need to be generated
 	uint32_t tick_add = 0;
 	uint32_t tick_counter = 0;
@@ -101,7 +99,7 @@ static struct {
 	MixerChannel *channels = nullptr;
 	bool nosound = false;
 	uint32_t freq = 0;
-	uint8_t latency = 0;
+	uint16_t blocksize = 0; // matches SDL AudioSpec.samples type
 	// Note: As stated earlier, all sdl code shall rather be in sdlmain
 	SDL_AudioDeviceID sdldevice = {};
 } mixer;
@@ -159,6 +157,16 @@ void MIXER_DelChannel(MixerChannel* delchan) {
 		where=&chan->next;
 		chan=chan->next;
 	}
+}
+
+static void MIXER_LockAudioDevice()
+{
+	SDL_LockAudioDevice(mixer.sdldevice);
+}
+
+static void MIXER_UnlockAudioDevice()
+{
+	SDL_UnlockAudioDevice(mixer.sdldevice);
 }
 
 void MixerChannel::RegisterLevelCallBack(apply_level_callback_f cb)
@@ -234,6 +242,9 @@ void MixerChannel::Enable(const bool should_enable)
 	if (is_enabled == should_enable)
 		return;
 
+	// Lock the channel before changing states
+	MIXER_LockAudioDevice();
+
 	// Prepare the channel to accept samples
 	if (should_enable) {
 		freq_counter = 0u;
@@ -255,6 +266,7 @@ void MixerChannel::Enable(const bool should_enable)
 		next_sample[1] = 0;
 	}
 	is_enabled = should_enable;
+	MIXER_UnlockAudioDevice();
 }
 
 void MixerChannel::SetFreq(Bitu freq)
@@ -295,7 +307,7 @@ void MixerChannel::Mix(Bitu _needed) {
 		Bitu left = (needed - done);
 		left *= freq_add;
 		left  = (left >> FREQ_SHIFT) + ((left & FREQ_MASK)!=0);
-		handler(left);
+		handler(static_cast<uint16_t>(left));
 	}
 }
 
@@ -325,8 +337,8 @@ void MixerChannel::AddSilence()
 				mixpos &= MIXER_BUFMASK;
 				Bit32s* write = mixer.work[mixpos];
 
-				write[0] += prev_sample[0] * volmul[0];
-				write[1] += (stereo ? prev_sample[1] : prev_sample[0]) * volmul[1];
+				write[0] += static_cast<int32_t>(prev_sample[0] * volmul[0]);
+				write[1] += static_cast<int32_t>((stereo ? prev_sample[1] : prev_sample[0]) * volmul[1]);
 
 				prev_sample[0] = next_sample[0];
 				prev_sample[1] = next_sample[1];
@@ -507,17 +519,17 @@ inline void MixerChannel::AddSamples(Bitu len, const Type* data) {
 		mixpos &= MIXER_BUFMASK;
 		Bit32s* write = mixer.work[mixpos];
 		if (!interpolate) {
-			write[0] += prev_sample[left_map] * volmul[0];
-			write[1] += (stereo ? prev_sample[right_map] : prev_sample[left_map]) * volmul[1];
+			write[0] += static_cast<int32_t>(prev_sample[left_map] * volmul[0]);
+			write[1] += static_cast<int32_t>((stereo ? prev_sample[right_map] : prev_sample[left_map]) * volmul[1]);
 		}
 		else {
 			Bits diff_mul = freq_counter & FREQ_MASK;
 			Bits sample = prev_sample[left_map] + (((next_sample[left_map] - prev_sample[left_map]) * diff_mul) >> FREQ_SHIFT);
-			write[0] += sample*volmul[0];
+			write[0] += static_cast<int32_t>(sample*volmul[0]);
 			if (stereo) {
 				sample = prev_sample[right_map] + (((next_sample[right_map] - prev_sample[right_map]) * diff_mul) >> FREQ_SHIFT);
 			}
-			write[1] += sample*volmul[1];
+			write[1] += static_cast<int32_t>(sample*volmul[1]);
 		}
 		//Prepare for next sample
 		freq_counter += freq_add;
@@ -552,8 +564,8 @@ void MixerChannel::AddStretched(Bitu len,Bit16s * data) {
 		index += index_add;
 		mixpos &= MIXER_BUFMASK;
 		Bits sample = prev_sample[0] + ((diff * diff_mul) >> FREQ_SHIFT);
-		mixer.work[mixpos][0] += sample * volmul[0];
-		mixer.work[mixpos][1] += sample * volmul[1];
+		mixer.work[mixpos][0] += static_cast<int32_t>(sample * volmul[0]);
+		mixer.work[mixpos][1] += static_cast<int32_t>(sample * volmul[1]);
 		mixpos++;
 	}
 }
@@ -612,7 +624,9 @@ void MixerChannel::FillUp()
 	if (!is_enabled || done < mixer.done)
 		return;
 	const auto index = PIC_TickIndex();
+	MIXER_LockAudioDevice();
 	Mix((Bitu)(index * static_cast<double>(mixer.needed)));
+	MIXER_UnlockAudioDevice();
 }
 
 extern bool ticksLocked;
@@ -623,7 +637,7 @@ static inline bool Mixer_irq_important()
 	return (ticksLocked || (CaptureState & (CAPTURE_WAVE|CAPTURE_VIDEO)));
 }
 
-static Bit32u calc_tickadd(Bit32u freq) {
+static constexpr Bit32u calc_tickadd(Bit32u freq) {
 #if TICK_SHIFT > 16
 	Bit64u freq64 = static_cast<Bit64u>(freq);
 	freq64 = (freq64<<TICK_SHIFT)/1000;
@@ -659,20 +673,17 @@ static void MIXER_MixData(Bitu needed) {
 	//Reset the the tick_add for constant speed
 	if( Mixer_irq_important() )
 		mixer.tick_add = calc_tickadd(mixer.freq);
-	mixer.done = needed;
+	mixer.done = static_cast<uint32_t>(needed);
 }
-
-static std::array<MixerFrame, MIXER_QUEUE_MAX_FRAMES> queue_buffer;
-static void MIXER_QueueAudio(uint16_t);
 
 static void MIXER_Mix()
 {
+	MIXER_LockAudioDevice();
 	MIXER_MixData(mixer.needed);
 	mixer.tick_counter += mixer.tick_add;
 	mixer.needed+=(mixer.tick_counter >> TICK_SHIFT);
 	mixer.tick_counter &= TICK_MASK;
-	assert(mixer.done <= queue_buffer.size());
-	MIXER_QueueAudio(static_cast<uint16_t>(mixer.done));
+	MIXER_UnlockAudioDevice();
 }
 
 static void MIXER_Mix_NoSound()
@@ -696,12 +707,84 @@ static void MIXER_Mix_NoSound()
 	mixer.done=0;
 }
 
-static void MIXER_QueueAudio(const uint16_t len)
+#define INDEX_SHIFT_LOCAL 14
+
+static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, int len)
 {
-	assert(len <= queue_buffer.size());
+	memset(stream, 0, len);
+	auto need = static_cast<uint32_t>(len / MIXER_SSIZE);
+	Bit16s *output = (Bit16s *)stream;
+	Bit32u reduce = 0;
+	Bit32u pos = 0;
+	// Local resampling counter to manipulate the data when sending it off
+	// to the callback
+	Bit32u index_add = (1 << INDEX_SHIFT_LOCAL);
+	Bit32u index = (index_add % need) ? need : 0;
 
-	auto reduce = len;
+	Bits sample = 0;
+	/* Enough room in the buffer ? */
+	if (mixer.done < need) {
+		//LOG_WARNING("Full underrun need %d, have %d, min %d", need, mixer.done, mixer.min_needed);
+		if ((need - mixer.done) > (need >> 7)) // Max 1 percent stretch.
+			return;
+		reduce = mixer.done;
+		index_add = (reduce << INDEX_SHIFT_LOCAL) / need;
+		mixer.tick_add = calc_tickadd(mixer.freq + mixer.min_needed);
+	} else if (mixer.done < mixer.max_needed) {
+		auto left = mixer.done - need;
+		if (left < mixer.min_needed) {
+			if (!Mixer_irq_important()) {
+				auto needed = mixer.needed - need;
+				auto diff = (mixer.min_needed > needed ? mixer.min_needed
+				                                       : needed) - left;
+				mixer.tick_add = calc_tickadd(mixer.freq +
+				                              (diff * 3));
+				left = 0; // No stretching as we compensate with
+				          // the tick_add value
+			} else {
+				left = (mixer.min_needed - left);
+				left = 1 + (2 * left) / mixer.min_needed; // left=1,2,3
+			}
+			//LOG_WARNING("needed underrun need %d, have %d, min %d, left %d", need, mixer.done, mixer.min_needed, left);
+			reduce = need - left;
+			index_add = (reduce << INDEX_SHIFT_LOCAL) / need;
+		} else {
+			reduce = need;
+			index_add = (1 << INDEX_SHIFT_LOCAL);
+			//			LOG_MSG("regular run need %d, have
+			//%d, min %d, left %d", need, mixer.done,
+			//mixer.min_needed, left);
 
+			/* Mixer tick value being updated:
+			 * 3 cases:
+			 * 1) A lot too high. >division by 5. but maxed by 2*
+			 * min to prevent too fast drops. 2) A little too high >
+			 * division by 8 3) A little to nothing above the
+			 * min_needed buffer > go to default value
+			 */
+			auto diff = left - mixer.min_needed;
+			if (diff > (mixer.min_needed << 1))
+				diff = mixer.min_needed << 1;
+			if (diff > (mixer.min_needed >> 1))
+				mixer.tick_add = calc_tickadd(mixer.freq -
+				                              (diff / 5));
+			else if (diff > (mixer.min_needed >> 2))
+				mixer.tick_add = calc_tickadd(mixer.freq -
+				                              (diff >> 3));
+			else
+				mixer.tick_add = calc_tickadd(mixer.freq);
+		}
+	} else {
+		/* There is way too much data in the buffer */
+		LOG_WARNING("overflow run need %u, have %u, min %u", need, mixer.done, mixer.min_needed);
+		if (mixer.done > MIXER_BUFSIZE)
+			index_add = MIXER_BUFSIZE - 2 * mixer.min_needed;
+		else
+			index_add = mixer.done - 2 * mixer.min_needed;
+		index_add = (index_add << INDEX_SHIFT_LOCAL) / need;
+		reduce = mixer.done - 2 * mixer.min_needed;
+		mixer.tick_add = calc_tickadd(mixer.freq - (mixer.min_needed / 5));
+	}
 	/* Reduce done count in all channels */
 	for (MixerChannel * chan=mixer.channels;chan;chan=chan->next) {
 		if (chan->done>reduce) chan->done-=reduce;
@@ -714,28 +797,39 @@ static void MIXER_QueueAudio(const uint16_t len)
 
 	mixer.done -= reduce;
 	mixer.needed -= reduce;
-	auto pos = mixer.pos;
+	pos = mixer.pos;
 	mixer.pos = (mixer.pos + reduce) & MIXER_BUFMASK;
-
-	int idx = 0;
-
-	while (reduce--) {
-		pos &= MIXER_BUFMASK;
-		const MixerFrame frame = {
-		        MIXER_CLIP(mixer.work[pos][0] >> MIXER_VOLSHIFT),
-		        MIXER_CLIP(mixer.work[pos][1] >> MIXER_VOLSHIFT)};
-		queue_buffer[idx++] = frame;
-
-		mixer.work[pos][0] = 0;
-		mixer.work[pos][1] = 0;
-		pos++;
+	if (need != reduce) {
+		while (need--) {
+			const auto i = (pos + (index >> INDEX_SHIFT_LOCAL)) & MIXER_BUFMASK;
+			index += index_add;
+			sample = mixer.work[i][0] >> MIXER_VOLSHIFT;
+			*output++ = MIXER_CLIP(sample);
+			sample = mixer.work[i][1] >> MIXER_VOLSHIFT;
+			*output++ = MIXER_CLIP(sample);
+		}
+		/* Clean the used buffer */
+		while (reduce--) {
+			pos &= MIXER_BUFMASK;
+			mixer.work[pos][0] = 0;
+			mixer.work[pos][1] = 0;
+			pos++;
+		}
+	} else {
+		while (reduce--) {
+			pos &= MIXER_BUFMASK;
+			sample = mixer.work[pos][0] >> MIXER_VOLSHIFT;
+			*output++ = MIXER_CLIP(sample);
+			sample = mixer.work[pos][1] >> MIXER_VOLSHIFT;
+			*output++ = MIXER_CLIP(sample);
+			mixer.work[pos][0] = 0;
+			mixer.work[pos][1] = 0;
+			pos++;
+		}
 	}
-
-	const uint32_t size = len * sizeof(MixerFrame);
-	const auto res = SDL_QueueAudio(mixer.sdldevice, queue_buffer.data(), size);
-	if (res != 0)
-		LOG_MSG("MIXER: SDL_QueueAudio error %s", SDL_GetError());
 }
+
+#undef INDEX_SHIFT_LOCAL
 
 static void MIXER_Stop(MAYBE_UNUSED Section *sec)
 {}
@@ -836,9 +930,8 @@ void MIXER_Init(Section* sec) {
 
 	mixer.nosound=section->Get_bool("nosound");
 	mixer.freq = static_cast<uint32_t>(section->Get_int("rate"));
-	mixer.latency = static_cast<uint8_t>(section->Get_int("latency"));
-	assert(mixer.latency <= 100);
-	const bool negotiate = section->Get_bool("negotiate");
+	mixer.blocksize = static_cast<uint16_t>(section->Get_int("blocksize"));
+	const auto negotiate = static_cast<bool>(section->Get_bool("negotiate"));
 
 	/* Initialize the internal stuff */
 	mixer.channels=0;
@@ -848,19 +941,16 @@ void MIXER_Init(Section* sec) {
 	mixer.mastervol[0]=1.0f;
 	mixer.mastervol[1]=1.0f;
 
-	/* Calculate blocksize from requested latency to nearest power of 2 */
-	auto blocksize = static_cast<uint16_t>(mixer.freq * mixer.latency / 1000);
-
 	/* Start the Mixer using SDL Sound at 22 khz */
 	SDL_AudioSpec spec;
 	SDL_AudioSpec obtained;
 
 	spec.freq = static_cast<int>(mixer.freq);
-	spec.format=AUDIO_S16SYS;
-	spec.channels=2;
-	spec.callback = nullptr;
+	spec.format = AUDIO_S16SYS;
+	spec.channels = 2;
+	spec.callback = MIXER_CallBack;
 	spec.userdata = nullptr;
-	spec.samples = blocksize;
+	spec.samples = mixer.blocksize;
 
 	int sdl_allow_flags = 0;
 
@@ -876,10 +966,9 @@ void MIXER_Init(Section* sec) {
 		LOG_MSG("MIXER: No Sound Mode Selected.");
 		mixer.tick_add=calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix_NoSound);
-	} else if ((mixer.sdldevice = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained,
-	                                                  sdl_allow_flags)) == 0) {
+	} else if ((mixer.sdldevice = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained, sdl_allow_flags)) ==0 ) {
 		mixer.nosound = true;
-		LOG_MSG("MIXER: Can't open audio: %s , running in nosound mode.",SDL_GetError());
+		LOG_WARNING("MIXER: Can't open audio: %s , running in nosound mode.",SDL_GetError());
 		mixer.tick_add=calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix_NoSound);
 	} else {
@@ -893,32 +982,33 @@ void MIXER_Init(Section* sec) {
 		       static_cast<unsigned>(obtained.freq) < UINT32_MAX);
 		const auto obtained_freq = static_cast<uint32_t>(obtained.freq);
 		if (obtained_freq != mixer.freq) {
-			LOG_MSG("MIXER: SDL changed the playback rate from %u to %u Hz",
+			LOG_WARNING("MIXER: SDL changed the playback rate from %u to %u Hz",
 			        mixer.freq, obtained_freq);
 			mixer.freq = obtained_freq;
 		}
 
 		// Does SDL want a different blocksize?
 		const auto obtained_blocksize = obtained.samples;
-		if (obtained_blocksize != blocksize) {
-			LOG_MSG("MIXER: SDL changed the blocksize from %u to %u frames",
-			        blocksize, obtained_blocksize);
-			blocksize = obtained_blocksize;
+		if (obtained_blocksize != mixer.blocksize) {
+			LOG_WARNING("MIXER: SDL changed the blocksize from %u to %u frames",
+			        mixer.blocksize, obtained_blocksize);
+			mixer.blocksize = obtained_blocksize;
 		}
 		mixer.tick_add = calc_tickadd(mixer.freq);
 		TIMER_AddTickHandler(MIXER_Mix);
 		SDL_PauseAudioDevice(mixer.sdldevice, 0);
 
-		const auto latency = blocksize / (mixer.freq / 1000);
-		LOG_MSG("MIXER: Negotiated %u-channel %u-Hz %ums-latency audio in %u-frame blocks",
-		        obtained.channels, mixer.freq, latency, blocksize);
+		LOG_MSG("MIXER: Negotiated %u-channel %u-Hz audio in %u-frame blocks",
+		        obtained.channels, mixer.freq, mixer.blocksize);
 	}
 
 	//1000 = 8 *125
 	mixer.tick_counter = (mixer.freq%125)?TICK_NEXT:0;
-
-	// calculate here in case SDL changed the freq
-	mixer.needed = mixer.freq / 1000;
+	const auto requested_prebuffer = section->Get_int("prebuffer");
+	mixer.min_needed = static_cast<uint16_t>(clamp(requested_prebuffer, 0, 100));
+	mixer.min_needed = (mixer.freq * mixer.min_needed) / 1000;
+	mixer.max_needed = mixer.blocksize * 2 + 2 * mixer.min_needed;
+	mixer.needed = mixer.min_needed + 1;
 
 	// Initialize the 8-bit to 16-bit lookup table
 	fill_8to16_lut();


### PR DESCRIPTION
After extensive testing and feedback, the push API is being reverted to the old pull/callback API. The push API ended up just being a game of shifting the latency around to different parts of the mixer pipeline with no clear benefit and many issues.

There have been some minor improvements retained, namely the `negotiate` config option that allows the system audio driver to modify the `rate` and `blocksize` options for optimal performance.

There were also many thread-safety issues related variables in the`mixer` struct being accessed from the callback function, which is called from a separate thread managed by SDL, and the other mixer code.