### PR TITLE
GUI remove conflict "-v" with --version / verbosity

### DIFF
--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -72,7 +72,7 @@ These are common options:
   -exit               Dosbox will close itself when the DOS program
                       specified by FILE ends.
 
-  -v, --version       Output version information and exit.
+  --version       Output version information and exit.
 
 You can find full list of options in the man page: dosbox(1)
 And in file: /usr/share/doc/dosbox-staging/README


### PR DESCRIPTION
loguru uses -v for verbosity
-v for --version is not defined anywhere else, so eliminating this switch for now until verbosity is updated.


https://github.com/dosbox-staging/dosbox-staging/issues/1472