### PR TITLE
Add crossfeed support for headphone listening

### DIFF
--- a/include/ansi_code_markup.h
+++ b/include/ansi_code_markup.h
@@ -31,4 +31,12 @@
  */
 std::string convert_ansi_markup(const char* str);
 
+/*!
+ * \brief Convert marked up strings to strings with ANSI codes
+ * 
+ * \param str 
+ * \return std::string 
+ */
+std::string convert_ansi_markup(std::string &str);
+
 #endif // DOSBOX_ANSI_CODE_MARKUP_H

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -131,6 +131,7 @@ public:
 	void ConfigureZeroOrderHoldUpsampler(const uint16_t target_freq);
 
 	void SetCrossfeedStrength(const float strength);
+	float GetCrossfeedStrength();
 
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
 	void AddSamples(uint16_t len, const Type *data);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -266,4 +266,7 @@ mixer_channel_t MIXER_FindChannel(const char *name);
 void PCSPEAKER_SetCounter(int cntr, int mode);
 void PCSPEAKER_SetType(int mode);
 
+// Mixer configuration and initialization
+void MIXER_AddConfigSection(const config_ptr_t &conf);
+
 #endif

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -130,6 +130,8 @@ public:
 	void EnableZeroOrderHoldUpsampler(const bool enabled = true);
 	void ConfigureZeroOrderHoldUpsampler(const uint16_t target_freq);
 
+	void SetCrossfeedStrength(const float strength);
+
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
 	void AddSamples(uint16_t len, const Type *data);
 
@@ -172,6 +174,8 @@ private:
 
 	void ConfigureResampler();
 	void UpdateZOHUpsamplerState();
+
+	AudioFrame ApplyCrossfeed(const AudioFrame &frame) const;
 
 	std::string name = {};
 	Envelope envelope;
@@ -236,6 +240,12 @@ private:
 		FilterState state = FilterState::Off;
 		std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
 	} filter = {};
+
+	struct {
+		float strength = 0.0f;
+		float pan_left = 0.0f;
+		float pan_right = 0.0f;
+	} crossfeed = {};
 };
 using mixer_channel_t = std::shared_ptr<MixerChannel>;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -214,8 +214,6 @@ private:
 
 	static constexpr StereoLine STEREO = {LEFT, RIGHT};
 	static constexpr StereoLine REVERSE = {RIGHT, LEFT};
-	static constexpr StereoLine LEFT_MONO = {LEFT, LEFT};
-	static constexpr StereoLine RIGHT_MONO = {RIGHT, RIGHT};
 
 	// User-configurable that defines how the channel's stereo line maps
 	// into the mixer.

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -491,7 +491,11 @@ CDROM_Interface_Image::CDROM_Interface_Image(uint8_t sub_unit)
 		if (!player.channel) {
 			const auto mixer_callback = std::bind(&CDROM_Interface_Image::CDAudioCallBack,
 			                                      this, std::placeholders::_1);
-			player.channel = MIXER_AddChannel(mixer_callback, 0, "CDAUDIO");
+			player.channel = MIXER_AddChannel(mixer_callback,
+			                                  0,
+			                                  "CDAUDIO",
+			                                  {ChannelFeature::Stereo});
+
 			player.channel->Enable(false); // only enabled during playback periods
 		}
 #ifdef DEBUG

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -82,7 +82,6 @@ void FPU_Init(Section*);
 
 void DMA_Init(Section*);
 
-void MIXER_Init(Section*);
 void HARDWARE_Init(Section*);
 
 #if defined(PCI_FUNCTIONALITY_ENABLED)
