### PR TITLE
Contribute a script to convert from YouTube chapters to CD-DA

### DIFF
--- a/contrib/scripts/yt-chapters-to-cdda.sh
+++ b/contrib/scripts/yt-chapters-to-cdda.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2022-2022  kcgen <kcgen@users.noreply.github.com>
+
+# Bash strict-mode
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT=$(basename "$0")
+readonly SCRIPT
+
+print_usage() {
+    echo ""
+    echo "usage: $SCRIPT URI [URI [...]]"
+    echo
+    echo "Convert a YouTube video with chapters into CDDA+CUE format."
+    echo " - Multiple videos can be provided; each will be converted."
+    echo " - URIs can be the full https:// URL or just the identifier."
+    echo ""
+    echo "Depends on:"
+    echo " - yt-dlp (install with pip3 install yt-dlp)"
+    echo " - ffmpeg: install with package manager"
+    echo " - basename: install with package manager"
+    echo ""
+}
+
+main() {
+    case ${1:-} in
+    -h | -help | --help) print_usage ;;
+    *)
+        check-dependencies
+        convert-chapters-to-cdda "$@"
+        ;;
+    esac
+}
+
+check-dependencies() {
+    local missing_deps=0
+    for dep in yt-dlp ffmpeg find sort rm basename; do
+        if ! command -v "$dep" &>/dev/null; then
+            echo "Missing dependency: $dep could not be found in the PATH"
+            ((missing_deps++))
+        fi
+    done
+    # Were any missing?
+    if [[ "$missing_deps" -gt 0 ]]; then
+        echo "Install the above programs and try again"
+        exit 1
+    fi
+}
+
+download-chapters-from-uri() {
+    local uri="$1"
+
+    # YouTube Opus format identifiers in order of quality
+    local webm_formats="338/251/250/249"
+
+    # Directory/##-Track output layout
+    local cdda_ouput="chapter:%(title)s/%(section_number)02d-%(section_title)s.%(ext)s"
+
+    # Fetch the track and split it on chapters
+    yt-dlp \
+        --split-chapters \
+        --restrict-filenames \
+        --format "$webm_formats" \
+        --output "$cdda_ouput" \
+        "$uri"
+}
+
+extract-opus-from-webm() {
+    local webm="$1"
+    local opus="${1%.webm}.opus"
+
+    if [[ -f "$webm" && ! -f "$opus" ]]; then
+        # Extract the Opus stream from the WebM
+        ffmpeg -hide_banner -loglevel error \
+            -i "$webm" \
+            -vn -acodec copy "$opus"
+        # Delete the WebM source if we've got the Opus
+        if [[ -f "$opus" ]]; then
+            rm "$webm"
+        fi
+    fi
+}
+
+add-track-to-cue() {
+    local dir
+    local webm
+    local opus
+    dir=$(basename "${1%/*}")
+    webm=$(basename "$1")
+    opus=$(basename "$webm" webm)opus
+
+    local track_number="$2"
+
+    # Ensure this directory and the track exists
+    if [[ ! -d "$dir" || ! -f "$dir/$opus" ]]; then
+        echo "Problem finding the CDDA directory ($dir) and/or track ($dir/$opus)"
+        exit 1
+    fi
+
+    # Add a CUE entry for the track
+    cue_path="$dir/cdrom.cue"
+    {
+        echo "FILE \"$opus\" OPUS"
+        echo "  TRACK $track_number AUDIO"
+        # Add pre-gap just for the first track
+        if [[ "$track_number" == "1" ]]; then
+            echo "  PREGAP 00:02:00"
+        fi
+        echo "  INDEX 01 00:00:00"
+        echo ""
+    } >>"$cue_path"
+}
+
+convert-local-webm-to-cdda() {
+    local count=1
+    for webm in $(find . -maxdepth 2 -mindepth 2 -name '*.webm' | sort); do
+        extract-opus-from-webm "$webm"
+        add-track-to-cue "$webm" "$count"
+        ((count += 1))
+    done
+}
+
+print-dosbox-imgmount-line() {
+    local cue="$1"
+    if [[ -n "$cue" ]]; then
+        echo "imgmount d \"$cue\" -t cdrom"
+    fi
+}
+
+convert-chapters-to-cdda() {
+    for uri in "$@"; do
+        cue_path=""
+        download-chapters-from-uri "$uri"
+        convert-local-webm-to-cdda
+        print-dosbox-imgmount-line "$cue_path"
+    done
+}
+
+main "$@"


