### PR TITLE
MSYS2 build improvements. Switch to Clang 64-bit release build

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -10,7 +10,7 @@ env:
   CCACHE_DIR:      "/c/ccache"
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
-  BUILD_FLAGS: "-Dbuildtype=release -Db_asneeded=true --force-fallback-for=fluidsynth,mt32emu,slirp -Dtry_static_libs=fluidsynth,mt32emu,opusfile,png,slirp"
+  BUILD_FLAGS: "-Dbuildtype=release -Db_asneeded=true --force-fallback-for=fluidsynth,mt32emu,slirp -Dtry_static_libs=fluidsynth,mt32emu,opusfile,png,slirp -Dfluidsynth:try-static-deps=true"
   BUILD_RELEASE_DIR: build/release
   BUILD_DEBUGGER_DIR: build/debugger
 
@@ -27,38 +27,32 @@ jobs:
             toolchain: ""
             arch: i686
             sys: MINGW32
-            cc: gcc
             max_warnings: 0
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            cc: gcc
             max_warnings: 0
           - name: Clang x86
             toolchain: clang-
             arch: i686
             sys: CLANG32
-            cc: clang
             max_warnings: 0
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
-            cc: clang
             max_warnings: 0
           - name: GCC +tests
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            cc: gcc
             run_tests: true
             max_warnings: -0
           - name: GCC +debugger
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            cc: gcc
             max_warnings: 2
             build_flags: -Denable_debugger=normal
     
@@ -92,7 +86,7 @@ jobs:
       - name: Install packages
         run: |
           pacman --noconfirm -S --needed --overwrite \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-${{matrix.conf.cc}} \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-toolchain \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf \
@@ -100,7 +94,6 @@ jobs:
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2 \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-fluidsynth \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-munt-mt32emu \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp \
@@ -202,7 +195,8 @@ jobs:
       - name: Install packages
         run: |
           pacman --noconfirm -S --needed --overwrite \
-            mingw-w64-clang-${{matrix.conf.arch}}-clang \
+            git \
+            mingw-w64-clang-${{matrix.conf.arch}}-toolchain \
             mingw-w64-clang-${{matrix.conf.arch}}-meson \
             mingw-w64-clang-${{matrix.conf.arch}}-ccache \
             mingw-w64-clang-${{matrix.conf.arch}}-pkgconf \
@@ -210,7 +204,6 @@ jobs:
             mingw-w64-clang-${{matrix.conf.arch}}-ntldd \
             mingw-w64-clang-${{matrix.conf.arch}}-ncurses \
             mingw-w64-clang-${{matrix.conf.arch}}-glib2 \
-            mingw-w64-clang-${{matrix.conf.arch}}-fluidsynth \
             mingw-w64-clang-${{matrix.conf.arch}}-munt-mt32emu \
             mingw-w64-clang-${{matrix.conf.arch}}-libpng \
             mingw-w64-clang-${{matrix.conf.arch}}-libslirp \

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -27,32 +27,38 @@ jobs:
             toolchain: ""
             arch: i686
             sys: MINGW32
+            cc: gcc
             max_warnings: 1
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
+            cc: gcc
             max_warnings: 1
-          - name: Clang x86
-            toolchain: clang-
-            arch: i686
-            sys: CLANG32
-            max_warnings: 3
+          - name: GCC (UCRT) x86_64
+            toolchain: ucrt-
+            arch: x86_64
+            sys: UCRT64
+            cc: gcc
+            max_warnings: 1
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
+            cc: clang
             max_warnings: 5
           - name: GCC +tests
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             run_tests: true
+            cc: gcc
             max_warnings: -1
           - name: GCC +debugger
             toolchain: ""
             arch: x86_64
             sys: MINGW64
+            cc: gcc
             max_warnings: 3
             build_flags: -Denable_debugger=normal
     
