### PR TITLE
Refactor ProgramStart functionality

### DIFF
--- a/include/programs.h
+++ b/include/programs.h
@@ -105,7 +105,7 @@ void PROGRAMS_MakeFile(char const * const name, PROGRAMS_Creator creator);
 template<class P>
 std::unique_ptr<Program> ProgramCreate() {
 	// ensure that P is derived from Program
-	static_assert(std::is_base_of_v<Program, P>);
+	static_assert(std::is_base_of_v<Program, P>, "class not derived from Program");
 	return std::make_unique<P>();
 }
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -98,12 +98,12 @@ public:
 	static void ResetLastWrittenChar(char c);
 };
 
-using PROGRAMS_Main = std::function<std::unique_ptr<Program>()>;
+using PROGRAMS_Creator = std::function<std::unique_ptr<Program>()>;
 void PROGRAMS_Destroy([[maybe_unused]] Section* sec);
-void PROGRAMS_MakeFile(char const * const name, PROGRAMS_Main p_main);
+void PROGRAMS_MakeFile(char const * const name, PROGRAMS_Creator creator);
 
 template<class P>
-std::unique_ptr<Program> ProgramStart() {
+std::unique_ptr<Program> ProgramCreate() {
 	// ensure that P is derived from Program
 	static_assert(std::is_base_of_v<Program, P>);
 	return std::make_unique<P>();

--- a/include/programs.h
+++ b/include/programs.h
@@ -21,7 +21,9 @@
 
 #include "dosbox.h"
 
+#include <functional>
 #include <list>
+#include <memory>
 #include <string>
 #include "std_filesystem.h"
 
@@ -96,8 +98,15 @@ public:
 	static void ResetLastWrittenChar(char c);
 };
 
-typedef void (PROGRAMS_Main)(Program * * make);
+using PROGRAMS_Main = std::function<std::unique_ptr<Program>()>;
 void PROGRAMS_Destroy([[maybe_unused]] Section* sec);
-void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main);
+void PROGRAMS_MakeFile(char const * const name, PROGRAMS_Main p_main);
+
+template<class P>
+std::unique_ptr<Program> ProgramStart() {
+	// ensure that P is derived from Program
+	static_assert(std::is_base_of_v<Program, P>);
+	return std::make_unique<P>();
+}
 
 #endif

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2224,10 +2224,6 @@ Bitu DEBUG_EnableDebugger()
 	return 0;
 }
 
