### PR TITLE
Use a shared pointer to ref-count residfp's matrix data

### DIFF
--- a/src/libs/residfp/array.h
+++ b/src/libs/residfp/array.h
@@ -43,13 +43,14 @@ class matrix
 {
 private:
     T* data = nullptr;
-    counter count = {};
+    counter* count = nullptr;
     const unsigned int x = 0;
     const unsigned int y = 0;
 
 public:
     matrix(unsigned int x, unsigned int y) :
         data(new T[x * y]),
+		count(new counter()),
         x(x),
         y(y) {}
 
@@ -57,9 +58,17 @@ public:
         data(p.data),
         count(p.count),
         x(p.x),
-        y(p.y) { count.increase(); }
+        y(p.y) { count->increase(); }
 
-    ~matrix() { if (count.decrease() == 0) { delete [] data; data = nullptr; } }
+    ~matrix() {
+		if (count->decrease() == 0) {
+			delete [] data;
+			data = nullptr;
+
+			delete count;
+			count = nullptr;
+		}
+	}
 
     matrix &operator=(const matrix&) = delete; // prevent assignment
 

--- a/src/libs/residfp/array.h
+++ b/src/libs/residfp/array.h
@@ -21,62 +21,55 @@
 #ifndef ARRAY_H
 #define ARRAY_H
 
-/**
- * Counter.
- */
-class counter
-{
-private:
-    unsigned int c = 0;
+#include <cassert>
+#include <memory>
+#include <vector>
 
-public:
-    counter() : c(1) {}
-    void increase() { ++c; }
-    unsigned int decrease() { return --c; }
-};
-
-/**
- * Reference counted pointer to matrix wrapper, for use with standard containers.
+/*
+ * Matrix wrapper using a shared pointer to data, for use with standard containers.
  */
 template<typename T>
 class matrix
 {
 private:
-    T* data = nullptr;
-    counter* count = nullptr;
+    using data_t = std::vector<T>;
+    using data_ptr_t = std::shared_ptr<data_t>;
+
+    const data_ptr_t data_ptr = {};
     const unsigned int x = 0;
     const unsigned int y = 0;
 
+    void check_dimensions() {
+       // debug-only check
+       assert(data_ptr);
+       assert(x * y == data_ptr->size());
+    }
+
 public:
     matrix(unsigned int x, unsigned int y) :
-        data(new T[x * y]),
-		count(new counter()),
+        data_ptr(std::make_shared<data_t>(x * y, 0)),
         x(x),
-        y(y) {}
+        y(y) { check_dimensions(); }
 
+    // copy-constructor
     matrix(const matrix& p) :
-        data(p.data),
-        count(p.count),
+        data_ptr(p.data_ptr), // data is reference-counted
         x(p.x),
-        y(p.y) { count->increase(); }
+        y(p.y) { check_dimensions(); }
 
-    ~matrix() {
-		if (count->decrease() == 0) {
-			delete [] data;
-			data = nullptr;
-
-			delete count;
-			count = nullptr;
-		}
-	}
-
+    matrix() = delete; // prevent default-construction
     matrix &operator=(const matrix&) = delete; // prevent assignment
 
-    unsigned int length() const { return x * y; }
+    unsigned int length() const { return static_cast<unsigned int>(data_ptr->size()); }
 
-    T* operator[](unsigned int a) { return &data[a * y]; }
+    T* operator[](unsigned int a) {
+        const auto index = a * y;
+        assert(index < length());
+        return data_ptr->data() + index;
+    }
 
-    T const* operator[](unsigned int a) const { return &data[a * y]; }
+    // Reuse the [] operate for const access
+    T const* operator[](unsigned int a) const { return this[a * y]; }
 };
 
 typedef matrix<short> matrix_t;


### PR DESCRIPTION
Builds on the regression fixed by @johnnovak in https://github.com/dosbox-staging/dosbox-staging/pull/1849.
 - Addresses the GCC compiler error regarding `use-after-free`.
 - Uses a const shared_pointer, to guarantee the content is never changes after construction.
 - Uses a vector as the underlying container being managed by the shared pointer.
 - Checks the consistency in both constructors to guarantee the vector is sized per the matrix's x & y dimensions.

This is a temporary PR until we see how it's fixed upstream. 