### PR TITLE
Move mouse parameters update

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1255,9 +1255,6 @@ finish:
 		                       height);
 	}
 
-	// Ensure mouse emulation knows the current parameters
-	NewMouseScreenParams();
-
 	// Force redraw after changing the window
 	if (sdl.draw.callback)
 		sdl.draw.callback(GFX_CallBackRedraw);
@@ -2052,6 +2049,8 @@ dosurface:
 #endif // C_OPENGL
 	}
 
+	// Ensure mouse emulation knows the current parameters
+	NewMouseScreenParams();
 	update_vsync_state();
 
 	if (retFlags)


### PR DESCRIPTION
Fixes weird mouse behaviour reported by @FeralChild64. Mouse never had a chance to receive updated viewport rectangle due to the viewport being set much later. This broke mouse cursor in programs like DOS Navigator and Win3.x.