### PR TITLE
Fix CHOICE command return code when calling from another program

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -38,6 +38,7 @@
 
 DOS_Block dos;
 DOS_InfoBlock dos_infoblock;
+unsigned int result_errorcode = 0;
 
 #define DOS_COPYBUFSIZE 0x10000
 Bit8u dos_copybuf[DOS_COPYBUFSIZE];
@@ -857,7 +858,8 @@ static Bitu DOS_21Handler(void) {
 			break;
 		}
 	case 0x4b:					/* EXEC Load and/or execute program */
-		{ 
+		{
+			result_errorcode = 0;
 			MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 			LOG(LOG_EXEC,LOG_ERROR)("Execute %s %d",name1,reg_al);
 			if (!DOS_Execute(name1,SegPhys(es)+reg_bx,reg_al)) {
@@ -869,6 +871,8 @@ static Bitu DOS_21Handler(void) {
 //TODO Check for use of execution state AL=5
 	case 0x4c:					/* EXIT Terminate with return code */
 		DOS_Terminate(dos.psp(),false,reg_al);
+		if (result_errorcode)
+			dos.return_code = result_errorcode;
 		break;
 	case 0x4d:					/* Get Return code */
 		reg_al=dos.return_code;/* Officially read from SDA and clear when read */

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -30,8 +30,6 @@
 #include "callback.h"
 #include "string_utils.h"
 
-unsigned int result_errorcode = 0;
-
 DOS_Shell::~DOS_Shell() {
 	bf.reset();
 }
@@ -587,7 +585,6 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		SegSet16(cs,RealSeg(newcsip));
 		reg_ip=RealOff(newcsip);
 #endif
-		result_errorcode = 0;
 		/* Start up a dos execute interrupt */
 		reg_ax=0x4b00;
 		//Filename pointer
@@ -600,8 +597,6 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		CALLBACK_RunRealInt(0x21);
 		/* Restore CS:IP and the stack */
 		reg_sp+=0x200;
-		if (result_errorcode)
-			dos.return_code = result_errorcode;
 #if 0
 		reg_eip=oldeip;
 		SegSet16(cs,oldcs);


### PR DESCRIPTION
This fixes the return code of CHOICE command so that it will be reported even if it is called from another program instead of the internal DOS shell. It solves issue #1455 as reported by @NicknineTheEagle.