### PR TITLE
Fixes artifact name for Windows installer

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -314,9 +314,9 @@ jobs:
             packageinfo="a development branch"
           fi
           mkdir out
-          echo "version_number=`git describe --tags`" >> $GITHUB_ENV
+          echo "version_number=`git describe --tags --abbrev=4`" >> $GITHUB_ENV
           sed -e "s|%PACKAGE_INFORMATION%|${packageinfo}|;s|%GITHUB_REPO%|${{ github.repository }}|" docs/README.template >out/setup_preamble.txt
-          sed -i "s|DOSBOX-STAGING-VERSION|`git describe --tags`|" contrib/windows_installer/DOSBox-Staging-setup.iss
+          sed -i "s|DOSBOX-STAGING-VERSION|`git describe --tags --abbrev=4`|" contrib/windows_installer/DOSBox-Staging-setup.iss
           echo @echo off >out/dosbox_with_console.bat
           echo \"%~dp0\\dosbox.exe\" %* >>out/dosbox_with_console.bat
           echo if errorlevel 1 pause >>out/dosbox_with_console.bat

--- a/contrib/windows_installer/DOSBox-Staging-setup.iss
+++ b/contrib/windows_installer/DOSBox-Staging-setup.iss
@@ -125,6 +125,7 @@ Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open wit
 
 [UninstallDelete]
 Type: files; Name: "{app}\stderr.txt"
+Type: files; Name: "{app}\stdout.txt"
 
 [Code]
 procedure CurPageChanged(CurPageID: Integer);


### PR DESCRIPTION
This makes the artifact name for Windows installer consistent with other artifacts in the MSYS2 workflow, e.g. "g7c2ba19c6" instead of "g7c2ba" as used by other artifacts. Also added the file "{app}\stdout.txt" in [UninstallDelete] section for removal during uninstallation.