### PR TITLE
Add an input permission check for Linux users running with `SDL_VIDEODRIVER=kmsdrm`

### DIFF
--- a/include/std_filesystem.h
+++ b/include/std_filesystem.h
@@ -21,7 +21,7 @@
 #ifndef DOSBOX_FILESYSTEM_H
 #define DOSBOX_FILESYSTEM_H
 
-#if defined(__clang__) || defined(_MSC_VER) || (defined(__GNUC__) && __GNUC_ >= 9)
+#if defined(__clang__) || defined(_MSC_VER) || (defined(__GNUC__) && __GNUC__ >= 9)
 #    include <filesystem>
      namespace std_fs = std::filesystem;
 #else

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3834,6 +3834,9 @@ int sdl_main(int argc, char *argv[])
 
 	loguru::init(argc, argv);
 
+	LOG_MSG("dosbox-staging version %s", DOSBOX_GetDetailedVersion());
+	LOG_MSG("---");
+
 	try {
 		Disable_OS_Scaling(); //Do this early on, maybe override it through some parameter.
 		OverrideWMClass(); // Before SDL2 video subsystem is initialized
@@ -3911,9 +3914,6 @@ int sdl_main(int argc, char *argv[])
 #if defined(WIN32)
 	SetConsoleCtrlHandler((PHANDLER_ROUTINE) ConsoleEventHandler,TRUE);
 #endif
-
-	LOG_MSG("dosbox-staging version %s", DOSBOX_GetDetailedVersion());
-	LOG_MSG("---");
 
 	check_kmsdrm_setting();
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3837,6 +3837,9 @@ int sdl_main(int argc, char *argv[])
 	LOG_MSG("dosbox-staging version %s", DOSBOX_GetDetailedVersion());
 	LOG_MSG("---");
 
+	LOG_MSG("LOG: Loguru version %d.%d.%d initialized", LOGURU_VERSION_MAJOR,
+	        LOGURU_VERSION_MINOR, LOGURU_VERSION_PATCH);
+
 	try {
 		Disable_OS_Scaling(); //Do this early on, maybe override it through some parameter.
 		OverrideWMClass(); // Before SDL2 video subsystem is initialized

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3926,6 +3926,10 @@ int sdl_main(int argc, char *argv[])
 	// Once initialized, ensure we clean up SDL for all exit conditions
 	atexit(QuitSDL);
 
+	LOG_MSG("SDL: version %d.%d.%d initialized (%s video and %s audio)",
+		SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL,
+		SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
+
 	const auto config_path = CROSS_GetPlatformConfigDir();
 	SETUP_ParseConfigFiles(config_path);
 
@@ -3979,7 +3983,7 @@ int sdl_main(int argc, char *argv[])
 		control->StartUp(); // Run the machine until shutdown
 		control.reset();  // Shutdown and release
 
-	} catch (char * error) {
+	} catch (char *error) {
 		rcode = 1;
 		GFX_ShowMsg("Exit to error: %s",error);
 		fflush(NULL);
@@ -3993,8 +3997,7 @@ int sdl_main(int argc, char *argv[])
 			Sleep(5000);
 #endif
 		}
-	}
-	catch (...) {
+	} catch (...) {
 		// just exit
 		rcode = 1;
 	}


### PR DESCRIPTION
If a user runs with the KSMDRM video driver without having access to the Linux input devices, then SDL will hard-lock all keyboard and mouse input. The only resolution is a push-button reboot or SSHing in and having systemctl stop the affected tty.

This PR adds a permission check and graceful exit with log message if the user is lacking permission to the input devices. This prevents SDL from initializing, which is where the input lockup occurs.