### PR TITLE
Make help category headings translatable

### DIFF
--- a/include/help_util.h
+++ b/include/help_util.h
@@ -22,5 +22,6 @@ void HELP_AddToHelpList(const std::string &cmd_name, const HELP_Detail &detail,
 const std::map<const std::string, HELP_Detail> &HELP_GetHelpList();
 std::string HELP_GetShortHelp(const std::string &cmd_name);
 const char *HELP_CategoryHeading(const HELP_Category category);
+void HELP_AddMessages();
 
 #endif // HELP_UTIL_H

--- a/src/misc/help_util.cpp
+++ b/src/misc/help_util.cpp
@@ -40,10 +40,19 @@ std::string HELP_GetShortHelp(const std::string &cmd_name)
 const char *HELP_CategoryHeading(const HELP_Category category)
 {
 	switch (category) {
-	case HELP_Category::Dosbox: return "DOSBox Commands";
-	case HELP_Category::File: return "File/Directory Commands";
-	case HELP_Category::Batch: return "Batch File Commands";
-	case HELP_Category::Misc: return "Miscellaneous Commands";
-	default: return "Unknown Commands";
+	case HELP_Category::Dosbox: return MSG_Get("HELP_UTIL_CATEGORY_DOSBOX");
+	case HELP_Category::File: return MSG_Get("HELP_UTIL_CATEGORY_FILE");
+	case HELP_Category::Batch: return MSG_Get("HELP_UTIL_CATEGORY_BATCH");
+	case HELP_Category::Misc: return MSG_Get("HELP_UTIL_CATEGORY_MISC");
+	default: return MSG_Get("HELP_UTIL_CATEGORY_UNKNOWN");
 	}
+}
+
+void HELP_AddMessages()
+{
+	MSG_Add("HELP_UTIL_CATEGORY_DOSBOX", "DOSBox Commands");
+	MSG_Add("HELP_UTIL_CATEGORY_FILE", "File/Directory Commands");
+	MSG_Add("HELP_UTIL_CATEGORY_BATCH", "Batch File Commands");
+	MSG_Add("HELP_UTIL_CATEGORY_MISC", "Miscellaneous Commands");
+	MSG_Add("HELP_UTIL_CATEGORY_UNKNOWN", "Unknown Command");
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1448,6 +1448,9 @@ void SHELL_Init() {
 	                             "DOS version %d.%02d\n");
 	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
 
+	/* Ensure help categories are loaded into the message vector */
+	HELP_AddMessages();
+
 	/* Regular startup */
 	call_shellstop=CALLBACK_Allocate();
 	/* Setup the startup CS:IP to kill the last running machine when exitted */


### PR DESCRIPTION
This is an addendum to #1696 

@Kappa971 mentioned in #1698 that the new category headings in `HELP` should be translatable. This PR implements that.

@kcgen should I generate new English `lng` file as part of this PR?