### PR TITLE
De-Bitu LazyFlags and PageHandler

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -74,7 +74,7 @@ public:
 	virtual bool writew_checked(PhysPt addr, uint16_t val);
 	virtual bool writed_checked(PhysPt addr, uint32_t val);
 
-	uint8_t flags = 0x0;
+	uint_fast8_t flags = 0x0;
 };
 
 /* Some other functions */

--- a/include/paging.h
+++ b/include/paging.h
@@ -74,7 +74,7 @@ public:
 	virtual bool writew_checked(PhysPt addr, uint16_t val);
 	virtual bool writed_checked(PhysPt addr, uint32_t val);
 
-	Bitu flags = 0x0;
+	uint8_t flags = 0x0;
 };
 
 /* Some other functions */

--- a/include/paging.h
+++ b/include/paging.h
@@ -86,8 +86,8 @@ void PAGING_SetDirBase(Bitu cr3);
 void PAGING_InitTLB(void);
 void PAGING_ClearTLB(void);
 
-void PAGING_LinkPage(Bitu lin_page,Bitu phys_page);
-void PAGING_LinkPage_ReadOnly(Bitu lin_page,Bitu phys_page);
+void PAGING_LinkPage(uint32_t lin_page,uint32_t phys_page);
+void PAGING_LinkPage_ReadOnly(uint32_t lin_page,uint32_t phys_page);
 void PAGING_UnlinkPages(Bitu lin_page,Bitu pages);
 /* This maps the page directly, only use when paging is disabled */
 void PAGING_MapPage(Bitu lin_page,Bitu phys_page);
