### PR TITLE
Test SpeexDSP's floating-point API during Meson setup

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -90,6 +90,7 @@ jobs:
           meson setup \
           -Dbuildtype=debug \
           -Ddefault_library=shared \
+          -Dsystem_libraries=speexdsp \
           -Duse_alsa=false \
           -Duse_fluidsynth=false \
           -Duse_mt32emu=false \

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -65,6 +65,7 @@ jobs:
           CC="clang" CXX="clang++" meson setup \
           -Dbuildtype=debug \
           -Dunit_tests=disabled \
+          -Dsystem_libraries=speexdsp \
           -Ddefault_library=shared \
           -Duse_alsa=false \
           -Duse_fluidsynth=false \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -254,8 +254,6 @@ jobs:
           ${{ matrix.conf.build_flags }}
           -Dwrap_mode=forcefallback -Dtry_static_libs=sdl2,sdl2_net
           build
-          # -Ddefault_library=shared
-          # -Dtry_static_libs=fluidsynth,glib,iir,mt32emu,opusfile,png,sdl2,sdl2_net,slirp,speexdsp,zlib
 
       - name: Build
         run:  arch -arch=${{ matrix.runner.arch }} meson compile -C build

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 265
+          MAX_BUGS: 264
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/BUILD.md
+++ b/BUILD.md
@@ -96,16 +96,16 @@ Please refer to the Tracy documentation for further information.
 ## Repository maintainer / packager builds
 
 Packagers interested in using shared libraries can use
-`-Ddefault_library=shared` and `-Duse_system_libs=lib1,lib2,etc` to
+`-Ddefault_library=shared` and `-Dsystem_libraries=lib1,lib2,etc` to
 ensure specific dependencies are provided by the system instead of
 via the Meson wraps. For example:
 
 ``` shell
-meson setup -Duse_system_libs=fluidsynth,speexdsp build/package
+meson setup -Dsystem_libraries=fluidsynth,speexdsp build/package
 meson compile -C build/package
 ```
 
-For the full list libraries available to use with `-Duse_system_libs`,
+For the full list libraries available to use with `-Dsystem_libraries`,
 see the `meson_options.txt` file. 
 
 Alternately, wraps can be fully disabled using `-Dwrap_mode=nofallback`,

