### PR TITLE
Fix regression when pixel-perfect scaling low-res VGA modes (#1526)

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -271,6 +271,8 @@ struct SDL_Block {
 		uint16_t previous_mode = 0;
 		bool has_changed = false;
 		GFX_CallBack_t callback = nullptr;
+		bool width_was_doubled = false;
+		bool height_was_doubled = false;
 	} draw = {};
 	struct {
 		struct {
@@ -1162,7 +1164,7 @@ static SDL_Point calc_pp_scale(int avw, int avh)
 
 Bitu GFX_SetSize(int width,
                  int height,
-                 [[maybe_unused]] Bitu flags,
+                 const Bitu flags,
                  double scalex,
                  double scaley,
                  GFX_CallBack_t callback,
@@ -1172,7 +1174,12 @@ Bitu GFX_SetSize(int width,
 	if (sdl.updating)
 		GFX_EndUpdate( 0 );
 
+	const bool double_width = flags & GFX_DBL_W;
+	const bool double_height = flags & GFX_DBL_H;
+
 	sdl.draw.has_changed = (sdl.draw.width != width || sdl.draw.height != height ||
+	                        sdl.draw.width_was_doubled != double_width ||
+	                        sdl.draw.height_was_doubled != double_height ||
 	                        sdl.draw.scalex != scalex ||
 	                        sdl.draw.scaley != scaley ||
 	                        sdl.draw.pixel_aspect != pixel_aspect ||
@@ -1180,6 +1187,8 @@ Bitu GFX_SetSize(int width,
 
 	sdl.draw.width = width;
 	sdl.draw.height = height;
+	sdl.draw.width_was_doubled = double_width;
+	sdl.draw.height_was_doubled = double_height;
 	sdl.draw.scalex = scalex;
 	sdl.draw.scaley = scaley;
 	sdl.draw.pixel_aspect = pixel_aspect;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1144,6 +1144,24 @@ static void check_kmsdrm_setting()
 	exit(1);
 }
 
+// Some video modes are effectively doubled in resolution but only have half the
+// unique pixel resolution.
+static bool is_draw_size_doubled()
+{
+	// Has either dimension been doubled?
+	const bool is_doubled = (sdl.draw.width_was_doubled ||
+	                         sdl.draw.height_was_doubled);
+
+	// Are the dimensions divisible by 2?
+	const bool is_divisible = (sdl.draw.width % 2 == 0 &&
+	                           sdl.draw.height % 2 == 0);
+
+	// Are the dimensions beyond low-res?
+	const bool is_large = (sdl.draw.width > 500 && sdl.draw.height > 350);
+
+	return is_doubled && is_divisible && is_large;
+}
+
 static SDL_Point calc_pp_scale(int avw, int avh)
 {
 	assert(sdl.draw.width > 0);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -251,6 +251,55 @@ enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_HIGHEST
 };
 
+class PPScale {
+public:
+	PPScale(const int source_w,
+	        const int source_h,
+	        const double aspect_ratio,
+	        const bool source_is_doubled,
+	        const int canvas_w,
+	        const int canvas_h)
+
+	{
+		assert(source_w > 0);
+		assert(source_h > 0);
+		assert(canvas_w > 0);
+		assert(canvas_h > 0);
+		assert(aspect_ratio > 0.1);
+
+		// divide the source if it's been doubled
+		effective_source_w = source_w / (source_is_doubled ? 2 : 1);
+		effective_source_h = source_h / (source_is_doubled ? 2 : 1);
+
+		// call the pixel-perfect library to get the scale factors
+		constexpr double aspect_weight = 1.14; // pixel-perfect constant
+		const int err = pp_getscale(effective_source_w, effective_source_h,
+		                            aspect_ratio, canvas_w, canvas_h,
+		                            aspect_weight, &scale_x, &scale_y);
+
+		// if the scaling failed, ensure the the multipliers are valid
+		if (err) {
+			scale_x = 1;
+			scale_y = 1;
+		}
+		// calculate the output dimensions
+		output_w = effective_source_w * scale_x;
+		output_h = effective_source_h * scale_y;
+		assert(output_w > 0);
+		assert(output_h > 0);
+	}
+	// default constructor
+	PPScale() {}
+
+	int effective_source_w = 0;
+	int effective_source_h = 0;
+	int output_w = 0;
+	int output_h = 0;
+private:
+	int scale_x = 0;
+	int scale_y = 0;
+};
+
 /* Alias for indicating, that new window should not be user-resizable: */
 constexpr bool FIXED_SIZE = false;
 


### PR DESCRIPTION
Pixel-perfect scaling could require a larger canvas size than necessary to integer-scale low-resolution VGA modes, such as mode 13h 320x200. Thanks to @diduz for reporting this.

![2022-01-15_08-05](https://user-images.githubusercontent.com/1557255/149628842-31e77890-dac5-4403-8b1c-400c2a20caa7.png)

![2022-01-15_07-54](https://user-images.githubusercontent.com/1557255/149628843-23dcaf01-639d-4fb0-94da-b0c5bbae19aa.png)

Fixes #1526.