### PR TITLE
MSVC & vcpkg build improvements

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,10 +82,8 @@ jobs:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
         run: python scripts\count-warnings.py -f --msvc vs\build.log
 
-
   build_windows_vs_release:
     name: ${{ matrix.conf.name }}
-    needs: build_windows_vs
     runs-on: windows-2022
     strategy:
       matrix:
@@ -93,9 +91,19 @@ jobs:
           - name: Release build (32-bit)
             arch: x86
             vs-release-dirname: Win32
+            debugger: false
           - name: Release build (64-bit)
             arch: x64
             vs-release-dirname: x64
+            debugger: false
+          - name: Release build w/ debugger (32-bit)
+            arch: x86
+            vs-release-dirname: Win32
+            debugger: true
+          - name: Release build w/ debugger (64-bit)
+            arch: x64
+            vs-release-dirname: x64
+            debugger: true
 
     steps:
       - name: Checkout repository
@@ -135,7 +143,8 @@ jobs:
         shell: pwsh
         run:   .\scripts\log-env.ps1
 
-      - name:  Adjust config.h
+      - name:  Set version
+        id:    set_dosbox_vers
         shell: bash
         run: |
           set -x
@@ -144,6 +153,15 @@ jobs:
           # inject version based on vcs
           sed -i "s|DOSBOX_DETAILED_VERSION \"git\"|DOSBOX_DETAILED_VERSION \"$VERSION\"|" src/platform/visualc/config.h
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "::set-output name=dosbox_vers::${VERSION}"
+
+      - name:  Enable the debugger in config.h
+        if: ${{ matrix.conf.debugger }}
+        shell: bash
+        run: |
+          set -x
+          sed -i "s|C_DEBUG.*|C_DEBUG 1|"             src/platform/visualc/config.h
+          sed -i "s|C_HEAVY_DEBUG.*|C_HEAVY_DEBUG 1|" src/platform/visualc/config.h
 
       - name:  Build release
         shell: pwsh
@@ -151,7 +169,14 @@ jobs:
           cd vs
           MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
 
-      - name: Package
+      - name:  Set packaging names
+        id:    set_pkg_dir
+        shell: bash
+        run: |
+          echo "::set-output name=pkg_dir::dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}"
+
+      - name: Package standard build
+        if: ${{ !matrix.conf.debugger }}
         shell: bash
         run: |
           # Construct VC_REDIST_DIR
@@ -165,39 +190,24 @@ jobs:
           ./scripts/create-package.sh \
             -p msvc \
             vs/${{ matrix.conf.vs-release-dirname }}/Release \
-            "dest"
-
-      - name:  Enable the debugger in config.h
-        shell: bash
-        run: |
-          set -x
-          sed -i "s|C_DEBUG.*|C_DEBUG 1|"             src/platform/visualc/config.h
-          sed -i "s|C_HEAVY_DEBUG.*|C_HEAVY_DEBUG 1|" src/platform/visualc/config.h
-
-      - name:  Build release with the debugger
-        shell: pwsh
-        env:
-          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
-        run: |
-          cd vs
-          MSBuild -m dosbox.sln -t:dosbox:"Clean;Rebuild" -p:Configuration=Release -p:Platform=${{ matrix.conf.arch }}
-
+            "${{ steps.set_pkg_dir.outputs.pkg_dir }}"
+      
       - name:  Package the debugger
+        if:    ${{ matrix.conf.debugger }}
         shell: bash
         run: |
           set -x
+          mkdir -p ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           # Move the debugger build into the release area
           readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
           ls "vs/$RELEASE_DIR"
-          cp vs/$RELEASE_DIR/dosbox.exe   dest/dosbox_with_debugger.exe
-          # Create dir for zipping
-          mv dest dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
+          cp vs/$RELEASE_DIR/dosbox.exe   ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
 
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          $dosboxDir = "${{ github.workspace }}\dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}"
+          $dosboxDir = "${{ github.workspace }}\${{ steps.set_pkg_dir.outputs.pkg_dir }}"
           & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
           if( $LASTEXITCODE -ne 0 ) {
               Get-Content -Path $env:TEMP\MpCmdRun.log
@@ -205,11 +215,18 @@ jobs:
           }
 
       - name: Upload package
-        uses: actions/upload-artifact@v2
+        if:   ${{ !matrix.conf.debugger }}
+        uses: actions/upload-artifact@v3
         with:
