### PR TITLE
Don't log subsequent unhandled port IO calls (#1448)

### DIFF
--- a/src/hardware/iohandler_containers.cpp
+++ b/src/hardware/iohandler_containers.cpp
@@ -28,6 +28,7 @@
 #include <unordered_map>
 
 #include "inout.h"
+#include "support.h"
 
 void IO_ReadHandleObject::Uninstall(){
 	if(!installed) return;
@@ -64,21 +65,19 @@ constexpr auto &io_write_byte_handler = io_write_handlers[0];
 constexpr auto &io_write_word_handler = io_write_handlers[1];
 constexpr auto &io_write_dword_handler = io_write_handlers[2];
 
-// type-sized IO handler API
-static uint8_t no_read(const io_port_t port)
+constexpr io_val_t blocked_read(const io_port_t, const io_width_t)
 {
-	LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected read from %04xh; blocking", port);
 	return 0xff;
 }
 
+// type-sized IO handler API
 uint8_t read_byte_from_port(const io_port_t port)
 {
-	const auto reader = io_read_byte_handler.find(port);
-	const io_val_t value = reader != io_read_byte_handler.end()
-	                           ? (reader->second(port, io_width_t::byte) & 0xff)
-	                           : no_read(port);
-	assert(value <= UINT8_MAX);
-	return static_cast<uint8_t>(value);
+	const auto [it, was_blocked] = io_read_byte_handler.emplace(port, blocked_read);
+	if (was_blocked)
+		LOG(LOG_IO, LOG_WARN)("Unhandled read from port %04Xh; blocking", port);
+	const auto value = it->second(port, io_width_t::byte);
+	return check_cast<uint8_t>(value);
 }
 
 uint16_t read_word_from_port(const io_port_t port)
@@ -89,8 +88,7 @@ uint16_t read_word_from_port(const io_port_t port)
 	                           : static_cast<io_val_t>(
 	                                     read_byte_from_port(port) |
 	                                     (read_byte_from_port(port + 1) << 8));
-	assert(value <= UINT16_MAX);
-	return static_cast<uint16_t>(value);
+	return check_cast<uint16_t>(value);
 }
 
 uint32_t read_dword_from_port(const io_port_t port)
@@ -105,18 +103,19 @@ uint32_t read_dword_from_port(const io_port_t port)
 	return static_cast<uint32_t>(value);
 }
 
-static void no_write(const io_port_t port, const uint8_t val)
+constexpr void blocked_write(const io_port_t, const io_val_t, const io_width_t)
 {
-	LOG(LOG_IO, LOG_WARN)("IOBUS: Unexpected write of %u to %04xh; blocking", val, port);
+	// nothing to write to
 }
 
 void write_byte_to_port(const io_port_t port, const uint8_t val)
 {
-	const auto writer = io_write_byte_handler.find(port);
-	if (writer != io_write_byte_handler.end())
-		writer->second(port, val, io_width_t::byte);
-	else
-		no_write(port, val);
+	const auto [it, was_blocked] = io_write_byte_handler.emplace(port, blocked_write);
+	if (was_blocked)
+		LOG(LOG_IO, LOG_WARN)("Unhandled write of value 0x%02x"
+		                      " (%u) to port %04Xh; blocking",
+		                      val, val, port);
+	it->second(port, val, io_width_t::byte);
 }
 
 void write_word_to_port(const io_port_t port, const uint16_t val)
