### PR TITLE
Fixes release package description in Windows installer and cross-platform README.TXT file

### DIFF
--- a/.github/workflows/windows-meson-msys2.yml
+++ b/.github/workflows/windows-meson-msys2.yml
@@ -306,6 +306,9 @@ jobs:
           if [[ "${{ github.ref }}" == "refs/tags/"* ]] && [[ "${{ github.ref }}" != *"-"* ]]; then
             version_tag=`echo ${{ github.ref }} | sed -r 's/([^\/]*\/){2}//'`
             packageinfo="release $version_tag"
+          elif [[ "${{ github.ref }}" == "refs/heads/release/"* ]]; then
+            version_tag=`git describe --tags | cut -f1 -d"-"`
+            packageinfo="release $version_tag"
           elif [ -n "${{ github.ref }}" ] && [ -n "${{ github.sha }}" ]; then
             git_branch=`echo ${{ github.ref }} | sed -r 's/([^\/]*\/){2}//'`
             git_commit=`echo ${{ github.sha }} | awk '{print substr($0,1,9);exit}'`

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,4 +1,4 @@
-name: Windows builds
+name: Windows MSVC builds
 
 on: [push, pull_request]
 

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -1,4 +1,4 @@
-name: MSYS2 builds
+name: Windows MSYS2 builds
 
 on: [push, pull_request]
 
@@ -295,7 +295,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: windows.yml
+          workflow: windows-msvc.yml
           name: ${{ env.artifact_name }}
           path: ${{ env.artifact_path }}
           if_no_artifact_found: warn

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -79,7 +79,7 @@ install_doc()
         package_information="release $version_tag"
     elif [[ "$git_branch" == "release/"* ]]; then
         version_tag=`git describe --tags | cut -f1 -d"-"`
-        packageinfo="release $version_tag"
+        package_information="release $version_tag"
     elif [ -n "$git_branch" ] && [ -n "$git_commit" ]; then
         package_information="a development branch named $git_branch with commit $git_commit"
     else

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -77,6 +77,9 @@ install_doc()
     if [[ "$git_branch" == "refs/tags/"* ]] && [[ "$git_branch" != *"-"* ]]; then
         version_tag=`echo $git_branch | awk '{print substr($0,11);exit}'`
         package_information="release $version_tag"
+    elif [[ "$git_branch" == "release/"* ]]; then
+        version_tag=`git describe --tags | cut -f1 -d"-"`
+        packageinfo="release $version_tag"
     elif [ -n "$git_branch" ] && [ -n "$git_commit" ]; then
         package_information="a development branch named $git_branch with commit $git_commit"
     else


### PR DESCRIPTION
It appears that the Windows installer assets may be directly obtained from the `release/...` branch rather than the main branch with `refs/tags/...`. This PR fixes the Windows installer preamble and cross-platform README.TXT files so that they will read e.g. "This package contains release v0.79.1 of the DOSBox Staging project" instead of something like "This package contains a development branch named release/0.79.x with commit e94742d51 of the DOSBox Staging project" as with the previous 0.79.0 release. Also renamed CI workflows `windows.yml` to `windows-msvc.yml` and `windows-meson-msys2.yml` to `windows-msys2.yml` considering that the MSYS2 builds now act like the standard Windows builds (and even the default ones) in addition to the MSVC builds.