### PR TITLE
Fix Windows CI builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,18 +38,14 @@ jobs:
         id:   cache-vcpkg
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
 
       - name:  Install new packages using vcpkg
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           rm -R c:\vcpkg
-          c:
-          cd \
-          git clone --depth 1 https://github.com/Microsoft/vcpkg.git
-          cd vcpkg
-          .\bootstrap-vcpkg.bat
+          mv c:\vcpkg-bak c:\vcpkg
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth pdcurses gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
           rm -R c:\vcpkg\buildtrees
@@ -124,7 +120,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
 
       - name:  Integrate packages
         shell: pwsh


### PR DESCRIPTION
Monday's VM rollover introduced an issue where the stable version of vcpkg became incompatible with something internal in MSVC, resulting in the following breakage during unit test execution:

![2021-11-15_08-17_1](https://user-images.githubusercontent.com/1557255/141836775-51808e62-1a74-423c-aadd-ea3c741eaa5e.png)
