### PR TITLE
IMGMOUNT command to display current disk image status

### DIFF
--- a/include/drives.h
+++ b/include/drives.h
@@ -42,6 +42,7 @@ public:
 //	static void CycleDisk(bool pressed);
 	static void CycleDisks(int drive, bool notify);
 	static void CycleAllDisks(void);
+	static char *GetDrivePosition(int drive);
 	static void Init(Section* sec);
 	
 private:

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -49,11 +49,12 @@ extern Bit32u floppytype;
 void DOS_SetupPrograms(void)
 {
 	/*Add Messages */
-	MSG_Add("PROGRAM_IMGMOUNT_IDE_CONTROLLERS_UNAVAILABLE", "No available IDE controllers. Drive will not have IDE emulation.\n");
 	MSG_Add("PROGRAM_MOUNT_CDROMS_FOUND","CDROMs found: %d\n");
 	MSG_Add("PROGRAM_MOUNT_STATUS_DRIVE", "Drive");
 	MSG_Add("PROGRAM_MOUNT_STATUS_TYPE", "Type");
 	MSG_Add("PROGRAM_MOUNT_STATUS_LABEL", "Label");
+	MSG_Add("PROGRAM_MOUNT_STATUS_NAME", "Image name");
+	MSG_Add("PROGRAM_MOUNT_STATUS_SLOT", "Swap slot");
 	MSG_Add("PROGRAM_MOUNT_STATUS_2","Drive %c is mounted as %s\n");
 	MSG_Add("PROGRAM_MOUNT_STATUS_1", "The currently mounted drives are:\n");
 	MSG_Add("PROGRAM_MOUNT_ERROR_1","Directory %s doesn't exist.\n");
@@ -438,6 +439,8 @@ void DOS_SetupPrograms(void)
 #endif
 	);
 
+	MSG_Add("PROGRAM_IMGMOUNT_STATUS_1",
+	        "The currently mounted disk and CD image drives are:\n");
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_DRIVE",
 	        "Must specify drive letter to mount image at.\n");
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY2",
@@ -448,6 +451,10 @@ void DOS_SetupPrograms(void)
 		"For \033[33mhardrive\033[0m images: Must specify drive geometry for hard drives:\n"
 		"bytes_per_sector, sectors_per_cylinder, heads_per_cylinder, cylinder_count.\n"
 		"\033[34;1mIMGMOUNT drive-letter location-of-image -size bps,spc,hpc,cyl\033[0m\n");
+	MSG_Add("PROGRAM_IMGMOUNT_STATUS_NONE",
+		"No drive available\n");
+	MSG_Add("PROGRAM_IMGMOUNT_IDE_CONTROLLERS_UNAVAILABLE",
+		"No available IDE controllers. Drive will not have IDE emulation.\n");
 	MSG_Add("PROGRAM_IMGMOUNT_INVALID_IMAGE","Could not load image file.\n"
 		"Check that the path is correct and the image is accessible.\n");
 	MSG_Add("PROGRAM_IMGMOUNT_INVALID_GEOMETRY","Could not extract drive geometry from image.\n"

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -259,8 +259,8 @@ int DriveManager::UnmountDrive(int drive) {
 char *DriveManager::GetDrivePosition(int drive)
 {
 	static char swap_position[10];
-	sprintf(swap_position, "%d / %d", driveInfos[drive].currentDisk + 1,
-	        (int)driveInfos[drive].disks.size());
+	safe_sprintf(swap_position, "%d / %d", driveInfos[drive].currentDisk + 1,
+	             (int)driveInfos[drive].disks.size());
 	return swap_position;
 }
 

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -256,6 +256,14 @@ int DriveManager::UnmountDrive(int drive) {
 	return result;
 }
 
+char *DriveManager::GetDrivePosition(int drive)
+{
+	static char swap_position[10];
+	sprintf(swap_position, "%d / %d", driveInfos[drive].currentDisk + 1,
+	        (int)driveInfos[drive].disks.size());
+	return swap_position;
+}
+
 void DriveManager::Init(Section* /* sec */) {
 	
 	// setup driveInfos structure

--- a/src/dos/program_imgmount.h
+++ b/src/dos/program_imgmount.h
@@ -25,6 +25,7 @@
 
 class IMGMOUNT final : public Program {
     public:
+        void ListImgMounts(void);
         void Run(void);
 };
 

--- a/src/dos/program_imgmount.h
+++ b/src/dos/program_imgmount.h
@@ -25,8 +25,8 @@
 
 class IMGMOUNT final : public Program {
     public:
-        void ListImgMounts(void);
-        void Run(void);
+        void ListImgMounts();
+        void Run();
 };
 
 void IMGMOUNT_ProgramStart(Program **make);

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -88,23 +88,26 @@ void MOUNT::ListMounts()
 	const std::string header_label = MSG_Get("PROGRAM_MOUNT_STATUS_LABEL");
 
 	const int term_width = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
-	const auto width_1 = static_cast<int>(header_drive.size());
-	const auto width_3 = std::max(11, static_cast<int>(header_label.size()));
-	const auto width_2 = term_width - 3 - width_1 - width_3;
+	const auto width_drive = static_cast<int>(header_drive.length());
+	const auto width_label = std::max(minimum_column_length,
+	                                  static_cast<int>(header_label.size()));
+	const auto width_type = term_width - 3 - width_drive - width_label;
+	if (width_type < 0) {
+		LOG_WARNING("Message is too long.");
+		return;
+	}
 
-	auto print_row = [&](const std::string &txt_1,
-							const std::string &txt_2,
-							const std::string &txt_3) {
-		WriteOut("%-*s %-*s %-*s\n",
-					width_1, txt_1.c_str(),
-					width_2, txt_2.c_str(),
-					width_3, txt_3.c_str());
+	auto print_row = [&](const std::string &txt_drive, const std::string &txt_type,
+	                     const std::string &txt_label) {
+		WriteOut("%-*s %-*s %-*s\n", width_drive, txt_drive.c_str(),
+		         width_type, txt_type.c_str(), width_label,
+		         txt_label.c_str());
 	};
 
 	WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_1"));
 	print_row(header_drive, header_type, header_label);
-	for (int i = 0; i < term_width; i++)
-		WriteOut_NoParsing("-");
+	const std::string horizontal_divider(term_width, '-');
+	WriteOut_NoParsing(horizontal_divider.c_str());
 
 	for (uint8_t d = 0; d < DOS_DRIVES; d++) {
 		if (Drives[d]) {

--- a/src/dos/program_mount.h
+++ b/src/dos/program_mount.h
@@ -27,7 +27,7 @@ class MOUNT final : public Program {
     public:
         void Move_Z(char new_z);
         void ListMounts();
-        void Run(void);
+        void Run();
 };
 
 void MOUNT_ProgramStart(Program **make);

--- a/src/dos/program_mount_common.h
+++ b/src/dos/program_mount_common.h
@@ -31,6 +31,9 @@
 
 extern Bitu ZDRIVE_NUM;
 
+// The minimum length for columns where drives are listed
+constexpr int minimum_column_length = 11;
+
 const char *UnmountHelper(char umount);
 
 #endif // DOSBOX_PROGRAM_MOUNT_COMMON_H


### PR DESCRIPTION
This PR allows IMGMOUNT command (without parameters) to display the current status of disk and CD images, including the current disk names, labels, and swap slots (e.g. 2 / 3). The format is somewhat similar to MOUNT command without parameters, but with different information displayed to users. The PR helps solve issue #997.