### PR TITLE
Unify all IO port write interfaces

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 20
+            max_warnings: 0
           - name: MSVC 64-bit
             arch: x64
             max_warnings: 1099

--- a/include/dma.h
+++ b/include/dma.h
@@ -123,7 +123,7 @@ public:
 			return nullptr;
 	}
 
-	void WriteControllerReg(io_port_t reg, uint16_t val, io_width_t width);
+	void WriteControllerReg(io_port_t reg, io_val_t value, io_width_t width);
 	uint16_t ReadControllerReg(io_port_t reg, io_width_t width);
 };
 

--- a/include/vga.h
+++ b/include/vga.h
@@ -525,7 +525,7 @@ struct VGA_ModeExtraData {
 };
 
 // Vector function prototypes
-typedef void (*tWritePort)(io_port_t reg, uint8_t val, io_width_t width);
+typedef void (*tWritePort)(io_port_t reg, io_val_t value, io_width_t width);
 typedef uint8_t (*tReadPort)(io_port_t reg, io_width_t width);
 typedef void (*tFinishSetMode)(io_port_t crtc_base, VGA_ModeExtraData *modeData);
 typedef void (*tDetermineMode)();

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -598,8 +598,9 @@ uint8_t Module::CtrlRead(void)
 	return 0xff;
 }
 
