### PR TITLE
Add help messages for COMMAND, LOADROM, and PAUSE commands 

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -310,7 +310,21 @@ void DOS_SetupPrograms(void)
 	MSG_Add("PROGRAM_BOOT_CART_WO_PCJR","PCjr cartridge found, but machine is not PCjr");
 	MSG_Add("PROGRAM_BOOT_CART_LIST_CMDS", "Available PCjr cartridge commands: %s");
 	MSG_Add("PROGRAM_BOOT_CART_NO_CMDS", "No PCjr cartridge commands found");
-
+	MSG_Add("SHELL_CMD_LOADROM_HELP_LONG",
+	        "Loads a ROM image of the video BIOS or IBM BASIC.\n"
+	        "\n"
+	        "Usage:\n"
+	        "  \033[32;1mloadrom \033[36;1mIMAGEFILE\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mIMAGEFILE\033[0m is a video BIOS or IBM BASIC ROM image.\n"
+	        "\n"
+	        "Notes:\n"
+	        "   After loading an IBM BASIC ROM image into the emulated ROM with the command,\n"
+	        "   you can run the original IBM BASIC interpreter program in DOSBox Staging.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mloadrom\033[0m \033[36;1mbios.rom\033[0m\n");
 	MSG_Add("PROGRAM_LOADROM_SPECIFY_FILE","Must specify ROM file to load.\n");
 	MSG_Add("PROGRAM_LOADROM_CANT_OPEN","ROM file not accessible.\n");
 	MSG_Add("PROGRAM_LOADROM_TOO_LARGE","ROM file too large.\n");

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -33,7 +33,10 @@ void LOADROM::Run(void) {
         WriteOut(MSG_Get("PROGRAM_LOADROM_SPECIFY_FILE"));
         return;
     }
-
+    if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+	    WriteOut(MSG_Get("SHELL_CMD_LOADROM_HELP_LONG"));
+	    return;
+    }
     Bit8u drive;
     char fullname[DOS_PATHLENGTH];
     localDrive* ldp=0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -712,8 +712,22 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_DIR_BYTES_FREE","%17d dir(s)  %21s bytes free\n");
 	MSG_Add("SHELL_EXECUTE_DRIVE_NOT_FOUND","Drive %c does not exist!\nYou must \033[31mmount\033[0m it first. Type \033[1;33mintro\033[0m or \033[1;33mintro mount\033[0m for more information.\n");
 	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND","Illegal command: %s.\n");
-	MSG_Add("SHELL_CMD_PAUSE","Press any key to continue...");
-	MSG_Add("SHELL_CMD_PAUSE_HELP","Waits for 1 keystroke to continue.\n");
+	MSG_Add("SHELL_CMD_PAUSE", "Press a key to continue...");
+	MSG_Add("SHELL_CMD_PAUSE_HELP", "Waits for a keystroke to continue.\n");
+	MSG_Add("SHELL_CMD_PAUSE_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mpause\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  This command has no parameters.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  This command is especially useful in batch programs to allow a user to\n"
+	        "  continue the batch program execution with a key press. The user can press\n"
+	        "  any key on the keyboard (except for certain control keys) to continue.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mpause\033[0m\n");
 	MSG_Add("SHELL_CMD_COPY_FAILURE","Copy failure : %s.\n");
 	MSG_Add("SHELL_CMD_COPY_SUCCESS","   %d File(s) copied.\n");
 	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -344,6 +344,10 @@ void DOS_Shell::Run()
 
 	char input_line[CMD_MAXLINE] = {0};
 	std::string line;
+	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+		WriteOut(MSG_Get("SHELL_CMD_COMMAND_HELP_LONG"));
+		return;
+	}
 	if (cmd->FindStringRemainBegin("/C",line)) {
 		safe_strcpy(input_line, line.c_str());
 		char* sep = strpbrk(input_line,"\r\n"); //GTA installer
@@ -668,6 +672,26 @@ void SHELL_Init() {
 	/* Add messages */
 	MSG_Add("SHELL_ILLEGAL_PATH","Illegal Path.\n");
 	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type \033[33;1mhelp /all\033[0m .\nA short list of the most often used commands:\n");
+	MSG_Add("SHELL_CMD_COMMAND_HELP_LONG",
+	        "Starts the DOSBox Staging command shell.\n"
+	        "Usage:\n"
+	        "  \033[32;1mcommand\033[0m\n"
+	        "  \033[32;1mcommand\033[0m /c (or /init) \033[36;1mCOMMAND\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mCOMMAND\033[0m is a DOS command, game, or program to run.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  DOSBox Staging automatically starts a DOS command shell by invoking this\n"
+	        "  command with /init option when it starts, which shows the welcome banner.\n"
+	        "  You can load a new instance of the command shell by running \033[32;1mcommand\033[0m.\n"
+	        "  Adding a /c option along with \033[36;1mCOMMAND\033[0m allows this command to run the\n"
+	        "  specified command (optionally with parameters) and then exit automatically.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mcommand\033[0m\n"
+	        "  \033[32;1mcommand\033[0m /c \033[36;1mecho\033[0m \033[37mHello world!\033[0m\n"
+	        "  \033[32;1mcommand\033[0m /init \033[36;1mdir\033[0m\n");
 	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
 	MSG_Add("SHELL_CMD_ECHO_OFF", "ECHO is off.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH","Illegal switch: %s.\n");


### PR DESCRIPTION
This new PR adds full help messages for DOS commands including COMMAND, LOADROM, and PAUSE, using the style of DOS commands such as MOUNT and VER. Virtually all DOS commands have help messages by now, although certain commands (e.g. DIR) still use older-style help messages and need to be updated to the new style.