### PR TITLE
Restore WheelHasMoved bit in DOS mouse driver to correct value

### DIFF
--- a/src/hardware/mouse/mouseif_dos_driver.cpp
+++ b/src/hardware/mouse/mouseif_dos_driver.cpp
@@ -67,7 +67,7 @@ enum class MouseEventId : uint8_t {
 	ReleasedRight  = 1 << 4,
 	PressedMiddle  = 1 << 5,
 	ReleasedMiddle = 1 << 6,
-	WheelHasMoved  = 1 << 0,
+	WheelHasMoved  = 1 << 7,
 };
 
 // These values represent 'hardware' state, not driver state


### PR DESCRIPTION
Looks like a refactor in commit b2e3cef0eb5b accidentally changed the WheelHasMoved enum value from bit 7 to 0. 
This technically breaks wheel API, even though I guess most programs will work anyway.
However, it does break wheel support in my 3.x mouse driver (see #1996). 
With this patch wheel support works again. 

cc @FeralChild64  (thanks for the absolute bit changes!)

Fixes: b2e3cef0eb5b ("Add mouse mapper, config tool and config section")