### PR TITLE
Cleanup `#pragma` and `unsigned char` warnings on some platforms

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -2,7 +2,7 @@ name: Code analysis
 
 on: [push, pull_request]
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -144,7 +144,7 @@ jobs:
               -Db_lundef=false
               -Ddefault_library=static
               --wrap-mode=forcefallback
-              -Dfluidsynth:try-static-deps=true 
+              -Dfluidsynth:try-static-deps=true
             logs: clang-uasan-logs
             max_issues: 4
     steps:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -3,7 +3,7 @@ name: Config heavy
 on:
   schedule: [cron: '0 16 * * *']
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: Linux builds
 
 on: [push, pull_request]
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@ name: macOS builds
 
 on: [push, pull_request]
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -259,7 +259,7 @@ jobs:
         with:
           name: dosbox-${{ matrix.runner.arch }}
           path: build/dosbox
-        
+
       - name: Upload resources
         uses: actions/upload-artifact@v2
         with:
@@ -282,11 +282,11 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Install brew depedencies
-        run: brew install librsvg          
+        run: brew install librsvg
 
       - name: Download binaries
         uses: actions/download-artifact@v2
-      
+
       - name: Package
         run: |
           mv Resources ../
@@ -296,13 +296,13 @@ jobs:
             -f \
             "$(pwd)" \
             "$(pwd)"
-          
+
       - name: Create dmg
         run: |
           ln -s /Applications dist/
 
           codesign -s "-" dist/dosbox-staging.app --force --deep -v
-          
+
           hdiutil create \
               -volname "dosbox-staging" \
               -srcfolder dist \
@@ -322,7 +322,7 @@ jobs:
         with:
           name: dosbox-staging-macOS-universal
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
-    
+
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:
   # https://dosbox-staging.github.io/downloads/devel/

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -3,7 +3,7 @@ name: Platform builds
 on:
   schedule: [cron: '0 14 * * *']
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -28,44 +28,44 @@ jobs:
             arch: i686
             sys: MINGW32
             cc: gcc
-            max_warnings: 1
+            max_warnings: 0
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             cc: gcc
-            max_warnings: 1
+            max_warnings: 0
           - name: GCC (UCRT) x86_64
             toolchain: ucrt-
             arch: x86_64
             sys: UCRT64
             cc: gcc
-            max_warnings: 1
+            max_warnings: 0
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
             cc: clang
-            max_warnings: 5
+            max_warnings: 0
           - name: GCC +tests
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             run_tests: true
             cc: gcc
-            max_warnings: -1
+            max_warnings: 0
           - name: GCC +debugger
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             cc: gcc
-            max_warnings: 3
+            max_warnings: 0
             build_flags: -Denable_debugger=normal
-    
+
     defaults:
       run:
         shell: msys2 {0}
-    
+
     steps:
       - name: Disable git line ending conversion
         shell: powershell

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -2,7 +2,7 @@ name: MSYS2 builds
 
 on: [push, pull_request]
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v2
-      
+
       - name: Setup MSYS2 and install packages
         uses: msys2/setup-msys2@v2
         with:
@@ -95,7 +95,7 @@ jobs:
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-SDL2_net
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib
-      
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         run: |
@@ -125,13 +125,13 @@ jobs:
       - name: Setup build
         run: |
           meson setup ${{ matrix.conf.build_flags }} build
-      
+
       - name: Build
         run: |
           set -xo pipefail
           ninja -C build |& tee build.log
           ccache -s
-      
+
       - name: Run tests
         if:   matrix.conf.run_tests
         run:  meson test -C build --print-errorlogs
@@ -146,18 +146,18 @@ jobs:
     name: ${{ matrix.conf.name }} Release
     runs-on: windows-latest
     if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,jnovak,FeralChild64', github.actor) == false
-    
+
     strategy:
       matrix:
         conf:
           - name: Clang x86_64
             arch: x86_64
             sys: CLANG64
-    
+
     defaults:
       run:
         shell: msys2 {0}
-   
+
     steps:
       - name: Disable git line ending conversion
         shell: powershell
@@ -190,7 +190,7 @@ jobs:
             mingw-w64-clang-${{matrix.conf.arch}}-SDL2
             mingw-w64-clang-${{matrix.conf.arch}}-SDL2_net
             mingw-w64-clang-${{matrix.conf.arch}}-zlib
-            
+
       - name:  Prepare compiler cache
         id:    prep-ccache
         run: |
@@ -212,7 +212,7 @@ jobs:
         with:
           path: subprojects/packagecache
           key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-1
-      
+
       - name: Log environment
         run:  ./scripts/log-env.sh
 
@@ -222,24 +222,24 @@ jobs:
           git fetch --prune --unshallow
           export VERSION=$(git describe --abbrev=5)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      
