### PR TITLE
Drop architecture spec from setup-msbuild GitHub action

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -52,7 +52,6 @@ jobs:
         uses: microsoft/setup-msbuild@v1.2
         with:
             vs-prerelease: true
-            msbuild-architecture: ${{ matrix.conf.arch }}
 
       - name:  Integrate packages
         shell: pwsh
@@ -135,7 +134,6 @@ jobs:
         uses: microsoft/setup-msbuild@v1.2
         with:
             vs-prerelease: true
-            msbuild-architecture: ${{ matrix.conf.arch }}
 
       - name:  Integrate packages
         shell: pwsh

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -183,7 +183,7 @@ jobs:
         run: |
           # Construct VC_REDIST_DIR
           readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
-          readonly VC_REDIST_VERSION="14.32.31326"
+          readonly VC_REDIST_VERSION="14.34.31931"
           readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
           export VC_REDIST_DIR="$VC_REDIST_BASE/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION"
           find "$VC_REDIST_BASE" -maxdepth 3 -type d


### PR DESCRIPTION
The recent bump from GitHub action `microsoft/setup-msbuild` from API v1.1 to v 1.2 no longer uses the architecture specifier. 

(Architecture is still specified on the command line).