### PR TITLE
Fix missing frames in GTA (#1349)

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -93,7 +93,6 @@ struct Render_t {
 	bool active = false;
 	bool aspect = true;
 	bool fullFrame = true;
-	bool forceUpdate = false;
 };
 
 extern Render_t render;
@@ -107,8 +106,6 @@ void RENDER_SetSize(uint32_t width,
                     bool dblh);
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
-void RENDER_SetPal(Bit8u entry,Bit8u red,Bit8u green,Bit8u blue);
-bool RENDER_GetForceUpdate(void);
-void RENDER_SetForceUpdate(bool);
+void RENDER_SetPal(Bit8u entry, Bit8u red, Bit8u green, Bit8u blue);
 
 #endif

--- a/include/timer.h
+++ b/include/timer.h
@@ -96,10 +96,10 @@ static inline void DelayUs(const int microseconds)
 }
 
 static inline void DelayPrecise(double seconds) {
-    static double estimate = 5e-3;
-    static double mean = 5e-3;
-    static double m2 = 0;
-    static int64_t count = 1;
+    thread_local double estimate = 5e-3;
+    thread_local double mean = 5e-3;
+    thread_local double m2 = 0;
+    thread_local int64_t count = 1;
 
     while (seconds > estimate) {
         const auto start = std::chrono::steady_clock::now();

--- a/include/timer.h
+++ b/include/timer.h
@@ -96,26 +96,26 @@ static inline void DelayUs(const int microseconds)
 }
 
 static inline void DelayPrecise(double seconds) {
-    thread_local double estimate = 5e-3;
-    thread_local double mean = 5e-3;
-    thread_local double m2 = 0;
-    thread_local int64_t count = 1;
+	thread_local double estimate = 5e-3;
+	thread_local double mean = 5e-3;
+	thread_local double m2 = 0;
+	thread_local int64_t count = 1;
 
-    while (seconds > estimate) {
-        const auto start = std::chrono::steady_clock::now();
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        const auto end = std::chrono::steady_clock::now();
+	while (seconds > estimate) {
+		const auto start = std::chrono::steady_clock::now();
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		const auto end = std::chrono::steady_clock::now();
 
-        const auto observed = (end - start).count() * 1e-9;
-        seconds -= observed;
+		const auto observed = (end - start).count() * 1e-9;
+		seconds -= observed;
 
-        ++count;
-        const auto delta = observed - mean;
-        mean += delta / count;
-        m2   += delta * (observed - mean);
-        const auto stddev = std::sqrt(m2 / (count - 1));
-        estimate = mean + stddev;
-    }
+		++count;
+		const auto delta = observed - mean;
+		mean += delta / count;
+		m2 += delta * (observed - mean);
+		const auto stddev = std::sqrt(m2 / (count - 1));
+		estimate = mean + stddev;
+	}
 
     // spin lock
     const auto start = std::chrono::steady_clock::now();

--- a/include/timer.h
+++ b/include/timer.h
@@ -23,6 +23,7 @@
 
 #include <chrono>
 #include <limits>
+#include <cmath>
 #include <thread>
 
 /* underlying clock rate in HZ */
@@ -91,6 +92,58 @@ static inline void Delay(const int milliseconds)
 static inline void DelayUs(const int microseconds)
 {
 	std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
+}
+
+// The duration to use for precise sleep
+static constexpr int precise_delay_duration_us = 50;
+// based on work from:
+// https://blat-blatnik.github.io/computerBear/making-accurate-sleep-function/
+static inline void DelayPrecise(const int microseconds)
+{
+	// The estimate of how long the sleep should take (microseconds)
+	static double estimate = 5e-5;
+	// Use the estimate value as the default mean time taken
+	static double mean = 5e-5;
+	static double m2 = 0;
+	static int64_t count = 1;
+	// Original code operated on seconds, convert
+	double seconds = microseconds / 1e6;
+	// sleep as long as we can, then spinlock the rest
+	while (seconds > estimate) {
+		const auto start = GetTicksUs();
+		DelayUs(precise_delay_duration_us);
+		// Original code operated on seconds, convert
+		const double observed = GetTicksUsSince(start) / 1e6;
+		seconds -= observed;
+		++count;
+		const double delta = observed - mean;
+		mean += delta / static_cast<double>(count);
+		m2 += delta * (observed - mean);
+		const double stddev = std::sqrt(m2 / static_cast<double>(count - 1));
+		estimate = mean + stddev;
+	}
+	// spin lock
+	const auto spin_start = GetTicksUs();
+	const auto spin_remain = static_cast<int>(seconds * 1e6);
+	do {
+		std::this_thread::yield();
+	} while (GetTicksUsSince(spin_start) <= spin_remain);
+}
+
+static inline bool CanDelayPrecise()
+{
+	// The tolerance to allow for sleep variation
+	constexpr int precise_delay_tolerance_us = precise_delay_duration_us;
+	bool is_precise = true;
+	for (int i = 0; i < 10; i++) {
+		const auto start = GetTicksUs();
+		DelayUs(precise_delay_duration_us);
+		const auto elapsed = GetTicksUsSince(start);
+		if (std::abs(elapsed - precise_delay_duration_us) >
+		    precise_delay_tolerance_us)
+			is_precise = false;
+	}
+	return is_precise;
 }
 
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -71,7 +71,7 @@ void GFX_Stop(void);
 void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
 void GFX_EndUpdate( const Bit16u *changedLines );
-void GFX_PresentFrame();
+void GFX_MaybePresentFrameAtHostRate();
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus(void);
 

--- a/include/video.h
+++ b/include/video.h
@@ -57,7 +57,7 @@ typedef void (*GFX_CallBack_t)( GFX_CallBackFunctions_t function );
 bool GFX_Events();
 
 Bitu GFX_GetBestMode(Bitu flags);
-int GFX_GetDisplayRefreshRate();
+int8_t GFX_GetDisplayRefreshRate();
 Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);
 void GFX_SetShader(const char* src);
 Bitu GFX_SetSize(int width, int height, Bitu flags,

--- a/include/video.h
+++ b/include/video.h
@@ -71,6 +71,7 @@ void GFX_Stop(void);
 void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
 void GFX_EndUpdate( const Bit16u *changedLines );
+void GFX_PresentFrame();
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus(void);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -162,10 +162,16 @@ static Bitu Normal_Loop() {
 		} else {
 			if (!GFX_Events())
 				return 0;
+
+			GFX_MaybePresentFrameAtHostRate();
+
 			if (ticksRemain > 0) {
 				TIMER_AddTick();
 				ticksRemain--;
-			} else {increaseticks();return 0;}
+			} else {
+				increaseticks();
+				return 0;
+			}
 		}
 	}
 }

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -48,7 +48,8 @@ ScalerLineHandler_t RENDER_DrawLine;
 
 static void RENDER_CallBack( GFX_CallBackFunctions_t function );
 
