### PR TITLE
Fix a GUS audio regression in Star Control II (#1530)

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -27,6 +27,8 @@
 #include "inout.h"
 #include "support.h"
 
+enum class DMA_DIRECTION { READ, WRITE };
+
 enum DMAEvent {
 	DMA_REACHED_TC,
 	DMA_MASKED,
@@ -84,8 +86,17 @@ public:
 	void Clear_Request(void) {
 		request=false;
 	}
-	Bitu Read(Bitu size, Bit8u * buffer);
-	Bitu Write(Bitu size, Bit8u * buffer);
+	size_t Read(size_t words, uint8_t *dest_buffer)
+	{
+		return ReadOrWrite(DMA_DIRECTION::READ, words, dest_buffer);
+	}
+	size_t Write(size_t words, uint8_t *src_buffer)
+	{
+		return ReadOrWrite(DMA_DIRECTION::WRITE, words, src_buffer);
+	}
+
+private:
+	size_t ReadOrWrite(DMA_DIRECTION direction, size_t words, uint8_t *buffer);
 };
 
 class DmaController {

--- a/include/dma.h
+++ b/include/dma.h
@@ -143,6 +143,6 @@ DmaChannel * GetDMAChannel(Bit8u chan);
 void CloseSecondDMAController(void);
 bool SecondDMAControllerAvailable(void);
 
-void DMA_SetWrapping(Bitu wrap);
+void DMA_SetWrapping(const uint32_t wrap);
 
 #endif

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -128,6 +128,7 @@ public:
 	void Enable(bool should_enable);
 	void FlushSamples();
 
+	Envelope envelope;
 	float volmain[2] = {1.0f, 1.0f};
 	std::atomic<int> done = 0; // Timing on how many samples have been done by the mixer
 	bool is_enabled = false;
@@ -138,7 +139,6 @@ private:
 	MixerChannel(const MixerChannel &) = delete;
 	MixerChannel &operator=(const MixerChannel &) = delete;
 
-	Envelope envelope;
 	MIXER_Handler handler = nullptr;
 	int freq_add = 0u;           // This gets added the frequency counter each mixer step
 	int freq_counter = 0u;       // When this flows over a new sample needs to be read from the device

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -320,9 +320,10 @@ DmaChannel::DmaChannel(uint8_t num, bool dma16)
 	increment = true;
 }
 
-size_t DmaChannel::ReadOrWrite(DMA_DIRECTION direction, size_t want, uint8_t *buffer)
+size_t DmaChannel::ReadOrWrite(DMA_DIRECTION direction, size_t words, uint8_t *buffer)
 {
-	size_t done = 0;
+	auto want = check_cast<uint16_t>(words);
+	uint16_t done = 0;
 	curraddr &= dma_wrapping;
 again:
 	Bitu left = (currcnt + 1);

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -165,18 +165,11 @@ static uint16_t DMA_Read_Port(io_port_t port, io_width_t width)
 	} else if (port >= 0xc0 && port <= 0xdf) {
 		/* read from the second DMA controller (channels 4-7) */
 		return DmaControllers[1]->ReadControllerReg((port - 0xc0) >> 1, width);
-	} else
-		switch (port) {
-		/* read DMA page register */
-		case 0x81:return GetDMAChannel(2)->pagenum;
-		case 0x82:return GetDMAChannel(3)->pagenum;
-		case 0x83:return GetDMAChannel(1)->pagenum;
-		case 0x87:return GetDMAChannel(0)->pagenum;
-		case 0x89:return GetDMAChannel(6)->pagenum;
-		case 0x8a:return GetDMAChannel(7)->pagenum;
-		case 0x8b:return GetDMAChannel(5)->pagenum;
-		case 0x8f:return GetDMAChannel(4)->pagenum;
-		}
+	} else {
+		const auto channel = GetChannelFromPort(port);
+		if (channel)
+			return channel->pagenum;
+	}
 	return 0;
 }
 

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -404,7 +404,7 @@ public:
 	}
 };
 
