### PR TITLE
Silence MSVC CRT warnings because they are not actionable

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,10 +12,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 212
+            max_warnings: 0
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1558
+            max_warnings: 1346
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -71,8 +71,10 @@
 #include "emu.h"
 #include "saa1099.h"
 
+#include <cassert>
 #include <cfloat>
 #include <cmath>
+#include <climits>
 
 #define LEFT    0x00
 #define RIGHT   0x01
@@ -185,7 +187,8 @@ void saa1099_device::device_start()
 	m_sample_rate = clock() / 256;
 
 	/* for each chip allocate one stream */
-	m_stream = stream_alloc(0, 2, m_sample_rate);
+	assert(m_sample_rate >= 0 && m_sample_rate <= INT_MAX);
+	m_stream = stream_alloc(0, 2, static_cast<int>(m_sample_rate));
 
 	save_item(NAME(m_noise_params));
 	save_item(NAME(m_env_enable));

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -55,10 +55,13 @@ differences between OPL2 and OPL3 shown in datasheets:
 
 
 */
-#include "support.h"
-
 #include "emu.h"
 #include "ymf262.h"
+
+#include <cassert>
+#include <cstdint>
+
+#include "support.h"
 
 /* output final shift */
 #if (OPL3_SAMPLE_BITS==16)
@@ -1393,7 +1396,8 @@ static void OPL3_initalize(OPL3 *chip)
 	/* Noise generator: a step takes 1 sample */
 	chip->noise_f = static_cast<uint32_t>((1.0 / 1.0) * (1<<FREQ_SH) * chip->freqbase);
 
-	chip->eg_timer_add  = (1<<EG_SH)  * chip->freqbase;
+        assert(chip->freqbase >= 0 && chip->freqbase <= UINT32_MAX);
+	chip->eg_timer_add  = (1<<EG_SH)  * static_cast<uint32_t>(chip->freqbase);
 	chip->eg_timer_overflow = (1) * (1<<EG_SH);
 	/*logerror("YMF262init eg_timer_add=%8x eg_timer_overflow=%8x\n", chip->eg_timer_add, chip->eg_timer_overflow);*/
 

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -81,3 +81,24 @@
 // Microsoft-specific names and functions instead of POSIX conformant ones.
 // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019#posix-function-names
 #define _CRT_NONSTDC_NO_WARNINGS
+
+// MSVC issues warnings on what it considers "unsafe" C-calls for
+// which "safer" (_s-equivalent) calls.
+//
+// To date, no effort has been made to transition toward these _s
+// calls, in part because no static analyzer (Coverity, PVS Studio,
+// or Clang) has flagged the project's use of the existing non-_s
+// calls as having security implications.
+//
+// Likewise, if there is going to be work put into altering the use
+// of these calls, it will involve transitioning toward modern C++
+// constructs as mentioned in #1314 (Ref:
+// https://github.com/dosbox-staging/dosbox-staging/issues/1314)
+//
+// Because the recommendations in these warnings will not be acted
+// upon given the planned direction of the the project, they
+// therefore provide no value and are being silenced.
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif


### PR DESCRIPTION
MSVC issues warnings on what it considers "unsafe" C-calls for which "safer" (_s-equivalent) calls.

To date, no effort has been made to transition toward these _s calls, in part because no static analyzer (Coverity, PVS Studio, or Clang) has flagged the project's use of the existing non-_s calls as having security implications.

Likewise, if there is going to be work put into altering the use of these calls, it will involve transitioning toward modern C++ constructs as mentioned in #1314.

Because the recommendations in these warnings will not be acted upon given the planned direction of the the project, they therefore provide no value and are being silenced.