### PR TITLE
Omit 320x200x15/16/24 modes from compatible VESA set

### DIFF
--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -700,9 +700,14 @@ void filter_s3_modes_to_oem_only()
 	case 8192 * 1024: dram_size = mb_8; break;
 	}
 	auto mode_not_allowed = [&](const VideoModeBlock &m) -> bool {
-		// Allows all the standard VESA modes, which start prior to 0x120
-		if (m.mode < 0x120)
+		// Allow all the standard VESA modes, which start prior to 0x120...
+		if (m.mode < 0x120) {
+			// ...except for 320x200x15/16/24 which were rarely supported until late 90s.
+			if (m.mode == 0x10d || m.mode == 0x10e || m.mode == 0x10f)
+				return true;
+
 			return false;
+		}
 
 		// Allow all modes that aren't part of the VESA VGA set (CGA/EGA/Hercules/etc)
 		constexpr auto vesa_vga_modes = M_LIN4 | M_LIN8 | M_LIN15 | M_LIN16 | M_LIN24 | M_LIN32;


### PR DESCRIPTION
This excludes VESA modes 010Dh, 010Eh and 010Fh from the compatible set provided by vesa_modes = compatible setting.
This notably fixes the infamous FMV problem in The Need for Speed: Special Edition: https://www.os2museum.com/wp/need-for-speed-se-video-glitch/. Due to a bug in the game code, the game plays showcase FMVs in 320x200x16 mode if it's available despite them being designed for 320x200x8 which is why FMVs appear garbled. This bug did not manifest itself back when the game was released since 320x200x16 was an extremely unusual mode in 1996 and it was rarely, if ever, supported.

See here for reference on VESA modes: https://en.wikipedia.org/wiki/VESA_BIOS_Extensions#Modes_defined_by_VESA