### PR TITLE
Fix S

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -1,0 +1,224 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_BITOPS_H
+#define DOSBOX_BITOPS_H
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+// An enum and functions to help with bit operations
+// Works with any unisigned integer type up to 32-bits
+// (Extending to 64-bits is currently not needed)
+//
+// Examples
+// ~~~~~~~~
+// uint8_t reg = 0;
+//
+// Setting:
+//   set_bits(reg, bit_0 | bit_1); // 0b0000'0011
+//   set_bits(reg, bit_8); // ASSERT FAIL (out of range)
+//   set_all_bits(reg); // 0b1111'1111
+//
+// Toggling:
+//   toggle_bits(reg, bit_4 | bit_5 | bit_6 | bit_7); // 0b0000'1111
+//   toggle_bits(reg, bit_8); // ASSERT FAIL (out of range)
+//   toggle_all_bits(reg); //  0b1111'0000
+//
+// Clearing:
+//   clear_bits(reg, bit_4 | bit_5); // 0b1100'0000
+//   clear_bits(reg, bit_8); // ASSERT FAIL (out of range)
+//
+// Checking:
+//   are_bits_set(reg, bit_6); // true
+//   are_bits_set(reg, bit_7); // true
+//   are_bits_set(reg, bit_8); // ASSERT FAIL (out of range)
+//   are_bits_set(reg, bit_6 | bit_7); // true (both need to be set)
+//   are_bits_set(reg, bit_5 | bit_6); // false (both aren't set)
+//   are_any_bits_set(reg, bit_5 | bit_6); // true (bit 6 is)
+//   are_bits_cleared(reg, bit_0 | bit_1 | bit_2 | bit_3); // true
+//
+
+enum BITS {
+	bit_0 = 1 << 0,
+	bit_1 = 1 << 1,
+	bit_2 = 1 << 2,
+	bit_3 = 1 << 3,
+	bit_4 = 1 << 4,
+	bit_5 = 1 << 5,
+	bit_6 = 1 << 6,
+	bit_7 = 1 << 7,
+	bit_8 = 1 << 8,
+	bit_9 = 1 << 9,
+	bit_10 = 1 << 10,
+	bit_11 = 1 << 11,
+	bit_12 = 1 << 12,
+	bit_13 = 1 << 13,
+	bit_14 = 1 << 14,
+	bit_15 = 1 << 15,
+	bit_16 = 1 << 16,
+	bit_17 = 1 << 17,
+	bit_18 = 1 << 18,
+	bit_19 = 1 << 19,
+	bit_20 = 1 << 20,
+	bit_21 = 1 << 21,
+	bit_22 = 1 << 22,
+	bit_23 = 1 << 23,
+	bit_24 = 1 << 24,
+	bit_25 = 1 << 25,
+	bit_26 = 1 << 26,
+	bit_27 = 1 << 27,
+	bit_28 = 1 << 28,
+	bit_29 = 1 << 29,
+	bit_30 = 1 << 30,
+	bit_31 = 1 << 31
+};
+
+// Is the bitmask within the maximum value of the register?
+template <typename T>
+static constexpr void validate_bit_width([[maybe_unused]] const T reg, const int bits)
+{
+	// ensure the register is unsigned
+	static_assert(std::is_unsigned<T>::value, "register must be unsigned");
+
+	// Ensure the bits fall within the type size
+	assert(static_cast<uint64_t>(bits) > 0);
+	assert(static_cast<int64_t>(bits) <=
+	       static_cast<int64_t>(std::numeric_limits<T>::max()));
+}
+
+// Set the indicated bits
+template <typename T>
+constexpr T set_bits_const(const T reg, const int bits)
+{
+	validate_bit_width(reg, bits);
+	return reg | static_cast<T>(bits);
+}
+template <typename T>
+constexpr void set_bits(T &reg, const int bits)
+{
+	reg = set_bits_const(reg, bits);
+}
+
+// Set all of the register's bits high
+//
+// It's often seen in code like this:
+//    unsigned long int flags = ~0; // [1]
+//    unsigned long int flags = 0xffffffff; // [2]
+//
+// But:
+//   [1] isn't portable because it relies on a two's-complement representation.
+//   [2] isn't portable because it assumes 32-bit ints.
+//
+// This function becomes self-documenting: it tells the reader that we intend to
+// use the bits in the register as opposed to being a plain old number or
+// counter.
+//
+template <typename T>
+constexpr T all_bits_set()
+{
+	return std::is_signed<T>::value ? static_cast<T>(-1)
+	                                : std::numeric_limits<T>::max();
+}
+template <typename T>
+constexpr void set_all_bits(T &reg)
+{
+	reg = all_bits_set<T>();
+}
+
+// Clear the indicated bits
+template <typename T>
+constexpr T clear_bits_const(const T reg, const int bits)
+{
+	validate_bit_width(reg, bits);
+	return reg & ~static_cast<T>(bits);
+}
+template <typename T>
+constexpr void clear_bits(T &reg, const int bits)
+{
+	reg = clear_bits_const(reg, bits);
+}
+
+// Set the indicated bits to the given bool value
+template <typename T>
+constexpr T set_bits_const_to(const T reg, const int bits, const bool value)
+{
+	validate_bit_width(reg, bits);
+	return value ? set_bits_const(reg, bits) : clear_bits_const(reg, bits);
+}
+template <typename T>
+constexpr void set_bits_to(T &reg, const int bits, const bool value)
+{
+	reg = set_bits_const_to(reg, bits, value);
+}
+
+// Toggle the indicated bits
+template <typename T>
+constexpr T toggle_bits_const(const T reg, const int bits)
+{
+	validate_bit_width(reg, bits);
+	return reg ^ static_cast<T>(bits);
+}
+template <typename T>
+constexpr void toggle_bits(T &reg, const int bits)
+{
+	reg = toggle_bits_const(reg, bits);
+}
+
+// Toggle all the bits in the register
+template <typename T>
+constexpr T toggle_all_bits_const(const T reg)
+{
+	return reg ^ all_bits_set<T>();
+}
+template <typename T>
+constexpr void toggle_all_bits(T &reg)
+{
+	reg = toggle_all_bits_const(reg);
+}
+
+// Check if the indicated bits are set
+template <typename T>
+constexpr bool are_bits_set(const T reg, const int bits)
+{
+	validate_bit_width(reg, bits);
+	return (reg & static_cast<T>(bits)) == static_cast<T>(bits);
+}
+
+// Check if any one of the indicated bits are set
+template <typename T>
+constexpr bool are_any_bits_set(const T reg, const int bits)
+{
+	validate_bit_width(reg, bits);
+	return reg & static_cast<T>(bits);
+}
+
+// Check if the indicated bits are cleared (not set)
+template <typename T>
+constexpr bool are_bits_cleared(const T reg, const int bits)
+{
+	validate_bit_width(reg, bits);
+	return (reg & static_cast<T>(bits)) == 0;
+}
+
+// close the header
+#endif

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -55,15 +55,6 @@ class Config;
 using config_ptr_t = std::unique_ptr<Config>;
 extern config_ptr_t control;
 
