### PR TITLE
Add more cleanup on audio device tear-down

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -419,6 +419,7 @@ void MIXER_DeregisterChannel(mixer_channel_t& channel);
 
 // Mixer configuration and initialization
 void MIXER_AddConfigSection(const config_ptr_t &conf);
+int MIXER_GetSampleRate();
 bool MIXER_IsManuallyMuted();
 void MIXER_SetState(const MixerState requested);
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -158,10 +158,13 @@ private:
 	std::string buf = {};
 
 public:
-	void Install(std::string const &in);
-	void InstallBefore(std::string const &in);
-	const std::string &GetLine() const { return buf; }
+	AutoexecObject() = default;
+	AutoexecObject(const std::string& line);
 	~AutoexecObject();
+
+	void Install(const std::string& in);
+	void InstallBefore(const std::string& in);
+
 private:
 	void CreateAutoexec();
 };

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -209,6 +209,11 @@ static struct mixer_t mixer = {};
 
 alignas(sizeof(float)) uint8_t MixTemp[MIXER_BUFSIZE] = {};
 
+int MIXER_GetSampleRate()
+{
+	return mixer.sample_rate.load();
+}
+
 static void MIXER_LockAudioDevice()
 {
 	SDL_LockAudioDevice(mixer.sdldevice);

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -354,10 +354,17 @@ getdefault:
 		assert((handler != nullptr) && (handler->GetName() == "none"s));
 	}
 
-	~MIDI(){
-		if(midi.available) midi.handler->Close();
+	~MIDI()
+	{
+		if (!midi.available) {
+			assert(!midi.handler);
+			return;
+		}
+
+		assert(midi.handler);
+		midi.handler->Close();
+		midi.handler = {};
 		midi.available = false;
-		midi.handler = 0;
 	}
 };
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -225,32 +225,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 		return false;
 	}
 
-	// Setup the mixer callback
-	const auto mixer_callback = std::bind(&MidiHandlerFluidsynth::MixerCallBack,
-	                                      this, std::placeholders::_1);
-
-	auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                      use_mixer_rate,
-	                                      "FSYNTH",
-	                                      {ChannelFeature::Sleep,
-	                                       ChannelFeature::Stereo,
-	                                       ChannelFeature::ReverbSend,
-	                                       ChannelFeature::ChorusSend,
-	                                       ChannelFeature::Synthesizer});
-
 	auto *section = static_cast<Section_prop *>(control->GetSection("fluidsynth"));
 	assert(section);
-
-	const std::string filter_prefs = section->Get_string("fsynth_filter");
-
-	if (!mixer_channel->TryParseAndSetCustomFilter(filter_prefs)) {
-		if (filter_prefs != "off")
-			LOG_WARNING("FSYNTH: Invalid 'fsynth_filter' value: '%s', using 'off'",
-			            filter_prefs.c_str());
-
-		mixer_channel->SetHighPassFilter(FilterState::Off);
-		mixer_channel->SetLowPassFilter(FilterState::Off);
-	}
 
 	// Detailed explanation of all available FluidSynth settings:
 	// http://www.fluidsynth.org/api/fluidsettings.xml
@@ -260,7 +236,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 	// channel first and use its native rate to configure FluidSynth.
 	fluid_settings_setnum(fluid_settings.get(),
 	                      "synth.sample-rate",
-	                      mixer_channel->GetSampleRate());
+	                      MIXER_GetSampleRate());
 
 	fsynth_ptr_t fluid_synth(new_fluid_synth(fluid_settings.get()),
 	                         delete_fluid_synth);
@@ -441,6 +417,34 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char *conf)
 		        reverb_width,
 		        reverb_level);
 
