### PR TITLE
Add the Covox and Stereo-On-1 LPT DAC devices

### DIFF
--- a/include/lpt.h
+++ b/include/lpt.h
@@ -71,7 +71,8 @@ union LptControlRegister {
 	bit_view<3, 1> select;
 	bit_view<4, 1> irq_ack;
 	bit_view<5, 1> bidi;
-	// bits 6 and 7 are unused
+	bit_view<6, 1> bit6; // unused
+	bit_view<7, 1> bit7; // unused
 };
 // The INITIALISE signal is active low when writing to the IO port.
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -131,6 +131,7 @@ enum class ChannelFeature {
 	Stereo,
 	Synthesizer,
 };
+using channel_features_t = std::set<ChannelFeature>;
 
 enum class FilterState { Off, On, ForcedOn };
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -87,6 +87,10 @@ extern int16_t lut_u8to16[UINT8_MAX + 1];
 
 static constexpr auto max_filter_order = 16;
 
+static constexpr auto millis_in_second = 1000.0;
+
+static constexpr uint8_t use_mixer_rate = 0;
+
 // Get a DOS-formatted silent-sample when there's a chance it will
 // be processed using AddSamples_nonnative()
 template <typename T>

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -493,7 +493,7 @@ CDROM_Interface_Image::CDROM_Interface_Image(uint8_t sub_unit)
 			                                      this, std::placeholders::_1);
 
 			player.channel = MIXER_AddChannel(mixer_callback,
-			                                  0,
+			                                  use_mixer_rate,
 			                                  "CDAUDIO",
 			                                  {ChannelFeature::Stereo,
 			                                   ChannelFeature::DigitalAudio});

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -918,12 +918,13 @@ const char *filter_on_or_off[] = {"on", "off", 0};
 
 	// LPT DAC device emulation
 	secprop->AddInitFunction(&LPT_DAC_Init, true);
-	const char *lpt_dac_types[] = {"none", "disney", "covox", "off", 0};
+	const char *lpt_dac_types[] = {"none", "disney", "covox", "ston1", "off", 0};
 	pstring = secprop->Add_string("lpt_dac", when_idle, lpt_dac_types[0]);
 	pstring->Set_help("Type of DAC plugged into the parallel port:\n"
-	                  "  disney:     Disney Sound Source.\n"
-	                  "  covox:      Covox Speech Thing.\n"
-	                  "  none/off:   Don't use a parallel port DAC (default).\n");
+	                  "  disney:    Disney Sound Source.\n"
+	                  "  covox:     Covox Speech Thing.\n"
+	                  "  ston1:     Stereo-on-1 DAC, in stereo up to 30 kHz.\n"
+	                  "  none/off:  Don't use a parallel port DAC (default).\n");
 	pstring->Set_values(lpt_dac_types);
 
 	pstring = secprop->Add_string("lpt_dac_filter", when_idle, "on");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -97,7 +97,7 @@ void SBLASTER_Init(Section*);
 void MPU401_Init(Section*);
 void PCSPEAKER_Init(Section*);
 void TANDYSOUND_Init(Section*);
-void DISNEY_Init(Section*);
+void LPT_DAC_Init(Section *);
 void PS1AUDIO_Init(Section *);
 void INNOVA_Init(Section*);
 void SERIAL_Init(Section*);
@@ -917,15 +917,22 @@ const char *filter_on_or_off[] = {"on", "off", 0};
 	                  "  off:  Don't filter the output.");
 
 	// Disney Audio emulation
-	secprop->AddInitFunction(&DISNEY_Init,true);//done
+	secprop->AddInitFunction(&LPT_DAC_Init, true);
+	const char *lpt_dac_types[] = {"none", "disney", "off", 0};
+	pstring = secprop->Add_string("lpt_dac", when_idle, lpt_dac_types[0]);
+	pstring->Set_help("Type of DAC plugged into the parallel port:\n"
+	                  "  disney:     Disney Sound Source.\n"
+	                  "  none/off:   Don't use a parallel port DAC (default).\n");
+	pstring->Set_values(lpt_dac_types);
 
