### PR TITLE
Refactor the ReelMagic audio FIFO class

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -65,7 +65,11 @@ struct AudioFrame {
 	float left  = 0.0f;
 	float right = 0.0f;
 
-	float &operator[](std::size_t i)
+	constexpr AudioFrame() = default;
+	constexpr AudioFrame(const float l, const float r) : left(l), right(r) {}
+	constexpr AudioFrame(const int16_t l, const int16_t r) : left(l), right(r) {}
+
+	constexpr float& operator[](const size_t i) noexcept
 	{
 		assert(i < 2);
 		return i == 0 ? left : right;

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -833,10 +833,8 @@ void CDROM_Interface_Image::ChannelControl(TCtrl ctrl)
 #endif
 		return;
 	}
-
 	// Adjust the volume of our mixer channel as defined by the application
-	player.channel->SetVolumeScale(static_cast<float>(ctrl.vol[0] / 255.0), // left vol
-	                               static_cast<float>(ctrl.vol[1] / 255.0)); // right vol
+	player.channel->SetAppVolume(ctrl.vol[0] / 255.0f, ctrl.vol[1] / 255.0f);
 
 	// Map the audio channels in our mixer channel as defined by the application
 	const auto left_mapped = static_cast<LINE_INDEX>(ctrl.out[0]);

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -631,8 +631,9 @@ void OPL::AdlibGoldControlWrite(const uint8_t val)
 		if (ctrl.mixer) {
 			// Dune CD version uses 32 volume steps in an apparent
 			// mistake, should be 128
-			channel->SetVolume((float)(ctrl.lvol & 0x1f) / 31.0f,
-			                   (float)(ctrl.rvol & 0x1f) / 31.0f);
+			channel->SetAppVolume(
+			        static_cast<float>(ctrl.lvol & 0x1f) / 31.0f,
+			        static_cast<float>(ctrl.rvol & 0x1f) / 31.0f);
 		}
 		break;
 
@@ -905,7 +906,7 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 	// universally "good" setting that would work well in all games in
 	// existence.
 	constexpr auto opl_volume_scale_factor = 1.5f;
-	channel->SetVolumeScale(opl_volume_scale_factor);
+	channel->Set0dbScalar(opl_volume_scale_factor);
 
 	Init(check_cast<uint16_t>(channel->GetSampleRate()));
 

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -1158,7 +1158,7 @@ static uint16_t GetMixerVolume(const char* const channelName, const bool right)
 		return 0;
 	}
 
-	const auto vol_gain       = chan->GetVolumeScale();
+	const auto vol_gain       = chan->GetAppVolume();
 	const auto vol_percentage = gain_to_percentage(vol_gain[right ? 1 : 0]);
 	return check_cast<uint16_t>(iroundf(vol_percentage));
 }
@@ -1170,9 +1170,9 @@ static void SetMixerVolume(const char* const channelName, const uint16_t percent
 		return;
 	}
 
-	AudioFrame vol_gain     = chan->GetVolumeScale();
+	AudioFrame vol_gain     = chan->GetAppVolume();
 	vol_gain[right ? 1 : 0] = percentage_to_gain(percentage);
-	chan->SetVolumeScale(vol_gain.left, vol_gain.right);
+	chan->SetAppVolume(vol_gain.left, vol_gain.right);
 }
 
 static bool RMDEV_SYS_int2fHandler()

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -868,7 +868,12 @@ void ReelMagic_EnableAudioChannel(const bool should_enable)
 	                             // ChannelFeature::ChorusSend,
 	                             ChannelFeature::DigitalAudio});
 	assert(_rmaudio);
