### PR TITLE
Standardize rendering routines in some audio devices

### DIFF
--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -21,9 +21,12 @@
 
 #include "innovation.h"
 
+#include "checks.h"
 #include "control.h"
 #include "pic.h"
 #include "support.h"
+
+CHECK_NARROWING();
 
 // Constants
 // ---------
@@ -70,14 +73,15 @@ void Innovation::Open(const std::string &model_choice,
 	else if (clock_choice == "c64ntsc")
 		chip_clock = 1022727.14;
 	else if (clock_choice == "c64pal")
-		chip_clock = 985250;
+		chip_clock = 985250.0;
 	else if (clock_choice == "hardsid")
-		chip_clock = 1000000;
+		chip_clock = 1000000.0;
 	assert(chip_clock);
+	ms_per_clock = 1000.0 / chip_clock;
 
 	// Setup the mixer and get it's sampling rate
 	using namespace std::placeholders;
-	const auto mixer_callback = std::bind(&Innovation::MixerCallBack, this, _1);
+	const auto mixer_callback = std::bind(&Innovation::AudioCallback, this, _1);
 	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
 	                                            0,
 	                                            "INNOVATION",
@@ -85,10 +89,9 @@ void Innovation::Open(const std::string &model_choice,
 	                                             ChannelFeature::ChorusSend});
 
 	const auto frame_rate_hz = mixer_channel->GetSampleRate();
-	frame_rate_per_ms = frame_rate_hz / 1000.0;
 
 	// Compute how many silent samples before idling the service
-	idle_after_silent_frames = iround(frame_rate_per_ms * idle_after_ms);
+	idle_after_silent_frames = iround(idle_after_ms * frame_rate_hz / 1000.0);
 
 	// Determine the passband frequency, which is capped at 90% of Nyquist.
 	const double passband = 0.9 * frame_rate_hz / 2;
