### PR TITLE
Add packaging script to replace 'Package' step in workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -204,50 +204,16 @@ jobs:
 
       - name: Package
         run: |
-          set -x
+          ./scripts/create-package.sh \
+            -p linux \
+            -c "$GITHUB_SHA" \
+            -b "${GITHUB_REF#refs/heads/}" \
+            -r "$GITHUB_REPOSITORY" \
+            build \
+            "dosbox-staging-linux-$VERSION"
 
-          # Print shared object dependencies
-          ldd build/dosbox
-
-          # Prepare content
-          install -DT        build/dosbox         dest/dosbox
-          install -DT -m 644 docs/README.template dest/README
-          install -DT -m 644 COPYING              dest/COPYING
-          install -DT -m 644 README               dest/doc/manual.txt
-          install -DT -m 644 docs/dosbox.1        dest/man/dosbox.1
-
-          # Install .desktop entry and icon files
-          install -DT contrib/linux/dosbox-staging.desktop dest/desktop/dosbox-staging.desktop
-          DESTDIR="$PWD" make -C contrib/icons/ install datadir=dest
-
-          # Fill README template file
-          sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README
-          sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README
-          sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README
-
-          # Prepare translation files
-          #
-          # Note:
-          #   We conciously drop the dialect postfix because no dialects are available.
-          #   (US was the default DOS dialect and therefore is the default for 'en').
-          #   There users get the generic translation and benefit from simpler filenames.
-          #   Dialect translations will be added if/when they're available.
-          #
-          install -DT -m 644 contrib/translations/de/de_DE.lng       dest/translations/de.lng
-          install -DT -m 644 contrib/translations/en/en_US.lng       dest/translations/en.lng
-          install -DT -m 644 contrib/translations/es/es_ES.lng       dest/translations/es.lng
-          install -DT -m 644 contrib/translations/fr/fr_FR.lng       dest/translations/fr.lng
-          install -DT -m 644 contrib/translations/it/it_IT.lng       dest/translations/it.lng
-          install -DT -m 644 contrib/translations/pl/pl_PL.CP437.lng dest/translations/pl.cp437.lng
-          install -DT -m 644 contrib/translations/pl/pl_PL.lng       dest/translations/pl.lng
-          install -DT -m 644 contrib/translations/ru/ru_RU.lng       dest/translations/ru.lng
-
-          # Finalize directory for tar'ing
-          mv dest "dosbox-staging-linux-$VERSION"
-          tree --si -p "dosbox-staging-linux-$VERSION"
-
-          # Create tarball
-          tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
+      - name: Create tarball
+        run: tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
 
       - name:  Prepare Clam AV DB cache
         id:    prep-clamdb

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -206,9 +206,6 @@ jobs:
         run: |
           ./scripts/create-package.sh \
             -p linux \
-            -c "$GITHUB_SHA" \
-            -b "${GITHUB_REF#refs/heads/}" \
-            -r "$GITHUB_REPOSITORY" \
             build \
             "dosbox-staging-linux-$VERSION"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -247,6 +247,7 @@ jobs:
           ./scripts/create-package.sh \
             -p macos \
             -v "${{ env.VERSION }}" \
+            -f \
             "$(pwd)" \
             "$(pwd)"
           

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -241,62 +241,20 @@ jobs:
 
       - name: Download binaries
         uses: actions/download-artifact@v2
-          
+      
       - name: Package
         run: |
-          set -x
-
-          # Print shared object dependencies
-          otool -L dosbox-arm64/dosbox
-          python3 scripts/verify-macos-dylibs.py dosbox-arm64/dosbox
+          ./scripts/create-package.sh \
+            -p macos \
+            -c "$GITHUB_SHA" \
+            -b "${GITHUB_REF#refs/heads/}" \
+            -r "$GITHUB_REPOSITORY" \
+            -v "${{ env.VERSION }}" \
+            "$(pwd)" \
+            "$(pwd)"
           
