### PR TITLE
Add `--working-dir` command line option

### DIFF
--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -35,7 +35,7 @@ There is NO WARRANTY, to the extent permitted by law.
 constexpr char help_msg[] =
         R"(Usage: dosbox [OPTION]... [FILE]
 
-These are the common options:
+List of common options:
 
   --printconf          Print the location of the default configuration file.
 
@@ -52,32 +52,30 @@ These are the common options:
   -nolocalconf         Don't read settings from "dosbox.conf" if present in
                        the current working directory.
 
-  -conf <configfile>   Start DOSBox with the options specified in <configfile>.
+  -conf <configfile>   Start with the options specified in <configfile>.
                        Multiple configfiles can be specified.
 
   --working-dir <path> Set working directory to <path>. DOSBox will act as if
                        started from this directory.
 
-  -fullscreen          Start DOSBox in fullscreen mode.
+  -fullscreen          Start in fullscreen mode.
 
-  -lang <langfile>     Start DOSBox with the language specified in <langfile>.
+  -lang <langfile>     Start with the language specified in <langfile>.
 
   --list-glshaders     List available GLSL shaders and their directories.
                        Results are useable in the "glshader = " config setting.
 
-  -machine <type>      Setup DOSBox to emulate a specific type of machine.
-                       The machine type has influence on both the videocard
-                       and the emulated soundcards. Valid choices are:
-                       hercules, cga, cga_mono, tandy, pcjr, ega, vgaonly,
-                       svga_s3 (default), svga_et3000, svga_et4000,
-                       svga_paradise, vesa_nolfb, vesa_oldvbe.
+  -machine <type>      Emulate a specific type of machine. The machine type has
+                       influence on both the emulated video and sound cards.
+                       Valid choices are: hercules, cga, cga_mono, tandy,
+                       pcjr, ega, vgaonly, svga_s3 (default), svga_et3000,
+                       svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe.
 
-  -exit                DOSBox will exit after the DOS program specified by
-                       FILE has ended.
+  -exit                Exit after the DOS program specified by FILE has ended.
 
-  -h, --help           Print this help message.
+  -h, --help           Print this help message and exit.
 
-  --version            Print version information and exit.
+  -v, --version        Print version information and exit.
 
 You can find full list of options in the man page: dosbox(1)
 And in the file: /usr/share/doc/dosbox-staging/README

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -37,44 +37,47 @@ constexpr char help_msg[] =
 
 These are the common options:
 
-  --printconf         Print the location of the default configuration file.
+  --printconf          Print the location of the default configuration file.
 
-  --editconf          Open the default configuration file in a text editor.
+  --editconf           Open the default configuration file in a text editor.
 
-  -c <command>        Run the specified DOS command before running FILE.
-                      Multiple commands can be specified.
+  -c <command>         Run the specified DOS command before running FILE.
+                       Multiple commands can be specified.
 
-  -noautoexec         Don't perform any [autoexec] actions.
+  -noautoexec          Don't perform any [autoexec] actions.
 
-  -noprimaryconf      Don't read settings from the primary configuration file
-                      located in your user folder.
+  -noprimaryconf       Don't read settings from the primary configuration file
+                       located in your user folder.
 
-  -nolocalconf        Don't read settings from "dosbox.conf" if present in
-                      the current working directory.
+  -nolocalconf         Don't read settings from "dosbox.conf" if present in
+                       the current working directory.
 
-  -conf <configfile>  Start DOSBox with the options specified in <configfile>.
-                      Multiple configfiles can be specified.
+  -conf <configfile>   Start DOSBox with the options specified in <configfile>.
+                       Multiple configfiles can be specified.
 
-  -fullscreen         Start DOSBox in fullscreen mode.
+  --working-dir <path> Set working directory to <path>. DOSBox will act as if
+                       started from this directory.
 
-  -lang <langfile>    Start DOSBox with the language specified in <langfile>.
+  -fullscreen          Start DOSBox in fullscreen mode.
 
-  --list-glshaders    List available GLSL shaders and their directories.
-                      Results are useable in the "glshader = " config setting.
+  -lang <langfile>     Start DOSBox with the language specified in <langfile>.
 
-  -machine <type>     Setup DOSBox to emulate a specific type of machine.
-                      The machine type has influence on both the videocard
-                      and the emulated soundcards. Valid choices are:
-                      hercules, cga, cga_mono, tandy, pcjr, ega, vgaonly,
-                      svga_s3 (default), svga_et3000, svga_et4000,
-                      svga_paradise, vesa_nolfb, vesa_oldvbe.
+  --list-glshaders     List available GLSL shaders and their directories.
+                       Results are useable in the "glshader = " config setting.
 
-  -exit               DOSBox will exit after the DOS program specified by
-                      FILE has ended.
+  -machine <type>      Setup DOSBox to emulate a specific type of machine.
+                       The machine type has influence on both the videocard
+                       and the emulated soundcards. Valid choices are:
+                       hercules, cga, cga_mono, tandy, pcjr, ega, vgaonly,
+                       svga_s3 (default), svga_et3000, svga_et4000,
+                       svga_paradise, vesa_nolfb, vesa_oldvbe.
 
