### PR TITLE
Refactor ReelMagic player with per-stream handle registration

### DIFF
--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -63,8 +63,6 @@ constexpr reelmagic_handle_t reelmagic_invalid_handle = 0;
 constexpr reelmagic_handle_t reelmagic_first_handle   = 1;
 constexpr reelmagic_handle_t reelmagic_last_handle    = {DOS_FILES - 1};
 
-#define REELMAGIC_MAX_HANDLES (16)
-typedef uint8_t ReelMagic_MediaPlayer_Handle;
 struct ReelMagic_PlayerConfiguration {
   bool     VideoOutputVisible;
   bool     UnderVga;
@@ -81,10 +79,9 @@ struct ReelMagic_PlayerConfiguration {
 struct ReelMagic_PlayerAttributes {
   struct {
 	  reelmagic_handle_t Base  = reelmagic_invalid_handle;
-    ReelMagic_MediaPlayer_Handle Master;
-    ReelMagic_MediaPlayer_Handle Demux;
-    ReelMagic_MediaPlayer_Handle Video;
-    ReelMagic_MediaPlayer_Handle Audio;
+    reelmagic_handle_t Demux = reelmagic_invalid_handle;
+    reelmagic_handle_t Video = reelmagic_invalid_handle;
+    reelmagic_handle_t Audio = reelmagic_invalid_handle;
   } Handles;
   struct {
     uint16_t Width, Height;
@@ -102,8 +99,7 @@ struct ReelMagic_MediaPlayer {
   virtual ReelMagic_PlayerConfiguration& Config() = 0;
   virtual const ReelMagic_PlayerAttributes& GetAttrs() const = 0;
 
-  virtual bool HasDemux() const        = 0;
-  virtual bool HasSystem() const = 0;
+  virtual bool HasDemux() const = 0;
   virtual bool HasVideo() const = 0;
   virtual bool HasAudio() const = 0;
   virtual bool IsPlaying() const = 0;
@@ -122,9 +118,9 @@ struct ReelMagic_MediaPlayer {
 };
 
 //note: once a player file object is handed to new/delete player, regardless of success, it will be cleaned up
-ReelMagic_MediaPlayer_Handle ReelMagic_NewPlayer(struct ReelMagic_MediaPlayerFile * const playerFile);
-void ReelMagic_DeletePlayer(const ReelMagic_MediaPlayer_Handle handle);
-ReelMagic_MediaPlayer& ReelMagic_HandleToMediaPlayer(const ReelMagic_MediaPlayer_Handle handle); //throws on invalid handle
+reelmagic_handle_t ReelMagic_NewPlayer(struct ReelMagic_MediaPlayerFile* const playerFile);
+void ReelMagic_DeletePlayer(const reelmagic_handle_t handle);
+ReelMagic_MediaPlayer& ReelMagic_HandleToMediaPlayer(const reelmagic_handle_t handle); // throws on invalid handle
 void ReelMagic_DeleteAllPlayers();
 
 void ReelMagic_InitPlayer(Section* /*sec*/);

--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -64,17 +64,19 @@ constexpr reelmagic_handle_t reelmagic_first_handle   = 1;
 constexpr reelmagic_handle_t reelmagic_last_handle    = {DOS_FILES - 1};
 
 struct ReelMagic_PlayerConfiguration {
-  bool     VideoOutputVisible;
-  bool     UnderVga;
-  uint8_t    VgaAlphaIndex;
-  uint32_t   MagicDecodeKey;
-  uint32_t   UserData;
+  bool VideoOutputVisible = false;
+  bool UnderVga           = false;
+  uint8_t VgaAlphaIndex   = 0;
+  uint32_t MagicDecodeKey = 0;
+  uint32_t UserData       = 0;
   struct {
-    uint16_t X, Y;
-  }        DisplayPosition;
+	  uint16_t X = 0;
+	  uint16_t Y = 0;
+  } DisplayPosition = {};
   struct {
-    uint16_t Width, Height;
-  }        DisplaySize;
+	  uint16_t Width  = 0;
+	  uint16_t Height = 0;
+  } DisplaySize = {};
 };
 struct ReelMagic_PlayerAttributes {
   struct {
@@ -82,10 +84,11 @@ struct ReelMagic_PlayerAttributes {
     reelmagic_handle_t Demux = reelmagic_invalid_handle;
     reelmagic_handle_t Video = reelmagic_invalid_handle;
     reelmagic_handle_t Audio = reelmagic_invalid_handle;
-  } Handles;
+  } Handles = {};
   struct {
-    uint16_t Width, Height;
-  } PictureSize;
+	  uint16_t Width  = 0;
+	  uint16_t Height = 0;
+  } PictureSize = {};
 };
 struct ReelMagic_MediaPlayerFile {
   virtual ~ReelMagic_MediaPlayerFile() {}
@@ -102,7 +105,8 @@ struct ReelMagic_MediaPlayer {
   virtual bool HasDemux() const = 0;
   virtual bool HasVideo() const = 0;
   virtual bool HasAudio() const = 0;
-  virtual bool IsPlaying() const = 0;
+
+  virtual bool IsPlaying() const       = 0;
   virtual Bitu GetBytesDecoded() const = 0;
 
   enum PlayMode {

--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -21,7 +21,7 @@
 
 #include "dosbox.h"
 
-
+#include "dos_inc.h"
 //
 // video mixer stuff
 //
@@ -57,6 +57,12 @@ void ReelMagic_EnableAudioChannel(const bool should_enable);
 // player stuff
 //
 
+// FMPDRV.EXE uses handle value 0 as invalid and 1+ as valid
+using reelmagic_handle_t = uint8_t;
+constexpr reelmagic_handle_t reelmagic_invalid_handle = 0;
+constexpr reelmagic_handle_t reelmagic_first_handle   = 1;
+constexpr reelmagic_handle_t reelmagic_last_handle    = {DOS_FILES - 1};
+
 #define REELMAGIC_MAX_HANDLES (16)
 typedef uint8_t ReelMagic_MediaPlayer_Handle;
 struct ReelMagic_PlayerConfiguration {
@@ -74,6 +80,7 @@ struct ReelMagic_PlayerConfiguration {
 };
 struct ReelMagic_PlayerAttributes {
   struct {
+	  reelmagic_handle_t Base  = reelmagic_invalid_handle;
     ReelMagic_MediaPlayer_Handle Master;
     ReelMagic_MediaPlayer_Handle Demux;
     ReelMagic_MediaPlayer_Handle Video;
@@ -95,6 +102,7 @@ struct ReelMagic_MediaPlayer {
   virtual ReelMagic_PlayerConfiguration& Config() = 0;
   virtual const ReelMagic_PlayerAttributes& GetAttrs() const = 0;
 
+  virtual bool HasDemux() const        = 0;
   virtual bool HasSystem() const = 0;
   virtual bool HasVideo() const = 0;
   virtual bool HasAudio() const = 0;

--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -28,25 +28,26 @@
 struct ReelMagic_PlayerConfiguration;
 struct ReelMagic_PlayerAttributes;
 struct ReelMagic_VideoMixerMPEGProvider {
-  virtual ~ReelMagic_VideoMixerMPEGProvider() {}
-  virtual void OnVerticalRefresh(void * const outputBuffer, const float fps) = 0;
-  virtual const ReelMagic_PlayerConfiguration& GetConfig() const = 0;
-  virtual const ReelMagic_PlayerAttributes& GetAttrs() const = 0;
+	virtual ~ReelMagic_VideoMixerMPEGProvider() {}
+	virtual void OnVerticalRefresh(void* const outputBuffer, const float fps) = 0;
+	virtual const ReelMagic_PlayerConfiguration& GetConfig() const = 0;
+	virtual const ReelMagic_PlayerAttributes& GetAttrs() const     = 0;
 };
 
-void ReelMagic_RENDER_SetPal(uint8_t entry,uint8_t red,uint8_t green,uint8_t blue);
-void ReelMagic_RENDER_SetSize(uint32_t width,uint32_t height,uint32_t bpp,double fps,double ratio,bool dblw,bool dblh);
+void ReelMagic_RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t blue);
+void ReelMagic_RENDER_SetSize(uint32_t width, uint32_t height, uint32_t bpp,
+                              double fps, double ratio, bool dblw, bool dblh);
 bool ReelMagic_RENDER_StartUpdate(void);
-//void ReelMagic_RENDER_EndUpdate(bool abort);
-//void ReelMagic_RENDER_DrawLine(const void *src);
-typedef void (*ReelMagic_ScalerLineHandler_t)(const void *src);
+// void ReelMagic_RENDER_EndUpdate(bool abort);
+// void ReelMagic_RENDER_DrawLine(const void *src);
+typedef void (*ReelMagic_ScalerLineHandler_t)(const void* src);
 extern ReelMagic_ScalerLineHandler_t ReelMagic_RENDER_DrawLine;
 
 bool ReelMagic_IsVideoMixerEnabled();
 void ReelMagic_ResetVideoMixer();
 void ReelMagic_SetVideoMixerEnabled(const bool enabled);
-ReelMagic_VideoMixerMPEGProvider *ReelMagic_GetVideoMixerMPEGProvider();
-void ReelMagic_SetVideoMixerMPEGProvider(ReelMagic_VideoMixerMPEGProvider * const provider);
+ReelMagic_VideoMixerMPEGProvider* ReelMagic_GetVideoMixerMPEGProvider();
+void ReelMagic_SetVideoMixerMPEGProvider(ReelMagic_VideoMixerMPEGProvider* const provider);
 void ReelMagic_InitVideoMixer(Section* /*sec*/);
 
 // audio mixer related
@@ -59,69 +60,75 @@ void ReelMagic_EnableAudioChannel(const bool should_enable);
 
 // FMPDRV.EXE uses handle value 0 as invalid and 1+ as valid
 using reelmagic_handle_t = uint8_t;
+
 constexpr reelmagic_handle_t reelmagic_invalid_handle = 0;
 constexpr reelmagic_handle_t reelmagic_first_handle   = 1;
 constexpr reelmagic_handle_t reelmagic_last_handle    = {DOS_FILES - 1};
 
 struct ReelMagic_PlayerConfiguration {
-  bool VideoOutputVisible = false;
-  bool UnderVga           = false;
-  uint8_t VgaAlphaIndex   = 0;
-  uint32_t MagicDecodeKey = 0;
-  uint32_t UserData       = 0;
-  struct {
-	  uint16_t X = 0;
-	  uint16_t Y = 0;
-  } DisplayPosition = {};
-  struct {
-	  uint16_t Width  = 0;
-	  uint16_t Height = 0;
-  } DisplaySize = {};
+	bool VideoOutputVisible = false;
+	bool UnderVga           = false;
+
+	uint8_t VgaAlphaIndex   = 0;
+	uint32_t MagicDecodeKey = 0;
+	uint32_t UserData       = 0;
+	struct {
+		uint16_t X = 0;
+		uint16_t Y = 0;
+	} DisplayPosition = {};
+	struct {
+		uint16_t Width  = 0;
+		uint16_t Height = 0;
+	} DisplaySize = {};
 };
 struct ReelMagic_PlayerAttributes {
-  struct {
-	  reelmagic_handle_t Base  = reelmagic_invalid_handle;
-    reelmagic_handle_t Demux = reelmagic_invalid_handle;
-    reelmagic_handle_t Video = reelmagic_invalid_handle;
-    reelmagic_handle_t Audio = reelmagic_invalid_handle;
-  } Handles = {};
-  struct {
-	  uint16_t Width  = 0;
-	  uint16_t Height = 0;
-  } PictureSize = {};
+	struct {
+		reelmagic_handle_t Base  = reelmagic_invalid_handle;
+		reelmagic_handle_t Demux = reelmagic_invalid_handle;
+		reelmagic_handle_t Video = reelmagic_invalid_handle;
+		reelmagic_handle_t Audio = reelmagic_invalid_handle;
+	} Handles = {};
+	struct {
+		uint16_t Width  = 0;
+		uint16_t Height = 0;
+	} PictureSize = {};
 };
 struct ReelMagic_MediaPlayerFile {
-  virtual ~ReelMagic_MediaPlayerFile() {}
-  virtual const char *GetFileName() const = 0;
-  virtual uint32_t GetFileSize() const = 0;
-  virtual uint32_t Read(uint8_t *data, uint32_t amount) = 0;
-  virtual void Seek(uint32_t pos, uint32_t type) = 0; // type can be either DOS_SEEK_SET || DOS_SEEK_CUR...
+	virtual ~ReelMagic_MediaPlayerFile() {}
+
+	virtual const char* GetFileName() const = 0;
+	virtual uint32_t GetFileSize() const    = 0;
+
+	virtual uint32_t Read(uint8_t* data, uint32_t amount) = 0;
+	// type can be either DOS_SEEK_SET || DOS_SEEK_CUR...
+	virtual void Seek(uint32_t pos, uint32_t type) = 0;
 };
 struct ReelMagic_MediaPlayer {
-  virtual ~ReelMagic_MediaPlayer() {}
-  virtual ReelMagic_PlayerConfiguration& Config() = 0;
-  virtual const ReelMagic_PlayerAttributes& GetAttrs() const = 0;
+	virtual ~ReelMagic_MediaPlayer() {}
+	virtual ReelMagic_PlayerConfiguration& Config()            = 0;
+	virtual const ReelMagic_PlayerAttributes& GetAttrs() const = 0;
 
-  virtual bool HasDemux() const = 0;
-  virtual bool HasVideo() const = 0;
-  virtual bool HasAudio() const = 0;
+	virtual bool HasDemux() const = 0;
+	virtual bool HasVideo() const = 0;
+	virtual bool HasAudio() const = 0;
 
-  virtual bool IsPlaying() const       = 0;
-  virtual Bitu GetBytesDecoded() const = 0;
+	virtual bool IsPlaying() const       = 0;
+	virtual Bitu GetBytesDecoded() const = 0;
 
-  enum PlayMode {
-    MPPM_PAUSEONCOMPLETE,
-    MPPM_STOPONCOMPLETE,
-    MPPM_LOOP,
-  };
-  virtual void Play(const PlayMode playMode = MPPM_PAUSEONCOMPLETE) = 0;
-  virtual void Pause() = 0;
-  virtual void Stop() = 0;
-  virtual void SeekToByteOffset(const uint32_t offset) = 0;
-  virtual void NotifyConfigChange() = 0;
+	enum PlayMode {
+		MPPM_PAUSEONCOMPLETE,
+		MPPM_STOPONCOMPLETE,
+		MPPM_LOOP,
+	};
+	virtual void Play(const PlayMode playMode = MPPM_PAUSEONCOMPLETE) = 0;
+	virtual void Pause()                                              = 0;
+	virtual void Stop()                                               = 0;
+	virtual void SeekToByteOffset(const uint32_t offset)              = 0;
+	virtual void NotifyConfigChange()                                 = 0;
 };
 
-//note: once a player file object is handed to new/delete player, regardless of success, it will be cleaned up
+// note: once a player file object is handed to new/delete player, regardless of
+// success, it will be cleaned up
 reelmagic_handle_t ReelMagic_NewPlayer(struct ReelMagic_MediaPlayerFile* const playerFile);
 void ReelMagic_DeletePlayer(const reelmagic_handle_t handle);
 ReelMagic_MediaPlayer& ReelMagic_HandleToMediaPlayer(const reelmagic_handle_t handle); // throws on invalid handle
@@ -131,15 +138,9 @@ void ReelMagic_InitPlayer(Section* /*sec*/);
 void ReelMagic_ResetPlayers();
 ReelMagic_PlayerConfiguration& ReelMagic_GlobalDefaultPlayerConfig();
 
-
-
-
 //
 // driver and general stuff
 //
 void ReelMagic_Init(Section* /*sec*/);
-
-
-
 
 #endif /* #ifndef DOSBOX_REELMAGIC_H */

--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -44,10 +44,11 @@ typedef void (*ReelMagic_ScalerLineHandler_t)(const void* src);
 extern ReelMagic_ScalerLineHandler_t ReelMagic_RENDER_DrawLine;
 
 bool ReelMagic_IsVideoMixerEnabled();
-void ReelMagic_ResetVideoMixer();
+void ReelMagic_ClearVideoMixer();
 void ReelMagic_SetVideoMixerEnabled(const bool enabled);
 ReelMagic_VideoMixerMPEGProvider* ReelMagic_GetVideoMixerMPEGProvider();
 void ReelMagic_SetVideoMixerMPEGProvider(ReelMagic_VideoMixerMPEGProvider* const provider);
+void ReelMagic_ClearVideoMixerMPEGProvider();
 void ReelMagic_InitVideoMixer(Section* /*sec*/);
 
 // audio mixer related
@@ -135,7 +136,7 @@ ReelMagic_MediaPlayer& ReelMagic_HandleToMediaPlayer(const reelmagic_handle_t ha
 void ReelMagic_DeleteAllPlayers();
 
 void ReelMagic_InitPlayer(Section* /*sec*/);
-void ReelMagic_ResetPlayers();
+void ReelMagic_ClearPlayers();
 ReelMagic_PlayerConfiguration& ReelMagic_GlobalDefaultPlayerConfig();
 
 //

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -562,8 +562,12 @@ static void InvokePlayerStateChangeCallbackOnCPUResumeIfRegistered(const bool is
 
 	if ((_userCallbackType == 0x2000) && (!isPausing)) {
 		// hack to make RTZ work for now...
-		_userCallbackStack.push(UserCallbackCall(
-		        5, attrs.Handles.Master, 0, 0, _userCallbackStack.size() != cbstackStartSize));
+		_userCallbackStack.push(UserCallbackCall(5,
+		                                         attrs.Handles.Base,
+		                                         0,
+		                                         0,
+		                                         _userCallbackStack.size() !=
+		                                                 cbstackStartSize));
 	}
 
 	if (isPausing) {
@@ -978,9 +982,9 @@ static Bitu FMPDRV_INTHandler()
 	}
 
 	// define what the registers mean up front...
-	const uint8_t command                     = reg_bh;
-	ReelMagic_MediaPlayer_Handle media_handle = reg_bl;
-	const uint16_t subfunc                    = reg_cx;
+	const uint8_t command           = reg_bh;
+	reelmagic_handle_t media_handle = reg_bl;
+	const uint16_t subfunc          = reg_cx;
 
 	// filename_ptr for command 0x1 & hardcoded to 1 for command 9
 	const uint16_t param1 = reg_ax;

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -315,10 +315,11 @@ public:
 		// not using fopen_wrap() as this class is really intended for
 		// debug...
 		_fp = fopen(hostFilepath, "rb");
-		if (_fp == NULL)
+		if (!_fp) {
 			throw RMException("Host File: fopen(\"%s\")failed: %s",
 			                  hostFilepath,
 			                  strerror(errno));
+		}
 
 		// Only get the size if we've got a valid file pointer
 		_fileSize = GetFileSize(_fp);
@@ -955,8 +956,8 @@ static uint32_t FMPDRV_driver_call(const uint8_t command, const uint8_t media_ha
 	//
 	case 0x0e:
 		LOG(LOG_REELMAGIC, LOG_NORMAL)("Reset");
-		ReelMagic_ResetPlayers();
-		ReelMagic_ResetVideoMixer();
+		ReelMagic_ClearPlayers();
+		ReelMagic_ClearVideoMixer();
 		_userCallbackFarPtr = 0;
 		_userCallbackType   = 0;
 		return 0;
@@ -1153,8 +1154,9 @@ void REELMAGIC_MaybeCreateFmpdrvExecutable()
 static uint16_t GetMixerVolume(const char* const channelName, const bool right)
 {
 	const auto chan = MIXER_FindChannel(channelName);
-	if (chan == NULL)
+	if (!chan) {
 		return 0;
+	}
 
 	const auto vol_gain       = chan->GetVolumeScale();
 	const auto vol_percentage = gain_to_percentage(vol_gain[right ? 1 : 0]);
@@ -1164,8 +1166,9 @@ static uint16_t GetMixerVolume(const char* const channelName, const bool right)
 static void SetMixerVolume(const char* const channelName, const uint16_t percentage, const bool right)
 {
 	auto chan = MIXER_FindChannel(channelName);
-	if (chan == NULL)
+	if (!chan) {
 		return;
+	}
 
 	AudioFrame vol_gain     = chan->GetVolumeScale();
 	vol_gain[right ? 1 : 0] = percentage_to_gain(percentage);

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -218,9 +218,9 @@ namespace {
 class ReelMagic_MediaPlayerImplementation : public ReelMagic_MediaPlayer,
                                             public ReelMagic_VideoMixerMPEGProvider {
 	// creation parameters...
-	ReelMagic_MediaPlayerFile* const _file = {};
+	const std::unique_ptr<ReelMagic_MediaPlayerFile> _file = {};
 	ReelMagic_PlayerConfiguration _config = _globalDefaultPlayerConfiguration;
-	ReelMagic_PlayerAttributes _attrs      = {};
+	ReelMagic_PlayerAttributes _attrs = {};
 
 	// running / adjustable variables...
 	bool _stopOnComplete = {};
@@ -514,7 +514,6 @@ public:
 			ReelMagic_SetVideoMixerMPEGProvider(NULL);
 		if (_plm != NULL)
 			plm_destroy(_plm);
-		delete _file;
 	}
 
 	//

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -219,7 +219,7 @@ class ReelMagic_MediaPlayerImplementation : public ReelMagic_MediaPlayer,
                                             public ReelMagic_VideoMixerMPEGProvider {
 	// creation parameters...
 	ReelMagic_MediaPlayerFile* const _file = {};
-	ReelMagic_PlayerConfiguration _config  = {};
+	ReelMagic_PlayerConfiguration _config = _globalDefaultPlayerConfiguration;
 	ReelMagic_PlayerAttributes _attrs      = {};
 
 	// running / adjustable variables...
@@ -440,17 +440,8 @@ public:
 	ReelMagic_MediaPlayerImplementation& operator=(const ReelMagic_MediaPlayerImplementation&) = delete;
 
 	ReelMagic_MediaPlayerImplementation(ReelMagic_MediaPlayerFile* const player_file)
-	        : _file(player_file),
-	          _stopOnComplete(false),
-	          _playing(false),
-	          _vgaFps(0.0f),
-	          _plm(NULL),
-	          _nextFrame(NULL),
-	          _magicalRSizeOverride(0)
+	        : _file(player_file)
 	{
-		memcpy(&_config, &_globalDefaultPlayerConfiguration, sizeof(_config));
-		memset(&_attrs, 0, sizeof(_attrs));
-
 		assert(_file);
 		auto plmBuf = plm_buffer_create_with_virtual_file(&plmBufferLoadCallback,
 		                                                  &plmBufferSeekCallback,


### PR DESCRIPTION
Suggest reviewing commit-by-commit.

The goal of this PR is to simplify and improve the robustness of the ReelMagic player's handle registration code.

@jrdennisoss nicely documents how the ReelMagic system allocates separate DOS file handles for the elementary streams making up a given MPEG-1 file (player): the muxer, and/or video stream, and/or audio stream:

https://github.com/dosbox-staging/dosbox-staging/blob/00595a004d7c079e053108433524da202fcdb1c3/src/hardware/reelmagic/player.cpp#L721-L728

It's tricky because the number of handles isn't known ahead of time: the MPEG-1 file needs to be parsed to figure it out. There's also a limited number of handles available (which might be used by other active MPEG-1 players); so if it happens that we will exceed the limit, then the creation process needs to be safely rolled back.

For references, here's the existing code: https://github.com/dosbox-staging/dosbox-staging/blob/00595a004d7c079e053108433524da202fcdb1c3/src/hardware/reelmagic/player.cpp#L730-L773 This works but can (in likely rarer scenarios) have out-of-bounds accesses as mentioned in this PR's commit: *https://github.com/dosbox-staging/dosbox-staging/commit/393736b0367f2d759230ba9b5f6b63482c0904e2*.

The refactored approach uses a shared pointer and a per-stream registration approach, and lets the shared-pointer tear down the file player if we need to roll back. It's hopefully a bit more readable (and fixes a couple potential out-of-bounds accesses).


@jrdennisoss , please feel free to comment; any feedback is very welcome!