### PR TITLE
Refactor `mount` directory handling with std::filesystem routines (#223)

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -306,4 +306,8 @@ FILE_unique_ptr make_fopen(const char *fname, const char *mode);
 
 const std_fs::path &GetExecutablePath();
 
+// Tests if the provided path is a system root path.
+// The root_path argument is overwritten with the system root path.
+bool is_path_a_root_path(const std_fs::path &test_path, std_fs::path &root_path);
+
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -62,9 +62,10 @@ void DOS_SetupPrograms(void)
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL","Virtual Drives can not be unMOUNTed.\n");
 	MSG_Add("PROGRAM_MOUNT_DRIVEID_ERROR", "'%c' is not a valid drive identifier.\n");
-	MSG_Add("PROGRAM_MOUNT_WARNING_WIN","\033[31;1mMounting c:\\ is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
-	MSG_Add("PROGRAM_MOUNT_WARNING_OTHER","\033[31;1mMounting / is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
-	MSG_Add("PROGRAM_MOUNT_NO_OPTION", "Warning: Ignoring unsupported option '%s'.\n");
+	MSG_Add("PROGRAM_MOUNT_ROOT_PATH_WARNING",
+	        "\033[31;1mWARNING: '%s' resolves to a root directory: '%s'\n"
+	        "Mounting a root directory is risky. Please use a subdirectory next time.\033[0m\n");
+	MSG_Add("PROGRAM_MOUNT_NO_OPTION","Warning: Ignoring unsupported option '%s'.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_NO_BASE","A normal directory needs to be MOUNTed first before an overlay can be added on top.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE","The overlay is NOT compatible with the drive that is specified.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_MIXED_BASE","The overlay needs to be specified using the same addressing as the underlying drive. No mixing of relative and absolute paths.");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -63,8 +63,10 @@ void DOS_SetupPrograms(void)
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL","Virtual Drives can not be unMOUNTed.\n");
 	MSG_Add("PROGRAM_MOUNT_DRIVEID_ERROR", "'%c' is not a valid drive identifier.\n");
 	MSG_Add("PROGRAM_MOUNT_ROOT_PATH_WARNING",
-	        "\033[31;1mWARNING: '%s' resolves to a root directory: '%s'\n"
+	        "\033[31;1mWARNING: The path \"%s\" resolves to a root directory \"%s\"\n"
 	        "Mounting a root directory is risky. Please use a subdirectory next time.\033[0m\n");
+	MSG_Add("PROGRAM_MOUNT_NO_DRIVE_PREFIX",
+	        "The absolute path \"%s\" is missing a drive prefix, such as \"c:%s\"\n");
 	MSG_Add("PROGRAM_MOUNT_NO_OPTION","Warning: Ignoring unsupported option '%s'.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_NO_BASE","A normal directory needs to be MOUNTed first before an overlay can be added on top.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE","The overlay is NOT compatible with the drive that is specified.\n");


### PR DESCRIPTION
 - Collapse the two usage cases into one
 - Improve mount -pr handling
 - Use 'is_directory' and 'exits' instead of stat()
 - Collapse WIN32 and POSIX root-path warning into one

Tentatively fixes #223.  