### PR TITLE
Add support for portable configuration layouts

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 12
+            max_warnings: 20
           - name: MSVC 64-bit
             arch: x64
             max_warnings: 1099

--- a/README
+++ b/README
@@ -90,13 +90,17 @@ AUTOMATION: Do I always have to type these commands?
     setting to "overwrite", in the [dosbox] section.  When in this mode, the
     the overwrite-order is as follows:
 
-    1. Highest priority are those command(s) provided on the command line
+    1. Highest priority are those command(s) provided on the command line.
     2. Second is the [autoexec] section from the last processed custom conf file.
-       This would be custom2, if: dosbox -conf custom1.conf -conf custom2.conf
+       This would be custom2 if: dosbox -conf custom1.conf -conf custom2.conf
     3. Third is the [autoexec] section from the local conf, ie: when
        dosbox.conf is present in the current directory
-    4. Last is the [autoexec] section from the users primary conf,
-       ie: /user/config/dosbox/dosbox-staging.conf.
+    4. Last is the [autoexec] section from the user's portable or primary conf,
+       where:
+        - The portable conf is dosbox-staging.conf that (may) reside along-side
+          the DOSBox executable.
+        - The primary conf is dosbox-staging.conf that (may) reside in the
+          user's configuration directory, which varies by operating system.
 
     This ordering of configuration files is also discussed in Section 3:
     "Command Line Parameters", and specific configuration file settings are
@@ -419,16 +423,23 @@ dosbox -opencaptures program
 
         DOSBox Staging uses a layered configuration approach, as follows:
 
-        1. The primary configuration file is loaded first, which comes
-           from the operating system's user configuration directory.
-           This can be thought of as your "global" configuration file,
-           The -noprimaryconf flag can be used in cases where you want
-           to avoid loading your primary conf file.
+        1. If a dosbox-staging.conf file is found along-side the
+           DOSBox executable, known as a portable layout, then this
+           configuration file is loaded first. In this case, the
+           executable's directory is used to load other assets such as
+           glshaders, mt32-roms, and soundfonts.
+
+           If a portable layout isn't found, the user's primary
+           configuration file is loaded from the operating system's
+           user configuration directory. This can be thought of as
+           your "global" configuration file, The -noprimaryconf flag
+           can be used in cases where you want to avoid loading your
+           primary conf file.
 
         2. Second, if the local directory contains a dosbox.conf file,
-           its settings override those previously set by your Primary file.
-           The -nolocalconf flag can be used in cases where you want to
-           avoid loading the local dosbox.conf file.
+           its settings override those previously set by your portable
+           or primary file. The -nolocalconf flag can be used in cases
+           where you want to avoid loading the local dosbox.conf file.
 
         3. Finally, custom configurations are layered on, in order,
            using one or more -conf <filename> arguments. For example:

--- a/include/programs.h
+++ b/include/programs.h
@@ -40,8 +40,7 @@ public:
 	bool FindCommand(unsigned int which,std::string & value);
 	bool FindStringBegin(char const * const begin,std::string & value, bool remove=false);
 	bool FindStringRemain(char const * const name,std::string & value);
-	bool FindStringRemainBegin(char const * const name,std::string & value);
-	const std_fs::path &GetExecutablePath() const;
+	bool FindStringRemainBegin(char const *const name, std::string &value);
 	bool GetStringRemain(std::string & value);
 	int GetParameterFromList(const char* const params[], std::vector<std::string> & output);
 	void FillVector(std::vector<std::string> & vector);

--- a/include/support.h
+++ b/include/support.h
@@ -39,6 +39,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "std_filesystem.h"
+
 #ifdef _MSC_VER
 #define strcasecmp(a, b) _stricmp(a, b)
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
@@ -301,5 +303,7 @@ using FILE_unique_ptr = std::unique_ptr<FILE, FILE_closer>;
 // Opens and returns a std::unique_ptr to a FILE, which automatically closes
 // itself when it goes out of scope
 FILE_unique_ptr make_fopen(const char *fname, const char *mode);
