### PR TITLE
Work around intermittent Meson wrap-build failures

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -189,7 +189,7 @@ jobs:
 
       - run:  meson setup -Dunit_tests=disabled ${{ matrix.conf.build_flags }} build
 
-      - run:  ninja -C build
+      - run:  meson compile -C build
 
       - name: Run sanitizer test cases
         run:  ./.github/scripts/run-sanitizers.sh build sanitizer-logs

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -115,7 +115,7 @@ jobs:
             ${{ matrix.conf.configure_flags }} \
             build
           cat build/meson-logs/meson-log.txt
-          ninja -C build
+          meson compile -C build
 
       - name:  Build ${{ matrix.conf.configure_flags }} (${{ matrix.system.name }})
         if:    matrix.system.name == 'macOS' || matrix.system.name == 'Linux'
@@ -124,4 +124,4 @@ jobs:
             -Dunit_tests=disabled \
             ${{ matrix.conf.configure_flags }} \
             build
-          ninja -C build
+          meson compile -C build

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -61,7 +61,7 @@ jobs:
           set -xeu
           CC="clang" CXX="clang++" meson setup -Duse_slirp=false -Duse_mt32emu=false -Duse_fluidsynth=false -Dunit_tests=disabled build
           PATH="${BASE_DIR}/cov-analysis-linux64-${PACKAGE_VERSION}/bin:${PATH}"
-          cov-build --dir cov-int ninja -C build
+          cov-build --dir cov-int meson compile -C build
           tar -cvaf package.tar.gz cov-int
 
       - name: Upload the package to Coverity

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Build
         run: |
           set -xo pipefail
-          ninja -C build |& tee build.log
+          meson compile -C build |& tee build.log
           ccache -s
 
       - name: Run tests
@@ -212,7 +212,7 @@ jobs:
             build
 
       - name: Build
-        run:  ninja -C build
+        run:  meson compile -C build
 
       - name: Package
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -248,7 +248,7 @@ jobs:
           build
 
       - name: Build
-        run:  arch -arch=${{ matrix.runner.arch }} ninja -C build
+        run:  arch -arch=${{ matrix.runner.arch }} meson compile -C build
 
       - name: Reinstate libintl.8.dylib
         if:   matrix.runner.needs_libintl_workaround

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           set -xeu
           meson setup -Dunit_tests=disabled --native-file=.github/meson/native-clang.ini build
-          pvs-studio-analyzer trace -- ninja -C build
+          pvs-studio-analyzer trace -- meson compile -C build
 
       - name: Analyze
         run: |

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -130,10 +130,11 @@ jobs:
       - name: Build
         run: |
           set -xo pipefail
-          until meson compile -C build |& tee build.log; do
-            echo "build failed, try again"
-          done
+          scripts/retry_command.sh 2 meson compile -C build |& tee build.log
           ccache -s
+          #
+          # Reason for retry is due to intermittent Python symbol extractor failure
+          # under MSYS2 reported in bug: https://github.com/msys2/MINGW-packages/issues/11864
 
       - name: Run tests
         if:   matrix.conf.run_tests
@@ -240,16 +241,19 @@ jobs:
 
       - name: Build release
         run: |
-          until meson compile -C $BUILD_RELEASE_DIR; do
-            echo "build failed, try again"
-          done
-
+          set -euo pipefail
+          scripts/retry_command.sh 2 meson compile -C $BUILD_RELEASE_DIR
+          #
+          # Reason for retry is due to intermittent Python symbol extractor failure
+          # under MSYS2 reported in bug: https://github.com/msys2/MINGW-packages/issues/11864
 
       - name: Build debugger
         run: |
-          until meson compile -C $BUILD_DEBUGGER_DIR; do
-            echo "build failed, try again"
-          done
+          set -euo pipefail
+          scripts/retry_command.sh 2 meson compile -C $BUILD_DEBUGGER_DIR
+          #
+          # Reason for retry is due to intermittent Python symbol extractor failure
+          # under MSYS2 reported in bug: https://github.com/msys2/MINGW-packages/issues/11864
 
       - name: Package
         run: |

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -130,7 +130,9 @@ jobs:
       - name: Build
         run: |
           set -xo pipefail
-          meson compile -C build |& tee build.log
+          until meson compile -C build |& tee build.log; do
+            echo "build failed, try again"
+          done
           ccache -s
 
       - name: Run tests
@@ -237,10 +239,17 @@ jobs:
         run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
 
       - name: Build release
-        run: meson compile -C $BUILD_RELEASE_DIR
+        run: |
+          until meson compile -C $BUILD_RELEASE_DIR; do
+            echo "build failed, try again"
+          done
+
 
       - name: Build debugger
