### PR TITLE
Fix viewport scaling on HiDPI displays

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -149,6 +149,7 @@ struct SDL_Block {
 		} requested_window_bounds = {};
 
 		uint8_t bpp = 0;
+		double dpi_scale = 1.0;
 		bool fullscreen = false;
 		// This flag indicates, that we are in the process of switching
 		// between fullscreen or window (as oppososed to changing

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1369,9 +1369,13 @@ static SDL_Window *setup_window_pp(SCREEN_TYPES screen_type, bool resizable)
 static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
 {
 	return sdl.use_viewport_limits
-	               ? SDL_Point{std::min(sdl.viewport_resolution.x, w),
-	                           std::min(sdl.viewport_resolution.y, h)}
-	               : SDL_Point{w, h};
+	             ? SDL_Point{std::min(iround(sdl.viewport_resolution.x *
+	                                         sdl.desktop.dpi_scale),
+	                                  w),
+	                         std::min(iround(sdl.viewport_resolution.y *
+	                                         sdl.desktop.dpi_scale),
+	                                  h)}
+	             : SDL_Point{w, h};
 }
 
 static SDL_Rect calc_viewport_fit(int win_width, int win_height);


### PR DESCRIPTION
`viewport_resolution` setting was incorrectly using physical pixels. This patch applies DPI scale to viewport rect, so now the user-facing setting is in logical points, and viewport rect is correctly scaled.

Fixes #1802.