### PR TITLE
Add an explicit copy constructor to bit_view and a couple more tests

### DIFF
--- a/include/bit_view.h
+++ b/include/bit_view.h
@@ -132,8 +132,20 @@ public:
 	template <class rhs_type>
 	constexpr bit_view(const rhs_type rhs_value) noexcept
 	{
-		// leverage the implicit conversion operator to assign the value
+		// leverage the assignment operator to check the type, shift and
+		// mask the value, and assign into our view's bits
 		*this = rhs_value;
+	}
+
+	// copy constructor
+	bit_view(const bit_view &other)
+	{
+		// get the other view's value using the data_type() operator
+		const data_type d = other;
+
+		// use the assignment operator to check the type, shift and mask
+		// the value, and assign into our view's bits
+		*this = d;
 	}
 
 	// assign from right-hand-side value
@@ -151,8 +163,12 @@ public:
 	// assign the view from another bit_view if the same type
 	constexpr bit_view &operator=(const bit_view &other) noexcept
 	{
+		// get the other view's value using the data_type() operator
 		const data_type d = other;
-		return *this      = d;
+
+		// use the assignment operator to check the type, shift and mask
+		// the value, and assign into our view's bits
+		return *this = d;
 	}
 
 	// read the view's value

--- a/tests/bit_view_tests.cpp
+++ b/tests/bit_view_tests.cpp
@@ -136,8 +136,10 @@ TEST(bit_view, increment)
 	EXPECT_EQ(r.middle_3, 0b000);
 	EXPECT_EQ(r.last_3, 0b111);
 
-	// overflow is caught
+	// overflow is caught with every increment method
 	EXPECT_DEBUG_DEATH({ r.first_2++; }, "");
+	EXPECT_DEBUG_DEATH({ ++r.first_2; }, "");
+	EXPECT_DEBUG_DEATH({ r.first_2 += 1; }, "");
 
 	// make sure adjacent bits are not affected
 	EXPECT_EQ(r.middle_3, 0b000);
@@ -172,8 +174,10 @@ TEST(bit_view, decrement)
 	EXPECT_EQ(r.middle_3, 0b000);
 	EXPECT_EQ(r.last_3, 0b111);
 
-	// underflow is caught
+	// underflow is caught with every decrement method
 	EXPECT_DEBUG_DEATH({ r.first_2--; }, "");
+	EXPECT_DEBUG_DEATH({ --r.first_2; }, "");
+	EXPECT_DEBUG_DEATH({ r.first_2 -= 1; }, "");
 
 	// make sure adjacent bits are not affected
 	EXPECT_EQ(r.middle_3, 0b000);


### PR DESCRIPTION
Fixes a warning from MSYS2 clang:

``` text
warning: definition of implicit copy constructor is deprecated
because it has a user-provided copy assignment operator
[-Wdeprecated-copy-with-user-provided-copy].
```

In this case, we now provide a matching user-provide copy constructor to go along with the same type handled in the copy assignment operator.