### PR TITLE
Fix residfp regression

### DIFF
--- a/src/libs/residfp/array.h
+++ b/src/libs/residfp/array.h
@@ -43,13 +43,14 @@ class matrix
 {
 private:
     T* data = nullptr;
-    counter count = {};
+    counter* count = nullptr;
     const unsigned int x = 0;
     const unsigned int y = 0;
 
 public:
     matrix(unsigned int x, unsigned int y) :
         data(new T[x * y]),
+		count(new counter()),
         x(x),
         y(y) {}
 
@@ -57,9 +58,17 @@ public:
         data(p.data),
         count(p.count),
         x(p.x),
-        y(p.y) { count.increase(); }
+        y(p.y) { count->increase(); }
 
-    ~matrix() { if (count.decrease() == 0) { delete [] data; data = nullptr; } }
+    ~matrix() {
+		if (count->decrease() == 0) {
+			delete [] data;
+			data = nullptr;
+
+			delete count;
+			count = nullptr;
+		}
+	}
 
     matrix &operator=(const matrix&) = delete; // prevent assignment
 


### PR DESCRIPTION
Reverting an earlier refactoring that broke residfp's `TwoPassSinceResampler`. This completely broke the audio generation for the PS/1 Audio, Innovation, Game Blaster, and Tandy sound card emulations.

For example, this is how the intro music of Maniac Mansion Enhanced sounds without the fix (test on macOS / Intel). Make sure to use `machine = tandy` if you want to reproduce it as the game can also use the PC speaker on non-Tandy machines.

[maniac-tandy-bad.mp3.zip](https://github.com/dosbox-staging/dosbox-staging/files/9330953/maniac-tandy-bad.mp3.zip)

By the way, the refactoring looks good on the surface, so I'm not quite sure what's wrong with it, but it definitely breaks something in the bowels of residfp... Probably not that much worth wasting a lot of time on finding the exact cause because the refactoring is not really necessary 🤷🏻 