### PR TITLE
Fix invalid ANSI erase codes

### DIFF
--- a/src/misc/ansi_code_markup.cpp
+++ b/src/misc/ansi_code_markup.cpp
@@ -285,7 +285,7 @@ static const char *get_ansi_code(const Tag &tag)
 		break;
 
 	case Tag::Group::Erasers:
-		safe_sprintf(ansi_code, "\033[%d%sm", ansi_num,
+		safe_sprintf(ansi_code, "\033[%d%s", ansi_num,
 		             type == Tag::Type::EraseL ? "K" : "J");
 		break;
 

--- a/tests/ansi_code_markup_tests.cpp
+++ b/tests/ansi_code_markup_tests.cpp
@@ -194,37 +194,37 @@ TEST(ConvertAnsiMarkup, ColorUppercaseValue)
 TEST(ConvertAnsiMarkup, EraseScreenBeginning)
 {
     const char str[] = "erase [erases=begin] to beginning of screen.";
-    EXPECT_EQ(convert_ansi_markup(str), "erase \033[1Jm to beginning of screen.");
+    EXPECT_EQ(convert_ansi_markup(str), "erase \033[1J to beginning of screen.");
 }
 
 TEST(ConvertAnsiMarkup, EraseScreenEnd)
 {
     const char str[] = "erase [erases=end] to end of screen.";
-    EXPECT_EQ(convert_ansi_markup(str), "erase \033[0Jm to end of screen.");
+    EXPECT_EQ(convert_ansi_markup(str), "erase \033[0J to end of screen.");
 }
 
 TEST(ConvertAnsiMarkup, EraseScreenEntire)
 {
     const char str[] = "[erases=entire] Erase entire screen.";
-    EXPECT_EQ(convert_ansi_markup(str), "\033[2Jm Erase entire screen.");
+    EXPECT_EQ(convert_ansi_markup(str), "\033[2J Erase entire screen.");
 }
 
 TEST(ConvertAnsiMarkup, EraseLineBeginning)
 {
     const char str[] = "erase [erasel=begin] to beginning of line.";
-    EXPECT_EQ(convert_ansi_markup(str), "erase \033[1Km to beginning of line.");
+    EXPECT_EQ(convert_ansi_markup(str), "erase \033[1K to beginning of line.");
 }
 
 TEST(ConvertAnsiMarkup, EraseLineEnd)
 {
     const char str[] = "erase [erasel=end] to end of line.";
-    EXPECT_EQ(convert_ansi_markup(str), "erase \033[0Km to end of line.");
+    EXPECT_EQ(convert_ansi_markup(str), "erase \033[0K to end of line.");
 }
 
 TEST(ConvertAnsiMarkup, EraseLineEntire)
 {
     const char str[] = "[erasel=entire] Erase entire line.";
-    EXPECT_EQ(convert_ansi_markup(str), "\033[2Km Erase entire line.");
+    EXPECT_EQ(convert_ansi_markup(str), "\033[2K Erase entire line.");
 }
 
 TEST(ConvertAnsiMarkup, Whitespace)


### PR DESCRIPTION
Does what it says on the tin. For some reason, I had an `m` suffix on the erase ANSI codes, where they shouldn't.