### PR TITLE
Fix texture renderer selection

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1692,9 +1692,6 @@ dosurface:
 		break; // SCREEN_SURFACE
 
 	case SCREEN_TEXTURE: {
-		if (sdl.render_driver != "auto")
-			SDL_SetHint(SDL_HINT_RENDER_DRIVER,
-			            sdl.render_driver.c_str());
 		SDL_SetHint(SDL_HINT_RENDER_VSYNC, wants_vsync ? "1" : "0");
 
 		if (!SetupWindowScaled(SCREEN_TEXTURE, false)) {
@@ -3211,6 +3208,13 @@ static void set_output(Section *sec, bool should_stretch_pixels)
 
 	sdl.render_driver = section->Get_string("texture_renderer");
 	lowcase(sdl.render_driver);
+	if (sdl.render_driver != "auto") {
+		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER,
+		                sdl.render_driver.c_str()) == SDL_FALSE) {
+			LOG_WARNING("SDL: Failed to set '%s' texture renderer driver; falling back to automatic selection",
+			            sdl.render_driver.c_str());
+		}
+	}
 
 	sdl.desktop.window.show_decorations = section->Get_bool("window_decorations");
 


### PR DESCRIPTION
Fixes a regression caused by 1a032fd61402dfc819c46d7fcdc08bbc6577d471 (oops). Now it's possible to override SDL renderer backend again.

Thanks @nemo93 for reporting!