### PR TITLE
Fix a regression in the discrete PC Speaker

### DIFF
--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -52,7 +52,10 @@ private:
 	static constexpr char device_name[] = "PCSPEAKER";
 	static constexpr char model_name[]  = "discrete";
 
-	static constexpr float pwm_scalar = 0.5f; // accomodate a full doubling
+	// The discrete PWM scalar was manually adjusted to roughly match voltage
+	// levels recorded from a hardware PC Speaker 
+	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
+	static constexpr float pwm_scalar = 0.75f;
 	static constexpr float sqw_scalar = pwm_scalar / 2.0f;
 
 	// Amplitude constants

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -52,7 +52,13 @@ private:
 	static constexpr char device_name[] = "PCSPEAKER";
 	static constexpr char model_name[]  = "impulse";
 
-	static constexpr int16_t positive_amplitude = 20000;
+	// Amplitude constants
+
+	// The impulse PWM scalar was manually adjusted to roughly match voltage
+	// levels recorded from a hardware PC Speaker 
+	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
+	static constexpr float pwm_scalar = 0.5f;
+	static constexpr int16_t positive_amplitude = static_cast<int16_t>(MAX_AUDIO * pwm_scalar);
 	static constexpr int16_t negative_amplitude = -positive_amplitude;
 	static constexpr int16_t neutral_amplitude  = 0;
 

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -370,17 +370,9 @@ static void write_latch(io_port_t port, io_val_t value, io_width_t)
 		bcd_to_decimal(channel.write_latch);
 
 	if (channel.write_mode != AccessMode::Latch) {
-		if (channel.write_latch == 0) {
-			channel.count = get_max_count(channel);
-		}
-		// square wave, count by 2
-		else if (channel.write_latch == 1 &&
-		         (channel.mode == PitMode::SquareWave ||
-		          channel.mode == PitMode::SquareWaveAlias))
-			// buzz (Paratrooper)
-			channel.count = get_max_count(channel) + 1;
-		else
-			channel.count = channel.write_latch;
+
+		channel.count = channel.write_latch ? channel.write_latch
+		                                    : get_max_count(channel);
 
 		if ((!channel.mode_changed) &&
 		    (channel.mode == PitMode::RateGenerator ||


### PR DESCRIPTION
fixes #1906.

Thanks for the careful listening and detailed report, @Burrito78.

Audacity screenshots taken using the PR branch, with default settings except for adjusting the `pcspeaker = discrete vs. impulse`:

![2022-09-06_22-17](https://user-images.githubusercontent.com/1557255/188794727-c968f42b-a5f3-421f-8128-bc63bc0c3822.png)
