### PR TITLE
Add sys_pagesize constexpr

### DIFF
--- a/include/mem.h
+++ b/include/mem.h
@@ -33,8 +33,6 @@ typedef uint8_t *HostPt;
 typedef uint32_t RealPt;
 typedef int32_t MemHandle;
 
-#define MEM_PAGESIZE 4096
-
 extern uint8_t MemBase[];
 HostPt GetMemBase();
 

--- a/include/support.h
+++ b/include/support.h
@@ -50,6 +50,14 @@
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
+#ifdef PAGESIZE
+constexpr size_t host_pagesize = PAGESIZE;
+#else
+constexpr size_t host_pagesize = 4096;
+#endif
+
+constexpr size_t dos_pagesize = 4096;
+
 // Some C functions operate on characters but return integers,
 // such as 'toupper'. This function asserts that a given int
 // is in-range of a char and returns it as such.

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -38,10 +38,6 @@
 
 #include <limits.h>
 
-#ifndef PAGESIZE
-#define PAGESIZE 4096
-#endif
-
 #endif // HAVE_MPROTECT
 
 #include "callback.h"

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -38,10 +38,6 @@
 
 #include <limits.h>
 
-#ifndef PAGESIZE
-#define PAGESIZE 4096
-#endif
-
 #endif // HAVE_MPROTECT
 
 #include "callback.h"

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -31,7 +31,7 @@
 
 DmaController *DmaControllers[2];
 
-#define EMM_PAGEFRAME4K ((0xE000 * 16) / MEM_PAGESIZE)
+#define EMM_PAGEFRAME4K ((0xE000 * 16) / dos_pagesize)
 uint32_t ems_board_mapping[LINK_START];
 
 constexpr uint16_t NULL_PAGE = 0xffff;
@@ -77,9 +77,9 @@ static void perform_dma_io(const DMA_DIRECTION direction,
 			page = paging.firstmb[page];
 
 		// Calculate the offset within the page
-		const auto pos_in_page = mem_address & (MEM_PAGESIZE - 1);
-		const auto bytes_to_page_end = check_cast<uint16_t>(MEM_PAGESIZE - pos_in_page);
-		const auto chunk_start = check_cast<PhysPt>(page * MEM_PAGESIZE + pos_in_page);
+		const auto pos_in_page = mem_address & (dos_pagesize - 1);
+		const auto bytes_to_page_end = check_cast<uint16_t>(dos_pagesize - pos_in_page);
+		const auto chunk_start = check_cast<PhysPt>(page * dos_pagesize + pos_in_page);
 
 		// Determine how many bytes to transfer within this page
 		const auto chunk_bytes = std::min(remaining_bytes, bytes_to_page_end);

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -259,7 +259,7 @@ private:
 	std::vector<float> render_buffer = {};
 	std::vector<int16_t> play_buffer = {};
 	pan_scalars_array_t pan_scalars = {{}};
-	ram_array_t ram = {{0u}};
+	alignas(sizeof(int16_t)) ram_array_t ram = {{0u}};
 	read_io_array_t read_handlers = {};   // std::functions
 	write_io_array_t write_handlers = {}; // std::functions
 	const address_array_t dma_addresses = {

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -57,11 +57,7 @@ static struct MemoryBlock {
 	} a20;
 } memory;
 
-#ifndef PAGESIZE
-#define PAGESIZE 4096
-#endif
-
-alignas(PAGESIZE) uint8_t MemBase[MAX_MEMORY*1024*1024];
+alignas(host_pagesize) uint8_t MemBase[MAX_MEMORY*1024*1024];
 
 class IllegalPageHandler final : public PageHandler {
 public:
@@ -101,10 +97,10 @@ public:
 		flags=PFLAG_READABLE|PFLAG_WRITEABLE;
 	}
 	HostPt GetHostReadPt(Bitu phys_page) {
-		return MemBase+phys_page*MEM_PAGESIZE;
+		return MemBase+phys_page*dos_pagesize;
 	}
 	HostPt GetHostWritePt(Bitu phys_page) {
-		return MemBase+phys_page*MEM_PAGESIZE;
+		return MemBase+phys_page*dos_pagesize;
 	}
 };
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -121,11 +121,7 @@ struct mixer_t {
 
 static struct mixer_t mixer = {};
 
-#ifndef PAGESIZE
-#define PAGESIZE 4096
-#endif
-
-alignas(PAGESIZE) uint8_t MixTemp[MIXER_BUFSIZE] = {};
+alignas(sizeof(float)) uint8_t MixTemp[MIXER_BUFSIZE] = {};
 
 static void MIXER_LockAudioDevice()
 {

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -956,7 +956,7 @@ static Bitu INT67_Handler(void) {
 				break;
 				}
 			case 0x02:		/* VCPI Maximum Physical Address */
-				reg_edx=((MEM_TotalPages()*MEM_PAGESIZE)-1)&0xfffff000;
+				reg_edx=((MEM_TotalPages()*dos_pagesize)-1)&0xfffff000;
 				reg_ah=EMM_NO_ERROR;
 				break;
 			case 0x03:		/* VCPI Get Number of Free Pages */

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -94,9 +94,9 @@ void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu
 		real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,rows-1);
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,(uint8_t)height);
 		//Page size
-		Bitu pagesize=rows*real_readb(BIOSMEM_SEG,BIOSMEM_NB_COLS)*2;
-		pagesize+=0x100; // bios adds extra on reload
-		real_writew(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE,pagesize);
+		Bitu bios_pagesize=rows*real_readb(BIOSMEM_SEG,BIOSMEM_NB_COLS)*2;
+		bios_pagesize+=0x100; // bios adds extra on reload
+		real_writew(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE,bios_pagesize);
 		//Cursor shape
 		if (height>=14) height--; // move up one line on 14+ line fonts
 		INT10_SetCursorShape(height-2,height-1);

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -391,7 +391,7 @@ Bitu XMS_Handler(void) {
 		reg_bl = XMS_QueryFreeMemory(reg_ax,reg_dx);
 		reg_eax &= 0xffff;
 		reg_edx &= 0xffff;
-		reg_ecx = (MEM_TotalPages()*MEM_PAGESIZE)-1;			// highest known physical memory address
+		reg_ecx = (MEM_TotalPages()*dos_pagesize)-1;			// highest known physical memory address
 		break;
 	case XMS_GET_EMB_HANDLE_INFORMATION_EXT: {					/* 8e */
 		uint8_t free_handles;


### PR DESCRIPTION
Create a simple constexpr that is clearly the system pagesize, compared to the other *PAGESIZE macros sprinkled throughout the codebase, and use it with pagesize-aligned byte arrays.