### PR TITLE
Implement 'modern' Sound Blaster filter

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -296,14 +296,14 @@ private:
 	struct {
 		SpeexResamplerState *state = nullptr;
 	} speex_resampler = {};
-	bool do_resampler = false;
+	bool do_resample = false;
 
 	struct {
 		uint16_t target_freq = 0;
 		float pos = 0.0f;
 		float step = 0.0f;
 	} zoh_upsampler = {};
-	bool do_zoh_upsampler = false;
+	bool do_zoh_upsample = false;
 
 	struct {
 		struct {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -303,8 +303,8 @@ private:
 	bool last_samples_were_stereo = false;
 	bool last_samples_were_silence = true;
 
-
 	ResampleMethod resample_method = {};
+	bool do_resample               = false;
 
 	struct {
 		float pos = 0.0f;
@@ -321,8 +321,6 @@ private:
 	struct {
 		SpeexResamplerState *state = nullptr;
 	} speex_resampler = {};
-
-	bool do_resample = false;
 
 	struct {
 		struct {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -52,16 +52,6 @@ typedef void (*MIXER_MixHandler)(uint8_t *sampdate, uint32_t len);
 // 48000 Hz, that's 48 frames.
 using MIXER_Handler = std::function<void(uint16_t frames)>;
 
-enum BlahModes {
-	MIXER_8MONO,MIXER_8STEREO,
-	MIXER_16MONO,MIXER_16STEREO
-};
-
-enum MixerModes {
-	M_8M,M_8S,
-	M_16M,M_16S
-};
-
 enum class MixerState {
 	Uninitialized,
 	NoSound,
@@ -292,6 +282,9 @@ private:
 
 	bool last_samples_were_stereo = false;
 	bool last_samples_were_silence = true;
+
+
+
 
 	struct {
 		SpeexResamplerState *state = nullptr;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -137,8 +137,21 @@ using channel_features_t = std::set<ChannelFeature>;
 enum class FilterState { Off, On, ForcedOn };
 
 enum class ResampleMethod {
+	// Use simple linear interpolation to resample from the channel sample
+	// rate to the mixer rate. This is the legacy behaviour, and it acts as a
+	// sort of a low-pass filter.
 	LinearInterpolation,
+
+	// Upsample from the channel sample rate to the zero-order-hold target
+	// frequency first (this is basically the "nearest-neighbour" equivalent
+	// in audio), then resample to the mixer rate with Speex. This method
+	// faithfully emulates the metallic, crunchy sound of old DACs.
 	ZeroOrderHoldAndResample,
+
+	// Resample from the channel sample rate to the mixer rate with Speex.
+	// This is mathematically correct, high-quality resampling that cuts all
+	// frequencies below the Nyquist frequency using a brickwall filter
+	// (everything below half the channel's sample rate is cut).
 	Resample
 };
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -191,7 +191,7 @@ public:
 	bool TryParseAndSetCustomFilter(const std::string &filter_prefs);
 
 	void SetResampleMethod(const ResampleMethod method);
-	void ConfigureZeroOrderHoldUpsampler(const uint16_t target_freq);
+	void SetZeroOrderHoldUpsamplerTargetFreq(const uint16_t target_freq);
 
 	void SetCrossfeedStrength(const float strength);
 	float GetCrossfeedStrength();
@@ -252,7 +252,8 @@ private:
 
 	void ConfigureResampler();
 	void ClearResampler();
-	void UpdateZOHUpsamplerState();
+	void InitZohUpsamplerState();
+	void InitLerpUpsamplerState();
 
 	AudioFrame ApplyCrossfeed(const AudioFrame &frame) const;
 
@@ -306,15 +307,22 @@ private:
 	ResampleMethod resample_method = {};
 
 	struct {
-		SpeexResamplerState *state = nullptr;
-	} speex_resampler = {};
-	bool do_resample = false;
+		float pos = 0.0f;
+		float step = 0.0f;
+		AudioFrame last_frame = {};
+	} lerp_upsampler = {};
 
 	struct {
 		uint16_t target_freq = 0;
 		float pos = 0.0f;
 		float step = 0.0f;
 	} zoh_upsampler = {};
+
+	struct {
+		SpeexResamplerState *state = nullptr;
+	} speex_resampler = {};
+
+	bool do_resample = false;
 
 	struct {
 		struct {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -303,7 +303,7 @@ private:
 	bool last_samples_were_silence = true;
 
 
-
+	ResampleMethod resample_method = {};
 
 	struct {
 		SpeexResamplerState *state = nullptr;
@@ -315,7 +315,6 @@ private:
 		float pos = 0.0f;
 		float step = 0.0f;
 	} zoh_upsampler = {};
-	bool do_zoh_upsample = false;
 
 	struct {
 		struct {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -295,7 +295,7 @@ private:
 
 	struct {
 		SpeexResamplerState *state = nullptr;
-	} resampler = {};
+	} speex_resampler = {};
 	bool do_resampler = false;
 
 	struct {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -136,6 +136,12 @@ using channel_features_t = std::set<ChannelFeature>;
 
 enum class FilterState { Off, On, ForcedOn };
 
+enum class ResampleMethod {
+	LinearInterpolation,
+	ZeroOrderHoldAndResample,
+	Resample
+};
+
 using work_index_t = uint16_t;
 
 // forward declarations
@@ -171,7 +177,7 @@ public:
 	void ConfigureLowPassFilter(const uint8_t order, const uint16_t cutoff_freq);
 	bool TryParseAndSetCustomFilter(const std::string &filter_prefs);
 
-	void EnableZeroOrderHoldUpsampler(const bool enabled = true);
+	void SetResampleMethod(const ResampleMethod method);
 	void ConfigureZeroOrderHoldUpsampler(const uint16_t target_freq);
 
 	void SetCrossfeedStrength(const float strength);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -868,7 +868,7 @@ void DOSBOX_Init() {
 	        "                lpf 2 12000\n"
 	        "                hpf 3 120 lfp 1 6500");
 
-	Pbool = secprop->Add_bool("sb_filter_always_on", when_idle, true);
+	Pbool = secprop->Add_bool("sb_filter_always_on", when_idle, false);
 	Pbool->Set_help("Force the Sound Blaster filter to be always on\n"
 					"(disallow programs from turning the filter off).");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -850,12 +850,14 @@ void DOSBOX_Init() {
 	Pstring = secprop->Add_string("oplemu", deprecated, "");
 	Pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
 
-	Pstring = secprop->Add_string("sb_filter", when_idle, "auto");
+	Pstring = secprop->Add_string("sb_filter", when_idle, "modern");
 	Pstring->Set_help(
 	        "Type of filter to emulate for the Sound Blaster digital sound output:\n"
-	        "  auto:      Use the appropriate filter determined by 'sbtype' (default).\n"
+	        "  auto:      Use the appropriate filter determined by 'sbtype'.\n"
 	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
 	        "             Use the filter of this Sound Blaster model.\n"
+	        "  modern:    Use linear interpolation upsampling that acts as a low-pass filter;\n"
+	        "             this is the legacy DOSBox behaviour (default).\n"
 	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  One or two custom filters in the following format:\n"
 	        "               TYPE ORDER FREQ\n"

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -48,8 +48,8 @@ void Disney::ConfigureFilters(const FilterState state)
 	assert(channel);
 	// Run the ZoH up-sampler at the higher mixer rate
 	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 	channel->ConfigureZeroOrderHoldUpsampler(mixer_rate_hz);
-	channel->EnableZeroOrderHoldUpsampler();
 
 	// Pull audio frames from the Disney DAC at 7 kHz
 	channel->SetSampleRate(dss_7khz_rate);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -49,8 +49,8 @@ void Disney::ConfigureFilters(const FilterState state)
 
 	// Run the ZoH up-sampler at the higher mixer rate
 	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
-	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 	channel->SetZeroOrderHoldUpsamplerTargetFreq(mixer_rate_hz);
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 
 	// Pull audio frames from the Disney DAC at 7 kHz
 	channel->SetSampleRate(dss_7khz_rate);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -46,10 +46,11 @@ void Disney::BindToPort(const io_port_t lpt_port)
 void Disney::ConfigureFilters(const FilterState state)
 {
 	assert(channel);
+
 	// Run the ZoH up-sampler at the higher mixer rate
 	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
-	channel->ConfigureZeroOrderHoldUpsampler(mixer_rate_hz);
+	channel->SetZeroOrderHoldUpsamplerTargetFreq(mixer_rate_hz);
 
 	// Pull audio frames from the Disney DAC at 7 kHz
 	channel->SetSampleRate(dss_7khz_rate);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -965,9 +965,10 @@ void MixerChannel::ConfigureZeroOrderHoldUpsampler(const uint16_t target_freq)
 	UpdateZOHUpsamplerState();
 }
 
-void MixerChannel::EnableZeroOrderHoldUpsampler(const bool enabled)
+
+void MixerChannel::SetResampleMethod(const ResampleMethod method)
 {
-	do_zoh_upsample = enabled;
+	do_zoh_upsample = (method == ResampleMethod::ZeroOrderHoldAndResample);
 
 	if (!do_zoh_upsample) {
 		// DEBUG_LOG_MSG("%s: Zero-order-hold upsampler is off",

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -926,8 +926,9 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string &filter_prefs)
 			return false;
 		}
 
-		const auto do_zoh_upsample = (resample_method ==
-		                              ResampleMethod::ZeroOrderHoldAndResample);
+		const auto do_zoh_upsample = do_resample &&
+		                             resample_method ==
+		                                     ResampleMethod::ZeroOrderHoldAndResample;
 
 		const auto max_cutoff_freq_hz = (do_zoh_upsample ? zoh_upsampler.target_freq
 		                                                 : sample_rate) / 2 - 1;
@@ -1315,7 +1316,8 @@ void MixerChannel::ConvertSamples(const Type *data, const uint16_t frames,
 		out.emplace_back(out_frame[0]);
 		out.emplace_back(out_frame[1]);
 
-		if (resample_method == ResampleMethod::ZeroOrderHoldAndResample) {
+		if (do_resample &&
+		    resample_method == ResampleMethod::ZeroOrderHoldAndResample) {
 			zoh_upsampler.pos += zoh_upsampler.step;
 			if (zoh_upsampler.pos > 1.0f) {
 				zoh_upsampler.pos -= 1.0f;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1430,11 +1430,11 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type *data)
 			auto &out = mixer.resample_out;
 			out.resize(0);
 
-			AudioFrame curr_frame = {*in_pos, *(in_pos + 1)};
-
 			out_frames = 0;
 
 			while (in_pos != mixer.resample_temp.end()) {
+				AudioFrame curr_frame = {*in_pos, *(in_pos + 1)};
+
 				const auto out_left = lerp(s.last_frame.left,
 				                           curr_frame.left,
 				                           s.pos);
@@ -1451,10 +1451,10 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type *data)
 
 				if (s.pos > 1.0f) {
 					s.pos -= 1.0f;
+					s.last_frame = curr_frame;
+
 					// Move to the next input frame
 					in_pos += 2;
-					s.last_frame = curr_frame;
-					curr_frame   = {*in_pos, *(in_pos + 1)};
 				}
 			}
 		} break;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -633,11 +633,9 @@ void MixerChannel::Enable(const bool should_enable)
 
 void MixerChannel::ConfigureResampler()
 {
-	const auto do_zoh_upsample = (resample_method ==
-	                              ResampleMethod::ZeroOrderHoldAndResample);
-
-	const auto in_rate = do_zoh_upsample ? zoh_upsampler.target_freq
-	                                     : sample_rate;
+	const auto in_rate = (resample_method == ResampleMethod::ZeroOrderHoldAndResample)
+	                           ? zoh_upsampler.target_freq
+	                           : sample_rate;
 
 	const auto out_rate = mixer.sample_rate.load();
 
@@ -931,9 +929,8 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string &filter_prefs)
 		const auto do_zoh_upsample = (resample_method ==
 		                              ResampleMethod::ZeroOrderHoldAndResample);
 
-		const auto max_cutoff_freq_hz = (do_zoh_upsample
-		                                         ? zoh_upsampler.target_freq
-		                                         : sample_rate) / 2 - 1;
+		const auto max_cutoff_freq_hz = (do_zoh_upsample ? zoh_upsampler.target_freq
+		                                                 : sample_rate) / 2 - 1;
 
 		if (cutoff_freq_hz > max_cutoff_freq_hz) {
 			LOG_WARNING("%s: Invalid custom filter cutoff frequency: '%s'. "
@@ -1454,7 +1451,7 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type *data)
 
 				if (s.pos > 1.0f) {
 					s.pos -= 1.0f;
-					// Move to the next input sample
+					// Move to the next input frame
 					in_pos += 2;
 					s.last_frame = curr_frame;
 					curr_frame   = {*in_pos, *(in_pos + 1)};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -847,9 +847,9 @@ void MixerChannel::ConfigureLowPassFilter(const uint8_t order,
 	filters.lowpass.cutoff_freq = cutoff_freq;
 }
 
-// Tries to set custom filter settings for the channel from the passed in
-// filter preferences. Returns true if the custom filters could be successfully
-// set, false otherwise and disabled all filters for the channel.
+// Tries to set custom filter settings from the passed in filter preferences.
+// Returns true if the custom filters could be successfully set, false
+// otherwise and disables all filters for the channel.
 bool MixerChannel::TryParseAndSetCustomFilter(const std::string &filter_prefs)
 {
 	SetLowPassFilter(FilterState::Off);

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -932,7 +932,7 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 
 	MAPPER_AddHandler(OPL_SaveRawEvent, SDL_SCANCODE_UNKNOWN, 0, "caprawopl", "Rec. OPL");
 
-	LOG_MSG("OPL: Mode: %s", opl_mode_to_string(mode).c_str());
+	LOG_MSG("OPL: Using OPL mode %s", opl_mode_to_string(mode).c_str());
 }
 
 OPL::~OPL()

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -347,8 +347,8 @@ struct FilterConfig {
 	uint8_t lpf_order           = {};
 	uint16_t lpf_cutoff_freq_hz = {};
 
-	bool zoh_upsampler_enabled = false;
-	uint16_t zoh_rate_hz       = {};
+	ResampleMethod resample_method = {};
+	uint16_t zoh_rate_hz           = {};
 };
 
 static void set_filter(mixer_channel_t channel, const FilterConfig &config)
@@ -367,12 +367,10 @@ static void set_filter(mixer_channel_t channel, const FilterConfig &config)
 	}
 	channel->SetLowPassFilter(config.lpf_state);
 
-	if (config.zoh_upsampler_enabled) {
-		channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
-		channel->ConfigureZeroOrderHoldUpsampler(config.zoh_rate_hz);
-	} else {
-		channel->SetResampleMethod(ResampleMethod::Resample);
-	}
+	if (config.resample_method == ResampleMethod::ZeroOrderHoldAndResample)
+		channel->SetZeroOrderHoldUpsamplerTargetFreq(config.zoh_rate_hz);
+
+	channel->SetResampleMethod(config.resample_method);
 }
 
 static std::optional<FilterType> determine_filter_type(const std::string &filter_choice,
@@ -415,14 +413,13 @@ static std::optional<FilterType> determine_filter_type(const std::string &filter
 
 static void configure_sb_filter(mixer_channel_t channel,
                                 const std::string &filter_prefs,
-								const bool filter_always_on,
-                                const SB_TYPES sb_type)
+                                const bool filter_always_on, const SB_TYPES sb_type)
 {
 	// A bit unfortunate, but we need to enable the ZOH upsampler and the the
 	// correct upsample rate first for the filter cutoff frequency validation
 	// to work correctly.
-	channel->ConfigureZeroOrderHoldUpsampler(native_dac_rate_hz);
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
+	channel->SetZeroOrderHoldUpsamplerTargetFreq(native_dac_rate_hz);
 
 	if (channel->TryParseAndSetCustomFilter(filter_prefs))
 		return;
@@ -432,6 +429,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 	const auto filter_choice = filter_prefs_parts.empty()
 	                                 ? "auto"
 	                                 : filter_prefs_parts[0];
+
 	FilterConfig config = {};
 
 	auto enable_lpf = [&](const uint8_t order, const uint16_t cutoff_freq_hz) {
@@ -443,8 +441,8 @@ static void configure_sb_filter(mixer_channel_t channel,
 	};
 
 	auto enable_zoh_upsampler = [&] {
-		config.zoh_upsampler_enabled = true;
-		config.zoh_rate_hz           = native_dac_rate_hz;
+		config.resample_method = ResampleMethod::ZeroOrderHoldAndResample;
+		config.zoh_rate_hz     = native_dac_rate_hz;
 	};
 
 	const auto filter_type = determine_filter_type(filter_choice, sb_type);
@@ -460,9 +458,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 	}
 
 	switch (*filter_type) {
-	case FilterType::None:
-		enable_zoh_upsampler();
-		break;
+	case FilterType::None: enable_zoh_upsampler(); break;
 
 	case FilterType::SB1:
 		enable_lpf(2, 3800);
@@ -486,14 +482,16 @@ static void configure_sb_filter(mixer_channel_t channel,
 		// This applies brickwall filtering at half the SB
 		// channel rate, which perfectly emulates the dynamic
 		// brickwall filter of the SB16.
+		config.resample_method = ResampleMethod::Resample;
 		break;
 
 	case FilterType::Modern:
 		// Linear interpolation upsampling is the legacy DOSBox behaviour
-		channel->SetResampleMethod(ResampleMethod::LinearInterpolation);
+		config.resample_method = ResampleMethod::LinearInterpolation;
 		break;
 	}
 
+	log_filter_config("SB", *filter_type);
 	set_filter(channel, config);
 }
 
@@ -509,7 +507,9 @@ static void configure_opl_filter(mixer_channel_t channel,
 	const auto filter_choice = filter_prefs_parts.empty()
 	                                 ? "auto"
 	                                 : filter_prefs_parts[0];
-	FilterConfig config = {};
+
+	FilterConfig config    = {};
+	config.resample_method = ResampleMethod::Resample;
 
 	auto enable_lpf = [&](const uint8_t order, const uint16_t cutoff_freq_hz) {
 		config.lpf_state          = FilterState::On;
@@ -522,7 +522,8 @@ static void configure_opl_filter(mixer_channel_t channel,
 	if (!filter_type) {
 		if (filter_choice != "off")
 			LOG_WARNING("%s: Invalid 'opl_filter' value: '%s', using 'off'",
-						CardType(), filter_choice.c_str());
+			            CardType(),
+			            filter_choice.c_str());
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
@@ -535,18 +536,13 @@ static void configure_opl_filter(mixer_channel_t channel,
 	switch (*filter_type) {
 	case FilterType::None:
 	case FilterType::SB16:
-	case FilterType::Modern:
-		break;
+	case FilterType::Modern: break;
 
 	case FilterType::SB1:
-	case FilterType::SB2:
-		enable_lpf(1, 12000);
-		break;
+	case FilterType::SB2: enable_lpf(1, 12000); break;
 
 	case FilterType::SBPro1:
-	case FilterType::SBPro2:
-		enable_lpf(1, 8000);
-		break;
+	case FilterType::SBPro2: enable_lpf(1, 8000); break;
 	}
 
 	log_filter_config("OPL", *filter_type);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -415,11 +415,11 @@ static void configure_sb_filter(mixer_channel_t channel,
                                 const std::string &filter_prefs,
                                 const bool filter_always_on, const SB_TYPES sb_type)
 {
-	// A bit unfortunate, but we need to enable the ZOH upsampler and the the
-	// correct upsample rate first for the filter cutoff frequency validation
-	// to work correctly.
-	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
+	// A bit unfortunate, but we need to enable the ZOH upsampler and the
+	// correct upsample rate first for the filter cutoff frequency
+	// validation to work correctly.
 	channel->SetZeroOrderHoldUpsamplerTargetFreq(native_dac_rate_hz);
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 
 	if (channel->TryParseAndSetCustomFilter(filter_prefs))
 		return;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -322,6 +322,7 @@ static void log_filter_config(const char *output_type, const FilterType filter)
 	        {FilterType::SBPro1, "Sound Blaster Pro 1"},
 	        {FilterType::SBPro2, "Sound Blaster Pro 2"},
 	        {FilterType::SB16, "Sound Blaster 16"},
+	        {FilterType::Modern, "Modern"},
 	};
 
 	if (filter == FilterType::None) {
@@ -491,7 +492,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 		break;
 	}
 
-	log_filter_config("SB", *filter_type);
+	log_filter_config("DAC", *filter_type);
 	set_filter(channel, config);
 }
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -84,6 +84,7 @@ enum class FilterType {
 	SBPro1,
 	SBPro2,
 	SB16,
+	Modern
 };
 
 enum SB_IRQS {SB_IRQ_8,SB_IRQ_16,SB_IRQ_MPU};
@@ -404,6 +405,9 @@ static std::optional<FilterType> determine_filter_type(const std::string &filter
 
 	} else if (filter_choice == "sb16") {
 		return FilterType::SB16;
+
+	} else if (filter_choice == "modern") {
+		return FilterType::Modern;
 	}
 
 	return {};
@@ -483,6 +487,11 @@ static void configure_sb_filter(mixer_channel_t channel,
 		// channel rate, which perfectly emulates the dynamic
 		// brickwall filter of the SB16.
 		break;
+
+	case FilterType::Modern:
+		// Linear interpolation upsampling is the legacy DOSBox behaviour
+		channel->SetResampleMethod(ResampleMethod::LinearInterpolation);
+		break;
 	}
 
 	set_filter(channel, config);
@@ -525,6 +534,8 @@ static void configure_opl_filter(mixer_channel_t channel,
 	// thing by ear only.
 	switch (*filter_type) {
 	case FilterType::None:
+	case FilterType::SB16:
+	case FilterType::Modern:
 		break;
 
 	case FilterType::SB1:
@@ -535,9 +546,6 @@ static void configure_opl_filter(mixer_channel_t channel,
 	case FilterType::SBPro1:
 	case FilterType::SBPro2:
 		enable_lpf(1, 8000);
-		break;
-
-	case FilterType::SB16:
 		break;
 	}
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -367,10 +367,10 @@ static void set_filter(mixer_channel_t channel, const FilterConfig &config)
 	channel->SetLowPassFilter(config.lpf_state);
 
 	if (config.zoh_upsampler_enabled) {
+		channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 		channel->ConfigureZeroOrderHoldUpsampler(config.zoh_rate_hz);
-		channel->EnableZeroOrderHoldUpsampler();
 	} else {
-		channel->EnableZeroOrderHoldUpsampler(false);
+		channel->SetResampleMethod(ResampleMethod::Resample);
 	}
 }
 
@@ -418,7 +418,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 	// correct upsample rate first for the filter cutoff frequency validation
 	// to work correctly.
 	channel->ConfigureZeroOrderHoldUpsampler(native_dac_rate_hz);
-	channel->EnableZeroOrderHoldUpsampler();
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 
 	if (channel->TryParseAndSetCustomFilter(filter_prefs))
 		return;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -224,8 +224,8 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter
 
 	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
 	// DACs
-	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 	channel->SetZeroOrderHoldUpsamplerTargetFreq(check_cast<uint16_t>(sample_rate));
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 
 	// Setup filters
 	if (filter_choice == "on") {

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -225,7 +225,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter
 	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
 	// DACs
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
-	channel->ConfigureZeroOrderHoldUpsampler(check_cast<uint16_t>(sample_rate));
+	channel->SetZeroOrderHoldUpsamplerTargetFreq(check_cast<uint16_t>(sample_rate));
 
 	// Setup filters
 	if (filter_choice == "on") {

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -219,12 +219,13 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::DigitalAudio});
 
-	sample_rate = channel->GetSampleRate();
+	const auto mixer_rate_hz = channel->GetSampleRate();
+	sample_rate = mixer_rate_hz;
 
 	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
 	// DACs
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 	channel->ConfigureZeroOrderHoldUpsampler(check_cast<uint16_t>(sample_rate));
-	channel->EnableZeroOrderHoldUpsampler();
 
 	// Setup filters
 	if (filter_choice == "on") {


### PR DESCRIPTION
This implements the `modern` Sound Blaster DAC filtering mode which uses simple linear interpolation upsampling like previous DOSBox versions. As discussed, this will be the default `sb_filter` setting for backwards-compatibility reasons.