### PR TITLE
Fix the order of precedence when selecting the language

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -11,7 +11,7 @@ jobs:
     name: PVS-Studio static analyzer
     runs-on: ubuntu-20.04
     env:
-      debfile: pvs-studio-7.15.53844.172-amd64.deb
+      debfile: pvs-studio-7.16.55312.178-amd64.deb
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/contrib/translations/meson.build
+++ b/contrib/translations/meson.build
@@ -1,0 +1,57 @@
+# Setup language translation files
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+translations_files = {
+  'de/de_DE.lng'       : 'de.lng',
+  'en/en_US.lng'       : 'en.lng',
+  'es/es_ES.lng'       : 'es.lng',
+  'fr/fr_FR.lng'       : 'fr.lng',
+  'it/it_IT.lng'       : 'it.lng',
+  'pl/pl_PL.lng'       : 'pl.lng',
+  'pl/pl_PL.CP437.lng' : 'pl.cp437.lng',
+  'ru/ru_RU.lng'       : 'ru.lng',
+}
+
+# Staging's downloable package includes bundled translations alone-side
+# the binary (or relative to the binary on macOS in ../Resources/), which
+# Staging tries to lookup when a language is provided.
+
+# This section sets up the same relative translation bundle inside the
+# build-dir so users who run and test from source builds also have
+# langauge support.
+#
+# NOTE: Meson currently doesn't support creating directories in the
+#       build-dir nor does it support trivially installing or copying
+#       source files into build-dir tree. Therefore we leverage the
+#       configure_file() function with 'mkdir' and 'install' calls to
+#       do this as best we can, platform-aware, until a more elegant
+#       approach exists. See:
+#         - https://github.com/mesonbuild/meson/issues/860
+#         - https://github.com/mesonbuild/meson/issues/7067
+#
+builddir_translations = meson.current_build_dir() / '../..' / \
+                        (host_machine.system() == 'darwin'
+                           ? '../Resources/translations'
+                           : 'translations')
+
+configure_file(
+  output:  'translations', # not used, information-only
+  command: ['mkdir', '-p', builddir_translations])
+
+install_cmd = ['install', '-m', '644']
+
+foreach source_file, target_name : translations_files
+  target_file = builddir_translations / target_name
+  configure_file(
+    output:  target_name, # not used, information-only
+    command: install_cmd + [ files(source_file), target_file])
+endforeach
+
+# Setup the translation files in the system
+if get_option('prefix') in ['/usr', '/usr/local']
+  system_translations = get_option('prefix') / 'share/dosbox-staging/translations'
+  foreach source_file, target_name : translations_files
+    install_data(builddir_translations / target_name,
+                 install_dir : system_translations)
+  endforeach
+endif

--- a/meson.build
+++ b/meson.build
@@ -365,7 +365,6 @@ configure_file(input : 'src/config.h.in', output : 'config.h',
                configuration : conf_data)
 
 
-
 # dosbox executable
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
@@ -417,3 +416,4 @@ install_data('AUTHORS', 'README', 'THANKS', install_dir : doc_dir)
 
 subdir('contrib/linux')
 subdir('contrib/icons')
+subdir('contrib/translations')

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -435,8 +435,12 @@ void DOSBOX_Init(void) {
 	                          "vesa_oldvbe",   0};
 
 	secprop = control->AddSection_prop("dosbox", &DOSBOX_RealInit);
-	pstring = secprop->Add_path("language", always, "");
-	pstring->Set_help("Select another language file.");
+	pstring = secprop->Add_string("language", always, "");
+	pstring->Set_help(
+	        "Select a language to use: de, en, es, fr, it, pl, and ru\n"
+	        "Notes: This setting will override the 'LANG' environment, if set.\n"
+	        "       The 'translations' directory bundled with the executable holds these data\n"
+	        "       files. Please keep it along-side the executable to support this feature.");
 
 	pstring = secprop->Add_string("machine", only_at_start, "svga_s3");
 	pstring->Set_values(machines);

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -188,9 +188,9 @@ static std::deque<std_fs::path> get_paths()
 	paths.emplace_back(exe_path / "translations");
 #endif
 
-	// fallback to any system-installed translations, which
-	// may be installed by package managers. This might exist
-	// on macOS, POSIX, and even MinGW/MSYS2/Cygwin.
+	// Try the user-installed and then repo-installed paths, which
+	// can exist on macOS, POSIX, and even MinGW/MSYS2/Cygwin.
+	paths.emplace_back("/usr/local/share/dosbox-staging/translations");
 	paths.emplace_back("/usr/share/dosbox-staging/translations");
 
 	// Worst-cast: fallback to the user's config directory


### PR DESCRIPTION
When multiple languages are provided, this PR uses the following order of precedence:
 1. command-line `-lang ..`
 2. conf-file `language = ..`
 3. environment `export LANG=..`
 4. English (built-in message)

Performing a system-level `ninja install -C ... ` to `/usr` or `/usr/local` will install the language files under that prefix, plus `share/dosbox-staging/translations`, which in turn Staging will read from.

Fixes #768, #1232, and #1425.
