### PR TITLE
Fix new coverity warnings flagged in the recently synced audio codecs

### DIFF
--- a/src/libs/decoders/stb_vorbis.h
+++ b/src/libs/decoders/stb_vorbis.h
@@ -5157,7 +5157,9 @@ unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
       set_file_offset(f, last_page_loc);
 
       // parse the header
-      getn(f, (unsigned char *)header, 6);
+      if (!getn(f, (unsigned char *)header, 6))
+          return error(f, VORBIS_unexpected_eof);
+
       // extract the absolute granule position
       lo = get32(f);
       hi = get32(f);

--- a/src/libs/residfp/FilterModelConfig.h
+++ b/src/libs/residfp/FilterModelConfig.h
@@ -62,14 +62,14 @@ protected:
 
     /// Lookup tables for gain and summer op-amps in output stage / filter.
     //@{
-    unsigned short* mixer[8];       //-V730_NOINIT this is initialized in the derived class constructor
-    unsigned short* summer[5];      //-V730_NOINIT this is initialized in the derived class constructor
-    unsigned short* gain_vol[16];   //-V730_NOINIT this is initialized in the derived class constructor
-    unsigned short* gain_res[16];   //-V730_NOINIT this is initialized in the derived class constructor
+    unsigned short* mixer[8] = {};
+    unsigned short* summer[5] = {};
+    unsigned short* gain_vol[16] = {};
+    unsigned short* gain_res[16] = {};
     //@}
 
     /// Reverse op-amp transfer function.
-    unsigned short opamp_rev[1 << 16]; //-V730_NOINIT this is initialized in the derived class constructor
+    unsigned short opamp_rev[1 << 16] = {};
 
 private:
     FilterModelConfig (const FilterModelConfig&) = delete;


### PR DESCRIPTION
``` text
New defect(s) Reported-by: Coverity Scan
Showing 2 of 2 defect(s)


** CID 351289:  Error handling issues  (CHECKED_RETURN)
/src/libs/decoders/stb_vorbis.h: 5160 in stb_vorbis_stream_length_in_samples()


________________________________________________________________________________________________________
*** CID 351289:  Error handling issues  (CHECKED_RETURN)
/src/libs/decoders/stb_vorbis.h: 5160 in stb_vorbis_stream_length_in_samples()
5154              last_page_loc = stb_vorbis_get_file_offset(f);
5155           }
5156     
5157           set_file_offset(f, last_page_loc);
5158     
5159           // parse the header
>>>     CID 351289:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "getn" without checking return value (as is done elsewhere 5 out of 6 times).
5160           getn(f, (unsigned char *)header, 6);
5161           // extract the absolute granule position
5162           lo = get32(f);
5163           hi = get32(f);
5164           if (lo == 0xffffffff && hi == 0xffffffff) {
5165              f->error = VORBIS_cant_find_last_page;

** CID 351288:  Uninitialized members  (UNINIT_CTOR)
/src/libs/residfp/FilterModelConfig.cpp: 77 in reSIDfp::FilterModelConfig::FilterModelConfig(double, double, double, double, double, double, const reSIDfp::Spline::Point *, int)()


________________________________________________________________________________________________________
*** CID 351288:  Uninitialized members  (UNINIT_CTOR)
/src/libs/residfp/FilterModelConfig.cpp: 77 in reSIDfp::FilterModelConfig::FilterModelConfig(double, double, double, double, double, double, const reSIDfp::Spline::Point *, int)()
71             const Spline::Point out = s.evaluate(x);
72             // If Vmax > max opamp_voltage the first elements may be negative
73             double tmp = out.x > 0. ? out.x : 0.;
74             assert(tmp < 65535.5);
75             opamp_rev[x] = static_cast<unsigned short>(tmp + 0.5);
76         }
>>>     CID 351288:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "gain_res" is not initialized in this constructor nor in any functions that it calls.
77     }
78     

```