### PR TITLE
Avoid loading duplicate config files

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -29,6 +29,7 @@
 
 #include "programs.h"
 #include "setup.h"
+#include "std_filesystem.h"
 
 enum class Verbosity : int8_t {
 	//                     Splash | Welcome | Early Stdout |

--- a/include/control.h
+++ b/include/control.h
@@ -53,6 +53,7 @@ private:
 public:
 	std::vector<std::string> startup_params = {};
 	std::vector<std::string> configfiles = {};
+	std::vector<std_fs::path> configFilesCanonical = {};
 
 	Config(CommandLine *cmd)
 	        : cmdline(cmd),

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -989,11 +989,17 @@ bool Config::ParseConfigFile(const std::string &type, const std::string &configf
 	if (ec)
 		return false;
 	
+	if (contains(configFilesCanonical, canonical_path)) {
+		LOG_INFO("CONFIG: Skipping duplicate config file '%s'", 
+			configfilename.c_str());
+		return true;
+	}
 	// static bool first_configfile = true;
 	ifstream in(canonical_path);
 	if (!in)
 		return false;
 	configfiles.push_back(configfilename);
+	configFilesCanonical.push_back(canonical_path);
 
 	// Get directory from configfilename, used with relative paths.
 	current_config_dir = canonical_path.parent_path().string();

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -983,18 +983,20 @@ const Section_line &Config::GetOverwrittenAutoexecSection() const
 
 bool Config::ParseConfigFile(const std::string &type, const std::string &configfilename)
 {
+	std::error_code ec;
+	const std_fs::path cfg_path = configfilename;
+	const auto canonical_path = std_fs::canonical(cfg_path, ec);
+	if (ec)
+		return false;
+	
 	// static bool first_configfile = true;
-	ifstream in(configfilename);
+	ifstream in(canonical_path);
 	if (!in)
 		return false;
 	configfiles.push_back(configfilename);
 
 	// Get directory from configfilename, used with relative paths.
-	current_config_dir = configfilename;
-	auto split_pos = current_config_dir.rfind(CROSS_FILESPLIT);
-	if (split_pos == std::string::npos)
-		split_pos = 0; // No directory then erase string
-	current_config_dir.erase(split_pos);
+	current_config_dir = canonical_path.parent_path().string();
 
 	string gegevens;
 	Section *currentsection = nullptr;


### PR DESCRIPTION
This PR refactors `Config::ParseConfigFile()` to use `std::filesystem`, and prevents loading the same config file multiple times. It should resolve #1562 

Tested on Windows 10. Probably needs testing on other platforms.