### PR TITLE
Add 'markup to ANSI codes' parser/lexer

### DIFF
--- a/include/ansi_code_markup.h
+++ b/include/ansi_code_markup.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_ANSI_CODE_MARKUP_H
+#define DOSBOX_ANSI_CODE_MARKUP_H
+
+#include <string>
+
+/*!
+ * \brief Convert marked up strings to strings with ANSI codes
+ * 
+ * \param str 
+ * \return std::string 
+ */
+std::string convert_ansi_markup(const char* str);
+
+#endif // DOSBOX_ANSI_CODE_MARKUP_H

--- a/include/support.h
+++ b/include/support.h
@@ -313,4 +313,10 @@ bool contains(const container_t &container, const typename container_t::value_ty
 	return std::find(container.begin(), container.end(), value) != container.end();
 }
 
+template <typename container_t>
+bool contains(const container_t &container, const typename container_t::key_type &key)
+{
+	return container.find(key) != container.end();
+}
+
 #endif

--- a/src/misc/ansi_code_markup.cpp
+++ b/src/misc/ansi_code_markup.cpp
@@ -1,0 +1,202 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <regex>
+#include <unordered_map>
+
+#include "string_utils.h"
+#include "support.h"
+#include "ansi_code_markup.h"
+
+static std::string empty;
+
+static char light_prefix[] = "light-";
+
+template <typename K, typename V>
+static bool map_contains(std::unordered_map<K, V> &map, K key)
+{
+	return map.find(key) != map.end();
+}
+
+class ColorParser {
+public:
+	/*!
+	 * \brief Returns a pointer to a color ANSI code
+	 *
+	 * The returned string is owned by this object. It remains valid until
+	 * the next call to this function.
+	 *
+	 * \param color the color value
+	 * \param background whether to set the backround (true) or foreground
+	 *                   (false) color
+	 * \return const char*
+	 */
+	const char *get_ansi_code(std::string &color, bool background)
+	{
+		reset_str(ansi_code);
+		std::string c = color;
+		bool light = starts_with(light_prefix, color);
+		if (light) {
+			c = color.substr(sizeof light_prefix - 1);
+		}
+		if (!map_contains<std::string, int>(base_colors, c)) {
+			return nullptr;
+		}
+		// Background colors have codes that are +10
+		// the equivalent foreground color.
+		int ansi_num = base_colors.at(c) + (background ? 10 : 0);
+		safe_sprintf(ansi_code, "\033[%d%sm", ansi_num, (light ? "" : ";1"));
+		return ansi_code;
+	}
+
+private:
+	char ansi_code[10] = {0};
+	std::unordered_map<std::string, int> base_colors = {
+	        {"black", 30},  {"red", 31},   {"green", 32},
+	        {"yellow", 33}, {"blue", 34},  {"magenta", 35},
+	        {"cyan", 36},   {"white", 37}, {"default", 39},
+	};
+};
+
+class TagParser {
+public:
+	TagParser() : color() {}
+	/*!
+	 * \brief Returns a pointer to an ANSI code
+	 *
+	 * The returned string is owned by this object. It remains valid until
+	 * the next call to this function.
+	 *
+	 * \param tag tag name (eg: b, color)
+	 * \param close whether this is a closing tag
+	 * \param color_val the color value if a color tag
+	 * \return const char*
+	 */
+	const char *get_ansi_code(std::string &tag, bool close, std::string &color_val)
+	{
+		if (tag == "color" || tag == "bgcolor") {
+			// We don't support closing color tags
+			if (close) {
+				return nullptr;
+			}
+			return color.get_ansi_code(color_val, tag == "bgcolor");
+		}
+		reset_str(ansi_code);
+		if (!map_contains<std::string, int>(tags, tag)) {
+			return nullptr;
+		}
+		int ansi_num = tags.at(tag);
+		if (close) {
+			// "closing" tags have ascii codes +20
+			ansi_num += 20 + (tag == "b" ? 1 : 0); // [/b] is the
+			                                       // same as [/dim]
+		}
+		safe_sprintf(ansi_code, "\033[%dm", ansi_num);
+		return ansi_code;
+	}
+
+private:
+	ColorParser color;
+	char ansi_code[10] = {0};
+	std::unordered_map<std::string, int> tags = {
+	        {"reset", 0}, {"b", 1},       {"dim", 2},
+	        {"i", 3},     {"u", 4},       {"s", 9},
+	        {"blink", 5}, {"inverse", 7}, {"hidden", 8},
+	};
+};
+
+static TagParser tag_parser;
+
+static std::regex markup("\\["      // Opening bracket
+                         "[ \\t]*?" // Optional spacing after opening bracket
+                         "(\\/?)"   // Check for losing tag
+                         "("        // Start group of tags
+                         "((?:bg)?color)" // Select color or bgcolor. bg not
+                                          // captured in separate group
+                         "(?:[ \\t]*?=[ \\t]*?([a-z\\-]+))?" // Color value. '='
+                                                             // not captured in
+                                                             // separate group.
+                                                             // Spacing around
+                                                             // '=' is allowed
+                         "|i|b|u|s|blink|dim|hidden|inverse|reset" // All other
+                                                                   // tags to match
+                         ")"        // End group of tags
+                         "[ \\t]*?" // Optional spacing before closing bracket
+                         "\\]" // Closing bracket. Note: Clang and MSVC requires
+                               // this to be escaped
+                         ,
+                         std::regex::icase);
+
+std::string convert_ansi_markup(std::string &str)
+{
+	return convert_ansi_markup(str.c_str());
+}
+
+/*!
+ * \brief Convert ANSI markup tags in string to ANSI terminal codes
+ *
+ * Tags are in the form of [tagname]some text[/tagname]. Not all tags
+ * have closing counterparts, such as [reset], [color], and [bgcolor].
+ *
+ * Color tags take a required parameter in the form [color=value] or
+ * [bgcolor=value]. Tag matching is case insensitive, and spacing is
+ * allowed between '[', ']' and '='.
+ *
+ * If a tag cannot be parsed for any reason, the resulting string will
+ * contain the original unparsed tag.
+ *
+ * Existing ANSI terminal codes are preserved in the output string.
+ *
+ * \param str string containing ANSI markup tags
+ * \return std::string
+ */
+std::string convert_ansi_markup(const char *str)
+{
+	std::string result;
+	const char *begin = str;
+	const char *last_match = str;
+	std::cmatch m;
+	while (std::regex_search(begin, m, markup)) {
+		bool close = (m[1].matched && m[1].str() == "/") ? true : false;
+		std::string tag = m[3].matched ? m[3].str() : m[2].str();
+		std::string color = m[3].matched ? m[4].str() : "";
+		lowcase(tag);
+		lowcase(color);
+
+		// Copy test before current match to output string
+		result += m.prefix().str();
+		if (const char *r = tag_parser.get_ansi_code(tag, close, color)) {
+			result += r;
+		} else {
+			result += m[0].str();
+		}
+		// Continue the next iteration from the end of the current match
+		begin += m.position() + m.length();
+		last_match = m[0].second;
+	}
+	// Add the rest of the string after all matches have been found
+	result += last_match;
+	// And just in case our result is empty for some reason, set output
+	// string to input string
+	if (result.empty()) {
+		result = str;
+	}
+	return result;
+}

