### PR TITLE
Improve logging of the current display mode

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -509,9 +509,9 @@ void VGA_SetupOther(void);
 void VGA_SetupXGA(void);
 void VGA_AddCompositeSettings(Config &conf);
 
-/* Some Support Functions */
-std::pair<const char *, const char *> VGA_DescribeType(const VGAModes type,
-                                                       const uint16_t mode);
+/* Some support functions */
+std::pair<std::string, std::string> VGA_DescribeType(const VGAModes type,
+                                                     const uint16_t mode);
 void VGA_SetClock(Bitu which, uint32_t target);
 
 // Save, get, and limit refresh and clock functions

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -737,8 +737,8 @@ static void log_display_properties(int source_w, int source_h,
 	const auto double_scanned_str = (refresh_rate <= REFRESH_RATE_DOS_DOUBLED_MAX)
 	                                        ? "double-scanned "
 	                                        : "";
-	LOG_MSG("DISPLAY: %s %dx%d%s (%Xh) at %s%2.5g Hz %s, scaled"
-	        " by %.1fx%.1f to %dx%d with %#.2g pixel-aspect",
+	LOG_MSG("DISPLAY: %s %dx%d%s (%02Xh) at %s%2.5g Hz %s, scaled"
+	        " by %.4gx%.4g to %dx%d with %.4g pixel-aspect",
 	        type_name,
 	        source_w,
 	        source_h,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -741,7 +741,7 @@ static void log_display_properties(int source_w, int source_h,
 	const auto colours = (type_colours == "") ? "" : " " + type_colours;
 
 	LOG_MSG("DISPLAY: %s %dx%d%s (mode %02Xh) at %s%2.5g Hz %s, scaled"
-	        " by %.4gx%.4g to %dx%d with %.4g pixel aspect ratio",
+	        " to %dx%d with %.4g pixel aspect ratio",
 	        type_name.c_str(),
 	        source_w,
 	        source_h,
@@ -750,8 +750,6 @@ static void log_display_properties(int source_w, int source_h,
 	        double_scanned_str,
 	        refresh_rate,
 	        frame_mode,
-	        scale_x,
-	        scale_y,
 	        target_w,
 	        target_h,
 	        out_par);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -735,14 +735,17 @@ static void log_display_properties(int source_w, int source_h,
 	// up to avoid confusion (ie: 30 Hz should actually be shown at 60Hz)
 	auto refresh_rate = VGA_GetPreferredRate();
 	const auto double_scanned_str = (refresh_rate <= REFRESH_RATE_DOS_DOUBLED_MAX)
-	                                        ? "double-scanned "
-	                                        : "";
+	                                      ? "double-scanned "
+	                                      : "";
+
+	const auto colours = (type_colours == "") ? "" : " " + type_colours;
+
 	LOG_MSG("DISPLAY: %s %dx%d%s (%02Xh) at %s%2.5g Hz %s, scaled"
 	        " by %.4gx%.4g to %dx%d with %.4g pixel-aspect",
-	        type_name,
+	        type_name.c_str(),
 	        source_w,
 	        source_h,
-	        type_colours,
+	        colours.c_str(),
 	        CurMode->mode,
 	        double_scanned_str,
 	        refresh_rate,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -740,8 +740,8 @@ static void log_display_properties(int source_w, int source_h,
 
 	const auto colours = (type_colours == "") ? "" : " " + type_colours;
 
-	LOG_MSG("DISPLAY: %s %dx%d%s (%02Xh) at %s%2.5g Hz %s, scaled"
-	        " by %.4gx%.4g to %dx%d with %.4g pixel-aspect",
+	LOG_MSG("DISPLAY: %s %dx%d%s (mode %02Xh) at %s%2.5g Hz %s, scaled"
+	        " by %.4gx%.4g to %dx%d with %.4g pixel aspect ratio",
 	        type_name.c_str(),
 	        source_w,
 	        source_h,

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -42,8 +42,7 @@ uint32_t ExpandTable[256];
 uint32_t Expand16Table[4][16];
 uint32_t FillTable[16];
 
-std::pair<const char *, const char *> VGA_DescribeType(const VGAModes type,
-                                                       uint16_t mode)
+std::pair<std::string, std::string> VGA_DescribeType(const VGAModes type, uint16_t mode)
 {
 	// clang-format off
 	switch (type) {
@@ -51,28 +50,28 @@ std::pair<const char *, const char *> VGA_DescribeType(const VGAModes type,
 	case M_HERC_TEXT:
 	case M_TANDY_TEXT:
 	case M_CGA_TEXT_COMPOSITE: return std::pair("Text", "");
-	case M_HERC_GFX:           return std::pair("Hercules", " monochrome");
+	case M_HERC_GFX:           return std::pair("Hercules", "monochrome");
 	case M_CGA2_COMPOSITE:
-	case M_CGA4_COMPOSITE:     return std::pair("CGA",   " composite");
-	case M_CGA2:               return std::pair("CGA",   " 2 color");
-	case M_CGA4:               return std::pair("CGA",   " 4 color");
-	case M_CGA16:              return std::pair("CGA",   " 16 color");
-	case M_TANDY2:             return std::pair("Tandy", " 2 color");
-	case M_TANDY4:             return std::pair("Tandy", " 4 color");
-	case M_TANDY16:            return std::pair("Tandy", " 16 color");
+	case M_CGA4_COMPOSITE:     return std::pair("CGA",   "composite");
+	case M_CGA2:               return std::pair("CGA",   "2 color");
+	case M_CGA4:               return std::pair("CGA",   "4 color");
+	case M_CGA16:              return std::pair("CGA",   "16 color");
+	case M_TANDY2:             return std::pair("Tandy", "2 color");
+	case M_TANDY4:             return std::pair("Tandy", "4 color");
+	case M_TANDY16:            return std::pair("Tandy", "16 color");
 	case M_EGA: // see comment below
 	    switch (mode) {
-	    case 0x011:            return std::pair("VGA",   " monochrome");
-	    case 0x012:            return std::pair("VGA",   " 16 color");
-	    default:               return std::pair("EGA",   " 16 color");
+	    case 0x011:            return std::pair("VGA",   "monochrome");
+	    case 0x012:            return std::pair("VGA",   "16 color");
+	    default:               return std::pair("EGA",   "16 color");
 	    }
-	case M_VGA:                return std::pair("VGA",   " 8-bit");
-	case M_LIN4:               return std::pair("VESA",  " 16 color");
-	case M_LIN8:               return std::pair("VESA",  " 8-bit");
-	case M_LIN15:              return std::pair("VESA",  " 15-bit");
-	case M_LIN16:              return std::pair("VESA",  " 16-bit");
-	case M_LIN24:              return std::pair("VESA",  " 24-bit");
-	case M_LIN32:              return std::pair("VESA",  " 32-bit");
+	case M_VGA:                return std::pair("VGA",   "8-bit");
+	case M_LIN4:               return std::pair("VESA",  "16 color");
+	case M_LIN8:               return std::pair("VESA",  "8-bit");
+	case M_LIN15:              return std::pair("VESA",  "15-bit");
+	case M_LIN16:              return std::pair("VESA",  "16-bit");
+	case M_LIN24:              return std::pair("VESA",  "24-bit");
+	case M_LIN32:              return std::pair("VESA",  "32-bit");
 	case M_ERROR:
 	default: return std::pair("Unknown", "");
 	}
@@ -83,9 +82,9 @@ std::pair<const char *, const char *> VGA_DescribeType(const VGAModes type,
 	// type for them), however they were classified as VGA from a standards
 	// perspective, so we report them as such.
 	// References:
-	// [1] IBM VGA Technical Reference, Mode of Operation, pp 2-12, 19 March, 1992.
-	// [2] "IBM PC Family- BIOS Video Modes", http://minuszerodegrees.net/video/bios_video_modes.htm
-
+	// [1] IBM VGA Technical Reference, Mode of Operation, pp 2-12, 19
+	// March, 1992. [2] "IBM PC Family- BIOS Video Modes",
+	// http://minuszerodegrees.net/video/bios_video_modes.htm
 }
 
 void VGA_LogInitialization(const char *adapter_name,


### PR DESCRIPTION
Before
```
DISPLAY: EGA 320x200 16 color (Dh) at 70.086 Hz VFR, scaled by 6.9x8.3 to 2205x1654 with 1.2 pixel-aspect
```

After 
```
DISPLAY: EGA 640x400 16 color (mode 0Dh) at 70.086 Hz VFR, scaled by 3.445x4.135 to 2205x1654 with 1.2 pixel aspect ratio
```

What this improves:

- The truncated scaling values are quite misleading and gave me a pause when troubleshooting the Windows high-DPI issue before I realised what is going on...
- DOS screen mode codes (and 16-bit WORD values in general) are zero-padded in most DOS programming related texts (so `0Dh` instead of `Dh`, in this example); without zero-padding it just looks weird to me from my assembly coding days 😎 (references: [this](https://stanislavs.org/helppc/int_10-0.html), and [this](http://vitaly_filatov.tripod.com/ng/asm/asm_023.1.html), and pretty much any book about DOS era assembly programming, and not just graphics related either)