### PR TITLE
Add shortcut to reload the current shader

### DIFF
--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -823,6 +823,28 @@ void RENDER_InitShaderSource([[maybe_unused]] Section *sec)
 #endif
 }
 
+void RENDER_Init(Section *sec);
+
+static void ReloadShader(bool)
+{
+	// Quick and dirty hack to reload the current shader. Very useful when
+	// tweaking shader presets. Ultimately, this code will go away once the new
+	// shading system has been introduced, so massaging the current code to
+	// make this "nicer" would be largely a wasted effort...
+	auto render_section = control->GetSection("render");
+	assert(render_section);
+
+	auto sec = static_cast<const Section_prop *>(render_section);
+	auto glshader_prop = sec->Get_path("glshader");
+	auto shader_path = std::string(glshader_prop->GetValue());
+
+	glshader_prop->SetValue("none");
+	RENDER_Init(render_section);
+
+	glshader_prop->SetValue(shader_path);
+	RENDER_Init(render_section);
+}
+
 void RENDER_Init(Section *sec)
 {
 	Section_prop * section=static_cast<Section_prop *>(sec);
@@ -904,5 +926,9 @@ void RENDER_Init(Section *sec)
 	                  "decfskip", "Dec Fskip");
 	MAPPER_AddHandler(IncreaseFrameSkip, SDL_SCANCODE_UNKNOWN, 0,
 	                  "incfskip", "Inc Fskip");
+
+	MAPPER_AddHandler(ReloadShader, SDL_SCANCODE_F2, PRIMARY_MOD,
+	                  "reloadshader", "Reload Shader");
+
 	GFX_SetTitle(-1,render.frameskip.max,false);
 }


### PR DESCRIPTION
This is a handy feature when tweaking shader settings, which currently involves making changes to the shader source file as we don't have any sort of preset system.

I tried to do it more cleanly, but gave up after an hour in frustration. The whole rendering pipeline is an unholy mess, you could spend a lot of time untangling it and trying to figure out what is a hack, what is needed, what is a bug, what is just superfluous stuff, etc. but ultimately it would be a massive wasted effort. It's unsalvageable and badly needs a rewrite, which would actually take a lot less time than trying to massage it into a less sucky shape.

So, my plan is to burn it to the ground in the near(ish) future and implement something much nicer. In the interim, this is a practical hack that serves a very useful purpose.