### PR TITLE
Fallback to linear interpolation for the Disney SS and Tandy DAC 

### DIFF
--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -49,10 +49,12 @@ void Disney::ConfigureFilters(const FilterState state)
 
 	// Pull audio frames from the Disney DAC at 7 kHz
 	channel->SetSampleRate(dss_7khz_rate);
-	channel->SetZeroOrderHoldUpsamplerTargetFreq(dss_7khz_rate);
-	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
-
 	ms_per_frame = millis_in_second / dss_7khz_rate;
+
+
+	// TODO: replace linear with ZoH resampler
+	channel->SetResampleMethod(ResampleMethod::LinearInterpolation);
+
 
 	if (state == FilterState::On) {
 		// The filters are meant to emulate the Disney's bandwidth

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -222,10 +222,9 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile, const std::string &filter
 	const auto mixer_rate_hz = channel->GetSampleRate();
 	sample_rate = mixer_rate_hz;
 
-	// Setup zero-order-hold resampler to emulate the "crunchiness" of early
-	// DACs
-	channel->SetZeroOrderHoldUpsamplerTargetFreq(check_cast<uint16_t>(sample_rate));
-	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
+	// TODO: replace linear with ZoH resampler
+	channel->SetResampleMethod(ResampleMethod::LinearInterpolation);
+
 
 	// Setup filters
 	if (filter_choice == "on") {


### PR DESCRIPTION
This works around a regression in the ZoH resampling chain by falling back to the linear resampler. 

@johnnovak , the ZoH resampler is applied more thoroughly for the sound blaster's DAC, so I was reluctant to touch that without your input.