-static void DEBUG_ProgramStart(Program * * make) {
-	*make=new DEBUG;
-}
-
 // INIT
 
 void DEBUG_SetupConsole(void) {
@@ -2267,8 +2263,8 @@ void DEBUG_Init(Section* sec) {
 	/* Reset code overview and input line */
 	memset((void*)&codeViewData,0,sizeof(codeViewData));
 	/* setup debug.com */
-	PROGRAMS_MakeFile("DEBUG.COM",DEBUG_ProgramStart);
-	PROGRAMS_MakeFile("DBXDEBUG.COM",DEBUG_ProgramStart);
+	PROGRAMS_MakeFile("DEBUG.COM",ProgramStart<DEBUG>);
+	PROGRAMS_MakeFile("DBXDEBUG.COM",ProgramStart<DEBUG>);
 	/* Setup callback */
 	debugCallback=CALLBACK_Allocate();
 	CALLBACK_Setup(debugCallback,DEBUG_EnableDebugger,CB_RETF,"debugger");

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2263,8 +2263,8 @@ void DEBUG_Init(Section* sec) {
 	/* Reset code overview and input line */
 	memset((void*)&codeViewData,0,sizeof(codeViewData));
 	/* setup debug.com */
-	PROGRAMS_MakeFile("DEBUG.COM",ProgramStart<DEBUG>);
-	PROGRAMS_MakeFile("DBXDEBUG.COM",ProgramStart<DEBUG>);
+	PROGRAMS_MakeFile("DEBUG.COM",ProgramCreate<DEBUG>);
+	PROGRAMS_MakeFile("DBXDEBUG.COM",ProgramCreate<DEBUG>);
 	/* Setup callback */
 	debugCallback=CALLBACK_Allocate();
 	CALLBACK_Setup(debugCallback,DEBUG_EnableDebugger,CB_RETF,"debugger");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -46,9 +46,9 @@
 extern uint32_t floppytype;
 
 extern char autoexec_data[autoexec_maxsize];
-void CONFIG_ProgramStart(Program **make);
-void MIXER_ProgramStart(Program **make);
-void SHELL_ProgramStart(Program **make);
+std::unique_ptr<Program> CONFIG_ProgramStart();
+std::unique_ptr<Program> MIXER_ProgramStart();
+std::unique_ptr<Program> SHELL_ProgramStart();
 void z_drive_getpath(std::string &path, const std::string &dirname);
 void z_drive_register(const std::string &path, const std::string &dir);
 
@@ -61,26 +61,26 @@ void Add_VFiles(const bool add_autoexec)
 	z_drive_getpath(path, dirname);
 	z_drive_register(path, "/");
 
-	PROGRAMS_MakeFile("ATTRIB.COM", ATTRIB_ProgramStart);
-	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
+	PROGRAMS_MakeFile("ATTRIB.COM", ProgramStart<ATTRIB>);
+	PROGRAMS_MakeFile("AUTOTYPE.COM", ProgramStart<AUTOTYPE>);
 #if C_DEBUG
-	PROGRAMS_MakeFile("BIOSTEST.COM", BIOSTEST_ProgramStart);
+	PROGRAMS_MakeFile("BIOSTEST.COM", ProgramStart<AUTOTYPE>);
 #endif
-	PROGRAMS_MakeFile("BOOT.COM", BOOT_ProgramStart);
-	PROGRAMS_MakeFile("CHOICE.COM", CHOICE_ProgramStart);
-	PROGRAMS_MakeFile("HELP.COM", HELP_ProgramStart);
-	PROGRAMS_MakeFile("IMGMOUNT.COM", IMGMOUNT_ProgramStart);
-	PROGRAMS_MakeFile("INTRO.COM", INTRO_ProgramStart);
-	PROGRAMS_MakeFile("KEYB.COM", KEYB_ProgramStart);
-	PROGRAMS_MakeFile("LOADFIX.COM", LOADFIX_ProgramStart);
-	PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
-	PROGRAMS_MakeFile("LS.COM", LS_ProgramStart);
-	PROGRAMS_MakeFile("MEM.COM", MEM_ProgramStart);
-	PROGRAMS_MakeFile("MOUNT.COM", MOUNT_ProgramStart);
-	PROGRAMS_MakeFile("RESCAN.COM", RESCAN_ProgramStart);
+	PROGRAMS_MakeFile("BOOT.COM", ProgramStart<AUTOTYPE>);
+	PROGRAMS_MakeFile("CHOICE.COM", ProgramStart<CHOICE>);
+	PROGRAMS_MakeFile("HELP.COM", ProgramStart<HELP>);
+	PROGRAMS_MakeFile("IMGMOUNT.COM", ProgramStart<IMGMOUNT>);
+	PROGRAMS_MakeFile("INTRO.COM", ProgramStart<INTRO>);
+	PROGRAMS_MakeFile("KEYB.COM", ProgramStart<KEYB>);
+	PROGRAMS_MakeFile("LOADFIX.COM", ProgramStart<LOADFIX>);
+	PROGRAMS_MakeFile("LOADROM.COM", ProgramStart<LOADROM>);
+	PROGRAMS_MakeFile("LS.COM", ProgramStart<LS>);
+	PROGRAMS_MakeFile("MEM.COM", ProgramStart<MEM>);
+	PROGRAMS_MakeFile("MOUNT.COM", ProgramStart<MOUNT>);
+	PROGRAMS_MakeFile("RESCAN.COM", ProgramStart<RESCAN>);
 	PROGRAMS_MakeFile("MIXER.COM", MIXER_ProgramStart);
 	PROGRAMS_MakeFile("CONFIG.COM", CONFIG_ProgramStart);
-	PROGRAMS_MakeFile("SERIAL.COM", SERIAL_ProgramStart);
+	PROGRAMS_MakeFile("SERIAL.COM", ProgramStart<SERIAL>);
 	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramStart);
 	if (add_autoexec)
 		VFILE_Register("AUTOEXEC.BAT", (uint8_t *)autoexec_data,

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -46,9 +46,9 @@
 extern uint32_t floppytype;
 
 extern char autoexec_data[autoexec_maxsize];
-std::unique_ptr<Program> CONFIG_ProgramStart();
-std::unique_ptr<Program> MIXER_ProgramStart();
-std::unique_ptr<Program> SHELL_ProgramStart();
+std::unique_ptr<Program> CONFIG_ProgramCreate();
+std::unique_ptr<Program> MIXER_ProgramCreate();
+std::unique_ptr<Program> SHELL_ProgramCreate();
 void z_drive_getpath(std::string &path, const std::string &dirname);
 void z_drive_register(const std::string &path, const std::string &dir);
 
@@ -61,27 +61,27 @@ void Add_VFiles(const bool add_autoexec)
 	z_drive_getpath(path, dirname);
 	z_drive_register(path, "/");
 
-	PROGRAMS_MakeFile("ATTRIB.COM", ProgramStart<ATTRIB>);
-	PROGRAMS_MakeFile("AUTOTYPE.COM", ProgramStart<AUTOTYPE>);
+	PROGRAMS_MakeFile("ATTRIB.COM", ProgramCreate<ATTRIB>);
+	PROGRAMS_MakeFile("AUTOTYPE.COM", ProgramCreate<AUTOTYPE>);
 #if C_DEBUG
-	PROGRAMS_MakeFile("BIOSTEST.COM", ProgramStart<AUTOTYPE>);
+	PROGRAMS_MakeFile("BIOSTEST.COM", ProgramCreate<AUTOTYPE>);
 #endif
-	PROGRAMS_MakeFile("BOOT.COM", ProgramStart<AUTOTYPE>);
-	PROGRAMS_MakeFile("CHOICE.COM", ProgramStart<CHOICE>);
-	PROGRAMS_MakeFile("HELP.COM", ProgramStart<HELP>);
-	PROGRAMS_MakeFile("IMGMOUNT.COM", ProgramStart<IMGMOUNT>);
-	PROGRAMS_MakeFile("INTRO.COM", ProgramStart<INTRO>);
-	PROGRAMS_MakeFile("KEYB.COM", ProgramStart<KEYB>);
-	PROGRAMS_MakeFile("LOADFIX.COM", ProgramStart<LOADFIX>);
-	PROGRAMS_MakeFile("LOADROM.COM", ProgramStart<LOADROM>);
-	PROGRAMS_MakeFile("LS.COM", ProgramStart<LS>);
-	PROGRAMS_MakeFile("MEM.COM", ProgramStart<MEM>);
-	PROGRAMS_MakeFile("MOUNT.COM", ProgramStart<MOUNT>);
-	PROGRAMS_MakeFile("RESCAN.COM", ProgramStart<RESCAN>);
-	PROGRAMS_MakeFile("MIXER.COM", MIXER_ProgramStart);
-	PROGRAMS_MakeFile("CONFIG.COM", CONFIG_ProgramStart);
-	PROGRAMS_MakeFile("SERIAL.COM", ProgramStart<SERIAL>);
-	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramStart);
+	PROGRAMS_MakeFile("BOOT.COM", ProgramCreate<AUTOTYPE>);
+	PROGRAMS_MakeFile("CHOICE.COM", ProgramCreate<CHOICE>);
+	PROGRAMS_MakeFile("HELP.COM", ProgramCreate<HELP>);
+	PROGRAMS_MakeFile("IMGMOUNT.COM", ProgramCreate<IMGMOUNT>);
+	PROGRAMS_MakeFile("INTRO.COM", ProgramCreate<INTRO>);
+	PROGRAMS_MakeFile("KEYB.COM", ProgramCreate<KEYB>);
+	PROGRAMS_MakeFile("LOADFIX.COM", ProgramCreate<LOADFIX>);
+	PROGRAMS_MakeFile("LOADROM.COM", ProgramCreate<LOADROM>);
+	PROGRAMS_MakeFile("LS.COM", ProgramCreate<LS>);
+	PROGRAMS_MakeFile("MEM.COM", ProgramCreate<MEM>);
+	PROGRAMS_MakeFile("MOUNT.COM", ProgramCreate<MOUNT>);
+	PROGRAMS_MakeFile("RESCAN.COM", ProgramCreate<RESCAN>);
+	PROGRAMS_MakeFile("MIXER.COM", MIXER_ProgramCreate);
+	PROGRAMS_MakeFile("CONFIG.COM", CONFIG_ProgramCreate);
+	PROGRAMS_MakeFile("SERIAL.COM", ProgramCreate<SERIAL>);
+	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramCreate);
 	if (add_autoexec)
 		VFILE_Register("AUTOEXEC.BAT", (uint8_t *)autoexec_data,
 		               (uint32_t)strlen(autoexec_data));

--- a/src/dos/program_attrib.cpp
+++ b/src/dos/program_attrib.cpp
@@ -33,8 +33,3 @@ void ATTRIB::Run()
 	safe_strcpy(args, tmp.c_str());
 	first_shell->CMD_ATTRIB(args);
 }
