### PR TITLE
Add modem call warm-up period

### DIFF
--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -45,6 +45,7 @@
 #define MODEM_TICKRATE 1000 // Ticks per second
 #define MODEM_TICKTIME (1000 / MODEM_TICKRATE) // Tick interval in milliseconds
 #define MODEM_RINGINTERVAL (3000 / MODEM_TICKTIME)
+#define MODEM_WARMUP_DELAY_MS (250 / MODEM_TICKTIME)
 
 
 enum ResTypes {
@@ -243,6 +244,7 @@ protected:
 	uint32_t flowcontrol = 0;
 	uint32_t dtrmode = 0;
 	int32_t dtrofftimer = 0;
+	int32_t warmup_remain_ticks = 0;
 	uint8_t tmpbuf[MODEM_BUFFER_QUEUE_SIZE] = {0};
 	uint16_t listenport = 23; // 23 is the default telnet TCP/IP port
 	uint8_t reg[SREGS] = {0};


### PR DESCRIPTION
This adds a short period after answering a modem call during which all incoming and outgoing packets are dropped. It is meant to to simulate reported real modem behavior where the first packet is usually bad (extra data in the buffer from connecting, noise, random nonsense).
Without this, a bug is triggered in Duke Nukem 3D net code where if the initial handshake succeeds on the first try, the dialing player will crash on level start.
This also doubles as a workaround for a flaw in Dosbox modem logic where, due to the lack of any kind of answer confirmation, the dialing instance thinks the call is answered before it really was and potentially sends data into "deaf ears". This "ghost" data then piles up in the answering instance's receive queue and then passed to COM port output all at once after call is answered which can potentially create issues.
The lack of answer confirmation is also why this logic is handled entirely on the answering side.