-          # Create universal binary from both architectures
-          mkdir dosbox-universal
-          lipo dosbox-x86_64/dosbox dosbox-arm64/dosbox -create -output dosbox-universal/dosbox
-
-          # Generate icon
-          make -C contrib/icons/ dosbox-staging.icns
-
-          dst=dist/dosbox-staging.app/Contents
-
-          # Prepare content
-          install -d "$dst/MacOS/"
-          install -d "$dst/Resources/"
-          install -d "$dst/SharedSupport/"
-                    
-          install        "dosbox-universal/dosbox"           "$dst/MacOS/"
-          install -m 644 "contrib/macos/Info.plist.template" "$dst/Info.plist"
-          install -m 644 "contrib/macos/PkgInfo"             "$dst/PkgInfo"
-          install -m 644 "contrib/icons/dosbox-staging.icns" "$dst/Resources/"
-          install -m 644 "docs/README.template"              "$dst/SharedSupport/README"
-          install -m 644 "COPYING"                           "$dst/SharedSupport/COPYING"
-          install -m 644 "README"                            "$dst/SharedSupport/manual.txt"
-          install -m 644 "docs/README.video"                 "$dst/SharedSupport/video.txt"
-
-          # Fill README template file
-          sed -i -e "s|%VERSION%|${{ env.VERSION }}|"           "$dst/Info.plist"
-          sed -i -e "s|%GIT_COMMIT%|$GITHUB_SHA|"               "$dst/SharedSupport/README"
-          sed -i -e "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" "$dst/SharedSupport/README"
-          sed -i -e "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       "$dst/SharedSupport/README"
-
-          # Prepare translation files
-          #
-          # Note:
-          #   We conciously drop the dialect postfix because no dialects are available.
-          #   (US was the default DOS dialect and therefore is the default for 'en').
-          #   There users get the generic translation and benefit from simpler filenames.
-          #   Dialect translations will be added if/when they're available.
-          #
-          dst_lng="$dst/Resources/translations/"
-          install -d "$dst_lng"
-          install -m 644 contrib/translations/de/de_DE.lng       "$dst_lng/de.lng"
-          install -m 644 contrib/translations/en/en_US.lng       "$dst_lng/en.lng"
-          install -m 644 contrib/translations/es/es_ES.lng       "$dst_lng/es.lng"
-          install -m 644 contrib/translations/fr/fr_FR.lng       "$dst_lng/fr.lng"
-          install -m 644 contrib/translations/it/it_IT.lng       "$dst_lng/it.lng"
-          install -m 644 contrib/translations/pl/pl_PL.CP437.lng "$dst_lng/pl.cp437.lng"
-          install -m 644 contrib/translations/pl/pl_PL.lng       "$dst_lng/pl.lng"
-          install -m 644 contrib/translations/ru/ru_RU.lng       "$dst_lng/ru.lng"
+      - name: Create dmg
+        run: |
           ln -s /Applications dist/
 
           codesign -s "-" dist/dosbox-staging.app --force --deep -v

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -246,9 +246,6 @@ jobs:
         run: |
           ./scripts/create-package.sh \
             -p macos \
-            -c "$GITHUB_SHA" \
-            -b "${GITHUB_REF#refs/heads/}" \
-            -r "$GITHUB_REPOSITORY" \
             -v "${{ env.VERSION }}" \
             "$(pwd)" \
             "$(pwd)"

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -248,9 +248,6 @@ jobs:
           for b in "${!builds[@]}"; do
             ./scripts/create-package.sh \
               -p msys2 \