-
-void ATTRIB_ProgramStart(Program **make)
-{
-	*make = new ATTRIB;
-}

--- a/src/dos/program_attrib.h
+++ b/src/dos/program_attrib.h
@@ -30,6 +30,4 @@ public:
 	void Run();
 };
 
-void ATTRIB_ProgramStart(Program **make);
-
 #endif

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -186,8 +186,3 @@ void AUTOTYPE::AddMessages() {
 	        "  [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]\n"
 	        "  [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter\n[reset]");
 }
-
-void AUTOTYPE_ProgramStart(Program **make)
-{
-	*make = new AUTOTYPE;
-}

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -41,6 +41,4 @@ private:
 	                   double &value);
 };
 
-void AUTOTYPE_ProgramStart(Program **make);
-
 #endif

--- a/src/dos/program_biostest.cpp
+++ b/src/dos/program_biostest.cpp
@@ -85,8 +85,4 @@ void BIOSTEST::Run(void) {
 	}
 }
 
-void BIOSTEST_ProgramStart(Program **make) {
-	*make = new BIOSTEST;
-}
-
 #endif // C_DEBUG

--- a/src/dos/program_biostest.h
+++ b/src/dos/program_biostest.h
@@ -29,6 +29,4 @@ class BIOSTEST final : public Program {
         void Run(void);
 };
 
