### PR TITLE
Dedupe the now-redundant CRT shaders' filename prefixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,7 @@ GPL-2.0-or-later terms, however there are some exceptions:
   LGPL-2.1-or-later terms.
 
 - Timothy Lottes' has dedicated his CRT-styled scan-line GLSL
-  shader, in file contrib/resources/glshaders/crt-fakelottes-flat.glsl,
+  shader, in file contrib/resources/glshaders/crt/fakelottes-flat.glsl,
   to the public domain.
 
 - Libraries in src/libs directory, are licensed as follows:

--- a/contrib/resources/glshaders/crt/aperture.glsl
+++ b/contrib/resources/glshaders/crt/aperture.glsl
@@ -3,6 +3,9 @@
 /*
 	CRT Shader by EasyMode
 	License: GPL
+
+	This file ported from Libretro's GLSL shader crt-aperture.glslp 
+	to DOSBox-compatible format by Tyrells.
 */
 
 /*

--- a/contrib/resources/glshaders/crt/caligari.glsl
+++ b/contrib/resources/glshaders/crt/caligari.glsl
@@ -5,6 +5,9 @@
 
 	 Ported by Hyllian.
 
+        This file ported from Libretro's GLSL shader crt-caligari.glslp 
+        to DOSBox-compatible format by Tyrells.
+
 	This program is free software; you can redistribute it and/or
 	modify it under the terms of the GNU General Public License
 	as published by the Free Software Foundation; either version 2
@@ -18,6 +21,8 @@
 	You should have received a copy of the GNU General Public License
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+
 
 */
 

--- a/contrib/resources/glshaders/crt/easymode.glsl
+++ b/contrib/resources/glshaders/crt/easymode.glsl
@@ -4,6 +4,9 @@
 	CRT Shader by EasyMode
 	License: GPL
 
+	This file ported from Libretro's GLSL shader crt-easymode.glslp
+	to DOSBox-compatible format by Tyrells.
+
 	A flat CRT shader ideally for 1080p or higher displays.
 
 	Recommended Settings:

--- a/contrib/resources/glshaders/crt/easymode.tweaked.glsl
+++ b/contrib/resources/glshaders/crt/easymode.tweaked.glsl
@@ -4,6 +4,9 @@
 	CRT Shader by EasyMode
 	License: GPL
 
+	This file ported from Libretro's GLSL shader crt-easymode.glslp 
+	to DOSBox-compatible format by Tyrells.
+
 	A flat CRT shader ideally for 1080p or higher displays.
 
 	Recommended Settings:

--- a/contrib/resources/glshaders/crt/fakelottes.glsl
+++ b/contrib/resources/glshaders/crt/fakelottes.glsl
@@ -16,6 +16,10 @@
  *   - 2018, hunterk: modified
  *           Simple scanlines with curvature and mask effects lifted from crt-lottes
  *           https://github.com/Themaister/slang-shaders/blob/master/crt/shaders/fakelottes.slang
+ *
+ *   - 2020, Ported from Libretro's GLSL shader crt-lottes.glslp 
+ *           to DOSBox-compatible format by Tyrells.
+ *
  */
 
 #version 120

--- a/contrib/resources/glshaders/crt/fakelottes.tweaked.glsl
+++ b/contrib/resources/glshaders/crt/fakelottes.tweaked.glsl
@@ -1,5 +1,8 @@
 #version 120
 
+// This file ported from Libretro's GLSL shader crt-lottes.glslp 
+// to DOSBox-compatible format by Tyrells.
+
 // Simple scanlines with curvature and mask effects lifted from crt-lottes
 // by hunterk
 

--- a/contrib/resources/glshaders/crt/geom.glsl
+++ b/contrib/resources/glshaders/crt/geom.glsl
@@ -4,6 +4,9 @@
 
 	Copyright (C) 2010-2012 cgwg, Themaister and DOLLS
 
+	Copyright (C) 2020, this file ported from Libretro's GLSL 
+	shader crt-geom.glslp to DOSBox-compatible format by Tyrells.
+
 	This program is free software; you can redistribute it and/or modify it
 	under the terms of the GNU General Public License as published by the Free
 	Software Foundation; either version 2 of the License, or (at your option)

