### PR TITLE
Update entire system for C++17 support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,7 +27,7 @@ ColumnLimit: 80
 Language: Cpp
 # in clang-format 9.x "Cpp11" covers formatting for C++11 and C++14
 # in clang-format 10.x: switch to "c++14"
-Standard: c++14
+Standard: c++17
 
 # The extra indent or outdent of class access modifiers, e.g. public:
 #

--- a/.github/meson/native-gcc-5.ini
+++ b/.github/meson/native-gcc-5.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = ['ccache', 'gcc-5']
-cpp = ['ccache', 'g++-5']

--- a/.github/meson/native-gcc-7.ini
+++ b/.github/meson/native-gcc-7.ini
@@ -1,0 +1,3 @@
+[binaries]
+c = ['ccache', 'gcc-7']
+cpp = ['ccache', 'g++-7']

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,10 +31,10 @@ jobs:
             build_flags: -Duse_fluidsynth=false
             max_warnings: 0
 
-          - name: GCC 5, Ubuntu 18.04
+          - name: GCC 7, Ubuntu 18.04
             os: ubuntu-18.04
-            packages: g++-5
-            build_flags: --native-file=.github/meson/native-gcc-5.ini --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_mt32emu=false
+            packages: g++-7
+            build_flags: --native-file=.github/meson/native-gcc-7.ini --wrap-mode=nofallback -Dunit_tests=disabled -Duse_fluidsynth=false -Duse_mt32emu=false
             max_warnings: 0
 
           - name: GCC, +tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 266