+	// Setup the mixer callback
+	const auto mixer_callback = std::bind(&MidiHandlerFluidsynth::MixerCallBack,
+	                                      this,
+	                                      std::placeholders::_1);
+
+	auto mixer_channel = MIXER_AddChannel(mixer_callback,
+	                                      use_mixer_rate,
+	                                      "FSYNTH",
+	                                      {ChannelFeature::Sleep,
+	                                       ChannelFeature::Stereo,
+	                                       ChannelFeature::ReverbSend,
+	                                       ChannelFeature::ChorusSend,
+	                                       ChannelFeature::Synthesizer});
+
+	const std::string filter_prefs = section->Get_string("fsynth_filter");
+
+	if (!mixer_channel->TryParseAndSetCustomFilter(filter_prefs)) {
+		if (filter_prefs != "off") {
+			LOG_WARNING("FSYNTH: Invalid 'fsynth_filter' value: '%s', using 'off'",
+			            filter_prefs.c_str());
+		}
+
+		mixer_channel->SetHighPassFilter(FilterState::Off);
+		mixer_channel->SetLowPassFilter(FilterState::Off);
+	}
+
+	// If we haven't failed yet, then we're ready to begin so move the local
+	// objects into the member variables.
 	settings = std::move(fluid_settings);
 	synth = std::move(fluid_synth);
 	channel = std::move(mixer_channel);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -586,8 +586,24 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	        rom_info.control_rom_description,
 	        loaded_model_and_dir->second.c_str());
 
+	mt32_service->setAnalogOutputMode(ANALOG_MODE);
+	mt32_service->selectRendererType(RENDERING_TYPE);
+	mt32_service->setStereoOutputSampleRate(MIXER_GetSampleRate());
+	mt32_service->setSamplerateConversionQuality(RATE_CONVERSION_QUALITY);
+	mt32_service->setDACInputMode(DAC_MODE);
+	mt32_service->setNiceAmpRampEnabled(USE_NICE_RAMP);
+	mt32_service->setNicePanningEnabled(USE_NICE_PANNING);
+	mt32_service->setNicePartialMixingEnabled(USE_NICE_PARTIAL_MIXING);
+
+	const auto rc = mt32_service->openSynth();
+	if (rc != MT32EMU_RC_OK) {
+		LOG_MSG("MT32: Error initialising emulation: %i", rc);
+		return false;
+	}
+
 	const auto mixer_callback = std::bind(&MidiHandler_mt32::MixerCallBack,
-	                                      this, std::placeholders::_1);
+	                                      this,
+	                                      std::placeholders::_1);
 
 	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
 	                                            use_mixer_rate,
@@ -610,22 +626,8 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 		mixer_channel->SetLowPassFilter(FilterState::Off);
 	}
 
-	const auto sample_rate = mixer_channel->GetSampleRate();
-
-	mt32_service->setAnalogOutputMode(ANALOG_MODE);
-	mt32_service->selectRendererType(RENDERING_TYPE);
-	mt32_service->setStereoOutputSampleRate(sample_rate);
-	mt32_service->setSamplerateConversionQuality(RATE_CONVERSION_QUALITY);
-	mt32_service->setDACInputMode(DAC_MODE);
-	mt32_service->setNiceAmpRampEnabled(USE_NICE_RAMP);
-	mt32_service->setNicePanningEnabled(USE_NICE_PANNING);
-	mt32_service->setNicePartialMixingEnabled(USE_NICE_PARTIAL_MIXING);
-
-	const auto rc = mt32_service->openSynth();
-	if (rc != MT32EMU_RC_OK) {
-		LOG_MSG("MT32: Error initialising emulation: %i", rc);
-		return false;
-	}
+	// If we haven't failed yet, then we're ready to begin so move the local
+	// objects into the member variables.
 	service = std::move(mt32_service);
 	channel = std::move(mixer_channel);
 	model_and_dir = std::move(loaded_model_and_dir);
@@ -638,7 +640,6 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	play_buffer = playable.Dequeue(); // populate the first play buffer
 
 	is_open = true;
-
 	return true;
 }
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -55,6 +55,11 @@ typedef std::list<std::string>::iterator auto_it;
 
 void VFILE_Remove(const char *name, const char *dir = "");
 
+AutoexecObject::AutoexecObject(const std::string& line)
+{
+	Install(line);
+}
+
 void AutoexecObject::Install(const std::string &in) {
 	if (GCC_UNLIKELY(installed))
 		E_Exit("autoexec: already created %s", buf.c_str());


### PR DESCRIPTION
Suggest reviewing commit-by-commit.

Thanks to @GranMinigun for flagging these cases.  

@GranMinigun - I haven't looked into why ReelMagic uses more cycles than other devices when it's activated (presumably, this has always been the case). My only hunch right now is that its audio channel doesn't have the `Feature::Sleep` (which auto-sleeps a given channel); so maybe it's flowing empty samples through the mixer?