### PR TITLE
Fix Visual Studio Dosbox project filters

### DIFF
--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -541,8 +541,9 @@
     <ClCompile Include="..\src\libs\whereami\whereami.c">
       <Filter>src\libs\whereami</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp" />
+    <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp">
       <Filter>src\libs\ghc</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\misc\ansi_code_markup.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>


### PR DESCRIPTION
@LowLevelMahn noticed that the Dosbox Visual Studio project isn't filtering files into "directories" in the solution explorer.

After a brief git bisect session, I put my hand up in apology, because I'm the one who broke it.

The problem was a `ClCompile` element improperly closed, likely due to a copy/paste mishap.