@@ -150,10 +150,10 @@ typedef struct {
 #endif
 
 struct PagingBlock {
-	Bitu			cr3;
-	Bitu			cr2;
+	uint32_t			cr3;
+	uint32_t			cr2;
 	struct {
-		Bitu page;
+		uint32_t page;
 		PhysPt addr;
 	} base;
 #if defined(USE_FULL_TLB)
@@ -169,7 +169,7 @@ struct PagingBlock {
 	tlb_entry *tlbh_banks[TLB_BANKS];
 #endif
 	struct {
-		Bitu used;
+		uint32_t used;
 		uint32_t entries[PAGING_LINKS];
 	} links;
 	uint32_t		firstmb[LINK_START];

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -44,10 +44,10 @@ static struct DynDecode {
 		Bitu first;
 	} page;
 	struct {
-		Bitu val;
-		Bitu mod;
-		Bitu rm;
-		Bitu reg;
+		uint_fast8_t val;
+		uint_fast8_t mod;
+		uint_fast8_t rm;
+		uint_fast8_t reg;
 	} modrm;
 	DynReg * segprefix;
 } decode;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -110,9 +110,9 @@ static struct DynDecode {
 	// modrm state of the current instruction (if used)
 	struct {
 //		Bitu val;
-		Bitu mod;
-		Bitu rm;
-		Bitu reg;
+		uint_fast8_t mod;
+		uint_fast8_t rm;
+		uint_fast8_t reg;
 	} modrm;
 } decode;
 
@@ -369,10 +369,9 @@ static bool decode_fetchd_imm(Bitu & val) {
 	return false;
 }
 
-
 // modrm decoding helper
 static void inline dyn_get_modrm(void) {
-	Bitu val=decode_fetchb();
+	const auto val=decode_fetchb();
 	decode.modrm.mod=(val >> 6) & 3;
 	decode.modrm.reg=(val >> 3) & 7;
 	decode.modrm.rm=(val & 7);

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -374,7 +374,7 @@ static void dyn_fpu_esc3()
 			switch (decode.modrm.rm) {
 			case 0x00:				//FNENI
 			case 0x01:				//FNDIS
-				LOG(LOG_FPU, LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %" PRIuPTR,
+				LOG(LOG_FPU, LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %u",
 				                        decode.modrm.rm);
 				break;
 			case 0x02:				//FNCLEX FCLEX
@@ -388,7 +388,7 @@ static void dyn_fpu_esc3()
 //				LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
 				break;
 			default:
-				E_Exit("ESC 3:ILLEGAL OPCODE group %" PRIuPTR " subfunction %" PRIuPTR,
+				E_Exit("ESC 3:ILLEGAL OPCODE group %u subfunction %u",
 				       decode.modrm.reg, decode.modrm.rm);
 			}
 			break;

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -836,7 +836,7 @@ static void inline gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
 	Bits len=cache.pos-data;
 	if (len<0) len=-len;
-	if (len>=0x00100000) LOG_MSG("Big jump %d",len);
+	if (len>=0x00100000) LOG_MSG("Big jump %ld",len);
 #endif
 	uint32_t offset = (uint32_t)(cache.pos-data) << 3;
 	cache_addw(((uint16_t)offset&~0x1f)|(data[0]&0x1f),data);

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -32,7 +32,6 @@ LazyFlags lflags;
           otherwise.
 */
 uint32_t get_CF(void) {
-
 	switch (lflags.type) {
 	case t_UNKNOWN:
 	case t_INCb:
@@ -112,7 +111,7 @@ uint32_t get_CF(void) {
 	case t_DIV:
 		return false;	/* Unknown */
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_CF Unknown %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("get_CF Unknown %u",lflags.type);
 	}
 	return 0;
 }
@@ -122,8 +121,7 @@ uint32_t get_CF(void) {
             arithmetic.
 */
 uint32_t get_AF(void) {
-	Bitu type=lflags.type;
-	switch (type) {
+	switch (lflags.type) {
 	case t_UNKNOWN:
 		return GETFLAG(AF);
 	case t_ADDb:	
@@ -194,7 +192,7 @@ uint32_t get_AF(void) {
 	case t_MUL:
 		return false; /* Unknown */
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_AF Unknown %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("get_AF Unknown %u",lflags.type);
 	}
 	return 0;
 }
@@ -203,8 +201,7 @@ uint32_t get_AF(void) {
 */
 
 uint32_t get_ZF(void) {
-	Bitu type=lflags.type;
-	switch (type) {
+	switch (lflags.type) {
 	case t_UNKNOWN:
 		return GETFLAG(ZF);
 	case t_ADDb:	
@@ -263,7 +260,7 @@ uint32_t get_ZF(void) {
 	case t_MUL:
 		return false; /* Unknown */
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_ZF Unknown %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("get_ZF Unknown %u",lflags.type);
 	}
 	return false;
 }
@@ -271,8 +268,7 @@ uint32_t get_ZF(void) {
             positive, 1 if negative).
 */
 uint32_t get_SF(void) {
-	Bitu type=lflags.type;
-	switch (type) {
+	switch (lflags.type) {
 	case t_UNKNOWN:
 		return GETFLAG(SF);
 	case t_ADDb:
@@ -331,14 +327,13 @@ uint32_t get_SF(void) {
 	case t_MUL:
 		return false; /* Unknown */
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_SF Unknown %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("get_SF Unknown %u",lflags.type);
 	}
 	return false;
 
 }
 uint32_t get_OF(void) {
-	Bitu type=lflags.type;
-	switch (type) {
+	switch (lflags.type) {
 	case t_UNKNOWN:
 	case t_MUL:
 		return GETFLAG(OF);
@@ -419,7 +414,7 @@ uint32_t get_OF(void) {
 	case t_DIV:
 		return false; /* Unknown */
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("get_OF Unknown %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("get_OF Unknown %u",lflags.type);
 	}
 	return false;
 }
@@ -821,7 +816,7 @@ uint32_t FillFlags(void) {
 		break;
 
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("Unhandled flag type %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("Unhandled flag type %u",lflags.type);
 		return 0;
 	}
 	lflags.type=t_UNKNOWN;
@@ -1046,7 +1041,7 @@ void FillFlagsNoCFOF(void) {
 		break;
 
 	default:
-		LOG(LOG_CPU,LOG_ERROR)("Unhandled flag type %" sBitfs(d),lflags.type);
+		LOG(LOG_CPU,LOG_ERROR)("Unhandled flag type %u",lflags.type);
 		break;
 	}
 	lflags.type=t_UNKNOWN;

--- a/src/cpu/lazyflags.h
+++ b/src/cpu/lazyflags.h
@@ -43,8 +43,8 @@ struct LazyFlags {
 	GenReg32 var1 = {};
 	GenReg32 var2 = {};
 	GenReg32 res = {};
-	uint8_t type  = 0;
-	uint8_t oldcf = 0;
+	uint_fast8_t type  = 0;
+	uint_fast8_t oldcf = 0;
 };
 
 extern LazyFlags lflags;

--- a/src/cpu/lazyflags.h
+++ b/src/cpu/lazyflags.h
@@ -43,9 +43,8 @@ struct LazyFlags {
 	GenReg32 var1 = {};
 	GenReg32 var2 = {};
 	GenReg32 res = {};
-	Bitu type = 0;
-	Bitu prev_type = 0;
-	Bitu oldcf = 0;
+	uint8_t type  = 0;
+	uint8_t oldcf = 0;
 };
 
 extern LazyFlags lflags;

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -346,7 +346,7 @@ public:
 			// 3: fails a privilege check
 			int priv_check=0;
 			if (InitPage_CheckUseraccess(entry.block.us,table.block.us)) {
-				if ((cpu.cpl&cpu.mpl)==3) priv_check=3;
+				if (USERWRITE_PROHIBITED) priv_check=3;
 				else {
 					switch (CPU_ArchitectureType) {
 					case CPU_ARCHTYPE_MIXED:
@@ -669,8 +669,8 @@ bool PAGING_ForcePageInit(Bitu lin_addr) {
 #if defined(USE_FULL_TLB)
 void PAGING_InitTLB(void) {
 	for (auto i=0;i<TLB_SIZE;i++) {
-		paging.tlb.read[i]=0;
-		paging.tlb.write[i]=0;
+		paging.tlb.read[i]=nullptr;
+		paging.tlb.write[i]=nullptr;
 		paging.tlb.readhandler[i]=&init_page_handler;
 		paging.tlb.writehandler[i]=&init_page_handler;
 	}
@@ -681,8 +681,8 @@ void PAGING_ClearTLB(void) {
 	uint32_t * entries=&paging.links.entries[0];
 	for (;paging.links.used>0;paging.links.used--) {
 		const auto page=*entries++;
-		paging.tlb.read[page]=0;
-		paging.tlb.write[page]=0;
+		paging.tlb.read[page]=nullptr;
+		paging.tlb.write[page]=nullptr;
 		paging.tlb.readhandler[page]=&init_page_handler;
 		paging.tlb.writehandler[page]=&init_page_handler;
 	}
@@ -691,8 +691,8 @@ void PAGING_ClearTLB(void) {
 
 void PAGING_UnlinkPages(Bitu lin_page,Bitu pages) {
 	for (;pages>0;pages--) {
-		paging.tlb.read[lin_page]=0;
-		paging.tlb.write[lin_page]=0;
+		paging.tlb.read[lin_page]=nullptr;
+		paging.tlb.write[lin_page]=nullptr;
 		paging.tlb.readhandler[lin_page]=&init_page_handler;
 		paging.tlb.writehandler[lin_page]=&init_page_handler;
 		lin_page++;
@@ -702,8 +702,8 @@ void PAGING_UnlinkPages(Bitu lin_page,Bitu pages) {
 void PAGING_MapPage(Bitu lin_page,Bitu phys_page) {
 	if (lin_page<LINK_START) {
 		paging.firstmb[lin_page]=phys_page;
-		paging.tlb.read[lin_page]=0;
-		paging.tlb.write[lin_page]=0;
+		paging.tlb.read[lin_page]=nullptr;
+		paging.tlb.write[lin_page]=nullptr;
 		paging.tlb.readhandler[lin_page]=&init_page_handler;
 		paging.tlb.writehandler[lin_page]=&init_page_handler;
 	} else {
@@ -725,9 +725,9 @@ void PAGING_LinkPage(uint32_t lin_page,uint32_t phys_page) {
 
 	paging.tlb.phys_page[lin_page]=phys_page;
 	if (handler->flags & PFLAG_READABLE) paging.tlb.read[lin_page]=handler->GetHostReadPt(phys_page)-lin_base;
-	else paging.tlb.read[lin_page]=0;
+	else paging.tlb.read[lin_page]=nullptr;
 	if (handler->flags & PFLAG_WRITEABLE) paging.tlb.write[lin_page]=handler->GetHostWritePt(phys_page)-lin_base;
-	else paging.tlb.write[lin_page]=0;
+	else paging.tlb.write[lin_page]=nullptr;
 
 	paging.links.entries[paging.links.used++]=lin_page;
 	paging.tlb.readhandler[lin_page]=handler;
@@ -748,8 +748,8 @@ void PAGING_LinkPage_ReadOnly(uint32_t lin_page,uint32_t phys_page) {
 
 	paging.tlb.phys_page[lin_page]=phys_page;
 	if (handler->flags & PFLAG_READABLE) paging.tlb.read[lin_page]=handler->GetHostReadPt(phys_page)-lin_base;
-	else paging.tlb.read[lin_page]=0;
-	paging.tlb.write[lin_page]=0;
+	else paging.tlb.read[lin_page]=nullptr;
+	paging.tlb.write[lin_page]=nullptr;
 
 	paging.links.entries[paging.links.used++]=lin_page;
 	paging.tlb.readhandler[lin_page]=handler;

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -147,10 +147,8 @@ bool first=false;
 
 void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,uint32_t faultcode) {
 	/* Save the state of the cpu cores */
-	LazyFlags old_lflags;
-	memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-	CPU_Decoder * old_cpudecoder;
-	old_cpudecoder=cpudecoder;
+	const auto old_lflags = lflags;
+	const auto old_cpudecoder=cpudecoder;
 	cpudecoder=&PageFaultCore;
 	paging.cr2=lin_addr;
 	PF_Entry * entry=&pf_queue.entries[pf_queue.used++];
@@ -167,7 +165,7 @@ void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,uint32_t faultcode) {
 	DOSBOX_RunMachine();
 	pf_queue.used--;
 	LOG(LOG_PAGING, LOG_NORMAL)("Left PageFault for %x queue %u", lin_addr, pf_queue.used);
-	memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+	lflags = old_lflags;
 	cpudecoder=old_cpudecoder;
 //	LOG_MSG("SS:%04x SP:%08X",SegValue(ss),reg_esp);
 }

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -112,10 +112,10 @@ bool PageHandler::writed_checked(PhysPt addr, uint32_t val)
 }
 
 struct PF_Entry {
-	Bitu cs;
-	Bitu eip;
-	Bitu page_addr;
-	Bitu mpl;
+	uint32_t cs;
+	uint32_t eip;
+	uint32_t page_addr;
+	uint32_t mpl;
 };
 
 #define PF_QUEUESIZE 16
@@ -145,7 +145,7 @@ static Bits PageFaultCore(void) {
 
 bool first=false;
 
-void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,uint32_t faultcode) {
+void PAGING_PageFault(PhysPt lin_addr,uint32_t page_addr,uint32_t faultcode) {
 	/* Save the state of the cpu cores */
 	const auto old_lflags = lflags;
 	const auto old_cpudecoder=cpudecoder;
@@ -170,7 +170,7 @@ void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,uint32_t faultcode) {
 //	LOG_MSG("SS:%04x SP:%08X",SegValue(ss),reg_esp);
 }
 
-static inline void InitPageUpdateLink(Bitu relink,PhysPt addr) {
+static inline void InitPageUpdateLink(uint32_t relink,PhysPt addr) {
 	if (relink==0) return;
 	if (paging.links.used) {
 		if (paging.links.entries[paging.links.used-1]==(addr>>12)) {
@@ -182,10 +182,10 @@ static inline void InitPageUpdateLink(Bitu relink,PhysPt addr) {
 }
 
 static inline void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEntry& table,X86PageEntry& entry) {
-	Bitu lin_page=lin_addr >> 12;
-	Bitu d_index=lin_page >> 10;
-	Bitu t_index=lin_page & 0x3ff;
-	Bitu table_addr=(paging.base.page<<12)+d_index*4;
+	const auto lin_page=lin_addr >> 12;
+	const auto d_index=lin_page >> 10;
+	const auto t_index=lin_page & 0x3ff;
+	const auto table_addr=(paging.base.page<<12)+d_index*4;
 	table.load=phys_readd(table_addr);
 	if (!table.block.p) {
 		LOG(LOG_PAGING,LOG_NORMAL)("NP Table");
@@ -195,7 +195,7 @@ static inline void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEnt
 		if (GCC_UNLIKELY(!table.block.p))
 			E_Exit("Pagefault didn't correct table");
 	}
-	Bitu entry_addr=(table.block.base<<12)+t_index*4;
+	const auto entry_addr=(table.block.base<<12)+t_index*4;
 	entry.load=phys_readd(entry_addr);
 	if (!entry.block.p) {
 //		LOG(LOG_PAGING,LOG_NORMAL)("NP Page");
@@ -208,10 +208,10 @@ static inline void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEnt
 }
 			
 static inline bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,X86PageEntry& table,X86PageEntry& entry) {
-	Bitu lin_page=lin_addr >> 12;
-	Bitu d_index=lin_page >> 10;
-	Bitu t_index=lin_page & 0x3ff;
-	Bitu table_addr=(paging.base.page<<12)+d_index*4;
+	const auto lin_page=lin_addr >> 12;
+	const auto d_index=lin_page >> 10;
+	const auto t_index=lin_page & 0x3ff;
+	const auto table_addr=(paging.base.page<<12)+d_index*4;
 	table.load=phys_readd(table_addr);
 	if (!table.block.p) {
 		paging.cr2=lin_addr;
@@ -219,7 +219,7 @@ static inline bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,
 		cpu.exception.error=(writing?0x02:0x00) | (((cpu.cpl&cpu.mpl)==0)?0x00:0x04);
 		return false;
 	}
-	Bitu entry_addr=(table.block.base<<12)+t_index*4;
+	const auto entry_addr=(table.block.base<<12)+t_index*4;
 	entry.load=phys_readd(entry_addr);
 	if (!entry.block.p) {
 		paging.cr2=lin_addr;
@@ -231,7 +231,7 @@ static inline bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,
 }
 
 // check if a user-level memory access would trigger a privilege page fault
-static inline bool InitPage_CheckUseraccess(Bitu u1,Bitu u2) {
+static inline bool InitPage_CheckUseraccess(uint32_t u1,uint32_t u2) {
 	switch (CPU_ArchitectureType) {
 	case CPU_ARCHTYPE_MIXED:
 	case CPU_ARCHTYPE_386SLOW:
@@ -332,9 +332,9 @@ public:
 			return false;
 		} else return true;
 	}
-	Bitu InitPage(Bitu lin_addr,bool writing) {
-		Bitu lin_page=lin_addr >> 12;
-		Bitu phys_page;
+	uint32_t InitPage(uint32_t lin_addr,bool writing) {
+		const auto lin_page=lin_addr >> 12;
+		uint32_t phys_page;
 		if (paging.enabled) {
 			X86PageEntry table;
 			X86PageEntry entry;
@@ -344,7 +344,7 @@ public:
 			// 1: can (but currently does not) fail a user-level access privilege check
 			// 2: can (but currently does not) fail a write privilege check
 			// 3: fails a privilege check
-			Bitu priv_check=0;
+			int priv_check=0;
 			if (InitPage_CheckUseraccess(entry.block.us,table.block.us)) {
 				if ((cpu.cpl&cpu.mpl)==3) priv_check=3;
 				else {
@@ -435,8 +435,8 @@ public:
 		}
 		return 0;
 	}
-	bool InitPageCheckOnly(Bitu lin_addr,bool writing) {
-		Bitu lin_page=lin_addr >> 12;
+	bool InitPageCheckOnly(uint32_t lin_addr,bool writing) {
+		const auto lin_page=lin_addr >> 12;
 		if (paging.enabled) {
 			X86PageEntry table;
 			X86PageEntry entry;
@@ -454,16 +454,16 @@ public:
 				return false;
 			}
 		} else {
-			Bitu phys_page;
+			uint32_t phys_page;
 			if (lin_page<LINK_START) phys_page=paging.firstmb[lin_page];
 			else phys_page=lin_page;
 			PAGING_LinkPage(lin_page,phys_page);
 		}
 		return true;
 	}
-	void InitPageForced(Bitu lin_addr) {
-		Bitu lin_page=lin_addr >> 12;
-		Bitu phys_page;
+	void InitPageForced(uint32_t lin_addr) {
+		const auto lin_page=lin_addr >> 12;
+		uint32_t phys_page;
 		if (paging.enabled) {
 			X86PageEntry table;
 			X86PageEntry entry;
@@ -509,7 +509,7 @@ public:
 	}
 	bool writeb_checked(PhysPt addr, uint8_t val)
 	{
-		Bitu writecode = InitPageCheckOnly(addr, val);
+		const auto writecode = InitPageCheckOnly(addr, val);
 		if (writecode) {
 			HostPt tlb_addr;
 			if (writecode>1) tlb_addr=get_tlb_read(addr);
@@ -521,7 +521,7 @@ public:
 	}
 	bool writew_checked(PhysPt addr, uint16_t val)
 	{
-		Bitu writecode = InitPageCheckOnly(addr, val);
+		const auto writecode = InitPageCheckOnly(addr, val);
 		if (writecode) {
 			HostPt tlb_addr;
 			if (writecode>1) tlb_addr=get_tlb_read(addr);
@@ -533,7 +533,7 @@ public:
 	}
 	bool writed_checked(PhysPt addr, uint32_t val)
 	{
-		Bitu writecode = InitPageCheckOnly(addr, val);
+		const auto writecode = InitPageCheckOnly(addr, val);
 		if (writecode) {
 			HostPt tlb_addr;
 			if (writecode>1) tlb_addr=get_tlb_read(addr);
@@ -543,9 +543,9 @@ public:
 		}
 		return true;
 	}
-	void InitPage(Bitu lin_addr, [[maybe_unused]] Bitu val) {
-		Bitu lin_page=lin_addr >> 12;
-		Bitu phys_page;
+	void InitPage(uint32_t lin_addr, [[maybe_unused]] uint32_t val) {
+		const auto lin_page=lin_addr >> 12;
+		uint32_t phys_page;
 		if (paging.enabled) {
 			if (!USERWRITE_PROHIBITED) return;
 
@@ -574,8 +574,8 @@ public:
 			PAGING_LinkPage(lin_page,phys_page);
 		}
 	}
-	Bitu InitPageCheckOnly(Bitu lin_addr, [[maybe_unused]] Bitu val) {
-		Bitu lin_page=lin_addr >> 12;
+	uint32_t InitPageCheckOnly(uint32_t lin_addr, [[maybe_unused]] uint32_t val) {
+		const auto lin_page=lin_addr >> 12;
 		if (paging.enabled) {
 			if (!USERWRITE_PROHIBITED) return 2;
 
@@ -593,16 +593,16 @@ public:
 			}
 			PAGING_LinkPage(lin_page,entry.block.base);
 		} else {
-			Bitu phys_page;
+			uint32_t phys_page;
 			if (lin_page<LINK_START) phys_page=paging.firstmb[lin_page];
 			else phys_page=lin_page;
 			PAGING_LinkPage(lin_page,phys_page);
 		}
 		return 1;
 	}
-	void InitPageForced(Bitu lin_addr) {
-		Bitu lin_page=lin_addr >> 12;
-		Bitu phys_page;
+	void InitPageForced(uint32_t lin_addr) {
+		const auto lin_page=lin_addr >> 12;
+		uint32_t phys_page;
 		if (paging.enabled) {
 			X86PageEntry table;
 			X86PageEntry entry;
@@ -627,9 +627,10 @@ public:
 
 
 bool PAGING_MakePhysPage(Bitu & page) {
+	assert(page <= UINT32_MAX);
 	if (paging.enabled) {
-		Bitu d_index=page >> 10;
-		Bitu t_index=page & 0x3ff;
+		uint32_t d_index=page >> 10;
+		uint32_t t_index=page & 0x3ff;
 		X86PageEntry table;
 		table.load=phys_readd((paging.base.page<<12)+d_index*4);
 		if (!table.block.p) return false;
@@ -667,7 +668,7 @@ bool PAGING_ForcePageInit(Bitu lin_addr) {
 
 #if defined(USE_FULL_TLB)
 void PAGING_InitTLB(void) {
-	for (Bitu i=0;i<TLB_SIZE;i++) {
+	for (auto i=0;i<TLB_SIZE;i++) {
 		paging.tlb.read[i]=0;
 		paging.tlb.write[i]=0;
 		paging.tlb.readhandler[i]=&init_page_handler;
@@ -679,7 +680,7 @@ void PAGING_InitTLB(void) {
 void PAGING_ClearTLB(void) {
 	uint32_t * entries=&paging.links.entries[0];
 	for (;paging.links.used>0;paging.links.used--) {
-		Bitu page=*entries++;
+		const auto page=*entries++;
 		paging.tlb.read[page]=0;
 		paging.tlb.write[page]=0;
 		paging.tlb.readhandler[page]=&init_page_handler;
@@ -710,9 +711,9 @@ void PAGING_MapPage(Bitu lin_page,Bitu phys_page) {
 	}
 }
 
-void PAGING_LinkPage(Bitu lin_page,Bitu phys_page) {
-	PageHandler * handler=MEM_GetPageHandler(phys_page);
-	Bitu lin_base=lin_page << 12;
+void PAGING_LinkPage(uint32_t lin_page,uint32_t phys_page) {
+	const auto handler=MEM_GetPageHandler(phys_page);
+	const auto lin_base=lin_page << 12;
 	if (lin_page>=TLB_SIZE || phys_page>=TLB_SIZE) 
 		E_Exit("Illegal page");
 
@@ -733,9 +734,9 @@ void PAGING_LinkPage(Bitu lin_page,Bitu phys_page) {
 	paging.tlb.writehandler[lin_page]=handler;
 }
 
-void PAGING_LinkPage_ReadOnly(Bitu lin_page,Bitu phys_page) {
-	PageHandler * handler=MEM_GetPageHandler(phys_page);
-	Bitu lin_base=lin_page << 12;
+void PAGING_LinkPage_ReadOnly(uint32_t lin_page,uint32_t phys_page) {
+	const auto handler=MEM_GetPageHandler(phys_page);
+	const auto lin_base=lin_page << 12;
 	if (lin_page>=TLB_SIZE || phys_page>=TLB_SIZE) 
 		E_Exit("Illegal page");
 
@@ -862,10 +863,11 @@ void PAGING_LinkPage_ReadOnly(Bitu lin_page,Bitu phys_page) {
 
 
 void PAGING_SetDirBase(Bitu cr3) {
-	paging.cr3=cr3;
+	assert(cr3 <= UINT32_MAX);
+	paging.cr3=static_cast<uint32_t>(cr3);
 	
-	paging.base.page=cr3 >> 12;
-	paging.base.addr=cr3 & ~4095;
+	paging.base.page=static_cast<uint32_t>(cr3 >> 12);
+	paging.base.addr=static_cast<PhysPt>(cr3 & ~4095);
 //	LOG(LOG_PAGING,LOG_NORMAL)("CR3:%X Base %X",cr3,paging.base.page);
 	if (paging.enabled) {
 		PAGING_ClearTLB();
@@ -899,8 +901,7 @@ public:
 		/* Setup default Page Directory, force it to update */
 		paging.enabled=false;
 		PAGING_InitTLB();
-		Bitu i;
-		for (i=0;i<LINK_START;i++) {
+		for (auto i=0;i<LINK_START;i++) {
 			paging.firstmb[i]=i;
 		}
 		pf_queue.used=0;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2060,7 +2060,7 @@ void LogPages(char* selname) {
 
 static void LogCPUInfo(void) {
 	char out1[512];
-	sprintf(out1,"cr0:%08" sBitfs(X) " cr2:%08" sBitfs(X) " cr3:%08" sBitfs(X) "  cpl=%" sBitfs(x),cpu.cr0,paging.cr2,paging.cr3,cpu.cpl);
+	sprintf(out1,"cr0:%08" sBitfs(X) " cr2:%08u cr3:%08u  cpl=%" sBitfs(x),cpu.cr0,paging.cr2,paging.cr3,cpu.cpl);
 	LOG(LOG_MISC,LOG_ERROR)("%s",out1);
 	sprintf(out1, "eflags:%08x [vm=%x iopl=%x nt=%x]", reg_flags,
 	        GETFLAG(VM) >> 17, GETFLAG(IOPL) >> 12, GETFLAG(NT) >> 14);

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -167,10 +167,8 @@ void IO_WriteB(io_port_t port, uint8_t val)
 {
 	log_io(io_width_t::byte, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
-		LazyFlags old_lflags;
-		memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-		CPU_Decoder * old_cpudecoder;
-		old_cpudecoder=cpudecoder;
+		const auto old_lflags = lflags;
+		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
 		IOF_Entry * entry=&iof_queue.entries[iof_queue.used++];
 		entry->cs=SegValue(cs);
@@ -191,7 +189,7 @@ void IO_WriteB(io_port_t port, uint8_t val)
 
 		reg_al = old_al;
 		reg_dx = old_dx;
-		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 	}
 	else {
@@ -204,10 +202,8 @@ void IO_WriteW(io_port_t port, uint16_t val)
 {
 	log_io(io_width_t::word, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
-		LazyFlags old_lflags;
-		memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-		CPU_Decoder * old_cpudecoder;
-		old_cpudecoder=cpudecoder;
+		const auto old_lflags = lflags;
+		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
 		IOF_Entry * entry=&iof_queue.entries[iof_queue.used++];
 		entry->cs=SegValue(cs);
@@ -228,7 +224,7 @@ void IO_WriteW(io_port_t port, uint16_t val)
 
 		reg_ax = old_ax;
 		reg_dx = old_dx;
-		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 	}
 	else {
@@ -241,10 +237,8 @@ void IO_WriteD(io_port_t port, uint32_t val)
 {
 	log_io(io_width_t::dword, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
-		LazyFlags old_lflags;
-		memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-		CPU_Decoder * old_cpudecoder;
-		old_cpudecoder=cpudecoder;
+		const auto old_lflags = lflags;
+		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
 		IOF_Entry * entry=&iof_queue.entries[iof_queue.used++];
 		entry->cs=SegValue(cs);
@@ -265,7 +259,7 @@ void IO_WriteD(io_port_t port, uint32_t val)
 
 		reg_eax = old_eax;
 		reg_dx = old_dx;
-		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 	} else {
 		write_dword_to_port(port, val);
@@ -276,10 +270,8 @@ uint8_t IO_ReadB(io_port_t port)
 {
 	uint8_t retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
-		LazyFlags old_lflags;
-		memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-		CPU_Decoder * old_cpudecoder;
-		old_cpudecoder=cpudecoder;
+		const auto old_lflags = lflags;
+		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
 		IOF_Entry * entry=&iof_queue.entries[iof_queue.used++];
 		entry->cs=SegValue(cs);
@@ -300,7 +292,7 @@ uint8_t IO_ReadB(io_port_t port)
 		retval = reg_al;
 		reg_al = old_al;
 		reg_dx = old_dx;
-		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 		return retval;
 	}
@@ -316,10 +308,8 @@ uint16_t IO_ReadW(io_port_t port)
 {
 	uint16_t retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
-		LazyFlags old_lflags;
-		memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-		CPU_Decoder * old_cpudecoder;
-		old_cpudecoder=cpudecoder;
+		const auto old_lflags = lflags;
+		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
 		IOF_Entry * entry=&iof_queue.entries[iof_queue.used++];
 		entry->cs=SegValue(cs);
@@ -340,7 +330,7 @@ uint16_t IO_ReadW(io_port_t port)
 		retval = reg_ax;
 		reg_ax = old_ax;
 		reg_dx = old_dx;
-		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 	}
 	else {
@@ -355,10 +345,8 @@ uint32_t IO_ReadD(io_port_t port)
 {
 	uint32_t retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
-		LazyFlags old_lflags;
-		memcpy(&old_lflags,&lflags,sizeof(LazyFlags));
-		CPU_Decoder * old_cpudecoder;
-		old_cpudecoder=cpudecoder;
+		const auto old_lflags = lflags;
+		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
 		IOF_Entry * entry=&iof_queue.entries[iof_queue.used++];
 		entry->cs=SegValue(cs);
@@ -379,7 +367,7 @@ uint32_t IO_ReadD(io_port_t port)
 		retval = reg_eax;
 		reg_eax = old_eax;
 		reg_dx = old_dx;
-		memcpy(&lflags,&old_lflags,sizeof(LazyFlags));
+		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 	} else {
 		retval = read_dword_from_port(port);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -427,8 +427,9 @@ bool MEM_A20_Enabled(void) {
 }
 
 void MEM_A20_Enable(bool enabled) {
-	Bitu phys_base=enabled ? (1024/4) : 0;
-	for (Bitu i=0;i<16;i++) PAGING_MapPage((1024/4)+i,phys_base+i);
+	if (enabled == memory.a20.enabled) return;
+	const uint32_t phys_base=enabled ? (1024/4) : 0;
+	for (int i=0;i<16;i++) PAGING_MapPage((1024/4)+i,phys_base+i);
 	memory.a20.enabled=enabled;
 }
 


### PR DESCRIPTION
Use the smallest needed types for `lflags` struct members and `PageHandler.flags`. Using the smaller types may improve performance, especially on AArch64 systems, since `lflags.type` is accessed so heavily for instruction decoding and execution, and `PageHandler.flags` when paging is active.