### PR TITLE
Improve window focus

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2968,6 +2968,7 @@ bool GFX_Events()
 				 * Update surface while using X11.
 				 */
 				GFX_ResetScreen();
+				FocusInput();
 				continue;
 
 			case SDL_WINDOWEVENT_RESIZED:
@@ -3000,7 +3001,6 @@ bool GFX_Events()
 				if (sdl.draw.callback)
 					sdl.draw.callback(GFX_CallBackRedraw);
 				GFX_UpdateMouseState();
-				FocusInput();
 
 				// When we're fullscreen, the DOS program might
 				// change underlying draw resolutions, which can
@@ -3015,6 +3015,7 @@ bool GFX_Events()
 					sdl.desktop.last_size_event != SDL_WINDOWEVENT_RESIZED)
 					GFX_ResetScreen();
 
+				FocusInput();
 				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_LOST:
@@ -3083,9 +3084,7 @@ bool GFX_Events()
 				break;
 
 			case SDL_WINDOWEVENT_TAKE_FOCUS:
-				// DEBUG_LOG_MSG("SDL: Window is being offered a focus");
-				// should SetWindowInputFocus() on itself or a
-				// subwindow, or ignore
+				FocusInput();
 				continue;
 
 			case SDL_WINDOWEVENT_HIT_TEST:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2537,9 +2537,7 @@ static void GUI_StartUp(Section *sec)
 		fullresolution = lowcase (res);//so x and X are allowed
 		if (strcmp(fullresolution,"original")) {
 			sdl.desktop.full.fixed = true;
-			if (!strcmp(fullresolution,"desktop")) { // Populate sdl.full.width and height with Desktop size
-				GFX_ObtainDisplayDimensions();
-			} else { // Use a custom resolution in WxH format
+			if (strcmp(fullresolution,"desktop")) { // desktop uses 0x0, below sets a custom WxH
 				char* height = const_cast<char*>(strchr(fullresolution,'x'));
 				if (height && * height) {
 					*height = 0;


### PR DESCRIPTION
This small PR fixes two issues:

1. Rolls back the change where `fullresolution = desktop` used the display's dimensions, which was reported to cause slowdown on Wayland during fullscreen and window-mode toggles.  This goes back to the original 0x0 internal-SDL behaviour. 

2. Applies more Focus-taking calls to ensure input devices are focused on Window exposed and change events, as on some systems the window comes alive, but the input devices are still focused on other desktop programs.

