### PR TITLE
Add extra MSYS2 builds to CI, implement ccache

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -58,6 +58,12 @@ jobs:
         shell: msys2 {0}
     
     steps:
+      - name: Disable git line ending conversion
+        shell: powershell
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - name: Checkout repository
         uses: actions/checkout@v2
       
@@ -151,6 +157,12 @@ jobs:
         shell: msys2 {0}
    
     steps:
+      - name: Disable git line ending conversion
+        shell: powershell
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -11,7 +11,126 @@ env:
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
 
-jobs:          
+jobs:
+  build_msys2:
+    name: ${{ matrix.conf.name }}
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,shermp', github.actor) == false
+
+    strategy:
+      matrix:
+        conf:
+          - name: GCC (MinGW) x86
+            toolchain: ""
+            arch: i686
+            sys: MINGW32
+            max_warnings: 19
+          - name: GCC (MinGW) x86_64
+            toolchain: ""
+            arch: x86_64
+            sys: MINGW64
+            max_warnings: 19
+          - name: Clang x86
+            toolchain: clang-
+            arch: i686
+            sys: CLANG32
+            max_warnings: 19
+          - name: Clang x86_64
+            toolchain: clang-
+            arch: x86_64
+            sys: CLANG64
+            max_warnings: 19
+          - name: GCC +tests
+            toolchain: ""
+            arch: x86_64
+            sys: MINGW64
+            run_tests: true
+            max_warnings: -1
+          - name: GCC +debugger
+            toolchain: ""
+            arch: x86_64
+            sys: MINGW64
+            max_warnings: 21
+            build_flags: -Denable_debugger=normal
+    
+    defaults:
+      run:
+        shell: msys2 {0}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.conf.sys}}
+          update: true
+          install: >-
+            git
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-gcc
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-python
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-fluidsynth
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-munt-mt32emu
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib
+      
+      - name:  Prepare compiler cache
+        id:    prep-ccache
+        shell: bash
+        run: |
+          mkdir -p "${CCACHE_DIR}"
+          echo "::set-output name=dir::$CCACHE_DIR"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+          echo "::set-output name=name_hash::$(echo '${{ matrix.conf.name }}' | shasum | cut -b-8)"
+
+      - uses:  actions/cache@v2
+        id:    cache-ccache
+        with:
+          path: ${{ steps.prep-ccache.outputs.dir }}
+          key:  ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.today }}-1
+          restore-keys: |
+            ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}-1
+
+      - name:  Cache subprojects
+        uses:  actions/cache@v2
+        with:
+          path: subprojects/packagecache
+          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}
+
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+
+      - name: Setup build
+        run: |
+          meson setup ${{ matrix.conf.build_flags }} build
+      
+      - name: Build
+        run: |
+          set -xo pipefail
+          ninja -C build |& tee build.log
+          ccache -s
+      
+      - name: Run tests
+        if:   matrix.conf.run_tests
+        run:  meson test -C build --print-errorlogs
+
+      - name: Summarize warnings
+        if:   matrix.conf.run_tests != true
+        env:
+          MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
+        run:  python ./scripts/count-warnings.py -lf build.log
+
   build_msys2_release:
     name: ${{ matrix.conf.name }}
     runs-on: windows-latest

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -30,11 +30,11 @@ jobs:
             arch: x86_64
             sys: MINGW64
             max_warnings: 19
-          - name: Clang x86
-            toolchain: clang-
-            arch: i686
-            sys: CLANG32
-            max_warnings: 19
+          # - name: Clang x86
+          #   toolchain: clang-
+          #   arch: i686
+          #   sys: CLANG32
+          #   max_warnings: 19
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CCACHE_DIR:      "/tmp/.ccache"
+  CCACHE_DIR:      "/c/ccache"
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
 
@@ -92,10 +92,9 @@ jobs:
       
       - name:  Prepare compiler cache
         id:    prep-ccache
-        shell: bash
         run: |
           mkdir -p "${CCACHE_DIR}"
-          echo "::set-output name=dir::$CCACHE_DIR"
+          echo "::set-output name=dir::C:\ccache"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
           echo "::set-output name=name_hash::$(echo '${{ matrix.conf.name }}' | shasum | cut -b-8)"
@@ -104,9 +103,9 @@ jobs:
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.today }}-1
+          key:  ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.today }}-2
           restore-keys: |
-            ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}-1
+            ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}-2
 
       - name:  Cache subprojects
         uses:  actions/cache@v2
@@ -194,7 +193,7 @@ jobs:
         id:    prep-ccache
         run: |
           mkdir -p "${CCACHE_DIR}"
