### PR TITLE
Add bit operations helpers

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -32,91 +32,108 @@
 //
 // Examples
 // ~~~~~~~~
-// uint8_t reg = 0;
+// auto reg = make<uint8_t>(b0, b1); // reg = 0b0000'0011
+// auto reg_all_on = all<uint8_t>(); // reg = 0b1111'1111
 //
 // Setting:
-//   set_bits(reg, bit_0 | bit_1); // 0b0000'0011
-//   set_bits(reg, bit_8); // ASSERT FAIL (out of range)
-//   set_all_bits(reg); // 0b1111'1111
+//   set(reg, b0, b1); // 0b0000'0011
+//   set(reg, b8); // ASSERT FAIL (out of range)
+//   set_all(reg); // 0b1111'1111
+//   set_to(reg, b1, b2, false); // 0b0000'0000
+//   set_to(reg, b1, true); // 0b0000'0000
 //
-// Toggling:
-//   toggle_bits(reg, bit_4 | bit_5 | bit_6 | bit_7); // 0b0000'1111
-//   toggle_bits(reg, bit_8); // ASSERT FAIL (out of range)
-//   toggle_all_bits(reg); //  0b1111'0000
+// Flipping:
+//   flip(reg, b4 | b5 | b6 | b7); // 0b0000'1111
+//   flip(reg, b8); // ASSERT FAIL (out of range)
+//   flip_all(reg); //  0b1111'0000
 //
 // Clearing:
-//   clear_bits(reg, bit_4 | bit_5); // 0b1100'0000
-//   clear_bits(reg, bit_8); // ASSERT FAIL (out of range)
+//   clear(reg, b4 | b5); // 0b1100'0000
+//   clear(reg, b8); // ASSERT FAIL (out of range)
 //
+// Masking: returns results, does not modify register
+//   mask_on(reg, b1, b2); // returns 0b0000'0110
+//   mask_off(reg, b1, b2); // returns 0b0000'0000
+//   mask_flip(reg, b1, b2); // returns 0b0000'0110
+//   mask_flip_all(reg); // returns 0b1111'01110
+//   mask_to(reg, b1, b2, false); // returns 0b0000'0000
+//   mask_to(reg, b1, b2, true); // returns 0b0000'0110
+
 // Checking:
-//   are_bits_set(reg, bit_6); // true
-//   are_bits_set(reg, bit_7); // true
-//   are_bits_set(reg, bit_8); // ASSERT FAIL (out of range)
-//   are_bits_set(reg, bit_6 | bit_7); // true (both need to be set)
-//   are_bits_set(reg, bit_5 | bit_6); // false (both aren't set)
-//   are_any_bits_set(reg, bit_5 | bit_6); // true (bit 6 is)
-//   are_bits_cleared(reg, bit_0 | bit_1 | bit_2 | bit_3); // true
+//   is(reg, b6); // true
+//   is(reg, b7); // true
+//   is(reg, b8); // ASSERT FAIL (out of range)
+//   is(reg, b6 | b7); // true (both need to be set)
+//   is(reg, b5 | b6); // false (both isn't set)
+//   any(reg, b5 | b6); // true (bit 6 is)
+//   cleared(reg, b0 | b1 | b2 | b3); // true
 //
 
