### PR TITLE
Explicitly halt MIDI playback during MPU Reset and when passed through UART-mode

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -32,8 +32,9 @@ extern uint8_t MIDI_evt_len[256];
 
 constexpr auto MIDI_SYSEX_SIZE = 8192;
 
-void MIDI_Init(Section *sec);
 bool MIDI_Available();
+void MIDI_HaltSequence();
+void MIDI_Init(Section *sec);
 void MIDI_ListAll(Program *output_handler);
 void MIDI_RawOutByte(uint8_t data);
 

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -693,6 +693,7 @@ static void MPU401_ResetDone(uint32_t)
 }
 static void MPU401_Reset()
 {
+	MIDI_HaltSequence();
 	PIC_DeActivateIRQ(mpu.irq);
 	mpu.mode = (mpu.intelligent ? M_INTELLIGENT : M_UART);
 	PIC_RemoveEvents(MPU401_Event);

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -56,6 +56,7 @@ constexpr uint8_t MSG_MPU_COMMAND_REQ = 0xf9;
 constexpr uint8_t MSG_MPU_END = 0xfc;
 constexpr uint8_t MSG_MPU_CLOCK = 0xfd;
 constexpr uint8_t MSG_MPU_ACK = 0xfe;
+constexpr uint8_t MSG_MPU_RESET = 0xff;
 
 static struct {
 	bool intelligent;
@@ -135,10 +136,10 @@ static uint8_t MPU401_ReadStatus(io_port_t, io_width_t)
 static void MPU401_WriteCommand(io_port_t, const io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
-	if (mpu.mode == M_UART && val != 0xff)
+	if (mpu.mode == M_UART && val != MSG_MPU_RESET)
 		return;
 	if (mpu.state.reset) {
-		if (mpu.state.cmd_pending || val != 0xff) {
+		if (mpu.state.cmd_pending || val != MSG_MPU_RESET) {
 			mpu.state.cmd_pending = val + 1;
 			return;
 		}
@@ -282,7 +283,7 @@ static void MPU401_WriteCommand(io_port_t, const io_val_t value, io_width_t)
 			mpu.state.req_mask = 0;
 			mpu.state.irq_pending = true;
 			break;
-		case 0xff: // Reset MPU-401
+		case MSG_MPU_RESET:
 			LOG(LOG_MISC, LOG_NORMAL)("MPU-401:Reset %u", val);
 			PIC_AddEvent(MPU401_ResetDone, MPU401_RESETBUSY);
 			mpu.state.reset = true;

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -203,6 +203,31 @@ void MIDI_RawOutByte(uint8_t data)
 	}
 }
 
+void MidiHandler::HaltSequence()
+{
+	uint8_t message[3] = {}; // see MIDI_evt_len for length lookup-table
+	constexpr uint8_t all_notes_off = 0x7b;
+	constexpr uint8_t all_controllers_off = 0x79;
+	constexpr uint8_t controller = 0xb0;
+
+	// from the first to last channel
+	for (uint8_t channel = 0x0; channel <= 0xf; ++channel) {
+		message[0] = controller | channel; // 0xb0 through 0xbf
+
+		message[1] = all_notes_off;
+		PlayMsg(message);
+
+		message[1] = all_controllers_off;
+		PlayMsg(message);
+	}
+}
+
+void MIDI_HaltSequence()
+{
+	if (midi.handler)
+		midi.handler->HaltSequence();
+}
+
 bool MIDI_Available()
 {
 	return midi.available;

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -51,23 +51,7 @@ public:
 
 	virtual void Close() {}
 
-	void HaltSequence()
-	{
-		uint8_t message[3] = {}; // see MIDI_evt_len for length lookup-table
-		constexpr uint8_t all_notes_off = 0x7b;
-		constexpr uint8_t all_controllers_off = 0x79;
-
-		// from the first to last channel
-		for (uint8_t channel = 0xb0; channel <= 0xbf; ++channel) {
-			message[0] = channel;
-
-			message[1] = all_notes_off;
-			PlayMsg(message);
-
-			message[1] = all_controllers_off;
-			PlayMsg(message);
-		}
-	}
+	void HaltSequence();
 
 	virtual void PlayMsg([[maybe_unused]] const uint8_t *msg) {}
 


### PR DESCRIPTION
Some MIDI devices don't stop their MIDI playback when receiving a reset in UART mode.

For example, when International Soccer Challenge (1990) passed back-to-back `0xFF`'s to the MT-32 via UART mode, this results in a hanging note. 

So this PR explicitly halts MIDI playback (by sending "note-off" messages and controller reset requests, for  all MIDI channels), during MPU resets and also when the reset command (0xFF) is passed to the MIDI device via the MPU's UART interface. 

Ref: https://steinberg.help/cubase_pro_artist/v9/en/cubase_nuendo/topics/recording/recording_reset_function_c.html

> "The Reset function sends out note-off messages and resets controllers on all MIDI channels. This is sometimes necessary if you experience hanging notes, constant vibrato, etc. when punching in and out on MIDI recordings with pitchbend or controller data."

