### PR TITLE
Fix regressions introduces in video recording

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -27,7 +27,7 @@ jobs:
             toolchain: ""
             arch: i686
             sys: MINGW32
-            max_warnings: 19
+            max_warnings: 17
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
@@ -42,7 +42,7 @@ jobs:
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
-            max_warnings: 19
+            max_warnings: 2
           - name: GCC +tests
             toolchain: ""
             arch: x86_64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,10 +16,10 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: -1
+            max_warnings: 12
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: -1
+            max_warnings: 1099
     steps:
       - name:  Backup existing vcpkg installation
         shell: pwsh

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -48,9 +48,18 @@ extern Bit8u adlib_commandreg;
 FILE * OpenCaptureFile(const char * type,const char * ext);
 
 void CAPTURE_AddWave(Bit32u freq, Bit32u len, Bit16s * data);
+
 #define CAPTURE_FLAG_DBLW	0x1
 #define CAPTURE_FLAG_DBLH	0x2
-void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags, float fps, Bit8u * data, Bit8u * pal);
+void CAPTURE_AddImage(int width,
+                      int height,
+                      int bpp,
+                      int pitch,
+                      uint8_t flags,
+                      float fps,
+                      uint8_t *data,
+                      uint8_t *pal);
+
 void CAPTURE_AddMidi(bool sysex, Bitu len, Bit8u * data);
 void CAPTURE_VideoStart();
 void CAPTURE_VideoStop();

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -434,8 +434,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			case 8:
 				if (is_double_width) {
 					for (auto x = 0; x < countWidth; ++x)
-						doubleRow[x*2+0] =
-						doubleRow[x*2+1] = ((Bit8u *)srcLine)[x];
+						doubleRow[x * 2 + 0] = doubleRow[x * 2 + 1] = srcLine[x];
 					rowPointer = doubleRow;
 				}
 				break;
@@ -492,21 +491,21 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			case 32:
 				if (is_double_width) {
 					for (auto x = 0; x < countWidth; ++x) {
-						doubleRow[x*6+0] = doubleRow[x*6+3] = ((Bit8u *)srcLine)[x*4+0];
-						doubleRow[x*6+1] = doubleRow[x*6+4] = ((Bit8u *)srcLine)[x*4+1];
-						doubleRow[x*6+2] = doubleRow[x*6+5] = ((Bit8u *)srcLine)[x*4+2];
+						doubleRow[x * 6 + 0] = doubleRow[x * 6 + 3] = srcLine[x * 4 + 0];
+						doubleRow[x * 6 + 1] = doubleRow[x * 6 + 4] = srcLine[x * 4 + 1];
+						doubleRow[x * 6 + 2] = doubleRow[x * 6 + 5] = srcLine[x * 4 + 2];
 					}
 				} else {
 					for (auto x = 0; x < countWidth; ++x) {
-						doubleRow[x*3+0] = ((Bit8u *)srcLine)[x*4+0];
-						doubleRow[x*3+1] = ((Bit8u *)srcLine)[x*4+1];
-						doubleRow[x*3+2] = ((Bit8u *)srcLine)[x*4+2];
+						doubleRow[x * 3 + 0] = srcLine[x * 4 + 0];
+						doubleRow[x * 3 + 1] = srcLine[x * 4 + 1];
+						doubleRow[x * 3 + 2] = srcLine[x * 4 + 2];
 					}
 				}
 				rowPointer = doubleRow;
 				break;
 			}
-			png_write_row(png_ptr, (png_bytep)rowPointer);
+			png_write_row(png_ptr, rowPointer);
 		}
 		/* Finish writing */
 		png_write_end(png_ptr, 0);

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -50,40 +50,45 @@ Bitu CaptureState;
 
 static struct {
 	struct {
-		FILE * handle;
-		Bit16s buf[WAVE_BUF][2];
-		Bitu used;
-		Bit32u length;
-		Bit32u freq;
-	} wave; 
+		FILE *handle = nullptr;
+		uint16_t buf[WAVE_BUF][2] = {};
+		int used = 0;
+		int length = 0;
+		int freq = 0;
+	} wave = {};
+	;
 	struct {
-		FILE * handle;
-		Bit8u buffer[MIDI_BUF];
-		Bitu used,done;
-		Bit32u last;
-	} midi;
+		FILE *handle = nullptr;
+		uint8_t buffer[MIDI_BUF] = {0};
+		int used = 0;
+		int done = 0;
+		int last = 0;
+	} midi = {};
 	struct {
-		Bitu rowlen;
-	} image;
+		int rowlen = 0;
+	} image = {};
 #if (C_SSHOT)
 	struct {
-		FILE		*handle;
-		Bitu		frames;
-		Bit16s		audiobuf[WAVE_BUF][2];
-		Bitu		audioused;
-		Bitu		audiorate;
-		Bitu		audiowritten;
-		VideoCodec	*codec;
-		Bitu		width, height, bpp;
-		Bitu		written;
-		float		fps;
-		int			bufSize;
-		void		*buf;
-		Bit8u		*index;
-		Bitu		indexsize, indexused;
-	} video;
+		FILE *handle = nullptr;
+		int frames = 0;
+		int16_t audiobuf[WAVE_BUF][2] = {};
+		int audioused = 0;
+		int audiorate = 0;
+		int audiowritten = 0;
+		VideoCodec *codec = nullptr;
+		int width = 0;
+		int height = 0;
+		int bpp = 0;
+		int written = 0;
+		float fps = 0.0f;
+		int bufSize = 0;
+		void *buf = nullptr;
+		uint8_t *index = nullptr;
+		int indexsize = 0;
+		int indexused = 0;
+	} video = {};
 #endif