@@ -70,38 +76,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       
-      - name: Setup MSYS2
+      - name: Setup MSYS2 and install packages
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.conf.sys}}
-          update: true            
-      
-      - name: Enable clang32 repo
-        if:   ${{matrix.conf.sys == 'CLANG32'}}
-        run: |
-          printf "%s\n" "[clang32]" >> /etc/pacman.conf
-          printf "%s\n" "Include = /etc/pacman.d/mirrorlist.mingw" >> /etc/pacman.conf
-          pacman -Sy
-      
-      - name: Install packages
-        run: |
-          toolchain_pkg=$(pacman -Sg mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-toolchain \
-            | sed -e 's/mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-toolchain //g' | tr '\n' ' ')
-          pacman --noconfirm -S --needed --overwrite \
-            $toolchain_pkg \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2 \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2 \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib \
-
+          update: true
+          install: >-
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-${{matrix.conf.cc}}
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib
       
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -157,9 +150,6 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: Clang x86
-            arch: i686
-            sys: CLANG32
           - name: Clang x86_64
             arch: x86_64
             sys: CLANG64
@@ -187,33 +177,20 @@ jobs:
           update: true
           install: |
             git
-      
-      - name: Enable clang32 repo
-        if:   ${{matrix.conf.sys == 'CLANG32'}}
-        run: |
-          printf "%s\n" "[clang32]" >> /etc/pacman.conf
-          printf "%s\n" "Include = /etc/pacman.d/mirrorlist.mingw" >> /etc/pacman.conf
-          pacman -Sy
-      
-      - name: Install packages
-        run: |
-          toolchain_pkg=$(pacman -Sg mingw-w64-clang-${{matrix.conf.arch}}-toolchain \
-            | sed -e 's/mingw-w64-clang-${{matrix.conf.arch}}-toolchain //g' | tr '\n' ' ')
-          pacman --noconfirm -S --needed --overwrite \
-            $toolchain_pkg \
-            mingw-w64-clang-${{matrix.conf.arch}}-meson \
-            mingw-w64-clang-${{matrix.conf.arch}}-ccache \
-            mingw-w64-clang-${{matrix.conf.arch}}-pkgconf \
-            mingw-w64-clang-${{matrix.conf.arch}}-ntldd \
-            mingw-w64-clang-${{matrix.conf.arch}}-ncurses \
-            mingw-w64-clang-${{matrix.conf.arch}}-glib2 \
-            mingw-w64-clang-${{matrix.conf.arch}}-libpng \
-            mingw-w64-clang-${{matrix.conf.arch}}-opusfile \
-            mingw-w64-clang-${{matrix.conf.arch}}-libslirp \
-            mingw-w64-clang-${{matrix.conf.arch}}-SDL2 \
-            mingw-w64-clang-${{matrix.conf.arch}}-SDL2_net \
+            mingw-w64-clang-${{matrix.conf.arch}}-clang
+            mingw-w64-clang-${{matrix.conf.arch}}-meson
+            mingw-w64-clang-${{matrix.conf.arch}}-ccache
+            mingw-w64-clang-${{matrix.conf.arch}}-pkgconf
+            mingw-w64-clang-${{matrix.conf.arch}}-ntldd
+            mingw-w64-clang-${{matrix.conf.arch}}-ncurses
+            mingw-w64-clang-${{matrix.conf.arch}}-glib2
+            mingw-w64-clang-${{matrix.conf.arch}}-libpng
+            mingw-w64-clang-${{matrix.conf.arch}}-opusfile
+            mingw-w64-clang-${{matrix.conf.arch}}-libslirp
+            mingw-w64-clang-${{matrix.conf.arch}}-SDL2
+            mingw-w64-clang-${{matrix.conf.arch}}-SDL2_net
             mingw-w64-clang-${{matrix.conf.arch}}-zlib
-
+            
       - name:  Prepare compiler cache
         id:    prep-ccache
         run: |

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -10,7 +10,7 @@ env:
   CCACHE_DIR:      "/c/ccache"
   CCACHE_MAXSIZE:  "64M"
   CCACHE_COMPRESS: "true"