--- a/src/misc/ansi_code_markup.cpp
+++ b/src/misc/ansi_code_markup.cpp
@@ -25,10 +25,6 @@
 #include "support.h"
 #include "ansi_code_markup.h"
 
-static std::string empty;
-
-static char light_prefix[] = "light-";
-
 template <typename K, typename V>
 static bool map_contains(std::unordered_map<K, V> &map, K key)
 {
@@ -68,6 +64,7 @@ public:
 
 private:
 	char ansi_code[10] = {0};
+	char light_prefix[7] = "light-";
 	std::unordered_map<std::string, int> base_colors = {
 	        {"black", 30},  {"red", 31},   {"green", 32},
 	        {"yellow", 33}, {"blue", 34},  {"magenta", 35},

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -1,4 +1,5 @@
 libmisc_sources = [
+  'ansi_code_markup.cpp',
   'cross.cpp',
   'ethernet.cpp',
   'ethernet_slirp.cpp',

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -34,6 +34,7 @@
 #include "string_utils.h"
 #include "setup.h"
 #include "support.h"
+#include "ansi_code_markup.h"
 
 #if C_COREFOUNDATION
 #include <CoreFoundation/CoreFoundation.h>
@@ -64,7 +65,7 @@ void MSG_Add(const char *name, const char *msg)
 {
 	// Only add the message if it doesn't exist yet
 	if (messages.find(name) == messages.end()) {
-		messages[name] = msg;
+		messages[name] = convert_ansi_markup(msg);
 		messages_order.emplace_back(name);
 	}
 }
@@ -76,7 +77,7 @@ void MSG_Replace(const char *name, const char *msg)
 	if (it == messages.end())
 		MSG_Add(name, msg);
 	else // replace the prior message
-		it->second = msg;
+		it->second = convert_ansi_markup(msg);
 }
 
 static bool LoadMessageFile(const std_fs::path &filename)

--- a/tests/ansi_code_markup_tests.cpp
+++ b/tests/ansi_code_markup_tests.cpp
@@ -1,0 +1,247 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "ansi_code_markup.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+TEST(ConvertAnsiMarkup, ValidForegroundColorMiddle)
+{
+    const char str[] = "this [color=red]colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "this \033[31;1mcolour is red");
+}
+
+TEST(ConvertAnsiMarkup, ValidForegroundColorStart)
+{
+    const char str[] = "[color=red]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "\033[31;1mthis colour is red");
+}
+
+TEST(ConvertAnsiMarkup, InvalidForegroundColorEnd)
+{
+    const char str[] = "the color will be reset[/color]";
+    EXPECT_EQ(convert_ansi_markup(str), "the color will be reset[/color]");
+}
+
+TEST(ConvertAnsiMarkup, ValidForegroundLightBlue)
+{
+    const char str[] = "this [color=light-blue]colour is light blue";
+    EXPECT_EQ(convert_ansi_markup(str), "this \033[34mcolour is light blue");
+}
+
+TEST(ConvertAnsiMarkup, InvalidForegroundColor)
+{
+    const char str[] = "[color=invalid]this is an invalid foreground color";
+    EXPECT_EQ(convert_ansi_markup(str), "[color=invalid]this is an invalid foreground color");
+}
+
+TEST(ConvertAnsiMarkup, ValidBackgroundColorMiddle)
+{
+    const char str[] = "this [bgcolor=red]colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "this \033[41;1mcolour is red");
+}
+
+TEST(ConvertAnsiMarkup, ValidBackgroundColorStart)
+{
+    const char str[] = "[bgcolor=red]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "\033[41;1mthis colour is red");
+}
+
+TEST(ConvertAnsiMarkup, InvalidBackgroundColorEnd)
+{
+    const char str[] = "the color will be reset[/bgcolor]";
+    EXPECT_EQ(convert_ansi_markup(str), "the color will be reset[/bgcolor]");
+}
+
+TEST(ConvertAnsiMarkup, ValidBackgroundLightBlue)
+{
+    const char str[] = "this [bgcolor=light-blue]colour is light blue";
+    EXPECT_EQ(convert_ansi_markup(str), "this \033[44mcolour is light blue");
+}
+
+TEST(ConvertAnsiMarkup, InvalidBackgroundColor)
+{
+    const char str[] = "[bgcolor=invalid]this is an invalid foreground color";
+    EXPECT_EQ(convert_ansi_markup(str), "[bgcolor=invalid]this is an invalid foreground color");
+}
+
+TEST(ConvertAnsiMarkup, ValidForegroundColorMultiple)
+{
+    const char str[] = "this [color=red]colour is red. [color=blue]And this is blue.[reset]";
+    EXPECT_EQ(convert_ansi_markup(str), "this \033[31;1mcolour is red. \033[34;1mAnd this is blue.\033[0m");
+}
+
+TEST(ConvertAnsiMarkup, InvalidForegroundColorNoValue)
+{
+    const char str[] = "this [color]colour is red.";
+    EXPECT_EQ(convert_ansi_markup(str), "this [color]colour is red.");
+}
+
+TEST(ConvertAnsiMarkup, InvalidBackgroundColorNoValue)
+{
+    const char str[] = "this [bgcolor]colour is red.";
+    EXPECT_EQ(convert_ansi_markup(str), "this [bgcolor]colour is red.");
+}
+
+TEST(ConvertAnsiMarkup, InvalidTagName)
+{
+    const char str[] = "this [sometag] tag is invalid.";
+    EXPECT_EQ(convert_ansi_markup(str), "this [sometag] tag is invalid.");
+}
+
+TEST(ConvertAnsiMarkup, InvalidTagUnclosed)
+{
+    const char str[] = "this [color=red colour is red.";
+    EXPECT_EQ(convert_ansi_markup(str), "this [color=red colour is red.");
+}
+
+TEST(ConvertAnsiMarkup, InvalidTagUnopened)
+{
+    const char str[] = "this color=red] colour is red.";
+    EXPECT_EQ(convert_ansi_markup(str), "this color=red] colour is red.");
+}
+
+TEST(ConvertAnsiMarkup, Bold)
+{
+    const char str[] = "This is [b]bold[/b] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[1mbold\033[22m text.");
+}
+
+TEST(ConvertAnsiMarkup, Italic)
+{
+    const char str[] = "This is [i]italic[/i] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[3mitalic\033[23m text.");
+}
+
+TEST(ConvertAnsiMarkup, Underline)
+{
+    const char str[] = "This is [u]underline[/u] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[4munderline\033[24m text.");
+}
+
+TEST(ConvertAnsiMarkup, Strikethrough)
+{
+    const char str[] = "This is [s]strikethrough[/s] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[9mstrikethrough\033[29m text.");
+}
+
+TEST(ConvertAnsiMarkup, Dim)
+{
+    const char str[] = "This is [dim]dim[/dim] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[2mdim\033[22m text.");
+}
+
+TEST(ConvertAnsiMarkup, blink)
+{
+    const char str[] = "This is [blink]blink[/blink] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[5mblink\033[25m text.");
+}
+
+TEST(ConvertAnsiMarkup, Inverse)
+{
+    const char str[] = "This is [inverse]inverse[/inverse] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[7minverse\033[27m text.");
+}
+
+TEST(ConvertAnsiMarkup, Hidden)
+{
+    const char str[] = "This is [hidden]hidden[/hidden] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[8mhidden\033[28m text.");
+}
+
+TEST(ConvertAnsiMarkup, Uppercase)
+{
+    const char str[] = "This is [HIDDEN]hidden[/HIDDEN] text.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[8mhidden\033[28m text.");
+}
+
+TEST(ConvertAnsiMarkup, ColorUppercase)
+{
+    const char str[] = "[COLOR=RED]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "\033[31;1mthis colour is red");
+}
+
+TEST(ConvertAnsiMarkup, ColorUppercaseTag)
+{
+    const char str[] = "[COLOR=red]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "\033[31;1mthis colour is red");
+}
+
+TEST(ConvertAnsiMarkup, ColorUppercaseValue)
+{
+    const char str[] = "[color=RED]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "\033[31;1mthis colour is red");
+}
+
+TEST(ConvertAnsiMarkup, Witespace)
+{
+    const char str[] = "[  color = red  ]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "\033[31;1mthis colour is red");
+}
+
+TEST(ConvertAnsiMarkup, NoMarkupPlain)
+{
+    const char str[] = "This is plain text with no markup.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is plain text with no markup.");
+}
+
+TEST(ConvertAnsiMarkup, NoMarkupExistingANSI)
+{
+    const char str[] = "This is \033[31;1mred text with no markup.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[31;1mred text with no markup.");
+}
+
+TEST(ConvertAnsiMarkup, MixedMarkupExistingANSI)
+{
+    const char str[] = "This is \033[31;1mred text with no markup. [color=blue]And this blue text with markup.";
+    EXPECT_EQ(convert_ansi_markup(str), "This is \033[31;1mred text with no markup. \033[34;1mAnd this blue text with markup.");
+}
+
+TEST(ConvertAnsiMarkup, StartupMessage)
+{
+    const char new_msg[] = "[bgcolor=blue]\xC9\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\n"
+	        "\xBA [color=light-green]Welcome to DOSBox Staging %-40s[color=light-white] \xBA\n"
+	        "\xBA                                                                    \xBA\n"
+	        "\xBA For a short introduction for new users type: [color=light-yellow]INTRO[color=light-white]                 \xBA\n"
+	        "\xBA For supported shell commands type: [color=light-yellow]HELP[color=light-white]                            \xBA\n"
+	        "\xBA                                                                    \xBA\n"
+	        "\xBA To adjust the emulated CPU speed, use [color=light-red]%s+F11[color=light-white] and \033[31m%s+F12[color=light-white].%s%s       \xBA\n"
+	        "\xBA To activate the keymapper [color=light-red]%s+F1[color=light-white].%s                                 \xBA\n"
+	        "\xBA For more information read the [color=light-cyan]README[color=light-white] file in the DOSBox directory. \xBA\n"
+	        "\xBA                                                                    \xBA\n";
+
+    std::string orig_msg = "\033[44;1m\xC9\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\n"
+	        "\xBA \033[32mWelcome to DOSBox Staging %-40s\033[37m \xBA\n"
+	        "\xBA                                                                    \xBA\n"
+	        "\xBA For a short introduction for new users type: \033[33mINTRO\033[37m                 \xBA\n"
+	        "\xBA For supported shell commands type: \033[33mHELP\033[37m                            \xBA\n"
+	        "\xBA                                                                    \xBA\n"
+	        "\xBA To adjust the emulated CPU speed, use \033[31m%s+F11\033[37m and \033[31m%s+F12\033[37m.%s%s       \xBA\n"
+	        "\xBA To activate the keymapper \033[31m%s+F1\033[37m.%s                                 \xBA\n"
+	        "\xBA For more information read the \033[36mREADME\033[37m file in the DOSBox directory. \xBA\n"
+	        "\xBA                                                                    \xBA\n";
+    EXPECT_EQ(convert_ansi_markup(new_msg), orig_msg);
+}
+}

--- a/tests/ansi_code_markup_tests.cpp
+++ b/tests/ansi_code_markup_tests.cpp
@@ -203,6 +203,30 @@ TEST(ConvertAnsiMarkup, EscapeTag)
     EXPECT_EQ(convert_ansi_markup(str), "[color=red]this colour is red");
 }
 
