### PR TITLE
Fix mouse button behavior in Master of Orion II

### DIFF
--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -895,7 +895,7 @@ void MOUSE_EventPressed(uint8_t idx)
     }
     if (changed_12S) {
         event.request_vmm = MOUSEVMM_NotifyPressedReleased(buttons_12S);
-        event.request_dos = MOUSEDOS_NotifyPressed(buttons_12S, idx_12S, event.id);
+        event.request_dos = MOUSEDOS_NotifyPressed(buttons_12S, idx_12S);
     }
 
     queue.AddEvent(event);
@@ -949,7 +949,7 @@ void MOUSE_EventReleased(uint8_t idx)
                                                        get_buttons_joined());
     if (changed_12S) {
         event.request_vmm = MOUSEVMM_NotifyPressedReleased(buttons_12S);
-        event.request_dos = MOUSEDOS_NotifyReleased(buttons_12S, idx_12S, event.id);
+        event.request_dos = MOUSEDOS_NotifyReleased(buttons_12S, idx_12S);
         MOUSESERIAL_NotifyPressedReleased(buttons_12S, idx_12S);
     }
 

--- a/src/ints/mouse_core.h
+++ b/src/ints/mouse_core.h
@@ -250,10 +250,8 @@ uintptr_t MOUSEDOS_DoCallback(const uint8_t mask, const MouseButtons12S buttons_
 
 bool MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
                           const uint16_t x_abs, const uint16_t y_abs);
-bool MOUSEDOS_NotifyPressed(const MouseButtons12S buttons_12S,
-                            const uint8_t idx, const MouseEventId event_id);
-bool MOUSEDOS_NotifyReleased(const MouseButtons12S buttons_12S,
-                             const uint8_t idx, const MouseEventId event_id);
+bool MOUSEDOS_NotifyPressed(const MouseButtons12S buttons_12S, const uint8_t idx);
+bool MOUSEDOS_NotifyReleased(const MouseButtons12S buttons_12S, const uint8_t idx);
 bool MOUSEDOS_NotifyWheel(const int16_t w_rel);
 
 #endif // DOSBOX_MOUSE_CORE_H


### PR DESCRIPTION
Fixes mouse button behavior in Master of Orion II, reported by @brandonrobertz.

Reason: the way game interacts with DOS mouse driver (it changes the event callback settings by calling INT 33 function 0x0F constantly) confused the recently introduced optimizations, which skipped pushing events through internal queue when it was thought to be safe. Optimizations had to be removed.