### PR TITLE
Improve readability in meson scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ brew install ccache meson libpng sdl2 sdl2_net opusfile fluid-synth
 
 ### Build and stay up-to-date with the latest sources
 
-  - Checkout the master branch:
+  - Checkout the main branch:
 
     ``` shell
     # commit or stash any personal code changes
-    git checkout master -f
+    git checkout main -f
     ```
 
   - Pull the latest updates. This is necessary every time you want a new build:

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,13 @@
 project('dosbox-staging', 'c', 'cpp',
         version : '0.78.0',
         license : 'GPL-2.0-or-later',
-        default_options : ['cpp_std=c++17', 'warning_level=3', 'b_ndebug=if-release', 'b_staticpic=false'],
-        meson_version : '>= 0.54.2')
+        meson_version : '>= 0.54.2',
+        default_options : [
+	  'cpp_std=c++17',
+	  'warning_level=3',
+	  'b_ndebug=if-release',
+	  'b_staticpic=false',
+	])
 
 # After increasing the minimum-required meson version, make the following
 # improvements:

--- a/meson.build
+++ b/meson.build
@@ -299,27 +299,17 @@ summary('OpenGL support', get_option('use_opengl'))
 
 # include directories
 #
-incdir = include_directories(
-           'include',
-           '.',
-           'src/libs/loguru',
-         )
+incdir = include_directories('include', '.')
 
 
 # bundled dependencies, in dependency-order
 #
 subdir('src/libs/loguru')
-libloguru_dep = declare_dependency(link_with : libloguru)
-
-subdir('src/libs/decoders') # depends on libloguru_dep
+subdir('src/libs/decoders')
 subdir('src/libs/nuked')
 subdir('src/libs/ppscale')
 subdir('src/libs/residfp')
 
-libdecoders_dep = declare_dependency(link_with : libdecoders)
-libnuked_dep    = declare_dependency(link_with : libnuked)
-libppscale_dep  = declare_dependency(link_with : libppscale)
-libresidfp_dep  = declare_dependency(link_with : libresidfp)
 
 # internal libs
 #
@@ -354,7 +344,7 @@ subdir('tests')
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
 executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
-           dependencies : [atomic_dep, threads_dep, sdl2_dep] + internal_deps,
+           dependencies : [atomic_dep, threads_dep, sdl2_dep, libloguru_dep] + internal_deps,
            include_directories : incdir,
            install : true)
 

