### PR TITLE
Report the active MT-32 ROM and source directory

### DIFF
--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -29,6 +29,8 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -37,6 +39,9 @@
 
 #include "mixer.h"
 #include "rwqueue.h"
+
+class LASynthModel;
+using model_and_dir_t = std::pair<const LASynthModel *, std::string>;
 
 static_assert(MT32EMU_VERSION_MAJOR > 2 ||
                       (MT32EMU_VERSION_MAJOR == 2 && MT32EMU_VERSION_MINOR >= 5),
@@ -74,6 +79,7 @@ private:
 	std::mutex service_mutex = {};
 	service_t service = {};
 	std::thread renderer = {};
+	std::optional<model_and_dir_t> model_and_dir = {};
 
 	// The following two members let us determine the total number of played
 	// frames, which is used by GetMidiEventTimestamp() to calculate a total


### PR DESCRIPTION
Previously the the code tried to highlight the active MT-32 ROM while simultaneously producing an inventory of available ROMs, this proved somewhat tricky and inconsistent because in some cases the MT32 might not be loaded.

This PR simplifies the report into two sections:
 - The inventory of ROMs and directories
 - The active ROM and from where it was loaded

![2022-09-04_19-13](https://user-images.githubusercontent.com/1557255/188348214-e51c213d-ed0e-4f10-b72c-128ca88e701a.png)

It also makes use of the new `simplify_path` routine, which helps cleanup printed paths.

