### PR TITLE
Add help message and fix for PATH command

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -792,7 +792,23 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_RMDIR_HELP","Remove Directory.\n");
 	MSG_Add("SHELL_CMD_RMDIR_HELP_LONG","RMDIR [drive:][path]\n"
 	        "RD [drive:][path]\n");
-	MSG_Add("SHELL_CMD_SET_HELP","Change environment variables.\n");
+	MSG_Add("SHELL_CMD_SET_HELP", "Displays or changes environment variables.\n");
+	MSG_Add("SHELL_CMD_SET_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mset\033[0m\n"
+	        "  \033[32;1mset\033[0m \033[37;1mVARIABLE\033[0m=\033[36;1m[STRING]\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[37;1mVARIABLE\033[0m The name of the environment variable.\n"
+	        "  \033[36;1mSTRING\033[0m   A series of characters to assign to the variable.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  - Assigning an empty string to the variable removes the variable.\n"
+	        "  - The command without a parameter displays current environment variables.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mset\033[0m\n"
+	        "  \033[32;1mset\033[0m \033[37;1mname\033[0m=\033[36;1mvalue\033[0m\n");
 	MSG_Add("SHELL_CMD_IF_HELP","Performs conditional processing in batch programs.\n");
 	MSG_Add("SHELL_CMD_GOTO_HELP","Jump to a labeled line in a batch script.\n");
 	MSG_Add("SHELL_CMD_SHIFT_HELP","Leftshift commandline parameters in a batch script.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -842,8 +842,24 @@ void SHELL_Init() {
 	        "  /N  -  Do not display the choices at end of prompt.\n"
 	        "  /S  -  Enables case-sensitive choices to be selected.\n"
 	        "  text  -  The text to display as a prompt.\n");
-	MSG_Add("SHELL_CMD_PATH_HELP","Provided for compatibility.\n");
-
+	MSG_Add("SHELL_CMD_PATH_HELP",
+	        "Displays or sets a search path for executable files.\n");
+	MSG_Add("SHELL_CMD_PATH_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mpath\033[0m\n"
+	        "  \033[32;1mpath\033[0m \033[36;1m[[drive:]path[;...]\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1m[[drive:]path[;...]\033[0m is a path containing a drive and directory.\n"
+	        "  More than one path can be specified, separated by a semi-colon (;).\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Parameter with a semi-colon (;) only clears all search path settings.\n"
+	        "  The path can also be set using \033[32;1mset\033[0m command, e.g. \033[32;1mset\033[0m \033[37;1mpath\033[0m=\033[36;1mZ:\\\033[0m\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mpath\033[0m\n"
+	        "  \033[32;1mpath\033[0m \033[36;1mZ:\\;C:\\DOS\033[0m\n");
 	MSG_Add("SHELL_CMD_VER_HELP", "View or set the reported DOS version.\n");
 	MSG_Add("SHELL_CMD_VER_HELP_LONG", "Usage:\n"
 	        "  \033[32;1mver\033[0m\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1617,6 +1617,8 @@ void DOS_Shell::CMD_PATH(char *args){
 		char set_path[DOS_PATHLENGTH + CROSS_LEN + 20] = {0};
 		while (args && *args && (*args == '='|| *args == ' '))
 			args++;
+		if (strlen(args) == 1 && *args == ';')
+			*args = 0;
 		safe_sprintf(set_path, "set PATH=%s", args);
 		this->ParseLine(set_path);
 		return;


### PR DESCRIPTION
Instead of "Provided for compatibility", this PR adds proper help message for the PATH command according to the style of commands like VER. Also fixed the command so that `PATH ;`  clears the PATH just like real DOS.