### PR TITLE
Bump the VC redistibutable package to version 14.31.31103

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -171,7 +171,7 @@ jobs:
           readonly VC_REDIST_VERSION="14.30.30704"
           readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
           export VC_REDIST_DIR="$VC_REDIST_BASE/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION"
-          find "$VC_REDIST_DIR" -maxdepth 3 -type d
+          find "$VC_REDIST_BASE" -maxdepth 3 -type d
 
           # Package
           ./scripts/create-package.sh \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           # Construct VC_REDIST_DIR
           readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
-          readonly VC_REDIST_VERSION="14.30.30704"
+          readonly VC_REDIST_VERSION="14.31.31103"
           readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
           export VC_REDIST_DIR="$VC_REDIST_BASE/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION"
           find "$VC_REDIST_BASE" -maxdepth 3 -type d


### PR DESCRIPTION
Microsoft pulled the prior version, 14.30.30704, so this moves us to the current version, releases as of last week: https://www.techspot.com/downloads/6776-visual-c-redistributable-package.html#certified

(This only affects the MSVC builds)