@@ -425,10 +424,6 @@ void DOSBOX_Init() {
 	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
-	// Some frequently used option sets
-	const char *rates[] = {"44100", "48000", "32000", "22050", "16000",
-	                       "11025", "8000",  "49716", 0};
-
 	/* Setup all the different modules making up DOSBox */
 	const char *machines[] = {"hercules",      "cga",
 	                          "cga_mono",      "tandy",
@@ -659,42 +654,8 @@ void DOSBOX_Init() {
 #endif
 
 
-	// Mixer defaults
-	constexpr int default_mixer_rate = 48000;
-#if defined(WIN32)
-	// Long stading known-good defaults for Windows
-	constexpr int default_mixer_blocksize = 1024;
-	constexpr int default_mixer_prebuffer = 25;
-	constexpr bool default_mixer_allow_negotiate = false;
-
-#else
-	// Non-Windows platforms tollerate slightly lower latency
-	constexpr int default_mixer_blocksize = 512;
-	constexpr int default_mixer_prebuffer = 20;
-	constexpr bool default_mixer_allow_negotiate = true;
-#endif
-
-	secprop=control->AddSection_prop("mixer",&MIXER_Init);
-	Pbool = secprop->Add_bool("nosound", only_at_start, false);
-	Pbool->Set_help("Enable silent mode, sound is still emulated though.");
-
-	Pint = secprop->Add_int("rate", only_at_start, default_mixer_rate);
-	Pint->Set_values(rates);
-	Pint->Set_help("Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.");
-
-	const char *blocksizes[] = {
-		 "1024", "2048", "4096", "8192", "512", "256", "128", 0};
-	Pint = secprop->Add_int("blocksize", only_at_start, default_mixer_blocksize);
-	Pint->Set_values(blocksizes);
-	Pint->Set_help("Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.");
-
-	Pint = secprop->Add_int("prebuffer",only_at_start, default_mixer_prebuffer);
-	Pint->SetMinMax(0,100);
-	Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
-
-	Pbool = secprop->Add_bool("negotiate", only_at_start,
-	                          default_mixer_allow_negotiate);
-	Pbool->Set_help("Let the system audio driver negotiate (possibly) better rate and blocksize settings.");
+	// Configure mixer
+	MIXER_AddConfigSection(control);
 
 	secprop = control->AddSection_prop("midi", &MIDI_Init, true);
 	secprop->AddInitFunction(&MPU401_Init, true);

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -853,7 +853,12 @@ Module::Module(Section *configuration)
 
 	ctrl.mixer = section->Get_bool("sbmixer");
 
-	mixerChan = MIXER_AddChannel(OPL_CallBack, 0, "FM");
+	std::set channel_features = {ChannelFeature::ReverbSend, ChannelFeature::ChorusSend};
+	if (oplmode != OPL_opl2)
+		channel_features.emplace(ChannelFeature::Stereo);
+
+	mixerChan = MIXER_AddChannel(OPL_CallBack, 0, "FM", channel_features);
+
 	//Used to be 2.0, which was measured to be too high. Exact value depends on card/clone.
 	mixerChan->SetScale( 1.5f );  
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -396,7 +396,11 @@ void DISNEY_Init(Section* sec) {
 		return;
 
 	// Setup the mixer callback
-	disney.chan = MIXER_AddChannel(DISNEY_CallBack, 10000, "DISNEY");
+	disney.chan = MIXER_AddChannel(DISNEY_CallBack,
+	                               10000,
+	                               "DISNEY",
+	                               {ChannelFeature::ReverbSend,
+	                                ChannelFeature::ChorusSend});
 
 	// Register port handlers for 8-bit IO
 	disney.write_handler.Install(DISNEY_BASE, disney_write, io_width_t::byte, 3);

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -81,7 +81,13 @@ void GameBlaster::Open(const int port_choice, const std::string_view card_choice
 	// Setup the mixer and level controls
 	const auto audio_callback = std::bind(&GameBlaster::AudioCallback, this, _1);
 	const auto level_callback = std::bind(&GameBlaster::LevelCallback, this, _1);
-	channel = MIXER_AddChannel(audio_callback, 0, CardName());
+	channel = MIXER_AddChannel(audio_callback,
+	                           0,
+	                           CardName(),
+	                           {ChannelFeature::Stereo,
+	                            ChannelFeature::ReverbSend,
+	                            ChannelFeature::ChorusSend});
+
 	channel->RegisterLevelCallBack(level_callback);
 
 	// Calculate rates and ratio based on the mixer's rate

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -602,7 +602,12 @@ Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
 	// Register the Audio and DMA channels
 	const auto mixer_callback = std::bind(&Gus::AudioCallback, this,
 	                                      std::placeholders::_1);
-	audio_channel = MIXER_AddChannel(mixer_callback, 0, "GUS");
+	audio_channel = MIXER_AddChannel(mixer_callback,
+	                                 0,
+	                                 "GUS",
+	                                 {ChannelFeature::Stereo,
+	                                  ChannelFeature::ReverbSend,
+	                                  ChannelFeature::ChorusSend});
 
 	// Let the mixer command adjust the GUS's internal amplitude level's
 	const auto set_level_callback = std::bind(&Gus::SetLevelCallback, this, _1);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -78,7 +78,12 @@ void Innovation::Open(const std::string &model_choice,
 	// Setup the mixer and get it's sampling rate
 	using namespace std::placeholders;
 	const auto mixer_callback = std::bind(&Innovation::MixerCallBack, this, _1);
-	const auto mixer_channel = MIXER_AddChannel(mixer_callback, 0, "INNOVATION");
+	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
+	                                            0,
+	                                            "INNOVATION",
+	                                            {ChannelFeature::ReverbSend,
+	                                             ChannelFeature::ChorusSend});
+
 	const auto frame_rate_hz = mixer_channel->GetSampleRate();
 	frame_rate_per_ms = frame_rate_hz / 1000.0;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1234,27 +1234,27 @@ private:
 
 	void ShowMixerStatus()
 	{
-		auto show_channel = [this](const char *name,
+		auto show_channel = [this](const std::string name,
 		                           const float vol0,
 		                           const float vol1,
 		                           const int rate,
-		                           const char *mode,
-		                           const char *xfeed) {
+		                           const std::string mode,
+		                           const std::string xfeed) {
 			WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s\n",
-			         name,
+			         name.c_str(),
 			         static_cast<double>(vol0 * 100),
 			         static_cast<double>(vol1 * 100),
 			         static_cast<double>(20 * log(vol0) / log(10.0f)),
 			         static_cast<double>(20 * log(vol1) / log(10.0f)),
 			         rate,
-			         mode,
-			         xfeed);
+			         mode.c_str(),
+			         xfeed.c_str());
 		};
 
 		WriteOut(convert_ansi_markup("[color=white]Channel     Volume    Volume(dB)   Rate(Hz)  Mode     Xfeed[reset]\n")
 		                 .c_str());
 
-		show_channel(convert_ansi_markup("[color=cyan]MASTER[reset]").c_str(),
+		show_channel(convert_ansi_markup("[color=cyan]MASTER[reset]"),
 		             mixer.mastervol[0],
 		             mixer.mastervol[1],
 		             mixer.sample_rate,
@@ -1282,12 +1282,12 @@ private:
 								? chan->DescribeLineout()
 								: "Mono";
 
-			show_channel(convert_ansi_markup(s.c_str()).c_str(),
+			show_channel(convert_ansi_markup(s.c_str()),
 			             chan->volmain[0],
 			             chan->volmain[1],
 			             chan->GetSampleRate(),
-			             mode.c_str(),
-			             xfeed.c_str());
+			             mode,
+			             xfeed);
 		}
 	}
 };

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1132,9 +1132,9 @@ public:
 			} else if (is_master) {
 				std::lock_guard lock(mixer.channel_mutex);
 
-				MakeVolume(const_cast<char *>(arg.c_str()),
-				           mixer.mastervol[0],
-				           mixer.mastervol[1]);
+				ParseVolume(const_cast<char *>(arg.c_str()),
+				            mixer.mastervol[0],
+				            mixer.mastervol[1]);
 
 			// Adjust settings of a regular non-master channel
 			} else if (curr_chan) {
@@ -1151,9 +1151,9 @@ public:
 
 				float left_vol = 0;
 				float right_vol = 0;
-				MakeVolume(const_cast<char *>(arg.c_str()),
-				           left_vol,
-				           right_vol);
+				ParseVolume(const_cast<char *>(arg.c_str()),
+				            left_vol,
+				            right_vol);
 
 				curr_chan->SetVolume(left_vol, right_vol);
 				curr_chan->UpdateVolume();
@@ -1194,7 +1194,7 @@ private:
 		        "  [color=green]mixer[reset] [color=white]x30[reset] [color=cyan]fm[reset] [color=white]150[reset] [color=cyan]sb[reset] [color=white]x10[reset]");
 	}
 
-	void MakeVolume(char *scan, float &vol0, float &vol1)
+	void ParseVolume(char *scan, float &vol0, float &vol1)
 	{
 		Bitu w = 0;
 		bool db = (toupper(*scan) == 'D');

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1091,11 +1091,10 @@ public:
 			WriteOut(MSG_Get("SHELL_CMD_MIXER_HELP_LONG"));
 			return;
 		}
-		if(cmd->FindExist("/LISTMIDI")) {
+		if (cmd->FindExist("/LISTMIDI")) {
 			ListMidi();
 			return;
 		}
-
 		auto noShow = cmd->FindExist("/NOSHOW", true);
 
 		std::vector<std::string> args = {};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1219,11 +1219,16 @@ public:
 				
 				auto s = std::string("[color=cyan]") + name +
 				         std::string("[reset]");
+
+				auto mode = chan->HasFeature(ChannelFeature::Stereo)
+				                    ? chan->DescribeLineout()
+				                    : "Mono";
+
 				ShowSettings(convert_ansi_markup(s.c_str()).c_str(),
 				             chan->volmain[0],
 				             chan->volmain[1],
 				             chan->GetSampleRate(),
-				             chan->DescribeLineout().c_str(),
+				             mode.c_str(),
 				             xfeed.c_str());
 			}
 		}
@@ -1231,16 +1236,16 @@ public:
 
 private:
 	void ShowSettings(const char *name, const float vol0, const float vol1,
-	                  const int rate, const char *lineout_mode, const char *xfeed)
+	                  const int rate, const char *mode, const char *xfeed)
 	{
-		WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %s     %3s\n",
+		WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s\n",
 		         name,
 		         static_cast<double>(vol0 * 100),
 		         static_cast<double>(vol1 * 100),
 		         static_cast<double>(20 * log(vol0) / log(10.0f)),
 		         static_cast<double>(20 * log(vol1) / log(10.0f)),
 		         rate,
-		         lineout_mode,
+		         mode,
 		         xfeed);
 	}
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1194,35 +1194,42 @@ private:
 		        "  [color=green]mixer[reset] [color=white]x30[reset] [color=cyan]fm[reset] [color=white]150[reset] [color=cyan]sb[reset] [color=white]x10[reset]");
 	}
 
