### PR TITLE
Fix regression from r4477 merge and add missing bits

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -578,7 +578,7 @@ bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 		exists = Drives[drive]->FileOpen(&Files[handle], fullname, flags);
 		if (exists)
 			Files[handle]->SetDrive(drive);
-		if (dos.errorcode)
+		if (dos.errorcode == DOSERR_ACCESS_CODE_INVALID)
 			return false;
 		dos.errorcode = old_errorcode;
 	}

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -221,6 +221,12 @@ void BOOT::Run(void)
 				continue;
 			}
 
+
+			if (imageDiskList[0] != nullptr || imageDiskList[1] != nullptr) {
+				WriteOut(MSG_Get("PROGRAM_BOOT_IMAGE_MOUNTED"));
+				return;
+			}
+
 			if (i >= MAX_SWAPPABLE_DISKS) {
 				return; // TODO give a warning.
 			}
@@ -520,6 +526,7 @@ void BOOT::AddMessages() {
 	        "Type \033[34;1mBOOT /?\033[0m for the syntax of this command.\033[0m\n");
 	MSG_Add("PROGRAM_BOOT_UNABLE","Unable to boot off of drive %c");
 	MSG_Add("PROGRAM_BOOT_IMAGE_OPEN","Opening image file: %s\n");
+	MSG_Add("PROGRAM_BOOT_IMAGE_MOUNTED","Floppy image(s) already mounted.\n");
 	MSG_Add("PROGRAM_BOOT_IMAGE_NOT_OPEN","Cannot open %s");
 	MSG_Add("PROGRAM_BOOT_BOOT","Booting from drive %c...\n");
 	MSG_Add("PROGRAM_BOOT_CART_WO_PCJR","PCjr cartridge found, but machine is not PCjr");

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -472,7 +472,10 @@ void IMGMOUNT::Run(void) {
 
         if (hdd) newImage->Set_Geometry(sizes[2],sizes[3],sizes[1],sizes[0]);
         imageDiskList[drive - '0'].reset(newImage);
-        updateDPT();
+
+    	if ((drive == '2' || drive == '3') && hdd)
+		    updateDPT();
+
         WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"),drive - '0',temp_line.c_str());
     }
 

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -382,14 +382,13 @@ void IMGMOUNT::Run(void) {
         }
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
 
-        if (paths.size() == 1) {
-            auto *newdrive = static_cast<fatDrive*>(imgDisks[0]);
-            if (('A' <= drive && drive <= 'B' && !(newdrive->loadedDisk->hardDrive)) ||
-                ('C' <= drive && drive <= 'D' && newdrive->loadedDisk->hardDrive)) {
-                const size_t idx = drive_index(drive);
-                imageDiskList[idx] = newdrive->loadedDisk;
-                updateDPT();
-            }
+        auto newdrive = static_cast<fatDrive*>(imgDisks[0]);
+        assert(newdrive);
+        if (('A' <= drive && drive <= 'B' && !(newdrive->loadedDisk->hardDrive)) ||
+            ('C' <= drive && drive <= 'D' && newdrive->loadedDisk->hardDrive)) {
+            const size_t idx = drive_index(drive);
+            imageDiskList[idx] = newdrive->loadedDisk;
+            updateDPT();
         }
     } else if (fstype=="iso") {
         if (Drives[drive_index(drive)]) {


### PR DESCRIPTION
Thanks to:
 - @FeralChild64, for reporting a regression w/ PROGMAN.EXE failing to load.  
 - @shermp, for bisecting.
 - @kklobe, for reproducing on macOS.

This was caused by a small difference between upstream and Staging:
 
``` diff
 		if (exists)
 			Files[handle]->SetDrive(drive);
-		if (dos.errorcode)
+		if (dos.errorcode == DOSERR_ACCESS_CODE_INVALID)
 			return false;
 		dos.errorcode = old_errorcode;
```
 
The ` == DOSERR_ACCESS_CODE_INVALID` was added in commit: https://github.com/dosbox-staging/dosbox-staging/commit/56ffb1, which is now retained here.
