### PR TITLE
Change MIDI config problems into warnings

### DIFF
--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -315,7 +315,7 @@ public:
 		while (handler) {
 			if (dev == handler->GetName()) {
 				if (!handler->Open(conf)) {
-					LOG_MSG("MIDI: Can't open device: %s with config: '%s'",
+					LOG_WARNING("MIDI: Can't open device: %s with config: '%s'",
 					        dev.c_str(), conf);
 					goto getdefault;
 				}

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -270,7 +270,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	}
 
 	// Load the requested SoundFont or quit if none provided
-	const auto sf_spec = parse_sf_pref(section->Get_string("soundfont"));
+	const char *sf_file = section->Get_string("soundfont");
+	const auto sf_spec = parse_sf_pref(sf_file);
 	const auto soundfont = find_sf_file(std::get<std::string>(sf_spec));
 	auto scale_by_percent = std::get<int>(sf_spec);
 
@@ -278,8 +279,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 		fluid_synth_sfload(fluid_synth.get(), soundfont.data(), true);
 	}
 	if (fluid_synth_sfcount(fluid_synth.get()) == 0) {
-		LOG_MSG("FSYNTH: FluidSynth failed to load '%s', check the path.",
-		        soundfont.c_str());
+		LOG_WARNING("FSYNTH: FluidSynth failed to load '%s', check the path.",
+		        sf_file);
 		return false;
 	}
 


### PR DESCRIPTION
It took me a while to find a typo in my FluidSynth config, which was not helped by the fact that the "failed to load soundfont" message didn't really stand out against the other messages, and also it didn't include the (incorrect) filename for the soundfont:

````
2022-09-22 22:00:00.131 | FSYNTH: FluidSynth failed to load '', check the path.
2022-09-22 22:00:00.132 | MIDI: Can't open device: fluidsynth with config: ''
````

I fixed both so that those warnings show up in color now, and the FluidSynth warning includes the filename it tries to load.

This could be extended to cover more warnings/errors in the MIDI subsystem (and others) but I wanted to get this PR out to gauge interest first :)