-enum MachineType {
-	MCH_HERC,
-	MCH_CGA,
-	MCH_TANDY,
-	MCH_PCJR,
-	MCH_EGA,
-	MCH_VGA
-};
-
 enum SVGACards {
 	SVGA_None,
 	SVGA_S3Trio,
@@ -73,9 +64,23 @@ enum SVGACards {
 }; 
 
 extern SVGACards svgaCard;
-extern MachineType machine;
 extern bool mono_cga;
 
+enum MachineType {
+	// In age-order: Hercules is the oldest and VGA is the newest
+	MCH_HERC  = 1 << 0,
+	MCH_CGA   = 1 << 1,
+	MCH_TANDY = 1 << 2,
+	MCH_PCJR  = 1 << 3,
+	MCH_EGA   = 1 << 4,
+	MCH_VGA   = 1 << 5,
+};
+
+extern MachineType machine;
+
+inline bool is_machine(const int type) {
+	return machine & type;
+}
 #define IS_TANDY_ARCH ((machine==MCH_TANDY) || (machine==MCH_PCJR))
 #define IS_EGAVGA_ARCH ((machine==MCH_EGA) || (machine==MCH_VGA))
 #define IS_VGA_ARCH (machine==MCH_VGA)

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -173,18 +173,29 @@ static void write_p60(io_port_t, io_val_t value, io_width_t)
 	}
 }
 