-	void MakeVolume(char * scan,float & vol0,float & vol1) {
-		Bitu w=0;
-		bool db=(toupper(*scan)=='D');
-		if (db) scan++;
+	void MakeVolume(char *scan, float &vol0, float &vol1)
+	{
+		Bitu w = 0;
+		bool db = (toupper(*scan) == 'D');
+		if (db)
+			scan++;
+
 		while (*scan) {
-			if (*scan==':') {
-				++scan;w=1;
+			if (*scan == ':') {
+				++scan;
+				w = 1;
 			}
-			char * before=scan;
-			float val=(float)strtod(scan,&scan);
-			if (before==scan) {
-				++scan;continue;
+			char *before = scan;
+			float val = (float)strtod(scan, &scan);
+			if (before == scan) {
+				++scan;
+				continue;
 			}
-			if (!db) val/=100;
+			if (!db)
+				val /= 100;
 			else
 				val = powf(10.0f, val / 20.0f);
-			if (val<0) val=1.0f;
+			if (val < 0)
+				val = 1.0f;
 
 			const auto min_vol = powf(10.0f, -99.99f / 20.0f);
 			constexpr auto max_vol = 99.99f;
 			val = clamp(val, min_vol, max_vol);
 
-			if (!w) {
-				vol0=val;
-			} else {
-				vol1=val;
-			}
+			if (!w)
+				vol0 = val;
+			else
+				vol1 = val;
 		}
-		if (!w) vol1=vol0;
+		if (!w)
+			vol1 = vol0;
 	}
 
 	void ShowMixerStatus()

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1421,19 +1421,18 @@ void MIXER_CloseAudioDevice()
 
 void init_mixer_dosbox_settings(Section_prop &sec_prop)
 {
-	// Mixer defaults
-	constexpr int default_mixer_rate = 48000;
+	constexpr int default_rate = 48000;
 #if defined(WIN32)
 	// Long stading known-good defaults for Windows
-	constexpr int default_mixer_blocksize = 1024;
-	constexpr int default_mixer_prebuffer = 25;
-	constexpr bool default_mixer_allow_negotiate = false;
+	constexpr int default_blocksize = 1024;
+	constexpr int default_prebuffer = 25;
+	constexpr bool default_allow_negotiate = false;
 
 #else
 	// Non-Windows platforms tollerate slightly lower latency
-	constexpr int default_mixer_blocksize = 512;
-	constexpr int default_mixer_prebuffer = 20;
-	constexpr bool default_mixer_allow_negotiate = true;
+	constexpr int default_blocksize = 512;
+	constexpr int default_prebuffer = 20;
+	constexpr bool default_allow_negotiate = true;
 #endif
 
 	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
@@ -1443,7 +1442,7 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	assert(bool_prop);
 	bool_prop->Set_help("Enable silent mode, sound is still emulated though.");
 
-	auto int_prop = sec_prop.Add_int("rate", only_at_start, default_mixer_rate);
+	auto int_prop = sec_prop.Add_int("rate", only_at_start, default_rate);
 	assert(int_prop);
 	const char *rates[] = {
 	        "8000", "11025", "16000", "22050", "32000", "44100", "48000", "49716", 0};
@@ -1453,19 +1452,19 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 
 	const char *blocksizes[] = {"128", "256", "512", "1024", "2048", "4096", "8192", 0};
 
-	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_mixer_blocksize);
+	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_blocksize);
 	int_prop->Set_values(blocksizes);
 	int_prop->Set_help(
 	        "Mixer block size; larger values might help with sound stuttering but sound will also be more lagged.");
 
-	int_prop = sec_prop.Add_int("prebuffer", only_at_start, default_mixer_prebuffer);
+	int_prop = sec_prop.Add_int("prebuffer", only_at_start, default_prebuffer);
 	int_prop->SetMinMax(0, 100);
 	int_prop->Set_help(
 	        "How many milliseconds of sound to render on top of the blocksize; larger values might help with sound stuttering but sound will also be more lagged.");
 
 	bool_prop = sec_prop.Add_bool("negotiate",
 	                              only_at_start,
-	                              default_mixer_allow_negotiate);
+	                              default_allow_negotiate);
 	bool_prop->Set_help(
 	        "Let the system audio driver negotiate (possibly) better rate and blocksize settings.");
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1410,6 +1410,7 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 #endif
 
 	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
+	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	auto bool_prop = sec_prop.Add_bool("nosound", only_at_start, false);
 	assert(bool_prop);
@@ -1440,8 +1441,16 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	                              default_mixer_allow_negotiate);
 	bool_prop->Set_help(
 	        "Let the system audio driver negotiate (possibly) better rate and blocksize settings.");
