### PR TITLE
Revert to sleep

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -28,7 +28,9 @@
 #include <limits>
 #include <unistd.h>
 
+#include <chrono>
 #include <functional>
+#include <thread>
 
 #include "debug.h"
 #include "cpu.h"
@@ -189,9 +191,8 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 		ticksAdded = 0;
 
 		constexpr auto duration = std::chrono::milliseconds(1);
-		const auto start = std::chrono::steady_clock::now();
-		while(std::chrono::steady_clock::now() - start <= duration);	
-		
+		std::this_thread::sleep_for(duration);
+
 		const auto timeslept = GetTicksSince(ticksNew);
 
 		// Update ticksDone with the time spent sleeping

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -29,7 +29,6 @@
 #include <unistd.h>
 
 #include <chrono>
-#include <functional>
 #include <thread>
 
 #include "debug.h"
@@ -138,7 +137,6 @@ void INT10_Init(Section*);
 
 static LoopHandler * loop;
 
-static std::function<void(int)> delay_fn = Delay;
 static int ticksRemain;
 static int64_t ticksLast;
 static int ticksAdded;
@@ -342,9 +340,6 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 static void DOSBOX_RealInit(Section * sec) {
 	Section_prop * section=static_cast<Section_prop *>(sec);
 	/* Initialize some dosbox internals */
-
-	delay_fn = CanDelayPrecise() ? DelayPrecise : Delay;
-
 	ticksRemain=0;
 	ticksLast=GetTicks();
 	ticksLocked = false;


### PR DESCRIPTION
The spinwait causes high CPU usage for relatively little performance gain at this point. Let's start with a clean slate of no sleeppattern logic and standard C++ `std::this_thread::sleep_for` and iterate on this later.