### PR TITLE
Fix various MSYS2 warnings

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -27,12 +27,12 @@ jobs:
             toolchain: ""
             arch: i686
             sys: MINGW32
-            max_warnings: 17
+            max_warnings: 1
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            max_warnings: 19
+            max_warnings: 1
           # - name: Clang x86
           #   toolchain: clang-
           #   arch: i686
@@ -42,7 +42,7 @@ jobs:
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
-            max_warnings: 2
+            max_warnings: 1
           - name: GCC +tests
             toolchain: ""
             arch: x86_64

--- a/meson.build
+++ b/meson.build
@@ -25,12 +25,18 @@ cxx = meson.get_compiler('cpp')
 summary('Build type',     get_option('buildtype'), section : 'Build Summary')
 summary('Install prefix', get_option('prefix'),    section : 'Build Summary')
 
-
 # compiler flags
 #
-foreach cxx_warning : ['-Wmaybe-uninitialized', '-Weffc++', '-Wextra-semi']
-  if cxx.has_argument(cxx_warning)
-    add_project_arguments(cxx_warning, language : 'cpp')
+extra_flags = ['-Wmaybe-uninitialized', '-Weffc++', '-Wextra-semi']
+if host_machine.system() == 'windows'
+  extra_flags += '-Wno-pedantic-ms-format'
+endif
+foreach flag : extra_flags
+  if cc.has_argument(flag)
+    add_project_arguments(flag, language : 'c')
+  endif
+  if cxx.has_argument(flag)
+    add_project_arguments(flag, language : 'cpp')
   endif
 endforeach
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -39,14 +39,12 @@ static struct {
 
 class GenReg {
 public:
-	GenReg(Bit8u _index) {
-		index=_index;
-		notusable=false;dynreg=0;
-	}
-	DynReg  * dynreg;
-	Bitu last_used;			//Keeps track of last assigned regs 
-    Bit8u index;
-	bool notusable;
+	Bit8u index = 0;
+	DynReg  * dynreg = nullptr;
+	Bitu last_used = 0;			//Keeps track of last assigned regs 
+	bool notusable = false;
+
+	GenReg(Bit8u _index) : index(_index) {}
 	void Load(DynReg * _dynreg,bool stale=false) {
 		if (!_dynreg) return;
 		if (GCC_UNLIKELY((Bitu)dynreg)) Clear();
@@ -318,6 +316,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 	switch (size) {
 	case 1:cache_addb(0x8a);break;	//mov byte
 	case 2:cache_addb(0x66);		//mov word
+	[[fallthrough]];
 	case 4:cache_addb(0x8b);break;	//mov
 	default:
 		IllegalOption("gen_mov_host");

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -796,7 +796,7 @@ static void DrawRegisters(void) {
 
 
 	SetColor(cpu.cpl ^ oldcpucpl);
-	mvwprintw (dbg.win_reg,2,78,"%01X",cpu.cpl);
+	mvwprintw (dbg.win_reg,2,78,"%01" PRIXPTR ,cpu.cpl);
 	oldcpucpl=cpu.cpl;
 
 	if (cpu.pmode) {
@@ -815,7 +815,7 @@ static void DrawRegisters(void) {
 	}
 
 	wattrset(dbg.win_reg,0);
-	mvwprintw(dbg.win_reg,3,60,"%u       ",cycle_count);
+	mvwprintw(dbg.win_reg,3,60,"%" PRIuPTR "       ",cycle_count);
 	wrefresh(dbg.win_reg);
 }
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -25,9 +25,7 @@
 #include <cassert>
 #include <cctype>
 #include <chrono>
-#include <cinttypes>
 #include <cstdarg>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -1852,7 +1850,7 @@ static void update_active_bind_ui()
 
 	// Format "Bind: " description
 	const auto mods = mapper.abind->mods;
-	bind_but.bind_title->Change("Bind %zu/%zu: %s%s%s%s",
+	bind_but.bind_title->Change("Bind %" PRIuPTR "/%" PRIuPTR ": %s%s%s%s",
 	                            active_bind_pos + 1, active_event_binds_num,
 	                            (mods & BMOD_Mod1 ? mod_1_desc.c_str() : ""),
 	                            (mods & BMOD_Mod2 ? mod_2_desc.c_str() : ""),

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3709,9 +3709,7 @@ static void erasemapperfile() {
 
 void Disable_OS_Scaling() {
 #if defined (WIN32)
-	typedef BOOL (*function_set_dpi_pointer)();
-	function_set_dpi_pointer function_set_dpi;
-	function_set_dpi = (function_set_dpi_pointer) GetProcAddress(LoadLibrary("user32.dll"), "SetProcessDPIAware");
+	FARPROC function_set_dpi = GetProcAddress(LoadLibrary("user32.dll"), "SetProcessDPIAware");
 	if (function_set_dpi) {
 		function_set_dpi();
 	}

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -42,6 +42,9 @@ private:
 	bool isOpen;
 public:
 	MidiHandler_win32() : MidiHandler(), isOpen(false) {}
+	
+	MidiHandler_win32(const MidiHandler_win32&) = delete;
+	MidiHandler_win32& operator=(const MidiHandler_win32&) = delete;
 
 	const char *GetName() const override { return "win32"; }
 

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -36,9 +36,9 @@
 
 class MidiHandler_win32 final : public MidiHandler {
 private:
-	HMIDIOUT m_out;
-	MIDIHDR m_hdr;
-	HANDLE m_event;
+	HMIDIOUT m_out = nullptr;
+	MIDIHDR m_hdr = {};
+	HANDLE m_event = nullptr;
 	bool isOpen;
 public:
 	MidiHandler_win32() : MidiHandler(), isOpen(false) {}

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -32,7 +32,7 @@
 #include "support.h"
 #include "cross.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (defined(__MINGW32__) && defined(__clang__))
 _CRTIMP extern char **_environ;
 #else
 extern char **environ;
@@ -1069,7 +1069,7 @@ parse_environ_result_t parse_environ(const char * const * envp) noexcept
 
 void Config::ParseEnv()
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (defined(__MINGW32__) && defined(__clang__))
 	const char *const *envp = _environ;
 #else
 	const char *const *envp = environ;


### PR DESCRIPTION
Fixes various warnings flagged by the MSYS2 CI builds.

Mostly type related warnings, and `printf` style format specifiers.