### PR TITLE
Refactor and simplify the Disney Sound Source code

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -80,6 +80,7 @@ struct AudioFrame {
 #define MIXER_BUFSIZE (16 * 1024)
 #define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
 extern uint8_t MixTemp[MIXER_BUFSIZE];
+extern int16_t lut_u8to16[UINT8_MAX + 1];
 
 #define MAX_AUDIO ((1<<(16-1))-1)
 #define MIN_AUDIO -(1<<(16-1))

--- a/include/parallel_port.h
+++ b/include/parallel_port.h
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef PARALLEL_PORT_H_
+#define PARALLEL_PORT_H_
+
+#include "bit_view.h"
+
+// There are three hexadecimal addresses commonly
+// used for parallel ports: 378h, 278h, 3BCh.
+// These are absolute addresses, fixed in memory.
+
+// They can be distinguished from them “logical”
+// addresses accessed by users and many programs:
+// LPT 1, LPT 2, LPT 3, ...
+// These logical addresses
+// can be interpreted as “1st Line Printer, 2nd
+// Line Printer, 3rd Line Printer,…”
+
+// Consequently, one cannot have a “2nd Line
+// Printer,” without having a “1st Line Printer.” –
+// ie: You can’t get a LPT 2, unless you already
+// have a LPT 1.
+// Ref: http://faq.lavalink.com/2006/11/understanding-parallel-port-addressing/
+
+enum LptPorts : io_port_t {
+	Lpt1Port = 0x378,
+	Lpt2Port = 0x278,
+	Lpt3Port = 0x3bc,
+};
+
+// The Parallel port has three registers:
+// Name      Read/write   Port offset
+// ~~~~      ~~~~~~~~~~   ~~~~~~~~~~~
+// Data      write-only   0
+// Status    read-only    1
+// Control   write-only   2
+
+union LptStatusRegister {
+	uint8_t data = 0xff;
+	bit_view<0, 2> reserved;
+	bit_view<2, 1> irq;
+	bit_view<3, 1> error;
+	bit_view<4, 1> select_in;
+	bit_view<5, 1> paper_out;
+	bit_view<6, 1> ack;
+	bit_view<7, 1> busy;
+};
+// The ERROR, ACK and BUSY signals are active-low when reading from the IO port.
+
+union LptControlRegister {
+	uint8_t data = 0;
+	bit_view<0, 1> strobe;
+	bit_view<1, 1> auto_lf;
+	bit_view<2, 1> initialize;
+	bit_view<3, 1> select;
+	bit_view<4, 1> irq_ack;
+	bit_view<5, 1> bidi;
+	// bits 6 and 7 are unused
+};
+// The INITIALISE signal is active low when writing to the IO port.
+
+// The STROBE signal is for handshaking and alerts the printer to data
+// being ready at the data port.
+
+// AUTO_LF is the Automatic Line-Feed signal. If this is set and the
+// printer receives a Carriage-Return character (0x0D), the printer will
+// automatically perform a Line-Feed (character 0x0A) as well.
+
+// INITIALISE, sometimes called PRIME, alerts the device that data that
+// a data conversation is about to start. This signal may result in a
+// printer performing a reset and any buffers being flushed.
+
+// Protocol: data is sent to the connected device by writing the byte to
+// the data port, then pulsing the STROBE signal. This pulse informs the
+// device that data is ready to be read. The device will respond by
+// raising its BUSY signal and then reading the data and performing some
+// processing on it. Once this processing is complete, the device will
+// lower the Busy signal and may raise a brief ACK signal to indicate
+// that it has finished.
+
+// Ref: https://wiki.osdev.org/Parallel_port
+
+#endif

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2021-2022  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -53,7 +54,6 @@ struct Disney {
 
 	// parallel port stuff
 	uint8_t data = 0;
-	uint8_t status = DISNEY_INIT_STATUS;
 	uint8_t control = 0;
 	// the D/A channels
 	dac_channel da[2] = {};
@@ -304,7 +304,6 @@ static uint8_t disney_read(io_port_t port, io_width_t)
 		return disney.data;
 		break;
 	case 1:		/* Status Port */
-//		LOG(LOG_MISC,"DISNEY:Read from status port %X",disney.status);
 		retval = 0x07;//0x40; // Stereo-on-1 and (or) New-Stereo DACs present
 		if (disney.interface_det_ext > 5) {
 			if (disney.leader && disney.leader->used >= 16){
@@ -465,7 +464,6 @@ void DISNEY_Init(Section* sec) {
 	disney.read_handler.Install(base_port, disney_read, io_width_t::byte, 3);
 
 	// Initialize the Disney states
-	disney.status = DISNEY_INIT_STATUS;
 	disney.control = 0;
 	disney.last_used = 0;
 	DISNEY_disable(0);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -20,29 +20,21 @@
 #include "dosbox.h"
 
 #include <cassert>
-#include <memory>
-#include <string.h>
+#include <queue>
 
+#include "bit_view.h"
+#include "checks.h"
 #include "inout.h"
 #include "mixer.h"
+#include "parallel_port.h"
 #include "pic.h"
 #include "setup.h"
-#include "support.h"
 
-static constexpr uint8_t buffer_samples = 128;
-
-struct DisneyDac {
-	uint8_t buffer[buffer_samples] = {};
-	uint8_t used = 0; // current data buffer level
-	double speedcheck_sum = 0.0;
-	double speedcheck_last = 0.0;
-	bool speedcheck_failed = false;
-	bool speedcheck_init = false;
-};
+CHECK_NARROWING();
 
 class Disney {
 public:
-	Disney(const std::string &filter_pref);
+	Disney(const io_port_t base_port, const std::string_view filter_pref);
 	~Disney();
 
 private:
@@ -50,431 +42,202 @@ private:
 	Disney(const Disney &)            = delete;
 	Disney &operator=(const Disney &) = delete;
 
-	// Types and enums
-	enum State { Idle, Running, Finished, Analyzing };
+	AudioFrame Render();
+	void RenderUpToNow();
+	void AudioCallback(const uint16_t requested_frames);
 
-	void Analyze(DisneyDac &dac);
-	void Enable(const int rate_hz);
+	bool IsFifoFull() const;
+	uint8_t ReadStatus(const io_port_t, const io_width_t);
+	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
+	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
 
-	int CalcSampleRate(const DisneyDac &dac);
-	void PlayStereo(uint16_t len, const uint8_t *l, const uint8_t *r);
+	// The DSS is an LPT DAC with a 16-level FIFO running at 7kHz
+	static constexpr auto dss_7khz_rate    = 7000;
+	static constexpr auto ms_per_frame     = 1000.0 / dss_7khz_rate;
+	static constexpr uint8_t max_fifo_size = 16;
 
-	void AudioCallback(uint16_t len);
-	void UpdateFilterFreq(const uint16_t rate_hz);
+	// Managed objects
+	mixer_channel_t channel                    = {};
+	std::queue<uint8_t> fifo                   = {};
+	std::queue<AudioFrame> render_queue        = {};
+	IO_WriteHandleObject data_write_handler    = {};
+	IO_ReadHandleObject status_read_handler    = {};
+	IO_WriteHandleObject control_write_handler = {};
 
-	uint8_t ReadFromPort(const io_port_t port, io_width_t);
-	void WriteToPort(const io_port_t port, const io_val_t value, io_width_t);
-
-	// Constants
-	static constexpr uint16_t base_port = 0x0378;
-
-	// The Disney Sound Source is an LPT DAC with a fixed sample rate of 7kHz.
-	static constexpr auto base_rate_hz = 7000;
-
-	// Managed and compound objects
-	IO_ReadHandleObject read_handler{};
-	IO_WriteHandleObject write_handler{};
-
-	mixer_channel_t channel = nullptr;
-
-	// the D/A channels
-	DisneyDac da[2] = {};
-
-	// For mono-output, the analysis step points the leader to the channel
-	// with the most rendered-samples. We use the left channel as a valid
-	// place-holder prior to the first analysis. This ensures the
-	// leader is always valid, such as in cases where the callback in
-	// enabled before the analysis.
-	DisneyDac *leader = &da[0];
-
-	State state = State::Idle;
-
-	uint32_t interface_det = 0;
-	uint32_t interface_det_ext = 0;
-
-	bool stereo         = false;
-	bool filter_enabled = false;
-
-	// parallel port registers
-	uint8_t data    = 0;
-	uint8_t control = 0;
+	// Runtime state
+	double last_rendered_ms        = 0.0;
+	uint8_t data_reg               = Mixer_GetSilentDOSSample<uint8_t>();
+	LptStatusRegister status_reg   = {};
+	LptControlRegister control_reg = {};
 };
 
-void Disney::UpdateFilterFreq(const uint16_t rate_hz)
+bool Disney::IsFifoFull() const
 {
-	if (!filter_enabled)
-		return;
-
-	// Disney only supports a single fixed 7kHz sample rate; the 6dB/oct LPF @
-	// 1kHz is an accurate emulation of how the actual Disney lowpass filter
-	// sounds.
-	//
-	// With Covox one can theorically achieve any sample rate as long as the
-	// CPU can keep up. Most Covox adapters have no lowpass filter whatsoever,
-	// but as the aim here is to make the sound more pleasant to listen to,
-	// we'll apply a gentle 6dB/oct LPF at a bit below half the sample rate to
-	// tame the harshest aliased frequencies while still retaining a good dose
-	// of the "raw crunchy DAC sound".
-	constexpr uint16_t default_cutoff_freq = 1000;
-	const auto cutoff_freq                 = (rate_hz == base_rate_hz)
-	                                               ? default_cutoff_freq
-	                                               : static_cast<uint16_t>(rate_hz * 0.45f);
-
-	constexpr auto order = 1;
-	channel->ConfigureLowPassFilter(order, cutoff_freq);
+	return fifo.size() >= max_fifo_size;
 }
 
-void Disney::Enable(const int rate_hz)
+// Eight bit data sent to the D/A convener is loaded into a 16 level FIFO. Data
+// is clocked from this FIFO at the fixed rate of 7 kHz +/- 5%.
+AudioFrame Disney::Render()
 {
-	if (rate_hz < 500 || rate_hz > 100000) {
-		// try again..
-		state = State::Idle;
+	assert(fifo.size());
+	const float sample = lut_u8to16[fifo.front()];
+	if (fifo.size() > 1)
+		fifo.pop();
+	return {sample, sample};
+}
+
+void Disney::RenderUpToNow()
+{
+	const auto now = PIC_FullIndex();
+
+	// Wake up the channel and update the last rendered time datum.
+	assert(channel);
+	if (channel->WakeUp()) {
+		last_rendered_ms = now;
 		return;
 	}
-#if 0
-	LOG(LOG_MISC,LOG_NORMAL)("DISNEY: enabled at %d Hz in %s", rate_hz,
-	                         stereo ? "stereo" : "mono");
-#endif
-	channel->SetSampleRate(rate_hz);
-	channel->Enable(true);
-
-	constexpr auto max_filter_freq = 44100;
-	const auto filter_freq         = std::min(rate_hz, max_filter_freq);
-	UpdateFilterFreq(check_cast<uint16_t>(filter_freq));
-
-	state = State::Running;
-}
-
-// Calculate the sample rate from DAC samples and speed parameters.
-// The maximum possible sample rate is 127,000 Hz which occurs when all 128
-// samples are used and the speedcheck_sum has accumulated only one single
-// tick.
-int Disney::CalcSampleRate(const DisneyDac &dac)
-{
-	if (dac.used <= 1)
-		return 0;
-
-	const auto k_samples = 1000 * (dac.used - 1);
-
-	const auto rate_hz = k_samples / dac.speedcheck_sum;
-
-	return iround(rate_hz);
-}
-
-void Disney::Analyze(DisneyDac &dac)
-{
-	switch (state) {
-	case State::Running: // should not get here
-		break;
-	case State::Idle:
-		// initialize channel data
-		for (int i = 0; i < 2; i++) {
-			da[i].used              = 0;
-			da[i].speedcheck_sum    = 0;
-			da[i].speedcheck_failed = false;
-			da[i].speedcheck_init   = false;
-		}
-		dac.speedcheck_last = PIC_FullIndex();
-		dac.speedcheck_init = true;
-
-		state = State::Analyzing;
-		break;
-
-	case State::Finished: {
-		// The leading channel has the most populated samples
-		leader = da[0].used > da[1].used ? &da[0] : &da[1];
-
-		// Stereo-mode if both DACs are similarly filled
-		const auto st_diff = abs(da[0].used - da[1].used);
-		stereo             = (st_diff < 5);
-
-		// Run with the greater DAC sample rate
-		const auto max_rate_hz = std::max(CalcSampleRate(da[0]),
-		                                  CalcSampleRate(da[1]));
-		Enable(max_rate_hz);
-	} break;
-
-	case State::Analyzing: {
-		const auto current = PIC_FullIndex();
-
-		if (!dac.speedcheck_init) {
-			dac.speedcheck_init = true;
-			dac.speedcheck_last = current;
-			break;
-		}
-		const auto speed_delta = current - dac.speedcheck_last;
-		dac.speedcheck_sum += speed_delta;
-		// LOG_MSG("t=%f",current - dac.speedcheck_last);
-
-		// sanity checks (printer...)
-		if (speed_delta < 0.01 || speed_delta > 2)
-			dac.speedcheck_failed = true;
-
-		// if both are failed we are back at start
-		if (da[0].speedcheck_failed && da[1].speedcheck_failed) {
-			state = State::Idle;
-			break;
-		}
-
-		dac.speedcheck_last = current;
-
-		// analyze finish condition
-		if (da[0].used > 30 || da[1].used > 30)
-			state = State::Finished;
-	} break;
+	// Keep rendering until we're current
+	while (last_rendered_ms < now) {
+		last_rendered_ms += ms_per_frame;
+		render_queue.emplace(Render());
 	}
 }
 
-void Disney::WriteToPort(const io_port_t port, const io_val_t value, io_width_t)
+void Disney::WriteData(const io_port_t, const io_val_t data, const io_width_t)
+{
+	data_reg = check_cast<uint8_t>(data);
+}
+
+void Disney::WriteControl(const io_port_t, const io_val_t value, const io_width_t)
+{
+	RenderUpToNow();
+
+	const auto new_control = LptControlRegister{check_cast<uint8_t>(value)};
+
+	// The rising edge of the pulse on Pin 17 from the printer interface
+	// is used to clock data into the FIFO. Note from diagram 1 that the
+	// SELECT and INIT inputs to the D/A chip are isolated from pin 17 by
+	// an RC lime constant. Ref:
+	// https://archive.org/stream/dss-programmers-guide/dss-programmers-guide_djvu.txt
+
+	if (!control_reg.select && new_control.select)
+		if (!IsFifoFull())
+			fifo.emplace(data_reg);
+
+	control_reg.data = new_control.data;
+}
+
+uint8_t Disney::ReadStatus(const io_port_t, const io_width_t)
+{
+	// The Disney ACK's (active-low) when the FIFO has room
+	status_reg.ack = IsFifoFull();
+	return status_reg.data;
+}
+
+void Disney::AudioCallback(const uint16_t requested_frames)
 {
 	assert(channel);
-	channel->WakeUp();
 
-	const auto val = check_cast<uint8_t>(value);
+	auto frames_remaining = requested_frames;
 
-	switch (port - base_port) {
-	case 0: /* Data Port */
-	{
-		data = val;
-		// if data is written here too often without using the stereo
-		// mechanism we use the simple DAC machanism.
-		if (state != State::Running) {
-			interface_det++;
-			if (interface_det > 5)
-				Analyze(da[0]);
-		}
-		if (interface_det > 5) {
-			if (da[0].used < buffer_samples) {
-				da[0].buffer[da[0].used] = data;
-				da[0].used++;
-			} // else LOG_MSG("disney overflow 0");
-		}
-		break;
+	// First, add any frames we've queued since the last callback
+	while (frames_remaining && render_queue.size()) {
+		channel->AddSamples_sfloat(1, &render_queue.front()[0]);
+		render_queue.pop();
+		--frames_remaining;
 	}
-	case 1:		/* Status Port */
-		LOG(LOG_MISC, LOG_NORMAL)("DISNEY:Status write %u", val);
-		break;
-	case 2:		/* Control Port */
-		if ((control & 0x2) && !(val & 0x2)) {
-			if (state != State::Running) {
-				interface_det     = 0;
-				interface_det_ext = 0;
-				Analyze(da[1]);
-			}
-
-			// stereo channel latch
-			if (da[1].used < buffer_samples) {
-				da[1].buffer[da[1].used] = data;
-				da[1].used++;
-			} // else LOG_MSG("disney overflow 1");
-		}
-
-		if ((control & 0x1) && !(val & 0x1)) {
-			if (state != State::Running) {
-				interface_det     = 0;
-				interface_det_ext = 0;
-				Analyze(da[0]);
-			}
-			// stereo channel latch
-			if (da[0].used < buffer_samples) {
-				da[0].buffer[da[0].used] = data;
-				da[0].used++;
-			} // else LOG_MSG("disney overflow 0");
-		}
-
-		if ((control & 0x8) && !(val & 0x8)) {
-			// emulate a device with 16-byte sound FIFO
-			if (state != State::Running) {
-				interface_det_ext++;
-				interface_det = 0;
-				if (interface_det_ext > 5) {
-					leader = &da[0];
-					Enable(base_rate_hz);
-				}
-			}
-			if (interface_det_ext > 5) {
-				if (da[0].used < buffer_samples) {
-					da[0].buffer[da[0].used] = data;
-					da[0].used++;
-				}
-			}
-		}
-
-//		LOG_WARN("DISNEY:Control write %x",val);
-		if (val&0x10) LOG(LOG_MISC,LOG_ERROR)("DISNEY:Parallel IRQ Enabled");
-		control = val;
-		break;
+	// If the queue's run dry, render the remainder and sync-up our time datum
+	while (frames_remaining) {
+		const auto frame = Render();
+		channel->AddSamples_sfloat(1, &frame[0]);
+		--frames_remaining;
 	}
+	last_rendered_ms = PIC_FullIndex();
 }
 
-uint8_t Disney::ReadFromPort(const io_port_t port, io_width_t)
+std::unique_ptr<Disney> disney = {};
+
+Disney::Disney(const io_port_t base_port, const std::string_view filter_pref)
 {
-	uint8_t retval;
-	switch (port - base_port) {
-	case 0: /* Data Port */
-		// LOG(LOG_MISC,LOG_NORMAL)("DISNEY:Read from data port");
-		return data;
-		break;
-	case 1:               /* Status Port */
-		retval = 0x07;//0x40; // Stereo-on-1 and (or) New-Stereo DACs present
-		if (interface_det_ext > 5) {
-			if (leader && leader->used >= 16) {
-				retval |= 0x40; // ack
-				retval &= ~0x4; // interrupt
-			}
-		}
-		if (!(data & 0x80))
-			retval |= 0x80; // pin 9 is wired to pin 11
-		return retval;
-		break;
-	case 2:		/* Control Port */
-		LOG(LOG_MISC,LOG_NORMAL)("DISNEY:Read from control port");
-		return control;
-		break;
-	}
-	return 0xff;
-}
+	// Prime the FIFO with a single silent sample
+	fifo.emplace(data_reg);
 
-void Disney::PlayStereo(uint16_t len, const uint8_t *l, const uint8_t *r)
-{
-	static uint8_t stereodata[buffer_samples * 2];
-	for (uint16_t i = 0; i < len; ++i) {
-		stereodata[i*2] = l[i];
-		stereodata[i*2+1] = r[i];
-	}
-	channel->AddSamples_s8(len, stereodata);
-}
-
-void Disney::AudioCallback(uint16_t len)
-{
-	if (!len || !channel)
-		return;
-
-	// get the smaller used
-	uint16_t real_used;
-	if (stereo) {
-		real_used = da[0].used;
-		if (da[1].used < real_used)
-			real_used = da[1].used;
-	} else
-		real_used = leader->used;
-
-	if (real_used >= len) { // enough data for now
-		if (stereo)
-			PlayStereo(len, da[0].buffer, da[1].buffer);
-		else
-			channel->AddSamples_m8(len, leader->buffer);
-
-		// put the rest back to start
-		for (uint8_t i = 0; i < 2; ++i) {
-			// TODO for mono only one
-			memmove(da[i].buffer,
-			        &da[i].buffer[len],
-			        buffer_samples /*real_used*/ - len);
-			da[i].used = check_cast<uint8_t>(da[i].used - len);
-		}
-	// TODO: len > DISNEY
-	} else { // not enough data
-		if (stereo) {
-			uint8_t gapfiller0 = 128;
-			uint8_t gapfiller1 = 128;
-			if (real_used) {
-				gapfiller0 = da[0].buffer[real_used - 1];
-				gapfiller1 = da[1].buffer[real_used - 1];
-			};
-
-			memset(da[0].buffer + real_used, gapfiller0, len - real_used);
-			memset(da[1].buffer + real_used, gapfiller1, len - real_used);
-
-			PlayStereo(len, da[0].buffer, da[1].buffer);
-			len -= real_used;
-
-		} else {                         // mono
-			uint8_t gapfiller = 128; // Keep the middle
-			if (real_used) {
-				// fix for some stupid game; it outputs 0 at the end of the stream
-				// causing a click. So if we have at least two bytes availible in the
-				// buffer and the last one is a 0 then ignore that.
-				if (leader->buffer[real_used - 1] == 0)
-					real_used--;
-			}
-			// do it this way because AddSilence sounds like a gnawing mouse
-			if (real_used)
-				gapfiller = leader->buffer[real_used - 1];
-			//LOG_MSG("gapfiller %x, fill len %d, realused %d",gapfiller,len-real_used,real_used);
-			memset(leader->buffer + real_used, gapfiller, len - real_used);
-			channel->AddSamples_m8(len, leader->buffer);
-		}
-		da[0].used = 0;
-		da[1].used = 0;
-
-		//LOG_MSG("disney underflow %d",len - real_used);
-	}
-}
-
-Disney::~Disney()
-{
-	DEBUG_LOG_MSG("DISNEY: Shutting down");
-
-	// Stop and remove the mixer callback
-	if (channel) {
-		channel->Enable(false);
-		channel.reset();
-	}
-
-	// Stop the game from accessing the IO ports
-	read_handler.Uninstall();
-	write_handler.Uninstall();
-}
-
-Disney::Disney(const std::string &filter_pref)
-{
 	using namespace std::placeholders;
 	const auto audio_callback = std::bind(&Disney::AudioCallback, this, _1);
 
 	// Setup the mixer callback
-	disney.chan = MIXER_AddChannel(DISNEY_CallBack,
-	                               0,
-	                               "DISNEY",
-	                               {ChannelFeature::Sleep,
-	                                ChannelFeature::ReverbSend,
-	                                ChannelFeature::ChorusSend,
-	                                ChannelFeature::DigitalAudio});
-
-	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
-	// DACs
+	channel = MIXER_AddChannel(audio_callback,
+	                           0,
+	                           "DISNEY",
+	                           {ChannelFeature::Sleep,
+	                            ChannelFeature::ReverbSend,
+	                            ChannelFeature::ChorusSend,
+	                            ChannelFeature::DigitalAudio});
 	assert(channel);
-	const auto rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
 
-	channel->ConfigureZeroOrderHoldUpsampler(rate_hz);
+	// Run the ZoH up-sampler at the higher mixer rate
+	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
+	channel->ConfigureZeroOrderHoldUpsampler(mixer_rate_hz);
 	channel->EnableZeroOrderHoldUpsampler();
 
+	// Pull audio frames from the Disney at the DAC's 7 kHz rate
+	channel->SetSampleRate(dss_7khz_rate);
+
 	if (filter_pref == "on") {
-		filter_enabled = true;
-		UpdateFilterFreq(rate_hz);
+		// Disney only supports a single fixed 7kHz sample rate. We'll
+		// apply a gentle 6dB/oct LPF at a bit below half the sample
+		// rate to tame the harshest aliased frequencies while still
+		// retaining a good dose of the "raw crunchy DAC sound".
+		constexpr auto lowpass_order = 1;
+		constexpr auto lowpass_freq  = static_cast<uint16_t>(
+                        dss_7khz_rate * 0.45);
+		channel->ConfigureLowPassFilter(lowpass_order, lowpass_freq);
 		channel->SetLowPassFilter(FilterState::On);
 	} else {
 		if (filter_pref != "off")
 			LOG_WARNING("DISNEY: Invalid filter setting '%s', using off",
-			            filter_pref.c_str());
-
-		filter_enabled = false;
+			            filter_pref.data());
 		channel->SetLowPassFilter(FilterState::Off);
 	}
 
 	// Register port handlers for 8-bit IO
-	const auto read_from_port = std::bind(&Disney::ReadFromPort, this, _1, _2);
-	const auto write_to_port = std::bind(&Disney::WriteToPort, this, _1, _2, _3);
+	const auto write_data = std::bind(&Disney::WriteData, this, _1, _2, _3);
+	data_write_handler.Install(base_port, write_data, io_width_t::byte);
 
-	write_handler.Install(base_port, write_to_port, io_width_t::byte, 3);
-	read_handler.Install(base_port, read_from_port, io_width_t::byte, 3);
+	const auto status_port = static_cast<io_port_t>(base_port + 1u);
+	const auto read_status = std::bind(&Disney::ReadStatus, this, _1, _2);
+	status_read_handler.Install(status_port, read_status, io_width_t::byte, 2);
 
-	// Initialize the Disney states
-	control = 0;
+	const auto control_port = static_cast<io_port_t>(base_port + 2u);
+	const auto write_control = std::bind(&Disney::WriteControl, this, _1, _2, _3);
+	control_write_handler.Install(control_port, write_control, io_width_t::byte);
+
+	// Update our status to indicate we're ready
+	status_reg.error = false;
+	status_reg.busy  = false;
+
+	LOG_MSG("DISNEY: Disney Sound Source available on LPT1 port %03xh", base_port);
 }
 
-// The Tandy DAC and PSG (programmable sound generator) managed pointers
-std::unique_ptr<Disney> disney = {};
+Disney::~Disney()
+{
+	LOG_MSG("DISNEY: Shutting down");
+
+	// Update our status to indicate we're no longer ready
+	status_reg.error = true;
+	status_reg.busy  = true;
+
+	// Stop the game from accessing the IO ports
+	status_read_handler.Uninstall();
+	data_write_handler.Uninstall();
+	control_write_handler.Uninstall();
+
+	channel->Enable(false);
+
+	fifo         = {};
+	render_queue = {};
+}
 
 void DISNEY_ShutDown([[maybe_unused]] Section *sec)
 {
@@ -487,13 +250,12 @@ void DISNEY_Init(Section *sec)
 	assert(section);
 
 	if (!section->Get_bool("disney")) {
-		DISNEY_ShutDown(sec);
+		DISNEY_ShutDown(nullptr);
 		return;
 	}
-
-	std::string filter_pref = section->Get_string("filter");
-
-	disney = std::make_unique<Disney>(filter_pref);
+	// Some games expect the DSS on port 378h and don't check 278h first.
+	disney = std::make_unique<Disney>(Lpt1Port,
+	                                  section->Get_string("disney_filter"));
 
 	sec->AddDestroyFunction(&DISNEY_ShutDown, true);
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -794,7 +794,7 @@ constexpr int16_t u8to16(const int u_val)
 }
 
 // 8-bit to 16-bit lookup tables
-static int16_t lut_u8to16[UINT8_MAX + 1] = {};
+int16_t lut_u8to16[UINT8_MAX + 1] = {};
 constexpr int16_t *lut_s8to16 = lut_u8to16 + 128;
 
 constexpr void fill_8to16_lut()


### PR DESCRIPTION
 - Moves it into a class structure
 - Removes non-Disney-related DAC handling, which was tricky to follow
 - Uses the same frame-rendering approach as other cards
 - Uses the floating-point AudioFrame interface to the mixer

When all audio devices support the same AudioFrame rendering approach, we can migrate that logic into the mixer.
