### PR TITLE
Add mouse related hints to title bar

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -165,6 +165,12 @@ struct SDL_Block {
 		SCREEN_TYPES want_type = SCREEN_SURFACE;
 	} desktop = {};
 	struct {
+		int num_cycles = 0;
+		std::string hint_mouse_str  = {};
+		std::string hint_paused_str = {};
+		std::string cycles_ms_str   = {};
+	} title_bar = {};
+	struct {
 		VsyncPreference when_windowed = {};
 		VsyncPreference when_fullscreen = {};
 		VSYNC_STATE current = VSYNC_STATE::ON;

--- a/include/video.h
+++ b/include/video.h
@@ -82,6 +82,19 @@ void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus();
 void GFX_RegenerateWindow(Section *sec);
 
+enum class MouseHint {
+    None,                    // no hint to display
+    NoMouse,                 // no mouse mode
+    CapturedHotkey,          // mouse captured, use hotkey to release
+    CapturedHotkeyMiddle,    // mouse captured, use hotkey or middle-click to release
+    ReleasedHotkey,          // mouse released, use hotkey to capture
+    ReleasedHotkeyMiddle,    // mouse released, use hotkey or middle-click to capture
+    ReleasedHotkeyAnyButton, // mouse released, use hotkey or any click to capture
+    SeamlessHotkey,          // seamless mouse, use hotkey to capture
+    SeamlessHotkeyMiddle,    // seamless mouse, use hotkey or middle-click to capture
+};
+
+void GFX_SetMouseHint(const MouseHint requested_hint_id);
 void GFX_SetMouseCapture(const bool requested_capture);
 void GFX_SetMouseVisibility(const bool requested_visible);
 void GFX_SetMouseRawInput(const bool requested_raw_input);

--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -550,7 +550,7 @@ void MOUSECTL::AddMessages()
 	        "Wrong syntax, sampling rate has to be one of:\n%s");
 
 	MSG_Add("SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE",
-	        "Mapping not available in NoMouse mode.");
+	        "Mapping not available in no-mouse mode.");
 	MSG_Add("SHELL_CMD_MOUSECTL_NO_INTERFACES", "No mouse interfaces available.");
 	MSG_Add("SHELL_CMD_MOUSECTL_MISSING_INTERFACES",
 	        "Mouse interface not available.");


### PR DESCRIPTION
1. Added mouse related hints to a title bar - they tell which mouse buttons or hotkeys can be used to capture/release the mouse
2. The title bar strings are now translatable

![Screenshot_TitleBarHint](https://user-images.githubusercontent.com/48332137/199729963-91f74b65-297e-46ad-b3f7-adb2ac7d4d08.png)

BTW, I’m not sure which hint would be better:

_mouse captured, Ctrl+F10 or middle-click to release_

or shortened:

_Ctrl+F10 or middle-click to release mouse_
