### PR TITLE
Build using Windows 2022 and Visual Studio 2022

### DIFF
--- a/.github/workflows/dormant/windows-2019.yml
+++ b/.github/workflows/dormant/windows-2019.yml
@@ -1,0 +1,239 @@
+name: Windows builds
+
+on: [push, pull_request]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_windows_vs:
+    name: ${{ matrix.conf.name }}
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    strategy:
+      matrix:
+        conf:
+          - name: MSVC 32-bit
+            arch: x86
+            max_warnings: 0
+          - name: MSVC 64-bit
+            arch: x64
+            max_warnings: 1125
+    steps:
+      - name:  Backup existing vcpkg installation
+        shell: pwsh
+        run: |
+          mv c:\vcpkg c:\vcpkg-bak
+          md c:\vcpkg -ea 0
+
+      - name: Generate vcpkg cache key
+        id:    prep-vcpkg
+        shell: bash
+        run: |
+          echo "::set-output name=year_and_week::$(date '+%Y%W')"
+
+      - name: Cache vcpkg
+        uses: actions/cache@v2
+        id:   cache-vcpkg
+        with:
+          path: c:\vcpkg
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
+
+      - name:  Install new packages using vcpkg
+        if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          rm -R c:\vcpkg
+          mv c:\vcpkg-bak c:\vcpkg
+          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth pdcurses gtest
+          if (-not $?) { throw "vcpkg failed to install library dependencies" }
+          rm -R c:\vcpkg\buildtrees
+          rm -R c:\vcpkg\packages
+
+      - name:  Integrate packages
+        shell: pwsh
+        run: |
+          vcpkg integrate install
+          if (-not $?) { throw "vcpkg failed to integrate packages" }
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name:  Log environment
+        shell: pwsh
+        run:   .\scripts\log-env.ps1
+
+      - name:  Run tests
+        shell: pwsh
+        env:
+          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
+        run: |
+          cd vs
+          # TODO: get unit tests working in Debug-mode; for now use release flags (better than nothing)
+          MSBuild -m dosbox.sln -t:tests:Rebuild -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
+
+      - name:  Build
+        shell: pwsh
+        env:
+          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
+        run: |
+          cd vs
+          MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Debug -p:Platform=${{ matrix.conf.arch }} | Tee-Object build.log
+
+      - name:  Summarize warnings
+        shell: pwsh
+        env:
+          MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
+        run: python scripts\count-warnings.py -f --msvc vs\build.log
+
+
+  build_windows_vs_release:
+    name: ${{ matrix.conf.name }}
+    needs: build_windows_vs
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        conf:
+          - name: Release build (32-bit)
+            arch: x86
+            vs-release-dirname: Win32
+          - name: Release build (64-bit)
+            arch: x64
+            vs-release-dirname: x64
+
+    steps:
+
+      - name:  Prepare vcpkg for cache restore
+        shell: pwsh
+        run: |
+          mv c:\vcpkg c:\vcpkg-bak
+          md c:\vcpkg -ea 0
+
+      - name: Generate vcpkg cache key
+        id:    prep-vcpkg
+        shell: bash
+        run: |
+          echo "::set-output name=year_and_week::$(date '+%Y%W')"
+
+      - name: Restore the most recent cache of vcpkg
+        uses: actions/cache@v2
+        with:
+          path: c:\vcpkg
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
+
+      - name:  Integrate packages
+        shell: pwsh
+        run: |
+          vcpkg integrate install
+          if (-not $?) { throw "vcpkg failed to integrate packages" }
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name:  Log environment
+        shell: pwsh
+        run:   .\scripts\log-env.ps1
+
+      - name:  Adjust config.h
+        shell: bash
+        run: |
+          set -x
+          git fetch --prune --unshallow
+          export VERSION=$(git describe --abbrev=4)
+          # inject version based on vcs
+          sed -i "s|DOSBOX_DETAILED_VERSION \"git\"|DOSBOX_DETAILED_VERSION \"$VERSION\"|" src/platform/visualc/config.h
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          # overwrite .conf file branding for release build
+          sed -i "s|CONF_SUFFIX \"-staging-git\"|CONF_SUFFIX \"-staging\"|" src/platform/visualc/config.h
+
+      - name:  Build release
+        shell: pwsh
+        env:
+          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
+        run: |
+          cd vs
+          MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
+
+      - name: Package
+        shell: bash
+        env:
+          # This should probably be in the matrix somewhere
+          VC_REDIST_DIR: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30133/${{ matrix.conf.arch }}/Microsoft.VC142.CRT
+        run: |
+          ./scripts/create-package.sh \
+            -p msvc \
+            vs/${{ matrix.conf.vs-release-dirname }}/Release \
+            "dest"
+
+      - name:  Enable the debugger in config.h
+        shell: bash
+        run: |
+          set -x
+          sed -i "s|C_DEBUG.*|C_DEBUG 1|"             src/platform/visualc/config.h
+          sed -i "s|C_HEAVY_DEBUG.*|C_HEAVY_DEBUG 1|" src/platform/visualc/config.h
+
+      - name:  Build release with the debugger
+        shell: pwsh
+        env:
+          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
+        run: |
+          cd vs
+          MSBuild -m dosbox.sln -t:dosbox:"Clean;Rebuild" -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
+
+      - name:  Package the debugger
+        shell: bash
+        run: |
+          set -x
+          # Move the debugger build into the release area
+          readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
+          ls "vs/$RELEASE_DIR"
+          cp vs/$RELEASE_DIR/dosbox.exe   dest/dosbox_with_debugger.exe
+          cp vs/$RELEASE_DIR/pdcurses.dll dest/
+          # Create dir for zipping
+          mv dest dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
+
+      - name: Windows Defender AV Scan
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}"
+          & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
+          if( $LASTEXITCODE -ne 0 ) {
+              Get-Content -Path $env:TEMP\MpCmdRun.log
+              Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
+          }
+
+      - name: Upload package
+        uses: actions/upload-artifact@v2
+        with:
+          name: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          path: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
+
+
+  # This job exists only to publish an artifact with version info when building
+  # from main branch, so snapshot build version will be visible on:
+  # https://dosbox-staging.github.io/downloads/devel/
+  #
+  publish_additional_artifacts:
+    name: Publish additional artifacts
+    needs: build_windows_vs_release
+    runs-on: windows-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate changelog
+        shell: bash
+        run: |
+          set +x
+          git fetch --unshallow
+          VERSION=$(git describe --abbrev=4)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          NEWEST_TAG=$(git describe --abbrev=0)
+          git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          # Keep exactly this artifact name; it's being used to propagate
+          # version info via GitHub REST API
+          name: changelog-${{ env.VERSION }}.txt
+          path: changelog-${{ env.VERSION }}.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -167,9 +167,15 @@ jobs:
 
       - name: Package
         shell: bash
