### PR TITLE
HiDPI support

### DIFF
--- a/contrib/macos/Info.plist.template
+++ b/contrib/macos/Info.plist.template
@@ -38,6 +38,9 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 
+	<key>NSHighResolutionCapable</key>
+	<string>YES</string>
+
 	<key>CGDisableCoalescedUpdates</key>
 	<true/>
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1361,17 +1361,6 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 		                                dpi_scale));
 	}
 
-	sdl.clip.w = img_width;
-	sdl.clip.h = img_height;
-	sdl.clip.x = sdl.desktop.fullscreen
-	                   ? (canvas.w - img_width) / 2
-	                   : (iroundf(static_cast<float>(win_width) * dpi_scale) -
-	                      img_width) / 2;
-	sdl.clip.y = sdl.desktop.fullscreen
-	                   ? (canvas.h - img_height) / 2
-	                   : (iroundf(static_cast<float>(win_height) * dpi_scale) -
-	                      img_height) / 2;
-
 	sdl.window = SetWindowMode(screen_type, win_width, win_height,
 	                           sdl.desktop.fullscreen, resizable);
 	return sdl.window;
@@ -1402,38 +1391,18 @@ static SDL_Window *SetupWindowScaled(SCREEN_TYPES screen_type, bool resizable)
 		window_height = sdl.desktop.window.height;
 	}
 
-	if (window_width > 0 && window_height > 0) {
-		sdl.window = SetWindowMode(screen_type,
-		                           window_width,
-		                           window_height,
-		                           sdl.desktop.fullscreen,
-		                           resizable);
-
-		const auto canvas = get_canvas_size(screen_type);
-
-		sdl.clip = calc_viewport_fit(canvas.w, canvas.h);
-
-		const auto is_window_fullscreen = SDL_GetWindowFlags(sdl.window) &
-		                                  SDL_WINDOW_FULLSCREEN;
-		if (sdl.window && is_window_fullscreen) {
-			sdl.clip.x = (canvas.w - sdl.clip.w) / 2;
-			sdl.clip.y = (canvas.h - sdl.clip.h) / 2;
-		}
-		return sdl.window;
-
-	} else {
-		const auto win_width = iround(sdl.draw.width * sdl.draw.scalex);
-		const auto win_height = iround(sdl.draw.height * sdl.draw.scaley);
-
-		sdl.window = SetWindowMode(screen_type, win_width, win_height,
-		                           sdl.desktop.fullscreen, resizable);
-
-		const auto canvas = get_canvas_size(screen_type);
-
-		sdl.clip = calc_viewport_fit(canvas.w, canvas.h);
-
-		return sdl.window;
+	if (window_width == 0 && window_height == 0) {
+		window_width  = iround(sdl.draw.width * sdl.draw.scalex);
+		window_height = iround(sdl.draw.height * sdl.draw.scaley);
 	}
+
+	sdl.window = SetWindowMode(screen_type,
+	                           window_width,
+	                           window_height,
+	                           sdl.desktop.fullscreen,
+	                           resizable);
+
+	return sdl.window;
 }
 
 #if C_OPENGL


### PR DESCRIPTION
This PR adds relatively basic handling for high DPI displays. Previously, only window size was queried, not the actual canvas size in physical pixels. This led to heavily blurred output on Apple devices. The actual impact on other platforms is uncertain: at least on Linux-based systems, both X11 and Wayland only report set DPI, not scale windows by themselves. Don't expect fancy stuff like per-monitor scaling; this is mostly for the output not to blur on macOS.

I had to move SDL renderer creation right after window creation, so that window setup routines have something to work with. OpenGL context was moved as well, for uniformity of sorts. It is possible that either renderer or context are left sitting in memory on the output type switch, but both should be destroyed on exit.

Also added viewport centring for SDL rendering output… well, copied one from OpenGL path nearby. I don't feel like this is right, but the path isn't hot, and window handling desperately cries for a complete redesign. I'm not sober enough to do it now, but it's inevitable.

Surface output wasn't touched (much) and was left without testing for ages anyway. Its days are numbered, and sooner or later someone (me?) will come for it on a combine, laughing maniacally.

Clang sanitizer in CI doesn't like me for whatever reason, but logs are written in address space, and I can't read that. MSVC doesn't like some maths in `setup_window_pp()`. Otherwise, the code is confirmed to be functional: OpenGL path was battle-tested by @Grounded0 for some time, and renderer path doesn't show any signs of weird behaviour caused by changes. Additional testing on all supported platforms is welcome, of course.