-void DMA_SetWrapping(Bitu wrap) {
+void DMA_SetWrapping(const uint32_t wrap) {
 	dma_wrapping = wrap;
 }
 

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -1,8 +1,8 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2021  The DOSBox Staging Team
- *  Copyright (C) 2019-2021  kcgen <kcgen@users.noreply.github.com>
+ *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2019-2022  kcgen <kcgen@users.noreply.github.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,88 +23,85 @@
 
 #include "support.h"
 
-Envelope::Envelope(const char *name) : channel_name(name)
-{}
+Envelope::Envelope([[maybe_unused]]const char *name)
+{
+}
 
 void Envelope::Reactivate()
 {
-	edge = 0;
-	frames_done = 0;
+	edge[0] = 0;
+	edge[1] = 0;
+	edge[2] = 0;
+	edge[3] = 0;
+	frames_processed = 0;
 	process = &Envelope::Apply;
 }
 
-void Envelope::Update(const int frame_rate,
-                      const int peak_amplitude,
-                      const uint8_t expansion_phase_ms,
-                      const uint8_t expire_after_seconds)
+void Envelope::SetFrameRate(const int rate)
 {
-	if (!frame_rate || !peak_amplitude || !expansion_phase_ms)
+	frame_rate = rate;
+	Update();
+}
+
+void Envelope::SetPeakAmplitude(const int peak)
+{
+	peak_amplitude = peak;
+	Update();
+}
+
+void Envelope::SetExpansionPercentage(const int percentage)
+{
+	expansion_percentage = percentage;
+	Update();
+}
+void Envelope::SetExpiration(const int expire_s)
+{
+	expire_after_seconds = expire_s;
+	Update();
+}
+
+void Envelope::Update()
+{
+	if (!frame_rate || !peak_amplitude || !expansion_percentage) {
+		process = &Envelope::Skip;
 		return;
+	}
 
 	// How many frames should we inspect before expiring?
 	expire_after_frames = expire_after_seconds * frame_rate;
-	assert(expire_after_frames > 0);
 
-	// The furtherest allowed edge is the peak sample amplitude.
-	edge_limit = peak_amplitude;
-
-	// Permit the envelop to achieve peak volume within the expansion_phase
-	// (in ms) if the samples happen to constantly press on the edges.
-	const auto expansion_phase_frames = ceil_sdivide(frame_rate * expansion_phase_ms,
-	                                                 1000);
-
-	// Calculate how much the envelope's edge will grow after a frame
-	// presses against it.
-	assert(expansion_phase_frames);
-	edge_increment = ceil_sdivide(peak_amplitude, expansion_phase_frames);
-
-	// DEBUG_LOG_MSG("ENVELOPE: %s grows by %-3u to %-5u across %-3u frames (%u ms)",
-	//               channel_name, edge_increment, edge_limit, expansion_phase_frames,
-	//               expansion_phase_ms);
+	// Calculate how much the envelope's edge can grow after a frame
+	// presses it outward.
+	assert(expansion_percentage <= 100);
+	expansion_increment = ceil_sdivide(peak_amplitude * expansion_percentage, 100);
+	Reactivate();
 }
 
-bool Envelope::ClampSample(int &sample, const int lip)
+void Envelope::Process(int prev[], int next[])
 {
-	if (std::abs(sample) > edge) {
-		sample = clamp(sample, -lip, lip);
-		return true;
+	process(*this, prev, next);
+}
+
+void Envelope::Apply(int prev[], int next[])
+{
+	// Let us easily iterate over the frames and channels.
+	int *samples[]{&prev[0], &prev[1], &next[0], &next[1]};
+
+	for (auto i = 0; i < num_channels; ++i) {
+		// compute the channels' envelope
+		const auto lower_lip = edge[i] - expansion_increment;
+		const auto upper_lip = edge[i] + expansion_increment;
+
+		// clamp with the envelope and within the overall range
+		auto sample = clamp(*samples[i], lower_lip, upper_lip);
+		sample = clamp(sample, -peak_amplitude, peak_amplitude);
+
+		// update the sample and it's new edge
+		*samples[i] = sample;
+		edge[i] = sample;
 	}
-	return false;
-}
-
-void Envelope::Process(const bool is_stereo,
-                       const bool is_interpolated,
-                       int prev[],
-                       int next[])
-{
-	process(*this, is_stereo, is_interpolated, prev, next);
-}
-
-void Envelope::Apply(const bool is_stereo,
-                     const bool is_interpolated,
-                     int prev[],
-                     int next[])
-{
-	// Only start the envelope once our samples have actual values
-	if (prev[0] == 0 && frames_done == 0u)
-		return;
-
-	// beyond the edge is the lip. Do any samples walk out onto the lip?
-	const int lip = edge + edge_increment;
-	const bool on_lip = (ClampSample(prev[0], lip)) || (is_stereo &&
-	                     ClampSample(prev[1], lip)) || (is_interpolated &&
-	                     (ClampSample(next[0], lip) || (is_stereo &&
-	                      ClampSample(next[1], lip))));
-
-	// If any of the samples are out on the lip, then march the edge forward
-	if (on_lip)
-		edge += edge_increment;
-
-	// Should we deactivate the envelope?
-	if (++frames_done > expire_after_frames || edge >= edge_limit) {
+	// Maybe expire the envelope
+	if (expire_after_frames && ++frames_processed > expire_after_frames) {
 		process = &Envelope::Skip;
-		(void)channel_name; // [[maybe_unused]] in release builds
-		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %u",
-		              channel_name, frames_done, edge);
 	}
 }

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -604,6 +604,9 @@ Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
 	                                      std::placeholders::_1);
 	audio_channel = MIXER_AddChannel(mixer_callback, 1, "GUS");
 
+	audio_channel->envelope.SetExpansionPercentage(12);
+	audio_channel->envelope.SetExpiration(0); // never expires
+
 	// Let the mixer command adjust the GUS's internal amplitude level's
 	const auto set_level_callback = std::bind(&Gus::SetLevelCallback, this, _1);
 	audio_channel->RegisterLevelCallBack(set_level_callback);

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -485,10 +485,9 @@ float Voice::Read8BitSample(const ram_array_t &ram, const int32_t addr) const no
 // Read a 16-bit sample returned as a float
 float Voice::Read16BitSample(const ram_array_t &ram, const int32_t addr) const noexcept
 {
-	// Calculate offset of the 16-bit sample
-	const auto lower = addr & 0b1100'0000'0000'0000'0000;
-	const auto upper = addr & 0b0001'1111'1111'1111'1111;
-	const auto i = static_cast<size_t>(lower | (upper << 1));
+	const auto upper = addr & 0b1100'0000'0000'0000'0000;
+	const auto lower = addr & 0b0001'1111'1111'1111'1111;
+	const auto i = static_cast<uint32_t>(upper | (lower << 1));
 	return static_cast<int16_t>(host_readw(&ram.at(i)));
 }
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -781,6 +781,9 @@ bool Gus::PerformDmaTransfer()
 	// scale the transfer by the DMA channel's bit-depth
 	const auto bytes_transfered = transfered * (dma_channel->DMA16 + 1u);
 
+	// Update the GUS's DMA address with the current position
+	UpdateDmaAddr(check_cast<uint32_t>(offset + bytes_transfered));
+
 	// If requested, invert the loaded samples' most-significant bits
 	if (is_reading && dma_ctrl & 0x80) {
 		auto ram_pos = ram.begin() + offset;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -416,7 +416,7 @@ float Voice::GetSample(const ram_array_t &ram) noexcept
 	float sample = is_16bit ? Read16BitSample(ram, addr)
 	                        : Read8BitSample(ram, addr);
 	if (should_interpolate) {
-		const auto next_addr = addr + 1;
+		const auto next_addr = addr + (1 << (is_16bit ? 1 : 0));
 		const float next_sample = is_16bit ? Read16BitSample(ram, next_addr)
 		                                   : Read8BitSample(ram, next_addr);
 		constexpr float WAVE_WIDTH_INV = 1.0 / WAVE_WIDTH;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -288,7 +288,7 @@ private:
 
 	// Register and playback rate
 	uint32_t dram_addr = 0u;
-	uint32_t playback_rate = 0u;
+	int playback_rate = 0;
 	uint16_t register_data = 0u;
 	uint8_t selected_register = 0u;
 
@@ -623,7 +623,7 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		active_voices = requested_voices;
 		assert(active_voices <= voices.size());
 		active_voice_mask = 0xffffffffu >> (MAX_VOICES - active_voices);
-		playback_rate = static_cast<uint32_t>(
+		playback_rate = static_cast<int>(
 		        round(1000000.0 / (1.619695497 * active_voices)));
 		audio_channel->SetFreq(playback_rate);
 	}
@@ -670,7 +670,7 @@ void Gus::BeginPlayback()
 	irq_enabled = ((register_data & 0x400) != 0);
 	audio_channel->Enable(true);
 	if (prev_logged_voices != active_voices) {
-		LOG_MSG("GUS: Activated %u voices at %u Hz", active_voices,
+		LOG_MSG("GUS: Activated %u voices at %d Hz", active_voices,
 		        playback_rate);
 		prev_logged_voices = active_voices;
 	}

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -803,6 +803,7 @@ bool Gus::PerformDmaTransfer()
 		dma_ctrl |= DMA_TC_STATUS_BITMASK;
 		irq_status |= 0x80;
 		CheckIrq();
+		assert(dma_channel->tcount); // hit terminal count, we're done
 		return false;
 	}
 	return true;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -823,10 +823,10 @@ void Gus::PopulateAutoExec(uint16_t port, const std::string &ultradir)
 	// maximum-limit.
 	assert(port < 0xfff);
 	assert(dma1 < 10 && dma2 < 10);
-	assert(irq1 < 10 && irq2 < 10);
+	assert(irq1 <= 12 && irq2 <= 12);
 
 	// ULTRASND variable
-	char set_ultrasnd[] = "@SET ULTRASND=HHH,D,D,I,I";
+	char set_ultrasnd[] = "@SET ULTRASND=HHH,D,D,II,II";
 	safe_sprintf(set_ultrasnd, 
 	         "@SET ULTRASND=%x,%u,%u,%u,%u", port, dma1, dma2, irq1, irq2);
 	LOG_MSG("GUS: %s", set_ultrasnd);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -71,9 +71,8 @@
 #define TICK_NEXT ( 1 << TICK_SHIFT)
 #define TICK_MASK (TICK_NEXT -1)
 
-// Over how many milliseconds will we permit a signal to grow from
-// zero up to peak amplitude? (recommended 10 to 20ms)
-#define ENVELOPE_MAX_EXPANSION_OVER_MS 15u
+// The percentage of the peak amplitude that the enveloper will bound-per sample
+#define ENVELOPE_MAX_EXPANSION_PERCENT 25
 
 // Regardless if the signal needed to be eveloped or not, how long
 // should the envelope monitor the initial signal? (recommended > 5s)
@@ -119,7 +118,11 @@ static struct mixer_t mixer = {};
 Bit8u MixTemp[MIXER_BUFSIZE] = {};
 
 MixerChannel::MixerChannel(MIXER_Handler _handler, const char *_name) : envelope(_name), handler(_handler)
-{}
+{
+	envelope.SetPeakAmplitude(MAX_AUDIO);
+	envelope.SetExpansionPercentage(ENVELOPE_MAX_EXPANSION_PERCENT);
+	envelope.SetExpiration(ENVELOPE_EXPIRES_AFTER_S);
+}
 
 mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const int freq, const char *name)
 {
@@ -271,8 +274,7 @@ void MixerChannel::SetFreq(int freq)
 	freq_add = (freq << FREQ_SHIFT) / mixer.freq;
 	interpolate = (freq != mixer.freq);
 	sample_rate = freq;
-	envelope.Update(sample_rate, peak_amplitude,
-	                ENVELOPE_MAX_EXPANSION_OVER_MS, ENVELOPE_EXPIRES_AFTER_S);
+	envelope.SetFrameRate(sample_rate);
 }
 
 bool MixerChannel::IsInterpolated() const
@@ -288,8 +290,7 @@ int MixerChannel::GetSampleRate() const
 void MixerChannel::SetPeakAmplitude(const int peak)
 {
 	peak_amplitude = peak;
-	envelope.Update(sample_rate, peak_amplitude,
-	                ENVELOPE_MAX_EXPANSION_OVER_MS, ENVELOPE_EXPIRES_AFTER_S);
+	envelope.SetPeakAmplitude(peak_amplitude);
 }
 
 void MixerChannel::Mix(const int _needed)
@@ -504,7 +505,7 @@ void MixerChannel::AddSamples(uint16_t len, const Type *data)
 
 		// Process initial samples through an expanding envelope to
 		// prevent severe clicks and pops. Becomes a no-op when done.
-		envelope.Process(stereo, interpolate, prev_sample, next_sample);
+		envelope.Process(prev_sample, next_sample);
 
 		// Apply the left and right channel mappers only on write[..]
 		// assignments.  This ensures the channels are mapped only once


### PR DESCRIPTION
This PR fixes a regression in the GUS emulation where it could use incomplete-sounding voices in Star Control 2. 

It does some code duplication cleanup in the GUS and fixes a Staging bug where the GUS IRQ was limited to 9 (when it should allow up to 12). 

It uses [a community patch](https://www.vogons.org/viewtopic.php?t=28331) that implements contiguous DMA transfers similar to what EMS386.EXE does -- thanks to @peterferrie from the Vogons forum, and then refactors that along with more code de-duping in the DMA area. These are are stand-alone commits meant to be bisectable if there are problems.

DMA transfers were tested using Quake and SC2, and run with UBSAN and ASAN instrumentation.


https://user-images.githubusercontent.com/1557255/150623662-70e62668-2d37-4e07-aae3-932d25b026b7.mp4


https://user-images.githubusercontent.com/1557255/150623663-15131b29-5fee-41f6-b9cc-5c934be4f135.mp4



Thanks to @marsej for the report and detailed comparisons!