--- a/contrib/resources/glshaders/crt/geom.tweaked.glsl
+++ b/contrib/resources/glshaders/crt/geom.tweaked.glsl
@@ -4,6 +4,9 @@
 
 	Copyright (C) 2010-2012 cgwg, Themaister and DOLLS
 
+	Copyright (C) 2020, this file ported from Libretro's GLSL 
+	shader crt-geom.glslp to DOSBox-compatible format by Tyrells.
+
 	This program is free software; you can redistribute it and/or modify it
 	under the terms of the GNU General Public License as published by the Free
 	Software Foundation; either version 2 of the License, or (at your option)

--- a/contrib/resources/glshaders/crt/hyllian-updated.glsl
+++ b/contrib/resources/glshaders/crt/hyllian-updated.glsl
@@ -5,6 +5,9 @@
 
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
+   Copyright (C) 2020, this file ported from Libretro's GLSL
+   shader crt-hyllian.glslp to DOSBox-compatible format by Tyrells.
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights

--- a/contrib/resources/glshaders/crt/hyllian.glsl
+++ b/contrib/resources/glshaders/crt/hyllian.glsl
@@ -5,6 +5,9 @@
 
    Copyright (C) 2011-2016 Hyllian - sergiogdb@gmail.com
 
+   Copyright (C) 2020, this file ported from Libretro's GLSL
+   shader crt-hyllian.glslp to DOSBox-compatible format by Tyrells.
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights

--- a/contrib/resources/glshaders/crt/lottes-fast.glsl
+++ b/contrib/resources/glshaders/crt/lottes-fast.glsl
@@ -9,6 +9,7 @@
 //                      by Timothy Lottes
 //             https://www.shadertoy.com/view/MtSfRK
 //               adapted for RetroArch by hunterk
+//  adapted for DOSBox by Tyrells (from crt-lottes-fast.glslp)
 //
 //
 //==============================================================
@@ -195,46 +196,14 @@ uniform COMPAT_PRECISION float MASK;
 uniform COMPAT_PRECISION float TRINITRON_CURVE;
 #else
 #define CRT_GAMMA 2.4
-#define SCANLINE_THINNESS 0.00
-#define SCAN_BLUR 8.8
-#define MASK_INTENSITY 0.44
+#define SCANLINE_THINNESS 0.5
+#define SCAN_BLUR 2.5
+#define MASK_INTENSITY 0.54
 #define CURVATURE 0.02
-#define CORNER 2.5
-#define MASK 3.0
+#define CORNER 3.0
+#define MASK 1.0
 #define TRINITRON_CURVE 0.0
 #endif
-
-//_____________________________/\_______________________________
-//==============================================================
-//
-//              ADDITIONAL FUNCTIONS AND DEFS
-//
-//--------------------------------------------------------------
-//--------------------------------------------------------------
-
-// Constants ---------------------------------------------------
-
-#define LUM_WEIGHTS vec3(0.299, 0.587, 0.114)
-
-// Params ------------------------------------------------------
-
-//#define SHOW_DRY 0.3			// if defined unprocessed image is shown at u > SHOW_DRY
-#define SHOW_DRY_MODE 1			// 0: unprocessed, 1: shader without final gain
-
-#define FINAL_GAIN_MULT 2.6
-#define FINAL_GAIN_POW 2.8
-#define FINAL_GAIN_MIX 0.6
-
-// Functions ----------------------------------------------------
-
-// Applied in main()
-vec3 finalGain(vec3 col)
-{
-	float lum = dot(col, LUM_WEIGHTS);
-	vec3 lum_mult = vec3(1.0) + pow(lum, FINAL_GAIN_POW) * FINAL_GAIN_MULT;
-	vec3 col_mult = vec3(1.0) + pow(col, vec3(FINAL_GAIN_POW)) * FINAL_GAIN_MULT;
-	return col * mix(lum_mult, col_mult, vec3(FINAL_GAIN_MIX));
-}
 
 //_____________________________/\_______________________________
 //==============================================================
