### PR TITLE
Adjust clock for pre-VGA color modes

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -196,6 +196,7 @@ struct VGA_Draw {
 	Bitu blinking = 0;
 	bool blink = false;
 	bool char9dot = false;
+	bool use_strict_ega_modes = true;
 	struct {
 		Bitu address = 0;
 		uint8_t sline = 0;
@@ -510,6 +511,8 @@ void VGA_AddCompositeSettings(Config &conf);
 /* Some Support Functions */
 std::pair<const char *, const char *> VGA_DescribeType(VGAModes type);
 void VGA_SetClock(Bitu which, uint32_t target);
+
+void VGA_UseStrictEgaModes(const bool enabled);
 
 // Save, get, and limit refresh and clock functions
 void VGA_SetHostRate(const double refresh_hz);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -408,6 +408,8 @@ static void DOSBOX_RealInit(Section * sec) {
 
 	VGA_SetRatePreference(section->Get_string("dos_rate"));
 
+	VGA_UseStrictEgaModes(section->Get_bool("strict_ega_modes"));
+
 	CPU_AllowSpeedMods = section->Get_bool("speed_mods");
 	LOG_MSG("SYSTEM: Speed modifications are %s",
 	        CPU_AllowSpeedMods ? "enabled" : "disabled");
@@ -521,6 +523,9 @@ void DOSBOX_Init() {
 	        "  all          Offers all modes for a given video memory size, however\n"
 	        "               some games may not use them properly (flickering) or may need\n"
 	        "               more system memory (mem = ) to use them.");
+
+	Pbool = secprop->Add_bool("strict_ega_modes", only_at_start, true);
+	Pbool->Set_help("Use original CGA and EGA clock rates instead of SVGA vendor's higher rates.");
 
 	Pbool = secprop->Add_bool("speed_mods", only_at_start, true);
 	Pbool->Set_help(

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -174,6 +174,10 @@ void VGA_SetRatePreference(const std::string &pref)
 	}
 }
 
+void VGA_UseStrictEgaModes(const bool enabled) {
+	vga.draw.use_strict_ega_modes = enabled;
+}
+
 double VGA_GetPreferredRate()
 {
 	// If we're in a text-mode, always use the as-indicated DOS rate because


### PR DESCRIPTION
Pre-VGA color modes often ran with a horizontal sync rate of 15.7 kHz (200-lines) or 21.85 KHz (350-lines), both producing a vertical sync rate of 60 Hz. So we adjust the clock when not natively running a CGA, EGA, or Tandy machine type.

Ref: http://minuszerodegrees.net/video/bios_video_modes.htm

The code is quite unpleasant given how specific the check is.

Recommend testing using `machine = svga_s3` and any older game that uses pre-VGA color modes (CGA/EGA/Tandy).

Here's a couple recordings from Prehistorik 2:

https://user-images.githubusercontent.com/1557255/181995696-30938954-2fa7-4833-9fc2-894c52ad10ca.mp4

https://user-images.githubusercontent.com/1557255/181995699-992a78a6-e275-49da-82cf-6b99237324ca.mp4
