### PR TITLE
Improve resource installation and lookup

### DIFF
--- a/contrib/resources/meson.build
+++ b/contrib/resources/meson.build
@@ -1,4 +1,4 @@
-resource_dirs = [
+resources = [
     'drives',
     'freedos-cpi',
     'freedos-keyboard',
@@ -7,9 +7,12 @@ resource_dirs = [
     # insert new resource subdirectory names here
 ]
 
-# This will install all the above resource_dirs into the
+# This will install all the above resources into the
 # platform-specific resources/ directory in the build area,
 # which is then bundled into the release package.
+
+# When "meson install" is used, the same tree is installed
+# under the provided data_dir (or prefix / share) area.
 
 # To add a new resources subdirectory, create a new directory
 # under ./contrib/resources/<here>.
@@ -22,7 +25,7 @@ resource_dirs = [
 #    resource_dirs = [ 'dir1', 'dir2', ... ]
 #  - See the translations directory for a working example.
 #  - Finally, add the name of the directory to the above
-#    resource_dirs list at the top of this file.
+#    'resources' list at the top of this file.
 
 # ---- no further changes are needed to add new resources ----
 
@@ -39,64 +42,64 @@ relative_resources = (
     target_machine.system() == 'darwin' ? '../../../Resources' : '../../resources'
 )
 
-target_resources = meson.current_build_dir() / relative_resources
+# Top-level resources directory for the build and installation area
+target_build_dir = meson.current_build_dir() / relative_resources
+target_install_dir = get_option('datadir') / meson.project_name()
 
-foreach source_dir : resource_dirs
+foreach resource : resources
 
-    # Create the resources/source_dir in the build area
-    target_dir = target_resources / source_dir
-    configure_file(output: source_dir, command: ['mkdir', '-p', target_dir])
+    # Create the resources/resource in the build area
+    configure_file(
+        output: resource,
+        command: ['mkdir', '-p', target_build_dir / resource],
+    )
 
     # These two variables get re-populated inside each subdir(..)
     resource_files = []
     resource_dirs = []
+    subdir(resource)
 
-    subdir(source_dir)
-
-    # Install each of the source_dir's resource files
-    foreach resource : resource_files
-        source_file = source_dir / resource
-        target_file = target_dir / resource
+    # Install each of the resource's files
+    foreach filename : resource_files
+        source_file = resource / filename
         configure_file(
-            output: resource,
-            command: ['install', '-m', '644', files(source_file), target_file],
+            output: filename,
+            command: [
+                'install',
+                '-m', '644',
+                files(source_file),
+                target_build_dir / resource / filename,
+            ],
+        )
+        install_data(
+            source_file,
+            install_dir: target_install_dir / resource,
         )
     endforeach
 
-    # Get this source_dir's full path
+    # Get this resource's full path
     source_dir_cmd = run_command(
         'dirname',
-        files(source_dir / 'meson.build'),
+        files(resource / 'meson.build'),
         check: true,
     )
-    source_dir_path = source_dir_cmd.stdout().strip()
+    resource_absolute_dir = source_dir_cmd.stdout().strip()
 
-    # Install each of the source_dir's resource dirs
-    foreach resource : resource_dirs
+    # Install each of the resource's dirs
+    foreach dirname : resource_dirs
         configure_file(
-            output: resource,
-            command: ['cp', '-f', '-R', '-P', source_dir_path / resource, target_dir],
+            output: dirname,
+            command: [
+                'cp',
+                '-f',
+                '-R',
+                '-P', resource_absolute_dir / dirname,
+                target_build_dir / resource,
+            ],
+        )
+        install_subdir(
+            resource / dirname,
+            install_dir: target_install_dir / resource,
         )
     endforeach
-
-    # Setup the the source_dir's resource files and dirs into the system (if requested)
-    if get_option('prefix') in ['/usr', '/usr/local']
-        system_resources = (
-            get_option('prefix') / 'share/dosbox-staging' / source_dir
-        )
-        foreach resource : resource_files
-            install_data(
-                target_dir / resource,
-                install_dir: system_resources,
-            )
-        endforeach
-
-        foreach resource : resource_dirs
-            install_subdir(
-                target_dir / resource,
-                install_dir: system_resources,
-            )
-        endforeach
-    endif
-
 endforeach

--- a/docs/README.resources
+++ b/docs/README.resources
@@ -1,18 +1,35 @@
-Starting with version 0.79, DOSBox Staging needs access to 
-bundled resource files.
+Starting with version 0.79, DOSBox Staging needs access to bundled 
+resource files.
 
 Meson will construct the deliverable "resources/" directory 
 along-side the compiled executable. This layout can be shipped 
-as-is. The executable will check the following paths for the 
-resources, in the following priority order:
+as-is.
+
+Additionally, if "meson install" is performed, the tree of 
+resources will be constructed as follows:
+
+ - /${prefix}/share/dosbox-staging/resource-subdirs/..
+   if meson is setup with --prefix, but without --datadir
+
+ - /usr/local/${datadir}/dosbox-staging/resource-subdirs/..
+   if meson is setup with --datadir, but without --prefix
+
+ - /${prefix}/{$datadir}/dosbox-staging/resource-subdirs/..
+   if meson is setup with --prefix and a **non-absolute** --datadir
+
+ - /${datadir}/dosbox-staging/resource-subdirs/..
+   if meson is setup with --prfix and an **absolute** --datadir
+
+At runtime, the executable will check the following paths
+for the resources, in the following priority order:
 
 1. Beside the executable:
     ./dosbox (executable)
     ./resources/subdirs/...
     (on macOS: ../Resources/subdirs/...)
 
-   This first instance should also be the prefered packaging
-   layout for wrapped formats like FlatPak, Snap, etc.
+   This first instance should also be the prefered packaging layout 
+   for wrapped formats like FlatPak, Snap, AppImage, etc.
 
 2. Up one directory from the executable (which allows unit tests 
    to access resources):
@@ -20,42 +37,44 @@ resources, in the following priority order:
     ./../resources/subdirs/...
     (on macOS: ../../Resources/subdirs/...)
 
-3. In the absolute path:
-    '/usr/local/share/dosbox-staging/subdirs/...'
+3. In XDG_DATA_HOME followed by the XDG_DATA_DIRS paths, where:
+    '${XDG_DATA}/dosbox-staging/subdirs/...'
 
-4. In the absolute path:
-   '/usr/share/dosbox-staging/subdirs/...'
-
-5. If your OS has a different prefered "application content" 
-   holding area, please open a ticket.
-
-6. In the user's configuration path:
+4. In the user's configuration path:
    'home/<user>/.config/dosbox/subdirs/...'
    (or the Windows configuration path)
 
-FAQ:
+FAQ
+~~~
 Q: Why can't these be embedded inside the executable?
 
-A1: Source files aren't filesystems, as such storing binaries as 
-    massive hex strings is a form of obfuscation that makes it 
-    harder to understand what they contain. With files, anyone 
-    can diff or create an md5 checksum. With files, anyone can 
-    notify the project when a file has become outdated.
+A1: Encoding binary data into the project's source tree as massive 
+    hex strings is a form of obfuscation that makes it harder to 
+    understand what they contain.
+
+    With raw files, anyone can use those files as intended by 3rd 
+    party software, diff or compare them, notify the project when 
+    they become outdated, and more importantly can maintain them 
+    without needing to setup a development environment.
 
 A2: Turning binary files into source involves placing tens of 
-    thousands of lines of hex address strings into your code 
-    base.
+    thousands of lines of hex values into the code base.
 
     These get parsed and become a persistent carrying "load" for 
-    editors and development IDEs.  They also become a source of
-    false-positive hits when grepping text files.
+    source editors and development IDEs. They generate 
+    false-positives when grepping the source for number patterns, 
+    so much so that they often flood the screen and need extra 
+    effort to filter them out.
+
 
 Q: How are the resources/ deployed into the build area by Meson?
+
 A: Read ./contrib/resources/meson.build This meson file copies
-   the deployable resource files into the build area.
+   the resource files into the build area.
+
 
 Q: How are the resources/ deployed into the build area by Visual
    Studio?
-A: Search the vcxproj files for "contrib\resources". These
-   snippets perform the copying.
 
+A: Search the vcxproj files for "contrib\resources". These
+   snippets perform the recursive copying.

--- a/meson.build
+++ b/meson.build
@@ -32,8 +32,8 @@ project(
 # These are always present regardless of host, compiler, dependencies, or options.
 #
 data_dir = get_option('datadir')
-licenses_dir = data_dir / 'licenses' / 'dosbox-staging'
-doc_dir = data_dir / 'doc' / 'dosbox-staging'
+licenses_dir = data_dir / 'licenses' / meson.project_name()
+doc_dir = data_dir / 'doc' / meson.project_name()
 
 install_man('docs/dosbox.1')
 install_data('COPYING', install_dir: licenses_dir)
@@ -42,7 +42,6 @@ install_data('AUTHORS', 'README', 'THANKS', install_dir: doc_dir)
 subdir('contrib/linux')
 subdir('contrib/icons')
 subdir('contrib/resources')
-
 
 # Gather compiler settings
 # ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/meson.build
+++ b/meson.build
@@ -146,6 +146,7 @@ endforeach
 #
 conf_data = configuration_data()
 conf_data.set('version', meson.project_version())
+conf_data.set('project_name', meson.project_name())
 
 os_family_name = {
   'linux'     : 'LINUX',

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -24,6 +24,9 @@
 /* Version and branding tweaks
  */
 
+// Name of project, lower-case without spaces
+#define CANONICAL_PROJECT_NAME "@project_name@"
+
 // Emulator Semantic Version (MAJOR.MINOR.PATCH), incremented as follows:
 //  - MAJOR version when you make incompatible API changes
 //  - MINOR version when you add functionality in a backwards compatible manner

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1229,7 +1229,7 @@ void DOSBOX_Init() {
 		"You can put your MOUNT lines here.\n"
 	);
 	MSG_Add("CONFIGFILE_INTRO",
-	        "# This is the configuration file for dosbox-staging (%s).\n"
+	        "# This is the configuration file for " CANONICAL_PROJECT_NAME " (%s).\n"
 	        "# Lines starting with a '#' character are comments.\n");
 	MSG_Add("CONFIG_SUGGESTED_VALUES", "Possible values");
 

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -22,7 +22,7 @@
 #define DOSBOX_GUI_MSGS_H
 
 constexpr char version_msg[] =
-        R"(dosbox (dosbox-staging), version %s
+        R"(%s, version %s
 
 Copyright (C) 2020-2022  The DOSBox Staging Team
 License: GNU GPL-2.0-or-later <https://www.gnu.org/licenses/gpl-2.0.html>

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4490,7 +4490,7 @@ void OverrideWMClass()
 {
 #if !defined(WIN32)
 	constexpr int overwrite = 0; // don't overwrite
-	setenv("SDL_VIDEO_X11_WMCLASS", "dosbox-staging", overwrite);
+	setenv("SDL_VIDEO_X11_WMCLASS", CANONICAL_PROJECT_NAME, overwrite);
 #endif
 }
 
@@ -4510,7 +4510,7 @@ int sdl_main(int argc, char *argv[])
 	if (control->cmdline->FindExist("--version") ||
 	    control->cmdline->FindExist("-version") ||
 	    control->cmdline->FindExist("-v")) {
-		printf(version_msg, DOSBOX_GetDetailedVersion());
+		printf(version_msg, CANONICAL_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 		return 0;
 	}
 
@@ -4532,7 +4532,7 @@ int sdl_main(int argc, char *argv[])
 
 	loguru::init(argc, argv);
 
-	LOG_MSG("dosbox-staging version %s", DOSBOX_GetDetailedVersion());
+	LOG_MSG("%s version %s", CANONICAL_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 	LOG_MSG("---");
 
 	LOG_MSG("LOG: Loguru version %d.%d.%d initialized", LOGURU_VERSION_MAJOR,

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -412,7 +412,7 @@ void CAPTURE_AddImage([[maybe_unused]] int width,
 		}
 #ifdef PNG_TEXT_SUPPORTED
 		constexpr char keyword[] = "Software";
-		constexpr char value[] = "dosbox-staging " VERSION;
+		constexpr char value[] = CANONICAL_PROJECT_NAME " " VERSION;
 		constexpr int num_text = 1;
 		static_assert(sizeof(keyword) < 80, "libpng limit");
 		png_text texts[num_text] = {};

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -57,7 +57,7 @@
 
 static std::string GetConfigName()
 {
-	return "dosbox-staging.conf";
+	return CANONICAL_PROJECT_NAME ".conf";
 }
 
 #ifndef WIN32

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -193,7 +193,7 @@ bool SlirpEthernetConnection::Initialize(Section *dosbox_config)
 	inet_pton(AF_INET6, "fec0::3", &config.vnameserver6);
 
 	/* DHCPv4, BOOTP, TFTP */
-	config.vhostname = "dosbox-staging";
+	config.vhostname = CANONICAL_PROJECT_NAME;
 	config.vdnssearch = NULL;
 	config.vdomainname = NULL;
 	config.tftp_server_name = NULL;

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -1,3 +1,6 @@
+/* Project name, lower-case and without spaces */
+#define CANONICAL_PROJECT_NAME "dosbox-staging"
+
 // Emulator Semantic Version (MAJOR.MINOR.PATCH), incremented as follows:
 //  - MAJOR version when you make incompatible API changes
 //  - MINOR version when you add functionality in a backwards compatible manner

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1092,7 +1092,7 @@ void SHELL_Init() {
 	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBC\033[0m\n"
 	        "\n");
 
-	MSG_Add("SHELL_STARTUP_SUB","[color=green]dosbox-staging %s\033[0m\n");
+	MSG_Add("SHELL_STARTUP_SUB","[color=green]" CANONICAL_PROJECT_NAME " %s\033[0m\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays or changes the current directory.\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG",
 	        "Usage:\n"


### PR DESCRIPTION
Previously, the resources weren't installed as part of a "meson install" step, which is used by package maintainers. 

This will now install the resources based on the specific prefix (see commits), and also look them up using the system's XDG data paths.

These details are added to the `docs/README.resources`.