@@ -707,6 +676,7 @@ vec3 CrtsFetch(vec2 uv){
 //--------------------------------------------------------------
  }
 
+
 void main()
 {
 	vec2 warp_factor;
@@ -727,16 +697,6 @@ void main()
 	CrtsTone(1.0,0.0,INPUT_THIN,INPUT_MASK));
 
 	// Shadertoy outputs non-linear color
-
-  #ifdef SHOW_DRY
-	if (vTexCoord.x > SHOW_DRY)
-	 if (SHOW_DRY_MODE == 0)
-		FragColor = vec4(texture2D(rubyTexture, vTexCoord.xy).rgb, 1.0);
-	 else
-	    FragColor = vec4(ToSrgb(FragColor.rgb), 1.0);
-	else
-  #endif
-	 FragColor = vec4(ToSrgb(finalGain(FragColor.rgb)), 1.0);
-
+	FragColor = vec4(ToSrgb(FragColor.rgb), 1.0);
 }
 #endif

--- a/contrib/resources/glshaders/crt/lottes-fast.subtle+gain.glsl
+++ b/contrib/resources/glshaders/crt/lottes-fast.subtle+gain.glsl
@@ -9,6 +9,7 @@
 //                      by Timothy Lottes
 //             https://www.shadertoy.com/view/MtSfRK
 //               adapted for RetroArch by hunterk
+//  adapted for DOSBox by Tyrells (from crt-lottes-fast.glslp)
 //
 //
 //==============================================================
@@ -195,14 +196,46 @@ uniform COMPAT_PRECISION float MASK;
 uniform COMPAT_PRECISION float TRINITRON_CURVE;
 #else
 #define CRT_GAMMA 2.4
-#define SCANLINE_THINNESS 0.5
-#define SCAN_BLUR 2.5
-#define MASK_INTENSITY 0.54
+#define SCANLINE_THINNESS 0.00
+#define SCAN_BLUR 8.8
+#define MASK_INTENSITY 0.44
 #define CURVATURE 0.02
-#define CORNER 3.0
-#define MASK 1.0
+#define CORNER 2.5
+#define MASK 3.0
 #define TRINITRON_CURVE 0.0
 #endif
+
+//_____________________________/\_______________________________
+//==============================================================
+//
+//              ADDITIONAL FUNCTIONS AND DEFS
+//
+//--------------------------------------------------------------
+//--------------------------------------------------------------
+
+// Constants ---------------------------------------------------
+
+#define LUM_WEIGHTS vec3(0.299, 0.587, 0.114)
+
+// Params ------------------------------------------------------
+
+//#define SHOW_DRY 0.3			// if defined unprocessed image is shown at u > SHOW_DRY
+#define SHOW_DRY_MODE 1			// 0: unprocessed, 1: shader without final gain
+
+#define FINAL_GAIN_MULT 2.6
+#define FINAL_GAIN_POW 2.8
+#define FINAL_GAIN_MIX 0.6
+
+// Functions ----------------------------------------------------
+
+// Applied in main()
+vec3 finalGain(vec3 col)
+{
+	float lum = dot(col, LUM_WEIGHTS);
+	vec3 lum_mult = vec3(1.0) + pow(lum, FINAL_GAIN_POW) * FINAL_GAIN_MULT;
+	vec3 col_mult = vec3(1.0) + pow(col, vec3(FINAL_GAIN_POW)) * FINAL_GAIN_MULT;
+	return col * mix(lum_mult, col_mult, vec3(FINAL_GAIN_MIX));
+}
 
 //_____________________________/\_______________________________
 //==============================================================
@@ -675,7 +708,6 @@ vec3 CrtsFetch(vec2 uv){
 //--------------------------------------------------------------
  }
 
-
 void main()
 {
 	vec2 warp_factor;
@@ -696,6 +728,16 @@ void main()
 	CrtsTone(1.0,0.0,INPUT_THIN,INPUT_MASK));
 
 	// Shadertoy outputs non-linear color
