### PR TITLE
Remove errorneous screen parameters check in mouse code

### DIFF
--- a/src/hardware/mouse/mouse.cpp
+++ b/src/hardware/mouse/mouse.cpp
@@ -83,7 +83,6 @@ static void update_cursor_absolute_position(const int32_t x_abs, const int32_t y
 	                     const uint32_t clipping,
 	                     const uint32_t resolution) -> uint32_t {
 		assert(resolution > 1u);
-		assert(clipping * 2 < resolution);
 
 		if (absolute < 0 || static_cast<uint32_t>(absolute) < clipping) {
 			// cursor is over the top or left black bar
@@ -415,26 +414,17 @@ void MOUSE_NewScreenParams(const uint32_t clip_x, const uint32_t clip_y,
                            const int32_t x_abs, const int32_t y_abs,
                            const bool is_fullscreen)
 {
-	static bool last_params_were_ok = true;
+	// clip_x, clip_y = black border (one side), in pixels
+	// res_x, res_y   = used display area, in pixels
+	// res_x + 2 * clip_x, res_y + 2 * clip_y = screen resolution or window size
 
 	assert(clip_x <= INT32_MAX);
 	assert(clip_y <= INT32_MAX);
 	assert(res_x <= INT32_MAX);
 	assert(res_y <= INT32_MAX);
 
-	if (clip_x * 2 >= res_x || clip_y * 2 >= res_y) {
-		if (last_params_were_ok) {
-			LOG_WARNING("MOUSE: Incorrect screen params: resolution %d/%d, clipping %d/%d",
-			            res_x, res_y, clip_x, clip_y);			
-		}
-		state.clip_x = 0;
-		state.clip_y = 0;
-		last_params_were_ok = false;
-	} else {
-		state.clip_x = clip_x;
-		state.clip_y = clip_y;
-		last_params_were_ok = true;
-	}
+	state.clip_x = clip_x;
+	state.clip_y = clip_y;
 
 	// Protection against strange window sizes,
 	// to prevent division by 0 in some places


### PR DESCRIPTION
The screen parameter checks that caused assertions were actually wrong - removed them, added comment in the code to prevent further mistakes.

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2112
