### PR TITLE
Catch two overruns in the code-page handler flagged by Coverity

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -781,8 +781,9 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
 	}
 
 	static Bit8u cpi_buf[65536];
-	Bit32u cpi_buf_size=0,size_of_cpxdata=0;;
-	bool upxfound=false;
+	size_t cpi_buf_size = 0;
+	size_t size_of_cpxdata = 0;
+	bool upxfound = false;
 	size_t found_at_pos = 5;
 	if (tempfile==NULL) {
 		// check if build-in codepage is available


### PR DESCRIPTION
The primary change in this PR replaces the code-page's 64 KiB C-array with a std::array with `at()` access calls to catch out-of-bounds events (in the very rare event a user reports issues with a code-page file). 

Tested with several compressed and uncompressed codepages. 

Suggest reviewing commit-by-commit.

The Coverity warning was as follows, which the PR should address (we won't know until we push to main and a scan gets underway). 

``` text
** CID 345200:    (OVERRUN)
________________________________________________________________________________________________________
*** CID 345200:    (OVERRUN)
/src/dos/dos_keyboard_layout.cpp: 928 in keyboard_layout::read_codepage_file(const char *, int)()
922             // search if codepage is provided by file
923             for (Bit16u test_codepage=0; test_codepage<number_of_codepages; test_codepage++) {
924                     Bit16u device_type, font_codepage, font_type;
925     
926                     // device type can be display/printer (only the first is supported)
927                     device_type=host_readw(&cpi_buf[start_pos+0x04]);
>>>     CID 345200:    (OVERRUN)
>>>     Overrunning array of 65536 bytes at byte offset 65553 by dereferencing pointer "&cpi_buf[start_pos + 14U]".
928                     font_codepage=host_readw(&cpi_buf[start_pos+0x0e]);
929     
930                     Bit32u font_data_header_pt;
931                     font_data_header_pt=host_readd(&cpi_buf[start_pos+0x16]);
932     
933                     font_type=host_readw(&cpi_buf[font_data_header_pt]);
/src/dos/dos_keyboard_layout.cpp: 931 in keyboard_layout::read_codepage_file(const char *, int)()
925     
926                     // device type can be display/printer (only the first is supported)
927                     device_type=host_readw(&cpi_buf[start_pos+0x04]);
928                     font_codepage=host_readw(&cpi_buf[start_pos+0x0e]);
929     
930                     Bit32u font_data_header_pt;
>>>     CID 345200:    (OVERRUN)
>>>     Overrunning array of 65536 bytes at byte offset 65561 by dereferencing pointer "&cpi_buf[start_pos + 22U]".
931                     font_data_header_pt=host_readd(&cpi_buf[start_pos+0x16]);
932     
933                     font_type=host_readw(&cpi_buf[font_data_header_pt]);
934     
935                     if ((device_type==0x0001) && (font_type==0x0001) && (font_codepage==codepage_id)) {
936                             // valid/matching codepage found
/src/dos/dos_keyboard_layout.cpp: 995 in keyboard_layout::read_codepage_file(const char *, int)()
989                             }
990                             INT10_SetupRomMemoryChecksum();
991     
992                             return KEYB_NOERROR;
993                     }
994     
>>>     CID 345200:    (OVERRUN)
>>>     Overrunning array of 65536 bytes at byte offset 65539 by dereferencing pointer "&cpi_buf[start_pos]".
995                     start_pos=host_readd(&cpi_buf[start_pos]);
996                     start_pos+=2;
997             }
998     
999             LOG(LOG_BIOS,LOG_ERROR)("Codepage %i not found",codepage_id);
1000     
/src/dos/dos_keyboard_layout.cpp: 927 in keyboard_layout::read_codepage_file(const char *, int)()
921     
922             // search if codepage is provided by file
923             for (Bit16u test_codepage=0; test_codepage<number_of_codepages; test_codepage++) {
924                     Bit16u device_type, font_codepage, font_type;
925     
926                     // device type can be display/printer (only the first is supported)
>>>     CID 345200:    (OVERRUN)
>>>     Overrunning array of 65536 bytes at byte offset 65543 by dereferencing pointer "&cpi_buf[start_pos + 4U]".
927                     device_type=host_readw(&cpi_buf[start_pos+0x04]);
928                     font_codepage=host_readw(&cpi_buf[start_pos+0x0e]);
929     
930                     Bit32u font_data_header_pt;
931                     font_data_header_pt=host_readd(&cpi_buf[start_pos+0x16]);
932     
```