### PR TITLE
Refactor internal help for consistency

### DIFF
--- a/contrib/old-translations/cs/cestina.lng
+++ b/contrib/old-translations/cs/cestina.lng
@@ -123,7 +123,7 @@ ipx -- Povolit ipx pøes UDP/IP emulaci.
 :PROGRAM_CONFIG_FILE_ERROR
 Nelze otevøít soubor %s
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Nastroj Config
 
 CONFIG -writeconf [jednotka:][cesta]jmeno_souboru

--- a/contrib/old-translations/da/lng.0.74-3.DK
+++ b/contrib/old-translations/da/lng.0.74-3.DK
@@ -251,7 +251,7 @@ Mulige værdier
 Kan ikke †bne filen: %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Konfigurations-muligheder:
 CONFIG -writeconf  Skriver den aktuelle konfiguration til disk.
 CONFIG -writelang  Skriver de aktuelle sprogstrenge til disk.

--- a/contrib/old-translations/de/german-0.74.lang
+++ b/contrib/old-translations/de/german-0.74.lang
@@ -256,7 +256,7 @@ An dieser Stelle k”nnen z.B. MOUNT-Befehle stehen.
 Die Konfigurationsdatei %s kann nicht ge”ffnet werden
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Konfigurations-Werkzeug "CONFIG":
  -writeconf  Speichert die aktuelle Konfigurationsdatei.
  -writelang  Speichert die aktuelle Sprachdatei.

--- a/contrib/old-translations/fi/Finnish.lng
+++ b/contrib/old-translations/fi/Finnish.lng
@@ -115,7 +115,7 @@ T„m„n lohkon rivit ajetaan k„ynnistyksen yhteydess„.
 :PROGRAM_CONFIG_FILE_ERROR
 Tiedostoa %s ei voitu avata
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Asetusty”kalu:
 K„yt„ komentoa -writeconf tiednimi kirjoittaaksesi nykyiset asetukset.
 K„yt„ komentoa -writelang tiednimi kirjoittaaksesi nykyiset kielimerkkijonot.

--- a/contrib/old-translations/hu/magyar.lng
+++ b/contrib/old-translations/hu/magyar.lng
@@ -120,7 +120,7 @@ Az ebben a szekci¢ban l‚v” sorokat ind¡t skor mag t¢l v‚grehajtja a DOSBox.
 :PROGRAM_CONFIG_FILE_ERROR
 Nem tudom megnyitni a %s f jlt.
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 DOSBox konfigur ci¢s eszk”z:
 CONFIG -writeconf [f jl] ki¡rja a jelenlegi konfigur ci¢t a megadott f jlba.
 CONFIG -writelang [f jl] ki¡rja a jelenlegi nyelv sz”vegeit a f jlba.

--- a/contrib/old-translations/ko/korean-0.72.lang
+++ b/contrib/old-translations/ko/korean-0.72.lang
@@ -122,7 +122,7 @@ ipx -- UDP/IP 가상 구현을 거쳐 IPX를 사용합니다.
 :PROGRAM_CONFIG_FILE_ERROR
 %s 파일을 열 수 없습니다
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config 도구:
 현재의 구성을 저장하려면 "-writeconf 파일 이름"을 사용하십시오.
 현재의 언어 문자열을 저장하려면 "-writelang 파일 이름"을 사용하십시오.

--- a/contrib/old-translations/nl/DOSBox-0.74.lng
+++ b/contrib/old-translations/nl/DOSBox-0.74.lng
@@ -244,7 +244,7 @@ Mogelijke waarden
 Kan het bestand %s niet openen.
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Configuratieprogramma:
 Typ -writeconf bestandsnaam om de huidige configuratie weg te schrijven.
 Typ -writelang bestandsnaam om de huidige taaltekenreeksen weg te schrijven.

--- a/contrib/old-translations/no/DOSBox-0.63-nb_NO
+++ b/contrib/old-translations/no/DOSBox-0.63-nb_NO
@@ -101,7 +101,7 @@ Linjer i dette området vil bli kjørt ved oppstart.
 :PROGRAM_CONFIG_FILE_ERROR
 Kan ikke åpne filen %s.
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Konfigureringsverktoey:
 Bruk "-writeconf FILNAVN" for † skrive gjeldende konfigurasjon.
 Bruk "-writelang FILNAVN" for † skrive gjeldende spr†kstrenger.

--- a/contrib/old-translations/pl/polish.lng
+++ b/contrib/old-translations/pl/polish.lng
@@ -166,7 +166,7 @@ Mo¾liwe warto˜ci.
 :PROGRAM_CONFIG_FILE_ERROR
 Nie mo¾na otworzy† pliku %s
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Narz©dzie Config:
 U¾yj -writeconf nazwapliku do zapisania aktualnej konfiguracji.
 U¾yj -writelang nazwapliku do zapisania aktualnych napis¢w j©zykowych.

--- a/contrib/old-translations/pt-br/portuguese.lang
+++ b/contrib/old-translations/pt-br/portuguese.lang
@@ -243,7 +243,7 @@ Valores possíveis
 NÆo foi poss¡vel abrir o arquivo %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Ferramenta config:
 Use -writeconf nomedoarquivo para salvar as configura‡äes atuais.
 Use -writelang nomedoarquivo para salvar os textos do idioma utilizado.

--- a/contrib/old-translations/tr/Turkish.lang
+++ b/contrib/old-translations/tr/Turkish.lang
@@ -244,7 +244,7 @@ Olasç deßerler
 %s dosyasç aáçlamadç.
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Yapçlandçrma aracç:
 Geáerli yapçlandçrmayç yazdçrmak iáin -writeconf dosyaismi kullançn.
 Geáerli dil katarlarç iáin -writelang dosyaismi kullançn.

--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -573,7 +573,7 @@ Kann die Datei %s nicht îffnen
 Schreibe Konfigurationsdatei %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config Tool:
 -writeconf / -wc ohne Parameter: in die primÑr geladene Config-Datei schreiben.
 -writeconf / -wc mit Dateiname: schreibt die Datei in das Konfig-Verzeichnis.
