### PR TITLE
Generate linker map file by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,8 @@ summary('Install prefix', get_option('prefix'), section: 'Build Summary')
 
 # extra build flags
 extra_flags = ['-Wno-unknown-pragmas']
-extra_link_flags = []
+# generate linker map file
+extra_link_flags = ['-Wl,-map,dosbox.map']
 
 # If the compiler provides std::filesystem, then we consider it modern enough
 # that we can trust it's extra helpful warnings to let us improve the code quality.


### PR DESCRIPTION
We noticed the MSYS2 toolchain was generating some very large binaries, and it was difficult to analyze exactly what was taking up all the space. I added linker commands to generate `dosbox.map` by default, since it adds almost no overhead to the build process, and will make it easier to diagnose/analyze these types of issues in the future.