-	_rmaudio->Enable(true);
+
+	// The decoded MP2 frame contains samples ranging from [-1.0f, +1.0f],
+	// so to hit 0 dB 16-bit signed, we need to multiply up from unity to
+	// the maximum magnitude (32k).
+	constexpr float mpeg1_db0_volume_scalar = {MAX_AUDIO};
+	_rmaudio->Set0dbScalar(mpeg1_db0_volume_scalar);
 }
 
 static void set_magic_key(const std::string_view key_choice)

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1638,11 +1638,20 @@ static void CTMIXER_UpdateVolumes() {
 	float m0 = calc_vol(sb.mixer.master[0]);
 	float m1 = calc_vol(sb.mixer.master[1]);
 	auto chan = MIXER_FindChannel("SB");
-	if (chan) chan->SetVolume(m0 * calc_vol(sb.mixer.dac[0]), m1 * calc_vol(sb.mixer.dac[1]));
+	if (chan) {
+		chan->SetAppVolume(m0 * calc_vol(sb.mixer.dac[0]),
+		                   m1 * calc_vol(sb.mixer.dac[1]));
+	}
 	chan = MIXER_FindChannel("OPL");
-	if (chan) chan->SetVolume(m0 * calc_vol(sb.mixer.fm[0]) , m1 * calc_vol(sb.mixer.fm[1]) );
+	if (chan) {
+		chan->SetAppVolume(m0 * calc_vol(sb.mixer.fm[0]),
+		                   m1 * calc_vol(sb.mixer.fm[1]));
+	}
 	chan = MIXER_FindChannel("CDAUDIO");
-	if (chan) chan->SetVolume(m0 * calc_vol(sb.mixer.cda[0]), m1 * calc_vol(sb.mixer.cda[1]));
+	if (chan) {
+		chan->SetAppVolume(m0 * calc_vol(sb.mixer.cda[0]),
+		                   m1 * calc_vol(sb.mixer.cda[1]));
+	}
 }
 
 static void CTMIXER_Reset() {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -64,6 +64,7 @@ constexpr uint8_t MIN_ADAPTIVE_STEP_SIZE = 0; // max is 32767
 constexpr uint8_t DSP_INITIAL_RESET_LIMIT = 4;
 
 constexpr auto native_dac_rate_hz = 45454;
+constexpr uint16_t default_playback_rate_hz = 22050;
 
 enum {DSP_S_RESET,DSP_S_RESET_WAIT,DSP_S_NORMAL,DSP_S_HIGHSPEED};
 
@@ -1019,10 +1020,33 @@ static void FlushRemainingDMATransfer()
 	}
 }
 
