### PR TITLE
Default reverb and chorus

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -144,6 +144,7 @@ public:
 
 	bool HasFeature(ChannelFeature feature);
 	int GetSampleRate() const;
+	std::string GetName() const;
 	using apply_level_callback_f = std::function<void(const AudioFrame &level)>;
 	void RegisterLevelCallBack(apply_level_callback_f cb);
 	void SetVolume(const float left, const float right);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2087,7 +2087,7 @@ private:
 		                           const std::string &xfeed,
 		                           const std::string &reverb,
 		                           const std::string &chorus) {
-			WriteOut("%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s %7s %7s\n",
+			WriteOut("%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %4s %7s %7s\n",
 			         name.c_str(),
 			         volume.left * 100.0f,
 			         volume.right * 100.0f,
@@ -2100,7 +2100,7 @@ private:
 			         chorus.c_str());
 		};
 
-		WriteOut(convert_ansi_markup("[color=white]Channel      Volume    Volume(dB)   Rate(Hz)  Mode     Xfeed  Reverb  Chorus[reset]\n")
+		WriteOut(convert_ansi_markup("[color=white]Channel      Volume    Volume(dB)   Rate(Hz)  Mode    Xfeed  Reverb  Chorus[reset]\n")
 		                 .c_str());
 
 		constexpr auto off_value  = "off";

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -205,8 +205,9 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	                                            0,
 	                                            "FSYNTH",
 	                                            {ChannelFeature::Sleep,
-	                                             ChannelFeature::ReverbSend,
 	                                             ChannelFeature::Stereo,
+	                                             ChannelFeature::ReverbSend,
+	                                             ChannelFeature::ChorusSend,
 	                                             ChannelFeature::Synthesizer});
 
 	const auto set_mixer_level = std::bind(&MidiHandlerFluidsynth::SetMixerLevel,


### PR DESCRIPTION
Removing the FluidSynth chorus and reverb and using the new global effects instead was a good idea, but I never really liked the fact that this resulted in basically losing the FluidSynth effects in the default basic usage scenario. This change remedies that by introducing special "default" presets for the reverb & chorus.

Special cases need special handling, and while I don't think the implementation is absolutely horrible, I'm open to improvement ideas at the code level.