### PR TITLE
Fix performance regression on some Windows systems (#1482)

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -57,6 +57,7 @@ extern Bit32s CPU_CycleLimit;
 extern Bit64s CPU_IODelayRemoved;
 extern bool CPU_CycleAutoAdjust;
 extern bool CPU_SkipCycleAutoAdjust;
+extern bool CPU_AllowSpeedMods;
 extern Bitu CPU_AutoDetermineMode;
 
 extern Bitu CPU_ArchitectureType;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -62,9 +62,11 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandler * &cph) {
 	PageHandler *handler = get_tlb_readhandler(lin_addr_as_physpt);
 	if (handler->flags & PFLAG_HASCODE) {
 		cph=( CodePageHandler *)handler;
-		if (handler->flags & cflag) return false;
+		if (CPU_AllowSpeedMods || (handler->flags & cflag)) {
+			return false;
+		}
 		cph->ClearRelease();
-		cph=0;
+		cph = nullptr;
 		handler = get_tlb_readhandler(lin_addr_as_physpt);
 	}
 	if (handler->flags & PFLAG_NOCODE) {
@@ -74,20 +76,22 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandler * &cph) {
 				cph=( CodePageHandler *)handler;
 				if (handler->flags & cflag) return false;
 				cph->ClearRelease();
-				cph=0;
+				cph = nullptr;
 				handler = get_tlb_readhandler(lin_addr_as_physpt);
 			}
 		}
 		if (handler->flags & PFLAG_NOCODE) {
 			LOG_MSG("DYNX86:Can't run code in this page!");
-			cph=0;		return false;
+			cph = nullptr;
+			return false;
 		}
 	} 
 	Bitu lin_page=lin_addr >> 12;
 	Bitu phys_page=lin_page;
 	if (!PAGING_MakePhysPage(phys_page)) {
 		LOG_MSG("DYNX86:Can't find physpage");
-		cph=0;		return false;
+		cph = nullptr;
+		return false;
 	}
 	/* Find a free CodePage */
 	if (!cache.free_pages && cache.used_pages) {

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -327,12 +327,12 @@ enum save_info_type {db_exception, cycle_check, normal, fpu_restore};
 
 
 static struct {
-	save_info_type type;
-	DynState state;
-	const Bit8u * branch_pos;
-	Bit32u eip_change;
-	Bitu cycles;
-	const Bit8u * return_pos;
+	save_info_type type = {};
+	DynState state = {};
+	const Bit8u * branch_pos = nullptr;
+	Bit32u eip_change = 0;
+	Bitu cycles = 0;
+	const Bit8u * return_pos = nullptr;
 } save_info[512];
 
 Bitu used_save_info=0;

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -268,14 +268,16 @@ public:
 			Save();
 		}
 		dynreg->flags&=~(DYNFLG_CHANGED|DYNFLG_ACTIVE);
-		dynreg->genreg=0;dynreg=0;
+		dynreg->genreg = nullptr;
+		dynreg = nullptr;
 	}
 	void Clear(void) {
 		if (!dynreg) return;
 		if (dynreg->flags&DYNFLG_CHANGED) {
 			Save();
 		}
-		dynreg->genreg=0;dynreg=0;
+		dynreg->genreg = nullptr;
+		dynreg = nullptr;
 	}
 };
 
@@ -422,7 +424,7 @@ static void ForceDynReg(GenReg * genreg,DynReg * dynreg) {
 		if (genreg->dynreg) genreg->Clear();
 		// mov dst32, src32
 		opcode(genreg->index).setrm(dynreg->genreg->index).Emit8(0x8B);
-		dynreg->genreg->dynreg=0;
+		dynreg->genreg->dynreg = nullptr;
 		dynreg->genreg=genreg;
 		genreg->dynreg=dynreg;
 	} else genreg->Load(dynreg);