-static void DSP_ChangeMode(DSP_MODES mode) {
-	if (sb.mode==mode) return;
-	else sb.chan->FillUp();
-	sb.mode=mode;
+static void set_channel_rate_hz(const uint32_t requested_rate_hz)
+{
+	// Valid output rates range from 5000 to 45 000 Hz, inclusive.
+	// Ref:
+	//   Sound Blaster Series Hardware Programming Guide,
+	//   41h Set digitized sound output sampling rate, DSP Commands 6-15
+	//   https://pdos.csail.mit.edu/6.828/2018/readings/hardware/SoundBlaster.pdf
+	//
+	constexpr int min_rate_hz = 5000;
+	constexpr int max_rate_hz = 45000;
+
+	const auto rate_hz = std::clamp(static_cast<int>(requested_rate_hz),
+	                                min_rate_hz,
+	                                max_rate_hz);
+
+	assert(sb.chan);
+	if (sb.chan->GetSampleRate() != rate_hz) {
+		sb.chan->SetSampleRate(rate_hz);
+	}
+}
+
+static void DSP_ChangeMode(const DSP_MODES mode)
+{
+	if (sb.mode != mode) {
+		sb.chan->FillUp();
+		sb.mode = mode;
+	}
 }
 
 static void DSP_RaiseIRQEvent(uint32_t /*val*/)
@@ -1092,7 +1116,7 @@ static void DSP_DoDMATransfer(const DMA_MODES mode, uint32_t freq, bool autoinit
 		sb.dma.mul*=2;
 	sb.dma.rate=(sb.freq*sb.dma.mul) >> SB_SH;
 	sb.dma.min=(sb.dma.rate*3)/1000;
-	sb.chan->SetSampleRate(freq);
+	set_channel_rate_hz(freq);
 
 	PIC_RemoveEvents(ProcessDMATransfer);
 	//Set to be masked, the dma call can change this again.
@@ -1188,7 +1212,7 @@ static void DSP_Reset() {
 	sb.dma.remain_size=0;
 	if (sb.dma.chan) sb.dma.chan->Clear_Request();
 
-	sb.freq=22050;
+	sb.freq = default_playback_rate_hz;
 	sb.time_constant=45;
 	sb.dac.used=0;
 	sb.dac.last=0;
@@ -1196,7 +1220,7 @@ static void DSP_Reset() {
 	sb.e2.count=0;
 	sb.irq.pending_8bit=false;
 	sb.irq.pending_16bit=false;
-	sb.chan->SetSampleRate(22050);
+	set_channel_rate_hz(default_playback_rate_hz);
 	InitializeSpeakerState();
 	PIC_RemoveEvents(ProcessDMATransfer);
 }
@@ -1242,7 +1266,7 @@ static void DSP_ChangeRate(uint32_t freq)
 {
 	if (sb.freq != freq && sb.dma.mode != DSP_DMA_NONE) {
 		sb.chan->FillUp();
-		sb.chan->SetSampleRate(freq / (sb.mixer.stereo ? 2 : 1));
+		set_channel_rate_hz(freq / (sb.mixer.stereo ? 2 : 1));
 		sb.dma.rate=(freq*sb.dma.mul) >> SB_SH;
 		sb.dma.min=(sb.dma.rate*3)/1000;
 	}
@@ -1643,12 +1667,12 @@ static void CTMIXER_Reset() {
 
 static void DSP_ChangeStereo(bool stereo) {
 	if (!sb.dma.stereo && stereo) {
-		sb.chan->SetSampleRate(sb.freq/2);
+		set_channel_rate_hz(sb.freq / 2);
 		sb.dma.mul*=2;
 		sb.dma.rate=(sb.freq*sb.dma.mul) >> SB_SH;
 		sb.dma.min=(sb.dma.rate*3)/1000;
 	} else if (sb.dma.stereo && !stereo) {
-		sb.chan->SetSampleRate(sb.freq);
+		set_channel_rate_hz(sb.freq);
 		sb.dma.mul/=2;
 		sb.dma.rate=(sb.freq*sb.dma.mul) >> SB_SH;
 		sb.dma.min=(sb.dma.rate*3)/1000;
@@ -2145,7 +2169,10 @@ public:
 		if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2 || sb.type == SBT_16)
 			channel_features.insert(ChannelFeature::Stereo);
 
-		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack, 22050, "SB", channel_features);
+		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack,
+		                           default_playback_rate_hz,
+		                           "SB",
+		                           channel_features);
 
 		const std::string sb_filter_prefs = section->Get_string("sb_filter");
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -286,7 +286,7 @@ void TandyDAC::ChangeMode()
 			channel->FillUp(); // using the prior frequency
 			channel->SetSampleRate(freq);
 			const auto vol = static_cast<float>(regs.amplitude) / 7.0f;
-			channel->SetVolume(vol, vol);
+			channel->SetAppVolume(vol, vol);
 			if ((regs.mode & 0x0c) == 0x0c) {
 				dma.is_done = false;
 				dma.channel = GetDMAChannel(io.dma);

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -277,12 +277,14 @@ static void counter_latch(PIT_Block &channel)
 	};
 
 	if (GCC_UNLIKELY(channel.mode_changed)) {
-		const auto total_ticks = static_cast<uint32_t>(
-		        elapsed_ms / period_of_1k_pit_ticks);
 		// if (channel.mode== PitMode::SquareWave) ticks_since_then /=
 		// 2; //
 		// TODO figure this out on real hardware
-		save_read_latch(channel.read_latch - total_ticks);
+
+		// Ensure the remaining ticks aren't negative
+		const auto elapsed_ticks   = elapsed_ms * PIT_TICK_RATE_KHZ;
+		const auto remaining_ticks = std::max(0.0, channel.read_latch - elapsed_ticks);
+		save_read_latch(remaining_ticks);
 		return;
 	}
 	const auto count = static_cast<double>(channel.count);

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -159,10 +159,9 @@ static int32_t RWops_opus_seek(void * stream, const opus_int64 offset, const int
  */
 static int32_t RWops_opus_close(void * stream)
 {
-    (void) stream; // deliberately unused, but present for API compliance
-    /* SDL closes this for us */
-    // return SDL_RWclose((SDL_RWops*)stream);
-    return 0;
+    constexpr auto success = 0;
+    const auto sdl_stream = static_cast<SDL_RWops*>(stream);
+    return sdl_stream ? SDL_RWclose(sdl_stream) : success;
 } /* RWops_opus_close */
 
 
@@ -240,6 +239,8 @@ static void opus_close(Sound_Sample * sample)
         op_free(of);
         internal->decoder_private = nullptr;
     }
+    // Close the SDL Sound's RW-ops callback pointer to prevent further operations on the stream
+    internal->rw = nullptr;
     return;
 
 } /* opus_close */


### PR DESCRIPTION
Suggest reviewing commit-by-commit.

The refactored ReelMagic AudioFifo class now loads audio directly into DOSBox Staging's mixer (via pointer into the MPEG stream's decoded interleaved audio buffer) without any intermediate queuing or math operations performed on the samples.

It now also skips initial gaps in decoded audio.

The ReelMagic's mixer channel is now activated on an as-needed basis.

Playback is working smooth with fewer initial audio hiccups, even at 800 Mhz:

![2022-11-26_13-11](https://user-images.githubusercontent.com/1557255/204109498-24f55cff-60b4-48ff-9f34-2bae045b7462.png)

### Tips for optimal performance

1. Use your lowest latency `[sdl]` conf settings.  If you're using a Raspberry Pi, be sure to use the [recommended baseline configs](https://github.com/dosbox-staging/dosbox-staging/wiki/Config-file-examples).

2. In addition baseline settings, further apply the following ReelMagic specific settings:

``` ini
[mixer]
rate = 44100
prebuffer = 33

[cpu]
core = dynamic
cycles = 3000

[dos]
umb = false
ems = false
xms = true

[reelmagic]
reelmagic = on
```

Notes:
 - The mixer's rate is run at 44.1 KHz to match the MEPG-1 Layer 2 steam found in all known ReelMagic DOS MPEG games.
 - The mixer's prebuffer is set to 33 ms to match the MPEG decoder's single frame of latency (1 000 ms / 29.97 fps = 33.36 ms). To confirm AV sync, watch scenes with explosions, gunshots, and verbal plosives.

