### PR TITLE
Support for customization and directory on Z drive

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -336,6 +336,6 @@ void DOS_AddDevice(DOS_Device * adddev);
 /* DelDevice destroys the device that is pointed to. */
 void DOS_DelDevice(DOS_Device * dev);
 
-void VFILE_Register(const char * name,Bit8u * data,Bit32u size);
+void VFILE_Register(const char *name, uint8_t *data, const uint32_t size, const char *dir = "");
 
 #endif

--- a/include/drives.h
+++ b/include/drives.h
@@ -31,6 +31,9 @@
 
 void Set_Label(char const * const input, char * const output, bool cdrom);
 std::string To_Label(const char* name);
+void generate_8x3(char *lfn, unsigned int k, unsigned int &i, unsigned int &t);
+bool filename_not_8x3(const char *n);
+bool filename_not_strict_8x3(const char *n);
 
 class DriveManager {
 public:
@@ -400,7 +403,7 @@ public:
 	bool FileExists(const char* name);
 	bool FileStat(const char* name, FileStat_Block* const stat_block);
 	Bit8u GetMediaByte(void);
-	void EmptyCache(void){}
+	void EmptyCache(void);
 	bool isRemote(void);
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);

--- a/include/drives.h
+++ b/include/drives.h
@@ -34,6 +34,8 @@ std::string To_Label(const char* name);
 std::string generate_8x3(const char *lfn, const unsigned int num, const bool start = false);
 bool filename_not_8x3(const char *n);
 bool filename_not_strict_8x3(const char *n);
+char *VFILE_Generate_8x3(const char *name, const unsigned int onpos);
+void VFILE_Register(const char *name, uint8_t *data, const uint32_t size, const char *dir);
 
 class DriveManager {
 public:
@@ -402,12 +404,12 @@ public:
 	bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	bool FileExists(const char* name);
 	bool FileStat(const char* name, FileStat_Block* const stat_block);
-	Bit8u GetMediaByte(void);
-	void EmptyCache(void);
-	bool isRemote(void);
-	virtual bool isRemovable(void);
-	virtual Bits UnMount(void);
-	virtual char const* GetLabel(void);
+	Bit8u GetMediaByte();
+	void EmptyCache();
+	bool isRemote();
+	virtual bool isRemovable();
+	virtual Bits UnMount();
+	virtual char const* GetLabel();
 private:
 	Virtual_Drive(const Virtual_Drive&); // prevent copying
 	Virtual_Drive& operator= (const Virtual_Drive&); // prevent assignment

--- a/include/drives.h
+++ b/include/drives.h
@@ -31,7 +31,7 @@
 
 void Set_Label(char const * const input, char * const output, bool cdrom);
 std::string To_Label(const char* name);
-void generate_8x3(char *lfn, unsigned int k, unsigned int &i, unsigned int &t);
+std::string generate_8x3(const char *lfn, const unsigned int num, const bool start = false);
 bool filename_not_8x3(const char *n);
 bool filename_not_strict_8x3(const char *n);
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -27,7 +27,7 @@
 
 #include "dos_inc.h"
 
-#define AUTOEXEC_SIZE 4096
+constexpr int autoexec_maxsize = 4096;
 
 class CommandLine {
 public:
@@ -94,7 +94,7 @@ public:
 };
 
 typedef void (PROGRAMS_Main)(Program * * make);
-void PROGRAMS_Destroy(Section *);
+void PROGRAMS_Destroy([[maybe_unused]] Section* sec);
 void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main);
 
 #endif

--- a/include/programs.h
+++ b/include/programs.h
@@ -27,6 +27,8 @@
 
 #include "dos_inc.h"
 
+#define AUTOEXEC_SIZE 4096
+
 class CommandLine {
 public:
 	CommandLine(int argc, char const *const argv[]);

--- a/include/programs.h
+++ b/include/programs.h
@@ -94,6 +94,7 @@ public:
 };
 
 typedef void (PROGRAMS_Main)(Program * * make);
+void PROGRAMS_Destroy(Section *);
 void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main);
 
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -46,12 +46,12 @@ extern Bit32u floppytype;
 #define WIKI_URL                   "https://github.com/dosbox-staging/dosbox-staging/wiki"
 #define WIKI_ADD_UTILITIES_ARTICLE WIKI_URL "/Add-Utilities"
 
-extern char autoexec_data[AUTOEXEC_SIZE];
+extern char autoexec_data[autoexec_maxsize];
 void CONFIG_ProgramStart(Program **make);
 void MIXER_ProgramStart(Program **make);
 void SHELL_ProgramStart(Program **make);