+TEST(ConvertAnsiMarkup, InvalidNesting)
+{
+    const char str[] = "This will be[bgcolor=light-blue [bgcolor=light-blue] ] light blue.";
+    EXPECT_EQ(convert_ansi_markup(str), "This will be[bgcolor=light-blue \033[44m ] light blue.");
+}
+
+TEST(ConvertAnsiMarkup, EscapedBothBrackets)
+{
+    const char str[] = "This will be \\[bgcolor=light-blue\\] light blue.";
+    EXPECT_EQ(convert_ansi_markup(str), "This will be \\[bgcolor=light-blue\\] light blue.");
+}
+
+TEST(ConvertAnsiMarkup, EscapedDoubleQuotes)
+{
+    const char str[] = "This will be [bgcolor=\"light-blue] light blue.";
+    EXPECT_EQ(convert_ansi_markup(str), "This will be [bgcolor=\"light-blue] light blue.");
+}
+
+TEST(ConvertAnsiMarkup, EscapedMixedQuotes)
+{
+    const char str[] = "This will be [\"bgcolor=\'light-blue] light blue.";
+    EXPECT_EQ(convert_ansi_markup(str), "This will be [\"bgcolor=\'light-blue] light blue.");
+}
+
 TEST(ConvertAnsiMarkup, NoMarkupPlain)
 {
     const char str[] = "This is plain text with no markup.";

--- a/tests/ansi_code_markup_tests.cpp
+++ b/tests/ansi_code_markup_tests.cpp
@@ -197,6 +197,12 @@ TEST(ConvertAnsiMarkup, Witespace)
     EXPECT_EQ(convert_ansi_markup(str), "\033[31;1mthis colour is red");
 }
 