+
       - name: Inject package name
         run: |
           set -x
           echo "PKG_RELEASE=dosbox-staging-windows-msys2-${{ matrix.conf.arch }}-${{ env.VERSION }}" >> $GITHUB_ENV
-           
+
       - name: Setup release build
         run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_FLAGS $BUILD_RELEASE_DIR
 
       - name: Setup debugger build
         run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
-      
+
       - name: Build release
         run: ninja -C $BUILD_RELEASE_DIR
-      
+
       - name: Build debugger
         run: ninja -C $BUILD_DEBUGGER_DIR
-            
+
       - name: Package
         run: |
           # Package the debug build to bring in required dependencies such as ncurses
@@ -249,7 +249,7 @@ jobs:
             "$PKG_RELEASE"
           mv "${PKG_RELEASE}/dosbox.exe" "${PKG_RELEASE}/dosbox_with_debugger.exe"
           install -DT "${BUILD_RELEASE_DIR}/dosbox.exe" "${PKG_RELEASE}/dosbox.exe"
-      
+
       - name: Windows Defender AV Scan
         shell: powershell
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: Windows builds
 
 on: [push, pull_request]
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/include/bitops.h
+++ b/include/bitops.h
@@ -132,7 +132,7 @@ static constexpr void check_state_type()
 
 // Ensure the bits fall within the register's type size
 template <typename T, typename B>
