### PR TITLE
Add support for NPOT-textures

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -60,7 +60,7 @@ Bitu GFX_GetBestMode(Bitu flags);
 int GFX_GetDisplayRefreshRate();
 Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);
 void GFX_SetShader(const char* src);
-Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags,
+Bitu GFX_SetSize(int width, int height, Bitu flags,
                  double scalex, double scaley,
                  GFX_CallBack_t callback,
                  double pixel_aspect);

--- a/src/gui/dosbox_staging_splash.c
+++ b/src/gui/dosbox_staging_splash.c
@@ -23,9 +23,9 @@
                __ip += __l; __rd += __l; } } \
   } } while (0)
 static constexpr struct {
-  unsigned int          width;
-  unsigned int          height;
-  unsigned int          bytes_per_pixel; /* 2:RGB16, 3:RGB, 4:RGBA */
+  int          width;
+  int          height;
+  int          bytes_per_pixel; /* 2:RGB16, 3:RGB, 4:RGBA */
   unsigned char         rle_pixel_data[37520 + 1];
 } splash_image = {
   640, 400, 3,


### PR DESCRIPTION
Non-power-of-two textures allow for lesser video memory consumption. This also fixes a thin black line along the window border visible with OpenGL output caused by sampling off a useful texture region.

For a very unlikely case when the extension is not available, fallback is implemented as well. Texture size is calculated for both dimensions, unlike in original code, which allows reducing texture size by half in typical scenarios (that is, games running in 320×200 or 640×480).
