### PR TITLE
Implement file attribute support and ATTRIB command

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -288,8 +288,8 @@ public:
 	virtual bool TestDir(char * _dir)=0;
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false)=0;
 	virtual bool FindNext(DOS_DTA & dta)=0;
-	virtual bool GetFileAttr(char * name, uint16_t * attr)=0;
-	virtual bool SetFileAttr(const char * name, uint16_t attr)=0;
+	virtual bool GetFileAttr(char * name, uint16_t * attr) = 0;
+	virtual bool SetFileAttr(const char * name, const uint16_t attr) = 0;
 	virtual bool Rename(char * oldname,char * newname)=0;
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters)=0;
 	virtual bool FileExists(const char* name)=0;

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -288,7 +288,8 @@ public:
 	virtual bool TestDir(char * _dir)=0;
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false)=0;
 	virtual bool FindNext(DOS_DTA & dta)=0;
-	virtual bool GetFileAttr(char * name,Bit16u * attr)=0;
+	virtual bool GetFileAttr(char * name, uint16_t * attr)=0;
+	virtual bool SetFileAttr(const char * name, uint16_t attr)=0;
 	virtual bool Rename(char * oldname,char * newname)=0;
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters)=0;
 	virtual bool FileExists(const char* name)=0;

--- a/include/drives.h
+++ b/include/drives.h
@@ -66,7 +66,8 @@ public:
 	virtual bool TestDir(char * dir);
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual bool FindNext(DOS_DTA & dta);
-	virtual bool GetFileAttr(char * name,Bit16u * attr);
+	virtual bool GetFileAttr(char * name, uint16_t * attr);
+	virtual bool SetFileAttr(const char * name, uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	virtual bool FileExists(const char* name);
@@ -166,7 +167,8 @@ public:
 	virtual bool TestDir(char * dir);
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual bool FindNext(DOS_DTA & dta);
-	virtual bool GetFileAttr(char * name,Bit16u * attr);
+	virtual bool GetFileAttr(char * name, uint16_t * attr);
+	virtual bool SetFileAttr(const char * name, uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	virtual bool FileExists(const char* name);
@@ -197,7 +199,7 @@ private:
 	Bit32u getClustFirstSect(Bit32u clustNum);
 	bool FindNextInternal(Bit32u dirClustNumber, DOS_DTA & dta, direntry *foundEntry);
 	bool getDirClustNum(char * dir, Bit32u * clustNum, bool parDir);
-	bool getFileDirEntry(char const * const filename, direntry * useEntry, Bit32u * dirClust, Bit32u * subEntry);
+	bool getFileDirEntry(char const * const filename, direntry * useEntry, Bit32u * dirClust, Bit32u * subEntry, bool dirOk=false);
 	bool addDirectoryEntry(Bit32u dirClustNumber, direntry useEntry);
 	void zeroOutCluster(Bit32u clustNumber);
 	bool getEntryName(char *fullname, char *entname);
@@ -227,7 +229,7 @@ public:
 	virtual bool RemoveDir(char * dir);
 	virtual bool MakeDir(char * dir);
 	virtual bool Rename(char * oldname,char * newname);
-	virtual bool GetFileAttr(char * name,Bit16u * attr);
+	virtual bool GetFileAttr(char * name, uint16_t * attr);
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual void SetDir(const char* path);
 	virtual bool isRemote(void);
@@ -327,7 +329,8 @@ public:
 	virtual bool TestDir(char *dir);
 	virtual bool FindFirst(char *_dir, DOS_DTA &dta, bool fcb_findfirst);
 	virtual bool FindNext(DOS_DTA &dta);
-	virtual bool GetFileAttr(char *name, Bit16u *attr);
+	virtual bool GetFileAttr(char *name, uint16_t *attr);
+	virtual bool SetFileAttr(const char * name, uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool AllocationInfo(Bit16u *bytes_sector, Bit8u *sectors_cluster, Bit16u *total_clusters, Bit16u *free_clusters);
 	virtual bool FileExists(const char *name);
@@ -390,7 +393,8 @@ public:
 	bool TestDir(char * dir);
 	bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst);
 	bool FindNext(DOS_DTA & dta);
-	bool GetFileAttr(char * name,Bit16u * attr);
+	bool GetFileAttr(char * name, uint16_t * attr);
+	bool SetFileAttr(const char * name, uint16_t attr);
 	bool Rename(char * oldname,char * newname);
 	bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	bool FileExists(const char* name);
@@ -423,7 +427,8 @@ public:
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst);
 	virtual bool FindNext(DOS_DTA & dta);
 	virtual bool FileUnlink(char * name);
-	virtual bool GetFileAttr(char * name,Bit16u * attr);
+	virtual bool GetFileAttr(char * name, uint16_t * attr);
+	virtual bool SetFileAttr(const char * name, uint16_t attr);
 	virtual bool FileExists(const char* name);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block);

