### PR TITLE
Add missing mouse button counters update

### DIFF
--- a/src/ints/mouse_dos_driver.cpp
+++ b/src/ints/mouse_dos_driver.cpp
@@ -926,11 +926,13 @@ bool MOUSEDOS_UpdateButtons(const MouseButtons12S new_buttons_12S)
     auto mark_pressed = [](const uint8_t idx) {
         state.last_pressed_x[idx] = get_pos_x();
         state.last_pressed_y[idx] = get_pos_y();
+        ++state.times_pressed[idx];
     };
 
     auto mark_released = [](const uint8_t idx) {
         state.last_released_x[idx] = get_pos_x();
         state.last_released_y[idx] = get_pos_y();
+        ++state.times_released[idx];
     };
 
     if (new_buttons_12S.left && !buttons.left)


### PR DESCRIPTION
Add missing update of mouse button pressed/released counters, omitted by mistake. 

Fixes Days of Tentacle non-working mouse click regression, https://github.com/dosbox-staging/dosbox-staging/issues/1835