-void BIOSTEST_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_BIOSTEST_H

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -527,8 +527,3 @@ void BOOT::AddMessages() {
 	MSG_Add("PROGRAM_BOOT_CART_LIST_CMDS", "Available PCjr cartridge commands: %s");
 	MSG_Add("PROGRAM_BOOT_CART_NO_CMDS", "No PCjr cartridge commands found");
 }
-
-void BOOT_ProgramStart(Program **make)
-{
-	*make = new BOOT;
-}

--- a/src/dos/program_boot.h
+++ b/src/dos/program_boot.h
@@ -37,6 +37,4 @@ class BOOT final : public Program {
         void disable_umb_ems_xms(void);
 };
 
-void BOOT_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_BOOT_H

--- a/src/dos/program_choice.cpp
+++ b/src/dos/program_choice.cpp
@@ -36,8 +36,3 @@ void CHOICE::Run()
 	first_shell->CMD_CHOICE(args);
 	result_errorcode = dos.return_code;
 }
-
-void CHOICE_ProgramStart(Program **make)
-{
-	*make = new CHOICE;
-}

--- a/src/dos/program_choice.h
+++ b/src/dos/program_choice.h
@@ -30,6 +30,4 @@ public:
 	void Run();
 };
 
-void CHOICE_ProgramStart(Program **make);
-
 #endif