-        env:
-          VC_REDIST_PATH: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC'
         run: |
+          # Construct VC_REDIST_DIR
+          readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
+          readonly VC_REDIST_VERSION="14.30.30704"
+          readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
+          export VC_REDIST_DIR="$VC_REDIST_BASE/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION"
+          find "$VC_REDIST_DIR" -maxdepth 3 -type d
+
+          # Package
           ./scripts/create-package.sh \
             -p msvc \
             vs/${{ matrix.conf.vs-release-dirname }}/Release \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build_windows_vs:
     name: ${{ matrix.conf.name }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
     strategy:
       matrix:
@@ -91,7 +91,7 @@ jobs:
   build_windows_vs_release:
     name: ${{ matrix.conf.name }}
     needs: build_windows_vs
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         conf:
@@ -158,8 +158,7 @@ jobs:
       - name: Package
         shell: bash
         env:
-          # This should probably be in the matrix somewhere
-          VC_REDIST_DIR: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.29.30133/${{ matrix.conf.arch }}/Microsoft.VC142.CRT
+          VC_REDIST_PATH: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC'
         run: |
           ./scripts/create-package.sh \
             -p msvc \
@@ -218,7 +217,7 @@ jobs:
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_windows_vs_release
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,10 +16,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 0
+            max_warnings: -1
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 1125
+            max_warnings: -1
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh
@@ -39,6 +39,12 @@ jobs:
         with:
           path: c:\vcpkg
           key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+            vs-prerelease: true
+            msbuild-architecture: ${{ matrix.conf.arch }}
 
       - name:  Install new packages using vcpkg
         if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
@@ -66,8 +72,6 @@ jobs:
 
       - name:  Run tests
         shell: pwsh
-        env:
-          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd vs
           # TODO: get unit tests working in Debug-mode; for now use release flags (better than nothing)
@@ -75,8 +79,6 @@ jobs:
 
       - name:  Build
         shell: pwsh
-        env:
-          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd vs
           MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Debug -p:Platform=${{ matrix.conf.arch }} | Tee-Object build.log
@@ -122,6 +124,12 @@ jobs:
           path: c:\vcpkg
           key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
 
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+            vs-prerelease: true
+            msbuild-architecture: ${{ matrix.conf.arch }}
+
       - name:  Integrate packages
         shell: pwsh
         run: |
@@ -149,8 +157,6 @@ jobs:
 
       - name:  Build release
         shell: pwsh
-        env:
-          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd vs
           MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
         id:   cache-vcpkg
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-3
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-2
+          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-3
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,11 @@ jobs:
         shell: pwsh
         run: |
           rm -R c:\vcpkg
-          mv c:\vcpkg-bak c:\vcpkg
+          c:
+          cd \
+          git clone --depth 1 https://github.com/Microsoft/vcpkg.git
+          cd vcpkg
+          .\bootstrap-vcpkg.bat
           vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth pdcurses gtest
           if (-not $?) { throw "vcpkg failed to install library dependencies" }
           rm -R c:\vcpkg\buildtrees

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -164,11 +164,9 @@ pkg_msvc()
     cp "${build_dir}"/*.dll                  "${pkg_dir}/"
     cp "src/libs/zmbv/${release_dir}"/*.dll  "${pkg_dir}/"
 
-    # Copy VC redistributable files
-    cp docs/vc_redist.txt                  "${pkg_dir}/doc/vc_redist.txt"
-    cp "$VC_REDIST_DIR/msvcp140.dll"       "${pkg_dir}/"
-    cp "$VC_REDIST_DIR/vcruntime140.dll"   "${pkg_dir}/"
-    cp "$VC_REDIST_DIR/vcruntime140_1.dll" "${pkg_dir}/" || true # might be missing, depending on arch
+    # Copy MSVC C++ redistributable files
+    cp docs/vc_redist.txt                    "${pkg_dir}/doc/vc_redist.txt"
+    cp "$VC_REDIST_DIR"/*.dll                "${pkg_dir}/"
 }
 
 # Get GitHub CI environment variables if available. The CLI options


### PR DESCRIPTION
Microsoft has release Windows 11 and server 2022, which this PR makes use of as its build environment. 

The solution files are left-as is, to to ensure users can continue to use VS 2019 or 2022. 

Binaries from this CI chain have been tested on Windows 7, 8.1, 10, and 11 - and are working without issue.

The 2019 CI workflow is moved into the dormant area, where we can quickly re-instate it if needed (or do a quick comparison build to see if fixes the tentative issue or behaves the same).

If problems arrive from this before the 0.78 release, then the 2019 build will be re-instated.
