### PR TITLE
Add mute hotkey (Ctrl+F8) and priority level

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -52,6 +52,14 @@ enum MixerModes {
 	M_16M,M_16S
 };
 
+enum class MixerState {
+	Uninitialized,
+	NoSound,
+	Off,
+	On,
+	Mute,
+};
+
 // A simple stereo audio frame
 struct AudioFrame {
 	float left = 0;
@@ -268,5 +276,7 @@ void PCSPEAKER_SetType(int mode);
 
 // Mixer configuration and initialization
 void MIXER_AddConfigSection(const config_ptr_t &conf);
+bool MIXER_IsManuallyMuted();
+void MIXER_SetState(const MixerState requested);
 
 #endif

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -100,7 +100,6 @@ struct VsyncPreference {
 
 enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_AUTO,
-	PRIORITY_LEVEL_PAUSE,
 	PRIORITY_LEVEL_LOWEST,
 	PRIORITY_LEVEL_LOWER,
 	PRIORITY_LEVEL_NORMAL,
@@ -200,9 +199,13 @@ struct SDL_Block {
 	} opengl = {};
 #endif // C_OPENGL
 	struct {
-		PRIORITY_LEVELS focus;
-		PRIORITY_LEVELS nofocus;
+		PRIORITY_LEVELS active   = PRIORITY_LEVEL_AUTO;
+		PRIORITY_LEVELS inactive = PRIORITY_LEVEL_AUTO;
 	} priority = {};
+
+	bool mute_when_inactive  = false;
+	bool pause_when_inactive = false;
+
 	SDL_Rect clip = {0, 0, 0, 0};
 	SDL_Surface *surface = nullptr;
 	SDL_Window *window = nullptr;

--- a/include/video.h
+++ b/include/video.h
@@ -58,6 +58,10 @@ typedef void (*GFX_CallBack_t)( GFX_CallBackFunctions_t function );
 // - false means event loop wants to quit.
 bool GFX_Events();
 
+// Let the presentation layer safely call no-op functions.
+// Useful during output initialization or transitions.
+void GFX_DisengageRendering();
+
 Bitu GFX_GetBestMode(Bitu flags);
 Bitu GFX_GetRGB(uint8_t red,uint8_t green,uint8_t blue);
 void GFX_SetShader(const std::string &source);

--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -24,14 +24,30 @@
 
 void INTRO::WriteOutProgramIntroSpecial()
 {
-    WriteOut(MSG_Get("PROGRAM_INTRO_SPECIAL"), MMOD2_NAME,
-                MMOD2_NAME, PRIMARY_MOD_NAME, PRIMARY_MOD_PAD,
-                PRIMARY_MOD_NAME, PRIMARY_MOD_PAD, PRIMARY_MOD_NAME,
-                PRIMARY_MOD_PAD, PRIMARY_MOD_NAME, PRIMARY_MOD_PAD,
-                PRIMARY_MOD_NAME, PRIMARY_MOD_PAD, PRIMARY_MOD_NAME,
-                PRIMARY_MOD_PAD, PRIMARY_MOD_NAME, PRIMARY_MOD_PAD,
-                PRIMARY_MOD_NAME, PRIMARY_MOD_PAD, PRIMARY_MOD_NAME,
-                PRIMARY_MOD_PAD, MMOD2_NAME);
+	WriteOut(MSG_Get("PROGRAM_INTRO_SPECIAL"),
+	         MMOD2_NAME,       // Alt, for fullscreen toggle
+	         MMOD2_NAME,       // Alt, for pause/unpause
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for keymapper
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for swap disk image
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for screenshot
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for sound recording
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for video recording
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for mute/unmute
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for shutdown
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for mouse capture
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for slow down
+	         PRIMARY_MOD_PAD,
+	         PRIMARY_MOD_NAME, // Ctrl/Cmd, for speed up
+	         PRIMARY_MOD_PAD,
+	         MMOD2_NAME); // Alt, for turbo
 }
 
 void INTRO::DisplayMount(void) {
@@ -186,6 +202,7 @@ void INTRO::AddMessages() {
 	        "\033[33;1m%s+F5\033[0m   %s Save a screenshot.\n"
 	        "\033[33;1m%s+F6\033[0m   %s Start/Stop recording sound output to a wave file.\n"
 	        "\033[33;1m%s+F7\033[0m   %s Start/Stop recording video output to a zmbv file.\n"
+	        "\033[33;1m%s+F8\033[0m   %s Mute/Unmute the audio.\n"
 	        "\033[33;1m%s+F9\033[0m   %s Shutdown emulator.\n"
 	        "\033[33;1m%s+F10\033[0m  %s Capture/Release the mouse.\n"
 	        "\033[33;1m%s+F11\033[0m  %s Slow down emulation.\n"

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2904,6 +2904,11 @@ void MAPPER_Run(bool pressed) {
 SDL_Surface* SDL_SetVideoMode_Wrap(int width,int height,int bpp,uint32_t flags);
 
 void MAPPER_DisplayUI() {
+	// The mapper is about to take-over SDL's surface and rendering
+	// functions, so disengage the main ones. When the mapper closes, SDL
+	// main will recreate its rendering pipeline.
+	GFX_DisengageRendering();
+
 	int cursor = SDL_ShowCursor(SDL_QUERY);
 	SDL_ShowCursor(SDL_ENABLE);
 	bool mousetoggle = false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -587,6 +587,14 @@ check_surface:
 	return flags;
 }
 
+// Let the presentation layer safely call no-op functions.
+// Useful during output initialization or transitions.
+void GFX_DisengageRendering()
+{
+	sdl.frame.update  = update_frame_noop;
+	sdl.frame.present = present_frame_noop;
+}
+
 /* Reset the screen with current values in the sdl structure */
 void GFX_ResetScreen(void) {
 	GFX_Stop();
@@ -608,14 +616,6 @@ void GFX_ForceFullscreenExit()
 	while ((val >>= 1) != 0)
 		log++;
 	return log;
-}
-
-// Let the presentation layer safely call no-op functions.
-// Useful during output initialization or transitions.
-static void disengage_frame_rendering()
-{
-	sdl.frame.update = update_frame_noop;
-	sdl.frame.present = present_frame_noop;
 }
 
 // This is a hack to prevent SDL2 from re-creating window internally. Prevents
@@ -1498,7 +1498,7 @@ Bitu GFX_SetSize(int width,
 	if (sdl.updating)
 		GFX_EndUpdate(nullptr);
 
-	disengage_frame_rendering();
+	GFX_DisengageRendering();
 	// The rendering objects are recreated below with new sizes, after which
 	// frame rendering is re-engaged with the output-type specific calls.
 
@@ -3051,7 +3051,7 @@ static void set_output(Section *sec, bool should_stretch_pixels)
 	const auto section = static_cast<const Section_prop *>(sec);
 	std::string output = section->Get_string("output");
 
-	disengage_frame_rendering();
+	GFX_DisengageRendering();
 	// it's the job of everything after this to re-engage it.
 
 	if (output == "surface") {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1569,6 +1569,8 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "  <strength>:  Set crossfeed strength from 0 to 100, where 0 means no crossfeed (off)\n"
 	        "               and 100 full crossfeed (effectively turning stereo content into mono).\n"
 	        "Note: You can set per-channel crossfeed via mixer commands.");
+
+	MAPPER_AddHandler(ToggleMute, SDL_SCANCODE_F8, PRIMARY_MOD, "mute", "Mute");
 }
 
 void MIXER_AddConfigSection(const config_ptr_t &conf)


### PR DESCRIPTION
Thanks to @Grounded0 for suggesting this!

One approach to muting is setting the system volume level to zero, which keeps the audio subsystem running at full power:
 - each channel's data (be it 8-bit or 16-bit, mono or stereo, etc) is type and value-normalized,
 - each channel's stream is resampled to SDL's output rate,
 - each channel's filters may be applied, 
 - the mixer combines the active channels into one output stream, and
 - SDL's audio thread pushes output to the host's audio driver

This PR uses a low-power approach:
 - Applies the mixer's "no-op" mode, which keeps the channels running on the DOS side but skips all of the above mixer steps. This mode is also used when `[mixer] nosound = true` is set.
 - When mute, this PR pauses SDL's audio device output, which might let the host place the audio device into a power-saving mode (if DOSBox is the only active output).

Also adds `mute` and `pause` when inactive conf settings:
``` ini
[sdl]
mute_when_inactive = true
pause_when_inactive = true
```

Removes `pause` from the list of priority settings, because it's not really a processing level.