### PR TITLE
Fix a regression in the composite color palette calculation

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -192,6 +192,14 @@ constexpr void clear(T &reg, const unsigned int bits)
 	reg = mask_off(reg, bits);
 }
 
+// Retain only the indicated bits, clearing the others
+template <typename T>
+constexpr void retain(T &reg, const unsigned int bits)
+{
+	check_width(reg, bits);
+	reg = reg & static_cast<T>(bits);
+}
+
 // Set the indicated bits to the given bool value
 template <typename T, typename S>
 constexpr T mask_to(const T reg, const unsigned int bits, const S state)

--- a/include/mem.h
+++ b/include/mem.h
@@ -174,7 +174,7 @@ static inline void real_writed(uint16_t seg, uint16_t off, uint32_t val)
 
 static inline uint16_t RealSeg(RealPt pt)
 {
-	return pt >> 16;
+	return static_cast<uint16_t>(pt >> 16);
 }
 
 static inline uint16_t RealOff(RealPt pt)

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1168,9 +1168,10 @@ static void write_pcjr(io_port_t port, io_val_t value, io_width_t)
 			write_tandy_reg(val);
 		else {
 			vga.tandy.reg_index = val;
-			if (vga.tandy.reg_index & 0x10)
-				vga.attr.disabled |= 2;
-			else vga.attr.disabled &= ~2;
+			if (is(vga.tandy.reg_index, b4))
+				set(vga.attr.disabled, b1);
+			else
+				clear(vga.attr.disabled, b1);
 		}
 		vga.tandy.pcjr_flipflop=!vga.tandy.pcjr_flipflop;
 		break;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1303,35 +1303,35 @@ static void write_hercules(io_port_t port, io_val_t value, io_width_t)
 	case 0x3b8: {
 		// the protected bits can always be cleared but only be set if the
 		// protection bits are set
-		if (vga.herc.mode_control&0x2) {
+		if (is(vga.herc.mode_control, b1)) {
 			// already set
-			if (!(val&0x2)) {
-				vga.herc.mode_control &= ~0x2;
+			if (cleared(val, b1)) {
+				clear(vga.herc.mode_control, b1);
 				VGA_SetMode(M_HERC_TEXT);
 			}
 		} else {
 			// not set, can only set if protection bit is set
-			if ((val & 0x2) && (vga.herc.enable_bits & 0x1)) {
-				vga.herc.mode_control |= 0x2;
+			if (is(val, b1) && is(vga.herc.enable_bits, b0)) {
+				set(vga.herc.mode_control, b1);
 				VGA_SetMode(M_HERC_GFX);
 			}
 		}
-		if (vga.herc.mode_control&0x80) {
-			if (!(val&0x80)) {
-				vga.herc.mode_control &= ~0x80;
+		if (is(vga.herc.mode_control, b7)) {
+			if (cleared(val, b7)) {
+				clear(vga.herc.mode_control, b7);
 				vga.tandy.draw_base = &vga.mem.linear[0];
 			}
 		} else {
-			if ((val & 0x80) && (vga.herc.enable_bits & 0x2)) {
-				vga.herc.mode_control |= 0x80;
-				vga.tandy.draw_base = &vga.mem.linear[32*1024];
+			if (is(val, b7) && is(vga.herc.enable_bits, b1)) {
+				set(vga.herc.mode_control, b7);
+				vga.tandy.draw_base = &vga.mem.linear[32 * 1024];
 			}
 		}
-		vga.draw.blinking = (val&0x20)!=0;
-		vga.herc.mode_control &= 0x82;
-		vga.herc.mode_control |= val & ~0x82;
+		vga.draw.blinking = is(val, b5);
+		retain(vga.herc.mode_control, b7 | b1);
+		set(vga.herc.mode_control, mask_off(val, b7 | b1));
 		break;
-		}
+	}
 	case 0x3bf:
 		if ( vga.herc.enable_bits ^ val) {
 			vga.herc.enable_bits=val;

--- a/tests/bitops_tests.cpp
+++ b/tests/bitops_tests.cpp
@@ -279,6 +279,20 @@ TEST(bitops, bits_not_too_wide_for_dword)
 	EXPECT_TRUE(bit::is(reg, b8 | b24 | b31));
 }
 
+// Retain operations
+TEST(bitops, retain)
+{
+	// Retain a positive bit, with surrounding other bits
+	uint8_t reg = (b0 | b1 | b2);
+	bit::retain(reg, b1);
+	EXPECT_EQ(reg, b1);
+
+	// Retain a negative bit, with surrounding other bits
+	reg = (b0 | b1 | b2 | b3 /*| b4*/ | b5 | b6 | b7);
+	bit::retain(reg, b4);
+	EXPECT_EQ(reg, 0);
+}
+
 // Masking operations
 TEST(bitops, masking)
 {


### PR DESCRIPTION
When built with optimizations, the red composite 8-bit palette index could rollover from 255 to 0 as a result of prior floating point calculations.

In tracking this down, I also added checks for type narrowing, so this PR includes those cleanups as well (most of which involve loss-of-precision warnings when performing bit operations on 8-bit values).

Thanks to @jkapp76 for flagging this!

Fixes #1874.




