### PR TITLE
Use non-throwing form of `std::filesystem` calls

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -24,6 +24,7 @@
 #include "config.h"
 
 #include <cinttypes>
+#include <ctime>
 #include <string>
 
 #include "std_filesystem.h"
@@ -76,5 +77,8 @@ std_fs::path simplify_path(const std_fs::path &path) noexcept;
 constexpr uint32_t OK_IF_EXISTS = 0x1;
 
 int create_dir(const char *path, uint32_t mode, uint32_t flags = 0x0) noexcept;
+
+// Convert a filesystem time to a raw time_t value
+std::time_t to_time_t(const std_fs::file_time_type &fs_time);
 
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -47,8 +47,8 @@ extern char autoexec_data[autoexec_maxsize];
 std::unique_ptr<Program> CONFIG_ProgramCreate();
 std::unique_ptr<Program> MIXER_ProgramCreate();
 std::unique_ptr<Program> SHELL_ProgramCreate();
-void z_drive_getpath(std::string &path, const std::string &dirname);
-void z_drive_register(const std::string &path, const std::string &dir);
+void VFILE_GetPathZDrive(std::string &path, const std::string &dirname);
+void VFILE_RegisterZDrive(const std_fs::path &z_drive_path);
 
 void Add_VFiles(const bool add_autoexec)
 {
@@ -56,8 +56,8 @@ void Add_VFiles(const bool add_autoexec)
 	std::string path = ".";
 	path += CROSS_FILESPLIT;
 	path += dirname;
-	z_drive_getpath(path, dirname);
-	z_drive_register(path, "/");
+	VFILE_GetPathZDrive(path, dirname);
+	VFILE_RegisterZDrive(path);
 
 	PROGRAMS_MakeFile("ATTRIB.COM", ProgramCreate<ATTRIB>);
 	PROGRAMS_MakeFile("AUTOTYPE.COM", ProgramCreate<AUTOTYPE>);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1203,13 +1203,15 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 
 	bool result = false;
 
-	// check if overlaynameold exista and if so rename it to overlaynamenew
-	if (std_fs::exists(overlaynameold)) {
-		std_fs::rename(overlaynameold, overlaynamenew);
-		result = true; // indicate that the rename succeeded
+	// check if overlaynameold exists and if so rename it to overlaynamenew
+	std::error_code ec = {};
+	if (std_fs::exists(overlaynameold, ec)) {
+		std_fs::rename(overlaynameold, overlaynamenew, ec);
+
+		result = !ec; // success if no error-code
 
 		// Overlay file renamed: mark the old base file as deleted.
-		if (localDrive::FileExists(oldname)) {
+		if (result == true && localDrive::FileExists(oldname)) {
 			add_deleted_file(oldname, true);
 		}
 	} else {

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -944,7 +944,8 @@ bool Overlay_Drive::FileUnlink(char * name) {
 			DOS_SetError(DOSERR_ACCESS_DENIED);
 			return false;
 		}
-		if (std_fs::remove(overlayname)) {
+		std::error_code ec = {};
+		if (std_fs::remove(overlayname, ec)) {
 			// Overlay file removed, mark basefile as deleted if it
 			// exists:
 			if (localDrive::FileExists(name))

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -695,8 +695,10 @@ std::deque<std::string> RENDER_InventoryShaders()
 
 	const std::string dir_prefix  = "Path '";
 	const std::string file_prefix = "        ";
+
+	std::error_code ec = {};
 	for (auto &[dir, shaders] : GetFilesInResource("glshaders", ".glsl")) {
-		const auto dir_exists      = std_fs::is_directory(dir);
+		const auto dir_exists      = std_fs::is_directory(dir, ec);
 		auto shader                = shaders.begin();
 		const auto dir_has_shaders = shader != shaders.end();
 		const auto dir_postfix     = dir_exists

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -661,9 +661,8 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program *caller)
 			if (ec)
 				break; // problem iterating, so skip the directory
 
-			// Is it a file?
-			if (!std_fs::is_regular_file(entry))
-				continue;
+			if (!entry.is_regular_file(ec))
+				continue; // problem with entry, move onto the next one
 
 			// Is it an .sf2 file?
 			auto ext = entry.path().extension().string();

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -165,7 +165,9 @@ std::string CROSS_GetPlatformConfigDir()
 	std::string config_file;
 	Cross::GetPlatformConfigName(config_file);
 	const auto portable_conf_path = GetExecutablePath() / config_file;
-	if (std_fs::is_regular_file(portable_conf_path)) {
+
+	std::error_code ec = {};
+	if (std_fs::is_regular_file(portable_conf_path, ec)) {
 		conf_dir = portable_conf_path.parent_path().string();
 		LOG_MSG("CONFIG: Using portable configuration layout in %s",
 		        conf_dir.c_str());

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -21,6 +21,7 @@
 #include "fs_utils.h"
 
 #include <cassert>
+#include <chrono>
 
 #include "checks.h"
 #include "std_filesystem.h"
@@ -56,4 +57,31 @@ std_fs::path simplify_path(const std_fs::path &original_path) noexcept
 	keep_simplest(std_fs::proximate(original_path, ec));
 
 	return simplest_path;
+}
+
+// Convert a filesystem time to a raw time_t value
+
+// the offset between the filesystem time datum and the system datum is fixed,
+// so we compute that difference once and then re-use it for the runtime's
+// lifetime. This reuse is important because querying the hosts's clock is much
+// slower than subtracting a single integer value.
+std::time_t to_time_t(const std_fs::file_time_type &fs_time)
+{
+	using namespace std::chrono;
+	constexpr auto fs_datum = std_fs::file_time_type{};
+
+	// Subtracting file_time_type's default() and now() values gives us a
+	// unitless scalar. which is then added-to by the system time - which
+	// transforms the value into a system-time type.
+	static auto fs_to_sys_delta = fs_datum -
+	                              std_fs::file_time_type::clock::now() +
+	                              system_clock::now();
+
+	// Again, we subtract file_time_type's default() from the actual time
+	// giving us another unitless scalar, and then add the previous system
+	// time delta to transform it to a system-time type.
+	const auto sys_time = time_point_cast<system_clock::duration>(
+	        fs_time - fs_datum + fs_to_sys_delta);
+
+	return system_clock::to_time_t(sys_time);
 }

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -136,14 +136,7 @@ static bool load_message_file(const std_fs::path &filename)
 	if (filename.empty())
 		return false;
 
-	auto check_file = [](const std_fs::path &filename) {
-		if (filename.empty())
-			return false;
-		return (std_fs::status(filename).type() !=
-		        std_fs::file_type::not_found);
-	};
-
-	if (!check_file(filename)) {
+	if (!path_exists(filename) || !is_readable(filename)) {
 		LOG_MSG("LANG: Language file %s not found, skipping",
 		        filename.string().c_str());
 		return false;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -229,7 +229,8 @@ static const std::deque<std_fs::path> &GetResourceParentPaths()
 		return paths;
 
 	auto add_if_exists = [&](const std_fs::path &p) {
-		if (std_fs::is_directory(p))
+		std::error_code ec = {};
+		if (std_fs::is_directory(p, ec))
 			paths.emplace_back(p);
 	};
 

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -485,8 +485,12 @@ bool path_exists(const std_fs::path &path)
 bool is_writable(const std_fs::path &p)
 {
 	using namespace std_fs;
-	std::error_code ec; // avoid exceptions
-	const auto perms = status(p, ec).permissions();
+	std::error_code ec  = {}; // avoid exceptions
+	const auto p_status = status(p, ec);
+	if (ec)
+		return false;
+
+	const auto perms = p_status.permissions();
 	return ((perms & perms::owner_write) != perms::none ||
 	        (perms & perms::group_write) != perms::none ||
 	        (perms & perms::others_write) != perms::none);
@@ -495,8 +499,12 @@ bool is_writable(const std_fs::path &p)
 bool is_readable(const std_fs::path &p)
 {
 	using namespace std_fs;
-	std::error_code ec; // avoid exceptions
-	const auto perms = status(p, ec).permissions();
+	std::error_code ec  = {}; // avoid exceptions
+	const auto p_status = status(p, ec);
+	if (ec)
+		return false;
+
+	const auto perms = p_status.permissions();
 	return ((perms & perms::owner_read) != perms::none ||
 	        (perms & perms::group_read) != perms::none ||
 	        (perms & perms::others_read) != perms::none);


### PR DESCRIPTION
The majority of our path support routines already used the non-throwing forms, however a [new scenario](https://github.com/dosbox-staging/dosbox-staging/issues/1994) involving checking the meson `--prefix /path/at/compile/time`, which is set at compile time, for resources happens to be a read-only physical CDROM drive, and this causes an exception.

Changes per-function and per-file are placed in separate commits to ease bisecting if this PR causes any regressions during the 0.80 period.

Fixes #1994