### PR TITLE
Add a `sleep` feature to the mixer channel 

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 291
+          MAX_BUGS: 288
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -213,6 +213,9 @@ static void DISNEY_analyze(Bitu channel){
 
 static void disney_write(io_port_t port, io_val_t value, io_width_t)
 {
+	assert(disney.chan);
+	disney.chan->WakeUp();
+
 	const auto val = check_cast<uint8_t>(value);
 
 	// LOG_MSG("write disney time %f addr%x val %x",PIC_FullIndex(),port,val);
@@ -429,7 +432,8 @@ void DISNEY_Init(Section* sec) {
 	disney.chan = MIXER_AddChannel(DISNEY_CallBack,
 	                               0,
 	                               "DISNEY",
-	                               {ChannelFeature::ReverbSend,
+	                               {ChannelFeature::Sleep,
+	                                ChannelFeature::ReverbSend,
 	                                ChannelFeature::ChorusSend,
 	                                ChannelFeature::DigitalAudio});
 

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -90,7 +90,6 @@ private:
 
 	// Runtime states
 	double last_rendered_ms        = 0;
-	int unused_for_ms              = 0;
 	io_port_t base_port            = 0;
 	bool is_standalone_gameblaster = false;
 	bool is_open                   = false;

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -65,8 +65,6 @@ private:
 
 	// Runtime states
 	double last_rendered_ms = 0.0;
-	int unused_for_ms       = 0;
-	int silent_frames       = 0;
 	bool is_open            = false;
 };
 

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -114,7 +114,6 @@ private:
 	// Playback related
 	double last_rendered_ms = 0.0;
 	double ms_per_frame     = 0.0;
-	uint16_t unused_for_ms  = 0;
 
 	// Last selected address in the chip for the different modes
 	union {
@@ -135,7 +134,6 @@ private:
 	void Init(const uint16_t sample_rate);
 
 	void AudioCallback(const uint16_t frames);
-	bool ChannelCanSleep();
 	AudioFrame RenderFrame();
 	void RenderUpToNow();
 

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -58,8 +58,6 @@ private:
 	static constexpr float amp_negative = MIN_AUDIO * pwm_scalar;
 	static constexpr float amp_neutral = (amp_positive + amp_negative) / 2.0f;
 
-	static constexpr int idle_grace_time_ms = 100;
-
 	struct DelayEntry {
 		float index = 0.0f;
 		float vol   = 0.0f;
@@ -85,7 +83,6 @@ private:
 	float volcur       = 0.0f;
 	float last_index   = 0.0f;
 
-	int sample_rate = 0;
-
+	int sample_rate       = 0;
 	int minimum_tick_rate = 0;
 };

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1854,6 +1854,8 @@ static uint8_t read_sb(io_port_t port, io_width_t)
 
 static void write_sb(io_port_t port, io_val_t value, io_width_t)
 {
+	sb.chan->WakeUp();
+
 	const auto val = check_cast<uint8_t>(value);
 	switch (port - sb.hw.base) {
 	case DSP_RESET: DSP_DoReset(val); break;
@@ -2021,14 +2023,18 @@ public:
 		}
 		if (sb.type==SBT_NONE || sb.type==SBT_GB) return;
 
-		std::set channel_features = {ChannelFeature::ReverbSend,
-		                             ChannelFeature::ChorusSend,
-		                             ChannelFeature::DigitalAudio};
+		std::set<ChannelFeature> channel_features = {
+		        ChannelFeature::Sleep,
+		        ChannelFeature::ReverbSend,
+		        ChannelFeature::ChorusSend,
+		        ChannelFeature::DigitalAudio};
 
 		if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2 || sb.type == SBT_16)
 			channel_features.insert(ChannelFeature::Stereo);
 
 		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack, 22050, "SB", channel_features);
+		assert(sb.chan);
+
 		configure_sb_filter();
 
 		sb.dsp.state=DSP_S_NORMAL;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -216,7 +216,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
 	                                            0,
 	                                            "FSYNTH",
-	                                            {ChannelFeature::ReverbSend,
+	                                            {ChannelFeature::Sleep,
+	                                             ChannelFeature::ReverbSend,
 	                                             ChannelFeature::Stereo,
 	                                             ChannelFeature::Synthesizer});
 
@@ -359,7 +360,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	play_buffer = playable.Dequeue(); // populate the first play buffer
 
 	// Start playback
-	channel->Enable(true);
+	// channel->Enable(true);
 	is_open = true;
 	return true;
 }
@@ -404,6 +405,9 @@ void MidiHandlerFluidsynth::Close()
 
 void MidiHandlerFluidsynth::PlayMsg(const uint8_t *msg)
 {
+	assert(channel);
+	channel->WakeUp();
+
 	const int chanID = msg[0] & 0b1111;
 
 	switch (msg[0] & 0b1111'0000) {
@@ -439,6 +443,9 @@ void MidiHandlerFluidsynth::PlayMsg(const uint8_t *msg)
 
 void MidiHandlerFluidsynth::PlaySysex(uint8_t *sysex, size_t len)
 {
+	assert(channel);
+	channel->WakeUp();
+
 	const char *data = reinterpret_cast<const char *>(sysex);
 	const auto n = static_cast<int>(len);
 	fluid_synth_sysex(synth.get(), data, n, nullptr, nullptr, nullptr, false);


### PR DESCRIPTION
Added one example use-case in the discrete PC speaker.

When we're happy w/ the feature, I'll add it to more audio devices.

Plan is to merge this after the reverb PR, to avoid mixer overlap. 