### PR TITLE
Add explicit handling for `bool`s in `bit_view`

### DIFF
--- a/include/bit_view.h
+++ b/include/bit_view.h
@@ -136,19 +136,17 @@ public:
 	template <class rhs_type>
 	constexpr bit_view(const rhs_type rhs_value) noexcept
 	{
-		// leverage the assignment operator to check the type, shift and
-		// mask the value, and assign into our view's bits
+		// use the = operator to save the value into the view
 		*this = rhs_value;
 	}
 
 	// copy constructor
-	constexpr bit_view(const bit_view &other)
+	constexpr bit_view(const bit_view &other) noexcept
 	{
 		// get the other view's value using the data_type() operator
 		const data_type d = other;
 
-		// use the assignment operator to check the type, shift and mask
-		// the value, and assign into our view's bits
+		// use the = operator to save the value into the view
 		*this = d;
 	}
 
@@ -179,8 +177,7 @@ public:
 		// get the other view's value using the data_type() operator
 		const data_type d = other;
 
-		// use the assignment operator to check the type, shift and mask
-		// the value, and assign into our view's bits
+		// use the = operator to save the value into the view
 		return *this = d;
 	}
 
@@ -193,6 +190,7 @@ public:
 	// pre-increment the view's value
 	constexpr bit_view &operator++() noexcept
 	{
+		// use the = operator to save the value into the view
 		return *this = *this + 1;
 	}
 
@@ -209,12 +207,14 @@ public:
 	constexpr bit_view &operator+=(const rhs_type rhs_value) noexcept
 	{
 		check_rhs(rhs_value);
+		// use the = operator to save the value into the view
 		return *this = *this + rhs_value;
 	}
 
 	// pre-decrement the view's value
 	constexpr bit_view &operator--() noexcept
 	{
+		// use the = operator to save the value into the view
 		return *this = *this - 1;
 	}
 

--- a/include/bit_view.h
+++ b/include/bit_view.h
@@ -107,6 +107,10 @@ private:
 		static_assert(std::is_integral<rhs_type>::value,
 		              "the bit_view's value can only accept integral types");
 
+		// detect use of bool, in which case the data is 1 bit and safe
+		if (std::is_same<rhs_type, bool>::value)
+			return;
+
 		// detect assignments of negative values
 		if (std::is_signed<rhs_type>::value)
 			assert(rhs_value >= 0);
@@ -146,6 +150,15 @@ public:
 		// use the assignment operator to check the type, shift and mask
 		// the value, and assign into our view's bits
 		*this = d;
+	}
+
+	// assign from right-hand-side boolean
+	constexpr bit_view &operator=(const bool b) noexcept
+	{
+		constexpr uint8_t bool_to_val[2] = {0, 1};
+
+		// use the = operator to save the value into the view
+		return *this = bool_to_val[static_cast<size_t>(b)];
 	}
 
 	// assign from right-hand-side value

--- a/tests/bit_view_tests.cpp
+++ b/tests/bit_view_tests.cpp
@@ -284,7 +284,7 @@ TEST(bit_view, size_safety)
 
 TEST(bit_view, illegal_view)
 {
-	union Register {
+	union BadRegister {
 		uint32_t data = 0;
 		// the following fails to compile because the view is out of
 		// range:

--- a/tests/bit_view_tests.cpp
+++ b/tests/bit_view_tests.cpp
@@ -184,6 +184,38 @@ TEST(bit_view, decrement)
 	EXPECT_EQ(r.last_3, 0b111);
 }
 
+TEST(bit_view, compare_with_bool)
+{
+	union RegSingles {
+		uint8_t data = 0;
+		bit_view<0, 1> bit0;
+		bit_view<7, 1> bit7;
+	};
+
+	RegSingles reg = {0};
+
+	reg.bit0 = true;
+	EXPECT_EQ(reg.data, 0b00000001);
+	EXPECT_EQ(reg.bit0, 1);
+	EXPECT_TRUE(reg.bit0);
+	EXPECT_TRUE(reg.bit0 == true);
+
+	reg.bit7 = true;
+	EXPECT_EQ(reg.data, 0b10000001);
+	EXPECT_EQ(reg.bit7, 1);
+	EXPECT_TRUE(reg.bit7 == true);
+
+	reg.bit0 = false;
+	EXPECT_EQ(reg.data, 0b10000000);
+	EXPECT_EQ(reg.bit0, 0);
+
+	EXPECT_FALSE(reg.bit0);
+	EXPECT_TRUE(reg.bit0 != true);
+	EXPECT_TRUE(reg.bit0 == false);
+	EXPECT_FALSE(reg.bit0 == reg.bit7);
+	EXPECT_TRUE(reg.bit0 != reg.bit7);
+}
+
 TEST(bit_view, clear)
 {
 	Register r = {0b111'111'11};


### PR DESCRIPTION
Fixes a warning caught while using `bit_view` in the PC Speaker PR.