### PR TITLE
Check CLI arguments for directories using non-invasive test

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 268
+          MAX_BUGS: 255
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -34,6 +34,9 @@
 // return the lines from the given text file or an empty optional
 std::optional<std::vector<std::string>> get_lines(const std_fs::path &text_file);
 
+// Is the candidate a directory or a symlink that points to one?
+bool is_directory(const std::string& candidate);
+
 /* Check if the given path corresponds to an existing file or directory.
  */
 

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -29,6 +29,20 @@
 
 CHECK_NARROWING();
 
+bool is_directory(const std::string& candidate)
+{
+	std::error_code ec;
+	const std_fs::path p(candidate);
+
+	// If it's a symlink then check what it points to ..
+	if (std_fs::is_symlink(p, ec)) {
+		const auto status = std_fs::symlink_status(p, ec);
+		return std_fs::is_directory(status);
+	}
+	// If it's not a symlink then we can check it directly ..
+	return std_fs::is_directory(p, ec);
+}
+
 // return the lines from the given text file or an empty optional
 std::optional<std::vector<std::string>> get_lines(const std_fs::path &text_file)
 {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -28,9 +28,10 @@
 #include <string_view>
 
 #include "control.h"
+#include "cross.h"
+#include "fs_utils.h"
 #include "string_utils.h"
 #include "support.h"
-#include "cross.h"
 
 #if defined(_MSC_VER) || (defined(__MINGW32__) && defined(__clang__))
 _CRTIMP extern char **_environ;
@@ -1267,10 +1268,7 @@ bool CommandLine::FindCommand(unsigned int which,std::string & value) {
 // Was a directory provided on the command line?
 bool CommandLine::HasDirectory() const
 {
-	for (const auto& arg : cmds)
-		if (open_directory(arg.c_str()))
-			return true;
-	return false;
+	return std::any_of(cmds.begin(), cmds.end(), is_directory);
 }
 
 // Was an executable filename provided on the command line?


### PR DESCRIPTION
@FeralChild64, thanks to your help discovering the fault inside `DOS_Drive_Cache::OpenDir`, it turns out this call was being used as a boolean check to test if any of CLI arguments are directories.

This expectedly opens any directories instead of merely checking if they are indeed directories. 

Fixes #2144.