-void get_drivez_path(std::string &path, const std::string &dirname);
-void drivez_register(const std::string &path, const std::string &dir);
+void z_drive_getpath(std::string &path, const std::string &dirname);
+void z_drive_register(const std::string &path, const std::string &dir);
 
 void Add_VFiles(const bool add_autoexec)
 {
@@ -59,8 +59,8 @@ void Add_VFiles(const bool add_autoexec)
 	std::string path = ".";
 	path += CROSS_FILESPLIT;
 	path += dirname;
-	get_drivez_path(path, dirname);
-	drivez_register(path, "/");
+	z_drive_getpath(path, dirname);
+	z_drive_register(path, "/");
 
 	PROGRAMS_MakeFile("ATTRIB.COM", ATTRIB_ProgramStart);
 	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -46,6 +46,48 @@ extern Bit32u floppytype;
 #define WIKI_URL                   "https://github.com/dosbox-staging/dosbox-staging/wiki"
 #define WIKI_ADD_UTILITIES_ARTICLE WIKI_URL "/Add-Utilities"
 
+extern char autoexec_data[AUTOEXEC_SIZE];
+void CONFIG_ProgramStart(Program **make);
+void MIXER_ProgramStart(Program **make);
+void SHELL_ProgramStart(Program **make);
+void get_drivez_path(std::string &path, const std::string &dirname);
+void drivez_register(const std::string &path, const std::string &dir);
+
+void Add_VFiles(const bool add_autoexec)
+{
+	const std::string dirname = "drivez";
+	std::string path = ".";
+	path += CROSS_FILESPLIT;
+	path += dirname;
+	get_drivez_path(path, dirname);
+	drivez_register(path, "/");
+
+	PROGRAMS_MakeFile("ATTRIB.COM", ATTRIB_ProgramStart);
+	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
+#if C_DEBUG
+	PROGRAMS_MakeFile("BIOSTEST.COM", BIOSTEST_ProgramStart);
+#endif
+	PROGRAMS_MakeFile("BOOT.COM", BOOT_ProgramStart);
+	PROGRAMS_MakeFile("CHOICE.COM", CHOICE_ProgramStart);
+	PROGRAMS_MakeFile("HELP.COM", HELP_ProgramStart);
+	PROGRAMS_MakeFile("IMGMOUNT.COM", IMGMOUNT_ProgramStart);
+	PROGRAMS_MakeFile("INTRO.COM", INTRO_ProgramStart);
+	PROGRAMS_MakeFile("KEYB.COM", KEYB_ProgramStart);
+	PROGRAMS_MakeFile("LOADFIX.COM", LOADFIX_ProgramStart);
+	PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
+	PROGRAMS_MakeFile("LS.COM", LS_ProgramStart);
+	PROGRAMS_MakeFile("MEM.COM", MEM_ProgramStart);
+	PROGRAMS_MakeFile("MOUNT.COM", MOUNT_ProgramStart);
+	PROGRAMS_MakeFile("RESCAN.COM", RESCAN_ProgramStart);
+	PROGRAMS_MakeFile("MIXER.COM", MIXER_ProgramStart);
+	PROGRAMS_MakeFile("CONFIG.COM", CONFIG_ProgramStart);
+	PROGRAMS_MakeFile("SERIAL.COM", SERIAL_ProgramStart);
+	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramStart);
+	if (add_autoexec)
+		VFILE_Register("AUTOEXEC.BAT", (uint8_t *)autoexec_data,
+		               (uint32_t)strlen(autoexec_data));
+}
+
 void DOS_SetupPrograms(void)
 {
 	/*Add Messages */
@@ -560,22 +602,6 @@ void DOS_SetupPrograms(void)
 	MSG_Add("WIKI_ADD_UTILITIES_ARTICLE", WIKI_ADD_UTILITIES_ARTICLE);
 	MSG_Add("WIKI_URL", WIKI_URL);
 
-	PROGRAMS_MakeFile("ATTRIB.COM", ATTRIB_ProgramStart);
-	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
-#if C_DEBUG
-	PROGRAMS_MakeFile("BIOSTEST.COM", BIOSTEST_ProgramStart);
-#endif
-	PROGRAMS_MakeFile("BOOT.COM", BOOT_ProgramStart);
-	PROGRAMS_MakeFile("CHOICE.COM", CHOICE_ProgramStart);
-	PROGRAMS_MakeFile("HELP.COM", HELP_ProgramStart);
-	PROGRAMS_MakeFile("IMGMOUNT.COM", IMGMOUNT_ProgramStart);
-	PROGRAMS_MakeFile("INTRO.COM", INTRO_ProgramStart);
-	PROGRAMS_MakeFile("KEYB.COM", KEYB_ProgramStart);
-	PROGRAMS_MakeFile("LOADFIX.COM", LOADFIX_ProgramStart);
-	PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
-	PROGRAMS_MakeFile("LS.COM", LS_ProgramStart);
-	PROGRAMS_MakeFile("MEM.COM", MEM_ProgramStart);
-	PROGRAMS_MakeFile("MOUNT.COM", MOUNT_ProgramStart);
-	PROGRAMS_MakeFile("RESCAN.COM", RESCAN_ProgramStart);
-	PROGRAMS_MakeFile("SERIAL.COM", SERIAL_ProgramStart);
+	const auto add_autoexec = false;
+	Add_VFiles(add_autoexec);
 }

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -25,7 +25,14 @@
 
 #include "dos_inc.h"
 #include "support.h"
+#include "shell.h"
 #include "cross.h"