-          name: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
-          path: dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}
-
+          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
+          path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
+      
+      - name: Upload debugger artifact
+        if:   ${{ matrix.conf.debugger }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
+          path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  VCPKG_ROOT: C:\vcpkg
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+  GH_NUGET_REGISTRY: https://nuget.pkg.github.com/dosbox-staging/index.json
+
 jobs:
   build_windows_vs:
     name: ${{ matrix.conf.name }}
@@ -21,24 +26,26 @@ jobs:
             arch: x64
             max_warnings: 1102
     steps:
-      - name:  Backup existing vcpkg installation
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name:  Prepare VCPKG
+        id: prep-vcpkg
         shell: pwsh
         run: |
-          mv c:\vcpkg c:\vcpkg-bak
-          md c:\vcpkg -ea 0
+          ${{ env.VCPKG_ROOT }}\bootstrap-vcpkg.bat
+          echo "::set-output name=nuget_bin::$(${{ env.VCPKG_ROOT }}\vcpkg.exe fetch nuget)"
 
-      - name: Generate vcpkg cache key
-        id:    prep-vcpkg
-        shell: bash
-        run: |
-          echo "::set-output name=year_and_week::$(date '+%Y%W')"
-
-      - name: Cache vcpkg
-        uses: actions/cache@v2
-        id:   cache-vcpkg
-        with:
-          path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+      - name: 'Setup NuGet Credentials'
+        shell: pwsh
+        run: >-
+          ${{ steps.prep-vcpkg.outputs.nuget_bin }}
+          sources add
+          -source "${{ env.GH_NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "dosbox-staging"
+          -password "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -46,29 +53,11 @@ jobs:
             vs-prerelease: true
             msbuild-architecture: ${{ matrix.conf.arch }}
 
-      - name:  Install new packages using vcpkg
-        if:    steps.cache-vcpkg.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          rm -R c:\vcpkg
-          c:
-          cd \
-          git clone --depth 1 https://github.com/Microsoft/vcpkg.git
-          cd vcpkg
-          .\bootstrap-vcpkg.bat
-          vcpkg install --triplet ${{ matrix.conf.arch }}-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest speexdsp
-          if (-not $?) { throw "vcpkg failed to install library dependencies" }
-          rm -R c:\vcpkg\buildtrees
-          rm -R c:\vcpkg\packages
-
       - name:  Integrate packages
         shell: pwsh
         run: |
-          vcpkg integrate install
+          ${{ env.VCPKG_ROOT }}\vcpkg.exe integrate install
           if (-not $?) { throw "vcpkg failed to integrate packages" }
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
 
       - name:  Log environment
         shell: pwsh
@@ -109,24 +98,26 @@ jobs:
             vs-release-dirname: x64
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - name:  Prepare vcpkg for cache restore
+      - name:  Prepare VCPKG
+        id: prep-vcpkg
         shell: pwsh
         run: |
-          mv c:\vcpkg c:\vcpkg-bak
-          md c:\vcpkg -ea 0
+          ${{ env.VCPKG_ROOT }}\bootstrap-vcpkg.bat
+          echo "::set-output name=nuget_bin::$(${{ env.VCPKG_ROOT }}\vcpkg.exe fetch nuget)"
 
-      - name: Generate vcpkg cache key
-        id:    prep-vcpkg
-        shell: bash
-        run: |
-          echo "::set-output name=year_and_week::$(date '+%Y%W')"
-
-      - name: Restore the most recent cache of vcpkg
-        uses: actions/cache@v2
-        with:
-          path: c:\vcpkg
-          key: vcpkg-${{ matrix.conf.arch }}-${{ steps.prep-vcpkg.outputs.year_and_week }}-1
+      - name: 'Setup NuGet Credentials'
+        shell: pwsh
+        run: >-
+          ${{ steps.prep-vcpkg.outputs.nuget_bin }}
+          sources add
+          -source "${{ env.GH_NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "dosbox-staging"
+          -password "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -137,11 +128,8 @@ jobs:
       - name:  Integrate packages
         shell: pwsh
         run: |
-          vcpkg integrate install
+          ${{ env.VCPKG_ROOT }}\vcpkg.exe integrate install
           if (-not $?) { throw "vcpkg failed to integrate packages" }
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
 
       - name:  Log environment
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ missed.txt
 build
 builddir
 
+# VCPKG
+vcpkg_installed
+
 # Visual Studio / Code
 .vs
 .vscode

--- a/README.md
+++ b/README.md
@@ -238,13 +238,26 @@ is bootstrapped, open PowerShell and run:
 
 ``` powershell
 PS:\> .\vcpkg integrate install
-PS:\> .\vcpkg install --triplet x64-windows libpng sdl2 sdl2-net libmt32emu opusfile fluidsynth gtest speexdsp
 ```
 
-These two steps will ensure that MSVC finds and links all dependencies.
+This step will ensure that MSVC can use vcpkg to build, find and links all 
+dependencies.
 
 Start Visual Studio and open file: `vs\dosbox.sln`. Make sure you have `x64`
 selected as the solution platform.  Use Ctrl+Shift+B to build all projects.
+
+Note, the first time you build a configuration, dependencies will be built 
+automatically and stored in the `vcpkg_installed` directory. This can take 
+a significant length of time.
+
+Occasionally, dosbox-staging will increase dependency requirements such that 
+a newer version of vcpkg is required. To upgrade, open powershell to the 
+`vcpkg` directory and run:
+
+``` powershell
+PS:\> git pull
+PS:\> .\bootstrap-vcpkg.bat
+```
 
 [vcpkg]: https://github.com/microsoft/vcpkg
 

--- a/README.md
+++ b/README.md
@@ -250,15 +250,6 @@ Note, the first time you build a configuration, dependencies will be built
 automatically and stored in the `vcpkg_installed` directory. This can take 
 a significant length of time.
 
-Occasionally, dosbox-staging will increase dependency requirements such that 
-a newer version of vcpkg is required. To upgrade, open powershell to the 
-`vcpkg` directory and run:
-
-``` powershell
-PS:\> git pull
-PS:\> .\bootstrap-vcpkg.bat
-```
-
 [vcpkg]: https://github.com/microsoft/vcpkg
 
 ### Windows (MSYS2), macOS (MacPorts), Haiku, others

--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -17,18 +17,10 @@ Note that the debugger imposes a significant runtime performance penalty.
 If you're not planning to use the debugger then the steps above will help
 you build a binary optimized for gaming.
 
-1. Follow the steps above to setup a working build environment.
-2. Install and integrate `pdcurses` using vcpkg:
-
-    ``` shell
-    cd \vcpkg
-    .\vcpkg install --triplet pdcurses
-    .\vcpkg integrate install
-    ```
-
-3. Edit `src\platform\visualc\config.h` and enable `C_DEBUG` and optionally
+1. Edit `src\platform\visualc\config.h` and enable `C_DEBUG` and optionally
   `C_HEAVY_DEBUG` by setting them to `1` instead of `0`.
-4. Select a **Release** build type in Visual Studio, and run the build.
+  
+2. Select a **Release** build type in Visual Studio, and run the build.
 
 ## Build using MSYS2
 

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -176,7 +176,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -212,7 +212,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
       <LanguageStandard>stdcpp17</LanguageStandard>

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -93,6 +93,9 @@
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\platform\visualc;..\ghc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -143,7 +143,7 @@ $(TargetPath)</Command>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ConformanceMode>Default</ConformanceMode>
       <OmitFramePointers>true</OmitFramePointers>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <AdditionalIncludeDirectories>..\..\src\libs\ghc;..\..\src\libs\iir1;..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -204,7 +204,7 @@ $(TargetPath)</Command>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
       <ConformanceMode>Default</ConformanceMode>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\..\src\libs\ghc;..\..\src\libs\iir1;..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
     </ClCompile>

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -99,6 +99,9 @@
     <ExternalIncludePath>..\..\include;$(ExternalIncludePath)</ExternalIncludePath>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,15 +3,14 @@
     "name": "dosbox-staging",
     "description": "DOSBox Staging is a fork of the DOSBox project that focuses on ease of use, modern technology and best practices.",
     "version": "0.79.0",
-    "builtin-baseline": "19fafcdb3557f8a029ee1a4eb203600ff638448e",
     "dependencies": [
-        {"name": "libpng", "version>=": "1.6.37#17"}, 
-        {"name": "sdl2", "version>=": "2.0.22#1"},
-        {"name": "sdl2-net", "version>=": "2.0.1#9"},
-        {"name": "libmt32emu", "version>=": "2.6.2"},
-        {"name": "opusfile", "version>=": "0.12#1"},
-        {"name": "fluidsynth", "version>=": "2.2.6#2"},
-        {"name": "gtest", "version>=": "1.11.0#5"},
-        {"name": "speexdsp", "version>=": "1.2.0#7"}
+        "libpng",
+        "sdl2",
+        "sdl2-net",
+        "libmt32emu",
+        "opusfile",
+        "fluidsynth",
+        "gtest",
+        "speexdsp"
     ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "dosbox-staging",
+    "description": "DOSBox Staging is a fork of the DOSBox project that focuses on ease of use, modern technology and best practices.",
+    "version": "0.79.0",
+    "builtin-baseline": "19fafcdb3557f8a029ee1a4eb203600ff638448e",
+    "dependencies": [
+        {"name": "libpng", "version>=": "1.6.37#17"}, 
+        {"name": "sdl2", "version>=": "2.0.22#1"},
+        {"name": "sdl2-net", "version>=": "2.0.1#9"},
+        {"name": "libmt32emu", "version>=": "2.6.2"},
+        {"name": "opusfile", "version>=": "0.12#1"},
+        {"name": "fluidsynth", "version>=": "2.2.6#2"},
+        {"name": "gtest", "version>=": "1.11.0#5"},
+        {"name": "speexdsp", "version>=": "1.2.0#7"}
+    ]
+}

--- a/vcpkg.json.release_only
+++ b/vcpkg.json.release_only
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "dosbox-staging",
+    "description": "DOSBox Staging is a fork of the DOSBox project that focuses on ease of use, modern technology and best practices.",
+    "version": "0.79.0",
+    "builtin-baseline": "19fafcdb3557f8a029ee1a4eb203600ff638448e",
+    "dependencies": [
+        {"name": "libpng", "version>=": "1.6.37#17"}, 
+        {"name": "sdl2", "version>=": "2.0.22#1"},
+        {"name": "sdl2-net", "version>=": "2.0.1#9"},
+        {"name": "libmt32emu", "version>=": "2.6.2"},
+        {"name": "opusfile", "version>=": "0.12#1"},
+        {"name": "fluidsynth", "version>=": "2.2.6#2"},
+        {"name": "gtest", "version>=": "1.11.0#5"},
+        {"name": "speexdsp", "version>=": "1.2.0#7"}
+    ]
+}

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -119,7 +119,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <MinimalRebuild>false</MinimalRebuild>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -163,7 +163,7 @@
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -209,7 +209,7 @@
       <FloatingPointModel>Fast</FloatingPointModel>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