-          echo "::set-output name=dir::$CCACHE_DIR"
+          echo "::set-output name=dir::C:\ccache"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
 
@@ -202,9 +201,9 @@ jobs:
         id:    cache-ccache
         with:
           path: ${{ steps.prep-ccache.outputs.dir }}
-          key:  ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.today }}-1
+          key:  ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.today }}-2
           restore-keys: |
-            ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.yesterday }}-1
+            ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.yesterday }}-2
 
       - name:  Cache subprojects
         uses:  actions/cache@v2

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -11,8 +11,8 @@ env:
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
 
-jobs:
-  build_win_meson_msys2_release:
+jobs:          
+  build_msys2_release:
     name: ${{ matrix.conf.name }}
     runs-on: windows-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,shermp', github.actor) == false
@@ -30,7 +30,7 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
-    
+   
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
@@ -91,6 +91,12 @@ jobs:
           export VERSION=$(git describe --abbrev=5)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       
+      - name: Set dest dir names
+        run: |
+          set -x
+          echo PKG_DEST_DIR=dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }} >> $GITHUB_ENV
+          echo PKG_DEST_DIR_DEBUGGER=dosbox-staging-windows-msys2-debugger-${{ matrix.conf.arch }}-${{ env.VERSION }} >> $GITHUB_ENV
+      
       - name: Setup release build
         run: |
           meson setup \
@@ -106,25 +112,50 @@ jobs:
       - name: Strip binary
         run: strip build/dosbox.exe
       
-      - name: Package
+      - name: Stage release binary
+        run: |
+          set -x
+          mkdir -p ${{ env.PKG_DEST_DIR }}/
+          cp build/dosbox.exe ${{ env.PKG_DEST_DIR }}/
+          ntldd -R ${{ env.PKG_DEST_DIR }}/dosbox.exe \
+            | sed -e 's/^[[:blank:]]*//g' \
+            | cut -d ' ' -f 3 \
+            | grep -E -i '(mingw|clang)(32|64)' \
+            | sed -e 's|\\|/|g' \
+            | xargs cp --target-directory=${{ env.PKG_DEST_DIR }}/
+      
+      - name: Setup release build w/ debugger
+        run: |
+          meson configure \
+            -Denable_debugger=normal \
+            build
+      
+      - name: Build w/ debugger
+        run: ninja -C build
+
+      - name: Strip debugger binary
+        run: strip build/dosbox.exe
+      
+      - name: Stage release binary w/ debugger
+        run: |
+          set -x
+          mkdir -p ${{ env.PKG_DEST_DIR_DEBUGGER }}/
+          cp build/dosbox.exe ${{ env.PKG_DEST_DIR_DEBUGGER }}/
+          ntldd -R ${{ env.PKG_DEST_DIR_DEBUGGER }}/dosbox.exe \
+            | sed -e 's/^[[:blank:]]*//g' \
+            | cut -d ' ' -f 3 \
+            | grep -E -i '(mingw|clang)(32|64)' \
+            | sed -e 's|\\|/|g' \
+            | xargs cp --target-directory=${{ env.PKG_DEST_DIR_DEBUGGER }}/
+      
+      - name: Setup common package dir
         run: |
           set -x
           mkdir -p dest/doc
-
-          cp build/dosbox.exe      dest/
           cp COPYING               dest/COPYING.txt
           cp docs/README.template  dest/README.txt
           cp docs/README.video     dest/doc/video.txt
           cp README                dest/doc/manual.txt
-
-
-          # The list of required dll files and their source paths can be found using ntldd
-          ntldd -R dest/dosbox.exe \
-            | sed -e 's/^[[:blank:]]*//g' \
-            | cut -d ' ' -f 3 \
-            | grep -E -i 'mingw(32|64)' \
-            | sed -e 's|\\|/|g' \
-            | xargs cp --target-directory=dest/
 
           # Prepare translation files
           #
@@ -150,21 +181,40 @@ jobs:
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
 
           # Create dir for zipping