-} capture;
+} capture = {};
 
 FILE * OpenCaptureFile(const char * type,const char * ext) {
 	if(capturedir.empty()) {

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -333,14 +333,14 @@ void CAPTURE_VideoStop() {
 #endif
 }
 
-void CAPTURE_AddImage([[maybe_unused]] Bitu width,
-                      [[maybe_unused]] Bitu height,
-                      [[maybe_unused]] Bitu bpp,
-                      [[maybe_unused]] Bitu pitch,
-                      [[maybe_unused]] Bitu flags,
+void CAPTURE_AddImage([[maybe_unused]] int width,
+                      [[maybe_unused]] int height,
+                      [[maybe_unused]] int bpp,
+                      [[maybe_unused]] int pitch,
+                      [[maybe_unused]] uint8_t flags,
                       [[maybe_unused]] float fps,
-                      [[maybe_unused]] Bit8u *data,
-                      [[maybe_unused]] Bit8u *pal)
+                      [[maybe_unused]] uint8_t *data,
+                      [[maybe_unused]] uint8_t *pal)
 {
 #if (C_SSHOT)
 	Bitu i;
@@ -574,7 +574,9 @@ skip_shot:
 		if (capture.video.frames % 300 == 0)
 			codecFlags = 1;
 		else codecFlags = 0;
-		if (!capture.video.codec->PrepareCompressFrame( codecFlags, format, (char *)pal, capture.video.buf, capture.video.bufSize))
+		if (!capture.video.codec->PrepareCompressFrame(codecFlags, format, pal,
+		                                               capture.video.buf,
+		                                               capture.video.bufSize))
 			goto skip_video;
 
 		for (i=0;i<height;i++) {

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -177,6 +177,8 @@ static void CAPTURE_VideoEvent(bool pressed) {
 		return;
 	if (CaptureState & CAPTURE_VIDEO) {
 		/* Close the video */
+		if (capture.video.codec)
+			capture.video.codec->FinishVideo();
 		CaptureState &= ~CAPTURE_VIDEO;
 		LOG_MSG("Stopped capturing video.");	
 

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -52,41 +52,44 @@ static struct {
 	struct {
 		FILE *handle = nullptr;
 		uint16_t buf[WAVE_BUF][2] = {};
-		int used = 0;
-		int length = 0;
-		int freq = 0;
+		uint32_t used = 0;
+		uint32_t length = 0;
+		uint32_t freq = 0;
 	} wave = {};
-	;
+
 	struct {
 		FILE *handle = nullptr;
 		uint8_t buffer[MIDI_BUF] = {0};
-		int used = 0;
-		int done = 0;
-		int last = 0;
+		uint32_t used = 0;
+		uint32_t done = 0;
+		uint32_t last = 0;
 	} midi = {};
+
 	struct {
-		int rowlen = 0;
+		uint32_t rowlen = 0;
 	} image = {};
+
 #if (C_SSHOT)
 	struct {
 		FILE *handle = nullptr;
-		int frames = 0;
+		uint32_t frames = 0;
 		int16_t audiobuf[WAVE_BUF][2] = {};
-		int audioused = 0;
-		int audiorate = 0;
-		int audiowritten = 0;
+		uint32_t audioused = 0;
+		uint32_t audiorate = 0;
+		uint32_t audiowritten = 0;
 		VideoCodec *codec = nullptr;
 		int width = 0;
 		int height = 0;
 		int bpp = 0;
-		int written = 0;
+		uint32_t written = 0;
 		float fps = 0.0f;
-		int bufSize = 0;
+		uint32_t bufSize = 0;
 		std::vector<uint8_t> buf = {};
 		std::vector<uint8_t> index = {};
-		int indexused = 0;
+		uint32_t indexused = 0;
 	} video = {};
 #endif
+
 } capture = {};
 
 FILE * OpenCaptureFile(const char * type,const char * ext) {
@@ -207,12 +210,12 @@ static void CAPTURE_VideoEvent(bool pressed) {
 		AVIOUTd(0);                         /* InitialFrames */
 		AVIOUTd(2);                         /* Stream count */
 		AVIOUTd(0);                         /* SuggestedBufferSize */
-		AVIOUTd(capture.video.width);       /* Width */
-		AVIOUTd(capture.video.height);      /* Height */
-		AVIOUTd(0);                         /* TimeScale:  Unit used to measure time */
-		AVIOUTd(0);                         /* DataRate:   Data rate of playback     */
-		AVIOUTd(0);                         /* StartTime:  Starting time of AVI data */
-		AVIOUTd(0);                         /* DataLength: Size of AVI data chunk    */
+		AVIOUTd(static_cast<uint32_t>(capture.video.width));  /* Width */
+		AVIOUTd(static_cast<uint32_t>(capture.video.height)); /* Height */
+		AVIOUTd(0);                                           /* TimeScale:  Unit used to measure time */
+		AVIOUTd(0);                                           /* DataRate:   Data rate of playback     */
+		AVIOUTd(0);                                           /* StartTime:  Starting time of AVI data */
+		AVIOUTd(0);                                           /* DataLength: Size of AVI data chunk    */
 
 		/* Video stream list */
 		AVIOUT4("LIST");
@@ -239,9 +242,9 @@ static void CAPTURE_VideoEvent(bool pressed) {
 		AVIOUT4("strf");
 		AVIOUTd(40);                 /* # of bytes to follow */
 		AVIOUTd(40);                 /* Size */
-		AVIOUTd(capture.video.width);         /* Width */
-		AVIOUTd(capture.video.height);        /* Height */
-//		OUTSHRT(1); OUTSHRT(24);     /* Planes, Count */
+		AVIOUTd(static_cast<uint32_t>(capture.video.width));  /* Width */
+		AVIOUTd(static_cast<uint32_t>(capture.video.height)); /* Height */
+		//		OUTSHRT(1); OUTSHRT(24);     /* Planes, Count */
 		AVIOUTd(0);
 		AVIOUT4(CODEC_4CC);          /* Compression */
 		AVIOUTd(capture.video.width * capture.video.height*4);  /* SizeImage (in bytes?) */
@@ -769,7 +772,7 @@ void CAPTURE_AddMidi(bool sysex, Bitu len, Bit8u * data) {
 	RawMidiAddNumber(delta);
 	if (sysex) {
 		RawMidiAdd( 0xf0 );
-		RawMidiAddNumber( len );
+		RawMidiAddNumber(static_cast<uint32_t>(len));
 	}
 	for (Bitu i=0;i<len;i++) 
 		RawMidiAdd(data[i]);

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -621,7 +621,7 @@ skip_shot:
 					rowPointer = srcLine;
 				}
 			}
-			capture.video.codec->CompressLines( 1, &rowPointer );
+			capture.video.codec->CompressLines( 1, &rowPointer);
 		}
 		int written = capture.video.codec->FinishCompressFrame();
 		if (written < 0)

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -515,7 +515,7 @@ void CAPTURE_AddImage([[maybe_unused]] Bitu width,
 	}
 skip_shot:
 	if (CaptureState & CAPTURE_VIDEO) {
-		zmbv_format_t format;
+		ZMBV_FORMAT format;
 		/* Disable capturing if any of the test fails */
 		if (capture.video.handle && (
 			capture.video.width != width ||
@@ -527,17 +527,17 @@ skip_shot:
 		}
 		CaptureState &= ~CAPTURE_VIDEO;
 		switch (bpp) {
-		case 8:format = ZMBV_FORMAT_8BPP;break;
-		case 15:format = ZMBV_FORMAT_15BPP;break;
-		case 16:format = ZMBV_FORMAT_16BPP;break;
+		case 8: format = ZMBV_FORMAT::BPP_8; break;
+		case 15: format = ZMBV_FORMAT::BPP_15; break;
+		case 16: format = ZMBV_FORMAT::BPP_16; break;
 
 		// ZMBV is "the DOSBox capture format" supported by external
 		// tools such as VLC, MPV, and ffmpeg. Because DOSBox originally
 		// didn't have 24-bit color, the format itself doesn't support
 		// it. I this case we tell ZMBV the data is 32-bit and let the
 		// rgb24's int() cast operator up-convert.
-		case 24: format = ZMBV_FORMAT_32BPP; break;
-		case 32: format = ZMBV_FORMAT_32BPP; break;
+		case 24: format = ZMBV_FORMAT::BPP_32; break;
+		case 32: format = ZMBV_FORMAT::BPP_32; break;
 		default: goto skip_video;
 		}
 		if (!capture.video.handle) {

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -437,17 +437,17 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			case 15:
 				if (is_double_width) {
 					for (auto x = 0; x < countWidth; ++x) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
-						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >>  2;
-						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x03e0) * 0x21) >>  7;
-						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0x7c00) * 0x21) >>  12;
+						const auto pixel = host_to_le(reinterpret_cast<uint16_t *>(srcLine)[x]);
+						doubleRow[x * 6 + 0] = doubleRow[x * 6 + 3] = ((pixel & 0x001f) * 0x21) >> 2;
+						doubleRow[x * 6 + 1] = doubleRow[x * 6 + 4] = ((pixel & 0x03e0) * 0x21) >> 7;
+						doubleRow[x * 6 + 2] = doubleRow[x * 6 + 5] = ((pixel & 0x7c00) * 0x21) >> 12;
 					}
 				} else {
 					for (auto x = 0; x < countWidth; ++x) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
-						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
-						doubleRow[x*3+1] = ((pixel& 0x03e0) * 0x21) >>  7;
-						doubleRow[x*3+2] = ((pixel& 0x7c00) * 0x21) >>  12;
+						const auto pixel = host_to_le(reinterpret_cast<uint16_t *>(srcLine)[x]);
+						doubleRow[x * 3 + 0] = ((pixel & 0x001f) * 0x21) >> 2;
+						doubleRow[x * 3 + 1] = ((pixel & 0x03e0) * 0x21) >> 7;
+						doubleRow[x * 3 + 2] = ((pixel & 0x7c00) * 0x21) >> 12;
 					}
 				}
 				rowPointer = doubleRow;
@@ -455,17 +455,17 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			case 16:
 				if (is_double_width) {
 					for (auto x = 0; x < countWidth; ++x) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
-						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >> 2;
-						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x07e0) * 0x41) >> 9;
-						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0xf800) * 0x21) >> 13;
+						const auto pixel = host_to_le(reinterpret_cast<uint16_t *>(srcLine)[x]);
+						doubleRow[x * 6 + 0] = doubleRow[x * 6 + 3] = ((pixel & 0x001f) * 0x21) >> 2;
+						doubleRow[x * 6 + 1] = doubleRow[x * 6 + 4] = ((pixel & 0x07e0) * 0x41) >> 9;
+						doubleRow[x * 6 + 2] = doubleRow[x * 6 + 5] = ((pixel & 0xf800) * 0x21) >> 13;
 					}
 				} else {
 					for (auto x = 0; x < countWidth; ++x) {
-						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
-						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
-						doubleRow[x*3+1] = ((pixel& 0x07e0) * 0x41) >>  9;
-						doubleRow[x*3+2] = ((pixel& 0xf800) * 0x21) >>  13;
+						const auto pixel = host_to_le(reinterpret_cast<uint16_t *>(srcLine)[x]);
+						doubleRow[x * 3 + 0] = ((pixel & 0x001f) * 0x21) >> 2;
+						doubleRow[x * 3 + 1] = ((pixel & 0x07e0) * 0x41) >> 9;
+						doubleRow[x * 3 + 2] = ((pixel & 0xf800) * 0x21) >> 13;
 					}
 				}
 				rowPointer = doubleRow;