-  BUILD_FLAGS: "-Dbuildtype=release -Db_asneeded=true --force-fallback-for=fluidsynth,mt32emu,slirp -Dtry_static_libs=fluidsynth,mt32emu,opusfile,png,slirp -Dfluidsynth:try-static-deps=true"
+  BUILD_FLAGS: "-Dbuildtype=release -Db_asneeded=true --force-fallback-for=fluidsynth,mt32emu -Dtry_static_libs=fluidsynth,mt32emu,opusfile,png,slirp -Dfluidsynth:try-static-deps=true"
   BUILD_RELEASE_DIR: build/release
   BUILD_DEBUGGER_DIR: build/debugger
 
@@ -97,9 +97,11 @@ jobs:
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2 \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2 \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib \
+
       
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -207,6 +209,7 @@ jobs:
             mingw-w64-clang-${{matrix.conf.arch}}-glib2 \
             mingw-w64-clang-${{matrix.conf.arch}}-libpng \
             mingw-w64-clang-${{matrix.conf.arch}}-opusfile \
+            mingw-w64-clang-${{matrix.conf.arch}}-libslirp \
             mingw-w64-clang-${{matrix.conf.arch}}-SDL2 \
             mingw-w64-clang-${{matrix.conf.arch}}-SDL2_net \
             mingw-w64-clang-${{matrix.conf.arch}}-zlib

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -27,33 +27,33 @@ jobs:
             toolchain: ""
             arch: i686
             sys: MINGW32
-            max_warnings: 0
+            max_warnings: 1
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            max_warnings: 0
+            max_warnings: 1
           - name: Clang x86
             toolchain: clang-
             arch: i686
             sys: CLANG32
-            max_warnings: 0
+            max_warnings: 3
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
-            max_warnings: 0
+            max_warnings: 5
           - name: GCC +tests
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             run_tests: true
-            max_warnings: -0
+            max_warnings: -1
           - name: GCC +debugger
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            max_warnings: 2
+            max_warnings: 3
             build_flags: -Denable_debugger=normal
     
     defaults:

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -185,7 +185,9 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.conf.sys}}
-          update: true            
+          update: true
+          install: |
+            git
       
       - name: Enable clang32 repo
         if:   ${{matrix.conf.sys == 'CLANG32'}}
@@ -199,7 +201,6 @@ jobs:
           toolchain_pkg=$(pacman -Sg mingw-w64-clang-${{matrix.conf.arch}}-toolchain \
             | sed -e 's/mingw-w64-clang-${{matrix.conf.arch}}-toolchain //g' | tr '\n' ' ')
           pacman --noconfirm -S --needed --overwrite \
-            git \
             $toolchain_pkg \
             mingw-w64-clang-${{matrix.conf.arch}}-meson \
             mingw-w64-clang-${{matrix.conf.arch}}-ccache \

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -229,10 +229,10 @@ jobs:
           echo "PKG_RELEASE=dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}" >> $GITHUB_ENV
            
       - name: Setup release build
-        run: meson setup -Db_lto=true -Db_lto_threads=2 $BUILD_FLAGS $BUILD_RELEASE_DIR
+        run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_FLAGS $BUILD_RELEASE_DIR
 
       - name: Setup debugger build
-        run: meson setup -Db_lto=true -Db_lto_threads=2 $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
+        run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
       
       - name: Build release
         run: ninja -C $BUILD_RELEASE_DIR

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -27,33 +27,39 @@ jobs:
             toolchain: ""
             arch: i686
             sys: MINGW32
-            max_warnings: 1
+            cc: gcc
+            max_warnings: 0
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            max_warnings: 1
-          # - name: Clang x86
-          #   toolchain: clang-
-          #   arch: i686
-          #   sys: CLANG32
-          #   max_warnings: 19
+            cc: gcc
+            max_warnings: 0
+          - name: Clang x86
+            toolchain: clang-
+            arch: i686
+            sys: CLANG32
+            cc: clang
+            max_warnings: 0
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
-            max_warnings: 5
+            cc: clang
+            max_warnings: 0
           - name: GCC +tests
             toolchain: ""
             arch: x86_64
             sys: MINGW64
