### PR TITLE
Better support for piping with builtin Y drive support

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -273,11 +273,13 @@ bool get_pipe_status(const char *out_file,
 		                              OPEN_READWRITE, DOS_ATTR_ARCHIVE,
 		                              0x12, &dummy, &dummy2);
 		if (pipe_file && (failed_pipe || !status) &&
-		    (Drives[0] || Drives[2]) && !strchr(pipe_tempfile, '\\')) {
+		    (Drives[0] || Drives[2] || Drives[24]) &&
+		    !strchr(pipe_tempfile, '\\')) {
 			// Insert a drive prefix into the pipe filename path.
 			// Note that the safe_strcpy truncates excess to prevent
 			// writing beyond pipe_tempfile's fixed size.
-			const std::string drive_prefix = Drives[2] ? "c:\\" : "a:\\";
+			const std::string drive_prefix =
+			        Drives[2] ? "c:\\" : (Drives[0] ? "a:\\" : "y:\\");
 			const std::string pipe_full_path = drive_prefix + pipe_tempfile;
 			safe_strcpy(pipe_tempfile, pipe_full_path.c_str());
 


### PR DESCRIPTION
The 0.79.0 version has added support for piping, but it did not consider the recent Y drive as a temporary piping directory, and also user has to add their own `MORE` and `SORT` commands for commands like `DIR | SORT | MORE` to work. This PR adds `MORE` and `SORT` commands from FreeDOS, and with builtin support for Y drive as a temporary piping directory, so that commands like `TYPE FILE.TXT | MORE` and `DIR | SORT | MORE` will right work out of the box (without any extra steps needed).