### PR TITLE
Improve debugger window interactions

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -21,7 +21,6 @@
 
 #include "dosbox.h"
 
-void DEBUG_SetupConsole(void);
 void DEBUG_DrawScreen(void);
 bool DEBUG_Breakpoint(void);
 bool DEBUG_IntBreakpoint(uint8_t intNum);

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,13 @@ project('dosbox-staging', 'c', 'cpp',
   version : '0.79.0',
   license : 'GPL-2.0-or-later',
   meson_version : '>= 0.54.2',
+  # After increasing the minimum-required meson version, make the following
+  # improvements:
+  #
+  # - 0.55.0 - subproject wraps are automatically promoted to fallbacks,
+  #            stop using: "fallback : ['foo', 'foo_dep']" for dependencies
+  # - 0.56.0 - use meson.current_source_dir() in unit tests
+
   default_options : [
     'cpp_std=c++17',
     'warning_level=3',
@@ -30,13 +37,27 @@ project('dosbox-staging', 'c', 'cpp',
   ]
 )
 
-# After increasing the minimum-required meson version, make the following
-# improvements:
-#
-# - 0.55.0 - subproject wraps are automatically promoted to fallbacks,
-#            stop using: "fallback : ['foo', 'foo_dep']" for dependencies
-# - 0.56.0 - use meson.current_source_dir() in unit tests
 
+# Gather internal resource dependencies
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# These are always present regardless of host, compiler, dependencies, or options.
+#
+data_dir     = get_option('datadir')
+licenses_dir = data_dir / 'licenses' / 'dosbox-staging'
+doc_dir      = data_dir / 'doc' / 'dosbox-staging'
+
+install_man('docs/dosbox.1')
+install_data('COPYING', install_dir : licenses_dir)
+install_data('AUTHORS', 'README', 'THANKS', install_dir : doc_dir)
+
+subdir('contrib/linux')
+subdir('contrib/icons')
+subdir('contrib/resources')
+
+
+# Gather compiler settings
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+#
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 prefers_static_libs = (get_option('default_library') == 'static')
@@ -112,10 +133,11 @@ foreach flag : extra_flags
   endif
 endforeach
 
-# gather data for config file
-#
-# Actual config.h file will be generated after all interpreting build files 
-# for all subdirs.
+
+# Gather data to populate config.h
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The actual config.h file will be generated after interpreting
+# all the build files in all the subdirs.
 #
 conf_data = configuration_data()
 conf_data.set('version', meson.project_version())
@@ -265,7 +287,8 @@ if cxx.compiles(builtin_expect_code, name : 'test for __builtin_expect support')
 endif
 
 
-# external dependencies
+# Gather external dependencies
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 static_libs_list = get_option('try_static_libs')
 msg = 'You can disable this dependency with: -D@0@=false'
@@ -368,6 +391,7 @@ if get_option('tracy')
   add_project_arguments('-g', language : ['c','cpp'])
   add_project_arguments('-fno-omit-frame-pointer', language : ['c','cpp'])
 endif
+
 # macOS-only dependencies
 #
 if host_machine.system() == 'darwin'
@@ -461,11 +485,7 @@ if host_machine.system() in ['windows', 'cygwin']
   winmm_dep = cxx.find_library('winmm', required : true)
 endif
 
-summary('OpenGL support', conf_data.get('C_OPENGL'))
-
-
-# include directories
-#
+# Setup include directories
 incdir = include_directories('include', '.')
 
 # bundled dependencies, in dependency-order
@@ -524,12 +544,12 @@ if get_option('enable_debugger') != 'none'
 endif
 
 # generate config.h
-#
 configure_file(input : 'src/config.h.in', output : 'config.h',
                configuration : conf_data)
 
 
-# dosbox executable
+# Setup the executable and libraries
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 version_file = vcs_tag(input : 'src/version.cpp.in', output : 'version.cpp')
 dosbox_sources = ['src/main.cpp', 'src/dosbox.cpp', version_file]
@@ -554,24 +574,10 @@ libdosbox = static_library('dosbox', ['src/dosbox.cpp', version_file],
 dosbox_dep = declare_dependency(link_with : libdosbox)
 
 
-# tests
-#
+# Setup unit tests
+# ~~~~~~~~~~~~~~~~
 # Some tests use relative paths; in meson 0.56.0 this can be replaced
 # with meson.project_source_root().
+#
 project_source_root = meson.current_source_dir()
 subdir('tests')
-
-
-# additional files for installation
-#
-data_dir     = get_option('datadir')
-licenses_dir = data_dir / 'licenses' / 'dosbox-staging'
-doc_dir      = data_dir / 'doc' / 'dosbox-staging'
-
-install_man('docs/dosbox.1')
-install_data('COPYING', install_dir : licenses_dir)
-install_data('AUTHORS', 'README', 'THANKS', install_dir : doc_dir)
-
-subdir('contrib/linux')
-subdir('contrib/icons')
-subdir('contrib/resources')

--- a/meson.build
+++ b/meson.build
@@ -136,7 +136,6 @@ conf_data.set10('C_MODEM', get_option('use_sdl2_net'))
 conf_data.set10('C_IPX', get_option('use_sdl2_net'))
 conf_data.set10('C_SLIRP', get_option('use_slirp'))
 conf_data.set10('C_NE2000', get_option('use_slirp'))
-conf_data.set10('C_OPENGL', get_option('use_opengl'))
 conf_data.set10('C_FLUIDSYNTH', get_option('use_fluidsynth'))
 conf_data.set10('C_MT32EMU', get_option('use_mt32emu'))
 conf_data.set10('C_SSHOT', get_option('use_png'))
@@ -306,9 +305,25 @@ if get_option('use_sdl2_net')
                             not_found_message : msg.format('use_sdl2_net'))
 endif
 
-if get_option('use_opengl')
+# OpenGL setup
+opengl_summary_msg = 'Disabled'
+if get_option('use_opengl') != 'false'
   opengl_dep = dependency('gl', not_found_message : msg.format('use_opengl'))
 endif
+
+if (opengl_dep.found()
+    and get_option('use_opengl') == 'auto'
+    and get_option('enable_debugger') != 'none')
+  warning('''
+    Disabling OpenGL because it's incompatible with the debugger.
+    To use OpenGL with the debugger, force it with "-Duse_opengl=true"''')
+  conf_data.set10('C_OPENGL', false)
+  opengl_summary_msg = 'Found, but disabled due to conflict with debugger'
+else
+  conf_data.set10('C_OPENGL', opengl_dep.found())
+  opengl_summary_msg = opengl_dep.found()
+endif
+summary('OpenGL support', opengl_summary_msg)
 
 # Use a single static setting for the pool of libraries that use glib
 is_glib_realm_static = prefers_static_libs
@@ -446,7 +461,7 @@ if host_machine.system() in ['windows', 'cygwin']
   winmm_dep = cxx.find_library('winmm', required : true)
 endif
 
-summary('OpenGL support', get_option('use_opengl'))
+summary('OpenGL support', conf_data.get('C_OPENGL'))
 
 
 # include directories

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,8 @@
 option('use_sdl2_net', type : 'boolean', value : true,
        description : 'Enable networking features via SDL2_net (modem, ipx)')
 
-option('use_opengl', type : 'boolean', value : true,
+option('use_opengl', type : 'combo',
+       choices : ['auto', 'true', 'false'], value : 'auto',
        description : 'Enable OpenGL support')
 
 option('use_fluidsynth', type : 'boolean', value : true,

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1594,7 +1594,11 @@ int32_t DEBUG_Run(int32_t amount,bool quickexit) {
 	else {
 		// ensure all breakpoints are activated
 		CBreakpoint::ActivateBreakpoints();
-		SDL_RaiseWindow(GFX_GetSDLWindow());
+
+		const auto graphics_window = GFX_GetSDLWindow();
+		SDL_RaiseWindow(graphics_window);
+		SDL_SetWindowInputFocus(graphics_window);
+
 		DOSBOX_SetNormalLoop();
 	}
 	return ret;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4611,10 +4611,6 @@ int sdl_main(int argc, char *argv[])
 			return 0;
 		}
 
-#if C_DEBUG
-		DEBUG_SetupConsole();
-#endif
-
 #if defined(WIN32)
 	SetConsoleCtrlHandler((PHANDLER_ROUTINE) ConsoleEventHandler,TRUE);
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -204,9 +204,6 @@ SDL_Block sdl;
 bool mouse_is_captured = false;       // the actual state of the mouse
 bool mouse_capture_requested = false; // if the user manually requested the capture
 
-// SDL allows pixels sizes (color-depth) from 1 to 4 bytes
-constexpr uint8_t MAX_BYTES_PER_PIXEL = 4;
-
 // Masks to be passed when creating SDL_Surface.
 // Remove ifndef if they'll be needed for MacOS X builds.
 #ifndef MACOSX
@@ -286,6 +283,11 @@ SDL_Window *GFX_GetSDLWindow(void)
 #endif
 
 #if C_OPENGL
+
+// SDL allows pixels sizes (color-depth) from 1 to 4 bytes
+constexpr uint8_t MAX_BYTES_PER_PIXEL = 4;
+
+
 #ifdef DB_OPENGL_ERROR
 void OPENGL_ERROR(const char* message) {
 	GLenum r = glGetError();


### PR DESCRIPTION
The PR attempts to prevent the debugger window from getting "stuck" on some platforms and SDL versions.

The PR also applies some non-functional cleanups, such as initializing global to default values and using range-based loops.