### PR TITLE
Fix a regression in the `windowresolution = ` preset size determination

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2375,6 +2375,18 @@ static SDL_Rect get_desktop_resolution()
 	SDL_Rect desktop;
 	assert(sdl.display_number >= 0);
 	SDL_GetDisplayBounds(sdl.display_number, &desktop);
+
+	// Deduct the border decorations from the desktop size
+	int top = 0;
+	int left = 0;
+	int bottom = 0;
+	int right = 0;
+	(void)SDL_GetWindowBordersSize(SDL_GetWindowFromID(sdl.display_number),
+	                               &top, &left, &bottom, &right);
+	// If SDL_GetWindowBordersSize fails, it populates the values with 0.
+	desktop.w -= (left + right);
+	desktop.h -= (top + bottom);
+
 	assert(desktop.w >= FALLBACK_WINDOW_DIMENSIONS.x);
 	assert(desktop.h >= FALLBACK_WINDOW_DIMENSIONS.y);
 	return desktop;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -234,7 +234,7 @@ enum class SCALING_MODE { NONE, NEAREST, PERFECT };
 // Size and ratio constants
 // ------------------------
 constexpr int SMALL_WINDOW_PERCENT = 50;
-constexpr int MEDIUM_WINDOW_PERCENT = 70;
+constexpr int MEDIUM_WINDOW_PERCENT = 74;
 constexpr int LARGE_WINDOW_PERCENT = 90;
 constexpr int DEFAULT_WINDOW_PERCENT = MEDIUM_WINDOW_PERCENT;
 static SDL_Point FALLBACK_WINDOW_DIMENSIONS = {640, 480};

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2442,10 +2442,7 @@ static SDL_Point window_bounds_from_label(const std::string &pref,
 		            pref.c_str());
 
 	const int w = ceil_sdivide(desktop.w * percent, 100);
-
-	// 320x200 when physically scaled by 3x4 produces 960x800 or a 6:5 aspect ratio
-	const int h_with_aspect = ceil_sdivide(desktop.w * percent * 5, 100 * 6);
-	const int h = std::min(desktop.h, h_with_aspect); // limit to desktop size
+	const int h = ceil_sdivide(desktop.h * percent, 100);
 	return {w, h};
 }
 


### PR DESCRIPTION
This PR should produce window sizes that fit within the desktop's drawable area, including taking window decoration sizes into consideration.

Given a 1080p display and "typical" OS configuration, this should allow the pixel-perfect algorithm to achieve the first integer step for a 320x200 game and 1.2 pixel-aspect, which is 3x4 (produces a 960x800 window):

``` ini
[sdl]
output = openglpp
windowresolution = medium
```