@@ -1824,7 +1824,7 @@ Beispiel:
   [32;1mloadrom[0m [36;1mbios.rom[0m
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Konfiguriert eine Tastatur fÅr eine bestimmte Sprache.
 
 Verwendung:
@@ -1849,7 +1849,7 @@ Beispiele:
   [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 Dieses Programm ist ein Platzhalter.
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP
@@ -2179,7 +2179,7 @@ Beispiele:
 Keine IDE-Controller verfÅgbar. Das Laufwerk wird keine IDE-Emulation haben.
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Verwalte die seriellen Schnittstellen.
 Verwendungsarten:
   SERIAL /L | /LIST             Liste der aktuellen seriellen Schnittstellen.

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -619,7 +619,7 @@ Can't open file %s
 Writing config file %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config tool:
 -writeconf or -wc without parameter: write to primary loaded config file.
 -writeconf or -wc with filename: write file to config directory.
@@ -1360,7 +1360,7 @@ Codepage %i has been loaded
 Codepage %i has been loaded for layout %s
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1409,7 +1409,7 @@ None or invalid codepage file for layout %s
 
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -1452,7 +1452,7 @@ Type must be one of the following:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 This program is a placeholder
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -572,7 +572,7 @@ No se puede abrir el archivo %s
 Escribiendo archivo de configuraci¢n %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Herramienta de configuraci¢n:
 -writeconf o -wc escribe al archivo de configuraci¢n primario cargado.
 -writeconf o -wc [nombre de archivo] escribe archivo al directorio de configuraci¢n.
@@ -1304,7 +1304,7 @@ P gina de c¢digo %i ha sido cargada
 P gina de c¢digo %i ha sido cargada para distribuci¢n %s
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configura un teclado para un idioma espec¡fico.
 
 Uso:
@@ -1353,7 +1353,7 @@ Archivo de p gina de c¢digo no v lido o no existe para la distribuci¢n %s
 
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Administra los puertos serie.
 
 Modos de uso:
@@ -1395,7 +1395,7 @@ El modo debe ser uno de los siguientes:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 Este programa es un marcador de posici¢n
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -407,7 +407,7 @@ Impossible d'ouvrir le fichier %s
 êcriture du fichier de configuration %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Outil de configuration :
 -writeconf ou -wc sans paramätre : Çcrit dans le fichier de configuration primaire chargÇ.
 -writeconf ou -wc avec un nom de fichier : Çcrit le fichier dans le rÇpertoire de configuration.

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -676,7 +676,7 @@ Impossibile aprire il file %s
 Scrittura del file di configurazione in %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Strumento di configurazione:
 -writeconf o -wc senza parametro: scrive nel file di config. primario caricato.
 -writeconf o -wc [nomefile]: scrive il file nella cartella di configurazione.
@@ -1441,7 +1441,7 @@ Tabella codici %i caricata.
 Tabella codici %i caricata per il layout %s
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configura una tastiera per una lingua specifica.
 
 Utilizzo:
@@ -1490,7 +1490,7 @@ File tabella codici mancante o non valido per il layout %s.
 
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Gestisce le porte seriali.
 
 Utilizzo:
@@ -1533,7 +1533,7 @@ Il tipo deve essere uno dei seguenti:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 Questo programma Š un segnaposto.
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/pl.cp437.lng
+++ b/contrib/resources/translations/pl.cp437.lng
@@ -402,7 +402,7 @@ Nie mozna otworzyc pliku %s
 Writing config file %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config tool:
 -writeconf or -wc without parameter: write to primary loaded config file.
 -writeconf or -wc with filename: write file to config directory.

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -402,7 +402,7 @@ Nie mo¾na otworzy† pliku %s
 Writing config file %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config tool:
 -writeconf or -wc without parameter: write to primary loaded config file.
 -writeconf or -wc with filename: write file to config directory.

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -568,7 +568,7 @@ MAC-адрес карты NE2000.
 Запись конфигурационного файла %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Инструмент конфигурации:
 -writeconf [имя_файла] или -wc [имя_файла]: Сохранить текущую конфигурацию
 в основной файл конфигурации или в указанный файл в директории конфигурации.
@@ -1780,7 +1780,7 @@ Examples:
   [32;1mloadrom[0m [36;1mbios.rom[0m
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1807,7 +1807,7 @@ Examples:
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Manage the serial ports.
 
 Usage modes:
@@ -1849,7 +1849,7 @@ Mode must be one of the following:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 This program is a placeholder
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/utf-8/de.txt
+++ b/contrib/resources/translations/utf-8/de.txt
@@ -623,7 +623,7 @@ Kann die Datei %s nicht öffnen
 Schreibe Konfigurationsdatei %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config Tool:
 -writeconf / -wc ohne Parameter: in die primär geladene Config-Datei schreiben.
 -writeconf / -wc mit Dateiname: schreibt die Datei in das Konfig-Verzeichnis.
@@ -1859,7 +1859,7 @@ Beispiel:
   [32;1mloadrom[0m [36;1mbios.rom[0m
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Konfiguriert eine Tastatur für eine bestimmte Sprache.
 
 Verwendung:
@@ -1884,7 +1884,7 @@ Beispiele:
   [32;1mKEYB[0m [36;1msp[0m [37;1m850[0m
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 Dieses Programm ist ein Platzhalter.
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP
@@ -2214,7 +2214,7 @@ Beispiele:
 Keine IDE-Controller verfügbar. Das Laufwerk wird keine IDE-Emulation haben.
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Verwalte die seriellen Schnittstellen.
 Verwendungsarten:
   SERIAL /L | /LIST             Liste der aktuellen seriellen Schnittstellen.

--- a/contrib/resources/translations/utf-8/en.txt
+++ b/contrib/resources/translations/utf-8/en.txt
@@ -619,7 +619,7 @@ Can't open file %s
 Writing config file %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config tool:
 -writeconf or -wc without parameter: write to primary loaded config file.
 -writeconf or -wc with filename: write file to config directory.
@@ -1360,7 +1360,7 @@ Codepage %i has been loaded
 Codepage %i has been loaded for layout %s
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1409,7 +1409,7 @@ None or invalid codepage file for layout %s
 
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -1452,7 +1452,7 @@ Type must be one of the following:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 This program is a placeholder
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/utf-8/es.txt
+++ b/contrib/resources/translations/utf-8/es.txt
@@ -623,7 +623,7 @@ No se puede abrir el archivo %s
 Escribiendo archivo de configuración %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Herramienta de configuración:
 -writeconf o -wc escribe al archivo de configuración primario cargado.
 -writeconf o -wc [nombre de archivo] escribe archivo al directorio de configuración.
@@ -1343,7 +1343,7 @@ Página de código %i ha sido cargada
 Página de código %i ha sido cargada para distribución %s
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configura un teclado para un idioma específico.
 
 Uso:
@@ -1392,7 +1392,7 @@ Archivo de página de código no válido o no existe para la distribución %s
 
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Administra los puertos serie.
 
 Modos de uso:
@@ -1430,7 +1430,7 @@ Debes especificar un valor de puerto numérico entre 1 y %d, incluido.
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 Este programa es un marcador de posición
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/utf-8/fr.txt
+++ b/contrib/resources/translations/utf-8/fr.txt
@@ -620,7 +620,7 @@ Impossible d'ouvrir le fichier %s
 Écriture du fichier de configuration %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Outil de configuration :
 -writeconf ou -wc sans paramètre : écrit dans le fichier de configuration primaire chargé.
 -writeconf ou -wc avec un nom de fichier : écrit le fichier dans le répertoire de configuration.
@@ -1823,7 +1823,7 @@ No drive available
 No available IDE controllers. Drive will not have IDE emulation.
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1850,7 +1850,7 @@ Examples:
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -1893,7 +1893,7 @@ Type must be one of the following:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 This program is a placeholder
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -676,7 +676,7 @@ Impossibile aprire il file %s
 Scrittura del file di configurazione in %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Strumento di configurazione:
 -writeconf o -wc senza parametro: scrive nel file di config. primario caricato.
 -writeconf o -wc [nomefile]: scrive il file nella cartella di configurazione.
@@ -1441,7 +1441,7 @@ Tabella codici %i caricata.
 Tabella codici %i caricata per il layout %s
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configura una tastiera per una lingua specifica.
 
 Utilizzo:
@@ -1490,7 +1490,7 @@ File tabella codici mancante o non valido per il layout %s.
 
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Gestisce le porte seriali.
 
 Utilizzo:
@@ -1533,7 +1533,7 @@ Il tipo deve essere uno dei seguenti:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 Questo programma è un segnaposto.
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/utf-8/pl.txt
+++ b/contrib/resources/translations/utf-8/pl.txt
@@ -615,7 +615,7 @@ Nie można otworzyć pliku %s
 Writing config file %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Config tool:
 -writeconf or -wc without parameter: write to primary loaded config file.
 -writeconf or -wc with filename: write file to config directory.
@@ -1815,7 +1815,7 @@ No drive available
 No available IDE controllers. Drive will not have IDE emulation.
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1842,7 +1842,7 @@ Examples:
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -1885,7 +1885,7 @@ Type must be one of the following:
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 This program is a placeholder
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/contrib/resources/translations/utf-8/ru.txt
+++ b/contrib/resources/translations/utf-8/ru.txt
@@ -619,7 +619,7 @@ MAC-адрес карты NE2000.
 Запись конфигурационного файла %s
 
 .
-:PROGRAM_CONFIG_USAGE
+:SHELL_CMD_CONFIG_HELP_LONG
 Инструмент конфигурации:
 -writeconf [имя_файла] или -wc [имя_файла]: Сохранить текущую конфигурацию
 в основной файл конфигурации или в указанный файл в директории конфигурации.
@@ -1798,7 +1798,7 @@ Examples:
   [32;1mloadrom[0m [36;1mbios.rom[0m
 
 .
-:PROGRAM_KEYB_HELP_LONG
+:SHELL_CMD_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1825,7 +1825,7 @@ Examples:
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
-:PROGRAM_SERIAL_HELP
+:SHELL_CMD_SERIAL_HELP_LONG
 Manage the serial ports.
 
 Usage modes:
@@ -1863,7 +1863,7 @@ Must specify a numeric port value between 1 and %d, inclusive.
   %s
 
 .
-:PROGRAM_PLACEHOLDER_SHORT_HELP
+:SHELL_CMD_PLACEHOLDER_HELP
 This program is a placeholder
 .
 :PROGRAM_PLACEHOLDER_LONG_HELP

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -38,6 +38,7 @@ extern bool shutdown_requested;
 
 void MSG_Add(const char*,const char*); //add messages to the internal languagefile
 const char* MSG_Get(char const *);     //get messages from the internal languagefile
+bool MSG_Exists(const char*);
 
 class Section;
 

--- a/include/help_util.h
+++ b/include/help_util.h
@@ -1,0 +1,26 @@
+#ifndef HELP_UTIL_H
+#define HELP_UTIL_H
+
+#include <map>
+#include <string>
+
+enum class HELP_Filter : uint8_t { All, Common };
+
+enum class HELP_Category : uint8_t { Misc, File, Dosbox, Batch };
+
+enum class HELP_CmdType : uint8_t { Shell, Program };
+
+struct HELP_Detail {
+	HELP_Filter filter = HELP_Filter::All;
+	HELP_Category category = HELP_Category::Misc;
+	HELP_CmdType type = HELP_CmdType::Shell;
+	std::string name = {};
+};
+
+void HELP_AddToHelpList(const std::string &cmd_name, const HELP_Detail &detail,
+                        bool replace_existing = false);
+const std::map<const std::string, HELP_Detail> &HELP_GetHelpList();
+std::string HELP_GetShortHelp(const std::string &cmd_name);
+const char *HELP_CategoryHeading(const HELP_Category category);
+
+#endif // HELP_UTIL_H

--- a/include/programs.h
+++ b/include/programs.h
@@ -98,6 +98,11 @@ public:
 	bool HelpRequested();
 
 	static void ResetLastWrittenChar(char c);
+
+	void AddToHelpList();
+
+protected:
+	HELP_Detail help_detail {};
 };
 
 using PROGRAMS_Creator = std::function<std::unique_ptr<Program>()>;

--- a/include/programs.h
+++ b/include/programs.h
@@ -28,6 +28,7 @@
 #include "std_filesystem.h"
 
 #include "dos_inc.h"
+#include "help_util.h"
 
 #define WIKI_URL                   "https://github.com/dosbox-staging/dosbox-staging/wiki"
 #define WIKI_ADD_UTILITIES_ARTICLE WIKI_URL "/Add-Utilities"

--- a/include/programs.h
+++ b/include/programs.h
@@ -94,6 +94,7 @@ public:
 	bool SuppressWriteOut(const char *format); // prevent writing to DOS stdout
 	void InjectMissingNewline();
 	void ChangeToLongCmd();
+	bool HelpRequested();
 
 	static void ResetLastWrittenChar(char c);
 };

--- a/include/shell.h
+++ b/include/shell.h
@@ -64,9 +64,9 @@ public:
 class AutoexecEditor;
 
 struct SHELL_Cmd {
-	uint32_t flags = 0;                               // Flags about the command
 	void (DOS_Shell::*handler)(char *args) = nullptr; // Handler for this command
 	const char *help = "";                       // String with command help
+	HELP_Filter filter = HELP_Filter::Common;
 	HELP_Category category = HELP_Category::Misc;
 };
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -30,6 +30,8 @@
 #include "programs.h"
 #endif
 
+#include "help_util.h"
+
 #define CMD_MAXLINE 4096
 #define CMD_MAXCMDS 20
 #define CMD_OLDSIZE 4096
@@ -60,10 +62,18 @@ public:
 };
 
 class AutoexecEditor;
+
+struct SHELL_Cmd {
+	uint32_t flags = 0;                               // Flags about the command
+	void (DOS_Shell::*handler)(char *args) = nullptr; // Handler for this command
+	const char *help = "";                       // String with command help
+	HELP_Category category = HELP_Category::Misc;
+};
+
 class DOS_Shell : public Program {
 private:
-	enum class HELP_LIST { ALL, COMMON };
-	void PrintHelpForCommands(HELP_LIST requested_list);
+	void PrintHelpForCommands(HELP_Filter req_filter);
+	void AddShellCmdsToHelpList();
 
 	friend class AutoexecEditor;
 	std::list<std::string> l_history{};
@@ -72,6 +82,7 @@ private:
 	char *completion_start = nullptr;
 	uint16_t completion_index = 0;
 	bool exit_cmd_called = false;
+	static inline bool help_list_populated = false;
 
 public:
 
@@ -132,13 +143,6 @@ public:
 	std::shared_ptr<BatchFile> bf = {}; // shared with BatchFile.prev
 	bool echo = false;
 	bool call = false;
-};
-
-struct SHELL_Cmd {
-	uint32_t flags = 0;                               // Flags about the command
-	void (DOS_Shell::*handler)(char *args) = nullptr; // Handler for this command
-	const char *help = nullptr;                       // String with command help
-	const char *long_help = nullptr;                  // String with long help (optional)
 };
 
 /* Object to manage lines in the autoexec.bat The lines get removed from

--- a/include/shell.h
+++ b/include/shell.h
@@ -138,6 +138,7 @@ public:
 	void CMD_SHIFT(char * args);
 	void CMD_VER(char * args);
 	void CMD_LS(char *args);
+
 	/* The shell's variables */
 	uint16_t input_handle = 0;
 	std::shared_ptr<BatchFile> bf = {}; // shared with BatchFile.prev

--- a/include/shell.h
+++ b/include/shell.h
@@ -74,6 +74,7 @@ class DOS_Shell : public Program {
 private:
 	void PrintHelpForCommands(HELP_Filter req_filter);
 	void AddShellCmdsToHelpList();
+	bool WriteHelp(const std::string &command, char* args);
 
 	friend class AutoexecEditor;
 	std::list<std::string> l_history{};

--- a/src/dos/program_attrib.h
+++ b/src/dos/program_attrib.h
@@ -27,6 +27,13 @@
 
 class ATTRIB final : public Program {
 public:
+	ATTRIB()
+	{
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::File,
+		               HELP_CmdType::Program,
+		               "ATTRIB"};
+	}
 	void Run();
 };
 

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -120,8 +120,7 @@ void AUTOTYPE::Run()
 	ChangeToLongCmd();
 
 	// Usage
-	if (!cmd->GetCount() || cmd->FindExist("/?", false) ||
-	    cmd->FindExist("-?", false) || cmd->FindExist("-help", false)) {
+	if (!cmd->GetCount() || HelpRequested()) {
 		WriteOut(MSG_Get("SHELL_CMD_AUTOTYPE_HELP_LONG"));
 		return;
 	}

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -27,7 +27,14 @@
 
 class AUTOTYPE final : public Program {
 public:
-	AUTOTYPE() { AddMessages(); }
+	AUTOTYPE()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "AUTOTYPE"};
+	}
 	void Run();
 private:
 	void AddMessages();

--- a/src/dos/program_biostest.h
+++ b/src/dos/program_biostest.h
@@ -26,7 +26,14 @@
 
 class BIOSTEST final : public Program {
     public:
-        void Run(void);
+	    BIOSTEST()
+	    {
+		    help_detail = {HELP_Filter::All,
+		                   HELP_Category::Misc,
+		                   HELP_CmdType::Program,
+		                   "BIOSTEST"};
+	    }
+	void Run(void);
 };
 
 #endif // DOSBOX_PROGRAM_BIOSTEST_H

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -164,8 +164,7 @@ void BOOT::Run(void)
 		return;
 	}
 
-	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
-	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+	if (HelpRequested()) {
 		WriteOut(MSG_Get("SHELL_CMD_BOOT_HELP_LONG"));
 		return;
 	}

--- a/src/dos/program_boot.h
+++ b/src/dos/program_boot.h
@@ -26,8 +26,15 @@
 
 class BOOT final : public Program {
     public:
-        BOOT() { AddMessages(); }
-        void Run(void);
+	    BOOT()
+	    {
+		    AddMessages();
+		    help_detail = {HELP_Filter::All,
+		                   HELP_Category::Dosbox,
+		                   HELP_CmdType::Program,
+		                   "BOOT"};
+	    }
+	    void Run(void);
 
     private:
         void AddMessages();

--- a/src/dos/program_choice.h
+++ b/src/dos/program_choice.h
@@ -27,6 +27,13 @@
 
 class CHOICE final : public Program {
 public:
+	CHOICE()
+	{
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Batch,
+		               HELP_CmdType::Program,
+		               "CHOICE"};
+	}
 	void Run();
 };
 

--- a/src/dos/program_help.h
+++ b/src/dos/program_help.h
@@ -27,6 +27,13 @@
 
 class HELP final : public Program {
 public:
+	HELP()
+	{
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "HELP"};
+	}
 	void Run();
 };
 

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -484,9 +484,6 @@ void IMGMOUNT::Run(void) {
 
 void IMGMOUNT::AddMessages() {
     AddCommonMountMessages();
-    MSG_Add("SHELL_CMD_IMGMOUNT_HELP",
-	        "mounts compact disc image(s) or floppy disk image(s) to a given drive letter.\n");
-
 	MSG_Add("SHELL_CMD_IMGMOUNT_HELP_LONG",
 	        "Mount a CD-ROM, floppy, or disk image to a drive letter.\n"
 	        "\n"

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -93,8 +93,7 @@ void IMGMOUNT::Run(void) {
         return;
     }
     // Usage
-    if (cmd->FindExist("/?", false) ||
-        cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+    if (HelpRequested()) {
         WriteOut(MSG_Get("SHELL_CMD_IMGMOUNT_HELP_LONG"), PRIMARY_MOD_NAME);
         return;
     }

--- a/src/dos/program_imgmount.h
+++ b/src/dos/program_imgmount.h
@@ -24,10 +24,17 @@
 #include "programs.h"
 
 class IMGMOUNT final : public Program {
-    public:
-        IMGMOUNT() { AddMessages(); }
-        void ListImgMounts();
-        void Run();
+public:
+	IMGMOUNT()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::Common,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "IMGMOUNT"};
+	}
+	void ListImgMounts();
+	void Run();
 
     private:
         void AddMessages();

--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -48,7 +48,7 @@ void INTRO::DisplayMount(void) {
 
 void INTRO::Run(void) {
 	// Usage
-	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+	if (HelpRequested()) {
 		WriteOut(MSG_Get("SHELL_CMD_INTRO_HELP_LONG"));
 		return;
 	}

--- a/src/dos/program_intro.h
+++ b/src/dos/program_intro.h
@@ -24,12 +24,19 @@
 #include "programs.h"
 
 class INTRO final : public Program {
-    public:
-        INTRO() { AddMessages(); }
-	    void DisplayMount(void);
-        void Run(void);
+public:
+	INTRO()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::Common,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "INTRO"};
+	}
+	void DisplayMount(void);
+	void Run(void);
 
-    private:
+private:
         void AddMessages();
         void WriteOutProgramIntroSpecial();
 };

--- a/src/dos/program_keyb.cpp
+++ b/src/dos/program_keyb.cpp
@@ -25,8 +25,7 @@
 
 void KEYB::Run(void) {
 	if (cmd->FindCommand(1,temp_line)) {
-		if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
-		    cmd->FindString("?", temp_line, false)) {
+		if (HelpRequested()) {
 			WriteOut(MSG_Get("SHELL_CMD_KEYB_HELP_LONG"));
 		} else {
 			/* first parameter is layout ID */

--- a/src/dos/program_keyb.cpp
+++ b/src/dos/program_keyb.cpp
@@ -27,7 +27,7 @@ void KEYB::Run(void) {
 	if (cmd->FindCommand(1,temp_line)) {
 		if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
 		    cmd->FindString("?", temp_line, false)) {
-			WriteOut(MSG_Get("PROGRAM_KEYB_HELP_LONG"));
+			WriteOut(MSG_Get("SHELL_CMD_KEYB_HELP_LONG"));
 		} else {
 			/* first parameter is layout ID */
 			Bitu keyb_error=0;
@@ -87,7 +87,7 @@ void KEYB::Run(void) {
 void KEYB::AddMessages() {
 	MSG_Add("PROGRAM_KEYB_INFO","Codepage %i has been loaded\n");
 	MSG_Add("PROGRAM_KEYB_INFO_LAYOUT","Codepage %i has been loaded for layout %s\n");
-	MSG_Add("PROGRAM_KEYB_HELP_LONG",
+	MSG_Add("SHELL_CMD_KEYB_HELP_LONG",
 	        "Configures a keyboard for a specific language.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_keyb.h
+++ b/src/dos/program_keyb.h
@@ -25,7 +25,14 @@
 
 class KEYB final : public Program {
 public:
-	KEYB() { AddMessages(); }
+	KEYB()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "KEYB"};
+	}
 	void Run(void);
 private:
 	void AddMessages();

--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -26,8 +26,7 @@
 
 void LOADFIX::Run(void)
 {
-	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
-	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+	if (HelpRequested()) {
 		WriteOut(MSG_Get("SHELL_CMD_LOADFIX_HELP_LONG"));
 		return;
 	}

--- a/src/dos/program_loadfix.h
+++ b/src/dos/program_loadfix.h
@@ -25,7 +25,14 @@
 
 class LOADFIX final : public Program {
 public:
-    LOADFIX() { AddMessages(); }
+	LOADFIX()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "LOADFIX"};
+	}
 	void Run(void);
 private:
     void AddMessages();

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -33,7 +33,7 @@ void LOADROM::Run(void) {
         WriteOut(MSG_Get("PROGRAM_LOADROM_SPECIFY_FILE"));
         return;
     }
-    if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+    if (HelpRequested()) {
 	    WriteOut(MSG_Get("SHELL_CMD_LOADROM_HELP_LONG"));
 	    return;
     }

--- a/src/dos/program_loadrom.h
+++ b/src/dos/program_loadrom.h
@@ -25,8 +25,15 @@
 
 class LOADROM final : public Program {
     public:
-        LOADROM() { AddMessages(); }
-        void Run(void);
+	    LOADROM()
+	    {
+		    AddMessages();
+		    help_detail = {HELP_Filter::All,
+		                   HELP_Category::Dosbox,
+		                   HELP_CmdType::Program,
+		                   "LOADROM"};
+	    }
+	    void Run(void);
     private:
         void AddMessages();
 };

--- a/src/dos/program_ls.h
+++ b/src/dos/program_ls.h
@@ -27,6 +27,13 @@
 
 class LS final : public Program {
 public:
+	LS()
+	{
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::File,
+		               HELP_CmdType::Program,
+		               "LS"};
+	}
 	void Run();
 };
 

--- a/src/dos/program_mem.cpp
+++ b/src/dos/program_mem.cpp
@@ -24,8 +24,7 @@
 #include "regs.h"
 
 void MEM::Run(void) {
-	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
-	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+	if (HelpRequested()) {
 		WriteOut(MSG_Get("SHELL_CMD_MEM_HELP_LONG"));
 		return;
 	}

--- a/src/dos/program_mem.h
+++ b/src/dos/program_mem.h
@@ -24,10 +24,17 @@
 #include "programs.h"
 
 class MEM final : public Program {
-    public:
-        MEM() { AddMessages(); }
-        void Run(void);
-    private:
+public:
+	MEM()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Misc,
+		               HELP_CmdType::Program,
+		               "MEM"};
+	}
+	void Run(void);
+private:
         void AddMessages();
 };
 

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -133,6 +133,13 @@ void MOUNT::Run(void) {
 		ListMounts();
 		return;
 	}
+	// Print help if requested. Previously, help was shown as 
+	// a side effect of not being able to parse the correct 
+	// command line options.
+	if (HelpRequested()) {
+		WriteOut(MSG_Get("SHELL_CMD_MOUNT_HELP_LONG"));
+		return;
+	}
 
 	/* In secure mode don't allow people to change mount points.
 		* Neither mount nor unmount */

--- a/src/dos/program_mount.h
+++ b/src/dos/program_mount.h
@@ -25,10 +25,17 @@
 
 class MOUNT final : public Program {
     public:
-        MOUNT() { AddMessages(); }
-        void Move_Z(char new_z);
-        void ListMounts();
-        void Run();
+	    MOUNT()
+	    {
+		    AddMessages();
+		    help_detail = {HELP_Filter::Common,
+		                   HELP_Category::Dosbox,
+		                   HELP_CmdType::Program,
+		                   "MOUNT"};
+	    }
+	    void Move_Z(char new_z);
+	    void ListMounts();
+	    void Run();
     private:
         void AddMessages();
 };

--- a/src/dos/program_placeholder.cpp
+++ b/src/dos/program_placeholder.cpp
@@ -26,19 +26,19 @@ void PLACEHOLDER::Run()
 {
 	const auto command = cmd->GetFileName();
 
-	LOG_WARNING("%s: %s", command, MSG_Get("PROGRAM_PLACEHOLDER_SHORT_HELP"));
+	LOG_WARNING("%s: %s", command, MSG_Get("SHELL_CMD_PLACEHOLDER_HELP"));
 	LOG_WARNING("%s: %s", command, MSG_Get("VISIT_FOR_MORE_HELP"));
 	LOG_WARNING("%s: %s/%s", command, MSG_Get("WIKI_URL"), "Add-Utilities");
 
-	WriteOut(MSG_Get("PROGRAM_PLACEHOLDER_LONG_HELP"), command);
+	WriteOut(MSG_Get("SHELL_CMD_PLACEHOLDER_HELP_LONG"), command);
 	WriteOut_NoParsing(MSG_Get("UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE"));
 
 	result_errorcode = dos.return_code;
 }
 
 void PLACEHOLDER::AddMessages() {
-	MSG_Add("PROGRAM_PLACEHOLDER_SHORT_HELP", "This program is a placeholder");
-	MSG_Add("PROGRAM_PLACEHOLDER_LONG_HELP",
+	MSG_Add("SHELL_CMD_PLACEHOLDER_HELP", "This program is a placeholder");
+	MSG_Add("SHELL_CMD_PLACEHOLDER_HELP_LONG",
 	        "%s is only a placeholder.\n"
 	        "\nInstall a 3rd-party and give its PATH precedence.\n"
 	        "\nFor example:");

--- a/src/dos/program_placeholder.h
+++ b/src/dos/program_placeholder.h
@@ -25,7 +25,14 @@
 
 class PLACEHOLDER final : public Program {
 public:
-	PLACEHOLDER() { AddMessages(); }
+	PLACEHOLDER()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Misc,
+		               HELP_CmdType::Program,
+		               "PLACEHOLDER"};
+	}
 	void Run();
 private:
 	void AddMessages();

--- a/src/dos/program_rescan.cpp
+++ b/src/dos/program_rescan.cpp
@@ -26,8 +26,7 @@ void RESCAN::Run(void)
 
 	uint8_t drive = DOS_GetDefaultDrive();
 
-	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
-	    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+	if (HelpRequested()) {
 		WriteOut(MSG_Get("SHELL_CMD_RESCAN_HELP_LONG"));
 		return;
 	}

--- a/src/dos/program_rescan.h
+++ b/src/dos/program_rescan.h
@@ -25,7 +25,14 @@
 
 class RESCAN final : public Program {
 public:
-	RESCAN() { AddMessages(); }
+	RESCAN()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::Common,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "RESCAN"};
+	}
 	void Run(void);
 private:
 	void AddMessages();

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -63,7 +63,7 @@ void SERIAL::Run()
 	}
 
 	// Select COM port type.
-	if (cmd->GetCount() >= 1 && !cmd->FindExist("/?", false)) {
+	if (cmd->GetCount() >= 1 && !HelpRequested()) {
 		// Which COM did they want to change?
 		int port = -1;
 		cmd->FindCommand(1, temp_line);

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -153,11 +153,11 @@ void SERIAL::Run()
 	}
 
 	// Show help.
-	WriteOut(MSG_Get("PROGRAM_SERIAL_HELP"), SERIAL_MAX_PORTS);
+	WriteOut(MSG_Get("SHELL_CMD_SERIAL_HELP_LONG"), SERIAL_MAX_PORTS);
 }
 
 void SERIAL::AddMessages() {
-	MSG_Add("PROGRAM_SERIAL_HELP",
+	MSG_Add("SHELL_CMD_SERIAL_HELP_LONG",
 	        "Manages the serial ports.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_serial.h
+++ b/src/dos/program_serial.h
@@ -27,7 +27,14 @@
 
 class SERIAL final : public Program {
 public:
-	SERIAL() { AddMessages(); }
+	SERIAL()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "SERIAL"};
+	}
 	void Run();
 
 private:

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1011,7 +1011,14 @@ static void MIXER_Stop([[maybe_unused]] Section *sec)
 
 class MIXER final : public Program {
 public:
-	MIXER() { AddMessages(); }
+	MIXER()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::Common,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "MIXER"};
+	}
 
 	void MakeVolume(char * scan,float & vol0,float & vol1) {
 		Bitu w=0;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1046,8 +1046,7 @@ public:
 
 	void Run()
 	{
-		if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false) ||
-		    cmd->FindExist("-h", false) || cmd->FindExist("--help", false)) {
+		if (HelpRequested()) {
 			WriteOut(MSG_Get("SHELL_CMD_MIXER_HELP_LONG"));
 			return;
 		}

--- a/src/misc/help_util.cpp
+++ b/src/misc/help_util.cpp
@@ -1,0 +1,49 @@
+#include "dosbox.h"
+
+#include <map>
+#include <string>
+
+#include "help_util.h"
+#include "string_utils.h"
+#include "support.h"
+
+static std::map<const std::string, HELP_Detail> help_list = {};
+
+void HELP_AddToHelpList(const std::string &cmd_name, const HELP_Detail &detail,
+                        bool replace_existing)
+{
+	if (replace_existing || !contains(help_list, cmd_name)) {
+		help_list[cmd_name] = detail;
+	}
+}
+
+const std::map<const std::string, HELP_Detail> &HELP_GetHelpList()
+{
+	return help_list;
+}
+
+std::string HELP_GetShortHelp(const std::string &cmd_name)
+{
+	const std::string short_key = "SHELL_CMD_" + cmd_name + "_HELP";
+	if (MSG_Exists(short_key.c_str())) {
+		return MSG_Get(short_key.c_str());
+	}
+	const std::string long_key = "SHELL_CMD_" + cmd_name + "_HELP_LONG";
+	if (MSG_Exists(long_key.c_str())) {
+		const std::string str(MSG_Get(long_key.c_str()));
+		const auto pos = str.find('\n');
+		return str.substr(0, pos != std::string::npos ? pos + 1 : pos);
+	}
+	return "No help available\n";
+}
+
+const char *HELP_CategoryHeading(const HELP_Category category)
+{
+	switch (category) {
+	case HELP_Category::Dosbox: return "DOSBox Commands";
+	case HELP_Category::File: return "File/Directory Commands";
+	case HELP_Category::Batch: return "Batch File Commands";
+	case HELP_Category::Misc: return "Miscellaneous Commands";
+	default: return "Unknown Commands";
+	}
+}

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -5,6 +5,7 @@ libmisc_sources = [
   'ethernet_slirp.cpp',
   'fs_utils_posix.cpp',
   'fs_utils_win32.cpp',
+  'help_util.cpp',
   'messages.cpp',
   'pacer.cpp',
   'programs.cpp',

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -185,6 +185,11 @@ const char *MSG_Get(char const *requested_name)
 	return "Message not Found!\n";
 }
 
+bool MSG_Exists(const char *requested_name) 
+{
+	return contains(messages, requested_name);
+}
+
 // Write the names and messages (in the order they were added) to the given location
 bool MSG_Write(const char * location) {
 	FILE *out = fopen(location, "w+t");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -480,13 +480,13 @@ void CONFIG::Run(void) {
 			[[fallthrough]];
 
 		case P_NOMATCH:
-			WriteOut(MSG_Get("PROGRAM_CONFIG_USAGE"));
+			WriteOut(MSG_Get("SHELL_CMD_CONFIG_HELP_LONG"));
 			return;
 
 		case P_HELP: case P_HELP2: case P_HELP3: {
 			switch(pvars.size()) {
 			case 0:
-				WriteOut(MSG_Get("PROGRAM_CONFIG_USAGE"));
+				WriteOut(MSG_Get("SHELL_CMD_CONFIG_HELP_LONG"));
 				return;
 			case 1: {
 				if (!strcasecmp("sections",pvars[0].c_str())) {
@@ -522,7 +522,7 @@ void CONFIG::Run(void) {
 				break;
 			}
 			default:
-				WriteOut(MSG_Get("PROGRAM_CONFIG_USAGE"));
+				WriteOut(MSG_Get("SHELL_CMD_CONFIG_HELP_LONG"));
 				return;
 			}	
 			// if we have one value in pvars, it's a section
@@ -833,7 +833,7 @@ void PROGRAMS_Init(Section* sec) {
 	MSG_Add("PROGRAM_CONFIG_FILE_WHICH", "Writing config file %s\n");
 	
 	// help
-	MSG_Add("PROGRAM_CONFIG_USAGE",
+	MSG_Add("SHELL_CMD_CONFIG_HELP_LONG",
 	        "Config tool:\n"
 	        "-writeconf or -wc without parameter: write to primary loaded config file.\n"
 	        "-writeconf or -wc with filename: write file to config directory.\n"

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -81,6 +81,9 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
 	// Register the program's main pointer
 	// NOTE: This step must come after the index is saved in the COM data
 	internal_progs.emplace_back(creator);
+
+	// Register help for command
+	creator()->AddToHelpList();
 }
 
 static Bitu PROGRAMS_Handler(void) {
@@ -346,11 +349,23 @@ bool Program::HelpRequested() {
 	       cmd->FindExist("--help", false);
 }
 
+void Program::AddToHelpList() {
+	if (help_detail.name.size())
+		HELP_AddToHelpList(help_detail.name, help_detail);
+}
+
 bool MSG_Write(const char *);
 void restart_program(std::vector<std::string> & parameters);
 
 class CONFIG final : public Program {
 public:
+	CONFIG()
+	{
+		help_detail = {HELP_Filter::Common,
+		               HELP_Category::Dosbox,
+		               HELP_CmdType::Program,
+		               "CONFIG"};
+	}
 	void Run(void);
 private:
 	void restart(const char* useconfig);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -341,6 +341,11 @@ bool Program::SetEnv(const char * entry,const char * new_string) {
 	return true;
 }
 
+bool Program::HelpRequested() {
+	return cmd->FindExist("/?", false) || cmd->FindExist("-h", false) ||
+	       cmd->FindExist("--help", false);
+}
+
 bool MSG_Write(const char *);
 void restart_program(std::vector<std::string> & parameters);
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -172,6 +172,10 @@ DOS_Shell::DOS_Shell()
           call(false)
 {
 	AddShellCmdsToHelpList();
+	help_detail = {HELP_Filter::All,
+	               HELP_Category::Misc,
+	               HELP_CmdType::Program,
+	               "COMMAND"};
 }
 
 void DOS_Shell::GetRedirection(char *line,

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -170,7 +170,9 @@ DOS_Shell::DOS_Shell()
           bf(nullptr),
           echo(true),
           call(false)
-{}
+{
+	AddShellCmdsToHelpList();
+}
 
 void DOS_Shell::GetRedirection(char *line,
                                std::string &in_file,

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <vector>
 
+#include "ansi_code_markup.h"
 #include "bios.h"
 #include "callback.h"
 #include "control.h"
@@ -48,37 +49,37 @@
 
 // clang-format off
 static const std::map<std::string, SHELL_Cmd> shell_cmds = {
-	{ "CALL",     {1, &DOS_Shell::CMD_CALL,     "SHELL_CMD_CALL_HELP",     nullptr } },
-	{ "CD",       {0, &DOS_Shell::CMD_CHDIR,    "SHELL_CMD_CHDIR_HELP",    "SHELL_CMD_CHDIR_HELP_LONG" } },
-	{ "CHDIR",    {1, &DOS_Shell::CMD_CHDIR,    "SHELL_CMD_CHDIR_HELP",    "SHELL_CMD_CHDIR_HELP_LONG" } },
-	{ "CLS",      {0, &DOS_Shell::CMD_CLS,      "SHELL_CMD_CLS_HELP",      nullptr } },
-	{ "COPY",     {0, &DOS_Shell::CMD_COPY,     "SHELL_CMD_COPY_HELP",     nullptr } },
-	{ "DATE",     {0, &DOS_Shell::CMD_DATE,     "SHELL_CMD_DATE_HELP",     "SHELL_CMD_DATE_HELP_LONG" } },
-	{ "DEL",      {0, &DOS_Shell::CMD_DELETE,   "SHELL_CMD_DELETE_HELP",   nullptr } },
-	{ "DELETE",   {1, &DOS_Shell::CMD_DELETE,   "SHELL_CMD_DELETE_HELP",   nullptr } },
-	{ "DIR",      {0, &DOS_Shell::CMD_DIR,      "SHELL_CMD_DIR_HELP",      "SHELL_CMD_DIR_HELP_LONG" } },
-	{ "ECHO",     {1, &DOS_Shell::CMD_ECHO,     "SHELL_CMD_ECHO_HELP",     nullptr } },
-	{ "ERASE",    {1, &DOS_Shell::CMD_DELETE,   "SHELL_CMD_DELETE_HELP",   nullptr } },
-	{ "EXIT",     {0, &DOS_Shell::CMD_EXIT,     "SHELL_CMD_EXIT_HELP",     nullptr } },
-	{ "GOTO",     {1, &DOS_Shell::CMD_GOTO,     "SHELL_CMD_GOTO_HELP",     nullptr } },
-	{ "IF",       {1, &DOS_Shell::CMD_IF,       "SHELL_CMD_IF_HELP",       nullptr } },
-	{ "LH",       {1, &DOS_Shell::CMD_LOADHIGH, "SHELL_CMD_LOADHIGH_HELP", nullptr } },
-	{ "LOADHIGH", {1, &DOS_Shell::CMD_LOADHIGH, "SHELL_CMD_LOADHIGH_HELP", nullptr } },
-	{ "MD",       {0, &DOS_Shell::CMD_MKDIR,    "SHELL_CMD_MKDIR_HELP",    "SHELL_CMD_MKDIR_HELP_LONG" } },
-	{ "MKDIR",    {1, &DOS_Shell::CMD_MKDIR,    "SHELL_CMD_MKDIR_HELP",    "SHELL_CMD_MKDIR_HELP_LONG" } },
-	{ "PATH",     {1, &DOS_Shell::CMD_PATH,     "SHELL_CMD_PATH_HELP",     nullptr } },
-	{ "PAUSE",    {1, &DOS_Shell::CMD_PAUSE,    "SHELL_CMD_PAUSE_HELP",    nullptr } },
-	{ "RD",       {0, &DOS_Shell::CMD_RMDIR,    "SHELL_CMD_RMDIR_HELP",    "SHELL_CMD_RMDIR_HELP_LONG" } },
-	{ "REM",      {1, &DOS_Shell::CMD_REM,      "SHELL_CMD_REM_HELP",      "SHELL_CMD_REM_HELP_LONG" } },
-	{ "REN",      {0, &DOS_Shell::CMD_RENAME,   "SHELL_CMD_RENAME_HELP",   "SHELL_CMD_RENAME_HELP_LONG" } },
-	{ "RENAME",   {1, &DOS_Shell::CMD_RENAME,   "SHELL_CMD_RENAME_HELP",   "SHELL_CMD_RENAME_HELP_LONG" } },
-	{ "RMDIR",    {1, &DOS_Shell::CMD_RMDIR,    "SHELL_CMD_RMDIR_HELP",    "SHELL_CMD_RMDIR_HELP_LONG" } },
-	{ "SET",      {1, &DOS_Shell::CMD_SET,      "SHELL_CMD_SET_HELP",      nullptr } },
-	{ "SHIFT",    {1, &DOS_Shell::CMD_SHIFT,    "SHELL_CMD_SHIFT_HELP",    nullptr } },
-	{ "SUBST",    {1, &DOS_Shell::CMD_SUBST,    "SHELL_CMD_SUBST_HELP",    nullptr } },
-	{ "TIME",     {0, &DOS_Shell::CMD_TIME,     "SHELL_CMD_TIME_HELP",     "SHELL_CMD_TIME_HELP_LONG" } },
-	{ "TYPE",     {0, &DOS_Shell::CMD_TYPE,     "SHELL_CMD_TYPE_HELP",     "SHELL_CMD_TYPE_HELP_LONG" } },
-	{ "VER",      {0, &DOS_Shell::CMD_VER,      "SHELL_CMD_VER_HELP",      "SHELL_CMD_VER_HELP_LONG" } },
+	{ "CALL",     {1, &DOS_Shell::CMD_CALL,     "CALL",     HELP_Category::Batch } },
+	{ "CD",       {1, &DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Category::File } },
+	{ "CHDIR",    {0, &DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Category::File } },
+	{ "CLS",      {1, &DOS_Shell::CMD_CLS,      "CLS",      HELP_Category::Misc} },
+	{ "COPY",     {1, &DOS_Shell::CMD_COPY,     "COPY",     HELP_Category::File} },
+	{ "DATE",     {0, &DOS_Shell::CMD_DATE,     "DATE",     HELP_Category::Misc } },
+	{ "DEL",      {1, &DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Category::File } },
+	{ "DELETE",   {0, &DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Category::File } },
+	{ "DIR",      {1, &DOS_Shell::CMD_DIR,      "DIR",      HELP_Category::File } },
+	{ "ECHO",     {0, &DOS_Shell::CMD_ECHO,     "ECHO",     HELP_Category::Batch } },
+	{ "ERASE",    {0, &DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Category::File } },
+	{ "EXIT",     {1, &DOS_Shell::CMD_EXIT,     "EXIT",     HELP_Category::Misc } },
+	{ "GOTO",     {0, &DOS_Shell::CMD_GOTO,     "GOTO",     HELP_Category::Batch } },
+	{ "IF",       {0, &DOS_Shell::CMD_IF,       "IF",       HELP_Category::Batch } },
+	{ "LH",       {0, &DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Category::Misc } },
+	{ "LOADHIGH", {0, &DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Category::Misc } },
+	{ "MD",       {1, &DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Category::File } },
+	{ "MKDIR",    {0, &DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Category::File } },
+	{ "PATH",     {0, &DOS_Shell::CMD_PATH,     "PATH",     HELP_Category::Misc} },
+	{ "PAUSE",    {0, &DOS_Shell::CMD_PAUSE,    "PAUSE",    HELP_Category::Batch } },
+	{ "RD",       {1, &DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Category::File } },
+	{ "REM",      {0, &DOS_Shell::CMD_REM,      "REM",      HELP_Category::Batch } },
+	{ "REN",      {1, &DOS_Shell::CMD_RENAME,   "RENAME",   HELP_Category::File } },
+	{ "RENAME",   {0, &DOS_Shell::CMD_RENAME,   "RENAME",   HELP_Category::File } },
+	{ "RMDIR",    {0, &DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Category::File } },
+	{ "SET",      {0, &DOS_Shell::CMD_SET,      "SET",      HELP_Category::Misc} },
+	{ "SHIFT",    {0, &DOS_Shell::CMD_SHIFT,    "SHIFT",    HELP_Category::Batch } },
+	{ "SUBST",    {0, &DOS_Shell::CMD_SUBST,    "SUBST",    HELP_Category::File} },
+	{ "TIME",     {0, &DOS_Shell::CMD_TIME,     "TIME",     HELP_Category::Misc } },
+	{ "TYPE",     {1, &DOS_Shell::CMD_TYPE,     "TYPE",     HELP_Category::Misc } },
+	{ "VER",      {0, &DOS_Shell::CMD_VER,      "VER",      HELP_Category::Misc } },
 	};
 // clang-format on
 
@@ -252,23 +253,58 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	dos.dta(save_dta);
 }
 
-void DOS_Shell::PrintHelpForCommands(const HELP_LIST requested_list)
+void DOS_Shell::PrintHelpForCommands(HELP_Filter req_filter)
 {
 	BIOS_NROWS; // macro creates 'nrows' queried from BIOS
+	nrows--;
 	int rows_printed = 0;
-	for (const auto &s : shell_cmds) {
-		if (requested_list == HELP_LIST::COMMON && !s.second.flags)
-			continue;
-
-		WriteOut("<\033[34;1m%-8s\033[0m> %s", s.first.c_str(),
-		         MSG_Get(s.second.help));
-
-		// Do we need a page-break?
+	auto page_break_if_required = [&]() {
 		if (++rows_printed == nrows) {
 			CMD_PAUSE(empty_string);
 			rows_printed = 0;
 		}
+	};
+	for (const auto &cat : {HELP_Category::Dosbox, HELP_Category::File, HELP_Category::Batch, HELP_Category::Misc}) {
+		bool category_started = false;
+		for (const auto &s : HELP_GetHelpList()) {
+			if (req_filter == HELP_Filter::Common &&
+				s.second.filter != HELP_Filter::Common)
+				continue;
+			if (s.second.category != cat)
+				continue;
+			if (!category_started) {
+				auto header_pattern = convert_ansi_markup("[color=blue]%s[reset]\n");
+				WriteOut(header_pattern.c_str(), HELP_CategoryHeading(cat));
+				category_started = true;
+				page_break_if_required();
+			}
+			std::string name(s.first);
+			lowcase(name);
+			auto pattern = convert_ansi_markup("  [color=green]%-8s[reset] %s");
+			WriteOut(pattern.c_str(),
+					name.c_str(),
+					HELP_GetShortHelp(s.second.name).c_str());
+
+			page_break_if_required();
+		}
 	}
+}
+
+void DOS_Shell::AddShellCmdsToHelpList() {
+	// Setup Help
+	if (DOS_Shell::help_list_populated) {
+		return;
+	}
+	for (const auto &c : shell_cmds) {
+		auto filter = c.second.flags == 1 ? HELP_Filter::Common : HELP_Filter::All;
+		HELP_AddToHelpList(c.first,
+		                 HELP_Detail{filter,
+		                        c.second.category,
+		                        HELP_CmdType::Shell,
+		                        c.second.help},
+		                 true);
+	}
+	DOS_Shell::help_list_populated = true;
 }
 
 void DOS_Shell::CMD_HELP(char * args){
@@ -276,18 +312,21 @@ void DOS_Shell::CMD_HELP(char * args){
 
 	upcase(args);
 	SHELL_Cmd shell_cmd = {};
-	if (lookup_shell_cmd(args, shell_cmd)) {
-		// Print the help for the provided command
-		WriteOut("%s\n", MSG_Get(shell_cmd.help));
-		WriteOut("%s\n", shell_cmd.long_help ? MSG_Get(shell_cmd.long_help)
-		                                     : args);
+	char help_arg[] = "/?";
+	const auto& hl = HELP_GetHelpList();
+	if (contains(hl, args) && hl.at(args).type == HELP_CmdType::Program) {
+		Execute(args, help_arg);
+	} else if (lookup_shell_cmd(args, shell_cmd)) {
+		// Print help for the provided command by
+		// calling it with the '/?' arg
+		(this->*(shell_cmd.handler))(help_arg);
 	} else if (ScanCMDBool(args, "A") || ScanCMDBool(args, "ALL")) {
 		// Print help for all the commands
-		PrintHelpForCommands(HELP_LIST::ALL);
+		PrintHelpForCommands(HELP_Filter::All);
 	} else {
 		// Print help for just the common commands
 		WriteOut(MSG_Get("SHELL_CMD_HELP"));
-		PrintHelpForCommands(HELP_LIST::COMMON);
+		PrintHelpForCommands(HELP_Filter::Common);
 	}
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -49,7 +49,7 @@
 
 // clang-format off
 static const std::map<std::string, SHELL_Cmd> shell_cmds = {
-	{ "CALL",     {&DOS_Shell::CMD_CALL,     "CALL",     HELP_Filter::Common, HELP_Category::Batch } },
+	{ "CALL",     {&DOS_Shell::CMD_CALL,     "CALL",     HELP_Filter::All, HELP_Category::Batch } },
 	{ "CD",       {&DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Filter::Common, HELP_Category::File } },
 	{ "CHDIR",    {&DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Filter::All,    HELP_Category::File } },
 	{ "CLS",      {&DOS_Shell::CMD_CLS,      "CLS",      HELP_Filter::Common, HELP_Category::Misc} },
@@ -271,6 +271,11 @@ void DOS_Shell::PrintHelpForCommands(HELP_Filter req_filter)
 			rows_printed = 0;
 		}
 	};
+	auto add_blank_line = [&]() {
+		WriteOut("\n");
+		page_break_if_required();
+	};
+
 	for (const auto &cat : {HELP_Category::Dosbox, HELP_Category::File, HELP_Category::Batch, HELP_Category::Misc}) {
 		bool category_started = false;
 		for (const auto &s : HELP_GetHelpList()) {
@@ -280,6 +285,15 @@ void DOS_Shell::PrintHelpForCommands(HELP_Filter req_filter)
 			if (s.second.category != cat)
 				continue;
 			if (!category_started) {
+				// Only add a newline to the first category heading when
+				// displaying "common" help
+				if (cat == HELP_Category::Dosbox) {
+					if (req_filter == HELP_Filter::Common) {
+						add_blank_line();
+					}
+				} else {
+					add_blank_line();
+				}
 				auto header_pattern = convert_ansi_markup("[color=blue]%s[reset]\n");
 				WriteOut(header_pattern.c_str(), HELP_CategoryHeading(cat));
 				category_started = true;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -186,15 +186,22 @@ void DOS_Shell::DoCommand(char * line) {
 	WriteOut(MSG_Get("SHELL_EXECUTE_ILLEGAL_COMMAND"),cmd_buffer);
 }
 
-#define HELP(command) \
-	if (ScanCMDBool(args,"?")) { \
-		WriteOut(MSG_Get("SHELL_CMD_" command "_HELP")); \
-		const char* long_m = MSG_Get("SHELL_CMD_" command "_HELP_LONG"); \
-		WriteOut("\n"); \
-		if (strcmp("Message not Found!\n",long_m)) WriteOut(long_m); \
-		else WriteOut(command "\n"); \
-		return; \
+bool DOS_Shell::WriteHelp(const std::string &command, char *args) {
+	if (!args || !ScanCMDBool(args, "?")) {
+		return false;
 	}
+	std::string short_key("SHELL_CMD_" + command + "_HELP");
+	WriteOut("%s\n", MSG_Get(short_key.c_str()));
+	std::string long_key("SHELL_CMD_" + command + "_HELP_LONG");
+	if (MSG_Exists(long_key.c_str())) {
+		WriteOut("%s", MSG_Get(long_key.c_str()));
+	} else {
+		WriteOut("%s\n", command.c_str());
+	}
+	return true;
+}
+
+#define HELP(command) if (WriteHelp((command), args)) return
 
 void DOS_Shell::CMD_CLS(char *args)
 {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -49,37 +49,37 @@
 
 // clang-format off
 static const std::map<std::string, SHELL_Cmd> shell_cmds = {
-	{ "CALL",     {1, &DOS_Shell::CMD_CALL,     "CALL",     HELP_Category::Batch } },
-	{ "CD",       {1, &DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Category::File } },
-	{ "CHDIR",    {0, &DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Category::File } },
-	{ "CLS",      {1, &DOS_Shell::CMD_CLS,      "CLS",      HELP_Category::Misc} },
-	{ "COPY",     {1, &DOS_Shell::CMD_COPY,     "COPY",     HELP_Category::File} },
-	{ "DATE",     {0, &DOS_Shell::CMD_DATE,     "DATE",     HELP_Category::Misc } },
-	{ "DEL",      {1, &DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Category::File } },
-	{ "DELETE",   {0, &DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Category::File } },
-	{ "DIR",      {1, &DOS_Shell::CMD_DIR,      "DIR",      HELP_Category::File } },
-	{ "ECHO",     {0, &DOS_Shell::CMD_ECHO,     "ECHO",     HELP_Category::Batch } },
-	{ "ERASE",    {0, &DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Category::File } },
-	{ "EXIT",     {1, &DOS_Shell::CMD_EXIT,     "EXIT",     HELP_Category::Misc } },
-	{ "GOTO",     {0, &DOS_Shell::CMD_GOTO,     "GOTO",     HELP_Category::Batch } },
-	{ "IF",       {0, &DOS_Shell::CMD_IF,       "IF",       HELP_Category::Batch } },
-	{ "LH",       {0, &DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Category::Misc } },
-	{ "LOADHIGH", {0, &DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Category::Misc } },
-	{ "MD",       {1, &DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Category::File } },
-	{ "MKDIR",    {0, &DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Category::File } },
-	{ "PATH",     {0, &DOS_Shell::CMD_PATH,     "PATH",     HELP_Category::Misc} },
-	{ "PAUSE",    {0, &DOS_Shell::CMD_PAUSE,    "PAUSE",    HELP_Category::Batch } },
-	{ "RD",       {1, &DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Category::File } },
-	{ "REM",      {0, &DOS_Shell::CMD_REM,      "REM",      HELP_Category::Batch } },
-	{ "REN",      {1, &DOS_Shell::CMD_RENAME,   "RENAME",   HELP_Category::File } },
-	{ "RENAME",   {0, &DOS_Shell::CMD_RENAME,   "RENAME",   HELP_Category::File } },
-	{ "RMDIR",    {0, &DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Category::File } },
-	{ "SET",      {0, &DOS_Shell::CMD_SET,      "SET",      HELP_Category::Misc} },
-	{ "SHIFT",    {0, &DOS_Shell::CMD_SHIFT,    "SHIFT",    HELP_Category::Batch } },
-	{ "SUBST",    {0, &DOS_Shell::CMD_SUBST,    "SUBST",    HELP_Category::File} },
-	{ "TIME",     {0, &DOS_Shell::CMD_TIME,     "TIME",     HELP_Category::Misc } },
-	{ "TYPE",     {1, &DOS_Shell::CMD_TYPE,     "TYPE",     HELP_Category::Misc } },
-	{ "VER",      {0, &DOS_Shell::CMD_VER,      "VER",      HELP_Category::Misc } },
+	{ "CALL",     {&DOS_Shell::CMD_CALL,     "CALL",     HELP_Filter::Common, HELP_Category::Batch } },
+	{ "CD",       {&DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Filter::Common, HELP_Category::File } },
+	{ "CHDIR",    {&DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Filter::All,    HELP_Category::File } },
+	{ "CLS",      {&DOS_Shell::CMD_CLS,      "CLS",      HELP_Filter::Common, HELP_Category::Misc} },
+	{ "COPY",     {&DOS_Shell::CMD_COPY,     "COPY",     HELP_Filter::Common, HELP_Category::File} },
+	{ "DATE",     {&DOS_Shell::CMD_DATE,     "DATE",     HELP_Filter::All,    HELP_Category::Misc } },
+	{ "DEL",      {&DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Filter::Common, HELP_Category::File } },
+	{ "DELETE",   {&DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Filter::All,    HELP_Category::File } },
+	{ "DIR",      {&DOS_Shell::CMD_DIR,      "DIR",      HELP_Filter::Common, HELP_Category::File } },
+	{ "ECHO",     {&DOS_Shell::CMD_ECHO,     "ECHO",     HELP_Filter::All,    HELP_Category::Batch } },
+	{ "ERASE",    {&DOS_Shell::CMD_DELETE,   "DELETE",   HELP_Filter::All,    HELP_Category::File } },
+	{ "EXIT",     {&DOS_Shell::CMD_EXIT,     "EXIT",     HELP_Filter::Common, HELP_Category::Misc } },
+	{ "GOTO",     {&DOS_Shell::CMD_GOTO,     "GOTO",     HELP_Filter::All,    HELP_Category::Batch } },
+	{ "IF",       {&DOS_Shell::CMD_IF,       "IF",       HELP_Filter::All,    HELP_Category::Batch } },
+	{ "LH",       {&DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Filter::All,    HELP_Category::Misc } },
+	{ "LOADHIGH", {&DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Filter::All,    HELP_Category::Misc } },
+	{ "MD",       {&DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Filter::Common, HELP_Category::File } },
+	{ "MKDIR",    {&DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Filter::All,    HELP_Category::File } },
+	{ "PATH",     {&DOS_Shell::CMD_PATH,     "PATH",     HELP_Filter::All,    HELP_Category::Misc} },
+	{ "PAUSE",    {&DOS_Shell::CMD_PAUSE,    "PAUSE",    HELP_Filter::All,    HELP_Category::Batch } },
+	{ "RD",       {&DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Filter::Common, HELP_Category::File } },
+	{ "REM",      {&DOS_Shell::CMD_REM,      "REM",      HELP_Filter::All,    HELP_Category::Batch } },
+	{ "REN",      {&DOS_Shell::CMD_RENAME,   "RENAME",   HELP_Filter::Common, HELP_Category::File } },
+	{ "RENAME",   {&DOS_Shell::CMD_RENAME,   "RENAME",   HELP_Filter::All,    HELP_Category::File } },
+	{ "RMDIR",    {&DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Filter::All,    HELP_Category::File } },
+	{ "SET",      {&DOS_Shell::CMD_SET,      "SET",      HELP_Filter::All,    HELP_Category::Misc} },
+	{ "SHIFT",    {&DOS_Shell::CMD_SHIFT,    "SHIFT",    HELP_Filter::All,    HELP_Category::Batch } },
+	{ "SUBST",    {&DOS_Shell::CMD_SUBST,    "SUBST",    HELP_Filter::All,    HELP_Category::File} },
+	{ "TIME",     {&DOS_Shell::CMD_TIME,     "TIME",     HELP_Filter::All,    HELP_Category::Misc } },
+	{ "TYPE",     {&DOS_Shell::CMD_TYPE,     "TYPE",     HELP_Filter::Common, HELP_Category::Misc } },
+	{ "VER",      {&DOS_Shell::CMD_VER,      "VER",      HELP_Filter::All,    HELP_Category::Misc } },
 	};
 // clang-format on
 
@@ -303,13 +303,12 @@ void DOS_Shell::AddShellCmdsToHelpList() {
 		return;
 	}
 	for (const auto &c : shell_cmds) {
-		auto filter = c.second.flags == 1 ? HELP_Filter::Common : HELP_Filter::All;
 		HELP_AddToHelpList(c.first,
-		                 HELP_Detail{filter,
-		                        c.second.category,
-		                        HELP_CmdType::Shell,
-		                        c.second.help},
-		                 true);
+		                   HELP_Detail{c.second.filter,
+		                               c.second.category,
+		                               HELP_CmdType::Shell,
+		                               c.second.help},
+		                   true);
 	}
 	DOS_Shell::help_list_populated = true;
 }

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -513,6 +513,7 @@
     <ClCompile Include="..\src\misc\ethernet.cpp" />
     <ClCompile Include="..\src\misc\ethernet_slirp.cpp" />
     <ClCompile Include="..\src\misc\fs_utils_win32.cpp" />
+    <ClCompile Include="..\src\misc\help_util.cpp" />
     <ClCompile Include="..\src\misc\messages.cpp" />
     <ClCompile Include="..\src\misc\pacer.cpp" />
     <ClCompile Include="..\src\misc\programs.cpp" />
@@ -555,6 +556,7 @@
     <ClInclude Include="..\include\fpu.h" />
     <ClInclude Include="..\include\fs_utils.h" />
     <ClInclude Include="..\include\hardware.h" />
+    <ClInclude Include="..\include\help_util.h" />
     <ClInclude Include="..\include\inout.h" />
     <ClInclude Include="..\include\joystick.h" />
     <ClInclude Include="..\include\keyboard.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -439,6 +439,9 @@
     <ClCompile Include="..\src\misc\fs_utils_win32.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\misc\help_util.cpp">
+      <Filter>src\misc</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\main.cpp">
       <Filter>src</Filter>
     </ClCompile>
@@ -769,6 +772,9 @@
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\include\hardware.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\help_util.h">
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\include\inout.h">


### PR DESCRIPTION
This is an attempt to resolve at least some of the issues raised about the current help system in #1660 and #1685

With this PR:

- All shell commands and programs now use the same help message key format of `SHELL_CMD_<cmd>_HELP[_LONG]`
- `help <cmd>` now works for all commands, not just shell commands
- `help <cmd>` now displays the same help as `cmd /?`
- `help /all` now lists all commands, not just internal shell ones
- All commands now accept `/?`, `-h`, `--help` options to show their help. I noticed some commands also accepted `-?`, should I add this back? It seems rather strange to me.
- I have grouped commands into categories. Exact category names and what belongs in them to be determined in this PR
- I have used suggestions from @Burrito78 and @johnnovak to come up with the list displayed when invoking `help`, this can be refined further in this PR
- `help` list appearance has been tweaked to remove the ugly `<` & `>` around commands. Commands our now colored green, and lower case, to be more consistent with style in long help messages.

Actual help text changes are generally out of scope in this PR, although I did tweak `imgmount` to use the first line of it's long help instead due to space constraints.

This is a draft PR, feel free to suggest changes and improvements. We may as well get this right!