### PR TITLE
Use standard `snprintf` on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 264
+            max_warnings: 212
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1610
+            max_warnings: 1558
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/cross.h
+++ b/include/cross.h
@@ -31,8 +31,6 @@
 #include <direct.h>
 #include <io.h>
 #define LONGTYPE(a) a##i64
-#define snprintf _snprintf
-#define vsnprintf _vsnprintf
 #else										/* LINUX / GCC */
 #include <dirent.h>
 #include <unistd.h>


### PR DESCRIPTION


Thank you @shermp for catching this standardization cleanup, and sanity checking the build. 