-        run: meson compile -C $BUILD_DEBUGGER_DIR
+        run: |
+          until meson compile -C $BUILD_DEBUGGER_DIR; do
+            echo "build failed, try again"
+          done
 
       - name: Package
         run: |

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Build
         run: |
           set -xo pipefail
-          ninja -C build |& tee build.log
+          meson compile -C build |& tee build.log
           ccache -s
 
       - name: Run tests
@@ -237,10 +237,10 @@ jobs:
         run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_FLAGS -Denable_debugger=normal $BUILD_DEBUGGER_DIR
 
       - name: Build release
-        run: ninja -C $BUILD_RELEASE_DIR
+        run: meson compile -C $BUILD_RELEASE_DIR
 
       - name: Build debugger
-        run: ninja -C $BUILD_DEBUGGER_DIR
+        run: meson compile -C $BUILD_DEBUGGER_DIR
 
       - name: Package
         run: |

--- a/scripts/retry_command.sh
+++ b/scripts/retry_command.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -e
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2022-2022  kcgen <kcgen@users.noreply.github.com>
+
+usage()
+{
+    printf "%s\n" "\
+    Usage: ATTEMPTS COMMAND [[ARG1] ARG2 ...]
+    Where:
+        ATTEMPTS  : Retry the COMMAND up to this many times.
+        COMMAND   : The executable or command to run.
+        ARG(s)    : One or more arguments for the COMMAND.
+
+    Note: Place COMMAND or ARG(s) inside single or double
+          quotes if they contain spaces.
+    "
+}
+
+# Setup the error handler
+error_code=1
+fail() {
+  if [ "$error_code" -ne 0 ]; then
+    echo "$1" >&2
+  fi
+  exit "$error_code"
+}
+
+# Check number of arguments
+if [ "$#" -lt 2 ]; then
+  usage
+  fail "Please provide both the number of ATTEMPTS and COMMAND to run."
+fi
+
+# Setup our current and total number of attempts
+attempt=1
+attempts="$1"
+shift
+case "$attempts" in
+    ''|*[!0-9]*) usage; fail "$attempts is invalid, please provide a number 1 or greater"  ;;
+esac
+if [ "$attempts" -lt 1 ]; then
+  usage
+  fail "$attempts cannot be a negative number, please provide a number 1 or greater"
+fi
+
+while true; do
+  # reset the error code
+  error_code=0
+
+  # Launch and capture the error code on failure
+  $* || error_code=$?
+
+  # Quit if it passed
+  if [ "$error_code" -eq 0 ]; then
+    break
+  fi
+
+  # Inform the user
+  echo -n "\"$*\" quit with error-code $error_code on attempt $attempt of $attempts, " >&2
+
+  # Maybe loop again or bail out
+  if [ "$attempt" -lt "$attempts" ]; then
+    attempt=$((attempt+1))
+    sleep 1
+    echo "retrying ...\n" >&2
+  else
+    fail "quitting.\n"
+  fi
+done


### PR DESCRIPTION
Attempts to solve the following through brute-force repetition:

``` text
FAILED: subprojects/fluidsynth-2.2.6/src/fluid_conv_tables.inc.h subprojects/fluidsynth-2.2.6/src/fluid_rvoice_dsp_tables.inc.h 
"D:/a/_temp/msys64/mingw64/bin/meson" "--internal" "exe" "--unpickle" "D:/a/dosbox-staging/dosbox-staging/build/meson-private/meson_exe_make_tables_76da7216b7ad891a922e4f7241616b5b130aafe7.dat"
[8/472] Compiling C object subprojects/fluidsynth-2.2.6/test/test_preset_sample_loading.exe.p/test_preset_sample_loading.c.obj
[9/472] Compiling C object subprojects/fluidsynth-2.2.6/test/test_sample_rate_change.exe.p/test_sample_rate_change.c.obj
../subprojects/fluidsynth-2.2.6/test/test_sample_rate_change.c: In function 'main':
../subprojects/fluidsynth-2.2.6/test/test_sample_rate_change.c:55:5: warning: 'fluid_synth_set_sample_rate' is deprecated [-Wdeprecated-declarations]
   55 |     fluid_synth_set_sample_rate(synth, sample_rate);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from subprojects/fluidsynth-2.2.6/include/fluidsynth.h:100,
                 from ../subprojects/fluidsynth-2.2.6/test/test_sample_rate_change.c:3:
../subprojects/fluidsynth-2.2.6/include/fluidsynth/synth.h:253:38: note: declared here
  253 | FLUID_DEPRECATED FLUIDSYNTH_API void fluid_synth_set_sample_rate(fluid_synth_t *synth, float sample_rate);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```