### PR TITLE
Refactor the shell's CHOICE command with regular expressions

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -38,6 +38,7 @@
 #include <sys/types.h>
 #include <thread>
 #include <type_traits>
+#include <unordered_set>
 #include <vector>
 
 #include "std_filesystem.h"
@@ -348,6 +349,24 @@ template <typename container_t>
 bool contains(const container_t &container, const typename container_t::key_type &key)
 {
 	return container.find(key) != container.end();
+}
+
+// remove duplicates from an unordered container using std::remove_if (C++17)
+
+// The std::remove_if algorithm moves 'failed' elements to the end of the
+// container, and then returns an iterator to the new end of the container.
+// We can then chop-off all the unwanted elements using a single std::erase
+// call (minimizing memory thrashing).
+
+template <typename container_t, typename value_t = typename container_t::value_type>
+void remove_duplicates(container_t &c)
+{
+	std::unordered_set<value_t> s;
+	auto val_is_duplicate = [&s](const value_t &value) {
+		return s.insert(value).second == false;
+	};
+	const auto end = std::remove_if(c.begin(), c.end(), val_is_duplicate);
+	c.erase(end, c.end());
 }
 
 // Convenience function to cast to the underlying type of an enum class

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1269,9 +1269,12 @@ class Typer {
 			m_stop_requested = true;
 			Wait();
 		}
