### PR TITLE
Fix minor PVS Studio warnings in Shell-related code

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 279
+          MAX_BUGS: 262
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/shell.h
+++ b/include/shell.h
@@ -147,13 +147,9 @@ struct SHELL_Cmd {
 class AutoexecObject{
 private:
 	bool installed = false;
-	std::string buf{};
+	std::string buf = {};
 
 public:
-	AutoexecObject()
-		: installed(false),
-		  buf("")
-	{}
 	void Install(std::string const &in);
 	void InstallBefore(std::string const &in);
 	const std::string &GetLine() const { return buf; }

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -104,4 +104,37 @@ bool ends_with(const std::string &str, const std::string &suffix) noexcept;
 
 bool find_in_case_insensitive(const std::string &needle, const std::string &haystack);
 
+// Safely terminate a C string at the given offset
+//
+// Convert code like: stuff[n] = 0;
+//  - "is stuff an integer array?"
+//  - "are we setting a counter back to 0?"
+//  - "is stuff a valid array?"
+//
+// To: terminate_str_at(stuff, n);
+// which is self-documenting about the type (stuff is a string),
+// intent (terminating), and where it's being applied (n);
+//
+template <typename T, typename INDEX_T>
+void terminate_str_at(T *str, INDEX_T i) noexcept
+{
+	// Check that we're only operating on bona-fide C strings
+	static_assert(std::is_same_v<T, char> || std::is_same_v<T, wchar_t>,
+	              "Can only reset a *char or *wchar_t with the string-terminator");
+
+	// Check that we don't underflow with a negative index
+	assert(std::is_unsigned_v<INDEX_T> || i >= 0);
+
+	// Check that we don't dereferrence a null pointer
+	assert(str != nullptr);
+	str[i] = '\0';
+}
+
+// reset a C string with the string-terminator character
+template <typename T>
+void reset_str(T *str) noexcept
+{
+	terminate_str_at(str, 0);
+}
+
 #endif

--- a/include/support.h
+++ b/include/support.h
@@ -215,8 +215,9 @@ inline bool is_empty(const char *str) noexcept
 {
 	return str[0] == '\0';
 }
-
-bool ScanCMDBool(char * cmd,char const * const check);
+// Scans the provided command-line string for the '/'flag and removes it from
+// the string, returning if the flag was found and removed.
+bool ScanCMDBool(char *cmd, const char * flag);
 char * ScanCMDRemain(char * cmd);
 char * StripWord(char *&cmd);
 

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -240,18 +240,24 @@ char * lowcase(char * str) {
 	return str;
 }
 
-bool ScanCMDBool(char * cmd, char const * const check)
+// Scans the provided command-line string for a '/'flag, removes it (if found),
+// and then returns a bool if it was indeed found and removed.
+bool ScanCMDBool(char *cmd, const char * flag)
 {
 	if (cmd == nullptr)
 		return false;
 	char *scan = cmd;
-	const size_t c_len = strlen(check);
+	const size_t flag_len = strlen(flag);
 	while ((scan = strchr(scan,'/'))) {
-		/* found a / now see behind it */
+		// Found a slash indicating the possible start of a flag.
+		// Now see if it's the flag we're looking for:
 		scan++;
-		if (strncasecmp(scan,check,c_len)==0 && (scan[c_len]==' ' || scan[c_len]=='\t' || scan[c_len]=='/' || scan[c_len]==0)) {
-		/* Found a math now remove it from the string */
-			memmove(scan-1,scan+c_len,strlen(scan+c_len)+1);
+		if (strncasecmp(scan, flag, flag_len) == 0 &&
+		    (scan[flag_len] == ' ' || scan[flag_len] == '\t' ||
+		     scan[flag_len] == '/' || scan[flag_len] == 0)) {
+
+			// Found a match for the flag, now remove it
+			memmove(scan - 1, scan + flag_len, strlen(scan + flag_len) + 1);
 			trim(scan-1);
 			return true;
 		}

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -254,7 +254,7 @@ bool ScanCMDBool(char *cmd, const char * flag)
 		scan++;
 		if (strncasecmp(scan, flag, flag_len) == 0 &&
 		    (scan[flag_len] == ' ' || scan[flag_len] == '\t' ||
-		     scan[flag_len] == '/' || scan[flag_len] == 0)) {
+		     scan[flag_len] == '/' || scan[flag_len] == '\0')) {
 
 			// Found a match for the flag, now remove it
 			memmove(scan - 1, scan + flag_len, strlen(scan + flag_len) + 1);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -155,11 +155,13 @@ AutoexecObject::~AutoexecObject(){
 			if (stringset && first_shell && first_shell->bf && first_shell->bf->filename.find("AUTOEXEC.BAT") != std::string::npos) {
 				//Replace entry with spaces if it is a set and from autoexec.bat, as else the location counter will be off.
 				*it = buf.assign(buf.size(),' ');
-				it++;
+				++it;
 			} else {
 				it = autoexec_strings.erase(it);
 			}
-		} else it++;
+		} else {
+			++it;
+		}
 	}
 	this->CreateAutoexec();
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -430,16 +430,19 @@ public:
 		: Module_base(configuration),
 		  autoexec_echo()
 	{
+		const auto cmdline = control->cmdline; // short-lived copy
+
 		// Initialize configurable states that control autoexec-related
 		// behavior
 
 		/* Check -securemode switch to disable mount/imgmount/boot after
 		 * running autoexec.bat */
-		const bool secure = control->cmdline->FindExist("-securemode", true);
+		const bool secure = cmdline->FindExist("-securemode", true);
 
 		// Are autoexec sections permitted?
 		const bool autoexec_is_allowed = !secure &&
-		                              !control->cmdline->FindExist("-noautoexec", true);
+		                                 !cmdline->FindExist("-noautoexec",
+		                                                     true);
 
 		// Should autoexec sections be joined or overwritten?
 		const auto ds = control->GetSection("dosbox");
@@ -452,7 +455,7 @@ public:
 		uint8_t i = 1;
 		std::string line;
 		bool exit_call_exists = false;
-		while (control->cmdline->FindString("-c", line, true) && (i <= 11)) {
+		while (cmdline->FindString("-c", line, true) && (i <= 11)) {
 #if defined(WIN32)
 			// replace single with double quotes so that mount
 			// commands can contain spaces
@@ -472,7 +475,7 @@ public:
 		}
 
 		// Check for the -exit switch, which indicates they want to quit
-		const bool exit_arg_exists = control->cmdline->FindExist("-exit");
+		const bool exit_arg_exists = cmdline->FindExist("-exit");
 
 		// Check if instant-launch is active
 		const bool using_instant_launch = control->GetStartupVerbosity() ==
@@ -490,7 +493,7 @@ public:
 
 		unsigned int command_index = 1;
 		bool found_dir_or_command = false;
-		while (control->cmdline->FindCommand(command_index++, line) &&
+		while (cmdline->FindCommand(command_index++, line) &&
 		       !found_dir_or_command) {
 			struct stat test;
 			if (line.length() > CROSS_LEN)
@@ -623,7 +626,7 @@ void AUTOEXEC::ProcessConfigFileAutoexec(const Section_line &section,
 	}
 
 	/* Install the stuff from the configfile if anything
-		* left after moving echo off */
+	 * left after moving echo off */
 	if (*extra) {
 		autoexec[0].Install(std::string(extra));
 		LOG_MSG("AUTOEXEC: Using autoexec from %s", source_name.c_str());

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -599,35 +599,34 @@ void AUTOEXEC::ProcessConfigFileAutoexec(const Section_line &section,
 		return;
 
 	auto extra = &section.data[0];
-	if (extra) {
-		/* detect if "echo off" is the first line */
-		size_t firstline_length = strcspn(extra, "\r\n");
-		bool echo_off = !strncasecmp(extra, "echo off", 8);
-		if (echo_off && firstline_length == 8)
-			extra += 8;
-		else {
-			echo_off = !strncasecmp(extra, "@echo off", 9);
-			if (echo_off && firstline_length == 9)
-				extra += 9;
-			else
-				echo_off = false;
-		}
 
-		/* if "echo off" move it to the front of autoexec.bat */
-		if (echo_off) {
-			autoexec_echo.InstallBefore("@echo off");
-			if (*extra == '\r')
-				extra++; // It can point to \0
-			if (*extra == '\n')
-				extra++; // same
-		}
+	/* detect if "echo off" is the first line */
+	size_t firstline_length = strcspn(extra, "\r\n");
+	bool echo_off = !strncasecmp(extra, "echo off", 8);
+	if (echo_off && firstline_length == 8)
+		extra += 8;
+	else {
+		echo_off = !strncasecmp(extra, "@echo off", 9);
+		if (echo_off && firstline_length == 9)
+			extra += 9;
+		else
+			echo_off = false;
+	}
 
-		/* Install the stuff from the configfile if anything
-		 * left after moving echo off */
-		if (*extra) {
-			autoexec[0].Install(std::string(extra));
-			LOG_MSG("AUTOEXEC: Using autoexec from %s", source_name.c_str());
-		}
+	/* if "echo off" move it to the front of autoexec.bat */
+	if (echo_off) {
+		autoexec_echo.InstallBefore("@echo off");
+		if (*extra == '\r')
+			extra++; // It can point to \0
+		if (*extra == '\n')
+			extra++; // same
+	}
+
+	/* Install the stuff from the configfile if anything
+		* left after moving echo off */
+	if (*extra) {
+		autoexec[0].Install(std::string(extra));
+		LOG_MSG("AUTOEXEC: Using autoexec from %s", source_name.c_str());
 	}
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1011,7 +1011,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 						strcat(source_x,"\\*.*");
 				}
 			}
-			sources.push_back(copysource(source_x,(plus)?true:false));
+			sources.emplace_back(copysource(source_x,(plus)?true:false));
 			source_p = plus;
 		} while (source_p && *source_p);
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1080,7 +1080,8 @@ void DOS_Shell::CMD_COPY(char * args) {
 					target_is_file = false;
 				}
 			}
-		} else target_is_file = false;
+		} else
+			target_is_file = false;
 
 		//Find first sourcefile
 		bool ret = DOS_FindFirst(const_cast<char*>(source.filename.c_str()),0xffff & ~DOS_ATTR_VOLUME);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -620,7 +620,9 @@ void DOS_Shell::CMD_DIR(char * args) {
 	}
 
 	bool optW=ScanCMDBool(args,"W");
-	ScanCMDBool(args,"S");
+
+	(void)ScanCMDBool(args, "S");
+
 	bool optP=ScanCMDBool(args,"P");
 	if (ScanCMDBool(args,"WP") || ScanCMDBool(args,"PW")) {
 		optW=optP=true;
@@ -970,9 +972,10 @@ void DOS_Shell::CMD_COPY(char * args) {
 	while (ScanCMDBool(args,"B")) ;
 	while (ScanCMDBool(args,"T")) ; //Shouldn't this be A ?
 	while (ScanCMDBool(args,"A")) ;
-	ScanCMDBool(args,"Y");
-	ScanCMDBool(args,"-Y");
-	ScanCMDBool(args,"V");
+
+	(void)ScanCMDBool(args, "Y");
+	(void)ScanCMDBool(args, "-Y");
+	(void)ScanCMDBool(args, "V");
 
 	char * rem=ScanCMDRemain(args);
 	if (rem) {
@@ -1578,7 +1581,9 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	if (args) {
 		optN = ScanCMDBool(args,"N");
 		optS = ScanCMDBool(args,"S"); //Case-sensitive matching
-		ScanCMDBool(args,"T"); //Default Choice after timeout
+
+		(void)ScanCMDBool(args, "T"); // Default Choice after timeout
+
 		char *last = strchr(args,0);
 		StripSpaces(args);
 		rem = ScanCMDRemain(args);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1070,9 +1070,11 @@ void DOS_Shell::CMD_COPY(char * args) {
 
 		// add '\\' if target is a directory
 		bool target_is_file = true;
-		if (pathTarget[strlen(pathTarget) - 1]!='\\') {
-			if (DOS_FindFirst(pathTarget,0xffff & ~DOS_ATTR_VOLUME)) {
-				dta.GetResult(name,size,date,time,attr);
+		const auto target_path_length = strlen(pathTarget);
+		assert(target_path_length > 0);
+		if (pathTarget[target_path_length - 1] != '\\') {
+			if (DOS_FindFirst(pathTarget, 0xffff & ~DOS_ATTR_VOLUME)) {
+				dta.GetResult(name, size, date, time, attr);
 				if (attr & DOS_ATTR_DIRECTORY) {
 					strcat(pathTarget,"\\");
 					target_is_file = false;
@@ -1103,7 +1105,10 @@ void DOS_Shell::CMD_COPY(char * args) {
 				if (DOS_OpenFile(nameSource,0,&sourceHandle)) {
 					// Create Target or open it if in concat mode
 					safe_strcpy(nameTarget, pathTarget);
-					if (nameTarget[strlen(nameTarget) - 1] == '\\') strcat(nameTarget,name);
+					const auto name_length = strlen(nameTarget);
+					assert(name_length > 0);
+					if (nameTarget[name_length - 1] == '\\')
+						strcat(nameTarget, name);
 
 					//Special variable to ensure that copy * a_file, where a_file is not a directory concats.
 					bool special = second_file_of_current_source && target_is_file;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -441,17 +441,19 @@ bool DOS_Shell::Execute(char * name,char * args) {
  * return false =>       check for hardware changes in do_command */
 	char fullname[DOS_PATHLENGTH+4]; //stores results from Which
 	char line[CMD_MAXLINE];
-	if(strlen(args)!= 0){
-		if(*args != ' '){ //put a space in front
-			line[0]=' ';line[1]=0;
-			strncat(line,args,CMD_MAXLINE-2);
+	const bool have_args = args && args[0] != '\0';
+	if (have_args) {
+		if (*args != ' ') { // put a space in front
+			line[0] = ' ';
+			line[1] = 0;
+			strncat(line, args, CMD_MAXLINE - 2);
 			line[CMD_MAXLINE-1]=0;
 		} else {
 			safe_strcpy(line, args);
 		}
-	}else{
+	} else {
 		line[0]=0;
-	};
+	}
 
 	/* check for a drive change */
 	if (((strcmp(name + 1, ":") == 0) || (strcmp(name + 1, ":\\") == 0)) && isalpha(*name))

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -138,36 +138,40 @@ void DOS_Shell::InputCommand(char * line) {
 					str_len = str_index = len;
 					size = CMD_MAXLINE - str_index - 2;
 					DOS_WriteFile(STDOUT, (Bit8u *)line, &len);
-					it_history ++;
+					++it_history;
 					break;
 
 				case 0x50: /* Down */
 					if (l_history.empty() || it_history == l_history.begin()) break;
 
 					// not very nice but works ..
-					it_history --;
+					--it_history;
 					if (it_history == l_history.begin()) {
 						// no previous commands in history
-						it_history ++;
+						++it_history;
 
 						// remove current command from history
 						if (current_hist) {
-							current_hist=false;
+							current_hist = false;
 							l_history.pop_front();
 						}
 						break;
-					} else it_history --;
+					} else {
+						--it_history;
+					}
 
-					for (;str_index>0; str_index--) {
+					for (; str_index > 0; str_index--) {
 						// removes all characters
-						outc(8); outc(' '); outc(8);
+						outc(8);
+						outc(' ');
+						outc(8);
 					}
 					strcpy(line, it_history->c_str());
 					len = (Bit16u)it_history->length();
 					str_len = str_index = len;
 					size = CMD_MAXLINE - str_index - 2;
 					DOS_WriteFile(STDOUT, (Bit8u *)line, &len);
-					it_history ++;
+					++it_history;
 
 					break;
 				case 0x53: /* Delete */
@@ -187,8 +191,10 @@ void DOS_Shell::InputCommand(char * line) {
 					break;
 				case 15: /* Shift+Tab */
 					if (l_completion.size()) {
-						if (it_completion == l_completion.begin()) it_completion = l_completion.end (); 
-						it_completion--;
+						if (it_completion == l_completion.begin()) {
+							it_completion = l_completion.end ();
+						}
+						--it_completion;
 		
 						if (it_completion->length()) {
 							for (;str_index > completion_index; str_index--) {
@@ -203,8 +209,7 @@ void DOS_Shell::InputCommand(char * line) {
 							DOS_WriteFile(STDOUT, (Bit8u *)it_completion->c_str(), &len);
 						}
 					}
-				default:
-					break;
+				default: break;
 				}
 			};
 			break;
@@ -241,11 +246,13 @@ void DOS_Shell::InputCommand(char * line) {
 		case'\t':
 			{
 				if (l_completion.size()) {
-					it_completion ++;
-					if (it_completion == l_completion.end()) it_completion = l_completion.begin();
+					++it_completion;
+					if (it_completion == l_completion.end())
+						it_completion = l_completion.begin();
 				} else {
 					// build new completion list
-					// Lines starting with CD will only get directories in the list
+					// Lines starting with CD will only get
+					// directories in the list
 					bool dir_only = (strncasecmp(line,"CD ",3)==0);
 
 					// get completion mask


### PR DESCRIPTION
Mostly just one-liner syntax changes and a couple sanity/asserts.  

The last bug-fix PR touched autoexec handling, so figured I might as well take a cleanup pass through and knock off any zero risk warnings while I'm in the code.

Tested with "none, one, and many command line arguments and autoexec file and conf-based quantities.
Results confirm no change in functionality.