### PR TITLE
Provide window resolution as requested and fix related sizing bugs

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -476,7 +476,7 @@ struct SDL_Block {
 	PPScale pp_scale = {};
 	SDL_Rect updateRects[1024];
 	bool use_exact_window_resolution = false;
-	bool use_max_resolution = false;
+	bool use_viewport_limits = false;
 	SDL_Point max_resolution = {-1, -1};
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
@@ -1507,7 +1507,7 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 	const int img_height = sdl.pp_scale.output_h;
 
 	int win_width, win_height;
-	if (sdl.use_exact_window_resolution && sdl.use_max_resolution) {
+	if (sdl.use_exact_window_resolution && sdl.use_viewport_limits) {
 		win_width = w;
 		win_height = h;
 	} else {
@@ -1529,7 +1529,7 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 static SDL_Point restrict_to_max_resolution(int width, int height)
 {
 	int w, h;
-	if (sdl.use_max_resolution) {
+	if (sdl.use_viewport_limits) {
 		w = std::min(width, sdl.max_resolution.x);
 		h = std::min(height, sdl.max_resolution.y);
 	} else {
@@ -3036,12 +3036,12 @@ static SDL_Point clamp_to_minimum_window_dimensions(SDL_Point size)
 //  - The 'max_resolution' config value: 'auto', 'WxH', or an invalid setting.
 //
 // Except for SURFACE and TEXTURE rendering, the function populates the following struct members:
-//  - 'sdl.desktop.use_max_resolution', true if the max_resolution feature is enabled.
+//  - 'sdl.desktop.use_viewport_limits', true if the max_resolution feature is enabled.
 //  - 'sdl.desktop.max_resolution', with the refined size.
 
 static void setup_max_resolution_from_conf(const std::string &max_resolution_val)
 {
-	sdl.use_max_resolution = false;
+	sdl.use_viewport_limits = false;
 	sdl.max_resolution = {-1, -1};
 
 	// TODO: Deprecate SURFACE output and remove this.
@@ -3081,7 +3081,7 @@ static void setup_max_resolution_from_conf(const std::string &max_resolution_val
 		                                  wants_stretched_pixels());
 	}
 
-	sdl.use_max_resolution = true;
+	sdl.use_viewport_limits = true;
 	sdl.max_resolution = refined_size;
 
 	LOG_MSG("DISPLAY: max_resolution set to %dx%d (refined from %dx%d)",
@@ -3183,7 +3183,7 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 
 	// Refine the coarse resolution and save it in the SDL struct.
 	auto refined_size = coarse_size;
-	if (sdl.use_exact_window_resolution && sdl.use_max_resolution) {
+	if (sdl.use_exact_window_resolution && sdl.use_viewport_limits) {
 		// If max_resolution is enabled, the refinement is applied to
 		// max_resolution instead of the the window dimensions.
 		refined_size = clamp_to_minimum_window_dimensions(coarse_size);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3777,6 +3777,11 @@ static void HandleVideoResize(int width, int height)
 	if (sdl.desktop.window.resizable && sdl.desktop.type == SCREEN_OPENGL) {
 		sdl.clip = calc_viewport(width, height);
 		glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
+
+		if (!sdl.desktop.fullscreen) {
+			sdl.desktop.window.width = width;
+			sdl.desktop.window.height = height;
+		}
 		return;
 	}
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1435,12 +1435,6 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 	// Maybe some requested fullscreen resolution is unsupported?
 finish:
 
-	if (sdl.desktop.window.resizable && !sdl.desktop.switching_fullscreen) {
-		const int w = iround(sdl.draw.width * sdl.draw.scalex);
-		const int h = iround(sdl.draw.height * sdl.draw.scaley);
-		SDL_SetWindowMinimumSize(sdl.window, w, h);
-	}
-
 	if (sdl.draw.has_changed) {
 		setup_presentation_mode(sdl.frame.mode);
 		log_display_properties(sdl.draw.width, sdl.draw.height,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2983,7 +2983,7 @@ static void maybe_limit_requested_resolution(int &w, int &h, const char *size_de
 		         size_description, w, h, desktop.w, desktop.h);
 }
 
-static SDL_Point window_bounds_from_resolution(const std::string &pref)
+static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
 {
 	int w = 0;
 	int h = 0;
@@ -3170,7 +3170,7 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 
 	sdl.use_exact_window_resolution = pref.find('x') != std::string::npos;
 	if (sdl.use_exact_window_resolution) {
-		coarse_size = window_bounds_from_resolution(pref);
+		coarse_size = parse_window_resolution_from_conf(pref);
 		refined_scaling_mode = drop_nearest();
 	} else {
 		coarse_size = window_bounds_from_label(pref, desktop);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -475,7 +475,7 @@ struct SDL_Block {
 	} mouse = {};
 	PPScale pp_scale = {};
 	SDL_Rect updateRects[1024];
-	bool window_resolution_specified = false;
+	bool use_exact_window_resolution = false;
 	bool use_max_resolution = false;
 	SDL_Point max_resolution = {-1, -1};
 #if defined (WIN32)
@@ -1507,7 +1507,7 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 	const int img_height = sdl.pp_scale.output_h;
 
 	int win_width, win_height;
-	if (sdl.window_resolution_specified && sdl.use_max_resolution) {
+	if (sdl.use_exact_window_resolution && sdl.use_max_resolution) {
 		win_width = w;
 		win_height = h;
 	} else {
@@ -3168,8 +3168,8 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 	const std::string pref = windowresolution_val;
 	SDL_Point coarse_size = FALLBACK_WINDOW_DIMENSIONS;
 
-	sdl.window_resolution_specified = pref.find('x') != std::string::npos;
-	if (sdl.window_resolution_specified) {
+	sdl.use_exact_window_resolution = pref.find('x') != std::string::npos;
+	if (sdl.use_exact_window_resolution) {
 		coarse_size = window_bounds_from_resolution(pref);
 		refined_scaling_mode = drop_nearest();
 	} else {
@@ -3183,7 +3183,7 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 
 	// Refine the coarse resolution and save it in the SDL struct.
 	auto refined_size = coarse_size;
-	if (sdl.window_resolution_specified && sdl.use_max_resolution) {
+	if (sdl.use_exact_window_resolution && sdl.use_max_resolution) {
 		// If max_resolution is enabled, the refinement is applied to
 		// max_resolution instead of the the window dimensions.
 		refined_size = clamp_to_minimum_window_dimensions(coarse_size);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3181,9 +3181,7 @@ static void setup_window_sizes_from_conf(const char *windowresolution_val,
 
 	// Refine the coarse resolution and save it in the SDL struct.
 	auto refined_size = coarse_size;
-	if (sdl.use_exact_window_resolution && sdl.use_viewport_limits) {
-		// If viewport_resolution is enabled, the refinement is applied to
-		// viewport_resolution instead of the the window dimensions.
+	if (sdl.use_exact_window_resolution) {
 		refined_size = clamp_to_minimum_window_dimensions(coarse_size);
 	} else {
 		refined_size = refine_window_size(coarse_size, refined_scaling_mode,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1525,18 +1525,12 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 	return sdl.window;
 }
 
-
-static SDL_Point restrict_to_viewport_resolution(int width, int height)
+static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
 {
-	int w, h;
-	if (sdl.use_viewport_limits) {
-		w = std::min(width, sdl.viewport_resolution.x);
-		h = std::min(height, sdl.viewport_resolution.y);
-	} else {
-		w = width;
-		h = height;
-	}
-	return {w, h};
+	return sdl.use_viewport_limits
+	               ? SDL_Point{std::min(sdl.viewport_resolution.x, w),
+	                           std::min(sdl.viewport_resolution.y, h)}
+	               : SDL_Point{w, h};
 }
 
 static SDL_Rect calc_viewport_fit(int win_width, int win_height);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4158,7 +4158,7 @@ void Config_Add_SDL() {
 	Section_prop* psection;
 
 	constexpr auto always = Property::Changeable::Always;
-	// constexpr auto deprecated = Property::Changeable::Deprecated;
+	constexpr auto deprecated = Property::Changeable::Deprecated;
 	constexpr auto on_start = Property::Changeable::OnlyAtStart;
 
 	Pbool = sdl_sec->Add_bool("fullscreen", always, false);
@@ -4184,6 +4184,13 @@ void Config_Add_SDL() {
 	        "             WxH format. For example: 1024x768.\n"
 	        "             Scaling is not performed for output=surface.");
 
+	pstring = sdl_sec->Add_path("viewport_resolution", always, "fit");
+	pstring->Set_help(
+	        "Set the viewport size (drawable area) within the window/screen:\n"
+	        "  fit:       Fit the viewport to the available window/screen (default).\n"
+	        "  <custom>:  Limit the viewport within to a custom resolution or percentage of\n"
+	        "             the desktop. Specified in WxH, N%, N.M%. Examples: 960x720 or 50%");
+
 	pstring = sdl_sec->Add_string("window_position", always, "auto");
 	pstring->Set_help(
 	        "Set initial window position when running in windowed mode:\n"
@@ -4198,12 +4205,8 @@ void Config_Add_SDL() {
 	Pint->Set_help("Set the transparency of the DOSBox Staging screen.\n"
 	               "From 0 (no transparency) to 90 (high transparency).");
 
-	pstring = sdl_sec->Add_path("viewport_resolution", always, "auto");
-	pstring->Set_help(
-	        "Optionally restricts the viewport resolution within the window/screen:\n"
-	        "  auto:      The viewport fills the window/screen (default).\n"
-	        "  <custom>:  Set max viewport resolution in WxH format.\n"
-	        "             For example: 960x720");
+	pstring = sdl_sec->Add_path("max_resolution", deprecated, "");
+	pstring->Set_help("This setting has been renamed to viewport_resolution.");
 
 	pstring = sdl_sec->Add_string("host_rate", on_start, "auto");
 	pstring->Set_help(


### PR DESCRIPTION
### Exact `windowresolution`s will now be provided as requested

For example, the setting `windowresolution = 1200x500` now produces:

![2022-04-03_14-10](https://user-images.githubusercontent.com/1557255/161448832-9ad8c0f3-e54b-4253-9c3a-8b98deffd37b.png)

Previously the excess black bars were dropped and the window was snapped to the content, so users need to be aware that if they set a window size with an aspect ratio that differs from the current DOS draw aspect ratio, some black borders will be present.

Thanks @GranMinigun for flagging this!

###  `max_resolution` has been renamed to `viewport_resolution`.

Previously the viewport could be limited by setting the `max_resolution`. To more closely align with what it does, this has been renamed to `viewport_resolution`, which controls the size of the viewport within the overall window size (or desktop size).

![2022-04-03_14-04](https://user-images.githubusercontent.com/1557255/161448721-c108a11b-cab0-4aa4-81f3-bbd9b5605955.png)

`viewport_resolution` can be given a dimension or a percentage (of the total display size). 
For example, setting `viewport_resolution = 50%` on a 4k system gives a viewport resolution of 1920x1080:

![2022-04-03_14-06](https://user-images.githubusercontent.com/1557255/161448706-bd80e96c-865b-45ea-9247-b2f0b3400636.png)

### A bug in the drawn content size has been fixed when limiting the viewport

Previously a bug existed that allowed the drawn area to exceed the viewport resolution when the window aspect ratio was less than the DOS aspect ratio.

The [viewport is properly constrained](https://github.com/dosbox-staging/dosbox-staging/commit/40f6798f890811c441019c1897b9a356287dee5f) based on both the window and viewport sizes:

 - ![2022-04-03_14-01](https://user-images.githubusercontent.com/1557255/161449744-10d0acbb-4700-4558-a865-7b65fea4ce23.png)
 - ![2022-04-03_14-00_1](https://user-images.githubusercontent.com/1557255/161449256-eb20ec23-6c34-4e0a-b0b4-879b3610bfad.png)
 - ![2022-04-03_14-00](https://user-images.githubusercontent.com/1557255/161449257-72597dcd-e507-46dc-82fe-fda97f223d13.png)
 - ![2022-04-03_13-59_1](https://user-images.githubusercontent.com/1557255/161449258-d1b3c55c-fa76-4a2a-89b5-3357f2f2f1a4.png)
 - ![2022-04-03_13-59](https://user-images.githubusercontent.com/1557255/161449259-01c9a2b2-d131-4f28-ba70-d303e02be15d.png)


### Resized windows now retain their dimensions across DOS video-mode changes

Previously a resized window only retained its dimensions for the current DOS video mode. When the DOS video mode changed, the window would pop-back to its original (as-configured on startup) resolution.

The window will now hold its size (possibly resized size) across DOS mode changes.