### PR TITLE
Fix debugger crash on Linux + ncurses 5.x

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -62,7 +62,11 @@ public:
 void DEBUG_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
 #define LOG_MSG DEBUG_ShowMsg
 
-#else  //C_DEBUG
+#define LOG_INFO(...)    LOG(LOG_ALL, LOG_NORMAL)(__VA_ARGS__)
+#define LOG_WARNING(...) LOG(LOG_ALL, LOG_WARN)(__VA_ARGS__)
+#define LOG_ERR(...)     LOG(LOG_ALL, LOG_ERROR)(__VA_ARGS__)
+
+#else // C_DEBUG
 
 struct LOG
 {
@@ -94,11 +98,11 @@ void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1,
 // Keep for compatibility
 #define LOG_MSG(...)	LOG_F(INFO, __VA_ARGS__)
 
-#endif //C_DEBUG
-
 #define LOG_INFO(...)		LOG_F(INFO, __VA_ARGS__)
 #define LOG_WARNING(...)	LOG_F(WARNING, __VA_ARGS__)
 #define LOG_ERR(...)		LOG_F(ERROR, __VA_ARGS__)
+
+#endif // C_DEBUG
 
 #ifdef NDEBUG
 // DEBUG_LOG_MSG exists only for messages useful during development, and not to

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -35,19 +35,19 @@
 #include "debug_inc.h"
 
 struct _LogGroup {
-	char const* front;
-	bool enabled;
+	char const *front = nullptr;
+	bool enabled = false;
 };
 #include <list>
 #include <string>
 using namespace std;
 
 #define MAX_LOG_BUFFER 500
-static list<string> logBuff;
+static list<string> logBuff = {};
 static list<string>::iterator logBuffPos = logBuff.end();
 
 static _LogGroup loggrp[LOG_MAX]={{"",true},{0,false}};
-static FILE* debuglog;
+static FILE *debuglog = nullptr;
 
 extern int old_cursor_state;
 

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -54,7 +54,10 @@ extern int old_cursor_state;
 
 
 void DEBUG_ShowMsg(char const* format,...) {
-	
+	// Quit early if the window hasn't been created yet
+	if (!dbg.win_out)
+		return;
+
 	char buf[512];
 	va_list msg;
 	va_start(msg,format);
@@ -87,8 +90,14 @@ void DEBUG_ShowMsg(char const* format,...) {
 }
 
 void DEBUG_RefreshPage(char scroll) {
-	if (scroll==-1 && logBuffPos!=logBuff.begin()) logBuffPos--;
-	else if (scroll==1 && logBuffPos!=logBuff.end()) logBuffPos++;
+	// Quit early if the window hasn't been created yet
+	if (!dbg.win_out)
+		return;
+
+	if (scroll == -1 && logBuffPos != logBuff.begin())
+		logBuffPos--;
+	else if (scroll == 1 && logBuffPos != logBuff.end())
+		logBuffPos++;
 
 	list<string>::iterator i = logBuffPos;
 	int maxy, maxx; getmaxyx(dbg.win_out,maxy,maxx);
@@ -122,6 +131,10 @@ void LOG::operator() (char const* format, ...){
 
 
 static void Draw_RegisterLayout(void) {
+	// Quit early if the window hasn't been created yet
+	if (!dbg.win_reg)
+		return;
+
 	mvwaddstr(dbg.win_reg,0,0,"EAX=");
 	mvwaddstr(dbg.win_reg,1,0,"EBX=");
 	mvwaddstr(dbg.win_reg,2,0,"ECX=");
@@ -195,7 +208,7 @@ static void MakeSubWindows(void) {
 	refresh();
 }
 
-static void MakePairs(void) {
+static void MakePairs() {
 	init_pair(PAIR_BLACK_BLUE, COLOR_BLACK, COLOR_CYAN);
 	init_pair(PAIR_BYELLOW_BLACK, COLOR_YELLOW /*| FOREGROUND_INTENSITY */, COLOR_BLACK);
 	init_pair(PAIR_GREEN_BLACK, COLOR_GREEN /*| FOREGROUND_INTENSITY */, COLOR_BLACK);

--- a/src/debug/debug_inc.h
+++ b/src/debug/debug_inc.h
@@ -22,39 +22,38 @@
 #include <curses.h>
 #include "mem.h"
 
-#define PAIR_BLACK_BLUE 1
-#define PAIR_BYELLOW_BLACK 2
-#define PAIR_GREEN_BLACK 3
-#define PAIR_BLACK_GREY 4
-#define PAIR_GREY_RED 5
-
-
-void DBGUI_StartUp(void);
-
-struct DBGBlock {
-	WINDOW * win_main;					/* The Main Window */
-	WINDOW * win_reg;					/* Register Window */
-	WINDOW * win_data;					/* Data Output window */
-	WINDOW * win_code;					/* Disassembly/Debug point Window */
-	WINDOW * win_var;					/* Variable Window */
-	WINDOW * win_out;					/* Text Output Window */
-	uint32_t active_win;					/* Current active window */
-	uint32_t input_y;
-	uint32_t global_mask;					/* Current msgmask */
+enum NCURSES_COLOR_PAIRS {
+	PAIR_BLACK_BLUE = 1,
+	PAIR_BYELLOW_BLACK = 2,
+	PAIR_GREEN_BLACK = 3,
+	PAIR_BLACK_GREY = 4,
+	PAIR_GREY_RED = 5,
 };
 
+void DBGUI_StartUp();
+
+struct DBGBlock {
+	WINDOW *win_main = nullptr; /* The Main Window */
+	WINDOW *win_reg = nullptr;  /* Register Window */
+	WINDOW *win_data = nullptr; /* Data Output window */
+	WINDOW *win_code = nullptr; /* Disassembly/Debug point Window */
+	WINDOW *win_var = nullptr;  /* Variable Window */
+	WINDOW *win_out = nullptr;  /* Text Output Window */
+	uint32_t active_win = 0;    /* Current active window */
+	uint32_t input_y = 0;
+	uint32_t global_mask = 0; /* Current msgmask */
+};
 
 struct DASMLine {
-	uint32_t pc;
-	char dasm[80];
-	PhysPt ea;
-	uint16_t easeg;
-	uint32_t eaoff;
+	uint32_t pc = 0;
+	char dasm[80] = {0};
+	PhysPt ea = 0;
+	uint16_t easeg = 0;
+	uint32_t eaoff = 0;
 };
 
 extern DBGBlock dbg;
 
 /* Local Debug Stuff */
 Bitu DasmI386(char* buffer, PhysPt pc, Bitu cur_ip, bool bit32);
-int  DasmLastOperandSize(void);
-
+int DasmLastOperandSize();

--- a/src/libs/loguru/loguru.cpp
+++ b/src/libs/loguru/loguru.cpp
@@ -78,7 +78,7 @@
 // TODO: use defined(_POSIX_VERSION) for some of these things?
 
 #ifndef LOGURU_USE_LOCALE
-	#define LOGURU_USE_LOCALE 1
+	#define LOGURU_USE_LOCALE 0
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/src/libs/loguru/loguru.hpp
+++ b/src/libs/loguru/loguru.hpp
@@ -175,6 +175,10 @@ Website: www.ilikebigbits.com
 	#define LOGURU_USE_FMTLIB 0
 #endif
 
+#ifndef LOGURU_USE_LOCALE
+	#define LOGURU_USE_LOCALE 0
+#endif
+
 #ifndef LOGURU_WITH_FILEABS
 	#define LOGURU_WITH_FILEABS 0
 #endif


### PR DESCRIPTION
This adds some general checks around use of the ncurses-populated pointers to prevent the use of them before they're constructed (because some logging calls might be made before the debugger's registered setup callback is run.
 