### PR TITLE
Parse language options before writing the conf file

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -59,7 +59,6 @@ MachineType machine;
 SVGACards svgaCard;
 
 /* The whole load of startups for all the subfunctions */
-void MSG_Init(Section_prop *);
 void LOG_StartUp();
 void MEM_Init(Section *);
 void PAGING_Init(Section *);
@@ -340,7 +339,6 @@ static void DOSBOX_RealInit(Section * sec) {
 	ticksLast=GetTicks();
 	ticksLocked = false;
 	DOSBOX_SetLoop(&Normal_Loop);
-	MSG_Init(section);
 
 	MAPPER_AddHandler(DOSBOX_UnlockSpeed, SDL_SCANCODE_F12, MMOD2,
 	                  "speedlock", "Speedlock");

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -7,7 +7,6 @@ libmisc_sources = [
     'fs_utils_posix.cpp',
     'fs_utils_win32.cpp',
     'help_util.cpp',
-    'messages.cpp',
     'pacer.cpp',
     'programs.cpp',
     'rwqueue.cpp',
@@ -17,22 +16,33 @@ libmisc_sources = [
     'unicode.cpp',
 ]
 
+libmisc_dependencies = [
+    corefoundation_dep,
+    ghc_dep,
+    libloguru_dep,
+    libslirp_dep,
+    libwhereami_dep,
+    sdl2_dep,
+    stdcppfs_dep,
+    winsock2_dep,
+]
+
 libmisc = static_library(
     'misc',
-    libmisc_sources,
+    libmisc_sources + 'messages.cpp',
     include_directories: incdir,
-    dependencies: [
-        corefoundation_dep,
-        ghc_dep,
-        libloguru_dep,
-        libslirp_dep,
-        libwhereami_dep,
-        sdl2_dep,
-        stdcppfs_dep,
-        winsock2_dep,
-    ],
+    dependencies: libmisc_dependencies,
+)
+
+libmisc_stubs = static_library(
+    'misc_stubs',
+    libmisc_sources + 'messages_stubs.cpp',
+    include_directories: incdir,
+    dependencies: libmisc_dependencies,
 )
 
 libmisc_dep = declare_dependency(link_with: libmisc)
+
+libmisc_stubs_dep = declare_dependency(link_with: libmisc_stubs)
 
 internal_deps += libmisc_dep

--- a/src/misc/messages_stubs.cpp
+++ b/src/misc/messages_stubs.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,22 +18,30 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include "dosbox.h"
+// Empty functions to suppress output in unit tests as well as a to eliminate
+// dependency-sprawl
 
-#include "control.h"
-#include "logging.h"
+void MSG_Add(const char *, const char *) {}
 
-// During testing we never want to log to stdout/stderr, as it could
-// negatively affect test harness.
-void GFX_ShowMsg(const char *, ...) {}
-void DEBUG_ShowMsg(const char *, ...) {}
-
-void DEBUG_HeavyWriteLogInstruction() {}
-
-#if C_DEBUG
-void LOG::operator()([[maybe_unused]] char const *buf, ...)
+const char *MSG_Get(char const *)
 {
-	(void)d_type;     // Deliberately unused.
-	(void)d_severity; // Deliberately unused.
+	return "";
 }
-#endif
+
+const char *MSG_GetRaw(char const *)
+{
+	return "";
+}
+
+bool MSG_Exists(const char *)
+{
+	return true;
+}
+
+bool MSG_Write(const char *)
+{
+	return true;
+}
+
+class Section_prop;
+void MSG_Init(Section_prop *) {}

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1544,6 +1544,7 @@ const std::string &SETUP_GetLanguage()
 
 // Parse the user's configuration files starting with the primary, then custom
 // -conf's, and finally the local dosbox.conf
+void MSG_Init(Section_prop *);
 void SETUP_ParseConfigFiles(const std::string &config_path)
 {
 	std::string config_file;
@@ -1572,6 +1573,13 @@ void SETUP_ParseConfigFiles(const std::string &config_path)
 			}
 		}
 	}