-              -c "$GITHUB_SHA" \
-              -b "${GITHUB_REF#refs/heads/}" \
-              -r "$GITHUB_REPOSITORY" \
               "$b" \
               "${builds[$b]}"
           done

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -223,6 +223,12 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=5)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+      
+      - name: Inject package names
+        run: |
+          set -x
+          echo "PKG_RELEASE=dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "PKG_DEBUGGER=dosbox-staging-windows-msys2-debugger-${{ matrix.conf.arch }}-${{ env.VERSION }}" >> $GITHUB_ENV
            
       - name: Setup release build
         run: meson setup $BUILD_FLAGS $BUILD_RELEASE_DIR
@@ -235,72 +241,25 @@ jobs:
       
       - name: Build w/ debugger
         run: ninja -C $BUILD_DEBUGGER_DIR
-      
-      - name: Stage binaries
-        run: |
-          set -x
-          for bin_dir in $BUILD_RELEASE_DIR $BUILD_DEBUGGER_DIR; do
-            mkdir -p stage/${bin_dir}
-            cp ${bin_dir}/dosbox.exe stage/${bin_dir}/
-            ntldd -R stage/${bin_dir}/dosbox.exe \
-              | sed -e 's/^[[:blank:]]*//g' \
-              | cut -d ' ' -f 3 \
-              | grep -E -i '(mingw|clang)(32|64)' \
-              | sed -e 's|\\|/|g' \
-              | xargs cp --target-directory=stage/${bin_dir}/
-          done
-
-      - name: Strip binaries
-        run: |
-          for bin_dir in $BUILD_RELEASE_DIR $BUILD_DEBUGGER_DIR; do
-            strip stage/${bin_dir}/dosbox.exe
-          done
             
-      - name: Setup common package dir
+      - name: Package
         run: |
-          set -x
-          mkdir -p dest/doc
-          cp COPYING               dest/COPYING.txt
-          cp docs/README.template  dest/README.txt
-          cp docs/README.video     dest/doc/video.txt
-          cp README                dest/doc/manual.txt
-
-          # Prepare translation files
-          #
-          # Note:
-          #   We conciously drop the dialect postfix because no dialects are available.
-          #   (US was the default DOS dialect and therefore is the default for 'en').
-          #   There users get the generic translation and benefit from simpler filenames.
-          #   Dialect translations will be added if/when they're available.
-          #
-          mkdir -p dest/translations
-          cp contrib/translations/de/de_DE.lng       dest/translations/de.lng
-          cp contrib/translations/en/en_US.lng       dest/translations/en.lng
-          cp contrib/translations/es/es_ES.lng       dest/translations/es.lng
-          cp contrib/translations/fr/fr_FR.lng       dest/translations/fr.lng
-          cp contrib/translations/it/it_IT.lng       dest/translations/it.lng
-          cp contrib/translations/pl/pl_PL.CP437.lng dest/translations/pl.cp437.lng
-          cp contrib/translations/pl/pl_PL.lng       dest/translations/pl.lng
-          cp contrib/translations/ru/ru_RU.lng       dest/translations/ru.lng
-
-          # Fill README template file
-          sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README.txt
-          sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README.txt
-          sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
-
-          # Create dir for zipping
-      
-      - name: Package binaries
-        run: |
-          for bin_dir in $BUILD_RELEASE_DIR $BUILD_DEBUGGER_DIR; do
-            cp -r dest/. stage/${bin_dir}/
+          declare -A builds=( ["$BUILD_RELEASE_DIR"]="$PKG_RELEASE" ["$BUILD_DEBUGGER_DIR"]="$PKG_DEBUGGER")
+          for b in "${!builds[@]}"; do
+            ./scripts/create-package.sh \
+              -p msys2 \
+              -c "$GITHUB_SHA" \
+              -b "${GITHUB_REF#refs/heads/}" \
+              -r "$GITHUB_REPOSITORY" \
+              "$b" \
+              "${builds[$b]}"
           done
       
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          $dosboxDirs = "${{ github.workspace }}\stage\${{ env.BUILD_RELEASE_DIR }}", "${{ github.workspace }}\stage\${{ env.BUILD_DEBUGGER_DIR }}"
+          $dosboxDirs = "${{ github.workspace }}\${{ env.PKG_RELEASE }}", "${{ github.workspace }}\${{ env.PKG_DEBUGGER }}"
           foreach ($dosboxDir in $dosboxDirs)
           {
             & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
@@ -313,14 +272,14 @@ jobs:
       - name: Upload release package
         uses: actions/upload-artifact@v2
         with:
-          name: dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}
-          path: stage/${{ env.BUILD_RELEASE_DIR }}
+          name: ${{ env.PKG_RELEASE }}
+          path: ${{ env.PKG_RELEASE }}
 
       - name: Upload debugger package
         uses: actions/upload-artifact@v2
         with:
