### PR TITLE
Support for changing output options at run-time

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -74,6 +74,10 @@ void GFX_EndUpdate( const Bit16u *changedLines );
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus(void);
 
+bool wants_stretched_pixels();
+void remove_window();
+void set_output(Section *sec, bool should_stretch_pixels);
+
 #if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -72,11 +72,8 @@ void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
 void GFX_EndUpdate( const Bit16u *changedLines );
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
-void GFX_LosingFocus(void);
-
-bool wants_stretched_pixels();
-void remove_window();
-void set_output(Section *sec, bool should_stretch_pixels);
+void GFX_LosingFocus();
+void GFX_RegenerateWindow(Section *sec);
 
 #if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -61,7 +61,6 @@ constexpr rgb24 off_color(0, 0, 0);          // Black for off/stopped/not-in-use
 
 /* Mouse related */
 void GFX_ToggleMouseCapture();
-static bool first_window = true;
 extern bool mouse_is_captured; //true if mouse is confined to window
 
 enum {
@@ -3004,12 +3003,7 @@ void MAPPER_BindKeys(Section *sec)
 	if (SDL_GetModState()&KMOD_NUM)
 		MAPPER_TriggerEvent(num_lock_event, false);
 
-	if (!first_window) {
-		remove_window();
-		set_output(sec, wants_stretched_pixels());
-		GFX_ResetScreen();
-	}
-	first_window = false;
+	GFX_RegenerateWindow(sec);
 }
 
 std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -61,6 +61,7 @@ constexpr rgb24 off_color(0, 0, 0);          // Black for off/stopped/not-in-use
 
 /* Mouse related */
 void GFX_ToggleMouseCapture();
+static bool first_window = true;
 extern bool mouse_is_captured; //true if mouse is confined to window
 
 enum {
@@ -3002,6 +3003,13 @@ void MAPPER_BindKeys(Section *sec)
 
 	if (SDL_GetModState()&KMOD_NUM)
 		MAPPER_TriggerEvent(num_lock_event, false);
+
+	if (!first_window) {
+		remove_window();
+		set_output(sec, wants_stretched_pixels());
+		GFX_ResetScreen();
+	}
+	first_window = false;
 }
 
 std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix) {


### PR DESCRIPTION
This adds support for changing options like output and transparency from the DOS command shell at run-time. For example, the command ``output texture`` changes the current output to "texture" from another one, and ``transparency 30`` changes the transparency to 30. Allowing run-time change of output options is also helpful for others features like Voodoo and TTF.

P.S. The bulk of code is moved from GUI_StartUp to set_output function to make dynamic change possible.