### PR TITLE
Add help messages for CALL, EXIT and LS commands 

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -979,8 +979,25 @@ void SHELL_Init() {
 	        "  \033[32;1msubst\033[0m \033[37;1me:\033[0m \033[36;1m/d\033[0m\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires xms=true,umb=true).\n");
 
-	MSG_Add("SHELL_CMD_LS_HELP", "List directory contents.\n");
-	MSG_Add("SHELL_CMD_LS_HELP_LONG", "ls [/?] [PATTERN]\n");
+	MSG_Add("SHELL_CMD_LS_HELP",
+	        "Displays directory contents in the wide list format.\n");
+	MSG_Add("SHELL_CMD_LS_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mls\033[0m \033[36;1mPATTERN\033[0m\n"
+	        "  \033[32;1mls\033[0m \033[36;1mPATH\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mPATTERN\033[0m can be either an exact filename or an inexact filename with\n"
+	        "          wildcards, which are the asterisk (*) and the question mark (?).\n"
+	        "  \033[36;1mPATH\033[0m    is an exact path in a mounted DOS drive to list contents.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  The command will list directories in \033[34;1mblue\033[0m, executable DOS programs\n"
+	        "   (*.com, *.exe, *.bat) in \033[32;1mgreen\033[0m, and other files in the normal color.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mls\033[0m \033[36;1mfile.txt\033[0m\n"
+	        "  \033[32;1mls\033[0m \033[36;1mc*.ba?\033[0m\n");
 	MSG_Add("SHELL_CMD_LS_PATH_ERR",
 	        "ls: cannot access '%s': No such file or directory\n");
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -799,7 +799,20 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  \033[32;1mecho\033[0m \033[36;1moff\033[0m\n"
 	        "  \033[32;1mecho\033[0m \033[36;1mHello world!\033[0m\n");
-	MSG_Add("SHELL_CMD_EXIT_HELP","Exit from the shell.\n");
+	MSG_Add("SHELL_CMD_EXIT_HELP", "Exits from the DOS shell.\n");
+	MSG_Add("SHELL_CMD_EXIT_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mexit\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  This command has no parameters.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  If you start a DOS shell from a program, running \033[32;1mexit\033[0m returns to the program.\n"
+	        "  If there is no DOS program running, the command quits from DOSBox Staging.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mexit\033[0m\n");
 	MSG_Add("SHELL_CMD_EXIT_TOO_SOON", "Preventing an early 'exit' call from terminating.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP",
 	        "Displays help information for DOS commands.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -943,7 +943,23 @@ void SHELL_Init() {
 	        "  \033[32;1mcopy\033[0m \033[37;1msource.bat\033[0m \033[36;1mnew.bat\033[0m\n"
 	        "  \033[32;1mcopy\033[0m \033[37;1mfile1.txt+file2.txt\033[0m \033[36;1mfile3.txt\033[0m\n"
 	        "  \033[32;1mcopy\033[0m \033[37;1m..\\c*.*\033[0m\n");
-	MSG_Add("SHELL_CMD_CALL_HELP","Start a batch file from within another batch file.\n");
+	MSG_Add("SHELL_CMD_CALL_HELP",
+	        "Starts a batch program from within another batch program.\n");
+	MSG_Add("SHELL_CMD_CALL_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mcall\033[0m \033[37;1mBATCH\033[0m \033[36;1m[PARAMETERS]\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[37;1mBATCH\033[0m      is a batch program to launch.\n"
+	        "  \033[36;1mPARAMETERS\033[0m are optional parameters for the batch program.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  After calling another batch program, the original batch program will\n"
+	        "  resume running after the other batch program ends.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mcall\033[0m \033[37;1mmybatch.bat\033[0m\n"
+	        "  \033[32;1mcall\033[0m \033[37;1mfile.bat\033[0m \033[36;1mHello world!\033[0m\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP", "Assign an internal directory to a drive.\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP_LONG",
 	        "Usage:\n"


### PR DESCRIPTION
This new round of PR adds full help messages for DOS commands including CALL, EXIT, and LS, using the style of DOS commands such as MOUNT and VER.