@@ -473,7 +473,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			case 24:
 				if (is_double_width) {
 					for (auto x = 0; x < countWidth; ++x) {
-						const auto pixel = host_to_le(static_cast<rgb24 *>(srcLine)[x]);
+						const auto pixel = host_to_le(reinterpret_cast<rgb24 *>(srcLine)[x]);
 						reinterpret_cast<rgb24 *>(doubleRow)[x * 2 + 0] = pixel;
 						reinterpret_cast<rgb24 *>(doubleRow)[x * 2 + 1] = pixel;
 						rowPointer = doubleRow;
@@ -583,8 +583,7 @@ skip_shot:
 				switch ( bpp) {
 				case 8:
 					for (auto x = 0; x < countWidth; ++x)
-						((Bit8u *)doubleRow)[x*2+0] =
-						((Bit8u *)doubleRow)[x*2+1] = ((Bit8u *)srcLine)[x];
+						doubleRow[x * 2 + 0] = doubleRow[x * 2 + 1] = srcLine[x];
 					break;
 				case 15:
 				case 16:

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -348,9 +348,8 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
                       [[maybe_unused]] uint8_t *pal)
 {
 #if (C_SSHOT)
-	Bitu i;
-	Bit8u doubleRow[SCALER_MAXWIDTH*4];
-	Bitu countWidth = width;
+	uint8_t doubleRow[SCALER_MAXWIDTH * 4];
+	auto countWidth = width;
 
 	if (flags & CAPTURE_FLAG_DBLH)
 		height *= 2;
@@ -400,7 +399,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			png_set_IHDR(png_ptr, info_ptr, width, height,
 				8, PNG_COLOR_TYPE_PALETTE, PNG_INTERLACE_NONE,
 				PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-			for (i=0;i<256;i++) {
+			for (auto i = 0; i < 256; ++i) {
 				palette[i].red=pal[i*4+0];
 				palette[i].green=pal[i*4+1];
 				palette[i].blue=pal[i*4+2];
@@ -425,7 +424,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 		png_set_text(png_ptr, info_ptr, texts, num_text);
 #endif
 		png_write_info(png_ptr, info_ptr);
-		for (i=0;i<height;i++) {
+		for (auto i = 0; i < height; ++i) {
 			void *rowPointer;
 			void *srcLine;
 			if (flags & CAPTURE_FLAG_DBLH)
@@ -436,7 +435,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 			switch (bpp) {
 			case 8:
 				if (flags & CAPTURE_FLAG_DBLW) {
-   					for (Bitu x=0;x<countWidth;x++)
+					for (auto x = 0; x < countWidth; ++x)
 						doubleRow[x*2+0] =
 						doubleRow[x*2+1] = ((Bit8u *)srcLine)[x];
 					rowPointer = doubleRow;
@@ -444,14 +443,14 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 				break;
 			case 15:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x=0;x<countWidth;x++) {
+					for (auto x = 0; x < countWidth; ++x) {
 						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x03e0) * 0x21) >>  7;
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0x7c00) * 0x21) >>  12;
 					}
 				} else {
-					for (Bitu x=0;x<countWidth;x++) {
+					for (auto x = 0; x < countWidth; ++x) {
 						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*3+1] = ((pixel& 0x03e0) * 0x21) >>  7;
@@ -462,14 +461,14 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 				break;
 			case 16:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x=0;x<countWidth;x++) {
+					for (auto x = 0; x < countWidth; ++x) {
 						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((pixel& 0x001f) * 0x21) >> 2;
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((pixel& 0x07e0) * 0x41) >> 9;
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((pixel& 0xf800) * 0x21) >> 13;
 					}
 				} else {
-					for (Bitu x=0;x<countWidth;x++) {
+					for (auto x = 0; x < countWidth; ++x) {
 						const Bitu pixel = host_to_le(static_cast<uint16_t *>(srcLine)[x]);
 						doubleRow[x*3+0] = ((pixel& 0x001f) * 0x21) >>  2;
 						doubleRow[x*3+1] = ((pixel& 0x07e0) * 0x41) >>  9;
@@ -480,7 +479,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 				break;
 			case 24:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (uint32_t x = 0; x < countWidth; ++x) {
+					for (auto x = 0; x < countWidth; ++x) {
 						const auto pixel = host_to_le(static_cast<rgb24 *>(srcLine)[x]);
 						reinterpret_cast<rgb24 *>(doubleRow)[x * 2 + 0] = pixel;
 						reinterpret_cast<rgb24 *>(doubleRow)[x * 2 + 1] = pixel;
@@ -494,13 +493,13 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 				break;
 			case 32:
 				if (flags & CAPTURE_FLAG_DBLW) {
-					for (Bitu x=0;x<countWidth;x++) {
+					for (auto x = 0; x < countWidth; ++x) {
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((Bit8u *)srcLine)[x*4+0];
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((Bit8u *)srcLine)[x*4+1];
 						doubleRow[x*6+2] = doubleRow[x*6+5] = ((Bit8u *)srcLine)[x*4+2];
 					}
 				} else {
-					for (Bitu x=0;x<countWidth;x++) {
+					for (auto x = 0; x < countWidth; ++x) {
 						doubleRow[x*3+0] = ((Bit8u *)srcLine)[x*4+0];
 						doubleRow[x*3+1] = ((Bit8u *)srcLine)[x*4+1];
 						doubleRow[x*3+2] = ((Bit8u *)srcLine)[x*4+2];
@@ -568,7 +567,7 @@ skip_shot:
 			capture.video.height = height;
 			capture.video.bpp = bpp;
 			capture.video.fps = fps;
-			for (i=0;i<AVI_HEADER_SIZE;i++)
+			for (auto i = 0; i < AVI_HEADER_SIZE; ++i)
 				fputc(0,capture.video.handle);
 			capture.video.frames = 0;
 			capture.video.written = 0;
@@ -584,37 +583,35 @@ skip_shot:
 		                                               capture.video.bufSize))
 			goto skip_video;
 
-		for (i=0;i<height;i++) {
-			void * rowPointer;
-			void * srcLine;
-			if (flags & CAPTURE_FLAG_DBLH)
-				srcLine=(data+(i >> 1)*pitch);
-			else
-				srcLine=(data+(i >> 0)*pitch);
+		for (auto i = 0; i < height; ++i) {
+			auto rowPointer = doubleRow;
+
+			const auto height_divisor = (flags & CAPTURE_FLAG_DBLH) ? 1 : 0;
+			const auto srcLine = data + (i >> height_divisor) * pitch;
+
 			if (flags & CAPTURE_FLAG_DBLW) {
-				uint32_t x = 0;
-				const uint32_t countWidth = width >> 1;
+				countWidth = width >> 1;
 				switch ( bpp) {
 				case 8:
-					for (x=0;x<countWidth;x++)
+					for (auto x = 0; x < countWidth; ++x)
 						((Bit8u *)doubleRow)[x*2+0] =
 						((Bit8u *)doubleRow)[x*2+1] = ((Bit8u *)srcLine)[x];
 					break;
 				case 15:
 				case 16:
-					for (x=0;x<countWidth;x++)
+					for (auto x = 0; x < countWidth; ++x)
 						((Bit16u *)doubleRow)[x*2+0] =
 						((Bit16u *)doubleRow)[x*2+1] = ((Bit16u *)srcLine)[x];
 					break;
 				case 24:
-					for (x = 0; x < countWidth; ++x) {
-						const auto pixel = static_cast<rgb24 *>(srcLine)[x];
+					for (auto x = 0; x < countWidth; ++x) {
+						const auto pixel = reinterpret_cast<rgb24 *>(srcLine)[x];
 						reinterpret_cast<uint32_t *>(doubleRow)[x * 2 + 0] = pixel;
 						reinterpret_cast<uint32_t *>(doubleRow)[x * 2 + 1] = pixel;
 					}
 					break;
 				case 32:
-					for (x=0;x<countWidth;x++)
+					for (auto x = 0; x < countWidth; ++x)
 						((Bit32u *)doubleRow)[x*2+0] =
 						((Bit32u *)doubleRow)[x*2+1] = ((Bit32u *)srcLine)[x];
 					break;
@@ -622,9 +619,8 @@ skip_shot:
                 rowPointer=doubleRow;
 			} else {
 				if (bpp == 24) {
-					const auto countWidth = width;
-					for (uint32_t x = 0; x < countWidth; ++x) {
-						const auto pixel = static_cast<rgb24 *>(srcLine)[x];
+					for (auto x = 0; x < width; ++x) {
+						const auto pixel = reinterpret_cast<rgb24 *>(srcLine)[x];
 						reinterpret_cast<uint32_t *>(doubleRow)[x] = pixel;
 					}
 					// Using doubleRow for this conversion when it is not actually double row!

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -77,9 +77,11 @@ bool VideoCodec::SetupBuffers(const ZMBV_FORMAT _format, const int blockwidth, c
 	};
 	bufsize = (height + 2 * MAX_VECTOR) * pitch * pixelsize + 2048;
 
-	buf1 = std::vector<uint8_t>(bufsize, 0);
-	buf2 = std::vector<uint8_t>(bufsize, 0);
-	work = std::vector<uint8_t>(bufsize, 0);
+	assert(bufsize > 0);
+	const auto buf_sizes = static_cast<size_t>(bufsize);
+	buf1 = std::vector<uint8_t>(buf_sizes, 0);
+	buf2 = std::vector<uint8_t>(buf_sizes, 0);
+	work = std::vector<uint8_t>(buf_sizes, 0);
 
 	auto xblocks = (width / blockwidth);
 	const auto xleft = width % blockwidth;

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -251,7 +251,7 @@ bool VideoCodec::SetupDecompress(const int _width, const int _height)
 	return true;
 }
 
-bool VideoCodec::PrepareCompressFrame(int flags, const ZMBV_FORMAT _format, const uint8_t *pal, uint8_t *writeBuf, const uint32_t writeSize)
+bool VideoCodec::PrepareCompressFrame(int flags, const ZMBV_FORMAT _format, uint8_t *pal, uint8_t *writeBuf, const uint32_t writeSize)
 {
 	if (_format != format) {
 		if (!SetupBuffers(_format, 16, 16))

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -442,7 +442,7 @@ bool VideoCodec::DecompressFrame(uint8_t *framedata, int size)
 			return false;
 		inflateReset(&zstream);
 	}
-	zstream.next_in = reinterpret_cast<Bytef *>(data);
+	zstream.next_in = data;
 	zstream.avail_in = size;
 	zstream.total_in = 0;
 

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -200,8 +200,8 @@ void VideoCodec::AddXorFrame()
 	assert(static_cast<size_t>(blockcount) == blocks.size());
 	for (FrameBlock_offset b = 0; b < blockcount; ++b) {
 		const auto block = blocks.begin() + b;
-		auto bestvx = 0;
-		auto bestvy = 0;
+		int8_t bestvx = 0;
+		int8_t bestvy = 0;
 		auto bestchange = CompareBlock<P>(0, 0, block);
 		auto possibles = 64;
 		for (auto v = 0; v < VectorCount && possibles; v++) {
@@ -215,13 +215,13 @@ void VideoCodec::AddXorFrame()
 				auto testchange = CompareBlock<P>(vx, vy, block);
 				if (testchange < bestchange) {
 					bestchange = testchange;
-					bestvx = vx;
-					bestvy = vy;
+					bestvx = check_cast<int8_t>(vx);
+					bestvy = check_cast<int8_t>(vy);
 				}
 			}
 		}
-		vectors[b * 2 + 0] = (bestvx << 1);
-		vectors[b * 2 + 1] = (bestvy << 1);
+		vectors[b * 2 + 0] = static_cast<uint8_t>(left_shift_signed(bestvx, 1));
+		vectors[b * 2 + 1] = static_cast<uint8_t>(left_shift_signed(bestvy, 1));
 		if (bestchange) {
 			vectors[b * 2 + 0] |= 1;
 			AddXorBlock<P>(bestvx, bestvy, block);

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -94,7 +94,7 @@ bool VideoCodec::SetupBuffers(const ZMBV_FORMAT _format, const int blockwidth, c
 	const auto yleft = height % blockheight;
 	if (yleft)
 		yblocks++;
-	blockcount = yblocks * xblocks;
+	blockcount = static_cast<FrameBlock_offset>(yblocks) * xblocks;
 	blocks.resize(blockcount);
 
 	size_t i = 0;

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -62,8 +62,8 @@ private:
 
 	struct Compress {
 		int linesDone = 0;
-		int writeSize = 0;
-		int writeDone = 0;
+		uint32_t writeSize = 0;
+		uint32_t writeDone = 0;
 		uint8_t *writeBuf = nullptr;
 	};
 
@@ -75,15 +75,16 @@ private:
 	std::vector<uint8_t> buf1 = {};
 	std::vector<uint8_t> buf2 = {};
 	std::vector<uint8_t> work = {};
-	int bufsize = 0;
+	uint32_t bufsize = 0;
 
-	int blockcount = 0;
 	std::vector<FrameBlock> blocks = {};
 	using FrameBlock_it = std::vector<FrameBlock>::const_iterator;
-	int workUsed = 0;
-	int workPos = 0;
+	using FrameBlock_offset = std::vector<FrameBlock>::difference_type;
+	FrameBlock_offset blockcount = 0;
+	uint32_t workUsed = 0;
+	uint32_t workPos = 0;
 
-	int palsize = 0;
+	uint32_t palsize = 0;
 	uint8_t palette[256 * 4] = {0};
 	int height = 0;
 	int width = 0;
@@ -125,7 +126,7 @@ public:
 	int NeededSize(int _width, int _height, ZMBV_FORMAT _format);
 
 	void CompressLines(int lineCount, uint8_t *lineData[]);
-	bool PrepareCompressFrame(int flags, ZMBV_FORMAT _format, const uint8_t *pal, uint8_t *writeBuf, int writeSize);
+	bool PrepareCompressFrame(int flags, ZMBV_FORMAT _format, const uint8_t *pal, uint8_t *writeBuf, uint32_t writeSize);
 	int FinishCompressFrame();
 	void FinishVideo();
 	bool DecompressFrame(uint8_t *framedata, int size);

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -126,7 +126,7 @@ public:
 	int NeededSize(int _width, int _height, ZMBV_FORMAT _format);
 
 	void CompressLines(int lineCount, uint8_t *lineData[]);
-	bool PrepareCompressFrame(int flags, ZMBV_FORMAT _format, const uint8_t *pal, uint8_t *writeBuf, uint32_t writeSize);
+	bool PrepareCompressFrame(int flags, ZMBV_FORMAT _format, uint8_t *pal, uint8_t *writeBuf, uint32_t writeSize);
 	int FinishCompressFrame();
 	void FinishVideo();
 	bool DecompressFrame(uint8_t *framedata, int size);

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -33,17 +33,17 @@
 
 #define CODEC_4CC "ZMBV"
 
-typedef enum {
-	ZMBV_FORMAT_NONE		= 0x00,
-	ZMBV_FORMAT_1BPP		= 0x01,
-	ZMBV_FORMAT_2BPP		= 0x02,
-	ZMBV_FORMAT_4BPP		= 0x03,
-	ZMBV_FORMAT_8BPP		= 0x04,
-	ZMBV_FORMAT_15BPP	= 0x05,
-	ZMBV_FORMAT_16BPP	= 0x06,
-	ZMBV_FORMAT_24BPP	= 0x07,
-	ZMBV_FORMAT_32BPP	= 0x08
-} zmbv_format_t;
+enum class ZMBV_FORMAT {
+	NONE = 0x00,
+	BPP_1 = 0x01,
+	BPP_2 = 0x02,
+	BPP_4 = 0x03,
+	BPP_8 = 0x04,
+	BPP_15 = 0x05,
+	BPP_16 = 0x06,
+	BPP_24 = 0x07,
+	BPP_32 = 0x08,
+};
 
 void Msg(const char fmt[], ...);
 class VideoCodec {
@@ -86,7 +86,7 @@ private:
 	int palsize;
 	char palette[256*4];
 	int height, width, pitch;
-	zmbv_format_t format;
+	ZMBV_FORMAT format;
 	int pixelsize;
 
 	z_stream zstream;
@@ -94,7 +94,7 @@ private:
 	// methods
 	void FreeBuffers(void);
 	void CreateVectorTable(void);
-	bool SetupBuffers(zmbv_format_t format, int blockwidth, int blockheight);
+	bool SetupBuffers(ZMBV_FORMAT format, int blockwidth, int blockheight);
 
 	template<class P>
 		void AddXorFrame(void);
@@ -119,11 +119,11 @@ public:
 
 	bool SetupCompress( int _width, int _height);
 	bool SetupDecompress( int _width, int _height);
-	zmbv_format_t BPPFormat( int bpp );
-	int NeededSize( int _width, int _height, zmbv_format_t _format);
+	ZMBV_FORMAT BPPFormat( int bpp );
+	int NeededSize( int _width, int _height, ZMBV_FORMAT _format);
 
 	void CompressLines(int lineCount, void *lineData[]);
-	bool PrepareCompressFrame(int flags,  zmbv_format_t _format, char * pal, void *writeBuf, int writeSize);
+	bool PrepareCompressFrame(int flags,  ZMBV_FORMAT _format, char * pal, void *writeBuf, int writeSize);
 	int FinishCompressFrame( void );
 	bool DecompressFrame(void * framedata, int size);
 	void Output_UpsideDown_24(void * output);

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -61,11 +61,11 @@ private:
 	};
 
 	struct Compress {
-		int		linesDone = 0;
-		int		writeSize = 0;
-		int		writeDone = 0;
-		uint8_t	*writeBuf = nullptr;
-	} ;
+		int linesDone = 0;
+		int writeSize = 0;
+		int writeDone = 0;
+		uint8_t *writeBuf = nullptr;
+	};
 
 	CodecVector VectorTable[512] = {};
 	int VectorCount = 0;
@@ -77,14 +77,14 @@ private:
 	std::vector<uint8_t> work = {};
 	int bufsize = 0;
 
-	int blockcount = 0; 
+	int blockcount = 0;
 	std::vector<FrameBlock> blocks = {};
 	using FrameBlock_it = std::vector<FrameBlock>::const_iterator;
 	int workUsed = 0;
 	int workPos = 0;
 
 	int palsize = 0;
-	uint8_t palette[256*4] = {0};
+	uint8_t palette[256 * 4] = {0};
 	int height = 0;
 	int width = 0;
 	int pitch = 0;
@@ -98,30 +98,38 @@ private:
 	void CreateVectorTable();
 	bool SetupBuffers(ZMBV_FORMAT format, int blockwidth, int blockheight);
 
-	template<class P> void AddXorFrame();
-	template<class P> void UnXorFrame();
-	template<class P> int PossibleBlock(int vx,int vy, FrameBlock_it block);
-	template<class P> int CompareBlock(int vx,int vy, FrameBlock_it block);
-	template<class P> void AddXorBlock(int vx,int vy, FrameBlock_it block);
-	template<class P> void UnXorBlock(int vx,int vy, FrameBlock_it block);
-	template<class P> void CopyBlock(int vx, int vy, FrameBlock_it block);
+	template <class P>
+	void AddXorFrame();
+	template <class P>
+	void UnXorFrame();
+	template <class P>
+	int PossibleBlock(int vx, int vy, FrameBlock_it block);
+	template <class P>
+	int CompareBlock(int vx, int vy, FrameBlock_it block);
+	template <class P>
+	void AddXorBlock(int vx, int vy, FrameBlock_it block);
+	template <class P>
+	void UnXorBlock(int vx, int vy, FrameBlock_it block);
+	template <class P>
+	void CopyBlock(int vx, int vy, FrameBlock_it block);
+
 public:
 	VideoCodec();
 
-	VideoCodec(const VideoCodec&) = delete; // prevent copy
-	VideoCodec &operator=(const VideoCodec&) = delete; // prevent assignment
+	VideoCodec(const VideoCodec &) = delete;            // prevent copy
+	VideoCodec &operator=(const VideoCodec &) = delete; // prevent assignment
 
-	bool SetupCompress( int _width, int _height);
-	bool SetupDecompress( int _width, int _height);
-	ZMBV_FORMAT BPPFormat( int bpp );
-	int NeededSize( int _width, int _height, ZMBV_FORMAT _format);
+	bool SetupCompress(int _width, int _height);
+	bool SetupDecompress(int _width, int _height);
+	ZMBV_FORMAT BPPFormat(int bpp);
+	int NeededSize(int _width, int _height, ZMBV_FORMAT _format);
 
-	void CompressLines(int lineCount, void *lineData[]);
-	bool PrepareCompressFrame(int flags,  ZMBV_FORMAT _format, char * pal, void *writeBuf, int writeSize);
-	int FinishCompressFrame( void );
-	bool DecompressFrame(void * framedata, int size);
-	void Output_UpsideDown_24(void * output);
+	void CompressLines(int lineCount, uint8_t *lineData[]);
+	bool PrepareCompressFrame(int flags, ZMBV_FORMAT _format, const uint8_t *pal, uint8_t *writeBuf, int writeSize);
+	int FinishCompressFrame();
+	void FinishVideo();
+	bool DecompressFrame(uint8_t *framedata, int size);
+	void Output_UpsideDown_24(uint8_t *output);
 };
 
 #endif
-

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -95,6 +95,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\platform\visualc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -125,6 +126,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\src\platform\visualc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -155,6 +157,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\src\platform\visualc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader />
@@ -188,6 +191,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\src\platform\visualc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>

--- a/src/libs/zmbv/zmbv_vfw.cpp
+++ b/src/libs/zmbv/zmbv_vfw.cpp
@@ -272,7 +272,7 @@ DWORD CodecInst::CompressGetSize(LPBITMAPINFOHEADER lpbiIn, LPBITMAPINFOHEADER l
 
 DWORD CodecInst::Compress(ICCOMPRESS* icinfo, DWORD dwSize) {
 	int i, pitch;
-	zmbv_format_t format;
+	ZMBV_FORMAT format;
 	LPBITMAPINFOHEADER lpbiIn=icinfo->lpbiInput;
 	LPBITMAPINFOHEADER lpbiOut=icinfo->lpbiOutput;
 	if (!CanCompress(lpbiIn, lpbiOut, true))
@@ -281,19 +281,19 @@ DWORD CodecInst::Compress(ICCOMPRESS* icinfo, DWORD dwSize) {
 		return ICERR_ABORT;
 	switch (GetInputBitDepth(lpbiIn)) {
 	case 8:
-		format = ZMBV_FORMAT_8BPP;
+		format = ZMBV_FORMAT::BPP_8;
 		pitch = lpbiIn->biWidth;
 		break;
 	case 15:
-		format = ZMBV_FORMAT_15BPP;
+		format = ZMBV_FORMAT::BPP_15;
 		pitch = lpbiIn->biWidth * 2;
 		break;
 	case 16:
-		format = ZMBV_FORMAT_16BPP;
+		format = ZMBV_FORMAT::BPP_16;
 		pitch = lpbiIn->biWidth * 2;
 		break;
 	case 32:
-		format = ZMBV_FORMAT_32BPP;
+		format = ZMBV_FORMAT::BPP_32;
 		pitch = lpbiIn->biWidth * 4;
 		break;
 	}

--- a/src/libs/zmbv/zmbv_vfw.cpp
+++ b/src/libs/zmbv/zmbv_vfw.cpp
@@ -292,6 +292,7 @@ DWORD CodecInst::Compress(ICCOMPRESS* icinfo, DWORD dwSize) {
 		format = ZMBV_FORMAT::BPP_16;
 		pitch = lpbiIn->biWidth * 2;
 		break;
+	case 24:
 	case 32:
 		format = ZMBV_FORMAT::BPP_32;
 		pitch = lpbiIn->biWidth * 4;


### PR DESCRIPTION
Fixes regressions introduced in ZMBV recording.  Thanks to @Grounded0 for reporting and regression testing.

Segfault on out-of-bound write:

![2021-11-27_21-31](https://user-images.githubusercontent.com/1557255/143732801-b48370f0-c488-4596-a259-aca5c3cce659.png)

Undefined behavior (shifting negative values and overflows):

![2021-11-27_21-30](https://user-images.githubusercontent.com/1557255/143732803-cc881c20-d7ad-4123-bf4e-b07778d77573.png)

Out-of-bounds memory read:

![2021-11-27_21-24](https://user-images.githubusercontent.com/1557255/143732805-5f8bc894-698d-4820-a695-7805172d8ff8.png)

Leaks: 

![2021-11-27_21-40](https://user-images.githubusercontent.com/1557255/143732796-1e605bbb-db65-46a9-bf47-568fe9723477.png)
