### PR TITLE
Prevent Loguru from using std::locale (#1561)

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -207,4 +207,13 @@
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
 #mesondefine _USE_MATH_DEFINES
 
+/* Loguru-related defines
+ */
+
+// Prevent loguru from parsing command-line arguments with
+// with the hosts's locale-applied, because this can foul up
+// ncurses. (DOSBox also doesn't have foreign-language arguments).
+//
+#define LOGURU_USE_LOCALE 0
+
 #endif

--- a/src/libs/loguru/loguru.hpp
+++ b/src/libs/loguru/loguru.hpp
@@ -195,6 +195,14 @@ Website: www.ilikebigbits.com
 #endif
 #endif
 
+#ifdef LOGURU_USE_ANONYMOUS_NAMESPACE
+	#define LOGURU_ANONYMOUS_NAMESPACE_BEGIN namespace {
+	#define LOGURU_ANONYMOUS_NAMESPACE_END }
+#else
+	#define LOGURU_ANONYMOUS_NAMESPACE_BEGIN
+	#define LOGURU_ANONYMOUS_NAMESPACE_END
+#endif
+
 // --------------------------------------------------------------------
 // Utility macros
 
@@ -248,7 +256,10 @@ Website: www.ilikebigbits.com
 	#define STRDUP(str) strdup(str)
 #endif
 
+#include <stdarg.h>
+
 // --------------------------------------------------------------------
+LOGURU_ANONYMOUS_NAMESPACE_BEGIN
 
 namespace loguru
 {
@@ -635,6 +646,10 @@ namespace loguru
 	LOGURU_EXPORT
 	void log(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(4, 5);
 
+	// Actual logging function.
+	LOGURU_EXPORT
+	void vlog(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, va_list) LOGURU_PRINTF_LIKE(4, 0);
+
 	// Log without any preamble or indentation.
 	LOGURU_EXPORT
 	void raw_log(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(4, 5);
@@ -645,8 +660,11 @@ namespace loguru
 	{
 	public:
 		LogScopeRAII() : _file(nullptr) {} // No logging
+		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, va_list vlist) LOGURU_PRINTF_LIKE(5, 0);
 		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(5, 6);
 		~LogScopeRAII();
+
+		void Init(LOGURU_FORMAT_STRING_TYPE format, va_list vlist) LOGURU_PRINTF_LIKE(2, 0);
 
 #if defined(_MSC_VER) && _MSC_VER > 1800
 		// older MSVC default move ctors close the scope on move. See
@@ -1020,6 +1038,8 @@ namespace loguru
 	*/
 } // namespace loguru
 
+LOGURU_ANONYMOUS_NAMESPACE_END
+
 // --------------------------------------------------------------------
 // Logging macros
 
@@ -1189,6 +1209,8 @@ namespace loguru
 #include <sstream> // Adds about 38 kLoC on clang.
 #include <string>
 
+LOGURU_ANONYMOUS_NAMESPACE_BEGIN
+
 namespace loguru
 {
 	// Like sprintf, but returns the formated text.
@@ -1303,6 +1325,8 @@ namespace loguru
 	inline long long          referenceable_value(long long          t) { return t; }
 	inline unsigned long long referenceable_value(unsigned long long t) { return t; }
 } // namespace loguru
+
+LOGURU_ANONYMOUS_NAMESPACE_END
 
 // -----------------------------------------------
 // Logging macros:

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -96,3 +96,12 @@
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
+
+/* Loguru-related defines
+ */
+
+// Prevent loguru from parsing command-line arguments with
+// with the hosts's locale-applied, because this can foul up
+// ncurses. (DOSBox also doesn't have foreign-language arguments).
+//
+#define LOGURU_USE_LOCALE 0


### PR DESCRIPTION
Fixes #1561, see discussion in the issue (thanks @LowLevelMahn)

The ability to exclude the use of locale has been PR'd upstream: https://github.com/emilk/loguru/pull/216/commits/a744ed5b3959e2352bee7110f1e51ae379f2b025

