### PR TITLE
Simplify management of the mixer channels

### DIFF
--- a/include/envelope.h
+++ b/include/envelope.h
@@ -63,13 +63,10 @@ class Envelope {
 public:
 	Envelope(const char* name);
 
-	void Process(bool is_stereo,
-	             bool is_interpolated,
-	             intptr_t prev[],
-	             intptr_t next[]);
+	void Process(bool is_stereo, bool is_interpolated, int prev[], int next[]);
 
-	void Update(uint32_t frame_rate,
-	            uint32_t peak_amplitude,
+	void Update(int frame_rate,
+	            int peak_amplitude,
 	            uint8_t expansion_phase_ms,
 	            uint8_t expire_after_seconds);
 
@@ -79,32 +76,29 @@ private:
 	Envelope(const Envelope &) = delete;            // prevent copying
 	Envelope &operator=(const Envelope &) = delete; // prevent assignment
 
-	bool ClampSample(intptr_t &sample, intptr_t next_edge);
+	bool ClampSample(int &sample, int next_edge);
 
-	void Apply(bool is_stereo,
-	           bool is_interpolated,
-	           intptr_t prev[],
-	           intptr_t next[]);
+	void Apply(bool is_stereo, bool is_interpolated, int prev[], int next[]);
 
 	void Skip([[maybe_unused]] bool is_stereo,
 	          [[maybe_unused]] bool is_interpolated,
-	          [[maybe_unused]] intptr_t prev[],
-	          [[maybe_unused]] intptr_t next[])
+	          [[maybe_unused]] int prev[],
+	          [[maybe_unused]] int next[])
 	{}
 
-	using process_f = std::function<void(Envelope &, bool, bool, intptr_t[], intptr_t[])>;
+	using process_f = std::function<void(Envelope &, bool, bool, int[], int[])>;
 	process_f process = &Envelope::Apply;
 
 	const char *channel_name = nullptr;
-	uint32_t expire_after_frames = 0u; // Stop enveloping when this many
-	                                   // frames have been processed.
-	uint32_t frames_done = 0u; // A tally of processed frames.
-	uint16_t edge = 0u; // The current edge of the envelope, which
-	                    // increments outward when samples press against it.
-	uint16_t edge_increment = 0u; // The amount the edge grows by once a
-	                              // sample is found to be beyond it.
-	uint16_t edge_limit = 0u; // Stop enveloping when the current edge is
-	                          // hits or exceeds this limit.
+	int expire_after_frames = 0; // Stop enveloping when this many
+	                             // frames have been processed.
+	int frames_done = 0;         // A tally of processed frames.
+	int edge = 0;                // The current edge of the envelope, which
+	              // increments outward when samples press against it.
+	int edge_increment = 0; // The amount the edge grows by once a
+	                        // sample is found to be beyond it.
+	int edge_limit = 0;     // Stop enveloping when the current edge is
+	                        // hits or exceeds this limit.
 };
 
 #endif

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 
 #include "envelope.h"
 
@@ -169,23 +170,10 @@ private:
 	bool last_samples_were_stereo = false;
 	bool last_samples_were_silence = true;
 };
+using mixer_channel_t = std::shared_ptr<MixerChannel>;
 
-MixerChannel * MIXER_AddChannel(MIXER_Handler handler,uint32_t freq,const char * name);
-MixerChannel * MIXER_FindChannel(const char * name);
-/* Find the device you want to delete with findchannel "delchan gets deleted" */
-void MIXER_DelChannel(MixerChannel* delchan); 
-
-/* Object to maintain a mixerchannel; As all objects it registers itself with create
- * and removes itself when destroyed. */
-class MixerObject{
-private:
-	bool installed = false;
-	char m_name[32] = "";
-
-public:
-	MixerChannel* Install(MIXER_Handler handler,Bitu freq,const char * name);
-	~MixerObject();
-};
+mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const uint32_t freq, const char *name);
+mixer_channel_t MIXER_FindChannel(const char *name);
 
 /* PC Speakers functions, tightly related to the timer functions */
 void PCSPEAKER_SetCounter(uint32_t cntr, uint32_t mode);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -127,10 +127,8 @@ public:
 	void Enable(bool should_enable);
 	void FlushSamples();
 
-	float volmain[2] = {0.0f, 0.0f};
-	MixerChannel *next = nullptr;
-	const char *name = nullptr;
-	std::atomic<Bitu> done; // Timing on how many samples have been done by the mixer
+	float volmain[2] = {1.0f, 1.0f};
+	std::atomic<uint32_t> done = 0; // Timing on how many samples have been done by the mixer
 	bool is_enabled = false;
 
 private:
@@ -146,21 +144,21 @@ private:
 	Bitu freq_counter = 0u; // When this flows over a new sample needs to be
 	                        // read from the device
 	Bitu needed = 0u; // Timing on how many samples were needed by the mixer
