### PR TITLE
Minor mouse enhancements

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -50,8 +50,7 @@ enum class MouseInterfaceId : uint8_t {
 	None  = UINT8_MAX
 };
 
-constexpr uint8_t num_mouse_interfaces = static_cast<uint8_t>(MouseInterfaceId::Last) +
-                                         1;
+constexpr uint8_t num_mouse_interfaces = static_cast<uint8_t>(MouseInterfaceId::Last) + 1;
 
 enum class MouseMapStatus : uint8_t {
 	HostPointer,
@@ -65,7 +64,7 @@ enum class MouseMapStatus : uint8_t {
 // ***************************************************************************
 
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
-                      const uint16_t x_abs, const uint16_t y_abs);
+                      const int32_t x_abs, const int32_t y_abs);
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
                       const MouseInterfaceId device_id);
 
@@ -76,23 +75,37 @@ void MOUSE_EventButton(const uint8_t idx, const bool pressed,
 void MOUSE_EventWheel(const int16_t w_rel);
 void MOUSE_EventWheel(const int16_t w_rel, const MouseInterfaceId device_id);
 
+// Notify that guest OS is being booted, so that certain
+// parts of the emulation (like DOS driver) should be disabled
 void MOUSE_NotifyBooting();
 
-void MOUSE_SetConfigSeamless(const bool seamless);
-void MOUSE_SetConfigNoMouse();
+// Notify that GFX subsystem (currently SDL) is started
+// and can accept requests from mouse emulation module
+void MOUSE_NotifyReadyGFX();
 
-void MOUSE_NewScreenParams(const uint16_t clip_x, const uint16_t clip_y,
-                           const uint16_t res_x, const uint16_t res_y,
-                           const bool fullscreen, const uint16_t x_abs,
-                           const uint16_t y_abs);
+// Notify that window has lost or gained focus, this tells the mouse
+// emulation code if it should process mouse events or ignore them
+void MOUSE_NotifyHasFocus(const bool has_focus);
 
-// ***************************************************************************
-// Information for the GFX subsystem
-// ***************************************************************************
+// A GUI has to use this function to tell when it takes over or releases
+// the mouse; this will change various settings like raw input (we don't
+// want it for the GUI) or cursor visibility (we want the host cursor
+// visible while a GUI is running)
+void MOUSE_NotifyTakeOver(const bool gui_has_taken_over);
 
-bool MOUSE_IsUsingSeamlessDriver(); // if driver with seamless pointer support
-                                    // is running
-bool MOUSE_IsUsingSeamlessSetting(); // if user selected seamless mode is in effect
+// To be called when screen mode changes, emulator window gets resized, etc.
+// clip_x / clip_y - size of the black bars around screen area
+// res_x / res_y   - size of drawing area (in hot OS pixels)
+// x_abs / y_abs   - new absolute mouse cursor position
+// is_fullscreen   - whether the new mode is fullscreen or windowed
+void MOUSE_NewScreenParams(const uint32_t clip_x, const uint32_t clip_y,
+                           const uint32_t res_x, const uint32_t res_y,
+                           const int32_t x_abs, const int32_t y_abs,
+                           const bool is_fullscreen);
+
+// Notification that user pressed/released the hotkey combination
+// to capture/release the mouse
+void MOUSE_ToggleUserCapture(const bool pressed);
 
 // ***************************************************************************
 // BIOS mouse interface for PS/2 mouse

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -48,13 +48,6 @@ static void update_frame_surface(const uint16_t *changedLines);
 constexpr void update_frame_noop([[maybe_unused]] const uint16_t *) { /* no-op */ }
 static inline bool present_frame_noop() { return true; }
 
-enum MouseControlType {
-	CaptureOnClick = 1 << 0,
-	CaptureOnStart = 1 << 1,
-	Seamless       = 1 << 2,
-	NoMouse        = 1 << 3
-};
-
 enum SCREEN_TYPES	{
 	SCREEN_SURFACE,
 	SCREEN_TEXTURE,
@@ -232,11 +225,6 @@ struct SDL_Block {
 		int period_us_early = 0;
 		int period_us_late = 0;
 	} frame = {};
-	struct {
-		MouseControlType control_choice = Seamless;
-		bool middle_will_release = true;
-		bool has_focus = false;
-	} mouse          = {};
 	PPScale pp_scale = {};
 	SDL_Rect updateRects[1024] = {};
 	bool use_exact_window_resolution = false;

--- a/include/video.h
+++ b/include/video.h
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2020-2022  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -78,12 +79,12 @@ void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
 void GFX_EndUpdate( const uint16_t *changedLines );
 void GFX_GetSize(int &width, int &height, bool &fullscreen);
-void GFX_UpdateMouseState();
 void GFX_LosingFocus();
 void GFX_RegenerateWindow(Section *sec);
-void GFX_SetMouseRawInput(const bool raw_input);
-void GFX_MouseCaptureAfterMapping();
-bool GFX_MouseIsAvailable();
+
+void GFX_SetMouseCapture(const bool requested_capture);
+void GFX_SetMouseVisibility(const bool requested_visible);
+void GFX_SetMouseRawInput(const bool requested_raw_input);
 
 #if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);

--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -23,7 +23,6 @@
 #include "ansi_code_markup.h"
 #include "checks.h"
 #include "string_utils.h"
-#include "video.h"
 
 #include <set>
 
@@ -323,8 +322,6 @@ void MOUSECTL::FinalizeMapping()
 	WriteOut("\n");
 	WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MAP_HINT"));
 	WriteOut("\n\n");
-
-	GFX_MouseCaptureAfterMapping();
 }
 
 bool MOUSECTL::CmdMap(const MouseInterfaceId interface_id, const std::string &pattern)

--- a/src/hardware/mouse/mouse_common.cpp
+++ b/src/hardware/mouse/mouse_common.cpp
@@ -29,9 +29,8 @@ CHECK_NARROWING();
 // Common variables
 // ***************************************************************************
 
-MouseInfo mouse_info;
+MouseInfo   mouse_info;
 MouseShared mouse_shared;
-MouseVideo mouse_video;
 
 // ***************************************************************************
 // Common helper calculations

--- a/src/hardware/mouse/mouse_common.h
+++ b/src/hardware/mouse/mouse_common.h
@@ -30,28 +30,21 @@
 class MouseShared {
 public:
 	bool active_bios = false; // true = BIOS has a registered callback
-	bool active_dos = false; // true = DOS driver has a functioning callback
-	bool active_vmm = false; // true = VMware-compatible driver is active
+	bool active_dos  = false; // true = DOS driver has a functioning callback
+	bool active_vmm  = false; // true = VMware-compatible driver is active
 
 	bool dos_cb_running = false; // true = DOS callback is running
 
 	// Readiness for initialization
-	bool ready_startup_sequence = false;
-	bool ready_config_mouse     = false;
-	bool ready_config_sdl       = false;
+	bool ready_init   = false; // if allowed to init in the main startup sequence
+	bool ready_config = false; // if configuration was read
+	bool ready_gfx    = false; // if GFX subsystem is ready
 
 	bool started = false;
-};
 
-class MouseVideo {
-public:
-	bool fullscreen = true;
-
-	uint16_t res_x = 640; // resolution to which guest image is scaled,
-	uint16_t res_y = 400; // excluding black borders
-
-	uint16_t clip_x = 0; // clipping = size of black border (one side)
-	uint16_t clip_y = 0;
+	// Screen size
+	uint32_t resolution_x = 640; // resolution to which guest image is scaled,
+	uint32_t resolution_y = 400; // excluding black borders
 };
 
 class MouseInfo {
@@ -60,11 +53,8 @@ public:
 	std::vector<MousePhysicalInfoEntry> physical    = {};
 };
 
-extern MouseInfo mouse_info;     // information which can be shared externally
+extern MouseInfo   mouse_info;   // information which can be shared externally
 extern MouseShared mouse_shared; // shared internal information
-extern MouseVideo mouse_video; // video information - resolution, clipping, etc.
-
-extern bool mouse_is_captured;
 
 // ***************************************************************************
 // Common helper calculations

--- a/src/hardware/mouse/mouse_config.h
+++ b/src/hardware/mouse/mouse_config.h
@@ -59,6 +59,8 @@ extern MousePredefined mouse_predefined;
 // Configuration file content
 // ***************************************************************************
 
+enum class MouseCapture : uint8_t { Seamless, OnClick, OnStart, NoMouse };
+
 enum class MouseModelPS2 : uint8_t {
 	// Values must match PS/2 protocol IDs
 	Standard     = 0x00,
@@ -74,19 +76,9 @@ enum class MouseModelCOM : uint8_t {
 	MouseSystems
 };
 
-enum class MouseModelBus : uint8_t {
-	NoMouse,
-	Bus,
-	InPort,
-};
-
 struct MouseConfig {
-	// From [sdl] section
-
-	bool no_mouse = false; // true = NoMouse selected in GUI
-	bool seamless = false; // true = seamless mouse integration
-
-	// From [mouse] section
+	MouseCapture capture = MouseCapture::OnStart;
+	bool middle_release  = true;
 
 	int16_t sensitivity_x = 50; // default sensitivity values
 	int16_t sensitivity_y = 50;
@@ -103,6 +95,8 @@ struct MouseConfig {
 	// Helper functions for external modules
 
 	static const std::vector<uint16_t> &GetValidMinRateList();
+	static bool ParseCaptureType(const std::string &capture_str,
+	                             MouseCapture &capture);
 	static bool ParseCOMModel(const std::string &model_str,
 	                          MouseModelCOM &model, bool &auto_msm);
 	static bool ParsePS2Model(const std::string &model_str, MouseModelPS2 &model);

--- a/src/hardware/mouse/mouse_interfaces.h
+++ b/src/hardware/mouse/mouse_interfaces.h
@@ -27,20 +27,22 @@
 // Main mouse module
 // ***************************************************************************
 
-void MOUSE_Startup();
+void MOUSE_StartupIfReady();
 
 void MOUSE_NotifyDisconnect(const MouseInterfaceId interface_id);
 void MOUSE_NotifyFakePS2(); // fake PS/2 event, for VMware protocol support
 void MOUSE_NotifyResetDOS();
-void MOUSE_NotifyStateChanged();
+
+bool MOUSE_IsCaptured();
+void MOUSE_UpdateGFX();
 
 // ***************************************************************************
 // DOS mouse driver
 // ***************************************************************************
 
 void MOUSEDOS_Init();
-void MOUSEDOS_NotifyMapped(const bool enabled);
-void MOUSEDOS_NotifyRawInput(const bool enabled);
+void MOUSEDOS_NotifyInputType(const bool new_use_relative,
+                              const bool new_is_input_raw);
 void MOUSEDOS_NotifyMinRate(const uint16_t value_hz);
 void MOUSEDOS_DrawCursor();
 
@@ -51,7 +53,7 @@ Bitu MOUSEDOS_DoCallback(const uint8_t mask, const MouseButtons12S buttons_12S);
 // - understands up to 3 buttons
 
 bool MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
-                          const uint16_t x_abs, const uint16_t y_abs);
+                          const uint32_t x_abs, const uint32_t y_abs);
 bool MOUSEDOS_NotifyWheel(const int16_t w_rel);
 
 uint8_t MOUSEDOS_UpdateMoved();
@@ -88,16 +90,16 @@ Bitu MOUSEBIOS_DoCallback();
 // ***************************************************************************
 
 void MOUSEVMM_Init();
-void MOUSEVMM_NotifyMapped(const bool enabled);
-void MOUSEVMM_NotifyRawInput(const bool enabled);
-void MOUSEVMM_NewScreenParams(const uint16_t x_abs, const uint16_t y_abs);
+void MOUSEVMM_NotifyInputType(const bool new_use_relative,
+                              const bool new_is_input_raw);
+void MOUSEVMM_NewScreenParams(const uint32_t x_abs, const uint32_t y_abs);
 void MOUSEVMM_Deactivate();
 
 // - needs absolute mouse position
 // - understands up to 3 buttons
 
 bool MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
-                          const uint16_t x_abs, const uint16_t y_abs);
+                          const uint32_t x_abs, const uint32_t y_abs);
 bool MOUSEVMM_NotifyButton(const MouseButtons12S buttons_12S);
 bool MOUSEVMM_NotifyWheel(const int16_t w_rel);
 