--- a/src/dos/program_help.cpp
+++ b/src/dos/program_help.cpp
@@ -33,8 +33,3 @@ void HELP::Run()
 	safe_strcpy(args, tmp.c_str());
 	first_shell->CMD_HELP(args);
 }
-
-void HELP_ProgramStart(Program **make)
-{
-	*make = new HELP;
-}

--- a/src/dos/program_help.h
+++ b/src/dos/program_help.h
@@ -30,6 +30,4 @@ public:
 	void Run();
 };
 
-void HELP_ProgramStart(Program **make);
-
 #endif

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -559,7 +559,3 @@ void IMGMOUNT::AddMessages() {
 	MSG_Add("PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE", "The image must be on a host or local drive.\n");
 	MSG_Add("PROGRAM_IMGMOUNT_MULTIPLE_NON_CUEISO_FILES", "Using multiple files is only supported for cue/iso images.\n");
 }
-
-void IMGMOUNT_ProgramStart(Program **make) {
-	*make=new IMGMOUNT;
-}

--- a/src/dos/program_imgmount.h
+++ b/src/dos/program_imgmount.h
@@ -33,6 +33,4 @@ class IMGMOUNT final : public Program {
         void AddMessages();
 };
 
-void IMGMOUNT_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_IMGMOUNT_H

--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -192,7 +192,3 @@ void INTRO::AddMessages() {
 	        "\033[33;1m%s+F12\033[0m  %s Speed up emulation.\n"
 	        "\033[33;1m%s+F12\033[0m    Unlock speed (turbo button/fast forward).\n");
 }
-
-void INTRO_ProgramStart(Program **make) {
-	*make=new INTRO;
-}

--- a/src/dos/program_intro.h
+++ b/src/dos/program_intro.h
@@ -34,6 +34,4 @@ class INTRO final : public Program {
         void WriteOutProgramIntroSpecial();
 };
 
-void INTRO_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_INTRO_H

--- a/src/dos/program_keyb.cpp
+++ b/src/dos/program_keyb.cpp
@@ -118,7 +118,3 @@ void KEYB::AddMessages() {
 	MSG_Add("PROGRAM_KEYB_LAYOUTNOTFOUND","No layout in %s for codepage %i\n");
 	MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
 }
-
-void KEYB_ProgramStart(Program * * make) {
-	*make=new KEYB;
-}

--- a/src/dos/program_keyb.h
+++ b/src/dos/program_keyb.h
@@ -32,6 +32,4 @@ private:
 
 };
 
-void KEYB_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_KEYB_H

--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -109,7 +109,3 @@ void LOADFIX::AddMessages() {
 	MSG_Add("PROGRAM_LOADFIX_DEALLOCALL","Used memory freed.\n");
 	MSG_Add("PROGRAM_LOADFIX_ERROR","Memory allocation error.\n");
 }
-
-void LOADFIX_ProgramStart(Program **make) {
-	*make=new LOADFIX;
-}

--- a/src/dos/program_loadfix.h
+++ b/src/dos/program_loadfix.h
@@ -31,6 +31,4 @@ private:
     void AddMessages();
 };
 
