### PR TITLE
Fix tab handling in MORE command

### DIFF
--- a/src/dos/program_more_output.h
+++ b/src/dos/program_more_output.h
@@ -65,6 +65,7 @@ protected:
 
 	State state = State::Normal;
 
+	uint16_t column_counter = 0;
 	// how many lines printed out since last user prompt
 	uint16_t line_counter = 0;
 


### PR DESCRIPTION
The text engine in MORE command was handling tabulations in a very crude way, blindly replacing them with given amount of spaces. This is now fixed, it tries to align the text after TAB to a proper column.