+            max_warnings: 264
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1633
+            max_warnings: 1610
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/callback.h
+++ b/include/callback.h
@@ -67,14 +67,14 @@ enum {
 
 extern Bit8u lastint;
 
-static INLINE RealPt CALLBACK_RealPointer(Bitu callback) {
+static inline RealPt CALLBACK_RealPointer(Bitu callback) {
 	return RealMake(CB_SEG,(Bit16u)(CB_SOFFSET+callback*CB_SIZE));
 }
-static INLINE PhysPt CALLBACK_PhysPointer(Bitu callback) {
+static inline PhysPt CALLBACK_PhysPointer(Bitu callback) {
 	return PhysMake(CB_SEG,(Bit16u)(CB_SOFFSET+callback*CB_SIZE));
 }
 
-static INLINE PhysPt CALLBACK_GetBase(void) {
+static inline PhysPt CALLBACK_GetBase(void) {
 	return (CB_SEG << 4) + CB_SOFFSET;
 }
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -46,31 +46,6 @@
 #define __has_attribute(x) 0 // for compatibility with non-supporting compilers
 #endif
 
-// When passing the -Wunused flag to GCC or Clang, entities that are unused by
-// the program may be diagnosed.  The MAYBE_UNUSED attribute can be used to
-// silence such diagnostics when the entity cannot be removed.
-//
-// The attribute may be applied to the declaration of a class, a typedef,
-// a variable, a function or method, a function parameter, an enumeration,
-// an enumerator, a non-static data member, or a label.
-
-#if __has_cpp_attribute(maybe_unused)
-#define MAYBE_UNUSED [[maybe_unused]]
-#elif __has_cpp_attribute(gnu::unused)
-#define MAYBE_UNUSED [[gnu::unused]]
-#else
-#define MAYBE_UNUSED
-#endif
-
-// Wrapper for C++17 [[fallthrough]] null statement. Use this to avoid implicit
-// fallthrough in switch statements (-Wimplicit-fallthrough flag).
-
-#if __has_cpp_attribute(fallthrough)
-#define FALLTHROUGH [[fallthrough]]
-#else
-#define FALLTHROUGH
-#endif
-
 // The __attribute__ syntax is supported by GCC, Clang, and IBM compilers.
 //
 // Provided for backwards-compatibility with old code; to be gradually
@@ -81,9 +56,6 @@
 #else
 #define GCC_ATTRIBUTE(x) /* attribute not supported */
 #endif
-
-// Just use the standard C++ inline keyword
-#define INLINE inline
 
 // GCC_LIKELY macro is incorrectly named, because other compilers support
 // this feature as well (e.g. Clang, Intel); leave it be for now, at

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -142,13 +142,13 @@ void CPU_ENTER(bool use32,Bitu bytes,Bitu level);
 #define CPU_INT_NOIOPLCHECK		0x8
 
 void CPU_Interrupt(Bitu num,Bitu type,Bitu oldeip);
-static INLINE void CPU_HW_Interrupt(Bitu num) {
+static inline void CPU_HW_Interrupt(Bitu num) {
 	CPU_Interrupt(num,0,reg_eip);
 }
-static INLINE void CPU_SW_Interrupt(Bitu num,Bitu oldeip) {
+static inline void CPU_SW_Interrupt(Bitu num,Bitu oldeip) {
 	CPU_Interrupt(num,CPU_INT_SOFTWARE,oldeip);
 }
-static INLINE void CPU_SW_Interrupt_NoIOPLCheck(Bitu num,Bitu oldeip) {
+static inline void CPU_SW_Interrupt_NoIOPLCheck(Bitu num,Bitu oldeip) {
 	CPU_Interrupt(num,CPU_INT_SOFTWARE|CPU_INT_NOIOPLCHECK,oldeip);
 }
 
@@ -485,12 +485,12 @@ struct CPUBlock {
 
 extern CPUBlock cpu;
 
-static INLINE void CPU_SetFlagsd(Bitu word) {
+static inline void CPU_SetFlagsd(Bitu word) {
 	Bitu mask=cpu.cpl ? FMASK_NORMAL : FMASK_ALL;
 	CPU_SetFlags(word,mask);
 }
 
-static INLINE void CPU_SetFlagsw(Bitu word) {
+static inline void CPU_SetFlagsw(Bitu word) {
 	Bitu mask=(cpu.cpl ? FMASK_NORMAL : FMASK_ALL) & 0xffff;
 	CPU_SetFlags(word,mask);
 }

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -218,7 +218,7 @@ enum {
 };
 
 
-static INLINE Bit16u long2para(Bit32u size) {
+static inline Bit16u long2para(Bit32u size) {
 	if (size>0xFFFF0) return 0xffff;
 	if (size&0xf) return (Bit16u)((size>>4)+1);
 	else return (Bit16u)(size>>4);
@@ -746,7 +746,7 @@ struct DOS_Block {
 
 extern DOS_Block dos;
 
-static INLINE Bit8u RealHandle(Bit16u handle) {
+static inline Bit8u RealHandle(Bit16u handle) {
 	DOS_PSP psp(dos.psp());	
 	return psp.GetFileHandle(handle);
 }

--- a/include/envelope.h
+++ b/include/envelope.h
@@ -86,10 +86,10 @@ private:
 	           intptr_t prev[],
 	           intptr_t next[]);
 
-	void Skip(MAYBE_UNUSED bool is_stereo,
-	          MAYBE_UNUSED bool is_interpolated,
-	          MAYBE_UNUSED intptr_t prev[],
-	          MAYBE_UNUSED intptr_t next[])
+	void Skip([[maybe_unused]] bool is_stereo,
+	          [[maybe_unused]] bool is_interpolated,
+	          [[maybe_unused]] intptr_t prev[],
+	          [[maybe_unused]] intptr_t next[])
 	{}
 
 	using process_f = std::function<void(Envelope &, bool, bool, intptr_t[], intptr_t[])>;

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -110,49 +110,49 @@ extern FPU_rec fpu;
 Bit16u FPU_GetTag(void);
 void FPU_FLDCW(PhysPt addr);
 
-static INLINE void FPU_SetTag(Bit16u tag){
+static inline void FPU_SetTag(Bit16u tag){
 	for(Bitu i=0;i<8;i++)
 		fpu.tags[i] = static_cast<FPU_Tag>((tag >>(2*i))&3);
 }
 
-static INLINE void FPU_SetCW(Bitu word){
+static inline void FPU_SetCW(Bitu word){
 	fpu.cw = (Bit16u)word;
 	fpu.cw_mask_all = (Bit16u)(word | 0x3f);
 	fpu.round = (FPU_Round)((word >> 10) & 3);
 }
 
 
-static INLINE Bitu FPU_GET_TOP(void) {
+static inline Bitu FPU_GET_TOP(void) {
 	return (fpu.sw & 0x3800)>>11;
 }
 
-static INLINE void FPU_SET_TOP(Bitu val){
+static inline void FPU_SET_TOP(Bitu val){
 	fpu.sw &= ~0x3800;
 	fpu.sw |= (val&7)<<11;
 }
 
 
-static INLINE void FPU_SET_C0(Bitu C){
+static inline void FPU_SET_C0(Bitu C){
 	fpu.sw &= ~0x0100;
 	if(C) fpu.sw |=  0x0100;
 }
 
-static INLINE void FPU_SET_C1(Bitu C){
+static inline void FPU_SET_C1(Bitu C){
 	fpu.sw &= ~0x0200;
 	if(C) fpu.sw |=  0x0200;
 }
 
-static INLINE void FPU_SET_C2(Bitu C){
+static inline void FPU_SET_C2(Bitu C){
 	fpu.sw &= ~0x0400;
 	if(C) fpu.sw |=  0x0400;
 }
 
-static INLINE void FPU_SET_C3(Bitu C){
+static inline void FPU_SET_C3(Bitu C){
 	fpu.sw &= ~0x4000;
 	if(C) fpu.sw |= 0x4000;
 }
 
-static INLINE void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr_t sub)
+static inline void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr_t sub)
 {
 	LOG(LOG_FPU, LOG_WARN)("ESC %u%s: Unhandled group %" PRIuPTR " subfunction %" PRIuPTR,
 	                       tree, ea ? " EA" : "", group, sub);

--- a/include/inout.h
+++ b/include/inout.h
@@ -97,12 +97,12 @@ public:
 	~IO_WriteHandleObject();
 };
 
-static INLINE void IO_Write(io_port_t port, Bit8u val)
+static inline void IO_Write(io_port_t port, Bit8u val)
 {
 	IO_WriteB(port,val);
 }
 
-static INLINE Bit8u IO_Read(io_port_t port){
+static inline Bit8u IO_Read(io_port_t port){
 	// cast to be dropped after deprecating the Bitu IO handler API
 	return (Bit8u)IO_ReadB(port);
 }

--- a/include/paging.h
+++ b/include/paging.h
@@ -196,25 +196,25 @@ bool mem_unalignedwrited_checked(PhysPt address,Bit32u val);
 
 #if defined(USE_FULL_TLB)
 
-static INLINE HostPt get_tlb_read(PhysPt address) {
+static inline HostPt get_tlb_read(PhysPt address) {
 	return paging.tlb.read[address>>12];
 }
-static INLINE HostPt get_tlb_write(PhysPt address) {
+static inline HostPt get_tlb_write(PhysPt address) {
 	return paging.tlb.write[address>>12];
 }
-static INLINE PageHandler* get_tlb_readhandler(PhysPt address) {
+static inline PageHandler* get_tlb_readhandler(PhysPt address) {
 	return paging.tlb.readhandler[address>>12];
 }
-static INLINE PageHandler* get_tlb_writehandler(PhysPt address) {
+static inline PageHandler* get_tlb_writehandler(PhysPt address) {
 	return paging.tlb.writehandler[address>>12];
 }
 
 /* Use these helper functions to access linear addresses in readX/writeX functions */
-static INLINE PhysPt PAGING_GetPhysicalPage(PhysPt linePage) {
+static inline PhysPt PAGING_GetPhysicalPage(PhysPt linePage) {
 	return (paging.tlb.phys_page[linePage>>12]<<12);
 }
 
-static INLINE PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
+static inline PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 	return (paging.tlb.phys_page[linAddr>>12]<<12)|(linAddr&0xfff);
 }
 
@@ -222,7 +222,7 @@ static INLINE PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 
 void PAGING_InitTLBBank(tlb_entry **bank);
 
-static INLINE tlb_entry *get_tlb_entry(PhysPt address) {
+static inline tlb_entry *get_tlb_entry(PhysPt address) {
 	Bitu index=(address>>12);
 	if (TLB_BANKS && (index >= TLB_SIZE)) {
 		Bitu bank=(address>>BANK_SHIFT) - 1;
@@ -233,26 +233,26 @@ static INLINE tlb_entry *get_tlb_entry(PhysPt address) {
 	return &paging.tlbh[index];
 }
 
-static INLINE HostPt get_tlb_read(PhysPt address) {
+static inline HostPt get_tlb_read(PhysPt address) {
 	return get_tlb_entry(address)->read;
 }
-static INLINE HostPt get_tlb_write(PhysPt address) {
+static inline HostPt get_tlb_write(PhysPt address) {
 	return get_tlb_entry(address)->write;
 }
-static INLINE PageHandler* get_tlb_readhandler(PhysPt address) {
+static inline PageHandler* get_tlb_readhandler(PhysPt address) {
 	return get_tlb_entry(address)->readhandler;
 }
-static INLINE PageHandler* get_tlb_writehandler(PhysPt address) {
+static inline PageHandler* get_tlb_writehandler(PhysPt address) {
 	return get_tlb_entry(address)->writehandler;
 }
 
 /* Use these helper functions to access linear addresses in readX/writeX functions */
-static INLINE PhysPt PAGING_GetPhysicalPage(PhysPt linePage) {
+static inline PhysPt PAGING_GetPhysicalPage(PhysPt linePage) {
 	tlb_entry *entry = get_tlb_entry(linePage);
 	return (entry->phys_page<<12);
 }
 
-static INLINE PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
+static inline PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 	tlb_entry *entry = get_tlb_entry(linAddr);
 	return (entry->phys_page<<12)|(linAddr&0xfff);
 }
@@ -260,13 +260,13 @@ static INLINE PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 
 /* Special inlined memory reading/writing */
 
-static INLINE Bit8u mem_readb_inline(PhysPt address) {
+static inline Bit8u mem_readb_inline(PhysPt address) {
 	HostPt tlb_addr=get_tlb_read(address);
 	if (tlb_addr) return host_readb(tlb_addr+address);
 	else return (Bit8u)(get_tlb_readhandler(address))->readb(address);
 }
 
-static INLINE Bit16u mem_readw_inline(PhysPt address) {
+static inline Bit16u mem_readw_inline(PhysPt address) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) return host_readw(tlb_addr+address);
@@ -274,7 +274,7 @@ static INLINE Bit16u mem_readw_inline(PhysPt address) {
 	} else return mem_unalignedreadw(address);
 }
 
-static INLINE uint32_t mem_readd_inline(PhysPt address)
+static inline uint32_t mem_readd_inline(PhysPt address)
 {
 	if ((address & 0xfff) < 0xffd) {
 		HostPt tlb_addr = get_tlb_read(address);
@@ -287,13 +287,13 @@ static INLINE uint32_t mem_readd_inline(PhysPt address)
 	}
 }
 
-static INLINE void mem_writeb_inline(PhysPt address,Bit8u val) {
+static inline void mem_writeb_inline(PhysPt address,Bit8u val) {
 	HostPt tlb_addr=get_tlb_write(address);
 	if (tlb_addr) host_writeb(tlb_addr+address,val);
 	else (get_tlb_writehandler(address))->writeb(address,val);
 }
 
-static INLINE void mem_writew_inline(PhysPt address,Bit16u val) {
+static inline void mem_writew_inline(PhysPt address,Bit16u val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) host_writew(tlb_addr+address,val);
@@ -301,7 +301,7 @@ static INLINE void mem_writew_inline(PhysPt address,Bit16u val) {
 	} else mem_unalignedwritew(address,val);
 }
 
-static INLINE void mem_writed_inline(PhysPt address,Bit32u val) {
+static inline void mem_writed_inline(PhysPt address,Bit32u val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) host_writed(tlb_addr+address,val);
@@ -310,7 +310,7 @@ static INLINE void mem_writed_inline(PhysPt address,Bit32u val) {
 }
 
 
-static INLINE bool mem_readb_checked(PhysPt address, Bit8u * val) {
+static inline bool mem_readb_checked(PhysPt address, Bit8u * val) {
 	HostPt tlb_addr=get_tlb_read(address);
 	if (tlb_addr) {
 		*val=host_readb(tlb_addr+address);
@@ -318,7 +318,7 @@ static INLINE bool mem_readb_checked(PhysPt address, Bit8u * val) {
 	} else return (get_tlb_readhandler(address))->readb_checked(address, val);
 }
 
-static INLINE bool mem_readw_checked(PhysPt address, Bit16u * val) {
+static inline bool mem_readw_checked(PhysPt address, Bit16u * val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) {
@@ -328,7 +328,7 @@ static INLINE bool mem_readw_checked(PhysPt address, Bit16u * val) {
 	} else return mem_unalignedreadw_checked(address, val);
 }
 
-static INLINE bool mem_readd_checked(PhysPt address, Bit32u * val) {
+static inline bool mem_readd_checked(PhysPt address, Bit32u * val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) {
@@ -338,7 +338,7 @@ static INLINE bool mem_readd_checked(PhysPt address, Bit32u * val) {
 	} else return mem_unalignedreadd_checked(address, val);
 }
 
-static INLINE bool mem_writeb_checked(PhysPt address,Bit8u val) {
+static inline bool mem_writeb_checked(PhysPt address,Bit8u val) {
 	HostPt tlb_addr=get_tlb_write(address);
 	if (tlb_addr) {
 		host_writeb(tlb_addr+address,val);
@@ -346,7 +346,7 @@ static INLINE bool mem_writeb_checked(PhysPt address,Bit8u val) {
 	} else return (get_tlb_writehandler(address))->writeb_checked(address,val);
 }
 
-static INLINE bool mem_writew_checked(PhysPt address,Bit16u val) {
+static inline bool mem_writew_checked(PhysPt address,Bit16u val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) {
@@ -356,7 +356,7 @@ static INLINE bool mem_writew_checked(PhysPt address,Bit16u val) {
 	} else return mem_unalignedwritew_checked(address,val);
 }
 
-static INLINE bool mem_writed_checked(PhysPt address,Bit32u val) {
+static inline bool mem_writed_checked(PhysPt address,Bit32u val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) {

--- a/include/regs.h
+++ b/include/regs.h
@@ -93,20 +93,20 @@ struct CPU_Regs {
 extern Segments Segs;
 extern CPU_Regs cpu_regs;
 
-static INLINE PhysPt SegPhys(SegNames index) {
+static inline PhysPt SegPhys(SegNames index) {
 	return Segs.phys[index];
 }
 
-static INLINE Bit16u SegValue(SegNames index) {
+static inline Bit16u SegValue(SegNames index) {
 	return (Bit16u)Segs.val[index];
 }
 	
-static INLINE RealPt RealMakeSeg(SegNames index,Bit16u off) {
+static inline RealPt RealMakeSeg(SegNames index,Bit16u off) {
 	return RealMake(SegValue(index),off);	
 }
 
 
-static INLINE void SegSet16(Bitu index,Bit16u val) {
+static inline void SegSet16(Bitu index,Bit16u val) {
 	Segs.val[index]=val;
 	Segs.phys[index]=val << 4;
 }

--- a/include/support.h
+++ b/include/support.h
@@ -74,8 +74,8 @@ T to_finite(const std::string& input) {
 			result = static_cast<T>(interim);
 	}
 	// Capture expected exceptions stod may throw
-	catch (MAYBE_UNUSED std::invalid_argument &e) {
-	} catch (MAYBE_UNUSED std::out_of_range &e) {
+	catch ([[maybe_unused]] std::invalid_argument &e) {
+	} catch ([[maybe_unused]] std::out_of_range &e) {
 	}
 	return result;
 }

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -344,7 +344,7 @@ run_block:
 		// LOG_MSG("selfmodification of running block at %x:%x",
 		//         SegValue(cs), reg_eip);
 		cpu.exception.which=0;
-		FALLTHROUGH; // let the normal core handle the block-modifying
+		[[fallthrough]]; // let the normal core handle the block-modifying
 		             // instruction
 	case BR_Opcode:
 		CPU_CycleLeft+=CPU_Cycles;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -163,7 +163,7 @@ static Bit32u decode_fetchd(void) {
 
 #define START_WMMEM 64
 
-static INLINE void decode_increase_wmapmask(Bitu size) {
+static inline void decode_increase_wmapmask(Bitu size) {
 	Bitu mapidx;
 	CacheBlock* activecb=decode.active_block; 
 	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
@@ -294,19 +294,19 @@ static void dyn_set_eip_last_end(DynReg * endreg) {
 	gen_dop_word_imm(DOP_ADD,decode.big_op,DREG(EIP),decode.op_start-decode.code_start);
 }
 
-static INLINE void dyn_set_eip_end(void) {
+static inline void dyn_set_eip_end(void) {
 	gen_protectflags();
 	gen_dop_word_imm(DOP_ADD,cpu.code.big,DREG(EIP),decode.code-decode.code_start);
 }
 
-static INLINE void dyn_set_eip_end(MAYBE_UNUSED DynReg * endreg) {
+static inline void dyn_set_eip_end([[maybe_unused]] DynReg * endreg) {
 	gen_protectflags();
 	if (cpu.code.big) gen_dop_word(DOP_MOV,true,DREG(TMPW),DREG(EIP));
 	else gen_extend_word(false,DREG(TMPW),DREG(EIP));
 	gen_dop_word_imm(DOP_ADD,cpu.code.big,DREG(TMPW),decode.code-decode.code_start);
 }
 
-static INLINE void dyn_set_eip_last(void) {
+static inline void dyn_set_eip_last(void) {
 	gen_protectflags();
 	gen_dop_word_imm(DOP_ADD,cpu.code.big,DREG(EIP),decode.op_start-decode.code_start);
 }
@@ -1055,7 +1055,7 @@ static void dyn_pop(DynReg * dynreg,bool checked=true) {
 	}
 }
 
-static INLINE void dyn_get_modrm(void) {
+static inline void dyn_get_modrm(void) {
 	decode.modrm.val=decode_fetchb();
 	decode.modrm.mod=(decode.modrm.val >> 6) & 3;
 	decode.modrm.reg=(decode.modrm.val >> 3) & 7;
@@ -2056,7 +2056,7 @@ static void dyn_iret(void) {
 	dyn_closeblock();
 }
 
-MAYBE_UNUSED static void dyn_interrupt(Bitu num)
+[[maybe_unused]] static void dyn_interrupt(Bitu num)
 {
 	gen_protectflags();
 	dyn_flags_gen_to_host();

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -133,7 +133,7 @@ private:
 					}
 				} else if ((modrm&7)!=4 || (sib&7)!=5)
 					break;
-				FALLTHROUGH;
+				[[fallthrough]];
 			case 2:	cache_addd((Bit32u)offset); break;
 			case 1: cache_addb((Bit8u)offset); break;
 			}
@@ -554,7 +554,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 		op.setreg(idx,di1);
 		tmp = 0x8A; // mov r8, []
 		break;
-	case 2: op.setword(); FALLTHROUGH; // mov r16, []
+	case 2: op.setword(); [[fallthrough]]; // mov r16, []
 	case 4: op.setreg(idx);
 		tmp = 0x8B; // mov r32, []
 		break;

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -119,21 +119,21 @@ static void dyn_string(STRING_OP op) {
 		switch (op) {
 		case STR_INSB:
 			gen_call_function((void*)&IO_ReadB,"%Dw%Rl",DREG(EDX),tmp_reg);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case STR_MOVSB:
 		case STR_STOSB:
 			dyn_write_byte(DREG(EA),tmp_reg,false);
 			break;
 		case STR_INSW:
 			gen_call_function((void*)&IO_ReadW,"%Dw%Rw",DREG(EDX),tmp_reg);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case STR_MOVSW:
 		case STR_STOSW:
 			dyn_write_word(DREG(EA),tmp_reg,false);
 			break;
 		case STR_INSD:
 			gen_call_function((void*)&IO_ReadD,"%Dw%Rd",DREG(EDX),tmp_reg);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case STR_MOVSD:
 		case STR_STOSD:
 			dyn_write_word(DREG(EA),tmp_reg,true);

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -306,7 +306,7 @@ run_block:
 			cpu.exception.which=0;
 			// let the normal core handle the block-modifying
 			// instruction
-			FALLTHROUGH;
+			[[fallthrough]];
 		case BR_Opcode:
 			// some instruction has been encountered that could not be translated
 			// (thus it is not part of the code block), the normal core will

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -255,7 +255,7 @@ static Bit32u decode_fetchd(void) {
 
 // adjust writemap mask to care for map holes due to special
 // codefetch functions
-static void INLINE decode_increase_wmapmask(Bitu size) {
+static void inline decode_increase_wmapmask(Bitu size) {
 	Bitu mapidx;
 	CacheBlock *activecb = decode.active_block;
 	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
@@ -375,7 +375,7 @@ static bool decode_fetchd_imm(Bitu & val) {
 
 
 // modrm decoding helper
-static void INLINE dyn_get_modrm(void) {
+static void inline dyn_get_modrm(void) {
 	Bitu val=decode_fetchb();
 	decode.modrm.mod=(val >> 6) & 3;
 	decode.modrm.reg=(val >> 3) & 7;
@@ -476,24 +476,24 @@ static void dyn_reduce_cycles(void) {
 
 // set reg to the start of the next instruction
 // set reg_eip to the start of the current instruction
-static INLINE void dyn_set_eip_last_end(HostReg reg) {
+static inline void dyn_set_eip_last_end(HostReg reg) {
 	gen_mov_word_to_reg(reg,&reg_eip,true);
 	gen_add_imm(reg,(Bit32u)(decode.code-decode.code_start));
 	gen_add_direct_word(&reg_eip,decode.op_start-decode.code_start,decode.big_op);
 }
 
 // set reg_eip to the start of the current instruction
-static INLINE void dyn_set_eip_last(void) {
+static inline void dyn_set_eip_last(void) {
 	gen_add_direct_word(&reg_eip,decode.op_start-decode.code_start,cpu.code.big);
 }
 
 // set reg_eip to the start of the next instruction
-static INLINE void dyn_set_eip_end(void) {
+static inline void dyn_set_eip_end(void) {
 	gen_add_direct_word(&reg_eip,decode.code-decode.code_start,cpu.code.big);
 }
 
 // set reg_eip to the start of the next instruction plus an offset (imm)
-static INLINE void dyn_set_eip_end(HostReg reg,Bit32u imm=0) {
+static inline void dyn_set_eip_end(HostReg reg,Bit32u imm=0) {
 	gen_mov_word_to_reg(reg,&reg_eip,true); //get_extend_word will mask off the upper bits
 	//gen_mov_word_to_reg(reg,&reg_eip,decode.big_op);
 	gen_add_imm(reg,(Bit32u)(decode.code-decode.code_start+imm));
@@ -506,72 +506,72 @@ static INLINE void dyn_set_eip_end(HostReg reg,Bit32u imm=0) {
 // is architecture dependent
 // R=host register; I=32bit immediate value; A=address value; m=memory
 
-static INLINE const Bit8u* gen_call_function_R(void * func,Bitu op) {
+static inline const Bit8u* gen_call_function_R(void * func,Bitu op) {
 	gen_load_param_reg(op,0);
 	return gen_call_function_setup(func, 1);
 }
 
-static INLINE const Bit8u* gen_call_function_R3(void * func,Bitu op) {
+static inline const Bit8u* gen_call_function_R3(void * func,Bitu op) {
 	gen_load_param_reg(op,2);
 	return gen_call_function_setup(func, 3, true);
 }
 
-static INLINE const Bit8u* gen_call_function_RI(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_RI(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_imm(op2,1);
 	gen_load_param_reg(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static INLINE const Bit8u* gen_call_function_RA(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_RA(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_addr(op2,1);
 	gen_load_param_reg(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static INLINE const Bit8u* gen_call_function_RR(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_RR(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_reg(op2,1);
 	gen_load_param_reg(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static INLINE const Bit8u* gen_call_function_IR(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_IR(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_reg(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static INLINE const Bit8u* gen_call_function_I(void * func,Bitu op) {
+static inline const Bit8u* gen_call_function_I(void * func,Bitu op) {
 	gen_load_param_imm(op,0);
 	return gen_call_function_setup(func, 1);
 }
 
-static INLINE const Bit8u* gen_call_function_II(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_II(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_imm(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static INLINE const Bit8u* gen_call_function_III(void * func,Bitu op1,Bitu op2,Bitu op3) {
+static inline const Bit8u* gen_call_function_III(void * func,Bitu op1,Bitu op2,Bitu op3) {
 	gen_load_param_imm(op3,2);
 	gen_load_param_imm(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 3);
 }
 
-static INLINE const Bit8u* gen_call_function_IA(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_IA(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_addr(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static INLINE const Bit8u* gen_call_function_IIR(void * func,Bitu op1,Bitu op2,Bitu op3) {
+static inline const Bit8u* gen_call_function_IIR(void * func,Bitu op1,Bitu op2,Bitu op3) {
 	gen_load_param_reg(op3,2);
 	gen_load_param_imm(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 3);
 }
 
-static INLINE const Bit8u* gen_call_function_IIIR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
+static inline const Bit8u* gen_call_function_IIIR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
 	gen_load_param_reg(op4,3);
 	gen_load_param_imm(op3,2);
 	gen_load_param_imm(op2,1);
@@ -579,7 +579,7 @@ static INLINE const Bit8u* gen_call_function_IIIR(void * func,Bitu op1,Bitu op2,
 	return gen_call_function_setup(func, 4);
 }
 
-static INLINE const Bit8u* gen_call_function_IRRR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
+static inline const Bit8u* gen_call_function_IRRR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
 	gen_load_param_reg(op4,3);
 	gen_load_param_reg(op3,2);
 	gen_load_param_reg(op2,1);
@@ -587,12 +587,12 @@ static INLINE const Bit8u* gen_call_function_IRRR(void * func,Bitu op1,Bitu op2,
 	return gen_call_function_setup(func, 4);
 }
 
-static INLINE const Bit8u* gen_call_function_m(void * func,Bitu op) {
+static inline const Bit8u* gen_call_function_m(void * func,Bitu op) {
 	gen_load_param_mem(op,2);
 	return gen_call_function_setup(func, 3, true);
 }
 
-static INLINE const Bit8u* gen_call_function_mm(void * func,Bitu op1,Bitu op2) {
+static inline const Bit8u* gen_call_function_mm(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_mem(op2,3);
 	gen_load_param_mem(op1,2);
 	return gen_call_function_setup(func, 4, true);
@@ -805,7 +805,7 @@ static void dyn_write_word(HostReg reg_addr,HostReg reg_val,bool dword) {
 
 // effective address calculation helper, op2 has to be present!
 // loads op1 into ea_reg and adds the scaled op2 and the immediate to it
-MAYBE_UNUSED static void dyn_lea_mem_mem(HostReg ea_reg,
+[[maybe_unused]] static void dyn_lea_mem_mem(HostReg ea_reg,
                                          void *op1,
                                          void *op2,
                                          Bitu scale,
@@ -1248,7 +1248,7 @@ static void InvalidateFlagsPartially(void* current_simple_function,const Bit8u* 
 }
 
 // the current function needs the condition flags thus reset the queue
-static void AcquireFlags(MAYBE_UNUSED Bitu flags_mask) {
+static void AcquireFlags([[maybe_unused]] Bitu flags_mask) {
 #ifdef DRC_FLAGS_INVALIDATION
 	mf_functions_num=0;
 #endif

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -248,7 +248,7 @@ static void dyn_dop_byte_imm_mem(DualOps op,Bit8u reg,Bit8u idx) {
 	if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,reg,idx);
 }
 
-static void dyn_prep_word_imm(MAYBE_UNUSED Bit8u reg) {
+static void dyn_prep_word_imm([[maybe_unused]] Bit8u reg) {
 	Bitu val;
 	if (decode.big_op) {
 		if (decode_fetchd_imm(val)) {
@@ -1250,7 +1250,7 @@ static void dyn_iret(void) {
 	dyn_closeblock();
 }
 
-MAYBE_UNUSED static void dyn_interrupt(Bit8u num)
+[[maybe_unused]] static void dyn_interrupt(Bit8u num)
 {
 	dyn_reduce_cycles();
 	dyn_set_eip_last_end(FC_RETOP);

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -52,14 +52,14 @@ static void FPU_FFREE(Bitu st) {
 #endif
 
 
-static INLINE void dyn_fpu_top() {
+static inline void dyn_fpu_top() {
 	gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
 	gen_add_imm(FC_OP2,decode.modrm.rm);
 	gen_and_imm(FC_OP2,7);
 	gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
 }
 
-static INLINE void dyn_fpu_top_swapped() {
+static inline void dyn_fpu_top_swapped() {
 	gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
 	gen_add_imm(FC_OP1,decode.modrm.rm);
 	gen_and_imm(FC_OP1,7);

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -85,7 +85,7 @@ static void DRC_CALL_CONV dynrec_cmp_byte(Bit8u op1,Bit8u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_cmp_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_byte_simple(MAYBE_UNUSED Bit8u op1,MAYBE_UNUSED Bit8u op2) {
+static void DRC_CALL_CONV dynrec_cmp_byte_simple([[maybe_unused]] Bit8u op1,[[maybe_unused]] Bit8u op2) {
 }
 
 static Bit8u DRC_CALL_CONV dynrec_xor_byte(Bit8u op1,Bit8u op2) DRC_FC;
@@ -139,7 +139,7 @@ static void DRC_CALL_CONV dynrec_test_byte(Bit8u op1,Bit8u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_test_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_byte_simple(MAYBE_UNUSED Bit8u op1,MAYBE_UNUSED Bit8u op2) {
+static void DRC_CALL_CONV dynrec_test_byte_simple([[maybe_unused]] Bit8u op1,[[maybe_unused]] Bit8u op2) {
 }
 
 static Bit16u DRC_CALL_CONV dynrec_add_word(Bit16u op1,Bit16u op2) DRC_FC;
@@ -209,7 +209,7 @@ static void DRC_CALL_CONV dynrec_cmp_word(Bit16u op1,Bit16u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_cmp_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_word_simple(MAYBE_UNUSED Bit16u op1, MAYBE_UNUSED Bit16u op2) {
+static void DRC_CALL_CONV dynrec_cmp_word_simple([[maybe_unused]] Bit16u op1, [[maybe_unused]] Bit16u op2) {
 }
 
 static Bit16u DRC_CALL_CONV dynrec_xor_word(Bit16u op1,Bit16u op2) DRC_FC;
@@ -263,7 +263,7 @@ static void DRC_CALL_CONV dynrec_test_word(Bit16u op1,Bit16u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_test_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_word_simple(MAYBE_UNUSED Bit16u op1, MAYBE_UNUSED Bit16u op2) {
+static void DRC_CALL_CONV dynrec_test_word_simple([[maybe_unused]] Bit16u op1, [[maybe_unused]] Bit16u op2) {
 }
 
 static Bit32u DRC_CALL_CONV dynrec_add_dword(Bit32u op1,Bit32u op2) DRC_FC;
@@ -333,7 +333,7 @@ static void DRC_CALL_CONV dynrec_cmp_dword(Bit32u op1,Bit32u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_cmp_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_dword_simple(MAYBE_UNUSED Bit32u op1, MAYBE_UNUSED Bit32u op2) {
+static void DRC_CALL_CONV dynrec_cmp_dword_simple([[maybe_unused]] Bit32u op1, [[maybe_unused]] Bit32u op2) {
 }
 
 static Bit32u DRC_CALL_CONV dynrec_xor_dword(Bit32u op1,Bit32u op2) DRC_FC;
@@ -387,7 +387,7 @@ static void DRC_CALL_CONV dynrec_test_dword(Bit32u op1,Bit32u op2) {
 }
 
 static void DRC_CALL_CONV dynrec_test_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_dword_simple(MAYBE_UNUSED Bit32u op1, MAYBE_UNUSED Bit32u op2) {
+static void DRC_CALL_CONV dynrec_test_dword_simple([[maybe_unused]] Bit32u op1, [[maybe_unused]] Bit32u op2) {
 }
 
 

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -80,4 +80,4 @@ typedef Bit8u HostReg;
 #define HOST_lr HOST_r14
 #define HOST_pc HOST_r15
 
-static void cache_block_closing(MAYBE_UNUSED const Bit8u *block_start, MAYBE_UNUSED Bitu block_size) { }
+static void cache_block_closing([[maybe_unused]] const Bit8u *block_start, [[maybe_unused]] Bitu block_size) { }

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -371,7 +371,7 @@ static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
 }
 
 // helper function for gen_mov_word_to_reg
-static void gen_mov_word_to_reg_helper(HostReg dest_reg, MAYBE_UNUSED void* data,bool dword,HostReg data_reg) {
+static void gen_mov_word_to_reg_helper(HostReg dest_reg, [[maybe_unused]] void* data,bool dword,HostReg data_reg) {
 	// alignment....
 	if (dword) {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
@@ -417,7 +417,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void INLINE gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
 	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
 }
 
@@ -475,7 +475,7 @@ static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
 }
 
 // helper function for gen_mov_word_from_reg
-static void gen_mov_word_from_reg_helper(HostReg src_reg, MAYBE_UNUSED void* dest,bool dword, HostReg data_reg) {
+static void gen_mov_word_from_reg_helper(HostReg src_reg, [[maybe_unused]] void* dest,bool dword, HostReg data_reg) {
 	// alignment....
 	if (dword) {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
@@ -533,7 +533,7 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	gen_mov_byte_to_reg_low(dest_reg, data);
 }
 
@@ -549,12 +549,12 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
-MAYBE_UNUSED static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
+[[maybe_unused]] static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
 		gen_mov_dword_to_reg_imm(temp1, (Bit32u)dest);
 		cache_addd( STRB_IMM(src_reg, temp1, 0) );      // strb src_reg, [temp1]
@@ -672,7 +672,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
@@ -692,7 +692,7 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-MAYBE_UNUSED static void gen_add_direct_byte(void* dest,Bit8s imm) {
+[[maybe_unused]] static void gen_add_direct_byte(void* dest,Bit8s imm) {
 	gen_add_direct_word(dest, (Bit32s)imm, 1);
 }
 
@@ -739,14 +739,14 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-MAYBE_UNUSED static void gen_sub_direct_byte(void* dest,Bit8s imm) {
+[[maybe_unused]] static void gen_sub_direct_byte(void* dest,Bit8s imm) {
 	gen_sub_direct_word(dest, (Bit32s)imm, 1);
 }
 
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	cache_addd( ADD_REG_LSL_IMM(dest_reg, dest_reg, scale_reg, scale) );      // add dest_reg, dest_reg, scale_reg, lsl #(scale)
 	gen_add_imm(dest_reg, imm);
 }
@@ -754,7 +754,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_addd( MOV_REG_LSL_IMM(dest_reg, dest_reg, scale) );      // mov dest_reg, dest_reg, lsl #(scale)
 	}
@@ -762,7 +762,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 #if C_TARGETCPU == ARMV7LE
 	cache_addd( MOVW(temp1, ((Bit32u)func) & 0xffff) );      // movw temp1, #(func & 0xffff)
 	cache_addd( MOVT(temp1, ((Bit32u)func) >> 16) );      // movt temp1, #(func >> 16)
@@ -778,7 +778,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bitu paramcount, MAYBE_UNUSED bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -788,22 +788,22 @@ static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bit
 // max of 4 parameters in a1-a4
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(param, reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(param, (void *)mem, 1);
 }
 #else
@@ -866,7 +866,7 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const Bit8u* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+8);
 	if (len<0) len=-len;
@@ -898,7 +898,7 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	gen_fill_branch(data);
 }
 

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -187,7 +187,7 @@ static Bit32u cache_dataindex = 0;		// used size of data pool = index of free da
 
 
 // forwarded function
-static void INLINE gen_create_branch_short(const Bit8u * func);
+static void inline gen_create_branch_short(const Bit8u * func);
 
 // function to check distance to data pool
 // if too close, then generate jump after data pool
@@ -471,7 +471,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void INLINE gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
 	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
 }
 
@@ -597,7 +597,7 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	gen_mov_byte_to_reg_low(dest_reg, data);
 }
 
@@ -614,7 +614,7 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
@@ -726,7 +726,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
@@ -798,7 +798,7 @@ static void gen_sub_direct_byte(void* dest,Bit8s imm) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_checkinstr(4);
 		cache_addw( LSL_IMM(templo1, scale_reg, scale) );      // lsl templo1, scale_reg, #(scale)
@@ -813,7 +813,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_checkinstr(2);
 		cache_addw( LSL_IMM(dest_reg, dest_reg, scale) );      // lsl dest_reg, dest_reg, #(scale)
@@ -848,7 +848,7 @@ static void gen_call_function_helper(void * func) {
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 	cache_checkinstr(12);
 	gen_call_function_helper(func);
 }
@@ -856,7 +856,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	cache_checkinstr(12);
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_helper(func);
@@ -870,22 +870,22 @@ static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,b
 // max of 4 parameters in a1-a4
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(param, reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(param, (void *)mem, 1);
 }
 #else
@@ -959,7 +959,7 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const Bit8u* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
@@ -1014,7 +1014,7 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	// this is an absolute branch
 	cache_addd((Bit32u)cache.pos+1,data); // add 1 to keep processor in thumb state
 }
@@ -1079,7 +1079,7 @@ static void gen_return_function(void) {
 
 // short unconditional jump (over data pool)
 // must emit at most CACHE_DATA_JUMP bytes
-static void INLINE gen_create_branch_short(const Bit8u * func) {
+static void inline gen_create_branch_short(const Bit8u * func) {
 	cache_addw( B_FWD(func - (cache.pos + 4)) );      // b func
 }
 
@@ -1454,7 +1454,7 @@ static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+static void inline gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
 	cache_checkinstr(4);
 	cache_addw( MOV_LO_HI(templo2, FC_REGS_ADDR) );      // mov templo2, FC_REGS_ADDR
 	cache_addw( LDRB_IMM(dest_reg, templo2, index) );      // ldrb dest_reg, [templo2, #index]

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -184,7 +184,7 @@ static Bit32u cache_dataindex = 0;		// used size of data pool = index of free da
 
 
 // forwarded function
-static void INLINE gen_create_branch_short(const Bit8u * func);
+static void inline gen_create_branch_short(const Bit8u * func);
 
 // function to check distance to data pool
 // if too close, then generate jump after data pool
@@ -468,7 +468,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void INLINE gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
 	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
 }
 
@@ -594,7 +594,7 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	gen_mov_byte_to_reg_low(dest_reg, data);
 }
 
@@ -611,7 +611,7 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
@@ -723,7 +723,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
@@ -795,7 +795,7 @@ static void gen_sub_direct_byte(void* dest,Bit8s imm) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_checkinstr(4);
 		cache_addw( LSL_IMM(templo1, scale_reg, scale) );      // lsl templo1, scale_reg, #(scale)
@@ -810,7 +810,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_checkinstr(2);
 		cache_addw( LSL_IMM(dest_reg, dest_reg, scale) );      // lsl dest_reg, dest_reg, #(scale)
@@ -847,7 +847,7 @@ static void gen_call_function_helper(void * func) {
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 	cache_checkinstr(18);
 	gen_call_function_helper(func);
 }
@@ -855,7 +855,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	cache_checkinstr(18);
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_helper(func);
@@ -869,22 +869,22 @@ static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,b
 // max of 4 parameters in a1-a4
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(param, reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(param, (void *)mem, 1);
 }
 #else
@@ -958,7 +958,7 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const Bit8u* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
@@ -1013,7 +1013,7 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	// this is an absolute branch
 	cache_addd((Bit32u)cache.pos + 1,data); // add 1 to keep processor in thumb state
 }
@@ -1078,7 +1078,7 @@ static void gen_return_function(void) {
 
 // short unconditional jump (over data pool)
 // must emit at most CACHE_DATA_JUMP bytes
-static void INLINE gen_create_branch_short(const Bit8u * func) {
+static void inline gen_create_branch_short(const Bit8u * func) {
 	cache_addw( B_FWD(func - (cache.pos + 4)) );      // b func
 }
 
@@ -1484,7 +1484,7 @@ static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+static void inline gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
 	cache_checkinstr(4);
 	cache_addw( MOV_LO_HI(templo2, FC_REGS_ADDR) );      // mov templo2, FC_REGS_ADDR
 	cache_addw( LDRB_IMM(dest_reg, templo2, index) );      // ldrb dest_reg, [templo2, #index]

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -338,7 +338,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void INLINE gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
 	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
 }
 
@@ -455,7 +455,7 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	gen_mov_byte_to_reg_low(dest_reg, data);
 }
 
@@ -471,7 +471,7 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
@@ -572,7 +572,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
@@ -640,7 +640,7 @@ static void gen_sub_direct_byte(void* dest,Bit8s imm) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_addw( LSL_IMM(templo1, scale_reg, scale) );      // lsl templo1, scale_reg, #(scale)
 		cache_addw( ADD_REG(dest_reg, dest_reg, templo1) );      // add dest_reg, dest_reg, templo1
@@ -653,7 +653,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_addw( LSL_IMM(dest_reg, dest_reg, scale) );      // lsl dest_reg, dest_reg, #(scale)
 	}
@@ -661,7 +661,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 	if (((Bit32u)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, 4) );      // ldr templo1, [pc, #4]
 		cache_addw( ADD_LO_PC_IMM(templo2, 8) );      // adr templo2, after_call (add templo2, pc, #8)
@@ -687,7 +687,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -700,22 +700,22 @@ static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,b
 // max of 4 parameters in a1-a4
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_dword_to_reg_imm(param, addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(param, reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(param, (void *)mem, 1);
 }
 #else
@@ -784,7 +784,7 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const Bit8u* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
@@ -836,7 +836,7 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	// this is an absolute branch
 	cache_addd((Bit32u)cache.pos + 1,data); // add 1 to keep processor in thumb state
 }
@@ -1287,7 +1287,7 @@ static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+static void inline gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
 	cache_addw( MOV_LO_HI(templo2, FC_REGS_ADDR) );      // mov templo2, FC_REGS_ADDR
 	cache_addw( LDRB_IMM(dest_reg, templo2, index) );      // ldrb dest_reg, [templo2, #index]
 }

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -447,7 +447,7 @@ static void gen_mov_qword_to_reg_imm(HostReg dest_reg,Bit64u imm) {
 }
 
 // helper function for gen_mov_word_to_reg
-static void gen_mov_word_to_reg_helper(HostReg dest_reg, MAYBE_UNUSED void* data,bool dword,HostReg data_reg) {
+static void gen_mov_word_to_reg_helper(HostReg dest_reg, [[maybe_unused]] void* data,bool dword,HostReg data_reg) {
 	if (dword) {
 		cache_addd( LDR_IMM(dest_reg, data_reg, 0) );       // ldr dest_reg, [data_reg]
 	} else {
@@ -466,7 +466,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void INLINE gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
 	cache_addd( MOVZ(dest_reg, imm, 0) );   // movz dest_reg, #imm
 }
 
@@ -523,7 +523,7 @@ static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
 }
 
 // helper function for gen_mov_word_from_reg
-static void gen_mov_word_from_reg_helper(HostReg src_reg, MAYBE_UNUSED void* dest,bool dword, HostReg data_reg) {
+static void gen_mov_word_from_reg_helper(HostReg src_reg, [[maybe_unused]] void* dest,bool dword, HostReg data_reg) {
 	if (dword) {
 		cache_addd( STR_IMM(src_reg, data_reg, 0) );        // str src_reg, [data_reg]
 	} else {
@@ -554,7 +554,7 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	gen_mov_byte_to_reg_low(dest_reg, data);
 }
 
@@ -570,7 +570,7 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
@@ -664,7 +664,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bitu imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bitu imm) {
 	gen_mov_qword_to_reg_imm(temp3, imm);
 	if (!gen_mov_memval_from_reg(temp3, dest, 8)) {
 		gen_mov_qword_to_reg_imm(temp1, (Bit64u)dest);
@@ -735,7 +735,7 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	cache_addd( ADD_REG_LSL_IMM(dest_reg, dest_reg, scale_reg, scale) );      // add dest_reg, dest_reg, scale_reg, lsl #scale
 	gen_add_imm(dest_reg, imm);
 }
@@ -743,7 +743,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_addd( MOV_REG_LSL_IMM(dest_reg, dest_reg, scale) );      // mov dest_reg, dest_reg, lsl #scale
 	}
@@ -751,7 +751,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 	cache_addd( MOVZ64(temp1, ((Bit64u)func) & 0xffff, 0) );            // movz dest_reg, #(func & 0xffff)
 	cache_addd( MOVK64(temp1, (((Bit64u)func) >> 16) & 0xffff, 16) );   // movk dest_reg, #((func >> 16) & 0xffff), lsl #16
 	cache_addd( MOVK64(temp1, (((Bit64u)func) >> 32) & 0xffff, 32) );   // movk dest_reg, #((func >> 32) & 0xffff), lsl #32
@@ -762,29 +762,29 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bitu paramcount, MAYBE_UNUSED bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
 }
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_qword_to_reg_imm(param, imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_qword_to_reg_imm(param, addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(param, reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(param, (void *)mem, 1);
 }
 
@@ -832,7 +832,7 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const Bit8u* data) {
 #if C_DEBUG
 	Bits len=cache.pos-data;
 	if (len<0) len=-len;
@@ -866,7 +866,7 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	// optimize for shorter branches ?
 	Bit32u offset = (Bit32u)(cache.pos-data) >> 2;
 	cache_addd(((data[3]<<24)&~0x03ffffff)|(offset&0x03ffffff),data);
@@ -1133,8 +1133,8 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 }
 #endif
 
-static void cache_block_closing(MAYBE_UNUSED const Bit8u *block_start,
-                                MAYBE_UNUSED Bitu block_size) { }
+static void cache_block_closing([[maybe_unused]] const Bit8u *block_start,
+                                [[maybe_unused]] Bitu block_size) { }
 
 static void cache_block_before_close(void) { }
 

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -120,7 +120,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 }
 
 // this is the only place temp1 should be modified
-static void INLINE mov_imm_to_temp1(Bit32u imm) {
+static void inline mov_imm_to_temp1(Bit32u imm) {
 	if (temp1_valid && (temp1_value == imm)) return;
 	gen_mov_dword_to_reg_imm(temp1, imm);
 	temp1_valid = true;
@@ -225,7 +225,7 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
+static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	gen_mov_byte_to_reg_low(dest_reg, data);
 }
 
@@ -233,7 +233,7 @@ static void INLINE gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 	gen_mov_word_to_reg_imm(dest_reg, imm);
 }
 
@@ -241,7 +241,7 @@ static void INLINE gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
@@ -320,18 +320,18 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void INLINE gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_dword(void* dest,Bit32u imm) {
 	gen_mov_dword_to_reg_imm(temp2, imm);
 	gen_mov_word_from_reg(temp2, dest, 1);
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void INLINE gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void inline gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 	if(!imm) return;
 	gen_mov_word_to_reg(temp2, dest, dword);
 	gen_add_imm(temp2, imm);
@@ -339,24 +339,24 @@ static void INLINE gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-static void INLINE gen_add_direct_byte(void* dest,Bit8s imm) {
+static void inline gen_add_direct_byte(void* dest,Bit8s imm) {
 	gen_add_direct_word(dest, (Bit32s)imm, 1);
 }
 
 // subtract an 8bit constant value from a dword memory value
-static void INLINE gen_sub_direct_byte(void* dest,Bit8s imm) {
+static void inline gen_sub_direct_byte(void* dest,Bit8s imm) {
 	gen_add_direct_word(dest, -((Bit32s)imm), 1);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void INLINE gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
+static void inline gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 	gen_add_direct_word(dest, -(Bit32s)imm, dword);
 }
 
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_addw((scale_reg<<11)+(scale<<6));		// sll scale_reg, scale_reg, scale
 		cache_addw(scale_reg);
@@ -369,7 +369,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	if (scale) {
 		cache_addw((dest_reg<<11)+(scale<<6));		// sll dest_reg, dest_reg, scale
 		cache_addw(dest_reg);
@@ -380,7 +380,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 #define DELAY cache_addd(0)			// nop
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 #if C_DEBUG
 	if (((Bit32u)cache.pos ^ (Bit32u)func) & 0xf0000000) LOG_MSG("jump overflow\n");
 #endif
@@ -392,7 +392,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -402,22 +402,22 @@ static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,b
 // max of 8 parameters in $a0-$a3 and $t0-$t3
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_dword_to_reg_imm(param+4, imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_dword_to_reg_imm(param+4, addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(param+4, reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(param+4, (void *)mem, 1);
 }
 #else
@@ -425,7 +425,7 @@ static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
 #endif
 
 // jump to an address pointed at by ptr, offset is in imm
-static void INLINE gen_jmp_ptr(void * ptr,Bits imm=0) {
+static void inline gen_jmp_ptr(void * ptr,Bits imm=0) {
 	gen_mov_word_to_reg(temp2, ptr, 1);
 	if((imm < -32768) || (imm >= 32768)) {
 		gen_add_imm(temp2, imm);
@@ -440,7 +440,7 @@ static void INLINE gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static INLINE const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static inline const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	temp1_valid = false;
 	if(!dword) { 
 		cache_addw(0xffff);	// andi temp1, reg, 0xffff
@@ -454,7 +454,7 @@ static INLINE const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static INLINE const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static inline const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	temp1_valid = false;
 	if(!dword) { 
 		cache_addw(0xffff);	// andi temp1, reg, 0xffff
@@ -467,7 +467,7 @@ static INLINE const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) 
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const Bit8u* data) {
 #if C_DEBUG
 	Bits len=cache.pos-data;
 	if (len<0) len=-len;
@@ -497,7 +497,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static INLINE const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static inline const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 	temp1_valid = false;
 	cache_addw(3);				// bgtz reg, +12
 	cache_addw(0x1c00+(reg<<5));
@@ -508,7 +508,7 @@ static INLINE const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	temp1_valid = false;
 	// this is an absolute branch
 	cache_addd(0x08000000+(((Bit32u)cache.pos>>2)&0x3ffffff),data);
@@ -530,7 +530,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static INLINE const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static inline const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 	temp1_valid = false;
 	cache_addw(0);			// blez reg, 0
 	cache_addw(0x1800+(reg<<5));
@@ -539,7 +539,7 @@ static INLINE const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const Bit8u* data) {
 	gen_fill_branch(data);
 }
 #endif
@@ -710,7 +710,7 @@ static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+static void inline gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
 // stub
 }
 

--- a/src/cpu/core_dynrec/risc_ppc.h
+++ b/src/cpu/core_dynrec/risc_ppc.h
@@ -155,7 +155,7 @@ static void gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm)
 DRC_PTR_SIZE_IM block_ptr;
 
 // Helper for loading addresses
-static HostReg INLINE gen_addr(Bit32s &addr, HostReg dest)
+static HostReg inline gen_addr(Bit32s &addr, HostReg dest)
 {
 	Bit32s off;
 
@@ -395,7 +395,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory (assumes address != NULL)
-static void INLINE gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm)
+static void inline gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm)
 {
 	block_ptr = 0;
 	gen_mov_dword_to_reg_imm(HOST_R27, imm);
@@ -436,7 +436,7 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm)
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm)
 {
 	if (scale)
 	{
@@ -451,7 +451,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm)
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm)
 {
 	if (scale)
 	{
@@ -462,7 +462,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm)
 }
 
 // helper function to choose direct or indirect call
-static int INLINE do_gen_call(void *func, Bit32u *pos, bool pad)
+static int inline do_gen_call(void *func, Bit32u *pos, bool pad)
 {
 	Bit32s f = (Bit32s)func;
 	Bit32s off = f - (Bit32s)pos;
@@ -488,7 +488,7 @@ static int INLINE do_gen_call(void *func, Bit32u *pos, bool pad)
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func,bool fastcall=true)
+static void inline gen_call_function_raw(void * func,bool fastcall=true)
 {
 	cache.pos += do_gen_call(func, (Bit32u*)cache.pos, fastcall);
 }
@@ -496,7 +496,7 @@ static void INLINE gen_call_function_raw(void * func,bool fastcall=true)
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static Bit32u INLINE gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false)
+static Bit32u inline gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false)
 {
 	Bit32u proc_addr=(Bit32u)cache.pos;
 	gen_call_function_raw(func,fastcall);
@@ -504,22 +504,22 @@ static Bit32u INLINE gen_call_function_setup(void * func,Bitu paramcount,bool fa
 }
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	gen_mov_dword_to_reg_imm(RegParams[param], imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_load_param_imm(addr, param);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	gen_mov_regs(RegParams[param], (HostReg)reg);
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	gen_mov_word_to_reg(RegParams[param], (void*)mem, true);
 }
 
@@ -860,7 +860,7 @@ static void gen_mov_regbyte_to_reg_low(HostReg dest_reg,Bitu index)
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
+static void inline gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg,Bitu index) {
 	gen_mov_byte_to_reg_low_canuseword(dest_reg, (Bit8u*)&cpu_regs + index);
 }
 

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -162,7 +162,7 @@ DRC_PTR_SIZE_IM block_ptr;
 
 // Helper for loading addresses
 // Emits relevant code to load the upper 48 bits if needed
-static HostReg INLINE gen_addr(Bit64s &addr, HostReg dest)
+static HostReg inline gen_addr(Bit64s &addr, HostReg dest)
 {
 	Bit64s off;
 
@@ -422,7 +422,7 @@ static void gen_mov_direct_dword(void *dest, Bit32u imm)
 }
 
 // move an address into memory (assumes address != NULL)
-static void INLINE gen_mov_direct_ptr(void *dest, DRC_PTR_SIZE_IM imm)
+static void inline gen_mov_direct_ptr(void *dest, DRC_PTR_SIZE_IM imm)
 {
 	block_ptr = 0;
 	gen_mov_qword_to_reg_imm(HOST_R27, imm);
@@ -469,7 +469,7 @@ static void gen_sub_direct_word(void *dest, Bit32u imm, bool dword)
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg, HostReg scale_reg, Bitu scale, Bits imm)
+static inline void gen_lea(HostReg dest_reg, HostReg scale_reg, Bitu scale, Bits imm)
 {
 	if (scale)
 	{
@@ -484,7 +484,7 @@ static INLINE void gen_lea(HostReg dest_reg, HostReg scale_reg, Bitu scale, Bits
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg, Bitu scale, Bits imm)
+static inline void gen_lea(HostReg dest_reg, Bitu scale, Bits imm)
 {
 	if (scale)
 	{
@@ -495,7 +495,7 @@ static INLINE void gen_lea(HostReg dest_reg, Bitu scale, Bits imm)
 }
 
 // helper function to choose direct or indirect call
-static int INLINE do_gen_call(void *func, Bit64u *npos, bool pad)
+static int inline do_gen_call(void *func, Bit64u *npos, bool pad)
 {
 	Bit64s f = (Bit64s)func;
 	Bit64s off = f - (Bit64s)npos;
@@ -534,7 +534,7 @@ static int INLINE do_gen_call(void *func, Bit64u *npos, bool pad)
 }
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void *func, bool fastcall = true)
+static void inline gen_call_function_raw(void *func, bool fastcall = true)
 {
 	cache.pos += do_gen_call(func, (Bit64u*)cache.pos, fastcall);
 }
@@ -542,7 +542,7 @@ static void INLINE gen_call_function_raw(void *func, bool fastcall = true)
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static Bit64u INLINE gen_call_function_setup(void *func,
+static Bit64u inline gen_call_function_setup(void *func,
                                              Bitu paramcount,
                                              bool fastcall = false)
 {
@@ -553,28 +553,28 @@ static Bit64u INLINE gen_call_function_setup(void *func,
 
 // load an immediate value as param'th function parameter
 // these are 32-bit (see risc_x64.h)
-static void INLINE gen_load_param_imm(Bitu imm, Bitu param)
+static void inline gen_load_param_imm(Bitu imm, Bitu param)
 {
 	gen_mov_dword_to_reg_imm(RegParams[param], imm);
 }
 
 // load an address as param'th function parameter
 // 32-bit
-static void INLINE gen_load_param_addr(Bitu addr, Bitu param)
+static void inline gen_load_param_addr(Bitu addr, Bitu param)
 {
 	gen_load_param_imm(addr, param);
 }
 
 // load a host-register as param'th function parameter
 // 32-bit
-static void INLINE gen_load_param_reg(Bitu reg, Bitu param)
+static void inline gen_load_param_reg(Bitu reg, Bitu param)
 {
 	gen_mov_regs(RegParams[param], (HostReg)reg);
 }
 
 // load a value from memory as param'th function parameter
 // 32-bit
-static void INLINE gen_load_param_mem(Bitu mem, Bitu param)
+static void inline gen_load_param_mem(Bitu mem, Bitu param)
 {
 	gen_mov_word_to_reg(RegParams[param], (void*)mem, true);
 }
@@ -959,7 +959,7 @@ static void gen_mov_regbyte_to_reg_low(HostReg dest_reg, Bitu index)
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void INLINE gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg, Bitu index)
+static void inline gen_mov_regbyte_to_reg_low_canuseword(HostReg dest_reg, Bitu index)
 {
 	gen_mov_byte_to_reg_low_canuseword(dest_reg, (Bit8u*)&cpu_regs + index);
 }

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -88,7 +88,7 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 static void gen_mov_reg_qword(HostReg dest_reg,Bit64u imm);
 
 // This function generates an instruction with register addressing and a memory location
-static INLINE void gen_reg_memaddr(HostReg reg,void* data,Bit8u op,Bit8u prefix=0) {
+static inline void gen_reg_memaddr(HostReg reg,void* data,Bit8u op,Bit8u prefix=0) {
 	Bit64s diff = (Bit64s)data-((Bit64s)cache.pos+(prefix?7:6));
 //	if ((diff<0x80000000LL) && (diff>-0x80000000LL)) { //clang messes itself up on this...
 	if ( (diff>>63) == (diff>>31) ) { //signed bit extend, test to see if value fits in a Bit32s
@@ -121,7 +121,7 @@ static INLINE void gen_reg_memaddr(HostReg reg,void* data,Bit8u op,Bit8u prefix=
 }
 
 // Same as above, but with immediate addressing and a memory location
-static INLINE void gen_memaddr(Bitu modreg,void* data,Bitu off,Bitu imm,Bit8u op,Bit8u prefix=0) {
+static inline void gen_memaddr(Bitu modreg,void* data,Bitu off,Bitu imm,Bit8u op,Bit8u prefix=0) {
 	Bit64s diff = (Bit64s)data-((Bit64s)cache.pos+off+(prefix?7:6));
 //	if ((diff<0x80000000LL) && (diff>-0x80000000LL)) {
 	if ( (diff>>63) == (diff>>31) ) {
@@ -287,7 +287,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bitu imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bitu imm) {
 	gen_mov_reg_qword(HOST_EAX,imm);
 	gen_mov_word_from_reg(HOST_EAX,dest,true,0x48);		// 0x48 prefixes full 64-bit mov
 }
@@ -330,7 +330,7 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	Bit8u rm_base;
 	Bitu imm_size;
 	if (!imm) {
@@ -357,7 +357,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	// ea_reg := ea_reg*(2^scale)+imm
 	// ea_reg :=   op2 *(2^scale)+imm
 	cache_addb(0x48);
@@ -371,7 +371,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 	cache_addw(0xb848);
 	cache_addq((Bit64u)func);
 	cache_addw(0xd0ff);
@@ -380,7 +380,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bitu paramcount, MAYBE_UNUSED bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
 	const Bit8u* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -388,7 +388,7 @@ static INLINE const Bit8u* gen_call_function_setup(void * func, MAYBE_UNUSED Bit
 
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	// move an immediate 32bit value into a 64bit param reg
 	switch (param) {
 		case 0:			// mov param1,imm32
@@ -421,7 +421,7 @@ static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	// move an immediate 64bit value into a 64bit param reg
 	switch (param) {
 		case 0:			// mov param1,addr64
@@ -454,7 +454,7 @@ static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	// move a register into a 64bit param reg, {inputregs}!={outputregs}
 	switch (param) {
 		case 0:		// mov param1,reg&7
@@ -487,7 +487,7 @@ static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	// move memory content into a 64bit param reg
 	switch (param) {
 		case 0:		// mov param1,[mem]
@@ -693,6 +693,6 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 }
 #endif
 
-static void cache_block_closing(MAYBE_UNUSED const Bit8u* block_start, MAYBE_UNUSED Bitu block_size) { }
+static void cache_block_closing([[maybe_unused]] const Bit8u* block_start, [[maybe_unused]] Bitu block_size) { }
 
 static void cache_block_before_close(void) { }

--- a/src/cpu/core_dynrec/risc_x86.h
+++ b/src/cpu/core_dynrec/risc_x86.h
@@ -205,7 +205,7 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,Bitu imm) {
+static void inline gen_mov_direct_ptr(void* dest,Bitu imm) {
 	gen_mov_direct_dword(dest,(Bit32u)imm);
 }
 
@@ -255,7 +255,7 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 // effective address calculation, destination is dest_reg
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
 	Bit8u rm_base;
 	Bitu imm_size;
 	if (!imm) {
@@ -281,7 +281,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 // effective address calculation, destination is dest_reg
 // dest_reg is scaled by scale (dest_reg*(2^scale)),
 // then the immediate value is added
-static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
+static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	// ea_reg := ea_reg*(2^scale)+imm
 	// ea_reg :=   op2 *(2^scale)+imm
 	cache_addb(0x8d);			//LEA
@@ -294,7 +294,7 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 
 // generate a call to a parameterless function
-static void INLINE gen_call_function_raw(void * func) {
+static void inline gen_call_function_raw(void * func) {
 	cache_addb(0xe8);
 	cache_addd((Bit32u)func - (Bit32u)cache.pos-4);
 }
@@ -302,7 +302,7 @@ static void INLINE gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	const Bit8u* proc_addr=cache.pos;
 	// Do the actual call to the procedure
 	cache_addb(0xe8);
@@ -318,24 +318,24 @@ static INLINE const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,b
 
 
 // load an immediate value as param'th function parameter
-static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
+static void inline gen_load_param_imm(Bitu imm,Bitu param) {
 	cache_addb(0x68);			// push immediate
 	cache_addd(imm);
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
+static void inline gen_load_param_addr(Bitu addr,Bitu param) {
 	cache_addb(0x68);			// push immediate (address)
 	cache_addd(addr);
 }
 
 // load a host-register as param'th function parameter
-static void INLINE gen_load_param_reg(Bitu reg,Bitu param) {
+static void inline gen_load_param_reg(Bitu reg,Bitu param) {
 	cache_addb(0x50+(reg&7));	// push reg
 }
 
 // load a value from memory as param'th function parameter
-static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
+static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 	cache_addw(0x35ff);			// push []
 	cache_addd(mem);
 }

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -50,7 +50,7 @@ l_MODRMswitch:
 			break;
 		case M_EbIb:
 			inst_op2_d=Fetchb();
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Eb:
 			if (inst.rm<0xc0) inst_op1_d=LoadMb(inst.rm_eaa);
 			else inst_op1_d=reg_8(inst.rm_eai);
@@ -63,7 +63,7 @@ l_MODRMswitch:
 		case M_GbEb:
 			if (inst.rm<0xc0) inst_op2_d=LoadMb(inst.rm_eaa);
 			else inst_op2_d=reg_8(inst.rm_eai);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Gb:
 			inst_op1_d=reg_8(inst.rm_index);;
 			break;
@@ -79,7 +79,7 @@ l_MODRMswitch:
 			goto l_M_Ewx;
 		case M_EwxIwx:
 			inst_op2_ds=Fetchws();
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Ewx:
 l_M_Ewx:
 			if (inst.rm<0xc0) inst_op1_ds=(Bit16s)LoadMw(inst.rm_eaa);
@@ -107,7 +107,7 @@ l_M_Ewx:
 		case M_EwGw:
 l_M_EwGw:
 			inst_op2_d=reg_16(inst.rm_index);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Ew:
 l_M_Ew:
 			if (inst.rm<0xc0) inst_op1_d=LoadMw(inst.rm_eaa);
@@ -116,7 +116,7 @@ l_M_Ew:
 		case M_GwEw:
 			if (inst.rm<0xc0) inst_op2_d=LoadMw(inst.rm_eaa);
 			else inst_op2_d=reg_16(inst.rm_eai);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Gw:
 			inst_op1_d=reg_16(inst.rm_index);;
 			break;
@@ -126,7 +126,7 @@ l_M_Ew:
 			break;
 		case M_EdxGdx:
 			inst_op2_ds=(Bit32s)reg_32(inst.rm_index);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Edx:
 			if (inst.rm<0xc0) inst_op1_d=(Bit32s)LoadMd(inst.rm_eaa);
 			else inst_op1_d=(Bit32s)reg_32(inst.rm_eai);
@@ -153,7 +153,7 @@ l_M_Ew:
 		case M_EdGd:
 l_M_EdGd:
 			inst_op2_d=reg_32(inst.rm_index);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Ed:
 l_M_Ed:
 			if (inst.rm<0xc0) inst_op1_d=LoadMd(inst.rm_eaa);
@@ -162,7 +162,7 @@ l_M_Ed:
 		case M_GdEd:
 			if (inst.rm<0xc0) inst_op2_d=LoadMd(inst.rm_eaa);
 			else inst_op2_d=reg_32(inst.rm_eai);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_Gd:
 			inst_op1_d=reg_32(inst.rm_index);
 			break;
@@ -258,19 +258,19 @@ l_M_Ed:
 /* Direct load of registers */
 	case L_REGbIb:
 		inst_op2_d=Fetchb();
-		FALLTHROUGH;
+		[[fallthrough]];
 	case L_REGb:
 		inst_op1_d=reg_8(inst.code.extra);
 		break;
 	case L_REGwIw:
 		inst_op2_d=Fetchw();
-		FALLTHROUGH;
+		[[fallthrough]];
 	case L_REGw:
 		inst_op1_d=reg_16(inst.code.extra);
 		break;
 	case L_REGdId:
 		inst_op2_d=Fetchd();
-		FALLTHROUGH;
+		[[fallthrough]];
 	case L_REGd:
 		inst_op1_d=reg_32(inst.code.extra);
 		break;

--- a/src/cpu/core_full/loadwrite.h
+++ b/src/cpu/core_full/loadwrite.h
@@ -25,18 +25,18 @@
 	continue;													\
 }
 
-static INLINE Bit8u the_Fetchb(EAPoint & loc) {
+static inline Bit8u the_Fetchb(EAPoint & loc) {
 	Bit8u temp=LoadMb(loc);
 	loc+=1;
 	return temp;
 }
 	
-static INLINE Bit16u the_Fetchw(EAPoint & loc) {
+static inline Bit16u the_Fetchw(EAPoint & loc) {
 	Bit16u temp=LoadMw(loc);
 	loc+=2;
 	return temp;
 }
-static INLINE Bit32u the_Fetchd(EAPoint & loc) {
+static inline Bit32u the_Fetchd(EAPoint & loc) {
 	Bit32u temp=LoadMd(loc);
 	loc+=4;
 	return temp;

--- a/src/cpu/core_full/save.h
+++ b/src/cpu/core_full/save.h
@@ -21,7 +21,7 @@ switch (inst.code.save) {
 /* Byte */
 	case S_C_Eb:
 		inst_op1_b=inst.cond ? 1 : 0;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case S_Eb:
 		if (inst.rm<0xc0) SaveMb(inst.rm_eaa,inst_op1_b);
 		else reg_8(inst.rm_eai)=inst_op1_b;
@@ -94,7 +94,7 @@ switch (inst.code.save) {
 
 	case S_C_AIPw:
 		if (!inst.cond) goto nextopcode;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case S_AIPw:
 		SaveIP();
 		reg_eip+=inst_op1_d;
@@ -102,14 +102,14 @@ switch (inst.code.save) {
 		continue;
 	case S_C_AIPd:
 		if (!inst.cond) goto nextopcode;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case S_AIPd:
 		SaveIP();
 		reg_eip+=inst_op1_d;
 		continue;
 	case S_IPIw:
 		reg_esp+=Fetchw();
-		FALLTHROUGH;
+		[[fallthrough]];
 	case S_IP:
 		SaveIP();
 		reg_eip=inst_op1_d;

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -109,18 +109,18 @@ static struct {
 #define BaseDS		core.base_ds
 #define BaseSS		core.base_ss
 
-static INLINE Bit8u Fetchb() {
+static inline Bit8u Fetchb() {
 	Bit8u temp=LoadMb(core.cseip);
 	core.cseip+=1;
 	return temp;
 }
 
-static INLINE Bit16u Fetchw() {
+static inline Bit16u Fetchw() {
 	Bit16u temp=LoadMw(core.cseip);
 	core.cseip+=2;
 	return temp;
 }
-static INLINE Bit32u Fetchd() {
+static inline Bit32u Fetchd() {
 	Bit32u temp=LoadMd(core.cseip);
 	core.cseip+=4;
 	return temp;

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -167,7 +167,7 @@
 		case 6: \
 			if (rm < 0x40) \
 				break; \
-			FALLTHROUGH; \
+			[[fallthrough]]; \
 		case 2: \
 		case 3: BaseDS = BaseSS; \
 		} \

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -511,7 +511,7 @@
 			switch (which) {
 			case 0x02:					/* MOV SS,Ew */
 				CPU_Cycles++; //Always do another instruction
-				FALLTHROUGH;
+				[[fallthrough]];
 			case 0x00:					/* MOV ES,Ew */
 			case 0x03:					/* MOV DS,Ew */
 			case 0x05:					/* MOV GS,Ew */

--- a/src/cpu/core_normal/support.h
+++ b/src/cpu/core_normal/support.h
@@ -29,14 +29,14 @@
 #define SaveRw(reg,val)	reg=val
 #define SaveRd(reg,val)	reg=val
 
-static INLINE Bit8s Fetchbs() {
+static inline Bit8s Fetchbs() {
 	return Fetchb();
 }
-static INLINE Bit16s Fetchws() {
+static inline Bit16s Fetchws() {
 	return Fetchw();
 }
 
-static INLINE Bit32s Fetchds() {
+static inline Bit32s Fetchds() {
 	return Fetchd();
 }
 

--- a/src/cpu/core_normal/table_ea.h
+++ b/src/cpu/core_normal/table_ea.h
@@ -49,7 +49,7 @@ static PhysPt EA_16_87_n(void) { return BaseDS+(Bit16u)(reg_bx+Fetchws()); }
 static Bit32u SIBZero=0;
 static Bit32u * SIBIndex[8]= { &reg_eax,&reg_ecx,&reg_edx,&reg_ebx,&SIBZero,&reg_ebp,&reg_esi,&reg_edi };
 
-static INLINE PhysPt Sib(Bitu mode) {
+static inline PhysPt Sib(Bitu mode) {
 	Bit8u sib=Fetchb();
 	PhysPt base;
 	switch (sib&7) {

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -105,18 +105,18 @@ static struct {
 #define BaseDS		core.base_ds
 #define BaseSS		core.base_ss
 
-static INLINE Bit8u Fetchb() {
+static inline Bit8u Fetchb() {
 	Bit8u temp=host_readb(core.cseip);
 	core.cseip+=1;
 	return temp;
 }
 
-static INLINE Bit16u Fetchw() {
+static inline Bit16u Fetchw() {
 	Bit16u temp=host_readw(core.cseip);
 	core.cseip+=2;
 	return temp;
 }
-static INLINE Bit32u Fetchd() {
+static inline Bit32u Fetchd() {
 	Bit32u temp=host_readd(core.cseip);
 	core.cseip+=4;
 	return temp;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -708,7 +708,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bitu oldeip) {
 					} 
 					if (cs_dpl!=cpu.cpl)
 						E_Exit("Non-conforming intra privilege INT with DPL!=CPL");
-					FALLTHROUGH;
+					[[fallthrough]];
 				case DESC_CODE_N_C_A:	case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:	case DESC_CODE_R_C_NA:
 					/* Prepare stack for gate to same priviledge */
@@ -1259,7 +1259,7 @@ call_code:
 						break;		
 					} else if (n_cs_dpl > cpu.cpl)
 						E_Exit("CALL:GATE:CS DPL>CPL");		// or #GP(sel)
-					FALLTHROUGH;
+					[[fallthrough]];
 				case DESC_CODE_N_C_A:case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:case DESC_CODE_R_C_NA:
 					// zrdx extender
@@ -1311,7 +1311,7 @@ call_code:
 }
 
 
-void CPU_RET(bool use32,Bitu bytes, MAYBE_UNUSED Bitu oldeip) {
+void CPU_RET(bool use32,Bitu bytes, [[maybe_unused]] Bitu oldeip) {
 	if (!cpu.pmode || (reg_flags & FLAG_VM)) {
 		Bitu new_ip,new_cs;
 		if (!use32) {
@@ -1789,7 +1789,7 @@ void CPU_LAR(Bitu selector,Bitu & ar) {
 				case DESC_CODE_R_NC_A:		case DESC_CODE_R_NC_NA:
 					if (desc.DPL()<cpu.cpl || desc.DPL()<rpl)
 						break;
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				case DESC_CODE_N_C_A:	case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:	case DESC_CODE_R_C_NA:
@@ -1827,7 +1827,7 @@ void CPU_LSL(Bitu selector,Bitu & limit) {
 				case DESC_CODE_R_NC_A:		case DESC_CODE_R_NC_NA:
 					if (desc.DPL()<cpu.cpl || desc.DPL()<rpl)
 						break;
-					FALLTHROUGH;
+					[[fallthrough]];
 				case DESC_CODE_N_C_A:	case DESC_CODE_N_C_NA:
 				case DESC_CODE_R_C_A:	case DESC_CODE_R_C_NA:
 					limit=desc.GetLimit();
@@ -2420,7 +2420,7 @@ public:
 
 static CPU * test;
 
-void CPU_ShutDown(MAYBE_UNUSED Section* sec) {
+void CPU_ShutDown([[maybe_unused]] Section* sec) {
 #if (C_DYNAMIC_X86)
 	CPU_Core_Dyn_X86_Cache_Close();
 #elif (C_DYNREC)

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -668,7 +668,7 @@ static void cache_closeblock()
 
 // place an 8bit value into the cache
 
-static INLINE void cache_addb(uint8_t val, const uint8_t *pos)
+static inline void cache_addb(uint8_t val, const uint8_t *pos)
 {
 	*const_cast<uint8_t *>(pos) = val;
 }
@@ -681,7 +681,7 @@ static inline void cache_addb(uint8_t val)
 
 // place a 16bit value into the cache
 
-static INLINE void cache_addw(uint16_t val, const uint8_t *pos)
+static inline void cache_addw(uint16_t val, const uint8_t *pos)
 {
 	write_unaligned_uint16(const_cast<uint8_t *>(pos), val);
 }
@@ -694,7 +694,7 @@ static inline void cache_addw(uint16_t val)
 
 // place a 32bit value into the cache
 
-static INLINE void cache_addd(uint32_t val, const uint8_t *pos)
+static inline void cache_addd(uint32_t val, const uint8_t *pos)
 {
 	write_unaligned_uint32(const_cast<uint8_t *>(pos), val);
 }
@@ -707,7 +707,7 @@ static inline void cache_addd(uint32_t val)
 
 // place a 64bit value into the cache
 
-static INLINE void cache_addq(uint64_t val, const uint8_t *pos)
+static inline void cache_addq(uint64_t val, const uint8_t *pos)
 {
 	write_unaligned_uint64(const_cast<uint8_t *>(pos), val);
 }
@@ -758,12 +758,12 @@ static inline void dyn_mem_set_access(void *ptr, size_t size, const bool execute
 		pthread_jit_write_protect_np(execute);
 #elif defined(HAVE_MPROTECT)
 	const int flags = (execute ? PROT_EXEC : PROT_WRITE) | PROT_READ;
-	MAYBE_UNUSED const int mp_res = mprotect(ptr, size, flags);
+	[[maybe_unused]] const int mp_res = mprotect(ptr, size, flags);
 	assert(mp_res == 0);
 #elif defined(WIN32)
 	DWORD old_protect = 0;
 	const DWORD flags = (execute ? PAGE_EXECUTE_READ : PAGE_READWRITE);
-	MAYBE_UNUSED const BOOL vp_res = VirtualProtect(ptr, size, flags,
+	[[maybe_unused]] const BOOL vp_res = VirtualProtect(ptr, size, flags,
 	                                                &old_protect);
 	assert(vp_res != 0);
 #else
@@ -782,8 +782,8 @@ static inline void dyn_mem_write(void *ptr, size_t size)
 	dyn_mem_set_access(ptr, size, false);
 }
 
-static inline void dyn_cache_invalidate(MAYBE_UNUSED void *ptr,
-                                        MAYBE_UNUSED size_t size)
+static inline void dyn_cache_invalidate([[maybe_unused]] void *ptr,
+                                        [[maybe_unused]] size_t size)
 {
 #if defined(HAVE_BUILTIN_CLEAR_CACHE)
 	const auto start = static_cast<char *>(ptr);

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -166,7 +166,7 @@ void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,uint32_t faultcode) {
 //	LOG_MSG("SS:%04x SP:%08X",SegValue(ss),reg_esp);
 }
 
-static INLINE void InitPageUpdateLink(Bitu relink,PhysPt addr) {
+static inline void InitPageUpdateLink(Bitu relink,PhysPt addr) {
 	if (relink==0) return;
 	if (paging.links.used) {
 		if (paging.links.entries[paging.links.used-1]==(addr>>12)) {
@@ -177,7 +177,7 @@ static INLINE void InitPageUpdateLink(Bitu relink,PhysPt addr) {
 	if (relink>1) PAGING_LinkPage_ReadOnly(addr>>12,relink);
 }
 
-static INLINE void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEntry& table,X86PageEntry& entry) {
+static inline void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEntry& table,X86PageEntry& entry) {
 	Bitu lin_page=lin_addr >> 12;
 	Bitu d_index=lin_page >> 10;
 	Bitu t_index=lin_page & 0x3ff;
@@ -203,7 +203,7 @@ static INLINE void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEnt
 	}
 }
 			
-static INLINE bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,X86PageEntry& table,X86PageEntry& entry) {
+static inline bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,X86PageEntry& table,X86PageEntry& entry) {
 	Bitu lin_page=lin_addr >> 12;
 	Bitu d_index=lin_page >> 10;
 	Bitu t_index=lin_page & 0x3ff;
@@ -227,7 +227,7 @@ static INLINE bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,
 }
 
 // check if a user-level memory access would trigger a privilege page fault
-static INLINE bool InitPage_CheckUseraccess(Bitu u1,Bitu u2) {
+static inline bool InitPage_CheckUseraccess(Bitu u1,Bitu u2) {
 	switch (CPU_ArchitectureType) {
 	case CPU_ARCHTYPE_MIXED:
 	case CPU_ARCHTYPE_386SLOW:
@@ -521,7 +521,7 @@ public:
 		}
 		return true;
 	}
-	void InitPage(Bitu lin_addr, MAYBE_UNUSED Bitu val) {
+	void InitPage(Bitu lin_addr, [[maybe_unused]] Bitu val) {
 		Bitu lin_page=lin_addr >> 12;
 		Bitu phys_page;
 		if (paging.enabled) {
@@ -552,7 +552,7 @@ public:
 			PAGING_LinkPage(lin_page,phys_page);
 		}
 	}
-	Bitu InitPageCheckOnly(Bitu lin_addr, MAYBE_UNUSED Bitu val) {
+	Bitu InitPageCheckOnly(Bitu lin_addr, [[maybe_unused]] Bitu val) {
 		Bitu lin_page=lin_addr >> 12;
 		if (paging.enabled) {
 			if (!USERWRITE_PROHIBITED) return 2;
@@ -735,7 +735,7 @@ void PAGING_LinkPage_ReadOnly(Bitu lin_page,Bitu phys_page) {
 
 #else
 
-static INLINE void InitTLBInt(tlb_entry *bank) {
+static inline void InitTLBInt(tlb_entry *bank) {
  	for (Bitu i=0;i<TLB_SIZE;i++) {
 		bank[i].read=0;
 		bank[i].write=0;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -522,7 +522,7 @@ bool CBreakpoint::CheckBreakpoint(Bitu seg, Bitu off)
 	return false;
 }
 
-bool CBreakpoint::CheckIntBreakpoint(MAYBE_UNUSED PhysPt adr, Bit8u intNr, Bit16u ahValue, Bit16u alValue)
+bool CBreakpoint::CheckIntBreakpoint([[maybe_unused]] PhysPt adr, Bit8u intNr, Bit16u ahValue, Bit16u alValue)
 // Checks if interrupt breakpoint is valid and should stop execution
 {
 	if (BPoints.empty()) return false;
@@ -1789,7 +1789,7 @@ Bit32u DEBUG_CheckKeys(void) {
 					break;
 				}
 				// If we aren't stepping over something, do a normal step.
-				/* FALLTHROUGH */
+				[[fallthrough]];
 		case KEY_F(11):	// trace into
 				exitLoop = false;
 				ret = DEBUG_Run(1,true);
@@ -1812,7 +1812,7 @@ Bit32u DEBUG_CheckKeys(void) {
 		case 0x08:	// delete 
 				if (codeViewData.inputPos == 0) break;
 				codeViewData.inputPos--;
-				// fallthrough
+				[[fallthrough]];
 		case KEY_DC: // delete character
 				if ((codeViewData.inputPos<0) || (codeViewData.inputPos>=MAXCMDLEN)) break;
 				if (codeViewData.inputStr[codeViewData.inputPos] != 0) {

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -82,11 +82,11 @@ typedef Bit32s INT32;
 /* Little endian uint read */
 #define	le_uint8(ptr) (*(UINT8*)ptr)
 
-INLINE UINT16 le_uint16(const void* ptr) {
+inline UINT16 le_uint16(const void* ptr) {
 	const UINT8* ptr8 = (const UINT8*)ptr;
 	return (UINT16)ptr8[0] | (UINT16)ptr8[1] << 8;
 }
-INLINE UINT32 le_uint32(const void* ptr) {
+inline UINT32 le_uint32(const void* ptr) {
 	const UINT8* ptr8 = (const UINT8*)ptr;
 	return (UINT32)ptr8[0] | (UINT32)ptr8[1] << 8 |	(UINT32)ptr8[2] << 16 | (UINT32)ptr8[3] << 24;
 }

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -128,7 +128,7 @@ public:
 	bool PauseAudio         (bool /*resume*/) { return true; }
 	bool StopAudio          (void) { return true; }
 
-	void ChannelControl(MAYBE_UNUSED TCtrl ctrl) {}
+	void ChannelControl([[maybe_unused]] TCtrl ctrl) {}
 
 	bool ReadSectors        (PhysPt /*buffer*/, const bool /*raw*/, const uint32_t /*sector*/, const uint16_t /*num*/) { return true; }
 	bool LoadUnloadMedia    (bool /*unload*/) { return true; }
@@ -206,7 +206,7 @@ private:
 		int             getLength();
 		// This is a no-op because we track the audio position in all
 		// areas of this class.
-		void setAudioPosition(MAYBE_UNUSED uint32_t pos) {}
+		void setAudioPosition([[maybe_unused]] uint32_t pos) {}
 	private:
 		Sound_Sample *sample = nullptr;
 	};

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -233,16 +233,16 @@ static void FPU_FBLD(PhysPt addr,Bitu store_to) {
 }
 
 
-static INLINE void FPU_FLD_F32_EA(PhysPt addr) {
+static inline void FPU_FLD_F32_EA(PhysPt addr) {
 	FPU_FLD_F32(addr,8);
 }
-static INLINE void FPU_FLD_F64_EA(PhysPt addr) {
+static inline void FPU_FLD_F64_EA(PhysPt addr) {
 	FPU_FLD_F64(addr,8);
 }
-static INLINE void FPU_FLD_I32_EA(PhysPt addr) {
+static inline void FPU_FLD_I32_EA(PhysPt addr) {
 	FPU_FLD_I32(addr,8);
 }
-static INLINE void FPU_FLD_I16_EA(PhysPt addr) {
+static inline void FPU_FLD_I16_EA(PhysPt addr) {
 	FPU_FLD_I16(addr,8);
 }
 
@@ -630,25 +630,25 @@ static void FPU_FLDZ(void){
 }
 
 
-static INLINE void FPU_FADD_EA(Bitu op1){
+static inline void FPU_FADD_EA(Bitu op1){
 	FPU_FADD(op1,8);
 }
-static INLINE void FPU_FMUL_EA(Bitu op1){
+static inline void FPU_FMUL_EA(Bitu op1){
 	FPU_FMUL(op1,8);
 }
-static INLINE void FPU_FSUB_EA(Bitu op1){
+static inline void FPU_FSUB_EA(Bitu op1){
 	FPU_FSUB(op1,8);
 }
-static INLINE void FPU_FSUBR_EA(Bitu op1){
+static inline void FPU_FSUBR_EA(Bitu op1){
 	FPU_FSUBR(op1,8);
 }
-static INLINE void FPU_FDIV_EA(Bitu op1){
+static inline void FPU_FDIV_EA(Bitu op1){
 	FPU_FDIV(op1,8);
 }
-static INLINE void FPU_FDIVR_EA(Bitu op1){
+static inline void FPU_FDIVR_EA(Bitu op1){
 	FPU_FDIVR(op1,8);
 }
-static INLINE void FPU_FCOM_EA(Bitu op1){
+static inline void FPU_FCOM_EA(Bitu op1){
 	FPU_FCOM(op1,8);
 }
 

--- a/src/gui/render_loops.h
+++ b/src/gui/render_loops.h
@@ -96,7 +96,7 @@ lastagain:
 			line4 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 4);
 #endif
 			SCALERFUNC;
-			FALLTHROUGH;
+			[[fallthrough]];
 		case SCALE_RIGHT:
 #if (SCALERHEIGHT > 1) 			
 			line1 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch);

--- a/src/gui/render_scalers.cpp
+++ b/src/gui/render_scalers.cpp
@@ -54,7 +54,7 @@ scalerChangeCache_t scalerChangeCache;
 #define conc3d(A,B,C) _conc5(A,_,B,_,C)
 #define conc4d(A,B,C,D) _conc7(A,_,B,_,C,_,D)
 
-static INLINE void BituMove( void *_dst, const void * _src, Bitu size) {
+static inline void BituMove( void *_dst, const void * _src, Bitu size) {
 	Bitu * dst=(Bitu *)(_dst);
 	const Bitu * src=(Bitu *)(_src);
 	size/=sizeof(Bitu);
@@ -62,7 +62,7 @@ static INLINE void BituMove( void *_dst, const void * _src, Bitu size) {
 		dst[x] = src[x];
 }
 
-static INLINE void ScalerAddLines( Bitu changed, Bitu count ) {
+static inline void ScalerAddLines( Bitu changed, Bitu count ) {
 	if ((Scaler_ChangedLineIndex & 1) == changed ) {
 		Scaler_ChangedLines[Scaler_ChangedLineIndex] += count;
 	} else {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2558,7 +2558,7 @@ void BIND_MappingEvents() {
 		case SDL_MOUSEBUTTONDOWN:
 			isButtonPressed = true;
 			/* Further check where are we pointing at right now */
-			FALLTHROUGH;
+			[[fallthrough]];
 		case SDL_MOUSEMOTION:
 			if (!isButtonPressed)
 				break;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -546,7 +546,7 @@ static void RequestExit(bool pressed)
 		DEBUG_LOG_MSG("SDL: Exit requested");
 }
 
-MAYBE_UNUSED static void PauseDOSBox(bool pressed)
+[[maybe_unused]] static void PauseDOSBox(bool pressed)
 {
 	if (!pressed)
 		return;
@@ -655,7 +655,7 @@ void GFX_ForceFullscreenExit()
 	GFX_ResetScreen();
 }
 
-MAYBE_UNUSED static int int_log2(int val)
+[[maybe_unused]] static int int_log2(int val)
 {
 	int log = 0;
 	while ((val >>= 1) != 0)
@@ -1070,7 +1070,7 @@ static SDL_Point calc_pp_scale(int avw, int avh)
 
 Bitu GFX_SetSize(Bitu width,
                  Bitu height,
-                 MAYBE_UNUSED Bitu flags,
+                 [[maybe_unused]] Bitu flags,
                  double scalex,
                  double scaley,
                  GFX_CallBack_t callback,
@@ -1479,7 +1479,7 @@ dosurface:
 	return retFlags;
 }
 
-void GFX_SetShader(MAYBE_UNUSED const char *src)
+void GFX_SetShader([[maybe_unused]] const char *src)
 {
 #if C_OPENGL
 	if (!sdl.opengl.use_shader || src == sdl.opengl.shader_src)
@@ -1714,7 +1714,7 @@ void GFX_EndUpdate(const Bit16u *changedLines)
 #endif
 	if ((!using_opengl || !RENDER_GetForceUpdate()) && !sdl.updating)
 		return;
-	MAYBE_UNUSED bool actually_updating = sdl.updating;
+	[[maybe_unused]] bool actually_updating = sdl.updating;
 	sdl.updating = false;
 	switch (sdl.desktop.type) {
 	case SCREEN_TEXTURE: {
@@ -2061,7 +2061,7 @@ static void DisplaySplash(int time_ms)
 	Delay(time_ms);
 }
 
-MAYBE_UNUSED static std::string get_glshader_value()
+[[maybe_unused]] static std::string get_glshader_value()
 {
 #if C_OPENGL
 	assert(control);
@@ -2464,7 +2464,7 @@ static SDL_Rect calc_viewport_pp(int win_width, int win_height)
 	return {x, y, w, h};
 }
 
-MAYBE_UNUSED static SDL_Rect calc_viewport(int width, int height)
+[[maybe_unused]] static SDL_Rect calc_viewport(int width, int height)
 {
 	if (sdl.scaling_mode == SCALING_MODE::PERFECT)
 		return calc_viewport_pp(width, height);
@@ -3177,7 +3177,7 @@ bool GFX_Events()
 			if ((event.key.keysym.sym == SDLK_TAB) &&
 			    (GetTicksSince(sdl.focus_ticks) < 2))
 				break;
-			FALLTHROUGH;
+			[[fallthrough]];
 #endif
 #if defined (MACOSX)
 		case SDL_KEYDOWN:
@@ -3188,7 +3188,7 @@ bool GFX_Events()
 				RequestExit(true);
 				break;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 #endif
 		default: MAPPER_CheckEvent(&event);
 		}

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -615,7 +615,7 @@ void Module::PortWrite(io_port_t port, uint8_t val, io_width_t)
 					break;
 				}
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		case MODE_OPL2:
 		case MODE_OPL3:
 			if ( !chip[0].Write( reg.normal, val ) ) {
@@ -655,7 +655,7 @@ void Module::PortWrite(io_port_t port, uint8_t val, io_width_t)
 					break;
 				}
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		case MODE_OPL3:
 			reg.normal = handler->WriteAddr( port, val ) & 0x1ff;
 			break;
@@ -700,7 +700,7 @@ uint8_t Module::PortRead(io_port_t port, io_width_t)
 				return CtrlRead();
 			}
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	case MODE_OPL3:
 		//We allocated 4 ports, so just return -1 for the higher ones
 		if ( !(port & 3 ) ) {

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -383,7 +383,7 @@ void Operator::UpdateRates( const Chip* chip ) {
 	UpdateRelease( chip );
 }
 
-INLINE Bit32s Operator::RateForward( Bit32u add ) {
+inline Bit32s Operator::RateForward( Bit32u add ) {
 	rateIndex += add;
 	Bit32s ret = rateIndex >> RATE_SH;
 	rateIndex = rateIndex & RATE_MASK;
@@ -428,7 +428,7 @@ Bits Operator::TemplateVolume(  ) {
 			return vol;
 		}
 		// In sustain phase, but not sustaining, do regular release
-		FALLTHROUGH;
+		[[fallthrough]];
 	case RELEASE:
 		vol += RateForward( releaseAdd );;
 		if ( GCC_UNLIKELY(vol >= ENV_MAX) ) {
@@ -450,12 +450,12 @@ static const VolumeHandler VolumeHandlerTable[5] = {
 	&Operator::TemplateVolume< Operator::ATTACK >
 };
 
-INLINE Bitu Operator::ForwardVolume() {
+inline Bitu Operator::ForwardVolume() {
 	return currentLevel + (this->*volHandler)();
 }
 
 
-INLINE Bitu Operator::ForwardWave() {
+inline Bitu Operator::ForwardWave() {
 	waveIndex += waveCurrent;	
 	return waveIndex >> WAVE_SH;
 }
@@ -532,12 +532,12 @@ void Operator::WriteE0( const Chip* chip, Bit8u val ) {
 #endif
 }
 
-INLINE void Operator::SetState( Bit8u s ) {
+inline void Operator::SetState( Bit8u s ) {
 	state = s;
 	volHandler = VolumeHandlerTable[ s ];
 }
 
-INLINE bool Operator::Silent() const {
+inline bool Operator::Silent() const {
 	if ( !ENV_SILENT( totalLevel + volume ) )
 		return false;
 	if ( !(rateZero & ( 1 << state ) ) )
@@ -545,7 +545,7 @@ INLINE bool Operator::Silent() const {
 	return true;
 }
 
-INLINE void Operator::Prepare( const Chip* chip )  {
+inline void Operator::Prepare( const Chip* chip )  {
 	currentLevel = totalLevel + (chip->tremoloValue & tremoloMask);
 	waveCurrent = waveAdd;
 	if ( vibStrength >> chip->vibratoShift ) {
@@ -581,7 +581,7 @@ void Operator::KeyOff( Bit8u mask ) {
 	}
 }
 
-INLINE Bits Operator::GetWave( Bitu index, Bitu vol ) {
+inline Bits Operator::GetWave( Bitu index, Bitu vol ) {
 #if ( DBOPL_WAVE == WAVE_HANDLER )
 	return waveHandler( index, vol << ( 3 - ENV_EXTRA ) );
 #elif ( DBOPL_WAVE == WAVE_TABLEMUL )
@@ -598,7 +598,7 @@ INLINE Bits Operator::GetWave( Bitu index, Bitu vol ) {
 #endif
 }
 
-Bits INLINE Operator::GetSample( Bits modulation ) {
+Bits inline Operator::GetSample( Bits modulation ) {
 	Bitu vol = ForwardVolume();
 	if ( ENV_SILENT( vol ) ) {
 		//Simply forward the wave
@@ -812,7 +812,7 @@ void Channel::UpdateSynth( const Chip* chip ) {
 }
 
 template< bool opl3Mode>
-INLINE void Channel::GeneratePercussion( Chip* chip, Bit32s* output ) {
+inline void Channel::GeneratePercussion( Chip* chip, Bit32s* output ) {
 	Channel* chan = this;
 
 	//BassDrum
@@ -998,7 +998,7 @@ Channel *Channel::BlockTemplate(Chip *chip, const uint16_t samples, Bit32s *outp
 	return 0;
 }
 
-INLINE Bit32u Chip::ForwardNoise() {
+inline Bit32u Chip::ForwardNoise() {
 	noiseCounter += noiseAdd;
 	Bitu count = noiseCounter >> LFO_SH;
 	noiseCounter &= ((1<<LFO_SH) - 1);
@@ -1010,7 +1010,7 @@ INLINE Bit32u Chip::ForwardNoise() {
 	return noiseValue;
 }
 
-INLINE Bit32u Chip::ForwardLFO(const uint16_t samples)
+inline Bit32u Chip::ForwardLFO(const uint16_t samples)
 {
 	// Current vibrato value, runs 4x slower than tremolo
 	vibratoSign = (VibratoTable[vibratoIndex >> 2]) >> 7;

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -367,7 +367,7 @@ static void DISNEY_CallBack(uint16_t len) {
 	}
 }
 
-static void DISNEY_ShutDown(MAYBE_UNUSED Section *sec)
+static void DISNEY_ShutDown([[maybe_unused]] Section *sec)
 {
 	DEBUG_LOG_MSG("DISNEY: Shutting down");
 

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -103,7 +103,7 @@ void Envelope::Apply(const bool is_stereo,
 	// Should we deactivate the envelope?
 	if (++frames_done > expire_after_frames || edge >= edge_limit) {
 		process = &Envelope::Skip;
-		(void)channel_name; // MAYBE_UNUSED in release builds
+		(void)channel_name; // [[maybe_unused]] in release builds
 		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %u",
 		              channel_name, frames_done, edge);
 	}

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -171,6 +171,6 @@ static CMS* test;
 void CMS_Init(Section* sec) {
 	test = new CMS(sec);
 }
-void CMS_ShutDown(MAYBE_UNUSED Section* sec) {
+void CMS_ShutDown([[maybe_unused]] Section* sec) {
 	delete test;	       
 }

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1452,7 +1452,7 @@ Gus::~Gus()
 		wh.Uninstall();
 }
 
-static void gus_destroy(MAYBE_UNUSED Section *sec)
+static void gus_destroy([[maybe_unused]] Section *sec)
 {
 	// GUS destroy is run when the user wants to deactivate the GUS:
 	// C:\> config -set gus=false

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -333,14 +333,14 @@ void CAPTURE_VideoStop() {
 #endif
 }
 
-void CAPTURE_AddImage(MAYBE_UNUSED Bitu width,
-                      MAYBE_UNUSED Bitu height,
-                      MAYBE_UNUSED Bitu bpp,
-                      MAYBE_UNUSED Bitu pitch,
-                      MAYBE_UNUSED Bitu flags,
-                      MAYBE_UNUSED float fps,
-                      MAYBE_UNUSED Bit8u *data,
-                      MAYBE_UNUSED Bit8u *pal)
+void CAPTURE_AddImage([[maybe_unused]] Bitu width,
+                      [[maybe_unused]] Bitu height,
+                      [[maybe_unused]] Bitu bpp,
+                      [[maybe_unused]] Bitu pitch,
+                      [[maybe_unused]] Bitu flags,
+                      [[maybe_unused]] float fps,
+                      [[maybe_unused]] Bit8u *data,
+                      [[maybe_unused]] Bit8u *pal)
 {
 #if (C_SSHOT)
 	Bitu i;
@@ -849,7 +849,7 @@ public:
 
 static HARDWARE *hardware_module;
 
-void HARDWARE_Destroy(MAYBE_UNUSED Section *sec)
+void HARDWARE_Destroy([[maybe_unused]] Section *sec)
 {
 	delete hardware_module;
 }

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -237,7 +237,7 @@ uint16_t Innovation::GetRemainingSamples()
 }
 
 Innovation innovation;
-static void innovation_destroy(MAYBE_UNUSED Section *sec)
+static void innovation_destroy([[maybe_unused]] Section *sec)
 {
 	innovation.Close();
 }

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1194,7 +1194,7 @@ public:
 
 static IPX* test;
 
-void IPX_ShutDown(MAYBE_UNUSED Section* sec) {
+void IPX_ShutDown([[maybe_unused]] Section* sec) {
 	delete test;    
 }
 

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -469,7 +469,7 @@ public:
 
 static JOYSTICK* test;
 
-void JOYSTICK_Destroy(MAYBE_UNUSED Section *sec)
+void JOYSTICK_Destroy([[maybe_unused]] Section *sec)
 {
 	delete test;
 }

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -162,7 +162,7 @@ static void write_p60(io_port_t, uint8_t val, io_width_t)
 			keyb.repeat.rate = repeat[val&0x1f];
 			keyb.command=CMD_NONE;
 		}
-		FALLTHROUGH; // CMD_SETLEDS does what we want
+		[[fallthrough]]; // CMD_SETLEDS does what we want
 	case CMD_SETLEDS:
 		keyb.command=CMD_NONE;
 		KEYBOARD_ClrBuffer();

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -54,7 +54,7 @@ struct machine_config;
 #define DECLARE_READ8_MEMBER(name)      u8     name( int, int)
 #define DECLARE_WRITE8_MEMBER(name)     void   name( int, int, u8 data)
 #define READ8_MEMBER(name)              u8     name( int, int)
-#define WRITE8_MEMBER(name)				void   name(MAYBE_UNUSED int offset, MAYBE_UNUSED int space, MAYBE_UNUSED u8 data)
+#define WRITE8_MEMBER(name)				void   name([[maybe_unused]] int offset, [[maybe_unused]] int space, [[maybe_unused]] u8 data)
 
 #define DECLARE_DEVICE_TYPE(Type, Class) \
 		extern const device_type Type; \
@@ -71,13 +71,13 @@ public:
 
 	sound_stream temp;
 
-	device_sound_interface(const machine_config & /* mconfig */, MAYBE_UNUSED device_t &_device)
+	device_sound_interface(const machine_config & /* mconfig */, [[maybe_unused]] device_t &_device)
 	        : temp()
 	{}
 
 	virtual ~device_sound_interface() = default;
 
-	sound_stream *stream_alloc(MAYBE_UNUSED int whatever, MAYBE_UNUSED int channels, MAYBE_UNUSED int size)
+	sound_stream *stream_alloc([[maybe_unused]] int whatever, [[maybe_unused]] int channels, [[maybe_unused]] int size)
 	{
 		return &temp;
 	}
@@ -91,7 +91,7 @@ public:
 struct attotime {
 	int whatever;
 
-	static attotime from_hz(MAYBE_UNUSED int hz) {
+	static attotime from_hz([[maybe_unused]] int hz) {
 		return attotime();
 	}
 };
@@ -120,7 +120,7 @@ public:
 		return clockRate;
 	}
 
-	void logerror(MAYBE_UNUSED const char* format, ...) {
+	void logerror([[maybe_unused]] const char* format, ...) {
 #if C_DEBUG
 		char buf[512*2];
 		va_list msg;
@@ -138,10 +138,10 @@ public:
 	virtual void device_start() {
 	}
 
-	void save_item(int, MAYBE_UNUSED int blah= 0) {
+	void save_item(int, [[maybe_unused]] int blah= 0) {
 	}
 
-	device_t(const machine_config & /* mconfig */, MAYBE_UNUSED device_type type, MAYBE_UNUSED const char *tag, MAYBE_UNUSED device_t *owner, u32 _clock) : clockRate( _clock ) {
+	device_t(const machine_config & /* mconfig */, [[maybe_unused]] device_type type, [[maybe_unused]] const char *tag, [[maybe_unused]] device_t *owner, u32 _clock) : clockRate( _clock ) {
 	}
 
 	virtual ~device_t() {

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -930,7 +930,7 @@ struct FM_OPL
 
 
 	/* lock/unlock for common table */
-	static int LockTable(MAYBE_UNUSED device_t *device)
+	static int LockTable([[maybe_unused]] device_t *device)
 	{
 		num_lock++;
 		if(num_lock>1) return 0;

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -224,8 +224,8 @@ void saa1099_device::device_start()
 //  sound_stream_update - handle a stream update
 //-------------------------------------------------
 
-void saa1099_device::sound_stream_update(MAYBE_UNUSED sound_stream &stream,
-                                         MAYBE_UNUSED stream_sample_t **inputs,
+void saa1099_device::sound_stream_update([[maybe_unused]] sound_stream &stream,
+                                         [[maybe_unused]] stream_sample_t **inputs,
                                          stream_sample_t **outputs,
                                          int samples)
 {

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -393,7 +393,7 @@ void sn76496_base_device::countdown_cycles()
 	}
 }
 
-void sn76496_base_device::sound_stream_update(MAYBE_UNUSED sound_stream &stream, MAYBE_UNUSED stream_sample_t **inputs, stream_sample_t **outputs, int samples)
+void sn76496_base_device::sound_stream_update([[maybe_unused]] sound_stream &stream, [[maybe_unused]] stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
 	int i;
 	stream_sample_t *lbuffer = outputs[0];

--- a/src/hardware/mame/ymdeltat.cpp
+++ b/src/hardware/mame/ymdeltat.cpp
@@ -460,7 +460,7 @@ void YM_DELTAT::postload(uint8_t *regs)
 		now_data = *(memory + (now_addr >> 1));
 
 }
-void YM_DELTAT::savestate(MAYBE_UNUSED device_t *device)
+void YM_DELTAT::savestate([[maybe_unused]] device_t *device)
 {
 #ifdef MAME_EMU_SAVE_H
 	YM_DELTAT *const DELTAT = this; // makes the save name sensible

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1633,7 +1633,7 @@ static inline void set_sl_rr(OPL3 *chip,int slot,int v)
 }
 
 
-static void update_channels(MAYBE_UNUSED OPL3 *chip, OPL3_CH *CH)
+static void update_channels([[maybe_unused]] OPL3 *chip, OPL3_CH *CH)
 {
 	/* update channel passed as a parameter and a channel at CH+=3; */
 	if (CH->extended)
@@ -2442,7 +2442,7 @@ static int OPL3TimerOver(OPL3 *chip,int c)
 	return chip->status>>7;
 }
 
-static void OPL3_save_state(MAYBE_UNUSED OPL3 *chip, MAYBE_UNUSED device_t *device) {
+static void OPL3_save_state([[maybe_unused]] OPL3 *chip, [[maybe_unused]] device_t *device) {
 #if 0 
 	for (int ch=0; ch<18; ch++) {
 		OPL3_CH *channel = &chip->P_CH[ch];

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -75,7 +75,7 @@ public:
 #endif
 		return 0xff;
 	}
-	void writeb(PhysPt addr, MAYBE_UNUSED Bitu val)
+	void writeb(PhysPt addr, [[maybe_unused]] Bitu val)
 	{
 #if C_DEBUG
 		LOG_MSG("Illegal write to %x, CS:IP %8x:%8x",addr,SegValue(cs),reg_eip);
@@ -248,7 +248,7 @@ Bitu MEM_AllocatedPages(MemHandle handle)
 
 //TODO Maybe some protection for this whole allocation scheme
 
-INLINE Bitu BestMatch(Bitu size) {
+inline Bitu BestMatch(Bitu size) {
 	Bitu index=XMS_START;	
 	Bitu first=0;
 	Bitu best=0xfffffff;
@@ -645,7 +645,7 @@ public:
 
 static MEMORY* test;
 
-static void MEM_ShutDown(MAYBE_UNUSED Section *sec)
+static void MEM_ShutDown([[maybe_unused]] Section *sec)
 {
 	delete test;
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -130,7 +130,7 @@ static struct mixer_t mixer;
 Bit8u MixTemp[MIXER_BUFSIZE];
 
 MixerChannel::MixerChannel(MIXER_Handler _handler,
-                           MAYBE_UNUSED Bitu _freq,
+                           [[maybe_unused]] Bitu _freq,
                            const char *_name)
         : name(_name),
           done(0),
@@ -754,7 +754,7 @@ static void MIXER_Mix_NoSound()
 
 #define INDEX_SHIFT_LOCAL 14
 
-static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, int len)
+static void SDLCALL MIXER_CallBack([[maybe_unused]] void *userdata, Uint8 *stream, int len)
 {
 	memset(stream, 0, len);
 	auto need = static_cast<uint32_t>(len / MIXER_SSIZE);
@@ -876,7 +876,7 @@ static void SDLCALL MIXER_CallBack(MAYBE_UNUSED void *userdata, Uint8 *stream, i
 
 #undef INDEX_SHIFT_LOCAL
 
-static void MIXER_Stop(MAYBE_UNUSED Section *sec)
+static void MIXER_Stop([[maybe_unused]] Section *sec)
 {}
 
 class MIXER final : public Program {

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1455,7 +1455,7 @@ void bx_ne2k_c::init()
   reset(BX_RESET_HARDWARE);
 }
 
-static void NE2000_TX_Event(MAYBE_UNUSED uint32_t val)
+static void NE2000_TX_Event([[maybe_unused]] uint32_t val)
 {
 	theNE2kDevice->tx_timer();
 }

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -915,7 +915,7 @@ uint8_t adlib_reg_read(io_port_t port) {
 #endif
 }
 
-void adlib_write_index(MAYBE_UNUSED io_port_t port, uint8_t val) {
+void adlib_write_index([[maybe_unused]] io_port_t port, uint8_t val) {
 	opl_index = val;
 #if defined(OPLTYPE_IS_OPL3)
 	if ((port&3)!=0) {
@@ -925,7 +925,7 @@ void adlib_write_index(MAYBE_UNUSED io_port_t port, uint8_t val) {
 #endif
 }
 
-static INLINE void clipit16(int32_t ival, int16_t *outval)
+static inline void clipit16(int32_t ival, int16_t *outval)
 {
 	if (ival<32768) {
 		if (ival>-32769) {

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -410,7 +410,7 @@ Ps1Synth::~Ps1Synth()
 static std::unique_ptr<Ps1Dac> ps1_dac = {};
 static std::unique_ptr<Ps1Synth> ps1_synth = {};
 
-static void PS1AUDIO_ShutDown(MAYBE_UNUSED Section *sec)
+static void PS1AUDIO_ShutDown([[maybe_unused]] Section *sec)
 {
 	LOG_MSG("PS/1: Shutting down IBM PS/1 Audio card");
 	ps1_dac.reset();
@@ -425,7 +425,7 @@ bool PS1AUDIO_IsEnabled()
 	return properties->Get_bool("ps1audio");
 }
 
-void PS1AUDIO_Init(MAYBE_UNUSED Section *sec)
+void PS1AUDIO_Init([[maybe_unused]] Section *sec)
 {
 	if (!PS1AUDIO_IsEnabled())
 		return;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -584,7 +584,7 @@ static void PlayDMATransfer(uint32_t bytes_requested)
 		break;
 	case DSP_DMA_16_ALIASED:
 		assert(dma16_to_sample_divisor == 2);
-		FALLTHROUGH;
+		[[fallthrough]];
 	case DSP_DMA_16:
 		if (sb.dma.stereo) {
 			bytes_read = ReadDMA16(bytes_to_read, sb.dma.remain_size);
@@ -1060,13 +1060,13 @@ static void DSP_DoCommand() {
 		break;
 	case 0x75:	/* 075h : Single Cycle 4-bit ADPCM Reference */
 		sb.adpcm.haveref = true;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0x74:	/* 074h : Single Cycle 4-bit ADPCM */
 		DSP_PrepareDMA_Old(DSP_DMA_4,false,false);
 		break;
 	case 0x77:	/* 077h : Single Cycle 3-bit(2.6bit) ADPCM Reference*/
 		sb.adpcm.haveref = true;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0x76:	/* 076h : Single Cycle 3-bit(2.6bit) ADPCM */
 		DSP_PrepareDMA_Old(DSP_DMA_3,false,false);
 		break;
@@ -1077,7 +1077,7 @@ static void DSP_DoCommand() {
 		break;
 	case 0x17:	/* 017h : Single Cycle 2-bit ADPCM Reference*/
 		sb.adpcm.haveref = true;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0x16:	/* 016h : Single Cycle 2-bit ADPCM */
 		DSP_PrepareDMA_Old(DSP_DMA_2,false,false);
 		break;
@@ -1101,7 +1101,7 @@ static void DSP_DoCommand() {
 		break;
 	case 0xd5:	/* Halt 16-bit DMA */
 		DSP_SB16_ONLY;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0xd0:	/* Halt 8-bit DMA */
 //		DSP_ChangeMode(MODE_NONE);
 		LOG(LOG_SB, LOG_NORMAL)("Halt DMA Command");
@@ -1126,7 +1126,7 @@ static void DSP_DoCommand() {
 		break;
 	case 0xd6:	/* Continue DMA 16-bit */
 		DSP_SB16_ONLY;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0xd4:	/* Continue DMA 8-bit*/
 		LOG(LOG_SB, LOG_NORMAL)("Continue DMA command");
 		if (sb.mode==MODE_DMA_PAUSE) {
@@ -1136,7 +1136,7 @@ static void DSP_DoCommand() {
 		break;
 	case 0xd9:  /* Exit Autoinitialize 16-bit */
 		DSP_SB16_ONLY;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0xda:	/* Exit Autoinitialize 8-bit */
 		DSP_SB2_ABOVE;
 		LOG(LOG_SB, LOG_NORMAL)("Exit Autoinit command");
@@ -1787,7 +1787,7 @@ public:
 			break;
 		case OPL_opl2:
 			CMS_Init(section);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case OPL_dualopl2:
 		case OPL_opl3:
 		case OPL_opl3gold:
@@ -1857,7 +1857,7 @@ public:
 			break;
 		case OPL_opl2:
 			CMS_ShutDown(m_configuration);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case OPL_dualopl2:
 		case OPL_opl3:
 		case OPL_opl3gold:

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -27,7 +27,7 @@
 #include "setup.h"
 #include "support.h"
 
-static INLINE void BIN2BCD(Bit16u& val) {
+static inline void BIN2BCD(Bit16u& val) {
 	const auto b = ((val / 10) % 10) << 4;
 	const auto c = ((val / 100) % 10) << 8;
 	const auto d = ((val / 1000) % 10) << 12;
@@ -37,7 +37,7 @@ static INLINE void BIN2BCD(Bit16u& val) {
 	val = temp;
 }
 
-static INLINE void BCD2BIN(Bit16u& val) {
+static inline void BCD2BIN(Bit16u& val) {
 	Bit16u temp= (val&0x0f) +((val>>4)&0x0f) *10 +((val>>8)&0x0f) *100 +((val>>12)&0x0f) *1000;
 	val=temp;
 }

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -202,7 +202,7 @@ void VGA_DAC_CombineColor(Bit8u attr,Bit8u pal) {
 		// used by copper demo; almost no video card seems to suport it
 		if (!IS_VGA_ARCH || (svgaCard != SVGA_None))
 			break;
-		FALLTHROUGH;
+		[[fallthrough]];
 	default:
 		VGA_DAC_SendColor( attr, pal );
 	}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -694,7 +694,7 @@ static uint8_t *VGA_TEXT_Xlat16_Draw_Line(Bitu vidstart, Bitu line)
 }
 
 #ifdef VGA_KEEP_CHANGES
-static INLINE void VGA_ChangesEnd(void ) {
+static inline void VGA_ChangesEnd(void ) {
 	if ( vga.changes.active ) {
 //		vga.changes.active = false;
 		Bitu end = vga.draw.address >> VGA_CHANGE_SHIFT;
@@ -882,7 +882,7 @@ void VGA_SetBlinking(const uint8_t enabled)
 }
 
 #ifdef VGA_KEEP_CHANGES
-static void INLINE VGA_ChangesStart( void ) {
+static void inline VGA_ChangesStart( void ) {
 	vga.changes.start = vga.draw.address >> VGA_CHANGE_SHIFT;
 	vga.changes.last = vga.changes.start;
 	if ( vga.changes.lastAddress != vga.draw.address ) {
@@ -998,7 +998,7 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 	case M_EGA:
 		if (!(vga.crtc.mode_control&0x1)) vga.draw.linear_mask &= ~0x10000;
 		else vga.draw.linear_mask |= 0x10000;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case M_LIN4:
 		vga.draw.byte_panning_shift = 8;
 		vga.draw.address += vga.draw.bytes_skip;
@@ -1016,7 +1016,7 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 			vga.draw.linear_base = vga.mem.linear;
 			vga.draw.linear_mask = vga.vmemwrap - 1;
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	case M_LIN8:
 	case M_LIN15:
 	case M_LIN24:
@@ -1134,7 +1134,7 @@ void VGA_CheckScanLength(void) {
 			vga.draw.address_add = vga.draw.blocks / 4;
 			break;
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	case M_CGA2_COMPOSITE: vga.draw.address_add = vga.draw.blocks; break;
 	case M_TANDY4:
 	case M_CGA4_COMPOSITE: vga.draw.address_add = vga.draw.blocks; break;

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -56,7 +56,7 @@
 #define TANDY_VIDBASE(_X_)  &MemBase[ 0x80000 + (_X_)]
 
 template <class Size>
-static INLINE void hostWrite(HostPt off, Bitu val) {
+static inline void hostWrite(HostPt off, Bitu val) {
 	if ( sizeof( Size ) == 1)
 		host_writeb( off, (Bit8u)val );
 	else if ( sizeof( Size ) == 2)
@@ -66,7 +66,7 @@ static INLINE void hostWrite(HostPt off, Bitu val) {
 }
 
 template <class Size>
-static INLINE Bitu  hostRead(HostPt off ) {
+static inline Bitu  hostRead(HostPt off ) {
 	if ( sizeof( Size ) == 1)
 		return host_readb( off );
 	else if ( sizeof( Size ) == 2)
@@ -79,7 +79,7 @@ static INLINE Bitu  hostRead(HostPt off ) {
 
 void VGA_MapMMIO(void);
 //Nice one from DosEmu
-INLINE static Bit32u RasterOp(Bit32u input,Bit32u mask) {
+inline static Bit32u RasterOp(Bit32u input,Bit32u mask) {
 	switch (vga.config.raster_op) {
 	case 0x00:	/* None */
 		return (input & mask) | (vga.latch.d & ~mask);
@@ -93,7 +93,7 @@ INLINE static Bit32u RasterOp(Bit32u input,Bit32u mask) {
 	return 0;
 }
 
-INLINE static Bit32u ModeOperation(Bit8u val) {
+inline static Bit32u ModeOperation(Bit8u val) {
 	Bit32u full;
 	switch (vga.config.write_mode) {
 	case 0x00:
@@ -328,11 +328,11 @@ public:
 		flags=PFLAG_NOCODE;
 	}
 	template <class Size>
-	static INLINE Bitu readHandler(PhysPt addr ) {
+	static inline Bitu readHandler(PhysPt addr ) {
 		return hostRead<Size>( &vga.mem.linear[((addr&~3)<<2)+(addr&3)] );
 	}
 	template <class Size>
-	static INLINE void writeCache(PhysPt addr, Bitu val) {
+	static inline void writeCache(PhysPt addr, Bitu val) {
 		hostWrite<Size>( &vga.fastmem[addr], val );
 		if (GCC_UNLIKELY(addr < 320)) {
 			// And replicate the first line
@@ -340,7 +340,7 @@ public:
 		}
 	}
 	template <class Size>
-	static INLINE void writeHandler(PhysPt addr, Bitu val) {
+	static inline void writeHandler(PhysPt addr, Bitu val) {
 		// No need to check for compatible chains here, this one is only enabled if that bit is set
 		hostWrite<Size>( &vga.mem.linear[((addr&~3)<<2)+(addr&3)], val );
 	}

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -965,7 +965,7 @@ static Bitu INT15_Handler(void) {
 			break;
 		case 0x01:               // reset
 			reg_bx = 0x00aa; // mouse
-			FALLTHROUGH;
+			[[fallthrough]];
 		case 0x05:		// initialize
 			if ((reg_al==0x05) && (reg_bh!=0x03)) {
 				// non-standard data packet sizes not supported

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -235,7 +235,7 @@ static Bit16u EMM_GetFreePages(void) {
 	return (Bit16u)count;
 }
 
-static bool INLINE ValidHandle(Bit16u handle) {
+static bool inline ValidHandle(Bit16u handle) {
 	if (handle>=EMM_MAX_HANDLES) return false;
 	if (emm_handles[handle].pages==NULL_HANDLE) return false;
 	return true;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -599,7 +599,7 @@ static bool INT10_SetVideoMode_OTHER(Bit16u mode, bool clearmem)
 	case MCH_CGA:
 		if (mode > 6)
 			return false;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case TANDY_ARCH_CASE:
 		if (mode>0xa) return false;
 		if (mode==7) mode=0; // PCJR defaults to 0 on illegal mode 7
@@ -1502,7 +1502,7 @@ att_text16:
 				}
 				break;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		case M_LIN4: //Added for CAD Software
 dac_text16:
 			for (i=0;i<64;i++) {

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -23,11 +23,11 @@
 
 #define ACTL_MAX_REG   0x14
 
-static INLINE void ResetACTL(void) {
+static inline void ResetACTL(void) {
 	IO_Read(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS) + 6);
 }
 
-static INLINE void WriteTandyACTL(Bit8u creg,Bit8u val) {
+static inline void WriteTandyACTL(Bit8u creg,Bit8u val) {
 	IO_Write(VGAREG_TDY_ADDRESS,creg);
 	if (machine==MCH_TANDY) IO_Write(VGAREG_TDY_DATA,val);
 	else IO_Write(VGAREG_PCJR_DATA,val);

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -135,7 +135,7 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 			LOG(LOG_INT10, LOG_ERROR)("PutPixel unhandled mode type %d", CurMode->type);
 			break;
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	case M_EGA: {
 		/* Set the correct bitmask for the pixel position */
 		IO_Write(0x3ce, 0x8);

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -205,7 +205,7 @@ void MOUSE_Limit_Events(uint32_t /*val*/)
 	}
 }
 
-INLINE void Mouse_AddEvent(Bit8u type) {
+inline void Mouse_AddEvent(Bit8u type) {
 	if (mouse.events<QUEUE_SIZE) {
 		if (mouse.events>0) {
 			/* Skip duplicate events */
@@ -727,7 +727,7 @@ static Bitu INT33_Handler(void) {
 	switch (reg_ax) {
 	case 0x00:	/* Reset Driver and Read Status */
 		Mouse_ResetHardware();
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0x21:	/* Software Reset */
 		reg_ax=0xffff;
 		reg_bx=MOUSE_BUTTONS;
@@ -845,7 +845,7 @@ static Bitu INT33_Handler(void) {
 	case 0x27:	/* Get Screen/Cursor Masks and Mickey Counts */
 		reg_ax=mouse.textAndMask;
 		reg_bx=mouse.textXorMask;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case 0x0b:	/* Read Motion Data */
 		reg_cx=static_cast<Bit16s>(mouse.mickey_x);
 		reg_dx=static_cast<Bit16s>(mouse.mickey_y);

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -119,7 +119,7 @@ static bool umb_available;
 
 static XMS_Block xms_handles[XMS_HANDLES];
 
-static INLINE bool InvalidHandle(Bitu handle) {
+static inline bool InvalidHandle(Bitu handle) {
 	return (!handle || (handle>=XMS_HANDLES) || xms_handles[handle].free);
 }
 
@@ -261,7 +261,7 @@ static bool multiplex_xms(void) {
 
 }
 
-INLINE void SET_RESULT(Bitu res,bool touch_bl_on_succes=true) {
+inline void SET_RESULT(Bitu res,bool touch_bl_on_succes=true) {
 	if(touch_bl_on_succes || res) reg_bl = (Bit8u)res;
 	reg_ax = (res==0);
 }
@@ -300,7 +300,7 @@ Bitu XMS_Handler(void) {
 		break;
 	case XMS_ALLOCATE_ANY_MEMORY:								/* 89 */
 		reg_edx &= 0xffff;
-		FALLTHROUGH;
+		[[fallthrough]];
 	case XMS_ALLOCATE_EXTENDED_MEMORY:							/* 09 */
 		{
 		Bit16u handle = 0;
@@ -331,7 +331,7 @@ Bitu XMS_Handler(void) {
 		break;
 	case XMS_RESIZE_ANY_EXTENDED_MEMORY_BLOCK:					/* 0x8f */
 		if(reg_ebx > reg_bx) LOG_MSG("64MB memory limit!");
-		FALLTHROUGH;
+		[[fallthrough]];
 	case XMS_RESIZE_EXTENDED_MEMORY_BLOCK:						/* 0f */
 		SET_RESULT(XMS_ResizeMemory(reg_dx, reg_bx));
 		break;

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -20,11 +20,13 @@
 #define DOSBOX_ZMBV_H
 
 #ifndef DOSBOX_DOSBOX_H
-#ifdef _MSC_VER
-#define INLINE __forceinline
+	#ifdef _MSC_VER
+		#define INLINE __forceinline
+	#else
+		#define INLINE inline
+	#endif
 #else
-#define INLINE inline
-#endif
+	#define INLINE inline
 #endif
 
 #include <zlib.h>

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -111,6 +111,7 @@
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <CompileAs>CompileAsCpp</CompileAs>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -141,6 +142,7 @@
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <CompileAs>CompileAsCpp</CompileAs>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -171,6 +173,7 @@
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -205,6 +208,7 @@
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -209,7 +209,7 @@ MidiHandlerFluidsynth::MidiHandlerFluidsynth()
           keep_rendering(false)
 {}
 
-bool MidiHandlerFluidsynth::Open(MAYBE_UNUSED const char *conf)
+bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 {
 	Close();
 
@@ -633,7 +633,7 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program *caller)
 	return MIDI_RC::OK;
 }
 
-static void fluid_init(MAYBE_UNUSED Section *sec)
+static void fluid_init([[maybe_unused]] Section *sec)
 {}
 
 void FLUID_AddConfigSection(Config *conf)

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -43,7 +43,7 @@ public:
 
 	virtual const char *GetName() const { return "none"; }
 
-	virtual bool Open(MAYBE_UNUSED const char *conf)
+	virtual bool Open([[maybe_unused]] const char *conf)
 	{
 		LOG_MSG("MIDI: No working MIDI device found/selected.");
 		return true;
@@ -69,9 +69,9 @@ public:
 		}
 	}
 
-	virtual void PlayMsg(MAYBE_UNUSED const uint8_t *msg) {}
+	virtual void PlayMsg([[maybe_unused]] const uint8_t *msg) {}
 
-	virtual void PlaySysex(MAYBE_UNUSED uint8_t *sysex, MAYBE_UNUSED size_t len) {}
+	virtual void PlaySysex([[maybe_unused]] uint8_t *sysex, [[maybe_unused]] size_t len) {}
 
 	virtual MIDI_RC ListAll(Program *)
 	{

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -315,7 +315,7 @@ static mt32emu_report_handler_i get_report_handler_interface()
 			return MT32EMU_REPORT_HANDLER_VERSION_0;
 		}
 
-		static void printDebug(MAYBE_UNUSED void *instance_data,
+		static void printDebug([[maybe_unused]] void *instance_data,
 		                       const char *fmt,
 		                       va_list list)
 		{
@@ -505,7 +505,7 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 	return MIDI_RC::OK;
 }
 
-bool MidiHandler_mt32::Open(MAYBE_UNUSED const char *conf)
+bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 {
 	Close();
 
@@ -720,7 +720,7 @@ void MidiHandler_mt32::Render()
 	}
 }
 
-static void mt32_init(MAYBE_UNUSED Section *sec)
+static void mt32_init([[maybe_unused]] Section *sec)
 {}
 
 void MT32_AddConfigSection(Config *conf)

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -54,7 +54,7 @@ static std::string translate_to_glob_pattern(const std::string &path) noexcept
 		case '?':
 		case '*':
 		case '[':
-		case ']': glob_pattern.push_back('\\'); FALLTHROUGH;
+		case ']': glob_pattern.push_back('\\'); [[fallthrough]];
 		default: glob_pattern.push_back(c); continue;
 		}
 	}

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -40,7 +40,7 @@ std::string to_native_path(const std::string &path) noexcept
 	return "";
 }
 
-int create_dir(const char *path, MAYBE_UNUSED uint32_t mode, uint32_t flags) noexcept
+int create_dir(const char *path, [[maybe_unused]] uint32_t mode, uint32_t flags) noexcept
 {
 	const int err = mkdir(path);
 	if ((errno == EEXIST) && (flags & OK_IF_EXISTS)) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -459,7 +459,7 @@ void CONFIG::Run(void) {
 		case P_NOPARAMS:
 			if (!first)
 				break;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case P_NOMATCH:
 			WriteOut(MSG_Get("PROGRAM_CONFIG_USAGE"));

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -316,11 +316,11 @@ void E_Exit(const char *format, ...)
 
 /* Overloaded function to handle different return types of POSIX and GNU
  * strerror_r variants */
-MAYBE_UNUSED static const char *strerror_result(int retval, const char *err_str)
+[[maybe_unused]] static const char *strerror_result(int retval, const char *err_str)
 {
 	return retval == 0 ? err_str : nullptr;
 }
-MAYBE_UNUSED static const char *strerror_result(const char *err_str, MAYBE_UNUSED const char *buf)
+[[maybe_unused]] static const char *strerror_result(const char *err_str, [[maybe_unused]] const char *buf)
 {
 	return err_str;
 }
@@ -337,7 +337,7 @@ std::string safe_strerror(int err) noexcept
 #endif
 }
 
-void set_thread_name(MAYBE_UNUSED std::thread& thread, MAYBE_UNUSED const char *name)
+void set_thread_name([[maybe_unused]] std::thread& thread, [[maybe_unused]] const char *name)
 {
 #if defined(HAVE_PTHREAD_SETNAME_NP) && defined(_GNU_SOURCE)
 	assert(strlen(name) < 16);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -454,7 +454,7 @@ void DOS_Shell::CMD_RMDIR(char * args) {
 
 static std::string format_number(size_t num)
 {
-	MAYBE_UNUSED constexpr uint64_t petabyte_si = 1'000'000'000'000'000;
+	[[maybe_unused]] constexpr uint64_t petabyte_si = 1'000'000'000'000'000;
 	assert(num <= petabyte_si);
 	const auto b = static_cast<unsigned>(num % 1000);
 	num /= 1000;

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -39,7 +39,7 @@ const char *MSG_Get(char const *)
 }
 
 #if C_DEBUG
-void LOG::operator()(MAYBE_UNUSED char const *buf, ...)
+void LOG::operator()([[maybe_unused]] char const *buf, ...)
 {
 	(void)d_type;     // Deliberately unused.
 	(void)d_severity; // Deliberately unused.

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -111,6 +111,7 @@
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,6 +142,7 @@ $(TargetPath)
       <OmitFramePointers>true</OmitFramePointers>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -170,6 +172,7 @@ $(TargetPath)
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>false</OmitFramePointers>
       <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -199,6 +202,7 @@ $(TargetPath)
       <OmitFramePointers>true</OmitFramePointers>
       <ConformanceMode>Default</ConformanceMode>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -117,6 +117,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;SDL2_net.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -154,6 +155,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;SDL2_net.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -194,6 +196,7 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -242,6 +245,7 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -490,6 +490,17 @@
     <ClCompile Include="..\src\libs\loguru\loguru.cpp">
       <Filter>src\libs\loguru</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_biostest.cpp" />
+    <ClCompile Include="..\src\dos\program_boot.cpp" />
+    <ClCompile Include="..\src\dos\program_imgmount.cpp" />
+    <ClCompile Include="..\src\dos\program_intro.cpp" />
+    <ClCompile Include="..\src\dos\program_keyb.cpp" />
+    <ClCompile Include="..\src\dos\program_loadfix.cpp" />
+    <ClCompile Include="..\src\dos\program_loadrom.cpp" />
+    <ClCompile Include="..\src\dos\program_mem.cpp" />
+    <ClCompile Include="..\src\dos\program_mount_common.cpp" />
+    <ClCompile Include="..\src\dos\program_mount.cpp" />
+    <ClCompile Include="..\src\dos\program_rescan.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\bios.h">


### PR DESCRIPTION
This is a wholesale batch of updates to bring the rest of the system up to the C++17 standard. The most notable change to the code is the removal of macros from `compiler.h` and a corresponding system-wide replacement with standard keywords. The minimum GCC version in `linux.yml` has also been raised to 7.