### PR TITLE
Add help messages for HELP, MD/MKDIR and RESCAN commands

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -100,18 +100,18 @@ void DOS_SetupPrograms(void)
 	        "\n"
 	        "Usage:\n"
 	        "  \033[32;1mrescan\033[0m \033[36;1mDRIVE\033[0m\n"
-	        "  \033[32;1mrescan\033[0m [/A]\n"
+	        "  \033[32;1mrescan\033[0m [/a]\n"
 	        "\n"
 	        "Where:\n"
 	        "  \033[36;1mDRIVE\033[0m is the drive to clear caches.\n"
 	        "\n"
 	        "Notes:\n"
-	        "  - Running \033[32;1mrecan\033[0m without an argument clears the caches of the current drive.\n"
-	        "  - You can also clear the caches of all mounted drives with the /A option.\n"
+	        "  - Running \033[32;1mrescan\033[0m without an argument clears the caches of the current drive.\n"
+	        "  - You can also clear the caches of all mounted drives with the /a option.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  \033[32;1mrescan\033[0m \033[36;1mc:\033[0m\n"
-	        "  \033[32;1mrescan\033[0m /A\n");
+	        "  \033[32;1mrescan\033[0m /a\n");
 	MSG_Add("PROGRAM_RESCAN_SUCCESS","Drive cache cleared.\n");
 
 	MSG_Add("PROGRAM_INTRO",

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -95,6 +95,23 @@ void DOS_SetupPrograms(void)
 	MSG_Add("MSCDEX_UNKNOWN_ERROR","MSCDEX: Failure: Unknown error.\n");
 	MSG_Add("MSCDEX_WARNING_NO_OPTION", "MSCDEX: Warning: Ignoring unsupported option '%s'.\n");
 
+	MSG_Add("SHELL_CMD_RESCAN_HELP_LONG",
+	        "Clears the caches of a mounted drive.\n"
+	        "\n"
+	        "Usage:\n"
+	        "  \033[32;1mrescan\033[0m \033[36;1mDRIVE\033[0m\n"
+	        "  \033[32;1mrescan\033[0m [/A]\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mDRIVE\033[0m is the drive to clear caches.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  - Running \033[32;1mrecan\033[0m without an argument clears the caches of the current drive.\n"
+	        "  - You can also clear the caches of all mounted drives with the /A option.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mrescan\033[0m \033[36;1mc:\033[0m\n"
+	        "  \033[32;1mrescan\033[0m /A\n");
 	MSG_Add("PROGRAM_RESCAN_SUCCESS","Drive cache cleared.\n");
 
 	MSG_Add("PROGRAM_INTRO",

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -96,23 +96,24 @@ void DOS_SetupPrograms(void)
 	MSG_Add("MSCDEX_WARNING_NO_OPTION", "MSCDEX: Warning: Ignoring unsupported option '%s'.\n");
 
 	MSG_Add("SHELL_CMD_RESCAN_HELP_LONG",
-	        "Clears the caches of a mounted drive.\n"
+	        "Scans for changes on mounted DOS drives.\n"
 	        "\n"
 	        "Usage:\n"
 	        "  \033[32;1mrescan\033[0m \033[36;1mDRIVE\033[0m\n"
 	        "  \033[32;1mrescan\033[0m [/a]\n"
 	        "\n"
 	        "Where:\n"
-	        "  \033[36;1mDRIVE\033[0m is the drive to clear caches.\n"
+	        "  \033[36;1mDRIVE\033[0m is the drive to scan for changes.\n"
 	        "\n"
 	        "Notes:\n"
-	        "  - Running \033[32;1mrescan\033[0m without an argument clears the caches of the current drive.\n"
-	        "  - You can also clear the caches of all mounted drives with the /a option.\n"
+	        "  - Running \033[32;1mrescan\033[0m without an argument scans for changes of the current drive.\n"
+	        "  - Changes to this drive made on the host will then be reflected inside DOS.\n"
+	        "  - You can also scan for changes on all mounted drives with the /a option.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  \033[32;1mrescan\033[0m \033[36;1mc:\033[0m\n"
 	        "  \033[32;1mrescan\033[0m /a\n");
-	MSG_Add("PROGRAM_RESCAN_SUCCESS","Drive cache cleared.\n");
+	MSG_Add("PROGRAM_RESCAN_SUCCESS","Drive re-scanned.\n");
 
 	MSG_Add("PROGRAM_INTRO",
 	        "\033[2J\033[32;1mWelcome to DOSBox Staging\033[0m, an x86 emulator with sound and graphics.\n"
@@ -121,7 +122,7 @@ void DOS_SetupPrograms(void)
 	        "For information about basic mount type \033[34;1mintro mount\033[0m\n"
 	        "For information about CD-ROM support type \033[34;1mintro cdrom\033[0m\n"
 	        "For information about special keys type \033[34;1mintro special\033[0m\n"
-	        "For more imformation, visit DOSBox Staging wiki:\033[34;1m\n" WIKI_URL
+	        "For more information, visit DOSBox Staging wiki:\033[34;1m\n" WIKI_URL
 	        "\033[0m\n"
 	        "\n"
 	        "\033[31;1mDOSBox will stop/exit without a warning if an error occurred!\033[0m\n");
@@ -204,7 +205,7 @@ void DOS_SetupPrograms(void)
 	        "\033[33;1m%s+Enter\033[0m  Switch between fullscreen and window mode.\n"
 	        "\033[33;1m%s+Pause\033[0m  Pause/Unpause emulator.\n"
 	        "\033[33;1m%s+F1\033[0m   %s Start the \033[33mkeymapper\033[0m.\n"
-	        "\033[33;1m%s+F4\033[0m   %s Swap mounted disk image, update directory cache for all drives.\n"
+	        "\033[33;1m%s+F4\033[0m   %s Swap mounted disk image, scan for changes on all drives.\n"
 	        "\033[33;1m%s+F5\033[0m   %s Save a screenshot.\n"
 	        "\033[33;1m%s+F6\033[0m   %s Start/Stop recording sound output to a wave file.\n"
 	        "\033[33;1m%s+F7\033[0m   %s Start/Stop recording video output to a zmbv file.\n"

--- a/src/dos/program_rescan.cpp
+++ b/src/dos/program_rescan.cpp
@@ -26,6 +26,12 @@ void RESCAN::Run(void)
 
 	Bit8u drive = DOS_GetDefaultDrive();
 
+	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
+	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+		WriteOut(MSG_Get("SHELL_CMD_RESCAN_HELP_LONG"));
+		return;
+	}
+
 	if (cmd->FindCommand(1,temp_line)) {
 		//-A -All /A /All
 		if (temp_line.size() >= 2 &&

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -803,9 +803,22 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_EXIT_TOO_SOON", "Preventing an early 'exit' call from terminating.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP","Show help.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP_LONG","HELP [command]\n");
-	MSG_Add("SHELL_CMD_MKDIR_HELP","Make Directory.\n");
-	MSG_Add("SHELL_CMD_MKDIR_HELP_LONG","MKDIR [drive:][path]\n"
-	        "MD [drive:][path]\n");
+	MSG_Add("SHELL_CMD_MKDIR_HELP", "Creates a directory.\n");
+	MSG_Add("SHELL_CMD_MKDIR_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mmd\033[0m \033[36;1mDIRECTORY\033[0m\n"
+	        "  \033[32;1mmkdir\033[0m \033[36;1mDIRECTORY\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mDIRECTORY\033[0m is the name of the directory to create.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  - The directory must be an exact name and does not yet exist.\n"
+	        "  - You can specify a path where the directory will be created.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mmd\033[0m \033[36;1mnewdir\033[0m\n"
+	        "  \033[32;1mmd\033[0m \033[36;1mc:\\games\\dir\033[0m\n");
 	MSG_Add("SHELL_CMD_RMDIR_HELP", "Removes a directory.\n");
 	MSG_Add("SHELL_CMD_RMDIR_HELP_LONG",
 	        "Usage:\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -801,8 +801,25 @@ void SHELL_Init() {
 	        "  \033[32;1mecho\033[0m \033[36;1mHello world!\033[0m\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP","Exit from the shell.\n");
 	MSG_Add("SHELL_CMD_EXIT_TOO_SOON", "Preventing an early 'exit' call from terminating.\n");
-	MSG_Add("SHELL_CMD_HELP_HELP","Show help.\n");
-	MSG_Add("SHELL_CMD_HELP_HELP_LONG","HELP [command]\n");
+	MSG_Add("SHELL_CMD_HELP_HELP",
+	        "Displays help information for DOS commands.\n");
+	MSG_Add("SHELL_CMD_HELP_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mhelp\033[0m\n"
+	        "  \033[32;1mhelp\033[0m /a[ll]\n"
+	        "  \033[32;1mhelp\033[0m \033[36;1mCOMMAND\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mCOMMAND\033[0m is the name of an internal DOS command, such as \033[36;1mdir\033[0m.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  - Running \033[32;1mecho\033[0m without an argument displays a DOS command list.\n"
+	        "  - You can view a full list of internal commands with the /a or /all option.\n"
+	        "  - Instead of \033[32;1mhelp\033[0m \033[36;1mCOMMAND\033[0m, you can also get command help with \033[36;1mCOMMAND\033[0m /?.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mhelp\033[0m \033[36;1mdir\033[0m\n"
+	        "  \033[32;1mhelp\033[0m /all\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP", "Creates a directory.\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP_LONG",
 	        "Usage:\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -272,7 +272,7 @@ void DOS_Shell::CMD_HELP(char * args){
 		WriteOut("%s\n", MSG_Get(shell_cmd.help));
 		WriteOut("%s\n", shell_cmd.long_help ? MSG_Get(shell_cmd.long_help)
 		                                     : args);
-	} else if (ScanCMDBool(args, "ALL")) {
+	} else if (ScanCMDBool(args, "A") || ScanCMDBool(args, "ALL")) {
 		// Print help for all the commands
 		PrintHelpForCommands(HELP_LIST::ALL);
 	} else {


### PR DESCRIPTION
This PR adds full help messages for DOS commands including HELP, MD/MKDIR, and RESCAN, using the style of commands such as MOUNT and VER. The HELP command allows to list all internal commands with /A option (or /ALL), similar to /A option of the RESCAN command.