### PR TITLE
Stop CHOICE from waiting for input when EOF is reached

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1408,7 +1408,8 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]choice[reset] /t:[color=white]y[reset],[color=magenta]2[reset] [color=cyan]Continue?[reset]\n"
 	        "  [color=green]choice[reset] /c:[color=white]abc[reset] /s [color=cyan]Type the letter a, b, or c[reset]\n");
-	MSG_Add("SHELL_CMD_CHOICE_ABORTED", "\nChoice aborted.\n");
+	MSG_Add("SHELL_CMD_CHOICE_EOF", "\n[color=red]Choice failed[reset]: the input stream ended without a valid choice.\n");
+	MSG_Add("SHELL_CMD_CHOICE_ABORTED", "\n[color=yellow]Choice aborted.[reset]\n");
 	MSG_Add("SHELL_CMD_PATH_HELP",
 	        "Displays or sets a search path for executable files.\n");
 	MSG_Add("SHELL_CMD_PATH_HELP_LONG",


### PR DESCRIPTION
Flagged by @SanekGamer007 in https://github.com/joncampbell123/dosbox-x/issues/3613 and documented and fixed by @Jookia in https://github.com/joncampbell123/dosbox-x/pull/3648, as follows:

Running `REM | CHOICE` or `CHOICE < NUL` will freeze CHOICE as it doesn't check for the end of file (EOF) condition.

FreeDOS and MS-DOS documentation specify the following behaviour:
- 0 is returned on abort (in this case Ctrl-C or break is pressed)
- 255 is returned on error (in this case no more input)

---

This PR was adapted from the EOF check authored by Jookia in https://github.com/joncampbell123/dosbox-x/pull/3648.

Thanks @SanekGamer007 and @Jookia!

This PR also improves the reporting for the EOF and abort conditions.

![2022-07-25_09-18](https://user-images.githubusercontent.com/1557255/180830309-ad3e040a-2182-4159-833f-80eddcbb6e03.png)