-static void Check_Palette(void) {
+static void Check_Palette(void)
+{
 	/* Clean up any previous changed palette data */
 	if (render.pal.changed) {
 		memset(render.pal.modified, 0, sizeof(render.pal.modified));
@@ -781,7 +782,8 @@ void RENDER_Init(Section * sec) {
 				   render.scale.forced))
 		RENDER_CallBack( GFX_CallBackReset );
 
-	if(!running) render.updating=true;
+	if (!running)
+		render.updating = true;
 	running = true;
 
 	MAPPER_AddHandler(DecreaseFrameSkip, SDL_SCANCODE_UNKNOWN, 0,

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -243,7 +243,7 @@ void RENDER_EndUpdate( bool abort ) {
 			total += render.frameskip.hadSkip[i];
 		LOG_MSG( "Skipped frame %d %d", PIC_Ticks, (total * 100) / RENDER_SKIP_CACHE );
 #endif
-		if (RENDER_GetForceUpdate()) GFX_EndUpdate(0);
+		GFX_EndUpdate(0);
 	}
 	render.frameskip.index = (render.frameskip.index + 1) & (RENDER_SKIP_CACHE - 1);
 	render.updating=false;
@@ -621,14 +621,6 @@ static void ChangeScaler(bool pressed) {
 	}
 	RENDER_CallBack( GFX_CallBackReset );
 } */
-
-bool RENDER_GetForceUpdate(void) {
-	return render.forceUpdate;
-}
-
-void RENDER_SetForceUpdate(bool f) {
-	render.forceUpdate = f;
-}
 
 #if C_OPENGL
 static bool RENDER_GetShader(std::string &shader_path, char *old_src)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -904,6 +904,7 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 	 * although it has its own issues.
 	 */
 	if (fullscreen) {
+		SaveWindowPosition();
 		SDL_DisplayMode displayMode;
 		SDL_GetWindowDisplayMode(sdl.window, &displayMode);
 		displayMode.w = width;
@@ -939,6 +940,7 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 		// If we're switching down from fullscreen, then it will use the set window size
 		if (sdl.desktop.switching_fullscreen) {
 			SDL_SetWindowFullscreen(sdl.window, 0);
+			RestoreWindowPosition();
 		}
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2343,8 +2343,12 @@ static void DisplaySplash(int time_ms)
 	}
 
 	const uint16_t lines[2] = {0, src_h}; // output=surface won't work otherwise
+
+	assert(sdl.updating && sdl.update_display_contents);
+	render_pacer.Reset();
 	GFX_EndUpdate(lines);
 	Delay(time_ms);
+	render_pacer.Reset();
 }
 
 static bool detect_resizable_window()

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -880,8 +880,10 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 
 		// Adjust the window dimensions if our window isn't sized yet or
 		// we're in PP mode
-		if (window_is_too_small || (sdl.scaling_mode == SCALING_MODE::PERFECT &&
-		                            window_dimensions_not_exact)) {
+		if (window_is_too_small ||
+		    (window_dimensions_not_exact &&
+		     (sdl.scaling_mode == SCALING_MODE::PERFECT ||
+		      sdl.desktop.type == SCREEN_SURFACE))) {
 			safe_set_window_size(width, height);
 		}
 		// If we're switching down from fullscreen, then it will use the set window size

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1463,12 +1463,9 @@ dosurface:
 					sdl.opengl.ruby.texture_size = glGetUniformLocation(sdl.opengl.program_object, "rubyTextureSize");
 					sdl.opengl.ruby.input_size = glGetUniformLocation(sdl.opengl.program_object, "rubyInputSize");
 					sdl.opengl.ruby.output_size = glGetUniformLocation(sdl.opengl.program_object, "rubyOutputSize");
-					sdl.opengl.ruby.frame_count = glGetUniformLocation(sdl.opengl.program_object, "rubyFrameCount");
-					// If the shader has a required frame-count, then
-					// force rendering updates to ensure each frame is provided.
-					if (sdl.opengl.ruby.frame_count > 0) {
-						RENDER_SetForceUpdate(true);
-					}
+					sdl.opengl.ruby.frame_count = glGetUniformLocation(
+					        sdl.opengl.program_object,
+					        "rubyFrameCount");
 				}
 			}
 		}
