### PR TITLE
Fix a Tandy audio glitch in the intro of Jumpman

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -235,6 +235,8 @@ atomic_dep         = cxx.find_library('atomic', required : false)
 stdcppfs_dep       = cxx.find_library('stdc++fs', required : false)
 opus_dep           = dependency('opusfile',
                                 static : ('opusfile' in static_libs_list))
+speexdsp_dep       = dependency('speexdsp',
+                                static : ('speexdsp' in static_libs_list))
 threads_dep        = dependency('threads')
 sdl2_dep           = dependency('sdl2', version : '>= 2.0.5',
                                 static : ('sdl2' in static_libs_list))

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -862,10 +862,6 @@ void DOSBOX_Init() {
 	Pstring->Set_values(tandys);
 	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
 
-	Pint = secprop->Add_int("tandyrate", when_idle, 44100);
-	Pint->Set_values(rates);
-	Pint->Set_help("Sample rate of the Tandy 3-Voice generation.");
-
 	secprop->AddInitFunction(&DISNEY_Init,true);//done
 
 	Pbool = secprop->Add_bool("disney", when_idle, true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -424,8 +424,8 @@ void DOSBOX_Init() {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	// Some frequently used option sets
-	const char *rates[] = {"44100", "48000", "32000", "22050", "16000",
-	                       "11025", "8000",  "49716", 0};
+	const char *rates[] = {"96000", "44100", "48000", "32000", "22050",
+	                       "16000", "11025", "8000",  "49716", 0};
 
 	/* Setup all the different modules making up DOSBox */
 	const char *machines[] = {"hercules",      "cga",

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -47,7 +47,7 @@
 constexpr uint8_t ADLIB_CMD_DEFAULT = 85u;
 
 // Buffer and memory constants
-constexpr int BUFFER_FRAMES = 48;
+constexpr int BUFFER_FRAMES = 96;
 constexpr uint32_t RAM_SIZE = 1024 * 1024;        // 1 MiB
 
 // DMA transfer size and rate constants

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -142,7 +142,7 @@
 
 #define MAX_OUTPUT 0x7fff
 //When you go over this create sample
-#define RATE_MAX ( 1 << 30)
+#define RATE_MAX ( 1 << 10)
 
 sn76496_base_device::sn76496_base_device(const machine_config &mconfig,
                                          device_type type,

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -67,6 +67,7 @@ libhardware = static_library('hardware', libhardware_sources,
                                png_dep,
                                sdl2_dep,
                                sdl2_net_dep,
+                               speexdsp_dep,
                                winsock2_dep,
                              ])
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -300,6 +300,9 @@ void MixerChannel::Mix(const int _needed)
 		auto left = needed - done;
 		left *= freq_add;
 		left  = (left >> FREQ_SHIFT) + ((left & FREQ_MASK)!=0);
+		if (left <= 0) // avoid underflow
+			break;
+		left = std::min(left, MIXER_BUFSIZE); // avoid overflow
 		handler(check_cast<uint16_t>(left));
 	}
 }

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -353,7 +353,7 @@ private:
 	IO_WriteHandleObject write_handler = {};
 	static constexpr auto clock_rate_hz = 4000000;
 	sn76496_device device;
-	static constexpr auto max_samples_expected = 64;
+	static constexpr auto max_samples_expected = 128;
 	int16_t buffer[1][max_samples_expected];
 	size_t last_write = 0;
 };

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -149,15 +149,18 @@ static void SN76496Update(uint16_t length)
 		tandy.chan->Enable(false);
 		return;
 	}
-	const Bitu MAX_SAMPLES = 2048;
-	if (length > MAX_SAMPLES)
-		return;
+	constexpr uint16_t MAX_SAMPLES = 2048;
 	Bit16s buffer[MAX_SAMPLES];
 	Bit16s* outputs = buffer;
 
 	device_sound_interface::sound_stream stream;
-	static_cast<device_sound_interface&>(device).sound_stream_update(stream, 0, &outputs, length);
-	tandy.chan->AddSamples_m16(length, buffer);
+
+	while (length) {
+		const auto n = std::min(MAX_SAMPLES, length);
+		static_cast<device_sound_interface &>(device).sound_stream_update(stream, 0, &outputs, n);
+		tandy.chan->AddSamples_m16(n, buffer);
+		length -= n;
+	}
 }
 
 bool TS_Get_Address(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma) {

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -387,7 +387,7 @@ public:
 			ReadHandler[1].Install(0xc4, TandyDACRead, io_width_t::byte, 4);
 
 			tandy.dac.enabled=true;
-			tandy.dac.chan = MIXER_AddChannel(&TandyDACUpdate, sample_rate, "TANDYDAC");
+			tandy.dac.chan = MIXER_AddChannel(&TandyDACUpdate, 0, "TANDYDAC");
 
 			tandy.dac.hw.base=0xc4;
 			tandy.dac.hw.irq =7;


### PR DESCRIPTION
This PR runs the Tandy SN76496 FM chip at one of two carefully selected sampling rates to avoid high-frequency harmonics.
 - One of the sampling rates (37286 Hz) is compatible with existing mixer rates.
 - The higher-quality sampling rate (74573 Hz) needs the mixer running at 96 kHz to accommodate the data rate.

Because both rates are pre-computed, we can finally get rid of the `tandyrate` conf setting.  The Tandy's DAC, which is a separate audio channel, now runs at the mixer's native rate - so it also no longer depends on `tandyrate`. 

To test this, use:

```
[dosbox]
machine = tandy
# or PCjr

[mixer]
rate = 96000
# or rate = 48000, or others too

[speaker]
pcspeaker = false
tandy = on
disney = off
```

---

## Jumpman

https://user-images.githubusercontent.com/1557255/150920561-4bf1177a-4e06-4c48-9817-e80ea88a9e9d.mp4

PC hardware: https://www.youtube.com/watch?v=NMIBvnX-Hwc (couldn't find a Tandy rendition)

---

## Skate or Die
(Ron Hubbard's intro track shreds the Tandy!)

https://user-images.githubusercontent.com/1557255/150924714-0f22118c-8af8-44ad-9c35-70ab60fba4d1.mp4

Tandy hardware: https://www.youtube.com/watch?v=daaZL_BuhnE