--- a/contrib/check-speexdsp/test_speexdsp_float_api.cpp
+++ b/contrib/check-speexdsp/test_speexdsp_float_api.cpp
@@ -1,0 +1,124 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+// Tests SpeexDSP's floating-point API for value-wrapping
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Usage:
+//    g++ or clang++ \
+//    test_speexdsp_float_api.cpp -lspeexdsp -o test_speexdsp_float_api
+//
+//    ./test_speexdsp_float_api && echo "passed"
+//
+// No output is provided because it's typically run by the build system.
+//
+
+#ifdef NDEBUG
+#	undef NDEBUG
+#endif // Ensure asserts are enabled
+#include <cassert>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+
+#include <speex/speex_resampler.h>
+
+// Resampling quality can range from 0 to 10
+constexpr auto quality = SPEEX_RESAMPLER_QUALITY_DESKTOP;
+
+// Latency rises in proportion to the quality, so we scale the number of frames
+// to ensure we pass enough data through the resampler to get output
+constexpr spx_uint32_t num_frames = 100 * (quality + 1);
+
+// The container type used to hold the input and output array of values
+using frame_array_t = std::array<float, num_frames>;
+
+// Generates a filled array
+static frame_array_t generate_frame_array(const float fill_value)
+{
+	// Ensure our array only has values well-beyond the 16-bit range
+	constexpr auto fifty_percent_beyond_16_bit = 1.5f * INT16_MAX;
+	assert(fabs(fill_value) > fifty_percent_beyond_16_bit);
+
+	frame_array_t frames = {};
+	for (auto &f : frames)
+		f = fill_value;
+	return frames;
+}
+
+int main()
+{
+	// Check our globals
+	static_assert(quality >= SPEEX_RESAMPLER_QUALITY_MIN,
+	              "Quality needs to be >= 0");
+	static_assert(quality <= SPEEX_RESAMPLER_QUALITY_MAX,
+	              "Quality needs to be <= 10");
+	static_assert(num_frames > 0,
+	              "Number of frames needs to be greater than zero");
+
+	// Resampler initialization constants
+	constexpr spx_uint32_t in_channels = 1;
+	constexpr spx_uint32_t in_rate     = 1;
+	constexpr spx_uint32_t out_rate    = 1;
+
+	// Initialize the resampler
+	auto rcode     = static_cast<int>(RESAMPLER_ERR_MAX_ERROR);
+	auto resampler = speex_resampler_init(
+	        in_channels, in_rate, out_rate, quality, &rcode);
+	assert(rcode == RESAMPLER_ERR_SUCCESS);
+	assert(resampler);
+
+	// Prime the resampler with fill content
+	speex_resampler_skip_zeros(resampler);
+
+	// Populate the input buffer with floats larger than 16-bit ints
+	constexpr auto fill_value = 75000.0f;
+	const auto in = generate_frame_array(fill_value);
+	auto in_frames = static_cast<spx_uint32_t>(in.size());
+
+	// Create the output buffer
+	auto out = frame_array_t();
+	auto out_frames = static_cast<spx_uint32_t>(out.size());
+
+	// Resample
+	assert(resampler);
+	rcode = speex_resampler_process_interleaved_float(
+	        resampler, in.data(), &in_frames, out.data(), &out_frames);
+	assert(rcode == RESAMPLER_ERR_SUCCESS);
+
+	// Ensure it produced frames
+	assert(out_frames && out_frames <= out.size());
+
+	// Cleanup
+	speex_resampler_destroy(resampler);
+	resampler = nullptr;
+
+	// Are the resampled values within expected bounds?
+	constexpr auto within_percent = 25.0f;
+	constexpr auto lower_bound = fill_value * (1.0f - within_percent / 100.0f);
+	constexpr auto upper_bound = fill_value * (1.0f + within_percent / 100.0f);
+
+	for (std::size_t i = 0; i < out_frames; ++i)
+		if (out[i] < lower_bound || out[i] > upper_bound)
+			return 1; // Don't trust the floating-point API
+
+	// All values in bounds; floating-point API is reliable
+	return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -347,12 +347,40 @@ zlib_dep = dependency(
     static: ('zlib' in static_libs_list or prefers_static_libs),
 )
 
-speexdsp_dep = dependency(
-    'speexdsp',
-    default_options: ['warning_level=0'],
-    allow_fallback: ('speexdsp' not in system_libs_list),
-    static: ('speexdsp' in static_libs_list or prefers_static_libs),
-)
+# SpeexDSP
+# ~~~~~~~~
+# If the user asked to use SpeexDSP from the system then
+# we need to ensure its floating-point API is reliable
+#
+use_speexdsp_from_system = 'speexdsp' in system_libs_list
+if use_speexdsp_from_system
+    check_cpp = files('contrib/check-speexdsp/test_speexdsp_float_api.cpp')
+    check_if_msg = 'SpeexDSP system library has reliable floating-point API'
+    check_result = cxx.run(
+        check_cpp,
+        dependencies: dependency('speexdsp'),
+        name: check_if_msg,
+    )
+    use_speexdsp_from_system = (
+        check_result.compiled()
+        and check_result.returncode() == 0
+    )
+endif
+if use_speexdsp_from_system
+    speexdsp_dep = dependency(
+        'speexdsp',
+        allow_fallback: false,
+        static: ('speexdsp' in static_libs_list or prefers_static_libs),
+    )
+    speexdsp_summary_msg = 'system library'
+else
+    speexdsp_dep = subproject(
+        'speexdsp',
+        default_options: ['default_library=static', 'warning_level=0'],
+    ).get_variable('speexdsp_dep')
+    speexdsp_summary_msg = 'built-in'
+endif
+summary('SpeexDSP provider', speexdsp_summary_msg)
 
 # Optional libraries
 optional_dep = dependency('', required: false)

--- a/meson.build
+++ b/meson.build
@@ -307,7 +307,7 @@ threads_dep = dependency('threads')
 
 # 3rd party libraries
 static_libs_list = get_option('try_static_libs')
-system_libs_list = get_option('use_system_libs')
+system_libs_list = get_option('system_libraries')
 
 wants_tests = true
 # tests are disabled for release builds unless requested

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,7 +108,7 @@ option(
 )
 
 option(
-    'use_system_libs',
+    'system_libraries',
     type: 'array',
     choices: [
         'fluidsynth',


### PR DESCRIPTION
Rasbian's SpeexDSP package has an unreliable floating-point interface.

This PR tests the system library first, before trusting it. If the test fails, Meson falls back to using the built-in wrap.
