### PR TITLE
Cleanup string IDs of DOS programs

### DIFF
--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -1069,7 +1069,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Geskriptete Tastatureingabe in ein laufendes DOS Programm.
 
 Verwendung:
@@ -1095,7 +1095,7 @@ Beispiele:
   [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter[reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Startet DOSBox Staging von einem DOS-Laufwerk oder einem Disk-Image.
 
 Verwendung:
@@ -1234,7 +1234,7 @@ Laufwerk %c ist eingebunden als %s
 Die aktuell eingebundenen Laufwerke sind:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Mounted ein CD-, Disketten- oder ein Disk-Image als Laufwerk.
 
 Verwendung:
@@ -1460,7 +1460,7 @@ Zeichentabelle %i wurde geladen
 Zeichentabelle %i wurde für Layout %s geladen
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Konfiguriert eine Tastatur für eine bestimmte Sprache.
 
 Verwendung:
@@ -1509,7 +1509,7 @@ Keine oder ungültige Zeichentabellendatei für Layout %s
 
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Lädt ein Programm in einen Speicherbereich und führt es dann aus.
 
 Verwendung:
@@ -1549,7 +1549,7 @@ Benutzter Speicher freigegeben.
 Fehler bei der Speicherallokation.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Lädt ein ROM-Abbild des Video-BIOS oder IBM BASIC.
 
 Verwendung:
@@ -1591,7 +1591,7 @@ ROM-Datei nicht erkannt.
 BASIC ROM geladen.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Zeigt die DOS-Speicherinformationen an.
 
 Verwendung:
@@ -1625,11 +1625,11 @@ Beispiel:
 %10d kB freier oberer Speicher in %d Blöcken (größter UMB %d kB)
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Ordnet physische Ordner oder Laufwerke einem virtuellen Laufwerk zu.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Einbinden eines Verzeichnisses des Host-Betriebssystems als Laufwerk.
 
 Verwendung:
@@ -1732,7 +1732,7 @@ Overlay %s auf Laufwerk %c eingebunden.
 Kann Laufwerk Z nicht verschieben. Laufwerk %c ist bereits eingebunden.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Sucht nach Änderungen auf eingebundenen DOS-Laufwerken.
 
 Verwendung:
@@ -1800,7 +1800,7 @@ Stereo
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Verwaltet die seriellen Schnittstellen.
 
 Verwendung:
@@ -2308,11 +2308,11 @@ Beispiele:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Zeigt eine bildschirmfüllende Einführung in DOSBox Staging an.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Verwendung:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]SEITE[reset]

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -1029,7 +1029,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Performs scripted keyboard entry into a running DOS game.
 
 Usage:
@@ -1055,7 +1055,7 @@ Examples:
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter
 [reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Boots DOSBox Staging from a DOS drive or disk image.
 
 Usage:
@@ -1191,7 +1191,7 @@ Drive %c is mounted as %s
 The currently mounted drives are:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Mount a CD-ROM, floppy, or disk image to a drive letter.
 
 Usage:
@@ -1408,7 +1408,7 @@ Codepage %i has been loaded
 Codepage %i has been loaded for layout %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1455,7 +1455,7 @@ No layout in %s for codepage %i
 None or invalid codepage file for layout %s
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Loads a program in the specific memory region and then runs it.
 
 Usage:
@@ -1493,7 +1493,7 @@ Used memory freed.
 Memory allocation error.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Loads a ROM image of the video BIOS or IBM BASIC.
 
 Usage:
@@ -1534,7 +1534,7 @@ ROM file not recognized.
 BASIC ROM loaded.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Displays the DOS memory information.
 
 Usage:
@@ -1567,11 +1567,11 @@ Examples:
 %10d kB free upper memory in %d blocks (largest UMB %d kB)
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 maps physical folders or drives to a virtual drive letter.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Mount a directory from the host OS to a drive letter.
 
 Usage:
@@ -1671,7 +1671,7 @@ Overlay %s on drive %c mounted.
 Can't move drive Z. Drive %c is mounted already.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scans for changes on mounted DOS drives.
 
 Usage:
@@ -1739,7 +1739,7 @@ Reverse
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -2238,11 +2238,11 @@ Examples:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Displays a full-screen introduction to DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Usage:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGE[reset]

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -1042,7 +1042,7 @@ Superposición %s en la unidad %c montada.
 No se puede mover la unidad Z. La unidad %c ya está montada.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Muestra la información de memoria DOS.
 
 Uso:
@@ -1075,7 +1075,7 @@ Ejemplos:
 %10d kB de memoria superior libre en %d bloques (UMB más grande %d kB)
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Carga un programa en la región de memoria específica y luego lo ejecuta.
 
 Uso:
@@ -1113,7 +1113,7 @@ Memoria usada liberada.
 Error de asignación de memoria.
 
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Realiza entrada de teclado con scripts en un juego DOS en ejecución.
 
 Uso:
@@ -1201,7 +1201,7 @@ MSCDEX: Error: Error desconocido.
 MSCDEX: Advertencia: Ignorando opción no soportada '%s'.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Escanea por cambios en unidades DOS montadas.
 
 Uso:
@@ -1327,7 +1327,7 @@ Se pueden cambiar en el [33mmapeador de teclas[0m.
 [33;1m%s+F12[0m    Desbloquea velocidad (botón turbo/avance rápido).
 
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Arranca DOSBox Staging desde una unidad DOS o una imagen de disco.
 
 Uso:
@@ -1396,7 +1396,7 @@ Comandos disponibles del cartucho PCjr: %s
 :PROGRAM_BOOT_CART_NO_CMDS
 No se han encontrado comandos del cartucho PCjr
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Carga una imagen ROM de la BIOS de vídeo o del IBM BASIC.
 
 Uso:
@@ -1437,7 +1437,7 @@ Archivo ROM no reconocido.
 ROM BASIC cargada.
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Monta un CD-ROM, disquete, o imagen de disco a una letra de unidad.
 
 Uso:
@@ -1463,11 +1463,11 @@ Ejemplos:
   [32;1mimgmount[0m [37;1mC[0m [36;1marranque.img[0m -t hdd -fs none -size 512,63,32,1023
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 asigna carpetas físicas o unidades a una letra de unidad virtual.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Monta un directorio del SO anfitrión a una letra de unidad.
 
 Uso:
@@ -1565,7 +1565,7 @@ Página de código %i ha sido cargada
 Página de código %i ha sido cargada para distribución %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configura un teclado para un idioma específico.
 
 Uso:
@@ -1614,7 +1614,7 @@ Archivo de página de código no válido o no existe para la distribución %s
 
 
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Administra los puertos serie.
 
 Modos de uso:
@@ -2088,11 +2088,11 @@ Ejemplos:
   [32;1mhelp[0m /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Muestra una introducción en pantalla completa a DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Uso:
   [32;1mintro[0m
   [32;1mintro[0m [37;1mPÁGINA[0m

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -1251,7 +1251,7 @@ Fichier ROM non reconnu.
 ROM BASIC chargé.
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Monte une image CD-ROM, disquette, ou disque dur sur une lettre de lecteur.
 
 Usage :
@@ -1276,11 +1276,11 @@ Exemples :
   [32;1mimgmount[0m [37;1mC[0m [36;1mdemarrage.img[0m -t hdd -fs none -size 512,63,32,1023
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 relie les dossiers ou lecteurs physiques à une lettre de lecteur virtuel.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Monte un répertoire de l'OS hôte sur une lettre de lecteur.
 
 Usage :
@@ -1851,7 +1851,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Performs scripted keyboard entry into a running DOS game.
 
 Usage:
@@ -1877,7 +1877,7 @@ Examples:
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter
 [reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Boots DOSBox Staging from a DOS drive or disk image.
 
 Usage:
@@ -1961,7 +1961,7 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1988,7 +1988,7 @@ Examples:
   [color=green]KEYB[reset] [color=cyan]de[reset] [color=white]858[reset] mycp.cpi
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Loads a program in the specific memory region and then runs it.
 
 Usage:
@@ -2010,7 +2010,7 @@ Examples:
   [color=green]loadfix[reset] /d
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Loads a ROM image of the video BIOS or IBM BASIC.
 
 Usage:
@@ -2027,7 +2027,7 @@ Examples:
   [color=green]loadrom[reset] [color=cyan]bios.rom[reset]
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Displays the DOS memory information.
 
 Usage:
@@ -2044,7 +2044,7 @@ Examples:
   [color=green]mem[reset]
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scans for changes on mounted DOS drives.
 
 Usage:
@@ -2105,7 +2105,7 @@ Stereo
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -2286,11 +2286,11 @@ Examples:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Displays a full-screen introduction to DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Usage:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGE[reset]

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -1140,7 +1140,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Esegue l'immissione da tastiera tramite script in un gioco DOS.
 
 Utilizzo:
@@ -1166,7 +1166,7 @@ Esempi:
   [color=green]autotype[reset] -w [color=white]1[reset] -p [color=white]0.3[reset] [color=cyan]up enter , right enter[reset]
   [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Avvia DOSBox Staging da un'unità DOS o da un'immagine disco.
 
 Utilizzo:
@@ -1307,7 +1307,7 @@ Unità %c montata come %s
 Le unità attualmente montate sono:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Monta un'immagine CD-ROM, floppy o disco su una lettera di unità.
 
 Utilizzo:
@@ -1529,7 +1529,7 @@ Tabella codici %i caricata.
 Tabella codici %i caricata per il layout %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configura la tastiera in base alla lingua specificata.
 
 Utilizzo:
@@ -1576,7 +1576,7 @@ Impossibile trovare il layout %s per la tabella codici %i.
 File tabella codici mancante o non valido per il layout %s.
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Carica un programma nella regione di memoria specifica e lo esegue.
 
 Utilizzo:
@@ -1616,7 +1616,7 @@ Memoria in uso liberata.
 Errore allocazione di memoria.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Carica un'immagine ROM del BIOS video o IBM BASIC.
 
 Utilizzo:
@@ -1658,7 +1658,7 @@ File ROM non riconosciuto.
 ROM BASIC caricata.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Visualizza le informazioni sulla memoria DOS.
 
 Utilizzo:
@@ -1692,11 +1692,7 @@ Esempi:
 %10d kB di memoria superiore libera in %d blocchi (UMB più grande %d kB)
 
 .
-:SHELL_CMD_MORE_HELP
-Visualizza l'output una schermata alla volta.
-
-.
-:SHELL_CMD_MORE_HELP_LONG
+:PROGRAM_MORE_HELP_LONG
 Visualizza l'output una schermata alla volta.
 
 Utilizzo:
@@ -1719,35 +1715,35 @@ Esempi:
   [color=green]more[reset] /t[color=white]4[reset] < [color=cyan]A:\MANUALE.TXT[reset]    ; mostra il contenuto del file con misura tab. 4
 
 .
-:SHELL_CMD_MORE_NO_FILE
+:PROGRAM_MORE_NO_FILE
 Nessun file di input trovato.
 .
-:SHELL_CMD_MORE_END
+:PROGRAM_MORE_END
 [reset][color=light-yellow]--- fine dell'input ---[reset]
 .
-:SHELL_CMD_MORE_NEW_FILE
+:PROGRAM_MORE_NEW_FILE
 [reset][color=light-yellow]--- file %s ---[reset]
 .
-:SHELL_CMD_MORE_NEW_DEVICE
+:PROGRAM_MORE_NEW_DEVICE
 [reset][color=light-yellow]--- dispositivo %s ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_SINGLE
+:PROGRAM_MORE_PROMPT_SINGLE
 [reset][color=light-yellow]--- premere SPAZIO per continuare ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_MULTI
+:PROGRAM_MORE_PROMPT_MULTI
 [reset][color=light-yellow]--- premere SPAZIO per continuare, N per il prossimo file ---[reset]
 .
-:SHELL_CMD_MORE_OPEN_ERROR
+:PROGRAM_MORE_OPEN_ERROR
 [reset][color=red]--- impossibile aprire %s ---[reset]
 .
-:SHELL_CMD_MORE_TERMINATE
+:PROGRAM_MORE_TERMINATE
 [reset][color=light-yellow](terminato)[reset]
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Mappa cartelle fisiche o unità su una lettera di unità virtuale.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Monta una directory del sistema operativo host su una lettera di unità.
 
 Utilizzo:
@@ -1852,7 +1848,7 @@ Sovrapposizione %s nell'unità %c montata.
 Impossibile spostare l'unità Z. L'unità %c è già montata.
 
 .
-:SHELL_CMD_MOUSECTL_HELP_LONG
+:PROGRAM_MOUSECTL_HELP_LONG
 Gestisce i mouse fisici e logici.
 
 Utilizzo:
@@ -1878,84 +1874,84 @@ Note:
 Esempi:
   [color=green]mousectl[reset] [color=white]DOS[reset] [color=white]COM1[reset] -map    ; chiede all'utente di selezionare i mouse da usare
 .
-:SHELL_CMD_MOUSECTL_SYNTAX
+:PROGRAM_MOUSECTL_SYNTAX
 Sintassi del comando errata.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_PATTERN
+:PROGRAM_MOUSECTL_SYNTAX_PATTERN
 Sintassi errata, sono ammessi solo caratteri ASCII.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY
+:PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY
 Sintassi errata, la sensibilità deve essere compresa tra -999 e +999.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_DUPLICATED
+:PROGRAM_MOUSECTL_SYNTAX_DUPLICATED
 Sintassi errata, interfacce del mouse duplicate.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE
+:PROGRAM_MOUSECTL_SYNTAX_MIN_RATE
 Sintassi errata, la frequenza di polling deve essere una dei seguenti:
 %s
 .
-:SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE
+:PROGRAM_MOUSECTL_MAPPING_NO_MOUSE
 Mappatura non disponibile in modalità NoMouse.
 .
-:SHELL_CMD_MOUSECTL_NO_INTERFACES
+:PROGRAM_MOUSECTL_NO_INTERFACES
 Nessuna interfaccia del mouse disponibile.
 .
-:SHELL_CMD_MOUSECTL_MISSING_INTERFACES
+:PROGRAM_MOUSECTL_MISSING_INTERFACES
 Interfaccia mouse non disponibile.
 .
-:SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE
+:PROGRAM_MOUSECTL_NO_PHYSICAL_MICE
 Nessun mouse fisico rilevato.
 .
-:SHELL_CMD_MOUSECTL_NO_MATCH
+:PROGRAM_MOUSECTL_NO_MATCH
 Nessun mouse corrispondente trovato.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER1
+:PROGRAM_MOUSECTL_TABLE_HEADER1
 [color=white]Interfaccia    Sensibilità    Frequenza (Hz)    Stato[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT1
+:PROGRAM_MOUSECTL_TABLE_LAYOUT1
 [color=cyan]%-4s[reset]          X:%+.3d Y:%+.3d       %1s %3s        %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER2
+:PROGRAM_MOUSECTL_TABLE_HEADER2
 [color=white]Interfaccia    Nome Mouse[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2
 [color=cyan]%-4s[reset]           %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
 non mappato    %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_HOST
+:PROGRAM_MOUSECTL_TABLE_STATUS_HOST
 utilizza il puntatore di sistema
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_MAPPED
+:PROGRAM_MOUSECTL_TABLE_STATUS_MAPPED
 mouse fisico mappato
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISCONNECTED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISCONNECTED
 [color=red]mouse mappato disconnesso[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISABLED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED
 disabilitato
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_COM
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_COM
 Le frequenze di polling per i mouse sulle interfacce [color=cyan]COM[reset] sono solo stime.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_MIN
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_MIN
 Le frequenze di polling con valore minimo impostato sono contrassegnate con '*'
 .
-:SHELL_CMD_MOUSECTL_MAP_ADVICE
+:PROGRAM_MOUSECTL_MAP_ADVICE
 Fare clic sul pulsante [color=white]sinistro[reset] del mouse per mappare il mouse fisico
 sull'interfaccia. Facendo clic su qualsiasi altro pulsante, si annulla la 
 mappatura e si assegna il puntatore di sistema a tutte le interfacce del mouse.
 .
-:SHELL_CMD_MOUSECTL_MAP_CANCEL
+:PROGRAM_MOUSECTL_MAP_CANCEL
 (mappatura annullata)
 .
-:SHELL_CMD_MOUSECTL_MAP_HINT
+:PROGRAM_MOUSECTL_MAP_HINT
 Mouse catturato. Il metodo di controllo del mouse 'seamless' è sempre
 disabilitato mentre la mappatura è attiva e i mouse mappati ricevono eventi di
 input non elaborati.
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scansiona le modifiche sulle unità DOS montate.
 
 Utilizzo:
@@ -2026,7 +2022,7 @@ Inverso
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Gestisce le porte seriali.
 
 Utilizzo:
@@ -2539,11 +2535,11 @@ Esempi:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Visualizza un'introduzione a schermo intero di DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Utilizzo:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGINA[reset]

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -1096,7 +1096,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Voert gescripte toetsenbordinvoer uit in een draaiend DOS-spel.
 
 Gebruik:
@@ -1122,7 +1122,7 @@ Voorbeelden:
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter
 [reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Start DOSBox Staging op vanaf een DOS-schijf of schijfimage.
 
 Usage:
@@ -1260,7 +1260,7 @@ Schijf %c is gekoppeld als %s
 De momenteel gekoppelde schijven zijn:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Koppel een cd-rom, diskette of schijfkopie aan een stationsletter.
 
 Gebruik:
@@ -1477,7 +1477,7 @@ Codetabel %i is geladen
 Codetabel %i is geladen voor lay-out %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configureert een toetsenbord voor een specifieke taal.
 
 Gebruik:
@@ -1524,7 +1524,7 @@ Geen lay-out in %s voor codetabel %i
 Geen of ongeldig codetabelbestand voor lay-out %s
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Laadt een programma in een specifiek geheugengebied en voert het uit.
 
 Gebruik:
@@ -1563,7 +1563,7 @@ Gebruikt geheugen vrijgemaakt.
 Geheugentoewijzingsfout.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Laadt een video-BIOS of IBM BASIC ROM-image.
 
 Gebruik:
@@ -1604,7 +1604,7 @@ ROM-bestand niet herkend.
 BASIC-ROM geladen.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Geeft de DOS-geheugeninformatie weer.
 
 Gebruik:
@@ -1638,11 +1638,7 @@ Voorbeelden:
 %10d kB vrij bovenste geheugen %d blok(ken) (grootste UMB %d kB)
 
 .
-:SHELL_CMD_MORE_HELP
-Geef opdrachtuitvoer of tekstbestand één scherm tegelijk weer.
-
-.
-:SHELL_CMD_MORE_HELP_LONG
+:PROGRAM_MORE_HELP_LONG
 Geef opdrachtuitvoer of tekstbestand één scherm tegelijk weer.
 
 Gebruik:
@@ -1666,35 +1662,35 @@ Voorbeelden:
   [color=green]more[reset] /t[color=white]4[reset] < [color=cyan]A:\MANUAL.TXT[reset]  ; toont de inhoud van het bestand met tabgrootte 4
 
 .
-:SHELL_CMD_MORE_NO_FILE
+:PROGRAM_MORE_NO_FILE
 Geen invoerbestand gevonden.
 .
-:SHELL_CMD_MORE_END
+:PROGRAM_MORE_END
 [reset][color=light-yellow]--- einde van invoer ---[reset]
 .
-:SHELL_CMD_MORE_NEW_FILE
+:PROGRAM_MORE_NEW_FILE
 [reset][color=light-yellow]--- bestand %s ---[reset]
 .
-:SHELL_CMD_MORE_NEW_DEVICE
+:PROGRAM_MORE_NEW_DEVICE
 [reset][color=light-yellow]--- apparaat %s ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_SINGLE
+:PROGRAM_MORE_PROMPT_SINGLE
 [reset][color=light-yellow]--- druk op SPATIEBALK voor meer ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_MULTI
+:PROGRAM_MORE_PROMPT_MULTI
 [reset][color=light-yellow]--- druk op SPATIEBALK voor meer, N for volgend bestand ---[reset]
 .
-:SHELL_CMD_MORE_OPEN_ERROR
+:PROGRAM_MORE_OPEN_ERROR
 [reset][color=red]--- kon %s niet openen ---[reset]
 .
-:SHELL_CMD_MORE_TERMINATE
+:PROGRAM_MORE_TERMINATE
 [reset][color=light-yellow](beëindigd)[reset]
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Wijst fysieke mappen of stations toe aan een virtuele stationsletter
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Koppel een map van het host-besturingssysteem aan een stationsletter.
 
 Gebruik:
@@ -1796,7 +1792,7 @@ Overlay %s op schijf %c gekoppeld.
 Kan station Z niet verplaatsen. Station %c is al aangekoppeld.
 
 .
-:SHELL_CMD_MOUSECTL_HELP_LONG
+:PROGRAM_MOUSECTL_HELP_LONG
 Beheert fysieke en logische muizen.
 
 Gebruik:
@@ -1822,83 +1818,83 @@ Opmerkingen:
 Voorbeelden:
   [color=green]mousectl[reset] [color=white]DOS[reset] [color=white]COM1[reset] -map    ; selecteer muizen voor een twee speler spel
 .
-:SHELL_CMD_MOUSECTL_SYNTAX
+:PROGRAM_MOUSECTL_SYNTAX
 Verkeerde opdrachtsyntaxis.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_PATTERN
+:PROGRAM_MOUSECTL_SYNTAX_PATTERN
 Verkeerde syntaxis, alleen ASCII-tekens toegestaan in patroon.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY
+:PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY
 Verkeerde syntaxis, gevoeligheid moet tussen -999 en +999 liggen.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_DUPLICATED
+:PROGRAM_MOUSECTL_SYNTAX_DUPLICATED
 Verkeerde syntaxis, gedupliceerde muisinterfaces.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE
+:PROGRAM_MOUSECTL_SYNTAX_MIN_RATE
 Verkeerde syntaxis, bemonsteringsfrequentie moet een van zijn:
 %s
 .
-:SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE
+:PROGRAM_MOUSECTL_MAPPING_NO_MOUSE
 Mapping niet beschikbaar in NoMouse-modus.
 .
-:SHELL_CMD_MOUSECTL_NO_INTERFACES
+:PROGRAM_MOUSECTL_NO_INTERFACES
 Geen muisinterfaces beschikbaar.
 .
-:SHELL_CMD_MOUSECTL_MISSING_INTERFACES
+:PROGRAM_MOUSECTL_MISSING_INTERFACES
 Muisinterface niet beschikbaar.
 .
-:SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE
+:PROGRAM_MOUSECTL_NO_PHYSICAL_MICE
 Geen fysieke muizen gedetecteerd.
 .
-:SHELL_CMD_MOUSECTL_NO_MATCH
+:PROGRAM_MOUSECTL_NO_MATCH
 Geen beschikbare muis die overeenkomt met het patroon gevonden.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER1
+:PROGRAM_MOUSECTL_TABLE_HEADER1
 [color=white]Interface      Gevoeligheid     Rate (Hz)     Status[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT1
+:PROGRAM_MOUSECTL_TABLE_LAYOUT1
 [color=cyan]%-4s[reset]          X:%+.3d Y:%+.3d       %1s %3s       %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER2
+:PROGRAM_MOUSECTL_TABLE_HEADER2
 [color=white]Interface     Muis Naam[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2
 [color=cyan]%-4s[reset]          %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
 niet gekoppeld    %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_HOST
+:PROGRAM_MOUSECTL_TABLE_STATUS_HOST
 gebruikt systeemaanwijzer
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_MAPPED
+:PROGRAM_MOUSECTL_TABLE_STATUS_MAPPED
 gekoppelde fysieke muis
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISCONNECTED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISCONNECTED
 [color=red]gekoppelde muis losgekoppeld[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISABLED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED
 uitgeschakeld
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_COM
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_COM
 Bemonsteringsfrequenties voor muizen op [color=cyan]COM[reset]-interfaces zijn enkel schattingen.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_MIN
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_MIN
 Bemonsteringsfrequenties gemarkeerd met '*' zijn minimumwaardes.
 .
-:SHELL_CMD_MOUSECTL_MAP_ADVICE
+:PROGRAM_MOUSECTL_MAP_ADVICE
 Klik op de [color=white]linkermuisknop[reset] om de fysieke muis toe te wijzen aan de interface.
 Als u op een andere knop klikt, wordt de toewijzing geannuleerd en wordt
 de systeemaanwijzer toegewezen aan alle muisinterfaces.
 .
-:SHELL_CMD_MOUSECTL_MAP_CANCEL
+:PROGRAM_MOUSECTL_MAP_CANCEL
 (toewijzing geannuleerd)
 .
-:SHELL_CMD_MOUSECTL_MAP_HINT
+:PROGRAM_MOUSECTL_MAP_HINT
 Muis gevangen. Naadloze muisintegratie is uitgeschakeld terwijl mapping actief
 is en toegewezen muizen ontvangen altijd onbewerkte invoergebeurtenissen.
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scant op wijzigingen op gekoppelde DOS-schijven.
 
 Gebruik:
@@ -1968,7 +1964,7 @@ Omgekeerd
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Beheert de seriële poorten.
 
 Gebruik:
@@ -2470,11 +2466,11 @@ Voorbeelden:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Geeft een inleiding op het volledige scherm van DOSBox Staging weer.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Gebruik:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGINA[reset]

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -1017,7 +1017,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Symulowanie naciśnięć klawiszy dla uruchomionego programu.
 
 Składnia:
@@ -1041,7 +1041,7 @@ Przykłady:
   [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter[reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Startowanie systemu z obrazu dyskietki lub zamontowanego dysku.
 
 Składnia:
@@ -1177,7 +1177,7 @@ Lista zamontowanych dysków:
 
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Montowanie obrazu dyskietki, płyty CD lub dysku pod wybraną literę.
 
 Składnia:
@@ -1398,7 +1398,7 @@ Strona kodowa %i została załadowana.
 Strona kodowa %i dla układu klawiatury '%s' została załadowana.
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Konfiguracja klawiatury i czcionki dla danego języka.
 
 Składnia:
@@ -1445,7 +1445,7 @@ Brak lub nieprawidłowy plik strony kodowej dla układu klawiatury '%s'.
 
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Ładowanie programu w określone miejsce pamięci i uruchomienie go.
 
 Składnia:
@@ -1482,7 +1482,7 @@ Używana pamięć została zwolniona.
 Błąd alokacji pamięci.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Ładowanie obrazu ROM języka IBM BASIC lub BIOSu karty graficznej.
 
 Składnia:
@@ -1521,7 +1521,7 @@ Nie można rozpoznać ROMu.
 Załadowano BASIC ROM.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Wyświetlenie informacji o użyciu pamięci.
 
 Składnia:
@@ -1553,11 +1553,11 @@ Przykłady:
 %10d kB wolnej pamięci UMB (górnej) w %d blokach (największy %d kB)
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Montowanie fizycznych katalogów lub dysków.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Montuje katalog z systemu gospodarza pod literę dysku.
 
 Składnia:
@@ -1659,7 +1659,7 @@ Nakładka ('overlay') '%s' zamontowana na dysku %c.
 Nie można przenieść dysku Z. Dysk %c jest już zamontowany.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Sprawdzenie zmian na zamontowanych dyskach.
 
 Składnia:
@@ -1723,7 +1723,7 @@ Stereo
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Zarządzanie portami szeregowymi.
 
 Składnia:
@@ -2218,11 +2218,11 @@ Przykłady:
   [color=green]help[reset] [color=cyan]dir[reset]
   [color=green]help[reset] /all
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Krótki, pełnoekranowy samouczek.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Składnia:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]STRONA[reset]

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -1271,7 +1271,7 @@ PCjr картридж найден, но машина не PCjr.
 Базовое ПЗУ загружено.
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Монтировать CD-ROM, дискету или образ диска на указанную букву диска.
 
 Использование:
@@ -1298,11 +1298,11 @@ PCjr картридж найден, но машина не PCjr.
   [32;1mimgmount[0m [37;1mC[0m [36;1mзагрузочный_образ.img[0m -t hdd -fs none -size 512,63,32,1023
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Сопоставить физическую директорию с буквой виртуального диска DOS.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Монтировать директорию из операционной системы на букву виртуального диска DOS.
 
 Использование:
@@ -1862,7 +1862,7 @@ choice [/c:клавиши] [/n] [/s] текст
 Нет доступных IDE контроллеров. Диск не будет иметь эмуляции IDE.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Displays the DOS memory information.
 
 Usage:
@@ -1879,7 +1879,7 @@ Examples:
   [32;1mmem[0m
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Loads a program in the specific memory region and then runs it.
 
 Usage:
@@ -1901,7 +1901,7 @@ Examples:
   [32;1mloadfix[0m /d
 
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Performs scripted keyboard entry into a running DOS game.
 
 Usage:
@@ -1949,7 +1949,7 @@ Examples:
   [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
   [32;1mmixer[0m /listmidi
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scans for changes on mounted DOS drives.
 
 Usage:
@@ -2009,7 +2009,7 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Boots DOSBox Staging from a DOS drive or disk image.
 
 Usage:
@@ -2030,7 +2030,7 @@ Examples:
   [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Loads a ROM image of the video BIOS or IBM BASIC.
 
 Usage:
@@ -2047,7 +2047,7 @@ Examples:
   [32;1mloadrom[0m [36;1mbios.rom[0m
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -2074,7 +2074,7 @@ Examples:
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Manage the serial ports.
 
 Usage modes:
@@ -2235,11 +2235,11 @@ Examples:
   [32;1mhelp[0m /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Displays a full-screen introduction to DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Usage:
   [32;1mintro[0m
   [32;1mintro[0m [37;1mPAGE[0m

--- a/contrib/resources/translations/utf-8/de.txt
+++ b/contrib/resources/translations/utf-8/de.txt
@@ -1069,7 +1069,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Geskriptete Tastatureingabe in ein laufendes DOS Programm.
 
 Verwendung:
@@ -1095,7 +1095,7 @@ Beispiele:
   [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter[reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Startet DOSBox Staging von einem DOS-Laufwerk oder einem Disk-Image.
 
 Verwendung:
@@ -1234,7 +1234,7 @@ Laufwerk %c ist eingebunden als %s
 Die aktuell eingebundenen Laufwerke sind:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Mounted ein CD-, Disketten- oder ein Disk-Image als Laufwerk.
 
 Verwendung:
@@ -1460,7 +1460,7 @@ Zeichentabelle %i wurde geladen
 Zeichentabelle %i wurde für Layout %s geladen
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Konfiguriert eine Tastatur für eine bestimmte Sprache.
 
 Verwendung:
@@ -1509,7 +1509,7 @@ Keine oder ungültige Zeichentabellendatei für Layout %s
 
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Lädt ein Programm in einen Speicherbereich und führt es dann aus.
 
 Verwendung:
@@ -1549,7 +1549,7 @@ Benutzter Speicher freigegeben.
 Fehler bei der Speicherallokation.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Lädt ein ROM-Abbild des Video-BIOS oder IBM BASIC.
 
 Verwendung:
@@ -1591,7 +1591,7 @@ ROM-Datei nicht erkannt.
 BASIC ROM geladen.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Zeigt die DOS-Speicherinformationen an.
 
 Verwendung:
@@ -1625,11 +1625,11 @@ Beispiel:
 %10d kB freier oberer Speicher in %d Blöcken (größter UMB %d kB)
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Ordnet physische Ordner oder Laufwerke einem virtuellen Laufwerk zu.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Einbinden eines Verzeichnisses des Host-Betriebssystems als Laufwerk.
 
 Verwendung:
@@ -1732,7 +1732,7 @@ Overlay %s auf Laufwerk %c eingebunden.
 Kann Laufwerk Z nicht verschieben. Laufwerk %c ist bereits eingebunden.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Sucht nach Änderungen auf eingebundenen DOS-Laufwerken.
 
 Verwendung:
@@ -1800,7 +1800,7 @@ Stereo
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Verwaltet die seriellen Schnittstellen.
 
 Verwendung:
@@ -2308,11 +2308,11 @@ Beispiele:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Zeigt eine bildschirmfüllende Einführung in DOSBox Staging an.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Verwendung:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]SEITE[reset]

--- a/contrib/resources/translations/utf-8/en.txt
+++ b/contrib/resources/translations/utf-8/en.txt
@@ -1029,7 +1029,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Performs scripted keyboard entry into a running DOS game.
 
 Usage:
@@ -1055,7 +1055,7 @@ Examples:
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter
 [reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Boots DOSBox Staging from a DOS drive or disk image.
 
 Usage:
@@ -1191,7 +1191,7 @@ Drive %c is mounted as %s
 The currently mounted drives are:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Mount a CD-ROM, floppy, or disk image to a drive letter.
 
 Usage:
@@ -1408,7 +1408,7 @@ Codepage %i has been loaded
 Codepage %i has been loaded for layout %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1455,7 +1455,7 @@ No layout in %s for codepage %i
 None or invalid codepage file for layout %s
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Loads a program in the specific memory region and then runs it.
 
 Usage:
@@ -1493,7 +1493,7 @@ Used memory freed.
 Memory allocation error.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Loads a ROM image of the video BIOS or IBM BASIC.
 
 Usage:
@@ -1534,7 +1534,7 @@ ROM file not recognized.
 BASIC ROM loaded.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Displays the DOS memory information.
 
 Usage:
@@ -1567,11 +1567,11 @@ Examples:
 %10d kB free upper memory in %d blocks (largest UMB %d kB)
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 maps physical folders or drives to a virtual drive letter.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Mount a directory from the host OS to a drive letter.
 
 Usage:
@@ -1671,7 +1671,7 @@ Overlay %s on drive %c mounted.
 Can't move drive Z. Drive %c is mounted already.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scans for changes on mounted DOS drives.
 
 Usage:
@@ -1739,7 +1739,7 @@ Reverse
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -2238,11 +2238,11 @@ Examples:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Displays a full-screen introduction to DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Usage:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGE[reset]

--- a/contrib/resources/translations/utf-8/es.txt
+++ b/contrib/resources/translations/utf-8/es.txt
@@ -1042,7 +1042,7 @@ Superposición %s en la unidad %c montada.
 No se puede mover la unidad Z. La unidad %c ya está montada.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Muestra la información de memoria DOS.
 
 Uso:
@@ -1075,7 +1075,7 @@ Ejemplos:
 %10d kB de memoria superior libre en %d bloques (UMB más grande %d kB)
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Carga un programa en la región de memoria específica y luego lo ejecuta.
 
 Uso:
@@ -1113,7 +1113,7 @@ Memoria usada liberada.
 Error de asignación de memoria.
 
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Realiza entrada de teclado con scripts en un juego DOS en ejecución.
 
 Uso:
@@ -1201,7 +1201,7 @@ MSCDEX: Error: Error desconocido.
 MSCDEX: Advertencia: Ignorando opción no soportada '%s'.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Escanea por cambios en unidades DOS montadas.
 
 Uso:
@@ -1327,7 +1327,7 @@ Se pueden cambiar en el [33mmapeador de teclas[0m.
 [33;1m%s+F12[0m    Desbloquea velocidad (botón turbo/avance rápido).
 
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Arranca DOSBox Staging desde una unidad DOS o una imagen de disco.
 
 Uso:
@@ -1396,7 +1396,7 @@ Comandos disponibles del cartucho PCjr: %s
 :PROGRAM_BOOT_CART_NO_CMDS
 No se han encontrado comandos del cartucho PCjr
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Carga una imagen ROM de la BIOS de vídeo o del IBM BASIC.
 
 Uso:
@@ -1437,7 +1437,7 @@ Archivo ROM no reconocido.
 ROM BASIC cargada.
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Monta un CD-ROM, disquete, o imagen de disco a una letra de unidad.
 
 Uso:
@@ -1463,11 +1463,11 @@ Ejemplos:
   [32;1mimgmount[0m [37;1mC[0m [36;1marranque.img[0m -t hdd -fs none -size 512,63,32,1023
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 asigna carpetas físicas o unidades a una letra de unidad virtual.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Monta un directorio del SO anfitrión a una letra de unidad.
 
 Uso:
@@ -1565,7 +1565,7 @@ Página de código %i ha sido cargada
 Página de código %i ha sido cargada para distribución %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configura un teclado para un idioma específico.
 
 Uso:
@@ -1614,7 +1614,7 @@ Archivo de página de código no válido o no existe para la distribución %s
 
 
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Administra los puertos serie.
 
 Modos de uso:
@@ -2088,11 +2088,11 @@ Ejemplos:
   [32;1mhelp[0m /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Muestra una introducción en pantalla completa a DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Uso:
   [32;1mintro[0m
   [32;1mintro[0m [37;1mPÁGINA[0m

--- a/contrib/resources/translations/utf-8/fr.txt
+++ b/contrib/resources/translations/utf-8/fr.txt
@@ -1251,7 +1251,7 @@ Fichier ROM non reconnu.
 ROM BASIC chargé.
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Monte une image CD-ROM, disquette, ou disque dur sur une lettre de lecteur.
 
 Usage :
@@ -1276,11 +1276,11 @@ Exemples :
   [32;1mimgmount[0m [37;1mC[0m [36;1mdemarrage.img[0m -t hdd -fs none -size 512,63,32,1023
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 relie les dossiers ou lecteurs physiques à une lettre de lecteur virtuel.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Monte un répertoire de l'OS hôte sur une lettre de lecteur.
 
 Usage :
@@ -1851,7 +1851,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Performs scripted keyboard entry into a running DOS game.
 
 Usage:
@@ -1877,7 +1877,7 @@ Examples:
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter
 [reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Boots DOSBox Staging from a DOS drive or disk image.
 
 Usage:
@@ -1961,7 +1961,7 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -1988,7 +1988,7 @@ Examples:
   [color=green]KEYB[reset] [color=cyan]de[reset] [color=white]858[reset] mycp.cpi
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Loads a program in the specific memory region and then runs it.
 
 Usage:
@@ -2010,7 +2010,7 @@ Examples:
   [color=green]loadfix[reset] /d
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Loads a ROM image of the video BIOS or IBM BASIC.
 
 Usage:
@@ -2027,7 +2027,7 @@ Examples:
   [color=green]loadrom[reset] [color=cyan]bios.rom[reset]
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Displays the DOS memory information.
 
 Usage:
@@ -2044,7 +2044,7 @@ Examples:
   [color=green]mem[reset]
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scans for changes on mounted DOS drives.
 
 Usage:
@@ -2105,7 +2105,7 @@ Stereo
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Manages the serial ports.
 
 Usage:
@@ -2286,11 +2286,11 @@ Examples:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Displays a full-screen introduction to DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Usage:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGE[reset]

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -1140,7 +1140,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Esegue l'immissione da tastiera tramite script in un gioco DOS.
 
 Utilizzo:
@@ -1166,7 +1166,7 @@ Esempi:
   [color=green]autotype[reset] -w [color=white]1[reset] -p [color=white]0.3[reset] [color=cyan]up enter , right enter[reset]
   [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Avvia DOSBox Staging da un'unità DOS o da un'immagine disco.
 
 Utilizzo:
@@ -1307,7 +1307,7 @@ Unità %c montata come %s
 Le unità attualmente montate sono:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Monta un'immagine CD-ROM, floppy o disco su una lettera di unità.
 
 Utilizzo:
@@ -1529,7 +1529,7 @@ Tabella codici %i caricata.
 Tabella codici %i caricata per il layout %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configura la tastiera in base alla lingua specificata.
 
 Utilizzo:
@@ -1576,7 +1576,7 @@ Impossibile trovare il layout %s per la tabella codici %i.
 File tabella codici mancante o non valido per il layout %s.
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Carica un programma nella regione di memoria specifica e lo esegue.
 
 Utilizzo:
@@ -1616,7 +1616,7 @@ Memoria in uso liberata.
 Errore allocazione di memoria.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Carica un'immagine ROM del BIOS video o IBM BASIC.
 
 Utilizzo:
@@ -1658,7 +1658,7 @@ File ROM non riconosciuto.
 ROM BASIC caricata.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Visualizza le informazioni sulla memoria DOS.
 
 Utilizzo:
@@ -1692,11 +1692,7 @@ Esempi:
 %10d kB di memoria superiore libera in %d blocchi (UMB più grande %d kB)
 
 .
-:SHELL_CMD_MORE_HELP
-Visualizza l'output una schermata alla volta.
-
-.
-:SHELL_CMD_MORE_HELP_LONG
+:PROGRAM_MORE_HELP_LONG
 Visualizza l'output una schermata alla volta.
 
 Utilizzo:
@@ -1719,35 +1715,35 @@ Esempi:
   [color=green]more[reset] /t[color=white]4[reset] < [color=cyan]A:\MANUALE.TXT[reset]    ; mostra il contenuto del file con misura tab. 4
 
 .
-:SHELL_CMD_MORE_NO_FILE
+:PROGRAM_MORE_NO_FILE
 Nessun file di input trovato.
 .
-:SHELL_CMD_MORE_END
+:PROGRAM_MORE_END
 [reset][color=light-yellow]--- fine dell'input ---[reset]
 .
-:SHELL_CMD_MORE_NEW_FILE
+:PROGRAM_MORE_NEW_FILE
 [reset][color=light-yellow]--- file %s ---[reset]
 .
-:SHELL_CMD_MORE_NEW_DEVICE
+:PROGRAM_MORE_NEW_DEVICE
 [reset][color=light-yellow]--- dispositivo %s ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_SINGLE
+:PROGRAM_MORE_PROMPT_SINGLE
 [reset][color=light-yellow]--- premere SPAZIO per continuare ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_MULTI
+:PROGRAM_MORE_PROMPT_MULTI
 [reset][color=light-yellow]--- premere SPAZIO per continuare, N per il prossimo file ---[reset]
 .
-:SHELL_CMD_MORE_OPEN_ERROR
+:PROGRAM_MORE_OPEN_ERROR
 [reset][color=red]--- impossibile aprire %s ---[reset]
 .
-:SHELL_CMD_MORE_TERMINATE
+:PROGRAM_MORE_TERMINATE
 [reset][color=light-yellow](terminato)[reset]
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Mappa cartelle fisiche o unità su una lettera di unità virtuale.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Monta una directory del sistema operativo host su una lettera di unità.
 
 Utilizzo:
@@ -1852,7 +1848,7 @@ Sovrapposizione %s nell'unità %c montata.
 Impossibile spostare l'unità Z. L'unità %c è già montata.
 
 .
-:SHELL_CMD_MOUSECTL_HELP_LONG
+:PROGRAM_MOUSECTL_HELP_LONG
 Gestisce i mouse fisici e logici.
 
 Utilizzo:
@@ -1878,84 +1874,84 @@ Note:
 Esempi:
   [color=green]mousectl[reset] [color=white]DOS[reset] [color=white]COM1[reset] -map    ; chiede all'utente di selezionare i mouse da usare
 .
-:SHELL_CMD_MOUSECTL_SYNTAX
+:PROGRAM_MOUSECTL_SYNTAX
 Sintassi del comando errata.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_PATTERN
+:PROGRAM_MOUSECTL_SYNTAX_PATTERN
 Sintassi errata, sono ammessi solo caratteri ASCII.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY
+:PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY
 Sintassi errata, la sensibilità deve essere compresa tra -999 e +999.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_DUPLICATED
+:PROGRAM_MOUSECTL_SYNTAX_DUPLICATED
 Sintassi errata, interfacce del mouse duplicate.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE
+:PROGRAM_MOUSECTL_SYNTAX_MIN_RATE
 Sintassi errata, la frequenza di polling deve essere una dei seguenti:
 %s
 .
-:SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE
+:PROGRAM_MOUSECTL_MAPPING_NO_MOUSE
 Mappatura non disponibile in modalità NoMouse.
 .
-:SHELL_CMD_MOUSECTL_NO_INTERFACES
+:PROGRAM_MOUSECTL_NO_INTERFACES
 Nessuna interfaccia del mouse disponibile.
 .
-:SHELL_CMD_MOUSECTL_MISSING_INTERFACES
+:PROGRAM_MOUSECTL_MISSING_INTERFACES
 Interfaccia mouse non disponibile.
 .
-:SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE
+:PROGRAM_MOUSECTL_NO_PHYSICAL_MICE
 Nessun mouse fisico rilevato.
 .
-:SHELL_CMD_MOUSECTL_NO_MATCH
+:PROGRAM_MOUSECTL_NO_MATCH
 Nessun mouse corrispondente trovato.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER1
+:PROGRAM_MOUSECTL_TABLE_HEADER1
 [color=white]Interfaccia    Sensibilità    Frequenza (Hz)    Stato[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT1
+:PROGRAM_MOUSECTL_TABLE_LAYOUT1
 [color=cyan]%-4s[reset]          X:%+.3d Y:%+.3d       %1s %3s        %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER2
+:PROGRAM_MOUSECTL_TABLE_HEADER2
 [color=white]Interfaccia    Nome Mouse[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2
 [color=cyan]%-4s[reset]           %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
 non mappato    %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_HOST
+:PROGRAM_MOUSECTL_TABLE_STATUS_HOST
 utilizza il puntatore di sistema
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_MAPPED
+:PROGRAM_MOUSECTL_TABLE_STATUS_MAPPED
 mouse fisico mappato
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISCONNECTED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISCONNECTED
 [color=red]mouse mappato disconnesso[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISABLED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED
 disabilitato
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_COM
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_COM
 Le frequenze di polling per i mouse sulle interfacce [color=cyan]COM[reset] sono solo stime.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_MIN
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_MIN
 Le frequenze di polling con valore minimo impostato sono contrassegnate con '*'
 .
-:SHELL_CMD_MOUSECTL_MAP_ADVICE
+:PROGRAM_MOUSECTL_MAP_ADVICE
 Fare clic sul pulsante [color=white]sinistro[reset] del mouse per mappare il mouse fisico
 sull'interfaccia. Facendo clic su qualsiasi altro pulsante, si annulla la 
 mappatura e si assegna il puntatore di sistema a tutte le interfacce del mouse.
 .
-:SHELL_CMD_MOUSECTL_MAP_CANCEL
+:PROGRAM_MOUSECTL_MAP_CANCEL
 (mappatura annullata)
 .
-:SHELL_CMD_MOUSECTL_MAP_HINT
+:PROGRAM_MOUSECTL_MAP_HINT
 Mouse catturato. Il metodo di controllo del mouse 'seamless' è sempre
 disabilitato mentre la mappatura è attiva e i mouse mappati ricevono eventi di
 input non elaborati.
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scansiona le modifiche sulle unità DOS montate.
 
 Utilizzo:
@@ -2026,7 +2022,7 @@ Inverso
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Gestisce le porte seriali.
 
 Utilizzo:
@@ -2539,11 +2535,11 @@ Esempi:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Visualizza un'introduzione a schermo intero di DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Utilizzo:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGINA[reset]

--- a/contrib/resources/translations/utf-8/nl.txt
+++ b/contrib/resources/translations/utf-8/nl.txt
@@ -1096,7 +1096,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Voert gescripte toetsenbordinvoer uit in een draaiend DOS-spel.
 
 Gebruik:
@@ -1122,7 +1122,7 @@ Voorbeelden:
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter
 [reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Start DOSBox Staging op vanaf een DOS-schijf of schijfimage.
 
 Usage:
@@ -1260,7 +1260,7 @@ Schijf %c is gekoppeld als %s
 De momenteel gekoppelde schijven zijn:
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Koppel een cd-rom, diskette of schijfkopie aan een stationsletter.
 
 Gebruik:
@@ -1477,7 +1477,7 @@ Codetabel %i is geladen
 Codetabel %i is geladen voor lay-out %s
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configureert een toetsenbord voor een specifieke taal.
 
 Gebruik:
@@ -1524,7 +1524,7 @@ Geen lay-out in %s voor codetabel %i
 Geen of ongeldig codetabelbestand voor lay-out %s
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Laadt een programma in een specifiek geheugengebied en voert het uit.
 
 Gebruik:
@@ -1563,7 +1563,7 @@ Gebruikt geheugen vrijgemaakt.
 Geheugentoewijzingsfout.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Laadt een video-BIOS of IBM BASIC ROM-image.
 
 Gebruik:
@@ -1604,7 +1604,7 @@ ROM-bestand niet herkend.
 BASIC-ROM geladen.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Geeft de DOS-geheugeninformatie weer.
 
 Gebruik:
@@ -1638,11 +1638,7 @@ Voorbeelden:
 %10d kB vrij bovenste geheugen %d blok(ken) (grootste UMB %d kB)
 
 .
-:SHELL_CMD_MORE_HELP
-Geef opdrachtuitvoer of tekstbestand één scherm tegelijk weer.
-
-.
-:SHELL_CMD_MORE_HELP_LONG
+:PROGRAM_MORE_HELP_LONG
 Geef opdrachtuitvoer of tekstbestand één scherm tegelijk weer.
 
 Gebruik:
@@ -1666,35 +1662,35 @@ Voorbeelden:
   [color=green]more[reset] /t[color=white]4[reset] < [color=cyan]A:\MANUAL.TXT[reset]  ; toont de inhoud van het bestand met tabgrootte 4
 
 .
-:SHELL_CMD_MORE_NO_FILE
+:PROGRAM_MORE_NO_FILE
 Geen invoerbestand gevonden.
 .
-:SHELL_CMD_MORE_END
+:PROGRAM_MORE_END
 [reset][color=light-yellow]--- einde van invoer ---[reset]
 .
-:SHELL_CMD_MORE_NEW_FILE
+:PROGRAM_MORE_NEW_FILE
 [reset][color=light-yellow]--- bestand %s ---[reset]
 .
-:SHELL_CMD_MORE_NEW_DEVICE
+:PROGRAM_MORE_NEW_DEVICE
 [reset][color=light-yellow]--- apparaat %s ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_SINGLE
+:PROGRAM_MORE_PROMPT_SINGLE
 [reset][color=light-yellow]--- druk op SPATIEBALK voor meer ---[reset]
 .
-:SHELL_CMD_MORE_PROMPT_MULTI
+:PROGRAM_MORE_PROMPT_MULTI
 [reset][color=light-yellow]--- druk op SPATIEBALK voor meer, N for volgend bestand ---[reset]
 .
-:SHELL_CMD_MORE_OPEN_ERROR
+:PROGRAM_MORE_OPEN_ERROR
 [reset][color=red]--- kon %s niet openen ---[reset]
 .
-:SHELL_CMD_MORE_TERMINATE
+:PROGRAM_MORE_TERMINATE
 [reset][color=light-yellow](beëindigd)[reset]
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Wijst fysieke mappen of stations toe aan een virtuele stationsletter
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Koppel een map van het host-besturingssysteem aan een stationsletter.
 
 Gebruik:
@@ -1796,7 +1792,7 @@ Overlay %s op schijf %c gekoppeld.
 Kan station Z niet verplaatsen. Station %c is al aangekoppeld.
 
 .
-:SHELL_CMD_MOUSECTL_HELP_LONG
+:PROGRAM_MOUSECTL_HELP_LONG
 Beheert fysieke en logische muizen.
 
 Gebruik:
@@ -1822,83 +1818,83 @@ Opmerkingen:
 Voorbeelden:
   [color=green]mousectl[reset] [color=white]DOS[reset] [color=white]COM1[reset] -map    ; selecteer muizen voor een twee speler spel
 .
-:SHELL_CMD_MOUSECTL_SYNTAX
+:PROGRAM_MOUSECTL_SYNTAX
 Verkeerde opdrachtsyntaxis.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_PATTERN
+:PROGRAM_MOUSECTL_SYNTAX_PATTERN
 Verkeerde syntaxis, alleen ASCII-tekens toegestaan in patroon.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY
+:PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY
 Verkeerde syntaxis, gevoeligheid moet tussen -999 en +999 liggen.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_DUPLICATED
+:PROGRAM_MOUSECTL_SYNTAX_DUPLICATED
 Verkeerde syntaxis, gedupliceerde muisinterfaces.
 .
-:SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE
+:PROGRAM_MOUSECTL_SYNTAX_MIN_RATE
 Verkeerde syntaxis, bemonsteringsfrequentie moet een van zijn:
 %s
 .
-:SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE
+:PROGRAM_MOUSECTL_MAPPING_NO_MOUSE
 Mapping niet beschikbaar in NoMouse-modus.
 .
-:SHELL_CMD_MOUSECTL_NO_INTERFACES
+:PROGRAM_MOUSECTL_NO_INTERFACES
 Geen muisinterfaces beschikbaar.
 .
-:SHELL_CMD_MOUSECTL_MISSING_INTERFACES
+:PROGRAM_MOUSECTL_MISSING_INTERFACES
 Muisinterface niet beschikbaar.
 .
-:SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE
+:PROGRAM_MOUSECTL_NO_PHYSICAL_MICE
 Geen fysieke muizen gedetecteerd.
 .
-:SHELL_CMD_MOUSECTL_NO_MATCH
+:PROGRAM_MOUSECTL_NO_MATCH
 Geen beschikbare muis die overeenkomt met het patroon gevonden.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER1
+:PROGRAM_MOUSECTL_TABLE_HEADER1
 [color=white]Interface      Gevoeligheid     Rate (Hz)     Status[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT1
+:PROGRAM_MOUSECTL_TABLE_LAYOUT1
 [color=cyan]%-4s[reset]          X:%+.3d Y:%+.3d       %1s %3s       %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_HEADER2
+:PROGRAM_MOUSECTL_TABLE_HEADER2
 [color=white]Interface     Muis Naam[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2
 [color=cyan]%-4s[reset]          %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
+:PROGRAM_MOUSECTL_TABLE_LAYOUT2_UNMAPPED
 niet gekoppeld    %s
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_HOST
+:PROGRAM_MOUSECTL_TABLE_STATUS_HOST
 gebruikt systeemaanwijzer
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_MAPPED
+:PROGRAM_MOUSECTL_TABLE_STATUS_MAPPED
 gekoppelde fysieke muis
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISCONNECTED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISCONNECTED
 [color=red]gekoppelde muis losgekoppeld[reset]
 .
-:SHELL_CMD_MOUSECTL_TABLE_STATUS_DISABLED
+:PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED
 uitgeschakeld
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_COM
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_COM
 Bemonsteringsfrequenties voor muizen op [color=cyan]COM[reset]-interfaces zijn enkel schattingen.
 .
-:SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_MIN
+:PROGRAM_MOUSECTL_TABLE_HINT_RATE_MIN
 Bemonsteringsfrequenties gemarkeerd met '*' zijn minimumwaardes.
 .
-:SHELL_CMD_MOUSECTL_MAP_ADVICE
+:PROGRAM_MOUSECTL_MAP_ADVICE
 Klik op de [color=white]linkermuisknop[reset] om de fysieke muis toe te wijzen aan de interface.
 Als u op een andere knop klikt, wordt de toewijzing geannuleerd en wordt
 de systeemaanwijzer toegewezen aan alle muisinterfaces.
 .
-:SHELL_CMD_MOUSECTL_MAP_CANCEL
+:PROGRAM_MOUSECTL_MAP_CANCEL
 (toewijzing geannuleerd)
 .
-:SHELL_CMD_MOUSECTL_MAP_HINT
+:PROGRAM_MOUSECTL_MAP_HINT
 Muis gevangen. Naadloze muisintegratie is uitgeschakeld terwijl mapping actief
 is en toegewezen muizen ontvangen altijd onbewerkte invoergebeurtenissen.
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scant op wijzigingen op gekoppelde DOS-schijven.
 
 Gebruik:
@@ -1968,7 +1964,7 @@ Omgekeerd
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Beheert de seriële poorten.
 
 Gebruik:
@@ -2470,11 +2466,11 @@ Voorbeelden:
   [color=green]help[reset] /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Geeft een inleiding op het volledige scherm van DOSBox Staging weer.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Gebruik:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]PAGINA[reset]

--- a/contrib/resources/translations/utf-8/pl.txt
+++ b/contrib/resources/translations/utf-8/pl.txt
@@ -1017,7 +1017,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki/Add-Utilities
 :WIKI_URL
 https://github.com/dosbox-staging/dosbox-staging/wiki
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Symulowanie naciśnięć klawiszy dla uruchomionego programu.
 
 Składnia:
@@ -1041,7 +1041,7 @@ Przykłady:
   [color=green]autotype[reset] -p [color=white]0.2[reset] [color=cyan]f1 kp_8 , , enter[reset]
   [color=green]autotype[reset] -w [color=white]1.3[reset] [color=cyan]esc enter , p l a y e r enter[reset]
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Startowanie systemu z obrazu dyskietki lub zamontowanego dysku.
 
 Składnia:
@@ -1177,7 +1177,7 @@ Lista zamontowanych dysków:
 
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Montowanie obrazu dyskietki, płyty CD lub dysku pod wybraną literę.
 
 Składnia:
@@ -1398,7 +1398,7 @@ Strona kodowa %i została załadowana.
 Strona kodowa %i dla układu klawiatury '%s' została załadowana.
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Konfiguracja klawiatury i czcionki dla danego języka.
 
 Składnia:
@@ -1445,7 +1445,7 @@ Brak lub nieprawidłowy plik strony kodowej dla układu klawiatury '%s'.
 
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Ładowanie programu w określone miejsce pamięci i uruchomienie go.
 
 Składnia:
@@ -1482,7 +1482,7 @@ Używana pamięć została zwolniona.
 Błąd alokacji pamięci.
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Ładowanie obrazu ROM języka IBM BASIC lub BIOSu karty graficznej.
 
 Składnia:
@@ -1521,7 +1521,7 @@ Nie można rozpoznać ROMu.
 Załadowano BASIC ROM.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Wyświetlenie informacji o użyciu pamięci.
 
 Składnia:
@@ -1553,11 +1553,11 @@ Przykłady:
 %10d kB wolnej pamięci UMB (górnej) w %d blokach (największy %d kB)
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Montowanie fizycznych katalogów lub dysków.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Montuje katalog z systemu gospodarza pod literę dysku.
 
 Składnia:
@@ -1659,7 +1659,7 @@ Nakładka ('overlay') '%s' zamontowana na dysku %c.
 Nie można przenieść dysku Z. Dysk %c jest już zamontowany.
 
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Sprawdzenie zmian na zamontowanych dyskach.
 
 Składnia:
@@ -1723,7 +1723,7 @@ Stereo
 :SHELL_CMD_MIXER_CHANNEL_MONO
 Mono
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Zarządzanie portami szeregowymi.
 
 Składnia:
@@ -2218,11 +2218,11 @@ Przykłady:
   [color=green]help[reset] [color=cyan]dir[reset]
   [color=green]help[reset] /all
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Krótki, pełnoekranowy samouczek.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Składnia:
   [color=green]intro[reset]
   [color=green]intro[reset] [color=white]STRONA[reset]

--- a/contrib/resources/translations/utf-8/ru.txt
+++ b/contrib/resources/translations/utf-8/ru.txt
@@ -1271,7 +1271,7 @@ PCjr картридж найден, но машина не PCjr.
 Базовое ПЗУ загружено.
 
 .
-:SHELL_CMD_IMGMOUNT_HELP_LONG
+:PROGRAM_IMGMOUNT_HELP_LONG
 Монтировать CD-ROM, дискету или образ диска на указанную букву диска.
 
 Использование:
@@ -1298,11 +1298,11 @@ PCjr картридж найден, но машина не PCjr.
   [32;1mimgmount[0m [37;1mC[0m [36;1mзагрузочный_образ.img[0m -t hdd -fs none -size 512,63,32,1023
 
 .
-:SHELL_CMD_MOUNT_HELP
+:PROGRAM_MOUNT_HELP
 Сопоставить физическую директорию с буквой виртуального диска DOS.
 
 .
-:SHELL_CMD_MOUNT_HELP_LONG
+:PROGRAM_MOUNT_HELP_LONG
 Монтировать директорию из операционной системы на букву виртуального диска DOS.
 
 Использование:
@@ -1862,7 +1862,7 @@ choice [/c:клавиши] [/n] [/s] текст
 Нет доступных IDE контроллеров. Диск не будет иметь эмуляции IDE.
 
 .
-:SHELL_CMD_MEM_HELP_LONG
+:PROGRAM_MEM_HELP_LONG
 Displays the DOS memory information.
 
 Usage:
@@ -1879,7 +1879,7 @@ Examples:
   [32;1mmem[0m
 
 .
-:SHELL_CMD_LOADFIX_HELP_LONG
+:PROGRAM_LOADFIX_HELP_LONG
 Loads a program in the specific memory region and then runs it.
 
 Usage:
@@ -1901,7 +1901,7 @@ Examples:
   [32;1mloadfix[0m /d
 
 .
-:SHELL_CMD_AUTOTYPE_HELP_LONG
+:PROGRAM_AUTOTYPE_HELP_LONG
 Performs scripted keyboard entry into a running DOS game.
 
 Usage:
@@ -1949,7 +1949,7 @@ Examples:
   [32;1mmixer[0m [36;1mmaster[0m [37;1m50[0m [36;1mrecord[0m [37;1m60[0m /noshow
   [32;1mmixer[0m /listmidi
 .
-:SHELL_CMD_RESCAN_HELP_LONG
+:PROGRAM_RESCAN_HELP_LONG
 Scans for changes on mounted DOS drives.
 
 Usage:
@@ -2009,7 +2009,7 @@ Additionally, you can use imgmount to mount iso or cue/bin images:
 [34;1mimgmount D ~/cd.cue -t cdrom[0m
 
 .
-:SHELL_CMD_BOOT_HELP_LONG
+:PROGRAM_BOOT_HELP_LONG
 Boots DOSBox Staging from a DOS drive or disk image.
 
 Usage:
@@ -2030,7 +2030,7 @@ Examples:
   [32;1mboot[0m [36;1mdisk1.ima disk2.ima[0m
 
 .
-:SHELL_CMD_LOADROM_HELP_LONG
+:PROGRAM_LOADROM_HELP_LONG
 Loads a ROM image of the video BIOS or IBM BASIC.
 
 Usage:
@@ -2047,7 +2047,7 @@ Examples:
   [32;1mloadrom[0m [36;1mbios.rom[0m
 
 .
-:SHELL_CMD_KEYB_HELP_LONG
+:PROGRAM_KEYB_HELP_LONG
 Configures a keyboard for a specific language.
 
 Usage:
@@ -2074,7 +2074,7 @@ Examples:
   [32;1mKEYB[0m [36;1mde[0m [37;1m858[0m mycp.cpi
 
 .
-:SHELL_CMD_SERIAL_HELP_LONG
+:PROGRAM_SERIAL_HELP_LONG
 Manage the serial ports.
 
 Usage modes:
@@ -2235,11 +2235,11 @@ Examples:
   [32;1mhelp[0m /all
 
 .
-:SHELL_CMD_INTRO_HELP
+:PROGRAM_INTRO_HELP
 Displays a full-screen introduction to DOSBox Staging.
 
 .
-:SHELL_CMD_INTRO_HELP_LONG
+:PROGRAM_INTRO_HELP_LONG
 Usage:
   [32;1mintro[0m
   [32;1mintro[0m [37;1mPAGE[0m

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -121,7 +121,7 @@ void AUTOTYPE::Run()
 
 	// Usage
 	if (!cmd->GetCount() || HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_AUTOTYPE_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_AUTOTYPE_HELP_LONG"));
 		return;
 	}
 
@@ -160,7 +160,7 @@ void AUTOTYPE::Run()
 }
 
 void AUTOTYPE::AddMessages() {
-	MSG_Add("SHELL_CMD_AUTOTYPE_HELP_LONG",
+	MSG_Add("PROGRAM_AUTOTYPE_HELP_LONG",
 	        "Performs scripted keyboard entry into a running DOS game.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -166,7 +166,7 @@ void BOOT::Run(void)
 	}
 
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_BOOT_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_BOOT_HELP_LONG"));
 		return;
 	}
 	if (cmd->GetCount() == 1) {
@@ -502,7 +502,7 @@ void BOOT::Run(void)
 }
 
 void BOOT::AddMessages() {
-	MSG_Add("SHELL_CMD_BOOT_HELP_LONG",
+	MSG_Add("PROGRAM_BOOT_HELP_LONG",
 	        "Boots DOSBox Staging from a DOS drive or disk image.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -96,7 +96,7 @@ void IMGMOUNT::Run(void) {
     }
     // Usage
     if (HelpRequested()) {
-        WriteOut(MSG_Get("SHELL_CMD_IMGMOUNT_HELP_LONG"), PRIMARY_MOD_NAME);
+        WriteOut(MSG_Get("PROGRAM_IMGMOUNT_HELP_LONG"), PRIMARY_MOD_NAME);
         return;
     }
 
@@ -492,7 +492,7 @@ void IMGMOUNT::Run(void) {
 
 void IMGMOUNT::AddMessages() {
     AddCommonMountMessages();
-	MSG_Add("SHELL_CMD_IMGMOUNT_HELP_LONG",
+	MSG_Add("PROGRAM_IMGMOUNT_HELP_LONG",
 	        "Mount a CD-ROM, floppy, or disk image to a drive letter.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -66,9 +66,9 @@ void INTRO::DisplayMount(void) {
 void INTRO::Run(void) {
 	// Usage
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_INTRO_HELP"));
+		WriteOut(MSG_Get("PROGRAM_INTRO_HELP"));
 		WriteOut("\n");
-		WriteOut(MSG_Get("SHELL_CMD_INTRO_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_INTRO_HELP_LONG"));
 		return;
 	}
     /* Only run if called from the first shell (Xcom TFTD runs any intro file in the path) */
@@ -106,6 +106,24 @@ void INTRO::Run(void) {
 }
 
 void INTRO::AddMessages() {
+	MSG_Add("PROGRAM_INTRO_HELP",
+	        "Displays a full-screen introduction to DOSBox Staging.\n");
+	MSG_Add("PROGRAM_INTRO_HELP_LONG",
+	        "Usage:\n"
+	        "  [color=green]intro[reset]\n"
+	        "  [color=green]intro[reset] [color=white]PAGE[reset]\n"
+	        "\n"
+	        "Where:\n"
+	        "  [color=white]PAGE[reset] is the page name to display, including [color=white]cdrom[reset], [color=white]mount[reset], and [color=white]special[reset].\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Running [color=green]intro[reset] without an argument displays one information page at a time;\n"
+	        "  press any key to move to the next page. If a page name is provided, then the\n"
+	        "  specified page will be displayed directly.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=green]intro[reset]\n"
+	        "  [color=green]intro[reset] [color=white]cdrom[reset]\n");
     MSG_Add("PROGRAM_INTRO",
 	        "[erases=entire][color=green]Welcome to DOSBox Staging[reset], an x86 emulator with sound and graphics.\n"
 	        "DOSBox creates a shell for you which looks like old plain DOS.\n"

--- a/src/dos/program_keyb.cpp
+++ b/src/dos/program_keyb.cpp
@@ -59,7 +59,7 @@ void KEYB::Run(void) {
 
 	// One argument: asked for help
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_KEYB_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_KEYB_HELP_LONG"));
 		return;
 	}
 
@@ -95,7 +95,7 @@ void KEYB::Run(void) {
 void KEYB::AddMessages() {
 	MSG_Add("PROGRAM_KEYB_INFO","Codepage %i has been loaded\n");
 	MSG_Add("PROGRAM_KEYB_INFO_LAYOUT","Codepage %i has been loaded for layout %s\n");
-	MSG_Add("SHELL_CMD_KEYB_HELP_LONG",
+	MSG_Add("PROGRAM_KEYB_HELP_LONG",
 	        "Configures a keyboard for a specific language.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -27,7 +27,7 @@
 void LOADFIX::Run(void)
 {
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_LOADFIX_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_LOADFIX_HELP_LONG"));
 		return;
 	}
 	uint16_t commandNr = 1;
@@ -83,7 +83,7 @@ void LOADFIX::Run(void)
 }
 
 void LOADFIX::AddMessages() {
-	MSG_Add("SHELL_CMD_LOADFIX_HELP_LONG",
+	MSG_Add("PROGRAM_LOADFIX_HELP_LONG",
 	        "Loads a program in the specific memory region and then runs it.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -34,7 +34,7 @@ void LOADROM::Run(void) {
         return;
     }
     if (HelpRequested()) {
-	    WriteOut(MSG_Get("SHELL_CMD_LOADROM_HELP_LONG"));
+	    WriteOut(MSG_Get("PROGRAM_LOADROM_HELP_LONG"));
 	    return;
     }
     uint8_t drive;
@@ -101,7 +101,7 @@ void LOADROM::Run(void) {
 }
 
 void LOADROM::AddMessages() {
-    MSG_Add("SHELL_CMD_LOADROM_HELP_LONG",
+    MSG_Add("PROGRAM_LOADROM_HELP_LONG",
 	        "Loads a ROM image of the video BIOS or IBM BASIC.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_mem.cpp
+++ b/src/dos/program_mem.cpp
@@ -25,7 +25,7 @@
 
 void MEM::Run(void) {
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_MEM_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_MEM_HELP_LONG"));
 		return;
 	}
     /* Show conventional Memory */
@@ -87,7 +87,7 @@ void MEM::Run(void) {
 }
 
 void MEM::AddMessages() {
-    MSG_Add("SHELL_CMD_MEM_HELP_LONG",
+    MSG_Add("PROGRAM_MEM_HELP_LONG",
 	        "Displays the DOS memory information.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -42,7 +42,7 @@ void MORE::Run()
 {
 	// Handle command line
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_MORE_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_MORE_HELP_LONG"));
 		return;
 	}
 	if (!ParseCommandLine() || shutdown_requested)
@@ -71,7 +71,7 @@ void MORE::Run()
 		if (max_lines - line_counter < free_rows_threshold)
 			PromptUser();
 
-		WriteOut(MSG_Get("SHELL_CMD_MORE_END"));
+		WriteOut(MSG_Get("PROGRAM_MORE_END"));
 		WriteOut("\n");
 	}
 
@@ -169,7 +169,7 @@ bool MORE::FindInputFiles(const std::vector<std::string> &params)
 	dos.dta(save_dta);
 
 	if (!shutdown_requested && input_files.empty()) {
-		WriteOut(MSG_Get("SHELL_CMD_MORE_NO_FILE"));
+		WriteOut(MSG_Get("PROGRAM_MORE_NO_FILE"));
 		WriteOut("\n");
 		return false;
 	}
@@ -228,8 +228,8 @@ void MORE::DisplayInputFiles()
 			LOG_WARNING("DOS: MORE.COM - could not open '%s'",
 			            input_file.name.c_str());
 			const auto short_name = GetShortName(input_file.name,
-			                                     "SHELL_CMD_MORE_OPEN_ERROR");
-			WriteOut(MSG_Get("SHELL_CMD_MORE_OPEN_ERROR"), short_name.c_str());
+			                                     "PROGRAM_MORE_OPEN_ERROR");
+			WriteOut(MSG_Get("PROGRAM_MORE_OPEN_ERROR"), short_name.c_str());
 			WriteOut("\n");
 			++line_counter;
 			continue;
@@ -237,12 +237,12 @@ void MORE::DisplayInputFiles()
 
 		if (input_file.is_device) {
 			const auto short_name = GetShortName(input_file.name,
-			                                     "SHELL_CMD_MORE_NEW_DEVICE");
-			WriteOut(MSG_Get("SHELL_CMD_MORE_NEW_DEVICE"), short_name.c_str());
+			                                     "PROGRAM_MORE_NEW_DEVICE");
+			WriteOut(MSG_Get("PROGRAM_MORE_NEW_DEVICE"), short_name.c_str());
 		} else {
 			const auto short_name = GetShortName(input_file.name,
-			                                     "SHELL_CMD_MORE_NEW_FILE");
-			WriteOut(MSG_Get("SHELL_CMD_MORE_NEW_FILE"), short_name.c_str());
+			                                     "PROGRAM_MORE_NEW_FILE");
+			WriteOut(MSG_Get("PROGRAM_MORE_NEW_FILE"), short_name.c_str());
 		}
 		WriteOut("\n");
 		++line_counter;
@@ -362,9 +362,9 @@ MORE::Decision MORE::PromptUser()
 		WriteOut("\n");
 
 	if (multiple_files)
-		WriteOut(MSG_Get("SHELL_CMD_MORE_PROMPT_MULTI"));
+		WriteOut(MSG_Get("PROGRAM_MORE_PROMPT_MULTI"));
 	else
-		WriteOut(MSG_Get("SHELL_CMD_MORE_PROMPT_SINGLE"));
+		WriteOut(MSG_Get("PROGRAM_MORE_PROMPT_SINGLE"));
 
 	auto decision = Decision::Terminate;
 	while (!shutdown_requested) {
@@ -396,7 +396,7 @@ MORE::Decision MORE::PromptUser()
 
 	if (decision == Decision::Terminate || decision == Decision::NextFile) {
 		WriteOut(" ");
-		WriteOut(MSG_Get("SHELL_CMD_MORE_TERMINATE"));
+		WriteOut(MSG_Get("PROGRAM_MORE_TERMINATE"));
 		WriteOut("\n");
 		++line_counter;
 	} else {
@@ -469,9 +469,7 @@ uint8_t MORE::GetCurrentRow()
 
 void MORE::AddMessages()
 {
-	MSG_Add("SHELL_CMD_MORE_HELP",
-	        "Display command output or text file one screen at a time.\n");
-	MSG_Add("SHELL_CMD_MORE_HELP_LONG",
+	MSG_Add("PROGRAM_MORE_HELP_LONG",
 	        "Display command output or text file one screen at a time.\n"
 	        "\n"
 	        "Usage:\n"
@@ -493,12 +491,12 @@ void MORE::AddMessages()
 	        "  [color=cyan]dir /on[reset] | [color=green]more[reset]             ; displays sorted directory one screen at a time\n"
 	        "  [color=green]more[reset] /t[color=white]4[reset] < [color=cyan]A:\\MANUAL.TXT[reset]   ; shows the file's content with tab size 4\n");
 
-	MSG_Add("SHELL_CMD_MORE_NO_FILE",       "No input file found.");
-	MSG_Add("SHELL_CMD_MORE_END",           "[reset][color=light-yellow]--- end of input ---[reset]");
-	MSG_Add("SHELL_CMD_MORE_NEW_FILE",      "[reset][color=light-yellow]--- file %s ---[reset]");
-	MSG_Add("SHELL_CMD_MORE_NEW_DEVICE",    "[reset][color=light-yellow]--- device %s ---[reset]");
-	MSG_Add("SHELL_CMD_MORE_PROMPT_SINGLE", "[reset][color=light-yellow]--- press SPACE for more ---[reset]");
-	MSG_Add("SHELL_CMD_MORE_PROMPT_MULTI",  "[reset][color=light-yellow]--- press SPACE for more, N for next file ---[reset]");
-	MSG_Add("SHELL_CMD_MORE_OPEN_ERROR",    "[reset][color=red]--- could not open %s ---[reset]");
-	MSG_Add("SHELL_CMD_MORE_TERMINATE",     "[reset][color=light-yellow](terminated)[reset]");
+	MSG_Add("PROGRAM_MORE_NO_FILE",       "No input file found.");
+	MSG_Add("PROGRAM_MORE_END",           "[reset][color=light-yellow]--- end of input ---[reset]");
+	MSG_Add("PROGRAM_MORE_NEW_FILE",      "[reset][color=light-yellow]--- file %s ---[reset]");
+	MSG_Add("PROGRAM_MORE_NEW_DEVICE",    "[reset][color=light-yellow]--- device %s ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_SINGLE", "[reset][color=light-yellow]--- press SPACE for more ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_MULTI",  "[reset][color=light-yellow]--- press SPACE for more, N for next file ---[reset]");
+	MSG_Add("PROGRAM_MORE_OPEN_ERROR",    "[reset][color=red]--- could not open %s ---[reset]");
+	MSG_Add("PROGRAM_MORE_TERMINATE",     "[reset][color=light-yellow](terminated)[reset]");
 }

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -137,7 +137,7 @@ void MOUNT::Run(void) {
 	// a side effect of not being able to parse the correct 
 	// command line options.
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUNT_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_MOUNT_HELP_LONG"));
 		return;
 	}
 
@@ -405,16 +405,16 @@ void MOUNT::Run(void) {
 	if (type == "floppy") incrementFDD();
 	return;
 showusage:
-	WriteOut(MSG_Get("SHELL_CMD_MOUNT_HELP_LONG"));
+	WriteOut(MSG_Get("PROGRAM_MOUNT_HELP_LONG"));
 	return;
 }
 
 void MOUNT::AddMessages() {
 	AddCommonMountMessages();
-	MSG_Add("SHELL_CMD_MOUNT_HELP",
+	MSG_Add("PROGRAM_MOUNT_HELP",
 	        "maps physical folders or drives to a virtual drive letter.\n");
 
-	MSG_Add("SHELL_CMD_MOUNT_HELP_LONG",
+	MSG_Add("PROGRAM_MOUNT_HELP_LONG",
 	        "Mount a directory from the host OS to a drive letter.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -31,7 +31,7 @@ CHECK_NARROWING();
 void MOUSECTL::Run()
 {
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_HELP_LONG"));
 		return;
 	}
 
@@ -110,7 +110,7 @@ bool MOUSECTL::ParseAndRun()
 			return CmdSensitivity(params[1], params[2]);
 	}
 
-	WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX"));
+	WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX"));
 	return false;
 }
 
@@ -120,14 +120,14 @@ bool MOUSECTL::ParseSensitivity(const std::string &param, int16_t &value)
 
 	int tmp = 0;
 	if (!ParseIntParam(param, tmp)) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY"));
 		return false;
 	}
 
 	// Maximum allowed user sensitivity value
 	constexpr int16_t sensitivity_user_max = 999;
 	if (tmp < -sensitivity_user_max || tmp > sensitivity_user_max) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY"));
 		return false;
 	}
 
@@ -176,7 +176,7 @@ bool MOUSECTL::ParseInterfaces(std::vector<std::string> &params)
 	// Check that all interfaces are unique
 	const std::set<MouseInterfaceId> tmp(list_ids.begin(), list_ids.end());
 	if (list_ids.size() != tmp.size()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_DUPLICATED"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_DUPLICATED"));
 		return false;
 	}
 
@@ -189,9 +189,9 @@ bool MOUSECTL::CheckInterfaces()
 		return true;
 
 	if (list_ids.empty())
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_NO_INTERFACES"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_NO_INTERFACES"));
 	else
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MISSING_INTERFACES"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MISSING_INTERFACES"));
 
 	return false;
 }
@@ -200,13 +200,13 @@ const char *MOUSECTL::GetMapStatusStr(const MouseMapStatus map_status)
 {
 	switch (map_status) {
 	case MouseMapStatus::HostPointer:
-		return MSG_Get("SHELL_CMD_MOUSECTL_TABLE_STATUS_HOST");
+		return MSG_Get("PROGRAM_MOUSECTL_TABLE_STATUS_HOST");
 	case MouseMapStatus::Mapped:
-		return MSG_Get("SHELL_CMD_MOUSECTL_TABLE_STATUS_MAPPED");
+		return MSG_Get("PROGRAM_MOUSECTL_TABLE_STATUS_MAPPED");
 	case MouseMapStatus::Disconnected:
-		return MSG_Get("SHELL_CMD_MOUSECTL_TABLE_STATUS_DISCONNECTED");
+		return MSG_Get("PROGRAM_MOUSECTL_TABLE_STATUS_DISCONNECTED");
 	case MouseMapStatus::Disabled:
-		return MSG_Get("SHELL_CMD_MOUSECTL_TABLE_STATUS_DISABLED");
+		return MSG_Get("PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED");
 	default:
 		assert(false); // missing implementation
 		return nullptr;
@@ -224,7 +224,7 @@ bool MOUSECTL::CmdShow(const bool show_all)
 
 	// Display emulated interface list
 	WriteOut("\n");
-	WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_HEADER1"));
+	WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_HEADER1"));
 	WriteOut("\n");
 	for (const auto &entry : info_interfaces) {
 		if (!entry.IsEmulated())
@@ -242,7 +242,7 @@ bool MOUSECTL::CmdShow(const bool show_all)
 		    interface_id == MouseInterfaceId::COM4)
 			hint_rate_com = true;
 
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_LAYOUT1"),
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_LAYOUT1"),
 		         MouseControlAPI::GetInterfaceNameStr(interface_id).c_str(),
 		         entry.GetSensitivityX(),
 		         entry.GetSensitivityY(),
@@ -260,11 +260,11 @@ bool MOUSECTL::CmdShow(const bool show_all)
 	const bool hint = hint_rate_com || hint_rate_min;
 	if (hint) {
 		if (hint_rate_com) {
-			WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_COM"));
+			WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_HINT_RATE_COM"));
 			WriteOut("\n");
 		}
 		if (hint_rate_min) {
-			WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_MIN"));
+			WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_HINT_RATE_MIN"));
 			WriteOut("\n");
 		}
 		WriteOut("\n");
@@ -275,14 +275,14 @@ bool MOUSECTL::CmdShow(const bool show_all)
 
 	const auto info_physical = mouse_config_api.GetInfoPhysical();
 	if (info_physical.empty()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_NO_PHYSICAL_MICE"));
 		WriteOut("\n\n");
 		return true;
 	}
 
 	if (hint)
 		WriteOut("\n");
-	WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_HEADER2"));
+	WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_HEADER2"));
 	WriteOut("\n");
 
 	// Display physical mice mapped to some interface
@@ -290,7 +290,7 @@ bool MOUSECTL::CmdShow(const bool show_all)
 	for (const auto &entry : info_interfaces) {
 		if (!entry.IsMapped() || entry.IsMappedDeviceDisconnected())
 			continue;
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_LAYOUT2"),
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_LAYOUT2"),
 		         MouseControlAPI::GetInterfaceNameStr(entry.GetInterfaceId())
 		                 .c_str(),
 		         entry.GetMappedDeviceName().c_str());
@@ -308,7 +308,7 @@ bool MOUSECTL::CmdShow(const bool show_all)
 	for (const auto &entry : info_physical) {
 		if (entry.IsMapped() || entry.IsDeviceDisconnected())
 			continue;
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_TABLE_LAYOUT2_UNMAPPED"),
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_TABLE_LAYOUT2_UNMAPPED"),
 		         entry.GetDeviceName().c_str());
 		WriteOut("\n");
 	}
@@ -320,7 +320,7 @@ bool MOUSECTL::CmdShow(const bool show_all)
 void MOUSECTL::FinalizeMapping()
 {
 	WriteOut("\n");
-	WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MAP_HINT"));
+	WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAP_HINT"));
 	WriteOut("\n\n");
 }
 
@@ -328,18 +328,18 @@ bool MOUSECTL::CmdMap(const MouseInterfaceId interface_id, const std::string &pa
 {
 	std::regex regex;
 	if (!MouseControlAPI::PatternToRegex(pattern, regex)) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_PATTERN"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_PATTERN"));
 		return false;
 	}
 
 	if (MouseControlAPI::IsNoMouseMode()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE"));
 		return false;
 	}
 
 	MouseControlAPI mouse_config_api;
 	if (!mouse_config_api.Map(interface_id, regex)) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_NO_MATCH"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_NO_MATCH"));
 		return false;
 	}
 
@@ -352,7 +352,7 @@ bool MOUSECTL::CmdMap()
 	assert(!list_ids.empty());
 
 	if (MouseControlAPI::IsNoMouseMode()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE"));
 		return false;
 	}
 
@@ -360,7 +360,7 @@ bool MOUSECTL::CmdMap()
 	const auto info_physical = mouse_config_api.GetInfoPhysical();
 
 	if (info_physical.empty()) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE"));
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_NO_PHYSICAL_MICE"));
 		WriteOut("\n\n");
 		return false;
 	}
@@ -370,7 +370,7 @@ bool MOUSECTL::CmdMap()
 	mouse_config_api.UnMap(empty);
 
 	WriteOut("\n");
-	WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MAP_ADVICE"));
+	WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAP_ADVICE"));
 	WriteOut("\n\n");
 
 	for (const auto &interface_id : list_ids) {
@@ -381,7 +381,7 @@ bool MOUSECTL::CmdMap()
 		if (!mouse_config_api.ProbeForMapping(device_id)) {
 			mouse_config_api.UnMap(empty);
 			WriteOut("\b");
-			WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_MAP_CANCEL"));
+			WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAP_CANCEL"));
 			WriteOut("\n\n");
 			return false;
 		}
@@ -479,14 +479,14 @@ bool MOUSECTL::CmdMinRate(const std::string &param)
 
 	int tmp = 0;
 	if (!ParseIntParam(param, tmp)) {
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE"),
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_MIN_RATE"),
 		         valid_str.c_str());
 		return false;
 	}
 
 	if (tmp < 0 || tmp > UINT16_MAX) {
 		// Parameter way out of range
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE"),
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_MIN_RATE"),
 		         valid_str.c_str());
 		return false;
 	}
@@ -494,7 +494,7 @@ bool MOUSECTL::CmdMinRate(const std::string &param)
 	const auto value_hz = static_cast<uint16_t>(tmp);
 	if (!contains(valid_list, value_hz)) {
 		// Parameter not in the list of allowed values
-		WriteOut(MSG_Get("SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE"),
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_SYNTAX_MIN_RATE"),
 		         valid_str.c_str());
 		return false;
 	}
@@ -513,7 +513,7 @@ bool MOUSECTL::CmdMinRate()
 
 void MOUSECTL::AddMessages()
 {
-	MSG_Add("SHELL_CMD_MOUSECTL_HELP_LONG",
+	MSG_Add("PROGRAM_MOUSECTL_HELP_LONG",
 	        "Manages physical and logical mice.\n"
 	        "\n"
 	        "Usage:\n"
@@ -539,53 +539,53 @@ void MOUSECTL::AddMessages()
 	        "Examples:\n"
 	        "  [color=green]mousectl[reset] [color=white]DOS[reset] [color=white]COM1[reset] -map    ; asks user to select mice for a two player game");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_SYNTAX", "Wrong command syntax.");
-	MSG_Add("SHELL_CMD_MOUSECTL_SYNTAX_PATTERN",
+	MSG_Add("PROGRAM_MOUSECTL_SYNTAX", "Wrong command syntax.");
+	MSG_Add("PROGRAM_MOUSECTL_SYNTAX_PATTERN",
 	        "Wrong syntax, only ASCII characters allowed in pattern.");
-	MSG_Add("SHELL_CMD_MOUSECTL_SYNTAX_SENSITIVITY",
+	MSG_Add("PROGRAM_MOUSECTL_SYNTAX_SENSITIVITY",
 	        "Wrong syntax, sensitivity needs to be in -999 to +999 range.");
-	MSG_Add("SHELL_CMD_MOUSECTL_SYNTAX_DUPLICATED",
+	MSG_Add("PROGRAM_MOUSECTL_SYNTAX_DUPLICATED",
 	        "Wrong syntax, duplicated mouse interfaces.");
-	MSG_Add("SHELL_CMD_MOUSECTL_SYNTAX_MIN_RATE",
+	MSG_Add("PROGRAM_MOUSECTL_SYNTAX_MIN_RATE",
 	        "Wrong syntax, sampling rate has to be one of:\n%s");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_MAPPING_NO_MOUSE",
+	MSG_Add("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE",
 	        "Mapping not available in no-mouse mode.");
-	MSG_Add("SHELL_CMD_MOUSECTL_NO_INTERFACES", "No mouse interfaces available.");
-	MSG_Add("SHELL_CMD_MOUSECTL_MISSING_INTERFACES",
+	MSG_Add("PROGRAM_MOUSECTL_NO_INTERFACES", "No mouse interfaces available.");
+	MSG_Add("PROGRAM_MOUSECTL_MISSING_INTERFACES",
 	        "Mouse interface not available.");
-	MSG_Add("SHELL_CMD_MOUSECTL_NO_PHYSICAL_MICE", "No physical mice detected.");
-	MSG_Add("SHELL_CMD_MOUSECTL_NO_MATCH",
+	MSG_Add("PROGRAM_MOUSECTL_NO_PHYSICAL_MICE", "No physical mice detected.");
+	MSG_Add("PROGRAM_MOUSECTL_NO_MATCH",
 	        "No available mouse matching the pattern found.");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_HEADER1",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_HEADER1",
 	        "[color=white]Interface      Sensitivity      Rate (Hz)     Status[reset]");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_LAYOUT1",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_LAYOUT1",
 	        "[color=cyan]%-4s[reset]          X:%+.3d Y:%+.3d       %1s %3s       %s");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_HEADER2",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_HEADER2",
 	        "[color=white]Interface     Mouse Name[reset]");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_LAYOUT2",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_LAYOUT2",
 	        "[color=cyan]%-4s[reset]          %s");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_LAYOUT2_UNMAPPED", "not mapped    %s");
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_LAYOUT2_UNMAPPED", "not mapped    %s");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_STATUS_HOST", "uses system pointer");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_STATUS_MAPPED", "mapped physical mouse");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_STATUS_DISCONNECTED",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_STATUS_HOST", "uses system pointer");
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_STATUS_MAPPED", "mapped physical mouse");
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_STATUS_DISCONNECTED",
 	        "[color=red]mapped mouse disconnected[reset]");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_STATUS_DISABLED", "disabled");
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED", "disabled");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_COM",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_HINT_RATE_COM",
 	        "Sampling rates for mice on [color=cyan]COM[reset] interfaces are estimations only.");
-	MSG_Add("SHELL_CMD_MOUSECTL_TABLE_HINT_RATE_MIN",
+	MSG_Add("PROGRAM_MOUSECTL_TABLE_HINT_RATE_MIN",
 	        "Sampling rates with minimum value set are marked with '*'.");
 
-	MSG_Add("SHELL_CMD_MOUSECTL_MAP_ADVICE",
+	MSG_Add("PROGRAM_MOUSECTL_MAP_ADVICE",
 	        "Click [color=white]left[reset] mouse button to map the physical mouse to the interface. Clicking\n"
 	        "any other button cancels the mapping and assigns system pointer to all the\n"
 	        "mouse interfaces.");
-	MSG_Add("SHELL_CMD_MOUSECTL_MAP_CANCEL", "(mapping cancelled)");
-	MSG_Add("SHELL_CMD_MOUSECTL_MAP_HINT",
+	MSG_Add("PROGRAM_MOUSECTL_MAP_CANCEL", "(mapping cancelled)");
+	MSG_Add("PROGRAM_MOUSECTL_MAP_HINT",
 	        "Mouse captured. Seamless mouse integration is always disabled while mapping is\n"
 	        "in effect and mapped mice always receive raw input events.");
 }

--- a/src/dos/program_placeholder.cpp
+++ b/src/dos/program_placeholder.cpp
@@ -26,19 +26,19 @@ void PLACEHOLDER::Run()
 {
 	const auto command = cmd->GetFileName();
 
-	LOG_WARNING("%s: %s", command, MSG_Get("SHELL_CMD_PLACEHOLDER_HELP"));
+	LOG_WARNING("%s: %s", command, MSG_Get("PROGRAM_PLACEHOLDER_HELP"));
 	LOG_WARNING("%s: %s", command, MSG_Get("VISIT_FOR_MORE_HELP"));
 	LOG_WARNING("%s: %s/%s", command, MSG_Get("WIKI_URL"), "Add-Utilities");
 
-	WriteOut(MSG_Get("SHELL_CMD_PLACEHOLDER_HELP_LONG"), command);
+	WriteOut(MSG_Get("PROGRAM_PLACEHOLDER_HELP_LONG"), command);
 	WriteOut_NoParsing(MSG_Get("UTILITY_DRIVE_EXAMPLE_NO_TRANSLATE"));
 
 	result_errorcode = dos.return_code;
 }
 
 void PLACEHOLDER::AddMessages() {
-	MSG_Add("SHELL_CMD_PLACEHOLDER_HELP", "This program is a placeholder");
-	MSG_Add("SHELL_CMD_PLACEHOLDER_HELP_LONG",
+	MSG_Add("PROGRAM_PLACEHOLDER_HELP", "This program is a placeholder");
+	MSG_Add("PROGRAM_PLACEHOLDER_HELP_LONG",
 	        "%s is only a placeholder.\n"
 	        "\nInstall a 3rd-party and give its PATH precedence.\n"
 	        "\nFor example:");

--- a/src/dos/program_rescan.cpp
+++ b/src/dos/program_rescan.cpp
@@ -29,7 +29,7 @@ void RESCAN::Run(void)
 	uint8_t drive = DOS_GetDefaultDrive();
 
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_RESCAN_HELP_LONG"));
+		WriteOut(MSG_Get("PROGRAM_RESCAN_HELP_LONG"));
 		return;
 	}
 
@@ -59,7 +59,7 @@ void RESCAN::Run(void)
 }
 
 void RESCAN::AddMessages() {
-	MSG_Add("SHELL_CMD_RESCAN_HELP_LONG",
+	MSG_Add("PROGRAM_RESCAN_HELP_LONG",
 	        "Scans for changes on mounted DOS drives.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -164,11 +164,11 @@ void SERIAL::Run()
 	}
 
 	// Show help.
-	WriteOut(MSG_Get("SHELL_CMD_SERIAL_HELP_LONG"), SERIAL_MAX_PORTS);
+	WriteOut(MSG_Get("PROGRAM_SERIAL_HELP_LONG"), SERIAL_MAX_PORTS);
 }
 
 void SERIAL::AddMessages() {
-	MSG_Add("SHELL_CMD_SERIAL_HELP_LONG",
+	MSG_Add("PROGRAM_SERIAL_HELP_LONG",
 	        "Manages the serial ports.\n"
 	        "\n"
 	        "Usage:\n"

--- a/src/misc/help_util.cpp
+++ b/src/misc/help_util.cpp
@@ -24,16 +24,31 @@ const std::map<const std::string, HELP_Detail> &HELP_GetHelpList()
 
 std::string HELP_GetShortHelp(const std::string &cmd_name)
 {
-	const std::string short_key = "SHELL_CMD_" + cmd_name + "_HELP";
-	if (MSG_Exists(short_key.c_str())) {
-		return MSG_Get(short_key.c_str());
+	// Try to find short help first
+	const std::string short_key_command = "SHELL_CMD_" + cmd_name + "_HELP";
+	if (MSG_Exists(short_key_command.c_str())) {
+		return MSG_Get(short_key_command.c_str());
 	}
-	const std::string long_key = "SHELL_CMD_" + cmd_name + "_HELP_LONG";
-	if (MSG_Exists(long_key.c_str())) {
+	const std::string short_key_program = "PROGRAM_" + cmd_name + "_HELP";
+	if (MSG_Exists(short_key_program.c_str())) {
+		return MSG_Get(short_key_program.c_str());
+	}
+
+	// If it does not exist, extract first line of long help
+	auto extract = [](const std::string &long_key) {
 		const std::string str(MSG_Get(long_key.c_str()));
 		const auto pos = str.find('\n');
 		return str.substr(0, pos != std::string::npos ? pos + 1 : pos);
+	};
+	const std::string long_key_command = "SHELL_CMD_" + cmd_name + "_HELP_LONG";
+	if (MSG_Exists(long_key_command.c_str())) {
+		return extract(long_key_command);
 	}
+	const std::string long_key_program = "PROGRAM_" + cmd_name + "_HELP_LONG";
+	if (MSG_Exists(long_key_program.c_str())) {
+		return extract(long_key_program);
+	}
+
 	return "No help available\n";
 }
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1192,24 +1192,6 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]help[reset] [color=cyan]dir[reset]\n"
 	        "  [color=green]help[reset] /all\n");
-	MSG_Add("SHELL_CMD_INTRO_HELP",
-	        "Displays a full-screen introduction to DOSBox Staging.\n");
-	MSG_Add("SHELL_CMD_INTRO_HELP_LONG",
-	        "Usage:\n"
-	        "  [color=green]intro[reset]\n"
-	        "  [color=green]intro[reset] [color=white]PAGE[reset]\n"
-	        "\n"
-	        "Where:\n"
-	        "  [color=white]PAGE[reset] is the page name to display, including [color=white]cdrom[reset], [color=white]mount[reset], and [color=white]special[reset].\n"
-	        "\n"
-	        "Notes:\n"
-	        "  Running [color=green]intro[reset] without an argument displays one information page at a time;\n"
-	        "  press any key to move to the next page. If a page name is provided, then the\n"
-	        "  specified page will be displayed directly.\n"
-	        "\n"
-	        "Examples:\n"
-	        "  [color=green]intro[reset]\n"
-	        "  [color=green]intro[reset] [color=white]cdrom[reset]\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP", "Creates a directory.\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP_LONG",
 	        "Usage:\n"


### PR DESCRIPTION
- harmonized string IDs for DOS programs, they all start with `PROGRAM_` now (previously some were starting from `SHELL_CMD_` - this was a search&replace change, covering also translation files); programs being shell commands at the same time (like ATTRIB) were left untouched
- moved two strings from `shell.cpp` to `program_intro.cpp` - they were probably left in `shell.cpp`
- removed `SHELL_CMD_MORE_HELP`, it is not needed
- improved `HELP_GetShortHelp` in `help_util.cpp`, it is now also looking for `PROGRAM_*_HELP` and `PROGRAM_*_HELP_LONG` strings