--- a/meson.build
+++ b/meson.build
@@ -7,17 +7,19 @@ project('dosbox-staging', 'c', 'cpp',
 # After increasing the minimum-required meson version, make the following
 # improvements:
 #
-# - 0.53.0 - use summary() to communicate setup result
 # - 0.55.0 - subproject wraps are automatically promoted to fallbacks,
 #            stop using: "fallback : ['foo', 'foo_dep']" for dependencies
 # - 0.56.0 - use meson.current_source_dir() in unit tests
 
-
-# compiler flags
-#
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 
+summary('Build type',     get_option('buildtype'), section : 'Build Summary')
+summary('Install prefix', get_option('prefix'),    section : 'Build Summary')
+
+
+# compiler flags
+#
 add_project_arguments('-Weffc++', language : 'cpp')
 if cxx.has_argument('-Wextra-semi')
     add_project_arguments('-Wextra-semi', language : 'cpp')
@@ -291,6 +293,9 @@ if host_machine.system() in ['windows', 'cygwin']
   winsock2_dep = cxx.find_library('ws2_32', required : true)
   winmm_dep = cxx.find_library('winmm', required : true)
 endif
+
+summary('OpenGL support', get_option('use_opengl'))
+
 
 # include directories
 #

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -37,17 +37,17 @@ foreach line : core_selection
   endif
 endforeach
 
+summary('Byte order', host_machine.endian() + '-endian')
 if conf_data.has('C_DYNAMIC_X86')
-  message('Building dynamic core optimized for x86/x86_64 (dyn-x86) ' +
-          'for ' + conf_data.get('C_TARGETCPU'))
+  summary('CPU dynamic core', 'optimized for x86/x86_64 (dyn-x86)')
+  summary('CPU core target arch', conf_data.get('C_TARGETCPU'))
 elif conf_data.has('C_DYNREC')
-  message('Building dynamic core (dynrec) ' +
-          'for ' + conf_data.get('C_TARGETCPU'))
+  summary('CPU dynamic core', 'generic (dynrec)')
+  summary('CPU core target arch', conf_data.get('C_TARGETCPU'))
 else
   warning('Building without dynamic core support')
+  summary('CPU core', 'disabled')
 endif
-
-message('Building for @0@-endian architecture'.format(host_machine.endian()))
 
 
 # cpu module sources

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -68,7 +68,7 @@ libcpu_sources = files([
 
 libcpu = static_library('cpu', libcpu_sources,
                         include_directories : incdir,
-                        dependencies : sdl2_dep)
+                        dependencies : [sdl2_dep, libloguru_dep])
 
 libcpu_dep = declare_dependency(link_with : libcpu)
 

--- a/src/debug/meson.build
+++ b/src/debug/meson.build
@@ -7,7 +7,11 @@ libdebug_sources = files([
 
 libdebug = static_library('debug', libdebug_sources,
                           include_directories : incdir,
-                          dependencies: [sdl2_dep, curses_dep])
+                          dependencies: [
+                            sdl2_dep,
+                            curses_dep,
+                            libloguru_dep,
+                         ])
 
 libdebug_dep = declare_dependency(link_with : libdebug)
 

--- a/src/fpu/meson.build
+++ b/src/fpu/meson.build
@@ -1,4 +1,6 @@
-libfpu = static_library('fpu', ['fpu.cpp'], include_directories : incdir)
+libfpu = static_library('fpu', ['fpu.cpp'],
+                        include_directories : incdir,
+                        dependencies: libloguru_dep)
 
 libfpu_dep = declare_dependency(link_with : libfpu)
 

--- a/src/libs/decoders/meson.build
+++ b/src/libs/decoders/meson.build
@@ -15,3 +15,5 @@ libdecoders = static_library('decoders', libdecoders_sources,
                                opus_dep,
                                libloguru_dep,
                              ])
+
+libdecoders_dep = declare_dependency(link_with : libdecoders)

--- a/src/libs/loguru/meson.build
+++ b/src/libs/loguru/meson.build
@@ -1,3 +1,6 @@
 libloguru = static_library('loguru',
                            'loguru.cpp',
                            dependencies : [ threads_dep, dl_dep ])
+
+libloguru_dep = declare_dependency(link_with : libloguru,
+                                   include_directories : '.')

--- a/src/libs/nuked/meson.build
+++ b/src/libs/nuked/meson.build
@@ -1,1 +1,3 @@
 libnuked = static_library('nuked', ['opl3.c'])
+
+libnuked_dep = declare_dependency(link_with : libnuked)

--- a/src/libs/ppscale/meson.build
+++ b/src/libs/ppscale/meson.build
@@ -1,1 +1,3 @@
 libppscale = static_library('ppscale', ['ppscale.c'])
+
+libppscale_dep = declare_dependency(link_with : libppscale)

--- a/src/libs/residfp/meson.build
+++ b/src/libs/residfp/meson.build
@@ -19,3 +19,4 @@ libresidfp_sources = files([
 
 libresidfp = static_library('residfp', libresidfp_sources)
 
+libresidfp_dep  = declare_dependency(link_with : libresidfp)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -28,13 +28,13 @@ endif
 # - fs_utils - depends on files in: tests/files/
 #
 example = executable('example', ['example_tests.cpp', 'stubs.cpp'],
-                     dependencies : [gtest_dep, sdl2_dep, libmisc_dep],
+                     dependencies : [gtest_dep, sdl2_dep, libmisc_dep, libloguru_dep],
                      include_directories : incdir)
 test('gtest example', example, 
      should_fail : true)
 
 fs_utils = executable('fs_utils', ['fs_utils_tests.cpp', 'stubs.cpp'],
-                      dependencies : [gtest_dep, libmisc_dep],
+                      dependencies : [gtest_dep, libmisc_dep, libloguru_dep],
                       include_directories : incdir)
 test('gtest fs_utils', fs_utils,
      workdir : project_source_root, is_parallel : false)
@@ -54,7 +54,7 @@ unit_tests = [
 foreach ut : unit_tests
   name = ut.get('name')
   exe = executable(name, [name + '_tests.cpp', 'stubs.cpp'],
-                   dependencies : [gtest_dep] + ut.get('deps'),
+                   dependencies : [gtest_dep, libloguru_dep] + ut.get('deps'),
                    include_directories : incdir)
   test('gtest ' + name, exe)
 endforeach


### PR DESCRIPTION
Several changes to improve readability of scripts or logs.

Since we must use Meson 0.54.2 now, we can use Meson `summary` function to highlight some important build information (so readers don't need to hunt for them in log). End of log looks like this right after this change:

```
...
Build targets in project: 25

dosbox-staging 0.78.0

  Build Summary
    Build type          : debug
    Install prefix      : /usr/local

    OpenGL support      : True
    Byte order          : little-endian
    CPU dynamic core    : optimized for x86/x86_64 (dyn-x86)
    CPU core target arch: X86_64

Found ninja-1.10.2 at /usr/bin/ninja

```
CPU core info was communicated via messages earlier - summary replaces those messages (but warnings are kept as they were).