-	Bits prev_sample[2] = {0}; // Previous and next samples
-	Bits next_sample[2] = {0};
+	Bits prev_sample[2] = {0, 0}; // Previous and next samples
+	Bits next_sample[2] = {0, 0};
 	// Simple way to lower the impact of DC offset. if MIXER_UPRAMP_STEPS is >0.
 	// Still work in progress and thus disabled for now.
-	Bits offset[2] = {0};
+	Bits offset[2] = {0, 0};
 	uint32_t sample_rate = 0u;
-	int32_t volmul[2] = {0};
-	float scale[2] = {0.0f, 0.0f};
+	int32_t volmul[2] = {1, 1};
+	float scale[2] = {1.0f, 1.0f};
 
 	// Defines the peak sample amplitude we can expect in this channel.
 	// Default to signed 16bit max, however channel's that know their own
 	// peak, like the PCSpeaker, should update it with: SetPeakAmplitude()
 	uint32_t peak_amplitude = MAX_AUDIO;
 
-	uint8_t channel_map[2] = {0u, 0u}; // Output channel mapping
+	uint8_t channel_map[2] = {0, 1}; // Output channel mapping
 
 	// The RegisterLevelCallBack() assigns this callback that can be used by
 	// the channel's source to manage the stream's level prior to mixing,

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -87,8 +87,8 @@ constexpr T Mixer_GetSilentDOSSample()
 
 class MixerChannel {
 public:
-	MixerChannel(MIXER_Handler _handler, const uint32_t _freq, const char *name);
-	uint32_t GetSampleRate() const;
+	MixerChannel(MIXER_Handler _handler, const char *name);
+	int GetSampleRate() const;
 	bool IsInterpolated() const;
 	using apply_level_callback_f = std::function<void(const AudioFrame &level)>;
 	void RegisterLevelCallBack(apply_level_callback_f cb);
@@ -97,39 +97,39 @@ public:
 	void SetScale(float _left, float _right);
 	void MapChannels(Bit8u _left, Bit8u _right);
 	void UpdateVolume();
-	void SetFreq(Bitu _freq);
-	void SetPeakAmplitude(uint32_t peak);
-	void Mix(Bitu _needed);
+	void SetFreq(int _freq);
+	void SetPeakAmplitude(int peak);
+	void Mix(int _needed);
 	void AddSilence(); // Fill up until needed
 
-	template<class Type,bool stereo,bool signeddata,bool nativeorder>
-	void AddSamples(Bitu len, const Type* data);
+	template <class Type, bool stereo, bool signeddata, bool nativeorder>
+	void AddSamples(uint16_t len, const Type *data);
 
-	void AddSamples_m8(Bitu len, const Bit8u * data);
-	void AddSamples_s8(Bitu len, const Bit8u * data);
-	void AddSamples_m8s(Bitu len, const Bit8s * data);
-	void AddSamples_s8s(Bitu len, const Bit8s * data);
-	void AddSamples_m16(Bitu len, const Bit16s * data);
-	void AddSamples_s16(Bitu len, const Bit16s * data);
-	void AddSamples_m16u(Bitu len, const Bit16u * data);
-	void AddSamples_s16u(Bitu len, const Bit16u * data);
-	void AddSamples_m32(Bitu len, const Bit32s * data);
-	void AddSamples_s32(Bitu len, const Bit32s * data);
-	void AddSamples_m16_nonnative(Bitu len, const Bit16s * data);
-	void AddSamples_s16_nonnative(Bitu len, const Bit16s * data);
-	void AddSamples_m16u_nonnative(Bitu len, const Bit16u * data);
-	void AddSamples_s16u_nonnative(Bitu len, const Bit16u * data);
-	void AddSamples_m32_nonnative(Bitu len, const Bit32s * data);
-	void AddSamples_s32_nonnative(Bitu len, const Bit32s * data);
-	
-	void AddStretched(Bitu len,Bit16s * data);		//Stretch block up into needed data
+	void AddSamples_m8(uint16_t len, const Bit8u *data);
+	void AddSamples_s8(uint16_t len, const Bit8u *data);
+	void AddSamples_m8s(uint16_t len, const Bit8s *data);
+	void AddSamples_s8s(uint16_t len, const Bit8s *data);
+	void AddSamples_m16(uint16_t len, const Bit16s *data);
+	void AddSamples_s16(uint16_t len, const Bit16s *data);
+	void AddSamples_m16u(uint16_t len, const Bit16u *data);
+	void AddSamples_s16u(uint16_t len, const Bit16u *data);
+	void AddSamples_m32(uint16_t len, const Bit32s *data);
+	void AddSamples_s32(uint16_t len, const Bit32s *data);
+	void AddSamples_m16_nonnative(uint16_t len, const Bit16s *data);
+	void AddSamples_s16_nonnative(uint16_t len, const Bit16s *data);
+	void AddSamples_m16u_nonnative(uint16_t len, const Bit16u *data);
+	void AddSamples_s16u_nonnative(uint16_t len, const Bit16u *data);
+	void AddSamples_m32_nonnative(uint16_t len, const Bit32s *data);
+	void AddSamples_s32_nonnative(uint16_t len, const Bit32s *data);
+
+	void AddStretched(uint16_t len, Bit16s *data); // Stretch block up into needed data
 
 	void FillUp();
 	void Enable(bool should_enable);
 	void FlushSamples();
 
 	float volmain[2] = {1.0f, 1.0f};
-	std::atomic<uint32_t> done = 0; // Timing on how many samples have been done by the mixer
+	std::atomic<int> done = 0; // Timing on how many samples have been done by the mixer
 	bool is_enabled = false;
 
 private:
@@ -140,24 +140,22 @@ private:
 
 	Envelope envelope;
 	MIXER_Handler handler = nullptr;
-	Bitu freq_add = 0u; // This gets added the frequency counter each mixer
-	                    // step
-	Bitu freq_counter = 0u; // When this flows over a new sample needs to be
-	                        // read from the device
-	Bitu needed = 0u; // Timing on how many samples were needed by the mixer
-	Bits prev_sample[2] = {0, 0}; // Previous and next samples
-	Bits next_sample[2] = {0, 0};
-	// Simple way to lower the impact of DC offset. if MIXER_UPRAMP_STEPS is >0.
-	// Still work in progress and thus disabled for now.
-	Bits offset[2] = {0, 0};
-	uint32_t sample_rate = 0u;
-	int32_t volmul[2] = {1, 1};
+	int freq_add = 0u;           // This gets added the frequency counter each mixer step
+	int freq_counter = 0u;       // When this flows over a new sample needs to be read from the device
+	int needed = 0u;             // Timing on how many samples were needed by the mixer
+	int prev_sample[2] = {0, 0}; // Previous and next samples
+	int next_sample[2] = {0, 0};
+	// Simple way to lower the impact of DC offset. if MIXER_UPRAMP_STEPS is
+	// >0. Still work in progress and thus disabled for now.
+	int offset[2] = {0, 0};
+	int sample_rate = 0u;
+	int volmul[2] = {1, 1};
 	float scale[2] = {1.0f, 1.0f};
 
 	// Defines the peak sample amplitude we can expect in this channel.
 	// Default to signed 16bit max, however channel's that know their own
 	// peak, like the PCSpeaker, should update it with: SetPeakAmplitude()
-	uint32_t peak_amplitude = MAX_AUDIO;
+	int peak_amplitude = MAX_AUDIO;
 
 	uint8_t channel_map[2] = {0, 1}; // Output channel mapping
 
@@ -172,7 +170,7 @@ private:
 };
 using mixer_channel_t = std::shared_ptr<MixerChannel>;
 
-mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const uint32_t freq, const char *name);
+mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const int freq, const char *name);
 mixer_channel_t MIXER_FindChannel(const char *name);
 
 /* PC Speakers functions, tightly related to the timer functions */

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -86,7 +86,7 @@ constexpr T Mixer_GetSilentDOSSample()
 
 class MixerChannel {
 public:
-	MixerChannel(MIXER_Handler _handler, Bitu _freq, const char * _name);
+	MixerChannel(MIXER_Handler _handler, const uint32_t _freq, const char *name);
 	uint32_t GetSampleRate() const;
 	bool IsInterpolated() const;
 	using apply_level_callback_f = std::function<void(const AudioFrame &level)>;
@@ -172,7 +172,7 @@ private:
 	bool last_samples_were_silence = true;
 };
 
-MixerChannel * MIXER_AddChannel(MIXER_Handler handler,Bitu freq,const char * name);
+MixerChannel * MIXER_AddChannel(MIXER_Handler handler,uint32_t freq,const char * name);
 MixerChannel * MIXER_FindChannel(const char * name);
 /* Find the device you want to delete with findchannel "delchan gets deleted" */
 void MIXER_DelChannel(MixerChannel* delchan); 

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -251,7 +251,7 @@ private:
 		std::weak_ptr<TrackFile> trackFile = {};
 		mixer_channel_t channel = nullptr;
 		CDROM_Interface_Image    *cd                = nullptr;
-		void (MixerChannel::*addFrames) (Bitu, const Bit16s*) = nullptr;
+		void (MixerChannel::*addFrames)(uint16_t, const int16_t *) = nullptr;
 		uint32_t                 playedTrackFrames  = 0;
 		uint32_t                 totalTrackFrames   = 0;
 		uint32_t                 startSector        = 0;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -248,9 +248,8 @@ public:
 private:
 	static struct imagePlayer {
 		// Objects, pointers, and then scalars; in descending size-order.
-		MixerObject              mixerChannel       = {};
 		std::weak_ptr<TrackFile> trackFile = {};
-		MixerChannel             *channel           = nullptr;
+		mixer_channel_t channel = nullptr;
 		CDROM_Interface_Image    *cd                = nullptr;
 		void (MixerChannel::*addFrames) (Bitu, const Bit16s*) = nullptr;
 		uint32_t                 playedTrackFrames  = 0;
@@ -268,7 +267,7 @@ private:
 	                 const uint16_t sectorSize,
 	                 const bool mode2);
 	std::vector<Track>::iterator GetTrack(const uint32_t sector);
