### PR TITLE
Cleanup help messages for SERIAL and CD/CHDIR commands

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -496,33 +496,34 @@ void DOS_SetupPrograms(void)
 	MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
 
 	MSG_Add("PROGRAM_SERIAL_HELP",
-	        "Manage the serial ports.\n"
+	        "Manages the serial ports.\n"
 	        "\n"
-	        "Usage modes:\n"
-	        "  SERIAL /L | /LIST             List the current serial ports.\n"
-	        "  SERIAL PORT# TYPE [settings]  Set the port to the given TYPE.\n"
+	        "Usage:\n"
+	        "  \033[32;1mserial\033[0m \033[37;1m[PORT#]\033[0m                List all or specified serial ports.\n"
+	        "  \033[32;1mserial\033[0m \033[37;1mPORT#\033[0m \033[36;1mTYPE\033[0m [settings]  Set the specified port to the given type.\n"
 	        "\n"
 	        "Where:\n"
-	        "  PORT# : 1, 2, 3, or 4\n"
-	        "  TYPE  : MODEM, NULLMODEM, DIRECTSERIAL, DUMMY, or DISABLED\n"
+	        "  \033[37;1mPORT#\033[0m The port number: \033[37;1m1\033[0m, \033[37;1m2\033[0m, \033[37;1m3\033[0m, or \033[37;1m4\033[0m\n"
+	        "  \033[36;1mTYPE\033[0m  The port type: \033[36;1mMODEM\033[0m, \033[36;1mNULLMODEM\033[0m, \033[36;1mDIRECTSERIAL\033[0m, \033[36;1mDUMMY\033[0m, or \033[36;1mDISABLED\033[0m\n"
 	        "\n"
-	        "Optional settings for each TYPE:\n"
-	        "  For MODEM        : IRQ, LISTENPORT, SOCK\n"
-	        "  For NULLMODEM    : IRQ, SERVER, RXDELAY, TXDELAY, TELNET,\n"
-			"                     USEDTR, TRANSPARENT, PORT, INHSOCKET, SOCK\n"
-	        "  For DIRECTSERIAL : IRQ, REALPORT (required), RXDELAY\n"
-	        "  For DUMMY        : IRQ\n"
+	        "Notes:\n"
+	        "  Optional settings for each \033[36;1mTYPE\033[0m:\n"
+	        "  For \033[36;1mMODEM\033[0m        : IRQ, LISTENPORT, SOCK\n"
+	        "  For \033[36;1mNULLMODEM\033[0m    : IRQ, SERVER, RXDELAY, TXDELAY, TELNET,\n"
+	        "                     USEDTR, TRANSPARENT, PORT, INHSOCKET, SOCK\n"
+	        "  For \033[36;1mDIRECTSERIAL\033[0m : IRQ, REALPORT (required), RXDELAY\n"
+	        "  For \033[36;1mDUMMY\033[0m        : IRQ\n"
 	        "\n"
-	        "Examples using port 1, or COM1 in DOS:\n"
-	        "  SERIAL /list                                 : List the current serial ports\n"
-	        "  SERIAL 1 NULLMODEM PORT:1250                 : Listen on TCP:1250 as server\n"
-	        "  SERIAL 1 NULLMODEM SERVER:10.0.0.6 PORT:1250 : Connect to TCP:1250 as client\n"
-	        "  SERIAL 1 MODEM LISTENPORT:5000 SOCK:1        : Listen on UDP:5000 as server\n"
-	        "  SERIAL 1 DIRECTSERIAL REALPORT:ttyUSB0       : Use a physical port on Linux\n");
+	        "Examples:\n"
+	        "  \033[32;1mSERIAL\033[0m                                       : List the current serial ports\n"
+	        "  \033[32;1mSERIAL\033[0m \033[37;1m1\033[0m \033[36;1mNULLMODEM\033[0m PORT:1250                 : Listen on TCP:1250 as server\n"
+	        "  \033[32;1mSERIAL\033[0m \033[37;1m2\033[0m \033[36;1mNULLMODEM\033[0m SERVER:10.0.0.6 PORT:1250 : Connect to TCP:1250 as client\n"
+	        "  \033[32;1mSERIAL\033[0m \033[37;1m3\033[0m \033[36;1mMODEM\033[0m LISTENPORT:5000 SOCK:1        : Listen on UDP:5000 as server\n"
+	        "  \033[32;1mSERIAL\033[0m \033[37;1m4\033[0m \033[36;1mDIRECTSERIAL\033[0m REALPORT:ttyUSB0       : Use a physical port on Linux\n");
 	MSG_Add("PROGRAM_SERIAL_SHOW_PORT", "COM%d: %s %s\n");
 	MSG_Add("PROGRAM_SERIAL_BAD_PORT",
 	        "Must specify a numeric port value between 1 and %d, inclusive.\n");
