### PR TITLE
Reduce MIDI rendering chunk sizes

### DIFF
--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -39,8 +39,7 @@
 #include "../ints/int10.h"
 #include "string_utils.h"
 
-
-static constexpr int FRAMES_PER_BUFFER = 512; // synth granularity
+static constexpr int FRAMES_PER_BUFFER = 48; // synth granularity
 
 MidiHandlerFluidsynth instance;
 

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -63,7 +63,7 @@ private:
 	std::string selected_font = "";
 
 	std::vector<float> play_buffer = {};
-	static constexpr auto num_buffers = 8;
+	static constexpr auto num_buffers = 20;
 	RWQueue<std::vector<float>> playable{num_buffers};
 	RWQueue<std::vector<float>> backstock{num_buffers};
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -49,8 +49,7 @@
 // Synth granularity in frames. We keep four buffers in-flight at any given
 // time: when playback exhausts the "head" buffer, we ask MT-32 to render the
 // next buffer, asynchronously, which is then placed at the back of the queue.
-// These four buffers mean we typically have 2048 frames or ~48 ms in backlog.
-static constexpr int FRAMES_PER_BUFFER = 512;
+static constexpr int FRAMES_PER_BUFFER = 48;
 
 // Analogue circuit modes: DIGITAL_ONLY, COARSE, ACCURATE, OVERSAMPLED
 constexpr auto ANALOG_MODE = MT32Emu::AnalogOutputMode_ACCURATE;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -67,7 +67,7 @@ private:
 	mixer_channel_t channel = nullptr;
 
 	std::vector<float> play_buffer = {};
-	static constexpr auto num_buffers = 4;
+	static constexpr auto num_buffers = 20;
 	RWQueue<std::vector<float>> playable{num_buffers};
 	RWQueue<std::vector<float>> backstock{num_buffers};
 


### PR DESCRIPTION
DOSBox's auto-cycler can allow up to 15 ticks of play before reducing cycles, so we use this plus a bit more (20 ms) as our rendering queue (or about 1.5 video frames @ 70Hz worth).
