### PR TITLE
Gamma-correct all built-in shaders

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -27,6 +27,9 @@
 
 #include "../src/gui/render_scalers.h"
 
+#include <string>
+#include <vector>
+
 #define RENDER_SKIP_CACHE	16
 //Enable this for scalers to support 0 input for empty lines
 //#define RENDER_NULL_INPUT
@@ -107,5 +110,9 @@ void RENDER_SetSize(uint32_t width,
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
 void RENDER_SetPal(uint8_t entry,uint8_t red,uint8_t green,uint8_t blue);
+
+#if C_OPENGL
+extern const std::vector<std::string> builtin_shader_names;
+#endif
 
 #endif

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -624,25 +624,33 @@ static void ChangeScaler(bool pressed) {
 } */
 
 #if C_OPENGL
+const std::unordered_map<std::string, const char *> builtin_shaders = {
+		{"advinterp2x", advinterp2x_glsl},
+		{"advinterp3x", advinterp3x_glsl},
+		{"advmame2x", advmame2x_glsl},
+		{"advmame3x", advmame3x_glsl},
+		{"crt-easymode-flat", crt_easymode_tweaked_glsl},
+		{"crt-fakelottes-flat", crt_fakelottes_tweaked_glsl},
+		{"default", sharp_glsl},
+		{"rgb2x", rgb2x_glsl},
+		{"rgb3x", rgb3x_glsl},
+		{"scan2x", scan2x_glsl},
+		{"scan3x", scan3x_glsl},
+		{"sharp", sharp_glsl},
+		{"tv2x", tv2x_glsl},
+		{"tv3x", tv3x_glsl},
+};
+
+const std::vector<std::string> builtin_shader_names = []{
+		std::vector<std::string> v;
+		for (auto &it : builtin_shaders) {
+			v.push_back(it.first);
+		}
+		return v;
+}();
+
 static bool RENDER_GetShader(std::string &shader_path, char *old_src)
 {
-	const std::unordered_map<std::string, const char *> builtin_shaders = {
-	        {"advinterp2x", advinterp2x_glsl},
-	        {"advinterp3x", advinterp3x_glsl},
-	        {"advmame2x", advmame2x_glsl},
-	        {"advmame3x", advmame3x_glsl},
-	        {"crt-easymode-flat", crt_easymode_tweaked_glsl},
-	        {"crt-fakelottes-flat", crt_fakelottes_tweaked_glsl},
-	        {"default", sharp_glsl},
-	        {"rgb2x", rgb2x_glsl},
-	        {"rgb3x", rgb3x_glsl},
-	        {"scan2x", scan2x_glsl},
-	        {"scan3x", scan3x_glsl},
-	        {"sharp", sharp_glsl},
-	        {"tv2x", tv2x_glsl},
-	        {"tv3x", tv3x_glsl},
-	};
-
 	char* src;
 	std::stringstream buf;
 	std::ifstream fshader(shader_path.c_str(), std::ios_base::binary);


### PR DESCRIPTION
...except for the CRT shaders that do their own gamma handling in the shader already.

The nice thing about this is that the shaders don't need to be changed at all, similarly to the `sharp` shader.

It's a bit harder to trigger interference patterns with these, for example with `advinterp2x` the previous 320x200 checkerboard pattern test image looks fine with the gamma-incorrect version too. But in Spellcasting 201 the difference can be easily seen, especially on text rendering (examples at 960x720 resolution).

Here's the 640x350 test image, might come in handy (rename to `*.bmp`).
[spellcasting201.zip](https://github.com/dosbox-staging/dosbox-staging/files/8596265/spellcasting201.zip)

### Gamma-incorrect

![sc201-wrong](https://user-images.githubusercontent.com/698770/166094553-235e4a4f-729a-400f-b7de-d5b1dd1c4d8b.png)

### Gamma-correct

![sc201-correct](https://user-images.githubusercontent.com/698770/166094554-43f18e4e-2828-4c52-9be8-506681d9f15e.png)



