### PR TITLE
Fixes mapper warning for key_rctrl event

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2434,7 +2434,9 @@ static struct {
                    {"lalt", SDL_SCANCODE_LALT},
                    {"ralt", SDL_SCANCODE_RALT},
                    {"lctrl", SDL_SCANCODE_LCTRL},
+#if !defined(MACOSX)
                    {"rctrl", SDL_SCANCODE_RCTRL},
+#endif
                    {"lgui", SDL_SCANCODE_LGUI},
                    {"rgui", SDL_SCANCODE_RGUI},
                    {"comma", SDL_SCANCODE_COMMA},


### PR DESCRIPTION
This fixes mapper warning "MAPPER: Can't find key binding for key_rctrl event" that shows in log when running on macOS, as reported in #1887 by @Burrito78.