-          mv dest dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
+      
+      - name: Package release
+        run: |
+            set -x
+            cp -r dest/. ${PKG_DEST_DIR}/
+      
+      - name: Package release w/ debugger
+        run: |
+            set -x
+            cp -r dest/. ${{ env.PKG_DEST_DIR_DEBUGGER }}/
+          
       
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}"
-          & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
-          if( $LASTEXITCODE -ne 0 ) {
-              Get-Content -Path $env:TEMP\MpCmdRun.log
-              Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
+          $dosboxDirs = "${{ github.workspace }}\${{ env.PKG_DEST_DIR }}", "${{ github.workspace }}\${{ env.PKG_DEST_DIR_DEBUGGER }}"
+          foreach ($dosboxDir in $dosboxDirs)
+          {
+            & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
+            if( $LASTEXITCODE -ne 0 ) {
+                Get-Content -Path $env:TEMP\MpCmdRun.log
+                Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
+            }
           }
 
-      - name: Upload package
+      - name: Upload release package
         uses: actions/upload-artifact@v2
         with:
-          name: dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
-          path: dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          name: ${{ env.PKG_DEST_DIR }}
+          path: ${{ env.PKG_DEST_DIR }}
+
+      - name: Upload debugger package
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PKG_DEST_DIR_DEBUGGER }}
+          path: ${{ env.PKG_DEST_DIR_DEBUGGER }}

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -6,6 +6,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CCACHE_DIR:      "/tmp/.ccache"
+  CCACHE_MAXSIZE:  "64M"
+  CCACHE_COMPRESS: "true"
+
 jobs:
   build_win_meson_msys2_release:
     name: ${{ matrix.conf.name }}
@@ -53,6 +58,28 @@ jobs:
             mingw-w64-${{matrix.conf.arch}}-SDL2
             mingw-w64-${{matrix.conf.arch}}-SDL2_net
             mingw-w64-${{matrix.conf.arch}}-zlib
+      
+      - name:  Prepare compiler cache
+        id:    prep-ccache
+        run: |
+          mkdir -p "${CCACHE_DIR}"
+          echo "::set-output name=dir::$CCACHE_DIR"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
+
+      - uses:  actions/cache@v2
+        id:    cache-ccache
+        with:
+          path: ${{ steps.prep-ccache.outputs.dir }}
+          key:  ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.today }}-1
+          restore-keys: |
+            ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.yesterday }}-1
+
+      - name:  Cache subprojects
+        uses:  actions/cache@v2
+        with:
+          path: subprojects/packagecache
+          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-1
       
       - name: Log environment
         run:  ./scripts/log-env.sh

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -132,7 +132,7 @@ jobs:
         run:  python ./scripts/count-warnings.py -lf build.log
 
   build_msys2_release:
-    name: ${{ matrix.conf.name }}
+    name: ${{ matrix.conf.name }} Release
     runs-on: windows-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,shermp', github.actor) == false
     

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -2,6 +2,10 @@ name: MSYS2 builds
 
 on: [push, pull_request]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_win_meson_msys2_release:
     name: ${{ matrix.conf.name }}

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -10,6 +10,9 @@ env:
   CCACHE_DIR:      "/c/ccache"
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
+  BUILD_FLAGS: "-Dbuildtype=release -Ddefault_library=static -Db_asneeded=true -Dtry_static_libs=png,opusfile"
+  BUILD_RELEASE_DIR: build/release
+  BUILD_DEBUGGER_DIR: build/debugger
 
 jobs:
   build_msys2:
@@ -94,7 +97,7 @@ jobs:
         id:    prep-ccache
         run: |
           mkdir -p "${CCACHE_DIR}"
-          echo "::set-output name=dir::C:\ccache"
+          echo "::set-output name=dir::$(cygpath -w $CCACHE_DIR)"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
           echo "::set-output name=name_hash::$(echo '${{ matrix.conf.name }}' | shasum | cut -b-8)"
@@ -193,7 +196,7 @@ jobs:
         id:    prep-ccache
         run: |
           mkdir -p "${CCACHE_DIR}"
-          echo "::set-output name=dir::C:\ccache"
+          echo "::set-output name=dir::$(cygpath -w $CCACHE_DIR)"
           echo "::set-output name=today::$(date -I)"
           echo "::set-output name=yesterday::$(date --date=yesterday -I)"
 
@@ -220,64 +223,39 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=5)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      
-      - name: Set dest dir names
-        run: |
-          set -x
-          echo PKG_DEST_DIR=dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }} >> $GITHUB_ENV
-          echo PKG_DEST_DIR_DEBUGGER=dosbox-staging-windows-msys2-debugger-${{ matrix.conf.arch }}-${{ env.VERSION }} >> $GITHUB_ENV
-      
+           
       - name: Setup release build
-        run: |
-          meson setup \
-            -Dbuildtype=release \
-            -Ddefault_library=static \
-            -Db_asneeded=true \
-            -Dtry_static_libs=png,opusfile \
-            build
+        run: meson setup $BUILD_FLAGS $BUILD_RELEASE_DIR
+
+      - name: Setup release w/ debugger build
+        run: meson setup $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
       
       - name: Build
