### PR TITLE
Simplify CI `push` vs `pull_request` de-dupe logic

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -14,8 +14,8 @@ env:
 jobs:
   run_linters:
     name: Script linters
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-20.04
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/dormant/windows-2019.yml
+++ b/.github/workflows/dormant/windows-2019.yml
@@ -10,7 +10,7 @@ jobs:
   build_windows_vs:
     name: ${{ matrix.conf.name }}
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     strategy:
       matrix:
         conf:

--- a/.github/workflows/dormant/windows-msys2.yml
+++ b/.github/workflows/dormant/windows-msys2.yml
@@ -6,7 +6,7 @@ jobs:
   build_windows_msys2:
     name: ${{ matrix.conf.compiler }} ${{ matrix.conf.bits }}-bit
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     strategy:
       # Because Clang depends on GCC, we run the Clang-32/64bit jobs
       # first to create combined caches that include both Clang and GCC.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
   build_ubuntu:
     name: ${{ matrix.conf.name }}
     runs-on: ${{ matrix.conf.os }}
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     strategy:
       matrix:
         conf:
@@ -150,7 +150,7 @@ jobs:
   build_linux_release:
     name: Release build
     runs-on: ubuntu-18.04
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
   build_macos:
     name: ${{ matrix.conf.name }} (${{ matrix.conf.arch }})
     runs-on: ${{ matrix.conf.host }}
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
   build_macos_release:
     name: Release build (${{ matrix.runner.arch }})
     runs-on: ${{ matrix.runner.host }}
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     env:
       MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runner.minimum_deployment }}
 

--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -18,7 +18,7 @@ jobs:
   build_msys2:
     name: ${{ matrix.conf.name }}
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
 
     strategy:
       matrix:
@@ -149,7 +149,7 @@ jobs:
   build_msys2_release:
     name: ${{ matrix.conf.name }} Release
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
 
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
   build_windows_vs:
     name: ${{ matrix.conf.name }}
     runs-on: windows-2022
-    if: github.event_name != 'pull_request' || contains('dreamer,kcgen,ant-222,Wengier,kklobe,shermp,johnnovak,FeralChild64', github.actor) == false
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     strategy:
       matrix:
         conf:
@@ -84,6 +84,7 @@ jobs:
 
   build_windows_vs_release:
     name: ${{ matrix.conf.name }}
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: windows-2022
     strategy:
       matrix:


### PR DESCRIPTION
GitHub workflows that run `on: [push, pull_request]` events create duplicate jobs when team members push updates to a PR, because this action creates both events.

This PR simplifies our existing job de-dupe logic.