### PR TITLE
Change GetTick functions to start from zero on startup

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -46,17 +46,19 @@ void TIMER_DelTickHandler(TIMER_TickHandler handler);
 /* This will add 1 milliscond to all timers */
 void TIMER_AddTick(void);
 
+extern const std::chrono::steady_clock::time_point system_start_time;
+
 static inline int64_t GetTicks()
 {
 	return std::chrono::duration_cast<std::chrono::milliseconds>(
-	               std::chrono::steady_clock::now().time_since_epoch())
+	               std::chrono::steady_clock::now() - system_start_time)
 	        .count();
 }
 
 static inline int64_t GetTicksUs()
 {
 	return std::chrono::duration_cast<std::chrono::microseconds>(
-	               std::chrono::steady_clock::now().time_since_epoch())
+	               std::chrono::steady_clock::now() - system_start_time)
 	        .count();
 }
 

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -27,6 +27,8 @@
 #include "setup.h"
 #include "support.h"
 
+const std::chrono::steady_clock::time_point system_start_time = std::chrono::steady_clock::now();
+
 static inline void BIN2BCD(Bit16u& val) {
 	const auto b = ((val / 10) % 10) << 4;
 	const auto c = ((val / 100) % 10) << 8;


### PR DESCRIPTION
The original SDL-based GetTick functionality started tick counts at zero and so always returned the number of ticks since startup. This change reverts to that behavior and makes more logical sense when looking at tick values in the debugger/logs/etc.