### PR TITLE
Fix several English strings too long to fit on screen

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -449,8 +449,8 @@ void DOSBOX_Init()
 	        "Select a language to use: de, en, es, fr, it, nl, pl, and ru\n"
 	        "Notes: This setting will override the 'LANG' environment, if set.\n"
 	        "       The 'resources/translations' directory bundled with the executable holds\n"
-	        "       these files. Please keep it along-side the executable to support this feature.");
-
+	        "       these files. Please keep it along-side the executable to support this\n"
+	        "       feature.");
 	pstring = secprop->Add_string("machine", only_at_start, "svga_s3");
 	pstring->Set_values(machines);
 	pstring->Set_help("The type of machine DOSBox tries to emulate.");
@@ -485,7 +485,8 @@ void DOSBOX_Init()
 	        "  repair:  Repair (and report) faults using adjacent chain blocks.\n"
 	        "  report:  Report faults but otherwise proceed as-is.\n"
 	        "  allow:   Allow faults to go unreported (hardware behavior).\n"
-	        "The default (deny) is recommended unless a game is failing with MCB corruption errors.");
+	        "The default (deny) is recommended unless a game is failing with MCB corruption\n"
+	        "errors.");
 	pstring->Set_values(mcb_fault_strategies);
 
 	const char *vmemsize_choices[] = {
@@ -504,8 +505,8 @@ void DOSBOX_Init()
 	};
 	pstring = secprop->Add_string("vmemsize", only_at_start, "auto");
 	pstring->Set_values(vmemsize_choices);
-	pstring->Set_help(
-	        "Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per video adapter.");
+	pstring->Set_help("Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per\n"
+	                  "video adapter.");
 
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(
@@ -602,31 +603,38 @@ void DOSBOX_Init()
 
 	pstring = secprop->Add_string("cga_colors", only_at_start, "default");
 	pstring->Set_help(
-	        "Sets the interpretation of CGA RGBI colors. Affects all machine types capable of\n"
-	        "displaying CGA or better graphics. Built-in presets:\n"
-	        "  default:       The canonical CGA palette, as emulated by VGA adapters (default).\n"
-	        "  tandy [BL]:    Emulation of an idealised Tandy monitor with adjustable Brown Level\n"
-	        "                 (0 - red, 50 - brown, 100 - dark yellow; defaults to 50).\n"
-	        "  tandy-warm:    Emulation of the actual color output of an unknown Tandy monitor.\n"
-	        "  ibm5153 [C]:   Emulation of the actual color output of an IBM 5153 monitor with\n"
-	        "                 a unique Contrast control that dims non-bright colors only\n"
-	        "                 (0 to 100; defaults to 100).\n"
+	        "Sets the interpretation of CGA RGBI colors. Affects all machine types capable\n"
+	        "of displaying CGA or better graphics. Built-in presets:\n"
+	        "  default:       The canonical CGA palette, as emulated by VGA adapters\n"
+	        "                 (default).\n"
+	        "  tandy [BL]:    Emulation of an idealised Tandy monitor with adjustable\n"
+	        "                 Brown Level (0 - red, 50 - brown, 100 - dark yellow;\n"
+	        "                 defaults to 50).\n"
+	        "  tandy-warm:    Emulation of the actual color output of an unknown Tandy\n"
+	        "                 monitor.\n"
+	        "  ibm5153 [C]:   Emulation of the actual color output of an IBM 5153 monitor\n"
+	        "                 with a unique Contrast control that dims non-bright colors\n"
+	        "                 only (0 to 100; defaults to 100).\n"
 	        "  agi-amiga-v1, agi-amiga-v2, agi-amiga-v3:\n"
 	        "                 Palettes used by the Amiga ports of Sierra AGI games\n"
 	        "                 (see the manual for further details).\n"
-	        "  agi-amigaish:  A mix of EGA and Amiga colors used by the Sarien AGI-interpreter.\n"
+	        "  agi-amigaish:  A mix of EGA and Amiga colors used by the Sarien\n"
+	        "                 AGI-interpreter.\n"
 	        "  scumm-amiga:   Palette used by the Amiga ports of LucasArts EGA games.\n"
 	        "  colodore:      Commodore 64 inspired colors based on the Colodore palette.\n"
 	        "  colodore-sat:  Colodore palette with 20% more saturation.\n"
-	        "  dga16:         A modern take on the canonical CGA palette with dialed back contrast.\n"
-	        "You can also set custom colors by specifying 16 space or comma separated color values,\n"
-	        "either as 3 or 6-digit hex codes (e.g. #f00 or #ff0000 for full red), or decimal\n"
-	        "RGB triplets (e.g. (255, 0, 255) for magenta). The 16 colors are ordered as follows:\n"
-	        "black, blue, green, cyan, red, magenta, brown, light-grey, dark-grey, light-blue,\n"
-	        "light-green, light-cyan, light-red, light-magenta, yellow, and white.\n"
+	        "  dga16:         A modern take on the canonical CGA palette with dialed back\n"
+	        "                 contrast.\n"
+	        "You can also set custom colors by specifying 16 space or comma separated color\n"
+	        "values, either as 3 or 6-digit hex codes (e.g. #f00 or #ff0000 for full red),\n"
+	        "or decimal RGB triplets (e.g. (255, 0, 255) for magenta). The 16 colors are\n"
+	        "ordered as follows:\n"
+	        "black, blue, green, cyan, red, magenta, brown, light-grey, dark-grey,\n"
+	        "light-blue, light-green, light-cyan, light-red, light-magenta, yellow,\n"
+	        "and white.\n"
 	        "Their default values, shown here in 6-digit hex code format, are:\n"
-	        "#000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff\n"
-	        "#55ff55 #55ffff #ff5555 #ff55ff #ffff55 and #ffffff, respectively.");
+	        "#000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555\n"
+	        "#5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 and #ffffff, respectively.");
 
 	pmulti = secprop->AddMultiVal("scaler", always, " ");
 	pmulti->SetValue("none");