-}
 
+	auto string_prop = sec_prop.Add_string("crossfeed", when_idle, "off");
+	string_prop->Set_help(
+	        "Set crossfeed globally on all stereo channels for headphone listening:\n"
+	        "  off:         No crossfeed (default).\n"
+	        "  on:          Enable crossfeed (at strength 30).\n"
+	        "  <strength>:  Set crossfeed strength from 0 to 100, where 0 means no crossfeed (off)\n"
+	        "               and 100 full crossfeed (effectively turning stereo content into mono).\n"
+	        "Note: You can set per-channel crossfeed via mixer commands.");
+}
 
 void MIXER_AddConfigSection(const config_ptr_t &conf)
 {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1101,9 +1101,27 @@ public:
 
 	void ShowMixerStatus()
 	{
+		auto show_channel = [this](const char *name,
+		                           const float vol0,
+		                           const float vol1,
+		                           const int rate,
+		                           const char *mode,
+		                           const char *xfeed) {
+			WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s\n",
+			         name,
+			         static_cast<double>(vol0 * 100),
+			         static_cast<double>(vol1 * 100),
+			         static_cast<double>(20 * log(vol0) / log(10.0f)),
+			         static_cast<double>(20 * log(vol1) / log(10.0f)),
+			         rate,
+			         mode,
+			         xfeed);
+		};
+
 		WriteOut(convert_ansi_markup("[color=white]Channel     Volume    Volume(dB)   Rate(Hz)  Mode     Xfeed[reset]\n")
 		                 .c_str());
-		ShowSettings(convert_ansi_markup("[color=cyan]MASTER[reset]").c_str(),
+
+		show_channel(convert_ansi_markup("[color=cyan]MASTER[reset]").c_str(),
 		             mixer.mastervol[0],
 		             mixer.mastervol[1],
 		             mixer.sample_rate,
@@ -1131,12 +1149,12 @@ public:
 								? chan->DescribeLineout()
 								: "Mono";
 
-			ShowSettings(convert_ansi_markup(s.c_str()).c_str(),
-						 chan->volmain[0],
-						 chan->volmain[1],
-						 chan->GetSampleRate(),
-						 mode.c_str(),
-						 xfeed.c_str());
+			show_channel(convert_ansi_markup(s.c_str()).c_str(),
+			             chan->volmain[0],
+			             chan->volmain[1],
+			             chan->GetSampleRate(),
+			             mode.c_str(),
+			             xfeed.c_str());
 		}
 	}
 
@@ -1237,20 +1255,6 @@ public:
 	}
 
 private:
