### PR TITLE
Support for piping from the command-line

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -83,7 +83,7 @@ public:
 	void RunInternal(); // for command /C
 	/* A load of subfunctions */
 	void ParseLine(char * line);
-	void GetRedirection(char *s, char **ifn, char **ofn, char **pipe, bool * append);
+	void GetRedirection(char *s, std::string &ifn, std::string &ofn, std::string &pipe, bool * append);
 	void InputCommand(char * line);
 	void ProcessCmdLineEnvVarStitution(char *line);
 	void ShowPrompt();

--- a/include/shell.h
+++ b/include/shell.h
@@ -83,7 +83,7 @@ public:
 	void RunInternal(); // for command /C
 	/* A load of subfunctions */
 	void ParseLine(char * line);
-	Bitu GetRedirection(char *s, char **ifn, char **ofn,bool * append);
+	Bitu GetRedirection(char *s, char **ifn, char **ofn, char **pipe, bool * append);
 	void InputCommand(char * line);
 	void ProcessCmdLineEnvVarStitution(char *line);
 	void ShowPrompt();

--- a/include/shell.h
+++ b/include/shell.h
@@ -83,7 +83,7 @@ public:
 	void RunInternal(); // for command /C
 	/* A load of subfunctions */
 	void ParseLine(char * line);
-	Bitu GetRedirection(char *s, char **ifn, char **ofn, char **pipe, bool * append);
+	void GetRedirection(char *s, char **ifn, char **ofn, char **pipe, bool * append);
 	void InputCommand(char * line);
 	void ProcessCmdLineEnvVarStitution(char *line);
 	void ShowPrompt();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -188,6 +188,8 @@ void DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn, char **pipe, boo
 	char **redir = nullptr;
 	size_t found, temp_len;
 	std::string str, chrs;
