### PR TITLE
Update the translation sources to reflect changes in the messages

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -5,13 +5,6 @@ Run INTRO and see Special Keys for window control hotkeys.
 :CONFIG_DISPLAY
 Number of display to use; values depend on OS and user settings.
 .
-:CONFIG_VSYNC
-Synchronize with display refresh rate if supported. This can
-reduce flickering and tearing, but may also impact performance.
-.
-:CONFIG_VSYNC_SKIP
-Number of microseconds to allow rendering to block before skipping the next frame.
-.
 :CONFIG_FULLRESOLUTION
 What resolution to use for fullscreen: 'original', 'desktop'
 or a fixed size (e.g. 1024x768).
@@ -26,6 +19,28 @@ Set window size when running in windowed mode:
              WxH format. For example: 1024x768.
              Scaling is not performed for output=surface.
 .
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Synchronize with display refresh rate if supported. This can
+reduce flickering and tearing, but may also impact performance.
+.
+:CONFIG_VSYNC_SKIP
+Number of microseconds to allow rendering to block before skipping the next frame. 0 disables this and will always render.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
+.
 :CONFIG_OUTPUT
 What video system to use for output.
 .
@@ -35,13 +50,13 @@ Use texture_renderer=auto for an automatic choice.
 .
 :CONFIG_CAPTURE_MOUSE
 Choose a mouse control method:
-   onclick:        Capture the mouse when clicking inside the window.
+   onclick:        Capture the mouse when clicking any button in the window.
    onstart:        Capture the mouse immediately on start.
-   seamless:       Never capture the mouse; let it move seamlessly.
+   seamless:       Let the mouse move seamlessly; captures only with middle-click or hotkey.
    nomouse:        Hide the mouse and don't send input to the game.
 Choose how middle-clicks are handled (second parameter):
    middlegame:     Middle-clicks are sent to the game.
-   middlerelease:  Middle-click will release the captured mouse.
+   middlerelease:  Middle-click will release the captured mouse, and also capture when seamless.
 Defaults (if not present or incorrect): seamless middlerelease
 .
 :CONFIG_SENSITIVITY
@@ -82,6 +97,22 @@ Amount of memory DOSBox has in megabytes.
 This value is best left at its default to avoid problems with some games,
 though few games might require a higher value.
 There is generally no speed advantage when raising this value.
+.
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
@@ -127,6 +158,29 @@ advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x, rgb3x,
 scan2x, scan3x, tv2x, tv3x, sharp (default).
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 CPU Core used in emulation. auto will switch to dynamic if available and
 appropriate.
@@ -163,6 +217,10 @@ Mixer block size, larger blocks might help sound stuttering but sound will also 
 .
 :CONFIG_PREBUFFER
 How many milliseconds of data to keep on top of the blocksize.
