### PR TITLE
Fix return code in FileOpen

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -574,7 +574,10 @@ bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb) {
 		Files[handle]=new DOS_Device(*Devices[devnum]);
 	} else {
 		exists=Drives[drive]->FileOpen(&Files[handle],fullname,flags);
-		if (exists) Files[handle]->SetDrive(drive);
+		if (exists)
+			Files[handle]->SetDrive(drive);
+		else if (dos.errorcode == DOSERR_ACCESS_CODE_INVALID)
+			return false;
 	}
 	if (exists || device ) { 
 		Files[handle]->AddRef();


### PR DESCRIPTION
There is a bug in the DOS_OpenFile function resulting incorrect error code to be returned, causing issue #1549. This PR fixes the return code bug so that the command ``tasm /o test.asm,test.obj`` will run as expected.