### PR TITLE
Fix gamma-incorrect interpolation in the 'sharp' OpenGL shader

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -185,6 +185,7 @@ struct SDL_Block {
 		bool pixel_buffer_object = false;
 		bool npot_textures_supported = false;
 		bool use_shader;
+		bool framebuffer_is_srgb_encoded;
 		GLuint program_object;
 		const char *shader_src;
 		struct {


### PR DESCRIPTION
# Problem description

The built-in 'sharp' OpenGL rescale filter is great, but it suffers from gamma-incorrect interpolation (it always uses hardware-accelerated linear interpolation on the sRGB encoded pixel values; this is mathemathically incorrect and yields wrong results). The adverse effects are most noticeable on high-contrast checkboard dither patterns, especially in EGA games (so half of the Sierra catalogue and early LucasArts games are affected), and on high-resolution text rendering (e.g. most Legend Entertainment adventure games).

Note that unless pixel-perfect mode is used, some interpolation will almost always be needed for screen modes that need aspect ratio correction, so for 320x200, 640x350 and 640x400, to name the most common ones. On 1080p displays the adverse interpolation artefacts can be quite visible, especially if the viewport is restricted to smaller than fullscreen, e.g. 960x720.

The following image illustrates the problem. Look for differences in text rendering quality and weird interference-like artefacts in checkerboard dither patterns (the red arrows show where to look). Make sure to check out the comparison images further down as well; they make the problem more apparent when switching back and forth between the good and bad images.

![comparison](https://user-images.githubusercontent.com/698770/165033434-dddd66aa-d95d-4316-9eed-7ce2b2c52d4f.png)

# Solution

The solution is to not use hardware interpolation, but gamma-decode (linearise) the colour values on the way in, perform the interpolation correctly in linear RGB space, then gamma-encode the results on the way out. This is pretty much what all good quality CRT shaders are doing.

There *might* be a way to get this done in hardware when specifying the textures as sRGB, but even the OpenGL specs are wishy-washy about this (it says the hardware _might_ perform the interpolation in linear space in that case... or not... The Vulkan specs seem to be much more strict and well-defined in this matter). Seems like it's another OpenGL feature that's highly driver and hardware dependent; no wonder virtually all high-quality CRT shaders bypass hardware interpolation completely and do their own linearisation & interpolation.

This makes the shader slower, but I doubt this would be a problem for any GPU released in the last 8-10 years. I have strong feelings about making the 'sharp' shader do the correct thing by default (as DOSBox-Staging generally tries to do), but perhaps we could also include the previous gamma-incorrect version as an option under the name 'sharp-fast'.

# Test images

_**You cannot properly see the problem by just looking at the images as they appear on this page because the browser scales them!**_

Please open the images pairwise in new tabs and switch between them, or download and view them with 1:1 pixel mapping in an image viewer; the differences are really easy to spot that way. 

The resolution was restricted to 960x720 on all test images. But the artefacts can happen at any resolution; they're just easier to spot on smaller output sizes. Especially for 640px-wide screen modes, these artefacts are almost always present, even at fullscreen.

Also note that _not_ just EGA games are affected. The degradation of text rendering can be observed in high-resolution VGA and SVGA games as well, and even in 320x200 VGA games that use pixel fonts with 1px wide lines.

## EGA dither test chart

This is a bit of a stress test, but these dither patterns appear quite frequently in EGA games, e.g. most old Sierra adventures.

Note the unevenness of the patterns in the vertical direction, the appearance of brighter "ghost" lines, and the overall luminance loss in the gamma-incorrect version.

![gamma-test-correct](https://user-images.githubusercontent.com/698770/165033458-34d62164-e809-4c23-9679-2905b79a8371.png)

![gamma-test-wrong](https://user-images.githubusercontent.com/698770/165033463-68ccdb28-2864-4f6a-89c8-8ffb6cf32ca8.png)


## Spellcasting 201

Noticeable artefacts of gamma-incorrect interpolation:

- Severe moire-like interference patterns on checkerboard dither patterns
- Severe degradation of text rendering

![spellcasting201-correct](https://user-images.githubusercontent.com/698770/165033481-0f806c9f-76a1-4285-affa-048b2e1672da.png)

![spellcasting201-wrong](https://user-images.githubusercontent.com/698770/165033482-86dcc019-7345-4142-a178-b13b1988fcad.png)

## Timequest

Noticeable artefacts of gamma-incorrect interpolation:

- Severe moire-like interference artefacts on checkerboard dither patterns
- Severe degradation of text rendering

![timequest-correct](https://user-images.githubusercontent.com/698770/165033486-365e9ce8-02aa-4bbe-a046-26314871ed00.png)

![timequest-wrong](https://user-images.githubusercontent.com/698770/165033495-542a2665-5a4d-4963-a1a4-12925cabf138.png)

## Loom

Noticeable artefacts of gamma-incorrect interpolation:

- Unevenness of checkerboard dither artefacts & appearance of horizontal "ghost" lines
- Loss of brighness of checkerboard dither patterns

![loom1-correct](https://user-images.githubusercontent.com/698770/165033465-51a0244e-8467-4fb3-a21a-5f1cf8a84fe0.png)

![loom1-wrong](https://user-images.githubusercontent.com/698770/165033469-eeaa1b63-7c47-468a-80fa-2d65f6ef5582.png)

## Space Quest 3

Noticeable artefacts of gamma-incorrect interpolation:

- Unevenness of checkerboard dither patterns & appearance of horizontal "ghost" lines
- Loss of brighness of checkerboard dither patterns

![spacequest1-correct](https://user-images.githubusercontent.com/698770/165033475-7dc42225-38b6-450e-84a0-bb60f795ade6.png)

![spacequest1-wrong](https://user-images.githubusercontent.com/698770/165033478-0b39c7dc-9e1b-40f3-81eb-8b65406e768b.png)

## Windwalker

Noticeable artefacts of gamma-incorrect interpolation:

- Unevenness of checkerboard dither patterns & appearance of horizontal "ghost" lines
- Loss of brighness of checkerboard dither patterns

![windwalker-correct](https://user-images.githubusercontent.com/698770/165033499-57cfd15d-204b-4f7e-b57e-923289db4449.png)

![windwalker-wrong](https://user-images.githubusercontent.com/698770/165033501-bc3eb141-c2fe-4541-ad25-3dc679d0611f.png)

## The Secret of Monkey Island

Noticeable artefacts of gamma-incorrect interpolation:

- Unevenness of checkerboard dither patterns & appearance of horizontal "ghost" lines
- Loss of brighness of checkerboard dither patterns
- Because the image has dithering all over the place, the result looks subtly uneven (super annoying once you start noticing it; you just cannot unsee it)

![monkey1-correct](https://user-images.githubusercontent.com/698770/165033470-b75dc5a7-8dc8-4ac2-bcd3-bbe2ff4a8906.png)

![monkey1-wrong](https://user-images.githubusercontent.com/698770/165033472-3a0725bc-38c1-432c-aaa6-42efefa17c41.png)

## Eye of the Beholder I

Noticeable artefacts of gamma-incorrect interpolation:

- Somewhat degraded text rendering; the lines of the pixel-font are a bit uneven

![eob-correct](https://user-images.githubusercontent.com/698770/165033442-6b606f04-dcbf-4a01-b9c3-3400ecc8c038.png)

![eob-wrong](https://user-images.githubusercontent.com/698770/165033448-4b753260-1754-435a-9cf8-93573b7811cf.png)