-void Module::PortWrite(io_port_t port, uint8_t val, io_width_t)
+void Module::PortWrite(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// Keep track of last write time
 	lastUsed = PIC_Ticks;
 	//Maybe only enable with a keyon?
@@ -884,8 +885,9 @@ Module::Module(Section *configuration)
 	const auto write_to = std::bind(&Module::PortWrite, this, _1, _2, _3);
 
 	// 0x388 range
-	WriteHandler[0].Install(0x388, write_to, io_width_t::byte, 4);
-	ReadHandler[0].Install(0x388, read_from, io_width_t::byte, 4);
+	constexpr io_port_t port_0x388 = 0x388;
+	WriteHandler[0].Install(port_0x388, write_to, io_width_t::byte, 4);
+	ReadHandler[0].Install(port_0x388, read_from, io_width_t::byte, 4);
 	// 0x220 range
 	if (!single) {
 		WriteHandler[1].Install(base, write_to, io_width_t::byte, 4);

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -186,7 +186,7 @@ public:
 	Chip	chip[2];
 
 	//Handle port writes
-	void PortWrite(io_port_t port, uint8_t val, io_width_t width);
+	void PortWrite(io_port_t port, io_val_t value, io_width_t width);
 	uint8_t PortRead(io_port_t port, io_width_t width);
 	void Init(Mode m);
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -26,6 +26,7 @@
 #include "mixer.h"
 #include "pic.h"
 #include "setup.h"
+#include "support.h"
 
 // Disney Sound Source Constants
 constexpr uint16_t DISNEY_BASE = 0x0378;
@@ -180,8 +181,10 @@ static void DISNEY_analyze(Bitu channel){
 	}
 }
 
-static void disney_write(io_port_t port, uint8_t val, io_width_t)
+static void disney_write(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
+
 	// LOG_MSG("write disney time %f addr%x val %x",PIC_FullIndex(),port,val);
 	disney.last_used = PIC_Ticks;
 	switch (port - DISNEY_BASE) {

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -38,11 +38,13 @@ constexpr uint32_t GAMEBLASTER_CLOCK_HZ = 7159090;
 static mixer_channel_t cms_chan;
 //Timer to disable the channel after a while
 static Bit32u lastWriteTicks;
-static uint16_t cmsBase;
+static io_port_t cmsBase;
 static saa1099_device* device[2];
 
-static void write_cms(io_port_t port, uint8_t val, io_width_t)
+static void write_cms(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
+
 	if (cms_chan && (!cms_chan->is_enabled))
 		cms_chan->Enable(true);
 	lastWriteTicks = PIC_Ticks;
@@ -98,8 +100,9 @@ static void CMS_CallBack(Bitu len) {
 // The Gameblaster detection
 static Bit8u cms_detect_register = 0xff;
 
-static void write_cms_detect(io_port_t port, uint8_t val, io_width_t)
+static void write_cms_detect(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (port - cmsBase) {
 	case 0x6:
 	case 0x7:
@@ -134,7 +137,7 @@ public:
 	{
 		Section_prop * section = static_cast<Section_prop *>(configuration);
 		Bitu sampleRate = section->Get_int( "oplrate" );
-		cmsBase = static_cast<uint16_t>(section->Get_hex("sbbase"));
+		cmsBase = static_cast<io_port_t>(section->Get_hex("sbbase"));
 		WriteHandler.Install(cmsBase, write_cms, io_width_t::byte, 4);
 
 		// A standalone Gameblaster has a magic chip on it which is

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -250,7 +250,7 @@ private:
 	void UpdateDmaAddress(uint8_t new_address);
 	void UpdateWaveMsw(int32_t &addr) const noexcept;
 	void UpdateWaveLsw(int32_t &addr) const noexcept;
-	void WriteToPort(io_port_t port, uint16_t val, io_width_t width);
+	void WriteToPort(io_port_t port, io_val_t value, io_width_t width);
 
 	void WriteToRegister();
 
@@ -278,7 +278,7 @@ private:
 	uint8_t &adlib_command_reg = adlib_commandreg;
 
 	// Port address
-	uint16_t port_base = 0u;
+	io_port_t port_base = 0u;
 
 	// Voice states
 	uint32_t active_voice_mask = 0u;
@@ -1190,8 +1190,10 @@ void Gus::UpdateDmaAddress(const uint8_t new_address)
 #endif
 }
 
-void Gus::WriteToPort(io_port_t port, uint16_t val, io_width_t width)
+void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 {
+	const auto val = check_cast<uint16_t>(value);
+
 	//	LOG_MSG("GUS: Write to port %x val %x", port, val);
 	switch (port - port_base) {
 	case 0x200:

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -88,7 +88,7 @@ void Innovation::Open(const std::string &model_choice,
 	// Setup and assign the port address
 	const auto read_from = std::bind(&Innovation::ReadFromPort, this, _1, _2);
 	const auto write_to = std::bind(&Innovation::WriteToPort, this, _1, _2, _3);
-	base_port = static_cast<uint16_t>(port_choice);
+	base_port = check_cast<io_port_t>(port_choice);
 	read_handler.Install(base_port, read_from, io_width_t::byte, 0x20);
 	write_handler.Install(base_port, write_to, io_width_t::byte, 0x20);
 
@@ -151,14 +151,15 @@ void Innovation::Close()
 
 uint8_t Innovation::ReadFromPort(io_port_t port, io_width_t)
 {
-	const auto sid_port = static_cast<uint16_t>(port - base_port);
+	const auto sid_port = static_cast<io_port_t>(port - base_port);
 	const std::lock_guard<std::mutex> lock(service_mutex);
 	return service->read(sid_port);
 }
 
-void Innovation::WriteToPort(io_port_t port, uint8_t data, io_width_t)
+void Innovation::WriteToPort(io_port_t port, io_val_t value, io_width_t)
 {
-	const auto sid_port = static_cast<uint16_t>(port - base_port);
+	const auto data = check_cast<uint8_t>(value);
+	const auto sid_port = static_cast<io_port_t>(port - base_port);
 	{ // service-lock
 		const std::lock_guard<std::mutex> lock(service_mutex);
 		service->write(sid_port, data);

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -52,7 +52,7 @@ private:
 	uint16_t GetRemainingSamples();
 	void MixerCallBack(uint16_t requested_samples);
 	uint8_t ReadFromPort(io_port_t port, io_width_t width);
-	void WriteToPort(io_port_t port, uint8_t data, io_width_t width);
+	void WriteToPort(io_port_t port, io_val_t value, io_width_t width);
 
 	// Managed objects
 	mixer_channel_t channel = nullptr;
@@ -70,7 +70,7 @@ private:
 	std::atomic_bool keep_rendering = {};
 
 	// Scalar members
-	uint16_t base_port = 0;
+	io_port_t base_port = 0;
 	double chip_clock = 0;
 	double sid_sample_rate = 0;
 	size_t last_used = 0;

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -24,6 +24,7 @@
 #include "mem.h"
 #include "mixer.h"
 #include "timer.h"
+#include "support.h"
 
 #define KEYBUFSIZE 32
 #define KEYDELAY   0.300 // Considering 20-30 khz serial clock and 11 bits/char
@@ -104,8 +105,9 @@ static uint8_t read_p60(io_port_t, io_width_t)
 	return keyb.p60data;
 }
 
-static void write_p60(io_port_t, uint8_t val, io_width_t)
+static void write_p60(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (keyb.command) {
 	case CMD_NONE:	/* None */
 		/* No active command this would normally get sent to the keyboard then */
@@ -184,8 +186,9 @@ static uint8_t read_p61(io_port_t, io_width_t)
 }
 
 extern void TIMER_SetGate2(bool);
-static void write_p61(io_port_t, uint8_t val, io_width_t)
+static void write_p61(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	if ((port_61_data ^ val) & 3) {
 		if ((port_61_data ^ val) & 1) TIMER_SetGate2(val&0x1);
 		PCSPEAKER_SetType(val & 3);
@@ -200,8 +203,9 @@ static uint8_t read_p62(io_port_t, io_width_t)
 	return ret;
 }
 
-static void write_p64(io_port_t, uint8_t val, io_width_t)
+static void write_p64(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (val) {
 	case 0xae:		/* Activate keyboard */
 		keyb.active=true;

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -17,14 +17,15 @@
  */
 
 
-#include "dosbox.h"
 #include "mem.h"
+
+#include <string.h>
+
 #include "inout.h"
 #include "setup.h"
 #include "paging.h"
 #include "regs.h"
-
-#include <string.h>
+#include "support.h"
 
 #define PAGES_IN_BLOCK	((1024*1024)/MEM_PAGE_SIZE)
 #define SAFE_MEMORY	32
@@ -532,8 +533,9 @@ void mem_writed(PhysPt address,Bit32u val) {
 	mem_writed_inline(address,val);
 }
 
-static void write_p92(io_port_t, uint8_t val, io_width_t)
+static void write_p92(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// Bit 0 = system reset (switch back to real mode)
 	if (val&1) E_Exit("XMS: CPU reset via port 0x92 not supported.");
 	memory.a20.controlport = val & ~2;

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1399,8 +1399,9 @@ uint16_t dosbox_read(io_port_t port, io_width_t width)
 	//	port, retval, len, theNE2kDevice->s.CR.pgsel,SegValue(cs),reg_eip);
 	return retval;
 }
-void dosbox_write(io_port_t port, uint16_t val, io_width_t width)
+void dosbox_write(io_port_t port, io_val_t value, io_width_t width)
 {
+  const auto val = check_cast<uint16_t>(value);
 	// LOG_MSG("ne2k wr port %x val %4x len %d page %d, CS:IP %8x:%8x",
 	//	port, val, len,theNE2kDevice->s.CR.pgsel,SegValue(cs),reg_eip);
 	const uint8_t bytes_to_write = width == io_width_t::byte ? 1 : 2;

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -918,7 +918,8 @@ uint8_t adlib_reg_read(io_port_t port) {
 #endif
 }
 
-void adlib_write_index([[maybe_unused]] io_port_t port, uint8_t val) {
+void adlib_write_index([[maybe_unused]] io_port_t port, io_val_t value) {
+	const auto val = check_cast<uint8_t>(value);
 	opl_index = val;
 #if defined(OPLTYPE_IS_OPL3)
 	if ((port&3)!=0) {

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -177,6 +177,6 @@ void adlib_write(io_port_t idx, Bit8u val);
 void adlib_getsample(Bit16s* sndptr, Bits numsamples);
 
 uint8_t adlib_reg_read(io_port_t port);
-void adlib_write_index(io_port_t port, uint8_t val);
+void adlib_write_index(io_port_t port, io_val_t value);
 
 static Bit32u generator_add;	// should be a chip parameter

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -44,7 +44,7 @@ static PCI_Device* pci_devices[PCI_MAX_PCIDEVICES];		// registered PCI devices
 // 10- 8 - subfunction number	(0x00000700)
 //  7- 2 - config register #	(0x000000fc)
 
-static void write_pci_addr(io_port_t port, uint32_t val, io_width_t)
+static void write_pci_addr(io_port_t port, io_val_t val, io_width_t)
 {
 	LOG(LOG_PCI, LOG_NORMAL)("Write PCI address :=%x", val);
 	pci_caddress = val;
@@ -71,10 +71,11 @@ static void write_pci_register(PCI_Device* dev,Bit8u regnum,Bit8u value) {
 		pci_cfg_data[dev->PCIId()][dev->PCISubfunction()][regnum]=(Bit8u)(parsed_register&0xff);
 }
 
-static void write_pci(io_port_t port, uint8_t val, io_width_t width)
+static void write_pci(io_port_t port, io_val_t value, io_width_t width)
 {
 	// write_pci is only ever registered as an 8-bit handler, despite appearing to handle up to 32-bit
 	// requests. Let's check that.
+	const auto val = check_cast<uint8_t>(value);
 	assert(width == io_width_t::byte);
 
 	LOG(LOG_PCI, LOG_NORMAL)("Write PCI data :=%x (io_width=%d)", port, val, static_cast<int>(width));

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -203,9 +203,11 @@ static struct {
 	PICEntry * next_entry;
 } pic_queue;
 
-static void write_command(io_port_t port, uint8_t val, io_width_t)
+static void write_command(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	PIC_Controller *pic = &pics[port == 0x20 ? 0 : 1];
+
 
 	if (GCC_UNLIKELY(val&0x10)) {		// ICW1 issued
 		if (val&0x04) E_Exit("PIC: 4 byte interval not handled");
@@ -256,8 +258,9 @@ static void write_command(io_port_t port, uint8_t val, io_width_t)
 	}	// end OCW2
 }
 
-static void write_data(io_port_t port, uint8_t val, io_width_t)
+static void write_data(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	PIC_Controller *pic = &pics[port == 0x21 ? 0 : 1];
 	switch (pic->icw_index) {
 	case 0: /* mask register */ pic->set_imr(val); break;

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -59,10 +59,10 @@ private:
 	uint8_t ReadTimingPort203(io_port_t port, io_width_t);
 	uint8_t ReadJoystickPorts204To207(io_port_t port, io_width_t);
 
-	void WriteDataPort200(io_port_t port, uint8_t data, io_width_t);
-	void WriteControlPort202(io_port_t port, uint8_t data, io_width_t);
-	void WriteTimingPort203(io_port_t port, uint8_t data, io_width_t);
-	void WriteFifoLevelPort204(io_port_t port, uint8_t data, io_width_t);
+	void WriteDataPort200(io_port_t port, io_val_t value, io_width_t);
+	void WriteControlPort202(io_port_t port, io_val_t value, io_width_t);
+	void WriteTimingPort203(io_port_t port, io_val_t value, io_width_t);
+	void WriteFifoLevelPort204(io_port_t port, io_val_t value, io_width_t);
 
 	// Constants
 	static constexpr auto clock_rate_hz = 1000000;
@@ -177,8 +177,9 @@ void Ps1Dac::Reset(bool should_clear_adder)
 	is_new_transfer = true;
 }
 
-void Ps1Dac::WriteDataPort200(io_port_t, uint8_t data, io_width_t)
+void Ps1Dac::WriteDataPort200(io_port_t, io_val_t value, io_width_t)
 {
+	const auto data = check_cast<uint8_t>(value);
 	keep_alive_channel(last_write, channel);
 	if (is_new_transfer) {
 		is_new_transfer = false;
@@ -199,16 +200,18 @@ void Ps1Dac::WriteDataPort200(io_port_t, uint8_t data, io_width_t)
 	}
 }
 
-void Ps1Dac::WriteControlPort202(io_port_t, uint8_t data, io_width_t)
+void Ps1Dac::WriteControlPort202(io_port_t, io_val_t value, io_width_t)
 {
+	const auto data = check_cast<uint8_t>(value);
 	keep_alive_channel(last_write, channel);
 	regs.command = data;
 	if (data & 3)
 		can_trigger_irq = true;
 }
 
-void Ps1Dac::WriteTimingPort203(io_port_t, uint8_t data, io_width_t)
+void Ps1Dac::WriteTimingPort203(io_port_t, io_val_t value, io_width_t)
 {
+	auto data = check_cast<uint8_t>(value);
 	keep_alive_channel(last_write, channel);
 	// Clock divisor (maybe trigger first IRQ here).
 	regs.divisor = data;
@@ -227,8 +230,9 @@ void Ps1Dac::WriteTimingPort203(io_port_t, uint8_t data, io_width_t)
 	}
 }
 
-void Ps1Dac::WriteFifoLevelPort204(io_port_t, uint8_t data, io_width_t)
+void Ps1Dac::WriteFifoLevelPort204(io_port_t, io_val_t value, io_width_t)
 {
+	const auto data = check_cast<uint8_t>(value);
 	keep_alive_channel(last_write, channel);
 	regs.fifo_level = data;
 	if (!data)
@@ -343,7 +347,7 @@ public:
 
 private:
 	void Update(uint16_t samples);
-	void WriteSoundGeneratorPort205(io_port_t port, uint8_t data, io_width_t);
+	void WriteSoundGeneratorPort205(io_port_t port, io_val_t, io_width_t);
 
 	mixer_channel_t channel = nullptr;
 	IO_WriteHandleObject write_handler = {};
@@ -368,8 +372,9 @@ Ps1Synth::Ps1Synth() : device(machine_config(), 0, 0, clock_rate_hz)
 	last_write = 0;
 }
 
-void Ps1Synth::WriteSoundGeneratorPort205(io_port_t, uint8_t data, io_width_t)
+void Ps1Synth::WriteSoundGeneratorPort205(io_port_t, io_val_t value, io_width_t)
 {
+	const auto data = check_cast<uint8_t>(value);
 	keep_alive_channel(last_write, channel);
 	device.write(data);
 }

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1645,8 +1645,9 @@ static uint8_t read_sb(io_port_t port, io_width_t)
 	return 0xff;
 }
 
-static void write_sb(io_port_t port, uint8_t val, io_width_t)
+static void write_sb(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (port - sb.hw.base) {
 	case DSP_RESET: DSP_DoReset(val); break;
 	case DSP_WRITE_DATA: DSP_DoWrite(val); break;
@@ -1656,8 +1657,9 @@ static void write_sb(io_port_t port, uint8_t val, io_width_t)
 	}
 }
 
-static void adlib_gusforward(io_port_t, uint8_t val, io_width_t)
+static void adlib_gusforward(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	adlib_commandreg = (Bit8u)(val & 0xff);
 }
 

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -140,8 +140,9 @@ static uint8_t SERIAL_Read(io_port_t port, io_width_t)
 #endif
 	return retval;
 }
-static void SERIAL_Write(io_port_t port, uint8_t val, io_width_t)
+static void SERIAL_Write(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	uint32_t i;
 	const uint8_t offset_type = static_cast<uint8_t>(port) & 0x7;
 	switch(port&0xff8) {

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -124,8 +124,9 @@ static ncr8496_device device_ncr8496(machine_config(), 0, 0, SOUND_CLOCK);
 static sn76496_base_device* activeDevice = &device_ncr8496;
 #define device (*activeDevice)
 
-static void SN76496Write(io_port_t, uint8_t data, io_width_t)
+static void SN76496Write(io_port_t, io_val_t value, io_width_t)
 {
+	const auto data = check_cast<uint8_t>(value);
 	tandy.last_write = PIC_Ticks;
 	if (!tandy.enabled && tandy.chan) {
 		tandy.chan->Enable(true);
@@ -227,8 +228,9 @@ static void TandyDACDMAEnabled()
 static void TandyDACDMADisabled()
 {}
 
-static void TandyDACWrite(io_port_t port, uint8_t data, io_width_t)
+static void TandyDACWrite(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto data = check_cast<uint8_t>(value);
 	switch (port) {
 	case 0xc4: {
 		Bitu oldmode = tandy.dac.mode;

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -223,8 +223,9 @@ static void counter_latch(uint32_t counter)
 	}
 }
 
-static void write_latch(io_port_t port, uint8_t val, io_width_t)
+static void write_latch(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// LOG(LOG_PIT,LOG_ERROR)("port %X write:%X
 	// state:%X",port,val,pit[port-0x40].write_state);
 	const uint16_t counter = port - 0x40;
@@ -347,8 +348,9 @@ static uint8_t read_latch(io_port_t port, io_width_t)
 	return ret;
 }
 
-static void write_p43(io_port_t, uint8_t val, io_width_t)
+static void write_p43(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// LOG(LOG_PIT,LOG_ERROR)("port 43 %X",val);
 	const uint8_t latch = (val >> 6) & 0x03;
 	switch (latch) {

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -99,8 +99,9 @@ uint8_t read_p3c0(io_port_t, io_width_t)
 	return retval;
 }
 
-void write_p3c0(io_port_t, uint8_t val, io_width_t)
+void write_p3c0(io_port_t, io_val_t value, io_width_t)
 {
+	auto val = check_cast<uint8_t>(value);
 	if (!vga.internal.attrindex) {
 		attr(index)=val & 0x1F;
 		vga.internal.attrindex=true;

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -32,10 +32,11 @@
 void VGA_MapMMIO(void);
 void VGA_UnmapMMIO(void);
 
-void vga_write_p3d5(io_port_t port, uint8_t val, io_width_t);
+void vga_write_p3d5(io_port_t port, io_val_t value, io_width_t);
 
-void vga_write_p3d4(io_port_t, uint8_t val, io_width_t)
+void vga_write_p3d4(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	crtc(index) = val;
 }
 
@@ -44,8 +45,9 @@ uint8_t vga_read_p3d4(io_port_t, io_width_t)
 	return crtc(index);
 }
 
-void vga_write_p3d5(io_port_t, uint8_t val, io_width_t)
+void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	//	if (crtc(index) > 0x18) LOG_MSG("VGA CRCT write %" sBitfs(X) " to reg %X",val,crtc(index));
 	switch (crtc(index)) {
 	case 0x00: /* Horizontal Total Register */

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -86,8 +86,9 @@ static void VGA_DAC_UpdateColor(uint16_t index)
 	VGA_DAC_SendColor(static_cast<uint8_t>(index), static_cast<uint8_t>(maskIndex));
 }
 
-static void write_p3c6(io_port_t, uint8_t val, io_width_t)
+static void write_p3c6(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	if (vga.dac.pel_mask != val) {
 		LOG(LOG_VGAMISC, LOG_NORMAL)("VGA:DCA:Pel Mask set to %X", val);
 		vga.dac.pel_mask = val;
@@ -101,8 +102,9 @@ static uint8_t read_p3c6(io_port_t, io_width_t)
 	return vga.dac.pel_mask;
 }
 
-static void write_p3c7(io_port_t, uint8_t val, io_width_t)
+static void write_p3c7(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	vga.dac.read_index = val;
 	vga.dac.pel_index = 0;
 	vga.dac.state = DAC_READ;
@@ -117,8 +119,9 @@ static uint8_t read_p3c7(io_port_t, io_width_t)
 		return 0x0;
 }
 
-static void write_p3c8(io_port_t, uint8_t val, io_width_t)
+static void write_p3c8(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	vga.dac.write_index = val;
 	vga.dac.pel_index = 0;
 	vga.dac.state = DAC_WRITE;
@@ -130,8 +133,9 @@ static uint8_t read_p3c8(Bitu, io_width_t)
 	return vga.dac.write_index;
 }
 
-static void write_p3c9(io_port_t, uint8_t val, io_width_t)
+static void write_p3c9(io_port_t, io_val_t value, io_width_t)
 {
+	auto val = check_cast<uint8_t>(value);
 	val &= 0x3f;
 	switch (vga.dac.pel_index) {
 	case 0:

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -24,8 +24,9 @@
 #define gfx(blah) vga.gfx.blah
 static bool index9warned=false;
 
-static void write_p3ce(io_port_t, uint8_t val, io_width_t)
+static void write_p3ce(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	gfx(index) = val & 0x0f;
 }
 
@@ -34,8 +35,9 @@ static uint8_t read_p3ce(io_port_t, io_width_t)
 	return gfx(index);
 }
 
-static void write_p3cf(io_port_t, uint8_t val, io_width_t)
+static void write_p3cf(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (gfx(index)) {
 	case 0:	/* Set/Reset Register */
 		gfx(set_reset)=val & 0x0f;

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -755,7 +755,7 @@ public:
 	}
 };
 
-extern void XGA_Write(io_port_t port, uint32_t val, io_width_t width);
+extern void XGA_Write(io_port_t port, io_val_t value, io_width_t width);
 extern uint32_t XGA_Read(io_port_t port, io_width_t width);
 
 class VGA_MMIO_Handler final : public PageHandler {

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -23,9 +23,9 @@
 #include "vga.h"
 #include <math.h>
 
-void vga_write_p3d4(io_port_t port, uint8_t val, io_width_t);
+void vga_write_p3d4(io_port_t port, io_val_t value, io_width_t);
 uint8_t vga_read_p3d4(io_port_t port, io_width_t);
-void vga_write_p3d5(io_port_t port, uint8_t val, io_width_t);
+void vga_write_p3d5(io_port_t port, io_val_t value, io_width_t);
 uint8_t vga_read_p3d5(io_port_t port, io_width_t);
 
 uint8_t vga_read_p3da(io_port_t, io_width_t)
@@ -55,8 +55,9 @@ uint8_t vga_read_p3da(io_port_t, io_width_t)
 	return retval;
 }
 
-static void write_p3c2(io_port_t, uint8_t val, io_width_t)
+static void write_p3c2(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	vga.misc_output = val;
 
 	const io_port_t base = (val & 0x1) ? 0x3d0 : 0x3b0;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -32,8 +32,9 @@
 #include "support.h"
 #include "vga.h"
 
-static void write_crtc_index_other(io_port_t, uint8_t val, io_width_t)
+static void write_crtc_index_other(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// only receives 8-bit data per its IO port registration
 	vga.other.index = val;
 }
@@ -44,9 +45,10 @@ static uint8_t read_crtc_index_other(io_port_t, io_width_t)
 	return vga.other.index;
 }
 
-static void write_crtc_data_other(io_port_t, uint8_t val, io_width_t)
+static void write_crtc_data_other(io_port_t, io_val_t value, io_width_t)
 {
 	// only receives 8-bit data per its IO port registration
+	auto val = check_cast<uint8_t>(value);
 
 	switch (vga.other.index) {
 	case 0x00:		//Horizontal total
@@ -176,7 +178,7 @@ static uint8_t read_crtc_data_other(io_port_t, io_width_t)
 	return static_cast<uint8_t>(~0);
 }
 
-static void write_lightpen(io_port_t port, uint8_t /*val*/, io_width_t)
+static void write_lightpen(io_port_t port, io_val_t, io_width_t)
 {
 	// only receives 8-bit data per its IO port registration
 	switch (port) {
@@ -797,8 +799,9 @@ static void write_cga_color_select(uint8_t val)
 	}
 }
 
-static void write_cga(io_port_t port, uint8_t val, io_width_t)
+static void write_cga(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// only receives 8-bit data per its IO port registration
 	switch (port) {
 	case 0x3d8:
@@ -1087,8 +1090,9 @@ static void write_tandy_reg(uint8_t val)
 	}
 }
 
-static void write_tandy(io_port_t port, uint8_t val, io_width_t)
+static void write_tandy(io_port_t port, io_val_t value, io_width_t)
 {
+	auto val = check_cast<uint8_t>(value);
 	// only receives 8-bit data per its IO port registration
 	switch (port) {
 	case 0x3d8:
@@ -1137,9 +1141,10 @@ static void write_tandy(io_port_t port, uint8_t val, io_width_t)
 	}
 }
 
-static void write_pcjr(io_port_t port, uint8_t val, io_width_t)
+static void write_pcjr(io_port_t port, io_val_t value, io_width_t)
 {
 	// only receives 8-bit data per its IO port registration
+	const auto val = check_cast<uint8_t>(value);
 	switch (port) {
 	case 0x3da:
 		if (vga.tandy.pcjr_flipflop)
@@ -1273,8 +1278,9 @@ void Herc_Palette()
 	}
 }
 
-static void write_hercules(io_port_t port, uint8_t val, io_width_t)
+static void write_hercules(io_port_t port, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (port) {
 	case 0x3b8: {
 		// the protected bits can always be cleared but only be set if the

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -58,8 +58,9 @@ static void bank_setup_pvga1a() {
 	}
 }
 
-void write_p3cf_pvga1a(io_port_t reg, uint8_t val, io_width_t)
+void write_p3cf_pvga1a(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	if (pvga1a.locked() && reg >= 0x09 && reg <= 0x0e)
 		return;
 

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -30,8 +30,9 @@
 #include "support.h"
 #include "vga.h"
 
-void SVGA_S3_WriteCRTC(io_port_t reg, uint8_t val, io_width_t)
+void SVGA_S3_WriteCRTC(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (reg) {
 	case 0x31:	/* CR31 Memory Configuration */
 //TODO Base address
@@ -450,8 +451,9 @@ uint8_t SVGA_S3_ReadCRTC(io_port_t reg, io_width_t)
 	}
 }
 
-void SVGA_S3_WriteSEQ(io_port_t reg, uint8_t val, io_width_t)
+void SVGA_S3_WriteSEQ(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	if (reg > 0x8 && vga.s3.pll.lock != 0x6)
 		return;
 

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -28,13 +28,15 @@ uint8_t read_p3c4(io_port_t, io_width_t)
 	return seq(index);
 }
 
-void write_p3c4(io_port_t, uint8_t val, io_width_t)
+void write_p3c4(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	seq(index) = val;
 }
 
-void write_p3c5(io_port_t, uint8_t val, io_width_t)
+void write_p3c5(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	//	LOG_MSG("SEQ WRITE reg %X val %X",seq(index),val);
 	switch (seq(index)) {
 	case 0: /* Reset */ seq(reset) = val; break;

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -66,8 +66,9 @@ static SVGA_ET4K_DATA et4k = { 1,0,0,0,0,0,0,0,0, 0,0, 0,0,
 		return et4k.store_##port##_##index;
 
 // Tseng ET4K implementation
-void write_p3d5_et4k(io_port_t reg, uint8_t val, io_width_t)
+void write_p3d5_et4k(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	if (!et4k.extensionsEnabled && reg != 0x33)
 		return;
 
@@ -201,8 +202,9 @@ uint8_t read_p3d5_et4k(io_port_t reg, io_width_t)
 	return 0x0;
 }
 
-void write_p3c5_et4k(io_port_t reg, uint8_t val, io_width_t)
+void write_p3c5_et4k(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (reg) {
 		/*
 		3C4h index  6  (R/W): TS State Control
@@ -239,8 +241,9 @@ uint8_t read_p3c5_et4k(io_port_t reg, io_width_t)
 bit 0-3  64k Write bank number (0..15)
     4-7  64k Read bank number (0..15)
 */
-void write_p3cd_et4k(io_port_t, uint8_t val, io_width_t)
+void write_p3cd_et4k(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	vga.svga.bank_write = val & 0x0f;
 	vga.svga.bank_read = (val >> 4) & 0x0f;
 	VGA_SetupHandlers();
@@ -251,8 +254,9 @@ uint8_t read_p3cd_et4k(io_port_t, io_width_t)
 	return (vga.svga.bank_read << 4) | vga.svga.bank_write;
 }
 
-void write_p3c0_et4k(io_port_t reg, uint8_t val, io_width_t)
+void write_p3c0_et4k(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (reg) {
 		// 3c0 index 16h: ATC Miscellaneous
 		// VGADOC provides a lot of information, Ferarro documents only two bits
@@ -503,8 +507,9 @@ static SVGA_ET3K_DATA et3k = { 0,0,0,0,0,0,0,0,0,0, 0,0, 0,0, {0,0,0,0,0,0,0,0},
 	case 0x##index: \
 		return et3k.store_##port##_##index;
 
-void write_p3d5_et3k(io_port_t reg, uint8_t val, io_width_t)
+void write_p3d5_et3k(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (reg) {
 		// 3d4 index 1bh-21h: Hardware zoom control registers
 		// I am not sure if there was a piece of software that used these.
@@ -602,8 +607,9 @@ uint8_t read_p3d5_et3k(io_port_t reg, io_width_t)
 	return 0x0;
 }
 
-void write_p3c5_et3k(io_port_t reg, uint8_t val, io_width_t)
+void write_p3c5_et3k(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	switch (reg) {
 		// Both registers deal mostly with hardware zoom which is not implemented. Other bits
 		// seem to be useless for emulation with the exception of index 7 bit 4 (font select)
@@ -635,8 +641,9 @@ bit 0-2  64k Write bank number
            2  1M linear memory
 NOTES: 1M linear memory is not supported
 */
-void write_p3cd_et3k(io_port_t, uint8_t val, io_width_t)
+void write_p3cd_et3k(io_port_t, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	vga.svga.bank_write = val & 0x07;
 	vga.svga.bank_read = (val>>3) & 0x07;
 	vga.svga.bank_size = (val&0x40)?64*1024:128*1024;
@@ -648,8 +655,9 @@ uint8_t read_p3cd_et3k(io_port_t, io_width_t)
 	return (vga.svga.bank_read << 3) | vga.svga.bank_write | ((vga.svga.bank_size == 128 * 1024) ? 0 : 0x40);
 }
 
-void write_p3c0_et3k(io_port_t reg, uint8_t val, io_width_t)
+void write_p3c0_et3k(io_port_t reg, io_val_t value, io_width_t)
 {
+	const auto val = check_cast<uint8_t>(value);
 	// See ET4K notes.
 	switch (reg) {
 		STORE_ET3K(3c0, 16);

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1040,13 +1040,14 @@ uint32_t XGA_GetDualReg(Bit32u reg) {
 
 extern uint8_t vga_read_p3da(io_port_t port, io_width_t width);
 
-extern void vga_write_p3d4(io_port_t port, uint8_t val, io_width_t width);
+extern void vga_write_p3d4(io_port_t port, io_val_t value, io_width_t width);
 extern uint8_t vga_read_p3d4(io_port_t port, io_width_t width);
 
-extern void vga_write_p3d5(io_port_t port, uint8_t val, io_width_t width);
+extern void vga_write_p3d5(io_port_t port, io_val_t value, io_width_t width);
 extern uint8_t vga_read_p3d5(io_port_t port, io_width_t width);
 
-void XGA_Write(io_port_t port, uint32_t val, io_width_t width)
+// Writes can range from 8bit to 32bit
+void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 {
 	//	LOG_MSG("XGA: Write to port %x, val %8x, len %x", port,val, len);
 


### PR DESCRIPTION
This moves the value type size from being controlled by the interface (and risking overflow/wrapping) to a `check_cast<>` that now detects and flags wrong type sizes.

This is also "for free", given the boundary `assert`s in the `check_cast` only are only performed in debug builds.