### PR TITLE
Use int instead of char for DEBUG_RefreshPage()

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -27,7 +27,7 @@ bool DEBUG_IntBreakpoint(uint8_t intNum);
 void DEBUG_Enable(bool pressed);
 void DEBUG_CheckExecuteBreakpoint(uint16_t seg, uint32_t off);
 bool DEBUG_ExitLoop(void);
-void DEBUG_RefreshPage(char scroll);
+void DEBUG_RefreshPage(int scroll);
 Bitu DEBUG_EnableDebugger(void);
 
 extern Bitu cycle_count;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -93,7 +93,7 @@ void DEBUG_ShowMsg(char const* format,...) {
 	wrefresh(dbg.win_out);
 }
 
-void DEBUG_RefreshPage(char scroll) {
+void DEBUG_RefreshPage(int scroll) {
 	// Quit early if the window hasn't been created yet
 	if (!dbg.win_out)
 		return;


### PR DESCRIPTION
char can be unsigned by default on some platforms,
causing the first condition in DEBUG_RefreshPage()
to always be false.

Received a GCC warning when building on Ubuntu 20.04.2 ARM64.