--- a/include/drives.h
+++ b/include/drives.h
@@ -67,7 +67,7 @@ public:
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual bool FindNext(DOS_DTA & dta);
 	virtual bool GetFileAttr(char * name, uint16_t * attr);
-	virtual bool SetFileAttr(const char * name, uint16_t attr);
+	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	virtual bool FileExists(const char* name);
@@ -168,7 +168,7 @@ public:
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual bool FindNext(DOS_DTA & dta);
 	virtual bool GetFileAttr(char * name, uint16_t * attr);
-	virtual bool SetFileAttr(const char * name, uint16_t attr);
+	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	virtual bool FileExists(const char* name);
@@ -330,7 +330,7 @@ public:
 	virtual bool FindFirst(char *_dir, DOS_DTA &dta, bool fcb_findfirst);
 	virtual bool FindNext(DOS_DTA &dta);
 	virtual bool GetFileAttr(char *name, uint16_t *attr);
-	virtual bool SetFileAttr(const char * name, uint16_t attr);
+	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool AllocationInfo(Bit16u *bytes_sector, Bit8u *sectors_cluster, Bit16u *total_clusters, Bit16u *free_clusters);
 	virtual bool FileExists(const char *name);
@@ -394,7 +394,7 @@ public:
 	bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst);
 	bool FindNext(DOS_DTA & dta);
 	bool GetFileAttr(char * name, uint16_t * attr);
-	bool SetFileAttr(const char * name, uint16_t attr);
+	bool SetFileAttr(const char * name, const uint16_t attr);
 	bool Rename(char * oldname,char * newname);
 	bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	bool FileExists(const char* name);
@@ -428,7 +428,7 @@ public:
 	virtual bool FindNext(DOS_DTA & dta);
 	virtual bool FileUnlink(char * name);
 	virtual bool GetFileAttr(char * name, uint16_t * attr);
-	virtual bool SetFileAttr(const char * name, uint16_t attr);
+	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool FileExists(const char* name);
 	virtual bool Rename(char * oldname,char * newname);
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block);

--- a/include/drives.h
+++ b/include/drives.h
@@ -199,7 +199,7 @@ private:
 	Bit32u getClustFirstSect(Bit32u clustNum);
 	bool FindNextInternal(Bit32u dirClustNumber, DOS_DTA & dta, direntry *foundEntry);
 	bool getDirClustNum(char * dir, Bit32u * clustNum, bool parDir);
-	bool getFileDirEntry(char const * const filename, direntry * useEntry, Bit32u * dirClust, Bit32u * subEntry, bool dirOk=false);
+	bool getFileDirEntry(char const * const filename, direntry * useEntry, uint32_t * dirClust, uint32_t * subEntry, const bool dir_ok = false);
 	bool addDirectoryEntry(Bit32u dirClustNumber, direntry useEntry);
 	void zeroOutCluster(Bit32u clustNumber);
 	bool getEntryName(char *fullname, char *entname);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -878,7 +878,6 @@ static Bitu DOS_21Handler(void) {
 				break;
 			};
 		case 0x01:				/* Set */
