### PR TITLE
Change 'config -wc' to write UTF-8 file

### DIFF
--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -36,8 +36,9 @@ extern bool shutdown_requested;
 [[noreturn]] void E_Exit(const char *message, ...)
         GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
 
-void MSG_Add(const char*,const char*); //add messages to the internal languagefile
-const char* MSG_Get(char const *);     //get messages from the internal languagefile
+void MSG_Add(const char*,const char*); // add messages (in UTF-8) to the language file
+const char* MSG_Get(char const *);     // get messages (adapted to current code page) from the language file
+const char* MSG_GetRaw(char const *);  // get messages (in UTF-8, without ANSI preprocessing) from the language file
 bool MSG_Exists(const char*);
 
 class Section;

--- a/include/setup.h
+++ b/include/setup.h
@@ -153,6 +153,7 @@ public:
 	void Set_help(const std::string &str);
 
 	const char* GetHelp() const;
+	const char* GetHelpUtf8() const;
 
 	virtual bool SetValue(const std::string &str) = 0;
 	const Value &GetValue() const

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -45,6 +45,8 @@
 
 CHECK_NARROWING();
 
+static const char *msg_not_found = "Message not Found!\n";
+
 class Message {
 private:
 	std::string markup_msg = {};
@@ -199,10 +201,17 @@ static bool load_message_file(const std_fs::path &filename)
 const char *MSG_Get(char const *requested_name)
 {
 	const auto it = messages.find(requested_name);
-	if (it != messages.end()) {
+	if (it != messages.end())
 		return it->second.GetRendered();
-	}
-	return "Message not Found!\n";
+	return msg_not_found;
+}
+
+const char* MSG_GetRaw(char const *requested_name)
+{
+	const auto it = messages.find(requested_name);
+	if (it != messages.end())
+		return it->second.GetRaw();
+	return msg_not_found;
 }
 
 bool MSG_Exists(const char *requested_name)

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -275,6 +275,13 @@ const char * Property::GetHelp() const
 	return MSG_Get(result.c_str());
 }
 
+const char * Property::GetHelpUtf8() const
+{
+	std::string result = "CONFIG_" + propname;
+	upcase(result);
+	return MSG_GetRaw(result.c_str());
+}
+
 bool Prop_int::SetVal(const Value &in, bool forced, bool warn)
 {
 	if (forced) {
@@ -821,7 +828,7 @@ bool Config::PrintConfig(const std::string &filename) const
 	if (outfile == NULL) return false;
 
 	/* Print start of configfile and add a return to improve readibility. */
-	fprintf(outfile, MSG_Get("CONFIGFILE_INTRO"), VERSION);
+	fprintf(outfile, MSG_GetRaw("CONFIGFILE_INTRO"), VERSION);
 	fprintf(outfile, "\n");
 
 	for (auto tel = sectionlist.cbegin(); tel != sectionlist.cend(); ++tel) {
@@ -847,7 +854,7 @@ bool Config::PrintConfig(const std::string &filename) const
 				if (p->IsDeprecated())
 					continue;
 
-				std::string help = p->GetHelp();
+				std::string help = p->GetHelpUtf8();
 				std::string::size_type pos = std::string::npos;
 				while ((pos = help.find('\n', pos+1)) != std::string::npos) {
 					help.replace(pos, 1, prefix);
@@ -857,7 +864,7 @@ bool Config::PrintConfig(const std::string &filename) const
 
 				std::vector<Value> values = p->GetValues();
 				if (!values.empty()) {
-					fprintf(outfile, "%s%s:", prefix, MSG_Get("CONFIG_SUGGESTED_VALUES"));
+					fprintf(outfile, "%s%s:", prefix, MSG_GetRaw("CONFIG_SUGGESTED_VALUES"));
 					std::vector<Value>::const_iterator it = values.begin();
 					while (it != values.end()) {
 						if((*it).ToString() != "%u") { //Hack hack hack. else we need to modify GetValues, but that one is const...
@@ -873,7 +880,7 @@ bool Config::PrintConfig(const std::string &filename) const
 		} else {
 			upcase(temp);
 			strcat(temp,"_CONFIGFILE_HELP");
-			const char * helpstr = MSG_Get(temp);
+			const char * helpstr = MSG_GetRaw(temp);
 			const char * linestart = helpstr;
 			char * helpwrite = helpline;
 			while (*helpstr && static_cast<size_t>(helpstr - linestart) < sizeof(helpline)) {

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -34,6 +34,10 @@ const char *MSG_Get(char const *)
 {
 	return nullptr;
 }
+const char *MSG_GetRaw(char const *)
+{
+    return nullptr;
+}
 
 #if C_DEBUG
 void LOG::operator()([[maybe_unused]] char const *buf, ...)


### PR DESCRIPTION
Changes `config -wc` to write UTF-8 file (not with encoding determined by current code page). This is a fix for issue https://github.com/dosbox-staging/dosbox-staging/issues/1799