### PR TITLE
Update Clang Format to 12.0.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
-# This file uses configuration options available in clang-format 8.0.
+# This file uses configuration options available in clang-format 12.0.
 #
 # More detailed description of all options:
-# https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 #
 # Note that version of clang-format provided by your distribution might be
 # newer and provide additional options, that won't work in 8.x.
@@ -40,7 +40,7 @@ AccessModifierOffset: -8
 #
 AlignAfterOpenBracket: Align
 
-# If true, aligns consecutive C/C++ preprocessor macros.
+# If Consecutive, aligns consecutive C/C++ preprocessor macros.
 #
 # This will align the C/C++ preprocessor macros of consecutive lines. This will
 # result in formattings like
@@ -51,7 +51,7 @@ AlignAfterOpenBracket: Align
 # #define foo(x)           (x * x)
 # #define bar(y, z)        (y + z)
 #
-AlignConsecutiveMacros: true
+AlignConsecutiveMacros: Consecutive
 
 # Don't align backslash character in macros, as it's unexpected during review
 # and does not look right when user changes the tab size character in their editor.
@@ -69,16 +69,7 @@ AlignEscapedNewlines: DontAlign
 #    SIX   = 6,
 #    SEVEN = 7
 # };
-AlignConsecutiveAssignments: true
-
-##
-#  If set to Left, backslashes are aligned and pushed to the left:
-#   #define A   \
-#     int aaaa; \
-#     int b;    \
-#     int dddddddddd;
-#
-AlignEscapedNewlinesLeft: false
+AlignConsecutiveAssignments: Consecutive
 
 ##
 #  the operator is un-indented so that the wrapped operand is aligned with the operand on the first line.
@@ -213,7 +204,7 @@ AlwaysBreakTemplateDeclarations: Yes
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum: false
   AfterFunction: true
   AfterNamespace: false
@@ -380,4 +371,4 @@ PenaltyReturnTypeOnItsOwnLine: 200
 #
 # See https://github.com/dosbox-staging/dosbox-staging/issues/196 for details.
 #
-SortIncludes: false
+SortIncludes: Never

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ project('dosbox-staging', 'c', 'cpp',
     'glib:xattr=false',
     'gtest:warning_level=0',
     'mt32emu:warning_level=0',
-    'slirp:warning_level=0',
+    'slirp:warning_level=0'
   ]
 )
 
@@ -340,6 +340,14 @@ if get_option('use_png')
                        not_found_message : msg.format('use_png'))
 endif
 
+tracy_proj = subproject('tracy')
+tracy_dep = tracy_proj.get_variable('tracy_dep')
+
+if get_option('tracy')
+  add_project_arguments('-DTRACY_ENABLE', language : ['c','cpp'])
+  add_project_arguments('-g', language : ['c','cpp'])
+  add_project_arguments('-fno-omit-frame-pointer', language : ['c','cpp'])
+endif
 # macOS-only dependencies
 #
 if host_machine.system() == 'darwin'
