### PR TITLE
Add 'force_update_ticks' option

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -89,6 +89,8 @@ typedef struct {
 	bool aspect;
 	bool fullFrame;
 	bool forceUpdate;
+	int forceUpdateTicks;
+	uint32_t nextForceUpdateTicks;
 } Render_t;
 
 extern Render_t render;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -547,6 +547,9 @@ void DOSBOX_Init(void) {
 	                 "fullresolution output.");
 
 	pstring = pmulti->GetSection()->Add_string("type", always, "none");
+	pint = secprop->Add_int("force_update_ticks", always, 0);
+	pint->Set_help("Forces the rendering to be performed for at least the number of ticks\n"
+	               "indicated. The game can still render faster than this if needed.");
 
 	const char *scalers[] = {
 		"none", "normal2x", "normal3x",

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1351,7 +1351,9 @@ dosurface:
 					sdl.opengl.ruby.output_size = glGetUniformLocation(sdl.opengl.program_object, "rubyOutputSize");
 					sdl.opengl.ruby.frame_count = glGetUniformLocation(sdl.opengl.program_object, "rubyFrameCount");
 					// Don't force updating unless a shader depends on frame_count
-					RENDER_SetForceUpdate(sdl.opengl.ruby.frame_count != -1);
+					if (GCC_LIKELY(!RENDER_GetForceUpdate())) {
+						RENDER_SetForceUpdate(sdl.opengl.ruby.frame_count != -1);
+					}
 				}
 			}
 		}
@@ -1728,6 +1730,7 @@ void GFX_EndUpdate(const Bit16u *changedLines)
 #endif
 	if ((!using_opengl || !RENDER_GetForceUpdate()) && !sdl.updating)
 		return;
+	render.forceUpdate = false;
 	[[maybe_unused]] bool actually_updating = sdl.updating;
 	sdl.updating = false;
 	switch (sdl.desktop.type) {


### PR DESCRIPTION
Hi there,

I'm not sure if this is useful in general, but I needed to add this so the Steam Overlay can work properly with dosbox-staging. This change forces rendering for at least the number of ticks specified in the config.

It might also help with #1228, although it's probably not the perfect solution for it (rendering will still be variable although a minimum rate will be guaranteed).

Even if you don't want to accept the patch, I'd like to hear feedback about my way of implementing said functionality, there might be a better way of doing what I did and I'd love to hear about it :).

Thanks in advance!