### PR TITLE
Revert "Refactor mount handling with std::filesystem routines (#1444)"

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -306,8 +306,4 @@ FILE_unique_ptr make_fopen(const char *fname, const char *mode);
 
 const std_fs::path &GetExecutablePath();
 
-// Tests if the provided path is a system root path.
-// The root_path argument is overwritten with the system root path.
-bool is_path_a_root_path(const std_fs::path &test_path, std_fs::path &root_path);
-
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -63,12 +63,9 @@ void DOS_SetupPrograms(void)
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL","Virtual Drives can not be unMOUNTed.\n");
 	MSG_Add("PROGRAM_MOUNT_DRIVEID_ERROR", "'%c' is not a valid drive identifier.\n");
-	MSG_Add("PROGRAM_MOUNT_ROOT_PATH_WARNING",
-	        "\033[31;1mWARNING: The path \"%s\" resolves to a root directory \"%s\"\n"
-	        "Mounting a root directory is risky. Please use a subdirectory next time.\033[0m\n");
-	MSG_Add("PROGRAM_MOUNT_NO_DRIVE_PREFIX",
-	        "The absolute path \"%s\" is missing a drive prefix, such as \"c:%s\"\n");
-	MSG_Add("PROGRAM_MOUNT_NO_OPTION","Warning: Ignoring unsupported option '%s'.\n");
+	MSG_Add("PROGRAM_MOUNT_WARNING_WIN","\033[31;1mMounting c:\\ is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
+	MSG_Add("PROGRAM_MOUNT_WARNING_OTHER","\033[31;1mMounting / is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
+	MSG_Add("PROGRAM_MOUNT_NO_OPTION", "Warning: Ignoring unsupported option '%s'.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_NO_BASE","A normal directory needs to be MOUNTed first before an overlay can be added on top.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE","The overlay is NOT compatible with the drive that is specified.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_MIXED_BASE","The overlay needs to be specified using the same addressing as the underlying drive. No mixing of relative and absolute paths.");

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -30,7 +30,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <system_error>
 #include <functional>
 #include <stdexcept>
 #include <string>
@@ -392,41 +391,4 @@ const std_fs::path &GetExecutablePath()
 		assert(!exe_path.empty());
 	}
 	return exe_path;
-}
-
-bool is_path_a_root_path(const std_fs::path &test_path, std_fs::path &root_path)
-{
-
-// Special handling for GCC on Windows
-#if defined(WIN32) && defined(__GNUC__) && !defined(__clang__)
-	const bool is_root_path = (test_path.string().length() == 3 && test_path.string()[1] == ':');
-	root_path = is_root_path ? test_path : std_fs::path("");
-	return is_root_path;
-#endif
-
-	// Try to discover the root path dynamically, which means we can handle
-	// all variety of filesystems like MorphOS, AmigaOS, etc.
-	std::error_code ec;
-	const auto as_canonical_path = std_fs::canonical(test_path, ec);
-	if (!as_canonical_path.empty() && as_canonical_path.has_root_directory())
-		root_path = as_canonical_path.root_directory();
-	else if (!as_canonical_path.empty() && as_canonical_path.has_root_path())
-		root_path = as_canonical_path.root_path();
-	else if (test_path.has_root_directory())
-		root_path = test_path.root_directory();
-	else if (test_path.has_root_path())
-		root_path = test_path.root_path();
-	else if (std_fs::current_path(ec).has_root_path())
-		root_path = std_fs::current_path(ec).root_path();
-
-	// Otherwise fallback to our best guess of the root path
-	if (root_path.empty())
-#if defined(WIN32)
-		root_path = "C:/";
-#else
-		root_path = "/";
-#endif
-
-	assert(!root_path.empty());
-	return std_fs::equivalent(test_path, root_path, ec);
 }


### PR DESCRIPTION
Currently the implementation-specific differences of how mingw gcc, mingw clang, and msvc handle std::filesystem unfortunately cause more problems versus benefit gained (in theory) with OS-agnostic path handling for systems like (MorphOS and Amiga).

Revisit the in the future with extensive unit tests.

This reverts:
 - commit 3db56fb16f17b60029225942b8fbbc0f40bdcf09.
 - commit 0d5fe2ee4a7317e040765d2a60c15151de92899b.

Fixes #1444.