@@ -464,6 +472,7 @@ third_party_deps = [atomic_dep,
                     libghc_dep,
                     libloguru_dep,
                     libsdlcd_dep,
+                    tracy_dep,
                     libwhereami_dep]
 
 # A list of DOSBox's internal libraries populated

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,9 @@ option('use_png', type : 'boolean', value : true,
 option('use_slirp', type : 'boolean', value : true,
        description : 'Enable Ethernet emulation using Libslirp')
 
+option('tracy', type : 'boolean', value : false,
+       description : 'Enable profiling using Tracy')
+
 # This option exists only for rare situations when Linux developer cannot
 # install ALSA library headers on their machine.
 #
@@ -53,6 +56,7 @@ option('try_static_libs',
            'sdl2_net',
            'slirp',
            'speexdsp',
+           'tracy',
            'zlib'],
        value : [],
        description : 'Attempt to statically link selected libraries.'

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -55,7 +55,7 @@ main () {
 handle_dependencies () {
 	assign_gnu_sed
 	assert_min_version git 1007010 "Use git version 1.7.10 or newer."
-	assert_min_version clang-format 9000000 "Use clang-format version 9.0.0 or newer."
+	assert_min_version clang-format 12000000 "Use clang-format version 12.0.0 or newer."
 }
 
 SED=""

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -40,6 +40,8 @@
 
 #endif // HAVE_MPROTECT
 
+#include <Tracy.hpp>
+
 #include "callback.h"
 #include "regs.h"
 #include "mem.h"
@@ -248,6 +250,7 @@ static void dyn_restoreregister(DynReg * src_reg, DynReg * dst_reg) {
 #include "core_dyn_x86/decoder.h"
 
 Bits CPU_Core_Dyn_X86_Run(void) {
+	ZoneScoped
 	// helper class to auto-save DH_FPU state on function exit
 	class auto_dh_fpu {
 	public:

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -40,6 +40,8 @@
 
 #endif // HAVE_MPROTECT
 
+#include <Tracy.hpp>
+
 #include "callback.h"
 #include "regs.h"
 #include "mem.h"
@@ -208,6 +210,7 @@ CacheBlock *LinkBlocks(BlockReturn ret)
 */
 
 Bits CPU_Core_Dynrec_Run(void) {
+	ZoneScoped
 	for (;;) {
 		// Determine the linear address of CS:EIP
 		PhysPt ip_point=SegPhys(cs)+reg_eip;

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -18,6 +18,8 @@
 
 #include "dosbox.h"
 
+#include <Tracy.hpp>
+
 #include "pic.h"
 #include "regs.h"
 #include "cpu.h"
@@ -27,7 +29,6 @@
 #include "debug.h"
 #include "inout.h"
 #include "callback.h"
-
 
 typedef PhysPt EAPoint;
 #define SegBase(c)	SegPhys(c)
@@ -62,6 +63,7 @@ typedef PhysPt EAPoint;
 	}
 
 Bits CPU_Core_Full_Run(void) {
+	ZoneScoped
 	FullData inst{};
 	while (CPU_Cycles-->0) {
 #if C_DEBUG

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -18,6 +18,8 @@
 
 #include <stdio.h>
 
+#include <Tracy.hpp>
+
 #include "dosbox.h"
 #include "mem.h"
 #include "cpu.h"
@@ -139,6 +141,7 @@ static inline uint32_t Fetchd() {
 #define EALookupTable (core.ea_table)
 
 Bits CPU_Core_Normal_Run(void) {
+	ZoneScoped
 	while (CPU_Cycles-->0) {
 		LOADIP;
 		core.opcode_index=cpu.code.big*0x200;

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -18,6 +18,8 @@
 
 #include <stdio.h>
 
+#include <Tracy.hpp>
+
 #include "dosbox.h"
 #include "mem.h"
 #include "cpu.h"
@@ -135,6 +137,7 @@ static inline uint32_t Fetchd() {
 #define EALookupTable (core.ea_table)
 
 Bits CPU_Core_Simple_Run(void) {
+	ZoneScoped
 	while (CPU_Cycles-->0) {
 		LOADIP;
 		core.opcode_index=cpu.code.big*0x200;

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -70,6 +70,7 @@ libcpu = static_library('cpu', libcpu_sources,
                         include_directories : incdir,
                         dependencies : [sdl2_dep,
                                         libghc_dep,
+                                        tracy_dep,
                                         libloguru_dep,
                                        ])
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -31,6 +31,8 @@
 #include <chrono>
 #include <thread>
 
+#include <Tracy.hpp>
+
 #include "debug.h"
 #include "cpu.h"
 #include "video.h"
@@ -170,6 +172,7 @@ static Bitu Normal_Loop() {
 }
 
 void increaseticks() { //Make it return ticksRemain and set it in the function above to remove the global variable.
+	ZoneScoped
 	if (GCC_UNLIKELY(ticksLocked)) { // For Fast Forward Mode
 		ticksRemain=5;
 		/* Reset any auto cycle guessing for this frame */

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -13,6 +13,7 @@ libgui = static_library('gui', libgui_sources,
                           opengl_dep,
                           libghc_dep,
                           libloguru_dep,
+                          tracy_dep,
                           libppscale_dep,
                         ])
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -47,6 +47,8 @@
 #include <SDL_opengl.h>
 #endif
 
+#include <Tracy.hpp>
+
 #include "control.h"
 #include "cpu.h"
 #include "cross.h"
@@ -2318,6 +2320,7 @@ void GFX_EndUpdate(const uint16_t *changedLines)
 		break;
 	}
 	sdl.updating = false;
+	FrameMark
 }
 
 // Texture update and presentation

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -70,6 +70,7 @@ libhardware = static_library('hardware', libhardware_sources,
                                sdl2_dep,
                                sdl2_net_dep,
                                speexdsp_dep,
+                               tracy_dep,
                                winsock2_dep,
                                zlib_dep,
                              ])

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -44,6 +44,7 @@
 
 #include <SDL.h>
 #include <speex/speex_resampler.h>
+#include <Tracy.hpp>
 
 #include "ansi_code_markup.h"
 #include "control.h"
@@ -1144,6 +1145,7 @@ static void MIXER_Mix_NoSound()
 static void SDLCALL MIXER_CallBack([[maybe_unused]] void *userdata,
                                    Uint8 *stream, int len)
 {
+	ZoneScoped
 	memset(stream, 0, len);
 
 	auto frames_requested = len / mixer_frame_size;

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Tracy|Win32">
+      <Configuration>Tracy</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Tracy|x64">
+      <Configuration>Tracy</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}</ProjectGuid>
@@ -29,7 +37,17 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
@@ -50,7 +68,13 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
@@ -86,7 +110,22 @@
     <CodeAnalysisRuleAssemblies />
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'">
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'">
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
@@ -192,7 +231,77 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\src\platform\visualc;..\ghc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level2</WarningLevel>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <SDLCheck>false</SDLCheck>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)zmbv.dll</OutputFile>
+      <ModuleDefinitionFile>zmbv.def</ModuleDefinitionFile>
+      <MapExports>true</MapExports>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\src\platform\visualc;..\ghc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level2</WarningLevel>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <SDLCheck>false</SDLCheck>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)zmbv.dll</OutputFile>
+      <ModuleDefinitionFile>zmbv.def</ModuleDefinitionFile>
+      <MapExports>true</MapExports>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\src\platform\visualc;..\ghc;..\loguru;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -6,4 +6,5 @@ libslirp-*
 munt-libmt32emu*
 packagecache
 pcre*
+tracy-*
 zlib*

--- a/subprojects/tracy.wrap
+++ b/subprojects/tracy.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = tracy-0.8.2.1
+source_url = https://github.com/wolfpld/tracy/archive/refs/tags/v0.8.2.1.tar.gz
+source_filename = tracy-0.8.2.1.tar.gz
+source_hash = 97f478579efa1f5ce4c8619014a20327010fea122c21248701fe2bbb46ec1c1f
+wrapdb_version = 0.8.2.1-1
+
+[provide]
+tracy = tracy_dep
+

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Tracy|Win32">
+      <Configuration>Tracy</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Tracy|x64">
+      <Configuration>Tracy</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -38,6 +46,12 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -45,6 +59,12 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -61,10 +81,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -84,6 +110,14 @@
     <ExternalIncludePath>..\..\include;$(ExternalIncludePath)</ExternalIncludePath>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'">
+    <IncludePath>..\..\src\platform\visualc;..\..\include;$(IncludePath)</IncludePath>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+    <ExternalIncludePath>..\..\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>..\..\src\platform\visualc;..\..\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
@@ -93,6 +127,13 @@
     <ExternalIncludePath>..\..\include;$(ExternalIncludePath)</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>..\..\src\platform\visualc;..\..\include;$(IncludePath)</IncludePath>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+    <ExternalIncludePath>..\..\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'">
     <IncludePath>..\..\src\platform\visualc;..\..\include;$(IncludePath)</IncludePath>
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
@@ -121,11 +162,11 @@
       <AdditionalDependencies>gmock_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+      <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
 cd $(SolutionDir)  &amp;&amp; ^
 cd ..  &amp;&amp; ^
 $(TargetPath)</Command>
-        <Message>Copy resources to output directory and run tests</Message>
+      <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -155,11 +196,45 @@ $(TargetPath)</Command>
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+      <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
 cd $(SolutionDir)  &amp;&amp; ^
 cd ..  &amp;&amp; ^
 $(TargetPath)</Command>
-        <Message>Copy resources to output directory and run tests</Message>
+      <Message>Copy resources to output directory and run tests</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ConformanceMode>Default</ConformanceMode>
+      <OmitFramePointers>true</OmitFramePointers>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <AdditionalIncludeDirectories>..\..\src\libs\ghc;..\..\src\libs\iir1;..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+cd $(SolutionDir)  &amp;&amp; ^
+cd ..  &amp;&amp; ^
+$(TargetPath)</Command>
+      <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -182,11 +257,11 @@ $(TargetPath)</Command>
       <AdditionalDependencies>gmock_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+      <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
 cd $(SolutionDir)  &amp;&amp; ^
 cd ..  &amp;&amp; ^
 $(TargetPath)</Command>
-        <Message>Copy resources to output directory and run tests</Message>
+      <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -216,11 +291,45 @@ $(TargetPath)</Command>
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-        <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+      <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
 cd $(SolutionDir)  &amp;&amp; ^
 cd ..  &amp;&amp; ^
 $(TargetPath)</Command>
-        <Message>Copy resources to output directory and run tests</Message>
+      <Message>Copy resources to output directory and run tests</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OmitFramePointers>true</OmitFramePointers>
+      <ConformanceMode>Default</ConformanceMode>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>..\..\src\libs\ghc;..\..\src\libs\iir1;..\..\src\libs\loguru;..\..\src\libs\whereami</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>%systemroot%\System32\xcopy ..\..\contrib\resources $(OutDir)resources /s /i /y  &amp;&amp; ^
+cd $(SolutionDir)  &amp;&amp; ^
+cd ..  &amp;&amp; ^
+$(TargetPath)</Command>
+      <Message>Copy resources to output directory and run tests</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -1,89 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="dosbox_sources">
-      <UniqueIdentifier>{3560079a-d647-4de5-acc1-76ef66ab9dd2}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="include">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
-    </Filter>
-    <Filter Include="resources">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
-    <Filter Include="tests">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\bitops_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\fs_utils_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\iohandler_containers_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rwqueue_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\setup_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\soft_limiter_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\string_utils_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\stubs.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\support_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\support.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\soft_limiter.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\setup.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\rwqueue.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\fs_utils_win32.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\cross.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libs\ghc\fs_std_impl.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libs\loguru\loguru.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libs\whereami\whereami.c">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
+    <ClCompile Include="..\..\src\misc\ansi_code_markup.cpp" />
+    <ClCompile Include="..\..\src\misc\cross.cpp" />
+    <ClCompile Include="..\..\src\misc\fs_utils_win32.cpp" />
+    <ClCompile Include="..\..\src\misc\rwqueue.cpp" />
+    <ClCompile Include="..\..\src\misc\setup.cpp" />
+    <ClCompile Include="..\..\src\misc\soft_limiter.cpp" />
+    <ClCompile Include="..\..\src\misc\support.cpp" />
+    <ClCompile Include="..\..\src\libs\ghc\fs_std_impl.cpp" />
+    <ClCompile Include="..\..\src\libs\loguru\loguru.cpp" />
+    <ClCompile Include="..\..\src\libs\whereami\whereami.c" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\Biquad.cpp" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\Butterworth.cpp" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\Cascade.cpp" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\ChebyshevI.cpp" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\ChebyshevII.cpp" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\Custom.cpp" />
+    <ClCompile Include="..\..\src\libs\iir1\iir\PoleFilter.cpp" />
     <ClCompile Include="..\..\src\libs\iir1\iir\RBJ.cpp" />
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\support_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\ansi_code_markup_tests.cpp">
-      <Filter>tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\ansi_code_markup.cpp">
-      <Filter>dosbox_sources</Filter>
-    </ClCompile>
+    <ClCompile Include="..\ansi_code_markup_tests.cpp" />
+    <ClCompile Include="..\bitops_tests.cpp" />
+    <ClCompile Include="..\bit_view_tests.cpp" />
+    <ClCompile Include="..\fs_utils_tests.cpp" />
+    <ClCompile Include="..\iohandler_containers_tests.cpp" />
+    <ClCompile Include="..\rwqueue_tests.cpp" />
+    <ClCompile Include="..\setup_tests.cpp" />
+    <ClCompile Include="..\soft_limiter_tests.cpp" />
+    <ClCompile Include="..\string_utils_tests.cpp" />
+    <ClCompile Include="..\stubs.cpp" />
+    <ClCompile Include="..\support_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\meson.build" />

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,7 @@
         "opusfile",
         "fluidsynth",
         "gtest",
-        "speexdsp"
+        "speexdsp",
+        "tracy"
     ]
 }

--- a/vs/dosbox.sln
+++ b/vs/dosbox.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29324.140
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dosbox", "dosbox.vcxproj", "{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -17,6 +17,8 @@ Global
 		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		Tracy|x64 = Tracy|x64
+		Tracy|x86 = Tracy|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Debug|x64.ActiveCfg = Debug|x64
@@ -27,6 +29,10 @@ Global
 		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Release|x64.Build.0 = Release|x64
 		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Release|x86.ActiveCfg = Release|Win32
 		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Release|x86.Build.0 = Release|Win32
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Tracy|x64.ActiveCfg = Tracy|x64
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Tracy|x64.Build.0 = Tracy|x64
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Tracy|x86.ActiveCfg = Tracy|Win32
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Tracy|x86.Build.0 = Tracy|Win32
 		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Debug|x64.ActiveCfg = Debug|x64
 		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Debug|x64.Build.0 = Debug|x64
 		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Debug|x86.ActiveCfg = Debug|Win32
@@ -35,6 +41,10 @@ Global
 		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Release|x64.Build.0 = Release|x64
 		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Release|x86.ActiveCfg = Release|Win32
 		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Release|x86.Build.0 = Release|Win32
+		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Tracy|x64.ActiveCfg = Tracy|x64
+		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Tracy|x64.Build.0 = Tracy|x64
+		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Tracy|x86.ActiveCfg = Tracy|Win32
+		{619CF3F9-C373-4BD5-93DA-025F5E16F8FA}.Tracy|x86.Build.0 = Tracy|Win32
 		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Debug|x64.ActiveCfg = Debug|x64
 		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Debug|x64.Build.0 = Debug|x64
 		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Debug|x86.ActiveCfg = Debug|Win32
@@ -43,6 +53,10 @@ Global
 		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Release|x64.Build.0 = Release|x64
 		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Release|x86.ActiveCfg = Release|Win32
 		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Release|x86.Build.0 = Release|Win32
+		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Tracy|x64.ActiveCfg = Tracy|x64
+		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Tracy|x64.Build.0 = Tracy|x64
+		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Tracy|x86.ActiveCfg = Tracy|Win32
+		{10F658E8-8DB0-4F7A-9B61-6272BB309144}.Tracy|x86.Build.0 = Tracy|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Tracy|Win32">
+      <Configuration>Tracy</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Tracy|x64">
+      <Configuration>Tracy</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <SccProjectName />
@@ -31,7 +39,20 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
@@ -56,7 +77,13 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
@@ -81,7 +108,19 @@
     <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'">
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'">
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
@@ -95,8 +134,14 @@
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Vcpkg">
+    <VcpkgConfiguration>Release</VcpkgConfiguration>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Vcpkg">
+    <VcpkgConfiguration>Release</VcpkgConfiguration>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
   </PropertyGroup>
@@ -241,6 +286,63 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <Message>Copy resources to output directory</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalIncludeDirectories>..\include;..\src\libs\ghc;..\src\libs\PDCurses;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;TRACY_ENABLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <BrowseInformation>true</BrowseInformation>
+      <WarningLevel>Level2</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ProgramDatabaseFile>
+      </ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <FixedBaseAddress>false</FixedBaseAddress>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SetChecksum>true</SetChecksum>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <Midl>
+      <TypeLibraryName>.\Release/dosbox.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <PostBuildEvent>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"
+IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
+      <Message>Copy resources to output directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
@@ -250,6 +352,62 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\include;..\src\libs\ghc;..\src\libs\PDCurses;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <BrowseInformation>true</BrowseInformation>
+      <WarningLevel>Level2</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ProgramDatabaseFile>
+      </ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <FixedBaseAddress>false</FixedBaseAddress>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SetChecksum>true</SetChecksum>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <Midl>
+      <TypeLibraryName>.\Release/dosbox.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <PostBuildEvent>
+      <Command>%systemroot%\System32\robocopy ..\contrib\resources "$(OutDir)resources" /mir /xf "meson.build" "*.sh"
+IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
+      <Message>Copy resources to output directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalIncludeDirectories>..\include;..\src\libs\ghc;..\src\libs\PDCurses;..\src\libs\loguru;..\src\libs\whereami;..\src\platform\visualc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;TRACY_ENABLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -406,7 +564,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\gui\sdlmain.cpp" />
     <ClCompile Include="..\src\gui\sdl_gui.cpp" />
     <ClCompile Include="..\src\gui\sdl_mapper.cpp" />
-	<ClCompile Include="..\src\hardware\adlib_gold.cpp" />
+    <ClCompile Include="..\src\hardware\adlib_gold.cpp" />
     <ClCompile Include="..\src\hardware\cmos.cpp" />
     <ClCompile Include="..\src\hardware\disney.cpp" />
     <ClCompile Include="..\src\hardware\dma.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -727,6 +727,9 @@
     <ClCompile Include="..\src\libs\iir1\iir\RBJ.cpp">
       <Filter>src\libs\iir1</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\libs\zmbv\drvproc.cpp" />
+    <ClCompile Include="..\src\libs\zmbv\zmbv.cpp" />
+    <ClCompile Include="..\src\libs\zmbv\zmbv_vfw.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\bios.h">
@@ -1224,6 +1227,8 @@
     <ClInclude Include="..\src\libs\iir1\iir.h">
       <Filter>src\libs\iir1</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\libs\zmbv\Resource.h" />
+    <ClInclude Include="..\src\libs\zmbv\zmbv.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\winres.rc">


### PR DESCRIPTION
@kcgen this can be a start for updating our clang-format config.

Just a couple [options](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html) we may want to look at:

`AllowShortBlocksOnASingleLine`
`BasedOnStyle`