+TEST(ConvertAnsiMarkup, EscapeTag)
+{
+    const char str[] = "\\[color=red]this colour is red";
+    EXPECT_EQ(convert_ansi_markup(str), "[color=red]this colour is red");
+}
+
 TEST(ConvertAnsiMarkup, NoMarkupPlain)
 {
     const char str[] = "This is plain text with no markup.";

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -68,6 +68,7 @@ unit_tests = [
   {'name' : 'drives',               'deps' : [dosbox_dep], 'extra_cpp': []},
   {'name' : 'dos_files',            'deps' : [dosbox_dep], 'extra_cpp': []},
   {'name' : 'shell_cmds',           'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'ansi_code_markup',     'deps' : [libmisc_dep]},
 ]
 
 foreach ut : unit_tests

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -221,6 +221,7 @@ $(TargetPath)
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\misc\ansi_code_markup.cpp" />
     <ClCompile Include="..\..\src\misc\cross.cpp" />
     <ClCompile Include="..\..\src\misc\fs_utils_win32.cpp" />
     <ClCompile Include="..\..\src\misc\rwqueue.cpp" />
@@ -230,6 +231,7 @@ $(TargetPath)
     <ClCompile Include="..\..\src\libs\ghc\fs_std_impl.cpp" />
     <ClCompile Include="..\..\src\libs\loguru\loguru.cpp" />
     <ClCompile Include="..\..\src\libs\whereami\whereami.c" />
+    <ClCompile Include="..\ansi_code_markup_tests.cpp" />
     <ClCompile Include="..\fs_utils_tests.cpp" />
     <ClCompile Include="..\iohandler_containers_tests.cpp" />
     <ClCompile Include="..\rwqueue_tests.cpp" />

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -72,6 +72,12 @@
     <ClCompile Include="..\support_tests.cpp">
       <Filter>tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\ansi_code_markup_tests.cpp">
+      <Filter>tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\misc\ansi_code_markup.cpp">
+      <Filter>dosbox_sources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\meson.build" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -432,6 +432,7 @@
     <ClCompile Include="..\src\midi\midi_fluidsynth.cpp" />
     <ClCompile Include="..\src\midi\midi_lasynth_model.cpp" />
     <ClCompile Include="..\src\midi\midi_mt32.cpp" />
+    <ClCompile Include="..\src\misc\ansi_code_markup.cpp" />
     <ClCompile Include="..\src\misc\cross.cpp" />
     <ClCompile Include="..\src\misc\ethernet.cpp" />
     <ClCompile Include="..\src\misc\ethernet_slirp.cpp" />
@@ -456,6 +457,7 @@
     <ResourceCompile Include="..\src\winres.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\include\ansi_code_markup.h" />
     <ClInclude Include="..\include\bios.h" />
     <ClInclude Include="..\include\bios_disk.h" />
     <ClInclude Include="..\include\byteorder.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -538,8 +538,10 @@
     <ClCompile Include="..\src\libs\whereami\whereami.c">
       <Filter>src\libs\whereami</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp">
+    <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp" />
       <Filter>src\libs\ghc</Filter>
+    <ClCompile Include="..\src\misc\ansi_code_markup.cpp">
+      <Filter>src\misc</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -983,6 +985,9 @@
     </ClInclude>
     <ClInclude Include="..\src\libs\whereami\whereami.h">
       <Filter>src\libs\whereami</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\ansi_code_markup.h">
+      <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Messages (especially help) in dosbox-staging often have embedded ANSI escape codes to control text colour etc. These codes are not at all human readable (how is anyone supposed to figure out what `\033[31m` means?), and cause issues for translation.

This PR creates a simple bbcode-like tag syntax for including in messages, and a lexer to replace these tokens with appropriate ANSI escape sequences.

A brief example:

Before
```
\033[44;1mThis is a brief example \033[31;1mwith red text\033[37;1m and blue background\033[0m
```
After
```
[bgcolor=blue]This is a brief example [color=red]with red text[color=white] and blue background[reset]
```
As well as colour support, there's also support for bold, dim, underline, strikethrough, italic, hidden, blinking styles (although I don't know how much the shell actually supports...).

I'm opening this as a draft PR for now, until final feature support is decided. For example, different tag delimiters could be used instead of `[` and `]`. Also, there was discussion of some sort of "dosbox theme" support that we need to decide whether to include, and if so, how.

This PR DOES NOT change any messages. That would come with subsequent PR's. This one just gets the support in place.

I welcome any and all suggestions opinions @kcgen  @Wengier @Burrito78 