### PR TITLE
Prepare for PVS Studio license renewal

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 262
+          MAX_BUGS: 288
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -64,6 +64,7 @@ jobs:
           mkdir -p "${reportdir}"
 
           pvs-studio-analyzer analyze \
+            --disableLicenseExpirationCheck \
             -a 63 \
             -e subprojects \
             -s .pvs-suppress \


### PR DESCRIPTION
This PR:
 - Disables the license notification error code, which arises 30 days before expiration. 
 - Updates the allowed warning count, which has changes due to the new PVS Studio version.