@@ -870,8 +878,8 @@ void DOSBOX_Init()
 	        "  auto:      Use the appropriate filter determined by 'sbtype'.\n"
 	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
 	        "             Use the filter of this Sound Blaster model.\n"
-	        "  modern:    Use linear interpolation upsampling that acts as a low-pass filter;\n"
-	        "             this is the legacy DOSBox behaviour (default).\n"
+	        "  modern:    Use linear interpolation upsampling that acts as a low-pass\n"
+	        "             filter; this is the legacy DOSBox behaviour (default).\n"
 	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  One or two custom filters in the following format:\n"
 	        "               TYPE ORDER FREQ\n"
@@ -942,7 +950,7 @@ void DOSBOX_Init()
 	Pstring = secprop->Add_string("tandy", when_idle, "auto");
 	Pstring->Set_values(tandys);
 	Pstring->Set_help(
-	        "Enable Tandy Sound System emulation."
+	        "Enable Tandy Sound System emulation.\n"
 	        "For 'auto', emulation is present only if machine is set to 'tandy'.");
 
 	Pstring = secprop->Add_string("tandy_filter", when_idle, "on");
@@ -956,7 +964,7 @@ void DOSBOX_Init()
 	Pstring->Set_help(
 	        "Filter for the Tandy DAC output:\n"
 	        "  on:        Filter the output (default).\n"
-	        "  off:       Don't filter the output."
+	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 
 	// LPT DAC device emulation
@@ -1018,12 +1026,14 @@ void DOSBOX_Init()
 	        "4axis_2  : Support the second joystick only.\n"
 	        "fcs      : Support a Thrustmaster-type joystick.\n"
 	        "ch       : Support a CH Flightstick-type joystick.\n"
-	        "hidden   : Prevent DOS from seeing the joystick(s), but enable them for mapping.\n"
+	        "hidden   : Prevent DOS from seeing the joystick(s), but enable them for\n"
+	        "           mapping.\n"
 	        "disabled : Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
 	        "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
 
 	Pbool = secprop->Add_bool("timed", when_idle, true);
-	Pbool->Set_help("enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).");
+	Pbool->Set_help("enable timed intervals for axis. Experiment with this option, if your\n"
+	                "joystick drifts (away).");
 
 	Pbool = secprop->Add_bool("autofire", when_idle, false);
 	Pbool->Set_help("continuously fires as long as you keep the button pressed.");
@@ -1045,7 +1055,8 @@ void DOSBOX_Init()
 	Pbool = secprop->Add_bool("use_joy_calibration_hotkeys", when_idle, false);
 	Pbool->Set_help(
 	        "Activates hotkeys to allow realtime calibration of the joystick's x and y axis.\n"
-	        "Only consider this if in-game calibration fails and other settings have been tried.\n"
+	        "Only consider this if in-game calibration fails and other settings have been\n"
+	        "tried.\n"
 	        " - Ctrl/Cmd+Arrow-keys adjusts the axis' scalar value:\n"
 	        "     - left and right diminish or magnify the x-axis scalar, respectively.\n"
 	        "     - down and up diminish or magnify the y-axis scalar, respectively.\n"
@@ -1053,8 +1064,9 @@ void DOSBOX_Init()
 	        "     - left and right shift x-axis offset in the given direction.\n"
 	        "     - down and up shift the y-axis offset in the given direction.\n"
 	        " - Reset the X and Y calibration using Ctrl+Delete and Ctrl+Home, respectively.\n"
-	        "Each tap will report X or Y calibration values you can set below. When you find parameters that work,\n"
-	        "quit the game, switch this setting back to false, and populate the reported calibration parameters.");
+	        "Each tap will report X or Y calibration values you can set below. When you find\n"
+	        "parameters that work, quit the game, switch this setting back to false, and\n"
+	        "populate the reported calibration parameters.");
 
 	pstring = secprop->Add_string("joy_x_calibration", when_idle, "auto");
 	pstring->Set_help(

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4159,10 +4159,14 @@ void Config_Add_SDL() {
 	pstring = sdl_sec->Add_string("host_rate", on_start, "auto");
 	pstring->Set_help(
 	        "Set the host's refresh rate:\n"
-	        "  auto:      Use SDI rates, or VRR rates when fullscreen on a high-refresh display.\n"
-	        "  sdi:       Use serial device interface (SDI) rates, without further adjustment.\n"
-	        "  vrr:       Deduct 3 Hz from the reported rate (best-practice for VRR displays).\n"
-	        "  <custom>:  Specify a custom rate as a whole or decimal value greater than 23.000.");
+	        "  auto:      Use SDI rates, or VRR rates when fullscreen on a high-refresh\n"
+	        "             display.\n"
+	        "  sdi:       Use serial device interface (SDI) rates, without further\n"
+	        "             adjustment.\n"
+	        "  vrr:       Deduct 3 Hz from the reported rate (best-practice for VRR\n"
+	        "             displays).\n"
+	        "  <custom>:  Specify a custom rate as a whole or decimal value greater than\n"
+	        "             23.000.");
 
 	Pbool = sdl_sec->Add_bool("vsync", on_start, false);
 	Pbool->Set_help(
@@ -4170,8 +4174,8 @@ void Config_Add_SDL() {
 	        "reduce flickering and tearing, but may also impact performance.");
 
 	pint = sdl_sec->Add_int("vsync_skip", on_start, 7000);
-	pint->Set_help("Number of microseconds to allow rendering to block before skipping "
-	               "the next frame. 0 disables this and will always render.");
+	pint->Set_help("Number of microseconds to allow rendering to block before skipping the next\n"
+	               "frame. 0 disables this and will always render.");
 	pint->SetMinMax(0, 14000);
 
 	const char *presentation_modes[] = {"auto", "cfr", "vfr", 0};
@@ -4239,17 +4243,20 @@ void Config_Add_SDL() {
 	        "Choose a mouse control method:\n"
 	        "   onclick:        Capture the mouse when clicking any button in the window.\n"
 	        "   onstart:        Capture the mouse immediately on start.\n"
-	        "   seamless:       Let the mouse move seamlessly; captures only with middle-click or hotkey.\n"
+	        "   seamless:       Let the mouse move seamlessly; captures only with\n"
+	        "                   middle-click or hotkey.\n"
 	        "   nomouse:        Hide the mouse and don't send input to the game.\n"
 	        "Choose how middle-clicks are handled (second parameter):\n"
 	        "   middlegame:     Middle-clicks are sent to the game.\n"
-	        "   middlerelease:  Middle-click will release the captured mouse, and also capture when seamless.\n"
+	        "   middlerelease:  Middle-click will release the captured mouse, and also\n"
+	        "                   capture when seamless.\n"
 	        "Defaults (if not present or incorrect): ");
 	mouse_control_help += mouse_control_defaults;
 	Pmulti->Set_help(mouse_control_help);
 
 	Pmulti = sdl_sec->AddMultiVal("sensitivity", always, ",");
-	Pmulti->Set_help("Mouse sensitivity. The optional second parameter specifies vertical sensitivity (e.g. 100,-50).");
+	Pmulti->Set_help("Mouse sensitivity. The optional second parameter specifies vertical sensitivity\n"
+	                 "(e.g. 100,-50).");
 	Pmulti->SetValue("100");
 	Pint = Pmulti->GetSection()->Add_int("xsens", always,100);
 	Pint->SetMinMax(-1000,1000);
@@ -4263,7 +4270,7 @@ void Config_Add_SDL() {
 	        "fullscreen or when the mouse is captured in window mode.");
 
 	Pbool = sdl_sec->Add_bool("waitonerror", always, true);
-	Pbool->Set_help("Wait before closing the console if dosbox has an error.");
+	Pbool->Set_help("Keep the console open if an error has occurred.");
 
 	Pmulti = sdl_sec->AddMultiVal("priority", always, " ");
 	Pmulti->SetValue("auto auto");

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2746,19 +2746,20 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 
 	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_blocksize);
 	int_prop->Set_values(blocksizes);
-	int_prop->Set_help(
-	        "Mixer block size; larger values might help with sound stuttering but sound will also be more lagged.");
+	int_prop->Set_help("Mixer block size; larger values might help with sound stuttering but sound will\n"
+	                   "also be more lagged.");
 
 	int_prop = sec_prop.Add_int("prebuffer", only_at_start, default_prebuffer_ms);
 	int_prop->SetMinMax(0, max_prebuffer_ms);
 	int_prop->Set_help(
-	        "How many milliseconds of sound to render on top of the blocksize; larger values might help with sound stuttering but sound will also be more lagged.");
+	        "How many milliseconds of sound to render on top of the blocksize; larger values\n"
+	        "might help with sound stuttering but sound will also be more lagged.");
 
 	bool_prop = sec_prop.Add_bool("negotiate",
 	                              only_at_start,
 	                              default_allow_negotiate);
