### PR TITLE
Implement CMS / Game Blaster filtering 

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -812,6 +812,11 @@ void DOSBOX_Init() {
 	                  "           Use the filter of this Sound Blaster model.\n"
 	                  "  none:    Don't filter the output.");
 
+	Pstring = secprop->Add_string("cms_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the Sound Blaster CMS output:\n"
+	                  "  on:    Filter the output (default).\n"
+	                  "  none:  Don't filter the output.");
+
 	// Configure Gravis UltraSound emulation
 	GUS_AddConfigSection(control);
 

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -26,7 +26,7 @@
 #include <array>
 #include <memory>
 #include <queue>
-#include <string_view>
+#include <string>
 #include <vector>
 
 #include "inout.h"
@@ -40,7 +40,9 @@
 
 class GameBlaster {
 public:
-	void Open(const int port_choice, const std::string_view card_choice);
+	void Open(const int port_choice, const std::string &card_choice,
+	          const std::string &filter_choice);
+
 	void Close();
 	~GameBlaster() { Close(); }
 


### PR DESCRIPTION
This implements https://github.com/dosbox-staging/dosbox-staging/issues/1675

Please see the related ticket, I've updated it with actual measurements of real hardware vs DOSBox with filter on and off.
The filtered sound is virtually indistinguishable from real hardware (minus the hiss, of course).

With filter and crossfeed on, CMS music starts sounding quite nice on headphones 😎🎧 