### PR TITLE
Don't reset screen on focus gain events

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3691,19 +3691,6 @@ bool GFX_Events()
 					sdl.draw.callback(GFX_CallBackRedraw);
 				GFX_UpdateMouseState();
 
-				// When we're fullscreen, the DOS program might
-				// change underlying draw resolutions, which can
-				// pose a problem when switching back to
-				// window-mode (beacuse the prior window-size
-				// may not longer accomodate the new draw-size).
-				// So in this case, we want to reset the screen
-				// size - but only if we're not in the middle of
-				// resizing the window (which also fires EXPOSED
-				// events).
-				if (!sdl.desktop.fullscreen &&
-					sdl.desktop.last_size_event != SDL_WINDOWEVENT_RESIZED)
-					GFX_ResetScreen();
-
 				FocusInput();
 				continue;
 


### PR DESCRIPTION
On Windows 10 when using DOSBox in windowed mode, there's some quite audible sound stuttering and display flashing when the DOSBox window regains focus. The sound stutter is basically the same stutter that happens when switching between windowed and fullscreen modes, so it's quite bad.

Now, this is a big problem for me personally because when I play oldschool grid-based RPGs, I always use windowed mode: on the left half of the screen is the DOSBox window, and on the right my map editor. Naturally, I keep alt-tabbing between the two quite vigorously as I'm mapping out a dungeon. Other emulators that I use the same way, such as WinUAE, don't have this problem.

@kcgen I saw that it was you who put this in; I've read your comment a few times and have concluded that this is not needed as `GFX_ResetScreen` is always called in `GFX_SwitchFullScreen` anyway. So why we should call it twice, I don't understand. Maybe it's required on Linux for some obscure reason, I really can't tell. All I know is that by removing this forced gfx reset on window focus & exposed events, my sound stutter and display flash issue is 100% gone. So at the very least I'd like to ifdef it out for the Windows builds.

Happy to have a further look at edge cases on my box if you tell me what to test specifically, but I couldn't notice any problems with the few games I tried.

