### PR TITLE
Sync GUS interrupt handling from PiGUS

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -782,8 +782,10 @@ void Gus::CheckVoiceIrq()
 	irq_status &= 0x9f;
 	const Bitu totalmask = (voice_irq.vol_state | voice_irq.wave_state) &
 	                       active_voice_mask;
-	if (!totalmask)
+	if (!totalmask) {
+		CheckIrq();
 		return;
+	}
 	if (voice_irq.vol_state)
 		irq_status |= 0x40;
 	if (voice_irq.wave_state)


### PR DESCRIPTION
Incorporates improved IRQ handling added by [the PiGUS project](https://www.vogons.org/viewtopic.php?f=62&t=88440):
 
Thank you, @polpo, I've credited your GitHub ID as the author on the respective commits, and included `"Imported-from: <ref>"` links back to your project's commits.

Regression tested against all know GUS games, the capamod (MOD player), and a handful of demos.

**(:arrow_down: unmute the video before playing :sweat_smile:)**

#### Crystal Dream 2


https://user-images.githubusercontent.com/1557255/175696785-dcdbd2e1-da3d-406c-a212-653d32531a9b.mp4

#### X14

https://user-images.githubusercontent.com/1557255/175696892-3daa924b-69b6-41cd-be9a-f7f7512eba7d.mp4