-enum BITS {
-	bit_0 = 1 << 0,
-	bit_1 = 1 << 1,
-	bit_2 = 1 << 2,
-	bit_3 = 1 << 3,
-	bit_4 = 1 << 4,
-	bit_5 = 1 << 5,
-	bit_6 = 1 << 6,
-	bit_7 = 1 << 7,
-	bit_8 = 1 << 8,
-	bit_9 = 1 << 9,
-	bit_10 = 1 << 10,
-	bit_11 = 1 << 11,
-	bit_12 = 1 << 12,
-	bit_13 = 1 << 13,
-	bit_14 = 1 << 14,
-	bit_15 = 1 << 15,
-	bit_16 = 1 << 16,
-	bit_17 = 1 << 17,
-	bit_18 = 1 << 18,
-	bit_19 = 1 << 19,
-	bit_20 = 1 << 20,
-	bit_21 = 1 << 21,
-	bit_22 = 1 << 22,
-	bit_23 = 1 << 23,
-	bit_24 = 1 << 24,
-	bit_25 = 1 << 25,
-	bit_26 = 1 << 26,
-	bit_27 = 1 << 27,
-	bit_28 = 1 << 28,
-	bit_29 = 1 << 29,
-	bit_30 = 1 << 30,
-	bit_31 = 1 << 31
-};
+namespace bit {
+
+namespace literals {
+constexpr auto b0 = 1 << 0;
+constexpr auto b1 = 1 << 1;
+constexpr auto b2 = 1 << 2;
+constexpr auto b3 = 1 << 3;
+constexpr auto b4 = 1 << 4;
+constexpr auto b5 = 1 << 5;
+constexpr auto b6 = 1 << 6;
+constexpr auto b7 = 1 << 7;
+constexpr auto b8 = 1 << 8;
+constexpr auto b9 = 1 << 9;
+constexpr auto b10 = 1 << 10;
+constexpr auto b11 = 1 << 11;
+constexpr auto b12 = 1 << 12;
+constexpr auto b13 = 1 << 13;
+constexpr auto b14 = 1 << 14;
+constexpr auto b15 = 1 << 15;
+constexpr auto b16 = 1 << 16;
+constexpr auto b17 = 1 << 17;
+constexpr auto b18 = 1 << 18;
+constexpr auto b19 = 1 << 19;
+constexpr auto b20 = 1 << 20;
+constexpr auto b21 = 1 << 21;
+constexpr auto b22 = 1 << 22;
+constexpr auto b23 = 1 << 23;
+constexpr auto b24 = 1 << 24;
+constexpr auto b25 = 1 << 25;
+constexpr auto b26 = 1 << 26;
+constexpr auto b27 = 1 << 27;
+constexpr auto b28 = 1 << 28;
+constexpr auto b29 = 1 << 29;
+constexpr auto b30 = 1 << 30;
+constexpr auto b31 = 1 << 31;
+} // namespace literals
 
 // Is the bitmask within the maximum value of the register?
-template <typename T>
-static constexpr void validate_bit_width([[maybe_unused]] const T reg, const int bits)
+template <typename T, typename B>
+static constexpr void check_width([[maybe_unused]] const T reg, const B bits)
 {
 	// ensure the register is unsigned
 	static_assert(std::is_unsigned<T>::value, "register must be unsigned");
 
 	// Ensure the bits fall within the type size
 	assert(static_cast<uint64_t>(bits) > 0);
+
+	// Note: if you'd like to extend this to 64-bits, double check that the
+	//       assertions still work.  Their purpose is to catch when the bit
+	//       value exceeds the maximum width of the template type.
 	assert(static_cast<int64_t>(bits) <=
 	       static_cast<int64_t>(std::numeric_limits<T>::max()));
 }
 
 // Set the indicated bits
 template <typename T>
-constexpr T set_bits_const(const T reg, const int bits)
+constexpr T mask_on(const T reg, const int bits)
 {
-	validate_bit_width(reg, bits);
+	check_width(reg, bits);
 	return reg | static_cast<T>(bits);
 }
 template <typename T>
-constexpr void set_bits(T &reg, const int bits)
+constexpr void set(T &reg, const int bits)
 {
-	reg = set_bits_const(reg, bits);
+	reg = mask_on(reg, bits);
 }
 
 // Set all of the register's bits high
@@ -134,91 +151,101 @@ constexpr void set_bits(T &reg, const int bits)
 // counter.
 //
 template <typename T>
-constexpr T all_bits_set()
+constexpr T all()
 {
 	return std::is_signed<T>::value ? static_cast<T>(-1)
 	                                : std::numeric_limits<T>::max();
 }
 template <typename T>
-constexpr void set_all_bits(T &reg)
+constexpr void set_all(T &reg)
 {
-	reg = all_bits_set<T>();
+	reg = all<T>();
+}
+
+// Make a bitmask of the indicated bits
+template <typename T>
+constexpr T make(const int bits)
+{
+	check_width(static_cast<T>(0), bits);
+	return static_cast<T>(bits);
 }
 
 // Clear the indicated bits
 template <typename T>
-constexpr T clear_bits_const(const T reg, const int bits)
+constexpr T mask_off(const T reg, const int bits)
 {
-	validate_bit_width(reg, bits);
+	check_width(reg, bits);
 	return reg & ~static_cast<T>(bits);
 }
 template <typename T>
-constexpr void clear_bits(T &reg, const int bits)
+constexpr void clear(T &reg, const int bits)
 {
-	reg = clear_bits_const(reg, bits);
+	reg = mask_off(reg, bits);
 }
 
 // Set the indicated bits to the given bool value
 template <typename T>
-constexpr T set_bits_const_to(const T reg, const int bits, const bool value)
+constexpr T mask_to(const T reg, const bool value, const int bits)
 {
-	validate_bit_width(reg, bits);
-	return value ? set_bits_const(reg, bits) : clear_bits_const(reg, bits);
+	check_width(reg, bits);
+	return value ? mask_on(reg, bits) : mask_off(reg, bits);
 }
 template <typename T>
-constexpr void set_bits_to(T &reg, const int bits, const bool value)
+constexpr void set_to(T &reg, const bool value, const int bits)
 {
-	reg = set_bits_const_to(reg, bits, value);
+	reg = mask_to(reg, value, bits);
 }
 
-// Toggle the indicated bits
+// flip the indicated bits
 template <typename T>
-constexpr T toggle_bits_const(const T reg, const int bits)
+constexpr T mask_flip(const T reg, const int bits)
 {
-	validate_bit_width(reg, bits);
+	check_width(reg, bits);
 	return reg ^ static_cast<T>(bits);
 }
 template <typename T>
-constexpr void toggle_bits(T &reg, const int bits)
+constexpr void flip(T &reg, const int bits)
 {
-	reg = toggle_bits_const(reg, bits);
+	reg = mask_flip(reg, bits);
 }
 
-// Toggle all the bits in the register
+// flip all the bits in the register
 template <typename T>
-constexpr T toggle_all_bits_const(const T reg)
+constexpr T mask_flip_all(const T reg)
 {
-	return reg ^ all_bits_set<T>();
+	return reg ^ all<T>();
 }
 template <typename T>
-constexpr void toggle_all_bits(T &reg)
+constexpr void flip_all(T &reg)
 {
-	reg = toggle_all_bits_const(reg);
+	reg = mask_flip_all(reg);
 }
 
-// Check if the indicated bits are set
+// Check if the indicated bits is set
 template <typename T>
-constexpr bool are_bits_set(const T reg, const int bits)
+constexpr bool is(const T reg, const int bits)
 {
-	validate_bit_width(reg, bits);
+	check_width(reg, bits);
 	return (reg & static_cast<T>(bits)) == static_cast<T>(bits);
 }
 
-// Check if any one of the indicated bits are set
+// Check if any one of the indicated bits is set
 template <typename T>
-constexpr bool are_any_bits_set(const T reg, const int bits)
+constexpr bool any(const T reg, const int bits)
 {
-	validate_bit_width(reg, bits);
+	check_width(reg, bits);
 	return reg & static_cast<T>(bits);
 }
 
-// Check if the indicated bits are cleared (not set)
+// Check if the indicated bits is cleisd (not set)
 template <typename T>
-constexpr bool are_bits_cleared(const T reg, const int bits)
+constexpr bool cleared(const T reg, const int bits)
 {
-	validate_bit_width(reg, bits);
+	check_width(reg, bits);
 	return (reg & static_cast<T>(bits)) == 0;
 }
+
+} // namespace bit
 
 // close the header
 #endif

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -30,6 +30,8 @@
 #define KEYBUFSIZE 32
 #define KEYDELAY   0.300 // Considering 20-30 khz serial clock and 11 bits/char
 
