### PR TITLE
Just use standard C++ 'inline' keyword for INLINE

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -82,31 +82,8 @@
 #define GCC_ATTRIBUTE(x) /* attribute not supported */
 #endif
 
-// Wrapper for various compiler extensions for inlining aggresively.
-//
-// There is NO way to truly FORCE compiler to do inlining, therefore all these
-// methods are only strong hints, usually non-preferrable over simple
-// 'inline' keyword.
-//
-// Normal C++ 'inline' is indicator that there might be more than one
-// definition for the function (as long as all definitions are the same).
-// It's used to define functions in C++ headers. Compiler will automatically
-// try to inline (embed compiled code without function call) any function
-// defined in a header.
-//
-// For details about GCC/Clang always_inline, see:
-// https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
-//
-// For details about MSVC __forceinline, see:
-// https://docs.microsoft.com/en-us/cpp/cpp/inline-functions-cpp#inline-__inline-and-__forceinline
-
-#if __has_attribute(always_inline)
-#define INLINE inline __attribute__((always_inline))
-#elif defined(_MSC_VER)
-#define INLINE __forceinline
-#else
+// Just use the standard C++ inline keyword
 #define INLINE inline
-#endif
 
 // GCC_LIKELY macro is incorrectly named, because other compilers support
 // this feature as well (e.g. Clang, Intel); leave it be for now, at


### PR DESCRIPTION
This improves stack traces on several titles and should have no detectable performance impact on modern systems. I noticed a more detailed stack trace when debugging a crash in First Encounter and thought this change would help with this and other debugging/profiling efforts.