### PR TITLE
Restore 0.79.1 mouse acceleration model in DOS driver

### DIFF
--- a/src/hardware/mouse/mouse_config.h
+++ b/src/hardware/mouse/mouse_config.h
@@ -36,17 +36,14 @@ struct MousePredefined {
 	const float sensitivity_ps2 = 1.0f;
 	const float sensitivity_vmm = 3.0f;
 	const float sensitivity_com = 1.0f;
-	// Constants to move 'intersection point' for the acceleration curve
+
+	// Constant to move 'intersection point' for the acceleration curve
 	// Requires raw mouse input, otherwise there is no effect
 	// Larger values = higher mouse acceleration
-	const float acceleration_dos = 1.0f;
 	const float acceleration_vmm = 1.0f;
 
 	// Maximum allowed user sensitivity value
 	const int16_t sensitivity_user_max = 999;
-	// How many user steps causes sensitivity to double
-	// (sensitivity works exponentially)
-	const float sensitivity_double_steps = 10.0f;
 
 	// IRQ used by PS/2 mouse - do not change unless you really know
 	// what you are doing!


### PR DESCRIPTION
This PR basically restores the 0.79.1 mouse acceleration code, as the one introduced with mouse mapping support was faulty (not reacting properly to application sensitivity settings, leading i. e. to cursor drawing oval shape even when user moved the mouse in a perfectly circular way).

The following improvements were kept:
- if the application/game sets mouse sensitivity to 0, it completely stops the cursor movement, as with Microsoft mouse driver
- if RAW mouse input is disabled (it is currently enabled by default) no DOSBox mouse acceleration is applied (just the sensitivity coefficient is used), to prevent two acceleration models being applied (host OS and DOSBox) - as this might cause unpredictable results 

