### PR TITLE
Improve management of audio devices

### DIFF
--- a/include/hardware.h
+++ b/include/hardware.h
@@ -38,8 +38,8 @@ extern Bitu CaptureState;
 
 void OPL_Init(Section *sec, OplMode mode);
 void CMS_Init(Section *sec);
-void OPL_ShutDown();
-void CMS_ShutDown();
+void OPL_ShutDown(Section* sec = nullptr);
+void CMS_ShutDown(Section* sec = nullptr);
 
 bool PS1AUDIO_IsEnabled();
 bool SB_Get_Address(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -414,8 +414,8 @@ mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const int freq,
                                  const std::set<ChannelFeature> &features);
 
 mixer_channel_t MIXER_FindChannel(const char *name);
-void MIXER_RemoveChannel(const std::string& name);
-void MIXER_RemoveChannel(mixer_channel_t& channel);
+void MIXER_DeregisterChannel(const std::string& name);
+void MIXER_DeregisterChannel(mixer_channel_t& channel);
 
 // Mixer configuration and initialization
 void MIXER_AddConfigSection(const config_ptr_t &conf);

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -512,12 +512,14 @@ CDROM_Interface_Image::~CDROM_Interface_Image()
 	refCount--;
 
 	// Stop playback before wiping out the CD Player
