### PR TITLE
Mass replace deprecated int types with cstdint types

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -121,7 +121,7 @@
 //#define MAX_SWAPPABLE_DISKS 20
 
 void BIOS_ZeroExtendedSize(bool in);
-void char_out(Bit8u chr,Bit32u att,Bit8u page);
+void char_out(uint8_t chr,uint32_t att,uint8_t page);
 void INT10_StartUp(void);
 void INT16_StartUp(void);
 void INT2A_StartUp(void);
@@ -129,10 +129,10 @@ void INT2F_StartUp(void);
 void INT33_StartUp(void);
 void INT13_StartUp(void);
 
-bool BIOS_AddKeyToBuffer(Bit16u code);
+bool BIOS_AddKeyToBuffer(uint16_t code);
 
 void INT10_ReloadRomFonts();
 
-void BIOS_SetComPorts (Bit16u baseaddr[]);
+void BIOS_SetComPorts (uint16_t baseaddr[]);
 
 #endif

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -34,25 +34,25 @@
 
 #define MAX_SWAPPABLE_DISKS 20
 struct diskGeo {
-	Bit32u ksize;  /* Size in kilobytes */
-	Bit16u secttrack; /* Sectors per track */
-	Bit16u headscyl;  /* Heads per cylinder */
-	Bit16u cylcount;  /* Cylinders per side */
-	Bit16u biosval;   /* Type to return from BIOS */
+	uint32_t ksize;  /* Size in kilobytes */
+	uint16_t secttrack; /* Sectors per track */
+	uint16_t headscyl;  /* Heads per cylinder */
+	uint16_t cylcount;  /* Cylinders per side */
+	uint16_t biosval;   /* Type to return from BIOS */
 };
 extern diskGeo DiskGeometryList[];
 
 class imageDisk  {
 public:
-	Bit8u Read_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * data);
-	Bit8u Write_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * data);
-	Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
-	Bit8u Write_AbsoluteSector(Bit32u sectnum, void * data);
+	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data);
+	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data);
+	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data);
+	uint8_t Write_AbsoluteSector(uint32_t sectnum, void * data);
 
-	void Set_Geometry(Bit32u setHeads, Bit32u setCyl, Bit32u setSect, Bit32u setSectSize);
-	void Get_Geometry(Bit32u * getHeads, Bit32u *getCyl, Bit32u *getSect, Bit32u *getSectSize);
-	Bit8u GetBiosType(void);
-	Bit32u getSectSize(void);
+	void Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t setSect, uint32_t setSectSize);
+	void Get_Geometry(uint32_t * getHeads, uint32_t *getCyl, uint32_t *getSect, uint32_t *getSectSize);
+	uint8_t GetBiosType(void);
+	uint32_t getSectSize(void);
 
 	imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, bool is_hdd);
 	imageDisk(const imageDisk&) = delete; // prevent copy
@@ -68,12 +68,12 @@ public:
 	bool active;
 	FILE *diskimg;
 	char diskname[512];
-	Bit8u floppytype;
+	uint8_t floppytype;
 
-	Bit32u sector_size;
-	Bit32u heads,cylinders,sectors;
+	uint32_t sector_size;
+	uint32_t heads,cylinders,sectors;
 private:
-	Bit32u current_fpos;
+	uint32_t current_fpos;
 	enum { NONE,READ,WRITE } last_action;
 };
 
@@ -87,7 +87,7 @@ void incrementFDD(void);
 extern std::array<std::shared_ptr<imageDisk>, MAX_DISK_IMAGES> imageDiskList;
 extern std::array<std::shared_ptr<imageDisk>, MAX_SWAPPABLE_DISKS> diskSwap;
 
-extern Bit16u imgDTASeg; /* Real memory location of temporary DTA pointer for fat image disk access */
+extern uint16_t imgDTASeg; /* Real memory location of temporary DTA pointer for fat image disk access */
 extern RealPt imgDTAPtr; /* Real memory location of temporary DTA pointer for fat image disk access */
 extern DOS_DTA *imgDTA;
 

--- a/include/callback.h
+++ b/include/callback.h
@@ -65,13 +65,13 @@ enum {
 	CBRET_NONE=0,CBRET_STOP=1
 };
 
-extern Bit8u lastint;
+extern uint8_t lastint;
 
 static inline RealPt CALLBACK_RealPointer(Bitu callback) {
-	return RealMake(CB_SEG,(Bit16u)(CB_SOFFSET+callback*CB_SIZE));
+	return RealMake(CB_SEG,(uint16_t)(CB_SOFFSET+callback*CB_SIZE));
 }
 static inline PhysPt CALLBACK_PhysPointer(Bitu callback) {
-	return PhysMake(CB_SEG,(Bit16u)(CB_SOFFSET+callback*CB_SIZE));
+	return PhysMake(CB_SEG,(uint16_t)(CB_SOFFSET+callback*CB_SIZE));
 }
 
 static inline PhysPt CALLBACK_GetBase(void) {
@@ -83,8 +83,8 @@ Bitu CALLBACK_Allocate();
 void CALLBACK_Idle(void);
 
 
-void CALLBACK_RunRealInt(Bit8u intnum);
-void CALLBACK_RunRealFar(Bit16u seg,Bit16u off);
+void CALLBACK_RunRealInt(uint8_t intnum);
+void CALLBACK_RunRealFar(uint16_t seg,uint16_t off);
 
 bool CALLBACK_Setup(Bitu callback,CallBack_Handler handler,Bitu type,const char* descr);
 Bitu CALLBACK_Setup(Bitu callback,CallBack_Handler handler,Bitu type,PhysPt addr,const char* descr);
@@ -127,12 +127,12 @@ public:
 
 	//Only allocate a callback number
 	void Allocate(CallBack_Handler handler,const char* description=0);
-	Bit16u Get_callback() {
-		return (Bit16u)m_callback;
+	uint16_t Get_callback() {
+		return (uint16_t)m_callback;
 	}
 	RealPt Get_RealPointer() {
 		return CALLBACK_RealPointer(m_callback);
 	}
-	void Set_RealVec(Bit8u vec);
+	void Set_RealVec(uint8_t vec);
 };
 #endif

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -48,13 +48,13 @@
 #define CPU_ARCHTYPE_PENTIUMSLOW	0x50
 
 /* CPU Cycle Timing */
-extern Bit32s CPU_Cycles;
-extern Bit32s CPU_CycleLeft;
-extern Bit32s CPU_CycleMax;
-extern Bit32s CPU_OldCycleMax;
-extern Bit32s CPU_CyclePercUsed;
-extern Bit32s CPU_CycleLimit;
-extern Bit64s CPU_IODelayRemoved;
+extern int32_t CPU_Cycles;
+extern int32_t CPU_CycleLeft;
+extern int32_t CPU_CycleMax;
+extern int32_t CPU_OldCycleMax;
+extern int32_t CPU_CyclePercUsed;
+extern int32_t CPU_CycleLimit;
+extern int64_t CPU_IODelayRemoved;
 extern bool CPU_CycleAutoAdjust;
 extern bool CPU_SkipCycleAutoAdjust;
 extern bool CPU_AllowSpeedMods;
@@ -88,7 +88,7 @@ void CPU_Reset_AutoAdjust(void);
 
 //CPU Stuff
 
-extern Bit16u parity_lookup[256];
+extern uint16_t parity_lookup[256];
 
 bool CPU_LLDT(Bitu selector);
 bool CPU_LTR(Bitu selector);
@@ -109,13 +109,13 @@ void CPU_LSL(Bitu selector,Bitu & limit);
 void CPU_SET_CRX(Bitu cr,Bitu value);
 bool CPU_WRITE_CRX(Bitu cr,Bitu value);
 Bitu CPU_GET_CRX(Bitu cr);
-bool CPU_READ_CRX(Bitu cr,Bit32u & retvalue);
+bool CPU_READ_CRX(Bitu cr,uint32_t & retvalue);
 
 bool CPU_WRITE_DRX(Bitu dr,Bitu value);
-bool CPU_READ_DRX(Bitu dr,Bit32u & retvalue);
+bool CPU_READ_DRX(Bitu dr,uint32_t & retvalue);
 
 bool CPU_WRITE_TRX(Bitu dr,Bitu value);
-bool CPU_READ_TRX(Bitu dr,Bit32u & retvalue);
+bool CPU_READ_TRX(Bitu dr,uint32_t & retvalue);
 
 Bitu CPU_SMSW(void);
 bool CPU_LMSW(Bitu word);
@@ -157,7 +157,7 @@ static inline void CPU_SW_Interrupt_NoIOPLCheck(Bitu num,Bitu oldeip) {
 
 bool CPU_PrepareException(Bitu which,Bitu error);
 void CPU_Exception(Bitu which,Bitu error=0);
-void CPU_DebugException(Bit32u triggers,Bitu oldeip);
+void CPU_DebugException(uint32_t triggers,Bitu oldeip);
 
 bool CPU_SetSegGeneral(SegNames seg,Bitu value);
 bool CPU_PopSeg(SegNames seg,bool use32);
@@ -237,95 +237,95 @@ void CPU_Push32(Bitu value);
 
 struct S_Descriptor {
 #ifdef WORDS_BIGENDIAN
-	Bit32u base_0_15	:16;
-	Bit32u limit_0_15	:16;
-	Bit32u base_24_31	:8;
-	Bit32u g			:1;
-	Bit32u big			:1;
-	Bit32u r			:1;
-	Bit32u avl			:1;
-	Bit32u limit_16_19	:4;
-	Bit32u p			:1;
-	Bit32u dpl			:2;
-	Bit32u type			:5;
-	Bit32u base_16_23	:8;
+	uint32_t base_0_15	:16;
+	uint32_t limit_0_15	:16;
+	uint32_t base_24_31	:8;
+	uint32_t g			:1;
+	uint32_t big			:1;
+	uint32_t r			:1;
+	uint32_t avl			:1;
+	uint32_t limit_16_19	:4;
+	uint32_t p			:1;
+	uint32_t dpl			:2;
+	uint32_t type			:5;
+	uint32_t base_16_23	:8;
 #else
-	Bit32u limit_0_15	:16;
-	Bit32u base_0_15	:16;
-	Bit32u base_16_23	:8;
-	Bit32u type			:5;
-	Bit32u dpl			:2;
-	Bit32u p			:1;
-	Bit32u limit_16_19	:4;
-	Bit32u avl			:1;
-	Bit32u r			:1;
-	Bit32u big			:1;
-	Bit32u g			:1;
-	Bit32u base_24_31	:8;
+	uint32_t limit_0_15	:16;
+	uint32_t base_0_15	:16;
+	uint32_t base_16_23	:8;
+	uint32_t type			:5;
+	uint32_t dpl			:2;
+	uint32_t p			:1;
+	uint32_t limit_16_19	:4;
+	uint32_t avl			:1;
+	uint32_t r			:1;
+	uint32_t big			:1;
+	uint32_t g			:1;
+	uint32_t base_24_31	:8;
 #endif
 }GCC_ATTRIBUTE(packed);
 
 struct G_Descriptor {
 #ifdef WORDS_BIGENDIAN
-	Bit32u selector:	16;
-	Bit32u offset_0_15	:16;
-	Bit32u offset_16_31	:16;
-	Bit32u p			:1;
-	Bit32u dpl			:2;
-	Bit32u type			:5;
-	Bit32u reserved		:3;
-	Bit32u paramcount	:5;
+	uint32_t selector:	16;
+	uint32_t offset_0_15	:16;
+	uint32_t offset_16_31	:16;
+	uint32_t p			:1;
+	uint32_t dpl			:2;
+	uint32_t type			:5;
+	uint32_t reserved		:3;
+	uint32_t paramcount	:5;
 #else
-	Bit32u offset_0_15	:16;
-	Bit32u selector		:16;
-	Bit32u paramcount	:5;
-	Bit32u reserved		:3;
-	Bit32u type			:5;
-	Bit32u dpl			:2;
-	Bit32u p			:1;
-	Bit32u offset_16_31	:16;
+	uint32_t offset_0_15	:16;
+	uint32_t selector		:16;
+	uint32_t paramcount	:5;
+	uint32_t reserved		:3;
+	uint32_t type			:5;
+	uint32_t dpl			:2;
+	uint32_t p			:1;
+	uint32_t offset_16_31	:16;
 #endif
 } GCC_ATTRIBUTE(packed);
 
 struct TSS_16 {	
-    Bit16u back;                 /* Back link to other task */
-    Bit16u sp0;				     /* The CK stack pointer */
-    Bit16u ss0;					 /* The CK stack selector */
-	Bit16u sp1;                  /* The parent KL stack pointer */
-    Bit16u ss1;                  /* The parent KL stack selector */
-	Bit16u sp2;                  /* Unused */
-    Bit16u ss2;                  /* Unused */
-    Bit16u ip;                   /* The instruction pointer */
-    Bit16u flags;                /* The flags */
-    Bit16u ax, cx, dx, bx;       /* The general purpose registers */
-    Bit16u sp, bp, si, di;       /* The special purpose registers */
-    Bit16u es;                   /* The extra selector */
-    Bit16u cs;                   /* The code selector */
-    Bit16u ss;                   /* The application stack selector */
-    Bit16u ds;                   /* The data selector */
-    Bit16u ldt;                  /* The local descriptor table */
+    uint16_t back;                 /* Back link to other task */
+    uint16_t sp0;				     /* The CK stack pointer */
+    uint16_t ss0;					 /* The CK stack selector */
+	uint16_t sp1;                  /* The parent KL stack pointer */
+    uint16_t ss1;                  /* The parent KL stack selector */
+	uint16_t sp2;                  /* Unused */
+    uint16_t ss2;                  /* Unused */
+    uint16_t ip;                   /* The instruction pointer */
+    uint16_t flags;                /* The flags */
+    uint16_t ax, cx, dx, bx;       /* The general purpose registers */
+    uint16_t sp, bp, si, di;       /* The special purpose registers */
+    uint16_t es;                   /* The extra selector */
+    uint16_t cs;                   /* The code selector */
+    uint16_t ss;                   /* The application stack selector */
+    uint16_t ds;                   /* The data selector */
+    uint16_t ldt;                  /* The local descriptor table */
 } GCC_ATTRIBUTE(packed);
 
 struct TSS_32 {	
-    Bit32u back;                /* Back link to other task */
-	Bit32u esp0;		         /* The CK stack pointer */
-    Bit32u ss0;					 /* The CK stack selector */
-	Bit32u esp1;                 /* The parent KL stack pointer */
-    Bit32u ss1;                  /* The parent KL stack selector */
-	Bit32u esp2;                 /* Unused */
-    Bit32u ss2;                  /* Unused */
-	Bit32u cr3;                  /* The page directory pointer */
-    Bit32u eip;                  /* The instruction pointer */
-    Bit32u eflags;               /* The flags */
-    Bit32u eax, ecx, edx, ebx;   /* The general purpose registers */
-    Bit32u esp, ebp, esi, edi;   /* The special purpose registers */
-    Bit32u es;                   /* The extra selector */
-    Bit32u cs;                   /* The code selector */
-    Bit32u ss;                   /* The application stack selector */
-    Bit32u ds;                   /* The data selector */
-    Bit32u fs;                   /* And another extra selector */
-    Bit32u gs;                   /* ... and another one */
-    Bit32u ldt;                  /* The local descriptor table */
+    uint32_t back;                /* Back link to other task */
+	uint32_t esp0;		         /* The CK stack pointer */
+    uint32_t ss0;					 /* The CK stack selector */
+	uint32_t esp1;                 /* The parent KL stack pointer */
+    uint32_t ss1;                  /* The parent KL stack selector */
+	uint32_t esp2;                 /* Unused */
+    uint32_t ss2;                  /* Unused */
+	uint32_t cr3;                  /* The page directory pointer */
+    uint32_t eip;                  /* The instruction pointer */
+    uint32_t eflags;               /* The flags */
+    uint32_t eax, ecx, edx, ebx;   /* The general purpose registers */
+    uint32_t esp, ebp, esi, edi;   /* The special purpose registers */
+    uint32_t es;                   /* The extra selector */
+    uint32_t cs;                   /* The code selector */
+    uint32_t ss;                   /* The application stack selector */
+    uint32_t ds;                   /* The data selector */
+    uint32_t fs;                   /* And another extra selector */
+    uint32_t gs;                   /* ... and another one */
+    uint32_t ldt;                  /* The local descriptor table */
 } GCC_ATTRIBUTE(packed);
 
 #ifdef _MSC_VER
@@ -508,8 +508,8 @@ struct CPUBlock {
 	} exception;
 	Bits direction;
 	bool trap_skip;
-	Bit32u drx[8];
-	Bit32u trx[8];
+	uint32_t drx[8];
+	uint32_t trx[8];
 };
 
 extern CPUBlock cpu;

--- a/include/debug.h
+++ b/include/debug.h
@@ -24,9 +24,9 @@
 void DEBUG_SetupConsole(void);
 void DEBUG_DrawScreen(void);
 bool DEBUG_Breakpoint(void);
-bool DEBUG_IntBreakpoint(Bit8u intNum);
+bool DEBUG_IntBreakpoint(uint8_t intNum);
 void DEBUG_Enable(bool pressed);
-void DEBUG_CheckExecuteBreakpoint(Bit16u seg, Bit32u off);
+void DEBUG_CheckExecuteBreakpoint(uint16_t seg, uint32_t off);
 bool DEBUG_ExitLoop(void);
 void DEBUG_RefreshPage(char scroll);
 Bitu DEBUG_EnableDebugger(void);

--- a/include/dma.h
+++ b/include/dma.h
@@ -40,17 +40,17 @@ using DMA_CallBack = std::function<void(DmaChannel *chan, DMAEvent event)>;
 
 class DmaChannel {
 public:
-	Bit32u pagebase;
-	Bit16u baseaddr;
-	Bit32u curraddr;
-	Bit16u basecnt;
-	Bit16u currcnt;
-	Bit8u channum;
-	Bit8u pagenum;
-	Bit8u DMA16;
+	uint32_t pagebase;
+	uint16_t baseaddr;
+	uint32_t curraddr;
+	uint16_t basecnt;
+	uint16_t currcnt;
+	uint8_t channum;
+	uint8_t pagenum;
+	uint8_t DMA16;
 	bool increment;
 	bool autoinit;
-//	Bit8u trantype; //Not used at the moment
+//	uint8_t trantype; //Not used at the moment
 	bool masked;
 	bool tcount;
 	bool request;
@@ -76,7 +76,7 @@ public:
 		tcount=true;
 		DoCallBack(DMA_REACHED_TC);
 	}
-	void SetPage(Bit8u val) {
+	void SetPage(uint8_t val) {
 		pagenum=val;
 		pagebase=(pagenum >> DMA16) << (16+DMA16);
 	}
@@ -138,7 +138,7 @@ public:
 	uint16_t ReadControllerReg(io_port_t reg, io_width_t width);
 };
 
-DmaChannel * GetDMAChannel(Bit8u chan);
+DmaChannel * GetDMAChannel(uint8_t chan);
 
 void CloseSecondDMAController(void);
 bool SecondDMAControllerAvailable(void);

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -44,13 +44,13 @@ struct CommandTail{
 #endif
 
 struct DOS_Date {
-	Bit16u year;
-	Bit8u month;
-	Bit8u day;
+	uint16_t year;
+	uint8_t month;
+	uint8_t day;
 };
 
 struct DOS_Version {
-	Bit8u major,minor,revision;
+	uint8_t major,minor,revision;
 };
 
 
@@ -59,14 +59,14 @@ struct DOS_Version {
 #endif
 union bootSector {
 	struct entries {
-		Bit8u jump[3];
-		Bit8u oem_name[8];
-		Bit16u bytesect;
-		Bit8u sectclust;
-		Bit16u reserve_sect;
-		Bit8u misc[496];
+		uint8_t jump[3];
+		uint8_t oem_name[8];
+		uint16_t bytesect;
+		uint8_t sectclust;
+		uint16_t reserve_sect;
+		uint8_t misc[496];
 	} bootdata;
-	Bit8u rawdata[512];
+	uint8_t rawdata[512];
 } GCC_ATTRIBUTE(packed);
 #ifdef _MSC_VER
 #pragma pack ()
@@ -100,10 +100,10 @@ extern DOS_File * Files[DOS_FILES];
 extern DOS_Drive * Drives[DOS_DRIVES];
 extern DOS_Device * Devices[DOS_DEVICES];
 
-extern Bit8u dos_copybuf[0x10000];
+extern uint8_t dos_copybuf[0x10000];
 
 
-void DOS_SetError(Bit16u code);
+void DOS_SetError(uint16_t code);
 
 /* File Handling Routines */
 
@@ -112,14 +112,14 @@ enum { HAND_NONE=0,HAND_FILE,HAND_DEVICE};
 
 /* Routines for File Class */
 void DOS_SetupFiles (void);
-bool DOS_ReadFile(Bit16u handle,Bit8u * data,Bit16u * amount, bool fcb = false);
-bool DOS_WriteFile(Bit16u handle,Bit8u * data,Bit16u * amount,bool fcb = false);
-bool DOS_SeekFile(Bit16u handle,Bit32u * pos,Bit32u type,bool fcb = false);
-bool DOS_CloseFile(Bit16u handle,bool fcb = false,Bit8u * refcnt = NULL);
-bool DOS_FlushFile(Bit16u handle);
-bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry);
-bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry);
-bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate);
+bool DOS_ReadFile(uint16_t handle,uint8_t * data,uint16_t * amount, bool fcb = false);
+bool DOS_WriteFile(uint16_t handle,uint8_t * data,uint16_t * amount,bool fcb = false);
+bool DOS_SeekFile(uint16_t handle,uint32_t * pos,uint32_t type,bool fcb = false);
+bool DOS_CloseFile(uint16_t handle,bool fcb = false,uint8_t * refcnt = NULL);
+bool DOS_FlushFile(uint16_t handle);
+bool DOS_DuplicateEntry(uint16_t entry,uint16_t * newentry);
+bool DOS_ForceDuplicateEntry(uint16_t entry,uint16_t newentry);
+bool DOS_GetFileDate(uint16_t entry, uint16_t* otime, uint16_t* odate);
 bool DOS_SetFileDate(uint16_t entry, uint16_t ntime, uint16_t ndate);
 
 // Date and Time Conversion
@@ -160,72 +160,72 @@ constexpr uint16_t DOS_PackDate(const struct tm &datetime) noexcept
 }
 
 /* Routines for Drive Class */
-bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb = false);
-bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bit16u action, Bit16u *entry, Bit16u* status);
-bool DOS_CreateFile(char const * name,Bit16u attribute,Bit16u * entry, bool fcb = false);
+bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb = false);
+bool DOS_OpenFileExtended(char const * name, uint16_t flags, uint16_t createAttr, uint16_t action, uint16_t *entry, uint16_t* status);
+bool DOS_CreateFile(char const * name,uint16_t attribute,uint16_t * entry, bool fcb = false);
 bool DOS_UnlinkFile(char const * const name);
 bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst = false);
 bool DOS_FindNext(void);
 bool DOS_Canonicalize(char const * const name,char * const big);
-bool DOS_CreateTempFile(char * const name,Bit16u * entry);
+bool DOS_CreateTempFile(char * const name,uint16_t * entry);
 bool DOS_FileExists(char const * const name);
 
 /* Helper Functions */
-bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive);
+bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive);
 /* Drive Handing Routines */
-Bit8u DOS_GetDefaultDrive(void);
-void DOS_SetDefaultDrive(Bit8u drive);
-bool DOS_SetDrive(Bit8u drive);
-bool DOS_GetCurrentDir(Bit8u drive,char * const buffer);
+uint8_t DOS_GetDefaultDrive(void);
+void DOS_SetDefaultDrive(uint8_t drive);
+bool DOS_SetDrive(uint8_t drive);
+bool DOS_GetCurrentDir(uint8_t drive,char * const buffer);
 bool DOS_ChangeDir(char const * const dir);
 bool DOS_MakeDir(char const * const dir);
 bool DOS_RemoveDir(char const * const dir);
 bool DOS_Rename(char const * const oldname,char const * const newname);
-bool DOS_GetFreeDiskSpace(Bit8u drive,Bit16u * bytes,Bit8u * sectors,Bit16u * clusters,Bit16u * free);
-bool DOS_GetFileAttr(char const * const name,Bit16u * attr);
-bool DOS_SetFileAttr(char const * const name,Bit16u attr);
+bool DOS_GetFreeDiskSpace(uint8_t drive,uint16_t * bytes,uint8_t * sectors,uint16_t * clusters,uint16_t * free);
+bool DOS_GetFileAttr(char const * const name,uint16_t * attr);
+bool DOS_SetFileAttr(char const * const name,uint16_t attr);
 
 /* IOCTL Stuff */
 bool DOS_IOCTL(void);
 bool DOS_GetSTDINStatus();
-Bit8u DOS_FindDevice(char const * name);
+uint8_t DOS_FindDevice(char const * name);
 void DOS_SetupDevices();
 void DOS_ShutDownDevices();
 
 /* Execute and new process creation */
-bool DOS_NewPSP(Bit16u pspseg,Bit16u size);
-bool DOS_ChildPSP(Bit16u pspseg,Bit16u size);
-bool DOS_Execute(char * name,PhysPt block,Bit8u flags);
-void DOS_Terminate(Bit16u pspseg,bool tsr,Bit8u exitcode);
+bool DOS_NewPSP(uint16_t pspseg,uint16_t size);
+bool DOS_ChildPSP(uint16_t pspseg,uint16_t size);
+bool DOS_Execute(char * name,PhysPt block,uint8_t flags);
+void DOS_Terminate(uint16_t pspseg,bool tsr,uint8_t exitcode);
 
 /* Memory Handling Routines */
 void DOS_SetupMemory(void);
-bool DOS_AllocateMemory(Bit16u * segment,Bit16u * blocks);
-bool DOS_ResizeMemory(Bit16u segment,Bit16u * blocks);
-bool DOS_FreeMemory(Bit16u segment);
-void DOS_FreeProcessMemory(Bit16u pspseg);
-Bit16u DOS_GetMemory(Bit16u pages);
-bool DOS_SetMemAllocStrategy(Bit16u strat);
-Bit16u DOS_GetMemAllocStrategy(void);
+bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks);
+bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks);
+bool DOS_FreeMemory(uint16_t segment);
+void DOS_FreeProcessMemory(uint16_t pspseg);
+uint16_t DOS_GetMemory(uint16_t pages);
+bool DOS_SetMemAllocStrategy(uint16_t strat);
+uint16_t DOS_GetMemAllocStrategy(void);
 void DOS_BuildUMBChain(bool umb_active,bool ems_active);
-bool DOS_LinkUMBsToMemChain(Bit16u linkstate);
+bool DOS_LinkUMBsToMemChain(uint16_t linkstate);
 
 /* FCB stuff */
-bool DOS_FCBOpen(Bit16u seg,Bit16u offset);
-bool DOS_FCBCreate(Bit16u seg,Bit16u offset);
-bool DOS_FCBClose(Bit16u seg,Bit16u offset);
-bool DOS_FCBFindFirst(Bit16u seg,Bit16u offset);
-bool DOS_FCBFindNext(Bit16u seg,Bit16u offset);
-Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset, Bit16u numBlocks);
-Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u numBlocks);
-Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore);
-Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore);
-bool DOS_FCBGetFileSize(Bit16u seg,Bit16u offset);
-bool DOS_FCBDeleteFile(Bit16u seg,Bit16u offset);
-bool DOS_FCBRenameFile(Bit16u seg, Bit16u offset);
-void DOS_FCBSetRandomRecord(Bit16u seg, Bit16u offset);
-Bit8u FCB_Parsename(Bit16u seg,Bit16u offset,Bit8u parser ,char *string, Bit8u *change);
-bool DOS_GetAllocationInfo(Bit8u drive,Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters);
+bool DOS_FCBOpen(uint16_t seg,uint16_t offset);
+bool DOS_FCBCreate(uint16_t seg,uint16_t offset);
+bool DOS_FCBClose(uint16_t seg,uint16_t offset);
+bool DOS_FCBFindFirst(uint16_t seg,uint16_t offset);
+bool DOS_FCBFindNext(uint16_t seg,uint16_t offset);
+uint8_t DOS_FCBRead(uint16_t seg,uint16_t offset, uint16_t numBlocks);
+uint8_t DOS_FCBWrite(uint16_t seg,uint16_t offset,uint16_t numBlocks);
+uint8_t DOS_FCBRandomRead(uint16_t seg,uint16_t offset,uint16_t * numRec,bool restore);
+uint8_t DOS_FCBRandomWrite(uint16_t seg,uint16_t offset,uint16_t * numRec,bool restore);
+bool DOS_FCBGetFileSize(uint16_t seg,uint16_t offset);
+bool DOS_FCBDeleteFile(uint16_t seg,uint16_t offset);
+bool DOS_FCBRenameFile(uint16_t seg, uint16_t offset);
+void DOS_FCBSetRandomRecord(uint16_t seg, uint16_t offset);
+uint8_t FCB_Parsename(uint16_t seg,uint16_t offset,uint8_t parser ,char *string, uint8_t *change);
+bool DOS_GetAllocationInfo(uint8_t drive,uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters);
 
 /* Extra DOS Interrupts */
 void DOS_SetupMisc(void);
@@ -239,7 +239,7 @@ void DOS_SetupPrograms(void);
 /* Initialize Keyboard Layout */
 void DOS_KeyboardLayout_Init(Section* sec);
 
-bool DOS_LayoutKey(Bitu key, Bit8u flags1, Bit8u flags2, Bit8u flags3);
+bool DOS_LayoutKey(Bitu key, uint8_t flags1, uint8_t flags2, uint8_t flags3);
 
 DOS_Version DOS_ParseVersion(const char *word, const char *args);
 
@@ -252,10 +252,10 @@ enum {
 };
 
 
-static inline Bit16u long2para(Bit32u size) {
+static inline uint16_t long2para(uint32_t size) {
 	if (size>0xFFFF0) return 0xffff;
-	if (size&0xf) return (Bit16u)((size>>4)+1);
-	else return (Bit16u)(size>>4);
+	if (size&0xf) return (uint16_t)((size>>4)+1);
+	else return (uint16_t)(size>>4);
 }
 
 /* Dos Error Codes */
@@ -383,31 +383,31 @@ private:
 	#pragma pack(1)
 	#endif
 	struct sPSP {
-		Bit8u   exit[2];     /* CP/M-like exit poimt */
-		Bit16u  next_seg;    /* Segment of first byte beyond memory allocated or program */
-		Bit8u   fill_1;      /* single char fill */
-		Bit8u   far_call;    /* far call opcode */
+		uint8_t   exit[2];     /* CP/M-like exit poimt */
+		uint16_t  next_seg;    /* Segment of first byte beyond memory allocated or program */
+		uint8_t   fill_1;      /* single char fill */
+		uint8_t   far_call;    /* far call opcode */
 		RealPt  cpm_entry;   /* CPM Service Request address*/
 		RealPt  int_22;      /* Terminate Address */
 		RealPt  int_23;      /* Break Address */
 		RealPt  int_24;      /* Critical Error Address */
-		Bit16u  psp_parent;  /* Parent PSP Segment */
-		Bit8u   files[20];   /* File Table - 0xff is unused */
-		Bit16u  environment; /* Segment of evironment table */
+		uint16_t  psp_parent;  /* Parent PSP Segment */
+		uint8_t   files[20];   /* File Table - 0xff is unused */
+		uint16_t  environment; /* Segment of evironment table */
 		RealPt  stack;       /* SS:SP Save point for int 0x21 calls */
-		Bit16u  max_files;   /* Maximum open files */
+		uint16_t  max_files;   /* Maximum open files */
 		RealPt  file_table;  /* Pointer to File Table PSP:0x18 */
 		RealPt  prev_psp;    /* Pointer to previous PSP */
-		Bit8u   interim_flag;
-		Bit8u   truename_flag;
-		Bit16u  nn_flags;
-		Bit16u  dos_version;
-		Bit8u   fill_2[14];  /* Lot's of unused stuff i can't care aboue */
-		Bit8u   service[3];  /* INT 0x21 Service call int 0x21;retf; */
-		Bit8u   fill_3[9];   /* This has some blocks with FCB info */
-		Bit8u   fcb1[16];    /* first FCB */
-		Bit8u   fcb2[16];    /* second FCB */
-		Bit8u   fill_4[4];   /* unused */
+		uint8_t   interim_flag;
+		uint8_t   truename_flag;
+		uint16_t  nn_flags;
+		uint16_t  dos_version;
+		uint8_t   fill_2[14];  /* Lot's of unused stuff i can't care aboue */
+		uint8_t   service[3];  /* INT 0x21 Service call int 0x21;retf; */
+		uint8_t   fill_3[9];   /* This has some blocks with FCB info */
+		uint8_t   fcb1[16];    /* first FCB */
+		uint8_t   fcb2[16];    /* second FCB */
+		uint8_t   fill_4[4];   /* unused */
 		CommandTail cmdtail;
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
@@ -417,7 +417,7 @@ private:
 	uint16_t seg;
 
 public:
-	static	Bit16u rootpsp;
+	static	uint16_t rootpsp;
 };
 
 class DOS_ParamBlock final : public MemStruct {
@@ -437,11 +437,11 @@ public:
 	#pragma pack (1)
 	#endif
 	struct sOverlay {
-		Bit16u loadseg;
-		Bit16u relocation;
+		uint16_t loadseg;
+		uint16_t relocation;
 	} GCC_ATTRIBUTE(packed);
 	struct sExec {
-		Bit16u envseg;
+		uint16_t envseg;
 		RealPt cmdtail;
 		RealPt fcb1;
 		RealPt fcb2;
@@ -486,59 +486,59 @@ public:
 	#pragma pack(1)
 	#endif
 	struct sDIB {
-		Bit8u	unknown1[4];
-		Bit16u	magicWord;			// -0x22 needs to be 1
-		Bit8u	unknown2[8];
-		Bit16u	regCXfrom5e;		// -0x18 CX from last int21/ah=5e
-		Bit16u	countLRUcache;		// -0x16 LRU counter for FCB caching
-		Bit16u	countLRUopens;		// -0x14 LRU counter for FCB openings
-		Bit8u	stuff[6];		// -0x12 some stuff, hopefully never used....
-		Bit16u	sharingCount;		// -0x0c sharing retry count
-		Bit16u	sharingDelay;		// -0x0a sharing retry delay
+		uint8_t	unknown1[4];
+		uint16_t	magicWord;			// -0x22 needs to be 1
+		uint8_t	unknown2[8];
+		uint16_t	regCXfrom5e;		// -0x18 CX from last int21/ah=5e
+		uint16_t	countLRUcache;		// -0x16 LRU counter for FCB caching
+		uint16_t	countLRUopens;		// -0x14 LRU counter for FCB openings
+		uint8_t	stuff[6];		// -0x12 some stuff, hopefully never used....
+		uint16_t	sharingCount;		// -0x0c sharing retry count
+		uint16_t	sharingDelay;		// -0x0a sharing retry delay
 		RealPt	diskBufPtr;		// -0x08 pointer to disk buffer
-		Bit16u	ptrCONinput;		// -0x04 pointer to con input
-		Bit16u	firstMCB;		// -0x02 first memory control block
+		uint16_t	ptrCONinput;		// -0x04 pointer to con input
+		uint16_t	firstMCB;		// -0x02 first memory control block
 		RealPt	firstDPB;		//  0x00 first drive parameter block
 		RealPt	firstFileTable;		//  0x04 first system file table
 		RealPt	activeClock;		//  0x08 active clock device header
 		RealPt	activeCon;		//  0x0c active console device header
-		Bit16u	maxSectorLength;	//  0x10 maximum bytes per sector of any block device;
+		uint16_t	maxSectorLength;	//  0x10 maximum bytes per sector of any block device;
 		RealPt	diskInfoBuffer;		//  0x12 pointer to disk info buffer
 		RealPt  curDirStructure;	//  0x16 pointer to current array of directory structure
 		RealPt	fcbTable;		//  0x1a pointer to system FCB table
-		Bit16u	protFCBs;		//  0x1e protected fcbs
-		Bit8u	blockDevices;		//  0x20 installed block devices
-		Bit8u	lastdrive;		//  0x21 lastdrive
-		Bit32u	nulNextDriver;	//  0x22 NUL driver next pointer
-		Bit16u	nulAttributes;	//  0x26 NUL driver aattributes
-		Bit32u	nulStrategy;	//  0x28 NUL driver strategy routine
-		Bit8u	nulString[8];	//  0x2c NUL driver name string
-		Bit8u	joindedDrives;		//  0x34 joined drives
-		Bit16u	specialCodeSeg;		//  0x35 special code segment
+		uint16_t	protFCBs;		//  0x1e protected fcbs
+		uint8_t	blockDevices;		//  0x20 installed block devices
+		uint8_t	lastdrive;		//  0x21 lastdrive
+		uint32_t	nulNextDriver;	//  0x22 NUL driver next pointer
+		uint16_t	nulAttributes;	//  0x26 NUL driver aattributes
+		uint32_t	nulStrategy;	//  0x28 NUL driver strategy routine
+		uint8_t	nulString[8];	//  0x2c NUL driver name string
+		uint8_t	joindedDrives;		//  0x34 joined drives
+		uint16_t	specialCodeSeg;		//  0x35 special code segment
 		RealPt  setverPtr;		//  0x37 pointer to setver
-		Bit16u  a20FixOfs;		//  0x3b a20 fix routine offset
-		Bit16u  pspLastIfHMA;		//  0x3d psp of last program (if dos in hma)
-		Bit16u	buffers_x;		//  0x3f x in BUFFERS x,y
-		Bit16u	buffers_y;		//  0x41 y in BUFFERS x,y
-		Bit8u	bootDrive;		//  0x43 boot drive
-		Bit8u	useDwordMov;		//  0x44 use dword moves
-		Bit16u	extendedSize;		//  0x45 size of extended memory
-		Bit32u	diskBufferHeadPt;	//  0x47 pointer to least-recently used buffer header
-		Bit16u	dirtyDiskBuffers;	//  0x4b number of dirty disk buffers
-		Bit32u	lookaheadBufPt;		//  0x4d pointer to lookahead buffer
-		Bit16u	lookaheadBufNumber;		//  0x51 number of lookahead buffers
-		Bit8u	bufferLocation;			//  0x53 workspace buffer location
-		Bit32u	workspaceBuffer;		//  0x54 pointer to workspace buffer
-		Bit8u	unknown3[11];			//  0x58
-		Bit8u	chainingUMB;			//  0x63 bit0: UMB chain linked to MCB chain
-		Bit16u	minMemForExec;			//  0x64 minimum paragraphs needed for current program
-		Bit16u	startOfUMBChain;		//  0x66 segment of first UMB-MCB
-		Bit16u	memAllocScanStart;		//  0x68 start paragraph for memory allocation
+		uint16_t  a20FixOfs;		//  0x3b a20 fix routine offset
+		uint16_t  pspLastIfHMA;		//  0x3d psp of last program (if dos in hma)
+		uint16_t	buffers_x;		//  0x3f x in BUFFERS x,y
+		uint16_t	buffers_y;		//  0x41 y in BUFFERS x,y
+		uint8_t	bootDrive;		//  0x43 boot drive
+		uint8_t	useDwordMov;		//  0x44 use dword moves
+		uint16_t	extendedSize;		//  0x45 size of extended memory
+		uint32_t	diskBufferHeadPt;	//  0x47 pointer to least-recently used buffer header
+		uint16_t	dirtyDiskBuffers;	//  0x4b number of dirty disk buffers
+		uint32_t	lookaheadBufPt;		//  0x4d pointer to lookahead buffer
+		uint16_t	lookaheadBufNumber;		//  0x51 number of lookahead buffers
+		uint8_t	bufferLocation;			//  0x53 workspace buffer location
+		uint32_t	workspaceBuffer;		//  0x54 pointer to workspace buffer
+		uint8_t	unknown3[11];			//  0x58
+		uint8_t	chainingUMB;			//  0x63 bit0: UMB chain linked to MCB chain
+		uint16_t	minMemForExec;			//  0x64 minimum paragraphs needed for current program
+		uint16_t	startOfUMBChain;		//  0x66 segment of first UMB-MCB
+		uint16_t	memAllocScanStart;		//  0x68 start paragraph for memory allocation
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
 	#pragma pack ()
 	#endif
-	Bit16u	seg;
+	uint16_t	seg;
 };
 
 /* Disk Transfer Address
@@ -576,17 +576,17 @@ private:
 	#pragma pack(1)
 	#endif
 	struct sDTA {
-		Bit8u sdrive;						/* The Drive the search is taking place */
-		Bit8u sname[8];						/* The Search pattern for the filename */
-		Bit8u sext[3];						/* The Search pattern for the extension */
-		Bit8u sattr;						/* The Attributes that need to be found */
-		Bit16u dirID;						/* custom: dir-search ID for multiple searches at the same time */
-		Bit16u dirCluster;					/* custom (drive_fat only): cluster number for multiple searches at the same time */
-		Bit8u fill[4];
-		Bit8u attr;
-		Bit16u time;
-		Bit16u date;
-		Bit32u size;
+		uint8_t sdrive;						/* The Drive the search is taking place */
+		uint8_t sname[8];						/* The Search pattern for the filename */
+		uint8_t sext[3];						/* The Search pattern for the extension */
+		uint8_t sattr;						/* The Attributes that need to be found */
+		uint16_t dirID;						/* custom: dir-search ID for multiple searches at the same time */
+		uint16_t dirCluster;					/* custom (drive_fat only): cluster number for multiple searches at the same time */
+		uint8_t fill[4];
+		uint8_t attr;
+		uint16_t time;
+		uint16_t date;
+		uint32_t size;
 		char name[DOS_NAMELENGTH_ASCII];
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
@@ -625,7 +625,7 @@ public:
 	void SetAttr(uint8_t attr);
 	void GetAttr(uint8_t &attr) const;
 
-	void SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr);
+	void SetResult(uint32_t size,uint16_t date,uint16_t time,uint8_t attr);
 
 	uint8_t GetDrive() const;
 
@@ -640,25 +640,25 @@ private:
 	#pragma pack (1)
 	#endif
 	struct sFCB {
-		Bit8u drive;			/* Drive number 0=default, 1=A, etc */
-		Bit8u filename[8];		/* Space padded name */
-		Bit8u ext[3];			/* Space padded extension */
-		Bit16u cur_block;		/* Current Block */
-		Bit16u rec_size;		/* Logical record size */
-		Bit32u filesize;		/* File Size */
+		uint8_t drive;			/* Drive number 0=default, 1=A, etc */
+		uint8_t filename[8];		/* Space padded name */
+		uint8_t ext[3];			/* Space padded extension */
+		uint16_t cur_block;		/* Current Block */
+		uint16_t rec_size;		/* Logical record size */
+		uint32_t filesize;		/* File Size */
 		uint16_t date;                  // Date of last modification
 		uint16_t time;                  // Time of last modification
 		/* Reserved Block should be 8 bytes */
-		Bit8u sft_entries;
-		Bit8u share_attributes;
-		Bit8u extra_info;
+		uint8_t sft_entries;
+		uint8_t share_attributes;
+		uint8_t extra_info;
 		/* Maybe swap file_handle and sft_entries now that fcbs
 		 * aren't stored in the psp filetable anymore */
-		Bit8u file_handle;
-		Bit8u reserved[4];
+		uint8_t file_handle;
+		uint8_t reserved[4];
 		/* end */
-		Bit8u  cur_rec;			/* Current record in current block */
-		Bit32u rndm;			/* Current relative record number */
+		uint8_t  cur_rec;			/* Current record in current block */
+		uint32_t rndm;			/* Current relative record number */
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
 	#pragma pack ()
@@ -688,11 +688,11 @@ private:
 	#pragma pack (1)
 	#endif
 	struct sMCB {
-		Bit8u type;
-		Bit16u psp_segment;
+		uint8_t type;
+		uint16_t psp_segment;
 		uint16_t size; // Allocation size in 16-byte paragraphs
-		Bit8u unused[3];
-		Bit8u filename[8];
+		uint8_t unused[3];
+		uint8_t filename[8];
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
 	#pragma pack ()
@@ -719,21 +719,21 @@ private:
 	#pragma pack (1)
 	#endif
 	struct sSDA {
-		Bit8u crit_error_flag;		/* 0x00 Critical Error Flag */
-		Bit8u inDOS_flag;		/* 0x01 InDOS flag (count of active INT 21 calls) */
-		Bit8u drive_crit_error;		/* 0x02 Drive on which current critical error occurred or FFh */
-		Bit8u locus_of_last_error;	/* 0x03 locus of last error */
-		Bit16u extended_error_code;	/* 0x04 extended error code of last error */
-		Bit8u suggested_action;		/* 0x06 suggested action for last error */
-		Bit8u error_class;		/* 0x07 class of last error*/
-		Bit32u last_error_pointer; 	/* 0x08 ES:DI pointer for last error */
-		Bit32u current_dta;		/* 0x0C current DTA (Disk Transfer Address) */
-		Bit16u current_psp; 		/* 0x10 current PSP */
-		Bit16u sp_int_23;		/* 0x12 stores SP across an INT 23 */
-		Bit16u return_code;		/* 0x14 return code from last process termination (zerod after reading with AH=4Dh) */
-		Bit8u current_drive;		/* 0x16 current drive */
-		Bit8u extended_break_flag; 	/* 0x17 extended break flag */
-		Bit8u fill[2];			/* 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort*/
+		uint8_t crit_error_flag;		/* 0x00 Critical Error Flag */
+		uint8_t inDOS_flag;		/* 0x01 InDOS flag (count of active INT 21 calls) */
+		uint8_t drive_crit_error;		/* 0x02 Drive on which current critical error occurred or FFh */
+		uint8_t locus_of_last_error;	/* 0x03 locus of last error */
+		uint16_t extended_error_code;	/* 0x04 extended error code of last error */
+		uint8_t suggested_action;		/* 0x06 suggested action for last error */
+		uint8_t error_class;		/* 0x07 class of last error*/
+		uint32_t last_error_pointer; 	/* 0x08 ES:DI pointer for last error */
+		uint32_t current_dta;		/* 0x0C current DTA (Disk Transfer Address) */
+		uint16_t current_psp; 		/* 0x10 current PSP */
+		uint16_t sp_int_23;		/* 0x12 stores SP across an INT 23 */
+		uint16_t return_code;		/* 0x14 return code from last process termination (zerod after reading with AH=4Dh) */
+		uint8_t current_drive;		/* 0x16 current drive */
+		uint8_t extended_break_flag; 	/* 0x17 extended break flag */
+		uint8_t fill[2];			/* 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort*/
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
 	#pragma pack()
@@ -744,21 +744,21 @@ extern DOS_InfoBlock dos_infoblock;
 struct DOS_Block {
 	DOS_Date date;
 	DOS_Version version;
-	Bit16u firstMCB;
-	Bit16u errorcode;
+	uint16_t firstMCB;
+	uint16_t errorcode;
 
 	uint16_t psp() { return DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).GetPSP(); }
 	void psp(uint16_t seg) { DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).SetPSP(seg); }
 
-	Bit16u env;
+	uint16_t env;
 	RealPt cpmentry;
 
 	RealPt dta() { return DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).GetDTA(); }
 	void dta(RealPt dtap) { DOS_SDA(DOS_SDA_SEG, DOS_SDA_OFS).SetDTA(dtap); }
 
-	Bit8u return_code,return_mode;
+	uint8_t return_code,return_mode;
 
-	Bit8u current_drive;
+	uint8_t current_drive;
 	bool verify;
 	bool breakcheck;
 	bool echo;          // if set to true dev_con::read will echo input 
@@ -772,16 +772,16 @@ struct DOS_Block {
 		RealPt filenamechar;
 		RealPt collatingseq;
 		RealPt upcase;
-		Bit8u* country;//Will be copied to dos memory. resides in real mem
-		Bit16u dpb; //Fake Disk parameter system using only the first entry so the drive letter matches
+		uint8_t* country;//Will be copied to dos memory. resides in real mem
+		uint16_t dpb; //Fake Disk parameter system using only the first entry so the drive letter matches
 	} tables;
-	Bit16u loaded_codepage;
+	uint16_t loaded_codepage;
 	uint16_t dcp;
 };
 
 extern DOS_Block dos;
 
-static inline Bit8u RealHandle(Bit16u handle) {
+static inline uint8_t RealHandle(uint16_t handle) {
 	DOS_PSP psp(dos.psp());	
 	return psp.GetFileHandle(handle);
 }

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -49,10 +49,10 @@ enum {
 };
 
 struct FileStat_Block {
-	Bit32u size;
-	Bit16u time;
-	Bit16u date;
-	Bit16u attr;
+	uint32_t size;
+	uint16_t time;
+	uint16_t date;
+	uint16_t attr;
 };
 
 class DOS_DTA;
@@ -85,11 +85,11 @@ public:
 		return !name.empty() && (strcasecmp(name.c_str(), str) == 0);
 	}
 
-	virtual bool	Read(Bit8u * data,Bit16u * size)=0;
-	virtual bool	Write(Bit8u * data,Bit16u * size)=0;
-	virtual bool	Seek(Bit32u * pos,Bit32u type)=0;
+	virtual bool	Read(uint8_t * data,uint16_t * size)=0;
+	virtual bool	Write(uint8_t * data,uint16_t * size)=0;
+	virtual bool	Seek(uint32_t * pos,uint32_t type)=0;
 	virtual bool	Close()=0;
-	virtual Bit16u	GetInformation(void)=0;
+	virtual uint16_t	GetInformation(void)=0;
 
 	virtual bool IsOpen() { return open; }
 	virtual void AddRef() { refCtr++; }
@@ -97,19 +97,19 @@ public:
 	virtual bool UpdateDateTimeFromHost() { return true; }
 	virtual void SetFlagReadOnlyMedium() {}
 
-	void SetDrive(Bit8u drv) { hdrive=drv;}
-	Bit8u GetDrive(void) { return hdrive;}
-	Bit32u flags;
-	Bit16u time;
-	Bit16u date;
-	Bit16u attr;
+	void SetDrive(uint8_t drv) { hdrive=drv;}
+	uint8_t GetDrive(void) { return hdrive;}
+	uint32_t flags;
+	uint16_t time;
+	uint16_t date;
+	uint16_t attr;
 	Bits refCtr;
 	bool open;
 	std::string name;
 	bool newtime;
 	/* Some Device Specific Stuff */
 private:
-	Bit8u hdrive;
+	uint8_t hdrive;
 };
 
 class DOS_Device : public DOS_File {
@@ -131,13 +131,13 @@ public:
 		return *this;
 	}
 
-	virtual bool	Read(Bit8u * data,Bit16u * size);
-	virtual bool	Write(Bit8u * data,Bit16u * size);
-	virtual bool	Seek(Bit32u * pos,Bit32u type);
+	virtual bool	Read(uint8_t * data,uint16_t * size);
+	virtual bool	Write(uint8_t * data,uint16_t * size);
+	virtual bool	Seek(uint32_t * pos,uint32_t type);
 	virtual bool	Close();
-	virtual Bit16u	GetInformation(void);
-	virtual bool	ReadFromControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode);
-	virtual bool	WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode);
+	virtual uint16_t	GetInformation(void);
+	virtual bool	ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
+	virtual bool	WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
 	virtual uint8_t GetStatus(bool input_flag);
 	void SetDeviceNumber(Bitu num) { devnum=num;}
 private:
@@ -187,15 +187,15 @@ public:
 	void SetBaseDir(const char *path);
 	void SetDirSort(TDirSort sort) { sortDirType = sort; }
 
-	bool  OpenDir              (const char* path, Bit16u& id);
-	bool  ReadDir              (Bit16u id, char* &result);
+	bool  OpenDir              (const char* path, uint16_t& id);
+	bool  ReadDir              (uint16_t id, char* &result);
 
 	void  ExpandName           (char* path);
 	char* GetExpandName        (const char* path);
 	bool  GetShortName         (const char* fullname, char* shortname);
 
-	bool  FindFirst            (char* path, Bit16u& id);
-	bool  FindNext             (Bit16u id, char* &result);
+	bool  FindFirst            (char* path, uint16_t& id);
+	bool  FindNext             (uint16_t id, char* &result);
 
 	void  CacheOut             (const char* path, bool ignoreLastDir = false);
 	void  AddEntry             (const char* path, bool checkExist = false);
@@ -234,7 +234,7 @@ public:
 		char        shortname[DOS_NAMELENGTH_ASCII];
 		bool        isOverlayDir;
 		bool        isDir;
-		Bit16u      id;
+		uint16_t      id;
 		Bitu        nextEntry;
 		unsigned    shortNr;
 		// contents
@@ -255,10 +255,10 @@ private:
 	bool		IsCachedIn		(CFileInfo* dir);
 	CFileInfo*	FindDirInfo		(const char* path, char* expandedPath);
 	bool		RemoveSpaces		(char* str);
-	bool		OpenDir			(CFileInfo* dir, const char* path, Bit16u& id);
+	bool		OpenDir			(CFileInfo* dir, const char* path, uint16_t& id);
 	void		CreateEntry		(CFileInfo* dir, const char* name, bool is_directory);
 	void		CopyEntry		(CFileInfo* dir, CFileInfo* from);
-	Bit16u		GetFreeID		(CFileInfo* dir);
+	uint16_t		GetFreeID		(CFileInfo* dir);
 	void		Clear			(void);
 
 	CFileInfo*	dirBase;
@@ -269,10 +269,10 @@ private:
 	char		save_path			[CROSS_LEN];
 	char		save_expanded		[CROSS_LEN];
 
-	Bit16u		srchNr;
+	uint16_t		srchNr;
 	CFileInfo*	dirSearch			[MAX_OPENDIRS];
 	CFileInfo*	dirFindFirst		[MAX_OPENDIRS];
-	Bit16u		nextFreeFindFirst;
+	uint16_t		nextFreeFindFirst;
 
 	char		label				[CROSS_LEN];
 	bool		updatelabel;
@@ -283,8 +283,8 @@ public:
 	DOS_Drive();
 	virtual ~DOS_Drive() = default;
 
-	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags)=0;
-	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes)=0;
+	virtual bool FileOpen(DOS_File * * file,char * name,uint32_t flags)=0;
+	virtual bool FileCreate(DOS_File * * file,char * name,uint16_t attributes)=0;
 	virtual bool FileUnlink(char * _name)=0;
 	virtual bool RemoveDir(char * _dir)=0;
 	virtual bool MakeDir(char * _dir)=0;
@@ -294,10 +294,10 @@ public:
 	virtual bool GetFileAttr(char * name, uint16_t * attr) = 0;
 	virtual bool SetFileAttr(const char * name, const uint16_t attr) = 0;
 	virtual bool Rename(char * oldname,char * newname)=0;
-	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters)=0;
+	virtual bool AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters,uint16_t * _free_clusters)=0;
 	virtual bool FileExists(const char* name)=0;
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block)=0;
-	virtual Bit8u GetMediaByte(void)=0;
+	virtual uint8_t GetMediaByte(void)=0;
 	virtual void SetDir(const char *path);
 	virtual void EmptyCache() { dirCache.EmptyCache(); }
 	virtual bool isRemote(void)=0;

--- a/include/drives.h
+++ b/include/drives.h
@@ -63,11 +63,11 @@ private:
 
 class localDrive : public DOS_Drive {
 public:
-	localDrive(const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid);
-	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
+	localDrive(const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid);
+	virtual bool FileOpen(DOS_File * * file,char * name,uint32_t flags);
 	virtual FILE *GetSystemFilePtr(char const * const name, char const * const type);
 	virtual bool GetSystemFilename(char* sysName, char const * const dosName);
-	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes);
+	virtual bool FileCreate(DOS_File * * file,char * name,uint16_t attributes);
 	virtual bool FileUnlink(char * name);
 	virtual bool RemoveDir(char * dir);
 	virtual bool MakeDir(char * dir);
@@ -77,10 +77,10 @@ public:
 	virtual bool GetFileAttr(char * name, uint16_t * attr);
 	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
-	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
+	virtual bool AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters,uint16_t * _free_clusters);
 	virtual bool FileExists(const char* name);
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block);
-	virtual Bit8u GetMediaByte(void);
+	virtual uint8_t GetMediaByte(void);
 	virtual bool isRemote(void);
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
@@ -96,11 +96,11 @@ private:
 	bool IsFirstEncounter(const std::string& filename);
 	std::unordered_set<std::string> write_protected_files;
 	struct {
-		Bit16u bytes_sector;
-		Bit8u sectors_cluster;
-		Bit16u total_clusters;
-		Bit16u free_clusters;
-		Bit8u mediaid;
+		uint16_t bytes_sector;
+		uint8_t sectors_cluster;
+		uint16_t total_clusters;
+		uint16_t free_clusters;
+		uint8_t mediaid;
 	} allocation;
 };
 
@@ -108,53 +108,53 @@ private:
 #pragma pack (1)
 #endif
 struct bootstrap {
-	Bit8u  nearjmp[3];
-	Bit8u  oemname[8];
-	Bit16u bytespersector;
-	Bit8u  sectorspercluster;
-	Bit16u reservedsectors;
-	Bit8u  fatcopies;
-	Bit16u rootdirentries;
-	Bit16u totalsectorcount;
-	Bit8u  mediadescriptor;
-	Bit16u sectorsperfat;
-	Bit16u sectorspertrack;
-	Bit16u headcount;
+	uint8_t  nearjmp[3];
+	uint8_t  oemname[8];
+	uint16_t bytespersector;
+	uint8_t  sectorspercluster;
+	uint16_t reservedsectors;
+	uint8_t  fatcopies;
+	uint16_t rootdirentries;
+	uint16_t totalsectorcount;
+	uint8_t  mediadescriptor;
+	uint16_t sectorsperfat;
+	uint16_t sectorspertrack;
+	uint16_t headcount;
 	/* 32-bit FAT extensions */
-	Bit32u hiddensectorcount;
-	Bit32u totalsecdword;
-	Bit8u  bootcode[474];
-	Bit8u  magic1; /* 0x55 */
-	Bit8u  magic2; /* 0xaa */
+	uint32_t hiddensectorcount;
+	uint32_t totalsecdword;
+	uint8_t  bootcode[474];
+	uint8_t  magic1; /* 0x55 */
+	uint8_t  magic2; /* 0xaa */
 } GCC_ATTRIBUTE(packed);
 
 struct direntry {
-	Bit8u entryname[11];
-	Bit8u attrib;
-	Bit8u NTRes;
-	Bit8u milliSecondStamp;
-	Bit16u crtTime;
-	Bit16u crtDate;
-	Bit16u accessDate;
-	Bit16u hiFirstClust;
-	Bit16u modTime;
-	Bit16u modDate;
-	Bit16u loFirstClust;
-	Bit32u entrysize;
+	uint8_t entryname[11];
+	uint8_t attrib;
+	uint8_t NTRes;
+	uint8_t milliSecondStamp;
+	uint16_t crtTime;
+	uint16_t crtDate;
+	uint16_t accessDate;
+	uint16_t hiFirstClust;
+	uint16_t modTime;
+	uint16_t modDate;
+	uint16_t loFirstClust;
+	uint32_t entrysize;
 } GCC_ATTRIBUTE(packed);
 
 struct partTable {
-	Bit8u booter[446];
+	uint8_t booter[446];
 	struct {
-		Bit8u bootflag;
-		Bit8u beginchs[3];
-		Bit8u parttype;
-		Bit8u endchs[3];
-		Bit32u absSectStart;
-		Bit32u partSize;
+		uint8_t bootflag;
+		uint8_t beginchs[3];
+		uint8_t parttype;
+		uint8_t endchs[3];
+		uint32_t absSectStart;
+		uint32_t partSize;
 	} pentry[4];
-	Bit8u  magic1; /* 0x55 */
-	Bit8u  magic2; /* 0xaa */
+	uint8_t  magic1; /* 0x55 */
+	uint8_t  magic2; /* 0xaa */
 } GCC_ATTRIBUTE(packed);
 
 #ifdef _MSC_VER
@@ -164,11 +164,11 @@ struct partTable {
 class imageDisk;
 class fatDrive final : public DOS_Drive {
 public:
-	fatDrive(const char * sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit32u startSector, bool roflag);
+	fatDrive(const char * sysFilename, uint32_t bytesector, uint32_t cylsector, uint32_t headscyl, uint32_t cylinders, uint32_t startSector, bool roflag);
 	fatDrive(const fatDrive&) = delete; // prevent copying
 	fatDrive& operator= (const fatDrive&) = delete; // prevent assignment
-	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
-	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes);
+	virtual bool FileOpen(DOS_File * * file,char * name,uint32_t flags);
+	virtual bool FileCreate(DOS_File * * file,char * name,uint16_t attributes);
 	virtual bool FileUnlink(char * name);
 	virtual bool RemoveDir(char * dir);
 	virtual bool MakeDir(char * dir);
@@ -178,61 +178,61 @@ public:
 	virtual bool GetFileAttr(char * name, uint16_t * attr);
 	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
-	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
+	virtual bool AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters,uint16_t * _free_clusters);
 	virtual bool FileExists(const char* name);
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block);
-	virtual Bit8u GetMediaByte(void);
+	virtual uint8_t GetMediaByte(void);
 	virtual bool isRemote(void);
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
 	virtual void EmptyCache(void){}
 public:
-	Bit8u readSector(Bit32u sectnum, void * data);
-	Bit8u writeSector(Bit32u sectnum, void * data);
-	Bit32u getAbsoluteSectFromBytePos(Bit32u startClustNum, Bit32u bytePos);
-	Bit32u getSectorSize(void);
-	Bit32u getClusterSize(void);
-	Bit32u getAbsoluteSectFromChain(Bit32u startClustNum, Bit32u logicalSector);
-	bool allocateCluster(Bit32u useCluster, Bit32u prevCluster);
-	Bit32u appendCluster(Bit32u startCluster);
-	void deleteClustChain(Bit32u startCluster, Bit32u bytePos);
-	Bit32u getFirstFreeClust(void);
-	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
-	bool directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum);
+	uint8_t readSector(uint32_t sectnum, void * data);
+	uint8_t writeSector(uint32_t sectnum, void * data);
+	uint32_t getAbsoluteSectFromBytePos(uint32_t startClustNum, uint32_t bytePos);
+	uint32_t getSectorSize(void);
+	uint32_t getClusterSize(void);
+	uint32_t getAbsoluteSectFromChain(uint32_t startClustNum, uint32_t logicalSector);
+	bool allocateCluster(uint32_t useCluster, uint32_t prevCluster);
+	uint32_t appendCluster(uint32_t startCluster);
+	void deleteClustChain(uint32_t startCluster, uint32_t bytePos);
+	uint32_t getFirstFreeClust(void);
+	bool directoryBrowse(uint32_t dirClustNumber, direntry *useEntry, int32_t entNum, int32_t start=0);
+	bool directoryChange(uint32_t dirClustNumber, direntry *useEntry, int32_t entNum);
 	std::shared_ptr<imageDisk> loadedDisk;
 	bool created_successfully;
 private:
-	Bit32u getClusterValue(Bit32u clustNum);
-	void setClusterValue(Bit32u clustNum, Bit32u clustValue);
-	Bit32u getClustFirstSect(Bit32u clustNum);
-	bool FindNextInternal(Bit32u dirClustNumber, DOS_DTA & dta, direntry *foundEntry);
-	bool getDirClustNum(char * dir, Bit32u * clustNum, bool parDir);
+	uint32_t getClusterValue(uint32_t clustNum);
+	void setClusterValue(uint32_t clustNum, uint32_t clustValue);
+	uint32_t getClustFirstSect(uint32_t clustNum);
+	bool FindNextInternal(uint32_t dirClustNumber, DOS_DTA & dta, direntry *foundEntry);
+	bool getDirClustNum(char * dir, uint32_t * clustNum, bool parDir);
 	bool getFileDirEntry(char const * const filename, direntry * useEntry, uint32_t * dirClust, uint32_t * subEntry, const bool dir_ok = false);
-	bool addDirectoryEntry(Bit32u dirClustNumber, direntry useEntry);
-	void zeroOutCluster(Bit32u clustNumber);
+	bool addDirectoryEntry(uint32_t dirClustNumber, direntry useEntry);
+	void zeroOutCluster(uint32_t clustNumber);
 	bool getEntryName(char *fullname, char *entname);
 	
 	bootstrap bootbuffer;
 	bool absolute;
 	bool readonly;
-	Bit8u fattype;
-	Bit32u CountOfClusters;
-	Bit32u partSectOff;
-	Bit32u firstDataSector;
-	Bit32u firstRootDirSect;
+	uint8_t fattype;
+	uint32_t CountOfClusters;
+	uint32_t partSectOff;
+	uint32_t firstDataSector;
+	uint32_t firstRootDirSect;
 
-	Bit32u cwdDirCluster;
+	uint32_t cwdDirCluster;
 
-	Bit8u fatSectBuffer[1024];
-	Bit32u curFatSect;
+	uint8_t fatSectBuffer[1024];
+	uint32_t curFatSect;
 };
 
 class cdromDrive final : public localDrive
 {
 public:
-	cdromDrive(const char _driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error);
-	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
-	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes);
+	cdromDrive(const char _driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, int& error);
+	virtual bool FileOpen(DOS_File * * file,char * name,uint32_t flags);
+	virtual bool FileCreate(DOS_File * * file,char * name,uint16_t attributes);
 	virtual bool FileUnlink(char * name);
 	virtual bool RemoveDir(char * dir);
 	virtual bool MakeDir(char * dir);
@@ -244,7 +244,7 @@ public:
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
 private:
-	Bit8u subUnit;
+	uint8_t subUnit;
 	char driveLetter;
 };
 
@@ -252,53 +252,53 @@ private:
 #pragma pack (1)
 #endif
 struct isoPVD {
-	Bit8u type;
-	Bit8u standardIdent[5];
-	Bit8u version;
-	Bit8u unused1;
-	Bit8u systemIdent[32];
-	Bit8u volumeIdent[32];
-	Bit8u unused2[8];
-	Bit32u volumeSpaceSizeL;
-	Bit32u volumeSpaceSizeM;
-	Bit8u unused3[32];
-	Bit16u volumeSetSizeL;
-	Bit16u volumeSetSizeM;
-	Bit16u volumeSeqNumberL;
-	Bit16u volumeSeqNumberM;
-	Bit16u logicBlockSizeL;
-	Bit16u logicBlockSizeM;
-	Bit32u pathTableSizeL;
-	Bit32u pathTableSizeM;
-	Bit32u locationPathTableL;
-	Bit32u locationOptPathTableL;
-	Bit32u locationPathTableM;
-	Bit32u locationOptPathTableM;
-	Bit8u rootEntry[34];
-	Bit32u unused4[1858];
+	uint8_t type;
+	uint8_t standardIdent[5];
+	uint8_t version;
+	uint8_t unused1;
+	uint8_t systemIdent[32];
+	uint8_t volumeIdent[32];
+	uint8_t unused2[8];
+	uint32_t volumeSpaceSizeL;
+	uint32_t volumeSpaceSizeM;
+	uint8_t unused3[32];
+	uint16_t volumeSetSizeL;
+	uint16_t volumeSetSizeM;
+	uint16_t volumeSeqNumberL;
+	uint16_t volumeSeqNumberM;
+	uint16_t logicBlockSizeL;
+	uint16_t logicBlockSizeM;
+	uint32_t pathTableSizeL;
+	uint32_t pathTableSizeM;
+	uint32_t locationPathTableL;
+	uint32_t locationOptPathTableL;
+	uint32_t locationPathTableM;
+	uint32_t locationOptPathTableM;
+	uint8_t rootEntry[34];
+	uint32_t unused4[1858];
 } GCC_ATTRIBUTE(packed);
 
 struct isoDirEntry {
-	Bit8u length;
-	Bit8u extAttrLength;
-	Bit32u extentLocationL;
-	Bit32u extentLocationM;
-	Bit32u dataLengthL;
-	Bit32u dataLengthM;
-	Bit8u dateYear;
-	Bit8u dateMonth;
-	Bit8u dateDay;
-	Bit8u timeHour;
-	Bit8u timeMin;
-	Bit8u timeSec;
-	Bit8u timeZone;
-	Bit8u fileFlags;
-	Bit8u fileUnitSize;
-	Bit8u interleaveGapSize;
-	Bit16u VolumeSeqNumberL;
-	Bit16u VolumeSeqNumberM;
-	Bit8u fileIdentLength;
-	Bit8u ident[222];
+	uint8_t length;
+	uint8_t extAttrLength;
+	uint32_t extentLocationL;
+	uint32_t extentLocationM;
+	uint32_t dataLengthL;
+	uint32_t dataLengthM;
+	uint8_t dateYear;
+	uint8_t dateMonth;
+	uint8_t dateDay;
+	uint8_t timeHour;
+	uint8_t timeMin;
+	uint8_t timeSec;
+	uint8_t timeZone;
+	uint8_t fileFlags;
+	uint8_t fileUnitSize;
+	uint8_t interleaveGapSize;
+	uint16_t VolumeSeqNumberL;
+	uint16_t VolumeSeqNumberM;
+	uint8_t fileIdentLength;
+	uint8_t ident[222];
 } GCC_ATTRIBUTE(packed);
 
 #ifdef _MSC_VER
@@ -327,10 +327,10 @@ struct isoDirEntry {
 
 class isoDrive final : public DOS_Drive {
 public:
-	isoDrive(char driveLetter, const char* device_name, Bit8u mediaid, int &error);
+	isoDrive(char driveLetter, const char* device_name, uint8_t mediaid, int &error);
 	~isoDrive();
-	virtual bool FileOpen(DOS_File **file, char *name, Bit32u flags);
-	virtual bool FileCreate(DOS_File **file, char *name, Bit16u attributes);
+	virtual bool FileOpen(DOS_File **file, char *name, uint32_t flags);
+	virtual bool FileCreate(DOS_File **file, char *name, uint16_t attributes);
 	virtual bool FileUnlink(char *name);
 	virtual bool RemoveDir(char *dir);
 	virtual bool MakeDir(char *dir);
@@ -340,50 +340,50 @@ public:
 	virtual bool GetFileAttr(char *name, uint16_t *attr);
 	virtual bool SetFileAttr(const char * name, const uint16_t attr);
 	virtual bool Rename(char * oldname,char * newname);
-	virtual bool AllocationInfo(Bit16u *bytes_sector, Bit8u *sectors_cluster, Bit16u *total_clusters, Bit16u *free_clusters);
+	virtual bool AllocationInfo(uint16_t *bytes_sector, uint8_t *sectors_cluster, uint16_t *total_clusters, uint16_t *free_clusters);
 	virtual bool FileExists(const char *name);
    	virtual bool FileStat(const char *name, FileStat_Block *const stat_block);
-	virtual Bit8u GetMediaByte(void);
+	virtual uint8_t GetMediaByte(void);
 	virtual void EmptyCache(void){}
 	virtual bool isRemote(void);
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
-	bool readSector(Bit8u *buffer, Bit32u sector);
+	bool readSector(uint8_t *buffer, uint32_t sector);
 	virtual const char *GetLabel() { return discLabel; }
 	virtual void Activate(void);
 private:
-	int  readDirEntry(isoDirEntry *de, Bit8u *data);
+	int  readDirEntry(isoDirEntry *de, uint8_t *data);
 	bool loadImage();
-	bool lookupSingle(isoDirEntry *de, const char *name, Bit32u sectorStart, Bit32u length);
+	bool lookupSingle(isoDirEntry *de, const char *name, uint32_t sectorStart, uint32_t length);
 	bool lookup(isoDirEntry *de, const char *path);
-	int  UpdateMscdex(char driveLetter, const char* physicalPath, Bit8u& subUnit);
+	int  UpdateMscdex(char driveLetter, const char* physicalPath, uint8_t& subUnit);
 	int  GetDirIterator(const isoDirEntry* de);
 	bool GetNextDirEntry(const int dirIterator, isoDirEntry* de);
 	void FreeDirIterator(const int dirIterator);
-	bool ReadCachedSector(Bit8u** buffer, const Bit32u sector);
+	bool ReadCachedSector(uint8_t** buffer, const uint32_t sector);
 	
 	struct DirIterator {
 		bool valid;
 		bool root;
-		Bit32u currentSector;
-		Bit32u endSector;
-		Bit32u pos;
+		uint32_t currentSector;
+		uint32_t endSector;
+		uint32_t pos;
 	} dirIterators[MAX_OPENDIRS];
 	
 	int nextFreeDirIterator;
 	
 	struct SectorHashEntry {
 		bool valid;
-		Bit32u sector;
-		Bit8u data[ISO_FRAMESIZE];
+		uint32_t sector;
+		uint8_t data[ISO_FRAMESIZE];
 	} sectorHashEntries[ISO_MAX_HASH_TABLE_SIZE];
 
 	bool iso;
 	bool dataCD;
 	isoDirEntry rootEntry;
-	Bit8u mediaid;
+	uint8_t mediaid;
 	char fileName[CROSS_LEN];
-	Bit8u subUnit;
+	uint8_t subUnit;
 	char driveLetter;
 	char discLabel[32];
 };
@@ -393,8 +393,8 @@ struct VFILE_Block;
 class Virtual_Drive final : public DOS_Drive {
 public:
 	Virtual_Drive();
-	bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
-	bool FileCreate(DOS_File * * file,char * name,Bit16u attributes);
+	bool FileOpen(DOS_File * * file,char * name,uint32_t flags);
+	bool FileCreate(DOS_File * * file,char * name,uint16_t attributes);
 	bool FileUnlink(char * name);
 	bool RemoveDir(char * dir);
 	bool MakeDir(char * dir);
@@ -404,10 +404,10 @@ public:
 	bool GetFileAttr(char * name, uint16_t * attr);
 	bool SetFileAttr(const char * name, const uint16_t attr);
 	bool Rename(char * oldname,char * newname);
-	bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
+	bool AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters,uint16_t * _free_clusters);
 	bool FileExists(const char* name);
 	bool FileStat(const char* name, FileStat_Block* const stat_block);
-	Bit8u GetMediaByte();
+	uint8_t GetMediaByte();
 	void EmptyCache();
 	bool isRemote();
 	virtual bool isRemovable();
@@ -431,7 +431,7 @@ public:
 	              uint8_t &error);
 
 	virtual bool FileOpen(DOS_File **file, char *name, uint32_t flags);
-	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/);
+	virtual bool FileCreate(DOS_File * * file,char * name,uint16_t /*attributes*/);
 	virtual bool FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst);
 	virtual bool FindNext(DOS_DTA & dta);
 	virtual bool FileUnlink(char * name);

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -50,25 +50,25 @@ typedef union {
     double d;
 #ifndef WORDS_BIGENDIAN
     struct {
-        Bit32u lower;
-        Bit32s upper;
+        uint32_t lower;
+        int32_t upper;
     } l;
 #else
     struct {
-        Bit32s upper;
-        Bit32u lower;
+        int32_t upper;
+        uint32_t lower;
     } l;
 #endif
-    Bit64s ll;
+    int64_t ll;
 } FPU_Reg;
 
 typedef struct {
-    Bit32u m1;
-    Bit32u m2;
-    Bit16u m3;
+    uint32_t m1;
+    uint32_t m2;
+    uint16_t m3;
 
-    Bit16u d1;
-    Bit32u d2;
+    uint16_t d1;
+    uint32_t d2;
 } FPU_P_Reg;
 
 enum FPU_Tag {
@@ -89,9 +89,9 @@ typedef struct FPU_rec {
 	FPU_Reg		regs[9];
 	FPU_P_Reg	p_regs[9];
 	FPU_Tag		tags[9];
-	Bit16u		cw,cw_mask_all;
-	Bit16u		sw;
-	Bit32u		top;
+	uint16_t		cw,cw_mask_all;
+	uint16_t		sw;
+	uint32_t		top;
 	FPU_Round	round;
 } FPU_rec;
 
@@ -107,17 +107,17 @@ extern FPU_rec fpu;
 #define STV(i)  ( (fpu.top+ (i) ) & 7 )
 
 
-Bit16u FPU_GetTag(void);
+uint16_t FPU_GetTag(void);
 void FPU_FLDCW(PhysPt addr);
 
-static inline void FPU_SetTag(Bit16u tag){
+static inline void FPU_SetTag(uint16_t tag){
 	for(Bitu i=0;i<8;i++)
 		fpu.tags[i] = static_cast<FPU_Tag>((tag >>(2*i))&3);
 }
 
 static inline void FPU_SetCW(Bitu word){
-	fpu.cw = (Bit16u)word;
-	fpu.cw_mask_all = (Bit16u)(word | 0x3f);
+	fpu.cw = (uint16_t)word;
+	fpu.cw_mask_all = (uint16_t)(word | 0x3f);
 	fpu.round = (FPU_Round)((word >> 10) & 3);
 }
 

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -44,10 +44,10 @@ bool PS1AUDIO_IsEnabled();
 bool SB_Get_Address(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma);
 bool TS_Get_Address(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
 
-extern Bit8u adlib_commandreg;
+extern uint8_t adlib_commandreg;
 FILE * OpenCaptureFile(const char * type,const char * ext);
 
-void CAPTURE_AddWave(Bit32u freq, Bit32u len, Bit16s * data);
+void CAPTURE_AddWave(uint32_t freq, uint32_t len, int16_t * data);
 
 #define CAPTURE_FLAG_DBLW	0x1
 #define CAPTURE_FLAG_DBLH	0x2
@@ -60,7 +60,7 @@ void CAPTURE_AddImage(int width,
                       uint8_t *data,
                       uint8_t *pal);
 
-void CAPTURE_AddMidi(bool sysex, Bitu len, Bit8u * data);
+void CAPTURE_AddMidi(bool sysex, Bitu len, uint8_t * data);
 void CAPTURE_VideoStart();
 void CAPTURE_VideoStop();
 

--- a/include/ipx.h
+++ b/include/ipx.h
@@ -97,9 +97,9 @@ struct IPXHeader {
 } GCC_ATTRIBUTE(packed);
 
 struct fragmentDescriptor {
-	Bit16u offset;
-	Bit16u segment;
-	Bit16u size;
+	uint16_t offset;
+	uint16_t segment;
+	uint16_t size;
 };
 
 #define IPXBUFFERSIZE 1424
@@ -111,10 +111,10 @@ public:
    	ECBClass *prevECB;	// Linked List
 	ECBClass *nextECB;
 	
-	Bit8u iuflag;		// Need to save data since we are not always in
-	Bit16u mysocket;	// real mode
+	uint8_t iuflag;		// Need to save data since we are not always in
+	uint16_t mysocket;	// real mode
 
-	Bit8u* databuffer;	// received data is stored here until we get called
+	uint8_t* databuffer;	// received data is stored here until we get called
 	Bitu buflen;		// by Interrupt
 
 #ifdef IPX_DEBUGMSG 
@@ -125,26 +125,26 @@ public:
 	ECBClass(const ECBClass &) = delete;            // prevent copying
 	ECBClass &operator=(const ECBClass &) = delete; // prevent assignment
 
-	Bit16u getSocket(void);
+	uint16_t getSocket(void);
 
-	Bit8u getInUseFlag(void);
+	uint8_t getInUseFlag(void);
 
-	void setInUseFlag(Bit8u flagval);
+	void setInUseFlag(uint8_t flagval);
 
-	void setCompletionFlag(Bit8u flagval);
+	void setCompletionFlag(uint8_t flagval);
 
-	Bit16u getFragCount(void);
+	uint16_t getFragCount(void);
 
 	bool writeData();
-	void writeDataBuffer(Bit8u* buffer, Bit16u length);
+	void writeDataBuffer(uint8_t* buffer, uint16_t length);
 
-	void getFragDesc(Bit16u descNum, fragmentDescriptor *fragDesc);
+	void getFragDesc(uint16_t descNum, fragmentDescriptor *fragDesc);
 	RealPt getESRAddr(void);
 
 	void NotifyESR(void);
 
-	void setImmAddress(Bit8u *immAddr);
-	void getImmAddress(Bit8u* immAddr);
+	void setImmAddress(uint8_t *immAddr);
+	void getImmAddress(uint8_t* immAddr);
 
 	~ECBClass();
 };

--- a/include/ipxserver.h
+++ b/include/ipxserver.h
@@ -24,9 +24,9 @@
 #include <SDL_net.h>
 
 struct packetBuffer {
-	Bit8u buffer[1024];
-	Bit16s packetSize;  // Packet size remaining in read
-	Bit16s packetRead;  // Bytes read of total packet
+	uint8_t buffer[1024];
+	int16_t packetSize;  // Packet size remaining in read
+	int16_t packetRead;  // Bytes read of total packet
 	bool inPacket;      // In packet reception flag
 	bool connected;		// Connected flag
 	bool waitsize;
@@ -41,7 +41,7 @@ void IPX_StopServer();
 bool IPX_StartServer(uint16_t portnum);
 bool IPX_isConnectedToServer(Bits tableNum, IPaddress ** ptrAddr);
 
-Bit8u packetCRC(Bit8u *buffer, Bit16u bufSize);
+uint8_t packetCRC(uint8_t *buffer, uint16_t bufSize);
 
 #endif
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -31,7 +31,7 @@
 
 #include "envelope.h"
 
-typedef void (*MIXER_MixHandler)(Bit8u *sampdate, Bit32u len);
+typedef void (*MIXER_MixHandler)(uint8_t *sampdate, uint32_t len);
 
 // The mixer callback can accept a static function or a member function
 // using a std::bind. The callback typically requests enough frames to
@@ -57,7 +57,7 @@ struct AudioFrame {
 
 #define MIXER_BUFSIZE (16 * 1024)
 #define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
-extern Bit8u MixTemp[MIXER_BUFSIZE];
+extern uint8_t MixTemp[MIXER_BUFSIZE];
 
 #define MAX_AUDIO ((1<<(16-1))-1)
 #define MIN_AUDIO -(1<<(16-1))
@@ -116,24 +116,24 @@ public:
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
 	void AddSamples(uint16_t len, const Type *data);
 
-	void AddSamples_m8(uint16_t len, const Bit8u *data);
-	void AddSamples_s8(uint16_t len, const Bit8u *data);
-	void AddSamples_m8s(uint16_t len, const Bit8s *data);
-	void AddSamples_s8s(uint16_t len, const Bit8s *data);
-	void AddSamples_m16(uint16_t len, const Bit16s *data);
-	void AddSamples_s16(uint16_t len, const Bit16s *data);
-	void AddSamples_m16u(uint16_t len, const Bit16u *data);
-	void AddSamples_s16u(uint16_t len, const Bit16u *data);
-	void AddSamples_m32(uint16_t len, const Bit32s *data);
-	void AddSamples_s32(uint16_t len, const Bit32s *data);
-	void AddSamples_m16_nonnative(uint16_t len, const Bit16s *data);
-	void AddSamples_s16_nonnative(uint16_t len, const Bit16s *data);
-	void AddSamples_m16u_nonnative(uint16_t len, const Bit16u *data);
-	void AddSamples_s16u_nonnative(uint16_t len, const Bit16u *data);
-	void AddSamples_m32_nonnative(uint16_t len, const Bit32s *data);
-	void AddSamples_s32_nonnative(uint16_t len, const Bit32s *data);
+	void AddSamples_m8(uint16_t len, const uint8_t *data);
+	void AddSamples_s8(uint16_t len, const uint8_t *data);
+	void AddSamples_m8s(uint16_t len, const int8_t *data);
+	void AddSamples_s8s(uint16_t len, const int8_t *data);
+	void AddSamples_m16(uint16_t len, const int16_t *data);
+	void AddSamples_s16(uint16_t len, const int16_t *data);
+	void AddSamples_m16u(uint16_t len, const uint16_t *data);
+	void AddSamples_s16u(uint16_t len, const uint16_t *data);
+	void AddSamples_m32(uint16_t len, const int32_t *data);
+	void AddSamples_s32(uint16_t len, const int32_t *data);
+	void AddSamples_m16_nonnative(uint16_t len, const int16_t *data);
+	void AddSamples_s16_nonnative(uint16_t len, const int16_t *data);
+	void AddSamples_m16u_nonnative(uint16_t len, const uint16_t *data);
+	void AddSamples_s16u_nonnative(uint16_t len, const uint16_t *data);
+	void AddSamples_m32_nonnative(uint16_t len, const int32_t *data);
+	void AddSamples_s32_nonnative(uint16_t len, const int32_t *data);
 
-	void AddStretched(uint16_t len, Bit16s *data); // Stretch block up into needed data
+	void AddStretched(uint16_t len, int16_t *data); // Stretch block up into needed data
 
 	void FillUp();
 	void Enable(bool should_enable);

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -26,13 +26,13 @@ void Mouse_HideCursor(void);
 
 bool Mouse_SetPS2State(bool use);
 
-void Mouse_ChangePS2Callback(Bit16u pseg, Bit16u pofs);
+void Mouse_ChangePS2Callback(uint16_t pseg, uint16_t pofs);
 
 
 void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate);
 void Mouse_CursorSet(float x,float y);
-void Mouse_ButtonPressed(Bit8u button);
-void Mouse_ButtonReleased(Bit8u button);
+void Mouse_ButtonPressed(uint8_t button);
+void Mouse_ButtonReleased(uint8_t button);
 
 void Mouse_AutoLock(bool enable);
 void Mouse_BeforeNewVideoMode();

--- a/include/paging.h
+++ b/include/paging.h
@@ -104,29 +104,29 @@ void MEM_ResetPageHandler(Bitu phys_page, Bitu pages);
 #endif
 struct X86_PageEntryBlock{
 #ifdef WORDS_BIGENDIAN
-	Bit32u		base:20;
-	Bit32u		avl:3;
-	Bit32u		g:1;
-	Bit32u		pat:1;
-	Bit32u		d:1;
-	Bit32u		a:1;
-	Bit32u		pcd:1;
-	Bit32u		pwt:1;
-	Bit32u		us:1;
-	Bit32u		wr:1;
-	Bit32u		p:1;
+	uint32_t		base:20;
+	uint32_t		avl:3;
+	uint32_t		g:1;
+	uint32_t		pat:1;
+	uint32_t		d:1;
+	uint32_t		a:1;
+	uint32_t		pcd:1;
+	uint32_t		pwt:1;
+	uint32_t		us:1;
+	uint32_t		wr:1;
+	uint32_t		p:1;
 #else
-	Bit32u		p:1;
-	Bit32u		wr:1;
-	Bit32u		us:1;
-	Bit32u		pwt:1;
-	Bit32u		pcd:1;
-	Bit32u		a:1;
-	Bit32u		d:1;
-	Bit32u		pat:1;
-	Bit32u		g:1;
-	Bit32u		avl:3;
-	Bit32u		base:20;
+	uint32_t		p:1;
+	uint32_t		wr:1;
+	uint32_t		us:1;
+	uint32_t		pwt:1;
+	uint32_t		pcd:1;
+	uint32_t		a:1;
+	uint32_t		d:1;
+	uint32_t		pat:1;
+	uint32_t		g:1;
+	uint32_t		avl:3;
+	uint32_t		base:20;
 #endif
 } GCC_ATTRIBUTE(packed);
 #ifdef _MSC_VER
@@ -135,7 +135,7 @@ struct X86_PageEntryBlock{
 
 
 union X86PageEntry {
-	Bit32u load;
+	uint32_t load;
 	X86_PageEntryBlock block;
 };
 
@@ -145,7 +145,7 @@ typedef struct {
 	HostPt write;
 	PageHandler * readhandler;
 	PageHandler * writehandler;
-	Bit32u phys_page;
+	uint32_t phys_page;
 } tlb_entry;
 #endif
 
@@ -162,7 +162,7 @@ struct PagingBlock {
 		HostPt write[TLB_SIZE];
 		PageHandler * readhandler[TLB_SIZE];
 		PageHandler * writehandler[TLB_SIZE];
-		Bit32u	phys_page[TLB_SIZE];
+		uint32_t	phys_page[TLB_SIZE];
 	} tlb;
 #else
 	tlb_entry tlbh[TLB_SIZE];
@@ -170,9 +170,9 @@ struct PagingBlock {
 #endif
 	struct {
 		Bitu used;
-		Bit32u entries[PAGING_LINKS];
+		uint32_t entries[PAGING_LINKS];
 	} links;
-	Bit32u		firstmb[LINK_START];
+	uint32_t		firstmb[LINK_START];
 	bool		enabled;
 };
 
@@ -184,15 +184,15 @@ PageHandler * MEM_GetPageHandler(Bitu phys_page);
 
 
 /* Unaligned address handlers */
-Bit16u mem_unalignedreadw(PhysPt address);
-Bit32u mem_unalignedreadd(PhysPt address);
-void mem_unalignedwritew(PhysPt address,Bit16u val);
-void mem_unalignedwrited(PhysPt address,Bit32u val);
+uint16_t mem_unalignedreadw(PhysPt address);
+uint32_t mem_unalignedreadd(PhysPt address);
+void mem_unalignedwritew(PhysPt address,uint16_t val);
+void mem_unalignedwrited(PhysPt address,uint32_t val);
 
-bool mem_unalignedreadw_checked(PhysPt address,Bit16u * val);
-bool mem_unalignedreadd_checked(PhysPt address,Bit32u * val);
-bool mem_unalignedwritew_checked(PhysPt address,Bit16u val);
-bool mem_unalignedwrited_checked(PhysPt address,Bit32u val);
+bool mem_unalignedreadw_checked(PhysPt address,uint16_t * val);
+bool mem_unalignedreadd_checked(PhysPt address,uint32_t * val);
+bool mem_unalignedwritew_checked(PhysPt address,uint16_t val);
+bool mem_unalignedwrited_checked(PhysPt address,uint32_t val);
 
 #if defined(USE_FULL_TLB)
 
@@ -260,14 +260,14 @@ static inline PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 
 /* Special inlined memory reading/writing */
 
-static inline Bit8u mem_readb_inline(PhysPt address) {
+static inline uint8_t mem_readb_inline(PhysPt address) {
 	HostPt tlb_addr=get_tlb_read(address);
 	if (tlb_addr) return host_readb(tlb_addr+address);
 	else
 		return (get_tlb_readhandler(address))->readb(address);
 }
 
-static inline Bit16u mem_readw_inline(PhysPt address) {
+static inline uint16_t mem_readw_inline(PhysPt address) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) return host_readw(tlb_addr+address);
@@ -289,13 +289,13 @@ static inline uint32_t mem_readd_inline(PhysPt address)
 	}
 }
 
-static inline void mem_writeb_inline(PhysPt address,Bit8u val) {
+static inline void mem_writeb_inline(PhysPt address,uint8_t val) {
 	HostPt tlb_addr=get_tlb_write(address);
 	if (tlb_addr) host_writeb(tlb_addr+address,val);
 	else (get_tlb_writehandler(address))->writeb(address,val);
 }
 
-static inline void mem_writew_inline(PhysPt address,Bit16u val) {
+static inline void mem_writew_inline(PhysPt address,uint16_t val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) host_writew(tlb_addr+address,val);
@@ -303,7 +303,7 @@ static inline void mem_writew_inline(PhysPt address,Bit16u val) {
 	} else mem_unalignedwritew(address,val);
 }
 
-static inline void mem_writed_inline(PhysPt address,Bit32u val) {
+static inline void mem_writed_inline(PhysPt address,uint32_t val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) host_writed(tlb_addr+address,val);
@@ -312,7 +312,7 @@ static inline void mem_writed_inline(PhysPt address,Bit32u val) {
 }
 
 
-static inline bool mem_readb_checked(PhysPt address, Bit8u * val) {
+static inline bool mem_readb_checked(PhysPt address, uint8_t * val) {
 	HostPt tlb_addr=get_tlb_read(address);
 	if (tlb_addr) {
 		*val=host_readb(tlb_addr+address);
@@ -320,7 +320,7 @@ static inline bool mem_readb_checked(PhysPt address, Bit8u * val) {
 	} else return (get_tlb_readhandler(address))->readb_checked(address, val);
 }
 
-static inline bool mem_readw_checked(PhysPt address, Bit16u * val) {
+static inline bool mem_readw_checked(PhysPt address, uint16_t * val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) {
@@ -330,7 +330,7 @@ static inline bool mem_readw_checked(PhysPt address, Bit16u * val) {
 	} else return mem_unalignedreadw_checked(address, val);
 }
 
-static inline bool mem_readd_checked(PhysPt address, Bit32u * val) {
+static inline bool mem_readd_checked(PhysPt address, uint32_t * val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) {
@@ -340,7 +340,7 @@ static inline bool mem_readd_checked(PhysPt address, Bit32u * val) {
 	} else return mem_unalignedreadd_checked(address, val);
 }
 
-static inline bool mem_writeb_checked(PhysPt address,Bit8u val) {
+static inline bool mem_writeb_checked(PhysPt address,uint8_t val) {
 	HostPt tlb_addr=get_tlb_write(address);
 	if (tlb_addr) {
 		host_writeb(tlb_addr+address,val);
@@ -348,7 +348,7 @@ static inline bool mem_writeb_checked(PhysPt address,Bit8u val) {
 	} else return (get_tlb_writehandler(address))->writeb_checked(address,val);
 }
 
-static inline bool mem_writew_checked(PhysPt address,Bit16u val) {
+static inline bool mem_writew_checked(PhysPt address,uint16_t val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) {
@@ -358,7 +358,7 @@ static inline bool mem_writew_checked(PhysPt address,Bit16u val) {
 	} else return mem_unalignedwritew_checked(address,val);
 }
 
-static inline bool mem_writed_checked(PhysPt address,Bit32u val) {
+static inline bool mem_writed_checked(PhysPt address,uint32_t val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) {

--- a/include/pci_bus.h
+++ b/include/pci_bus.h
@@ -30,7 +30,7 @@
 class PCI_Device {
 private:
 	Bits pci_id, pci_subfunction;
-	Bit16u vendor_id, device_id;
+	uint16_t vendor_id, device_id;
 
 	// subdevices declarations, they will respond to pci functions 1 to 7
 	// (main device is attached to function 0)
@@ -38,7 +38,7 @@ private:
 	PCI_Device* subdevices[PCI_MAX_PCIFUNCTIONS-1];
 
 public:
-	PCI_Device(Bit16u vendor, Bit16u device);
+	PCI_Device(uint16_t vendor, uint16_t device);
 
 	Bits PCIId(void) {
 		return pci_id;
@@ -46,10 +46,10 @@ public:
 	Bits PCISubfunction(void) {
 		return pci_subfunction;
 	}
-	Bit16u VendorID(void) {
+	uint16_t VendorID(void) {
 		return vendor_id;
 	}
-	Bit16u DeviceID(void) {
+	uint16_t DeviceID(void) {
 		return device_id;
 	}
 
@@ -60,9 +60,9 @@ public:
 
 	PCI_Device* GetSubdevice(Bits subfct);
 
-	Bit16u NumSubdevices(void) {
-		if (num_subdevices>PCI_MAX_PCIFUNCTIONS-1) return (Bit16u)(PCI_MAX_PCIFUNCTIONS-1);
-		return (Bit16u)num_subdevices;
+	uint16_t NumSubdevices(void) {
+		if (num_subdevices>PCI_MAX_PCIFUNCTIONS-1) return (uint16_t)(PCI_MAX_PCIFUNCTIONS-1);
+		return (uint16_t)num_subdevices;
 	}
 
 	Bits GetNextSubdeviceNumber(void) {
@@ -70,10 +70,10 @@ public:
 		return (Bits)num_subdevices+1;
 	}
 
-	virtual Bits ParseReadRegister(Bit8u regnum)=0;
-	virtual bool OverrideReadRegister(Bit8u regnum, Bit8u* rval, Bit8u* rval_mask)=0;
-	virtual Bits ParseWriteRegister(Bit8u regnum,Bit8u value)=0;
-	virtual bool InitializeRegisters(Bit8u registers[256])=0;
+	virtual Bits ParseReadRegister(uint8_t regnum)=0;
+	virtual bool OverrideReadRegister(uint8_t regnum, uint8_t* rval, uint8_t* rval_mask)=0;
+	virtual Bits ParseWriteRegister(uint8_t regnum,uint8_t value)=0;
+	virtual bool InitializeRegisters(uint8_t registers[256])=0;
 
 };
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -50,7 +50,7 @@ public:
 	bool HasExecutableName() const;
 	unsigned int GetCount(void);
 	void Shift(unsigned int amount=1);
-	Bit16u Get_arglength();
+	uint16_t Get_arglength();
 
 private:
 	using cmd_it = std::list<std::string>::iterator;

--- a/include/render.h
+++ b/include/render.h
@@ -106,6 +106,6 @@ void RENDER_SetSize(uint32_t width,
                     bool dblh);
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
-void RENDER_SetPal(Bit8u entry,Bit8u red,Bit8u green,Bit8u blue);
+void RENDER_SetPal(uint8_t entry,uint8_t red,uint8_t green,uint8_t blue);
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -37,16 +37,7 @@
 #define PRIuPTR "I64u"
 #endif
 
-using Bit8u  = uint8_t;
-using Bit16u = uint16_t;
-using Bit32u = uint32_t;
-using Bit64u = uint64_t;
 using Bitu   = uintptr_t;
-
-using Bit8s  = int8_t;
-using Bit16s = int16_t;
-using Bit32s = int32_t;
-using Bit64s = int64_t;
 using Bits   = intptr_t;
 
 using Real64 = double;

--- a/include/vga.h
+++ b/include/vga.h
@@ -120,29 +120,29 @@ struct VGA_Config {
 	bool compatible_chain4 = false;
 
 	/* Pixel Scrolling */
-	Bit8u pel_panning = 0; /* Amount of pixels to skip when starting
+	uint8_t pel_panning = 0; /* Amount of pixels to skip when starting
 	                          horizontal line */
-	Bit8u hlines_skip = 0;
-	Bit8u bytes_skip = 0;
-	Bit8u addr_shift = 0;
+	uint8_t hlines_skip = 0;
+	uint8_t bytes_skip = 0;
+	uint8_t addr_shift = 0;
 
 	/* Specific stuff memory write/read handling */
 
-	Bit8u read_mode = 0;
-	Bit8u write_mode = 0;
-	Bit8u read_map_select = 0;
-	Bit8u color_dont_care = 0;
-	Bit8u color_compare = 0;
-	Bit8u data_rotate = 0;
-	Bit8u raster_op = 0;
+	uint8_t read_mode = 0;
+	uint8_t write_mode = 0;
+	uint8_t read_map_select = 0;
+	uint8_t color_dont_care = 0;
+	uint8_t color_compare = 0;
+	uint8_t data_rotate = 0;
+	uint8_t raster_op = 0;
 
-	Bit32u full_bit_mask = 0;
-	Bit32u full_map_mask = 0;
-	Bit32u full_not_map_mask = 0;
-	Bit32u full_set_reset = 0;
-	Bit32u full_not_enable_set_reset = 0;
-	Bit32u full_enable_set_reset = 0;
-	Bit32u full_enable_and_set_reset = 0;
+	uint32_t full_bit_mask = 0;
+	uint32_t full_map_mask = 0;
+	uint32_t full_not_map_mask = 0;
+	uint32_t full_set_reset = 0;
+	uint32_t full_not_enable_set_reset = 0;
+	uint32_t full_enable_set_reset = 0;
+	uint32_t full_enable_and_set_reset = 0;
 };
 
 enum Drawmode { PART, DRAWLINE, EGALINE };
@@ -157,7 +157,7 @@ struct VGA_Draw {
 	Bitu address = 0;
 	uint16_t panning = 0;
 	Bitu bytes_skip = 0;
-	Bit8u *linear_base = nullptr;
+	uint8_t *linear_base = nullptr;
 	Bitu linear_mask = 0;
 	Bitu address_add = 0;
 	uint32_t line_length = 0;
@@ -191,35 +191,35 @@ struct VGA_Draw {
 	bool double_scan = false;
 	bool doublewidth = false;
 	bool doubleheight = false;
-	Bit8u font[64 * 1024] = {};
-	Bit8u *font_tables[2] = {nullptr, nullptr};
+	uint8_t font[64 * 1024] = {};
+	uint8_t *font_tables[2] = {nullptr, nullptr};
 	Bitu blinking = 0;
 	bool blink = false;
 	bool char9dot = false;
 	struct {
 		Bitu address = 0;
-		Bit8u sline = 0;
+		uint8_t sline = 0;
 		uint8_t eline = 0;
-		Bit8u count = 0;
+		uint8_t count = 0;
 		uint8_t delay = 0;
-		Bit8u enabled = 0;
+		uint8_t enabled = 0;
 	} cursor = {};
 	Drawmode mode = {};
 	bool vret_triggered = false;
 };
 
 struct VGA_HWCURSOR {
-	Bit8u curmode = 0;
-	Bit16u originx = 0;
+	uint8_t curmode = 0;
+	uint16_t originx = 0;
 	uint16_t originy = 0;
-	Bit8u fstackpos = 0;
+	uint8_t fstackpos = 0;
 	uint8_t bstackpos = 0;
-	Bit8u forestack[4] = {};
-	Bit8u backstack[4] = {};
-	Bit16u startaddr = 0;
-	Bit8u posx = 0;
+	uint8_t forestack[4] = {};
+	uint8_t backstack[4] = {};
+	uint16_t startaddr = 0;
+	uint8_t posx = 0;
 	uint8_t posy = 0;
-	Bit8u mc[64][64] = {};
+	uint8_t mc[64][64] = {};
 };
 
 struct VGA_S3 {
@@ -264,65 +264,65 @@ struct VGA_S3 {
 };
 
 struct VGA_HERC {
-	Bit8u mode_control = 0;
-	Bit8u enable_bits = 0;
+	uint8_t mode_control = 0;
+	uint8_t enable_bits = 0;
 };
 
 struct VGA_OTHER {
-	Bit8u index = 0;
-	Bit8u htotal = 0;
-	Bit8u hdend = 0;
-	Bit8u hsyncp = 0;
-	Bit8u hsyncw = 0;
-	Bit8u vtotal = 0;
-	Bit8u vdend = 0;
-	Bit8u vadjust = 0;
-	Bit8u vsyncp = 0;
-	Bit8u vsyncw = 0;
-	Bit8u max_scanline = 0;
-	Bit16u lightpen = 0;
+	uint8_t index = 0;
+	uint8_t htotal = 0;
+	uint8_t hdend = 0;
+	uint8_t hsyncp = 0;
+	uint8_t hsyncw = 0;
+	uint8_t vtotal = 0;
+	uint8_t vdend = 0;
+	uint8_t vadjust = 0;
+	uint8_t vsyncp = 0;
+	uint8_t vsyncw = 0;
+	uint8_t max_scanline = 0;
+	uint16_t lightpen = 0;
 	bool lightpen_triggered = false;
-	Bit8u cursor_start = 0;
-	Bit8u cursor_end = 0;
+	uint8_t cursor_start = 0;
+	uint8_t cursor_end = 0;
 };
 
 struct VGA_TANDY {
-	Bit8u pcjr_flipflop = 0;
-	Bit8u mode_control = 0;
-	Bit8u color_select = 0;
-	Bit8u disp_bank = 0;
-	Bit8u reg_index = 0;
-	Bit8u gfx_control = 0;
-	Bit8u palette_mask = 0;
-	Bit8u extended_ram = 0;
-	Bit8u border_color = 0;
-	Bit8u line_mask = 0;
+	uint8_t pcjr_flipflop = 0;
+	uint8_t mode_control = 0;
+	uint8_t color_select = 0;
+	uint8_t disp_bank = 0;
+	uint8_t reg_index = 0;
+	uint8_t gfx_control = 0;
+	uint8_t palette_mask = 0;
+	uint8_t extended_ram = 0;
+	uint8_t border_color = 0;
+	uint8_t line_mask = 0;
 	uint8_t line_shift = 0;
-	Bit8u draw_bank = 0;
+	uint8_t draw_bank = 0;
 	uint8_t mem_bank = 0;
-	Bit8u *draw_base = nullptr;
+	uint8_t *draw_base = nullptr;
 	uint8_t *mem_base = nullptr;
 	Bitu addr_mask = 0;
 };
 
 struct VGA_Seq {
-	Bit8u index = 0;
-	Bit8u reset = 0;
-	Bit8u clocking_mode = 0;
-	Bit8u map_mask = 0;
-	Bit8u character_map_select = 0;
-	Bit8u memory_mode = 0;
+	uint8_t index = 0;
+	uint8_t reset = 0;
+	uint8_t clocking_mode = 0;
+	uint8_t map_mask = 0;
+	uint8_t character_map_select = 0;
+	uint8_t memory_mode = 0;
 };
 
 struct VGA_Attr {
-	Bit8u palette[16] = {};
-	Bit8u mode_control = 0;
-	Bit8u horizontal_pel_panning = 0;
-	Bit8u overscan_color = 0;
-	Bit8u color_plane_enable = 0;
-	Bit8u color_select = 0;
-	Bit8u index = 0;
-	Bit8u disabled = 0; // Used for disabling the screen.
+	uint8_t palette[16] = {};
+	uint8_t mode_control = 0;
+	uint8_t horizontal_pel_panning = 0;
+	uint8_t overscan_color = 0;
+	uint8_t color_plane_enable = 0;
+	uint8_t color_select = 0;
+	uint8_t index = 0;
+	uint8_t disabled = 0; // Used for disabling the screen.
 	                    // Bit0: screen disabled by attribute controller
 	                    // index Bit1: screen disabled by sequencer index 1
 	                    // bit 5 These are put together in one variable for
@@ -332,66 +332,66 @@ struct VGA_Attr {
 };
 
 struct VGA_Crtc {
-	Bit8u horizontal_total = 0;
-	Bit8u horizontal_display_end = 0;
-	Bit8u start_horizontal_blanking = 0;
-	Bit8u end_horizontal_blanking = 0;
-	Bit8u start_horizontal_retrace = 0;
-	Bit8u end_horizontal_retrace = 0;
-	Bit8u vertical_total = 0;
-	Bit8u overflow = 0;
-	Bit8u preset_row_scan = 0;
-	Bit8u maximum_scan_line = 0;
-	Bit8u cursor_start = 0;
-	Bit8u cursor_end = 0;
-	Bit8u start_address_high = 0;
-	Bit8u start_address_low = 0;
-	Bit8u cursor_location_high = 0;
-	Bit8u cursor_location_low = 0;
-	Bit8u vertical_retrace_start = 0;
-	Bit8u vertical_retrace_end = 0;
-	Bit8u vertical_display_end = 0;
-	Bit8u offset = 0;
-	Bit8u underline_location = 0;
-	Bit8u start_vertical_blanking = 0;
-	Bit8u end_vertical_blanking = 0;
-	Bit8u mode_control = 0;
-	Bit8u line_compare = 0;
+	uint8_t horizontal_total = 0;
+	uint8_t horizontal_display_end = 0;
+	uint8_t start_horizontal_blanking = 0;
+	uint8_t end_horizontal_blanking = 0;
+	uint8_t start_horizontal_retrace = 0;
+	uint8_t end_horizontal_retrace = 0;
+	uint8_t vertical_total = 0;
+	uint8_t overflow = 0;
+	uint8_t preset_row_scan = 0;
+	uint8_t maximum_scan_line = 0;
+	uint8_t cursor_start = 0;
+	uint8_t cursor_end = 0;
+	uint8_t start_address_high = 0;
+	uint8_t start_address_low = 0;
+	uint8_t cursor_location_high = 0;
+	uint8_t cursor_location_low = 0;
+	uint8_t vertical_retrace_start = 0;
+	uint8_t vertical_retrace_end = 0;
+	uint8_t vertical_display_end = 0;
+	uint8_t offset = 0;
+	uint8_t underline_location = 0;
+	uint8_t start_vertical_blanking = 0;
+	uint8_t end_vertical_blanking = 0;
+	uint8_t mode_control = 0;
+	uint8_t line_compare = 0;
 
-	Bit8u index = 0;
+	uint8_t index = 0;
 	bool read_only = false;
 };
 
 struct VGA_Gfx {
-	Bit8u index = 0;
-	Bit8u set_reset = 0;
-	Bit8u enable_set_reset = 0;
-	Bit8u color_compare = 0;
-	Bit8u data_rotate = 0;
-	Bit8u read_map_select = 0;
-	Bit8u mode = 0;
-	Bit8u miscellaneous = 0;
-	Bit8u color_dont_care = 0;
-	Bit8u bit_mask = 0;
+	uint8_t index = 0;
+	uint8_t set_reset = 0;
+	uint8_t enable_set_reset = 0;
+	uint8_t color_compare = 0;
+	uint8_t data_rotate = 0;
+	uint8_t read_map_select = 0;
+	uint8_t mode = 0;
+	uint8_t miscellaneous = 0;
+	uint8_t color_dont_care = 0;
+	uint8_t bit_mask = 0;
 };
 
 struct RGBEntry {
-	Bit8u red = 0;
-	Bit8u green = 0;
-	Bit8u blue = 0;
+	uint8_t red = 0;
+	uint8_t green = 0;
+	uint8_t blue = 0;
 };
 
 struct VGA_Dac {
-	Bit8u bits = 0; /* DAC bits, usually 6 or 8 */
-	Bit8u pel_mask = 0;
-	Bit8u pel_index = 0;
-	Bit8u state = 0;
-	Bit8u write_index = 0;
-	Bit8u read_index = 0;
+	uint8_t bits = 0; /* DAC bits, usually 6 or 8 */
+	uint8_t pel_mask = 0;
+	uint8_t pel_index = 0;
+	uint8_t state = 0;
+	uint8_t write_index = 0;
+	uint8_t read_index = 0;
 	Bitu first_changed = 0;
-	Bit8u combine[16] = {};
+	uint8_t combine[16] = {};
 	RGBEntry rgb[0x100] = {};
-	Bit16u xlat16[256] = {};
+	uint16_t xlat16[256] = {};
 };
 
 struct VGA_SVGA {
@@ -399,43 +399,43 @@ struct VGA_SVGA {
 	Bitu bankMask = 0;
 	Bitu bank_read_full = 0;
 	Bitu bank_write_full = 0;
-	Bit8u bank_read = 0;
-	Bit8u bank_write = 0;
+	uint8_t bank_read = 0;
+	uint8_t bank_write = 0;
 	Bitu bank_size = 0;
 };
 
 union VGA_Latch {
-	Bit32u d = 0;
-	Bit8u b[4];
+	uint32_t d = 0;
+	uint8_t b[4];
 };
 
 struct VGA_Memory {
-	Bit8u *linear = nullptr;
-	Bit8u *linear_orgptr = nullptr;
+	uint8_t *linear = nullptr;
+	uint8_t *linear_orgptr = nullptr;
 };
 
 struct VGA_Changes {
 	//Add a few more just to be safe
-	Bit8u *map = nullptr; /* allocated dynamically: [(VGA_MEMORY >> VGA_CHANGE_SHIFT) + 32] */
-	Bit8u checkMask = 0;
+	uint8_t *map = nullptr; /* allocated dynamically: [(VGA_MEMORY >> VGA_CHANGE_SHIFT) + 32] */
+	uint8_t checkMask = 0;
 	uint8_t frame = 0;
 	uint8_t writeMask = 0;
 	bool active = 0;
-	Bit32u clearMask = 0;
-	Bit32u start = 0, last = 0;
-	Bit32u lastAddress = 0;
+	uint32_t clearMask = 0;
+	uint32_t start = 0, last = 0;
+	uint32_t lastAddress = 0;
 };
 
 struct VGA_LFB {
-	Bit32u page = 0;
-	Bit32u addr = 0;
-	Bit32u mask = 0;
+	uint32_t page = 0;
+	uint32_t addr = 0;
+	uint32_t mask = 0;
 	PageHandler *handler = nullptr;
 };
 
 struct VGA_Type {
 	VGAModes mode = {}; /* The mode the vga system is in */
-	Bit8u misc_output = 0;
+	uint8_t misc_output = 0;
 	VGA_Draw draw = {};
 	VGA_Config config = {};
 	VGA_Internal internal = {};
@@ -452,11 +452,11 @@ struct VGA_Type {
 	VGA_TANDY tandy = {};
 	VGA_OTHER other = {};
 	VGA_Memory mem = {};
-	Bit32u vmemwrap = 0;      /* this is assumed to be power of 2 */
-	Bit8u *fastmem = nullptr; /* memory for fast (usually 16-color)
+	uint32_t vmemwrap = 0;      /* this is assumed to be power of 2 */
+	uint8_t *fastmem = nullptr; /* memory for fast (usually 16-color)
 	                             rendering, always twice as big as vmemsize */
-	Bit8u *fastmem_orgptr = nullptr;
-	Bit32u vmemsize = 0;
+	uint8_t *fastmem_orgptr = nullptr;
+	uint32_t vmemsize = 0;
 #ifdef VGA_KEEP_CHANGES
 	VGA_Changes changes = {};
 #endif
@@ -484,9 +484,9 @@ void VGA_CheckScanLength(void);
 void VGA_ChangedBank(void);
 
 /* Some DAC/Attribute functions */
-void VGA_DAC_CombineColor(Bit8u attr,Bit8u pal);
-void VGA_DAC_SetEntry(Bitu entry,Bit8u red,Bit8u green,Bit8u blue);
-void VGA_ATTR_SetPalette(Bit8u index,Bit8u val);
+void VGA_DAC_CombineColor(uint8_t attr,uint8_t pal);
+void VGA_DAC_SetEntry(Bitu entry,uint8_t red,uint8_t green,uint8_t blue);
+void VGA_ATTR_SetPalette(uint8_t index,uint8_t val);
 
 enum EGAMonitorMode { CGA, EGA, MONO };
 
@@ -517,8 +517,8 @@ void VGA_DACSetEntirePalette(void);
 void VGA_StartRetrace(void);
 void VGA_StartUpdateLFB(void);
 void VGA_SetBlinking(uint8_t enabled);
-void VGA_SetCGA2Table(Bit8u val0,Bit8u val1);
-void VGA_SetCGA4Table(Bit8u val0,Bit8u val1,Bit8u val2,Bit8u val3);
+void VGA_SetCGA2Table(uint8_t val0,uint8_t val1);
+void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3);
 void VGA_ActivateHardwareCursor(void);
 void VGA_KillDrawing(void);
 
@@ -540,8 +540,8 @@ extern VGA_Type vga;
    It also contains basic int10 mode data - number, vtotal, htotal
    */
 struct VGA_ModeExtraData {
-	Bit8u ver_overflow = 0;
-	Bit8u hor_overflow = 0;
+	uint8_t ver_overflow = 0;
+	uint8_t hor_overflow = 0;
 	Bitu offset = 0;
 	Bitu modeNo = 0;
 	uint32_t htotal = 0;
@@ -587,17 +587,17 @@ void SVGA_Setup_Driver(void);
 // Amount of video memory required for a mode, implemented in int10_modes.cpp
 uint32_t VideoModeMemSize(uint16_t mode);
 
-extern Bit32u ExpandTable[256];
-extern Bit32u FillTable[16];
-extern Bit32u CGA_2_Table[16];
-extern Bit32u CGA_4_Table[256];
-extern Bit32u CGA_4_HiRes_Table[256];
-extern Bit32u CGA_16_Table[256];
+extern uint32_t ExpandTable[256];
+extern uint32_t FillTable[16];
+extern uint32_t CGA_2_Table[16];
+extern uint32_t CGA_4_Table[256];
+extern uint32_t CGA_4_HiRes_Table[256];
+extern uint32_t CGA_16_Table[256];
 extern int CGA_Composite_Table[1024];
-extern Bit32u TXT_Font_Table[16];
-extern Bit32u TXT_FG_Table[16];
-extern Bit32u TXT_BG_Table[16];
-extern Bit32u Expand16Table[4][16];
-extern Bit32u Expand16BigTable[0x10000];
+extern uint32_t TXT_Font_Table[16];
+extern uint32_t TXT_FG_Table[16];
+extern uint32_t TXT_BG_Table[16];
+extern uint32_t Expand16Table[4][16];
+extern uint32_t Expand16BigTable[0x10000];
 
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -57,7 +57,7 @@ typedef void (*GFX_CallBack_t)( GFX_CallBackFunctions_t function );
 bool GFX_Events();
 
 Bitu GFX_GetBestMode(Bitu flags);
-Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);
+Bitu GFX_GetRGB(uint8_t red,uint8_t green,uint8_t blue);
 void GFX_SetShader(const char* src);
 Bitu GFX_SetSize(int width, int height, Bitu flags,
                  double scalex, double scaley,
@@ -70,7 +70,7 @@ void GFX_Start(void);
 void GFX_Stop(void);
 void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
-void GFX_EndUpdate( const Bit16u *changedLines );
+void GFX_EndUpdate( const uint16_t *changedLines );
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus();
 void GFX_RegenerateWindow(Section *sec);

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -62,8 +62,8 @@ void CALLBACK_Idle(void) {
 /* this makes the cpu execute instructions to handle irq's and then come back */
 	Bitu oldIF=GETFLAG(IF);
 	SETFLAGBIT(IF,true);
-	Bit16u oldcs=SegValue(cs);
-	Bit32u oldeip=reg_eip;
+	uint16_t oldcs=SegValue(cs);
+	uint32_t oldeip=reg_eip;
 	SegSet16(cs,CB_SEG);
 	reg_eip=CB_SOFFSET+call_idle*CB_SIZE;
 	DOSBOX_RunMachine();
@@ -85,12 +85,12 @@ static Bitu stop_handler(void) {
 
 
 
-void CALLBACK_RunRealFar(Bit16u seg,Bit16u off) {
+void CALLBACK_RunRealFar(uint16_t seg,uint16_t off) {
 	reg_sp-=4;
 	mem_writew(SegPhys(ss)+reg_sp,RealOff(CALLBACK_RealPointer(call_stop)));
 	mem_writew(SegPhys(ss)+reg_sp+2,RealSeg(CALLBACK_RealPointer(call_stop)));
-	Bit32u oldeip=reg_eip;
-	Bit16u oldcs=SegValue(cs);
+	uint32_t oldeip=reg_eip;
+	uint16_t oldcs=SegValue(cs);
 	reg_eip=off;
 	SegSet16(cs,seg);
 	DOSBOX_RunMachine();
@@ -98,9 +98,9 @@ void CALLBACK_RunRealFar(Bit16u seg,Bit16u off) {
 	SegSet16(cs,oldcs);
 }
 
-void CALLBACK_RunRealInt(Bit8u intnum) {
-	Bit32u oldeip=reg_eip;
-	Bit16u oldcs=SegValue(cs);
+void CALLBACK_RunRealInt(uint8_t intnum) {
+	uint32_t oldeip=reg_eip;
+	uint16_t oldcs=SegValue(cs);
 	reg_eip=CB_SOFFSET+(CB_MAX*CB_SIZE)+(intnum*6);
 	SegSet16(cs,CB_SEG);
 	DOSBOX_RunMachine();
@@ -109,21 +109,21 @@ void CALLBACK_RunRealInt(Bit8u intnum) {
 }
 
 void CALLBACK_SZF(bool val) {
-	Bit16u tempf = mem_readw(SegPhys(ss)+reg_sp+4);
+	uint16_t tempf = mem_readw(SegPhys(ss)+reg_sp+4);
 	if (val) tempf |= FLAG_ZF;
 	else tempf &= ~FLAG_ZF;
 	mem_writew(SegPhys(ss)+reg_sp+4,tempf);
 }
 
 void CALLBACK_SCF(bool val) {
-	Bit16u tempf = mem_readw(SegPhys(ss)+reg_sp+4);
+	uint16_t tempf = mem_readw(SegPhys(ss)+reg_sp+4);
 	if (val) tempf |= FLAG_CF;
 	else tempf &= ~FLAG_CF;
 	mem_writew(SegPhys(ss)+reg_sp+4,tempf);
 }
 
 void CALLBACK_SIF(bool val) {
-	Bit16u tempf = mem_readw(SegPhys(ss)+reg_sp+4);
+	uint16_t tempf = mem_readw(SegPhys(ss)+reg_sp+4);
 	if (val) tempf |= FLAG_IF;
 	else tempf &= ~FLAG_IF;
 	mem_writew(SegPhys(ss)+reg_sp+4,tempf);
@@ -147,384 +147,384 @@ Bitu CALLBACK_SetupExtra(Bitu callback, Bitu type, PhysPt physAddress, bool use_
 	switch (type) {
 	case CB_RETN:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0xC3);		//A RETN Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xC3);		//A RETN Instruction
 		return (use_cb?5:1);
 	case CB_RETF:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xCB);		//A RETF Instruction
 		return (use_cb?5:1);
 	case CB_RETF8:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0xCA);		//A RETF 8 Instruction
-		phys_writew(physAddress+0x01,(Bit16u)0x0008);
+		phys_writeb(physAddress+0x00,(uint8_t)0xCA);		//A RETF 8 Instruction
+		phys_writew(physAddress+0x01,(uint16_t)0x0008);
 		return (use_cb?7:3);
 	case CB_RETF_STI:
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		//STI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		//STI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCB);		//A RETF Instruction
 		return (use_cb?6:2);
 	case CB_RETF_CLI:
-		phys_writeb(physAddress+0x00,(Bit8u)0xFA);		//CLI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFA);		//CLI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCB);		//A RETF Instruction
 		return (use_cb?6:2);
 	case CB_IRET:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xCF);		//An IRET Instruction
 		return (use_cb?5:1);
 	case CB_IRETD:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0x66);		//An IRETD Instruction
-		phys_writeb(physAddress+0x01,(Bit8u)0xCF);
+		phys_writeb(physAddress+0x00,(uint8_t)0x66);		//An IRETD Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCF);
 		return (use_cb?6:2);
 	case CB_IRET_STI:
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		//STI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		//STI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCF);		//An IRET Instruction
 		return (use_cb?6:2);
 	case CB_IRET_EOI_PIC1:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0x50);		// push ax
-		phys_writeb(physAddress+0x01,(Bit8u)0xb0);		// mov al, 0x20
-		phys_writeb(physAddress+0x02,(Bit8u)0x20);
-		phys_writeb(physAddress+0x03,(Bit8u)0xe6);		// out 0x20, al
-		phys_writeb(physAddress+0x04,(Bit8u)0x20);
-		phys_writeb(physAddress+0x05,(Bit8u)0x58);		// pop ax
-		phys_writeb(physAddress+0x06,(Bit8u)0xcf);		//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0x50);		// push ax
+		phys_writeb(physAddress+0x01,(uint8_t)0xb0);		// mov al, 0x20
+		phys_writeb(physAddress+0x02,(uint8_t)0x20);
+		phys_writeb(physAddress+0x03,(uint8_t)0xe6);		// out 0x20, al
+		phys_writeb(physAddress+0x04,(uint8_t)0x20);
+		phys_writeb(physAddress+0x05,(uint8_t)0x58);		// pop ax
+		phys_writeb(physAddress+0x06,(uint8_t)0xcf);		//An IRET Instruction
 		return (use_cb?0x0b:0x07);
 	case CB_IRQ0:	// timer int8
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		//STI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		//STI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0x1e);		// push ds
-		phys_writeb(physAddress+0x02,(Bit8u)0x50);		// push ax
-		phys_writeb(physAddress+0x03,(Bit8u)0x52);		// push dx
-		phys_writew(physAddress+0x04,(Bit16u)0x1ccd);	// int 1c
-		phys_writeb(physAddress+0x06,(Bit8u)0xfa);		// cli
-		phys_writew(physAddress+0x07,(Bit16u)0x20b0);	// mov al, 0x20
-		phys_writew(physAddress+0x09,(Bit16u)0x20e6);	// out 0x20, al
-		phys_writeb(physAddress+0x0b,(Bit8u)0x5a);		// pop dx
-		phys_writeb(physAddress+0x0c,(Bit8u)0x58);		// pop ax
-		phys_writeb(physAddress+0x0d,(Bit8u)0x1f);		// pop ds
-		phys_writeb(physAddress+0x0e,(Bit8u)0xcf);		//An IRET Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0x1e);		// push ds
+		phys_writeb(physAddress+0x02,(uint8_t)0x50);		// push ax
+		phys_writeb(physAddress+0x03,(uint8_t)0x52);		// push dx
+		phys_writew(physAddress+0x04,(uint16_t)0x1ccd);	// int 1c
+		phys_writeb(physAddress+0x06,(uint8_t)0xfa);		// cli
+		phys_writew(physAddress+0x07,(uint16_t)0x20b0);	// mov al, 0x20
+		phys_writew(physAddress+0x09,(uint16_t)0x20e6);	// out 0x20, al
+		phys_writeb(physAddress+0x0b,(uint8_t)0x5a);		// pop dx
+		phys_writeb(physAddress+0x0c,(uint8_t)0x58);		// pop ax
+		phys_writeb(physAddress+0x0d,(uint8_t)0x1f);		// pop ds
+		phys_writeb(physAddress+0x0e,(uint8_t)0xcf);		//An IRET Instruction
 		return (use_cb?0x13:0x0f);
 	case CB_IRQ1:	// keyboard int9
-		phys_writeb(physAddress+0x00,(Bit8u)0x50);			// push ax
-		phys_writew(physAddress+0x01,(Bit16u)0x60e4);		// in al, 0x60
-		phys_writew(physAddress+0x03,(Bit16u)0x4fb4);		// mov ah, 0x4f
-		phys_writeb(physAddress+0x05,(Bit8u)0xf9);			// stc
-		phys_writew(physAddress+0x06,(Bit16u)0x15cd);		// int 15
+		phys_writeb(physAddress+0x00,(uint8_t)0x50);			// push ax
+		phys_writew(physAddress+0x01,(uint16_t)0x60e4);		// in al, 0x60
+		phys_writew(physAddress+0x03,(uint16_t)0x4fb4);		// mov ah, 0x4f
+		phys_writeb(physAddress+0x05,(uint8_t)0xf9);			// stc
+		phys_writew(physAddress+0x06,(uint16_t)0x15cd);		// int 15
 		if (use_cb) {
-			phys_writew(physAddress+0x08,(Bit16u)0x0473);	// jc skip
-			phys_writeb(physAddress+0x0a,(Bit8u)0xFE);		//GRP 4
-			phys_writeb(physAddress+0x0b,(Bit8u)0x38);		//Extra Callback instruction
-			phys_writew(physAddress+0x0c,(Bit16u)callback);			//The immediate word
+			phys_writew(physAddress+0x08,(uint16_t)0x0473);	// jc skip
+			phys_writeb(physAddress+0x0a,(uint8_t)0xFE);		//GRP 4
+			phys_writeb(physAddress+0x0b,(uint8_t)0x38);		//Extra Callback instruction
+			phys_writew(physAddress+0x0c,(uint16_t)callback);			//The immediate word
 			// jump here to (skip):
 			physAddress+=6;
 		}
-		phys_writeb(physAddress+0x08,(Bit8u)0xfa);			// cli
-		phys_writew(physAddress+0x09,(Bit16u)0x20b0);		// mov al, 0x20
-		phys_writew(physAddress+0x0b,(Bit16u)0x20e6);		// out 0x20, al
-		phys_writeb(physAddress+0x0d,(Bit8u)0x58);			// pop ax
-		phys_writeb(physAddress+0x0e,(Bit8u)0xcf);			//An IRET Instruction
-		phys_writeb(physAddress+0x0f,(Bit8u)0xfa);			// cli
-		phys_writew(physAddress+0x10,(Bit16u)0x20b0);		// mov al, 0x20
-		phys_writew(physAddress+0x12,(Bit16u)0x20e6);		// out 0x20, al
-		phys_writeb(physAddress+0x14,(Bit8u)0x55);			// push bp
-		phys_writew(physAddress+0x15,(Bit16u)0x05cd);		// int 5
-		phys_writeb(physAddress+0x17,(Bit8u)0x5d);			// pop bp
-		phys_writeb(physAddress+0x18,(Bit8u)0x58);			// pop ax
-		phys_writeb(physAddress+0x19,(Bit8u)0xcf);			//An IRET Instruction
+		phys_writeb(physAddress+0x08,(uint8_t)0xfa);			// cli
+		phys_writew(physAddress+0x09,(uint16_t)0x20b0);		// mov al, 0x20
+		phys_writew(physAddress+0x0b,(uint16_t)0x20e6);		// out 0x20, al
+		phys_writeb(physAddress+0x0d,(uint8_t)0x58);			// pop ax
+		phys_writeb(physAddress+0x0e,(uint8_t)0xcf);			//An IRET Instruction
+		phys_writeb(physAddress+0x0f,(uint8_t)0xfa);			// cli
+		phys_writew(physAddress+0x10,(uint16_t)0x20b0);		// mov al, 0x20
+		phys_writew(physAddress+0x12,(uint16_t)0x20e6);		// out 0x20, al
+		phys_writeb(physAddress+0x14,(uint8_t)0x55);			// push bp
+		phys_writew(physAddress+0x15,(uint16_t)0x05cd);		// int 5
+		phys_writeb(physAddress+0x17,(uint8_t)0x5d);			// pop bp
+		phys_writeb(physAddress+0x18,(uint8_t)0x58);			// pop ax
+		phys_writeb(physAddress+0x19,(uint8_t)0xcf);			//An IRET Instruction
 		return (use_cb?0x20:0x1a);
 	case CB_IRQ9:	// pic cascade interrupt
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0x50);		// push ax
-		phys_writew(physAddress+0x01,(Bit16u)0x61b0);	// mov al, 0x61
-		phys_writew(physAddress+0x03,(Bit16u)0xa0e6);	// out 0xa0, al
-		phys_writew(physAddress+0x05,(Bit16u)0x0acd);	// int a
-		phys_writeb(physAddress+0x07,(Bit8u)0xfa);		// cli
-		phys_writeb(physAddress+0x08,(Bit8u)0x58);		// pop ax
-		phys_writeb(physAddress+0x09,(Bit8u)0xcf);		//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0x50);		// push ax
+		phys_writew(physAddress+0x01,(uint16_t)0x61b0);	// mov al, 0x61
+		phys_writew(physAddress+0x03,(uint16_t)0xa0e6);	// out 0xa0, al
+		phys_writew(physAddress+0x05,(uint16_t)0x0acd);	// int a
+		phys_writeb(physAddress+0x07,(uint8_t)0xfa);		// cli
+		phys_writeb(physAddress+0x08,(uint8_t)0x58);		// pop ax
+		phys_writeb(physAddress+0x09,(uint8_t)0xcf);		//An IRET Instruction
 		return (use_cb?0x0e:0x0a);
 	case CB_IRQ12:	// ps2 mouse int74
 		if (!use_cb) E_Exit("int74 callback must implement a callback handler!");
-		phys_writeb(physAddress+0x00,(Bit8u)0xfb);		// sti
-		phys_writeb(physAddress+0x01,(Bit8u)0x1e);		// push ds
-		phys_writeb(physAddress+0x02,(Bit8u)0x06);		// push es
-		phys_writew(physAddress+0x03,(Bit16u)0x6066);	// pushad
-		phys_writeb(physAddress+0x05,(Bit8u)0xFE);		//GRP 4
-		phys_writeb(physAddress+0x06,(Bit8u)0x38);		//Extra Callback instruction
-		phys_writew(physAddress+0x07,(Bit16u)callback);			//The immediate word
-		phys_writeb(physAddress+0x09,(Bit8u)0x50);		// push ax
-		phys_writew(physAddress+0x0a,(Bit16u)0x20b0);	// mov al, 0x20
-		phys_writew(physAddress+0x0c,(Bit16u)0xa0e6);	// out 0xa0, al
-		phys_writew(physAddress+0x0e,(Bit16u)0x20e6);	// out 0x20, al
-		phys_writeb(physAddress+0x10,(Bit8u)0x58);		// pop ax
-		phys_writeb(physAddress+0x11,(Bit8u)0xfc);		// cld
-		phys_writeb(physAddress+0x12,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xfb);		// sti
+		phys_writeb(physAddress+0x01,(uint8_t)0x1e);		// push ds
+		phys_writeb(physAddress+0x02,(uint8_t)0x06);		// push es
+		phys_writew(physAddress+0x03,(uint16_t)0x6066);	// pushad
+		phys_writeb(physAddress+0x05,(uint8_t)0xFE);		//GRP 4
+		phys_writeb(physAddress+0x06,(uint8_t)0x38);		//Extra Callback instruction
+		phys_writew(physAddress+0x07,(uint16_t)callback);			//The immediate word
+		phys_writeb(physAddress+0x09,(uint8_t)0x50);		// push ax
+		phys_writew(physAddress+0x0a,(uint16_t)0x20b0);	// mov al, 0x20
+		phys_writew(physAddress+0x0c,(uint16_t)0xa0e6);	// out 0xa0, al
+		phys_writew(physAddress+0x0e,(uint16_t)0x20e6);	// out 0x20, al
+		phys_writeb(physAddress+0x10,(uint8_t)0x58);		// pop ax
+		phys_writeb(physAddress+0x11,(uint8_t)0xfc);		// cld
+		phys_writeb(physAddress+0x12,(uint8_t)0xCB);		//A RETF Instruction
 		return 0x13;
 	case CB_IRQ12_RET:	// ps2 mouse int74 return
-		phys_writeb(physAddress+0x00,(Bit8u)0xfa);		// cli
-		phys_writew(physAddress+0x01,(Bit16u)0x20b0);	// mov al, 0x20
-		phys_writew(physAddress+0x03,(Bit16u)0xa0e6);	// out 0xa0, al
-		phys_writew(physAddress+0x05,(Bit16u)0x20e6);	// out 0x20, al
+		phys_writeb(physAddress+0x00,(uint8_t)0xfa);		// cli
+		phys_writew(physAddress+0x01,(uint16_t)0x20b0);	// mov al, 0x20
+		phys_writew(physAddress+0x03,(uint16_t)0xa0e6);	// out 0xa0, al
+		phys_writew(physAddress+0x05,(uint16_t)0x20e6);	// out 0x20, al
 		if (use_cb) {
-			phys_writeb(physAddress+0x07,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x08,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x09,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x07,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x08,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x09,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writew(physAddress+0x07,(Bit16u)0x6166);	// popad
-		phys_writeb(physAddress+0x09,(Bit8u)0x07);		// pop es
-		phys_writeb(physAddress+0x0a,(Bit8u)0x1f);		// pop ds
-		phys_writeb(physAddress+0x0b,(Bit8u)0xcf);		//An IRET Instruction
+		phys_writew(physAddress+0x07,(uint16_t)0x6166);	// popad
+		phys_writeb(physAddress+0x09,(uint8_t)0x07);		// pop es
+		phys_writeb(physAddress+0x0a,(uint8_t)0x1f);		// pop ds
+		phys_writeb(physAddress+0x0b,(uint8_t)0xcf);		//An IRET Instruction
 		return (use_cb?0x10:0x0c);
 	case CB_IRQ6_PCJR:	// pcjr keyboard interrupt
-		phys_writeb(physAddress+0x00,(Bit8u)0x50);			// push ax
-		phys_writew(physAddress+0x01,(Bit16u)0x60e4);		// in al, 0x60
-		phys_writew(physAddress+0x03,(Bit16u)0xe03c);		// cmp al, 0xe0
+		phys_writeb(physAddress+0x00,(uint8_t)0x50);			// push ax
+		phys_writew(physAddress+0x01,(uint16_t)0x60e4);		// in al, 0x60
+		phys_writew(physAddress+0x03,(uint16_t)0xe03c);		// cmp al, 0xe0
 		if (use_cb) {
-			phys_writew(physAddress+0x05,(Bit16u)0x0b74);	// je skip
-			phys_writeb(physAddress+0x07,(Bit8u)0xFE);		//GRP 4
-			phys_writeb(physAddress+0x08,(Bit8u)0x38);		//Extra Callback instruction
-			phys_writew(physAddress+0x09,(Bit16u)callback);			//The immediate word
+			phys_writew(physAddress+0x05,(uint16_t)0x0b74);	// je skip
+			phys_writeb(physAddress+0x07,(uint8_t)0xFE);		//GRP 4
+			phys_writeb(physAddress+0x08,(uint8_t)0x38);		//Extra Callback instruction
+			phys_writew(physAddress+0x09,(uint16_t)callback);			//The immediate word
 			physAddress+=4;
 		} else {
-			phys_writew(physAddress+0x05,(Bit16u)0x0774);	// je skip
+			phys_writew(physAddress+0x05,(uint16_t)0x0774);	// je skip
 		}
-		phys_writeb(physAddress+0x07,(Bit8u)0x1e);			// push ds
-		phys_writew(physAddress+0x08,(Bit16u)0x406a);		// push 0x0040
-		phys_writeb(physAddress+0x0a,(Bit8u)0x1f);			// pop ds
-		phys_writew(physAddress+0x0b,(Bit16u)0x09cd);		// int 9
-		phys_writeb(physAddress+0x0d,(Bit8u)0x1f);			// pop ds
+		phys_writeb(physAddress+0x07,(uint8_t)0x1e);			// push ds
+		phys_writew(physAddress+0x08,(uint16_t)0x406a);		// push 0x0040
+		phys_writeb(physAddress+0x0a,(uint8_t)0x1f);			// pop ds
+		phys_writew(physAddress+0x0b,(uint16_t)0x09cd);		// int 9
+		phys_writeb(physAddress+0x0d,(uint8_t)0x1f);			// pop ds
 		// jump here to (skip):
-		phys_writeb(physAddress+0x0e,(Bit8u)0xfa);			// cli
-		phys_writew(physAddress+0x0f,(Bit16u)0x20b0);		// mov al, 0x20
-		phys_writew(physAddress+0x11,(Bit16u)0x20e6);		// out 0x20, al
-		phys_writeb(physAddress+0x13,(Bit8u)0x58);			// pop ax
-		phys_writeb(physAddress+0x14,(Bit8u)0xcf);			//An IRET Instruction
+		phys_writeb(physAddress+0x0e,(uint8_t)0xfa);			// cli
+		phys_writew(physAddress+0x0f,(uint16_t)0x20b0);		// mov al, 0x20
+		phys_writew(physAddress+0x11,(uint16_t)0x20e6);		// out 0x20, al
+		phys_writeb(physAddress+0x13,(uint8_t)0x58);			// pop ax
+		phys_writeb(physAddress+0x14,(uint8_t)0xcf);			//An IRET Instruction
 		return (use_cb?0x19:0x15);
 	case CB_MOUSE:
-		phys_writew(physAddress+0x00,(Bit16u)0x07eb);		// jmp i33hd
+		phys_writew(physAddress+0x00,(uint16_t)0x07eb);		// jmp i33hd
 		physAddress+=9;
 		// jump here to (i33hd):
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xCF);		//An IRET Instruction
 		return (use_cb?0x0e:0x0a);
 	case CB_INT16:
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		//STI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		//STI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCF);		//An IRET Instruction
 		for (Bitu i=0;i<=0x0b;i++) phys_writeb(physAddress+0x02+i,0x90);
-		phys_writew(physAddress+0x0e,(Bit16u)0xedeb);	//jmp callback
+		phys_writew(physAddress+0x0e,(uint16_t)0xedeb);	//jmp callback
 		return (use_cb?0x10:0x0c);
 	case CB_INT29:	// fast console output
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0x50);	// push ax
-		phys_writeb(physAddress+0x01,(Bit8u)0x53);	// push bx
-		phys_writew(physAddress+0x02,(Bit16u)0x0eb4);	// mov ah, 0x0e
-		phys_writeb(physAddress+0x04,(Bit8u)0xbb);	// mov bx,
-		phys_writew(physAddress+0x05,(Bit16u)0x0007);	// 0x0007
-		phys_writew(physAddress+0x07,(Bit16u)0x10cd);	// int 10
-		phys_writeb(physAddress+0x09,(Bit8u)0x5b);	// pop bx
-		phys_writeb(physAddress+0x0a,(Bit8u)0x58);	// pop ax
-		phys_writeb(physAddress+0x0b,(Bit8u)0xcf);	//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0x50);	// push ax
+		phys_writeb(physAddress+0x01,(uint8_t)0x53);	// push bx
+		phys_writew(physAddress+0x02,(uint16_t)0x0eb4);	// mov ah, 0x0e
+		phys_writeb(physAddress+0x04,(uint8_t)0xbb);	// mov bx,
+		phys_writew(physAddress+0x05,(uint16_t)0x0007);	// 0x0007
+		phys_writew(physAddress+0x07,(uint16_t)0x10cd);	// int 10
+		phys_writeb(physAddress+0x09,(uint8_t)0x5b);	// pop bx
+		phys_writeb(physAddress+0x0a,(uint8_t)0x58);	// pop ax
+		phys_writeb(physAddress+0x0b,(uint8_t)0xcf);	//An IRET Instruction
 		return (use_cb?0x10:0x0c);
 	case CB_HOOKABLE:
-		phys_writeb(physAddress+0x00,(Bit8u)0xEB);		//jump near
-		phys_writeb(physAddress+0x01,(Bit8u)0x03);		//offset
-		phys_writeb(physAddress+0x02,(Bit8u)0x90);		//NOP
-		phys_writeb(physAddress+0x03,(Bit8u)0x90);		//NOP
-		phys_writeb(physAddress+0x04,(Bit8u)0x90);		//NOP
+		phys_writeb(physAddress+0x00,(uint8_t)0xEB);		//jump near
+		phys_writeb(physAddress+0x01,(uint8_t)0x03);		//offset
+		phys_writeb(physAddress+0x02,(uint8_t)0x90);		//NOP
+		phys_writeb(physAddress+0x03,(uint8_t)0x90);		//NOP
+		phys_writeb(physAddress+0x04,(uint8_t)0x90);		//NOP
 		if (use_cb) {
-			phys_writeb(physAddress+0x05,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x06,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x07,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x05,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x06,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x07,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x05,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x05,(uint8_t)0xCB);		//A RETF Instruction
 		return (use_cb?0x0a:0x06);
 	case CB_TDE_IRET:	// TandyDAC end transfer
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);		//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);		//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x00,(Bit8u)0x50);		// push ax
-		phys_writeb(physAddress+0x01,(Bit8u)0xb8);		// mov ax, 0x91fb
-		phys_writew(physAddress+0x02,(Bit16u)0x91fb);
-		phys_writew(physAddress+0x04,(Bit16u)0x15cd);	// int 15
-		phys_writeb(physAddress+0x06,(Bit8u)0xfa);		// cli
-		phys_writew(physAddress+0x07,(Bit16u)0x20b0);	// mov al, 0x20
-		phys_writew(physAddress+0x09,(Bit16u)0x20e6);	// out 0x20, al
-		phys_writeb(physAddress+0x0b,(Bit8u)0x58);		// pop ax
-		phys_writeb(physAddress+0x0c,(Bit8u)0xcf);		//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0x50);		// push ax
+		phys_writeb(physAddress+0x01,(uint8_t)0xb8);		// mov ax, 0x91fb
+		phys_writew(physAddress+0x02,(uint16_t)0x91fb);
+		phys_writew(physAddress+0x04,(uint16_t)0x15cd);	// int 15
+		phys_writeb(physAddress+0x06,(uint8_t)0xfa);		// cli
+		phys_writew(physAddress+0x07,(uint16_t)0x20b0);	// mov al, 0x20
+		phys_writew(physAddress+0x09,(uint16_t)0x20e6);	// out 0x20, al
+		phys_writeb(physAddress+0x0b,(uint8_t)0x58);		// pop ax
+		phys_writeb(physAddress+0x0c,(uint8_t)0xcf);		//An IRET Instruction
 		return (use_cb?0x11:0x0d);
 /*	case CB_IPXESR:		// IPX ESR
 		if (!use_cb) E_Exit("ipx esr must implement a callback handler!");
-		phys_writeb(physAddress+0x00,(Bit8u)0x1e);		// push ds
-		phys_writeb(physAddress+0x01,(Bit8u)0x06);		// push es
-		phys_writew(physAddress+0x02,(Bit16u)0xa00f);	// push fs
-		phys_writew(physAddress+0x04,(Bit16u)0xa80f);	// push gs
-		phys_writeb(physAddress+0x06,(Bit8u)0x60);		// pusha
-		phys_writeb(physAddress+0x07,(Bit8u)0xFE);		//GRP 4
-		phys_writeb(physAddress+0x08,(Bit8u)0x38);		//Extra Callback instruction
-		phys_writew(physAddress+0x09,(Bit16u)callback);	//The immediate word
-		phys_writeb(physAddress+0x0b,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0x1e);		// push ds
+		phys_writeb(physAddress+0x01,(uint8_t)0x06);		// push es
+		phys_writew(physAddress+0x02,(uint16_t)0xa00f);	// push fs
+		phys_writew(physAddress+0x04,(uint16_t)0xa80f);	// push gs
+		phys_writeb(physAddress+0x06,(uint8_t)0x60);		// pusha
+		phys_writeb(physAddress+0x07,(uint8_t)0xFE);		//GRP 4
+		phys_writeb(physAddress+0x08,(uint8_t)0x38);		//Extra Callback instruction
+		phys_writew(physAddress+0x09,(uint16_t)callback);	//The immediate word
+		phys_writeb(physAddress+0x0b,(uint8_t)0xCB);		//A RETF Instruction
 		return 0x0c;
 	case CB_IPXESR_RET:		// IPX ESR return
 		if (use_cb) E_Exit("ipx esr return must not implement a callback handler!");
-		phys_writeb(physAddress+0x00,(Bit8u)0xfa);		// cli
-		phys_writew(physAddress+0x01,(Bit16u)0x20b0);	// mov al, 0x20
-		phys_writew(physAddress+0x03,(Bit16u)0xa0e6);	// out 0xa0, al
-		phys_writew(physAddress+0x05,(Bit16u)0x20e6);	// out 0x20, al
-		phys_writeb(physAddress+0x07,(Bit8u)0x61);		// popa
-		phys_writew(physAddress+0x08,(Bit16u)0xA90F);	// pop gs
-		phys_writew(physAddress+0x0a,(Bit16u)0xA10F);	// pop fs
-		phys_writeb(physAddress+0x0c,(Bit8u)0x07);		// pop es
-		phys_writeb(physAddress+0x0d,(Bit8u)0x1f);		// pop ds
-		phys_writeb(physAddress+0x0e,(Bit8u)0xcf);		//An IRET Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xfa);		// cli
+		phys_writew(physAddress+0x01,(uint16_t)0x20b0);	// mov al, 0x20
+		phys_writew(physAddress+0x03,(uint16_t)0xa0e6);	// out 0xa0, al
+		phys_writew(physAddress+0x05,(uint16_t)0x20e6);	// out 0x20, al
+		phys_writeb(physAddress+0x07,(uint8_t)0x61);		// popa
+		phys_writew(physAddress+0x08,(uint16_t)0xA90F);	// pop gs
+		phys_writew(physAddress+0x0a,(uint16_t)0xA10F);	// pop fs
+		phys_writeb(physAddress+0x0c,(uint8_t)0x07);		// pop es
+		phys_writeb(physAddress+0x0d,(uint8_t)0x1f);		// pop ds
+		phys_writeb(physAddress+0x0e,(uint8_t)0xcf);		//An IRET Instruction
 		return 0x0f; */
 	case CB_INT21:
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		//STI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		//STI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0xCF);		//An IRET Instruction
-		phys_writeb(physAddress+0x02,(Bit8u)0xCB);		//A RETF Instruction
-		phys_writeb(physAddress+0x03,(Bit8u)0x51);		// push cx
-		phys_writeb(physAddress+0x04,(Bit8u)0xB9);		// mov cx,
-		phys_writew(physAddress+0x05,(Bit16u)0x0140);		// 0x140
-		phys_writew(physAddress+0x07,(Bit16u)0xFEE2);		// loop $-2
-		phys_writeb(physAddress+0x09,(Bit8u)0x59);		// pop cx
-		phys_writeb(physAddress+0x0A,(Bit8u)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x02,(uint8_t)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x03,(uint8_t)0x51);		// push cx
+		phys_writeb(physAddress+0x04,(uint8_t)0xB9);		// mov cx,
+		phys_writew(physAddress+0x05,(uint16_t)0x0140);		// 0x140
+		phys_writew(physAddress+0x07,(uint16_t)0xFEE2);		// loop $-2
+		phys_writeb(physAddress+0x09,(uint8_t)0x59);		// pop cx
+		phys_writeb(physAddress+0x0A,(uint8_t)0xCF);		//An IRET Instruction
 		return (use_cb?15:11);
 	case CB_INT13:
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		//STI
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		//STI
 		if (use_cb) {
-			phys_writeb(physAddress+0x01,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x02,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x03,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x01,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x02,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x03,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writeb(physAddress+0x01,(Bit8u)0xCF);		//An IRET Instruction
-		phys_writew(physAddress+0x02,(Bit16u)0x0ECD);		// int 0e
-		phys_writeb(physAddress+0x04,(Bit8u)0xCF);		//An IRET Instruction
+		phys_writeb(physAddress+0x01,(uint8_t)0xCF);		//An IRET Instruction
+		phys_writew(physAddress+0x02,(uint16_t)0x0ECD);		// int 0e
+		phys_writeb(physAddress+0x04,(uint8_t)0xCF);		//An IRET Instruction
 		return (use_cb?9:5);
 	case CB_VESA_WAIT:
 		if (use_cb) E_Exit("VESA wait must not implement a callback handler!");
-		phys_writeb(physAddress+0x00,(Bit8u)0xFB);		// sti
-		phys_writeb(physAddress+0x01,(Bit8u)0x50);		// push ax
-		phys_writeb(physAddress+0x02,(Bit8u)0x52);		// push dx
-		phys_writeb(physAddress+0x03,(Bit8u)0xBA);		// mov dx,
-		phys_writew(physAddress+0x04,(Bit16u)0x03DA);	// 0x3da
-		phys_writeb(physAddress+0x06,(Bit8u)0xEC);		// in al,dx
-		phys_writew(physAddress+0x07,(Bit16u)0x08A8);	// test al,8
-		phys_writew(physAddress+0x09,(Bit16u)0xFB75);	// jne $-5
-		phys_writeb(physAddress+0x0B,(Bit8u)0xEC);		// in al,dx
-		phys_writew(physAddress+0x0C,(Bit16u)0x08A8);	// test al,8
-		phys_writew(physAddress+0x0E,(Bit16u)0xFB74);	// je $-5
-		phys_writeb(physAddress+0x10,(Bit8u)0x5A);		// pop dx
-		phys_writeb(physAddress+0x11,(Bit8u)0x58);		// pop ax
-		phys_writeb(physAddress+0x12,(Bit8u)0xCB);		//A RETF Instruction
+		phys_writeb(physAddress+0x00,(uint8_t)0xFB);		// sti
+		phys_writeb(physAddress+0x01,(uint8_t)0x50);		// push ax
+		phys_writeb(physAddress+0x02,(uint8_t)0x52);		// push dx
+		phys_writeb(physAddress+0x03,(uint8_t)0xBA);		// mov dx,
+		phys_writew(physAddress+0x04,(uint16_t)0x03DA);	// 0x3da
+		phys_writeb(physAddress+0x06,(uint8_t)0xEC);		// in al,dx
+		phys_writew(physAddress+0x07,(uint16_t)0x08A8);	// test al,8
+		phys_writew(physAddress+0x09,(uint16_t)0xFB75);	// jne $-5
+		phys_writeb(physAddress+0x0B,(uint8_t)0xEC);		// in al,dx
+		phys_writew(physAddress+0x0C,(uint16_t)0x08A8);	// test al,8
+		phys_writew(physAddress+0x0E,(uint16_t)0xFB74);	// je $-5
+		phys_writeb(physAddress+0x10,(uint8_t)0x5A);		// pop dx
+		phys_writeb(physAddress+0x11,(uint8_t)0x58);		// pop ax
+		phys_writeb(physAddress+0x12,(uint8_t)0xCB);		//A RETF Instruction
 		return 19;
 	case CB_VESA_PM:
 		if (use_cb) {
-			phys_writeb(physAddress+0x00,(Bit8u)0xFE);	//GRP 4
-			phys_writeb(physAddress+0x01,(Bit8u)0x38);	//Extra Callback instruction
-			phys_writew(physAddress+0x02,(Bit16u)callback);	//The immediate word
+			phys_writeb(physAddress+0x00,(uint8_t)0xFE);	//GRP 4
+			phys_writeb(physAddress+0x01,(uint8_t)0x38);	//Extra Callback instruction
+			phys_writew(physAddress+0x02,(uint16_t)callback);	//The immediate word
 			physAddress+=4;
 		}
-		phys_writew(physAddress+0x00,(Bit16u)0xC3F6);	// test bl,
-		phys_writeb(physAddress+0x02,(Bit8u)0x80);		// 0x80
-		phys_writew(physAddress+0x03,(Bit16u)0x1674);	// je $+22
-		phys_writew(physAddress+0x05,(Bit16u)0x5066);	// push ax
-		phys_writew(physAddress+0x07,(Bit16u)0x5266);	// push dx
-		phys_writew(physAddress+0x09,(Bit16u)0xBA66);	// mov dx,
-		phys_writew(physAddress+0x0B,(Bit16u)0x03DA);	// 0x3da
-		phys_writeb(physAddress+0x0D,(Bit8u)0xEC);		// in al,dx
-		phys_writew(physAddress+0x0E,(Bit16u)0x08A8);	// test al,8
-		phys_writew(physAddress+0x10,(Bit16u)0xFB75);	// jne $-5
-		phys_writeb(physAddress+0x12,(Bit8u)0xEC);		// in al,dx
-		phys_writew(physAddress+0x13,(Bit16u)0x08A8);	// test al,8
-		phys_writew(physAddress+0x15,(Bit16u)0xFB74);	// je $-5
-		phys_writew(physAddress+0x17,(Bit16u)0x5A66);	// pop dx
-		phys_writew(physAddress+0x19,(Bit16u)0x5866);	// pop ax
+		phys_writew(physAddress+0x00,(uint16_t)0xC3F6);	// test bl,
+		phys_writeb(physAddress+0x02,(uint8_t)0x80);		// 0x80
+		phys_writew(physAddress+0x03,(uint16_t)0x1674);	// je $+22
+		phys_writew(physAddress+0x05,(uint16_t)0x5066);	// push ax
+		phys_writew(physAddress+0x07,(uint16_t)0x5266);	// push dx
+		phys_writew(physAddress+0x09,(uint16_t)0xBA66);	// mov dx,
+		phys_writew(physAddress+0x0B,(uint16_t)0x03DA);	// 0x3da
+		phys_writeb(physAddress+0x0D,(uint8_t)0xEC);		// in al,dx
+		phys_writew(physAddress+0x0E,(uint16_t)0x08A8);	// test al,8
+		phys_writew(physAddress+0x10,(uint16_t)0xFB75);	// jne $-5
+		phys_writeb(physAddress+0x12,(uint8_t)0xEC);		// in al,dx
+		phys_writew(physAddress+0x13,(uint16_t)0x08A8);	// test al,8
+		phys_writew(physAddress+0x15,(uint16_t)0xFB74);	// je $-5
+		phys_writew(physAddress+0x17,(uint16_t)0x5A66);	// pop dx
+		phys_writew(physAddress+0x19,(uint16_t)0x5866);	// pop ax
 		if (use_cb)
-			phys_writeb(physAddress+0x1B,(Bit8u)0xC3);	//A RETN Instruction
+			phys_writeb(physAddress+0x1B,(uint8_t)0xC3);	//A RETN Instruction
 		return (use_cb?32:27);
 	default:
 		E_Exit("CALLBACK:Setup:Illegal type %" sBitfs(u),type);
@@ -552,7 +552,7 @@ Bitu CALLBACK_Setup(Bitu callback,CallBack_Handler handler,Bitu type,PhysPt addr
 
 void CALLBACK_RemoveSetup(Bitu callback) {
 	for (Bitu i = 0;i < CB_SIZE;i++) {
-		phys_writeb(CALLBACK_PhysPointer(callback)+i ,(Bit8u) 0x00);
+		phys_writeb(CALLBACK_PhysPointer(callback)+i ,(uint8_t) 0x00);
 	}
 }
 
@@ -611,7 +611,7 @@ void CALLBACK_HandlerObject::Allocate(CallBack_Handler handler,const char* descr
 	} else E_Exit("Callback handler object already installed");
 }
 
-void CALLBACK_HandlerObject::Set_RealVec(Bit8u vec){
+void CALLBACK_HandlerObject::Set_RealVec(uint8_t vec){
 	if(!vectorhandler.installed) {
 		vectorhandler.installed=true;
 		vectorhandler.interrupt=vec;
@@ -631,7 +631,7 @@ void CALLBACK_Init(Section* /*sec*/) {
 	CALLBACK_SetDescription(call_stop,"stop");
 	phys_writeb(CALLBACK_PhysPointer(call_stop)+0,0xFE);
 	phys_writeb(CALLBACK_PhysPointer(call_stop)+1,0x38);
-	phys_writew(CALLBACK_PhysPointer(call_stop)+2,(Bit16u)call_stop);
+	phys_writew(CALLBACK_PhysPointer(call_stop)+2,(uint16_t)call_stop);
 
 	/* Setup the idle handler */
 	call_idle=CALLBACK_Allocate();
@@ -640,27 +640,27 @@ void CALLBACK_Init(Section* /*sec*/) {
 	for (i=0;i<=11;i++) phys_writeb(CALLBACK_PhysPointer(call_idle)+i,0x90);
 	phys_writeb(CALLBACK_PhysPointer(call_idle)+12,0xFE);
 	phys_writeb(CALLBACK_PhysPointer(call_idle)+13,0x38);
-	phys_writew(CALLBACK_PhysPointer(call_idle)+14,(Bit16u)call_idle);
+	phys_writew(CALLBACK_PhysPointer(call_idle)+14,(uint16_t)call_idle);
 
 	/* Default handlers for unhandled interrupts that have to be non-null */
 	call_default=CALLBACK_Allocate();
 	CALLBACK_Setup(call_default,&default_handler,CB_IRET,"default");
 
 	/* Only setup default handler for first part of interrupt table */
-	for (Bit16u ct=0;ct<0x60;ct++) {
+	for (uint16_t ct=0;ct<0x60;ct++) {
 		real_writed(0,ct*4,CALLBACK_RealPointer(call_default));
 	}
-	for (Bit16u ct=0x68;ct<0x70;ct++) {
+	for (uint16_t ct=0x68;ct<0x70;ct++) {
 		real_writed(0,ct*4,CALLBACK_RealPointer(call_default));
 	}
 	/* Setup block of 0xCD 0xxx instructions */
 	PhysPt rint_base=CALLBACK_GetBase()+CB_MAX*CB_SIZE;
 	for (i=0;i<=0xff;i++) {
 		phys_writeb(rint_base,0xCD);
-		phys_writeb(rint_base+1,(Bit8u)i);
+		phys_writeb(rint_base+1,(uint8_t)i);
 		phys_writeb(rint_base+2,0xFE);
 		phys_writeb(rint_base+3,0x38);
-		phys_writew(rint_base+4,(Bit16u)call_stop);
+		phys_writew(rint_base+4,(uint16_t)call_stop);
 		rint_base+=6;
 
 	}
@@ -674,19 +674,19 @@ void CALLBACK_Init(Section* /*sec*/) {
 	call_priv_io=CALLBACK_Allocate();
 
 	// virtualizable in-out opcodes
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x00,(Bit8u)0xec);	// in al, dx
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x01,(Bit8u)0xcb);	// retf
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x02,(Bit8u)0xed);	// in ax, dx
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x03,(Bit8u)0xcb);	// retf
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x04,(Bit8u)0x66);	// in eax, dx
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x05,(Bit8u)0xed);
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x06,(Bit8u)0xcb);	// retf
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x00,(uint8_t)0xec);	// in al, dx
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x01,(uint8_t)0xcb);	// retf
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x02,(uint8_t)0xed);	// in ax, dx
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x03,(uint8_t)0xcb);	// retf
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x04,(uint8_t)0x66);	// in eax, dx
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x05,(uint8_t)0xed);
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x06,(uint8_t)0xcb);	// retf
 
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x08,(Bit8u)0xee);	// out dx, al
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x09,(Bit8u)0xcb);	// retf
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0a,(Bit8u)0xef);	// out dx, ax
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0b,(Bit8u)0xcb);	// retf
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0c,(Bit8u)0x66);	// out dx, eax
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0d,(Bit8u)0xef);
-	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0e,(Bit8u)0xcb);	// retf
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x08,(uint8_t)0xee);	// out dx, al
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x09,(uint8_t)0xcb);	// retf
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0a,(uint8_t)0xef);	// out dx, ax
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0b,(uint8_t)0xcb);	// retf
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0c,(uint8_t)0x66);	// out dx, eax
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0d,(uint8_t)0xef);
+	phys_writeb(CALLBACK_PhysPointer(call_priv_io)+0x0e,(uint8_t)0xcb);	// retf
 }

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -153,7 +153,7 @@ static DynReg DynRegs[G_MAX];
 #define DREG(_WHICH_) &DynRegs[G_ ## _WHICH_ ]
 
 static struct {
-	Bit32u ea,tmpb,tmpd,stack,shift,newesp;
+	uint32_t ea,tmpb,tmpd,stack,shift,newesp;
 } extra_regs;
 
 #define IllegalOption(msg) E_Exit("DYNX86: illegal option in " msg)
@@ -168,22 +168,22 @@ static struct {
 
 #if defined(X86_DYNFPU_DH_ENABLED)
 static struct dyn_dh_fpu {
-	Bit16u		cw,host_cw;
+	uint16_t		cw,host_cw;
 	bool		state_used;
 	// some fields expanded here for alignment purposes
 	struct {
-		Bit32u cw;
-		Bit32u sw;
-		Bit32u tag;
-		Bit32u ip;
-		Bit32u cs;
-		Bit32u ea;
-		Bit32u ds;
-		Bit8u st_reg[8][10];
+		uint32_t cw;
+		uint32_t sw;
+		uint32_t tag;
+		uint32_t ip;
+		uint32_t cs;
+		uint32_t ea;
+		uint32_t ds;
+		uint8_t st_reg[8][10];
 	} state;
 	FPU_P_Reg	temp,temp2;
-	Bit32u		dh_fpu_enabled;
-	Bit8u		temp_state[128];
+	uint32_t		dh_fpu_enabled;
+	uint8_t		temp_state[128];
 } dyn_dh_fpu;
 #endif
 
@@ -287,7 +287,7 @@ restart_core:
 		if (!chandler->invalidation_map || (chandler->invalidation_map[ip_point&4095]<4)) {
 			block=CreateCacheBlock(chandler,ip_point,32);
 		} else {
-			Bit32s old_cycles=CPU_Cycles;
+			int32_t old_cycles=CPU_Cycles;
 			CPU_Cycles=1;
 			// manually save
 			fpu_saver = auto_dh_fpu();
@@ -353,7 +353,7 @@ run_block:
 	case BR_Link1:
 	case BR_Link2:
 		{
-			Bit32u temp_ip=SegPhys(cs)+reg_eip;
+			uint32_t temp_ip=SegPhys(cs)+reg_eip;
 			CodePageHandler* temp_handler = reinterpret_cast<CodePageHandler *>(get_tlb_readhandler(temp_ip));
 			if (temp_handler->flags & (cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16)) {
 				block=temp_handler->FindCacheBlock(temp_ip & 4095);
@@ -368,7 +368,7 @@ run_block:
 }
 
 Bits CPU_Core_Dyn_X86_Trap_Run(void) {
-	Bit32s oldCycles = CPU_Cycles;
+	int32_t oldCycles = CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;
 

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -634,7 +634,7 @@ static void dyn_fpu_esc7()
 	} else {
 		dyn_fill_ea();
 		switch (group) {
-		case 0x00:  /* FILD Bit16s */
+		case 0x00:  /* FILD int16_t */
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4); 
 			gen_call_function((void*)&FPU_FLD_I16,"%Drd%Drd",DREG(EA),DREG(TMPB));
@@ -642,10 +642,10 @@ static void dyn_fpu_esc7()
 		case 0x01:
 			FPU_LOG_WARN(7,true,group,sub);
 			break;
-		case 0x02:   /* FIST Bit16s */
+		case 0x02:   /* FIST int16_t */
 			gen_call_function((void*)&FPU_FST_I16,"%Drd",DREG(EA));
 			break;
-		case 0x03:	/* FISTP Bit16s */
+		case 0x03:	/* FISTP int16_t */
 			gen_call_function((void*)&FPU_FST_I16,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
@@ -654,7 +654,7 @@ static void dyn_fpu_esc7()
 			gen_load_host(&TOP,DREG(TMPB),4);
 			gen_call_function((void*)&FPU_FBLD,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
-		case 0x05:  /* FILD Bit64s */
+		case 0x05:  /* FILD int64_t */
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4);
 			gen_call_function((void*)&FPU_FLD_I64,"%Drd%Drd",DREG(EA),DREG(TMPB));
@@ -663,7 +663,7 @@ static void dyn_fpu_esc7()
 			gen_call_function((void*)&FPU_FBST,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
-		case 0x07:  /* FISTP Bit64s */
+		case 0x07:  /* FISTP int64_t */
 			gen_call_function((void*)&FPU_FST_I64,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -21,11 +21,11 @@
 #if C_FPU
 
 static void FPU_FLD_16(PhysPt addr) {
-	dyn_dh_fpu.temp.m1 = (Bit32u)mem_readw(addr);
+	dyn_dh_fpu.temp.m1 = (uint32_t)mem_readw(addr);
 }
 
 static void FPU_FST_16(PhysPt addr) {
-	mem_writew(addr,(Bit16u)dyn_dh_fpu.temp.m1);
+	mem_writew(addr,(uint16_t)dyn_dh_fpu.temp.m1);
 }
 
 static void FPU_FLD_32(PhysPt addr) {
@@ -60,11 +60,11 @@ static void FPU_FST_80(PhysPt addr) {
 
 static void FPU_FLDCW_DH(PhysPt addr){
 	dyn_dh_fpu.cw = mem_readw(addr);
-	dyn_dh_fpu.temp.m1 = (Bit32u)(dyn_dh_fpu.cw|0x3f);
+	dyn_dh_fpu.temp.m1 = (uint32_t)(dyn_dh_fpu.cw|0x3f);
 }
 
 static void FPU_FNSTCW_DH(PhysPt addr){
-	mem_writew(addr,(Bit16u)(dyn_dh_fpu.cw&0xffff));
+	mem_writew(addr,(uint16_t)(dyn_dh_fpu.cw&0xffff));
 }
 
 static void FPU_FNINIT_DH(void){
@@ -74,7 +74,7 @@ static void FPU_FNINIT_DH(void){
 static void FPU_FSTENV_DH(PhysPt addr){
 	if(!cpu.code.big) {
 		mem_writew(addr+0,dyn_dh_fpu.cw);
-		mem_writew(addr+2,(Bit16u)dyn_dh_fpu.temp.m2);
+		mem_writew(addr+2,(uint16_t)dyn_dh_fpu.temp.m2);
 		mem_writew(addr+4,dyn_dh_fpu.temp.m3);
 	} else { 
 		mem_writed(addr+0,dyn_dh_fpu.temp.m1);
@@ -86,12 +86,12 @@ static void FPU_FSTENV_DH(PhysPt addr){
 
 static void FPU_FLDENV_DH(PhysPt addr){
 	if(!cpu.code.big) {
-		dyn_dh_fpu.cw = (Bit32u)mem_readw(addr);
+		dyn_dh_fpu.cw = (uint32_t)mem_readw(addr);
 		dyn_dh_fpu.temp.m1 = dyn_dh_fpu.cw|0x3f;
-		dyn_dh_fpu.temp.m2 = (Bit32u)mem_readw(addr+2);
+		dyn_dh_fpu.temp.m2 = (uint32_t)mem_readw(addr+2);
 		dyn_dh_fpu.temp.m3 = mem_readw(addr+4);
 	} else { 
-		dyn_dh_fpu.cw = (Bit32u)mem_readw(addr);
+		dyn_dh_fpu.cw = (uint32_t)mem_readw(addr);
 		dyn_dh_fpu.temp.m1 = mem_readd(addr)|0x3f;
 		dyn_dh_fpu.temp.m2 = mem_readd(addr+4);
 		dyn_dh_fpu.temp.m3 = mem_readw(addr+8);
@@ -125,7 +125,7 @@ static void FPU_FSAVE_DH(PhysPt addr){
 
 static void FPU_FRSTOR_DH(PhysPt addr){
 	if (!cpu.code.big) {
-		dyn_dh_fpu.cw = (Bit32u)mem_readw(addr);
+		dyn_dh_fpu.cw = (uint32_t)mem_readw(addr);
 		dyn_dh_fpu.temp_state[0x00] = mem_readb(addr++)|0x3f;
 		dyn_dh_fpu.temp_state[0x01] = mem_readb(addr++);
 		dyn_dh_fpu.temp_state[0x04] = mem_readb(addr++);
@@ -142,17 +142,17 @@ static void FPU_FRSTOR_DH(PhysPt addr){
 		dyn_dh_fpu.temp_state[0x19] = mem_readb(addr++);
 		for(Bitu i=28;i<108;i++) dyn_dh_fpu.temp_state[i] = mem_readb(addr++);
 	} else {
-		dyn_dh_fpu.cw = (Bit32u)mem_readw(addr);
+		dyn_dh_fpu.cw = (uint32_t)mem_readw(addr);
 		for(Bitu i=0;i<108;i++) dyn_dh_fpu.temp_state[i] = mem_readb(addr++);
 		dyn_dh_fpu.temp_state[0]|=0x3f;
 	}
 }
 
-static void dh_fpu_mem(Bit8u inst, Bitu reg=decode.modrm.reg, void* mem=&dyn_dh_fpu.temp.m1) {
+static void dh_fpu_mem(uint8_t inst, Bitu reg=decode.modrm.reg, void* mem=&dyn_dh_fpu.temp.m1) {
 #if C_TARGETCPU == X86
 	cache_addb(inst);
 	cache_addb(0x05|(reg<<3));
-	cache_addd((Bit32u)(mem));
+	cache_addd((uint32_t)(mem));
 #else // X86_64
 	opcode(reg).setabsaddr(mem).Emit8(inst);
 #endif
@@ -388,15 +388,15 @@ static void dh_fpu_esc7(){
 	} else {
 		dyn_fill_ea(); 
 		switch(group){
-		case 0x00:  /* FILD Bit16s */
+		case 0x00:  /* FILD int16_t */
 			gen_call_function((void*)&FPU_FLD_16,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdf);
 			break;
 		case 0x01:
 			FPU_LOG_WARN(7,true,1,sub);
 			break;
-		case 0x02:   /* FIST Bit16s */
-		case 0x03:	/* FISTP Bit16s */
+		case 0x02:   /* FIST int16_t */
+		case 0x03:	/* FISTP int16_t */
 			dh_fpu_mem(0xdf);
 			gen_call_function((void*)&FPU_FST_16,"%Drd",DREG(EA));
 			break;
@@ -404,7 +404,7 @@ static void dh_fpu_esc7(){
 			gen_call_function((void*)&FPU_FLD_80,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdf);
 			break;
-		case 0x05:  /* FILD Bit64s */
+		case 0x05:  /* FILD int64_t */
 			gen_call_function((void*)&FPU_FLD_64,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdf);
 			break;
@@ -412,7 +412,7 @@ static void dh_fpu_esc7(){
 			dh_fpu_mem(0xdf);
 			gen_call_function((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
-		case 0x07:  /* FISTP Bit64s */
+		case 0x07:  /* FISTP int64_t */
 			dh_fpu_mem(0xdf);
 			gen_call_function((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;

--- a/src/cpu/core_dyn_x86/helpers.h
+++ b/src/cpu/core_dyn_x86/helpers.h
@@ -16,71 +16,71 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-static bool dyn_helper_divb(Bit8u val) {
+static bool dyn_helper_divb(uint8_t val) {
 	if (!val) return CPU_PrepareException(0,0);
 	Bitu quo=reg_ax / val;
-	Bit8u rem=(Bit8u)(reg_ax % val);
-	Bit8u quo8=(Bit8u)(quo&0xff);
+	uint8_t rem=(uint8_t)(reg_ax % val);
+	uint8_t quo8=(uint8_t)(quo&0xff);
 	if (quo>0xff) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8;
 	return false;
 }
 
-static bool dyn_helper_idivb(Bit8s val) {
+static bool dyn_helper_idivb(int8_t val) {
 	if (!val) return CPU_PrepareException(0,0);
-	Bits quo=(Bit16s)reg_ax / val;
-	Bit8s rem=(Bit8s)((Bit16s)reg_ax % val);
-	Bit8s quo8s=(Bit8s)(quo&0xff);
-	if (quo!=(Bit16s)quo8s) return CPU_PrepareException(0,0);
+	Bits quo=(int16_t)reg_ax / val;
+	int8_t rem=(int8_t)((int16_t)reg_ax % val);
+	int8_t quo8s=(int8_t)(quo&0xff);
+	if (quo!=(int16_t)quo8s) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8s;
 	return false;
 }
 
-static bool dyn_helper_divw(Bit16u val) {
+static bool dyn_helper_divw(uint16_t val) {
 	if (!val) return CPU_PrepareException(0,0);
-	Bit32u num=(((Bit32u)reg_dx)<<16)|reg_ax;
-	Bit32u quo=num/val;
-	Bit16u rem=(Bit16u)(num % val);
-	Bit16u quo16=(Bit16u)(quo&0xffff);
-	if (quo!=(Bit32u)quo16) return CPU_PrepareException(0,0);
+	uint32_t num=(((uint32_t)reg_dx)<<16)|reg_ax;
+	uint32_t quo=num/val;
+	uint16_t rem=(uint16_t)(num % val);
+	uint16_t quo16=(uint16_t)(quo&0xffff);
+	if (quo!=(uint32_t)quo16) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16;
 	return false;
 }
 
-static bool dyn_helper_idivw(Bit16s val) {
+static bool dyn_helper_idivw(int16_t val) {
 	if (!val) return CPU_PrepareException(0,0);
-	Bit32s num=(((Bit32u)reg_dx)<<16)|reg_ax;
-	Bit32s quo=num/val;
-	Bit16s rem=(Bit16s)(num % val);
-	Bit16s quo16s=(Bit16s)quo;
-	if (quo!=(Bit32s)quo16s) return CPU_PrepareException(0,0);
+	int32_t num=(((uint32_t)reg_dx)<<16)|reg_ax;
+	int32_t quo=num/val;
+	int16_t rem=(int16_t)(num % val);
+	int16_t quo16s=(int16_t)quo;
+	if (quo!=(int32_t)quo16s) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16s;
 	return false;
 }
 
-static bool dyn_helper_divd(Bit32u val) {
+static bool dyn_helper_divd(uint32_t val) {
 	if (!val) return CPU_PrepareException(0,0);
-	Bit64u num=(((Bit64u)reg_edx)<<32)|reg_eax;
-	Bit64u quo=num/val;
-	Bit32u rem=(Bit32u)(num % val);
-	Bit32u quo32=(Bit32u)(quo&0xffffffff);
-	if (quo!=(Bit64u)quo32) return CPU_PrepareException(0,0);
+	uint64_t num=(((uint64_t)reg_edx)<<32)|reg_eax;
+	uint64_t quo=num/val;
+	uint32_t rem=(uint32_t)(num % val);
+	uint32_t quo32=(uint32_t)(quo&0xffffffff);
+	if (quo!=(uint64_t)quo32) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32;
 	return false;
 }
 
-static bool dyn_helper_idivd(Bit32s val) {
+static bool dyn_helper_idivd(int32_t val) {
 	if (!val) return CPU_PrepareException(0,0);
-	Bit64s num=(((Bit64u)reg_edx)<<32)|reg_eax;
-	Bit64s quo=num/val;
-	Bit32s rem=(Bit32s)(num % val);
-	Bit32s quo32s=(Bit32s)(quo&0xffffffff);
-	if (quo!=(Bit64s)quo32s) return CPU_PrepareException(0,0);
+	int64_t num=(((uint64_t)reg_edx)<<32)|reg_eax;
+	int64_t quo=num/val;
+	int32_t rem=(int32_t)(num % val);
+	int32_t quo32s=(int32_t)(quo&0xffffffff);
+	if (quo!=(int64_t)quo32s) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32s;
 	return false;

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -72,7 +72,7 @@ static void dyn_string(STRING_OP op) {
 	}
 	DynState rep_state;
 	dyn_savestate(&rep_state);
-	const Bit8u * rep_start=cache.pos;
+	const uint8_t * rep_start=cache.pos;
 
 	/* Check if ECX!=zero */
 	if (decode.rep) {

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -126,10 +126,10 @@ static void IllegalOptionDynrec(const char* msg) {
 }
 
 struct core_dynrec_t {
-	BlockReturn (*runcode)(const Bit8u*);		// points to code that can start a block
+	BlockReturn (*runcode)(const uint8_t*);		// points to code that can start a block
 	Bitu callback;				// the occurred callback
 	Bitu readdata;				// spare space used when reading from memory
-	Bit32u protected_regs[8];	// space to save/restore register values
+	uint32_t protected_regs[8];	// space to save/restore register values
 };
 
 static core_dynrec_t core_dynrec;

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -40,7 +40,7 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 	decode.page.invmap=codepage->invalidation_map;
 	decode.page.first=start >> 12;
 	decode.active_block=decode.block=cache_openblock();
-	decode.block->page.start=(Bit16u)decode.page.index;
+	decode.block->page.start=(uint16_t)decode.page.index;
 	codepage->AddCacheBlock(decode.block);
 
 	auto cache_addr = static_cast<void *>(
@@ -200,7 +200,7 @@ restart_prefix:
 				case 0x80:case 0x81:case 0x82:case 0x83:case 0x84:case 0x85:case 0x86:case 0x87:	
 				case 0x88:case 0x89:case 0x8a:case 0x8b:case 0x8c:case 0x8d:case 0x8e:case 0x8f:	
 					dyn_branched_exit((BranchTypes)(dual_code&0xf),
-						decode.big_op ? (Bit32s)decode_fetchd() : (Bit16s)decode_fetchw());
+						decode.big_op ? (int32_t)decode_fetchd() : (int16_t)decode_fetchw());
 					goto finish_block;
 
 				// conditional byte set instructions
@@ -290,7 +290,7 @@ restart_prefix:
 			dyn_push_word_imm(decode.big_op ? decode_fetchd() :  decode_fetchw());
 			break;
 		case 0x6a:
-			dyn_push_byte_imm((Bit8s)decode_fetchb());
+			dyn_push_byte_imm((int8_t)decode_fetchb());
 			break;
 
 		// signed multiplication
@@ -302,7 +302,7 @@ restart_prefix:
 		// short conditional jumps
 		case 0x70:case 0x71:case 0x72:case 0x73:case 0x74:case 0x75:case 0x76:case 0x77:	
 		case 0x78:case 0x79:case 0x7a:case 0x7b:case 0x7c:case 0x7d:case 0x7e:case 0x7f:	
-			dyn_branched_exit((BranchTypes)(opcode&0xf),(Bit8s)decode_fetchb());	
+			dyn_branched_exit((BranchTypes)(opcode&0xf),(int8_t)decode_fetchb());	
 			goto finish_block;
 
 		// 'op []/reg8,imm8'
@@ -524,7 +524,7 @@ restart_prefix:
 			goto finish_block;
 		// 'jmp near imm16/32'
 		case 0xe9:
-			dyn_exit_link(decode.big_op ? (Bit32s)decode_fetchd() : (Bit16s)decode_fetchw());
+			dyn_exit_link(decode.big_op ? (int32_t)decode_fetchd() : (int16_t)decode_fetchw());
 			goto finish_block;
 		// 'jmp far'
 		case 0xea:
@@ -532,7 +532,7 @@ restart_prefix:
 			goto finish_block;
 		// 'jmp short imm8'
 		case 0xeb:
-			dyn_exit_link((Bit8s)decode_fetchb());
+			dyn_exit_link((int8_t)decode_fetchb());
 			goto finish_block;
 
 
@@ -619,7 +619,7 @@ illegalopcode:
 finish_block:
 	// setup the correct end-address
 	decode.page.index--;
-	decode.active_block->page.end=(Bit16u)decode.page.index;
+	decode.active_block->page.end=(uint16_t)decode.page.index;
 	dyn_mem_execute(cache_addr, cache_bytes);
 	const auto cache_flush_bytes = static_cast<size_t>(decode.block->cache.size);
 	dyn_cache_invalidate(cache_addr, cache_flush_bytes);

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -91,7 +91,7 @@ static struct DynDecode {
 	REP_Type rep;			// current repeat prefix
 	Bitu cycles;			// number cycles used by currently translated code
 	bool seg_prefix_used;	// segment overridden
-	Bit8u seg_prefix;		// segment prefix (if seg_prefix_used==true)
+	uint8_t seg_prefix;		// segment prefix (if seg_prefix_used==true)
 
 	// block that contains the first instruction translated
 	CacheBlock *block;
@@ -102,8 +102,8 @@ static struct DynDecode {
 	struct {
 		CodePageHandler *code;
 		Bitu index;		// index to the current byte of the instruction stream
-		Bit8u * wmap;	// write map that indicates code presence for every byte of this page
-		Bit8u * invmap;	// invalidation map
+		uint8_t * wmap;	// write map that indicates code presence for every byte of this page
+		uint8_t * invmap;	// invalidation map
 		Bitu first;		// page number 
 	} page;
 
@@ -118,7 +118,7 @@ static struct DynDecode {
 
 static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
 {
-	Bit8u rdval;
+	uint8_t rdval;
 	const Bitu cflag = cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16;
 	//Ensure page contains memory:
 	if (GCC_UNLIKELY(mem_readb_checked(lin_addr,&rdval))) return true;
@@ -212,7 +212,7 @@ static void decode_advancepage(void) {
 }
 
 // fetch the next byte of the instruction stream
-static Bit8u decode_fetchb(void) {
+static uint8_t decode_fetchb(void) {
 	if (GCC_UNLIKELY(decode.page.index>=4096)) {
 		decode_advancepage();
 	}
@@ -222,9 +222,9 @@ static Bit8u decode_fetchb(void) {
 	return mem_readb(decode.code-1);
 }
 // fetch the next word of the instruction stream
-static Bit16u decode_fetchw(void) {
+static uint16_t decode_fetchw(void) {
 	if (GCC_UNLIKELY(decode.page.index>=4095)) {
-   		Bit16u val=decode_fetchb();
+   		uint16_t val=decode_fetchb();
 		val|=decode_fetchb() << 8;
 		return val;
 	}
@@ -233,9 +233,9 @@ static Bit16u decode_fetchw(void) {
 	return mem_readw(decode.code-2);
 }
 // fetch the next dword of the instruction stream
-static Bit32u decode_fetchd(void) {
+static uint32_t decode_fetchd(void) {
 	if (GCC_UNLIKELY(decode.page.index>=4093)) {
-   		Bit32u val=decode_fetchb();
+   		uint32_t val=decode_fetchb();
 		val|=decode_fetchb() << 8;
 		val|=decode_fetchb() << 16;
 		val|=decode_fetchb() << 24;
@@ -256,7 +256,7 @@ static void inline decode_increase_wmapmask(Bitu size) {
 	CacheBlock *activecb = decode.active_block;
 	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
 		// no mask memory yet allocated, start with a small buffer
-		activecb->cache.wmapmask=(Bit8u*)malloc(START_WMMEM);
+		activecb->cache.wmapmask=(uint8_t*)malloc(START_WMMEM);
 		memset(activecb->cache.wmapmask,0,START_WMMEM);
 		activecb->cache.maskstart=decode.page.index;	// start of buffer is current code position
 		activecb->cache.masklen=START_WMMEM;
@@ -267,7 +267,7 @@ static void inline decode_increase_wmapmask(Bitu size) {
 			// mask buffer too small, increase
 			Bitu newmasklen=activecb->cache.masklen*4;
 			if (newmasklen<mapidx+size) newmasklen=((mapidx+size)&~3)*2;
-			Bit8u* tempmem=(Bit8u*)malloc(newmasklen);
+			uint8_t* tempmem=(uint8_t*)malloc(newmasklen);
 			memset(tempmem,0,newmasklen);
 			memcpy(tempmem,activecb->cache.wmapmask,activecb->cache.masklen);
 			free(activecb->cache.wmapmask);
@@ -293,7 +293,7 @@ static bool decode_fetchb_imm(Bitu & val) {
 	if (decode.page.invmap != NULL) {
 		if (decode.page.invmap[decode.page.index] == 0) {
 			// position not yet modified
-			val=(Bit32u)decode_fetchb();
+			val=(uint32_t)decode_fetchb();
 			return false;
 		}
 
@@ -307,7 +307,7 @@ static bool decode_fetchb_imm(Bitu & val) {
 		}
 	}
 	// first time decoding or not directly accessible, just fetch the value
-	val=(Bit32u)decode_fetchb();
+	val=(uint32_t)decode_fetchb();
 	return false;
 }
 
@@ -474,7 +474,7 @@ static void dyn_reduce_cycles(void) {
 // set reg_eip to the start of the current instruction
 static inline void dyn_set_eip_last_end(HostReg reg) {
 	gen_mov_word_to_reg(reg,&reg_eip,true);
-	gen_add_imm(reg,(Bit32u)(decode.code-decode.code_start));
+	gen_add_imm(reg,(uint32_t)(decode.code-decode.code_start));
 	gen_add_direct_word(&reg_eip,decode.op_start-decode.code_start,decode.big_op);
 }
 
@@ -489,10 +489,10 @@ static inline void dyn_set_eip_end(void) {
 }
 
 // set reg_eip to the start of the next instruction plus an offset (imm)
-static inline void dyn_set_eip_end(HostReg reg,Bit32u imm=0) {
+static inline void dyn_set_eip_end(HostReg reg,uint32_t imm=0) {
 	gen_mov_word_to_reg(reg,&reg_eip,true); //get_extend_word will mask off the upper bits
 	//gen_mov_word_to_reg(reg,&reg_eip,decode.big_op);
-	gen_add_imm(reg,(Bit32u)(decode.code-decode.code_start+imm));
+	gen_add_imm(reg,(uint32_t)(decode.code-decode.code_start+imm));
 }
 
 
@@ -502,72 +502,72 @@ static inline void dyn_set_eip_end(HostReg reg,Bit32u imm=0) {
 // is architecture dependent
 // R=host register; I=32bit immediate value; A=address value; m=memory
 
-static inline const Bit8u* gen_call_function_R(void * func,Bitu op) {
+static inline const uint8_t* gen_call_function_R(void * func,Bitu op) {
 	gen_load_param_reg(op,0);
 	return gen_call_function_setup(func, 1);
 }
 
-static inline const Bit8u* gen_call_function_R3(void * func,Bitu op) {
+static inline const uint8_t* gen_call_function_R3(void * func,Bitu op) {
 	gen_load_param_reg(op,2);
 	return gen_call_function_setup(func, 3, true);
 }
 
-static inline const Bit8u* gen_call_function_RI(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_RI(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_imm(op2,1);
 	gen_load_param_reg(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static inline const Bit8u* gen_call_function_RA(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_RA(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_addr(op2,1);
 	gen_load_param_reg(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static inline const Bit8u* gen_call_function_RR(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_RR(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_reg(op2,1);
 	gen_load_param_reg(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static inline const Bit8u* gen_call_function_IR(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_IR(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_reg(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static inline const Bit8u* gen_call_function_I(void * func,Bitu op) {
+static inline const uint8_t* gen_call_function_I(void * func,Bitu op) {
 	gen_load_param_imm(op,0);
 	return gen_call_function_setup(func, 1);
 }
 
-static inline const Bit8u* gen_call_function_II(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_II(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_imm(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static inline const Bit8u* gen_call_function_III(void * func,Bitu op1,Bitu op2,Bitu op3) {
+static inline const uint8_t* gen_call_function_III(void * func,Bitu op1,Bitu op2,Bitu op3) {
 	gen_load_param_imm(op3,2);
 	gen_load_param_imm(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 3);
 }
 
-static inline const Bit8u* gen_call_function_IA(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_IA(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_addr(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 2);
 }
 
-static inline const Bit8u* gen_call_function_IIR(void * func,Bitu op1,Bitu op2,Bitu op3) {
+static inline const uint8_t* gen_call_function_IIR(void * func,Bitu op1,Bitu op2,Bitu op3) {
 	gen_load_param_reg(op3,2);
 	gen_load_param_imm(op2,1);
 	gen_load_param_imm(op1,0);
 	return gen_call_function_setup(func, 3);
 }
 
-static inline const Bit8u* gen_call_function_IIIR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
+static inline const uint8_t* gen_call_function_IIIR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
 	gen_load_param_reg(op4,3);
 	gen_load_param_imm(op3,2);
 	gen_load_param_imm(op2,1);
@@ -575,7 +575,7 @@ static inline const Bit8u* gen_call_function_IIIR(void * func,Bitu op1,Bitu op2,
 	return gen_call_function_setup(func, 4);
 }
 
-static inline const Bit8u* gen_call_function_IRRR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
+static inline const uint8_t* gen_call_function_IRRR(void * func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
 	gen_load_param_reg(op4,3);
 	gen_load_param_reg(op3,2);
 	gen_load_param_reg(op2,1);
@@ -583,12 +583,12 @@ static inline const Bit8u* gen_call_function_IRRR(void * func,Bitu op1,Bitu op2,
 	return gen_call_function_setup(func, 4);
 }
 
-static inline const Bit8u* gen_call_function_m(void * func,Bitu op) {
+static inline const uint8_t* gen_call_function_m(void * func,Bitu op) {
 	gen_load_param_mem(op,2);
 	return gen_call_function_setup(func, 3, true);
 }
 
-static inline const Bit8u* gen_call_function_mm(void * func,Bitu op1,Bitu op2) {
+static inline const uint8_t* gen_call_function_mm(void * func,Bitu op1,Bitu op2) {
 	gen_load_param_mem(op2,3);
 	gen_load_param_mem(op1,2);
 	return gen_call_function_setup(func, 4, true);
@@ -600,7 +600,7 @@ enum save_info_type {db_exception, cycle_check, string_break};
 
 
 // function that is called on exceptions
-static BlockReturn DynRunException(Bit32u eip_add,Bit32u cycle_sub) {
+static BlockReturn DynRunException(uint32_t eip_add,uint32_t cycle_sub) {
 	reg_eip+=eip_add;
 	CPU_Cycles-=cycle_sub;
 	if (cpu.exception.which==SMC_CURRENT_BLOCK) return BR_SMCBlock;
@@ -613,8 +613,8 @@ static BlockReturn DynRunException(Bit32u eip_add,Bit32u cycle_sub) {
 // end of a cache block because it is rarely reached (like exceptions)
 static struct {
 	save_info_type type;
-	const Bit8u* branch_pos;
-	Bit32u eip_change;
+	const uint8_t* branch_pos;
+	uint32_t eip_change;
 	Bitu cycles;
 } save_info_dynrec[512];
 
@@ -691,7 +691,7 @@ bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) {
 		memcpy(&core_dynrec.readdata, &byte, sizeof(byte));
 		return false;
 	} else {
-		return get_tlb_readhandler(address)->readb_checked(address, (Bit8u*)(&core_dynrec.readdata));
+		return get_tlb_readhandler(address)->readb_checked(address, (uint8_t*)(&core_dynrec.readdata));
 	}
 }
 
@@ -703,8 +703,8 @@ bool DRC_CALL_CONV mem_readw_checked_drc(PhysPt address) {
 			const uint16_t word = host_readw(tlb_addr + address);
 			memcpy(&core_dynrec.readdata, &word, sizeof(word));
 			return false;
-		} else return get_tlb_readhandler(address)->readw_checked(address, (Bit16u*)(&core_dynrec.readdata));
-	} else return mem_unalignedreadw_checked(address, ((Bit16u*)(&core_dynrec.readdata)));
+		} else return get_tlb_readhandler(address)->readw_checked(address, (uint16_t*)(&core_dynrec.readdata));
+	} else return mem_unalignedreadw_checked(address, ((uint16_t*)(&core_dynrec.readdata)));
 }
 
 bool DRC_CALL_CONV mem_readd_checked_drc(PhysPt address) DRC_FC;
@@ -715,12 +715,12 @@ bool DRC_CALL_CONV mem_readd_checked_drc(PhysPt address) {
 			const uint32_t dword = host_readd(tlb_addr + address);
 			memcpy(&core_dynrec.readdata, &dword, sizeof(dword));
 			return false;
-		} else return get_tlb_readhandler(address)->readd_checked(address, (Bit32u*)(&core_dynrec.readdata));
-	} else return mem_unalignedreadd_checked(address, ((Bit32u*)(&core_dynrec.readdata)));
+		} else return get_tlb_readhandler(address)->readd_checked(address, (uint32_t*)(&core_dynrec.readdata));
+	} else return mem_unalignedreadd_checked(address, ((uint32_t*)(&core_dynrec.readdata)));
 }
 
-bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, Bit8u val) DRC_FC;
-bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, Bit8u val)
+bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, uint8_t val) DRC_FC;
+bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, uint8_t val)
 {
 	HostPt tlb_addr = get_tlb_write(address);
 	if (tlb_addr) {
@@ -731,8 +731,8 @@ bool DRC_CALL_CONV mem_writeb_checked_drc(PhysPt address, Bit8u val)
 	}
 }
 
-bool DRC_CALL_CONV mem_writew_checked_drc(PhysPt address,Bit16u val) DRC_FC;
-bool DRC_CALL_CONV mem_writew_checked_drc(PhysPt address,Bit16u val) {
+bool DRC_CALL_CONV mem_writew_checked_drc(PhysPt address,uint16_t val) DRC_FC;
+bool DRC_CALL_CONV mem_writew_checked_drc(PhysPt address,uint16_t val) {
 	if ((address & 0xfff)<0xfff) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) {
@@ -742,8 +742,8 @@ bool DRC_CALL_CONV mem_writew_checked_drc(PhysPt address,Bit16u val) {
 	} else return mem_unalignedwritew_checked(address,val);
 }
 
-bool DRC_CALL_CONV mem_writed_checked_drc(PhysPt address,Bit32u val) DRC_FC;
-bool DRC_CALL_CONV mem_writed_checked_drc(PhysPt address,Bit32u val) {
+bool DRC_CALL_CONV mem_writed_checked_drc(PhysPt address,uint32_t val) DRC_FC;
+bool DRC_CALL_CONV mem_writed_checked_drc(PhysPt address,uint32_t val) {
 	if ((address & 0xfff)<0xffd) {
 		HostPt tlb_addr=get_tlb_write(address);
 		if (tlb_addr) {
@@ -898,13 +898,13 @@ static void dyn_lea_segphys_mem(HostReg ea_reg,Bitu op1_index,void* op2,Bitu sca
 
 // calculate the effective address and store it in ea_reg
 static void dyn_fill_ea(HostReg ea_reg,bool addseg=true) {
-	Bit8u seg_base=DRC_SEG_DS;
+	uint8_t seg_base=DRC_SEG_DS;
 	if (!decode.big_addr) {
 		Bits imm = 0;
 		switch (decode.modrm.mod) {
 		case 0:imm=0;break;
-		case 1:imm=(Bit8s)decode_fetchb();break;
-		case 2:imm=(Bit16s)decode_fetchw();break;
+		case 1:imm=(int8_t)decode_fetchb();break;
+		case 2:imm=(int16_t)decode_fetchw();break;
 		}
 		switch (decode.modrm.rm) {
 		case 0:// BX+SI
@@ -923,26 +923,26 @@ static void dyn_fill_ea(HostReg ea_reg,bool addseg=true) {
 			break;
 		case 4:// SI
 			MOV_REG_VAL_TO_HOST_REG(ea_reg,DRC_REG_ESI);
-			if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+			if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 			break;
 		case 5:// DI
 			MOV_REG_VAL_TO_HOST_REG(ea_reg,DRC_REG_EDI);
-			if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+			if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 			break;
 		case 6:// imm/BP
 			if (!decode.modrm.mod) {
 				imm=decode_fetchw();
-				gen_mov_dword_to_reg_imm(ea_reg,(Bit32u)imm);
+				gen_mov_dword_to_reg_imm(ea_reg,(uint32_t)imm);
 				goto skip_extend_word;
 			} else {
 				MOV_REG_VAL_TO_HOST_REG(ea_reg,DRC_REG_EBP);
-				gen_add_imm(ea_reg,(Bit32u)imm);
+				gen_add_imm(ea_reg,(uint32_t)imm);
 				seg_base=DRC_SEG_SS;
 			}
 			break;
 		case 7: // BX
 			MOV_REG_VAL_TO_HOST_REG(ea_reg,DRC_REG_EBX);
-			if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+			if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 			break;
 		}
 		// zero out the high 16bit so ea_reg can be used as full register
@@ -954,8 +954,8 @@ skip_extend_word:
 		}
 	} else {
 		Bits imm = 0;
-		Bit8u base_reg = 0;
-		Bit8u scaled_reg = 0;
+		uint8_t base_reg = 0;
+		uint8_t scaled_reg = 0;
 		Bitu scale = 0;
 		switch (decode.modrm.rm) {
 		case 0:base_reg=DRC_REG_EAX;break;
@@ -966,7 +966,7 @@ skip_extend_word:
 			{
 				Bitu sib=decode_fetchb();
 				bool scaled_reg_used=false;
-				static Bit8u scaledtable[8]={
+				static uint8_t scaledtable[8]={
 					DRC_REG_EAX,DRC_REG_ECX,DRC_REG_EDX,DRC_REG_EBX,
 							0,DRC_REG_EBP,DRC_REG_ESI,DRC_REG_EDI
 				};
@@ -1008,18 +1008,18 @@ skip_extend_word:
 							return;
 						}
 						// couldn't get a pointer, use the current value
-						imm=(Bit32s)val;
+						imm=(int32_t)val;
 
 						if (!addseg) {
 							if (!scaled_reg_used) {
-								gen_mov_dword_to_reg_imm(ea_reg,(Bit32u)imm);
+								gen_mov_dword_to_reg_imm(ea_reg,(uint32_t)imm);
 							} else {
 								DYN_LEA_MEM_REG_VAL(ea_reg,NULL,scaled_reg,scale,imm);
 							}
 						} else {
 							if (!scaled_reg_used) {
 								MOV_SEG_PHYS_TO_HOST_REG(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base));
-								if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+								if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 							} else {
 								DYN_LEA_SEG_PHYS_REG_VAL(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base),scaled_reg,scale,imm);
 							}
@@ -1034,7 +1034,7 @@ skip_extend_word:
 				// basereg, maybe scalereg
 				switch (decode.modrm.mod) {
 				case 1:
-					imm=(Bit8s)decode_fetchb();
+					imm=(int8_t)decode_fetchb();
 					break;
 				case 2: {
 					Bitu val;
@@ -1061,7 +1061,7 @@ skip_extend_word:
 						return;
 					}
 					// couldn't get a pointer, use the current value
-					imm=(Bit32s)val;
+					imm=(int32_t)val;
 					break;
 					}
 				}
@@ -1069,7 +1069,7 @@ skip_extend_word:
 				if (!addseg) {
 					if (!scaled_reg_used) {
 						MOV_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-						gen_add_imm(ea_reg,(Bit32u)imm);
+						gen_add_imm(ea_reg,(uint32_t)imm);
 					} else {
 						DYN_LEA_REG_VAL_REG_VAL(ea_reg,base_reg,scaled_reg,scale,imm);
 					}
@@ -1077,7 +1077,7 @@ skip_extend_word:
 					if (!scaled_reg_used) {
 						MOV_SEG_PHYS_TO_HOST_REG(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base));
 						ADD_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-						if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+						if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 					} else {
 						DYN_LEA_SEG_PHYS_REG_VAL(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base),scaled_reg,scale,imm);
 						ADD_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
@@ -1093,12 +1093,12 @@ skip_extend_word:
 			} else {
 				// no base, no scalereg
 
-				imm=(Bit32s)decode_fetchd();
+				imm=(int32_t)decode_fetchd();
 				if (!addseg) {
-					gen_mov_dword_to_reg_imm(ea_reg,(Bit32u)imm);
+					gen_mov_dword_to_reg_imm(ea_reg,(uint32_t)imm);
 				} else {
 					MOV_SEG_PHYS_TO_HOST_REG(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base));
-					if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+					if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 				}
 
 				return;
@@ -1112,7 +1112,7 @@ skip_extend_word:
 
 		switch (decode.modrm.mod) {
 		case 1:
-			imm=(Bit8s)decode_fetchb();
+			imm=(int8_t)decode_fetchb();
 			break;
 		case 2: {
 			Bitu val;
@@ -1130,18 +1130,18 @@ skip_extend_word:
 				return;
 			}
 			// couldn't get a pointer, use the current value
-			imm=(Bit32s)val;
+			imm=(int32_t)val;
 			break;
 			}
 		}
 
 		if (!addseg) {
 			MOV_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-			if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+			if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 		} else {
 			MOV_SEG_PHYS_TO_HOST_REG(ea_reg,(decode.seg_prefix_used ? decode.seg_prefix : seg_base));
 			ADD_REG_VAL_TO_HOST_REG(ea_reg,base_reg);
-			if (imm) gen_add_imm(ea_reg,(Bit32u)imm);
+			if (imm) gen_add_imm(ea_reg,(uint32_t)imm);
 		}
 	}
 }
@@ -1183,7 +1183,7 @@ static void gen_restore_reg(HostReg reg,HostReg dest_reg) {
 
 static Bitu mf_functions_num=0;
 static struct {
-	const Bit8u* pos;
+	const uint8_t* pos;
 	void* fct_ptr;
 	Bitu ftype;
 } mf_functions[64];
@@ -1234,7 +1234,7 @@ static void InvalidateFlagsPartially(void* current_simple_function,Bitu flags_ty
 // enqueue this instruction, if later an instruction is encountered that
 // destroys all condition flags and the flags weren't needed in-between
 // this function can be replaced by a simpler one as well
-static void InvalidateFlagsPartially(void* current_simple_function,const Bit8u* cpos,Bitu flags_type) {
+static void InvalidateFlagsPartially(void* current_simple_function,const uint8_t* cpos,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION
 	mf_functions[mf_functions_num].pos=cpos;
 	mf_functions[mf_functions_num].fct_ptr=current_simple_function;

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -191,7 +191,7 @@ static void dyn_dop_evgv_xchg(void) {
 	}
 }
 
-static void dyn_xchg_ax(Bit8u reg) {
+static void dyn_xchg_ax(uint8_t reg) {
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_EAX,decode.big_op);
 	MOV_REG_WORD_TO_HOST_REG(FC_OP2,reg,decode.big_op);
 	MOV_REG_WORD_FROM_HOST_REG(FC_OP1,reg,decode.big_op);
@@ -230,26 +230,26 @@ static void dyn_dop_gvev_mov(void) {
 	}
 }
 
-static void dyn_dop_byte_imm(DualOps op,Bit8u reg,Bit8u idx) {
+static void dyn_dop_byte_imm(DualOps op,uint8_t reg,uint8_t idx) {
 	MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,reg,idx);
 	gen_mov_byte_to_reg_low_imm_canuseword(FC_OP2,decode_fetchb());
 	dyn_dop_byte_gencall(op);
 	if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,reg,idx);
 }
 
-static void dyn_dop_byte_imm_mem(DualOps op,Bit8u reg,Bit8u idx) {
+static void dyn_dop_byte_imm_mem(DualOps op,uint8_t reg,uint8_t idx) {
 	MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,reg,idx);
 	Bitu val;
 	if (decode_fetchb_imm(val)) {
 		gen_mov_byte_to_reg_low_canuseword(FC_OP2,(void*)val);
 	} else {
-		gen_mov_byte_to_reg_low_imm_canuseword(FC_OP2,(Bit8u)val);
+		gen_mov_byte_to_reg_low_imm_canuseword(FC_OP2,(uint8_t)val);
 	}
 	dyn_dop_byte_gencall(op);
 	if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,reg,idx);
 }
 
-static void dyn_prep_word_imm([[maybe_unused]] Bit8u reg) {
+static void dyn_prep_word_imm([[maybe_unused]] uint8_t reg) {
 	Bitu val;
 	if (decode.big_op) {
 		if (decode_fetchd_imm(val)) {
@@ -262,31 +262,31 @@ static void dyn_prep_word_imm([[maybe_unused]] Bit8u reg) {
 			return;
 		}
 	}
-	if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(Bit32u)val);
-	else gen_mov_word_to_reg_imm(FC_OP2,(Bit16u)val);
+	if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(uint32_t)val);
+	else gen_mov_word_to_reg_imm(FC_OP2,(uint16_t)val);
 }
 
-static void dyn_dop_word_imm(DualOps op,Bit8u reg) {
+static void dyn_dop_word_imm(DualOps op,uint8_t reg) {
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,reg,decode.big_op);
 	dyn_prep_word_imm(reg);
 	dyn_dop_word_gencall(op,decode.big_op);
 	if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_WORD_FROM_HOST_REG(FC_RETOP,reg,decode.big_op);
 }
 
-static void dyn_dop_word_imm_old(DualOps op,Bit8u reg,Bitu imm) {
+static void dyn_dop_word_imm_old(DualOps op,uint8_t reg,Bitu imm) {
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,reg,decode.big_op);
-	if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(Bit32u)imm);
-	else gen_mov_word_to_reg_imm(FC_OP2,(Bit16u)imm);
+	if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(uint32_t)imm);
+	else gen_mov_word_to_reg_imm(FC_OP2,(uint16_t)imm);
 	dyn_dop_word_gencall(op,decode.big_op);
 	if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_WORD_FROM_HOST_REG(FC_RETOP,reg,decode.big_op);
 }
 
-static void dyn_mov_byte_imm(Bit8u reg,Bit8u idx,Bit8u imm) {
+static void dyn_mov_byte_imm(uint8_t reg,uint8_t idx,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(FC_TMP_BA1,imm);
 	MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,reg,idx);
 }
 
-static void dyn_mov_word_imm(Bit8u reg) {
+static void dyn_mov_word_imm(uint8_t reg) {
 	Bitu val;
 	if (decode.big_op) {
 		if (decode_fetchd_imm(val)) {
@@ -301,13 +301,13 @@ static void dyn_mov_word_imm(Bit8u reg) {
 			return;
 		}
 	}
-	if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP1,(Bit32u)val);
-	else gen_mov_word_to_reg_imm(FC_OP1,(Bit16u)val);
+	if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP1,(uint32_t)val);
+	else gen_mov_word_to_reg_imm(FC_OP1,(uint16_t)val);
 	MOV_REG_WORD_FROM_HOST_REG(FC_OP1,reg,decode.big_op);
 }
 
 
-static void dyn_sop_word(SingleOps op,Bit8u reg) {
+static void dyn_sop_word(SingleOps op,uint8_t reg) {
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,reg,decode.big_op);
 	dyn_sop_word_gencall(op,decode.big_op);
 	MOV_REG_WORD_FROM_HOST_REG(FC_RETOP,reg,decode.big_op);
@@ -335,7 +335,7 @@ static void dyn_mov_byte_direct_al() {
 		if (decode_fetchd_imm(val)) {
 			gen_add_LE(FC_ADDR,(void*)val);
 		} else {
-			gen_add_imm(FC_ADDR,(Bit32u)val);
+			gen_add_imm(FC_ADDR,(uint32_t)val);
 		}
 	} else {
 		gen_add_imm(FC_ADDR,decode_fetchw());
@@ -400,7 +400,7 @@ static void dyn_lea(void) {
 }
 
 
-static void dyn_push_seg(Bit8u seg) {
+static void dyn_push_seg(uint8_t seg) {
 	MOV_SEG_VAL_TO_HOST_REG(FC_OP1,seg);
 	if (decode.big_op) {
 		gen_extend_word(false,FC_OP1);
@@ -410,25 +410,25 @@ static void dyn_push_seg(Bit8u seg) {
 	}
 }
 
-static void dyn_pop_seg(Bit8u seg) {
+static void dyn_pop_seg(uint8_t seg) {
 	gen_call_function_II((void *)&CPU_PopSeg,seg,decode.big_op);
 	dyn_check_exception(FC_RETOP);
 }
 
-static void dyn_push_reg(Bit8u reg) {
+static void dyn_push_reg(uint8_t reg) {
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,reg,decode.big_op);
 	if (decode.big_op) gen_call_function_raw((void*)&dynrec_push_dword);
 	else gen_call_function_raw((void*)&dynrec_push_word);
 }
 
-static void dyn_pop_reg(Bit8u reg) {
+static void dyn_pop_reg(uint8_t reg) {
 	if (decode.big_op) gen_call_function_raw((void*)&dynrec_pop_dword);
 	else gen_call_function_raw((void*)&dynrec_pop_word);
 	MOV_REG_WORD_FROM_HOST_REG(FC_RETOP,reg,decode.big_op);
 }
 
-static void dyn_push_byte_imm(Bit8s imm) {
-	gen_mov_dword_to_reg_imm(FC_OP1,(Bit32u)imm);
+static void dyn_push_byte_imm(int8_t imm) {
+	gen_mov_dword_to_reg_imm(FC_OP1,(uint32_t)imm);
 	if (decode.big_op) gen_call_function_raw((void*)&dynrec_push_dword);
 	else gen_call_function_raw((void*)&dynrec_push_word);
 }
@@ -438,7 +438,7 @@ static void dyn_push_word_imm(Bitu imm) {
 		gen_mov_dword_to_reg_imm(FC_OP1,imm);
 		gen_call_function_raw((void*)&dynrec_push_dword);
 	} else {
-		gen_mov_word_to_reg_imm(FC_OP1,(Bit16u)imm);
+		gen_mov_word_to_reg_imm(FC_OP1,(uint16_t)imm);
 		gen_call_function_raw((void*)&dynrec_push_word);
 	}
 }
@@ -457,7 +457,7 @@ static void dyn_pop_ev(void) {
 		if (decode.big_op) gen_call_function_raw((void *)&mem_writed_checked_drc);
 		else gen_call_function_raw((void *)&mem_writew_checked_drc);
 		gen_extend_byte(false,FC_RETOP); // bool -> dword
-		const Bit8u* no_fault = gen_create_branch_on_zero(FC_RETOP, true);
+		const uint8_t* no_fault = gen_create_branch_on_zero(FC_RETOP, true);
 		// restore original ESP
 		gen_restore_reg(FC_OP2);
 		MOV_REG_WORD32_FROM_HOST_REG(FC_OP2,DRC_REG_ESP);
@@ -471,7 +471,7 @@ static void dyn_pop_ev(void) {
 }
 
 
-static void dyn_segprefix(Bit8u seg) {
+static void dyn_segprefix(uint8_t seg) {
 //	if (GCC_UNLIKELY(decode.seg_prefix_used)) IllegalOptionDynrec("dyn_segprefix");
 	decode.seg_prefix=seg;
 	decode.seg_prefix_used=true;
@@ -490,7 +490,7 @@ static void dyn_segprefix(Bit8u seg) {
 	dyn_check_exception(FC_RETOP);
 }
 
-static void dyn_load_seg_off_ea(Bit8u seg) {
+static void dyn_load_seg_off_ea(uint8_t seg) {
 	if (decode.modrm.mod<3) {
 		dyn_fill_ea(FC_ADDR);
 		gen_protect_addr_reg();
@@ -527,16 +527,16 @@ static void dyn_imul_gvev(Bitu immsize) {
 			MOV_REG_WORD_TO_HOST_REG(FC_OP2,decode.modrm.reg,decode.big_op);
 			break;
 		case 1:
-			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(Bit8s)decode_fetchb());
-			else  gen_mov_word_to_reg_imm(FC_OP2,(Bit8s)decode_fetchb());
+			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(int8_t)decode_fetchb());
+			else  gen_mov_word_to_reg_imm(FC_OP2,(int8_t)decode_fetchb());
 			break;
 		case 2:
-			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(Bit16s)decode_fetchw());
-			else gen_mov_word_to_reg_imm(FC_OP2,(Bit16s)decode_fetchw());
+			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(int16_t)decode_fetchw());
+			else gen_mov_word_to_reg_imm(FC_OP2,(int16_t)decode_fetchw());
 			break;
 		case 4:
-			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(Bit32s)decode_fetchd());
-			else gen_mov_word_to_reg_imm(FC_OP2,(Bit16u)((Bit32s)decode_fetchd()));
+			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(int32_t)decode_fetchd());
+			else gen_mov_word_to_reg_imm(FC_OP2,(uint16_t)((int32_t)decode_fetchd()));
 			break;
 	}
 
@@ -600,9 +600,9 @@ static void dyn_grp1_ev_iv(bool withbyte) {
 		if (!withbyte) {
 			dyn_prep_word_imm(FC_OP2);
 		} else {
-			Bits imm=(Bit8s)decode_fetchb(); 
-			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(Bit32u)imm);
-			else gen_mov_word_to_reg_imm(FC_OP2,(Bit16u)imm);
+			Bits imm=(int8_t)decode_fetchb(); 
+			if (decode.big_op) gen_mov_dword_to_reg_imm(FC_OP2,(uint32_t)imm);
+			else gen_mov_word_to_reg_imm(FC_OP2,(uint16_t)imm);
 		}
 
 		dyn_dop_word_gencall(op,decode.big_op);
@@ -615,7 +615,7 @@ static void dyn_grp1_ev_iv(bool withbyte) {
 		if (!withbyte) {
 			dyn_dop_word_imm(op,decode.modrm.rm);
 		} else {
-			Bits imm=withbyte ? (Bit8s)decode_fetchb() : (decode.big_op ? decode_fetchd(): decode_fetchw()); 
+			Bits imm=withbyte ? (int8_t)decode_fetchb() : (decode.big_op ? decode_fetchd(): decode_fetchw()); 
 			dyn_dop_word_imm_old(op,decode.modrm.rm,imm);
 		}
 	}
@@ -637,7 +637,7 @@ static void dyn_grp2_eb(grp2_types type) {
 		dyn_shift_byte_gencall((ShiftOps)decode.modrm.reg);
 		break;
 	case grp2_imm: {
-		Bit8u imm=decode_fetchb();
+		uint8_t imm=decode_fetchb();
 		if (imm) {
 			gen_mov_byte_to_reg_low_imm_canuseword(FC_OP2,imm&0x1f);
 			dyn_shift_byte_gencall((ShiftOps)decode.modrm.reg);
@@ -680,7 +680,7 @@ static void dyn_grp2_ev(grp2_types type) {
 			dyn_shift_word_gencall((ShiftOps)decode.modrm.reg,decode.big_op);
 			break;
 		}
-		Bit8u imm=(Bit8u)val;
+		uint8_t imm=(uint8_t)val;
 		if (imm) {
 			gen_mov_byte_to_reg_low_imm_canuseword(FC_OP2,imm&0x1f);
 			dyn_shift_word_gencall((ShiftOps)decode.modrm.reg,decode.big_op);
@@ -852,7 +852,7 @@ static Bitu dyn_grp4_ev(void) {
 		gen_mov_regs(FC_ADDR,FC_OP1);
 		gen_protect_addr_reg();
 		gen_mov_word_to_reg(FC_OP1,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),decode.big_op);
-		gen_add_imm(FC_OP1,(Bit32u)(decode.code-decode.code_start));
+		gen_add_imm(FC_OP1,(uint32_t)(decode.code-decode.code_start));
 		if (decode.big_op) gen_call_function_raw((void*)&dynrec_push_dword);
 		else gen_call_function_raw((void*)&dynrec_push_word);
 
@@ -1038,7 +1038,7 @@ static void dyn_larlsl(bool is_lar) {
 	gen_extend_word(false,FC_RETOP);
 	if (is_lar) gen_call_function((void*)CPU_LAR,"%R%A",FC_RETOP,(DRC_PTR_SIZE_IM)&core_dynrec.readdata);
 	else gen_call_function((void*)CPU_LSL,"%R%A",FC_RETOP,(DRC_PTR_SIZE_IM)&core_dynrec.readdata);
-	const Bit8u* brnz=gen_create_branch_on_nonzero(FC_RETOP,true);
+	const uint8_t* brnz=gen_create_branch_on_nonzero(FC_RETOP,true);
 	gen_mov_word_to_reg(FC_OP2,&core_dynrec.readdata,true);
 	MOV_REG_WORD_FROM_HOST_REG(FC_OP2,decode.modrm.reg,decode.big_op);
 	gen_fill_branch(brnz);
@@ -1104,12 +1104,12 @@ static void dyn_exit_link(Bits eip_change) {
 }
 
 
-static void dyn_branched_exit(BranchTypes btype,Bit32s eip_add) {
+static void dyn_branched_exit(BranchTypes btype,int32_t eip_add) {
 	Bitu eip_base=decode.code-decode.code_start;
 	dyn_reduce_cycles();
 
 	dyn_branchflag_to_reg(btype);
-	const Bit8u* data=gen_create_branch_on_nonzero(FC_RETOP,true);
+	const uint8_t* data=gen_create_branch_on_nonzero(FC_RETOP,true);
 
  	// Branch not taken
 	gen_add_direct_word(&reg_eip,eip_base,decode.big_op);
@@ -1138,10 +1138,10 @@ static void dyn_set_byte_on_condition(BranchTypes btype) {
 
 static void dyn_loop(LoopTypes type) {
 	dyn_reduce_cycles();
-	Bits eip_add=(Bit8s)decode_fetchb();
+	Bits eip_add=(int8_t)decode_fetchb();
 	Bitu eip_base=decode.code-decode.code_start;
-	const Bit8u* branch1=0;
-	const Bit8u* branch2=0;
+	const uint8_t* branch1=0;
+	const uint8_t* branch2=0;
 	switch (type) {
 	case LOOP_E:
 		dyn_branchflag_to_reg(BR_NZ);
@@ -1160,7 +1160,7 @@ static void dyn_loop(LoopTypes type) {
 	case LOOP_NE:
 	case LOOP_NONE:
 		MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
-		gen_add_imm(FC_OP1,(Bit32u)(-1));
+		gen_add_imm(FC_OP1,(uint32_t)(-1));
 		MOV_REG_WORD_FROM_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
 		branch2=gen_create_branch_on_zero(FC_OP1,decode.big_addr);
 		break;
@@ -1174,7 +1174,7 @@ static void dyn_loop(LoopTypes type) {
 	if (branch1) {
 		gen_fill_branch(branch1);
 		MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
-		gen_add_imm(FC_OP1,(Bit32u)(-1));
+		gen_add_imm(FC_OP1,(uint32_t)(-1));
 		MOV_REG_WORD_FROM_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
 	}
 	// Branch taken
@@ -1199,8 +1199,8 @@ static void dyn_ret_near(Bitu bytes) {
 
 static void dyn_call_near_imm(void) {
 	Bits imm;
-	if (decode.big_op) imm=(Bit32s)decode_fetchd();
-	else imm=(Bit16s)decode_fetchw();
+	if (decode.big_op) imm=(int32_t)decode_fetchd();
+	else imm=(int16_t)decode_fetchw();
 	dyn_set_eip_end(FC_OP1);
 	if (decode.big_op) gen_call_function_raw((void*)&dynrec_push_dword);
 	else gen_call_function_raw((void*)&dynrec_push_word);
@@ -1251,7 +1251,7 @@ static void dyn_iret(void) {
 	dyn_closeblock();
 }
 
-[[maybe_unused]] static void dyn_interrupt(Bit8u num)
+[[maybe_unused]] static void dyn_interrupt(uint8_t num)
 {
 	dyn_reduce_cycles();
 	dyn_set_eip_last_end(FC_RETOP);
@@ -1264,7 +1264,7 @@ static void dyn_string(STRING_OP op) {
 	if (decode.rep) MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
 	else gen_mov_dword_to_reg_imm(FC_OP1,1);
 	gen_mov_word_to_reg(FC_OP2,&cpu.direction,true);
-	Bit8u di_base_addr=decode.seg_prefix_used ? decode.seg_prefix : DRC_SEG_DS;
+	uint8_t di_base_addr=decode.seg_prefix_used ? decode.seg_prefix : DRC_SEG_DS;
 	switch (op) {
 		case R_MOVSB:
 			if (decode.big_addr) gen_call_function_mm((void*)&dynrec_movsb_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
@@ -1320,25 +1320,25 @@ static void dyn_string(STRING_OP op) {
 }
 
 
-static void dyn_read_port_byte_direct(Bit8u port) {
+static void dyn_read_port_byte_direct(uint8_t port) {
 	gen_mov_dword_to_reg_imm(FC_OP1,port);
 	gen_call_function_raw((void*)&dynrec_io_readB);
 	dyn_check_exception(FC_RETOP);
 }
 
-static void dyn_read_port_word_direct(Bit8u port) {
+static void dyn_read_port_word_direct(uint8_t port) {
 	gen_mov_dword_to_reg_imm(FC_OP1,port);
 	gen_call_function_raw(decode.big_op?((void*)&dynrec_io_readD):((void*)&dynrec_io_readW));
 	dyn_check_exception(FC_RETOP);
 }
 
-static void dyn_write_port_byte_direct(Bit8u port) {
+static void dyn_write_port_byte_direct(uint8_t port) {
 	gen_mov_dword_to_reg_imm(FC_OP1,port);
 	gen_call_function_raw((void*)&dynrec_io_writeB);
 	dyn_check_exception(FC_RETOP);
 }
 
-static void dyn_write_port_word_direct(Bit8u port) {
+static void dyn_write_port_word_direct(uint8_t port) {
 	gen_mov_dword_to_reg_imm(FC_OP1,port);
 	gen_call_function_raw(decode.big_op?((void*)&dynrec_io_writeD):((void*)&dynrec_io_writeW));
 	dyn_check_exception(FC_RETOP);
@@ -1383,7 +1383,7 @@ static void dyn_enter(void) {
 static void dynrec_leave_word(void) {
 	reg_esp&=cpu.stack.notmask;
 	reg_esp|=(reg_ebp&cpu.stack.mask);
-	reg_bp=(Bit16u)CPU_Pop16();
+	reg_bp=(uint16_t)CPU_Pop16();
 }
 
 static void dynrec_leave_dword(void) {
@@ -1399,7 +1399,7 @@ static void dyn_leave(void) {
 
 
 static void dynrec_pusha_word(void) {
-	Bit16u old_sp=reg_sp;
+	uint16_t old_sp=reg_sp;
 	CPU_Push16(reg_ax);CPU_Push16(reg_cx);CPU_Push16(reg_dx);CPU_Push16(reg_bx);
 	CPU_Push16(old_sp);CPU_Push16(reg_bp);CPU_Push16(reg_si);CPU_Push16(reg_di);
 }
@@ -1411,10 +1411,10 @@ static void dynrec_pusha_dword(void) {
 }
 
 static void dynrec_popa_word(void) {
-	reg_di=(Bit16u)CPU_Pop16();reg_si=(Bit16u)CPU_Pop16();
-	reg_bp=(Bit16u)CPU_Pop16();CPU_Pop16();		//Don't save SP
-	reg_bx=(Bit16u)CPU_Pop16();reg_dx=(Bit16u)CPU_Pop16();
-	reg_cx=(Bit16u)CPU_Pop16();reg_ax=(Bit16u)CPU_Pop16();
+	reg_di=(uint16_t)CPU_Pop16();reg_si=(uint16_t)CPU_Pop16();
+	reg_bp=(uint16_t)CPU_Pop16();CPU_Pop16();		//Don't save SP
+	reg_bx=(uint16_t)CPU_Pop16();reg_dx=(uint16_t)CPU_Pop16();
+	reg_cx=(uint16_t)CPU_Pop16();reg_ax=(uint16_t)CPU_Pop16();
 }
 
 static void dynrec_popa_dword(void) {

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -648,7 +648,7 @@ static void dyn_fpu_esc7(){
 		}
 	} else {
 		switch(decode.modrm.reg){
-		case 0x00:  /* FILD Bit16s */
+		case 0x00:  /* FILD int16_t */
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
@@ -657,11 +657,11 @@ static void dyn_fpu_esc7(){
 		case 0x01:
 			LOG(LOG_FPU,LOG_WARN)("ESC 7 EA:Unhandled group %X subfunction %X",static_cast<uint32_t>(decode.modrm.reg),static_cast<uint32_t>(decode.modrm.rm));
 			break;
-		case 0x02:   /* FIST Bit16s */
+		case 0x02:   /* FIST int16_t */
 			dyn_fill_ea(FC_ADDR); 
 			gen_call_function_R((void*)&FPU_FST_I16,FC_ADDR);
 			break;
-		case 0x03:	/* FISTP Bit16s */
+		case 0x03:	/* FISTP int16_t */
 			dyn_fill_ea(FC_ADDR); 
 			gen_call_function_R((void*)&FPU_FST_I16,FC_ADDR);
 			gen_call_function_raw((void*)&FPU_FPOP);
@@ -672,7 +672,7 @@ static void dyn_fpu_esc7(){
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
 			gen_call_function_RR((void*)&FPU_FBLD,FC_OP1,FC_OP2);
 			break;
-		case 0x05:  /* FILD Bit64s */
+		case 0x05:  /* FILD int64_t */
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1);
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
@@ -683,7 +683,7 @@ static void dyn_fpu_esc7(){
 			gen_call_function_R((void*)&FPU_FBST,FC_ADDR);
 			gen_call_function_raw((void*)&FPU_FPOP);
 			break;
-		case 0x07:  /* FISTP Bit64s */
+		case 0x07:  /* FISTP int64_t */
 			dyn_fill_ea(FC_ADDR); 
 			gen_call_function_R((void*)&FPU_FST_I64,FC_ADDR);
 			gen_call_function_raw((void*)&FPU_FPOP);

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -18,78 +18,78 @@
 
 
 
-static Bit8u DRC_CALL_CONV dynrec_add_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_add_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_add_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_add_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
-	lf_resb=(Bit8u)(lf_var1b+lf_var2b);
+	lf_resb=(uint8_t)(lf_var1b+lf_var2b);
 	lflags.type=t_ADDb;
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_add_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_add_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_add_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_add_byte_simple(uint8_t op1,uint8_t op2) {
 	return op1+op2;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_adc_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_adc_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_adc_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_adc_byte(uint8_t op1,uint8_t op2) {
 	lflags.oldcf=get_CF()!=0;
 	lf_var1b=op1;
 	lf_var2b=op2;
-	lf_resb=(Bit8u)(lf_var1b+lf_var2b+lflags.oldcf);
+	lf_resb=(uint8_t)(lf_var1b+lf_var2b+lflags.oldcf);
 	lflags.type=t_ADCb;
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_adc_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_adc_byte_simple(Bit8u op1,Bit8u op2) {
-	return (Bit8u)(op1+op2+(Bitu)(get_CF()!=0));
+static uint8_t DRC_CALL_CONV dynrec_adc_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_adc_byte_simple(uint8_t op1,uint8_t op2) {
+	return (uint8_t)(op1+op2+(Bitu)(get_CF()!=0));
 }
 
-static Bit8u DRC_CALL_CONV dynrec_sub_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_sub_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_sub_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_sub_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
-	lf_resb=(Bit8u)(lf_var1b-lf_var2b);
+	lf_resb=(uint8_t)(lf_var1b-lf_var2b);
 	lflags.type=t_SUBb;
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_sub_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_sub_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_sub_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_sub_byte_simple(uint8_t op1,uint8_t op2) {
 	return op1-op2;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_sbb_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_sbb_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_sbb_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_sbb_byte(uint8_t op1,uint8_t op2) {
 	lflags.oldcf=get_CF()!=0;
 	lf_var1b=op1;
 	lf_var2b=op2;
-	lf_resb=(Bit8u)(lf_var1b-(lf_var2b+lflags.oldcf));
+	lf_resb=(uint8_t)(lf_var1b-(lf_var2b+lflags.oldcf));
 	lflags.type=t_SBBb;
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_sbb_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_sbb_byte_simple(Bit8u op1,Bit8u op2) {
-	return (Bit8u)(op1-(op2+(Bitu)(get_CF()!=0)));
+static uint8_t DRC_CALL_CONV dynrec_sbb_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_sbb_byte_simple(uint8_t op1,uint8_t op2) {
+	return (uint8_t)(op1-(op2+(Bitu)(get_CF()!=0)));
 }
 
-static void DRC_CALL_CONV dynrec_cmp_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_byte(Bit8u op1,Bit8u op2) {
+static void DRC_CALL_CONV dynrec_cmp_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_cmp_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
-	lf_resb=(Bit8u)(lf_var1b-lf_var2b);
+	lf_resb=(uint8_t)(lf_var1b-lf_var2b);
 	lflags.type=t_CMPb;
 }
 
-static void DRC_CALL_CONV dynrec_cmp_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_byte_simple([[maybe_unused]] Bit8u op1,[[maybe_unused]] Bit8u op2) {
+static void DRC_CALL_CONV dynrec_cmp_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_cmp_byte_simple([[maybe_unused]] uint8_t op1,[[maybe_unused]] uint8_t op2) {
 }
 
-static Bit8u DRC_CALL_CONV dynrec_xor_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_xor_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_xor_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_xor_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
 	lf_resb=lf_var1b ^ lf_var2b;
@@ -97,13 +97,13 @@ static Bit8u DRC_CALL_CONV dynrec_xor_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_xor_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_xor_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_xor_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_xor_byte_simple(uint8_t op1,uint8_t op2) {
 	return op1 ^ op2;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_and_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_and_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_and_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_and_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
 	lf_resb=lf_var1b & lf_var2b;
@@ -111,13 +111,13 @@ static Bit8u DRC_CALL_CONV dynrec_and_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_and_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_and_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_and_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_and_byte_simple(uint8_t op1,uint8_t op2) {
 	return op1 & op2;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_or_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_or_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_or_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_or_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
 	lf_resb=lf_var1b | lf_var2b;
@@ -125,95 +125,95 @@ static Bit8u DRC_CALL_CONV dynrec_or_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_or_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_or_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_or_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_or_byte_simple(uint8_t op1,uint8_t op2) {
 	return op1 | op2;
 }
 
-static void DRC_CALL_CONV dynrec_test_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_byte(Bit8u op1,Bit8u op2) {
+static void DRC_CALL_CONV dynrec_test_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_test_byte(uint8_t op1,uint8_t op2) {
 	lf_var1b=op1;
 	lf_var2b=op2;
 	lf_resb=lf_var1b & lf_var2b;
 	lflags.type=t_TESTb;
 }
 
-static void DRC_CALL_CONV dynrec_test_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_byte_simple([[maybe_unused]] Bit8u op1,[[maybe_unused]] Bit8u op2) {
+static void DRC_CALL_CONV dynrec_test_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_test_byte_simple([[maybe_unused]] uint8_t op1,[[maybe_unused]] uint8_t op2) {
 }
 
-static Bit16u DRC_CALL_CONV dynrec_add_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_add_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_add_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_add_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
-	lf_resw=(Bit16u)(lf_var1w+lf_var2w);
+	lf_resw=(uint16_t)(lf_var1w+lf_var2w);
 	lflags.type=t_ADDw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_add_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_add_word_simple(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_add_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_add_word_simple(uint16_t op1,uint16_t op2) {
 	return op1+op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_adc_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_adc_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_adc_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_adc_word(uint16_t op1,uint16_t op2) {
 	lflags.oldcf=get_CF()!=0;
 	lf_var1w=op1;
 	lf_var2w=op2;
-	lf_resw=(Bit16u)(lf_var1w+lf_var2w+lflags.oldcf);
+	lf_resw=(uint16_t)(lf_var1w+lf_var2w+lflags.oldcf);
 	lflags.type=t_ADCw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_adc_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_adc_word_simple(Bit16u op1,Bit16u op2) {
-	return (Bit16u)(op1+op2+(Bitu)(get_CF()!=0));
+static uint16_t DRC_CALL_CONV dynrec_adc_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_adc_word_simple(uint16_t op1,uint16_t op2) {
+	return (uint16_t)(op1+op2+(Bitu)(get_CF()!=0));
 }
 
-static Bit16u DRC_CALL_CONV dynrec_sub_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_sub_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_sub_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_sub_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
-	lf_resw=(Bit16u)(lf_var1w-lf_var2w);
+	lf_resw=(uint16_t)(lf_var1w-lf_var2w);
 	lflags.type=t_SUBw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_sub_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_sub_word_simple(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_sub_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_sub_word_simple(uint16_t op1,uint16_t op2) {
 	return op1-op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_sbb_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_sbb_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_sbb_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_sbb_word(uint16_t op1,uint16_t op2) {
 	lflags.oldcf=get_CF()!=0;
 	lf_var1w=op1;
 	lf_var2w=op2;
-	lf_resw=(Bit16u)(lf_var1w-(lf_var2w+lflags.oldcf));
+	lf_resw=(uint16_t)(lf_var1w-(lf_var2w+lflags.oldcf));
 	lflags.type=t_SBBw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_sbb_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_sbb_word_simple(Bit16u op1,Bit16u op2) {
-	return (Bit16u)(op1-(op2+(Bitu)(get_CF()!=0)));
+static uint16_t DRC_CALL_CONV dynrec_sbb_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_sbb_word_simple(uint16_t op1,uint16_t op2) {
+	return (uint16_t)(op1-(op2+(Bitu)(get_CF()!=0)));
 }
 
-static void DRC_CALL_CONV dynrec_cmp_word(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_word(Bit16u op1,Bit16u op2) {
+static void DRC_CALL_CONV dynrec_cmp_word(uint16_t op1,uint16_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_cmp_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
-	lf_resw=(Bit16u)(lf_var1w-lf_var2w);
+	lf_resw=(uint16_t)(lf_var1w-lf_var2w);
 	lflags.type=t_CMPw;
 }
 
-static void DRC_CALL_CONV dynrec_cmp_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_word_simple([[maybe_unused]] Bit16u op1, [[maybe_unused]] Bit16u op2) {
+static void DRC_CALL_CONV dynrec_cmp_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_cmp_word_simple([[maybe_unused]] uint16_t op1, [[maybe_unused]] uint16_t op2) {
 }
 
-static Bit16u DRC_CALL_CONV dynrec_xor_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_xor_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_xor_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_xor_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
 	lf_resw=lf_var1w ^ lf_var2w;
@@ -221,13 +221,13 @@ static Bit16u DRC_CALL_CONV dynrec_xor_word(Bit16u op1,Bit16u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_xor_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_xor_word_simple(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_xor_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_xor_word_simple(uint16_t op1,uint16_t op2) {
 	return op1 ^ op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_and_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_and_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_and_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_and_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
 	lf_resw=lf_var1w & lf_var2w;
@@ -235,13 +235,13 @@ static Bit16u DRC_CALL_CONV dynrec_and_word(Bit16u op1,Bit16u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_and_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_and_word_simple(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_and_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_and_word_simple(uint16_t op1,uint16_t op2) {
 	return op1 & op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_or_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_or_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_or_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_or_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
 	lf_resw=lf_var1w | lf_var2w;
@@ -249,25 +249,25 @@ static Bit16u DRC_CALL_CONV dynrec_or_word(Bit16u op1,Bit16u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_or_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_or_word_simple(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_or_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_or_word_simple(uint16_t op1,uint16_t op2) {
 	return op1 | op2;
 }
 
-static void DRC_CALL_CONV dynrec_test_word(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_word(Bit16u op1,Bit16u op2) {
+static void DRC_CALL_CONV dynrec_test_word(uint16_t op1,uint16_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_test_word(uint16_t op1,uint16_t op2) {
 	lf_var1w=op1;
 	lf_var2w=op2;
 	lf_resw=lf_var1w & lf_var2w;
 	lflags.type=t_TESTw;
 }
 
-static void DRC_CALL_CONV dynrec_test_word_simple(Bit16u op1,Bit16u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_word_simple([[maybe_unused]] Bit16u op1, [[maybe_unused]] Bit16u op2) {
+static void DRC_CALL_CONV dynrec_test_word_simple(uint16_t op1,uint16_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_test_word_simple([[maybe_unused]] uint16_t op1, [[maybe_unused]] uint16_t op2) {
 }
 
-static Bit32u DRC_CALL_CONV dynrec_add_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_add_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_add_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_add_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d+lf_var2d;
@@ -275,13 +275,13 @@ static Bit32u DRC_CALL_CONV dynrec_add_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_add_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_add_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_add_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_add_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1 + op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_adc_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_adc_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_adc_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_adc_dword(uint32_t op1,uint32_t op2) {
 	lflags.oldcf=get_CF()!=0;
 	lf_var1d=op1;
 	lf_var2d=op2;
@@ -290,13 +290,13 @@ static Bit32u DRC_CALL_CONV dynrec_adc_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_adc_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_adc_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_adc_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_adc_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1+op2+(Bitu)(get_CF()!=0);
 }
 
-static Bit32u DRC_CALL_CONV dynrec_sub_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_sub_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_sub_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_sub_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d-lf_var2d;
@@ -304,13 +304,13 @@ static Bit32u DRC_CALL_CONV dynrec_sub_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_sub_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_sub_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_sub_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_sub_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1-op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_sbb_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_sbb_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_sbb_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_sbb_dword(uint32_t op1,uint32_t op2) {
 	lflags.oldcf=get_CF()!=0;
 	lf_var1d=op1;
 	lf_var2d=op2;
@@ -319,25 +319,25 @@ static Bit32u DRC_CALL_CONV dynrec_sbb_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_sbb_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_sbb_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_sbb_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_sbb_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1-(op2+(Bitu)(get_CF()!=0));
 }
 
-static void DRC_CALL_CONV dynrec_cmp_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_dword(Bit32u op1,Bit32u op2) {
+static void DRC_CALL_CONV dynrec_cmp_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_cmp_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d-lf_var2d;
 	lflags.type=t_CMPd;
 }
 
-static void DRC_CALL_CONV dynrec_cmp_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_cmp_dword_simple([[maybe_unused]] Bit32u op1, [[maybe_unused]] Bit32u op2) {
+static void DRC_CALL_CONV dynrec_cmp_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_cmp_dword_simple([[maybe_unused]] uint32_t op1, [[maybe_unused]] uint32_t op2) {
 }
 
-static Bit32u DRC_CALL_CONV dynrec_xor_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_xor_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_xor_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_xor_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d ^ lf_var2d;
@@ -345,13 +345,13 @@ static Bit32u DRC_CALL_CONV dynrec_xor_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_xor_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_xor_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_xor_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_xor_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1 ^ op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_and_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_and_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_and_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_and_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d & lf_var2d;
@@ -359,13 +359,13 @@ static Bit32u DRC_CALL_CONV dynrec_and_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_and_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_and_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_and_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_and_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1 & op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_or_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_or_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_or_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_or_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d | lf_var2d;
@@ -373,21 +373,21 @@ static Bit32u DRC_CALL_CONV dynrec_or_dword(Bit32u op1,Bit32u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_or_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_or_dword_simple(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_or_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_or_dword_simple(uint32_t op1,uint32_t op2) {
 	return op1 | op2;
 }
 
-static void DRC_CALL_CONV dynrec_test_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_dword(Bit32u op1,Bit32u op2) {
+static void DRC_CALL_CONV dynrec_test_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_test_dword(uint32_t op1,uint32_t op2) {
 	lf_var1d=op1;
 	lf_var2d=op2;
 	lf_resd=lf_var1d & lf_var2d;
 	lflags.type=t_TESTd;
 }
 
-static void DRC_CALL_CONV dynrec_test_dword_simple(Bit32u op1,Bit32u op2) DRC_FC;
-static void DRC_CALL_CONV dynrec_test_dword_simple([[maybe_unused]] Bit32u op1, [[maybe_unused]] Bit32u op2) {
+static void DRC_CALL_CONV dynrec_test_dword_simple(uint32_t op1,uint32_t op2) DRC_FC;
+static void DRC_CALL_CONV dynrec_test_dword_simple([[maybe_unused]] uint32_t op1, [[maybe_unused]] uint32_t op2) {
 }
 
 
@@ -524,8 +524,8 @@ static void dyn_dop_word_gencall(DualOps op,bool dword) {
 }
 
 
-static Bit8u DRC_CALL_CONV dynrec_inc_byte(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_inc_byte(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_inc_byte(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_inc_byte(uint8_t op) {
 	LoadCF;
 	lf_var1b=op;
 	lf_resb=lf_var1b+1;
@@ -533,13 +533,13 @@ static Bit8u DRC_CALL_CONV dynrec_inc_byte(Bit8u op) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_inc_byte_simple(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_inc_byte_simple(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_inc_byte_simple(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_inc_byte_simple(uint8_t op) {
 	return op+1;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_dec_byte(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_dec_byte(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_dec_byte(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_dec_byte(uint8_t op) {
 	LoadCF;
 	lf_var1b=op;
 	lf_resb=lf_var1b-1;
@@ -547,31 +547,31 @@ static Bit8u DRC_CALL_CONV dynrec_dec_byte(Bit8u op) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_dec_byte_simple(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_dec_byte_simple(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_dec_byte_simple(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_dec_byte_simple(uint8_t op) {
 	return op-1;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_not_byte(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_not_byte(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_not_byte(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_not_byte(uint8_t op) {
 	return ~op;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_neg_byte(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_neg_byte(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_neg_byte(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_neg_byte(uint8_t op) {
 	lf_var1b=op;
 	lf_resb=0-lf_var1b;
 	lflags.type=t_NEGb;
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_neg_byte_simple(Bit8u op) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_neg_byte_simple(Bit8u op) {
+static uint8_t DRC_CALL_CONV dynrec_neg_byte_simple(uint8_t op) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_neg_byte_simple(uint8_t op) {
 	return 0-op;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_inc_word(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_inc_word(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_inc_word(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_inc_word(uint16_t op) {
 	LoadCF;
 	lf_var1w=op;
 	lf_resw=lf_var1w+1;
@@ -579,13 +579,13 @@ static Bit16u DRC_CALL_CONV dynrec_inc_word(Bit16u op) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_inc_word_simple(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_inc_word_simple(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_inc_word_simple(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_inc_word_simple(uint16_t op) {
 	return op+1;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_dec_word(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dec_word(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_dec_word(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dec_word(uint16_t op) {
 	LoadCF;
 	lf_var1w=op;
 	lf_resw=lf_var1w-1;
@@ -593,31 +593,31 @@ static Bit16u DRC_CALL_CONV dynrec_dec_word(Bit16u op) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_dec_word_simple(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dec_word_simple(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_dec_word_simple(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dec_word_simple(uint16_t op) {
 	return op-1;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_not_word(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_not_word(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_not_word(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_not_word(uint16_t op) {
 	return ~op;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_neg_word(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_neg_word(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_neg_word(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_neg_word(uint16_t op) {
 	lf_var1w=op;
 	lf_resw=0-lf_var1w;
 	lflags.type=t_NEGw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_neg_word_simple(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_neg_word_simple(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_neg_word_simple(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_neg_word_simple(uint16_t op) {
 	return 0-op;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_inc_dword(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_inc_dword(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_inc_dword(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_inc_dword(uint32_t op) {
 	LoadCF;
 	lf_var1d=op;
 	lf_resd=lf_var1d+1;
@@ -625,13 +625,13 @@ static Bit32u DRC_CALL_CONV dynrec_inc_dword(Bit32u op) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_inc_dword_simple(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_inc_dword_simple(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_inc_dword_simple(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_inc_dword_simple(uint32_t op) {
 	return op+1;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dec_dword(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dec_dword(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_dec_dword(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dec_dword(uint32_t op) {
 	LoadCF;
 	lf_var1d=op;
 	lf_resd=lf_var1d-1;
@@ -639,26 +639,26 @@ static Bit32u DRC_CALL_CONV dynrec_dec_dword(Bit32u op) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dec_dword_simple(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dec_dword_simple(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_dec_dword_simple(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dec_dword_simple(uint32_t op) {
 	return op-1;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_not_dword(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_not_dword(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_not_dword(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_not_dword(uint32_t op) {
 	return ~op;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_neg_dword(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_neg_dword(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_neg_dword(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_neg_dword(uint32_t op) {
 	lf_var1d=op;
 	lf_resd=0-lf_var1d;
 	lflags.type=t_NEGd;
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_neg_dword_simple(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_neg_dword_simple(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_neg_dword_simple(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_neg_dword_simple(uint32_t op) {
 	return 0-op;
 }
 
@@ -727,8 +727,8 @@ static void dyn_sop_word_gencall(SingleOps op,bool dword) {
 }
 
 
-static Bit8u DRC_CALL_CONV dynrec_rol_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_rol_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_rol_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_rol_byte(uint8_t op1,uint8_t op2) {
 	if (!(op2&0x7)) {
 		if (op2&0x18) {
 			FillFlagsNoCFOF();
@@ -746,14 +746,14 @@ static Bit8u DRC_CALL_CONV dynrec_rol_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_rol_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_rol_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_rol_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_rol_byte_simple(uint8_t op1,uint8_t op2) {
 	if (!(op2&0x7)) return op1;
 	return (op1 << (op2&0x07)) | (op1 >> (8-(op2&0x07)));
 }
 
-static Bit8u DRC_CALL_CONV dynrec_ror_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_ror_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_ror_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_ror_byte(uint8_t op1,uint8_t op2) {
 	if (!(op2&0x7)) {
 		if (op2&0x18) {
 			FillFlagsNoCFOF();
@@ -771,16 +771,16 @@ static Bit8u DRC_CALL_CONV dynrec_ror_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_ror_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_ror_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_ror_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_ror_byte_simple(uint8_t op1,uint8_t op2) {
 	if (!(op2&0x7)) return op1;
 	return (op1 >> (op2&0x07)) | (op1 << (8-(op2&0x07)));
 }
 
-static Bit8u DRC_CALL_CONV dynrec_rcl_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_rcl_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_rcl_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_rcl_byte(uint8_t op1,uint8_t op2) {
 	if (op2%9) {
-		Bit8u cf=(Bit8u)FillFlags()&0x1;
+		uint8_t cf=(uint8_t)FillFlags()&0x1;
 		lf_var1b=op1;
 		lf_var2b=op2%9;
 		lf_resb=(lf_var1b << lf_var2b) | (cf << (lf_var2b-1)) | (lf_var1b >> (9-lf_var2b));
@@ -790,10 +790,10 @@ static Bit8u DRC_CALL_CONV dynrec_rcl_byte(Bit8u op1,Bit8u op2) {
 	} else return op1;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_rcr_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_rcr_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_rcr_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_rcr_byte(uint8_t op1,uint8_t op2) {
 	if (op2%9) {
-		Bit8u cf=(Bit8u)FillFlags()&0x1;
+		uint8_t cf=(uint8_t)FillFlags()&0x1;
 		lf_var1b=op1;
 		lf_var2b=op2%9;
 		lf_resb = (lf_var1b >> lf_var2b) | (cf << (8 - lf_var2b)) |
@@ -804,8 +804,8 @@ static Bit8u DRC_CALL_CONV dynrec_rcr_byte(Bit8u op1,Bit8u op2) {
 	} else return op1;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_shl_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_shl_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_shl_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_shl_byte(uint8_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1b=op1;
 	lf_var2b=op2;
@@ -814,14 +814,14 @@ static Bit8u DRC_CALL_CONV dynrec_shl_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_shl_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_shl_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_shl_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_shl_byte_simple(uint8_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return op1 << op2;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_shr_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_shr_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_shr_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_shr_byte(uint8_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1b=op1;
 	lf_var2b=op2;
@@ -830,14 +830,14 @@ static Bit8u DRC_CALL_CONV dynrec_shr_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_shr_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_shr_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_shr_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_shr_byte_simple(uint8_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return op1 >> op2;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_sar_byte(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_sar_byte(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_sar_byte(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_sar_byte(uint8_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1b=op1;
 	lf_var2b=op2;
@@ -851,16 +851,16 @@ static Bit8u DRC_CALL_CONV dynrec_sar_byte(Bit8u op1,Bit8u op2) {
 	return lf_resb;
 }
 
-static Bit8u DRC_CALL_CONV dynrec_sar_byte_simple(Bit8u op1,Bit8u op2) DRC_FC;
-static Bit8u DRC_CALL_CONV dynrec_sar_byte_simple(Bit8u op1,Bit8u op2) {
+static uint8_t DRC_CALL_CONV dynrec_sar_byte_simple(uint8_t op1,uint8_t op2) DRC_FC;
+static uint8_t DRC_CALL_CONV dynrec_sar_byte_simple(uint8_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	if (op2>8) op2=8;
     if (op1 & 0x80) return (op1 >> op2) | (0xff << (8 - op2));
 	else return op1 >> op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_rol_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_rol_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_rol_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_rol_word(uint16_t op1,uint8_t op2) {
 	if (!(op2&0xf)) {
 		if (op2&0x10) {
 			FillFlagsNoCFOF();
@@ -878,14 +878,14 @@ static Bit16u DRC_CALL_CONV dynrec_rol_word(Bit16u op1,Bit8u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_rol_word_simple(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_rol_word_simple(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_rol_word_simple(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_rol_word_simple(uint16_t op1,uint8_t op2) {
 	if (!(op2&0xf)) return op1;
 	return (op1 << (op2&0xf)) | (op1 >> (16-(op2&0xf)));
 }
 
-static Bit16u DRC_CALL_CONV dynrec_ror_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_ror_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_ror_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_ror_word(uint16_t op1,uint8_t op2) {
 	if (!(op2&0xf)) {
 		if (op2&0x10) {
 			FillFlagsNoCFOF();
@@ -903,16 +903,16 @@ static Bit16u DRC_CALL_CONV dynrec_ror_word(Bit16u op1,Bit8u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_ror_word_simple(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_ror_word_simple(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_ror_word_simple(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_ror_word_simple(uint16_t op1,uint8_t op2) {
 	if (!(op2&0xf)) return op1;
 	return (op1 >> (op2&0xf)) | (op1 << (16-(op2&0xf)));
 }
 
-static Bit16u DRC_CALL_CONV dynrec_rcl_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_rcl_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_rcl_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_rcl_word(uint16_t op1,uint8_t op2) {
 	if (op2%17) {
-		Bit16u cf=(Bit16u)FillFlags()&0x1;
+		uint16_t cf=(uint16_t)FillFlags()&0x1;
 		lf_var1w=op1;
 		lf_var2b=op2%17;
 		lf_resw=(lf_var1w << lf_var2b) | (cf << (lf_var2b-1)) | (lf_var1w >> (17-lf_var2b));
@@ -922,10 +922,10 @@ static Bit16u DRC_CALL_CONV dynrec_rcl_word(Bit16u op1,Bit8u op2) {
 	} else return op1;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_rcr_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_rcr_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_rcr_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_rcr_word(uint16_t op1,uint8_t op2) {
 	if (op2%17) {
-		Bit16u cf=(Bit16u)FillFlags()&0x1;
+		uint16_t cf=(uint16_t)FillFlags()&0x1;
 		lf_var1w=op1;
 		lf_var2b=op2%17;
 	 	lf_resw=(lf_var1w >> lf_var2b) | (cf << (16-lf_var2b)) | (lf_var1w << (17-lf_var2b));
@@ -935,8 +935,8 @@ static Bit16u DRC_CALL_CONV dynrec_rcr_word(Bit16u op1,Bit8u op2) {
 	} else return op1;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_shl_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_shl_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_shl_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_shl_word(uint16_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1w=op1;
 	lf_var2b=op2;
@@ -945,14 +945,14 @@ static Bit16u DRC_CALL_CONV dynrec_shl_word(Bit16u op1,Bit8u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_shl_word_simple(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_shl_word_simple(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_shl_word_simple(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_shl_word_simple(uint16_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return op1 << op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_shr_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_shr_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_shr_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_shr_word(uint16_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1w=op1;
 	lf_var2b=op2;
@@ -961,14 +961,14 @@ static Bit16u DRC_CALL_CONV dynrec_shr_word(Bit16u op1,Bit8u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_shr_word_simple(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_shr_word_simple(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_shr_word_simple(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_shr_word_simple(uint16_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return op1 >> op2;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_sar_word(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_sar_word(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_sar_word(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_sar_word(uint16_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1w=op1;
 	lf_var2b=op2;
@@ -982,16 +982,16 @@ static Bit16u DRC_CALL_CONV dynrec_sar_word(Bit16u op1,Bit8u op2) {
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_sar_word_simple(Bit16u op1,Bit8u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_sar_word_simple(Bit16u op1,Bit8u op2) {
+static uint16_t DRC_CALL_CONV dynrec_sar_word_simple(uint16_t op1,uint8_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_sar_word_simple(uint16_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	if (op2>16) op2=16;
 	if (op1 & 0x8000) return (op1 >> op2) | (0xffff << (16 - op2));
 	else return op1 >> op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_rol_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_rol_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_rol_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_rol_dword(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	FillFlagsNoCFOF();
 	lf_var1d=op1;
@@ -1002,14 +1002,14 @@ static Bit32u DRC_CALL_CONV dynrec_rol_dword(Bit32u op1,Bit8u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_rol_dword_simple(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_rol_dword_simple(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_rol_dword_simple(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_rol_dword_simple(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return (op1 << op2) | (op1 >> (32-op2));
 }
 
-static Bit32u DRC_CALL_CONV dynrec_ror_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_ror_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_ror_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_ror_dword(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	FillFlagsNoCFOF();
 	lf_var1d=op1;
@@ -1020,16 +1020,16 @@ static Bit32u DRC_CALL_CONV dynrec_ror_dword(Bit32u op1,Bit8u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_ror_dword_simple(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_ror_dword_simple(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_ror_dword_simple(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_ror_dword_simple(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return (op1 >> op2) | (op1 << (32-op2));
 }
 
-static Bit32u DRC_CALL_CONV dynrec_rcl_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_rcl_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_rcl_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_rcl_dword(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
-	Bit32u cf=(Bit32u)FillFlags()&0x1;
+	uint32_t cf=(uint32_t)FillFlags()&0x1;
 	lf_var1d=op1;
 	lf_var2b=op2;
 	if (lf_var2b==1) {
@@ -1042,10 +1042,10 @@ static Bit32u DRC_CALL_CONV dynrec_rcl_dword(Bit32u op1,Bit8u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_rcr_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_rcr_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_rcr_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_rcr_dword(uint32_t op1,uint8_t op2) {
 	if (op2) {
-		Bit32u cf=(Bit32u)FillFlags()&0x1;
+		uint32_t cf=(uint32_t)FillFlags()&0x1;
 		lf_var1d=op1;
 		lf_var2b=op2;
 		if (lf_var2b==1) {
@@ -1059,8 +1059,8 @@ static Bit32u DRC_CALL_CONV dynrec_rcr_dword(Bit32u op1,Bit8u op2) {
 	} else return op1;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_shl_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_shl_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_shl_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_shl_dword(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1d=op1;
 	lf_var2b=op2;
@@ -1069,14 +1069,14 @@ static Bit32u DRC_CALL_CONV dynrec_shl_dword(Bit32u op1,Bit8u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_shl_dword_simple(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_shl_dword_simple(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_shl_dword_simple(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_shl_dword_simple(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return op1 << op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_shr_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_shr_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_shr_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_shr_dword(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var1d=op1;
 	lf_var2b=op2;
@@ -1085,14 +1085,14 @@ static Bit32u DRC_CALL_CONV dynrec_shr_dword(Bit32u op1,Bit8u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_shr_dword_simple(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_shr_dword_simple(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_shr_dword_simple(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_shr_dword_simple(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	return op1 >> op2;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_sar_dword(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_sar_dword(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_sar_dword(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_sar_dword(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	lf_var2b=op2;
 	lf_var1d=op1;
@@ -1105,8 +1105,8 @@ static Bit32u DRC_CALL_CONV dynrec_sar_dword(Bit32u op1,Bit8u op2) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_sar_dword_simple(Bit32u op1,Bit8u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_sar_dword_simple(Bit32u op1,Bit8u op2) {
+static uint32_t DRC_CALL_CONV dynrec_sar_dword_simple(uint32_t op1,uint8_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_sar_dword_simple(uint32_t op1,uint8_t op2) {
 	if (!op2) return op1;
 	if (op1 & 0x80000000) return (op1 >> op2) | (0xffffffff << (32 - op2));
 	else return op1 >> op2;
@@ -1217,31 +1217,31 @@ static void dyn_shift_word_gencall(ShiftOps op,bool dword) {
 	}
 }
 
-static Bit16u DRC_CALL_CONV dynrec_dshl_word(Bit16u op1,Bit16u op2,Bit8u op3) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dshl_word(Bit16u op1,Bit16u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint16_t DRC_CALL_CONV dynrec_dshl_word(uint16_t op1,uint16_t op2,uint8_t op3) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dshl_word(uint16_t op1,uint16_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
 	lf_var2b=val;
 	lf_var1d=(op1<<16)|op2;
-	Bit32u tempd=lf_var1d << lf_var2b;
+	uint32_t tempd=lf_var1d << lf_var2b;
   	if (lf_var2b>16) tempd |= (op2 << (lf_var2b - 16));
-	lf_resw=(Bit16u)(tempd >> 16);
+	lf_resw=(uint16_t)(tempd >> 16);
 	lflags.type=t_DSHLw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_dshl_word_simple(Bit16u op1,Bit16u op2,Bit8u op3) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dshl_word_simple(Bit16u op1,Bit16u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint16_t DRC_CALL_CONV dynrec_dshl_word_simple(uint16_t op1,uint16_t op2,uint8_t op3) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dshl_word_simple(uint16_t op1,uint16_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
-	Bit32u tempd=(Bit32u)((((Bit32u)op1)<<16)|op2) << val;
+	uint32_t tempd=(uint32_t)((((uint32_t)op1)<<16)|op2) << val;
   	if (val>16) tempd |= (op2 << (val - 16));
-	return (Bit16u)(tempd >> 16);
+	return (uint16_t)(tempd >> 16);
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dshl_dword(Bit32u op1,Bit32u op2,Bit8u op3) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dshl_dword(Bit32u op1,Bit32u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint32_t DRC_CALL_CONV dynrec_dshl_dword(uint32_t op1,uint32_t op2,uint8_t op3) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dshl_dword(uint32_t op1,uint32_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
 	lf_var2b=val;
 	lf_var1d=op1;
@@ -1250,38 +1250,38 @@ static Bit32u DRC_CALL_CONV dynrec_dshl_dword(Bit32u op1,Bit32u op2,Bit8u op3) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dshl_dword_simple(Bit32u op1,Bit32u op2,Bit8u op3) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dshl_dword_simple(Bit32u op1,Bit32u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint32_t DRC_CALL_CONV dynrec_dshl_dword_simple(uint32_t op1,uint32_t op2,uint8_t op3) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dshl_dword_simple(uint32_t op1,uint32_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
 	return (op1 << val) | (op2 >> (32-val));
 }
 
-static Bit16u DRC_CALL_CONV dynrec_dshr_word(Bit16u op1,Bit16u op2,Bit8u op3) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dshr_word(Bit16u op1,Bit16u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint16_t DRC_CALL_CONV dynrec_dshr_word(uint16_t op1,uint16_t op2,uint8_t op3) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dshr_word(uint16_t op1,uint16_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
 	lf_var2b=val;
 	lf_var1d=(op2<<16)|op1;
-	Bit32u tempd=lf_var1d >> lf_var2b;
+	uint32_t tempd=lf_var1d >> lf_var2b;
   	if (lf_var2b>16) tempd |= (op2 << (32-lf_var2b ));
-	lf_resw=(Bit16u)(tempd);
+	lf_resw=(uint16_t)(tempd);
 	lflags.type=t_DSHRw;
 	return lf_resw;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_dshr_word_simple(Bit16u op1,Bit16u op2,Bit8u op3) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dshr_word_simple(Bit16u op1,Bit16u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint16_t DRC_CALL_CONV dynrec_dshr_word_simple(uint16_t op1,uint16_t op2,uint8_t op3) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dshr_word_simple(uint16_t op1,uint16_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
-	Bit32u tempd=(Bit32u)((((Bit32u)op2)<<16)|op1) >> val;
+	uint32_t tempd=(uint32_t)((((uint32_t)op2)<<16)|op1) >> val;
   	if (val>16) tempd |= (op2 << (32-val));
-	return (Bit16u)(tempd);
+	return (uint16_t)(tempd);
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dshr_dword(Bit32u op1,Bit32u op2,Bit8u op3) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dshr_dword(Bit32u op1,Bit32u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint32_t DRC_CALL_CONV dynrec_dshr_dword(uint32_t op1,uint32_t op2,uint8_t op3) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dshr_dword(uint32_t op1,uint32_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
 	lf_var2b=val;
 	lf_var1d=op1;
@@ -1290,68 +1290,68 @@ static Bit32u DRC_CALL_CONV dynrec_dshr_dword(Bit32u op1,Bit32u op2,Bit8u op3) {
 	return lf_resd;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dshr_dword_simple(Bit32u op1,Bit32u op2,Bit8u op3) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dshr_dword_simple(Bit32u op1,Bit32u op2,Bit8u op3) {
-	Bit8u val=op3 & 0x1f;
+static uint32_t DRC_CALL_CONV dynrec_dshr_dword_simple(uint32_t op1,uint32_t op2,uint8_t op3) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dshr_dword_simple(uint32_t op1,uint32_t op2,uint8_t op3) {
+	uint8_t val=op3 & 0x1f;
 	if (!val) return op1;
 	return (op1 >> val) | (op2 << (32-val));
 }
 
 static void dyn_dpshift_word_gencall(bool left) {
 	if (left) {
-		const Bit8u* proc_addr=gen_call_function_R3((void*)&dynrec_dshl_word,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3((void*)&dynrec_dshl_word,FC_OP3);
 		InvalidateFlagsPartially((void*)&dynrec_dshl_word_simple,proc_addr,t_DSHLw);
 	} else {
-		const Bit8u* proc_addr=gen_call_function_R3((void*)&dynrec_dshr_word,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3((void*)&dynrec_dshr_word,FC_OP3);
 		InvalidateFlagsPartially((void*)&dynrec_dshr_word_simple,proc_addr,t_DSHRw);
 	}
 }
 
 static void dyn_dpshift_dword_gencall(bool left) {
 	if (left) {
-		const Bit8u* proc_addr=gen_call_function_R3((void*)&dynrec_dshl_dword,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3((void*)&dynrec_dshl_dword,FC_OP3);
 		InvalidateFlagsPartially((void*)&dynrec_dshl_dword_simple,proc_addr,t_DSHLd);
 	} else {
-		const Bit8u* proc_addr=gen_call_function_R3((void*)&dynrec_dshr_dword,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3((void*)&dynrec_dshr_dword,FC_OP3);
 		InvalidateFlagsPartially((void*)&dynrec_dshr_dword_simple,proc_addr,t_DSHRd);
 	}
 }
 
 
 
-static Bit32u DRC_CALL_CONV dynrec_get_of(void)		DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_of(void)		{ return TFLG_O; }
-static Bit32u DRC_CALL_CONV dynrec_get_nof(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_nof(void)	{ return TFLG_NO; }
-static Bit32u DRC_CALL_CONV dynrec_get_cf(void)		DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_cf(void)		{ return TFLG_B; }
-static Bit32u DRC_CALL_CONV dynrec_get_ncf(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_ncf(void)	{ return TFLG_NB; }
-static Bit32u DRC_CALL_CONV dynrec_get_zf(void)		DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_zf(void)		{ return TFLG_Z; }
-static Bit32u DRC_CALL_CONV dynrec_get_nzf(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_nzf(void)	{ return TFLG_NZ; }
-static Bit32u DRC_CALL_CONV dynrec_get_sf(void)		DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_sf(void)		{ return TFLG_S; }
-static Bit32u DRC_CALL_CONV dynrec_get_nsf(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_nsf(void)	{ return TFLG_NS; }
-static Bit32u DRC_CALL_CONV dynrec_get_pf(void)		DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_pf(void)		{ return TFLG_P; }
-static Bit32u DRC_CALL_CONV dynrec_get_npf(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_npf(void)	{ return TFLG_NP; }
+static uint32_t DRC_CALL_CONV dynrec_get_of(void)		DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_of(void)		{ return TFLG_O; }
+static uint32_t DRC_CALL_CONV dynrec_get_nof(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_nof(void)	{ return TFLG_NO; }
+static uint32_t DRC_CALL_CONV dynrec_get_cf(void)		DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_cf(void)		{ return TFLG_B; }
+static uint32_t DRC_CALL_CONV dynrec_get_ncf(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_ncf(void)	{ return TFLG_NB; }
+static uint32_t DRC_CALL_CONV dynrec_get_zf(void)		DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_zf(void)		{ return TFLG_Z; }
+static uint32_t DRC_CALL_CONV dynrec_get_nzf(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_nzf(void)	{ return TFLG_NZ; }
+static uint32_t DRC_CALL_CONV dynrec_get_sf(void)		DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_sf(void)		{ return TFLG_S; }
+static uint32_t DRC_CALL_CONV dynrec_get_nsf(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_nsf(void)	{ return TFLG_NS; }
+static uint32_t DRC_CALL_CONV dynrec_get_pf(void)		DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_pf(void)		{ return TFLG_P; }
+static uint32_t DRC_CALL_CONV dynrec_get_npf(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_npf(void)	{ return TFLG_NP; }
 
-static Bit32u DRC_CALL_CONV dynrec_get_cf_or_zf(void)			DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_cf_or_zf(void)			{ return TFLG_BE; }
-static Bit32u DRC_CALL_CONV dynrec_get_ncf_and_nzf(void)		DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_ncf_and_nzf(void)		{ return TFLG_NBE; }
-static Bit32u DRC_CALL_CONV dynrec_get_sf_neq_of(void)			DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_sf_neq_of(void)			{ return TFLG_L; }
-static Bit32u DRC_CALL_CONV dynrec_get_sf_eq_of(void)			DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_sf_eq_of(void)			{ return TFLG_NL; }
-static Bit32u DRC_CALL_CONV dynrec_get_zf_or_sf_neq_of(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_zf_or_sf_neq_of(void)	{ return TFLG_LE; }
-static Bit32u DRC_CALL_CONV dynrec_get_nzf_and_sf_eq_of(void)	DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_get_nzf_and_sf_eq_of(void)	{ return TFLG_NLE; }
+static uint32_t DRC_CALL_CONV dynrec_get_cf_or_zf(void)			DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_cf_or_zf(void)			{ return TFLG_BE; }
+static uint32_t DRC_CALL_CONV dynrec_get_ncf_and_nzf(void)		DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_ncf_and_nzf(void)		{ return TFLG_NBE; }
+static uint32_t DRC_CALL_CONV dynrec_get_sf_neq_of(void)			DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_sf_neq_of(void)			{ return TFLG_L; }
+static uint32_t DRC_CALL_CONV dynrec_get_sf_eq_of(void)			DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_sf_eq_of(void)			{ return TFLG_NL; }
+static uint32_t DRC_CALL_CONV dynrec_get_zf_or_sf_neq_of(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_zf_or_sf_neq_of(void)	{ return TFLG_LE; }
+static uint32_t DRC_CALL_CONV dynrec_get_nzf_and_sf_eq_of(void)	DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_get_nzf_and_sf_eq_of(void)	{ return TFLG_NLE; }
 
 
 static void dyn_branchflag_to_reg(BranchTypes btype) {
@@ -1377,8 +1377,8 @@ static void dyn_branchflag_to_reg(BranchTypes btype) {
 }
 
 
-static void DRC_CALL_CONV dynrec_mul_byte(Bit8u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_mul_byte(Bit8u op) {
+static void DRC_CALL_CONV dynrec_mul_byte(uint8_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_mul_byte(uint8_t op) {
 	FillFlagsNoCFOF();
 	reg_ax=reg_al*op;
 	SETFLAGBIT(ZF,reg_al == 0);
@@ -1391,10 +1391,10 @@ static void DRC_CALL_CONV dynrec_mul_byte(Bit8u op) {
 	}
 }
 
-static void DRC_CALL_CONV dynrec_imul_byte(Bit8u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_imul_byte(Bit8u op) {
+static void DRC_CALL_CONV dynrec_imul_byte(uint8_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_imul_byte(uint8_t op) {
 	FillFlagsNoCFOF();
-	reg_ax=((Bit8s)reg_al) * ((Bit8s)op);
+	reg_ax=((int8_t)reg_al) * ((int8_t)op);
 	if ((reg_ax & 0xff80)==0xff80 || (reg_ax & 0xff80)==0x0000) {
 		SETFLAGBIT(CF,false);
 		SETFLAGBIT(OF,false);
@@ -1404,12 +1404,12 @@ static void DRC_CALL_CONV dynrec_imul_byte(Bit8u op) {
 	}
 }
 
-static void DRC_CALL_CONV dynrec_mul_word(Bit16u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_mul_word(Bit16u op) {
+static void DRC_CALL_CONV dynrec_mul_word(uint16_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_mul_word(uint16_t op) {
 	FillFlagsNoCFOF();
 	Bitu tempu=(Bitu)reg_ax*(Bitu)op;
-	reg_ax=(Bit16u)(tempu);
-	reg_dx=(Bit16u)(tempu >> 16);
+	reg_ax=(uint16_t)(tempu);
+	reg_dx=(uint16_t)(tempu >> 16);
 	SETFLAGBIT(ZF,reg_ax == 0);
 	if (reg_dx) {
 		SETFLAGBIT(CF,true);
@@ -1420,12 +1420,12 @@ static void DRC_CALL_CONV dynrec_mul_word(Bit16u op) {
 	}
 }
 
-static void DRC_CALL_CONV dynrec_imul_word(Bit16u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_imul_word(Bit16u op) {
+static void DRC_CALL_CONV dynrec_imul_word(uint16_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_imul_word(uint16_t op) {
 	FillFlagsNoCFOF();
-	Bits temps=((Bit16s)reg_ax)*((Bit16s)op);
-	reg_ax=(Bit16s)(temps);
-	reg_dx=(Bit16s)(temps >> 16);
+	Bits temps=((int16_t)reg_ax)*((int16_t)op);
+	reg_ax=(int16_t)(temps);
+	reg_dx=(int16_t)(temps >> 16);
 	if (((temps & 0xffff8000)==0xffff8000 || (temps & 0xffff8000)==0x0000)) {
 		SETFLAGBIT(CF,false);
 		SETFLAGBIT(OF,false);
@@ -1435,12 +1435,12 @@ static void DRC_CALL_CONV dynrec_imul_word(Bit16u op) {
 	}
 }
 
-static void DRC_CALL_CONV dynrec_mul_dword(Bit32u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_mul_dword(Bit32u op) {
+static void DRC_CALL_CONV dynrec_mul_dword(uint32_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_mul_dword(uint32_t op) {
 	FillFlagsNoCFOF();
-	Bit64u tempu=(Bit64u)reg_eax*(Bit64u)op;
-	reg_eax=(Bit32u)(tempu);
-	reg_edx=(Bit32u)(tempu >> 32);
+	uint64_t tempu=(uint64_t)reg_eax*(uint64_t)op;
+	reg_eax=(uint32_t)(tempu);
+	reg_edx=(uint32_t)(tempu >> 32);
 	SETFLAGBIT(ZF,reg_eax == 0);
 	if (reg_edx) {
 		SETFLAGBIT(CF,true);
@@ -1451,12 +1451,12 @@ static void DRC_CALL_CONV dynrec_mul_dword(Bit32u op) {
 	}
 }
 
-static void DRC_CALL_CONV dynrec_imul_dword(Bit32u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_imul_dword(Bit32u op) {
+static void DRC_CALL_CONV dynrec_imul_dword(uint32_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_imul_dword(uint32_t op) {
 	FillFlagsNoCFOF();
-	Bit64s temps=((Bit64s)((Bit32s)reg_eax))*((Bit64s)((Bit32s)op));
-	reg_eax=(Bit32u)(temps);
-	reg_edx=(Bit32u)(temps >> 32);
+	int64_t temps=((int64_t)((int32_t)reg_eax))*((int64_t)((int32_t)op));
+	reg_eax=(uint32_t)(temps);
+	reg_edx=(uint32_t)(temps >> 32);
 	if ((reg_edx==0xffffffff) && (reg_eax & 0x80000000) ) {
 		SETFLAGBIT(CF,false);
 		SETFLAGBIT(OF,false);
@@ -1470,93 +1470,93 @@ static void DRC_CALL_CONV dynrec_imul_dword(Bit32u op) {
 }
 
 
-static bool DRC_CALL_CONV dynrec_div_byte(Bit8u op) DRC_FC;
-static bool DRC_CALL_CONV dynrec_div_byte(Bit8u op) {
+static bool DRC_CALL_CONV dynrec_div_byte(uint8_t op) DRC_FC;
+static bool DRC_CALL_CONV dynrec_div_byte(uint8_t op) {
 	Bitu val=op;
 	if (val==0) return CPU_PrepareException(0,0);
 	Bitu quo=reg_ax / val;
-	Bit8u rem=(Bit8u)(reg_ax % val);
-	Bit8u quo8=(Bit8u)(quo&0xff);
+	uint8_t rem=(uint8_t)(reg_ax % val);
+	uint8_t quo8=(uint8_t)(quo&0xff);
 	if (quo>0xff) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8;
 	return false;
 }
 
-static bool DRC_CALL_CONV dynrec_idiv_byte(Bit8u op) DRC_FC;
-static bool DRC_CALL_CONV dynrec_idiv_byte(Bit8u op) {
-	Bits val=(Bit8s)op;
+static bool DRC_CALL_CONV dynrec_idiv_byte(uint8_t op) DRC_FC;
+static bool DRC_CALL_CONV dynrec_idiv_byte(uint8_t op) {
+	Bits val=(int8_t)op;
 	if (val==0) return CPU_PrepareException(0,0);
-	Bits quo=((Bit16s)reg_ax) / val;
-	Bit8s rem=(Bit8s)((Bit16s)reg_ax % val);
-	Bit8s quo8s=(Bit8s)(quo&0xff);
-	if (quo!=(Bit16s)quo8s) return CPU_PrepareException(0,0);
+	Bits quo=((int16_t)reg_ax) / val;
+	int8_t rem=(int8_t)((int16_t)reg_ax % val);
+	int8_t quo8s=(int8_t)(quo&0xff);
+	if (quo!=(int16_t)quo8s) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8s;
 	return false;
 }
 
-static bool DRC_CALL_CONV dynrec_div_word(Bit16u op) DRC_FC;
-static bool DRC_CALL_CONV dynrec_div_word(Bit16u op) {
+static bool DRC_CALL_CONV dynrec_div_word(uint16_t op) DRC_FC;
+static bool DRC_CALL_CONV dynrec_div_word(uint16_t op) {
 	Bitu val=op;
 	if (val==0)	return CPU_PrepareException(0,0);
-	Bitu num=((Bit32u)reg_dx<<16)|reg_ax;
+	Bitu num=((uint32_t)reg_dx<<16)|reg_ax;
 	Bitu quo=num/val;
-	Bit16u rem=(Bit16u)(num % val);
-	Bit16u quo16=(Bit16u)(quo&0xffff);
-	if (quo!=(Bit32u)quo16) return CPU_PrepareException(0,0);
+	uint16_t rem=(uint16_t)(num % val);
+	uint16_t quo16=(uint16_t)(quo&0xffff);
+	if (quo!=(uint32_t)quo16) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16;
 	return false;
 }
 
-static bool DRC_CALL_CONV dynrec_idiv_word(Bit16u op) DRC_FC;
-static bool DRC_CALL_CONV dynrec_idiv_word(Bit16u op) {
-	Bits val=(Bit16s)op;
+static bool DRC_CALL_CONV dynrec_idiv_word(uint16_t op) DRC_FC;
+static bool DRC_CALL_CONV dynrec_idiv_word(uint16_t op) {
+	Bits val=(int16_t)op;
 	if (val==0) return CPU_PrepareException(0,0);
-	Bits num=(Bit32s)((reg_dx<<16)|reg_ax);
+	Bits num=(int32_t)((reg_dx<<16)|reg_ax);
 	Bits quo=num/val;
-	Bit16s rem=(Bit16s)(num % val);
-	Bit16s quo16s=(Bit16s)quo;
-	if (quo!=(Bit32s)quo16s) return CPU_PrepareException(0,0);
+	int16_t rem=(int16_t)(num % val);
+	int16_t quo16s=(int16_t)quo;
+	if (quo!=(int32_t)quo16s) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16s;
 	return false;
 }
 
-static bool DRC_CALL_CONV dynrec_div_dword(Bit32u op) DRC_FC;
-static bool DRC_CALL_CONV dynrec_div_dword(Bit32u op) {
+static bool DRC_CALL_CONV dynrec_div_dword(uint32_t op) DRC_FC;
+static bool DRC_CALL_CONV dynrec_div_dword(uint32_t op) {
 	Bitu val=op;
 	if (val==0) return CPU_PrepareException(0,0);
-	Bit64u num=(((Bit64u)reg_edx)<<32)|reg_eax;
-	Bit64u quo=num/val;
-	Bit32u rem=(Bit32u)(num % val);
-	Bit32u quo32=(Bit32u)(quo&0xffffffff);
-	if (quo!=(Bit64u)quo32) return CPU_PrepareException(0,0);
+	uint64_t num=(((uint64_t)reg_edx)<<32)|reg_eax;
+	uint64_t quo=num/val;
+	uint32_t rem=(uint32_t)(num % val);
+	uint32_t quo32=(uint32_t)(quo&0xffffffff);
+	if (quo!=(uint64_t)quo32) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32;
 	return false;
 }
 
-static bool DRC_CALL_CONV dynrec_idiv_dword(Bit32u op) DRC_FC;
-static bool DRC_CALL_CONV dynrec_idiv_dword(Bit32u op) {
-	Bits val=(Bit32s)op;
+static bool DRC_CALL_CONV dynrec_idiv_dword(uint32_t op) DRC_FC;
+static bool DRC_CALL_CONV dynrec_idiv_dword(uint32_t op) {
+	Bits val=(int32_t)op;
 	if (val==0) return CPU_PrepareException(0,0);
-	Bit64s num=(((Bit64u)reg_edx)<<32)|reg_eax;	
-	Bit64s quo=num/val;
-	Bit32s rem=(Bit32s)(num % val);
-	Bit32s quo32s=(Bit32s)(quo&0xffffffff);
-	if (quo!=(Bit64s)quo32s) return CPU_PrepareException(0,0);
+	int64_t num=(((uint64_t)reg_edx)<<32)|reg_eax;	
+	int64_t quo=num/val;
+	int32_t rem=(int32_t)(num % val);
+	int32_t quo32s=(int32_t)(quo&0xffffffff);
+	if (quo!=(int64_t)quo32s) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32s;
 	return false;
 }
 
 
-static Bit16u DRC_CALL_CONV dynrec_dimul_word(Bit16u op1,Bit16u op2) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_dimul_word(Bit16u op1,Bit16u op2) {
+static uint16_t DRC_CALL_CONV dynrec_dimul_word(uint16_t op1,uint16_t op2) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_dimul_word(uint16_t op1,uint16_t op2) {
 	FillFlagsNoCFOF();
-	Bits res=((Bit16s)op1) * ((Bit16s)op2);
+	Bits res=((int16_t)op1) * ((int16_t)op2);
 	if ((res>-32768)  && (res<32767)) {
 		SETFLAGBIT(CF,false);
 		SETFLAGBIT(OF,false);
@@ -1564,50 +1564,50 @@ static Bit16u DRC_CALL_CONV dynrec_dimul_word(Bit16u op1,Bit16u op2) {
 		SETFLAGBIT(CF,true);
 		SETFLAGBIT(OF,true);
 	}
-	return (Bit16u)(res & 0xffff);
+	return (uint16_t)(res & 0xffff);
 }
 
-static Bit32u DRC_CALL_CONV dynrec_dimul_dword(Bit32u op1,Bit32u op2) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_dimul_dword(Bit32u op1,Bit32u op2) {
+static uint32_t DRC_CALL_CONV dynrec_dimul_dword(uint32_t op1,uint32_t op2) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_dimul_dword(uint32_t op1,uint32_t op2) {
 	FillFlagsNoCFOF();
-	Bit64s res=((Bit64s)((Bit32s)op1))*((Bit64s)((Bit32s)op2));
-	if ((res>-((Bit64s)(2147483647)+1)) && (res<(Bit64s)2147483647)) {
+	int64_t res=((int64_t)((int32_t)op1))*((int64_t)((int32_t)op2));
+	if ((res>-((int64_t)(2147483647)+1)) && (res<(int64_t)2147483647)) {
 		SETFLAGBIT(CF,false);
 		SETFLAGBIT(OF,false);
 	} else {
 		SETFLAGBIT(CF,true);
 		SETFLAGBIT(OF,true);
 	}
-	return (Bit32s)res;
+	return (int32_t)res;
 }
 
 
 
-static Bit16u DRC_CALL_CONV dynrec_cbw(Bit8u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_cbw(Bit8u op) {
-	return (Bit8s)op;
+static uint16_t DRC_CALL_CONV dynrec_cbw(uint8_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_cbw(uint8_t op) {
+	return (int8_t)op;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_cwde(Bit16u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_cwde(Bit16u op) {
-	return (Bit16s)op;
+static uint32_t DRC_CALL_CONV dynrec_cwde(uint16_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_cwde(uint16_t op) {
+	return (int16_t)op;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_cwd(Bit16u op) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_cwd(Bit16u op) {
+static uint16_t DRC_CALL_CONV dynrec_cwd(uint16_t op) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_cwd(uint16_t op) {
 	if (op & 0x8000) return 0xffff;
 	else return 0;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_cdq(Bit32u op) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_cdq(Bit32u op) {
+static uint32_t DRC_CALL_CONV dynrec_cdq(uint32_t op) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_cdq(uint32_t op) {
 	if (op & 0x80000000) return 0xffffffff;
 	else return 0;
 }
 
 
-static void DRC_CALL_CONV dynrec_sahf(Bit16u op) DRC_FC;
-static void DRC_CALL_CONV dynrec_sahf(Bit16u op) {
+static void DRC_CALL_CONV dynrec_sahf(uint16_t op) DRC_FC;
+static void DRC_CALL_CONV dynrec_sahf(uint16_t op) {
 	SETFLAGBIT(OF,get_OF());
 	lflags.type=t_UNKNOWN;
 	CPU_SetFlags(op>>8,FMASK_NORMAL & 0xff);
@@ -1641,14 +1641,14 @@ static void DRC_CALL_CONV dynrec_std(void) {
 }
 
 
-static Bit16u DRC_CALL_CONV dynrec_movsb_word(Bit16u count,Bit16s add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_movsb_word(Bit16u count,Bit16s add_index,PhysPt si_base,PhysPt di_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_movsb_word(uint16_t count,int16_t add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_movsb_word(uint16_t count,int16_t add_index,PhysPt si_base,PhysPt di_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	for (;count>0;count--) {
@@ -1659,9 +1659,9 @@ static Bit16u DRC_CALL_CONV dynrec_movsb_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_movsb_dword(Bit32u count,Bit32s add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_movsb_dword(Bit32u count,Bit32s add_index,PhysPt si_base,PhysPt di_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_movsb_dword(uint32_t count,int32_t add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_movsb_dword(uint32_t count,int32_t add_index,PhysPt si_base,PhysPt di_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1677,14 +1677,14 @@ static Bit32u DRC_CALL_CONV dynrec_movsb_dword(Bit32u count,Bit32s add_index,Phy
 	return count_left;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_movsw_word(Bit16u count,Bit16s add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_movsw_word(Bit16u count,Bit16s add_index,PhysPt si_base,PhysPt di_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_movsw_word(uint16_t count,int16_t add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_movsw_word(uint16_t count,int16_t add_index,PhysPt si_base,PhysPt di_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=1;
@@ -1696,9 +1696,9 @@ static Bit16u DRC_CALL_CONV dynrec_movsw_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_movsw_dword(Bit32u count,Bit32s add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_movsw_dword(Bit32u count,Bit32s add_index,PhysPt si_base,PhysPt di_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_movsw_dword(uint32_t count,int32_t add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_movsw_dword(uint32_t count,int32_t add_index,PhysPt si_base,PhysPt di_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1715,14 +1715,14 @@ static Bit32u DRC_CALL_CONV dynrec_movsw_dword(Bit32u count,Bit32s add_index,Phy
 	return count_left;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_movsd_word(Bit16u count,Bit16s add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_movsd_word(Bit16u count,Bit16s add_index,PhysPt si_base,PhysPt di_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_movsd_word(uint16_t count,int16_t add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_movsd_word(uint16_t count,int16_t add_index,PhysPt si_base,PhysPt di_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=2;
@@ -1734,9 +1734,9 @@ static Bit16u DRC_CALL_CONV dynrec_movsd_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_movsd_dword(Bit32u count,Bit32s add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_movsd_dword(Bit32u count,Bit32s add_index,PhysPt si_base,PhysPt di_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_movsd_dword(uint32_t count,int32_t add_index,PhysPt si_base,PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_movsd_dword(uint32_t count,int32_t add_index,PhysPt si_base,PhysPt di_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1754,14 +1754,14 @@ static Bit32u DRC_CALL_CONV dynrec_movsd_dword(Bit32u count,Bit32s add_index,Phy
 }
 
 
-static Bit16u DRC_CALL_CONV dynrec_lodsb_word(Bit16u count,Bit16s add_index,PhysPt si_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_lodsb_word(Bit16u count,Bit16s add_index,PhysPt si_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_lodsb_word(uint16_t count,int16_t add_index,PhysPt si_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_lodsb_word(uint16_t count,int16_t add_index,PhysPt si_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	for (;count>0;count--) {
@@ -1771,9 +1771,9 @@ static Bit16u DRC_CALL_CONV dynrec_lodsb_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_lodsb_dword(Bit32u count,Bit32s add_index,PhysPt si_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_lodsb_dword(Bit32u count,Bit32s add_index,PhysPt si_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_lodsb_dword(uint32_t count,int32_t add_index,PhysPt si_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_lodsb_dword(uint32_t count,int32_t add_index,PhysPt si_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1788,14 +1788,14 @@ static Bit32u DRC_CALL_CONV dynrec_lodsb_dword(Bit32u count,Bit32s add_index,Phy
 	return count_left;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_lodsw_word(Bit16u count,Bit16s add_index,PhysPt si_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_lodsw_word(Bit16u count,Bit16s add_index,PhysPt si_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_lodsw_word(uint16_t count,int16_t add_index,PhysPt si_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_lodsw_word(uint16_t count,int16_t add_index,PhysPt si_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=1;
@@ -1806,9 +1806,9 @@ static Bit16u DRC_CALL_CONV dynrec_lodsw_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_lodsw_dword(Bit32u count,Bit32s add_index,PhysPt si_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_lodsw_dword(Bit32u count,Bit32s add_index,PhysPt si_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_lodsw_dword(uint32_t count,int32_t add_index,PhysPt si_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_lodsw_dword(uint32_t count,int32_t add_index,PhysPt si_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1824,14 +1824,14 @@ static Bit32u DRC_CALL_CONV dynrec_lodsw_dword(Bit32u count,Bit32s add_index,Phy
 	return count_left;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_lodsd_word(Bit16u count,Bit16s add_index,PhysPt si_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_lodsd_word(Bit16u count,Bit16s add_index,PhysPt si_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_lodsd_word(uint16_t count,int16_t add_index,PhysPt si_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_lodsd_word(uint16_t count,int16_t add_index,PhysPt si_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=2;
@@ -1842,9 +1842,9 @@ static Bit16u DRC_CALL_CONV dynrec_lodsd_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_lodsd_dword(Bit32u count,Bit32s add_index,PhysPt si_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_lodsd_dword(Bit32u count,Bit32s add_index,PhysPt si_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_lodsd_dword(uint32_t count,int32_t add_index,PhysPt si_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_lodsd_dword(uint32_t count,int32_t add_index,PhysPt si_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1861,14 +1861,14 @@ static Bit32u DRC_CALL_CONV dynrec_lodsd_dword(Bit32u count,Bit32s add_index,Phy
 }
 
 
-static Bit16u DRC_CALL_CONV dynrec_stosb_word(Bit16u count,Bit16s add_index,PhysPt di_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_stosb_word(Bit16u count,Bit16s add_index,PhysPt di_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_stosb_word(uint16_t count,int16_t add_index,PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_stosb_word(uint16_t count,int16_t add_index,PhysPt di_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	for (;count>0;count--) {
@@ -1878,9 +1878,9 @@ static Bit16u DRC_CALL_CONV dynrec_stosb_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_stosb_dword(Bit32u count,Bit32s add_index,PhysPt di_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_stosb_dword(Bit32u count,Bit32s add_index,PhysPt di_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_stosb_dword(uint32_t count,int32_t add_index,PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_stosb_dword(uint32_t count,int32_t add_index,PhysPt di_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1895,14 +1895,14 @@ static Bit32u DRC_CALL_CONV dynrec_stosb_dword(Bit32u count,Bit32s add_index,Phy
 	return count_left;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_stosw_word(Bit16u count,Bit16s add_index,PhysPt di_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_stosw_word(Bit16u count,Bit16s add_index,PhysPt di_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_stosw_word(uint16_t count,int16_t add_index,PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_stosw_word(uint16_t count,int16_t add_index,PhysPt di_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=1;
@@ -1913,9 +1913,9 @@ static Bit16u DRC_CALL_CONV dynrec_stosw_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_stosw_dword(Bit32u count,Bit32s add_index,PhysPt di_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_stosw_dword(Bit32u count,Bit32s add_index,PhysPt di_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_stosw_dword(uint32_t count,int32_t add_index,PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_stosw_dword(uint32_t count,int32_t add_index,PhysPt di_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1931,14 +1931,14 @@ static Bit32u DRC_CALL_CONV dynrec_stosw_dword(Bit32u count,Bit32s add_index,Phy
 	return count_left;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_stosd_word(Bit16u count,Bit16s add_index,PhysPt di_base) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_stosd_word(Bit16u count,Bit16s add_index,PhysPt di_base) {
-	Bit16u count_left;
+static uint16_t DRC_CALL_CONV dynrec_stosd_word(uint16_t count,int16_t add_index,PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_stosd_word(uint16_t count,int16_t add_index,PhysPt di_base) {
+	uint16_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=(Bit16u)(count-CPU_Cycles);
-		count=(Bit16u)CPU_Cycles;
+		count_left=(uint16_t)(count-CPU_Cycles);
+		count=(uint16_t)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=2;
@@ -1949,9 +1949,9 @@ static Bit16u DRC_CALL_CONV dynrec_stosd_word(Bit16u count,Bit16s add_index,Phys
 	return count_left;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_stosd_dword(Bit32u count,Bit32s add_index,PhysPt di_base) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_stosd_dword(Bit32u count,Bit32s add_index,PhysPt di_base) {
-	Bit32u count_left;
+static uint32_t DRC_CALL_CONV dynrec_stosd_dword(uint32_t count,int32_t add_index,PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_stosd_dword(uint32_t count,int32_t add_index,PhysPt di_base) {
+	uint32_t count_left;
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
@@ -1968,30 +1968,30 @@ static Bit32u DRC_CALL_CONV dynrec_stosd_dword(Bit32u count,Bit32s add_index,Phy
 }
 
 
-static void DRC_CALL_CONV dynrec_push_word(Bit16u value) DRC_FC;
-static void DRC_CALL_CONV dynrec_push_word(Bit16u value) {
-	Bit32u new_esp=(reg_esp&cpu.stack.notmask)|((reg_esp-2)&cpu.stack.mask);
+static void DRC_CALL_CONV dynrec_push_word(uint16_t value) DRC_FC;
+static void DRC_CALL_CONV dynrec_push_word(uint16_t value) {
+	uint32_t new_esp=(reg_esp&cpu.stack.notmask)|((reg_esp-2)&cpu.stack.mask);
 	mem_writew(SegPhys(ss) + (new_esp & cpu.stack.mask),value);
 	reg_esp=new_esp;
 }
 
-static void DRC_CALL_CONV dynrec_push_dword(Bit32u value) DRC_FC;
-static void DRC_CALL_CONV dynrec_push_dword(Bit32u value) {
-	Bit32u new_esp=(reg_esp&cpu.stack.notmask)|((reg_esp-4)&cpu.stack.mask);
+static void DRC_CALL_CONV dynrec_push_dword(uint32_t value) DRC_FC;
+static void DRC_CALL_CONV dynrec_push_dword(uint32_t value) {
+	uint32_t new_esp=(reg_esp&cpu.stack.notmask)|((reg_esp-4)&cpu.stack.mask);
 	mem_writed(SegPhys(ss) + (new_esp & cpu.stack.mask) ,value);
 	reg_esp=new_esp;
 }
 
-static Bit16u DRC_CALL_CONV dynrec_pop_word(void) DRC_FC;
-static Bit16u DRC_CALL_CONV dynrec_pop_word(void) {
-	Bit16u val=mem_readw(SegPhys(ss) + (reg_esp & cpu.stack.mask));
+static uint16_t DRC_CALL_CONV dynrec_pop_word(void) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_pop_word(void) {
+	uint16_t val=mem_readw(SegPhys(ss) + (reg_esp & cpu.stack.mask));
 	reg_esp=(reg_esp&cpu.stack.notmask)|((reg_esp+2)&cpu.stack.mask);
 	return val;
 }
 
-static Bit32u DRC_CALL_CONV dynrec_pop_dword(void) DRC_FC;
-static Bit32u DRC_CALL_CONV dynrec_pop_dword(void) {
-	Bit32u val=mem_readd(SegPhys(ss) + (reg_esp & cpu.stack.mask));
+static uint32_t DRC_CALL_CONV dynrec_pop_dword(void) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_pop_dword(void) {
+	uint32_t val=mem_readd(SegPhys(ss) + (reg_esp & cpu.stack.mask));
 	reg_esp=(reg_esp&cpu.stack.notmask)|((reg_esp+4)&cpu.stack.mask);
 	return val;
 }
@@ -2020,20 +2020,20 @@ static bool DRC_CALL_CONV dynrec_io_writeD(Bitu port) {
 static bool DRC_CALL_CONV dynrec_io_readB(Bitu port) DRC_FC;
 static bool DRC_CALL_CONV dynrec_io_readB(Bitu port) {
 	bool ex = CPU_IO_Exception(port,1);
-	if (!ex) reg_al = (Bit8u)IO_ReadB(port);
+	if (!ex) reg_al = (uint8_t)IO_ReadB(port);
 	return ex;
 }
 
 static bool DRC_CALL_CONV dynrec_io_readW(Bitu port) DRC_FC;
 static bool DRC_CALL_CONV dynrec_io_readW(Bitu port) {
 	bool ex = CPU_IO_Exception(port,2);
-	if (!ex) reg_ax = (Bit16u)IO_ReadW(port);
+	if (!ex) reg_ax = (uint16_t)IO_ReadW(port);
 	return ex;
 }
 
 static bool DRC_CALL_CONV dynrec_io_readD(Bitu port) DRC_FC;
 static bool DRC_CALL_CONV dynrec_io_readD(Bitu port) {
 	bool ex = CPU_IO_Exception(port,4);
-	if (!ex) reg_eax = (Bit32u)IO_ReadD(port);
+	if (!ex) reg_eax = (uint32_t)IO_ReadD(port);
 	return ex;
 }

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -39,7 +39,7 @@
 #define DRC_USE_SEGS_ADDR
 
 // register mapping
-typedef Bit8u HostReg;
+typedef uint8_t HostReg;
 
 // "lo" registers
 #define HOST_r0		 0
@@ -80,4 +80,4 @@ typedef Bit8u HostReg;
 #define HOST_lr HOST_r14
 #define HOST_pc HOST_r15
 
-static void cache_block_closing([[maybe_unused]] const Bit8u *block_start, [[maybe_unused]] Bitu block_size) { }
+static void cache_block_closing([[maybe_unused]] const uint8_t *block_start, [[maybe_unused]] Bitu block_size) { }

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -201,8 +201,8 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 }
 
 // helper function
-static bool val_is_operand2(Bit32u value, Bit32u *val_shift) {
-	Bit32u shift;
+static bool val_is_operand2(uint32_t value, uint32_t *val_shift) {
+	uint32_t shift;
 
 	if (GCC_UNLIKELY(value == 0)) {
 		*val_shift = 0;
@@ -223,7 +223,7 @@ static bool val_is_operand2(Bit32u value, Bit32u *val_shift) {
 
 #if C_TARGETCPU != ARMV7LE
 // helper function
-static Bits get_imm_gen_len(Bit32u imm) {
+static Bits get_imm_gen_len(uint32_t imm) {
 	Bits ret;
 	if (imm == 0) {
 		return 1;
@@ -241,7 +241,7 @@ static Bits get_imm_gen_len(Bit32u imm) {
 }
 
 // helper function
-static Bits get_min_imm_gen_len(Bit32u imm) {
+static Bits get_min_imm_gen_len(uint32_t imm) {
 	Bits num1, num2;
 
 	num1 = get_imm_gen_len(imm);
@@ -252,9 +252,9 @@ static Bits get_min_imm_gen_len(Bit32u imm) {
 #endif
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
 #if C_TARGETCPU == ARMV7LE
-	Bit32u scale;
+	uint32_t scale;
 
 	if ( val_is_operand2(imm, &scale) ) {
 		cache_addd( MOV_IMM(dest_reg, imm >> scale, ROTATE_SCALE(scale)) );      // mov dest_reg, #imm
@@ -269,7 +269,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 		}
 	}
 #else
-	Bit32u imm2, first, scale;
+	uint32_t imm2, first, scale;
 
 	scale = 0;
 	first = 1;
@@ -318,7 +318,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 }
 
 // helper function
-static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
@@ -364,9 +364,9 @@ static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu siz
 
 // helper function
 static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -375,8 +375,8 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg, [[maybe_unused]] void* 
 	// alignment....
 	if (dword) {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
-		if ((Bit32u)data & 3) {
-			if ( ((Bit32u)data & 3) == 2 ) {
+		if ((uint32_t)data & 3) {
+			if ( ((uint32_t)data & 3) == 2 ) {
 				cache_addd( LDRH_IMM(dest_reg, data_reg, 0) );      // ldrh dest_reg, [data_reg]
 				cache_addd( LDRH_IMM(temp2, data_reg, 2) );      // ldrh temp2, [data_reg, #2]
 				cache_addd( ORR_REG_LSL_IMM(dest_reg, dest_reg, temp2, 16) );      // orr dest_reg, dest_reg, temp2, lsl #16
@@ -394,7 +394,7 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg, [[maybe_unused]] void* 
 		}
 	} else {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
-		if ((Bit32u)data & 1) {
+		if ((uint32_t)data & 1) {
 			cache_addd( LDRB_IMM(dest_reg, data_reg, 0) );      // ldrb dest_reg, [data_reg]
 			cache_addd( LDRB_IMM(temp2, data_reg, 1) );      // ldrb temp2, [data_reg, #1]
 			cache_addd( ORR_REG_LSL_IMM(dest_reg, dest_reg, temp2, 8) );      // orr dest_reg, dest_reg, temp2, lsl #8
@@ -410,19 +410,19 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg, [[maybe_unused]] void* 
 // 16bit moves may destroy the upper 16bit of the destination register
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(temp1, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(temp1, (uint32_t)data);
 		gen_mov_word_to_reg_helper(dest_reg, data, dword, temp1);
 	}
 }
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
-	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
+	gen_mov_dword_to_reg_imm(dest_reg, (uint32_t)imm);
 }
 
 // helper function
-static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_from_reg_helper(HostReg src_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
@@ -468,9 +468,9 @@ static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu si
 
 // helper function
 static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -479,8 +479,8 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg, [[maybe_unused]] void*
 	// alignment....
 	if (dword) {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
-		if ((Bit32u)dest & 3) {
-			if ( ((Bit32u)dest & 3) == 2 ) {
+		if ((uint32_t)dest & 3) {
+			if ( ((uint32_t)dest & 3) == 2 ) {
 				cache_addd( STRH_IMM(src_reg, data_reg, 0) );      // strh src_reg, [data_reg]
 				cache_addd( MOV_REG_LSR_IMM(temp2, src_reg, 16) );      // mov temp2, src_reg, lsr #16
 				cache_addd( STRH_IMM(temp2, data_reg, 2) );      // strh temp2, [data_reg, #2]
@@ -498,7 +498,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg, [[maybe_unused]] void*
 		}
 	} else {
 #if !(defined(C_UNALIGNED_MEMORY) || (C_TARGETCPU == ARMV7LE))
-		if ((Bit32u)dest & 1) {
+		if ((uint32_t)dest & 1) {
 			cache_addd( STRB_IMM(src_reg, data_reg, 0) );      // strb src_reg, [data_reg]
 			cache_addd( MOV_REG_LSR_IMM(temp2, src_reg, 8) );      // mov temp2, src_reg, lsr #8
 			cache_addd( STRB_IMM(temp2, data_reg, 1) );      // strb temp2, [data_reg, #1]
@@ -513,7 +513,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg, [[maybe_unused]] void*
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(temp1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(temp1, (uint32_t)dest);
 		gen_mov_word_from_reg_helper(src_reg, dest, dword, temp1);
 	}
 }
@@ -524,7 +524,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, 1)) {
-		gen_mov_dword_to_reg_imm(temp1, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(temp1, (uint32_t)data);
 		cache_addd( LDRB_IMM(dest_reg, temp1, 0) );      // ldrb dest_reg, [temp1]
 	}
 }
@@ -541,7 +541,7 @@ static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	cache_addd( MOV_IMM(dest_reg, imm, 0) );      // mov dest_reg, #(imm)
 }
 
@@ -549,14 +549,14 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
 [[maybe_unused]] static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
-		gen_mov_dword_to_reg_imm(temp1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(temp1, (uint32_t)dest);
 		cache_addd( STRB_IMM(src_reg, temp1, 0) );      // strb src_reg, [temp1]
 	}
 }
@@ -609,12 +609,12 @@ static void gen_add(HostReg reg,void* op) {
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_add_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	if(!imm) return;
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if ( val_is_operand2(imm, &scale) ) {
 		cache_addd( ADD_IMM(reg, reg, imm >> scale, ROTATE_SCALE(scale)) );      // add reg, reg, #imm
@@ -641,8 +641,8 @@ static void gen_add_imm(HostReg reg,Bit32u imm) {
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_and_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	imm2 = ~imm;
 	if(!imm2) return;
@@ -666,23 +666,23 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 	gen_mov_dword_to_reg_imm(temp3, imm);
 	gen_mov_word_from_reg(temp3, dest, 1);
 }
 
 // move an address into memory
-static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,uint32_t imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(temp3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(temp1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(temp1, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(temp3, dest, dword, temp1);
 	}
 	gen_add_imm(temp3, imm);
@@ -692,23 +692,23 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-[[maybe_unused]] static void gen_add_direct_byte(void* dest,Bit8s imm) {
-	gen_add_direct_word(dest, (Bit32s)imm, 1);
+[[maybe_unused]] static void gen_add_direct_byte(void* dest,int8_t imm) {
+	gen_add_direct_word(dest, (int32_t)imm, 1);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
-	Bit32u imm2, scale;
+static void gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
+	uint32_t imm2, scale;
 
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(temp3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(temp1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(temp1, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(temp3, dest, dword, temp1);
 	}
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if ( val_is_operand2(imm, &scale) ) {
 		cache_addd( SUB_IMM(temp3, temp3, imm >> scale, ROTATE_SCALE(scale)) );      // sub temp3, temp3, #imm
@@ -739,8 +739,8 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-[[maybe_unused]] static void gen_sub_direct_byte(void* dest,Bit8s imm) {
-	gen_sub_direct_word(dest, (Bit32s)imm, 1);
+[[maybe_unused]] static void gen_sub_direct_byte(void* dest,int8_t imm) {
+	gen_sub_direct_word(dest, (int32_t)imm, 1);
 }
 
 // effective address calculation, destination is dest_reg
@@ -764,22 +764,22 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 // generate a call to a parameterless function
 static void inline gen_call_function_raw(void * func) {
 #if C_TARGETCPU == ARMV7LE
-	cache_addd( MOVW(temp1, ((Bit32u)func) & 0xffff) );      // movw temp1, #(func & 0xffff)
-	cache_addd( MOVT(temp1, ((Bit32u)func) >> 16) );      // movt temp1, #(func >> 16)
+	cache_addd( MOVW(temp1, ((uint32_t)func) & 0xffff) );      // movw temp1, #(func & 0xffff)
+	cache_addd( MOVT(temp1, ((uint32_t)func) >> 16) );      // movt temp1, #(func >> 16)
 	cache_addd( BLX_REG(temp1) );      // blx temp1
 #else
 	cache_addd( LDR_IMM(temp1, HOST_pc, 4) );      // ldr temp1, [pc, #4]
 	cache_addd( ADD_IMM(HOST_lr, HOST_pc, 4, 0) );      // add lr, pc, #4
 	cache_addd( BX(temp1) );      // bx temp1
-	cache_addd((Bit32u)func);      // .int func
+	cache_addd((uint32_t)func);      // .int func
 #endif
 }
 
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
-	const Bit8u* proc_addr = cache.pos;
+static inline const uint8_t* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
 }
@@ -843,7 +843,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addd( CMP_IMM(reg, 0, 0) );      // cmp reg, #0
 	} else {
@@ -855,7 +855,7 @@ static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addd( CMP_IMM(reg, 0, 0) );      // cmp reg, #0
 	} else {
@@ -866,21 +866,21 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+8);
 	if (len<0) len=-len;
 	if (len>0x02000000) LOG_MSG("Big jump %d",len);
 #endif
 	Bitu off = (cache.pos - (data+8)) >> 2;
-	cache_addw((Bit16u)off,data);
-	cache_addb((Bit8u)(off>>16),data+2);
+	cache_addw((uint16_t)off,data);
+	cache_addb((uint8_t)(off>>16),data+2);
 }
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	if (isdword) {
 		cache_addd( CMP_IMM(reg, 0, 0) );      // cmp reg, #0
 	} else {
@@ -891,14 +891,14 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	cache_addd( CMP_IMM(reg, 0, 0) );      // cmp reg, #0
 	cache_addd( BLE_FWD(0) );      // ble j
 	return (cache.pos-4);
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	gen_fill_branch(data);
 }
 
@@ -906,18 +906,18 @@ static void gen_run_code(void) {
 #if C_TARGETCPU == ARMV7LE
 	cache_addd(0xe92d4df0);			// stmfd sp!, {v1-v5,v7,v8,lr}
 
-	cache_addd( MOVW(FC_SEGS_ADDR, ((Bit32u)&Segs) & 0xffff) );      // movw FC_SEGS_ADDR, #(&Segs & 0xffff)
-	cache_addd( MOVT(FC_SEGS_ADDR, ((Bit32u)&Segs) >> 16) );      // movt FC_SEGS_ADDR, #(&Segs >> 16)
+	cache_addd( MOVW(FC_SEGS_ADDR, ((uint32_t)&Segs) & 0xffff) );      // movw FC_SEGS_ADDR, #(&Segs & 0xffff)
+	cache_addd( MOVT(FC_SEGS_ADDR, ((uint32_t)&Segs) >> 16) );      // movt FC_SEGS_ADDR, #(&Segs >> 16)
 
-	cache_addd( MOVW(FC_REGS_ADDR, ((Bit32u)&cpu_regs) & 0xffff) );      // movw FC_REGS_ADDR, #(&cpu_regs & 0xffff)
-	cache_addd( MOVT(FC_REGS_ADDR, ((Bit32u)&cpu_regs) >> 16) );      // movt FC_REGS_ADDR, #(&cpu_regs >> 16)
+	cache_addd( MOVW(FC_REGS_ADDR, ((uint32_t)&cpu_regs) & 0xffff) );      // movw FC_REGS_ADDR, #(&cpu_regs & 0xffff)
+	cache_addd( MOVT(FC_REGS_ADDR, ((uint32_t)&cpu_regs) >> 16) );      // movt FC_REGS_ADDR, #(&cpu_regs >> 16)
 
 	cache_addd( MOVW(readdata_addr, ((Bitu)&core_dynrec.readdata) & 0xffff) );      // movw readdata_addr, #(&core_dynrec.readdata & 0xffff)
 	cache_addd( MOVT(readdata_addr, ((Bitu)&core_dynrec.readdata) >> 16) );      // movt readdata_addr, #(&core_dynrec.readdata >> 16)
 
 	cache_addd( BX(HOST_r0) );			// bx r0
 #else
-	const Bit8u *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 	cache_addd(0xe92d4df0);			// stmfd sp!, {v1-v5,v7,v8,lr}
 
@@ -936,13 +936,13 @@ static void gen_run_code(void) {
 	}
 
 	cache_addd(LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)),pos1);      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
-	cache_addd((Bit32u)&Segs);      // address of "Segs"
+	cache_addd((uint32_t)&Segs);      // address of "Segs"
 
 	cache_addd(LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)),pos2);      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
-	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
+	cache_addd((uint32_t)&cpu_regs);  // address of "cpu_regs"
 
 	cache_addd(LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)),pos3);      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
-	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
+	cache_addd((uint32_t)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
 	if ((((Bitu)cache.pos) & 0x1f) != 0) {
@@ -960,7 +960,7 @@ static void gen_return_function(void) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
@@ -1183,20 +1183,20 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 			break;
 		default:
 #if C_TARGETCPU == ARMV7LE
-			cache_addd(MOVW(temp1, ((Bit32u)fct_ptr) & 0xffff),pos+0);      // movw temp1, #(fct_ptr & 0xffff)
-			cache_addd(MOVT(temp1, ((Bit32u)fct_ptr) >> 16),pos+4);      // movt temp1, #(fct_ptr >> 16)
+			cache_addd(MOVW(temp1, ((uint32_t)fct_ptr) & 0xffff),pos+0);      // movw temp1, #(fct_ptr & 0xffff)
+			cache_addd(MOVT(temp1, ((uint32_t)fct_ptr) >> 16),pos+4);      // movt temp1, #(fct_ptr >> 16)
 #else
-			cache_addd((Bit32u)fct_ptr,pos+12);		// simple_func
+			cache_addd((uint32_t)fct_ptr,pos+12);		// simple_func
 #endif
 			break;
 
 	}
 #else
 #if C_TARGETCPU == ARMV7LE
-	cache_addd(MOVW(temp1, ((Bit32u)fct_ptr) & 0xffff),pos+0);      // movw temp1, #(fct_ptr & 0xffff)
-	cache_addd(MOVT(temp1, ((Bit32u)fct_ptr) >> 16),pos+4);      // movt temp1, #(fct_ptr >> 16)
+	cache_addd(MOVW(temp1, ((uint32_t)fct_ptr) & 0xffff),pos+0);      // movw temp1, #(fct_ptr & 0xffff)
+	cache_addd(MOVT(temp1, ((uint32_t)fct_ptr) >> 16),pos+4);      // movt temp1, #(fct_ptr >> 16)
 #else
-	cache_addd((Bit32u)fct_ptr,pos+12);		// simple_func
+	cache_addd((uint32_t)fct_ptr,pos+12);		// simple_func
 #endif
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -181,17 +181,17 @@
 #define CACHE_DATA_MAX	 (288)
 
 // data pool variables
-static const Bit8u * cache_datapos = NULL;	// position of data pool in the cache block
-static Bit32u cache_datasize = 0;		// total size of data pool
-static Bit32u cache_dataindex = 0;		// used size of data pool = index of free data item (in bytes) in data pool
+static const uint8_t * cache_datapos = NULL;	// position of data pool in the cache block
+static uint32_t cache_datasize = 0;		// total size of data pool
+static uint32_t cache_dataindex = 0;		// used size of data pool = index of free data item (in bytes) in data pool
 
 
 // forwarded function
-static void inline gen_create_branch_short(const Bit8u * func);
+static void inline gen_create_branch_short(const uint8_t * func);
 
 // function to check distance to data pool
 // if too close, then generate jump after data pool
-static void cache_checkinstr(Bit32u size) {
+static void cache_checkinstr(uint32_t size) {
 	if (cache_datasize == 0) {
 		if (cache_datapos != NULL) {
 			if (cache.pos + size + CACHE_DATA_JUMP >= cache_datapos) {
@@ -204,7 +204,7 @@ static void cache_checkinstr(Bit32u size) {
 	if (cache.pos + size + CACHE_DATA_JUMP <= cache_datapos) return;
 
 	{
-		register const Bit8u * newcachepos;
+		register const uint8_t * newcachepos;
 
 		newcachepos = cache_datapos + cache_datasize;
 		gen_create_branch_short(newcachepos);
@@ -214,18 +214,18 @@ static void cache_checkinstr(Bit32u size) {
 	if (cache.pos + CACHE_DATA_MAX + CACHE_DATA_ALIGN >= cache.block.active->cache.start + cache.block.active->cache.size &&
 		cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) < cache.block.active->cache.start + cache.block.active->cache.size)
 	{
-		cache_datapos = (const Bit8u *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
+		cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
 	} else {
-		register Bit32u cachemodsize;
+		register uint32_t cachemodsize;
 
 		cachemodsize = (cache.pos - cache.block.active->cache.start) & (CACHE_MAXSIZE - 1);
 
 		if (cachemodsize + CACHE_DATA_MAX + CACHE_DATA_ALIGN <= CACHE_MAXSIZE ||
 			cachemodsize + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) > CACHE_MAXSIZE)
 		{
-			cache_datapos = (const Bit8u *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		} else {
-			cache_datapos = (const Bit8u *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
 		}
 	}
 
@@ -235,11 +235,11 @@ static void cache_checkinstr(Bit32u size) {
 
 // function to reserve item in data pool
 // returns address of item
-static const Bit8u * cache_reservedata(void) {
+static const uint8_t * cache_reservedata(void) {
 	// if data pool not yet initialized, then initialize data pool
 	if (GCC_UNLIKELY(cache_datapos == NULL)) {
 		if (cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN < cache.block.active->cache.start + CACHE_DATA_MAX) {
-			cache_datapos = (const Bit8u *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		}
 	}
 
@@ -250,18 +250,18 @@ static const Bit8u * cache_reservedata(void) {
 			if (cache.pos + CACHE_DATA_MAX + CACHE_DATA_ALIGN >= cache.block.active->cache.start + cache.block.active->cache.size &&
 				cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) < cache.block.active->cache.start + cache.block.active->cache.size)
 			{
-				cache_datapos = (const Bit8u *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
+				cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
 			} else {
-				register Bit32u cachemodsize;
+				register uint32_t cachemodsize;
 
 				cachemodsize = (cache.pos - cache.block.active->cache.start) & (CACHE_MAXSIZE - 1);
 
 				if (cachemodsize + CACHE_DATA_MAX + CACHE_DATA_ALIGN <= CACHE_MAXSIZE ||
 					cachemodsize + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) > CACHE_MAXSIZE)
 				{
-					cache_datapos = (const Bit8u *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+					cache_datapos = (const uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 				} else {
-					cache_datapos = (const Bit8u *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
+					cache_datapos = (const uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
 				}
 			}
 		}
@@ -300,8 +300,8 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 }
 
 // helper function
-static bool val_single_shift(Bit32u value, Bit32u *val_shift) {
-	Bit32u shift;
+static bool val_single_shift(uint32_t value, uint32_t *val_shift) {
+	uint32_t shift;
 
 	if (GCC_UNLIKELY(value == 0)) {
 		*val_shift = 0;
@@ -321,8 +321,8 @@ static bool val_single_shift(Bit32u value, Bit32u *val_shift) {
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
-	Bit32u scale;
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
+	uint32_t scale;
 
 	if (imm < 256) {
 		cache_checkinstr(2);
@@ -336,26 +336,26 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 		cache_addw( MOV_IMM(dest_reg, imm >> scale) );      // mov dest_reg, #(imm >> scale)
 		cache_addw( LSL_IMM(dest_reg, dest_reg, scale) );      // lsl dest_reg, dest_reg, #scale
 	} else {
-		Bit32u diff;
+		uint32_t diff;
 
 		cache_checkinstr(4);
 
-		diff = imm - ((Bit32u)cache.pos+4);
+		diff = imm - ((uint32_t)cache.pos+4);
 
 		if ((diff < 1024) && ((imm & 0x03) == 0)) {
-			if (((Bit32u)cache.pos & 0x03) == 0) {
+			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( ADD_LO_PC_IMM(dest_reg, diff >> 2) );      // add dest_reg, pc, #(diff >> 2)
 			} else {
 				cache_addw( NOP );      // nop
 				cache_addw( ADD_LO_PC_IMM(dest_reg, (diff - 2) >> 2) );      // add dest_reg, pc, #((diff - 2) >> 2)
 			}
 		} else {
-			const Bit8u *datapos;
+			const uint8_t *datapos;
 
 			datapos = cache_reservedata();
 			cache_addd(imm,datapos);
 
-			if (((Bit32u)cache.pos & 0x03) == 0) {
+			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( LDR_PC_IMM(dest_reg, datapos - (cache.pos + 4)) );      // ldr dest_reg, [pc, datapos]
 			} else {
 				cache_addw( LDR_PC_IMM(dest_reg, datapos - (cache.pos + 2)) );      // ldr dest_reg, [pc, datapos]
@@ -365,7 +365,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 }
 
 // helper function
-static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !defined(C_UNALIGNED_MEMORY)
@@ -408,9 +408,9 @@ static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu siz
 
 // helper function
 static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -419,8 +419,8 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 	// alignment....
 	if (dword) {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)data & 3) {
-			if ( ((Bit32u)data & 3) == 2 ) {
+		if ((uint32_t)data & 3) {
+			if ( ((uint32_t)data & 3) == 2 ) {
 				cache_checkinstr(8);
 				cache_addw( LDRH_IMM(dest_reg, data_reg, 0) );      // ldrh dest_reg, [data_reg]
 				cache_addw( LDRH_IMM(templo1, data_reg, 2) );      // ldrh templo1, [data_reg, #2]
@@ -445,7 +445,7 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 		}
 	} else {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)data & 1) {
+		if ((uint32_t)data & 1) {
 			cache_checkinstr(8);
 			cache_addw( LDRB_IMM(dest_reg, data_reg, 0) );      // ldrb dest_reg, [data_reg]
 			cache_addw( LDRB_IMM(templo1, data_reg, 1) );      // ldrb templo1, [data_reg, #1]
@@ -464,19 +464,19 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 // 16bit moves may destroy the upper 16bit of the destination register
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)data);
 		gen_mov_word_to_reg_helper(dest_reg, data, dword, templo2);
 	}
 }
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
-	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
+	gen_mov_dword_to_reg_imm(dest_reg, (uint32_t)imm);
 }
 
 // helper function
-static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_from_reg_helper(HostReg src_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !defined(C_UNALIGNED_MEMORY)
@@ -519,9 +519,9 @@ static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu si
 
 // helper function
 static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -530,8 +530,8 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 	// alignment....
 	if (dword) {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)dest & 3) {
-			if ( ((Bit32u)dest & 3) == 2 ) {
+		if ((uint32_t)dest & 3) {
+			if ( ((uint32_t)dest & 3) == 2 ) {
 				cache_checkinstr(8);
 				cache_addw( STRH_IMM(src_reg, data_reg, 0) );      // strh src_reg, [data_reg]
 				cache_addw( MOV_REG(templo1, src_reg) );      // mov templo1, src_reg
@@ -558,7 +558,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 		}
 	} else {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)dest & 1) {
+		if ((uint32_t)dest & 1) {
 			cache_checkinstr(8);
 			cache_addw( STRB_IMM(src_reg, data_reg, 0) );      // strb src_reg, [data_reg]
 			cache_addw( MOV_REG(templo1, src_reg) );      // mov templo1, src_reg
@@ -576,7 +576,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_from_reg_helper(src_reg, dest, dword, templo2);
 	}
 }
@@ -587,7 +587,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, 1)) {
-		gen_mov_dword_to_reg_imm(templo1, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(templo1, (uint32_t)data);
 		cache_checkinstr(2);
 		cache_addw( LDRB_IMM(dest_reg, templo1, 0) );      // ldrb dest_reg, [templo1]
 	}
@@ -605,7 +605,7 @@ static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	cache_checkinstr(2);
 	cache_addw( MOV_IMM(dest_reg, imm) );      // mov dest_reg, #(imm)
 }
@@ -614,14 +614,14 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
 static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
-		gen_mov_dword_to_reg_imm(templo1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo1, (uint32_t)dest);
 		cache_checkinstr(2);
 		cache_addw( STRB_IMM(src_reg, templo1, 0) );      // strb src_reg, [templo1]
 	}
@@ -663,12 +663,12 @@ static void gen_add(HostReg reg,void* op) {
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_add_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	if(!imm) return;
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm <= 255) {
 		cache_checkinstr(2);
@@ -693,8 +693,8 @@ static void gen_add_imm(HostReg reg,Bit32u imm) {
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_and_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	imm2 = ~imm;
 	if(!imm2) return;
@@ -720,23 +720,23 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 	gen_mov_dword_to_reg_imm(templo3, imm);
 	gen_mov_word_from_reg(templo3, dest, 1);
 }
 
 // move an address into memory
-static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,uint32_t imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(templo3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(templo3, dest, dword, templo2);
 	}
 	gen_add_imm(templo3, imm);
@@ -746,23 +746,23 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-static void gen_add_direct_byte(void* dest,Bit8s imm) {
-	gen_add_direct_word(dest, (Bit32s)imm, 1);
+static void gen_add_direct_byte(void* dest,int8_t imm) {
+	gen_add_direct_word(dest, (int32_t)imm, 1);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
-	Bit32u imm2, scale;
+static void gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
+	uint32_t imm2, scale;
 
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(templo3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(templo3, dest, dword, templo2);
 	}
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm <= 255) {
 		cache_checkinstr(2);
@@ -791,8 +791,8 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-static void gen_sub_direct_byte(void* dest,Bit8s imm) {
-	gen_sub_direct_word(dest, (Bit32s)imm, 1);
+static void gen_sub_direct_byte(void* dest,int8_t imm) {
+	gen_sub_direct_word(dest, (int32_t)imm, 1);
 }
 
 // effective address calculation, destination is dest_reg
@@ -823,12 +823,12 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 // helper function for gen_call_function_raw and gen_call_function_setup
 static void gen_call_function_helper(void * func) {
-	const Bit8u *datapos;
+	const uint8_t *datapos;
 
 	datapos = cache_reservedata();
-	cache_addd((Bit32u)func,datapos);
+	cache_addd((uint32_t)func,datapos);
 
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
 		cache_addw( ADD_LO_PC_IMM(templo2, 8) );      // adr templo2, after_call (add templo2, pc, #8)
 		cache_addw( ADD_IMM8(templo2, 1) );      // add templo2, #1
@@ -856,9 +856,9 @@ static void inline gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	cache_checkinstr(12);
-	const Bit8u* proc_addr = cache.pos;
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_helper(func);
 	return proc_addr;
 	// if proc_addr is on word  boundary ((proc_addr & 0x03) == 0)
@@ -934,7 +934,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	cache_checkinstr(4);
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
@@ -947,7 +947,7 @@ static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	cache_checkinstr(4);
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
@@ -959,21 +959,21 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
 	if (len>252) LOG_MSG("Big jump %d",len);
 #endif
-	cache_addb((Bit8u)((cache.pos-(data+4))>>1),data);
+	cache_addb((uint8_t)((cache.pos-(data+4))>>1),data);
 }
 
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
-	const Bit8u *datapos;
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+	const uint8_t *datapos;
 
 	cache_checkinstr(8);
 	datapos = cache_reservedata();
@@ -984,7 +984,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 		cache_addw( LSL_IMM(templo2, reg, 24) );      // lsl templo2, reg, #24
 	}
 	cache_addw( BEQ_FWD(2) );      // beq nobranch (pc+2)
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
 	} else {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 2)) );      // ldr templo1, [pc, datapos]
@@ -995,15 +995,15 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
-	const Bit8u *datapos;
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
+	const uint8_t *datapos;
 
 	cache_checkinstr(8);
 	datapos = cache_reservedata();
 
 	cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
 	cache_addw( BGT_FWD(2) );      // bgt nobranch (pc+2)
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
 	} else {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 2)) );      // ldr templo1, [pc, datapos]
@@ -1014,13 +1014,13 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	// this is an absolute branch
-	cache_addd((Bit32u)cache.pos+1,data); // add 1 to keep processor in thumb state
+	cache_addd((uint32_t)cache.pos+1,data); // add 1 to keep processor in thumb state
 }
 
 static void gen_run_code(void) {
-	const Bit8u *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 #if (__ARM_EABI__)
 	// 8-byte stack alignment
@@ -1055,13 +1055,13 @@ static void gen_run_code(void) {
 	}
 
 	cache_addd(ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)),pos1);      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
-	cache_addd((Bit32u)&Segs);      // address of "Segs"
+	cache_addd((uint32_t)&Segs);      // address of "Segs"
 
 	cache_addd(ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)),pos2);      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
-	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
+	cache_addd((uint32_t)&cpu_regs);  // address of "cpu_regs"
 
 	cache_addd(ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)),pos3);      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
-	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
+	cache_addd((uint32_t)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
 	if ((((Bitu)cache.pos) & 0x1f) != 0) {
@@ -1079,7 +1079,7 @@ static void gen_return_function(void) {
 
 // short unconditional jump (over data pool)
 // must emit at most CACHE_DATA_JUMP bytes
-static void inline gen_create_branch_short(const Bit8u * func) {
+static void inline gen_create_branch_short(const uint8_t * func) {
 	cache_addw( B_FWD(func - (cache.pos + 4)) );      // b func
 }
 
@@ -1088,17 +1088,17 @@ static void inline gen_create_branch_short(const Bit8u * func) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
-	if ((*(const Bit16u*)pos & 0xf000) == 0xe000) {
-		if ((*(const Bit16u*)pos & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
-			(*(const Bit16u*)pos & 0x0fff) < 0x0800)
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
+	if ((*(const uint16_t*)pos & 0xf000) == 0xe000) {
+		if ((*(const uint16_t*)pos & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
+			(*(const uint16_t*)pos & 0x0fff) < 0x0800)
 		{
-			pos = (const Bit8u *) ( ( ( (Bit32u)(*(const Bit16u*)pos & 0x0fff) ) << 1 ) + ((Bit32u)pos + 4) );
+			pos = (const uint8_t *) ( ( ( (uint32_t)(*(const uint16_t*)pos & 0x0fff) ) << 1 ) + ((uint32_t)pos + 4) );
 		}
 	}
 
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
-	if (((Bit32u)pos & 0x03) == 0)
+	if (((uint32_t)pos & 0x03) == 0)
 	{
 		// try to avoid function calls but rather directly fill in code
 		switch (flags_type) {
@@ -1241,7 +1241,7 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 				cache_addw(B_FWD(6),pos+2);							// b after_call (pc+6)
 				break;
 			default:
-				cache_addd((Bit32u)fct_ptr,pos+4+pos[0]*4);		// simple_func
+				cache_addd((uint32_t)fct_ptr,pos+4+pos[0]*4);		// simple_func
 				break;
 		}
 	}
@@ -1366,19 +1366,19 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 				cache_addw(B_FWD(4),pos+2);							// b after_call (pc+4)
 				break;
 			default:
-				cache_addd((Bit32u)fct_ptr,pos+2+pos[0]*4);	// simple_func
+				cache_addd((uint32_t)fct_ptr,pos+2+pos[0]*4);	// simple_func
 				break;
 		}
 
 	}
 #else
-	if (((Bit32u)pos & 0x03) == 0)
+	if (((uint32_t)pos & 0x03) == 0)
 	{
-		cache_addd((Bit32u)fct_ptr,pos+4+pos[0]*4); // simple_func
+		cache_addd((uint32_t)fct_ptr,pos+4+pos[0]*4); // simple_func
 	}
 	else
 	{
-		cache_addd((Bit32u)fct_ptr,pos+2+pos[0]*4); // simple_func
+		cache_addd((uint32_t)fct_ptr,pos+2+pos[0]*4); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -178,17 +178,17 @@
 #define CACHE_DATA_MAX	 (288)
 
 // data pool variables
-static const Bit8u * cache_datapos = NULL;	// position of data pool in the cache block
-static Bit32u cache_datasize = 0;		// total size of data pool
-static Bit32u cache_dataindex = 0;		// used size of data pool = index of free data item (in bytes) in data pool
+static const uint8_t * cache_datapos = NULL;	// position of data pool in the cache block
+static uint32_t cache_datasize = 0;		// total size of data pool
+static uint32_t cache_dataindex = 0;		// used size of data pool = index of free data item (in bytes) in data pool
 
 
 // forwarded function
-static void inline gen_create_branch_short(const Bit8u * func);
+static void inline gen_create_branch_short(const uint8_t * func);
 
 // function to check distance to data pool
 // if too close, then generate jump after data pool
-static void cache_checkinstr(Bit32u size) {
+static void cache_checkinstr(uint32_t size) {
 	if (cache_datasize == 0) {
 		if (cache_datapos != NULL) {
 			if (cache.pos + size + CACHE_DATA_JUMP >= cache_datapos) {
@@ -201,7 +201,7 @@ static void cache_checkinstr(Bit32u size) {
 	if (cache.pos + size + CACHE_DATA_JUMP <= cache_datapos) return;
 
 	{
-		register const Bit8u * newcachepos;
+		register const uint8_t * newcachepos;
 
 		newcachepos = cache_datapos + cache_datasize;
 		gen_create_branch_short(newcachepos);
@@ -211,18 +211,18 @@ static void cache_checkinstr(Bit32u size) {
 	if (cache.pos + CACHE_DATA_MAX + CACHE_DATA_ALIGN >= cache.block.active->cache.start + cache.block.active->cache.size &&
 		cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) < cache.block.active->cache.start + cache.block.active->cache.size)
 	{
-		cache_datapos = (const Bit8u *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
+		cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
 	} else {
-		register Bit32u cachemodsize;
+		register uint32_t cachemodsize;
 
 		cachemodsize = (cache.pos - cache.block.active->cache.start) & (CACHE_MAXSIZE - 1);
 
 		if (cachemodsize + CACHE_DATA_MAX + CACHE_DATA_ALIGN <= CACHE_MAXSIZE ||
 			cachemodsize + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) > CACHE_MAXSIZE)
 		{
-			cache_datapos = (const Bit8u *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		} else {
-			cache_datapos = (const Bit8u *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
 		}
 	}
 
@@ -232,11 +232,11 @@ static void cache_checkinstr(Bit32u size) {
 
 // function to reserve item in data pool
 // returns address of item
-static const Bit8u * cache_reservedata(void) {
+static const uint8_t * cache_reservedata(void) {
 	// if data pool not yet initialized, then initialize data pool
 	if (GCC_UNLIKELY(cache_datapos == NULL)) {
 		if (cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN < cache.block.active->cache.start + CACHE_DATA_MAX) {
-			cache_datapos = (const Bit8u *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		}
 	}
 
@@ -247,18 +247,18 @@ static const Bit8u * cache_reservedata(void) {
 			if (cache.pos + CACHE_DATA_MAX + CACHE_DATA_ALIGN >= cache.block.active->cache.start + cache.block.active->cache.size &&
 				cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) < cache.block.active->cache.start + cache.block.active->cache.size)
 			{
-				cache_datapos = (const Bit8u *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
+				cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
 			} else {
-				register Bit32u cachemodsize;
+				register uint32_t cachemodsize;
 
 				cachemodsize = (cache.pos - cache.block.active->cache.start) & (CACHE_MAXSIZE - 1);
 
 				if (cachemodsize + CACHE_DATA_MAX + CACHE_DATA_ALIGN <= CACHE_MAXSIZE ||
 					cachemodsize + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) > CACHE_MAXSIZE)
 				{
-					cache_datapos = (const Bit8u *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+					cache_datapos = (const uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 				} else {
-					cache_datapos = (const Bit8u *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
+					cache_datapos = (const uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
 				}
 			}
 		}
@@ -297,8 +297,8 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 }
 
 // helper function
-static bool val_single_shift(Bit32u value, Bit32u *val_shift) {
-	Bit32u shift;
+static bool val_single_shift(uint32_t value, uint32_t *val_shift) {
+	uint32_t shift;
 
 	if (GCC_UNLIKELY(value == 0)) {
 		*val_shift = 0;
@@ -318,8 +318,8 @@ static bool val_single_shift(Bit32u value, Bit32u *val_shift) {
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
-	Bit32u scale;
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
+	uint32_t scale;
 
 	if (imm < 256) {
 		cache_checkinstr(2);
@@ -333,26 +333,26 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 		cache_addw( MOV_IMM(dest_reg, imm >> scale) );      // mov dest_reg, #(imm >> scale)
 		cache_addw( LSL_IMM(dest_reg, dest_reg, scale) );      // lsl dest_reg, dest_reg, #scale
 	} else {
-		Bit32u diff;
+		uint32_t diff;
 
 		cache_checkinstr(4);
 
-		diff = imm - ((Bit32u)cache.pos+4);
+		diff = imm - ((uint32_t)cache.pos+4);
 
 		if ((diff < 1024) && ((imm & 0x03) == 0)) {
-			if (((Bit32u)cache.pos & 0x03) == 0) {
+			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( ADD_LO_PC_IMM(dest_reg, diff >> 2) );      // add dest_reg, pc, #(diff >> 2)
 			} else {
 				cache_addw( NOP );      // nop
 				cache_addw( ADD_LO_PC_IMM(dest_reg, (diff - 2) >> 2) );      // add dest_reg, pc, #((diff - 2) >> 2)
 			}
 		} else {
-			const Bit8u *datapos;
+			const uint8_t *datapos;
 
 			datapos = cache_reservedata();
 			cache_addd(imm,datapos);
 
-			if (((Bit32u)cache.pos & 0x03) == 0) {
+			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( LDR_PC_IMM(dest_reg, datapos - (cache.pos + 4)) );      // ldr dest_reg, [pc, datapos]
 			} else {
 				cache_addw( LDR_PC_IMM(dest_reg, datapos - (cache.pos + 2)) );      // ldr dest_reg, [pc, datapos]
@@ -362,7 +362,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 }
 
 // helper function
-static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !defined(C_UNALIGNED_MEMORY)
@@ -405,9 +405,9 @@ static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu siz
 
 // helper function
 static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -416,8 +416,8 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 	// alignment....
 	if (dword) {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)data & 3) {
-			if ( ((Bit32u)data & 3) == 2 ) {
+		if ((uint32_t)data & 3) {
+			if ( ((uint32_t)data & 3) == 2 ) {
 				cache_checkinstr(8);
 				cache_addw( LDRH_IMM(dest_reg, data_reg, 0) );      // ldrh dest_reg, [data_reg]
 				cache_addw( LDRH_IMM(templo1, data_reg, 2) );      // ldrh templo1, [data_reg, #2]
@@ -442,7 +442,7 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 		}
 	} else {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)data & 1) {
+		if ((uint32_t)data & 1) {
 			cache_checkinstr(8);
 			cache_addw( LDRB_IMM(dest_reg, data_reg, 0) );      // ldrb dest_reg, [data_reg]
 			cache_addw( LDRB_IMM(templo1, data_reg, 1) );      // ldrb templo1, [data_reg, #1]
@@ -461,19 +461,19 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 // 16bit moves may destroy the upper 16bit of the destination register
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)data);
 		gen_mov_word_to_reg_helper(dest_reg, data, dword, templo2);
 	}
 }
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
-	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
+	gen_mov_dword_to_reg_imm(dest_reg, (uint32_t)imm);
 }
 
 // helper function
-static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_from_reg_helper(HostReg src_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !defined(C_UNALIGNED_MEMORY)
@@ -516,9 +516,9 @@ static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu si
 
 // helper function
 static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -527,8 +527,8 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 	// alignment....
 	if (dword) {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)dest & 3) {
-			if ( ((Bit32u)dest & 3) == 2 ) {
+		if ((uint32_t)dest & 3) {
+			if ( ((uint32_t)dest & 3) == 2 ) {
 				cache_checkinstr(8);
 				cache_addw( STRH_IMM(src_reg, data_reg, 0) );      // strh src_reg, [data_reg]
 				cache_addw( MOV_REG(templo1, src_reg) );      // mov templo1, src_reg
@@ -555,7 +555,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 		}
 	} else {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)dest & 1) {
+		if ((uint32_t)dest & 1) {
 			cache_checkinstr(8);
 			cache_addw( STRB_IMM(src_reg, data_reg, 0) );      // strb src_reg, [data_reg]
 			cache_addw( MOV_REG(templo1, src_reg) );      // mov templo1, src_reg
@@ -573,7 +573,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_from_reg_helper(src_reg, dest, dword, templo2);
 	}
 }
@@ -584,7 +584,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, 1)) {
-		gen_mov_dword_to_reg_imm(templo1, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(templo1, (uint32_t)data);
 		cache_checkinstr(2);
 		cache_addw( LDRB_IMM(dest_reg, templo1, 0) );      // ldrb dest_reg, [templo1]
 	}
@@ -602,7 +602,7 @@ static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	cache_checkinstr(2);
 	cache_addw( MOV_IMM(dest_reg, imm) );      // mov dest_reg, #(imm)
 }
@@ -611,14 +611,14 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
 static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
-		gen_mov_dword_to_reg_imm(templo1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo1, (uint32_t)dest);
 		cache_checkinstr(2);
 		cache_addw( STRB_IMM(src_reg, templo1, 0) );      // strb src_reg, [templo1]
 	}
@@ -660,12 +660,12 @@ static void gen_add(HostReg reg,void* op) {
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_add_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	if(!imm) return;
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm <= 255) {
 		cache_checkinstr(2);
@@ -690,8 +690,8 @@ static void gen_add_imm(HostReg reg,Bit32u imm) {
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_and_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	imm2 = ~imm;
 	if(!imm2) return;
@@ -717,23 +717,23 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 	gen_mov_dword_to_reg_imm(templo3, imm);
 	gen_mov_word_from_reg(templo3, dest, 1);
 }
 
 // move an address into memory
-static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,uint32_t imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(templo3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(templo3, dest, dword, templo2);
 	}
 	gen_add_imm(templo3, imm);
@@ -743,23 +743,23 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-static void gen_add_direct_byte(void* dest,Bit8s imm) {
-	gen_add_direct_word(dest, (Bit32s)imm, 1);
+static void gen_add_direct_byte(void* dest,int8_t imm) {
+	gen_add_direct_word(dest, (int32_t)imm, 1);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
-	Bit32u imm2, scale;
+static void gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
+	uint32_t imm2, scale;
 
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(templo3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(templo3, dest, dword, templo2);
 	}
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm <= 255) {
 		cache_checkinstr(2);
@@ -788,8 +788,8 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-static void gen_sub_direct_byte(void* dest,Bit8s imm) {
-	gen_sub_direct_word(dest, (Bit32s)imm, 1);
+static void gen_sub_direct_byte(void* dest,int8_t imm) {
+	gen_sub_direct_word(dest, (int32_t)imm, 1);
 }
 
 // effective address calculation, destination is dest_reg
@@ -820,12 +820,12 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 // helper function for gen_call_function_raw and gen_call_function_setup
 static void gen_call_function_helper(void * func) {
-	const Bit8u *datapos;
+	const uint8_t *datapos;
 
 	datapos = cache_reservedata();
-	cache_addd((Bit32u)func,datapos);
+	cache_addd((uint32_t)func,datapos);
 
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
 		cache_addw( ADD_LO_PC_IMM(templo2, 4) );      // adr templo2, after_call (add templo2, pc, #4)
 		cache_addw( MOV_HI_LO(HOST_lr, templo2) );      // mov lr, templo2
@@ -855,9 +855,9 @@ static void inline gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+static inline const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	cache_checkinstr(18);
-	const Bit8u* proc_addr = cache.pos;
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_helper(func);
 	return proc_addr;
 	// if proc_addr is on word  boundary ((proc_addr & 0x03) == 0)
@@ -933,7 +933,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	cache_checkinstr(4);
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
@@ -946,7 +946,7 @@ static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	cache_checkinstr(4);
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
@@ -958,21 +958,21 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
 	if (len>252) LOG_MSG("Big jump %d",len);
 #endif
-	cache_addb((Bit8u)((cache.pos-(data+4)) >> 1 ),data);
+	cache_addb((uint8_t)((cache.pos-(data+4)) >> 1 ),data);
 }
 
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
-	const Bit8u *datapos;
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+	const uint8_t *datapos;
 
 	cache_checkinstr(8);
 	datapos = cache_reservedata();
@@ -983,7 +983,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 		cache_addw( LSL_IMM(templo2, reg, 24) );      // lsl templo2, reg, #24
 	}
 	cache_addw( BEQ_FWD(2) );      // beq nobranch (pc+2)
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
 	} else {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 2)) );      // ldr templo1, [pc, datapos]
@@ -994,15 +994,15 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
-	const Bit8u *datapos;
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
+	const uint8_t *datapos;
 
 	cache_checkinstr(8);
 	datapos = cache_reservedata();
 
 	cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
 	cache_addw( BGT_FWD(2) );      // bgt nobranch (pc+2)
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
 	} else {
 		cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 2)) );      // ldr templo1, [pc, datapos]
@@ -1013,13 +1013,13 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	// this is an absolute branch
-	cache_addd((Bit32u)cache.pos + 1,data); // add 1 to keep processor in thumb state
+	cache_addd((uint32_t)cache.pos + 1,data); // add 1 to keep processor in thumb state
 }
 
 static void gen_run_code(void) {
-	const Bit8u *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 #if (__ARM_EABI__)
 	// 8-byte stack alignment
@@ -1054,13 +1054,13 @@ static void gen_run_code(void) {
 	}
 
 	cache_addd(ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)),pos1);;      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
-	cache_addd((Bit32u)&Segs);      // address of "Segs"
+	cache_addd((uint32_t)&Segs);      // address of "Segs"
 
 	cache_addd(ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)),pos2);      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
-	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
+	cache_addd((uint32_t)&cpu_regs);  // address of "cpu_regs"
 
 	cache_addd(ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)),pos3);      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
-	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
+	cache_addd((uint32_t)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
 	if ((((Bitu)cache.pos) & 0x1f) != 0) {
@@ -1078,7 +1078,7 @@ static void gen_return_function(void) {
 
 // short unconditional jump (over data pool)
 // must emit at most CACHE_DATA_JUMP bytes
-static void inline gen_create_branch_short(const Bit8u * func) {
+static void inline gen_create_branch_short(const uint8_t * func) {
 	cache_addw( B_FWD(func - (cache.pos + 4)) );      // b func
 }
 
@@ -1087,17 +1087,17 @@ static void inline gen_create_branch_short(const Bit8u * func) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
-	if ((*(Bit16u*)pos & 0xf000) == 0xe000) {
-		if ((*(Bit16u*)pos & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
-			(*(Bit16u*)pos & 0x0fff) < 0x0800)
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
+	if ((*(uint16_t*)pos & 0xf000) == 0xe000) {
+		if ((*(uint16_t*)pos & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
+			(*(uint16_t*)pos & 0x0fff) < 0x0800)
 		{
-			pos = (const Bit8u *) ( ( ( (Bit32u)(*(Bit16u*)pos & 0x0fff) ) << 1 ) + ((Bit32u)pos + 4) );
+			pos = (const uint8_t *) ( ( ( (uint32_t)(*(uint16_t*)pos & 0x0fff) ) << 1 ) + ((uint32_t)pos + 4) );
 		}
 	}
 
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
-	if (((Bit32u)pos & 0x03) == 0)
+	if (((uint32_t)pos & 0x03) == 0)
 	{
 		// try to avoid function calls but rather directly fill in code
 		switch (flags_type) {
@@ -1243,7 +1243,7 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			default:
-				cache_addd((Bit32u)fct_ptr,pos+4+pos[0]*4); // simple_func
+				cache_addd((uint32_t)fct_ptr,pos+4+pos[0]*4); // simple_func
 				break;
 		}
 	}
@@ -1396,19 +1396,19 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			default:
-				cache_addd((Bit32u)fct_ptr,pos+2+pos[0]*4); // simple_func
+				cache_addd((uint32_t)fct_ptr,pos+2+pos[0]*4); // simple_func
 				break;
 		}
 
 	}
 #else
-	if (((Bit32u)pos & 0x03) == 0)
+	if (((uint32_t)pos & 0x03) == 0)
 	{
-		cache_addd((Bit32u)fct_ptr,pos+4+pos[0]*4); // simple_func
+		cache_addd((uint32_t)fct_ptr,pos+4+pos[0]*4); // simple_func
 	}
 	else
 	{
-		cache_addd((Bit32u)fct_ptr,pos+2+pos[0]*4); // simple_func
+		cache_addd((uint32_t)fct_ptr,pos+2+pos[0]*4); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -178,8 +178,8 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 }
 
 // helper function
-static bool val_single_shift(Bit32u value, Bit32u *val_shift) {
-	Bit32u shift;
+static bool val_single_shift(uint32_t value, uint32_t *val_shift) {
+	uint32_t shift;
 
 	if (GCC_UNLIKELY(value == 0)) {
 		*val_shift = 0;
@@ -199,8 +199,8 @@ static bool val_single_shift(Bit32u value, Bit32u *val_shift) {
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
-	Bit32u scale;
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
+	uint32_t scale;
 
 	if (imm < 256) {
 		cache_addw( MOV_IMM(dest_reg, imm) );      // mov dest_reg, #imm
@@ -211,19 +211,19 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 		cache_addw( MOV_IMM(dest_reg, imm >> scale) );      // mov dest_reg, #(imm >> scale)
 		cache_addw( LSL_IMM(dest_reg, dest_reg, scale) );      // lsl dest_reg, dest_reg, #scale
 	} else {
-		Bit32u diff;
+		uint32_t diff;
 
-		diff = imm - ((Bit32u)cache.pos+4);
+		diff = imm - ((uint32_t)cache.pos+4);
 
 		if ((diff < 1024) && ((imm & 0x03) == 0)) {
-			if (((Bit32u)cache.pos & 0x03) == 0) {
+			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( ADD_LO_PC_IMM(dest_reg, diff) );      // add dest_reg, pc, #(diff >> 2)
 			} else {
 				cache_addw( NOP );      // nop
 				cache_addw( ADD_LO_PC_IMM(dest_reg, diff - 2) );      // add dest_reg, pc, #((diff - 2) >> 2)
 			}
 		} else {
-			if (((Bit32u)cache.pos & 0x03) == 0) {
+			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( LDR_PC_IMM(dest_reg, 0) );      // ldr dest_reg, [pc, #0]
 				cache_addw( B_FWD(2) );      // b next_code (pc+2)
 				cache_addd(imm);      // .int imm
@@ -240,7 +240,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 }
 
 // helper function
-static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !defined(C_UNALIGNED_MEMORY)
@@ -280,9 +280,9 @@ static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit32u data, Bitu siz
 
 // helper function
 static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit32u)data, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint32_t)data, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -291,8 +291,8 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 	// alignment....
 	if (dword) {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)data & 3) {
-			if ( ((Bit32u)data & 3) == 2 ) {
+		if ((uint32_t)data & 3) {
+			if ( ((uint32_t)data & 3) == 2 ) {
 				cache_addw( LDRH_IMM(dest_reg, data_reg, 0) );      // ldrh dest_reg, [data_reg]
 				cache_addw( LDRH_IMM(templo1, data_reg, 2) );      // ldrh templo1, [data_reg, #2]
 				cache_addw( LSL_IMM(templo1, templo1, 16) );      // lsl templo1, templo1, #16
@@ -314,7 +314,7 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 		}
 	} else {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)data & 1) {
+		if ((uint32_t)data & 1) {
 			cache_addw( LDRB_IMM(dest_reg, data_reg, 0) );      // ldrb dest_reg, [data_reg]
 			cache_addw( LDRB_IMM(templo1, data_reg, 1) );      // ldrb templo1, [data_reg, #1]
 			cache_addw( LSL_IMM(templo1, templo1, 8) );      // lsl templo1, templo1, #8
@@ -331,19 +331,19 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,Ho
 // 16bit moves may destroy the upper 16bit of the destination register
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)data);
 		gen_mov_word_to_reg_helper(dest_reg, data, dword, templo2);
 	}
 }
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
-	gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
+	gen_mov_dword_to_reg_imm(dest_reg, (uint32_t)imm);
 }
 
 // helper function
-static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu size, HostReg addr_reg, Bit32u addr_data) {
+static bool gen_mov_memval_from_reg_helper(HostReg src_reg, uint32_t data, Bitu size, HostReg addr_reg, uint32_t addr_data) {
 	switch (size) {
 		case 4:
 #if !defined(C_UNALIGNED_MEMORY)
@@ -383,9 +383,9 @@ static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit32u data, Bitu si
 
 // helper function
 static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_REGS_ADDR, (Bit32u)&cpu_regs)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, readdata_addr, (Bit32u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit32u)dest, size, FC_SEGS_ADDR, (Bit32u)&Segs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_REGS_ADDR, (uint32_t)&cpu_regs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, readdata_addr, (uint32_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint32_t)dest, size, FC_SEGS_ADDR, (uint32_t)&Segs)) return true;
 	return false;
 }
 
@@ -394,8 +394,8 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 	// alignment....
 	if (dword) {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)dest & 3) {
-			if ( ((Bit32u)dest & 3) == 2 ) {
+		if ((uint32_t)dest & 3) {
+			if ( ((uint32_t)dest & 3) == 2 ) {
 				cache_addw( STRH_IMM(src_reg, data_reg, 0) );      // strh src_reg, [data_reg]
 				cache_addw( MOV_REG(templo1, src_reg) );      // mov templo1, src_reg
 				cache_addw( LSR_IMM(templo1, templo1, 16) );      // lsr templo1, templo1, #16
@@ -419,7 +419,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 		}
 	} else {
 #if !defined(C_UNALIGNED_MEMORY)
-		if ((Bit32u)dest & 1) {
+		if ((uint32_t)dest & 1) {
 			cache_addw( STRB_IMM(src_reg, data_reg, 0) );      // strb src_reg, [data_reg]
 			cache_addw( MOV_REG(templo1, src_reg) );      // mov templo1, src_reg
 			cache_addw( LSR_IMM(templo1, templo1, 8) );      // lsr templo1, templo1, #8
@@ -435,7 +435,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, 
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_from_reg_helper(src_reg, dest, dword, templo2);
 	}
 }
@@ -446,7 +446,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, 1)) {
-		gen_mov_dword_to_reg_imm(templo1, (Bit32u)data);
+		gen_mov_dword_to_reg_imm(templo1, (uint32_t)data);
 		cache_addw( LDRB_IMM(dest_reg, templo1, 0) );      // ldrb dest_reg, [templo1]
 	}
 }
@@ -463,7 +463,7 @@ static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	cache_addw( MOV_IMM(dest_reg, imm) );      // mov dest_reg, #(imm)
 }
 
@@ -471,14 +471,14 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
 static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
-		gen_mov_dword_to_reg_imm(templo1, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo1, (uint32_t)dest);
 		cache_addw( STRB_IMM(src_reg, templo1, 0) );      // strb src_reg, [templo1]
 	}
 }
@@ -516,12 +516,12 @@ static void gen_add(HostReg reg,void* op) {
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_add_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	if(!imm) return;
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm <= 255) {
 		cache_addw( ADD_IMM8(reg, imm) );      // add reg, #imm
@@ -542,8 +542,8 @@ static void gen_add_imm(HostReg reg,Bit32u imm) {
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2, scale;
+static void gen_and_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2, scale;
 
 	imm2 = ~imm;
 	if(!imm2) return;
@@ -566,23 +566,23 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 	gen_mov_dword_to_reg_imm(templo3, imm);
 	gen_mov_word_from_reg(templo3, dest, 1);
 }
 
 // move an address into memory
-static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,uint32_t imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(templo3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(templo3, dest, dword, templo2);
 	}
 	gen_add_imm(templo3, imm);
@@ -592,23 +592,23 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-static void gen_add_direct_byte(void* dest,Bit8s imm) {
-	gen_add_direct_word(dest, (Bit32s)imm, 1);
+static void gen_add_direct_byte(void* dest,int8_t imm) {
+	gen_add_direct_word(dest, (int32_t)imm, 1);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
-	Bit32u imm2, scale;
+static void gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
+	uint32_t imm2, scale;
 
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(templo3, dest, (dword)?4:2)) {
-		gen_mov_dword_to_reg_imm(templo2, (Bit32u)dest);
+		gen_mov_dword_to_reg_imm(templo2, (uint32_t)dest);
 		gen_mov_word_to_reg_helper(templo3, dest, dword, templo2);
 	}
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm <= 255) {
 		cache_addw( SUB_IMM8(templo3, imm) );      // sub templo3, #imm
@@ -633,8 +633,8 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-static void gen_sub_direct_byte(void* dest,Bit8s imm) {
-	gen_sub_direct_word(dest, (Bit32s)imm, 1);
+static void gen_sub_direct_byte(void* dest,int8_t imm) {
+	gen_sub_direct_word(dest, (int32_t)imm, 1);
 }
 
 // effective address calculation, destination is dest_reg
@@ -662,7 +662,7 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 // generate a call to a parameterless function
 static void inline gen_call_function_raw(void * func) {
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( LDR_PC_IMM(templo1, 4) );      // ldr templo1, [pc, #4]
 		cache_addw( ADD_LO_PC_IMM(templo2, 8) );      // adr templo2, after_call (add templo2, pc, #8)
 		cache_addw( MOV_HI_LO(HOST_lr, templo2) );      // mov lr, templo2
@@ -674,7 +674,7 @@ static void inline gen_call_function_raw(void * func) {
 		cache_addw( BX(templo1) );      // bx templo1     --- switch to arm state
 		cache_addw( NOP );      // nop
 	}
-	cache_addd((Bit32u)func);      // .int func
+	cache_addd((uint32_t)func);      // .int func
 	// after_call:
 
 	// switch from arm to thumb state
@@ -687,8 +687,8 @@ static void inline gen_call_function_raw(void * func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
-	const Bit8u* proc_addr = cache.pos;
+static inline const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
 	// if proc_addr is on word  boundary ((proc_addr & 0x03) == 0)
@@ -761,7 +761,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
 	} else {
@@ -773,7 +773,7 @@ static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
 	} else {
@@ -784,25 +784,25 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
 	if (len>252) LOG_MSG("Big jump %d",len);
 #endif
-	cache_addb((Bit8u)((cache.pos-(data+4)) >> 1),data);
+	cache_addb((uint8_t)((cache.pos-(data+4)) >> 1),data);
 }
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	if (isdword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
 	} else {
 		cache_addw( LSL_IMM(templo2, reg, 24) );      // lsl templo2, reg, #24
 	}
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( BEQ_FWD(8) );      // beq nobranch (pc+8)
 		cache_addw( LDR_PC_IMM(templo1, 4) );      // ldr templo1, [pc, #4]
 		cache_addw( BX(templo1) );      // bx templo1
@@ -818,9 +818,9 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
-	if (((Bit32u)cache.pos & 0x03) == 0) {
+	if (((uint32_t)cache.pos & 0x03) == 0) {
 		cache_addw( BGT_FWD(8) );      // bgt nobranch (pc+8)
 		cache_addw( LDR_PC_IMM(templo1, 4) );      // ldr templo1, [pc, #4]
 		cache_addw( BX(templo1) );      // bx templo1
@@ -836,13 +836,13 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	// this is an absolute branch
-	cache_addd((Bit32u)cache.pos + 1,data); // add 1 to keep processor in thumb state
+	cache_addd((uint32_t)cache.pos + 1,data); // add 1 to keep processor in thumb state
 }
 
 static void gen_run_code(void) {
-	const Bit8u *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 #if (__ARM_EABI__)
 	// 8-byte stack alignment
@@ -877,13 +877,13 @@ static void gen_run_code(void) {
 	}
 
 	cache_addd(ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)),pos1);      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
-	cache_addd((Bit32u)&Segs);      // address of "Segs"
+	cache_addd((uint32_t)&Segs);      // address of "Segs"
 
 	cache_addd(ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)),pos2);      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
-	cache_addd((Bit32u)&cpu_regs);  // address of "cpu_regs"
+	cache_addd((uint32_t)&cpu_regs);  // address of "cpu_regs"
 
 	cache_addd(ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)),pos3);      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
-	cache_addd((Bit32u)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
+	cache_addd((uint32_t)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
 	if ((((Bitu)cache.pos) & 0x1f) != 0) {
@@ -901,9 +901,9 @@ static void gen_return_function(void) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
-	if (((Bit32u)pos & 0x03) == 0)
+	if (((uint32_t)pos & 0x03) == 0)
 	{
 		// try to avoid function calls but rather directly fill in code
 		switch (flags_type) {
@@ -1049,7 +1049,7 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 				cache_addw(B_FWD(14),pos+2);						// b after_call (pc+14)
 				break;
 			default:
-				cache_addd((Bit32u)fct_ptr,pos+8); // simple_func
+				cache_addd((uint32_t)fct_ptr,pos+8); // simple_func
 				break;
 		}
 	}
@@ -1200,26 +1200,26 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 				cache_addw(B_FWD(16),pos+2);						// b after_call (pc+16)
 				break;
 			default:
-				cache_addd((Bit32u)fct_ptr,pos+10); // simple_func
+				cache_addd((uint32_t)fct_ptr,pos+10); // simple_func
 				break;
 		}
 
 	}
 #else
-	if (((Bit32u)pos & 0x03) == 0)
+	if (((uint32_t)pos & 0x03) == 0)
 	{
-		cache_addd((Bit32u)fct_ptr,pos+8);		// simple_func
+		cache_addd((uint32_t)fct_ptr,pos+8);		// simple_func
 	}
 	else
 	{
-		cache_addd((Bit32u)fct_ptr,pos+10);		// simple_func
+		cache_addd((uint32_t)fct_ptr,pos+10);		// simple_func
 	}
 #endif
 }
 #endif
 
 static void cache_block_before_close(void) {
-	if ((((Bit32u)cache.pos) & 3) != 0) {
+	if ((((uint32_t)cache.pos) & 3) != 0) {
 		cache_addw( NOP );      // nop
 	}
 }

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -39,7 +39,7 @@
 #define DRC_USE_SEGS_ADDR
 
 // register mapping
-typedef Bit8u HostReg;
+typedef uint8_t HostReg;
 
 // registers
 #define HOST_r0		 0
@@ -342,7 +342,7 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
 	if ( (imm & 0xffff0000) == 0 ) {
 		cache_addd( MOVZ(dest_reg, imm, 0) );               // movz dest_reg, #imm
 	} else if ( (imm & 0x0000ffff) == 0 ) {
@@ -358,7 +358,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 }
 
 // helper function
-static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit64u data, Bitu size, HostReg addr_reg, Bit64u addr_data) {
+static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, uint64_t data, Bitu size, HostReg addr_reg, uint64_t addr_data) {
 	switch (size) {
 		case 8:
 			if (((data & 7) == 0) && (data >= addr_data) && (data < addr_data + 32768)) {
@@ -403,14 +403,14 @@ static bool gen_mov_memval_to_reg_helper(HostReg dest_reg, Bit64u data, Bitu siz
 
 // helper function
 static bool gen_mov_memval_to_reg(HostReg dest_reg, void *data, Bitu size) {
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit64u)data, size, FC_REGS_ADDR, (Bit64u)&cpu_regs)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit64u)data, size, readdata_addr, (Bit64u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_to_reg_helper(dest_reg, (Bit64u)data, size, FC_SEGS_ADDR, (Bit64u)&Segs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint64_t)data, size, FC_REGS_ADDR, (uint64_t)&cpu_regs)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint64_t)data, size, readdata_addr, (uint64_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_to_reg_helper(dest_reg, (uint64_t)data, size, FC_SEGS_ADDR, (uint64_t)&Segs)) return true;
 	return false;
 }
 
 // helper function - move a 64bit constant value into dest_reg
-static void gen_mov_qword_to_reg_imm(HostReg dest_reg,Bit64u imm) {
+static void gen_mov_qword_to_reg_imm(HostReg dest_reg,uint64_t imm) {
 	bool isfirst = true;
 
 	if ( (imm & 0xffff) != 0 ) {
@@ -459,19 +459,19 @@ static void gen_mov_word_to_reg_helper(HostReg dest_reg, [[maybe_unused]] void* 
 // 16bit moves may destroy the upper 16bit of the destination register
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, (dword)?4:2)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)data);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)data);
 		gen_mov_word_to_reg_helper(dest_reg, data, dword, temp1);
 	}
 }
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void inline gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
 	cache_addd( MOVZ(dest_reg, imm, 0) );   // movz dest_reg, #imm
 }
 
 // helper function
-static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit64u data, Bitu size, HostReg addr_reg, Bit64u addr_data) {
+static bool gen_mov_memval_from_reg_helper(HostReg src_reg, uint64_t data, Bitu size, HostReg addr_reg, uint64_t addr_data) {
 	switch (size) {
 		case 8:
 			if (((data & 7) == 0) && (data >= addr_data) && (data < addr_data + 32768)) {
@@ -516,9 +516,9 @@ static bool gen_mov_memval_from_reg_helper(HostReg src_reg, Bit64u data, Bitu si
 
 // helper function
 static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit64u)dest, size, FC_REGS_ADDR, (Bit64u)&cpu_regs)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit64u)dest, size, readdata_addr, (Bit64u)&core_dynrec.readdata)) return true;
-	if (gen_mov_memval_from_reg_helper(src_reg, (Bit64u)dest, size, FC_SEGS_ADDR, (Bit64u)&Segs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint64_t)dest, size, FC_REGS_ADDR, (uint64_t)&cpu_regs)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint64_t)dest, size, readdata_addr, (uint64_t)&core_dynrec.readdata)) return true;
+	if (gen_mov_memval_from_reg_helper(src_reg, (uint64_t)dest, size, FC_SEGS_ADDR, (uint64_t)&Segs)) return true;
 	return false;
 }
 
@@ -534,7 +534,7 @@ static void gen_mov_word_from_reg_helper(HostReg src_reg, [[maybe_unused]] void*
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 	if (!gen_mov_memval_from_reg(src_reg, dest, (dword)?4:2)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)dest);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)dest);
 		gen_mov_word_from_reg_helper(src_reg, dest, dword, temp1);
 	}
 }
@@ -545,7 +545,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 	if (!gen_mov_memval_to_reg(dest_reg, data, 1)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)data);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)data);
 		cache_addd( LDRB_IMM(dest_reg, temp1, 0) );     // ldrb dest_reg, [temp1]
 	}
 }
@@ -562,7 +562,7 @@ static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	cache_addd( MOVZ(dest_reg, imm, 0) );   // movz dest_reg, #imm
 }
 
@@ -570,14 +570,14 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
 // static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 // 	if (!gen_mov_memval_from_reg(src_reg, dest, 1)) {
-// 		gen_mov_qword_to_reg_imm(temp1, (Bit64u)dest);
+// 		gen_mov_qword_to_reg_imm(temp1, (uint64_t)dest);
 // 		cache_addd( STRB_IMM(src_reg, temp1, 0) );      // strb src_reg, [temp1]
 // 	}
 // }
@@ -611,12 +611,12 @@ static void gen_add(HostReg reg,void* op) {
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2;
+static void gen_add_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2;
 
 	if(!imm) return;
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm < 4096) {
 		cache_addd( ADD_IMM(reg, reg, imm, 0) );            // add reg, reg, #imm
@@ -636,8 +636,8 @@ static void gen_add_imm(HostReg reg,Bit32u imm) {
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
-	Bit32u imm2;
+static void gen_and_imm(HostReg reg,uint32_t imm) {
+	uint32_t imm2;
 
 	imm2 = ~imm;
 	if(!imm2) return;
@@ -658,7 +658,7 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 	gen_mov_dword_to_reg_imm(temp3, imm);
 	gen_mov_word_from_reg(temp3, dest, 1);
 }
@@ -667,18 +667,18 @@ static void gen_mov_direct_dword(void* dest,Bit32u imm) {
 static void inline gen_mov_direct_ptr(void* dest,Bitu imm) {
 	gen_mov_qword_to_reg_imm(temp3, imm);
 	if (!gen_mov_memval_from_reg(temp3, dest, 8)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)dest);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)dest);
 		cache_addd( STR64_IMM(temp3, temp1, 0) );       // str temp3, [temp1]
 	}
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(temp3, dest, (dword)?4:2)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)dest);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)dest);
 		gen_mov_word_to_reg_helper(temp3, dest, dword, temp1);
 	}
 	gen_add_imm(temp3, imm);
@@ -688,23 +688,23 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-// static void gen_add_direct_byte(void* dest,Bit8s imm) {
-// 	gen_add_direct_word(dest, (Bit32s)imm, 1);
+// static void gen_add_direct_byte(void* dest,int8_t imm) {
+// 	gen_add_direct_word(dest, (int32_t)imm, 1);
 // }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
-	Bit32u imm2;
+static void gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
+	uint32_t imm2;
 
 	if (!dword) imm &= 0xffff;
 	if(!imm) return;
 
 	if (!gen_mov_memval_to_reg(temp3, dest, (dword)?4:2)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)dest);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)dest);
 		gen_mov_word_to_reg_helper(temp3, dest, dword, temp1);
 	}
 
-	imm2 = (Bit32u) (-((Bit32s)imm));
+	imm2 = (uint32_t) (-((int32_t)imm));
 
 	if (imm < 4096) {
 		cache_addd( SUB_IMM(temp3, temp3, imm, 0) );            // sub temp3, temp3, #imm
@@ -728,8 +728,8 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // subtract an 8bit constant value from a dword memory value
-// static void gen_sub_direct_byte(void* dest,Bit8s imm) {
-// 	gen_sub_direct_word(dest, (Bit32s)imm, 1);
+// static void gen_sub_direct_byte(void* dest,int8_t imm) {
+// 	gen_sub_direct_word(dest, (int32_t)imm, 1);
 // }
 
 // effective address calculation, destination is dest_reg
@@ -752,18 +752,18 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 // generate a call to a parameterless function
 static void inline gen_call_function_raw(void * func) {
-	cache_addd( MOVZ64(temp1, ((Bit64u)func) & 0xffff, 0) );            // movz dest_reg, #(func & 0xffff)
-	cache_addd( MOVK64(temp1, (((Bit64u)func) >> 16) & 0xffff, 16) );   // movk dest_reg, #((func >> 16) & 0xffff), lsl #16
-	cache_addd( MOVK64(temp1, (((Bit64u)func) >> 32) & 0xffff, 32) );   // movk dest_reg, #((func >> 32) & 0xffff), lsl #32
-	cache_addd( MOVK64(temp1, (((Bit64u)func) >> 48) & 0xffff, 48) );   // movk dest_reg, #((func >> 48) & 0xffff), lsl #48
+	cache_addd( MOVZ64(temp1, ((uint64_t)func) & 0xffff, 0) );            // movz dest_reg, #(func & 0xffff)
+	cache_addd( MOVK64(temp1, (((uint64_t)func) >> 16) & 0xffff, 16) );   // movk dest_reg, #((func >> 16) & 0xffff), lsl #16
+	cache_addd( MOVK64(temp1, (((uint64_t)func) >> 32) & 0xffff, 32) );   // movk dest_reg, #((func >> 32) & 0xffff), lsl #32
+	cache_addd( MOVK64(temp1, (((uint64_t)func) >> 48) & 0xffff, 48) );   // movk dest_reg, #((func >> 48) & 0xffff), lsl #48
 	cache_addd( BLR_REG(temp1) );      // blr temp1
 }
 
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
-	const Bit8u* proc_addr = cache.pos;
+static inline const uint8_t* gen_call_function_setup(void * func, [[maybe_unused]] Bitu paramcount, [[maybe_unused]] bool fastcall=false) {
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
 }
@@ -791,7 +791,7 @@ static void inline gen_load_param_mem(Bitu mem,Bitu param) {
 // jump to an address pointed at by ptr, offset is in imm
 static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 	if (!gen_mov_memval_to_reg(temp3, ptr, 8)) {
-		gen_mov_qword_to_reg_imm(temp1, (Bit64u)ptr);
+		gen_mov_qword_to_reg_imm(temp1, (uint64_t)ptr);
 		cache_addd( LDR64_IMM(temp3, temp1, 0) );     // ldr temp3, [temp1]
 	}
 
@@ -809,7 +809,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addd( CBZ_FWD(reg, 0) );      // cbz reg, j
 	} else {
@@ -821,7 +821,7 @@ static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addd( CBNZ_FWD(reg, 0) );     // cbnz reg, j
 	} else {
@@ -832,21 +832,21 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-data;
 	if (len<0) len=-len;
 	if (len>=0x00100000) LOG_MSG("Big jump %d",len);
 #endif
-	Bit32u offset = (Bit32u)(cache.pos-data) << 3;
-	cache_addw(((Bit16u)offset&~0x1f)|(data[0]&0x1f),data);
-	cache_addb((Bit8u)(offset>>16),data+2);
+	uint32_t offset = (uint32_t)(cache.pos-data) << 3;
+	cache_addw(((uint16_t)offset&~0x1f)|(data[0]&0x1f),data);
+	cache_addb((uint8_t)(offset>>16),data+2);
 }
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	if (isdword) {
 		cache_addd( CBZ_FWD(reg, 8) );      // cbz reg, pc+8    // skip next instruction
 	} else {
@@ -858,7 +858,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	cache_addd( CMP_IMM(reg, 0, 0) );       // cmp reg, #0
 	cache_addd( BGT_FWD(8) );               // bgt pc+8 // skip next instruction
 	cache_addd( B_FWD(0) );                 // b j
@@ -866,14 +866,14 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	// optimize for shorter branches ?
-	Bit32u offset = (Bit32u)(cache.pos-data) >> 2;
+	uint32_t offset = (uint32_t)(cache.pos-data) >> 2;
 	cache_addd(((data[3]<<24)&~0x03ffffff)|(offset&0x03ffffff),data);
 }
 
 static void gen_run_code(void) {
-	const Bit8u *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 	cache_addd( 0xa9bd7bfd );                                           // stp fp, lr, [sp, #-48]!
 	cache_addd( 0x910003fd );                                           // mov fp, sp
@@ -895,13 +895,13 @@ static void gen_run_code(void) {
 	}
 
 	cache_addd(LDR64_PC(FC_SEGS_ADDR, cache.pos - pos1),pos1);   // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
-	cache_addq((Bit64u)&Segs);                      // address of "Segs"
+	cache_addq((uint64_t)&Segs);                      // address of "Segs"
 
 	cache_addd(LDR64_PC(FC_REGS_ADDR, cache.pos - pos2),pos2);   // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
-	cache_addq((Bit64u)&cpu_regs);                  // address of "cpu_regs"
+	cache_addq((uint64_t)&cpu_regs);                  // address of "cpu_regs"
 
 	cache_addd(LDR64_PC(readdata_addr, cache.pos - pos3),pos3);  // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
-	cache_addq((Bit64u)&core_dynrec.readdata);      // address of "core_dynrec.readdata"
+	cache_addq((uint64_t)&core_dynrec.readdata);      // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
 	if ((((Bitu)cache.pos) & 0x1f) != 0) {
@@ -921,7 +921,7 @@ static void gen_return_function(void) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
@@ -1117,23 +1117,23 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 			cache_addd(LSRV64(FC_RETOP, HOST_x0, HOST_x2),pos+16);				// lsrv FC_RETOP, x0, x2
 			break;
 		default:
-			cache_addd(MOVZ64(temp1, ((Bit64u)fct_ptr) & 0xffff, 0),pos+0);                 // movz temp1, #(fct_ptr & 0xffff)
-			cache_addd(MOVK64(temp1, (((Bit64u)fct_ptr) >> 16) & 0xffff, 16),pos+4);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-			cache_addd(MOVK64(temp1, (((Bit64u)fct_ptr) >> 32) & 0xffff, 32),pos+8);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-			cache_addd(MOVK64(temp1, (((Bit64u)fct_ptr) >> 48) & 0xffff, 48),pos+12);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+			cache_addd(MOVZ64(temp1, ((uint64_t)fct_ptr) & 0xffff, 0),pos+0);                 // movz temp1, #(fct_ptr & 0xffff)
+			cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 16) & 0xffff, 16),pos+4);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
+			cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 32) & 0xffff, 32),pos+8);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
+			cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 48) & 0xffff, 48),pos+12);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
 			break;
 
 	}
 #else
-	cache_addd(MOVZ64(temp1, ((Bit64u)fct_ptr) & 0xffff, 0),pos+0);                 // movz temp1, #(fct_ptr & 0xffff)
-	cache_addd(MOVK64(temp1, (((Bit64u)fct_ptr) >> 16) & 0xffff, 16),pos+4);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-	cache_addd(MOVK64(temp1, (((Bit64u)fct_ptr) >> 32) & 0xffff, 32),pos+8);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-	cache_addd(MOVK64(temp1, (((Bit64u)fct_ptr) >> 48) & 0xffff, 48),pos+12);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+	cache_addd(MOVZ64(temp1, ((uint64_t)fct_ptr) & 0xffff, 0),pos+0);                 // movz temp1, #(fct_ptr & 0xffff)
+	cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 16) & 0xffff, 16),pos+4);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
+	cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 32) & 0xffff, 32),pos+8);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
+	cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 48) & 0xffff, 48),pos+12);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
 #endif
 }
 #endif
 
-static void cache_block_closing([[maybe_unused]] const Bit8u *block_start,
+static void cache_block_closing([[maybe_unused]] const uint8_t *block_start,
                                 [[maybe_unused]] Bitu block_size) { }
 
 static void cache_block_before_close(void) { }

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -39,7 +39,7 @@
 //#define DRC_USE_SEGS_ADDR
 
 // register mapping
-typedef Bit8u HostReg;
+typedef uint8_t HostReg;
 
 #define HOST_v0 2
 #define HOST_v1 3
@@ -91,7 +91,7 @@ typedef Bit8u HostReg;
 
 // save some state to improve code gen
 static bool temp1_valid = false;
-static Bit32u temp1_value;
+static uint32_t temp1_value;
 
 // move a full register from reg_src to reg_dst
 static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
@@ -101,35 +101,35 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
 	if(imm < 65536) {
-		cache_addw((Bit16u)imm);		// ori dest_reg, $0, imm
+		cache_addw((uint16_t)imm);		// ori dest_reg, $0, imm
 		cache_addw(0x3400+dest_reg);
-	} else if(((Bit32s)imm < 0) && ((Bit32s)imm >= -32768)) {
-		cache_addw((Bit16u)imm);		// addiu dest_reg, $0, imm
+	} else if(((int32_t)imm < 0) && ((int32_t)imm >= -32768)) {
+		cache_addw((uint16_t)imm);		// addiu dest_reg, $0, imm
 		cache_addw(0x2400+dest_reg);
 	} else if(!(imm & 0xffff)) {
-		cache_addw((Bit16u)(imm >> 16));	// lui dest_reg, %hi(imm)
+		cache_addw((uint16_t)(imm >> 16));	// lui dest_reg, %hi(imm)
 		cache_addw(0x3c00+dest_reg);
 	} else {
-		cache_addw((Bit16u)(imm >> 16));	// lui dest_reg, %hi(imm)
+		cache_addw((uint16_t)(imm >> 16));	// lui dest_reg, %hi(imm)
 		cache_addw(0x3c00+dest_reg);
-		cache_addw((Bit16u)imm);		// ori dest_reg, dest_reg, %lo(imm)
+		cache_addw((uint16_t)imm);		// ori dest_reg, dest_reg, %lo(imm)
 		cache_addw(0x3400+(dest_reg<<5)+dest_reg);
 	}
 }
 
 // this is the only place temp1 should be modified
-static void inline mov_imm_to_temp1(Bit32u imm) {
+static void inline mov_imm_to_temp1(uint32_t imm) {
 	if (temp1_valid && (temp1_value == imm)) return;
 	gen_mov_dword_to_reg_imm(temp1, imm);
 	temp1_valid = true;
 	temp1_value = imm;
 }
 
-static Bit16s gen_addr_temp1(Bit32u addr) {
-	Bit32u hihalf = addr & 0xffff0000;
-	Bit16s lohalf = addr & 0xffff;
+static int16_t gen_addr_temp1(uint32_t addr) {
+	uint32_t hihalf = addr & 0xffff0000;
+	int16_t lohalf = addr & 0xffff;
 	if (lohalf > 32764) {  // [l,s]wl will overflow
 		hihalf = addr;
 		lohalf = 0;
@@ -141,10 +141,10 @@ static Bit16s gen_addr_temp1(Bit32u addr) {
 // move a 32bit (dword==true) or 16bit (dword==false) value from memory into dest_reg
 // 16bit moves may destroy the upper 16bit of the destination register
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
-	Bit16s lohalf = gen_addr_temp1((Bit32u)data);
+	int16_t lohalf = gen_addr_temp1((uint32_t)data);
 	// alignment....
 	if (dword) {
-		if ((Bit32u)data & 3) {
+		if ((uint32_t)data & 3) {
 			cache_addw(lohalf+3);		// lwl dest_reg, 3(temp1)
 			cache_addw(0x8800+(temp1<<5)+dest_reg);
 			cache_addw(lohalf);		// lwr dest_reg, 0(temp1)
@@ -154,7 +154,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 			cache_addw(0x8C00+(temp1<<5)+dest_reg);
 		}
 	} else {
-		if ((Bit32u)data & 1) {
+		if ((uint32_t)data & 1) {
 			cache_addw(lohalf);		// lbu dest_reg, 0(temp1)
 			cache_addw(0x9000+(temp1<<5)+dest_reg);
 			cache_addw(lohalf+1);		// lbu temp2, 1(temp1)
@@ -177,17 +177,17 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
 	cache_addw(imm);			// ori dest_reg, $0, imm
 	cache_addw(0x3400+dest_reg);
 }
 
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
-	Bit16s lohalf = gen_addr_temp1((Bit32u)dest);
+	int16_t lohalf = gen_addr_temp1((uint32_t)dest);
 	// alignment....
 	if (dword) {
-		if ((Bit32u)dest & 3) {
+		if ((uint32_t)dest & 3) {
 			cache_addw(lohalf+3);		// swl src_reg, 3(temp1)
 			cache_addw(0xA800+(temp1<<5)+src_reg);
 			cache_addw(lohalf);		// swr src_reg, 0(temp1)
@@ -197,7 +197,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 			cache_addw(0xAC00+(temp1<<5)+src_reg);
 		}
 	} else {
-		if((Bit32u)dest & 1) {
+		if((uint32_t)dest & 1) {
 			cache_addw(lohalf);		// sb src_reg, 0(temp1)
 			cache_addw(0xA000+(temp1<<5)+src_reg);
 			cache_addw((temp2<<11)+0x202);		// srl temp2, src_reg, 8
@@ -216,7 +216,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
-	Bit16s lohalf = gen_addr_temp1((Bit32u)data);
+	int16_t lohalf = gen_addr_temp1((uint32_t)data);
 	cache_addw(lohalf);			// lbu dest_reg, 0(temp1)
 	cache_addw(0x9000+(temp1<<5)+dest_reg);
 }
@@ -233,7 +233,7 @@ static void inline gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* dat
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	gen_mov_word_to_reg_imm(dest_reg, imm);
 }
 
@@ -241,13 +241,13 @@ static void inline gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void inline gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	gen_mov_byte_to_reg_low_imm(dest_reg, imm);
 }
 
 // move the lowest 8bit of a register into memory
 static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
-	Bit16s lohalf = gen_addr_temp1((Bit32u)dest);
+	int16_t lohalf = gen_addr_temp1((uint32_t)dest);
 	cache_addw(lohalf);			// sb src_reg, 0(temp1)
 	cache_addw(0xA000+(temp1<<5)+src_reg);
 }
@@ -294,10 +294,10 @@ static void gen_add(HostReg reg,void* op) {
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
+static void gen_add_imm(HostReg reg,uint32_t imm) {
 	if(!imm) return;
-	if(((Bit32s)imm >= -32768) && ((Bit32s)imm < 32768)) {
-		cache_addw((Bit16u)imm);	// addiu reg, reg, imm
+	if(((int32_t)imm >= -32768) && ((int32_t)imm < 32768)) {
+		cache_addw((uint16_t)imm);	// addiu reg, reg, imm
 		cache_addw(0x2400+(reg<<5)+reg);
 	} else {
 		mov_imm_to_temp1(imm);
@@ -307,12 +307,12 @@ static void gen_add_imm(HostReg reg,Bit32u imm) {
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
+static void gen_and_imm(HostReg reg,uint32_t imm) {
 	if(imm < 65536) { 
-		cache_addw((Bit16u)imm);      // andi reg, reg, imm 
+		cache_addw((uint16_t)imm);      // andi reg, reg, imm 
 		cache_addw(0x3000+(reg<<5)+reg); 
 	} else { 
-		mov_imm_to_temp1((Bit32u)imm); 
+		mov_imm_to_temp1((uint32_t)imm); 
 		cache_addw((reg<<11)+0x24);      // and reg, temp1, reg 
 		cache_addw((temp1<<5)+reg); 
 	} 
@@ -320,18 +320,18 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void inline gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_dword(void* dest,uint32_t imm) {
 	gen_mov_dword_to_reg_imm(temp2, imm);
 	gen_mov_word_from_reg(temp2, dest, 1);
 }
 
 // move an address into memory
-static void inline gen_mov_direct_ptr(void* dest,Bit32u imm) {
+static void inline gen_mov_direct_ptr(void* dest,uint32_t imm) {
 	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void inline gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void inline gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if(!imm) return;
 	gen_mov_word_to_reg(temp2, dest, dword);
 	gen_add_imm(temp2, imm);
@@ -339,18 +339,18 @@ static void inline gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 }
 
 // add an 8bit constant value to a dword memory value
-static void inline gen_add_direct_byte(void* dest,Bit8s imm) {
-	gen_add_direct_word(dest, (Bit32s)imm, 1);
+static void inline gen_add_direct_byte(void* dest,int8_t imm) {
+	gen_add_direct_word(dest, (int32_t)imm, 1);
 }
 
 // subtract an 8bit constant value from a dword memory value
-static void inline gen_sub_direct_byte(void* dest,Bit8s imm) {
-	gen_add_direct_word(dest, -((Bit32s)imm), 1);
+static void inline gen_sub_direct_byte(void* dest,int8_t imm) {
+	gen_add_direct_word(dest, -((int32_t)imm), 1);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void inline gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
-	gen_add_direct_word(dest, -(Bit32s)imm, dword);
+static void inline gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
+	gen_add_direct_word(dest, -(int32_t)imm, dword);
 }
 
 // effective address calculation, destination is dest_reg
@@ -382,18 +382,18 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 // generate a call to a parameterless function
 static void inline gen_call_function_raw(void * func) {
 #if C_DEBUG
-	if (((Bit32u)cache.pos ^ (Bit32u)func) & 0xf0000000) LOG_MSG("jump overflow\n");
+	if (((uint32_t)cache.pos ^ (uint32_t)func) & 0xf0000000) LOG_MSG("jump overflow\n");
 #endif
 	temp1_valid = false;
-	cache_addd(0x0c000000+(((Bit32u)func>>2)&0x3ffffff));		// jal func
+	cache_addd(0x0c000000+(((uint32_t)func>>2)&0x3ffffff));		// jal func
 	DELAY;
 }
 
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
-	const Bit8u* proc_addr = cache.pos;
+static inline const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
 }
@@ -432,7 +432,7 @@ static void inline gen_jmp_ptr(void * ptr,Bits imm=0) {
 		imm = 0;
 	}
 	temp1_valid = false;
-	cache_addw((Bit16u)imm);	// lw temp2, imm(temp2)
+	cache_addw((uint16_t)imm);	// lw temp2, imm(temp2)
 	cache_addw(0x8C00+(temp2<<5)+temp2);
 	cache_addd((temp2<<21)+8); 	// jr temp2 
 	DELAY;
@@ -440,7 +440,7 @@ static void inline gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static inline const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static inline const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	temp1_valid = false;
 	if(!dword) { 
 		cache_addw(0xffff);	// andi temp1, reg, 0xffff
@@ -454,7 +454,7 @@ static inline const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static inline const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static inline const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	temp1_valid = false;
 	if(!dword) { 
 		cache_addw(0xffff);	// andi temp1, reg, 0xffff
@@ -467,14 +467,14 @@ static inline const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) 
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch(const Bit8u* data) {
+static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-data;
 	if (len<0) len=-len;
 	if (len>126) LOG_MSG("Big jump %d",len);
 #endif
 	temp1_valid = false;			// this is a branch target
-	cache_addw((Bit16u)(cache.pos-data-4)>>2,data);
+	cache_addw((uint16_t)(cache.pos-data-4)>>2,data);
 }
 
 #if 0	// assume for the moment no branch will go farther then +/- 128KB
@@ -482,7 +482,7 @@ static void inline gen_fill_branch(const Bit8u* data) {
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	temp1_valid = false;
 	if (!isdword) {
 		cache_addw(0xff);	// andi temp1, reg, 0xff
@@ -497,7 +497,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static inline const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static inline const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	temp1_valid = false;
 	cache_addw(3);				// bgtz reg, +12
 	cache_addw(0x1c00+(reg<<5));
@@ -508,16 +508,16 @@ static inline const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	temp1_valid = false;
 	// this is an absolute branch
-	cache_addd(0x08000000+(((Bit32u)cache.pos>>2)&0x3ffffff),data);
+	cache_addd(0x08000000+(((uint32_t)cache.pos>>2)&0x3ffffff),data);
 }
 #else		
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	temp1_valid = false;
 	if (!isdword) {
 		cache_addw(0xff);	// andi temp1, reg, 0xff
@@ -530,7 +530,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static inline const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static inline const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	temp1_valid = false;
 	cache_addw(0);			// blez reg, 0
 	cache_addw(0x1800+(reg<<5));
@@ -539,7 +539,7 @@ static inline const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void inline gen_fill_branch_long(const Bit8u* data) {
+static void inline gen_fill_branch_long(const uint8_t* data) {
 	gen_fill_branch(data);
 }
 #endif
@@ -564,7 +564,7 @@ static void gen_return_function(void) {
 #ifdef DRC_FLAGS_INVALIDATION
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
@@ -635,20 +635,20 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 			cache_addd(0x00041023,pos);					// subu $v0, $0, $a0
 			break;
 		default:
-			cache_addd(0x0c000000+(((Bit32u)fct_ptr)>>2)&0x3ffffff,pos);		// jal simple_func
+			cache_addd(0x0c000000+(((uint32_t)fct_ptr)>>2)&0x3ffffff,pos);		// jal simple_func
 			break;
 	}
 #else
-	cache_addd(0x0c000000+(((Bit32u)fct_ptr)>>2)&0x3ffffff,pos);	// jal simple_func
+	cache_addd(0x0c000000+(((uint32_t)fct_ptr)>>2)&0x3ffffff,pos);	// jal simple_func
 #endif
 }
 #endif
 
-static void cache_block_closing(const Bit8u* block_start,Bitu block_size) {
+static void cache_block_closing(const uint8_t* block_start,Bitu block_size) {
 #ifdef PSP
 // writeback dcache and invalidate icache
-	Bit32u inval_start = ((Bit32u)block_start) & ~63;
-	Bit32u inval_end = (((Bit32u)block_start) + block_size + 64) & ~63;
+	uint32_t inval_start = ((uint32_t)block_start) & ~63;
+	uint32_t inval_end = (((uint32_t)block_start) + block_size + 64) & ~63;
 	for (;inval_start < inval_end; inval_start+=64) {
 		__builtin_allegrex_cache(0x1a, inval_start);
 		__builtin_allegrex_cache(0x08, inval_start);

--- a/src/cpu/core_dynrec/risc_x86.h
+++ b/src/cpu/core_dynrec/risc_x86.h
@@ -91,19 +91,19 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 	if (!dword) cache_addb(0x66);
 	cache_addw(0x058b+(dest_reg<<11));	// mov reg,[data]
-	cache_addd((Bit32u)data);
+	cache_addd((uint32_t)data);
 }
 
 // move a 16bit constant value into dest_reg
 // the upper 16bit of the destination register may be destroyed
-static void gen_mov_word_to_reg_imm(HostReg dest_reg,Bit16u imm) {
+static void gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm) {
 	cache_addb(0x66);
 	cache_addb(0xb8+dest_reg);			// mov reg,imm
 	cache_addw(imm);
 }
 
 // move a 32bit constant value into dest_reg
-static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
+static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
 	cache_addb(0xb8+dest_reg);			// mov reg,imm
 	cache_addd(imm);
 }
@@ -112,7 +112,7 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 	if (!dword) cache_addb(0x66);
 	cache_addw(0x0589+(src_reg<<11));	// mov [data],reg
-	cache_addd((Bit32u)dest);
+	cache_addd((uint32_t)dest);
 }
 
 // move an 8bit value from memory into dest_reg
@@ -121,7 +121,7 @@ static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword) {
 // registers might not be directly byte-accessible on some architectures
 static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 	cache_addw(0x058a+(dest_reg<<11));	// mov reg,[data]
-	cache_addd((Bit32u)data);
+	cache_addd((uint32_t)data);
 }
 
 // move an 8bit value from memory into dest_reg
@@ -131,14 +131,14 @@ static void gen_mov_byte_to_reg_low(HostReg dest_reg,void* data) {
 static void gen_mov_byte_to_reg_low_canuseword(HostReg dest_reg,void* data) {
 	cache_addb(0x66);
 	cache_addw(0x058b+(dest_reg<<11));	// mov reg,[data]
-	cache_addd((Bit32u)data);
+	cache_addd((uint32_t)data);
 }
 
 // move an 8bit constant value into dest_reg
 // the upper 24bit of the destination register can be destroyed
 // this function does not use FC_OP1/FC_OP2 as dest_reg as these
 // registers might not be directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,uint8_t imm) {
 	cache_addb(0xb0+dest_reg);			// mov reg,imm
 	cache_addb(imm);
 }
@@ -147,7 +147,7 @@ static void gen_mov_byte_to_reg_low_imm(HostReg dest_reg,Bit8u imm) {
 // the upper 24bit of the destination register can be destroyed
 // this function can use FC_OP1/FC_OP2 as dest_reg which are
 // not directly byte-accessible on some architectures
-static void gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
+static void gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,uint8_t imm) {
 	cache_addb(0x66);
 	cache_addb(0xb8+dest_reg);			// mov reg,imm
 	cache_addw(imm);
@@ -156,7 +156,7 @@ static void gen_mov_byte_to_reg_low_imm_canuseword(HostReg dest_reg,Bit8u imm) {
 // move the lowest 8bit of a register into memory
 static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 	cache_addw(0x0588+(src_reg<<11));	// mov [data],reg
-	cache_addd((Bit32u)dest);
+	cache_addd((uint32_t)dest);
 }
 
 
@@ -180,17 +180,17 @@ static void gen_extend_word(bool sign,HostReg reg) {
 // add a 32bit value from memory to a full register
 static void gen_add(HostReg reg,void* op) {
 	cache_addw(0x0503+(reg<<11));		// add reg,[data]
-	cache_addd((Bit32u)op);
+	cache_addd((uint32_t)op);
 }
 
 // add a 32bit constant value to a full register
-static void gen_add_imm(HostReg reg,Bit32u imm) {
+static void gen_add_imm(HostReg reg,uint32_t imm) {
 	cache_addw(0xc081+(reg<<8));		// add reg,imm
 	cache_addd(imm);
 }
 
 // and a 32bit constant value with a full register
-static void gen_and_imm(HostReg reg,Bit32u imm) {
+static void gen_and_imm(HostReg reg,uint32_t imm) {
 	cache_addw(0xe081+(reg<<8));		// and reg,imm
 	cache_addd(imm);
 }
@@ -198,56 +198,56 @@ static void gen_and_imm(HostReg reg,Bit32u imm) {
 
 
 // move a 32bit constant value into memory
-static void gen_mov_direct_dword(void* dest,Bit32u imm) {
+static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 	cache_addw(0x05c7);					// mov [data],imm
-	cache_addd((Bit32u)dest);
+	cache_addd((uint32_t)dest);
 	cache_addd(imm);
 }
 
 // move an address into memory
 static void inline gen_mov_direct_ptr(void* dest,Bitu imm) {
-	gen_mov_direct_dword(dest,(Bit32u)imm);
+	gen_mov_direct_dword(dest,(uint32_t)imm);
 }
 
 
 // add an 8bit constant value to a memory value
-static void gen_add_direct_byte(void* dest,Bit8s imm) {
+static void gen_add_direct_byte(void* dest,int8_t imm) {
 	cache_addw(0x0583);					// add [data],imm
-	cache_addd((Bit32u)dest);
+	cache_addd((uint32_t)dest);
 	cache_addb(imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
-static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_add_direct_word(void* dest,uint32_t imm,bool dword) {
 	if ((imm<128) && dword) {
-		gen_add_direct_byte(dest,(Bit8s)imm);
+		gen_add_direct_byte(dest,(int8_t)imm);
 		return;
 	}
 	if (!dword) cache_addb(0x66);
 	cache_addw(0x0581);					// add [data],imm
-	cache_addd((Bit32u)dest);
-	if (dword) cache_addd((Bit32u)imm);
-	else cache_addw((Bit16u)imm);
+	cache_addd((uint32_t)dest);
+	if (dword) cache_addd((uint32_t)imm);
+	else cache_addw((uint16_t)imm);
 }
 
 // subtract an 8bit constant value from a memory value
-static void gen_sub_direct_byte(void* dest,Bit8s imm) {
+static void gen_sub_direct_byte(void* dest,int8_t imm) {
 	cache_addw(0x2d83);					// sub [data],imm
-	cache_addd((Bit32u)dest);
+	cache_addd((uint32_t)dest);
 	cache_addb(imm);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
-static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
+static void gen_sub_direct_word(void* dest,uint32_t imm,bool dword) {
 	if ((imm<128) && dword) {
-		gen_sub_direct_byte(dest,(Bit8s)imm);
+		gen_sub_direct_byte(dest,(int8_t)imm);
 		return;
 	}
 	if (!dword) cache_addb(0x66);
 	cache_addw(0x2d81);					// sub [data],imm
-	cache_addd((Bit32u)dest);
-	if (dword) cache_addd((Bit32u)imm);
-	else cache_addw((Bit16u)imm);
+	cache_addd((uint32_t)dest);
+	if (dword) cache_addd((uint32_t)imm);
+	else cache_addw((uint16_t)imm);
 }
 
 
@@ -256,7 +256,7 @@ static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
 // scale_reg is scaled by scale (scale_reg*(2^scale)) and
 // added to dest_reg, then the immediate value is added
 static inline void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits imm) {
-	Bit8u rm_base;
+	uint8_t rm_base;
 	Bitu imm_size;
 	if (!imm) {
 		imm_size=0;	rm_base=0x0;			//no imm
@@ -296,17 +296,17 @@ static inline void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 // generate a call to a parameterless function
 static void inline gen_call_function_raw(void * func) {
 	cache_addb(0xe8);
-	cache_addd((Bit32u)func - (Bit32u)cache.pos-4);
+	cache_addd((uint32_t)func - (uint32_t)cache.pos-4);
 }
 
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-static inline const Bit8u* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
-	const Bit8u* proc_addr=cache.pos;
+static inline const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+	const uint8_t* proc_addr=cache.pos;
 	// Do the actual call to the procedure
 	cache_addb(0xe8);
-	cache_addd((Bit32u)func - (Bit32u)cache.pos-4);
+	cache_addd((uint32_t)func - (uint32_t)cache.pos-4);
 
 	// Restore the params of the stack
 	if (paramcount) {
@@ -360,7 +360,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	if (!dword) cache_addb(0x66);
 	cache_addb(0x0b);					// or reg,reg
 	cache_addb(0xc0+reg+(reg<<3));
@@ -371,7 +371,7 @@ static const Bit8u* gen_create_branch_on_zero(HostReg reg,bool dword) {
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	if (!dword) cache_addb(0x66);
 	cache_addb(0x0b);					// or reg,reg
 	cache_addb(0xc0+reg+(reg<<3));
@@ -381,19 +381,19 @@ static const Bit8u* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void gen_fill_branch(const Bit8u* data) {
+static void gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
-	Bits len=(Bit32u)cache.pos-data;
+	Bits len=(uint32_t)cache.pos-data;
 	if (len<0) len=-len;
 	if (len>126) LOG_MSG("Big jump %d",len);
 #endif
-	cache_addb((Bit8u)(cache.pos-data-1),data);
+	cache_addb((uint8_t)(cache.pos-data-1),data);
 }
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	// isdword: cmp reg32,0
 	// not isdword: cmp reg8,0
 	cache_addb(0x0a+(isdword?1:0));				// or reg,reg
@@ -405,7 +405,7 @@ static const Bit8u* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	cache_addw(0xf883+(reg<<8));
 	cache_addb(0x00);		// cmp reg,0
 
@@ -415,8 +415,8 @@ static const Bit8u* gen_create_branch_long_leqzero(HostReg reg) {
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void gen_fill_branch_long(const Bit8u* data) {
-	cache_addd((Bit32u)(cache.pos-data-4),data);
+static void gen_fill_branch_long(const uint8_t* data) {
+	cache_addd((uint32_t)(cache.pos-data-4),data);
 }
 
 
@@ -437,7 +437,7 @@ static void gen_return_function(void) {
 #ifdef DRC_FLAGS_INVALIDATION
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
@@ -498,15 +498,15 @@ static void gen_fill_function_ptr(const Bit8u * pos,void* fct_ptr,Bitu flags_typ
 			cache_addb(0x90,pos+4);
 			break;
 		default:
-			cache_addd((Bit32u)((Bit8u*)fct_ptr - (pos+1+4)),pos+1);	// fill function pointer
+			cache_addd((uint32_t)((uint8_t*)fct_ptr - (pos+1+4)),pos+1);	// fill function pointer
 			break;
 	}
 #else
-	cache_addd((Bit32u)((Bit8u*)fct_ptr - (pos+1+4)),pos+1);	// fill function pointer
+	cache_addd((uint32_t)((uint8_t*)fct_ptr - (pos+1+4)),pos+1);	// fill function pointer
 #endif
 }
 #endif
 
-static void cache_block_closing(const Bit8u* block_start,Bitu block_size) { }
+static void cache_block_closing(const uint8_t* block_start,Bitu block_size) { }
 
 static void cache_block_before_close(void) { }

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -36,9 +36,9 @@ typedef PhysPt EAPoint;
 #define LoadMw(off) mem_readw_inline(off)
 #define LoadMd(off) mem_readd_inline(off)
 
-#define LoadMbs(off) (Bit8s)(LoadMb(off))
-#define LoadMws(off) (Bit16s)(LoadMw(off))
-#define LoadMds(off) (Bit32s)(LoadMd(off))
+#define LoadMbs(off) (int8_t)(LoadMb(off))
+#define LoadMws(off) (int16_t)(LoadMw(off))
+#define LoadMds(off) (int32_t)(LoadMd(off))
 
 #define SaveMb(off,val)	mem_writeb_inline(off,val)
 #define SaveMw(off,val)	mem_writew_inline(off,val)
@@ -56,7 +56,7 @@ typedef PhysPt EAPoint;
 
 #define EXCEPTION(blah)										\
 	{														\
-		Bit8u new_num=blah;									\
+		uint8_t new_num=blah;									\
 		CPU_Exception(new_num,0);							\
 		continue;											\
 	}

--- a/src/cpu/core_full/ea_lookup.h
+++ b/src/cpu/core_full/ea_lookup.h
@@ -18,7 +18,7 @@
 
 {
 	EAPoint seg_base = 0;
-	Bit16u off = 0;
+	uint16_t off = 0;
 	switch ((inst.rm_mod << 3) | inst.rm_eai) {
 	case 0x00:
 		off=reg_bx+reg_si;
@@ -143,10 +143,10 @@
 	}																\
 	off+=*SIBIndex[(sib >> 3) &7] << (sib >> 6);					\
 };																	
-	static Bit32u SIBZero=0;
-	static Bit32u * SIBIndex[8]= { &reg_eax,&reg_ecx,&reg_edx,&reg_ebx,&SIBZero,&reg_ebp,&reg_esi,&reg_edi };
+	static uint32_t SIBZero=0;
+	static uint32_t * SIBIndex[8]= { &reg_eax,&reg_ecx,&reg_edx,&reg_ebx,&SIBZero,&reg_ebp,&reg_esi,&reg_edi };
 	EAPoint seg_base = 0;
-	Bit32u off = 0;
+	uint32_t off = 0;
 	switch ((inst.rm_mod<<3)|inst.rm_eai) {
 	case 0x00:
 		off=reg_eax;

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -45,8 +45,8 @@ l_MODRMswitch:
 			inst_op1_d=Fetchb();
 			break;
 		case M_Ebx:
-			if (inst.rm<0xc0) inst_op1_ds=(Bit8s)LoadMb(inst.rm_eaa);
-			else inst_op1_ds=(Bit8s)reg_8(inst.rm_eai);
+			if (inst.rm<0xc0) inst_op1_ds=(int8_t)LoadMb(inst.rm_eaa);
+			else inst_op1_ds=(int8_t)reg_8(inst.rm_eai);
 			break;
 		case M_EbIb:
 			inst_op2_d=Fetchb();
@@ -72,7 +72,7 @@ l_MODRMswitch:
 			inst_op1_d=Fetchw();
 			break;
 		case M_EwxGwx:
-			inst_op2_ds=(Bit16s)reg_16(inst.rm_index);
+			inst_op2_ds=(int16_t)reg_16(inst.rm_index);
 			goto l_M_Ewx;
 		case M_EwxIbx:
 			inst_op2_ds=Fetchbs();
@@ -82,8 +82,8 @@ l_MODRMswitch:
 			[[fallthrough]];
 		case M_Ewx:
 l_M_Ewx:
-			if (inst.rm<0xc0) inst_op1_ds=(Bit16s)LoadMw(inst.rm_eaa);
-			else inst_op1_ds=(Bit16s)reg_16(inst.rm_eai);
+			if (inst.rm<0xc0) inst_op1_ds=(int16_t)LoadMw(inst.rm_eaa);
+			else inst_op1_ds=(int16_t)reg_16(inst.rm_eai);
 			break;
 		case M_EwIb:
 			inst_op2_d=Fetchb();
@@ -102,7 +102,7 @@ l_M_Ewx:
 			goto l_M_EwGw;
 		case M_EwGwt:
 			inst_op2_d=reg_16(inst.rm_index);
-			inst.rm_eaa+=((Bit16s)inst_op2_d >> 4) * 2;
+			inst.rm_eaa+=((int16_t)inst_op2_d >> 4) * 2;
 			goto l_M_Ew;
 		case M_EwGw:
 l_M_EwGw:
@@ -125,11 +125,11 @@ l_M_Ew:
 			inst_op1_d=Fetchd();
 			break;
 		case M_EdxGdx:
-			inst_op2_ds=(Bit32s)reg_32(inst.rm_index);
+			inst_op2_ds=(int32_t)reg_32(inst.rm_index);
 			[[fallthrough]];
 		case M_Edx:
-			if (inst.rm<0xc0) inst_op1_d=(Bit32s)LoadMd(inst.rm_eaa);
-			else inst_op1_d=(Bit32s)reg_32(inst.rm_eai);
+			if (inst.rm<0xc0) inst_op1_d=(int32_t)LoadMd(inst.rm_eaa);
+			else inst_op1_d=(int32_t)reg_32(inst.rm_eai);
 			break;
 		case M_EdIb:
 			inst_op2_d=Fetchb();
@@ -145,7 +145,7 @@ l_M_Ew:
 			goto l_M_EdGd;
 		case M_EdGdt:
 			inst_op2_d=reg_32(inst.rm_index);
-			inst.rm_eaa+=((Bit32s)inst_op2_d >> 5) * 4;
+			inst.rm_eaa+=((int32_t)inst_op2_d >> 5) * 4;
 			goto l_M_Ed;
 		case M_EdGdIb:
 			inst_imm_d=Fetchb();
@@ -358,14 +358,14 @@ l_M_Ed:
 		goto nextopcode;
 	case D_PUSHAw:
 		{
-			Bit16u old_sp=reg_sp;
+			uint16_t old_sp=reg_sp;
 			Push_16(reg_ax);Push_16(reg_cx);Push_16(reg_dx);Push_16(reg_bx);
 			Push_16(old_sp);Push_16(reg_bp);Push_16(reg_si);Push_16(reg_di);
 		}
 		goto nextopcode;
 	case D_PUSHAd:
 		{
-			Bit32u old_esp=reg_esp;
+			uint32_t old_esp=reg_esp;
 			Push_32(reg_eax);Push_32(reg_ecx);Push_32(reg_edx);Push_32(reg_ebx);
 			Push_32(old_esp);Push_32(reg_ebp);Push_32(reg_esi);Push_32(reg_edi);
 		}
@@ -393,22 +393,22 @@ l_M_Ed:
 			        reg_al = LoadMb(inst.seg.base + (reg_ebx + reg_al));
 		        } else {
 			        reg_al = LoadMb(inst.seg.base +
-			                        (Bit16u)(reg_bx + reg_al));
+			                        (uint16_t)(reg_bx + reg_al));
 		        }
 	        } else {
 			if (inst.prefix & PREFIX_ADDR) {
 			        reg_al = LoadMb(SegBase(ds) + (reg_ebx + reg_al));
 		        } else {
 			        reg_al = LoadMb(SegBase(ds) +
-			                        (Bit16u)(reg_bx + reg_al));
+			                        (uint16_t)(reg_bx + reg_al));
 		        }
 	        }
 		goto nextopcode;
 	case D_CBW:
-		reg_ax=(Bit8s)reg_al;
+		reg_ax=(int8_t)reg_al;
 		goto nextopcode;
 	case D_CWDE:
-		reg_eax=(Bit16s)reg_ax;
+		reg_eax=(int16_t)reg_ax;
 		goto nextopcode;
 	case D_CWD:
 		if (reg_ax & 0x8000) reg_dx=0xffff;
@@ -520,11 +520,11 @@ l_M_Ed:
 	case D_RDTSC: {
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW)
 			goto illegalopcode;
-	        Bit64s tsc = (Bit64s)(PIC_FullIndex() *
+	        int64_t tsc = (int64_t)(PIC_FullIndex() *
 	                              static_cast<double>(
 	                                      CPU_CycleAutoAdjust ? 70000 : CPU_CycleMax));
-	        reg_edx = (Bit32u)(tsc >> 32);
-		reg_eax = (Bit32u)(tsc & 0xffffffff);
+	        reg_edx = (uint32_t)(tsc >> 32);
+		reg_eax = (uint32_t)(tsc & 0xffffffff);
 		break;
 	}
 	default:

--- a/src/cpu/core_full/loadwrite.h
+++ b/src/cpu/core_full/loadwrite.h
@@ -25,19 +25,19 @@
 	continue;													\
 }
 
-static inline Bit8u the_Fetchb(EAPoint & loc) {
-	Bit8u temp=LoadMb(loc);
+static inline uint8_t the_Fetchb(EAPoint & loc) {
+	uint8_t temp=LoadMb(loc);
 	loc+=1;
 	return temp;
 }
 	
-static inline Bit16u the_Fetchw(EAPoint & loc) {
-	Bit16u temp=LoadMw(loc);
+static inline uint16_t the_Fetchw(EAPoint & loc) {
+	uint16_t temp=LoadMw(loc);
 	loc+=2;
 	return temp;
 }
-static inline Bit32u the_Fetchd(EAPoint & loc) {
-	Bit32u temp=LoadMd(loc);
+static inline uint32_t the_Fetchd(EAPoint & loc) {
+	uint32_t temp=LoadMd(loc);
 	loc+=4;
 	return temp;
 }
@@ -46,9 +46,9 @@ static inline Bit32u the_Fetchd(EAPoint & loc) {
 #define Fetchw() the_Fetchw(inst.cseip)
 #define Fetchd() the_Fetchd(inst.cseip)
 
-#define Fetchbs() (Bit8s)the_Fetchb(inst.cseip)
-#define Fetchws() (Bit16s)the_Fetchw(inst.cseip)
-#define Fetchds() (Bit32s)the_Fetchd(inst.cseip)
+#define Fetchbs() (int8_t)the_Fetchb(inst.cseip)
+#define Fetchws() (int16_t)the_Fetchw(inst.cseip)
+#define Fetchds() (int32_t)the_Fetchd(inst.cseip)
 
 #define Push_16 CPU_Push16
 #define Push_32 CPU_Push32

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -319,14 +319,14 @@ switch (inst.code.op) {
 		break;
 	case O_XCHG_AX:
 		{
-			Bit16u temp=reg_ax;
+			uint16_t temp=reg_ax;
 			reg_ax=inst_op1_w;
 			inst_op1_w=temp;
 			break;
 		}
 	case O_XCHG_EAX:
 		{
-			Bit32u temp=reg_eax;
+			uint32_t temp=reg_eax;
 			reg_eax=inst_op1_d;
 			inst_op1_d=temp;
 			break;
@@ -397,10 +397,10 @@ switch (inst.code.op) {
 		if ((reg_flags & FLAG_VM) || (!cpu.pmode)) goto illegalopcode;
 		switch (inst.rm_index) {
 		case 0x00:	/* SLDT */
-			inst_op1_d=(Bit32u)CPU_SLDT();
+			inst_op1_d=(uint32_t)CPU_SLDT();
 			break;
 		case 0x01:	/* STR */
-			inst_op1_d=(Bit32u)CPU_STR();
+			inst_op1_d=(uint32_t)CPU_STR();
 			break;
 		case 0x02:	/* LLDT */
 			if (cpu.cpl) EXCEPTION(EXCEPTION_GP);
@@ -479,21 +479,21 @@ switch (inst.code.op) {
 		{
 			Bitu ar=inst_op2_d;
 			CPU_LAR(inst_op1_w,ar);
-			inst_op1_d=(Bit32u)ar;
+			inst_op1_d=(uint32_t)ar;
 		}
 		break;
 	case O_LSL:
 		{
 			Bitu limit=inst_op2_d;
 			CPU_LSL(inst_op1_w,limit);
-			inst_op1_d=(Bit32u)limit;
+			inst_op1_d=(uint32_t)limit;
 		}
 		break;
 	case O_ARPL:
 		{
 			Bitu new_sel=inst_op1_d;
 			CPU_ARPL(new_sel,inst_op2_d);
-			inst_op1_d=(Bit32u)new_sel;
+			inst_op1_d=(uint32_t)new_sel;
 		}
 		break;
 	case O_BSFw:
@@ -651,10 +651,10 @@ switch (inst.code.op) {
 #endif
 	case O_BOUNDw:
 		{
-			Bit16s bound_min, bound_max;
+			int16_t bound_min, bound_max;
 			bound_min=LoadMw(inst.rm_eaa);
 			bound_max=LoadMw(inst.rm_eaa+2);
-			if ( (((Bit16s)inst_op1_w) < bound_min) || (((Bit16s)inst_op1_w) > bound_max) ) {
+			if ( (((int16_t)inst_op1_w) < bound_min) || (((int16_t)inst_op1_w) > bound_max) ) {
 				EXCEPTION(5);
 			}
 		}

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -160,7 +160,7 @@
 		break;
 	case R_SCASB:
 		{
-			Bit8u val2;
+			uint8_t val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val2=LoadMb(di_base+di_index);
@@ -173,7 +173,7 @@
 	case R_SCASW:
 		{
 			add_index *= 2;
-			Bit16u val2;
+			uint16_t val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val2=LoadMw(di_base+di_index);
@@ -186,7 +186,7 @@
 	case R_SCASD:
 		{
 			add_index *= 4;
-			Bit32u val2;
+			uint32_t val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val2=LoadMd(di_base+di_index);
@@ -198,7 +198,7 @@
 		break;
 	case R_CMPSB:
 		{
-			Bit8u val1,val2;
+			uint8_t val1,val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val1=LoadMb(si_base+si_index);
@@ -213,7 +213,7 @@
 	case R_CMPSW:
 		{
 			add_index *= 2;
-			Bit16u val1,val2;
+			uint16_t val1,val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val1=LoadMw(si_base+si_index);
@@ -228,7 +228,7 @@
 	case R_CMPSD:
 		{
 			add_index *= 4;
-			Bit32u val1,val2;
+			uint32_t val1,val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val1=LoadMd(si_base+si_index);

--- a/src/cpu/core_full/support.h
+++ b/src/cpu/core_full/support.h
@@ -166,7 +166,7 @@ enum {
 };
 
 struct OpCode {
-	Bit8u load,op,save,extra;
+	uint8_t load,op,save,extra;
 };
 
 struct FullData {
@@ -181,18 +181,18 @@ struct FullData {
 	EAPoint cseip;
 #ifdef WORDS_BIGENDIAN
 	union {
-		Bit32u dword[1];
-		Bit32s dwords[1];
-		Bit16u word[2];
-		Bit16s words[2];
-		Bit8u byte[4];
-		Bit8s bytes[4];
+		uint32_t dword[1];
+		int32_t dwords[1];
+		uint16_t word[2];
+		int16_t words[2];
+		uint8_t byte[4];
+		int8_t bytes[4];
 		} blah1,blah2,blah_imm;
 #else
 	union {	
-		Bit8u b;Bit8s bs;
-		Bit16u w;Bit16s ws;
-		Bit32u d;Bit32s ds;
+		uint8_t b;int8_t bs;
+		uint16_t w;int16_t ws;
+		uint32_t d;int32_t ds;
 	} op1,op2,imm;
 #endif
 	Bitu new_flags;

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -89,7 +89,7 @@ extern Bitu cycle_count;
 
 typedef PhysPt (*GetEAHandler)(void);
 
-static const Bit32u AddrMaskTable[2]={0x0000ffff,0xffffffff};
+static const uint32_t AddrMaskTable[2]={0x0000ffff,0xffffffff};
 
 static struct {
 	Bitu opcode_index;
@@ -109,19 +109,19 @@ static struct {
 #define BaseDS		core.base_ds
 #define BaseSS		core.base_ss
 
-static inline Bit8u Fetchb() {
-	Bit8u temp=LoadMb(core.cseip);
+static inline uint8_t Fetchb() {
+	uint8_t temp=LoadMb(core.cseip);
 	core.cseip+=1;
 	return temp;
 }
 
-static inline Bit16u Fetchw() {
-	Bit16u temp=LoadMw(core.cseip);
+static inline uint16_t Fetchw() {
+	uint16_t temp=LoadMw(core.cseip);
 	core.cseip+=2;
 	return temp;
 }
-static inline Bit32u Fetchd() {
-	Bit32u temp=LoadMd(core.cseip);
+static inline uint32_t Fetchd() {
+	uint32_t temp=LoadMd(core.cseip);
 	core.cseip+=4;
 	return temp;
 }

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -133,7 +133,7 @@
 	{ inst(reg_eax,Fetchd(),LoadRd,SaveRd);}
 
 #define FPU_ESC(code) {														\
-	Bit8u rm=Fetchb();														\
+	uint8_t rm=Fetchb();														\
 	if (rm >= 0xc0) {															\
 		FPU_ESC ## code ## _Normal(rm);										\
 	} else {																\
@@ -171,5 +171,5 @@
 		case 2: \
 		case 3: BaseDS = BaseSS; \
 		} \
-		eaa = BaseDS + (Bit16u)(eaa - BaseDS); \
+		eaa = BaseDS + (uint16_t)(eaa - BaseDS); \
 	} while (0)

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -121,7 +121,7 @@
 			} else {
 				GetEAa;CPU_LAR(LoadMw(eaa),ar);
 			}
-			*rmrw=(Bit16u)ar;
+			*rmrw=(uint16_t)ar;
 		}
 		break;
 	CASE_0F_W(0x03)												/* LSL Gw,Ew */
@@ -133,7 +133,7 @@
 			} else {
 				GetEAa;CPU_LSL(LoadMw(eaa),limit);
 			}
-			*rmrw=(Bit16u)limit;
+			*rmrw=(uint16_t)limit;
 		}
 		break;
 	CASE_0F_B(0x06)												/* CLTS */
@@ -154,7 +154,7 @@
 				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,CR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
-			Bit32u crx_value;
+			uint32_t crx_value;
 			if (CPU_READ_CRX(which,crx_value)) RUNEXCEPTION();
 			*eard=crx_value;
 		}
@@ -168,7 +168,7 @@
 				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,DR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
-			Bit32u drx_value;
+			uint32_t drx_value;
 			if (CPU_READ_DRX(which,drx_value)) RUNEXCEPTION();
 			*eard=drx_value;
 		}
@@ -206,7 +206,7 @@
 				LOG(LOG_CPU,LOG_ERROR)("MOV XXX,TR%u with non-register", static_cast<uint32_t>(which));
 			}
 			GetEArd;
-			Bit32u trx_value;
+			uint32_t trx_value;
 			if (CPU_READ_TRX(which,trx_value)) RUNEXCEPTION();
 			*eard=trx_value;
 		}
@@ -228,12 +228,12 @@
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_PENTIUMSLOW)
 				goto illegal_opcode;
 			/* Use a fixed number when in auto cycles mode as else the reported value changes constantly */
-	                Bit64s tsc = (Bit64s)(PIC_FullIndex() *
+	                int64_t tsc = (int64_t)(PIC_FullIndex() *
 	                                      static_cast<double>(CPU_CycleAutoAdjust
 	                                                                  ? 70000
 	                                                                  : CPU_CycleMax));
-	                reg_edx = (Bit32u)(tsc >> 32);
-			reg_eax = (Bit32u)(tsc & 0xffffffff);
+	                reg_edx = (uint32_t)(tsc >> 32);
+			reg_eax = (uint32_t)(tsc & 0xffffffff);
 		}
 		break;
 	CASE_0F_W(0x80) /* JO */
@@ -313,14 +313,14 @@
 	CASE_0F_W(0xa3)												/* BT Ew,Gw */
 		{
 			FillFlags();GetRMrw;
-			Bit16u mask=1 << (*rmrw & 15);
+			uint16_t mask=1 << (*rmrw & 15);
 			if (rm >= 0xc0 ) {
 				GetEArw;
 				SETFLAGBIT(CF,(*earw & mask));
 			} else {
-				GetEAa;eaa+=(((Bit16s)*rmrw)>>4)*2;
+				GetEAa;eaa+=(((int16_t)*rmrw)>>4)*2;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit16u old=LoadMw(eaa);
+				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 			}
 			break;
@@ -339,15 +339,15 @@
 	CASE_0F_W(0xab)												/* BTS Ew,Gw */
 		{
 			FillFlags();GetRMrw;
-			Bit16u mask=1 << (*rmrw & 15);
+			uint16_t mask=1 << (*rmrw & 15);
 			if (rm >= 0xc0 ) {
 				GetEArw;
 				SETFLAGBIT(CF,(*earw & mask));
 				*earw|=mask;
 			} else {
-				GetEAa;eaa+=(((Bit16s)*rmrw)>>4)*2;
+				GetEAa;eaa+=(((int16_t)*rmrw)>>4)*2;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit16u old=LoadMw(eaa);
+				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMw(eaa,old | mask);
 			}
@@ -378,7 +378,7 @@
 				}
 			} else {
    				GetEAa;
-				Bit8u val = LoadMb(eaa);
+				uint8_t val = LoadMb(eaa);
 				if (reg_al == val) { 
 					SaveMb(eaa,*rmrb);
 					SETFLAGBIT(ZF,1);
@@ -406,7 +406,7 @@
 				}
 			} else {
    				GetEAa;
-				Bit16u val = LoadMw(eaa);
+				uint16_t val = LoadMw(eaa);
 				if(reg_ax == val) { 
 					SaveMw(eaa,*rmrw);
 					SETFLAGBIT(ZF,1);
@@ -431,15 +431,15 @@
 	CASE_0F_W(0xb3)												/* BTR Ew,Gw */
 		{
 			FillFlags();GetRMrw;
-			Bit16u mask=1 << (*rmrw & 15);
+			uint16_t mask=1 << (*rmrw & 15);
 			if (rm >= 0xc0 ) {
 				GetEArw;
 				SETFLAGBIT(CF,(*earw & mask));
 				*earw&= ~mask;
 			} else {
-				GetEAa;eaa+=(((Bit16s)*rmrw)>>4)*2;
+				GetEAa;eaa+=(((int16_t)*rmrw)>>4)*2;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit16u old=LoadMw(eaa);
+				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMw(eaa,old & ~mask);
 			}
@@ -483,7 +483,7 @@
 			FillFlags();GetRM;
 			if (rm >= 0xc0 ) {
 				GetEArw;
-				Bit16u mask=1 << (Fetchb() & 15);
+				uint16_t mask=1 << (Fetchb() & 15);
 				SETFLAGBIT(CF,(*earw & mask));
 				switch (rm & 0x38) {
 				case 0x20:										/* BT */
@@ -501,8 +501,8 @@
 					E_Exit("CPU:0F:BA:Illegal subfunction %X",rm & 0x38);
 				}
 			} else {
-				GetEAa;Bit16u old=LoadMw(eaa);
-				Bit16u mask=1 << (Fetchb() & 15);
+				GetEAa;uint16_t old=LoadMw(eaa);
+				uint16_t mask=1 << (Fetchb() & 15);
 				SETFLAGBIT(CF,(old & mask));
 				switch (rm & 0x38) {
 				case 0x20:										/* BT */
@@ -525,15 +525,15 @@
 	CASE_0F_W(0xbb)												/* BTC Ew,Gw */
 		{
 			FillFlags();GetRMrw;
-			Bit16u mask=1 << (*rmrw & 15);
+			uint16_t mask=1 << (*rmrw & 15);
 			if (rm >= 0xc0 ) {
 				GetEArw;
 				SETFLAGBIT(CF,(*earw & mask));
 				*earw^=mask;
 			} else {
-				GetEAa;eaa+=(((Bit16s)*rmrw)>>4)*2;
+				GetEAa;eaa+=(((int16_t)*rmrw)>>4)*2;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit16u old=LoadMw(eaa);
+				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMw(eaa,old ^ mask);
 			}
@@ -542,7 +542,7 @@
 	CASE_0F_W(0xbc)												/* BSF Gw,Ew */
 		{
 			GetRMrw;
-			Bit16u result,value;
+			uint16_t result,value;
 			if (rm >= 0xc0) { GetEArw; value=*earw; } 
 			else			{ GetEAa; value=LoadMw(eaa); }
 			if (value==0) {
@@ -559,7 +559,7 @@
 	CASE_0F_W(0xbd)												/* BSR Gw,Ew */
 		{
 			GetRMrw;
-			Bit16u result,value;
+			uint16_t result,value;
 			if (rm >= 0xc0) { GetEArw; value=*earw; } 
 			else			{ GetEAa; value=LoadMw(eaa); }
 			if (value==0) {
@@ -576,14 +576,14 @@
 	CASE_0F_W(0xbe)												/* MOVSX Gw,Eb */
 		{
 			GetRMrw;															
-			if (rm >= 0xc0 ) {GetEArb;*rmrw=*(Bit8s *)earb;}
+			if (rm >= 0xc0 ) {GetEArb;*rmrw=*(int8_t *)earb;}
 			else {GetEAa;*rmrw=LoadMbs(eaa);}
 			break;
 		}
 	CASE_0F_B(0xc0)												/* XADD Gb,Eb */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrb;Bit8u oldrmrb=*rmrb;
+			GetRMrb;uint8_t oldrmrb=*rmrb;
 			if (rm >= 0xc0 ) {GetEArb;*rmrb=*earb;*earb+=oldrmrb;}
 			else {GetEAa;*rmrb=LoadMb(eaa);SaveMb(eaa,LoadMb(eaa)+oldrmrb);}
 			break;
@@ -591,7 +591,7 @@
 	CASE_0F_W(0xc1)												/* XADD Gw,Ew */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrw;Bit16u oldrmrw=*rmrw;
+			GetRMrw;uint16_t oldrmrw=*rmrw;
 			if (rm >= 0xc0 ) {GetEArw;*rmrw=*earw;*earw+=oldrmrw;}
 			else {GetEAa;*rmrw=LoadMw(eaa);SaveMw(eaa,LoadMw(eaa)+oldrmrw);}
 			break;

--- a/src/cpu/core_normal/prefix_66.h
+++ b/src/cpu/core_normal/prefix_66.h
@@ -158,11 +158,11 @@
 		break;
 	CASE_D(0x62)												/* BOUND Ed */
 		{
-			Bit32s bound_min, bound_max;
+			int32_t bound_min, bound_max;
 			GetRMrd;GetEAa;
 			bound_min=LoadMd(eaa);
 			bound_max=LoadMd(eaa+4);
-			if ( (((Bit32s)*rmrd) < bound_min) || (((Bit32s)*rmrd) > bound_max) ) {
+			if ( (((int32_t)*rmrd) < bound_min) || (((int32_t)*rmrd) > bound_max) ) {
 				EXCEPTION(5);
 			}
 		}
@@ -172,13 +172,13 @@
 			if (((cpu.pmode) && (reg_flags & FLAG_VM)) || (!cpu.pmode)) goto illegal_opcode;
 			GetRMrw;
 			if (rm >= 0xc0 ) {
-				GetEArd;Bitu new_sel=(Bit16u)*eard;
+				GetEArd;Bitu new_sel=(uint16_t)*eard;
 				CPU_ARPL(new_sel,*rmrw);
-				*eard=(Bit32u)new_sel;
+				*eard=(uint32_t)new_sel;
 			} else {
 				GetEAa;Bitu new_sel=LoadMw(eaa);
 				CPU_ARPL(new_sel,*rmrw);
-				SaveMd(eaa,(Bit32u)new_sel);
+				SaveMd(eaa,(uint32_t)new_sel);
 			}
 		}
 		break;
@@ -234,7 +234,7 @@
 		{
 			GetRM;Bitu which=(rm>>3)&7;
 			if (rm >= 0xc0) {
-				GetEArd;Bit32u id=Fetchd();
+				GetEArd;uint32_t id=Fetchd();
 				switch (which) {
 				case 0x00:ADDD(*eard,id,LoadRd,SaveRd);break;
 				case 0x01: ORD(*eard,id,LoadRd,SaveRd);break;
@@ -246,7 +246,7 @@
 				case 0x07:CMPD(*eard,id,LoadRd,SaveRd);break;
 				}
 			} else {
-				GetEAa;Bit32u id=Fetchd();
+				GetEAa;uint32_t id=Fetchd();
 				switch (which) {
 				case 0x00:ADDD(eaa,id,LoadMd,SaveMd);break;
 				case 0x01: ORD(eaa,id,LoadMd,SaveMd);break;
@@ -264,7 +264,7 @@
 		{
 			GetRM;Bitu which=(rm>>3)&7;
 			if (rm >= 0xc0) {
-				GetEArd;Bit32u id=(Bit32s)Fetchbs();
+				GetEArd;uint32_t id=(int32_t)Fetchbs();
 				switch (which) {
 				case 0x00:ADDD(*eard,id,LoadRd,SaveRd);break;
 				case 0x01: ORD(*eard,id,LoadRd,SaveRd);break;
@@ -276,7 +276,7 @@
 				case 0x07:CMPD(*eard,id,LoadRd,SaveRd);break;
 				}
 			} else {
-				GetEAa;Bit32u id=(Bit32s)Fetchbs();
+				GetEAa;uint32_t id=(int32_t)Fetchbs();
 				switch (which) {
 				case 0x00:ADDD(eaa,id,LoadMd,SaveMd);break;
 				case 0x01: ORD(eaa,id,LoadMd,SaveMd);break;
@@ -294,7 +294,7 @@
 		RMEdGd(TESTD);break;
 	CASE_D(0x87)												/* XCHG Ed,Gd */
 		{	
-			GetRMrd;Bit32u oldrmrd=*rmrd;
+			GetRMrd;uint32_t oldrmrd=*rmrd;
 			if (rm >= 0xc0 ) {GetEArd;*rmrd=*eard;*eard=oldrmrd;}
 			else {GetEAa;*rmrd=LoadMd(eaa);SaveMd(eaa,oldrmrd);}
 			break;
@@ -315,7 +315,7 @@
 		}
 	CASE_D(0x8c)												/* Mov Ew,Sw */
 			{
-				GetRM;Bit16u val;Bitu which=(rm>>3)&7;
+				GetRM;uint16_t val;Bitu which=(rm>>3)&7;
 				switch (which) {
 				case 0x00:					/* MOV Ew,ES */
 					val=SegValue(es);break;
@@ -352,41 +352,41 @@
                 }
 	CASE_D(0x8f)												/* POP Ed */
 		{
-			Bit32u val=Pop_32();
+			uint32_t val=Pop_32();
 			GetRM;
 			if (rm >= 0xc0 ) {GetEArd;*eard=val;}
 			else {GetEAa;SaveMd(eaa,val);}
 			break;
 		}
 	CASE_D(0x91)												/* XCHG ECX,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_ecx;reg_ecx=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_ecx;reg_ecx=temp;break;}
 	CASE_D(0x92)												/* XCHG EDX,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_edx;reg_edx=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_edx;reg_edx=temp;break;}
 		break;
 	CASE_D(0x93)												/* XCHG EBX,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_ebx;reg_ebx=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_ebx;reg_ebx=temp;break;}
 		break;
 	CASE_D(0x94)												/* XCHG ESP,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_esp;reg_esp=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_esp;reg_esp=temp;break;}
 		break;
 	CASE_D(0x95)												/* XCHG EBP,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_ebp;reg_ebp=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_ebp;reg_ebp=temp;break;}
 		break;
 	CASE_D(0x96)												/* XCHG ESI,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_esi;reg_esi=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_esi;reg_esi=temp;break;}
 		break;
 	CASE_D(0x97)												/* XCHG EDI,EAX */
-		{ Bit32u temp=reg_eax;reg_eax=reg_edi;reg_edi=temp;break;}
+		{ uint32_t temp=reg_eax;reg_eax=reg_edi;reg_edi=temp;break;}
 		break;
 	CASE_D(0x98)												/* CWDE */
-		reg_eax=(Bit16s)reg_ax;break;
+		reg_eax=(int16_t)reg_ax;break;
 	CASE_D(0x99)												/* CDQ */
 		if (reg_eax & 0x80000000) reg_edx=0xffffffff;
 		else reg_edx=0;
 		break;
 	CASE_D(0x9a)												/* CALL FAR Ad */
 		{ 
-			Bit32u newip=Fetchd();Bit16u newcs=Fetchw();
+			uint32_t newip=Fetchd();uint16_t newcs=Fetchw();
 			FillFlags();
 			CPU_CALL(true,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK
@@ -569,7 +569,7 @@
 		}
 	CASE_D(0xe8)												/* CALL Jd */
 		{ 
-			Bit32s addip=Fetchds();
+			int32_t addip=Fetchds();
 			SAVEIP;
 			Push_32(reg_eip);
 			reg_eip+=addip;
@@ -577,15 +577,15 @@
 		}
 	CASE_D(0xe9)												/* JMP Jd */
 		{ 
-			Bit32s addip=Fetchds();
+			int32_t addip=Fetchds();
 			SAVEIP;
 			reg_eip+=addip;
 			continue;
 		}
 	CASE_D(0xea)												/* JMP Ad */
 		{ 
-			Bit32u newip=Fetchd();
-			Bit16u newcs=Fetchw();
+			uint32_t newip=Fetchd();
+			uint16_t newcs=Fetchw();
 			FillFlags();
 			CPU_JMP(true,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK
@@ -598,7 +598,7 @@
 		}
 	CASE_D(0xeb)												/* JMP Jb */
 		{ 
-			Bit32s addip=Fetchbs();
+			int32_t addip=Fetchbs();
 			SAVEIP;
 			reg_eip+=addip;
 			continue;
@@ -674,8 +674,8 @@
 				{
 					if (rm >= 0xc0) goto illegal_opcode;
 					GetEAa;
-					Bit32u newip=LoadMd(eaa);
-					Bit16u newcs=LoadMw(eaa+4);
+					uint32_t newip=LoadMd(eaa);
+					uint16_t newcs=LoadMw(eaa+4);
 					FillFlags();
 					CPU_CALL(true,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK
@@ -694,8 +694,8 @@
 				{
 					if (rm >= 0xc0) goto illegal_opcode;
 					GetEAa;
-					Bit32u newip=LoadMd(eaa);
-					Bit16u newcs=LoadMw(eaa+4);
+					uint32_t newip=LoadMd(eaa);
+					uint16_t newcs=LoadMw(eaa+4);
 					FillFlags();
 					CPU_JMP(true,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -27,7 +27,7 @@
 					Bitu saveval;
 					if (!which) saveval=CPU_SLDT();
 					else saveval=CPU_STR();
-					if (rm >= 0xc0) {GetEArw;*earw=(Bit16u)saveval;}
+					if (rm >= 0xc0) {GetEArw;*earw=(uint16_t)saveval;}
 					else {GetEAa;SaveMw(eaa,saveval);}
 				}
 				break;
@@ -68,12 +68,12 @@
 				GetEAa;Bitu limit;
 				switch (which) {
 				case 0x00:										/* SGDT */
-					SaveMw(eaa,(Bit16u)CPU_SGDT_limit());
-					SaveMd(eaa+2,(Bit32u)CPU_SGDT_base());
+					SaveMw(eaa,(uint16_t)CPU_SGDT_limit());
+					SaveMd(eaa+2,(uint32_t)CPU_SGDT_base());
 					break;
 				case 0x01:										/* SIDT */
-					SaveMw(eaa,(Bit16u)CPU_SIDT_limit());
-					SaveMd(eaa+2,(Bit32u)CPU_SIDT_base());
+					SaveMw(eaa,(uint16_t)CPU_SIDT_limit());
+					SaveMd(eaa+2,(uint32_t)CPU_SIDT_base());
 					break;
 				case 0x02:										/* LGDT */
 					if (cpu.pmode && cpu.cpl) EXCEPTION(EXCEPTION_GP);
@@ -84,11 +84,11 @@
 					CPU_LIDT(LoadMw(eaa),LoadMd(eaa+2));
 					break;
 				case 0x04:										/* SMSW */
-					SaveMw(eaa,(Bit16u)CPU_SMSW());
+					SaveMw(eaa,(uint16_t)CPU_SMSW());
 					break;
 				case 0x06:										/* LMSW */
 					limit=LoadMw(eaa);
-					if (CPU_LMSW((Bit16u)limit)) RUNEXCEPTION();
+					if (CPU_LMSW((uint16_t)limit)) RUNEXCEPTION();
 					break;
 				case 0x07:										/* INVLPG */
 					if (cpu.pmode && cpu.cpl) EXCEPTION(EXCEPTION_GP);
@@ -103,7 +103,7 @@
 					if (cpu.pmode && cpu.cpl) EXCEPTION(EXCEPTION_GP);
 					goto illegal_opcode;
 				case 0x04:										/* SMSW */
-					*eard=(Bit32u)CPU_SMSW();
+					*eard=(uint32_t)CPU_SMSW();
 					break;
 				case 0x06:										/* LMSW */
 					if (CPU_LMSW(*eard)) RUNEXCEPTION();
@@ -126,7 +126,7 @@
 			} else {
 				GetEAa;CPU_LAR(LoadMw(eaa),ar);
 			}
-			*rmrd=(Bit32u)ar;
+			*rmrd=(uint32_t)ar;
 		}
 		break;
 	CASE_0F_D(0x03)												/* LSL Gd,Ew */
@@ -139,7 +139,7 @@
 			} else {
 				GetEAa;CPU_LSL(LoadMw(eaa),limit);
 			}
-			*rmrd=(Bit32u)limit;
+			*rmrd=(uint32_t)limit;
 		}
 		break;
 	CASE_0F_D(0x80)												/* JO */
@@ -183,14 +183,14 @@
 	CASE_0F_D(0xa3)												/* BT Ed,Gd */
 		{
 			FillFlags();GetRMrd;
-			Bit32u mask=1 << (*rmrd & 31);
+			uint32_t mask=1 << (*rmrd & 31);
 			if (rm >= 0xc0 ) {
 				GetEArd;
 				SETFLAGBIT(CF,(*eard & mask));
 			} else {
-				GetEAa;eaa+=(((Bit32s)*rmrd)>>5)*4;
+				GetEAa;eaa+=(((int32_t)*rmrd)>>5)*4;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit32u old=LoadMd(eaa);
+				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 			}
 			break;
@@ -209,15 +209,15 @@
 	CASE_0F_D(0xab)												/* BTS Ed,Gd */
 		{
 			FillFlags();GetRMrd;
-			Bit32u mask=1 << (*rmrd & 31);
+			uint32_t mask=1 << (*rmrd & 31);
 			if (rm >= 0xc0 ) {
 				GetEArd;
 				SETFLAGBIT(CF,(*eard & mask));
 				*eard|=mask;
 			} else {
-				GetEAa;eaa+=(((Bit32s)*rmrd)>>5)*4;
+				GetEAa;eaa+=(((int32_t)*rmrd)>>5)*4;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit32u old=LoadMd(eaa);
+				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMd(eaa,old | mask);
 			}
@@ -251,7 +251,7 @@
 				}
 			} else {
 				GetEAa;
-				Bit32u val=LoadMd(eaa);
+				uint32_t val=LoadMd(eaa);
 				if (val==reg_eax) {
 					SaveMd(eaa,*rmrd);
 					SETFLAGBIT(ZF,1);
@@ -275,15 +275,15 @@
 	CASE_0F_D(0xb3)												/* BTR Ed,Gd */
 		{
 			FillFlags();GetRMrd;
-			Bit32u mask=1 << (*rmrd & 31);
+			uint32_t mask=1 << (*rmrd & 31);
 			if (rm >= 0xc0 ) {
 				GetEArd;
 				SETFLAGBIT(CF,(*eard & mask));
 				*eard&= ~mask;
 			} else {
-				GetEAa;eaa+=(((Bit32s)*rmrd)>>5)*4;
+				GetEAa;eaa+=(((int32_t)*rmrd)>>5)*4;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit32u old=LoadMd(eaa);
+				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMd(eaa,old & ~mask);
 			}
@@ -326,7 +326,7 @@
 			FillFlags();GetRM;
 			if (rm >= 0xc0 ) {
 				GetEArd;
-				Bit32u mask=1 << (Fetchb() & 31);
+				uint32_t mask=1 << (Fetchb() & 31);
 				SETFLAGBIT(CF,(*eard & mask));
 				switch (rm & 0x38) {
 				case 0x20:											/* BT */
@@ -345,8 +345,8 @@
 					E_Exit("CPU:66:0F:BA:Illegal subfunction %X",rm & 0x38);
 				}
 			} else {
-				GetEAa;Bit32u old=LoadMd(eaa);
-				Bit32u mask=1 << (Fetchb() & 31);
+				GetEAa;uint32_t old=LoadMd(eaa);
+				uint32_t mask=1 << (Fetchb() & 31);
 				SETFLAGBIT(CF,(old & mask));
 				switch (rm & 0x38) {
 				case 0x20:											/* BT */
@@ -371,15 +371,15 @@
 	CASE_0F_D(0xbb)												/* BTC Ed,Gd */
 		{
 			FillFlags();GetRMrd;
-			Bit32u mask=1 << (*rmrd & 31);
+			uint32_t mask=1 << (*rmrd & 31);
 			if (rm >= 0xc0 ) {
 				GetEArd;
 				SETFLAGBIT(CF,(*eard & mask));
 				*eard^=mask;
 			} else {
-				GetEAa;eaa+=(((Bit32s)*rmrd)>>5)*4;
+				GetEAa;eaa+=(((int32_t)*rmrd)>>5)*4;
 				if (!TEST_PREFIX_ADDR) FixEA16;
-				Bit32u old=LoadMd(eaa);
+				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMd(eaa,old ^ mask);
 			}
@@ -388,7 +388,7 @@
 	CASE_0F_D(0xbc)												/* BSF Gd,Ed */
 		{
 			GetRMrd;
-			Bit32u result,value;
+			uint32_t result,value;
 			if (rm >= 0xc0) { GetEArd; value=*eard; } 
 			else			{ GetEAa; value=LoadMd(eaa); }
 			if (value==0) {
@@ -405,7 +405,7 @@
 	CASE_0F_D(0xbd)												/*  BSR Gd,Ed */
 		{
 			GetRMrd;
-			Bit32u result,value;
+			uint32_t result,value;
 			if (rm >= 0xc0) { GetEArd; value=*eard; } 
 			else			{ GetEAa; value=LoadMd(eaa); }
 			if (value==0) {
@@ -422,21 +422,21 @@
 	CASE_0F_D(0xbe)												/* MOVSX Gd,Eb */
 		{
 			GetRMrd;															
-			if (rm >= 0xc0 ) {GetEArb;*rmrd=*(Bit8s *)earb;}
+			if (rm >= 0xc0 ) {GetEArb;*rmrd=*(int8_t *)earb;}
 			else {GetEAa;*rmrd=LoadMbs(eaa);}
 			break;
 		}
 	CASE_0F_D(0xbf)												/* MOVSX Gd,Ew */
 		{
 			GetRMrd;															
-			if (rm >= 0xc0 ) {GetEArw;*rmrd=*(Bit16s *)earw;}
+			if (rm >= 0xc0 ) {GetEArw;*rmrd=*(int16_t *)earw;}
 			else {GetEAa;*rmrd=LoadMws(eaa);}
 			break;
 		}
 	CASE_0F_D(0xc1)												/* XADD Gd,Ed */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrd;Bit32u oldrmrd=*rmrd;
+			GetRMrd;uint32_t oldrmrd=*rmrd;
 			if (rm >= 0xc0 ) {GetEArd;*rmrd=*eard;*eard+=oldrmrd;}
 			else {GetEAa;*rmrd=LoadMd(eaa);SaveMd(eaa,LoadMd(eaa)+oldrmrd);}
 			break;

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -216,7 +216,7 @@
 		reg_di=Pop_16();break;
 	CASE_W(0x60)												/* PUSHA */
 		{
-			Bit16u old_sp=reg_sp;
+			uint16_t old_sp=reg_sp;
 			Push_16(reg_ax);Push_16(reg_cx);Push_16(reg_dx);Push_16(reg_bx);
 			Push_16(old_sp);Push_16(reg_bp);Push_16(reg_si);Push_16(reg_di);
 		}
@@ -227,11 +227,11 @@
 		break;
 	CASE_W(0x62)												/* BOUND */
 		{
-			Bit16s bound_min, bound_max;
+			int16_t bound_min, bound_max;
 			GetRMrw;GetEAa;
 			bound_min=LoadMw(eaa);
 			bound_max=LoadMw(eaa+2);
-			if ( (((Bit16s)*rmrw) < bound_min) || (((Bit16s)*rmrw) > bound_max) ) {
+			if ( (((int16_t)*rmrw) < bound_min) || (((int16_t)*rmrw) > bound_max) ) {
 				EXCEPTION(5);
 			}
 		}
@@ -243,11 +243,11 @@
 			if (rm >= 0xc0 ) {
 				GetEArw;Bitu new_sel=*earw;
 				CPU_ARPL(new_sel,*rmrw);
-				*earw=(Bit16u)new_sel;
+				*earw=(uint16_t)new_sel;
 			} else {
 				GetEAa;Bitu new_sel=LoadMw(eaa);
 				CPU_ARPL(new_sel,*rmrw);
-				SaveMw(eaa,(Bit16u)new_sel);
+				SaveMw(eaa,(uint16_t)new_sel);
 			}
 		}
 		break;
@@ -320,7 +320,7 @@
 		{
 			GetRM;Bitu which=(rm>>3)&7;
 			if (rm>= 0xc0) {
-				GetEArb;Bit8u ib=Fetchb();
+				GetEArb;uint8_t ib=Fetchb();
 				switch (which) {
 				case 0x00:ADDB(*earb,ib,LoadRb,SaveRb);break;
 				case 0x01: ORB(*earb,ib,LoadRb,SaveRb);break;
@@ -332,7 +332,7 @@
 				case 0x07:CMPB(*earb,ib,LoadRb,SaveRb);break;
 				}
 			} else {
-				GetEAa;Bit8u ib=Fetchb();
+				GetEAa;uint8_t ib=Fetchb();
 				switch (which) {
 				case 0x00:ADDB(eaa,ib,LoadMb,SaveMb);break;
 				case 0x01: ORB(eaa,ib,LoadMb,SaveMb);break;
@@ -350,7 +350,7 @@
 		{
 			GetRM;Bitu which=(rm>>3)&7;
 			if (rm>= 0xc0) {
-				GetEArw;Bit16u iw=Fetchw();
+				GetEArw;uint16_t iw=Fetchw();
 				switch (which) {
 				case 0x00:ADDW(*earw,iw,LoadRw,SaveRw);break;
 				case 0x01: ORW(*earw,iw,LoadRw,SaveRw);break;
@@ -362,7 +362,7 @@
 				case 0x07:CMPW(*earw,iw,LoadRw,SaveRw);break;
 				}
 			} else {
-				GetEAa;Bit16u iw=Fetchw();
+				GetEAa;uint16_t iw=Fetchw();
 				switch (which) {
 				case 0x00:ADDW(eaa,iw,LoadMw,SaveMw);break;
 				case 0x01: ORW(eaa,iw,LoadMw,SaveMw);break;
@@ -380,7 +380,7 @@
 		{
 			GetRM;Bitu which=(rm>>3)&7;
 			if (rm>= 0xc0) {
-				GetEArw;Bit16u iw=(Bit16s)Fetchbs();
+				GetEArw;uint16_t iw=(int16_t)Fetchbs();
 				switch (which) {
 				case 0x00:ADDW(*earw,iw,LoadRw,SaveRw);break;
 				case 0x01: ORW(*earw,iw,LoadRw,SaveRw);break;
@@ -392,7 +392,7 @@
 				case 0x07:CMPW(*earw,iw,LoadRw,SaveRw);break;
 				}
 			} else {
-				GetEAa;Bit16u iw=(Bit16s)Fetchbs();
+				GetEAa;uint16_t iw=(int16_t)Fetchbs();
 				switch (which) {
 				case 0x00:ADDW(eaa,iw,LoadMw,SaveMw);break;
 				case 0x01: ORW(eaa,iw,LoadMw,SaveMw);break;
@@ -414,14 +414,14 @@
 		break;
 	CASE_B(0x86)												/* XCHG Eb,Gb */
 		{	
-			GetRMrb;Bit8u oldrmrb=*rmrb;
+			GetRMrb;uint8_t oldrmrb=*rmrb;
 			if (rm >= 0xc0 ) {GetEArb;*rmrb=*earb;*earb=oldrmrb;}
 			else {GetEAa;*rmrb=LoadMb(eaa);SaveMb(eaa,oldrmrb);}
 			break;
 		}
 	CASE_W(0x87)												/* XCHG Ew,Gw */
 		{	
-			GetRMrw;Bit16u oldrmrw=*rmrw;
+			GetRMrw;uint16_t oldrmrw=*rmrw;
 			if (rm >= 0xc0 ) {GetEArw;*rmrw=*earw;*earw=oldrmrw;}
 			else {GetEAa;*rmrw=LoadMw(eaa);SaveMw(eaa,oldrmrw);}
 			break;
@@ -468,7 +468,7 @@
 		}
 	CASE_W(0x8c)												/* Mov Ew,Sw */
 		{
-			GetRM;Bit16u val;Bitu which=(rm>>3)&7;
+			GetRM;uint16_t val;Bitu which=(rm>>3)&7;
 			switch (which) {
 			case 0x00:					/* MOV Ew,ES */
 				val=SegValue(es);break;
@@ -497,15 +497,15 @@
 			//Little hack to always use segprefixed version
 			BaseDS=BaseSS=0;
 			if (TEST_PREFIX_ADDR) {
-				*rmrw=(Bit16u)(*EATable[256+rm])();
+				*rmrw=(uint16_t)(*EATable[256+rm])();
 			} else {
-				*rmrw=(Bit16u)(*EATable[rm])();
+				*rmrw=(uint16_t)(*EATable[rm])();
 			}
 			break;
 		}
 	CASE_B(0x8e)												/* MOV Sw,Ew */
 		{
-			GetRM;Bit16u val;Bitu which=(rm>>3)&7;
+			GetRM;uint16_t val;Bitu which=(rm>>3)&7;
 			if (rm >= 0xc0 ) {GetEArw;val=*earw;}
 			else {GetEAa;val=LoadMw(eaa);}
 			switch (which) {
@@ -525,7 +525,7 @@
 		}							
 	CASE_W(0x8f)												/* POP Ew */
 		{
-			Bit16u val=Pop_16();
+			uint16_t val=Pop_16();
 			GetRM;
 			if (rm >= 0xc0 ) {GetEArw;*earw=val;}
 			else {GetEAa;SaveMw(eaa,val);}
@@ -534,35 +534,35 @@
 	CASE_B(0x90)												/* NOP */
 		break;
 	CASE_W(0x91)												/* XCHG CX,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_cx;reg_cx=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_cx;reg_cx=temp; }
 		break;
 	CASE_W(0x92)												/* XCHG DX,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_dx;reg_dx=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_dx;reg_dx=temp; }
 		break;
 	CASE_W(0x93)												/* XCHG BX,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_bx;reg_bx=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_bx;reg_bx=temp; }
 		break;
 	CASE_W(0x94)												/* XCHG SP,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_sp;reg_sp=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_sp;reg_sp=temp; }
 		break;
 	CASE_W(0x95)												/* XCHG BP,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_bp;reg_bp=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_bp;reg_bp=temp; }
 		break;
 	CASE_W(0x96)												/* XCHG SI,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_si;reg_si=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_si;reg_si=temp; }
 		break;
 	CASE_W(0x97)												/* XCHG DI,AX */
-		{ Bit16u temp=reg_ax;reg_ax=reg_di;reg_di=temp; }
+		{ uint16_t temp=reg_ax;reg_ax=reg_di;reg_di=temp; }
 		break;
 	CASE_W(0x98)												/* CBW */
-		reg_ax=(Bit8s)reg_al;break;
+		reg_ax=(int8_t)reg_al;break;
 	CASE_W(0x99)												/* CWD */
 		if (reg_ax & 0x8000) reg_dx=0xffff;else reg_dx=0;
 		break;
 	CASE_W(0x9a)												/* CALL Ap */
 		{ 
 			FillFlags();
-			Bit16u newip=Fetchw();Bit16u newcs=Fetchw();
+			uint16_t newip=Fetchw();uint16_t newcs=Fetchw();
 			CPU_CALL(false,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK
 			if (GETFLAG(TF)) {	
@@ -755,7 +755,7 @@
 		continue;
 	CASE_B(0xcd)												/* INT Ib */	
 		{
-			Bit8u num=Fetchb();
+			uint8_t num=Fetchb();
 #if C_DEBUG
 			FillFlags();
 			if (DEBUG_IntBreakpoint(num)) {
@@ -810,7 +810,7 @@
 		if (TEST_PREFIX_ADDR) {
 	                reg_al = LoadMb(BaseDS + (reg_ebx + reg_al));
                 } else {
-	                reg_al = LoadMb(BaseDS + (Bit16u)(reg_bx + reg_al));
+	                reg_al = LoadMb(BaseDS + (uint16_t)(reg_bx + reg_al));
                 }
                 break;
 #ifdef CPU_FPU
@@ -841,7 +841,7 @@
 	CASE_B(0xdf)												/* FPU ESC 7 */
 		{
 			LOG(LOG_CPU,LOG_NORMAL)("FPU used");
-			Bit8u rm=Fetchb();
+			uint8_t rm=Fetchb();
 			if (rm<0xc0) GetEAa;
 		}
 		break;
@@ -900,23 +900,23 @@
 		}
 	CASE_W(0xe8)												/* CALL Jw */
 		{ 
-			Bit16u addip=Fetchws();
+			uint16_t addip=Fetchws();
 			SAVEIP;
 			Push_16(reg_eip);
-			reg_eip=(Bit16u)(reg_eip+addip);
+			reg_eip=(uint16_t)(reg_eip+addip);
 			continue;
 		}
 	CASE_W(0xe9)												/* JMP Jw */
 		{ 
-			Bit16u addip=Fetchws();
+			uint16_t addip=Fetchws();
 			SAVEIP;
-			reg_eip=(Bit16u)(reg_eip+addip);
+			reg_eip=(uint16_t)(reg_eip+addip);
 			continue;
 		}
 	CASE_W(0xea)												/* JMP Ap */
 		{ 
-			Bit16u newip=Fetchw();
-			Bit16u newcs=Fetchw();
+			uint16_t newip=Fetchw();
+			uint16_t newcs=Fetchw();
 			FillFlags();
 			CPU_JMP(false,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK
@@ -929,9 +929,9 @@
 		}
 	CASE_W(0xeb)												/* JMP Jb */
 		{ 
-			Bit16s addip=Fetchbs();
+			int16_t addip=Fetchbs();
 			SAVEIP;
-			reg_eip=(Bit16u)(reg_eip+addip);
+			reg_eip=(uint16_t)(reg_eip+addip);
 			continue;
 		}
 	CASE_B(0xec)												/* IN AL,DX */
@@ -1128,8 +1128,8 @@
 				{
 					if (rm >= 0xc0) goto illegal_opcode;
 					GetEAa;
-					Bit16u newip=LoadMw(eaa);
-					Bit16u newcs=LoadMw(eaa+2);
+					uint16_t newip=LoadMw(eaa);
+					uint16_t newcs=LoadMw(eaa+2);
 					FillFlags();
 					CPU_CALL(false,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK
@@ -1149,8 +1149,8 @@
 				{
 					if (rm >= 0xc0) goto illegal_opcode;
 					GetEAa;
-					Bit16u newip=LoadMw(eaa);
-					Bit16u newcs=LoadMw(eaa+2);
+					uint16_t newip=LoadMw(eaa);
+					uint16_t newcs=LoadMw(eaa+2);
 					FillFlags();
 					CPU_JMP(false,newcs,newip,GETIP);
 #if CPU_TRAP_CHECK

--- a/src/cpu/core_normal/string.h
+++ b/src/cpu/core_normal/string.h
@@ -156,7 +156,7 @@ static void DoString(STRING_OP type) {
 		break;
 	case R_SCASB:
 		{
-			Bit8u val2;
+			uint8_t val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val2=LoadMb(di_base+di_index);
@@ -169,7 +169,7 @@ static void DoString(STRING_OP type) {
 	case R_SCASW:
 		{
 			add_index *= 2;
-			Bit16u val2;
+			uint16_t val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val2=LoadMw(di_base+di_index);
@@ -182,7 +182,7 @@ static void DoString(STRING_OP type) {
 	case R_SCASD:
 		{
 			add_index *= 4;
-			Bit32u val2;
+			uint32_t val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val2=LoadMd(di_base+di_index);
@@ -194,7 +194,7 @@ static void DoString(STRING_OP type) {
 		break;
 	case R_CMPSB:
 		{
-			Bit8u val1,val2;
+			uint8_t val1,val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val1=LoadMb(si_base+si_index);
@@ -209,7 +209,7 @@ static void DoString(STRING_OP type) {
 	case R_CMPSW:
 		{
 			add_index *= 2;
-			Bit16u val1,val2;
+			uint16_t val1,val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val1=LoadMw(si_base+si_index);
@@ -224,7 +224,7 @@ static void DoString(STRING_OP type) {
 	case R_CMPSD:
 		{
 			add_index *= 4;
-			Bit32u val1,val2;
+			uint32_t val1,val2;
 			for (;count>0;) {
 				count--;CPU_Cycles--;
 				val1=LoadMd(si_base+si_index);

--- a/src/cpu/core_normal/support.h
+++ b/src/cpu/core_normal/support.h
@@ -17,9 +17,9 @@
  */
 
 
-#define LoadMbs(off) (Bit8s)(LoadMb(off))
-#define LoadMws(off) (Bit16s)(LoadMw(off))
-#define LoadMds(off) (Bit32s)(LoadMd(off))
+#define LoadMbs(off) (int8_t)(LoadMb(off))
+#define LoadMws(off) (int16_t)(LoadMw(off))
+#define LoadMds(off) (int32_t)(LoadMd(off))
 
 #define LoadRb(reg) reg
 #define LoadRw(reg) reg

--- a/src/cpu/core_normal/table_ea.h
+++ b/src/cpu/core_normal/table_ea.h
@@ -19,38 +19,38 @@
 typedef PhysPt (*EA_LookupHandler)(void);
 
 /* The MOD/RM Decoder for EA for this decoder's addressing modes */
-static PhysPt EA_16_00_n(void) { return BaseDS+(Bit16u)(reg_bx+(Bit16s)reg_si); }
-static PhysPt EA_16_01_n(void) { return BaseDS+(Bit16u)(reg_bx+(Bit16s)reg_di); }
-static PhysPt EA_16_02_n(void) { return BaseSS+(Bit16u)(reg_bp+(Bit16s)reg_si); }
-static PhysPt EA_16_03_n(void) { return BaseSS+(Bit16u)(reg_bp+(Bit16s)reg_di); }
+static PhysPt EA_16_00_n(void) { return BaseDS+(uint16_t)(reg_bx+(int16_t)reg_si); }
+static PhysPt EA_16_01_n(void) { return BaseDS+(uint16_t)(reg_bx+(int16_t)reg_di); }
+static PhysPt EA_16_02_n(void) { return BaseSS+(uint16_t)(reg_bp+(int16_t)reg_si); }
+static PhysPt EA_16_03_n(void) { return BaseSS+(uint16_t)(reg_bp+(int16_t)reg_di); }
 static PhysPt EA_16_04_n() { return BaseDS + reg_si; }
 static PhysPt EA_16_05_n() { return BaseDS + reg_di; }
 static PhysPt EA_16_06_n() { return BaseDS + Fetchw(); }
 static PhysPt EA_16_07_n() { return BaseDS + reg_bx; }
 
-static PhysPt EA_16_40_n(void) { return BaseDS+(Bit16u)(reg_bx+(Bit16s)reg_si+Fetchbs()); }
-static PhysPt EA_16_41_n(void) { return BaseDS+(Bit16u)(reg_bx+(Bit16s)reg_di+Fetchbs()); }
-static PhysPt EA_16_42_n(void) { return BaseSS+(Bit16u)(reg_bp+(Bit16s)reg_si+Fetchbs()); }
-static PhysPt EA_16_43_n(void) { return BaseSS+(Bit16u)(reg_bp+(Bit16s)reg_di+Fetchbs()); }
-static PhysPt EA_16_44_n(void) { return BaseDS+(Bit16u)(reg_si+Fetchbs()); }
-static PhysPt EA_16_45_n(void) { return BaseDS+(Bit16u)(reg_di+Fetchbs()); }
-static PhysPt EA_16_46_n(void) { return BaseSS+(Bit16u)(reg_bp+Fetchbs()); }
-static PhysPt EA_16_47_n(void) { return BaseDS+(Bit16u)(reg_bx+Fetchbs()); }
+static PhysPt EA_16_40_n(void) { return BaseDS+(uint16_t)(reg_bx+(int16_t)reg_si+Fetchbs()); }
+static PhysPt EA_16_41_n(void) { return BaseDS+(uint16_t)(reg_bx+(int16_t)reg_di+Fetchbs()); }
+static PhysPt EA_16_42_n(void) { return BaseSS+(uint16_t)(reg_bp+(int16_t)reg_si+Fetchbs()); }
+static PhysPt EA_16_43_n(void) { return BaseSS+(uint16_t)(reg_bp+(int16_t)reg_di+Fetchbs()); }
+static PhysPt EA_16_44_n(void) { return BaseDS+(uint16_t)(reg_si+Fetchbs()); }
+static PhysPt EA_16_45_n(void) { return BaseDS+(uint16_t)(reg_di+Fetchbs()); }
+static PhysPt EA_16_46_n(void) { return BaseSS+(uint16_t)(reg_bp+Fetchbs()); }
+static PhysPt EA_16_47_n(void) { return BaseDS+(uint16_t)(reg_bx+Fetchbs()); }
 
-static PhysPt EA_16_80_n(void) { return BaseDS+(Bit16u)(reg_bx+(Bit16s)reg_si+Fetchws()); }
-static PhysPt EA_16_81_n(void) { return BaseDS+(Bit16u)(reg_bx+(Bit16s)reg_di+Fetchws()); }
-static PhysPt EA_16_82_n(void) { return BaseSS+(Bit16u)(reg_bp+(Bit16s)reg_si+Fetchws()); }
-static PhysPt EA_16_83_n(void) { return BaseSS+(Bit16u)(reg_bp+(Bit16s)reg_di+Fetchws()); }
-static PhysPt EA_16_84_n(void) { return BaseDS+(Bit16u)(reg_si+Fetchws()); }
-static PhysPt EA_16_85_n(void) { return BaseDS+(Bit16u)(reg_di+Fetchws()); }
-static PhysPt EA_16_86_n(void) { return BaseSS+(Bit16u)(reg_bp+Fetchws()); }
-static PhysPt EA_16_87_n(void) { return BaseDS+(Bit16u)(reg_bx+Fetchws()); }
+static PhysPt EA_16_80_n(void) { return BaseDS+(uint16_t)(reg_bx+(int16_t)reg_si+Fetchws()); }
+static PhysPt EA_16_81_n(void) { return BaseDS+(uint16_t)(reg_bx+(int16_t)reg_di+Fetchws()); }
+static PhysPt EA_16_82_n(void) { return BaseSS+(uint16_t)(reg_bp+(int16_t)reg_si+Fetchws()); }
+static PhysPt EA_16_83_n(void) { return BaseSS+(uint16_t)(reg_bp+(int16_t)reg_di+Fetchws()); }
+static PhysPt EA_16_84_n(void) { return BaseDS+(uint16_t)(reg_si+Fetchws()); }
+static PhysPt EA_16_85_n(void) { return BaseDS+(uint16_t)(reg_di+Fetchws()); }
+static PhysPt EA_16_86_n(void) { return BaseSS+(uint16_t)(reg_bp+Fetchws()); }
+static PhysPt EA_16_87_n(void) { return BaseDS+(uint16_t)(reg_bx+Fetchws()); }
 
-static Bit32u SIBZero=0;
-static Bit32u * SIBIndex[8]= { &reg_eax,&reg_ecx,&reg_edx,&reg_ebx,&SIBZero,&reg_ebp,&reg_esi,&reg_edi };
+static uint32_t SIBZero=0;
+static uint32_t * SIBIndex[8]= { &reg_eax,&reg_ecx,&reg_edx,&reg_ebx,&SIBZero,&reg_ebp,&reg_esi,&reg_edi };
 
 static inline PhysPt Sib(Bitu mode) {
-	Bit8u sib=Fetchb();
+	uint8_t sib=Fetchb();
 	PhysPt base;
 	switch (sib&7) {
 	case 0:	/* EAX Base */

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -90,7 +90,7 @@ extern Bitu cycle_count;
 
 typedef PhysPt (*GetEAHandler)(void);
 
-static const Bit32u AddrMaskTable[2]={0x0000ffff,0xffffffff};
+static const uint32_t AddrMaskTable[2]={0x0000ffff,0xffffffff};
 
 static struct {
 	Bitu opcode_index;
@@ -112,12 +112,12 @@ static struct {
 
 
 #define MAX_PQ_SIZE 32
-static Bit8u prefetch_buffer[MAX_PQ_SIZE];
+static uint8_t prefetch_buffer[MAX_PQ_SIZE];
 static bool pq_valid=false;
 static Bitu pq_start;
 
-static Bit8u Fetchb() {
-	Bit8u temp;
+static uint8_t Fetchb() {
+	uint8_t temp;
 	if (pq_valid && (core.cseip>=pq_start) && (core.cseip<pq_start+CPU_PrefetchQueueSize)) {
 		temp=prefetch_buffer[core.cseip-pq_start];
 		if ((core.cseip+1>=pq_start+CPU_PrefetchQueueSize-4) &&
@@ -141,8 +141,8 @@ static Bit8u Fetchb() {
 	return temp;
 }
 
-static Bit16u Fetchw() {
-	Bit16u temp;
+static uint16_t Fetchw() {
+	uint16_t temp;
 	if (pq_valid && (core.cseip>=pq_start) && (core.cseip+2<pq_start+CPU_PrefetchQueueSize)) {
 		temp=prefetch_buffer[core.cseip-pq_start]|
 			(prefetch_buffer[core.cseip-pq_start+1]<<8);
@@ -167,8 +167,8 @@ static Bit16u Fetchw() {
 	return temp;
 }
 
-static Bit32u Fetchd() {
-	Bit32u temp;
+static uint32_t Fetchd() {
+	uint32_t temp;
 	if (pq_valid && (core.cseip>=pq_start) && (core.cseip+4<pq_start+CPU_PrefetchQueueSize)) {
 		temp=prefetch_buffer[core.cseip-pq_start]|
 			(prefetch_buffer[core.cseip-pq_start+1]<<8)|
@@ -232,7 +232,7 @@ Bits CPU_Core_Prefetch_Run(void) {
 		cycle_count++;
 #endif
 restart_opcode:
-		Bit8u next_opcode=Fetchb();
+		uint8_t next_opcode=Fetchb();
 		invalidate_pq=false;
 		if (core.opcode_index&OPCODE_0F) invalidate_pq=true;
 		else switch (next_opcode) {

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -81,7 +81,7 @@ extern Bitu cycle_count;
 
 typedef PhysPt (*GetEAHandler)(void);
 
-static const Bit32u AddrMaskTable[2]={0x0000ffff,0xffffffff};
+static const uint32_t AddrMaskTable[2]={0x0000ffff,0xffffffff};
 
 static struct {
 	Bitu opcode_index;
@@ -105,19 +105,19 @@ static struct {
 #define BaseDS		core.base_ds
 #define BaseSS		core.base_ss
 
-static inline Bit8u Fetchb() {
-	Bit8u temp=host_readb(core.cseip);
+static inline uint8_t Fetchb() {
+	uint8_t temp=host_readb(core.cseip);
 	core.cseip+=1;
 	return temp;
 }
 
-static inline Bit16u Fetchw() {
-	Bit16u temp=host_readw(core.cseip);
+static inline uint16_t Fetchw() {
+	uint16_t temp=host_readw(core.cseip);
 	core.cseip+=2;
 	return temp;
 }
-static inline Bit32u Fetchd() {
-	Bit32u temp=host_readd(core.cseip);
+static inline uint32_t Fetchd() {
+	uint32_t temp=host_readd(core.cseip);
 	core.cseip+=4;
 	return temp;
 }

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -169,7 +169,7 @@ public:
 		                               // modified, it has to be exited
 		                               // as soon as possible
 
-		Bit32u ip_point=SegPhys(cs)+reg_eip;
+		uint32_t ip_point=SegPhys(cs)+reg_eip;
 		ip_point = (PAGING_GetPhysicalPage(ip_point) -
 		            check_cast<uint32_t>(phys_page << 12)) +
 		           (ip_point & 0xfff);
@@ -904,7 +904,7 @@ static void cache_init(bool enable) {
 
 #if (C_DYNREC)
 		cache.pos=&cache_code_link_blocks[64];
-		core_dynrec.runcode=(BlockReturn (*)(const Bit8u*))cache.pos;
+		core_dynrec.runcode=(BlockReturn (*)(const uint8_t*))cache.pos;
 //		link_blocks[1].cache.start=cache.pos;
 		dyn_run_code();
 #endif

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -31,7 +31,7 @@ LazyFlags lflags;
 /* CF     Carry Flag -- Set on high-order bit carry or borrow; cleared
           otherwise.
 */
-Bit32u get_CF(void) {
+uint32_t get_CF(void) {
 
 	switch (lflags.type) {
 	case t_UNKNOWN:
@@ -88,9 +88,9 @@ Bit32u get_CF(void) {
 	case t_SHRd:
 	case t_DSHRw:	/* Hmm this is not correct for shift higher than 16 */
 	case t_DSHRd: return (lf_var1d >> lf_var2b_minus_one()) & 1;
-	case t_SARb: return (((Bit8s)lf_var1b) >> lf_var2b_minus_one()) & 1;
-	case t_SARw: return (((Bit16s)lf_var1w) >> lf_var2b_minus_one()) & 1;
-	case t_SARd: return (((Bit32s)lf_var1d) >> lf_var2b_minus_one()) & 1;
+	case t_SARb: return (((int8_t)lf_var1b) >> lf_var2b_minus_one()) & 1;
+	case t_SARw: return (((int16_t)lf_var1w) >> lf_var2b_minus_one()) & 1;
+	case t_SARd: return (((int32_t)lf_var1d) >> lf_var2b_minus_one()) & 1;
 	case t_NEGb: return lf_var1b;
 	case t_NEGw:
 		return lf_var1w;
@@ -121,7 +121,7 @@ Bit32u get_CF(void) {
             four bits of   AL; cleared otherwise. Used for decimal
             arithmetic.
 */
-Bit32u get_AF(void) {
+uint32_t get_AF(void) {
 	Bitu type=lflags.type;
 	switch (type) {
 	case t_UNKNOWN:
@@ -202,7 +202,7 @@ Bit32u get_AF(void) {
 /* ZF     Zero Flag -- Set if result is zero; cleared otherwise.
 */
 
-Bit32u get_ZF(void) {
+uint32_t get_ZF(void) {
 	Bitu type=lflags.type;
 	switch (type) {
 	case t_UNKNOWN:
@@ -270,7 +270,7 @@ Bit32u get_ZF(void) {
 /* SF     Sign Flag -- Set equal to high-order bit of result (0 is
             positive, 1 if negative).
 */
-Bit32u get_SF(void) {
+uint32_t get_SF(void) {
 	Bitu type=lflags.type;
 	switch (type) {
 	case t_UNKNOWN:
@@ -336,7 +336,7 @@ Bit32u get_SF(void) {
 	return false;
 
 }
-Bit32u get_OF(void) {
+uint32_t get_OF(void) {
 	Bitu type=lflags.type;
 	switch (type) {
 	case t_UNKNOWN:
@@ -424,7 +424,7 @@ Bit32u get_OF(void) {
 	return false;
 }
 
-Bit16u parity_lookup[256] = {
+uint16_t parity_lookup[256] = {
   FLAG_PF, 0, 0, FLAG_PF, 0, FLAG_PF, FLAG_PF, 0, 0, FLAG_PF, FLAG_PF, 0, FLAG_PF, 0, 0, FLAG_PF,
   0, FLAG_PF, FLAG_PF, 0, FLAG_PF, 0, 0, FLAG_PF, FLAG_PF, 0, 0, FLAG_PF, 0, FLAG_PF, FLAG_PF, 0,
   0, FLAG_PF, FLAG_PF, 0, FLAG_PF, 0, 0, FLAG_PF, FLAG_PF, 0, 0, FLAG_PF, 0, FLAG_PF, FLAG_PF, 0,
@@ -443,7 +443,7 @@ Bit16u parity_lookup[256] = {
   FLAG_PF, 0, 0, FLAG_PF, 0, FLAG_PF, FLAG_PF, 0, 0, FLAG_PF, FLAG_PF, 0, FLAG_PF, 0, 0, FLAG_PF
   };
 
-Bit32u get_PF(void) {
+uint32_t get_PF(void) {
 	switch (lflags.type) {
 	case t_UNKNOWN:
 		return GETFLAG(PF);
@@ -722,7 +722,7 @@ uint32_t FillFlags(void) {
 
 
 	case t_SARb:
-		SET_FLAG(CF, (((Bit8s)lf_var1b) >> lf_var2b_minus_one()) & 1);
+		SET_FLAG(CF, (((int8_t)lf_var1b) >> lf_var2b_minus_one()) & 1);
 		DOFLAG_ZFb;
 		DOFLAG_SFb;
 		SET_FLAG(OF,false);
@@ -730,7 +730,7 @@ uint32_t FillFlags(void) {
 		SET_FLAG(AF,(lf_var2b&0x1f));
 		break;
 	case t_SARw:
-		SET_FLAG(CF, (((Bit16s)lf_var1w) >> lf_var2b_minus_one()) & 1);
+		SET_FLAG(CF, (((int16_t)lf_var1w) >> lf_var2b_minus_one()) & 1);
 		DOFLAG_ZFw;
 		DOFLAG_SFw;
 		SET_FLAG(OF,false);
@@ -738,7 +738,7 @@ uint32_t FillFlags(void) {
 		SET_FLAG(AF,(lf_var2w&0x1f));
 		break;
 	case t_SARd:
-		SET_FLAG(CF, (((Bit32s)lf_var1d) >> lf_var2b_minus_one()) & 1);
+		SET_FLAG(CF, (((int32_t)lf_var1d) >> lf_var2b_minus_one()) & 1);
 		DOFLAG_ZFd;
 		DOFLAG_SFd;
 		SET_FLAG(OF,false);

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -293,7 +293,7 @@
 
 #define RCLB(op1,op2,load,save)							\
 	if (!(op2%9)) break;								\
-{	Bit8u cf=(Bit8u)FillFlags()&0x1;					\
+{	uint8_t cf=(uint8_t)FillFlags()&0x1;					\
 	lf_var1b=load(op1);									\
 	lf_var2b=op2%9;										\
 	lf_resb=(lf_var1b << lf_var2b) |					\
@@ -306,7 +306,7 @@
 
 #define RCLW(op1,op2,load,save)							\
 	if (!(op2%17)) break;								\
-{	Bit16u cf=(Bit16u)FillFlags()&0x1;					\
+{	uint16_t cf=(uint16_t)FillFlags()&0x1;					\
 	lf_var1w=load(op1);									\
 	lf_var2b=op2%17;									\
 	lf_resw=(lf_var1w << lf_var2b) |					\
@@ -338,7 +338,7 @@
 
 #define RCRB(op1, op2, load, save) \
 	if (op2 % 9) { \
-		Bit8u cf = (Bit8u)FillFlags() & 0x1; \
+		uint8_t cf = (uint8_t)FillFlags() & 0x1; \
 		lf_var1b = load(op1); \
 		lf_var2b = op2 % 9; \
 		lf_resb = (lf_var1b >> lf_var2b) | (cf << (8 - lf_var2b)) | \
@@ -350,7 +350,7 @@
 
 #define RCRW(op1, op2, load, save) \
 	if (op2 % 17) { \
-		Bit16u cf = (Bit16u)FillFlags() & 0x1; \
+		uint16_t cf = (uint16_t)FillFlags() & 0x1; \
 		lf_var1w = load(op1); \
 		lf_var2b = op2 % 17; \
 		lf_resw = (lf_var1w >> lf_var2b) | (cf << (16 - lf_var2b)) | \
@@ -479,7 +479,7 @@
 
 #define DAS()												\
 {															\
-	Bit8u osigned=reg_al & 0x80;							\
+	uint8_t osigned=reg_al & 0x80;							\
 	if (((reg_al & 0x0f) > 9) || get_AF()) {				\
 		if ((reg_al>0x99) || get_CF()) {					\
 			reg_al-=0x60;									\
@@ -556,7 +556,7 @@
 
 #define AAM(op1)											\
 {															\
-	Bit8u dv=op1;											\
+	uint8_t dv=op1;											\
 	if (dv!=0) {											\
 		reg_ah=reg_al / dv;									\
 		reg_al=reg_al % dv;									\
@@ -574,9 +574,9 @@
 //Took this from bochs, i seriously hate these weird bcd opcodes
 #define AAD(op1)											\
 	{														\
-		Bit16u ax1 = reg_ah * op1;							\
-		Bit16u ax2 = ax1 + reg_al;							\
-		reg_al = (Bit8u) ax2;								\
+		uint16_t ax1 = reg_ah * op1;							\
+		uint16_t ax2 = ax1 + reg_al;							\
+		reg_al = (uint8_t) ax2;								\
 		reg_ah = 0;											\
 		SETFLAGBIT(CF,false);								\
 		SETFLAGBIT(OF,false);								\
@@ -636,8 +636,8 @@
 	Bitu val=load(op1);										\
 	if (val==0)	EXCEPTION(0);								\
 	Bitu quo=reg_ax / val;									\
-	Bit8u rem=(Bit8u)(reg_ax % val);						\
-	Bit8u quo8=(Bit8u)(quo&0xff);							\
+	uint8_t rem=(uint8_t)(reg_ax % val);						\
+	uint8_t quo8=(uint8_t)(quo&0xff);							\
 	if (quo>0xff) EXCEPTION(0);								\
 	reg_ah=rem;												\
 	reg_al=quo8;											\
@@ -649,11 +649,11 @@
 {															\
 	Bitu val=load(op1);										\
 	if (val==0)	EXCEPTION(0);								\
-	Bitu num=((Bit32u)reg_dx<<16)|reg_ax;							\
+	Bitu num=((uint32_t)reg_dx<<16)|reg_ax;							\
 	Bitu quo=num/val;										\
-	Bit16u rem=(Bit16u)(num % val);							\
-	Bit16u quo16=(Bit16u)(quo&0xffff);						\
-	if (quo!=(Bit32u)quo16) EXCEPTION(0);					\
+	uint16_t rem=(uint16_t)(num % val);							\
+	uint16_t quo16=(uint16_t)(quo&0xffff);						\
+	if (quo!=(uint32_t)quo16) EXCEPTION(0);					\
 	reg_dx=rem;												\
 	reg_ax=quo16;											\
 	SETFLAGBIT(OF,false);									\
@@ -663,11 +663,11 @@
 {															\
 	Bitu val=load(op1);										\
 	if (val==0) EXCEPTION(0);									\
-	Bit64u num=(((Bit64u)reg_edx)<<32)|reg_eax;				\
-	Bit64u quo=num/val;										\
-	Bit32u rem=(Bit32u)(num % val);							\
-	Bit32u quo32=(Bit32u)(quo&0xffffffff);					\
-	if (quo!=(Bit64u)quo32) EXCEPTION(0);					\
+	uint64_t num=(((uint64_t)reg_edx)<<32)|reg_eax;				\
+	uint64_t quo=num/val;										\
+	uint32_t rem=(uint32_t)(num % val);							\
+	uint32_t quo32=(uint32_t)(quo&0xffffffff);					\
+	if (quo!=(uint64_t)quo32) EXCEPTION(0);					\
 	reg_edx=rem;											\
 	reg_eax=quo32;											\
 	SETFLAGBIT(OF,false);									\
@@ -676,12 +676,12 @@
 
 #define IDIVB(op1,load,save)								\
 {															\
-	Bits val=(Bit8s)(load(op1));							\
+	Bits val=(int8_t)(load(op1));							\
 	if (val==0)	EXCEPTION(0);								\
-	Bits quo=((Bit16s)reg_ax) / val;						\
-	Bit8s rem=(Bit8s)((Bit16s)reg_ax % val);				\
-	Bit8s quo8s=(Bit8s)(quo&0xff);							\
-	if (quo!=(Bit16s)quo8s) EXCEPTION(0);					\
+	Bits quo=((int16_t)reg_ax) / val;						\
+	int8_t rem=(int8_t)((int16_t)reg_ax % val);				\
+	int8_t quo8s=(int8_t)(quo&0xff);							\
+	if (quo!=(int16_t)quo8s) EXCEPTION(0);					\
 	reg_ah=rem;												\
 	reg_al=quo8s;											\
 	SETFLAGBIT(OF,false);									\
@@ -705,13 +705,13 @@
 
 #define IDIVD(op1,load,save)								\
 {															\
-	Bits val=(Bit32s)(load(op1));							\
+	Bits val=(int32_t)(load(op1));							\
 	if (val==0) EXCEPTION(0);									\
-	Bit64s num=(((Bit64u)reg_edx)<<32)|reg_eax;				\
-	Bit64s quo=num/val;										\
-	Bit32s rem=(Bit32s)(num % val);							\
-	Bit32s quo32s=(Bit32s)(quo&0xffffffff);					\
-	if (quo!=(Bit64s)quo32s) EXCEPTION(0);					\
+	int64_t num=(((uint64_t)reg_edx)<<32)|reg_eax;				\
+	int64_t quo=num/val;										\
+	int32_t rem=(int32_t)(num % val);							\
+	int32_t quo32s=(int32_t)(quo&0xffffffff);					\
+	if (quo!=(int64_t)quo32s) EXCEPTION(0);					\
 	reg_edx=rem;											\
 	reg_eax=quo32s;											\
 	SETFLAGBIT(OF,false);									\
@@ -719,7 +719,7 @@
 
 #define IMULB(op1,load,save)								\
 {															\
-	reg_ax=((Bit8s)reg_al) * ((Bit8s)(load(op1)));			\
+	reg_ax=((int8_t)reg_al) * ((int8_t)(load(op1)));			\
 	FillFlagsNoCFOF();										\
 	SETFLAGBIT(ZF,reg_al == 0);								\
 	SETFLAGBIT(SF,reg_al & 0x80);							\
@@ -752,10 +752,10 @@
 
 #define IMULD(op1, load, save) \
 	{ \
-		Bit64s temps = ((Bit64s)((Bit32s)reg_eax)) * \
-		               ((Bit64s)((Bit32s)(load(op1)))); \
-		reg_eax = (Bit32s)(temps); \
-		reg_edx = (Bit32s)(temps >> 32); \
+		int64_t temps = ((int64_t)((int32_t)reg_eax)) * \
+		               ((int64_t)((int32_t)(load(op1)))); \
+		reg_eax = (int32_t)(temps); \
+		reg_edx = (int32_t)(temps >> 32); \
 		FillFlagsNoCFOF(); \
 		SETFLAGBIT(ZF, reg_eax == 0); \
 		SETFLAGBIT(SF, reg_eax & 0x80000000); \
@@ -789,10 +789,10 @@
 	{ \
 		const auto res = static_cast<int64_t>(op2) * \
 		                 static_cast<int64_t>(op3); \
-		save(op1, (Bit32s)res); \
+		save(op1, (int32_t)res); \
 		FillFlagsNoCFOF(); \
-		if ((res >= -((Bit64s)(2147483647) + 1)) && \
-		    (res <= (Bit64s)2147483647)) { \
+		if ((res >= -((int64_t)(2147483647) + 1)) && \
+		    (res <= (int64_t)2147483647)) { \
 			SETFLAGBIT(CF, false); \
 			SETFLAGBIT(OF, false); \
 		} else { \
@@ -806,7 +806,7 @@
 	GetRM;Bitu which=(rm>>3)&7;								\
 	if (rm >= 0xc0) {										\
 		GetEArb;											\
-		Bit8u val=blah & 0x1f;								\
+		uint8_t val=blah & 0x1f;								\
 		if (!val) break;									\
 		switch (which)	{									\
 		case 0x00:ROLB(*earb,val,LoadRb,SaveRb);break;		\
@@ -820,7 +820,7 @@
 		}													\
 	} else {												\
 		GetEAa;												\
-		Bit8u val=blah & 0x1f;								\
+		uint8_t val=blah & 0x1f;								\
 		if (!val) break;									\
 		switch (which) {									\
 		case 0x00:ROLB(eaa,val,LoadMb,SaveMb);break;		\
@@ -842,7 +842,7 @@
 	GetRM;Bitu which=(rm>>3)&7;								\
 	if (rm >= 0xc0) {										\
 		GetEArw;											\
-		Bit8u val=blah & 0x1f;								\
+		uint8_t val=blah & 0x1f;								\
 		if (!val) break;									\
 		switch (which)	{									\
 		case 0x00:ROLW(*earw,val,LoadRw,SaveRw);break;		\
@@ -856,7 +856,7 @@
 		}													\
 	} else {												\
 		GetEAa;												\
-		Bit8u val=blah & 0x1f;								\
+		uint8_t val=blah & 0x1f;								\
 		if (!val) break;									\
 		switch (which) {									\
 		case 0x00:ROLW(eaa,val,LoadMw,SaveMw);break;		\
@@ -877,7 +877,7 @@
 	GetRM;Bitu which=(rm>>3)&7;								\
 	if (rm >= 0xc0) {										\
 		GetEArd;											\
-		Bit8u val=blah & 0x1f;								\
+		uint8_t val=blah & 0x1f;								\
 		if (!val) break;									\
 		switch (which)	{									\
 		case 0x00:ROLD(*eard,val,LoadRd,SaveRd);break;		\
@@ -891,7 +891,7 @@
 		}													\
 	} else {												\
 		GetEAa;												\
-		Bit8u val=blah & 0x1f;								\
+		uint8_t val=blah & 0x1f;								\
 		if (!val) break;									\
 		switch (which) {									\
 		case 0x00:ROLD(eaa,val,LoadMd,SaveMd);break;		\
@@ -909,17 +909,17 @@
 /* let's hope bochs has it correct with the higher than 16 shifts */
 /* double-precision shift left has low bits in second argument */
 #define DSHLW(op1,op2,op3,load,save)									\
-	Bit8u val=op3 & 0x1F;												\
+	uint8_t val=op3 & 0x1F;												\
 	if (!val) break;													\
 	lf_var2b=val;lf_var1d=(load(op1)<<16)|op2;					\
-	Bit32u tempd=lf_var1d << lf_var2b;							\
+	uint32_t tempd=lf_var1d << lf_var2b;							\
   	if (lf_var2b>16) tempd |= (op2 << (lf_var2b - 16));			\
-	lf_resw=(Bit16u)(tempd >> 16);								\
+	lf_resw=(uint16_t)(tempd >> 16);								\
 	save(op1,lf_resw);											\
 	lflags.type=t_DSHLw;
 
 #define DSHLD(op1,op2,op3,load,save)									\
-	Bit8u val=op3 & 0x1F;												\
+	uint8_t val=op3 & 0x1F;												\
 	if (!val) break;													\
 	lf_var2b=val;lf_var1d=load(op1);							\
 	lf_resd=(lf_var1d << lf_var2b) | (op2 >> (32-lf_var2b));	\
@@ -928,17 +928,17 @@
 
 /* double-precision shift right has high bits in second argument */
 #define DSHRW(op1,op2,op3,load,save)									\
-	Bit8u val=op3 & 0x1F;												\
+	uint8_t val=op3 & 0x1F;												\
 	if (!val) break;													\
 	lf_var2b=val;lf_var1d=(op2<<16)|load(op1);					\
-	Bit32u tempd=lf_var1d >> lf_var2b;							\
+	uint32_t tempd=lf_var1d >> lf_var2b;							\
   	if (lf_var2b>16) tempd |= (op2 << (32-lf_var2b ));			\
-	lf_resw=(Bit16u)(tempd);										\
+	lf_resw=(uint16_t)(tempd);										\
 	save(op1,lf_resw);											\
 	lflags.type=t_DSHRw;
 
 #define DSHRD(op1,op2,op3,load,save)									\
-	Bit8u val=op3 & 0x1F;												\
+	uint8_t val=op3 & 0x1F;												\
 	if (!val) break;													\
 	lf_var2b=val;lf_var1d=load(op1);							\
 	lf_resd=(lf_var1d >> lf_var2b) | (op2 << (32-lf_var2b));	\

--- a/src/cpu/modrm.cpp
+++ b/src/cpu/modrm.cpp
@@ -19,7 +19,7 @@
 #include "cpu.h"
 
 
-Bit8u * lookupRMregb[]=
+uint8_t * lookupRMregb[]=
 {
 	&reg_al,&reg_al,&reg_al,&reg_al,&reg_al,&reg_al,&reg_al,&reg_al,
 	&reg_cl,&reg_cl,&reg_cl,&reg_cl,&reg_cl,&reg_cl,&reg_cl,&reg_cl,
@@ -58,7 +58,7 @@ Bit8u * lookupRMregb[]=
 	&reg_bh,&reg_bh,&reg_bh,&reg_bh,&reg_bh,&reg_bh,&reg_bh,&reg_bh
 };
 
-Bit16u * lookupRMregw[]={
+uint16_t * lookupRMregw[]={
 	&reg_ax,&reg_ax,&reg_ax,&reg_ax,&reg_ax,&reg_ax,&reg_ax,&reg_ax,
 	&reg_cx,&reg_cx,&reg_cx,&reg_cx,&reg_cx,&reg_cx,&reg_cx,&reg_cx,
 	&reg_dx,&reg_dx,&reg_dx,&reg_dx,&reg_dx,&reg_dx,&reg_dx,&reg_dx,
@@ -96,7 +96,7 @@ Bit16u * lookupRMregw[]={
 	&reg_di,&reg_di,&reg_di,&reg_di,&reg_di,&reg_di,&reg_di,&reg_di
 };
 
-Bit32u * lookupRMregd[256]={
+uint32_t * lookupRMregd[256]={
 	&reg_eax,&reg_eax,&reg_eax,&reg_eax,&reg_eax,&reg_eax,&reg_eax,&reg_eax,
 	&reg_ecx,&reg_ecx,&reg_ecx,&reg_ecx,&reg_ecx,&reg_ecx,&reg_ecx,&reg_ecx,
 	&reg_edx,&reg_edx,&reg_edx,&reg_edx,&reg_edx,&reg_edx,&reg_edx,&reg_edx,
@@ -135,7 +135,7 @@ Bit32u * lookupRMregd[256]={
 };
 
 
-Bit8u * lookupRMEAregb[256]={
+uint8_t * lookupRMEAregb[256]={
 /* 12 lines of 16*0 should give nice errors when used */
 	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,
 	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,
@@ -159,7 +159,7 @@ Bit8u * lookupRMEAregb[256]={
 	&reg_al,&reg_cl,&reg_dl,&reg_bl,&reg_ah,&reg_ch,&reg_dh,&reg_bh
 };
 
-Bit16u * lookupRMEAregw[256]={
+uint16_t * lookupRMEAregw[256]={
 /* 12 lines of 16*0 should give nice errors when used */
 	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,
 	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,
@@ -183,7 +183,7 @@ Bit16u * lookupRMEAregw[256]={
 	&reg_ax,&reg_cx,&reg_dx,&reg_bx,&reg_sp,&reg_bp,&reg_si,&reg_di
 };
 
-Bit32u * lookupRMEAregd[256]={
+uint32_t * lookupRMEAregd[256]={
 /* 12 lines of 16*0 should give nice errors when used */
 	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,
 	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,

--- a/src/cpu/modrm.h
+++ b/src/cpu/modrm.h
@@ -16,26 +16,26 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-extern Bit8u  * lookupRMregb[];
-extern Bit16u * lookupRMregw[];
-extern Bit32u * lookupRMregd[];
-extern Bit8u  * lookupRMEAregb[256];
-extern Bit16u * lookupRMEAregw[256];
-extern Bit32u * lookupRMEAregd[256];
+extern uint8_t  * lookupRMregb[];
+extern uint16_t * lookupRMregw[];
+extern uint32_t * lookupRMregd[];
+extern uint8_t  * lookupRMEAregb[256];
+extern uint16_t * lookupRMEAregw[256];
+extern uint32_t * lookupRMEAregd[256];
 
 #define GetRM												\
-	Bit8u rm=Fetchb();
+	uint8_t rm=Fetchb();
 
 #define Getrb												\
-	Bit8u * rmrb;											\
+	uint8_t * rmrb;											\
 	rmrb=lookupRMregb[rm];			
 	
 #define Getrw												\
-	Bit16u * rmrw;											\
+	uint16_t * rmrw;											\
 	rmrw=lookupRMregw[rm];			
 
 #define Getrd												\
-	Bit32u * rmrd;											\
+	uint32_t * rmrd;											\
 	rmrd=lookupRMregd[rm];			
 
 
@@ -53,12 +53,12 @@ extern Bit32u * lookupRMEAregd[256];
 
 
 #define GetEArb												\
-	Bit8u * earb=lookupRMEAregb[rm];
+	uint8_t * earb=lookupRMEAregb[rm];
 
 #define GetEArw												\
-	Bit16u * earw=lookupRMEAregw[rm];
+	uint16_t * earw=lookupRMEAregw[rm];
 
 #define GetEArd												\
-	Bit32u * eard=lookupRMEAregd[rm];
+	uint32_t * eard=lookupRMEAregd[rm];
 
 

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -64,15 +64,15 @@ void PageHandler::writeb(PhysPt addr, uint8_t /*val*/)
 
 void PageHandler::writew(PhysPt addr, uint16_t val)
 {
-	writeb(addr+0,(Bit8u) (val >> 0));
-	writeb(addr+1,(Bit8u) (val >> 8));
+	writeb(addr+0,(uint8_t) (val >> 0));
+	writeb(addr+1,(uint8_t) (val >> 8));
 }
 void PageHandler::writed(PhysPt addr, uint32_t val)
 {
-	writeb(addr+0,(Bit8u) (val >> 0));
-	writeb(addr+1,(Bit8u) (val >> 8));
-	writeb(addr+2,(Bit8u) (val >> 16));
-	writeb(addr+3,(Bit8u) (val >> 24));
+	writeb(addr+0,(uint8_t) (val >> 0));
+	writeb(addr+1,(uint8_t) (val >> 8));
+	writeb(addr+2,(uint8_t) (val >> 16));
+	writeb(addr+3,(uint8_t) (val >> 24));
 }
 
 HostPt PageHandler::GetHostReadPt(Bitu /*phys_page*/) {
@@ -679,7 +679,7 @@ void PAGING_InitTLB(void) {
 }
 
 void PAGING_ClearTLB(void) {
-	Bit32u * entries=&paging.links.entries[0];
+	uint32_t * entries=&paging.links.entries[0];
 	for (;paging.links.used>0;paging.links.used--) {
 		Bitu page=*entries++;
 		paging.tlb.read[page]=0;
@@ -780,7 +780,7 @@ void PAGING_InitTLB(void) {
 }
 
 void PAGING_ClearTLB(void) {
-	Bit32u * entries=&paging.links.entries[0];
+	uint32_t * entries=&paging.links.entries[0];
 	for (;paging.links.used>0;paging.links.used--) {
 		Bitu page=*entries++;
 		tlb_entry *entry = get_tlb_entry(page<<12);

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -70,13 +70,13 @@ Any comments/updates/bug reports to:
 #include <stdlib.h>
 #include "mem.h"
 
-typedef Bit8u  UINT8;
-typedef Bit16u UINT16;
-typedef Bit32u UINT32;
+typedef uint8_t  UINT8;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
 
-typedef Bit8s  INT8;
-typedef Bit16s INT16;
-typedef Bit32s INT32;
+typedef int8_t  INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
 
 
 /* Little endian uint read */

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -117,7 +117,7 @@ void LOG::operator() (char const* format, ...){
 
 	if (d_type>=LOG_MAX) return;
 	if ((d_severity!=LOG_ERROR) && (!loggrp[d_type].enabled)) return;
-	DEBUG_ShowMsg("%10u: %s:%s\n",static_cast<Bit32u>(cycle_count),loggrp[d_type].front,buf);
+	DEBUG_ShowMsg("%10u: %s:%s\n",static_cast<uint32_t>(cycle_count),loggrp[d_type].front,buf);
 }
 
 

--- a/src/debug/debug_inc.h
+++ b/src/debug/debug_inc.h
@@ -38,18 +38,18 @@ struct DBGBlock {
 	WINDOW * win_code;					/* Disassembly/Debug point Window */
 	WINDOW * win_var;					/* Variable Window */
 	WINDOW * win_out;					/* Text Output Window */
-	Bit32u active_win;					/* Current active window */
-	Bit32u input_y;
-	Bit32u global_mask;					/* Current msgmask */
+	uint32_t active_win;					/* Current active window */
+	uint32_t input_y;
+	uint32_t global_mask;					/* Current msgmask */
 };
 
 
 struct DASMLine {
-	Bit32u pc;
+	uint32_t pc;
 	char dasm[80];
 	PhysPt ea;
-	Bit16u easeg;
-	Bit32u eaoff;
+	uint16_t easeg;
+	uint32_t eaoff;
 };
 
 extern DBGBlock dbg;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -73,8 +73,8 @@ struct TMSF
 };
 
 typedef struct SCtrl {
-	Bit8u	out[4];			// output channel mapping
-	Bit8u	vol[4];			// channel volume (0 to 255)
+	uint8_t	out[4];			// output channel mapping
+	uint8_t	vol[4];			// channel volume (0 to 255)
 } TCtrl;
 
 // Conversion function from frames to Minutes/Second/Frames
@@ -202,7 +202,7 @@ private:
 	// Nested Class Definitions
 	class TrackFile {
 	protected:
-		TrackFile(Bit16u _chunkSize) : chunkSize(_chunkSize) {}
+		TrackFile(uint16_t _chunkSize) : chunkSize(_chunkSize) {}
 		bool offsetInsideTrack(const uint32_t offset);
 		uint32_t adjustOverRead(const uint32_t offset,
 		                        const uint32_t requested_bytes);
@@ -216,12 +216,12 @@ private:
 		                      const uint32_t requested_bytes) = 0;
 		virtual bool     seek(const uint32_t offset) = 0;
 		virtual uint32_t decode(int16_t *buffer, const uint32_t desired_track_frames) = 0;
-		virtual Bit16u   getEndian() = 0;
-		virtual Bit32u   getRate() = 0;
-		virtual Bit8u    getChannels() = 0;
+		virtual uint16_t   getEndian() = 0;
+		virtual uint32_t   getRate() = 0;
+		virtual uint8_t    getChannels() = 0;
 		virtual int      getLength() = 0;
 		virtual void setAudioPosition(uint32_t pos) = 0;
-		const Bit16u chunkSize = 0;
+		const uint16_t chunkSize = 0;
 	};
 
 	class BinaryFile final : public TrackFile {
@@ -238,9 +238,9 @@ private:
 		                     const uint32_t requested_bytes);
 		bool            seek(const uint32_t offset);
 		uint32_t        decode(int16_t *buffer, const uint32_t desired_track_frames);
-		Bit16u          getEndian();
-		Bit32u          getRate() { return 44100; }
-		Bit8u           getChannels() { return 2; }
+		uint16_t          getEndian();
+		uint32_t          getRate() { return 44100; }
+		uint8_t           getChannels() { return 2; }
 		int             getLength();
 		void setAudioPosition(uint32_t pos) { audio_pos = pos; }
 
@@ -262,9 +262,9 @@ private:
 		                     const uint32_t requested_bytes);
 		bool            seek(const uint32_t offset);
 		uint32_t        decode(int16_t *buffer, const uint32_t desired_track_frames);
-		Bit16u          getEndian();
-		Bit32u          getRate();
-		Bit8u           getChannels();
+		uint16_t          getEndian();
+		uint32_t          getRate();
+		uint8_t           getChannels();
 		int             getLength();
 		// This is a no-op because we track the audio position in all
 		// areas of this class.

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -158,7 +158,7 @@ int CDROM_Interface_Image::BinaryFile::getLength()
 	return length_redbook_bytes;
 }
 
-Bit16u CDROM_Interface_Image::BinaryFile::getEndian()
+uint16_t CDROM_Interface_Image::BinaryFile::getEndian()
 {
 	// Image files are always little endian
 	return AUDIO_S16LSB;
@@ -442,17 +442,17 @@ uint32_t CDROM_Interface_Image::AudioFile::decode(int16_t *buffer,
 	return frames_decoded;
 }
 
-Bit16u CDROM_Interface_Image::AudioFile::getEndian()
+uint16_t CDROM_Interface_Image::AudioFile::getEndian()
 {
 	return sample ? sample->actual.format : AUDIO_S16SYS;
 }
 
-Bit32u CDROM_Interface_Image::AudioFile::getRate()
+uint32_t CDROM_Interface_Image::AudioFile::getRate()
 {
 	return sample ? sample->actual.rate : 0;
 }
 
-Bit8u CDROM_Interface_Image::AudioFile::getChannels()
+uint8_t CDROM_Interface_Image::AudioFile::getChannels()
 {
 	return sample ? sample->actual.channels : 0;
 }
@@ -525,8 +525,8 @@ bool CDROM_Interface_Image::SetDevice(const char* path, [[maybe_unused]] const i
 		// print error message on dosbox console
 		char buf[MAX_LINE_LENGTH];
 		snprintf(buf, MAX_LINE_LENGTH, "Could not load image file: %s\r\n", path);
-		Bit16u size = (Bit16u)strlen(buf);
-		DOS_WriteFile(STDOUT, (Bit8u*)buf, &size);
+		uint16_t size = (uint16_t)strlen(buf);
+		DOS_WriteFile(STDOUT, (uint8_t*)buf, &size);
 	}
 	return result;
 }
@@ -1034,12 +1034,12 @@ void CDROM_Interface_Image::CDAudioCallBack(uint16_t desired_track_frames)
 		const double percent_played = static_cast<double>(
 		                              player.playedTrackFrames)
 		                              / player.totalTrackFrames;
-		const Bit32u played_redbook_frames = static_cast<Bit32u>(ceil(
+		const uint32_t played_redbook_frames = static_cast<uint32_t>(ceil(
 		                                     percent_played
 		                                     * player.totalRedbookFrames));
-		const Bit32u new_redbook_start_frame = player.startSector
+		const uint32_t new_redbook_start_frame = player.startSector
 		                                       + played_redbook_frames;
-		const Bit32u remaining_redbook_frames = player.totalRedbookFrames -
+		const uint32_t remaining_redbook_frames = player.totalRedbookFrames -
 		                                        played_redbook_frames;
 		player.cd->PlayAudioSector(new_redbook_start_frame, remaining_redbook_frames);
 		return;
@@ -1108,7 +1108,7 @@ bool CDROM_Interface_Image::CanReadPVD(TrackFile *file,
 	if (file == nullptr) return false;
 
 	// Initialize our array in the event file->read() doesn't fully write it
-	Bit8u pvd[BYTES_PER_COOKED_REDBOOK_FRAME] = {0};
+	uint8_t pvd[BYTES_PER_COOKED_REDBOOK_FRAME] = {0};
 
 	uint32_t seek = 16 * sectorSize;  // first vd is located at sector 16
 	if (sectorSize == BYTES_PER_RAW_REDBOOK_FRAME && !mode2) seek += 16;
@@ -1385,7 +1385,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 	char fullname[CROSS_LEN];
 	char tmp[CROSS_LEN];
 	safe_strcpy(tmp, filename.c_str());
-	Bit8u drive;
+	uint8_t drive;
 	if (!DOS_MakeName(tmp, fullname, &drive)) {
 		return false;
 	}

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -47,7 +47,7 @@ unsigned int result_errorcode = 0;
 #define DOS_COPYBUFSIZE 0x10000
 uint8_t dos_copybuf[DOS_COPYBUFSIZE];
 
-void DOS_SetError(Bit16u code) {
+void DOS_SetError(uint16_t code) {
 	dos.errorcode=code;
 }
 
@@ -181,7 +181,7 @@ void DOS_SetCountry(uint16_t country_number)
 static void DOS_AddDays(Bitu days)
 {
 	dos.date.day += days;
-	Bit8u monthlimit = DOS_DATE_months[dos.date.month];
+	uint8_t monthlimit = DOS_DATE_months[dos.date.month];
 
 	if(dos.date.day > monthlimit) {
 		if((dos.date.year %4 == 0) && (dos.date.month==2)) {
@@ -231,10 +231,10 @@ static void DOS_LoadResources() {
 			                                mandatory);
 }
 
-static Bit16u DOS_GetAmount(void) {
-	Bit16u amount = reg_cx;
+static uint16_t DOS_GetAmount(void) {
+	uint16_t amount = reg_cx;
 	if (amount > 0xfff1) {
-		Bit16u overflow = (amount & 0xf) + (reg_dx & 0xf);
+		uint16_t overflow = (amount & 0xf) + (reg_dx & 0xf);
 		if (overflow > 0x10) {
 			amount -= (overflow & 0xf);
 			LOG(LOG_DOSMISC,LOG_WARN)("DOS:0x%X:Amount reduced from %X to %X",reg_ah,reg_cx,amount);
@@ -296,7 +296,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x01:		/* Read character from STDIN, with echo */
 		{	
-			Bit8u c;Bit16u n=1;
+			uint8_t c;uint16_t n=1;
 			dos.echo=true;
 			DOS_ReadFile(STDIN,&c,&n);
 			reg_al=c;
@@ -305,7 +305,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x02:		/* Write character to STDOUT */
 		{
-			Bit8u c=reg_dl;Bit16u n=1;
+			uint8_t c=reg_dl;uint16_t n=1;
 			DOS_WriteFile(STDOUT,&c,&n);
 			//Not in the official specs, but happens nonetheless. (last written character)
 			reg_al=(c==9)?0x20:c; //strangely, tab conversion to spaces is reflected here
@@ -313,9 +313,9 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x03:		/* Read character from STDAUX */
 		{
-			Bit16u port = real_readw(0x40,0);
+			uint16_t port = real_readw(0x40,0);
 			if(port!=0 && serialports[0]) {
-				Bit8u status;
+				uint8_t status;
 				// RTS/DTR on
 				IO_WriteB(port+4,0x3);
 				serialports[0]->Getchar(&reg_al, &status, true, 0xFFFFFFFF);
@@ -324,7 +324,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x04:		/* Write Character to STDAUX */
 		{
-			Bit16u port = real_readw(0x40,0);
+			uint16_t port = real_readw(0x40,0);
 			if(port!=0 && serialports[0]) {
 				// RTS/DTR on
 				IO_WriteB(port+4,0x3);
@@ -350,7 +350,7 @@ static Bitu DOS_21Handler(void) {
 					CALLBACK_SZF(true);
 					break;
 				}
-				Bit8u c;Bit16u n=1;
+				uint8_t c;uint16_t n=1;
 				DOS_ReadFile(STDIN,&c,&n);
 				reg_al=c;
 				CALLBACK_SZF(false);
@@ -358,7 +358,7 @@ static Bitu DOS_21Handler(void) {
 			}
 		default:
 			{
-				Bit8u c = reg_dl;Bit16u n = 1;
+				uint8_t c = reg_dl;uint16_t n = 1;
 				dos.direct_output=true;
 				DOS_WriteFile(STDOUT,&c,&n);
 				dos.direct_output=false;
@@ -369,21 +369,21 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x07:		/* Character Input, without echo */
 		{
-				Bit8u c;Bit16u n=1;
+				uint8_t c;uint16_t n=1;
 				DOS_ReadFile (STDIN,&c,&n);
 				reg_al=c;
 				break;
 		};
 	case 0x08:		/* Direct Character Input, without echo (checks for breaks officially :)*/
 		{
-				Bit8u c;Bit16u n=1;
+				uint8_t c;uint16_t n=1;
 				DOS_ReadFile (STDIN,&c,&n);
 				reg_al=c;
 				break;
 		};
 	case 0x09:		/* Write string to STDOUT */
 		{	
-			Bit8u c;Bit16u n=1;
+			uint8_t c;uint16_t n=1;
 			PhysPt buf=SegPhys(ds)+reg_dx;
 			while ((c=mem_readb(buf++))!='$') {
 				DOS_WriteFile(STDOUT,&c,&n);
@@ -395,8 +395,8 @@ static Bitu DOS_21Handler(void) {
 		{
 			//TODO ADD Break checkin in STDIN but can't care that much for it
 			PhysPt data=SegPhys(ds)+reg_dx;
-			Bit8u free=mem_readb(data);
-			Bit8u read=0;Bit8u c;Bit16u n=1;
+			uint8_t free=mem_readb(data);
+			uint8_t read=0;uint8_t c;uint16_t n=1;
 			if (!free) break;
 			free--;
 			for(;;) {
@@ -416,7 +416,7 @@ static Bitu DOS_21Handler(void) {
 					continue;
 				}
 				if (read == free && c != 13) {		// Keyboard buffer full
-					Bit8u bell = 7;
+					uint8_t bell = 7;
 					DOS_WriteFile(STDOUT, &bell, &n);
 					continue;
 				}
@@ -439,9 +439,9 @@ static Bitu DOS_21Handler(void) {
 	case 0x0c:		/* Flush Buffer and read STDIN call */
 		{
 			/* flush buffer if STDIN is CON */
-			Bit8u handle=RealHandle(STDIN);
+			uint8_t handle=RealHandle(STDIN);
 			if (handle!=0xFF && Files[handle] && Files[handle]->IsName("CON")) {
-				Bit8u c;Bit16u n;
+				uint8_t c;uint16_t n;
 				while (DOS_GetSTDINStatus()) {
 					n=1;	DOS_ReadFile(STDIN,&c,&n);
 				}
@@ -453,7 +453,7 @@ static Bitu DOS_21Handler(void) {
 			case 0x8:
 			case 0xa:
 				{ 
-					Bit8u oldah=reg_ah;
+					uint8_t oldah=reg_ah;
 					reg_ah=reg_al;
 					DOS_21Handler();
 					reg_ah=oldah;
@@ -531,14 +531,14 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x21:		/* Read random record from FCB */
 		{
-			Bit16u toread=1;
+			uint16_t toread=1;
 			reg_al = DOS_FCBRandomRead(SegValue(ds),reg_dx,&toread,true);
 		}
 		LOG(LOG_FCB,LOG_NORMAL)("DOS:0x21 FCB-Random read used, result:al=%d",reg_al);
 		break;
 	case 0x22:		/* Write random record to FCB */
 		{
-			Bit16u towrite=1;
+			uint16_t towrite=1;
 			reg_al=DOS_FCBRandomWrite(SegValue(ds),reg_dx,&towrite,true);
 		}
 		LOG(LOG_FCB,LOG_NORMAL)("DOS:0x22 FCB-Random write used, result:al=%d",reg_al);
@@ -560,7 +560,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x29:		/* Parse filename into FCB */
 		{   
-			Bit8u difference;
+			uint8_t difference;
 			char string[1024];
 			MEM_StrCopy(SegPhys(ds)+reg_si,string,1023); // 1024 toasts the stack
 			reg_al=FCB_Parsename(SegValue(es),reg_di,reg_al ,string, &difference);
@@ -615,13 +615,13 @@ static Bitu DOS_21Handler(void) {
 		if(time_start<=ticks) ticks-=time_start;
 		Bitu time=(Bitu)((100.0/((double)PIT_TICK_RATE/65536.0)) * (double)ticks);
 
-		reg_dl=(Bit8u)((Bitu)time % 100); // 1/100 seconds
+		reg_dl=(uint8_t)((Bitu)time % 100); // 1/100 seconds
 		time/=100;
-		reg_dh=(Bit8u)((Bitu)time % 60); // seconds
+		reg_dh=(uint8_t)((Bitu)time % 60); // seconds
 		time/=60;
-		reg_cl=(Bit8u)((Bitu)time % 60); // minutes
+		reg_cl=(uint8_t)((Bitu)time % 60); // minutes
 		time/=60;
-		reg_ch=(Bit8u)((Bitu)time % 24); // hours
+		reg_ch=(uint8_t)((Bitu)time % 24); // hours
 
 		//Simulate DOS overhead for timing-sensitive games
         //Robomaze 2
@@ -639,9 +639,9 @@ static Bitu DOS_21Handler(void) {
 			// easy to count hours and days. More precisely:
 			//
 			// clock updates at 1193180/65536 ticks per second.
-			// ticks per second ≈ 18.2
-			// ticks per hour   ≈ 65543
-			// ticks per day    ≈ 1573040
+			// ticks per second ??? 18.2
+			// ticks per hour   ??? 65543
+			// ticks per day    ??? 1573040
 			constexpr uint64_t ticks_per_day = 1573040;
 			const auto seconds = reg_ch * 3600 + reg_cl * 60 + reg_dh;
 			const auto ticks = ticks_per_day * seconds / (24 * 3600);
@@ -673,7 +673,7 @@ static Bitu DOS_21Handler(void) {
 	case 0x1f: /* Get drive parameter block for default drive */
 	case 0x32: /* Get drive parameter block for specific drive */
 		{	/* Officially a dpb should be returned as well. The disk detection part is implemented */
-			Bit8u drive=reg_dl;
+			uint8_t drive=reg_dl;
 			if (!drive || reg_ah==0x1f) drive = DOS_GetDefaultDrive();
 			else drive--;
 			if (drive < DOS_DRIVES && Drives[drive] && !Drives[drive]->isRemovable()) {
@@ -714,20 +714,20 @@ static Bitu DOS_21Handler(void) {
 		reg_bx=DOS_SDA_OFS + 0x01;
 		break;
 	case 0x35:		/* Get interrupt vector */
-		reg_bx=real_readw(0,((Bit16u)reg_al)*4);
-		SegSet16(es,real_readw(0,((Bit16u)reg_al)*4+2));
+		reg_bx=real_readw(0,((uint16_t)reg_al)*4);
+		SegSet16(es,real_readw(0,((uint16_t)reg_al)*4+2));
 		break;
 	case 0x36:		/* Get Free Disk Space */
 		{
-			Bit16u bytes,clusters,free;
-			Bit8u sectors;
+			uint16_t bytes,clusters,free;
+			uint8_t sectors;
 			if (DOS_GetFreeDiskSpace(reg_dl,&bytes,&sectors,&clusters,&free)) {
 				reg_ax=sectors;
 				reg_bx=free;
 				reg_cx=bytes;
 				reg_dx=clusters;
 			} else {
-				Bit8u drive=reg_dl;
+				uint8_t drive=reg_dl;
 				if (drive==0) drive=DOS_GetDefaultDrive();
 				else drive--;
 				if (drive<2) {
@@ -826,7 +826,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x3f:		/* READ Read from file or device */
 		{ 
-			Bit16u toread=DOS_GetAmount();
+			uint16_t toread=DOS_GetAmount();
 			dos.echo=true;
 			if (DOS_ReadFile(reg_bx,dos_copybuf,&toread)) {
 				MEM_BlockWrite(SegPhys(ds)+reg_dx,dos_copybuf,toread);
@@ -842,7 +842,7 @@ static Bitu DOS_21Handler(void) {
 		}
 	case 0x40:					/* WRITE Write to file or device */
 		{
-			Bit16u towrite=DOS_GetAmount();
+			uint16_t towrite=DOS_GetAmount();
 			MEM_BlockRead(SegPhys(ds)+reg_dx,dos_copybuf,towrite);
 			if (DOS_WriteFile(reg_bx,dos_copybuf,&towrite)) {
 				reg_ax=towrite;
@@ -865,10 +865,10 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x42:					/* LSEEK Set current file position */
 		{
-			Bit32u pos=(reg_cx<<16) + reg_dx;
+			uint32_t pos=(reg_cx<<16) + reg_dx;
 			if (DOS_SeekFile(reg_bx,&pos,reg_al)) {
-				reg_dx=(Bit16u)(pos >> 16);
-				reg_ax=(Bit16u)(pos & 0xFFFF);
+				reg_dx=(uint16_t)(pos >> 16);
+				reg_ax=(uint16_t)(pos & 0xFFFF);
 				CALLBACK_SCF(false);
 			} else {
 				reg_ax=dos.errorcode;
@@ -881,7 +881,7 @@ static Bitu DOS_21Handler(void) {
 		switch (reg_al) {
 		case 0x00:				/* Get */
 			{
-				Bit16u attr_val=reg_cx;
+				uint16_t attr_val=reg_cx;
 				if (DOS_GetFileAttr(name1,&attr_val)) {
 					reg_cx=attr_val;
 					reg_ax=attr_val; /* Undocumented */   
@@ -945,7 +945,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x48:					/* Allocate memory */
 		{
-			Bit16u size=reg_bx;Bit16u seg;
+			uint16_t size=reg_bx;uint16_t seg;
 			if (DOS_AllocateMemory(&seg,&size)) {
 				reg_ax=seg;
 				CALLBACK_SCF(false);
@@ -966,7 +966,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x4a:					/* Resize memory block */
 		{
-			Bit16u size=reg_bx;
+			uint16_t size=reg_bx;
 			if (DOS_ResizeMemory(SegValue(es),&size)) {
 				reg_ax=SegValue(es);
 				CALLBACK_SCF(false);
@@ -1025,7 +1025,7 @@ static Bitu DOS_21Handler(void) {
 		reg_bx=dos.psp();
 		break;
 	case 0x52: {				/* Get list of lists */
-		Bit8u count=2; // floppy drives always counted
+		uint8_t count=2; // floppy drives always counted
 		while (count<DOS_DRIVES && Drives[count] && !Drives[count]->isRemovable()) count++;
 		dos_infoblock.SetBlockDevices(count);
 		RealPt addr=dos_infoblock.GetPointer();
@@ -1116,7 +1116,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x5a:					/* Create temporary file */
 		{
-			Bit16u handle;
+			uint16_t handle;
 			MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 			if (DOS_CreateTempFile(name1,&handle)) {
 				reg_ax=handle;
@@ -1131,7 +1131,7 @@ static Bitu DOS_21Handler(void) {
 	case 0x5b:					/* Create new file */
 		{
 			MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
-			Bit16u handle;
+			uint16_t handle;
 			if (DOS_OpenFile(name1,0,&handle)) {
 				DOS_CloseFile(handle);
 				DOS_SetError(DOSERR_FILE_ALREADY_EXISTS);
@@ -1258,7 +1258,7 @@ static Bitu DOS_21Handler(void) {
 				{
 					int in  = reg_dl;
 					int out = toupper(in);
-					reg_dl  = (Bit8u)out;
+					reg_dl  = (uint8_t)out;
 				}
 				CALLBACK_SCF(false);
 				break;
@@ -1274,7 +1274,7 @@ static Bitu DOS_21Handler(void) {
 					dos_copybuf[len] = 0;
 					//No upcase as String(0x21) might be multiple asciz strings
 					for (Bitu count = 0; count < len;count++)
-						dos_copybuf[count] = (Bit8u)toupper(*reinterpret_cast<unsigned char*>(dos_copybuf+count));
+						dos_copybuf[count] = (uint8_t)toupper(*reinterpret_cast<unsigned char*>(dos_copybuf+count));
 					MEM_BlockWrite(data,dos_copybuf,len);
 				}
 				CALLBACK_SCF(false);
@@ -1311,7 +1311,7 @@ static Bitu DOS_21Handler(void) {
 		break;
 	case 0x69:					/* Get/Set disk serial number */
 		{
-			Bit16u old_cx=reg_cx;
+			uint16_t old_cx=reg_cx;
 			switch(reg_al)		{
 			case 0x00:				/* Get */
 				LOG(LOG_DOSMISC,LOG_WARN)("DOS:Get Disk serial number");
@@ -1371,8 +1371,8 @@ static Bitu DOS_20Handler(void) {
 
 static Bitu DOS_27Handler(void) {
 	// Terminate & stay resident
-	Bit16u para = (reg_dx/16)+((reg_dx % 16)>0);
-	Bit16u psp = dos.psp(); //mem_readw(SegPhys(ss)+reg_sp+2);
+	uint16_t para = (reg_dx/16)+((reg_dx % 16)>0);
+	uint16_t psp = dos.psp(); //mem_readw(SegPhys(ss)+reg_sp+2);
 	if (DOS_ResizeMemory(psp,&para)) DOS_Terminate(psp,true,0);
 	return CBRET_NONE;
 }
@@ -1513,7 +1513,7 @@ public:
 		}
 	}
 	~DOS(){
-		for (Bit16u i = 0; i < DOS_DRIVES; i++)	delete Drives[i];
+		for (uint16_t i = 0; i < DOS_DRIVES; i++)	delete Drives[i];
 		// de-init devices, this allows DOSBox to cleanly re-initialize
 		// without throwing an inevitable `DOS: Too many devices added`
 		// exception

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -136,7 +136,7 @@ void DOS_InfoBlock::SetBuffers(uint16_t x, uint16_t y)
 	SSET_WORD(sDIB, buffers_y, y);
 }
 
-Bit16u DOS_PSP::rootpsp = 0;
+uint16_t DOS_PSP::rootpsp = 0;
 
 void DOS_PSP::MakeNew(uint16_t mem_size)
 {
@@ -171,7 +171,7 @@ void DOS_PSP::MakeNew(uint16_t mem_size)
 	const RealPt ftab_addr = RealMake(seg, offsetof(sPSP, files));
 	SSET_DWORD(sPSP, file_table, ftab_addr);
 	SSET_WORD(sPSP, max_files, uint16_t(20));
-	for (Bit16u ct=0;ct<20;ct++) SetFileHandle(ct,0xff);
+	for (uint16_t ct=0;ct<20;ct++) SetFileHandle(ct,0xff);
 
 	/* User Stack pointer */
 //	if (prevpsp.GetSegment()!=0) SSET_DWORD(sPSP,stack,prevpsp.GetStack());
@@ -223,8 +223,8 @@ uint16_t DOS_PSP::FindEntryByHandle(uint8_t handle) const
 void DOS_PSP::CopyFileTable(DOS_PSP *srcpsp, bool createchildpsp)
 {
 	/* Copy file table from calling process */
-	for (Bit16u i=0;i<20;i++) {
-		Bit8u handle = srcpsp->GetFileHandle(i);
+	for (uint16_t i=0;i<20;i++) {
+		uint8_t handle = srcpsp->GetFileHandle(i);
 		if(createchildpsp)
 		{	//copy obeying not inherit flag.(but dont duplicate them)
 			bool allowCopy = true;//(handle==0) || ((handle>0) && (FindEntryByHandle(handle)==0xff));
@@ -502,7 +502,7 @@ void DOS_FCB::SetAttr(uint8_t attr)
 		mem_writeb(pt - 1, attr);
 }
 
-void DOS_FCB::SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr) {
+void DOS_FCB::SetResult(uint32_t size,uint16_t date,uint16_t time,uint8_t attr) {
 	mem_writed(pt + 0x1d,size);
 	mem_writew(pt + 0x19,date);
 	mem_writew(pt + 0x17,time);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -257,44 +257,44 @@ class device_NUL : public DOS_Device {
 public:
 	device_NUL() { SetName("NUL"); }
 
-	virtual bool Read(Bit8u * /*data*/,Bit16u * size) {
+	virtual bool Read(uint8_t * /*data*/,uint16_t * size) {
 		*size = 0; //Return success and no data read. 
 		LOG(LOG_IOCTL,LOG_NORMAL)("%s:READ",GetName());
 		return true;
 	}
-	virtual bool Write(Bit8u * /*data*/,Bit16u * /*size*/) {
+	virtual bool Write(uint8_t * /*data*/,uint16_t * /*size*/) {
 		LOG(LOG_IOCTL,LOG_NORMAL)("%s:WRITE",GetName());
 		return true;
 	}
-	virtual bool Seek(Bit32u * /*pos*/,Bit32u /*type*/) {
+	virtual bool Seek(uint32_t * /*pos*/,uint32_t /*type*/) {
 		LOG(LOG_IOCTL,LOG_NORMAL)("%s:SEEK",GetName());
 		return true;
 	}
 	virtual bool Close() { return true; }
 	virtual uint16_t GetInformation() { return 0x8084; }
-	virtual bool ReadFromControlChannel(PhysPt /*bufptr*/,Bit16u /*size*/,Bit16u * /*retcode*/){return false;}
-	virtual bool WriteToControlChannel(PhysPt /*bufptr*/,Bit16u /*size*/,Bit16u * /*retcode*/){return false;}
+	virtual bool ReadFromControlChannel(PhysPt /*bufptr*/,uint16_t /*size*/,uint16_t * /*retcode*/){return false;}
+	virtual bool WriteToControlChannel(PhysPt /*bufptr*/,uint16_t /*size*/,uint16_t * /*retcode*/){return false;}
 };
 
 class device_LPT1 final : public device_NUL {
 public:
    	device_LPT1() { SetName("LPT1");}
 	uint16_t GetInformation() { return 0x80A0; }
-	bool Read(Bit8u* /*data*/,Bit16u * /*size*/){
+	bool Read(uint8_t* /*data*/,uint16_t * /*size*/){
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}	
 };
 
-bool DOS_Device::Read(Bit8u * data,Bit16u * size) {
+bool DOS_Device::Read(uint8_t * data,uint16_t * size) {
 	return Devices[devnum]->Read(data,size);
 }
 
-bool DOS_Device::Write(Bit8u * data,Bit16u * size) {
+bool DOS_Device::Write(uint8_t * data,uint16_t * size) {
 	return Devices[devnum]->Write(data,size);
 }
 
-bool DOS_Device::Seek(Bit32u * pos,Bit32u type) {
+bool DOS_Device::Seek(uint32_t * pos,uint32_t type) {
 	return Devices[devnum]->Seek(pos,type);
 }
 
@@ -306,11 +306,11 @@ uint16_t DOS_Device::GetInformation() {
 	return Devices[devnum]->GetInformation();
 }
 
-bool DOS_Device::ReadFromControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode) { 
+bool DOS_Device::ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) { 
 	return Devices[devnum]->ReadFromControlChannel(bufptr,size,retcode);
 }
 
-bool DOS_Device::WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode) { 
+bool DOS_Device::WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) { 
 	return Devices[devnum]->WriteToControlChannel(bufptr,size,retcode);
 }
 
@@ -337,9 +337,9 @@ DOS_File &DOS_File::operator=(const DOS_File &orig)
 	return *this;
 }
 
-Bit8u DOS_FindDevice(char const * name) {
+uint8_t DOS_FindDevice(char const * name) {
 	/* should only check for the names before the dot and spacepadded */
-	char fullname[DOS_PATHLENGTH];Bit8u drive;
+	char fullname[DOS_PATHLENGTH];uint8_t drive;
 //	if(!name || !(*name)) return DOS_DEVICES; //important, but makename does it
 	if (!DOS_MakeName(name,fullname,&drive)) return DOS_DEVICES;
 
@@ -383,7 +383,7 @@ Bit8u DOS_FindDevice(char const * name) {
 		name_part = lpt;
 
 	/* loop through devices */
-	for(Bit8u index = 0;index < DOS_DEVICES;index++) {
+	for(uint8_t index = 0;index < DOS_DEVICES;index++) {
 		if (Devices[index]) {
 			if (WildFileCmp(name_part, Devices[index]->GetName()))
 				return index;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -46,19 +46,19 @@
 DOS_File * Files[DOS_FILES];
 DOS_Drive * Drives[DOS_DRIVES];
 
-Bit8u DOS_GetDefaultDrive(void) {
+uint8_t DOS_GetDefaultDrive(void) {
 //	return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDrive();
-	Bit8u d = DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDrive();
+	uint8_t d = DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDrive();
 	if( d != dos.current_drive ) LOG(LOG_DOSMISC,LOG_ERROR)("SDA drive %d not the same as dos.current_drive %d",d,dos.current_drive);
 	return dos.current_drive;
 }
 
-void DOS_SetDefaultDrive(Bit8u drive) {
+void DOS_SetDefaultDrive(uint8_t drive) {
 //	if (drive<=DOS_DRIVES && ((drive<2) || Drives[drive])) DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(drive);
 	if (drive<DOS_DRIVES && ((drive<2) || Drives[drive])) {dos.current_drive = drive; DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(drive);}
 }
 
-bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
+bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive) {
 	if(!name || *name == 0 || *name == ' ') {
 		/* Both \0 and space are seperators and
 		 * empty filenames report file not found */
@@ -69,7 +69,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	char tempdir[DOS_PATHLENGTH];
 	char upname[DOS_PATHLENGTH];
 	Bitu r,w;
-	Bit8u c;
+	uint8_t c;
 	*drive = DOS_GetDefaultDrive();
 	/* First get the drive */
 	if (name_int[1]==':') {
@@ -94,7 +94,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	/* Now parse the new file name to make the final filename */
 	if (upname[0]!='\\') strcpy(fullname,Drives[*drive]->curdir);
 	else fullname[0]=0;
-	Bit32u lastdir=0;Bit32u t=0;
+	uint32_t lastdir=0;uint32_t t=0;
 	while (fullname[t]!=0) {
 		if ((fullname[t]=='\\') && (fullname[t+1]!=0)) lastdir=t;
 		t++;
@@ -113,17 +113,17 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 				continue;
 			}
 
-			Bit32s iDown;
+			int32_t iDown;
 			bool dots = true;
-			Bit32s templen=(Bit32s)strlen(tempdir);
+			int32_t templen=(int32_t)strlen(tempdir);
 			for(iDown=0;(iDown < templen) && dots;iDown++)
 				if(tempdir[iDown] != '.')
 					dots = false;
 
 			// only dots?
 			if (dots && (templen > 1)) {
-				Bit32s cDots = templen - 1;
-				for(iDown=(Bit32s)strlen(fullname)-1;iDown>=0;iDown--) {
+				int32_t cDots = templen - 1;
+				for(iDown=(int32_t)strlen(fullname)-1;iDown>=0;iDown--) {
 					if(fullname[iDown]=='\\' || iDown==0) {
 						lastdir = iDown;
 						cDots--;
@@ -143,7 +143,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 			}
 			
 
-			lastdir=(Bit32u)strlen(fullname);
+			lastdir=(uint32_t)strlen(fullname);
 
 			if (lastdir!=0) strcat(fullname,"\\");
 			char * ext=strchr(tempdir,'.');
@@ -195,7 +195,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	return true;	
 }
 
-bool DOS_GetCurrentDir(Bit8u drive,char * const buffer) {
+bool DOS_GetCurrentDir(uint8_t drive,char * const buffer) {
 	if (drive==0) drive=DOS_GetDefaultDrive();
 	else drive--;
 	if ((drive>=DOS_DRIVES) || (!Drives[drive])) {
@@ -219,7 +219,7 @@ bool DOS_ChangeDir(char const * const dir) {
 }
 
 bool DOS_MakeDir(char const * const dir) {
-	Bit8u drive;char fulldir[DOS_PATHLENGTH];
+	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	size_t len = strlen(dir);
 	if(!len || dir[len-1] == '\\') {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
@@ -241,7 +241,7 @@ bool DOS_RemoveDir(char const * const dir) {
  * the host to forbid removal of the current directory.
  * We never change directory. Everything happens in the drives.
  */
-	Bit8u drive;char fulldir[DOS_PATHLENGTH];
+	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
 	/* Check if exists */
 	if(!Drives[drive]->TestDir(fulldir)) {
@@ -272,15 +272,15 @@ static bool PathExists(char const * const name) {
 	char * lead = strrchr(temp,'\\');
 	if (lead == temp) return true;
 	*lead = 0;
-	Bit8u drive;char fulldir[DOS_PATHLENGTH];
+	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	if (!DOS_MakeName(temp,fulldir,&drive)) return false;
 	if(!Drives[drive]->TestDir(fulldir)) return false;
 	return true;
 }
 
 bool DOS_Rename(char const * const oldname,char const * const newname) {
-	Bit8u driveold;char fullold[DOS_PATHLENGTH];
-	Bit8u drivenew;char fullnew[DOS_PATHLENGTH];
+	uint8_t driveold;char fullold[DOS_PATHLENGTH];
+	uint8_t drivenew;char fullnew[DOS_PATHLENGTH];
 	if (!DOS_MakeName(oldname,fullold,&driveold)) return false;
 	if (!DOS_MakeName(newname,fullnew,&drivenew)) return false;
 	/* No tricks with devices */
@@ -295,7 +295,7 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 		return false;
 	}
 	/*Test if target exists => no access */
-	Bit16u attr;
+	uint16_t attr;
 	if(Drives[drivenew]->GetFileAttr(fullnew,&attr)) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
@@ -317,7 +317,7 @@ bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst)
 {
 	LOG(LOG_FILES,LOG_NORMAL)("file search attributes %X name %s",attr,search);
 	DOS_DTA dta(dos.dta());
-	Bit8u drive;char fullsearch[DOS_PATHLENGTH];
+	uint8_t drive;char fullsearch[DOS_PATHLENGTH];
 	char dir[DOS_PATHLENGTH];char pattern[DOS_PATHLENGTH];
 	size_t len = strlen(search);
 
@@ -346,7 +346,7 @@ bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst)
 		safe_strcpy(dir, fullsearch);
 	}
 
-	dta.SetupSearch(drive,(Bit8u)attr,pattern);
+	dta.SetupSearch(drive,(uint8_t)attr,pattern);
 
 	if(device) {
 		find_last = strrchr(pattern,'.');
@@ -364,7 +364,7 @@ bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst)
 
 bool DOS_FindNext(void) {
 	DOS_DTA dta(dos.dta());
-	Bit8u i = dta.GetSearchDrive();
+	uint8_t i = dta.GetSearchDrive();
 	if(i >= DOS_DRIVES || !Drives[i]) {
 		/* Corrupt search. */
 		LOG(LOG_FILES,LOG_ERROR)("Corrupt search!!!!");
@@ -376,8 +376,8 @@ bool DOS_FindNext(void) {
 }
 
 
-bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
-	Bit32u handle = fcb?entry:RealHandle(entry);
+bool DOS_ReadFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
+	uint32_t handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -392,14 +392,14 @@ bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
 		return false;
 	}
 */
-	Bit16u toread=*amount;
+	uint16_t toread=*amount;
 	bool ret=Files[handle]->Read(data,&toread);
 	*amount=toread;
 	return ret;
 }
 
-bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
-	Bit32u handle = fcb?entry:RealHandle(entry);
+bool DOS_WriteFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
+	uint32_t handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -414,14 +414,14 @@ bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
 		return false;
 	}
 */
-	Bit16u towrite=*amount;
+	uint16_t towrite=*amount;
 	bool ret=Files[handle]->Write(data,&towrite);
 	*amount=towrite;
 	return ret;
 }
 
-bool DOS_SeekFile(Bit16u entry,Bit32u * pos,Bit32u type,bool fcb) {
-	Bit32u handle = fcb?entry:RealHandle(entry);
+bool DOS_SeekFile(uint16_t entry,uint32_t * pos,uint32_t type,bool fcb) {
+	uint32_t handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -433,8 +433,8 @@ bool DOS_SeekFile(Bit16u entry,Bit32u * pos,Bit32u type,bool fcb) {
 	return Files[handle]->Seek(pos,type);
 }
 
-bool DOS_CloseFile(Bit16u entry, bool fcb, Bit8u * refcnt) {
-	Bit32u handle = fcb?entry:RealHandle(entry);
+bool DOS_CloseFile(uint16_t entry, bool fcb, uint8_t * refcnt) {
+	uint32_t handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -456,12 +456,12 @@ bool DOS_CloseFile(Bit16u entry, bool fcb, Bit8u * refcnt) {
 		Files[handle]=0;
 		refs=0;
 	}
-	if (refcnt!=NULL) *refcnt=static_cast<Bit8u>(refs+1);
+	if (refcnt!=NULL) *refcnt=static_cast<uint8_t>(refs+1);
 	return true;
 }
 
-bool DOS_FlushFile(Bit16u entry) {
-	Bit32u handle=RealHandle(entry);
+bool DOS_FlushFile(uint16_t entry) {
+	uint32_t handle=RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -474,7 +474,7 @@ bool DOS_FlushFile(Bit16u entry) {
 	return true;
 }
 
-bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry,bool fcb) {
+bool DOS_CreateFile(char const * name,uint16_t attributes,uint16_t * entry,bool fcb) {
 	// Creation of a device is the same as opening it
 	// Tc201 installer
 	if (DOS_FindDevice(name) != DOS_DEVICES)
@@ -526,13 +526,13 @@ bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry,bool fcb)
 	}
 }
 
-bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb) {
+bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 	/* First check for devices */
 	if (flags>2) LOG(LOG_FILES,LOG_ERROR)("Special file open command %X file %s",flags,name);
 	else LOG(LOG_FILES,LOG_NORMAL)("file open command %X file %s",flags,name);
 
-	Bit16u attr = 0;
-	Bit8u devnum = DOS_FindDevice(name);
+	uint16_t attr = 0;
+	uint8_t devnum = DOS_FindDevice(name);
 	bool device = (devnum != DOS_DEVICES);
 	if(!device && DOS_GetFileAttr(name,&attr)) {
 	//DON'T ALLOW directories to be openened.(skip test if file is device).
@@ -595,9 +595,9 @@ bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb) {
 	}
 }
 
-bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bit16u action, Bit16u *entry, Bit16u* status) {
+bool DOS_OpenFileExtended(char const * name, uint16_t flags, uint16_t createAttr, uint16_t action, uint16_t *entry, uint16_t* status) {
 // FIXME: Not yet supported : Bit 13 of flags (int 0x24 on critical error)
-	Bit16u result = 0;
+	uint16_t result = 0;
 	if (action==0) {
 		// always fail setting
 		DOS_SetError(DOSERR_FUNCTION_NUMBER_INVALID);
@@ -609,7 +609,7 @@ bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bi
 			return false;
 		}
 	}
-	if (DOS_OpenFile(name, (Bit8u)(flags&0xff), entry)) {
+	if (DOS_OpenFile(name, (uint8_t)(flags&0xff), entry)) {
 		// File already exists
 		switch (action & 0x0f) {
 			case 0x00:		// failed
@@ -668,7 +668,7 @@ bool DOS_UnlinkFile(char const * const name) {
 bool DOS_GetFileAttr(char const *const name, uint16_t *attr)
 {
 	char fullname[DOS_PATHLENGTH];
-	Bit8u drive;
+	uint8_t drive;
 	if (!DOS_MakeName(name, fullname, &drive))
 		return false;
 	if (Drives[drive]->GetFileAttr(fullname, attr)) {
@@ -682,7 +682,7 @@ bool DOS_GetFileAttr(char const *const name, uint16_t *attr)
 bool DOS_SetFileAttr(char const *const name, uint16_t attr)
 {
 	char fullname[DOS_PATHLENGTH];
-	Bit8u drive;
+	uint8_t drive;
 	if (!DOS_MakeName(name, fullname, &drive))
 		return false;
 	if (strncmp(Drives[drive]->GetInfo(), "CDRom ", 6) == 0 ||
@@ -713,7 +713,7 @@ bool DOS_SetFileAttr(char const *const name, uint16_t attr)
 
 bool DOS_Canonicalize(char const * const name,char * const big) {
 //TODO Add Better support for devices and shit but will it be needed i doubt it :) 
-	Bit8u drive;
+	uint8_t drive;
 	char fullname[DOS_PATHLENGTH];
 	if (!DOS_MakeName(name,fullname,&drive)) return false;
 	big[0]=drive+'A';
@@ -723,7 +723,7 @@ bool DOS_Canonicalize(char const * const name,char * const big) {
 	return true;
 }
 
-bool DOS_GetFreeDiskSpace(Bit8u drive,Bit16u * bytes,Bit8u * sectors,Bit16u * clusters,Bit16u * free) {
+bool DOS_GetFreeDiskSpace(uint8_t drive,uint16_t * bytes,uint8_t * sectors,uint16_t * clusters,uint16_t * free) {
 	if (drive==0) drive=DOS_GetDefaultDrive();
 	else drive--;
 	if ((drive>=DOS_DRIVES) || (!Drives[drive])) {
@@ -733,7 +733,7 @@ bool DOS_GetFreeDiskSpace(Bit8u drive,Bit16u * bytes,Bit8u * sectors,Bit16u * cl
 	return Drives[drive]->AllocationInfo(bytes,sectors,clusters,free);
 }
 
-bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry) {
+bool DOS_DuplicateEntry(uint16_t entry,uint16_t * newentry) {
 	// Dont duplicate console handles
 /*	if (entry<=STDPRN) {
 		*newentry = entry;
@@ -760,12 +760,12 @@ bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry) {
 	return true;
 }
 
-bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry) {
+bool DOS_ForceDuplicateEntry(uint16_t entry,uint16_t newentry) {
 	if(entry == newentry) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	}
-	Bit8u orig = RealHandle(entry);
+	uint8_t orig = RealHandle(entry);
 	if (orig >= DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -774,7 +774,7 @@ bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	Bit8u newone = RealHandle(newentry);
+	uint8_t newone = RealHandle(newentry);
 	if (newone < DOS_FILES && Files[newone]) {
 		DOS_CloseFile(newentry);
 	}
@@ -785,7 +785,7 @@ bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry) {
 }
 
 
-bool DOS_CreateTempFile(char * const name,Bit16u * entry) {
+bool DOS_CreateTempFile(char * const name,uint16_t * entry) {
 	size_t namelen=strlen(name);
 	char * tempname=name+namelen;
 	if (namelen==0) {
@@ -802,7 +802,7 @@ bool DOS_CreateTempFile(char * const name,Bit16u * entry) {
 
 	static const auto randomize_letter = CreateRandomizer<char>('A', 'Z');
 	do {
-		Bit32u i;
+		uint32_t i;
 		for (i=0;i<8;i++) {
 			tempname[i] = randomize_letter();
 		}
@@ -832,7 +832,7 @@ char DOS_ToUpper(char c) {
 
 static bool isvalid(const char in){
 	const char ill[]=ILLEGAL;    
-	return (Bit8u(in)>0x1F) && (!strchr(ill,in));
+	return (uint8_t(in)>0x1F) && (!strchr(ill,in));
 }
 
 #define PARSE_SEP_STOP          0x01
@@ -845,9 +845,9 @@ static bool isvalid(const char in){
 #define PARSE_RET_BADDRIVE      0xff
 
 // TODO: Refactor and document this function until it's understandable
-Bit8u FCB_Parsename(Bit16u seg,Bit16u offset,Bit8u parser ,char *string, Bit8u *change) {
+uint8_t FCB_Parsename(uint16_t seg,uint16_t offset,uint8_t parser ,char *string, uint8_t *change) {
 	char * string_begin=string;
-	Bit8u ret=0;
+	uint8_t ret=0;
 	if (!(parser & PARSE_DFLT_DRIVE)) {
 		// default drive forced, this intentionally invalidates an extended FCB
 		mem_writeb(PhysMake(seg,offset),0);
@@ -857,7 +857,7 @@ Bit8u FCB_Parsename(Bit16u seg,Bit16u offset,Bit8u parser ,char *string, Bit8u *
 	bool hasname = false;
 	bool hasext = false;
 	Bitu index=0;
-	Bit8u fill=' ';
+	uint8_t fill=' ';
 /* First get the old data from the fcb */
 #ifdef _MSC_VER
 #pragma pack (1)
@@ -971,7 +971,7 @@ savefcb:
 		safe_strcpy(fcb_name.part.ext, "   ");
 	fcb.SetName(fcb_name.part.drive[0], fcb_name.part.name, fcb_name.part.ext);
 	fcb.ClearBlockRecsize(); //Undocumented bonus work.
-	*change=(Bit8u)(string-string_begin);
+	*change=(uint8_t)(string-string_begin);
 	return ret;
 }
 
@@ -991,11 +991,11 @@ static void DTAExtendName(char * const name,char * const filename,char * const e
 
 static void SaveFindResult(DOS_FCB & find_fcb) {
 	DOS_DTA find_dta(dos.tables.tempdta);
-	char name[DOS_NAMELENGTH_ASCII];Bit32u size;Bit16u date;Bit16u time;Bit8u attr;Bit8u drive;
+	char name[DOS_NAMELENGTH_ASCII];uint32_t size;uint16_t date;uint16_t time;uint8_t attr;uint8_t drive;
 	char file_name[9];char ext[4];
 	find_dta.GetResult(name,size,date,time,attr);
 	drive=find_fcb.GetDrive()+1;
-	Bit8u find_attr = DOS_ATTR_ARCHIVE;
+	uint8_t find_attr = DOS_ATTR_ARCHIVE;
 	find_fcb.GetAttr(find_attr); /* Gets search attributes if extended */
 	/* Create a correct file and extention */
 	DTAExtendName(name,file_name,ext);	
@@ -1006,21 +1006,21 @@ static void SaveFindResult(DOS_FCB & find_fcb) {
 	fcb.SetResult(size,date,time,attr);
 }
 
-bool DOS_FCBCreate(Bit16u seg,Bit16u offset) { 
+bool DOS_FCBCreate(uint16_t seg,uint16_t offset) { 
 	DOS_FCB fcb(seg,offset);
-	char shortname[DOS_FCBNAME];Bit16u handle;
+	char shortname[DOS_FCBNAME];uint16_t handle;
 	fcb.GetName(shortname);
-	Bit8u attr = DOS_ATTR_ARCHIVE;
+	uint8_t attr = DOS_ATTR_ARCHIVE;
 	fcb.GetAttr(attr);
 	if (!attr) attr = DOS_ATTR_ARCHIVE; //Better safe than sorry 
 	if (!DOS_CreateFile(shortname,attr,&handle,true)) return false;
-	fcb.FileOpen((Bit8u)handle);
+	fcb.FileOpen((uint8_t)handle);
 	return true;
 }
 
-bool DOS_FCBOpen(Bit16u seg,Bit16u offset) { 
+bool DOS_FCBOpen(uint16_t seg,uint16_t offset) { 
 	DOS_FCB fcb(seg,offset);
-	char shortname[DOS_FCBNAME];Bit16u handle;
+	char shortname[DOS_FCBNAME];uint16_t handle;
 	fcb.GetName(shortname);
 
 	/* Search for file if name has wildcards */
@@ -1030,7 +1030,7 @@ bool DOS_FCBOpen(Bit16u seg,Bit16u offset) {
 		DOS_DTA find_dta(dos.tables.tempdta);
 		DOS_FCB find_fcb(RealSeg(dos.tables.tempdta),RealOff(dos.tables.tempdta));
 		char name[DOS_NAMELENGTH_ASCII],file_name[9],ext[4];
-		Bit32u size;Bit16u date,time;Bit8u attr;
+		uint32_t size;uint16_t date,time;uint8_t attr;
 		find_dta.GetResult(name,size,date,time,attr);
 		DTAExtendName(name,file_name,ext);
 		find_fcb.SetName(fcb.GetDrive()+1,file_name,ext);
@@ -1053,24 +1053,24 @@ bool DOS_FCBOpen(Bit16u seg,Bit16u offset) {
 	}
 
 	if (!DOS_OpenFile(shortname,OPEN_READWRITE,&handle,true)) return false;
-	fcb.FileOpen((Bit8u)handle);
+	fcb.FileOpen((uint8_t)handle);
 	return true;
 }
 
-bool DOS_FCBClose(Bit16u seg,Bit16u offset) {
+bool DOS_FCBClose(uint16_t seg,uint16_t offset) {
 	DOS_FCB fcb(seg,offset);
 	if(!fcb.Valid()) return false;
-	Bit8u fhandle;
+	uint8_t fhandle;
 	fcb.FileClose(fhandle);
 	DOS_CloseFile(fhandle,true);
 	return true;
 }
 
-bool DOS_FCBFindFirst(Bit16u seg,Bit16u offset) {
+bool DOS_FCBFindFirst(uint16_t seg,uint16_t offset) {
 	DOS_FCB fcb(seg,offset);
 	RealPt old_dta=dos.dta();dos.dta(dos.tables.tempdta);
 	char name[DOS_FCBNAME];fcb.GetName(name);
-	Bit8u attr = DOS_ATTR_ARCHIVE;
+	uint8_t attr = DOS_ATTR_ARCHIVE;
 	fcb.GetAttr(attr); /* Gets search attributes if extended */
 	bool ret=DOS_FindFirst(name,attr,true);
 	dos.dta(old_dta);
@@ -1078,7 +1078,7 @@ bool DOS_FCBFindFirst(Bit16u seg,Bit16u offset) {
 	return ret;
 }
 
-bool DOS_FCBFindNext(Bit16u seg,Bit16u offset) {
+bool DOS_FCBFindNext(uint16_t seg,uint16_t offset) {
 	DOS_FCB fcb(seg,offset);
 	RealPt old_dta=dos.dta();dos.dta(dos.tables.tempdta);
 	bool ret=DOS_FindNext();
@@ -1087,9 +1087,9 @@ bool DOS_FCBFindNext(Bit16u seg,Bit16u offset) {
 	return ret;
 }
 
-Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset,Bit16u recno) {
+uint8_t DOS_FCBRead(uint16_t seg,uint16_t offset,uint16_t recno) {
 	DOS_FCB fcb(seg,offset);
-	Bit8u fhandle,cur_rec;Bit16u cur_block,rec_size;
+	uint8_t fhandle,cur_rec;uint16_t cur_block,rec_size;
 	fcb.GetSeqData(fhandle,rec_size);
 	if (fhandle==0xff && rec_size!=0) {
 		if (!DOS_FCBOpen(seg,offset)) return FCB_READ_NODATA;
@@ -1101,9 +1101,9 @@ Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset,Bit16u recno) {
 		fcb.SetSeqData(fhandle,rec_size);
 	}
 	fcb.GetRecord(cur_block,cur_rec);
-	Bit32u pos=((cur_block*128)+cur_rec)*rec_size;
+	uint32_t pos=((cur_block*128)+cur_rec)*rec_size;
 	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET,true)) return FCB_READ_NODATA; 
-	Bit16u toread=rec_size;
+	uint16_t toread=rec_size;
 	if (!DOS_ReadFile(fhandle,dos_copybuf,&toread,true)) return FCB_READ_NODATA;
 	if (toread == 0)
 		return FCB_READ_NODATA;
@@ -1118,9 +1118,9 @@ Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset,Bit16u recno) {
 	return FCB_READ_PARTIAL;
 }
 
-Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u recno) {
+uint8_t DOS_FCBWrite(uint16_t seg,uint16_t offset,uint16_t recno) {
 	DOS_FCB fcb(seg,offset);
-	Bit8u fhandle,cur_rec;Bit16u cur_block,rec_size;
+	uint8_t fhandle,cur_rec;uint16_t cur_block,rec_size;
 	fcb.GetSeqData(fhandle,rec_size);
 	if (fhandle==0xff && rec_size!=0) {
 		if (!DOS_FCBOpen(seg,offset)) return FCB_READ_NODATA;
@@ -1132,21 +1132,21 @@ Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u recno) {
 		fcb.SetSeqData(fhandle,rec_size);
 	}
 	fcb.GetRecord(cur_block,cur_rec);
-	Bit32u pos=((cur_block*128)+cur_rec)*rec_size;
+	uint32_t pos=((cur_block*128)+cur_rec)*rec_size;
 	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET,true)) return FCB_ERR_WRITE; 
 	MEM_BlockRead(Real2Phys(dos.dta())+recno*rec_size,dos_copybuf,rec_size);
-	Bit16u towrite=rec_size;
+	uint16_t towrite=rec_size;
 	if (!DOS_WriteFile(fhandle,dos_copybuf,&towrite,true)) return FCB_ERR_WRITE;
-	Bit32u size;Bit16u date,time;
+	uint32_t size;uint16_t date,time;
 	fcb.GetSizeDateTime(size,date,time);
 	if (pos+towrite>size) size=pos+towrite;
 	//time doesn't keep track of endofday
 	date = DOS_PackDate(dos.date.year,dos.date.month,dos.date.day);
-	Bit32u ticks = mem_readd(BIOS_TIMER);
-	Bit32u seconds = (ticks*10)/182;
-	Bit16u hour = (Bit16u)(seconds/3600);
-	Bit16u min = (Bit16u)((seconds % 3600)/60);
-	Bit16u sec = (Bit16u)(seconds % 60);
+	uint32_t ticks = mem_readd(BIOS_TIMER);
+	uint32_t seconds = (ticks*10)/182;
+	uint16_t hour = (uint16_t)(seconds/3600);
+	uint16_t min = (uint16_t)((seconds % 3600)/60);
+	uint16_t sec = (uint16_t)(seconds % 60);
 	time = DOS_PackTime(hour,min,sec);
 
 	assert(fhandle < DOS_FILES);
@@ -1158,25 +1158,25 @@ Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u recno) {
 	return FCB_SUCCESS;
 }
 
-Bit8u DOS_FCBIncreaseSize(Bit16u seg,Bit16u offset) {
+uint8_t DOS_FCBIncreaseSize(uint16_t seg,uint16_t offset) {
 	DOS_FCB fcb(seg,offset);
-	Bit8u fhandle,cur_rec;Bit16u cur_block,rec_size;
+	uint8_t fhandle,cur_rec;uint16_t cur_block,rec_size;
 	fcb.GetSeqData(fhandle,rec_size);
 	fcb.GetRecord(cur_block,cur_rec);
-	Bit32u pos=((cur_block*128)+cur_rec)*rec_size;
+	uint32_t pos=((cur_block*128)+cur_rec)*rec_size;
 	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET,true)) return FCB_ERR_WRITE; 
-	Bit16u towrite=0;
+	uint16_t towrite=0;
 	if (!DOS_WriteFile(fhandle,dos_copybuf,&towrite,true)) return FCB_ERR_WRITE;
-	Bit32u size;Bit16u date,time;
+	uint32_t size;uint16_t date,time;
 	fcb.GetSizeDateTime(size,date,time);
 	if (pos+towrite>size) size=pos+towrite;
 	//time doesn't keep track of endofday
 	date = DOS_PackDate(dos.date.year,dos.date.month,dos.date.day);
-	Bit32u ticks = mem_readd(BIOS_TIMER);
-	Bit32u seconds = (ticks*10)/182;
-	Bit16u hour = (Bit16u)(seconds/3600);
-	Bit16u min = (Bit16u)((seconds % 3600)/60);
-	Bit16u sec = (Bit16u)(seconds % 60);
+	uint32_t ticks = mem_readd(BIOS_TIMER);
+	uint32_t seconds = (ticks*10)/182;
+	uint16_t hour = (uint16_t)(seconds/3600);
+	uint16_t min = (uint16_t)((seconds % 3600)/60);
+	uint16_t sec = (uint16_t)(seconds % 60);
 	time = DOS_PackTime(hour,min,sec);
 	Files[fhandle]->time = time;
 	Files[fhandle]->date = date;
@@ -1185,21 +1185,21 @@ Bit8u DOS_FCBIncreaseSize(Bit16u seg,Bit16u offset) {
 	return FCB_SUCCESS;
 }
 
-Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
+uint8_t DOS_FCBRandomRead(uint16_t seg,uint16_t offset,uint16_t * numRec,bool restore) {
 /* if restore is true :random read else random blok read. 
  * random read updates old block and old record to reflect the random data
  * before the read!!!!!!!!! and the random data is not updated! (user must do this)
  * Random block read updates these fields to reflect the state after the read!
  */
 	DOS_FCB fcb(seg,offset);
-	Bit16u old_block=0;
-	Bit8u old_rec=0;
-	Bit8u error=0;
-	Bit16u count;
+	uint16_t old_block=0;
+	uint8_t old_rec=0;
+	uint8_t error=0;
+	uint16_t count;
 
 	/* Set the correct record from the random data */
 	const uint32_t random = fcb.GetRandom();
-	fcb.SetRecord((Bit16u)(random / 128),(Bit8u)(random & 127));
+	fcb.SetRecord((uint16_t)(random / 128),(uint8_t)(random & 127));
 	if (restore) fcb.GetRecord(old_block,old_rec);//store this for after the read.
 	// Read records
 	for (count=0; count<*numRec; count++) {
@@ -1208,7 +1208,7 @@ Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
 	}
 	if (error==FCB_READ_PARTIAL) count++;	//partial read counts
 	*numRec=count;
-	Bit16u new_block;Bit8u new_rec;
+	uint16_t new_block;uint8_t new_rec;
 	fcb.GetRecord(new_block,new_rec);
 	if (restore) fcb.SetRecord(old_block,old_rec);
 	/* Update the random record pointer with new position only when restore is false*/
@@ -1216,17 +1216,17 @@ Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
 	return error;
 }
 
-Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) {
+uint8_t DOS_FCBRandomWrite(uint16_t seg,uint16_t offset,uint16_t * numRec,bool restore) {
 /* see FCB_RandomRead */
 	DOS_FCB fcb(seg,offset);
-	Bit16u old_block=0;
-	Bit8u old_rec=0;
-	Bit8u error=0;
-	Bit16u count;
+	uint16_t old_block=0;
+	uint8_t old_rec=0;
+	uint8_t error=0;
+	uint16_t count;
 
 	/* Set the correct record from the random data */
 	const uint32_t random = fcb.GetRandom();
-	fcb.SetRecord((Bit16u)(random / 128),(Bit8u)(random & 127));
+	fcb.SetRecord((uint16_t)(random / 128),(uint8_t)(random & 127));
 	if (restore) fcb.GetRecord(old_block,old_rec);
 	if (*numRec > 0) {
 		/* Write records */
@@ -1238,7 +1238,7 @@ Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) 
 	} else {
 		DOS_FCBIncreaseSize(seg,offset);
 	}
-	Bit16u new_block;Bit8u new_rec;
+	uint16_t new_block;uint8_t new_rec;
 	fcb.GetRecord(new_block,new_rec);
 	if (restore) fcb.SetRecord(old_block,old_rec);
 	/* Update the random record pointer with new position only when restore is false */
@@ -1246,26 +1246,26 @@ Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) 
 	return error;
 }
 
-bool DOS_FCBGetFileSize(Bit16u seg,Bit16u offset) {
-	char shortname[DOS_PATHLENGTH];Bit16u entry;
+bool DOS_FCBGetFileSize(uint16_t seg,uint16_t offset) {
+	char shortname[DOS_PATHLENGTH];uint16_t entry;
 	DOS_FCB fcb(seg,offset);
 	fcb.GetName(shortname);
 	if (!DOS_OpenFile(shortname,OPEN_READ,&entry,true)) return false;
-	Bit32u size = 0;
+	uint32_t size = 0;
 	Files[entry]->Seek(&size,DOS_SEEK_END);
 	DOS_CloseFile(entry,true);
 
-	Bit8u handle; Bit16u rec_size;
+	uint8_t handle; uint16_t rec_size;
 	fcb.GetSeqData(handle,rec_size);
 	if (rec_size == 0) rec_size = 128; //Use default if missing.
 	
-	Bit32u random=(size/rec_size);
+	uint32_t random=(size/rec_size);
 	if (size % rec_size) random++;
 	fcb.SetRandom(random);
 	return true;
 }
 
-bool DOS_FCBDeleteFile(Bit16u seg,Bit16u offset){
+bool DOS_FCBDeleteFile(uint16_t seg,uint16_t offset){
 /* FCB DELETE honours wildcards. it will return true if one or more
  * files get deleted. 
  * To get this: the dta is set to temporary dta in which found files are
@@ -1288,7 +1288,7 @@ bool DOS_FCBDeleteFile(Bit16u seg,Bit16u offset){
 	return return_value;
 }
 
-bool DOS_FCBRenameFile(Bit16u seg, Bit16u offset){
+bool DOS_FCBRenameFile(uint16_t seg, uint16_t offset){
 	DOS_FCB fcbold(seg,offset);
 	DOS_FCB fcbnew(seg,offset+16);
 	if(!fcbold.Valid()) return false;
@@ -1305,7 +1305,7 @@ bool DOS_FCBRenameFile(Bit16u seg, Bit16u offset){
 	DOS_PSP psp(dos.psp());
 	for (uint8_t i = 0; i < DOS_FILES; ++i) {
 		if (Files[i] && Files[i]->IsOpen() && Files[i]->IsName(fullname)) {
-			Bit16u handle = psp.FindEntryByHandle(i);
+			uint16_t handle = psp.FindEntryByHandle(i);
 			//(more than once maybe)
 			if (handle == 0xFF) {
 				DOS_CloseFile(i,true);
@@ -1319,35 +1319,35 @@ bool DOS_FCBRenameFile(Bit16u seg, Bit16u offset){
 	return DOS_Rename(oldname,newname);
 }
 
-void DOS_FCBSetRandomRecord(Bit16u seg, Bit16u offset) {
+void DOS_FCBSetRandomRecord(uint16_t seg, uint16_t offset) {
 	DOS_FCB fcb(seg,offset);
-	Bit16u block;Bit8u rec;
+	uint16_t block;uint8_t rec;
 	fcb.GetRecord(block,rec);
 	fcb.SetRandom(block*128+rec);
 }
 
 
 bool DOS_FileExists(char const * const name) {
-	char fullname[DOS_PATHLENGTH];Bit8u drive;
+	char fullname[DOS_PATHLENGTH];uint8_t drive;
 	if (!DOS_MakeName(name,fullname,&drive)) return false;
 	return Drives[drive]->FileExists(fullname);
 }
 
-bool DOS_GetAllocationInfo(Bit8u drive,Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters) {
+bool DOS_GetAllocationInfo(uint8_t drive,uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters) {
 	if (!drive) drive =  DOS_GetDefaultDrive();
 	else drive--;
 	if (drive >= DOS_DRIVES || !Drives[drive]) {
 		DOS_SetError(DOSERR_INVALID_DRIVE);
 		return false;
 	}
-	Bit16u _free_clusters;
+	uint16_t _free_clusters;
 	Drives[drive]->AllocationInfo(_bytes_sector,_sectors_cluster,_total_clusters,&_free_clusters);
 	SegSet16(ds,RealSeg(dos.tables.mediaid));
 	reg_bx=RealOff(dos.tables.mediaid+drive*9);
 	return true;
 }
 
-bool DOS_SetDrive(Bit8u drive) {
+bool DOS_SetDrive(uint8_t drive) {
 	if (Drives[drive]) {
 		DOS_SetDefaultDrive(drive);
 		return true;
@@ -1356,8 +1356,8 @@ bool DOS_SetDrive(Bit8u drive) {
 	}
 }
 
-bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate) {
-	Bit32u handle=RealHandle(entry);
+bool DOS_GetFileDate(uint16_t entry, uint16_t* otime, uint16_t* odate) {
+	uint32_t handle=RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -57,7 +57,7 @@ bool DOS_IOCTL(void) {
 		if (Files[handle]->GetInformation() & 0x8000) {	//Check for device
 			reg_dx = Files[handle]->GetInformation() & ~EXT_DEVICE_BIT;
 		} else {
-			Bit8u hdrive=Files[handle]->GetDrive();
+			uint8_t hdrive=Files[handle]->GetDrive();
 			if (hdrive==0xff) {
 				LOG(LOG_IOCTL,LOG_NORMAL)("00:No drive set");
 				hdrive=2;	// defaulting to C:
@@ -84,7 +84,7 @@ bool DOS_IOCTL(void) {
 		if (Files[handle]->GetInformation() & 0xc000) {
 			/* is character device with IOCTL support */
 			PhysPt bufptr=PhysMake(SegValue(ds),reg_dx);
-			Bit16u retcode=0;
+			uint16_t retcode=0;
 			if (((DOS_Device*)(Files[handle]))->ReadFromControlChannel(bufptr,reg_cx,&retcode)) {
 				reg_ax=retcode;
 				return true;
@@ -96,7 +96,7 @@ bool DOS_IOCTL(void) {
 		if (Files[handle]->GetInformation() & 0xc000) {
 			/* is character device with IOCTL support */
 			PhysPt bufptr=PhysMake(SegValue(ds),reg_dx);
-			Bit16u retcode=0;
+			uint16_t retcode=0;
 			if (((DOS_Device*)(Files[handle]))->WriteToControlChannel(bufptr,reg_cx,&retcode)) {
 				reg_ax=retcode;
 				return true;
@@ -108,9 +108,9 @@ bool DOS_IOCTL(void) {
 		if (Files[handle]->GetInformation() & 0x8000) {		//Check for device
 			reg_al=(Files[handle]->GetInformation() & 0x40) ? 0x0 : 0xff;
 		} else { // FILE
-			Bit32u oldlocation=0;
+			uint32_t oldlocation=0;
 			Files[handle]->Seek(&oldlocation, DOS_SEEK_CUR);
-			Bit32u endlocation=0;
+			uint32_t endlocation=0;
 			Files[handle]->Seek(&endlocation, DOS_SEEK_END);
 			if(oldlocation < endlocation){//Still data available
 				reg_al=0xff;
@@ -231,7 +231,7 @@ bool DOS_IOCTL(void) {
 
 
 bool DOS_GetSTDINStatus(void) {
-	Bit32u handle=RealHandle(STDIN);
+	uint32_t handle=RealHandle(STDIN);
 	if (handle==0xFF) return false;
 	if (Files[handle] && (Files[handle]->GetInformation() & 64)) return false;
 	return true;

--- a/src/dos/dos_keyboard_layout.h
+++ b/src/dos/dos_keyboard_layout.h
@@ -23,8 +23,8 @@
 
 #include "dosbox.h"
 
-Bitu DOS_SwitchKeyboardLayout(const char* new_layout, Bit32s& tried_cp);
-Bitu DOS_LoadKeyboardLayout(const char * layoutname, Bit32s codepage, const char * codepagefile);
+Bitu DOS_SwitchKeyboardLayout(const char* new_layout, int32_t& tried_cp);
+Bitu DOS_LoadKeyboardLayout(const char * layoutname, int32_t codepage, const char * codepagefile);
 const char* DOS_GetLoadedLayout(void);
 
 #endif

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -73,7 +73,7 @@ static bool DOS_MultiplexFunctions(void) {
 
 			if (!Files[reg_bx]) return true;
 
-			Bit32u handle=RealHandle(reg_bx);
+			uint32_t handle=RealHandle(reg_bx);
 			if (handle>=DOS_FILES) {
 				mem_writew(sftptr+sftofs+0x02,0x02);	// file open mode
 				mem_writeb(sftptr+sftofs+0x04,0x00);	// file attribute
@@ -84,17 +84,17 @@ static bool DOS_MultiplexFunctions(void) {
 				mem_writew(sftptr+sftofs+0x11,0);		// size
 				mem_writew(sftptr+sftofs+0x15,0);		// current position
 			} else {
-				Bit8u drive=Files[reg_bx]->GetDrive();
+				uint8_t drive=Files[reg_bx]->GetDrive();
 
-				mem_writew(sftptr+sftofs+0x02,(Bit16u)(Files[reg_bx]->flags&3));	// file open mode
-				mem_writeb(sftptr+sftofs+0x04,(Bit8u)(Files[reg_bx]->attr));		// file attribute
+				mem_writew(sftptr+sftofs+0x02,(uint16_t)(Files[reg_bx]->flags&3));	// file open mode
+				mem_writeb(sftptr+sftofs+0x04,(uint8_t)(Files[reg_bx]->attr));		// file attribute
 				mem_writew(sftptr+sftofs+0x05,0x40|drive);							// device info word
 				mem_writed(sftptr+sftofs+0x07,RealMake(dos.tables.dpb,drive*9));	// dpb of the drive
 				mem_writew(sftptr+sftofs+0x0d,Files[reg_bx]->time);					// packed file time
 				mem_writew(sftptr+sftofs+0x0f,Files[reg_bx]->date);					// packed file date
-				Bit32u curpos=0;
+				uint32_t curpos=0;
 				Files[reg_bx]->Seek(&curpos,DOS_SEEK_CUR);
-				Bit32u endpos=0;
+				uint32_t endpos=0;
 				Files[reg_bx]->Seek(&endpos,DOS_SEEK_END);
 				mem_writed(sftptr+sftofs+0x11,endpos);		// size
 				mem_writed(sftptr+sftofs+0x15,curpos);		// current position

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -123,13 +123,13 @@ public:
 	#endif
 	struct sDeviceHeader {
 		RealPt	nextDeviceHeader;
-		Bit16u	devAttributes;
-		Bit16u	strategy;
-		Bit16u	interrupt;
-		Bit8u	name[8];
-		Bit16u  wReserved;
-		Bit8u	driveLetter;
-		Bit8u	numSubUnits;
+		uint16_t	devAttributes;
+		uint16_t	strategy;
+		uint16_t	interrupt;
+		uint8_t	name[8];
+		uint16_t  wReserved;
+		uint8_t	driveLetter;
+		uint8_t	numSubUnits;
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
 	#pragma pack()
@@ -152,72 +152,72 @@ public:
 	uint16_t GetNumDrives() const { return numDrives; }
 	uint16_t GetFirstDrive() const { return dinfo[0].drive; }
 
-	Bit8u		GetSubUnit			(Bit16u _drive);
-	bool		GetUPC				(Bit8u subUnit, Bit8u& attr, char* upc);
+	uint8_t		GetSubUnit			(uint16_t _drive);
+	bool		GetUPC				(uint8_t subUnit, uint8_t& attr, char* upc);
 
-	void		InitNewMedia		(Bit8u subUnit);
-	bool		PlayAudioSector		(Bit8u subUnit, Bit32u start, Bit32u length);
-	bool		PlayAudioMSF		(Bit8u subUnit, Bit32u start, Bit32u length);
-	bool		StopAudio			(Bit8u subUnit);
-	bool		GetAudioStatus		(Bit8u subUnit, bool& playing, bool& pause, TMSF& start, TMSF& end);
+	void		InitNewMedia		(uint8_t subUnit);
+	bool		PlayAudioSector		(uint8_t subUnit, uint32_t start, uint32_t length);
+	bool		PlayAudioMSF		(uint8_t subUnit, uint32_t start, uint32_t length);
+	bool		StopAudio			(uint8_t subUnit);
+	bool		GetAudioStatus		(uint8_t subUnit, bool& playing, bool& pause, TMSF& start, TMSF& end);
 
-	bool		GetSubChannelData	(Bit8u subUnit, Bit8u& attr, Bit8u& track, Bit8u &index, TMSF& rel, TMSF& abs);
+	bool		GetSubChannelData	(uint8_t subUnit, uint8_t& attr, uint8_t& track, uint8_t &index, TMSF& rel, TMSF& abs);
 
-	int			RemoveDrive			(Bit16u _drive);
-	int			AddDrive			(Bit16u _drive, char* physicalPath, Bit8u& subUnit);
-	bool 		HasDrive			(Bit16u drive);
-	void		ReplaceDrive		(CDROM_Interface* newCdrom, Bit8u subUnit);
+	int			RemoveDrive			(uint16_t _drive);
+	int			AddDrive			(uint16_t _drive, char* physicalPath, uint8_t& subUnit);
+	bool 		HasDrive			(uint16_t drive);
+	void		ReplaceDrive		(CDROM_Interface* newCdrom, uint8_t subUnit);
 	void		GetDrives			(PhysPt data);
 	void		GetDriverInfo		(PhysPt data);
-	bool		GetVolumeName		(Bit8u subUnit, char* name);
-	bool		GetFileName			(Bit16u drive, Bit16u pos, PhysPt data);	
-	bool		GetDirectoryEntry	(Bit16u drive, bool copyFlag, PhysPt pathname, PhysPt buffer, Bit16u& error);
-	bool		ReadVTOC			(Bit16u drive, Bit16u volume, PhysPt data, Bit16u& offset, Bit16u& error);
-	bool		ReadSectors			(Bit16u drive, Bit32u sector, Bit16u num, PhysPt data);
-	bool		ReadSectors			(Bit8u subUnit, bool raw, Bit32u sector, Bit16u num, PhysPt data);
-	bool		ReadSectorsMSF		(Bit8u subUnit, bool raw, Bit32u sector, Bit16u num, PhysPt data);
-	bool		SendDriverRequest	(Bit16u drive, PhysPt data);
-	bool		IsValidDrive		(Bit16u drive);
-	bool		GetCDInfo			(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut);
-	Bit32u		GetVolumeSize		(Bit8u subUnit);
-	bool		GetTrackInfo		(Bit8u subUnit, Bit8u track, Bit8u& attr, TMSF& start);
-	Bit16u		GetStatusWord		(Bit8u subUnit,Bit16u status);
-	bool		GetCurrentPos		(Bit8u subUnit, TMSF& pos);
-	Bit32u		GetDeviceStatus		(Bit8u subUnit);
-	bool		GetMediaStatus		(Bit8u subUnit, Bit8u& status);
-	bool		LoadUnloadMedia		(Bit8u subUnit, bool unload);
-	bool		ResumeAudio			(Bit8u subUnit);
-	bool		GetMediaStatus		(Bit8u subUnit, bool& media, bool& changed, bool& trayOpen);
+	bool		GetVolumeName		(uint8_t subUnit, char* name);
+	bool		GetFileName			(uint16_t drive, uint16_t pos, PhysPt data);	
+	bool		GetDirectoryEntry	(uint16_t drive, bool copyFlag, PhysPt pathname, PhysPt buffer, uint16_t& error);
+	bool		ReadVTOC			(uint16_t drive, uint16_t volume, PhysPt data, uint16_t& offset, uint16_t& error);
+	bool		ReadSectors			(uint16_t drive, uint32_t sector, uint16_t num, PhysPt data);
+	bool		ReadSectors			(uint8_t subUnit, bool raw, uint32_t sector, uint16_t num, PhysPt data);
+	bool		ReadSectorsMSF		(uint8_t subUnit, bool raw, uint32_t sector, uint16_t num, PhysPt data);
+	bool		SendDriverRequest	(uint16_t drive, PhysPt data);
+	bool		IsValidDrive		(uint16_t drive);
+	bool		GetCDInfo			(uint8_t subUnit, uint8_t& tr1, uint8_t& tr2, TMSF& leadOut);
+	uint32_t		GetVolumeSize		(uint8_t subUnit);
+	bool		GetTrackInfo		(uint8_t subUnit, uint8_t track, uint8_t& attr, TMSF& start);
+	uint16_t		GetStatusWord		(uint8_t subUnit,uint16_t status);
+	bool		GetCurrentPos		(uint8_t subUnit, TMSF& pos);
+	uint32_t		GetDeviceStatus		(uint8_t subUnit);
+	bool		GetMediaStatus		(uint8_t subUnit, uint8_t& status);
+	bool		LoadUnloadMedia		(uint8_t subUnit, bool unload);
+	bool		ResumeAudio			(uint8_t subUnit);
+	bool		GetMediaStatus		(uint8_t subUnit, bool& media, bool& changed, bool& trayOpen);
 
 private:
 
 	PhysPt		GetDefaultBuffer	(void);
 	PhysPt		GetTempBuffer		(void);
 
-	Bit16u		numDrives;
+	uint16_t		numDrives;
 
 	typedef struct SDriveInfo {
-		Bit8u	drive;			// drive letter in dosbox
-		Bit8u	physDrive;		// drive letter in system
+		uint8_t	drive;			// drive letter in dosbox
+		uint8_t	physDrive;		// drive letter in system
 		bool	audioPlay;		// audio playing active
 		bool	audioPaused;	// audio playing paused
-		Bit32u	audioStart;		// StartLoc for resume
-		Bit32u	audioEnd;		// EndLoc for resume
+		uint32_t	audioStart;		// StartLoc for resume
+		uint32_t	audioEnd;		// EndLoc for resume
 		bool	locked;			// drive locked ?
 		bool	lastResult;		// last operation success ?
-		Bit32u	volumeSize;		// for media change
+		uint32_t	volumeSize;		// for media change
 		TCtrl	audioCtrl;		// audio channel control
 	} TDriveInfo;
 
-	Bit16u            defaultBufSeg;
+	uint16_t            defaultBufSeg;
 	
 public:
-	Bit16u rootDriverHeaderSeg;
+	uint16_t rootDriverHeaderSeg;
 	TDriveInfo        dinfo[MSCDEX_MAX_DRIVES];
 	CDROM_Interface * cdrom[MSCDEX_MAX_DRIVES];
 
-	bool ChannelControl(Bit8u subUnit, TCtrl ctrl);
-	bool GetChannelControl(Bit8u subUnit, TCtrl &ctrl);
+	bool ChannelControl(uint8_t subUnit, TCtrl ctrl);
+	bool GetChannelControl(uint8_t subUnit, TCtrl &ctrl);
 };
 
 CMscdex::CMscdex()
@@ -239,27 +239,27 @@ CMscdex::~CMscdex()
 
 void CMscdex::GetDrives(PhysPt data)
 {
-	for (Bit16u i=0; i<GetNumDrives(); i++) mem_writeb(data+i,dinfo[i].drive);
+	for (uint16_t i=0; i<GetNumDrives(); i++) mem_writeb(data+i,dinfo[i].drive);
 }
 
-bool CMscdex::IsValidDrive(Bit16u _drive)
+bool CMscdex::IsValidDrive(uint16_t _drive)
 {
 	_drive &= 0xff; //Only lowerpart (Ultimate domain)
-	for (Bit16u i=0; i<GetNumDrives(); i++) if (dinfo[i].drive==_drive) return true;
+	for (uint16_t i=0; i<GetNumDrives(); i++) if (dinfo[i].drive==_drive) return true;
 	return false;
 }
 
-Bit8u CMscdex::GetSubUnit(Bit16u _drive)
+uint8_t CMscdex::GetSubUnit(uint16_t _drive)
 {
 	_drive &= 0xff; //Only lowerpart (Ultimate domain)
-	for (Bit16u i=0; i<GetNumDrives(); i++) if (dinfo[i].drive==_drive) return (Bit8u)i;
+	for (uint16_t i=0; i<GetNumDrives(); i++) if (dinfo[i].drive==_drive) return (uint8_t)i;
 	return 0xff;
 }
 
-int CMscdex::RemoveDrive(Bit16u _drive)
+int CMscdex::RemoveDrive(uint16_t _drive)
 {
-	Bit16u idx = MSCDEX_MAX_DRIVES;
-	for (Bit16u i=0; i<GetNumDrives(); i++) {
+	uint16_t idx = MSCDEX_MAX_DRIVES;
+	for (uint16_t i=0; i<GetNumDrives(); i++) {
 		if (dinfo[i].drive == _drive) {
 			idx = i;
 			break;
@@ -269,7 +269,7 @@ int CMscdex::RemoveDrive(Bit16u _drive)
 	if (idx == MSCDEX_MAX_DRIVES || (idx!=0 && idx!=GetNumDrives()-1)) return 0;
 	delete (cdrom)[idx];
 	if (idx==0) {
-		for (Bit16u i=0; i<GetNumDrives(); i++) {
+		for (uint16_t i=0; i<GetNumDrives(); i++) {
 			if (i == MSCDEX_MAX_DRIVES-1) {
 				cdrom[i] = 0;
 				memset(&dinfo[i],0,sizeof(TDriveInfo));
@@ -286,7 +286,7 @@ int CMscdex::RemoveDrive(Bit16u _drive)
 
 	if (GetNumDrives() == 0) {
 		DOS_DeviceHeader devHeader(PhysMake(rootDriverHeaderSeg,0));
-		Bit16u off = sizeof(DOS_DeviceHeader::sDeviceHeader);
+		uint16_t off = sizeof(DOS_DeviceHeader::sDeviceHeader);
 		devHeader.SetStrategy(off+4);		// point to the RETF (To deactivate MSCDEX)
 		devHeader.SetInterrupt(off+4);		// point to the RETF (To deactivate MSCDEX)
 		devHeader.SetDriveLetter(0);
@@ -297,7 +297,7 @@ int CMscdex::RemoveDrive(Bit16u _drive)
 	return 1;
 }
 
-int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
+int CMscdex::AddDrive(uint16_t _drive, char* physicalPath, uint8_t& subUnit)
 {
 	subUnit = 0;
 	if ((Bitu)GetNumDrives()+1>=MSCDEX_MAX_DRIVES) return 4;
@@ -320,7 +320,7 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 		break;
 	case MountType::ISO_IMAGE:
 		LOG(LOG_MISC,LOG_NORMAL)("MSCDEX: Mounting iso file as cdrom: %s", physicalPath);
-		cdrom[numDrives] = new CDROM_Interface_Image((Bit8u)numDrives);
+		cdrom[numDrives] = new CDROM_Interface_Image((uint8_t)numDrives);
 		break;
 	case MountType::DIRECTORY:
 		LOG(LOG_MISC,LOG_NORMAL)("MSCDEX: Mounting directory as cdrom: %s", physicalPath);
@@ -342,7 +342,7 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 		
 		// Create Device Header
 		static_assert((driverSize % 16) == 0, "should always be zero");
-		Bit16u seg = DOS_GetMemory(driverSize / 16);
+		uint16_t seg = DOS_GetMemory(driverSize / 16);
 		DOS_DeviceHeader devHeader(PhysMake(seg,0));
 		devHeader.SetNextDeviceHeader	(0xFFFFFFFF);
 		devHeader.SetAttribute(0xc800);
@@ -351,41 +351,41 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 		devHeader.SetName				("MSCD001 ");
 
 		//Link it in the device chain
-		Bit32u start = dos_infoblock.GetDeviceChain();
-		Bit16u segm  = (Bit16u)(start>>16);
-		Bit16u offm  = (Bit16u)(start&0xFFFF);
+		uint32_t start = dos_infoblock.GetDeviceChain();
+		uint16_t segm  = (uint16_t)(start>>16);
+		uint16_t offm  = (uint16_t)(start&0xFFFF);
 		while(start != 0xFFFFFFFF) {
-			segm  = (Bit16u)(start>>16);
-			offm  = (Bit16u)(start&0xFFFF);
+			segm  = (uint16_t)(start>>16);
+			offm  = (uint16_t)(start&0xFFFF);
 			start = real_readd(segm,offm);
 		}
 		real_writed(segm,offm,seg<<16);
 
 		// Create Callback Strategy
-		Bit16u off = sizeof(DOS_DeviceHeader::sDeviceHeader);
-		Bit16u call_strategy=(Bit16u)CALLBACK_Allocate();
+		uint16_t off = sizeof(DOS_DeviceHeader::sDeviceHeader);
+		uint16_t call_strategy=(uint16_t)CALLBACK_Allocate();
 		CallBack_Handlers[call_strategy]=MSCDEX_Strategy_Handler;
-		real_writeb(seg,off+0,(Bit8u)0xFE);		//GRP 4
-		real_writeb(seg,off+1,(Bit8u)0x38);		//Extra Callback instruction
+		real_writeb(seg,off+0,(uint8_t)0xFE);		//GRP 4
+		real_writeb(seg,off+1,(uint8_t)0x38);		//Extra Callback instruction
 		real_writew(seg,off+2,call_strategy);	//The immediate word
-		real_writeb(seg,off+4,(Bit8u)0xCB);		//A RETF Instruction
+		real_writeb(seg,off+4,(uint8_t)0xCB);		//A RETF Instruction
 		devHeader.SetStrategy(off);
 		
 		// Create Callback Interrupt
 		off += 5;
-		Bit16u call_interrupt=(Bit16u)CALLBACK_Allocate();
+		uint16_t call_interrupt=(uint16_t)CALLBACK_Allocate();
 		CallBack_Handlers[call_interrupt]=MSCDEX_Interrupt_Handler;
-		real_writeb(seg,off+0,(Bit8u)0xFE);		//GRP 4
-		real_writeb(seg,off+1,(Bit8u)0x38);		//Extra Callback instruction
+		real_writeb(seg,off+0,(uint8_t)0xFE);		//GRP 4
+		real_writeb(seg,off+1,(uint8_t)0x38);		//Extra Callback instruction
 		real_writew(seg,off+2,call_interrupt);	//The immediate word
-		real_writeb(seg,off+4,(Bit8u)0xCB);		//A RETF Instruction
+		real_writeb(seg,off+4,(uint8_t)0xCB);		//A RETF Instruction
 		devHeader.SetInterrupt(off);
 		
 		rootDriverHeaderSeg = seg;
 	
 	} else if (GetNumDrives() == 0) {
 		DOS_DeviceHeader devHeader(PhysMake(rootDriverHeaderSeg,0));
-		Bit16u off = sizeof(DOS_DeviceHeader::sDeviceHeader);
+		uint16_t off = sizeof(DOS_DeviceHeader::sDeviceHeader);
 		devHeader.SetDriveLetter(_drive+1);
 		devHeader.SetStrategy(off);
 		devHeader.SetInterrupt(off+5);
@@ -398,24 +398,24 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 	if (dinfo[0].drive-1==_drive) {
 		CDROM_Interface *_cdrom = cdrom[numDrives];
 		CDROM_Interface_Image *_cdimg = CDROM_Interface_Image::images[numDrives];
-		for (Bit16u i=GetNumDrives(); i>0; i--) {
+		for (uint16_t i=GetNumDrives(); i>0; i--) {
 			dinfo[i] = dinfo[i-1];
 			cdrom[i] = cdrom[i-1];
 			CDROM_Interface_Image::images[i] = CDROM_Interface_Image::images[i-1];
 		}
 		cdrom[0] = _cdrom;
 		CDROM_Interface_Image::images[0] = _cdimg;
-		dinfo[0].drive		= (Bit8u)_drive;
-		dinfo[0].physDrive	= (Bit8u)toupper(physicalPath[0]);
+		dinfo[0].drive		= (uint8_t)_drive;
+		dinfo[0].physDrive	= (uint8_t)toupper(physicalPath[0]);
 		subUnit = 0;
 	} else {
-		dinfo[numDrives].drive		= (Bit8u)_drive;
-		dinfo[numDrives].physDrive	= (Bit8u)toupper(physicalPath[0]);
-		subUnit = (Bit8u)numDrives;
+		dinfo[numDrives].drive		= (uint8_t)_drive;
+		dinfo[numDrives].physDrive	= (uint8_t)toupper(physicalPath[0]);
+		subUnit = (uint8_t)numDrives;
 	}
 	numDrives++;
 	// init channel control
-	for (Bit8u chan=0;chan<4;chan++) {
+	for (uint8_t chan=0;chan<4;chan++) {
 		dinfo[subUnit].audioCtrl.out[chan]=chan;
 		dinfo[subUnit].audioCtrl.vol[chan]=0xff;
 	}
@@ -424,11 +424,11 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 	return result;
 }
 
-bool CMscdex::HasDrive(Bit16u drive) {
+bool CMscdex::HasDrive(uint16_t drive) {
 	return (GetSubUnit(drive) != 0xff);
 }
 
-void CMscdex::ReplaceDrive(CDROM_Interface* newCdrom, Bit8u subUnit) {
+void CMscdex::ReplaceDrive(CDROM_Interface* newCdrom, uint8_t subUnit) {
 	if (cdrom[subUnit] != NULL) {
 		StopAudio(subUnit);
 		delete cdrom[subUnit];
@@ -438,7 +438,7 @@ void CMscdex::ReplaceDrive(CDROM_Interface* newCdrom, Bit8u subUnit) {
 
 PhysPt CMscdex::GetDefaultBuffer(void) {
 	if (defaultBufSeg==0) {
-		Bit16u size = (2352*2+15)/16;
+		uint16_t size = (2352*2+15)/16;
 		defaultBufSeg = DOS_GetMemory(size);
 	};
 	return PhysMake(defaultBufSeg,2352);
@@ -446,21 +446,21 @@ PhysPt CMscdex::GetDefaultBuffer(void) {
 
 PhysPt CMscdex::GetTempBuffer(void) {
 	if (defaultBufSeg==0) {
-		Bit16u size = (2352*2+15)/16;
+		uint16_t size = (2352*2+15)/16;
 		defaultBufSeg = DOS_GetMemory(size);
 	};
 	return PhysMake(defaultBufSeg,0);
 }
 
 void CMscdex::GetDriverInfo	(PhysPt data) {
-	for (Bit16u i=0; i<GetNumDrives(); i++) {
-		mem_writeb(data  ,(Bit8u)i);	// subunit
+	for (uint16_t i=0; i<GetNumDrives(); i++) {
+		mem_writeb(data  ,(uint8_t)i);	// subunit
 		mem_writed(data+1,RealMake(rootDriverHeaderSeg,0));
 		data+=5;
 	};
 }
 
-bool CMscdex::GetCDInfo(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut) {
+bool CMscdex::GetCDInfo(uint8_t subUnit, uint8_t& tr1, uint8_t& tr2, TMSF& leadOut) {
 	if (subUnit>=numDrives) return false;
 	// Assume Media change
 	cdrom[subUnit]->InitNewMedia();
@@ -468,7 +468,7 @@ bool CMscdex::GetCDInfo(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut) {
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::GetTrackInfo(Bit8u subUnit, Bit8u track, Bit8u& attr, TMSF& start) {
+bool CMscdex::GetTrackInfo(uint8_t subUnit, uint8_t track, uint8_t& attr, TMSF& start) {
 	if (subUnit>=numDrives) return false;
 	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioTrackInfo(track,start,attr);	
 	if (!dinfo[subUnit].lastResult) {
@@ -478,7 +478,7 @@ bool CMscdex::GetTrackInfo(Bit8u subUnit, Bit8u track, Bit8u& attr, TMSF& start)
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::PlayAudioSector(Bit8u subUnit, Bit32u sector, Bit32u length) {
+bool CMscdex::PlayAudioSector(uint8_t subUnit, uint32_t sector, uint32_t length) {
 	if (subUnit>=numDrives) return false;
 	// If value from last stop is used, this is meant as a resume
 	// better start using resume command
@@ -496,19 +496,19 @@ bool CMscdex::PlayAudioSector(Bit8u subUnit, Bit32u sector, Bit32u length) {
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::PlayAudioMSF(Bit8u subUnit, Bit32u start, Bit32u length) {
+bool CMscdex::PlayAudioMSF(uint8_t subUnit, uint32_t start, uint32_t length) {
 	if (subUnit>=numDrives) return false;
-	Bit8u min		= (Bit8u)(start>>16) & 0xFF;
-	Bit8u sec		= (Bit8u)(start>> 8) & 0xFF;
-	Bit8u fr		= (Bit8u)(start>> 0) & 0xFF;
-	Bit32u sector	= min * 60 * REDBOOK_FRAMES_PER_SECOND
+	uint8_t min		= (uint8_t)(start>>16) & 0xFF;
+	uint8_t sec		= (uint8_t)(start>> 8) & 0xFF;
+	uint8_t fr		= (uint8_t)(start>> 0) & 0xFF;
+	uint32_t sector	= min * 60 * REDBOOK_FRAMES_PER_SECOND
 	                  + sec * REDBOOK_FRAMES_PER_SECOND
 	                  + fr
 	                  - REDBOOK_FRAME_PADDING;
 	return dinfo[subUnit].lastResult = PlayAudioSector(subUnit,sector,length);
 }
 
-bool CMscdex::GetSubChannelData(Bit8u subUnit, Bit8u& attr, Bit8u& track, Bit8u &index, TMSF& rel, TMSF& abs) {
+bool CMscdex::GetSubChannelData(uint8_t subUnit, uint8_t& attr, uint8_t& track, uint8_t &index, TMSF& rel, TMSF& abs) {
 	if (subUnit>=numDrives) return false;
 	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioSub(attr,track,index,rel,abs);
 	if (!dinfo[subUnit].lastResult) {
@@ -519,23 +519,23 @@ bool CMscdex::GetSubChannelData(Bit8u subUnit, Bit8u& attr, Bit8u& track, Bit8u 
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::GetAudioStatus(Bit8u subUnit, bool& playing, bool& pause, TMSF& start, TMSF& end) {
+bool CMscdex::GetAudioStatus(uint8_t subUnit, bool& playing, bool& pause, TMSF& start, TMSF& end) {
 	if (subUnit>=numDrives) return false;
 	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioStatus(playing,pause);
 	if (dinfo[subUnit].lastResult) {
 		if (playing) {
 			// Start
-			Bit32u addr = dinfo[subUnit].audioStart + REDBOOK_FRAME_PADDING;
-			start.fr    = (Bit8u)(addr % REDBOOK_FRAMES_PER_SECOND);
+			uint32_t addr = dinfo[subUnit].audioStart + REDBOOK_FRAME_PADDING;
+			start.fr    = (uint8_t)(addr % REDBOOK_FRAMES_PER_SECOND);
 			addr       /= REDBOOK_FRAMES_PER_SECOND;
-			start.sec   = (Bit8u)(addr % 60);
-			start.min   = (Bit8u)(addr / 60);
+			start.sec   = (uint8_t)(addr % 60);
+			start.min   = (uint8_t)(addr / 60);
 			// End
 			addr        = dinfo[subUnit].audioEnd + REDBOOK_FRAME_PADDING;
-			end.fr      = (Bit8u)(addr % REDBOOK_FRAMES_PER_SECOND);
+			end.fr      = (uint8_t)(addr % REDBOOK_FRAMES_PER_SECOND);
 			addr       /= REDBOOK_FRAMES_PER_SECOND;
-			end.sec     = (Bit8u)(addr % 60);
-			end.min     = (Bit8u)(addr / 60);
+			end.sec     = (uint8_t)(addr % 60);
+			end.min     = (uint8_t)(addr / 60);
 		} else {
 			memset(&start,0,sizeof(start));
 			memset(&end,0,sizeof(end));
@@ -550,7 +550,7 @@ bool CMscdex::GetAudioStatus(Bit8u subUnit, bool& playing, bool& pause, TMSF& st
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::StopAudio(Bit8u subUnit) {
+bool CMscdex::StopAudio(uint8_t subUnit) {
 	if (subUnit>=numDrives) return false;
 	if (dinfo[subUnit].audioPlay) {
 		// Check if audio is still playing....
@@ -585,14 +585,14 @@ bool CMscdex::StopAudio(Bit8u subUnit) {
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::ResumeAudio(Bit8u subUnit) {
+bool CMscdex::ResumeAudio(uint8_t subUnit) {
 	if (subUnit>=numDrives) return false;
 	return dinfo[subUnit].lastResult = PlayAudioSector(subUnit,dinfo[subUnit].audioStart,dinfo[subUnit].audioEnd);
 }
 
-Bit32u CMscdex::GetVolumeSize(Bit8u subUnit) {
+uint32_t CMscdex::GetVolumeSize(uint8_t subUnit) {
 	if (subUnit>=numDrives) return false;
-	Bit8u tr1,tr2; // <== place-holders (use lead-out for size calculation)
+	uint8_t tr1,tr2; // <== place-holders (use lead-out for size calculation)
 	TMSF leadOut;
 	dinfo[subUnit].lastResult = GetCDInfo(subUnit,tr1,tr2,leadOut);
 	if (dinfo[subUnit].lastResult)
@@ -602,8 +602,8 @@ Bit32u CMscdex::GetVolumeSize(Bit8u subUnit) {
 	return 0;
 }
 
-bool CMscdex::ReadVTOC(Bit16u drive, Bit16u volume, PhysPt data, Bit16u& offset, Bit16u& error) {
-	Bit8u subunit = GetSubUnit(drive);
+bool CMscdex::ReadVTOC(uint16_t drive, uint16_t volume, PhysPt data, uint16_t& offset, uint16_t& error) {
+	uint8_t subunit = GetSubUnit(drive);
 /*	if (subunit>=numDrives) {
 		error=MSCDEX_ERROR_UNKNOWN_DRIVE;
 		return false;
@@ -623,16 +623,16 @@ bool CMscdex::ReadVTOC(Bit16u drive, Bit16u volume, PhysPt data, Bit16u& offset,
 			return false;
 		}
 	}
-	Bit8u type = mem_readb(data + offset);
+	uint8_t type = mem_readb(data + offset);
 	error = (type == 1) ? 1 : (type == 0xFF) ? 0xFF : 0;
 	return true;
 }
 
-bool CMscdex::GetVolumeName(Bit8u subUnit, char* data) {	
+bool CMscdex::GetVolumeName(uint8_t subUnit, char* data) {	
 	if (subUnit>=numDrives) return false;
-	Bit16u drive = dinfo[subUnit].drive;
+	uint16_t drive = dinfo[subUnit].drive;
 
-	Bit16u offset = 0, error;
+	uint16_t offset = 0, error;
 	bool success = false;
 	PhysPt ptoc = GetTempBuffer();
 	success = ReadVTOC(drive,0x00,ptoc,offset,error);
@@ -645,15 +645,15 @@ bool CMscdex::GetVolumeName(Bit8u subUnit, char* data) {
 	return success; 
 }
 
-bool CMscdex::GetFileName(Bit16u drive, Bit16u pos, PhysPt data) {
-	Bit16u offset = 0, error;
+bool CMscdex::GetFileName(uint16_t drive, uint16_t pos, PhysPt data) {
+	uint16_t offset = 0, error;
 	bool success = false;
 	PhysPt ptoc = GetTempBuffer();
 	success = ReadVTOC(drive,0x00,ptoc,offset,error);
 	if (success) {
 		Bitu len;
 		for (len=0;len<37;len++) {
-			Bit8u c=mem_readb(ptoc+offset+pos+len);
+			uint8_t c=mem_readb(ptoc+offset+pos+len);
 			if (c==0 || c==0x20) break;
 		}
 		MEM_BlockCopy(data,ptoc+offset+pos,len);
@@ -662,13 +662,13 @@ bool CMscdex::GetFileName(Bit16u drive, Bit16u pos, PhysPt data) {
 	return success; 
 }
 
-bool CMscdex::GetUPC(Bit8u subUnit, Bit8u& attr, char* upc)
+bool CMscdex::GetUPC(uint8_t subUnit, uint8_t& attr, char* upc)
 {
 	if (subUnit>=numDrives) return false;
 	return dinfo[subUnit].lastResult = cdrom[subUnit]->GetUPC(attr,&upc[0]);
 }
 
-bool CMscdex::ReadSectors(Bit8u subUnit, bool raw, Bit32u sector, Bit16u num, PhysPt data) {
+bool CMscdex::ReadSectors(uint8_t subUnit, bool raw, uint32_t sector, uint16_t num, PhysPt data) {
 	if (subUnit>=numDrives) return false;
 	if ((4*num*2048+5) < CPU_Cycles) CPU_Cycles -= 4*num*2048;
 	else CPU_Cycles = 5;
@@ -676,12 +676,12 @@ bool CMscdex::ReadSectors(Bit8u subUnit, bool raw, Bit32u sector, Bit16u num, Ph
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::ReadSectorsMSF(Bit8u subUnit, bool raw, Bit32u start, Bit16u num, PhysPt data) {
+bool CMscdex::ReadSectorsMSF(uint8_t subUnit, bool raw, uint32_t start, uint16_t num, PhysPt data) {
 	if (subUnit>=numDrives) return false;
-	Bit8u min		= (Bit8u)(start>>16) & 0xFF;
-	Bit8u sec		= (Bit8u)(start>> 8) & 0xFF;
-	Bit8u fr		= (Bit8u)(start>> 0) & 0xFF;
-	Bit32u sector	= min * 60 * REDBOOK_FRAMES_PER_SECOND
+	uint8_t min		= (uint8_t)(start>>16) & 0xFF;
+	uint8_t sec		= (uint8_t)(start>> 8) & 0xFF;
+	uint8_t fr		= (uint8_t)(start>> 0) & 0xFF;
+	uint32_t sector	= min * 60 * REDBOOK_FRAMES_PER_SECOND
 	                  + sec * REDBOOK_FRAMES_PER_SECOND
 	                  + fr
 	                  - REDBOOK_FRAME_PADDING;
@@ -689,11 +689,11 @@ bool CMscdex::ReadSectorsMSF(Bit8u subUnit, bool raw, Bit32u start, Bit16u num, 
 }
 
 // Called from INT 2F
-bool CMscdex::ReadSectors(Bit16u drive, Bit32u sector, Bit16u num, PhysPt data) {
+bool CMscdex::ReadSectors(uint16_t drive, uint32_t sector, uint16_t num, PhysPt data) {
 	return ReadSectors(GetSubUnit(drive),false,sector,num,data);
 }
 
-bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, PhysPt buffer, Bit16u& error) {
+bool CMscdex::GetDirectoryEntry(uint16_t drive, bool copyFlag, PhysPt pathname, PhysPt buffer, uint16_t& error) {
 	char	volumeID[6] = {0};
 	char	searchName[256];
 	char	entryName[256];
@@ -723,7 +723,7 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 		MEM_StrCopy(defBuffer+9,volumeID,5);
 		if (strcmp("CDROM",volumeID)!=0) E_Exit("MSCDEX: GetDirEntry: Not an ISO 9660 or HSF CD.");
 	}
-	Bit16u offset = iso ? 156:180;
+	uint16_t offset = iso ? 156:180;
 	// get directory position
 	Bitu dirEntrySector	= mem_readd(defBuffer+offset+2);
 	Bits dirSize		= mem_readd(defBuffer+offset+10);
@@ -771,8 +771,8 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 			if (foundComplete) {
 				if (copyFlag) {
 					LOG(LOG_MISC,LOG_WARN)("MSCDEX: GetDirEntry: Copyflag structure not entirely accurate maybe");
-					Bit8u readBuf[256];
-					Bit8u writeBuf[256];
+					uint8_t readBuf[256];
+					uint8_t writeBuf[256];
 					assertm(entryLength <= 256, "entryLength should never exceed 256");
 					MEM_BlockRead( defBuffer+index, readBuf, entryLength );
 					writeBuf[0] = readBuf[1];						// 00h	BYTE	length of XAR in Logical Block Numbers
@@ -810,22 +810,22 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 	return false; // not found
 }
 
-bool CMscdex::GetCurrentPos(Bit8u subUnit, TMSF& pos) {
+bool CMscdex::GetCurrentPos(uint8_t subUnit, TMSF& pos) {
 	if (subUnit>=numDrives) return false;
 	TMSF rel;
-	Bit8u attr,track,index;
+	uint8_t attr,track,index;
 	dinfo[subUnit].lastResult = GetSubChannelData(subUnit, attr, track, index, rel, pos);
 	if (!dinfo[subUnit].lastResult) memset(&pos,0,sizeof(pos));
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::GetMediaStatus(Bit8u subUnit, bool& media, bool& changed, bool& trayOpen) {
+bool CMscdex::GetMediaStatus(uint8_t subUnit, bool& media, bool& changed, bool& trayOpen) {
 	if (subUnit>=numDrives) return false;
 	dinfo[subUnit].lastResult = cdrom[subUnit]->GetMediaTrayStatus(media,changed,trayOpen);
 	return dinfo[subUnit].lastResult;
 }
 
-Bit32u CMscdex::GetDeviceStatus(Bit8u subUnit) {
+uint32_t CMscdex::GetDeviceStatus(uint8_t subUnit) {
 	if (subUnit>=numDrives) return false;
 	bool media,changed,trayOpen;
 
@@ -840,7 +840,7 @@ Bit32u CMscdex::GetDeviceStatus(Bit8u subUnit) {
 			dinfo[subUnit].audioPlay = false;
 	}
 
-	Bit32u status = ((trayOpen?1:0) << 0)					|	// Drive is open ?
+	uint32_t status = ((trayOpen?1:0) << 0)					|	// Drive is open ?
 					((dinfo[subUnit].locked?1:0) << 1)		|	// Drive is locked ?
 					(1<<2)									|	// raw + cooked sectors
 					(1<<4)									|	// Can read sudio
@@ -851,7 +851,7 @@ Bit32u CMscdex::GetDeviceStatus(Bit8u subUnit) {
 	return status;
 }
 
-bool CMscdex::GetMediaStatus(Bit8u subUnit, Bit8u& status) {
+bool CMscdex::GetMediaStatus(uint8_t subUnit, uint8_t& status) {
 	if (subUnit>=numDrives) return false;
 /*	bool media,changed,open,result;
 	result = GetMediaStatus(subUnit,media,changed,open);
@@ -861,14 +861,14 @@ bool CMscdex::GetMediaStatus(Bit8u subUnit, Bit8u& status) {
 	return true;
 }
 
-bool CMscdex::LoadUnloadMedia(Bit8u subUnit, bool unload) {
+bool CMscdex::LoadUnloadMedia(uint8_t subUnit, bool unload) {
 	if (subUnit>=numDrives) return false;
 	dinfo[subUnit].lastResult = cdrom[subUnit]->LoadUnloadMedia(unload);
 	return dinfo[subUnit].lastResult;
 }
 
-bool CMscdex::SendDriverRequest(Bit16u drive, PhysPt data) {
-	Bit8u subUnit = GetSubUnit(drive);
+bool CMscdex::SendDriverRequest(uint16_t drive, PhysPt data) {
+	uint8_t subUnit = GetSubUnit(drive);
 	if (subUnit>=numDrives) return false;
 	// Get SubUnit
 	mem_writeb(data+1,subUnit);
@@ -878,7 +878,7 @@ bool CMscdex::SendDriverRequest(Bit16u drive, PhysPt data) {
 	return true;
 }
 
-Bit16u CMscdex::GetStatusWord(Bit8u subUnit,Bit16u status) {
+uint16_t CMscdex::GetStatusWord(uint8_t subUnit,uint16_t status) {
 	if (subUnit>=numDrives) return REQUEST_STATUS_ERROR | 0x02; // error : Drive not ready
 
 	if (dinfo[subUnit].lastResult)	status |= REQUEST_STATUS_DONE;				// ok
@@ -899,14 +899,14 @@ Bit16u CMscdex::GetStatusWord(Bit8u subUnit,Bit16u status) {
 	return status;
 }
 
-void CMscdex::InitNewMedia(Bit8u subUnit) {
+void CMscdex::InitNewMedia(uint8_t subUnit) {
 	if (subUnit<numDrives) {
 		// Reopen new media
 		cdrom[subUnit]->InitNewMedia();
 	}
 }
 
-bool CMscdex::ChannelControl(Bit8u subUnit, TCtrl ctrl) {
+bool CMscdex::ChannelControl(uint8_t subUnit, TCtrl ctrl) {
 	if (subUnit>=numDrives) return false;
 	// adjust strange channel mapping
 	if (ctrl.out[0]>1) ctrl.out[0]=0;
@@ -916,7 +916,7 @@ bool CMscdex::ChannelControl(Bit8u subUnit, TCtrl ctrl) {
 	return true;
 }
 
-bool CMscdex::GetChannelControl(Bit8u subUnit, TCtrl& ctrl) {
+bool CMscdex::GetChannelControl(uint8_t subUnit, TCtrl& ctrl) {
 	if (subUnit>=numDrives) return false;
 	ctrl=dinfo[subUnit].audioCtrl;
 	return true;
@@ -944,8 +944,8 @@ bool GetMSCDEXDrive(unsigned char drive_letter,CDROM_Interface **_cdrom) {
 	return false;
 }
 
-static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
-	Bit8u ioctl_fct = mem_readb(buffer);
+static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer,uint8_t drive_unit) {
+	uint8_t ioctl_fct = mem_readb(buffer);
 	MSCDEX_LOG("MSCDEX: IOCTL INPUT Subfunction %02X",ioctl_fct);
 	switch (ioctl_fct) {
 		case 0x00 : /* Get Device Header address */
@@ -954,9 +954,9 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 		case 0x01 :{/* Get current position */
 					TMSF pos = {0, 0, 0};
 					mscdex->GetCurrentPos(drive_unit,pos);
-					Bit8u addr_mode = mem_readb(buffer+1);
+					uint8_t addr_mode = mem_readb(buffer+1);
 					if (addr_mode == 0) { // HSG
-						Bit32u frames = static_cast<Bit32u>(msf_to_frames(pos));
+						uint32_t frames = static_cast<uint32_t>(msf_to_frames(pos));
 						if (frames < REDBOOK_FRAME_PADDING)
 							MSCDEX_LOG("MSCDEX: Get position: invalid position %d:%d:%d", pos.min, pos.sec, pos.fr);
 						else
@@ -975,7 +975,7 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 		case 0x04 : /* Audio Channel control */
 					TCtrl ctrl;
 					if (!mscdex->GetChannelControl(drive_unit,ctrl)) return 0x01;
-					for (Bit8u chan=0;chan<4;chan++) {
+					for (uint8_t chan=0;chan<4;chan++) {
 						mem_writeb(buffer+chan*2+1,ctrl.out[chan]);
 						mem_writeb(buffer+chan*2+2,ctrl.vol[chan]);
 					}
@@ -992,14 +992,14 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 					mem_writed(buffer+1,mscdex->GetVolumeSize(drive_unit));
 					break;
 		case 0x09 : /* Media change ? */
-					Bit8u status;
+					uint8_t status;
 					if (!mscdex->GetMediaStatus(drive_unit,status)) {
 						status = 0;		// state unknown
 					}
 					mem_writeb(buffer+1,status);
 					break;
 		case 0x0A : /* Get Audio Disk info */	
-					Bit8u tr1,tr2; TMSF leadOut;
+					uint8_t tr1,tr2; TMSF leadOut;
 					if (!mscdex->GetCDInfo(drive_unit,tr1,tr2,leadOut)) {
 						// The MSCDEX spec says that tracks return values
 						// must be bounded inclusively between 1 and 99, so
@@ -1018,8 +1018,8 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 					mem_writeb(buffer+6,0x00);
 					break;
 		case 0x0B :{/* Audio Track Info */
-					Bit8u attr; TMSF start;
-					Bit8u track = mem_readb(buffer+1);
+					uint8_t attr; TMSF start;
+					uint8_t track = mem_readb(buffer+1);
 					mscdex->GetTrackInfo(drive_unit,track,attr,start);		
 					mem_writeb(buffer+2,start.fr);
 					mem_writeb(buffer+3,start.sec);
@@ -1028,7 +1028,7 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 					mem_writeb(buffer+6,attr);
 					break; };
 		case 0x0C :{/* Get Audio Sub Channel data */
-					Bit8u attr,track,index; 
+					uint8_t attr,track,index; 
 					TMSF abs,rel;
 					mscdex->GetSubChannelData(drive_unit,attr,track,index,rel,abs);
 					mem_writeb(buffer+1,attr);
@@ -1044,7 +1044,7 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 					break;
 				   };
 		case 0x0E :{ /* Get UPC */	
-					Bit8u attr; char upc[8];
+					uint8_t attr; char upc[8];
 					mscdex->GetUPC(drive_unit,attr,&upc[0]);
 					mem_writeb(buffer+1,attr);
 					for (int i=0; i<7; i++) mem_writeb(buffer+2+i,upc[i]);
@@ -1074,8 +1074,8 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 	return 0x00;	// success
 }
 
-static Bit16u MSCDEX_IOCTL_Optput(PhysPt buffer,Bit8u drive_unit) {
-	Bit8u ioctl_fct = mem_readb(buffer);
+static uint16_t MSCDEX_IOCTL_Optput(PhysPt buffer,uint8_t drive_unit) {
+	uint8_t ioctl_fct = mem_readb(buffer);
 //	MSCDEX_LOG("MSCDEX: IOCTL OUTPUT Subfunction %02X",ioctl_fct);
 	switch (ioctl_fct) {
 		case 0x00 :	// Unload /eject media
@@ -1083,7 +1083,7 @@ static Bit16u MSCDEX_IOCTL_Optput(PhysPt buffer,Bit8u drive_unit) {
 					break;
 		case 0x03: //Audio Channel control
 					TCtrl ctrl;
-					for (Bit8u chan=0;chan<4;chan++) {
+					for (uint8_t chan=0;chan<4;chan++) {
 						ctrl.out[chan]=mem_readb(buffer+chan*2+1);
 						ctrl.vol[chan]=mem_readb(buffer+chan*2+2);
 					}
@@ -1144,9 +1144,9 @@ static Bitu MSCDEX_Interrupt_Handler(void) {
 		MSCDEX_LOG("MSCDEX: invalid call to interrupt handler");						
 		return CBRET_NONE;
 	}
-	Bit8u	subUnit		= mem_readb(curReqheaderPtr+1);
-	Bit8u	funcNr		= mem_readb(curReqheaderPtr+2);
-	Bit16u	errcode		= 0;
+	uint8_t	subUnit		= mem_readb(curReqheaderPtr+1);
+	uint8_t	funcNr		= mem_readb(curReqheaderPtr+2);
+	uint16_t	errcode		= 0;
 	PhysPt	buffer		= 0;
 
 	MSCDEX_LOG("MSCDEX: Driver Function %02X",funcNr);
@@ -1157,12 +1157,12 @@ static Bitu MSCDEX_Interrupt_Handler(void) {
 
  	switch (funcNr) {
 		case 0x03	: {	/* IOCTL INPUT */
-						Bit16u error=MSCDEX_IOCTL_Input(buffer,subUnit);
+						uint16_t error=MSCDEX_IOCTL_Input(buffer,subUnit);
 						if (error) errcode = error;
 						break;
 					  };
 		case 0x0C	: {	/* IOCTL OUTPUT */
-						Bit16u error=MSCDEX_IOCTL_Optput(buffer,subUnit);
+						uint16_t error=MSCDEX_IOCTL_Optput(buffer,subUnit);
 						if (error) errcode = error;
 						break;
 					  };
@@ -1171,8 +1171,8 @@ static Bitu MSCDEX_Interrupt_Handler(void) {
 						break;
 		case 0x80	:	// Read long
 		case 0x82	: { // Read long prefetch -> both the same here :)
-						Bit32u start = mem_readd(curReqheaderPtr+0x14);
-						Bit16u len	 = mem_readw(curReqheaderPtr+0x12);
+						uint32_t start = mem_readd(curReqheaderPtr+0x14);
+						uint16_t len	 = mem_readw(curReqheaderPtr+0x12);
 						bool raw	 = (mem_readb(curReqheaderPtr+0x18)==1);
 						if (mem_readb(curReqheaderPtr+0x0D)==0x00) // HSG
 							mscdex->ReadSectors(subUnit,raw,start,len,buffer);
@@ -1183,8 +1183,8 @@ static Bitu MSCDEX_Interrupt_Handler(void) {
 		case 0x83	:	// Seek - dont care :)
 						break;
 		case 0x84	: {	/* Play Audio Sectors */
-						Bit32u start = mem_readd(curReqheaderPtr+0x0E);
-						Bit32u len	 = mem_readd(curReqheaderPtr+0x12);
+						uint32_t start = mem_readd(curReqheaderPtr+0x0E);
+						uint32_t len	 = mem_readd(curReqheaderPtr+0x12);
 						if (mem_readb(curReqheaderPtr+0x0D)==0x00) // HSG
 							mscdex->PlayAudioSector(subUnit,start,len);
 						else // RED BOOK
@@ -1247,7 +1247,7 @@ static bool MSCDEX_Handler(void) {
 						}
 						break;
 		case 0x1505: {	// read vtoc 
-						Bit16u offset = 0, error = 0;
+						uint16_t offset = 0, error = 0;
 						bool success = mscdex->ReadVTOC(reg_cx,reg_dx,data,offset,error);
 						reg_ax = error;
 						if (!success) CALLBACK_SCF(true);
@@ -1258,7 +1258,7 @@ static bool MSCDEX_Handler(void) {
 						// not functional in production MSCDEX
 						break;
 		case 0x1508: {	// read sectors 
-						Bit32u sector = (reg_si<<16)+reg_di;
+						uint32_t sector = (reg_si<<16)+reg_di;
 						if (mscdex->ReadSectors(reg_cx,sector,reg_dx,data)) {
 							reg_ax = 0;
 						} else {
@@ -1305,7 +1305,7 @@ static bool MSCDEX_Handler(void) {
 						}
 						break;
 		case 0x150F: {	// Get directory entry
-						Bit16u error;
+						uint16_t error;
 						bool success = mscdex->GetDirectoryEntry(reg_cl,reg_ch&1,data,PhysMake(reg_si,reg_di),error);
 						reg_ax = error;
 						if (!success) CALLBACK_SCF(true);
@@ -1328,21 +1328,21 @@ static bool MSCDEX_Handler(void) {
 class device_MSCDEX final : public DOS_Device {
 public:
 	device_MSCDEX() { SetName("MSCD001"); }
-	bool Read (Bit8u * /*data*/,Bit16u * /*size*/) { return false;}
-	bool Write(Bit8u * /*data*/,Bit16u * /*size*/) { 
+	bool Read (uint8_t * /*data*/,uint16_t * /*size*/) { return false;}
+	bool Write(uint8_t * /*data*/,uint16_t * /*size*/) { 
 		LOG(LOG_ALL,LOG_NORMAL)("Write to mscdex device");	
 		return false;
 	}
-	bool Seek(Bit32u * /*pos*/,Bit32u /*type*/){return false;}
+	bool Seek(uint32_t * /*pos*/,uint32_t /*type*/){return false;}
 	bool Close(){return false;}
-	Bit16u GetInformation(void){return 0xc880;}
-	bool ReadFromControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode);
-	bool WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode);
+	uint16_t GetInformation(void){return 0xc880;}
+	bool ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
+	bool WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
 private:
-//	Bit8u cache;
+//	uint8_t cache;
 };
 
-bool device_MSCDEX::ReadFromControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode) { 
+bool device_MSCDEX::ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) { 
 	if (MSCDEX_IOCTL_Input(bufptr,0)==0) {
 		*retcode=size;
 		return true;
@@ -1350,7 +1350,7 @@ bool device_MSCDEX::ReadFromControlChannel(PhysPt bufptr,Bit16u size,Bit16u * re
 	return false;
 }
 
-bool device_MSCDEX::WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * retcode) { 
+bool device_MSCDEX::WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) { 
 	if (MSCDEX_IOCTL_Optput(bufptr,0)==0) {
 		*retcode=size;
 		return true;
@@ -1361,7 +1361,7 @@ bool device_MSCDEX::WriteToControlChannel(PhysPt bufptr,Bit16u size,Bit16u * ret
 // TODO: this functions modifies physicalPath despite several callers passing it
 // a const char*. Figure out if a copy can suffice or if the it really should
 // change it upstream (in which case we should drop const and fix the callers).
-int MSCDEX_AddDrive(char driveLetter, const char* physicalPath, Bit8u& subUnit)
+int MSCDEX_AddDrive(char driveLetter, const char* physicalPath, uint8_t& subUnit)
 {
 	int result = mscdex->AddDrive(drive_index(driveLetter),
 	                              const_cast<char*>(physicalPath), subUnit);
@@ -1379,27 +1379,27 @@ bool MSCDEX_HasDrive(char driveLetter)
 	return mscdex->HasDrive(drive_index(driveLetter));
 }
 
-void MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, Bit8u subUnit)
+void MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, uint8_t subUnit)
 {
 	mscdex->ReplaceDrive(cdrom, subUnit);
 }
 
-Bit8u MSCDEX_GetSubUnit(char driveLetter)
+uint8_t MSCDEX_GetSubUnit(char driveLetter)
 {
 	return mscdex->GetSubUnit(drive_index(driveLetter));
 }
 
-bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name)
+bool MSCDEX_GetVolumeName(uint8_t subUnit, char* name)
 {
 	return mscdex->GetVolumeName(subUnit,name);
 }
 
-bool MSCDEX_HasMediaChanged(Bit8u subUnit)
+bool MSCDEX_HasMediaChanged(uint8_t subUnit)
 {
 	bool has_changed = true;
 	static TMSF leadOut[MSCDEX_MAX_DRIVES];
 	TMSF leadnew;
-	Bit8u tr1,tr2; // <== place-holders (use lead-out for change status)
+	uint8_t tr1,tr2; // <== place-holders (use lead-out for change status)
 	if (mscdex->GetCDInfo(subUnit,tr1,tr2,leadnew)) {
 		has_changed = (leadOut[subUnit].min != leadnew.min
 		               || leadOut[subUnit].sec != leadnew.sec

--- a/src/dos/dos_mscdex.h
+++ b/src/dos/dos_mscdex.h
@@ -22,13 +22,13 @@
 #include "dosbox.h"
 #include "cdrom.h"
 
-int   MSCDEX_AddDrive(char driveLetter, const char *physicalPath, Bit8u &subUnit);
+int   MSCDEX_AddDrive(char driveLetter, const char *physicalPath, uint8_t &subUnit);
 int   MSCDEX_RemoveDrive(char driveLetter);
 bool  MSCDEX_HasDrive(char driveLetter);
-void  MSCDEX_ReplaceDrive(CDROM_Interface *cdrom, Bit8u subUnit);
-Bit8u MSCDEX_GetSubUnit(char driveLetter);
-bool  MSCDEX_GetVolumeName(Bit8u subUnit, char *name);
-bool  MSCDEX_HasMediaChanged(Bit8u subUnit);
+void  MSCDEX_ReplaceDrive(CDROM_Interface *cdrom, uint8_t subUnit);
+uint8_t MSCDEX_GetSubUnit(char driveLetter);
+bool  MSCDEX_GetVolumeName(uint8_t subUnit, char *name);
+bool  MSCDEX_HasMediaChanged(uint8_t subUnit);
 
 #endif // DOSBOX_DOS_MSCDEX_H
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -43,7 +43,7 @@
 
 #include "dos_resources.h"
 
-extern Bit32u floppytype;
+extern uint32_t floppytype;
 
 #define WIKI_URL                   "https://github.com/dosbox-staging/dosbox-staging/wiki"
 #define WIKI_ADD_UTILITIES_ARTICLE WIKI_URL "/Add-Utilities"

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -26,8 +26,8 @@
 #pragma pack(1)
 #endif
 struct DOS_TableCase {	
-	Bit16u size;
-	Bit8u chars[256];
+	uint16_t size;
+	uint8_t chars[256];
 }
 GCC_ATTRIBUTE (packed);
 #ifdef _MSC_VER
@@ -39,13 +39,13 @@ RealPt DOS_TableLowCase;
 
 static Bitu call_casemap;
 
-static Bit16u dos_memseg=DOS_PRIVATE_SEGMENT;
+static uint16_t dos_memseg=DOS_PRIVATE_SEGMENT;
 
-Bit16u DOS_GetMemory(Bit16u pages) {
+uint16_t DOS_GetMemory(uint16_t pages) {
 	if ((Bitu)pages+(Bitu)dos_memseg>=DOS_PRIVATE_SEGMENT_END) {
 		E_Exit("DOS:Not enough memory for internal tables");
 	}
-	Bit16u page=dos_memseg;
+	uint16_t page=dos_memseg;
 	dos_memseg+=pages;
 	return page;
 }
@@ -55,7 +55,7 @@ static Bitu DOS_CaseMapFunc(void) {
 	return CBRET_NONE;
 }
 
-static Bit8u country_info[0x22] = {
+static uint8_t country_info[0x22] = {
 /* Date format      */  0x00, 0x00,
 /* Currencystring   */  0x24, 0x00, 0x00, 0x00, 0x00,
 /* Thousands sep    */  0x2c, 0x00,
@@ -72,7 +72,7 @@ static Bit8u country_info[0x22] = {
 };
 
 void DOS_SetupTables(void) {
-	Bit16u seg;Bitu i;
+	uint16_t seg;Bitu i;
 	dos.tables.tempdta=RealMake(DOS_GetMemory(4),0);
 	dos.tables.tempdta_fcbdelete=RealMake(DOS_GetMemory(4),0);
 	/* Create the DOS Info Block */

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -88,7 +88,7 @@ DOS_Drive_Cache::DOS_Drive_Cache(const char* path)
 
 DOS_Drive_Cache::~DOS_Drive_Cache(void) {
 	Clear();
-	for (Bit32u i=0; i<MAX_OPENDIRS; i++) {
+	for (uint32_t i=0; i<MAX_OPENDIRS; i++) {
 		DeleteFileInfo(dirFindFirst[i]);
 		dirFindFirst[i] = nullptr;
 	}
@@ -98,7 +98,7 @@ void DOS_Drive_Cache::Clear(void) {
 	DeleteFileInfo(dirBase);
 	dirBase = nullptr;
 	nextFreeFindFirst	= 0;
-	for (Bit32u i=0; i<MAX_OPENDIRS; i++)
+	for (uint32_t i=0; i<MAX_OPENDIRS; i++)
 		dirSearch[i] = nullptr;
 }
 
@@ -122,10 +122,10 @@ void DOS_Drive_Cache::SetLabel(const char* vname,bool cdrom,bool allowupdate) {
 	LOG(LOG_DOSMISC,LOG_NORMAL)("DIRCACHE: Set volume label to %s",label);
 }
 
-Bit16u DOS_Drive_Cache::GetFreeID(CFileInfo* dir) {
+uint16_t DOS_Drive_Cache::GetFreeID(CFileInfo* dir) {
 	if (dir->id != MAX_OPENDIRS)
 		return dir->id;
-	for (Bit16u i=0; i<MAX_OPENDIRS; i++) {
+	for (uint16_t i=0; i<MAX_OPENDIRS; i++) {
 		if (!dirSearch[i]) {
 			dir->id = i;
 			return i;
@@ -147,7 +147,7 @@ void DOS_Drive_Cache::SetBaseDir(const char *baseDir)
 	}
 
 	safe_strcpy(basePath, baseDir);
-	Bit16u id;
+	uint16_t id;
 	if (OpenDir(baseDir,id)) {
 		char* result = 0;
 		ReadDir(id,result);
@@ -222,10 +222,10 @@ void DOS_Drive_Cache::AddEntry(const char* path, bool checkExists) {
 
 		Bits index = GetLongName(dir, file, sizeof(file));
 		if (index>=0) {
-			Bit32u i;
+			uint32_t i;
 			// Check if there are any open search dir that are affected by this...
 			for (i=0; i<MAX_OPENDIRS; i++) {
-				if ((dirSearch[i]==dir) && ((Bit32u)index<=dirSearch[i]->nextEntry)) 
+				if ((dirSearch[i]==dir) && ((uint32_t)index<=dirSearch[i]->nextEntry)) 
 					dirSearch[i]->nextEntry++;
 			}
 		}
@@ -282,10 +282,10 @@ void DOS_Drive_Cache::AddEntryDirOverlay(const char* path, bool checkExists) {
 
 		Bits index = GetLongName(dir, file, sizeof(file));
 		if (index>=0) {
-			Bit32u i;
+			uint32_t i;
 			// Check if there are any open search dir that are affected by this...
 			for (i=0; i<MAX_OPENDIRS; i++) {
-				if ((dirSearch[i]==dir) && ((Bit32u)index<=dirSearch[i]->nextEntry)) 
+				if ((dirSearch[i]==dir) && ((uint32_t)index<=dirSearch[i]->nextEntry)) 
 					dirSearch[i]->nextEntry++;
 			}
 
@@ -306,7 +306,7 @@ void DOS_Drive_Cache::DeleteEntry(const char* path, bool ignoreLastDir) {
 
 	if (!ignoreLastDir) {
 		// Check if there are any open search dir that are affected by this...
-		Bit32u i;
+		uint32_t i;
 		char expand	[CROSS_LEN];
 		CFileInfo* dir = FindDirInfo(path,expand);
 		if (dir) for (i=0; i<MAX_OPENDIRS; i++) {
@@ -322,10 +322,10 @@ void DOS_Drive_Cache::CacheOut(const char* path, bool ignoreLastDir) {
 	
 	if (ignoreLastDir) {
 		char tmp[CROSS_LEN] = { 0 };
-		Bit32s len=0;
+		int32_t len=0;
 		const char* pos = strrchr(path,CROSS_FILESPLIT);
 		if (pos)
-			len = (Bit32s)(pos - path);
+			len = (int32_t)(pos - path);
 		if (len>0) {
 			safe_strncpy(tmp,path,len+1);
 		} else	{
@@ -339,7 +339,7 @@ void DOS_Drive_Cache::CacheOut(const char* path, bool ignoreLastDir) {
 //	LOG_DEBUG("DIR: Caching out %s : dir %s",expand,dir->orgname);
 	// delete file objects...
 	//Maybe check if it is a file and then only delete the file and possibly the long name. instead of all objects in the dir.
-	for(Bit32u i=0; i<dir->fileList.size(); i++) {
+	for(uint32_t i=0; i<dir->fileList.size(); i++) {
 		if (dirSearch[srchNr]==dir->fileList[i])
 			dirSearch[srchNr] = nullptr;
 		DeleteFileInfo(dir->fileList[i]);
@@ -676,7 +676,7 @@ DOS_Drive_Cache::CFileInfo* DOS_Drive_Cache::FindDirInfo(const char* path, char*
 	const char*	start = path;
 	const char*		pos;
 	CFileInfo*	curDir = dirBase;
-	Bit16u		id;
+	uint16_t		id;
 
 	if (save_dir && (strcmp(path,save_path)==0)) {
 		safe_strncpy(expandedPath, save_expanded, CROSS_LEN);
@@ -756,7 +756,7 @@ DOS_Drive_Cache::CFileInfo* DOS_Drive_Cache::FindDirInfo(const char* path, char*
 	return curDir;
 }
 
-bool DOS_Drive_Cache::OpenDir(const char* path, Bit16u& id) {
+bool DOS_Drive_Cache::OpenDir(const char* path, uint16_t& id) {
 	char expand[CROSS_LEN] = {0};
 	CFileInfo* dir = FindDirInfo(path,expand);
 	if (OpenDir(dir,expand,id)) {
@@ -766,7 +766,7 @@ bool DOS_Drive_Cache::OpenDir(const char* path, Bit16u& id) {
 	return false;
 }
 
-bool DOS_Drive_Cache::OpenDir(CFileInfo* dir, const char* expand, Bit16u& id) {
+bool DOS_Drive_Cache::OpenDir(CFileInfo* dir, const char* expand, uint16_t& id) {
 	id = GetFreeID(dir);
 	dirSearch[id] = dir;
 	char expandcopy [CROSS_LEN];
@@ -841,7 +841,7 @@ void DOS_Drive_Cache::CopyEntry(CFileInfo* dir, CFileInfo* from) {
 	dir->fileList.push_back(info);
 }
 
-bool DOS_Drive_Cache::ReadDir(Bit16u id, char* &result) {
+bool DOS_Drive_Cache::ReadDir(uint16_t id, char* &result) {
 	// shouldnt happen...
 	if (id >= MAX_OPENDIRS)
 		return false;
@@ -903,21 +903,21 @@ bool DOS_Drive_Cache::SetResult(CFileInfo* dir, char* &result, Bitu entryNr)
 }
 
 // FindFirst / FindNext
-bool DOS_Drive_Cache::FindFirst(char* path, Bit16u& id) {
-	Bit16u	dirID;
+bool DOS_Drive_Cache::FindFirst(char* path, uint16_t& id) {
+	uint16_t	dirID;
 	// Cache directory in 
 	if (!OpenDir(path,dirID)) return false;
 
 	//Find a free slot.
 	//If the next one isn't free, move on to the next, if none is free => reset and assume the worst
-	Bit16u local_findcounter = 0;
+	uint16_t local_findcounter = 0;
 	while ( local_findcounter < MAX_OPENDIRS ) {
 		if (dirFindFirst[this->nextFreeFindFirst] == nullptr) break;
 		if (++this->nextFreeFindFirst >= MAX_OPENDIRS) this->nextFreeFindFirst = 0; //Wrap around
 		local_findcounter++;
 	}
 
-	Bit16u	dirFindFirstID = this->nextFreeFindFirst++;
+	uint16_t	dirFindFirstID = this->nextFreeFindFirst++;
 	if (this->nextFreeFindFirst >= MAX_OPENDIRS) this->nextFreeFindFirst = 0; //Increase and wrap around for the next search.
 
 	if (local_findcounter == MAX_OPENDIRS) { //Here is the reset from above.
@@ -956,7 +956,7 @@ bool DOS_Drive_Cache::FindFirst(char* path, Bit16u& id) {
 	return true;
 }
 
-bool DOS_Drive_Cache::FindNext(Bit16u id, char* &result) {
+bool DOS_Drive_Cache::FindNext(uint16_t id, char* &result) {
 	// out of range ?
 	if ((id>=MAX_OPENDIRS) || !dirFindFirst[id]) {
 		LOG(LOG_MISC,LOG_ERROR)("DIRCACHE: FindFirst/Next failure : ID out of range: %04X",id);
@@ -972,7 +972,7 @@ bool DOS_Drive_Cache::FindNext(Bit16u id, char* &result) {
 }
 
 void DOS_Drive_Cache::ClearFileInfo(CFileInfo *dir) {
-	for(Bit32u i=0; i<dir->fileList.size(); i++) {
+	for(uint32_t i=0; i<dir->fileList.size(); i++) {
 		if (CFileInfo *info = dir->fileList[i])
 			ClearFileInfo(info);
 	}

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -51,7 +51,7 @@ private:
 	uint8_t buffer[ISO_FRAMESIZE] = {{}};
 };
 
-isoFile::isoFile(isoDrive *iso_drive, const char *name, FileStat_Block *stat, Bit32u offset)
+isoFile::isoFile(isoDrive *iso_drive, const char *name, FileStat_Block *stat, uint32_t offset)
         : drive(iso_drive),
           fileBegin(offset),
           filePos(offset),
@@ -67,9 +67,9 @@ isoFile::isoFile(isoDrive *iso_drive, const char *name, FileStat_Block *stat, Bi
 	open = true;
 }
 
-bool isoFile::Read(Bit8u *data, Bit16u *size) {
+bool isoFile::Read(uint8_t *data, uint16_t *size) {
 	if (filePos + *size > fileEnd)
-		*size = (Bit16u)(fileEnd - filePos);
+		*size = (uint16_t)(fileEnd - filePos);
 
 	uint16_t nowSize = 0;
 	uint32_t sector = filePos / ISO_FRAMESIZE;
@@ -87,8 +87,8 @@ bool isoFile::Read(Bit8u *data, Bit16u *size) {
 	auto sectorPos = static_cast<uint16_t>(filePos % ISO_FRAMESIZE);
 
 	while (nowSize < *size) {
-		Bit16u remSector = ISO_FRAMESIZE - sectorPos;
-		Bit16u remSize = *size - nowSize;
+		uint16_t remSector = ISO_FRAMESIZE - sectorPos;
+		uint16_t remSize = *size - nowSize;
 		if(remSector < remSize) {
 			memcpy(&data[nowSize], &buffer[sectorPos], remSector);
 			nowSize += remSector;
@@ -109,11 +109,11 @@ bool isoFile::Read(Bit8u *data, Bit16u *size) {
 	return true;
 }
 
-bool isoFile::Write(Bit8u* /*data*/, Bit16u* /*size*/) {
+bool isoFile::Write(uint8_t* /*data*/, uint16_t* /*size*/) {
 	return false;
 }
 
-bool isoFile::Seek(Bit32u *pos, Bit32u type) {
+bool isoFile::Seek(uint32_t *pos, uint32_t type) {
 	switch (type) {
 		case DOS_SEEK_SET:
 			filePos = fileBegin + *pos;
@@ -139,11 +139,11 @@ bool isoFile::Close() {
 	return true;
 }
 
-Bit16u isoFile::GetInformation(void) {
+uint16_t isoFile::GetInformation(void) {
 	return 0x40;		// read-only drive
 }
 
-isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &error)
+isoDrive::isoDrive(char driveLetter, const char *fileName, uint8_t mediaid, int &error)
         : nextFreeDirIterator(0),
           iso(false),
           dataCD(false),
@@ -209,7 +209,7 @@ void isoDrive::Activate(void) {
 	UpdateMscdex(driveLetter, fileName, subUnit);
 }
 
-bool isoDrive::FileOpen(DOS_File **file, char *name, Bit32u flags) {
+bool isoDrive::FileOpen(DOS_File **file, char *name, uint32_t flags) {
 	if ((flags & 0x0f) == OPEN_WRITE) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
@@ -230,7 +230,7 @@ bool isoDrive::FileOpen(DOS_File **file, char *name, Bit32u flags) {
 	return success;
 }
 
-bool isoDrive::FileCreate(DOS_File** /*file*/, char* /*name*/, Bit16u /*attributes*/) {
+bool isoDrive::FileCreate(DOS_File** /*file*/, char* /*name*/, uint16_t /*attributes*/) {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
@@ -266,9 +266,9 @@ bool isoDrive::FindFirst(char *dir, DOS_DTA &dta, bool fcb_findfirst) {
 	int dirIterator = GetDirIterator(&de);
 	bool isRoot = (*dir == 0);
 	dirIterators[dirIterator].root = isRoot;
-	dta.SetDirID((Bit16u)dirIterator);
+	dta.SetDirID((uint16_t)dirIterator);
 
-	Bit8u attr;
+	uint8_t attr;
 	char pattern[ISO_MAXPATHNAME];
 	dta.GetSearchParams(attr, pattern);
 
@@ -287,7 +287,7 @@ bool isoDrive::FindFirst(char *dir, DOS_DTA &dta, bool fcb_findfirst) {
 }
 
 bool isoDrive::FindNext(DOS_DTA &dta) {
-	Bit8u attr;
+	uint8_t attr;
 	char pattern[DOS_NAMELENGTH_ASCII];
 	dta.GetSearchParams(attr, pattern);
 
@@ -296,7 +296,7 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 
 	isoDirEntry de;
 	while (GetNextDirEntry(dirIterator, &de)) {
-		Bit8u findAttr = 0;
+		uint8_t findAttr = 0;
 		if (IS_DIR(FLAGS1)) findAttr |= DOS_ATTR_DIRECTORY;
 		else findAttr |= DOS_ATTR_ARCHIVE;
 		if (IS_HIDDEN(FLAGS1)) findAttr |= DOS_ATTR_HIDDEN;
@@ -311,9 +311,9 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 				safe_strcpy(findName, (char *)de.ident);
 				upcase(findName);
 			}
-			Bit32u findSize = DATA_LENGTH(de);
-			Bit16u findDate = DOS_PackDate(1900 + de.dateYear, de.dateMonth, de.dateDay);
-			Bit16u findTime = DOS_PackTime(de.timeHour, de.timeMin, de.timeSec);
+			uint32_t findSize = DATA_LENGTH(de);
+			uint16_t findDate = DOS_PackDate(1900 + de.dateYear, de.dateMonth, de.dateDay);
+			uint16_t findTime = DOS_PackTime(de.timeHour, de.timeMin, de.timeSec);
 			dta.SetResult(findName, findSize, findDate, findTime, findAttr);
 			return true;
 		}
@@ -351,7 +351,7 @@ bool isoDrive::SetFileAttr(const char * name, [[maybe_unused]] const uint16_t at
 	return false;
 }
 
-bool isoDrive::AllocationInfo(Bit16u *bytes_sector, Bit8u *sectors_cluster, Bit16u *total_clusters, Bit16u *free_clusters) {
+bool isoDrive::AllocationInfo(uint16_t *bytes_sector, uint8_t *sectors_cluster, uint16_t *total_clusters, uint16_t *free_clusters) {
 	*bytes_sector = 2048;
 	*sectors_cluster = 1; // cluster size for cdroms ?
 	*total_clusters = 65535;
@@ -379,7 +379,7 @@ bool isoDrive::FileStat(const char *name, FileStat_Block *const stat_block) {
 	return success;
 }
 
-Bit8u isoDrive::GetMediaByte(void) {
+uint8_t isoDrive::GetMediaByte(void) {
 	return mediaid;
 }
 
@@ -421,7 +421,7 @@ int isoDrive::GetDirIterator(const isoDirEntry* de) {
 
 bool isoDrive::GetNextDirEntry(const int dirIteratorHandle, isoDirEntry* de) {
 	bool result = false;
-	Bit8u* buffer = NULL;
+	uint8_t* buffer = NULL;
 	DirIterator& dirIterator = dirIterators[dirIteratorHandle];
 
 	// check if the directory entry is valid
@@ -466,7 +466,7 @@ void isoDrive::FreeDirIterator(const int dirIterator) {
 	}
 }
 
-bool isoDrive::ReadCachedSector(Bit8u** buffer, const Bit32u sector) {
+bool isoDrive::ReadCachedSector(uint8_t** buffer, const uint32_t sector) {
 	// get hash table entry
 	int pos = sector % ISO_MAX_HASH_TABLE_SIZE;
 	SectorHashEntry& he = sectorHashEntries[pos];
@@ -484,11 +484,11 @@ bool isoDrive::ReadCachedSector(Bit8u** buffer, const Bit32u sector) {
 	return true;
 }
 
-inline bool isoDrive :: readSector(Bit8u *buffer, Bit32u sector) {
+inline bool isoDrive :: readSector(uint8_t *buffer, uint32_t sector) {
 	return CDROM_Interface_Image::images[subUnit]->ReadSector(buffer, false, sector);
 }
 
-int isoDrive :: readDirEntry(isoDirEntry *de, Bit8u *data) {
+int isoDrive :: readDirEntry(isoDirEntry *de, uint8_t *data) {
 	// copy data into isoDirEntry struct, data[0] = length of DirEntry
 //	if (data[0] > sizeof(isoDirEntry)) return -1;//check disabled as isoDirentry is currently 258 bytes large. So it always fits
 	memcpy(de, data, data[0]);//Perharps care about a zero at the end.
@@ -534,13 +534,13 @@ int isoDrive :: readDirEntry(isoDirEntry *de, Bit8u *data) {
 }
 
 bool isoDrive :: loadImage() {
-	Bit8u pvd[BYTES_PER_COOKED_REDBOOK_FRAME];
+	uint8_t pvd[BYTES_PER_COOKED_REDBOOK_FRAME];
 	dataCD = false;
 	readSector(pvd, ISO_FIRST_VD);
 	if (pvd[0] == 1 && !strncmp((char*)(&pvd[1]), "CD001", 5) && pvd[6] == 1) iso = true;
 	else if (pvd[8] == 1 && !strncmp((char*)(&pvd[9]), "CDROM", 5) && pvd[14] == 1) iso = false;
 	else return false;
-	Bit16u offset = iso ? 156 : 180;
+	uint16_t offset = iso ? 156 : 180;
 	if (readDirEntry(&this->rootEntry, &pvd[offset])>0) {
 		dataCD = true;
 		return true;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -46,7 +46,7 @@
 #include "cross.h"
 #include "inout.h"
 
-bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/) {
+bool localDrive::FileCreate(DOS_File * * file,char * name,uint16_t /*attributes*/) {
 //TODO Maybe care for attributes but not likely
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
@@ -109,7 +109,7 @@ DOS_File *FindOpenFile(const DOS_Drive *drive, const char *name)
 	return nullptr;
 }
 
-bool localDrive::FileOpen(DOS_File **file, char *name, Bit32u flags)
+bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
 {
 	const char *type = nullptr;
 	switch (flags&0xf) {
@@ -276,7 +276,7 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	if (tempDir[strlen(tempDir) - 1] != CROSS_FILESPLIT)
 		safe_strcat(tempDir, end);
 
-	Bit16u id;
+	uint16_t id;
 	if (!dirCache.FindFirst(tempDir,id)) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
@@ -284,7 +284,7 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	safe_strcpy(srchInfo[id].srch_dir, tempDir);
 	dta.SetDirID(id);
 	
-	Bit8u sAttr;
+	uint8_t sAttr;
 	dta.GetSearchParams(sAttr,tempDir);
 
 	if (this->isRemote() && this->isRemovable()) {
@@ -323,11 +323,11 @@ bool localDrive::FindNext(DOS_DTA & dta) {
 	char full_name[CROSS_LEN];
 	char dir_entcopy[CROSS_LEN];
 
-	Bit8u srch_attr;char srch_pattern[DOS_NAMELENGTH_ASCII];
-	Bit8u find_attr;
+	uint8_t srch_attr;char srch_pattern[DOS_NAMELENGTH_ASCII];
+	uint8_t find_attr;
 
 	dta.GetSearchParams(srch_attr,srch_pattern);
-	Bit16u id = dta.GetDirID();
+	uint16_t id = dta.GetDirID();
 
 again:
 	if (!dirCache.FindNext(id,dir_ent)) {
@@ -378,7 +378,7 @@ again:
 		upcase(find_name);
 	} 
 
-	find_size=(Bit32u) stat_block.st_size;
+	find_size=(uint32_t) stat_block.st_size;
 	struct tm datetime;
 	if (cross::localtime_r(&stat_block.st_mtime, &datetime)) {
 		find_date = DOS_PackDate(datetime);
@@ -516,7 +516,7 @@ bool localDrive::Rename(char * oldname,char * newname) {
 
 }
 
-bool localDrive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters) {
+bool localDrive::AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters,uint16_t * _free_clusters) {
 	*_bytes_sector=allocation.bytes_sector;
 	*_sectors_cluster=allocation.sectors_cluster;
 	*_total_clusters=allocation.total_clusters;
@@ -552,12 +552,12 @@ bool localDrive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	} else {
 		LOG_MSG("FS: error while converting date in: %s", name);
 	}
-	stat_block->size=(Bit32u)temp_stat.st_size;
+	stat_block->size=(uint32_t)temp_stat.st_size;
 	return true;
 }
 
 
-Bit8u localDrive::GetMediaByte(void) {
+uint8_t localDrive::GetMediaByte(void) {
 	return allocation.mediaid;
 }
 
@@ -575,11 +575,11 @@ Bits localDrive::UnMount(void) {
 }
 
 localDrive::localDrive(const char * startdir,
-                       Bit16u _bytes_sector,
-                       Bit8u _sectors_cluster,
-                       Bit16u _total_clusters,
-                       Bit16u _free_clusters,
-                       Bit8u _mediaid)
+                       uint16_t _bytes_sector,
+                       uint8_t _sectors_cluster,
+                       uint16_t _total_clusters,
+                       uint16_t _free_clusters,
+                       uint8_t _mediaid)
 	: write_protected_files{},
 	  allocation{_bytes_sector,
 	             _sectors_cluster,
@@ -653,7 +653,7 @@ bool localFile::Read(uint8_t *data, uint16_t *size)
 	/* Same for Igor */
 	/* hardrive motion => unmask irq 2. Only do it when it's masked as
 	 * unmasking is realitively heavy to emulate */
-	Bit8u mask = IO_Read(0x21);
+	uint8_t mask = IO_Read(0x21);
 	if (mask & 0x4)
 		IO_Write(0x21, mask & 0xfb);
 	return true;
@@ -661,7 +661,7 @@ bool localFile::Read(uint8_t *data, uint16_t *size)
 
 bool localFile::Write(uint8_t *data, uint16_t *size)
 {
-	Bit32u lastflags = this->flags & 0xf;
+	uint32_t lastflags = this->flags & 0xf;
 	if (lastflags == OPEN_READ || lastflags == OPEN_READ_NO_MOD) {	// check if file opened in read-only mode
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
@@ -728,7 +728,7 @@ bool localFile::Seek(uint32_t *pos_addr, uint32_t type)
 #if 0
 	fpos_t temppos;
 	fgetpos(fhandle,&temppos);
-	Bit32u * fake_pos=(Bit32u*)&temppos;
+	uint32_t * fake_pos=(uint32_t*)&temppos;
 	*pos_addr = *fake_pos;
 #endif
 	static_cast<void>(ftell_and_check());
@@ -786,7 +786,7 @@ bool localFile::Close() {
 	return true;
 }
 
-Bit16u localFile::GetInformation(void) {
+uint16_t localFile::GetInformation(void) {
 	return read_only_medium?0x40:0;
 }
 
@@ -848,11 +848,11 @@ void localFile::Flush()
 
 cdromDrive::cdromDrive(const char _driveLetter,
                        const char * startdir,
-                       Bit16u _bytes_sector,
-                       Bit8u _sectors_cluster,
-                       Bit16u _total_clusters,
-                       Bit16u _free_clusters,
-                       Bit8u _mediaid,
+                       uint16_t _bytes_sector,
+                       uint8_t _sectors_cluster,
+                       uint16_t _total_clusters,
+                       uint16_t _free_clusters,
+                       uint8_t _mediaid,
                        int& error)
 	: localDrive(startdir,
 	             _bytes_sector,
@@ -872,7 +872,7 @@ cdromDrive::cdromDrive(const char _driveLetter,
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
 }
 
-bool cdromDrive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
+bool cdromDrive::FileOpen(DOS_File * * file,char * name,uint32_t flags) {
 	if ((flags&0xf)==OPEN_READWRITE) {
 		flags &= ~static_cast<unsigned>(OPEN_READWRITE);
 	} else if ((flags&0xf)==OPEN_WRITE) {
@@ -885,7 +885,7 @@ bool cdromDrive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 	return success;
 }
 
-bool cdromDrive::FileCreate(DOS_File * * /*file*/,char * /*name*/,Bit16u /*attributes*/) {
+bool cdromDrive::FileCreate(DOS_File * * /*file*/,char * /*name*/,uint16_t /*attributes*/) {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -102,7 +102,7 @@ bool Overlay_Drive::RemoveDir(char * dir) {
 		}
 		return (temp == 0);
 	} else {
-		Bit16u olderror = dos.errorcode; //FindFirst/Next always set an errorcode, while RemoveDir itself shouldn't touch it if successful
+		uint16_t olderror = dos.errorcode; //FindFirst/Next always set an errorcode, while RemoveDir itself shouldn't touch it if successful
 		DOS_DTA dta(dos.tables.tempdta);
 		char stardotstar[4] = {'*', '.', '*', 0};
 		dta.SetupSearch(0,(0xff & ~DOS_ATTR_VOLUME),stardotstar); //Fake drive as we don't use it.
@@ -114,7 +114,7 @@ bool Overlay_Drive::RemoveDir(char * dir) {
 		}
 		bool empty = true;
 		do {
-			char name[DOS_NAMELENGTH_ASCII];Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
+			char name[DOS_NAMELENGTH_ASCII];uint32_t size;uint16_t date;uint16_t time;uint8_t attr;
 			dta.GetResult(name,size,date,time,attr);
 			if (logoverlay) LOG_MSG("RemoveDir found %s",name);
 			if (empty && strcmp(".",name ) && strcmp("..",name)) 
@@ -203,8 +203,8 @@ public:
 			LOG_MSG("constructing OverlayFile: %s", name);
 	}
 
-	bool Write(Bit8u * data,Bit16u * size) {
-		Bit32u f = flags&0xf;
+	bool Write(uint8_t * data,uint16_t * size) {
+		uint32_t f = flags&0xf;
 		if (!overlay_active && (f == OPEN_READWRITE || f == OPEN_WRITE)) {
 			if (logoverlay) LOG_MSG("write detected, switching file for %s",GetName());
 			if (*data == 0) {
@@ -269,7 +269,7 @@ bool OverlayFile::create_copy() {
 	fseek(lhandle,0L,SEEK_SET);
 	
 	FILE* newhandle = NULL;
-	Bit8u drive_set = GetDrive();
+	uint8_t drive_set = GetDrive();
 	if (drive_set != 0xff && drive_set < DOS_DRIVES && Drives[drive_set]){
 		Overlay_Drive* od = dynamic_cast<Overlay_Drive*>(Drives[drive_set]);
 		if (od) {
@@ -411,7 +411,7 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 	}
 }
 
-bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
+bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,uint32_t flags) {
 	const char* type;
 	switch (flags&0xf) {
 	case OPEN_READ:        type = "rb" ; break;
@@ -476,7 +476,7 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 }
 
 
-bool Overlay_Drive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/) {
+bool Overlay_Drive::FileCreate(DOS_File * * file,char * name,uint16_t /*attributes*/) {
 	//TODO Check if it exists in the dirCache ? // fix addentry ?  or just double check (ld and overlay)
 	//AddEntry looks sound to me.. 
 	
@@ -757,11 +757,11 @@ bool Overlay_Drive::FindNext(DOS_DTA & dta) {
 	char full_name[CROSS_LEN];
 	char dir_entcopy[CROSS_LEN];
 
-	Bit8u srch_attr;char srch_pattern[DOS_NAMELENGTH_ASCII];
-	Bit8u find_attr;
+	uint8_t srch_attr;char srch_pattern[DOS_NAMELENGTH_ASCII];
+	uint8_t find_attr;
 
 	dta.GetSearchParams(srch_attr,srch_pattern);
-	Bit16u id = dta.GetDirID();
+	uint16_t id = dta.GetDirID();
 
 again:
 	if (!dirCache.FindNext(id,dir_ent)) {
@@ -823,14 +823,14 @@ again:
 
 	
 	/* file is okay, setup everything to be copied in DTA Block */
-	char find_name[DOS_NAMELENGTH_ASCII];Bit16u find_date,find_time;Bit32u find_size;
+	char find_name[DOS_NAMELENGTH_ASCII];uint16_t find_date,find_time;uint32_t find_size;
 
 	if(safe_strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII){
 		safe_strcpy(find_name, dir_entcopy);
 		upcase(find_name);
 	} 
 
-	find_size=(Bit32u) stat_block.st_size;
+	find_size=(uint32_t) stat_block.st_size;
 	struct tm datetime;
 	if (cross::localtime_r(&stat_block.st_mtime, &datetime)) {
 		find_date = DOS_PackDate(datetime);
@@ -1142,7 +1142,7 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 	//if oldname is on base => copy file to overlay with new name and mark old file as deleted. 
 	//More advanced version. keep track of the file being renamed in order to detect that the file is being renamed back. 
 	
-	Bit16u attr = 0;
+	uint16_t attr = 0;
 	if (!GetFileAttr(oldname,&attr)) E_Exit("rename, but source doesn't exist, should not happen %s",oldname);
 	if (attr&DOS_ATTR_DIRECTORY) {
 		//See if the directory exists only in the overlay, then it should be possible.
@@ -1246,7 +1246,7 @@ bool Overlay_Drive::FileStat(const char* name, FileStat_Block * const stat_block
 	} else {
 		LOG_MSG("OVERLAY: Error while converting date in: %s", name);
 	}
-	stat_block->size=(Bit32u)temp_stat.st_size;
+	stat_block->size=(uint32_t)temp_stat.st_size;
 	return true;
 }
 

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -281,11 +281,11 @@ public:
 	Virtual_File(const Virtual_File &) = delete; // prevent copying
 	Virtual_File &operator=(const Virtual_File &) = delete; // prevent assignment
 
-	bool Read(Bit8u * data,Bit16u * size);
-	bool Write(Bit8u * data,Bit16u * size);
-	bool Seek(Bit32u * pos,Bit32u type);
+	bool Read(uint8_t * data,uint16_t * size);
+	bool Write(uint8_t * data,uint16_t * size);
+	bool Seek(uint32_t * pos,uint32_t type);
 	bool Close();
-	Bit16u GetInformation();
+	uint16_t GetInformation();
 
 private:
 	uint32_t file_size;
@@ -303,11 +303,11 @@ Virtual_File::Virtual_File(uint8_t *in_data, uint32_t in_size)
 	open = true;
 }
 
-bool Virtual_File::Read(Bit8u * data,Bit16u * size) {
-	Bit32u left=file_size-file_pos;
+bool Virtual_File::Read(uint8_t * data,uint16_t * size) {
+	uint32_t left=file_size-file_pos;
 	if (left <= *size) {
 		memcpy(data, &file_data[file_pos], left);
-		*size = (Bit16u)left;
+		*size = (uint16_t)left;
 	} else {
 		memcpy(data, &file_data[file_pos], *size);
 	}
@@ -315,12 +315,12 @@ bool Virtual_File::Read(Bit8u * data,Bit16u * size) {
 	return true;
 }
 
-bool Virtual_File::Write(Bit8u * /*data*/,Bit16u * /*size*/){
+bool Virtual_File::Write(uint8_t * /*data*/,uint16_t * /*size*/){
 	/* Not really writable */
 	return false;
 }
 
-bool Virtual_File::Seek(Bit32u * new_pos,Bit32u type){
+bool Virtual_File::Seek(uint32_t * new_pos,uint32_t type){
 	switch (type) {
 	case DOS_SEEK_SET:
 		if (*new_pos <= file_size) file_pos = *new_pos;
@@ -344,7 +344,7 @@ bool Virtual_File::Close(){
 }
 
 
-Bit16u Virtual_File::GetInformation() {
+uint16_t Virtual_File::GetInformation() {
 	return 0x40;	// read-only drive
 }
 
@@ -355,7 +355,7 @@ Virtual_Drive::Virtual_Drive() : search_file(nullptr)
 		parent_dir = new VFILE_Block;
 }
 
-bool Virtual_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
+bool Virtual_Drive::FileOpen(DOS_File * * file,char * name,uint32_t flags) {
 	assert(name);
 	if (*name == 0) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
@@ -380,7 +380,7 @@ bool Virtual_Drive::FileOpen(DOS_File * * file,char * name,Bit32u flags) {
 	return false;
 }
 
-bool Virtual_Drive::FileCreate(DOS_File * * /*file*/,char * /*name*/,Bit16u /*attributes*/) {
+bool Virtual_Drive::FileCreate(DOS_File * * /*file*/,char * /*name*/,uint16_t /*attributes*/) {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
@@ -473,7 +473,7 @@ bool Virtual_Drive::FindFirst(char *_dir, DOS_DTA &dta, bool fcb_findfirst)
 		}
 	}
 	dta.SetDirID(onpos);
-	Bit8u attr;
+	uint8_t attr;
 	char pattern[DOS_NAMELENGTH_ASCII];
 	dta.GetSearchParams(attr, pattern);
 	search_file = (attr & DOS_ATTR_DIRECTORY) && onpos > 0 ? parent_dir
@@ -498,7 +498,7 @@ bool Virtual_Drive::FindFirst(char *_dir, DOS_DTA &dta, bool fcb_findfirst)
 
 bool Virtual_Drive::FindNext(DOS_DTA &dta)
 {
-	Bit8u attr;
+	uint8_t attr;
 	char pattern[DOS_NAMELENGTH_ASCII];
 	dta.GetSearchParams(attr, pattern);
 	unsigned int pos = dta.GetDirID();
@@ -528,7 +528,7 @@ bool Virtual_Drive::FindNext(DOS_DTA &dta)
 	return false;
 }
 
-bool Virtual_Drive::GetFileAttr(char *name, Bit16u *attr)
+bool Virtual_Drive::GetFileAttr(char *name, uint16_t *attr)
 {
 	assert(name);
 	if (*name == 0) {
@@ -580,7 +580,7 @@ bool Virtual_Drive::Rename([[maybe_unused]] char * oldname, [[maybe_unused]] cha
 	return false;
 }
 
-bool Virtual_Drive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters) {
+bool Virtual_Drive::AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters,uint16_t * _free_clusters) {
 	*_bytes_sector = 512;
 	*_sectors_cluster = 32;
 	*_total_clusters = 32765; // total size is always 500 mb
@@ -588,7 +588,7 @@ bool Virtual_Drive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_clust
 	return true;
 }
 
-Bit8u Virtual_Drive::GetMediaByte() {
+uint8_t Virtual_Drive::GetMediaByte() {
 	return 0xF8;
 }
 

--- a/src/dos/program_biostest.cpp
+++ b/src/dos/program_biostest.cpp
@@ -36,7 +36,7 @@ void BIOSTEST::Run(void) {
 		return;
 	}
 
-	Bit8u drive;
+	uint8_t drive;
 	char fullname[DOS_PATHLENGTH];
 	localDrive *ldp = 0;
 	if (!DOS_MakeName((char *)temp_line.c_str(), fullname, &drive))
@@ -60,7 +60,7 @@ void BIOSTEST::Run(void) {
 			return;
 		}
 		fseek(tmpfile, 0L, SEEK_SET);
-		Bit8u buffer[64 * 1024];
+		uint8_t buffer[64 * 1024];
 		const auto bytes_read = fread(buffer, 1, sizeof(buffer), tmpfile);
 		assert(bytes_read <= sizeof(buffer));
 

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -32,13 +32,13 @@
 #include "regs.h"
 #include "string_utils.h"
 
-FILE *BOOT::getFSFile_mounted(char const *filename, Bit32u *ksize, Bit32u *bsize, Bit8u *error)
+FILE *BOOT::getFSFile_mounted(char const *filename, uint32_t *ksize, uint32_t *bsize, uint8_t *error)
 {
 	// if return NULL then put in error the errormessage code if an error
 	// was requested
 	bool tryload = (*error) ? true : false;
 	*error = 0;
-	Bit8u drive;
+	uint8_t drive;
 	FILE *tmpfile;
 	char fullname[DOS_PATHLENGTH];
 
@@ -83,9 +83,9 @@ FILE *BOOT::getFSFile_mounted(char const *filename, Bit32u *ksize, Bit32u *bsize
 	}
 }
 
-FILE *BOOT::getFSFile(char const *filename, Bit32u *ksize, Bit32u *bsize, bool tryload)
+FILE *BOOT::getFSFile(char const *filename, uint32_t *ksize, uint32_t *bsize, bool tryload)
 {
-	Bit8u error = tryload ? 1 : 0;
+	uint8_t error = tryload ? 1 : 0;
 	FILE *tmpfile = getFSFile_mounted(filename, ksize, bsize, &error);
 	if (tmpfile)
 		return tmpfile;
@@ -152,9 +152,9 @@ void BOOT::Run(void)
 	FILE *usefile_1 = NULL;
 	FILE *usefile_2 = NULL;
 	Bitu i = 0;
-	Bit32u floppysize = 0;
-	Bit32u rombytesize_1 = 0;
-	Bit32u rombytesize_2 = 0;
+	uint32_t floppysize = 0;
+	uint32_t rombytesize_1 = 0;
+	uint32_t rombytesize_2 = 0;
 	char drive = 'A';
 	std::string cart_cmd = "";
 
@@ -226,7 +226,7 @@ void BOOT::Run(void)
 			}
 			WriteOut(MSG_Get("PROGRAM_BOOT_IMAGE_OPEN"),
 			         temp_line.c_str());
-			Bit32u rombytesize;
+			uint32_t rombytesize;
 			FILE *usefile = getFSFile(temp_line.c_str(),
 			                          &floppysize, &rombytesize);
 			if (usefile != NULL) {
@@ -264,7 +264,7 @@ void BOOT::Run(void)
 		if (machine != MCH_PCJR) {
 			WriteOut(MSG_Get("PROGRAM_BOOT_CART_WO_PCJR"));
 		} else {
-			Bit8u rombuf[65536];
+			uint8_t rombuf[65536];
 			Bits cfound_at = -1;
 			if (!cart_cmd.empty()) {
 				/* read cartridge data into buffer */
@@ -348,11 +348,11 @@ void BOOT::Run(void)
 			if (usefile_1 == NULL)
 				return;
 
-			Bit32u sz1, sz2;
+			uint32_t sz1, sz2;
 			FILE *tfile = getFSFile("system.rom", &sz1, &sz2, true);
 			if (tfile != NULL) {
 				fseek(tfile, 0x3000L, SEEK_SET);
-				Bit32u drd = (Bit32u)fread(rombuf, 1, 0xb000, tfile);
+				uint32_t drd = (uint32_t)fread(rombuf, 1, 0xb000, tfile);
 				if (drd == 0xb000) {
 					for (i = 0; i < 0xb000; i++)
 						phys_writeb(0xf3000 + i, rombuf[i]);
@@ -395,7 +395,7 @@ void BOOT::Run(void)
 				return;
 			}
 
-			Bit16u romseg = host_readw(&rombuf[0x1ce]);
+			uint16_t romseg = host_readw(&rombuf[0x1ce]);
 
 			/* read cartridge data into buffer */
 			fseek(usefile_1, 0x200L, SEEK_SET);
@@ -417,7 +417,7 @@ void BOOT::Run(void)
 				disk.reset();
 
 			if (cart_cmd.empty()) {
-				Bit32u old_int18 = mem_readd(0x60);
+				uint32_t old_int18 = mem_readd(0x60);
 				/* run cartridge setup */
 				SegSet16(ds, romseg);
 				SegSet16(es, romseg);
@@ -425,7 +425,7 @@ void BOOT::Run(void)
 				reg_esp = 0xfffe;
 				CALLBACK_RunRealFar(romseg, 0x0003);
 
-				Bit32u new_int18 = mem_readd(0x60);
+				uint32_t new_int18 = mem_readd(0x60);
 				if (old_int18 != new_int18) {
 					/* boot cartridge (int18) */
 					SegSet16(cs, RealSeg(new_int18));

--- a/src/dos/program_boot.h
+++ b/src/dos/program_boot.h
@@ -28,8 +28,8 @@ class BOOT final : public Program {
     public:
         void Run(void);
     private:
-        FILE* getFSFile_mounted(char const* filename, Bit32u *ksize, Bit32u *bsize, Bit8u *error);
-        FILE* getFSFile(char const * filename, Bit32u *ksize, Bit32u *bsize,bool tryload=false);
+        FILE* getFSFile_mounted(char const* filename, uint32_t *ksize, uint32_t *bsize, uint8_t *error);
+        FILE* getFSFile(char const * filename, uint32_t *ksize, uint32_t *bsize,bool tryload=false);
         void printError(void);
         void disable_umb_ems_xms(void);
 };

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -137,11 +137,11 @@ void IMGMOUNT::Run(void) {
         return;
     }
 
-    Bit16u sizes[4] = {0};
+    uint16_t sizes[4] = {0};
     bool imgsizedetect = false;
 
     std::string str_size = "";
-    Bit8u mediaid = 0xF8;
+    uint8_t mediaid = 0xF8;
 
     // Possibly used to hold the IDE channel and drive slot for CDROM types
     std::string ide_value = {};
@@ -254,7 +254,7 @@ void IMGMOUNT::Run(void) {
                 char tmp[CROSS_LEN];
                 safe_strcpy(tmp, temp_line.c_str());
 
-                Bit8u dummy;
+                uint8_t dummy;
                 if (!DOS_MakeName(tmp, fullname, &dummy) || strncmp(Drives[dummy]->GetInfo(),"local directory",15)) {
                     WriteOut(MSG_Get("PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE"));
                     return;
@@ -303,10 +303,10 @@ void IMGMOUNT::Run(void) {
                 return;
             }
             fseek(diskfile, 0L, SEEK_END);
-            Bit32u fcsize = (Bit32u)(ftell(diskfile) / 512L);
-            Bit8u buf[512];
+            uint32_t fcsize = (uint32_t)(ftell(diskfile) / 512L);
+            uint8_t buf[512];
             fseek(diskfile, 0L, SEEK_SET);
-            if (fread(buf,sizeof(Bit8u),512,diskfile)<512) {
+            if (fread(buf,sizeof(uint8_t),512,diskfile)<512) {
                 fclose(diskfile);
                 WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
                 return;
@@ -461,7 +461,7 @@ void IMGMOUNT::Run(void) {
             return;
         }
         fseek(newDisk,0L, SEEK_END);
-        Bit32u imagesize = (ftell(newDisk) / 1024);
+        uint32_t imagesize = (ftell(newDisk) / 1024);
         const bool hdd = (imagesize > 2880);
         //Seems to make sense to require a valid geometry..
         if (hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 && sizes[3] == 0) {

--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -73,7 +73,7 @@ void INTRO::Run(void) {
     }
     /* Default action is to show all pages */
     WriteOut(MSG_Get("PROGRAM_INTRO"));
-    Bit8u c;Bit16u n=1;
+    uint8_t c;uint16_t n=1;
     DOS_ReadFile (STDIN,&c,&n);
     DisplayMount();
     DOS_ReadFile (STDIN,&c,&n);

--- a/src/dos/program_keyb.cpp
+++ b/src/dos/program_keyb.cpp
@@ -32,7 +32,7 @@ void KEYB::Run(void) {
 			/* first parameter is layout ID */
 			Bitu keyb_error=0;
 			std::string cp_string;
-			Bit32s tried_cp = -1;
+			int32_t tried_cp = -1;
 			if (cmd->FindCommand(2,cp_string)) {
 				/* second parameter is codepage number */
 				tried_cp=atoi(cp_string.c_str());

--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -31,8 +31,8 @@ void LOADFIX::Run(void)
 		WriteOut(MSG_Get("SHELL_CMD_LOADFIX_HELP_LONG"));
 		return;
 	}
-	Bit16u commandNr = 1;
-	Bit16u kb = 64;
+	uint16_t commandNr = 1;
+	uint16_t kb = 64;
 	if (cmd->FindCommand(commandNr, temp_line)) {
 		if (temp_line[0] == '-' || temp_line[0] == '/') {
 			const auto ch = std::toupper(temp_line[1]);
@@ -50,10 +50,10 @@ void LOADFIX::Run(void)
 		}
 	}
 	// Allocate Memory
-	Bit16u segment;
-	Bit16u blocks = kb*1024/16;
+	uint16_t segment;
+	uint16_t blocks = kb*1024/16;
 	if (DOS_AllocateMemory(&segment,&blocks)) {
-		DOS_MCB mcb((Bit16u)(segment-1));
+		DOS_MCB mcb((uint16_t)(segment-1));
 		mcb.SetPSPSeg(0x40);			// use fake segment
 		WriteOut(MSG_Get("PROGRAM_LOADFIX_ALLOC"),kb);
 		// Prepare commandline...

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -37,7 +37,7 @@ void LOADROM::Run(void) {
 	    WriteOut(MSG_Get("SHELL_CMD_LOADROM_HELP_LONG"));
 	    return;
     }
-    Bit8u drive;
+    uint8_t drive;
     char fullname[DOS_PATHLENGTH];
     localDrive* ldp=0;
     if (!DOS_MakeName((char *)temp_line.c_str(),fullname,&drive)) return;
@@ -59,7 +59,7 @@ void LOADROM::Run(void) {
             return;
         }
         fseek(tmpfile, 0L, SEEK_SET);
-        Bit8u rom_buffer[0x8000];
+        uint8_t rom_buffer[0x8000];
         Bitu data_read = fread(rom_buffer, 1, 0x8000, tmpfile);
         fclose(tmpfile);
 

--- a/src/dos/program_mem.cpp
+++ b/src/dos/program_mem.cpp
@@ -32,15 +32,15 @@ void MEM::Run(void) {
     /* Show conventional Memory */
     WriteOut("\n");
 
-    Bit16u umb_start=dos_infoblock.GetStartOfUMBChain();
-    Bit8u umb_flag=dos_infoblock.GetUMBChainState();
-    Bit8u old_memstrat=DOS_GetMemAllocStrategy()&0xff;
+    uint16_t umb_start=dos_infoblock.GetStartOfUMBChain();
+    uint8_t umb_flag=dos_infoblock.GetUMBChainState();
+    uint8_t old_memstrat=DOS_GetMemAllocStrategy()&0xff;
     if (umb_start!=0xffff) {
         if ((umb_flag&1)==1) DOS_LinkUMBsToMemChain(0);
         DOS_SetMemAllocStrategy(0);
     }
 
-    Bit16u seg,blocks;blocks=0xffff;
+    uint16_t seg,blocks;blocks=0xffff;
     DOS_AllocateMemory(&seg,&blocks);
     WriteOut(MSG_Get("PROGRAM_MEM_CONVEN"),blocks*16/1024);
 
@@ -48,7 +48,7 @@ void MEM::Run(void) {
         DOS_LinkUMBsToMemChain(1);
         DOS_SetMemAllocStrategy(0x40);	// search in UMBs only
 
-        Bit16u largest_block=0,total_blocks=0,block_count=0;
+        uint16_t largest_block=0,total_blocks=0,block_count=0;
         for (;; block_count++) {
             blocks=0xffff;
             DOS_AllocateMemory(&seg,&blocks);
@@ -58,7 +58,7 @@ void MEM::Run(void) {
             DOS_AllocateMemory(&seg,&blocks);
         }
 
-        Bit8u current_umb_flag=dos_infoblock.GetUMBChainState();
+        uint8_t current_umb_flag=dos_infoblock.GetUMBChainState();
         if ((current_umb_flag&1)!=(umb_flag&1)) DOS_LinkUMBsToMemChain(umb_flag);
         DOS_SetMemAllocStrategy(old_memstrat);	// restore strategy
 
@@ -69,7 +69,7 @@ void MEM::Run(void) {
     reg_ax=0x4300;CALLBACK_RunRealInt(0x2f);
     if (reg_al==0x80) {
         reg_ax=0x4310;CALLBACK_RunRealInt(0x2f);
-        Bit16u xms_seg=SegValue(es);Bit16u xms_off=reg_bx;
+        uint16_t xms_seg=SegValue(es);uint16_t xms_off=reg_bx;
         reg_ah=8;
         CALLBACK_RunRealFar(xms_seg,xms_off);
         if (!reg_bl) {
@@ -77,7 +77,7 @@ void MEM::Run(void) {
         }
     }
     /* Test for and show free EMS */
-    Bit16u handle;
+    uint16_t handle;
     char emm[9] = { 'E','M','M','X','X','X','X','0',0 };
     if (DOS_OpenFile(emm,0,&handle)) {
         DOS_CloseFile(handle);

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -168,8 +168,8 @@ void MOUNT::Run(void) {
 	cmd->FindString("-t",type,true);
 	bool iscdrom = (type =="cdrom"); //Used for mscdex bug cdrom label name emulation
 	if (type=="floppy" || type=="dir" || type=="cdrom" || type =="overlay") {
-		Bit16u sizes[4] ={0};
-		Bit8u mediaid;
+		uint16_t sizes[4] ={0};
+		uint8_t mediaid;
 		std::string str_size = "";
 		if (type=="floppy") {
 			str_size="512,1,2880,2880";/* All space free */
@@ -190,13 +190,13 @@ void MOUNT::Run(void) {
 		std::string mb_size;
 		if (cmd->FindString("-freesize",mb_size,true)) {
 			char teststr[1024];
-			Bit16u freesize = static_cast<Bit16u>(atoi(mb_size.c_str()));
+			uint16_t freesize = static_cast<uint16_t>(atoi(mb_size.c_str()));
 			if (type=="floppy") {
 				// freesize in kb
 				sprintf(teststr,"512,1,2880,%d",freesize*1024/(512*1));
 			} else {
-				Bit32u total_size_cyl=32765;
-				Bit32u free_size_cyl=(Bit32u)freesize*1024*1024/(512*32);
+				uint32_t total_size_cyl=32765;
+				uint32_t free_size_cyl=(uint32_t)freesize*1024*1024/(512*32);
 				if (free_size_cyl>65534) free_size_cyl=65534;
 				if (total_size_cyl<free_size_cyl) total_size_cyl=free_size_cyl+10;
 				if (total_size_cyl>65534) total_size_cyl=65534;
@@ -298,7 +298,7 @@ void MOUNT::Run(void) {
 		}
 
 		if (temp_line[temp_line.size() - 1] != CROSS_FILESPLIT) temp_line += CROSS_FILESPLIT;
-		Bit8u bit8size = (Bit8u)sizes[1];
+		uint8_t int8_tize = (uint8_t)sizes[1];
 
 		if (type == "cdrom") {
 			// Following options were relevant only for physical CD-ROM support:
@@ -311,7 +311,7 @@ void MOUNT::Run(void) {
 			MSCDEX_SetCDInterface(CDROM_USE_SDL, num);
 
 			int error = 0;
-			newdrive  = new cdromDrive(drive,temp_line.c_str(),sizes[0],bit8size,sizes[2],0,mediaid,error);
+			newdrive  = new cdromDrive(drive,temp_line.c_str(),sizes[0],int8_tize,sizes[2],0,mediaid,error);
 			// Check Mscdex, if it worked out...
 			switch (error) {
 				case 0  :	WriteOut(MSG_Get("MSCDEX_SUCCESS"));				break;
@@ -345,8 +345,8 @@ void MOUNT::Run(void) {
 					return;
 				}
 				std::string base = ldp->GetBasedir();
-				Bit8u o_error = 0;
-				newdrive = new Overlay_Drive(base.c_str(),temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,o_error);
+				uint8_t o_error = 0;
+				newdrive = new Overlay_Drive(base.c_str(),temp_line.c_str(),sizes[0],int8_tize,sizes[2],sizes[3],mediaid,o_error);
 				//Erase old drive on success
 				if (o_error) {
 					if (o_error == 1) WriteOut("No mixing of relative and absolute paths. Overlay failed.");
@@ -364,7 +364,7 @@ void MOUNT::Run(void) {
 				delete Drives[drive_index(drive)];
 				Drives[drive_index(drive)] = nullptr;
 			} else {
-				newdrive = new localDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid);
+				newdrive = new localDrive(temp_line.c_str(),sizes[0],int8_tize,sizes[2],sizes[3],mediaid);
 			}
 		}
 	} else {

--- a/src/dos/program_rescan.cpp
+++ b/src/dos/program_rescan.cpp
@@ -24,7 +24,7 @@ void RESCAN::Run(void)
 {
 	bool all = false;
 
-	Bit8u drive = DOS_GetDefaultDrive();
+	uint8_t drive = DOS_GetDefaultDrive();
 
 	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
 	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -222,9 +222,9 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero
 		/* ratio we are aiming for is around 90% usage*/
-		Bit32s ratio = (ticksScheduled * (CPU_CyclePercUsed*90*1024/100/100)) / ticksDone;
-		Bit32s new_cmax = CPU_CycleMax;
-		Bit64s cproc = (Bit64s)CPU_CycleMax * (Bit64s)ticksScheduled;
+		int32_t ratio = (ticksScheduled * (CPU_CyclePercUsed*90*1024/100/100)) / ticksDone;
+		int32_t new_cmax = CPU_CycleMax;
+		int64_t cproc = (int64_t)CPU_CycleMax * (int64_t)ticksScheduled;
 		double ratioremoved = 0.0; //increase scope for logging
 		if (cproc > 0) {
 			/* ignore the cycles added due to the IO delay code in order
@@ -232,7 +232,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 			ratioremoved = (double) CPU_IODelayRemoved / (double) cproc;
 			if (ratioremoved < 1.0) {
 				double ratio_not_removed = 1 - ratioremoved;
-				ratio = (Bit32s)((double)ratio * ratio_not_removed);
+				ratio = (int32_t)((double)ratio * ratio_not_removed);
 
 				/* Don't allow very high ratio which can cause us to lock as we don't scale down
 				 * for very low ratios. High ratio might result because of timing resolution */
@@ -250,11 +250,11 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 				if (ratio <= 1024) {
 					// ratio_not_removed = 1.0; //enabling this restores the old formula
 					double r = (1.0 + ratio_not_removed) /(ratio_not_removed + 1024.0/(static_cast<double>(ratio)));
-					new_cmax = 1 + static_cast<Bit32s>(CPU_CycleMax * r);
+					new_cmax = 1 + static_cast<int32_t>(CPU_CycleMax * r);
 				} else {
-					Bit64s ratio_with_removed = (Bit64s) ((((double)ratio - 1024.0) * ratio_not_removed) + 1024.0);
-					Bit64s cmax_scaled = (Bit64s)CPU_CycleMax * ratio_with_removed;
-					new_cmax = (Bit32s)(1 + (CPU_CycleMax >> 1) + cmax_scaled / (Bit64s)2048);
+					int64_t ratio_with_removed = (int64_t) ((((double)ratio - 1024.0) * ratio_not_removed) + 1024.0);
+					int64_t cmax_scaled = (int64_t)CPU_CycleMax * ratio_with_removed;
+					new_cmax = (int32_t)(1 + (CPU_CycleMax >> 1) + cmax_scaled / (int64_t)2048);
 				}
 			}
 		}

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -30,12 +30,12 @@
 FPU_rec fpu;
 
 void FPU_FLDCW(PhysPt addr){
-	Bit16u temp = mem_readw(addr);
+	uint16_t temp = mem_readw(addr);
 	FPU_SetCW(temp);
 }
 
-Bit16u FPU_GetTag(void){
-	Bit16u tag=0;
+uint16_t FPU_GetTag(void){
+	uint16_t tag=0;
 	for(Bitu i=0;i<8;i++)
 		tag |= ( (fpu.tags[i]&3) <<(2*i));
 	return tag;
@@ -554,17 +554,17 @@ void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
 	Bitu group=(rm >> 3) & 7;
 	Bitu sub=(rm & 7);
 	switch(group){
-	case 0x00:  /* FILD Bit16s */
+	case 0x00:  /* FILD int16_t */
 		FPU_PREP_PUSH();
 		FPU_FLD_I16(addr,TOP);
 		break;
 	case 0x01:
 		FPU_LOG_WARN(7,true,group,sub);
 		break;
-	case 0x02:   /* FIST Bit16s */
+	case 0x02:   /* FIST int16_t */
 		FPU_FST_I16(addr);
 		break;
-	case 0x03:	/* FISTP Bit16s */
+	case 0x03:	/* FISTP int16_t */
 		FPU_FST_I16(addr);
 		FPU_FPOP();
 		break;
@@ -572,7 +572,7 @@ void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
 		FPU_PREP_PUSH();
 		FPU_FBLD(addr,TOP);
 		break;
-	case 0x05:  /* FILD Bit64s */
+	case 0x05:  /* FILD int64_t */
 		FPU_PREP_PUSH();
 		FPU_FLD_I64(addr,TOP);
 		break;
@@ -580,7 +580,7 @@ void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
 		FPU_FBST(addr);
 		FPU_FPOP();
 		break;
-	case 0x07:  /* FISTP Bit64s */
+	case 0x07:  /* FISTP int64_t */
 		FPU_FST_I64(addr);
 		FPU_FPOP();
 		break;

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -41,7 +41,7 @@
 		}
 #else
 #define FPUD_LOAD(op,szI,szA)			\
-		Bit16u new_sw;					\
+		uint16_t new_sw;					\
 		__asm {							\
 		__asm	mov		eax, 8			\
 		__asm	shl		eax, 4			\
@@ -62,7 +62,7 @@
 		}
 #else
 #define FPUD_LOAD_EA(op,szI,szA)		\
-		Bit16u new_sw;					\
+		uint16_t new_sw;					\
 		__asm {							\
 		__asm	mov		eax, 8			\
 		__asm	shl		eax, 4			\
@@ -75,7 +75,7 @@
 
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_STORE(op,szI,szA)				\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, TOP			\
@@ -87,7 +87,7 @@
 		}
 #else
 #define FPUD_STORE(op,szI,szA)				\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	fldcw	fpu.cw_mask_all		\
@@ -106,7 +106,7 @@
 
 // handles fsin,fcos,f2xm1,fchs,fabs
 #define FPUD_TRIG(op)				\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		eax, TOP	\
 		__asm	shl		eax, 4		\
@@ -120,7 +120,7 @@
 
 // handles fsincos
 #define FPUD_SINCOS()				\
-		Bit16u new_sw;					\
+		uint16_t new_sw;					\
 		__asm {							\
 		__asm	mov		eax, TOP		\
 		__asm	mov		ebx, eax		\
@@ -147,7 +147,7 @@
 
 // handles fptan
 #define FPUD_PTAN()					\
-		Bit16u new_sw;					\
+		uint16_t new_sw;					\
 		__asm {							\
 		__asm	mov		eax, TOP		\
 		__asm	mov		ebx, eax		\
@@ -190,7 +190,7 @@
 		FPU_PREP_PUSH();
 #else
 #define FPUD_XTRACT						\
-		Bit16u new_sw;					\
+		uint16_t new_sw;					\
 		__asm {							\
 		__asm	mov		eax, TOP		\
 		__asm	mov		ebx, eax		\
@@ -212,7 +212,7 @@
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1(op)						\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
@@ -228,7 +228,7 @@
 		}
 #else
 #define FPUD_ARITH1(op)						\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	fldcw	fpu.cw_mask_all		\
@@ -250,7 +250,7 @@
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1_EA(op)					\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
@@ -264,7 +264,7 @@
 		}
 #else
 #define FPUD_ARITH1_EA(op)					\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	fldcw	fpu.cw_mask_all		\
@@ -284,7 +284,7 @@
 // handles fsqrt,frndint
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH2(op)						\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, TOP			\
@@ -297,7 +297,7 @@
 		}
 #else
 #define FPUD_ARITH2(op)						\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	fldcw	fpu.cw_mask_all		\
@@ -316,7 +316,7 @@
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1 but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3(op)						\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	fldcw	fpu.cw_mask_all		\
@@ -337,7 +337,7 @@
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3_EA(op)					\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
@@ -355,7 +355,7 @@
 
 // handles fprem,fprem1,fscale
 #define FPUD_REMAINDER(op)			\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		eax, TOP	\
 		__asm	mov		ebx, eax	\
@@ -375,7 +375,7 @@
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)			\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		ebx, op2	\
 		__asm	mov		eax, op1	\
@@ -390,7 +390,7 @@
 		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
 
 #define FPUD_COMPARE_EA(op)			\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		eax, op1	\
 		__asm	shl		eax, 4		\
@@ -403,7 +403,7 @@
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)			\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		eax, TOP	\
 		__asm	shl		eax, 4		\
@@ -433,7 +433,7 @@
 		FPU_FPOP();
 #else
 #define FPUD_WITH_POP(op)			\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		eax, TOP	\
 		__asm	mov		ebx, eax	\
@@ -470,7 +470,7 @@
 		FPU_FPOP();
 #else
 #define FPUD_FYL2X(op)				\
-		Bit16u new_sw;				\
+		uint16_t new_sw;				\
 		__asm {						\
 		__asm	mov		eax, TOP	\
 		__asm	mov		ebx, eax	\
@@ -520,7 +520,7 @@
 		);
 #else
 #define FPUD_LOAD(op,szI,szA)				\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fclex						\n"	\
 			#op #szA "	%2				\n"	\
@@ -541,7 +541,7 @@
 		);
 #else
 #define FPUD_LOAD_EA(op,szI,szA)			\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fclex						\n"	\
 			#op #szA "	%1				\n"	\
@@ -555,7 +555,7 @@
 
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_STORE(op,szI,szA)				\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%3				\n"	\
@@ -567,7 +567,7 @@
 		);
 #else
 #define FPUD_STORE(op,szI,szA)				\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -584,7 +584,7 @@
 
 // handles fsin,fcos,f2xm1,fchs,fabs
 #define FPUD_TRIG(op)						\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			clx" 						\n"	\
@@ -597,7 +597,7 @@
 
 // handles fsincos
 #define FPUD_SINCOS()					\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			clx" 						\n"	\
@@ -619,7 +619,7 @@
 
 // handles fptan
 #define FPUD_PTAN()						\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			clx" 						\n"	\
@@ -652,7 +652,7 @@
 		FPU_PREP_PUSH();
 #else
 #define FPUD_XTRACT						\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			"fclex						\n"	\
@@ -670,7 +670,7 @@
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1(op)						\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%3				\n"	\
@@ -684,7 +684,7 @@
 		);
 #else
 #define FPUD_ARITH1(op)						\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -704,7 +704,7 @@
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1_EA(op)					\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%2				\n"	\
@@ -717,7 +717,7 @@
 		);
 #else
 #define FPUD_ARITH1_EA(op)					\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -736,7 +736,7 @@
 // handles fsqrt,frndint
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH2(op)						\
-		Bit16u save_cw;						\
+		uint16_t save_cw;						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%2				\n"	\
@@ -749,7 +749,7 @@
 		);
 #else
 #define FPUD_ARITH2(op)						\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -768,7 +768,7 @@
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1 but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3(op)						\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -787,7 +787,7 @@
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3_EA(op)					\
-		Bit16u new_sw,save_cw;				\
+		uint16_t new_sw,save_cw;				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -804,7 +804,7 @@
 
 // handles fprem,fprem1,fscale
 #define FPUD_REMAINDER(op)					\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%2				\n"	\
 			"fldt		%1				\n"	\
@@ -820,7 +820,7 @@
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)					\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%2				\n"	\
 			"fldt		%1				\n"	\
@@ -834,7 +834,7 @@
 
 // handles fcom,fucom
 #define FPUD_COMPARE_EA(op)					\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			clx" 						\n"	\
@@ -847,7 +847,7 @@
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)					\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			clx" 						\n"	\
@@ -873,7 +873,7 @@
 		FPU_FPOP();
 #else
 #define FPUD_WITH_POP(op)					\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			"fldt		%2				\n"	\
@@ -902,7 +902,7 @@
 		FPU_FPOP();
 #else
 #define FPUD_FYL2X(op)						\
-		Bit16u new_sw;						\
+		uint16_t new_sw;						\
 		__asm__ volatile (					\
 			"fldt		%1				\n"	\
 			"fldt		%2				\n"	\
@@ -930,9 +930,9 @@
 #endif
 
 #ifdef WEAK_EXCEPTIONS
-const Bit16u exc_mask=0x7f00;
+const uint16_t exc_mask=0x7f00;
 #else
-const Bit16u exc_mask=0xffbf;
+const uint16_t exc_mask=0xffbf;
 #endif
 
 static void FPU_FINIT(void) {
@@ -1031,12 +1031,12 @@ static void FPU_FLD_F80(PhysPt addr) {
 }
 
 static void FPU_FLD_I16(PhysPt addr,Bitu store_to) {
-	fpu.p_regs[8].m1 = (Bit32u)mem_readw(addr);
+	fpu.p_regs[8].m1 = (uint32_t)mem_readw(addr);
 	FPUD_LOAD(fild,WORD,s)
 }
 
 static void FPU_FLD_I16_EA(PhysPt addr) {
-	fpu.p_regs[8].m1 = (Bit32u)mem_readw(addr);
+	fpu.p_regs[8].m1 = (uint32_t)mem_readw(addr);
 	FPUD_LOAD_EA(fild,WORD,s)
 }
 
@@ -1083,7 +1083,7 @@ static void FPU_FST_F80(PhysPt addr) {
 
 static void FPU_FST_I16(PhysPt addr) {
 	FPUD_STORE(fistp,WORD,s)
-	mem_writew(addr,(Bit16u)fpu.p_regs[8].m1);
+	mem_writew(addr,(uint16_t)fpu.p_regs[8].m1);
 }
 
 static void FPU_FST_I32(PhysPt addr) {
@@ -1183,9 +1183,9 @@ static void FPU_FXCH(Bitu stv, Bitu other){
 	fpu.tags[other] = fpu.tags[stv];
 	fpu.tags[stv] = tag;
 
-	Bit32u m1s = fpu.p_regs[other].m1;
-	Bit32u m2s = fpu.p_regs[other].m2;
-	Bit16u m3s = fpu.p_regs[other].m3;
+	uint32_t m1s = fpu.p_regs[other].m1;
+	uint32_t m2s = fpu.p_regs[other].m2;
+	uint16_t m3s = fpu.p_regs[other].m3;
 	fpu.p_regs[other].m1 = fpu.p_regs[stv].m1;
 	fpu.p_regs[other].m2 = fpu.p_regs[stv].m2;
 	fpu.p_regs[other].m3 = fpu.p_regs[stv].m3;
@@ -1264,15 +1264,15 @@ static void FPU_FSTENV(PhysPt addr){
 		mem_writew(addr+2,fpu.sw);
 		mem_writew(addr+4,FPU_GetTag());
 	} else { 
-		mem_writed(addr+0,static_cast<Bit32u>(fpu.cw));
-		mem_writed(addr+4,static_cast<Bit32u>(fpu.sw));
-		mem_writed(addr+8,static_cast<Bit32u>(FPU_GetTag()));
+		mem_writed(addr+0,static_cast<uint32_t>(fpu.cw));
+		mem_writed(addr+4,static_cast<uint32_t>(fpu.sw));
+		mem_writed(addr+8,static_cast<uint32_t>(FPU_GetTag()));
 	}
 }
 
 static void FPU_FLDENV(PhysPt addr){
-	Bit16u tag;
-	Bit32u tagbig;
+	uint16_t tag;
+	uint32_t tagbig;
 	Bitu cw;
 	if(!cpu.code.big) {
 		cw     = mem_readw(addr+0);
@@ -1280,9 +1280,9 @@ static void FPU_FLDENV(PhysPt addr){
 		tag    = mem_readw(addr+4);
 	} else { 
 		cw     = mem_readd(addr+0);
-		fpu.sw = (Bit16u)mem_readd(addr+4);
+		fpu.sw = (uint16_t)mem_readd(addr+4);
 		tagbig = mem_readd(addr+8);
-		tag    = static_cast<Bit16u>(tagbig);
+		tag    = static_cast<uint16_t>(tagbig);
 	}
 	FPU_SetTag(tag);
 	FPU_SetCW(cw);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -63,10 +63,10 @@ static void Check_Palette(void) {
 	case scalerMode15:
 	case scalerMode16:
 		for (i=render.pal.first;i<=render.pal.last;i++) {
-			Bit8u r=render.pal.rgb[i].red;
-			Bit8u g=render.pal.rgb[i].green;
-			Bit8u b=render.pal.rgb[i].blue;
-			Bit16u newPal = GFX_GetRGB(r,g,b);
+			uint8_t r=render.pal.rgb[i].red;
+			uint8_t g=render.pal.rgb[i].green;
+			uint8_t b=render.pal.rgb[i].blue;
+			uint16_t newPal = GFX_GetRGB(r,g,b);
 			if (newPal != render.pal.lut.b16[i]) {
 				render.pal.changed = true;
 				render.pal.modified[i] = 1;
@@ -77,10 +77,10 @@ static void Check_Palette(void) {
 	case scalerMode32:
 	default:
 		for (i=render.pal.first;i<=render.pal.last;i++) {
-			Bit8u r=render.pal.rgb[i].red;
-			Bit8u g=render.pal.rgb[i].green;
-			Bit8u b=render.pal.rgb[i].blue;
-			Bit32u newPal = GFX_GetRGB(r,g,b);
+			uint8_t r=render.pal.rgb[i].red;
+			uint8_t g=render.pal.rgb[i].green;
+			uint8_t b=render.pal.rgb[i].blue;
+			uint32_t newPal = GFX_GetRGB(r,g,b);
 			if (newPal != render.pal.lut.b32[i]) {
 				render.pal.changed = true;
 				render.pal.modified[i] = 1;
@@ -94,7 +94,7 @@ static void Check_Palette(void) {
 	render.pal.last=0;
 }
 
-void RENDER_SetPal(Bit8u entry,Bit8u red,Bit8u green,Bit8u blue) {
+void RENDER_SetPal(uint8_t entry,uint8_t red,uint8_t green,uint8_t blue) {
 	render.pal.rgb[entry].red=red;
 	render.pal.rgb[entry].green=green;
 	render.pal.rgb[entry].blue=blue;
@@ -146,9 +146,9 @@ static void RENDER_FinishLineHandler(const void * s) {
 
 static void RENDER_ClearCacheHandler(const void * src) {
 	Bitu x, width;
-	Bit32u *srcLine, *cacheLine;
-	srcLine = (Bit32u *)src;
-	cacheLine = (Bit32u *)render.scale.cacheRead;
+	uint32_t *srcLine, *cacheLine;
+	srcLine = (uint32_t *)src;
+	cacheLine = (uint32_t *)render.scale.cacheRead;
 	width = render.scale.cachePitch / 4;
 	for (x=0;x<width;x++)
 		cacheLine[x] = ~srcLine[x];
@@ -170,7 +170,7 @@ bool RENDER_StartUpdate(void) {
 	}
 	render.scale.inLine = 0;
 	render.scale.outLine = 0;
-	render.scale.cacheRead = (Bit8u*)&scalerSourceCache;
+	render.scale.cacheRead = (uint8_t*)&scalerSourceCache;
 	render.scale.outWrite = 0;
 	render.scale.outPitch = 0;
 	Scaler_ChangedLines[0] = 0;
@@ -229,8 +229,8 @@ void RENDER_EndUpdate( bool abort ) {
 			fps /= fps_skip;
 		}
 		CAPTURE_AddImage(render.src.width, render.src.height, render.src.bpp,
-		                 pitch, flags, static_cast<float>(fps), (Bit8u *)&scalerSourceCache,
-		                 (Bit8u *)&render.pal.rgb);
+		                 pitch, flags, static_cast<float>(fps), (uint8_t *)&scalerSourceCache,
+		                 (uint8_t *)&render.pal.rgb);
 	}
 	if ( render.scale.outWrite ) {
 		GFX_EndUpdate( abort? NULL : Scaler_ChangedLines );
@@ -594,7 +594,7 @@ void RENDER_SetSize(uint32_t width,
 	RENDER_Reset( );
 }
 
-extern void GFX_SetTitle(Bit32s cycles, int frameskip,bool paused);
+extern void GFX_SetTitle(int32_t cycles, int frameskip,bool paused);
 static void IncreaseFrameSkip(bool pressed) {
 	if (!pressed)
 		return;

--- a/src/gui/render_loops.h
+++ b/src/gui/render_loops.h
@@ -42,7 +42,7 @@ lastagain:
 	CC[render.scale.outLine][0] = 0;
 	const PTYPE * fc = &FC[render.scale.outLine][1];
 	PTYPE * line0=(PTYPE *)(render.scale.outWrite);
-	Bit8u * changed = &CC[render.scale.outLine][1];
+	uint8_t * changed = &CC[render.scale.outLine][1];
 	Bitu b;
 	for (b=0;b<render.scale.blocks;b++) {
 #if (SCALERHEIGHT > 1) 
@@ -67,16 +67,16 @@ lastagain:
 			continue;
 		case SCALE_LEFT:
 #if (SCALERHEIGHT > 1) 
-			line1 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch);
+			line1 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch);
 #endif
 #if (SCALERHEIGHT > 2) 
-			line2 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 2);
+			line2 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 2);
 #endif
 #if (SCALERHEIGHT > 3) 
-			line3 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 3);
+			line3 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 3);
 #endif
 #if (SCALERHEIGHT > 4) 
-			line4 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 4);
+			line4 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 4);
 #endif
 			SCALERFUNC;
 			line0 += SCALERWIDTH * SCALER_BLOCKSIZE;
@@ -84,31 +84,31 @@ lastagain:
 			break;
 		case SCALE_LEFT | SCALE_RIGHT:
 #if (SCALERHEIGHT > 1) 
-			line1 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch);
+			line1 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch);
 #endif
 #if (SCALERHEIGHT > 2) 
-			line2 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 2);
+			line2 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 2);
 #endif
 #if (SCALERHEIGHT > 3) 
-			line3 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 3);
+			line3 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 3);
 #endif
 #if (SCALERHEIGHT > 4) 
-			line4 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 4);
+			line4 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 4);
 #endif
 			SCALERFUNC;
 			[[fallthrough]];
 		case SCALE_RIGHT:
 #if (SCALERHEIGHT > 1) 			
-			line1 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch);
+			line1 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch);
 #endif
 #if (SCALERHEIGHT > 2) 
-			line2 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 2);
+			line2 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 2);
 #endif
 #if (SCALERHEIGHT > 3) 
-			line3 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 3);
+			line3 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 3);
 #endif
 #if (SCALERHEIGHT > 4) 
-			line4 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 4);
+			line4 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 4);
 #endif
 			line0 += SCALERWIDTH * (SCALER_BLOCKSIZE -1);
 #if (SCALERHEIGHT > 1) 
@@ -144,16 +144,16 @@ lastagain:
 #endif
 #else
 #if (SCALERHEIGHT > 1) 
-			line1 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch);
+			line1 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch);
 #endif
 #if (SCALERHEIGHT > 2) 
-			line2 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 2);
+			line2 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 2);
 #endif
 #if (SCALERHEIGHT > 3) 
-			line3 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 3);
+			line3 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 3);
 #endif
 #if (SCALERHEIGHT > 4) 
-			line4 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 4);
+			line4 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 4);
 #endif
 #endif //defined(SCALERLINEAR)
 			for (Bitu i = 0; i<SCALER_BLOCKSIZE;i++) {
@@ -175,16 +175,16 @@ lastagain:
 			}
 #if defined(SCALERLINEAR)
 #if (SCALERHEIGHT > 1) 
-			BituMove((Bit8u*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch  ,WC[0], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
+			BituMove((uint8_t*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch  ,WC[0], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
 #endif
 #if (SCALERHEIGHT > 2) 
-			BituMove((Bit8u*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch*2,WC[1], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
+			BituMove((uint8_t*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch*2,WC[1], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
 #endif
 #if (SCALERHEIGHT > 3) 
-			BituMove((Bit8u*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch*3,WC[2], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
+			BituMove((uint8_t*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch*3,WC[2], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
 #endif
 #if (SCALERHEIGHT > 4) 
-			BituMove((Bit8u*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch*4,WC[3], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
+			BituMove((uint8_t*)(&line0[-SCALER_BLOCKSIZE*SCALERWIDTH])+render.scale.outPitch*4,WC[3], SCALER_BLOCKSIZE *SCALERWIDTH*PSIZE);
 #endif
 #endif //defined(SCALERLINEAR)
 			break;

--- a/src/gui/render_scalers.cpp
+++ b/src/gui/render_scalers.cpp
@@ -25,15 +25,15 @@
 #include "render.h"
 #include <string.h>
 
-Bit8u Scaler_Aspect[SCALER_MAXHEIGHT];
-Bit16u Scaler_ChangedLines[SCALER_MAXHEIGHT];
+uint8_t Scaler_Aspect[SCALER_MAXHEIGHT];
+uint16_t Scaler_ChangedLines[SCALER_MAXHEIGHT];
 Bitu Scaler_ChangedLineIndex;
 
 static union {
 	 //The +1 is a at least for the normal scalers not needed. (-1 is enough)
-	Bit32u b32 [SCALER_MAX_MUL_HEIGHT + 1][SCALER_MAXLINE_WIDTH];
-	Bit16u b16 [SCALER_MAX_MUL_HEIGHT + 1][SCALER_MAXLINE_WIDTH];
-	Bit8u   b8 [SCALER_MAX_MUL_HEIGHT + 1][SCALER_MAXLINE_WIDTH];
+	uint32_t b32 [SCALER_MAX_MUL_HEIGHT + 1][SCALER_MAXLINE_WIDTH];
+	uint16_t b16 [SCALER_MAX_MUL_HEIGHT + 1][SCALER_MAXLINE_WIDTH];
+	uint8_t   b8 [SCALER_MAX_MUL_HEIGHT + 1][SCALER_MAXLINE_WIDTH];
 } scalerWriteCache;
 //scalerFrameCache_t scalerFrameCache;
 scalerSourceCache_t scalerSourceCache;

--- a/src/gui/render_scalers.h
+++ b/src/gui/render_scalers.h
@@ -75,23 +75,23 @@ typedef enum scalerOperation {
 typedef void (*ScalerLineHandler_t)(const void *src);
 typedef void (*ScalerComplexHandler_t)(void);
 
-extern Bit8u Scaler_Aspect[];
-extern Bit8u diff_table[];
+extern uint8_t Scaler_Aspect[];
+extern uint8_t diff_table[];
 extern Bitu Scaler_ChangedLineIndex;
-extern Bit16u Scaler_ChangedLines[];
+extern uint16_t Scaler_ChangedLines[];
 #if RENDER_USE_ADVANCED_SCALERS>1
 /* Not entirely happy about those +2's since they make a non power of 2, with muls instead of shift */
-typedef Bit8u scalerChangeCache_t [SCALER_COMPLEXHEIGHT][SCALER_COMPLEXWIDTH / SCALER_BLOCKSIZE] ;
+typedef uint8_t scalerChangeCache_t [SCALER_COMPLEXHEIGHT][SCALER_COMPLEXWIDTH / SCALER_BLOCKSIZE] ;
 typedef union {
-	Bit32u b32	[SCALER_COMPLEXHEIGHT] [SCALER_COMPLEXWIDTH];
-	Bit16u b16	[SCALER_COMPLEXHEIGHT] [SCALER_COMPLEXWIDTH];
-	Bit8u b8	[SCALER_COMPLEXHEIGHT] [SCALER_COMPLEXWIDTH];
+	uint32_t b32	[SCALER_COMPLEXHEIGHT] [SCALER_COMPLEXWIDTH];
+	uint16_t b16	[SCALER_COMPLEXHEIGHT] [SCALER_COMPLEXWIDTH];
+	uint8_t b8	[SCALER_COMPLEXHEIGHT] [SCALER_COMPLEXWIDTH];
 } scalerFrameCache_t;
 #endif
 typedef union {
-	Bit32u b32	[SCALER_MAXHEIGHT] [SCALER_MAXWIDTH];
-	Bit16u b16	[SCALER_MAXHEIGHT] [SCALER_MAXWIDTH];
-	Bit8u b8	[SCALER_MAXHEIGHT] [SCALER_MAXWIDTH];
+	uint32_t b32	[SCALER_MAXHEIGHT] [SCALER_MAXWIDTH];
+	uint16_t b16	[SCALER_MAXHEIGHT] [SCALER_MAXWIDTH];
+	uint8_t b8	[SCALER_MAXHEIGHT] [SCALER_MAXWIDTH];
 } scalerSourceCache_t;
 extern scalerSourceCache_t scalerSourceCache;
 #if RENDER_USE_ADVANCED_SCALERS>1

--- a/src/gui/render_simple.h
+++ b/src/gui/render_simple.h
@@ -51,7 +51,7 @@ static void conc4d(SCALERNAME,SBPP,DBPP,R)(const void *s) {
 	PTYPE * line0=(PTYPE *)(render.scale.outWrite);
 #if (SBPP == 9)
 	for (Bits x=render.src.width;x>0;) {
-		if (*(Bit32u const*)src == *(Bit32u*)cache && !(
+		if (*(uint32_t const*)src == *(uint32_t*)cache && !(
 			render.pal.modified[src[0]] | 
 			render.pal.modified[src[1]] | 
 			render.pal.modified[src[2]] | 
@@ -92,16 +92,16 @@ static void conc4d(SCALERNAME,SBPP,DBPP,R)(const void *s) {
 #endif
 #else
 #if (SCALERHEIGHT > 1) 
-		PTYPE *line1 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch);
+		PTYPE *line1 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch);
 #endif
 #if (SCALERHEIGHT > 2) 
-		PTYPE *line2 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 2);
+		PTYPE *line2 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 2);
 #endif
 #if (SCALERHEIGHT > 3) 
-		PTYPE *line3 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 3);
+		PTYPE *line3 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 3);
 #endif
 #if (SCALERHEIGHT > 4) 
-		PTYPE *line4 = (PTYPE *)(((Bit8u*)line0)+ render.scale.outPitch * 4);
+		PTYPE *line4 = (PTYPE *)(((uint8_t*)line0)+ render.scale.outPitch * 4);
 #endif
 #endif //defined(SCALERLINEAR)
 			hadChange = 1;
@@ -127,17 +127,17 @@ static void conc4d(SCALERNAME,SBPP,DBPP,R)(const void *s) {
 			}
 #if defined(SCALERLINEAR)
 #if (SCALERHEIGHT > 1)
-			Bitu copyLen = (Bitu)((Bit8u*)line1 - (Bit8u*)WC[0]);
-			BituMove(((Bit8u*)line0)-copyLen+render.scale.outPitch  ,WC[0], copyLen );
+			Bitu copyLen = (Bitu)((uint8_t*)line1 - (uint8_t*)WC[0]);
+			BituMove(((uint8_t*)line0)-copyLen+render.scale.outPitch  ,WC[0], copyLen );
 #endif
 #if (SCALERHEIGHT > 2) 
-			BituMove(((Bit8u*)line0)-copyLen+render.scale.outPitch*2,WC[1], copyLen );
+			BituMove(((uint8_t*)line0)-copyLen+render.scale.outPitch*2,WC[1], copyLen );
 #endif
 #if (SCALERHEIGHT > 3) 
-			BituMove(((Bit8u*)line0)-copyLen+render.scale.outPitch*3,WC[2], copyLen );
+			BituMove(((uint8_t*)line0)-copyLen+render.scale.outPitch*3,WC[2], copyLen );
 #endif
 #if (SCALERHEIGHT > 4) 
-			BituMove(((Bit8u*)line0)-copyLen+render.scale.outPitch*4,WC[3], copyLen );
+			BituMove(((uint8_t*)line0)-copyLen+render.scale.outPitch*4,WC[3], copyLen );
 #endif
 
 #endif //defined(SCALERLINEAR)

--- a/src/gui/render_templates.h
+++ b/src/gui/render_templates.h
@@ -18,7 +18,7 @@
 
 #if DBPP == 8
 #define PSIZE 1
-#define PTYPE Bit8u
+#define PTYPE uint8_t
 #define WC scalerWriteCache.b8
 //#define FC scalerFrameCache.b8
 #define FC (*(scalerFrameCache_t*)(&scalerSourceCache.b32[400][0])).b8
@@ -33,7 +33,7 @@
 #define blueShift	0
 #elif DBPP == 15 || DBPP == 16
 #define PSIZE 2
-#define PTYPE Bit16u
+#define PTYPE uint16_t
 #define WC scalerWriteCache.b16
 //#define FC scalerFrameCache.b16
 #define FC (*(scalerFrameCache_t*)(&scalerSourceCache.b32[400][0])).b16
@@ -60,7 +60,7 @@
 #endif
 #elif DBPP == 32
 #define PSIZE 4
-#define PTYPE Bit32u
+#define PTYPE uint32_t
 #define WC scalerWriteCache.b32
 //#define FC scalerFrameCache.b32
 #define FC (*(scalerFrameCache_t*)(&scalerSourceCache.b32[400][0])).b32
@@ -89,7 +89,7 @@
 #elif DBPP == 32
 #define PMAKE(_VAL) render.pal.lut.b32[_VAL]
 #endif
-#define SRCTYPE Bit8u
+#define SRCTYPE uint8_t
 #endif
 
 #if SBPP == 15
@@ -111,7 +111,7 @@
 #define PMAKE(_VAL)  (((_VAL&(31<<10))<<9)|((_VAL&(31<<5))<<6)|((_VAL&31)<<3)|((_VAL&(7<<12))<<4)|((_VAL&(7<<7))<<1)|((_VAL&(7<<2))>>2))
 #endif
 #endif
-#define SRCTYPE Bit16u
+#define SRCTYPE uint16_t
 #endif
 
 #if SBPP == 16
@@ -133,7 +133,7 @@
 #define PMAKE(_VAL)  (((_VAL&(31<<11))<<8)|((_VAL&(63<<5))<<5)|((_VAL&0xE01F)<<3)|((_VAL&(3<<9))>>1)|((_VAL&(7<<2))>>2))
 #endif
 #endif
-#define SRCTYPE Bit16u
+#define SRCTYPE uint16_t
 #endif
 
 #if SBPP == 24
@@ -168,7 +168,7 @@
 #define PMAKE(_VAL) (_VAL)
 #endif
 #endif
-#define SRCTYPE Bit32u
+#define SRCTYPE uint32_t
 #endif
 
 //  C0 C1 C2 D3

--- a/src/gui/render_templates_hq.h
+++ b/src/gui/render_templates_hq.h
@@ -27,31 +27,31 @@
 #ifndef RENDER_TEMPLATES_HQNX_TABLE_H
 #define RENDER_TEMPLATES_HQNX_TABLE_H
 
-static Bit32u *_RGBtoYUV = 0;
-static inline bool diffYUV(Bit32u yuv1, Bit32u yuv2)
+static uint32_t *_RGBtoYUV = 0;
+static inline bool diffYUV(uint32_t yuv1, uint32_t yuv2)
 {
-	static const Bit32u Ymask = 0x00FF0000;
-	static const Bit32u Umask = 0x0000FF00;
-	static const Bit32u Vmask = 0x000000FF;
-	static const Bit32u trY   = 0x00300000;
-	static const Bit32u trU   = 0x00000700;
-	static const Bit32u trV   = 0x00000006;
+	static const uint32_t Ymask = 0x00FF0000;
+	static const uint32_t Umask = 0x0000FF00;
+	static const uint32_t Vmask = 0x000000FF;
+	static const uint32_t trY   = 0x00300000;
+	static const uint32_t trU   = 0x00000700;
+	static const uint32_t trV   = 0x00000006;
 
-	Bit32u diff;
-	Bit32u mask;
+	uint32_t diff;
+	uint32_t mask;
 
 	diff = ((yuv1 & Ymask) - (yuv2 & Ymask));
-	mask = ((Bit32s)diff) >> 31; // ~1/-1 if value < 0, 0 otherwise
+	mask = ((int32_t)diff) >> 31; // ~1/-1 if value < 0, 0 otherwise
 	diff = (diff ^ mask) - mask; //-1: ~value + 1; 0: value
 	if (diff > trY) return true;
 
 	diff = ((yuv1 & Umask) - (yuv2 & Umask));
-	mask = ((Bit32s)diff)>> 31; // ~1/-1 if value < 0, 0 otherwise
+	mask = ((int32_t)diff)>> 31; // ~1/-1 if value < 0, 0 otherwise
 	diff = (diff ^ mask) - mask; //-1: ~value + 1; 0: value
 	if (diff > trU) return true;
 
 	diff = ((yuv1 & Vmask) - (yuv2 & Vmask));
-	mask = ((Bit32s)diff) >> 31; // ~1/-1 if value < 0, 0 otherwise
+	mask = ((int32_t)diff) >> 31; // ~1/-1 if value < 0, 0 otherwise
 	diff = (diff ^ mask) - mask; //-1: ~value + 1; 0: value
 	if (diff > trV) return true;
 
@@ -65,7 +65,7 @@ static inline void conc2d(InitLUTs,SBPP)(void)
 	int r, g, b;
 	int Y, u, v;
 
-	_RGBtoYUV = (Bit32u *)malloc(65536 * sizeof(Bit32u));
+	_RGBtoYUV = (uint32_t *)malloc(65536 * sizeof(uint32_t));
 	if (_RGBtoYUV == nullptr) {
 		return;
 	}

--- a/src/gui/render_templates_hq2x.h
+++ b/src/gui/render_templates_hq2x.h
@@ -89,8 +89,8 @@ inline void conc2d(Hq2x,SBPP)(PTYPE * line0, PTYPE * line1, const PTYPE * fc)
 {
 	if (_RGBtoYUV == 0) conc2d(InitLUTs,SBPP)();
 
-	Bit32u pattern = 0;
-	const Bit32u YUV4 = RGBtoYUV(C4);
+	uint32_t pattern = 0;
+	const uint32_t YUV4 = RGBtoYUV(C4);
 	if (C4 != C0 && diffYUV(YUV4, RGBtoYUV(C0))) pattern |= 0x0001;
 	if (C4 != C1 && diffYUV(YUV4, RGBtoYUV(C1))) pattern |= 0x0002;
 	if (C4 != C2 && diffYUV(YUV4, RGBtoYUV(C2))) pattern |= 0x0004;

--- a/src/gui/render_templates_hq3x.h
+++ b/src/gui/render_templates_hq3x.h
@@ -91,8 +91,8 @@ inline void conc2d(Hq3x,SBPP)(PTYPE * line0, PTYPE * line1, PTYPE * line2, const
 {
 	if (_RGBtoYUV == 0) conc2d(InitLUTs,SBPP)();
 
-	Bit32u pattern = 0;
-	const Bit32u YUV4 = RGBtoYUV(C4);
+	uint32_t pattern = 0;
+	const uint32_t YUV4 = RGBtoYUV(C4);
 
 	if (C4 != C0 && diffYUV(YUV4, RGBtoYUV(C0))) pattern |= 0x0001;
 	if (C4 != C1 && diffYUV(YUV4, RGBtoYUV(C1))) pattern |= 0x0002;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -37,9 +37,9 @@
 #include <cctype>
 #include <assert.h>
 
-extern Bit8u int10_font_14[256 * 14];
+extern uint8_t int10_font_14[256 * 14];
 extern bool MSG_Write(const char *);
-extern void GFX_SetTitle(Bit32s cycles, int frameskip, bool paused);
+extern void GFX_SetTitle(int32_t cycles, int frameskip, bool paused);
 
 static int cursor, saved_bpp;
 static int old_unicode;
@@ -59,29 +59,29 @@ static void getPixel(Bits x, Bits y, int &r, int &g, int &b, int shift)
 	if (x < 0) x = 0;
 	if (y < 0) y = 0;
 
-	Bit8u* src = (Bit8u *)&scalerSourceCache;
-	Bit32u pixel;
+	uint8_t* src = (uint8_t *)&scalerSourceCache;
+	uint32_t pixel;
 	switch (render.scale.inMode) {
 	case scalerMode8:
-		pixel = *(x+(Bit8u*)(src+y*render.scale.cachePitch));
+		pixel = *(x+(uint8_t*)(src+y*render.scale.cachePitch));
 		r += render.pal.rgb[pixel].red >> shift;
 		g += render.pal.rgb[pixel].green >> shift;
 		b += render.pal.rgb[pixel].blue >> shift;
 		break;
 	case scalerMode15:
-		pixel = *(x+(Bit16u*)(src+y*render.scale.cachePitch));
+		pixel = *(x+(uint16_t*)(src+y*render.scale.cachePitch));
 		r += (pixel >> (7+shift)) & (0xf8 >> shift);
 		g += (pixel >> (2+shift)) & (0xf8 >> shift);
 		b += (pixel << (3-shift)) & (0xf8 >> shift);
 		break;
 	case scalerMode16:
-		pixel = *(x+(Bit16u*)(src+y*render.scale.cachePitch));
+		pixel = *(x+(uint16_t*)(src+y*render.scale.cachePitch));
 		r += (pixel >> (8+shift)) & (0xf8 >> shift);
 		g += (pixel >> (3+shift)) & (0xfc >> shift);
 		b += (pixel << (3-shift)) & (0xf8 >> shift);
 		break;
 	case scalerMode32:
-		pixel = *(x+(Bit32u*)(src+y*render.scale.cachePitch));
+		pixel = *(x+(uint32_t*)(src+y*render.scale.cachePitch));
 		r += (pixel >> (16+shift)) & (0xff >> shift);
 		g += (pixel >> (8+shift))  & (0xff >> shift);
 		b += (pixel >> shift)      & (0xff >> shift);
@@ -114,7 +114,7 @@ static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
 	// create screenshot for fade effect
 	int rs = screenshot->format->Rshift, gs = screenshot->format->Gshift, bs = screenshot->format->Bshift, am = GUI::Color::AlphaMask;
 	for (int y = 0; y < h; y++) {
-		Bit32u *bg = (Bit32u*)(y*screenshot->pitch + (char*)screenshot->pixels);
+		uint32_t *bg = (uint32_t*)(y*screenshot->pitch + (char*)screenshot->pixels);
 		for (int x = 0; x < w; x++) {
 			int r = 0, g = 0, b = 0;
 			getPixel(x    *(int)render.src.width/w, y    *(int)render.src.height/h, r, g, b, 0);
@@ -125,7 +125,7 @@ static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
 	background = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32, GUI::Color::RedMask, GUI::Color::GreenMask, GUI::Color::BlueMask, GUI::Color::AlphaMask);
 	// use a blurred and sepia-toned screenshot as menu background
 	for (int y = 0; y < h; y++) {
-		Bit32u *bg = (Bit32u*)(y*background->pitch + (char*)background->pixels);
+		uint32_t *bg = (uint32_t*)(y*background->pitch + (char*)background->pixels);
 		for (int x = 0; x < w; x++) {
 			int r = 0, g = 0, b = 0;
 			getPixel(x    *(int)render.src.width/w, y    *(int)render.src.height/h, r, g, b, 3);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -107,7 +107,7 @@ class CBindGroup;
 
 static void SetActiveEvent(CEvent * event);
 static void SetActiveBind(CBind * _bind);
-extern Bit8u int10_font_14[256 * 14];
+extern uint8_t int10_font_14[256 * 14];
 
 static std::vector<CEvent *> events;
 static std::vector<CButton *> buttons;
@@ -1165,7 +1165,7 @@ public:
 		}
 
 		unsigned i;
-		Bit16u j;
+		uint16_t j;
 		j=button_state;
 		for(i=0;i<16;i++) if (j & 1) break; else j>>=1;
 		JOYSTICK_Button(0,0,i&1);
@@ -1364,13 +1364,13 @@ void CBindGroup::DeactivateBindList(CBindList * list,bool ev_trigger) {
 	}
 }
 
-static void DrawText(Bitu x,Bitu y,const char * text,Bit8u color) {
-	Bit8u * draw = ((Bit8u *)mapper.draw_surface->pixels) + (y * mapper.draw_surface->w) + x;
+static void DrawText(Bitu x,Bitu y,const char * text,uint8_t color) {
+	uint8_t * draw = ((uint8_t *)mapper.draw_surface->pixels) + (y * mapper.draw_surface->w) + x;
 	while (*text) {
-		Bit8u * font=&int10_font_14[(*text)*14];
-		Bitu i,j;Bit8u * draw_line=draw;
+		uint8_t * font=&int10_font_14[(*text)*14];
+		Bitu i,j;uint8_t * draw_line=draw;
 		for (i=0;i<14;i++) {
-			Bit8u map=*font++;
+			uint8_t map=*font++;
 			for (j=0;j<8;j++) {
 				if (map & 0x80) *(draw_line+j)=color;
 				else *(draw_line+j)=CLR_BLACK;
@@ -1400,7 +1400,7 @@ public:
 	virtual void Draw() {
 		if (!enabled)
 			return;
-		Bit8u * point = ((Bit8u *)mapper.draw_surface->pixels) + (y * mapper.draw_surface->w) + x;
+		uint8_t * point = ((uint8_t *)mapper.draw_surface->pixels) + (y * mapper.draw_surface->w) + x;
 		for (Bitu lines=0;lines<dy;lines++)  {
 			if (lines==0 || lines==(dy-1)) {
 				for (Bitu cols=0;cols<dx;cols++) *(point+cols)=color;
@@ -1422,10 +1422,10 @@ public:
 		mapper.redraw = true;
 	}
 
-	void SetColor(Bit8u _col) { color=_col; }
+	void SetColor(uint8_t _col) { color=_col; }
 protected:
 	Bitu x,y,dx,dy;
-	Bit8u color;
+	uint8_t color;
 	bool enabled;
 };
 
@@ -1516,7 +1516,7 @@ void CCaptionButton::Change(const char * format,...) {
 	mapper.redraw=true;
 }
 
-static void change_action_text(const char* text,Bit8u col);
+static void change_action_text(const char* text,uint8_t col);
 
 static void MAPPER_SaveBinds();
 
@@ -1590,7 +1590,7 @@ public:
 			break;
 		}
 		if (checked) {
-			Bit8u * point=((Bit8u *)mapper.draw_surface->pixels)+((y+2)*mapper.draw_surface->w)+x+dx-dy+2;
+			uint8_t * point=((uint8_t *)mapper.draw_surface->pixels)+((y+2)*mapper.draw_surface->w)+x+dx-dy+2;
 			for (Bitu lines=0;lines<(dy-4);lines++)  {
 				memset(point,color,dy-4);
 				point+=mapper.draw_surface->w;
@@ -1650,7 +1650,7 @@ public:
 	CJAxisEvent& operator=(const CJAxisEvent&) = delete; // prevent assignment
 
 	void Active(bool /*moved*/) {
-		virtual_joysticks[stick].axis_pos[axis]=(Bit16s)(GetValue()*(positive?1:-1));
+		virtual_joysticks[stick].axis_pos[axis]=(int16_t)(GetValue()*(positive?1:-1));
 	}
 	virtual Bitu GetActivityCount() {
 		return activity|opposite_axis->activity;
@@ -1777,7 +1777,7 @@ static struct {
 } bind_but;
 
 
-static void change_action_text(const char* text,Bit8u col) {
+static void change_action_text(const char* text,uint8_t col) {
 	bind_but.action->Change(text,"");
 	bind_but.action->SetColor(col);
 }
@@ -1917,8 +1917,8 @@ static void SetActiveEvent(CEvent * event) {
 	}
 }
 
-extern SDL_Window * GFX_SetSDLSurfaceWindow(Bit16u width, Bit16u height);
-extern SDL_Rect GFX_GetSDLSurfaceSubwindowDims(Bit16u width, Bit16u height);
+extern SDL_Window * GFX_SetSDLSurfaceWindow(uint16_t width, uint16_t height);
+extern SDL_Rect GFX_GetSDLSurfaceSubwindowDims(uint16_t width, uint16_t height);
 extern void GFX_UpdateDisplayDimensions(int width, int height);
 
 static void DrawButtons() {
@@ -2784,7 +2784,7 @@ static void CreateBindGroups() {
 			mapper.sticks.stick[mapper.sticks.num_groups] = nullptr;
 		}
 
-		Bit8u joyno = 0;
+		uint8_t joyno = 0;
 		switch (joytype) {
 		case JOY_DISABLED:
 		case JOY_NONE_FOUND: break;
@@ -2864,7 +2864,7 @@ void MAPPER_Run(bool pressed) {
 	PIC_AddEvent(MAPPER_RunEvent,0);	//In case mapper deletes the key object that ran it
 }
 
-SDL_Surface* SDL_SetVideoMode_Wrap(int width,int height,int bpp,Bit32u flags);
+SDL_Surface* SDL_SetVideoMode_Wrap(int width,int height,int bpp,uint32_t flags);
 
 void MAPPER_DisplayUI() {
 	int cursor = SDL_ShowCursor(SDL_QUERY);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -391,7 +391,7 @@ struct SDL_Block {
 			int height = 0;
 		} requested_window_bounds = {};
 
-		Bit8u bpp = 0;
+		uint8_t bpp = 0;
 		bool fullscreen = false;
 		// This flag indicates, that we are in the process of switching
 		// between fullscreen or window (as oppososed to changing
@@ -559,7 +559,7 @@ extern bool CPU_CycleAutoAdjust;
 bool startup_state_numlock=false;
 bool startup_state_capslock=false;
 
-void GFX_SetTitle(Bit32s cycles, int /*frameskip*/, bool paused)
+void GFX_SetTitle(int32_t cycles, int /*frameskip*/, bool paused)
 {
 	char title[200] = {0};
 
@@ -569,7 +569,7 @@ void GFX_SetTitle(Bit32s cycles, int /*frameskip*/, bool paused)
 	const char* build_type = "";
 #endif
 
-	static Bit32s internal_cycles = 0;
+	static int32_t internal_cycles = 0;
 	if (cycles != -1)
 		internal_cycles = cycles;
 
@@ -1457,7 +1457,7 @@ finish:
 
 // Used for the mapper UI and more: Creates a fullscreen window with desktop res
 // on Android, and a non-fullscreen window with the input dimensions otherwise.
-SDL_Window * GFX_SetSDLSurfaceWindow(Bit16u width, Bit16u height)
+SDL_Window * GFX_SetSDLSurfaceWindow(uint16_t width, uint16_t height)
 {
 	constexpr bool fullscreen = false;
 	return SetWindowMode(SCREEN_SURFACE, width, height, fullscreen, FIXED_SIZE);
@@ -1465,7 +1465,7 @@ SDL_Window * GFX_SetSDLSurfaceWindow(Bit16u width, Bit16u height)
 
 // Returns the rectangle in the current window to be used for scaling a
 // sub-window with the given dimensions, like the mapper UI.
-SDL_Rect GFX_GetSDLSurfaceSubwindowDims(Bit16u width, Bit16u height)
+SDL_Rect GFX_GetSDLSurfaceSubwindowDims(uint16_t width, uint16_t height)
 {
 	SDL_Rect rect;
 	rect.x = rect.y = 0;
@@ -2562,7 +2562,7 @@ static void update_frame_surface([[maybe_unused]] const uint16_t *changedLines)
 	}
 }
 
-Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue) {
+Bitu GFX_GetRGB(uint8_t red,uint8_t green,uint8_t blue) {
 	switch (sdl.desktop.type) {
 	case SCREEN_SURFACE:
 		return SDL_MapRGB(sdl.surface->format,red,green,blue);
@@ -2710,15 +2710,15 @@ static void SetPriority(PRIORITY_LEVELS level)
 }
 
 #ifdef WIN32
-extern Bit8u int10_font_14[256 * 14];
-static void OutputString(Bitu x,Bitu y,const char * text,Bit32u color,Bit32u color2,SDL_Surface * output_surface) {
-	Bit32u * draw=(Bit32u*)(((Bit8u *)output_surface->pixels)+((y)*output_surface->pitch))+x;
+extern uint8_t int10_font_14[256 * 14];
+static void OutputString(Bitu x,Bitu y,const char * text,uint32_t color,uint32_t color2,SDL_Surface * output_surface) {
+	uint32_t * draw=(uint32_t*)(((uint8_t *)output_surface->pixels)+((y)*output_surface->pitch))+x;
 	while (*text) {
-		Bit8u * font=&int10_font_14[(*text)*14];
+		uint8_t * font=&int10_font_14[(*text)*14];
 		Bitu i,j;
-		Bit32u * draw_line=draw;
+		uint32_t * draw_line=draw;
 		for (i=0;i<14;i++) {
-			Bit8u map=*font++;
+			uint8_t map=*font++;
 			for (j=0;j<8;j++) {
 				*(draw_line + j) = map & 0x80 ? color : color2;
 				map<<=1;

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -43,12 +43,12 @@ namespace OPL2 {
 	#include "opl.cpp"
 
 struct Handler : public Adlib::Handler {
-	virtual void WriteReg(Bit32u reg, Bit8u val) { adlib_write(reg, val); }
-	virtual Bit32u WriteAddr(io_port_t, Bit8u val) { return val; }
+	virtual void WriteReg(uint32_t reg, uint8_t val) { adlib_write(reg, val); }
+	virtual uint32_t WriteAddr(io_port_t, uint8_t val) { return val; }
 
 	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
-		Bit16s buf[1024];
+		int16_t buf[1024];
 		int remaining = samples;
 		while (remaining > 0) {
 			const auto todo = std::min(remaining, 1024);
@@ -68,15 +68,15 @@ namespace OPL3 {
 	#include "opl.cpp"
 
 struct Handler : public Adlib::Handler {
-	virtual void WriteReg(Bit32u reg, Bit8u val) { adlib_write(reg, val); }
-	virtual Bit32u WriteAddr(io_port_t port, Bit8u val)
+	virtual void WriteReg(uint32_t reg, uint8_t val) { adlib_write(reg, val); }
+	virtual uint32_t WriteAddr(io_port_t port, uint8_t val)
 	{
 		adlib_write_index(port, val);
 		return opl_index;
 	}
 	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
-		Bit16s buf[1024 * 2];
+		int16_t buf[1024 * 2];
 		int remaining = samples;
 		while (remaining > 0) {
 			const auto todo = std::min(remaining, 1024);
@@ -96,14 +96,14 @@ namespace MAMEOPL2 {
 struct Handler : public Adlib::Handler {
 	void *chip = nullptr;
 
-	virtual void WriteReg(Bit32u reg, Bit8u val) {
+	virtual void WriteReg(uint32_t reg, uint8_t val) {
 		ym3812_write(chip, 0, reg);
 		ym3812_write(chip, 1, val);
 	}
-	virtual Bit32u WriteAddr(io_port_t, Bit8u val) { return val; }
+	virtual uint32_t WriteAddr(io_port_t, uint8_t val) { return val; }
 	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
-		Bit16s buf[1024 * 2];
+		int16_t buf[1024 * 2];
 		int remaining = samples;
 		while (remaining > 0) {
 			const auto todo = std::min(remaining, 1024);
@@ -129,18 +129,18 @@ namespace MAMEOPL3 {
 struct Handler : public Adlib::Handler {
 	void *chip = nullptr;
 
-	virtual void WriteReg(Bit32u reg, Bit8u val) {
+	virtual void WriteReg(uint32_t reg, uint8_t val) {
 		ymf262_write(chip, 0, reg);
 		ymf262_write(chip, 1, val);
 	}
-	virtual Bit32u WriteAddr(io_port_t, Bit8u val) { return val; }
+	virtual uint32_t WriteAddr(io_port_t, uint8_t val) { return val; }
 	virtual void Generate(mixer_channel_t &chan, const uint16_t samples)
 	{
 		// We generate data for 4 channels, but only the first 2 are
 		// connected on a pc
-		Bit16s buf[4][1024];
-		Bit16s result[1024][2];
-		Bit16s* buffers[4] = { buf[0], buf[1], buf[2], buf[3] };
+		int16_t buf[4][1024];
+		int16_t result[1024][2];
+		int16_t* buffers[4] = { buf[0], buf[1], buf[2], buf[3] };
 
 		int remaining = samples;
 		while (remaining > 0) {
@@ -170,18 +170,18 @@ namespace NukedOPL {
 
 struct Handler : public Adlib::Handler {
 	opl3_chip chip = {};
-	Bit8u newm = 0;
+	uint8_t newm = 0;
 
-	void WriteReg(Bit32u reg, Bit8u val) override
+	void WriteReg(uint32_t reg, uint8_t val) override
 	{
-		OPL3_WriteRegBuffered(&chip, (Bit16u)reg, val);
+		OPL3_WriteRegBuffered(&chip, (uint16_t)reg, val);
 		if (reg == 0x105)
 			newm = reg & 0x01;
 	}
 
-	Bit32u WriteAddr(io_port_t port, Bit8u val) override
+	uint32_t WriteAddr(io_port_t port, uint8_t val) override
 	{
-		Bit16u addr;
+		uint16_t addr;
 		addr = val;
 		if ((port & 2) && (addr == 0x05 || newm)) {
 			addr |= 0x100;
@@ -228,17 +228,17 @@ namespace Adlib {
 #define HW_OPL3 2
 
 struct RawHeader {
-	Bit8u id[8];				/* 0x00, "DBRAWOPL" */
-	Bit16u versionHigh;			/* 0x08, size of the data following the m */
-	Bit16u versionLow;			/* 0x0a, size of the data following the m */
-	Bit32u commands;			/* 0x0c, Bit32u amount of command/data pairs */
-	Bit32u milliseconds;		/* 0x10, Bit32u Total milliseconds of data in this chunk */
-	Bit8u hardware;				/* 0x14, Bit8u Hardware Type 0=opl2,1=dual-opl2,2=opl3 */
-	Bit8u format;				/* 0x15, Bit8u Format 0=cmd/data interleaved, 1 maybe all cdms, followed by all data */
-	Bit8u compression;			/* 0x16, Bit8u Compression Type, 0 = No Compression */
-	Bit8u delay256;				/* 0x17, Bit8u Delay 1-256 msec command */
-	Bit8u delayShift8;			/* 0x18, Bit8u (delay + 1)*256 */			
-	Bit8u conversionTableSize;	/* 0x191, Bit8u Raw Conversion Table size */
+	uint8_t id[8];				/* 0x00, "DBRAWOPL" */
+	uint16_t versionHigh;			/* 0x08, size of the data following the m */
+	uint16_t versionLow;			/* 0x0a, size of the data following the m */
+	uint32_t commands;			/* 0x0c, uint32_t amount of command/data pairs */
+	uint32_t milliseconds;		/* 0x10, uint32_t Total milliseconds of data in this chunk */
+	uint8_t hardware;				/* 0x14, uint8_t Hardware Type 0=opl2,1=dual-opl2,2=opl3 */
+	uint8_t format;				/* 0x15, uint8_t Format 0=cmd/data interleaved, 1 maybe all cdms, followed by all data */
+	uint8_t compression;			/* 0x16, uint8_t Compression Type, 0 = No Compression */
+	uint8_t delay256;				/* 0x17, uint8_t Delay 1-256 msec command */
+	uint8_t delayShift8;			/* 0x18, uint8_t (delay + 1)*256 */			
+	uint8_t conversionTableSize;	/* 0x191, uint8_t Raw Conversion Table size */
 } GCC_ATTRIBUTE(packed);
 #ifdef _MSC_VER
 #pragma pack()
@@ -251,28 +251,28 @@ struct RawHeader {
 
 //Table to map the opl register to one <127 for dro saving
 class Capture {
-	Bit8u ToReg[127];       // 127 entries to go from raw data to registers
-	Bit8u RawUsed = 0;      // How many entries in the ToPort are used
-	Bit8u ToRaw[256];       // 256 entries to go from port index to raw data
-	Bit8u delay256 = 0;
-	Bit8u delayShift8 = 0;
+	uint8_t ToReg[127];       // 127 entries to go from raw data to registers
+	uint8_t RawUsed = 0;      // How many entries in the ToPort are used
+	uint8_t ToRaw[256];       // 256 entries to go from port index to raw data
+	uint8_t delay256 = 0;
+	uint8_t delayShift8 = 0;
 	RawHeader header;
 
 	FILE*  handle = nullptr;  // File used for writing
-	Bit32u startTicks = 0;    // Start used to check total raw length on end
-	Bit32u lastTicks = 0;     // Last ticks when last last cmd was added
-	Bit8u  buf[1024];         // 16 added for delay commands and what not
-	Bit32u bufUsed = 0;
+	uint32_t startTicks = 0;    // Start used to check total raw length on end
+	uint32_t lastTicks = 0;     // Last ticks when last last cmd was added
+	uint8_t  buf[1024];         // 16 added for delay commands and what not
+	uint32_t bufUsed = 0;
 
 	RegisterCache* cache;
 
-	void MakeEntry( Bit8u reg, Bit8u& raw ) {
+	void MakeEntry( uint8_t reg, uint8_t& raw ) {
 		ToReg[ raw ] = reg;
 		ToRaw[ reg ] = raw;
 		raw++;
 	}
 	void MakeTables( void ) {
-		Bit8u index = 0;
+		uint8_t index = 0;
 		memset( ToReg, 0xff, sizeof ( ToReg ) );
 		memset( ToRaw, 0xff, sizeof ( ToRaw ) );
 		//Select the entries that are valid and the index is the mapping to the index entry
@@ -309,15 +309,15 @@ class Capture {
 		header.commands += bufUsed / 2;
 		bufUsed = 0;
 	}
-	void AddBuf( Bit8u raw, Bit8u val ) {
+	void AddBuf( uint8_t raw, uint8_t val ) {
 		buf[bufUsed++] = raw;
 		buf[bufUsed++] = val;
 		if ( bufUsed >= sizeof( buf ) ) {
 			ClearBuf();
 		}
 	}
-	void AddWrite( Bit32u regFull, Bit8u val ) {
-		Bit8u regMask = regFull & 0xff;
+	void AddWrite( uint32_t regFull, uint8_t val ) {
+		uint8_t regMask = regFull & 0xff;
 		/*
 			Do some special checks if we're doing opl3 or dualopl2 commands
 			Although you could pretty much just stick to always doing opl3 on the player side
@@ -331,7 +331,7 @@ class Capture {
 		if ( header.hardware == HW_OPL2 && regFull >= 0x1b0 && regFull <=0x1b8 && val ) {
 			header.hardware = HW_DUALOPL2;
 		}
-		Bit8u raw = ToRaw[ regMask ];
+		uint8_t raw = ToRaw[ regMask ];
 		if ( raw == 0xff )
 			return;
 		if ( regFull & 0x100 )
@@ -388,14 +388,14 @@ class Capture {
 		}
 	}
 public:
-	bool DoWrite( Bit32u regFull, Bit8u val ) {
-		Bit8u regMask = regFull & 0xff;
+	bool DoWrite( uint32_t regFull, uint8_t val ) {
+		uint8_t regMask = regFull & 0xff;
 		//Check the raw index for this register if we actually have to save it
 		if ( handle ) {
 			/*
 				Check if we actually care for this to be logged, else just ignore it
 			*/
-			Bit8u raw = ToRaw[ regMask ];
+			uint8_t raw = ToRaw[ regMask ];
 			if ( raw == 0xff ) {
 				return true;
 			}
@@ -481,7 +481,7 @@ Chip
 Chip::Chip() : timer0(80), timer1(320) {
 }
 
-bool Chip::Write( Bit32u reg, Bit8u val ) {
+bool Chip::Write( uint32_t reg, uint8_t val ) {
 	//if(reg == 0x02 || reg == 0x03 || reg == 0x04) LOG(LOG_MISC,LOG_ERROR)("write adlib timer %X %X",reg,val);
 	switch ( reg ) {
 	case 0x02:
@@ -520,9 +520,9 @@ bool Chip::Write( Bit32u reg, Bit8u val ) {
 }
 
 
-Bit8u Chip::Read( ) {
+uint8_t Chip::Read( ) {
 	const auto time(PIC_FullIndex());
-	Bit8u ret = 0;
+	uint8_t ret = 0;
 	//Overflow won't be set if a channel is masked
 	if (timer0.Update(time)) {
 		ret |= 0x40;
@@ -535,7 +535,7 @@ Bit8u Chip::Read( ) {
 	return ret;
 }
 
-void Module::CacheWrite(Bit32u port, Bit8u val)
+void Module::CacheWrite(uint32_t port, uint8_t val)
 {
 	// capturing?
 	if (capture) {
@@ -545,7 +545,7 @@ void Module::CacheWrite(Bit32u port, Bit8u val)
 	cache[port] = val;
 }
 
-void Module::DualWrite(Bit8u index, Bit8u port, Bit8u val)
+void Module::DualWrite(uint8_t index, uint8_t port, uint8_t val)
 {
 	// Make sure you don't use opl3 features
 	// Don't allow write to disable opl3
@@ -569,7 +569,7 @@ void Module::DualWrite(Bit8u index, Bit8u port, Bit8u val)
 	CacheWrite(full_port, val);
 }
 
-void Module::CtrlWrite( Bit8u val ) {
+void Module::CtrlWrite( uint8_t val ) {
 	switch ( ctrl.index ) {
 	case 0x09: /* Left FM Volume */
 		ctrl.lvol = val;
@@ -627,7 +627,7 @@ void Module::PortWrite(io_port_t port, io_val_t value, io_width_t)
 		case MODE_DUALOPL2:
 			//Not a 0x??8 port, then write to a specific port
 			if ( !(port & 0x8) ) {
-				Bit8u index = ( port & 2 ) >> 1;
+				uint8_t index = ( port & 2 ) >> 1;
 				DualWrite( index, reg.dual[index], val );
 			} else {
 				//Write to both ports
@@ -663,7 +663,7 @@ void Module::PortWrite(io_port_t port, io_val_t value, io_width_t)
 		case MODE_DUALOPL2:
 			//Not a 0x?88 port, when write to a specific side
 			if ( !(port & 0x8) ) {
-				Bit8u index = ( port & 2 ) >> 1;
+				uint8_t index = ( port & 2 ) >> 1;
 				reg.dual[index] = val & 0xff;
 			} else {
 				reg.dual[0] = val & 0xff;
@@ -770,9 +770,9 @@ static void SaveRad() {
 	b[w++] = 0x06;		//default speed and no description
 	//Write 18 instuments for all operators in the cache
 	for ( int i = 0; i < 18; i++ ) {
-		Bit8u* set = module->cache + ( i / 9 ) * 256;
+		uint8_t* set = module->cache + ( i / 9 ) * 256;
 		const auto offset = ((i % 9) / 3) * 8 + (i % 3);
-		Bit8u* base = set + offset;
+		uint8_t* base = set + offset;
 		b[w++] = 1 + i;		//instrument number
 		b[w++] = base[0x23];
 		b[w++] = base[0x20];

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -83,7 +83,7 @@ public:
 		overflow = false;
 	}
 
-	void SetCounter(Bit8u val) {
+	void SetCounter(uint8_t val) {
 		counter = val;
 		//Interval for next cycle
 		counterInterval = (256 - counter) * clockInterval;
@@ -118,9 +118,9 @@ struct Chip {
 	//Last selected register
 	Timer timer0, timer1;
 	//Check for it being a write to the timer
-	bool Write( Bit32u addr, Bit8u val );
+	bool Write( uint32_t addr, uint8_t val );
 	//Read the current timer state, will use current double
-	Bit8u Read( );
+	uint8_t Read( );
 
 	Chip();
 };
@@ -136,9 +136,9 @@ typedef enum {
 class Handler {
 public:
 	//Write an address to a chip, returns the address the chip sets
-	virtual Bit32u WriteAddr(io_port_t port, Bit8u val) = 0;
+	virtual uint32_t WriteAddr(io_port_t port, uint8_t val) = 0;
 	//Write to a specific register in the chip
-	virtual void WriteReg( Bit32u addr, Bit8u val ) = 0;
+	virtual void WriteReg( uint32_t addr, uint8_t val ) = 0;
 	//Generate a certain amount of samples
 	virtual void Generate(mixer_channel_t &chan, uint16_t samples) = 0;
 	//Initialize at a specific sample rate and mode
@@ -147,7 +147,7 @@ public:
 };
 
 //The cache for 2 chips or an opl3
-typedef Bit8u RegisterCache[512];
+typedef uint8_t RegisterCache[512];
 
 //Internal class used for dro capturing
 class Capture;
@@ -160,25 +160,25 @@ class Module: public Module_base {
 	Mode mode;
 	//Last selected address in the chip for the different modes
 	union {
-		Bit32u normal;
-		Bit8u dual[2];
+		uint32_t normal;
+		uint8_t dual[2];
 	} reg;
 	struct {
 		bool active;
-		Bit8u index;
-		Bit8u lvol;
-		Bit8u rvol;
+		uint8_t index;
+		uint8_t lvol;
+		uint8_t rvol;
 		bool mixer;
 	} ctrl;
-	void CacheWrite( Bit32u reg, Bit8u val );
-	void DualWrite( Bit8u index, Bit8u reg, Bit8u val );
-	void CtrlWrite( Bit8u val );
+	void CacheWrite( uint32_t reg, uint8_t val );
+	void DualWrite( uint8_t index, uint8_t reg, uint8_t val );
+	void CtrlWrite( uint8_t val );
 	uint8_t CtrlRead(void);
 
 public:
 	static OPL_Mode oplmode;
 	mixer_channel_t mixerChan;
-	Bit32u lastUsed;				//Ticks when adlib was last used to turn of mixing after a few second
+	uint32_t lastUsed;				//Ticks when adlib was last used to turn of mixing after a few second
 
 	Handler* handler;				//Handler that will generate the sound
 	RegisterCache cache;

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -30,13 +30,13 @@
 #include "timer.h"
 
 static struct {
-	Bit8u regs[0x40];
+	uint8_t regs[0x40];
 	bool nmi;
 	bool bcd;
-	Bit8u reg;
+	uint8_t reg;
 	struct {
 		bool enabled;
-		Bit8u div;
+		uint8_t div;
 		double delay;
 		bool acknowledged;
 	} timer;
@@ -135,7 +135,7 @@ static uint8_t cmos_readreg(io_port_t, io_width_t)
 		return 0xff;
 	}
 	Bitu drive_a, drive_b;
-	Bit8u hdparm;
+	uint8_t hdparm;
 
 	const time_t curtime = time(nullptr);
 	struct tm datetime;
@@ -172,12 +172,12 @@ static uint8_t cmos_readreg(io_port_t, io_width_t)
 		cmos.timer.acknowledged=true;
 		if (cmos.timer.enabled) {
 			/* In periodic interrupt mode only care for those flags */
-			Bit8u val=cmos.regs[0xc];
+			uint8_t val=cmos.regs[0xc];
 			cmos.regs[0xc]=0;
 			return val;
 		} else {
 			/* Give correct values at certain times */
-			Bit8u val=0;
+			uint8_t val=0;
 			const auto index = PIC_FullIndex();
 			if (index>=(cmos.last.timer+cmos.timer.delay)) {
 				cmos.last.timer=index;
@@ -285,7 +285,7 @@ static uint8_t cmos_readreg(io_port_t, io_width_t)
 	}
 }
 
-void CMOS_SetRegister(Bitu regNr, Bit8u val) {
+void CMOS_SetRegister(Bitu regNr, uint8_t val) {
 	cmos.regs[regNr] = val;
 }
 
@@ -316,14 +316,14 @@ public:
 		                                                     on */
 		// Equipment is updated from bios.cpp and bios_disk.cpp
 		/* Fill in base memory size, it is 640K always */
-		cmos.regs[0x15]=(Bit8u)0x80;
-		cmos.regs[0x16]=(Bit8u)0x02;
+		cmos.regs[0x15]=(uint8_t)0x80;
+		cmos.regs[0x16]=(uint8_t)0x02;
 		/* Fill in extended memory size */
 		Bitu exsize=(MEM_TotalPages()*4)-1024;
-		cmos.regs[0x17]=(Bit8u)exsize;
-		cmos.regs[0x18]=(Bit8u)(exsize >> 8);
-		cmos.regs[0x30]=(Bit8u)exsize;
-		cmos.regs[0x31]=(Bit8u)(exsize >> 8);
+		cmos.regs[0x17]=(uint8_t)exsize;
+		cmos.regs[0x18]=(uint8_t)(exsize >> 8);
+		cmos.regs[0x30]=(uint8_t)exsize;
+		cmos.regs[0x31]=(uint8_t)(exsize >> 8);
 	}
 };
 

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -97,7 +97,7 @@ namespace DBOPL {
 
 
 //How much to substract from the base value for the final attenuation
-static const Bit8u KslCreateTable[16] = {
+static const uint8_t KslCreateTable[16] = {
 	//0 will always be be lower than 7 * 8
 	64, 32, 24, 19, 
 	16, 12, 11, 10, 
@@ -105,22 +105,22 @@ static const Bit8u KslCreateTable[16] = {
 	 3,  2,  1,  0,
 };
 
-#define M(_X_) ((Bit8u)( (_X_) * 2))
-static const Bit8u FreqCreateTable[16] = {
+#define M(_X_) ((uint8_t)( (_X_) * 2))
+static const uint8_t FreqCreateTable[16] = {
 	M(0.5), M(1 ), M(2 ), M(3 ), M(4 ), M(5 ), M(6 ), M(7 ),
 	M(8  ), M(9 ), M(10), M(10), M(12), M(12), M(15), M(15)
 };
 #undef M
 
 //We're not including the highest attack rate, that gets a special value
-static const Bit8u AttackSamplesTable[13] = {
+static const uint8_t AttackSamplesTable[13] = {
 	69, 55, 46, 40,
 	35, 29, 23, 20,
 	19, 15, 11, 10,
 	9
 };
 //On a real opl these values take 8 samples to reach and are based upon larger tables
-static const Bit8u EnvelopeIncreaseTable[13] = {
+static const uint8_t EnvelopeIncreaseTable[13] = {
 	4,  5,  6,  7,
 	8, 10, 12, 14,
 	16, 20, 24, 28,
@@ -128,12 +128,12 @@ static const Bit8u EnvelopeIncreaseTable[13] = {
 };
 
 #if ( DBOPL_WAVE == WAVE_HANDLER ) || ( DBOPL_WAVE == WAVE_TABLELOG )
-static Bit16u ExpTable[ 256 ];
+static uint16_t ExpTable[ 256 ];
 #endif
 
 #if ( DBOPL_WAVE == WAVE_HANDLER )
 //PI table used by WAVEHANDLER
-static Bit16u SinTable[ 512 ];
+static uint16_t SinTable[ 512 ];
 #endif
 
 #if ( DBOPL_WAVE > WAVE_HANDLER )
@@ -146,52 +146,52 @@ static Bit16u SinTable[ 512 ];
 
 //6 is just 0 shifted and masked
 
-static Bit16s WaveTable[ 8 * 512 ];
+static int16_t WaveTable[ 8 * 512 ];
 //Distance into WaveTable the wave starts
-static const Bit16u WaveBaseTable[8] = {
+static const uint16_t WaveBaseTable[8] = {
 	0x000, 0x200, 0x200, 0x800,
 	0xa00, 0xc00, 0x100, 0x400,
 
 };
 //Mask the counter with this
-static const Bit16u WaveMaskTable[8] = {
+static const uint16_t WaveMaskTable[8] = {
 	1023, 1023, 511, 511,
 	1023, 1023, 512, 1023,
 };
 
 //Where to start the counter on at keyon
-static const Bit16u WaveStartTable[8] = {
+static const uint16_t WaveStartTable[8] = {
 	512, 0, 0, 0,
 	0, 512, 512, 256,
 };
 #endif
 
 #if ( DBOPL_WAVE == WAVE_TABLEMUL )
-static Bit16u MulTable[ 384 ];
+static uint16_t MulTable[ 384 ];
 #endif
 
-static Bit8u KslTable[ 8 * 16 ];
-static Bit8u TremoloTable[ TREMOLO_TABLE ];
+static uint8_t KslTable[ 8 * 16 ];
+static uint8_t TremoloTable[ TREMOLO_TABLE ];
 //Start of a channel behind the chip struct start
-static Bit16u ChanOffsetTable[32];
+static uint16_t ChanOffsetTable[32];
 //Start of an operator behind the chip struct start
-static Bit16u OpOffsetTable[64];
+static uint16_t OpOffsetTable[64];
 
 //The lower bits are the shift of the operator vibrato value
 //The highest bit is right shifted to generate -1 or 0 for negation
 //So taking the highest input value of 7 this gives 3, 7, 3, 0, -3, -7, -3, 0
-static const Bit8s VibratoTable[ 8 ] = {	
+static const int8_t VibratoTable[ 8 ] = {	
 	1 - 0x00, 0 - 0x00, 1 - 0x00, 30 - 0x00, 
 	1 - 0x80, 0 - 0x80, 1 - 0x80, 30 - 0x80 
 };
 
 //Shift strength for the ksl value determined by ksl strength
-static const Bit8u KslShiftTable[4] = {
+static const uint8_t KslShiftTable[4] = {
 	31,1,2,0
 };
 
 //Generate a table index and table shift value using input value from a selected rate
-static void EnvelopeSelect( Bit8u val, Bit8u& index, Bit8u& shift ) {
+static void EnvelopeSelect( uint8_t val, uint8_t& index, uint8_t& shift ) {
 	if ( val < 13 * 4 ) {				//Rate 0 - 12
 		shift = 12 - ( val >> 2 );
 		index = val & 3;
@@ -231,7 +231,7 @@ static Bits WaveForm0(Bitu i, Bitu volume)
 
 static Bits WaveForm1(Bitu i, Bitu volume)
 {
-	Bit32u wave = SinTable[i & 511];
+	uint32_t wave = SinTable[i & 511];
 	wave |= ( ( (i ^ 512 ) & 512) - 1) >> ( 32 - 12 );
 	return MakeVolume( wave, volume );
 }
@@ -297,9 +297,9 @@ static const WaveHandler WaveHandlerTable[8] = {
 
 //We zero out when rate == 0
 inline void Operator::UpdateAttack( const Chip* chip ) {
-	Bit8u rate = reg60 >> 4;
+	uint8_t rate = reg60 >> 4;
 	if ( rate ) {
-		Bit8u val = (rate << 2) + ksr;
+		uint8_t val = (rate << 2) + ksr;
 		attackAdd = chip->attackRates[ val ];
 		rateZero &= ~(1 << ATTACK);
 	} else {
@@ -308,9 +308,9 @@ inline void Operator::UpdateAttack( const Chip* chip ) {
 	}
 }
 inline void Operator::UpdateDecay( const Chip* chip ) {
-	Bit8u rate = reg60 & 0xf;
+	uint8_t rate = reg60 & 0xf;
 	if ( rate ) {
-		Bit8u val = (rate << 2) + ksr;
+		uint8_t val = (rate << 2) + ksr;
 		decayAdd = chip->linearRates[ val ];
 		rateZero &= ~(1 << DECAY);
 	} else {
@@ -319,9 +319,9 @@ inline void Operator::UpdateDecay( const Chip* chip ) {
 	}
 }
 inline void Operator::UpdateRelease( const Chip* chip ) {
-	Bit8u rate = reg80 & 0xf;
+	uint8_t rate = reg80 & 0xf;
 	if ( rate ) {
-		Bit8u val = (rate << 2) + ksr;
+		uint8_t val = (rate << 2) + ksr;
 		releaseAdd = chip->linearRates[ val ];
 		rateZero &= ~(1 << RELEASE);
 		if ( !(reg20 & MASK_SUSTAIN ) ) {
@@ -337,17 +337,17 @@ inline void Operator::UpdateRelease( const Chip* chip ) {
 }
 
 inline void Operator::UpdateAttenuation( ) {
-	Bit8u kslBase = (Bit8u)((chanData >> SHIFT_KSLBASE) & 0xff);
-	Bit32u tl = reg40 & 0x3f;
-	Bit8u kslShift = KslShiftTable[ reg40 >> 6 ];
+	uint8_t kslBase = (uint8_t)((chanData >> SHIFT_KSLBASE) & 0xff);
+	uint32_t tl = reg40 & 0x3f;
+	uint8_t kslShift = KslShiftTable[ reg40 >> 6 ];
 	//Make sure the attenuation goes to the right bits
 	totalLevel = tl << ( ENV_BITS - 7 );	//Total level goes 2 bits below max
 	totalLevel += ( kslBase << ENV_EXTRA ) >> kslShift;
 }
 
 void Operator::UpdateFrequency(  ) {
-	Bit32u freq = chanData & (( 1 << 10 ) - 1);
-	Bit32u block = (chanData >> 10) & 0xff;
+	uint32_t freq = chanData & (( 1 << 10 ) - 1);
+	uint32_t block = (chanData >> 10) & 0xff;
 #ifdef WAVE_PRECISION
 	block = 7 - block;
 	waveAdd = ( freq * freqMul ) >> block;
@@ -355,7 +355,7 @@ void Operator::UpdateFrequency(  ) {
 	waveAdd = ( freq << block ) * freqMul;
 #endif
 	if ( reg20 & MASK_VIBRATO ) {
-		vibStrength = (Bit8u)(freq >> 7);
+		vibStrength = (uint8_t)(freq >> 7);
 
 #ifdef WAVE_PRECISION
 		vibrato = ( vibStrength * freqMul ) >> block;
@@ -371,7 +371,7 @@ void Operator::UpdateFrequency(  ) {
 void Operator::UpdateRates( const Chip* chip ) {
 	//Mame seems to reverse this where enabling ksr actually lowers
 	//the rate, but pdf manuals says otherwise?
-	Bit8u newKsr = (Bit8u)((chanData >> SHIFT_KEYCODE) & 0xff);
+	uint8_t newKsr = (uint8_t)((chanData >> SHIFT_KEYCODE) & 0xff);
 	if ( !( reg20 & MASK_KSR ) ) {
 		newKsr >>= 2;
 	}
@@ -383,17 +383,17 @@ void Operator::UpdateRates( const Chip* chip ) {
 	UpdateRelease( chip );
 }
 
-inline Bit32s Operator::RateForward( Bit32u add ) {
+inline int32_t Operator::RateForward( uint32_t add ) {
 	rateIndex += add;
-	Bit32s ret = rateIndex >> RATE_SH;
+	int32_t ret = rateIndex >> RATE_SH;
 	rateIndex = rateIndex & RATE_MASK;
 	return ret;
 }
 
 template< Operator::State yes>
 Bits Operator::TemplateVolume(  ) {
-	Bit32s vol = volume;
-	Bit32s change;
+	int32_t vol = volume;
+	int32_t change;
 	switch ( yes ) {
 	case OFF:
 		return ENV_MAX;
@@ -460,13 +460,13 @@ inline Bitu Operator::ForwardWave() {
 	return waveIndex >> WAVE_SH;
 }
 
-void Operator::Write20( const Chip* chip, Bit8u val ) {
-	Bit8u change = (reg20 ^ val );
+void Operator::Write20( const Chip* chip, uint8_t val ) {
+	uint8_t change = (reg20 ^ val );
 	if ( !change ) 
 		return;
 	reg20 = val;
 	//Shift the tremolo bit over the entire register, saved a branch, YES!
-	tremoloMask = (Bit8s)(val) >> 7;
+	tremoloMask = (int8_t)(val) >> 7;
 	tremoloMask &= ~(( 1 << ENV_EXTRA ) -1);
 	//Update specific features based on changes
 	if ( change & MASK_KSR ) {
@@ -485,15 +485,15 @@ void Operator::Write20( const Chip* chip, Bit8u val ) {
 	}
 }
 
-void Operator::Write40( const Chip* /*chip*/, Bit8u val ) {
+void Operator::Write40( const Chip* /*chip*/, uint8_t val ) {
 	if (!(reg40 ^ val )) 
 		return;
 	reg40 = val;
 	UpdateAttenuation( );
 }
 
-void Operator::Write60( const Chip* chip, Bit8u val ) {
-	Bit8u change = reg60 ^ val;
+void Operator::Write60( const Chip* chip, uint8_t val ) {
+	uint8_t change = reg60 ^ val;
 	reg60 = val;
 	if ( change & 0x0f ) {
 		UpdateDecay( chip );
@@ -503,12 +503,12 @@ void Operator::Write60( const Chip* chip, Bit8u val ) {
 	}
 }
 
-void Operator::Write80( const Chip* chip, Bit8u val ) {
-	Bit8u change = (reg80 ^ val );
+void Operator::Write80( const Chip* chip, uint8_t val ) {
+	uint8_t change = (reg80 ^ val );
 	if ( !change ) 
 		return;
 	reg80 = val;
-	Bit8u sustain = val >> 4;
+	uint8_t sustain = val >> 4;
 	//Turn 0xf into 0x1f
 	sustain |= ( sustain + 1) & 0x10;
 	sustainLevel = sustain << ( ENV_BITS - 5 );
@@ -517,11 +517,11 @@ void Operator::Write80( const Chip* chip, Bit8u val ) {
 	}
 }
 
-void Operator::WriteE0( const Chip* chip, Bit8u val ) {
+void Operator::WriteE0( const Chip* chip, uint8_t val ) {
 	if ( !(regE0 ^ val) ) 
 		return;
 	//in opl3 mode you can always selet 7 waveforms regardless of waveformselect
-	const Bit8u waveForm = val & ( ( 0x3 & chip->waveFormMask ) | (0x7 & chip->opl3Active ) );
+	const uint8_t waveForm = val & ( ( 0x3 & chip->waveFormMask ) | (0x7 & chip->opl3Active ) );
 	regE0 = val;
 #if ( DBOPL_WAVE == WAVE_HANDLER )
 	waveHandler = WaveHandlerTable[ waveForm ];
@@ -532,7 +532,7 @@ void Operator::WriteE0( const Chip* chip, Bit8u val ) {
 #endif
 }
 
-inline void Operator::SetState( Bit8u s ) {
+inline void Operator::SetState( uint8_t s ) {
 	state = s;
 	volHandler = VolumeHandlerTable[ s ];
 }
@@ -549,16 +549,16 @@ inline void Operator::Prepare( const Chip* chip )  {
 	currentLevel = totalLevel + (chip->tremoloValue & tremoloMask);
 	waveCurrent = waveAdd;
 	if ( vibStrength >> chip->vibratoShift ) {
-		Bit32s add = vibrato >> chip->vibratoShift;
+		int32_t add = vibrato >> chip->vibratoShift;
 		//Sign extend over the shift value
-		Bit32s neg = chip->vibratoSign;
+		int32_t neg = chip->vibratoSign;
 		//Negate the add with -1 or 0
 		add = ( add ^ neg ) - neg; 
 		waveCurrent += add;
 	}
 }
 
-void Operator::KeyOn( Bit8u mask ) {
+void Operator::KeyOn( uint8_t mask ) {
 	if ( !keyOn ) {
 		//Restart the frequency generator
 #if ( DBOPL_WAVE > WAVE_HANDLER )
@@ -572,7 +572,7 @@ void Operator::KeyOn( Bit8u mask ) {
 	keyOn |= mask;
 }
 
-void Operator::KeyOff( Bit8u mask ) {
+void Operator::KeyOff( uint8_t mask ) {
 	keyOn &= ~mask;
 	if ( !keyOn ) {
 		if ( state != OFF ) {
@@ -587,11 +587,11 @@ inline Bits Operator::GetWave( Bitu index, Bitu vol ) {
 #elif ( DBOPL_WAVE == WAVE_TABLEMUL )
 	return (waveBase[ index & waveMask ] * MulTable[ vol >> ENV_EXTRA ]) >> MUL_SH;
 #elif ( DBOPL_WAVE == WAVE_TABLELOG )
-	Bit32s wave = waveBase[ index & waveMask ];
-	Bit32u total = ( wave & 0x7fff ) + vol << ( 3 - ENV_EXTRA );
-	Bit32s sig = ExpTable[ total & 0xff ];
-	Bit32u exp = total >> 8;
-	Bit32s neg = wave >> 16;
+	int32_t wave = waveBase[ index & waveMask ];
+	uint32_t total = ( wave & 0x7fff ) + vol << ( 3 - ENV_EXTRA );
+	int32_t sig = ExpTable[ total & 0xff ];
+	uint32_t exp = total >> 8;
+	int32_t neg = wave >> 16;
 	return ((sig ^ neg) - neg) >> exp;
 #else
 #error "No valid wave routine"
@@ -661,8 +661,8 @@ Channel::Channel()
           maskRight(-1)
 {}
 
-void Channel::SetChanData( const Chip* chip, Bit32u data ) {
-	Bit32u change = chanData ^ data;
+void Channel::SetChanData( const Chip* chip, uint32_t data ) {
+	uint32_t change = chanData ^ data;
 	chanData = data;
 	Op( 0 )->chanData = data;
 	Op( 1 )->chanData = data;
@@ -679,11 +679,11 @@ void Channel::SetChanData( const Chip* chip, Bit32u data ) {
 	}
 }
 
-void Channel::UpdateFrequency( const Chip* chip, Bit8u fourOp ) {
+void Channel::UpdateFrequency( const Chip* chip, uint8_t fourOp ) {
 	//Extrace the frequency bits
-	Bit32u data = chanData & 0xffff;
-	Bit32u kslBase = KslTable[ data >> 6 ];
-	Bit32u keyCode = ( data & 0x1c00) >> 9;
+	uint32_t data = chanData & 0xffff;
+	uint32_t kslBase = KslTable[ data >> 6 ];
+	uint32_t keyCode = ( data & 0x1c00) >> 9;
 	if ( chip->reg08 & 0x40 ) {
 		keyCode |= ( data & 0x100)>>8;	/* notesel == 1 */
 	} else {
@@ -697,20 +697,20 @@ void Channel::UpdateFrequency( const Chip* chip, Bit8u fourOp ) {
 	}
 }
 
-void Channel::WriteA0( const Chip* chip, Bit8u val ) {
-	Bit8u fourOp = chip->reg104 & chip->opl3Active & fourMask;
+void Channel::WriteA0( const Chip* chip, uint8_t val ) {
+	uint8_t fourOp = chip->reg104 & chip->opl3Active & fourMask;
 	//Don't handle writes to silent fourop channels
 	if ( fourOp > 0x80 )
 		return;
-	Bit32u change = (chanData ^ val ) & 0xff;
+	uint32_t change = (chanData ^ val ) & 0xff;
 	if ( change ) {
 		chanData ^= change;
 		UpdateFrequency( chip, fourOp );
 	}
 }
 
-void Channel::WriteB0( const Chip* chip, Bit8u val ) {
-	Bit8u fourOp = chip->reg104 & chip->opl3Active & fourMask;
+void Channel::WriteB0( const Chip* chip, uint8_t val ) {
+	uint8_t fourOp = chip->reg104 & chip->opl3Active & fourMask;
 	//Don't handle writes to silent fourop channels
 	if ( fourOp > 0x80 )
 		return;
@@ -740,8 +740,8 @@ void Channel::WriteB0( const Chip* chip, Bit8u val ) {
 	}
 }
 
-void Channel::WriteC0(const Chip* chip, Bit8u val) {
-	Bit8u change = val ^ regC0;
+void Channel::WriteC0(const Chip* chip, uint8_t val) {
+	uint8_t change = val ^ regC0;
 	if (!change)
 		return;
 	regC0 = val;
@@ -771,7 +771,7 @@ void Channel::UpdateSynth( const Chip* chip ) {
 				chan1 = this;
 			}
 
-			Bit8u synth = ( (chan0->regC0 & 1) << 0 )| (( chan1->regC0 & 1) << 1 );
+			uint8_t synth = ( (chan0->regC0 & 1) << 0 )| (( chan1->regC0 & 1) << 1 );
 			switch ( synth ) {
 			case 0:
 				chan0->synthHandler = &Channel::BlockTemplate< sm3FMFM >;
@@ -812,11 +812,11 @@ void Channel::UpdateSynth( const Chip* chip ) {
 }
 
 template< bool opl3Mode>
-inline void Channel::GeneratePercussion( Chip* chip, Bit32s* output ) {
+inline void Channel::GeneratePercussion( Chip* chip, int32_t* output ) {
 	Channel* chan = this;
 
 	//BassDrum
-	Bit32s mod = (Bit32u)((old[0] + old[1])) >> feedback;
+	int32_t mod = (uint32_t)((old[0] + old[1])) >> feedback;
 	old[0] = old[1];
 	old[1] = Op(0)->GetSample( mod ); 
 
@@ -826,34 +826,34 @@ inline void Channel::GeneratePercussion( Chip* chip, Bit32s* output ) {
 	} else {
 		mod = old[0];
 	}
-	Bit32s sample = Op(1)->GetSample( mod ); 
+	int32_t sample = Op(1)->GetSample( mod ); 
 
 
 	//Precalculate stuff used by other outputs
-	Bit32u noiseBit = chip->ForwardNoise() & 0x1;
-	Bit32u c2 = Op(2)->ForwardWave();
-	Bit32u c5 = Op(5)->ForwardWave();
-	Bit32u phaseBit = (((c2 & 0x88) ^ ((c2<<5) & 0x80)) | ((c5 ^ (c5<<2)) & 0x20)) ? 0x02 : 0x00;
+	uint32_t noiseBit = chip->ForwardNoise() & 0x1;
+	uint32_t c2 = Op(2)->ForwardWave();
+	uint32_t c5 = Op(5)->ForwardWave();
+	uint32_t phaseBit = (((c2 & 0x88) ^ ((c2<<5) & 0x80)) | ((c5 ^ (c5<<2)) & 0x20)) ? 0x02 : 0x00;
 
 	//Hi-Hat
-	Bit32u hhVol = Op(2)->ForwardVolume();
+	uint32_t hhVol = Op(2)->ForwardVolume();
 	if ( !ENV_SILENT( hhVol ) ) {
-		Bit32u hhIndex = (phaseBit<<8) | (0x34 << ( phaseBit ^ (noiseBit << 1 )));
+		uint32_t hhIndex = (phaseBit<<8) | (0x34 << ( phaseBit ^ (noiseBit << 1 )));
 		sample += Op(2)->GetWave( hhIndex, hhVol );
 	}
 	//Snare Drum
-	Bit32u sdVol = Op(3)->ForwardVolume();
+	uint32_t sdVol = Op(3)->ForwardVolume();
 	if ( !ENV_SILENT( sdVol ) ) {
-		Bit32u sdIndex = ( 0x100 + (c2 & 0x100) ) ^ ( noiseBit << 8 );
+		uint32_t sdIndex = ( 0x100 + (c2 & 0x100) ) ^ ( noiseBit << 8 );
 		sample += Op(3)->GetWave( sdIndex, sdVol );
 	}
 	//Tom-tom
 	sample += Op(4)->GetSample( 0 );
 
 	//Top-Cymbal
-	Bit32u tcVol = Op(5)->ForwardVolume();
+	uint32_t tcVol = Op(5)->ForwardVolume();
 	if ( !ENV_SILENT( tcVol ) ) {
-		Bit32u tcIndex = (1 + phaseBit) << 8;
+		uint32_t tcIndex = (1 + phaseBit) << 8;
 		sample += Op(5)->GetWave( tcIndex, tcVol );
 	}
 	sample *= 2; // don't bit-shift signed values
@@ -866,7 +866,7 @@ inline void Channel::GeneratePercussion( Chip* chip, Bit32s* output ) {
 }
 
 template <SynthMode mode>
-Channel *Channel::BlockTemplate(Chip *chip, const uint16_t samples, Bit32s *output)
+Channel *Channel::BlockTemplate(Chip *chip, const uint16_t samples, int32_t *output)
 {
 	switch (mode) {
 	case sm2AM:
@@ -933,11 +933,11 @@ Channel *Channel::BlockTemplate(Chip *chip, const uint16_t samples, Bit32s *outp
 		}
 
 		//Do unsigned shift so we can shift out all bits but still stay in 10 bit range otherwise
-		Bit32s mod = (Bit32u)((old[0] + old[1])) >> feedback;
+		int32_t mod = (uint32_t)((old[0] + old[1])) >> feedback;
 		old[0] = old[1];
 		old[1] = Op(0)->GetSample( mod );
-		Bit32s sample;
-		Bit32s out0 = old[0];
+		int32_t sample;
+		int32_t out0 = old[0];
 		if ( mode == sm2AM || mode == sm3AM ) {
 			sample = out0 + Op(1)->GetSample( 0 );
 		} else if ( mode == sm2FM || mode == sm3FM ) {
@@ -1004,7 +1004,7 @@ Channel *Channel::BlockTemplate(Chip *chip, const uint16_t samples, Bit32s *outp
 Chip::Chip(bool _opl3Mode) : opl3Mode(_opl3Mode)
 {}
 
-inline Bit32u Chip::ForwardNoise() {
+inline uint32_t Chip::ForwardNoise() {
 	noiseCounter += noiseAdd;
 	Bitu count = noiseCounter >> LFO_SH;
 	noiseCounter &= ((1<<LFO_SH) - 1);
@@ -1016,7 +1016,7 @@ inline Bit32u Chip::ForwardNoise() {
 	return noiseValue;
 }
 
-inline Bit32u Chip::ForwardLFO(const uint16_t samples)
+inline uint32_t Chip::ForwardLFO(const uint16_t samples)
 {
 	// Current vibrato value, runs 4x slower than tremolo
 	const auto vibrato = VibratoTable[vibratoIndex >> 2];
@@ -1026,8 +1026,8 @@ inline Bit32u Chip::ForwardLFO(const uint16_t samples)
 	tremoloValue = TremoloTable[tremoloIndex] >> tremoloStrength;
 
 	//Check hom many samples there can be done before the value changes
-	Bit32u todo = LFO_MAX - lfoCounter;
-	Bit32u count = (todo + lfoAdd - 1) / lfoAdd;
+	uint32_t todo = LFO_MAX - lfoCounter;
+	uint32_t count = (todo + lfoAdd - 1) / lfoAdd;
 	if ( count > samples ) {
 		count = samples;
 		lfoCounter += count * lfoAdd;
@@ -1045,8 +1045,8 @@ inline Bit32u Chip::ForwardLFO(const uint16_t samples)
 	return count;
 }
 
-void Chip::WriteBD( Bit8u val ) {
-	Bit8u change = regBD ^ val;
+void Chip::WriteBD( uint8_t val ) {
+	uint8_t change = regBD ^ val;
 	if ( !change )
 		return;
 	regBD = val;
@@ -1130,7 +1130,7 @@ void Chip::UpdateSynths() {
 }
 
 
-void Chip::WriteReg( Bit32u reg, Bit8u val ) {
+void Chip::WriteReg( uint32_t reg, uint8_t val ) {
 	Bitu index;
 	switch ( (reg & 0xf0) >> 4 ) {
 	case 0x00 >> 4:
@@ -1195,7 +1195,7 @@ void Chip::WriteReg( Bit32u reg, Bit8u val ) {
 	}
 }
 
-Bit32u Chip::WriteAddr(uint16_t port, Bit8u val)
+uint32_t Chip::WriteAddr(uint16_t port, uint8_t val)
 {
 	switch (port & 3) {
 	case 0: return val;
@@ -1208,11 +1208,11 @@ Bit32u Chip::WriteAddr(uint16_t port, Bit8u val)
 	return 0;
 }
 
-void Chip::GenerateBlock2(uint16_t total, Bit32s *output)
+void Chip::GenerateBlock2(uint16_t total, int32_t *output)
 {
 	while (total > 0) {
 		const auto samples = ForwardLFO(total);
-		memset(output, 0, sizeof(Bit32s) * samples);
+		memset(output, 0, sizeof(int32_t) * samples);
 		//		int count = 0;
 		for( Channel* ch = chan; ch < chan + 9; ) {
 //			count++;
@@ -1223,11 +1223,11 @@ void Chip::GenerateBlock2(uint16_t total, Bit32s *output)
 	}
 }
 
-void Chip::GenerateBlock3(uint16_t total, Bit32s *output)
+void Chip::GenerateBlock3(uint16_t total, int32_t *output)
 {
 	while (total > 0) {
 		const auto samples = ForwardLFO(total);
-		memset(output, 0, sizeof(Bit32s) * samples * 2);
+		memset(output, 0, sizeof(int32_t) * samples * 2);
 		//		int count = 0;
 		for (Channel *ch = chan; ch < chan + 18;) {
 			//			count++;
@@ -1238,18 +1238,18 @@ void Chip::GenerateBlock3(uint16_t total, Bit32s *output)
 	}
 }
 
-void Chip::Setup( Bit32u rate ) {
+void Chip::Setup( uint32_t rate ) {
 	double original = OPLRATE;
 //	double original = rate;
 	double scale = original / (double)rate;
 
 	//Noise counter is run at the same precision as general waves
-	noiseAdd = (Bit32u)( 0.5 + scale * ( 1 << LFO_SH ) );
+	noiseAdd = (uint32_t)( 0.5 + scale * ( 1 << LFO_SH ) );
 	noiseCounter = 0;
 	noiseValue = 1;	//Make sure it triggers the noise xor the first time
 	//The low frequency oscillation counter
 	//Every time his overflows vibrato and tremoloindex are increased
-	lfoAdd = (Bit32u)( 0.5 + scale * ( 1 << LFO_SH ) );
+	lfoAdd = (uint32_t)( 0.5 + scale * ( 1 << LFO_SH ) );
 	lfoCounter = 0;
 	vibratoIndex = 0;
 	tremoloIndex = 0;
@@ -1259,39 +1259,39 @@ void Chip::Setup( Bit32u rate ) {
 #ifdef WAVE_PRECISION
 	double freqScale = ( 1 << 7 ) * scale * ( 1 << ( WAVE_SH - 1 - 10));
 	for ( int i = 0; i < 16; i++ ) {
-		freqMul[i] = (Bit32u)( 0.5 + freqScale * FreqCreateTable[ i ] );
+		freqMul[i] = (uint32_t)( 0.5 + freqScale * FreqCreateTable[ i ] );
 	}
 #else
-	Bit32u freqScale = (Bit32u)( 0.5 + scale * ( 1 << ( WAVE_SH - 1 - 10)));
+	uint32_t freqScale = (uint32_t)( 0.5 + scale * ( 1 << ( WAVE_SH - 1 - 10)));
 	for ( int i = 0; i < 16; i++ ) {
 		freqMul[i] = freqScale * FreqCreateTable[ i ];
 	}
 #endif
 
 	//-3 since the real envelope takes 8 steps to reach the single value we supply
-	for ( Bit8u i = 0; i < 76; i++ ) {
-		Bit8u index, shift;
+	for ( uint8_t i = 0; i < 76; i++ ) {
+		uint8_t index, shift;
 		EnvelopeSelect( i, index, shift );
-		linearRates[i] = (Bit32u)( scale * (EnvelopeIncreaseTable[ index ] << ( RATE_SH + ENV_EXTRA - shift - 3 )));
+		linearRates[i] = (uint32_t)( scale * (EnvelopeIncreaseTable[ index ] << ( RATE_SH + ENV_EXTRA - shift - 3 )));
 	}
-//	Bit32s attackDiffs[62];
+//	int32_t attackDiffs[62];
 	//Generate the best matching attack rate
-	for ( Bit8u i = 0; i < 62; i++ ) {
-		Bit8u index, shift;
+	for ( uint8_t i = 0; i < 62; i++ ) {
+		uint8_t index, shift;
 		EnvelopeSelect( i, index, shift );
 		//Original amount of samples the attack would take
-		Bit32s original = (Bit32u)( (AttackSamplesTable[ index ] << shift) / scale);
+		int32_t original = (uint32_t)( (AttackSamplesTable[ index ] << shift) / scale);
 		 
-		Bit32s guessAdd = (Bit32u)( scale * (EnvelopeIncreaseTable[ index ] << ( RATE_SH - shift - 3 )));
-		Bit32s bestAdd = guessAdd;
-		Bit32u bestDiff = 1 << 30;
-		for( Bit32u passes = 0; passes < 16; passes ++ ) {
-			Bit32s volume = ENV_MAX;
-			Bit32s samples = 0;
-			Bit32u count = 0;
+		int32_t guessAdd = (uint32_t)( scale * (EnvelopeIncreaseTable[ index ] << ( RATE_SH - shift - 3 )));
+		int32_t bestAdd = guessAdd;
+		uint32_t bestDiff = 1 << 30;
+		for( uint32_t passes = 0; passes < 16; passes ++ ) {
+			int32_t volume = ENV_MAX;
+			int32_t samples = 0;
+			uint32_t count = 0;
 			while ( volume > 0 && samples < original * 2 ) {
 				count += guessAdd;
-				Bit32s change = count >> RATE_SH;
+				int32_t change = count >> RATE_SH;
 				count &= RATE_MASK;
 				if ( GCC_UNLIKELY(change) ) { // less than 1 % 
 					volume += ( ~volume * change ) >> 3;
@@ -1299,8 +1299,8 @@ void Chip::Setup( Bit32u rate ) {
 				samples++;
 
 			}
-			Bit32s diff = original - samples;
-			Bit32u lDiff = labs( diff );
+			int32_t diff = original - samples;
+			uint32_t lDiff = labs( diff );
 			//Init last on first pass
 			if ( lDiff < bestDiff ) {
 				bestDiff = lDiff;
@@ -1311,7 +1311,7 @@ void Chip::Setup( Bit32u rate ) {
 			}
 			//Linear correction factor, not exactly perfect but seems to work
 			double correct = (original - diff) / (double)original;
-			guessAdd = (Bit32u)(guessAdd * correct); 
+			guessAdd = (uint32_t)(guessAdd * correct); 
 			//Below our target
 			if ( diff < 0 ) {
 				//Always add one here for rounding, an overshoot will get corrected by another pass decreasing
@@ -1322,7 +1322,7 @@ void Chip::Setup( Bit32u rate ) {
 		//Keep track of the diffs for some debugging
 //		attackDiffs[i] = bestDiff;
 	}
-	for ( Bit8u i = 62; i < 76; i++ ) {
+	for ( uint8_t i = 62; i < 76; i++ ) {
 		//This should provide instant volume maximizing
 		attackRates[i] = 8 << RATE_SH;
 	}
@@ -1382,7 +1382,7 @@ void InitTables( void ) {
 	//Add 0.5 for the trunc rounding of the integer cast
 	//Do a PI sinetable instead of the original 0.5 PI
 	for ( int i = 0; i < 512; i++ ) {
-		SinTable[i] = (Bit16s)(0.5 - log10(sin((i + 0.5) * (M_PI / 512.0))) /
+		SinTable[i] = (int16_t)(0.5 - log10(sin((i + 0.5) * (M_PI / 512.0))) /
 		                                     log10(2.0) * 256);
 	}
 #endif
@@ -1392,33 +1392,33 @@ void InitTables( void ) {
 		int s = i * 8;
 		//TODO maybe keep some of the precision errors of the original table?
 		double val = ( 0.5 + ( pow(2.0, -1.0 + ( 255 - s) * ( 1.0 /256 ) )) * ( 1 << MUL_SH ));
-		MulTable[i] = (Bit16u)(val);
+		MulTable[i] = (uint16_t)(val);
 	}
 
 	//Sine Wave Base
 	for ( int i = 0; i < 512; i++ ) {
-		WaveTable[0x0200 + i] = (Bit16s)(
+		WaveTable[0x0200 + i] = (int16_t)(
 		        sin((i + 0.5) * (M_PI / 512.0)) * 4084);
 		WaveTable[ 0x0000 + i ] = -WaveTable[ 0x200 + i ];
 	}
 	//Exponential wave
 	for ( int i = 0; i < 256; i++ ) {
-		WaveTable[ 0x700 + i ] = (Bit16s)( 0.5 + ( pow(2.0, -1.0 + ( 255 - i * 8) * ( 1.0 /256 ) ) ) * 4085 );
+		WaveTable[ 0x700 + i ] = (int16_t)( 0.5 + ( pow(2.0, -1.0 + ( 255 - i * 8) * ( 1.0 /256 ) ) ) * 4085 );
 		WaveTable[ 0x6ff - i ] = -WaveTable[ 0x700 + i ];
 	}
 #endif
 #if ( DBOPL_WAVE == WAVE_TABLELOG )
 	//Sine Wave Base
 	for ( int i = 0; i < 512; i++ ) {
-		WaveTable[0x0200 + i] = (Bit16s)(
+		WaveTable[0x0200 + i] = (int16_t)(
 		        0.5 - log10(sin((i + 0.5) * (M_PI / 512.0))) /
 		                      log10(2.0) * 256);
-		WaveTable[ 0x0000 + i ] = ((Bit16s)0x8000) | WaveTable[ 0x200 + i];
+		WaveTable[ 0x0000 + i ] = ((int16_t)0x8000) | WaveTable[ 0x200 + i];
 	}
 	//Exponential wave
 	for ( int i = 0; i < 256; i++ ) {
 		WaveTable[ 0x700 + i ] = i * 8;
-		WaveTable[ 0x6ff - i ] = ((Bit16s)0x8000) | i * 8;
+		WaveTable[ 0x6ff - i ] = ((int16_t)0x8000) | i * 8;
 	} 
 #endif
 
@@ -1457,7 +1457,7 @@ void InitTables( void ) {
 	}
 	//Create the Tremolo table, just increase and decrease a triangle wave
 	for (uint8_t i = 0; i < TREMOLO_TABLE / 2; i++) {
-		Bit8u val = i << ENV_EXTRA;
+		uint8_t val = i << ENV_EXTRA;
 		TremoloTable[i] = val;
 		TremoloTable[TREMOLO_TABLE - 1 - i] = val;
 	}
@@ -1482,7 +1482,7 @@ void InitTables( void ) {
 		              "offset table stores values relative to the start of struct");
 		// values stored in offset tables are artificially increased by 1
 		// to keep macros REGCHAN and REGOP working correctly
-		ChanOffsetTable[i] = 1+(Bit16u)(index*sizeof(DBOPL::Channel));
+		ChanOffsetTable[i] = 1+(uint16_t)(index*sizeof(DBOPL::Channel));
 	}
 	//Same for operators
 	for (uint8_t i = 0; i < 64; i++) {
@@ -1500,14 +1500,14 @@ void InitTables( void ) {
 		              "struct Channel is not a standard layout type");
 		static_assert(offsetof(Channel, op) == 0,
 		              "offset table stores values relative to the start of struct");
-		OpOffsetTable[i] = ChanOffsetTable[chNum]+(Bit16u)(opNum*sizeof(DBOPL::Operator));
+		OpOffsetTable[i] = ChanOffsetTable[chNum]+(uint16_t)(opNum*sizeof(DBOPL::Operator));
 		assert(OpOffsetTable[i] > 0); // needs to be non-zero; see REGOP macro
 	}
 #if 0
 	DBOPL::Chip* chip = 0;
 	//Stupid checks if table's are correct
 	for ( uint8_t i = 0; i < 18; i++ ) {
-		Bit32u find = (Bit16u)( &(chip->chan[ i ]) );
+		uint32_t find = (uint16_t)( &(chip->chan[ i ]) );
 		for ( uint8_t c = 0; c < 32; c++ ) {
 			if ( ChanOffsetTable[c] == find+1 ) {
 				find = 0;
@@ -1519,7 +1519,7 @@ void InitTables( void ) {
 		}
 	}
 	for ( uint8_t i = 0; i < 36; i++ ) {
-		Bit32u find = (Bit16u)( &(chip->chan[ i / 2 ].op[i % 2]) );
+		uint32_t find = (uint16_t)( &(chip->chan[ i / 2 ].op[i % 2]) );
 		for ( uint8_t c = 0; c < 64; c++ ) {
 			if ( OpOffsetTable[c] == find+1 ) {
 				find = 0;
@@ -1533,17 +1533,17 @@ void InitTables( void ) {
 #endif
 }
 
-Bit32u Handler::WriteAddr(io_port_t port, Bit8u val)
+uint32_t Handler::WriteAddr(io_port_t port, uint8_t val)
 {
 	return chip.WriteAddr(port, val);
 }
-void Handler::WriteReg( Bit32u addr, Bit8u val ) {
+void Handler::WriteReg( uint32_t addr, uint8_t val ) {
 	chip.WriteReg( addr, val );
 }
 
 void Handler::Generate(mixer_channel_t &chan, uint16_t samples)
 {
-	Bit32s buffer[512 * 2];
+	int32_t buffer[512 * 2];
 	if (GCC_UNLIKELY(samples > 512))
 		samples = 512;
 	if ( !chip.opl3Active ) {

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -42,7 +42,7 @@ typedef Bits (*WaveHandler)(Bitu i, Bitu volume);
 typedef Bits ( DBOPL::Operator::*VolumeHandler) ( );
 typedef Channel *(DBOPL::Channel::*SynthHandler)(Chip *chip,
                                                  uint16_t samples,
-                                                 Bit32s *output);
+                                                 int32_t *output);
 
 //Different synth modes that can generate blocks of data
 typedef enum {
@@ -89,41 +89,41 @@ public:
 #if (DBOPL_WAVE == WAVE_HANDLER)
 	WaveHandler waveHandler;	//Routine that generate a wave 
 #else
-	Bit16s* waveBase;
-	Bit32u waveMask;
-	Bit32u waveStart;
+	int16_t* waveBase;
+	uint32_t waveMask;
+	uint32_t waveStart;
 #endif
-	Bit32u waveIndex;			//WAVE_BITS shifted counter of the frequency index
-	Bit32u waveAdd;				//The base frequency without vibrato
-	Bit32u waveCurrent;			//waveAdd + vibratao
+	uint32_t waveIndex;			//WAVE_BITS shifted counter of the frequency index
+	uint32_t waveAdd;				//The base frequency without vibrato
+	uint32_t waveCurrent;			//waveAdd + vibratao
 
-	Bit32u chanData;			//Frequency/octave and derived data coming from whatever channel controls this
-	Bit32u freqMul;				//Scale channel frequency with this, TODO maybe remove?
-	Bit32u vibrato;				//Scaled up vibrato strength
-	Bit32s sustainLevel;		//When stopping at sustain level stop here
-	Bit32s totalLevel;			//totalLevel is added to every generated volume
-	Bit32u currentLevel;		//totalLevel + tremolo
-	Bit32s volume;				//The currently active volume
+	uint32_t chanData;			//Frequency/octave and derived data coming from whatever channel controls this
+	uint32_t freqMul;				//Scale channel frequency with this, TODO maybe remove?
+	uint32_t vibrato;				//Scaled up vibrato strength
+	int32_t sustainLevel;		//When stopping at sustain level stop here
+	int32_t totalLevel;			//totalLevel is added to every generated volume
+	uint32_t currentLevel;		//totalLevel + tremolo
+	int32_t volume;				//The currently active volume
 	
-	Bit32u attackAdd;			//Timers for the different states of the envelope
-	Bit32u decayAdd;
-	Bit32u releaseAdd;
-	Bit32u rateIndex;			//Current position of the evenlope
+	uint32_t attackAdd;			//Timers for the different states of the envelope
+	uint32_t decayAdd;
+	uint32_t releaseAdd;
+	uint32_t rateIndex;			//Current position of the evenlope
 
-	Bit8u rateZero;				//Bits for the different states of the envelope having no changes
-	Bit8u keyOn;				//Bitmask of different values that can generate keyon
+	uint8_t rateZero;				//Bits for the different states of the envelope having no changes
+	uint8_t keyOn;				//Bitmask of different values that can generate keyon
 	//Registers, also used to check for changes
-	Bit8u reg20, reg40, reg60, reg80, regE0;
+	uint8_t reg20, reg40, reg60, reg80, regE0;
 	//Active part of the envelope we're in
-	Bit8u state;
+	uint8_t state;
 	//0xff when tremolo is enabled
-	Bit8u tremoloMask;
+	uint8_t tremoloMask;
 	//Strength of the vibrato
-	Bit8u vibStrength;
+	uint8_t vibStrength;
 	//Keep track of the calculated KSR so we can check for changes
-	Bit8u ksr;
+	uint8_t ksr;
 private:
-	void SetState( Bit8u s );
+	void SetState( uint8_t s );
 	void UpdateAttack( const Chip* chip );
 	void UpdateRelease( const Chip* chip );
 	void UpdateDecay( const Chip* chip );
@@ -132,22 +132,22 @@ public:
 	void UpdateRates( const Chip* chip );
 	void UpdateFrequency( );
 
-	void Write20( const Chip* chip, Bit8u val );
-	void Write40( const Chip* chip, Bit8u val );
-	void Write60( const Chip* chip, Bit8u val );
-	void Write80( const Chip* chip, Bit8u val );
-	void WriteE0( const Chip* chip, Bit8u val );
+	void Write20( const Chip* chip, uint8_t val );
+	void Write40( const Chip* chip, uint8_t val );
+	void Write60( const Chip* chip, uint8_t val );
+	void Write80( const Chip* chip, uint8_t val );
+	void WriteE0( const Chip* chip, uint8_t val );
 
 	bool Silent() const;
 	void Prepare( const Chip* chip );
 
-	void KeyOn( Bit8u mask);
-	void KeyOff( Bit8u mask);
+	void KeyOn( uint8_t mask);
+	void KeyOff( uint8_t mask);
 
 	template< State state>
 	Bits TemplateVolume( );
 
-	Bit32s RateForward( Bit32u add );
+	int32_t RateForward( uint32_t add );
 	Bitu ForwardWave();
 	Bitu ForwardVolume();
 
@@ -163,33 +163,33 @@ struct Channel {
 		return &( ( this + (index >> 1) )->op[ index & 1 ]);
 	}
 	SynthHandler synthHandler;
-	Bit32u chanData;		//Frequency/octave and derived values
-	Bit32s old[2];			//Old data for feedback
+	uint32_t chanData;		//Frequency/octave and derived values
+	int32_t old[2];			//Old data for feedback
 
-	Bit8u feedback;			//Feedback shift
-	Bit8u regB0;			//Register values to check for changes
-	Bit8u regC0;
+	uint8_t feedback;			//Feedback shift
+	uint8_t regB0;			//Register values to check for changes
+	uint8_t regC0;
 	//This should correspond with reg104, bit 6 indicates a Percussion channel, bit 7 indicates a silent channel
-	Bit8u fourMask;
-	Bit8s maskLeft;		//Sign extended values for both channel's panning
-	Bit8s maskRight;
+	uint8_t fourMask;
+	int8_t maskLeft;		//Sign extended values for both channel's panning
+	int8_t maskRight;
 
 	//Forward the channel data to the operators of the channel
-	void SetChanData( const Chip* chip, Bit32u data );
+	void SetChanData( const Chip* chip, uint32_t data );
 	//Change in the chandata, check for new values and if we have to forward to operators
-	void UpdateFrequency( const Chip* chip, Bit8u fourOp );
+	void UpdateFrequency( const Chip* chip, uint8_t fourOp );
 	void UpdateSynth(const Chip* chip);
-	void WriteA0( const Chip* chip, Bit8u val );
-	void WriteB0( const Chip* chip, Bit8u val );
-	void WriteC0( const Chip* chip, Bit8u val );
+	void WriteA0( const Chip* chip, uint8_t val );
+	void WriteB0( const Chip* chip, uint8_t val );
+	void WriteC0( const Chip* chip, uint8_t val );
 
 	//call this for the first channel
 	template< bool opl3Mode >
-	void GeneratePercussion( Chip* chip, Bit32s* output );
+	void GeneratePercussion( Chip* chip, int32_t* output );
 
 	//Generate blocks of data in specific modes
 	template <SynthMode mode>
-	Channel *BlockTemplate(Chip *chip, uint16_t samples, Bit32s *output);
+	Channel *BlockTemplate(Chip *chip, uint16_t samples, int32_t *output);
 	Channel();
 };
 
@@ -230,29 +230,29 @@ struct Chip {
 	const bool opl3Mode;
 
 	//Return the maximum amount of samples before and LFO change
-	Bit32u ForwardLFO(uint16_t samples);
-	Bit32u ForwardNoise();
+	uint32_t ForwardLFO(uint16_t samples);
+	uint32_t ForwardNoise();
 
-	void WriteBD( Bit8u val );
-	void WriteReg(Bit32u reg, Bit8u val );
+	void WriteBD( uint8_t val );
+	void WriteReg(uint32_t reg, uint8_t val );
 
-	Bit32u WriteAddr(uint16_t port, Bit8u val);
+	uint32_t WriteAddr(uint16_t port, uint8_t val);
 
-	void GenerateBlock2(uint16_t samples, Bit32s *output);
-	void GenerateBlock3(uint16_t samples, Bit32s *output);
+	void GenerateBlock2(uint16_t samples, int32_t *output);
+	void GenerateBlock3(uint16_t samples, int32_t *output);
 
 	//Update the synth handlers in all channels
 	void UpdateSynths();
 	void Generate(uint16_t samples);
-	void Setup( Bit32u r );
+	void Setup( uint32_t r );
 
 	Chip( bool opl3Mode );
 };
 
 struct Handler : public Adlib::Handler {
 	DBOPL::Chip chip;
-	virtual Bit32u WriteAddr(io_port_t port, Bit8u val);
-	virtual void WriteReg( Bit32u addr, Bit8u val );
+	virtual uint32_t WriteAddr(io_port_t port, uint8_t val);
+	virtual void WriteReg( uint32_t addr, uint8_t val );
 	virtual void Generate(mixer_channel_t &chan, uint16_t samples);
 	virtual void Init(uint32_t rate);
 

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -32,7 +32,7 @@
 DmaController *DmaControllers[2];
 
 #define EMM_PAGEFRAME4K ((0xE000 * 16) / MEM_PAGESIZE)
-Bit32u ems_board_mapping[LINK_START];
+uint32_t ems_board_mapping[LINK_START];
 
 constexpr uint16_t NULL_PAGE = 0xffff;
 static uint32_t dma_wrapping = NULL_PAGE; // initial value
@@ -100,7 +100,7 @@ static void perform_dma_io(const DMA_DIRECTION direction,
 	} while (remaining_bytes);
 }
 
-DmaChannel * GetDMAChannel(Bit8u chan) {
+DmaChannel * GetDMAChannel(uint8_t chan) {
 	if (chan<4) {
 		/* channel on first DMA controller */
 		if (DmaControllers[0]) return DmaControllers[0]->GetChannel(chan);
@@ -188,7 +188,7 @@ void DmaController::WriteControllerReg(io_port_t reg, io_val_t value, io_width_t
 	/* set base address of DMA transfer (1st byte low part, 2nd byte high part) */
 	case 0x0:case 0x2:case 0x4:case 0x6:
 		UpdateEMSMapping();
-		chan=GetChannel((Bit8u)(reg >> 1));
+		chan=GetChannel((uint8_t)(reg >> 1));
 		flipflop=!flipflop;
 		if (flipflop) {
 			chan->baseaddr=(chan->baseaddr&0xff00)|val;
@@ -201,7 +201,7 @@ void DmaController::WriteControllerReg(io_port_t reg, io_val_t value, io_width_t
 	/* set DMA transfer count (1st byte low part, 2nd byte high part) */
 	case 0x1:case 0x3:case 0x5:case 0x7:
 		UpdateEMSMapping();
-		chan=GetChannel((Bit8u)(reg >> 1));
+		chan=GetChannel((uint8_t)(reg >> 1));
 		flipflop=!flipflop;
 		if (flipflop) {
 			chan->basecnt=(chan->basecnt&0xff00)|val;
@@ -232,7 +232,7 @@ void DmaController::WriteControllerReg(io_port_t reg, io_val_t value, io_width_t
 		flipflop=false;
 		break;
 	case 0xd: /* Clear/Reset all channels */
-		for (Bit8u ct=0;ct<4;ct++) {
+		for (uint8_t ct=0;ct<4;ct++) {
 			chan=GetChannel(ct);
 			chan->SetMask(true);
 			chan->tcount=false;
@@ -241,14 +241,14 @@ void DmaController::WriteControllerReg(io_port_t reg, io_val_t value, io_width_t
 		break;
 	case 0xe:		/* Clear Mask register */		
 		UpdateEMSMapping();
-		for (Bit8u ct=0;ct<4;ct++) {
+		for (uint8_t ct=0;ct<4;ct++) {
 			chan=GetChannel(ct);
 			chan->SetMask(false);
 		}
 		break;
 	case 0xf:		/* Multiple Mask register */
 		UpdateEMSMapping();
-		for (Bit8u ct=0;ct<4;ct++) {
+		for (uint8_t ct=0;ct<4;ct++) {
 			chan=GetChannel(ct);
 			chan->SetMask(val & 1);
 			val>>=1;
@@ -267,7 +267,7 @@ uint16_t DmaController::ReadControllerReg(io_port_t reg, io_width_t)
 	case 0x2:
 	case 0x4:
 	case 0x6:
-		chan = GetChannel((Bit8u)(reg >> 1));
+		chan = GetChannel((uint8_t)(reg >> 1));
 		flipflop = !flipflop;
 		if (flipflop) {
 			return chan->curraddr & 0xff;
@@ -279,7 +279,7 @@ uint16_t DmaController::ReadControllerReg(io_port_t reg, io_width_t)
 	case 0x3:
 	case 0x5:
 	case 0x7:
-		chan = GetChannel((Bit8u)(reg >> 1));
+		chan = GetChannel((uint8_t)(reg >> 1));
 		flipflop = !flipflop;
 		if (flipflop) {
 			return chan->currcnt & 0xff;

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -37,7 +37,7 @@ constexpr uint32_t GAMEBLASTER_CLOCK_HZ = 7159090;
 //My mixer channel
 static mixer_channel_t cms_chan;
 //Timer to disable the channel after a while
-static Bit32u lastWriteTicks;
+static uint32_t lastWriteTicks;
 static io_port_t cmsBase;
 static saa1099_device* device[2];
 
@@ -79,9 +79,9 @@ static void CMS_CallBack(Bitu len) {
 			cms_chan->Enable( false );
 			return;
 		}
-		Bit32s result[BUFFER_SIZE][2];
-		Bit16s work[2][BUFFER_SIZE];
-		Bit16s* buffers[2] = { work[0], work[1] };
+		int32_t result[BUFFER_SIZE][2];
+		int16_t work[2][BUFFER_SIZE];
+		int16_t* buffers[2] = { work[0], work[1] };
 		device_sound_interface::sound_stream stream;
 		device[0]->sound_stream_update(stream, 0, buffers, len);
 		for (Bitu i = 0; i < len; i++) {
@@ -98,7 +98,7 @@ static void CMS_CallBack(Bitu len) {
 }
 
 // The Gameblaster detection
-static Bit8u cms_detect_register = 0xff;
+static uint8_t cms_detect_register = 0xff;
 
 static void write_cms_detect(io_port_t port, io_val_t value, io_width_t)
 {
@@ -113,7 +113,7 @@ static void write_cms_detect(io_port_t port, io_val_t value, io_width_t)
 
 static uint8_t read_cms_detect(io_port_t port, io_width_t)
 {
-	Bit8u retval = 0xff;
+	uint8_t retval = 0xff;
 	switch ( port - cmsBase ) {
 	case 0x4:
 		retval = 0x7f;

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -148,8 +148,8 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 }
 
 #if (C_SSHOT)
-static void CAPTURE_AddAviChunk(const char * tag, Bit32u size, void * data, Bit32u flags) {
-	Bit8u chunk[8];Bit8u *index;Bit32u pos, writesize;
+static void CAPTURE_AddAviChunk(const char * tag, uint32_t size, void * data, uint32_t flags) {
+	uint8_t chunk[8];uint8_t *index;uint32_t pos, writesize;
 
 	chunk[0] = tag[0];chunk[1] = tag[1];chunk[2] = tag[2];chunk[3] = tag[3];
 	host_writed(&chunk[4], size);   
@@ -185,7 +185,7 @@ static void CAPTURE_VideoEvent(bool pressed) {
 		CaptureState &= ~CAPTURE_VIDEO;
 		LOG_MSG("Stopped capturing video.");	
 
-		Bit8u avi_header[AVI_HEADER_SIZE];
+		uint8_t avi_header[AVI_HEADER_SIZE];
 		Bitu main_list;
 		Bitu header_pos=0;
 #define AVIOUT4(_S_) memcpy(&avi_header[header_pos],_S_,4);header_pos+=4;
@@ -202,7 +202,7 @@ static void CAPTURE_VideoEvent(bool pressed) {
 
 		AVIOUT4("avih");
 		AVIOUTd(56);                         /* # of bytes to follow */
-		AVIOUTd((Bit32u)(1000000 / capture.video.fps));       /* Microseconds per frame */
+		AVIOUTd((uint32_t)(1000000 / capture.video.fps));       /* Microseconds per frame */
 		AVIOUTd(0);
 		AVIOUTd(0);                         /* PaddingGranularity (whatever that might be) */
 		AVIOUTd(0x110);                     /* Flags,0x10 has index, 0x100 interleaved */
@@ -230,7 +230,7 @@ static void CAPTURE_VideoEvent(bool pressed) {
 		AVIOUTd(0);                         /* Reserved, MS says: wPriority, wLanguage */
 		AVIOUTd(0);                         /* InitialFrames */
 		AVIOUTd(1000000);                   /* Scale */
-		AVIOUTd((Bit32u)(1000000 * capture.video.fps));              /* Rate: Rate/Scale == samples/second */
+		AVIOUTd((uint32_t)(1000000 * capture.video.fps));              /* Rate: Rate/Scale == samples/second */
 		AVIOUTd(0);                         /* Start */
 		AVIOUTd(capture.video.frames);      /* Length */
 		AVIOUTd(0);                  /* SuggestedBufferSize */
@@ -592,8 +592,8 @@ skip_shot:
 				case 15:
 				case 16:
 					for (auto x = 0; x < countWidth; ++x)
-						((Bit16u *)doubleRow)[x*2+0] =
-						((Bit16u *)doubleRow)[x*2+1] = ((Bit16u *)srcLine)[x];
+						((uint16_t *)doubleRow)[x*2+0] =
+						((uint16_t *)doubleRow)[x*2+1] = ((uint16_t *)srcLine)[x];
 					break;
 				case 24:
 					for (auto x = 0; x < countWidth; ++x) {
@@ -604,8 +604,8 @@ skip_shot:
 					break;
 				case 32:
 					for (auto x = 0; x < countWidth; ++x)
-						((Bit32u *)doubleRow)[x*2+0] =
-						((Bit32u *)doubleRow)[x*2+1] = ((Bit32u *)srcLine)[x];
+						((uint32_t *)doubleRow)[x*2+0] =
+						((uint32_t *)doubleRow)[x*2+1] = ((uint32_t *)srcLine)[x];
 					break;
 				}
                 rowPointer=doubleRow;
@@ -653,16 +653,16 @@ static void CAPTURE_ScreenShotEvent(bool pressed) {
 
 
 /* WAV capturing */
-static Bit8u wavheader[]={
-	'R','I','F','F',	0x0,0x0,0x0,0x0,		/* Bit32u Riff Chunk ID /  Bit32u riff size */
-	'W','A','V','E',	'f','m','t',' ',		/* Bit32u Riff Format  / Bit32u fmt chunk id */
-	0x10,0x0,0x0,0x0,	0x1,0x0,0x2,0x0,		/* Bit32u fmt size / Bit16u encoding/ Bit16u channels */
-	0x0,0x0,0x0,0x0,	0x0,0x0,0x0,0x0,		/* Bit32u freq / Bit32u byterate */
-	0x4,0x0,0x10,0x0,	'd','a','t','a',		/* Bit16u byte-block / Bit16u bits / Bit16u data chunk id */
-	0x0,0x0,0x0,0x0,							/* Bit32u data size */
+static uint8_t wavheader[]={
+	'R','I','F','F',	0x0,0x0,0x0,0x0,		/* uint32_t Riff Chunk ID /  uint32_t riff size */
+	'W','A','V','E',	'f','m','t',' ',		/* uint32_t Riff Format  / uint32_t fmt chunk id */
+	0x10,0x0,0x0,0x0,	0x1,0x0,0x2,0x0,		/* uint32_t fmt size / uint16_t encoding/ uint16_t channels */
+	0x0,0x0,0x0,0x0,	0x0,0x0,0x0,0x0,		/* uint32_t freq / uint32_t byterate */
+	0x4,0x0,0x10,0x0,	'd','a','t','a',		/* uint16_t byte-block / uint16_t bits / uint16_t data chunk id */
+	0x0,0x0,0x0,0x0,							/* uint32_t data size */
 };
 
-void CAPTURE_AddWave(Bit32u freq, Bit32u len, Bit16s * data) {
+void CAPTURE_AddWave(uint32_t freq, uint32_t len, int16_t * data) {
 #if (C_SSHOT)
 	if (CaptureState & CAPTURE_VIDEO) {
 		Bitu left = WAVE_BUF - capture.video.audioused;
@@ -685,7 +685,7 @@ void CAPTURE_AddWave(Bit32u freq, Bit32u len, Bit16s * data) {
 			capture.wave.freq = freq;
 			fwrite(wavheader,1,sizeof(wavheader),capture.wave.handle);
 		}
-		Bit16s * read = data;
+		int16_t * read = data;
 		while (len > 0 ) {
 			Bitu left = WAVE_BUF - capture.wave.used;
 			if (!left) {
@@ -729,19 +729,19 @@ static void CAPTURE_WaveEvent(bool pressed) {
 
 /* MIDI capturing */
 
-static Bit8u midi_header[]={
-	'M','T','h','d',			/* Bit32u, Header Chunk */
-	0x0,0x0,0x0,0x6,			/* Bit32u, Chunk Length */
-	0x0,0x0,					/* Bit16u, Format, 0=single track */
-	0x0,0x1,					/* Bit16u, Track Count, 1 track */
-	0x01,0xf4,					/* Bit16u, Timing, 2 beats/second with 500 frames */
-	'M','T','r','k',			/* Bit32u, Track Chunk */
-	0x0,0x0,0x0,0x0,			/* Bit32u, Chunk Length */
+static uint8_t midi_header[]={
+	'M','T','h','d',			/* uint32_t, Header Chunk */
+	0x0,0x0,0x0,0x6,			/* uint32_t, Chunk Length */
+	0x0,0x0,					/* uint16_t, Format, 0=single track */
+	0x0,0x1,					/* uint16_t, Track Count, 1 track */
+	0x01,0xf4,					/* uint16_t, Timing, 2 beats/second with 500 frames */
+	'M','T','r','k',			/* uint32_t, Track Chunk */
+	0x0,0x0,0x0,0x0,			/* uint32_t, Chunk Length */
 	//Track data
 };
 
 
-static void RawMidiAdd(Bit8u data) {
+static void RawMidiAdd(uint8_t data) {
 	capture.midi.buffer[capture.midi.used++]=data;
 	if (capture.midi.used >= MIDI_BUF ) {
 		capture.midi.done += capture.midi.used;
@@ -750,14 +750,14 @@ static void RawMidiAdd(Bit8u data) {
 	}
 }
 
-static void RawMidiAddNumber(Bit32u val) {
-	if (val & 0xfe00000) RawMidiAdd((Bit8u)(0x80|((val >> 21) & 0x7f)));
-	if (val & 0xfffc000) RawMidiAdd((Bit8u)(0x80|((val >> 14) & 0x7f)));
-	if (val & 0xfffff80) RawMidiAdd((Bit8u)(0x80|((val >> 7) & 0x7f)));
-	RawMidiAdd((Bit8u)(val & 0x7f));
+static void RawMidiAddNumber(uint32_t val) {
+	if (val & 0xfe00000) RawMidiAdd((uint8_t)(0x80|((val >> 21) & 0x7f)));
+	if (val & 0xfffc000) RawMidiAdd((uint8_t)(0x80|((val >> 14) & 0x7f)));
+	if (val & 0xfffff80) RawMidiAdd((uint8_t)(0x80|((val >> 7) & 0x7f)));
+	RawMidiAdd((uint8_t)(val & 0x7f));
 }
 
-void CAPTURE_AddMidi(bool sysex, Bitu len, Bit8u * data) {
+void CAPTURE_AddMidi(bool sysex, Bitu len, uint8_t * data) {
 	if (!capture.midi.handle) {
 		capture.midi.handle=OpenCaptureFile("Raw Midi",".mid");
 		if (!capture.midi.handle) {
@@ -766,7 +766,7 @@ void CAPTURE_AddMidi(bool sysex, Bitu len, Bit8u * data) {
 		fwrite(midi_header,1,sizeof(midi_header),capture.midi.handle);
 		capture.midi.last=PIC_Ticks;
 	}
-	Bit32u delta=PIC_Ticks-capture.midi.last;
+	uint32_t delta=PIC_Ticks-capture.midi.last;
 	capture.midi.last=PIC_Ticks;
 	RawMidiAddNumber(delta);
 	if (sysex) {
@@ -793,11 +793,11 @@ static void CAPTURE_MidiEvent(bool pressed) {
 		fwrite(capture.midi.buffer,1,capture.midi.used,capture.midi.handle);
 		capture.midi.done+=capture.midi.used;
 		fseek(capture.midi.handle,18, SEEK_SET);
-		Bit8u size[4];
-		size[0]=(Bit8u)(capture.midi.done >> 24);
-		size[1]=(Bit8u)(capture.midi.done >> 16);
-		size[2]=(Bit8u)(capture.midi.done >> 8);
-		size[3]=(Bit8u)(capture.midi.done >> 0);
+		uint8_t size[4];
+		size[0]=(uint8_t)(capture.midi.done >> 24);
+		size[1]=(uint8_t)(capture.midi.done >> 16);
+		size[2]=(uint8_t)(capture.midi.done >> 8);
+		size[3]=(uint8_t)(capture.midi.done >> 0);
 		fwrite(&size,1,4,capture.midi.handle);
 		fclose(capture.midi.handle);
 		capture.midi.handle=0;

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -102,7 +102,7 @@ inline void IO_USEC_write_delay() {
 }
 
 #ifdef ENABLE_PORTLOG
-static Bit8u crtc_index = 0;
+static uint8_t crtc_index = 0;
 
 void log_io(io_width_t width, bool write, io_port_t port, io_val_t val)
 {
@@ -113,8 +113,8 @@ void log_io(io_width_t width, bool write, io_port_t port, io_val_t val)
 	if (write) {
 		// skip the video cursor position spam
 		if (port==0x3d4) {
-			if (width==io_width_t::byte) crtc_index = (Bit8u)val;
-			else if(width==io_width_t::word) crtc_index = (Bit8u)(val>>8);
+			if (width==io_width_t::byte) crtc_index = (uint8_t)val;
+			else if(width==io_width_t::word) crtc_index = (uint8_t)(val>>8);
 		}
 		if (crtc_index==0xe || crtc_index==0xf) {
 			if((width==io_width_t::byte && (port==0x3d4 || port==0x3d5))||(width==io_width_t::word && port==0x3d4))
@@ -177,8 +177,8 @@ void IO_WriteB(io_port_t port, uint8_t val)
 		entry->eip=reg_eip;
 		CPU_Push16(SegValue(cs));
 		CPU_Push16(reg_ip);
-		Bit8u old_al = reg_al;
-		Bit16u old_dx = reg_dx;
+		uint8_t old_al = reg_al;
+		uint16_t old_dx = reg_dx;
 		reg_al = val;
 		reg_dx = port;
 		RealPt icb = CALLBACK_RealPointer(call_priv_io);
@@ -214,8 +214,8 @@ void IO_WriteW(io_port_t port, uint16_t val)
 		entry->eip=reg_eip;
 		CPU_Push16(SegValue(cs));
 		CPU_Push16(reg_ip);
-		Bit16u old_ax = reg_ax;
-		Bit16u old_dx = reg_dx;
+		uint16_t old_ax = reg_ax;
+		uint16_t old_dx = reg_dx;
 		reg_ax = val;
 		reg_dx = port;
 		RealPt icb = CALLBACK_RealPointer(call_priv_io);
@@ -251,8 +251,8 @@ void IO_WriteD(io_port_t port, uint32_t val)
 		entry->eip=reg_eip;
 		CPU_Push16(SegValue(cs));
 		CPU_Push16(reg_ip);
-		Bit32u old_eax = reg_eax;
-		Bit16u old_dx = reg_dx;
+		uint32_t old_eax = reg_eax;
+		uint16_t old_dx = reg_dx;
 		reg_eax = val;
 		reg_dx = port;
 		RealPt icb = CALLBACK_RealPointer(call_priv_io);
@@ -286,8 +286,8 @@ uint8_t IO_ReadB(io_port_t port)
 		entry->eip=reg_eip;
 		CPU_Push16(SegValue(cs));
 		CPU_Push16(reg_ip);
-		Bit8u old_al = reg_al;
-		Bit16u old_dx = reg_dx;
+		uint8_t old_al = reg_al;
+		uint16_t old_dx = reg_dx;
 		reg_dx = port;
 		RealPt icb = CALLBACK_RealPointer(call_priv_io);
 		SegSet16(cs,RealSeg(icb));
@@ -326,8 +326,8 @@ uint16_t IO_ReadW(io_port_t port)
 		entry->eip=reg_eip;
 		CPU_Push16(SegValue(cs));
 		CPU_Push16(reg_ip);
-		Bit16u old_ax = reg_ax;
-		Bit16u old_dx = reg_dx;
+		uint16_t old_ax = reg_ax;
+		uint16_t old_dx = reg_dx;
 		reg_dx = port;
 		RealPt icb = CALLBACK_RealPointer(call_priv_io);
 		SegSet16(cs,RealSeg(icb));
@@ -365,8 +365,8 @@ uint32_t IO_ReadD(io_port_t port)
 		entry->eip=reg_eip;
 		CPU_Push16(SegValue(cs));
 		CPU_Push16(reg_ip);
-		Bit32u old_eax = reg_eax;
-		Bit16u old_dx = reg_dx;
+		uint32_t old_eax = reg_eax;
+		uint16_t old_dx = reg_dx;
 		reg_dx = port;
 		RealPt icb = CALLBACK_RealPointer(call_priv_io);
 		SegSet16(cs,RealSeg(icb));

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -49,13 +49,13 @@ struct ipxnetaddr {
 	Uint8 netnode[6];
 } localIpxAddr;
 
-Bit32u udpPort;
+uint32_t udpPort;
 bool isIpxServer;
 bool isIpxConnected;
 IPaddress ipxServConnIp;			// IPAddress for client connection to server
 UDPsocket ipxClientSocket;
 int UDPChannel;						// Channel used by UDP connection
-Bit8u recvBuffer[IPXBUFFERSIZE];	// Incoming packet buffer
+uint8_t recvBuffer[IPXBUFFERSIZE];	// Incoming packet buffer
 
 static RealPt ipx_callback;
 
@@ -63,10 +63,10 @@ SDLNet_SocketSet clientSocketSet;
 
 packetBuffer incomingPacket;
 
-static Bit16u socketCount;
-static Bit16u opensockets[SOCKTABLESIZE]; 
+static uint16_t socketCount;
+static uint16_t opensockets[SOCKTABLESIZE]; 
 
-static Bit16u swapByte(Bit16u sockNum) {
+static uint16_t swapByte(uint16_t sockNum) {
 	return (((sockNum>> 8)) | (sockNum << 8));
 }
 
@@ -128,16 +128,16 @@ ECBClass::ECBClass(uint16_t segment, uint16_t offset)
 	mysocket = getSocket();
 }
 
-void ECBClass::writeDataBuffer(Bit8u* buffer, Bit16u length) {
+void ECBClass::writeDataBuffer(uint8_t* buffer, uint16_t length) {
 	if(databuffer!=0) delete [] databuffer;
-	databuffer = new Bit8u[length];
+	databuffer = new uint8_t[length];
 	memcpy(databuffer,buffer,length);
 	buflen=length;
 
 }
 bool ECBClass::writeData() {
 	Bitu length=buflen;
-	Bit8u* buffer = databuffer;
+	uint8_t* buffer = databuffer;
 	fragmentDescriptor tmpFrag;
 	setInUseFlag(USEFLAG_AVAILABLE);
 	Bitu fragCount = getFragCount(); 
@@ -161,29 +161,29 @@ bool ECBClass::writeData() {
 	return false;
 }
 
-Bit16u ECBClass::getSocket(void) {
+uint16_t ECBClass::getSocket(void) {
 	return swapByte(real_readw(RealSeg(ECBAddr), RealOff(ECBAddr) + 0xa));
 }
 
-Bit8u ECBClass::getInUseFlag(void) {
+uint8_t ECBClass::getInUseFlag(void) {
 	return real_readb(RealSeg(ECBAddr), RealOff(ECBAddr) + 0x8);
 }
 
-void ECBClass::setInUseFlag(Bit8u flagval) {
+void ECBClass::setInUseFlag(uint8_t flagval) {
 	iuflag = flagval;
 	real_writeb(RealSeg(ECBAddr), RealOff(ECBAddr) + 0x8, flagval);
 }
 
-void ECBClass::setCompletionFlag(Bit8u flagval) {
+void ECBClass::setCompletionFlag(uint8_t flagval) {
 	real_writeb(RealSeg(ECBAddr), RealOff(ECBAddr) + 0x9, flagval);
 }
 
-Bit16u ECBClass::getFragCount(void) {
+uint16_t ECBClass::getFragCount(void) {
 	return real_readw(RealSeg(ECBAddr), RealOff(ECBAddr) + 34);
 }
 
-void ECBClass::getFragDesc(Bit16u descNum, fragmentDescriptor *fragDesc) {
-	Bit16u memoff = RealOff(ECBAddr) + 30 + ((descNum+1) * 6);
+void ECBClass::getFragDesc(uint16_t descNum, fragmentDescriptor *fragDesc) {
+	uint16_t memoff = RealOff(ECBAddr) + 30 + ((descNum+1) * 6);
 	fragDesc->offset = real_readw(RealSeg(ECBAddr), memoff);
 	memoff += 2;
 	fragDesc->segment = real_readw(RealSeg(ECBAddr), memoff);
@@ -199,7 +199,7 @@ RealPt ECBClass::getESRAddr(void) {
 }
 
 void ECBClass::NotifyESR(void) {
-	Bit32u ESRval = real_readd(RealSeg(ECBAddr), RealOff(ECBAddr)+4);
+	uint32_t ESRval = real_readd(RealSeg(ECBAddr), RealOff(ECBAddr)+4);
 	if(ESRval || databuffer) { // databuffer: write data at realmode/v86 time
 		// LOG_IPX("ECB: SN%7d to be notified.", SerialNumber);
 		// take the ECB out of the current list
@@ -232,12 +232,12 @@ void ECBClass::NotifyESR(void) {
 	else delete this;
 }
 
-void ECBClass::setImmAddress(Bit8u *immAddr) {
+void ECBClass::setImmAddress(uint8_t *immAddr) {
 	for(Bitu i=0;i<6;i++)
 		real_writeb(RealSeg(ECBAddr), RealOff(ECBAddr)+28+i, immAddr[i]);
 }
 
-void ECBClass::getImmAddress(Bit8u* immAddr) {
+void ECBClass::getImmAddress(uint8_t* immAddr) {
 	for(Bitu i=0;i<6;i++)
 		immAddr[i] = real_readb(RealSeg(ECBAddr), RealOff(ECBAddr)+28+i);
 }
@@ -265,7 +265,7 @@ ECBClass::~ECBClass() {
 
 
 
-static bool sockInUse(Bit16u sockNum) {
+static bool sockInUse(uint16_t sockNum) {
 	for(Bitu i=0;i<socketCount;i++) {
 		if (opensockets[i] == sockNum) return true;
 	}
@@ -273,7 +273,7 @@ static bool sockInUse(Bit16u sockNum) {
 }
 
 static void OpenSocket(void) {
-	Bit16u sockNum, sockAlloc;
+	uint16_t sockNum, sockAlloc;
 	sockNum = swapByte(reg_dx);
 
 	if(socketCount >= SOCKTABLESIZE) {
@@ -306,7 +306,7 @@ static void OpenSocket(void) {
 }
 
 static void CloseSocket(void) {
-	Bit16u sockNum, i;
+	uint16_t sockNum, i;
 	ECBClass* tmpECB = ECBList;
 	ECBClass* tmp2ECB = ECBList;
 
@@ -469,8 +469,8 @@ static void handleIpxRequest(void) {
 		        localIpxAddr.netnode[3], localIpxAddr.netnode[2],
 		        localIpxAddr.netnode[1], localIpxAddr.netnode[0]);
 
-		Bit8u *addrptr = (Bit8u *)&localIpxAddr;
-		for (Bit16u i = 0; i < 10; i++)
+		uint8_t *addrptr = (uint8_t *)&localIpxAddr;
+		for (uint16_t i = 0; i < 10; i++)
 			real_writeb(SegValue(es), reg_si + i, addrptr[i]);
 	} break;
 
@@ -570,11 +570,11 @@ static void pingSend(void) {
 		LOG_MSG("IPX: Failed to send a ping packet: %s", SDLNet_GetError());
 }
 
-static void receivePacket(Bit8u *buffer, Bit16s bufSize) {
+static void receivePacket(uint8_t *buffer, int16_t bufSize) {
 	ECBClass *useECB;
 	ECBClass *nextECB;
-	Bit16u *bufword = (Bit16u *)buffer;
-	Bit16u useSocket = swapByte(bufword[8]);
+	uint16_t *bufword = (uint16_t *)buffer;
+	uint16_t useSocket = swapByte(bufword[8]);
 	IPXHeader * tmpHeader;
 	tmpHeader = (IPXHeader *)buffer;
 
@@ -628,11 +628,11 @@ void DisconnectFromServer(bool unexpected) {
 }
 
 static void sendPacket(ECBClass* sendecb) {
-	Bit8u outbuffer[IPXBUFFERSIZE];
+	uint8_t outbuffer[IPXBUFFERSIZE];
 	fragmentDescriptor tmpFrag; 
-	Bit16u i, fragCount,t;
-	Bit16s packetsize;
-	Bit16u *wordptr;
+	uint16_t i, fragCount,t;
+	int16_t packetsize;
+	uint16_t *wordptr;
 	UDPpacket outPacket;
 		
 	sendecb->setInUseFlag(USEFLAG_AVAILABLE);
@@ -643,16 +643,16 @@ static void sendPacket(ECBClass* sendecb) {
 		if(i==0) {
 			// Fragment containing IPX header
 			// Must put source address into header
-			Bit8u * addrptr;
+			uint8_t * addrptr;
 			
 			// source netnum
-			addrptr = (Bit8u *)&localIpxAddr.netnum;
-			for(Bit16u m=0;m<4;m++) {
+			addrptr = (uint8_t *)&localIpxAddr.netnum;
+			for(uint16_t m=0;m<4;m++) {
 				real_writeb(tmpFrag.segment,tmpFrag.offset+m+18,addrptr[m]);
 			}
 			// source node number
-			addrptr = (Bit8u *)&localIpxAddr.netnode;
-			for(Bit16u m=0;m<6;m++) {
+			addrptr = (uint8_t *)&localIpxAddr.netnode;
+			for(uint16_t m=0;m<6;m++) {
 				real_writeb(tmpFrag.segment,tmpFrag.offset+m+22,addrptr[m]);
 			}
 			// Source socket
@@ -675,7 +675,7 @@ static void sendPacket(ECBClass* sendecb) {
 	}
 	
 	// Add length and source socket to IPX header
-	wordptr = (Bit16u *)&outbuffer[0];
+	wordptr = (uint16_t *)&outbuffer[0];
 	// Blank CRC
 	//wordptr[0] = 0xffff;
 	// Length
@@ -687,7 +687,7 @@ static void sendPacket(ECBClass* sendecb) {
 	real_writew(tmpFrag.segment,tmpFrag.offset+2, swapByte(packetsize));
 	
 
-	Bit8u immedAddr[6];
+	uint8_t immedAddr[6];
 	sendecb->getImmAddress(immedAddr);
 	// filter out broadcasts and local loopbacks
 	// Real implementation uses the ImmedAddr to check wether this is a broadcast
@@ -695,13 +695,13 @@ static void sendPacket(ECBClass* sendecb) {
 	bool islocalbroadcast=true;
 	bool isloopback=true;
 
-	Bit8u * addrptr;
+	uint8_t * addrptr;
 			
-	addrptr = (Bit8u *)&localIpxAddr.netnum;
+	addrptr = (uint8_t *)&localIpxAddr.netnum;
 	for(Bitu m=0;m<4;m++) {
 		if(addrptr[m]!=outbuffer[m+0x6])isloopback=false;
 	}
-	addrptr = (Bit8u *)&localIpxAddr.netnode;
+	addrptr = (uint8_t *)&localIpxAddr.netnode;
 	for(Bitu m=0;m<6;m++) {
 		if(addrptr[m]!=outbuffer[m+0xa])isloopback=false;
 		if(immedAddr[m]!=0xff) islocalbroadcast=false;
@@ -757,7 +757,7 @@ bool ConnectToServer(char const *strAddr) {
 	int numsent;
 	UDPpacket regPacket;
 	IPXHeader regHeader;
-	if(!SDLNet_ResolveHost(&ipxServConnIp, strAddr, (Bit16u)udpPort)) {
+	if(!SDLNet_ResolveHost(&ipxServConnIp, strAddr, (uint16_t)udpPort)) {
 
 		// Generate the MAC address.  This is made by zeroing out the first two
 		// octets and then using the actual IP address for the last 4 octets.
@@ -800,7 +800,7 @@ bool ConnectToServer(char const *strAddr) {
 			} else {
 				// Wait for return packet from server.
 				// This will contain our IPX address and port num
-				Bit32u elapsed;
+				uint32_t elapsed;
 				const auto ticks = GetTicks();
 
 				while(true) {
@@ -949,7 +949,7 @@ public:
 					} else {
 						udpPort = strtol(temp_line.c_str(), NULL, 10);
 					}
-					startsuccess = IPX_StartServer((Bit16u)udpPort);
+					startsuccess = IPX_StartServer((uint16_t)udpPort);
 					if(startsuccess) {
 						WriteOut("IPX Tunneling Server started\n");
 						isIpxServer = true;
@@ -1099,7 +1099,7 @@ private:
 	CALLBACK_HandlerObject callback_esr = {};
 	CALLBACK_HandlerObject callback_ipxint = {};
 	RealPt old_73_vector = 0;
-	static Bit16u dospage;
+	static uint16_t dospage;
 
 public:
 	IPX(Section *configuration) : Module_base(configuration)
@@ -1127,7 +1127,7 @@ public:
 		callback_ipxint.Set_RealVec(0x7a);
 
 		callback_esr.Allocate(&IPX_ESRHandler,"IPX_ESR");
-		Bit16u call_ipxesr1 = callback_esr.Get_callback();
+		uint16_t call_ipxesr1 = callback_esr.Get_callback();
 
 		if(!dospage) dospage = DOS_GetMemory(2); // can not be freed yet
 
@@ -1136,29 +1136,29 @@ public:
 		LOG_IPX("ESR callback address: %x, HandlerID %d", phyDospage,call_ipxesr1);
 
 		//save registers
-		phys_writeb(phyDospage+0,(Bit8u)0xFA);    // CLI
-		phys_writeb(phyDospage+1,(Bit8u)0x60);    // PUSHA
-		phys_writeb(phyDospage+2,(Bit8u)0x1E);    // PUSH DS
-		phys_writeb(phyDospage+3,(Bit8u)0x06);    // PUSH ES
-		phys_writew(phyDospage+4,(Bit16u)0xA00F); // PUSH FS
-		phys_writew(phyDospage+6,(Bit16u)0xA80F); // PUSH GS
+		phys_writeb(phyDospage+0,(uint8_t)0xFA);    // CLI
+		phys_writeb(phyDospage+1,(uint8_t)0x60);    // PUSHA
+		phys_writeb(phyDospage+2,(uint8_t)0x1E);    // PUSH DS
+		phys_writeb(phyDospage+3,(uint8_t)0x06);    // PUSH ES
+		phys_writew(phyDospage+4,(uint16_t)0xA00F); // PUSH FS
+		phys_writew(phyDospage+6,(uint16_t)0xA80F); // PUSH GS
 
 		// callback
-		phys_writeb(phyDospage+8,(Bit8u)0xFE);  // GRP 4
-		phys_writeb(phyDospage+9,(Bit8u)0x38);  // Extra Callback instruction
+		phys_writeb(phyDospage+8,(uint8_t)0xFE);  // GRP 4
+		phys_writeb(phyDospage+9,(uint8_t)0x38);  // Extra Callback instruction
 		phys_writew(phyDospage+10,call_ipxesr1);        // Callback identifier
 
 		// register recreation
-		phys_writew(phyDospage+12,(Bit16u)0xA90F); // POP GS
-		phys_writew(phyDospage+14,(Bit16u)0xA10F); // POP FS
-		phys_writeb(phyDospage+16,(Bit8u)0x07);    // POP ES
-		phys_writeb(phyDospage+17,(Bit8u)0x1F);    // POP DS
-		phys_writeb(phyDospage+18,(Bit8u)0x61);    // POPA
-		phys_writeb(phyDospage+19,(Bit8u)0xCF);    // IRET: restores flags, CS, IP
+		phys_writew(phyDospage+12,(uint16_t)0xA90F); // POP GS
+		phys_writew(phyDospage+14,(uint16_t)0xA10F); // POP FS
+		phys_writeb(phyDospage+16,(uint8_t)0x07);    // POP ES
+		phys_writeb(phyDospage+17,(uint8_t)0x1F);    // POP DS
+		phys_writeb(phyDospage+18,(uint8_t)0x61);    // POPA
+		phys_writeb(phyDospage+19,(uint8_t)0xCF);    // IRET: restores flags, CS, IP
 
 		// IPX version 2.12
-		//phys_writeb(phyDospage+27,(Bit8u)0x2);
-		//phys_writeb(phyDospage+28,(Bit8u)0x12);
+		//phys_writeb(phyDospage+27,(uint8_t)0x2);
+		//phys_writeb(phyDospage+28,(uint8_t)0x12);
 		//IPXVERpointer = RealMake(dospage,27);
 
 		RealPt ESRRoutineBase = RealMake(dospage, 0);
@@ -1187,7 +1187,7 @@ public:
    
 		PhysPt phyDospage = PhysMake(dospage,0);
 		for(Bitu i = 0;i < 32;i++)
-			phys_writeb(phyDospage+i,(Bit8u)0x00);
+			phys_writeb(phyDospage+i,(uint8_t)0x00);
 
 		VFILE_Remove("IPXNET.COM");
 	}
@@ -1205,6 +1205,6 @@ void IPX_Init(Section* sec) {
 }
 
 //Initialize static members;
-Bit16u IPX::dospage = 0;
+uint16_t IPX::dospage = 0;
 
 #endif

--- a/src/hardware/ipxserver.cpp
+++ b/src/hardware/ipxserver.cpp
@@ -33,15 +33,15 @@ UDPsocket ipxServerSocket;  // Listening server socket
 
 packetBuffer connBuffer[SOCKETTABLESIZE];
 
-Bit8u inBuffer[IPXBUFFERSIZE];
+uint8_t inBuffer[IPXBUFFERSIZE];
 IPaddress ipconn[SOCKETTABLESIZE];  // Active TCP/IP connection
 UDPsocket tcpconn[SOCKETTABLESIZE]; // Active TCP/IP connections
 SDLNet_SocketSet serverSocketSet;
 TIMER_TickHandler* serverTimer;
 
-Bit8u packetCRC(Bit8u *buffer, Bit16u bufSize) {
-	Bit8u tmpCRC = 0;
-	Bit16u i;
+uint8_t packetCRC(uint8_t *buffer, uint16_t bufSize) {
+	uint8_t tmpCRC = 0;
+	uint16_t i;
 	for(i=0;i<bufSize;i++) {
 		tmpCRC ^= *buffer;
 		buffer++;
@@ -50,8 +50,8 @@ Bit8u packetCRC(Bit8u *buffer, Bit16u bufSize) {
 }
 
 /*
-static void closeSocket(Bit16u sockidx) {
-	Bit32u host;
+static void closeSocket(uint16_t sockidx) {
+	uint32_t host;
 
 	host = ipconn[sockidx].host;
 	LOG_MSG("IPXSERVER: %d.%d.%d.%d disconnected", CONVIP(host));
@@ -63,9 +63,9 @@ static void closeSocket(Bit16u sockidx) {
 }
 */
 
-static void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
-	Bit16u srcport, destport;
-	Bit32u srchost, desthost;
+static void sendIPXPacket(uint8_t *buffer, int16_t bufSize) {
+	uint16_t srcport, destport;
+	uint32_t srchost, desthost;
 	UDPpacket outPacket;
 	outPacket.channel = -1;
 	outPacket.data = buffer;
@@ -152,7 +152,7 @@ static void IPX_ServerLoop() {
 
 	//char regString[] = "IPX Register\0";
 
-	Bit32u host;
+	uint32_t host;
 
 	inPacket.channel = -1;
 	inPacket.data = &inBuffer[0];
@@ -196,7 +196,7 @@ static void IPX_ServerLoop() {
 		}
 
 		// IPX packet is complete.  Now interpret IPX header and send to respective IP address
-		sendIPXPacket((Bit8u *)inPacket.data, inPacket.len);
+		sendIPXPacket((uint8_t *)inPacket.data, inPacket.len);
 	}
 }
 

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -40,7 +40,7 @@ enum KeyCommands {
 };
 
 static struct {
-	Bit8u buffer[KEYBUFSIZE];
+	uint8_t buffer[KEYBUFSIZE];
 	Bitu used;
 	Bitu pos;
 	struct {
@@ -49,14 +49,14 @@ static struct {
 		Bitu pause,rate;
 	} repeat;
 	KeyCommands command;
-	Bit8u p60data;
+	uint8_t p60data;
 	bool p60changed;
 	bool active;
 	bool scanning;
 	bool scheduled;
 } keyb;
 
-static void KEYBOARD_SetPort60(Bit8u val) {
+static void KEYBOARD_SetPort60(uint8_t val) {
 	keyb.p60changed=true;
 	keyb.p60data=val;
 	if (machine==MCH_PCJR) PIC_ActivateIRQ(6);
@@ -82,7 +82,7 @@ void KEYBOARD_ClrBuffer(void) {
 	keyb.scheduled=false;
 }
 
-static void KEYBOARD_AddBuffer(Bit8u data) {
+static void KEYBOARD_AddBuffer(uint8_t data) {
 	if (keyb.used>=KEYBUFSIZE) {
 		LOG(LOG_KEYBOARD,LOG_NORMAL)("Buffer full, dropping code");
 		return;
@@ -198,7 +198,7 @@ bit 2      reserved, often used as turbo switch
 bit 1 = 1  speaker data enable
 bit 0 = 1  timer 2 gate to speaker enable
 */
-static Bit8u port_61_data = 0;
+static uint8_t port_61_data = 0;
 extern void TIMER_SetGate2(bool);
 static void write_p61(io_port_t, io_val_t value, io_width_t)
 {
@@ -295,12 +295,12 @@ static void write_p64(io_port_t, io_val_t value, io_width_t)
 
 static uint8_t read_p64(io_port_t, io_width_t)
 {
-	Bit8u status = 0x1c | (keyb.p60changed ? 0x1 : 0x0);
+	uint8_t status = 0x1c | (keyb.p60changed ? 0x1 : 0x0);
 	return status;
 }
 
 void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
-	Bit8u ret=0;bool extend=false;
+	uint8_t ret=0;bool extend=false;
 	switch (keytype) {
 	case KBD_esc:ret=1;break;
 	case KBD_1:ret=2;break;

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -39,10 +39,10 @@
 #include <stdarg.h>
 #endif
 
-typedef Bit16s stream_sample_t;
+typedef int16_t stream_sample_t;
 
-typedef Bit8u u8;
-typedef Bit32u u32;
+typedef uint8_t u8;
+typedef uint32_t u32;
 
 class device_t;
 struct machine_config;

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -36,7 +36,7 @@
 
 struct LinkBlock {
 	Bitu used;
-	Bit32u pages[MAX_LINKS];
+	uint32_t pages[MAX_LINKS];
 };
 
 static struct MemoryBlock {
@@ -53,7 +53,7 @@ static struct MemoryBlock {
 	} lfb;
 	struct {
 		bool enabled;
-		Bit8u controlport;
+		uint8_t controlport;
 	} a20;
 } memory;
 
@@ -171,7 +171,7 @@ Bitu mem_strlen(PhysPt pt) {
 }
 
 void mem_strcpy(PhysPt dest,PhysPt src) {
-	Bit8u r;
+	uint8_t r;
 	while ( (r = mem_readb(src++)) ) mem_writeb_inline(dest++,r);
 	mem_writeb_inline(dest,0);
 }
@@ -181,7 +181,7 @@ void mem_memcpy(PhysPt dest,PhysPt src,Bitu size) {
 }
 
 void MEM_BlockRead(PhysPt pt,void * data,Bitu size) {
-	Bit8u * write=reinterpret_cast<Bit8u *>(data);
+	uint8_t * write=reinterpret_cast<uint8_t *>(data);
 	while (size--) {
 		*write++=mem_readb_inline(pt++);
 	}
@@ -201,7 +201,7 @@ void MEM_BlockCopy(PhysPt dest,PhysPt src,Bitu size) {
 
 void MEM_StrCopy(PhysPt pt,char * data,Bitu size) {
 	while (size--) {
-		Bit8u r=mem_readb_inline(pt++);
+		uint8_t r=mem_readb_inline(pt++);
 		if (!r) break;
 		*data++=r;
 	}
@@ -430,14 +430,14 @@ void MEM_A20_Enable(bool enabled) {
 
 
 /* Memory access functions */
-Bit16u mem_unalignedreadw(PhysPt address) {
-	Bit16u ret = mem_readb_inline(address);
+uint16_t mem_unalignedreadw(PhysPt address) {
+	uint16_t ret = mem_readb_inline(address);
 	ret       |= mem_readb_inline(address+1) << 8;
 	return ret;
 }
 
-Bit32u mem_unalignedreadd(PhysPt address) {
-	Bit32u ret = mem_readb_inline(address);
+uint32_t mem_unalignedreadd(PhysPt address) {
+	uint32_t ret = mem_readb_inline(address);
 	ret       |= mem_readb_inline(address+1) << 8;
 	ret       |= mem_readb_inline(address+2) << 16;
 	ret       |= mem_readb_inline(address+3) << 24;
@@ -445,20 +445,20 @@ Bit32u mem_unalignedreadd(PhysPt address) {
 }
 
 
-void mem_unalignedwritew(PhysPt address,Bit16u val) {
-	mem_writeb_inline(address,(Bit8u)val);val>>=8;
-	mem_writeb_inline(address+1,(Bit8u)val);
+void mem_unalignedwritew(PhysPt address,uint16_t val) {
+	mem_writeb_inline(address,(uint8_t)val);val>>=8;
+	mem_writeb_inline(address+1,(uint8_t)val);
 }
 
-void mem_unalignedwrited(PhysPt address,Bit32u val) {
-	mem_writeb_inline(address,(Bit8u)val);val>>=8;
-	mem_writeb_inline(address+1,(Bit8u)val);val>>=8;
-	mem_writeb_inline(address+2,(Bit8u)val);val>>=8;
-	mem_writeb_inline(address+3,(Bit8u)val);
+void mem_unalignedwrited(PhysPt address,uint32_t val) {
+	mem_writeb_inline(address,(uint8_t)val);val>>=8;
+	mem_writeb_inline(address+1,(uint8_t)val);val>>=8;
+	mem_writeb_inline(address+2,(uint8_t)val);val>>=8;
+	mem_writeb_inline(address+3,(uint8_t)val);
 }
 
 
-bool mem_unalignedreadw_checked(PhysPt address, Bit16u * val) {
+bool mem_unalignedreadw_checked(PhysPt address, uint16_t * val) {
 	uint8_t rval1;
 	if (mem_readb_checked(address + 0, &rval1))
 		return true;
@@ -471,7 +471,7 @@ bool mem_unalignedreadw_checked(PhysPt address, Bit16u * val) {
 	return false;
 }
 
-bool mem_unalignedreadd_checked(PhysPt address, Bit32u * val) {
+bool mem_unalignedreadd_checked(PhysPt address, uint32_t * val) {
 	uint8_t rval1;
 	if (mem_readb_checked(address+0, &rval1)) return true;
 
@@ -491,45 +491,45 @@ bool mem_unalignedreadd_checked(PhysPt address, Bit32u * val) {
 	return false;
 }
 
-bool mem_unalignedwritew_checked(PhysPt address, Bit16u val) {
-	if (mem_writeb_checked(address+0, (Bit8u)(val & 0xff))) return true;
+bool mem_unalignedwritew_checked(PhysPt address, uint16_t val) {
+	if (mem_writeb_checked(address+0, (uint8_t)(val & 0xff))) return true;
 	val >>= 8;
-	if (mem_writeb_checked(address+1, (Bit8u)(val & 0xff))) return true;
+	if (mem_writeb_checked(address+1, (uint8_t)(val & 0xff))) return true;
 	return false;
 }
 
-bool mem_unalignedwrited_checked(PhysPt address, Bit32u val) {
-	if (mem_writeb_checked(address+0, (Bit8u)(val & 0xff))) return true;
+bool mem_unalignedwrited_checked(PhysPt address, uint32_t val) {
+	if (mem_writeb_checked(address+0, (uint8_t)(val & 0xff))) return true;
 	val >>= 8;
-	if (mem_writeb_checked(address+1, (Bit8u)(val & 0xff))) return true;
+	if (mem_writeb_checked(address+1, (uint8_t)(val & 0xff))) return true;
 	val >>= 8;
-	if (mem_writeb_checked(address+2, (Bit8u)(val & 0xff))) return true;
+	if (mem_writeb_checked(address+2, (uint8_t)(val & 0xff))) return true;
 	val >>= 8;
-	if (mem_writeb_checked(address+3, (Bit8u)(val & 0xff))) return true;
+	if (mem_writeb_checked(address+3, (uint8_t)(val & 0xff))) return true;
 	return false;
 }
 
-Bit8u mem_readb(PhysPt address) {
+uint8_t mem_readb(PhysPt address) {
 	return mem_readb_inline(address);
 }
 
-Bit16u mem_readw(PhysPt address) {
+uint16_t mem_readw(PhysPt address) {
 	return mem_readw_inline(address);
 }
 
-Bit32u mem_readd(PhysPt address) {
+uint32_t mem_readd(PhysPt address) {
 	return mem_readd_inline(address);
 }
 
-void mem_writeb(PhysPt address,Bit8u val) {
+void mem_writeb(PhysPt address,uint8_t val) {
 	mem_writeb_inline(address,val);
 }
 
-void mem_writew(PhysPt address,Bit16u val) {
+void mem_writew(PhysPt address,uint16_t val) {
 	mem_writew_inline(address,val);
 }
 
-void mem_writed(PhysPt address,Bit32u val) {
+void mem_writed(PhysPt address,uint32_t val) {
 	mem_writed_inline(address,val);
 }
 
@@ -589,7 +589,7 @@ public:
 			LOG_MSG("Memory sizes above %d MB are NOT recommended.",SAFE_MEMORY - 1);
 			LOG_MSG("Stick with the default values unless you are absolutely certain.");
 		}
-		MemBase = new (std::nothrow) Bit8u[memsize * 1024 * 1024];
+		MemBase = new (std::nothrow) uint8_t[memsize * 1024 * 1024];
 		if (!MemBase) {
 			E_Exit("Can't allocate main memory of %u MB", memsize);
 		}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -116,7 +116,7 @@ struct mixer_t {
 
 static struct mixer_t mixer = {};
 
-Bit8u MixTemp[MIXER_BUFSIZE] = {};
+uint8_t MixTemp[MIXER_BUFSIZE] = {};
 
 MixerChannel::MixerChannel(MIXER_Handler _handler, const char *_name) : envelope(_name), handler(_handler)
 {}
@@ -460,8 +460,8 @@ void MixerChannel::AddSamples(uint16_t len, const Type *data)
 								next_sample[0] = (int16_t)host_readw((HostPt)&data[pos * 2 + 0]);
 								next_sample[1] = (int16_t)host_readw((HostPt)&data[pos * 2 + 1]);
 							} else {
-								next_sample[0]=(Bit32s)host_readd((HostPt)&data[pos*2+0]);
-								next_sample[1]=(Bit32s)host_readd((HostPt)&data[pos*2+1]);
+								next_sample[0]=(int32_t)host_readd((HostPt)&data[pos*2+0]);
+								next_sample[1]=(int32_t)host_readd((HostPt)&data[pos*2+1]);
 							}
 						}
 					} else {
@@ -471,7 +471,7 @@ void MixerChannel::AddSamples(uint16_t len, const Type *data)
 							if ( sizeof( Type) == 2) {
 								next_sample[0] = (int16_t)host_readw((HostPt)&data[pos]);
 							} else {
-								next_sample[0]=(Bit32s)host_readd((HostPt)&data[pos]);
+								next_sample[0]=(int32_t)host_readd((HostPt)&data[pos]);
 							}
 						}
 					}
@@ -604,21 +604,21 @@ void MixerChannel::AddStretched(uint16_t len, int16_t *data)
 	MIXER_UnlockAudioDevice();
 }
 
-void MixerChannel::AddSamples_m8(uint16_t len, const Bit8u *data)
+void MixerChannel::AddSamples_m8(uint16_t len, const uint8_t *data)
 {
-	AddSamples<Bit8u, false, false, true>(len, data);
+	AddSamples<uint8_t, false, false, true>(len, data);
 }
-void MixerChannel::AddSamples_s8(uint16_t len, const Bit8u *data)
+void MixerChannel::AddSamples_s8(uint16_t len, const uint8_t *data)
 {
-	AddSamples<Bit8u, true, false, true>(len, data);
+	AddSamples<uint8_t, true, false, true>(len, data);
 }
-void MixerChannel::AddSamples_m8s(uint16_t len, const Bit8s *data)
+void MixerChannel::AddSamples_m8s(uint16_t len, const int8_t *data)
 {
-	AddSamples<Bit8s, false, true, true>(len, data);
+	AddSamples<int8_t, false, true, true>(len, data);
 }
-void MixerChannel::AddSamples_s8s(uint16_t len, const Bit8s *data)
+void MixerChannel::AddSamples_s8s(uint16_t len, const int8_t *data)
 {
-	AddSamples<Bit8s, true, true, true>(len, data);
+	AddSamples<int8_t, true, true, true>(len, data);
 }
 void MixerChannel::AddSamples_m16(uint16_t len, const int16_t *data)
 {
@@ -628,21 +628,21 @@ void MixerChannel::AddSamples_s16(uint16_t len, const int16_t *data)
 {
 	AddSamples<int16_t, true, true, true>(len, data);
 }
-void MixerChannel::AddSamples_m16u(uint16_t len, const Bit16u *data)
+void MixerChannel::AddSamples_m16u(uint16_t len, const uint16_t *data)
 {
-	AddSamples<Bit16u, false, false, true>(len, data);
+	AddSamples<uint16_t, false, false, true>(len, data);
 }
-void MixerChannel::AddSamples_s16u(uint16_t len, const Bit16u *data)
+void MixerChannel::AddSamples_s16u(uint16_t len, const uint16_t *data)
 {
-	AddSamples<Bit16u, true, false, true>(len, data);
+	AddSamples<uint16_t, true, false, true>(len, data);
 }
-void MixerChannel::AddSamples_m32(uint16_t len, const Bit32s *data)
+void MixerChannel::AddSamples_m32(uint16_t len, const int32_t *data)
 {
-	AddSamples<Bit32s, false, true, true>(len, data);
+	AddSamples<int32_t, false, true, true>(len, data);
 }
-void MixerChannel::AddSamples_s32(uint16_t len, const Bit32s *data)
+void MixerChannel::AddSamples_s32(uint16_t len, const int32_t *data)
 {
-	AddSamples<Bit32s, true, true, true>(len, data);
+	AddSamples<int32_t, true, true, true>(len, data);
 }
 void MixerChannel::AddSamples_m16_nonnative(uint16_t len, const int16_t *data)
 {
@@ -652,21 +652,21 @@ void MixerChannel::AddSamples_s16_nonnative(uint16_t len, const int16_t *data)
 {
 	AddSamples<int16_t, true, true, false>(len, data);
 }
-void MixerChannel::AddSamples_m16u_nonnative(uint16_t len, const Bit16u *data)
+void MixerChannel::AddSamples_m16u_nonnative(uint16_t len, const uint16_t *data)
 {
-	AddSamples<Bit16u, false, false, false>(len, data);
+	AddSamples<uint16_t, false, false, false>(len, data);
 }
-void MixerChannel::AddSamples_s16u_nonnative(uint16_t len, const Bit16u *data)
+void MixerChannel::AddSamples_s16u_nonnative(uint16_t len, const uint16_t *data)
 {
-	AddSamples<Bit16u, true, false, false>(len, data);
+	AddSamples<uint16_t, true, false, false>(len, data);
 }
-void MixerChannel::AddSamples_m32_nonnative(uint16_t len, const Bit32s *data)
+void MixerChannel::AddSamples_m32_nonnative(uint16_t len, const int32_t *data)
 {
-	AddSamples<Bit32s, false, true, false>(len, data);
+	AddSamples<int32_t, false, true, false>(len, data);
 }
-void MixerChannel::AddSamples_s32_nonnative(uint16_t len, const Bit32s *data)
+void MixerChannel::AddSamples_s32_nonnative(uint16_t len, const int32_t *data)
 {
-	AddSamples<Bit32s, true, true, false>(len, data);
+	AddSamples<int32_t, true, true, false>(len, data);
 }
 
 void MixerChannel::FillUp()

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -34,24 +34,24 @@
 #include "support.h"
 
 static fltype recipsamp;	// inverse of sampling rate
-static Bit16s wavtable[WAVEPREC*3];	// wave form table
+static int16_t wavtable[WAVEPREC*3];	// wave form table
 
 // vibrato/tremolo tables
-static Bit32s vib_table[VIBTAB_SIZE];
-static Bit32s trem_table[TREMTAB_SIZE*2];
+static int32_t vib_table[VIBTAB_SIZE];
+static int32_t trem_table[TREMTAB_SIZE*2];
 
-static Bit32s vibval_const[BLOCKBUF_SIZE];
-static Bit32s tremval_const[BLOCKBUF_SIZE];
+static int32_t vibval_const[BLOCKBUF_SIZE];
+static int32_t tremval_const[BLOCKBUF_SIZE];
 
 // vibrato value tables (used per-operator)
-static Bit32s vibval_var1[BLOCKBUF_SIZE];
-static Bit32s vibval_var2[BLOCKBUF_SIZE];
-//static Bit32s vibval_var3[BLOCKBUF_SIZE];
-//static Bit32s vibval_var4[BLOCKBUF_SIZE];
+static int32_t vibval_var1[BLOCKBUF_SIZE];
+static int32_t vibval_var2[BLOCKBUF_SIZE];
+//static int32_t vibval_var3[BLOCKBUF_SIZE];
+//static int32_t vibval_var4[BLOCKBUF_SIZE];
 
 // vibrato/trmolo value table pointers
-static Bit32s *vibval1, *vibval2, *vibval3, *vibval4;
-static Bit32s *tremval1, *tremval2, *tremval3, *tremval4;
+static int32_t *vibval1, *vibval2, *vibval3, *vibval4;
+static int32_t *tremval1, *tremval2, *tremval3, *tremval4;
 
 // return a pointer to the requested operator, but only after ensuring it's valid
 op_type *get_op(const int64_t i)
@@ -73,10 +73,10 @@ static const fltype frqmul_tab[16] = {
 static fltype frqmul[16];
 
 // key scale levels
-static Bit8u kslev[8][16];
+static uint8_t kslev[8][16];
 
 // map a channel number to the register offset of the modulator (=register base)
-static const Bit8u modulatorbase[9]	= {
+static const uint8_t modulatorbase[9]	= {
 	0,1,2,
 	8,9,10,
 	16,17,18
@@ -97,7 +97,7 @@ constexpr uint8_t regbase2op[44] = {
 };
 
 // start of the waveform
-static Bit32u waveform[8] = {
+static uint32_t waveform[8] = {
 	WAVEPREC,
 	WAVEPREC>>1,
 	WAVEPREC,
@@ -109,7 +109,7 @@ static Bit32u waveform[8] = {
 };
 
 // length of the waveform as mask
-static Bit32u wavemask[8] = {
+static uint32_t wavemask[8] = {
 	WAVEPREC-1,
 	WAVEPREC-1,
 	(WAVEPREC>>1)-1,
@@ -121,7 +121,7 @@ static Bit32u wavemask[8] = {
 };
 
 // where the first entry resides
-static Bit32u wavestart[8] = {
+static uint32_t wavestart[8] = {
 	0,
 	WAVEPREC>>1,
 	0,
@@ -147,32 +147,32 @@ static fltype decrelconst[4] = {
 };
 
 
-void operator_advance(op_type* op_pt, Bit32s vib) {
+void operator_advance(op_type* op_pt, int32_t vib) {
 	op_pt->wfpos = op_pt->tcount;						// waveform position
 	
 	// advance waveform time
 	op_pt->tcount += op_pt->tinc;
-	op_pt->tcount += (Bit32s)(op_pt->tinc)*vib/FIXEDPT;
+	op_pt->tcount += (int32_t)(op_pt->tinc)*vib/FIXEDPT;
 
 	op_pt->generator_pos += generator_add;
 }
 
-void operator_advance_drums(op_type* op_pt1, Bit32s vib1, op_type* op_pt2, Bit32s vib2, op_type* op_pt3, Bit32s vib3) {
-	Bit32u c1 = op_pt1->tcount/FIXEDPT;
-	Bit32u c3 = op_pt3->tcount/FIXEDPT;
-	Bit32u phasebit = (((c1 & 0x88) ^ ((c1<<5) & 0x80)) | ((c3 ^ (c3<<2)) & 0x20)) ? 0x02 : 0x00;
+void operator_advance_drums(op_type* op_pt1, int32_t vib1, op_type* op_pt2, int32_t vib2, op_type* op_pt3, int32_t vib3) {
+	uint32_t c1 = op_pt1->tcount/FIXEDPT;
+	uint32_t c3 = op_pt3->tcount/FIXEDPT;
+	uint32_t phasebit = (((c1 & 0x88) ^ ((c1<<5) & 0x80)) | ((c3 ^ (c3<<2)) & 0x20)) ? 0x02 : 0x00;
 
 	static const auto randomize_bit = CreateRandomizer<uint8_t>(0, 1);
 	const auto noisebit = randomize_bit();
 
-	Bit32u snare_phase_bit = (((Bitu)((op_pt1->tcount/FIXEDPT) / 0x100))&1);
+	uint32_t snare_phase_bit = (((Bitu)((op_pt1->tcount/FIXEDPT) / 0x100))&1);
 
 	//Hihat
-	Bit32u inttm = (phasebit<<8) | (0x34<<(phasebit ^ (noisebit<<1)));
+	uint32_t inttm = (phasebit<<8) | (0x34<<(phasebit ^ (noisebit<<1)));
 	op_pt1->wfpos = inttm*FIXEDPT;				// waveform position
 	// advance waveform time
 	op_pt1->tcount += op_pt1->tinc;
-	op_pt1->tcount += (Bit32s)(op_pt1->tinc)*vib1/FIXEDPT;
+	op_pt1->tcount += (int32_t)(op_pt1->tinc)*vib1/FIXEDPT;
 	op_pt1->generator_pos += generator_add;
 
 	//Snare
@@ -180,7 +180,7 @@ void operator_advance_drums(op_type* op_pt1, Bit32s vib1, op_type* op_pt2, Bit32
 	op_pt2->wfpos = inttm*FIXEDPT;				// waveform position
 	// advance waveform time
 	op_pt2->tcount += op_pt2->tinc;
-	op_pt2->tcount += (Bit32s)(op_pt2->tinc)*vib2/FIXEDPT;
+	op_pt2->tcount += (int32_t)(op_pt2->tinc)*vib2/FIXEDPT;
 	op_pt2->generator_pos += generator_add;
 
 	//Cymbal
@@ -188,24 +188,24 @@ void operator_advance_drums(op_type* op_pt1, Bit32s vib1, op_type* op_pt2, Bit32
 	op_pt3->wfpos = inttm*FIXEDPT;				// waveform position
 	// advance waveform time
 	op_pt3->tcount += op_pt3->tinc;
-	op_pt3->tcount += (Bit32s)(op_pt3->tinc)*vib3/FIXEDPT;
+	op_pt3->tcount += (int32_t)(op_pt3->tinc)*vib3/FIXEDPT;
 	op_pt3->generator_pos += generator_add;
 }
 
 
 // output level is sustained, mode changes only when operator is turned off (->release)
 // or when the keep-sustained bit is turned off (->sustain_nokeep)
-void operator_output(op_type* op_pt, Bit32s modulator, Bit32s trem) {
+void operator_output(op_type* op_pt, int32_t modulator, int32_t trem) {
 	if (op_pt->op_state != OF_TYPE_OFF) {
 		op_pt->lastcval = op_pt->cval;
-		Bit32u i = (Bit32u)((op_pt->wfpos+modulator)/FIXEDPT);
+		uint32_t i = (uint32_t)((op_pt->wfpos+modulator)/FIXEDPT);
 
 		// wform: -16384 to 16383 (0x4000)
 		// trem :  32768 to 65535 (0x10000)
 		// step_amp: 0.0 to 1.0
 		// vol  : 1/2^14 to 1/2^29 (/0x4000; /1../0x8000)
 
-		op_pt->cval = (Bit32s)(op_pt->step_amp*op_pt->vol*op_pt->cur_wform[i&op_pt->cur_wmask]*trem/16.0);
+		op_pt->cval = (int32_t)(op_pt->step_amp*op_pt->vol*op_pt->cur_wform[i&op_pt->cur_wmask]*trem/16.0);
 	}
 }
 
@@ -217,8 +217,8 @@ void operator_off(op_type* /*op_pt*/) {
 // output level is sustained, mode changes only when operator is turned off (->release)
 // or when the keep-sustained bit is turned off (->sustain_nokeep)
 void operator_sustain(op_type* op_pt) {
-	Bit32u num_steps_add = op_pt->generator_pos/FIXEDPT;	// number of (standardized) samples
-	for (Bit32u ct=0; ct<num_steps_add; ct++) {
+	uint32_t num_steps_add = op_pt->generator_pos/FIXEDPT;	// number of (standardized) samples
+	for (uint32_t ct=0; ct<num_steps_add; ct++) {
 		op_pt->cur_env_step++;
 	}
 	op_pt->generator_pos -= num_steps_add*FIXEDPT;
@@ -232,8 +232,8 @@ void operator_release(op_type* op_pt) {
 		op_pt->amp *= op_pt->releasemul;
 	}
 
-	Bit32u num_steps_add = op_pt->generator_pos/FIXEDPT;	// number of (standardized) samples
-	for (Bit32u ct=0; ct<num_steps_add; ct++) {
+	uint32_t num_steps_add = op_pt->generator_pos/FIXEDPT;	// number of (standardized) samples
+	for (uint32_t ct=0; ct<num_steps_add; ct++) {
 		op_pt->cur_env_step++;						// sample counter
 		if ((op_pt->cur_env_step & op_pt->env_step_r)==0) {
 			if (op_pt->amp <= 0.00000001) {
@@ -257,8 +257,8 @@ void operator_decay(op_type* op_pt) {
 		op_pt->amp *= op_pt->decaymul;
 	}
 
-	Bit32u num_steps_add = op_pt->generator_pos/FIXEDPT;	// number of (standardized) samples
-	for (Bit32u ct=0; ct<num_steps_add; ct++) {
+	uint32_t num_steps_add = op_pt->generator_pos/FIXEDPT;	// number of (standardized) samples
+	for (uint32_t ct=0; ct<num_steps_add; ct++) {
 		op_pt->cur_env_step++;
 		if ((op_pt->cur_env_step & op_pt->env_step_d)==0) {
 			if (op_pt->amp <= op_pt->sustain_level) {
@@ -283,8 +283,8 @@ void operator_decay(op_type* op_pt) {
 void operator_attack(op_type* op_pt) {
 	op_pt->amp = ((op_pt->a3*op_pt->amp + op_pt->a2)*op_pt->amp + op_pt->a1)*op_pt->amp + op_pt->a0;
 
-	Bit32u num_steps_add = op_pt->generator_pos/FIXEDPT;		// number of (standardized) samples
-	for (Bit32u ct=0; ct<num_steps_add; ct++) {
+	uint32_t num_steps_add = op_pt->generator_pos/FIXEDPT;		// number of (standardized) samples
+	for (uint32_t ct=0; ct<num_steps_add; ct++) {
 		op_pt->cur_env_step++;	// next sample
 		if ((op_pt->cur_env_step & op_pt->env_step_a)==0) {		// check if next step already reached
 			if (op_pt->amp > 1.0) {
@@ -330,7 +330,7 @@ void change_attackrate(Bitu regbase, op_type* op_pt) {
 		op_pt->env_step_a = (1<<(steps<=12?12-steps:0))-1;
 
 		Bits step_num = (step_skip<=48)?(4-(step_skip&3)):0;
-		static Bit8u step_skip_mask[5] = {0xff, 0xfe, 0xee, 0xba, 0xaa}; 
+		static uint8_t step_skip_mask[5] = {0xff, 0xfe, 0xee, 0xba, 0xaa}; 
 		op_pt->env_step_skip_a = step_skip_mask[step_num];
 
 #if defined(OPLTYPE_IS_OPL3)
@@ -421,19 +421,19 @@ void change_vibrato(Bitu regbase, op_type* op_pt) {
 // change amount of self-feedback
 void change_feedback(Bitu chanbase, op_type* op_pt) {
 	Bits feedback = adlibreg[ARC_FEEDBACK+chanbase]&14;
-	if (feedback) op_pt->mfbi = (Bit32s)(pow(FL2,(fltype)((feedback>>1)+8)));
+	if (feedback) op_pt->mfbi = (int32_t)(pow(FL2,(fltype)((feedback>>1)+8)));
 	else op_pt->mfbi = 0;
 }
 
 void change_frequency(Bitu chanbase, Bitu regbase, op_type* op_pt) {
 	// frequency
-	Bit32u frn = ((((Bit32u)adlibreg[ARC_KON_BNUM+chanbase])&3)<<8) + (Bit32u)adlibreg[ARC_FREQ_NUM+chanbase];
+	uint32_t frn = ((((uint32_t)adlibreg[ARC_KON_BNUM+chanbase])&3)<<8) + (uint32_t)adlibreg[ARC_FREQ_NUM+chanbase];
 	// block number/octave
-	Bit32u oct = ((((Bit32u)adlibreg[ARC_KON_BNUM+chanbase])>>2)&7);
-	op_pt->freq_high = (Bit32s)((frn>>7)&7);
+	uint32_t oct = ((((uint32_t)adlibreg[ARC_KON_BNUM+chanbase])>>2)&7);
+	op_pt->freq_high = (int32_t)((frn>>7)&7);
 
 	// keysplit
-	Bit32u note_sel = (adlibreg[8]>>6)&1;
+	uint32_t note_sel = (adlibreg[8]>>6)&1;
 	op_pt->toff = ((frn>>9)&(note_sel^1)) | ((frn>>8)&note_sel);
 	op_pt->toff += (oct<<1);
 
@@ -441,7 +441,7 @@ void change_frequency(Bitu chanbase, Bitu regbase, op_type* op_pt) {
 	if (!(adlibreg[ARC_TVS_KSR_MUL+regbase]&0x10)) op_pt->toff >>= 2;
 
 	// 20+a0+b0:
-	op_pt->tinc = (Bit32u)((((fltype)(frn<<oct))*frqmul[adlibreg[ARC_TVS_KSR_MUL+regbase]&15]));
+	op_pt->tinc = (uint32_t)((((fltype)(frn<<oct))*frqmul[adlibreg[ARC_TVS_KSR_MUL+regbase]&15]));
 	// 40+a0+b0:
 	fltype vol_in = (fltype)((fltype)(adlibreg[ARC_KSL_OUTLEV+regbase]&63) +
 							kslmul[adlibreg[ARC_KSL_OUTLEV+regbase]>>6]*kslev[oct][frn>>6]);
@@ -453,7 +453,7 @@ void change_frequency(Bitu chanbase, Bitu regbase, op_type* op_pt) {
 	change_releaserate(regbase,op_pt);
 }
 
-void enable_operator(Bitu regbase, op_type* op_pt, Bit32u act_type) {
+void enable_operator(Bitu regbase, op_type* op_pt, uint32_t act_type) {
 	// check if this is really an off-on transition
 	if (op_pt->act_state == OP_ACT_OFF) {
 		Bits wselbase = regbase;
@@ -469,7 +469,7 @@ void enable_operator(Bitu regbase, op_type* op_pt, Bit32u act_type) {
 	}
 }
 
-void disable_operator(op_type* op_pt, Bit32u act_type) {
+void disable_operator(op_type* op_pt, uint32_t act_type) {
 	// check if this is really an on-off transition
 	if (op_pt->act_state != OP_ACT_OFF) {
 		op_pt->act_state &= (~act_type);
@@ -479,12 +479,12 @@ void disable_operator(op_type* op_pt, Bit32u act_type) {
 	}
 }
 
-void adlib_init(Bit32u samplerate) {
+void adlib_init(uint32_t samplerate) {
 	Bits i, j, oct;
 
 	int_samplerate = samplerate;
 
-	generator_add = (Bit32u)(INTFREQU*FIXEDPT/int_samplerate);
+	generator_add = (uint32_t)(INTFREQU*FIXEDPT/int_samplerate);
 
 
 	memset((void *)adlibreg,0,sizeof(adlibreg));
@@ -537,14 +537,14 @@ void adlib_init(Bit32u samplerate) {
 	for (i=4; i<VIBTAB_SIZE; i++) vib_table[i] = vib_table[i-4]*-1;
 
 	// vibrato at ~6.1 ?? (opl3 docs say 6.1, opl4 docs say 6.0, y8950 docs say 6.4)
-	vibtab_add = static_cast<Bit32u>(VIBTAB_SIZE*FIXEDPT_LFO/8192*INTFREQU/int_samplerate);
+	vibtab_add = static_cast<uint32_t>(VIBTAB_SIZE*FIXEDPT_LFO/8192*INTFREQU/int_samplerate);
 	vibtab_pos = 0;
 
 	for (i=0; i<BLOCKBUF_SIZE; i++) vibval_const[i] = 0;
 
 
 	// create tremolo table
-	Bit32s trem_table_int[TREMTAB_SIZE];
+	int32_t trem_table_int[TREMTAB_SIZE];
 	for (i=0; i<14; i++)	trem_table_int[i] = i-13;		// upwards (13 to 26 -> -0.5/6 to 0)
 	for (i=14; i<41; i++)	trem_table_int[i] = -i+14;		// downwards (26 to 0 -> 0 to -1/6)
 	for (i=41; i<53; i++)	trem_table_int[i] = i-40-26;	// upwards (1 to 12 -> -1/6 to -0.5/6)
@@ -552,14 +552,14 @@ void adlib_init(Bit32u samplerate) {
 	for (i=0; i<TREMTAB_SIZE; i++) {
 		// 0.0 .. -26/26*4.8/6 == [0.0 .. -0.8], 4/53 steps == [1 .. 0.57]
 		fltype trem_val1=(fltype)(((fltype)trem_table_int[i])*4.8/26.0/6.0);				// 4.8db
-		fltype trem_val2=(fltype)((fltype)((Bit32s)(trem_table_int[i]/4))*1.2/6.0/6.0);		// 1.2db (larger stepping)
+		fltype trem_val2=(fltype)((fltype)((int32_t)(trem_table_int[i]/4))*1.2/6.0/6.0);		// 1.2db (larger stepping)
 
-		trem_table[i] = (Bit32s)(pow(FL2,trem_val1)*FIXEDPT);
-		trem_table[TREMTAB_SIZE+i] = (Bit32s)(pow(FL2,trem_val2)*FIXEDPT);
+		trem_table[i] = (int32_t)(pow(FL2,trem_val1)*FIXEDPT);
+		trem_table[TREMTAB_SIZE+i] = (int32_t)(pow(FL2,trem_val2)*FIXEDPT);
 	}
 
 	// tremolo at 3.7hz
-	tremtab_add = (Bit32u)((fltype)TREMTAB_SIZE * TREM_FREQ * FIXEDPT_LFO / (fltype)int_samplerate);
+	tremtab_add = (uint32_t)((fltype)TREMTAB_SIZE * TREM_FREQ * FIXEDPT_LFO / (fltype)int_samplerate);
 	tremtab_pos = 0;
 
 	for (i=0; i<BLOCKBUF_SIZE; i++) tremval_const[i] = FIXEDPT;
@@ -571,17 +571,17 @@ void adlib_init(Bit32u samplerate) {
 
 		// create waveform tables
 		for (i=0;i<(WAVEPREC>>1);i++) {
-			wavtable[(i << 1) + WAVEPREC] = (Bit16s)(
+			wavtable[(i << 1) + WAVEPREC] = (int16_t)(
 			        16384 * sin((fltype)((i << 1)) * M_PI * 2 / WAVEPREC));
-			wavtable[(i << 1) + 1 + WAVEPREC] = (Bit16s)(
+			wavtable[(i << 1) + 1 + WAVEPREC] = (int16_t)(
 			        16384 *
 			        sin((fltype)((i << 1) + 1) * M_PI * 2 / WAVEPREC));
 			wavtable[i] = wavtable[(i << 1) + WAVEPREC];
 			// alternative: (zero-less)
 			/*			wavtable[(i<<1)  +WAVEPREC]	=
-			   (Bit16s)(16384*sin((fltype)((i<<2)+1)*M_PI/WAVEPREC));
+			   (int16_t)(16384*sin((fltype)((i<<2)+1)*M_PI/WAVEPREC));
 			                        wavtable[(i<<1)+1+WAVEPREC] =
-			   (Bit16s)(16384*sin((fltype)((i<<2)+3)*M_PI/WAVEPREC));
+			   (int16_t)(16384*sin((fltype)((i<<2)+3)*M_PI/WAVEPREC));
 			                        wavtable[i]
 			   = wavtable[(i<<1)-1+WAVEPREC]; */
 		}
@@ -594,12 +594,12 @@ void adlib_init(Bit32u samplerate) {
 		kslev[7][0] = 0;	kslev[7][1] = 24;	kslev[7][2] = 32;	kslev[7][3] = 37;
 		kslev[7][4] = 40;	kslev[7][5] = 43;	kslev[7][6] = 45;	kslev[7][7] = 47;
 		kslev[7][8] = 48;
-		for (i=9;i<16;i++) kslev[7][i] = (Bit8u)(i+41);
+		for (i=9;i<16;i++) kslev[7][i] = (uint8_t)(i+41);
 		for (j=6;j>=0;j--) {
 			for (i=0;i<16;i++) {
 				oct = (Bits)kslev[j+1][i]-8;
 				if (oct < 0) oct = 0;
-				kslev[j][i] = (Bit8u)oct;
+				kslev[j][i] = (uint8_t)oct;
 			}
 		}
 	}
@@ -608,8 +608,8 @@ void adlib_init(Bit32u samplerate) {
 
 
 
-void adlib_write(io_port_t idx, Bit8u val) {
-	Bit32u second_set = idx&0x100;
+void adlib_write(io_port_t idx, uint8_t val) {
+	uint32_t second_set = idx&0x100;
 	adlibreg[idx] = val;
 
 	switch (idx&0xf0) {
@@ -935,7 +935,7 @@ static inline void clipit16(int32_t ival, int16_t *outval)
 {
 	if (ival<32768) {
 		if (ival>-32769) {
-			*outval=(Bit16s)ival;
+			*outval=(int16_t)ival;
 		} else {
 			*outval = -32768;
 		}
@@ -961,19 +961,19 @@ static inline void clipit16(int32_t ival, int16_t *outval)
 	outbufl[i] += chanval;
 #endif
 
-void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
+void adlib_getsample(int16_t* sndptr, Bits numsamples) {
 	Bits i, endsamples;
 	op_type* cptr;
 
-	Bit32s outbufl[BLOCKBUF_SIZE];
+	int32_t outbufl[BLOCKBUF_SIZE];
 #if defined(OPLTYPE_IS_OPL3)
 	// second output buffer (right channel for opl3 stereo)
-	Bit32s outbufr[BLOCKBUF_SIZE];
+	int32_t outbufr[BLOCKBUF_SIZE];
 #endif
 
 	// vibrato/tremolo lookup tables (global, to possibly be used by all operators)
-	Bit32s vib_lut[BLOCKBUF_SIZE];
-	Bit32s trem_lut[BLOCKBUF_SIZE];
+	int32_t vib_lut[BLOCKBUF_SIZE];
+	int32_t trem_lut[BLOCKBUF_SIZE];
 
 	Bits samples_to_process = numsamples;
 
@@ -981,14 +981,14 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 		endsamples = samples_to_process-cursmp;
 		if (endsamples>BLOCKBUF_SIZE) endsamples = BLOCKBUF_SIZE;
 
-		memset((void*)&outbufl,0,endsamples*sizeof(Bit32s));
+		memset((void*)&outbufl,0,endsamples*sizeof(int32_t));
 #if defined(OPLTYPE_IS_OPL3)
 		// clear second output buffer (opl3 stereo)
-		if (adlibreg[0x105]&1) memset((void*)&outbufr,0,endsamples*sizeof(Bit32s));
+		if (adlibreg[0x105]&1) memset((void*)&outbufr,0,endsamples*sizeof(int32_t));
 #endif
 
 		// calculate vibrato/tremolo lookup tables
-		Bit32s vib_tshift = ((adlibreg[ARC_PERC_MODE]&0x40)==0) ? 1 : 0;	// 14cents/7cents switching
+		int32_t vib_tshift = ((adlibreg[ARC_PERC_MODE]&0x40)==0) ? 1 : 0;	// 14cents/7cents switching
 		for (i=0;i<endsamples;i++) {
 			// cycle through vibrato table
 			vibtab_pos += vibtab_add;
@@ -1011,7 +1011,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 					if (cptr[9].vibrato) {
 						vibval1 = vibval_var1;
 						for (i=0;i<endsamples;i++)
-							vibval1[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+							vibval1[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 					} else vibval1 = vibval_const;
 					if (cptr[9].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 					else tremval1 = tremval_const;
@@ -1022,7 +1022,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 						opfuncs[cptr[9].op_state](&cptr[9]);
 						operator_output(&cptr[9],0,tremval1[i]);
 						
-						Bit32s chanval = cptr[9].cval*2;
+						int32_t chanval = cptr[9].cval*2;
 						CHANVAL_OUT
 					}
 				}
@@ -1032,12 +1032,12 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 					if ((cptr[0].vibrato) && (cptr[0].op_state != OF_TYPE_OFF)) {
 						vibval1 = vibval_var1;
 						for (i=0;i<endsamples;i++)
-							vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+							vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 					} else vibval1 = vibval_const;
 					if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 						vibval2 = vibval_var2;
 						for (i=0;i<endsamples;i++)
-							vibval2[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+							vibval2[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 					} else vibval2 = vibval_const;
 					if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 					else tremval1 = tremval_const;
@@ -1054,7 +1054,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 						opfuncs[cptr[9].op_state](&cptr[9]);
 						operator_output(&cptr[9],cptr[0].cval*FIXEDPT,tremval2[i]);
 						
-						Bit32s chanval = cptr[9].cval*2;
+						int32_t chanval = cptr[9].cval*2;
 						CHANVAL_OUT
 					}
 				}
@@ -1066,7 +1066,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 				if (cptr[0].vibrato) {
 					vibval3 = vibval_var1;
 					for (i=0;i<endsamples;i++)
-						vibval3[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval3[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval3 = vibval_const;
 
 				if (cptr[0].tremolo) tremval3 = trem_lut;	// tremolo enabled, use table
@@ -1077,7 +1077,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 					operator_advance(&cptr[0],vibval3[i]);
 					opfuncs[cptr[0].op_state](&cptr[0]);		//TomTom
 					operator_output(&cptr[0],0,tremval3[i]);
-					Bit32s chanval = cptr[0].cval*2;
+					int32_t chanval = cptr[0].cval*2;
 					CHANVAL_OUT
 				}
 			}
@@ -1089,12 +1089,12 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 				if ((cptr[0].vibrato) && (cptr[0].op_state != OF_TYPE_OFF)) {
 					vibval1 = vibval_var1;
 					for (i=0;i<endsamples;i++)
-						vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval1 = vibval_const;
 				if ((cptr[9].vibrato) && (cptr[9].op_state == OF_TYPE_OFF)) {
 					vibval2 = vibval_var2;
 					for (i=0;i<endsamples;i++)
-						vibval2[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval2[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval2 = vibval_const;
 
 				if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
@@ -1106,7 +1106,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 				if ((cptr[9].vibrato) && (cptr[9].op_state == OF_TYPE_OFF)) {
 					vibval4 = vibval_var2;
 					for (i=0;i<endsamples;i++)
-						vibval4[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval4[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval4 = vibval_const;
 
 				if (cptr[9].tremolo) tremval4 = trem_lut;	// tremolo enabled, use table
@@ -1126,7 +1126,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 					opfuncs[op[8 + 9].op_state](get_op(8 + 9)); // Cymbal
 					operator_output(get_op(8 + 9), 0, tremval4[i]);
 
-					Bit32s chanval = (op[7].cval + op[7+9].cval + op[8+9].cval)*2;
+					int32_t chanval = (op[7].cval + op[7+9].cval + op[8+9].cval)*2;
 					CHANVAL_OUT
 				}
 			}
@@ -1164,7 +1164,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 							if (cptr[0].vibrato) {
 								vibval1 = vibval_var1;
 								for (i=0;i<endsamples;i++)
-									vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval1 = vibval_const;
 							if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 							else tremval1 = tremval_const;
@@ -1175,7 +1175,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[0].op_state](&cptr[0]);
 								operator_output(&cptr[0],(cptr[0].lastcval+cptr[0].cval)*cptr[0].mfbi/2,tremval1[i]);
 
-								Bit32s chanval = cptr[0].cval;
+								int32_t chanval = cptr[0].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1184,7 +1184,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 							if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 								vibval1 = vibval_var1;
 								for (i=0;i<endsamples;i++)
-									vibval1[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval1[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval1 = vibval_const;
 							if (cptr[9].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 							else tremval1 = tremval_const;
@@ -1201,7 +1201,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[3].op_state](&cptr[3]);
 								operator_output(&cptr[3],cptr[9].cval*FIXEDPT,tremval2[i]);
 
-								Bit32s chanval = cptr[3].cval;
+								int32_t chanval = cptr[3].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1216,7 +1216,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[3+9].op_state](&cptr[3+9]);
 								operator_output(&cptr[3+9],0,tremval1[i]);
 
-								Bit32s chanval = cptr[3+9].cval;
+								int32_t chanval = cptr[3+9].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1226,7 +1226,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 							if (cptr[0].vibrato) {
 								vibval1 = vibval_var1;
 								for (i=0;i<endsamples;i++)
-									vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval1 = vibval_const;
 							if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 							else tremval1 = tremval_const;
@@ -1237,7 +1237,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[0].op_state](&cptr[0]);
 								operator_output(&cptr[0],(cptr[0].lastcval+cptr[0].cval)*cptr[0].mfbi/2,tremval1[i]);
 
-								Bit32s chanval = cptr[0].cval;
+								int32_t chanval = cptr[0].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1246,7 +1246,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 							if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 								vibval1 = vibval_var1;
 								for (i=0;i<endsamples;i++)
-									vibval1[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval1[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval1 = vibval_const;
 							if (cptr[9].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 							else tremval1 = tremval_const;
@@ -1269,7 +1269,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[3+9].op_state](&cptr[3+9]);
 								operator_output(&cptr[3+9],cptr[3].cval*FIXEDPT,tremval3[i]);
 
-								Bit32s chanval = cptr[3+9].cval;
+								int32_t chanval = cptr[3+9].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1282,12 +1282,12 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 				if ((cptr[0].vibrato) && (cptr[0].op_state != OF_TYPE_OFF)) {
 					vibval1 = vibval_var1;
 					for (i=0;i<endsamples;i++)
-						vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval1 = vibval_const;
 				if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 					vibval2 = vibval_var2;
 					for (i=0;i<endsamples;i++)
-						vibval2[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval2[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval2 = vibval_const;
 				if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 				else tremval1 = tremval_const;
@@ -1306,7 +1306,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 					opfuncs[cptr[9].op_state](&cptr[9]);
 					operator_output(&cptr[9],0,tremval2[i]);
 
-					Bit32s chanval = cptr[9].cval + cptr[0].cval;
+					int32_t chanval = cptr[9].cval + cptr[0].cval;
 					CHANVAL_OUT
 				}
 			} else {
@@ -1318,12 +1318,12 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 							if ((cptr[0].vibrato) && (cptr[0].op_state != OF_TYPE_OFF)) {
 								vibval1 = vibval_var1;
 								for (i=0;i<endsamples;i++)
-									vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval1 = vibval_const;
 							if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 								vibval2 = vibval_var2;
 								for (i=0;i<endsamples;i++)
-									vibval2[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval2[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval2 = vibval_const;
 							if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 							else tremval1 = tremval_const;
@@ -1340,7 +1340,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[9].op_state](&cptr[9]);
 								operator_output(&cptr[9],cptr[0].cval*FIXEDPT,tremval2[i]);
 
-								Bit32s chanval = cptr[9].cval;
+								int32_t chanval = cptr[9].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1361,7 +1361,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[3+9].op_state](&cptr[3+9]);
 								operator_output(&cptr[3+9],cptr[3].cval*FIXEDPT,tremval2[i]);
 
-								Bit32s chanval = cptr[3+9].cval;
+								int32_t chanval = cptr[3+9].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1373,12 +1373,12 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 							if ((cptr[0].vibrato) && (cptr[0].op_state != OF_TYPE_OFF)) {
 								vibval1 = vibval_var1;
 								for (i=0;i<endsamples;i++)
-									vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval1 = vibval_const;
 							if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 								vibval2 = vibval_var2;
 								for (i=0;i<endsamples;i++)
-									vibval2[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+									vibval2[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 							} else vibval2 = vibval_const;
 							if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 							else tremval1 = tremval_const;
@@ -1407,7 +1407,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 								opfuncs[cptr[3+9].op_state](&cptr[3+9]);
 								operator_output(&cptr[3+9],cptr[3].cval*FIXEDPT,tremval4[i]);
 
-								Bit32s chanval = cptr[3+9].cval;
+								int32_t chanval = cptr[3+9].cval;
 								CHANVAL_OUT
 							}
 						}
@@ -1420,12 +1420,12 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 				if ((cptr[0].vibrato) && (cptr[0].op_state != OF_TYPE_OFF)) {
 					vibval1 = vibval_var1;
 					for (i=0;i<endsamples;i++)
-						vibval1[i] = (Bit32s)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval1[i] = (int32_t)((vib_lut[i]*cptr[0].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval1 = vibval_const;
 				if ((cptr[9].vibrato) && (cptr[9].op_state != OF_TYPE_OFF)) {
 					vibval2 = vibval_var2;
 					for (i=0;i<endsamples;i++)
-						vibval2[i] = (Bit32s)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
+						vibval2[i] = (int32_t)((vib_lut[i]*cptr[9].freq_high/8)*FIXEDPT*VIBFAC);
 				} else vibval2 = vibval_const;
 				if (cptr[0].tremolo) tremval1 = trem_lut;	// tremolo enabled, use table
 				else tremval1 = tremval_const;
@@ -1444,7 +1444,7 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 					opfuncs[cptr[9].op_state](&cptr[9]);
 					operator_output(&cptr[9],cptr[0].cval*FIXEDPT,tremval2[i]);
 
-					Bit32s chanval = cptr[9].cval;
+					int32_t chanval = cptr[9].cval;
 					CHANVAL_OUT
 				}
 			}

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -102,33 +102,33 @@
      channel.
 */
 typedef struct operator_struct {
-	Bit32s cval, lastcval;			// current output/last output (used for feedback)
-	Bit32u tcount, wfpos, tinc;		// time (position in waveform) and time increment
+	int32_t cval, lastcval;			// current output/last output (used for feedback)
+	uint32_t tcount, wfpos, tinc;		// time (position in waveform) and time increment
 	fltype amp, step_amp;			// and amplification (envelope)
 	fltype vol;						// volume
 	fltype sustain_level;			// sustain level
-	Bit32s mfbi;					// feedback amount
+	int32_t mfbi;					// feedback amount
 	fltype a0, a1, a2, a3;			// attack rate function coefficients
 	fltype decaymul, releasemul;	// decay/release rate functions
-	Bit32u op_state;				// current state of operator (attack/decay/sustain/release/off)
-	Bit32u toff;
-	Bit32s freq_high;				// highest three bits of the frequency, used for vibrato calculations
-	Bit16s* cur_wform;				// start of selected waveform
-	Bit32u cur_wmask;				// mask for selected waveform
-	Bit32u act_state;				// activity state (regular, percussion)
+	uint32_t op_state;				// current state of operator (attack/decay/sustain/release/off)
+	uint32_t toff;
+	int32_t freq_high;				// highest three bits of the frequency, used for vibrato calculations
+	int16_t* cur_wform;				// start of selected waveform
+	uint32_t cur_wmask;				// mask for selected waveform
+	uint32_t act_state;				// activity state (regular, percussion)
 	bool sus_keep;					// keep sustain level when decay finished
 	bool vibrato,tremolo;			// vibrato/tremolo enable bits
 	
 	// variables used to provide non-continuous envelopes
-	Bit32u generator_pos;			// for non-standard sample rates we need to determine how many samples have passed
+	uint32_t generator_pos;			// for non-standard sample rates we need to determine how many samples have passed
 	Bits cur_env_step;				// current (standardized) sample position
 	Bits env_step_a,env_step_d,env_step_r;	// number of std samples of one step (for attack/decay/release mode)
-	Bit8u step_skip_pos_a;			// position of 8-cyclic step skipping (always 2^x to check against mask)
+	uint8_t step_skip_pos_a;			// position of 8-cyclic step skipping (always 2^x to check against mask)
 	Bits env_step_skip_a;			// bitmask that determines if a step is skipped (respective bit is zero then)
 
 #if defined(OPLTYPE_IS_OPL3)
 	bool is_4op,is_4op_attached;	// base of a 4op channel/part of a 4op channel
-	Bit32s left_pan,right_pan;		// opl3 stereo panning amount
+	int32_t left_pan,right_pan;		// opl3 stereo panning amount
 #endif
 } op_type;
 
@@ -138,22 +138,22 @@ op_type op[MAXOPERATORS];
 
 Bits int_samplerate;
 	
-Bit8u status;
-Bit32u opl_index;
+uint8_t status;
+uint32_t opl_index;
 #if defined(OPLTYPE_IS_OPL3)
-Bit8u adlibreg[512];	// adlib register set (including second set)
-Bit8u wave_sel[44];		// waveform selection
+uint8_t adlibreg[512];	// adlib register set (including second set)
+uint8_t wave_sel[44];		// waveform selection
 #else
-Bit8u adlibreg[256];	// adlib register set
-Bit8u wave_sel[22];		// waveform selection
+uint8_t adlibreg[256];	// adlib register set
+uint8_t wave_sel[22];		// waveform selection
 #endif
 
 
 // vibrato/tremolo increment/counter
-Bit32u vibtab_pos;
-Bit32u vibtab_add;
-Bit32u tremtab_pos;
-Bit32u tremtab_add;
+uint32_t vibtab_pos;
+uint32_t vibtab_add;
+uint32_t tremtab_pos;
+uint32_t tremtab_add;
 
 
 // enable an operator
@@ -172,11 +172,11 @@ void change_vibrato(Bitu regbase, op_type* op_pt);
 void change_feedback(Bitu chanbase, op_type* op_pt);
 
 // general functions
-void adlib_init(Bit32u samplerate);
-void adlib_write(io_port_t idx, Bit8u val);
-void adlib_getsample(Bit16s* sndptr, Bits numsamples);
+void adlib_init(uint32_t samplerate);
+void adlib_write(io_port_t idx, uint8_t val);
+void adlib_getsample(int16_t* sndptr, Bits numsamples);
 
 uint8_t adlib_reg_read(io_port_t port);
 void adlib_write_index(io_port_t port, io_val_t value);
 
-static Bit32u generator_add;	// should be a chip parameter
+static uint32_t generator_add;	// should be a chip parameter

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -397,7 +397,7 @@ static void PCSPEAKER_CallBack(uint16_t len)
 	if (!SpeakerExists())
 		return;
 
-	Bit16s * stream=(Bit16s*)MixTemp;
+	int16_t * stream=(int16_t*)MixTemp;
 	ForwardPIT(1);
 	spkr.last_index=0;
 	auto count = len;
@@ -456,7 +456,7 @@ static void PCSPEAKER_CallBack(uint16_t len)
 			}
 		}
 		spkr.prev_pos = pos;
-		*stream++=(Bit16s)(value/sample_add);
+		*stream++=(int16_t)(value/sample_add);
 	}
 
 	int16_t *buffer = reinterpret_cast<int16_t *>(MixTemp);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -179,7 +179,7 @@ struct SB_INFO {
 static SB_INFO sb = {};
 
 // number of bytes in input for commands (sb/sbpro)
-static Bit8u DSP_cmd_len_sb[256] = {
+static uint8_t DSP_cmd_len_sb[256] = {
   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,  // 0x00
 //  1,0,0,0, 2,0,2,2, 0,0,0,0, 0,0,0,0,  // 0x10
   1,0,0,0, 2,2,2,2, 0,0,0,0, 0,0,0,0,  // 0x10 Wari hack
@@ -203,7 +203,7 @@ static Bit8u DSP_cmd_len_sb[256] = {
 };
 
 // number of bytes in input for commands (sb16)
-static Bit8u DSP_cmd_len_sb16[256] = {
+static uint8_t DSP_cmd_len_sb16[256] = {
   0,0,0,0, 1,2,0,0, 1,0,0,0, 0,0,2,1,  // 0x00
 //  1,0,0,0, 2,0,2,2, 0,0,0,0, 0,0,0,0,  // 0x10
   1,0,0,0, 2,2,2,2, 0,0,0,0, 0,0,0,0,  // 0x10 Wari hack
@@ -226,7 +226,7 @@ static Bit8u DSP_cmd_len_sb16[256] = {
   0,0,0,0, 0,0,0,0, 0,1,0,0, 0,0,0,0   // 0xf0
 };
 
-static Bit8u ASP_regs[256];
+static uint8_t ASP_regs[256];
 static bool ASP_init_in_progress = false;
 
 static int E2_incr_table[4][9] = {
@@ -859,7 +859,7 @@ static void DSP_PrepareDMA_New(DMA_MODES mode, uint32_t length, bool autoinit, b
 	DSP_DoDMATransfer(mode,freq,autoinit,stereo);
 }
 
-static void DSP_AddData(Bit8u val) {
+static void DSP_AddData(uint8_t val) {
 	if (sb.dsp.out.used<DSP_BUFSIZE) {
 		auto start = sb.dsp.out.used + sb.dsp.out.pos;
 		if (start>=DSP_BUFSIZE) start-=DSP_BUFSIZE;
@@ -913,7 +913,7 @@ static void DSP_Reset() {
 	PIC_RemoveEvents(ProcessDMATransfer);
 }
 
-static void DSP_DoReset(Bit8u val) {
+static void DSP_DoReset(uint8_t val) {
 	if (((val&1)!=0) && (sb.dsp.state!=DSP_S_RESET)) {
 		// TODO Get out of highspeed mode
 		// Halt the channel so we're silent across reset events.
@@ -932,7 +932,7 @@ static void DSP_DoReset(Bit8u val) {
 
 static void DSP_E2_DMA_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 	if (event==DMA_UNMASKED) {
-		Bit8u val=(Bit8u)(sb.e2.value&0xff);
+		uint8_t val=(uint8_t)(sb.e2.value&0xff);
 		DmaChannel * chan=GetDMAChannel(sb.hw.dma8);
 		chan->Register_Callback(0);
 		chan->Write(1,&val);
@@ -941,7 +941,7 @@ static void DSP_E2_DMA_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 
 static void DSP_ADC_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 	if (event!=DMA_UNMASKED) return;
-	Bit8u val=128;
+	uint8_t val=128;
 	DmaChannel * ch=GetDMAChannel(sb.hw.dma8);
 	while (sb.dma.left--) {
 		ch->Write(1,&val);
@@ -1021,8 +1021,8 @@ static void DSP_DoCommand() {
 	case 0x10:	/* Direct DAC */
 		DSP_ChangeMode(MODE_DAC);
 		if (sb.dac.used<DSP_DACSIZE) {
-			sb.dac.data[sb.dac.used++]=(Bit8s(sb.dsp.in.data[0] ^ 0x80)) << 8;
-			sb.dac.data[sb.dac.used++]=(Bit8s(sb.dsp.in.data[0] ^ 0x80)) << 8;
+			sb.dac.data[sb.dac.used++]=(int8_t(sb.dsp.in.data[0] ^ 0x80)) << 8;
+			sb.dac.data[sb.dac.used++]=(int8_t(sb.dsp.in.data[0] ^ 0x80)) << 8;
 		}
 		break;
 	case 0x24:	/* Singe Cycle 8-Bit DMA ADC */
@@ -1277,7 +1277,7 @@ static void DSP_DoCommand() {
 	sb.dsp.in.pos=0;
 }
 
-static void DSP_DoWrite(Bit8u val) {
+static void DSP_DoWrite(uint8_t val) {
 	switch (sb.dsp.cmd) {
 	case DSP_NO_COMMAND:
 		sb.dsp.cmd=val;
@@ -1293,7 +1293,7 @@ static void DSP_DoWrite(Bit8u val) {
 	}
 }
 
-static Bit8u DSP_ReadData() {
+static uint8_t DSP_ReadData() {
 /* Static so it repeats the last value on succesive reads (JANGLE DEMO) */
 	if (sb.dsp.out.used) {
 		sb.dsp.out.lastval=sb.dsp.out.data[sb.dsp.out.pos];
@@ -1304,8 +1304,8 @@ static Bit8u DSP_ReadData() {
 	return sb.dsp.out.lastval;
 }
 
-static float calc_vol(Bit8u amount) {
-	Bit8u count = 31 - amount;
+static float calc_vol(uint8_t amount) {
+	uint8_t count = 31 - amount;
 	float db = static_cast<float>(count);
 	if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2) {
 		if (count) {
@@ -1368,7 +1368,7 @@ static void DSP_ChangeStereo(bool stereo) {
 	sb.dma.stereo=stereo;
 }
 
-static void CTMIXER_Write(Bit8u val) {
+static void CTMIXER_Write(uint8_t val) {
 	switch (sb.mixer.index) {
 	case 0x00:		/* Reset */
 		CTMIXER_Reset();
@@ -1508,8 +1508,8 @@ static void CTMIXER_Write(Bit8u val) {
 	}
 }
 
-static Bit8u CTMIXER_Read() {
-	Bit8u ret;
+static uint8_t CTMIXER_Read() {
+	uint8_t ret;
 //	if ( sb.mixer.index< 0x80) LOG_MSG("Read mixer %x",sb.mixer.index);
 	switch (sb.mixer.index) {
 	case 0x00:		/* RESET */
@@ -1668,7 +1668,7 @@ static void write_sb(io_port_t port, io_val_t value, io_width_t)
 static void adlib_gusforward(io_port_t, io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
-	adlib_commandreg = (Bit8u)(val & 0xff);
+	adlib_commandreg = (uint8_t)(val & 0xff);
 }
 
 bool SB_Get_Address(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma)

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -57,7 +57,7 @@ if (tandy.dac.dma.last_sample != 128) {
                 tandy.dac.chan->AddSamples_m8(1,&tandy.dac.dma.last_sample);
                 if (tandy.dac.dma.last_sample != 128)
                         tandy.dac.dma.last_sample =
-(Bit8u)(((((int)tandy.dac.dma.last_sample - 128) * 63) / 64) + 128);
+(uint8_t)(((((int)tandy.dac.dma.last_sample - 128) * 63) / 64) + 128);
         }
 }
 
@@ -101,19 +101,19 @@ static struct {
 		bool enabled = false;
 		struct {
 			Bitu base = 0u;
-			Bit8u irq = 0u;
-			Bit8u dma = 0u;
+			uint8_t irq = 0u;
+			uint8_t dma = 0u;
 		} hw;
 		struct {
 			Bitu rate = 0u;
-			Bit8u buf[TDAC_DMA_BUFSIZE] = {};
+			uint8_t buf[TDAC_DMA_BUFSIZE] = {};
 			DmaChannel *chan = nullptr;
 			bool transfer_done = false;
 		} dma;
-		Bit8u mode = 0u;
-		Bit8u control = 0u;
-		Bit16u frequency = 0u;
-		Bit8u amplitude = 0u;
+		uint8_t mode = 0u;
+		uint8_t control = 0u;
+		uint16_t frequency = 0u;
+		uint8_t amplitude = 0u;
 		bool irq_activated = false;
 	} dac = {};
 } tandy = {};
@@ -152,8 +152,8 @@ static void SN76496Update(uint16_t length)
 	const Bitu MAX_SAMPLES = 2048;
 	if (length > MAX_SAMPLES)
 		return;
-	Bit16s buffer[MAX_SAMPLES];
-	Bit16s* outputs = buffer;
+	int16_t buffer[MAX_SAMPLES];
+	int16_t* outputs = buffer;
 
 	device_sound_interface::sound_stream stream;
 	static_cast<device_sound_interface&>(device).sound_stream_update(stream, 0, &outputs, length);

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -29,7 +29,7 @@
 
 const std::chrono::steady_clock::time_point system_start_time = std::chrono::steady_clock::now();
 
-static inline void BIN2BCD(Bit16u& val) {
+static inline void BIN2BCD(uint16_t& val) {
 	const auto b = ((val / 10) % 10) << 4;
 	const auto c = ((val / 100) % 10) << 8;
 	const auto d = ((val / 1000) % 10) << 12;
@@ -39,8 +39,8 @@ static inline void BIN2BCD(Bit16u& val) {
 	val = temp;
 }
 
-static inline void BCD2BIN(Bit16u& val) {
-	Bit16u temp= (val&0x0f) +((val>>4)&0x0f) *10 +((val>>8)&0x0f) *100 +((val>>12)&0x0f) *1000;
+static inline void BCD2BIN(uint16_t& val) {
+	uint16_t temp= (val&0x0f) +((val>>4)&0x0f) *10 +((val>>8)&0x0f) *100 +((val>>12)&0x0f) *1000;
 	val=temp;
 }
 
@@ -49,13 +49,13 @@ struct PIT_Block {
 	double delay;
 	double start;
 
-	Bit16u read_latch;
-	Bit16u write_latch;
+	uint16_t read_latch;
+	uint16_t write_latch;
 
-	Bit8u mode;
-	Bit8u latch_mode;
-	Bit8u read_state;
-	Bit8u write_state;
+	uint8_t mode;
+	uint8_t latch_mode;
+	uint8_t read_state;
+	uint8_t write_state;
 
 	bool bcd;
 	bool go_read_latch;
@@ -68,7 +68,7 @@ struct PIT_Block {
 static PIT_Block pit[3];
 static bool gate2;
 
-static Bit8u latched_timerstatus;
+static uint8_t latched_timerstatus;
 // the timer status can not be overwritten until it is read or the timer was 
 // reprogrammed.
 static bool latched_timerstatus_locked;
@@ -310,7 +310,7 @@ static uint8_t read_latch(io_port_t port, io_width_t)
 {
 	// LOG(LOG_PIT,LOG_ERROR)("port read %X",port);
 	const uint16_t counter = port - 0x40;
-	Bit8u ret = 0;
+	uint8_t ret = 0;
 	if (GCC_UNLIKELY(pit[counter].counterstatus_set)) {
 		pit[counter].counterstatus_set = false;
 		latched_timerstatus_locked = false;
@@ -384,7 +384,7 @@ static void write_p43(io_port_t, io_val_t value, io_width_t)
 			pit[latch].counting = false;
 			pit[latch].read_state = (val >> 4) & 0x03;
 			pit[latch].write_state = (val >> 4) & 0x03;
-			Bit8u mode = (val >> 1) & 0x07;
+			uint8_t mode = (val >> 1) & 0x07;
 			if (mode > 5)
 				mode -= 4; // 6,7 become 2 and 3
 
@@ -438,7 +438,7 @@ static void write_p43(io_port_t, io_val_t value, io_width_t)
 void TIMER_SetGate2(bool in) {
 	//No changes if gate doesn't change
 	if(gate2 == in) return;
-	Bit8u & mode=pit[2].mode;
+	uint8_t & mode=pit[2].mode;
 	switch (mode) {
 	case 0:
 		if(in) pit[2].start = PIC_FullIndex();

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -31,18 +31,18 @@
 VGA_Type vga;
 SVGA_Driver svga;
 
-Bit32u CGA_2_Table[16];
-Bit32u CGA_4_Table[256];
-Bit32u CGA_4_HiRes_Table[256];
+uint32_t CGA_2_Table[16];
+uint32_t CGA_4_Table[256];
+uint32_t CGA_4_HiRes_Table[256];
 uint32_t CGA_16_Table[256];
 int CGA_Composite_Table[1024];
-Bit32u TXT_Font_Table[16];
-Bit32u TXT_FG_Table[16];
-Bit32u TXT_BG_Table[16];
-Bit32u ExpandTable[256];
-Bit32u Expand16Table[4][16];
-Bit32u FillTable[16];
-Bit32u ColorTable[16];
+uint32_t TXT_Font_Table[16];
+uint32_t TXT_FG_Table[16];
+uint32_t TXT_BG_Table[16];
+uint32_t ExpandTable[256];
+uint32_t Expand16Table[4][16];
+uint32_t FillTable[16];
+uint32_t ColorTable[16];
 
 std::pair<const char *, const char *> VGA_DescribeType(const VGAModes type)
 {
@@ -251,8 +251,8 @@ void VGA_SetClock(const Bitu which, const uint32_t desired_clock)
 	VGA_StartResize();
 }
 
-void VGA_SetCGA2Table(Bit8u val0,Bit8u val1) {
-	Bit8u total[2]={ val0,val1};
+void VGA_SetCGA2Table(uint8_t val0,uint8_t val1) {
+	uint8_t total[2]={ val0,val1};
 	for (Bitu i=0;i<16;i++) {
 		CGA_2_Table[i]=
 #ifdef WORDS_BIGENDIAN
@@ -265,8 +265,8 @@ void VGA_SetCGA2Table(Bit8u val0,Bit8u val1) {
 	}
 }
 
-void VGA_SetCGA4Table(Bit8u val0,Bit8u val1,Bit8u val2,Bit8u val3) {
-	Bit8u total[4]={ val0,val1,val2,val3};
+void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3) {
+	uint8_t total[4]={ val0,val1,val2,val3};
 	for (Bitu i=0;i<256;i++) {
 		CGA_4_Table[i]=
 #ifdef WORDS_BIGENDIAN

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -59,7 +59,7 @@ void VGA_ATTR_SetEGAMonitorPalette(EGAMonitorMode m) {
 		case MONO:
 			//LOG_MSG("Monitor MONO");
 			for (Bitu i=0;i<64;i++) {
-				Bit8u value = ((i & 0x8)? 0x2a:0) + ((i & 0x10)? 0x15:0);
+				uint8_t value = ((i & 0x8)? 0x2a:0) + ((i & 0x10)? 0x15:0);
 				vga.dac.rgb[i].red = vga.dac.rgb[i].green =
 					vga.dac.rgb[i].blue = value;
 			}
@@ -67,7 +67,7 @@ void VGA_ATTR_SetEGAMonitorPalette(EGAMonitorMode m) {
 	}
 
 	// update the mappings
-	for (Bit8u i=0;i<0x10;i++)
+	for (uint8_t i=0;i<0x10;i++)
 		VGA_ATTR_SetPalette(i,vga.attr.palette[i]);
 }
 
@@ -134,7 +134,7 @@ void write_p3c0(io_port_t, io_val_t value, io_width_t)
 			attr(mode_control) = val;
 
 			if (difference & 0x80) {
-				for (Bit8u i=0;i<0x10;i++)
+				for (uint8_t i=0;i<0x10;i++)
 					VGA_ATTR_SetPalette(i,vga.attr.palette[i]);
 			}
 			if (difference & 0x08)
@@ -183,7 +183,7 @@ void write_p3c0(io_port_t, io_val_t value, io_width_t)
 			if ((attr(color_plane_enable)^val) & 0xf) {
 				// in case the plane enable bits change...
 				attr(color_plane_enable) = val;
-				for (Bit8u i=0;i<0x10;i++)
+				for (uint8_t i=0;i<0x10;i++)
 					VGA_ATTR_SetPalette(i,vga.attr.palette[i]);
 			} else
 				attr(color_plane_enable) = val;
@@ -240,7 +240,7 @@ void write_p3c0(io_port_t, io_val_t value, io_width_t)
 			}
 			if (attr(color_select) ^ val) {
 				attr(color_select) = val;
-				for (Bit8u i=0;i<0x10;i++)
+				for (uint8_t i=0;i<0x10;i++)
 					VGA_ATTR_SetPalette(i,vga.attr.palette[i]);
 			}
 			/*

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -181,7 +181,7 @@ static void write_p3c9(io_port_t, io_val_t value, io_width_t)
 
 static uint8_t read_p3c9(io_port_t, io_width_t)
 {
-	Bit8u ret;
+	uint8_t ret;
 	switch (vga.dac.pel_index) {
 	case 0:
 		ret=vga.dac.rgb[vga.dac.read_index].red;
@@ -205,7 +205,7 @@ static uint8_t read_p3c9(io_port_t, io_width_t)
 	return ret;
 }
 
-void VGA_DAC_CombineColor(Bit8u attr,Bit8u pal) {
+void VGA_DAC_CombineColor(uint8_t attr,uint8_t pal) {
 	/* Check if this is a new color */
 	vga.dac.combine[attr]=pal;
 	switch (vga.mode) {
@@ -221,7 +221,7 @@ void VGA_DAC_CombineColor(Bit8u attr,Bit8u pal) {
 	}
 }
 
-void VGA_DAC_SetEntry(Bitu entry,Bit8u red,Bit8u green,Bit8u blue) {
+void VGA_DAC_SetEntry(Bitu entry,uint8_t red,uint8_t green,uint8_t blue) {
 	//Should only be called in machine != vga
 	vga.dac.rgb[entry].red=red;
 	vga.dac.rgb[entry].green=green;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -36,13 +36,13 @@
 
 #define VGA_PARTS 4
 
-typedef Bit8u * (* VGA_Line_Handler)(Bitu vidstart, Bitu line);
+typedef uint8_t * (* VGA_Line_Handler)(Bitu vidstart, Bitu line);
 
 static VGA_Line_Handler VGA_DrawLine;
 static uint8_t TempLine[SCALER_MAXWIDTH * 4];
 
-static Bit8u * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {
-	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
+static uint8_t * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {
+	const uint8_t *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
 
 	uint16_t i = 0;
 	for (Bitu x = vga.draw.blocks; x > 0; --x, ++vidstart) {
@@ -53,8 +53,8 @@ static Bit8u * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {
 	return TempLine;
 }
 
-static Bit8u * VGA_Draw_2BPP_Line(Bitu vidstart, Bitu line) {
-	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
+static uint8_t * VGA_Draw_2BPP_Line(Bitu vidstart, Bitu line) {
+	const uint8_t *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
 
 	uint16_t i = 0;
 	for (Bitu x = 0; x < vga.draw.blocks; ++x) {
@@ -65,8 +65,8 @@ static Bit8u * VGA_Draw_2BPP_Line(Bitu vidstart, Bitu line) {
 	return TempLine;
 }
 
-static Bit8u * VGA_Draw_2BPPHiRes_Line(Bitu vidstart, Bitu line) {
-	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
+static uint8_t * VGA_Draw_2BPPHiRes_Line(Bitu vidstart, Bitu line) {
+	const uint8_t *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
 
 	uint16_t i = 0;
 	for (Bitu x = 0; x < vga.draw.blocks; ++x) {
@@ -131,7 +131,7 @@ static uint8_t byte_clamp(int v)
 	return v < 0 ? 0u : (v > 255 ? 255u : static_cast<uint8_t>(v));
 }
 
-static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
+static uint8_t *Composite_Process(uint8_t border, uint32_t blocks, bool doublewidth)
 {
 	static int temp[SCALER_MAXWIDTH + 10] = {0};
 	static int atemp[SCALER_MAXWIDTH + 2] = {0};
@@ -140,8 +140,8 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 	int w = blocks * 4;
 
 	if (doublewidth) {
-		Bit8u *source = TempLine + w - 1;
-		Bit8u *dest = TempLine + w * 2 - 2;
+		uint8_t *source = TempLine + w - 1;
+		uint8_t *dest = TempLine + w * 2 - 2;
 		for (int x = 0; x < w; ++x) {
 			*dest = *source;
 			*(dest + 1) = *source;
@@ -159,7 +159,7 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 		++o;
 	};
 
-	Bit8u *rgbi = TempLine;
+	uint8_t *rgbi = TempLine;
 	int *b = &CGA_Composite_Table[border * 68];
 	for (int x = 0; x < 4; ++x)
 		push_pixel(b[(x + 3) & 3]);
@@ -176,7 +176,7 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 		// Decode
 		int *i = temp + 5;
 		uint16_t idx = 0;
-		for (Bit32u x = 0; x < blocks * 4; ++x) {
+		for (uint32_t x = 0; x < blocks * 4; ++x) {
 			int c = (i[0] + i[0]) << 3;
 			int d = (i[-1] + i[1]) << 3;
 			int y = ((c + d) << 8) + vga.sharpness * (c - d);
@@ -217,7 +217,7 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 			write_unaligned_uint32_at(TempLine, idx++, srgb);
 		};
 
-		for (Bit32u x = 0; x < blocks; ++x) {
+		for (uint32_t x = 0; x < blocks; ++x) {
 			COMPOSITE_CONVERT(ap[0], bp[0]);
 			COMPOSITE_CONVERT(-bp[0], ap[0]);
 			COMPOSITE_CONVERT(-ap[0], -bp[0]);
@@ -227,33 +227,33 @@ static Bit8u *Composite_Process(Bit8u border, Bit32u blocks, bool doublewidth)
 	return TempLine;
 }
 
-static Bit8u *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line);
+static uint8_t *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line);
 
-static Bit8u *VGA_CGA_TEXT_Composite_Draw_Line(Bitu vidstart, Bitu line)
+static uint8_t *VGA_CGA_TEXT_Composite_Draw_Line(Bitu vidstart, Bitu line)
 {
 	VGA_TEXT_Draw_Line(vidstart, line);
 	return Composite_Process(vga.tandy.color_select & 0x0f, vga.draw.blocks * 2,
 	                         (vga.tandy.mode_control & 0x1) == 0);
 }
 
-static Bit8u *VGA_Draw_CGA2_Composite_Line(Bitu vidstart, Bitu line)
+static uint8_t *VGA_Draw_CGA2_Composite_Line(Bitu vidstart, Bitu line)
 {
 	VGA_Draw_1BPP_Line(vidstart, line);
 	return Composite_Process(0, vga.draw.blocks * 2, false);
 }
 
-static Bit8u *VGA_Draw_CGA4_Composite_Line(Bitu vidstart, Bitu line)
+static uint8_t *VGA_Draw_CGA4_Composite_Line(Bitu vidstart, Bitu line)
 {
 	VGA_Draw_2BPP_Line(vidstart, line);
 	return Composite_Process(vga.tandy.color_select & 0x0f, vga.draw.blocks, true);
 }
 
-static Bit8u * VGA_Draw_4BPP_Line(Bitu vidstart, Bitu line) {
-	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
-	Bit8u* draw=TempLine;
+static uint8_t * VGA_Draw_4BPP_Line(Bitu vidstart, Bitu line) {
+	const uint8_t *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
+	uint8_t* draw=TempLine;
 	Bitu end = vga.draw.blocks*2;
 	while(end) {
-		Bit8u byte = base[vidstart & vga.tandy.addr_mask];
+		uint8_t byte = base[vidstart & vga.tandy.addr_mask];
 		*draw++=vga.attr.palette[byte >> 4];
 		*draw++=vga.attr.palette[byte & 0x0f];
 		++vidstart;
@@ -262,13 +262,13 @@ static Bit8u * VGA_Draw_4BPP_Line(Bitu vidstart, Bitu line) {
 	return TempLine;
 }
 
-static Bit8u * VGA_Draw_4BPP_Line_Double(Bitu vidstart, Bitu line) {
-	const Bit8u *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
-	Bit8u* draw=TempLine;
+static uint8_t * VGA_Draw_4BPP_Line_Double(Bitu vidstart, Bitu line) {
+	const uint8_t *base = vga.tandy.draw_base + ((line & vga.tandy.line_mask) << vga.tandy.line_shift);
+	uint8_t* draw=TempLine;
 	Bitu end = vga.draw.blocks;
 	while(end) {
-		Bit8u byte = base[vidstart & vga.tandy.addr_mask];
-		Bit8u data = vga.attr.palette[byte >> 4];
+		uint8_t byte = base[vidstart & vga.tandy.addr_mask];
+		uint8_t data = vga.attr.palette[byte >> 4];
 		*draw++ = data; *draw++ = data;
 		data = vga.attr.palette[byte & 0x0f];
 		*draw++ = data; *draw++ = data;
@@ -279,9 +279,9 @@ static Bit8u * VGA_Draw_4BPP_Line_Double(Bitu vidstart, Bitu line) {
 }
 
 #ifdef VGA_KEEP_CHANGES
-static Bit8u * VGA_Draw_Changes_Line(Bitu vidstart, Bitu line) {
+static uint8_t * VGA_Draw_Changes_Line(Bitu vidstart, Bitu line) {
 	Bitu checkMask = vga.changes.checkMask;
-	Bit8u *map = vga.changes.map;
+	uint8_t *map = vga.changes.map;
 	Bitu start = (vidstart >> VGA_CHANGE_SHIFT);
 	Bitu end = ((vidstart + vga.draw.line_length ) >> VGA_CHANGE_SHIFT);
 	for (; start <= end; ++start) {
@@ -289,7 +289,7 @@ static Bit8u * VGA_Draw_Changes_Line(Bitu vidstart, Bitu line) {
 			Bitu offset = vidstart & vga.draw.linear_mask;
 			if (vga.draw.linear_mask-offset < vga.draw.line_length)
 				memcpy(vga.draw.linear_base+vga.draw.linear_mask+1, vga.draw.linear_base, vga.draw.line_length);
-			Bit8u *ret = &vga.draw.linear_base[ offset ];
+			uint8_t *ret = &vga.draw.linear_base[ offset ];
 #if !defined(C_UNALIGNED_MEMORY)
 			if (GCC_UNLIKELY( ((Bitu)ret) & (sizeof(Bitu)-1)) ) {
 				memcpy( TempLine, ret, vga.draw.line_length );
@@ -306,9 +306,9 @@ static Bit8u * VGA_Draw_Changes_Line(Bitu vidstart, Bitu line) {
 
 #endif
 
-static Bit8u * VGA_Draw_Linear_Line(Bitu vidstart, Bitu /*line*/) {
+static uint8_t * VGA_Draw_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 	Bitu offset = vidstart & vga.draw.linear_mask;
-	Bit8u* ret = &vga.draw.linear_base[offset];
+	uint8_t* ret = &vga.draw.linear_base[offset];
 	
 	// in case (vga.draw.line_length + offset) has bits set that
 	// are not set in the mask: ((x|y)!=y) equals (x&~y)
@@ -371,7 +371,7 @@ static uint8_t *VGA_Draw_Xlat16_Linear_Line(Bitu vidstart, Bitu /*line*/)
 }
 
 //Test version, might as well keep it
-/* static Bit8u * VGA_Draw_Chain_Line(Bitu vidstart, Bitu line) {
+/* static uint8_t * VGA_Draw_Chain_Line(Bitu vidstart, Bitu line) {
 	Bitu i = 0;
 	for ( i = 0; i < vga.draw.width;i++ ) {
 		Bitu addr = vidstart + i;
@@ -380,7 +380,7 @@ static uint8_t *VGA_Draw_Xlat16_Linear_Line(Bitu vidstart, Bitu /*line*/)
 	return TempLine;
 } */
 
-static Bit8u * VGA_Draw_VGA_Line_HWMouse( Bitu vidstart, Bitu /*line*/) {
+static uint8_t * VGA_Draw_VGA_Line_HWMouse( Bitu vidstart, Bitu /*line*/) {
 	if (!svga.hardware_cursor_active || !svga.hardware_cursor_active())
 		// HW Mouse not enabled, use the tried and true call
 		return &vga.mem.linear[vidstart];
@@ -403,19 +403,19 @@ static Bit8u * VGA_Draw_VGA_Line_HWMouse( Bitu vidstart, Bitu /*line*/) {
 		// convert to video memory addr and bit index
 		// start adjusted to the pattern structure (thus shift address by 2 instead of 3)
 		// Need to get rid of the third bit, so "/8 *2" becomes ">> 2 & ~1"
-		Bitu cursorMemStart = ((sourceStartBit >> 2)& ~1) + (((Bit32u)vga.s3.hgc.startaddr) << 10);
+		Bitu cursorMemStart = ((sourceStartBit >> 2)& ~1) + (((uint32_t)vga.s3.hgc.startaddr) << 10);
 		Bitu cursorStartBit = sourceStartBit & 0x7;
 		// stay at the right position in the pattern
 		if (cursorMemStart & 0x2)
 			--cursorMemStart;
 		Bitu cursorMemEnd = cursorMemStart + ((64-vga.s3.hgc.posx) >> 2);
-		Bit8u* xat = &TempLine[vga.s3.hgc.originx]; // mouse data start pos. in scanline
+		uint8_t* xat = &TempLine[vga.s3.hgc.originx]; // mouse data start pos. in scanline
 		for (Bitu m = cursorMemStart; m < cursorMemEnd;
 		     (m & 1) ? (m += 3) : ++m) {
 			// for each byte of cursor data
-			Bit8u bitsA = vga.mem.linear[m];
-			Bit8u bitsB = vga.mem.linear[m+2];
-			for (Bit8u bit=(0x80 >> cursorStartBit); bit != 0; bit >>= 1) {
+			uint8_t bitsA = vga.mem.linear[m];
+			uint8_t bitsB = vga.mem.linear[m+2];
+			for (uint8_t bit=(0x80 >> cursorStartBit); bit != 0; bit >>= 1) {
 				// for each bit
 				cursorStartBit=0; // only the first byte has some bits cut off
 				if (bitsA&bit) {
@@ -433,7 +433,7 @@ static Bit8u * VGA_Draw_VGA_Line_HWMouse( Bitu vidstart, Bitu /*line*/) {
 	}
 }
 
-static Bit8u * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
+static uint8_t * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 	if (!svga.hardware_cursor_active || !svga.hardware_cursor_active())
 		return &vga.mem.linear[vidstart];
 
@@ -445,7 +445,7 @@ static Bit8u * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 	} else {
 		memcpy(TempLine, &vga.mem.linear[ vidstart ], vga.draw.width*2);
 		Bitu sourceStartBit = ((lineat - vga.s3.hgc.originy) + vga.s3.hgc.posy)*64 + vga.s3.hgc.posx; 
- 		Bitu cursorMemStart = ((sourceStartBit >> 2)& ~1) + (((Bit32u)vga.s3.hgc.startaddr) << 10);
+ 		Bitu cursorMemStart = ((sourceStartBit >> 2)& ~1) + (((uint32_t)vga.s3.hgc.startaddr) << 10);
 		Bitu cursorStartBit = sourceStartBit & 0x7;
 		if (cursorMemStart & 0x2) cursorMemStart--;
 		Bitu cursorMemEnd = cursorMemStart + ((64-vga.s3.hgc.posx) >> 2);
@@ -454,9 +454,9 @@ static Bit8u * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 		for (Bitu m = cursorMemStart; m < cursorMemEnd;
 		     (m & 1) ? (m += 3) : ++m) {
 			// for each byte of cursor data
-			Bit8u bitsA = vga.mem.linear[m];
-			Bit8u bitsB = vga.mem.linear[m+2];
-			for (Bit8u bit=(0x80 >> cursorStartBit); bit != 0; bit >>= 1) {
+			uint8_t bitsA = vga.mem.linear[m];
+			uint8_t bitsB = vga.mem.linear[m+2];
+			for (uint8_t bit=(0x80 >> cursorStartBit); bit != 0; bit >>= 1) {
 				// for each bit
 				cursorStartBit=0;
 				if (bitsA&bit) {
@@ -467,7 +467,7 @@ static Bit8u * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 					}
 					// else Transparent
 				} else if (bitsB & bit) {
-					// Source as well as destination are Bit8u arrays, 
+					// Source as well as destination are uint8_t arrays, 
 					// so this should work out endian-wise?
 					const auto fore = read_unaligned_uint16(vga.s3.hgc.forestack);
 					write_unaligned_uint16_at(TempLine, i, fore);
@@ -482,7 +482,7 @@ static Bit8u * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 	}
 }
 
-static Bit8u * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
+static uint8_t * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 	if (!svga.hardware_cursor_active || !svga.hardware_cursor_active())
 		return &vga.mem.linear[vidstart];
 
@@ -494,7 +494,7 @@ static Bit8u * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 	} else {
 		memcpy(TempLine, &vga.mem.linear[ vidstart ], vga.draw.width*4);
 		Bitu sourceStartBit = ((lineat - vga.s3.hgc.originy) + vga.s3.hgc.posy)*64 + vga.s3.hgc.posx; 
-		Bitu cursorMemStart = ((sourceStartBit >> 2)& ~1) + (((Bit32u)vga.s3.hgc.startaddr) << 10);
+		Bitu cursorMemStart = ((sourceStartBit >> 2)& ~1) + (((uint32_t)vga.s3.hgc.startaddr) << 10);
 		Bitu cursorStartBit = sourceStartBit & 0x7;
 		if (cursorMemStart & 0x2)
 			--cursorMemStart;
@@ -503,9 +503,9 @@ static Bit8u * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 		for (Bitu m = cursorMemStart; m < cursorMemEnd;
 		     (m & 1) ? (m += 3) : ++m) {
 			// for each byte of cursor data
-			Bit8u bitsA = vga.mem.linear[m];
-			Bit8u bitsB = vga.mem.linear[m+2];
-			for (Bit8u bit=(0x80 >> cursorStartBit); bit != 0; bit >>= 1) { // for each bit
+			uint8_t bitsA = vga.mem.linear[m];
+			uint8_t bitsB = vga.mem.linear[m+2];
+			for (uint8_t bit=(0x80 >> cursorStartBit); bit != 0; bit >>= 1) { // for each bit
 				cursorStartBit=0;
 				if (bitsA&bit) {
 					if (bitsB & bit) {
@@ -527,7 +527,7 @@ static Bit8u * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 	}
 }
 
-static const Bit8u* VGA_Text_Memwrap(Bitu vidstart) {
+static const uint8_t* VGA_Text_Memwrap(Bitu vidstart) {
 	vidstart &= vga.draw.linear_mask;
 	Bitu line_end = 2 * vga.draw.blocks;
 	if (GCC_UNLIKELY((vidstart + line_end) > vga.draw.linear_mask)) {
@@ -547,19 +547,19 @@ static bool SkipCursor(Bitu vidstart, Bitu line)
 	       (vga.draw.cursor.address < vidstart);
 }
 
-static Bit32u FontMask[2]={0xffffffff,0x0};
+static uint32_t FontMask[2]={0xffffffff,0x0};
 static uint8_t *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line)
 {
 	uint16_t i = 0;
-	const Bit8u* vidmem = VGA_Text_Memwrap(vidstart);
+	const uint8_t* vidmem = VGA_Text_Memwrap(vidstart);
 	for (Bitu cx = 0; cx < vga.draw.blocks; ++cx) {
 		Bitu chr=vidmem[cx*2];
 		Bitu col=vidmem[cx*2+1];
 		Bitu font=vga.draw.font_tables[(col >> 3)&1][chr*32+line];
-		Bit32u mask1=TXT_Font_Table[font>>4] & FontMask[col >> 7];
-		Bit32u mask2=TXT_Font_Table[font&0xf] & FontMask[col >> 7];
-		Bit32u fg=TXT_FG_Table[col&0xf];
-		Bit32u bg=TXT_BG_Table[col>>4];
+		uint32_t mask1=TXT_Font_Table[font>>4] & FontMask[col >> 7];
+		uint32_t mask2=TXT_Font_Table[font&0xf] & FontMask[col >> 7];
+		uint32_t fg=TXT_FG_Table[col&0xf];
+		uint32_t bg=TXT_BG_Table[col>>4];
 		write_unaligned_uint32_at(TempLine, i++, (fg & mask1) | (bg & ~mask1));
 		write_unaligned_uint32_at(TempLine, i++, (fg & mask2) | (bg & ~mask2));
 	}
@@ -567,8 +567,8 @@ static uint8_t *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line)
 		return TempLine;
 	const Bitu font_addr = (vga.draw.cursor.address - vidstart) >> 1;
 	if (font_addr < vga.draw.blocks) {
-		Bit32u *draw = (Bit32u *)&TempLine[font_addr * 8];
-		Bit32u att=TXT_FG_Table[vga.tandy.draw_base[vga.draw.cursor.address+1]&0xf];
+		uint32_t *draw = (uint32_t *)&TempLine[font_addr * 8];
+		uint32_t att=TXT_FG_Table[vga.tandy.draw_base[vga.draw.cursor.address+1]&0xf];
 		*draw++ = att;
 		*draw++ = att;
 	}
@@ -578,7 +578,7 @@ static uint8_t *VGA_TEXT_Draw_Line(Bitu vidstart, Bitu line)
 static uint8_t *VGA_TEXT_Herc_Draw_Line(Bitu vidstart, Bitu line)
 {
 	uint16_t i = 0;
-	const Bit8u* vidmem = VGA_Text_Memwrap(vidstart);
+	const uint8_t* vidmem = VGA_Text_Memwrap(vidstart);
 
 	for (Bitu cx = 0; cx < vga.draw.blocks; ++cx) {
 		Bitu chr=vidmem[cx*2];
@@ -588,7 +588,7 @@ static uint8_t *VGA_TEXT_Herc_Draw_Line(Bitu vidstart, Bitu line)
 			write_unaligned_uint32_at(TempLine, i++, 0);
 			write_unaligned_uint32_at(TempLine, i++, 0);
 		} else {
-			Bit32u bg, fg;
+			uint32_t bg, fg;
 			bool underline=false;
 			if ((attrib&0x77)==0x70) {
 				bg = TXT_BG_Table[0x7];
@@ -600,7 +600,7 @@ static uint8_t *VGA_TEXT_Herc_Draw_Line(Bitu vidstart, Bitu line)
 				if (attrib&0x8) fg = TXT_FG_Table[0xf];
 				else fg = TXT_FG_Table[0x7];
 			}
-			Bit32u mask1, mask2;
+			uint32_t mask1, mask2;
 			if (GCC_UNLIKELY(underline)) mask1 = mask2 = FontMask[attrib >> 7];
 			else {
 				Bitu font=vga.draw.font_tables[0][chr*32+line];
@@ -615,9 +615,9 @@ static uint8_t *VGA_TEXT_Herc_Draw_Line(Bitu vidstart, Bitu line)
 		return TempLine;
 	const Bitu font_addr = (vga.draw.cursor.address - vidstart) >> 1;
 	if (font_addr < vga.draw.blocks) {
-		Bit32u *draw = (Bit32u *)&TempLine[font_addr * 8];
-		Bit8u attr = vga.tandy.draw_base[vga.draw.cursor.address+1];
-		Bit32u cg;
+		uint32_t *draw = (uint32_t *)&TempLine[font_addr * 8];
+		uint8_t attr = vga.tandy.draw_base[vga.draw.cursor.address+1];
+		uint32_t cg;
 		if (attr&0x8) {
 			cg = TXT_FG_Table[0xf];
 		} else if ((attr&0x77)==0x70) {
@@ -635,7 +635,7 @@ static uint8_t *VGA_TEXT_Xlat16_Draw_Line(Bitu vidstart, Bitu line)
 {
 	// keep it aligned:
 	uint16_t idx = 16 - vga.draw.panning;
-	const Bit8u* vidmem = VGA_Text_Memwrap(vidstart); // pointer to chars+attribs
+	const uint8_t* vidmem = VGA_Text_Memwrap(vidstart); // pointer to chars+attribs
 	Bitu blocks = vga.draw.blocks;
 	if (vga.draw.panning)
 		++blocks; // if the text is panned part of an
@@ -682,7 +682,7 @@ static uint8_t *VGA_TEXT_Xlat16_Draw_Line(Bitu vidstart, Bitu line)
 		const Bitu attr_addr = (vga.draw.cursor.address - vidstart) >> 1;
 		if (attr_addr < vga.draw.blocks) {
 			Bitu index = attr_addr * (vga.draw.char9dot? 18:16);
-			Bit16u *draw = (Bit16u *)(&TempLine[index]) + 16 -
+			uint16_t *draw = (uint16_t *)(&TempLine[index]) + 16 -
 			               vga.draw.panning;
 
 			Bitu foreground = vga.tandy.draw_base[vga.draw.cursor.address+1] & 0xf;
@@ -700,9 +700,9 @@ static inline void VGA_ChangesEnd(void ) {
 //		vga.changes.active = false;
 		Bitu end = vga.draw.address >> VGA_CHANGE_SHIFT;
 		Bitu total = 4 + end - vga.changes.start;
-		Bit32u clearMask = vga.changes.clearMask;
+		uint32_t clearMask = vga.changes.clearMask;
 		total >>= 2;
-		Bit32u *clear = (Bit32u *)&vga.changes.map[  vga.changes.start & ~3 ];
+		uint32_t *clear = (uint32_t *)&vga.changes.map[  vga.changes.start & ~3 ];
 		while ( total-- ) {
 			clear[0] &= clearMask;
 			++clear;
@@ -728,7 +728,7 @@ static void VGA_ProcessSplit() {
 	vga.draw.address_line=0;
 }
 
-static Bit8u bg_color_index = 0; // screen-off black index
+static uint8_t bg_color_index = 0; // screen-off black index
 static void VGA_DrawSingleLine(uint32_t /*blah*/)
 {
 	if (GCC_UNLIKELY(vga.attr.disabled)) {
@@ -783,14 +783,14 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 		if (vga.draw.bpp==8) {
 			memset(TempLine, bg_color_index, sizeof(TempLine));
 		} else if (vga.draw.bpp == 16) {
-			Bit16u value = vga.dac.xlat16[bg_color_index];
+			uint16_t value = vga.dac.xlat16[bg_color_index];
 			for (size_t i = 0; i < sizeof(TempLine) / 2; ++i) {
 				write_unaligned_uint16_at(TempLine, i, value);
 			}
 		}
 		RENDER_DrawLine(TempLine);
 	} else {
-		Bit8u * data=VGA_DrawLine( vga.draw.address, vga.draw.address_line );	
+		uint8_t * data=VGA_DrawLine( vga.draw.address, vga.draw.address_line );	
 		RENDER_DrawLine(data);
 	}
 
@@ -814,7 +814,7 @@ static void VGA_DrawEGASingleLine(uint32_t /*blah*/)
 	} else {
 		Bitu address = vga.draw.address;
 		if (vga.mode!=M_TEXT) address += vga.draw.panning;
-		Bit8u * data=VGA_DrawLine(address, vga.draw.address_line );	
+		uint8_t * data=VGA_DrawLine(address, vga.draw.address_line );	
 		RENDER_DrawLine(data);
 	}
 
@@ -833,7 +833,7 @@ static void VGA_DrawEGASingleLine(uint32_t /*blah*/)
 static void VGA_DrawPart(uint32_t lines)
 {
 	while (lines--) {
-		Bit8u * data=VGA_DrawLine( vga.draw.address, vga.draw.address_line );
+		uint8_t * data=VGA_DrawLine( vga.draw.address, vga.draw.address_line );
 		RENDER_DrawLine(data);
 		++vga.draw.address_line;
 		if (vga.draw.address_line>=vga.draw.address_line_total) {

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -219,7 +219,7 @@ static uint8_t read_p3cf(io_port_t port, io_width_t)
 	default:
 		if (svga.read_p3cf)
 			return svga.read_p3cf(gfx(index), io_width_t::byte);
-		LOG(LOG_VGAMISC,LOG_NORMAL)("Reading from illegal index %2X in port %4X",static_cast<Bit32u>(gfx(index)),port);
+		LOG(LOG_VGAMISC,LOG_NORMAL)("Reading from illegal index %2X in port %4X",static_cast<uint32_t>(gfx(index)),port);
 		break;
 	}
 	return 0;	/* Compiler happy */

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -30,7 +30,7 @@ uint8_t vga_read_p3d5(io_port_t port, io_width_t);
 
 uint8_t vga_read_p3da(io_port_t, io_width_t)
 {
-	Bit8u retval = 4; // bit 2 set, needed by Blues Brothers
+	uint8_t retval = 4; // bit 2 set, needed by Blues Brothers
 	const auto timeInFrame = PIC_FullIndex() - vga.draw.delay.framestart;
 
 	vga.internal.attrindex=false;
@@ -124,7 +124,7 @@ static uint8_t read_p3c8(io_port_t, io_width_t)
 
 static uint8_t read_p3c2(io_port_t, io_width_t)
 {
-	Bit8u retval = 0;
+	uint8_t retval = 0;
 
 	if (machine==MCH_EGA) retval = 0x0F;
 	else if (IS_VGA_ARCH) retval = 0x60;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -193,7 +193,7 @@ static void write_lightpen(io_port_t port, io_val_t, io_width_t)
 			const auto timeInLine = fmod(timeInFrame, vga.draw.delay.htotal);
 			Bitu current_scanline = (Bitu)(timeInFrame / vga.draw.delay.htotal);
 
-			vga.other.lightpen = (Bit16u)((vga.draw.address_add/2) * (current_scanline/2));
+			vga.other.lightpen = (uint16_t)((vga.draw.address_add/2) * (current_scanline/2));
 			vga.other.lightpen += static_cast<uint16_t>(
 			        (timeInLine / vga.draw.delay.hdend) *
 			        (static_cast<double>(vga.draw.address_add / 2)));

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -151,7 +151,7 @@ void FinishSetMode_PVGA1A(io_port_t /*crtc_base*/, VGA_ModeExtraData *modeData)
 	IO_Write(0x3ce, 0x0a);
 	IO_Write(0x3cf, 0x00);
 	IO_Write(0x3ce, 0x0b);
-	Bit8u val = IO_Read(0x3cf);
+	uint8_t val = IO_Read(0x3cf);
 	IO_Write(0x3cf, val & ~0x08);
 	IO_Write(0x3ce, 0x0c);
 	IO_Write(0x3cf, 0x00);

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -441,9 +441,9 @@ uint8_t SVGA_S3_ReadCRTC(io_port_t reg, io_width_t)
 	case 0x67:	/* Extended Miscellaneous Control 2 */
 		return vga.s3.misc_control_2;
 	case 0x69:	/* Extended System Control 3 */
-		return (Bit8u)((vga.config.display_start & 0x1f0000)>>16);
+		return (uint8_t)((vga.config.display_start & 0x1f0000)>>16);
 	case 0x6a:	/* Extended System Control 4 */
-		return (Bit8u)(vga.svga.bank_read & 0x7f);
+		return (uint8_t)(vga.svga.bank_read & 0x7f);
 	case 0x6b:	// BIOS scatchpad: LFB address
 		return vga.s3.reg_6b;
 	default:

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -83,7 +83,7 @@ void write_p3c5(io_port_t, io_val_t value, io_width_t)
 		        if (IS_VGA_ARCH)
 			        font1 |= (val & 0x10) >> 4;
 		        vga.draw.font_tables[0] = &vga.draw.font[font1 * 8 * 1024];
-		        Bit8u font2 = ((val & 0xc) >> 1);
+		        uint8_t font2 = ((val & 0xc) >> 1);
 		        if (IS_VGA_ARCH)
 			        font2 |= (val & 0x20) >> 5;
 		        vga.draw.font_tables[1] = &vga.draw.font[font2 * 8 * 1024];

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -30,7 +30,7 @@
 
 // Tseng ET4K data
 typedef struct {
-	Bit8u extensionsEnabled;
+	uint8_t extensionsEnabled;
 
 // Stored exact values of some registers. Documentation only specifies some bits but hardware checks may
 // expect other bits to be preserved.
@@ -126,7 +126,7 @@ void write_p3d5_et4k(io_port_t reg, io_val_t value, io_width_t)
 		vga.config.line_compare = (vga.config.line_compare & 0x3ff) | ((val&0x10)<<6);
 	// Abusing s3 ex_ver_overflow field. This is to be cleaned up later.
 		{
-			Bit8u s3val =
+			uint8_t s3val =
 				((val & 0x01) << 2) | // vbstart
 				((val & 0x02) >> 1) | // vtotal
 				((val & 0x04) >> 1) | // vdispend
@@ -336,14 +336,14 @@ void FinishSetMode_ET4K(io_port_t crtc_base, VGA_ModeExtraData *modeData)
 	// Reinterpret hor_overflow. Curiously, three bits out of four are
 	// in the same places. Input has hdispend (not supported), output
 	// has CRTC offset (also not supported)
-	Bit8u et4k_hor_overflow =
+	uint8_t et4k_hor_overflow =
 		(modeData->hor_overflow & 0x01) |
 		(modeData->hor_overflow & 0x04) |
 		(modeData->hor_overflow & 0x10);
 	IO_Write(crtc_base,0x3f);IO_Write(crtc_base+1,et4k_hor_overflow);
 
 	// Reinterpret ver_overflow
-	Bit8u et4k_ver_overflow =
+	uint8_t et4k_ver_overflow =
 		((modeData->ver_overflow & 0x01) << 1) | // vtotal10
 		((modeData->ver_overflow & 0x02) << 1) | // vdispend10
 		((modeData->ver_overflow & 0x04) >> 2) | // vbstart10
@@ -568,7 +568,7 @@ void write_p3d5_et3k(io_port_t reg, io_val_t value, io_width_t)
 		vga.config.line_compare = (vga.config.line_compare & 0x3ff) | ((val&0x10)<<6);
 	// Abusing s3 ex_ver_overflow field. This is to be cleaned up later.
 		{
-			Bit8u s3val =
+			uint8_t s3val =
 				((val & 0x01) << 2) | // vbstart
 				((val & 0x02) >> 1) | // vtotal
 				((val & 0x04) >> 1) | // vdispend
@@ -711,7 +711,7 @@ void FinishSetMode_ET3K(io_port_t crtc_base, VGA_ModeExtraData *modeData)
 
 	// Tseng ET3K does not have horizontal overflow bits
 	// Reinterpret ver_overflow
-	Bit8u et4k_ver_overflow =
+	uint8_t et4k_ver_overflow =
 		((modeData->ver_overflow & 0x01) << 1) | // vtotal10
 		((modeData->ver_overflow & 0x02) << 1) | // vdispend10
 		((modeData->ver_overflow & 0x04) >> 2) | // vbstart10
@@ -739,7 +739,7 @@ void FinishSetMode_ET3K(io_port_t crtc_base, VGA_ModeExtraData *modeData)
 		Bitu best = 1;
 		int dist = 100000000;
 		for (Bitu i = 0; i < 8; i++) {
-			int cdiff = abs( static_cast<Bit32s>(target - static_cast<Bits>(et3k.clockFreq[i])) );
+			int cdiff = abs( static_cast<int32_t>(target - static_cast<Bits>(et3k.clockFreq[i])) );
 			if (cdiff < dist) {
 				best = i;
 				dist = cdiff;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -42,39 +42,39 @@ constexpr uint16_t XGA_32_BIT = 0x0008;
 
 struct XGAStatus {
 	struct scissorreg {
-		Bit16u x1, y1, x2, y2;
+		uint16_t x1, y1, x2, y2;
 	} scissors;
 
-	Bit32u readmask;
-	Bit32u writemask;
+	uint32_t readmask;
+	uint32_t writemask;
 
-	Bit32u forecolor;
-	Bit32u backcolor;
+	uint32_t forecolor;
+	uint32_t backcolor;
 
 	Bitu curcommand;
 
-	Bit16u foremix;
-	Bit16u backmix;
+	uint16_t foremix;
+	uint16_t backmix;
 
-	Bit16u curx, cury;
-	Bit16u destx, desty;
+	uint16_t curx, cury;
+	uint16_t destx, desty;
 
-	Bit16u ErrTerm;
-	Bit16u MIPcount;
-	Bit16u MAPcount;
+	uint16_t ErrTerm;
+	uint16_t MIPcount;
+	uint16_t MAPcount;
 
-	Bit16u pix_cntl;
-	Bit16u control1;
-	Bit16u control2;
-	Bit16u read_sel;
+	uint16_t pix_cntl;
+	uint16_t control1;
+	uint16_t control2;
+	uint16_t read_sel;
 
 	struct XGA_WaitCmd {
 		bool newline;
 		bool wait;
-		Bit16u cmd;
-		Bit16u curx, cury;
-		Bit16u x1, y1, x2, y2, sizex, sizey;
-		Bit32u data; /* transient data passed by multiple calls */
+		uint16_t cmd;
+		uint16_t curx, cury;
+		uint16_t x1, y1, x2, y2, sizex, sizey;
+		uint32_t data; /* transient data passed by multiple calls */
 		Bitu datasize;
 		Bitu buswidth;
 	} waitcmd;
@@ -159,15 +159,15 @@ void XGA_DrawPoint(Bitu x, Bitu y, Bitu c) {
 			break;
 		case M_LIN15:
 			if (GCC_UNLIKELY(memaddr*2 >= vga.vmemsize)) break;
-			((Bit16u*)(vga.mem.linear))[memaddr] = (Bit16u)(c&0x7fff);
+			((uint16_t*)(vga.mem.linear))[memaddr] = (uint16_t)(c&0x7fff);
 			break;
 		case M_LIN16:
 			if (GCC_UNLIKELY(memaddr*2 >= vga.vmemsize)) break;
-			((Bit16u*)(vga.mem.linear))[memaddr] = (Bit16u)(c&0xffff);
+			((uint16_t*)(vga.mem.linear))[memaddr] = (uint16_t)(c&0xffff);
 			break;
 		case M_LIN32:
 			if (GCC_UNLIKELY(memaddr*4 >= vga.vmemsize)) break;
-			((Bit32u*)(vga.mem.linear))[memaddr] = c;
+			((uint32_t*)(vga.mem.linear))[memaddr] = c;
 			break;
 		default:
 			break;
@@ -185,10 +185,10 @@ Bitu XGA_GetPoint(Bitu x, Bitu y) {
 	case M_LIN15:
 	case M_LIN16:
 		if (GCC_UNLIKELY(memaddr*2 >= vga.vmemsize)) break;
-		return ((Bit16u*)(vga.mem.linear))[memaddr];
+		return ((uint16_t*)(vga.mem.linear))[memaddr];
 	case M_LIN32:
 		if (GCC_UNLIKELY(memaddr*4 >= vga.vmemsize)) break;
-		return ((Bit32u*)(vga.mem.linear))[memaddr];
+		return ((uint32_t*)(vga.mem.linear))[memaddr];
 	default:
 		break;
 	}
@@ -377,7 +377,7 @@ static void XGA_DrawLineBresenham(const uint32_t val, const bool skip_last_pixel
 	//
 	// lpast = 2 * min(abs(dx),abs(dy))
 
-	dminor = (Bits)((Bit16s)xga.desty);
+	dminor = (Bits)((int16_t)xga.desty);
 	if(xga.desty&0x2000) dminor |= ~0x1fff;
 	dminor >>= 1;
 
@@ -389,7 +389,7 @@ static void XGA_DrawLineBresenham(const uint32_t val, const bool skip_last_pixel
 	//
 	// lpdst = 2 * min(abs(dx),abs(dy)) - max(abs(dx),abs(dy))
 
-	destxtmp = (Bits)((Bit16s)xga.destx);
+	destxtmp = (Bits)((int16_t)xga.destx);
 	if (xga.destx & 0x2000)
 		destxtmp |= ~0x1fff;
 
@@ -412,7 +412,7 @@ static void XGA_DrawLineBresenham(const uint32_t val, const bool skip_last_pixel
 	// if x1 < x2: 2 * min(abs(dx),abs(dy)) - max(abs(dx),abs(dy))
 	// if x1 >= x2: 2 * min(abs(dx),abs(dy)) - max(abs(dx),abs(dy)) - 1
 
-	e = (Bits)((Bit16s)xga.ErrTerm);
+	e = (Bits)((int16_t)xga.ErrTerm);
 	if(xga.ErrTerm&0x2000) e |= ~0x1fff;
 	xat = xga.curx;
 	yat = xga.cury;
@@ -577,9 +577,9 @@ bool XGA_CheckX(void) {
 		if((xga.waitcmd.cury<2048)&&(xga.waitcmd.cury > xga.waitcmd.y2))
 			xga.waitcmd.wait = false;
 	} else if(xga.waitcmd.curx>=2048) {
-		Bit16u realx = 4096-xga.waitcmd.curx;
+		uint16_t realx = 4096-xga.waitcmd.curx;
 		if(xga.waitcmd.x2>2047) { // x end is negative too
-			Bit16u realxend=4096-xga.waitcmd.x2;
+			uint16_t realxend=4096-xga.waitcmd.x2;
 			if(realx==realxend) {
 				xga.waitcmd.curx = xga.waitcmd.x1;
 				xga.waitcmd.cury++;
@@ -792,7 +792,7 @@ void XGA_DrawWait(uint32_t val, io_width_t width)
 }
 
 void XGA_BlitRect(Bitu val) {
-	Bit32u xat, yat;
+	uint32_t xat, yat;
 	Bitu srcdata;
 	Bitu dstdata;
 	Bits srcx, srcy, tarx, tary, dx, dy;
@@ -956,7 +956,7 @@ void XGA_DrawPattern(Bitu val) {
 
 static void XGA_DrawCmd(const uint32_t val)
 {
-	Bit16u cmd;
+	uint16_t cmd;
 	cmd = val >> 13;
 #if XGA_SHOW_COMMAND_TRACE == 1
 	//LOG_MSG("XGA: Draw command %x", cmd);
@@ -1013,8 +1013,8 @@ static void XGA_DrawCmd(const uint32_t val)
 			        xga.waitcmd.cury = xga.cury;
 			        xga.waitcmd.x1 = xga.curx;
 			        xga.waitcmd.y1 = xga.cury;
-			        xga.waitcmd.x2 = (Bit16u)((xga.curx + xga.MAPcount)&0x0fff);
-				xga.waitcmd.y2 = (Bit16u)((xga.cury + xga.MIPcount + 1)&0x0fff);
+			        xga.waitcmd.x2 = (uint16_t)((xga.curx + xga.MAPcount)&0x0fff);
+				xga.waitcmd.y2 = (uint16_t)((xga.cury + xga.MIPcount + 1)&0x0fff);
 				xga.waitcmd.sizex = xga.MAPcount;
 				xga.waitcmd.sizey = xga.MIPcount + 1;
 				xga.waitcmd.cmd = 2;
@@ -1050,13 +1050,13 @@ static void XGA_DrawCmd(const uint32_t val)
 	}
 }
 
-void XGA_SetDualReg(Bit32u &reg, uint32_t val)
+void XGA_SetDualReg(uint32_t &reg, uint32_t val)
 {
 	switch (XGA_COLOR_MODE) {
-	case M_LIN8: reg = (Bit8u)(val & 0xff); break;
+	case M_LIN8: reg = (uint8_t)(val & 0xff); break;
 	case M_LIN15:
 	case M_LIN16:
-		reg = (Bit16u)(val&0xffff); break;
+		reg = (uint16_t)(val&0xffff); break;
 	case M_LIN32:
 		if (xga.control1 & 0x200)
 			reg = val;
@@ -1071,12 +1071,12 @@ void XGA_SetDualReg(Bit32u &reg, uint32_t val)
 	}
 }
 
-uint32_t XGA_GetDualReg(Bit32u reg) {
+uint32_t XGA_GetDualReg(uint32_t reg) {
 	switch(XGA_COLOR_MODE) {
 	case M_LIN8:
-		return (Bit8u)(reg&0xff);
+		return (uint8_t)(reg&0xff);
 	case M_LIN15: case M_LIN16:
-		return (Bit16u)(reg&0xffff);
+		return (uint16_t)(reg&0xffff);
 	case M_LIN32:
 		if (xga.control1 & 0x200) return reg;
 		xga.control1 ^= 0x10;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -47,15 +47,15 @@ diskGeo DiskGeometryList[] = {
 
 Bitu call_int13;
 Bitu diskparm0, diskparm1;
-static Bit8u last_status;
-static Bit8u last_drive;
-Bit16u imgDTASeg;
+static uint8_t last_status;
+static uint8_t last_drive;
+uint16_t imgDTASeg;
 RealPt imgDTAPtr;
 DOS_DTA *imgDTA;
 bool killRead;
 static bool swapping_requested;
 
-void BIOS_SetEquipment(Bit16u equipment);
+void BIOS_SetEquipment(uint16_t equipment);
 
 /* 2 floppys and 2 harddrives, max */
 std::array<std::shared_ptr<imageDisk>, MAX_DISK_IMAGES> imageDiskList;
@@ -64,33 +64,33 @@ std::array<std::shared_ptr<imageDisk>, MAX_SWAPPABLE_DISKS> diskSwap;
 unsigned int swapPosition;
 
 void updateDPT(void) {
-	Bit32u tmpheads, tmpcyl, tmpsect, tmpsize;
+	uint32_t tmpheads, tmpcyl, tmpsect, tmpsize;
 	if(imageDiskList[2]) {
 		PhysPt dp0physaddr=CALLBACK_PhysPointer(diskparm0);
 		imageDiskList[2]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-		phys_writew(dp0physaddr,(Bit16u)tmpcyl);
-		phys_writeb(dp0physaddr+0x2,(Bit8u)tmpheads);
+		phys_writew(dp0physaddr,(uint16_t)tmpcyl);
+		phys_writeb(dp0physaddr+0x2,(uint8_t)tmpheads);
 		phys_writew(dp0physaddr+0x3,0);
-		phys_writew(dp0physaddr+0x5,(Bit16u)-1);
+		phys_writew(dp0physaddr+0x5,(uint16_t)-1);
 		phys_writeb(dp0physaddr+0x7,0);
 		phys_writeb(dp0physaddr+0x8,(0xc0 | (((imageDiskList[2]->heads) > 8) << 3)));
 		phys_writeb(dp0physaddr+0x9,0);
 		phys_writeb(dp0physaddr+0xa,0);
 		phys_writeb(dp0physaddr+0xb,0);
-		phys_writew(dp0physaddr+0xc,(Bit16u)tmpcyl);
-		phys_writeb(dp0physaddr+0xe,(Bit8u)tmpsect);
+		phys_writew(dp0physaddr+0xc,(uint16_t)tmpcyl);
+		phys_writeb(dp0physaddr+0xe,(uint8_t)tmpsect);
 	}
 	if(imageDiskList[3]) {
 		PhysPt dp1physaddr=CALLBACK_PhysPointer(diskparm1);
 		imageDiskList[3]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-		phys_writew(dp1physaddr,(Bit16u)tmpcyl);
-		phys_writeb(dp1physaddr+0x2,(Bit8u)tmpheads);
-		phys_writeb(dp1physaddr+0xe,(Bit8u)tmpsect);
+		phys_writew(dp1physaddr,(uint16_t)tmpcyl);
+		phys_writeb(dp1physaddr+0x2,(uint8_t)tmpheads);
+		phys_writeb(dp1physaddr+0xe,(uint8_t)tmpsect);
 	}
 }
 
 void incrementFDD(void) {
-	Bit16u equipment=mem_readw(BIOS_CONFIGURATION);
+	uint16_t equipment=mem_readw(BIOS_CONFIGURATION);
 	if(equipment&1) {
 		Bitu numofdisks = (equipment>>6)&3;
 		numofdisks++;
@@ -154,16 +154,16 @@ void swapInNextDisk(bool pressed) {
 }
 
 
-Bit8u imageDisk::Read_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * data) {
-	Bit32u sectnum;
+uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data) {
+	uint32_t sectnum;
 
 	sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
 
 	return Read_AbsoluteSector(sectnum, data);
 }
 
-Bit8u imageDisk::Read_AbsoluteSector(Bit32u sectnum, void * data) {
-	Bit32u bytenum;
+uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+	uint32_t bytenum;
 
 	bytenum = sectnum * sector_size;
 
@@ -175,8 +175,8 @@ Bit8u imageDisk::Read_AbsoluteSector(Bit32u sectnum, void * data) {
 	return 0x00;
 }
 
-Bit8u imageDisk::Write_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * data) {
-	Bit32u sectnum;
+uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data) {
+	uint32_t sectnum;
 
 	sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
 
@@ -184,8 +184,8 @@ Bit8u imageDisk::Write_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * d
 }
 
 
-Bit8u imageDisk::Write_AbsoluteSector(Bit32u sectnum, void *data) {
-	Bit32u bytenum;
+uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void *data) {
+	uint32_t bytenum;
 
 	bytenum = sectnum * sector_size;
 
@@ -216,7 +216,7 @@ imageDisk::imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, 
 	memset(diskname,0,512);
 	safe_strcpy(diskname, img_name);
 	if (!is_hdd) {
-		Bit8u i=0;
+		uint8_t i=0;
 		bool founddisk = false;
 		while (DiskGeometryList[i].ksize!=0x0) {
 			if ((DiskGeometryList[i].ksize == img_size_k) ||
@@ -241,7 +241,7 @@ imageDisk::imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, 
 	}
 }
 
-void imageDisk::Set_Geometry(Bit32u setHeads, Bit32u setCyl, Bit32u setSect, Bit32u setSectSize) {
+void imageDisk::Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t setSect, uint32_t setSectSize) {
 	heads = setHeads;
 	cylinders = setCyl;
 	sectors = setSect;
@@ -249,24 +249,24 @@ void imageDisk::Set_Geometry(Bit32u setHeads, Bit32u setCyl, Bit32u setSect, Bit
 	active = true;
 }
 
-void imageDisk::Get_Geometry(Bit32u * getHeads, Bit32u *getCyl, Bit32u *getSect, Bit32u *getSectSize) {
+void imageDisk::Get_Geometry(uint32_t * getHeads, uint32_t *getCyl, uint32_t *getSect, uint32_t *getSectSize) {
 	*getHeads = heads;
 	*getCyl = cylinders;
 	*getSect = sectors;
 	*getSectSize = sector_size;
 }
 
-Bit8u imageDisk::GetBiosType(void) {
+uint8_t imageDisk::GetBiosType(void) {
 	if(!hardDrive) {
-		return (Bit8u)DiskGeometryList[floppytype].biosval;
+		return (uint8_t)DiskGeometryList[floppytype].biosval;
 	} else return 0;
 }
 
-Bit32u imageDisk::getSectSize(void) {
+uint32_t imageDisk::getSectSize(void) {
 	return sector_size;
 }
 
-static Bit8u GetDosDriveNumber(Bit8u biosNum) {
+static uint8_t GetDosDriveNumber(uint8_t biosNum) {
 	switch(biosNum) {
 		case 0x0:
 			return 0x0;
@@ -285,7 +285,7 @@ static Bit8u GetDosDriveNumber(Bit8u biosNum) {
 	}
 }
 
-static bool driveInactive(Bit8u driveNum) {
+static bool driveInactive(uint8_t driveNum) {
 	if(driveNum>=(2 + MAX_HDD_IMAGES)) {
 		LOG(LOG_BIOS,LOG_ERROR)("Disk %d non-existent", driveNum);
 		last_status = 0x01;
@@ -314,9 +314,9 @@ static bool has_image(const std::array<T, N> &arr) {
 }
 
 static Bitu INT13_DiskHandler(void) {
-	Bit16u segat, bufptr;
-	Bit8u sectbuf[512];
-	Bit8u  drivenum;
+	uint16_t segat, bufptr;
+	uint8_t sectbuf[512];
+	uint8_t  drivenum;
 	Bitu t;
 	last_drive = reg_dl;
 	drivenum = GetDosDriveNumber(reg_dl);
@@ -397,7 +397,7 @@ static Bitu INT13_DiskHandler(void) {
 		segat = SegValue(es);
 		bufptr = reg_bx;
 		for (Bitu i = 0; i < reg_al; i++) {
-			last_status = imageDiskList[drivenum]->Read_Sector((Bit32u)reg_dh, (Bit32u)(reg_ch | ((reg_cl & 0xc0)<< 2)), (Bit32u)((reg_cl & 63)+i), sectbuf);
+			last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
 			if((last_status != 0x00) || (killRead)) {
 				LOG_MSG("Error in disk read");
 				killRead = false;
@@ -425,7 +425,7 @@ static Bitu INT13_DiskHandler(void) {
 				sectbuf[t] = real_readb(SegValue(es),bufptr);
 				bufptr++;
 			}
-			last_status = imageDiskList[drivenum]->Write_Sector((Bit32u)reg_dh, (Bit32u)(reg_ch | ((reg_cl & 0xc0) << 2)), (Bit32u)((reg_cl & 63) + i), &sectbuf[0]);
+			last_status = imageDiskList[drivenum]->Write_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)), (uint32_t)((reg_cl & 63) + i), &sectbuf[0]);
 			if(last_status != 0x00) {
 				CALLBACK_SCF(true);
 				return CBRET_NONE;
@@ -450,7 +450,7 @@ static Bitu INT13_DiskHandler(void) {
 		segat = SegValue(es);
 		bufptr = reg_bx;
 		for(i=0;i<reg_al;i++) {
-			last_status = imageDiskList[drivenum]->Read_Sector((Bit32u)reg_dh, (Bit32u)(reg_ch | ((reg_cl & 0xc0)<< 2)), (Bit32u)((reg_cl & 63)+i), sectbuf);
+			last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
 			if(last_status != 0x00) {
 				LOG_MSG("Error in disk read");
 				CALLBACK_SCF(true);
@@ -486,15 +486,15 @@ static Bitu INT13_DiskHandler(void) {
 		}
 		reg_ax = 0x00;
 		reg_bl = imageDiskList[drivenum]->GetBiosType();
-		Bit32u tmpheads, tmpcyl, tmpsect, tmpsize;
+		uint32_t tmpheads, tmpcyl, tmpsect, tmpsize;
 		imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
 		if (tmpcyl==0) LOG(LOG_BIOS,LOG_ERROR)("INT13 DrivParm: cylinder count zero!");
 		else tmpcyl--;		// cylinder count -> max cylinder
 		if (tmpheads==0) LOG(LOG_BIOS,LOG_ERROR)("INT13 DrivParm: head count zero!");
 		else tmpheads--;	// head count -> max head
-		reg_ch = (Bit8u)(tmpcyl & 0xff);
-		reg_cl = (Bit8u)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f)); 
-		reg_dh = (Bit8u)tmpheads;
+		reg_ch = (uint8_t)(tmpcyl & 0xff);
+		reg_cl = (uint8_t)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f)); 
+		reg_dh = (uint8_t)tmpheads;
 		last_status = 0x00;
 		if (reg_dl&0x80) {	// harddisks
 			reg_dl = 0;
@@ -535,8 +535,8 @@ static Bitu INT13_DiskHandler(void) {
 
 			reg_ah = (drivenum <2)?1:3; //With 2 for floppy MSDOS starts calling int 13 ah 16
 			if(reg_ah == 3) {
-				reg_cx = static_cast<Bit16u>(ts >>16);
-				reg_dx = static_cast<Bit16u>(ts & 0xffff);
+				reg_cx = static_cast<uint16_t>(ts >>16);
+				reg_dx = static_cast<uint16_t>(ts & 0xffff);
 			}
 			CALLBACK_SCF(false);
 		} else {

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -32,10 +32,10 @@ static Bitu call_int16,call_irq1,call_irq6;
 /* Nice table from BOCHS i should feel bad for ripping this */
 #define none 0
 static struct {
-  Bit16u normal;
-  Bit16u shift;
-  Bit16u control;
-  Bit16u alt;
+  uint16_t normal;
+  uint16_t shift;
+  uint16_t control;
+  uint16_t alt;
   } scan_to_scanascii[MAX_SCAN_CODE + 1] = {
       {   none,   none,   none,   none },
       { 0x011b, 0x011b, 0x011b, 0x01f0 }, /* escape */
@@ -128,9 +128,9 @@ static struct {
       { 0x8600, 0x8800, 0x8a00, 0x8c00 }  /* F12 */
       };
 
-bool BIOS_AddKeyToBuffer(Bit16u code) {
+bool BIOS_AddKeyToBuffer(uint16_t code) {
 	if (mem_readb(BIOS_KEYBOARD_FLAGS2)&8) return true;
-	Bit16u start,end,head,tail,ttail;
+	uint16_t start,end,head,tail,ttail;
 	if (machine==MCH_PCJR) {
 		/* should be done for cga and others as well, to be tested */
 		start=0x1e;
@@ -153,12 +153,12 @@ bool BIOS_AddKeyToBuffer(Bit16u code) {
 	return true;
 }
 
-static void add_key(Bit16u code) {
+static void add_key(uint16_t code) {
 	if (code!=0) BIOS_AddKeyToBuffer(code);
 }
 
-static bool get_key(Bit16u &code) {
-	Bit16u start,end,head,tail,thead;
+static bool get_key(uint16_t &code) {
+	uint16_t start,end,head,tail,thead;
 	if (machine==MCH_PCJR) {
 		/* should be done for cga and others as well, to be tested */
 		start=0x1e;
@@ -178,8 +178,8 @@ static bool get_key(Bit16u &code) {
 	return true;
 }
 
-static bool check_key(Bit16u &code) {
-	Bit16u head,tail;
+static bool check_key(uint16_t &code) {
+	uint16_t head,tail;
 	head =mem_readw(BIOS_KEYBOARD_BUFFER_HEAD);
 	tail =mem_readw(BIOS_KEYBOARD_BUFFER_TAIL);
 	code = real_readw(0x40,head);
@@ -229,7 +229,7 @@ static Bitu IRQ1_Handler(void) {
  */
 	Bitu scancode=reg_al;	/* Read the code */
 
-	Bit8u flags1,flags2,flags3,leds;
+	uint8_t flags1,flags2,flags3,leds;
 	flags1=mem_readb(BIOS_KEYBOARD_FLAGS1);
 	flags2=mem_readb(BIOS_KEYBOARD_FLAGS2);
 	flags3=mem_readb(BIOS_KEYBOARD_FLAGS3);
@@ -290,7 +290,7 @@ static Bitu IRQ1_Handler(void) {
 		else flags2 &= ~0x02;
 		if( !( (flags3 &0x08) || (flags2 &0x02) ) ) { /* Both alt released */
 			flags1 &= ~0x08;
-			Bit16u token =mem_readb(BIOS_KEYBOARD_TOKEN);
+			uint16_t token =mem_readb(BIOS_KEYBOARD_TOKEN);
 			if(token != 0){
 				add_key(token);
 				mem_writeb(BIOS_KEYBOARD_TOKEN,0);
@@ -366,8 +366,8 @@ static Bitu IRQ1_Handler(void) {
 			break;
 		}
 		if(flags1 &0x08) {
-			Bit8u token = mem_readb(BIOS_KEYBOARD_TOKEN);
-			token = token*10 + (Bit8u)(scan_to_scanascii[scancode].alt&0xff);
+			uint8_t token = mem_readb(BIOS_KEYBOARD_TOKEN);
+			token = token*10 + (uint8_t)(scan_to_scanascii[scancode].alt&0xff);
 			mem_writeb(BIOS_KEYBOARD_TOKEN,token);
 		} else if (flags1 &0x04) {
 			add_key(scan_to_scanascii[scancode].control);
@@ -378,7 +378,7 @@ static Bitu IRQ1_Handler(void) {
 
 	default: /* Normal Key */
 normal_key:
-		Bit16u asciiscan;
+		uint16_t asciiscan;
 		/* Now Handle the releasing of keys and see if they match up for a code */
 		/* Handle the actual scancode */
 		if (scancode & 0x80) goto irq1_end;
@@ -433,7 +433,7 @@ irq1_end:
 #if 0
 /* Signal the keyboard for next code */
 /* In dosbox port 60 reads do this as well */
-	Bit8u old61=IO_Read(0x61);
+	uint8_t old61=IO_Read(0x61);
 	IO_Write(0x61,old61 | 128);
 	IO_Write(0x64,0xae);
 #endif
@@ -443,7 +443,7 @@ irq1_end:
 
 /* check whether key combination is enhanced or not,
    translate key if necessary */
-static bool IsEnhancedKey(Bit16u &key) {
+static bool IsEnhancedKey(uint16_t &key) {
 	/* test for special keys (return and slash on numblock) */
 	if ((key>>8)==0xe0) {
 		if (((key&0xff)==0x0a) || ((key&0xff)==0x0d)) {
@@ -468,7 +468,7 @@ static bool IsEnhancedKey(Bit16u &key) {
 }
 
 static Bitu INT16_Handler(void) {
-	Bit16u temp=0;
+	uint16_t temp=0;
 	switch (reg_ah) {
 	case 0x00: /* GET KEYSTROKE */
 		if ((get_key(temp)) && (!IsEnhancedKey(temp))) {
@@ -569,8 +569,8 @@ static void InitBiosSegment(void) {
 	mem_writew(BIOS_KEYBOARD_BUFFER_END,0x3e);
 	mem_writew(BIOS_KEYBOARD_BUFFER_HEAD,0x1e);
 	mem_writew(BIOS_KEYBOARD_BUFFER_TAIL,0x1e);
-	Bit8u flag1 = 0;
-	Bit8u leds = 16; /* Ack received */
+	uint8_t flag1 = 0;
+	uint8_t leds = 16; /* Ack received */
 	mem_writeb(BIOS_KEYBOARD_FLAGS1,flag1);
 	mem_writeb(BIOS_KEYBOARD_FLAGS2,0);
 	mem_writeb(BIOS_KEYBOARD_FLAGS3,16); /* Enhanced keyboard installed */	

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -74,7 +74,7 @@ static Bitu INT10_Handler(void) {
 		break;
 	case 0x05:								/* Set Active Page */
 		if ((reg_al & 0x80) && IS_TANDY_ARCH) {
-			Bit8u crtcpu=real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE);		
+			uint8_t crtcpu=real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE);		
 			switch (reg_al) {
 			case 0x80:
 				reg_bh=crtcpu & 7;
@@ -141,7 +141,7 @@ static Bitu INT10_Handler(void) {
 		reg_bh=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 		reg_al=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
 		if (IS_EGAVGA_ARCH) reg_al|=real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL)&0x80;
-		reg_ah=(Bit8u)real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+		reg_ah=(uint8_t)real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
 		break;					
 	case 0x10:								/* Palette functions */
 		if (!IS_EGAVGA_ARCH && (reg_al>0x02)) break;
@@ -341,8 +341,8 @@ graphics_chars:
 						break;
 					}
 				}
-				Bit8u modeset_ctl = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL);
-				Bit8u video_switches = real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES)&0xf0;
+				uint8_t modeset_ctl = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL);
+				uint8_t video_switches = real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES)&0xf0;
 				switch(reg_al) {
 				case 0: // 200
 					modeset_ctl &= 0xef;
@@ -376,7 +376,7 @@ graphics_chars:
 					reg_al=0;		//invalid subfunction
 					break;
 				}
-				Bit8u temp = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 0xf7;
+				uint8_t temp = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 0xf7;
 				if (reg_al&1) temp|=8;		// enable if al=0
 				real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,temp);
 				reg_al=0x12;
@@ -397,7 +397,7 @@ graphics_chars:
 					reg_al=0;
 					break;
 				}
-				Bit8u temp = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 0xfd;
+				uint8_t temp = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 0xfd;
 				if (!(reg_al&1)) temp|=2;		// enable if al=0
 				real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,temp);
 				reg_al=0x12;
@@ -412,7 +412,7 @@ graphics_chars:
 					reg_al=0;
 					break;
 				}
-				Bit8u temp = real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL) & 0xfe;
+				uint8_t temp = real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL) & 0xfe;
 				real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,temp|reg_al);
 				reg_al=0x12;
 				break;	
@@ -429,7 +429,7 @@ graphics_chars:
 				break;
 			}
 			IO_Write(0x3c4,0x1);
-			Bit8u clocking = IO_Read(0x3c5);
+			uint8_t clocking = IO_Read(0x3c5);
 			
 			if (reg_al==0) clocking &= ~0x20;
 			else clocking |= 0x20;
@@ -476,7 +476,7 @@ graphics_chars:
 				Bitu ret=INT10_VideoState_GetSize(reg_cx);
 				if (ret) {
 					reg_al=0x1c;
-					reg_bx=(Bit16u)ret;
+					reg_bx=(uint16_t)ret;
 				} else reg_al=0;
 				}
 				break;
@@ -522,7 +522,7 @@ graphics_chars:
 					Bitu ret=INT10_VideoState_GetSize(reg_cx);
 					if (ret) {
 						reg_ah=0;
-						reg_bx=(Bit16u)ret;
+						reg_bx=(uint16_t)ret;
 					} else reg_ah=1;
 					}
 					break;
@@ -702,7 +702,7 @@ static void INT10_InitVGA(void) {
 }
 
 static void SetupTandyBios(void) {
-	static Bit8u TandyConfig[130]= {
+	static uint8_t TandyConfig[130]= {
 		0x21, 0x42, 0x49, 0x4f, 0x53, 0x20, 0x52, 0x4f, 0x4d, 0x20, 0x76, 0x65, 0x72,
 		0x73, 0x69, 0x6f, 0x6e, 0x20, 0x30, 0x32, 0x2e, 0x30, 0x30, 0x2e, 0x30, 0x30,
 		0x0d, 0x0a, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x74, 0x69, 0x62, 0x69, 0x6c, 0x69,

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -100,18 +100,18 @@
 #define VGAMEM_CTEXT 0xB800
 #define VGAMEM_MTEXT 0xB000
 
-#define BIOS_NCOLS Bit16u ncols=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-#define BIOS_NROWS Bit16u nrows=IS_EGAVGA_ARCH?((Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1):25;
-#define BIOS_CHEIGHT Bit8u cheight=IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT):8;
+#define BIOS_NCOLS uint16_t ncols=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+#define BIOS_NROWS uint16_t nrows=IS_EGAVGA_ARCH?((uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1):25;
+#define BIOS_CHEIGHT uint8_t cheight=IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT):8;
 
 uint16_t INT10_GetTextColumns();
 uint16_t INT10_GetTextRows();
 
-extern Bit8u int10_font_08[256 * 8];
-extern Bit8u int10_font_14[256 * 14];
-extern Bit8u int10_font_16[256 * 16];
-extern Bit8u int10_font_14_alternate[20 * 15 + 1];
-extern Bit8u int10_font_16_alternate[19 * 17 + 1];
+extern uint8_t int10_font_08[256 * 8];
+extern uint8_t int10_font_14[256 * 14];
+extern uint8_t int10_font_16[256 * 16];
+extern uint8_t int10_font_14_alternate[20 * 15 + 1];
+extern uint8_t int10_font_16_alternate[19 * 17 + 1];
 
 struct VideoModeBlock {
 	uint16_t mode;
@@ -156,13 +156,13 @@ struct Int10Data {
 		RealPt wait_retrace;
 		RealPt set_window;
 		RealPt pmode_interface;
-		Bit16u pmode_interface_size;
-		Bit16u pmode_interface_start;
-		Bit16u pmode_interface_window;
-		Bit16u pmode_interface_palette;
-		Bit16u used;
+		uint16_t pmode_interface_size;
+		uint16_t pmode_interface_start;
+		uint16_t pmode_interface_window;
+		uint16_t pmode_interface_palette;
+		uint16_t used;
 	} rom = {};
-	Bit16u vesa_setmode = 0;
+	uint16_t vesa_setmode = 0;
 
 	VESA_MODE_PREF vesa_mode_preference = VESA_MODE_PREF::COMPATIBLE;
 	bool vesa_nolfb = false;
@@ -171,34 +171,34 @@ struct Int10Data {
 
 extern Int10Data int10;
 
-static inline Bit8u CURSOR_POS_COL(Bit8u page) {
+static inline uint8_t CURSOR_POS_COL(uint8_t page) {
 	return real_readb(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2);
 }
 
-static inline Bit8u CURSOR_POS_ROW(Bit8u page) {
+static inline uint8_t CURSOR_POS_ROW(uint8_t page) {
 	return real_readb(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2+1);
 }
 
-bool INT10_SetVideoMode(Bit16u mode);
+bool INT10_SetVideoMode(uint16_t mode);
 void INT10_SetCurMode(void);
 
-void INT10_ScrollWindow(Bit8u rul,Bit8u cul,Bit8u rlr,Bit8u clr,Bit8s nlines,Bit8u attr,Bit8u page);
+void INT10_ScrollWindow(uint8_t rul,uint8_t cul,uint8_t rlr,uint8_t clr,int8_t nlines,uint8_t attr,uint8_t page);
 
-void INT10_SetActivePage(Bit8u page);
-void INT10_DisplayCombinationCode(Bit16u * dcc,bool set);
+void INT10_SetActivePage(uint8_t page);
+void INT10_DisplayCombinationCode(uint16_t * dcc,bool set);
 void INT10_GetFuncStateInformation(PhysPt save);
 
-void INT10_SetCursorShape(Bit8u first,Bit8u last);
-void INT10_SetCursorPos(Bit8u row,Bit8u col,Bit8u page);
-void INT10_TeletypeOutput(Bit8u chr,Bit8u attr);
-void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr);
-void INT10_ReadCharAttr(Bit16u * result,Bit8u page);
+void INT10_SetCursorShape(uint8_t first,uint8_t last);
+void INT10_SetCursorPos(uint8_t row,uint8_t col,uint8_t page);
+void INT10_TeletypeOutput(uint8_t chr,uint8_t attr);
+void INT10_TeletypeOutputAttr(uint8_t chr,uint8_t attr,bool useattr);
+void INT10_ReadCharAttr(uint16_t * result,uint8_t page);
 void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bool showattr);
-void INT10_WriteString(Bit8u row,Bit8u col,Bit8u flag,Bit8u attr,PhysPt string,Bit16u count,Bit8u page);
+void INT10_WriteString(uint8_t row,uint8_t col,uint8_t flag,uint8_t attr,PhysPt string,uint16_t count,uint8_t page);
 
 /* Graphics Stuff */
-void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color);
-void INT10_GetPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u * color);
+void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color);
+void INT10_GetPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t * color);
 
 /* Font Stuff */
 void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu height);
@@ -206,37 +206,37 @@ void INT10_ReloadFont(void);
 
 /* Palette Group */
 void INT10_SetBackgroundBorder(uint8_t val);
-void INT10_SetColorSelect(Bit8u val);
+void INT10_SetColorSelect(uint8_t val);
 void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val);
 void INT10_SetOverscanBorderColor(uint8_t val);
 void INT10_SetAllPaletteRegisters(PhysPt data);
-void INT10_ToggleBlinkingBit(Bit8u state);
-void INT10_GetSinglePaletteRegister(Bit8u reg,Bit8u * val);
-void INT10_GetOverscanBorderColor(Bit8u * val);
+void INT10_ToggleBlinkingBit(uint8_t state);
+void INT10_GetSinglePaletteRegister(uint8_t reg,uint8_t * val);
+void INT10_GetOverscanBorderColor(uint8_t * val);
 void INT10_GetAllPaletteRegisters(PhysPt data);
-void INT10_SetSingleDACRegister(Bit8u index,Bit8u red,Bit8u green,Bit8u blue);
-void INT10_GetSingleDACRegister(Bit8u index,Bit8u * red,Bit8u * green,Bit8u * blue);
-void INT10_SetDACBlock(Bit16u index,Bit16u count,PhysPt data);
-void INT10_GetDACBlock(Bit16u index,Bit16u count,PhysPt data);
-void INT10_SelectDACPage(Bit8u function,Bit8u mode);
-void INT10_GetDACPage(Bit8u* mode,Bit8u* page);
-void INT10_SetPelMask(Bit8u mask);
-void INT10_GetPelMask(Bit8u & mask);
-void INT10_PerformGrayScaleSumming(Bit16u start_reg,Bit16u count);
+void INT10_SetSingleDACRegister(uint8_t index,uint8_t red,uint8_t green,uint8_t blue);
+void INT10_GetSingleDACRegister(uint8_t index,uint8_t * red,uint8_t * green,uint8_t * blue);
+void INT10_SetDACBlock(uint16_t index,uint16_t count,PhysPt data);
+void INT10_GetDACBlock(uint16_t index,uint16_t count,PhysPt data);
+void INT10_SelectDACPage(uint8_t function,uint8_t mode);
+void INT10_GetDACPage(uint8_t* mode,uint8_t* page);
+void INT10_SetPelMask(uint8_t mask);
+void INT10_GetPelMask(uint8_t & mask);
+void INT10_PerformGrayScaleSumming(uint16_t start_reg,uint16_t count);
 
 
 /* Vesa Group */
-Bit8u VESA_GetSVGAInformation(Bit16u seg,Bit16u off);
-Bit8u VESA_GetSVGAModeInformation(Bit16u mode,Bit16u seg,Bit16u off);
-Bit8u VESA_SetSVGAMode(Bit16u mode);
-Bit8u VESA_GetSVGAMode(Bit16u & mode);
-Bit8u VESA_SetCPUWindow(Bit8u window,Bit8u address);
-Bit8u VESA_GetCPUWindow(Bit8u window,Bit16u & address);
-Bit8u VESA_ScanLineLength(Bit8u subcall, Bit16u val, Bit16u & bytes,Bit16u & pixels,Bit16u & lines);
-Bit8u VESA_SetDisplayStart(Bit16u x,Bit16u y,bool wait);
-Bit8u VESA_GetDisplayStart(Bit16u & x,Bit16u & y);
-Bit8u VESA_SetPalette(PhysPt data,Bitu index,Bitu count,bool wait);
-Bit8u VESA_GetPalette(PhysPt data,Bitu index,Bitu count);
+uint8_t VESA_GetSVGAInformation(uint16_t seg,uint16_t off);
+uint8_t VESA_GetSVGAModeInformation(uint16_t mode,uint16_t seg,uint16_t off);
+uint8_t VESA_SetSVGAMode(uint16_t mode);
+uint8_t VESA_GetSVGAMode(uint16_t & mode);
+uint8_t VESA_SetCPUWindow(uint8_t window,uint8_t address);
+uint8_t VESA_GetCPUWindow(uint8_t window,uint16_t & address);
+uint8_t VESA_ScanLineLength(uint8_t subcall, uint16_t val, uint16_t & bytes,uint16_t & pixels,uint16_t & lines);
+uint8_t VESA_SetDisplayStart(uint16_t x,uint16_t y,bool wait);
+uint8_t VESA_GetDisplayStart(uint16_t & x,uint16_t & y);
+uint8_t VESA_SetPalette(PhysPt data,Bitu index,Bitu count,bool wait);
+uint8_t VESA_GetPalette(PhysPt data,Bitu index,Bitu count);
 
 /* Sub Groups */
 void INT10_SetupRomMemory(void);
@@ -245,12 +245,12 @@ void INT10_SetupVESA(void);
 
 /* EGA RIL */
 RealPt INT10_EGA_RIL_GetVersionPt(void);
-void INT10_EGA_RIL_ReadRegister(Bit8u & bl, Bit16u dx);
-void INT10_EGA_RIL_WriteRegister(Bit8u & bl, Bit8u bh, Bit16u dx);
-void INT10_EGA_RIL_ReadRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt dst);
-void INT10_EGA_RIL_WriteRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt dst);
-void INT10_EGA_RIL_ReadRegisterSet(Bit16u cx, PhysPt tbl);
-void INT10_EGA_RIL_WriteRegisterSet(Bit16u cx, PhysPt tbl);
+void INT10_EGA_RIL_ReadRegister(uint8_t & bl, uint16_t dx);
+void INT10_EGA_RIL_WriteRegister(uint8_t & bl, uint8_t bh, uint16_t dx);
+void INT10_EGA_RIL_ReadRegisterRange(uint8_t ch, uint8_t cl, uint16_t dx, PhysPt dst);
+void INT10_EGA_RIL_WriteRegisterRange(uint8_t ch, uint8_t cl, uint16_t dx, PhysPt dst);
+void INT10_EGA_RIL_ReadRegisterSet(uint16_t cx, PhysPt tbl);
+void INT10_EGA_RIL_WriteRegisterSet(uint16_t cx, PhysPt tbl);
 
 /* Video State */
 Bitu INT10_VideoState_GetSize(Bitu state);
@@ -258,7 +258,7 @@ bool INT10_VideoState_Save(Bitu state,RealPt buffer);
 bool INT10_VideoState_Restore(Bitu state,RealPt buffer);
 
 /* Video Parameter Tables */
-Bit16u INT10_SetupVideoParameterTable(PhysPt basepos);
+uint16_t INT10_SetupVideoParameterTable(PhysPt basepos);
 void INT10_SetupBasicVideoParameterTable(void);
 
 #endif

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -26,7 +26,7 @@
 #include "pic.h"
 #include "callback.h"
 
-static void CGA2_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
+static void CGA2_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
 	BIOS_CHEIGHT;
 	PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/2)+cleft);
 	PhysPt src=base+((CurMode->twidth*rold)*(cheight/2)+cleft);
@@ -39,7 +39,7 @@ static void CGA2_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt b
 	}
 }
 
-static void CGA4_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
+static void CGA4_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
 	BIOS_CHEIGHT;
 	PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/2)+cleft)*2;
 	PhysPt src=base+((CurMode->twidth*rold)*(cheight/2)+cleft)*2;	
@@ -51,9 +51,9 @@ static void CGA4_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt b
 	}
 }
 
-static void TANDY16_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
+static void TANDY16_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
 	BIOS_CHEIGHT;
-	Bit8u banks=CurMode->twidth/10;
+	uint8_t banks=CurMode->twidth/10;
 	PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/banks)+cleft)*4;
 	PhysPt src=base+((CurMode->twidth*rold)*(cheight/banks)+cleft)*4;
 	Bitu copy=(cright-cleft)*4;Bitu nextline=CurMode->twidth*4;
@@ -63,7 +63,7 @@ static void TANDY16_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysP
 	}
 }
 
-static void EGA16_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
+static void EGA16_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
 	PhysPt src,dest;Bitu copy;
 	BIOS_CHEIGHT;
 	dest=base+(CurMode->twidth*rnew)*cheight+cleft;
@@ -83,7 +83,7 @@ static void EGA16_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt 
 	IO_Write(0x3ce,5);IO_Write(0x3cf,0);		/* Normal transfer mode */
 }
 
-static void VGA_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
+static void VGA_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
 	PhysPt src,dest;Bitu copy;
 	BIOS_CHEIGHT;
 	dest=base+8*((CurMode->twidth*rnew)*cheight+cleft);
@@ -97,14 +97,14 @@ static void VGA_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt ba
 	}
 }
 
-static void TEXT_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
+static void TEXT_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
 	PhysPt src,dest;
 	src=base+(rold*CurMode->twidth+cleft)*2;
 	dest=base+(rnew*CurMode->twidth+cleft)*2;
 	MEM_BlockCopy(dest,src,(cright-cleft)*2);
 }
 
-static void CGA2_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
+static void CGA2_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
 	BIOS_CHEIGHT;
 	PhysPt dest=base+((CurMode->twidth*row)*(cheight/2)+cleft);
 	Bitu copy=(cright-cleft);
@@ -119,7 +119,7 @@ static void CGA2_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u at
 	}
 }
 
-static void CGA4_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
+static void CGA4_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
 	BIOS_CHEIGHT;
 	PhysPt dest=base+((CurMode->twidth*row)*(cheight/2)+cleft)*2;
 	Bitu copy=(cright-cleft)*2;Bitu nextline=CurMode->twidth*2;
@@ -133,9 +133,9 @@ static void CGA4_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u at
 	}
 }
 
-static void TANDY16_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
+static void TANDY16_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
 	BIOS_CHEIGHT;
-	Bit8u banks=CurMode->twidth/10;
+	uint8_t banks=CurMode->twidth/10;
 	PhysPt dest=base+((CurMode->twidth*row)*(cheight/banks)+cleft)*4;
 	Bitu copy=(cright-cleft)*4;Bitu nextline=CurMode->twidth*4;
 	attr=(attr & 0xf) | (attr & 0xf) << 4;
@@ -147,7 +147,7 @@ static void TANDY16_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u
 	}
 }
 
-static void EGA16_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
+static void EGA16_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
 	/* Set Bitmask / Color / Full Set Reset */
 	IO_Write(0x3ce,0x8);IO_Write(0x3cf,0xff);
 	IO_Write(0x3ce,0x0);IO_Write(0x3cf,attr);
@@ -166,7 +166,7 @@ static void EGA16_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u a
 	IO_Write(0x3cf,0);
 }
 
-static void VGA_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
+static void VGA_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
 	/* Write some bytes */
 	BIOS_CHEIGHT;
 	PhysPt dest=base+8*((CurMode->twidth*row)*cheight+cleft);
@@ -178,12 +178,12 @@ static void VGA_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u att
 	}
 }
 
-static void TEXT_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
+static void TEXT_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
 	/* Do some filing */
 	PhysPt dest;
 	dest=base+(row*CurMode->twidth+cleft)*2;
-	Bit16u fill=(attr<<8)+' ';
-	for (Bit8u x=0;x<(cright-cleft);x++) {
+	uint16_t fill=(attr<<8)+' ';
+	for (uint8_t x=0;x<(cright-cleft);x++) {
 		mem_writew(dest,fill);
 		dest+=2;
 	}
@@ -202,14 +202,14 @@ uint16_t INT10_GetTextRows()
 		return 25;
 }
 
-void INT10_ScrollWindow(Bit8u rul,Bit8u cul,Bit8u rlr,Bit8u clr,Bit8s nlines,Bit8u attr,Bit8u page) {
+void INT10_ScrollWindow(uint8_t rul,uint8_t cul,uint8_t rlr,uint8_t clr,int8_t nlines,uint8_t attr,uint8_t page) {
 /* Do some range checking */
 	if (CurMode->type!=M_TEXT) page=0xff;
 	BIOS_NCOLS;BIOS_NROWS;
 	if(rul>rlr) return;
 	if(cul>clr) return;
-	if(rlr>=nrows) rlr=(Bit8u)nrows-1;
-	if(clr>=ncols) clr=(Bit8u)ncols-1;
+	if(rlr>=nrows) rlr=(uint8_t)nrows-1;
+	if(clr>=ncols) clr=(uint8_t)ncols-1;
 	clr++;
 
 	/* Get the correct page: current start address for current page (0xFF),
@@ -232,7 +232,7 @@ void INT10_ScrollWindow(Bit8u rul,Bit8u cul,Bit8u rlr,Bit8u clr,Bit8s nlines,Bit
 	}
 
 	/* See how much lines need to be copied */
-	Bit8u start,end;Bits next;
+	uint8_t start,end;Bits next;
 	/* Copy some lines */
 	if (nlines>0) {
 		start=rlr-nlines+1;
@@ -307,8 +307,8 @@ filling:
 	} 
 }
 
-void INT10_SetActivePage(Bit8u page) {
-	Bit16u mem_address;
+void INT10_SetActivePage(uint8_t page) {
+	uint16_t mem_address;
 	if (page>7) LOG(LOG_INT10,LOG_ERROR)("INT10_SetActivePage page %d",page);
 
 	if (IS_EGAVGA_ARCH && (svgaCard==SVGA_S3Trio)) page &= 7;
@@ -323,21 +323,21 @@ void INT10_SetActivePage(Bit8u page) {
 		mem_address>>=1;
 	}
 	/* Write the new start address in vgahardware */
-	Bit16u base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+	uint16_t base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 	IO_Write(base,0x0c);
-	IO_Write(base+1,(Bit8u)(mem_address>>8));
+	IO_Write(base+1,(uint8_t)(mem_address>>8));
 	IO_Write(base,0x0d);
-	IO_Write(base+1,(Bit8u)mem_address);
+	IO_Write(base+1,(uint8_t)mem_address);
 
 	// And change the BIOS page
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE,page);
-	Bit8u cur_row=CURSOR_POS_ROW(page);
-	Bit8u cur_col=CURSOR_POS_COL(page);
+	uint8_t cur_row=CURSOR_POS_ROW(page);
+	uint8_t cur_col=CURSOR_POS_COL(page);
 	// Display the cursor, now the page is active
 	INT10_SetCursorPos(cur_row,cur_col,page);
 }
 
-void INT10_SetCursorShape(Bit8u first,Bit8u last) {
+void INT10_SetCursorShape(uint8_t first,uint8_t last) {
 	real_writew(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE,last|(first<<8));
 	if (machine==MCH_CGA || IS_TANDY_ARCH) goto dowrite;
 	/* Skip CGA cursor emulation if EGA/VGA system is active */
@@ -352,7 +352,7 @@ void INT10_SetCursorShape(Bit8u first,Bit8u last) {
 		if (machine==MCH_HERC || !(real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL) & 0x1)) { // set by int10 fun12 sub34
 //			if (CurMode->mode>0x3) goto dowrite;	//Only mode 0-3 are text modes on cga
 			if ((first & 0xe0) || (last & 0xe0)) goto dowrite;
-			Bit8u cheight=((machine==MCH_HERC)?14:real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT))-1;
+			uint8_t cheight=((machine==MCH_HERC)?14:real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT))-1;
 			/* Creative routine i based of the original ibmvga bios */
 
 			if (last<first) {
@@ -383,20 +383,20 @@ void INT10_SetCursorShape(Bit8u first,Bit8u last) {
 		}
 	}
 dowrite:
-	Bit16u base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+	uint16_t base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 	IO_Write(base,0xa);IO_Write(base+1,first);
 	IO_Write(base,0xb);IO_Write(base+1,last);
 }
 
-void INT10_SetCursorPos(Bit8u row,Bit8u col,Bit8u page) {
-	Bit16u address;
+void INT10_SetCursorPos(uint8_t row,uint8_t col,uint8_t page) {
+	uint16_t address;
 
 	if (page>7) LOG(LOG_INT10,LOG_ERROR)("INT10_SetCursorPos page %d",page);
 	// Bios cursor pos
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2,col);
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2+1,row);
 	// Set the hardware cursor
-	Bit8u current=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+	uint8_t current=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 	if(page==current) {
 		// Get the dimensions
 		BIOS_NCOLS;
@@ -404,25 +404,25 @@ void INT10_SetCursorPos(Bit8u row,Bit8u col,Bit8u page) {
 		// NOTE: BIOSMEM_CURRENT_START counts in colour/flag pairs
 		address=(ncols*row)+col+real_readw(BIOSMEM_SEG,BIOSMEM_CURRENT_START)/2;
 		// CRTC regs 0x0e and 0x0f
-		Bit16u base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 		IO_Write(base,0x0e);
-		IO_Write(base+1,(Bit8u)(address>>8));
+		IO_Write(base+1,(uint8_t)(address>>8));
 		IO_Write(base,0x0f);
-		IO_Write(base+1,(Bit8u)address);
+		IO_Write(base+1,(uint8_t)address);
 	}
 }
 
-void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
+void ReadCharAttr(uint16_t col,uint16_t row,uint8_t page,uint16_t * result) {
 	/* Externally used by the mouse routine */
 	PhysPt fontdata;
-	Bit16u cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+	uint16_t cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
 	BIOS_CHEIGHT;
 	bool split_chr = false;
 	switch (CurMode->type) {
 	case M_TEXT:
 		{	
 			// Compute the address  
-			Bit16u address=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
+			uint16_t address=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
 			address+=(row*cols+col)*2;
 			// read the char 
 			PhysPt where = CurMode->pstart+address;
@@ -456,17 +456,17 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
 	const auto y = row * cheight * (cols / CurMode->twidth);
 	assert(y >= 0 && y <= UINT16_MAX);
 
-	for (Bit16u chr=0;chr<256;chr++) {
+	for (uint16_t chr=0;chr<256;chr++) {
 
 		if (chr==128 && split_chr) fontdata=Real2Phys(RealGetVec(0x1f));
 
 		bool error=false;
 		auto ty = static_cast<uint16_t>(y);
-		for (Bit8u h=0;h<cheight;h++) {
-			Bit8u bitsel=128;
-			Bit8u bitline=mem_readb(fontdata++);
-			Bit8u res=0;
-			Bit8u vidline=0;
+		for (uint8_t h=0;h<cheight;h++) {
+			uint8_t bitsel=128;
+			uint8_t bitline=mem_readb(fontdata++);
+			uint8_t res=0;
+			uint8_t vidline=0;
 			auto tx = static_cast<uint16_t>(x);
 			while (bitsel) {
 				//Construct bitline in memory
@@ -492,23 +492,23 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
 	LOG(LOG_INT10,LOG_ERROR)("ReadChar didn't find character");
 	*result = 0;
 }
-void INT10_ReadCharAttr(Bit16u * result,Bit8u page) {
+void INT10_ReadCharAttr(uint16_t * result,uint8_t page) {
 	if(page==0xFF) page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	Bit8u cur_row=CURSOR_POS_ROW(page);
-	Bit8u cur_col=CURSOR_POS_COL(page);
+	uint8_t cur_row=CURSOR_POS_ROW(page);
+	uint8_t cur_col=CURSOR_POS_COL(page);
 	ReadCharAttr(cur_col,cur_row,page,result);
 }
-void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit8u chr,Bit8u attr,bool useattr) {
+void WriteChar(uint16_t col,uint16_t row,uint8_t page,uint8_t chr,uint8_t attr,bool useattr) {
 	/* Externally used by the mouse routine */
 	RealPt fontdata;
-	Bit16u cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-	Bit8u back;
+	uint16_t cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+	uint8_t back;
 	BIOS_CHEIGHT;
 	switch (CurMode->type) {
 	case M_TEXT:
 		{	
 			// Compute the address  
-			Bit16u address=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
+			uint16_t address=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
 			address+=(row*cols+col)*2;
 			// Write the char 
 			PhysPt where = CurMode->pstart+address;
@@ -593,9 +593,9 @@ void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit8u chr,Bit8u attr,bool useatt
 	assert(y >= 0 && y <= UINT16_MAX);
 
 	auto ty = static_cast<uint16_t>(y);
-	for (Bit8u h = 0; h < cheight; h++) {
-		Bit8u bitsel=128;
-		Bit8u bitline=mem_readb(Real2Phys(fontdata));
+	for (uint8_t h = 0; h < cheight; h++) {
+		uint8_t bitsel=128;
+		uint8_t bitline=mem_readb(Real2Phys(fontdata));
 		fontdata=RealMake(RealSeg(fontdata),RealOff(fontdata)+1);
 		auto tx = static_cast<uint16_t>(x);
 		while (bitsel) {
@@ -609,7 +609,7 @@ void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit8u chr,Bit8u attr,bool useatt
 
 void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bool showattr)
 {
-	Bit8u pospage=page;
+	uint8_t pospage=page;
 	if (CurMode->type!=M_TEXT) {
 		showattr=true; //Use attr in graphics mode always
 		switch (machine) {
@@ -636,8 +636,8 @@ void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bo
 		}
 	}
 
-	Bit8u cur_row=CURSOR_POS_ROW(pospage);
-	Bit8u cur_col=CURSOR_POS_COL(pospage);
+	uint8_t cur_row=CURSOR_POS_ROW(pospage);
+	uint8_t cur_col=CURSOR_POS_COL(pospage);
 	BIOS_NCOLS;
 	while (count>0) {
 		WriteChar(cur_col,cur_row,page,chr,attr,showattr);
@@ -655,10 +655,10 @@ void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bo
 	}
 }
 
-static void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr,Bit8u page) {
+static void INT10_TeletypeOutputAttr(uint8_t chr,uint8_t attr,bool useattr,uint8_t page) {
 	BIOS_NCOLS;BIOS_NROWS;
-	Bit8u cur_row=CURSOR_POS_ROW(page);
-	Bit8u cur_col=CURSOR_POS_COL(page);
+	uint8_t cur_row=CURSOR_POS_ROW(page);
+	uint8_t cur_col=CURSOR_POS_COL(page);
 	switch (chr) {
 	case 7: /* Beep */
 		// Prepare PIT counter 2 for ~900 Hz square wave
@@ -697,30 +697,30 @@ static void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr,Bit8u pag
 	// Do we need to scroll ?
 	if(cur_row==nrows) {
 		//Fill with black on non-text modes and with attribute at cursor on textmode
-		Bit8u fill=0;
+		uint8_t fill=0;
 		if (CurMode->type==M_TEXT) {
-			Bit16u chat;
+			uint16_t chat;
 			INT10_ReadCharAttr(&chat,page);
-			fill=(Bit8u)(chat>>8);
+			fill=(uint8_t)(chat>>8);
 		}
-		INT10_ScrollWindow(0,0,(Bit8u)(nrows-1),(Bit8u)(ncols-1),-1,fill,page);
+		INT10_ScrollWindow(0,0,(uint8_t)(nrows-1),(uint8_t)(ncols-1),-1,fill,page);
 		cur_row--;
 	}
 	// Set the cursor for the page
 	INT10_SetCursorPos(cur_row,cur_col,page);
 }
 
-void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr) {
+void INT10_TeletypeOutputAttr(uint8_t chr,uint8_t attr,bool useattr) {
 	INT10_TeletypeOutputAttr(chr,attr,useattr,real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE));
 }
 
-void INT10_TeletypeOutput(Bit8u chr,Bit8u attr) {
+void INT10_TeletypeOutput(uint8_t chr,uint8_t attr) {
 	INT10_TeletypeOutputAttr(chr,attr,CurMode->type!=M_TEXT);
 }
 
-void INT10_WriteString(Bit8u row,Bit8u col,Bit8u flag,Bit8u attr,PhysPt string,Bit16u count,Bit8u page) {
-	Bit8u cur_row=CURSOR_POS_ROW(page);
-	Bit8u cur_col=CURSOR_POS_COL(page);
+void INT10_WriteString(uint8_t row,uint8_t col,uint8_t flag,uint8_t attr,PhysPt string,uint16_t count,uint8_t page) {
+	uint8_t cur_row=CURSOR_POS_ROW(page);
+	uint8_t cur_col=CURSOR_POS_COL(page);
 	
 	// if row=0xff special case : use current cursor position
 	if (row==0xff) {
@@ -729,7 +729,7 @@ void INT10_WriteString(Bit8u row,Bit8u col,Bit8u flag,Bit8u attr,PhysPt string,B
 	}
 	INT10_SetCursorPos(row,col,page);
 	while (count>0) {
-		Bit8u chr=mem_readb(string);
+		uint8_t chr=mem_readb(string);
 		string++;
 		if (flag&2) {
 			attr=mem_readb(string);

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -21,7 +21,7 @@
 #include "mem.h"
 #include "inout.h"
 
-static Bit8u static_functionality[0x10]=
+static uint8_t static_functionality[0x10]=
 {
  /* 0 */ 0xff,  // All modes supported #1
  /* 1 */ 0xff,  // All modes supported #2
@@ -38,14 +38,14 @@ static Bit8u static_functionality[0x10]=
  /* f */ 0x00   // reserved
 };
 
-static Bit16u map_offset[8]={
+static uint16_t map_offset[8]={
 	0x0000,0x4000,0x8000,0xc000,
 	0x2000,0x6000,0xa000,0xe000
 };
 
 void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu height) {
-	PhysPt ftwhere=PhysMake(0xa000,map_offset[map & 0x7]+(Bit16u)(offset*32));
-	Bit16u base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+	PhysPt ftwhere=PhysMake(0xa000,map_offset[map & 0x7]+(uint16_t)(offset*32));
+	uint16_t base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 	bool mono=(base==VGAREG_MDA_CRTC_ADDRESS);
 
 	//Put video adapter in planar mode
@@ -84,7 +84,7 @@ void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu
 		Bitu rows=CurMode->sheight/height;
 		Bitu vdend=rows*height*((CurMode->sheight==200)?2:1)-1;
 		IO_Write(base,0x12);
-		IO_Write(base+1,(Bit8u)vdend);
+		IO_Write(base+1,(uint8_t)vdend);
 		//Underline location
 		if (CurMode->mode==7) {
 			IO_Write(base,0x14);
@@ -92,7 +92,7 @@ void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu
 		}
 		//Rows setting in bios segment
 		real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,rows-1);
-		real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,(Bit8u)height);
+		real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,(uint8_t)height);
 		//Page size
 		Bitu pagesize=rows*real_readb(BIOSMEM_SEG,BIOSMEM_NB_COLS)*2;
 		pagesize+=0x100; // bios adds extra on reload
@@ -314,18 +314,18 @@ void INT10_ReloadRomFonts(void) {
 void INT10_SetupRomMemoryChecksum(void) {
 	if (IS_EGAVGA_ARCH) { //EGA/VGA. Just to be safe
 		/* Sum of all bytes in rom module 256 should be 0 */
-		Bit8u sum = 0;
+		uint8_t sum = 0;
 		PhysPt rom_base = PhysMake(0xc000,0);
 		Bitu last_rombyte = 32*1024 - 1;		//32 KB romsize
 		for (Bitu i = 0;i < last_rombyte;i++)
 			sum += phys_readb(rom_base + i);	//OVERFLOW IS OKAY
-		sum = (Bit8u)((256 - (Bitu)sum)&0xff);
+		sum = (uint8_t)((256 - (Bitu)sum)&0xff);
 		phys_writeb(rom_base + last_rombyte,sum);
 	}
 }
 
 
-Bit8u int10_font_08[256 * 8] = {
+uint8_t int10_font_08[256 * 8] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x7e, 0x81, 0xa5, 0x81, 0xbd, 0x99, 0x81, 0x7e,
   0x7e, 0xff, 0xdb, 0xff, 0xc3, 0xe7, 0xff, 0x7e,
@@ -584,7 +584,7 @@ Bit8u int10_font_08[256 * 8] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-Bit8u int10_font_14[256 * 14] = {
+uint8_t int10_font_14[256 * 14] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x7e, 0x81, 0xa5, 0x81, 0x81, 0xbd, 0x99, 0x81,
@@ -1035,7 +1035,7 @@ Bit8u int10_font_14[256 * 14] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-Bit8u int10_font_16[256 * 16] = {
+uint8_t int10_font_16[256 * 16] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x7e, 0x81, 0xa5, 0x81, 0x81, 0xbd,
@@ -1550,7 +1550,7 @@ Bit8u int10_font_16[256 * 16] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-Bit8u int10_font_14_alternate[20 * 15 + 1] = {
+uint8_t int10_font_14_alternate[20 * 15 + 1] = {
   0x1d,
   0x00, 0x00, 0x00, 0x00, 0x24, 0x66, 0xff,
   0x66, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1614,7 +1614,7 @@ Bit8u int10_font_14_alternate[20 * 15 + 1] = {
   0x00
 };
 
-Bit8u int10_font_16_alternate[19 * 17 + 1] = {
+uint8_t int10_font_16_alternate[19 * 17 + 1] = {
   0x1d,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x66, 0xff,
   0x66, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/src/ints/int10_misc.cpp
+++ b/src/ints/int10_misc.cpp
@@ -24,26 +24,26 @@
 #pragma pack(1)
 struct Dynamic_Functionality {
 	RealPt static_table;		/* 00h   DWORD  address of static functionality table */
-	Bit8u cur_mode;				/* 04h   BYTE   video mode in effect */
-	Bit16u num_cols;			/* 05h   WORD   number of columns */
-	Bit16u regen_size;			/* 07h   WORD   length of regen buffer in bytes */
-	Bit16u regen_start;			/* 09h   WORD   starting address of regen buffer*/
-	Bit16u cursor_pos[8];		/* 0Bh   WORD   cursor position for page 0-7 */
-	Bit16u cursor_type;			/* 1Bh   WORD   cursor type */
-	Bit8u active_page;			/* 1Dh   BYTE   active display page */
-	Bit16u crtc_address;		/* 1Eh   WORD   CRTC port address */
-	Bit8u reg_3x8;				/* 20h   BYTE   current setting of register (3?8) */
-	Bit8u reg_3x9;				/* 21h   BYTE   current setting of register (3?9) */
-	Bit8u num_rows;				/* 22h   BYTE   number of rows */
-	Bit16u bytes_per_char;		/* 23h   WORD   bytes/character */
-	Bit8u dcc;					/* 25h   BYTE   display combination code of active display */
-	Bit8u dcc_alternate;		/* 26h   BYTE   DCC of alternate display */
-	Bit16u num_colors;			/* 27h   WORD   number of colors supported in current mode */
-	Bit8u num_pages;			/* 29h   BYTE   number of pages supported in current mode */
-	Bit8u num_scanlines;		/* 2Ah   BYTE   number of scan lines active mode (0,1,2,3) = (200,350,400,480) */
-	Bit8u pri_char_block;		/* 2Bh   BYTE   primary character block */
-	Bit8u sec_char_block;		/* 2Ch   BYTE   secondary character block */
-	Bit8u misc_flags;			/* 2Dh   BYTE   miscellaneous flags
+	uint8_t cur_mode;				/* 04h   BYTE   video mode in effect */
+	uint16_t num_cols;			/* 05h   WORD   number of columns */
+	uint16_t regen_size;			/* 07h   WORD   length of regen buffer in bytes */
+	uint16_t regen_start;			/* 09h   WORD   starting address of regen buffer*/
+	uint16_t cursor_pos[8];		/* 0Bh   WORD   cursor position for page 0-7 */
+	uint16_t cursor_type;			/* 1Bh   WORD   cursor type */
+	uint8_t active_page;			/* 1Dh   BYTE   active display page */
+	uint16_t crtc_address;		/* 1Eh   WORD   CRTC port address */
+	uint8_t reg_3x8;				/* 20h   BYTE   current setting of register (3?8) */
+	uint8_t reg_3x9;				/* 21h   BYTE   current setting of register (3?9) */
+	uint8_t num_rows;				/* 22h   BYTE   number of rows */
+	uint16_t bytes_per_char;		/* 23h   WORD   bytes/character */
+	uint8_t dcc;					/* 25h   BYTE   display combination code of active display */
+	uint8_t dcc_alternate;		/* 26h   BYTE   DCC of alternate display */
+	uint16_t num_colors;			/* 27h   WORD   number of colors supported in current mode */
+	uint8_t num_pages;			/* 29h   BYTE   number of pages supported in current mode */
+	uint8_t num_scanlines;		/* 2Ah   BYTE   number of scan lines active mode (0,1,2,3) = (200,350,400,480) */
+	uint8_t pri_char_block;		/* 2Bh   BYTE   primary character block */
+	uint8_t sec_char_block;		/* 2Ch   BYTE   secondary character block */
+	uint8_t misc_flags;			/* 2Dh   BYTE   miscellaneous flags
 									bit 0 all modes on all displays on
 									1 grey summing on
 									2 monochrome display attached
@@ -53,9 +53,9 @@ struct Dynamic_Functionality {
 									6 PS/2 P70 plasma display (without 9-dot wide font) active
 									7 reserved
 								*/
-	Bit8u reserved1[3];			/* 2Eh  3 BYTEs reserved (00h) */
-	Bit8u vid_mem;				/* 31h   BYTE   video memory available 00h = 64K, 01h = 128K, 02h = 192K, 03h = 256K */
-	Bit8u savep_state_flag;		/* 32h   BYTE   save pointer state flags 
+	uint8_t reserved1[3];			/* 2Eh  3 BYTEs reserved (00h) */
+	uint8_t vid_mem;				/* 31h   BYTE   video memory available 00h = 64K, 01h = 128K, 02h = 192K, 03h = 256K */
+	uint8_t savep_state_flag;		/* 32h   BYTE   save pointer state flags 
 									bit 0 512 character set active
 									1 dynamic save area present
 									2 alpha font override active
@@ -65,24 +65,24 @@ struct Dynamic_Functionality {
 									6 reserved
 									7 reserved
 								*/
-	Bit8u reserved2[13];		/*  33h 13 BYTEs reserved (00h) */
+	uint8_t reserved2[13];		/*  33h 13 BYTEs reserved (00h) */
 } GCC_ATTRIBUTE(packed);
 #pragma pack()
 
-void INT10_DisplayCombinationCode(Bit16u * dcc,bool set) {
-	Bit8u index=0xff;
-	Bit16u dccentry=0xffff;
+void INT10_DisplayCombinationCode(uint16_t * dcc,bool set) {
+	uint8_t index=0xff;
+	uint16_t dccentry=0xffff;
 	// walk the tables...
 	RealPt vsavept=real_readd(BIOSMEM_SEG,BIOSMEM_VS_POINTER);
 	RealPt svstable=real_readd(RealSeg(vsavept),RealOff(vsavept)+0x10);
 	if (svstable) {
 		RealPt dcctable=real_readd(RealSeg(svstable),RealOff(svstable)+0x02);
-		Bit8u entries=real_readb(RealSeg(dcctable),RealOff(dcctable)+0x00);
+		uint8_t entries=real_readb(RealSeg(dcctable),RealOff(dcctable)+0x00);
 		if (set) {
 			if (entries) {
-				Bit16u swap=(*dcc<<8)|(*dcc>>8);
+				uint16_t swap=(*dcc<<8)|(*dcc>>8);
 				// search for the index in the dcc table
-				for (Bit8u entry=0; entry<entries; entry++) {
+				for (uint8_t entry=0; entry<entries; entry++) {
 					dccentry=real_readw(RealSeg(dcctable),RealOff(dcctable)+0x04+entry*2);
 					if ((dccentry==*dcc) || (dccentry==swap)) {
 						index=entry;
@@ -97,7 +97,7 @@ void INT10_DisplayCombinationCode(Bit16u * dcc,bool set) {
 				dccentry=real_readw(RealSeg(dcctable),RealOff(dcctable)+0x04+index*2);
 				if ((dccentry&0xff)==0) dccentry>>=8;
 				else if (dccentry>>8) {
-					Bit16u cfg_mono=((real_readw(BIOSMEM_SEG,BIOSMEM_INITIAL_MODE)&0x30)==0x30)?1:0;
+					uint16_t cfg_mono=((real_readw(BIOSMEM_SEG,BIOSMEM_INITIAL_MODE)&0x30)==0x30)?1:0;
 					if (cfg_mono^(dccentry&1)) dccentry=(dccentry<<8)|(dccentry>>8);
 				}
 			}
@@ -111,7 +111,7 @@ void INT10_GetFuncStateInformation(PhysPt save) {
 	/* set static state pointer */
 	mem_writed(save,int10.rom.static_state);
 	/* Copy BIOS Segment areas */
-	Bit16u i;
+	uint16_t i;
 
 	/* First area in Bios Seg */
 	for (i=0;i<0x1e;i++) {
@@ -125,11 +125,11 @@ void INT10_GetFuncStateInformation(PhysPt save) {
 	/* Zero out rest of block */
 	for (i=0x25;i<0x40;i++) mem_writeb(save+i,0);
 	/* DCC */
-	Bit16u dcc=0;
+	uint16_t dcc=0;
 	INT10_DisplayCombinationCode(&dcc,false);
 	mem_writew(save+0x25,dcc);
 
-	Bit16u col_count=0;
+	uint16_t col_count=0;
 	switch (CurMode->type) {
 	case M_TEXT:
 		if (CurMode->mode==0x7) col_count=1; else col_count=16;break; 
@@ -176,7 +176,7 @@ RealPt INT10_EGA_RIL_GetVersionPt(void) {
 	return RealMake(0xc000,0x30);
 }
 
-static void EGA_RIL(Bit16u dx, Bit16u& port, Bit16u& regs) {
+static void EGA_RIL(uint16_t dx, uint16_t& port, uint16_t& regs) {
 	port = 0;
 	regs = 0; //if nul is returned it's a single register port
 	switch(dx) {
@@ -214,9 +214,9 @@ static void EGA_RIL(Bit16u dx, Bit16u& port, Bit16u& regs) {
 	}
 }
 
-void INT10_EGA_RIL_ReadRegister(Bit8u & bl, Bit16u dx) {
-	Bit16u port = 0;
-	Bit16u regs = 0;
+void INT10_EGA_RIL_ReadRegister(uint8_t & bl, uint16_t dx) {
+	uint16_t port = 0;
+	uint16_t regs = 0;
 	EGA_RIL(dx,port,regs);
 	if(regs == 0) {
 		if(port) bl = IO_Read(port);
@@ -229,9 +229,9 @@ void INT10_EGA_RIL_ReadRegister(Bit8u & bl, Bit16u dx) {
 	}
 }
 
-void INT10_EGA_RIL_WriteRegister(Bit8u & bl, Bit8u bh, Bit16u dx) {
-	Bit16u port = 0;
-	Bit16u regs = 0;
+void INT10_EGA_RIL_WriteRegister(uint8_t & bl, uint8_t bh, uint16_t dx) {
+	uint16_t port = 0;
+	uint16_t regs = 0;
 	EGA_RIL(dx,port,regs);
 	if(regs == 0) {
 		if(port) IO_Write(port,bl);
@@ -249,15 +249,15 @@ void INT10_EGA_RIL_WriteRegister(Bit8u & bl, Bit8u bh, Bit16u dx) {
 	}
 }
 
-void INT10_EGA_RIL_ReadRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt dst) {
-	Bit16u port = 0;
-	Bit16u regs = 0;
+void INT10_EGA_RIL_ReadRegisterRange(uint8_t ch, uint8_t cl, uint16_t dx, PhysPt dst) {
+	uint16_t port = 0;
+	uint16_t regs = 0;
 	EGA_RIL(dx,port,regs);
 	if(regs == 0) {
 		LOG(LOG_INT10,LOG_ERROR)("EGA RIL range read with port %x called",port);
 	} else {
 		if(ch<regs) {
-			if ((Bitu)ch+cl>regs) cl=(Bit8u)(regs-ch);
+			if ((Bitu)ch+cl>regs) cl=(uint8_t)(regs-ch);
 			for (Bitu i=0; i<cl; i++) {
 				if(port == 0x3c0) IO_Read(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS) + 6);
 				IO_Write(port,ch+i);
@@ -268,15 +268,15 @@ void INT10_EGA_RIL_ReadRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt dst) 
 	}
 }
 
-void INT10_EGA_RIL_WriteRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt src) {
-	Bit16u port = 0;
-	Bit16u regs = 0;
+void INT10_EGA_RIL_WriteRegisterRange(uint8_t ch, uint8_t cl, uint16_t dx, PhysPt src) {
+	uint16_t port = 0;
+	uint16_t regs = 0;
 	EGA_RIL(dx,port,regs);
 	if(regs == 0) {
 		LOG(LOG_INT10,LOG_ERROR)("EGA RIL range write called with port %x",port);
 	} else {
 		if(ch<regs) {
-			if ((Bitu)ch+cl>regs) cl=(Bit8u)(regs-ch);
+			if ((Bitu)ch+cl>regs) cl=(uint8_t)(regs-ch);
 			if(port == 0x3c0) {
 				IO_Read(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS) + 6);
 				for (Bitu i=0; i<cl; i++) {
@@ -298,27 +298,27 @@ void INT10_EGA_RIL_WriteRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt src)
    offset 2 (byte): register number (0 for single registers, ignored)
    offset 3 (byte): register value (return value when reading)
 */
-void INT10_EGA_RIL_ReadRegisterSet(Bit16u cx, PhysPt tbl) {
+void INT10_EGA_RIL_ReadRegisterSet(uint16_t cx, PhysPt tbl) {
 	/* read cx register sets */
-	for (Bit16u i=0; i<cx; i++) {
-		Bit8u vl=mem_readb(tbl+2);
+	for (uint16_t i=0; i<cx; i++) {
+		uint8_t vl=mem_readb(tbl+2);
 		INT10_EGA_RIL_ReadRegister(vl, mem_readw(tbl));
 		mem_writeb(tbl+3, vl);
 		tbl+=4;
 	}
 }
 
-void INT10_EGA_RIL_WriteRegisterSet(Bit16u cx, PhysPt tbl) {
+void INT10_EGA_RIL_WriteRegisterSet(uint16_t cx, PhysPt tbl) {
 	/* write cx register sets */
-	Bit16u port = 0;
-	Bit16u regs = 0;
-	for (Bit16u i=0; i<cx; i++) {
+	uint16_t port = 0;
+	uint16_t regs = 0;
+	for (uint16_t i=0; i<cx; i++) {
 		EGA_RIL(mem_readw(tbl),port,regs);
-		Bit8u vl=mem_readb(tbl+3);
+		uint8_t vl=mem_readb(tbl+3);
 		if(regs == 0) {
 			if(port) IO_Write(port,vl);
 		} else {
-			Bit8u idx=mem_readb(tbl+2);
+			uint8_t idx=mem_readb(tbl+2);
 			if(port == 0x3c0) {
 				IO_Read(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS) + 6);
 				IO_Write(port,idx);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -324,7 +324,7 @@ std::vector<VideoModeBlock> Hercules_Mode = {
 	{0x007, M_TEXT, 640, 350, 80, 25, 8, 14, 1, 0xB0000, 0x1000, 97, 25, 80, 25, 0},
 };
 
-static Bit8u text_palette[64][3]=
+static uint8_t text_palette[64][3]=
 {
   {0x00,0x00,0x00},{0x00,0x00,0x2a},{0x00,0x2a,0x00},{0x00,0x2a,0x2a},{0x2a,0x00,0x00},{0x2a,0x00,0x2a},{0x2a,0x2a,0x00},{0x2a,0x2a,0x2a},
   {0x00,0x00,0x15},{0x00,0x00,0x3f},{0x00,0x2a,0x15},{0x00,0x2a,0x3f},{0x2a,0x00,0x15},{0x2a,0x00,0x3f},{0x2a,0x2a,0x15},{0x2a,0x2a,0x3f},
@@ -336,7 +336,7 @@ static Bit8u text_palette[64][3]=
   {0x15,0x15,0x15},{0x15,0x15,0x3f},{0x15,0x3f,0x15},{0x15,0x3f,0x3f},{0x3f,0x15,0x15},{0x3f,0x15,0x3f},{0x3f,0x3f,0x15},{0x3f,0x3f,0x3f}
 };
 
-static Bit8u mtext_palette[64][3]=
+static uint8_t mtext_palette[64][3]=
 {
   {0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},
   {0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},
@@ -348,7 +348,7 @@ static Bit8u mtext_palette[64][3]=
   {0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f} 
 };
 
-static Bit8u mtext_s3_palette[64][3]=
+static uint8_t mtext_s3_palette[64][3]=
 {
   {0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},{0x00,0x00,0x00},
   {0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},{0x2a,0x2a,0x2a},
@@ -360,7 +360,7 @@ static Bit8u mtext_s3_palette[64][3]=
   {0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f},{0x3f,0x3f,0x3f} 
 };
 
-static Bit8u ega_palette[64][3]=
+static uint8_t ega_palette[64][3]=
 {
   {0x00,0x00,0x00}, {0x00,0x00,0x2a}, {0x00,0x2a,0x00}, {0x00,0x2a,0x2a}, {0x2a,0x00,0x00}, {0x2a,0x00,0x2a}, {0x2a,0x15,0x00}, {0x2a,0x2a,0x2a},
   {0x00,0x00,0x00}, {0x00,0x00,0x2a}, {0x00,0x2a,0x00}, {0x00,0x2a,0x2a}, {0x2a,0x00,0x00}, {0x2a,0x00,0x2a}, {0x2a,0x15,0x00}, {0x2a,0x2a,0x2a},
@@ -372,13 +372,13 @@ static Bit8u ega_palette[64][3]=
   {0x15,0x15,0x15}, {0x15,0x15,0x3f}, {0x15,0x3f,0x15}, {0x15,0x3f,0x3f}, {0x3f,0x15,0x15}, {0x3f,0x15,0x3f}, {0x3f,0x3f,0x15}, {0x3f,0x3f,0x3f}
 };
 
-static Bit8u cga_palette[16][3]=
+static uint8_t cga_palette[16][3]=
 {
 	{0x00,0x00,0x00}, {0x00,0x00,0x2a}, {0x00,0x2a,0x00}, {0x00,0x2a,0x2a}, {0x2a,0x00,0x00}, {0x2a,0x00,0x2a}, {0x2a,0x15,0x00}, {0x2a,0x2a,0x2a},
 	{0x15,0x15,0x15}, {0x15,0x15,0x3f}, {0x15,0x3f,0x15}, {0x15,0x3f,0x3f}, {0x3f,0x15,0x15}, {0x3f,0x15,0x3f}, {0x3f,0x3f,0x15}, {0x3f,0x3f,0x3f},
 };
 
-static Bit8u cga_palette_2[64][3]=
+static uint8_t cga_palette_2[64][3]=
 {
 	{0x00,0x00,0x00}, {0x00,0x00,0x2a}, {0x00,0x2a,0x00}, {0x00,0x2a,0x2a}, {0x2a,0x00,0x00}, {0x2a,0x00,0x2a}, {0x2a,0x15,0x00}, {0x2a,0x2a,0x2a},
 	{0x00,0x00,0x00}, {0x00,0x00,0x2a}, {0x00,0x2a,0x00}, {0x00,0x2a,0x2a}, {0x2a,0x00,0x00}, {0x2a,0x00,0x2a}, {0x2a,0x15,0x00}, {0x2a,0x2a,0x2a},
@@ -390,7 +390,7 @@ static Bit8u cga_palette_2[64][3]=
 	{0x15,0x15,0x15}, {0x15,0x15,0x3f}, {0x15,0x3f,0x15}, {0x15,0x3f,0x3f}, {0x3f,0x15,0x15}, {0x3f,0x15,0x3f}, {0x3f,0x3f,0x15}, {0x3f,0x3f,0x3f},
 };
 
-static Bit8u vga_palette[248][3]=
+static uint8_t vga_palette[248][3]=
 {
   {0x00,0x00,0x00},{0x00,0x00,0x2a},{0x00,0x2a,0x00},{0x00,0x2a,0x2a},{0x2a,0x00,0x00},{0x2a,0x00,0x2a},{0x2a,0x15,0x00},{0x2a,0x2a,0x2a},
   {0x15,0x15,0x15},{0x15,0x15,0x3f},{0x15,0x3f,0x15},{0x15,0x3f,0x3f},{0x3f,0x15,0x15},{0x3f,0x15,0x3f},{0x3f,0x3f,0x15},{0x3f,0x3f,0x3f},
@@ -429,7 +429,7 @@ static Bit8u vga_palette[248][3]=
 };
 std::vector<VideoModeBlock>::const_iterator CurMode = std::prev(ModeList_VGA.end());
 
-static bool SetCurMode(const std::vector<VideoModeBlock> &modeblock, Bit16u mode)
+static bool SetCurMode(const std::vector<VideoModeBlock> &modeblock, uint16_t mode)
 {
 	size_t i = 0;
 	while (modeblock[i].mode != 0xffff) {
@@ -466,7 +466,7 @@ static void SetTextLines(void) {
 }
 
 void INT10_SetCurMode(void) {
-	Bit16u bios_mode=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
+	uint16_t bios_mode=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
 	if (GCC_UNLIKELY(CurMode->mode!=bios_mode)) {
 		bool mode_changed=false;
 		switch (machine) {
@@ -518,7 +518,7 @@ static void FinishSetMode(bool clearmem) {
 		case M_CGA16:
 			if ((machine==MCH_PCJR) && (CurMode->mode >= 9)) {
 				// PCJR cannot access the full 32k at 0xb800
-				for (Bit16u ct=0;ct<16*1024;ct++) {
+				for (uint16_t ct=0;ct<16*1024;ct++) {
 					// 0x1800 is the last 32k block in 128k, as set in the CRTCPU_PAGE register 
 					real_writew(0x1800,ct*2,0x0000);
 				}
@@ -526,7 +526,7 @@ static void FinishSetMode(bool clearmem) {
 			}
 			// fall-through
 		case M_CGA2:
-			for (Bit16u ct=0;ct<16*1024;ct++) {
+			for (uint16_t ct=0;ct<16*1024;ct++) {
 				real_writew( 0xb800,ct*2,0x0000);
 			}
 			break;
@@ -535,8 +535,8 @@ static void FinishSetMode(bool clearmem) {
 		case M_TEXT: {
 			// TODO Hercules had 32KiB compared to CGA/MDA 16KiB,
 			// but does it matter in here?
-			Bit16u seg = (CurMode->mode==7)?0xb000:0xb800;
-			for (Bit16u ct=0;ct<16*1024;ct++) real_writew(seg,ct*2,0x0720);
+			uint16_t seg = (CurMode->mode==7)?0xb000:0xb800;
+			for (uint16_t ct=0;ct<16*1024;ct++) real_writew(seg,ct*2,0x0720);
 			break;
 		}
 		case M_EGA:
@@ -563,15 +563,15 @@ static void FinishSetMode(bool clearmem) {
 		}
 	}
 	//  Setup the BIOS
-	if (CurMode->mode<128) real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE,(Bit8u)CurMode->mode);
-	else real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE,(Bit8u)(CurMode->mode-0x98));	//Looks like the s3 bios
-	real_writew(BIOSMEM_SEG,BIOSMEM_NB_COLS,(Bit16u)CurMode->twidth);
-	real_writew(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE,(Bit16u)CurMode->plength);
+	if (CurMode->mode<128) real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE,(uint8_t)CurMode->mode);
+	else real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE,(uint8_t)(CurMode->mode-0x98));	//Looks like the s3 bios
+	real_writew(BIOSMEM_SEG,BIOSMEM_NB_COLS,(uint16_t)CurMode->twidth);
+	real_writew(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE,(uint16_t)CurMode->plength);
 	real_writew(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS,((CurMode->mode==7 )|| (CurMode->mode==0x0f)) ? 0x3b4 : 0x3d4);
 
 	if (IS_EGAVGA_ARCH) {
-		real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,(Bit8u)(CurMode->theight-1));
-		real_writew(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,(Bit16u)CurMode->cheight);
+		real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,(uint8_t)(CurMode->theight-1));
+		real_writew(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,(uint16_t)CurMode->cheight);
 		real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,(0x60|(clearmem?0:0x80)));
 		real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0x09);
 		// this is an index into the dcc table:
@@ -594,12 +594,12 @@ static void FinishSetMode(bool clearmem) {
 		INT10_SetCursorShape(0x06,0x07);
 	}
 	// Set cursor pos for page 0..7
-	for (Bit8u ct=0;ct<8;ct++) INT10_SetCursorPos(0,0,ct);
+	for (uint8_t ct=0;ct<8;ct++) INT10_SetCursorPos(0,0,ct);
 	// Set active page 0
 	INT10_SetActivePage(0);
 }
 
-static bool INT10_SetVideoMode_OTHER(Bit16u mode, bool clearmem)
+static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 {
 	switch (machine) {
 	case MCH_CGA:
@@ -677,21 +677,21 @@ static bool INT10_SetVideoMode_OTHER(Bit16u mode, bool clearmem)
 	}
 	IO_WriteW(crtc_base,0x09 | (scanline-1) << 8);
 	//Setup the CGA palette using VGA DAC palette
-	for (Bit8u ct=0;ct<16;ct++) VGA_DAC_SetEntry(ct,cga_palette[ct][0],cga_palette[ct][1],cga_palette[ct][2]);
+	for (uint8_t ct=0;ct<16;ct++) VGA_DAC_SetEntry(ct,cga_palette[ct][0],cga_palette[ct][1],cga_palette[ct][2]);
 	//Setup the tandy palette
-	for (Bit8u ct=0;ct<16;ct++) VGA_DAC_CombineColor(ct,ct);
+	for (uint8_t ct=0;ct<16;ct++) VGA_DAC_CombineColor(ct,ct);
 	//Setup the special registers for each machine type
-	Bit8u mode_control_list[0xa+1]={
+	uint8_t mode_control_list[0xa+1]={
 		0x2c,0x28,0x2d,0x29,	//0-3
 		0x2a,0x2e,0x1e,0x29,	//4-7
 		0x2a,0x2b,0x3b			//8-a
 	};
-	Bit8u mode_control_list_pcjr[0xa+1]={
+	uint8_t mode_control_list_pcjr[0xa+1]={
 		0x0c,0x08,0x0d,0x09,	//0-3
 		0x0a,0x0e,0x0e,0x09,	//4-7		
 		0x1a,0x1b,0x0b			//8-a
 	};
-	Bit8u mode_control,color_select;
+	uint8_t mode_control,color_select;
 	uint8_t crtpage;
 	switch (machine) {
 	case MCH_HERC:
@@ -788,7 +788,7 @@ static bool INT10_SetVideoMode_OTHER(Bit16u mode, bool clearmem)
 	RealPt vparams = RealGetVec(0x1d);
 	if ((vparams != RealMake(0xf000,0xf0a4)) && (mode < 8)) {
 		// load crtc parameters from video params table
-		Bit16u crtc_block_index = 0;
+		uint16_t crtc_block_index = 0;
 		if (mode < 2) crtc_block_index = 0;
 		else if (mode < 4) crtc_block_index = 1;
 		else if (mode < 7) crtc_block_index = 2;
@@ -801,7 +801,7 @@ static bool INT10_SetVideoMode_OTHER(Bit16u mode, bool clearmem)
 		// else crtc_block_index = 3; // Tandy/PCjr modes
 
 		// init CRTC registers
-		for (Bit16u i = 0; i < 16; i++)
+		for (uint16_t i = 0; i < 16; i++)
 			IO_WriteW(crtc_base, i | (real_readb(RealSeg(vparams), 
 				RealOff(vparams) + i + crtc_block_index*16) << 8));
 	}
@@ -809,7 +809,7 @@ static bool INT10_SetVideoMode_OTHER(Bit16u mode, bool clearmem)
 	return true;
 }
 
-bool INT10_SetVideoMode(Bit16u mode)
+bool INT10_SetVideoMode(uint16_t mode)
 {
 	bool clearmem = true;
 	Bitu i;
@@ -829,9 +829,9 @@ bool INT10_SetVideoMode(Bit16u mode)
 		return INT10_SetVideoMode_OTHER(mode, clearmem);
 
 	//  First read mode setup settings from bios area
-	//	Bit8u video_ctl=real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL);
-	//	Bit8u vga_switches=real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES);
-	Bit8u modeset_ctl = real_readb(BIOSMEM_SEG, BIOSMEM_MODESET_CTL);
+	//	uint8_t video_ctl=real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL);
+	//	uint8_t vga_switches=real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES);
+	uint8_t modeset_ctl = real_readb(BIOSMEM_SEG, BIOSMEM_MODESET_CTL);
 
 	if (IS_VGA_ARCH) {
 		if (svga.accepts_mode) {
@@ -868,7 +868,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 
 	//  Setup the VGA to the correct mode
 
-	Bit16u crtc_base;
+	uint16_t crtc_base;
 	bool mono_mode=(mode == 7) || (mode==0xf);  
 	if (mono_mode) crtc_base=0x3b4;
 	else crtc_base=0x3d4;
@@ -880,7 +880,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	}
 
 	//  Setup MISC Output Register
-	Bit8u misc_output=0x2 | (mono_mode ? 0x0 : 0x1);
+	uint8_t misc_output=0x2 | (mono_mode ? 0x0 : 0x1);
 
 	if (machine==MCH_EGA) {
 		// 16MHz clock for 350-line EGA modes except mode F
@@ -906,7 +906,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	IO_Write(0x3c2,misc_output);		//Setup for 3b4 or 3d4
 
 	//  Program Sequencer
-	Bit8u seq_data[SEQ_REGS];
+	uint8_t seq_data[SEQ_REGS];
 	memset(seq_data,0,SEQ_REGS);
 	seq_data[1]|=0x01;	//8 dot fonts by default
 	if (CurMode->special & EGA_HALF_CLOCK)
@@ -960,7 +960,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 		assert(false); 
 		break;
 	}
-	for (Bit8u ct=0;ct<SEQ_REGS;ct++) {
+	for (uint8_t ct=0;ct<SEQ_REGS;ct++) {
 		IO_Write(0x3c4,ct);
 		IO_Write(0x3c5,seq_data[ct]);
 	}
@@ -971,19 +971,19 @@ bool INT10_SetVideoMode(Bit16u mode)
 	IO_Write(crtc_base, 0x11);
 	IO_Write(crtc_base + 1, IO_Read(crtc_base + 1) & 0x7f);
 	//  Clear all the regs
-	for (Bit8u ct=0x0;ct<=0x18;ct++) {
+	for (uint8_t ct=0x0;ct<=0x18;ct++) {
 		IO_Write(crtc_base,ct);IO_Write(crtc_base+1,0);
 	}
-	Bit8u overflow=0;Bit8u max_scanline=0;
-	Bit8u ver_overflow=0;Bit8u hor_overflow=0;
+	uint8_t overflow=0;uint8_t max_scanline=0;
+	uint8_t ver_overflow=0;uint8_t hor_overflow=0;
 	//  Horizontal Total
-	IO_Write(crtc_base,0x00);IO_Write(crtc_base+1,(Bit8u)(CurMode->htotal-5));
+	IO_Write(crtc_base,0x00);IO_Write(crtc_base+1,(uint8_t)(CurMode->htotal-5));
 	hor_overflow|=((CurMode->htotal-5) & 0x100) >> 8;
 	//  Horizontal Display End
-	IO_Write(crtc_base,0x01);IO_Write(crtc_base+1,(Bit8u)(CurMode->hdispend-1));
+	IO_Write(crtc_base,0x01);IO_Write(crtc_base+1,(uint8_t)(CurMode->hdispend-1));
 	hor_overflow|=((CurMode->hdispend-1) & 0x100) >> 7;
 	//  Start horizontal Blanking
-	IO_Write(crtc_base,0x02);IO_Write(crtc_base+1,(Bit8u)CurMode->hdispend);
+	IO_Write(crtc_base,0x02);IO_Write(crtc_base+1,(uint8_t)CurMode->hdispend);
 	hor_overflow|=((CurMode->hdispend) & 0x100) >> 6;
 	//  End horizontal Blanking
 	Bitu blank_end=(CurMode->htotal-2) & 0x7f;
@@ -998,7 +998,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	else
 		ret_start = (CurMode->hdispend + 4);
 	IO_Write(crtc_base, 0x04);
-	IO_Write(crtc_base + 1, (Bit8u)ret_start);
+	IO_Write(crtc_base + 1, (uint8_t)ret_start);
 	hor_overflow |= (ret_start & 0x100) >> 4;
 
 	//  End Horizontal Retrace
@@ -1014,10 +1014,10 @@ bool INT10_SetVideoMode(Bit16u mode)
 	else
 		ret_end = (CurMode->htotal - 4) & 0x1f;
 
-	IO_Write(crtc_base,0x05);IO_Write(crtc_base+1,(Bit8u)(ret_end | (blank_end & 0x20) << 2));
+	IO_Write(crtc_base,0x05);IO_Write(crtc_base+1,(uint8_t)(ret_end | (blank_end & 0x20) << 2));
 
 	//  Vertical Total
-	IO_Write(crtc_base,0x06);IO_Write(crtc_base+1,(Bit8u)(CurMode->vtotal-2));
+	IO_Write(crtc_base,0x06);IO_Write(crtc_base+1,(uint8_t)(CurMode->vtotal-2));
 	overflow|=((CurMode->vtotal-2) & 0x100) >> 8;
 	overflow|=((CurMode->vtotal-2) & 0x200) >> 4;
 	ver_overflow|=((CurMode->vtotal-2) & 0x400) >> 10;
@@ -1042,7 +1042,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	}
 
 	//  Vertical Retrace Start
-	IO_Write(crtc_base,0x10);IO_Write(crtc_base+1,(Bit8u)vretrace);
+	IO_Write(crtc_base,0x10);IO_Write(crtc_base+1,(uint8_t)vretrace);
 	overflow|=(vretrace & 0x100) >> 6;
 	overflow|=(vretrace & 0x200) >> 2;
 	ver_overflow|=(vretrace & 0x400) >> 6;
@@ -1051,7 +1051,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	IO_Write(crtc_base,0x11);IO_Write(crtc_base+1,(vretrace+2) & 0xF);
 
 	//  Vertical Display End
-	IO_Write(crtc_base,0x12);IO_Write(crtc_base+1,(Bit8u)(CurMode->vdispend-1));
+	IO_Write(crtc_base,0x12);IO_Write(crtc_base+1,(uint8_t)(CurMode->vdispend-1));
 	overflow|=((CurMode->vdispend-1) & 0x100) >> 7;
 	overflow|=((CurMode->vdispend-1) & 0x200) >> 3;
 	ver_overflow|=((CurMode->vdispend-1) & 0x400) >> 9;
@@ -1076,13 +1076,13 @@ bool INT10_SetVideoMode(Bit16u mode)
 	}
 
 	//  Vertical Blank Start
-	IO_Write(crtc_base,0x15);IO_Write(crtc_base+1,(Bit8u)(CurMode->vdispend+vblank_trim));
+	IO_Write(crtc_base,0x15);IO_Write(crtc_base+1,(uint8_t)(CurMode->vdispend+vblank_trim));
 	overflow|=((CurMode->vdispend+vblank_trim) & 0x100) >> 5;
 	max_scanline|=((CurMode->vdispend+vblank_trim) & 0x200) >> 4;
 	ver_overflow|=((CurMode->vdispend+vblank_trim) & 0x400) >> 8;
 
 	//  Vertical Blank End
-	IO_Write(crtc_base,0x16);IO_Write(crtc_base+1,(Bit8u)(CurMode->vtotal-vblank_trim-2));
+	IO_Write(crtc_base,0x16);IO_Write(crtc_base+1,(uint8_t)(CurMode->vtotal-vblank_trim-2));
 
 	//  Line Compare
 	Bitu line_compare=(CurMode->vtotal < 1024) ? 1023 : 2047;
@@ -1090,7 +1090,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	overflow|=(line_compare & 0x100) >> 4;
 	max_scanline|=(line_compare & 0x200) >> 3;
 	ver_overflow|=(line_compare & 0x400) >> 4;
-	Bit8u underline=0;
+	uint8_t underline=0;
 	//  Maximum scanline / Underline Location
 	if (CurMode->special & EGA_LINE_DOUBLE) {
 		if (machine!=MCH_EGA) max_scanline|=0x80;
@@ -1161,7 +1161,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 		//  Extended System Control 2 Register
 		//  This register actually has more bits but only use the extended offset ones
 		IO_Write(crtc_base, 0x51);
-		IO_Write(crtc_base + 1, (Bit8u)((offset & 0x300) >> 4));
+		IO_Write(crtc_base + 1, (uint8_t)((offset & 0x300) >> 4));
 		//  Clear remaining bits of the display start
 		IO_Write(crtc_base,0x69);
 		IO_Write(crtc_base + 1,0);
@@ -1170,7 +1170,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	}
 
 	//  Mode Control
-	Bit8u mode_control=0;
+	uint8_t mode_control=0;
 
 	switch (CurMode->type) {
 	case M_CGA2:
@@ -1256,7 +1256,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 
 			VGA_SetClock(3, static_cast<uint32_t>(s3_clock_khz));
 		}
-		Bit8u misc_control_2;
+		uint8_t misc_control_2;
 		//  Setup Pixel format
 		switch (CurMode->type) {
 		case M_LIN8:
@@ -1284,7 +1284,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 	//  Write Misc Output
 	IO_Write(0x3c2,misc_output);
 	//  Program Graphics controller
-	Bit8u gfx_data[GFX_REGS];
+	uint8_t gfx_data[GFX_REGS];
 	memset(gfx_data,0,GFX_REGS);
 	gfx_data[0x7] = 0xf;  //  Color don't care
 	gfx_data[0x8] = 0xff; //  BitMask
@@ -1336,11 +1336,11 @@ bool INT10_SetVideoMode(Bit16u mode)
 		assert(false); 
 		break;
 	}
-	for (Bit8u ct=0;ct<GFX_REGS;ct++) {
+	for (uint8_t ct=0;ct<GFX_REGS;ct++) {
 		IO_Write(0x3ce,ct);
 		IO_Write(0x3cf,gfx_data[ct]);
 	}
-	Bit8u att_data[ATT_REGS];
+	uint8_t att_data[ATT_REGS];
 	memset(att_data,0,ATT_REGS);
 	att_data[0x12]=0xf;				//Always have all color planes enabled
 	//  Program Attribute Controller
@@ -1368,7 +1368,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 		default:
 			if ( CurMode->type == M_LIN4 )
 				goto att_text16;
-			for (Bit8u ct=0;ct<8;ct++) {
+			for (uint8_t ct=0;ct<8;ct++) {
 				att_data[ct]=ct;
 				att_data[ct+8]=ct+0x10;
 			}
@@ -1380,7 +1380,7 @@ bool INT10_SetVideoMode(Bit16u mode)
 		//       this function is supposed to deal with
 		//       MCH_EGA and MCH_VGA only.
 		att_data[0x10]=0x01;		//Color Graphics
-		for (Bit8u ct=0;ct<16;ct++) att_data[ct]=ct;
+		for (uint8_t ct=0;ct<16;ct++) att_data[ct]=ct;
 		break;
 	case M_TEXT:
 		if (CurMode->cwidth==9) {
@@ -1400,7 +1400,7 @@ att_text16:
 				att_data[i+8]=0x18;
 			}
 		} else {
-			for (Bit8u ct=0;ct<8;ct++) {
+			for (uint8_t ct=0;ct<8;ct++) {
 				att_data[ct]=ct;
 				att_data[ct+8]=ct+0x38;
 			}
@@ -1424,7 +1424,7 @@ att_text16:
 		att_data[5]=0x04;
 		att_data[6]=0x06;
 		att_data[7]=0x07;
-		for (Bit8u ct=0x8;ct<0x10;ct++) 
+		for (uint8_t ct=0x8;ct<0x10;ct++) 
 			att_data[ct] = ct + 0x8;
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL,0x30);
 		break;
@@ -1434,7 +1434,7 @@ att_text16:
 	case M_LIN16:
 	case M_LIN24:
 	case M_LIN32:
-		for (Bit8u ct=0;ct<16;ct++) att_data[ct]=ct;
+		for (uint8_t ct=0;ct<16;ct++) att_data[ct]=ct;
 		att_data[0x10]=0x41;		//Color Graphics 8-bit
 		break;
 	case M_CGA16:              // only in MCH_TANDY, MCH_PCJR
@@ -1455,7 +1455,7 @@ att_text16:
 	}
 	IO_Read(mono_mode ? 0x3ba : 0x3da);
 	if ((modeset_ctl & 8)==0) {
-		for (Bit8u ct=0;ct<ATT_REGS;ct++) {
+		for (uint8_t ct=0;ct<ATT_REGS;ct++) {
 			IO_Write(0x3c0,ct);
 			IO_Write(0x3c0,att_data[ct]);
 		}
@@ -1558,7 +1558,7 @@ dac_text16:
 			}
 		}
 	} else {
-		for (Bit8u ct=0x10;ct<ATT_REGS;ct++) {
+		for (uint8_t ct=0x10;ct<ATT_REGS;ct++) {
 			if (ct==0x11) continue;	// skip overscan register
 			IO_Write(0x3c0,ct);
 			IO_Write(0x3c0,att_data[ct]);
@@ -1570,7 +1570,7 @@ dac_text16:
 	RealPt vsavept=real_readd(BIOSMEM_SEG,BIOSMEM_VS_POINTER);
 	RealPt dsapt=real_readd(RealSeg(vsavept),RealOff(vsavept)+4);
 	if (dsapt) {
-		for (Bit8u ct=0;ct<0x10;ct++) {
+		for (uint8_t ct=0;ct<0x10;ct++) {
 			real_writeb(RealSeg(dsapt),RealOff(dsapt)+ct,att_data[ct]);
 		}
 		real_writeb(RealSeg(dsapt),RealOff(dsapt)+0x10,0); // overscan
@@ -1604,11 +1604,11 @@ dac_text16:
 		IO_Write(crtc_base+1,0);
 		//  Setup the linear frame buffer
 		IO_Write(crtc_base,0x59);
-		IO_Write(crtc_base+1,(Bit8u)((S3_LFB_BASE >> 24)&0xff));
+		IO_Write(crtc_base+1,(uint8_t)((S3_LFB_BASE >> 24)&0xff));
 		IO_Write(crtc_base,0x5a);
-		IO_Write(crtc_base+1,(Bit8u)((S3_LFB_BASE >> 16)&0xff));
+		IO_Write(crtc_base+1,(uint8_t)((S3_LFB_BASE >> 16)&0xff));
 		IO_Write(crtc_base,0x6b); // BIOS scratchpad
-		IO_Write(crtc_base+1,(Bit8u)((S3_LFB_BASE >> 24)&0xff));
+		IO_Write(crtc_base+1,(uint8_t)((S3_LFB_BASE >> 24)&0xff));
 
 		//  Setup some remaining S3 registers
 		IO_Write(crtc_base,0x41); // BIOS scratchpad
@@ -1639,7 +1639,7 @@ dac_text16:
 		}
 		IO_WriteB(crtc_base,0x50); IO_WriteB(crtc_base+1,reg_50);
 
-		Bit8u reg_31, reg_3a;
+		uint8_t reg_31, reg_3a;
 		switch (CurMode->type) {
 			case M_LIN15:
 			case M_LIN16:

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -27,7 +27,7 @@ static inline void ResetACTL(void) {
 	IO_Read(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS) + 6);
 }
 
-static inline void WriteTandyACTL(Bit8u creg,Bit8u val) {
+static inline void WriteTandyACTL(uint8_t creg,uint8_t val) {
 	IO_Write(VGAREG_TDY_ADDRESS,creg);
 	if (machine==MCH_TANDY) IO_Write(VGAREG_TDY_DATA,val);
 	else IO_Write(VGAREG_PCJR_DATA,val);
@@ -59,7 +59,7 @@ void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val)
 				// which entry is used for the requested color.
 				if (reg > 3) break;
 				if (reg != 0) { // 0 is assumed to be at 0
-					Bit8u color_select=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
+					uint8_t color_select=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
 					reg = reg*2+8; // Green Red Brown
 					if (color_select& 0x20) reg++; // Cyan Magenta White
 				}
@@ -116,7 +116,7 @@ void INT10_SetAllPaletteRegisters(PhysPt data)
 	case TANDY_ARCH_CASE:
 		IO_Read(VGAREG_TDY_RESET);
 		// First the colors
-		for(Bit8u i=0;i<0x10;i++) {
+		for(uint8_t i=0;i<0x10;i++) {
 			WriteTandyACTL(i+0x10,mem_readb(data));
 			data++;
 		}
@@ -126,7 +126,7 @@ void INT10_SetAllPaletteRegisters(PhysPt data)
 	case EGAVGA_ARCH_CASE:
 		ResetACTL();
 		// First the colors
-		for(Bit8u i=0;i<0x10;i++) {
+		for(uint8_t i=0;i<0x10;i++) {
 			IO_Write(VGAREG_ACTL_ADDRESS,i);
 			IO_Write(VGAREG_ACTL_WRITE_DATA,mem_readb(data));
 			data++;
@@ -142,9 +142,9 @@ void INT10_SetAllPaletteRegisters(PhysPt data)
 	}
 }
 
-void INT10_ToggleBlinkingBit(Bit8u state) {
+void INT10_ToggleBlinkingBit(uint8_t state) {
 	if(IS_VGA_ARCH) {
-		Bit8u value;
+		uint8_t value;
 	//	state&=0x01;
 		if ((state>1) && (svgaCard==SVGA_S3Trio)) return;
 		ResetACTL();
@@ -162,7 +162,7 @@ void INT10_ToggleBlinkingBit(Bit8u state) {
 		IO_Write(VGAREG_ACTL_ADDRESS,32);		//Enable output and protect palette
 
 		if (state<=1) {
-			Bit8u msrval=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR)&0xdf;
+			uint8_t msrval=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR)&0xdf;
 			if (state) msrval|=0x20;
 			real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR,msrval);
 		}
@@ -170,7 +170,7 @@ void INT10_ToggleBlinkingBit(Bit8u state) {
 		// Usually it reads this from the mode list in ROM
 		if (CurMode->type!=M_TEXT) return;
 
-		Bit8u value = (CurMode->cwidth==9)? 0x4:0x0;
+		uint8_t value = (CurMode->cwidth==9)? 0x4:0x0;
 		if (state) value |= 0x8;
 		
 		ResetACTL();
@@ -178,13 +178,13 @@ void INT10_ToggleBlinkingBit(Bit8u state) {
 		IO_Write(VGAREG_ACTL_WRITE_DATA,value);
 		IO_Write(VGAREG_ACTL_ADDRESS,0x20);
 
-		Bit8u msrval=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR)& ~0x20;
+		uint8_t msrval=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR)& ~0x20;
 		if (state) msrval|=0x20;
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR,msrval);
 	}
 }
 
-void INT10_GetSinglePaletteRegister(Bit8u reg,Bit8u * val) {
+void INT10_GetSinglePaletteRegister(uint8_t reg,uint8_t * val) {
 	if(reg<=ACTL_MAX_REG) {
 		ResetACTL();
 		IO_Write(VGAREG_ACTL_ADDRESS,reg+32);
@@ -193,7 +193,7 @@ void INT10_GetSinglePaletteRegister(Bit8u reg,Bit8u * val) {
 	}
 }
 
-void INT10_GetOverscanBorderColor(Bit8u * val) {
+void INT10_GetOverscanBorderColor(uint8_t * val) {
 	ResetACTL();
 	IO_Write(VGAREG_ACTL_ADDRESS,0x11+32);
 	*val=IO_Read(VGAREG_ACTL_READ_DATA);
@@ -203,7 +203,7 @@ void INT10_GetOverscanBorderColor(Bit8u * val) {
 void INT10_GetAllPaletteRegisters(PhysPt data) {
 	ResetACTL();
 	// First the colors
-	for(Bit8u i=0;i<0x10;i++) {
+	for(uint8_t i=0;i<0x10;i++) {
 		IO_Write(VGAREG_ACTL_ADDRESS,i);
 		mem_writeb(data,IO_Read(VGAREG_ACTL_READ_DATA));
 		ResetACTL();
@@ -215,31 +215,31 @@ void INT10_GetAllPaletteRegisters(PhysPt data) {
 	ResetACTL();
 }
 
-void INT10_SetSingleDACRegister(Bit8u index,Bit8u red,Bit8u green,Bit8u blue) {
-	IO_Write(VGAREG_DAC_WRITE_ADDRESS,(Bit8u)index);
+void INT10_SetSingleDACRegister(uint8_t index,uint8_t red,uint8_t green,uint8_t blue) {
+	IO_Write(VGAREG_DAC_WRITE_ADDRESS,(uint8_t)index);
 	if ((real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL)&0x06)==0) {
 		IO_Write(VGAREG_DAC_DATA,red);
 		IO_Write(VGAREG_DAC_DATA,green);
 		IO_Write(VGAREG_DAC_DATA,blue);
 	} else {
 		/* calculate clamped intensity, taken from VGABIOS */
-		Bit32u i=(( 77*red + 151*green + 28*blue ) + 0x80) >> 8;
-		Bit8u ic=(i>0x3f) ? 0x3f : ((Bit8u)(i & 0xff));
+		uint32_t i=(( 77*red + 151*green + 28*blue ) + 0x80) >> 8;
+		uint8_t ic=(i>0x3f) ? 0x3f : ((uint8_t)(i & 0xff));
 		IO_Write(VGAREG_DAC_DATA,ic);
 		IO_Write(VGAREG_DAC_DATA,ic);
 		IO_Write(VGAREG_DAC_DATA,ic);
 	}
 }
 
-void INT10_GetSingleDACRegister(Bit8u index,Bit8u * red,Bit8u * green,Bit8u * blue) {
+void INT10_GetSingleDACRegister(uint8_t index,uint8_t * red,uint8_t * green,uint8_t * blue) {
 	IO_Write(VGAREG_DAC_READ_ADDRESS,index);
 	*red=IO_Read(VGAREG_DAC_DATA);
 	*green=IO_Read(VGAREG_DAC_DATA);
 	*blue=IO_Read(VGAREG_DAC_DATA);
 }
 
-void INT10_SetDACBlock(Bit16u index,Bit16u count,PhysPt data) {
- 	IO_Write(VGAREG_DAC_WRITE_ADDRESS,(Bit8u)index);
+void INT10_SetDACBlock(uint16_t index,uint16_t count,PhysPt data) {
+ 	IO_Write(VGAREG_DAC_WRITE_ADDRESS,(uint8_t)index);
 	if ((real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL)&0x06)==0) {
 		for (;count>0;count--) {
 			IO_Write(VGAREG_DAC_DATA,mem_readb(data++));
@@ -248,13 +248,13 @@ void INT10_SetDACBlock(Bit16u index,Bit16u count,PhysPt data) {
 		}
 	} else {
 		for (;count>0;count--) {
-			Bit8u red=mem_readb(data++);
-			Bit8u green=mem_readb(data++);
-			Bit8u blue=mem_readb(data++);
+			uint8_t red=mem_readb(data++);
+			uint8_t green=mem_readb(data++);
+			uint8_t blue=mem_readb(data++);
 
 			/* calculate clamped intensity, taken from VGABIOS */
-			Bit32u i=(( 77*red + 151*green + 28*blue ) + 0x80) >> 8;
-			Bit8u ic=(i>0x3f) ? 0x3f : ((Bit8u)(i & 0xff));
+			uint32_t i=(( 77*red + 151*green + 28*blue ) + 0x80) >> 8;
+			uint8_t ic=(i>0x3f) ? 0x3f : ((uint8_t)(i & 0xff));
 			IO_Write(VGAREG_DAC_DATA,ic);
 			IO_Write(VGAREG_DAC_DATA,ic);
 			IO_Write(VGAREG_DAC_DATA,ic);
@@ -262,8 +262,8 @@ void INT10_SetDACBlock(Bit16u index,Bit16u count,PhysPt data) {
 	}
 }
 
-void INT10_GetDACBlock(Bit16u index,Bit16u count,PhysPt data) {
- 	IO_Write(VGAREG_DAC_READ_ADDRESS,(Bit8u)index);
+void INT10_GetDACBlock(uint16_t index,uint16_t count,PhysPt data) {
+ 	IO_Write(VGAREG_DAC_READ_ADDRESS,(uint8_t)index);
 	for (;count>0;count--) {
 		mem_writeb(data++,IO_Read(VGAREG_DAC_DATA));
 		mem_writeb(data++,IO_Read(VGAREG_DAC_DATA));
@@ -271,10 +271,10 @@ void INT10_GetDACBlock(Bit16u index,Bit16u count,PhysPt data) {
 	}
 }
 
-void INT10_SelectDACPage(Bit8u function,Bit8u mode) {
+void INT10_SelectDACPage(uint8_t function,uint8_t mode) {
 	ResetACTL();
 	IO_Write(VGAREG_ACTL_ADDRESS,0x10);
-	Bit8u old10=IO_Read(VGAREG_ACTL_READ_DATA);
+	uint8_t old10=IO_Read(VGAREG_ACTL_READ_DATA);
 	if (!function) {		//Select paging mode
 		if (mode) old10|=0x80;
 		else old10&=0x7f;
@@ -290,10 +290,10 @@ void INT10_SelectDACPage(Bit8u function,Bit8u mode) {
 	IO_Write(VGAREG_ACTL_ADDRESS,32);		//Enable output and protect palette
 }
 
-void INT10_GetDACPage(Bit8u* mode,Bit8u* page) {
+void INT10_GetDACPage(uint8_t* mode,uint8_t* page) {
 	ResetACTL();
 	IO_Write(VGAREG_ACTL_ADDRESS,0x10);
-	Bit8u reg10=IO_Read(VGAREG_ACTL_READ_DATA);
+	uint8_t reg10=IO_Read(VGAREG_ACTL_READ_DATA);
 	IO_Write(VGAREG_ACTL_WRITE_DATA,reg10);
 	*mode=(reg10&0x80)?0x01:0x00;
 	IO_Write(VGAREG_ACTL_ADDRESS,0x14);
@@ -308,17 +308,17 @@ void INT10_GetDACPage(Bit8u* mode,Bit8u* page) {
 	IO_Write(VGAREG_ACTL_ADDRESS,32);		//Enable output and protect palette
 }
 
-void INT10_SetPelMask(Bit8u mask) {
+void INT10_SetPelMask(uint8_t mask) {
 	IO_Write(VGAREG_PEL_MASK,mask);
 }	
 
-void INT10_GetPelMask(Bit8u & mask) {
+void INT10_GetPelMask(uint8_t & mask) {
 	mask=IO_Read(VGAREG_PEL_MASK);
 }
 
 void INT10_SetBackgroundBorder(uint8_t val)
 {
-	Bit8u color_select=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
+	uint8_t color_select=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
 	color_select=(color_select & 0xe0) | (val & 0x1f);
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL,color_select);
 
@@ -381,8 +381,8 @@ void INT10_SetBackgroundBorder(uint8_t val)
 	}
 }
 
-void INT10_SetColorSelect(Bit8u val) {
-	Bit8u temp=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
+void INT10_SetColorSelect(uint8_t val) {
+	uint8_t temp=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL);
 	temp=(temp & 0xdf) | ((val & 1) ? 0x20 : 0x0);
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL,temp);
 	if (machine == MCH_CGA || machine==MCH_TANDY)
@@ -392,8 +392,8 @@ void INT10_SetColorSelect(Bit8u val) {
 		switch (CurMode->mode) {
 		case 4: // CGA 4-color mode
 		case 5: // Also CGA 4-color mode
-			for (Bit8u i = 0x11; i < 0x14; i++) {
-				const Bit8u t4_table[] = {0,2,4,6, 0,3,5,0xf};
+			for (uint8_t i = 0x11; i < 0x14; i++) {
+				const uint8_t t4_table[] = {0,2,4,6, 0,3,5,0xf};
 				IO_Write(VGAREG_TDY_ADDRESS, i);
 				IO_Write(VGAREG_PCJR_DATA, t4_table[(i-0x10)+(val&1? 4:0)]);
 			}
@@ -404,7 +404,7 @@ void INT10_SetColorSelect(Bit8u val) {
 			break;
 		default:
 			// 16-color modes: always write the same palette
-			for(Bit8u i = 0x11; i < 0x20; i++) {
+			for(uint8_t i = 0x11; i < 0x20; i++) {
 				IO_Write(VGAREG_TDY_ADDRESS, i);
 				IO_Write(VGAREG_PCJR_DATA, i-0x10);
 			}
@@ -424,17 +424,17 @@ void INT10_SetColorSelect(Bit8u val) {
 	}
 }
 
-void INT10_PerformGrayScaleSumming(Bit16u start_reg,Bit16u count) {
+void INT10_PerformGrayScaleSumming(uint16_t start_reg,uint16_t count) {
 	if (count>0x100) count=0x100;
 	for (Bitu ct=0; ct<count; ct++) {
 		IO_Write(VGAREG_DAC_READ_ADDRESS,start_reg+ct);
-		Bit8u red=IO_Read(VGAREG_DAC_DATA);
-		Bit8u green=IO_Read(VGAREG_DAC_DATA);
-		Bit8u blue=IO_Read(VGAREG_DAC_DATA);
+		uint8_t red=IO_Read(VGAREG_DAC_DATA);
+		uint8_t green=IO_Read(VGAREG_DAC_DATA);
+		uint8_t blue=IO_Read(VGAREG_DAC_DATA);
 
 		/* calculate clamped intensity, taken from VGABIOS */
-		Bit32u i=(( 77*red + 151*green + 28*blue ) + 0x80) >> 8;
-		Bit8u ic=(i>0x3f) ? 0x3f : ((Bit8u)(i & 0xff));
+		uint32_t i=(( 77*red + 151*green + 28*blue ) + 0x80) >> 8;
+		uint8_t ic=(i>0x3f) ? 0x3f : ((uint8_t)(i & 0xff));
 		INT10_SetSingleDACRegister(start_reg+ct,ic,ic,ic);
 	}
 }

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -21,10 +21,10 @@
 #include "mem.h"
 #include "inout.h"
 
-static Bit8u cga_masks[4]={0x3f,0xcf,0xf3,0xfc};
-static Bit8u cga_masks2[8]={0x7f,0xbf,0xdf,0xef,0xf7,0xfb,0xfd,0xfe};
+static uint8_t cga_masks[4]={0x3f,0xcf,0xf3,0xfc};
+static uint8_t cga_masks2[8]={0x7f,0xbf,0xdf,0xef,0xf7,0xfb,0xfd,0xfe};
 
-void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
+void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color) {
 	static bool putpixelwarned = false;
 
 	switch (CurMode->type) {
@@ -32,10 +32,10 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 	{
 		if (real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE)<=5) {
 			// this is a 16k mode
-			Bit16u off=(y>>1)*80+(x>>2);
+			uint16_t off=(y>>1)*80+(x>>2);
 			if (y&1) off+=8*1024;
 
-			Bit8u old=real_readb(0xb800,off);
+			uint8_t old=real_readb(0xb800,off);
 			if (color & 0x80) {
 				color&=3;
 				old^=color << (2*(3-(x&3)));
@@ -45,7 +45,7 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 			real_writeb(0xb800,off,old);
 		} else {
 			// a 32k mode: PCJr special case (see M_TANDY16)
-			Bit16u seg;
+			uint16_t seg;
 			if (machine==MCH_PCJR) {
 				Bitu cpupage =
 					(real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE) >> 3) & 0x7;
@@ -53,10 +53,10 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 			} else
 				seg = 0xb800;
 
-			Bit16u off=(y>>2)*160+((x>>2)&(~1));
+			uint16_t off=(y>>2)*160+((x>>2)&(~1));
 			off+=(8*1024) * (y & 3);
 
-			Bit16u old=real_readw(seg,off);
+			uint16_t old=real_readw(seg,off);
 			if (color & 0x80) {
 				old^=(color&1) << (7-(x&7));
 				old^=((color&2)>>1) << ((7-(x&7))+8);
@@ -69,9 +69,9 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 	break;
 	case M_CGA2:
 		{
-				Bit16u off=(y>>1)*80+(x>>3);
+				uint16_t off=(y>>1)*80+(x>>3);
 				if (y&1) off+=8*1024;
-				Bit8u old=real_readb(0xb800,off);
+				uint8_t old=real_readb(0xb800,off);
 				if (color & 0x80) {
 					color&=1;
 					old^=color << ((7-(x&7)));
@@ -89,7 +89,7 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 		bool is_32k = (real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_MODE) >= 9)?
 			true:false;
 
-		Bit16u segment, offset;
+		uint16_t segment, offset;
 		if (is_32k) {
 			if (machine==MCH_PCJR) {
 				Bitu cpupage =
@@ -110,8 +110,8 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 		}
 
 		// update the pixel
-		Bit8u old=real_readb(segment, offset);
-		Bit8u p[2];
+		uint8_t old=real_readb(segment, offset);
+		uint8_t p[2];
 		p[1] = (old >> 4) & 0xf;
 		p[0] = old & 0xf;
 		Bitu ind = 1-(x & 0x1);
@@ -139,7 +139,7 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 	case M_EGA: {
 		/* Set the correct bitmask for the pixel position */
 		IO_Write(0x3ce, 0x8);
-		Bit8u mask = 128 >> (x & 7);
+		uint8_t mask = 128 >> (x & 7);
 		IO_Write(0x3cf, mask);
 		/* Set the color to set/reset register */
 		IO_Write(0x3ce, 0x0);
@@ -203,28 +203,28 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color) {
 	}	
 }
 
-void INT10_GetPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u * color) {
+void INT10_GetPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t * color) {
 	switch (CurMode->type) {
 	case M_CGA4:
 		{
-			Bit16u off=(y>>1)*80+(x>>2);
+			uint16_t off=(y>>1)*80+(x>>2);
 			if (y&1) off+=8*1024;
-			Bit8u val=real_readb(0xb800,off);
+			uint8_t val=real_readb(0xb800,off);
 			*color=(val>>(((3-(x&3)))*2)) & 3 ;
 		}
 		break;
 	case M_CGA2:
 		{
-			Bit16u off=(y>>1)*80+(x>>3);
+			uint16_t off=(y>>1)*80+(x>>3);
 			if (y&1) off+=8*1024;
-			Bit8u val=real_readb(0xb800,off);
+			uint8_t val=real_readb(0xb800,off);
 			*color=(val>>(((7-(x&7))))) & 1 ;
 		}
 		break;
 	case M_TANDY16:
 		{
 			bool is_32k = (real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_MODE) >= 9)?true:false;
-			Bit16u segment, offset;
+			uint16_t segment, offset;
 			if (is_32k) {
 				if (machine==MCH_PCJR) {
 					Bitu cpupage = (real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE) >> 3) & 0x7;
@@ -237,7 +237,7 @@ void INT10_GetPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u * color) {
 				offset = (y >> 1) * (CurMode->swidth >> 1) + (x>>1);
 				offset += (8*1024) * (y & 1);
 			}
-			Bit8u val=real_readb(segment,offset);
+			uint8_t val=real_readb(segment,offset);
 			*color=(val>>((x&1)?0:4)) & 0xf;
 		}
 		break;

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -51,39 +51,39 @@ static char string_productrev[]="DOSBox " VERSION;
 #pragma pack (1)
 #endif
 struct MODE_INFO{
-	Bit16u ModeAttributes;
-	Bit8u WinAAttributes;
-	Bit8u WinBAttributes;
-	Bit16u WinGranularity;
-	Bit16u WinSize;
-	Bit16u WinASegment;
-	Bit16u WinBSegment;
-	Bit32u WinFuncPtr;
-	Bit16u BytesPerScanLine;
-	Bit16u XResolution;
-	Bit16u YResolution;
-	Bit8u XCharSize;
-	Bit8u YCharSize;
-	Bit8u NumberOfPlanes;
-	Bit8u BitsPerPixel;
-	Bit8u NumberOfBanks;
-	Bit8u MemoryModel;
-	Bit8u BankSize;
-	Bit8u NumberOfImagePages;
-	Bit8u Reserved_page;
-	Bit8u RedMaskSize;
-	Bit8u RedMaskPos;
-	Bit8u GreenMaskSize;
-	Bit8u GreenMaskPos;
-	Bit8u BlueMaskSize;
-	Bit8u BlueMaskPos;
-	Bit8u ReservedMaskSize;
-	Bit8u ReservedMaskPos;
-	Bit8u DirectColorModeInfo;
-	Bit32u PhysBasePtr;
-	Bit32u OffScreenMemOffset;
-	Bit16u OffScreenMemSize;
-	Bit8u Reserved[206];
+	uint16_t ModeAttributes;
+	uint8_t WinAAttributes;
+	uint8_t WinBAttributes;
+	uint16_t WinGranularity;
+	uint16_t WinSize;
+	uint16_t WinASegment;
+	uint16_t WinBSegment;
+	uint32_t WinFuncPtr;
+	uint16_t BytesPerScanLine;
+	uint16_t XResolution;
+	uint16_t YResolution;
+	uint8_t XCharSize;
+	uint8_t YCharSize;
+	uint8_t NumberOfPlanes;
+	uint8_t BitsPerPixel;
+	uint8_t NumberOfBanks;
+	uint8_t MemoryModel;
+	uint8_t BankSize;
+	uint8_t NumberOfImagePages;
+	uint8_t Reserved_page;
+	uint8_t RedMaskSize;
+	uint8_t RedMaskPos;
+	uint8_t GreenMaskSize;
+	uint8_t GreenMaskPos;
+	uint8_t BlueMaskSize;
+	uint8_t BlueMaskPos;
+	uint8_t ReservedMaskSize;
+	uint8_t ReservedMaskPos;
+	uint8_t DirectColorModeInfo;
+	uint32_t PhysBasePtr;
+	uint32_t OffScreenMemOffset;
+	uint16_t OffScreenMemSize;
+	uint8_t Reserved[206];
 } GCC_ATTRIBUTE(packed);
 #ifdef _MSC_VER
 #pragma pack()
@@ -91,11 +91,11 @@ struct MODE_INFO{
 
 
 
-Bit8u VESA_GetSVGAInformation(Bit16u seg,Bit16u off) {
+uint8_t VESA_GetSVGAInformation(uint16_t seg,uint16_t off) {
 	/* Fill 256 byte buffer with VESA information */
 	PhysPt buffer=PhysMake(seg,off);
 	Bitu i;
-	bool vbe2=false;Bit16u vbe2_pos=256+off;
+	bool vbe2=false;uint16_t vbe2_pos=256+off;
 	Bitu id=mem_readd(buffer);
 	if (((id==0x56424532)||(id==0x32454256)) && (!int10.vesa_oldvbe)) vbe2=true;
 	if (vbe2) {
@@ -122,7 +122,7 @@ Bit8u VESA_GetSVGAInformation(Bit16u seg,Bit16u off) {
 	}
 	mem_writed(buffer+0x0a,0x0);					//Capabilities and flags
 	mem_writed(buffer+0x0e,int10.rom.vesa_modes);	//VESA Mode list
-	mem_writew(buffer+0x12,(Bit16u)(vga.vmemsize/(64*1024))); // memory size in 64kb blocks
+	mem_writew(buffer+0x12,(uint16_t)(vga.vmemsize/(64*1024))); // memory size in 64kb blocks
 	return VESA_SUCCESS;
 }
 
@@ -147,12 +147,12 @@ static bool can_triple_buffer_8bit(const VideoModeBlock &m)
 	return vga.vmemsize >= needed_bytes;
 }
 
-Bit8u VESA_GetSVGAModeInformation(Bit16u mode,Bit16u seg,Bit16u off) {
+uint8_t VESA_GetSVGAModeInformation(uint16_t mode,uint16_t seg,uint16_t off) {
 	MODE_INFO minfo;
 	memset(&minfo,0,sizeof(minfo));
 	PhysPt buf=PhysMake(seg,off);
 	int pageSize = 0;
-	Bit8u modeAttributes;
+	uint8_t modeAttributes;
 
 	mode&=0x3fff;	// vbe2 compatible, ignore lfb and keep screen content bits
 	if (mode<0x100) return 0x01;
@@ -335,7 +335,7 @@ Bit8u VESA_GetSVGAModeInformation(Bit16u mode,Bit16u seg,Bit16u off) {
 	return VESA_SUCCESS;
 }
 
-Bit8u VESA_SetSVGAMode(Bit16u mode) {
+uint8_t VESA_SetSVGAMode(uint16_t mode) {
 	if (INT10_SetVideoMode(mode)) {
 		int10.vesa_setmode=mode&0x7fff;
 		return VESA_SUCCESS;
@@ -343,22 +343,22 @@ Bit8u VESA_SetSVGAMode(Bit16u mode) {
 	return VESA_FAIL;
 }
 
-Bit8u VESA_GetSVGAMode(Bit16u & mode) {
+uint8_t VESA_GetSVGAMode(uint16_t & mode) {
 	if (int10.vesa_setmode!=0xffff) mode=int10.vesa_setmode;
 	else mode=CurMode->mode;
 	return VESA_SUCCESS;
 }
 
-Bit8u VESA_SetCPUWindow(Bit8u window,Bit8u address) {
+uint8_t VESA_SetCPUWindow(uint8_t window,uint8_t address) {
 	if (window) return VESA_FAIL;
-	if ((Bit32u)(address)*64*1024 < vga.vmemsize) {
+	if ((uint32_t)(address)*64*1024 < vga.vmemsize) {
 		IO_Write(0x3d4,0x6a);
 		IO_Write(0x3d5, address);
 		return VESA_SUCCESS;
 	} else return VESA_FAIL;
 }
 
-Bit8u VESA_GetCPUWindow(Bit8u window,Bit16u & address) {
+uint8_t VESA_GetCPUWindow(uint8_t window,uint16_t & address) {
 	if (window) return VESA_FAIL;
 	IO_Write(0x3d4,0x6a);
 	address=IO_Read(0x3d5);
@@ -366,16 +366,16 @@ Bit8u VESA_GetCPUWindow(Bit8u window,Bit16u & address) {
 }
 
 
-Bit8u VESA_SetPalette(PhysPt data,Bitu index,Bitu count,bool wait) {
+uint8_t VESA_SetPalette(PhysPt data,Bitu index,Bitu count,bool wait) {
 //Structure is (vesa 3.0 doc): blue,green,red,alignment
-	Bit8u r,g,b;
+	uint8_t r,g,b;
 	if (index>255) return VESA_FAIL;
 	if (index+count>256) return VESA_FAIL;
 
 	// Wait for retrace if requested
 	if (wait) CALLBACK_RunRealFar(RealSeg(int10.rom.wait_retrace),RealOff(int10.rom.wait_retrace));
 
-	IO_Write(0x3c8,(Bit8u)index);
+	IO_Write(0x3c8,(uint8_t)index);
 	while (count) {
 		b = mem_readb(data++);
 		g = mem_readb(data++);
@@ -390,11 +390,11 @@ Bit8u VESA_SetPalette(PhysPt data,Bitu index,Bitu count,bool wait) {
 }
 
 
-Bit8u VESA_GetPalette(PhysPt data,Bitu index,Bitu count) {
-	Bit8u r,g,b;
+uint8_t VESA_GetPalette(PhysPt data,Bitu index,Bitu count) {
+	uint8_t r,g,b;
 	if (index>255) return VESA_FAIL;
 	if (index+count>256) return VESA_FAIL;
-	IO_Write(0x3c7,(Bit8u)index);
+	IO_Write(0x3c7,(uint8_t)index);
 	while (count) {
 		r = IO_Read(0x3c9);
 		g = IO_Read(0x3c9);
@@ -525,7 +525,7 @@ uint8_t VESA_ScanLineLength(uint8_t subcall,
 	return VESA_SUCCESS;
 }
 
-Bit8u VESA_SetDisplayStart(Bit16u x,Bit16u y,bool wait) {
+uint8_t VESA_SetDisplayStart(uint16_t x,uint16_t y,bool wait) {
 	uint8_t panning_factor = 1;
 	uint8_t bits_per_pixel = 0;
 	bool align_to_nearest_4th_pixel = false;
@@ -570,7 +570,7 @@ Bit8u VESA_SetDisplayStart(Bit16u x,Bit16u y,bool wait) {
 	return VESA_SUCCESS;
 }
 
-Bit8u VESA_GetDisplayStart(Bit16u & x,Bit16u & y) {
+uint8_t VESA_GetDisplayStart(uint16_t & x,uint16_t & y) {
 	Bitu pixels_per_offset;
 	Bitu panning_factor = 1;
 
@@ -597,7 +597,7 @@ Bit8u VESA_GetDisplayStart(Bit16u & x,Bit16u & y) {
 
 	IO_Read(0x3da);              // reset attribute flipflop
 	IO_Write(0x3c0,0x13 | 0x20); // panning register, screen on
-	Bit8u panning = IO_Read(0x3c1);
+	uint8_t panning = IO_Read(0x3c1);
 
 	Bitu virtual_screen_width = vga.config.scan_len * pixels_per_offset;
 	Bitu start_pixel = vga.config.display_start * (pixels_per_offset/2) 
@@ -610,7 +610,7 @@ Bit8u VESA_GetDisplayStart(Bit16u & x,Bit16u & y) {
 
 static Bitu VESA_SetWindow(void) {
 	if (reg_bh) reg_ah=VESA_GetCPUWindow(reg_bl,reg_dx);
-	else reg_ah=VESA_SetCPUWindow(reg_bl,(Bit8u)reg_dx);
+	else reg_ah=VESA_SetCPUWindow(reg_bl,(uint8_t)reg_dx);
 	reg_al=0x4f;
 	return CBRET_NONE;
 }
@@ -622,7 +622,7 @@ static Bitu VESA_PMSetWindow(void) {
 }
 static Bitu VESA_PMSetPalette(void) {
 	PhysPt data=SegPhys(es)+reg_edi;
-	Bit32u count=reg_cx;
+	uint32_t count=reg_cx;
 	IO_Write(0x3c8,reg_dl);
 	do {
 		IO_Write(0x3c9,mem_readb(data+2));
@@ -633,7 +633,7 @@ static Bitu VESA_PMSetPalette(void) {
 	return CBRET_NONE;
 }
 static Bitu VESA_PMSetStart(void) {
-	Bit32u start = (reg_dx << 16) | reg_cx;
+	uint32_t start = (reg_dx << 16) | reg_cx;
 	vga.config.display_start = start;
 	return CBRET_NONE;
 }
@@ -670,10 +670,10 @@ void INT10_SetupVESA(void) {
 	}
 	/* Prepare the real mode interface */
 	int10.rom.wait_retrace=RealMake(0xc000,int10.rom.used);
-	int10.rom.used += (Bit16u)CALLBACK_Setup(0, NULL, CB_VESA_WAIT, PhysMake(0xc000,int10.rom.used), "");
+	int10.rom.used += (uint16_t)CALLBACK_Setup(0, NULL, CB_VESA_WAIT, PhysMake(0xc000,int10.rom.used), "");
 	callback.rmWindow=CALLBACK_Allocate();
 	int10.rom.set_window=RealMake(0xc000,int10.rom.used);
-	int10.rom.used += (Bit16u)CALLBACK_Setup(callback.rmWindow, VESA_SetWindow, CB_RETF, PhysMake(0xc000,int10.rom.used), "VESA Real Set Window");
+	int10.rom.used += (uint16_t)CALLBACK_Setup(callback.rmWindow, VESA_SetWindow, CB_RETF, PhysMake(0xc000,int10.rom.used), "VESA Real Set Window");
 	/* Prepare the pmode interface */
 	int10.rom.pmode_interface=RealMake(0xc000,int10.rom.used);
 	int10.rom.used += 8;		//Skip the byte later used for offsets
@@ -681,12 +681,12 @@ void INT10_SetupVESA(void) {
 	int10.rom.pmode_interface_window = int10.rom.used - RealOff( int10.rom.pmode_interface );
 	phys_writew( Real2Phys(int10.rom.pmode_interface) + 0, int10.rom.pmode_interface_window );
 	callback.pmWindow=CALLBACK_Allocate();
-	int10.rom.used += (Bit16u)CALLBACK_Setup(callback.pmWindow, VESA_PMSetWindow, CB_RETN, PhysMake(0xc000,int10.rom.used), "VESA PM Set Window");
+	int10.rom.used += (uint16_t)CALLBACK_Setup(callback.pmWindow, VESA_PMSetWindow, CB_RETN, PhysMake(0xc000,int10.rom.used), "VESA PM Set Window");
 	/* PM Set start call */
 	int10.rom.pmode_interface_start = int10.rom.used - RealOff( int10.rom.pmode_interface );
 	phys_writew( Real2Phys(int10.rom.pmode_interface) + 2, int10.rom.pmode_interface_start);
 	callback.pmStart=CALLBACK_Allocate();
-	int10.rom.used += (Bit16u)CALLBACK_Setup(callback.pmStart,
+	int10.rom.used += (uint16_t)CALLBACK_Setup(callback.pmStart,
 	                                         VESA_PMSetStart, CB_VESA_PM,
 	                                         PhysMake(0xc000, int10.rom.used),
 	                                         "VESA PM Set Start");
@@ -694,8 +694,8 @@ void INT10_SetupVESA(void) {
 	int10.rom.pmode_interface_palette = int10.rom.used - RealOff( int10.rom.pmode_interface );
 	phys_writew( Real2Phys(int10.rom.pmode_interface) + 4, int10.rom.pmode_interface_palette);
 	callback.pmPalette=CALLBACK_Allocate();
-	int10.rom.used += (Bit16u)CALLBACK_Setup(0, NULL, CB_VESA_PM, PhysMake(0xc000,int10.rom.used), "");
-	int10.rom.used += (Bit16u)CALLBACK_Setup(callback.pmPalette, VESA_PMSetPalette, CB_RETN, PhysMake(0xc000,int10.rom.used), "VESA PM Set Palette");
+	int10.rom.used += (uint16_t)CALLBACK_Setup(0, NULL, CB_VESA_PM, PhysMake(0xc000,int10.rom.used), "");
+	int10.rom.used += (uint16_t)CALLBACK_Setup(callback.pmPalette, VESA_PMSetPalette, CB_RETN, PhysMake(0xc000,int10.rom.used), "VESA PM Set Palette");
 	/* Finalize the size and clear the required ports pointer */
 	phys_writew( Real2Phys(int10.rom.pmode_interface) + 6, 0);
 	int10.rom.pmode_interface_size=int10.rom.used - RealOff( int10.rom.pmode_interface );

--- a/src/ints/int10_video_state.cpp
+++ b/src/ints/int10_video_state.cpp
@@ -46,7 +46,7 @@ bool INT10_VideoState_Save(Bitu state,RealPt buffer) {
 	if (state&1)  {
 		real_writew(base_seg,RealOff(buffer),base_dest);
 
-		Bit16u crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 		real_writew(base_seg,base_dest+0x40,crt_reg);
 
 		real_writeb(base_seg,base_dest+0x00,IO_ReadB(0x3c4));
@@ -85,15 +85,15 @@ bool INT10_VideoState_Save(Bitu state,RealPt buffer) {
 
 		// save some registers
 		IO_WriteB(0x3c4,2);
-		Bit8u crtc_2=IO_ReadB(0x3c5);
+		uint8_t crtc_2=IO_ReadB(0x3c5);
 		IO_WriteB(0x3c4,4);
-		Bit8u crtc_4=IO_ReadB(0x3c5);
+		uint8_t crtc_4=IO_ReadB(0x3c5);
 		IO_WriteB(0x3ce,6);
-		Bit8u gfx_6=IO_ReadB(0x3cf);
+		uint8_t gfx_6=IO_ReadB(0x3cf);
 		IO_WriteB(0x3ce,5);
-		Bit8u gfx_5=IO_ReadB(0x3cf);
+		uint8_t gfx_5=IO_ReadB(0x3cf);
 		IO_WriteB(0x3ce,4);
-		Bit8u gfx_4=IO_ReadB(0x3cf);
+		uint8_t gfx_4=IO_ReadB(0x3cf);
 
 		// reprogram for full access to plane latches
 		IO_WriteW(0x3c4,0x0f02);
@@ -146,7 +146,7 @@ bool INT10_VideoState_Save(Bitu state,RealPt buffer) {
 	if (state&4)  {
 		real_writew(base_seg,RealOff(buffer)+4,base_dest);
 
-		Bit16u crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 
 		IO_ReadB(crt_reg+6);
 		IO_WriteB(0x3c0,0x14);
@@ -175,7 +175,7 @@ bool INT10_VideoState_Save(Bitu state,RealPt buffer) {
 	if ((svgaCard==SVGA_S3Trio) && (state&8))  {
 		real_writew(base_seg,RealOff(buffer)+6,base_dest);
 
-		Bit16u crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 
 		IO_WriteB(0x3c4,0x08);
 //		Bitu seq_8=IO_ReadB(0x3c5);
@@ -216,12 +216,12 @@ bool INT10_VideoState_Restore(Bitu state,RealPt buffer) {
 	Bitu ct;
 	if ((state&7)==0) return false;
 
-	Bit16u base_seg=RealSeg(buffer);
-	Bit16u base_dest;
+	uint16_t base_seg=RealSeg(buffer);
+	uint16_t base_dest;
 
 	if (state&1)  {
 		base_dest=real_readw(base_seg,RealOff(buffer));
-		Bit16u crt_reg=real_readw(base_seg,base_dest+0x40);
+		uint16_t crt_reg=real_readw(base_seg,base_dest+0x40);
 
 		// reprogram for full access to plane latches
 		IO_WriteW(0x3c4,0x0704);
@@ -303,7 +303,7 @@ bool INT10_VideoState_Restore(Bitu state,RealPt buffer) {
 	if (state&4)  {
 		base_dest=real_readw(base_seg,RealOff(buffer)+4);
 
-		Bit16u crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 
 		IO_WriteB(0x3c6,real_readb(base_seg,base_dest+0x002));
 
@@ -329,7 +329,7 @@ bool INT10_VideoState_Restore(Bitu state,RealPt buffer) {
 	if ((svgaCard==SVGA_S3Trio) && (state&8))  {
 		base_dest=real_readw(base_seg,RealOff(buffer)+6);
 
-		Bit16u crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 
 		Bitu seq_idx=IO_ReadB(0x3c4);
 		IO_WriteB(0x3c4,0x08);

--- a/src/ints/int10_vptable.cpp
+++ b/src/ints/int10_vptable.cpp
@@ -21,7 +21,7 @@
 #include "mem.h"
 #include "inout.h"
 
-const Bit8u vparams[] = {
+const uint8_t vparams[] = {
 	// 40x25 mode 0 and 1 crtc registers
 	0x38, 0x28, 0x2d, 0x0a, 0x1f, 0x06, 0x19, 0x1c, 0x02, 0x07, 0x06, 0x07, 0,0,0,0,
 	// 80x25 mode 2 and 3 crtc registers
@@ -38,7 +38,7 @@ const Bit8u vparams[] = {
 	0x2c, 0x28, 0x2d, 0x29, 0x2a, 0x2e, 0x1e, 0x29
 };
 
-const Bit8u vparams_pcjr[] = {
+const uint8_t vparams_pcjr[] = {
 	// 40x25 mode 0 and 1 crtc registers
 	0x38, 0x28, 0x2c, 0x06, 0x1f, 0x06, 0x19, 0x1c, 0x02, 0x07, 0x06, 0x07, 0,0,0,0,
 	// 80x25 mode 2 and 3 crtc registers
@@ -55,7 +55,7 @@ const Bit8u vparams_pcjr[] = {
 	0x2c, 0x28, 0x2d, 0x29, 0x2a, 0x2e, 0x1e, 0x29
 };
 
-const Bit8u vparams_tandy[] = {
+const uint8_t vparams_tandy[] = {
 	// 40x25 mode 0 and 1 crtc registers
 	0x38, 0x28, 0x2c, 0x08, 0x1f, 0x06, 0x19, 0x1c, 0x02, 0x07, 0x06, 0x07, 0,0,0,0,
 	// 80x25 mode 2 and 3 crtc registers
@@ -73,7 +73,7 @@ const Bit8u vparams_tandy[] = {
 };
 
 #if 0
-const Bit8u vparams_tandy_td[] = {
+const uint8_t vparams_tandy_td[] = {
 	// 40x25 mode 0 and 1 crtc registers
 	0x38, 0x28, 0x2d, 0x0a, 0x1f, 0x06, 0x19, 0x1c, 0x02, 0x07, 0x06, 0x07, 0,0,0,0,
 	// 80x25 mode 2 and 3 crtc registers
@@ -93,7 +93,7 @@ const Bit8u vparams_tandy_td[] = {
 };
 #endif
 
-static Bit8u video_parameter_table_vga[0x40*0x1d]={
+static uint8_t video_parameter_table_vga[0x40*0x1d]={
 // video parameter table for mode 0 (cga emulation)
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -325,7 +325,7 @@ static Bit8u video_parameter_table_vga[0x40*0x1d]={
   0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x05, 0x0f, 0xff  // graphics registers 0-8
 };
 
-static Bit8u video_parameter_table_ega[0x40*0x17]={
+static uint8_t video_parameter_table_ega[0x40*0x17]={
 // video parameter table for mode 0 (cga emulation)
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -516,7 +516,7 @@ static Bit8u video_parameter_table_ega[0x40*0x17]={
 };
 
 
-Bit16u INT10_SetupVideoParameterTable(PhysPt basepos) {
+uint16_t INT10_SetupVideoParameterTable(PhysPt basepos) {
 	if (IS_VGA_ARCH) {
 		for (Bitu i=0;i<0x40*0x1d;i++) {
 			phys_writeb(basepos+i,video_parameter_table_vga[i]);
@@ -535,17 +535,17 @@ void INT10_SetupBasicVideoParameterTable(void) {
 	RealSetVec(0x1d,RealMake(0xF000, 0xF0A4));
 	switch (machine) {
 	case MCH_TANDY:
-		for (Bit16u i = 0; i < sizeof(vparams_tandy); i++) {
+		for (uint16_t i = 0; i < sizeof(vparams_tandy); i++) {
 			phys_writeb(0xFF0A4+i,vparams_tandy[i]);
 		}
 		break;
 	case MCH_PCJR:
-		for (Bit16u i = 0; i < sizeof(vparams_pcjr); i++) {
+		for (uint16_t i = 0; i < sizeof(vparams_pcjr); i++) {
 			phys_writeb(0xFF0A4+i,vparams_pcjr[i]);
 		}
 		break;
 	default:
-		for (Bit16u i = 0; i < sizeof(vparams); i++) {
+		for (uint16_t i = 0; i < sizeof(vparams); i++) {
 			phys_writeb(0xFF0A4+i,vparams[i]);
 		}
 		break;
@@ -582,7 +582,7 @@ void INT10_GenerateVideoParameterTable(void) {
 			LOG_MSG("  0x%02x, 0x%02x, 0x%02x, 0x%02x, // sequencer registers",seq_regs[0],seq_regs[1],seq_regs[2],seq_regs[3]);
 			LOG_MSG("  0x%02x, // misc output registers",IO_ReadB(0x3cc));
 			Bitu crtc_regs[0x19];
-			Bit16u crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+			uint16_t crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 			for (ct=0; ct<0x19; ct++) {
 				IO_WriteB(crt_addr,ct);
 				crtc_regs[ct]=IO_ReadB(crt_addr+1);
@@ -640,7 +640,7 @@ void INT10_GenerateVideoParameterTable(void) {
 		LOG_MSG("  0x%02x, 0x%02x, 0x%02x, 0x%02x, // sequencer registers",seq_regs[0],seq_regs[1],seq_regs[2],seq_regs[3]);
 		LOG_MSG("  0x%02x, // misc output registers",IO_ReadB(0x3cc));
 		Bitu crtc_regs[0x19];
-		Bit16u crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+		uint16_t crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 		for (ct=0; ct<0x19; ct++) {
 			IO_WriteB(crt_addr,ct);
 			crtc_regs[ct]=IO_ReadB(crt_addr+1);
@@ -697,7 +697,7 @@ void INT10_GenerateVideoParameterTable(void) {
 			LOG_MSG("  0x%02x, 0x%02x, 0x%02x, 0x%02x, // sequencer registers",seq_regs[0],seq_regs[1],seq_regs[2],seq_regs[3]);
 			LOG_MSG("  0x%02x, // misc output registers",IO_ReadB(0x3cc));
 			Bitu crtc_regs[0x19];
-			Bit16u crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+			uint16_t crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 			for (ct=0; ct<0x19; ct++) {
 				IO_WriteB(crt_addr,ct);
 				crtc_regs[ct]=IO_ReadB(crt_addr+1);
@@ -752,7 +752,7 @@ void INT10_GenerateVideoParameterTable(void) {
 			LOG_MSG("  0x%02x, 0x%02x, 0x%02x, 0x%02x, // sequencer registers",seq_regs[0],seq_regs[1],seq_regs[2],seq_regs[3]);
 			LOG_MSG("  0x%02x, // misc output registers",IO_ReadB(0x3cc));
 			Bitu crtc_regs[0x19];
-			Bit16u crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+			uint16_t crt_addr=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 			for (ct=0; ct<0x19; ct++) {
 				IO_WriteB(crt_addr,ct);
 				crtc_regs[ct]=IO_ReadB(crt_addr+1);

--- a/src/ints/xms.h
+++ b/src/ints/xms.h
@@ -19,13 +19,13 @@
 #ifndef __XMS_H__
 #define __XMS_H__
 
-Bitu	XMS_QueryFreeMemory		(Bit16u& largestFree, Bit16u& totalFree);
-Bitu	XMS_AllocateMemory		(Bitu size, Bit16u& handle);
+Bitu	XMS_QueryFreeMemory		(uint16_t& largestFree, uint16_t& totalFree);
+Bitu	XMS_AllocateMemory		(Bitu size, uint16_t& handle);
 Bitu	XMS_FreeMemory			(Bitu handle);
 Bitu	XMS_MoveMemory			(PhysPt bpt);
-Bitu	XMS_LockMemory			(Bitu handle, Bit32u& address);
+Bitu	XMS_LockMemory			(Bitu handle, uint32_t& address);
 Bitu	XMS_UnlockMemory		(Bitu handle);
-Bitu	XMS_GetHandleInformation(Bitu handle, Bit8u& lockCount, Bit8u& numFree, Bit16u& size);
+Bitu	XMS_GetHandleInformation(Bitu handle, uint8_t& lockCount, uint8_t& numFree, uint16_t& size);
 Bitu	XMS_ResizeMemory		(Bitu handle, Bitu newSize);
 
 Bitu	XMS_EnableA20			(bool enable);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -58,7 +58,7 @@ constexpr auto ANALOG_MODE = MT32Emu::AnalogOutputMode_ACCURATE;
 // DAC Emulation modes: NICE, PURE, GENERATION1, and GENERATION2
 constexpr auto DAC_MODE = MT32Emu::DACInputMode_NICE;
 
-// Analog rendering types: BIT16S, FLOAT
+// Analog rendering types: int16_t, FLOAT
 constexpr auto RENDERING_TYPE = MT32Emu::RendererType_FLOAT;
 
 // Sample rate conversion quality: FASTEST, FAST, GOOD, BEST

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -85,8 +85,8 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Main *main)
 
 static Bitu PROGRAMS_Handler(void) {
 	/* This sets up everything for a program start up call */
-	Bitu size=sizeof(Bit8u);
-	Bit8u index;
+	Bitu size=sizeof(uint8_t);
+	uint8_t index;
 
 	// Sanity check the exec_block size before down-casting
 	constexpr auto exec_block_size = exe_block.size();
@@ -179,10 +179,10 @@ void Program::WriteOut(const char *format, ...)
 	vsnprintf(buf,2047,format,msg);
 	va_end(msg);
 
-	Bit16u size = (Bit16u)strlen(buf);
+	uint16_t size = (uint16_t)strlen(buf);
 	dos.internal_output=true;
-	for (Bit16u i = 0; i < size; i++) {
-		Bit8u out;Bit16u s=1;
+	for (uint16_t i = 0; i < size; i++) {
+		uint8_t out;uint16_t s=1;
 		if (buf[i] == 0xA && last_written_character != 0xD) {
 			out = 0xD;DOS_WriteFile(STDOUT,&out,&s);
 		}
@@ -191,7 +191,7 @@ void Program::WriteOut(const char *format, ...)
 	}
 	dos.internal_output=false;
 
-//	DOS_WriteFile(STDOUT,(Bit8u *)buf,&size);
+//	DOS_WriteFile(STDOUT,(uint8_t *)buf,&size);
 }
 
 void Program::WriteOut(const char *format, const char *arguments)
@@ -202,10 +202,10 @@ void Program::WriteOut(const char *format, const char *arguments)
 	char buf[2048];
 	sprintf(buf,format,arguments);
 
-	Bit16u size = (Bit16u)strlen(buf);
+	uint16_t size = (uint16_t)strlen(buf);
 	dos.internal_output=true;
-	for (Bit16u i = 0; i < size; i++) {
-		Bit8u out;Bit16u s=1;
+	for (uint16_t i = 0; i < size; i++) {
+		uint8_t out;uint16_t s=1;
 		if (buf[i] == 0xA && last_written_character != 0xD) {
 			out = 0xD;DOS_WriteFile(STDOUT,&out,&s);
 		}
@@ -219,11 +219,11 @@ void Program::WriteOut_NoParsing(const char * format) {
 	if (SuppressWriteOut(format))
 		return;
 
-	Bit16u size = (Bit16u)strlen(format);
+	uint16_t size = (uint16_t)strlen(format);
 	char const* buf = format;
 	dos.internal_output=true;
-	for (Bit16u i = 0; i < size; i++) {
-		Bit8u out;Bit16u s=1;
+	for (uint16_t i = 0; i < size; i++) {
+		uint8_t out;uint16_t s=1;
 		if (buf[i] == 0xA && last_written_character != 0xD) {
 			out = 0xD;DOS_WriteFile(STDOUT,&out,&s);
 		}
@@ -232,7 +232,7 @@ void Program::WriteOut_NoParsing(const char * format) {
 	}
 	dos.internal_output=false;
 
-//	DOS_WriteFile(STDOUT,(Bit8u *)format,&size);
+//	DOS_WriteFile(STDOUT,(uint8_t *)format,&size);
 }
 
 void Program::ResetLastWrittenChar(char c)
@@ -310,7 +310,7 @@ bool Program::SetEnv(const char * entry,const char * new_string) {
 	
 	//Get size of environment.
 	DOS_MCB mcb(psp->GetEnvironment() - 1);
-	Bit16u envsize = mcb.GetSize()*16;
+	uint16_t envsize = mcb.GetSize()*16;
 
 
 	PhysPt env_write = env_read;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1367,7 +1367,7 @@ CommandLine::CommandLine(int argc, char const *const argv[])
 	}
 }
 
-Bit16u CommandLine::Get_arglength()
+uint16_t CommandLine::Get_arglength()
 {
 	if (cmds.empty())
 		return 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -124,7 +124,7 @@ void AutoexecObject::CreateAutoexec()
 		}
 		sprintf((autoexec_data + auto_len),"%s\r\n",linecopy.c_str());
 	}
-	if (first_shell) VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data));
+	if (first_shell) VFILE_Register("AUTOEXEC.BAT",(uint8_t *)autoexec_data,(uint32_t)strlen(autoexec_data));
 }
 
 AutoexecObject::~AutoexecObject(){
@@ -730,7 +730,7 @@ public:
 		// for (const auto &autoexec_line : autoexec)
 		// 	LOG_INFO("AUTOEXEC-LINE: %s", autoexec_line.GetLine().c_str());
 
-		VFILE_Register("AUTOEXEC.BAT",(Bit8u *)autoexec_data,(Bit32u)strlen(autoexec_data));
+		VFILE_Register("AUTOEXEC.BAT",(uint8_t *)autoexec_data,(uint32_t)strlen(autoexec_data));
 	}
 };
 
@@ -783,7 +783,7 @@ static Bitu INT2E_Handler()
 {
 	/* Save return address and current process */
 	RealPt save_ret=real_readd(SegValue(ss),reg_sp);
-	Bit16u save_psp=dos.psp();
+	uint16_t save_psp=dos.psp();
 
 	/* Set first shell as process and copy command */
 	dos.psp(DOS_FIRST_SHELL);
@@ -1455,19 +1455,19 @@ void SHELL_Init() {
 	PROGRAMS_MakeFile("COMMAND.COM",SHELL_ProgramStart);
 
 	/* Now call up the shell for the first time */
-	Bit16u psp_seg=DOS_FIRST_SHELL;
-	Bit16u env_seg=DOS_FIRST_SHELL+19; //DOS_GetMemory(1+(4096/16))+1;
-	Bit16u stack_seg=DOS_GetMemory(2048/16);
+	uint16_t psp_seg=DOS_FIRST_SHELL;
+	uint16_t env_seg=DOS_FIRST_SHELL+19; //DOS_GetMemory(1+(4096/16))+1;
+	uint16_t stack_seg=DOS_GetMemory(2048/16);
 	SegSet16(ss,stack_seg);
 	reg_sp=2046;
 
 	/* Set up int 24 and psp (Telarium games) */
 	real_writeb(psp_seg+16+1,0,0xea);		/* far jmp */
 	real_writed(psp_seg+16+1,1,real_readd(0,0x24*4));
-	real_writed(0,0x24*4,((Bit32u)psp_seg<<16) | ((16+1)<<4));
+	real_writed(0,0x24*4,((uint32_t)psp_seg<<16) | ((16+1)<<4));
 
 	/* Set up int 23 to "int 20" in the psp. Fixes what.exe */
-	real_writed(0,0x23*4,((Bit32u)psp_seg<<16));
+	real_writed(0,0x23*4,((uint32_t)psp_seg<<16));
 
 	/* Set up int 2e handler */
 	Bitu call_int2e=CALLBACK_Allocate();
@@ -1476,11 +1476,11 @@ void SHELL_Init() {
 	RealSetVec(0x2e,addr_int2e);
 
 	/* Setup MCBs */
-	DOS_MCB pspmcb((Bit16u)(psp_seg-1));
+	DOS_MCB pspmcb((uint16_t)(psp_seg-1));
 	pspmcb.SetPSPSeg(psp_seg);	// MCB of the command shell psp
 	pspmcb.SetSize(0x10+2);
 	pspmcb.SetType(0x4d);
-	DOS_MCB envmcb((Bit16u)(env_seg-1));
+	DOS_MCB envmcb((uint16_t)(env_seg-1));
 	envmcb.SetPSPSeg(psp_seg);	// MCB of the command shell environment
 	envmcb.SetSize(DOS_MEM_START-env_seg);
 	envmcb.SetType(0x4d);
@@ -1504,7 +1504,7 @@ void SHELL_Init() {
 	 * 01 01 01 00 02
 	 * In order to achieve this: First open 2 files. Close the first and
 	 * duplicate the second (so the entries get 01) */
-	Bit16u dummy=0;
+	uint16_t dummy=0;
 	DOS_OpenFile("CON",OPEN_READWRITE,&dummy);	/* STDIN  */
 	DOS_OpenFile("CON",OPEN_READWRITE,&dummy);	/* STDOUT */
 	DOS_CloseFile(0);							/* Close STDIN */
@@ -1514,8 +1514,8 @@ void SHELL_Init() {
 	DOS_OpenFile("PRN",OPEN_READWRITE,&dummy);	/* STDPRN */
 
 	/* Create appearance of handle inheritance by first shell */
-	for (Bit16u i=0;i<5;i++) {
-		Bit8u handle=psp.GetFileHandle(i);
+	for (uint16_t i=0;i<5;i++) {
+		uint8_t handle=psp.GetFileHandle(i);
 		if (Files[handle]) Files[handle]->AddRef();
 	}
 
@@ -1524,7 +1524,7 @@ void SHELL_Init() {
 	psp.SetEnvironment(env_seg);
 	/* Set the command line for the shell start up */
 	CommandTail tail;
-	tail.count=(Bit8u)strlen(init_line);
+	tail.count=(uint8_t)strlen(init_line);
 	memset(&tail.buffer,0,127);
 	safe_strcpy(tail.buffer, init_line);
 	MEM_BlockWrite(PhysMake(psp_seg,128),&tail,128);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -237,7 +237,7 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	}
 	//end can't be 0, but if it is we'll get a nice crash, who cares :)
 	char * end=strrchr(full,'\\')+1;*end=0;
-	char name[DOS_NAMELENGTH_ASCII];Bit32u size;Bit16u time,date;Bit8u attr;
+	char name[DOS_NAMELENGTH_ASCII];uint32_t size;uint16_t time,date;uint8_t attr;
 	DOS_DTA dta(dos.dta());
 	while (res) {
 		dta.GetResult(name,size,date,time,attr);
@@ -379,13 +379,13 @@ void DOS_Shell::CMD_EXIT(char *args)
 void DOS_Shell::CMD_CHDIR(char * args) {
 	HELP("CHDIR");
 	StripSpaces(args);
-	Bit8u drive = DOS_GetDefaultDrive()+'A';
+	uint8_t drive = DOS_GetDefaultDrive()+'A';
 	char dir[DOS_PATHLENGTH];
 	if (!*args) {
 		DOS_GetCurrentDir(0,dir);
 		WriteOut("%c:\\%s\n",drive,dir);
 	} else if (strlen(args) == 2 && args[1] == ':') {
-		Bit8u targetdrive = (args[0] | 0x20) - 'a' + 1;
+		uint8_t targetdrive = (args[0] | 0x20) - 'a' + 1;
 		unsigned char targetdisplay = *reinterpret_cast<unsigned char*>(&args[0]);
 		if (!DOS_GetCurrentDir(targetdrive,dir)) {
 			if (drive == 'Z') {
@@ -499,10 +499,10 @@ static std::string format_number(size_t num)
 
 struct DtaResult {
 	char name[DOS_NAMELENGTH_ASCII];
-	Bit32u size;
-	Bit16u date;
-	Bit16u time;
-	Bit8u attr;
+	uint32_t size;
+	uint16_t date;
+	uint16_t time;
+	uint8_t attr;
 
 	static bool compareName(const DtaResult &lhs, const DtaResult &rhs) { return strcmp(lhs.name, rhs.name) < 0; }
 	static bool compareExt(const DtaResult &lhs, const DtaResult &rhs) { return strcmp(lhs.getExtension(), rhs.getExtension()) < 0; }
@@ -1053,7 +1053,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 	RealPt save_dta=dos.dta();
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
-	Bit32u size;Bit16u date;Bit16u time;Bit8u attr;
+	uint32_t size;uint16_t date;uint16_t time;uint8_t attr;
 	char name[DOS_NAMELENGTH_ASCII];
 	std::vector<copysource> sources;
 	// ignore /b and /t switches: always copy binary
@@ -1125,7 +1125,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 
 	copysource oldsource;
 	copysource source;
-	Bit32u count = 0;
+	uint32_t count = 0;
 	while (sources.size()) {
 		/* Get next source item and keep track of old source for concat start end */
 		oldsource = source;
@@ -1182,7 +1182,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 			return;
 		}
 
-		Bit16u sourceHandle,targetHandle;
+		uint16_t sourceHandle,targetHandle;
 		char nameTarget[DOS_PATHLENGTH];
 		char nameSource[DOS_PATHLENGTH];
 
@@ -1208,12 +1208,12 @@ void DOS_Shell::CMD_COPY(char * args) {
 					if (special) oldsource.concat = true;
 					//Don't create a new file when in concat mode
 					if (oldsource.concat || DOS_CreateFile(nameTarget,0,&targetHandle)) {
-						Bit32u dummy=0;
+						uint32_t dummy=0;
 						//In concat mode. Open the target and seek to the eof
 						if (!oldsource.concat || (DOS_OpenFile(nameTarget,OPEN_READWRITE,&targetHandle) &&
 					        	                  DOS_SeekFile(targetHandle,&dummy,DOS_SEEK_END))) {
 							// Copy
-							static Bit8u buffer[0x8000]; // static, otherwise stack overflow possible.
+							static uint8_t buffer[0x8000]; // static, otherwise stack overflow possible.
 							uint16_t toread = 0x8000;
 							do {
 								DOS_ReadFile(sourceHandle, buffer, &toread);
@@ -1522,7 +1522,7 @@ void DOS_Shell::CMD_IF(char * args) {
 			return;
 		}
 
-		Bit8u n = 0;
+		uint8_t n = 0;
 		do n = n * 10 + (*word - '0');
 		while (isdigit(*++word));
 		if (*word && !isspace(*word)) {
@@ -1620,7 +1620,7 @@ void DOS_Shell::CMD_TYPE(char * args) {
 		WriteOut(MSG_Get("SHELL_SYNTAXERROR"));
 		return;
 	}
-	Bit16u handle;
+	uint16_t handle;
 	char * word;
 nextfile:
 	word=StripWord(args);
@@ -1628,7 +1628,7 @@ nextfile:
 		WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),word);
 		return;
 	}
-	Bit16u n;Bit8u c;
+	uint16_t n;uint8_t c;
 	do {
 		n=1;
 		DOS_ReadFile(handle,&c,&n);
@@ -1743,12 +1743,12 @@ void DOS_Shell::CMD_DATE(char *args)
 	CALLBACK_RunRealInt(0x21);
 
 	const char *datestring = MSG_Get("SHELL_CMD_DATE_DAYS");
-	Bit32u length;
+	uint32_t length;
 	char day[6] = {0};
 	if (sscanf(datestring, "%u", &length) && (length < 5) &&
 	    (strlen(datestring) == (length * 7 + 1))) {
 		// date string appears valid
-		for (Bit32u i = 0; i < length; i++)
+		for (uint32_t i = 0; i < length; i++)
 			day[i] = datestring[reg_al * length + 1 + i];
 	}
 	bool dateonly = ScanCMDBool(args, "T");
@@ -1861,7 +1861,7 @@ void DOS_Shell::CMD_SUBST (char * args) {
 		strcat(mountstring, temp_str);
 		strcat(mountstring, " ");
 
-   		Bit8u drive;char fulldir[DOS_PATHLENGTH];
+   		uint8_t drive;char fulldir[DOS_PATHLENGTH];
 		if (!DOS_MakeName(const_cast<char*>(arg.c_str()),fulldir,&drive)) throw 0;
 
 		if ( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
@@ -1893,14 +1893,14 @@ void DOS_Shell::CMD_SUBST (char * args) {
 
 void DOS_Shell::CMD_LOADHIGH(char *args){
 	HELP("LOADHIGH");
-	Bit16u umb_start=dos_infoblock.GetStartOfUMBChain();
-	Bit8u umb_flag=dos_infoblock.GetUMBChainState();
-	Bit8u old_memstrat=(Bit8u)(DOS_GetMemAllocStrategy()&0xff);
+	uint16_t umb_start=dos_infoblock.GetStartOfUMBChain();
+	uint8_t umb_flag=dos_infoblock.GetUMBChainState();
+	uint8_t old_memstrat=(uint8_t)(DOS_GetMemAllocStrategy()&0xff);
 	if (umb_start == 0x9fff) {
 		if ((umb_flag&1) == 0) DOS_LinkUMBsToMemChain(1);
 		DOS_SetMemAllocStrategy(0x80);	// search in UMBs first
 		this->ParseLine(args);
-		Bit8u current_umb_flag=dos_infoblock.GetUMBChainState();
+		uint8_t current_umb_flag=dos_infoblock.GetUMBChainState();
 		if ((current_umb_flag&1)!=(umb_flag&1)) DOS_LinkUMBsToMemChain(umb_flag);
 		DOS_SetMemAllocStrategy(old_memstrat);	// restore strategy
 	} else this->ParseLine(args);
@@ -1938,7 +1938,7 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	}
 	if (!rem || !*rem) rem = defchoice; /* No choices specified use YN */
 	ptr = rem;
-	Bit8u c;
+	uint8_t c;
 	if (!optS) while ((c = *ptr)) *ptr++ = (char)toupper(c); /* When in no case-sensitive mode. make everything upcase */
 	if (args && *args ) {
 		StripSpaces(args);
@@ -1960,16 +1960,16 @@ void DOS_Shell::CMD_CHOICE(char * args){
 		WriteOut("%c]?",rem[len-1]);
 	}
 
-	Bit16u n=1;
+	uint16_t n=1;
 	do {
 		DOS_ReadFile(STDIN, &c, &n);
 		if (shutdown_requested)
 			break;
 	} while (!c || !(ptr = strchr(rem, (optS ? c : toupper(c)))));
-	c = optS ? c : (Bit8u)toupper(c);
+	c = optS ? c : (uint8_t)toupper(c);
 	DOS_WriteFile(STDOUT, &c, &n);
 	WriteOut_NoParsing("\n");
-	dos.return_code = (Bit8u)(ptr-rem+1);
+	dos.return_code = (uint8_t)(ptr-rem+1);
 }
 
 void DOS_Shell::CMD_PATH(char *args){

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -36,7 +36,7 @@ DOS_Shell::~DOS_Shell() {
 }
 
 void DOS_Shell::ShowPrompt(void) {
-	Bit8u drive=DOS_GetDefaultDrive()+'A';
+	uint8_t drive=DOS_GetDefaultDrive()+'A';
 	char dir[DOS_PATHLENGTH];
 	reset_str(dir); // DOS_GetCurrentDir doesn't always return
 	                // something. (if drive is messed up)
@@ -46,8 +46,8 @@ void DOS_Shell::ShowPrompt(void) {
 	ResetLastWrittenChar('\n'); // prevents excessive newline if cmd prints nothing
 }
 
-static void outc(Bit8u c) {
-	Bit16u n=1;
+static void outc(uint8_t c) {
+	uint16_t n=1;
 	DOS_WriteFile(STDOUT,&c,&n);
 }
 
@@ -63,10 +63,10 @@ static void move_cursor_back_one() {
 
 void DOS_Shell::InputCommand(char * line) {
 	Bitu size=CMD_MAXLINE-2; //lastcharacter+0
-	Bit8u c;Bit16u n=1;
+	uint8_t c;uint16_t n=1;
 	size_t str_len = 0;
 	size_t str_index = 0;
-	Bit16u len=0;
+	uint16_t len=0;
 	bool current_hist=false; // current command stored in history?
 
 	reset_str(line);
@@ -76,7 +76,7 @@ void DOS_Shell::InputCommand(char * line) {
 	while (size && !shutdown_requested) {
 		dos.echo=false;
 		while(!DOS_ReadFile(input_handle,&c,&n)) {
-			Bit16u dummy;
+			uint16_t dummy;
 			DOS_CloseFile(input_handle);
 			DOS_OpenFile("con",2,&dummy);
 			LOG(LOG_MISC,LOG_ERROR)("Reopening the input handle. This is a bug!");
@@ -148,10 +148,10 @@ void DOS_Shell::InputCommand(char * line) {
 						move_cursor_back_one();
 					}
 					strcpy(line, it_history->c_str());
-					len = (Bit16u)it_history->length();
+					len = (uint16_t)it_history->length();
 					str_len = str_index = len;
 					size = CMD_MAXLINE - str_index - 2;
-					DOS_WriteFile(STDOUT, (Bit8u *)line, &len);
+					DOS_WriteFile(STDOUT, (uint8_t *)line, &len);
 					++it_history;
 					break;
 
@@ -181,10 +181,10 @@ void DOS_Shell::InputCommand(char * line) {
 						move_cursor_back_one();
 					}
 					strcpy(line, it_history->c_str());
-					len = (Bit16u)it_history->length();
+					len = (uint16_t)it_history->length();
 					str_len = str_index = len;
 					size = CMD_MAXLINE - str_index - 2;
-					DOS_WriteFile(STDOUT, (Bit8u *)line, &len);
+					DOS_WriteFile(STDOUT, (uint8_t *)line, &len);
 					++it_history;
 
 					break;
@@ -192,7 +192,7 @@ void DOS_Shell::InputCommand(char * line) {
 					{
 						if(str_index>=str_len) break;
 						auto text_len = static_cast<uint16_t>(str_len - str_index - 1);
-						Bit8u* text=reinterpret_cast<Bit8u*>(&line[str_index+1]);
+						uint8_t* text=reinterpret_cast<uint8_t*>(&line[str_index+1]);
 						DOS_WriteFile(STDOUT, text, &text_len); // write buffer to screen
 						outc(' ');
 						move_cursor_back_one();
@@ -220,10 +220,10 @@ void DOS_Shell::InputCommand(char * line) {
 							}
 
 							strcpy(&line[completion_index], it_completion->c_str());
-							len = (Bit16u)it_completion->length();
+							len = (uint16_t)it_completion->length();
 							str_len = str_index = completion_index + len;
 							size = CMD_MAXLINE - str_index - 2;
-							DOS_WriteFile(STDOUT, (Bit8u *)it_completion->c_str(), &len);
+							DOS_WriteFile(STDOUT, (uint8_t *)it_completion->c_str(), &len);
 						}
 					}
 				default: break;
@@ -279,15 +279,15 @@ void DOS_Shell::InputCommand(char * line) {
 
 					if (p_completion_start) {
 						p_completion_start ++;
-						completion_index = (Bit16u)(str_len - strlen(p_completion_start));
+						completion_index = (uint16_t)(str_len - strlen(p_completion_start));
 					} else {
 						p_completion_start = line;
 						completion_index = 0;
 					}
 
 					char *path;
-					if ((path = strrchr(line+completion_index,'\\'))) completion_index = (Bit16u)(path-line+1);
-					if ((path = strrchr(line+completion_index,'/'))) completion_index = (Bit16u)(path-line+1);
+					if ((path = strrchr(line+completion_index,'\\'))) completion_index = (uint16_t)(path-line+1);
+					if ((path = strrchr(line+completion_index,'/'))) completion_index = (uint16_t)(path-line+1);
 
 					// build the completion list
 					char mask[DOS_PATHLENGTH] = {0};
@@ -319,7 +319,7 @@ void DOS_Shell::InputCommand(char * line) {
 					}
 
 					DOS_DTA dta(dos.dta());
-					char name[DOS_NAMELENGTH_ASCII];Bit32u sz;Bit16u date;Bit16u time;Bit8u att;
+					char name[DOS_NAMELENGTH_ASCII];uint32_t sz;uint16_t date;uint16_t time;uint8_t att;
 
 					std::list<std::string> executable;
 					while (res) {
@@ -355,10 +355,10 @@ void DOS_Shell::InputCommand(char * line) {
 					}
 
 					strcpy(&line[completion_index], it_completion->c_str());
-					len = (Bit16u)it_completion->length();
+					len = (uint16_t)it_completion->length();
 					str_len = str_index = completion_index + len;
 					size = CMD_MAXLINE - str_index - 2;
-					DOS_WriteFile(STDOUT, (Bit8u *)it_completion->c_str(), &len);
+					DOS_WriteFile(STDOUT, (uint8_t *)it_completion->c_str(), &len);
 				}
 			}
 			break;
@@ -381,7 +381,7 @@ void DOS_Shell::InputCommand(char * line) {
 			if(str_index < str_len && true) { //mem_readb(BIOS_KEYBOARD_FLAGS1)&0x80) dev_con.h ?
 				outc(' ');//move cursor one to the right.
 				auto text_len = static_cast<uint16_t>(str_len - str_index);
-				Bit8u* text=reinterpret_cast<Bit8u*>(&line[str_index]);
+				uint8_t* text=reinterpret_cast<uint8_t*>(&line[str_index]);
 				DOS_WriteFile(STDOUT, text, &text_len); // write buffer to screen
 				move_cursor_back_one(); //undo the cursor the right.
 				for (auto i = str_len; i > str_index; i--) {
@@ -602,8 +602,8 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		terminate_str_at(parseline, 257);
 
 		/* Parse FCB (first two parameters) and put them into the current DOS_PSP */
-		Bit8u add;
-		Bit16u skip = 0;
+		uint8_t add;
+		uint16_t skip = 0;
 		//find first argument, we end up at parseline[256] if there is only one argument (similar for the second), which exists and is 0.
 		while(skip < 256 && parseline[skip] == 0) skip++;
 		FCB_Parsename(dos.psp(),0x5C,0x01,parseline + skip,&add);
@@ -621,8 +621,8 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		block.SaveData();
 #if 0
 		/* Save CS:IP to some point where i can return them from */
-		Bit32u oldeip=reg_eip;
-		Bit16u oldcs=SegValue(cs);
+		uint32_t oldeip=reg_eip;
+		uint16_t oldcs=SegValue(cs);
 		RealPt newcsip=CALLBACK_RealPointer(call_shellstop);
 		SegSet16(cs,RealSeg(newcsip));
 		reg_ip=RealOff(newcsip);

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -79,7 +79,7 @@ void assert_DOS_MakeName(char const *const input,
                          std::string exp_fullname = "",
                          int exp_drive = 0)
 {
-	Bit8u drive_result;
+	uint8_t drive_result;
 	char fullname_result[DOS_PATHLENGTH];
 	bool result = DOS_MakeName(input, fullname_result, &drive_result);
 	EXPECT_EQ(result, exp_result);
@@ -111,7 +111,7 @@ TEST_F(DOS_FilesTest, DOS_MakeName_Z_AUTOEXEC_BAT_exists)
 // ramifications across the codebase if not replicated
 TEST_F(DOS_FilesTest, DOS_MakeName_Drive_Index_Set_On_Failure)
 {
-	Bit8u drive_result;
+	uint8_t drive_result;
 	char fullname_result[DOS_PATHLENGTH];
 	bool result;
 	result = DOS_MakeName("A:\r\n", fullname_result, &drive_result);


### PR DESCRIPTION
This does mass replace of int types including Bit8u, Bit16u, Bit32u, Bit64u, Bit8s, Bit16s, Bit32s, and Bit64s to cstdint types uin8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, and int64_t respectively, since the former types are now deprecated.