### PR TITLE
Fix crash when exiting full-screen and using OpenGL output

### DIFF
--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -23,6 +23,8 @@
 #include "compiler.h"
 #include "types.h"
 
+#include <memory>
+
 int sdl_main(int argc, char *argv[]);
 
 // The shutdown_requested bool is a conditional break in the parse-loop and
@@ -50,7 +52,8 @@ void DOSBOX_SetNormalLoop();
 void DOSBOX_Init(void);
 
 class Config;
-extern Config * control;
+using config_ptr_t = std::unique_ptr<Config>;
+extern config_ptr_t control;
 
 enum MachineType {
 	MCH_HERC,

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -64,11 +64,10 @@ void CAPTURE_AddMidi(bool sysex, Bitu len, Bit8u * data);
 void CAPTURE_VideoStart();
 void CAPTURE_VideoStop();
 
-class Config;
 // Gravis UltraSound configuration and initialization
-void GUS_AddConfigSection(Config *conf);
+void GUS_AddConfigSection(const config_ptr_t &conf);
 
 // Innovation SSI-2001 configuration and initialization
-void INNOVATION_AddConfigSection(Config *conf);
+void INNOVATION_AddConfigSection(const config_ptr_t &conf);
 
 #endif

--- a/include/midi.h
+++ b/include/midi.h
@@ -38,11 +38,11 @@ void MIDI_ListAll(Program *output_handler);
 void MIDI_RawOutByte(uint8_t data);
 
 #if C_FLUIDSYNTH
-void FLUID_AddConfigSection(Config *conf);
+void FLUID_AddConfigSection(const config_ptr_t &conf);
 #endif
 
 #if C_MT32EMU
-void MT32_AddConfigSection(Config *conf);
+void MT32_AddConfigSection(const config_ptr_t &conf);
 #endif
 
 #endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -55,7 +55,6 @@
 #include "hardware.h"
 #include "ne2000.h"
 
-Config * control;
 bool shutdown_requested = false;
 MachineType machine;
 SVGACards svgaCard;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3770,8 +3770,9 @@ int sdl_main(int argc, char *argv[])
 		CROSS_DetermineConfigPaths();
 
 		CommandLine com_line(argc,argv);
-		Config myconf(&com_line);
-		control=&myconf;
+
+		control = std::make_unique<Config>(&com_line);
+
 		/* Init the configuration system and add default values */
 		Config_Add_SDL();
 		DOSBOX_Init();
@@ -3899,9 +3900,9 @@ int sdl_main(int argc, char *argv[])
 		if (control->cmdline->FindExist("-startmapper"))
 			MAPPER_DisplayUI();
 
-		/* Start up main machine */
-		control->StartUp();
-		/* Shutdown everything */
+		control->StartUp(); // Run the machine until shutdown
+		control.reset();  // Shutdown and release
+
 	} catch (char * error) {
 		rcode = 1;
 		GFX_ShowMsg("Exit to error: %s",error);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1075,13 +1075,13 @@ static bool LoadGLShaders(const char *src, GLuint *vertex, GLuint *fragment) {
 [[maybe_unused]] static std::string get_glshader_value()
 {
 #if C_OPENGL
-	assert(control);
-	const Section *rs = control->GetSection("render");
-	assert(rs);
-	return rs->GetPropValue("glshader");
-#else
-	return "";
+	if (control) {
+		const Section *rs = control->GetSection("render");
+		assert(rs);
+		return rs->GetPropValue("glshader");
+	}
 #endif // C_OPENGL
+	return "";
 }
 
 // "flexible" shaders properly handle window-resizing and NPOT textures

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1519,7 +1519,7 @@ void init_gus_dosbox_settings(Section_prop &secprop)
 	                   "with Timidity should work fine.");
 }
 
-void GUS_AddConfigSection(Config *conf)
+void GUS_AddConfigSection(const config_ptr_t &conf)
 {
 	assert(conf);
 	Section_prop *sec = conf->AddSection_prop("gus", &gus_init, true);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -306,7 +306,7 @@ static void init_innovation_dosbox_settings(Section_prop &sec_prop)
 	        "Adjusts the 8580's filtering strength as a percent from 0 to 100.");
 }
 
-void INNOVATION_AddConfigSection(Config *conf)
+void INNOVATION_AddConfigSection(const config_ptr_t &conf)
 {
 	assert(conf);
 	Section_prop *sec = conf->AddSection_prop("innovation",

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -635,7 +635,7 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program *caller)
 static void fluid_init([[maybe_unused]] Section *sec)
 {}
 
-void FLUID_AddConfigSection(Config *conf)
+void FLUID_AddConfigSection(const config_ptr_t &conf)
 {
 	assert(conf);
 	Section_prop *sec = conf->AddSection_prop("fluidsynth", &fluid_init);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -722,7 +722,7 @@ void MidiHandler_mt32::Render()
 static void mt32_init([[maybe_unused]] Section *sec)
 {}
 
-void MT32_AddConfigSection(Config *conf)
+void MT32_AddConfigSection(const config_ptr_t &conf)
 {
 	assert(conf);
 	Section_prop *sec_prop = conf->AddSection_prop("mt32", &mt32_init);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -39,7 +39,12 @@ extern char **environ;
 #endif
 
 using namespace std;
-static std::string current_config_dir; // Set by parseconfigfile so Prop_path can use it to construct the realpath
+
+// Commonly accessed global that holds configuration records
+std::unique_ptr<Config> control = {};
+
+// Set by parseconfigfile so Prop_path can use it to construct the realpath
+static std::string current_config_dir;
 void Value::destroy() throw(){
 	if (type == V_STRING) delete _string;
 }

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -15,10 +15,9 @@ public:
 	DOSBoxTestFixture()
 	        : arg_c_str("-conf tests/files/dosbox-staging-tests.conf\0"),
 	          argv{arg_c_str},
-	          com_line(1, argv),
-	          config(Config(&com_line))
+	          com_line(1, argv)
 	{
-		control = &config;
+		control = std::make_unique<Config>(&com_line);
 	}
 
 	void SetUp() override
@@ -59,7 +58,7 @@ private:
 	char const *arg_c_str;
 	const char *argv[1];
 	CommandLine com_line;
-	Config config;
+	config_ptr_t config;
 	// Only init these sections for our tests
 	std::vector<std::string> sections{"dosbox", "cpu",      "mixer",
 	                                  "midi",   "sblaster", "speaker",

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -23,9 +23,6 @@
 #include "control.h"
 #include "logging.h"
 
-// This global variable should be setup/torn down per test.
-Config *control = nullptr;
-
 // During testing we never want to log to stdout/stderr, as it could
 // negatively affect test harness.
 void GFX_ShowMsg(const char *, ...) {}


### PR DESCRIPTION
This fixes an out-of-scope access when shutting down in fullscreen OpenGL mode.

Context: previously, the global config record was constructed within SDL main's `try { ... }` block, which
goes out-of-scope when an exception is thrown. Attempting to access any configuration records after the exception (such as when changing video modes during shutdown) would result in accessing previously destroyed memory.