### PR TITLE
Add missing Windows 11 features to MORE command

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -168,36 +168,38 @@ constexpr uint16_t DOS_PackDate(const struct tm &datetime) noexcept
 }
 
 /* Routines for Drive Class */
-bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb = false);
-bool DOS_OpenFileExtended(char const * name, uint16_t flags, uint16_t createAttr, uint16_t action, uint16_t *entry, uint16_t* status);
-bool DOS_CreateFile(char const * name,uint16_t attribute,uint16_t * entry, bool fcb = false);
-bool DOS_UnlinkFile(char const * const name);
+bool DOS_OpenFile(const char* name, uint8_t flags, uint16_t* entry, bool fcb = false);
+bool DOS_OpenFileExtended(const char* name, uint16_t flags, uint16_t createAttr,
+                          uint16_t action, uint16_t* entry, uint16_t* status);
+bool DOS_CreateFile(const char* name, uint16_t attribute, uint16_t* entry,
+                    bool fcb = false);
+bool DOS_UnlinkFile(const char* const name);
 bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst = false);
 bool DOS_FindNext(void);
-bool DOS_Canonicalize(char const * const name,char * const big);
+bool DOS_Canonicalize(const char* const name, char* const big);
 bool DOS_CreateTempFile(char * const name,uint16_t * entry);
-bool DOS_FileExists(char const * const name);
+bool DOS_FileExists(const char* const name);
 
 /* Helper Functions */
-bool DOS_MakeName(char const *const name, char *const fullname, uint8_t *drive);
+bool DOS_MakeName(const char* const name, char* const fullname, uint8_t* drive);
 
 /* Drive Handing Routines */
 uint8_t DOS_GetDefaultDrive(void);
 void DOS_SetDefaultDrive(uint8_t drive);
 bool DOS_SetDrive(uint8_t drive);
 bool DOS_GetCurrentDir(uint8_t drive,char * const buffer);
-bool DOS_ChangeDir(char const * const dir);
-bool DOS_MakeDir(char const * const dir);
-bool DOS_RemoveDir(char const * const dir);
-bool DOS_Rename(char const * const oldname,char const * const newname);
+bool DOS_ChangeDir(const char* const dir);
+bool DOS_MakeDir(const char* const dir);
+bool DOS_RemoveDir(const char* const dir);
+bool DOS_Rename(const char* const oldname, const char* const newname);
 bool DOS_GetFreeDiskSpace(uint8_t drive,uint16_t * bytes,uint8_t * sectors,uint16_t * clusters,uint16_t * free);
-bool DOS_GetFileAttr(char const * const name,uint16_t * attr);
-bool DOS_SetFileAttr(char const * const name,uint16_t attr);
+bool DOS_GetFileAttr(const char* const name, uint16_t* attr);
+bool DOS_SetFileAttr(const char* const name, uint16_t attr);
 
 /* IOCTL Stuff */
 bool DOS_IOCTL(void);
 bool DOS_GetSTDINStatus();
-uint8_t DOS_FindDevice(char const * name);
+uint8_t DOS_FindDevice(const char* name);
 void DOS_SetupDevices();
 void DOS_ShutDownDevices();
 
