### PR TITLE
Detect value and type narrowing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,23 +24,23 @@ jobs:
             os: ubuntu-20.04
             packages: clang
             build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-clang.ini
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, Ubuntu 20.04
             os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, Ubuntu 18.04
             os: ubuntu-18.04
             build_flags: -Dunit_tests=disabled
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC 7, Ubuntu 18.04
             os: ubuntu-18.04
             packages: g++-7
             build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-gcc-7.ini
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, +tests
             os: ubuntu-20.04
@@ -50,22 +50,22 @@ jobs:
           - name: GCC, +debugger
             os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Denable_debugger=normal
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, -dyn-x86
             os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Ddynamic_core=dynrec
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, -dyn-x86, +debugger
             os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Ddynamic_core=dynrec -Denable_debugger=normal
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, -network
             os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Duse_sdl2_net=false -Duse_slirp=false
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC, minimum build
             os: ubuntu-20.04
@@ -80,7 +80,7 @@ jobs:
               -Duse_sdl2_net=false
               -Duse_slirp=false
             min_dependencies: true
-            max_warnings: 0
+            max_warnings: -1
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
             needs_deps: true
             packages: meson
             build_flags: -Dunit_tests=disabled
-            max_warnings: 0
+            max_warnings: -1
 
           - name: Clang
             host: macos-latest
@@ -35,7 +35,7 @@ jobs:
             needs_deps: true
             packages: meson
             build_flags: -Dunit_tests=disabled
-            max_warnings: 0
+            max_warnings: -1
 
           - name: GCC 11
             host: macos-latest
@@ -43,7 +43,7 @@ jobs:
             needs_deps: true
             packages: gcc@11
             build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-gcc-11.ini
-            max_warnings: 0
+            max_warnings: -1
 
           - name: Clang, +tests
             host: macos-latest
@@ -57,7 +57,7 @@ jobs:
             arch: x86_64
             needs_deps: true
             build_flags: -Dunit_tests=disabled -Denable_debugger=normal
-            max_warnings: 0
+            max_warnings: -1
 
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]
@@ -65,7 +65,7 @@ jobs:
             needs_deps: false
             packages: meson
             build_flags: -Dunit_tests=disabled
-            max_warnings: 0
+            max_warnings: -1
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -28,38 +28,38 @@ jobs:
             arch: i686
             sys: MINGW32
             cc: gcc
-            max_warnings: 0
+            max_warnings: -1
           - name: GCC (MinGW) x86_64
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             cc: gcc
-            max_warnings: 0
+            max_warnings: -1
           - name: GCC (UCRT) x86_64
             toolchain: ucrt-
             arch: x86_64
             sys: UCRT64
             cc: gcc
-            max_warnings: 0
+            max_warnings: -1
           - name: Clang x86_64
             toolchain: clang-
             arch: x86_64
             sys: CLANG64
             cc: clang
-            max_warnings: 0
+            max_warnings: -1
           - name: GCC +tests
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             run_tests: true
             cc: gcc
-            max_warnings: 0
+            max_warnings: -1
           - name: GCC +debugger
             toolchain: ""
             arch: x86_64
             sys: MINGW64
             cc: gcc
-            max_warnings: 0
+            max_warnings: -1
             build_flags: -Denable_debugger=normal
 
     defaults:

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,10 @@ summary('Build type',     get_option('buildtype'), section : 'Build Summary')
 summary('Install prefix', get_option('prefix'),    section : 'Build Summary')
 
 # extra compiler flags
-extra_flags = ['-Wno-unknown-pragmas']
+extra_flags = [
+  '-Wno-unknown-pragmas',
+  '-Wconversion',
+  '-Wnarrowing']
 
 # If the compiler provides std::filesystem, then we consider it modern enough
 # that we can trust it's extra helpful warnings to let us improve the code quality.


### PR DESCRIPTION
All cases being:

``` c++
  // initialized in-place from literal
  const int a{DOUBLE_AS_LITERAL}; 

  // initialized in-place from variable
  const int b{double_as_variable};

  // assigned from initialized literal
  const int c = {DOUBLE_AS_LITERAL};

  // assigned from initialized variable
  const int d = {double_as_variable}; 

  // assigned from literal
  const int e = DOUBLE_AS_LITERAL;

  // assigned from variable
  const int f = double_as_variable; 
```

Previously, only the first (`a = `) and third (`c = `) assignments were being flagged.  The other narrowing events were silently allowed.

This PR will now warn about all of the above.
 - Existing code that narrows will have their warnings grandfathered in.
 - For new code, the added warnings will blocked by CI.

To address these existing and new warnings, the types can be replaced (if that's more correct) or explicitly cast to make it clear that this is intended.
