### PR TITLE
Improve the bit operations compile-time checks and fix the `*_to` argument ordering

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -208,16 +208,17 @@ constexpr void clear(T &reg, const int bits)
 }
 
 // Set the indicated bits to the given bool value
-template <typename T>
-constexpr T mask_to(const T reg, const bool value, const int bits)
+template <typename T, typename S>
+constexpr T mask_to(const T reg, const int bits, const S state)
 {
+	check_state_type<S>();
 	check_width(reg, bits);
-	return value ? mask_on(reg, bits) : mask_off(reg, bits);
+	return state ? mask_on(reg, bits) : mask_off(reg, bits);
 }
-template <typename T>
-constexpr void set_to(T &reg, const bool value, const int bits)
+template <typename T, typename S>
+constexpr void set_to(T &reg, const int bits, const S state)
 {
-	reg = mask_to(reg, value, bits);
+	reg = mask_to(reg, bits, state);
 }
 
 // flip the indicated bits

--- a/tests/bitops_tests.cpp
+++ b/tests/bitops_tests.cpp
@@ -289,8 +289,8 @@ TEST(bitops, masking)
 
 	EXPECT_TRUE(is(mask_on(reg, b4), b4));
 	EXPECT_TRUE(cleared(mask_off(reg, b4), b4));
-	EXPECT_TRUE(any(mask_to(reg, true, b4), b4));
-	EXPECT_TRUE(cleared(mask_to(reg, false, b4), b4));
+	EXPECT_TRUE(any(mask_to(reg, b4, true), b4));
+	EXPECT_TRUE(cleared(mask_to(reg, b4, false), b4));
 	EXPECT_TRUE(any(mask_flip(reg, b4), b4));
 	EXPECT_TRUE(is(mask_flip_all(reg), b4));
 }


### PR DESCRIPTION
The `mask_to` and `set_to` functions take in a register, the desired bit(s) being "set to", and the boolean state to apply to those bit(s). Prior to this PR, the bit(s) and the boolean state value were swapped.

Even though the bit(s) are an `int` type and the state is a `bool` type,  C/C++ lets the two types act as one-another. So this PR adds more compile-time assertion to catch these type-mistakes as well.