### PR TITLE
Improve & expand unit test scaffolding/fixtures

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
 
-      - run:  meson setup build
+      - run:  meson setup -Dunit_tests=disabled build
 
       - name: Build and run scan-build
         run: |

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -18,7 +18,7 @@ extraction:
     - meson --version
     configure:
       command:
-      - meson setup -Duse_fluidsynth=false -Duse_mt32emu=false build
+      - meson setup -Duse_fluidsynth=false -Duse_mt32emu=false -Dunit_tests=disabled build
     index:
       build_command:
       - ninja -C build

--- a/include/programs.h
+++ b/include/programs.h
@@ -82,7 +82,8 @@ public:
 	bool GetEnvNum(Bitu num, std::string &result) const;
 	Bitu GetEnvCount() const;
 	bool SetEnv(const char * entry,const char * new_string);
-	void WriteOut(const char *format, ...);	// printf to DOS stdout
+	virtual void WriteOut(const char *format, const char * arguments);
+	virtual void WriteOut(const char *format, ...);	// printf to DOS stdout
 	void WriteOut_NoParsing(const char *str); // write string to DOS stdout
 	bool SuppressWriteOut(const char *format); // prevent writing to DOS stdout
 	void InjectMissingNewline();

--- a/include/shell.h
+++ b/include/shell.h
@@ -60,7 +60,7 @@ public:
 };
 
 class AutoexecEditor;
-class DOS_Shell final : public Program {
+class DOS_Shell : public Program {
 private:
 	enum class HELP_LIST { ALL, COMMON };
 	void PrintHelpForCommands(HELP_LIST requested_list);
@@ -91,6 +91,8 @@ public:
 	bool Execute(char * name,char * args);
 	/* Checks if it matches a hardware-property */
 	bool CheckConfig(char* cmd_in,char*line);
+	/* Internal utilities for testing */
+	virtual bool execute_shell_cmd(char *name, char *arguments);
 
 	/* Some internal used functions */
 	const char *Which(const char *name) const;

--- a/meson.build
+++ b/meson.build
@@ -382,7 +382,7 @@ executable('dosbox', dosbox_sources,
 # create a library so we can test things inside DOSBOX dep path
 libdosbox = static_library('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
                         include_directories : incdir,
-                        dependencies : [atomic_dep, threads_dep, sdl2_dep] + internal_deps)
+                        dependencies : [atomic_dep, threads_dep, sdl2_dep, libloguru_dep] + internal_deps)
 dosbox_dep = declare_dependency(link_with : libdosbox)
 
 

--- a/meson.build
+++ b/meson.build
@@ -356,13 +356,6 @@ configure_file(input : 'src/config.h.in', output : 'config.h',
                configuration : conf_data)
 
 
-# tests
-#
-# Some tests use relative paths; in meson 0.56.0 this can be replaced
-# with meson.project_source_root().
-project_source_root = meson.current_source_dir()
-subdir('tests')
-
 
 # dosbox executable
 #
@@ -386,6 +379,21 @@ executable('dosbox', dosbox_sources,
                           + internal_deps,
            include_directories : incdir,
            install : true)
+# create a library so we can test things inside DOSBOX dep path
+libdosbox = static_library('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
+                        include_directories : incdir,
+                        dependencies : [atomic_dep, threads_dep, sdl2_dep] + internal_deps)
+dosbox_dep = declare_dependency(link_with : libdosbox)
+
+
+
+# tests
+#
+# Some tests use relative paths; in meson 0.56.0 this can be replaced
+# with meson.project_source_root().
+project_source_root = meson.current_source_dir()
+subdir('tests')
+
 
 
 # additional files for installation

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1370,7 +1370,11 @@ public:
 		}
 	}
 	~DOS(){
-		for (Bit16u i=0;i<DOS_DRIVES;i++) delete Drives[i];
+		for (Bit16u i = 0; i < DOS_DRIVES; i++)	delete Drives[i];
+		// de-init devices, this allows DOSBox to cleanly re-initialize
+		// without throwing an inevitable `DOS: Too many devices added`
+		// exception
+		for (auto& device : Devices) device = nullptr;
 	}
 };
 

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -20,6 +20,7 @@
 
 #include "string_utils.h"
 
+
 bool WildFileCmp(const char *file, const char *wild)
 {
 	char file_name[9];
@@ -45,6 +46,7 @@ bool WildFileCmp(const char *file, const char *wild)
 		memcpy(file_name, file, strnlen(file, 8));
 	}
 	upcase(file_name);upcase(file_ext);