+            cc: gcc
             run_tests: true
             max_warnings: -0
           - name: GCC +debugger
             toolchain: ""
             arch: x86_64
             sys: MINGW64
-            max_warnings: 3
+            cc: gcc
+            max_warnings: 2
             build_flags: -Denable_debugger=normal
     
     defaults:
@@ -74,24 +80,33 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.conf.sys}}
-          update: true
-          install: >-
-            git
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-gcc
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-python
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-fluidsynth
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-munt-mt32emu
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net
+          update: true            
+      
+      - name: Enable clang32 repo
+        if:   ${{matrix.conf.sys == 'CLANG32'}}
+        run: |
+          printf "%s\n" "[clang32]" >> /etc/pacman.conf
+          printf "%s\n" "Include = /etc/pacman.d/mirrorlist.mingw" >> /etc/pacman.conf
+          pacman -Sy
+      
+      - name: Install packages
+        run: |
+          pacman --noconfirm -S --needed --overwrite \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-${{matrix.conf.cc}} \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-python \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2 \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-fluidsynth \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-munt-mt32emu \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2 \
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib
       
       - name:  Prepare compiler cache
@@ -148,12 +163,12 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: GCC (MinGW) x86
+          - name: Clang x86
             arch: i686
-            sys: MINGW32
-          - name: GCC (MinGW) x86_64
+            sys: CLANG32
+          - name: Clang x86_64
             arch: x86_64
-            sys: MINGW64
+            sys: CLANG64
     
     defaults:
       run:
@@ -175,25 +190,35 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.conf.sys}}
-          update: true
-          install: >-
-            git
-            mingw-w64-${{matrix.conf.arch}}-meson
-            mingw-w64-${{matrix.conf.arch}}-gcc
-            mingw-w64-${{matrix.conf.arch}}-ccache
-            mingw-w64-${{matrix.conf.arch}}-pkgconf
-            mingw-w64-${{matrix.conf.arch}}-ntldd
-            mingw-w64-${{matrix.conf.arch}}-ncurses
-            mingw-w64-${{matrix.conf.arch}}-glib2
-            mingw-w64-${{matrix.conf.arch}}-fluidsynth
-            mingw-w64-${{matrix.conf.arch}}-munt-mt32emu
-            mingw-w64-${{matrix.conf.arch}}-libpng
-            mingw-w64-${{matrix.conf.arch}}-libslirp
-            mingw-w64-${{matrix.conf.arch}}-opusfile
-            mingw-w64-${{matrix.conf.arch}}-SDL2
-            mingw-w64-${{matrix.conf.arch}}-SDL2_net
-            mingw-w64-${{matrix.conf.arch}}-zlib
+          update: true            
       
+      - name: Enable clang32 repo
+        if:   ${{matrix.conf.sys == 'CLANG32'}}
+        run: |
+          printf "%s\n" "[clang32]" >> /etc/pacman.conf
+          printf "%s\n" "Include = /etc/pacman.d/mirrorlist.mingw" >> /etc/pacman.conf
+          pacman -Sy
+      
+      - name: Install packages
+        run: |
+          pacman --noconfirm -S --needed --overwrite \
+            mingw-w64-clang-${{matrix.conf.arch}}-clang \
+            mingw-w64-clang-${{matrix.conf.arch}}-meson \
+            mingw-w64-clang-${{matrix.conf.arch}}-ccache \
+            mingw-w64-clang-${{matrix.conf.arch}}-pkgconf \
+            mingw-w64-clang-${{matrix.conf.arch}}-python \
+            mingw-w64-clang-${{matrix.conf.arch}}-ntldd \
+            mingw-w64-clang-${{matrix.conf.arch}}-ncurses \
+            mingw-w64-clang-${{matrix.conf.arch}}-glib2 \
+            mingw-w64-clang-${{matrix.conf.arch}}-fluidsynth \
+            mingw-w64-clang-${{matrix.conf.arch}}-munt-mt32emu \
+            mingw-w64-clang-${{matrix.conf.arch}}-libpng \
+            mingw-w64-clang-${{matrix.conf.arch}}-libslirp \
+            mingw-w64-clang-${{matrix.conf.arch}}-opusfile \
+            mingw-w64-clang-${{matrix.conf.arch}}-SDL2 \
+            mingw-w64-clang-${{matrix.conf.arch}}-SDL2_net \
+            mingw-w64-clang-${{matrix.conf.arch}}-zlib
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         run: |

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -249,10 +249,10 @@ jobs:
           echo "PKG_RELEASE=dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}" >> $GITHUB_ENV
            
       - name: Setup release build