@@ -128,7 +130,7 @@ public:
 	static MouseInterface *GetSerial(const uint8_t port_id);
 
 	virtual void NotifyMoved(MouseEvent &ev, const float x_rel, const float y_rel,
-	                         const uint16_t x_abs, const uint16_t y_abs) = 0;
+	                         const uint32_t x_abs, const uint32_t y_abs) = 0;
 	virtual void NotifyButton(MouseEvent &ev, const uint8_t idx,
 	                          const bool pressed)                 = 0;
 	virtual void NotifyWheel(MouseEvent &ev, const int16_t w_rel) = 0;
@@ -166,6 +168,7 @@ public:
 	void ConfigResetMinRate();
 
 	virtual void UpdateConfig();
+	virtual void UpdateInputType();
 	virtual void RegisterListener(CSerialMouse &listener_object);
 	virtual void UnRegisterListener();
 
@@ -182,7 +185,6 @@ protected:
 	void SetMapStatus(const MouseMapStatus status,
 	                  const uint8_t device_idx = idx_host_pointer);
 
-	virtual void UpdateRawMapped();
 	virtual void UpdateSensitivity();
 	virtual void UpdateMinRate();
 	virtual void UpdateRate();

--- a/src/hardware/mouse/mouse_manymouse.cpp
+++ b/src/hardware/mouse/mouse_manymouse.cpp
@@ -342,7 +342,7 @@ void ManyMouseGlue::MapFinalize()
 	PIC_RemoveEvents(manymouse_tick);
 	is_mapping_in_effect = false;
 	for (const auto &entry : mouse_info.physical) {
-		if (entry.IsMapped())
+		if (!entry.IsMapped())
 			continue;
 
 		is_mapping_in_effect = true;

--- a/src/hardware/mouse/mouseif_ps2_bios.cpp
+++ b/src/hardware/mouse/mouseif_ps2_bios.cpp
@@ -438,14 +438,14 @@ void MOUSEBIOS_SetScaling21(const bool enable)
 bool MOUSEBIOS_Enable()
 {
 	mouse_shared.active_bios = callback_init;
-	MOUSE_NotifyStateChanged();
+	MOUSE_UpdateGFX();
 	return callback_init;
 }
 
 bool MOUSEBIOS_Disable()
 {
 	mouse_shared.active_bios = false;
-	MOUSE_NotifyStateChanged();
+	MOUSE_UpdateGFX();
 	return true;
 }
 


### PR DESCRIPTION
## User visible changes

1. `capture_mouse` option was removed from `[sdl]` section, it can now be configured in `[mouse]`
2. `middlerelease` is now a separate boolean option - rationale: 
- _middlerelease_ is prone to spelling mistakes, especially when typed by someone with a very basic English skills
- it allows to display the allowed/default values - the multivalue type always leaves them empty
3. Minor improvement related to mouse cursor visibility - try the following:
- configure Seamless mouse integration and a fixed 4:3 aspect ratio
- switch to windowed mode, resize window so that black bars appear at the top/bottom or left/right of the guest display
- as you move the mouse, the cursor will only disappear over the guest display; over the black bars it is now visible (contrary to behavior on _main_)
4. Fixed a stupid bug (wrong condition in `ManyMouseGlue::MapFinalize()`) which prevented re-scanning for newly connected mice in some cases.

## Refactoring

1. All the toolkit-independent code was taken away from  `sdlmain.cpp` - rationale:
- migration to SDL 3.x (or other toolkit) or further GFX rework will be slightly easier
- less complicated inter-module communication
- potential for future behavior improvements, as mouse emulation code has more relevant knowledge than `sdlmain.cpp`

2. The cursor captured/released/visible/hidden/capture-with-middle-click/etc. business logic was rewritten - all the decisions are now taken in one sections of `mouse.cpp` instead of being spread over the whole `sdlmain.cpp`