@@ -146,7 +145,6 @@ void IO_RegisterReadHandler(io_port_t port,
                             const io_width_t max_width,
                             io_port_t range)
 {
-	// assert(port != 39656);
 	while (range--) {
 		io_read_byte_handler[port] = handler;
 		if (max_width == io_width_t::word || max_width == io_width_t::dword)

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -477,12 +477,14 @@ bx_ne2k_c::asic_write(io_port_t offset, io_val_t value, io_width_t io_len)
 uint32_t
 bx_ne2k_c::page0_read(io_port_t offset, io_width_t io_len)
 {
-  BX_DEBUG("NE2000: page 0 read from port %04x, len=%u", (unsigned) offset,
-	   (unsigned) io_len);
-  if (static_cast<uint8_t>(io_len) > 1) {
-    BX_ERROR("NE2000: bad length! page 0 read from port %04x, len=%u", (unsigned) offset,
-             (unsigned) io_len); /* encountered with win98 hardware probe */
-	return 0;
+	BX_DEBUG("NE2000: page 0 read from port %04x, len=%u", (unsigned)offset,
+	         (unsigned)io_len);
+	if (static_cast<uint8_t>(io_len) > 1) {
+		BX_ERROR("NE2000: bad length! page 0 read from port %04x, len=%u",
+		         (unsigned)offset, (unsigned)io_len); /* encountered
+		                                                 with win98
+		                                                 hardware probe */
+		return 0;
   }
 
 
@@ -699,13 +701,13 @@ bx_ne2k_c::page0_write(io_port_t offset, io_val_t data, io_width_t io_len)
 
     // Monitor bit is a little suspicious...
     if (value & 0x20)
-      BX_INFO(("NE2000: RCR write, monitor bit set!"));
+	    BX_INFO(("NE2000: RCR write, monitor bit set!"));
     break;
 
   case 0xd:  // TCR
     // Check reserved bits
     if (value & 0xe0)
-      BX_ERROR(("NE2000: TCR write, reserved bits set"));
+	    BX_ERROR(("NE2000: TCR write, reserved bits set"));
 
     // Test loop mode (not supported)
     if (value & 0x06) {
@@ -730,7 +732,7 @@ bx_ne2k_c::page0_write(io_port_t offset, io_val_t data, io_width_t io_len)
   case 0xe:  // DCR
     // the loopback mode is not suppported yet
     if (!(value & 0x08)) {
-      BX_ERROR(("NE2000: DCR write, loopback mode selected"));
+	    BX_ERROR(("NE2000: DCR write, loopback mode selected"));
     }
     // It is questionable to set longaddr and auto_rx, since they
     // aren't supported on the ne2000. Print a warning and continue
@@ -761,9 +763,9 @@ bx_ne2k_c::page0_write(io_port_t offset, io_val_t data, io_width_t io_len)
     BX_NE2K_THIS s.IMR.overw_inte = ((value & 0x10) == 0x10);
     BX_NE2K_THIS s.IMR.cofl_inte  = ((value & 0x20) == 0x20);
     BX_NE2K_THIS s.IMR.rdma_inte  = ((value & 0x40) == 0x40);
-	if(BX_NE2K_THIS s.ISR.pkt_tx && BX_NE2K_THIS s.IMR.tx_inte) {
-	  PIC_ActivateIRQ(s.base_irq);
-	}
+    if (BX_NE2K_THIS s.ISR.pkt_tx && BX_NE2K_THIS s.IMR.tx_inte) {
+	    PIC_ActivateIRQ(s.base_irq);
+    }
     break;
   default:
     BX_PANIC("page 0 write, bad offset %0x", offset);
@@ -898,9 +900,9 @@ bx_ne2k_c::page2_read(io_port_t offset, io_width_t io_len)
   case 0x9:
   case 0xa:
   case 0xb:
-    BX_ERROR("NE2000: reserved read - page 2, 0x%02x", (unsigned) offset);
-    return (0xff);
-    break;
+	  BX_ERROR("NE2000: reserved read - page 2, 0x%02x", (unsigned)offset);
+	  return (0xff);
+	  break;
 
   case 0xc:  // RCR
     return
@@ -958,7 +960,7 @@ bx_ne2k_c::page2_write(io_port_t offset, io_val_t data, io_width_t io_len)
   // affect internal operation, but let them through for now
   // and print a warning.
   if (offset != 0)
-    BX_ERROR(("NE2000: page 2 write ?"));
+	  BX_ERROR(("NE2000: page 2 write ?"));
 
   switch (offset) {
   case 0x1:  // CLDA0


### PR DESCRIPTION
Previously, Staging reported every unhandled IO call.

For programs that don't heed the first failed result, repeated calls to the same port can generate excessive logging, which prevents the user from seeing other important log output.

This commit will suppress logging of subsequent unhandled IO calls, matching upstream behavior.

Unit test results for this change:

``` text
Running main() from ../../subprojects/googletest-release-1.11.0/googletest/src/gtest_main.cc
[==========] Running 9 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 9 tests from iohandler_containers
[ RUN      ] iohandler_containers.valid_bytes
[       OK ] iohandler_containers.valid_bytes (9 ms)
[ RUN      ] iohandler_containers.valid_words
[       OK ] iohandler_containers.valid_words (4 ms)
[ RUN      ] iohandler_containers.valid_dwords
[       OK ] iohandler_containers.valid_dwords (65 ms)
[ RUN      ] iohandler_containers.empty_reads
[       OK ] iohandler_containers.empty_reads (0 ms)
[ RUN      ] iohandler_containers.empty_writes
[       OK ] iohandler_containers.empty_writes (0 ms)
[ RUN      ] iohandler_containers.adjacent_word_read
[       OK ] iohandler_containers.adjacent_word_read (0 ms)
[ RUN      ] iohandler_containers.adjacent_dword_read
[       OK ] iohandler_containers.adjacent_dword_read (0 ms)
[ RUN      ] iohandler_containers.adjacent_word_write
[       OK ] iohandler_containers.adjacent_word_write (0 ms)
[ RUN      ] iohandler_containers.adjacent_dword_write
[       OK ] iohandler_containers.adjacent_dword_write (0 ms)
[----------] 9 tests from iohandler_containers (79 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 1 test suite ran. (79 ms total)
[  PASSED  ] 9 tests.
```

Fixes #1448