### PR TITLE
Codify the use of Semantic Versioning (MAJOR.MINOR.PATCH)

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -24,7 +24,13 @@
 /* Version and branding tweaks
  */
 
-// Emulator version
+// Emulator Semantic Version (MAJOR.MINOR.PATCH), incremented as follows:
+//  - MAJOR version when you make incompatible API changes
+//  - MINOR version when you add functionality in a backwards compatible manner
+//  - PATCH version when you make backwards compatible bug fixes
+// Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+// Ref: https://semver.org/
+
 #define VERSION "@version@"
 
 /* Operating System

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -1,5 +1,11 @@
-/* Version number of package */
-#define VERSION "0.79.0"
+// Emulator Semantic Version (MAJOR.MINOR.PATCH), incremented as follows:
+//  - MAJOR version when you make incompatible API changes
+//  - MINOR version when you add functionality in a backwards compatible manner
+//  - PATCH version when you make backwards compatible bug fixes
+// Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+// Ref: https://semver.org/
+
+#define VERSION "0.80.0-alpha"
 
 /* This macro is going to be overriden via CI */
 #define DOSBOX_DETAILED_VERSION "git"


### PR DESCRIPTION
Just a comment above our VERSION defines clarifying that we plan to continue using the X.Y.Z version approach.

No extra code or fancy ways of separating the numbers (because it's over-engineering at this point); we're not a library or doing version comparisons.

The most important part is that another PR will be needed to undo it if the project wants to use a different format.