-void LOADFIX_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_LOADFIX_H

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -123,7 +123,3 @@ void LOADROM::AddMessages() {
 	MSG_Add("PROGRAM_LOADROM_UNRECOGNIZED","ROM file not recognized.\n");
 	MSG_Add("PROGRAM_LOADROM_BASIC_LOADED","BASIC ROM loaded.\n");
 }
-
-void LOADROM_ProgramStart(Program **make) {
-	*make=new LOADROM;
-}

--- a/src/dos/program_loadrom.h
+++ b/src/dos/program_loadrom.h
@@ -31,6 +31,4 @@ class LOADROM final : public Program {
         void AddMessages();
 };
 
-void LOADROM_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_LOADROM_H

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -33,8 +33,3 @@ void LS::Run()
 	safe_strcpy(args, tmp.c_str());
 	first_shell->CMD_LS(args);
 }
-
-void LS_ProgramStart(Program **make)
-{
-	*make = new LS;
-}

--- a/src/dos/program_ls.h
+++ b/src/dos/program_ls.h
@@ -30,6 +30,4 @@ public:
 	void Run();
 };
 
-void LS_ProgramStart(Program **make);
-
 #endif

--- a/src/dos/program_mem.cpp
+++ b/src/dos/program_mem.cpp
@@ -109,7 +109,3 @@ void MEM::AddMessages() {
 	MSG_Add("PROGRAM_MEM_UPPER",
 	        "%10d kB free upper memory in %d blocks (largest UMB %d kB)\n");
 }
-
-void MEM_ProgramStart(Program * * make) {
-	*make=new MEM;
-}

--- a/src/dos/program_mem.h
+++ b/src/dos/program_mem.h
@@ -31,6 +31,4 @@ class MEM final : public Program {
         void AddMessages();
 };
 
-void MEM_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_MEM_H

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -460,6 +460,3 @@ void MOUNT::AddMessages() {
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_STATUS","Overlay %s on drive %c mounted.\n");
 	MSG_Add("PROGRAM_MOUNT_MOVE_Z_ERROR_1", "Can't move drive Z. Drive %c is mounted already.\n");
 }
-void MOUNT_ProgramStart(Program **make) {
-	*make=new MOUNT;
-}

--- a/src/dos/program_mount.h
+++ b/src/dos/program_mount.h
@@ -33,6 +33,4 @@ class MOUNT final : public Program {
         void AddMessages();
 };
 
-void MOUNT_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_MOUNT_H

--- a/src/dos/program_placeholder.cpp
+++ b/src/dos/program_placeholder.cpp
@@ -54,8 +54,3 @@ void PLACEHOLDER::AddMessages() {
 	
 	MSG_Add("VISIT_FOR_MORE_HELP", "Visit the following for more help:");
 }
-
-void PLACEHOLDER_ProgramStart(Program **make)
-{
-	*make = new PLACEHOLDER;
-}

--- a/src/dos/program_placeholder.h
+++ b/src/dos/program_placeholder.h
@@ -31,6 +31,4 @@ private:
 	void AddMessages();
 };
 
-void PLACEHOLDER_ProgramStart(Program **make);
-
 #endif

--- a/src/dos/program_rescan.cpp
+++ b/src/dos/program_rescan.cpp
@@ -78,7 +78,3 @@ void RESCAN::AddMessages() {
 	        "  [color=green]rescan[reset] /a\n");
 	MSG_Add("PROGRAM_RESCAN_SUCCESS","Drive re-scanned.\n");
 }
-
-void RESCAN_ProgramStart(Program **make) {
-	*make=new RESCAN;
-}

--- a/src/dos/program_rescan.h
+++ b/src/dos/program_rescan.h
@@ -31,6 +31,4 @@ private:
 	void AddMessages();
 };
 
-void RESCAN_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_RESCAN_H

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -188,8 +188,3 @@ void SERIAL::AddMessages() {
 	MSG_Add("PROGRAM_SERIAL_BAD_TYPE", "Type must be one of the following:\n");
 	MSG_Add("PROGRAM_SERIAL_INDENTED_LIST", "  %s\n");
 }