+
 	find_ext=strrchr(wild,'.');
 	if (find_ext) {
 		Bitu size=(Bitu)(find_ext-wild);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -612,7 +612,7 @@ void DOSBOX_Init(void) {
 	Pmulti_remain->SetValue("auto");
 	Pstring->Set_values(cyclest);
 
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", always, "");
+	Pmulti_remain->GetSection()->Add_string("parameters", always, "");
 
 	Pint = secprop->Add_int("cycleup", always, 10);
 	Pint->SetMinMax(1,1000000);
@@ -890,7 +890,7 @@ void DOSBOX_Init(void) {
 	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
 	Pmulti_remain->SetValue("dummy");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
+	Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help(
 		"set type of device connected to com port.\n"
 		"Can be disabled, dummy, modem, nullmodem, directserial.\n"
@@ -907,21 +907,21 @@ void DOSBOX_Init(void) {
 	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
 	Pmulti_remain->SetValue("dummy");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
+	Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help("see serial1");
 
 	Pmulti_remain = secprop->Add_multiremain("serial3", when_idle, " ");
 	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	Pmulti_remain->SetValue("disabled");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
+	Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help("see serial1");
 
 	Pmulti_remain = secprop->Add_multiremain("serial4", when_idle, " ");
 	Pstring = Pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	Pmulti_remain->SetValue("disabled");
 	Pstring->Set_values(serials);
-	Pstring = Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
+	Pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	Pmulti_remain->Set_help("see serial1");
 
 	pstring = secprop->Add_path("phonebookfile", only_at_start, "phonebook.txt");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -194,6 +194,27 @@ void Program::WriteOut(const char *format, ...)
 //	DOS_WriteFile(STDOUT,(Bit8u *)buf,&size);
 }
 
+void Program::WriteOut(const char *format, const char *arguments)
+{
+	if (SuppressWriteOut(format))
+		return;
+
+	char buf[2048];
+	sprintf(buf,format,arguments);
+
+	Bit16u size = (Bit16u)strlen(buf);
+	dos.internal_output=true;
+	for (Bit16u i = 0; i < size; i++) {
+		Bit8u out;Bit16u s=1;
+		if (buf[i] == 0xA && last_written_character != 0xD) {
+			out = 0xD;DOS_WriteFile(STDOUT,&out,&s);
+		}
+		last_written_character = out = buf[i];
+		DOS_WriteFile(STDOUT,&out,&s);
+	}
+	dos.internal_output=false;
+}
+
 void Program::WriteOut_NoParsing(const char * format) {
 	if (SuppressWriteOut(format))
 		return;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -884,12 +884,19 @@ static void CONFIG_ProgramStart(Program * * make) {
 	*make=new CONFIG;
 }
 
+void PROGRAMS_Destroy(Section*) {
+	internal_progs_comdata.clear();
+	internal_progs.clear();
+}
 
-void PROGRAMS_Init(Section* /*sec*/) {
+void PROGRAMS_Init(Section* sec) {
 	/* Setup a special callback to start virtual programs */
 	call_program=CALLBACK_Allocate();
 	CALLBACK_Setup(call_program,&PROGRAMS_Handler,CB_RETF,"internal program");
 	PROGRAMS_MakeFile("CONFIG.COM",CONFIG_ProgramStart);
+
+	// Cleanup -- allows unit tests to run indefinitely & cleanly
+	sec->AddDestroyFunction(&PROGRAMS_Destroy,false);
 
 	// listconf
 	MSG_Add("PROGRAM_CONFIG_NOCONFIGFILE","No config file loaded!\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -143,19 +143,19 @@ bool DOS_Shell::CheckConfig(char *cmd_in, char *line) {
 	return true;
 }
 
+bool DOS_Shell::execute_shell_cmd(char *name, char *arguments) {
+	SHELL_Cmd shell_cmd = {};
+	if (!lookup_shell_cmd(name, shell_cmd))
+		return false; // name isn't a shell command!
+	(this->*(shell_cmd.handler))(arguments);
+	return true;
+}
+
 void DOS_Shell::DoCommand(char * line) {
 /* First split the line into command and arguments */
 	line=trim(line);
 	char cmd_buffer[CMD_MAXLINE];
 	char * cmd_write=cmd_buffer;
-
-	auto execute_shell_cmd = [this](char *name, char *arguments) {
-		SHELL_Cmd shell_cmd = {};
-		if (!lookup_shell_cmd(name, shell_cmd))
-			return false; // name isn't a shell command!
-		(this->*(shell_cmd.handler))(arguments);
-		return true;
-	};
 
 	while (*line) {
 		if (*line == 32) break;

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -1,0 +1,56 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* This sample shows how to write a simple unit test for dosbox-staging using
+ * Google C++ testing framework.
+ *
+ * Read Google Test Primer for reference of most available features, macros,
+ * and guidance about writing unit tests:
+ *
+ * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
+ */
+
+/* Include necessary header files; order of headers should be as follows:
+ *
+ * 1. Header declaring functions/classes being tested
+ * 2. <gtest/gtest.h>, which declares the testing framework
+ * 3. Additional system headers (if needed)
+ * 4. Additional dosbox-staging headers (if needed)
+ */
+
+#include "dos_inc.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+// Open anonymous namespace (this is Google Test requirement)
+
+namespace {
+
+TEST(DOS_MakeName, FailOnNull)
+{
+	Bit8u drive;
+    char fulldir[DOS_PATHLENGTH];
+    bool result = DOS_MakeName("\0",fulldir,&drive);
+    EXPECT_EQ(false, result);
+}
+
+} // namespace

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -58,7 +58,7 @@ void assert_DTAExtendName(std::string input,
                           std::string expected_name,
                           std::string expected_ext)
 {
-	char *const input_str = const_cast<char *const>(&input.c_str()[0]);
+	char *const input_str = const_cast<char *>(&input.c_str()[0]);
 	// char * const input_name = &input[0];
 	// needs to be minimum length of the input up to the dot + 1 (null)
 	char output_filename[DOS_PATHLENGTH];

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -37,6 +37,8 @@
 
 #include "dos_inc.h"
 
+#include "control.h"
+
 #include <gtest/gtest.h>
 
 #include <string>
@@ -52,5 +54,26 @@ TEST(DOS_MakeName, FailOnNull)
     bool result = DOS_MakeName("\0",fulldir,&drive);
     EXPECT_EQ(false, result);
 }
+
+TEST(DOS_MakeName, DriveNotFound)
+{
+    char arg_c_str[] = "-conf tests/files/dosbox-staging-tests.conf";
+    char *argv[1] = {arg_c_str};
+
+    CommandLine com_line(1,argv);
+    Config myconf(&com_line);
+    control=&myconf;
+    DOSBOX_Init();
+
+    std::cout << "Running control->GetSection('dosbox')...\n";
+    Section *sec = control->GetSection("dosbox");
+    sec->ExecuteInit();
+
+	Bit8u drive;
+    char fulldir[DOS_PATHLENGTH];
+    bool result = DOS_MakeName("N:\\AUTOEXEC.BAT",fulldir,&drive);
+    EXPECT_EQ(false, result);
+}
+
 
 } // namespace

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -47,59 +47,12 @@
 #include "shell.h"
 #include "string_utils.h"
 
+#include "dosbox_test_fixture.h"
 #include "../src/dos/dos_files.cpp"
 
-// Open anonymous namespace (this is Google Test requirement)
 namespace {
 
-class DOS_FilesTest : public ::testing::Test {
-public:
-	DOS_FilesTest()
-	        : arg_c_str("-conf tests/files/dosbox-staging-tests.conf\0"),
-	          argv{arg_c_str},
-	          com_line(1, argv),
-	          config(Config(&com_line))
-	{
-		control = &config;
-	}
-
-	void SetUp() override
-	{
-		// This will register all the init functions, but won't run them
-		DOSBOX_Init();
-
-		for (auto section_name : sections) {
-			_sec = control->GetSection(section_name);
-			// NOTE: Some of the sections will return null pointers,
-			// if you add a section below, make sure to test for
-			// nullptr before executing early init.
-			_sec->ExecuteEarlyInit();
-		}
-
-		for (auto section_name : sections) {
-			_sec = control->GetSection(section_name);
-			_sec->ExecuteInit();
-		}
-	}
-
-	void TearDown() override
-	{
-		std::vector<std::string>::reverse_iterator r = sections.rbegin();
-		for (; r != sections.rend(); ++r)
-			control->GetSection(*r)->ExecuteDestroy();
-	}
-
-private:
-	char const *arg_c_str;
-	const char *argv[1];
-	CommandLine com_line;
-	Config config;
-	Section *_sec;
-	// Only init these sections for our tests
-	std::vector<std::string> sections{"dosbox", "cpu",      "mixer",
-	                                  "midi",   "sblaster", "speaker",
-	                                  "serial", "dos",      "autoexec"};
-};
+class DOS_FilesTest : public DOSBoxTestFixture {};
 
 void assert_DTAExtendName(std::string input,
                           std::string expected_name,

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -37,7 +37,6 @@
 
 #include "dos_inc.h"
 
-#include <iostream>
 #include <iterator>
 #include <string>
 
@@ -45,6 +44,8 @@
 
 #include "control.h"
 #include "dos_system.h"
+#include "shell.h"
+#include "string_utils.h"
 
 // Open anonymous namespace (this is Google Test requirement)
 namespace {
@@ -98,26 +99,214 @@ private:
 	                                  "serial", "dos",      "autoexec"};
 };
 
-TEST_F(DOS_FilesTest, DOS_MakeName_FailOnNull)
+void assert_DOS_MakeName(char const *const input,
+                         bool exp_result,
+                         std::string exp_fullname = "",
+                         int exp_drive = 0)
 {
-	Bit8u drive;
-	char fulldir[DOS_PATHLENGTH];
-	bool result = DOS_MakeName("\0", fulldir, &drive);
-	EXPECT_EQ(false, result);
+	Bit8u drive_result;
+	char fullname_result[DOS_PATHLENGTH];
+	bool result = DOS_MakeName(input, fullname_result, &drive_result);
+	EXPECT_EQ(result, exp_result);
+	// if we expected success, also test these
+	if (exp_result) {
+		EXPECT_EQ(std::string(fullname_result), exp_fullname);
+		EXPECT_EQ(drive_result, exp_drive);
+	}
 }
 
-TEST_F(DOS_FilesTest, DOS_MakeName_DriveNotFound)
+TEST_F(DOS_FilesTest, DOS_MakeName_Basic_Failures)
 {
-	Bit8u drive;
-	char fulldir[DOS_PATHLENGTH];
-	EXPECT_EQ(false, DOS_MakeName("B:\\AUTOEXEC.BAT", fulldir, &drive));
+	// make sure we get failures, not explosions
+	assert_DOS_MakeName("\0", false);
+	assert_DOS_MakeName(" ", false);
+	assert_DOS_MakeName(" NAME", false);
+	assert_DOS_MakeName("\1:\\AUTOEXEC.BAT", false);
+	assert_DOS_MakeName(nullptr, false);
+	assert_DOS_MakeName("B:\\AUTOEXEC.BAT", false);
 }
 
 TEST_F(DOS_FilesTest, DOS_MakeName_Z_AUTOEXEC_BAT_exists)
 {
-	Bit8u drive;
-	char fulldir[DOS_PATHLENGTH];
-	EXPECT_EQ(true, DOS_MakeName("Z:\\AUTOEXEC.BAT", fulldir, &drive));
+	assert_DOS_MakeName("Z:\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+}
+
+// This captures a particularity of the DOSBox code where the
+// drive index is set even though the path failed. this could have
+// ramifications across the codebase if not replicated
+TEST_F(DOS_FilesTest, DOS_MakeName_Drive_Index_Set_On_Failure)
+{
+	Bit8u drive_result;
+	char fullname_result[DOS_PATHLENGTH];
+	bool result;
+	result = DOS_MakeName("A:\r\n", fullname_result, &drive_result);
+	EXPECT_EQ(result, false);
+	EXPECT_EQ(drive_result, 0);
+	result = DOS_MakeName("B:\r\n", fullname_result, &drive_result);
+	EXPECT_EQ(drive_result, 1);
+	EXPECT_EQ(result, false);
+	result = DOS_MakeName("C:\r\n", fullname_result, &drive_result);
+	EXPECT_EQ(drive_result, 2);
+	EXPECT_EQ(result, false);
+	result = DOS_MakeName("Z:\r\n", fullname_result, &drive_result);
+	EXPECT_EQ(drive_result, 25);
+	EXPECT_EQ(result, false);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_Uppercase)
+{
+	assert_DOS_MakeName("Z:\\autoexec.bat", true, "AUTOEXEC.BAT", 25);
+	// lower case
+	assert_DOS_MakeName("z:\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	// current dir isn't uppercased if it's not already
+	safe_strcpy(Drives[25]->curdir, "Windows\\Folder");
+	assert_DOS_MakeName("autoexec.bat", true,
+	                    "Windows\\Folder\\AUTOEXEC.BAT", 25);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_CONVERTS_FWD_SLASH)
+{
+	assert_DOS_MakeName("Z:/AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+}
+
+// spaces get stripped out before processing (\t, \r, etc, are illegal chars,
+// not whitespace)
+TEST_F(DOS_FilesTest, DOS_MakeName_STRIP_SPACE)
+{
+	assert_DOS_MakeName("Z:\\   A U T  OE X   EC     .BAT", true,
+	                    "AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("Z: \\   A U T  OE X   EC     .BAT", true,
+	                    "AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("12345   678.123", true, "12345678.123", 25);
+	// except here, whitespace isn't stripped & causes failure
+	assert_DOS_MakeName("Z :\\AUTOEXEC.BAT", false);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_Dir_Handling)
+{
+	assert_DOS_MakeName("Z:\\CODE\\", true, "CODE", 25);
+	assert_DOS_MakeName("Z:\\CODE\\AUTOEXEC.BAT", true, "CODE\\AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("Z:\\DIR\\UNTERM", true, "DIR\\UNTERM", 25);
+	// trailing gets trimmed
+	assert_DOS_MakeName("Z:\\CODE\\TERM\\", true, "CODE\\TERM", 25);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_Assumes_Current_Drive_And_Dir)
+{
+	// when passed only a filename, assume default drive and current dir
+	assert_DOS_MakeName("AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	// artificially change directory
+	safe_strcpy(Drives[25]->curdir, "CODE");
+	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\AUTOEXEC.BAT", 25);
+	// artificially change directory
+	safe_strcpy(Drives[25]->curdir, "CODE\\BIN");
+	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\BIN\\AUTOEXEC.BAT", 25);
+	// ignores current dir and goes to root
+	assert_DOS_MakeName("\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	safe_strcpy(Drives[25]->curdir, "");
+	assert_DOS_MakeName("Z:\\CODE\\BIN", true, "CODE\\BIN", 25);
+	assert_DOS_MakeName("Z:", true, "", 25);
+	assert_DOS_MakeName("Z:\\", true, "", 25);
+	// This is a bug but we need to capture this functionality
+	safe_strcpy(Drives[25]->curdir, "CODE\\BIN\\");
+	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\BIN\\\\AUTOEXEC.BAT", 25);
+	safe_strcpy(Drives[25]->curdir, "CODE\\BIN\\\\");
+	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\BIN\\\\\\AUTOEXEC.BAT", 25);
+}
+
+// This tests that illegal char matching happens AFTER 8.3 trimming
+TEST_F(DOS_FilesTest, DOS_MakeName_Illegal_Chars_After_8_3)
+{
+	safe_strcpy(Drives[25]->curdir, "BIN");
+	assert_DOS_MakeName("\n2345678AAAAABBB.BAT", false);
+	assert_DOS_MakeName("12345678.\n23BBBBBAAA", false);
+	assert_DOS_MakeName("12345678AAAAABB\n.BAT", true, "BIN\\12345678.BAT", 25);
+	assert_DOS_MakeName("12345678.123BBBBBAAA\n", true, "BIN\\12345678.123", 25);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_DOS_PATHLENGTH_checks)
+{
+	// Right on the line ...
+	safe_strcpy(Drives[25]->curdir,
+	            "aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaaa");
+	assert_DOS_MakeName("BBBBB.BB", true,
+	                    "aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaaa\\BBBBB.BB",
+	                    25);
+	// Equal to...
+	assert_DOS_MakeName("BBBBBB.BB", false);
+	// Over...
+	assert_DOS_MakeName("BBBBBBB.BB", false);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_Enforce_8_3)
+{
+	safe_strcpy(Drives[25]->curdir, "BIN");
+	assert_DOS_MakeName("12345678AAAAABBBB.BAT", true, "BIN\\12345678.BAT", 25);
+	assert_DOS_MakeName("12345678.123BBBBBAAAA", true, "BIN\\12345678.123", 25);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_Dot_Handling)
+{
+	safe_strcpy(Drives[25]->curdir, "WINDOWS\\CONFIG");
+	assert_DOS_MakeName(".", true, "WINDOWS\\CONFIG", 25);
+	assert_DOS_MakeName("..", true, "WINDOWS", 25);
+	assert_DOS_MakeName("...", true, "", 25);
+	assert_DOS_MakeName(".\\AUTOEXEC.BAT", true,
+	                    "WINDOWS\\CONFIG\\AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("..\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("...\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	safe_strcpy(Drives[25]->curdir, "WINDOWS\\CONFIG\\FOLDER");
+	assert_DOS_MakeName("...\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("....\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	safe_strcpy(Drives[25]->curdir, "WINDOWS\\CONFIG\\FOLDER\\DEEP");
+	assert_DOS_MakeName("....\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName(".....\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	// make sure we can exceed the depth
+	assert_DOS_MakeName("......\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("...........\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+	// make sure we have arbitrary expansion
+	assert_DOS_MakeName("...\\FOLDER\\...\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
+	assert_DOS_MakeName("...\\FOLDER\\....\\.\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_No_SlashSlash)
+{
+	assert_DOS_MakeName("Z:..\\tmp.txt", true, "TMP.TXT", 25);
+}
+
+// Exhaustive test of all good chars
+TEST_F(DOS_FilesTest, DOS_MakeName_GoodChars)
+{
+	unsigned char start_letter = 'A';
+	unsigned char start_number = '0';
+	std::vector<unsigned char> symbols{'$', '#',  '@',  '(',  ')', '!', '%',
+	                                   '{', '}',  '`',  '~',  '_', '-', '.',
+	                                   '*', '?',  '&',  '\'', '+', '^', 246,
+	                                   255, 0xa0, 0xe5, 0xbd, 0x9d};
+	for (unsigned char li = 0; li < 26; li++) {
+		for (unsigned char ni = 0; ni < 10; ni++) {
+			for (auto &c : symbols) {
+				unsigned char input_array[3] = {
+				        static_cast<unsigned char>(start_letter + li),
+				        static_cast<unsigned char>(start_number + ni),
+				        c,
+				};
+				std::string test_input(reinterpret_cast<char *>(
+				                               input_array),
+				                       3);
+				assert_DOS_MakeName(test_input.c_str(), true,
+				                    test_input, 25);
+			}
+		}
+	}
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_Colon_Illegal_Paths)
+{
+	assert_DOS_MakeName(":..\\tmp.txt", false);
+	assert_DOS_MakeName(" :..\\tmp.txt", false);
+	assert_DOS_MakeName(": \\tmp.txt", false);
+	assert_DOS_MakeName(":", false);
 }
 
 } // namespace

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -37,43 +37,55 @@
 
 #include "dos_inc.h"
 
-#include "control.h"
+#include <iostream>
+#include <string>
 
 #include <gtest/gtest.h>
 
-#include <string>
+#include "control.h"
 
 // Open anonymous namespace (this is Google Test requirement)
-
 namespace {
 
-TEST(DOS_MakeName, FailOnNull)
+class DOS_FilesTest : public ::testing::Test {
+public:
+	DOS_FilesTest()
+	        : arg_c_str("-conf tests/files/dosbox-staging-tests.conf\0"),
+	          argv{arg_c_str},
+	          com_line(1, argv),
+	          config(Config(&com_line))
+	{
+		control = &config;
+	}
+
+	void SetUp() override
+	{
+		DOSBOX_Init();
+		_sec = control->GetSection("dosbox");
+		_sec->ExecuteInit();
+	}
+
+private:
+	char const *arg_c_str;
+	const char *argv[1];
+	CommandLine com_line;
+	Config config;
+	Section *_sec;
+};
+
+TEST_F(DOS_FilesTest, DOS_MakeName_FailOnNull)
 {
 	Bit8u drive;
-    char fulldir[DOS_PATHLENGTH];
-    bool result = DOS_MakeName("\0",fulldir,&drive);
-    EXPECT_EQ(false, result);
+	char fulldir[DOS_PATHLENGTH];
+	bool result = DOS_MakeName("\0", fulldir, &drive);
+	EXPECT_EQ(false, result);
 }
 
-TEST(DOS_MakeName, DriveNotFound)
+TEST_F(DOS_FilesTest, DOS_MakeName_DriveNotFound)
 {
-    char arg_c_str[] = "-conf tests/files/dosbox-staging-tests.conf";
-    char *argv[1] = {arg_c_str};
-
-    CommandLine com_line(1,argv);
-    Config myconf(&com_line);
-    control=&myconf;
-    DOSBOX_Init();
-
-    std::cout << "Running control->GetSection('dosbox')...\n";
-    Section *sec = control->GetSection("dosbox");
-    sec->ExecuteInit();
-
 	Bit8u drive;
-    char fulldir[DOS_PATHLENGTH];
-    bool result = DOS_MakeName("N:\\AUTOEXEC.BAT",fulldir,&drive);
-    EXPECT_EQ(false, result);
+	char fulldir[DOS_PATHLENGTH];
+	EXPECT_EQ(false, DOS_MakeName("B:\\AUTOEXEC.BAT", fulldir, &drive));
 }
-
 
 } // namespace

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#define SDL_MAIN_HANDLED
+
 #include "control.h"
 
 class DOSBoxTestFixture : public ::testing::Test {

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -23,6 +23,14 @@ public:
 
 	void SetUp() override
 	{
+		// Create DOSBox Staging's config directory, which is a
+		// pre-requisite that's asserted during the Init process.
+		//
+		CROSS_DetermineConfigPaths();
+		const auto config_path = CROSS_GetPlatformConfigDir();
+		SETUP_ParseConfigFiles(config_path);
+
+		Section *_sec;
 		// This will register all the init functions, but won't run them
 		DOSBOX_Init();
 
@@ -52,7 +60,6 @@ private:
 	const char *argv[1];
 	CommandLine com_line;
 	Config config;
-	Section *_sec;
 	// Only init these sections for our tests
 	std::vector<std::string> sections{"dosbox", "cpu",      "mixer",
 	                                  "midi",   "sblaster", "speaker",

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -1,0 +1,60 @@
+#ifndef DOSBOX_TEST_FIXTURE_H
+#define DOSBOX_TEST_FIXTURE_H
+
+#include <iterator>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "control.h"
+
+class DOSBoxTestFixture : public ::testing::Test {
+public:
+	DOSBoxTestFixture()
+	        : arg_c_str("-conf tests/files/dosbox-staging-tests.conf\0"),
+	          argv{arg_c_str},
+	          com_line(1, argv),
+	          config(Config(&com_line))
+	{
+		control = &config;
+	}
+
+	void SetUp() override
+	{
+		// This will register all the init functions, but won't run them
+		DOSBOX_Init();
+
+		for (auto section_name : sections) {
+			_sec = control->GetSection(section_name);
+			// NOTE: Some of the sections will return null pointers,
+			// if you add a section below, make sure to test for
+			// nullptr before executing early init.
+			_sec->ExecuteEarlyInit();
+		}
+
+		for (auto section_name : sections) {
+			_sec = control->GetSection(section_name);
+			_sec->ExecuteInit();
+		}
+	}
+
+	void TearDown() override
+	{
+		std::vector<std::string>::reverse_iterator r = sections.rbegin();
+		for (; r != sections.rend(); ++r)
+			control->GetSection(*r)->ExecuteDestroy();
+	}
+
+private:
+	char const *arg_c_str;
+	const char *argv[1];
+	CommandLine com_line;
+	Config config;
+	Section *_sec;
+	// Only init these sections for our tests
+	std::vector<std::string> sections{"dosbox", "cpu",      "mixer",
+	                                  "midi",   "sblaster", "speaker",
+	                                  "serial", "dos",      "autoexec"};
+};
+
+#endif

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -87,7 +87,7 @@ TEST(Set_Label, Daggerfall)
     bool cdrom = false;
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
     Set_Label(input.c_str(), output, cdrom);
-    EXPECT_EQ(0, std::string("DAGGERFA.LL").compare(output));
+    EXPECT_EQ("DAGGERFA.LL",std::string(output));
 }
 TEST(Set_Label, DaggerfallCD)
 {
@@ -96,7 +96,7 @@ TEST(Set_Label, DaggerfallCD)
     bool cdrom = true;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("Daggerfa.ll").compare(output));
+    EXPECT_EQ("Daggerfa.ll",std::string(output));
 }
 
 TEST(Set_Label, LongerThan11)
@@ -106,7 +106,7 @@ TEST(Set_Label, LongerThan11)
     bool cdrom = false;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("A1234567.89A").compare(output));
+    EXPECT_EQ("A1234567.89A",std::string(output));
 }
 TEST(Set_Label, LongerThan11CD)
 {
@@ -115,7 +115,7 @@ TEST(Set_Label, LongerThan11CD)
     bool cdrom = true;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("a1234567.89A").compare(output));
+    EXPECT_EQ("a1234567.89A",std::string(output));
 }
 
 TEST(Set_Label, ShorterThan8)
@@ -125,7 +125,7 @@ TEST(Set_Label, ShorterThan8)
     bool cdrom = false;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("A123456").compare(output));
+    EXPECT_EQ("A123456",std::string(output));
 }
 TEST(Set_Label, ShorterThan8CD)
 {
@@ -134,9 +134,11 @@ TEST(Set_Label, ShorterThan8CD)
     bool cdrom = true;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("a123456").compare(output));
+    EXPECT_EQ("a123456",std::string(output));
 }
 
+// Tests that the CD-ROM version adds a trailing dot when
+// input is 8 chars plus one dot (9 chars total)
 TEST(Set_Label, EqualTo8)
 {
     std::string input = "a1234567";
@@ -144,7 +146,7 @@ TEST(Set_Label, EqualTo8)
     bool cdrom = false;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("A1234567").compare(output));
+    EXPECT_EQ("A1234567",std::string(output));
 }
 TEST(Set_Label, EqualTo8CD)
 {
@@ -153,7 +155,47 @@ TEST(Set_Label, EqualTo8CD)
     bool cdrom = true;
     Set_Label(input.c_str(), output, cdrom);
     std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ(0, std::string("a1234567.").compare(output));
+    EXPECT_EQ("a1234567.",std::string(output));
+}
+
+// A test to ensure non-CD-ROM function strips trailing dot
+TEST(Set_Label, StripEndingDot)
+{
+    std::string input = "a1234567.";
+    char output[9] = { 0 };
+    bool cdrom = false;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ("A1234567",std::string(output));
+}
+TEST(Set_Label, NoStripEndingDotCD)
+{
+    std::string input = "a1234567.";
+    char output[9] = { 0 };
+    bool cdrom = true;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ("a1234567.",std::string(output));
+}
+
+// Just to make sure this function doesn't clean invalid DOS labels
+TEST(Set_Label, InvalidCharsEndingDot)
+{
+    std::string input = "?*':&@(..";
+    char output[9] = { 0 };
+    bool cdrom = false;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ("?*':&@(.",std::string(output));
+}
+TEST(Set_Label, InvalidCharsEndingDotCD)
+{
+    std::string input = "?*':&@(..";
+    char output[9] = { 0 };
+    bool cdrom = true;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ("?*':&@(..",std::string(output));
 }
 
 } // namespace

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -41,6 +41,14 @@
 
 #include <string>
 
+std::string run_Set_Label(char const * const input, bool cdrom) {
+    char output[32] = { 0 };
+    Set_Label(input, output, cdrom);
+    std::cout << "Set_Label " << "CD-ROM? " << (cdrom ? 'y' : 'n') << \
+        " Input: " << input << " Output: " << output << '\n';
+    return std::string(output);
+}
+
 // Open anonymous namespace (this is Google Test requirement)
 
 namespace {
@@ -80,122 +88,78 @@ TEST(WildFileCmp, QuestionMark)
     EXPECT_EQ(true, WildFileCmp("TEST", "???T.???"));
 }
 
+/**
+ * Set_Labels tests. These test the conversion of a FAT/CD-ROM volume
+ * label to an MS-DOS 8.3 label with a variety of edge cases & oddities.
+ */
 TEST(Set_Label, Daggerfall)
 {
-    std::string input = "Daggerfall";
-    char output[9] = { 0 };
-    bool cdrom = false;
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    Set_Label(input.c_str(), output, cdrom);
-    EXPECT_EQ("DAGGERFA.LL",std::string(output));
+    std::string output = run_Set_Label("Daggerfall", false);
+    EXPECT_EQ("DAGGERFA.LL", output);
 }
 TEST(Set_Label, DaggerfallCD)
 {
-    std::string input = "Daggerfall";
-    char output[9] = { 0 };
-    bool cdrom = true;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("Daggerfa.ll",std::string(output));
+    std::string output = run_Set_Label("Daggerfall", true);
+    EXPECT_EQ("Daggerfa.ll", output);
 }
 
 TEST(Set_Label, LongerThan11)
 {
-    std::string input = "a123456789AAA";
-    char output[9] = { 0 };
-    bool cdrom = false;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("A1234567.89A",std::string(output));
+    std::string output = run_Set_Label("a123456789AAA", false);
+    EXPECT_EQ("A1234567.89A", output);
 }
 TEST(Set_Label, LongerThan11CD)
 {
-    std::string input = "a123456789AAA";
-    char output[9] = { 0 };
-    bool cdrom = true;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("a1234567.89A",std::string(output));
+    std::string output = run_Set_Label("a123456789AAA", true);
+    EXPECT_EQ("a1234567.89A", output);
 }
 
 TEST(Set_Label, ShorterThan8)
 {
-    std::string input = "a123456";
-    char output[9] = { 0 };
-    bool cdrom = false;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("A123456",std::string(output));
+    std::string output = run_Set_Label("a123456", false);
+    EXPECT_EQ("A123456", output);
 }
 TEST(Set_Label, ShorterThan8CD)
 {
-    std::string input = "a123456";
-    char output[9] = { 0 };
-    bool cdrom = true;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("a123456",std::string(output));
+    std::string output = run_Set_Label("a123456", true);
+    EXPECT_EQ("a123456", output);
 }
 
 // Tests that the CD-ROM version adds a trailing dot when
 // input is 8 chars plus one dot (9 chars total)
 TEST(Set_Label, EqualTo8)
 {
-    std::string input = "a1234567";
-    char output[9] = { 0 };
-    bool cdrom = false;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("A1234567",std::string(output));
+    std::string output = run_Set_Label("a1234567", false);
+    EXPECT_EQ("A1234567", output);
 }
 TEST(Set_Label, EqualTo8CD)
 {
-    std::string input = "a1234567";
-    char output[9] = { 0 };
-    bool cdrom = true;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("a1234567.",std::string(output));
+    std::string output = run_Set_Label("a1234567", true);
+    EXPECT_EQ("a1234567.", output);
 }
 
 // A test to ensure non-CD-ROM function strips trailing dot
 TEST(Set_Label, StripEndingDot)
 {
-    std::string input = "a1234567.";
-    char output[9] = { 0 };
-    bool cdrom = false;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("A1234567",std::string(output));
+    std::string output = run_Set_Label("a1234567.", false);
+    EXPECT_EQ("A1234567", output);
 }
 TEST(Set_Label, NoStripEndingDotCD)
 {
-    std::string input = "a1234567.";
-    char output[9] = { 0 };
-    bool cdrom = true;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("a1234567.",std::string(output));
+    std::string output = run_Set_Label("a1234567.", true);
+    EXPECT_EQ("a1234567.", output);
 }
 
 // Just to make sure this function doesn't clean invalid DOS labels
 TEST(Set_Label, InvalidCharsEndingDot)
 {
-    std::string input = "?*':&@(..";
-    char output[9] = { 0 };
-    bool cdrom = false;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("?*':&@(.",std::string(output));
+    std::string output = run_Set_Label("?*':&@(..", false);
+    EXPECT_EQ("?*':&@(.", output);
 }
 TEST(Set_Label, InvalidCharsEndingDotCD)
 {
-    std::string input = "?*':&@(..";
-    char output[9] = { 0 };
-    bool cdrom = true;
-    Set_Label(input.c_str(), output, cdrom);
-    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
-    EXPECT_EQ("?*':&@(..",std::string(output));
+    std::string output = run_Set_Label("?*':&@(..", true);
+    EXPECT_EQ("?*':&@(..", output);
 }
 
 } // namespace

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -118,4 +118,42 @@ TEST(Set_Label, LongerThan11CD)
     EXPECT_EQ(0, std::string("a1234567.89A").compare(output));
 }
 
+TEST(Set_Label, ShorterThan8)
+{
+    std::string input = "a123456";
+    char output[9] = { 0 };
+    bool cdrom = false;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("A123456").compare(output));
+}
+TEST(Set_Label, ShorterThan8CD)
+{
+    std::string input = "a123456";
+    char output[9] = { 0 };
+    bool cdrom = true;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("a123456").compare(output));
+}
+
+TEST(Set_Label, EqualTo8)
+{
+    std::string input = "a1234567";
+    char output[9] = { 0 };
+    bool cdrom = false;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("A1234567").compare(output));
+}
+TEST(Set_Label, EqualTo8CD)
+{
+    std::string input = "a1234567";
+    char output[9] = { 0 };
+    bool cdrom = true;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("a1234567.").compare(output));
+}
+
 } // namespace

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -80,4 +80,42 @@ TEST(WildFileCmp, QuestionMark)
     EXPECT_EQ(true, WildFileCmp("TEST", "???T.???"));
 }
 
+TEST(Set_Label, Daggerfall)
+{
+    std::string input = "Daggerfall";
+    char output[9] = { 0 };
+    bool cdrom = false;
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    Set_Label(input.c_str(), output, cdrom);
+    EXPECT_EQ(0, std::string("DAGGERFA.LL").compare(output));
+}
+TEST(Set_Label, DaggerfallCD)
+{
+    std::string input = "Daggerfall";
+    char output[9] = { 0 };
+    bool cdrom = true;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("Daggerfa.ll").compare(output));
+}
+
+TEST(Set_Label, LongerThan11)
+{
+    std::string input = "a123456789AAA";
+    char output[9] = { 0 };
+    bool cdrom = false;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("A1234567.89A").compare(output));
+}
+TEST(Set_Label, LongerThan11CD)
+{
+    std::string input = "a123456789AAA";
+    char output[9] = { 0 };
+    bool cdrom = true;
+    Set_Label(input.c_str(), output, cdrom);
+    std::cout << "CD-ROM? " << cdrom << " Input: " << input << " Output: " << output << '\n';
+    EXPECT_EQ(0, std::string("a1234567.89A").compare(output));
+}
+
 } // namespace

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -1,0 +1,83 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* This sample shows how to write a simple unit test for dosbox-staging using
+ * Google C++ testing framework.
+ *
+ * Read Google Test Primer for reference of most available features, macros,
+ * and guidance about writing unit tests:
+ *
+ * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
+ */
+
+/* Include necessary header files; order of headers should be as follows:
+ *
+ * 1. Header declaring functions/classes being tested
+ * 2. <gtest/gtest.h>, which declares the testing framework
+ * 3. Additional system headers (if needed)
+ * 4. Additional dosbox-staging headers (if needed)
+ */
+
+#include "drives.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+// Open anonymous namespace (this is Google Test requirement)
+
+namespace {
+
+TEST(WildFileCmp, ExactMatch)
+{
+    EXPECT_EQ(true, WildFileCmp("TEST.EXE", "TEST.EXE"));
+    EXPECT_EQ(true, WildFileCmp("TEST", "TEST"));
+    EXPECT_EQ(false, WildFileCmp("TEST.EXE", ".EXE"));
+    EXPECT_EQ(true, WildFileCmp(".EXE", ".EXE"));
+}
+
+TEST(WildFileCmp, WildDotWild)
+{
+    EXPECT_EQ(true, WildFileCmp("TEST.EXE", "*.*"));
+    EXPECT_EQ(true, WildFileCmp("TEST", "*.*"));
+    EXPECT_EQ(true, WildFileCmp(".EXE", "*.*"));
+}
+
+TEST(WildFileCmp, WildcardNoExt)
+{
+    EXPECT_EQ(false, WildFileCmp("TEST.EXE", "*"));
+    EXPECT_EQ(false, WildFileCmp(".EXE", "*"));
+    EXPECT_EQ(true, WildFileCmp("TEST", "*"));
+    EXPECT_EQ(true, WildFileCmp("TEST", "T*"));
+    EXPECT_EQ(false, WildFileCmp("TEST", "Z*"));
+}
+
+TEST(WildFileCmp, QuestionMark)
+{
+    EXPECT_EQ(true, WildFileCmp("TEST.EXE", "?EST.EXE"));
+    EXPECT_EQ(true, WildFileCmp("TEST", "?EST"));
+    EXPECT_EQ(false, WildFileCmp("TEST", "???Z"));
+    EXPECT_EQ(true, WildFileCmp("TEST.EXE", "TEST.???"));
+    EXPECT_EQ(true, WildFileCmp("TEST.EXE", "TEST.?XE"));
+    EXPECT_EQ(true, WildFileCmp("TEST.EXE", "???T.EXE"));
+    EXPECT_EQ(true, WildFileCmp("TEST", "???T.???"));
+}
+
+} // namespace

--- a/tests/files/dosbox-staging-tests.conf
+++ b/tests/files/dosbox-staging-tests.conf
@@ -1,0 +1,163 @@
+[sdl]
+fullscreen         = false
+display            = 0
+fullresolution     = desktop
+windowresolution   = default
+window_position    = auto
+window_decorations = true
+vsync              = false
+vsync_skip         = 7000
+max_resolution     = auto
+output             = opengl
+texture_renderer   = auto
+capture_mouse      = seamless middlerelease
+sensitivity        = 100
+raw_mouse_input    = false
+waitonerror        = true
+priority           = auto,auto
+mapperfile         = mapper-sdl2-0.78.0.map
+screensaver        = auto
+
+[dosbox]
+language          = 
+machine           = svga_s3
+captures          = capture
+memsize           = 16
+vmemsize          = auto
+vesa_modes        = compatible
+startup_verbosity = auto
+
+[log]
+logfile     = 
+vga         = true
+vgagfx      = true
+vgamisc     = true
+int10       = true
+sblaster    = true
+dma_control = true
+fpu         = true
+cpu         = true
+paging      = true
+fcb         = true
+files       = true
+ioctl       = true
+exec        = true
+dosmisc     = true
+pit         = true
+keyboard    = true
+pic         = true
+mouse       = true
+bios        = true
+gui         = true
+misc        = true
+io          = true
+pci         = true
+
+[render]
+frameskip          = 0
+aspect             = true
+monochrome_palette = white
+scaler             = none
+glshader           = default
+
+[composite]
+composite   = auto
+era         = auto
+hue         = 0
+saturation  = 100
+contrast    = 100
+brightness  = 0
+convergence = 0
+
+[cpu]
+core      = auto
+cputype   = auto
+cycles    = auto
+cycleup   = 10
+cycledown = 20
+
+[mixer]
+nosound   = false
+rate      = 48000
+blocksize = 512
+prebuffer = 20
+negotiate = true
+
+[midi]
+mididevice = auto
+midiconfig = 
+mpu401     = intelligent
+
+[fluidsynth]
+soundfont = default.sf2
+chorus    = auto
+reverb    = auto
+
+[mt32]
+model  = auto
+romdir = 
+
+[debug]
+
+
+[sblaster]
+sbtype  = sb16
+sbbase  = 220
+irq     = 7
+dma     = 1
+hdma    = 5
+sbmixer = true
+oplmode = auto
+oplemu  = default
+
+[gus]
+gus      = false
+gusbase  = 240
+gusirq   = 5
+gusdma   = 3
+ultradir = C:\ULTRASND
+
+[innovation]
+sidmodel   = none
+sidclock   = default
+sidport    = 280
+6581filter = 50
+8580filter = 50
+
+[speaker]
+pcspeaker   = true
+pcrate      = 18939
+zero_offset = auto
+tandy       = auto
+tandyrate   = 44100
+disney      = true
+ps1audio    = false
+
+[joystick]
+joysticktype  = auto
+timed         = true
+autofire      = false
+swap34        = false
+buttonwrap    = false
+circularinput = false
+deadzone      = 10
+
+[serial]
+serial1       = dummy
+serial2       = dummy
+serial3       = disabled
+serial4       = disabled
+phonebookfile = phonebook.txt
+
+[dos]
+xms            = true
+ems            = true
+umb            = true
+ver            = 5.0
+keyboardlayout = auto
+
+[ipx]
+ipx = false
+
+[autoexec]
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -57,6 +57,7 @@ unit_tests = [
   {'name' : 'support',              'deps' : [libmisc_dep]},
   {'name' : 'drives',               'deps' : [dosbox_dep], 'extra_cpp': []},
   {'name' : 'dos_files',            'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'shell_cmds',           'deps' : [dosbox_dep], 'extra_cpp': []},
 ]
 
 foreach ut : unit_tests

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,7 +20,7 @@ if not (get_option('buildtype') == 'release' and get_option('unit_tests').auto()
                          required : get_option('unit_tests'),
                          fallback : ['gtest', 'gtest_main_dep'])
 
-  gmock_dep = dependency('gmock',
+  gmock_dep = dependency('gmock', main : true,
                          required : get_option('unit_tests'),
                          fallback : ['gtest', 'gmock_dep'])
 endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,13 +46,8 @@ fs_utils = executable('fs_utils', ['fs_utils_tests.cpp', 'stubs.cpp'],
 test('gtest fs_utils', fs_utils,
      workdir : project_source_root, is_parallel : false)
 
-drives = executable('drives', ['drives_tests.cpp'],
-                      dependencies : [gtest_dep, dosbox_dep],
-                      include_directories : incdir)
-test('gtest drives', drives, workdir : project_source_root, is_parallel : false)
-
 # other unit tests
-#
+
 unit_tests = [
   {'name' : 'iohandler_containers', 'deps' : [libmisc_dep]},
   {'name' : 'rwqueue',              'deps' : [libmisc_dep]},
@@ -60,11 +55,14 @@ unit_tests = [
   {'name' : 'string_utils',         'deps' : []},
   {'name' : 'setup',                'deps' : [stdcppfs_dep, libmisc_dep]},
   {'name' : 'support',              'deps' : [libmisc_dep]},
+  {'name' : 'drives',               'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'dos_files',            'deps' : [dosbox_dep], 'extra_cpp': []},
 ]
 
 foreach ut : unit_tests
   name = ut.get('name')
-  exe = executable(name, [name + '_tests.cpp', 'stubs.cpp'],
+  extra_cpp = ut.get('extra_cpp', ['stubs.cpp'])
+  exe = executable(name, [name + '_tests.cpp'] + extra_cpp,
                    dependencies : [gmock_dep, gtest_dep, libloguru_dep] + ut.get('deps'),
                    include_directories : incdir)
   test('gtest ' + name, exe)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,6 +29,16 @@ if not (gtest_dep.found() or gmock_dep.found())
   gmock_dep = disabler()
 endif
 
+# Disable compiler flags that generate warnings
+# from deliberately flawed unit test code.
+#
+cpp_args = []
+foreach false_positive_flag : ['-Wno-effc++', '-Wno-gnu-zero-variadic-macro-arguments']
+  if cxx.has_argument(false_positive_flag)
+    cpp_args += false_positive_flag
+  endif
+endforeach
+
 # unit tests with specific requirements
 #
 # - example  - has a failing testcase (on purpose)
@@ -36,13 +46,13 @@ endif
 #
 example = executable('example', ['example_tests.cpp', 'stubs.cpp'],
                      dependencies : [gmock_dep, gtest_dep, libmisc_dep, libloguru_dep],
-                     include_directories : incdir)
+                     include_directories : incdir, cpp_args : cpp_args)
 test('gtest example', example, 
      should_fail : true)
 
 fs_utils = executable('fs_utils', ['fs_utils_tests.cpp', 'stubs.cpp'],
                       dependencies : [gmock_dep, gtest_dep, libmisc_dep, libloguru_dep],
-                      include_directories : incdir)
+                      include_directories : incdir, cpp_args : cpp_args)
 test('gtest fs_utils', fs_utils,
      workdir : project_source_root, is_parallel : false)
 
@@ -55,9 +65,9 @@ unit_tests = [
   {'name' : 'string_utils',         'deps' : []},
   {'name' : 'setup',                'deps' : [stdcppfs_dep, libmisc_dep]},
   {'name' : 'support',              'deps' : [libmisc_dep]},
-  {'name' : 'drives',               'deps' : [dosbox_dep], 'extra_cpp': []},
-  {'name' : 'dos_files',            'deps' : [dosbox_dep], 'extra_cpp': []},
-  {'name' : 'shell_cmds',           'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'drives',               'deps' : [dosbox_dep, stdcppfs_dep], 'extra_cpp': []},
+  {'name' : 'dos_files',            'deps' : [dosbox_dep, stdcppfs_dep], 'extra_cpp': []},
+  {'name' : 'shell_cmds',           'deps' : [dosbox_dep, stdcppfs_dep], 'extra_cpp': []},
 ]
 
 foreach ut : unit_tests
@@ -65,6 +75,6 @@ foreach ut : unit_tests
   extra_cpp = ut.get('extra_cpp', ['stubs.cpp'])
   exe = executable(name, [name + '_tests.cpp'] + extra_cpp,
                    dependencies : [gmock_dep, gtest_dep, libloguru_dep] + ut.get('deps'),
-                   include_directories : incdir)
+                   include_directories : incdir, cpp_args : cpp_args)
   test('gtest ' + name, exe)
 endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,6 +46,10 @@ fs_utils = executable('fs_utils', ['fs_utils_tests.cpp', 'stubs.cpp'],
 test('gtest fs_utils', fs_utils,
      workdir : project_source_root, is_parallel : false)
 
+drives = executable('drives', ['drives_tests.cpp'],
+                      dependencies : [gtest_dep, dosbox_dep],
+                      include_directories : incdir)
+test('gtest drives', drives, workdir : project_source_root, is_parallel : false)
 
 # other unit tests
 #

--- a/tests/shell_cmds_tests.cpp
+++ b/tests/shell_cmds_tests.cpp
@@ -69,6 +69,10 @@ public:
 	 * }
 	 */
 	MOCK_METHOD(bool, execute_shell_cmd, (char *name, char *arguments), (override));
+	MOCK_METHOD(void,
+	            WriteOut,
+	            (const char *format, const char *arguments),
+	            (override));
 
 private:
 	DOS_Shell real_; // Keeps an instance of the real in the mock.
@@ -147,6 +151,45 @@ TEST_F(DOS_Shell_CMDSTest, DoCommand_Nospace_Slash_Handling)
 {
 	assert_DoCommand("CD\\DIRECTORY", "CD", "\\DIRECTORY");
 	assert_DoCommand("CD\\", "CD", "\\");
+}
+
+TEST_F(DOS_Shell_CMDSTest, CMD_ECHO_off_on)
+{
+	MockDOS_Shell shell;
+	EXPECT_TRUE(shell.echo); // should be the default
+	EXPECT_CALL(shell, WriteOut(_, _)).Times(0);
+	EXPECT_NO_THROW({ shell.CMD_ECHO(const_cast<char *>("OFF")); });
+	EXPECT_FALSE(shell.echo);
+	EXPECT_NO_THROW({ shell.CMD_ECHO(const_cast<char *>("ON")); });
+	EXPECT_TRUE(shell.echo);
+}
+
+TEST_F(DOS_Shell_CMDSTest, CMD_ECHO_space_handling)
+{
+	MockDOS_Shell shell;
+
+	EXPECT_TRUE(shell.echo);
+	EXPECT_CALL(shell, WriteOut(_, StrEq("OFF "))).Times(1);
+	// this DOES NOT trigger ECHO OFF (trailing space causes it to not)
+	EXPECT_NO_THROW({ shell.CMD_ECHO(const_cast<char *>(" OFF ")); });
+	EXPECT_TRUE(shell.echo);
+
+	EXPECT_CALL(shell, WriteOut(_, StrEq("FF "))).Times(1);
+	// this DOES NOT trigger ECHO OFF (initial 'O' gets stripped)
+	EXPECT_NO_THROW({ shell.CMD_ECHO(const_cast<char *>("OFF ")); });
+	EXPECT_TRUE(shell.echo);
+
+	// no trailing space, echo off should work
+	EXPECT_CALL(shell, WriteOut(_, _)).Times(0);
+	EXPECT_NO_THROW({ shell.CMD_ECHO(const_cast<char *>(" OFF")); });
+	// check that OFF worked properly, despite spaces
+	EXPECT_FALSE(shell.echo);
+
+	// NOTE: the expected string here is missing the leading char of the
+	// input to ECHO. the first char is stripped as it's assumed it will be
+	// a space, period or slash.
+	EXPECT_CALL(shell, WriteOut(_, StrEq("    HI "))).Times(1);
+	EXPECT_NO_THROW({ shell.CMD_ECHO(const_cast<char *>(".    HI ")); });
 }
 
 } // namespace

--- a/tests/shell_cmds_tests.cpp
+++ b/tests/shell_cmds_tests.cpp
@@ -1,0 +1,110 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* This sample shows how to write a simple unit test for dosbox-staging using
+ * Google C++ testing framework.
+ *
+ * Read Google Test Primer for reference of most available features, macros,
+ * and guidance about writing unit tests:
+ *
+ * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
+ */
+
+/* Include necessary header files; order of headers should be as follows:
+ *
+ * 1. Header declaring functions/classes being tested
+ * 2. <gtest/gtest.h>, which declares the testing framework
+ * 3. Additional system headers (if needed)
+ * 4. Additional dosbox-staging headers (if needed)
+ */
+
+#include "shell.h"
+
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "dosbox_test_fixture.h"
+#include "../src/shell/shell_cmds.cpp"
+
+namespace {
+
+using namespace testing;
+
+class DOS_Shell_CMDSTest : public DOSBoxTestFixture {};
+
+class MockDOS_Shell : public DOS_Shell {
+	public:
+		/*
+		 * NOTE: If we need to call the actual object, we use this
+		MockDOS_Shell() {
+			// delegate call to the real object.
+			ON_CALL(*this, execute_shell_cmd).WillByDefault([this](char *name, char *arguments) {
+				std::cout << "CALLING REAL execute_shell_cmd!\n";
+				return real_.execute_shell_cmd(name, arguments);
+			});
+		}
+		*/
+		MOCK_METHOD(bool, execute_shell_cmd, (char *name, char *arguments), (override));
+
+	private:
+		DOS_Shell real_;  // Keeps an instance of the real in the mock.
+};
+
+TEST_F(DOS_Shell_CMDSTest, DoCommand_Basic_Rejections)
+{
+	MockDOS_Shell shell;
+	std::string line = "\t";
+	char * line_c_str = const_cast<char *>(line.c_str());
+	EXPECT_NO_THROW({
+		shell.DoCommand(line_c_str);
+	});
+	EXPECT_CALL(shell, execute_shell_cmd(_, _)).Times(0);
+}
+
+TEST_F(DOS_Shell_CMDSTest, DoCommand_Splits_Cmd_and_Args)
+{
+	std::string input = "DIR *.*";
+	char * input_c_str = const_cast<char *>(input.c_str());
+
+	MockDOS_Shell shell;
+	EXPECT_CALL(shell, execute_shell_cmd(StrEq("DIR"), StrEq(" *.*"))).Times(1);
+	EXPECT_NO_THROW({
+		shell.DoCommand(input_c_str);
+	});
+}
+
+TEST_F(DOS_Shell_CMDSTest, DoCommand_All_Cmds_Do_Valid_Execute)
+{
+	MockDOS_Shell shell;
+	for (std::pair<std::string, SHELL_Cmd> cmd : shell_cmds) {
+		std::string input = cmd.first;
+		char * input_c_str = const_cast<char *>(input.c_str());
+
+		MockDOS_Shell shell;
+		EXPECT_CALL(shell, execute_shell_cmd(StrEq(input), StrEq(""))).Times(1);
+		EXPECT_NO_THROW({
+			shell.DoCommand(input_c_str);
+		});
+	}
+}
+
+} // namespace


### PR DESCRIPTION
This improves the unit test suite, adding a fixture that cleanly sets up & tears down DOSBox, mocks and adds unit tests around many of the files/drives/shell functions. This is a WIP, intended to be an example for further tests and also defining the expected functionality required to enable refactoring of these parts of the codebase (a pattern that hopefully will be replicated elsewhere).

Most of the changes are located inside the `tests/` directory, but some changes were required to DOSBox itself to allow testing. I tried to keep these minimal.