### PR TITLE
Cleanup issues in ReelMagic flagged by Coverity

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# This file uses configuration options available in clang-format 12.0.
+# This file uses configuration options available in clang-format 15.0.
 #
 # More detailed description of all options:
 # https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
@@ -160,6 +160,36 @@ AlwaysBreakTemplateDeclarations: Yes
 #             "eeee";
 #
 # AlwaysBreakBeforeMultilineStrings: true
+
+# Insert braces after control statements (``if``, ``else``, ``for``, ``do``,
+#  and ``while``) in C++ unless the control statements are inside macro
+#  definitions or the braces would enclose preprocessor directives.
+#
+#   == WARNING ==
+#   Setting this option to `true` could lead to incorrect code formatting due
+#   to clang-format's lack of complete semantic information. As such, extra
+#   care should be taken to review code changes made by this option.
+#
+#    false:                                    true:
+#
+#    if (isa<FunctionDecl>(D))        vs.      if (isa<FunctionDecl>(D)) {
+#      handleFunctionDecl(D);                    handleFunctionDecl(D);
+#    else if (isa<VarDecl>(D))                 } else if (isa<VarDecl>(D)) {
+#      handleVarDecl(D);                         handleVarDecl(D);
+#    else                                      } else {
+#      return;                                   return;
+#                                              }
+#
+#    while (i--)                      vs.      while (i--) {
+#      for (auto *A : D.attrs())                 for (auto *A : D.attrs()) {
+#        handleAttr(A);                            handleAttr(A);
+#                                                }
+#                                              }
+#    do                               vs.      do {
+#      --i;                                      --i;
+#    while (i);
+#
+InsertBraces: true
 
 # Attach braces to surrounding context except break before braces on function
 # definitions (also known as K&R indentation style). This is C-derived style,

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -55,7 +55,7 @@ main () {
 handle_dependencies () {
 	assign_gnu_sed
 	assert_min_version git 1007010 "Use git version 1.7.10 or newer."
-	assert_min_version clang-format 12000000 "Use clang-format version 12.0.0 or newer."
+	assert_min_version clang-format 15000000 "Use clang-format version 15.0.0 or newer."
 }
 
 SED=""

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1024,7 +1024,7 @@ void DOSBOX_Init()
 	pstring->Set_help(
 	        "Set the 32-bit magic key used to decode the game's videos.\n"
 	        "  auto:     Use the built-in routines to determine the key (default).\n"
-	        "  default:  Use the most commonly found key, which is 0x40044041.\n"
+	        "  common:   Use the most commonly found key, which is 0x40044041.\n"
 	        "  thehorde: Use The Horde's key, which is 0xC39D7088.\n"
 	        "  <custom>: Set a custom key in hex format (e.g., 0x12345678).");
 

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -362,10 +362,11 @@ static bool FMPDRV_InstallINTHandler()
 		              // for...
 	}
 
-	// The upper 8-bits of the callback are used below, however the maximum
-	// callback number is only 128 so we simply confirm that the upper 8-bits are
-	// zero and hardcode zero below.
-	assert((static_cast<uint16_t>(_dosboxCallbackNumber) >> 8) == 0);
+
+	// Taking the upper 8 bits if the callback number is always zero because
+	// the maximum callback number is only 128. So we just confirm that here.
+	static_assert(sizeof(_dosboxCallbackNumber) < sizeof(uint16_t));
+	constexpr uint8_t upper_8_bits_of_callback = 0;
 
 	// This is the contents of the "FMPDRV.EXE" INT handler which will be put in
 	// the ROM region (Note: this is derrived from "case CB_IRET:" in
@@ -401,7 +402,7 @@ static bool FMPDRV_InstallINTHandler()
 	                            0xFE,
 	                            0x38, // GRP 4 + Extra Callback Instruction
 	                            _dosboxCallbackNumber,
-	                            0,
+	                            upper_8_bits_of_callback,
 	                            0xCF, // IRET
 
 	                            // Extra "unreachable" callback instruction used
@@ -411,7 +412,7 @@ static bool FMPDRV_InstallINTHandler()
 	                            0xFE,
 	                            0x38, // GRP 4 + Extra Callback Instruction
 	                            _dosboxCallbackNumber,
-	                            0};
+	                            upper_8_bits_of_callback};
 	// Note: checking against double CB_SIZE. This is because we allocate two
 	// callbacks to make this fit within the "callback ROM" region. See comment in
 	// ReelMagic_Init() function below

--- a/src/hardware/reelmagic/mpeg_decoder.h
+++ b/src/hardware/reelmagic/mpeg_decoder.h
@@ -1773,7 +1773,6 @@ plm_demux_t *plm_demux_create(plm_buffer_t *buffer, int destroy_when_done) {
 	self->duration = PLM_PACKET_INVALID_TS;
 	self->start_code = -1;
 
-	plm_demux_has_headers(self);
 	return self;
 }
 