-
-void SERIAL_ProgramStart(Program **make)
-{
-	*make = new SERIAL;
-}

--- a/src/dos/program_serial.h
+++ b/src/dos/program_serial.h
@@ -35,6 +35,4 @@ private:
 	void showPort(int port);
 };
 
-void SERIAL_ProgramStart(Program **make);
-
 #endif // DOSBOX_PROGRAM_SERIAL_H

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1163,7 +1163,7 @@ public:
 		RealSetVec(0x73,ESRRoutineBase,old_73_vector);	// IRQ11
 		IO_WriteB(0xa1,IO_ReadB(0xa1)&(~8));			// enable IRQ11
 
-		PROGRAMS_MakeFile("IPXNET.COM",ProgramStart<IPXNET>);
+		PROGRAMS_MakeFile("IPXNET.COM",ProgramCreate<IPXNET>);
 	}
 
 	~IPX() {

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1064,10 +1064,6 @@ public:
 	}
 };
 
-static void IPXNET_ProgramStart(Program * * make) {
-	*make=new IPXNET;
-}
-
 Bitu IPX_ESRHandler(void) {
 	LOG_IPX("ESR: >>>>>>>>>>>>>>>" );
 	while(ESRList!=NULL) {
@@ -1167,7 +1163,7 @@ public:
 		RealSetVec(0x73,ESRRoutineBase,old_73_vector);	// IRQ11
 		IO_WriteB(0xa1,IO_ReadB(0xa1)&(~8));			// enable IRQ11
 
-		PROGRAMS_MakeFile("IPXNET.COM",IPXNET_ProgramStart);
+		PROGRAMS_MakeFile("IPXNET.COM",ProgramStart<IPXNET>);
 	}
 
 	~IPX() {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1039,8 +1039,8 @@ private:
 	}
 };
 
-std::unique_ptr<Program> MIXER_ProgramStart() {
-	return ProgramStart<MIXER>();
+std::unique_ptr<Program> MIXER_ProgramCreate() {
+	return ProgramCreate<MIXER>();
 }
 
 void MIXER_Init(Section* sec) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1039,8 +1039,8 @@ private:
 	}
 };
 