-	FragColor = vec4(ToSrgb(FragColor.rgb), 1.0);
+
+  #ifdef SHOW_DRY
+	if (vTexCoord.x > SHOW_DRY)
+	 if (SHOW_DRY_MODE == 0)
+		FragColor = vec4(texture2D(rubyTexture, vTexCoord.xy).rgb, 1.0);
+	 else
+	    FragColor = vec4(ToSrgb(FragColor.rgb), 1.0);
+	else
+  #endif
+	 FragColor = vec4(ToSrgb(finalGain(FragColor.rgb)), 1.0);
+
 }
 #endif

--- a/contrib/resources/glshaders/crt/lottes.glsl
+++ b/contrib/resources/glshaders/crt/lottes.glsl
@@ -16,6 +16,9 @@
 // It is an example what I personally would want as a display option for pixel art games.
 // Please take and use, change, or whatever.
 
+// This file ported from Libretro's GLSL shader crt-lottes.glslp
+// to DOSBox-compatible format by Tyrells.
+
 /*
 
 // Parameter lines go here:

--- a/contrib/resources/glshaders/crt/lottes.tweaked.glsl
+++ b/contrib/resources/glshaders/crt/lottes.tweaked.glsl
@@ -16,6 +16,9 @@
 // It is an example what I personally would want as a display option for pixel art games.
 // Please take and use, change, or whatever.
 
+// This file ported from Libretro's GLSL shader crt-lottes.glslp 
+// to DOSBox-compatible format by Tyrells.
+
 /*
 
 // Parameter lines go here:

--- a/contrib/resources/glshaders/crt/mattias.glsl
+++ b/contrib/resources/glshaders/crt/mattias.glsl
@@ -4,6 +4,9 @@
 // by Mattias
 // https://www.shadertoy.com/view/lsB3DV
 
+// This file ported from Libretro's GLSL shader crt-mattias.glslp 
+// to DOSBox-compatible format by Tyrells.
+
 /*
 
 #pragma parameter CURVATURE "Curvature" 0.5 0.0 1.0 0.05

--- a/contrib/resources/glshaders/crt/pi-vertical.glsl
+++ b/contrib/resources/glshaders/crt/pi-vertical.glsl
@@ -29,6 +29,9 @@ BLOOM_FACTOR controls the increase in width for bright scanlines.
 
 MASK_TYPE defines what, if any, shadow mask to use. MASK_BRIGHTNESS defines how much the mask type darkens the screen.
 
+This file ported from Libretro's GLSL shader crt-pi-vertical.glslp
+to DOSBox-compatible format by Tyrells.	
+
 */
 
 /*

--- a/contrib/resources/glshaders/crt/pi.glsl
+++ b/contrib/resources/glshaders/crt/pi.glsl
@@ -27,6 +27,9 @@ BLOOM_FACTOR controls the increase in width for bright scanlines.
 
 MASK_TYPE defines what, if any, shadow mask to use. MASK_BRIGHTNESS defines how much the mask type darkens the screen.
 
+This file ported from Libretro's GLSL shader crt-pi.glslp
+to DOSBox-compatible format by Tyrells.
+
 */
 
 /*

--- a/contrib/resources/glshaders/crt/yee64.glsl
+++ b/contrib/resources/glshaders/crt/yee64.glsl
@@ -2,6 +2,9 @@
 
 // ported from ReShade
 
+// This file ported from Libretro's GLSL shader yee64.glslp
+// to DOSBox-compatible format by Tyrells.
+
 #if defined(VERTEX)
 
 #if __VERSION__ >= 130

--- a/contrib/resources/glshaders/crt/yeetron.glsl
+++ b/contrib/resources/glshaders/crt/yeetron.glsl
@@ -2,6 +2,9 @@
 
 // ported from ReShade
 
+// This file ported from Libretro's GLSL shader yeetron.glslp
+// to DOSBox-compatible format by Tyrells.
+
 #if defined(VERTEX)
 
 #if __VERSION__ >= 130

--- a/contrib/resources/glshaders/crt/zfast-composite.glsl
+++ b/contrib/resources/glshaders/crt/zfast-composite.glsl
@@ -11,6 +11,9 @@
     Software Foundation; either version 2 of the License, or (at your option)
     any later version.
 
+    This file ported from Libretro's GLSL shader zfast-composite.glslp
+    to DOSBox-compatible format by Tyrells.
+
 */
 
 /* 

--- a/contrib/resources/glshaders/crt/zfast.glsl
+++ b/contrib/resources/glshaders/crt/zfast.glsl
@@ -18,6 +18,11 @@ Notes:  This shader does scaling with a weighted linear filter for adjustable
 	based on pixel brighness is applied along with a monochrome aperture mask.
 	This shader runs at 60fps on the Raspberry Pi 3 hardware at 2mpix/s
 	resolutions (1920x1080 or 1600x1200).
+
+        This file ported from Libretro's GLSL shader zfast-crt.glslp
+        to DOSBox-compatible format by Tyrells.
+
+
 */
 
 //This can't be an option without slowing the shader down

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -645,10 +645,9 @@ void DOSBOX_Init()
 #if C_OPENGL
 	pstring = secprop->Add_path("glshader", always, "default");
 	pstring->Set_help(
-	        "Either 'none' or a GLSL shader name. Works only with\n"
-	        "OpenGL output. Can be either an absolute path or a file\n"
-	        "in the 'glshaders' subdirectory of the DOSBox configuration\n"
-	        "directory. The '.glsl' extension can be omitted.");
+	        "Options include 'default', 'none', a shader listed using the --list-glshaders\n"
+	        "command-line argument, or an absolute or relative path to a file.\n"
+	        "In all cases, you may omit the shader's '.glsl' file extension.");
 #endif
 
 	// Add the [composite] conf block after [render]

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -642,7 +642,7 @@ void log_warning_if_legacy_shader_name(const std::string &name)
 	        {"advinterp3x", "scaler/advinterp3x"},
 	        {"advmame2x", "scaler/advmame2x"},
 	        {"advmame3x", "scaler/advmame3x"},