@@ -1846,7 +1843,7 @@ void GFX_EndUpdate(const Bit16u *changedLines)
 #else
 	const bool using_opengl = false;
 #endif
-	if ((!using_opengl || !RENDER_GetForceUpdate()) && !sdl.updating)
+	if (!using_opengl && !sdl.updating)
 		return;
 	[[maybe_unused]] bool actually_updating = sdl.updating;
 	sdl.updating = false;


### PR DESCRIPTION
This attempts to fix the remainder of dropped frames [as reported here](https://github.com/dosbox-staging/dosbox-staging/issues/1349). Thanks to @nemo93 for the details reports and detailed test reports.

**Background**: when the DOS applications draws new content, DOSBox pushes those changes out to the host in the form of updated frames. If the DOS side is able to render new content at 70 Hz, then the host received up to 70 frames/s.   Many games render content at lower rates (15 fps, 25 fps, etc) - but some can go up to 60 and even 70 Hz.

With SDL2, we noticed some hosts struggle to keep up with these faster rates. Eventually, the host can  "jam-up" and hard-block DOSBox for many-milliseconds (in the rendering call, even without vsync). 

These jam-ups can be so severe that they drain the audio buffer and cause stuttering.

Staging uses [a feature called the rendering pacer](https://github.com/dosbox-staging/dosbox-staging/pull/1158) to detect these jam-ups and also mitigate them from worsening by cancelling the next frame from being rendered, to give the host time to recover.

With the rendering pacer acting as a "pressure release value" on the back-end, this PR's acts as front-end mitigation to relax pressure on the hosts rendering pipeline by throttling the rendering rate to not exceed what the host can handle. 