### PR TITLE
Add/cleanup help messages for DATE, LH/LOADHIGH, and TIME commands

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -504,13 +504,15 @@ static Bitu DOS_21Handler(void) {
 		break;
 	}
 	case 0x2d:		/* Set System Time */
-		LOG(LOG_DOSMISC,LOG_ERROR)("DOS:Set System Time not supported");
-		//Check input parameters nonetheless
 		if( reg_ch > 23 || reg_cl > 59 || reg_dh > 59 || reg_dl > 99 )
 			reg_al = 0xff; 
 		else { //Allow time to be set to zero. Restore the orginal time for all other parameters. (QuickBasic)
 			if (reg_cx == 0 && reg_dx == 0) {time_start = mem_readd(BIOS_TIMER);LOG_MSG("Warning: game messes with DOS time!");}
 			else time_start = 0;
+			uint32_t ticks = (uint32_t)(
+			        ((double)(reg_ch * 3600 + reg_cl * 60 + reg_dh)) *
+			        18.206481481);
+			mem_writed(BIOS_TIMER, ticks);
 			reg_al = 0;
 		}
 		break;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1101,8 +1101,23 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  \033[32;1msubst\033[0m \033[37;1md:\033[0m \033[36;1mc:\\games\033[0m\n"
 	        "  \033[32;1msubst\033[0m \033[37;1me:\033[0m \033[36;1m/d\033[0m\n");
-	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires xms=true,umb=true).\n");
-
+	MSG_Add("SHELL_CMD_LOADHIGH_HELP", "Loads a DOS program into upper memory.\n");
+	MSG_Add("SHELL_CMD_LOADHIGH_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mlh\033[0m \033[36;1mPROGRAM\033[0m \033[37;1m[PARAMETERS]\033[0m\n"
+	        "  \033[32;1mloadhigh\033[0m \033[36;1mPROGRAM\033[0m \033[37;1m[PARAMETERS]\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mPROGRAM\033[0m is a DOS TSR program to be loaded, optionally with parameters.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  This command intends to save the conventional memory by loading specified DOS\n"
+	        "  TSR programs into upper memory if possible. Such programs may be required for\n"
+	        "  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).\n"
+	        "  Not all DOS TSR programs can be loaded into upper memory with this command.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mlh\033[0m \033[36;1mtsrapp\033[0m \033[37;1margs\033[0m\n");
 	MSG_Add("SHELL_CMD_LS_HELP",
 	        "Displays directory contents in the wide list format.\n");
 	MSG_Add("SHELL_CMD_LS_HELP_LONG",

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -712,11 +712,28 @@ void SHELL_Init() {
                                     "  /F:         Switch back to DOSBox internal time (opposite of /S)\n"\
 									"  /T:         Only display date\n"\
 									"  /H:         Synchronize with host\n");
-	MSG_Add("SHELL_CMD_TIME_HELP","Displays the internal time.\n");
-	MSG_Add("SHELL_CMD_TIME_NOW","Current time: ");
-	MSG_Add("SHELL_CMD_TIME_HELP_LONG","TIME [/T] [/H]\n"\
-									"  /T:         Display simple time\n"\
-									"  /H:         Synchronize with host\n");
+	MSG_Add("SHELL_CMD_TIME_HELP", "Displays or changes the internal time.\n");
+	MSG_Add("SHELL_CMD_TIME_ERROR", "The specified time is not correct.\n");
+	MSG_Add("SHELL_CMD_TIME_NOW", "Current time: ");
+	MSG_Add("SHELL_CMD_TIME_SETHLP", "Type 'time hh:mm:ss' to change.\n");
+	MSG_Add("SHELL_CMD_TIME_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mtime\033[0m [/t]\n"
+	        "  \033[32;1mtime\033[0m /h\n"
+	        "  \033[32;1mtime\033[0m \033[36;1mTIME\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mTIME\033[0m is the new time to set to, in the format of \033[36;1mhh:mm:ss\033[0m.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Running \033[32;1mtime\033[0m without an argument shows the current time, or a simple time\n"
+	        "  with the /t option. You can force a time synchronization of with the host\n"
+	        "  system with the /h option, or manually specify a new time to set to.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mtime\033[0m\n"
+	        "  \033[32;1mtime\033[0m /h\n"
+	        "  \033[32;1mtime\033[0m \033[36;1m13:14:15\033[0m\n");
 	MSG_Add("SHELL_CMD_MKDIR_ERROR","Unable to make: %s.\n");
 	MSG_Add("SHELL_CMD_RMDIR_ERROR","Unable to remove: %s.\n");
 	MSG_Add("SHELL_CMD_DEL_ERROR","Unable to delete: %s.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -700,18 +700,30 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_CHDIR_HINT","Hint: To change to different drive type \033[31m%c:\033[0m\n");
 	MSG_Add("SHELL_CMD_CHDIR_HINT_2","directoryname is longer than 8 characters and/or contains spaces.\nTry \033[31mcd %s\033[0m\n");
 	MSG_Add("SHELL_CMD_CHDIR_HINT_3","You are still on drive Z:, change to a mounted drive with \033[31mC:\033[0m.\n");
-	MSG_Add("SHELL_CMD_DATE_HELP","Displays or changes the internal date.\n");
-	MSG_Add("SHELL_CMD_DATE_ERROR","The specified date is not correct.\n");
-	MSG_Add("SHELL_CMD_DATE_DAYS","3SunMonTueWedThuFriSat"); // "2SoMoDiMiDoFrSa"
-	MSG_Add("SHELL_CMD_DATE_NOW","Current date: ");
-	MSG_Add("SHELL_CMD_DATE_SETHLP","Type 'date MM-DD-YYYY' to change.\n");
-	MSG_Add("SHELL_CMD_DATE_FORMAT","M/D/Y");
-	MSG_Add("SHELL_CMD_DATE_HELP_LONG","DATE [[/T] [/H] [/S] | MM-DD-YYYY]\n"\
-									"  MM-DD-YYYY: new date to set\n"\
-									"  /S:         Permanently use host time and date as DOS time\n"\
-                                    "  /F:         Switch back to DOSBox internal time (opposite of /S)\n"\
-									"  /T:         Only display date\n"\
-									"  /H:         Synchronize with host\n");
+	MSG_Add("SHELL_CMD_DATE_HELP", "Displays or changes the internal date.\n");
+	MSG_Add("SHELL_CMD_DATE_ERROR", "The specified date is not correct.\n");
+	MSG_Add("SHELL_CMD_DATE_DAYS", "3SunMonTueWedThuFriSat"); // "2SoMoDiMiDoFrSa"
+	MSG_Add("SHELL_CMD_DATE_NOW", "Current date: ");
+	MSG_Add("SHELL_CMD_DATE_SETHLP", "Type 'date MM-DD-YYYY' to change.\n");
+	MSG_Add("SHELL_CMD_DATE_FORMAT", "M/D/Y");
+	MSG_Add("SHELL_CMD_DATE_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mdate\033[0m [/t]\n"
+	        "  \033[32;1mdate\033[0m /h\n"
+	        "  \033[32;1mdate\033[0m \033[36;1mDATE\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mDATE\033[0m is the new date to set to, in the format of \033[36;1mMM-DD-YYYY\033[0m.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Running \033[32;1mdate\033[0m without an argument shows the current date, or only a date\n"
+	        "  with the /t option. You can force a date synchronization of with the host\n"
+	        "  system with the /h option, or manually specify a new date to set to.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mdate\033[0m\n"
+	        "  \033[32;1mdate\033[0m /h\n"
+	        "  \033[32;1mdate\033[0m \033[36;1m10-11-2012\033[0m\n");
 	MSG_Add("SHELL_CMD_TIME_HELP", "Displays or changes the internal time.\n");
 	MSG_Add("SHELL_CMD_TIME_ERROR", "The specified time is not correct.\n");
 	MSG_Add("SHELL_CMD_TIME_NOW", "Current time: ");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1450,6 +1450,21 @@ void DOS_Shell::CMD_TIME(char * args) {
 		mem_writed(BIOS_TIMER, static_cast<uint32_t>(ticks_now));
 		return;
 	}
+	uint32_t newhour, newminute, newsecond;
+	if (sscanf(args, "%u:%u:%u", &newhour, &newminute, &newsecond) == 3) {
+		if (newhour > 23 || newminute > 59 || newsecond > 59)
+			WriteOut(MSG_Get("SHELL_CMD_TIME_ERROR"));
+		else {
+			reg_ch = static_cast<Bit8u>(newhour);
+			reg_cl = static_cast<Bit8u>(newminute);
+			reg_dh = static_cast<Bit8u>(newsecond);
+
+			reg_ah=0x2d; // set system time
+			CALLBACK_RunRealInt(0x21);
+			if (reg_al == 0xff) WriteOut(MSG_Get("SHELL_CMD_TIME_ERROR"));
+		}
+		return;
+	}
 	bool timeonly = ScanCMDBool(args,"T");
 
 	reg_ah=0x2c; // get system time
@@ -1465,6 +1480,7 @@ void DOS_Shell::CMD_TIME(char * args) {
 	} else {
 		WriteOut(MSG_Get("SHELL_CMD_TIME_NOW"));
 		WriteOut("%2u:%02u:%02u,%02u\n",reg_ch,reg_cl,reg_dh,reg_dl);
+		WriteOut(MSG_Get("SHELL_CMD_TIME_SETHLP"));
 	}
 }
 


### PR DESCRIPTION
This new PR adds full help messages for DOS commands DATE, LH/LOADHIGH, and TIME, using the style of DOS commands such as MOUNT and VER, including major cleanups of the help messages for DATE and TIME command to use the new style. Also, the ability to change the internal time with TIME command is added, similar to DATE command which already allowed to change the internal date.