### PR TITLE
Separate class definitions in sdlmain.cpp to sdlmain.h

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -107,55 +107,6 @@ enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_HIGHEST
 };
 
-class PPScale {
-public:
-	PPScale(const int source_w,
-	        const int source_h,
-	        const double aspect_ratio,
-	        const bool source_is_doubled,
-	        const int canvas_w,
-	        const int canvas_h)
-
-	{
-		assert(source_w > 0);
-		assert(source_h > 0);
-		assert(canvas_w > 0);
-		assert(canvas_h > 0);
-		assert(aspect_ratio > 0.1);
-
-		// divide the source if it's been doubled
-		effective_source_w = source_w / (source_is_doubled ? 2 : 1);
-		effective_source_h = source_h / (source_is_doubled ? 2 : 1);
-
-		// call the pixel-perfect library to get the scale factors
-		constexpr double aspect_weight = 1.14; // pixel-perfect constant
-		const int err = pp_getscale(effective_source_w, effective_source_h,
-		                            aspect_ratio, canvas_w, canvas_h,
-		                            aspect_weight, &scale_x, &scale_y);
-
-		// if the scaling failed, ensure the the multipliers are valid
-		if (err) {
-			scale_x = 1;
-			scale_y = 1;
-		}
-		// calculate the output dimensions
-		output_w = effective_source_w * scale_x;
-		output_h = effective_source_h * scale_y;
-		assert(output_w > 0);
-		assert(output_h > 0);
-	}
-	// default constructor
-	PPScale() {}
-
-	int effective_source_w = 0;
-	int effective_source_h = 0;
-	int output_w = 0;
-	int output_h = 0;
-private:
-	int scale_x = 0;
-	int scale_y = 0;
-};
-
 struct SDL_Block {
 	bool initialized = false;
 	bool active = false; // If this isn't set don't draw

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -1,0 +1,273 @@
+#include <string>
+#include <string.h>
+#include "SDL.h"
+#if C_OPENGL
+#include <SDL_opengl.h>
+#endif
+#include "video.h"
+
+#include "../libs/ppscale/ppscale.h"
+
+#define SDL_NOFRAME 0x00000020
+
+// Texture buffer and presentation functions and type-defines
+using update_frame_buffer_f = void(const uint16_t *);
+using present_frame_f = bool();
+static void update_frame_texture([[maybe_unused]] const uint16_t *changedLines);
+static bool present_frame_texture();
+#if C_OPENGL
+static void update_frame_gl_pbo([[maybe_unused]] const uint16_t *changedLines);
+static void update_frame_gl_fb(const uint16_t *changedLines);
+static bool present_frame_gl();
+#endif
+static void update_frame_surface(const uint16_t *changedLines);
+constexpr void update_frame_noop([[maybe_unused]] const uint16_t *) { /* no-op */ }
+static inline bool present_frame_noop() { return true; }
+
+enum MouseControlType {
+	CaptureOnClick = 1 << 0,
+	CaptureOnStart = 1 << 1,
+	Seamless       = 1 << 2,
+	NoMouse        = 1 << 3
+};
+
+enum SCREEN_TYPES	{
+	SCREEN_SURFACE,
+	SCREEN_TEXTURE,
+#if C_OPENGL
+	SCREEN_OPENGL
+#endif
+};
+
+enum class FRAME_MODE {
+	UNSET,
+	CFR,        // constant frame rate, as defined by the emulated system
+	VFR,        // variable frame rate, as defined by the emulated system
+	SYNCED_CFR, // constant frame rate, synced with the display's refresh rate
+	THROTTLED_VFR, // variable frame rate, throttled to the display's rate
+};
+
+enum class HOST_RATE_MODE {
+	AUTO,
+	SDI, // serial digital interface
+	VRR, // variable refresh rate
+	CUSTOM,
+};
+
+enum class SCALING_MODE { NONE, NEAREST, PERFECT };
+
+enum class VSYNC_STATE {
+	UNSET = -2,
+	ADAPTIVE = -1,
+	OFF = 0,
+	ON = 1,
+};
+
+// A vsync preference consists of three parts:
+//  - What the user asked for
+//  - What the host reports vsync as after setting it
+//  - What the actual resulting state is after setting it
+struct VsyncPreference {
+	VSYNC_STATE requested = VSYNC_STATE::UNSET;
+	VSYNC_STATE reported = VSYNC_STATE::UNSET;
+	VSYNC_STATE resultant = VSYNC_STATE::UNSET;
+	int16_t benchmarked_rate = 0;
+};
+
+enum PRIORITY_LEVELS {
+	PRIORITY_LEVEL_AUTO,
+	PRIORITY_LEVEL_PAUSE,
+	PRIORITY_LEVEL_LOWEST,
+	PRIORITY_LEVEL_LOWER,
+	PRIORITY_LEVEL_NORMAL,
+	PRIORITY_LEVEL_HIGHER,
+	PRIORITY_LEVEL_HIGHEST
+};
+
+class PPScale {
+public:
+	PPScale(const int source_w,
+	        const int source_h,
+	        const double aspect_ratio,
+	        const bool source_is_doubled,
+	        const int canvas_w,
+	        const int canvas_h)
+
+	{
+		assert(source_w > 0);
+		assert(source_h > 0);
+		assert(canvas_w > 0);
+		assert(canvas_h > 0);
+		assert(aspect_ratio > 0.1);
+
+		// divide the source if it's been doubled
+		effective_source_w = source_w / (source_is_doubled ? 2 : 1);
+		effective_source_h = source_h / (source_is_doubled ? 2 : 1);
+
+		// call the pixel-perfect library to get the scale factors
+		constexpr double aspect_weight = 1.14; // pixel-perfect constant
+		const int err = pp_getscale(effective_source_w, effective_source_h,
+		                            aspect_ratio, canvas_w, canvas_h,
+		                            aspect_weight, &scale_x, &scale_y);
+
+		// if the scaling failed, ensure the the multipliers are valid
+		if (err) {
+			scale_x = 1;
+			scale_y = 1;
+		}
+		// calculate the output dimensions
+		output_w = effective_source_w * scale_x;
+		output_h = effective_source_h * scale_y;
+		assert(output_w > 0);
+		assert(output_h > 0);
+	}
+	// default constructor
+	PPScale() {}
+
+	int effective_source_w = 0;
+	int effective_source_h = 0;
+	int output_w = 0;
+	int output_h = 0;
+private:
+	int scale_x = 0;
+	int scale_y = 0;
+};
+
+struct SDL_Block {
+	bool initialized = false;
+	bool active = false; // If this isn't set don't draw
+	bool updating = false;
+	bool update_display_contents = true;
+	bool resizing_window = false;
+	bool wait_on_error = false;
+	SCALING_MODE scaling_mode = SCALING_MODE::NONE;
+	struct {
+		int width = 0;
+		int height = 0;
+		double scalex = 1.0;
+		double scaley = 1.0;
+		double pixel_aspect = 1.0;
+		uint16_t previous_mode = 0;
+		bool has_changed = false;
+		GFX_CallBack_t callback = nullptr;
+		bool width_was_doubled = false;
+		bool height_was_doubled = false;
+	} draw = {};
+	struct {
+		struct {
+			int width = 0;
+			int height = 0;
+			bool fixed = false;
+			bool display_res = false;
+		} full = {};
+		struct {
+			int width = 0;
+			int height = 0;
+			bool resizable = false;
+			bool show_decorations = true;
+			bool adjusted_initial_size = false;
+			int initial_x_pos = -1;
+			int initial_y_pos = -1;
+		} window = {};
+		struct {
+			int width = 0;
+			int height = 0;
+		} requested_window_bounds = {};
+
+		uint8_t bpp = 0;
+		bool fullscreen = false;
+		// This flag indicates, that we are in the process of switching
+		// between fullscreen or window (as oppososed to changing
+		// rendering size due to rotating screen, emulation state, or
+		// user resizing the window).
+		bool switching_fullscreen = false;
+		// Lazy window size init triggers updating window size and
+		// position when leaving fullscreen for the first time.
+		// See FinalizeWindowState function for details.
+		bool lazy_init_window_size = false;
+		HOST_RATE_MODE host_rate_mode = HOST_RATE_MODE::AUTO;
+		double preferred_host_rate = 0.0;
+		bool want_resizable_window = false;
+		SDL_WindowEventID last_size_event = {};
+		SCREEN_TYPES type = SCREEN_SURFACE;
+		SCREEN_TYPES want_type = SCREEN_SURFACE;
+	} desktop = {};
+	struct {
+		VsyncPreference when_windowed = {};
+		VsyncPreference when_fullscreen = {};
+		VSYNC_STATE current = VSYNC_STATE::ON;
+		int skip_us = 0;
+	} vsync = {};
+#if C_OPENGL
+	struct {
+		SDL_GLContext context;
+		int pitch = 0;
+		void *framebuf = nullptr;
+		GLuint buffer;
+		GLuint texture;
+		GLuint displaylist;
+		GLint max_texsize;
+		bool bilinear;
+		bool pixel_buffer_object = false;
+		bool npot_textures_supported = false;
+		bool use_shader;
+		GLuint program_object;
+		const char *shader_src;
+		struct {
+			GLint texture_size;
+			GLint input_size;
+			GLint output_size;
+			GLint frame_count;
+		} ruby = {};
+		GLuint actual_frame_count;
+		GLfloat vertex_data[2*3];
+	} opengl = {};
+#endif // C_OPENGL
+	struct {
+		PRIORITY_LEVELS focus;
+		PRIORITY_LEVELS nofocus;
+	} priority = {};
+	SDL_Rect clip = {0, 0, 0, 0};
+	SDL_Surface *surface = nullptr;
+	SDL_Window *window = nullptr;
+	SDL_Renderer *renderer = nullptr;
+	std::string render_driver = "";
+	int display_number = 0;
+	struct {
+		SDL_Surface *input_surface = nullptr;
+		SDL_Texture *texture = nullptr;
+		SDL_PixelFormat *pixelFormat = nullptr;
+	} texture = {};
+	struct {
+		present_frame_f *present = present_frame_noop;
+		update_frame_buffer_f *update = update_frame_noop;
+		FRAME_MODE desired_mode = FRAME_MODE::UNSET;
+		FRAME_MODE mode = FRAME_MODE::UNSET;
+		double period_ms = 0.0; // in ms, for use with PIC timers
+		int period_us = 0;      // same but in us, for use with chrono
+		int period_us_early = 0;
+		int period_us_late = 0;
+	} frame = {};
+	struct {
+		int xsensitivity = 0;
+		int ysensitivity = 0;
+		int sensitivity = 0;
+		MouseControlType control_choice = Seamless;
+		bool middle_will_release = true;
+		bool has_focus = false;
+	} mouse = {};
+	PPScale pp_scale = {};
+	SDL_Rect updateRects[1024];
+	bool use_exact_window_resolution = false;
+	bool use_viewport_limits = false;
+	SDL_Point viewport_resolution = {-1, -1};
+#if defined (WIN32)
+	// Time when sdl regains focus (Alt+Tab) in windowed mode
+	int64_t focus_ticks = 0;
+#endif
+	// State of Alt keys for certain special handlings
+	SDL_EventType laltstate = SDL_KEYUP;
+	SDL_EventType raltstate = SDL_KEYUP;
+};
+
+extern SDL_Block sdl;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -1,3 +1,26 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+ 
+#ifndef DOSBOX_SDLMAIN_H
+#define DOSBOX_SDLMAIN_H
+ 
 #include <string>
 #include <string.h>
 #include "SDL.h"
@@ -271,3 +294,5 @@ struct SDL_Block {
 };
 
 extern SDL_Block sdl;
+
+#endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -59,11 +59,10 @@
 #include "setup.h"
 #include "string_utils.h"
 #include "support.h"
+#include "sdlmain.h"
 #include "timer.h"
 #include "vga.h"
 #include "video.h"
-
-#include "../libs/ppscale/ppscale.h"
 
 #define MAPPERFILE "mapper-sdl2-" VERSION ".map"
 
@@ -192,6 +191,8 @@ PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer = NULL;
 #define PRIO_TOTAL (PRIO_MAX - PRIO_MIN)
 #endif
 
+SDL_Block sdl;
+
 bool mouse_is_captured = false;       // the actual state of the mouse
 bool mouse_capture_requested = false; // if the user manually requested the capture
 
@@ -214,56 +215,6 @@ constexpr uint32_t AMASK = 0xff000000;
 #endif
 #endif // !MACOSX
 
-enum MouseControlType {
-	CaptureOnClick = 1 << 0,
-	CaptureOnStart = 1 << 1,
-	Seamless       = 1 << 2,
-	NoMouse        = 1 << 3
-};
-
-enum SCREEN_TYPES	{
-	SCREEN_SURFACE,
-	SCREEN_TEXTURE,
-#if C_OPENGL
-	SCREEN_OPENGL
-#endif
-};
-
-enum class FRAME_MODE {
-	UNSET,
-	CFR,        // constant frame rate, as defined by the emulated system
-	VFR,        // variable frame rate, as defined by the emulated system
-	SYNCED_CFR, // constant frame rate, synced with the display's refresh rate
-	THROTTLED_VFR, // variable frame rate, throttled to the display's rate
-};
-
-enum class HOST_RATE_MODE {
-	AUTO,
-	SDI, // serial digital interface
-	VRR, // variable refresh rate
-	CUSTOM,
-};
-
-enum class SCALING_MODE { NONE, NEAREST, PERFECT };
-
-enum class VSYNC_STATE {
-	UNSET = -2,
-	ADAPTIVE = -1,
-	OFF = 0,
-	ON = 1,
-};
-
-// A vsync preference consists of three parts:
-//  - What the user asked for
-//  - What the host reports vsync as after setting it
-//  - What the actual resulting state is after setting it
-struct VsyncPreference {
-	VSYNC_STATE requested = VSYNC_STATE::UNSET;
-	VSYNC_STATE reported = VSYNC_STATE::UNSET;
-	VSYNC_STATE resultant = VSYNC_STATE::UNSET;
-	int16_t benchmarked_rate = 0;
-};
-
 // Size and ratio constants
 // ------------------------
 constexpr int SMALL_WINDOW_PERCENT = 50;
@@ -274,221 +225,10 @@ static SDL_Point FALLBACK_WINDOW_DIMENSIONS = {640, 480};
 constexpr SDL_Point RATIOS_FOR_STRETCHED_PIXELS = {4, 3};
 constexpr SDL_Point RATIOS_FOR_SQUARE_PIXELS = {8, 5};
 
-enum PRIORITY_LEVELS {
-	PRIORITY_LEVEL_AUTO,
-	PRIORITY_LEVEL_PAUSE,
-	PRIORITY_LEVEL_LOWEST,
-	PRIORITY_LEVEL_LOWER,
-	PRIORITY_LEVEL_NORMAL,
-	PRIORITY_LEVEL_HIGHER,
-	PRIORITY_LEVEL_HIGHEST
-};
-
-class PPScale {
-public:
-	PPScale(const int source_w,
-	        const int source_h,
-	        const double aspect_ratio,
-	        const bool source_is_doubled,
-	        const int canvas_w,
-	        const int canvas_h)
-
-	{
-		assert(source_w > 0);
-		assert(source_h > 0);
-		assert(canvas_w > 0);
-		assert(canvas_h > 0);
-		assert(aspect_ratio > 0.1);
-
-		// divide the source if it's been doubled
-		effective_source_w = source_w / (source_is_doubled ? 2 : 1);
-		effective_source_h = source_h / (source_is_doubled ? 2 : 1);
-
-		// call the pixel-perfect library to get the scale factors
-		constexpr double aspect_weight = 1.14; // pixel-perfect constant
-		const int err = pp_getscale(effective_source_w, effective_source_h,
-		                            aspect_ratio, canvas_w, canvas_h,
-		                            aspect_weight, &scale_x, &scale_y);
-
-		// if the scaling failed, ensure the the multipliers are valid
-		if (err) {
-			scale_x = 1;
-			scale_y = 1;
-		}
-		// calculate the output dimensions
-		output_w = effective_source_w * scale_x;
-		output_h = effective_source_h * scale_y;
-		assert(output_w > 0);
-		assert(output_h > 0);
-	}
-	// default constructor
-	PPScale() {}
-
-	int effective_source_w = 0;
-	int effective_source_h = 0;
-	int output_w = 0;
-	int output_h = 0;
-private:
-	int scale_x = 0;
-	int scale_y = 0;
-};
-
 /* Alias for indicating, that new window should not be user-resizable: */
 constexpr bool FIXED_SIZE = false;
 
-// Texture buffer and presentation functions and type-defines
-using update_frame_buffer_f = void(const uint16_t *);
-using present_frame_f = bool();
-static void update_frame_texture([[maybe_unused]] const uint16_t *changedLines);
-static bool present_frame_texture();
-#if C_OPENGL
-static void update_frame_gl_pbo([[maybe_unused]] const uint16_t *changedLines);
-static void update_frame_gl_fb(const uint16_t *changedLines);
-static bool present_frame_gl();
-#endif
-static void update_frame_surface(const uint16_t *changedLines);
-constexpr void update_frame_noop([[maybe_unused]] const uint16_t *) { /* no-op */ }
-static inline bool present_frame_noop() { return true; }
-
-struct SDL_Block {
-	bool initialized = false;
-	bool active = false; // If this isn't set don't draw
-	bool updating = false;
-	bool update_display_contents = true;
-	bool resizing_window = false;
-	bool wait_on_error = false;
-	SCALING_MODE scaling_mode = SCALING_MODE::NONE;
-	struct {
-		int width = 0;
-		int height = 0;
-		double scalex = 1.0;
-		double scaley = 1.0;
-		double pixel_aspect = 1.0;
-		uint16_t previous_mode = 0;
-		bool has_changed = false;
-		GFX_CallBack_t callback = nullptr;
-		bool width_was_doubled = false;
-		bool height_was_doubled = false;
-	} draw = {};
-	struct {
-		struct {
-			int width = 0;
-			int height = 0;
-			bool fixed = false;
-			bool display_res = false;
-		} full = {};
-		struct {
-			int width = 0;
-			int height = 0;
-			bool resizable = false;
-			bool show_decorations = true;
-			bool adjusted_initial_size = false;
-			int initial_x_pos = -1;
-			int initial_y_pos = -1;
-		} window = {};
-		struct {
-			int width = 0;
-			int height = 0;
-		} requested_window_bounds = {};
-
-		uint8_t bpp = 0;
-		bool fullscreen = false;
-		// This flag indicates, that we are in the process of switching
-		// between fullscreen or window (as oppososed to changing
-		// rendering size due to rotating screen, emulation state, or
-		// user resizing the window).
-		bool switching_fullscreen = false;
-		// Lazy window size init triggers updating window size and
-		// position when leaving fullscreen for the first time.
-		// See FinalizeWindowState function for details.
-		bool lazy_init_window_size = false;
-		HOST_RATE_MODE host_rate_mode = HOST_RATE_MODE::AUTO;
-		double preferred_host_rate = 0.0;
-		bool want_resizable_window = false;
-		SDL_WindowEventID last_size_event = {};
-		SCREEN_TYPES type = SCREEN_SURFACE;
-		SCREEN_TYPES want_type = SCREEN_SURFACE;
-	} desktop = {};
-	struct {
-		VsyncPreference when_windowed = {};
-		VsyncPreference when_fullscreen = {};
-		VSYNC_STATE current = VSYNC_STATE::ON;
-		int skip_us = 0;
-	} vsync = {};
-#if C_OPENGL
-	struct {
-		SDL_GLContext context;
-		int pitch = 0;
-		void *framebuf = nullptr;
-		GLuint buffer;
-		GLuint texture;
-		GLuint displaylist;
-		GLint max_texsize;
-		bool bilinear;
-		bool pixel_buffer_object = false;
-		bool npot_textures_supported = false;
-		bool use_shader;
-		GLuint program_object;
-		const char *shader_src;
-		struct {
-			GLint texture_size;
-			GLint input_size;
-			GLint output_size;
-			GLint frame_count;
-		} ruby = {};
-		GLuint actual_frame_count;
-		GLfloat vertex_data[2*3];
-	} opengl = {};
-#endif // C_OPENGL
-	struct {
-		PRIORITY_LEVELS focus;
-		PRIORITY_LEVELS nofocus;
-	} priority = {};
-	SDL_Rect clip = {0, 0, 0, 0};
-	SDL_Surface *surface = nullptr;
-	SDL_Window *window = nullptr;
-	SDL_Renderer *renderer = nullptr;
-	std::string render_driver = "";
-	int display_number = 0;
-	struct {
-		SDL_Surface *input_surface = nullptr;
-		SDL_Texture *texture = nullptr;
-		SDL_PixelFormat *pixelFormat = nullptr;
-	} texture = {};
-	struct {
-		present_frame_f *present = present_frame_noop;
-		update_frame_buffer_f *update = update_frame_noop;
-		FRAME_MODE desired_mode = FRAME_MODE::UNSET;
-		FRAME_MODE mode = FRAME_MODE::UNSET;
-		double period_ms = 0.0; // in ms, for use with PIC timers
-		int period_us = 0;      // same but in us, for use with chrono
-		int period_us_early = 0;
-		int period_us_late = 0;
-	} frame = {};
-	struct {
-		int xsensitivity = 0;
-		int ysensitivity = 0;
-		int sensitivity = 0;
-		MouseControlType control_choice = Seamless;
-		bool middle_will_release = true;
-		bool has_focus = false;
-	} mouse = {};
-	PPScale pp_scale = {};
-	SDL_Rect updateRects[1024];
-	bool use_exact_window_resolution = false;
-	bool use_viewport_limits = false;
-	SDL_Point viewport_resolution = {-1, -1};
-#if defined (WIN32)
-	// Time when sdl regains focus (Alt+Tab) in windowed mode
-	int64_t focus_ticks = 0;
-#endif
-	// State of Alt keys for certain special handlings
-	SDL_EventType laltstate = SDL_KEYUP;
-	SDL_EventType raltstate = SDL_KEYUP;
-};
-
 static bool first_window = true;
-static SDL_Block sdl;
 
 static SDL_Point restrict_to_viewport_resolution(int width, int height);
 static PPScale calc_pp_scale(int width, int heigth);

--- a/src/libs/ppscale/ppscale.h
+++ b/src/libs/ppscale/ppscale.h
@@ -38,4 +38,53 @@ int pp_scale /* magnify an image in a pixel-perfect manner */
 }
 #endif
 
