### PR TITLE
Avoid calling `AddSamples()` with zero frames

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -526,7 +526,9 @@ spx_uint32_t estimate_max_out_frames(SpeexResamplerState *resampler,
 template <class Type, bool stereo, bool signeddata, bool nativeorder>
 void MixerChannel::AddSamples(const uint16_t frames, const Type *data)
 {
+	assert(frames > 0);
 	assert(frames <= MIXER_BUFSIZE);
+
 	MIXER_LockAudioDevice();
 	last_samples_were_stereo = stereo;
 


### PR DESCRIPTION
The resampler addition included an `assert` in the following function that calculates the maximum size of the vector into which we're resampling:

``` c++
spx_uint32_t estimate_max_out_frames(SpeexResamplerState *resampler,
                                     const spx_uint32_t in_frames)
{
	assert(in_frames);
```

I went through all the AddSamples calls, and found that of them, only the CD Audio could call `AddSamples` with a zero value (which could have happened at the end of a track). 

So this PR re-arranges those checks to avoid that empty `AddSamples` call).

We could have used "if (!frames) return;", but I preferred this route. 