### PR TITLE
Support networking in Windows for Workgroups 3.11 from the shell

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -30,6 +30,8 @@
 #include "dos_system.h"
 #include "mem.h"
 
+#define EXT_DEVICE_BIT 0x0200
+
 #ifdef _MSC_VER
 #pragma pack (1)
 #endif
@@ -742,6 +744,7 @@ struct DOS_Block {
 		Bit16u dpb; //Fake Disk parameter system using only the first entry so the drive letter matches
 	} tables;
 	Bit16u loaded_codepage;
+	uint16_t dcp;
 };
 
 extern DOS_Block dos;

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -135,6 +135,7 @@ public:
 	virtual Bit16u	GetInformation(void);
 	virtual bool	ReadFromControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode);
 	virtual bool	WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode);
+	virtual uint8_t GetStatus(bool input_flag);
 	void SetDeviceNumber(Bitu num) { devnum=num;}
 private:
 	Bitu devnum;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1034,8 +1034,23 @@ static Bitu DOS_21Handler(void) {
 			LOG(LOG_DOSMISC,LOG_ERROR)("Get SDA, Let's hope for the best!");
 		}
 		break;
-	case 0x5f:					/* Network redirection */
-		reg_ax=0x0001;		//Failing it
+	case 0x5e:             /* Network and printer functions */
+		if (!reg_al) { // Get machine name
+			int result = gethostname(name1, DOSNAMEBUF);
+			if (!result) {
+				strcat(name1, "               ");
+				name1[15] = 0;
+				MEM_BlockWrite(SegPhys(ds) + reg_dx, name1, 16);
+				reg_cx = 0x1ff;
+				CALLBACK_SCF(false);
+				break;
+			}
+		}
+		reg_al = 1;
+		CALLBACK_SCF(true);
+		break;
+	case 0x5f:               /* Network redirection */
+		reg_ax = 0x0001; // Failing it
 		CALLBACK_SCF(true);
 		break; 
 	case 0x60:					/* Canonicalize filename or path */