-			LOG(LOG_MISC,LOG_ERROR)("DOS:Set File Attributes for %s not supported",name1);
 			if (DOS_SetFileAttr(name1,reg_cx)) {
 				reg_ax=0x202;	/* ax destroyed */
 				CALLBACK_SCF(false);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -20,6 +20,7 @@
 
 #include "programs.h"
 
+#include "program_attrib.h"
 #include "program_autotype.h"
 #include "program_boot.h"
 #include "program_choice.h"
@@ -546,7 +547,7 @@ void DOS_SetupPrograms(void)
 	MSG_Add("WIKI_ADD_UTILITIES_ARTICLE", WIKI_ADD_UTILITIES_ARTICLE);
 	MSG_Add("WIKI_URL", WIKI_URL);
 
-	PROGRAMS_MakeFile("ATTRIB.COM", PLACEHOLDER_ProgramStart);
+	PROGRAMS_MakeFile("ATTRIB.COM", ATTRIB_ProgramStart);
 	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
 #if C_DEBUG
 	PROGRAMS_MakeFile("BIOSTEST.COM", BIOSTEST_ProgramStart);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -433,7 +433,7 @@ bool fatDrive::getEntryName(char *fullname, char *entname) {
 	return true;
 }
 
-bool fatDrive::getFileDirEntry(char const * const filename, direntry * useEntry, uint32_t * dirClust, uint32_t * subEntry, bool dir_ok) {
+bool fatDrive::getFileDirEntry(char const * const filename, direntry * useEntry, uint32_t * dirClust, uint32_t * subEntry, const bool dir_ok) {
 	size_t len = strnlen(filename, DOS_PATHLENGTH);
 	char dirtoken[DOS_PATHLENGTH];
 	Bit32u currentClust = 0;
@@ -468,7 +468,6 @@ bool fatDrive::getFileDirEntry(char const * const filename, direntry * useEntry,
 			}
 
 			currentClust = foundEntry.loFirstClust;
-			findDir = strtok(NULL,"\\");
 		}
 	} else {
 		/* Set to root directory */

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -342,7 +342,7 @@ bool isoDrive::GetFileAttr(char *name, uint16_t *attr) {
 	return success;
 }
 
-bool isoDrive::SetFileAttr(const char * name, uint16_t attr) {
+bool isoDrive::SetFileAttr(const char * name, uint16_t /*attr*/) {
 	isoDirEntry de;
 	if (lookup(&de, name))
 		DOS_SetError(DOSERR_ACCESS_DENIED);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -330,7 +330,7 @@ bool isoDrive::Rename(char* /*oldname*/, char* /*newname*/) {
 	return false;
 }
 
-bool isoDrive::GetFileAttr(char *name, Bit16u *attr) {
+bool isoDrive::GetFileAttr(char *name, uint16_t *attr) {
 	*attr = 0;
 	isoDirEntry de;
 	bool success = lookup(&de, name);
@@ -340,6 +340,15 @@ bool isoDrive::GetFileAttr(char *name, Bit16u *attr) {
 		if (IS_DIR(FLAGS1)) *attr |= DOS_ATTR_DIRECTORY;
 	}
 	return success;
+}
+
+bool isoDrive::SetFileAttr(const char * name, uint16_t attr) {
+	isoDirEntry de;
+	if (lookup(&de, name))
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+	else
+		DOS_SetError(DOSERR_FILE_NOT_FOUND);
+	return false;
 }
 
 bool isoDrive::AllocationInfo(Bit16u *bytes_sector, Bit8u *sectors_cluster, Bit16u *total_clusters, Bit16u *free_clusters) {

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -342,7 +342,7 @@ bool isoDrive::GetFileAttr(char *name, uint16_t *attr) {
 	return success;
 }
 
-bool isoDrive::SetFileAttr(const char * name, uint16_t /*attr*/) {
+bool isoDrive::SetFileAttr(const char * name, [[maybe_unused]] const uint16_t attr) {
 	isoDirEntry de;
 	if (lookup(&de, name))
 		DOS_SetError(DOSERR_ACCESS_DENIED);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -343,22 +343,29 @@ again:
 	//and due to its design dir_ent might be lost.)
 	//Copying dir_ent first
 	safe_strcpy(dir_entcopy, dir_ent);
-	if (stat(dirCache.GetExpandName(full_name),&stat_block)!=0) { 
+	char *temp_name = dirCache.GetExpandName(full_name);
+	if (stat(temp_name, &stat_block) != 0) {
 		goto again;//No symlinks and such
-	}	
+	}
 
-	if (stat_block.st_mode & S_IFDIR) find_attr=DOS_ATTR_DIRECTORY;
-	else find_attr = 0;
-#if defined (WIN32)
-	Bitu attribs = GetFileAttributesW(host_name);
+	if (stat_block.st_mode & S_IFDIR)
+		find_attr = DOS_ATTR_DIRECTORY;
+	else
+		find_attr = 0;
+#if defined(WIN32)
+	Bitu attribs = GetFileAttributes(temp_name);
 	if (attribs != INVALID_FILE_ATTRIBUTES)
-		find_attr|=attribs&0x3f;
+		find_attr |= attribs & 0x3f;
 #else
-	if (!(find_attr&DOS_ATTR_DIRECTORY)) find_attr|=DOS_ATTR_ARCHIVE;
-	if (!(stat_block.st_mode & S_IWUSR)) find_attr|=DOS_ATTR_READ_ONLY;
+	if (!(find_attr & DOS_ATTR_DIRECTORY))
+		find_attr |= DOS_ATTR_ARCHIVE;
+	if (!(stat_block.st_mode & S_IWUSR))
+		find_attr |= DOS_ATTR_READ_ONLY;
 #endif
- 	if (~srch_attr & find_attr & (DOS_ATTR_DIRECTORY | DOS_ATTR_HIDDEN | DOS_ATTR_SYSTEM)) goto again;
-	
+	if (~srch_attr & find_attr &
+	    (DOS_ATTR_DIRECTORY | DOS_ATTR_HIDDEN | DOS_ATTR_SYSTEM))
+		goto again;
+
 	/*file is okay, setup everything to be copied in DTA Block */
 	char find_name[DOS_NAMELENGTH_ASCII] = "";
 	uint16_t find_date;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -353,9 +353,10 @@ again:
 	else
 		find_attr = 0;
 #if defined(WIN32)
+	constexpr int8_t maximum_attribs = 0x3f;
 	Bitu attribs = GetFileAttributes(temp_name);
 	if (attribs != INVALID_FILE_ATTRIBUTES)
-		find_attr |= attribs & 0x3f;
+		find_attr |= attribs & maximum_attribs;
 #else
 	if (!(find_attr & DOS_ATTR_DIRECTORY))
 		find_attr |= DOS_ATTR_ARCHIVE;
@@ -421,7 +422,7 @@ bool localDrive::GetFileAttr(char *name, uint16_t *attr)
 #endif
 }
 
-bool localDrive::SetFileAttr(const char *name, uint16_t attr)
+bool localDrive::SetFileAttr(const char *name, const uint16_t attr)
 {
 	char newname[CROSS_LEN];
 	strcpy(newname, basedir);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -943,28 +943,43 @@ bool Overlay_Drive::FileUnlink(char * name) {
 	}
 }
 
-
-bool Overlay_Drive::GetFileAttr(char * name,Bit16u * attr) {
+bool Overlay_Drive::GetFileAttr(char *name, uint16_t *attr)
+{
 	char overlayname[CROSS_LEN];
 	safe_strcpy(overlayname, overlaydir);
 	safe_strcat(overlayname, name);
 	CROSS_FILENAME(overlayname);
 
 	struct stat status;
-	if (stat(overlayname,&status)==0) {
-		*attr=DOS_ATTR_ARCHIVE;
-		if(status.st_mode & S_IFDIR) *attr|=DOS_ATTR_DIRECTORY;
+	if (stat(overlayname, &status) == 0) {
+		*attr = DOS_ATTR_ARCHIVE;
+		if (status.st_mode & S_IFDIR)
+			*attr |= DOS_ATTR_DIRECTORY;
 		return true;
 	}
-	//Maybe check for deleted path as well
+	// Maybe check for deleted path as well
 	if (is_deleted_file(name)) {
 		*attr = 0;
 		return false;
 	}
-	return localDrive::GetFileAttr(name,attr);
-
+	return localDrive::GetFileAttr(name, attr);
 }
 
+bool Overlay_Drive::SetFileAttr(const char *name, uint16_t /*attr*/)
+{
+	char overlayname[CROSS_LEN];
+	safe_strcpy(overlayname, overlaydir);
+	safe_strcat(overlayname, name);
+	CROSS_FILENAME(overlayname);
+
+	struct stat status;
+	if (stat(overlayname, &status) == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return true;
+	}
+	DOS_SetError(DOSERR_FILE_NOT_FOUND);
+	return false;
+}
 
 void Overlay_Drive::add_deleted_file(const char* name,bool create_on_disk) {
 	if (logoverlay) LOG_MSG("add del file %s",name);

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -236,15 +236,35 @@ bool Virtual_Drive::FindNext(DOS_DTA & dta) {
 	return false;
 }
 
-bool Virtual_Drive::GetFileAttr(char * name,Bit16u * attr) {
-	VFILE_Block * cur_file = first_file;
+bool Virtual_Drive::GetFileAttr(char *name, Bit16u *attr)
+{
+	VFILE_Block *cur_file = first_file;
 	while (cur_file) {
 		if (strcasecmp(name, cur_file->name) == 0) {
-			*attr = DOS_ATTR_ARCHIVE;	//Maybe readonly ?
+			*attr = DOS_ATTR_ARCHIVE; // Maybe readonly ?
 			return true;
 		}
 		cur_file = cur_file->next;
 	}
+	return false;
+}
+
+bool Virtual_Drive::SetFileAttr(const char *name, uint16_t attr)
+{
+	(void)attr; // UNUSED
+	if (*name == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return true;
+	}
+	const VFILE_Block *cur_file = first_file;
+	while (cur_file) {
+		if (strcasecmp(name, cur_file->name) == 0) {
+			DOS_SetError(DOSERR_ACCESS_DENIED);
+			return false;
+		}
+		cur_file = cur_file->next;
+	}
+	DOS_SetError(DOSERR_FILE_NOT_FOUND);
 	return false;
 }
 

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -20,6 +20,7 @@ libdos_sources = files([
   'drive_overlay.cpp',
   'drives.cpp',
   'drive_virtual.cpp',
+  'program_attrib.cpp',
   'program_autotype.cpp',
   'program_biostest.cpp',
   'program_boot.cpp',

--- a/src/dos/program_attrib.cpp
+++ b/src/dos/program_attrib.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2022  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/program_attrib.cpp
+++ b/src/dos/program_attrib.cpp
@@ -1,0 +1,40 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "program_attrib.h"
+
+#include <string>
+
+#include "shell.h"
+#include "string_utils.h"
+
+void ATTRIB::Run()
+{
+	std::string tmp = "";
+	cmd->GetStringRemain(tmp);
+	char args[CMD_MAXLINE];
+	safe_strcpy(args, tmp.c_str());
+	first_shell->CMD_ATTRIB(args);
+}
+
+void ATTRIB_ProgramStart(Program **make)
+{
+	*make = new ATTRIB;
+}

--- a/src/dos/program_attrib.h
+++ b/src/dos/program_attrib.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *  Copyright (C) 2020-2022  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/program_attrib.h
+++ b/src/dos/program_attrib.h
@@ -1,0 +1,35 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PROGRAM_ATTRIB_H
+#define DOSBOX_PROGRAM_ATTRIB_H
+
+#include "programs.h"
+
+#include <string>
+
+class ATTRIB final : public Program {
+public:
+	void Run();
+};
+
+void ATTRIB_ProgramStart(Program **make);
+
+#endif

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1218,6 +1218,29 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_LS_PATH_ERR",
 	        "ls: cannot access '%s': No such file or directory\n");
 
+	MSG_Add("SHELL_CMD_ATTRIB_HELP",
+			"Displays or changes file attributes.\n");
+	MSG_Add("SHELL_CMD_ATTRIB_HELP_LONG",
+	        "Usage:\n"
+	        "  \033[32;1mattrib\033[0m \033[37;1m[ATTRIBUTES]\033[0m \033[36;1mPATTERN\033[0m [/S]\n"
+	        "\n"
+	        "Where:\n"
+	        "  \033[37;1mATTRIBUTES\033[0m are attributes to apply, including one or more of the following:\n"
+	        "             \033[37;1m+R\033[0m, \033[37;1m-R\033[0m, \033[37;1m+A\033[0m, \033[37;1m-A\033[0m, \033[37;1m+S\033[0m, \033[37;1m-S\033[0m, \033[37;1m+H\033[0m, \033[37;1m-H\033[0m\n"
+	        "             Where: R = Read-only, A = Archive, S = System, H = Hidden\n"
+	        "  \033[36;1mPATTERN\033[0m    can be either an exact filename or an inexact filename with\n"
+	        "             wildcards, which are the asterisk (*) and the question mark (?),\n"
+	        "             or an exact name of a directory."
+	        "\n"
+	        "Notes:\n"
+	        "  Multiple attributes can be specified in the command, separated by spaces.\n"
+	        "  If not specified, the command shows the current file/directory attributes.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  \033[32;1mattrib\033[0m \033[36;1mfile.txt\033[0m\n"
+	        "  \033[32;1mattrib\033[0m \033[37;1m+R\033[0m \033[37;1m-A\033[0m \033[36;1m*.txt\033[0m\n");
+	MSG_Add("SHELL_CMD_ATTRIB_GET_ERROR", "Unable to get attributes: %s\n");
+	MSG_Add("SHELL_CMD_ATTRIB_SET_ERROR", "Unable to set attributes: %s\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP",
 	        "Waits for a keypress and sets an ERRORLEVEL value.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG",

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1275,9 +1275,24 @@ static void show_attributes(DOS_Shell *shell, const uint16_t fattr, const char *
 			attr_r ? 'R' : ' ', name);
 }
 
+char *get_filename(char *args)
+{
+	static char *fname = strrchr(args, '\\');
+	if (fname != NULL)
+		fname++;
+	else {
+		fname = strrchr(args, ':');
+		if (fname != NULL)
+			fname++;
+		else
+			fname = args;
+	}
+	return fname;
+}
+
 static bool attrib_recursive(DOS_Shell *shell,
                              char *args,
-                             const DOS_DTA dta,
+                             const DOS_DTA &dta,
                              const bool optS,
                              attributes attribs)
 {
@@ -1346,24 +1361,14 @@ static bool attrib_recursive(DOS_Shell *shell,
 				DtaResult result;
 				dta.GetResult(result.name, result.size, result.date,
 				              result.time, result.attr);
-
 				if ((result.attr & DOS_ATTR_DIRECTORY) &&
 				    strcmp(result.name, ".") &&
 				    strcmp(result.name, "..")) {
-					strcat(path, result.name);
-					strcat(path, "\\");
-					char *fname = strrchr(args, '\\');
-					if (fname != NULL)
-						fname++;
-					else {
-						fname = strrchr(args, ':');
-						if (fname != NULL)
-							fname++;
-						else
-							fname = args;
-					}
-					strcat(path, fname);
-					found_dirs.push_back(path);
+					std::string fullname = result.name +
+					                       std::string(1, '\\') +
+					                       get_filename(args);
+					found_dirs.push_back(fullname);
+					strcpy(path, fullname.c_str());
 					*(path + len) = 0;
 				}
 			} while (DOS_FindNext());

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -309,6 +309,7 @@
     <ClCompile Include="..\src\dos\drive_local.cpp" />
     <ClCompile Include="..\src\dos\drive_overlay.cpp" />
     <ClCompile Include="..\src\dos\drive_virtual.cpp" />
+    <ClCompile Include="..\src\dos\program_attrib.cpp" />
     <ClCompile Include="..\src\dos\program_autotype.cpp" />
     <ClCompile Include="..\src\dos\program_biostest.cpp" />
     <ClCompile Include="..\src\dos\program_boot.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -412,6 +412,9 @@
     <ClCompile Include="..\src\midi\midi.cpp">
       <Filter>src\midi</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_attrib.cpp">
+      <Filter>src\dos</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\dos\program_autotype.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>


### PR DESCRIPTION
This adds support for file attributes as well as implementing ATTRIB command. The ATTRIB command which was previously a placeholder is now a functional DOS program on Z: drive, with help messages added accordingly. Archive, read-only, system and hidden attributes are fully supported in disk images and mounted local drives, with the exception of system and hidden attributes on mounted local drives for non-Windows platforms.