### PR TITLE
Ignore the `-noconsole` flag under MSYS2 builds

### DIFF
--- a/README
+++ b/README
@@ -494,7 +494,7 @@ dosbox -opencaptures program
 
         The machinetype affects the video card and the available sound cards.
 
-  -noconsole (Windows Only)
+  -noconsole (Windows Visual Studio-builds only)
         Start DOSBox without showing the DOSBox status window (console).
         Output will be redirected to stdout.txt and stderr.txt
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3870,8 +3870,8 @@ int sdl_main(int argc, char *argv[])
 		if(control->cmdline->FindExist("-erasemapper")) erasemapperfile();
 		if(control->cmdline->FindExist("-resetmapper")) erasemapperfile();
 
-		/* Can't disable the console with debugger enabled */
-#if defined(WIN32) && !(C_DEBUG)
+		/* Can't disable the console with debugger-enabled or when built with mingw */
+#if defined(WIN32) && !((C_DEBUG) || defined(__MINGW32__))
 		if (control->cmdline->FindExist("-noconsole")) {
 			FreeConsole();
 			/* Redirect standard input and standard output */
@@ -3891,7 +3891,7 @@ int sdl_main(int argc, char *argv[])
 			}
 			SetConsoleTitle("DOSBox Status Window");
 		}
-#endif  //defined(WIN32) && !(C_DEBUG)
+#endif  //defined(WIN32) && !((C_DEBUG) || defined(__MINGW32__))
 
 		if (control->cmdline->FindExist("--version") ||
 		    control->cmdline->FindExist("-version") ||


### PR DESCRIPTION
Two reports have indicated launch problems using the release binaries (built with MSYS2). 
This PR always launches with the console active for MSYS2 builds.
The README is updated to indicate that `-noconsole` only applies to Visual Studio builds.