-		void End() {
-			m_stop_requested = true;
-		}
+	        void StopImmediately()
+	        {
+		        m_stop_requested = true;
+		        if (m_instance.joinable())
+			        m_instance.detach();
+	        }
 
 	private:
 		void Callback() {
@@ -3031,8 +3034,9 @@ void MAPPER_AutoType(std::vector<std::string> &sequence,
 	mapper.typist.Start(&events, sequence, wait_ms, pace_ms);
 }
 
-void MAPPER_AutoType_End() {
-	mapper.typist.End();
+void MAPPER_AutoTypeStopImmediately()
+{
+	mapper.typist.StopImmediately();
 }
 
 void MAPPER_StartUp(Section * sec) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1238,43 +1238,44 @@ void MAPPER_TriggerEvent(const CEvent *event, const bool deactivation_state) {
 }
 
 class Typer {
-	public:
-		Typer() = default;
-		Typer(const Typer&) = delete; // prevent copy
-		Typer& operator=(const Typer&) = delete; // prevent assignment
-		~Typer() {
-			Stop();
-		}
-		void Start(std::vector<CEvent*>     *ext_events,
-		           std::vector<std::string> &ext_sequence,
-                   const uint32_t           wait_ms,
-                   const uint32_t           pace_ms) {
-			// Guard against empty inputs
-			if (!ext_events || ext_sequence.empty())
-				return;
-			Wait();
-			m_events = ext_events;
-			m_sequence = std::move(ext_sequence);
-			m_wait_ms = wait_ms;
-			m_pace_ms = pace_ms;
-			m_stop_requested = false;
-			m_instance = std::thread(&Typer::Callback, this);
-			set_thread_name(m_instance, "dosbox:autotype");
-		}
-		void Wait() {
-			if (m_instance.joinable())
-				m_instance.join();
-		}
-		void Stop() {
-			m_stop_requested = true;
-			Wait();
-		}
-	        void StopImmediately()
-	        {
-		        m_stop_requested = true;
-		        if (m_instance.joinable())
-			        m_instance.detach();
-	        }
+public:
+	Typer() = default;
+	Typer(const Typer &) = delete;            // prevent copy
+	Typer &operator=(const Typer &) = delete; // prevent assignment
+	~Typer() { Stop(); }
+	void Start(std::vector<CEvent *> *ext_events,
+	           std::vector<std::string> &ext_sequence,
+	           const uint32_t wait_ms,
+	           const uint32_t pace_ms)
+	{
+		// Guard against empty inputs
+		if (!ext_events || ext_sequence.empty())
+			return;
+		Wait();
+		m_events = ext_events;
+		m_sequence = std::move(ext_sequence);
+		m_wait_ms = wait_ms;
+		m_pace_ms = pace_ms;
+		m_stop_requested = false;
+		m_instance = std::thread(&Typer::Callback, this);
+		set_thread_name(m_instance, "dosbox:autotype");
+	}
+	void Wait()
+	{
+		if (m_instance.joinable())
+			m_instance.join();
+	}
+	void Stop()
+	{
+		m_stop_requested = true;
+		Wait();
+	}
+	void StopImmediately()
+	{
+		m_stop_requested = true;
+		if (m_instance.joinable())
+			m_instance.detach();
+	}
 
 private:
 	// find the event for the lshift key and return it

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1406,6 +1406,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]choice[reset] /t:[color=white]y[reset],[color=magenta]2[reset] [color=cyan]Continue?[reset]\n"
 	        "  [color=green]choice[reset] /c:[color=white]abc[reset] /s [color=cyan]Type the letter a, b, or c[reset]\n");
+	MSG_Add("SHELL_CMD_CHOICE_ABORTED", "\nChoice aborted.\n");
 	MSG_Add("SHELL_CMD_PATH_HELP",
 	        "Displays or sets a search path for executable files.\n");
 	MSG_Add("SHELL_CMD_PATH_HELP_LONG",

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -28,8 +28,10 @@
 #include <cstring>
 #include <ctime>
 #include <limits>
-#include <string>
 #include <map>
+#include <regex>
+#include <stack>
+#include <string>
 #include <vector>
 
 #include "bios.h"
@@ -1906,109 +1908,121 @@ void DOS_Shell::CMD_LOADHIGH(char *args){
 	} else this->ParseLine(args);
 }
 
-bool get_param(char *&args, char *&rem, char *&temp, char &wait_char, int &wait_sec)
-{
-	const char *last = strchr(args, 0);
-	StripSpaces(args);
-	temp = ScanCMDRemain(args);
-	const bool optC = temp && tolower(temp[1]) == 'c';
-	const bool optT = temp && tolower(temp[1]) == 't';
-	if (temp && *temp && !optC && !optT)
-		return false;
-	if (temp) {
-		if (args == temp)
-			args = strchr(temp, 0) + 1;
-		temp += 2;
-		if (temp[0] == ':')
-			temp++;
-	}
-	if (optC) {
-		rem = temp;
-	} else if (optT) {
-		if (temp && *temp && *(temp + 1) == ',') {
-			wait_char = *temp;
-			wait_sec = atoi(temp + 2);
-		} else
-			wait_sec = 0;
-	}
-	if (args > last)
-		args = NULL;
-	return true;
-}
-
 void MAPPER_AutoType(std::vector<std::string> &sequence,
                      const uint32_t wait_ms,
                      const uint32_t pacing_ms);
-void MAPPER_AutoType_End();
+void MAPPER_AutoTypeStopImmediately();
+void DOS_21Handler();
 
 void DOS_Shell::CMD_CHOICE(char * args){
 	HELP("CHOICE");
-	static char defchoice[3] = {'y','n',0};
-	char *rem = nullptr;
-	char *ptr = nullptr;
-	char *temp = nullptr;
-	char wait_char = '\0';
-	int wait_sec = 0;
-	bool optN = false;
-	bool optS = false;
-	if (args) {
-		optN = ScanCMDBool(args, "N");
-		optS = ScanCMDBool(args, "S"); // Case-sensitive matching
-		if (!get_param(args, rem, temp, wait_char, wait_sec)) {
-			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), temp);
-			return;
+
+	// Parse "/n"; does the user want to show choices or not?
+	const bool should_show_choices = !ScanCMDBool(args, "N");
+
+	// Parse "/s"; does the user want choices to be case-sensitive?
+	const bool always_capitalize = !ScanCMDBool(args, "S");
+
+	// Prepare the command line for use with regular expressions
+	assert(args);
+	std::string cmdline = args;
+	std::smatch match; // will contain the last valid match
+	std::stack<std::smatch> matches = {};
+
+	// helper to snip the stack of regex matches from the cmdline
+	auto snip_matches_from_cmdline = [&]() {
+		while (!matches.empty()) {
+			const auto &m = matches.top();
+			const auto start = static_cast<size_t>(m.position());
+			const auto length = static_cast<size_t>(m.length());
+			assert(start + length <= cmdline.size());
+			cmdline.erase(start, length);
+			matches.pop();
 		}
-		if (args && !get_param(args, rem, temp, wait_char, wait_sec)) {
-			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), temp);
-			return;
-		}
-	}
-	if (!rem || !*rem)
-		rem = defchoice; /* No choices specified use YN */
-	ptr = rem;
-	uint8_t c;
-	if (!optS) while ((c = *ptr)) *ptr++ = (char)toupper(c); /* When in no case-sensitive mode. make everything upcase */
-	if (args && *args ) {
-		StripSpaces(args);
-		size_t argslen = strlen(args);
-		if (argslen > 1 && args[0] == '"' && args[argslen-1] == '"') {
-			args[argslen-1] = 0; //Remove quotes
-			args++;
-		}
-		WriteOut(args);
-	}
-	/* Show question prompt of the form [a,b]? where a b are the choice values */
-	if (!optN) {
-		if (args && *args) WriteOut(" ");
-		WriteOut("[");
-		size_t len = strlen(rem);
-		for (size_t t = 1; t < len; t++) {
-			WriteOut("%c,",rem[t-1]);
-		}
-		WriteOut("%c]?",rem[len-1]);
+	};
+	// helper to search the cmdline for the last regex match
+	auto search_cmdline_for = [&](const std::regex &r) -> bool {
+		matches = {};
+		auto it = std::sregex_iterator(cmdline.begin(), cmdline.end(), r);
+		while (it != std::sregex_iterator())
+			matches.emplace(*it++);
+		match = matches.size() ? matches.top() : std::smatch();
+		return match.ready();
+	};
+
+	// Parse /c[:]abc ... has the user provided custom choices?
+	static const std::regex re_choices("/[cC]:?([0-9a-zA-Z]+)");
+	const auto has_choices = search_cmdline_for(re_choices);
+	auto choices = has_choices ? match[1].str() : std::string("yn");
+	if (always_capitalize)
+		upcase(choices);
+	remove_duplicates(choices);
+	snip_matches_from_cmdline();
+
+	// Parse /t[:]c,nn ... was a default choice and timeout provided?
+	static const std::regex re_timeout(R"(/[tT]:?([0-9a-zA-Z]),(\d+))");
+	auto has_default = search_cmdline_for(re_timeout);
+	const auto default_wait_s = has_default ? std::stoi(match[2]) : 0;
+	char default_choice = has_default ? match[1].str()[0] : '\0';
+	if (always_capitalize)
+		default_choice = check_cast<char>(toupper(default_choice));
+	snip_matches_from_cmdline();
+
+	// Parse and print any text message(s) witout whitespace and quotes
+	static const std::regex re_trim(R"(^["\s]+|["\s]+$)");
+	const auto messages = split(std::regex_replace(cmdline, re_trim, ""));
+	for (const auto &message : messages)
+		WriteOut("%s ", message.c_str());
+
+	// Show question prompt of the form [a,b]? where a b are the choice values
+	if (should_show_choices) {
+		WriteOut_NoParsing("[");
+		assert(choices.size() > 0);
+		for (size_t i = 0; i < choices.size() - 1; i++)
+			WriteOut("%c,", choices[i]);
+		WriteOut("%c]?", choices.back());
 	}
 
