### PR TITLE
Improve MSYS2 compilation support, add to GH actions

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -1,0 +1,136 @@
+name: Windows Meson MSYS2 builds
+
+on: [push, pull_request]
+
+jobs:
+  build_win_meson_msys2_release:
+    name: ${{ matrix.conf.name }}
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,shermp', github.actor) == false
+    
+    strategy:
+      matrix:
+        conf:
+          - name: Meson MinGW 32-bit
+            arch: i686
+            sys: MINGW32
+          - name: Meson MinGW 64-bit
+            arch: x86_64
+            sys: MINGW64
+    
+    defaults:
+      run:
+        shell: msys2 {0}
+    
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.conf.sys}}
+          update: true
+          install: >-
+            git
+            mingw-w64-${{matrix.conf.arch}}-meson
+            mingw-w64-${{matrix.conf.arch}}-gcc
+            mingw-w64-${{matrix.conf.arch}}-ccache
+            mingw-w64-${{matrix.conf.arch}}-pkgconf
+            mingw-w64-${{matrix.conf.arch}}-ntldd
+            mingw-w64-${{matrix.conf.arch}}-ncurses
+            mingw-w64-${{matrix.conf.arch}}-glib2
+            mingw-w64-${{matrix.conf.arch}}-fluidsynth
+            mingw-w64-${{matrix.conf.arch}}-munt-mt32emu
+            mingw-w64-${{matrix.conf.arch}}-libpng
+            mingw-w64-${{matrix.conf.arch}}-opusfile
+            mingw-w64-${{matrix.conf.arch}}-SDL2
+            mingw-w64-${{matrix.conf.arch}}-SDL2_net
+            mingw-w64-${{matrix.conf.arch}}-zlib
+      
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+
+      - name: Inject version string
+        run: |
+          set -x
+          git fetch --prune --unshallow
+          export VERSION=$(git describe --abbrev=5)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      
+      - name: Setup release build
+        run: |
+          meson setup \
+            -Dbuildtype=release \
+            -Ddefault_library=static \
+            -Db_asneeded=true \
+            -Dtry_static_libs=png,opusfile \
+            build
+      
+      - name: Build
+        run: ninja -C build
+
+      - name: Strip binary
+        run: strip build/dosbox.exe
+      
+      - name: Package
+        run: |
+          set -x
+          mkdir -p dest/doc
+
+          cp build/dosbox.exe      dest/
+          cp COPYING               dest/COPYING.txt
+          cp docs/README.template  dest/README.txt
+          cp docs/README.video     dest/doc/video.txt
+          cp README                dest/doc/manual.txt
+
+
+          # The list of required dll files and their source paths can be found using ntldd
+          for lib in $(ntldd -R dest/dosbox.exe | sed -e 's/^[[:blank:]]*//g' | cut -d ' ' -f 3 | grep -E -i 'mingw(32|64)' | sed -e 's|\\|/|g'); do 
+            cp "$lib" dest/
+          done
+
+          # Prepare translation files
+          #
+          # Note:
+          #   We conciously drop the dialect postfix because no dialects are available.
+          #   (US was the default DOS dialect and therefore is the default for 'en').
+          #   There users get the generic translation and benefit from simpler filenames.
+          #   Dialect translations will be added if/when they're available.
+          #
+          mkdir -p dest/translations
+          cp contrib/translations/de/de_DE.lng       dest/translations/de.lng
+          cp contrib/translations/en/en_US.lng       dest/translations/en.lng
+          cp contrib/translations/es/es_ES.lng       dest/translations/es.lng
+          cp contrib/translations/fr/fr_FR.lng       dest/translations/fr.lng
+          cp contrib/translations/it/it_IT.lng       dest/translations/it.lng
+          cp contrib/translations/pl/pl_PL.CP437.lng dest/translations/pl.cp437.lng
+          cp contrib/translations/pl/pl_PL.lng       dest/translations/pl.lng
+          cp contrib/translations/ru/ru_RU.lng       dest/translations/ru.lng
+
+          # Fill README template file
+          sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README.txt
+          sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README.txt
+          sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
+
+          # Create dir for zipping
+          mv dest dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
+      
+      - name: Windows Defender AV Scan
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}"
+          & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
+          if( $LASTEXITCODE -ne 0 ) {
+              Get-Content -Path $env:TEMP\MpCmdRun.log
+              Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
+          }
+
+      - name: Upload package
+        uses: actions/upload-artifact@v2
+        with:
+          name: dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          path: dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -1,4 +1,4 @@
-name: Windows Meson MSYS2 builds
+name: MSYS2 builds
 
 on: [push, pull_request]
 

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: Meson MinGW 32-bit
+          - name: GCC (MinGW) x86
             arch: i686
             sys: MINGW32
