### PR TITLE
Fix unnecessary serial mouse events

### DIFF
--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -888,7 +888,7 @@ void MOUSE_EventPressed(uint8_t idx)
 
     if (!mouse_video.autoseamless || mouse_is_captured) {
         if (changed_12S) {
-            MOUSESERIAL_NotifyPressed(buttons_12S, idx_12S);
+            MOUSESERIAL_NotifyPressedReleased(buttons_12S, idx_12S);
         }
         event.request_ps2 = MOUSEPS2_NotifyPressedReleased(buttons_12S,
                                                            get_buttons_joined());
@@ -896,7 +896,6 @@ void MOUSE_EventPressed(uint8_t idx)
     if (changed_12S) {
         event.request_vmm = MOUSEVMM_NotifyPressedReleased(buttons_12S);
         event.request_dos = MOUSEDOS_NotifyPressed(buttons_12S, idx_12S, event.id);
-        MOUSESERIAL_NotifyPressed(buttons_12S, idx_12S);
     }
 
     queue.AddEvent(event);
@@ -951,7 +950,7 @@ void MOUSE_EventReleased(uint8_t idx)
     if (changed_12S) {
         event.request_vmm = MOUSEVMM_NotifyPressedReleased(buttons_12S);
         event.request_dos = MOUSEDOS_NotifyReleased(buttons_12S, idx_12S, event.id);
-        MOUSESERIAL_NotifyReleased(buttons_12S, idx_12S);
+        MOUSESERIAL_NotifyPressedReleased(buttons_12S, idx_12S);
     }
 
     queue.AddEvent(event);

--- a/src/ints/mouse_core.h
+++ b/src/ints/mouse_core.h
@@ -176,8 +176,8 @@ void MOUSE_NotifyStateChanged();
 // - needs index of button which changed state
 
 void MOUSESERIAL_NotifyMoved(const float x_rel, const float y_rel);
-void MOUSESERIAL_NotifyPressed(const MouseButtons12S buttons_12S, const uint8_t idx);
-void MOUSESERIAL_NotifyReleased(const MouseButtons12S buttons_12S, const uint8_t idx);
+void MOUSESERIAL_NotifyPressedReleased(const MouseButtons12S buttons_12S,
+                                       const uint8_t idx);
 void MOUSESERIAL_NotifyWheel(const int16_t w_rel);
 
 // ***************************************************************************

--- a/src/ints/mouse_serial.cpp
+++ b/src/ints/mouse_serial.cpp
@@ -72,13 +72,8 @@ void MOUSESERIAL_NotifyMoved(const float x_rel, const float y_rel)
     }
 }
 
-void MOUSESERIAL_NotifyPressed(const MouseButtons12S buttons_12S, const uint8_t idx)
-{
-    for (auto &listener : listeners)
-        listener->OnMouseEventButton(buttons_12S.data, idx);
-}
-
-void MOUSESERIAL_NotifyReleased(const MouseButtons12S buttons_12S, const uint8_t idx)
+void MOUSESERIAL_NotifyPressedReleased(const MouseButtons12S buttons_12S,
+                                       const uint8_t idx)
 {
     for (auto &listener : listeners)
         listener->OnMouseEventButton(buttons_12S.data, idx);


### PR DESCRIPTION
There is some unneeded/unwanted code left in serial mouse emulation, which can trigger unnecessary mouse events. This PR fixes the problem, it also de-duplicates some code.