@@ -109,10 +112,9 @@ void Innovation::Open(const std::string &model_choice,
 	channel = std::move(mixer_channel);
 
 	// Ready state-values for rendering
-	last_render_time = 0;
-	unwritten_for_ms = 0;
-	silent_frames = 0;
-	is_enabled = false;
+	last_rendered_ms = 0.0;
+	unused_for_ms    = 0;
+	silent_frames    = 0;
 
 	constexpr auto us_per_s = 1'000'000.0;
 	if (filter_strength == 0)
@@ -155,68 +157,86 @@ uint8_t Innovation::ReadFromPort(io_port_t port, io_width_t)
 
 void Innovation::WriteToPort(io_port_t port, io_val_t value, io_width_t)
 {
-	const auto now = PIC_FullIndex();
+	RenderUpToNow();
 
-	// Turn on the channel after the data's written
-	if (!is_enabled) {
-		assert(channel);
-		channel->Enable(true);
-		is_enabled = true;
-	} else {
-		RenderForMs(now - last_render_time);
-	}
-	last_render_time = now;
+	unused_for_ms = 0;
 
 	const auto data = check_cast<uint8_t>(value);
 	const auto sid_port = static_cast<io_port_t>(port - base_port);
 	service->write(sid_port, data);
-	unwritten_for_ms = 0;
 }
 
-int16_t Innovation::RenderOnce()
+void Innovation::RenderUpToNow()
 {
-	int16_t sample = 0;
-	while (!service->clock(1, &sample))
-		; // cycle until we have a sample
-	if (!sample) {
+	const auto now = PIC_FullIndex();
+
+	// Wake up the channel and update the last rendered time datum.
+	assert(channel);
+	if (!channel->is_enabled) {
+		channel->Enable(true);
+		last_rendered_ms = now;
+		return;
+	}
+	// Keep rendering until we're current
+	while (last_rendered_ms < now) {
+		last_rendered_ms += ms_per_clock;
+		if (float frame = 0.0f; MaybeRenderFrame(frame))
+			fifo.emplace(frame);
+	}
+}
+
+int16_t Innovation::TallySilence(const int16_t sample)
+{
+	if (!sample)
 		++silent_frames;
-		return 0;
-	}
-	silent_frames = 0;
-	return check_cast<int16_t>(sample * 2);
+	else
+		silent_frames = 0;
+	return sample;
 }
 
-void Innovation::RenderForMs(const double duration_ms)
+bool Innovation::MaybeRenderFrame(float &frame)
 {
-	auto render_count = iround(duration_ms * frame_rate_per_ms);
-	while (render_count-- > 0)
-		fifo.push(RenderOnce());
+	assert(service);
+
+	int16_t sample = {0};
+
+	const auto frame_is_ready = service->clock(1, &sample);
+
+	// Get the frame and pass it through the silence-tracker
+	if (frame_is_ready)
+		frame = static_cast<float>(TallySilence(sample) * 2);
+
+	return frame_is_ready;
 }
 
-double Innovation::ConvertFramesToMs(const int frames)
+void Innovation::AudioCallback(const uint16_t requested_frames)
 {
-	return frames / frame_rate_per_ms;
-}
+	assert(channel);
 
-void Innovation::MixerCallBack(uint16_t requested_frames)
-{
-	while (requested_frames && fifo.size()) {
-		channel->AddSamples_m16(1, &fifo.front());
+	//if (fifo.size())
+	//	LOG_MSG("INNOVATION: Queued %2lu cycle-accurate frames", fifo.size());
+
+	auto frames_remaining = requested_frames;
+
+	// First, send any frames we've queued since the last callback
+	while (frames_remaining && fifo.size()) {
+		channel->AddSamples_mfloat(1, &fifo.front());
 		fifo.pop();
-		--requested_frames;
+		--frames_remaining;
 	}
-	if (requested_frames) {
-		last_render_time += ConvertFramesToMs(requested_frames);
-		while (requested_frames--) {
-			const auto frame = RenderOnce();
-			channel->AddSamples_m16(1, &frame);
+	// If the queue's run dry, render the remainder and sync-up our time datum
+	while (frames_remaining) {
+		if (float frame = 0.0f; MaybeRenderFrame(frame)) {
+			channel->AddSamples_mfloat(1, &frame);
 		}
+		--frames_remaining;
 	}
+	last_rendered_ms = PIC_FullIndex();
 
-	if (unwritten_for_ms++ > idle_after_ms &&
+	// Maybe idle the channel if the device has been unused and playing silence
+	if (unused_for_ms++ > idle_after_ms &&
 	    silent_frames > idle_after_silent_frames) {
 		channel->Enable(false);
-		is_enabled = false;
 	}
 }
 

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -43,37 +43,31 @@ public:
 	~Innovation() { Close(); }
 
 private:
-	void Render();
-	double ConvertFramesToMs(const int samples);
-
-	int16_t RenderOnce();
-	void RenderForMs(const double duration_ms);
-
-	void MixerCallBack(uint16_t requested_frames);
+	bool MaybeRenderFrame(float &frame);
+	void AudioCallback(const uint16_t requested_frames);
 	uint8_t ReadFromPort(io_port_t port, io_width_t width);
+	void RenderUpToNow();
+	int16_t TallySilence(const int16_t sample);
 	void WriteToPort(io_port_t port, io_val_t value, io_width_t width);
 
 	// Managed objects
-	mixer_channel_t channel = nullptr;
-
-	IO_ReadHandleObject read_handler = {};
-	IO_WriteHandleObject write_handler = {};
-
+	mixer_channel_t channel               = nullptr;
+	IO_ReadHandleObject read_handler      = {};
+	IO_WriteHandleObject write_handler    = {};
 	std::unique_ptr<reSIDfp::SID> service = {};
-	std::queue<int16_t> fifo = {};
+	std::queue<float> fifo                = {};
 
 	// Initial configuration
-	io_port_t base_port = 0;
-	double chip_clock = 0;
-	double frame_rate_per_ms = 0;
+	double chip_clock            = 0.0;
+	double ms_per_clock          = 0.0;
+	io_port_t base_port          = 0;
 	int idle_after_silent_frames = 0;
 
 	// Runtime states
-	double last_render_time = 0;
-	int unwritten_for_ms = 0;
-	int silent_frames = 0;
-	bool is_enabled = false;
-	bool is_open = false;
+	double last_rendered_ms = 0.0;
+	int unused_for_ms       = 0;
+	int silent_frames       = 0;
+	bool is_open            = false;
 };
 
 #endif

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
+#include <queue>
 #include <string.h>
 
 #include "control.h"
@@ -36,6 +37,7 @@
 
 #include "mame/emu.h"
 #include "mame/sn76496.h"
+#include "../libs/residfp/resample/TwoPassSincResampler.h"
 
 using namespace std::placeholders;
 
@@ -173,7 +175,7 @@ Ps1Dac::Ps1Dac(const std::string &filter_choice)
 	                          io_width_t::byte);
 
 	// Operate at native sampling rates
-	sample_rate = channel->GetSampleRate();
+	sample_rate = check_cast<uint32_t>(channel->GetSampleRate());
 	last_write = 0;
 	Reset(true);
 }
@@ -382,22 +384,45 @@ public:
 	~Ps1Synth();
 
 private:
-	void Update(uint16_t samples);
+	// Block alternate construction routes
+	Ps1Synth()                            = delete;
+	Ps1Synth(const Ps1Synth &)            = delete;
+	Ps1Synth &operator=(const Ps1Synth &) = delete;
+
+	void AudioCallback(uint16_t requested_frames);
+	bool MaybeRenderFrame(float &frame);
+	void RenderUpToNow();
+	int TallySilence(const int sample);
+
 	void WriteSoundGeneratorPort205(io_port_t port, io_val_t, io_width_t);
 
+	// Managed objects
 	mixer_channel_t channel = nullptr;
 	IO_WriteHandleObject write_handler = {};
-	static constexpr auto clock_rate_hz = 4000000;
 	sn76496_device device;
-	static constexpr auto max_samples_expected = 64;
-	int16_t buffer[1][max_samples_expected];
-	size_t last_write = 0;
+	std::unique_ptr<reSIDfp::TwoPassSincResampler> resampler = {};
+	std::queue<float> fifo                                   = {};
+
+	// Static rate-related configuration
+	static constexpr auto ps1_psg_clock_hz = 4000000;
+	static constexpr auto render_divisor   = 16;
+	static constexpr auto render_rate_hz   = ceil_sdivide(ps1_psg_clock_hz,
+                                                            render_divisor);
+	static constexpr auto ms_per_render    = 1000.0 / render_rate_hz;
+	static constexpr auto idle_after_ms    = 2000;
+
+	// Runtime states
+	device_sound_interface *dsi = static_cast<sn76496_base_device *>(&device);
+	double last_rendered_ms     = 0.0;
+	int idle_after_silent_samples = 0;
+	int silent_samples            = 0;
+	int unused_for_ms             = 0;
 };
 
 Ps1Synth::Ps1Synth(const std::string &filter_choice)
-        : device(machine_config(), 0, 0, clock_rate_hz)
+        : device(machine_config(), 0, 0, ps1_psg_clock_hz)
 {
-	const auto callback = std::bind(&Ps1Synth::Update, this, _1);
+	const auto callback = std::bind(&Ps1Synth::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
 	                           0,
@@ -420,38 +445,110 @@ Ps1Synth::Ps1Synth(const std::string &filter_choice)
 		channel->SetLowPassFilter(FilterState::Off);
 	}
 
+	// Setup the resampler
+	const auto channel_rate_hz = channel->GetSampleRate();
+	const auto max_freq = std::max(channel_rate_hz * 0.9 / 2, 8000.0);
+	resampler.reset(reSIDfp::TwoPassSincResampler::create(render_rate_hz,
+	                                                      channel_rate_hz,
+	                                                      max_freq));
+
+	// Compute how many silent samples before idling the PSG
+	idle_after_silent_samples = channel_rate_hz * idle_after_ms / 1000;
+
 	const auto generate_sound =
 	        std::bind(&Ps1Synth::WriteSoundGeneratorPort205, this, _1, _2, _3);
 	write_handler.Install(0x205, generate_sound, io_width_t::byte);
 	static_cast<device_t &>(device).device_start();
+	device.convert_samplerate(render_rate_hz);
+}
 
-	auto sample_rate = static_cast<int32_t>(channel->GetSampleRate());
-	device.convert_samplerate(sample_rate);
-	last_write = 0;
+int Ps1Synth::TallySilence(const int sample)
+{
+	if (!sample)
+		++silent_samples;
+	else
+		silent_samples = 0;
+	return sample;
+}
+
+bool Ps1Synth::MaybeRenderFrame(float &frame)
+{
+	assert(dsi);
+	assert(resampler);
+
+	// Request a frame from the audio device
+	static int16_t sample;
+	static int16_t *buf[] = {&sample, nullptr};
+	static device_sound_interface::sound_stream ss;
+	dsi->sound_stream_update(ss, nullptr, buf, 1);
+
+	const auto frame_is_ready = resampler->input(sample);
+
+	// Get the frame and pass it through the silence-tracker
+	if (frame_is_ready)
+		frame = static_cast<float>(TallySilence(resampler->output()));
+
+	return frame_is_ready;
+}
+
+void Ps1Synth::RenderUpToNow()
+{
+	const auto now = PIC_FullIndex();
+
+	// Wake up the channel and update the last rendered time datum.
+	assert(channel);
+	if (!channel->is_enabled) {
+		channel->Enable(true);
+		last_rendered_ms = now;
+		return;
+	}
+	// Keep rendering until we're current
+	while (last_rendered_ms < now) {
+		last_rendered_ms += ms_per_render;
+		if (float frame = 0.0f; MaybeRenderFrame(frame))
+			fifo.emplace(frame);
+	}
 }
 
 void Ps1Synth::WriteSoundGeneratorPort205(io_port_t, io_val_t value, io_width_t)
 {
+	unused_for_ms = 0;
+
+	RenderUpToNow();
+
 	const auto data = check_cast<uint8_t>(value);
-	keep_alive_channel(last_write, channel);
 	device.write(data);
 }
 
-void Ps1Synth::Update(uint16_t samples)
+void Ps1Synth::AudioCallback(const uint16_t requested_frames)
 {
-	assert(samples <= max_samples_expected);
+	assert(channel);
 
-	// sound_stream_update's API requires an array of two pointers that
-	// point to either the mono array head or left and right heads. In this
-	// case, we're using a mono array but we still want to comply with the
-	// API, so we give it a valid two-element pointer array.
-	int16_t *buffer_head[] = {buffer[0], buffer[0]};
+	// if (fifo.size())
+	//	LOG_MSG("PS1: Queued %2lu cycle-accurate frames", fifo.size());
 
-	device_sound_interface::sound_stream ss;
-	static_cast<device_sound_interface &>(device).sound_stream_update(
-	        ss, nullptr, buffer_head, samples);
-	channel->AddSamples_m16(samples, buffer[0]);
-	maybe_suspend_channel(last_write, channel);
+	auto frames_remaining = requested_frames;
+
+	// First, send any frames we've queued since the last callback
+	while (requested_frames && fifo.size()) {
+		channel->AddSamples_mfloat(1, &fifo.front());
+		fifo.pop();
+		--frames_remaining;
+	}
+	// If the queue's run dry, render the remainder and sync-up our time datum
+	while (frames_remaining) {
+		if (float frame = 0.0f; MaybeRenderFrame(frame)) {
+			channel->AddSamples_mfloat(1, &frame);
+		}
+		--frames_remaining;
+	}
+	last_rendered_ms = PIC_FullIndex();
+
+	// Maybe idle the channel if the device has been unused and playing silence
+	if (unused_for_ms++ > idle_after_ms &&
+	    silent_samples > idle_after_silent_samples) {
+		channel->Enable(false);
+	}
 }
 
 Ps1Synth::~Ps1Synth()


### PR DESCRIPTION
Moves more of the rendering details and state tracking inside two rendering functions:

1. `(Maybe)RenderFrame`
    - What's a "maybe-rendered" frame? The idea is that we're rendering at the devices rendering rate, which may or may not result in an audio frame. The rendering rate can be higher than our channel's playback rate, and therefore sometimes a small number of rendering cycles won't actually produce a frame for us to use.

2. `RenderUpToNow()`
    - This function is called on IO port-writes to render as many times as needed until the we're caught up with "now". 
    - It makes use of `(Maybe)RenderFrame`, asking it to queue any resulting frames.
 
3. The Audio callback now also makes use of `(Maybe)RenderFrame`

These devices now exclusively use the mixer channel's float API.

If we can standardize this approach, the next step is rolling it out to other devices.