@@ -1211,7 +1226,6 @@ static Bitu DOS_21Handler(void) {
 	case 0x6b:		            /* NULL Function */
 	case 0x61:		            /* UNUSED */
 	case 0xEF:                  /* Used in Ancient Art Of War CGA */
-	case 0x5e:					/* More Network Functions */
 	default:
 		if (reg_ah < 0x6d) LOG(LOG_DOSMISC,LOG_ERROR)("DOS:Unhandled call %02X al=%02X. Set al to default of 0",reg_ah,reg_al); //Less errors. above 0x6c the functions are simply always skipped, only al is zeroed, all other registers untouched
 		reg_al=0x00; /* default value */

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -32,6 +32,10 @@
 #include "string_utils.h"
 #include "support.h"
 
+#if defined(WIN32)
+#include <winsock2.h> // for gethostname
+#endif
+
 DOS_Block dos;
 DOS_InfoBlock dos_infoblock;
 

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -32,6 +32,227 @@
 
 DOS_Device * Devices[DOS_DEVICES];
 
+struct ExtDeviceData {
+	uint16_t attribute;
+	uint16_t segment;
+	uint16_t strategy;
+	uint16_t interrupt;
+};
+
+class DOS_ExtDevice : public DOS_Device {
+public:
+	DOS_ExtDevice(const char *name, uint16_t seg, uint16_t off)
+	{
+		SetName(name);
+		ext.attribute = real_readw(seg, off + 4);
+		ext.segment = seg;
+		ext.strategy = real_readw(seg, off + 6);
+		ext.interrupt = real_readw(seg, off + 8);
+	}
+	virtual bool Read(uint8_t *data, uint16_t *size);
+	virtual bool Write(uint8_t *data, uint16_t *size);
+	virtual bool Seek(uint32_t *pos, uint32_t type);
+	virtual bool Close();
+	virtual uint16_t GetInformation();
+	virtual bool ReadFromControlChannel(PhysPt bufptr, uint16_t size, uint16_t *retcode);
+	virtual bool WriteToControlChannel(PhysPt bufptr, uint16_t size, uint16_t *retcode);
+	virtual uint8_t GetStatus(bool input_flag);
+	bool CheckSameDevice(uint16_t seg, uint16_t s_off, uint16_t i_off);
+
+private:
+	struct ExtDeviceData ext;
+
+	uint16_t CallDeviceFunction(uint8_t command, uint8_t length, PhysPt bufptr, uint16_t size);
+};
+
+bool DOS_ExtDevice::CheckSameDevice(uint16_t seg, uint16_t s_off, uint16_t i_off)
+{
+	if (seg == ext.segment && s_off == ext.strategy && i_off == ext.interrupt) {
+		return true;
+	}
+	return false;
+}
+
+uint16_t DOS_ExtDevice::CallDeviceFunction(uint8_t command, uint8_t length, PhysPt bufptr, uint16_t size)
+{
+	uint16_t oldbx = reg_bx;
+	uint16_t oldes = SegValue(es);
+
+	real_writeb(dos.dcp, 0, length);
+	real_writeb(dos.dcp, 1, 0);
+	real_writeb(dos.dcp, 2, command);
+	real_writew(dos.dcp, 3, 0);
+	real_writed(dos.dcp, 5, 0);
+	real_writed(dos.dcp, 9, 0);
+	real_writeb(dos.dcp, 13, 0);
+	real_writew(dos.dcp, 14, (uint16_t)(bufptr & 0x000f));
+	real_writew(dos.dcp, 16, (uint16_t)(bufptr >> 4));
+	real_writew(dos.dcp, 18, size);
+
+	reg_bx = 0;
+	SegSet16(es, dos.dcp);
+	CALLBACK_RunRealFar(ext.segment, ext.strategy);
+	CALLBACK_RunRealFar(ext.segment, ext.interrupt);
+	reg_bx = oldbx;
+	SegSet16(es, oldes);
+
+	return real_readw(dos.dcp, 3);
+}
+
+bool DOS_ExtDevice::ReadFromControlChannel(PhysPt bufptr, uint16_t size, uint16_t *retcode)
+{
+	if (ext.attribute & 0x4000) {
+		// IOCTL INPUT
+		if ((CallDeviceFunction(3, 26, bufptr, size) & 0x8000) == 0) {
+			*retcode = real_readw(dos.dcp, 18);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool DOS_ExtDevice::WriteToControlChannel(PhysPt bufptr, uint16_t size, uint16_t *retcode)
+{
+	if (ext.attribute & 0x4000) {
+		// IOCTL OUTPUT
+		if ((CallDeviceFunction(12, 26, bufptr, size) & 0x8000) == 0) {
+			*retcode = real_readw(dos.dcp, 18);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool DOS_ExtDevice::Read(uint8_t *data, uint16_t *size)
+{
+	PhysPt bufptr = (dos.dcp << 4) | 32;
+	for (uint16_t no = 0; no < *size; no++) {
+		// INPUT
+		if ((CallDeviceFunction(4, 26, bufptr, 1) & 0x8000)) {
+			return false;
+		} else {
+			if (real_readw(dos.dcp, 18) != 1) {
+				return false;
+			}
+			*data++ = mem_readb(bufptr);
+		}
+	}
+	return true;
+}
+
+bool DOS_ExtDevice::Write(uint8_t *data, uint16_t *size)
+{
+	PhysPt bufptr = (dos.dcp << 4) | 32;
+	for (uint16_t no = 0; no < *size; no++) {
+		mem_writeb(bufptr, *data);
+		// OUTPUT
+		if ((CallDeviceFunction(8, 26, bufptr, 1) & 0x8000)) {
+			return false;
+		} else {
+			if (real_readw(dos.dcp, 18) != 1) {
+				return false;
+			}
+		}
+		data++;
+	}
+	return true;
+}
+
+bool DOS_ExtDevice::Close()
+{
+	return true;
+}
+
+bool DOS_ExtDevice::Seek([[maybe_unused]] uint32_t *pos, [[maybe_unused]] uint32_t type)
+{
+	return true;
+}
+
+uint16_t DOS_ExtDevice::GetInformation()
+{
+	// bit9=1 .. ExtDevice
+	return (ext.attribute & 0xc07f) | 0x0080 | EXT_DEVICE_BIT;
+}
+
+uint8_t DOS_ExtDevice::GetStatus(bool input_flag)
+{
+	uint16_t status;
+	if (input_flag) {
+		// NON-DESTRUCTIVE INPUT NO WAIT
+		status = CallDeviceFunction(5, 14, 0, 0);
+	} else {
+		// OUTPUT STATUS
+		status = CallDeviceFunction(10, 13, 0, 0);
+	}
+	// check NO ERROR & BUSY
+	if ((status & 0x8200) == 0) {
+		return 0xff;
+	}
+	return 0x00;
+}
+
+uint32_t DOS_CheckExtDevice(const char *name, bool already_flag)
+{
+	uint32_t addr = dos_infoblock.GetDeviceChain();
+	uint16_t seg, off;
+	uint16_t next_seg, next_off;
+	uint16_t no;
+	char devname[8 + 1];
+
+	seg = addr >> 16;
+	off = addr & 0xffff;
+	while (1) {
+		no = real_readw(seg, off + 4);
+		next_seg = real_readw(seg, off + 2);
+		next_off = real_readw(seg, off);
+		if (next_seg == 0xffff && next_off == 0xffff) {
+			break;
+		}
+		if (no & 0x8000) {
+			for (no = 0; no < 8; no++) {
+				if ((devname[no] = real_readb(seg, off + 10 + no)) <= 0x20) {
+					devname[no] = 0;
+					break;
+				}
+			}
+			devname[8] = 0;
+			if (!strcmp(name, devname)) {
+				if (already_flag) {
+					for (no = 0; no < DOS_DEVICES; no++) {
+						if (Devices[no]) {
+							if (Devices[no]->GetInformation() & EXT_DEVICE_BIT) {
+								if (((DOS_ExtDevice *)Devices[no])
+								            ->CheckSameDevice(seg, real_readw(seg, off + 6),
+								                              real_readw(seg, off + 8))) {
+									return 0;
+								}
+							}
+						}
+					}
+				}
+				// Exclude the default CON and NUL
+				if (real_readd(seg, off + 6) == 0 || real_readd(seg, off + 6) == 0xffffffff) {
+					return 0;
+				}
+				return (uint32_t)seg << 16 | (uint32_t)off;
+			}
+		}
+		seg = next_seg;
+		off = next_off;
+	}
+	return 0;
+}
+
+static void DOS_CheckOpenExtDevice(const char *name)
+{
+	uint32_t addr;
+
+	if ((addr = DOS_CheckExtDevice(name, true)) != 0) {
+		DOS_ExtDevice *device = new DOS_ExtDevice(name, addr >> 16, addr & 0xffff);
+		DOS_AddDevice(device);
+	}
+}
+
 class device_NUL : public DOS_Device {
 public:
 	device_NUL() { SetName("NUL"); }
@@ -50,7 +271,7 @@ public:
 		return true;
 	}
 	virtual bool Close() { return true; }
-	virtual Bit16u GetInformation(void) { return 0x8084; }
+	virtual uint16_t GetInformation() { return 0x8084; }
 	virtual bool ReadFromControlChannel(PhysPt /*bufptr*/,Bit16u /*size*/,Bit16u * /*retcode*/){return false;}
 	virtual bool WriteToControlChannel(PhysPt /*bufptr*/,Bit16u /*size*/,Bit16u * /*retcode*/){return false;}
 };
@@ -58,7 +279,7 @@ public:
 class device_LPT1 final : public device_NUL {
 public:
    	device_LPT1() { SetName("LPT1");}
-	Bit16u GetInformation(void) { return 0x80A0; }
+	uint16_t GetInformation() { return 0x80A0; }
 	bool Read(Bit8u* /*data*/,Bit16u * /*size*/){
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
@@ -81,7 +302,7 @@ bool DOS_Device::Close() {
 	return Devices[devnum]->Close();
 }
 
-Bit16u DOS_Device::GetInformation(void) { 
+uint16_t DOS_Device::GetInformation() { 
 	return Devices[devnum]->GetInformation();
 }
 
@@ -93,8 +314,18 @@ bool DOS_Device::WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcod
 	return Devices[devnum]->WriteToControlChannel(bufptr,size,retcode);
 }
 
-DOS_File & DOS_File::operator= (const DOS_File & orig) {
-	flags=orig.flags;
+uint8_t DOS_Device::GetStatus(bool input_flag)
+{
+	uint16_t info = Devices[devnum]->GetInformation();
+	if (info & EXT_DEVICE_BIT) {
+		return Devices[devnum]->GetStatus(input_flag);
+	}
+	return (info & 0x40) ? 0x00 : 0xff;
+}
+
+DOS_File &DOS_File::operator=(const DOS_File &orig)
+{
+	flags = orig.flags;
 	time=orig.time;
 	date=orig.date;
 	attr=orig.attr;
@@ -121,6 +352,25 @@ Bit8u DOS_FindDevice(char const * name) {
    
 	char* dot = strrchr(name_part,'.');
 	if(dot) *dot = 0; //no ext checking
+
+	DOS_CheckOpenExtDevice(name_part);
+	for (int index = DOS_DEVICES - 1; index >= 0; index--) {
+		if (Devices[index]) {
+			if (Devices[index]->GetInformation() & EXT_DEVICE_BIT) {
+				if (WildFileCmp(name_part, Devices[index]->name.c_str())) {
+					if (DOS_CheckExtDevice(name_part, false) != 0) {
+						return index;
+					} else {
+						delete Devices[index];
+						Devices[index] = 0;
+						break;
+					}
+				}
+			} else {
+				break;
+			}
+		}
+	}
 
 	// AUX is alias for COM1 and PRN for LPT1
 	// A bit of a hack. (but less then before).
@@ -168,7 +418,7 @@ void DOS_DelDevice(DOS_Device * dev) {
 	}
 }
 
-void DOS_SetupDevices(void) {
+void DOS_SetupDevices() {
 	DOS_Device * newdev;
 	newdev=new device_CON();
 	DOS_AddDevice(newdev);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -60,7 +60,7 @@ public:
 	bool CheckSameDevice(uint16_t seg, uint16_t s_off, uint16_t i_off);
 
 private:
-	struct ExtDeviceData ext;
+	struct ExtDeviceData ext = {};
 
 	uint16_t CallDeviceFunction(uint8_t command, uint8_t length, PhysPt bufptr, uint16_t size);
 };

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -73,7 +73,7 @@ bool DOS_IOCTL(void) {
 			return false;
 		} else {
 			if (Files[handle]->GetInformation() & 0x8000) {	//Check for device
-				reg_al = ((DOS_Device*)(Files[handle]))->GetStatus(true);
+				reg_al = reinterpret_cast<DOS_Device *>(Files[handle])->GetStatus(true);
 			} else {
 				DOS_SetError(DOSERR_FUNCTION_NUMBER_INVALID);
 				return false;
@@ -123,7 +123,7 @@ bool DOS_IOCTL(void) {
 		return true;
 	case 0x07:		/* Get Output Status */
 		if (Files[handle]->GetInformation() & EXT_DEVICE_BIT) {
-			reg_al = ((DOS_Device*)(Files[handle]))->GetStatus(false);
+			reg_al = reinterpret_cast<DOS_Device *>(Files[handle])->GetStatus(false);
 			return true;
 		}
 		LOG(LOG_IOCTL, LOG_NORMAL)("07:Fakes output status is ready for handle %u", handle);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1167,12 +1167,8 @@ static bool MSCDEX_Handler(void) {
 			}
 			reg_al = 0xff;
 			return true;
-		} else {
-			LOG(LOG_MISC,LOG_ERROR)("NETWORK REDIRECTOR USED!!!");
-			reg_ax = 0x49;//NETWERK SOFTWARE NOT INSTALLED
-			CALLBACK_SCF(true);
-			return true;
-		}
+		} else
+			return false;
 	}
 
 	if (reg_ah!=0x15) return false;		// not handled here, continue chain

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -157,6 +157,9 @@ void DOS_SetupTables(void) {
 		mem_writew(Real2Phys(dos.tables.mediaid)+i*9,0);
 	}
 
+	/* Create Device command packet area */
+	dos.dcp = DOS_GetMemory(3);
+
 	/* Create a fake disk buffer head */
 	seg=DOS_GetMemory(6);
 	for (Bitu ct=0; ct<0x20; ct++) real_writeb(seg,ct,0);


### PR DESCRIPTION
Thank you for this generous contribution from the DOSBox-X project, @Wengier. 

This will allow easier network setup combined with a higher performance and more stable TCP/IP stack versus the DOS + win31 approach, all of which will benefit windows 3.1x multiplayer games.