### PR TITLE
Specify library module for FluidSynth dep

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -446,6 +446,7 @@ if get_option('use_fluidsynth')
     fluid_dep = dependency(
         'fluidsynth',
         version: '>= 2.2.3',
+        modules: ['FluidSynth::libfluidsynth'],
         allow_fallback: ('fluidsynth' not in system_libs_list),
         static: ('fluidsynth' in static_libs_list or prefers_static_libs),
         not_found_message: msg.format('use_fluidsynth'),


### PR DESCRIPTION
After updating to FluidSynth 2.3.0 on macOS via homebrew, I received a link error:

```
ld: can't link with a main executable file '/opt/homebrew/bin/fluidsynth' for architecture arm64
```

Looking through meson-log.txt, it appears that the normal Meson dep resolution order of `pkg-config` -> `cmake` was causing `pkg-config` to fail with 2.3.0 due to an inability to locate `readline`, unless an environment variable is specified, as described by `brew info readline`. After `pkg-config` fails, Meson tries `cmake`, but the default module is the binary (`[FluidSynth::fluidsynth]`), not the library (`[FluidSynth::libfluidsynth]`), likely a change resulting from the re-worked CMake system for 2.3.0 (https://github.com/FluidSynth/fluidsynth/pull/969).

This patch just specifies the library module explicitly.