### PR TITLE
MORE text output engine fixes

### DIFF
--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -185,4 +185,5 @@ void MORE::AddMessages()
 	MSG_Add("PROGRAM_MORE_PROMPT_MULTI",  "[reset][color=light-yellow]--- press SPACE for more, N for next file ---[reset]");
 	MSG_Add("PROGRAM_MORE_OPEN_ERROR",    "[reset][color=red]--- could not open %s ---[reset]");
 	MSG_Add("PROGRAM_MORE_TERMINATE",     "[reset][color=light-yellow](terminated)[reset]");
+	MSG_Add("PROGRAM_MORE_NEXT_FILE",     "[reset][color=light-yellow](next file)[reset]");
 }

--- a/src/dos/program_more_output.cpp
+++ b/src/dos/program_more_output.cpp
@@ -136,15 +136,18 @@ UserDecision MoreOutputBase::DisplaySingleStream()
 
 		// Detect 'new line' due to character passing the last column
 		const auto current_column = GetCurrentColumn();
+		bool line_overflow = false;
 		if (!current_column && previous_column && code != code_cr &&
 		    code != code_lf) {
 			// The cursor just moved to new line due to too small
-			// screen width. If this is followed by new line, ignore
-			// it, so that it is possible to i. e. nicely display up
-			// to 80-character lines on a standard 80 column screen
-			skip_next_cr = true;
-			skip_next_lf = true;
-			new_line     = true;
+			// screen width (line overflow). If this is followed by
+			// a new line, ignore it, so that it is possible to i. e.
+			// nicely display up to 80-character lines on a standard
+			// 80 column screen
+			skip_next_cr  = true;
+			skip_next_lf  = true;
+			new_line      = true;
+			line_overflow = true;
 		}
 		previous_column = current_column;
 
@@ -155,9 +158,10 @@ UserDecision MoreOutputBase::DisplaySingleStream()
 		if (code != '\n') {
 			was_prompt_recently = false;
 		}
-		if (is_last) {
+		if (is_last && !line_overflow) {
 			// Skip further processing (including possible user prompt)
-			// if we know no data is left
+			// if we know no data is left and no line overflow produced
+			// an 'artificial new line'
 			decision = UserDecision::Next;
 			break;
 		}
@@ -509,7 +513,6 @@ void MoreOutputStrings::Display()
 	DisplaySingleStream();
 
 	input_strings.clear();
-	WriteOut("\n");
 }
 
 bool MoreOutputStrings::GetCharacterRaw(char &code, bool &is_last)

--- a/src/dos/program_more_output.h
+++ b/src/dos/program_more_output.h
@@ -52,7 +52,21 @@ protected:
 
 	virtual bool GetCharacterRaw(char &code, bool &is_last) = 0;
 
-	uint16_t line_counter = 0; // how many lines printed out since last user prompt
+	enum class State {
+		Normal,
+		AnsiEsc,     // ANSI escape code started
+		AnsiEscEnd,  // last character of ANSI escape code
+		AnsiSci,     // ANSI control sequence started
+		AnsiSciEnd,  // last character of ANSI control sequence
+		NewLineCR,   // not ANSI, character code is Carriage Return
+		NewLineLF,   // not ANSI, character code is Line Feed
+		LineOverflow // line too long, cursor skipped to the next one
+	};
+
+	State state = State::Normal;
+
+	// how many lines printed out since last user prompt
+	uint16_t line_counter = 0;
 
 	bool is_output_redirected = false;
 	bool was_prompt_recently  = false; // if next user prompt can be skipped
@@ -76,17 +90,14 @@ protected:
 private:
 	Program &program;
 
-	bool GetCharacter(char &code, bool &is_last);
+	bool GetCharacter(char& code, bool& is_last_character);
 
-	uint16_t max_lines   = 0; // max number of lines to display between user prompts
+	uint16_t max_lines   = 0; // max lines to display between user prompts
 	uint16_t max_columns = 0;
 
 	uint8_t tab_size       = 8; // how many spaces to print for a TAB
 	uint8_t tabs_remaining = 0; // how many spaces still to be printed for the current TAB
 	bool    is_tab_last    = false;
-
-	bool skip_next_cr = false;
-	bool skip_next_lf = false;
 };
 
 // ***************************************************************************
@@ -106,7 +117,7 @@ private:
 
 	std::string GetShortPath(const std::string &file_path, const char *msg_id);
 
-	bool GetCharacterRaw(char &code, bool &is_last) override;
+	bool GetCharacterRaw(char& code, bool& is_last_character) override;
 
 	struct InputFile {
 		std::string path = "";
@@ -129,7 +140,7 @@ public:
 	void Display() override;
 
 private:
-	bool GetCharacterRaw(char &code, bool &is_last) override;
+	bool GetCharacterRaw(char& code, bool& is_last_character) override;
 
 	std::string input_strings = {};
 	size_t input_position     = 0;

--- a/src/dos/program_more_output.h
+++ b/src/dos/program_more_output.h
@@ -39,6 +39,9 @@ public:
 	virtual void Display() = 0;
 
 protected:
+	// Get cursor position from BIOS
+	static uint8_t GetCursorColumn();
+	static uint8_t GetCursorRow();
 
 	uint16_t GetMaxLines() const;
 	uint16_t GetMaxColumns() const;
@@ -51,6 +54,7 @@ protected:
 
 	uint16_t line_counter = 0; // how many lines printed out since last user prompt
 
+	bool is_output_redirected = false;
 	bool was_prompt_recently  = false; // if next user prompt can be skipped
 	bool has_multiple_files   = false; // if more than 1 file has to be displayed
 	bool should_end_on_ctrl_c = false; // reaction on CTRL+C in the input
@@ -72,8 +76,6 @@ protected:
 private:
 	Program &program;
 
-	static uint8_t GetCurrentColumn();
-	static uint8_t GetCurrentRow();
 	bool GetCharacter(char &code, bool &is_last);
 
 	uint16_t max_lines   = 0; // max number of lines to display between user prompts


### PR DESCRIPTION
Improve MORE command/engine output:

- fix for top line cut if help string is exactly 24 lines long (bug noticed by @Kappa971), also fixed the situation when last (23rd) line of input is exactly 80 characters long
- command help now detects whether output is redirected and acts accordingly (requested by @Kappa971)
- improved the output a little, got rid of unnecessary empty lines at output start/end if `command | MORE` is executed