### PR TITLE
Fix PVS issues in CreateAutoexec

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 282
+          MAX_BUGS: 280
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -101,16 +101,18 @@ void AutoexecObject::CreateAutoexec()
 	//Create a new autoexec.bat
 	autoexec_data[0] = 0;
 	size_t auto_len;
-	for(auto_it it = autoexec_strings.begin(); it != autoexec_strings.end(); it++) {
-
-		std::string linecopy = (*it);
+	for (std::string linecopy : autoexec_strings) {
 		std::string::size_type offset = 0;
-		//Lets have \r\n as line ends in autoexec.bat.
+		// Lets have \r\n as line ends in autoexec.bat.
 		while(offset < linecopy.length()) {
-			std::string::size_type  n = linecopy.find("\n",offset);
-			if ( n == std::string::npos ) break;
-			std::string::size_type rn = linecopy.find("\r\n",offset);
-			if ( rn != std::string::npos && rn + 1 == n) {offset = n + 1; continue;}
+			const auto n = linecopy.find('\n', offset);
+			if (n == std::string::npos)
+				break;
+			const auto rn = linecopy.find("\r\n", offset);
+			if (rn != std::string::npos && rn + 1 == n) {
+				offset = n + 1;
+				continue;
+			}
 			// \n found without matching \r
 			linecopy.replace(n,1,"\r\n");
 			offset = n + 2;


### PR DESCRIPTION
Avoid following reports:

- V803 Decreased performance. In case 'it' is iterator it's more
  effective to use prefix form of increment. Replace iterator++ with
  ++iterator.
- V817 It is more efficient to seek '\n' character rather than a string.