-  -h, --help          Print this help message.
+  -exit                DOSBox will exit after the DOS program specified by
+                       FILE has ended.
 
-  --version           Print version information and exit.
+  -h, --help           Print this help message.
+
+  --version            Print version information and exit.
 
 You can find full list of options in the man page: dosbox(1)
 And in the file: /usr/share/doc/dosbox-staging/README

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -35,50 +35,49 @@ There is NO WARRANTY, to the extent permitted by law.
 constexpr char help_msg[] =
         R"(Usage: dosbox [OPTION]... [FILE]
 
-These are common options:
+These are the common options:
 
-  -h, --help          Displays this message.
-
-  --printconf         Prints the location of the default configuration file.
+  --printconf         Print the location of the default configuration file.
 
   --editconf          Open the default configuration file in a text editor.
 
-  -c <command>        Runs the specified DOS command before running FILE.
+  -c <command>        Run the specified DOS command before running FILE.
                       Multiple commands can be specified.
 
   -noautoexec         Don't perform any [autoexec] actions.
 
   -noprimaryconf      Don't read settings from the primary configuration file
-                      located in ~/.config/dosbox/dosbox-staging.conf.
+                      located in your user folder.
 
   -nolocalconf        Don't read settings from "dosbox.conf" if present in
-                      the local current working directory.
+                      the current working directory.
 
-  -conf <configfile>  Start dosbox with the options specified in <configfile>.
-                      Multiple configfiles can be present at the commandline.
+  -conf <configfile>  Start DOSBox with the options specified in <configfile>.
+                      Multiple configfiles can be specified.
 
-  -fullscreen         Start dosbox in fullscreen mode.
+  -fullscreen         Start DOSBox in fullscreen mode.
 
-  -lang <langfile>    Start dosbox with the language specified in
-                      <langfile>.
+  -lang <langfile>    Start DOSBox with the language specified in <langfile>.
 
   --list-glshaders    List available GLSL shaders and their directories.
-                      Results are useable in the "glshader = " conf setting.
+                      Results are useable in the "glshader = " config setting.
 
-  -machine <type>     Setup dosbox to emulate a specific type of machine.
+  -machine <type>     Setup DOSBox to emulate a specific type of machine.
                       The machine type has influence on both the videocard
-                      and the emulated soundcards.  Valid choices are:
+                      and the emulated soundcards. Valid choices are:
                       hercules, cga, cga_mono, tandy, pcjr, ega, vgaonly,
                       svga_s3 (default), svga_et3000, svga_et4000,
                       svga_paradise, vesa_nolfb, vesa_oldvbe.
 
-  -exit               Dosbox will close itself when the DOS program
-                      specified by FILE ends.
+  -exit               DOSBox will exit after the DOS program specified by
+                      FILE has ended.
 
-  --version       Output version information and exit.
+  -h, --help          Print this help message.
+
+  --version           Print version information and exit.
 
 You can find full list of options in the man page: dosbox(1)
-And in file: /usr/share/doc/dosbox-staging/README
+And in the file: /usr/share/doc/dosbox-staging/README
 )";
 
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4627,6 +4627,18 @@ int sdl_main(int argc, char *argv[])
 
 	int rcode = 0; // assume good until proven otherwise
 	try {
+		std::string working_dir;
+		constexpr bool remove_arg = true;
+		if (control->cmdline->FindString("--working-dir", working_dir, remove_arg) ||
+		    control->cmdline->FindString("-working-dir", working_dir, remove_arg)) {
+			std::error_code ec;
+			std::filesystem::current_path(working_dir, ec);
+			if (ec) {
+				LOG_ERR("Cannot set working directory to %s",
+				        working_dir.c_str());
+			}
+		}
+
 		OverrideWMClass(); // Before SDL2 video subsystem is initialized
 
 		CROSS_DetermineConfigPaths();


### PR DESCRIPTION
This is a simple enhancement to allow macOS users launch DOSBox from Finder with per-game configs (related to https://github.com/dosbox-staging/dosbox-staging/issues/1909).

### How to use it

You only need to put a simple bash script called `<some-name>.command` in your game folder as per below, then you can start the game by launching the `.command` file from Finder:

```
Prince of Persia
   drives
      c
         ...
   dosbox.conf
   run.command
```

Create `run.command` with the following content (you'll only need to do this once):

```bash
#!/bin/bash

CWD=$(dirname $0)
open -a DOSBox\ Staging --args --working-dir "$CWD"
```

Then give it the necessary permissions with `chmod 755 run.command`.

After this, you can simply copy `run.command` to all your game folders, and ThingsWillJustWork(tm) 😎 

macOS might ask you to give DOSBox access to whatever folder the game resides in upon the first launch — just click OK if that dialog comes up.

### Further improvements

To auto-close the appearing Terminal window when launching a game this way, you can configure the Terminal as follows. Launch the Terminal app first, then open the Preferences dialog by pressing Cmd + , (comma)

<img width="659" alt="image" src="https://user-images.githubusercontent.com/698770/207312665-ef6efc59-8d69-42b9-9a4c-142840ac6dc3.png">
