### PR TITLE
Look for libXInput dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Install build dependencies appropriate for your OS:
 # Fedora
 sudo dnf install ccache gcc-c++ meson alsa-lib-devel libatomic libpng-devel \
                  SDL2-devel SDL2_image-devel SDL2_net-devel opusfile-devel \
-                 fluidsynth-devel mt32emu-devel libslirp-devel speexdsp-devel \
-                 libXi-devel
+                 fluidsynth-devel iir1-devel mt32emu-devel libslirp-devel \
+                 speexdsp-devel libXi-devel
 ```
 
 ``` shell

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ support today's systems.
 | **Version control**            | Git
 | **Language**                   | C++17
 | **SDL**                        | >= 2.0.5
-| **Logging**                    | Loguru for C++<sup>[5]</sup>  
+| **Logging**                    | Loguru for C++<sup>[5]</sup>
 | **Buildsystem**                | Meson or Visual Studio 2019
 | **CI**                         | Yes
 | **Static analysis**            | Yes<sup>[1],[2],[3],[4]</sup>
@@ -53,7 +53,7 @@ support today's systems.
 | **CD-DA file codecs**       | Yes: Opus, OGG/Vorbus, MP3, FLAC, and WAV
 | **Pixel-perfect mode**      | Yes: `output=openglpp` or `output=texturepp`
 | **Resizable window**        | Yes, for all `output=opengl` modes
-| **Relative window size**    | `windowresolution=small`, `medium`, or `large`  
+| **Relative window size**    | `windowresolution=small`, `medium`, or `large`
 | **Window placement**        | `windowposition = 0,0`, and more<sup>[16]</sup>
 | **[OPL] emulator**          |  Nuked OPL, a highly accurate (YMF262, CT1747) emulator <sup>[8]</sup>
 | **[CGA]/mono support**      | `machine=cga_mono`<sup>[9]</sup>
@@ -141,14 +141,15 @@ Install build dependencies appropriate for your OS:
 # Fedora
 sudo dnf install ccache gcc-c++ meson alsa-lib-devel libatomic libpng-devel \
                  SDL2-devel SDL2_image-devel SDL2_net-devel opusfile-devel \
-                 fluidsynth-devel mt32emu-devel libslirp-devel speexdsp-devel
+                 fluidsynth-devel mt32emu-devel libslirp-devel speexdsp-devel \
+                 libXi-devel
 ```
 
 ``` shell
 # Debian, Ubuntu
 sudo apt install ccache build-essential libasound2-dev libatomic1 libpng-dev \
                  libsdl2-dev libsdl2-image-dev libsdl2-net-dev libopusfile-dev \
-                 libfluidsynth-dev libslirp-dev libspeexdsp-dev
+                 libfluidsynth-dev libslirp-dev libspeexdsp-dev libxi-dev
 
 # Install Meson on Debian-10 "Buster" or Ubuntu-20.04 and older
 sudo apt install python3-setuptools python3-pip
@@ -161,7 +162,7 @@ sudo apt install meson
 ``` shell
 # Arch, Manjaro
 sudo pacman -S ccache gcc meson alsa-lib libpng sdl2 sdl2_image sdl2_net \
-               opusfile fluidsynth libslirp speexdsp
+               opusfile fluidsynth libslirp speexdsp libxi
 ```
 
 ``` shell
@@ -169,7 +170,7 @@ sudo pacman -S ccache gcc meson alsa-lib libpng sdl2 sdl2_image sdl2_net \
 sudo zypper install ccache gcc gcc-c++ meson alsa-devel libatomic1 libpng-devel \
                     libSDL2-devel libSDL2_image-devel libSDL2_net-devel \
                     opusfile-devel fluidsynth-devel libmt32emu-devel libslirp-devel \
-                    speexdsp
+                    speexdsp libXi-devel
 ```
 
 ``` shell
@@ -177,7 +178,7 @@ sudo zypper install ccache gcc gcc-c++ meson alsa-devel libatomic1 libpng-devel 
 sudo xbps-install -S SDL2-devel SDL2_image-devel SDL2_net-devel alsa-lib-devel \
                      fluidsynth-devel libiir1-devel libmt32emu-devel \
                      libpng-devel libslirp-devel opusfile-devel \
-                     speexdsp-devel libatomic-devel
+                     speexdsp-devel libatomic-devel libXi-devel
 ```
 
 ``` shell

--- a/meson.build
+++ b/meson.build
@@ -691,6 +691,13 @@ if host_machine.system() in ['windows', 'cygwin']
     summary('Windows Multimedia support', winmm_dep.found())
 endif
 
+# X11 Input Extension dependency for ManyMouse library
+xi_dep = optional_dep
+using_x11 = os_family_name in ['LINUX', 'BSD']
+if using_x11 and (conf_data.get('C_MANYMOUSE') == true)
+    xi_dep = dependency('xi')
+endif
+
 # Setup include directories
 incdir = include_directories('include', '.')
 

--- a/packages/fedora-latest.txt
+++ b/packages/fedora-latest.txt
@@ -1,1 +1,1 @@
-alsa-lib-devel cmake desktop-file-utils fluidsynth-devel gcc gcc-c++ git gmock-devel gtest-devel libappstream-glib libatomic libpng-devel libslirp make meson ninja opusfile-devel SDL2-devel SDL2_net-devel SDL2_image-devel speexdsp-devel libXi-devel
+alsa-lib-devel cmake desktop-file-utils fluidsynth-devel gcc gcc-c++ git gmock-devel gtest-devel libappstream-glib libatomic libpng-devel libslirp make meson ninja opusfile-devel SDL2-devel SDL2_net-devel SDL2_image-devel speexdsp-devel libXi-devel iir1-devel

--- a/packages/fedora-latest.txt
+++ b/packages/fedora-latest.txt
@@ -1,1 +1,1 @@
-alsa-lib-devel cmake desktop-file-utils fluidsynth-devel gcc gcc-c++ git gmock-devel gtest-devel libappstream-glib libatomic libpng-devel libslirp make meson ninja opusfile-devel SDL2-devel SDL2_net-devel SDL2_image-devel speexdsp-devel
+alsa-lib-devel cmake desktop-file-utils fluidsynth-devel gcc gcc-c++ git gmock-devel gtest-devel libappstream-glib libatomic libpng-devel libslirp make meson ninja opusfile-devel SDL2-devel SDL2_net-devel SDL2_image-devel speexdsp-devel libXi-devel

--- a/src/libs/manymouse/meson.build
+++ b/src/libs/manymouse/meson.build
@@ -12,6 +12,7 @@ libmanymouse = static_library(
   manymouse_sources,
   dependencies: [
     iokit_dep,
+    xi_dep,
   ],
 )
 


### PR DESCRIPTION
It's a ManyMouse library dependency - at least on non-Windows, non-macOS systems. If package is not installed then build fails with:

> ../src/libs/manymouse/x11_xinput2.c:31:10: fatal error: X11/extensions/XInput2.h: No such file or directory
   31 | #include <X11/extensions/XInput2.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.


Also, add `iir1-devel` package to instructions for Fedora users, as the package is available.