### PR TITLE
Fix a range-check typo in bit operations

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -114,7 +114,7 @@ static constexpr void check_width([[maybe_unused]] const T reg, const B bits)
 	static_assert(std::is_unsigned<T>::value, "register must be unsigned");
 
 	// Ensure the bits fall within the type size
-	assert(static_cast<uint64_t>(bits) > 0);
+	assert(static_cast<uint64_t>(bits) >= 0); // can't set negative bits
 
 	// Note: if you'd like to extend this to 64-bits, double check that the
 	//       assertions still work.  Their purpose is to catch when the bit


### PR DESCRIPTION
This fixes a typo in the bit operations valid range check. Fixes a false-positive assertion in debub builds:

![2022-02-10_23-30](https://user-images.githubusercontent.com/1557255/153552789-ecc469ea-28bf-4733-8431-98272a0b64c0.png)