-static constexpr void check_width([[maybe_unused]] const T reg, const B bits)
+static constexpr void check_width([[maybe_unused]] const T reg, [[maybe_unused]] const B bits)
 {
 	check_reg_type<T>();
 	check_bits_type<B>();

--- a/include/support.h
+++ b/include/support.h
@@ -53,6 +53,15 @@
 // is in-range of a char and returns it as such.
 char int_to_char(int val);
 
+constexpr bool char_is_negative([[maybe_unused]] char c)
+{
+#if (CHAR_MIN < 0) // char is signed
+	return c < 0;
+#else // char is unsigned
+	return false;
+#endif
+}
+
 // Given a case-insensitive drive letter (a/A .. z/Z),
 // returns a zero-based index starting at 0 for drive A
 // through to 26 for drive Z.

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ summary('Build type',     get_option('buildtype'), section : 'Build Summary')
 summary('Install prefix', get_option('prefix'),    section : 'Build Summary')
 
 # extra compiler flags
-extra_flags = []
+extra_flags = ['-Wno-unknown-pragmas']
 
 # If the compiler provides std::filesystem, then we consider it modern enough
 # that we can trust it's extra helpful warnings to let us improve the code quality.

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -468,20 +468,43 @@ bool DOS_Drive_Cache::RemoveTrailingDot(char* shortname) {
 // From the Wine project
 static Bits wine_hash_short_file_name( char* name, char* buffer )
 {
-	static const char hash_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
-	static const char invalid_chars[] = { '*','?','<','>','|','"','+','=',',',';','[',']',' ','\345','~','.',0 };
-	char* p;
-	char* ext;
-	char* end = name + strlen(name);
-	char* dst;
-	unsigned short hash;
-	int i;
+	constexpr char hash_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
+
+	// returns '_' if invalid or upper case if valid.
+	auto replace_invalid = [](char c) -> char {
+		constexpr char invalid_chars[] = {'*',
+		                                  '?',
+		                                  '<',
+		                                  '>',
+		                                  '|',
+		                                  '"',
+		                                  '+',
+		                                  '=',
+		                                  ',',
+		                                  ';',
+		                                  '[',
+		                                  ']',
+		                                  ' ',
+		                                  '\345',
+		                                  '~',
+		                                  '.',
+		                                  '\0'};
+		const auto is_invalid = char_is_negative(c) ||
+		                        strchr(invalid_chars, c);
+		return is_invalid ? '_' : toupper(c);
+	};
+
+	char *p = nullptr;
+	char *ext = nullptr;
+	char *end = name + strlen(name);
+	char *dst = nullptr;
+	uint16_t hash = 0;
+	int i = 0;
 
 	// Compute the hash code of the file name
 	for (p = name, hash = 0xbeef; p < end - 1; p++)
 		hash = (hash<<3) ^ (hash>>5) ^ tolower(*p) ^ (tolower(p[1]) << 8);
 	hash = (hash<<3) ^ (hash>>5) ^ tolower(*p); // Last character
-
 
 	// Find last dot for start of the extension
 	for (p = name + 1, ext = NULL; p < end - 1; p++) if (*p == '.') ext = p;
@@ -489,11 +512,14 @@ static Bits wine_hash_short_file_name( char* name, char* buffer )
 	// Copy first 4 chars, replacing invalid chars with '_'
 	for (i = 4, p = name, dst = buffer; i > 0; i--, p++)
 	{
-		if (p == end || p == ext) break;
-		*dst++ = (*p < 0 || strchr( invalid_chars, *p ) != NULL) ? '_' : toupper(*p);
+		if (p == end || p == ext) {
+			break;
+		}
+		*dst++ = replace_invalid(*p);
 	}
 	// Pad to 5 chars with '~'
-	while (i-- >= 0) *dst++ = '~';
+	while (i-- >= 0)
+		*dst++ = '~';
 
 	// Insert hash code converted to 3 ASCII chars
 	*dst++ = hash_chars[(hash >> 10) & 0x1f];
@@ -501,11 +527,11 @@ static Bits wine_hash_short_file_name( char* name, char* buffer )
 	*dst++ = hash_chars[hash & 0x1f];
 
 	// Copy the first 3 chars of the extension (if any)
-	if (ext)
-	{
+	if (ext) {
 		*dst++ = '.';
-		for (i = 3, ext++; (i > 0) && ext < end; i--, ext++)
-			*dst++ = (*ext < 0 || strchr( invalid_chars, *ext ) != NULL) ? '_' : toupper(*ext);
+		for (i = 3, ext++; (i > 0) && ext < end; i--, ext++) {
+			*dst++ = replace_invalid(*ext);
+		}
 	}
 
 	return dst - buffer;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -666,16 +666,11 @@ static SDL_Point refine_window_size(const SDL_Point &size,
 // Logs the source and target resolution including describing scaling method
 // and pixel-aspect ratios. Note that this function deliberately doesn't use
 // any global structs to disentangle it from the existing sdl-main design.
-static void log_display_properties(int in_x,
-                                   int in_y,
-                                   const double in_par,
-                                   const SCALING_MODE scaling_mode,
-                                   const PPScale &pp_scale,
-                                   int out_x,
-                                   int out_y)
+static void log_display_properties(int in_x, int in_y, const SCALING_MODE scaling_mode,
+                                   const PPScale &pp_scale, int out_x, int out_y)
 {
 	// Sanity check expectations
-	assert(in_x > 0 && in_y > 0 && in_par > 0);
+	assert(in_x > 0 && in_y > 0);
 	assert(out_x > 0 && out_y > 0);
 
 	if (scaling_mode == SCALING_MODE::PERFECT) {
@@ -1213,9 +1208,12 @@ finish:
 
 	if (sdl.draw.has_changed) {
 		setup_presentation_mode(sdl.frame.mode);
-		log_display_properties(sdl.draw.width, sdl.draw.height,
-		                       sdl.draw.pixel_aspect, sdl.scaling_mode,
-		                       sdl.pp_scale, width, height);
+		log_display_properties(sdl.draw.width,
+		                       sdl.draw.height,
+		                       sdl.scaling_mode,
+		                       sdl.pp_scale,
+		                       width,
+		                       height);
 	}
 
 	// Force redraw after changing the window
@@ -2140,8 +2138,10 @@ void GFX_SwitchFullScreen()
 	GFX_ResetScreen();
 	FocusInput();
 	setup_presentation_mode(sdl.frame.mode);
-	log_display_properties(sdl.draw.width, sdl.draw.height,
-	                       sdl.draw.pixel_aspect, sdl.scaling_mode, sdl.pp_scale,
+	log_display_properties(sdl.draw.width,
+	                       sdl.draw.height,
+	                       sdl.scaling_mode,
+	                       sdl.pp_scale,
 	                       sdl.desktop.fullscreen ? sdl.desktop.full.width
 	                                              : sdl.desktop.window.width,
 	                       sdl.desktop.fullscreen ? sdl.desktop.full.height

--- a/src/libs/enet/include/enet.h
+++ b/src/libs/enet/include/enet.h
@@ -4902,7 +4902,7 @@ extern "C" {
             return (t);
         }
 
-        int clock_gettime(int X, struct timespec *tv) {
+        int clock_gettime(int /* X */, struct timespec *tv) {
             LARGE_INTEGER t;
             FILETIME f;
             double microseconds;


### PR DESCRIPTION
Some platforms used an unsigned type for `char`, leading to warnings like:

``` text
  ../src/dos/drive_cache.cpp: In function ‘Bits wine_hash_short_file_name(char*, char*)’:
  ../src/dos/drive_cache.cpp:493:16: warning: comparison is always false due to limited range of data type [-Wtype-limits]
    493 |   *dst++ = (*p < 0 || strchr( invalid_chars, *p ) != NULL) ? '_' : toupper(*p);
        |             ~~~^~~
  ../src/dos/drive_cache.cpp:508:19: warning: comparison is always false due to limited range of data type [-Wtype-limits]
    508 |    *dst++ = (*ext < 0 || strchr( invalid_chars, *ext ) != NULL) ? '_' : toupper(*ext);
        |              ~~~~~^~~
```
