### PR TITLE
Add help messages for BOOT, GOTO, and MEM commands

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -73,6 +73,21 @@ void DOS_SetupPrograms(void)
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_STATUS","Overlay %s on drive %c mounted.\n");
 	MSG_Add("PROGRAM_MOUNT_MOVE_Z_ERROR_1", "Can't move drive Z. Drive %c is mounted already.\n");
 
+	MSG_Add("SHELL_CMD_MEM_HELP_LONG",
+	        "Displays the DOS memory information.\n"
+	        "\n"
+	        "Usage:\n"
+	        "  \033[32;1mmem\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  This command has no parameters.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  This command shows the DOS memory status, including the free conventional\n"
+	        "  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mmem\033[0m\n");
 	MSG_Add("PROGRAM_MEM_CONVEN", "%10d kB free conventional memory\n");
 	MSG_Add("PROGRAM_MEM_EXTEND", "%10d kB free extended memory\n");
 	MSG_Add("PROGRAM_MEM_EXPAND", "%10d kB free expanded memory\n");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -215,19 +215,37 @@ void DOS_SetupPrograms(void)
 	        "\033[33;1m%s+F12\033[0m  %s Speed up emulation.\n"
 	        "\033[33;1m%s+F12\033[0m    Unlock speed (turbo button/fast forward).\n");
 
+	MSG_Add("SHELL_CMD_BOOT_HELP_LONG",
+	        "Boots DOSBox Staging from a DOS drive or disk image.\n"
+	        "\n"
+	        "Usage:\n"
+	        "  \033[32;1mboot\033[0m \033[37;1mDRIVE\033[0m\n"
+	        "  \033[32;1mboot\033[0m \033[36;1mIMAGEFILE\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[37;1mDRIVE\033[0m is a drive to boot from, must be \033[37;1mA:\033[0m, \033[37;1mC:\033[0m, or \033[37;1mD:\033[0m.\n"
+	        "  \033[36;1mIMAGEFILE\033[0m is one or more floppy images, separated by spaces.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  A DOS drive letter must have been mounted previously with \033[32;1mimgmount\033[0m command.\n"
+	        "  The DOS drive or disk image must be bootable, containing DOS system files.\n"
+	        "  If more than one disk images are specified, you can swap them with a hotkey.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mboot\033[0m \033[37;1mc:\033[0m\n"
+	        "  \033[32;1mboot\033[0m \033[36;1mdisk1.ima disk2.ima\033[0m\n");
 	MSG_Add("PROGRAM_BOOT_NOT_EXIST","Bootdisk file does not exist.  Failing.\n");
 	MSG_Add("PROGRAM_BOOT_NOT_OPEN","Cannot open bootdisk file.  Failing.\n");
 	MSG_Add("PROGRAM_BOOT_WRITE_PROTECTED","Image file is read-only! Might create problems.\n");
 	MSG_Add("PROGRAM_BOOT_PRINT_ERROR",
-	        "This command boots DOSBox from either a floppy or hard disk image.\n\n"
+	        "This command boots DOSBox Staging from either a floppy or hard disk image.\n\n"
 	        "For this command, one can specify a succession of floppy disks swappable\n"
 	        "by pressing %s+F4, and -l specifies the mounted drive to boot from.  If\n"
 	        "no drive letter is specified, this defaults to booting from the A drive.\n"
 	        "The only bootable drive letters are A, C, and D.  For booting from a hard\n"
 	        "drive (C or D), the image should have already been mounted using the\n"
 	        "\033[34;1mIMGMOUNT\033[0m command.\n\n"
-	        "The syntax of this command is:\n\n"
-	        "\033[34;1mBOOT [diskimg1.img diskimg2.img] [-l driveletter]\033[0m\n");
+	        "Type \033[34;1mBOOT /?\033[0m for the syntax of this command.\033[0m\n");
 	MSG_Add("PROGRAM_BOOT_UNABLE","Unable to boot off of drive %c");
 	MSG_Add("PROGRAM_BOOT_IMAGE_OPEN","Opening image file: %s\n");
 	MSG_Add("PROGRAM_BOOT_IMAGE_NOT_OPEN","Cannot open %s");

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -148,6 +148,24 @@ void BOOT::Run(void) {
         printError();
         return;
     }
+
+    if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
+	cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+	    WriteOut(MSG_Get("SHELL_CMD_BOOT_HELP_LONG"));
+	    return;
+    }
+    if (cmd->GetCount() == 1) {
+	    cmd->FindCommand(1, temp_line);
+	    if (temp_line.length() == 2 && toupper(temp_line[0]) >= 'A' &&
+		toupper(temp_line[0]) <= 'Z' && temp_line[1] == ':') {
+		    drive = toupper(temp_line[0]);
+		    if ((drive != 'A') && (drive != 'C') && (drive != 'D')) {
+			    printError();
+			    return;
+		    }
+		    i++;
+	    }
+    }
     while (i<cmd->GetCount()) {
         if (cmd->FindCommand(i+1, temp_line)) {
             if ((temp_line == "-l") || (temp_line == "-L")) {

--- a/src/dos/program_mem.cpp
+++ b/src/dos/program_mem.cpp
@@ -24,6 +24,11 @@
 #include "regs.h"
 
 void MEM::Run(void) {
+	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
+	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+		WriteOut(MSG_Get("SHELL_CMD_MEM_HELP_LONG"));
+		return;
+	}
     /* Show conventional Memory */
     WriteOut("\n");
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -881,7 +881,21 @@ void SHELL_Init() {
 	        "  \033[32;1mset\033[0m\n"
 	        "  \033[32;1mset\033[0m \033[37;1mname\033[0m=\033[36;1mvalue\033[0m\n");
 	MSG_Add("SHELL_CMD_IF_HELP","Performs conditional processing in batch programs.\n");
-	MSG_Add("SHELL_CMD_GOTO_HELP","Jump to a labeled line in a batch script.\n");
+	MSG_Add("SHELL_CMD_GOTO_HELP",
+	        "Jumps to a labeled line in a batch program.\n");
+	MSG_Add("SHELL_CMD_GOTO_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mgoto\033[0m \033[36;1mLABEL\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mLABEL\033[0m is text string used in the batch program as a label.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  A label is on a line by itself, beginning with a colon (:).\n"
+	        "  The label must be unique, and can be anywhere within the batch program.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mgoto\033[0m \033[36;1mmylabel\033[0m\n");
 	MSG_Add("SHELL_CMD_SHIFT_HELP","Leftshift commandline parameters in a batch script.\n");
 	MSG_Add("SHELL_CMD_TYPE_HELP", "Display the contents of a text file.\n");
 	MSG_Add("SHELL_CMD_TYPE_HELP_LONG",


### PR DESCRIPTION
This new PR adds full help messages for DOS commands including BOOT, GOTO, and MEM, using the style of DOS commands such as MOUNT and VER. The BOOT command adds support for BOOT [drive:] (e.g. `BOOT C:`), which is much easier to remember and use than the old -L option (also supported in DOSBox-X).