### PR TITLE
Displays help header for INTRO command

### DIFF
--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -65,6 +65,8 @@ void INTRO::DisplayMount(void) {
 void INTRO::Run(void) {
 	// Usage
 	if (HelpRequested()) {
+		WriteOut(MSG_Get("SHELL_CMD_INTRO_HELP"));
+		WriteOut("\n");
 		WriteOut(MSG_Get("SHELL_CMD_INTRO_HELP_LONG"));
 		return;
 	}


### PR DESCRIPTION
There was a bug that the help header for INTRO command was not shown as reported by @Kappa971. It is fixed so that the command ``INTRO /?`` will show the "Displays a full-screen introduction to DOSBox Staging" header similar to other commands.

<img width="945" alt="image" src="https://user-images.githubusercontent.com/8216923/190525153-6f5e86be-47a2-4d84-9cec-a7fb759ea53f.png">
