### PR TITLE
Document that numlock and caplock are off on startup

### DIFF
--- a/README
+++ b/README
@@ -271,6 +271,12 @@ KEYBOARD: Common key-presses conflict with system actions on macOS
      - "Move left a space" to deconflict Control+Left
      - "Move right a space" to deconflict Control+Right
 
+KEYBOARD: The numlock and capslock state isn't correct.
+    A known issue prevents SDL from reading the numlock and capslock
+    states on startup. Until this is resolved, we recommend toggling these
+    off prior to starting DOSBox. After startup, you may use numlock and
+    capslock as desired.
+
 KEYBOARD: I can't type \ or : in DOSBox.
     This can happen in various cases, like your host keyboard layout does not
     have a matching DOS layout representation (or it was not correctly

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2860,10 +2860,12 @@ static void GUI_StartUp(Section *sec)
 #endif
 	/* Get Keyboard state of numlock and capslock */
 	SDL_Keymod keystate = SDL_GetModState();
-	if (keystate & KMOD_NUM)
-		startup_state_numlock = true;
-	if (keystate & KMOD_CAPS)
-		startup_state_capslock = true;
+
+	// A long-standing SDL1 and SDL2 bug prevents it from detecting the
+	// numlock and capslock states on startup. Instead, these states must
+	// be toggled by the user /after/ starting DOSBox.
+	startup_state_numlock = keystate & KMOD_NUM;
+	startup_state_capslock = keystate & KMOD_CAPS;
 }
 
 static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {


### PR DESCRIPTION
A known issue prevents SDL from reading the numlock and capslock state on startup. Until this is resolved, we recommend toggling these off prior to starting DOSBox to ensure your keyboard state and DOSBox's state are in-sync.  After starting you may toggle these as desired.

This is a long-standing SDL issue: https://discourse.libsdl.org/t/numlock-caps-lock/10109/3, which apparently still isn't fixed (as I tested it in code using SDL 2.0.16).

Thanks to @madbad for mentioning this.
