### PR TITLE
Fix a regression where pixel-perfect mode failed use aspect correction (#1485)

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2378,7 +2378,10 @@ static SDL_Point window_bounds_from_label(const std::string &pref,
 		            pref.c_str());
 
 	const int w = ceil_sdivide(desktop.w * percent, 100);
-	const int h = ceil_sdivide(desktop.h * percent, 100);
+
+	// 320x200 when physically scaled by 3x4 produces 960x800 or a 6:5 aspect ratio
+	const int h_with_aspect = ceil_sdivide(desktop.w * percent * 5, 100 * 6);
+	const int h = std::min(desktop.h, h_with_aspect); // limit to desktop size
 	return {w, h};
 }
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1784,9 +1784,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		doubleheight=true;
 	}
 	vga.draw.vblank_skip = vblank_skip;
-		
-	if (!(IS_VGA_ARCH && (svgaCard==SVGA_None) && (vga.mode==M_EGA || vga.mode==M_VGA))) {
-		//Only check for extra double height in vga modes
+
+	const bool has_extra_double_height = doublewidth && !doubleheight && height > width;
+	// Only check for extra double height in vga modes
+	if (IS_VGA_ARCH && has_extra_double_height) {
 		//(line multiplying by address_line_total)
 		if (!doubleheight && (vga.mode<M_TEXT) && !(vga.draw.address_line_total & 1)) {
 			vga.draw.address_line_total/=2;


### PR DESCRIPTION
Tested on Linux and Windows:

![Capture](https://user-images.githubusercontent.com/1557255/147950288-da322754-7502-492e-9c63-b9a52477285c.PNG)
