### PR TITLE
Add missing #endif that results in compilation error

### DIFF
--- a/contrib/resources/glshaders/crt-easymode-flat.glsl
+++ b/contrib/resources/glshaders/crt-easymode-flat.glsl
@@ -263,3 +263,5 @@ void main()
 
 	FragColor = vec4(col * BRIGHT_BOOST, 1.0);
 }
+
+#endif


### PR DESCRIPTION
Someone must have deleted that last line accidentally or something because I distinctly remember this shader used to work fine about a year ago (or maybe certain drivers are more lenient; I noticed the failure on macOS, and last time I tried this shader was on Windows).

In any case, the fix is trivial.

```log
2022-07-08 11:52:43.428 | Error compiling shader: ERROR: 0:268: '' : syntax error: #endif missing!! Compilation stopped
2022-07-08 11:52:43.428 | SDL:OPENGL: Failed to compile shader!
```