-	Pbool = secprop->Add_bool("disney", when_idle, true);
-	Pbool->Set_help("Enable Disney Sound Source emulation. (Covox Voice Master and Speech Thing compatible).");
-
-	Pstring = secprop->Add_string("disney_filter", when_idle, "on");
-	Pstring->Set_help("Filter for the Disney audio output:\n"
+	pstring = secprop->Add_string("lpt_dac_filter", when_idle, "on");
+	pstring->Set_help("Filter for the LPT DAC audio device(s):\n"
 	                  "  on:   Filter the output (default).\n"
 	                  "  off:  Don't filter the output.");
+
+	// Deprecate the overloaded Disney setting
+	Pbool = secprop->Add_bool("disney", deprecated, false);
+	Pbool->Set_help("Use 'lpt_dac=disney' to enable the Disney Sound Source.");
 
 	// IBM PS/1 Audio emulation
 	secprop->AddInitFunction(&PS1AUDIO_Init, true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -916,12 +916,13 @@ const char *filter_on_or_off[] = {"on", "off", 0};
 	                  "  on:   Filter the output (default).\n"
 	                  "  off:  Don't filter the output.");
 
-	// Disney Audio emulation
+	// LPT DAC device emulation
 	secprop->AddInitFunction(&LPT_DAC_Init, true);
-	const char *lpt_dac_types[] = {"none", "disney", "off", 0};
+	const char *lpt_dac_types[] = {"none", "disney", "covox", "off", 0};
 	pstring = secprop->Add_string("lpt_dac", when_idle, lpt_dac_types[0]);
 	pstring->Set_help("Type of DAC plugged into the parallel port:\n"
 	                  "  disney:     Disney Sound Source.\n"
+	                  "  covox:      Covox Speech Thing.\n"
 	                  "  none/off:   Don't use a parallel port DAC (default).\n");
 	pstring->Set_values(lpt_dac_types);
 

--- a/src/hardware/covox.cpp
+++ b/src/hardware/covox.cpp
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "covox.h"
+
+#include <cassert>
+
+#include "checks.h"
+
+CHECK_NARROWING();
+
+void Covox::BindToPort(const io_port_t lpt_port)
+{
+	using namespace std::placeholders;
+	const auto write_data  = std::bind(&Covox::WriteData, this, _1, _2, _3);
+	const auto read_status = std::bind(&Covox::ReadStatus, this, _1, _2);
+	const auto write_control = std::bind(&Covox::WriteControl, this, _1, _2, _3);
+	BindHandlers(lpt_port, write_data, read_status, write_control);
+	LOG_MSG("LPT_DAC: Initialized Covox Speech Thing on LPT port %03xh", lpt_port);
+}
+
+void Covox::ConfigureFilters(const FilterState state)
+{
+	assert(channel);
+	if (state == FilterState::On) {
+		constexpr uint8_t lp_order = 2;
+		const uint16_t lp_cutoff_freq = 9000;
+		channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
+	}
+	channel->SetLowPassFilter(state);
+}
+
+AudioFrame Covox::Render()
+{
+	const float sample = lut_u8to16[data_reg];
+	return {sample, sample};
+}
+
+void Covox::WriteData(const io_port_t, const io_val_t data, const io_width_t)
+{
+	RenderUpToNow();
+	data_reg = check_cast<uint8_t>(data);
+}
+
+uint8_t Covox::ReadStatus(const io_port_t, const io_width_t)
+{
+	return status_reg.data;
+}

--- a/src/hardware/covox.h
+++ b/src/hardware/covox.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_Covox_H
+#define DOSBOX_Covox_H
+
+#include "dosbox.h"
+
+#include "inout.h"
+#include "lpt_dac.h"
+#include "mixer.h"
+
+class Covox final : public LptDac {
+public:
+	Covox() : LptDac("COVOX", use_mixer_rate) {}
+	void BindToPort(const io_port_t lpt_port) final;
+	void ConfigureFilters(const FilterState state) final;
+
+protected:
+	AudioFrame Render() final;
+
+private:
+	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
+	uint8_t ReadStatus(const io_port_t, const io_width_t);
+	void WriteControl(const io_port_t, const io_val_t, const io_width_t) {}
+};
+
+#endif

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -17,63 +17,60 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include "dosbox.h"
+#include "disney.h"
 
 #include <cassert>
-#include <queue>
 
-#include "bit_view.h"
 #include "checks.h"
-#include "inout.h"
-#include "mixer.h"
-#include "parallel_port.h"
-#include "pic.h"
-#include "setup.h"
 
 CHECK_NARROWING();
 
-class Disney {
-public:
-	Disney(const io_port_t base_port, const std::string_view filter_pref);
-	~Disney();
-
-private:
-	Disney()                          = delete;
-	Disney(const Disney &)            = delete;
-	Disney &operator=(const Disney &) = delete;
-
-	AudioFrame Render();
-	void RenderUpToNow();
-	void AudioCallback(const uint16_t requested_frames);
-
-	bool IsFifoFull() const;
-	uint8_t ReadStatus(const io_port_t, const io_width_t);
-	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
-	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
-
-	// The DSS is an LPT DAC with a 16-level FIFO running at 7kHz
-	static constexpr auto dss_7khz_rate    = 7000;
-	static constexpr auto ms_per_frame     = 1000.0 / dss_7khz_rate;
-	static constexpr uint8_t max_fifo_size = 16;
-
-	// Managed objects
-	mixer_channel_t channel                    = {};
-	std::queue<uint8_t> fifo                   = {};
-	std::queue<AudioFrame> render_queue        = {};
-	IO_WriteHandleObject data_write_handler    = {};
-	IO_ReadHandleObject status_read_handler    = {};
-	IO_WriteHandleObject control_write_handler = {};
-
-	// Runtime state
-	double last_rendered_ms        = 0.0;
-	uint8_t data_reg               = Mixer_GetSilentDOSSample<uint8_t>();
-	LptStatusRegister status_reg   = {};
-	LptControlRegister control_reg = {};
-};
-
-bool Disney::IsFifoFull() const
+Disney::Disney() : LptDac("DISNEY", use_mixer_rate)
 {
-	return fifo.size() >= max_fifo_size;
+	// Prime the FIFO with a single silent sample
+	fifo.emplace(data_reg);
+}
+
+void Disney::BindToPort(const io_port_t lpt_port)
+{
+	using namespace std::placeholders;
+
+	// Register port handlers for 8-bit IO
+	const auto write_data = std::bind(&Disney::WriteData, this, _1, _2, _3);
+	const auto read_status = std::bind(&Disney::ReadStatus, this, _1, _2);
+	const auto write_control = std::bind(&Disney::WriteControl, this, _1, _2, _3);
+	BindHandlers(lpt_port, write_data, read_status, write_control);
+	LOG_MSG("LPT_DAC: Initialized Disney Sound Source on LPT port %03xh", lpt_port);
+}
+
+void Disney::ConfigureFilters(const FilterState state)
+{
+	assert(channel);
+	// Run the ZoH up-sampler at the higher mixer rate
+	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
+	channel->ConfigureZeroOrderHoldUpsampler(mixer_rate_hz);
+	channel->EnableZeroOrderHoldUpsampler();
+
+	// Pull audio frames from the Disney DAC at 7 kHz
+	channel->SetSampleRate(dss_7khz_rate);
+	ms_per_frame = millis_in_second / dss_7khz_rate;
+
+	if (state == FilterState::On) {
+		// The filters are meant to emulate the Disney's bandwidth
+		// limitations both by ear and spectrum analysis when compared
+		// against LGR Oddware's recordings of an authentic Disney Sound
+		// Source in ref: https://youtu.be/A1YThKmV2dk?t=1126
+
+		constexpr auto hp_order       = 2;
+		constexpr auto hp_cutoff_freq = 100;
+		channel->ConfigureHighPassFilter(hp_order, hp_cutoff_freq);
+
+		constexpr auto lp_order       = 2;
+		constexpr auto lp_cutoff_freq = 2000;
+		channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
+	}
+	channel->SetHighPassFilter(state);
+	channel->SetLowPassFilter(state);
 }
 
 // Eight bit data sent to the D/A convener is loaded into a 16 level FIFO. Data
@@ -87,26 +84,21 @@ AudioFrame Disney::Render()
 	return {sample, sample};
 }
 
