### PR TITLE
Update Italian (it-it) translation

### DIFF
--- a/contrib/resources/translations/encode.sh
+++ b/contrib/resources/translations/encode.sh
@@ -34,21 +34,21 @@ tconv_l CP437 "utf-8/en.txt" en
 # keyb de
 # keyb de 437
 # keyb de 858
-tconv_l CP858 "utf-8/de.txt" de
+tconv_l CP850 "utf-8/de.txt" de
 
 # keyb es
 # keyb es 437
 # keyb es 858
-tconv_l CP858 "utf-8/es.txt" es
+tconv_l CP850 "utf-8/es.txt" es
 
 # keyb fr
 # keyb fr 437
 # keyb fr 858
-tconv_l CP858 "utf-8/fr.txt" fr
+tconv_l CP850 "utf-8/fr.txt" fr
 
 # keyb it
 # keyb it 858
-tconv_l CP858 "utf-8/it.txt" it
+tconv_l CP850 "utf-8/it.txt" it
 
 # keyb pl
 # keyb pl 852

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -378,7 +378,7 @@ spazializzazione del suono:
   on:      Abilita riverbero (preset medio).
   tiny:    Simula il suono di un piccolo altoparlante integrato in una stanza;
            specificamente progettato per sistemi audio di piccole dimensioni
-           (PC Speaker, Tandy, PS/1 Audio, e Disney).
+           (PC Speaker, Tandy, PS/1 Audio, e dispositivi DAC LPT).
   small:   Aggiunge un sottile senso di spazializzazione; ottimo per i giochi
            che usano un singolo canale del sintetizzatore (tipicamente OPL)
            sia per la musica che per gli effetti sonori.

--- a/contrib/resources/translations/update-sources.sh
+++ b/contrib/resources/translations/update-sources.sh
@@ -95,10 +95,10 @@ update en 437
 # any missing messages into them in english, so translators can easily
 # find and update those new messages.
 #
-update de 858
-update es 858
-update fr 858
-update it 858
+update de 850
+update es 850
+update fr 850
+update it 850
 update pl 437 .cp437
 update pl 852
 update ru 866

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -378,7 +378,7 @@ spazializzazione del suono:
   on:      Abilita riverbero (preset medio).
   tiny:    Simula il suono di un piccolo altoparlante integrato in una stanza;
            specificamente progettato per sistemi audio di piccole dimensioni
-           (PC Speaker, Tandy, PS/1 Audio, e Disney).
+           (PC Speaker, Tandy, PS/1 Audio, e dispositivi DAC LPT).
   small:   Aggiunge un sottile senso di spazializzazione; ottimo per i giochi
            che usano un singolo canale del sintetizzatore (tipicamente OPL)
            sia per la musica che per gli effetti sonori.


### PR DESCRIPTION
Update Italian (it-it) translation.

The `encode.sh` script still uses code page 858 and not 850:
![scr1](https://user-images.githubusercontent.com/62349018/189498286-c7db2c6e-90ef-4a5c-98f3-d19de2ee098a.png)