-	void ShowSettings(const char *name, const float vol0, const float vol1,
-	                  const int rate, const char *mode, const char *xfeed)
-	{
-		WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s\n",
-		         name,
-		         static_cast<double>(vol0 * 100),
-		         static_cast<double>(vol1 * 100),
-		         static_cast<double>(20 * log(vol0) / log(10.0f)),
-		         static_cast<double>(20 * log(vol1) / log(10.0f)),
-		         rate,
-		         mode,
-		         xfeed);
-	}
-
 	void AddMessages()
 	{
 		MSG_Add("SHELL_CMD_MIXER_HELP_LONG",

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1159,15 +1159,15 @@ public:
 					continue;
 				}
 
-				// Only setting the volume is allowed for the
-				// MASTER channel
+			// Only setting the volume is allowed for the
+			// MASTER channel
 			} else if (is_master) {
 				std::lock_guard lock(mixer.channel_mutex);
 				ParseVolume(arg,
 				            mixer.mastervol[0],
 				            mixer.mastervol[1]);
 
-				// Adjust settings of a regular non-master channel
+			// Adjust settings of a regular non-master channel
 			} else if (curr_chan) {
 				std::lock_guard lock(mixer.channel_mutex);
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -151,6 +151,8 @@ static void set_global_channel_settings(mixer_channel_t channel)
 	if (crossfeed_pref == "on") {
 		constexpr auto default_crossfeed_strength = 0.3f;
 		crossfeed = default_crossfeed_strength;
+	} else if (crossfeed_pref == "off") {
+		crossfeed = 0.0f;
 	} else {
 		const auto cf = to_finite<double>(crossfeed_pref);
 		if (std::isfinite(cf) && cf >= 0.0 && cf <= 100.0) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -154,7 +154,7 @@ static void set_global_channel_settings(mixer_channel_t channel)
 	} else if (crossfeed_pref == "off") {
 		crossfeed = 0.0f;
 	} else {
-		const auto cf = to_finite<double>(crossfeed_pref);
+		const auto cf = to_finite<float>(crossfeed_pref);
 		if (std::isfinite(cf) && cf >= 0.0 && cf <= 100.0) {
 			crossfeed = cf / 100.0f;
 		} else {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1235,17 +1235,17 @@ private:
 	void ShowMixerStatus()
 	{
 		auto show_channel = [this](const std::string name,
-		                           const float vol0,
-		                           const float vol1,
+		                           const float vol_left,
+		                           const float vol_right,
 		                           const int rate,
 		                           const std::string mode,
 		                           const std::string xfeed) {
 			WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s\n",
 			         name.c_str(),
-			         static_cast<double>(vol0 * 100),
-			         static_cast<double>(vol1 * 100),
-			         static_cast<double>(20 * log(vol0) / log(10.0f)),
-			         static_cast<double>(20 * log(vol1) / log(10.0f)),
+			         vol_left * 100.0f,
+			         vol_right * 100.0f,
+			         20.0f * log(vol_left) / log(10.0f),
+			         20.0f * log(vol_right) / log(10.0f),
 			         rate,
 			         mode.c_str(),
 			         xfeed.c_str());
@@ -1268,21 +1268,21 @@ private:
 			if (chan->HasFeature(ChannelFeature::Stereo)) {
 				if (chan->GetCrossfeedStrength() > 0.0f) {
 					xfeed = std::to_string(static_cast<uint8_t>(
-							round(chan->GetCrossfeedStrength() *
-								  100)));
+					        round(chan->GetCrossfeedStrength() *
+					              100)));
 				} else {
 					xfeed = "off";
 				}
 			}
 
-			auto s = std::string("[color=cyan]") + name +
-					 std::string("[reset]");
+			auto channel_name = std::string("[color=cyan]") + name +
+			                    std::string("[reset]");
 
 			auto mode = chan->HasFeature(ChannelFeature::Stereo)
-								? chan->DescribeLineout()
-								: "Mono";
+			                    ? chan->DescribeLineout()
+			                    : "Mono";
 
-			show_channel(convert_ansi_markup(s.c_str()),
+			show_channel(convert_ansi_markup(channel_name),
 			             chan->volmain[0],
 			             chan->volmain[1],
 			             chan->GetSampleRate(),

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1423,7 +1423,7 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	int_prop->Set_help(
 	        "Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.");
 
-	const char *blocksizes[] = {"1024", "2048", "4096", "8192", "512", "256", "128", 0};
+	const char *blocksizes[] = {"128", "256", "512", "1024", "2048", "4096", "8192", 0};
 
 	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_mixer_blocksize);
 	int_prop->Set_values(blocksizes);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1135,7 +1135,7 @@ public:
 			}
 
 			auto parse_prefixed_percentage = [](const char prefix,
-			                                    const std::string s,
+			                                    const std::string &s,
 			                                    float &value_out) {
 				if (s.size() > 1 && s[0] == prefix) {
 					float p = 0.0f;
@@ -1223,7 +1223,7 @@ private:
 		        "  [color=green]mixer[reset] [color=white]x30[reset] [color=cyan]fm[reset] [color=white]150[reset] [color=cyan]sb[reset] [color=white]x10[reset]");
 	}
 
-	void ParseVolume(const std::string s, float &vol_left, float &vol_right)
+	void ParseVolume(const std::string &s, float &vol_left, float &vol_right)
 	{
 		auto vol_parts = split(s, ':');
 		if (vol_parts.empty())
@@ -1262,12 +1262,12 @@ private:
 
 	void ShowMixerStatus()
 	{
-		auto show_channel = [this](const std::string name,
+		auto show_channel = [this](const std::string &name,
 		                           const float vol_left,
 		                           const float vol_right,
 		                           const int rate,
-		                           const std::string mode,
-		                           const std::string xfeed) {
+		                           const std::string &mode,
+		                           const std::string &xfeed) {
 			WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s\n",
 			         name.c_str(),
 			         vol_left * 100.0f,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -820,10 +820,6 @@ std::string MixerChannel::DescribeLineout() const
 		return "Stereo";
 	if (output_map == REVERSE)
 		return "Reverse";
-	if (output_map == LEFT_MONO)
-		return "LeftMono";
-	if (output_map == RIGHT_MONO)
-		return "RightMono";
 
 	// Output_map is programmtically set (not directly assigned from user
 	// data), so we can assert.
@@ -842,10 +838,6 @@ bool MixerChannel::ChangeLineoutMap(std::string choice)
 		output_map = STEREO;
 	else if (choice == "reverse")
 		output_map = REVERSE;
-	else if (choice == "leftmono")
-		output_map = LEFT_MONO;
-	else if (choice == "rightmono")
-		output_map = RIGHT_MONO;
 	else
 		return false;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <map>
 #include <mutex>
+#include <set>
 #include <sys/types.h>
 
 #if defined (WIN32)
@@ -117,20 +118,29 @@ static struct mixer_t mixer = {};
 
 uint8_t MixTemp[MIXER_BUFSIZE] = {};
 
-MixerChannel::MixerChannel(MIXER_Handler _handler, const char *_name)
+MixerChannel::MixerChannel(MIXER_Handler _handler, const char *_name,
+                           const std::set<ChannelFeature> &_features)
         : name(_name),
           envelope(_name),
-          handler(_handler)
+          handler(_handler),
+          features(_features)
 {}
+
+bool MixerChannel::HasFeature(ChannelFeature feature)
+{
+	return features.find(feature) != features.end();
+}
 
 bool MixerChannel::StereoLine::operator==(const StereoLine &other) const
 {
 	return left == other.left && right == other.right;
 }
 
-mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const int freq, const char *name)
+mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const int freq,
+                                 const char *name,
+                                 const std::set<ChannelFeature> &features)
 {
-	auto chan = std::make_shared<MixerChannel>(handler, name);
+	auto chan = std::make_shared<MixerChannel>(handler, name, features);
 	chan->SetSampleRate(freq);
 	chan->SetScale(1.0);
 	chan->SetVolume(1, 1);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1160,8 +1160,8 @@ public:
 
 				float value = 0.0f;
 				if (parse_prefixed_percentage('X', arg, value)) {
-					for (auto &[name, chan] : mixer.channels) {
-						chan->SetCrossfeedStrength(value);
+					for (auto &it : mixer.channels) {
+						it.second->SetCrossfeedStrength(value);
 					}
 					continue;
 				}
@@ -1211,18 +1211,23 @@ public:
 		{
 			std::lock_guard lock(mixer.channel_mutex);
 
-			for (auto &[name, channel] : mixer.channels) {
-				auto xfeed = channel->GetCrossfeedStrength() > 0.0f
-				                     ? std::to_string(static_cast<uint8_t>(
-				                               round(channel->GetCrossfeedStrength() *
-				                                     100)))
-				                     : "off";
+			for (auto &[name, chan] : mixer.channels) {
+				std::string xfeed = "-";
+				if (chan->HasFeature(ChannelFeature::Stereo)) {
+					if (chan->GetCrossfeedStrength() > 0.0f) {
+						xfeed = std::to_string(static_cast<uint8_t>(
+						        round(chan->GetCrossfeedStrength() *
+						              100)));
+					} else {
+						xfeed = "off";
+					}
+				}
 
 				ShowSettings(name.c_str(),
-				             channel->volmain[0],
-				             channel->volmain[1],
-				             channel->GetSampleRate(),
-				             channel->DescribeLineout().c_str(),
+				             chan->volmain[0],
+				             chan->volmain[1],
+				             chan->GetSampleRate(),
+				             chan->DescribeLineout().c_str(),
 				             xfeed.c_str());
 			}
 		}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -129,7 +129,7 @@ MixerChannel::MixerChannel(MIXER_Handler _handler, const char *_name,
           features(_features)
 {}
 
-bool MixerChannel::HasFeature(ChannelFeature feature)
+bool MixerChannel::HasFeature(const ChannelFeature feature)
 {
 	return features.find(feature) != features.end();
 }
@@ -656,10 +656,10 @@ AudioFrame MixerChannel::ApplyCrossfeed(const AudioFrame &frame) const
 	// Pan mono sample using -6dB linear pan law in the stereo field
 	// pan: 0.0 = left, 0.5 = center, 1.0 = right
 	auto pan = [](const float sample, const float pan) -> AudioFrame {
-		return {(1 - pan) * sample, pan * sample};
+		return {(1.0f - pan) * sample, pan * sample};
 	};
-	auto a = pan(frame.left, crossfeed.pan_left);
-	auto b = pan(frame.right, crossfeed.pan_right);
+	const auto a = pan(frame.left, crossfeed.pan_left);
+	const auto b = pan(frame.right, crossfeed.pan_right);
 	return {a.left + b.left, a.right + b.right};
 }
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1251,6 +1251,8 @@ private:
 			         xfeed.c_str());
 		};
 
+		std::lock_guard lock(mixer.channel_mutex);
+
 		WriteOut(convert_ansi_markup("[color=white]Channel     Volume    Volume(dB)   Rate(Hz)  Mode     Xfeed[reset]\n")
 		                 .c_str());
 
@@ -1260,8 +1262,6 @@ private:
 		             mixer.sample_rate,
 		             "Stereo",
 		             "-");
-
-		std::lock_guard lock(mixer.channel_mutex);
 
 		for (auto &[name, chan] : mixer.channels) {
 			std::string xfeed = "-";

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -439,6 +439,9 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	assert(strength >= 0.0f);
 	assert(strength <= 1.0f);
 
+	if (!HasFeature(ChannelFeature::Stereo))
+		return;
+
 	crossfeed.strength = strength;
 
 	// map [0, 1] range to [0.5, 0]
@@ -829,6 +832,9 @@ std::string MixerChannel::DescribeLineout() const
 
 bool MixerChannel::ChangeLineoutMap(std::string choice)
 {
+	if (!HasFeature(ChannelFeature::Stereo))
+		return false;
+
 	lowcase(choice);
 
 	if (choice == "stereo")

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1194,7 +1194,7 @@ public:
 		if (noShow)
 			return;
 
-		WriteOut(convert_ansi_markup("[color=white]Channel     Volume    Volume(dB)   Rate(Hz)  Lineout  Xfeed[reset]\n")
+		WriteOut(convert_ansi_markup("[color=white]Channel     Volume    Volume(dB)   Rate(Hz)  Mode     Xfeed[reset]\n")
 		                 .c_str());
 		ShowSettings(convert_ansi_markup("[color=cyan]MASTER[reset]").c_str(),
 		             mixer.mastervol[0],

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1417,8 +1417,8 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 
 	auto int_prop = sec_prop.Add_int("rate", only_at_start, default_mixer_rate);
 	assert(int_prop);
-	const char *rates[] = {"44100", "48000", "32000", "22050", "16000",
-	                       "11025", "8000",  "49716", 0};
+	const char *rates[] = {
+	        "8000", "11025", "16000", "22050", "32000", "44100", "48000", "49716", 0};
 	int_prop->Set_values(rates);
 	int_prop->Set_help(
 	        "Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.");
@@ -1436,11 +1436,12 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "How many milliseconds of data to keep on top of the blocksize.");
 
 	bool_prop = sec_prop.Add_bool("negotiate",
-	                               only_at_start,
-	                               default_mixer_allow_negotiate);
+	                              only_at_start,
+	                              default_mixer_allow_negotiate);
 	bool_prop->Set_help(
 	        "Let the system audio driver negotiate (possibly) better rate and blocksize settings.");
 }
+
 
 void MIXER_AddConfigSection(const config_ptr_t &conf)
 {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1104,18 +1104,23 @@ public:
 		auto is_master = false;
 
 		for (auto &arg : args) {
+			// Does this argument set the target channel of subsequent
+			// commands?
 			upcase(arg);
 			if (arg == "MASTER") {
 				curr_chan = nullptr;
 				is_master = true;
 				continue;
+			} else {
+				auto chan = MIXER_FindChannel(arg.c_str());
+				if (chan) {
+					curr_chan = chan;
+					is_master = false;
+					continue;
+				}
 			}
-			auto chan = MIXER_FindChannel(arg.c_str());
-			if (chan) {
-				curr_chan = chan;
-				is_master = false;
-				continue;
-			}
+
+			// Only setting the volume is allowed for the MASTER channel
 			if (is_master) {
 				std::lock_guard lock(mixer.channel_mutex);
 
@@ -1123,6 +1128,7 @@ public:
 				           mixer.mastervol[0],
 				           mixer.mastervol[1]);
 
+			// Adjust settings of a regular non-master channel
 			} else if (curr_chan) {
 				std::lock_guard lock(mixer.channel_mutex);
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1428,12 +1428,12 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_mixer_blocksize);
 	int_prop->Set_values(blocksizes);
 	int_prop->Set_help(
-	        "Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.");
+	        "Mixer block size; larger values might help with sound stuttering but sound will also be more lagged.");
 
 	int_prop = sec_prop.Add_int("prebuffer", only_at_start, default_mixer_prebuffer);
 	int_prop->SetMinMax(0, 100);
 	int_prop->Set_help(
-	        "How many milliseconds of data to keep on top of the blocksize.");
+	        "How many milliseconds of sound to render on top of the blocksize; larger values might help with sound stuttering but sound will also be more lagged.");
 
 	bool_prop = sec_prop.Add_bool("negotiate",
 	                              only_at_start,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1423,13 +1423,13 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 {
 	constexpr int default_rate = 48000;
 #if defined(WIN32)
-	// Long stading known-good defaults for Windows
+	// Longstanding known-good defaults for Windows
 	constexpr int default_blocksize = 1024;
 	constexpr int default_prebuffer = 25;
 	constexpr bool default_allow_negotiate = false;
 
 #else
-	// Non-Windows platforms tollerate slightly lower latency
+	// Non-Windows platforms tolerate slightly lower latency
 	constexpr int default_blocksize = 512;
 	constexpr int default_prebuffer = 20;
 	constexpr bool default_allow_negotiate = true;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1229,33 +1229,33 @@ private:
 
 	void ListMidi() { MIDI_ListAll(this); }
 
-	void AddMessages() 
+	void AddMessages()
 	{
 		MSG_Add("SHELL_CMD_MIXER_HELP_LONG",
 		        "Displays or changes the sound mixer settings.\n"
 		        "\n"
 		        "Usage:\n"
-		        "  [color=green]mixer[reset] [color=cyan]CHANNEL[reset] [color=white]VOLUME[reset] [/noshow]\n"
-		        "  [color=green]mixer[reset] [color=cyan]CHANNEL[reset] [color=white]LINEOUT[reset] [/noshow]\n"
+		        "  [color=green]mixer[reset] [color=cyan][CHANNEL][reset] [color=white]COMMANDS[reset] [/noshow]\n"
 		        "  [color=green]mixer[reset] [/listmidi]\n"
 		        "\n"
 		        "Where:\n"
-		        "  [color=cyan]CHANNEL[reset] is the sound channel to change the settings of.\n"
-		        "  [color=white]VOLUME[reset]  is either a percentage value between 0.0 and 100.0,\n"
-		        "          or a decibel value prefixed with [color=white]d[reset] (e.g. d-7.5).\n"
-		        "  [color=white]LINEOUT[reset] sets the channel's line out mode to one of the following:\n"
-		        "          [color=white]stereo, reverse, leftmono, rightmono[reset]"
+		        "  [color=cyan]CHANNEL[reset]  is the sound channel to change the settings of.\n"
+		        "  [color=white]COMMANDS[reset] is one or more of the following commands:\n"
+		        "    Volume:    [color=white]0[reset] to [color=white]100[reset], or decibel value prefixed with [color=white]d[reset] (e.g. [color=white]d-7.5[reset])\n"
+		        "               use [color=white]L:R[reset] to set the left and right side separately (e.g. [color=white]10:20[reset])\n"
+		        "    Lineout:   [color=white]stereo[reset], [color=white]reverse[reset] (for stereo channels only)\n"
+		        "    Crossfeed: [color=white]x0[reset] to [color=white]x100[reset]\n"
 		        "\n"
 		        "Notes:\n"
 		        "  Running [color=green]mixer[reset] without an argument shows the current mixer settings.\n"
-		        "  You can view the list of available MIDI devices with /listmidi.\n"
 		        "  You may change the settings of more than one channel in a single command.\n"
+		        "  If channel is unspecified, you can set crossfeed, reverb or chorus globally.\n"
+		        "  You can view the list of available MIDI devices with /listmidi.\n"
 		        "  The /noshow option applies the changes without showing the mixer settings.\n"
 		        "\n"
 		        "Examples:\n"
-		        "  [color=green]mixer[reset]\n"
 		        "  [color=green]mixer[reset] [color=cyan]cdda[reset] [color=white]50[reset] [color=cyan]sb[reset] [color=white]reverse[reset] /noshow\n"
-		        "  [color=green]mixer[reset] /listmidi");
+		        "  [color=green]mixer[reset] [color=white]x30[reset] [color=cyan]fm[reset] [color=white]150[reset] [color=cyan]sb[reset] [color=white]x10[reset]");
 	}
 };
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1132,6 +1132,27 @@ public:
 			} else if (curr_chan) {
 				std::lock_guard lock(mixer.channel_mutex);
 
+				auto parse_prefixed_percentage = [](const char prefix,
+				                                    const std::string s,
+				                                    float &value_out) {
+					if (s.size() > 1 && s[0] == prefix) {
+						float p = 0.0f;
+						if (sscanf(s.c_str() + 1, "%f", &p)) {
+							value_out = clamp(p / 100,
+							                  0.0f,
+							                  1.0f);
+							return true;
+						}
+					}
+					return false;
+				};
+
+				float value = 0.0f;
+				if (parse_prefixed_percentage('X', arg, value)) {
+					curr_chan->SetCrossfeedStrength(value);
+					continue;
+				}
+
 				if (curr_chan->ChangeLineoutMap(arg))
 					continue;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -46,6 +46,7 @@
 #include <SDL.h>
 #include <speex/speex_resampler.h>
 
+#include "ansi_code_markup.h"
 #include "mem.h"
 #include "pic.h"
 #include "mixer.h"
@@ -1201,8 +1202,9 @@ public:
 		if (noShow)
 			return;
 
-		WriteOut("Channel     Volume    Volume(dB)   Rate(Hz)  Lineout  Xfeed\n");
-		ShowSettings("MASTER",
+		WriteOut(convert_ansi_markup("[color=white]Channel     Volume    Volume(dB)   Rate(Hz)  Lineout  Xfeed[reset]\n")
+		                 .c_str());
+		ShowSettings(convert_ansi_markup("[color=cyan]MASTER[reset]").c_str(),
 		             mixer.mastervol[0],
 		             mixer.mastervol[1],
 		             mixer.sample_rate,
@@ -1222,8 +1224,10 @@ public:
 						xfeed = "off";
 					}
 				}
-
-				ShowSettings(name.c_str(),
+				
+				auto s = std::string("[color=cyan]") + name +
+				         std::string("[reset]");
+				ShowSettings(convert_ansi_markup(s.c_str()).c_str(),
 				             chan->volmain[0],
 				             chan->volmain[1],
 				             chan->GetSampleRate(),
@@ -1237,7 +1241,7 @@ private:
 	void ShowSettings(const char *name, const float vol0, const float vol1,
 	                  const int rate, const char *lineout_mode, const char *xfeed)
 	{
-		WriteOut("%-10s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %s     %3s\n",
+		WriteOut("%-21s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %s     %3s\n",
 		         name,
 		         static_cast<double>(vol0 * 100),
 		         static_cast<double>(vol1 * 100),

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1147,7 +1147,7 @@ public:
 			return;
 		}
 		if (cmd->FindExist("/LISTMIDI")) {
-			ListMidi();
+			MIDI_ListAll(this);
 			return;
 		}
 		auto showStatus = !cmd->FindExist("/NOSHOW", true);
@@ -1250,8 +1250,6 @@ private:
 		         mode,
 		         xfeed);
 	}
-
-	void ListMidi() { MIDI_ListAll(this); }
 
 	void AddMessages()
 	{

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -489,7 +489,11 @@ public:
 
 		spkr.min_tr = (PIT_TICK_RATE + spkr.rate / 2 - 1) / (spkr.rate / 2);
 		/* Register the sound channel */
-		spkr.chan = MIXER_AddChannel(&PCSPEAKER_CallBack, spkr.rate, "SPKR");
+		spkr.chan = MIXER_AddChannel(&PCSPEAKER_CallBack,
+		                             spkr.rate,
+		                             "SPKR",
+		                             {ChannelFeature::ReverbSend,
+		                              ChannelFeature::ChorusSend});
 		spkr.chan->SetPeakAmplitude(
 		        static_cast<uint32_t>(AMPLITUDE_POSITIVE));
 	}

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -121,7 +121,11 @@ static void maybe_suspend_channel(const size_t last_used_on, mixer_channel_t &ch
 Ps1Dac::Ps1Dac()
 {
 	const auto callback = std::bind(&Ps1Dac::Update, this, _1);
-	channel = MIXER_AddChannel(callback, 0, "PS1DAC");
+	channel = MIXER_AddChannel(callback,
+	                           0,
+	                           "PS1DAC",
+	                           {ChannelFeature::ReverbSend,
+	                            ChannelFeature::ChorusSend});
 
 	// Register DAC per-port read handlers
 	read_handlers[0].Install(0x02F, std::bind(&Ps1Dac::ReadPresencePort02F, this, _1, _2), io_width_t::byte);
@@ -363,7 +367,11 @@ private:
 Ps1Synth::Ps1Synth() : device(machine_config(), 0, 0, clock_rate_hz)
 {
 	const auto callback = std::bind(&Ps1Synth::Update, this, _1);
-	channel = MIXER_AddChannel(callback, 0, "PS1");
+	channel = MIXER_AddChannel(callback,
+	                           0,
+	                           "PS1",
+	                           {ChannelFeature::ReverbSend,
+	                            ChannelFeature::ChorusSend});
 
 	const auto generate_sound = std::bind(&Ps1Synth::WriteSoundGeneratorPort205, this, _1, _2, _3);
 	write_handler.Install(0x205, generate_sound, io_width_t::byte);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1980,7 +1980,13 @@ public:
 		}
 		if (sb.type==SBT_NONE || sb.type==SBT_GB) return;
 
-		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack, 22050, "SB");
+		std::set channel_features = {ChannelFeature::ReverbSend,
+		                             ChannelFeature::ChorusSend};
+
+		if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2 || sb.type == SBT_16)
+			channel_features.insert(ChannelFeature::Stereo);
+
+		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack, 22050, "SB", channel_features);
 		configure_sb_filter();
 
 		sb.dsp.state=DSP_S_NORMAL;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -197,7 +197,12 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile)
 
 	// Run the audio channel at the mixer's native rate
 	const auto callback = std::bind(&TandyDAC::AudioCallback, this, _1);
-	channel = MIXER_AddChannel(callback, 0, "TANDYDAC");
+	channel = MIXER_AddChannel(callback,
+	                           0,
+	                           "TANDYDAC",
+	                           {ChannelFeature::ReverbSend,
+	                            ChannelFeature::ChorusSend});
+
 	sample_rate = channel->GetSampleRate();
 
 	// Register DAC per-port read handlers
@@ -392,7 +397,11 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 
 	// Run the audio channel at the mixer's native rate
 	const auto callback = std::bind(&TandyPSG::AudioCallback, this, _1);
-	channel = MIXER_AddChannel(callback, 0, "TANDY");
+	channel = MIXER_AddChannel(callback,
+	                           0,
+	                           "TANDY",
+	                           {ChannelFeature::ReverbSend,
+	                            ChannelFeature::ChorusSend});
 
 	// Setup the resampler
 	const auto sample_rate = channel->GetSampleRate();

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -29,6 +29,7 @@
 
 #include <SDL.h>
 
+#include "ansi_code_markup.h"
 #include "cross.h"
 #include "hardware.h"
 #include "mapper.h"
@@ -318,7 +319,9 @@ void MIDI_ListAll(Program *caller)
 		if (name == "none")
 			continue;
 
-		caller->WriteOut("%s:\n", name.c_str());
+		caller->WriteOut(
+		        convert_ansi_markup("[color=white]%s:[reset]\n").c_str(),
+		        name.c_str());
 
 		const auto err = handler->ListAll(caller);
 		if (err == MIDI_RC::ERR_DEVICE_NOT_CONFIGURED)

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -223,7 +223,11 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	// Setup the mixer channel and level callback
 	const auto mixer_callback = std::bind(&MidiHandlerFluidsynth::MixerCallBack,
 	                                      this, std::placeholders::_1);
-	const auto mixer_channel = MIXER_AddChannel(mixer_callback, 0, "FSYNTH");
+
+	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
+	                                            0,
+	                                            "FSYNTH",
+	                                            {ChannelFeature::Stereo});
 
 	const auto set_mixer_level = std::bind(&MidiHandlerFluidsynth::SetMixerLevel,
 	                                       this, std::placeholders::_1);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -531,7 +531,11 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 
 	const auto mixer_callback = std::bind(&MidiHandler_mt32::MixerCallBack,
 	                                      this, std::placeholders::_1);
-	const auto mixer_channel = MIXER_AddChannel(mixer_callback, 0, "MT32");
+
+	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
+	                                            0,
+	                                            "MT32",
+	                                            {ChannelFeature::Stereo});
 
 	// Let the mixer command adjust the MT32's services gain-level
 	const auto set_mixer_level = std::bind(&MidiHandler_mt32::SetMixerLevel,


### PR DESCRIPTION
This implements https://github.com/dosbox-staging/dosbox-staging/issues/1678

Main changes:

- Add crossfeed support via a single config param ("easy mode") and mixer commands ("advanced mode")
- Remove the `leftmono` and `rightmono` lineout modes as they interfered with the crossfeed concept in weird ways
- The mixer now shows whether a channel is mono or stereo
- Make the mixer output more colourful
- Lots of other small code-level improvements

### Mixer help text

![mixer-help](https://user-images.githubusercontent.com/698770/171399765-a6c5d55c-f8d2-496e-abd9-fc124c4ed41c.png)

### Mixer output

![mixer-status](https://user-images.githubusercontent.com/698770/171399927-45cad1dc-875d-4434-9c81-59f17201823d.png)

![mixer-listmidi](https://user-images.githubusercontent.com/698770/171399898-0ca71e4f-7fb4-4eb6-9bdf-d0ade70aa47f.png)

--------

For reference, here's how the final mixer help text will look like with chorus & reverb added:

![mixer-help-final](https://user-images.githubusercontent.com/698770/171399786-3b214976-10b2-4af2-9ee2-ac5cf9843d6d.png)


