### PR TITLE
Add frame presentation modes (#953,  #1167, #1197, #1228, #1363)

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -93,7 +93,6 @@ struct Render_t {
 	bool active = false;
 	bool aspect = true;
 	bool fullFrame = true;
-	bool forceUpdate = false;
 };
 
 extern Render_t render;
@@ -108,7 +107,5 @@ void RENDER_SetSize(uint32_t width,
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
 void RENDER_SetPal(Bit8u entry,Bit8u red,Bit8u green,Bit8u blue);
-bool RENDER_GetForceUpdate(void);
-void RENDER_SetForceUpdate(bool);
 
 #endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -59,9 +59,21 @@ enum VGAModes {
 	M_ERROR = 1 << 31,
 };
 
+constexpr auto M_TEXT_MODES = M_TEXT | M_HERC_TEXT | M_TANDY_TEXT | M_CGA_TEXT_COMPOSITE;
+
 constexpr uint16_t EGA_HALF_CLOCK = 1 << 0;
 constexpr uint16_t EGA_LINE_DOUBLE = 1 << 1;
 constexpr uint16_t VGA_PIXEL_DOUBLE = 1 << 2;
+
+// Refresh rate constants
+constexpr auto REFRESH_RATE_MIN = 23;
+constexpr auto REFRESH_RATE_DOS_DOUBLED_MAX = 35;
+constexpr auto REFRESH_RATE_HOST_VRR_LFC = 48;
+constexpr auto REFRESH_RATE_HOST_TV_MAX = 50;
+constexpr auto REFRESH_RATE_HOST_DEFAULT = 60;
+constexpr auto REFRESH_RATE_DOS_DEFAULT = 70;
+constexpr auto REFRESH_RATE_HOST_VRR_MIN = 75;
+constexpr auto REFRESH_RATE_MAX = 1000;
 
 #define CLK_25 25175
 #define CLK_28 28322
@@ -135,6 +147,8 @@ struct VGA_Config {
 
 enum Drawmode { PART, DRAWLINE, EGALINE };
 
+enum class VGA_RATE_MODE { DEFAULT, HOST, CUSTOM };
+
 struct VGA_Draw {
 	bool resizing = false;
 	Bitu width = 0;
@@ -169,6 +183,10 @@ struct VGA_Draw {
 		double parts = 0;
 	} delay;
 	Bitu bpp = 0;
+	double host_refresh_hz = REFRESH_RATE_HOST_DEFAULT;
+	double dos_refresh_hz = REFRESH_RATE_DOS_DEFAULT;
+	double custom_refresh_hz = REFRESH_RATE_DOS_DEFAULT;
+	VGA_RATE_MODE dos_rate_mode = VGA_RATE_MODE::DEFAULT;
 	double aspect_ratio = 0;
 	bool double_scan = false;
 	bool doublewidth = false;
@@ -489,6 +507,12 @@ void VGA_AddCompositeSettings(Config &conf);
 /* Some Support Functions */
 std::pair<const char *, const char *> VGA_DescribeType(VGAModes type);
 void VGA_SetClock(Bitu which, uint32_t target);
+
+// Save, get, and limit refresh and clock functions
+void VGA_SetHostRate(const double refresh_hz);
+void VGA_SetRatePreference(const std::string &pref);
+double VGA_GetPreferredRate();
+
 void VGA_DACSetEntirePalette(void);
 void VGA_StartRetrace(void);
 void VGA_StartUpdateLFB(void);

--- a/include/vga.h
+++ b/include/vga.h
@@ -181,7 +181,7 @@ struct VGA_Draw {
 		double vdend = 0, vtotal = 0;
 		double hdend = 0, htotal = 0;
 		double parts = 0;
-	} delay;
+	} delay = {};
 	Bitu bpp = 0;
 	double host_refresh_hz = REFRESH_RATE_HOST_DEFAULT;
 	double dos_refresh_hz = REFRESH_RATE_DOS_DEFAULT;
@@ -203,8 +203,8 @@ struct VGA_Draw {
 		Bit8u count = 0;
 		uint8_t delay = 0;
 		Bit8u enabled = 0;
-	} cursor;
-	Drawmode mode;
+	} cursor = {};
+	Drawmode mode = {};
 	bool vret_triggered = false;
 };
 