-void MIXER_ProgramStart(Program * * make) {
-	*make=new MIXER;
+std::unique_ptr<Program> MIXER_ProgramStart() {
+	return ProgramStart<MIXER>();
 }
 
 void MIXER_Init(Section* sec) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -59,9 +59,9 @@ constexpr int callback_pos = 12;
 // Persistent program containers
 using comdata_t = std::vector<uint8_t>;
 static std::vector<comdata_t> internal_progs_comdata;
-static std::vector<PROGRAMS_Main> internal_progs;
+static std::vector<PROGRAMS_Creator> internal_progs;
 
-void PROGRAMS_MakeFile(const char *name, PROGRAMS_Main p_main)
+void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
 {
 	comdata_t comdata(exe_block.begin(), exe_block.end());
 	comdata.at(callback_pos) = static_cast<uint8_t>(call_program & 0xff);
@@ -80,7 +80,7 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Main p_main)
 
 	// Register the program's main pointer
 	// NOTE: This step must come after the index is saved in the COM data
-	internal_progs.push_back(p_main);
+	internal_progs.push_back(creator);
 }
 
 static Bitu PROGRAMS_Handler(void) {
@@ -98,8 +98,8 @@ static Bitu PROGRAMS_Handler(void) {
 	HostPt writer=(HostPt)&index;
 	for (;size>0;size--) *writer++=mem_readb(reader++);
 	if (index >= internal_progs.size()) E_Exit("something is messing with the memory");
-	PROGRAMS_Main handler = internal_progs[index];
-	auto new_program = handler();
+	PROGRAMS_Creator creator = internal_progs[index];
+	auto new_program = creator();
 	new_program->Run();
 	return CBRET_NONE;
 }
@@ -805,8 +805,8 @@ void CONFIG::Run(void) {
 }
 
 
-std::unique_ptr<Program> CONFIG_ProgramStart() {
-	return ProgramStart<CONFIG>();
+std::unique_ptr<Program> CONFIG_ProgramCreate() {
+	return ProgramCreate<CONFIG>();
 }
 
 void PROGRAMS_Destroy([[maybe_unused]] Section* sec) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -80,7 +80,7 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
 
 	// Register the program's main pointer
 	// NOTE: This step must come after the index is saved in the COM data
-	internal_progs.push_back(creator);
+	internal_progs.emplace_back(creator);
 }
 
 static Bitu PROGRAMS_Handler(void) {
@@ -97,9 +97,8 @@ static Bitu PROGRAMS_Handler(void) {
 	                         256 + static_cast<uint16_t>(exec_block_size));
 	HostPt writer=(HostPt)&index;
 	for (;size>0;size--) *writer++=mem_readb(reader++);
-	if (index >= internal_progs.size()) E_Exit("something is messing with the memory");
-	PROGRAMS_Creator creator = internal_progs[index];
-	auto new_program = creator();
+	const PROGRAMS_Creator& creator = internal_progs.at(index);
+	const auto new_program = creator();
 	new_program->Run();
 	return CBRET_NONE;
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -41,8 +41,8 @@ static Bitu shellstop_handler()
 	return CBRET_STOP;
 }
 
-std::unique_ptr<Program> SHELL_ProgramStart() {
-	return ProgramStart<DOS_Shell>();
+std::unique_ptr<Program> SHELL_ProgramCreate() {
+	return ProgramCreate<DOS_Shell>();
 }
 
 char autoexec_data[autoexec_maxsize] = { 0 };
@@ -1449,7 +1449,7 @@ void SHELL_Init() {
 	reg_ip=RealOff(newcsip);
 
 	CALLBACK_Setup(call_shellstop,shellstop_handler,CB_IRET,"shell stop");
-	PROGRAMS_MakeFile("COMMAND.COM",SHELL_ProgramStart);
+	PROGRAMS_MakeFile("COMMAND.COM",SHELL_ProgramCreate);
 
 	/* Now call up the shell for the first time */
 	uint16_t psp_seg=DOS_FIRST_SHELL;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -41,13 +41,8 @@ static Bitu shellstop_handler()
 	return CBRET_STOP;
 }
 
-void SHELL_ProgramStart(Program * * make) {
-	*make = new DOS_Shell;
-}
-//Repeat it with the correct type, could do it in the function below, but this way it should be 
-//clear that if the above function is changed, this function might need a change as well.
-static void SHELL_ProgramStart_First_shell(DOS_Shell * * make) {
-	*make = new DOS_Shell;
+std::unique_ptr<Program> SHELL_ProgramStart() {
+	return ProgramStart<DOS_Shell>();
 }
 
 char autoexec_data[autoexec_maxsize] = { 0 };
@@ -1536,7 +1531,9 @@ void SHELL_Init() {
 	dos.psp(psp_seg);
 
 
-	SHELL_ProgramStart_First_shell(&first_shell);
+	// first_shell is only setup here, so may as well invoke
+	// it's constructor directly
+	first_shell = new DOS_Shell;
 	first_shell->Run();
 	delete first_shell;
 	first_shell = nullptr; // Make clear that it shouldn't be used anymore


### PR DESCRIPTION
While working on the program messages refactor, I thought the `ProgramStart` implementation could use a bit of refinement.

This PR replaces the individual `<program>_ProgramStart()` functions with a single template function. The new function returns a `std::unique_ptr`, instead of taking a double pointer parameter.

I've also switched out the raw function pointer for `std::function` instead.