+
+#define MAX_VFILES 500
+unsigned int vfpos = 1;
+
+extern char sfn[DOS_NAMELENGTH_ASCII];
+char vfnames[MAX_VFILES][CROSS_LEN], vfsnames[MAX_VFILES][DOS_NAMELENGTH_ASCII];
 
 struct VFILE_Block {
 	const char * name;
@@ -33,35 +40,220 @@ struct VFILE_Block {
 	Bit32u size;
 	Bit16u date;
 	Bit16u time;
+	unsigned int onpos;
+	bool isdir;
 	VFILE_Block * next;
 };
 
+static VFILE_Block *first_file, *parent_dir = NULL;
 
-static VFILE_Block * first_file;
+char *VFILE_Generate_SFN(const char *name, unsigned int onpos)
+{
+	if (!filename_not_8x3(name)) {
+		strcpy(sfn, name);
+		upcase(sfn);
+		return sfn;
+	}
+	char lfn[LFN_NAMELENGTH + 1];
+	if (name == NULL || !*name)
+		return NULL;
+	if (strlen(name) > LFN_NAMELENGTH) {
+		strncpy(lfn, name, LFN_NAMELENGTH);
+		lfn[LFN_NAMELENGTH] = 0;
+	} else
+		strcpy(lfn, name);
+	if (!strlen(lfn))
+		return NULL;
+	unsigned int k = 1, i, t = 10000;
+	const VFILE_Block *cur_file;
+	while (k < 10000) {
+		GenerateSFN(lfn, k, i, t);
+		cur_file = first_file;
+		bool found = false;
+		while (cur_file) {
+			if (onpos == cur_file->onpos &&
+			    (strcasecmp(sfn, cur_file->name) == 0)) {
+				found = true;
+				break;
+			}
+			cur_file = cur_file->next;
+		}
+		if (!found)
+			return sfn;
+		k++;
+	}
+	return 0;
+}
 
-void VFILE_Register(const char * name,Bit8u * data,Bit32u size) {
-	VFILE_Block * new_file = new VFILE_Block;
-	new_file->name = name;
+uint16_t fztime = 0, fzdate = 0;
+void VFILE_Register(const char *name, Bit8u *data, Bit32u size, const char *dir)
+{
+	bool isdir = !strcmp(dir, "/") || !strcmp(name, ".") || !strcmp(name, "..");
+	unsigned int onpos = 0;
+	char fullname[CROSS_LEN], fullsname[CROSS_LEN];
+	if (strlen(dir) > 2 && dir[0] == '/' && dir[strlen(dir) - 1] == '/') {
+		for (unsigned int i = 1; i < vfpos; i++)
+			if (!strcasecmp((std::string(vfsnames[i]) + "/").c_str(),
+			                dir + 1) ||
+			    !strcasecmp((std::string(vfnames[i]) + "/").c_str(),
+			                dir + 1)) {
+				onpos = i;
+				break;
+			}
+		if (onpos == 0)
+			return;
+	}
+	const VFILE_Block *cur_file = first_file;
+	while (cur_file) {
+		if (onpos == cur_file->onpos && strcasecmp(name, cur_file->name) == 0)
+			return;
+		cur_file = cur_file->next;
+	}
+	std::string sname = filename_not_strict_8x3(name)
+	                            ? VFILE_Generate_SFN(name, onpos)
+	                            : name;
+	strcpy(vfnames[vfpos], name);
+	strcpy(vfsnames[vfpos], sname.c_str());
+	if (!strlen(trim(vfnames[vfpos])) || !strlen(trim(vfsnames[vfpos])))
+		return;
+	VFILE_Block *new_file = new VFILE_Block;
+	new_file->name = vfsnames[vfpos];
+	vfpos++;
 	new_file->data = data;
 	new_file->size = size;
-	new_file->date = DOS_PackDate(2002,10,1);
-	new_file->time = DOS_PackTime(12,34,56);
+	new_file->date = fztime || fzdate ? fzdate : DOS_PackDate(2002, 10, 1);
+	new_file->time = fztime || fzdate ? fztime : DOS_PackTime(12, 34, 56);
+	new_file->onpos = onpos;
+	new_file->isdir = isdir;
 	new_file->next = first_file;
 	first_file = new_file;
 }
 
-void VFILE_Remove(const char *name) {
+void VFILE_Remove(const char *name,const char *dir = "") {
+	unsigned int onpos = 0;
+	if (*dir) {
+		for (unsigned int i = 1; i < vfpos; i++)
+			if (!strcasecmp(vfsnames[i], dir) ||
+			    !strcasecmp(vfnames[i], dir)) {
+				onpos = i;
+				break;
+			}
+		if (onpos == 0)
+			return;
+	}
 	VFILE_Block * chan = first_file;
 	VFILE_Block * * where = &first_file;
 	while (chan) {
-		if (strcmp(name,chan->name) == 0) {
+		if (onpos == chan->onpos && strcmp(name, chan->name) == 0) {
 			*where = chan->next;
-			if (chan == first_file) first_file = chan->next;
+			if (chan == first_file)
+				first_file = chan->next;
 			delete chan;
 			return;
 		}
 		where = &chan->next;
 		chan = chan->next;
+	}
+}
+
+void get_drivez_path(std::string &path, std::string dirname)
+{
+	struct stat cstat;
+	int res = stat(path.c_str(), &cstat);
+	if (res == -1 || !(cstat.st_mode & S_IFDIR)) {
+		path = GetExecutablePath().string();
+		if (path.size()) {
+			path += dirname;
+			res = stat(path.c_str(), &cstat);
+		}
+		if (!path.size() || res == -1 || (cstat.st_mode & S_IFDIR) == 0) {
+			path = "";
+			Cross::CreatePlatformConfigDir(path);
+			path += dirname;
+			res = stat(path.c_str(), &cstat);
+			if (res == -1 || (cstat.st_mode & S_IFDIR) == 0)
+				path = "";
+		}
+	}
+}
+
+void drivez_register(std::string path, std::string dir)
+{
+	char exePath[CROSS_LEN];
+	std::vector<std::string> names;
+	if (path.size()) {
+		const std_fs::path dir = path;
+		for (const auto &entry : std_fs::directory_iterator(dir)) {
+			const auto result = entry.path().filename();
+			if (!entry.is_directory())
+				names.emplace_back(result.string().c_str());
+			else if (result.string() != "." && result.string() != "..")
+				names.push_back((result.string() + "/").c_str());
+		}
+	}
+	int res;
+	long f_size;
+	uint8_t *f_data;
+	struct stat temp_stat;
+	const struct tm *ltime;
+	for (std::string name : names) {
+		if (!name.size())
+			continue;
+		if (name.back() == '/' && dir == "/") {
+			res = stat((path + CROSS_FILESPLIT + name).c_str(),
+			           &temp_stat);
+			if (res)
+				res = stat((GetExecutablePath().string() +
+				            path + CROSS_FILESPLIT + name)
+				                   .c_str(),
+				           &temp_stat);
+			if (res == 0 &&
+			    (ltime = localtime(&temp_stat.st_mtime)) != 0) {
+				fztime = DOS_PackTime((uint16_t)ltime->tm_hour,
+				                      (uint16_t)ltime->tm_min,
+				                      (uint16_t)ltime->tm_sec);
+				fzdate = DOS_PackDate((uint16_t)(ltime->tm_year + 1900),
+				                      (uint16_t)(ltime->tm_mon + 1),
+				                      (uint16_t)ltime->tm_mday);
+			}
+			VFILE_Register(name.substr(0, name.size() - 1).c_str(),
+			               0, 0, dir.c_str());
+			fztime = fzdate = 0;
+			drivez_register(path + CROSS_FILESPLIT +
+			                        name.substr(0, name.size() - 1),
+			                dir + name);
+			continue;
+		}
+		FILE *f = fopen((path + CROSS_FILESPLIT + name).c_str(), "rb");
+		if (f == NULL) {
+			strcpy(exePath, GetExecutablePath().string().c_str());
+			strcat(exePath, (path + CROSS_FILESPLIT + name).c_str());
+			f = fopen(exePath, "rb");
+		}
+		f_size = 0;
+		f_data = NULL;
+		if (f != NULL) {
+			res = fstat(fileno(f), &temp_stat);
+			if (res == 0 &&
+			    (ltime = localtime(&temp_stat.st_mtime)) != 0) {
+				fztime = DOS_PackTime((uint16_t)ltime->tm_hour,
+				                      (uint16_t)ltime->tm_min,
+				                      (uint16_t)ltime->tm_sec);
+				fzdate = DOS_PackDate((uint16_t)(ltime->tm_year + 1900),
+				                      (uint16_t)(ltime->tm_mon + 1),
+				                      (uint16_t)ltime->tm_mday);
+			}
+			fseek(f, 0, SEEK_END);
+			f_size = ftell(f);
+			f_data = (uint8_t *)malloc(f_size);
+			fseek(f, 0, SEEK_SET);
+			fread(f_data, sizeof(char), f_size, f);
+			fclose(f);
+		}
+		if (f_data)
+			VFILE_Register(name.c_str(), f_data, f_size,
+			               dir == "/" ? "" : dir.c_str());
+		fztime = fzdate = 0;
 	}
 }
 
@@ -142,14 +334,24 @@ Bit16u Virtual_File::GetInformation(void) {
 Virtual_Drive::Virtual_Drive() : search_file(nullptr)
 {
 	strcpy(info,"Internal Virtual Drive");
+	if (parent_dir == NULL) parent_dir = new VFILE_Block;
 }
 
 bool Virtual_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
+	if (*name == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return false;
+	}
 /* Scan through the internal list of files */
 	VFILE_Block * cur_file = first_file;
 	while (cur_file) {
-		if (strcasecmp(name,cur_file->name) == 0) {
-		/* We have a match */
+		unsigned int onpos = cur_file->onpos;
+		if (strcasecmp(name, (std::string(onpos ? vfsnames[onpos] +
+		                                                  std::string(1, '\\')
+		                                        : "") +
+		                      cur_file->name)
+		                             .c_str()) == 0) {
+			/* We have a match */
 			*file = new Virtual_File(cur_file->data, cur_file->size);
 			(*file)->flags = flags;
 			return true;
@@ -160,6 +362,7 @@ bool Virtual_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 }
 
 bool Virtual_Drive::FileCreate(DOS_File * * /*file*/,char * /*name*/,Bit16u /*attributes*/) {
+	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
 
@@ -169,23 +372,35 @@ bool Virtual_Drive::FileUnlink(char * /*name*/) {
 }
 
 bool Virtual_Drive::RemoveDir(char * /*dir*/) {
+	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
 
 bool Virtual_Drive::MakeDir(char * /*dir*/) {
+	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
 
 bool Virtual_Drive::TestDir(char * dir) {
 	if (!dir[0]) return true;		//only valid dir is the empty dir
+	const VFILE_Block* cur_file = first_file;
+	while (cur_file) {
+		if (cur_file->isdir&&(!strcasecmp(cur_file->name, dir))) return true;
+		cur_file=cur_file->next;
+	}
 	return false;
 }
 
 bool Virtual_Drive::FileStat(const char* name, FileStat_Block * const stat_block){
 	VFILE_Block * cur_file = first_file;
 	while (cur_file) {
-		if (strcasecmp(name,cur_file->name) == 0) {
-			stat_block->attr = DOS_ATTR_ARCHIVE;
+		unsigned int onpos = cur_file->onpos;
+		if (strcasecmp(name, (std::string(onpos ? vfsnames[onpos] +
+		                                                  std::string(1, '\\')
+		                                        : "") +
+		                      cur_file->name)
+		                             .c_str()) == 0) {
+			stat_block->attr = cur_file->isdir?DOS_ATTR_DIRECTORY:DOS_ATTR_ARCHIVE;
 			stat_block->size = cur_file->size;
 			stat_block->date = DOS_PackDate(2002,10,1);
 			stat_block->time = DOS_PackTime(12,34,56);
@@ -199,34 +414,85 @@ bool Virtual_Drive::FileStat(const char* name, FileStat_Block * const stat_block
 bool Virtual_Drive::FileExists(const char* name){
 	VFILE_Block * cur_file = first_file;
 	while (cur_file) {
-		if (strcasecmp(name, cur_file->name) == 0) return true;
+		unsigned int onpos = cur_file->onpos;
+		if (strcasecmp(name, (std::string(onpos ? vfsnames[onpos] +
+		                                                  std::string(1, '\\')
+		                                        : "") +
+		                      cur_file->name)
+		                             .c_str()) == 0)
+			return !cur_file->isdir;
 		cur_file = cur_file->next;
 	}
 	return false;
 }
 
-bool Virtual_Drive::FindFirst(char * /*_dir*/,DOS_DTA & dta,bool fcb_findfirst) {
-	search_file = first_file;
-	Bit8u attr;char pattern[DOS_NAMELENGTH_ASCII];
-	dta.GetSearchParams(attr,pattern);
+bool Virtual_Drive::FindFirst(char *_dir, DOS_DTA &dta, bool fcb_findfirst)
+{
+	unsigned int onpos = 0;
+	if (*_dir) {
+		if (FileExists(_dir)) {
+			DOS_SetError(DOSERR_FILE_NOT_FOUND);
+			return false;
+		}
+		for (unsigned int i = 1; i < vfpos; i++) {
+			if (!strcasecmp(vfsnames[i], _dir) ||
+			    !strcasecmp(vfnames[i], _dir)) {
+				onpos = i;
+				break;
+			}
+		}
+		if (!onpos) {
+			DOS_SetError(DOSERR_PATH_NOT_FOUND);
+			return false;
+		}
+	}
+	dta.SetDirID(onpos);
+	Bit8u attr;
+	char pattern[DOS_NAMELENGTH_ASCII];
+	dta.GetSearchParams(attr, pattern);
+	search_file = (attr & DOS_ATTR_DIRECTORY) && onpos > 0 ? parent_dir
+	                                                       : first_file;
 	if (attr == DOS_ATTR_VOLUME) {
-		dta.SetResult(GetLabel(),0,0,0,DOS_ATTR_VOLUME);
+		dta.SetResult(GetLabel(), 0, 0, 0, DOS_ATTR_VOLUME);
 		return true;
 	} else if ((attr & DOS_ATTR_VOLUME) && !fcb_findfirst) {
-		if (WildFileCmp(GetLabel(),pattern)) {
-			dta.SetResult(GetLabel(),0,0,0,DOS_ATTR_VOLUME);
+		if (WildFileCmp(GetLabel(), pattern)) {
+			dta.SetResult(GetLabel(), 0, 0, 0, DOS_ATTR_VOLUME);
+			return true;
+		}
+	} else if ((attr & DOS_ATTR_DIRECTORY) && onpos > 0) {
+		if (WildFileCmp(".", pattern)) {
+			dta.SetResult(".", 0, DOS_PackDate(2002, 10, 1),
+			              DOS_PackTime(12, 34, 56), DOS_ATTR_DIRECTORY);
 			return true;
 		}
 	}
 	return FindNext(dta);
 }
 
-bool Virtual_Drive::FindNext(DOS_DTA & dta) {
-	Bit8u attr;char pattern[DOS_NAMELENGTH_ASCII];
+bool Virtual_Drive::FindNext(DOS_DTA &dta)
+{
+	Bit8u attr;
+	char pattern[DOS_NAMELENGTH_ASCII];
 	dta.GetSearchParams(attr, pattern);
+	unsigned int pos = dta.GetDirID();
+	if (search_file == parent_dir) {
+		bool cmp = WildFileCmp("..", pattern);
+		if (cmp)
+			dta.SetResult("..", 0, DOS_PackDate(2002, 10, 1),
+			              DOS_PackTime(12, 34, 56), DOS_ATTR_DIRECTORY);
+		search_file = first_file;
+		if (cmp)
+			return true;
+	}
 	while (search_file) {
-		if (WildFileCmp(search_file->name, pattern)) {
-			dta.SetResult(search_file->name, search_file->size, search_file->date, search_file->time, DOS_ATTR_ARCHIVE);
+		if (pos == search_file->onpos &&
+		    ((attr & DOS_ATTR_DIRECTORY) || !search_file->isdir) &&
+		    WildFileCmp(search_file->name, pattern)) {
+			dta.SetResult(search_file->name, search_file->size,
+			              search_file->date, search_file->time,
+			              search_file->isdir ? DOS_ATTR_DIRECTORY
+			                                 : DOS_ATTR_ARCHIVE);
 			search_file = search_file->next;
 			return true;
 		}
@@ -238,13 +504,24 @@ bool Virtual_Drive::FindNext(DOS_DTA & dta) {
 
 bool Virtual_Drive::GetFileAttr(char *name, Bit16u *attr)
 {
+	if (*name == 0) {
+		*attr=DOS_ATTR_DIRECTORY;
+		return true;
+	}
 	VFILE_Block *cur_file = first_file;
 	while (cur_file) {
-		if (strcasecmp(name, cur_file->name) == 0) {
-			*attr = DOS_ATTR_ARCHIVE; // Maybe readonly ?
+		unsigned int onpos = cur_file->onpos;
+		if (strcasecmp(name, (std::string(onpos ? vfsnames[onpos] +
+		                                                  std::string(1, '\\')
+		                                        : "") +
+		                      cur_file->name)
+		                             .c_str()) == 0) {
+			*attr = cur_file->isdir ? DOS_ATTR_DIRECTORY
+			                        : DOS_ATTR_ARCHIVE; // Maybe
+			                                            // readonly ?
 			return true;
 		}
-		cur_file = cur_file->next;
+		cur_file=cur_file->next;
 	}
 	return false;
 }
@@ -258,7 +535,12 @@ bool Virtual_Drive::SetFileAttr(const char *name, uint16_t attr)
 	}
 	const VFILE_Block *cur_file = first_file;
 	while (cur_file) {
-		if (strcasecmp(name, cur_file->name) == 0) {
+		unsigned int onpos = cur_file->onpos;
+		if (strcasecmp(name, (std::string(onpos ? vfsnames[onpos] +
+		                                                  std::string(1, '\\')
+		                                        : "") +
+		                      cur_file->name)
+		                             .c_str()) == 0) {
 			DOS_SetError(DOSERR_ACCESS_DENIED);
 			return false;
 		}
@@ -298,4 +580,18 @@ Bits Virtual_Drive::UnMount(void) {
 
 char const* Virtual_Drive::GetLabel(void) {
 	return "DOSBOX";
+}
+
+void PROGRAMS_Destroy(Section*);
+void Add_VFiles(bool add_autoexec);
+extern DOS_Shell *first_shell;
+void Virtual_Drive::EmptyCache(void) {
+	while (first_file != NULL) {
+		VFILE_Block *n = first_file->next;
+		delete first_file;
+		first_file = n;
+	}
+	vfpos=1;
+	PROGRAMS_Destroy(NULL);
+	Add_VFiles(first_shell);
 }

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -53,8 +53,10 @@ static VFILE_Block *first_file, *parent_dir = NULL;
 
 char *VFILE_Generate_8x3(const char *name, const unsigned int onpos)
 {
-	if (name == NULL || !*name)
-		return NULL;
+	if (name == NULL || !*name) {
+		strcpy(sfn, "");
+		return sfn;
+	}
 	if (!filename_not_8x3(name)) {
 		strcpy(sfn, name);
 		upcase(sfn);
@@ -67,15 +69,16 @@ char *VFILE_Generate_8x3(const char *name, const unsigned int onpos)
 	} else {
 		strcpy(lfn, name);
 	}
-	if (!strlen(lfn))
-		return NULL;
-	constexpr int tilde_limit = 10000;
-	unsigned int k = 1;
-	unsigned int i = 0;
-	unsigned int t = tilde_limit;
+	if (!strlen(lfn)) {
+		strcpy(sfn, "");
+		return sfn;
+	}
+	unsigned int num = 1;
 	const VFILE_Block *cur_file;
-	while (k < tilde_limit) {
-		generate_8x3(lfn, k, i, t);
+	while (1) {
+		strcpy(sfn, generate_8x3(lfn, num).c_str());
+		if (!*sfn)
+			return sfn;
 		cur_file = first_file;
 		bool found = false;
 		while (cur_file) {
@@ -88,9 +91,10 @@ char *VFILE_Generate_8x3(const char *name, const unsigned int onpos)
 		}
 		if (!found)
 			return sfn;
-		k++;
+		num++;
 	}
-	return 0;
+	strcpy(sfn, "");
+	return sfn;
 }
 
 void VFILE_Register(const char *name, uint8_t *data, const uint32_t size, const char *dir)

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -28,9 +28,10 @@
 #include "support.h"
 #include "shell.h"
 #include "cross.h"
+#include "string_utils.h"
 
-#define default_date DOS_PackDate(2002, 10, 1)
-#define default_time DOS_PackTime(12, 34, 56)
+constexpr auto default_date = DOS_PackDate(2002, 10, 1);
+constexpr auto default_time = DOS_PackTime(12, 34, 56);
 
 struct Filename {
 	std::string fullname = {};
@@ -62,10 +63,11 @@ static VFILE_Block *parent_dir = nullptr;
 char *VFILE_Generate_8x3(const char *name, const unsigned int onpos)
 {
 	if (!name || !*name) {
-		strcpy(sfn, "");
+		reset_str(sfn);
 		return sfn;
 	}
 	if (!filename_not_8x3(name)) {
+		assert(strlen(name) < DOS_NAMELENGTH_ASCII);
 		strcpy(sfn, name);
 		upcase(sfn);
 		return sfn;
@@ -77,7 +79,8 @@ char *VFILE_Generate_8x3(const char *name, const unsigned int onpos)
 	const VFILE_Block *cur_file;
 	// Get 8.3 names for LFNs by iterating the numbers
 	while (1) {
-		strcpy(sfn, generate_8x3(lfn.c_str(), num).c_str());
+		const auto str = generate_8x3(lfn.c_str(), num);
+		strcpy(sfn, str.length() < DOS_NAMELENGTH_ASCII ? str.c_str() : "");
 		if (!*sfn)
 			return sfn;
 		cur_file = first_file;
@@ -96,7 +99,7 @@ char *VFILE_Generate_8x3(const char *name, const unsigned int onpos)
 			return sfn;
 		num++;
 	}
-	strcpy(sfn, "");
+	reset_str(sfn);
 	return sfn;
 }
 

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -20,6 +20,7 @@
 
 #include "ide.h"
 #include "string_utils.h"
+#include <string_view>
 
 extern char sfn[DOS_NAMELENGTH_ASCII];
 
@@ -72,11 +73,10 @@ void Set_Label(char const * const input, char * const output, bool cdrom) {
 		output[labelPos-1] = 0;
 }
 
-bool is_special_character(char c)
+constexpr bool is_special_character(const char c)
 {
-	return c == '"' || c == '+' || c == '=' || c == ',' || c == ';' ||
-	       c == ':' || c == '<' || c == '>' || c == '[' || c == ']' ||
-	       c == '|' || c == '?' || c == '*';
+    constexpr auto special_characters = std::string_view("\"+=,;:<>[]|?*");
+    return special_characters.find(c) != std::string_view::npos;
 }
 
 /* Generate 8.3 names from LFNs, with tilde usage (from ~1 to ~9999). */

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1090,7 +1090,7 @@ Bitu IPX_ESRHandler(void) {
 	return CBRET_NONE;
 }
 
-void VFILE_Remove(const char *name,const char *dir = "");
+void VFILE_Remove(const char *name, const char *dir = "");
 bool NetWrapper_InitializeSDLNet(); // from misc_util.cpp
 
 class IPX final : public Module_base {

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1090,7 +1090,7 @@ Bitu IPX_ESRHandler(void) {
 	return CBRET_NONE;
 }
 
-void VFILE_Remove(const char *name);
+void VFILE_Remove(const char *name,const char *dir = "");
 bool NetWrapper_InitializeSDLNet(); // from misc_util.cpp
 
 class IPX final : public Module_base {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -934,7 +934,7 @@ private:
 	void ListMidi() { MIDI_ListAll(this); }
 };
 
-static void MIXER_ProgramStart(Program * * make) {
+void MIXER_ProgramStart(Program * * make) {
 	*make=new MIXER;
 }
 
@@ -1016,8 +1016,6 @@ void MIXER_Init(Section* sec) {
 
 	// Initialize the 8-bit to 16-bit lookup table
 	fill_8to16_lut();
-
-	PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart);
 }
 
 void MIXER_CloseAudioDevice()

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -807,7 +807,7 @@ void CONFIG::Run(void) {
 }
 
 
-static void CONFIG_ProgramStart(Program * * make) {
+void CONFIG_ProgramStart(Program * * make) {
 	*make=new CONFIG;
 }
 
@@ -820,7 +820,6 @@ void PROGRAMS_Init(Section* sec) {
 	/* Setup a special callback to start virtual programs */
 	call_program=CALLBACK_Allocate();
 	CALLBACK_Setup(call_program,&PROGRAMS_Handler,CB_RETF,"internal program");
-	PROGRAMS_MakeFile("CONFIG.COM",CONFIG_ProgramStart);
 
 	// Cleanup -- allows unit tests to run indefinitely & cleanly
 	sec->AddDestroyFunction(&PROGRAMS_Destroy,false);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -811,7 +811,7 @@ void CONFIG_ProgramStart(Program * * make) {
 	*make=new CONFIG;
 }
 
-void PROGRAMS_Destroy(Section*) {
+void PROGRAMS_Destroy([[maybe_unused]] Section* sec) {
 	internal_progs_comdata.clear();
 	internal_progs.clear();
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -50,7 +50,7 @@ static void SHELL_ProgramStart_First_shell(DOS_Shell * * make) {
 	*make = new DOS_Shell;
 }
 
-char autoexec_data[AUTOEXEC_SIZE] = { 0 };
+char autoexec_data[autoexec_maxsize] = { 0 };
 static std::list<std::string> autoexec_strings;
 typedef std::list<std::string>::iterator auto_it;
 
@@ -119,7 +119,7 @@ void AutoexecObject::CreateAutoexec()
 		}
 
 		auto_len = safe_strlen(autoexec_data);
-		if ((auto_len+linecopy.length() + 3) > AUTOEXEC_SIZE) {
+		if ((auto_len+linecopy.length() + 3) > autoexec_maxsize) {
 			E_Exit("SYSTEM:Autoexec.bat file overflow");
 		}
 		sprintf((autoexec_data + auto_len),"%s\r\n",linecopy.c_str());

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -41,7 +41,7 @@ static Bitu shellstop_handler()
 	return CBRET_STOP;
 }
 
-static void SHELL_ProgramStart(Program * * make) {
+void SHELL_ProgramStart(Program * * make) {
 	*make = new DOS_Shell;
 }
 //Repeat it with the correct type, could do it in the function below, but this way it should be 
@@ -50,12 +50,11 @@ static void SHELL_ProgramStart_First_shell(DOS_Shell * * make) {
 	*make = new DOS_Shell;
 }
 
-#define AUTOEXEC_SIZE 4096
-static char autoexec_data[AUTOEXEC_SIZE] = { 0 };
+char autoexec_data[AUTOEXEC_SIZE] = { 0 };
 static std::list<std::string> autoexec_strings;
 typedef std::list<std::string>::iterator auto_it;
 
-void VFILE_Remove(const char *name);
+void VFILE_Remove(const char *name,const char *dir = "");
 
 void AutoexecObject::Install(const std::string &in) {
 	if (GCC_UNLIKELY(installed))
@@ -731,7 +730,7 @@ public:
 		// for (const auto &autoexec_line : autoexec)
 		// 	LOG_INFO("AUTOEXEC-LINE: %s", autoexec_line.GetLine().c_str());
 
-		VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data));
+		VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data),"");
 	}
 };
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -54,7 +54,7 @@ char autoexec_data[AUTOEXEC_SIZE] = { 0 };
 static std::list<std::string> autoexec_strings;
 typedef std::list<std::string>::iterator auto_it;
 
-void VFILE_Remove(const char *name,const char *dir = "");
+void VFILE_Remove(const char *name, const char *dir = "");
 
 void AutoexecObject::Install(const std::string &in) {
 	if (GCC_UNLIKELY(installed))
@@ -730,7 +730,7 @@ public:
 		// for (const auto &autoexec_line : autoexec)
 		// 	LOG_INFO("AUTOEXEC-LINE: %s", autoexec_line.GetLine().c_str());
 
-		VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data),"");
+		VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data));
 	}
 };
 

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -44,6 +44,7 @@
 
 #include "control.h"
 #include "dos_system.h"
+#include "drives.h"
 #include "shell.h"
 #include "string_utils.h"
 
@@ -371,6 +372,20 @@ TEST_F(DOS_FilesTest, DOS_DTAExtendName_Space_Pads)
 TEST_F(DOS_FilesTest, DOS_DTAExtendName_Enforces_8_3)
 {
 	assert_DTAExtendName("12345678ABCDEF.123ABCDE", "12345678", "123");
+}
+
+TEST_F(DOS_FilesTest, VFILE_Register)
+{
+	VFILE_Register("TEST", 0, 0, "/");
+	EXPECT_FALSE(DOS_FindFirst("Z:\\TEST\\FILENA~1.TXT", 0, false));
+	VFILE_Register("filename_1.txt", 0, 0, "/TEST/");
+	EXPECT_TRUE(DOS_FindFirst("Z:\\TEST\\FILENA~1.TXT", 0, false));
+	EXPECT_FALSE(DOS_FindFirst("Z:\\TEST\\FILENA~2.TXT", 0, false));
+	VFILE_Register("filename_2.txt", 0, 0, "/TEST/");
+	EXPECT_TRUE(DOS_FindFirst("Z:\\TEST\\FILENA~2.TXT", 0, false));
+	EXPECT_FALSE(DOS_FindFirst("Z:\\TEST\\FILENA~3.TXT", 0, false));
+	VFILE_Register("filename_3.txt", 0, 0, "/TEST/");
+	EXPECT_TRUE(DOS_FindFirst("Z:\\TEST\\FILENA~3.TXT", 0, false));
 }
 
 } // namespace

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -127,6 +127,31 @@ TEST(WildFileCmp, LongCompare)
     EXPECT_EQ(false, WildFileCmp("TEST FILE NAME", "*F*X*", true));
 }
 
+TEST(generate_8x3, SFNTest)
+{
+	EXPECT_EQ("TESTLO~1", generate_8x3("test long name...", 1, true));
+	EXPECT_EQ("TESTLO~2.TXT", generate_8x3("test long name.txt", 2, true));
+	EXPECT_EQ("TESTL~20.TEX", generate_8x3("test long name.txt.text", 20, true));
+	EXPECT_EQ("TEST__~2.TEX", generate_8x3("test[ ]long name.text", 2, true));
+	EXPECT_EQ("TEST_~20", generate_8x3("... test[ ]long name ...", 20, true));
+	EXPECT_EQ("TEST~200.TT", generate_8x3("test long name.txt.tt", 200, true));
+	EXPECT_EQ("TES~2000.TXT", generate_8x3("test[]long name.txt", 2000, true));
+	EXPECT_EQ("TE~20000.EXT", generate_8x3("test long long name.txt..ext..", 20000, true));
+	EXPECT_EQ("T~200000.TXT", generate_8x3("test long long name.txt", 200000, true));
+	EXPECT_EQ("", generate_8x3("test long long name.txt", 2000000, true));
+}
+
+TEST(filename_not_8x3, NameTest)
+{
+	EXPECT_FALSE(filename_not_8x3("testfile.txt"));
+	EXPECT_TRUE(filename_not_8x3("test_file.txt"));
+	EXPECT_FALSE(filename_not_8x3("myfile.t"));
+	EXPECT_TRUE(filename_not_8x3("my file.txt"));
+	EXPECT_TRUE(filename_not_8x3("my+file.txt"));
+	EXPECT_TRUE(filename_not_8x3("myfile.text"));
+	EXPECT_TRUE(filename_not_8x3("myfile..txt"));
+}
+
 /**
  * Set_Labels tests. These test the conversion of a FAT/CD-ROM volume
  * label to an MS-DOS 8.3 label with a variety of edge cases & oddities.


### PR DESCRIPTION
This adds support for customizations on Z drive, allowing users to add any of their own files/programs on Z drive by putting them in the "drivez" subdirectory of the program directory. If any files/programs with same names already exist on Z drive, then they will be replaced by the ones added by users, so for example users can put their own MEM.COM, KEYB.COM, etc to replace the default programs on Z drive. Moreover, support for one-level directories is added, allowing users to put their files/programs in directories so that Z drive will look more clean. The Z drive can also be RESCANed to reflect any external changes to the drive.

Functions like generate_8x3 and filename_not_8x3 are helper functions which will also be used by other drives when LFN support is implemented.