### PR TITLE
Fortify sprintf usage in shell_cmds

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -672,7 +672,7 @@ char *format_time(const uint8_t hour,
                   bool full = false)
 {
 	uint8_t fhour = hour;
-	static char return_time_buffer[14] = {0};
+	static char return_time_buffer[19] = {0};
 	char ampm[3] = "";
 	char time_format = dos.tables.country[17];
 	if (!time_format) { // 12 hour notation?
@@ -685,13 +685,13 @@ char *format_time(const uint8_t hour,
 	const char time_separator = dos.tables.country[13];
 	const char decimal_separator = dos.tables.country[9];
 	if (full) // Example full time format: 1:02:03.04am
-		sprintf(return_time_buffer, "%u%c%02u%c%02u%c%02u%s",
-		        (unsigned int)hour, time_separator, (unsigned int)min,
-		        time_separator, (unsigned int)sec, decimal_separator,
-		        (unsigned int)msec, ampm);
+		safe_sprintf(return_time_buffer, "%u%c%02u%c%02u%c%02u%s",
+		             (unsigned int)hour, time_separator,
+		             (unsigned int)min, time_separator, (unsigned int)sec,
+		             decimal_separator, (unsigned int)msec, ampm);
 	else // Example short time format: 1:02p
-		sprintf(return_time_buffer, "%2u%c%02u%s", (unsigned int)hour,
-		        time_separator, (unsigned int)min, ampm);
+		safe_sprintf(return_time_buffer, "%2u%c%02u%s", (unsigned int)hour,
+		             time_separator, (unsigned int)min, ampm);
 	return return_time_buffer;
 }
 


### PR DESCRIPTION
When creating a release build, Linux distributions like to enable
additional GNU fortification flags to detect common vulnerabilities.

In this case this turns out to be false-positive (due to range of values
happening in date formatting), but compiler cannot know this.

Fixes following compiler warning on release build:
```
shell_cmds.cpp:688:48 warning: ‘%02u’ directive writing between 2 and
3 bytes into a region of size between 2 and 6 [-Wformat-overflow=]

stdio2.h:36:34: note: ‘__builtin___sprintf_chk’ output between 11 and
18 bytes into a destination of size 14
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```