+	*ifn = *ofn = *pipe = 0;
+	*append = false;
 
 	while ((ch = *lr++)) {
 		if (quote && ch != '"') { /* don't parse redirection within

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -339,7 +339,6 @@ void DOS_Shell::ParseLine(char *line)
 	line = trim(line);
 
 	/* Do redirection and pipe checks */
-
 	char *in = nullptr;
 	char *out = nullptr;
 	char *pipe = nullptr;
@@ -401,11 +400,10 @@ void DOS_Shell::ParseLine(char *line)
 			// Read only file, open con again
 			open_console_device();
 			if (!pipe) {
-				if (*out)
-					WriteOut(MSG_Get(dos.errorcode == DOSERR_ACCESS_DENIED
-					                         ? "SHELL_CMD_FILE_ACCESS_DENIED"
-					                         : "SHELL_CMD_FILE_CREATE_ERROR"),
-					         out);
+				WriteOut(MSG_Get(dos.errorcode == DOSERR_ACCESS_DENIED
+				                         ? "SHELL_CMD_FILE_ACCESS_DENIED"
+				                         : "SHELL_CMD_FILE_CREATE_ERROR"),
+				         *out ? out : "(unnamed)");
 				close_stdout();
 				open_stdout_as("nul");
 			}
@@ -438,7 +436,7 @@ void DOS_Shell::ParseLine(char *line)
 			close_stdin();
 			open_console_device(normalstdin);
 		} else {
-			WriteOut("\nFailed to create/open a temporary file for piping. Check the %%TEMP%% variable.\n");
+			WriteOut(MSG_Get("SHELL_CMD_FAILED_PIPE"));
 		}
 		delete[] pipe;
 		if (DOS_FindFirst(pipetmp, ~DOS_ATTR_VOLUME))
@@ -904,6 +902,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_GOTO_LABEL_NOT_FOUND","GOTO: Label %s not found.\n");
 	MSG_Add("SHELL_CMD_FILE_ACCESS_DENIED", "Access denied - %s\n");
 	MSG_Add("SHELL_CMD_DUPLICATE_REDIRECTION", "Duplicate redirection - %s\n");
+	MSG_Add("SHELL_CMD_FAILED_PIPE", "\nFailed to create/open a temporary file for piping. Check the %%TEMP%% variable.\n");
 	MSG_Add("SHELL_CMD_FILE_CREATE_ERROR", "File creation error - %s\n");
 	MSG_Add("SHELL_CMD_FILE_OPEN_ERROR", "File open error - %s\n");
 	MSG_Add("SHELL_CMD_FILE_NOT_FOUND", "File not found: %s\n");

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -68,6 +68,7 @@ unit_tests = [
   {'name' : 'drives',               'deps' : [dosbox_dep], 'extra_cpp': []},
   {'name' : 'dos_files',            'deps' : [dosbox_dep], 'extra_cpp': []},
   {'name' : 'shell_cmds',           'deps' : [dosbox_dep], 'extra_cpp': []},
+  {'name' : 'shell_redirection',    'deps' : [dosbox_dep], 'extra_cpp': []},
   {'name' : 'ansi_code_markup',     'deps' : [libmisc_dep]},
 ]
 

--- a/tests/shell_redirection_tests.cpp
+++ b/tests/shell_redirection_tests.cpp
@@ -43,7 +43,6 @@
 #include <gtest/gtest.h>
 
 #include "dosbox_test_fixture.h"
-#include "../src/shell/shell.cpp"
 
 namespace {
 
@@ -68,42 +67,106 @@ TEST_F(DOS_Shell_REDIRTest, CMD_Redirection)
 {
 	MockDOS_Shell shell;
 	bool append;
-	char *in = 0, *out = 0, *pipe = 0, *line = 0;
+	char line[CROSS_LEN];
+	std::string in = "", out = "", pipe = "";
 
-	line = "echo hello!";
-	shell.GetRedirection(line, &in, &out, &pipe, &append);
-	EXPECT_EQ(line, "echo hello!");
-	EXPECT_EQ(in, "");
-	EXPECT_EQ(out, "");
-	EXPECT_EQ(pipe, "");
+	strcpy(line, "echo hello!");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "echo hello!");
+	EXPECT_TRUE(in == "");
+	EXPECT_TRUE(out == "");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
 
-	line = "echo test>test.txt";
-	shell.GetRedirection(line, &in, &out, &pipe, &append);
-	EXPECT_EQ(line, "echo test");
-	EXPECT_EQ(in, "");
-	EXPECT_EQ(out, "test.txt");
-	EXPECT_EQ(pipe, "");
+	in = out = pipe = "";
+	strcpy(line, "echo test>test.txt");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "echo test");
+	EXPECT_TRUE(in == "");
+	EXPECT_TRUE(out == "test.txt");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
 
-	line = "sort<test.txt";
-	shell.GetRedirection(line, &in, &out, &pipe, &append);
-	EXPECT_EQ(line, "sort");
-	EXPECT_EQ(in, "test.txt");
-	EXPECT_EQ(out, "");
-	EXPECT_EQ(pipe, "");
+	in = out = pipe = "";
+	strcpy(line, "sort<test.txt");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "sort");
+	EXPECT_TRUE(in == "test.txt");
+	EXPECT_TRUE(out == "");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
 
-	line = "less<in.txt>out.txt";
-	shell.GetRedirection(line, &in, &out, &pipe, &append);
-	EXPECT_EQ(line, "less");
-	EXPECT_EQ(in, "in.txt");
-	EXPECT_EQ(out, "out.txt");
-	EXPECT_EQ(pipe, "");
+	in = out = pipe = "";
+	strcpy(line, "less<in.txt>out.txt");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "less");
+	EXPECT_TRUE(in == "in.txt");
+	EXPECT_TRUE(out == "out.txt");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
 
-	line = "more<file.txt|sort";
-	shell.GetRedirection(line, &in, &out, &pipe, &append);
-	EXPECT_EQ(line, "more");
-	EXPECT_EQ(in, "file.txt");
-	EXPECT_EQ(out, "");
-	EXPECT_EQ(pipe, "sort");
+	in = out = pipe = "";
+	strcpy(line, "more<file.txt|sort");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "more");
+	EXPECT_TRUE(in == "file.txt");
+	EXPECT_TRUE(out == "");
+	EXPECT_TRUE(pipe == "sort");
+	EXPECT_EQ(append, false);
+
+	in = out = pipe = "";
+	strcpy(line, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<in.txt>>out.txt");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+	EXPECT_TRUE(in == "in.txt");
+	EXPECT_TRUE(out == "out.txt");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, true);
+
+	in = out = pipe = "";
+	strcpy(line, "");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "");
+	EXPECT_TRUE(in == "");
+	EXPECT_TRUE(out == "");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
+
+	in = out = pipe = "";
+	strcpy(line, " echo  test < in.txt > out.txt ");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, " echo  test   ");
+	EXPECT_TRUE(in == "in.txt");
+	EXPECT_TRUE(out == "out.txt");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
+
+	in = out = pipe = "";
+	strcpy(line, "dir || more");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "dir ");
+	EXPECT_TRUE(in == "");
+	EXPECT_TRUE(out == "");
+	EXPECT_TRUE(pipe == "| more");
+	EXPECT_EQ(append, false);
+
+	in = out = pipe = "";
+	strcpy(line, "dir *.bat << in.txt >> out.txt");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "dir *.bat  in.txt ");
+	EXPECT_TRUE(in == "<");
+	EXPECT_TRUE(out == "out.txt");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, true);
+
+	in = out = pipe = "";
+	strcpy(line, "echo test>out1.txt>>out2.txt");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "echo test");
+	EXPECT_TRUE(in == "");
+	EXPECT_TRUE(out == "out1.txt>>out2.txt");
+	EXPECT_TRUE(pipe == "");
+	EXPECT_EQ(append, false);
 }
 
 } // namespace