-extern bool TIMER_GetOutput2(void);
-static Bit8u port_61_data = 0;
-static uint8_t read_p61(io_port_t, io_width_t)
-{
-	if (TIMER_GetOutput2())
-		port_61_data |= 0x20;
-	else
-		port_61_data &= ~0x20;
-	port_61_data ^= 0x10;
-	return port_61_data;
-}
+/* Bochs: 8255 Programmable Peripheral Interface
 
+0061	w	KB controller port B (ISA, EISA)   (PS/2 port A is at 0092)
+system control port for compatibility with 8255
+bit 7      (1= IRQ 0 reset )
+bit 6-4    reserved
+bit 3 = 1  channel check enable
+bit 2 = 1  parity check enable
+bit 1 = 1  speaker data enable
+bit 0 = 1  timer 2 gate to speaker enable
+
+0061	w	PPI  Programmable Peripheral Interface 8255 (XT only)
+system control port
+bit 7 = 1  clear keyboard
+bit 6 = 0  hold keyboard clock low
+bit 5 = 0  I/O check enable
+bit 4 = 0  RAM parity check enable
+bit 3 = 0  read low switches
+bit 2      reserved, often used as turbo switch
+bit 1 = 1  speaker data enable
+bit 0 = 1  timer 2 gate to speaker enable
+*/
+static Bit8u port_61_data = 0;
 extern void TIMER_SetGate2(bool);
 static void write_p61(io_port_t, io_val_t value, io_width_t)
 {
@@ -196,6 +207,41 @@ static void write_p61(io_port_t, io_val_t value, io_width_t)
 	port_61_data = val;
 }
 