-          name: dosbox-staging-windows-msys2-debugger-${{ matrix.conf.arch }}-${{ env.VERSION }}
-          path: stage/${{ env.BUILD_DEBUGGER_DIR }}
+          name: ${{ env.PKG_DEBUGGER }}
+          path: ${{ env.PKG_DEBUGGER }}
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -155,58 +155,19 @@ jobs:
           cd vs
           MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
 
-      - name:  Package
+      - name: Package
         shell: bash
         env:
-          VC_REDIST_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC'
+          # This should probably be in the matrix somewhere
+          VC_REDIST_DIR: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30133/${{ matrix.conf.arch }}/Microsoft.VC142.CRT
         run: |
-          set -x
-
-          # Prepare content
-          readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
-          ls "vs/$RELEASE_DIR"
-          mkdir -p dest/doc
-          cp vs/$RELEASE_DIR/dosbox.exe           dest/
-          cp COPYING                              dest/COPYING.txt
-          cp docs/README.template                 dest/README.txt
-          cp docs/README.video                    dest/doc/video.txt
-          cp docs/vc_redist.txt                   dest/doc/vc_redist.txt
-          cp README                               dest/doc/manual.txt
-          cp vs/$RELEASE_DIR/*.dll                dest/
-          cp src/libs/zmbv/$RELEASE_DIR/*.dll     dest/
-
-          # Prepare translation files
-          #
-          # Note:
-          #   We conciously drop the dialect postfix because no dialects are available.
-          #   (US was the default DOS dialect and therefore is the default for 'en').
-          #   There users get the generic translation and benefit from simpler filenames.
-          #   Dialect translations will be added if/when they're available.
-          #
-          mkdir -p dest/translations
-          cp contrib/translations/de/de_DE.lng       dest/translations/de.lng
-          cp contrib/translations/en/en_US.lng       dest/translations/en.lng
-          cp contrib/translations/es/es_ES.lng       dest/translations/es.lng
-          cp contrib/translations/fr/fr_FR.lng       dest/translations/fr.lng
-          cp contrib/translations/it/it_IT.lng       dest/translations/it.lng
-          cp contrib/translations/pl/pl_PL.CP437.lng dest/translations/pl.cp437.lng
-          cp contrib/translations/pl/pl_PL.lng       dest/translations/pl.lng
-          cp contrib/translations/ru/ru_RU.lng       dest/translations/ru.lng
-
-          # List version of available Visual C++ Redistributable files
-          ls -l "$VC_REDIST_PATH"
-
-          # Include the necessary dlls from one of available versions
-          readonly VC_REDIST_VERSION="14.29.30133"
-          readonly VC_REDIST_DIR="$VC_REDIST_PATH/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/Microsoft.VC142.CRT"
-          cp "$VC_REDIST_DIR/msvcp140.dll"       dest/
-          cp "$VC_REDIST_DIR/vcruntime140.dll"   dest/
-          cp "$VC_REDIST_DIR/vcruntime140_1.dll" dest/ || true # might be missing, depending on arch
-
-          # Fill README template file
-          sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README.txt
-          sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README.txt
-          sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
+          ./scripts/create-package.sh \
+            -p msvc \
+            -c "$GITHUB_SHA" \
+            -b "${GITHUB_REF#refs/heads/}" \
+            -r "$GITHUB_REPOSITORY" \
+            vs/${{ matrix.conf.vs-release-dirname }}/Release \
+            "dest"
 
       - name:  Enable the debugger in config.h
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -163,9 +163,6 @@ jobs:
         run: |
           ./scripts/create-package.sh \
             -p msvc \
-            -c "$GITHUB_SHA" \
-            -b "${GITHUB_REF#refs/heads/}" \
-            -r "$GITHUB_REPOSITORY" \
             vs/${{ matrix.conf.vs-release-dirname }}/Release \
             "dest"
 

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -168,6 +168,12 @@ pkg_msvc()
     cp "$VC_REDIST_DIR/vcruntime140_1.dll" "${pkg_dir}/" || true # might be missing, depending on arch
 }
 
+# Get GitHub CI environment variables if available. The CLI options
+# '-c', '-b', '-r' will override these if set.
+git_commit=$GITHUB_SHA
+git_branch=${GITHUB_REF#refs/heads/}
+git_repo=$GITHUB_REPOSITORY
+
 while getopts 'p:c:b:r:v:h' c
 do
     case $c in

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -154,7 +154,7 @@ pkg_msys2()
 pkg_msvc()
 {
     # Get the release dir name from $build_dir
-    release_dir=$(basename "${build_dir}")
+    release_dir=$(basename -- "$(dirname -- "${build_dir}")")/$(basename -- "${build_dir}")
 
     # Copy binary
     cp "${build_dir}/dosbox.exe"  "${pkg_dir}/dosbox.exe"

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -e
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -73,9 +73,15 @@ install_doc()
             ;;
     esac
     # Fill template variables in README.template
-    [ -n "$git_commit" ] && sed -i -e "s|%GIT_COMMIT%|$git_commit|" "$readme_tmpl"
-    [ -n "$git_branch" ] && sed -i -e "s|%GIT_BRANCH%|$git_branch|" "$readme_tmpl"
-    [ -n "$git_repo" ]   && sed -i -e "s|%GITHUB_REPO%|$git_repo|"  "$readme_tmpl"
+    if [ -n "$git_commit" ]; then 
+        sed -i -e "s|%GIT_COMMIT%|$git_commit|" "$readme_tmpl"
+    fi
+    if [ -n "$git_branch" ]; then 
+        sed -i -e "s|%GIT_BRANCH%|$git_branch|" "$readme_tmpl"
+    fi
+    if [ -n "$git_repo" ]; then
+        sed -i -e "s|%GITHUB_REPO%|$git_repo|"  "$readme_tmpl"
+    fi
 }
 
 install_translation()
@@ -235,6 +241,7 @@ if [ "$platform" = "msvc" ] && [ -z "$VC_REDIST_DIR" ]; then
     usage
     exit 1
 fi
+set -x
 
 mkdir -p "$pkg_dir"
 install_doc

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -98,10 +98,11 @@ install_translation()
     #   (US was the default DOS dialect and therefore is the default for 'en').
     #   Dialect translations will be added if/when they're available.
     #
-    for source in $(find contrib/translations -name '*.lng'); do
-        target=$(basename "$source" | tr '[:upper:]' '[:lower:]')
-        install_file "$source" "$lng_dir/${target#??_}"
-    done
+    find contrib/translations -name '*.lng' |
+        while IFS= read -r src; do
+            target=$(basename "$src" | tr '[:upper:]' '[:lower:]')
+            install_file "$src" "$lng_dir/${target#??_}"
+        done
 }
 
 pkg_linux()
@@ -247,8 +248,8 @@ fi
 
 mkdir -p "$pkg_dir"
 
-if [ -z "$(find ${pkg_dir} -maxdepth 0 -empty)" ] && [ "$force_pkg" != "true" ]; then
-    echo "PACKAGE_DIR must be empty. Use '-f' to foce creation anyway"
+if [ -z "$(find "${pkg_dir}" -maxdepth 0 -empty)" ] && [ "$force_pkg" != "true" ]; then
+    echo "PACKAGE_DIR must be empty. Use '-f' to force creation anyway"
     usage
     exit 1
 fi

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+
+set -x
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2020-2021  Sherman Perry
+
+usage()
+{
+    printf "%s\n" "\
+    Usage: -p <platform> [-h -c <commit> -b <branch> -r <repo> -v <version>] BUILD_DIR PACKAGE_DIR
+    Where:
+        -h          : Show this help message
+        -p          : Buld platform. Can be one of linux, macos, msys2, msvc
+        -c          : Git commit
+        -b          : Git branch
+        -r          : Git repository
+        -v          : dosbox-staging version
+        BUILD_DIR   : Meson build directory
+        PACKAGE_DIR : Package directory
+    
+    Note: On macos, '-v' must be set. On msvc, the environment variable VC_REDIST_DIR must be set."
+}
+
+create_parent_dir()
+{
+    path=$1
+    dir=$(dirname "$path")
+    if [ "$dir" != "." ]; then
+        case $platform in
+             msvc) mkdir -p "$dir" ;;
+             macos) install -d "${dir}/"
+        esac
+    fi
+}
+
+install_file()
+{
+    src=$1
+    dest=$2
+    case $platform in
+        linux|msys2) install -DT -m 644 "$src" "$dest" ;;
+        msvc) create_parent_dir "$dest" && cp "$src" "$dest" ;;
+        macos) create_parent_dir "$dest" && install -m 644 "$src" "$dest" ;;
+    esac
+}
+
+install_doc()
+{
+    # Install common documentation files
+    case $platform in
+        linux)
+            install_file docs/README.template "${pkg_dir}/README"
+            install_file COPYING              "${pkg_dir}/COPYING"
+            install_file README               "${pkg_dir}/doc/manual.txt"
+            install_file docs/dosbox.1        "${pkg_dir}/man/dosbox.1"
+            readme_tmpl="${pkg_dir}/README"
+            ;;
+        macos)
+            install_file docs/README.template "${macos_dst_dir}/SharedSupport/README"
+            install_file COPYING              "${macos_dst_dir}/SharedSupport/COPYING"
+            install_file README               "${macos_dst_dir}/SharedSupport/manual.txt"
+            install_file docs/README.video    "${macos_dst_dir}/SharedSupport/video.txt"
+            readme_tmpl="${macos_dst_dir}/SharedSupport/README"
+            ;;
+        msys2|msvc)
+            install_file COPYING              "${pkg_dir}/COPYING.txt"
+            install_file docs/README.template "${pkg_dir}/README.txt"
+            install_file docs/README.video    "${pkg_dir}/doc/video.txt"
+            install_file README               "${pkg_dir}/doc/manual.txt"
+            readme_tmpl="${pkg_dir}/README.txt"
+            ;;
+    esac
+    # Fill template variables in README.template
+    [ -n "$git_commit" ] && sed -i -e "s|%GIT_COMMIT%|$git_commit|" "$readme_tmpl"
+    [ -n "$git_branch" ] && sed -i -e "s|%GIT_BRANCH%|$git_branch|" "$readme_tmpl"
+    [ -n "$git_repo" ]   && sed -i -e "s|%GITHUB_REPO%|$git_repo|"  "$readme_tmpl"
+}
+
+install_translation()
+{
+    lng_dir=${pkg_dir}/translations
+    if [ "$platform" = "macos" ]; then
+        lng_dir=${macos_dst_dir}/Resources/translations
+    fi
+    # Prepare translation files
+    #
+    # Note:
+    #   We conciously drop the dialect postfix because no dialects are available.
+    #   (US was the default DOS dialect and therefore is the default for 'en').
+    #   There users get the generic translation and benefit from simpler filenames.
+    #   Dialect translations will be added if/when they're available.
+    #
+    install_file contrib/translations/de/de_DE.lng       "$lng_dir/de.lng"
+    install_file contrib/translations/en/en_US.lng       "$lng_dir/en.lng"
+    install_file contrib/translations/es/es_ES.lng       "$lng_dir/es.lng"
+    install_file contrib/translations/fr/fr_FR.lng       "$lng_dir/fr.lng"
+    install_file contrib/translations/it/it_IT.lng       "$lng_dir/it.lng"
+    install_file contrib/translations/pl/pl_PL.CP437.lng "$lng_dir/pl.cp437.lng"
+    install_file contrib/translations/pl/pl_PL.lng       "$lng_dir/pl.lng"
+    install_file contrib/translations/ru/ru_RU.lng       "$lng_dir/ru.lng"
+}
+
+pkg_linux()
+{
+    # Print shared object dependencies
+    ldd "${build_dir}/dosbox"
+    install -DT "${build_dir}/dosbox" "${pkg_dir}/dosbox"
+
+    install -DT contrib/linux/dosbox-staging.desktop "${pkg_dir}/desktop/dosbox-staging.desktop"
+    DESTDIR="$(realpath "$pkg_dir")" make -C contrib/icons/ install datadir=
+}
+
+pkg_macos()
+{
+    # Note, this script assumes macos builds have x86_64 and ARM64 subdirectories
+
+    # Print shared object dependencies
+    otool -L "${build_dir}/dosbox-arm64/dosbox"
+    python3 scripts/verify-macos-dylibs.py "${build_dir}/dosbox-arm64/dosbox"
+
+    # Create universal binary from both architectures
+    mkdir dosbox-universal
+    lipo dosbox-x86_64/dosbox dosbox-arm64/dosbox -create -output dosbox-universal/dosbox
+
+    # Generate icon
+    make -C contrib/icons/ dosbox-staging.icns
+
+    install -d   "${macos_dst_dir}/MacOS/"
+    install      dosbox-universal/dosbox           "${macos_dst_dir}/MacOS/"
+    install_file contrib/macos/Info.plist.template "${macos_dst_dir}/Info.plist"
+    install_file contrib/macos/PkgInfo             "${macos_dst_dir}/PkgInfo"
+    install_file contrib/icons/dosbox-staging.icns "${macos_dst_dir}/Resources/"
+
+    sed -i -e "s|%VERSION%|${dbox_version}|"       "${macos_dst_dir}/Info.plist"
+}
+
+pkg_msys2()
+{
+    install -DT "${build_dir}/dosbox.exe" "${pkg_dir}/dosbox.exe"
+
+    # Discover and copy required dll files
+    ntldd -R "${pkg_dir}/dosbox.exe" \
+        | sed -e 's/^[[:blank:]]*//g' \
+        | cut -d ' ' -f 3 \
+        | grep -E -i '(mingw|clang)(32|64)' \
+        | sed -e 's|\\|/|g' \
+        | xargs cp --target-directory="${pkg_dir}/"
+}
+
+pkg_msvc()
+{
+    # Get the release dir name from $build_dir
+    release_dir=$(basename "${build_dir}")
+
+    # Copy binary
+    cp "${build_dir}/dosbox.exe"  "${pkg_dir}/dosbox.exe"
+
+    # Copy dll files
+    cp "${build_dir}"/*.dll                  "${pkg_dir}/"
+    cp "src/libs/zmbv/${release_dir}"/*.dll  "${pkg_dir}/"
+
+    # Copy VC redistributable files
+    cp docs/vc_redist.txt                  "${pkg_dir}/doc/vc_redist.txt"
+    cp "$VC_REDIST_DIR/msvcp140.dll"       "${pkg_dir}/"
+    cp "$VC_REDIST_DIR/vcruntime140.dll"   "${pkg_dir}/"
+    cp "$VC_REDIST_DIR/vcruntime140_1.dll" "${pkg_dir}/" || true # might be missing, depending on arch
+}
+
+while getopts 'p:c:b:r:v:h' c
+do
+    case $c in
+        h) print_usage="true" ;;
+        p) platform=$OPTARG ;;
+        c) git_commit=$OPTARG ;;
+        b) git_branch=$OPTARG ;;
+        r) git_repo=$OPTARG ;;
+        v) dbox_version=$OPTARG ;;
+        *) true ;; # keep shellcheck happy
+    esac
+done
+
+shift "$((OPTIND - 1))"
+
+build_dir=$1
+pkg_dir=$2
+
+if [ "$print_usage" = "true" ]; then
+    usage
+    exit 0
+fi
+
+p=$platform
+case $p in
+    linux|macos|msys2|msvc) true ;;
+    *) platform="unsupported" ;;
+esac
+
+if [ "$platform" = "unsupported" ]; then
+    echo "Platform not set or unsupported"
+    usage
+    exit 1
+fi
+
+if [ ! -d "$build_dir" ]; then
+    echo "Build directory not set, or does not exist"
+    usage
+    exit 1
+fi
+
+if [ -z "$pkg_dir" ]; then
+    echo "Package directory not set"
+    usage
+    exit 1
+fi
+
+if [ "$platform" = "macos" ]; then 
+    if [ -z "$dbox_version" ]; then
+        echo "Dosbox version required on MacOS"
+        usage
+        exit 1
+    fi
+    macos_dst_dir=${pkg_dir}/dist/dosbox-staging.app/Contents
+fi
+
+if [ "$platform" = "msvc" ] && [ -z "$VC_REDIST_DIR" ]; then
+    echo "VC_REDIST_DIR environment variable not set"
+    usage
+    exit 1
+fi
+
+mkdir -p "$pkg_dir"
+install_doc
+install_translation
+
+case $platform in
+    linux) pkg_linux ;;
+    macos) pkg_macos ;;
+    msys2) pkg_msys2 ;;
+    msvc)  pkg_msvc  ;;
+    *)     echo "Oops."; usage; exit 1 ;;
+esac

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -95,17 +95,12 @@ install_translation()
     # Note:
     #   We conciously drop the dialect postfix because no dialects are available.
     #   (US was the default DOS dialect and therefore is the default for 'en').
-    #   There users get the generic translation and benefit from simpler filenames.
     #   Dialect translations will be added if/when they're available.
     #
-    install_file contrib/translations/de/de_DE.lng       "$lng_dir/de.lng"
-    install_file contrib/translations/en/en_US.lng       "$lng_dir/en.lng"
-    install_file contrib/translations/es/es_ES.lng       "$lng_dir/es.lng"
-    install_file contrib/translations/fr/fr_FR.lng       "$lng_dir/fr.lng"
-    install_file contrib/translations/it/it_IT.lng       "$lng_dir/it.lng"
-    install_file contrib/translations/pl/pl_PL.CP437.lng "$lng_dir/pl.cp437.lng"
-    install_file contrib/translations/pl/pl_PL.lng       "$lng_dir/pl.lng"
-    install_file contrib/translations/ru/ru_RU.lng       "$lng_dir/ru.lng"
+    for source in $(find contrib/translations -name '*.lng'); do
+        target=$(basename "$source" | tr '[:upper:]' '[:lower:]')
+        install_file "$source" "$lng_dir/${target#??_}"
+    done
 }
 
 pkg_linux()


### PR DESCRIPTION
The 'Package' step in the workflow files was basically a shell script on it's own. So I've created an actual shell script to use in it's place.

The script attempts to closely match the existing packaging behavior for all platforms. Platform packaging improvements are out of scope for this PR.

The script is cross platform, and should run anywhere a POSIX compatible `sh` is available.