--- a/include/video.h
+++ b/include/video.h
@@ -57,7 +57,6 @@ typedef void (*GFX_CallBack_t)( GFX_CallBackFunctions_t function );
 bool GFX_Events();
 
 Bitu GFX_GetBestMode(Bitu flags);
-int GFX_GetDisplayRefreshRate();
 Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);
 void GFX_SetShader(const char* src);
 Bitu GFX_SetSize(int width, int height, Bitu flags,

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -401,6 +401,8 @@ static void DOSBOX_RealInit(Section * sec) {
 	else
 		int10.vesa_mode_preference = VESA_MODE_PREF::COMPATIBLE;
 
+	VGA_SetRatePreference(section->Get_string("dos_rate"));
+
 	CPU_AllowSpeedMods = section->Get_bool("speed_mods");
 	LOG_MSG("SYSTEM: Speed modifications are %s",
 	        CPU_AllowSpeedMods ? "enabled" : "disabled");
@@ -477,6 +479,14 @@ void DOSBOX_Init() {
 	pstring->Set_values(vmemsize_choices);
 	pstring->Set_help(
 	        "Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.");
+
+	pstring = secprop->Add_string("dos_rate", when_idle, "default");
+	pstring->Set_help(
+	        "Customize the emulated video mode's frame rate, in Hz:\n"
+	        "default:  The DOS video mode determines the rate (recommended).\n"
+	        "host:     Match the DOS rate to the host rate (see 'host_rate' setting).\n"
+	        "<value>:  Sets the rate to an exact value, between 24.000 and 1000.000 (Hz).\n"
+	        "We recommend the 'default' rate; otherwise test and set on a per-game basis.");
 
 	const char *vesa_modes_choices[] = {"compatible", "all", 0};
 	Pstring = secprop->Add_string("vesa_modes", only_at_start, "compatible");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -243,7 +243,8 @@ void RENDER_EndUpdate( bool abort ) {
 			total += render.frameskip.hadSkip[i];
 		LOG_MSG( "Skipped frame %d %d", PIC_Ticks, (total * 100) / RENDER_SKIP_CACHE );
 #endif
-		if (RENDER_GetForceUpdate()) GFX_EndUpdate(0);
+		// If we made it here, then there's nothing new to render.
+		GFX_EndUpdate(nullptr);
 	}
 	render.frameskip.index = (render.frameskip.index + 1) & (RENDER_SKIP_CACHE - 1);
 	render.updating=false;
@@ -621,14 +622,6 @@ static void ChangeScaler(bool pressed) {
 	}
 	RENDER_CallBack( GFX_CallBackReset );
 } */
-
-bool RENDER_GetForceUpdate(void) {
-	return render.forceUpdate;
-}
-
-void RENDER_SetForceUpdate(bool f) {
-	render.forceUpdate = f;
-}
 
 #if C_OPENGL
 static bool RENDER_GetShader(std::string &shader_path, char *old_src)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1533,11 +1533,6 @@ dosurface:
 					sdl.opengl.ruby.input_size = glGetUniformLocation(sdl.opengl.program_object, "rubyInputSize");
 					sdl.opengl.ruby.output_size = glGetUniformLocation(sdl.opengl.program_object, "rubyOutputSize");
 					sdl.opengl.ruby.frame_count = glGetUniformLocation(sdl.opengl.program_object, "rubyFrameCount");
-					// If the shader has a required frame-count, then
-					// force rendering updates to ensure each frame is provided.
-					if (sdl.opengl.ruby.frame_count > 0) {
-						RENDER_SetForceUpdate(true);
-					}
 				}
 			}
 		}
@@ -1915,7 +1910,7 @@ void GFX_EndUpdate(const Bit16u *changedLines)
 #else
 	const bool using_opengl = false;
 #endif
-	if ((!using_opengl || !RENDER_GetForceUpdate()) && !sdl.updating)
+	if (!using_opengl && !sdl.updating)
 		return;
 	[[maybe_unused]] bool actually_updating = sdl.updating;
 	sdl.updating = false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -896,7 +896,7 @@ static void safe_set_window_size(const int w, const int h)
 	std::swap(sdl.draw.callback, saved_callback);
 }
 
