### PR TITLE
More HiDPI work

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3820,11 +3820,17 @@ bool GFX_Events()
 				// DEBUG_LOG_MSG("SDL: Window has been hidden");
 				continue;
 
-#if 0 // ifdefed out only because it's too noisy
+#if defined C_OPENGL && defined __APPLE__
 			case SDL_WINDOWEVENT_MOVED:
 				// DEBUG_LOG_MSG("SDL: Window has been moved to %d, %d",
 				//               event.window.data1,
 				//               event.window.data2);
+				if (sdl.desktop.type == SCREEN_OPENGL) {
+					glViewport(sdl.clip.x,
+					           sdl.clip.y,
+					           sdl.clip.w,
+					           sdl.clip.h);
+				}
 				continue;
 #endif
 


### PR DESCRIPTION
This PR introduces basic handling of multi-display setups, and also adds a workaround for viewport resetting on macOS.

In multi-display setups, different monitors may have different DPI and resolution set. SDL 2.0.18 introduced an event for that, so now we detect when the window is moved to another display and adjust settings accordingly. No change for earlier SDL versions, and single-display setups are unaffected.

On macOS with a window created with a High DPI flag, with OpenGL output set, moving the window resets its viewport, which leads to image stretching. This workaround just sets the viewport on each window move, until a proper fix is available.