@@ -292,10 +294,7 @@ static inline uint16_t long2para(uint32_t size) {
 #define DOSERR_FILE_ALREADY_EXISTS 80
 
 /* Wait/check user input */
-enum class UserDecision { Cancel, Continue, Next };
 bool DOS_IsCancelRequest();
-UserDecision DOS_WaitForCancelContinue();
-UserDecision DOS_WaitForCancelContinueNext();
 
 /* Macros SSET_* and SGET_* are used to safely access fields in memory-mapped
  * DOS structures represented via classes inheriting from MemStruct class.
@@ -687,7 +686,10 @@ class DOS_MCB final : public MemStruct {
 public:
 	DOS_MCB(uint16_t seg) : MemStruct(seg, 0) {}
 
-	void SetFileName(char const * const _name) { MEM_BlockWrite(pt+offsetof(sMCB,filename),_name,8); }
+	void SetFileName(const char* const _name)
+	{
+		MEM_BlockWrite(pt + offsetof(sMCB, filename), _name, 8);
+	}
 	void GetFileName(char * const _name) { MEM_BlockRead(pt+offsetof(sMCB,filename),_name,8);_name[8]=0;}
 
 	void SetType(uint8_t mcb_type) { SSET_BYTE(sMCB, type, mcb_type); }

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -273,4 +273,8 @@ std::optional<float> parse_prefixed_value(const char prefix, const std::string &
 // parse_prefixed_value clamped between 0 and 100
 std::optional<float> parse_prefixed_percentage(const char prefix, const std::string &s);
 
+// tries to convert string to integer,
+// returns value only if succeeded
+std::optional<int> to_int(const std::string& value);
+
 #endif

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1441,7 +1441,6 @@ static Bitu DOS_26Handler(void) {
 }
 
 constexpr uint8_t code_ctrl_c = 0x03;
-constexpr uint8_t code_return = 0x0d;
 constexpr uint8_t code_esc    = 0x1b;
 
 bool DOS_IsCancelRequest()
@@ -1465,47 +1464,6 @@ bool DOS_IsCancelRequest()
 
 	// Return control if no key pressed
 	return shutdown_requested;
-}
-
-UserDecision DOS_WaitForCancelContinue()
-{
-	auto decision = UserDecision::Next;
-	while (decision == UserDecision::Next)
-		decision = DOS_WaitForCancelContinueNext();
-
-	return decision;
-}
-
-UserDecision DOS_WaitForCancelContinueNext()
-{
-	auto decision = UserDecision::Cancel;
-	while (!shutdown_requested) {
-		CALLBACK_Idle();
-
-		// Try to read the key
-		uint16_t count = 1;
-		uint8_t code   = 0;
-		DOS_ReadFile(STDIN, &code, &count);
-
-		if (shutdown_requested || count == 0 ||
-		    code == 'q' || code == 'Q' ||
-		    code == code_ctrl_c || code == code_esc) {
-			decision = UserDecision::Cancel;
-			break;
-		}
-
-		if (code == code_return || code == ' ') {
-			decision = UserDecision::Continue;
-			break;
-		}
-
-		if (code == 'n' || code == 'N') {
-			decision = UserDecision::Next;
-			break;
-		}
-	}
-
-	return decision;
 }
 
 DOS_Version DOS_ParseVersion(const char *word, const char *args)

--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <stdexcept>
 
 CHECK_NARROWING();
 
@@ -47,7 +48,8 @@ void MORE::Run()
 	}
 
 	MoreOutputFiles output(*this);
-	if (!ParseCommandLine(output) || shutdown_requested) {
+	if (!ParseCommandLine(output) || !FindInputFiles(output) ||
+	    shutdown_requested) {
 		return;
 	}
 	output.Display();
@@ -55,38 +57,60 @@ void MORE::Run()
 
 bool MORE::ParseCommandLine(MoreOutputFiles &output)
 {
-	// Put all the parameters into vector
-	std::vector<std::string> params;
-	cmd->FillVector(params);
+	// Check (and remove if found) all the simple arguments
+	auto has_arg = [&](const char* arg) {
+		constexpr bool remove_if_found = true;
+		return cmd->FindExist(arg, remove_if_found);
+	};
+	output.SetOptionClear(has_arg("/c"));
+	output.SetOptionExtendedMode(has_arg("/e"));
+	output.SetOptionExpandFormFeed(has_arg("/p"));
+	output.SetOptionSquish(has_arg("/s"));
+
+	std::string tmp_str;
 
 	// Check if specified tabulation size
-	if (!params.empty()) {
-		const auto &param = params[0];
-		if ((starts_with("/t", param) || starts_with("/T", param)) &&
-		    (param.length() == 3) && (param.back() >= '1') &&
-		    (param.back() <= '9')) {
-			// FreeDOS extension - custom TAB size
-			output.SetTabSize(static_cast<uint8_t>(param.back() - '0'));
-			params.erase(params.begin());
+	if (cmd->FindStringBegin("/t", tmp_str, true)) {
+		const auto value = to_int(tmp_str);
+		if (!value || *value < 1 || *value > 9) {
+			std::string full_switch = std::string("/t") + tmp_str;
+			result_errorcode = DOSERR_FUNCTION_NUMBER_INVALID;
+			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), full_switch.c_str());
+			return false;
 		}
+
+		output.SetOptionTabSize(static_cast<uint8_t>(*value));
+	}
+
+	// Check if specified start line
+	if (cmd->FindStringBegin("+", tmp_str, true)) {
+		const auto value = to_int(tmp_str);
+		if (!value || *value < 0) {
+			std::string full_switch = std::string("+") + tmp_str;
+			result_errorcode = DOSERR_FUNCTION_NUMBER_INVALID;
+			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), full_switch.c_str());
+			return false;
+		}
+
+		output.SetOptionStartLine(static_cast<uint32_t>(*value));
 	}
 
 	// Make sure no other switches are supplied
-	for (const auto &param : params) {
-		if (starts_with("/", param)) {
-			result_errorcode = DOSERR_FUNCTION_NUMBER_INVALID;
-			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), param.c_str());
-			return false;
-		}
+	if (cmd->FindStringBegin("/", tmp_str)) {
+		tmp_str = std::string("/") + tmp_str;
+		result_errorcode = DOSERR_FUNCTION_NUMBER_INVALID;
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), tmp_str.c_str());
+		return false;
 	}
 
-	// Create list of input files
-	return FindInputFiles(output, params);
+	return true;
 }
 
-bool MORE::FindInputFiles(MoreOutputFiles &output,
-                          const std::vector<std::string> &params)
+bool MORE::FindInputFiles(MoreOutputFiles &output)
 {
+	// Put all the remaining parameters into vector
+	std::vector<std::string> params;
+	cmd->FillVector(params);
 	if (params.empty())
 		return true;
 
@@ -159,31 +183,64 @@ void MORE::AddMessages()
 	        "Display command output or text file one screen at a time.\n"
 	        "\n"
 	        "Usage:\n"
-	        "  [color=cyan]COMMAND[reset] | [color=green]more[reset] [/t[color=white]n[reset]]\n"
-	        "  [color=green]more[reset] [/t[color=white]n[reset]] < [color=cyan]FILE[reset]\n"
-	        "  [color=green]more[reset] [/t[color=white]n[reset]] [color=cyan]PATTERN[reset] [[color=cyan]PATTERN[reset] ...]\n"
+	        "  [color=cyan]COMMAND[reset] | [color=green]more[reset] [/c] [/e] [/p] [[reset]/s] [/t[color=white]n[reset]] [+[color=white]nnn[reset]]\n"
+	        "  [color=green]more[reset] [/c] [/e] [/p] [[reset]/s] [/t[color=white]n[reset]] [+[color=white]nnn[reset]] < [color=cyan]FILE[reset]\n"
+	        "  [color=green]more[reset] [/c] [/e] [/p] [[reset]/s] [/t[color=white]n[reset]] [+[color=white]nnn[reset]] [color=cyan]PATTERN[reset] [[color=cyan]PATTERN[reset] ...]\n"
 	        "\n"
 	        "Where:\n"
 	        "  [color=cyan]COMMAND[reset] is the command to display the output of.\n"
 	        "  [color=cyan]FILE[reset]    is an exact name of the file to display, optionally with a path.\n"
 	        "  [color=cyan]PATTERN[reset] is either a path to a single file or a path with wildcards,\n"
 	        "          which are the asterisk (*) and the question mark (?).\n"
-	        "  [color=white]n[reset]       is the tab size, 1-9, default is 8.\n"
+	        "  /c      clears the screen before each file.\n"
+	        "  /e      extended mode, with more hotkeys available.\n"
+	        "  /p      expands the new page / form feed character.\n"
+	        "  /s      squishes multiple empty lines into one.\n"
+	        "  /t[color=white]n[reset]     specifies the tab size, 1-9, default is 8.\n"
+	        "  +[color=white]nnn[reset]    line number to start the first file from.\n"
 	        "\n"
 	        "Notes:\n"
 	        "  This command is only for viewing text files, not binary files.\n"
+	        "  The following hotkeys are available:\n"
+	        "  [color=yellow]Space[reset]          to show the next screen.\n"
+	        "  [color=yellow]Enter[reset]          to show the next line.\n"
+	        "  [color=yellow]N[reset] or [color=yellow]F[reset]         to skip to the next file.\n"
+	        "  [color=yellow]Q[reset], [color=yellow]Esc[reset], [color=yellow]Ctrl+C[reset] to terminate the command.\n"
+	        "  Also, the [color=yellow]Ctrl+C[reset] can be used to terminate the command reading data from the\n"
+	        "  keyboard input, like when [color=green]more[reset] is executed without any arguments.\n"
+	        "  The following extra hotkeys are available in extended mode only:\n"
+	        "  [color=yellow]P[reset] [color=white]nnn[reset]          to display the next [color=white]nnn[reset] lines and prompt again.\n"
+	        "  [color=yellow]S[reset] [color=white]nnn[reset]          to skip the next [color=white]nnn[reset] lines.\n"
+	        "  [color=yellow]=[reset]              to display the current line number.\n"
+	        "  Option /p disables certain incompatible hotkeys.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  [color=cyan]dir /on[reset] | [color=green]more[reset]             ; displays sorted directory one screen at a time\n"
 	        "  [color=green]more[reset] /t[color=white]4[reset] < [color=cyan]A:\\MANUAL.TXT[reset]   ; shows the file's content with tab size 4\n");
 
-	MSG_Add("PROGRAM_MORE_NO_FILE",       "No input file found.");
-	MSG_Add("PROGRAM_MORE_END",           "[reset][color=light-yellow]--- end of input ---[reset]");
-	MSG_Add("PROGRAM_MORE_NEW_FILE",      "[reset][color=light-yellow]--- file %s ---[reset]");
-	MSG_Add("PROGRAM_MORE_NEW_DEVICE",    "[reset][color=light-yellow]--- device %s ---[reset]");
-	MSG_Add("PROGRAM_MORE_PROMPT_SINGLE", "[reset][color=light-yellow]--- press SPACE for more ---[reset]");
-	MSG_Add("PROGRAM_MORE_PROMPT_MULTI",  "[reset][color=light-yellow]--- press SPACE for more, N for next file ---[reset]");
-	MSG_Add("PROGRAM_MORE_OPEN_ERROR",    "[reset][color=red]--- could not open %s ---[reset]");
-	MSG_Add("PROGRAM_MORE_TERMINATE",     "[reset][color=light-yellow](terminated)[reset]");
-	MSG_Add("PROGRAM_MORE_NEXT_FILE",     "[reset][color=light-yellow](next file)[reset]");
+	MSG_Add("PROGRAM_MORE_NO_FILE", "No input file found.");
+	MSG_Add("PROGRAM_MORE_END",
+	        "[reset][color=light-yellow]--- end of input ---[reset]");
+	MSG_Add("PROGRAM_MORE_NEW_FILE",
+	        "[reset][color=light-yellow]--- file %s ---[reset]");
+	MSG_Add("PROGRAM_MORE_NEW_DEVICE",
+	        "[reset][color=light-yellow]--- device %s ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_SINGLE",
+	        "[reset][color=light-yellow]--- press SPACE or ENTER for more ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_PERCENT",
+	        "[reset][color=light-yellow]--- (%d%%) press SPACE or ENTER for more ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_MULTI",
+	        "[reset][color=light-yellow]--- press SPACE or ENTER for more, N for next file ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_LINE",
+	        "[reset][color=light-yellow]--- line %u ---[reset]");
+	MSG_Add("PROGRAM_MORE_OPEN_ERROR",
+	        "[reset][color=red]--- could not open %s ---[reset]");
+	MSG_Add("PROGRAM_MORE_TERMINATE",
+	        "[reset][color=light-yellow](terminated)[reset]");
+	MSG_Add("PROGRAM_MORE_NEXT_FILE",
+	        "[reset][color=light-yellow](next file)[reset]");
+	MSG_Add("PROGRAM_MORE_SKIPPED",
+	        "[reset][color=light-yellow](skipped content)[reset]");
+	MSG_Add("PROGRAM_MORE_HOW_MANY_LINES",
+	        "[reset][color=light-yellow]how many lines?[reset]");
 }

--- a/src/dos/program_more.h
+++ b/src/dos/program_more.h
@@ -39,8 +39,7 @@ public:
 
 private:
 	bool ParseCommandLine(MoreOutputFiles &output);
-	bool FindInputFiles(MoreOutputFiles &output,
-	                    const std::vector<std::string> &params);
+	bool FindInputFiles(MoreOutputFiles& output);
 
 	void AddMessages();
 };

--- a/src/dos/program_more_output.h
+++ b/src/dos/program_more_output.h
@@ -34,21 +34,40 @@ public:
 	MoreOutputBase(Program &program);
 	virtual ~MoreOutputBase() = default;
 
-	void SetTabSize(const uint8_t new_tab_size);
+	void SetOptionClear(const bool enabled);
+	void SetOptionExtendedMode(const bool enabled);
+	void SetOptionExpandFormFeed(const bool enabled);
+	void SetOptionSquish(const bool enabled);
+	void SetOptionStartLine(const uint32_t line_num);
+	void SetOptionTabSize(const uint8_t tab_size);
 
 	virtual void Display() = 0;
 
 protected:
+	enum class UserDecision {
+		Cancel,
+		More,
+		MoreOneLine,
+		MoreNumLines,
+		SkipNumLines,
+		NextFile,
+		SwitchPrompt
+	};
+
+	void SetLinesInStream(const uint32_t lines);
+
 	// Get cursor position from BIOS
 	static uint8_t GetCursorColumn();
 	static uint8_t GetCursorRow();
 
 	uint16_t GetMaxLines() const;
 	uint16_t GetMaxColumns() const;
+	void ClearScreenIfRequested();
 
 	void PrepareInternals();
 	UserDecision DisplaySingleStream();
 	UserDecision PromptUser();
+	UserDecision PromptUserIfNeeded();
 
 	virtual bool GetCharacterRaw(char &code, bool &is_last) = 0;
 
@@ -66,14 +85,19 @@ protected:
 	State state = State::Normal;
 
 	uint16_t column_counter = 0;
-	// how many lines printed out since last user prompt
-	uint16_t line_counter = 0;
+	// How many lines printed out since last user prompt / start of stream
+	uint16_t screen_line_counter = 0;
+	uint32_t stream_line_counter = 0;
 
 	bool is_output_redirected = false;
-	bool was_prompt_recently  = false; // if next user prompt can be skipped
 	bool has_multiple_files   = false; // if more than 1 file has to be displayed
 	bool should_end_on_ctrl_c = false; // reaction on CTRL+C in the input
 	bool should_print_ctrl_c  = false; // if Ctrl+C on input should print '^C'
+
+	// If true, we can safely skip a 'dummy' prompt, which normally
+	// prevents the DOS prompt after the command execution to hide
+	// lines not yet read by the user
+	bool should_skip_pre_exit_prompt = false;
 
 	// Wrappers for Program:: methods
 
@@ -93,12 +117,38 @@ private:
 
 	bool GetCharacter(char& code, bool& is_last_character);
 
+	uint32_t GetNumLinesFromUser(UserDecision& decision);
+	UserDecision WaitForCancelContinue();
+	UserDecision WaitForCancelContinueNext();
+
 	uint16_t max_lines   = 0; // max lines to display between user prompts
 	uint16_t max_columns = 0;
 
-	uint8_t tab_size       = 8; // how many spaces to print for a TAB
-	uint8_t tabs_remaining = 0; // how many spaces still to be printed for the current TAB
-	bool    is_tab_last    = false;
+	// Command line options
+	bool has_option_clear  = false; // true = clear screen at start of each stream
+	bool has_option_squish = false; // true = squish multiple empty lines into one
+	bool has_option_extended_mode    = false;
+	bool has_option_expand_form_feed = false;
+	uint8_t option_tab_size = 8; // how many spaces to print for a TAB
+	uint32_t option_start_line_num = 0;
+
+	// Line number to start displaying from
+	uint32_t start_line_num = 0;
+	// Number of lines to display before the user prompt
+	uint32_t lines_to_display = 0;
+	// Number of lines to skip before displaying the input
+	uint32_t lines_to_skip = 0;
+	// Total number of lines in the input, 0 for unknown
+	uint32_t lines_in_stream = 0;
+
+	// How many spaces still to be printed for the current TAB
+	uint8_t tabs_remaining = 0;
+	// How many new lines lines still to be printed instead of FormFeed
+	uint16_t new_lines_ramaining = 0;
+	// Is the character we are replacing the last one in the file
+	bool is_replacing_last = false;
+
+	char last_fetched_code = 0; // code of previously fetched character, or 0
 };
 
 // ***************************************************************************

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -273,3 +273,12 @@ std::optional<float> parse_prefixed_percentage(const char prefix, const std::str
 	constexpr auto max_percentage = 100.0f;
 	return parse_prefixed_value(prefix, s, min_percentage, max_percentage);
 }
+
+std::optional<int> to_int(const std::string& value)
+{
+	try {
+		return std::stoi(value);
+	} catch (...) {
+		return {};
+	}
+}


### PR DESCRIPTION
Adds several `MORE` command features, found in Windows 11 (possibly earlier releases too):
- `ENTER` scrolls one line, not the whole screen
- `F` skips to the next file (like in Windows), `N` (like in FreeDOS) is still supported
- option `/c`, to clean screen before displaying a new file/stream
- option `/s`, to squish multiple empty lines into a single one
- option `/e` (extended mode), enabling additional hotkeys: `P` or `S` (prints/skips user-specified number of lines), `=` (shows line number)
- option `/p`, to expand the `0x0c` character (form feed)
- option `+nnn` to skip the first lines of the file/stream
