### PR TITLE
Fix CONFIG command's description

### DIFF
--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -700,7 +700,7 @@ Writing config file %s
 
 .
 :SHELL_CMD_CONFIG_HELP_LONG
-Config tool:
+Adjusts DOSBox Staging's configurable parameters.
 -writeconf or -wc without parameter: write to primary loaded config file.
 -writeconf or -wc with filename: write file to config directory.
 Use -writelang or -wl filename to write the current language strings.

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -854,7 +854,7 @@ void PROGRAMS_Init(Section* sec) {
 	
 	// help
 	MSG_Add("SHELL_CMD_CONFIG_HELP_LONG",
-	        "Config tool:\n"
+	        "Adjusts DOSBox Staging's configurable parameters.\n"
 	        "-writeconf or -wc without parameter: write to primary loaded config file.\n"
 	        "-writeconf or -wc with filename: write file to config directory.\n"
 	        "Use -writelang or -wl filename to write the current language strings.\n"


### PR DESCRIPTION
This fixes issue #1804 (reported by @Burrito78) by changing the description of CONFIG command from a simple "Config tool:" to the more descriptive "Adjusts DOSBox Staging's configurable values." so that ``HELP /ALL`` should look better. See screenshot below:

![image](https://user-images.githubusercontent.com/8216923/188804883-67e41343-d368-43ab-b384-856d23ca34c3.png)
