### PR TITLE
Restore bottom six channel output to CMS/Gameblaster emulation

### DIFF
--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -133,21 +133,24 @@ bool GameBlaster::MaybeRenderFrame(AudioFrame &frame)
 	static int16_t *p_buf[]           = {&buf[0], &buf[1]};
 	static device_sound_interface::sound_stream stream;
 
+	int16_t leftAccum = 0;
+	int16_t rightAccum = 0;
+
 	// Accumulate the samples from both SAA-1099 devices
 	devices[0]->sound_stream_update(stream, 0, p_buf, 1);
-	frame.left  = buf[0];
-	frame.right = buf[1];
+	leftAccum = buf[0];
+	rightAccum = buf[1];
 
 	devices[1]->sound_stream_update(stream, 0, p_buf, 1);
-	frame.left += buf[0];
-	frame.right += buf[1];
+	leftAccum += buf[0];
+	rightAccum += buf[1];
 
 	// Increment our time datum up to which the device has rendered
 	last_rendered_ms += ms_per_render;
 
 	// Resample the limited frame
-	const auto l_ready = resamplers[0]->input(buf[0]);
-	const auto r_ready = resamplers[1]->input(buf[1]);
+	const auto l_ready = resamplers[0]->input(leftAccum);
+	const auto r_ready = resamplers[1]->input(rightAccum);
 	assert(l_ready == r_ready);
 	const auto frame_is_ready = l_ready && r_ready;
 

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -135,8 +135,8 @@ bool GameBlaster::MaybeRenderFrame(AudioFrame &frame)
 
 	// Accumulate the samples from both SAA-1099 devices
 	devices[0]->sound_stream_update(stream, 0, p_buf, 1);
-	int16_t left_accum = buf[0];
-	int16_t right_accum = buf[1];
+	int left_accum = buf[0];
+	int right_accum = buf[1];
 
 	devices[1]->sound_stream_update(stream, 0, p_buf, 1);
 	left_accum += buf[0];

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -133,24 +133,21 @@ bool GameBlaster::MaybeRenderFrame(AudioFrame &frame)
 	static int16_t *p_buf[]           = {&buf[0], &buf[1]};
 	static device_sound_interface::sound_stream stream;
 
-	int16_t leftAccum = 0;
-	int16_t rightAccum = 0;
-
 	// Accumulate the samples from both SAA-1099 devices
 	devices[0]->sound_stream_update(stream, 0, p_buf, 1);
-	leftAccum = buf[0];
-	rightAccum = buf[1];
+	int16_t left_accum = buf[0];
+	int16_t right_accum = buf[1];
 
 	devices[1]->sound_stream_update(stream, 0, p_buf, 1);
-	leftAccum += buf[0];
-	rightAccum += buf[1];
+	left_accum += buf[0];
+	right_accum += buf[1];
 
 	// Increment our time datum up to which the device has rendered
 	last_rendered_ms += ms_per_render;
 
 	// Resample the limited frame
-	const auto l_ready = resamplers[0]->input(leftAccum);
-	const auto r_ready = resamplers[1]->input(rightAccum);
+	const auto l_ready = resamplers[0]->input(left_accum);
+	const auto r_ready = resamplers[1]->input(right_accum);
 	assert(l_ready == r_ready);
 	const auto frame_is_ready = l_ready && r_ready;
 


### PR DESCRIPTION
In the existing codebase samples are read from the first and second device in order into the `buf` static array. They're assigned and accumulated into `frame.left` and `frame.right` respectively but this value is thrown away. On lines 149 and 150 only the samples stored in the `buf` array are submitted to the resamplers for output. With output from the resamplers, the `frame.left` and `frame.right` values are overwritten.

**The consequence of the existing code is that only the top six channels on the CMS/Gameblaster can be heard.** The fix here is to prevent trampling and the actual use of the combined values from the resampler. This is confirmed correct by comparing output of youtube videos of Silpheed with the actual audible output. 