--- a/src/hardware/reelmagic/mpeg_decoder.h
+++ b/src/hardware/reelmagic/mpeg_decoder.h
@@ -1400,9 +1400,19 @@ plm_buffer_t *plm_buffer_create_with_file(FILE *fh, int close_when_done) {
 	self->mode = PLM_BUFFER_MODE_FILE;
 	self->discard_read_bytes = TRUE;
 	
-	fseek(self->fh, 0, SEEK_END);
+	assert(self->fh);
+	if (fseek(self->fh, 0, SEEK_END) != 0) {
+		// buffer_destroy takes care of closing the file
+		plm_buffer_destroy(self);
+		return NULL;
+	}
 	self->total_size = ftell(self->fh);
-	fseek(self->fh, 0, SEEK_SET);
+
+	if (fseek(self->fh, 0, SEEK_SET) != 0) {
+		// buffer_destroy takes care of closing the file
+		plm_buffer_destroy(self);
+		return NULL;
+	}
 
 	plm_buffer_set_load_callback(self, plm_buffer_load_file_callback, NULL);
 	return self;

--- a/src/hardware/reelmagic/mpeg_decoder.h
+++ b/src/hardware/reelmagic/mpeg_decoder.h
@@ -1547,8 +1547,13 @@ void plm_buffer_seek(plm_buffer_t *self, size_t pos) {
 	if (self->mode == PLM_BUFFER_MODE_FILE) {
 		if (self->seek_callback)
 			(*self->seek_callback)(self, self->load_callback_user_data, pos);
-		else
-			fseek(self->fh, pos, SEEK_SET);
+		else {
+			assert (self->fh);
+			if (fseek(self->fh, pos, SEEK_SET) != 0) {
+				// Don't trust the file's state if seeking failed
+				return;
+			}
+		}
 		self->bit_index = 0;
 		self->length = 0;
 		self->file_pos = pos;

--- a/src/hardware/reelmagic/mpeg_decoder.h
+++ b/src/hardware/reelmagic/mpeg_decoder.h
@@ -894,7 +894,6 @@ plm_t *plm_create_with_buffer(plm_buffer_t *buffer, int destroy_when_done) {
 	self->demux = plm_demux_create(buffer, destroy_when_done);
 	self->video_enabled = TRUE;
 	self->audio_enabled = TRUE;
-	plm_init_decoders(self);
 
 	return self;
 }

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -723,15 +723,18 @@ ReelMagic_MediaPlayer_Handle ReelMagic_NewPlayer(struct ReelMagic_MediaPlayerFil
 	// to ensure maximum compatibility, we must also emulate this behavior
 
 	const Bitu freeHandles = ComputeFreePlayerHandleCount();
-	uint8_t handleIndex;
+
+	uint8_t handleIndex = 0; // the last valid handle encountered
 
 	try {
 		if (freeHandles < 1)
 			throw RMException("Out of handles!");
-		for (handleIndex = 0; handleIndex < REELMAGIC_MAX_HANDLES; ++handleIndex) {
-			if (_rmhandles[handleIndex] == NULL) {
-				_rmhandles[handleIndex] = new ReelMagic_MediaPlayerImplementation(
-				        playerFile, handleIndex + 1);
+
+		for (uint8_t i = 0; i < REELMAGIC_MAX_HANDLES; ++i) {
+			handleIndex = i;
+			if (_rmhandles[i] == NULL) {
+				_rmhandles[i] = new ReelMagic_MediaPlayerImplementation(
+				        playerFile, i + 1);
 				break;
 			}
 		}
@@ -740,6 +743,7 @@ ReelMagic_MediaPlayer_Handle ReelMagic_NewPlayer(struct ReelMagic_MediaPlayerFil
 		throw;
 	}
 
+	assert(handleIndex < REELMAGIC_MAX_HANDLES);
 	Bitu handlesNeeded = _rmhandles[handleIndex]->GetHandlesNeeded();
 	if (freeHandles < handlesNeeded) {
 		delete _rmhandles[handleIndex];

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -448,17 +448,21 @@ public:
 
 		bool detetectedFileTypeVesOnly = false;
 
+		assert(_file); 		
 		auto plmBuf = plm_buffer_create_with_virtual_file(&plmBufferLoadCallback,
 		                                                  &plmBufferSeekCallback,
 		                                                  this,
 		                                                  _file->GetFileSize());
-		_plm = plm_create_with_buffer(plmBuf, TRUE); // TRUE = destroy buffer when done
+		assert(plmBuf);
+
+		// TRUE means that the buffer is destroyed on failure or when closing _plm
+		_plm = plm_create_with_buffer(plmBuf, TRUE);
+
 		if (_plm == NULL) {
 			LOG(LOG_REELMAGIC, LOG_ERROR)
 			("Player with handle #%u failed creating buffer using file %s",
 			 (unsigned)_attrs.Handles.Master,
 			 _file->GetFileName());
-			plm_buffer_destroy(plmBuf);
 			plmBuf = NULL;
 			return;
 		}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -69,9 +69,9 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
 
 	// Taking the upper 8 bits if the callback number is always zero because
 	// the maximum callback number is only 128. So we just confirm that here.
-	assert((static_cast<uint8_t>(static_cast<uint16_t>(call_program) >> 8) &
-	        0xff) == 0);
-	comdata.at(callback_pos + 1) = 0;
+	static_assert(sizeof(callback_number_t) < sizeof(uint16_t));
+	constexpr uint8_t upper_8_bits_of_callback = 0;
+	comdata.at(callback_pos + 1) = upper_8_bits_of_callback;
 
 	// Save the current program's vector index in its COM data
 	const auto index = internal_progs.size();


### PR DESCRIPTION
Also:
 - always registers the ReelMagic messages (for translation)
 - renames the 'default' key to `common` to disambiguate it with the description for `auto`
 - fixes inability to set `reelmagic_key = thehorde`

Suggest reviewing commit-by-commit.
(Note that coding style is meant to fit w/ the RealMagic sources).