-	if (refCount == 0 && player.cd) {
-		StopAudio();
+	if (refCount == 0) {
+		LOG_MSG("CDROM: Shutting down CD-DA player");
+
+		if (player.cd) {
+			StopAudio();
+		}
+		MIXER_DeregisterChannel(player.channel);
 		player.channel.reset();
-#ifdef DEBUG
-		LOG_MSG("CDROM: Released CD Player resources");
-#endif
 	}
 	if (player.cd == this) {
 		player.cd = nullptr;

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -141,7 +141,7 @@ void Innovation::Close()
 	if (!is_open)
 		return;
 
-	DEBUG_LOG_MSG("INNOVATION: Shutting down the SSI-2001 on port %xh", base_port);
+	LOG_MSG("INNOVATION: Shutting down");
 
 	// Stop playback
 	if (channel)
@@ -150,6 +150,11 @@ void Innovation::Close()
 	// Remove the IO handlers before removing the SID device
 	read_handler.Uninstall();
 	write_handler.Uninstall();
+
+	// Deregister the mixer channel and remove it
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
+	channel.reset();
 
 	// Reset the members
 	channel.reset();

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -118,6 +118,8 @@ void LptDac::AudioCallback(const uint16_t requested_frames)
 
 LptDac::~LptDac()
 {
+	LOG_MSG("%s: Shutting down DAC", dac_name.c_str());
+
 	// Update our status to indicate we're no longer ready
 	status_reg.error = true;
 	status_reg.busy  = true;
@@ -127,7 +129,9 @@ LptDac::~LptDac()
 	data_write_handler.Uninstall();
 	control_write_handler.Uninstall();
 
-	channel->Enable(false);
+	// Deregister the mixer channel, after which it's cleaned up
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 
 	render_queue = {};
 }

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -22,6 +22,7 @@
 #include "dosbox.h"
 
 #include <cmath>
+#include <memory>
 #include <queue>
 
 #include "adlib_gold.h"
@@ -85,7 +86,7 @@ public:
 
 	RegisterCache cache = {};
 
-	Capture *capture = nullptr;
+	std::unique_ptr<Capture> capture = {};
 
 	OPL(Section *configuration, const OplMode _oplmode);
 	~OPL();

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -490,7 +490,9 @@ PcSpeakerDiscrete::PcSpeakerDiscrete()
 
 PcSpeakerDiscrete::~PcSpeakerDiscrete()
 {
-	assert(channel);
-	channel.reset();
 	LOG_MSG("%s: Shutting down %s model", device_name, model_name);
+
+	// Deregister the mixer channel, after which it's cleaned up
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 }

--- a/src/hardware/pcspeaker_impulse.cpp
+++ b/src/hardware/pcspeaker_impulse.cpp
@@ -517,7 +517,8 @@ PcSpeakerImpulse::PcSpeakerImpulse()
 	// multiples of 8000, such as 8 Khz, 16 Khz, or 32 Khz. Anything besides
 	// these will produce unwanted artifacts.
 	static_assert(sample_rate >= 8000, "Sample rate must be at least 8 kHz");
-	static_assert(sample_rate % 1000 == 0, "PC Speaker sample must be a multiple of 1000");
+	static_assert(sample_rate % 1000 == 0,
+	              "Sample rate must be a multiple of 1000");
 
 	InitializeImpulseLUT();
 
@@ -544,6 +545,9 @@ PcSpeakerImpulse::PcSpeakerImpulse()
 
 PcSpeakerImpulse::~PcSpeakerImpulse()
 {
-	channel->Enable(false);
 	LOG_MSG("%s: Shutting down %s model", device_name, model_name);
+
+	// Deregister the mixer channel, after which it's cleaned up
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 }

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -353,17 +353,20 @@ void Ps1Dac::Update(uint16_t samples)
 
 Ps1Dac::~Ps1Dac()
 {
+	// Stop playback
+	if (channel) {
+		channel->Enable(false);
+	}
+
 	// Stop the game from accessing the IO ports
 	for (auto &handler : read_handlers)
 		handler.Uninstall();
 	for (auto &handler : write_handlers)
 		handler.Uninstall();
 
-	// Stop and remove the mixer callback
-	if (channel) {
-		channel->Enable(false);
-		channel.reset();
-	}
+	// Deregister the mixer channel, after which it's cleaned up
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 }
 
 class Ps1Synth {
@@ -517,13 +520,17 @@ void Ps1Synth::AudioCallback(const uint16_t requested_frames)
 
 Ps1Synth::~Ps1Synth()
 {
+	// Stop playback
+	if (channel) {
+		channel->Enable(false);
+	}
+
 	// Stop the game from accessing the IO ports
 	write_handler.Uninstall();
 
-	if (channel) {
-		channel->Enable(false);
-		channel.reset();
-	}
+	// Deregister the mixer channel, after which it's cleaned up
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 }
 
 static std::unique_ptr<Ps1Dac> ps1_dac = {};

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -780,8 +780,9 @@ static void RMMixerChannelCallback(uint16_t frames_remaining)
 void ReelMagic_EnableAudioChannel(const bool should_enable)
 {
 	if (should_enable == false) {
-		MIXER_RemoveChannel(mixer_channel);
-		assert(!mixer_channel);
+		// Deregister the mixer channel and remove it
+		MIXER_DeregisterChannel(mixer_channel);
+		mixer_channel.reset();
 		return;
 	}
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -468,6 +468,8 @@ void MidiHandlerFluidsynth::Close()
 	if (!is_open)
 		return;
 
+	LOG_MSG("FSYNTH: Shutting down");
+
 	// Stop playback
 	if (channel)
 		channel->Enable(false);
@@ -483,8 +485,12 @@ void MidiHandlerFluidsynth::Close()
 	if (renderer.joinable())
 		renderer.join();
 
-	// Reset the members
+	// Deregister the mixer channel and remove it
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 	channel.reset();
+
+	// Reset the members
 	synth.reset();
 	settings.reset();
 	last_played_frame = 0;

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -652,6 +652,8 @@ void MidiHandler_mt32::Close()
 	if (!is_open)
 		return;
 
+	LOG_MSG("MT32: Shutting down");
+
 	// Stop playback
 	if (channel)
 		channel->Enable(false);
@@ -673,8 +675,12 @@ void MidiHandler_mt32::Close()
 		service->freeContext();
 	}
 
-	// Reset the members
+	// Deregister the mixer channel and remove it
+	assert(channel);
+	MIXER_DeregisterChannel(channel);
 	channel.reset();
+
+	// Reset the members
 	service.reset();
 	total_buffers_played = 0;
 	last_played_frame = 0;


### PR DESCRIPTION
This PR lets audio devices be created and destroyed dynamically at runtime.
Memory issues (like double-free or leaks) should no occur regardless of how many times a device is created, changed, or destroyed.

Test it at runtime using the conf name a a value:

| Audio Device           |   Conf Name  | Values                                          |
| ---------------------- | :----------: | :---------------------------------------------- |
| CD-ROM Digital Audio   |      N/A     | RedBook bin/cue must be `imgmount`ed            |
| Gravis UltraSound      |     `gus`    | `on`, `off`                                         |
| Innovation SSI-2001    |  `sidmodel`  | `none`, `auto`, `6581`, `8580`                         |
| LPT DAC                |   `lpt_dac`  | `none`, `disney`, `covox`, `ston1`, `off`               |
| MIDI Device            | `mididevice` | `fluidsynth`, `mt32`, `none`                          |
| PC Speaker             |  `pcspeaker` | `discrete`, `impulse`, `none`, `off`                    |
| PS/1 Audio card        |  `ps1audio`  | `on`, `off`                                         |
| ReelMagic audio        |  `reelmagic` | `on`, `off`                                         |
| Sound Blaster          |   `sbtype`   | `sb1`, `sb2`, `sbpro1`, `sbpro2`, `sb16`, `gb`, `none`        |
| Sound Blaster FM Synth |   `oplmode`  | `auto`, `cms`, `opl2`, `dualopl2`, `opl3`, `opl3gold`, `none` |
| Tandy PSSJ (PSG+DAC)   |    `tandy`   | `auto`, `on`, `off`                                   |

