### PR TITLE
Mixer improvements

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2192,7 +2192,7 @@ private:
 		                           const std::string &xfeed,
 		                           const std::string &reverb,
 		                           const std::string &chorus) {
-			WriteOut("%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f %-8s %5s %7s %7s\n",
+			WriteOut("%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f  %-8s %5s %7s %7s\n",
 			         name.c_str(),
 			         volume.left * 100.0f,
 			         volume.right * 100.0f,
@@ -2204,7 +2204,7 @@ private:
 			         chorus.c_str());
 		};
 
-		WriteOut(convert_ansi_markup("[color=white]Channel      Volume    Volume(dB)   Mode     Xfeed  Reverb  Chorus[reset]\n")
+		WriteOut(convert_ansi_markup("[color=white]Channel      Volume    Volume (dB)   Mode     Xfeed  Reverb  Chorus[reset]\n")
 		                 .c_str());
 
 		constexpr auto off_value  = "off";

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2188,25 +2188,23 @@ private:
 	{
 		auto show_channel = [this](const std::string &name,
 		                           const AudioFrame &volume,
-		                           const int rate,
 		                           const std::string &mode,
 		                           const std::string &xfeed,
 		                           const std::string &reverb,
 		                           const std::string &chorus) {
-			WriteOut("%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f %8d  %-8s %5s %7s %7s\n",
+			WriteOut("%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f %-8s %5s %7s %7s\n",
 			         name.c_str(),
 			         volume.left * 100.0f,
 			         volume.right * 100.0f,
 			         gain_to_decibel(volume.left),
 			         gain_to_decibel(volume.right),
-			         rate,
 			         mode.c_str(),
 			         xfeed.c_str(),
 			         reverb.c_str(),
 			         chorus.c_str());
 		};
 
-		WriteOut(convert_ansi_markup("[color=white]Channel      Volume    Volume(dB)   Rate(Hz)  Mode     Xfeed  Reverb  Chorus[reset]\n")
+		WriteOut(convert_ansi_markup("[color=white]Channel      Volume    Volume(dB)   Mode     Xfeed  Reverb  Chorus[reset]\n")
 		                 .c_str());
 
 		constexpr auto off_value  = "off";
@@ -2215,7 +2213,6 @@ private:
 		MIXER_LockAudioDevice();
 		show_channel(convert_ansi_markup("[color=cyan]MASTER[reset]"),
 		             mixer.master_volume,
-		             mixer.sample_rate,
 		             "Stereo",
 		             none_value,
 		             none_value,
@@ -2236,8 +2233,8 @@ private:
 			std::string reverb = none_value;
 			if (chan->HasFeature(ChannelFeature::ReverbSend)) {
 				if (chan->GetReverbLevel() > 0.0f) {
-					reverb = std::to_string(static_cast<uint8_t>(
-					        round(chan->GetReverbLevel() * 100.0f)));
+					reverb = std::to_string(static_cast<uint8_t>(round(
+					        chan->GetReverbLevel() * 100.0f)));
 				} else {
 					reverb = off_value;
 				}
@@ -2246,8 +2243,8 @@ private:
 			std::string chorus = none_value;
 			if (chan->HasFeature(ChannelFeature::ChorusSend)) {
 				if (chan->GetChorusLevel() > 0.0f) {
-					chorus = std::to_string(static_cast<uint8_t>(
-					        round(chan->GetChorusLevel() * 100.0f)));
+					chorus = std::to_string(static_cast<uint8_t>(round(
+					        chan->GetChorusLevel() * 100.0f)));
 				} else {
 					chorus = off_value;
 				}
@@ -2262,12 +2259,12 @@ private:
 
 			show_channel(convert_ansi_markup(channel_name),
 			             chan->volume,
-			             chan->GetSampleRate(),
 			             mode,
 			             xfeed,
 			             reverb,
 			             chorus);
 		}
+
 		MIXER_UnlockAudioDevice();
 	}
 };


### PR DESCRIPTION
This PR removes the display of the channels' sample rate from the mixer because it's beyond useless; it's actually quite misleading and confusing. Some examples why displaying the rate doesn't serve any useful purpose:

- Some audio card emulations perform high-quality resampling internally to the host rate, therefore they will always report the host rate, which is misleading (e.g. Game Blaster, PS/1 Audio, Tandy, OPL, etc.)
- Some other cards report the rate accurately (e.g. Sound Blaster and GUS), but displaying this in the mixer is not useful at all because virtually all games set different rates dynamically during the game anyway.

While technically we could report and display the true sample rate for some of the cards that use fixed rates, the problem for cards that set the rate dynamically is still unsolveable (the user would either see the default rate at startup, or whatever rate the game left the card in after exit — both options are misleading).

Ultimately, the "true" internal sample rate is an implementation detail that regular users should not care about; the mixer should only display parameters that can be changed via mixer commands (e.g. why don't we also display the bit-depth then?) People can look up some technical documentation if they're interested about the internal sampling rate of a sound card; the mixer is not the place to convey such information.