### PR TITLE
Use a bool to record if the channel should sleep

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -350,8 +350,8 @@ private:
 
 	private:
 		MixerChannel &channel;
-		int64_t woken_at_ms   = 0;
-		int accumulated_noise = 0;
+		int64_t woken_at_ms = 0;
+		bool had_noise      = false;
 	};
 	Sleeper sleeper;
 	const bool do_sleep = false;


### PR DESCRIPTION
Fixes a UBSAN warning when casting from a float sample that exceeds the 16-bit range.