-	        {"crt-easymode-flat", "crt/crt-easymode.tweaked"},
+	        {"crt-easymode-flat", "crt/easymode.tweaked"},
 	        {"crt-fakelottes-flat", "crt/fakelottes"},
 	        {"rgb2x", "scaler/rgb2x"},
 	        {"rgb3x", "scaler/rgb3x"},


### PR DESCRIPTION
With the shaders now organized by category into sub-directories, some of the filename prefixes are now redundant.

`glshader = crt/crt-easymode`

now collapses to:

`glshader = crt/easymode`

(Alternatively, if we wanted to keep the dupes, we should be consistent with category filename prefixes, i.e.: `glshader = scaler/scaler-advmame3x.glsl`)

---

Here's the tree:

```
glshaders/
├── crt
│   ├── aperture.glsl
│   ├── caligari.glsl
│   ├── easymode.glsl
│   ├── easymode.tweaked.glsl
│   ├── fakelottes.glsl
│   ├── fakelottes.tweaked.glsl
│   ├── geom.glsl
│   ├── geom.tweaked.glsl
│   ├── hyllian.glsl
│   ├── hyllian-updated.glsl
│   ├── lottes-fast.glsl
│   ├── lottes-fast.subtle+gain.glsl
│   ├── lottes.glsl
│   ├── lottes.tweaked.glsl
│   ├── mattias.glsl
│   ├── pi.glsl
│   ├── pi-vertical.glsl
│   ├── yee64.glsl
│   ├── yeetron.glsl
│   ├── zfast-composite.glsl
│   └── zfast.glsl
├── interpolation
│   ├── catmull-rom.glsl
│   └── sharp.glsl
├── scaler
│   ├── advinterp2x.glsl
│   ├── advinterp3x.glsl
│   ├── advmame2x.glsl
│   ├── advmame3x.glsl
│   ├── rgb2x.glsl
│   ├── rgb3x.glsl
│   ├── scan2x.glsl
│   ├── scan3x.glsl
│   ├── tv2x.glsl
│   └── tv3x.glsl
├── meson.build
└── none.glsl
```