-static Pacer render_pacer("Render", 7000, Pacer::LogLevel::NOTHING);
+static Pacer render_pacer("Render", 7000, Pacer::LogLevel::TIMEOUTS);
 
 static void remove_window()
 {
@@ -4236,13 +4236,6 @@ int sdl_main(int argc, char *argv[])
 		control->Init();
 		/* Some extra SDL Functions */
 		Section_prop * sdl_sec=static_cast<Section_prop *>(control->GetSection("sdl"));
-
-		render_pacer.SetTimeout(sdl.desktop.vsync_skip);
-
-		const auto pacer_log_level = sdl.desktop.vsync
-		                                     ? Pacer::LogLevel::NOTHING
-		                                     : Pacer::LogLevel::TIMEOUTS;
-		render_pacer.SetLogLevel(pacer_log_level);
 
 		if (control->cmdline->FindExist("-fullscreen") ||
 		    sdl_sec->Get_bool("fullscreen")) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1741,7 +1741,7 @@ Bitu GFX_SetSize(int width,
 {
 	Bitu retFlags = 0;
 	if (sdl.updating)
-		GFX_EndUpdate( 0 );
+		GFX_EndUpdate(nullptr);
 
 	const bool double_width = flags & GFX_DBL_W;
 	const bool double_height = flags & GFX_DBL_H;
@@ -2598,7 +2598,7 @@ Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue) {
 
 void GFX_Stop() {
 	if (sdl.updating)
-		GFX_EndUpdate( 0 );
+		GFX_EndUpdate(nullptr);
 	sdl.active=false;
 }
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1371,8 +1371,9 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 #endif
 
 	// The screen refresh frequency and clock settings, per the DOS-mode
-	const auto f_clock = static_cast<double>(clock);
-	const auto fps = f_clock / static_cast<double>(vtotal * htotal);
+	vga.draw.dos_refresh_hz = static_cast<double>(clock) / (vtotal * htotal);
+	const auto fps = VGA_GetPreferredRate();
+	const auto f_clock = fps * vtotal * htotal;
 
 	// Horizontal total (that's how long a line takes with whistles and bells)
 	vga.draw.delay.htotal = static_cast<double>(htotal) * 1000.0 / f_clock; //  milliseconds


### PR DESCRIPTION
**Background**: DOSBox (and thus Staging) presents a new frame to the host at the end of the DOS video mode's vblank period, provided new DOS screen content is present. Satisfying both conditions means the effective frame rate can be as low as 0 FPS (if the screen content isn't changing) and as fast as the DOS rate (often up to ~70 Hz).  We'll call this existing presentation mode: **Variable Frame Rate or VFR.**

This PR adds some more presentation modes:
 - **CFR** delivers a constant frame rate defined by the emulated DOS rate. Similar to VFR however this presents all frames.
 - **Synced CFR** delivers a constant frame rate synchronized with the host's refresh rate. It presents only the most recently updated frame when the DOS rate exceeds the host rate.
 - **Throttled VFR** delivers a variable frame rate up to the DOS rate throttled to the display's rate.   It presents only the most recently updated frame when the DOS rate exceeds the host rate.

**_Given these modes either show duplicate frames or may drop frames, why would we want them?_**

 - Some displays include a "variable refresh rate" feature that changes the physical refresh rate based on the inbound frame rate. Some models will flicker and dim when fed frame rates that rapidly bobble around and dip. Therefore these displays behave better with constant frame rates.
 - SDL2 on modern desktops and display drivers can effectively enforce vsync (https://user-images.githubusercontent.com/1557255/159196458-6fff6d8c-0b34-4971-aceb-f59a5017e58c.png), which means the host can absorb frames no faster than the display's frame period and will stall the presenter (ie: DOSBox) with more closely spaced framed. For these systems, spacing our frames out to the host's desired pace means we can avoid stalling DOSBox.

By default, this PR inspects real-time conditions and picks the optimal presentation mode and frame period.  For power-users, these conditions are configurable:
 - `[sdl] presentation_mode = auto / cfr / vfr`
 - `[sdl] host_rate = auto / sdi / vrr / custom`
 - `[dosbox] dos_rate = default / host / custom`

These are described in the updated config file, which can be written with: `Z:\> config -wc`.

Contributors to this PR include:
 - @nemo93, who thoroughly reporting several issues regarding dropped and stalled frames.
 - @0mnicydle, @Kappa971 and @shermp who extensively tested and provided feedback during its development.

**Linked issues:**
 - Fixes #953 
 - Fixes #1167 
 - Fixes #1197 
 - Fixes #1228 
 - Fixes #1363