-	MSG_Add("PROGRAM_SERIAL_BAD_MODE", "Mode must be one of the following:\n");
+	MSG_Add("PROGRAM_SERIAL_BAD_TYPE", "Type must be one of the following:\n");
 	MSG_Add("PROGRAM_SERIAL_INDENTED_LIST", "  %s\n");
 
 	MSG_Add("PROGRAM_PLACEHOLDER_SHORT_HELP", "This program is a placeholder");

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -56,14 +56,14 @@ void SERIAL::showPort(int port)
 void SERIAL::Run()
 {
 	// Show current serial configurations.
-	if (cmd->FindExist("/l", false) || cmd->FindExist("/list", false)) {
+	if (!cmd->GetCount()) {
 		for (int x = 0; x < SERIAL_MAX_PORTS; x++)
 			showPort(x);
 		return;
 	}
 
 	// Select COM port type.
-	if (cmd->GetCount() >= 2) {
+	if (cmd->GetCount() >= 1 && !cmd->FindExist("/?", false)) {
 		// Which COM did they want to change?
 		int port = -1;
 		cmd->FindCommand(1, temp_line);
@@ -78,7 +78,10 @@ void SERIAL::Run()
 		}
 		const auto port_index = port - 1;
 		assert(port_index >= 0 && port_index < SERIAL_MAX_PORTS);
-
+		if (cmd->GetCount() == 1) {
+			showPort(port_index);
+			return;
+		}
 		// Which type of device do they want?
 		SERIAL_PORT_TYPE desired_type = SERIAL_PORT_TYPE::INVALID;
 		cmd->FindCommand(2, temp_line);
@@ -90,7 +93,7 @@ void SERIAL::Run()
 		}
 		if (desired_type == SERIAL_PORT_TYPE::INVALID) {
 			// No idea what they asked for.
-			WriteOut(MSG_Get("PROGRAM_SERIAL_BAD_MODE"));
+			WriteOut(MSG_Get("PROGRAM_SERIAL_BAD_TYPE"));
 			for (const auto &type_name : serial_type_names) {
 				if (type_name.first == SERIAL_PORT_TYPE::DISABLED)
 					continue; // Don't show the invalid placeholder.
@@ -110,7 +113,7 @@ void SERIAL::Run()
 		                                           commandLineString.c_str());
 		// Remove existing port.
 		delete serialports[port_index];
-		// Recreate the port with the new mode.
+		// Recreate the port with the new type.
 		switch (desired_type) {
 		case SERIAL_PORT_TYPE::INVALID:
 		case SERIAL_PORT_TYPE::DISABLED:

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -832,14 +832,22 @@ void SHELL_Init() {
 	        "\n");
 
 	MSG_Add("SHELL_STARTUP_SUB","\033[32;1mdosbox-staging %s\033[0m\n");
-	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays/changes the current directory.\n");
-	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG","CHDIR [drive:][path]\n"
-	        "CHDIR [..]\n"
-	        "CD [drive:][path]\n"
-	        "CD [..]\n\n"
-	        "  ..   Specifies that you want to change to the parent directory.\n\n"
-	        "Type CD drive: to display the current directory in the specified drive.\n"
-	        "Type CD without parameters to display the current drive and directory.\n");
+	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays or changes the current directory.\n");
+	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mcd\033[0m \033[36;1mDIRECTORY\033[0m\n"
+	        "  \033[32;1mchdir\033[0m \033[36;1mDIRECTORY\033[0m\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[36;1mDIRECTORY\033[0m is the name of the directory to change to.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Running \033[32;1mcd\033[0m without an argument displays the current directory.\n"
+	        "  With \033[36;1mDIRECTORY\033[0m the command only changes the directory, not the current drive.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mcd\033[0m\n"
+	        "  \033[32;1mcd\033[0m \033[36;1mmydir\033[0m\n");
 	MSG_Add("SHELL_CMD_CLS_HELP", "Clears the DOS screen.\n");
 	MSG_Add("SHELL_CMD_CLS_HELP_LONG",
 	        "Usage:\n"


### PR DESCRIPTION
The SERIAL command has been added recently, but its help message did not yet fully conform to the style of DOS commands such as MOUNT and VER. So I improved it to the desired style in this PR. Also, I noticed that the help message for CD/CHDIR command was not yet updated to the new style, so this PR updates it as well.

Also, ``SERIAL`` command without any argument will list all serial ports, or ``SERIAL n`` for listing the specified port. ``SERIAL /?`` will show its help information.