-	bool_prop->Set_help(
-	        "Let the system audio driver negotiate (possibly) better rate and blocksize settings.");
+	bool_prop->Set_help("Let the system audio driver negotiate (possibly) better rate and blocksize\n"
+	                    "settings.");
 
 	const auto default_on = true;
 	bool_prop = sec_prop.Add_bool("compressor", when_idle, default_on);
@@ -2772,8 +2773,9 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "Set crossfeed globally on all stereo channels for headphone listening:\n"
 	        "  off:         No crossfeed (default).\n"
 	        "  on:          Enable crossfeed (at strength 40).\n"
-	        "  <strength>:  Set crossfeed strength from 0 to 100, where 0 means no crossfeed (off)\n"
-	        "               and 100 full crossfeed (effectively turning stereo content into mono).\n"
+	        "  <strength>:  Set crossfeed strength from 0 to 100, where 0 means no crossfeed\n"
+	        "               (off) and 100 full crossfeed (effectively turning stereo content\n"
+	        "               into mono).\n"
 	        "Note: You can set per-channel crossfeed via mixer commands.");
 
 	const char *reverb_presets[] = {"off", "on", "tiny", "small", "medium", "large", "huge", nullptr};


### PR DESCRIPTION
There are a lot of English strings which has too long lines (over 79 characters), which results in commands like:

```
config -h sdl host_rate
config -h sdl vsync_skip
config -h sdl capture_mouse
config -h dosbox language
config -h dosbox mcb_fault_strategy
config -h dosbox vmemsize
config -h render cga_colors
config -h mixer negotiate
config -h mixer crossfeedconfig -h joystick
config -h sblaster sb_filter
config -h speaker tandy
config -h speaker tandy_dac_filter
config -h joystick timed
config -h joystick use_joy_calibration_hotkeys
```

to display malformed output on standard 80-column DOS screen mode. This PR fixes every one I could find. Note: despite changes in English strings, the translated strings shouldn't be invalidated!