### PR TITLE
Use visual studio to setup the local `resources` tree

### DIFF
--- a/docs/README.resources
+++ b/docs/README.resources
@@ -1,0 +1,61 @@
+Starting with version 0.79, DOSBox Staging needs access to 
+bundled resource files.
+
+Meson will construct the deliverable "resources/" directory 
+along-side the compiled executable. This layout can be shipped 
+as-is. The executable will check the following paths for the 
+resources, in the following priority order:
+
+1. Beside the executable:
+    ./dosbox (executable)
+    ./resources/subdirs/...
+    (on macOS: ../Resources/subdirs/...)
+
+   This first instance should also be the prefered packaging
+   layout for wrapped formats like FlatPak, Snap, etc.
+
+2. Up one directory from the executable (which allows unit tests 
+   to access resources):
+    ./dosbox
+    ./../resources/subdirs/...
+    (on macOS: ../../Resources/subdirs/...)
+
+3. In the absolute path:
+    '/usr/local/share/dosbox-staging/subdirs/...'
+
+4. In the absolute path:
+   '/usr/share/dosbox-staging/subdirs/...'
+
+5. If your OS has a different prefered "application content" 
+   holding area, please open a ticket.
+
+6. In the user's configuration path:
+   'home/<user>/.config/dosbox/subdirs/...'
+   (or the Windows configuration path)
+
+FAQ:
+Q: Why can't these be embedded inside the executable?
+
+A1: Source files aren't filesystems, as such storing binaries as 
+    massive hex strings is a form of obfuscation that makes it 
+    harder to understand what they contain. With files, anyone 
+    can diff or create an md5 checksum. With files, anyone can 
+    notify the project when a file has become outdated.
+
+A2: Turning binary files into source involves placing tens of 
+    thousands of lines of hex address strings into your code 
+    base.
+
+    These get parsed and become a persistent carrying "load" for 
+    editors and development IDEs.  They also become a source of
+    false-positive hits when grepping text files.
+
+Q: How are the resources/ deployed into the build area by Meson?
+A: Read ./contrib/resources/meson.build This meson file copies
+   the deployable resource files into the build area.
+
+Q: How are the resources/ deployed into the build area by Visual
+   Studio?
+A: Search the vcxproj files for "contrib\resources". These
+   snippets perform the copying.
+

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -465,9 +465,14 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
 	float dx = xrel * mouse.pixelPerMickey_x;
 	float dy = yrel * mouse.pixelPerMickey_y;
 
+	LOG_MSG("Mouse moved rel (%f, %f), abs(%f, %f), delta=(%f, %f)",xrel,yrel,x,y, dx, dy);
+
 	if((fabs(xrel) > 1.0) || (mouse.senv_x < 1.0)) dx *= mouse.senv_x;
 	if((fabs(yrel) > 1.0) || (mouse.senv_y < 1.0)) dy *= mouse.senv_y;
 	if (useps2callback) dy *= 2;	
+
+	// log dx and dy
+	LOG_MSG("Mouse moved  delta=(%f, %f)", dx, dy);
 
 	mouse.mickey_x += (dx * mouse.mickeysPerPixel_x);
 	mouse.mickey_y += (dy * mouse.mickeysPerPixel_y);

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -118,11 +118,11 @@
       <AdditionalDependencies>gmock_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>cd $(SolutionDir)
-cd ..
-$(TargetPath)
-</Command>
-      <Message>Run tests</Message>
+        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+cd $(SolutionDir)  &amp;&amp; ^
+cd ..  &amp;&amp; ^
+$(TargetPath)</Command>
+        <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -152,11 +152,11 @@ $(TargetPath)
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>cd $(SolutionDir)
-cd ..
-$(TargetPath)
-</Command>
-      <Message>Run tests</Message>
+        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+cd $(SolutionDir)  &amp;&amp; ^
+cd ..  &amp;&amp; ^
+$(TargetPath)</Command>
+        <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -179,11 +179,11 @@ $(TargetPath)
       <AdditionalDependencies>gmock_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>cd $(SolutionDir)
-cd ..
-$(TargetPath)
-</Command>
-      <Message>Run tests</Message>
+        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+cd $(SolutionDir)  &amp;&amp; ^
+cd ..  &amp;&amp; ^
+$(TargetPath)</Command>
+        <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -213,11 +213,11 @@ $(TargetPath)
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>cd $(SolutionDir)
-cd ..
-$(TargetPath)
-</Command>
-      <Message>Run tests</Message>
+        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+cd $(SolutionDir)  &amp;&amp; ^
+cd ..  &amp;&amp; ^
+$(TargetPath)</Command>
+        <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -133,6 +133,10 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
+    <PostBuildEvent>
+        <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+        <Message>Copy resources to output directory</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -170,6 +174,10 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
+    <PostBuildEvent>
+        <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+        <Message>Copy resources to output directory</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -219,6 +227,10 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
+    <PostBuildEvent>
+        <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+        <Message>Copy resources to output directory</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -269,6 +281,10 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
+    <PostBuildEvent>
+        <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+        <Message>Copy resources to output directory</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\dosbox.cpp" />


### PR DESCRIPTION
This makes the visual studio solution comparable to the meson when it comes to seting the `resources` tree in the build area.  

Thanks to @NicknineTheEagle for reporting this. 