### PR TITLE
Mouse code simplification, fix for rare cases of stuck "fire" in DOOM

### DIFF
--- a/src/ints/mouse_core.h
+++ b/src/ints/mouse_core.h
@@ -254,8 +254,8 @@ bool MOUSEDOS_NotifyMoved(const float x_rel,
                           const uint16_t y_abs);
 bool MOUSEDOS_NotifyWheel(const int16_t w_rel);
 
-bool MOUSEDOS_UpdateMoved();
-bool MOUSEDOS_UpdateButtons(const MouseButtons12S buttons_12S);
-bool MOUSEDOS_UpdateWheel();
+uint8_t MOUSEDOS_UpdateMoved();
+uint8_t MOUSEDOS_UpdateButtons(const MouseButtons12S buttons_12S);
+uint8_t MOUSEDOS_UpdateWheel();
 
 #endif // DOSBOX_MOUSE_CORE_H


### PR DESCRIPTION
1. Removed code which (intentionally) sometimes forwarded mouse clicks to a game with frequency higher than emulated mouse sampling rate. This code increases complication, and with 200 Hz sampling rate being the default it has almost no effect nevertheless (in 25% of cases where mouse button was pressed/released while the mouse was being moved, it would report the event to the game 1 millisecond earlier).

2. Do not queue mouse button presses; the code here was really complicated, and the only "benefit" was that mouse click-release or release-click cycle that was shorter than sampling period (5 milliseconds for 200 Hz rate) wouldn't be forgotten.
This is not how the real mouse hardware works - if mouse clicks last that short, it means the switches are broken and need replacing; I admit I don't understand why the original DOSBox implemented this in the first place.
Moreover, the code most likely had some subtle bugs - on current 'main' I could observe that "fire" could got stuck in DOOM in very rare cases, if mouse button was pressed for prolonged time while moving the mouse at the same time; after removal of the queuing code I can no longer reproduce the problem.