### PR TITLE
Workaround Ubuntu 22.04 libudev held package issue

### DIFF
--- a/.github/meson/native-gcc-10.ini
+++ b/.github/meson/native-gcc-10.ini
@@ -1,0 +1,3 @@
+[binaries]
+c = ['ccache', 'gcc-10']
+cpp = ['ccache', 'g++-10']

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -15,7 +15,7 @@ jobs:
   run_linters:
     name: Script linters
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
 
   build_clang_static_analyser:
     name: Clang static analyzer
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: run_linters
     steps:
       - name: Checkout repository
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install clang-tools python3-bs4 $(cat packages/ubuntu-22.04-apt.txt)
+          sudo apt-get install clang-tools python3-bs4 $(cat packages/ubuntu-20.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
@@ -113,7 +113,7 @@ jobs:
   dynamic_matrix:
     name: ${{ matrix.conf.name }}
     needs: run_linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         conf:
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install $(cat packages/ubuntu-22.04-apt.txt)
+          sudo apt-get install $(cat packages/ubuntu-20.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
       # Workaround frequent HTTPS-based connectivity issues

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -37,7 +37,7 @@ jobs:
           - name: macOS
             os: macos-latest
           - name: Linux
-            os: ubuntu-22.04
+            os: ubuntu-20.04
         conf:
           - configure_flags:  -Duse_slirp=false
           - configure_flags:  -Duse_sdl2_net=false
@@ -96,7 +96,7 @@ jobs:
         if:    matrix.system.name == 'Linux'
         run: |
           sudo apt-get -y update
-          sudo apt-get install $(cat packages/ubuntu-22.04-apt.txt)
+          sudo apt-get install $(cat packages/ubuntu-20.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
       - name:  Install dependencies (macOS)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,16 +20,16 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: GCC 12, Ubuntu 22.04
-            os: ubuntu-22.04
-            packages: g++-12
-            build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-gcc-12.ini
+          - name: GCC 12, Ubuntu 20.04
+            os: ubuntu-20.04
+            packages: g++-10
+            build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-gcc-10.ini
             max_warnings: 0
 
-          - name: Clang, Ubuntu 22.04
-            os: ubuntu-22.04
-            packages: clang
-            build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-clang.ini
+          - name: Clang 12, Ubuntu 20.04
+            os: ubuntu-20.04
+            packages: clang-12
+            build_flags: -Dunit_tests=disabled --native-file=.github/meson/native-clang-12.ini
             max_warnings: 0
 
           - name: GCC, Ubuntu 20.04
@@ -43,32 +43,32 @@ jobs:
             max_warnings: 0
 
           - name: GCC, +tests
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             run_tests: true
             max_warnings: -1
 
           - name: GCC, +debugger
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Denable_debugger=normal
             max_warnings: 0
 
           - name: GCC, -dyn-x86
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Ddynamic_core=dynrec
             max_warnings: 0
 
           - name: GCC, -dyn-x86, +debugger
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Ddynamic_core=dynrec -Denable_debugger=normal
             max_warnings: 0
 
           - name: GCC, -network
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             build_flags: -Dunit_tests=disabled -Duse_sdl2_net=false -Duse_slirp=false
             max_warnings: 0
 
           - name: GCC, minimum build
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             build_flags: >-
               --wrap-mode=nofallback
               -Dunit_tests=disabled
@@ -88,7 +88,16 @@ jobs:
         with:
           submodules: false
 
-      - run:  sudo apt-get update
+      - run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          # use the following to force full upgrades
+          # sudo apt-get -y upgrade
+          # sudo apt-get -y --with-new-pkgs upgrade
+          # sudo apt-get -y install -y aptitude
+          # echo -e "n\ny\ny" | sudo aptitude -y -f full-upgrade
+          # sudo apt-get update
+          # sudo apt-get -y upgrade
 
       - name: Install dependencies (minimum set)
         if:   matrix.conf.min_dependencies


### PR DESCRIPTION
CI nodes have started failing with:

The following packages have unmet dependencies:
  libudev-dev :
    Depends: libudev1 (=249.11-0ubuntu3)
    but 249.11-0ubuntu3.3 is to be installed.
    Unable to correct problems, you have held broken
    packages.

ref: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1979850