### PR TITLE
Catch IIR's potential exception AdlibGold during setup

### DIFF
--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -110,7 +110,7 @@ StereoProcessor::StereoProcessor(const uint16_t _sample_rate)
 	SetHighShelfGain(0.0);
 }
 
-void StereoProcessor::SetLowShelfGain(const double gain_db) noexcept
+void StereoProcessor::SetLowShelfGain(const double gain_db)
 {
 	constexpr auto cutoff_freq = 400.0;
 	constexpr auto slope       = 0.5;
@@ -118,7 +118,7 @@ void StereoProcessor::SetLowShelfGain(const double gain_db) noexcept
 		f.setup(sample_rate, cutoff_freq, gain_db, slope);
 }
 
-void StereoProcessor::SetHighShelfGain(const double gain_db) noexcept
+void StereoProcessor::SetHighShelfGain(const double gain_db)
 {
 	constexpr auto cutoff_freq = 2500.0;
 	constexpr auto slope       = 0.5;

--- a/src/hardware/adlib_gold.h
+++ b/src/hardware/adlib_gold.h
@@ -93,8 +93,8 @@ public:
 	void ControlWrite(const StereoProcessorControlReg, const uint8_t data) noexcept;
 	AudioFrame Process(const AudioFrame &frame) noexcept;
 
-	void SetLowShelfGain(const double gain_db) noexcept;
-	void SetHighShelfGain(const double gain_db) noexcept;
+	void SetLowShelfGain(const double gain_db);
+	void SetHighShelfGain(const double gain_db);
 
 	// prevent copying
 	StereoProcessor(const StereoProcessor &) = delete;


### PR DESCRIPTION
This simply removes the `noexcept` label from the member function, which allows the possible exception to be caught by the top-level catch statement (in `main`).

Fixes the follow, flagged by Coverity:

```
353568 Uncaught exception

If the exception is ever thrown, the program will crash.
In StereoProcessor::​SetLowShelfGain(double): A C++
exception is thrown but never caught (CWE-248)
```

![2022-06-20_15-10_1](https://user-images.githubusercontent.com/1557255/174686706-c21125f9-6cfe-466d-a8a0-836535005b06.png)

![2022-06-20_15-10](https://user-images.githubusercontent.com/1557255/174686709-34787766-d801-4f16-94c1-338a1a951949.png)