+
+	// Once we've parsed all the potential conf files, we've down our best
+	// to discover the user's desired language. At this point, we can now
+	// initialize the messaging system which honors the language and loads
+	// those messages.
+	if (const auto sec = control->GetSection("dosbox"); sec)
+		MSG_Init(static_cast<Section_prop *>(sec));
 
 	// Create a new primary if permitted and no other conf was loaded
 	if (wants_primary_conf && !control->configfiles.size()) {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -43,7 +43,7 @@ endforeach
 example = executable(
     'example',
     ['example_tests.cpp', 'stubs.cpp'],
-    dependencies: [gmock_dep, libmisc_dep, ghc_dep, libloguru_dep],
+    dependencies: [gmock_dep, libmisc_stubs_dep, ghc_dep, libloguru_dep],
     include_directories: incdir,
     cpp_args: cpp_args,
 )
@@ -52,7 +52,7 @@ test('gtest example', example, should_fail: true)
 fs_utils = executable(
     'fs_utils',
     ['fs_utils_tests.cpp', 'stubs.cpp'],
-    dependencies: [gmock_dep, libmisc_dep, ghc_dep, libloguru_dep],
+    dependencies: [gmock_dep, libmisc_stubs_dep, ghc_dep, libloguru_dep],
     include_directories: incdir,
     cpp_args: cpp_args,
 )
@@ -66,20 +66,20 @@ test(
 # other unit tests
 
 unit_tests = [
-    {'name': 'ansi_code_markup', 'deps': [libmisc_dep]},
+    {'name': 'ansi_code_markup', 'deps': [libmisc_stubs_dep]},
     {'name': 'bit_view', 'deps': []},
     {'name': 'bitops', 'deps': []},
     {'name': 'dos_files', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'drives', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'int10_modes', 'deps': [dosbox_dep], 'extra_cpp': []},
-    {'name': 'iohandler_containers', 'deps': [libmisc_dep]},
-    {'name': 'math_utils', 'deps': [libmisc_dep]},
-    {'name': 'rwqueue', 'deps': [libmisc_dep]},
-    {'name': 'setup', 'deps': [libmisc_dep]},
+    {'name': 'iohandler_containers', 'deps': [libmisc_stubs_dep]},
+    {'name': 'math_utils', 'deps': [libmisc_stubs_dep]},
+    {'name': 'rwqueue', 'deps': [libmisc_stubs_dep]},
+    {'name': 'setup', 'deps': [libmisc_stubs_dep]},
     {'name': 'shell_cmds', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'shell_redirection', 'deps': [dosbox_dep], 'extra_cpp': []},
-    {'name': 'string_utils', 'deps': [libmisc_dep]},
-    {'name': 'support', 'deps': [libmisc_dep]},
+    {'name': 'string_utils', 'deps': [libmisc_stubs_dep]},
+    {'name': 'support', 'deps': [libmisc_stubs_dep]},
 ]
 
 extra_link_flags = []

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -340,6 +340,7 @@ $(TargetPath)</Command>
     <ClCompile Include="..\..\src\misc\cross.cpp" />
     <ClCompile Include="..\..\src\misc\fs_utils.cpp" />
     <ClCompile Include="..\..\src\misc\fs_utils_win32.cpp" />
+    <ClCompile Include="..\..\src\misc\messages_stubs.cpp" />
     <ClCompile Include="..\..\src\misc\rwqueue.cpp" />
     <ClCompile Include="..\..\src\misc\setup.cpp" />
     <ClCompile Include="..\..\src\misc\string_utils.cpp" />


### PR DESCRIPTION
How to test:

1. Delete (or rename) your primary conf file.
1. Launch this branch with one of the translated languages set using any of the known mechanisms including in a local conf, `LANG=..` environment variable, or `-lang ..` command-line argument.
1. Check the your freshly written primary conf.

The `--printconf` CLI argument will print the full path your primary conf (if it's hard to find).
 
Fixes #1997 
