### PR TITLE
Add per-file code checks using helper macros

### DIFF
--- a/include/checks.h
+++ b/include/checks.h
@@ -1,0 +1,68 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_CHECKS_H
+#define DOSBOX_CHECKS_H
+
+// This file contains macros that enable extra code checks at the file-level.
+//
+// Checks can include any compiler-toggleable features that the project team
+// feels can improve code-quality. This might include:
+//   - warnings
+//   - warnings-as-errors
+//   - diagnostics
+//   - formatting / structure / design / etc..
+//
+// These checks are those that (currently) can't be enabled project-wide
+// because they would be fatal (ie, -Werror) or too verbose (ie, -Wnarrowing
+// generating 3,400+ warnings!)
+//
+// So this per-file approach lets us focus down one file at a time and then
+// declare that it's free from the issue(s) we're checking.
+//
+// Usage:
+//     #include "checks.h"
+//     CHECK_NARROWING();
+//
+// How to add new checks:
+//
+//   1. Assess how much work it would be to enable it at the project-level. If
+//      the check is too burdensome, then carry on.
+//
+//   2. The C98 and c++11 standards supports the _Pragma() function to add
+//      #pragma strings. We can use it to add compiler-specific features.
+//
+//   3. Finish the macro with END_MACRO to swalllow the semicolon and avoid
+//      name collisions and warnings about unused variables.
+
+#define END_MACRO \
+	struct END_MACRO_##__FILE__##__LINE__ {}
+
+#ifdef __GNUC__
+#	define CHECK_NARROWING() \
+		_Pragma("GCC diagnostic warning \"-Wsign-conversion\"") \
+		_Pragma("GCC diagnostic warning \"-Wconversion\"") \
+		_Pragma("GCC diagnostic warning \"-Wnarrowing\"") \
+		END_MACRO
+#else
+#	define CHECK_NARROWING()
+#endif
+
+#endif


### PR DESCRIPTION
(described inside the header)

With the recent PR that moves ZMBV to a library, I decided to try it inside `zmbv.cpp`:

``` c++

#include "checks.h"

CHECK_NARROWING();
```

And it works :+1: , we get helpful warnings about type narrowing:

``` text
../../src/libs/zmbv/zmbv.cpp:108:16: warning: implicit conversion changes signedness: 'VideoCodec::FrameBlock_offset' (aka 'long') to 'std::vector::size_type' (aka 'unsigned long') [-Wsign-conversion]
        blocks.resize(blockcount);
               ~~~~~~ ^~~~~~~~~~
../../src/libs/zmbv/zmbv.cpp:208:45: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workUsed = (workUsed + blockcount * 2 + 3) & ~3;
                 ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:431:43: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workPos = (workPos + blockcount * 2 + 3) & ~3;
                ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:469:21: warning: implicit conversion changes signedness: 'int' to 'uInt' (aka 'unsigned int') [-Wsign-conversion]
        zstream.avail_in = size;
                         ~ ^~~~
../../src/libs/zmbv/zmbv.cpp:499:39: warning: implicit conversion changes signedness: 'const int' to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
                        memcpy(writeframe, &work[workPos], line_width);
                        ~~~~~~                             ^~~~~~~~~~
../../src/libs/zmbv/zmbv.cpp:501:15: warning: implicit conversion changes signedness: 'const int' to 'unsigned int' [-Wsign-conversion]
                        workPos += line_width;
                                ~~ ^~~~~~~~~~
../../src/libs/zmbv/zmbv.cpp:545:48: warning: implicit conversion changes signedness: 'int' to 'uintptr_t' (aka 'unsigned long') [-Wsign-conversion]
                                const auto c = read_unaligned_uint16_at(r, j);
                                               ~~~~~~~~~~~~~~~~~~~~~~~~    ^
../../src/libs/zmbv/zmbv.cpp:554:48: warning: implicit conversion changes signedness: 'int' to 'uintptr_t' (aka 'unsigned long') [-Wsign-conversion]
                                const auto c = read_unaligned_uint16_at(r, j);
                                               ~~~~~~~~~~~~~~~~~~~~~~~~    ^
../../src/libs/zmbv/zmbv.cpp:208:45: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workUsed = (workUsed + blockcount * 2 + 3) & ~3;
                 ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:370:28: note: in instantiation of function template specialization 'VideoCodec::AddXorFrame<unsigned char>' requested here
                case ZMBV_FORMAT::BPP_8: AddXorFrame<uint8_t>(); break;
                                         ^
../../src/libs/zmbv/zmbv.cpp:208:45: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workUsed = (workUsed + blockcount * 2 + 3) & ~3;
                 ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:372:29: note: in instantiation of function template specialization 'VideoCodec::AddXorFrame<unsigned short>' requested here
                case ZMBV_FORMAT::BPP_16: AddXorFrame<uint16_t>(); break;
                                          ^
../../src/libs/zmbv/zmbv.cpp:208:45: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workUsed = (workUsed + blockcount * 2 + 3) & ~3;
                 ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:374:29: note: in instantiation of function template specialization 'VideoCodec::AddXorFrame<unsigned int>' requested here
                case ZMBV_FORMAT::BPP_32: AddXorFrame<uint32_t>(); break;
                                          ^
../../src/libs/zmbv/zmbv.cpp:431:43: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workPos = (workPos + blockcount * 2 + 3) & ~3;
                ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:515:28: note: in instantiation of function template specialization 'VideoCodec::UnXorFrame<unsigned char>' requested here
                case ZMBV_FORMAT::BPP_8: UnXorFrame<uint8_t>(); break;
                                         ^
../../src/libs/zmbv/zmbv.cpp:431:43: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workPos = (workPos + blockcount * 2 + 3) & ~3;
                ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:517:29: note: in instantiation of function template specialization 'VideoCodec::UnXorFrame<unsigned short>' requested here
                case ZMBV_FORMAT::BPP_16: UnXorFrame<uint16_t>(); break;
                                          ^
../../src/libs/zmbv/zmbv.cpp:431:43: warning: implicit conversion loses integer precision: 'long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
        workPos = (workPos + blockcount * 2 + 3) & ~3;
                ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
../../src/libs/zmbv/zmbv.cpp:519:29: note: in instantiation of function template specialization 'VideoCodec::UnXorFrame<unsigned int>' requested here
                case ZMBV_FORMAT::BPP_32: UnXorFrame<uint32_t>(); break;
                                          ^
14 warnings generated.
[11/11] Linking target tests/shell_redirection

```
