### PR TITLE
Allow to cancel interactive mouse mapping with a keyboard

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -179,7 +179,8 @@ bool DOS_CreateTempFile(char * const name,uint16_t * entry);
 bool DOS_FileExists(char const * const name);
 
 /* Helper Functions */
-bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive);
+bool DOS_MakeName(char const *const name, char *const fullname, uint8_t *drive);
+
 /* Drive Handing Routines */
 uint8_t DOS_GetDefaultDrive(void);
 void DOS_SetDefaultDrive(uint8_t drive);
@@ -289,6 +290,12 @@ static inline uint16_t long2para(uint32_t size) {
 #define DOSERR_NOT_SAME_DEVICE 17
 #define DOSERR_NO_MORE_FILES 18
 #define DOSERR_FILE_ALREADY_EXISTS 80
+
+/* Wait/check user input */
+enum class UserDecision { Cancel, Continue, Next };
+bool DOS_IsCancelRequest();
+UserDecision DOS_WaitForCancelContinue();
+UserDecision DOS_WaitForCancelContinueNext();
 
 /* Macros SSET_* and SGET_* are used to safely access fields in memory-mapped
  * DOS structures represented via classes inheriting from MemStruct class.

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1440,6 +1440,74 @@ static Bitu DOS_26Handler(void) {
     return CBRET_NONE;
 }
 
+constexpr uint8_t code_ctrl_c = 0x03;
+constexpr uint8_t code_return = 0x0d;
+constexpr uint8_t code_esc    = 0x1b;
+
+bool DOS_IsCancelRequest()
+{
+	if (shutdown_requested)
+		return true;
+
+	CALLBACK_Idle();
+	while (!(Files[STDIN]->GetInformation() & (1 << 6))) {
+		// A key is waiting, read it
+		uint16_t count = 1;
+		uint8_t code   = 0;
+		DOS_ReadFile(STDIN, &code, &count);
+
+		// Check if user requested to cancel
+		if (shutdown_requested || count == 0 ||
+			code == 'q' || code == 'Q' ||
+		    code == code_ctrl_c || code == code_esc)
+			return true;
+	}
+
+	// Return control if no key pressed
+	return shutdown_requested;
+}
+
+UserDecision DOS_WaitForCancelContinue()
+{
+	auto decision = UserDecision::Next;
+	while (decision == UserDecision::Next)
+		decision = DOS_WaitForCancelContinueNext();
+
+	return decision;
+}
+
+UserDecision DOS_WaitForCancelContinueNext()
+{
+	auto decision = UserDecision::Cancel;
+	while (!shutdown_requested) {
+		CALLBACK_Idle();
+
+		// Try to read the key
+		uint16_t count = 1;
+		uint8_t code   = 0;
+		DOS_ReadFile(STDIN, &code, &count);
+
+		if (shutdown_requested || count == 0 ||
+		    code == 'q' || code == 'Q' ||
+		    code == code_ctrl_c || code == code_esc) {
+			decision = UserDecision::Cancel;
+			break;
+		}
+
+		if (code == code_return || code == ' ') {
+			decision = UserDecision::Continue;
+			break;
+		}
+
+		if (code == 'n' || code == 'N') {
+			decision = UserDecision::Next;
+			break;
+		}
+	}
+
+	return decision;
+}
+
 DOS_Version DOS_ParseVersion(const char *word, const char *args)
 {
 	DOS_Version new_version = {5, 0, 0}; // Default to 5.0

--- a/src/dos/program_more.h
+++ b/src/dos/program_more.h
@@ -38,19 +38,13 @@ public:
 	void Run();
 
 private:
-	enum class Decision {
-		More,
-		Terminate,
-		NextFile,
-	};
-
 	bool ParseCommandLine();
 	bool FindInputFiles(const std::vector<std::string> &params);
 
 	void DisplayInputFiles();
 	void DisplayInputStream();
-	Decision DisplaySingleStream();
-	Decision PromptUser();
+	UserDecision DisplaySingleStream();
+	UserDecision PromptUser();
 
 	std::string GetShortName(const std::string &file_name, const char *msg_id);
 	static uint8_t GetCurrentColumn();

--- a/src/hardware/mouse/mouse_manymouse.cpp
+++ b/src/hardware/mouse/mouse_manymouse.cpp
@@ -254,15 +254,10 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &device_id)
 		HandleEvent(event, true); // handle critical events
 
 	bool success = false;
-	while (!shutdown_requested) {
-		if (IsCancelRequested())
-			break; // user cancelled using a keyboard
-
+	while (!DOS_IsCancelRequest()) {
 		// Poll mouse events, handle critical ones
-		if (!ManyMouse_PollEvent(&event)) {
-			CALLBACK_Idle();
+		if (!ManyMouse_PollEvent(&event))
 			continue;
-		}
 		if (event.device >= max_mice)
 			continue;
 		HandleEvent(event, true);
@@ -292,24 +287,6 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &device_id)
 	if (is_mapping_in_effect)
 		PIC_AddEvent(manymouse_tick, tick_interval);
 	return success;
-}
-
-bool ManyMouseGlue::IsCancelRequested()
-{
-	constexpr uint8_t code_ctrl_c = 0x03;
-	constexpr uint8_t code_esc    = 0x1b;
-
-	while (!(Files[STDIN]->GetInformation() & (1 << 6))) {
-		// A key is waiting, read it
-		uint16_t count = 1;
-		uint8_t code   = 0;
-		DOS_ReadFile(STDIN, &code, &count);
-		// Check if requested to cancel
-		if (code == code_ctrl_c || code == code_esc || code == 'q' || code == 'Q')
-			return true;
-	}
-
-	return false;
 }
 
 uint8_t ManyMouseGlue::GetIdx(const std::regex &regex)

--- a/src/hardware/mouse/mouse_manymouse.cpp
+++ b/src/hardware/mouse/mouse_manymouse.cpp
@@ -22,6 +22,7 @@
 
 #include "callback.h"
 #include "checks.h"
+#include "dos_inc.h"
 #include "math_utils.h"
 #include "pic.h"
 #include "string_utils.h"
@@ -254,6 +255,9 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &device_id)
 
 	bool success = false;
 	while (!shutdown_requested) {
+		if (IsCancelRequested())
+			break; // user cancelled using a keyboard
+
 		// Poll mouse events, handle critical ones
 		if (!ManyMouse_PollEvent(&event)) {
 			CALLBACK_Idle();
@@ -269,7 +273,7 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &device_id)
 		device_id = static_cast<uint8_t>(event.device);
 
 		if (event.item >= 1)
-			break; // user cancelled the interactive mouse mapping
+			break; // user cancelled using a mouse button
 
 		// Do not accept already mapped devices
 		bool already_mapped = false;
@@ -288,6 +292,24 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &device_id)
 	if (is_mapping_in_effect)
 		PIC_AddEvent(manymouse_tick, tick_interval);
 	return success;
+}
+
+bool ManyMouseGlue::IsCancelRequested()
+{
+	constexpr uint8_t code_ctrl_c = 0x03;
+	constexpr uint8_t code_esc    = 0x1b;
+
+	while (!(Files[STDIN]->GetInformation() & (1 << 6))) {
+		// A key is waiting, read it
+		uint16_t count = 1;
+		uint8_t code   = 0;
+		DOS_ReadFile(STDIN, &code, &count);
+		// Check if requested to cancel
+		if (code == code_ctrl_c || code == code_esc || code == 'q' || code == 'Q')
+			return true;
+	}
+
+	return false;
 }
 
 uint8_t ManyMouseGlue::GetIdx(const std::regex &regex)

--- a/src/hardware/mouse/mouse_manymouse.h
+++ b/src/hardware/mouse/mouse_manymouse.h
@@ -72,6 +72,7 @@ private:
 	ManyMouseGlue(const ManyMouseGlue &)            = delete;
 	ManyMouseGlue &operator=(const ManyMouseGlue &) = delete;
 
+	bool IsCancelRequested();
 	void Tick();
 	friend void manymouse_tick(uint32_t);
 

--- a/src/hardware/mouse/mouse_manymouse.h
+++ b/src/hardware/mouse/mouse_manymouse.h
@@ -72,7 +72,6 @@ private:
 	ManyMouseGlue(const ManyMouseGlue &)            = delete;
 	ManyMouseGlue &operator=(const ManyMouseGlue &) = delete;
 
-	bool IsCancelRequested();
 	void Tick();
 	friend void manymouse_tick(uint32_t);
 


### PR DESCRIPTION
It is now possible to cancel interactive mouse mapping (i. e. started with command `mousectl dos com1 -map`) by pressing CTRL+C, ESC or Q. Requested in issue https://github.com/dosbox-staging/dosbox-staging/issues/2066.