### PR TITLE
Let the mixer configure the channels lineout modes (#1590, #1594)

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -104,7 +104,7 @@ public:
 	void SetVolume(float _left, float _right);
 	void SetScale(float f);
 	void SetScale(float _left, float _right);
-	void MapChannels(Bit8u _left, Bit8u _right);
+	void ChangeChannelMap(const LINE_INDEX left, const LINE_INDEX right);
 	void UpdateVolume();
 	void SetFreq(int _freq);
 	void SetPeakAmplitude(int peak);
@@ -173,7 +173,9 @@ private:
 	};
 	static constexpr StereoLine STEREO = {LEFT, RIGHT};
 
-	uint8_t channel_map[2] = {0, 1}; // Output channel mapping
+	// DOS application-configurable that maps the channels own "left" or
+	// "right" as themselves or vice-versa.
+	StereoLine channel_map = STEREO;
 
 	// The RegisterLevelCallBack() assigns this callback that can be used by
 	// the channel's source to manage the stream's level prior to mixing,

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -85,6 +85,15 @@ constexpr T Mixer_GetSilentDOSSample()
 	static_assert(sizeof(T) <= 2, "DOS only produced 8 and 16-bit samples");
 }
 
+// A simple enum to describe the array index associated with a given audio line
+enum LINE_INDEX : uint8_t {
+	LEFT = 0,
+	RIGHT = 1,
+	// DOS games didn't support surround sound, but if we up need to
+	// populate extra output channels (if surround sound becomes standard at
+	// the host-level), then then these additional line indexes would go here.
+};
+
 class MixerChannel {
 public:
 	MixerChannel(MIXER_Handler _handler, const char *name);
@@ -156,6 +165,13 @@ private:
 	// Default to signed 16bit max, however channel's that know their own
 	// peak, like the PCSpeaker, should update it with: SetPeakAmplitude()
 	int peak_amplitude = MAX_AUDIO;
+
+	struct StereoLine {
+		LINE_INDEX left = LEFT;
+		LINE_INDEX right = RIGHT;
+		bool operator==(const StereoLine &other) const;
+	};
+	static constexpr StereoLine STEREO = {LEFT, RIGHT};
 
 	uint8_t channel_map[2] = {0, 1}; // Output channel mapping
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <string_view>
 
 #include "envelope.h"
 
@@ -89,9 +90,8 @@ constexpr T Mixer_GetSilentDOSSample()
 enum LINE_INDEX : uint8_t {
 	LEFT = 0,
 	RIGHT = 1,
-	// DOS games didn't support surround sound, but if we up need to
-	// populate extra output channels (if surround sound becomes standard at
-	// the host-level), then then these additional line indexes would go here.
+	// DOS games didn't support surround sound, but if surround sound becomes
+	// standard at the host-level, then additional line indexes would go here.
 };
 
 class MixerChannel {
@@ -105,6 +105,8 @@ public:
 	void SetScale(float f);
 	void SetScale(float _left, float _right);
 	void ChangeChannelMap(const LINE_INDEX left, const LINE_INDEX right);
+	bool ChangeLineoutMap(std::string choice);
+	std::string_view DescribeLineout() const;
 	void UpdateVolume();
 	void SetFreq(int _freq);
 	void SetPeakAmplitude(int peak);
@@ -171,7 +173,15 @@ private:
 		LINE_INDEX right = RIGHT;
 		bool operator==(const StereoLine &other) const;
 	};
+
 	static constexpr StereoLine STEREO = {LEFT, RIGHT};
+	static constexpr StereoLine REVERSE = {RIGHT, LEFT};
+	static constexpr StereoLine LEFT_MONO = {LEFT, LEFT};
+	static constexpr StereoLine RIGHT_MONO = {RIGHT, RIGHT};
+
+	// User-configurable that defines how the channel's stereo line maps
+	// into the mixer.
+	StereoLine output_map = STEREO;
 
 	// DOS application-configurable that maps the channels own "left" or
 	// "right" as themselves or vice-versa.

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -833,8 +833,9 @@ void CDROM_Interface_Image::ChannelControl(TCtrl ctrl)
 	                         static_cast<float>(ctrl.vol[1]/255.0)); // right vol
 
 	// Map the audio channels in our mixer channel as defined by the application
-	player.channel->MapChannels(ctrl.out[0],  // left map
-	                            ctrl.out[1]); // right map
+	const auto left_mapped = static_cast<LINE_INDEX>(ctrl.out[0]);
+	const auto right_mapped = static_cast<LINE_INDEX>(ctrl.out[1]);
+	player.channel->ChangeChannelMap(left_mapped, right_mapped);
 
 #ifdef DEBUG
 	LOG_MSG("CDROM: ChannelControl => volumes %d/255 and %d/255, "

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -121,6 +121,11 @@ Bit8u MixTemp[MIXER_BUFSIZE] = {};
 MixerChannel::MixerChannel(MIXER_Handler _handler, const char *_name) : envelope(_name), handler(_handler)
 {}
 
+bool MixerChannel::StereoLine::operator==(const StereoLine &other) const
+{
+	return left == other.left && right == other.right;
+}
+
 mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const int freq, const char *name)
 {
 	auto chan = std::make_shared<MixerChannel>(handler, name);


### PR DESCRIPTION
This adds the ability to adjust a given channel's lineout mode via the mixer's command-line.

Similar to how the mixer already provides volume control for the channels, this adds the following line-out modes (per emulated audio device/channel):

 - `stereo`: normal 1:1 connection (left-to-left, right-to-right). This is the default.
 - `reverse`: the channel's left line is fed into the mixer's right line (and vice-versa).
 - `leftmono`: both of the channel's lines are fed into mixer's left line.
 - `rightmono`: both of the channel's lines are fed into mixer's right line.

This avoids having to further pollute the conf file with reverse stereo settings in each audio device section (ie: "mt32_reverse", "sb_reverse", and so on).

Likewise, real hardware such as CD players, headphones, and TVs similarly don't include a toggle switch to reverse their stereo output. Instead, people who care about this stuff adjust the physical RCA lineouts feeding into their amplifier (or logically in the amplifier itself).

**Added to `mixer /?`:**

![2022-03-22_23-06](https://user-images.githubusercontent.com/1557255/159640690-28caddc3-40cf-456a-a36d-5d38cbf3eeef.png)

**Examples:**

![2022-03-22_23-07](https://user-images.githubusercontent.com/1557255/159640721-2c006d8c-9d05-432c-9546-20477f522a95.png)

**Issues:**
 - Fixes #1590
 - Fixes #1594
