### PR TITLE
Add enum_val to support.h

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -319,4 +319,12 @@ bool contains(const container_t &container, const typename container_t::key_type
 	return container.find(key) != container.end();
 }
 
+// Convenience function to cast to the underlying type of an enum class
+template <typename enum_t>
+constexpr auto enum_val(enum_t e)
+{
+	static_assert(std::is_enum_v<enum_t>);
+	return static_cast<std::underlying_type_t<enum_t>>(e);
+}
+
 #endif

--- a/src/misc/ansi_code_markup.cpp
+++ b/src/misc/ansi_code_markup.cpp
@@ -101,13 +101,7 @@ public:
 	bool color_is_light() const { return c_detail.is_light; }
 	int ansi_num() const;
 
-private:
-	template <typename E>
-	constexpr auto enum_val(E e) const
-	{
-		return static_cast<std::underlying_type_t<E>>(e);
-	}
-	
+private:	
 	bool parse_color_val(const std::string &val);
 	bool parse_erase_val(const std::string &val);
 


### PR DESCRIPTION
Moved from the ANSI markup code in my previous PR, this is a convenience function to cast an enum class to its underlying type.

Name can be changed if desired.