### PR DESCRIPTION
This is a handy script to simplify the task of generating DOSBox mountable CD-DA content from public domain or creative-commons-licensed YouTube chapters.

This might be for listening with a DOS CD-DA player or perhaps using remastered/remixed tracks that can be swapped in for a games' original CD-DA tracks.

This isn't critical or mandatory, but it's specifically developed to assist with generating DOSBox Staging mountable content and therefore lives in the `./contrib/scripts/` directory (not part of resources).

(Other helper scripts to simplify managing DOSBox Staging-related inputs or outputs are welcome!)

## How to use it?

1. Install its dependencies:
 - `pip3 install yt-dlp`
 - ffmpeg
 - GNU find
 - GNU bash

2. Create or enter the directory where you want to create the CD-DA content.

    We will create new `sjgplay` directory with [the player](http://www.6502.org/users/sjgray/software/sjgplay/sjgplay_dos.html) inside, and will stay within this directory for all of the subsequent steps in this example.

    ``` shell
    mkdir sjgplay
    cd sjgplay
    wget https://software-archive.tifan.la/cndos-new-dos-16-years-collection/soft/doswares/sjgpl129.zip
    unzip -o sjgpl129.zip
    rm *.zip *.ZIP
    ```

    Create a **`dosbox.conf`** (inside this sjgplay directory) with minimal content, as follows:

    ``` ini
    [sdl]
    windowresolution = s
    
    # Headphone listening
    [mixer]
    compressor = on
    chorus     = on
    crossfeed  = on
    
    [midi]
    midiconfig = none
    
    [sblaster]
    sbtype = none
    
    [gus]
    gus = none
    
    [speaker]
    pcspeaker = none
    tandy = off
    lpt_dac = none
    
    [autoexec]
    mount c .
    c:
    autotype enter
    sjgplay.exe
    ````

3. Find a public domain or creative-commons YouTube video 99-minutes or less that includes chapters. For example:

    ![2022-10-16_22-20](https://user-images.githubusercontent.com/1557255/196096462-33b55641-2949-4fe7-8af4-dbfd3b10dc1e.png)

---

4. Click on the video and copy its identifier

    ![2022-10-16_22-26](https://user-images.githubusercontent.com/1557255/196096525-93a3e002-7d4c-49a4-bb62-903ffff636ec.png)

---

 
5. Pass the identifier to the `yt-chapters-to-cdda.sh` script:

    ``` shell
    # ensure you're still in your CD-DA directory
    ~/src/dosbox-staging/contrib/scripts/yt-chapters-to-cdda.sh hri2T0ZIy6w
    ```

    It will produce a subdirectory with tracks and print an `imgmount` command that you can drop in dosbox.conf's `[autoexec]` section:

    ```
    imgmount d "Best_Classic_Piano_Vol.1/cdrom.cue" -t cdrom
    ```

6. Paste the imgmount line into your conf's `[autoexec]` section:

    ``` ini
    [autoexec]
    imgmount d "Best_Classic_Piano_Vol.1/cdrom.cue" -t cdrom
    mount c .
    c:
    autotype enter
    sjgplay.exe
    ```

7. Launch DOSBox Staging, while staying within your `sjgplay` directory (your current working directory). DOSBox Staging should mount your new CD-DA directory and start the CD-DA player:

    ![Screenshot from 2022-10-16 22-46-29](https://user-images.githubusercontent.com/1557255/196098471-8c6d55d0-7216-4fac-bfd3-a9a230592e2d.png)

