### PR TITLE
Fix sentence starting with lower case in MOUNT command help

### DIFF
--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -412,7 +412,7 @@ showusage:
 void MOUNT::AddMessages() {
 	AddCommonMountMessages();
 	MSG_Add("PROGRAM_MOUNT_HELP",
-	        "maps physical folders or drives to a virtual drive letter.\n");
+	        "Maps physical folders or drives to a virtual drive letter.\n");
 
 	MSG_Add("PROGRAM_MOUNT_HELP_LONG",
 	        "Mount a directory from the host OS to a drive letter.\n"


### PR DESCRIPTION
Fixes a sentence starting with lowercase letter, well visible in the output of HELP command:

![Screenshot_Case](https://user-images.githubusercontent.com/48332137/200142734-03b1a86e-5723-4117-994c-8d424b335d82.png)
