### PR TITLE
Drop work-around for previously broken Ruby Cargo installation

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,7 +33,6 @@ jobs:
           sudo apt-get install ruby-full
           ruby --version
           sudo gem install mdl
-          sudo chmod go-w /usr/share/rust/.cargo/bin
       - name: Run markdownlint
         run:  ./scripts/verify-markdown.sh
       - name: Install appstream-util


### PR DESCRIPTION
Fixes:

![2021-12-02_08-35](https://user-images.githubusercontent.com/1557255/144463892-c90a031e-3619-4edd-b847-6aef5524c821.png)
