### PR TITLE
Use gamma-correct interpolation in shaders that benefit from it

### DIFF
--- a/contrib/resources/glshaders/advinterp2x.glsl
+++ b/contrib/resources/glshaders/advinterp2x.glsl
@@ -25,6 +25,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;
 uniform vec2 rubyInputSize;

--- a/contrib/resources/glshaders/advinterp3x.glsl
+++ b/contrib/resources/glshaders/advinterp3x.glsl
@@ -25,6 +25,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;
 uniform vec2 rubyInputSize;

--- a/contrib/resources/glshaders/advmame2x.glsl
+++ b/contrib/resources/glshaders/advmame2x.glsl
@@ -25,6 +25,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;
 uniform vec2 rubyInputSize;

--- a/contrib/resources/glshaders/advmame3x.glsl
+++ b/contrib/resources/glshaders/advmame3x.glsl
@@ -25,6 +25,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;
 uniform vec2 rubyInputSize;

--- a/contrib/resources/glshaders/none.glsl
+++ b/contrib/resources/glshaders/none.glsl
@@ -22,6 +22,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 varying vec2 v_texCoord;
 #if defined(VERTEX)
 uniform vec2 rubyTextureSize;

--- a/contrib/resources/glshaders/sharp.glsl
+++ b/contrib/resources/glshaders/sharp.glsl
@@ -22,6 +22,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 varying vec2 v_texCoord;
 uniform vec2 rubyInputSize;
 uniform vec2 rubyOutputSize;


### PR DESCRIPTION
Follow-up task to https://github.com/dosbox-staging/dosbox-staging/pull/1649.

The `rgb*`, `scan*` and `tv*` shaders are best left alone -- I've tried them with gamma-correct interpolation, but they look broken as they were tuned for gamma-incorrect interpolation which gives quite different results.

We're only keeping them for backwards compatibilty, right? Because frankly they're quite bad and the lightweight/fast CRT shaders from Tyrell's repo surpass them by far.

I've also raised a PR in Tyrell's repo to add gamma-correct interpolation support to shaders that actually benefit from it (turns out it's just 3 for the same reasons)

https://github.com/tyrells/dosbox-svn-shaders/pull/10
