### PR TITLE
Don't stop the discrete PC Speaker channel

### DIFF
--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -45,8 +45,6 @@ private:
 	bool IsWaveSquare() const;
 	float NeutralOr(const float fallback) const;
 	float NeutralLastPitOr(const float fallback) const;
-	void PlayOrSleep(const bool samples_were_processed,
-	                 uint16_t requested_samples, float buffer[]);
 
 	// Constants
 	static constexpr char device_name[] = "PCSPEAKER";
@@ -90,6 +88,4 @@ private:
 	int sample_rate = 0;
 
 	int minimum_tick_rate = 0;
-
-	int idle_countdown = idle_grace_time_ms;
 };


### PR DESCRIPTION
Commit 83c1126 removed the DC silencer from the discrete PC Speaker, which meant that its channel can be left in a DC-biased state prior to the channel being shutdown.

This potential DC-biased state combined with the existing channel-shutdown feature meant that "idling" the channel could introduce an audio discontinuity when the channel's signal is taken from its DC-biased position (some small positive or negative value) to zero.

This behavior was reported in #1783 by @johnnovak in Maniac Mansion Enhanced edition using the default config:
 1. Start the game with MANIAC
 2. Press Shit + M to enable the mouse.
 3. Click on one of the faces to select it.
 4. There's a buzzing sound that keeps playing indefinitely after the "click" sound (should be silence).

This PR removes the discrete PC Speaker's channel-shutdown feature until it can be correctly handled (by the upcoming auto-sleep PR).

Fixes #1783.