### PR TITLE
Expand macOS build instructions

### DIFF
--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -2,7 +2,7 @@ macOS builds can be created using the Meson buildsystem, compiled using
 the Clang or GCC compilers, and provided with dependencies using the Homebrew
 or MacPorts package managers.
 
-We're recommending using Homebrew and Clang, because Apple's Core SDKs can be
+We recommend using Homebrew and Clang, because Apple's Core SDKs can be
 used only with Apple's fork of Clang compiler.
 
 ## Install Dependencies under macOS
@@ -13,26 +13,40 @@ to be installed and the license agreed to:
 ## Xcode Installation
 
 1. Install the command line tools: `xcode-select --install`
-2. Accept the license agreement: `sudo xcodebuild -license`
+    and accept the license agreement
+2. Install software updates:
+    **Apple menu** >
+    **System Preferences** >
+    **Software Update** >
+    *"Updates are available: command line tools for Xcode"*
+    Click **Update Now** to proceed.
 3. Install build dependencies using either Homebrew or MacPorts.
 
 ### Install dependencies (Homebrew)
 
 1. Install Homebrew: <https://brew.sh>.
-2. Install dependencies:
+2. Install dependencies and related tools:
 
     ``` shell
-    brew install ccache meson libpng sdl2 sdl2_net opusfile fluid-synth
+    brew install ccache cmake fluid-synth libpng meson \
+                 opusfile pkg-config python3 sdl2 sdl2_net
+    ```
+
+3. Add brew to your shell path:
+
+    ``` shell
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME"/.zprofile
+    eval "$(/opt/homebrew/bin/brew shellenv)"
     ```
 
 ### Install dependencies (MacPorts)
 
 1. Install MacPorts: <https://www.macports.org/install.php>
-2. Install dependencies:
+2. Install dependencies and related tools:
 
     ``` shell
-    sudo port -q install meson ccache libpng libsdl2 libsdl2_net \
-                         opusfile fluidsynth
+    sudo port -q install ccache cmake fluidsynth libpng libsdl2 \
+              libsdl2_net meson opusfile pkg-config python3
     ```
 
 ## Build
@@ -41,10 +55,28 @@ Once you have depenendcies installed using either environment, clone and
 enter the repository's directory:
 
 ``` shell
+cd
+mkdir -p src
+cd src
 git clone https://github.com/dosbox-staging/dosbox-staging.git
 cd dosbox-staging
 meson setup build
 ninja -C build
 ```
 
-Detailed instructions and build options are documented in [BUILD.md](/BUILD.md).
+See more build options in [BUILD.md](/BUILD.md).
+
+## Permissions and Running
+
+1. Allow the terminal to get keyboard events, which will let you
+   launch dosbox from the command line.
+   
+    In System Settings > Privacy > Input Monitoring > Terminal (enable)
+    
+2. Launch DOSBox Staging:
+
+    ``` shell
+    cd src/dosbox-staging/
+    ./build/dosbox
+    ```
+ 


### PR DESCRIPTION
 - Mention system-update to install xcode
 - Add python3, pkg-config, and cmake as related tools
     Staging itself doesn't depend on these, but Meson uses pkg-config and cmake)
     To work with Staging sources, we have many helpful python3 scripts
 - Add notes about giving the terminal permissions