### PR TITLE
Add handling for ABNT2 slash/question mark key

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -113,7 +113,7 @@
 #define BIOS_DEFAULT_RESET_LOCATION		(RealMake(0xf000,(machine==MCH_PCJR)?0x0043:0xe05b))
 
 /* maximum of scancodes handled by keyboard bios routines */
-#define MAX_SCAN_CODE 0x58
+#define MAX_SCAN_CODE 0x59
 
 /* The Section handling Bios Disk Access */
 //#define BIOS_MAX_DISK 10

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -132,6 +132,8 @@ enum KBD_KEYS {
 	KBD_kpenter,
 	KBD_kpperiod,
 
+	KBD_intl1,
+
 	KBD_LAST
 };
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2176,6 +2176,19 @@ static void CreateLayout() {
 	AddKeyButtonEvent(PX(XO+2),PY(YO+4),BW,BH,".","kp_period",KBD_kpperiod);
 #undef XO
 #undef YO
+
+#define XO 0
+#define YO 11
+#define MX      1
+#define MY      1
+#define CX      (BW / 2)
+#define BU(_X_) (BW * (_X_) + MX * ((_X_)-1))
+#define BV(_Y_) (BH * (_Y_) + MY * ((_Y_)-1))
+
+    AddKeyButtonEvent(PX(XO + 4) + CX, PY(YO + 0), BU(1), BV(1), "\\", "intl1", KBD_intl1);
+#undef XO
+#undef YO
+
 #define XO 10
 #define YO 8
 	/* Joystick Buttons/Texts */
@@ -2475,6 +2488,8 @@ static struct {
                    /* Is that the extra backslash key ("less than" key) */
                    /* on some keyboards with the 102-keys layout??      */
                    {"lessthan", SDL_SCANCODE_NONUSBACKSLASH},
+				   				   
+                   {"intl1", SDL_SCANCODE_INTERNATIONAL1},
 
                    {0, SDL_SCANCODE_UNKNOWN}};
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -363,6 +363,8 @@ public:
 	{
 		if (key == SDL_SCANCODE_RETURN)
 			return "Enter"; // instead of "Return"
+		else if (key == SDL_SCANCODE_INTERNATIONAL1)
+			return "International 1"; // instead of empty string
 		else
 			return SDL_GetScancodeName(key);
 	}

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2174,18 +2174,9 @@ static void CreateLayout() {
 	AddKeyButtonEvent(PX(XO+3),PY(YO+3),BW,BH*2,"ENT","kp_enter",KBD_kpenter);
 	AddKeyButtonEvent(PX(XO),PY(YO+4),BW*2,BH,"0","kp_0",KBD_kp0);
 	AddKeyButtonEvent(PX(XO+2),PY(YO+4),BW,BH,".","kp_period",KBD_kpperiod);
-#undef XO
-#undef YO
 
-#define XO 0
-#define YO 11
-#define MX      1
-#define MY      1
-#define CX      (BW / 2)
-#define BU(_X_) (BW * (_X_) + MX * ((_X_)-1))
-#define BV(_Y_) (BH * (_Y_) + MY * ((_Y_)-1))
-
-    AddKeyButtonEvent(PX(XO + 4) + CX, PY(YO + 0), BU(1), BV(1), "\\", "intl1", KBD_intl1);
+	/* International Keys */
+	AddKeyButtonEvent(PX(XO + 5), PY(YO), BW * 2, BH, "Intl1", "intl1", KBD_intl1);
 #undef XO
 #undef YO
 

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -408,6 +408,10 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_f11:ret=87;break;
 	case KBD_f12:ret=88;break;
 
+	// International keys
+
+	case KBD_intl1:ret=89;break;
+
 	//The Extended keys
 
 	case KBD_kpenter:extend=true;ret=28;break;
@@ -424,11 +428,9 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_pagedown:extend=true;ret=81;break;
 	case KBD_insert:extend=true;ret=82;break;
 	case KBD_delete:extend=true;ret=83;break;
-	case KBD_leftgui: ret = 89; break;
-	case KBD_rightgui:
-		extend = true;
-		ret = 89;
-		break;
+	case KBD_leftgui:extend=true;ret=90;break;
+	case KBD_rightgui:extend=true;ret=89;break;
+	
 	case KBD_pause:
 		KEYBOARD_AddBuffer(0xe1);
 		KEYBOARD_AddBuffer(29|(pressed?0:0x80));
@@ -440,9 +442,6 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 		KEYBOARD_AddBuffer(0xe0);
 		KEYBOARD_AddBuffer(55|(pressed?0:0x80));
 		return;
-	case KBD_intl1:
-		ret = 89;
-		break;
 	default:
 		E_Exit("Unsupported key press");
 		break;

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -440,6 +440,9 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 		KEYBOARD_AddBuffer(0xe0);
 		KEYBOARD_AddBuffer(55|(pressed?0:0x80));
 		return;
+	case KBD_intl1:
+		ret = 89;
+		break;
 	default:
 		E_Exit("Unsupported key press");
 		break;

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -126,7 +126,7 @@ static struct {
       { 0x565c, 0x567c,   none,   none }, /* (102-key) */
       { 0x8500, 0x8700, 0x8900, 0x8b00 }, /* F11 */
       { 0x8600, 0x8800, 0x8a00, 0x8c00 }, /* F12 */
-      { 0x352f, 0x353f,   none, 0x35f0 }  /* international 1 */
+      { 0x352f, 0x353f,   none,   none }  /* international 1 */
       };
 
 bool BIOS_AddKeyToBuffer(uint16_t code) {

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -125,7 +125,8 @@ static struct {
       {   none,   none,   none,   none },
       { 0x565c, 0x567c,   none,   none }, /* (102-key) */
       { 0x8500, 0x8700, 0x8900, 0x8b00 }, /* F11 */
-      { 0x8600, 0x8800, 0x8a00, 0x8c00 }  /* F12 */
+      { 0x8600, 0x8800, 0x8a00, 0x8c00 }, /* F12 */
+      { 0x352f, 0x353f,   none, 0x35f0 }  /* international 1 */
       };
 
 bool BIOS_AddKeyToBuffer(uint16_t code) {


### PR DESCRIPTION
This fixes #1981.

The modifications to function CreateLayout() in sdl_mapper.cpp were necessary for it to work, but the parameters were just copied or adapted from dosbox-x and from what I can tell should be different on staging. Someone who actually understands what is going on there should give their input.

I also didn't test very much if adding this key affected other pre-existing keys.