+using namespace bit::literals;
+
 enum KeyCommands {
 	CMD_NONE,
 	CMD_SETLEDS,
@@ -203,7 +205,7 @@ static void write_p61(io_port_t, io_val_t value, io_width_t)
 	const auto val = check_cast<uint8_t>(value);
 
 	// Clear the keyboard buffer on XT
-	if (machine < MCH_EGA && are_bits_set(val, bit_7))
+	if (machine < MCH_EGA && bit::is(val, b7))
 		KEYBOARD_ClrBuffer();
 
 	if ((port_61_data ^ val) & 3) {
@@ -230,14 +232,14 @@ extern bool TIMER_GetOutput2(void);
 static uint8_t read_p61(io_port_t, io_width_t)
 {
 	// Bit 4 must be toggled each request
-	toggle_bits(port_61_data, bit_4);
+	bit::flip(port_61_data, b4);
 
 	// On PC/AT systems, bit 5 sets the timer 2 output status
 	if (is_machine(MCH_EGA | MCH_VGA))
-		set_bits_to(port_61_data, bit_5, TIMER_GetOutput2());
+		bit::set_to(port_61_data, b5, TIMER_GetOutput2());
 	else
 		// On XT systems always toggle bit 5 (Spellicopter CGA)
-		toggle_bits(port_61_data, bit_5);
+		bit::flip(port_61_data, b5);
 
 	return port_61_data;
 }
@@ -255,10 +257,10 @@ bit 0 = 1  loop in POST
 */
 static uint8_t read_p62(io_port_t, io_width_t)
 {
-	auto ret = all_bits_set<uint8_t>();
+	auto ret = bit::all<uint8_t>();
 
 	if(!TIMER_GetOutput2())
-		clear_bits(ret, bit_5);
+		bit::clear(ret, b5);
 
 	return ret;
 }

--- a/tests/bitops_tests.cpp
+++ b/tests/bitops_tests.cpp
@@ -24,259 +24,275 @@
 
 namespace {
 
+using namespace bit::literals;
+
 TEST(bitops, enum_vals)
 {
 	// check against bit-shifts
-	EXPECT_FALSE(bit_0 == 0 << 0);
-	EXPECT_TRUE(bit_0 == 1 << 0); // this is why
-	EXPECT_FALSE(bit_0 == 1 << 1);
+	EXPECT_FALSE(b0 == 0 << 0);
+	EXPECT_TRUE(b0 == 1 << 0); // this is why
+	EXPECT_FALSE(b0 == 1 << 1);
 
-	EXPECT_FALSE(bit_5 == 1 << 4);
-	EXPECT_TRUE(bit_5 == 1 << 5); // industry prefers
-	EXPECT_FALSE(bit_5 == 1 << 6);
+	EXPECT_FALSE(b5 == 1 << 4);
+	EXPECT_TRUE(b5 == 1 << 5); // industry prefers
+	EXPECT_FALSE(b5 == 1 << 6);
 
-	EXPECT_FALSE(bit_12 == 1 << 11);
-	EXPECT_TRUE(bit_12 == 1 << 12); // zero-based bit names
-	EXPECT_FALSE(bit_12 == 1 << 13);
+	EXPECT_FALSE(b12 == 1 << 11);
+	EXPECT_TRUE(b12 == 1 << 12); // zero-based bit names
+	EXPECT_FALSE(b12 == 1 << 13);
 
-	EXPECT_FALSE(bit_22 == 1 << 21);
-	EXPECT_TRUE(bit_22 == 1 << 22); // and not one-based
-	EXPECT_FALSE(bit_22 == 1 << 23);
+	EXPECT_FALSE(b22 == 1 << 21);
+	EXPECT_TRUE(b22 == 1 << 22); // and not one-based
+	EXPECT_FALSE(b22 == 1 << 23);
 
-	EXPECT_FALSE(bit_31 == 1 << 30);
-	EXPECT_TRUE(bit_31 == 1 << 31);
+	EXPECT_FALSE(b31 == 1 << 30);
+	EXPECT_TRUE(b31 == 1 << 31);
 
 	// check against bit literals
-	EXPECT_TRUE(bit_0 == 0b1);
-	EXPECT_TRUE(bit_5 == 0b100000);
-	EXPECT_TRUE(bit_12 == 0b1000000000000);
-	EXPECT_TRUE(bit_22 == 0b10000000000000000000000);
-	EXPECT_TRUE(static_cast<uint32_t>(bit_14 | bit_22 | bit_31) ==
+	EXPECT_TRUE(b0 == 0b1);
+	EXPECT_TRUE(b5 == 0b100000);
+	EXPECT_TRUE(b12 == 0b1000000000000);
+	EXPECT_TRUE(b22 == 0b10000000000000000000000);
+	EXPECT_TRUE(static_cast<uint32_t>(b14 | b22 | b31) ==
 	            0b10000000010000000100000000000000);
 
 	// check against magic numbers
-	EXPECT_TRUE(bit_0 == 1);
-	EXPECT_TRUE(bit_5 == 32);
-	EXPECT_TRUE(bit_12 == 4096);
-	EXPECT_TRUE(bit_22 == 4194304);
-	EXPECT_TRUE(static_cast<uint32_t>(bit_14 | bit_22 | bit_31) == 2151694336);
+	EXPECT_TRUE(b0 == 1);
+	EXPECT_TRUE(b5 == 32);
+	EXPECT_TRUE(b12 == 4096);
+	EXPECT_TRUE(b22 == 4194304);
+	EXPECT_TRUE(static_cast<uint32_t>(b14 | b22 | b31) == 2151694336);
 
 	// check some combos
-	EXPECT_FALSE((bit_4 | bit_5) == 0b1'1000);
-	EXPECT_TRUE((bit_4 | bit_5) == 0b11'0000);
-	EXPECT_FALSE((bit_4 | bit_5) == 0b110'0000);
+	EXPECT_FALSE((b4 | b5) == 0b1'1000);
+	EXPECT_TRUE((b4 | b5) == 0b11'0000);
+	EXPECT_FALSE((b4 | b5) == 0b110'0000);
 }
 
 TEST(bitops, nominal_byte)
 {
-	const auto even_bits = bit_0 | bit_2 | bit_4 | bit_6;
-	const auto odd_bits = bit_1 | bit_3 | bit_5 | bit_7;
+	const auto even_bits = (b0 | b2 | b4 | b6);
+	const auto odd_bits = (b1 | b3 | b5 | b7);
 
 	uint8_t reg = 0;
-	set_bits(reg, odd_bits);
+	bit::set(reg, odd_bits);
 	EXPECT_EQ(reg, 0b10101010);
 
-	set_bits(reg, even_bits);
+	bit::set(reg, even_bits);
 	EXPECT_EQ(reg, 0b11111111);
 
-	EXPECT_TRUE(are_bits_set(reg, bit_0));
-	EXPECT_TRUE(are_bits_set(reg, bit_3));
-	EXPECT_TRUE(are_bits_set(reg, bit_7));
-	EXPECT_TRUE(are_bits_set(reg, even_bits));
-	EXPECT_TRUE(are_bits_set(reg, odd_bits));
+	EXPECT_TRUE(bit::is(reg, b0));
+	EXPECT_TRUE(bit::is(reg, b3));
+	EXPECT_TRUE(bit::is(reg, b7));
+	EXPECT_TRUE(bit::is(reg, even_bits));
+	EXPECT_TRUE(bit::is(reg, odd_bits));
 
-	EXPECT_FALSE(are_bits_cleared(reg, bit_0));
-	EXPECT_FALSE(are_bits_cleared(reg, bit_3));
-	EXPECT_FALSE(are_bits_cleared(reg, bit_7));
-	EXPECT_FALSE(are_bits_cleared(reg, even_bits));
-	EXPECT_FALSE(are_bits_cleared(reg, odd_bits));
+	EXPECT_FALSE(bit::cleared(reg, b0));
+	EXPECT_FALSE(bit::cleared(reg, b3));
+	EXPECT_FALSE(bit::cleared(reg, b7));
+	EXPECT_FALSE(bit::cleared(reg, even_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits));
 
-	clear_bits(reg, odd_bits); // odd-off, even-on
+	bit::clear(reg, odd_bits); // odd-off, even-on
 	EXPECT_EQ(reg, even_bits);
-	EXPECT_TRUE(are_bits_set(reg, even_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, odd_bits));
+	EXPECT_TRUE(bit::is(reg, even_bits));
+	EXPECT_TRUE(bit::cleared(reg, odd_bits));
 
-	toggle_bits(reg, odd_bits); // both are on
-	EXPECT_TRUE(are_bits_set(reg, (odd_bits | even_bits)));
-	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	bit::flip(reg, odd_bits); // both is on
+	EXPECT_TRUE(bit::is(reg, odd_bits | even_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits | even_bits));
 
-	toggle_bits(reg, even_bits); // odd-on, even-off
-	EXPECT_TRUE(are_bits_set(reg, odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, even_bits));
+	bit::flip(reg, even_bits); // odd-on, even-off
+	EXPECT_TRUE(bit::is(reg, odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, even_bits));
 
-	toggle_bits(reg, even_bits | odd_bits); // odd-off, even-on
+	bit::flip(reg, even_bits | odd_bits); // odd-off, even-on
 	EXPECT_EQ(reg, even_bits);
 
 	// set all bits
-	set_all_bits(reg);
+	bit::set_all(reg);
 	EXPECT_EQ(reg, 0b1111'1111);
-	EXPECT_TRUE(are_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	EXPECT_TRUE(bit::is(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits | even_bits));
 
-	// toggle all bits
-	toggle_all_bits(reg);
+	// flip all bits
+	bit::flip_all(reg);
 	EXPECT_EQ(reg, 0b0000'0000);
-	EXPECT_FALSE(are_bits_set(reg, even_bits | odd_bits));
-	EXPECT_FALSE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	EXPECT_FALSE(bit::is(reg, even_bits | odd_bits));
+	EXPECT_FALSE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, odd_bits | even_bits));
 }
 
 TEST(bitops, nominal_word)
 {
-	const auto even_bits = bit_8 | bit_10 | bit_12 | bit_14;
-	const auto odd_bits = bit_9 | bit_11 | bit_13 | bit_15;
+	const auto even_bits = (b8 | b10 | b12 | b14);
+	const auto odd_bits = (b9 | b11 | b13 | b15);
 
 	uint16_t reg = 0;
-	set_bits(reg, odd_bits);
+	bit::set(reg, odd_bits);
 	EXPECT_EQ(reg, 0b10101010'00000000);
 
-	set_bits(reg, even_bits);
+	bit::set(reg, even_bits);
 	EXPECT_EQ(reg, 0b11111111'00000000);
 
-	EXPECT_FALSE(are_bits_cleared(reg, bit_8));
-	EXPECT_FALSE(are_bits_cleared(reg, bit_12));
-	EXPECT_FALSE(are_bits_cleared(reg, bit_15));
-	EXPECT_FALSE(are_bits_cleared(reg, even_bits));
-	EXPECT_FALSE(are_bits_cleared(reg, odd_bits));
+	EXPECT_FALSE(bit::cleared(reg, b8));
+	EXPECT_FALSE(bit::cleared(reg, b12));
+	EXPECT_FALSE(bit::cleared(reg, b15));
+	EXPECT_FALSE(bit::cleared(reg, even_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits));
 
-	clear_bits(reg, odd_bits); // odd-off, even-on
+	bit::clear(reg, odd_bits); // odd-off, even-on
 	EXPECT_EQ(reg, even_bits);
-	EXPECT_TRUE(are_bits_set(reg, even_bits));
-	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, odd_bits));
+	EXPECT_TRUE(bit::is(reg, even_bits));
+	EXPECT_TRUE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, odd_bits));
 
-	toggle_bits(reg, odd_bits); // both are on
-	EXPECT_TRUE(are_bits_set(reg, (odd_bits | even_bits)));
-	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	bit::flip(reg, odd_bits); // both is on
+	EXPECT_TRUE(bit::is(reg, odd_bits | even_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits | even_bits));
 
-	toggle_bits(reg, even_bits); // odd-on, even-off
-	EXPECT_TRUE(are_bits_set(reg, odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, even_bits));
+	bit::flip(reg, even_bits); // odd-on, even-off
+	EXPECT_TRUE(bit::is(reg, odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, even_bits));
 
-	toggle_bits(reg, even_bits | odd_bits); // odd-off, even-on
+	bit::flip(reg, even_bits | odd_bits); // odd-off, even-on
 	EXPECT_EQ(reg, even_bits);
 
 	// set all bits
-	set_all_bits(reg);
+	bit::set_all(reg);
 	EXPECT_EQ(reg, 0b11111111'11111111);
-	EXPECT_TRUE(are_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	EXPECT_TRUE(bit::is(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits | even_bits));
 
-	// toggle all bits
-	toggle_all_bits(reg);
+	// flip all bits
+	bit::flip_all(reg);
 	EXPECT_EQ(reg, 0b00000000'00000000);
-	EXPECT_FALSE(are_bits_set(reg, even_bits | odd_bits));
-	EXPECT_FALSE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	EXPECT_FALSE(bit::is(reg, even_bits | odd_bits));
+	EXPECT_FALSE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, odd_bits | even_bits));
 }
 
 TEST(bitops, nominal_dword)
 {
-	const auto even_bits = bit_16 | bit_18 | bit_20 | bit_22 | bit_24 |
-	                       bit_26 | bit_28 | bit_30;
-	const auto odd_bits = bit_17 | bit_19 | bit_21 | bit_23 | bit_25 |
-	                      bit_27 | bit_29 | bit_31;
+	const auto even_bits = (b16 | b18 | b20 | b22 | b24 | b26 | b28 | b30);
+	const auto odd_bits = (b17 | b19 | b21 | b23 | b25 | b27 | b29 | b31);
 
 	uint32_t reg = 0;
 
-	set_bits(reg, even_bits);
+	bit::set(reg, even_bits);
 	EXPECT_EQ(reg, 0b01010101'01010101'00000000'00000000);
 
-	set_bits(reg, odd_bits);
+	bit::set(reg, odd_bits);
 	EXPECT_EQ(reg, 0b11111111'11111111'00000000'00000000);
 
-	EXPECT_FALSE(are_bits_cleared(reg, bit_16));
-	EXPECT_FALSE(are_bits_cleared(reg, bit_24));
-	EXPECT_FALSE(are_bits_cleared(reg, bit_31));
-	EXPECT_FALSE(are_bits_cleared(reg, even_bits));
-	EXPECT_FALSE(are_bits_cleared(reg, odd_bits));
+	EXPECT_FALSE(bit::cleared(reg, b16));
+	EXPECT_FALSE(bit::cleared(reg, b24));
+	EXPECT_FALSE(bit::cleared(reg, b31));
+	EXPECT_FALSE(bit::cleared(reg, even_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits));
 
-	clear_bits(reg, odd_bits); // odd-off, even-on
+	bit::clear(reg, odd_bits); // odd-off, even-on
 	EXPECT_EQ(reg, even_bits);
-	EXPECT_TRUE(are_bits_set(reg, even_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, odd_bits));
+	EXPECT_TRUE(bit::is(reg, even_bits));
+	EXPECT_TRUE(bit::cleared(reg, odd_bits));
 
-	toggle_bits(reg, odd_bits); // both are on
-	EXPECT_TRUE(are_bits_set(reg, (odd_bits | even_bits)));
-	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	bit::flip(reg, odd_bits); // both is on
+	EXPECT_TRUE(bit::is(reg, odd_bits | even_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits | even_bits));
 
-	toggle_bits(reg, even_bits); // odd-on, even-off
-	EXPECT_TRUE(are_bits_set(reg, odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, even_bits));
+	bit::flip(reg, even_bits); // odd-on, even-off
+	EXPECT_TRUE(bit::is(reg, odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, even_bits));
 
-	toggle_bits(reg, even_bits | odd_bits); // odd-off, even-on
+	bit::flip(reg, even_bits | odd_bits); // odd-off, even-on
 	EXPECT_EQ(reg, even_bits);
 
 	// set all bits
-	set_all_bits(reg);
+	bit::set_all(reg);
 	EXPECT_EQ(reg, 0b11111111'11111111'11111111'11111111);
-	EXPECT_TRUE(are_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	EXPECT_TRUE(bit::is(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_FALSE(bit::cleared(reg, odd_bits | even_bits));
 
-	// toggle all bits
-	toggle_all_bits(reg);
+	// flip all bits
+	bit::flip_all(reg);
 	EXPECT_EQ(reg, 0b00000000'00000000'00000000'00000000);
-	EXPECT_FALSE(are_bits_set(reg, even_bits | odd_bits));
-	EXPECT_FALSE(are_any_bits_set(reg, even_bits | odd_bits));
-	EXPECT_TRUE(are_bits_cleared(reg, (odd_bits | even_bits)));
+	EXPECT_FALSE(bit::is(reg, even_bits | odd_bits));
+	EXPECT_FALSE(bit::any(reg, even_bits | odd_bits));
+	EXPECT_TRUE(bit::cleared(reg, odd_bits | even_bits));
 }
 
 TEST(bitops, bits_too_wide_for_byte)
 {
 	uint8_t reg = 0;
-	set_bits(reg, bit_7);
-	EXPECT_TRUE(are_bits_set(reg, bit_7));
-	EXPECT_DEBUG_DEATH({ set_bits(reg, bit_8); }, "");
-	EXPECT_DEBUG_DEATH({ are_bits_set(reg, bit_8); }, "");
+	bit::set(reg, b7);
+	EXPECT_TRUE(bit::is(reg, b7));
+	EXPECT_DEBUG_DEATH({ bit::set(reg, b8); }, "");
+	EXPECT_DEBUG_DEATH({ bit::is(reg, b8); }, "");
 
-	clear_bits(reg, bit_7);
-	EXPECT_TRUE(are_bits_cleared(reg, bit_7));
-	EXPECT_DEBUG_DEATH({ clear_bits(reg, bit_8); }, "");
-	EXPECT_DEBUG_DEATH({ are_bits_cleared(reg, bit_8); }, "");
+	bit::clear(reg, b7);
+	EXPECT_TRUE(bit::cleared(reg, b7));
+	EXPECT_DEBUG_DEATH({ bit::clear(reg, b8); }, "");
+	EXPECT_DEBUG_DEATH({ bit::cleared(reg, b8); }, "");
 
-	toggle_bits(reg, bit_7);
-	EXPECT_TRUE(are_bits_set(reg, bit_7));
-	EXPECT_DEBUG_DEATH({ toggle_bits(reg, bit_8); }, "");
+	bit::flip(reg, b7);
+	EXPECT_TRUE(bit::is(reg, b7));
+	EXPECT_DEBUG_DEATH({ bit::flip(reg, b8); }, "");
 }
 
 TEST(bitops, bits_too_wide_for_word)
 {
 	uint16_t reg = 0;
-	set_bits(reg, bit_8);
-	EXPECT_TRUE(are_bits_set(reg, bit_8));
-	EXPECT_DEBUG_DEATH({ set_bits(reg, bit_16); }, "");
-	EXPECT_DEBUG_DEATH({ are_bits_set(reg, bit_16); }, "");
+	bit::set(reg, b8);
+	EXPECT_TRUE(bit::is(reg, b8));
+	EXPECT_DEBUG_DEATH({ bit::set(reg, b16); }, "");
+	EXPECT_DEBUG_DEATH({ bit::is(reg, b16); }, "");
 
-	clear_bits(reg, bit_8);
-	EXPECT_TRUE(are_bits_cleared(reg, bit_8));
-	EXPECT_DEBUG_DEATH({ clear_bits(reg, bit_16); }, "");
-	EXPECT_DEBUG_DEATH({ are_bits_cleared(reg, bit_16); }, "");
+	bit::clear(reg, b8);
+	EXPECT_TRUE(bit::cleared(reg, b8));
+	EXPECT_DEBUG_DEATH({ bit::clear(reg, b16); }, "");
+	EXPECT_DEBUG_DEATH({ bit::cleared(reg, b16); }, "");
 
-	toggle_bits(reg, bit_8);
-	EXPECT_TRUE(are_bits_set(reg, bit_8));
-	EXPECT_DEBUG_DEATH({ toggle_bits(reg, bit_16); }, "");
+	bit::flip(reg, b8);
+	EXPECT_TRUE(bit::is(reg, b8));
+	EXPECT_DEBUG_DEATH({ bit::flip(reg, b16); }, "");
 }
 
 TEST(bitops, bits_not_too_wide_for_dword)
 {
 	uint32_t reg = 0;
-	set_bits(reg, bit_8);
-	set_bits(reg, bit_24);
-	set_bits(reg, bit_31);
-	EXPECT_TRUE(are_bits_set(reg, (bit_8 | bit_24 | bit_31)));
+	bit::set(reg, b8);
+	bit::set(reg, b24);
+	bit::set(reg, b31);
+	EXPECT_TRUE(bit::is(reg, b8 | b24 | b31));
 
-	clear_bits(reg, bit_8);
-	clear_bits(reg, bit_24);
-	clear_bits(reg, bit_31);
-	EXPECT_TRUE(are_bits_cleared(reg, (bit_8 | bit_24 | bit_31)));
+	bit::clear(reg, b8);
+	bit::clear(reg, b24);
+	bit::clear(reg, b31);
+	EXPECT_TRUE(bit::cleared(reg, b8 | b24 | b31));
 
-	toggle_bits(reg, bit_8);
-	toggle_bits(reg, bit_24);
-	toggle_bits(reg, bit_31);
-	EXPECT_TRUE(are_bits_set(reg, (bit_8 | bit_24 | bit_31)));
+	bit::flip(reg, b8);
+	bit::flip(reg, b24);
+	bit::flip(reg, b31);
+	EXPECT_TRUE(bit::is(reg, b8 | b24 | b31));
+}
+
+// Masking operations
+TEST(bitops, masking)
+{
+	using namespace bit;
+
+	// Prepopulated register with bit 4 cleared:
+	constexpr uint8_t reg = (b0 | b1 | b2 | b3 /*| b4*/ | b5 | b6 | b7);
+
+	EXPECT_TRUE(is(mask_on(reg, b4), b4));
+	EXPECT_TRUE(cleared(mask_off(reg, b4), b4));
+	EXPECT_TRUE(any(mask_to(reg, true, b4), b4));
+	EXPECT_TRUE(cleared(mask_to(reg, false, b4), b4));
+	EXPECT_TRUE(any(mask_flip(reg, b4), b4));
+	EXPECT_TRUE(is(mask_flip_all(reg), b4));
 }
 
 } // namespace


### PR DESCRIPTION
This adds some bit operations helpers that will make working with registers (setting, clearing, toggling, and checking) more natural to read and write.

This will let us avoid mixing different bitops styles.  It should also make some operations more correct.

This is a prerequisite PR to making some small changes in the port 61h and 62h timing handlers, which I've added some Bochs documentation against to show how the new routines can be used.

