### PR TITLE
Revert "Assure gtest and gmock in the same version"

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,34 +16,18 @@ gtest_dep = optional_dep
 gmock_dep = optional_dep
 
 if not (get_option('buildtype') == 'release' and get_option('unit_tests').auto())
-  gtest_system_dep = dependency('gtest', main : true,
-                                required : get_option('unit_tests'))
-  gmock_system_dep = dependency('gmock', main : true,
-                                required : get_option('unit_tests'))
+  gtest_dep = dependency('gtest', main : true,
+                         required : get_option('unit_tests'),
+                         fallback : ['gtest', 'gtest_main_dep'])
 
-  # GTest and GMock are closely coupled together, we must use them in exactly
-  # the same version.  We can't allow situation when one of packages is
-  # system-installed and another one is used from meson subproject.
-  #
-  if (gmock_system_dep.found() and gtest_system_dep.found())
-    gtest_dep = gtest_system_dep
-    gmock_dep = gmock_system_dep
-  else
-    message('GTest or GMock is not installed, using fallback for both dependencies')
-    gtest_dep = dependency('', main : true,
-                           required : get_option('unit_tests'),
-                           fallback : ['gtest', 'gtest_main_dep'])
-    gmock_dep = dependency('', main : true,
-                           required : get_option('unit_tests'),
-                           fallback : ['gtest', 'gmock_dep'])
-  endif
+  gmock_dep = dependency('gmock', main : true,
+                         required : get_option('unit_tests'),
+                         fallback : ['gtest', 'gmock_dep'])
 endif
-if not (gtest_dep.found() and gmock_dep.found())
+if not (gtest_dep.found() or gmock_dep.found())
   gtest_dep = disabler()
   gmock_dep = disabler()
 endif
-
-summary('Unit tests', gtest_dep.found() and gmock_dep.found())
 
 # Disable compiler flags that generate warnings
 # from deliberately flawed unit test code.


### PR DESCRIPTION
This reverts commit 15e106100fdf3a29c1e74ea0635f51164e4710b1.

My local gtest/gmock tests broke after I `rm -rf build` and `git clean -fdx`:

![2022-02-16_09-18](https://user-images.githubusercontent.com/1557255/154320687-6bb42de7-a4d9-4e78-ab7b-7ac6a48bfd7a.png)

Will revert this to get back to a working state, and the re-assess going w/ the gmock-only approach.