+class PPScale {
+public:
+	PPScale(const int source_w,
+	        const int source_h,
+	        const double aspect_ratio,
+	        const bool source_is_doubled,
+	        const int canvas_w,
+	        const int canvas_h)
+
+	{
+		assert(source_w > 0);
+		assert(source_h > 0);
+		assert(canvas_w > 0);
+		assert(canvas_h > 0);
+		assert(aspect_ratio > 0.1);
+
+		// divide the source if it's been doubled
+		effective_source_w = source_w / (source_is_doubled ? 2 : 1);
+		effective_source_h = source_h / (source_is_doubled ? 2 : 1);
+
+		// call the pixel-perfect library to get the scale factors
+		constexpr double aspect_weight = 1.14; // pixel-perfect constant
+		const int err = pp_getscale(effective_source_w, effective_source_h,
+		                            aspect_ratio, canvas_w, canvas_h,
+		                            aspect_weight, &scale_x, &scale_y);
+
+		// if the scaling failed, ensure the the multipliers are valid
+		if (err) {
+			scale_x = 1;
+			scale_y = 1;
+		}
+		// calculate the output dimensions
+		output_w = effective_source_w * scale_x;
+		output_h = effective_source_h * scale_y;
+		assert(output_w > 0);
+		assert(output_h > 0);
+	}
+	// default constructor
+	PPScale() {}
+
+	int effective_source_w = 0;
+	int effective_source_h = 0;
+	int output_w = 0;
+	int output_h = 0;
+private:
+	int scale_x = 0;
+	int scale_y = 0;
+};
+
 #endif /* PPSCALE_H */


### PR DESCRIPTION
This moves some class definitions in sdlmain.cpp into a separate header file sdlmain.h, so that the header file can be included in other source files such as render.cpp for features like TTF support.