### PR TITLE
Improve modem command-mode handling

### DIFF
--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -851,6 +851,15 @@ void CSerialModem::TelnetEmulation(uint8_t *data, uint32_t size)
 	}
 }
 
+void CSerialModem::Echo(uint8_t ch)
+{
+	if (echo) {
+		rqueue->addb(ch);
+		// LOG_MSG("SERIAL: Port %" PRIu8 " echo back to queue: %x.",
+		//         GetPortNumber(), txval);
+	}
+}
+
 void CSerialModem::Timer2() {
 	uint32_t txbuffersize = 0;
 
@@ -877,11 +886,7 @@ void CSerialModem::Timer2() {
 	while (tqueue->inuse()) {
 		const uint8_t txval = tqueue->getb();
 		if (commandmode) {
-			if (echo) {
-				rqueue->addb(txval);
-				// LOG_MSG("SERIAL: Port %" PRIu8 " echo back to queue: %x.",
-				//         GetPortNumber(), txval);
-			}
+			Echo(txval);
 
 			if (txval == '\n')
 				continue; // Real modem doesn't seem to skip this?

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -209,18 +209,18 @@ void CSerialModem::handleUpperEvent(uint16_t type)
 }
 
 void CSerialModem::SendLine(const char *line) {
-	rqueue->addb(0xd);
-	rqueue->addb(0xa);
+	rqueue->addb(reg[MREG_CR_CHAR]);
+	rqueue->addb(reg[MREG_LF_CHAR]);
 	rqueue->adds((uint8_t *)line, strlen(line));
-	rqueue->addb(0xd);
-	rqueue->addb(0xa);
+	rqueue->addb(reg[MREG_CR_CHAR]);
+	rqueue->addb(reg[MREG_LF_CHAR]);
 }
 
 // only for numbers < 1000...
 void CSerialModem::SendNumber(uint32_t val)
 {
-	rqueue->addb(0xd);
-	rqueue->addb(0xa);
+	rqueue->addb(reg[MREG_CR_CHAR]);
+	rqueue->addb(reg[MREG_LF_CHAR]);
 
 	rqueue->addb(val / 100 + '0');
 	val = val%100;
@@ -228,8 +228,8 @@ void CSerialModem::SendNumber(uint32_t val)
 	val = val%10;
 	rqueue->addb(val + '0');
 
-	rqueue->addb(0xd);
-	rqueue->addb(0xa);
+	rqueue->addb(reg[MREG_CR_CHAR]);
+	rqueue->addb(reg[MREG_LF_CHAR]);
 }
 
 void CSerialModem::SendRes(const ResTypes response) {
@@ -889,12 +889,13 @@ void CSerialModem::Timer2() {
 			Echo(txval);
 
 			if (txval == '\n')
+			if (txval == reg[MREG_LF_CHAR])
 				continue; // Real modem doesn't seem to skip this?
 
-			if (txval == '\b') {
+			if (txval == reg[MREG_BACKSPACE_CHAR]) {
 				if (cmdpos > 0)
 					cmdpos--;
-			} else if (txval == '\r') {
+			} else if (txval == reg[MREG_CR_CHAR]) {
 				DoCommand();
 			} else if (cmdpos < 99) {
 				cmdbuf[cmdpos] = txval;

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -479,14 +479,16 @@ void CSerialModem::DoCommand()
 					SendRes(ResERROR);
 					return;
 				}
-				socketType = (SocketTypesE)requested_mode;
-				// This will break when there's more than two
-				// socket types.
-				LOG_MSG("SERIAL: Port %" PRIu8 " socket type %s",
-				        GetPortNumber(),
-				        socketType ? "ENet" : "TCP");
-				// Reset port state.
-				EnterIdleState();
+				if (socketType != (SocketTypesE)requested_mode) {
+					socketType = (SocketTypesE)requested_mode;
+					// This will break when there's more than two
+					// socket types.
+					LOG_MSG("SERIAL: Port %" PRIu8 " socket type %s",
+							GetPortNumber(),
+							socketType ? "ENet" : "TCP");
+					// Reset port state.
+					EnterIdleState();
+				}
 				break;
 			}
 			// If the command wasn't recognized then stop parsing

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -193,7 +193,7 @@ public:
 
 	void TelnetEmulation(uint8_t *data, uint32_t size);
 
-	//TODO
+	void Echo(uint8_t ch);
 	void Timer2();
 	void handleUpperEvent(uint16_t type);
 


### PR DESCRIPTION
* Actually use modem registers for setting CR, LF and BS chars.
* Ignore everything in modem command mode until "AT" sequenced is encountered.

Fixes:
* The Need for Speed - sends "+++AT" to the modem at init time.
* Duke Nukem 3D - sends three ESC chars before modem init command.