-	static void CDAudioCallBack (Bitu desired_frames);
+	void CDAudioCallBack(uint16_t desired_frames);
 
 	// Private functions for cue sheet processing
 	bool  LoadCueSheet(char *cuefile);

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -46,7 +46,7 @@ struct Handler : public Adlib::Handler {
 	virtual void WriteReg(Bit32u reg, Bit8u val) { adlib_write(reg, val); }
 	virtual Bit32u WriteAddr(io_port_t, Bit8u val) { return val; }
 
-	virtual void Generate(MixerChannel *chan, const uint16_t samples)
+	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
 		Bit16s buf[1024];
 		int remaining = samples;
@@ -74,7 +74,7 @@ struct Handler : public Adlib::Handler {
 		adlib_write_index(port, val);
 		return opl_index;
 	}
-	virtual void Generate(MixerChannel *chan, const uint16_t samples)
+	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
 		Bit16s buf[1024 * 2];
 		int remaining = samples;
@@ -101,7 +101,7 @@ struct Handler : public Adlib::Handler {
 		ym3812_write(chip, 1, val);
 	}
 	virtual Bit32u WriteAddr(io_port_t, Bit8u val) { return val; }
-	virtual void Generate(MixerChannel *chan, const uint16_t samples)
+	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
 		Bit16s buf[1024 * 2];
 		int remaining = samples;
@@ -134,7 +134,7 @@ struct Handler : public Adlib::Handler {
 		ymf262_write(chip, 1, val);
 	}
 	virtual Bit32u WriteAddr(io_port_t, Bit8u val) { return val; }
-	virtual void Generate(MixerChannel *chan, const uint16_t samples)
+	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
 		// We generate data for 4 channels, but only the first 2 are
 		// connected on a pc
@@ -189,7 +189,7 @@ struct Handler : public Adlib::Handler {
 		return addr;
 	}
 
-	void Generate(MixerChannel *chan, uint16_t samples) override
+	void Generate(mixer_channel_t &chan, uint16_t samples) override
 	{
 		int16_t buf[1024 * 2];
 		while (samples > 0) {
@@ -838,22 +838,21 @@ static Handler * make_opl_handler(const std::string &oplemu, OPL_Mode mode)
 }
 
 Module::Module(Section *configuration)
-	: Module_base(configuration),
-	  mixerObject(),
-	  mode(MODE_OPL2), // TODO this is set in Init and there's no good default
-	  reg{0}, // union
-	  ctrl{false, 0, 0xff, 0xff, false},
-	  mixerChan(nullptr),
-	  lastUsed(0),
-	  handler(nullptr),
-	  capture(nullptr)
+        : Module_base(configuration),
+          mode(MODE_OPL2), // TODO this is set in Init and there's no good default
+          reg{0},          // union
+          ctrl{false, 0, 0xff, 0xff, false},
+          mixerChan(nullptr),
+          lastUsed(0),
+          handler(nullptr),
+          capture(nullptr)
 {
 	Section_prop * section=static_cast<Section_prop *>(configuration);
 	const auto base = static_cast<uint16_t>(section->Get_hex("sbbase"));
 
 	ctrl.mixer = section->Get_bool("sbmixer");
 
-	mixerChan = mixerObject.Install(OPL_CallBack, 0, "FM");
+	mixerChan = MIXER_AddChannel(OPL_CallBack, 0, "FM");
 	//Used to be 2.0, which was measured to be too high. Exact value depends on card/clone.
 	mixerChan->SetScale( 1.5f );  
 

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -140,7 +140,7 @@ public:
 	//Write to a specific register in the chip
 	virtual void WriteReg( Bit32u addr, Bit8u val ) = 0;
 	//Generate a certain amount of samples
-	virtual void Generate(MixerChannel *chan, uint16_t samples) = 0;
+	virtual void Generate(mixer_channel_t &chan, uint16_t samples) = 0;
 	//Initialize at a specific sample rate and mode
 	virtual void Init(uint32_t rate) = 0;
 	virtual ~Handler() = default;
@@ -155,7 +155,6 @@ class Capture;
 class Module: public Module_base {
 	IO_ReadHandleObject ReadHandler[3];
 	IO_WriteHandleObject WriteHandler[3];
-	MixerObject mixerObject;
 
 	//Mode we're running in
 	Mode mode;
@@ -178,7 +177,7 @@ class Module: public Module_base {
 
 public:
 	static OPL_Mode oplmode;
-	MixerChannel* mixerChan;
+	mixer_channel_t mixerChan;
 	Bit32u lastUsed;				//Ticks when adlib was last used to turn of mixing after a few second
 
 	Handler* handler;				//Handler that will generate the sound

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -1541,7 +1541,7 @@ void Handler::WriteReg( Bit32u addr, Bit8u val ) {
 	chip.WriteReg( addr, val );
 }
 
-void Handler::Generate(MixerChannel *chan, uint16_t samples)
+void Handler::Generate(mixer_channel_t &chan, uint16_t samples)
 {
 	Bit32s buffer[512 * 2];
 	if (GCC_UNLIKELY(samples > 512))

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -253,7 +253,7 @@ struct Handler : public Adlib::Handler {
 	DBOPL::Chip chip;
 	virtual Bit32u WriteAddr(io_port_t port, Bit8u val);
 	virtual void WriteReg( Bit32u addr, Bit8u val );
-	virtual void Generate(MixerChannel *chan, uint16_t samples);
+	virtual void Generate(mixer_channel_t &chan, uint16_t samples);
 	virtual void Init(uint32_t rate);
 
 	Handler(bool opl3Mode) : chip(opl3Mode) {

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -302,7 +302,7 @@ static void DISNEY_CallBack(uint16_t len) {
 		return;
 
 	// get the smaller used
-	Bitu real_used;
+	uint16_t real_used;
 	if (disney.stereo) {
 		real_used = disney.da[0].used;
 		if(disney.da[1].used < real_used) real_used = disney.da[1].used;

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -35,7 +35,7 @@ constexpr uint32_t GAMEBLASTER_CLOCK_HZ = 7159090;
 
 
 //My mixer channel
-static MixerChannel * cms_chan;
+static mixer_channel_t cms_chan;
 //Timer to disable the channel after a while
 static Bit32u lastWriteTicks;
 static uint16_t cmsBase;
@@ -128,7 +128,6 @@ private:
 	IO_WriteHandleObject WriteHandler = {};
 	IO_WriteHandleObject DetWriteHandler = {};
 	IO_ReadHandleObject DetReadHandler = {};
-	MixerObject MixerChan = {};
 
 public:
 	CMS(Section *configuration) : Module_base(configuration)
@@ -147,7 +146,7 @@ public:
 		}
 
 		/* Register the Mixer CallBack */
-		cms_chan = MixerChan.Install(CMS_CallBack,sampleRate,"CMS");
+		cms_chan = MIXER_AddChannel(CMS_CallBack, sampleRate, "CMS");
 
 		lastWriteTicks = PIC_Ticks;
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -117,7 +117,6 @@ using ram_array_t = std::array<uint8_t, RAM_SIZE>;
 using read_io_array_t = std::array<IO_ReadHandleObject, READ_HANDLERS>;
 using vol_scalars_array_t = std::array<float, VOLUME_LEVELS>;
 using write_io_array_t = std::array<IO_WriteHandleObject, WRITE_HANDLERS>;
-using mixer_channel_ptr_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
 // A Voice is used by the Gus class and instantiates 32 of these.
 // Each voice represents a single "mono" render_buffer of audio having its own
@@ -275,7 +274,7 @@ private:
 	SoftLimiter soft_limiter;
 	Voice *target_voice = nullptr;
 	DmaChannel *dma_channel = nullptr;
-	mixer_channel_ptr_t audio_channel{nullptr, MIXER_DelChannel};
+	mixer_channel_t audio_channel = nullptr;
 	uint8_t &adlib_command_reg = adlib_commandreg;
 
 	// Port address
@@ -602,9 +601,8 @@ Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
 	// Register the Audio and DMA channels
 	const auto mixer_callback = std::bind(&Gus::AudioCallback, this,
 	                                      std::placeholders::_1);
-	audio_channel = mixer_channel_ptr_t(MIXER_AddChannel(mixer_callback, 1, "GUS"),
-	                                    MIXER_DelChannel);
-	assert(audio_channel);
+	audio_channel = MIXER_AddChannel(mixer_callback, 1, "GUS");
+
 	// Let the mixer command adjust the GUS's internal amplitude level's
 	const auto set_level_callback = std::bind(&Gus::SetLevelCallback, this, _1);
 	audio_channel->RegisterLevelCallBack(set_level_callback);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -75,8 +75,7 @@ void Innovation::Open(const std::string &model_choice,
 	// Setup the mixer and get it's sampling rate
 	using namespace std::placeholders;
 	const auto mixer_callback = std::bind(&Innovation::MixerCallBack, this, _1);
-	channel_t mixer_channel(MIXER_AddChannel(mixer_callback, 0, "INNOVATION"),
-	                        MIXER_DelChannel);
+	const auto mixer_channel = MIXER_AddChannel(mixer_callback, 0, "INNOVATION");
 	sid_sample_rate = mixer_channel->GetSampleRate();
 
 	// Determine the passband frequency, which is capped at 90% of Nyquist.

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -48,8 +48,6 @@ public:
 	~Innovation() { Close(); }
 
 private:
-	using channel_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
-
 	void Render();
 	uint16_t GetRemainingSamples();
 	void MixerCallBack(uint16_t requested_samples);
@@ -57,7 +55,7 @@ private:
 	void WriteToPort(io_port_t port, uint8_t data, io_width_t width);
 
 	// Managed objects
-	channel_t channel{nullptr, MIXER_DelChannel};
+	mixer_channel_t channel = nullptr;
 
 	IO_ReadHandleObject read_handler = {};
 	IO_WriteHandleObject write_handler = {};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -565,7 +565,7 @@ void MixerChannel::AddStretched(uint16_t len, int16_t *data)
 		const auto diff_mul = index & FREQ_MASK;
 		index += index_add;
 		mixpos &= MIXER_BUFMASK;
-		Bits sample = prev_sample[0] + ((diff * diff_mul) >> FREQ_SHIFT);
+		const auto sample = prev_sample[0] + ((diff * diff_mul) >> FREQ_SHIFT);
 		mixer.work[mixpos][0] += sample * volmul[0];
 		mixer.work[mixpos][1] += sample * volmul[1];
 		mixpos++;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -90,44 +90,28 @@ static constexpr int16_t MIXER_CLIP(const Bits SAMP)
 }
 
 struct mixer_t {
-	matrix<int32_t, MIXER_BUFSIZE, 2> work;
+	matrix<int32_t, MIXER_BUFSIZE, 2> work = {};
 	//Write/Read pointers for the buffer
-	std::atomic<uint32_t> pos;
-	std::atomic<uint32_t> done;
-	std::atomic<uint32_t> needed;
-	std::atomic<uint32_t> min_needed;
-	std::atomic<uint32_t> max_needed;
+	std::atomic<uint32_t> pos = 0;
+	std::atomic<uint32_t> done = 0;
+	std::atomic<uint32_t> needed = 0;
+	std::atomic<uint32_t> min_needed = 0;
+	std::atomic<uint32_t> max_needed = 0;
 	// For every millisecond tick how many samples need to be generated
-	std::atomic<uint32_t> tick_add;
-	uint32_t tick_counter;
-	std::array<float, 2> mastervol;
+	std::atomic<uint32_t> tick_add = 0;
+	uint32_t tick_counter = 0;
+	std::array<float, 2> mastervol = {1.0f, 1.0f};
 	MixerChannel *channels;
-	bool nosound;
-	uint32_t freq;
-	uint16_t blocksize; // matches SDL AudioSpec.samples type
+	bool nosound = false;
+	uint32_t freq = 0;
+	uint16_t blocksize = 0; // matches SDL AudioSpec.samples type
 	// Note: As stated earlier, all sdl code shall rather be in sdlmain
-	SDL_AudioDeviceID sdldevice;
-	mixer_t()
-	        : work(),
-			  pos(0),
-	          done(0),
-	          needed(0),
-	          min_needed(0),
-	          max_needed(0),
-	          tick_add(0),
-			  tick_counter(0),
-			  mastervol{1.0f, 1.0f},
-			  channels(nullptr),
-			  nosound(false),
-	          freq(0),
-			  blocksize(0),
-			  sdldevice(0)
-	{}
+	SDL_AudioDeviceID sdldevice = 0;
 };
 
-static struct mixer_t mixer;
+static struct mixer_t mixer = {};
 
-Bit8u MixTemp[MIXER_BUFSIZE];
+Bit8u MixTemp[MIXER_BUFSIZE] = {};
 
 MixerChannel::MixerChannel(MIXER_Handler _handler,
                            [[maybe_unused]] uint32_t _freq,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -130,7 +130,7 @@ static struct mixer_t mixer;
 Bit8u MixTemp[MIXER_BUFSIZE];
 
 MixerChannel::MixerChannel(MIXER_Handler _handler,
-                           [[maybe_unused]] Bitu _freq,
+                           [[maybe_unused]] uint32_t _freq,
                            const char *_name)
         : name(_name),
           done(0),
@@ -138,7 +138,7 @@ MixerChannel::MixerChannel(MIXER_Handler _handler,
           handler(_handler)
 {}
 
-MixerChannel * MIXER_AddChannel(MIXER_Handler handler, Bitu freq, const char * name) {
+MixerChannel * MIXER_AddChannel(MIXER_Handler handler, uint32_t freq, const char * name) {
 	MixerChannel * chan=new MixerChannel(handler, freq, name);
 	chan->next=mixer.channels;
 	chan->SetFreq(freq); // also enables 'interpolate' if needed

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -70,7 +70,7 @@ struct DelayEntry {
 static struct {
 	DelayEntry entries[SPKR_ENTRIES] = {};
 	DCSilencer dc_silencer = {};
-	MixerChannel *chan = nullptr;
+	mixer_channel_t chan = nullptr;
 	SPKR_MODES prev_mode = SPKR_OFF;
 	SPKR_MODES mode = SPKR_OFF;
 	uint32_t prev_pit_mode = 3;
@@ -465,8 +465,6 @@ static void PCSPEAKER_CallBack(uint16_t len)
 		spkr.chan->AddSamples_m16(len, buffer);
 }
 class PCSPEAKER final : public Module_base {
-private:
-	MixerObject MixerChan = {};
 public:
 	PCSPEAKER(Section *configuration) : Module_base(configuration)
 	{
@@ -490,7 +488,7 @@ public:
 
 		spkr.min_tr = (PIT_TICK_RATE + spkr.rate / 2 - 1) / (spkr.rate / 2);
 		/* Register the sound channel */
-		spkr.chan = MixerChan.Install(&PCSPEAKER_CallBack, spkr.rate, "SPKR");
+		spkr.chan = MIXER_AddChannel(&PCSPEAKER_CallBack, spkr.rate, "SPKR");
 		spkr.chan->SetPeakAmplitude(
 		        static_cast<uint32_t>(AMPLITUDE_POSITIVE));
 	}

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -27,9 +27,10 @@
 #include <limits>
 
 #include "dc_silencer.h"
-#include "timer.h"
-#include "setup.h"
 #include "pic.h"
+#include "setup.h"
+#include "support.h"
+#include "timer.h"
 
 #define SPKR_ENTRIES 1024
 
@@ -388,7 +389,7 @@ static void PlayOrFadeout(const uint16_t speaker_movements,
 		spkr.chan->Enable(false);
 	}
 
-	spkr.chan->AddSamples_m16(requested_samples, buffer);
+	spkr.chan->AddSamples_m16(check_cast<uint16_t>(requested_samples), buffer);
 }
 
 static void PCSPEAKER_CallBack(uint16_t len)

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -175,7 +175,7 @@ struct SB_INFO {
 		int value = 0;
 		uint32_t count = 0;
 	} e2 = {};
-	MixerChannel *chan = nullptr;
+	mixer_channel_t chan = nullptr;
 };
 
 static SB_INFO sb = {};
@@ -1314,10 +1314,10 @@ static float calc_vol(Bit8u amount) {
 }
 static void CTMIXER_UpdateVolumes() {
 	if (!sb.mixer.enabled) return;
-	MixerChannel * chan;
+
 	float m0 = calc_vol(sb.mixer.master[0]);
 	float m1 = calc_vol(sb.mixer.master[1]);
-	chan = MIXER_FindChannel("SB");
+	auto chan = MIXER_FindChannel("SB");
 	if (chan) chan->SetVolume(m0 * calc_vol(sb.mixer.dac[0]), m1 * calc_vol(sb.mixer.dac[1]));
 	chan = MIXER_FindChannel("FM");
 	if (chan) chan->SetVolume(m0 * calc_vol(sb.mixer.fm[0]) , m1 * calc_vol(sb.mixer.fm[1]) );
@@ -1709,7 +1709,6 @@ private:
 	IO_ReadHandleObject ReadHandler[0x10];
 	IO_WriteHandleObject WriteHandler[0x10];
 	AutoexecObject autoexecline;
-	MixerObject MixerChan;
 	OPL_Mode oplmode;
 
 	/* Support Functions */
@@ -1764,7 +1763,6 @@ public:
 	SBLASTER(Section *configuration)
 	        : Module_base(configuration),
 	          autoexecline{},
-	          MixerChan{},
 	          oplmode(OPL_none)
 	{
 		Section_prop * section=static_cast<Section_prop *>(configuration);
@@ -1797,7 +1795,7 @@ public:
 		}
 		if (sb.type==SBT_NONE || sb.type==SBT_GB) return;
 
-		sb.chan=MixerChan.Install(&SBLASTER_CallBack,22050,"SB");
+		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack, 22050, "SB");
 		sb.dsp.state=DSP_S_NORMAL;
 		sb.dsp.out.lastval=0xaa;
 		sb.dma.chan=NULL;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -93,11 +93,11 @@ constexpr int SOUND_CLOCK = 14318180 / 4;
 constexpr uint16_t TDAC_DMA_BUFSIZE = 1024;
 
 static struct {
-	MixerChannel *chan = nullptr;
+	mixer_channel_t chan = nullptr;
 	bool enabled = false;
 	Bitu last_write = 0u;
 	struct {
-		MixerChannel *chan = nullptr;
+		mixer_channel_t chan = nullptr;
 		bool enabled = false;
 		struct {
 			Bitu base = 0u;
@@ -332,13 +332,9 @@ class TANDYSOUND final : public Module_base {
 private:
 	IO_WriteHandleObject WriteHandler[4];
 	IO_ReadHandleObject ReadHandler[4];
-	MixerObject MixerChan;
-	MixerObject MixerChanDAC;
+
 public:
-	TANDYSOUND(Section *configuration)
-	        : Module_base(configuration),
-	          MixerChan(),
-	          MixerChanDAC()
+	TANDYSOUND(Section *configuration) : Module_base(configuration)
 	{
 		Section_prop *section = static_cast<Section_prop *>(configuration);
 
@@ -376,7 +372,7 @@ public:
 		}
 
 		const auto sample_rate = static_cast<uint32_t>(section->Get_int("tandyrate"));
-		tandy.chan=MixerChan.Install(&SN76496Update,sample_rate,"TANDY");
+		tandy.chan = MIXER_AddChannel(&SN76496Update, sample_rate, "TANDY");
 
 		WriteHandler[0].Install(0xc0, SN76496Write, io_width_t::byte, 2);
 
@@ -386,7 +382,7 @@ public:
 			ReadHandler[1].Install(0xc4, TandyDACRead, io_width_t::byte, 4);
 
 			tandy.dac.enabled=true;
-			tandy.dac.chan=MixerChanDAC.Install(&TandyDACUpdate,sample_rate,"TANDYDAC");
+			tandy.dac.chan = MIXER_AddChannel(&TandyDACUpdate, sample_rate, "TANDYDAC");
 
 			tandy.dac.hw.base=0xc4;
 			tandy.dac.hw.irq =7;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -223,8 +223,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	// Setup the mixer channel and level callback
 	const auto mixer_callback = std::bind(&MidiHandlerFluidsynth::MixerCallBack,
 	                                      this, std::placeholders::_1);
-	channel_t mixer_channel(MIXER_AddChannel(mixer_callback, 0, "FSYNTH"),
-	                        MIXER_DelChannel);
+	const auto mixer_channel = MIXER_AddChannel(mixer_callback, 0, "FSYNTH");
 
 	const auto set_mixer_level = std::bind(&MidiHandlerFluidsynth::SetMixerLevel,
 	                                       this, std::placeholders::_1);

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -58,11 +58,10 @@ private:
 	using fluid_settings_ptr_t =
 	        std::unique_ptr<fluid_settings_t, decltype(&delete_fluid_settings)>;
 	using fsynth_ptr_t = std::unique_ptr<fluid_synth_t, decltype(&delete_fluid_synth)>;
-	using channel_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
 
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
-	channel_t channel{nullptr, MIXER_DelChannel};
+	mixer_channel_t channel = nullptr;
 	std::string selected_font = "";
 
 	std::vector<int16_t> play_buffer = {};

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -531,8 +531,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 
 	const auto mixer_callback = std::bind(&MidiHandler_mt32::MixerCallBack,
 	                                      this, std::placeholders::_1);
-	channel_t mixer_channel(MIXER_AddChannel(mixer_callback, 0, "MT32"),
-	                        MIXER_DelChannel);
+	const auto mixer_channel = MIXER_AddChannel(mixer_callback, 0, "MT32");
 
 	// Let the mixer command adjust the MT32's services gain-level
 	const auto set_mixer_level = std::bind(&MidiHandler_mt32::SetMixerLevel,

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -44,9 +44,6 @@ static_assert(MT32EMU_VERSION_MAJOR > 2 ||
               "libmt32emu >= 2.5.0 required (using " MT32EMU_VERSION ")");
 
 class MidiHandler_mt32 final : public MidiHandler {
-private:
-	using channel_t = std::unique_ptr<MixerChannel, decltype(&MIXER_DelChannel)>;
-
 public:
 	using service_t = std::unique_ptr<MT32Emu::Service>;
 
@@ -69,7 +66,7 @@ private:
 	void Render();
 
 	// Managed objects
-	channel_t channel{nullptr, MIXER_DelChannel};
+	mixer_channel_t channel = nullptr;
 
 	std::vector<int16_t> play_buffer = {};
 	static constexpr auto num_buffers = 4;


### PR DESCRIPTION
Previously the mixer's channels were managed using the `MixerObject` helper class. Multiple channels were connected using an internal linked-list.

This commit places the channels in a `std::map` container where the key is the channel name (ie: `"CDAUDIO"`).  The key is only used for "find" lookup operations (in SB's CT Mixer) and when using `MIXER.COM` to set volumes.

This PR also fixes potential race conditions between the mixer's channels and channel-management operations done in the audio devices.

---

Here's an example where the PC speaker is deleting its channel before the mixer's exited its mix loop:

![2021-11-16_19-00](https://user-images.githubusercontent.com/1557255/142155894-b8fb12eb-cf72-45c6-941b-895f4316ef7d.png)

---

Here's an example where Tandy sound is deleting its channel before the mixer's exited its mix loop:

![2021-11-16_19-02](https://user-images.githubusercontent.com/1557255/142155895-1da24370-0a61-443f-83e2-b44a4df4f086.png)

---

Here's an example where the GUS is deleting its channel before the mixer's exited its mix loop:

![2021-11-16_19-06](https://user-images.githubusercontent.com/1557255/142155898-c8969fed-2a69-43f6-8b70-778dd5111877.png)

---

Here's an example where the Adlib and Sound Blaster devices are both deleting their channels before the mixer's exited its mix loop:

![2021-11-16_19-10](https://user-images.githubusercontent.com/1557255/142155899-7f73ee6f-06cc-44da-8d9f-ee2b9207dd80.png)
 