-        run: ninja -C build
-
-      - name: Strip binary
-        run: strip build/dosbox.exe
-      
-      - name: Stage release binary
-        run: |
-          set -x
-          mkdir -p ${{ env.PKG_DEST_DIR }}/
-          cp build/dosbox.exe ${{ env.PKG_DEST_DIR }}/
-          ntldd -R ${{ env.PKG_DEST_DIR }}/dosbox.exe \
-            | sed -e 's/^[[:blank:]]*//g' \
-            | cut -d ' ' -f 3 \
-            | grep -E -i '(mingw|clang)(32|64)' \
-            | sed -e 's|\\|/|g' \
-            | xargs cp --target-directory=${{ env.PKG_DEST_DIR }}/
-      
-      - name: Setup release build w/ debugger
-        run: |
-          meson configure \
-            -Denable_debugger=normal \
-            build
+        run: ninja -C $BUILD_RELEASE_DIR
       
       - name: Build w/ debugger
-        run: ninja -C build
-
-      - name: Strip debugger binary
-        run: strip build/dosbox.exe
+        run: ninja -C $BUILD_DEBUGGER_DIR
       
-      - name: Stage release binary w/ debugger
+      - name: Stage binaries
         run: |
           set -x
-          mkdir -p ${{ env.PKG_DEST_DIR_DEBUGGER }}/
-          cp build/dosbox.exe ${{ env.PKG_DEST_DIR_DEBUGGER }}/
-          ntldd -R ${{ env.PKG_DEST_DIR_DEBUGGER }}/dosbox.exe \
-            | sed -e 's/^[[:blank:]]*//g' \
-            | cut -d ' ' -f 3 \
-            | grep -E -i '(mingw|clang)(32|64)' \
-            | sed -e 's|\\|/|g' \
-            | xargs cp --target-directory=${{ env.PKG_DEST_DIR_DEBUGGER }}/
-      
+          for bin_dir in $BUILD_RELEASE_DIR $BUILD_DEBUGGER_DIR; do
+            mkdir -p stage/${bin_dir}
+            cp ${bin_dir}/dosbox.exe stage/${bin_dir}/
+            ntldd -R stage/${bin_dir}/dosbox.exe \
+              | sed -e 's/^[[:blank:]]*//g' \
+              | cut -d ' ' -f 3 \
+              | grep -E -i '(mingw|clang)(32|64)' \
+              | sed -e 's|\\|/|g' \
+              | xargs cp --target-directory=stage/${bin_dir}/
+          done
+
+      - name: Strip binaries
+        run: |
+          for bin_dir in $BUILD_RELEASE_DIR $BUILD_DEBUGGER_DIR; do
+            strip stage/${bin_dir}/dosbox.exe
+          done
+            
       - name: Setup common package dir
         run: |
           set -x
@@ -312,22 +290,17 @@ jobs:
 
           # Create dir for zipping
       
-      - name: Package release
+      - name: Package binaries
         run: |
-            set -x
-            cp -r dest/. ${PKG_DEST_DIR}/
-      
-      - name: Package release w/ debugger
-        run: |
-            set -x
-            cp -r dest/. ${{ env.PKG_DEST_DIR_DEBUGGER }}/
-          
+          for bin_dir in $BUILD_RELEASE_DIR $BUILD_DEBUGGER_DIR; do
+            cp -r dest/. stage/${bin_dir}/
+          done
       
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          $dosboxDirs = "${{ github.workspace }}\${{ env.PKG_DEST_DIR }}", "${{ github.workspace }}\${{ env.PKG_DEST_DIR_DEBUGGER }}"
+          $dosboxDirs = "${{ github.workspace }}\stage\${{ env.BUILD_RELEASE_DIR }}", "${{ github.workspace }}\stage\${{ env.BUILD_DEBUGGER_DIR }}"
           foreach ($dosboxDir in $dosboxDirs)
           {
             & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
@@ -340,11 +313,11 @@ jobs:
       - name: Upload release package
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.PKG_DEST_DIR }}
-          path: ${{ env.PKG_DEST_DIR }}
+          name: dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          path: stage/${{ env.BUILD_RELEASE_DIR }}
 
       - name: Upload debugger package
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.PKG_DEST_DIR_DEBUGGER }}
-          path: ${{ env.PKG_DEST_DIR_DEBUGGER }}
+          name: dosbox-staging-windows-msys2-debugger-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          path: stage/${{ env.BUILD_DEBUGGER_DIR }}


### PR DESCRIPTION
This PR enhances the MSYS2 GitHub workflow by adding extra builds to check warning counts, run tests etc.

It also implements ccache for all builds for dramatic CI speedup of subsequent runs.