+
+const std_fs::path &GetExecutablePath();
 
 #endif

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -145,7 +145,24 @@ static void W32_ConfDir(std::string& in,bool create) {
 
 std::string CROSS_GetPlatformConfigDir()
 {
-	std::string conf_dir = "";
+	// Cache the result, as this doesn't change
+	static std::string conf_dir = {};
+	if (conf_dir.length())
+		return conf_dir;
+
+	// Check if a portable layout exists
+	std::string config_file;
+	Cross::GetPlatformConfigName(config_file);
+	const auto portable_conf_path = GetExecutablePath() / config_file;
+	if (std_fs::is_regular_file(portable_conf_path)) {
+		conf_dir = portable_conf_path.parent_path().string();
+		LOG_MSG("CONFIG: Using portable configuration layout in %s",
+		        conf_dir.c_str());
+		conf_dir += CROSS_FILESPLIT;
+		return conf_dir;
+	}
+
+	// Otherwise get the OS-specific configuration directory
 #ifdef WIN32
 	W32_ConfDir(conf_dir, false);
 	conf_dir += "\\DOSBox\\";

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -15,6 +15,7 @@ libmisc = static_library('misc', libmisc_sources,
                          include_directories : incdir,
                          dependencies : [
                            sdl2_dep,
+                           stdcppfs_dep,
                            libloguru_dep,
                            libwhereami_dep,
                          ])

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -181,7 +181,7 @@ static std::deque<std_fs::path> get_paths()
 {
 	std::deque<std_fs::path> paths = {};
 
-	const auto exe_path = control->cmdline->GetExecutablePath();
+	const auto exe_path = GetExecutablePath();
 #if defined(MACOSX)
 	paths.emplace_back(exe_path / "../Resources/translations");
 #else

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -27,8 +27,6 @@
 #include <sstream>
 #include <string_view>
 
-#include "whereami.h"
-
 #include "control.h"
 #include "string_utils.h"
 #include "support.h"
@@ -1354,21 +1352,6 @@ CommandLine::CommandLine(int argc, char const *const argv[])
 		cmds.push_back(argv[i]);
 		i++;
 	}
-}
-
-const std_fs::path &CommandLine::GetExecutablePath() const
-{
-	static std_fs::path exe_path;
-	if (exe_path.empty()) {
-		int length = wai_getExecutablePath(nullptr, 0, nullptr);
-		// const auto length = wai_getExecutablePath(nullptr, 0, nullptr);
-		std::string s;
-		s.resize(check_cast<uint16_t>(length));
-		wai_getExecutablePath(&s[0], length, nullptr);
-		exe_path = s;
-		assert(!exe_path.empty());
-	}
-	return exe_path;
 }
 
 Bit16u CommandLine::Get_arglength()

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -39,6 +39,8 @@
 #include "fs_utils.h"
 #include "video.h"
 
+#include "whereami.h"
+
 char int_to_char(int val)
 {
 	// To handle inbound values cast from unsigned chars, permit a slightly
@@ -377,3 +379,16 @@ FILE_unique_ptr make_fopen(const char *fname, const char *mode)
 	return f ? FILE_unique_ptr(f) : nullptr;
 }
 
+const std_fs::path &GetExecutablePath()
+{
+	static std_fs::path exe_path;
+	if (exe_path.empty()) {
+		int length = wai_getExecutablePath(nullptr, 0, nullptr);
+		std::string s;
+		s.resize(check_cast<uint16_t>(length));
+		wai_getExecutablePath(&s[0], length, nullptr);
+		exe_path = std_fs::path(s).parent_path();
+		assert(!exe_path.empty());
+	}
+	return exe_path;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -63,11 +63,11 @@ unit_tests = [
   {'name' : 'rwqueue',              'deps' : [libmisc_dep]},
   {'name' : 'soft_limiter',         'deps' : [atomic_dep, libmisc_dep]},
   {'name' : 'string_utils',         'deps' : []},
-  {'name' : 'setup',                'deps' : [stdcppfs_dep, libmisc_dep]},
+  {'name' : 'setup',                'deps' : [libmisc_dep]},
   {'name' : 'support',              'deps' : [libmisc_dep]},
-  {'name' : 'drives',               'deps' : [dosbox_dep, stdcppfs_dep], 'extra_cpp': []},
-  {'name' : 'dos_files',            'deps' : [dosbox_dep, stdcppfs_dep], 'extra_cpp': []},
-  {'name' : 'shell_cmds',           'deps' : [dosbox_dep, stdcppfs_dep], 'extra_cpp': []},
+  {'name' : 'drives',               'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'dos_files',            'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'shell_cmds',           'deps' : [dosbox_dep], 'extra_cpp': []},
 ]
 
 foreach ut : unit_tests


### PR DESCRIPTION
If a `dosbox-staging.conf`[1] is found along-side the executable, then this directory is used as the base configuration path instead of the user's home directory path. This PR describes this in the README.

[1]  or `dosbox-staging-git.conf` for non-release binaries.

This allow Staging to be packaged and shared in a portable way, including custom GL shaders, MT-32 ROMs, and Soundfonts.

Thanks to @NicknineTheEagle for reporting this. Fixes #1397.