@@ -264,7 +264,7 @@
       <FloatingPointModel>Fast</FloatingPointModel>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
-      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -138,7 +138,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -180,7 +180,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -234,7 +234,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -289,7 +289,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\xcopy ..\contrib\resources "$(OutDir)\resources" /s /i /y</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -97,6 +97,9 @@
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -138,7 +138,8 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"
+%systemroot%\System32\xcopy "$(VcpkgManifestRoot)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin\speexdsp.dll" "$(OutDir)libspeexdsp.dll*" /y</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -180,7 +181,8 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"
+%systemroot%\System32\xcopy "$(VcpkgManifestRoot)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin\speexdsp.dll" "$(OutDir)libspeexdsp.dll*" /y</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -234,7 +236,8 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"
+%systemroot%\System32\xcopy "$(VcpkgManifestRoot)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin\speexdsp.dll" "$(OutDir)libspeexdsp.dll*" /y</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -289,7 +292,8 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"</Command>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"
+%systemroot%\System32\xcopy "$(VcpkgManifestRoot)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin\speexdsp.dll" "$(OutDir)libspeexdsp.dll*" /y</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
This PR aims to improve dependency handling and CI speed improvements for Visual Studio builds.

I switched to using vcpkg's [manifest mode](https://github.com/microsoft/vcpkg/blob/master/docs/users/manifests.md). This means that dependencies for the project are now stored in a `vcpkg.json` file in the repository, and MSBuild will directly install vcpkg dependencies.

Note, this may trigger a rebuild/reinstall of dependencies for existing Visual Studio users.

On the CI side, I've replaced `actions/cache` with vcpkg's [binary caching](https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md). Specifically, binaries are cached to the Github nuget package registry. This vastly simplifies dependency caching, and best of all, it's incremental, so dependencies are still cached even if the workflow fails for any reason.

I suspect dependencies will be rebuilt whenever the compiler version changes, so there will still be the occasional 40+ min build.

The vcpkg changes have made building release and debugger builds in parallel possible. Along with the `actions/upload-artifact@v3` action, which can upload multiple files to the same name from different jobs (eg: the artifact name essentially acts like a shared folder, or bucket).

And I added a workaround for the `libspeexdspdll` issue.