### PR TITLE
Set joystick illuminator color based on status (#1248)

### DIFF
--- a/include/rgb24.h
+++ b/include/rgb24.h
@@ -2,12 +2,11 @@
 #define DOSBOX_RGB24_H
 
 typedef struct rgb24 {
-protected:
+public:
 	uint8_t red = 0;
 	uint8_t green = 0;
 	uint8_t blue = 0;
 
-public:
 	constexpr rgb24() {}
 	constexpr rgb24(const rgb24 &val) { *this = val; }
 	constexpr rgb24(const uint8_t r, const uint8_t g, const uint8_t b)


### PR DESCRIPTION
This PR applies standard status colors to the joystick's illuminator, if available.
 -  amber during initialization
 - green when active and in-use (this is the lowest possible green level to conserve battery life)
 - black when inactive or when exiting the program (ensures batteries are not drained after exit)
 
Thanks to @maxigaz for reporting this in #1248.