-	std::vector<std::string> sequence;
-	bool in_char = optS ? (strchr(rem, wait_char) != nullptr)
-	                    : (strchr(rem, toupper(wait_char)) ||
-	                       strchr(rem, tolower(wait_char)));
-	bool auto_type = wait_char && *rem && in_char && wait_sec > 0;
-	if (auto_type) {
-		sequence.emplace_back(std::string(1, tolower(wait_char)));
-		MAPPER_AutoType(sequence, wait_sec * 1000, 500);
+	// If a default was given, is it in the choices and is the wait valid?
+	const auto using_auto_type = has_default &&
+	                             contains(choices, default_choice) &&
+	                             default_wait_s > 0;
+	if (using_auto_type) {
+		std::vector<std::string> sequence{std::string{default_choice}};
+		const auto start_after_ms = static_cast<uint32_t>(default_wait_s * 1000);
+		MAPPER_AutoType(sequence, start_after_ms, 500);
 	}
-	uint16_t n = 1;
-	do {
-		DOS_ReadFile(STDIN, &c, &n);
-		if (auto_type)
-			MAPPER_AutoType_End();
+
+	// Begin waiting for input, but maybe break on some conditions
+	constexpr char ctrl_c = 3;
+	char choice = '\0';
+	while (!contains(choices, choice)) {
+		uint16_t n = 1;
+		DOS_ReadFile(STDIN, reinterpret_cast<uint8_t *>(&choice), &n);
+		if (always_capitalize)
+			choice = static_cast<char>(toupper(choice));
+		if (using_auto_type)
+			MAPPER_AutoTypeStopImmediately();
 		if (shutdown_requested)
 			break;
-	} while (!c || !(ptr = strchr(rem, (optS ? c : toupper(c)))));
-	c = optS ? c : (uint8_t)toupper(c);
-	DOS_WriteFile(STDOUT, &c, &n);
-	WriteOut_NoParsing("\n");
-	dos.return_code = (uint8_t)(ptr-rem+1);
+		if (choice == ctrl_c)
+			break;
+	}
+
+	// Print the choice and return the index (or zero if aborted)
+	const auto num_choices = static_cast<int>(choices.size());
+	if (contains(choices, choice)) {
+		WriteOut("%c\n", choice);
+		const auto nth_choice = choices.find(choice) % 254 + 1;
+		dos.return_code = check_cast<uint8_t>(nth_choice);
+		LOG_MSG("CHOICE: '%c' (#%u of %d choices)", choice,
+		        dos.return_code, num_choices);
+	} else {
+		WriteOut_NoParsing(MSG_Get("SHELL_CMD_CHOICE_ABORTED"));
+		dos.return_code = 0;
+		LOG_MSG("CHOICE: Aborted, returning %u (from %d choices)",
+		        dos.return_code, num_choices);
+	}
 }
 
 void DOS_Shell::CMD_PATH(char *args){


### PR DESCRIPTION
Also adds a Ctrl + C break to the choice loop (and returns 0 as the `%errorlevel%`) which matches Microsoft's description for when Ctrl + C breaks out of CHOICE.

Ref: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/choice

I'm not sure if Ctrl+C was allowed in DOS, but we know what the user wants, so this is a quality of life improvement (instead of trapping them in CHOICE).