+/* Bochs: 8255 Programmable Peripheral Interface
+
+0061	r	KB controller port B control register (ISA, EISA)
+system control port for compatibility with 8255
+bit 7    parity check occurred
+bit 6    channel check occurred
+bit 5    mirrors timer 2 output condition
+bit 4    toggles with each refresh request
+bit 3    channel check status
+bit 2    parity check status
+bit 1    speaker data status
+bit 0    timer 2 gate to speaker status
+*/
+extern bool TIMER_GetOutput2(void);
+static uint8_t read_p61(io_port_t, io_width_t)
+{
+	if (TIMER_GetOutput2())
+		port_61_data |= 0x20;
+	else
+		port_61_data &= ~0x20;
+	port_61_data ^= 0x10;
+	return port_61_data;
+}
+
+/* Bochs: 8255 Programmable Peripheral Interface
+0062	r/w	PPI (XT only)
+bit 7 = 1  RAM parity check
+bit 6 = 1  I/O channel check
+bit 5 = 1  timer 2 channel out
+bit 4      reserved
+bit 3 = 1  system board RAM size type 1
+bit 2 = 1  system board RAM size type 2
+bit 1 = 1  coprocessor installed
+bit 0 = 1  loop in POST
+*/
 static uint8_t read_p62(io_port_t, io_width_t)
 {
 	Bit8u ret = ~0x20;

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -255,8 +255,11 @@ bit 0 = 1  loop in POST
 */
 static uint8_t read_p62(io_port_t, io_width_t)
 {
-	Bit8u ret = ~0x20;
-	if (TIMER_GetOutput2()) ret |= 0x20;
+	auto ret = all_bits_set<uint8_t>();
+
+	if(!TIMER_GetOutput2())
+		clear_bits(ret, bit_5);
+
 	return ret;
 }
 

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -16,9 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
 #include "keyboard.h"
+
+#include "bitops.h"
 #include "inout.h"
 #include "pic.h"
 #include "mem.h"
@@ -200,6 +201,11 @@ extern void TIMER_SetGate2(bool);
 static void write_p61(io_port_t, io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
+
+	// Clear the keyboard buffer on XT
+	if (machine < MCH_EGA && are_bits_set(val, bit_7))
+		KEYBOARD_ClrBuffer();
+
 	if ((port_61_data ^ val) & 3) {
 		if ((port_61_data ^ val) & 1) TIMER_SetGate2(val&0x1);
 		PCSPEAKER_SetType(val & 3);

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -229,11 +229,16 @@ bit 0    timer 2 gate to speaker status
 extern bool TIMER_GetOutput2(void);
 static uint8_t read_p61(io_port_t, io_width_t)
 {
-	if (TIMER_GetOutput2())
-		port_61_data |= 0x20;
+	// Bit 4 must be toggled each request
+	toggle_bits(port_61_data, bit_4);
+
+	// On PC/AT systems, bit 5 sets the timer 2 output status
+	if (is_machine(MCH_EGA | MCH_VGA))
+		set_bits_to(port_61_data, bit_5, TIMER_GetOutput2());
 	else
-		port_61_data &= ~0x20;
-	port_61_data ^= 0x10;
+		// On XT systems always toggle bit 5 (Spellicopter CGA)
+		toggle_bits(port_61_data, bit_5);
+
 	return port_61_data;
 }
 

--- a/tests/bitops_tests.cpp
+++ b/tests/bitops_tests.cpp
@@ -1,0 +1,282 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "bitops.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(bitops, enum_vals)
+{
+	// check against bit-shifts
+	EXPECT_FALSE(bit_0 == 0 << 0);
+	EXPECT_TRUE(bit_0 == 1 << 0); // this is why
+	EXPECT_FALSE(bit_0 == 1 << 1);
+
+	EXPECT_FALSE(bit_5 == 1 << 4);
+	EXPECT_TRUE(bit_5 == 1 << 5); // industry prefers
+	EXPECT_FALSE(bit_5 == 1 << 6);
+
+	EXPECT_FALSE(bit_12 == 1 << 11);
+	EXPECT_TRUE(bit_12 == 1 << 12); // zero-based bit names
+	EXPECT_FALSE(bit_12 == 1 << 13);
+
+	EXPECT_FALSE(bit_22 == 1 << 21);
+	EXPECT_TRUE(bit_22 == 1 << 22); // and not one-based
+	EXPECT_FALSE(bit_22 == 1 << 23);
+
+	EXPECT_FALSE(bit_31 == 1 << 30);
+	EXPECT_TRUE(bit_31 == 1 << 31);
+
+	// check against bit literals
+	EXPECT_TRUE(bit_0 == 0b1);
+	EXPECT_TRUE(bit_5 == 0b100000);
+	EXPECT_TRUE(bit_12 == 0b1000000000000);
+	EXPECT_TRUE(bit_22 == 0b10000000000000000000000);
+	EXPECT_TRUE(static_cast<uint32_t>(bit_14 | bit_22 | bit_31) ==
+	            0b10000000010000000100000000000000);
+
+	// check against magic numbers
+	EXPECT_TRUE(bit_0 == 1);
+	EXPECT_TRUE(bit_5 == 32);
+	EXPECT_TRUE(bit_12 == 4096);
+	EXPECT_TRUE(bit_22 == 4194304);
+	EXPECT_TRUE(static_cast<uint32_t>(bit_14 | bit_22 | bit_31) == 2151694336);
+
+	// check some combos
+	EXPECT_FALSE((bit_4 | bit_5) == 0b1'1000);
+	EXPECT_TRUE((bit_4 | bit_5) == 0b11'0000);
+	EXPECT_FALSE((bit_4 | bit_5) == 0b110'0000);
+}
+
+TEST(bitops, nominal_byte)
+{
+	const auto even_bits = bit_0 | bit_2 | bit_4 | bit_6;
+	const auto odd_bits = bit_1 | bit_3 | bit_5 | bit_7;
+
+	uint8_t reg = 0;
+	set_bits(reg, odd_bits);
+	EXPECT_EQ(reg, 0b10101010);
+
+	set_bits(reg, even_bits);
+	EXPECT_EQ(reg, 0b11111111);
+
+	EXPECT_TRUE(are_bits_set(reg, bit_0));
+	EXPECT_TRUE(are_bits_set(reg, bit_3));
+	EXPECT_TRUE(are_bits_set(reg, bit_7));
+	EXPECT_TRUE(are_bits_set(reg, even_bits));
+	EXPECT_TRUE(are_bits_set(reg, odd_bits));
+
+	EXPECT_FALSE(are_bits_cleared(reg, bit_0));
+	EXPECT_FALSE(are_bits_cleared(reg, bit_3));
+	EXPECT_FALSE(are_bits_cleared(reg, bit_7));
+	EXPECT_FALSE(are_bits_cleared(reg, even_bits));
+	EXPECT_FALSE(are_bits_cleared(reg, odd_bits));
+
+	clear_bits(reg, odd_bits); // odd-off, even-on
+	EXPECT_EQ(reg, even_bits);
+	EXPECT_TRUE(are_bits_set(reg, even_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, odd_bits));
+
+	toggle_bits(reg, odd_bits); // both are on
+	EXPECT_TRUE(are_bits_set(reg, (odd_bits | even_bits)));
+	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+
+	toggle_bits(reg, even_bits); // odd-on, even-off
+	EXPECT_TRUE(are_bits_set(reg, odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, even_bits));
+
+	toggle_bits(reg, even_bits | odd_bits); // odd-off, even-on
+	EXPECT_EQ(reg, even_bits);
+
+	// set all bits
+	set_all_bits(reg);
+	EXPECT_EQ(reg, 0b1111'1111);
+	EXPECT_TRUE(are_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+
+	// toggle all bits
+	toggle_all_bits(reg);
+	EXPECT_EQ(reg, 0b0000'0000);
+	EXPECT_FALSE(are_bits_set(reg, even_bits | odd_bits));
+	EXPECT_FALSE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, (odd_bits | even_bits)));
+}
+
+TEST(bitops, nominal_word)
+{
+	const auto even_bits = bit_8 | bit_10 | bit_12 | bit_14;
+	const auto odd_bits = bit_9 | bit_11 | bit_13 | bit_15;
+
+	uint16_t reg = 0;
+	set_bits(reg, odd_bits);
+	EXPECT_EQ(reg, 0b10101010'00000000);
+
+	set_bits(reg, even_bits);
+	EXPECT_EQ(reg, 0b11111111'00000000);
+
+	EXPECT_FALSE(are_bits_cleared(reg, bit_8));
+	EXPECT_FALSE(are_bits_cleared(reg, bit_12));
+	EXPECT_FALSE(are_bits_cleared(reg, bit_15));
+	EXPECT_FALSE(are_bits_cleared(reg, even_bits));
+	EXPECT_FALSE(are_bits_cleared(reg, odd_bits));
+
+	clear_bits(reg, odd_bits); // odd-off, even-on
+	EXPECT_EQ(reg, even_bits);
+	EXPECT_TRUE(are_bits_set(reg, even_bits));
+	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, odd_bits));
+
+	toggle_bits(reg, odd_bits); // both are on
+	EXPECT_TRUE(are_bits_set(reg, (odd_bits | even_bits)));
+	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+
+	toggle_bits(reg, even_bits); // odd-on, even-off
+	EXPECT_TRUE(are_bits_set(reg, odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, even_bits));
+
+	toggle_bits(reg, even_bits | odd_bits); // odd-off, even-on
+	EXPECT_EQ(reg, even_bits);
+
+	// set all bits
+	set_all_bits(reg);
+	EXPECT_EQ(reg, 0b11111111'11111111);
+	EXPECT_TRUE(are_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+
+	// toggle all bits
+	toggle_all_bits(reg);
+	EXPECT_EQ(reg, 0b00000000'00000000);
+	EXPECT_FALSE(are_bits_set(reg, even_bits | odd_bits));
+	EXPECT_FALSE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, (odd_bits | even_bits)));
+}
+
+TEST(bitops, nominal_dword)
+{
+	const auto even_bits = bit_16 | bit_18 | bit_20 | bit_22 | bit_24 |
+	                       bit_26 | bit_28 | bit_30;
+	const auto odd_bits = bit_17 | bit_19 | bit_21 | bit_23 | bit_25 |
+	                      bit_27 | bit_29 | bit_31;
+
+	uint32_t reg = 0;
+
+	set_bits(reg, even_bits);
+	EXPECT_EQ(reg, 0b01010101'01010101'00000000'00000000);
+
+	set_bits(reg, odd_bits);
+	EXPECT_EQ(reg, 0b11111111'11111111'00000000'00000000);
+
+	EXPECT_FALSE(are_bits_cleared(reg, bit_16));
+	EXPECT_FALSE(are_bits_cleared(reg, bit_24));
+	EXPECT_FALSE(are_bits_cleared(reg, bit_31));
+	EXPECT_FALSE(are_bits_cleared(reg, even_bits));
+	EXPECT_FALSE(are_bits_cleared(reg, odd_bits));
+
+	clear_bits(reg, odd_bits); // odd-off, even-on
+	EXPECT_EQ(reg, even_bits);
+	EXPECT_TRUE(are_bits_set(reg, even_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, odd_bits));
+
+	toggle_bits(reg, odd_bits); // both are on
+	EXPECT_TRUE(are_bits_set(reg, (odd_bits | even_bits)));
+	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+
+	toggle_bits(reg, even_bits); // odd-on, even-off
+	EXPECT_TRUE(are_bits_set(reg, odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, even_bits));
+
+	toggle_bits(reg, even_bits | odd_bits); // odd-off, even-on
+	EXPECT_EQ(reg, even_bits);
+
+	// set all bits
+	set_all_bits(reg);
+	EXPECT_EQ(reg, 0b11111111'11111111'11111111'11111111);
+	EXPECT_TRUE(are_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_FALSE(are_bits_cleared(reg, (odd_bits | even_bits)));
+
+	// toggle all bits
+	toggle_all_bits(reg);
+	EXPECT_EQ(reg, 0b00000000'00000000'00000000'00000000);
+	EXPECT_FALSE(are_bits_set(reg, even_bits | odd_bits));
+	EXPECT_FALSE(are_any_bits_set(reg, even_bits | odd_bits));
+	EXPECT_TRUE(are_bits_cleared(reg, (odd_bits | even_bits)));
+}
+
+TEST(bitops, bits_too_wide_for_byte)
+{
+	uint8_t reg = 0;
+	set_bits(reg, bit_7);
+	EXPECT_TRUE(are_bits_set(reg, bit_7));
+	EXPECT_DEBUG_DEATH({ set_bits(reg, bit_8); }, "");
+	EXPECT_DEBUG_DEATH({ are_bits_set(reg, bit_8); }, "");
+
+	clear_bits(reg, bit_7);
+	EXPECT_TRUE(are_bits_cleared(reg, bit_7));
+	EXPECT_DEBUG_DEATH({ clear_bits(reg, bit_8); }, "");
+	EXPECT_DEBUG_DEATH({ are_bits_cleared(reg, bit_8); }, "");
+
+	toggle_bits(reg, bit_7);
+	EXPECT_TRUE(are_bits_set(reg, bit_7));
+	EXPECT_DEBUG_DEATH({ toggle_bits(reg, bit_8); }, "");
+}
+
+TEST(bitops, bits_too_wide_for_word)
+{
+	uint16_t reg = 0;
+	set_bits(reg, bit_8);
+	EXPECT_TRUE(are_bits_set(reg, bit_8));
+	EXPECT_DEBUG_DEATH({ set_bits(reg, bit_16); }, "");
+	EXPECT_DEBUG_DEATH({ are_bits_set(reg, bit_16); }, "");
+
+	clear_bits(reg, bit_8);
+	EXPECT_TRUE(are_bits_cleared(reg, bit_8));
+	EXPECT_DEBUG_DEATH({ clear_bits(reg, bit_16); }, "");
+	EXPECT_DEBUG_DEATH({ are_bits_cleared(reg, bit_16); }, "");
+
+	toggle_bits(reg, bit_8);
+	EXPECT_TRUE(are_bits_set(reg, bit_8));
+	EXPECT_DEBUG_DEATH({ toggle_bits(reg, bit_16); }, "");
+}
+
+TEST(bitops, bits_not_too_wide_for_dword)
+{
+	uint32_t reg = 0;
+	set_bits(reg, bit_8);
+	set_bits(reg, bit_24);
+	set_bits(reg, bit_31);
+	EXPECT_TRUE(are_bits_set(reg, (bit_8 | bit_24 | bit_31)));
+
+	clear_bits(reg, bit_8);
+	clear_bits(reg, bit_24);
+	clear_bits(reg, bit_31);
+	EXPECT_TRUE(are_bits_cleared(reg, (bit_8 | bit_24 | bit_31)));
+
+	toggle_bits(reg, bit_8);
+	toggle_bits(reg, bit_24);
+	toggle_bits(reg, bit_31);
+	EXPECT_TRUE(are_bits_set(reg, (bit_8 | bit_24 | bit_31)));
+}
+
+} // namespace

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -59,6 +59,7 @@ test('gtest fs_utils', fs_utils,
 # other unit tests
 
 unit_tests = [
+  {'name' : 'bitops',               'deps' : []},
   {'name' : 'iohandler_containers', 'deps' : [libmisc_dep]},
   {'name' : 'rwqueue',              'deps' : [libmisc_dep]},
   {'name' : 'soft_limiter',         'deps' : [atomic_dep, libmisc_dep]},

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -232,6 +232,7 @@ $(TargetPath)
     <ClCompile Include="..\..\src\libs\loguru\loguru.cpp" />
     <ClCompile Include="..\..\src\libs\whereami\whereami.c" />
     <ClCompile Include="..\ansi_code_markup_tests.cpp" />
+    <ClCompile Include="..\bitops_tests.cpp" />
     <ClCompile Include="..\fs_utils_tests.cpp" />
     <ClCompile Include="..\iohandler_containers_tests.cpp" />
     <ClCompile Include="..\rwqueue_tests.cpp" />

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -18,6 +18,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\bitops_tests.cpp">
+      <Filter>tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\fs_utils_tests.cpp">
       <Filter>tests</Filter>
     </ClCompile>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -461,6 +461,7 @@
     <ClInclude Include="..\include\ansi_code_markup.h" />
     <ClInclude Include="..\include\bios.h" />
     <ClInclude Include="..\include\bios_disk.h" />
+    <ClInclude Include="..\include\bitops.h" />
     <ClInclude Include="..\include\byteorder.h" />
     <ClInclude Include="..\include\callback.h" />
     <ClInclude Include="..\include\compiler.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -554,6 +554,9 @@
     <ClInclude Include="..\include\bios_disk.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\bitops.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\byteorder.h">
       <Filter>include</Filter>
     </ClInclude>


### PR DESCRIPTION
This reverts the 8255 PPI's port 61h read response to match that of DOSBox 0.74.x when in XT-mode.
This fixes Spellicopter (CGA) and continues to work as expected for all other tested CGA, Tandy, and PCjr games.

Thanks to @SmilingSpectre for reporting this!

``` ini
[sdl]
output = openglpp

[cpu]
cycles = 300

[render]
glshader = crt-easymode.tweaked.glsl
monochrome_palette = paperwhite

[dosbox]
machine = cga
# or cga_mono

[speaker]
pcspeaker   = true
```

![2022-01-25_10-50](https://user-images.githubusercontent.com/1557255/151040088-08268fab-d0a8-4508-99fc-e1d6e1b4ac06.png)

![2022-01-25_10-48](https://user-images.githubusercontent.com/1557255/151040092-cb5d3d26-6df4-4746-9434-33dde4e56d24.png)
