### PR TITLE
Expand search-path for bundled `translations/` language files

### DIFF
--- a/contrib/translations/utf-8/ru/ru-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/ru/ru-0.78.0-alpha.txt
@@ -8,7 +8,7 @@
 Настройка вертикальной синхронизации не реализована (настройка игнорируется).
 .
 :CONFIG_VSYNC_SKIP
-Number of microseconds to allow rendering to block before skipping the next frame.
+Количество микросекунд, в течение которых рендеринг должен блокироваться перед пропуском следующего кадра.
 .
 :CONFIG_FULLRESOLUTION
 Какое разрешение использовать для полноэкранного режима: 'original', 'desktop'
@@ -270,30 +270,30 @@ DOSBox, с последующей проверкой других мест в с
 используемые с Timidity должны работать хорошо.
 .
 :CONFIG_SIDMODEL
-Model of chip to emulate in the Innovation SSI-2001 card:
- - auto:  Selects the 6581 chip.
- - 6581:  The original chip, known for its bassy and rich character.
- - 8580:  A later revision that more closely matched the SID specification.
-          It fixed the 6581's DC bias and is less prone to distortion.
-          The 8580 is an option on reproduction cards, like the DuoSID.
- - none:  Disables the card.
+Модель чипа для эмуляции в карте Innovation SSI-2001:
+ - auto:  Выбирает чип 6581.
+ - 6581:  Оригинальный чип, известный своим басовитым и богатым звучанием.
+ - 8580:  Более поздняя модификация, более точно соответствующая спецификации SID.
+          В нём исправлено смещение постоянного тока 6581 и он менее подвержен искажениям.
+          8580 является опцией для репродуктивных карт, таких как DuoSID.
+ - none:  Отключает карту.
 .
 :CONFIG_SIDCLOCK
-The SID chip's clock frequency, which is jumperable on reproduction cards.
- - default: uses 0.895 MHz, per the original SSI-2001 card.
- - c64ntsc: uses 1.023 MHz, per NTSC Commodore PCs and the DuoSID.
- - c64pal:  uses 0.985 MHz, per PAL Commodore PCs and the DuoSID.
- - hardsid: uses 1.000 MHz, available on the DuoSID.
+Тактовая частота чипа SID, которая на картах устанавливается перемычкой.
+ - default: использует 0.895 МГц, для оригинальной карты SSI-2001.
+ - c64ntsc: использует 1.023 МГц, для NTSC Commodore PC и DuoSID.
+ - c64pal:  использует 0.985 МГц, для PAL Commodore PC и DuoSID.
+ - hardsid: использует 1.000 МГц, доступно на DuoSID.
 .
 :CONFIG_SIDPORT
-The IO port address of the Innovation SSI-2001.
+Адрес порта ввода-вывода SSI-2001.
 .
 :CONFIG_6581FILTER
-The SID's analog filtering meant that each chip was physically unique.
-Adjusts the 6581's filtering strength as a percent from 0 to 100.
+Аналоговая фильтрация SID означала, что каждый чип был физически уникален.
+Регулирует силу фильтрации 6581 в процентах от 0 до 100.
 .
 :CONFIG_8580FILTER
-Adjusts the 8580's filtering strength as a percent from 0 to 100.
+Регулирует силу фильтрации 8580 в процентах от 0 до 100.
 .
 :CONFIG_PCSPEAKER
 Включить эмуляцию PC-Speaker.
@@ -854,11 +854,11 @@ PCjr картридж найден, но машина не PCjr.
 
 .
 :SHELL_CMD_IMGMOUNT_HELP
-Монтировать образы компакт-дисков или дискет на указанную букву диска.
+Смонтировать образы компакт-дисков или дискет на указанную букву диска.
 
 .
 :SHELL_CMD_IMGMOUNT_HELP_LONG