-        run: meson setup $BUILD_FLAGS $BUILD_RELEASE_DIR
+        run: meson setup -Db_lto=true -Db_lto_threads=2 $BUILD_FLAGS $BUILD_RELEASE_DIR
 
       - name: Setup debugger build
-        run: meson setup $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
+        run: meson setup -Db_lto=true -Db_lto_threads=2 $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
       
       - name: Build release
         run: ninja -C $BUILD_RELEASE_DIR

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -85,8 +85,10 @@ jobs:
       
       - name: Install packages
         run: |
+          toolchain_pkg=$(pacman -Sg mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-toolchain \
+            | sed -e 's/mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-toolchain //g' | tr '\n' ' ')
           pacman --noconfirm -S --needed --overwrite \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-toolchain \
+            $toolchain_pkg \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf \
@@ -194,9 +196,11 @@ jobs:
       
       - name: Install packages
         run: |
+          toolchain_pkg=$(pacman -Sg mingw-w64-clang-${{matrix.conf.arch}}-toolchain \
+            | sed -e 's/mingw-w64-clang-${{matrix.conf.arch}}-toolchain //g' | tr '\n' ' ')
           pacman --noconfirm -S --needed --overwrite \
             git \
-            mingw-w64-clang-${{matrix.conf.arch}}-toolchain \
+            $toolchain_pkg \
             mingw-w64-clang-${{matrix.conf.arch}}-meson \
             mingw-w64-clang-${{matrix.conf.arch}}-ccache \
             mingw-w64-clang-${{matrix.conf.arch}}-pkgconf \

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -92,13 +92,10 @@ jobs:
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-meson \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ccache \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-pkgconf \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-python \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ntldd \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-ncurses \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-glib2 \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-munt-mt32emu \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libpng \
-            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-libslirp \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-opusfile \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2 \
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net \
@@ -205,13 +202,10 @@ jobs:
             mingw-w64-clang-${{matrix.conf.arch}}-meson \
             mingw-w64-clang-${{matrix.conf.arch}}-ccache \
             mingw-w64-clang-${{matrix.conf.arch}}-pkgconf \
-            mingw-w64-clang-${{matrix.conf.arch}}-python \
             mingw-w64-clang-${{matrix.conf.arch}}-ntldd \
             mingw-w64-clang-${{matrix.conf.arch}}-ncurses \
             mingw-w64-clang-${{matrix.conf.arch}}-glib2 \
-            mingw-w64-clang-${{matrix.conf.arch}}-munt-mt32emu \
             mingw-w64-clang-${{matrix.conf.arch}}-libpng \
-            mingw-w64-clang-${{matrix.conf.arch}}-libslirp \
             mingw-w64-clang-${{matrix.conf.arch}}-opusfile \
             mingw-w64-clang-${{matrix.conf.arch}}-SDL2 \
             mingw-w64-clang-${{matrix.conf.arch}}-SDL2_net \


### PR DESCRIPTION
This PR adds some improvements to the MSYS2 CI configuration. Notable changes are:

* Switching release builds from the legacy MinGW toolchain, to the new Clang 64 toolchain.
* Enabling LTO for release builds
* Linking against MSYS2 version of SLIRP to avoid SLIRP compiler warnings