+.
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
 .
 :CONFIG_MIDIDEVICE
 Device that will receive the MIDI data (from the emulated MIDI
@@ -201,6 +259,29 @@ An optional percentage will scale the SoundFont's volume.
 For example: 'soundfont.sf2 50' will attenuate it by 50 percent.
 The scaling percentage can range from 1 to 500.
 .
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
+.
 :CONFIG_MODEL
 Model of synthesizer to use.
 'auto' picks the first model with available ROMs, in order as listed.
@@ -216,7 +297,6 @@ ROM files inside this directory may include any of the following:
   - MT32_CONTROL.ROM and MT32_PCM.ROM, for the 'mt32' model.
   - CM32L_CONTROL.ROM and CM32L_PCM.ROM, for the 'cm32l' model.
   - Unzipped MAME MT-32 and CM-32L ROMs, for the versioned models.
-
 .
 :CONFIG_SBTYPE
 Type of Sound Blaster to emulate. 'gb' is Game Blaster.
@@ -317,12 +397,14 @@ Enable IBM PS/1 Audio emulation.
 .
 :CONFIG_JOYSTICKTYPE
 Type of joystick to emulate: auto (default),
-none (disables joystick emulation),
-2axis (supports two joysticks),
-4axis (supports one joystick, first joystick used),
-4axis_2 (supports one joystick, second joystick used),
-fcs (Thrustmaster), ch (CH Flightstick).
-auto chooses emulation depending on real joystick(s).
+auto     : Detect and use any joystick(s), if possible.,
+2axis    : Support up to two joysticks.
+4axis    : Support the first joystick only.
+4axis_2  : Support the second joystick only.
+fcs      : Support a Thrustmaster-type joystick.
+ch       : Support a CH Flightstick-type joystick.
+hidden   : Prevent DOS from seeing the joystick(s), but enable them for mapping.
+disabled : Fully disable joysticks: won't be polled, mapped, or visible in DOS.
 (Remember to reset DOSBox's mapperfile if you saved it earlier)
 .
 :CONFIG_TIMED
@@ -533,6 +615,14 @@ DOSBox was started with the following command line parameters:
 Missing parameter.
 
 .
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
 :PROGRAM_MOUNT_CDROMS_FOUND
 CDROMs found: %d
 
@@ -625,6 +715,23 @@ Overlay %s on drive %c mounted.
 Can't move drive Z. Drive %c is mounted already.
 
 .
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
 :PROGRAM_MEM_CONVEN
 %10d kB free conventional memory
 
@@ -639,6 +746,28 @@ Can't move drive Z. Drive %c is mounted already.
 .
 :PROGRAM_MEM_UPPER
 %10d kB free upper memory in %d blocks (largest UMB %d kB)
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
 
 .
 :PROGRAM_LOADFIX_ALLOC
@@ -656,6 +785,54 @@ Used memory freed.
 :PROGRAM_LOADFIX_ERROR
 Memory allocation error.
 
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
 .
 :MSCDEX_SUCCESS
 MSCDEX installed.
@@ -697,8 +874,28 @@ MSCDEX: Failure: Unknown error.
 MSCDEX: Warning: Ignoring unsupported option '%s'.
 
 .
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
 :PROGRAM_RESCAN_SUCCESS
-Drive cache cleared.
+Drive re-scanned.
 
 .
 :PROGRAM_INTRO
@@ -708,7 +905,7 @@ DOSBox creates a shell for you which looks like old plain DOS.
 For information about basic mount type [34;1mintro mount[0m
 For information about CD-ROM support type [34;1mintro cdrom[0m
 For information about special keys type [34;1mintro special[0m
-For more imformation, visit DOSBox Staging wiki:[34;1m
+For more information, visit DOSBox Staging wiki:[34;1m
 https://github.com/dosbox-staging/dosbox-staging/wiki[0m
 
 [31;1mDOSBox will stop/exit without a warning if an error occurred![0m
@@ -792,7 +989,7 @@ They can be changed in the [33mkeymapper[0m.
 [33;1m%s+Enter[0m  Switch between fullscreen and window mode.
 [33;1m%s+Pause[0m  Pause/Unpause emulator.
 [33;1m%s+F1[0m   %s Start the [33mkeymapper[0m.
-[33;1m%s+F4[0m   %s Swap mounted disk image, update directory cache for all drives.
+[33;1m%s+F4[0m   %s Swap mounted disk image, scan for changes on all drives.
 [33;1m%s+F5[0m   %s Save a screenshot.
 [33;1m%s+F6[0m   %s Start/Stop recording sound output to a wave file.
 [33;1m%s+F7[0m   %s Start/Stop recording video output to a zmbv file.
@@ -801,6 +998,27 @@ They can be changed in the [33mkeymapper[0m.
 [33;1m%s+F11[0m  %s Slow down emulation.
 [33;1m%s+F12[0m  %s Speed up emulation.
 [33;1m%s+F12[0m    Unlock speed (turbo button/fast forward).
+
+.
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
 
 .
 :PROGRAM_BOOT_NOT_EXIST
@@ -816,7 +1034,7 @@ Image file is read-only! Might create problems.
 
 .
 :PROGRAM_BOOT_PRINT_ERROR
-This command boots DOSBox from either a floppy or hard disk image.
+This command boots DOSBox Staging from either a floppy or hard disk image.
 
 For this command, one can specify a succession of floppy disks swappable
 by pressing %s+F4, and -l specifies the mounted drive to boot from.  If
@@ -825,9 +1043,7 @@ The only bootable drive letters are A, C, and D.  For booting from a hard
 drive (C or D), the image should have already been mounted using the
 [34;1mIMGMOUNT[0m command.
 
-The syntax of this command is:
-
-[34;1mBOOT [diskimg1.img diskimg2.img] [-l driveletter][0m
+Type [34;1mBOOT /?[0m for the syntax of this command.[0m
 
 .
 :PROGRAM_BOOT_UNABLE
@@ -852,6 +1068,23 @@ Available PCjr cartridge commands: %s
 .
 :PROGRAM_BOOT_CART_NO_CMDS
 No PCjr cartridge commands found
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
 .
 :PROGRAM_LOADROM_SPECIFY_FILE
 Must specify ROM file to load.
@@ -1009,14 +1242,31 @@ Codepage %i has been loaded
 Codepage %i has been loaded for layout %s
 
 .
-:PROGRAM_KEYB_SHOWHELP
-[32;1mKEYB[0m [keyboard layout ID[ codepage number[ codepage file]]]
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
 
-Some examples:
-  [32;1mKEYB[0m: Display currently loaded codepage.
-  [32;1mKEYB[0m sp: Load the spanish (SP) layout, use an appropriate codepage.
-  [32;1mKEYB[0m sp 850: Load the spanish (SP) layout, use codepage 850.
-  [32;1mKEYB[0m sp 850 mycp.cpi: Same as above, but use file mycp.cpi.
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
 :PROGRAM_KEYB_NOERROR
@@ -1041,6 +1291,33 @@ None or invalid codepage file for layout %s
 
 
 .
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
 :SHELL_ILLEGAL_PATH
 Illegal Path.
 
@@ -1048,6 +1325,28 @@ Illegal Path.
 :SHELL_CMD_HELP
 If you want a list of all supported commands type [33;1mhelp /all[0m .
 A short list of the most often used commands:
+
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
 
 .
 :SHELL_CMD_ECHO_ON
@@ -1105,25 +1404,58 @@ Type 'date MM-DD-YYYY' to change.
 M/D/Y
 .
 :SHELL_CMD_DATE_HELP_LONG
-DATE [[/T] [/H] [/S] | MM-DD-YYYY]
-  MM-DD-YYYY: new date to set
-  /S:         Permanently use host time and date as DOS time
-  /F:         Switch back to DOSBox internal time (opposite of /S)
-  /T:         Only display date
-  /H:         Synchronize with host
+Usage:
+  [32;1mdate[0m [/t]
+  [32;1mdate[0m /h
+  [32;1mdate[0m [36;1mDATE[0m
+
+Where:
+  [36;1mDATE[0m is the new date to set to, in the format of [36;1mMM-DD-YYYY[0m.
+
+Notes:
+  Running [32;1mdate[0m without an argument shows the current date, or only a date
+  with the /t option. You can force a date synchronization of with the host
+  system with the /h option, or manually specify a new date to set to.
+
+Examples:
+  [32;1mdate[0m
+  [32;1mdate[0m /h
+  [32;1mdate[0m [36;1m10-11-2012[0m
 
 .
 :SHELL_CMD_TIME_HELP
-Displays the internal time.
+Displays or changes the internal time.
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
 
 .
 :SHELL_CMD_TIME_NOW
 Current time: 
 .
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
 :SHELL_CMD_TIME_HELP_LONG
-TIME [/T] [/H]
-  /T:         Display simple time
-  /H:         Synchronize with host
+Usage:
+  [32;1mtime[0m [/t]
+  [32;1mtime[0m /h
+  [32;1mtime[0m [36;1mTIME[0m
+
+Where:
+  [36;1mTIME[0m is the new time to set to, in the format of [36;1mhh:mm:ss[0m.
+
+Notes:
+  Running [32;1mtime[0m without an argument shows the current time, or a simple time
+  with the /t option. You can force a time synchronization of with the host
+  system with the /h option, or manually specify a new time to set to.
+
+Examples:
+  [32;1mtime[0m
+  [32;1mtime[0m /h
+  [32;1mtime[0m [36;1m13:14:15[0m
 
 .
 :SHELL_CMD_MKDIR_ERROR
@@ -1171,7 +1503,7 @@ GOTO: Label %s not found.
 
 .
 :SHELL_CMD_FILE_NOT_FOUND
-File %s not found.
+File not found: %s
 
 .
 :SHELL_CMD_FILE_EXISTS
@@ -1204,10 +1536,26 @@ Illegal command: %s.
 
 .
 :SHELL_CMD_PAUSE
-Press any key to continue...
+Press a key to continue...
 .
 :SHELL_CMD_PAUSE_HELP
-Waits for 1 keystroke to continue.
+Waits for a keystroke to continue.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
 
 .
 :SHELL_CMD_COPY_FAILURE
@@ -1242,7 +1590,7 @@ It's only possible to use SUBST on Local drives
 :SHELL_STARTUP_CGA
 º DOSBox supports Composite CGA mode.                                º
 º Use [31mF12[37m to set composite output ON, OFF, or AUTO (default).        º
-º [31m(%s+)F11[37m changes hue; [31m%s+%s+F11[37m selects early/late CGA model.%s  º
+º [31mF10[37m selects the CGA settings to change and [31m(%s+)F11[37m changes it.   º
 º                                                                    º
 
 .
@@ -1288,7 +1636,22 @@ Type CD without parameters to display the current drive and directory.
 
 .
 :SHELL_CMD_CLS_HELP
-Clear the screen.
+Clears the DOS screen.
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
 
 .
 :SHELL_CMD_DIR_HELP
@@ -1296,85 +1659,285 @@ Displays a list of files and subdirectories in a directory.
 
 .
 :SHELL_CMD_DIR_HELP_LONG
-DIR [drive:][path][filename] [/[W|B]] [/P] [/[AD]|[A-D]] [/O[-][N|E|S|D]]
+Usage:
+  [32;1mdir[0m [36;1m[PATTERN][0m [/w] [/b] [/p] [ad] [a-d] [/o[37;1mORDER[0m]
 
-  [drive:][path][filename]
-              Specifies drive, directory, and/or files to list.
-  /W          Uses wide list format.
-  /B          Uses bare format (no heading information or summary).
-  /P          Pauses after each screenful of information.
-  /AD         Displays all directories.
-  /A-D        Displays all files.
-  /O          List by files in sorted order.
-               -  Prefix to reverse order
-  sortorder    N  By name (alphabetic)       S  By size (smallest first)
-               E  By extension (alphabetic)  D  By date & time (oldest first)
+Where:
+  [36;1mPATTERN[0m is either an exact filename or an inexact filename with wildcards,
+          which are the asterisk (*) and the question mark (?). A path can be
+          specified in the pattern to list contents in the specified directory.
+  [37;1mORDER[0m   is a listing order, including [37;1mn[0m (by name, alphabetic), [37;1ms[0m (by size,
+          smallest first), [37;1me[0m (by extension, alphabetic), [37;1md[0m (by date/time,
+          oldest first), with an optional [37;1m-[0m prefix to reverse order.
+  /w      lists 5 files/directories in a row; /b      lists the names only.
+  /o[37;1mORDER[0m orders the list (see above)         /p      pauses after each screen.
+  /ad     lists all directories;              /a-d    lists all files.
+
+Notes:
+  Running [32;1mdir[0m without an argument lists all files and subdirectories in the
+  current directory, which is the same as [32;1mdir[0m [36;1m*.*[0m.
+
+Examples:
+  [32;1mdir[0m [36;1m[0m
+  [32;1mdir[0m [36;1mgames.*[0m /p
+  [32;1mdir[0m [36;1mc:\games\*.exe[0m /b /o[37;1m-d[0m
 
 .
 :SHELL_CMD_ECHO_HELP
-Display messages and enable/disable command echoing.
+Displays messages and enables/disables command echoing.
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
 
 .
 :SHELL_CMD_EXIT_HELP
-Exit from the shell.
+Exits from the DOS shell.
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
 
 .
 :SHELL_CMD_HELP_HELP
-Show help.
+Displays help information for DOS commands.
 
 .
 :SHELL_CMD_HELP_HELP_LONG
-HELP [command]
+Usage:
+  [32;1mhelp[0m
+  [32;1mhelp[0m /a[ll]
+  [32;1mhelp[0m [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is the name of an internal DOS command, such as [36;1mdir[0m.
+
+Notes:
+  - Running [32;1mecho[0m without an argument displays a DOS command list.
+  - You can view a full list of internal commands with the /a or /all option.
+  - Instead of [32;1mhelp[0m [36;1mCOMMAND[0m, you can also get command help with [36;1mCOMMAND[0m /?.
+
+Examples:
+  [32;1mhelp[0m [36;1mdir[0m
+  [32;1mhelp[0m /all
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
 
 .
 :SHELL_CMD_MKDIR_HELP
-Make Directory.
+Creates a directory.
 
 .
 :SHELL_CMD_MKDIR_HELP_LONG
-MKDIR [drive:][path]
-MD [drive:][path]
+Usage:
+  [32;1mmd[0m [36;1mDIRECTORY[0m
+  [32;1mmkdir[0m [36;1mDIRECTORY[0m
+
+Where:
+  [36;1mDIRECTORY[0m is the name of the directory to create.
+
+Notes:
+  - The directory must be an exact name and does not yet exist.
+  - You can specify a path where the directory will be created.
+
+Examples:
+  [32;1mmd[0m [36;1mnewdir[0m
+  [32;1mmd[0m [36;1mc:\games\dir[0m
 
 .
 :SHELL_CMD_RMDIR_HELP
-Remove Directory.
+Removes a directory.
 
 .
 :SHELL_CMD_RMDIR_HELP_LONG
-RMDIR [drive:][path]
-RD [drive:][path]
+Usage:
+  [32;1mrd[0m [36;1mDIRECTORY[0m
+  [32;1mrmdir[0m [36;1mDIRECTORY[0m
+
+Where:
+  [36;1mDIRECTORY[0m is the name of the directory to remove.
+
+Notes:
+  The directory must be empty with no files or subdirectories.
+
+Examples:
+  [32;1mrd[0m [36;1memptydir[0m
 
 .
 :SHELL_CMD_SET_HELP
-Change environment variables.
+Displays or changes environment variables.
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
 
 .
 :SHELL_CMD_IF_HELP
 Performs conditional processing in batch programs.
 
 .
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
 :SHELL_CMD_GOTO_HELP
-Jump to a labeled line in a batch script.
+Jumps to a labeled line in a batch program.
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
 
 .
 :SHELL_CMD_SHIFT_HELP
-Leftshift commandline parameters in a batch script.
+Left-shifts command-line parameters in a batch program.
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
 
 .
 :SHELL_CMD_TYPE_HELP
-Display the contents of a text-file.
+Display the contents of a text file.
 
 .
 :SHELL_CMD_TYPE_HELP_LONG
-TYPE [drive:][path][filename]
+Usage:
+  [32;1mtype[0m [36;1mFILE[0m
+
+Where:
+  [36;1mFILE[0m is the name of the file to display.
+
+Notes:
+  The file must be an exact file name, optionally with a path.
+  This command is only for viewing text files, not binary files.
+
+Examples:
+  [32;1mtype[0m [36;1mtext.txt[0m
+  [32;1mtype[0m [36;1mc:\dos\readme.txt[0m
 
 .
 :SHELL_CMD_REM_HELP
-Add comments in a batch file.
+Adds comments in a batch program.
 
 .
 :SHELL_CMD_REM_HELP_LONG
-REM [comment]
+Usage:
+  [32;1mrem[0m [36;1mCOMMENT[0m
+
+Where:
+  [36;1mCOMMENT[0m is any comment you want to add.
+
+Notes:
+  Adding comments to a batch program can make it easier to understand.
+  You can also temporarily comment out some commands with this command.
+
+Examples:
+  [32;1mrem[0m [36;1mThis is my test batch program.[0m
 
 .
 :SHELL_CMD_NO_WILD
@@ -1386,10 +1949,21 @@ Renames one or more files.
 
 .
 :SHELL_CMD_RENAME_HELP_LONG
-RENAME [drive:][path]filename1 filename2.
-REN [drive:][path]filename1 filename2.
+Usage:
+  [32;1mren[0m [37;1mSOURCE[0m [36;1mDESTINATION[0m
+  [32;1mrename[0m [37;1mSOURCE[0m [36;1mDESTINATION[0m
 
-Note that you can not specify a new drive or path for your destination file.
+Where:
+  [37;1mSOURCE[0m      is the name of the file to rename.
+  [36;1mDESTINATION[0m is the new name for the renamed file.
+
+Notes:
+  - The source file must be an exact file name, optionally with a path.
+  - The destination file must be an exact file name without a path.
+
+Examples:
+  [32;1mren[0m [37;1moldname[0m [36;1mnewname[0m
+  [32;1mren[0m [37;1mc:\dos\file.txt[0m [36;1mf.txt[0m
 
 .
 :SHELL_CMD_DELETE_HELP
@@ -1418,27 +1992,115 @@ Examples:
 
 .
 :SHELL_CMD_COPY_HELP
-Copy files.
+Copies one or more files.
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
 
 .
 :SHELL_CMD_CALL_HELP
-Start a batch file from within another batch file.
+Starts a batch program from within another batch program.
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
 
 .
 :SHELL_CMD_SUBST_HELP
 Assign an internal directory to a drive.
 
 .
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
 :SHELL_CMD_LOADHIGH_HELP
-Loads a program into upper memory (requires xms=true,umb=true).
+Loads a DOS program into upper memory.
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
 
 .
 :SHELL_CMD_LS_HELP
-List directory contents.
+Displays directory contents in the wide list format.
 
 .
 :SHELL_CMD_LS_HELP_LONG
-ls [/?] [PATTERN]
+Usage:
+  [32;1mls[0m [36;1mPATTERN[0m
+  [32;1mls[0m [36;1mPATH[0m
+
+Where:
+  [36;1mPATTERN[0m can be either an exact filename or an inexact filename with
+          wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mPATH[0m    is an exact path in a mounted DOS drive to list contents.
+
+Notes:
+  The command will list directories in [34;1mblue[0m, executable DOS programs
+   (*.com, *.exe, *.bat) in [32;1mgreen[0m, and other files in the normal color.
+
+Examples:
+  [32;1mls[0m [36;1mfile.txt[0m
+  [32;1mls[0m [36;1mc*.ba?[0m
 
 .
 :SHELL_CMD_LS_PATH_ERR
@@ -1446,23 +2108,51 @@ ls: cannot access '%s': No such file or directory
 
 .
 :SHELL_CMD_CHOICE_HELP
-Waits for a keypress and sets ERRORLEVEL.
+Waits for a keypress and sets an ERRORLEVEL value.
 
 .
 :SHELL_CMD_CHOICE_HELP_LONG
-CHOICE [/C:choices] [/N] [/S] text
-  /C[:]choices  -  Specifies allowable keys.  Default is: yn.
-  /N  -  Do not display the choices at end of prompt.
-  /S  -  Enables case-sensitive choices to be selected.
-  text  -  The text to display as a prompt.
+Usage:
+  [32;1mchoice[0m [36;1m[TEXT][0m
+  [32;1mchoice[0m /c[:][37;1mCHOICES[0m [/n] [/s] [36;1m[TEXT][0m
 
-.
-:SHELL_CMD_ATTRIB_HELP
-Does nothing. Provided for compatibility.
+Where:
+  [36;1mTEXT[0m         is the text to display as a prompt, or empty.
+  /c[:][37;1mCHOICES[0m Specifies allowable keys, which default to [37;1myn[0m.
+  /n           Do not display the choices at end of prompt.
+  /s           Enables case-sensitive choices to be selected.
+
+Notes:
+  This command sets an ERRORLEVEL value starting from 1 according to the
+  allowable keys specified in /c option, and the user input can then be checked
+  with [32;1mif[0m command. With /n option only the specified text will be displayed,
+  but not the actual choices (such as the default [37;1m[Y,N]?[0m) in the end.
+
+Examples:
+  [32;1mchoice[0m [36;1mContinue?[0m
+  [32;1mchoice[0m /c:[37;1mabc[0m /s [36;1mType the letter a, b, or c[0m
 
 .
 :SHELL_CMD_PATH_HELP
-Provided for compatibility.
+Displays or sets a search path for executable files.
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .
 :SHELL_CMD_VER_HELP

--- a/contrib/translations/utf-8/de/de-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/de/de-0.78.0-alpha.txt
@@ -1,14 +1,9 @@
- :CONFIG_FULLSCREEN
-Startet DOSBox direkt im Vollbildmodus.
+:CONFIG_FULLSCREEN
+Start directly in fullscreen.
+Run INTRO and see Special Keys for window control hotkeys.
 .
 :CONFIG_DISPLAY
 Nummer der zu verwendenden Anzeige; die Werte hängen vom Betriebssystem und den Benutzereinstellungen ab.
-.
-:CONFIG_VSYNC
-Vertikale Synchronisations-Einstellung nicht implementiert (Einstellung wird ignoriert)
-.
-:CONFIG_VSYNC_SKIP
-Anzahl der Mikrosekunden, die das Rendering verzögert sein darf, bevor der nächste Frame übersprungen wird.
 .
 :CONFIG_FULLRESOLUTION
 Welche Auflösung für den Vollbildmodus verwendet werden soll: 'Original', 'Desktop'
@@ -25,6 +20,27 @@ Bestimmt die Fenstergröße, die verwendet werden soll:
   <custom>:  Skaliere den Fensterinhalt auf die angegebenen
              Abmessungen, im Format BxH. Zum Beispiel: 1024x768.
              Die Skalierung wird bei output=surface nicht durchgeführt.
+.
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Vertikale Synchronisations-Einstellung nicht implementiert (Einstellung wird ignoriert)
+.
+:CONFIG_VSYNC_SKIP
+Anzahl der Mikrosekunden, die das Rendering verzögert sein darf, bevor der nächste Frame übersprungen wird.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
 .
 :CONFIG_OUTPUT
 Welches Videosystem soll für die Ausgabe verwendet werden.
@@ -91,6 +107,22 @@ Dieser Wert wird am besten auf dem Standardwert belassen, um Probleme mit einige
 obwohl einige wenige Programme einen höheren Wert benötigen könnten.
 Es gibt generell keinen Geschwindigkeitsvorteil, wenn du diesen Wert erhöhst.
 .
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
+.
 :CONFIG_STARTUP_VERBOSITY
 Bestimmt die Ausführlichkeit der Anzeigen, bevor das Programm angezeigt wird:
 Verbosität  | Logo  |Willkommen| Frühe Ausgabe
@@ -134,6 +166,29 @@ advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x, rgb3x,
 scan2x, scan3x, tv2x, tv3x, sharp (Standard).
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 CPU-Kern, der für die Emulation verwendet wird. 'auto' schaltet auf dynamisch, wenn verfügbar und
 angemessen.
@@ -169,6 +224,10 @@ Mixer-Blockgröße. Größere Blöcke können stotternde Audioausgabe verhindern
 :CONFIG_PREBUFFER
 Wie viele Millisekunden an Daten zusätzlich zur Blockgröße vorgehalten werden sollen.
 .
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
+.
 :CONFIG_MIDIDEVICE
 Gerät, das die MIDI-Daten empfangen wird (von der emulierten MIDI
 Schnittstelle - MPU-401). Wähle eine der folgenden Möglichkeiten:
@@ -203,6 +262,29 @@ des 'soundfonts' Verzeichnises innerhalb deines DOSBox Konfigurations-Verzeichni
 Ein optionaler Prozentsatz skaliert die Lautstärke des SoundFonts.
 Zum Beispiel: 'soundfont.sf2 50' wird die Lautstärke um 50 Prozent abschwächen.
 Der Skalierungsprozentsatz kann von 1 bis 500 reichen.
+.
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
 .
 :CONFIG_MODEL
 Modell des zu verwendenden Synthesizers. Die Voreinstellung (auto) bevorzugt CM-32L
@@ -404,6 +486,10 @@ Du kannst deine MOUNT-Zeilen hier einfügen.
 .
 :CONFIG_SUGGESTED_VALUES
 Mögliche Werte
+.
+:
+ :CONFIG_FULLSCREEN
+Startet DOSBox direkt im Vollbildmodus.
 .
 :PROGRAM_CONFIG_NOCONFIGFILE
 Keine Konfigurationsdatei geladen!
@@ -1495,5 +1581,495 @@ Beispiele:
   [32;1mdel[0m [36;1mtest.bat[0m
   [32;1mdel[0m [36;1mc*.*[0m
   [32;1mdel[0m [36;1ma?b.c*[0m
+
+.
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
+
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
+.
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
+
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
+.
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
+
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
+
+.
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
+
+.
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
+
+.
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .

--- a/contrib/translations/utf-8/en/en-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/en/en-0.78.0-alpha.txt
@@ -5,13 +5,6 @@ Run INTRO and see Special Keys for window control hotkeys.
 :CONFIG_DISPLAY
 Number of display to use; values depend on OS and user settings.
 .
-:CONFIG_VSYNC
-Synchronize with display refresh rate if supported. This can
-reduce flickering and tearing, but may also impact performance.
-.
-:CONFIG_VSYNC_SKIP
-Number of microseconds to allow rendering to block before skipping the next frame.
-.
 :CONFIG_FULLRESOLUTION
 What resolution to use for fullscreen: 'original', 'desktop'
 or a fixed size (e.g. 1024x768).
@@ -26,6 +19,28 @@ Set window size when running in windowed mode:
              WxH format. For example: 1024x768.
              Scaling is not performed for output=surface.
 .
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Synchronize with display refresh rate if supported. This can
+reduce flickering and tearing, but may also impact performance.
+.
+:CONFIG_VSYNC_SKIP
+Number of microseconds to allow rendering to block before skipping the next frame. 0 disables this and will always render.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
+.
 :CONFIG_OUTPUT
 What video system to use for output.
 .
@@ -35,13 +50,13 @@ Use texture_renderer=auto for an automatic choice.
 .
 :CONFIG_CAPTURE_MOUSE
 Choose a mouse control method:
-   onclick:        Capture the mouse when clicking inside the window.
+   onclick:        Capture the mouse when clicking any button in the window.
    onstart:        Capture the mouse immediately on start.
-   seamless:       Never capture the mouse; let it move seamlessly.
+   seamless:       Let the mouse move seamlessly; captures only with middle-click or hotkey.
    nomouse:        Hide the mouse and don't send input to the game.
 Choose how middle-clicks are handled (second parameter):
    middlegame:     Middle-clicks are sent to the game.
-   middlerelease:  Middle-click will release the captured mouse.
+   middlerelease:  Middle-click will release the captured mouse, and also capture when seamless.
 Defaults (if not present or incorrect): seamless middlerelease
 .
 :CONFIG_SENSITIVITY
@@ -82,6 +97,22 @@ Amount of memory DOSBox has in megabytes.
 This value is best left at its default to avoid problems with some games,
 though few games might require a higher value.
 There is generally no speed advantage when raising this value.
+.
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
 .
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
@@ -127,6 +158,29 @@ advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x, rgb3x,
 scan2x, scan3x, tv2x, tv3x, sharp (default).
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 CPU Core used in emulation. auto will switch to dynamic if available and
 appropriate.
@@ -163,6 +217,10 @@ Mixer block size, larger blocks might help sound stuttering but sound will also 
 .
 :CONFIG_PREBUFFER
 How many milliseconds of data to keep on top of the blocksize.
+.
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
 .
 :CONFIG_MIDIDEVICE
 Device that will receive the MIDI data (from the emulated MIDI
@@ -201,6 +259,29 @@ An optional percentage will scale the SoundFont's volume.
 For example: 'soundfont.sf2 50' will attenuate it by 50 percent.
 The scaling percentage can range from 1 to 500.
 .
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
+.
 :CONFIG_MODEL
 Model of synthesizer to use.
 'auto' picks the first model with available ROMs, in order as listed.
@@ -216,7 +297,6 @@ ROM files inside this directory may include any of the following:
   - MT32_CONTROL.ROM and MT32_PCM.ROM, for the 'mt32' model.
   - CM32L_CONTROL.ROM and CM32L_PCM.ROM, for the 'cm32l' model.
   - Unzipped MAME MT-32 and CM-32L ROMs, for the versioned models.
-
 .
 :CONFIG_SBTYPE
 Type of Sound Blaster to emulate. 'gb' is Game Blaster.
@@ -317,12 +397,14 @@ Enable IBM PS/1 Audio emulation.
 .
 :CONFIG_JOYSTICKTYPE
 Type of joystick to emulate: auto (default),
-none (disables joystick emulation),
-2axis (supports two joysticks),
-4axis (supports one joystick, first joystick used),
-4axis_2 (supports one joystick, second joystick used),
-fcs (Thrustmaster), ch (CH Flightstick).
-auto chooses emulation depending on real joystick(s).
+auto     : Detect and use any joystick(s), if possible.,
+2axis    : Support up to two joysticks.
+4axis    : Support the first joystick only.
+4axis_2  : Support the second joystick only.
+fcs      : Support a Thrustmaster-type joystick.
+ch       : Support a CH Flightstick-type joystick.
+hidden   : Prevent DOS from seeing the joystick(s), but enable them for mapping.
+disabled : Fully disable joysticks: won't be polled, mapped, or visible in DOS.
 (Remember to reset DOSBox's mapperfile if you saved it earlier)
 .
 :CONFIG_TIMED
@@ -533,6 +615,14 @@ DOSBox was started with the following command line parameters:
 Missing parameter.
 
 .
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
 :PROGRAM_MOUNT_CDROMS_FOUND
 CDROMs found: %d
 
@@ -625,6 +715,23 @@ Overlay %s on drive %c mounted.
 Can't move drive Z. Drive %c is mounted already.
 
 .
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
 :PROGRAM_MEM_CONVEN
 %10d kB free conventional memory
 
@@ -639,6 +746,28 @@ Can't move drive Z. Drive %c is mounted already.
 .
 :PROGRAM_MEM_UPPER
 %10d kB free upper memory in %d blocks (largest UMB %d kB)
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
 
 .
 :PROGRAM_LOADFIX_ALLOC
@@ -656,6 +785,54 @@ Used memory freed.
 :PROGRAM_LOADFIX_ERROR
 Memory allocation error.
 
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
 .
 :MSCDEX_SUCCESS
 MSCDEX installed.
@@ -697,8 +874,28 @@ MSCDEX: Failure: Unknown error.
 MSCDEX: Warning: Ignoring unsupported option '%s'.
 
 .
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
 :PROGRAM_RESCAN_SUCCESS
-Drive cache cleared.
+Drive re-scanned.
 
 .
 :PROGRAM_INTRO
@@ -708,7 +905,7 @@ DOSBox creates a shell for you which looks like old plain DOS.
 For information about basic mount type [34;1mintro mount[0m
 For information about CD-ROM support type [34;1mintro cdrom[0m
 For information about special keys type [34;1mintro special[0m
-For more imformation, visit DOSBox Staging wiki:[34;1m
+For more information, visit DOSBox Staging wiki:[34;1m
 https://github.com/dosbox-staging/dosbox-staging/wiki[0m
 
 [31;1mDOSBox will stop/exit without a warning if an error occurred![0m
@@ -792,7 +989,7 @@ They can be changed in the [33mkeymapper[0m.
 [33;1m%s+Enter[0m  Switch between fullscreen and window mode.
 [33;1m%s+Pause[0m  Pause/Unpause emulator.
 [33;1m%s+F1[0m   %s Start the [33mkeymapper[0m.
-[33;1m%s+F4[0m   %s Swap mounted disk image, update directory cache for all drives.
+[33;1m%s+F4[0m   %s Swap mounted disk image, scan for changes on all drives.
 [33;1m%s+F5[0m   %s Save a screenshot.
 [33;1m%s+F6[0m   %s Start/Stop recording sound output to a wave file.
 [33;1m%s+F7[0m   %s Start/Stop recording video output to a zmbv file.
@@ -801,6 +998,27 @@ They can be changed in the [33mkeymapper[0m.
 [33;1m%s+F11[0m  %s Slow down emulation.
 [33;1m%s+F12[0m  %s Speed up emulation.
 [33;1m%s+F12[0m    Unlock speed (turbo button/fast forward).
+
+.
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
 
 .
 :PROGRAM_BOOT_NOT_EXIST
@@ -816,7 +1034,7 @@ Image file is read-only! Might create problems.
 
 .
 :PROGRAM_BOOT_PRINT_ERROR
-This command boots DOSBox from either a floppy or hard disk image.
+This command boots DOSBox Staging from either a floppy or hard disk image.
 
 For this command, one can specify a succession of floppy disks swappable
 by pressing %s+F4, and -l specifies the mounted drive to boot from.  If
@@ -825,9 +1043,7 @@ The only bootable drive letters are A, C, and D.  For booting from a hard
 drive (C or D), the image should have already been mounted using the
 [34;1mIMGMOUNT[0m command.
 
-The syntax of this command is:
-
-[34;1mBOOT [diskimg1.img diskimg2.img] [-l driveletter][0m
+Type [34;1mBOOT /?[0m for the syntax of this command.[0m
 
 .
 :PROGRAM_BOOT_UNABLE
@@ -852,6 +1068,23 @@ Available PCjr cartridge commands: %s
 .
 :PROGRAM_BOOT_CART_NO_CMDS
 No PCjr cartridge commands found
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
 .
 :PROGRAM_LOADROM_SPECIFY_FILE
 Must specify ROM file to load.
@@ -1009,14 +1242,31 @@ Codepage %i has been loaded
 Codepage %i has been loaded for layout %s
 
 .
-:PROGRAM_KEYB_SHOWHELP
-[32;1mKEYB[0m [keyboard layout ID[ codepage number[ codepage file]]]
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
 
-Some examples:
-  [32;1mKEYB[0m: Display currently loaded codepage.
-  [32;1mKEYB[0m sp: Load the spanish (SP) layout, use an appropriate codepage.
-  [32;1mKEYB[0m sp 850: Load the spanish (SP) layout, use codepage 850.
-  [32;1mKEYB[0m sp 850 mycp.cpi: Same as above, but use file mycp.cpi.
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
 :PROGRAM_KEYB_NOERROR
@@ -1041,6 +1291,33 @@ None or invalid codepage file for layout %s
 
 
 .
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
 :SHELL_ILLEGAL_PATH
 Illegal Path.
 
@@ -1048,6 +1325,28 @@ Illegal Path.
 :SHELL_CMD_HELP
 If you want a list of all supported commands type [33;1mhelp /all[0m .
 A short list of the most often used commands:
+
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
 
 .
 :SHELL_CMD_ECHO_ON
@@ -1105,25 +1404,58 @@ Type 'date MM-DD-YYYY' to change.
 M/D/Y
 .
 :SHELL_CMD_DATE_HELP_LONG
-DATE [[/T] [/H] [/S] | MM-DD-YYYY]
-  MM-DD-YYYY: new date to set
-  /S:         Permanently use host time and date as DOS time
-  /F:         Switch back to DOSBox internal time (opposite of /S)
-  /T:         Only display date
-  /H:         Synchronize with host
+Usage:
+  [32;1mdate[0m [/t]
+  [32;1mdate[0m /h
+  [32;1mdate[0m [36;1mDATE[0m
+
+Where:
+  [36;1mDATE[0m is the new date to set to, in the format of [36;1mMM-DD-YYYY[0m.
+
+Notes:
+  Running [32;1mdate[0m without an argument shows the current date, or only a date
+  with the /t option. You can force a date synchronization of with the host
+  system with the /h option, or manually specify a new date to set to.
+
+Examples:
+  [32;1mdate[0m
+  [32;1mdate[0m /h
+  [32;1mdate[0m [36;1m10-11-2012[0m
 
 .
 :SHELL_CMD_TIME_HELP
-Displays the internal time.
+Displays or changes the internal time.
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
 
 .
 :SHELL_CMD_TIME_NOW
 Current time: 
 .
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
 :SHELL_CMD_TIME_HELP_LONG
-TIME [/T] [/H]
-  /T:         Display simple time
-  /H:         Synchronize with host
+Usage:
+  [32;1mtime[0m [/t]
+  [32;1mtime[0m /h
+  [32;1mtime[0m [36;1mTIME[0m
+
+Where:
+  [36;1mTIME[0m is the new time to set to, in the format of [36;1mhh:mm:ss[0m.
+
+Notes:
+  Running [32;1mtime[0m without an argument shows the current time, or a simple time
+  with the /t option. You can force a time synchronization of with the host
+  system with the /h option, or manually specify a new time to set to.
+
+Examples:
+  [32;1mtime[0m
+  [32;1mtime[0m /h
+  [32;1mtime[0m [36;1m13:14:15[0m
 
 .
 :SHELL_CMD_MKDIR_ERROR
@@ -1171,7 +1503,7 @@ GOTO: Label %s not found.
 
 .
 :SHELL_CMD_FILE_NOT_FOUND
-File %s not found.
+File not found: %s
 
 .
 :SHELL_CMD_FILE_EXISTS
@@ -1204,10 +1536,26 @@ Illegal command: %s.
 
 .
 :SHELL_CMD_PAUSE
-Press any key to continue...
+Press a key to continue...
 .
 :SHELL_CMD_PAUSE_HELP
-Waits for 1 keystroke to continue.
+Waits for a keystroke to continue.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
 
 .
 :SHELL_CMD_COPY_FAILURE
@@ -1242,7 +1590,7 @@ It's only possible to use SUBST on Local drives
 :SHELL_STARTUP_CGA
 ║ DOSBox supports Composite CGA mode.                                ║
 ║ Use [31mF12[37m to set composite output ON, OFF, or AUTO (default).        ║
-║ [31m(%s+)F11[37m changes hue; [31m%s+%s+F11[37m selects early/late CGA model.%s  ║
+║ [31mF10[37m selects the CGA settings to change and [31m(%s+)F11[37m changes it.   ║
 ║                                                                    ║
 
 .
@@ -1288,7 +1636,22 @@ Type CD without parameters to display the current drive and directory.
 
 .
 :SHELL_CMD_CLS_HELP
-Clear the screen.
+Clears the DOS screen.
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
 
 .
 :SHELL_CMD_DIR_HELP
@@ -1296,85 +1659,285 @@ Displays a list of files and subdirectories in a directory.
 
 .
 :SHELL_CMD_DIR_HELP_LONG
-DIR [drive:][path][filename] [/[W|B]] [/P] [/[AD]|[A-D]] [/O[-][N|E|S|D]]
+Usage:
+  [32;1mdir[0m [36;1m[PATTERN][0m [/w] [/b] [/p] [ad] [a-d] [/o[37;1mORDER[0m]
 
-  [drive:][path][filename]
-              Specifies drive, directory, and/or files to list.
-  /W          Uses wide list format.
-  /B          Uses bare format (no heading information or summary).
-  /P          Pauses after each screenful of information.
-  /AD         Displays all directories.
-  /A-D        Displays all files.
-  /O          List by files in sorted order.
-               -  Prefix to reverse order
-  sortorder    N  By name (alphabetic)       S  By size (smallest first)
-               E  By extension (alphabetic)  D  By date & time (oldest first)
+Where:
+  [36;1mPATTERN[0m is either an exact filename or an inexact filename with wildcards,
+          which are the asterisk (*) and the question mark (?). A path can be
+          specified in the pattern to list contents in the specified directory.
+  [37;1mORDER[0m   is a listing order, including [37;1mn[0m (by name, alphabetic), [37;1ms[0m (by size,
+          smallest first), [37;1me[0m (by extension, alphabetic), [37;1md[0m (by date/time,
+          oldest first), with an optional [37;1m-[0m prefix to reverse order.
+  /w      lists 5 files/directories in a row; /b      lists the names only.
+  /o[37;1mORDER[0m orders the list (see above)         /p      pauses after each screen.
+  /ad     lists all directories;              /a-d    lists all files.
+
+Notes:
+  Running [32;1mdir[0m without an argument lists all files and subdirectories in the
+  current directory, which is the same as [32;1mdir[0m [36;1m*.*[0m.
+
+Examples:
+  [32;1mdir[0m [36;1m[0m
+  [32;1mdir[0m [36;1mgames.*[0m /p
+  [32;1mdir[0m [36;1mc:\games\*.exe[0m /b /o[37;1m-d[0m
 
 .
 :SHELL_CMD_ECHO_HELP
-Display messages and enable/disable command echoing.
+Displays messages and enables/disables command echoing.
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
 
 .
 :SHELL_CMD_EXIT_HELP
-Exit from the shell.
+Exits from the DOS shell.
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
 
 .
 :SHELL_CMD_HELP_HELP
-Show help.
+Displays help information for DOS commands.
 
 .
 :SHELL_CMD_HELP_HELP_LONG
-HELP [command]
+Usage:
+  [32;1mhelp[0m
+  [32;1mhelp[0m /a[ll]
+  [32;1mhelp[0m [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is the name of an internal DOS command, such as [36;1mdir[0m.
+
+Notes:
+  - Running [32;1mecho[0m without an argument displays a DOS command list.
+  - You can view a full list of internal commands with the /a or /all option.
+  - Instead of [32;1mhelp[0m [36;1mCOMMAND[0m, you can also get command help with [36;1mCOMMAND[0m /?.
+
+Examples:
+  [32;1mhelp[0m [36;1mdir[0m
+  [32;1mhelp[0m /all
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
 
 .
 :SHELL_CMD_MKDIR_HELP
-Make Directory.
+Creates a directory.
 
 .
 :SHELL_CMD_MKDIR_HELP_LONG
-MKDIR [drive:][path]
-MD [drive:][path]
+Usage:
+  [32;1mmd[0m [36;1mDIRECTORY[0m
+  [32;1mmkdir[0m [36;1mDIRECTORY[0m
+
+Where:
+  [36;1mDIRECTORY[0m is the name of the directory to create.
+
+Notes:
+  - The directory must be an exact name and does not yet exist.
+  - You can specify a path where the directory will be created.
+
+Examples:
+  [32;1mmd[0m [36;1mnewdir[0m
+  [32;1mmd[0m [36;1mc:\games\dir[0m
 
 .
 :SHELL_CMD_RMDIR_HELP
-Remove Directory.
+Removes a directory.
 
 .
 :SHELL_CMD_RMDIR_HELP_LONG
-RMDIR [drive:][path]
-RD [drive:][path]
+Usage:
+  [32;1mrd[0m [36;1mDIRECTORY[0m
+  [32;1mrmdir[0m [36;1mDIRECTORY[0m
+
+Where:
+  [36;1mDIRECTORY[0m is the name of the directory to remove.
+
+Notes:
+  The directory must be empty with no files or subdirectories.
+
+Examples:
+  [32;1mrd[0m [36;1memptydir[0m
 
 .
 :SHELL_CMD_SET_HELP
-Change environment variables.
+Displays or changes environment variables.
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
 
 .
 :SHELL_CMD_IF_HELP
 Performs conditional processing in batch programs.
 
 .
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
 :SHELL_CMD_GOTO_HELP
-Jump to a labeled line in a batch script.
+Jumps to a labeled line in a batch program.
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
 
 .
 :SHELL_CMD_SHIFT_HELP
-Leftshift commandline parameters in a batch script.
+Left-shifts command-line parameters in a batch program.
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
 
 .
 :SHELL_CMD_TYPE_HELP
-Display the contents of a text-file.
+Display the contents of a text file.
 
 .
 :SHELL_CMD_TYPE_HELP_LONG
-TYPE [drive:][path][filename]
+Usage:
+  [32;1mtype[0m [36;1mFILE[0m
+
+Where:
+  [36;1mFILE[0m is the name of the file to display.
+
+Notes:
+  The file must be an exact file name, optionally with a path.
+  This command is only for viewing text files, not binary files.
+
+Examples:
+  [32;1mtype[0m [36;1mtext.txt[0m
+  [32;1mtype[0m [36;1mc:\dos\readme.txt[0m
 
 .
 :SHELL_CMD_REM_HELP
-Add comments in a batch file.
+Adds comments in a batch program.
 
 .
 :SHELL_CMD_REM_HELP_LONG
-REM [comment]
+Usage:
+  [32;1mrem[0m [36;1mCOMMENT[0m
+
+Where:
+  [36;1mCOMMENT[0m is any comment you want to add.
+
+Notes:
+  Adding comments to a batch program can make it easier to understand.
+  You can also temporarily comment out some commands with this command.
+
+Examples:
+  [32;1mrem[0m [36;1mThis is my test batch program.[0m
 
 .
 :SHELL_CMD_NO_WILD
@@ -1386,10 +1949,21 @@ Renames one or more files.
 
 .
 :SHELL_CMD_RENAME_HELP_LONG
-RENAME [drive:][path]filename1 filename2.
-REN [drive:][path]filename1 filename2.
+Usage:
+  [32;1mren[0m [37;1mSOURCE[0m [36;1mDESTINATION[0m
+  [32;1mrename[0m [37;1mSOURCE[0m [36;1mDESTINATION[0m
 
-Note that you can not specify a new drive or path for your destination file.
+Where:
+  [37;1mSOURCE[0m      is the name of the file to rename.
+  [36;1mDESTINATION[0m is the new name for the renamed file.
+
+Notes:
+  - The source file must be an exact file name, optionally with a path.
+  - The destination file must be an exact file name without a path.
+
+Examples:
+  [32;1mren[0m [37;1moldname[0m [36;1mnewname[0m
+  [32;1mren[0m [37;1mc:\dos\file.txt[0m [36;1mf.txt[0m
 
 .
 :SHELL_CMD_DELETE_HELP
@@ -1418,27 +1992,115 @@ Examples:
 
 .
 :SHELL_CMD_COPY_HELP
-Copy files.
+Copies one or more files.
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
 
 .
 :SHELL_CMD_CALL_HELP
-Start a batch file from within another batch file.
+Starts a batch program from within another batch program.
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
 
 .
 :SHELL_CMD_SUBST_HELP
 Assign an internal directory to a drive.
 
 .
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
 :SHELL_CMD_LOADHIGH_HELP
-Loads a program into upper memory (requires xms=true,umb=true).
+Loads a DOS program into upper memory.
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
 
 .
 :SHELL_CMD_LS_HELP
-List directory contents.
+Displays directory contents in the wide list format.
 
 .
 :SHELL_CMD_LS_HELP_LONG
-ls [/?] [PATTERN]
+Usage:
+  [32;1mls[0m [36;1mPATTERN[0m
+  [32;1mls[0m [36;1mPATH[0m
+
+Where:
+  [36;1mPATTERN[0m can be either an exact filename or an inexact filename with
+          wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mPATH[0m    is an exact path in a mounted DOS drive to list contents.
+
+Notes:
+  The command will list directories in [34;1mblue[0m, executable DOS programs
+   (*.com, *.exe, *.bat) in [32;1mgreen[0m, and other files in the normal color.
+
+Examples:
+  [32;1mls[0m [36;1mfile.txt[0m
+  [32;1mls[0m [36;1mc*.ba?[0m
 
 .
 :SHELL_CMD_LS_PATH_ERR
@@ -1446,23 +2108,51 @@ ls: cannot access '%s': No such file or directory
 
 .
 :SHELL_CMD_CHOICE_HELP
-Waits for a keypress and sets ERRORLEVEL.
+Waits for a keypress and sets an ERRORLEVEL value.
 
 .
 :SHELL_CMD_CHOICE_HELP_LONG
-CHOICE [/C:choices] [/N] [/S] text
-  /C[:]choices  -  Specifies allowable keys.  Default is: yn.
-  /N  -  Do not display the choices at end of prompt.
-  /S  -  Enables case-sensitive choices to be selected.
-  text  -  The text to display as a prompt.
+Usage:
+  [32;1mchoice[0m [36;1m[TEXT][0m
+  [32;1mchoice[0m /c[:][37;1mCHOICES[0m [/n] [/s] [36;1m[TEXT][0m
 
-.
-:SHELL_CMD_ATTRIB_HELP
-Does nothing. Provided for compatibility.
+Where:
+  [36;1mTEXT[0m         is the text to display as a prompt, or empty.
+  /c[:][37;1mCHOICES[0m Specifies allowable keys, which default to [37;1myn[0m.
+  /n           Do not display the choices at end of prompt.
+  /s           Enables case-sensitive choices to be selected.
+
+Notes:
+  This command sets an ERRORLEVEL value starting from 1 according to the
+  allowable keys specified in /c option, and the user input can then be checked
+  with [32;1mif[0m command. With /n option only the specified text will be displayed,
+  but not the actual choices (such as the default [37;1m[Y,N]?[0m) in the end.
+
+Examples:
+  [32;1mchoice[0m [36;1mContinue?[0m
+  [32;1mchoice[0m /c:[37;1mabc[0m /s [36;1mType the letter a, b, or c[0m
 
 .
 :SHELL_CMD_PATH_HELP
-Provided for compatibility.
+Displays or sets a search path for executable files.
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .
 :SHELL_CMD_VER_HELP

--- a/contrib/translations/utf-8/es/es-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/es/es-0.78.0-alpha.txt
@@ -4,12 +4,6 @@ Inicia DOSBox directamente en pantalla completa.
 :CONFIG_DISPLAY
 Número de pantalla a usar; valores dependen del SO y configuración del usuario.
 .
-:CONFIG_VSYNC
-Configuración de sincronización vertical no implementada (ajuste ignorado)
-.
-:CONFIG_VSYNC_SKIP
-Number of microseconds to allow rendering to block before skipping the next frame.
-.
 :CONFIG_FULLRESOLUTION
 Qué resolución usar para pantalla completa: 'original', 'desktop'
 o un tamaño fijo (por ejemplo, 1024x768).
@@ -26,6 +20,27 @@ Establezca tamaño de ventana a utilizar cuando se ejecute en modo ventana:
   <custom>:  Escala el contenido de la ventana a las dimensiones
              indicadas, en formato LxA. Por ejemplo: 1024x768.
              El escalado no se realiza para output=surface.
+.
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Configuración de sincronización vertical no implementada (ajuste ignorado)
+.
+:CONFIG_VSYNC_SKIP
+Number of microseconds to allow rendering to block before skipping the next frame. 0 disables this and will always render.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
 .
 :CONFIG_OUTPUT
 Qué sistema de vídeo utilizar para la salida.
@@ -91,6 +106,22 @@ Es mejor dejar este valor por defecto para evitar problemas con algunos juegos,
 aunque algunos juegos pueden requerir un valor más alto.
 Por lo general, no hay ninguna ventaja de velocidad al aumentar este valor.
 .
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
+.
 :CONFIG_STARTUP_VERBOSITY
 Controla la verbosidad antes de mostrar el programa:
 Verbosidad  | Inicio | Bienvenida | Salida anticipada
@@ -135,6 +166,29 @@ advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x, rgb3x,
 scan2x, scan3x, tv2x, tv3x, sharp (por defecto).
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 Núcleo de CPU utilizado en emulación. auto cambiará a dinámico si esta disponible y
 es apropiado.
@@ -170,6 +224,10 @@ Tamaño del bloque mezclador, bloques grandes podrían ayudar al tartamudeo del 
 .
 :CONFIG_PREBUFFER
 Cuántos milisegundos de datos para mantener encima del tamaño de bloque.
+.
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
 .
 :CONFIG_MIDIDEVICE
 Dispositivo que recibirá los datos MIDI (de la interfaz emulada
@@ -207,6 +265,29 @@ configuración de DOSBox.
 Un porcentaje opcional escalará el volumen del SoundFont.
 Por ejemplo: 'soundfont.sf2 50' lo atenuará en un 50%.
 El porcentaje de escalado puede ir de 1 a 500.
+.
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
 .
 :CONFIG_MODEL
 Modelo de sintetizador a utilizar. El valor por defecto (auto) prefiere CM-32L
@@ -1456,6 +1537,121 @@ DOS versión %d.%02d
 La versión DOS especificada no es correcta.
 
 .
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
+
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
+.
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
 :PROGRAM_INTRO_CDROM_WINDOWS
 [2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
 DOSBox provides CD-ROM emulation on several levels.
@@ -1496,8 +1692,307 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
+
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
+.
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
+
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
+
+.
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
+
+.
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
+
+.
 :SHELL_CMD_HELP_HELP_LONG
-HELP [command]
+Usage:
+  [32;1mhelp[0m
+  [32;1mhelp[0m /a[ll]
+  [32;1mhelp[0m [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is the name of an internal DOS command, such as [36;1mdir[0m.
+
+Notes:
+  - Running [32;1mecho[0m without an argument displays a DOS command list.
+  - You can view a full list of internal commands with the /a or /all option.
+  - Instead of [32;1mhelp[0m [36;1mCOMMAND[0m, you can also get command help with [36;1mCOMMAND[0m /?.
+
+Examples:
+  [32;1mhelp[0m [36;1mdir[0m
+  [32;1mhelp[0m /all
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
+
+.
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
 
 .
 :SHELL_CMD_DELETE_HELP_LONG
@@ -1519,5 +2014,96 @@ Examples:
   [32;1mdel[0m [36;1mtest.bat[0m
   [32;1mdel[0m [36;1mc*.*[0m
   [32;1mdel[0m [36;1ma?b.c*[0m
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .

--- a/contrib/translations/utf-8/fr/fr-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/fr/fr-0.78.0-alpha.txt
@@ -4,12 +4,6 @@ Démarrer DOSBox directement en mode plein écran.
 :CONFIG_DISPLAY
 Nombre d'écrans à utiliser ; les valeurs dépendent de l'OS et des paramètres utilisateur.
 .
-:CONFIG_VSYNC
-Paramètre de synchro verticale non implémenté (paramètre ignoré)
-.
-:CONFIG_VSYNC_SKIP
-Number of microseconds to allow rendering to block before skipping the next frame.
-.
 :CONFIG_FULLRESOLUTION
 Résolution utiliser pour le mode plein écran : 'original', 'desktop' (bureau)
 ou une taille fixe (ex. : 1024x768).
@@ -26,6 +20,27 @@ Défini la taille de la fenêtre pendant l'utilisation en mode fenêtré :
   <custom>:  Redimensionne le contenu de la fenêtre
              aux dimensions indiquées, au format lxh (largeur x hauteur). Par ex. : 1024x768.
              Le redimensionnement n'est pas disponible pour output=surface.
+.
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Paramètre de synchro verticale non implémenté (paramètre ignoré)
+.
+:CONFIG_VSYNC_SKIP
+Number of microseconds to allow rendering to block before skipping the next frame. 0 disables this and will always render.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
 .
 :CONFIG_OUTPUT
 Système vidéo à utiliser pour la sortie.
@@ -91,6 +106,22 @@ Il est mieux de laisser cette valeur d'origine pour éviter les problèmes avec 
 bien que quelques jeux puissent nécessiter une valeur plus élevée.
 Il n'y a généralement pas de gain de vitesse en augmentant cette valeur.
 .
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
+.
 :CONFIG_STARTUP_VERBOSITY
 Contrôle la verbosité avant l'affichage du programme :
             | Écran de démarrage | Écran de bienvenue | Sorties écran de démarrage
@@ -135,6 +166,29 @@ advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x, rgb3x,
 scan2x, scan3x, tv2x, tv3x, sharp (défaut).
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 Core CPU utilisé dans l'émulation. 'auto' bascule de 'normal' à 'dynamic' si c'est disponible et
 approprié.
@@ -172,6 +226,10 @@ Taille de bloc du mixer, des blocs plus grands peuvent aider pour les saccades d
 :CONFIG_PREBUFFER
 Nombre de millisecondes de données à garder en amont du paramètre blocksize.
 .
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
+.
 :CONFIG_MIDIDEVICE
 Préiphérique qui recevra les données MIDI (depuis l'interface
 émulée - MPU-401). Choisissez l'un des suivants :
@@ -208,6 +266,29 @@ de DOSBox.
 Un pourcentage optionnel réglera le volume du SoundFont.
 Par exemple: 'soundfont.sf2 50' le diminuera de 50 pourcents.
 L'échelle de pourcentage peut aller de 1 à 500.
+.
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
 .
 :CONFIG_MODEL
 Modèle de synthétiseur à utiliser. Par défaut, préfère CM-32L
@@ -1459,6 +1540,121 @@ DOS version %d.%02d
 La version spécifiée de DOS n'est pas correcte.
 
 .
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
+
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
+.
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
 :PROGRAM_INTRO_CDROM_WINDOWS
 [2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
 DOSBox provides CD-ROM emulation on several levels.
@@ -1499,8 +1695,307 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
+
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
+.
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
+
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
+
+.
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
+
+.
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
+
+.
 :SHELL_CMD_HELP_HELP_LONG
-HELP [command]
+Usage:
+  [32;1mhelp[0m
+  [32;1mhelp[0m /a[ll]
+  [32;1mhelp[0m [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is the name of an internal DOS command, such as [36;1mdir[0m.
+
+Notes:
+  - Running [32;1mecho[0m without an argument displays a DOS command list.
+  - You can view a full list of internal commands with the /a or /all option.
+  - Instead of [32;1mhelp[0m [36;1mCOMMAND[0m, you can also get command help with [36;1mCOMMAND[0m /?.
+
+Examples:
+  [32;1mhelp[0m [36;1mdir[0m
+  [32;1mhelp[0m /all
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
+
+.
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
 
 .
 :SHELL_CMD_DELETE_HELP_LONG
@@ -1522,5 +2017,96 @@ Examples:
   [32;1mdel[0m [36;1mtest.bat[0m
   [32;1mdel[0m [36;1mc*.*[0m
   [32;1mdel[0m [36;1ma?b.c*[0m
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .

--- a/contrib/translations/utf-8/it/it-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/it/it-0.78.0-alpha.txt
@@ -7,13 +7,6 @@ tasti di scelta rapida per il controllo della finestra.
 Numero dello schermo da utilizzare; Il valore dipende dal sistema operativo
 e dalle impostazioni dell'utente.
 .
-:CONFIG_VSYNC
-Impostazione Sincronizzazione Verticale non implementata (parametro ignorato).
-.
-:CONFIG_VSYNC_SKIP
-Numero di microsecondi per consentire il blocco del rendering prima di saltare
-il fotogramma successivo.
-.
 :CONFIG_FULLRESOLUTION
 Risoluzione da usare a schermo intero: 'original', 'desktop' o
 dimensione fissa (es. 1024x768).
@@ -28,6 +21,28 @@ in modalità finestra:
   <custom>:  Ridimensiona la finestra in base alle dimensioni indicate
              nel formato WxH. Per esempio: 1024x768.
              Il ridimensionamento non viene eseguito con output=surface.
+.
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Impostazione Sincronizzazione Verticale non implementata (parametro ignorato).
+.
+:CONFIG_VSYNC_SKIP
+Numero di microsecondi per consentire il blocco del rendering prima di saltare
+il fotogramma successivo.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
 .
 :CONFIG_OUTPUT
 Sistema video da usare per l'output.
@@ -90,6 +105,22 @@ Si consiglia di non modificare questo valore per evitare problemi con alcuni
 giochi, anche se potrebbe essere necessario aumentarlo per farne funzionare
 alcuni. Di solito non vi è nessun guadagno in velocità alzando questo valore.
 .
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
+.
 :CONFIG_STARTUP_VERBOSITY
 Determina il livello di verbosità prima di visualizzare il programma: 
 Verbosità   |Schermata iniziale|Schermata di benvenuto|Output DOSBox
@@ -132,6 +163,29 @@ incorporati:
 advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x,
 rgb3x, scan2x, scan3x, tv2x, tv3x, sharp (predefinito).
+.
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
 .
 :CONFIG_CORE
 Core CPU usato nell'emulazione. 'auto' diventerà 'dynamic' quando possibile e
@@ -180,6 +234,10 @@ ma possono introdurre ritardi.
 Quantità di dati, in millisecondi, da tenere in cima alla dimensione dei 
 blocchi.
 .
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
+.
 :CONFIG_MIDIDEVICE
 Dispositivo che riceverà i dati MIDI (dall'interfaccia MIDI emulata - MPU-401).
 Scegli uno dei seguenti:
@@ -215,6 +273,29 @@ assoluto o relativo, o il nome di un file .sf2 all'interno della cartella
 Una percentuale opzionale regolerà il volume del SoundFont.
 Ad esempio: 'soundfont.sf2 50' lo attenuerà del 50 percento.
 La percentuale del volume può variare da 1 a 500.
+.
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
 .
 :CONFIG_MODEL
 Modello di sintetizzatore da utilizzare. 
@@ -1534,5 +1615,495 @@ DOS versione %d.%02d
 .
 :SHELL_CMD_VER_INVALID
 La versione DOS specificata non è corretta.
+
+.
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
+
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
+.
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
+
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
+.
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
+
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
+
+.
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
+
+.
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
+
+.
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .

--- a/contrib/translations/utf-8/pl/pl-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/pl/pl-0.78.0-alpha.txt
@@ -4,12 +4,6 @@ Włącz DOSBoxa na pełnym ekranie.
 :CONFIG_DISPLAY
 Numer ekranu do użycia; wartość zależy od ustawień użytkownika.
 .
-:CONFIG_VSYNC
-Vertical sync setting not implemented (setting ignored)
-.
-:CONFIG_VSYNC_SKIP
-Number of microseconds to allow rendering to block before skipping the next frame.
-.
 :CONFIG_FULLRESOLUTION
 Jakiej rozdzielczości użyć w pełnym ekranie: 'original', 'desktop',
 lub dokładna rozdzielczość (np. 1024x768).
@@ -26,6 +20,27 @@ Ustaw wielkość okna w trybie okienkowym:
   <custom>:  Skaluj zawartość okna do wybranej wielkości, użyj
              wielkości w formacie XxY, na przykład: 1024x768.
              Skalowanie nie działa dla output=surface.
+.
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Vertical sync setting not implemented (setting ignored)
+.
+:CONFIG_VSYNC_SKIP
+Number of microseconds to allow rendering to block before skipping the next frame. 0 disables this and will always render.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
 .
 :CONFIG_OUTPUT
 What video system to use for output.
@@ -89,6 +104,22 @@ Tej wartości lepiej nie zmieniać aby uniknąć problemów z niektórymi grami,
 choć czasem gry mogą wymagać większej wartości.
 Generalnie podniesienie tej wartości nie powoduje przyśpieszenia.
 .
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
+.
 :CONFIG_STARTUP_VERBOSITY
 Controls verbosity prior to displaying the program:
             | Splash | Welcome | Early stdout
@@ -133,6 +164,29 @@ advinterp2x, advinterp3x, advmame2x, advmame3x,
 crt-easymode-flat, crt-fakelottes-flat, rgb2x, rgb3x,
 scan2x, scan3x, tv2x, tv3x, sharp (default).
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 CPU Core used in emulation. auto will switch to dynamic if available and
 appropriate.
@@ -168,6 +222,10 @@ Mixer block size, larger blocks might help sound stuttering but sound will also 
 .
 :CONFIG_PREBUFFER
 How many milliseconds of data to keep on top of the blocksize.
+.
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
 .
 :CONFIG_MIDIDEVICE
 Device that will receive the MIDI data (from the emulated MIDI
@@ -205,6 +263,29 @@ directory.
 An optional percentage will scale the SoundFont's volume.
 For example: 'soundfont.sf2 50' will attenuate it by 50 percent.
 The scaling percentage can range from 1 to 500.
+.
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
 .
 :CONFIG_MODEL
 Model of synthesizer to use. The default (auto) prefers CM-32L
@@ -1448,6 +1529,121 @@ DOS wersja %d.%02d
 Podana wersja DOSa jest nieprawidłowa.
 
 .
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
+
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
+
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
+.
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
 :PROGRAM_INTRO_CDROM_WINDOWS
 [2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
 DOSBox provides CD-ROM emulation on several levels.
@@ -1488,11 +1684,310 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
+
+.
 :PROGRAM_BOOT_UNABLE
 Unable to boot off of drive %c
 .
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
+.
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
+
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
+
+.
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
+
+.
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
+
+.
 :SHELL_CMD_HELP_HELP_LONG
-HELP [command]
+Usage:
+  [32;1mhelp[0m
+  [32;1mhelp[0m /a[ll]
+  [32;1mhelp[0m [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is the name of an internal DOS command, such as [36;1mdir[0m.
+
+Notes:
+  - Running [32;1mecho[0m without an argument displays a DOS command list.
+  - You can view a full list of internal commands with the /a or /all option.
+  - Instead of [32;1mhelp[0m [36;1mCOMMAND[0m, you can also get command help with [36;1mCOMMAND[0m /?.
+
+Examples:
+  [32;1mhelp[0m [36;1mdir[0m
+  [32;1mhelp[0m /all
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
+
+.
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
 
 .
 :SHELL_CMD_DELETE_HELP_LONG
@@ -1514,5 +2009,96 @@ Examples:
   [32;1mdel[0m [36;1mtest.bat[0m
   [32;1mdel[0m [36;1mc*.*[0m
   [32;1mdel[0m [36;1ma?b.c*[0m
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .

--- a/contrib/translations/utf-8/ru/ru-0.78.0-alpha.txt
+++ b/contrib/translations/utf-8/ru/ru-0.78.0-alpha.txt
@@ -4,12 +4,6 @@
 :CONFIG_DISPLAY
 Количество используемых дисплеев. Значение зависит от ОС и настроек пользователя.
 .
-:CONFIG_VSYNC
-Настройка вертикальной синхронизации не реализована (настройка игнорируется).
-.
-:CONFIG_VSYNC_SKIP
-Количество микросекунд, в течение которых рендеринг должен блокироваться перед пропуском следующего кадра.
-.
 :CONFIG_FULLRESOLUTION
 Какое разрешение использовать для полноэкранного режима: 'original', 'desktop'
 или фиксированный размер (например, '1024x768').
@@ -26,6 +20,27 @@
   'ШxВ':     Масштабировать содержимое окна до указанного размера,
              в формате ШxВ. Например: '1024x768'.
              Масштабирование не выполняется для output=surface.
+.
+:CONFIG_WINDOW_POSITION
+Set initial window position when running in windowed mode:
+  auto:      Let the window manager decide the position.
+  <custom>:  Set window position in X,Y format. For example: 250,100
+             0,0 is the top-left corner of the screen.
+.
+:CONFIG_WINDOW_DECORATIONS
+Controls whether to display window decorations in windowed mode.
+.
+:CONFIG_VSYNC
+Настройка вертикальной синхронизации не реализована (настройка игнорируется).
+.
+:CONFIG_VSYNC_SKIP
+Number of microseconds to allow rendering to block before skipping the next frame. 0 disables this and will always render.
+.
+:CONFIG_MAX_RESOLUTION
+Optionally restricts the viewport resolution within the window/screen:
+  auto:      The viewport fills the window/screen (default).
+  <custom>:  Set max viewport resolution in WxH format.
+             For example: 960x720
 .
 :CONFIG_OUTPUT
 Какую видеосистему использовать для вывода изображения.
@@ -91,6 +106,22 @@
 хотя несколько игр могут потребовать более высоких значений.
 Как правило, нет никакого преимущества в скорости при повышении этой величины.
 .
+:CONFIG_VMEMSIZE
+Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.
+.
+:CONFIG_VESA_MODES
+Controls the selection of VESA 1.2 and 2.0 modes offered:
+  compatible   A tailored selection that maximizes game compatibility.
+               This is recommended along with 4 or 8 MB of video memory.
+  all          Offers all modes for a given video memory size, however
+               some games may not use them properly (flickering) or may need
+               more system memory (mem = ) to use them.
+.
+:CONFIG_AUTOEXEC_SECTION
+How autoexec sections are handled from multiple config files.
+join      : combines them into one big section (legacy behavior).
+overwrite : use the last one encountered, like other conf settings.
+.
 :CONFIG_STARTUP_VERBOSITY
 Управляет количеством информации перед отображением программы:
             | Заставка | Приветствие | Ранний вывод
@@ -135,6 +166,29 @@ auto        | 'low', если передан исполняемый файл и�
 'crt-easymode-flat', 'crt-fakelottes-flat', 'rgb2x', 'rgb3x',
 'scan2x', 'scan3x', 'tv2x', 'tv3x', 'sharp' ('default').
 .
+:CONFIG_COMPOSITE
+Enable composite mode on start. 'auto' lets the program decide.
+Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.
+      Then read the new settings from your console and enter them here.
+.
+:CONFIG_ERA
+Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.
+.
+:CONFIG_HUE
+Appearance of RGB palette. For example, adjust until sky is blue.
+.
+:CONFIG_SATURATION
+Intensity of colors, from washed out to vivid.
+.
+:CONFIG_CONTRAST
+Ratio between the dark and light area.
+.
+:CONFIG_BRIGHTNESS
+Luminosity of the image, from dark to light.
+.
+:CONFIG_CONVERGENCE
+Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).
+.
 :CONFIG_CORE
 Ядро процессора, используемое в эмуляции.
 Значение 'auto' переключит в динамический режим, если это доступно и целесообразно.
@@ -169,6 +223,10 @@ auto        | 'low', если передан исполняемый файл и�
 .
 :CONFIG_PREBUFFER
 Сколько миллисекунд нужно удерживать данные на вершине блока.
+.
+:CONFIG_NEGOTIATE
+Allow system audio driver to negotiate optimal rate and blocksize
+as close to the specified values as possible.
 .
 :CONFIG_MIDIDEVICE
 Устройство, которое будет принимать MIDI-данные (от эмулированного MIDI
@@ -205,6 +263,29 @@ auto        | 'low', если передан исполняемый файл и�
 Необязательный процент будет изменять громкость SoundFont.
 Например: 'FluidR3_GM.sf2 50' ослабит её на 50 процентов.
 Изменение в процентах может быть в пределах от 1 до 500.
+.
+:CONFIG_CHORUS
+Chorus effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All five must be provided in-order and space-separated.
+  They are: voice-count level speed depth modulation-wave, where:
+  - voice-count is an integer from 0 to 99.
+  - level is a decimal from 0.0 to 10.0
+  - speed is a decimal, measured in Hz, from 0.1 to 5.0
+  - depth is a decimal from 0.0 to 21.0
+  - modulation-wave is either 'sine' or 'triangle'
+  For example: chorus = 3 1.2 0.3 8.0 sine
+.
+:CONFIG_REVERB
+Reverb effect: 'auto', 'on', 'off', or custom values.
+When using custom values:
+  All four must be provided in-order and space-separated.
+  They are: room-size damping width level, where:
+  - room-size is a decimal from 0.0 to 1.0
+  - damping is a decimal from 0.0 to 1.0
+  - width is a decimal from 0.0 to 100.0
+  - level is a decimal from 0.0 to 1.0
+  For example: reverb = 0.61 0.23 0.76 0.56
 .
 :CONFIG_MODEL
 Модель синтезатора для использования. По умолчанию 'auto' предпочитает CM-32L,
@@ -270,30 +351,30 @@ DOSBox, с последующей проверкой других мест в с
 используемые с Timidity должны работать хорошо.
 .
 :CONFIG_SIDMODEL
-Модель чипа для эмуляции в карте Innovation SSI-2001:
- - auto:  Выбирает чип 6581.
- - 6581:  Оригинальный чип, известный своим басовитым и богатым звучанием.
- - 8580:  Более поздняя модификация, более точно соответствующая спецификации SID.
-          В нём исправлено смещение постоянного тока 6581 и он менее подвержен искажениям.
-          8580 является опцией для репродуктивных карт, таких как DuoSID.
- - none:  Отключает карту.
+Model of chip to emulate in the Innovation SSI-2001 card:
+ - auto:  Selects the 6581 chip.
+ - 6581:  The original chip, known for its bassy and rich character.
+ - 8580:  A later revision that more closely matched the SID specification.
+          It fixed the 6581's DC bias and is less prone to distortion.
+          The 8580 is an option on reproduction cards, like the DuoSID.
+ - none:  Disables the card.
 .
 :CONFIG_SIDCLOCK
-Тактовая частота чипа SID, которая на картах устанавливается перемычкой.
- - default: использует 0.895 МГц, для оригинальной карты SSI-2001.
- - c64ntsc: использует 1.023 МГц, для NTSC Commodore PC и DuoSID.
- - c64pal:  использует 0.985 МГц, для PAL Commodore PC и DuoSID.
- - hardsid: использует 1.000 МГц, доступно на DuoSID.
+The SID chip's clock frequency, which is jumperable on reproduction cards.
+ - default: uses 0.895 MHz, per the original SSI-2001 card.
+ - c64ntsc: uses 1.023 MHz, per NTSC Commodore PCs and the DuoSID.
+ - c64pal:  uses 0.985 MHz, per PAL Commodore PCs and the DuoSID.
+ - hardsid: uses 1.000 MHz, available on the DuoSID.
 .
 :CONFIG_SIDPORT
-Адрес порта ввода-вывода SSI-2001.
+The IO port address of the Innovation SSI-2001.
 .
 :CONFIG_6581FILTER
-Аналоговая фильтрация SID означала, что каждый чип был физически уникален.
-Регулирует силу фильтрации 6581 в процентах от 0 до 100.
+The SID's analog filtering meant that each chip was physically unique.
+Adjusts the 6581's filtering strength as a percent from 0 to 100.
 .
 :CONFIG_8580FILTER
-Регулирует силу фильтрации 8580 в процентах от 0 до 100.
+Adjusts the 8580's filtering strength as a percent from 0 to 100.
 .
 :CONFIG_PCSPEAKER
 Включить эмуляцию PC-Speaker.
@@ -854,11 +935,11 @@ PCjr картридж найден, но машина не PCjr.
 
 .
 :SHELL_CMD_IMGMOUNT_HELP
-Смонтировать образы компакт-дисков или дискет на указанную букву диска.
+Монтировать образы компакт-дисков или дискет на указанную букву диска.
 
 .
 :SHELL_CMD_IMGMOUNT_HELP_LONG
-Смонтировать CD-ROM, дискету или образ диска на указанную букву диска.
+Монтировать CD-ROM, дискету или образ диска на указанную букву диска.
 
 Использование:
   [32;1mimgmount[0m [37;1mДИСК[0m [36;1mCDROM-SET[0m [CDROM-SET_2 [..]] [-fs iso] -t cdrom|iso
@@ -889,7 +970,7 @@ PCjr картридж найден, но машина не PCjr.
 
 .
 :SHELL_CMD_MOUNT_HELP_LONG
-Смонтировать директорию из операционной системы на букву виртуального диска DOS.
+Монтировать директорию из операционной системы на букву виртуального диска DOS.
 
 Использование:
   [32;1mmount[0m [37;1mДиск[0m [36;1mДиректория[0m [-t Тип] [-freesize Размер] [-label Метка]
@@ -1449,20 +1530,135 @@ choice [/c:клавиши] [/n] [/s] текст
 Неправильная версия DOS.
 
 .
-:PROGRAM_INTRO_CDROM_WINDOWS
-[2J[32;1mКак смонтировать виртуальный привод CD-ROM в DOSBox:[0m
-DOSBox обеспечивает эмуляцию CD-ROM на нескольких уровнях.
+:PROGRAM_PATH_TOO_LONG
+The path "%s" exceeds the DOS maximum length of %d characters
 
-Это работает во всех обычных директориях, устанавливает MSCDEX и помечает
-файлы только для чтения. Обычно этого достаточно для большинства игр:
+.
+:PROGRAM_EXECUTABLE_MISSING
+Executable file not found: %s
+
+.
+:SHELL_CMD_MEM_HELP_LONG
+Displays the DOS memory information.
+
+Usage:
+  [32;1mmem[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command shows the DOS memory status, including the free conventional
+  memory, UMB (upper) memory, XMS (extended) memory, and EMS (expanded) memory.
+
+Examples:
+  [32;1mmem[0m
+
+.
+:SHELL_CMD_LOADFIX_HELP_LONG
+Loads a program in the specific memory region and then runs it.
+
+Usage:
+  [32;1mloadfix[0m [36;1mGAME[0m [37;1m[PARAMETERS][0m
+  [32;1mloadfix[0m [/d] (or [/f])[0m
+
+Where:
+  [36;1mGAME[0m is a game or program to be loaded, optionally with parameters.
+
+Notes:
+  The most common use cases of this command are to fix DOS games or programs
+  which show either the "[37;1mPacked File Corrupt[0m" or "[37;1mNot enough memory"[0m (e.g.,
+  from some 1980's games such as California Games II) error message when run.
+  Running [32;1mloadfix[0m without an argument simply allocates memory for your game
+  to run; you can free the memory with either /d or /f option when it finishes.
+
+Examples:
+  [32;1mloadfix[0m [36;1mmygame[0m [37;1margs[0m
+  [32;1mloadfix[0m /d
+
+.
+:SHELL_CMD_AUTOTYPE_HELP_LONG
+Performs scripted keyboard entry into a running DOS game.
+
+Usage:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m [-w [37;1mWAIT[0m] [-p [37;1mPACE[0m] [36;1mBUTTONS[0m
+
+Where:
+  [37;1mWAIT[0m    is the number of seconds to wait before typing begins (max of 30).
+  [37;1mPACE[0m    is the number of seconds before each keystroke (max of 10).
+  [36;1mBUTTONS[0m is one or more space-separated buttons.
+
+Notes:
+  The [36;1mBUTTONS[0m supplied in the command will be autotyped into running DOS games
+  after they start. Autotyping begins after [36;1mWAIT[0m seconds, and each button is
+  entered every [37;1mPACE[0m seconds. The [36;1m,[0m character inserts an extra [37;1mPACE[0m delay.
+  [37;1mWAIT[0m and [37;1mPACE[0m default to 2 and 0.5 seconds respectively if not specified.
+  A list of all available button names can be obtained using the -list option.
+
+Examples:
+  [32;1mautotype[0m -list
+  [32;1mautotype[0m -w [37;1m1[0m -p [37;1m0.3[0m [36;1mup enter , right enter[0m
+  [32;1mautotype[0m -p [37;1m0.2[0m [36;1mf1 kp_8 , , enter[0m
+  [32;1mautotype[0m -w [37;1m1.3[0m [36;1mesc enter , p l a y e r enter
+[0m
+.
+:SHELL_CMD_MIXER_HELP_LONG
+Displays or changes the current sound mixer volumes.
+
+Usage:
+  [32;1mmixer[0m [36;1mCHANNEL[0m [37;1mVOLUME[0m [/noshow]
+  [32;1mmixer[0m [/listmidi][0m
+
+Where:
+  [36;1mCHANNEL[0m is the sound channel you want to change the volume.
+  [37;1mVOLUME[0m  is an integer between 0 and 100 representing the volume.
+
+Notes:
+  Running [32;1mmixer[0m without an argument shows the volumes of all sound channels.
+  You can view available MIDI devices and user options with /listmidi option.
+  You may change the volumes of more than one sound channels in one command.
+  The /noshow option causes mixer not to show the volumes when making a change.
+
+Examples:
+  [32;1mmixer[0m
+  [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
+  [32;1mmixer[0m /listmidi
+.
+:SHELL_CMD_RESCAN_HELP_LONG
+Scans for changes on mounted DOS drives.
+
+Usage:
+  [32;1mrescan[0m [36;1mDRIVE[0m
+  [32;1mrescan[0m [/a]
+
+Where:
+  [36;1mDRIVE[0m is the drive to scan for changes.
+
+Notes:
+  - Running [32;1mrescan[0m without an argument scans for changes of the current drive.
+  - Changes to this drive made on the host will then be reflected inside DOS.
+  - You can also scan for changes on all mounted drives with the /a option.
+
+Examples:
+  [32;1mrescan[0m [36;1mc:[0m
+  [32;1mrescan[0m /a
+
+.
+:PROGRAM_INTRO_CDROM_WINDOWS
+[2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
+DOSBox provides CD-ROM emulation on several levels.
+
+This works on all normal directories, installs MSCDEX and marks the files
+read-only. Usually this is enough for most games:
 
 [34;1mmount D C:\example -t cdrom[0m
 
-Если это не сработает, возможно, Вам придется сообщить DOSBox метку CD-ROM:
+If it doesn't work you might have to tell DOSBox the label of the CD-ROM:
 
-[34;1mmount D C:\example -t cdrom -label метка[0m
+[34;1mmount D C:\example -t cdrom -label CDLABEL[0m
 
-Также Вы можете использовать imgmount для монтирования образов iso или cue/bin:
+Additionally, you can use imgmount to mount iso or cue/bin images:
 
 [34;1mimgmount D C:\cd.iso -t cdrom[0m
 
@@ -1470,47 +1666,437 @@ DOSBox обеспечивает эмуляцию CD-ROM на нескольки�
 
 .
 :PROGRAM_INTRO_CDROM_OTHER
-[2J[32;1mКак смонтировать виртуальный привод CD-ROM в DOSBox:[0m
-DOSBox обеспечивает эмуляцию CD-ROM на нескольких уровнях.
+[2J[32;1mHow to mount a virtual CD-ROM Drive in DOSBox:[0m
+DOSBox provides CD-ROM emulation on several levels.
 
-Это работает во всех обычных директориях, устанавливает MSCDEX и помечает
-файлы только для чтения. Обычно этого достаточно для большинства игр:
+This works on all normal directories, installs MSCDEX and marks the files
+read-only. Usually this is enough for most games:
 
 [34;1mmount D ~/example -t cdrom[0m
 
-Если это не сработает, возможно, Вам придется сообщить DOSBox метку CD-ROM:
+If it doesn't work you might have to tell DOSBox the label of the CD-ROM:
 
-[34;1mmount D ~/example -t cdrom -label метка[0m
+[34;1mmount D ~/example -t cdrom -label CDLABEL[0m
 
-Также Вы можете использовать imgmount для монтирования образов iso или cue/bin:
+Additionally, you can use imgmount to mount iso or cue/bin images:
 
 [34;1mimgmount D ~/cd.iso -t cdrom[0m
 
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
+:SHELL_CMD_BOOT_HELP_LONG
+Boots DOSBox Staging from a DOS drive or disk image.
+
+Usage:
+  [32;1mboot[0m [37;1mDRIVE[0m
+  [32;1mboot[0m [36;1mIMAGEFILE[0m
+
+Where:
+  [37;1mDRIVE[0m is a drive to boot from, must be [37;1mA:[0m, [37;1mC:[0m, or [37;1mD:[0m.
+  [36;1mIMAGEFILE[0m is one or more floppy images, separated by spaces.
+
+Notes:
+  A DOS drive letter must have been mounted previously with [32;1mimgmount[0m command.
+  The DOS drive or disk image must be bootable, containing DOS system files.
+  If more than one disk images are specified, you can swap them with a hotkey.
+
+Examples:
+  [32;1mboot[0m [37;1mc:[0m
+  [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
+
+.
+:SHELL_CMD_LOADROM_HELP_LONG
+Loads a ROM image of the video BIOS or IBM BASIC.
+
+Usage:
+  [32;1mloadrom [36;1mIMAGEFILE[0m
+
+Where:
+  [36;1mIMAGEFILE[0m is a video BIOS or IBM BASIC ROM image.
+
+Notes:
+   After loading an IBM BASIC ROM image into the emulated ROM with the command,
+   you can run the original IBM BASIC interpreter program in DOSBox Staging.
+
+Examples:
+  [32;1mloadrom[0m [36;1mbios.rom[0m
+
+.
+:PROGRAM_KEYB_HELP_LONG
+Configures a keyboard for a specific language.
+
+Usage:
+  [32;1mkeyb[0m [36;1m[LANGCODE][0m
+  [32;1mkeyb[0m [36;1mLANGCODE[0m [37;1mCODEPAGE[0m [CODEPAGEFILE]
+
+Where:
+  [36;1mLANGCODE[0m     is a language code or keyboard layout ID.
+  [37;1mCODEPAGE[0m     is a code page number, such as [37;1m437[0m and [37;1m850[0m.
+  CODEPAGEFILE is a file containing information for a code page.
+
+Notes:
+  Running [32;1mkeyb[0m without an argument shows the currently loaded keyboard layout
+  and code page. It will change to [36;1mLANGCODE[0m if provided, optionally with a
+  [37;1mCODEPAGE[0m and an additional CODEPAGEFILE to load the specified code page
+  number and code page file if provided. This command is especially useful if
+  you use a non-US keyboard, and [36;1mLANGCODE[0m can also be set in the configuration
+  file under the [dos] section using the "keyboardlayout = [36;1mLANGCODE[0m" setting.
+
+Examples:
+  [32;1mKEYB[0m
+  [32;1mKEYB[0m [36;1muk[0m
+  [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
+  [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
+
+.
+:PROGRAM_PLACEHOLDER_SHORT_HELP
+This program is a placeholder
+.
+:PROGRAM_PLACEHOLDER_LONG_HELP
+%s is only a placeholder.
+
+Install a 3rd-party and give its PATH precedence.
+
+For example:
+.
+:UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE
+
+   [autoexec]
+   mount u ~/dos/utils
+   set PATH=u:\;%PATH%
+
+
+.
+:VISIT_FOR_MORE_HELP
+Visit the following for more help:
+.
+:WIKI_ADD_UTILITIES_ARTICLE
+https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
+.
+:WIKI_URL
+https://github.com/dosbox-staging/dosbox-staging/wiki
+.
+:SHELL_CMD_COMMAND_HELP_LONG
+Starts the DOSBox Staging command shell.
+Usage:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c (or /init) [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is a DOS command, game, or program to run.
+
+Notes:
+  DOSBox Staging automatically starts a DOS command shell by invoking this
+  command with /init option when it starts, which shows the welcome banner.
+  You can load a new instance of the command shell by running [32;1mcommand[0m.
+  Adding a /c option along with [36;1mCOMMAND[0m allows this command to run the
+  specified command (optionally with parameters) and then exit automatically.
+
+Examples:
+  [32;1mcommand[0m
+  [32;1mcommand[0m /c [36;1mecho[0m [37mHello world![0m
+  [32;1mcommand[0m /init [36;1mdir[0m
+
+.
+:SHELL_CMD_TIME_ERROR
+The specified time is not correct.
+
+.
+:SHELL_CMD_TIME_SETHLP
+Type 'time hh:mm:ss' to change.
+
+.
+:SHELL_CMD_PAUSE_HELP_LONG
+Usage:
+  [32;1mpause[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command is especially useful in batch programs to allow a user to
+  continue the batch program execution with a key press. The user can press
+  any key on the keyboard (except for certain control keys) to continue.
+
+Examples:
+  [32;1mpause[0m
+
+.
+:SHELL_CMD_CLS_HELP_LONG
+Usage:
+  [32;1mcls[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  Running [32;1mcls[0m clears all texts on the DOS screen, except for the command
+  prompt (e.g. [37;1mZ:\>[0m or [37;1mC:\GAMES>[0m) on the top-left corner of the screen.
+
+Examples:
+  [32;1mcls[0m
+
+.
+:SHELL_CMD_ECHO_HELP_LONG
+Usage:
+  [32;1mecho[0m [36;1m[on|off][0m
+  [32;1mecho[0m [36;1m[MESSAGE][0m
+
+Where:
+  [36;1mon|off[0m  Turns on/off command echoing.
+  [36;1mMESSAGE[0m The message to display.
+
+Notes:
+  - Running [32;1mecho[0m without an argument shows the current on or off status.
+  - Echo is especially useful when writing or debugging batch files.
+
+Examples:
+  [32;1mecho[0m [36;1moff[0m
+  [32;1mecho[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_EXIT_HELP_LONG
+Usage:
+  [32;1mexit[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  If you start a DOS shell from a program, running [32;1mexit[0m returns to the program.
+  If there is no DOS program running, the command quits from DOSBox Staging.
+
+Examples:
+  [32;1mexit[0m
+
+.
+:SHELL_CMD_EXIT_TOO_SOON
+Preventing an early 'exit' call from terminating.
+
+.
 :SHELL_CMD_HELP_HELP_LONG
-HELP [команда]
+Usage:
+  [32;1mhelp[0m
+  [32;1mhelp[0m /a[ll]
+  [32;1mhelp[0m [36;1mCOMMAND[0m
+
+Where:
+  [36;1mCOMMAND[0m is the name of an internal DOS command, such as [36;1mdir[0m.
+
+Notes:
+  - Running [32;1mecho[0m without an argument displays a DOS command list.
+  - You can view a full list of internal commands with the /a or /all option.
+  - Instead of [32;1mhelp[0m [36;1mCOMMAND[0m, you can also get command help with [36;1mCOMMAND[0m /?.
+
+Examples:
+  [32;1mhelp[0m [36;1mdir[0m
+  [32;1mhelp[0m /all
+
+.
+:SHELL_CMD_INTRO_HELP
+Displays a full-screen introduction to DOSBox Staging.
+
+.
+:SHELL_CMD_INTRO_HELP_LONG
+Usage:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mPAGE[0m
+
+Where:
+  [37;1mPAGE[0m is the page name to display, including [37;1mcdrom[0m, [37;1mmount[0m, and [37;1mspecial[0m.
+
+Notes:
+  Running [32;1mintro[0m without an argument displays one information page at a time;
+  press any key to move to the next page. If a page name is provided, then the
+  specified page will be displayed directly.
+
+Examples:
+  [32;1mintro[0m
+  [32;1mintro[0m [37;1mcdrom[0m
+
+.
+:SHELL_CMD_SET_HELP_LONG
+Usage:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mVARIABLE[0m=[36;1m[STRING][0m
+
+Where:
+  [37;1mVARIABLE[0m The name of the environment variable.
+  [36;1mSTRING[0m   A series of characters to assign to the variable.
+
+Notes:
+  - Assigning an empty string to the variable removes the variable.
+  - The command without a parameter displays current environment variables.
+
+Examples:
+  [32;1mset[0m
+  [32;1mset[0m [37;1mname[0m=[36;1mvalue[0m
+
+.
+:SHELL_CMD_IF_HELP_LONG
+Usage:
+  [32;1mif[0m [35;1m[not][0m [36;1merrorlevel[0m [37;1mNUMBER[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [37;1mSTR1==STR2[0m COMMAND
+  [32;1mif[0m [35;1m[not][0m [36;1mexist[0m [37;1mFILE[0m COMMAND
+
+Where:
+  [37;1mNUMBER[0m     is a positive integer less or equal to the desired value.
+  [37;1mSTR1==STR2[0m compares two text strings (case-sensitive).
+  [37;1mFILE[0m       is an exact file name to check for existence.
+  COMMAND    is a DOS command or program to run, optionally with parameters.
+
+Notes:
+  The COMMAND is run if any of the three conditions in the usage are met.
+  If [38;1mnot[0m is specified, then the command runs only with the false condition.
+  The [36;1merrorlevel[0m condition is useful for checking if a programs ran correctly.
+  If either [37;1mSTR1[0m or [37;1mSTR2[0m may be empty, you can enclose them in quotes (").
+
+Examples:
+  [32;1mif[0m [36;1merrorlevel[0m [37;1m2[0m dir
+  [32;1mif[0m [37;1m"%%myvar%%"=="mystring"[0m echo Hello world!
+  [32;1mif[0m [35;1mnot[0m [36;1mexist[0m [37;1mfile.txt[0m exit
+
+.
+:SHELL_CMD_GOTO_HELP_LONG
+Usage:
+  [32;1mgoto[0m [36;1mLABEL[0m
+
+Where:
+  [36;1mLABEL[0m is text string used in the batch program as a label.
+
+Notes:
+  A label is on a line by itself, beginning with a colon (:).
+  The label must be unique, and can be anywhere within the batch program.
+
+Examples:
+  [32;1mgoto[0m [36;1mmylabel[0m
+
+.
+:SHELL_CMD_SHIFT_HELP_LONG
+Usage:
+  [32;1mshift[0m
+
+Where:
+  This command has no parameters.
+
+Notes:
+  This command allows a DOS batch program to accept more than 9 parameters.
+  Running [32;1mshift[0m left-shifts the batch program variable %%1 to %%0, %%2 to %%1, etc.
+
+Examples:
+  [32;1mshift[0m
 
 .
 :SHELL_CMD_DELETE_HELP_LONG
-Использование:
-  [32;1mdel[0m [36;1mшаблон[0m
-  [32;1merase[0m [36;1mшаблон[0m
+Usage:
+  [32;1mdel[0m [36;1mPATTERN[0m
+  [32;1merase[0m [36;1mPATTERN[0m
 
-Где:
-  [36;1mшаблон[0m может быть как точным именем файла (например, [36;1mfile.txt[0m), так и неточным
-          именем файла с использованием одного или нескольких символов подстановки, которым является
-          звёздочка (*), обозначающая любую последовательность из одного или нескольких символов,
-          и вопросительный знак (?), обозначающий любой одиночный символ, например, [36;1m*.bat[0m и [36;1mc?.txt[0m.
+Where:
+  [36;1mPATTERN[0m can be either an exact filename (such as [36;1mfile.txt[0m) or an inexact
+          filename using one or more wildcards, which are the asterisk (*)
+          representing any sequence of one or more characters, and the question
+          mark (?) representing any single character, such as [36;1m*.bat[0m and [36;1mc?.txt[0m.
 
-Внимание:
-  Будьте осторожны при использовании шаблона с подстановочными знаками, особенно с
-  [36;1m*.*[0m, так как все файлы соответствующие шаблону, будут удалены.
+Warning:
+  Be careful when using a pattern with wildcards, especially [36;1m*.*[0m, as all files
+  matching the pattern will be deleted.
 
-Примеры:
+Examples:
   [32;1mdel[0m [36;1mtest.bat[0m
   [32;1mdel[0m [36;1mc*.*[0m
   [32;1mdel[0m [36;1ma?b.c*[0m
+
+.
+:SHELL_CMD_COPY_HELP_LONG
+Usage:
+  [32;1mcopy[0m [37;1mSOURCE[0m [36;1m[DESTINATION][0m
+  [32;1mcopy[0m [37;1mSOURCE1+SOURCE2[+...][0m [36;1m[DESTINATION][0m
+
+Where:
+  [37;1mSOURCE[0m      Can be either an exact filename or an inexact filename with
+              wildcards, which are the asterisk (*) and the question mark (?).
+  [36;1mDESTINATION[0m An exact filename or directory, not containing any wildcards.
+
+Notes:
+  The [37;1m+[0m operator combines multiple source files provided to a single file.
+  Destination is optional: if omitted, files are copied to the current path.
+
+Examples:
+  [32;1mcopy[0m [37;1msource.bat[0m [36;1mnew.bat[0m
+  [32;1mcopy[0m [37;1mfile1.txt+file2.txt[0m [36;1mfile3.txt[0m
+  [32;1mcopy[0m [37;1m..\c*.*[0m
+
+.
+:SHELL_CMD_CALL_HELP_LONG
+Usage:
+  [32;1mcall[0m [37;1mBATCH[0m [36;1m[PARAMETERS][0m
+
+Where:
+  [37;1mBATCH[0m      is a batch program to launch.
+  [36;1mPARAMETERS[0m are optional parameters for the batch program.
+
+Notes:
+  After calling another batch program, the original batch program will
+  resume running after the other batch program ends.
+
+Examples:
+  [32;1mcall[0m [37;1mmybatch.bat[0m
+  [32;1mcall[0m [37;1mfile.bat[0m [36;1mHello world![0m
+
+.
+:SHELL_CMD_SUBST_HELP_LONG
+Usage:
+  [32;1msubst[0m [37;1mDRIVE[0m [36;1mPATH[0m
+  [32;1msubst[0m [37;1mDRIVE[0m /d
+
+Where:
+  [37;1mDRIVE[0m is a drive to which you want to assign a path.
+  [36;1mPATH[0m  is a mounted DOS path you want to assign to.
+
+Notes:
+  The path must be on a drive mounted by the [32;1mmount[0m command.
+  You can remove an assigned drive with the /d option.
+
+Examples:
+  [32;1msubst[0m [37;1md:[0m [36;1mc:\games[0m
+  [32;1msubst[0m [37;1me:[0m [36;1m/d[0m
+
+.
+:SHELL_CMD_LOADHIGH_HELP_LONG
+Usage:
+  [32;1mlh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+  [32;1mloadhigh[0m [36;1mPROGRAM[0m [37;1m[PARAMETERS][0m
+
+Where:
+  [36;1mPROGRAM[0m is a DOS TSR program to be loaded, optionally with parameters.
+
+Notes:
+  This command intends to save the conventional memory by loading specified DOS
+  TSR programs into upper memory if possible. Such programs may be required for
+  some DOS games; XMS and UMB memory must be enabled (xms=true and umb=true).
+  Not all DOS TSR programs can be loaded into upper memory with this command.
+
+Examples:
+  [32;1mlh[0m [36;1mtsrapp[0m [37;1margs[0m
+
+.
+:SHELL_CMD_PATH_HELP_LONG
+Usage:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1m[[drive:]path[;...][0m
+
+Where:
+  [36;1m[[drive:]path[;...][0m is a path containing a drive and directory.
+  More than one path can be specified, separated by a semi-colon (;).
+
+Notes:
+  Parameter with a semi-colon (;) only clears all search path settings.
+  The path can also be set using [32;1mset[0m command, e.g. [32;1mset[0m [37;1mpath[0m=[36;1mZ:\[0m
+
+Examples:
+  [32;1mpath[0m
+  [32;1mpath[0m [36;1mZ:\;C:\DOS[0m
 
 .


### PR DESCRIPTION
 - Delete translations for messages that not long exist in 0.78.
 - Insert new messages unique to 0.78 that require new translation.
 - Replace translations with newer English wording, if those messages have changed (these require re-translation).

Performing all of this re-translation will be a significant undertaking (which is appreciated in any capacity!)
However, if we're going to try to spare the team's effort on this, I would suggest we defer translation until after the transition to gettext is complete,  when better gettext tooling and web resources are available to ease this task.