--- a/tests/shell_redirection_tests.cpp
+++ b/tests/shell_redirection_tests.cpp
@@ -1,0 +1,109 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* This sample shows how to write a simple unit test for dosbox-staging using
+ * Google C++ testing framework.
+ *
+ * Read Google Test Primer for reference of most available features, macros,
+ * and guidance about writing unit tests:
+ *
+ * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
+ */
+
+/* Include necessary header files; order of headers should be as follows:
+ *
+ * 1. Header declaring functions/classes being tested
+ * 2. <gtest/gtest.h>, which declares the testing framework
+ * 3. Additional system headers (if needed)
+ * 4. Additional dosbox-staging headers (if needed)
+ */
+
+#include "shell.h"
+
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "dosbox_test_fixture.h"
+#include "../src/shell/shell.cpp"
+
+namespace {
+
+using namespace testing;
+
+class DOS_Shell_REDIRTest : public DOSBoxTestFixture {};
+
+class MockDOS_Shell : public DOS_Shell {
+public:
+	/**
+	 * NOTE: If we need to call the actual object, we use this. By
+	 * default, the mocked functions return whatever we tell it to
+	 * (if given a .WillOnce(Return(...)), or a default value
+	 * (false).
+	 */
+
+private:
+	DOS_Shell real_; // Keeps an instance of the real in the mock.
+};
+
+TEST_F(DOS_Shell_REDIRTest, CMD_Redirection)
+{
+	MockDOS_Shell shell;
+	bool append;
+	char *in = 0, *out = 0, *pipe = 0, *line = 0;
+
+	line = "echo hello!";
+	shell.GetRedirection(line, &in, &out, &pipe, &append);
+	EXPECT_EQ(line, "echo hello!");
+	EXPECT_EQ(in, "");
+	EXPECT_EQ(out, "");
+	EXPECT_EQ(pipe, "");
+
+	line = "echo test>test.txt";
+	shell.GetRedirection(line, &in, &out, &pipe, &append);
+	EXPECT_EQ(line, "echo test");
+	EXPECT_EQ(in, "");
+	EXPECT_EQ(out, "test.txt");
+	EXPECT_EQ(pipe, "");
+
+	line = "sort<test.txt";
+	shell.GetRedirection(line, &in, &out, &pipe, &append);
+	EXPECT_EQ(line, "sort");
+	EXPECT_EQ(in, "test.txt");
+	EXPECT_EQ(out, "");
+	EXPECT_EQ(pipe, "");
+
+	line = "less<in.txt>out.txt";
+	shell.GetRedirection(line, &in, &out, &pipe, &append);
+	EXPECT_EQ(line, "less");
+	EXPECT_EQ(in, "in.txt");
+	EXPECT_EQ(out, "out.txt");
+	EXPECT_EQ(pipe, "");
+
+	line = "more<file.txt|sort";
+	shell.GetRedirection(line, &in, &out, &pipe, &append);
+	EXPECT_EQ(line, "more");
+	EXPECT_EQ(in, "file.txt");
+	EXPECT_EQ(out, "");
+	EXPECT_EQ(pipe, "sort");
+}
+
+} // namespace


### PR DESCRIPTION
This adds support for piping (|), so that commands like ``DIR | MORE`` will work. Multiple piping is supported, e.g. ``DIR | SORT | MORE``. If the current directory and C:\ are both read-only, the environment variable %TEMP% (or %TMP%) need to be set within DOS so that piping will work properly (e.g. ``SET TEMP=C:\TEMP``).