-Монтировать CD-ROM, дискету или образ диска на указанную букву диска.
+Смонтировать CD-ROM, дискету или образ диска на указанную букву диска.
 
 Использование:
   [32;1mimgmount[0m [37;1mДИСК[0m [36;1mCDROM-SET[0m [CDROM-SET_2 [..]] [-fs iso] -t cdrom|iso
@@ -889,7 +889,7 @@ PCjr картридж найден, но машина не PCjr.
 
 .
 :SHELL_CMD_MOUNT_HELP_LONG
-Монтировать директорию из операционной системы на букву виртуального диска DOS.
+Смонтировать директорию из операционной системы на букву виртуального диска DOS.
 
 Использование:
   [32;1mmount[0m [37;1mДиск[0m [36;1mДиректория[0m [-t Тип] [-freesize Размер] [-label Метка]
@@ -1450,19 +1450,19 @@ choice [/c:клавиши] [/n] [/s] текст
 
 .
 :PROGRAM_INTRO_CDROM_WINDOWS
-[2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
-DOSBox provides CD-ROM emulation on several levels.
+[2J[32;1mКак смонтировать виртуальный привод CD-ROM в DOSBox:[0m
+DOSBox обеспечивает эмуляцию CD-ROM на нескольких уровнях.
 
-This works on all normal directories, installs MSCDEX and marks the files
-read-only. Usually this is enough for most games:
+Это работает во всех обычных директориях, устанавливает MSCDEX и помечает
+файлы только для чтения. Обычно этого достаточно для большинства игр:
 
 [34;1mmount D C:\example -t cdrom[0m
 
-If it doesn't work you might have to tell DOSBox the label of the CD-ROM:
+Если это не сработает, возможно, Вам придется сообщить DOSBox метку CD-ROM:
 
-[34;1mmount D C:\example -t cdrom -label CDLABEL[0m
+[34;1mmount D C:\example -t cdrom -label метка[0m
 
-Additionally, you can use imgmount to mount iso or cue/bin images:
+Также Вы можете использовать imgmount для монтирования образов iso или cue/bin:
 
 [34;1mimgmount D C:\cd.iso -t cdrom[0m
 
@@ -1470,19 +1470,19 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 
 .
 :PROGRAM_INTRO_CDROM_OTHER
-[2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
-DOSBox provides CD-ROM emulation on several levels.
+[2J[32;1mКак смонтировать виртуальный привод CD-ROM в DOSBox:[0m
+DOSBox обеспечивает эмуляцию CD-ROM на нескольких уровнях.
 
-This works on all normal directories, installs MSCDEX and marks the files
-read-only. Usually this is enough for most games:
+Это работает во всех обычных директориях, устанавливает MSCDEX и помечает
+файлы только для чтения. Обычно этого достаточно для большинства игр:
 
 [34;1mmount D ~/example -t cdrom[0m
 
-If it doesn't work you might have to tell DOSBox the label of the CD-ROM:
+Если это не сработает, возможно, Вам придется сообщить DOSBox метку CD-ROM:
 
-[34;1mmount D ~/example -t cdrom -label CDLABEL[0m
+[34;1mmount D ~/example -t cdrom -label метка[0m
 
-Additionally, you can use imgmount to mount iso or cue/bin images:
+Также Вы можете использовать imgmount для монтирования образов iso или cue/bin:
 
 [34;1mimgmount D ~/cd.iso -t cdrom[0m
 
@@ -1490,25 +1490,25 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 
 .
 :SHELL_CMD_HELP_HELP_LONG
-HELP [command]
+HELP [команда]
 
 .
 :SHELL_CMD_DELETE_HELP_LONG
-Usage:
-  [32;1mdel[0m [36;1mPATTERN[0m
-  [32;1merase[0m [36;1mPATTERN[0m
+Использование:
+  [32;1mdel[0m [36;1mшаблон[0m
+  [32;1merase[0m [36;1mшаблон[0m
 
-Where:
-  [36;1mPATTERN[0m can be either an exact filename (such as [36;1mfile.txt[0m) or an inexact
-          filename using one or more wildcards, which are the asterisk (*)
-          representing any sequence of one or more characters, and the question
-          mark (?) representing any single character, such as [36;1m*.bat[0m and [36;1mc?.txt[0m.
+Где:
+  [36;1mшаблон[0m может быть как точным именем файла (например, [36;1mfile.txt[0m), так и неточным
+          именем файла с использованием одного или нескольких символов подстановки, которым является
+          звёздочка (*), обозначающая любую последовательность из одного или нескольких символов,
+          и вопросительный знак (?), обозначающий любой одиночный символ, например, [36;1m*.bat[0m и [36;1mc?.txt[0m.
 
-Warning:
-  Be careful when using a pattern with wildcards, especially [36;1m*.*[0m, as all files
-  matching the pattern will be deleted.
+Внимание:
+  Будьте осторожны при использовании шаблона с подстановочными знаками, особенно с
+  [36;1m*.*[0m, так как все файлы соответствующие шаблону, будут удалены.
 
-Examples:
+Примеры:
   [32;1mdel[0m [36;1mtest.bat[0m
   [32;1mdel[0m [36;1mc*.*[0m
   [32;1mdel[0m [36;1ma?b.c*[0m

--- a/include/programs.h
+++ b/include/programs.h
@@ -21,9 +21,9 @@
 
 #include "dosbox.h"
 
-#include <filesystem>
 #include <list>
 #include <string>
+#include "std_filesystem.h"
 
 #include "dos_inc.h"
 
@@ -41,7 +41,7 @@ public:
 	bool FindStringBegin(char const * const begin,std::string & value, bool remove=false);
 	bool FindStringRemain(char const * const name,std::string & value);
 	bool FindStringRemainBegin(char const * const name,std::string & value);
-	const std::filesystem::path & GetExecutablePath() const;
+	const std_fs::path &GetExecutablePath() const;
 	bool GetStringRemain(std::string & value);
 	int GetParameterFromList(const char* const params[], std::vector<std::string> & output);
 	void FillVector(std::vector<std::string> & vector);

--- a/include/programs.h
+++ b/include/programs.h
@@ -21,6 +21,7 @@
 
 #include "dosbox.h"
 
+#include <filesystem>
 #include <list>
 #include <string>
 
@@ -40,6 +41,7 @@ public:
 	bool FindStringBegin(char const * const begin,std::string & value, bool remove=false);
 	bool FindStringRemain(char const * const name,std::string & value);
 	bool FindStringRemainBegin(char const * const name,std::string & value);
+	const std::filesystem::path & GetExecutablePath() const;
 	bool GetStringRemain(std::string & value);
 	int GetParameterFromList(const char* const params[], std::vector<std::string> & output);
 	void FillVector(std::vector<std::string> & vector);

--- a/include/std_filesystem.h
+++ b/include/std_filesystem.h
@@ -1,0 +1,32 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_FILESYSTEM_H
+#define DOSBOX_FILESYSTEM_H
+
+#if defined(__clang__) || defined(_MSC_VER) || (defined(__GNUC__) && __GNUC_ >= 9)
+#    include <filesystem>
+     namespace std_fs = std::filesystem;
+#else
+#    include <experimental/filesystem>
+     namespace std_fs = std::experimental::filesystem;
+#endif
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -306,7 +306,6 @@ summary('OpenGL support', get_option('use_opengl'))
 #
 incdir = include_directories('include', '.')
 
-
 # bundled dependencies, in dependency-order
 #
 subdir('src/libs/loguru')
@@ -314,7 +313,7 @@ subdir('src/libs/decoders')
 subdir('src/libs/nuked')
 subdir('src/libs/ppscale')
 subdir('src/libs/residfp')
-
+subdir('src/libs/whereami')
 
 # internal libs
 #
@@ -349,7 +348,7 @@ subdir('tests')
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
 executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
-           dependencies : [atomic_dep, threads_dep, sdl2_dep, libloguru_dep] + internal_deps,
+           dependencies : [atomic_dep, threads_dep, sdl2_dep, libloguru_dep, libwhereami_dep] + internal_deps,
            include_directories : incdir,
            install : true)
 

--- a/meson.build
+++ b/meson.build
@@ -189,6 +189,7 @@ msg = 'You can disable this dependency with: -D@0@=false'
 optional_dep  = dependency('', required : false)
 dl_dep        = cc.find_library('dl', required : false)
 atomic_dep    = cxx.find_library('atomic', required : false)
+stdcppfs_dep  = cxx.find_library('stdc++fs', required : false)
 opus_dep      = dependency('opusfile',
                            static : ('opusfile' in static_libs_list))
 threads_dep   = dependency('threads')
@@ -348,7 +349,13 @@ subdir('tests')
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
 executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
-           dependencies : [atomic_dep, threads_dep, sdl2_dep, libloguru_dep, libwhereami_dep] + internal_deps,
+           dependencies : [atomic_dep,
+                           stdcppfs_dep,
+                           sdl2_dep,
+                           threads_dep,
+                           libloguru_dep,
+                           libwhereami_dep]
+                          + internal_deps,
            include_directories : incdir,
            install : true)
 

--- a/src/libs/whereami/LICENSE.MIT
+++ b/src/libs/whereami/LICENSE.MIT
@@ -1,0 +1,18 @@
+Copyright Gregory Pakosz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/libs/whereami/LICENSE.WTFPLv2
+++ b/src/libs/whereami/LICENSE.WTFPLv2
@@ -1,0 +1,25 @@
+--------------------------------------------------------------------------------
+        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+  1. Bla bla bla
+  2. Montesqieu et camembert, vive la France, zut alors!
+
+--------------------------------------------------------------------------------
+
+WTFPLv2 is very permissive, see http://www.wtfpl.net/faq/
+
+However, if this WTFPLV2 is REALLY a blocker and is the reason you can't use
+this project, contact me and I'll dual license it.
+
+--------------------------------------------------------------------------------

--- a/src/libs/whereami/README.txt
+++ b/src/libs/whereami/README.txt
@@ -1,0 +1,123 @@
+# Where Am I?
+
+A drop-in two files library to locate the current executable and the current
+module on the file system.
+
+Supported platforms:
+
+- Windows
+- Linux
+- Mac
+- iOS
+- Android
+- QNX Neutrino
+- FreeBSD
+- NetBSD
+- DragonFly BSD
+- SunOS
+- OpenBSD
+
+Just drop `whereami.h` and `whereami.c` into your build and get started. (see
+also [customizing compilation])
+
+[customizing compilation]: #customizing-compilation
+
+--------------------------------------------------------------------------------
+
+## Usage
+
+- `wai_getExecutablePath()` returns the path of the enclosing executable
+- `wai_getModulePath()` returns the path of the enclosing module
+
+Example usage:
+
+- first call `int length = wai_getExecutablePath(NULL, 0, NULL);` to retrieve
+ the length of the path
+- allocate the destination buffer with `path = (char*)malloc(length + 1);`
+- call `wai_getExecutablePath(path, length, &dirname_length)` again to retrieve
+ the path
+- add a terminal `NUL` character with `path[length] = '\0';`
+
+Here is the output of the example:
+
+    $ make -j -C _gnu-make
+    $ cp ./bin/mac-x86_64/library.dylib /tmp/
+    $ ./bin/mac-x86_64/executable --load-library=/tmp/library.dylib
+
+    executable path: /Users/gregory/Projects/whereami/bin/mac-x86_64/executable
+      dirname: /Users/gregory/Projects/whereami/bin/mac-x86_64
+      basename: executable
+    module path: /Users/gregory/Projects/whereami/bin/mac-x86_64/executable
+      dirname: /Users/gregory/Projects/whereami/bin/mac-x86_64
+      basename: executable
+
+    library loaded
+    executable path: /Users/gregory/Projects/whereami/bin/mac-x86_64/executable
+      dirname: /Users/gregory/Projects/whereami/bin/mac-x86_64
+      basename: executable
+    module path: /private/tmp/library.dylib
+      dirname: /private/tmp
+      basename: library.dylib
+    library unloaded
+
+--------------------------------------------------------------------------------
+
+## Customizing compilation
+
+You can customize the library's behavior by defining the following macros:
+
+- `WAI_FUNCSPEC`
+- `WAI_PREFIX`
+- `WAI_MALLOC`
+- `WAI_REALLOC`
+- `WAI_FREE`
+
+## Compiling for Windows
+
+There is a Visual Studio 2015 solution in the `_win-vs14/` folder.
+
+## Compiling for Linux or Mac
+
+There is a GNU Make 3.81 `MakeFile` in the `_gnu-make/` folder:
+
+    $ make -j -C _gnu-make/
+
+## Compiling for Mac
+
+See above if you want to compile from command line. Otherwise there is an Xcode
+project located in the `_mac-xcode/` folder.
+
+## Compiling for iOS
+
+There is an Xcode project located in the `_ios-xcode/` folder.
+
+If you prefer compiling from command line and deploying to a jailbroken device
+through SSH, use:
+
+    $ make -j -C _gnu-make/ binsubdir=ios CC="$(xcrun --sdk iphoneos --find clang) -isysroot $(xcrun --sdk iphoneos --show-sdk-path) -arch armv7 -arch armv7s -arch arm64" postbuild="codesign -s 'iPhone Developer'"
+
+## Compiling for Android
+
+You will have to install the Android NDK, and point the `$NDK_ROOT` environment
+variable to the NDK path: e.g. `export NDK_ROOT=/opt/android-ndk` (without a
+trailing `/` character).
+
+Next, the easy way is to make a standalone Android toolchain with the following
+command:
+
+    $ $NDK_ROOT/build/tools/make_standalone_toolchain.py --arch=arm64 --api 21 --install-dir=/tmp/android-toolchain
+
+Now you can compile the example by running:
+
+    $ make -j -C _gnu-make/ platform=android architecture=arm64 CC=/tmp/android-toolchain/bin/aarch64-linux-android-gcc CXX=/tmp/android-toolchain/bin/aarch64-linux-android-g++
+
+Loading page aligned library straight from APKs is supported. To test, use the
+following:
+
+    $ zip -Z store app bin/android/library.so
+    $ zipalign -v -f -p 4 ./app.zip ./app.apk
+
+Then copy `bin/android/executable` and `app.apk` to your Android device and
+there launch:
+
+    $ ./executable --load-library=$PWD/app.apk!/bin/android/library.so

--- a/src/libs/whereami/meson.build
+++ b/src/libs/whereami/meson.build
@@ -1,0 +1,1 @@
+libwhereami = static_library('whereami', 'whereami.c')

--- a/src/libs/whereami/meson.build
+++ b/src/libs/whereami/meson.build
@@ -1,1 +1,4 @@
 libwhereami = static_library('whereami', 'whereami.c')
+
+libwhereami_dep = declare_dependency(link_with : libwhereami,
+                                     include_directories : '.')

--- a/src/libs/whereami/whereami.c
+++ b/src/libs/whereami/whereami.c
@@ -1,0 +1,799 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+// in case you want to #include "whereami.c" in a larger compilation unit
+#if !defined(WHEREAMI_H)
+#include <whereami.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
+#include <stdlib.h>
+#endif
+
+#if !defined(WAI_MALLOC)
+#define WAI_MALLOC(size) malloc(size)
+#endif
+
+#if !defined(WAI_FREE)
+#define WAI_FREE(p) free(p)
+#endif
+
+#if !defined(WAI_REALLOC)
+#define WAI_REALLOC(p, size) realloc(p, size)
+#endif
+
+#ifndef WAI_NOINLINE
+#if defined(_MSC_VER)
+#define WAI_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define WAI_NOINLINE __attribute__((noinline))
+#else
+#error unsupported compiler
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#define WAI_RETURN_ADDRESS() _ReturnAddress()
+#elif defined(__GNUC__)
+#define WAI_RETURN_ADDRESS() __builtin_extract_return_addr(__builtin_return_address(0))
+#else
+#error unsupported compiler
+#endif
+
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push, 3)
+#endif
+#include <windows.h>
+#include <intrin.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
+{
+  wchar_t buffer1[MAX_PATH];
+  wchar_t buffer2[MAX_PATH];
+  wchar_t* path = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    DWORD size;
+    int length_, length__;
+
+    size = GetModuleFileNameW(module, buffer1, sizeof(buffer1) / sizeof(buffer1[0]));
+
+    if (size == 0)
+      break;
+    else if (size == (DWORD)(sizeof(buffer1) / sizeof(buffer1[0])))
+    {
+      DWORD size_ = size;
+      do
+      {
+        wchar_t* path_;
+
+        path_ = (wchar_t*)WAI_REALLOC(path, sizeof(wchar_t) * size_ * 2);
+        if (!path_)
+          break;
+        size_ *= 2;
+        path = path_;
+        size = GetModuleFileNameW(module, path, size_);
+      }
+      while (size == size_);
+
+      if (size == size_)
+        break;
+    }
+    else
+      path = buffer1;
+
+    if (!_wfullpath(buffer2, path, MAX_PATH))
+      break;
+    length_ = (int)wcslen(buffer2);
+    length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_ , out, capacity, NULL, NULL);
+
+    if (length__ == 0)
+      length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_, NULL, 0, NULL, NULL);
+    if (length__ == 0)
+      break;
+
+    if (length__ <= capacity && dirname_length)
+    {
+      int i;
+
+      for (i = length__ - 1; i >= 0; --i)
+      {
+        if (out[i] == '\\')
+        {
+          *dirname_length = i;
+          break;
+        }
+      }
+    }
+
+    length = length__;
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  return WAI_PREFIX(getModulePath_)(NULL, out, capacity, dirname_length);
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  HMODULE module;
+  int length = -1;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4054)
+#endif
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)WAI_RETURN_ADDRESS(), &module))
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+  {
+    length = WAI_PREFIX(getModulePath_)(module, out, capacity, dirname_length);
+  }
+
+  return length;
+}
+
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if defined(__linux__)
+#include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#if defined(__sun)
+#define WAI_PROC_SELF_EXE "/proc/self/path/a.out"
+#else
+#define WAI_PROC_SELF_EXE "/proc/self/exe"
+#endif
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    resolved = realpath(WAI_PROC_SELF_EXE, buffer);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#if !defined(WAI_PROC_SELF_MAPS_RETRY)
+#define WAI_PROC_SELF_MAPS_RETRY 5
+#endif
+
+#if !defined(WAI_PROC_SELF_MAPS)
+#if defined(__sun)
+#define WAI_PROC_SELF_MAPS "/proc/self/map"
+#else
+#define WAI_PROC_SELF_MAPS "/proc/self/maps"
+#endif
+#endif
+
+#if defined(__ANDROID__) || defined(ANDROID)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  int length = -1;
+  FILE* maps = NULL;
+
+  for (int r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
+  {
+    maps = fopen(WAI_PROC_SELF_MAPS, "r");
+    if (!maps)
+      break;
+
+    for (;;)
+    {
+      char buffer[PATH_MAX < 1024 ? 1024 : PATH_MAX];
+      uint64_t low, high;
+      char perms[5];
+      uint64_t offset;
+      uint32_t major, minor;
+      char path[PATH_MAX];
+      uint32_t inode;
+
+      if (!fgets(buffer, sizeof(buffer), maps))
+        break;
+
+      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+      {
+        uint64_t addr = (uintptr_t)WAI_RETURN_ADDRESS();
+        if (low <= addr && addr <= high)
+        {
+          char* resolved;
+
+          resolved = realpath(path, buffer);
+          if (!resolved)
+            break;
+
+          length = (int)strlen(resolved);
+#if defined(__ANDROID__) || defined(ANDROID)
+          if (length > 4
+              &&buffer[length - 1] == 'k'
+              &&buffer[length - 2] == 'p'
+              &&buffer[length - 3] == 'a'
+              &&buffer[length - 4] == '.')
+          {
+            int fd = open(path, O_RDONLY);
+            if (fd == -1)
+            {
+              length = -1; // retry
+              break;
+            }
+
+            char* begin = (char*)mmap(0, offset, PROT_READ, MAP_SHARED, fd, 0);
+            if (begin == MAP_FAILED)
+            {
+              close(fd);
+              length = -1; // retry
+              break;
+            }
+
+            char* p = begin + offset - 30; // minimum size of local file header
+            while (p >= begin) // scan backwards
+            {
+              if (*((uint32_t*)p) == 0x04034b50UL) // local file header signature found
+              {
+                uint16_t length_ = *((uint16_t*)(p + 26));
+
+                if (length + 2 + length_ < (int)sizeof(buffer))
+                {
+                  memcpy(&buffer[length], "!/", 2);
+                  memcpy(&buffer[length + 2], p + 30, length_);
+                  length += 2 + length_;
+                }
+
+                break;
+              }
+
+              --p;
+            }
+
+            munmap(begin, offset);
+            close(fd);
+          }
+#endif
+          if (length <= capacity)
+          {
+            memcpy(out, resolved, length);
+
+            if (dirname_length)
+            {
+              int i;
+
+              for (i = length - 1; i >= 0; --i)
+              {
+                if (out[i] == '/')
+                {
+                  *dirname_length = i;
+                  break;
+                }
+              }
+            }
+          }
+
+          break;
+        }
+      }
+    }
+
+    fclose(maps);
+    maps = NULL;
+
+    if (length != -1)
+      break;
+  }
+
+  if (maps)
+    fclose(maps);
+
+  return length;
+}
+
+#elif defined(__APPLE__)
+
+#define _DARWIN_BETTER_REALPATH
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    uint32_t size = (uint32_t)sizeof(buffer1);
+    if (_NSGetExecutablePath(path, &size) == -1)
+    {
+      path = (char*)WAI_MALLOC(size);
+      if (!_NSGetExecutablePath(path, &size))
+        break;
+    }
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__QNXNTO__)
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#define WAI_PROC_SELF_EXE "/proc/self/exefile"
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* resolved = NULL;
+  FILE* self_exe = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    self_exe = fopen(WAI_PROC_SELF_EXE, "r");
+    if (!self_exe)
+      break;
+
+    if (!fgets(buffer1, sizeof(buffer1), self_exe))
+      break;
+
+    resolved = realpath(buffer1, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  fclose(self_exe);
+
+  return length;
+}
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || \
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <dlfcn.h>
+
+#if defined(__OpenBSD__)
+
+#include <unistd.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[4096];
+  char buffer2[PATH_MAX];
+  char buffer3[PATH_MAX];
+  char** argv = (char**)buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
+    size_t size;
+
+    if (sysctl(mib, 4, NULL, &size, NULL, 0) != 0)
+        break;
+
+    if (size > sizeof(buffer1))
+    {
+      argv = (char**)WAI_MALLOC(size);
+      if (!argv)
+        break;
+    }
+
+    if (sysctl(mib, 4, argv, &size, NULL, 0) != 0)
+        break;
+
+    if (strchr(argv[0], '/'))
+    {
+      resolved = realpath(argv[0], buffer2);
+      if (!resolved)
+        break;
+    }
+    else
+    {
+      const char* PATH = getenv("PATH");
+      if (!PATH)
+        break;
+
+      size_t argv0_length = strlen(argv[0]);
+
+      const char* begin = PATH;
+      while (1)
+      {
+        const char* separator = strchr(begin, ':');
+        const char* end = separator ? separator : begin + strlen(begin);
+
+        if (end - begin > 0)
+        {
+          if (*(end -1) == '/')
+            --end;
+
+          if (((end - begin) + 1 + argv0_length + 1) <= sizeof(buffer2))
+          {
+            memcpy(buffer2, begin, end - begin);
+            buffer2[end - begin] = '/';
+            memcpy(buffer2 + (end - begin) + 1, argv[0], argv0_length + 1);
+
+            resolved = realpath(buffer2, buffer3);
+            if (resolved)
+              break;
+          }
+        }
+
+        if (!separator)
+          break;
+
+        begin = ++separator;
+      }
+
+      if (!resolved)
+        break;
+    }
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  if (argv != (char**)buffer1)
+    WAI_FREE(argv);
+
+  return length;
+}
+
+#else
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+#if defined(__NetBSD__)
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
+    size_t size = sizeof(buffer1);
+
+    if (sysctl(mib, 4, path, &size, NULL, 0) != 0)
+        break;
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#endif
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#else
+
+#error unsupported platform
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libs/whereami/whereami.h
+++ b/src/libs/whereami/whereami.h
@@ -1,0 +1,67 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+#ifndef WHEREAMI_H
+#define WHEREAMI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WAI_FUNCSPEC
+  #define WAI_FUNCSPEC
+#endif
+#ifndef WAI_PREFIX
+#define WAI_PREFIX(function) wai_##function
+#endif
+
+/**
+ * Returns the path to the current executable.
+ *
+ * Usage:
+ *  - first call `int length = wai_getExecutablePath(NULL, 0, NULL);` to
+ *    retrieve the length of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getExecutablePath(path, length, NULL)` again to retrieve the
+ *    path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the executable path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length);
+
+/**
+ * Returns the path to the current module
+ *
+ * Usage:
+ *  - first call `int length = wai_getModulePath(NULL, 0, NULL);` to retrieve
+ *    the length  of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getModulePath(path, length, NULL)` again to retrieve the path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the module path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // #ifndef WHEREAMI_H

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -16,6 +16,7 @@ libmisc = static_library('misc', libmisc_sources,
                          dependencies : [
                            sdl2_dep,
                            libloguru_dep,
+                           libwhereami_dep,
                          ])
 
 libmisc_dep = declare_dependency(link_with : libmisc)

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -22,7 +22,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <deque>
-#include <filesystem>
+
+#include "std_filesystem.h"
 #include <string>
 #include <unordered_map>
 
@@ -58,23 +59,24 @@ void MSG_Replace(const char *name, const char *msg)
 		it->second = msg;
 }
 
-static bool LoadMessageFile(const std::filesystem::path & filename)
+static bool LoadMessageFile(const std_fs::path &filename)
 {
 	if (filename.empty())
 		return false;
 
+	const auto filename_str = filename.string();
+
 	// Was the file not found?
-	if (std::filesystem::status(filename).type() ==
-	    std::filesystem::file_type::not_found) {
+	if (std_fs::status(filename).type() == std_fs::file_type::not_found) {
 		LOG_MSG("LANG: Language file %s not found, skipping",
-		        filename.c_str());
+		        filename_str.c_str());
 		return false;
 	}
 
-	FILE *mfile = fopen(filename.c_str(), "rt");
+	FILE *mfile = fopen(filename_str.c_str(), "rt");
 	if (!mfile) {
 		LOG_MSG("LANG: Failed opening language file: %s, skipping",
-		        filename.c_str());
+		        filename_str.c_str());
 		return false;
 	}
 
@@ -116,7 +118,7 @@ static bool LoadMessageFile(const std::filesystem::path & filename)
 		}
 	}
 	fclose(mfile);
-	LOG_MSG("LANG: Loaded language file: %s", filename.c_str());
+	LOG_MSG("LANG: Loaded language file: %s", filename_str.c_str());
 	return true;
 }
 
@@ -175,9 +177,9 @@ static std::deque<std::string> get_language(const Section_prop *section)
 	return langs;
 }
 
-static std::deque<std::filesystem::path> get_paths()
+static std::deque<std_fs::path> get_paths()
 {
-	std::deque<std::filesystem::path> paths = {};
+	std::deque<std_fs::path> paths = {};
 
 	const auto exe_path = control->cmdline->GetExecutablePath();
 #if defined(MACOSX)
@@ -186,7 +188,7 @@ static std::deque<std::filesystem::path> get_paths()
 	paths.emplace_back(exe_path / "translations");
 #endif
 
-	const std::filesystem::path config_path(CROSS_GetPlatformConfigDir());
+	const std_fs::path config_path(CROSS_GetPlatformConfigDir());
 	paths.emplace_back(config_path / "translations");
 
 	// Possibly exists on macOS, POSIX, and even MSYS2 or Cygwin (Windows)
@@ -208,7 +210,8 @@ static std::deque<std::filesystem::path> get_paths()
 void MSG_Init(Section_prop *section)
 {
 	for (const auto &l : get_language(section)) {
-		// If the language is english, then always prefer the internal version
+		// If the language is english, then always prefer the internal
+		// version
 		if (starts_with("en", l)) {
 			LOG_MSG("LANG: Using internal English language messages");
 			return;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1329,9 +1329,9 @@ CommandLine::CommandLine(int argc, char const *const argv[])
 	}
 }
 
-const std::filesystem::path & CommandLine::GetExecutablePath() const
+const std_fs::path &CommandLine::GetExecutablePath() const
 {
-	static std::filesystem::path exe_path;
+	static std_fs::path exe_path;
 	if (exe_path.empty()) {
 		int length = wai_getExecutablePath(nullptr, 0, nullptr);
 		// const auto length = wai_getExecutablePath(nullptr, 0, nullptr);
@@ -1344,8 +1344,10 @@ const std::filesystem::path & CommandLine::GetExecutablePath() const
 	return exe_path;
 }
 
-Bit16u CommandLine::Get_arglength() {
-	if (cmds.empty()) return 0;
+Bit16u CommandLine::Get_arglength()
+{
+	if (cmds.empty())
+		return 0;
 
 	size_t total_length = 0;
 	for (const auto &cmd : cmds)

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -713,8 +713,10 @@ void Section_prop::PrintData(FILE* outfile) const {
 
 	// Determine maximum length of the props in this section
 	int len = 0;
-	for (const auto &tel : properties)
-		len = std::max<int>(len, tel->propname.length());
+	for (const auto &tel : properties) {
+		const auto prop_length = check_cast<int>(tel->propname.length());
+		len = std::max<int>(len, prop_length);
+	}
 
 	for (const auto &tel : properties) {
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -151,7 +151,7 @@ bool Value::SetValue(string const& in,Etype _type) {
 bool Value::set_hex(std::string const& in) {
 	istringstream input(in);
 	input.flags(ios::hex);
-	Bits result = INT_MIN;
+	int result = INT_MIN;
 	input >> result;
 	if(result == INT_MIN) return false;
 	_hex = result;
@@ -160,7 +160,7 @@ bool Value::set_hex(std::string const& in) {
 
 bool Value::set_int(string const &in) {
 	istringstream input(in);
-	Bits result = INT_MIN;
+	int result = INT_MIN;
 	input >> result;
 	if(result == INT_MIN) return false;
 	_int = result;
@@ -397,11 +397,12 @@ bool Prop_hex::SetValue(std::string const& input) {
 	return SetVal(val,false,true);
 }
 
-void Prop_multival::make_default_value() {
-	Bitu i = 1;
+void Prop_multival::make_default_value()
+{
 	Property *p = section->Get_prop(0);
 	if (!p) return;
 
+	int i = 1;
 	std::string result = p->Get_Default_Value().ToString();
 	while( (p = section->Get_prop(i++)) ) {
 		std::string props = p->Get_Default_Value().ToString();
@@ -773,14 +774,14 @@ bool Config::PrintConfig(const std::string &filename) const
 		Section_prop *sec = dynamic_cast<Section_prop *>(*tel);
 		if (sec) {
 			Property *p;
-			size_t i = 0, maxwidth = 0;
+			int i = 0;
+			size_t maxwidth = 0;
 			while ((p = sec->Get_prop(i++))) {
-				size_t w = strlen(p->propname.c_str());
-				if (w > maxwidth) maxwidth = w;
+				maxwidth = std::max(maxwidth, p->propname.length());
 			}
 			i=0;
 			char prefix[80];
-			int intmaxwidth = std::min<int>(60, maxwidth);
+			int intmaxwidth = std::min<int>(60, check_cast<int>(maxwidth));
 			snprintf(prefix, sizeof(prefix), "\n# %*s  ", intmaxwidth , "");
 			while ((p = sec->Get_prop(i++))) {
 
@@ -1252,7 +1253,7 @@ int CommandLine::GetParameterFromList(const char* const params[], std::vector<st
 	cmd_it it = cmds.begin();
 	while(it != cmds.end()) {
 		bool found = false;
-		for(Bitu i = 0; *params[i]!=0; i++) {
+		for (int i = 0; *params[i] != 0; ++i) {
 			if (!strcasecmp((*it).c_str(),params[i])) {
 				// found a parameter
 				found = true;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -26,6 +26,8 @@
 #include <regex>
 #include <sstream>
 
+#include "whereami.h"
+
 #include "control.h"
 #include "string_utils.h"
 #include "support.h"
@@ -1325,6 +1327,21 @@ CommandLine::CommandLine(int argc, char const *const argv[])
 		cmds.push_back(argv[i]);
 		i++;
 	}
+}
+
+const std::filesystem::path & CommandLine::GetExecutablePath() const
+{
+	static std::filesystem::path exe_path;
+	if (exe_path.empty()) {
+		int length = wai_getExecutablePath(nullptr, 0, nullptr);
+		// const auto length = wai_getExecutablePath(nullptr, 0, nullptr);
+		std::string s;
+		s.resize(check_cast<uint16_t>(length));
+		wai_getExecutablePath(&s[0], length, nullptr);
+		exe_path = s;
+		assert(!exe_path.empty());
+	}
+	return exe_path;
 }
 
 Bit16u CommandLine::Get_arglength() {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -47,7 +47,7 @@ unit_tests = [
   {'name' : 'rwqueue',              'deps' : [libmisc_dep]},
   {'name' : 'soft_limiter',         'deps' : [atomic_dep, sdl2_dep, libmisc_dep]},
   {'name' : 'string_utils',         'deps' : []},
-  {'name' : 'setup',                'deps' : [sdl2_dep, libmisc_dep]},
+  {'name' : 'setup',                'deps' : [stdcppfs_dep, sdl2_dep, libmisc_dep]},
   {'name' : 'support',              'deps' : [sdl2_dep, libmisc_dep]},
 ]
 

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -110,7 +110,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -141,7 +141,7 @@ $(TargetPath)
       <ConformanceMode>Default</ConformanceMode>
       <OmitFramePointers>true</OmitFramePointers>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
-      <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -171,7 +171,7 @@ $(TargetPath)
       <FloatingPointExceptions>true</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>false</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -203,7 +203,7 @@ $(TargetPath)
       <ConformanceMode>Default</ConformanceMode>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>..\..\src\libs\loguru</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -228,6 +228,7 @@ $(TargetPath)
     <ClCompile Include="..\..\src\misc\soft_limiter.cpp" />
     <ClCompile Include="..\..\src\misc\support.cpp" />
     <ClCompile Include="..\..\src\libs\loguru\loguru.cpp" />
+    <ClCompile Include="..\..\src\libs\whereami\whereami.c" />
     <ClCompile Include="..\fs_utils_tests.cpp" />
     <ClCompile Include="..\rwqueue_tests.cpp" />
     <ClCompile Include="..\setup_tests.cpp" />

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="..\..\src\libs\loguru\loguru.cpp">
       <Filter>dosbox_sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\libs\whereami\whereami.c">
+      <Filter>dosbox_sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\support_tests.cpp">
       <Filter>tests</Filter>
     </ClCompile>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -100,7 +100,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -137,7 +137,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -178,7 +178,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -227,7 +227,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -444,6 +444,7 @@
     <ClCompile Include="..\src\shell\shell_cmds.cpp" />
     <ClCompile Include="..\src\shell\shell_misc.cpp" />
     <ClCompile Include="..\src\libs\loguru\loguru.cpp" />
+    <ClCompile Include="..\src\libs\whereami\whereami.c" />
     <ClCompile Include="..\src\platform\visualc\version.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -595,6 +596,7 @@
     <ClInclude Include="..\src\platform\visualc\config.h" />
     <ClInclude Include="..\src\platform\visualc\unistd.h" />
     <ClInclude Include="..\src\libs\loguru\loguru.hpp" />
+    <ClInclude Include="..\src\libs\whereami\whereami.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\src\dosbox.ico" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -490,6 +490,9 @@
     <ClCompile Include="..\src\libs\loguru\loguru.cpp">
       <Filter>src\libs\loguru</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\libs\whereami\whereami.c">
+      <Filter>src\libs\whereami</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\dos\program_biostest.cpp" />
     <ClCompile Include="..\src\dos\program_boot.cpp" />
     <ClCompile Include="..\src\dos\program_imgmount.cpp" />
@@ -937,6 +940,9 @@
     </ClInclude>
     <ClInclude Include="..\src\libs\loguru\loguru.hpp">
       <Filter>src\libs\loguru</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\libs\whereami\whereami.h">
+      <Filter>src\libs\whereami</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR will additionally search for the bundled `translations` directory in:
 - the as-bundled location, assuming the user has simply extracted the ZIP package and runs from there.
 - `/usr/share/dosbox/translations`, which can possibly exist in macOS, POSIX, and MSYS2/Cygwin environments.

If the user leaves their `language = ` setting empty, then this PR will also check the `LANG` environment variable and attempt to load that language.  If the language is English, then the internal messages are used.

Thank you @IlyaIndigo for these suggested improvements!