### PR TITLE
Change mouse capture default to 'onclick'

### DIFF
--- a/src/hardware/mouse/mouse_config.cpp
+++ b/src/hardware/mouse/mouse_config.cpp
@@ -258,13 +258,14 @@ static void config_init(Section_prop &secprop)
 	// General configuration
 
 	prop_str = secprop.Add_string("mouse_capture", always,
-	                              capture_type_onstart_str);
+	                              capture_type_onclick_str);
 	assert(prop_str);
 	prop_str->Set_values(list_capture_types);
 	prop_str->Set_help(
 	        "Choose a mouse control method:\n"
 	        "  onclick:   Capture the mouse when clicking any button in the window.\n"
-	        "  onstart:   Capture the mouse immediately on start.\n"
+	        "  onstart:   Capture the mouse immediately on start. Might not work correctly\n"
+	        "             on some host operating systems.\n"
 	        "  seamless:  Let the mouse move seamlessly; captures only with middle-click or\n"
 	        "             hotkey. Seamless mouse does not work correctly with all the games,\n"
 	        "             Windows 3.1x can be made compatible with a custom mouse driver.\n"


### PR DESCRIPTION
Unfortunately, some environments seems to not like applications capturing the mouse if they don't have focus and/or user won't move the mouse cursor over their window. One report was on Discord (regarding Wayland), another (macOS) is here: https://github.com/dosbox-staging/dosbox-staging/issues/2170

Therefore, it seems that `onclick` is the only sane default for mouse capture.