-          - name: Meson MinGW 64-bit
+          - name: GCC (MinGW) x86_64
             arch: x86_64
             sys: MINGW64
     
@@ -88,9 +88,12 @@ jobs:
 
 
           # The list of required dll files and their source paths can be found using ntldd
-          for lib in $(ntldd -R dest/dosbox.exe | sed -e 's/^[[:blank:]]*//g' | cut -d ' ' -f 3 | grep -E -i 'mingw(32|64)' | sed -e 's|\\|/|g'); do 
-            cp "$lib" dest/
-          done
+          ntldd -R dest/dosbox.exe \
+            | sed -e 's/^[[:blank:]]*//g' \
+            | cut -d ' ' -f 3 \
+            | grep -E -i 'mingw(32|64)' \
+            | sed -e 's|\\|/|g' \
+            | xargs cp --target-directory=dest/
 
           # Prepare translation files
           #

--- a/include/cross.h
+++ b/include/cross.h
@@ -52,7 +52,7 @@
 #define CROSS_FILE	1
 #define CROSS_DIR	2
 
-#if defined (WIN32)
+#if defined (WIN32) && !defined (__MINGW32__)
 #define ftruncate(blah,blah2) chsize(blah,blah2)
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -367,7 +367,16 @@ subdir('tests')
 # dosbox executable
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
-executable('dosbox', ['src/main.cpp', 'src/dosbox.cpp', version_file],
+dosbox_sources = ['src/main.cpp', 'src/dosbox.cpp', version_file]
+
+# Add Windows resources file if building on Windows
+if host_machine.system() == 'windows'
+  winmod = import('windows')
+  res_file = winmod.compile_resources('src/winres.rc')
+  dosbox_sources += res_file
+endif
+
+executable('dosbox', dosbox_sources,
            dependencies : [atomic_dep,
                            stdcppfs_dep,
                            sdl2_dep,

--- a/meson.build
+++ b/meson.build
@@ -251,7 +251,7 @@ if get_option('use_slirp') # disabled by default
 endif
 
 if get_option('enable_debugger') != 'none'
-  curses_dep = dependency('ncurses') # or pdcurses on Windows
+  curses_dep = dependency('curses') # use the new 'curses' for msys2 compatibility
 endif
 
 # macOS-only dependencies

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -35,7 +35,7 @@ endif
 # - fs_utils - depends on files in: tests/files/
 #
 example = executable('example', ['example_tests.cpp', 'stubs.cpp'],
-                     dependencies : [gmock_dep, gtest_dep, sdl2_dep, libmisc_dep, libloguru_dep],
+                     dependencies : [gmock_dep, gtest_dep, libmisc_dep, libloguru_dep],
                      include_directories : incdir)
 test('gtest example', example, 
      should_fail : true)
@@ -52,10 +52,10 @@ test('gtest fs_utils', fs_utils,
 unit_tests = [
   {'name' : 'iohandler_containers', 'deps' : [libmisc_dep]},
   {'name' : 'rwqueue',              'deps' : [libmisc_dep]},
-  {'name' : 'soft_limiter',         'deps' : [atomic_dep, sdl2_dep, libmisc_dep]},
+  {'name' : 'soft_limiter',         'deps' : [atomic_dep, libmisc_dep]},
   {'name' : 'string_utils',         'deps' : []},
-  {'name' : 'setup',                'deps' : [stdcppfs_dep, sdl2_dep, libmisc_dep]},
-  {'name' : 'support',              'deps' : [sdl2_dep, libmisc_dep]},
+  {'name' : 'setup',                'deps' : [stdcppfs_dep, libmisc_dep]},
+  {'name' : 'support',              'deps' : [libmisc_dep]},
 ]
 
 foreach ut : unit_tests


### PR DESCRIPTION
This PR improves support for compiling dosbox-staging on MSYS2. It also adds a basic GH action to create builds.

Subsequent PR's can improve the workflow including better caching, unit tests, warnings support, debug builds etc.