### PR TITLE
Add global compressor to the master audio channel

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -97,7 +97,8 @@ extern int16_t lut_u8to16[UINT8_MAX + 1];
 
 static constexpr auto max_filter_order = 16;
 
-static constexpr auto millis_in_second = 1000.0;
+static constexpr auto millis_in_second   = 1000.0;
+static constexpr auto millis_in_second_f = 1000.0f;
 
 static constexpr uint8_t use_mixer_rate = 0;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -31,6 +31,7 @@
 #include <set>
 
 #include "envelope.h"
+#include "../src/hardware/compressor.h"
 
 // Disable effc++ for Iir until its release.
 // Ref: https://github.com/berndporr/iir1/pull/39

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -39,12 +39,12 @@ Compressor::~Compressor() = default;
 
 void Compressor::Configure(const uint16_t _sample_rate_hz,
                            const float _0dbfs_sample_value, const float threshold_db,
-                           const float ratio, const float attack_time_ms,
+                           const float _ratio, const float attack_time_ms,
                            const float release_time_ms, const float rms_window_ms)
 {
 	assert(_sample_rate_hz > 0);
 	assert(_0dbfs_sample_value > 0.0f);
-	assert(ratio > 0.0f);
+	assert(_ratio > 0.0f);
 	assert(attack_time_ms > 0.0f);
 	assert(release_time_ms > 0.0f);
 	assert(rms_window_ms > 0.0f);
@@ -55,7 +55,7 @@ void Compressor::Configure(const uint16_t _sample_rate_hz,
 	scale_out = _0dbfs_sample_value;
 
 	threshold_value = expf(threshold_db * db_to_log);
-	ratio_minus_one = ratio;
+	ratio           = _ratio;
 	attack_coeff    = expf(-1.0f / (attack_time_ms * sample_rate_hz));
 	release_coeff   = expf(-millis_in_second_f / (release_time_ms * sample_rate_hz));
 	rms_coeff       = expf(-millis_in_second_f / (rms_window_ms * sample_rate_hz));
@@ -95,7 +95,7 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 	over_db = run_db;
 
 	constexpr auto ratio_threshold_db = 6.0f;
-	comp_ratio = 1.0f + ratio_minus_one * fminf(over_db, ratio_threshold_db) /
+	comp_ratio = 1.0f + ratio * fminf(over_db, ratio_threshold_db) /
 	                            ratio_threshold_db;
 
 	const auto gain_reduction_db = -over_db * (comp_ratio - 1.0f) / comp_ratio;

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -38,13 +38,14 @@ Compressor::Compressor() {}
 Compressor::~Compressor() {}
 
 void Compressor::Configure(const uint16_t _sample_rate_hz,
-                           const float _0dbfs_sample_value,
-                           const float threshold_db, const float ratio,
+                           const float _0dbfs_sample_value, const float threshold_db,
+                           const float ratio, const float attack_time_ms,
                            const float release_time_ms, const float rms_window_ms)
 {
 	assert(_sample_rate_hz > 0);
 	assert(_0dbfs_sample_value > 0.0f);
 	assert(ratio > 0.0f);
+	assert(attack_time_ms > 0.0f);
 	assert(release_time_ms > 0.0f);
 	assert(rms_window_ms > 0.0f);
 
@@ -53,18 +54,17 @@ void Compressor::Configure(const uint16_t _sample_rate_hz,
 	scale_in  = 1.0f / _0dbfs_sample_value;
 	scale_out = _0dbfs_sample_value;
 
-	ratio_minus_one = ratio;
 	threshold_value = expf(threshold_db * db_to_log);
+	ratio_minus_one = ratio;
+	attack_coeff    = expf(-1.0f / (attack_time_ms * sample_rate_hz));
 	release_coeff   = expf(-millis_in_second_f / (release_time_ms * sample_rate_hz));
-	rms_coeff       = expf(-millis_in_second_f / (rms_window_ms   * sample_rate_hz));
+	rms_coeff       = expf(-millis_in_second_f / (rms_window_ms * sample_rate_hz));
 
 	Reset();
 }
 
 void Compressor::Reset()
 {
-	attack_time_ms  = 0.010f;
-	attack_coeff    = expf(-1.0f / (attack_time_ms * sample_rate_hz));
 	comp_ratio      = 0.0f;
 	run_db          = 0.0f;
 	run_sum_squares = 0.0f;

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -25,7 +25,10 @@
 #include <cassert>
 #include <cmath>
  
+#include "checks.h"
 #include "mixer.h"
+
+CHECK_NARROWING();
 
 constexpr auto log_to_db = 8.685889638065035f;  // 20.0 / log(10.0)
 constexpr auto db_to_log = 0.1151292546497022f; // log(10.0) / 20.0

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -59,8 +59,8 @@ void Compressor::Configure(const uint16_t _sample_rate_hz,
 
 	ratio           = _ratio;
 	threshold_value = expf(threshold_db * db_to_log);
-	release_coeff   = expf(-millis_in_second / (release_time_ms * sample_rate_hz));
-	rms_coeff       = expf(-millis_in_second / (rms_window_ms   * sample_rate_hz));
+	release_coeff   = expf(-millis_in_second_f / (release_time_ms * sample_rate_hz));
+	rms_coeff       = expf(-millis_in_second_f / (rms_window_ms   * sample_rate_hz));
 
 	Reset();
 }
@@ -84,7 +84,7 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 
 	const auto sum_squares = (left * left) + (right * right);
 	run_sum_squares = sum_squares + rms_coeff * (run_sum_squares - sum_squares);
-	const auto det = sqrtf(fmax(0.0f, run_sum_squares));
+	const auto det = sqrtf(fmaxf(0.0f, run_sum_squares));
 
 	over_db = 2.08136898f * logf(det / threshold_value) * log_to_db;
 
@@ -100,7 +100,7 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 		attack_coeff = expf(-1.0f / (attack_time_ms * sample_rate_hz));
 	}
 
-	over_db = fmax(0.0, over_db);
+	over_db = fmaxf(0.0f, over_db);
 
 	if (over_db > run_db)
 		run_db = over_db + attack_coeff * (run_db - over_db);

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -24,18 +24,22 @@
 #include "compressor.h"
 #include "mixer.h"
 
-constexpr float log_to_db = 8.685889638065035f;  // 20.0 / log(10.0)
-constexpr float db_to_log = 0.1151292546497022f; // log(10.0) / 20.0
+constexpr auto log_to_db = 8.685889638065035f;  // 20.0 / log(10.0)
+constexpr auto db_to_log = 0.1151292546497022f; // log(10.0) / 20.0
 
-std::array<float, 120> attack_times_ms = {};
+using attack_times_lut_t = std::array<float, 120>;
 
-constexpr void fill_attack_times_lut()
+constexpr attack_times_lut_t fill_attack_times_lut()
 {
-	for (size_t i = 0; i < attack_times_ms.size(); ++i) {
-		const auto n = i + 1;
-		attack_times_ms[i] = ((0.08924f / n) + (0.60755f / (n * n)) - 0.00006f);
+	int16_t n = 1;
+	attack_times_lut_t lut = {};
+	for (auto &time_ms : lut) {
+		time_ms = ((0.08924f / n) + (0.60755f / (n * n)) - 0.00006f);
+		++n;
 	}
+	return lut;
 }
+constexpr auto attack_times_ms = fill_attack_times_lut();
 
 Compressor::Compressor() {}
 

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -18,7 +18,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "mixer.h"
 #include "compressor.h"

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -37,7 +37,7 @@ using attack_times_lut_t = std::array<float, 120>;
 
 constexpr attack_times_lut_t fill_attack_times_lut()
 {
-	int16_t n = 1;
+	auto n = 1.0f;
 	attack_times_lut_t lut = {};
 	for (auto &time_ms : lut) {
 		time_ms = ((0.08924f / n) + (0.60755f / (n * n)) - 0.00006f);
@@ -120,7 +120,7 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 	over_db = run_db;
 
 	constexpr auto ratio_threshold_db = 6.0f;
-	comp_ratio = 1.0f + ratio_minus_one * fmin(over_db, ratio_threshold_db) /
+	comp_ratio = 1.0f + ratio_minus_one * fminf(over_db, ratio_threshold_db) /
 	                            ratio_threshold_db;
 
 	const auto gain_reduction_db = -over_db * (comp_ratio - 1.0f) / comp_ratio;

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -33,20 +33,6 @@ CHECK_NARROWING();
 constexpr auto log_to_db = 8.685889638065035f;  // 20.0 / log(10.0)
 constexpr auto db_to_log = 0.1151292546497022f; // log(10.0) / 20.0
 
-using attack_times_lut_t = std::array<float, 120>;
-
-constexpr attack_times_lut_t fill_attack_times_lut()
-{
-	auto n = 1.0f;
-	attack_times_lut_t lut = {};
-	for (auto &time_ms : lut) {
-		time_ms = ((0.08924f / n) + (0.60755f / (n * n)) - 0.00006f);
-		++n;
-	}
-	return lut;
-}
-constexpr auto attack_times_ms = fill_attack_times_lut();
-
 Compressor::Compressor() {}
 
 Compressor::~Compressor() {}
@@ -98,19 +84,8 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 
 	over_db = 2.08136898f * logf(det / threshold_value) * log_to_db;
 
-	if (over_db > max_over_db) {
+	if (over_db > max_over_db)
 		max_over_db = over_db;
-
-		constexpr size_t min_i = 0;
-		constexpr size_t max_i = attack_times_ms.size() - 1;
-
-		const auto i = std::clamp(static_cast<size_t>(fabsf(over_db)),
-		                          min_i,
-		                          max_i);
-
-		attack_time_ms = attack_times_ms[i];
-		attack_coeff = expf(-1.0f / (attack_time_ms * sample_rate_hz));
-	}
 
 	over_db = fmaxf(0.0f, over_db);
 

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -1,0 +1,82 @@
+#include <math.h>
+
+#include "mixer.h"
+#include "compressor.h"
+
+constexpr double log_to_db = 8.685889638065035;  // 20.0 / log(10.0)
+constexpr double db_to_log = 0.1151292546497022; // log(10.0) / 20.0
+
+Compressor::Compressor()
+{
+	for (int i = 0; i < num_attack_times; ++i)
+		attack_times_ms[i] = ((0.08924 / i) + (0.60755 / (i * i)) - 0.00006);
+}
+
+Compressor::~Compressor() {}
+
+void Compressor::Configure(const uint16_t _sample_rate_hz,
+                           const float threshold_db, const float _ratio,
+                           const float release_time_ms, const float rms_window_ms)
+{
+	sample_rate_hz = _sample_rate_hz;
+	ratio          = _ratio;
+
+	threshold_value = exp(threshold_db * db_to_log);
+
+	constexpr auto millis_in_second = 1000.0;
+
+	release_coeff = exp(-millis_in_second / (release_time_ms * sample_rate_hz));
+	rms_coeff     = exp(-millis_in_second / (rms_window_ms   * sample_rate_hz));
+
+	Reset();
+}
+
+void Compressor::Reset()
+{
+	attack_time_ms = 0.010;
+	comp_ratio     = 0.0;
+	run_db         = 0.0;
+	over_db        = 0.0;
+	run_max_db     = 0.0;
+	max_over_db    = 0.0;
+	attack_coeff   = exp(-1.0 / (attack_time_ms * sample_rate_hz));
+}
+
+AudioFrame Compressor::Process(const AudioFrame &in)
+{
+	const double left  = in.left;
+	const double right = in.right;
+
+	const auto average = (left * left) + (right * right);
+	run_average        = average + rms_coeff * (run_average - average);
+	const auto det     = sqrt(fmax(0.0, run_average));
+
+	over_db = 2.08136898 * log(det / threshold_value) * log_to_db;
+
+	if (over_db > max_over_db) {
+		max_over_db    = over_db;
+		const auto i   = static_cast<size_t>(fmax(0.0, floor(fabs(over_db))));
+		attack_time_ms = attack_times_ms[i];
+		attack_coeff   = exp(-1.0 / (attack_time_ms * sample_rate_hz));
+	}
+
+	over_db = fmax(0.0, over_db);
+
+	if (over_db > run_db)
+		run_db = over_db + attack_coeff * (run_db - over_db);
+	else
+		run_db = over_db + release_coeff * (run_db - over_db);
+
+	over_db    = run_db;
+	comp_ratio = 1.0 + (ratio - 1.0) * fmin(over_db, 6.0) / 6.0;
+
+	const auto gain_reduction_db = -over_db * (comp_ratio - 1.0) / comp_ratio;
+	const auto gain_reduction_factor = exp(gain_reduction_db * db_to_log);
+
+	run_max_db  = max_over_db + release_coeff * (run_max_db - max_over_db);
+	max_over_db = run_max_db;
+
+	return {static_cast<float>(left * gain_reduction_factor),
+	        static_cast<float>(right * gain_reduction_factor)};
+}
+

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -33,9 +33,9 @@ CHECK_NARROWING();
 constexpr auto log_to_db = 8.685889638065035f;  // 20.0 / log(10.0)
 constexpr auto db_to_log = 0.1151292546497022f; // log(10.0) / 20.0
 
-Compressor::Compressor() {}
+Compressor::Compressor() = default;
 
-Compressor::~Compressor() {}
+Compressor::~Compressor() = default;
 
 void Compressor::Configure(const uint16_t _sample_rate_hz,
                            const float _0dbfs_sample_value, const float threshold_db,

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -18,21 +18,22 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <algorithm>
 #include <cmath>
 
-#include "mixer.h"
 #include "compressor.h"
+#include "mixer.h"
 
-constexpr double log_to_db = 8.685889638065035;  // 20.0 / log(10.0)
-constexpr double db_to_log = 0.1151292546497022; // log(10.0) / 20.0
+constexpr float log_to_db = 8.685889638065035f;  // 20.0 / log(10.0)
+constexpr float db_to_log = 0.1151292546497022f; // log(10.0) / 20.0
 
-std::array<double, 120> attack_times_ms = {};
+std::array<float, 120> attack_times_ms = {};
 
 constexpr void fill_attack_times_lut()
 {
 	for (size_t i = 0; i < attack_times_ms.size(); ++i) {
 		const auto n = i + 1;
-		attack_times_ms[i] = ((0.08924 / n) + (0.60755 / (n * n)) - 0.00006);
+		attack_times_ms[i] = ((0.08924f / n) + (0.60755f / (n * n)) - 0.00006f);
 	}
 }
 
@@ -52,47 +53,51 @@ void Compressor::Configure(const uint16_t _sample_rate_hz,
 	assert(rms_window_ms > 0.0f);
 
 	sample_rate_hz = _sample_rate_hz;
-	scale_in       = 1.0 / _0dbfs_sample_value;
-	scale_out      = _0dbfs_sample_value;
+
+	scale_in  = 1.0f / _0dbfs_sample_value;
+	scale_out = _0dbfs_sample_value;
 
 	ratio           = _ratio;
-	threshold_value = exp(threshold_db * db_to_log);
-	release_coeff   = exp(-millis_in_second / (release_time_ms * sample_rate_hz));
-	rms_coeff       = exp(-millis_in_second / (rms_window_ms * sample_rate_hz));
+	threshold_value = expf(threshold_db * db_to_log);
+	release_coeff   = expf(-millis_in_second / (release_time_ms * sample_rate_hz));
+	rms_coeff       = expf(-millis_in_second / (rms_window_ms   * sample_rate_hz));
 
 	Reset();
 }
 
 void Compressor::Reset()
 {
-	attack_time_ms  = 0.010;
-	attack_coeff    = exp(-1.0 / (attack_time_ms * sample_rate_hz));
-	comp_ratio      = 0.0;
-	run_db          = 0.0;
-	run_sum_squares = 0.0;
-	over_db         = 0.0;
-	run_max_db      = 0.0;
-	max_over_db     = 0.0;
+	attack_time_ms  = 0.010f;
+	attack_coeff    = expf(-1.0f / (attack_time_ms * sample_rate_hz));
+	comp_ratio      = 0.0f;
+	run_db          = 0.0f;
+	run_sum_squares = 0.0f;
+	over_db         = 0.0f;
+	run_max_db      = 0.0f;
+	max_over_db     = 0.0f;
 }
 
 AudioFrame Compressor::Process(const AudioFrame &in)
 {
-	const double left  = in.left  * scale_in;
-	const double right = in.right * scale_in;
+	const float left  = in.left  * scale_in;
+	const float right = in.right * scale_in;
 
 	const auto sum_squares = (left * left) + (right * right);
 	run_sum_squares = sum_squares + rms_coeff * (run_sum_squares - sum_squares);
-	const auto det = sqrt(fmax(0.0, run_sum_squares));
+	const auto det = sqrtf(fmax(0.0f, run_sum_squares));
 
-	over_db = 2.08136898 * log(det / threshold_value) * log_to_db;
+	over_db = 2.08136898f * logf(det / threshold_value) * log_to_db;
 
 	if (over_db > max_over_db) {
 		max_over_db = over_db;
-		const auto i = std::clamp(static_cast<unsigned long>(std::fabs(over_db)),
-		                          0ul,
-		                          attack_times_ms.size() - 1);
+
+		const auto i = std::clamp(static_cast<size_t>(fabsf(over_db)),
+		                          static_cast<size_t>(0),
+		                          static_cast<size_t>(
+		                                  attack_times_ms.size() - 1));
+
 		attack_time_ms = attack_times_ms[i];
-		attack_coeff   = exp(-1.0 / (attack_time_ms * sample_rate_hz));
+		attack_coeff = expf(-1.0f / (attack_time_ms * sample_rate_hz));
 	}
 
 	over_db = fmax(0.0, over_db);
@@ -103,15 +108,15 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 		run_db = over_db + release_coeff * (run_db - over_db);
 
 	over_db    = run_db;
-	comp_ratio = 1.0 + (ratio - 1.0) * fmin(over_db, 6.0) / 6.0;
+	comp_ratio = 1.0f + (ratio - 1.0f) * fmin(over_db, 6.0f) / 6.0f;
 
-	const auto gain_reduction_db = -over_db * (comp_ratio - 1.0) / comp_ratio;
-	const auto gain_reduction_factor = exp(gain_reduction_db * db_to_log);
+	const auto gain_reduction_db = -over_db * (comp_ratio - 1.0f) / comp_ratio;
+	const auto gain_reduction_factor = expf(gain_reduction_db * db_to_log);
 
 	run_max_db  = max_over_db + release_coeff * (run_max_db - max_over_db);
 	max_over_db = run_max_db;
 
-	return {static_cast<float>(left  * gain_reduction_factor * scale_out),
-	        static_cast<float>(right * gain_reduction_factor * scale_out)};
+	return {left  * gain_reduction_factor * scale_out,
+	        right * gain_reduction_factor * scale_out};
 }
 

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -36,28 +36,29 @@ constexpr void fill_attack_times_lut()
 	}
 }
 
-Compressor::Compressor()
-{
-}
+Compressor::Compressor() {}
 
 Compressor::~Compressor() {}
 
 void Compressor::Configure(const uint16_t _sample_rate_hz,
+                           const float _0dbfs_sample_value,
                            const float threshold_db, const float _ratio,
                            const float release_time_ms, const float rms_window_ms)
 {
 	assert(_sample_rate_hz > 0);
+	assert(_0dbfs_sample_value > 0.0f);
 	assert(_ratio > 0.0f);
 	assert(release_time_ms > 0.0f);
 	assert(rms_window_ms > 0.0f);
 
 	sample_rate_hz = _sample_rate_hz;
-	ratio          = _ratio;
+	scale_in       = 1.0 / _0dbfs_sample_value;
+	scale_out      = _0dbfs_sample_value;
 
+	ratio           = _ratio;
 	threshold_value = exp(threshold_db * db_to_log);
-
-	release_coeff = exp(-millis_in_second / (release_time_ms * sample_rate_hz));
-	rms_coeff     = exp(-millis_in_second / (rms_window_ms   * sample_rate_hz));
+	release_coeff   = exp(-millis_in_second / (release_time_ms * sample_rate_hz));
+	rms_coeff       = exp(-millis_in_second / (rms_window_ms * sample_rate_hz));
 
 	Reset();
 }
@@ -76,8 +77,8 @@ void Compressor::Reset()
 
 AudioFrame Compressor::Process(const AudioFrame &in)
 {
-	const double left  = in.left;
-	const double right = in.right;
+	const double left  = in.left  * scale_in;
+	const double right = in.right * scale_in;
 
 	const auto sum_squares = (left * left) + (right * right);
 	run_sum_squares = sum_squares + rms_coeff * (run_sum_squares - sum_squares);
@@ -110,7 +111,7 @@ AudioFrame Compressor::Process(const AudioFrame &in)
 	run_max_db  = max_over_db + release_coeff * (run_max_db - max_over_db);
 	max_over_db = run_max_db;
 
-	return {static_cast<float>(left * gain_reduction_factor),
-	        static_cast<float>(right * gain_reduction_factor)};
+	return {static_cast<float>(left  * gain_reduction_factor * scale_out),
+	        static_cast<float>(right * gain_reduction_factor * scale_out)};
 }
 

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -1,3 +1,23 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #include <math.h>
 
 #include "mixer.h"

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -97,7 +97,7 @@ private:
 	float scale_out         = {};
 
 	float threshold_value = {};
-	float ratio           = {};
+	float ratio_minus_one = {};
 	float release_coeff   = {};
 	float rms_coeff       = {};
 

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -76,9 +76,9 @@ public:
 	Compressor();
 	~Compressor();
 
-	void Configure(const uint16_t sample_rate_hz, const float threshold_db,
-	               const float ratio, const float release_time_ms,
-	               const float rms_window_ms);
+	void Configure(const uint16_t sample_rate_hz, const float _0dbfs_sample_value,
+	               const float threshold_db, const float ratio,
+	               const float release_time_ms, const float rms_window_ms);
 	void Reset();
 
 	AudioFrame Process(const AudioFrame &in);
@@ -90,8 +90,8 @@ public:
 
 private:
 	uint16_t sample_rate_hz = {};
-
-//	std::array<double, 120> attack_times_ms = {};
+	double scale_in         = {};
+	double scale_out        = {};
 
 	double threshold_value = {};
 	double ratio           = {};

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -18,8 +18,11 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-/* This is a simplified port of the "Master Tom Compressor" JSFX effect
- * bundled with REAPER, originally written by Thomas Scott Stillwell.
+/* ---------------------------------------------------------------------------
+ * This is a simplified port of Thomas Scott Stillwell's "Master Tom
+ * Compressor" JSFX effect bundled with REAPER (just the RMS & feedforward
+ * path).
+ *
  * Copyright notice of the original effect plugin:
  *
  *
@@ -90,23 +93,23 @@ public:
 
 private:
 	uint16_t sample_rate_hz = {};
-	double scale_in         = {};
-	double scale_out        = {};
+	float scale_in          = {};
+	float scale_out         = {};
 
-	double threshold_value = {};
-	double ratio           = {};
-	double release_coeff   = {};
-	double rms_coeff       = {};
+	float threshold_value = {};
+	float ratio           = {};
+	float release_coeff   = {};
+	float rms_coeff       = {};
 
 	// state variables
-	double attack_time_ms  = {};
-	double attack_coeff    = {};
-	double comp_ratio      = {};
-	double run_db          = {};
-	double run_sum_squares = {};
-	double over_db         = {};
-	double run_max_db      = {};
-	double max_over_db     = {};
+	float attack_time_ms  = {};
+	float attack_coeff    = {};
+	float comp_ratio      = {};
+	float run_db          = {};
+	float run_sum_squares = {};
+	float over_db         = {};
+	float run_max_db      = {};
+	float max_over_db     = {};
 };
 
 #endif

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -98,7 +98,7 @@ private:
 	float scale_out         = {};
 
 	float threshold_value = {};
-	float ratio_minus_one = {};
+	float ratio           = {};
 	float attack_coeff    = {};
 	float release_coeff   = {};
 	float rms_coeff       = {};

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -62,6 +62,15 @@
 
 typedef struct AudioFrame AudioFrame_;
 
+// Implements a dynamic-range reducing audio signal compressor to reduce the
+// volume of loud sounds above a given threshold.
+//
+// The compressor uses the standard set of of adjustable control parameters
+// common to all compressors; the following Wikipedia page gives a good
+// overview about them:
+//
+// https://en.wikipedia.org/wiki/Dynamic_range_compression#Controls_and_features
+//
 class Compressor {
 public:
 	Compressor();
@@ -82,23 +91,22 @@ public:
 private:
 	uint16_t sample_rate_hz = {};
 
-	static constexpr auto num_attack_times = 120;
-	double attack_times_ms[num_attack_times] = {};
+//	std::array<double, 120> attack_times_ms = {};
 
 	double threshold_value = {};
 	double ratio           = {};
 	double release_coeff   = {};
 	double rms_coeff       = {};
 
-	// state vars
-	double attack_time_ms = {};
-	double attack_coeff   = {};
-	double comp_ratio     = {};
-	double run_db         = {};
-	double run_average    = {};
-	double over_db        = {};
-	double run_max_db     = {};
-	double max_over_db    = {};
+	// state variables
+	double attack_time_ms  = {};
+	double attack_coeff    = {};
+	double comp_ratio      = {};
+	double run_db          = {};
+	double run_sum_squares = {};
+	double over_db         = {};
+	double run_max_db      = {};
+	double max_over_db     = {};
 };
 
 #endif

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -79,8 +79,9 @@ public:
 	Compressor();
 	~Compressor();
 
-	void Configure(const uint16_t sample_rate_hz, const float _0dbfs_sample_value,
-	               const float threshold_db, const float ratio,
+	void Configure(const uint16_t sample_rate_hz,
+	               const float _0dbfs_sample_value, const float threshold_db,
+	               const float ratio, const float attack_time_ms,
 	               const float release_time_ms, const float rms_window_ms);
 	void Reset();
 
@@ -98,12 +99,11 @@ private:
 
 	float threshold_value = {};
 	float ratio_minus_one = {};
+	float attack_coeff    = {};
 	float release_coeff   = {};
 	float rms_coeff       = {};
 
 	// state variables
-	float attack_time_ms  = {};
-	float attack_coeff    = {};
 	float comp_ratio      = {};
 	float run_db          = {};
 	float run_sum_squares = {};

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -56,6 +56,10 @@
 #ifndef DOSBOX_COMPRESSOR_H
 #define DOSBOX_COMPRESSOR_H
 
+#include "dosbox.h"
+
+#include <cstdint>
+
 typedef struct AudioFrame AudioFrame_;
 
 class Compressor {

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -1,0 +1,100 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* This is a simplified port of the "Master Tom Compressor" JSFX effect
+ * bundled with REAPER, originally written by Thomas Scott Stillwell.
+ * Copyright notice of the original effect plugin:
+ *
+ *
+ * Copyright 2006, Thomas Scott Stillwell
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * The name of Thomas Scott Stillwell may not be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DOSBOX_COMPRESSOR_H
+#define DOSBOX_COMPRESSOR_H
+
+typedef struct AudioFrame AudioFrame_;
+
+class Compressor {
+public:
+	Compressor();
+	~Compressor();
+
+	void Configure(const uint16_t sample_rate_hz, const float threshold_db,
+	               const float ratio, const float release_time_ms,
+	               const float rms_window_ms);
+	void Reset();
+
+	AudioFrame Process(const AudioFrame &in);
+
+	// prevent copying
+	Compressor(const Compressor &) = delete;
+	// prevent assignment
+	Compressor &operator=(const Compressor &) = delete;
+
+private:
+	uint16_t sample_rate_hz = {};
+
+	static constexpr auto num_attack_times = 120;
+	double attack_times_ms[num_attack_times] = {};
+
+	double threshold_value = {};
+	double ratio           = {};
+	double release_coeff   = {};
+	double rms_coeff       = {};
+
+	// state vars
+	double attack_time_ms = {};
+	double attack_coeff   = {};
+	double comp_ratio     = {};
+	double run_db         = {};
+	double run_average    = {};
+	double over_db        = {};
+	double run_max_db     = {};
+	double max_over_db    = {};
+};
+
+#endif

--- a/src/hardware/meson.build
+++ b/src/hardware/meson.build
@@ -12,6 +12,7 @@ libhardware_sources = files(
     'adlib_gold.cpp',
     'cmos.cpp',
     'covox.cpp',
+    'compressor.cpp',
     'disney.cpp',
     'dma.cpp',
     'envelope.cpp',

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1584,13 +1584,10 @@ static void MIXER_MixData(const int frames_requested)
 	for (work_index_t i = 0; i < frames_added; ++i) {
 		AudioFrame frame = {mixer.work[pos][0], mixer.work[pos][1]};
 
-		frame.left /= INT16_MAX;
-		frame.right /= INT16_MAX;
-
 		frame = mixer.compressor.Process(frame);
 
-		mixer.work[pos][0] = frame.left * INT16_MAX;
-		mixer.work[pos][1] = frame.right * INT16_MAX;
+		mixer.work[pos][0] = frame.left;
+		mixer.work[pos][1] = frame.right;
 
 		pos = (pos + 1) & MIXER_BUFMASK;
 	}
@@ -2379,12 +2376,14 @@ void MIXER_Init(Section *sec)
 	configure_chorus(section->Get_string("chorus"));
 
 	// Initialise compressor
-	const auto threshold_db    = -6.0f;
-	const auto ratio           = 2.0f;
-	const auto release_time_ms = 5000.0f;
-	const auto rms_window_ms   = 10.0;
+	const auto _0dbfs_sample_value = INT16_MAX;
+	const auto threshold_db        = -6.0f;
+	const auto ratio               = 2.0f;
+	const auto release_time_ms     = 5000.0f;
+	const auto rms_window_ms       = 10.0;
 
 	mixer.compressor.Configure(mixer.sample_rate,
+	                           _0dbfs_sample_value,
 	                           threshold_db,
 	                           ratio,
 	                           release_time_ms,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2487,10 +2487,10 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 
 	const auto default_on = true;
 	bool_prop = sec_prop.Add_bool("compressor", when_idle, default_on);
-	bool_prop->Set_help("Enable compressor/auto-leveler on the master channel to prevent clipping\n"
+	bool_prop->Set_help("Enable the auto-leveling compressor on the master channel to prevent clipping\n"
 	                    "of the audio output:\n"
 	                    "  off:  Disable compressor.\n"
-	                    "  on:   Enable compressor (default).\n");
+	                    "  on:   Enable compressor (default).");
 
 	auto string_prop = sec_prop.Add_string("crossfeed", when_idle, "off");
 	string_prop->Set_help(

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1581,7 +1581,7 @@ static void MIXER_MixData(const int frames_requested)
 	// Apply compressor to the master output as the very last step
 	pos = start_pos;
 
-/*	for (work_index_t i = 0; i < frames_added; ++i) {
+	for (work_index_t i = 0; i < frames_added; ++i) {
 		AudioFrame frame = {mixer.work[pos][0], mixer.work[pos][1]};
 
 		frame.left /= INT16_MAX;
@@ -1593,7 +1593,7 @@ static void MIXER_MixData(const int frames_requested)
 		mixer.work[pos][1] = frame.right * INT16_MAX;
 
 		pos = (pos + 1) & MIXER_BUFMASK;
-	} */
+	}
 
 	// Capture audio output if requested
 	if (CaptureState & (CAPTURE_WAVE | CAPTURE_VIDEO)) {
@@ -2379,8 +2379,8 @@ void MIXER_Init(Section *sec)
 	configure_chorus(section->Get_string("chorus"));
 
 	// Initialise compressor
-	const auto threshold_db    = -3.0f;
-	const auto ratio           = 4.0f;
+	const auto threshold_db    = -6.0f;
+	const auto ratio           = 2.0f;
 	const auto release_time_ms = 5000.0f;
 	const auto rms_window_ms   = 10.0;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -444,7 +444,7 @@ static void configure_compressor(const bool compressor_enabled)
 
 	const auto _0dbfs_sample_value = INT16_MAX;
 	const auto threshold_db        = -6.0f;
-	const auto ratio               = 2.0f;
+	const auto ratio               = 3.0f;
 	const auto attack_time_ms      = 0.01f;
 	const auto release_time_ms     = 5000.0f;
 	const auto rms_window_ms       = 10.0;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -445,15 +445,17 @@ static void configure_compressor(const bool compressor_enabled)
 	const auto _0dbfs_sample_value = INT16_MAX;
 	const auto threshold_db        = -6.0f;
 	const auto ratio               = 2.0f;
+	const auto attack_time_ms      = 0.01f;
 	const auto release_time_ms     = 5000.0f;
 	const auto rms_window_ms       = 10.0;
 
 	mixer.compressor.Configure(mixer.sample_rate,
-							   _0dbfs_sample_value,
-							   threshold_db,
-							   ratio,
-							   release_time_ms,
-							   rms_window_ms);
+	                           _0dbfs_sample_value,
+	                           threshold_db,
+	                           ratio,
+	                           attack_time_ms,
+	                           release_time_ms,
+	                           rms_window_ms);
 
 	LOG_MSG("MIXER: Master compressor enabled");
 }

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -567,6 +567,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\hardware\adlib_gold.cpp" />
     <ClCompile Include="..\src\hardware\cmos.cpp" />
     <ClCompile Include="..\src\hardware\covox.cpp" />
+    <ClCompile Include="..\src\hardware\compressor.cpp" />
     <ClCompile Include="..\src\hardware\disney.cpp" />
     <ClCompile Include="..\src\hardware\dma.cpp" />
     <ClCompile Include="..\src\hardware\envelope.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClCompile Include="..\src\hardware\covox.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\hardware\compressor.cpp">
+      <Filter>src\hardware</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\hardware\disney.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>


### PR DESCRIPTION
This implements https://github.com/dosbox-staging/dosbox-staging/issues/1743.

The compressor is applied to the master output as the final step before converting the float sample stream to 16-bit integers. Without going into audio-engineering territory much, it acts like the compressor you can enable on many AVR receivers and TVs that evens out the difference between quiet and loud sounds (sometimes they call this feature "night mode", so you can turn down the volume at night and still hear the quiet parts). Another example is the broadcast compressors used by radio channels to ensure an even level of sound so people can hear the quiet parts in noisy environments such as cars, and to even out the level-differences between different songs.

It's important to realise that because this is a fully automatic process, it cannot work wonders. The keyword here is damage mitigation -- it should tuck in overly loud signals very well into the normal 16-bit range instead of letting them clip, and it shouldn't affect normal loud audio that is just a little below the clipping range _too much_. But it _will_ affect it a bit, this is unavoidable (for the record, anything louder than -3dB will be affected progressively as the volume gets louder). However, 90%+ of people won't notice anything about this, but will benefit from the automatic gain reduction on overly loud parts. The release is set relatively slow (5 seconds), but that's more like a "guideline" to the algorithm as it's effectively dynamic and program-dependent. So the volume will slowly creep back to normal levels after loud segments, and the slow release time ensures that audible "volume pumping" artifacts are minimised.

That's about the best we can do without training the users to become amateur audio engineers themselves, and requiring them to tweak the compressor settings for every single song in every single game :sunglasses: For purists, I will add an option to disable the compressor, and I might tweak the settings a bit further later too. But those are small incremental tweaks; I think we should merge this is as soon as possible so people can play around with it and test the performance on a Raspberry, etc.

--------

And now, some example audio!

Below is a comparison of the Dune intro & menu music with and without the compressor. It is important to use the floppy version if you want to reproduce my results, as the CD version scales the master volume back to 25% to avoid severe clipping (not *by* 25%, *to* 25% of the volume of the floppy version! So you can replicate this by setting `mixer master 25` in the floppy version.) Also, you'll only get clipping in the floppy version when using the Adlib Gold emulation -- it doesn't clip at all with regular OPL2/OPL3. That's because in Adlib Gold mode the game boosts the bass by 15dB via the onboard DSP, which is _a lot_! So make sure to set `oplmode = opl3gold` when testing this.

You can also go crazy and set the master volume to 200 or even 400! Yep, the compressor will just deal with it, it's that good :sunglasses: You won't hear any severe distortion, but the volume changes will be like a rollercoaster ride sometimes... (this will never happen under normal circumstances, only when the user messes up the mixer settings).

### Dune (Floppy version) - No compressor

![dune-no-compressor](https://user-images.githubusercontent.com/698770/182618789-1ae9468b-dbd2-4206-ab04-5c03d799e724.png)

[dune-no-compressor.mp3.zip](https://github.com/dosbox-staging/dosbox-staging/files/9251671/dune-no-compressor.mp3.zip)

### Dune (Floppy version) - Compressor

![dune-compressor](https://user-images.githubusercontent.com/698770/182618772-9be1f368-3142-4e82-a915-c24797b9833a.png)

[dune-compressor.mp3.zip](https://github.com/dosbox-staging/dosbox-staging/files/9251674/dune-compressor.mp3.zip)


