### PR TITLE
Implement filtering for small-speaker audio systems

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -244,9 +244,16 @@ private:
 	} zoh_upsampler = {};
 
 	struct {
-		FilterState state = FilterState::Off;
-		std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
-	} filter = {};
+		struct {
+			FilterState state = FilterState::Off;
+			std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
+		} lowpass = {};
+
+		struct {
+			FilterState state = FilterState::Off;
+			std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
+		} lowpass = {};
+	} filters = {};
 
 	struct {
 		float strength = 0.0f;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -129,7 +129,9 @@ public:
 	void Mix(int _needed);
 	void AddSilence(); // Fill up until needed
 
+	void SetHighPassFilter(const FilterState state);
 	void SetLowPassFilter(const FilterState state);
+	void ConfigureHighPassFilter(const uint8_t order, const uint16_t cutoff_freq);
 	void ConfigureLowPassFilter(const uint8_t order, const uint16_t cutoff_freq);
 
 	void EnableZeroOrderHoldUpsampler(const bool enabled = true);
@@ -246,8 +248,8 @@ private:
 	struct {
 		struct {
 			FilterState state = FilterState::Off;
-			std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
-		} lowpass = {};
+			std::array<Iir::Butterworth::HighPass<max_filter_order>, 2> hpf = {};
+		} highpass = {};
 
 		struct {
 			FilterState state = FilterState::Off;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -879,10 +879,23 @@ void DOSBOX_Init() {
 
 	// IBM PS/1 Audio emulation
 	secprop->AddInitFunction(&PS1AUDIO_Init, true);
+
 	Pbool = secprop->Add_bool("ps1audio", when_idle, false);
 	Pbool->Set_help("Enable IBM PS/1 Audio emulation.");
 
+	Pstring = secprop->Add_string("ps1audio_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the PS/1 Audio synth output:\n"
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
+
+	Pstring = secprop->Add_string("ps1audio_dac_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the PS/1 Audio DAC output:\n"
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
+
+	// Joystick emulation
 	secprop=control->AddSection_prop("joystick",&BIOS_Init,false);//done
+
 	secprop->AddInitFunction(&INT10_Init);
 	secprop->AddInitFunction(&MOUSE_Init); //Must be after int10 as it uses CurMode
 	secprop->AddInitFunction(&JOYSTICK_Init,true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -798,24 +798,24 @@ void DOSBOX_Init() {
 	Pstring = secprop->Add_string("sb_filter", when_idle, "auto");
 	Pstring->Set_help(
 	        "Type of filter to emulate for the Sound Blaster digital sound output:\n"
-	        "  auto:    Use the appropriate filter determined by 'sbtype' (default).\n"
+	        "  auto:  Use the appropriate filter determined by 'sbtype' (default).\n"
 	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
 	        "           Use the filter of this Sound Blaster model.\n"
-	        "  none:    Don't filter the output.\n"
+	        "  off:   Don't filter the output.\n"
 	        "A second 'always_on' parameter can be provided to disallow programs from turning the filter off.\n"
 	        "(Example: sbpro1 always_on)");
 
 	Pstring = secprop->Add_string("opl_filter", when_idle, "auto");
 	Pstring->Set_help("Type of filter to emulate for the Sound Blaster OPL output:\n"
-	                  "  auto:    Use the appropriate filter determined by 'sbtype' (default).\n"
+	                  "  auto:  Use the appropriate filter determined by 'sbtype' (default).\n"
 	                  "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
 	                  "           Use the filter of this Sound Blaster model.\n"
-	                  "  none:    Don't filter the output.");
+	                  "  off:   Don't filter the output.");
 
 	Pstring = secprop->Add_string("cms_filter", when_idle, "on");
 	Pstring->Set_help("Filter for the Sound Blaster CMS output:\n"
-	                  "  on:    Filter the output (default).\n"
-	                  "  none:  Don't filter the output.");
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
 
 	// Configure Gravis UltraSound emulation
 	GUS_AddConfigSection(control);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -865,7 +865,7 @@ void DOSBOX_Init() {
 	Pstring = secprop->Add_string("tandy", when_idle, "auto");
 	Pstring->Set_values(tandys);
 	Pstring->Set_help(
-	        "Enable Tandy Sound System emulation. "
+	        "Enable Tandy Sound System emulation."
 	        "For 'auto', emulation is present only if machine is set to 'tandy'.");
 
 	Pstring = secprop->Add_string("tandy_filter", when_idle, "on");
@@ -883,6 +883,11 @@ void DOSBOX_Init() {
 
 	Pbool = secprop->Add_bool("disney", when_idle, true);
 	Pbool->Set_help("Enable Disney Sound Source emulation. (Covox Voice Master and Speech Thing compatible).");
+
+	Pstring = secprop->Add_string("disney_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the Disney audio output:\n"
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
 
 	// IBM PS/1 Audio emulation
 	secprop->AddInitFunction(&PS1AUDIO_Init, true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -823,11 +823,13 @@ void DOSBOX_Init() {
 	// Configure Innovation SSI-2001 emulation
 	INNOVATION_AddConfigSection(control);
 
+	// PC speaker emulation
 	secprop = control->AddSection_prop("speaker",&PCSPEAKER_Init,true);//done
-	Pbool = secprop->Add_bool("pcspeaker", when_idle, true);
-	Pbool->Set_help("Enable PC-Speaker emulation.");
 
-	// Basis for the default PC-Speaker sample generation rate:
+	Pbool = secprop->Add_bool("pcspeaker", when_idle, true);
+	Pbool->Set_help("Enable PC speaker emulation.");
+
+	// Basis for the default PC speaker sample generation rate:
 	//   "With the PC speaker, typically a 6-bit DAC with a maximum value of
 	//   63
 	//    is used at a sample rate of 18,939.4 Hz."
@@ -840,7 +842,7 @@ void DOSBOX_Init() {
 	// the authors.
 	pint = secprop->Add_int("pcrate", when_idle, 18939);
 	pint->SetMinMax(8000, 48000);
-	pint->Set_help("Sample rate of the PC-Speaker sound generation.");
+	pint->Set_help("Sample rate of the PC speaker sound generation.");
 
 	const char *zero_offset_opts[] = {"auto", "true", "false", 0};
 	pstring = secprop->Add_string("zero_offset", when_idle, zero_offset_opts[0]);
@@ -849,6 +851,11 @@ void DOSBOX_Init() {
 	        "Neutralizes and prevents the PC speaker's DC-offset from harming other sources.\n"
 	        "'auto' enables this for non-Windows systems and disables it on Windows.\n"
 	        "If your OS performs its own DC-offset correction, then set this to 'false'.");
+
+	Pstring = secprop->Add_string("pcspeaker_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the PC speaker output:\n"
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
 
 	// Tandy audio emulation
 	secprop->AddInitFunction(&TANDYSOUND_Init, true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -850,12 +850,28 @@ void DOSBOX_Init() {
 	        "'auto' enables this for non-Windows systems and disables it on Windows.\n"
 	        "If your OS performs its own DC-offset correction, then set this to 'false'.");
 
+	// Tandy audio emulation
 	secprop->AddInitFunction(&TANDYSOUND_Init, true);
+
 	const char *tandys[] = {"auto", "on", "off", 0};
+
 	Pstring = secprop->Add_string("tandy", when_idle, "auto");
 	Pstring->Set_values(tandys);
-	Pstring->Set_help("Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.");
+	Pstring->Set_help(
+	        "Enable Tandy Sound System emulation. "
+	        "For 'auto', emulation is present only if machine is set to 'tandy'.");
 
+	Pstring = secprop->Add_string("tandy_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the Tandy synth output:\n"
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
+
+	Pstring = secprop->Add_string("tandy_dac_filter", when_idle, "on");
+	Pstring->Set_help("Filter for the Tandy DAC output:\n"
+	                  "  on:   Filter the output (default).\n"
+	                  "  off:  Don't filter the output.");
+
+	// Disney Audio emulation
 	secprop->AddInitFunction(&DISNEY_Init,true);//done
 
 	Pbool = secprop->Add_bool("disney", when_idle, true);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -33,6 +33,9 @@ constexpr uint16_t DISNEY_BASE = 0x0378;
 constexpr uint8_t BUFFER_SAMPLES = 128;
 constexpr uint8_t DISNEY_INIT_STATUS = 0x84;
 
+// The Disney Sound Source is an LPT DAC with a fixed sample rate of 7kHz.
+constexpr auto disney_sample_rate = 7000;
+
 enum DISNEY_STATE { IDLE, RUNNING, FINISHED, ANALYZING };
 
 struct dac_channel {
@@ -58,6 +61,7 @@ struct Disney {
 	Bitu last_used = 0;
 	mixer_channel_t chan = nullptr;
 	bool stereo = false;
+	bool filter_enabled = false;
 
 	// For mono-output, the analysis step points the leader to the channel
 	// with the most rendered-samples. We use the left channel as a valid
@@ -86,33 +90,59 @@ static void DISNEY_disable(uint32_t)
 	disney.stereo = false;
 }
 
-static void DISNEY_enable(uint32_t freq)
+static void update_filter_freq(const uint32_t sample_rate)
 {
-	if (freq < 500 || freq > 100000) {
+	if (!disney.filter_enabled)
+		return;
+
+	// Disney only supports a single fixed 7kHz sample rate; the 6dB/oct LPF @
+	// 1kHz is an accurate emulation of how the actual Disney lowpass filter
+	// sounds.
+	//
+	// With Covox one can theorically achieve any sample rate as long as the
+	// CPU can keep up. Most Covox adapters have no lowpass filter whatsoever,
+	// but as the aim here is to make the sound more pleasant to listen to,
+	// we'll apply a gentle 6dB/oct LPF at a bit below half the sample rate to
+	// tame the harshest aliased frequencies while still retaining a good dose
+	// of the "raw crunchy DAC sound".
+	constexpr auto order              = 1;
+	constexpr auto disney_cutoff_freq = 1000;
+
+	const auto cutoff_freq = (sample_rate == disney_sample_rate)
+	                               ? disney_cutoff_freq
+	                               : static_cast<uint16_t>(sample_rate * 0.45);
+
+	disney.chan->ConfigureLowPassFilter(order, cutoff_freq);
+}
+
+static void DISNEY_enable(uint32_t sample_rate)
+{
+	if (sample_rate < 500 || sample_rate > 100000) {
 		// try again..
 		disney.state = DISNEY_STATE::IDLE;
 		return;
 	}
 #if 0
-	LOG(LOG_MISC,LOG_NORMAL)("DISNEY: enabled at %d Hz in %s", freq,
+	LOG(LOG_MISC,LOG_NORMAL)("DISNEY: enabled at %d Hz in %s", sample_rate,
 	                         disney.stereo ? "stereo" : "mono");
 #endif
-	disney.chan->SetSampleRate(freq);
+	disney.chan->SetSampleRate(sample_rate);
 	disney.chan->Enable(true);
 	disney.state = DISNEY_STATE::RUNNING;
+	update_filter_freq(sample_rate);
 }
 
-// Calculate the frequency from DAC samples and speed parameters
-// The maximum possible frequency return is 127000 Hz, which
-// occurs when all 128 samples are used and the speedcheck_sum
-// has accumulated only one single tick.
-static uint32_t calc_frequency(const dac_channel &dac)
+// Calculate the sample rate from DAC samples and speed parameters.
+// The maximum possible sample rate is 127,000 Hz which occurs when all 128
+// samples are used and the speedcheck_sum has accumulated only one single
+// tick.
+static uint32_t calc_sample_rate(const dac_channel &dac)
 {
 	if (dac.used <= 1)
 		return 0;
 	const uint32_t k_samples = 1000 * (dac.used - 1);
-	const auto frequency = k_samples / dac.speedcheck_sum;
-	return static_cast<uint32_t>(frequency);
+	const auto sample_rate   = k_samples / dac.speedcheck_sum;
+	return static_cast<uint32_t>(sample_rate);
 }
 
 static void DISNEY_analyze(Bitu channel){
@@ -143,10 +173,10 @@ static void DISNEY_analyze(Bitu channel){
 		const auto st_diff = abs(disney.da[0].used - disney.da[1].used);
 		disney.stereo = (st_diff < 5);
 
-		// Run with the greater DAC frequency
-		const auto max_freq = std::max(calc_frequency(disney.da[0]),
-		                               calc_frequency(disney.da[1]));
-		DISNEY_enable(max_freq);
+		// Run with the greater DAC sample rate
+		const auto max_sample_rate = std::max(calc_sample_rate(disney.da[0]),
+		                                      calc_sample_rate(disney.da[1]));
+		DISNEY_enable(max_sample_rate);
 	} break;
 
 	case DISNEY_STATE::ANALYZING: {
@@ -244,7 +274,7 @@ static void disney_write(io_port_t port, io_val_t value, io_width_t)
 				disney.interface_det = 0;
 				if(disney.interface_det_ext > 5) {
 					disney.leader = &disney.da[0];
-					DISNEY_enable(7000);
+					DISNEY_enable(disney_sample_rate);
 				}
 			}
 			if (disney.interface_det_ext > 5) {
@@ -397,10 +427,32 @@ void DISNEY_Init(Section* sec) {
 
 	// Setup the mixer callback
 	disney.chan = MIXER_AddChannel(DISNEY_CallBack,
-	                               10000,
+	                               0,
 	                               "DISNEY",
 	                               {ChannelFeature::ReverbSend,
 	                                ChannelFeature::ChorusSend});
+
+	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
+	// DACs
+	const auto sample_rate = disney.chan->GetSampleRate();
+
+	disney.chan->ConfigureZeroOrderHoldUpsampler(sample_rate);
+	disney.chan->EnableZeroOrderHoldUpsampler();
+
+	// Parse filter setting
+	std::string filter_pref = section->Get_string("disney_filter");
+
+	if (filter_pref == "on") {
+		disney.filter_enabled = true;
+		disney.chan->SetLowPassFilter(FilterState::On);
+	} else {
+		if (filter_pref != "off")
+			LOG_WARNING("DISNEY: Invalid filter setting '%s', using off",
+			            filter_pref.c_str());
+
+		disney.filter_enabled = false;
+		disney.chan->SetLowPassFilter(FilterState::Off);
+	}
 
 	// Register port handlers for 8-bit IO
 	disney.write_handler.Install(DISNEY_BASE, disney_write, io_width_t::byte, 3);

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -90,7 +90,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	                            ChannelFeature::ChorusSend});
 
 	// The filter parameters have been tweaked by analysing real hardware
-	// recordings. The results are virtually undistinguishable from the
+	// recordings. The results are virtually indistinguishable from the
 	// real thing by ear only.
 	if (filter_choice == "on") {
 		constexpr auto order       = 1;

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -89,8 +89,13 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::ChorusSend});
 
+	// The filter parameters have been tweaked by analysing real hardware
+	// recordings. The results are virtually undistinguishable from the
+	// real thing by ear only.
 	if (filter_choice == "on") {
-		channel->ConfigureLowPassFilter(1, 6000);
+		constexpr auto order       = 1;
+		constexpr auto cutoff_freq = 6000.0f;
+		channel->ConfigureLowPassFilter(order, cutoff_freq);
 		channel->SetLowPassFilter(FilterState::On);
 	} else {
 		if (filter_choice != "off")

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -94,7 +94,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	// real thing by ear only.
 	if (filter_choice == "on") {
 		constexpr auto order       = 1;
-		constexpr auto cutoff_freq = 6000.0f;
+		constexpr auto cutoff_freq = 6000;
 		channel->ConfigureLowPassFilter(order, cutoff_freq);
 		channel->SetLowPassFilter(FilterState::On);
 	} else {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -429,9 +429,9 @@ void MixerChannel::SetHighPassFilter(const FilterState state)
 {
 	filters.highpass.state = state;
 
-	auto it = filter_state_map.find(state);
+	const auto it = filter_state_map.find(state);
 	if (it != filter_state_map.end()) {
-		auto filter_state = it->second;
+		const auto filter_state = it->second;
 		LOG_MSG("MIXER: %s channel highpass filter %s",
 		        name.c_str(),
 		        filter_state.c_str());
@@ -442,9 +442,9 @@ void MixerChannel::SetLowPassFilter(const FilterState state)
 {
 	filters.lowpass.state = state;
 
-	auto it = filter_state_map.find(state);
+	const auto it = filter_state_map.find(state);
 	if (it != filter_state_map.end()) {
-		auto filter_state = it->second;
+		const auto filter_state = it->second;
 		LOG_MSG("MIXER: %s channel lowpass filter %s",
 		        name.c_str(),
 		        filter_state.c_str());

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -421,7 +421,7 @@ void MixerChannel::AddSilence()
 
 void MixerChannel::SetLowPassFilter(const FilterState state)
 {
-	filter.state = state;
+	filters.lowpass.state = state;
 
 	static const std::map<FilterState, std::string> filter_state_map = {
 	        {FilterState::Off, "disabled"},
@@ -439,7 +439,7 @@ void MixerChannel::ConfigureLowPassFilter(const uint8_t order,
                                           const uint16_t cutoff_freq)
 {
 	assert(order > 0 && order <= max_filter_order);
-	for (auto &f : filter.lpf)
+	for (auto &f : filters.lowpass.lpf)
 		f.setup(order, mixer.sample_rate, cutoff_freq);
 }
 
@@ -698,8 +698,8 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type *data)
 	auto pos = mixer.resample_out.begin();
 	auto mixpos = check_cast<work_index_t>(mixer.pos + done);
 
-	const auto do_filter = filter.state == FilterState::On ||
-	                       filter.state == FilterState::ForcedOn;
+	const auto do_filter = filters.lowpass.state == FilterState::On ||
+	                       filters.lowpass.state == FilterState::ForcedOn;
 
 	const auto do_crossfeed = crossfeed.strength > 0.0f;
 
@@ -708,8 +708,8 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type *data)
 
 		AudioFrame frame = {*pos++, *pos++};
 		if (do_filter) {
-			frame.left = filter.lpf[0].filter(frame.left);
-			frame.right = filter.lpf[1].filter(frame.right);
+			frame.left = filters.lowpass.lpf[0].filter(frame.left);
+			frame.right = filters.lowpass.lpf[1].filter(frame.right);
 		}
 		if (do_crossfeed)
 			frame = ApplyCrossfeed(frame);

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -140,13 +140,19 @@ static void AddDelayEntry(double index, double vol)
 		vol *= AMPLITUDE_SQUARE_WAVE_REDUCER;
 // #define DEBUG_SQUARE_WAVE 1
 #ifdef DEBUG_SQUARE_WAVE
-		LOG_MSG("SPEAKER: square-wave [prev_pos=%u, prev_mode=%u, mode=%u, prev_pit=%lu, pit=%lu]",
-		        spkr.prev_pos, spkr.prev_mode, spkr.mode,
-		        spkr.prev_pit_mode, spkr.pit_mode);
+		LOG_MSG("PCSPEAKER: square-wave [prev_pos=%u, prev_mode=%u, mode=%u, prev_pit=%lu, pit=%lu]",
+		        spkr.prev_pos,
+		        spkr.prev_mode,
+		        spkr.mode,
+		        spkr.prev_pit_mode,
+		        spkr.pit_mode);
 	} else {
-		LOG_MSG("SPEAKER: sine-wave [prev_pos=%u, prev_mode=%u, mode=%u, prev_pit=%lu, pit=%lu], ",
-		        spkr.prev_pos, spkr.prev_mode, spkr.mode,
-		        spkr.prev_pit_mode, spkr.pit_mode);
+		LOG_MSG("PCSPEAKER: sine-wave [prev_pos=%u, prev_mode=%u, mode=%u, prev_pit=%lu, pit=%lu], ",
+		        spkr.prev_pos,
+		        spkr.prev_mode,
+		        spkr.mode,
+		        spkr.prev_pit_mode,
+		        spkr.pit_mode);
 #endif
 	}
 
@@ -157,7 +163,7 @@ static void AddDelayEntry(double index, double vol)
 	// This is extremely verbose; pipe the output to a file.
 	// Display the previous and current speaker modes w/ requested volume
 	if (fabs(vol) > AMPLITUDE_NEUTRAL)
-		LOG_MSG("SPEAKER: Adding pos=%3s, pit=%" PRIuPTR "|%" PRIuPTR
+		LOG_MSG("PCSPEAKER: Adding pos=%3s, pit=%" PRIuPTR "|%" PRIuPTR
 		        ", pwm=%d|%d, volume=%6.0f",
 		        spkr.prev_pos > 0 ? "yes" : "no", spkr.prev_pit_mode,
 		        spkr.pit_mode, spkr.prev_mode, spkr.mode,
@@ -310,7 +316,7 @@ void PCSPEAKER_SetCounter(int cntr, int mode)
 		break;
 	default:
 #if C_DEBUG
-		LOG_MSG("Unhandled speaker mode %u", mode);
+		LOG_MSG("PCSPEAKER: Unhandled speaker mode %u", mode);
 #endif
 		return;
 	}

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -488,6 +488,7 @@ public:
 		                           DC_SILENCER_WAVES, DC_SILENCER_WAVE_HZ);
 
 		spkr.min_tr = (PIT_TICK_RATE + spkr.rate / 2 - 1) / (spkr.rate / 2);
+
 		/* Register the sound channel */
 		spkr.chan = MIXER_AddChannel(&PCSPEAKER_CallBack,
 		                             spkr.rate,
@@ -496,6 +497,29 @@ public:
 		                              ChannelFeature::ChorusSend});
 		spkr.chan->SetPeakAmplitude(
 		        static_cast<uint32_t>(AMPLITUDE_POSITIVE));
+
+
+		// Setup filters
+		std::string filter_pref = section->Get_string("pcspeaker_filter");
+
+		if (filter_pref == "on") {
+			constexpr auto hp_order       = 3;
+			constexpr auto hp_cutoff_freq = 120.0f;
+			spkr.chan->ConfigureHighPassFilter(hp_order, hp_cutoff_freq);
+			spkr.chan->SetHighPassFilter(FilterState::On);
+
+			constexpr auto lp_order       = 2;
+			constexpr auto lp_cutoff_freq = 4800.0f;
+			spkr.chan->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
+			spkr.chan->SetLowPassFilter(FilterState::On);
+		} else {
+			if (filter_pref != "off")
+				LOG_WARNING("PCSPEAKER: Invalid filter setting '%s', using off",
+				            filter_pref.c_str());
+
+			spkr.chan->SetHighPassFilter(FilterState::Off);
+			spkr.chan->SetLowPassFilter(FilterState::Off);
+		}
 	}
 
 	PCSPEAKER(const PCSPEAKER&) = delete; // prevent copying

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -509,13 +509,18 @@ public:
 		std::string filter_pref = section->Get_string("pcspeaker_filter");
 
 		if (filter_pref == "on") {
+			// The filters are meant to emulate the bandwidth limited
+			// sound of the small PC speaker. This more accurately
+			// reflects people's actual experience of the PC speaker
+			// sound than the raw unfiltered output, and it's a lot
+			// more pleasant to listen to, especially in headphones.
 			constexpr auto hp_order       = 3;
-			constexpr auto hp_cutoff_freq = 120.0f;
+			constexpr auto hp_cutoff_freq = 120;
 			spkr.chan->ConfigureHighPassFilter(hp_order, hp_cutoff_freq);
 			spkr.chan->SetHighPassFilter(FilterState::On);
 
 			constexpr auto lp_order       = 2;
-			constexpr auto lp_cutoff_freq = 4800.0f;
+			constexpr auto lp_cutoff_freq = 4800;
 			spkr.chan->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
 			spkr.chan->SetLowPassFilter(FilterState::On);
 		} else {

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -409,7 +409,7 @@ Ps1Synth::Ps1Synth(const std::string &filter_choice)
 	if (filter_choice == "on") {
 		// The filter parameters have been tweaked by analysing real
 		// hardware recordings. The results are virtually
-		// undistinguishable from the real thing by ear only.
+		// indistinguishable from the real thing by ear only.
 		setup_filter(channel);
 	} else {
 		if (filter_choice != "off")

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -150,7 +150,7 @@ Ps1Dac::Ps1Dac(const std::string &filter_choice)
 		setup_filter(channel);
 	} else {
 		if (filter_choice != "off")
-			LOG_WARNING("PSDAC: Invalid filter setting '%s', using off",
+			LOG_WARNING("PS1DAC: Invalid filter setting '%s', using off",
 			            filter_choice.c_str());
 
 		channel->SetHighPassFilter(FilterState::Off);
@@ -470,7 +470,7 @@ static std::unique_ptr<Ps1Synth> ps1_synth = {};
 
 static void PS1AUDIO_ShutDown([[maybe_unused]] Section *sec)
 {
-	LOG_MSG("PS/1: Shutting down IBM PS/1 Audio card");
+	LOG_MSG("PS1: Shutting down IBM PS/1 Audio card");
 	ps1_dac.reset();
 	ps1_synth.reset();
 }
@@ -496,7 +496,7 @@ void PS1AUDIO_Init(Section *section)
 	ps1_synth = std::make_unique<Ps1Synth>(
 	        prop->Get_string("ps1audio_filter"));
 
-	LOG_MSG("PS/1: Initialized IBM PS/1 Audio card");
+	LOG_MSG("PS1: Initialized IBM PS/1 Audio card");
 
 	section->AddDestroyFunction(&PS1AUDIO_ShutDown, true);
 }

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -399,7 +399,7 @@ static void configure_sb_filter()
 	};
 
 	// The filter parameters have been tweaked by analysing real hardware
-	// recordings. The results are virtually undistinguishable from the real
+	// recordings. The results are virtually indistinguishable from the real
 	// thing by ear only.
 	switch (sb.sb_filter_type) {
 	case FilterType::None:
@@ -450,7 +450,7 @@ static void configure_opl_filter()
 		return;
 
 	// The filter parameters have been tweaked by analysing real hardware
-	// recordings. The results are virtually undistinguishable from the real
+	// recordings. The results are virtually indistinguishable from the real
 	// thing by ear only.
 	switch (sb.opl_filter_type) {
 	case FilterType::SB1:

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -398,6 +398,9 @@ static void configure_sb_filter()
 		sb.chan->EnableZeroOrderHoldUpsampler();
 	};
 
+	// The filter parameters have been tweaked by analysing real hardware
+	// recordings. The results are virtually undistinguishable from the real
+	// thing by ear only.
 	switch (sb.sb_filter_type) {
 	case FilterType::None:
 		disable_filter();
@@ -446,6 +449,9 @@ static void configure_opl_filter()
 	if (!chan)
 		return;
 
+	// The filter parameters have been tweaked by analysing real hardware
+	// recordings. The results are virtually undistinguishable from the real
+	// thing by ear only.
 	switch (sb.opl_filter_type) {
 	case FilterType::SB1:
 	case FilterType::SB2: set_filter(chan, 1, 12000); break;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -19,7 +19,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-/* 
+/*
 	Based of sn76496.c of the M.A.M.E. project
 */
 
@@ -130,7 +130,7 @@ class TandyDAC {
 	};
 
 public:
-	TandyDAC(const ConfigProfile config_profile);
+	TandyDAC(const ConfigProfile config_profile, const std::string &filter_choice);
 	bool IsEnabled() const { return is_enabled; }
 	const IOConfig &GetIOConfig() const { return io; }
 
@@ -158,7 +158,8 @@ private:
 
 class TandyPSG {
 public:
-	TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled);
+	TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled,
+	         const std::string &filter_choice);
 
 private:
 	TandyPSG() = delete;
@@ -191,12 +192,30 @@ private:
 	bool is_enabled = false;
 };
 
-TandyDAC::TandyDAC(const ConfigProfile config_profile)
+static void setup_filters(mixer_channel_t &channel) {
+	// The filters are meant to emulate the bandwidth limited sound of the
+	// small integrated speaker of the Tandy. This more accurately
+	// reflects people's actual experience of the Tandy sound than the raw
+	// unfiltered output, and it's a lot more pleasant to listen to,
+	// especially in headphones.
+	constexpr auto hp_order       = 3;
+	constexpr auto hp_cutoff_freq = 120;
+	channel->ConfigureHighPassFilter(hp_order, hp_cutoff_freq);
+	channel->SetHighPassFilter(FilterState::On);
+
+	constexpr auto lp_order       = 2;
+	constexpr auto lp_cutoff_freq = 4800;
+	channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
+	channel->SetLowPassFilter(FilterState::On);
+}
+
+TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter_choice)
 {
 	assert(config_profile != ConfigProfile::SoundCardRemoved);
 
 	// Run the audio channel at the mixer's native rate
 	const auto callback = std::bind(&TandyDAC::AudioCallback, this, _1);
+
 	channel = MIXER_AddChannel(callback,
 	                           0,
 	                           "TANDYDAC",
@@ -204,6 +223,23 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile)
 	                            ChannelFeature::ChorusSend});
 
 	sample_rate = channel->GetSampleRate();
+
+	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
+	// DACs
+	channel->ConfigureZeroOrderHoldUpsampler(sample_rate);
+	channel->EnableZeroOrderHoldUpsampler();
+
+	// Setup filters
+	if (filter_choice == "on") {
+		setup_filters(channel);
+	} else {
+		if (filter_choice != "off")
+			LOG_WARNING("TANDYDAC: Invalid filter setting '%s', using off",
+			            filter_choice.c_str());
+
+		channel->SetHighPassFilter(FilterState::Off);
+		channel->SetLowPassFilter(FilterState::Off);
+	}
 
 	// Register DAC per-port read handlers
 	const auto reader = std::bind(&TandyDAC::ReadFromPort, this, _1, _2);
@@ -371,7 +407,8 @@ void TandyDAC::AudioCallback(uint16_t requested)
 	}
 }
 
-TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled)
+TandyPSG::TandyPSG(const ConfigProfile config_profile,
+                   const bool is_dac_enabled, const std::string &filter_choice)
 {
 	assert(config_profile != ConfigProfile::SoundCardRemoved);
 
@@ -403,11 +440,24 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 	                           {ChannelFeature::ReverbSend,
 	                            ChannelFeature::ChorusSend});
 
+	// Setup filters
+	if (filter_choice == "on") {
+		setup_filters(channel);
+	} else {
+		if (filter_choice != "off")
+			LOG_WARNING("TANDY: Invalid filter setting '%s', using off",
+			            filter_choice.c_str());
+
+		channel->SetHighPassFilter(FilterState::Off);
+		channel->SetLowPassFilter(FilterState::Off);
+	}
+
 	// Setup the resampler
 	const auto sample_rate = channel->GetSampleRate();
-	const auto max_freq = std::max(sample_rate * 0.9 / 2, 8000.0);
+	const auto max_freq    = std::max(sample_rate * 0.9 / 2, 8000.0);
 	resampler.reset(reSIDfp::TwoPassSincResampler::create(render_rate_hz,
-	                                                      sample_rate, max_freq));
+	                                                      sample_rate,
+	                                                      max_freq));
 	render_to_play_ratio = static_cast<double>(render_rate_hz) / sample_rate;
 
 	// Compute how many silent samples before idling the PSG
@@ -570,8 +620,11 @@ void TANDYSOUND_Init(Section *section)
 
 	const auto can_use_tandy_dac = is_sound_blaster_absent();
 	if (can_use_tandy_dac)
-		tandy_dac = std::make_unique<TandyDAC>(cfg);
-	tandy_psg = std::make_unique<TandyPSG>(cfg, can_use_tandy_dac);
+		tandy_dac = std::make_unique<TandyDAC>(
+		        cfg, prop->Get_string("tandy_dac_filter"));
+
+	tandy_psg = std::make_unique<TandyPSG>(
+	        cfg, can_use_tandy_dac, prop->Get_string("tandy_filter"));
 
 	set_tandy_sound_flag_in_bios(true);
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -258,7 +258,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter
 
 void TandyDAC::DmaCallback([[maybe_unused]] DmaChannel *, DMAEvent event)
 {
-	// LOG_MSG("TandyDAC: DMA event %d", event);
+	// LOG_MSG("TANDYDAC: DMA event %d", event);
 	if (event != DMA_REACHED_TC)
 		return;
 	dma.is_done = true;
@@ -272,7 +272,7 @@ void TandyDAC::ChangeMode()
 	constexpr auto dac_min_freq_hz = 4900;
 	constexpr auto dac_max_freq_hz = 49000;
 
-	// LOG_MSG("TandyDAC: Mode changed to %d", regs.mode);
+	// LOG_MSG("TANDYDAC: Mode changed to %d", regs.mode);
 	switch (regs.mode & 3) {
 	case 0: // joystick mode
 	case 1:
@@ -297,9 +297,7 @@ void TandyDAC::ChangeMode()
 					                  this, _1, _2);
 					dma.channel->Register_Callback(callback);
 					channel->Enable(true);
-					// LOG_MSG("Tandy DAC: playback started
-					// with freqency %f, volume %f", freq,
-					// vol);
+					// LOG_MSG("TANDYDAC: playback started with freqency %f, volume %f", freq, vol);
 				}
 			}
 		}
@@ -309,7 +307,7 @@ void TandyDAC::ChangeMode()
 
 uint8_t TandyDAC::ReadFromPort(io_port_t port, io_width_t)
 {
-	// LOG_MSG("TandyDAC: Read from port %04x", port);
+	// LOG_MSG("TANDYDAC: Read from port %04x", port);
 	switch (port) {
 	case 0xc4:
 		return (regs.mode & 0x77) | (regs.irq_activated ? 0x08 : 0x00);
@@ -318,7 +316,7 @@ uint8_t TandyDAC::ReadFromPort(io_port_t port, io_width_t)
 		return static_cast<uint8_t>(((regs.frequency >> 8) & 0xf) |
 		                            (regs.amplitude << 5));
 	}
-	LOG_MSG("Tandy DAC: Read from unknown %x", port);
+	LOG_MSG("TANDYDAC: Read from unknown %x", port);
 	return 0xff;
 }
 
@@ -372,17 +370,15 @@ void TandyDAC::WriteToPort(io_port_t port, io_val_t value, io_width_t)
 		}
 		break;
 	}
-	// LOG_MSG("TandyDAC: Write %02x to port %04x", data, port);
-	// LOG_MSG("TandyDAC: Mode %02x, Control %02x, Frequency %04x, Amplitude
-	// %02x",
+	// LOG_MSG("TANDYDAC: Write %02x to port %04x", data, port);
+	// LOG_MSG("TANDYDAC: Mode %02x, Control %02x, Frequency %04x, Amplitude %02x",
 	//        regs.mode, regs.control, regs.frequency, regs.amplitude);
 }
 
 void TandyDAC::AudioCallback(uint16_t requested)
 {
 	if (!channel || !dma.channel) {
-		DEBUG_LOG_MSG(
-		        "TANDY: Skipping update until the DAC is initialized");
+		DEBUG_LOG_MSG("TANDY: Skipping update until the DAC is initialized");
 		return;
 	}
 	const bool should_read = is_enabled && (regs.mode & 0x0c) == 0x0c &&


### PR DESCRIPTION
This implements https://github.com/dosbox-staging/dosbox-staging/issues/1676

The goal here is to introduce filtering for small-speaker systems (Tandy, PC Speaker, Disney/Covox, and PS/1 Audio) to make them more pleasant to listen to, especially on headphones. The filter choice was pretty much a judgment call per each individual system, see the comments for more details. In some cases emulating the actual hardware output was enough (e.g. in case of the PS/1 where I was able to find some real hardware recordings, and it turns out the output is heavily filtered), in other cases I just picked some highpass and lowpass settings that emulate the lack of bass of a small integrated speaker and the air-dampening of a real acoustic environment (e.g. for the Tandy and the PC speaker). So it's a mixture of accuracy where the original hardware featured a filter and sample recordings were available, or just taming the harshness were the output is either completely unfiltered or I couldn't find any recordings.

I think they sound pretty good already, but they will really come alive with the `tiny` reverb preset (when it's implemented). That will make the Tandy music in old Sierra games almost pleasant to listen to (instead of giving you ringing ears after half an hour when on headphones...)