### PR TITLE
Refactor Tandy sound

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -872,10 +872,6 @@ void DOSBOX_Init() {
 	Pstring->Set_values(tandys);
 	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
 
-	Pint = secprop->Add_int("tandyrate", when_idle, 44100);
-	Pint->Set_values(rates);
-	Pint->Set_help("Sample rate of the Tandy 3-Voice generation.");
-
 	secprop->AddInitFunction(&DISNEY_Init,true);//done
 
 	Pbool = secprop->Add_bool("disney", when_idle, true);

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -102,7 +102,7 @@ struct machine_config {
 typedef int device_type;
 
 class device_t {
-	u32 clockRate;
+	u32 clockRate = 0;
 public:
 	struct machine_t {
 		int describe_context() const {

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -104,6 +104,7 @@ typedef int device_type;
 class device_t {
 	u32 clockRate = 0;
 public:
+	const char *shortName = nullptr;
 	struct machine_t {
 		int describe_context() const {
 			return 0;
@@ -141,8 +142,14 @@ public:
 	void save_item(int, [[maybe_unused]] int blah= 0) {
 	}
 
-	device_t(const machine_config & /* mconfig */, [[maybe_unused]] device_type type, [[maybe_unused]] const char *tag, [[maybe_unused]] device_t *owner, u32 _clock) : clockRate( _clock ) {
-	}
+	device_t(const machine_config & /* mconfig */,
+	         [[maybe_unused]] device_type type,
+	         const char *short_name,
+	         [[maybe_unused]] device_t *owner,
+	         u32 _clock)
+	        : clockRate(_clock),
+	          shortName(short_name)
+	{}
 
 	virtual ~device_t() {
 	}

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -146,6 +146,9 @@ public:
 
 	virtual ~device_t() {
 	}
+	// prevent copying and assignment
+	device_t(const device_t &) = delete;
+	device_t &operator=(const device_t &) = delete;
 };
 
 #define auto_alloc_array_clear(m, t, c) calloc(c, sizeof(t) )

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -141,6 +141,7 @@
 #include "sn76496.h"
 
 #include <algorithm>
+#include <cassert>
 
 #define MAX_OUTPUT 0x7fff
 //When you go over this create sample
@@ -401,8 +402,10 @@ void sn76496_base_device::countdown_cycles()
 void sn76496_base_device::sound_stream_update([[maybe_unused]] sound_stream &stream, [[maybe_unused]] stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
 	int i;
+
+	assert(outputs);
 	stream_sample_t *lbuffer = outputs[0];
-	stream_sample_t *rbuffer = (m_stereo)? outputs[1] : 0;//nullptr;
+	stream_sample_t *rbuffer = (m_stereo) ? outputs[1] : nullptr;
 
 	int16_t out;
 	int16_t out2 = 0;
@@ -477,8 +480,14 @@ void sn76496_base_device::sound_stream_update([[maybe_unused]] sound_stream &str
 		}
 
 		if (m_negate) { out = -out; out2 = -out2; }
+
+		assert(lbuffer);
 		*(lbuffer++) = out;
-		if (m_stereo) *(rbuffer++) = out2;
+
+		if (m_stereo) {
+			assert(rbuffer);
+			*(rbuffer++) = out2;
+		}
 		samples--;
 	}
 }

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -145,7 +145,7 @@
 
 #define MAX_OUTPUT 0x7fff
 //When you go over this create sample
-#define RATE_MAX ( 1 << 30)
+#define RATE_MAX (1 << 10)
 
 sn76496_base_device::sn76496_base_device(const machine_config &mconfig,
                                          device_type type,

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -274,7 +274,7 @@ void sn76496_base_device::device_start()
 	m_current_clock = m_clock_divider-1;
 
 	// set gain
-	gain = 0;
+	gain = 16;
 
 	gain &= 0xff;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -300,6 +300,9 @@ void MixerChannel::Mix(const int _needed)
 		auto left = needed - done;
 		left *= freq_add;
 		left  = (left >> FREQ_SHIFT) + ((left & FREQ_MASK)!=0);
+		if (left <= 0) // avoid underflow
+			break;
+		left = std::min(left, MIXER_BUFSIZE); // avoid overflow
 		handler(check_cast<uint16_t>(left));
 	}
 }


### PR DESCRIPTION
This PR lightly refactors the DAC and PSG implementations into two classes, isolating their functionality and state variables from each other.

It resamples the Tandy audio to match the mixer rate, so we can do away with the `tandyrate` conf setting.

It adds more assertions and boundary checks, and makes use of modern containers and string operations.

The core functionality of the Tandy is left the same, with minimal changes to the code or variable names and types.  The refactoring mostly involves moving from a global struct (and functions that act on it) to a couple managed classes.