### PR TITLE
sdl: mouse: Clamp absolute mouse coordinates

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3568,8 +3568,8 @@ static void HandleMouseMotion(SDL_MouseMotionEvent *motion)
 	    sdl.mouse.control_choice == Seamless)
 		MOUSE_EventMoved(check_cast<int16_t>(motion->xrel),
 		                 check_cast<int16_t>(motion->yrel),
-		                 check_cast<uint16_t>(motion->x),
-		                 check_cast<uint16_t>(motion->y),
+		                 std::clamp(motion->x, 0, static_cast<int>(UINT16_MAX)),
+		                 std::clamp(motion->y, 0, static_cast<int>(UINT16_MAX)),
 		                 mouse_is_captured);
 }
 


### PR DESCRIPTION
(I appreciate that this is probably a bit controversial, as it appears to have been discussed in #1719. I do think that this is the technically correct solution, though.)

SDL's mouse events can return absolute coordinates from outside the window (and hence negative coordinates) in a number of real-world situations. This triggers an assert on debug builds of DOSBox, rendering them nigh-unusable.

(In particular, this occurs with fullscreen, alt+tab, and multiple monitors on at least X11, but I think there are other cases where this can occur, particularly with mouse grabs and/or multiple windows.)

Simply clamp the coordinates, which will neither crash, nor have nasty overflow behaviour.