@@ -444,7 +446,8 @@ static void gen_setupreg(DynReg * dnew,DynReg * dsetup) {
 	/* Not the same genreg must be wrong */
 	if (dnew->genreg) {
 		/* Check if the genreg i'm changing is actually linked to me */
-		if (dnew->genreg->dynreg==dnew) dnew->genreg->dynreg=0;
+		if (dnew->genreg->dynreg == dnew)
+			dnew->genreg->dynreg = nullptr;
 	}
 	dnew->genreg=dsetup->genreg;
 	if (dnew->genreg) dnew->genreg->dynreg=dnew;
@@ -523,7 +526,7 @@ static void gen_reinit(void) {
 	x64gen.last_used=0;
 	x64gen.flagsactive=false;
 	for (Bitu i=0;i<X64_REGS;i++) {
-		x64gen.regs[i]->dynreg=0;
+		x64gen.regs[i]->dynreg = nullptr;
 	}
 }
 
@@ -900,12 +903,14 @@ static void gen_dop_word_imm_mem(DualOps op,bool dword,DynReg * dr1,void* data) 
 	if ((Bit32s)addr==addr || (Bit32s)rbpdiff==rbpdiff || ripdiff < 0x7FFFFFE0ll)
 		i = opcode(FindDynReg(dr1,dword && op==DOP_MOV)->index,dword).setabsaddr(data);
 	else if (dword && op==DOP_MOV) {
-		if (dr1->genreg) dr1->genreg->dynreg=0;
-		x64gen.regs[X64_REG_RAX]->Load(dr1,true);
+		if (dr1->genreg)
+			dr1->genreg->dynreg = nullptr;
+		x64gen.regs[X64_REG_RAX]->Load(dr1, true);
 		if ((Bit32u)addr == (Bitu)addr) {
 			cache_addb(0x67);
 			opcode(0).setimm(addr,4).Emit8Reg(0xA1);
-		} else opcode(0).setimm(addr,8).Emit8Reg(0xA1);
+		} else
+			opcode(0).setimm(addr, 8).Emit8Reg(0xA1);
 		dr1->flags|=DYNFLG_CHANGED;
 		return;
 	} else {
@@ -1111,8 +1116,9 @@ static void gen_call_function(void * func,const char* ops,...) {
 		GenReg * genret;
 		if (rettype == 'd') {
 			genret=x64gen.regs[X64_REG_RAX];
-			if (dynret->genreg) dynret->genreg->dynreg=0;
-			genret->Load(dynret,true);
+			if (dynret->genreg)
+				dynret->genreg->dynreg = nullptr;
+			genret->Load(dynret, true);
 		} else {
 			opcode op(0); // src=eax/ax/al/ah
 			x64gen.regs[X64_REG_RAX]->notusable = true;

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -70,14 +70,16 @@ public:
 			Save();
 		}
 		dynreg->flags&=~(DYNFLG_CHANGED|DYNFLG_ACTIVE);
-		dynreg->genreg=0;dynreg=0;
+		dynreg->genreg = nullptr;
+		dynreg = nullptr;
 	}
 	void Clear(void) {
 		if (!dynreg) return;
 		if (dynreg->flags&DYNFLG_CHANGED) {
 			Save();
 		}
-		dynreg->genreg=0;dynreg=0;
+		dynreg->genreg = nullptr;
+		dynreg = nullptr;
 	}
 };
 
@@ -211,7 +213,8 @@ static void gen_setupreg(DynReg * dnew,DynReg * dsetup) {
 	/* Not the same genreg must be wrong */
 	if (dnew->genreg) {
 		/* Check if the genreg i'm changing is actually linked to me */
-		if (dnew->genreg->dynreg==dnew) dnew->genreg->dynreg=0;
+		if (dnew->genreg->dynreg == dnew)
+			dnew->genreg->dynreg = nullptr;
 	}
 	dnew->genreg=dsetup->genreg;
 	if (dnew->genreg) dnew->genreg->dynreg=dnew;
@@ -292,7 +295,7 @@ static void gen_reinit(void) {
 	x86gen.last_used=0;
 	x86gen.flagsactive=false;
 	for (Bitu i=0;i<X86_REGS;i++) {
-		x86gen.regs[i]->dynreg=0;
+		x86gen.regs[i]->dynreg = nullptr;
 	}
 }
 

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -127,12 +127,14 @@ static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
 	if (handler->flags & PFLAG_HASCODE) {
 		// this is a codepage handler, make sure it matches current code size
 		cph = (CodePageHandler *)handler;
-		if (handler->flags & cflag) return false;
+		if (CPU_AllowSpeedMods || (handler->flags & cflag)) {
+			return false;
+		}
 		// wrong code size/stale dynamic code, drop it
 		cph->ClearRelease();
-		cph=0;
+		cph = nullptr;
 		// handler was changed, refresh
-		handler=get_tlb_readhandler(lin_addr);
+		handler = get_tlb_readhandler(lin_addr);
 	}
 	if (handler->flags & PFLAG_NOCODE) {
 		if (PAGING_ForcePageInit(lin_addr)) {
@@ -141,13 +143,13 @@ static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
 				cph = (CodePageHandler *)handler;
 				if (handler->flags & cflag) return false;
 				cph->ClearRelease();
-				cph=0;
+				cph = nullptr;
 				handler=get_tlb_readhandler(static_cast<PhysPt>(lin_addr));
 			}
 		}
 		if (handler->flags & PFLAG_NOCODE) {
 			LOG_MSG("DYNREC:Can't run code in this page");
-			cph=0;
+			cph = nullptr;
 			return false;
 		}
 	} 
