### PR TITLE
Shaders can now use sRGB texture or framebuffer via pragmas

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -87,6 +87,10 @@ struct Render_t {
 	} scale = {};
 #if C_OPENGL
 	char *shader_src = nullptr;
+  struct {
+    bool use_srgb_texture = false;
+    bool use_srgb_framebuffer = false;
+  } shader_opts = {};
 #endif
 	RenderPal_t pal = {};
 	bool updating = false;
@@ -107,5 +111,10 @@ void RENDER_SetSize(uint32_t width,
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
 void RENDER_SetPal(uint8_t entry,uint8_t red,uint8_t green,uint8_t blue);
+
+#if C_OPENGL
+bool RENDER_UseSRGBTexture();
+bool RENDER_UseSRGBFramebuffer();
+#endif
 
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1423,15 +1423,6 @@ static bool LoadGLShaders(const char *src, GLuint *vertex, GLuint *fragment) {
 	return "";
 }
 
-[[maybe_unused]] static bool is_sharp_shader()
-{
-	constexpr std::array<std::string_view, 2> sharp_shader_names{{
-	        "sharp",
-	        "default",
-	}};
-	return contains(sharp_shader_names, get_glshader_value());
-}
-
 [[maybe_unused]] static bool is_shader_flexible()
 {
 	constexpr std::array<std::string_view, 3> flexible_shader_names{{
@@ -1906,13 +1897,13 @@ dosurface:
 		SDL_GL_GetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
 		                    &is_framebuffer_srgb_capable);
 
-		sdl.opengl.framebuffer_is_srgb_encoded = is_sharp_shader() && is_framebuffer_srgb_capable > 0;
+		sdl.opengl.framebuffer_is_srgb_encoded = RENDER_UseSRGBFramebuffer() && is_framebuffer_srgb_capable > 0;
 
-		if (is_sharp_shader() && !sdl.opengl.framebuffer_is_srgb_encoded)
+		if (RENDER_UseSRGBFramebuffer() && !sdl.opengl.framebuffer_is_srgb_encoded)
 			LOG_WARNING("OPENGL: sRGB framebuffer not supported");
 
 		// Using GL_SRGB8_ALPHA8 because GL_SRGB8 doesn't work properly with Mesa drivers on certain integrated Intel GPUs
-		const auto texformat = sdl.opengl.framebuffer_is_srgb_encoded ? GL_SRGB8_ALPHA8 : GL_RGB8;
+		const auto texformat = RENDER_UseSRGBTexture() ? GL_SRGB8_ALPHA8 : GL_RGB8;
 		glTexImage2D(GL_TEXTURE_2D, 0, texformat, texsize_w, texsize_h,
 		             0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, emptytex);
 		delete[] emptytex;


### PR DESCRIPTION
Discussion that led to this PR: https://github.com/dosbox-staging/dosbox-staging/pull/1634
This is the prerequisite for supporting sRGB in shaders in a relatively clean way. Updating all existing shaders will come in a separate PR after https://github.com/dosbox-staging/dosbox-staging/pull/1648 has been merged in.

I recommend testing it with the `sharp` shader as external shader. Try removing either or both pragmas to see the difference.

Let me know what you think about the pragma parsing, it doesn't handle comments but I think it's robust enough for the purpose. I forgot how much of a pain string handling is in C/C++...

```glsl
#pragma use_srgb_texture
#pragma use_srgb_framebuffer

varying vec2 v_texCoord;
uniform vec2 rubyInputSize;
uniform vec2 rubyOutputSize;
uniform vec2 rubyTextureSize;
varying vec2 prescale; // const set by vertex shader

#if defined(VERTEX)

attribute vec4 a_position;

void main() {
	gl_Position = a_position;
	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize;
	prescale = ceil(rubyOutputSize / rubyInputSize);
}

#elif defined(FRAGMENT)

uniform sampler2D rubyTexture;

void main() {
	const vec2 halfp = vec2(0.5);
	vec2 texel_floored = floor(v_texCoord);
	vec2 s = fract(v_texCoord);
	vec2 region_range = halfp - halfp / prescale;

	vec2 center_dist = s - halfp;
	vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * prescale + halfp;

	vec2 mod_texel = min(texel_floored + f, rubyInputSize-halfp);
	gl_FragColor = texture2D(rubyTexture, mod_texel / rubyTextureSize);
}
#endif
```