### PR TITLE
Add configurable softmodem connect speed

### DIFF
--- a/README
+++ b/README
@@ -1570,7 +1570,8 @@ Typically these are:
   COM1:
     - COM port 1
     - 8N1, meaning: data-bits (8), parity (none), and stop-bits (1).
-    - 57600 baud
+    - 57600 baud, which can be changed to 300 <= VALUE <= 57600 with the
+      baudrate:VALUE setting.
     - 03F8 address
     - IRQ4 interrupt
     - 16550 fifo enabled

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1015,7 +1015,7 @@ const char *filter_on_or_off[] = {"on", "off", 0};
 	        "   Default is type:wheel+msm rate:smooth\n"
 	        "for direct: realport (required), rxdelay (optional).\n"
 	        "   (realport:COM1 realport:ttyS0).\n"
-	        "for modem: listenport sock (all optional).\n"
+	        "for modem: listenport, sock, baudrate (all optional).\n"
 	        "for nullmodem: server, rxdelay, txdelay, telnet, usedtr,\n"
 	        "   transparent, port, inhsocket, sock (all optional).\n"
 	        "SOCK parameter specifies the protocol to be used by both sides\n"

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -150,6 +150,21 @@ CSerialModem::CSerialModem(const uint8_t port_idx, CommandLine *cmd)
 		        GetPortNumber(), telnet_mode ? "enabled" : "disabled");
 	}
 
+	// Get the connect speed to report
+	constexpr auto min_baudrate = 300u;
+	constexpr auto max_baudrate = 57600u;
+	if (getUintFromString("baudrate:", val, cmd)) {
+		val = clamp(val, min_baudrate, max_baudrate);
+	} else {
+		val = max_baudrate;
+	}
+
+	assert(val >= min_baudrate && val <= max_baudrate);
+	safe_sprintf(connect_string, "CONNECT %d", val);
+
+	LOG_MSG("SERIAL: Port %" PRIu8 " will report baud rate %d",
+			GetPortNumber(), val);
+
 	InstallationSuccessful=true;
 }
 
@@ -237,7 +252,7 @@ void CSerialModem::SendRes(const ResTypes response) {
 	uint32_t code = -1;
 	switch (response) {
 		case ResOK:         code = 0; string = "OK"; break;
-		case ResCONNECT:    code = 1; string = "CONNECT 57600"; break;
+		case ResCONNECT:    code = 1; string = connect_string; break;
 		case ResRING:       code = 2; string = "RING"; break;
 		case ResNOCARRIER:  code = 3; string = "NO CARRIER"; break;
 		case ResERROR:      code = 4; string = "ERROR"; break;

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -231,6 +231,7 @@ protected:
 	                              // false: send text (i.e. NO DIALTONE)
 	bool telnet_mode = false; // Default to direct null modem connection;
 	                         // Telnet mode interprets IAC
+	char connect_string[14] = {"CONNECT 57600"}; // default connect string
 	bool connected = false;
 	uint32_t doresponse = 0;
 	uint8_t waiting_tx_character = 0;


### PR DESCRIPTION
Tested with:

```
serial1       = modem baudrate:2400  # reports CONNECT 2400
serial1       = modem                # reports CONNECT 57600
serial1       = modem baudrate:1     # reports CONNECT 1
serial1       = modem baudrate:0     # reports CONNECT 57600
serial1       = modem baudrate:-123  # reports CONNECT 57600
serial1       = modem baudrate:foo   # reports CONNECT 57600


```