@@ -156,7 +158,7 @@ static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
 	// find the physical page that the linear page is mapped to
 	if (!PAGING_MakePhysPage(phys_page)) {
 		LOG_MSG("DYNREC:Can't find physpage");
-		cph=0;
+		cph = nullptr;
 		return false;
 	}
 	// find a free CodePage

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -59,6 +59,7 @@ Bit64s CPU_IODelayRemoved = 0;
 CPU_Decoder * cpudecoder;
 bool CPU_CycleAutoAdjust = false;
 bool CPU_SkipCycleAutoAdjust = false;
+bool CPU_AllowSpeedMods = false;
 Bitu CPU_AutoDetermineMode = 0;
 
 Bitu CPU_ArchitectureType = CPU_ARCHTYPE_MIXED;

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -802,12 +802,14 @@ static inline void dyn_cache_invalidate([[maybe_unused]] void *ptr,
 #elif defined(HAVE_SYS_ICACHE_INVALIDATE)
 #if defined(HAVE_BUILTIN_AVAILABLE)
 	if (__builtin_available(macOS 11.0, *))
-#endif	
+#endif
 		sys_icache_invalidate(ptr, size);
 #elif defined(WIN32)
+	if (CPU_AllowSpeedMods)
+		return;
 	FlushInstructionCache(GetCurrentProcess(), ptr, size);
 #else
-	#error "Don't know how to clear the cache on this platform"
+#error "Don't know how to clear the cache on this platform: please report this"
 #endif
 }
 

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -783,8 +783,7 @@ static inline void dyn_mem_set_access([[maybe_unused]] void *ptr,
 	                                                    &old_protect);
 	assert(vp_res != 0);
 #else
-	LOG_MSG("No method to set memory access %p, %zu, %d on this platform",
-	        ptr, size, execute);
+#error "no dynamic memory protection on this platform: please report this"
 #endif
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -400,6 +400,10 @@ static void DOSBOX_RealInit(Section * sec) {
 		int10.vesa_mode_preference = VESA_MODE_PREF::ALL;
 	else
 		int10.vesa_mode_preference = VESA_MODE_PREF::COMPATIBLE;
+
+	CPU_AllowSpeedMods = section->Get_bool("speed_mods");
+	LOG_MSG("SYSTEM: Speed modifications are %s",
+	        CPU_AllowSpeedMods ? "enabled" : "disabled");
 }
 
 void DOSBOX_Init() {
@@ -484,6 +488,12 @@ void DOSBOX_Init() {
 	        "  all          Offers all modes for a given video memory size, however\n"
 	        "               some games may not use them properly (flickering) or may need\n"
 	        "               more system memory (mem = ) to use them.");
+
+	Pbool = secprop->Add_bool("speed_mods", only_at_start, true);
+	Pbool->Set_help(
+	        "Permit changes known to improve performance. Currently no games are known\n"
+	        "to be affected by this. Please file a bug with the project if you find a\n"
+	        "game that fails when this is set to true so we will list them here.");
 
 	secprop->AddInitFunction(&CALLBACK_Init);
 	secprop->AddInitFunction(&PIC_Init);//done

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -532,14 +532,14 @@
     <ClCompile Include="..\src\dos\program_serial.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp">
-      <Filter>src\libs\ghc</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\libs\loguru\loguru.cpp">
       <Filter>src\libs\loguru</Filter>
     </ClCompile>
     <ClCompile Include="..\src\libs\whereami\whereami.c">
       <Filter>src\libs\whereami</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp">
+      <Filter>src\libs\ghc</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1082,6 +1082,9 @@
     </Filter>
     <Filter Include="src\libs\whereami">
       <UniqueIdentifier>{d1c1e098-73ca-4f3a-a2f7-e8186a52c4dc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\libs\ghc">
+      <UniqueIdentifier>{9df2bcc2-35e3-4be4-a577-dff8be565c65}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Investigation into ticket #1482 showed that some Windows configurations are more affected by the W^X page tagging and invalidation routines than other Windows 10 systems. 

Relaxing the page-tagging routines _does_ help but the behaviour isn't strictly compliant to Microsoft's documentation: but it works on all tested systems.

To accommodate this issue but not dispose of the compliant behaviour, a new configuration setting is added: 

``` ini
[dosbox]
speed_mods =true
```

Which can be disabled should it be needed for some games or Windows W^X compliance.
This setting will let us add other speed-related modifications when performance is critical (ie: on the Pi or in this case: running lates-90s games at very high DOS resolutions).

Thanks to @raymanxy for reporting and testing this. 

Tested on Windows 10:

![Capture](https://user-images.githubusercontent.com/1557255/147989926-c14af77e-a0f5-4da2-b027-a2105013dd72.PNG)

This still attracts some attention from WindowsDefender, however this is assumed to be due to the binary hashes not yet being added to Microsoft's allow-list.