### PR TITLE
Fix variable expansion issue in the command shell

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1140,6 +1140,11 @@ void DOSBOX_Init() {
 	               "If set to 0, the country code corresponding to the\n"
 	               "selected keyboard layout will be used.");
 
+	Pbool = secprop->Add_bool("expand_shell_variable", when_idle, false);
+	Pbool->Set_help("Enable expanding environment variables such as %PATH%\n"
+	                "while in the DOS command shell. FreeDOS and MS-DOS 7/8\n"
+	                "COMMAND.COM supports this behavior.");
+
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init,true);
 	Pstring = secprop->Add_string("keyboardlayout", when_idle,  "auto");
 	Pstring->Set_help("Language code of the keyboard layout (or none).");

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -420,7 +420,10 @@ void DOS_Shell::InputCommand(char * line) {
 	if (l_completion.size()) l_completion.clear();
 
 	/* DOS %variable% substitution */
-	ProcessCmdLineEnvVarStitution(line);
+	const auto dos = static_cast<Section_prop *>(control->GetSection("dos"));
+	assert(dos);
+	if (dos->Get_bool("expand_shell_variable"))
+		ProcessCmdLineEnvVarStitution(line);
 }
 
 /* Note: Buffer pointed to by "line" must be at least CMD_MAXLINE+1 bytes long! */


### PR DESCRIPTION
It was mentioned earlier by @Grounded0 that "DOSBox COMMAND.COM processes % as %; FreeDOS COMMAND.COM processes them like MS-DOS COMMAND.COM so %% is processed as %." Looking into it the problem is actually caused by the variable-expansion-at-command-shell feature implemented earlier, making it somehow incompatible with DOSBox COMMAND.COM. This PR disables the variable-expansion-at-command-shell function by default for backward compatibility with vanilla DOSBox, while adding config option "expand_shell_variable" (in [dos] section) to (re-)enable this. 