### PR TITLE
Work-around freedesktop's periodic https-based GitLab outages 

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -157,6 +157,11 @@ jobs:
           sudo apt-get install $(cat .github/packages/ubuntu-20.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
+      # Workaround frequent HTTPS-based connectivity issues
+      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
+      - name:  Fetch the libffi subproject for Glib
+        run: ./scripts/fetch-libffi-subproject.sh
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -99,6 +99,11 @@ jobs:
         run: |
           brew install $(cat .github/packages/macos-latest-brew.txt)
 
+      # Workaround frequent HTTPS-based connectivity issues
+      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
+      - name:  Fetch the libffi subproject for Glib
+        run: ./scripts/fetch-libffi-subproject.sh
+
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
         if:    matrix.system.name == 'Windows'
         shell: python scripts\msys-bash.py {0}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -162,6 +162,11 @@ jobs:
             $(cat ./.github/packages/ubuntu-18.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
+      # Workaround frequent HTTPS-based connectivity issues
+      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
+      - name:  Fetch the libffi subproject for Glib
+        run: ./scripts/fetch-libffi-subproject.sh
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -190,6 +190,11 @@ jobs:
           arch -arch=${{ matrix.runner.arch }} brew install librsvg tree
           ccache libpng meson opusfile sdl2 sdl2_net
 
+      # Workaround frequent HTTPS-based connectivity issues
+      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
+      - name:  Fetch the libffi subproject for Glib
+        run: ./scripts/fetch-libffi-subproject.sh
+
       - uses:  actions/cache@v2
         if:    matrix.runner.needs_deps
         with:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # Workaround frequent HTTPS-based connectivity issues
+      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
+      - name:  Fetch the libffi subproject for Glib
+        run: ./scripts/fetch-libffi-subproject.sh
+
       - name: Build
         uses: uraimo/run-on-arch-action@master
         with:

--- a/scripts/fetch-libffi-subproject.sh
+++ b/scripts/fetch-libffi-subproject.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021-2021  kcgen <kcgen@users.noreply.github.com>
+
+# This script exists only to easily fetch the libffi subproject
+# because the repository's HTTPS interface used by the glib wrap
+# is frequently down.
+#
+# Ref: https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi/-/issues/8
+#
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+subproject_branch="meson"
+subproject_dir="$repo_root/subprojects/libffi"
+subproject_repo="git@gitlab.freedesktop.org:gstreamer/meson-ports/libffi.git"
+fallback_tarball="https://github.com/dosbox-staging/dosbox-staging/files/7780837/libffi.tar.xz.zip"
+
+if [[ ! -d "$subproject_dir" ]]; then
+	GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR" \
+	git clone --depth 1 --branch "$subproject_branch" "$subproject_repo" "$subproject_dir" || \
+	curl -L "$fallback_tarball" | xz -dc | tar -x -C "$repo_root/subprojects/"
+else
+	echo "subproject_dir already exists, skipping clone"
+fi


### PR DESCRIPTION
These have been periodically impacting the project's CI chain for quite some time, however they have grown increasingly bad of the last couple days. 

This PR is a (hopefully) a temporary stop-gap until this issue is permanently solved. 

Ref: https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407

For example: 

![2021-12-27_06-38](https://user-images.githubusercontent.com/1557255/147487868-d139c641-80b5-4163-aa1e-c1947fc37f82.png)