-void Disney::RenderUpToNow()
+bool Disney::IsFifoFull() const
 {
-	const auto now = PIC_FullIndex();
-
-	// Wake up the channel and update the last rendered time datum.
-	assert(channel);
-	if (channel->WakeUp()) {
-		last_rendered_ms = now;
-		return;
-	}
-	// Keep rendering until we're current
-	while (last_rendered_ms < now) {
-		last_rendered_ms += ms_per_frame;
-		render_queue.emplace(Render());
-	}
+	return fifo.size() >= max_fifo_size;
 }
 
 void Disney::WriteData(const io_port_t, const io_val_t data, const io_width_t)
 {
 	data_reg = check_cast<uint8_t>(data);
+}
+
+uint8_t Disney::ReadStatus(const io_port_t, const io_width_t)
+{
+	// The Disney ACK's (active-low) when the FIFO has room
+	status_reg.ack = IsFifoFull();
+	return status_reg.data;
 }
 
 void Disney::WriteControl(const io_port_t, const io_val_t value, const io_width_t)
@@ -128,147 +120,7 @@ void Disney::WriteControl(const io_port_t, const io_val_t value, const io_width_
 	control_reg.data = new_control.data;
 }
 
-uint8_t Disney::ReadStatus(const io_port_t, const io_width_t)
-{
-	// The Disney ACK's (active-low) when the FIFO has room
-	status_reg.ack = IsFifoFull();
-	return status_reg.data;
-}
-
-void Disney::AudioCallback(const uint16_t requested_frames)
-{
-	assert(channel);
-
-	auto frames_remaining = requested_frames;
-
-	// First, add any frames we've queued since the last callback
-	while (frames_remaining && render_queue.size()) {
-		channel->AddSamples_sfloat(1, &render_queue.front()[0]);
-		render_queue.pop();
-		--frames_remaining;
-	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
-	while (frames_remaining) {
-		const auto frame = Render();
-		channel->AddSamples_sfloat(1, &frame[0]);
-		--frames_remaining;
-	}
-	last_rendered_ms = PIC_FullIndex();
-}
-
-std::unique_ptr<Disney> disney = {};
-
-static void setup_filters(mixer_channel_t &channel)
-{
-	// The filters are meant to emulate the Disney's bandwidth limitations
-	// both by ear and spectrum analysis when compared against LGR Oddware's
-	// recordings of an authentic Disney Sound Source in ref:
-	// https://youtu.be/A1YThKmV2dk?t=1126
-
-	constexpr auto hp_order       = 2;
-	constexpr auto hp_cutoff_freq = 100;
-	channel->ConfigureHighPassFilter(hp_order, hp_cutoff_freq);
-	channel->SetHighPassFilter(FilterState::On);
-
-	constexpr auto lp_order       = 2;
-	constexpr auto lp_cutoff_freq = 2000;
-	channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
-	channel->SetLowPassFilter(FilterState::On);
-}
-
-Disney::Disney(const io_port_t base_port, const std::string_view filter_choice)
-{
-	// Prime the FIFO with a single silent sample
-	fifo.emplace(data_reg);
-
-	using namespace std::placeholders;
-	const auto audio_callback = std::bind(&Disney::AudioCallback, this, _1);
-
-	// Setup the mixer callback
-	channel = MIXER_AddChannel(audio_callback,
-	                           0,
-	                           "DISNEY",
-	                           {ChannelFeature::Sleep,
-	                            ChannelFeature::ReverbSend,
-	                            ChannelFeature::ChorusSend,
-	                            ChannelFeature::DigitalAudio});
-	assert(channel);
-
-	// Run the ZoH up-sampler at the higher mixer rate
-	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
-	channel->ConfigureZeroOrderHoldUpsampler(mixer_rate_hz);
-	channel->EnableZeroOrderHoldUpsampler();
-
-	// Pull audio frames from the Disney at the DAC's 7 kHz rate
-	channel->SetSampleRate(dss_7khz_rate);
-
-	// Setup filters
-	if (filter_choice == "on") {
-		setup_filters(channel);
-	} else {
-		if (filter_choice != "off")
-			LOG_WARNING("DISNEY: Invalid filter setting '%s', using off",
-			            filter_choice.data());
-
-		channel->SetHighPassFilter(FilterState::Off);
-		channel->SetLowPassFilter(FilterState::Off);
-	}
-
-	// Register port handlers for 8-bit IO
-	const auto write_data = std::bind(&Disney::WriteData, this, _1, _2, _3);
-	data_write_handler.Install(base_port, write_data, io_width_t::byte);
-
-	const auto status_port = static_cast<io_port_t>(base_port + 1u);
-	const auto read_status = std::bind(&Disney::ReadStatus, this, _1, _2);
-	status_read_handler.Install(status_port, read_status, io_width_t::byte, 2);
-
-	const auto control_port = static_cast<io_port_t>(base_port + 2u);
-	const auto write_control = std::bind(&Disney::WriteControl, this, _1, _2, _3);
-	control_write_handler.Install(control_port, write_control, io_width_t::byte);
-
-	// Update our status to indicate we're ready
-	status_reg.error = false;
-	status_reg.busy  = false;
-
-	LOG_MSG("DISNEY: Disney Sound Source available on LPT1 port %03xh", base_port);
-}
-
 Disney::~Disney()
 {
-	LOG_MSG("DISNEY: Shutting down");
-
-	// Update our status to indicate we're no longer ready
-	status_reg.error = true;
-	status_reg.busy  = true;
-
-	// Stop the game from accessing the IO ports
-	status_read_handler.Uninstall();
-	data_write_handler.Uninstall();
-	control_write_handler.Uninstall();
-
-	channel->Enable(false);
-
-	fifo         = {};
-	render_queue = {};
-}
-
-void DISNEY_ShutDown([[maybe_unused]] Section *sec)
-{
-	disney.reset();
-}
-
-void DISNEY_Init(Section *sec)
-{
-	Section_prop *section = static_cast<Section_prop *>(sec);
-	assert(section);
-
-	if (!section->Get_bool("disney")) {
-		DISNEY_ShutDown(nullptr);
-		return;
-	}
-	// Some games expect the DSS on port 378h and don't check 278h first.
-	disney = std::make_unique<Disney>(Lpt1Port,
-	                                  section->Get_string("disney_filter"));
-
-	sec->AddDestroyFunction(&DISNEY_ShutDown, true);
+	fifo = {};
 }

--- a/src/hardware/disney.h
+++ b/src/hardware/disney.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_DISNEY_H
+#define DOSBOX_DISNEY_H
+
+#include "dosbox.h"
+
+#include <queue>
+
+#include "inout.h"
+#include "lpt_dac.h"
+#include "mixer.h"
+
+class Disney final : public LptDac {
+public:
+	Disney();
+	~Disney() final;
+
+	void BindToPort(const io_port_t lpt_port) final;
+	void ConfigureFilters(const FilterState state) final;
+
+protected:
+	AudioFrame Render() final;
+
+private:
+	bool IsFifoFull() const;
+	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
+	uint8_t ReadStatus(const io_port_t, const io_width_t);
+	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
+
+	// The DSS is an LPT DAC with a 16-level FIFO running at 7kHz
+	static constexpr auto dss_7khz_rate = 7000;
+	static constexpr uint8_t max_fifo_size = 16;
+
+	// Managed objects
+	std::queue<uint8_t> fifo = {};
+};
+
+#endif

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -80,7 +80,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	const auto audio_callback = std::bind(&GameBlaster::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(audio_callback,
-	                           0,
+	                           use_mixer_rate,
 	                           CardName(),
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::Stereo,

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -83,7 +83,7 @@ private:
 	static constexpr auto render_divisor = 32;
 	static constexpr auto render_rate_hz = ceil_sdivide(chip_clock,
 	                                                    render_divisor);
-	static constexpr auto ms_per_render  = 1000.0 / render_rate_hz;
+	static constexpr auto ms_per_render  = millis_in_second / render_rate_hz;
 
 	// Runtime states
 	double last_rendered_ms        = 0;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -52,7 +52,7 @@ constexpr uint32_t RAM_SIZE = 1024 * 1024; // 1 MiB
 constexpr uint32_t BYTES_PER_DMA_XFER = 8 * 1024;         // 8 KiB per transfer
 constexpr uint32_t ISA_BUS_THROUGHPUT = 32 * 1024 * 1024; // 32 MiB/s
 constexpr uint16_t DMA_TRANSFERS_PER_S = ISA_BUS_THROUGHPUT / BYTES_PER_DMA_XFER;
-constexpr double MS_PER_DMA_XFER = 1000.0 / DMA_TRANSFERS_PER_S;
+constexpr double MS_PER_DMA_XFER = millis_in_second / DMA_TRANSFERS_PER_S;
 
 // Voice-channel and state related constants
 constexpr uint8_t MAX_VOICES = 32u;
@@ -596,7 +596,7 @@ Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
 	                                      std::placeholders::_1);
 
 	audio_channel = MIXER_AddChannel(mixer_callback,
-	                                 0,
+	                                 use_mixer_rate,
 	                                 "GUS",
 	                                 {ChannelFeature::Sleep,
 	                                  ChannelFeature::Stereo,
@@ -605,7 +605,7 @@ Gus::Gus(uint16_t port, uint8_t dma, uint8_t irq, const std::string &ultradir)
 	                                  ChannelFeature::DigitalAudio});
 
 	assert(audio_channel);
-	ms_per_render = 1000.0 / audio_channel->GetSampleRate();
+	ms_per_render = millis_in_second / audio_channel->GetSampleRate();
 
 	// Let the mixer command adjust the GUS's internal amplitude level's
 	const auto set_level_callback = std::bind(&Gus::SetLevelCallback, this, _1);
@@ -632,7 +632,7 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		// v2.22 (21 December 1994), pp. 3 of 113.
 		frame_rate_hz = static_cast<int>(1000000.0 /
 		                                 (1.619695497 * active_voices));
-		ms_per_render = 1000.0 / frame_rate_hz;
+		ms_per_render = millis_in_second / frame_rate_hz;
 
 		audio_channel->SetSampleRate(frame_rate_hz);
 	}

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -73,14 +73,14 @@ void Innovation::Open(const std::string &model_choice,
 	else if (clock_choice == "hardsid")
 		chip_clock = 1000000.0;
 	assert(chip_clock);
-	ms_per_clock = 1000.0 / chip_clock;
+	ms_per_clock = millis_in_second / chip_clock;
 
 	// Setup the mixer and get it's sampling rate
 	using namespace std::placeholders;
 	const auto mixer_callback = std::bind(&Innovation::AudioCallback, this, _1);
 
 	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                            0,
+	                                            use_mixer_rate,
 	                                            "INNOVATION",
 	                                            {ChannelFeature::Sleep,
 	                                             ChannelFeature::ReverbSend,

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -29,6 +29,7 @@
 
 #include "covox.h"
 #include "disney.h"
+#include "ston1_dac.h"
 
 LptDac::LptDac(const std::string &name, const uint16_t channel_rate_hz,
                channel_features_t extra_features)
@@ -147,6 +148,8 @@ void LPT_DAC_Init(Section *section)
 		lpt_dac = std::make_unique<Disney>();
 	else if (dac_choice == "covox")
 		lpt_dac = std::make_unique<Covox>();
+	else if (dac_choice == "ston1")
+		lpt_dac = std::make_unique<StereoOn1>();
 	else if (dac_choice == "none" || dac_choice == "off")
 		return;
 

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -1,0 +1,161 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+// NOTE: a lot of this code assumes that the callback is called every emulated
+// millisecond
+
+#include "dosbox.h"
+
+#include "pic.h"
+#include "setup.h"
+#include "support.h"
+
+#include "disney.h"
+
+LptDac::LptDac(const std::string &name, const uint16_t channel_rate_hz,
+               channel_features_t extra_features)
+        : dac_name(name)
+{
+	using namespace std::placeholders;
+	const auto audio_callback = std::bind(&LptDac::AudioCallback, this, _1);
+
+	auto features = channel_features_t{ChannelFeature::Sleep,
+	                                   ChannelFeature::ReverbSend,
+	                                   ChannelFeature::ChorusSend,
+	                                   ChannelFeature::DigitalAudio};
+
+	features.merge(extra_features);
+
+	// Setup the mixer callback
+	channel = MIXER_AddChannel(audio_callback,
+	                           channel_rate_hz,
+	                           dac_name.c_str(),
+	                           features);
+
+	ms_per_frame = millis_in_second / channel->GetSampleRate();
+
+	// Update our status to indicate we're ready
+	status_reg.error = false;
+	status_reg.busy  = false;
+}
+
+void LptDac::BindHandlers(const io_port_t lpt_port, const io_write_f write_data,
+                          const io_read_f read_status, const io_write_f write_control)
+{
+	// Register port handlers for 8-bit IO
+	data_write_handler.Install(lpt_port, write_data, io_width_t::byte);
+
+	const auto status_port = static_cast<io_port_t>(lpt_port + 1u);
+	status_read_handler.Install(status_port, read_status, io_width_t::byte);
+
+	const auto control_port = static_cast<io_port_t>(lpt_port + 2u);
+	control_write_handler.Install(control_port, write_control, io_width_t::byte);
+}
+
+void LptDac::RenderUpToNow()
+{
+	const auto now = PIC_FullIndex();
+
+	// Wake up the channel and update the last rendered time datum.
+	assert(channel);
+	if (channel->WakeUp()) {
+		last_rendered_ms = now;
+		return;
+	}
+	// Keep rendering until we're current
+	assert(ms_per_frame > 0.0);
+	while (last_rendered_ms < now) {
+		last_rendered_ms += ms_per_frame;
+		render_queue.emplace(Render());
+	}
+}
+
+void LptDac::AudioCallback(const uint16_t requested_frames)
+{
+	assert(channel);
+
+	auto frames_remaining = requested_frames;
+
+	// First, add any frames we've queued since the last callback
+	while (frames_remaining && render_queue.size()) {
+		channel->AddSamples_sfloat(1, &render_queue.front()[0]);
+		render_queue.pop();
+		--frames_remaining;
+	}
+	// If the queue's run dry, render the remainder and sync-up our time datum
+	while (frames_remaining) {
+		const auto frame = Render();
+		channel->AddSamples_sfloat(1, &frame[0]);
+		--frames_remaining;
+	}
+	last_rendered_ms = PIC_FullIndex();
+}
+
+LptDac::~LptDac()
+{
+	// Update our status to indicate we're no longer ready
+	status_reg.error = true;
+	status_reg.busy  = true;
+
+	// Stop the game from accessing the IO ports
+	status_read_handler.Uninstall();
+	data_write_handler.Uninstall();
+	control_write_handler.Uninstall();
+
+	channel->Enable(false);
+
+	render_queue = {};
+}
+
+std::unique_ptr<LptDac> lpt_dac = {};
+
+void LPT_DAC_ShutDown([[maybe_unused]] Section *sec)
+{
+	lpt_dac.reset();
+}
+
+void LPT_DAC_Init(Section *section)
+{
+	// Always reset on changes
+	LPT_DAC_ShutDown(nullptr);
+
+	// Get the user's LPT DAC choices
+	assert(section);
+	const auto prop = static_cast<Section_prop *>(section);
+	const std::string_view dac_choice    = prop->Get_string("lpt_dac");
+	const std::string_view filter_choice = prop->Get_string("lpt_dac_filter");
+
+	if (dac_choice == "disney")
+		lpt_dac = std::make_unique<Disney>();
+	else if (dac_choice == "none" || dac_choice == "off")
+		return;
+
+	const auto filter_state = filter_choice == "on" ? FilterState::On
+	                                                : FilterState::Off;
+	if (filter_state == FilterState::Off && filter_choice != "off")
+		LOG_WARNING("LPT_DAC: Invalid lpt_dac_filter setting: '%s', using off",
+		            filter_choice.data());
+
+	assert(lpt_dac);
+	lpt_dac->ConfigureFilters(filter_state);
+	lpt_dac->BindToPort(Lpt1Port);
+
+	section->AddDestroyFunction(&LPT_DAC_ShutDown, true);
+}

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -27,6 +27,7 @@
 #include "setup.h"
 #include "support.h"
 
+#include "covox.h"
 #include "disney.h"
 
 LptDac::LptDac(const std::string &name, const uint16_t channel_rate_hz,
@@ -144,6 +145,8 @@ void LPT_DAC_Init(Section *section)
 
 	if (dac_choice == "disney")
 		lpt_dac = std::make_unique<Disney>();
+	else if (dac_choice == "covox")
+		lpt_dac = std::make_unique<Covox>();
 	else if (dac_choice == "none" || dac_choice == "off")
 		return;
 

--- a/src/hardware/lpt_dac.h
+++ b/src/hardware/lpt_dac.h
@@ -1,0 +1,74 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_LPT_DAC_H
+#define DOSBOX_LPT_DAC_H
+
+#include "dosbox.h"
+
+#include <queue>
+
+#include "inout.h"
+#include "lpt.h"
+#include "mixer.h"
+
+// Provides mandatory scafolding for derived LPT DAC devices
+class LptDac {
+public:
+	LptDac(const std::string &name, const uint16_t channel_rate_hz,
+	       channel_features_t extra_features = {});
+	virtual ~LptDac();
+
+	// public interfaces
+	virtual void ConfigureFilters(const FilterState state) = 0;
+	virtual void BindToPort(const io_port_t lpt_port)      = 0;
+
+protected:
+	LptDac()                          = delete;
+	LptDac(const LptDac &)            = delete;
+	LptDac &operator=(const LptDac &) = delete;
+
+	// Base LPT DAC functionality
+	virtual AudioFrame Render() = 0;
+	void RenderUpToNow();
+	void AudioCallback(const uint16_t requested_frames);
+	std::queue<AudioFrame> render_queue = {};
+	mixer_channel_t channel             = {};
+
+	double last_rendered_ms = 0.0;
+	double ms_per_frame     = 0.0;
+
+	std::string dac_name = {};
+
+	// All LPT devices support data write, status read, and control write
+	void BindHandlers(const io_port_t lpt_port, const io_write_f write_data,
+	                  const io_read_f read_status,
+	                  const io_write_f write_control);
+
+	IO_WriteHandleObject data_write_handler    = {};
+	IO_ReadHandleObject status_read_handler    = {};
+	IO_WriteHandleObject control_write_handler = {};
+
+	uint8_t data_reg               = Mixer_GetSilentDOSSample<uint8_t>();
+	LptStatusRegister status_reg   = {};
+	LptControlRegister control_reg = {};
+};
+
+#endif

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -1,6 +1,7 @@
 libhardware_sources = files([
   'adlib_gold.cpp',
   'cmos.cpp',
+  'covox.cpp',
   'disney.cpp',
   'dma.cpp',
   'envelope.cpp',

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -15,6 +15,7 @@ libhardware_sources = files([
   'ipxserver.cpp',
   'joystick.cpp',
   'keyboard.cpp',
+  'lpt_dac.cpp',
   'mame/saa1099.cpp',
   'mame/sn76496.cpp',
   'memory.cpp',

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -39,6 +39,7 @@ libhardware_sources = files([
   'serialport/serialmouse.cpp',
   'serialport/serialport.cpp',
   'serialport/softmodem.cpp',
+  'ston1_dac.cpp',
   'tandy_sound.cpp',
   'timer.cpp',
   'vga_attr.cpp',

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -473,7 +473,7 @@ void OPL::Init(const uint16_t sample_rate)
 	newm = 0;
 	OPL3_Reset(&oplchip, sample_rate);
 
-	ms_per_frame = 1000.0 / sample_rate;
+	ms_per_frame = millis_in_second / sample_rate;
 
 	memset(cache, 0, ARRAY_LEN(cache));
 
@@ -894,7 +894,7 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 	                                      std::placeholders::_1);
 
 	// Register the Audio channel
-	channel = MIXER_AddChannel(mixer_callback, 0, "OPL", channel_features);
+	channel = MIXER_AddChannel(mixer_callback, use_mixer_rate, "OPL", channel_features);
 
 	// Used to be 2.0, which was measured to be too high. Exact value
 	// depends on card/clone.

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -465,7 +465,7 @@ PcSpeakerDiscrete::PcSpeakerDiscrete()
 	                                std::placeholders::_1);
 
 	channel = MIXER_AddChannel(callback,
-	                           0,
+	                           use_mixer_rate,
 	                           device_name,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ChorusSend,

--- a/src/hardware/pcspeaker_impulse.cpp
+++ b/src/hardware/pcspeaker_impulse.cpp
@@ -424,7 +424,7 @@ void PcSpeakerImpulse::AddImpulse(float index, const int16_t amplitude)
 
 #else
 	// Mathematically intensive reference implementation
-	const auto portion_of_ms = static_cast < double(index) / 1000.0;
+	const auto portion_of_ms = static_cast <double>(index) / millis_in_second;
 	for (size_t i = 0; i < waveform_deque.size(); ++i) {
 		const auto impulse_time = static_cast<double>(i) / sample_rate - portion_of_ms;
 

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -124,7 +124,7 @@ Ps1Dac::Ps1Dac(const std::string &filter_choice)
 	const auto callback = std::bind(&Ps1Dac::Update, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           0,
+	                           use_mixer_rate,
 	                           "PS1DAC",
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,
@@ -393,7 +393,7 @@ private:
 	static constexpr auto render_divisor   = 16;
 	static constexpr auto render_rate_hz   = ceil_sdivide(ps1_psg_clock_hz,
                                                             render_divisor);
-	static constexpr auto ms_per_render    = 1000.0 / render_rate_hz;
+	static constexpr auto ms_per_render    = millis_in_second / render_rate_hz;
 
 	// Runtime states
 	device_sound_interface *dsi = static_cast<sn76496_base_device *>(&device);
@@ -406,7 +406,7 @@ Ps1Synth::Ps1Synth(const std::string &filter_choice)
 	const auto callback = std::bind(&Ps1Synth::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           0,
+	                           use_mixer_rate,
 	                           "PS1",
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,

--- a/src/hardware/ston1_dac.cpp
+++ b/src/hardware/ston1_dac.cpp
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "ston1_dac.h"
+
+#include <cassert>
+
+#include "checks.h"
+
+CHECK_NARROWING();
+void StereoOn1::BindToPort(const io_port_t lpt_port)
+{
+	using namespace std::placeholders;
+	const auto write_data = std::bind(&StereoOn1::WriteData, this, _1, _2, _3);
+	const auto read_status = std::bind(&StereoOn1::ReadStatus, this, _1, _2);
+	const auto write_control = std::bind(&StereoOn1::WriteControl, this, _1, _2, _3);
+	BindHandlers(lpt_port, write_data, read_status, write_control);
+	LOG_MSG("LPT_DAC: Initialized Stereo-On-1 DAC on LPT port %03xh", lpt_port);
+}
+
+void StereoOn1::ConfigureFilters(const FilterState state)
+{
+	assert(channel);
+ 	if (state == FilterState::On) {
+		constexpr uint8_t lp_order = 2;
+		const uint16_t lp_cutoff_freq = 9000;
+		channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq);
+	}
+	channel->SetLowPassFilter(state);
+}
+
+AudioFrame StereoOn1::Render()
+{
+	const float left = lut_u8to16[stereo_data[0]];
+	const float right = lut_u8to16[stereo_data[1]];
+	return {left, right};
+}
+
+void StereoOn1::WriteData(const io_port_t, const io_val_t data, const io_width_t)
+{
+	data_reg = check_cast<uint8_t>(data);
+}
+
+uint8_t StereoOn1::ReadStatus(const io_port_t, const io_width_t)
+{
+	const LptStatusRegister data_status = {data_reg};
+
+	// The Stereo-On-1 DAC ties pin 9 to 11 for detection, which
+	// is the last bit of the data inversely tied to the last bit of the
+	// status. Ref: modplay 2.x hardware documention.
+	status_reg.busy = !data_status.busy;
+	return status_reg.data;
+}
+
+void StereoOn1::WriteControl(const io_port_t, const io_val_t value, const io_width_t)
+{
+	RenderUpToNow();
+
+	const auto new_control = LptControlRegister{check_cast<uint8_t>(value)};
+
+	// Write data to the left channel
+	if (control_reg.auto_lf && !new_control.auto_lf)
+		stereo_data[0] = data_reg;
+
+	// Write data to the right channel
+	if (control_reg.strobe && !new_control.strobe)
+		stereo_data[1] = data_reg;
+
+	control_reg.data = new_control.data;
+}

--- a/src/hardware/ston1_dac.h
+++ b/src/hardware/ston1_dac.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_STEREO_ON_1_H
+#define DOSBOX_STEREO_ON_1_H
+
+#include "dosbox.h"
+
+#include "inout.h"
+#include "lpt_dac.h"
+#include "mixer.h"
+
+class StereoOn1 final : public LptDac {
+public:
+	StereoOn1() : LptDac("STON1", ston1_max_30_khz, {ChannelFeature::Stereo}){}
+	void BindToPort(const io_port_t lpt_port) final;
+	void ConfigureFilters(const FilterState state) final;
+
+protected:
+	AudioFrame Render() final;
+	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
+	uint8_t ReadStatus(const io_port_t, const io_width_t);
+	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
+
+private:
+	static constexpr uint16_t ston1_max_30_khz = 30000u;
+
+	uint8_t stereo_data[2] = {data_reg, data_reg};
+};
+
+#endif

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -179,7 +179,7 @@ private:
 	static constexpr auto render_divisor = 16;
 	static constexpr auto render_rate_hz = ceil_sdivide(tandy_psg_clock_hz,
 	                                                    render_divisor);
-	static constexpr auto ms_per_render  = 1000.0 / render_rate_hz;
+	static constexpr auto ms_per_render  = millis_in_second / render_rate_hz;
 
 	// Runtime states
 	device_sound_interface *dsi       = nullptr;
@@ -211,7 +211,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter
 	const auto callback = std::bind(&TandyDAC::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           0,
+	                           use_mixer_rate,
 	                           "TANDYDAC",
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ChorusSend,
@@ -428,7 +428,7 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile,
 	const auto callback = std::bind(&TandyPSG::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           0,
+	                           use_mixer_rate,
 	                           "TANDY",
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -189,7 +189,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	                                      this, std::placeholders::_1);
 
 	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                            0,
+	                                            use_mixer_rate,
 	                                            "FSYNTH",
 	                                            {ChannelFeature::Sleep,
 	                                             ChannelFeature::ReverbSend,

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -531,7 +531,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	                                      this, std::placeholders::_1);
 
 	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                            0,
+	                                            use_mixer_rate,
 	                                            "MT32",
 	                                            {ChannelFeature::Sleep,
 	                                             ChannelFeature::Stereo,

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -566,6 +566,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\gui\sdl_mapper.cpp" />
     <ClCompile Include="..\src\hardware\adlib_gold.cpp" />
     <ClCompile Include="..\src\hardware\cmos.cpp" />
+    <ClCompile Include="..\src\hardware\covox.cpp" />
     <ClCompile Include="..\src\hardware\disney.cpp" />
     <ClCompile Include="..\src\hardware\dma.cpp" />
     <ClCompile Include="..\src\hardware\envelope.cpp" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -580,6 +580,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\hardware\ipxserver.cpp" />
     <ClCompile Include="..\src\hardware\joystick.cpp" />
     <ClCompile Include="..\src\hardware\keyboard.cpp" />
+    <ClCompile Include="..\src\hardware\lpt_dac.cpp" />
     <ClCompile Include="..\src\hardware\mame\saa1099.cpp" />
     <ClCompile Include="..\src\hardware\mame\sn76496.cpp" />
     <ClCompile Include="..\src\hardware\memory.cpp" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -603,6 +603,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\hardware\serialport\serialmouse.cpp" />
     <ClCompile Include="..\src\hardware\serialport\serialport.cpp" />
     <ClCompile Include="..\src\hardware\serialport\softmodem.cpp" />
+    <ClCompile Include="..\src\hardware\ston1_dac.cpp" />
     <ClCompile Include="..\src\hardware\tandy_sound.cpp" />
     <ClCompile Include="..\src\hardware\timer.cpp" />
     <ClCompile Include="..\src\hardware\vga.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -241,6 +241,9 @@
     <ClCompile Include="..\src\hardware\serialport\softmodem.cpp">
       <Filter>src\hardware\serialport</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\ston1_dac.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\tandy_sound.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -172,6 +172,9 @@
     <ClCompile Include="..\src\hardware\keyboard.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\lpt_dac.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\mame\saa1099.cpp">
       <Filter>src\hardware\mame</Filter>
     </ClCompile>

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="..\src\hardware\cmos.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\covox.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\disney.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>


### PR DESCRIPTION
This PR breaks out the common LPT and DAC handling into a base base (only because it saved a lot of duplicate code in each device class), and re-adds the Covox and Stereo-On-1 LPT DACs.
