### PR TITLE
Assure gtest and gmock in the same version

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,18 +16,34 @@ gtest_dep = optional_dep
 gmock_dep = optional_dep
 
 if not (get_option('buildtype') == 'release' and get_option('unit_tests').auto())
-  gtest_dep = dependency('gtest', main : true,
-                         required : get_option('unit_tests'),
-                         fallback : ['gtest', 'gtest_main_dep'])
+  gtest_system_dep = dependency('gtest', main : true,
+                                required : get_option('unit_tests'))
+  gmock_system_dep = dependency('gmock', main : true,
+                                required : get_option('unit_tests'))
 
-  gmock_dep = dependency('gmock', main : true,
-                         required : get_option('unit_tests'),
-                         fallback : ['gtest', 'gmock_dep'])
+  # GTest and GMock are closely coupled together, we must use them in exactly
+  # the same version.  We can't allow situation when one of packages is
+  # system-installed and another one is used from meson subproject.
+  #
+  if (gmock_system_dep.found() and gtest_system_dep.found())
+    gtest_dep = gtest_system_dep
+    gmock_dep = gmock_system_dep
+  else
+    message('GTest or GMock is not installed, using fallback for both dependencies')
+    gtest_dep = dependency('', main : true,
+                           required : get_option('unit_tests'),
+                           fallback : ['gtest', 'gtest_main_dep'])
+    gmock_dep = dependency('', main : true,
+                           required : get_option('unit_tests'),
+                           fallback : ['gtest', 'gmock_dep'])
+  endif
 endif
-if not (gtest_dep.found() or gmock_dep.found())
+if not (gtest_dep.found() and gmock_dep.found())
   gtest_dep = disabler()
   gmock_dep = disabler()
 endif
+
+summary('Unit tests', gtest_dep.found() and gmock_dep.found())
 
 # Disable compiler flags that generate warnings
 # from deliberately flawed unit test code.


### PR DESCRIPTION
Prevent situation when one of these dependencies is pulled from OS
repository and another one is pulled via Meson wrap.

When gtest and gmock are incompatible, it might result in compilation
issues, or even worse: false negative test results.

*I hit this issue while having gtest-devel installed and gmock-devel missing - meson setup succeeded but initially I got compilation issues, and after cleaning subprojects dir - the compilation isses turned into failing testcases. Keeping gtest and gmock in sync should prevent this from ever happening again.*
