### PR TITLE
Standardize MIDI rendering approach

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 255
+          MAX_BUGS: 252
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/audio_frame.h
+++ b/include/audio_frame.h
@@ -1,0 +1,56 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_AUDIO_FRAME_H
+#define DOSBOX_AUDIO_FRAME_H
+
+#include <cassert>
+#include <cstddef>
+
+// A simple stereo audio frame
+struct AudioFrame {
+	float left  = 0.0f;
+	float right = 0.0f;
+
+	constexpr AudioFrame() = default;
+
+	constexpr AudioFrame(const float l, const float r)
+	        : left(l),
+	          right(r)
+	{}
+
+	constexpr AudioFrame(const int16_t l, const int16_t r)
+	        : left(l),
+	          right(r)
+	{}
+
+	constexpr float& operator[](const size_t i) noexcept
+	{
+		assert(i < 2);
+		return i == 0 ? left : right;
+	}
+	constexpr const float& operator[](const size_t i) const noexcept
+	{
+		assert(i < 2);
+		return i == 0 ? left : right;
+	}
+};
+
+#endif

--- a/include/midi.h
+++ b/include/midi.h
@@ -41,6 +41,38 @@ void MIDI_ListAll(Program *output_handler);
 void MIDI_RawOutByte(uint8_t data);
 void MIDI_ResumeSequence();
 
+enum class MessageType : uint8_t {
+	Channel,
+	SysEx,
+};
+
+struct MidiWork {
+	std::vector<uint8_t> message      = {};
+	uint16_t num_pending_audio_frames = 0;
+	MessageType message_type          = {};
+
+	// Default value constructor
+	MidiWork()                      = default;
+	MidiWork(MidiWork&&)            = default;
+	MidiWork& operator=(MidiWork&&) = default;
+
+	// Construct from movable values
+	MidiWork(std::vector<uint8_t>&& _message,
+	         const uint16_t _num_audio_frames_pending,
+	         const MessageType _message_type)
+	        : message(std::move(_message)),
+	          num_pending_audio_frames(_num_audio_frames_pending),
+	          message_type(_message_type)
+	{
+		// leave the source in a valid state
+		_message.clear();
+	}
+
+	// Prevent copy construction
+	MidiWork(const MidiWork&)            = default;
+	MidiWork& operator=(const MidiWork&) = delete;
+};
+
 #if C_FLUIDSYNTH
 void FLUID_AddConfigSection(const config_ptr_t &conf);
 #endif

--- a/include/midi.h
+++ b/include/midi.h
@@ -69,7 +69,7 @@ struct MidiWork {
 	}
 
 	// Prevent copy construction
-	MidiWork(const MidiWork&)            = default;
+	MidiWork(const MidiWork&)            = delete;
 	MidiWork& operator=(const MidiWork&) = delete;
 };
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -30,8 +30,9 @@
 #include <memory>
 #include <set>
 
-#include "envelope.h"
 #include "../src/hardware/compressor.h"
+#include "audio_frame.h"
+#include "envelope.h"
 
 // Disable effc++ for Iir until its release.
 // Ref: https://github.com/berndporr/iir1/pull/39
@@ -58,27 +59,6 @@ enum class MixerState {
 	Off,
 	On,
 	Mute,
-};
-
-// A simple stereo audio frame
-struct AudioFrame {
-	float left  = 0.0f;
-	float right = 0.0f;
-
-	constexpr AudioFrame() = default;
-	constexpr AudioFrame(const float l, const float r) : left(l), right(r) {}
-	constexpr AudioFrame(const int16_t l, const int16_t r) : left(l), right(r) {}
-
-	constexpr float& operator[](const size_t i) noexcept
-	{
-		assert(i < 2);
-		return i == 0 ? left : right;
-	}
-	constexpr const float &operator[](const size_t i) const noexcept
-	{
-		assert(i < 2);
-		return i == 0 ? left : right;
-	}
 };
 
 #define MIXER_BUFSIZE (16 * 1024)

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -420,6 +420,7 @@ void MIXER_DeregisterChannel(mixer_channel_t& channel);
 // Mixer configuration and initialization
 void MIXER_AddConfigSection(const config_ptr_t &conf);
 int MIXER_GetSampleRate();
+uint16_t MIXER_GetPreBufferMs();
 bool MIXER_IsManuallyMuted();
 void MIXER_SetState(const MixerState requested);
 

--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -60,10 +60,12 @@ public:
 	RWQueue<T>& operator=(const RWQueue<T>& other) = delete;
 
 	RWQueue(size_t queue_capacity);
+	void Resize(size_t queue_capacity);
 
 	bool IsEmpty();
 	size_t Size();
 	size_t MaxCapacity() const;
+	float GetPercentFull();
 
 	void Enqueue(const T& item);
 

--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -67,7 +67,11 @@ public:
 	size_t MaxCapacity() const;
 	float GetPercentFull();
 
-	void Enqueue(const T& item);
+	// Discourage copying into the queue. Instead, use std::move into the
+	// queue to explicitly invalidate the source object to avoid having
+	// two source objects floating around.
+	//
+	// void Enqueue(const T& item);
 
 	// items will be empty (moved-out) after call
 	void Enqueue(T&& item);

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -100,7 +100,7 @@ void Envelope::Apply(const bool is_stereo, AudioFrame &frame)
 	if (++frames_done > expire_after_frames || edge >= edge_limit) {
 		process = &Envelope::Skip;
 		(void)channel_name; // [[maybe_unused]] in release builds
-		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %f",
+		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %.4f",
 		              channel_name,
 		              frames_done,
 		              edge);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1405,19 +1405,19 @@ void MixerChannel::ConvertSamples(const Type *data, const uint16_t frames,
 			        data, pos);
 		}
 
+		AudioFrame frame_with_gain = {
+		        prev_frame[mapped_channel_left] * combined_volume_scalar.left,
+		        (stereo ? prev_frame[mapped_channel_right]
+		                : prev_frame[mapped_channel_left]) *
+		                combined_volume_scalar.right};
+
 		// Process initial samples through an expanding envelope to
 		// prevent severe clicks and pops. Becomes a no-op when done.
-		envelope.Process(stereo, prev_frame);
-
-		const auto left = prev_frame[mapped_channel_left] *
-		                  combined_volume_scalar.left;
-		const auto right = (stereo ? prev_frame[mapped_channel_right]
-		                           : prev_frame[mapped_channel_left]) *
-		                   combined_volume_scalar.right;
+		envelope.Process(stereo, frame_with_gain);
 
 		out_frame = {0.0f, 0.0f};
-		out_frame[mapped_output_left] += left;
-		out_frame[mapped_output_right] += right;
+		out_frame[mapped_output_left] += frame_with_gain.left;
+		out_frame[mapped_output_right] += frame_with_gain.right;
 
 		out.emplace_back(out_frame[0]);
 		out.emplace_back(out_frame[1]);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -221,7 +221,9 @@ uint16_t MIXER_GetPreBufferMs()
 
 int MIXER_GetSampleRate()
 {
-	return mixer.sample_rate.load();
+	const auto sample_rate_hz = mixer.sample_rate.load();
+	assert(sample_rate_hz > 0);
+	return sample_rate_hz;
 }
 
 static void MIXER_LockAudioDevice()

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -183,12 +183,16 @@ struct Int10Data {
 
 extern Int10Data int10;
 
-static inline uint8_t CURSOR_POS_COL(uint8_t page) {
-	return real_readb(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2);
+inline uint8_t CURSOR_POS_COL(const uint8_t page)
+{
+	const auto cursor_offset = static_cast<uint16_t>(page * 2);
+	return real_readb(BIOSMEM_SEG, BIOSMEM_CURSOR_POS + cursor_offset);
 }
 
-static inline uint8_t CURSOR_POS_ROW(uint8_t page) {
-	return real_readb(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2+1);
+inline uint8_t CURSOR_POS_ROW(const uint8_t page)
+{
+	const auto cursor_offset = static_cast<uint16_t>(page * 2 + 1);
+	return real_readb(BIOSMEM_SEG, BIOSMEM_CURSOR_POS + cursor_offset);
 }
 
 void INT10_SetupPalette();

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -49,11 +49,11 @@ public:
 private:
 	void ApplyChannelMessage(const std::vector<uint8_t>& msg);
 	void ApplySysexMessage(const std::vector<uint8_t>& msg);
-	void MixerCallBack(uint16_t requested_frames);
+	void MixerCallBack(uint16_t requested_audio_frames);
 	void ProcessWorkFromFifo();
 
-	uint16_t GetNumPendingFrames();
-	void RenderFramesToFifo(const uint16_t num_frames = 1);
+	uint16_t GetNumPendingAudioFrames();
+	void RenderAudioFramesToFifo(const uint16_t num_audio_frames = 1);
 	void Render();
 
 	using fluid_settings_ptr_t =
@@ -64,7 +64,7 @@ private:
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 
 	mixer_channel_t channel = nullptr;
-	RWQueue<AudioFrame> frame_fifo{1};
+	RWQueue<AudioFrame> audio_frame_fifo{1};
 	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};
 
@@ -73,7 +73,7 @@ private:
 	// Used to track the balance of time between the last mixer callback
 	// versus the current MIDI Sysex or Msg event.
 	double last_rendered_ms = 0.0;
-	double ms_per_frame     = 0.0;
+	double ms_per_audio_frame = 0.0;
 
 	std::atomic_bool keep_rendering = {};
 	bool is_open = false;

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -1,9 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
- *  Copyright (C) 2020-2020  Nikos Chantziaras <realnc@gmail.com>
- *  Copyright (C) 2002-2011  The DOSBox Team
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -49,8 +47,13 @@ public:
 	MIDI_RC ListAll(Program *caller) override;
 
 private:
+	void ApplyChannelMessage(const std::vector<uint8_t>& msg);
+	void ApplySysexMessage(const std::vector<uint8_t>& msg);
 	void MixerCallBack(uint16_t requested_frames);
-	uint16_t GetRemainingFrames();
+	void ProcessWorkFromFifo();
+
+	uint16_t GetNumPendingFrames();
+	void RenderFramesToFifo(const uint16_t num_frames = 1);
 	void Render();
 
 	using fluid_settings_ptr_t =
@@ -59,17 +62,19 @@ private:
 
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
+
 	mixer_channel_t channel = nullptr;
-	std::string selected_font = "";
-
-	std::vector<float> play_buffer = {};
-	static constexpr auto num_buffers = 20;
-	RWQueue<std::vector<float>> playable{num_buffers};
-	RWQueue<std::vector<float>> backstock{num_buffers};
-
+	RWQueue<AudioFrame> frame_fifo{1};
+	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};
 
-	uint16_t last_played_frame = 0; // relative frame-offset in the play buffer
+	std::string selected_font = "";
+
+	// Used to track the balance of time between the last mixer callback
+	// versus the current MIDI Sysex or Msg event.
+	double last_rendered_ms = 0.0;
+	double ms_per_frame     = 0.0;
+
 	std::atomic_bool keep_rendering = {};
 	bool is_open = false;
 };

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -588,12 +588,12 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	        rom_info.control_rom_description,
 	        loaded_model_and_dir->second.c_str());
 
-	const auto frame_rate_hz = MIXER_GetSampleRate();
-	ms_per_frame             = millis_in_second / frame_rate_hz;
+	const auto audio_frame_rate_hz = MIXER_GetSampleRate();
+	ms_per_audio_frame             = millis_in_second / audio_frame_rate_hz;
 
 	mt32_service->setAnalogOutputMode(ANALOG_MODE);
 	mt32_service->selectRendererType(RENDERING_TYPE);
-	mt32_service->setStereoOutputSampleRate(frame_rate_hz);
+	mt32_service->setStereoOutputSampleRate(audio_frame_rate_hz);
 	mt32_service->setSamplerateConversionQuality(RATE_CONVERSION_QUALITY);
 	mt32_service->setDACInputMode(DAC_MODE);
 	mt32_service->setNiceAmpRampEnabled(USE_NICE_RAMP);
@@ -611,14 +611,14 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	                                      std::placeholders::_1);
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                      frame_rate_hz,
+	                                      audio_frame_rate_hz,
 	                                      "MT32",
 	                                      {ChannelFeature::Sleep,
 	                                       ChannelFeature::Stereo,
 	                                       ChannelFeature::Synthesizer});
 
-	// libmt32emu renders float frames between -1.0f and +1.0f, so we ask the
-	// channel to scale all the samples up to it's 0db level.
+	// libmt32emu renders float audio frames between -1.0f and +1.0f, so we
+	// ask the channel to scale all the samples up to it's 0db level.
 	mixer_channel->Set0dbScalar(MAX_AUDIO);
 
 	const auto section = static_cast<Section_prop *>(control->GetSection("mt32"));
@@ -635,14 +635,32 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 		mixer_channel->SetLowPassFilter(FilterState::Off);
 	}
 
-	// Double the baseline PCM prebuffer because MIDI is demanding
+	// Double the baseline PCM prebuffer because MIDI is demanding and
+	// bursty. The Mixer's default of ~20 ms becomes 40 ms here, which gives
+	// slower systems a better to keep up (and prevent their audio frame
+	// FIFO from running dry).
 	const auto render_ahead_ms = MIXER_GetPreBufferMs() * 2;
 
-	static constexpr auto max_frames_per_ms = 48;
-	frame_fifo.Resize(render_ahead_ms * max_frames_per_ms);
+	// Size the out-bound audio frame FIFO
+	assert(audio_frame_rate_hz > 8000); // sane lower-bound of 8 KHz
+	const auto audio_frames_per_ms = iround(audio_frame_rate_hz / millis_in_second);
+	audio_frame_fifo.Resize(
+	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));
 
-	static constexpr auto max_midi_msg_per_ms = 255;
-	work_fifo.Resize(render_ahead_ms * max_midi_msg_per_ms);
+	// Size the in-bound work FIFO
+
+	// MIDI has a Baud rate of 31250; at optimum this is 31250 bits per
+	// second. A MIDI byte is 8 bits plus a start and stop bit, and each
+	// MIDI message is three bytes, which gives a total of 30 bits per
+	// message. This means that under optimal conditions, a maximum of 1042
+	// messages per second can be obtained via > the MIDI protocol.
+
+	// We have measured DOS games sending hundreds of MIDI messages within a
+	// short handful of millseconds, so a safe but very generous upper bound
+	// is used (Note: the actual memory used by the FIFO is incremental
+	// based on actual usage).
+	static constexpr uint16_t midi_spec_max_msg_rate_hz = 1042;
+	work_fifo.Resize(midi_spec_max_msg_rate_hz * 10);
 
 	// If we haven't failed yet, then we're ready to begin so move the local
 	// objects into the member variables.
@@ -678,8 +696,8 @@ void MidiHandler_mt32::Close()
 
 	// Stop rendering and drain the fifo
 	keep_rendering = false;
-	while (frame_fifo.Size()) {
-		[[maybe_unused]] auto frame = frame_fifo.Dequeue();
+	while (audio_frame_fifo.Size()) {
+		(void)audio_frame_fifo.Dequeue();
 	}
 
 	// Wait for the rendering thread to finish
@@ -702,12 +720,12 @@ void MidiHandler_mt32::Close()
 	service.reset();
 
 	last_rendered_ms = 0.0;
-	ms_per_frame     = 0.0;
+	ms_per_audio_frame = 0.0;
 
 	is_open          = false;
 }
 
-uint16_t MidiHandler_mt32::GetNumPendingFrames()
+uint16_t MidiHandler_mt32::GetNumPendingAudioFrames()
 {
 	const auto now_ms = PIC_FullIndex();
 
@@ -720,12 +738,13 @@ uint16_t MidiHandler_mt32::GetNumPendingFrames()
 	if (last_rendered_ms >= now_ms) {
 		return 0;
 	}
-	// Return the number of frames needed to get current again
-	assert(ms_per_frame > 0.0);
+	// Return the number of audio frames needed to get current again
+	assert(ms_per_audio_frame > 0.0);
 	const auto elapsed_ms = now_ms - last_rendered_ms;
-	const auto frames     = iround(ceil(elapsed_ms / ms_per_frame));
-	last_rendered_ms += (frames * ms_per_frame);
-	return check_cast<uint16_t>(frames);
+
+	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
+	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
+	return check_cast<uint16_t>(num_audio_frames);
 }
 
 // The request to play the channel message is placed in the MIDI work FIFO
@@ -733,7 +752,9 @@ void MidiHandler_mt32::PlayMsg(const uint8_t *msg)
 {
 	constexpr auto channel_len = 4;
 	std::vector<uint8_t> message(msg, msg + channel_len);
-	MidiWork work{std::move(message), GetNumPendingFrames(), MessageType::Channel};
+	MidiWork work{std::move(message),
+	              GetNumPendingAudioFrames(),
+	              MessageType::Channel};
 	work_fifo.Enqueue(std::move(work));
 }
 
@@ -741,18 +762,19 @@ void MidiHandler_mt32::PlayMsg(const uint8_t *msg)
 void MidiHandler_mt32::PlaySysex(uint8_t *sysex, size_t len)
 {
 	std::vector<uint8_t> message(sysex, sysex + len);
-	MidiWork work{std::move(message), GetNumPendingFrames(), MessageType::SysEx};
+	MidiWork work{std::move(message), GetNumPendingAudioFrames(), MessageType::SysEx};
 	work_fifo.Enqueue(std::move(work));
 }
 
-// The callback operates at the frame-level, steadily adding samples to the
-// mixer until the requested numbers of frames is met.
-void MidiHandler_mt32::MixerCallBack(const uint16_t requested_frames)
+// The callback operates at the audio frame-level, steadily adding samples to
+// the mixer until the requested numbers of audio frames is met.
+void MidiHandler_mt32::MixerCallBack(const uint16_t requested_audio_frames)
 {
 	assert(channel);
 
 	constexpr auto warning_percent = 5.0f;
-	if (const auto percent_full = frame_fifo.GetPercentFull(); percent_full < warning_percent) {
+	if (const auto percent_full = audio_frame_fifo.GetPercentFull();
+	    percent_full < warning_percent) {
 		static auto iteration = 0;
 		if (iteration++ % 100 == 0) {
 			LOG_WARNING("MT32: Audio FIFO is %4.2f%% full",
@@ -760,26 +782,26 @@ void MidiHandler_mt32::MixerCallBack(const uint16_t requested_frames)
 		}
 	}
 
-	static std::vector<AudioFrame> frames = {};
-	frame_fifo.BulkDequeue(frames, requested_frames);
-	channel->AddSamples_sfloat(requested_frames, &frames[0][0]);
+	static std::vector<AudioFrame> audio_frames = {};
+	audio_frame_fifo.BulkDequeue(audio_frames, requested_audio_frames);
+	channel->AddSamples_sfloat(requested_audio_frames, &audio_frames[0][0]);
 
 	last_rendered_ms = PIC_FullIndex();
 }
 
-void MidiHandler_mt32::RenderFramesToFifo(const uint16_t num_frames)
+void MidiHandler_mt32::RenderAudioFramesToFifo(const uint16_t num_frames)
 {
-	static std::vector<AudioFrame> frames = {};
+	static std::vector<AudioFrame> audio_frames = {};
 	// Maybe expand the vector
-	if (frames.size() < num_frames) {
-		frames.resize(num_frames);
+	if (audio_frames.size() < num_frames) {
+		audio_frames.resize(num_frames);
 	}
 
 	std::unique_lock<std::mutex> lock(service_mutex);
-	service->renderFloat(&frames[0][0], num_frames);
+	service->renderFloat(&audio_frames[0][0], num_frames);
 	lock.unlock();
 
-	frame_fifo.BulkEnqueue(frames, num_frames);
+	audio_frame_fifo.BulkEnqueue(audio_frames, num_frames);
 }
 
 // The next MIDI work task is processed, which includes rendering audio frames
@@ -790,16 +812,16 @@ void MidiHandler_mt32::ProcessWorkFromFifo()
 
 	/* // Comment-in to log inter-cycle rendering
 	if (work.num_pending_audio_frames > 0) {
-		LOG_MSG("MT32: %2u frames prior to %s message, followed by "
-		        "%2lu more messages. Have %4lu frames queued",
-		        work.num_pending_audio_frames,
-		        work.message_type == MessageType::Channel ? "channel" : "sysex",
-		        work_fifo.Size(),
-		        frame_fifo.Size());
+	        LOG_MSG("MT32: %2u audio frames prior to %s message, followed by
+	"
+	                "%2lu more messages. Have %4lu audio frames queued",
+	                work.num_pending_audio_frames,
+	                work.message_type == MessageType::Channel ? "channel" :
+	"sysex", work_fifo.Size(), audio_frame_fifo.Size());
 	}*/
 
 	if (work.num_pending_audio_frames > 0) {
-		RenderFramesToFifo(work.num_pending_audio_frames);
+		RenderAudioFramesToFifo(work.num_pending_audio_frames);
 	}
 
 	// Request exclusive access prior to applying messages
@@ -818,7 +840,8 @@ void MidiHandler_mt32::ProcessWorkFromFifo()
 void MidiHandler_mt32::Render()
 {
 	while (keep_rendering.load()) {
-		work_fifo.IsEmpty() ? RenderFramesToFifo() : ProcessWorkFromFifo();
+		work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
+		                    : ProcessWorkFromFifo();
 	}
 }
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -610,12 +610,12 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	                                      this,
 	                                      std::placeholders::_1);
 
-	const auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                            frame_rate_hz,
-	                                            "MT32",
-	                                            {ChannelFeature::Sleep,
-	                                             ChannelFeature::Stereo,
-	                                             ChannelFeature::Synthesizer});
+	auto mixer_channel = MIXER_AddChannel(mixer_callback,
+	                                      frame_rate_hz,
+	                                      "MT32",
+	                                      {ChannelFeature::Sleep,
+	                                       ChannelFeature::Stereo,
+	                                       ChannelFeature::Synthesizer});
 
 	// libmt32emu renders float frames between -1.0f and +1.0f, so we ask the
 	// channel to scale all the samples up to it's 0db level.

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -65,13 +65,13 @@ private:
 	void MixerCallBack(uint16_t len);
 	void ProcessWorkFromFifo();
 
-	uint16_t GetNumPendingFrames();
-	void RenderFramesToFifo(const uint16_t num_frames = 1);
+	uint16_t GetNumPendingAudioFrames();
+	void RenderAudioFramesToFifo(const uint16_t num_frames = 1);
 	void Render();
 
 	// Managed objects
 	mixer_channel_t channel = nullptr;
-	RWQueue<AudioFrame> frame_fifo{1};
+	RWQueue<AudioFrame> audio_frame_fifo{1};
 	RWQueue<MidiWork> work_fifo{1};
 
 	std::mutex service_mutex = {};
@@ -82,7 +82,7 @@ private:
 	// Used to track the balance of time between the last mixer callback
 	// versus the current MIDI Sysex or Msg event.
 	double last_rendered_ms = 0.0;
-	double ms_per_frame     = 0.0;
+	double ms_per_audio_frame = 0.0;
 
 	std::atomic_bool keep_rendering = {};
 	bool is_open = false;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -1,8 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2012-2021  sergm <sergm@bigmir.net>
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -62,30 +61,28 @@ public:
 	void PrintStats();
 
 private:
-	uint32_t GetMidiEventTimestamp() const;
 	service_t GetService();
 	void MixerCallBack(uint16_t len);
-	uint16_t GetRemainingFrames();
+	void ProcessWorkFromFifo();
+
+	uint16_t GetNumPendingFrames();
+	void RenderFramesToFifo(const uint16_t num_frames = 1);
 	void Render();
 
 	// Managed objects
 	mixer_channel_t channel = nullptr;
-
-	std::vector<float> play_buffer = {};
-	static constexpr auto num_buffers = 20;
-	RWQueue<std::vector<float>> playable{num_buffers};
-	RWQueue<std::vector<float>> backstock{num_buffers};
+	RWQueue<AudioFrame> frame_fifo{1};
+	RWQueue<MidiWork> work_fifo{1};
 
 	std::mutex service_mutex = {};
 	service_t service = {};
 	std::thread renderer = {};
 	std::optional<model_and_dir_t> model_and_dir = {};
 
-	// The following two members let us determine the total number of played
-	// frames, which is used by GetMidiEventTimestamp() to calculate a total
-	// time offset.
-	uint32_t total_buffers_played = 0;
-	uint16_t last_played_frame = 0; // relative frame-offset in the play buffer
+	// Used to track the balance of time between the last mixer callback
+	// versus the current MIDI Sysex or Msg event.
+	double last_rendered_ms = 0.0;
+	double ms_per_frame     = 0.0;
 
 	std::atomic_bool keep_rendering = {};
 	bool is_open = false;

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -65,19 +65,6 @@ bool RWQueue<T>::IsEmpty()
 }
 
 template <typename T>
-void RWQueue<T>::Enqueue(const T& item)
-{
-	// wait until the queue has room to accept the item
-	std::unique_lock<std::mutex> lock(mutex);
-	has_room.wait(lock, [this] { return queue.size() < capacity; });
-
-	// add it, and notify the next waiting thread that we've got an item
-	queue.emplace(queue.end(), item);
-	lock.unlock();
-	has_items.notify_one();
-}
-
-template <typename T>
 void RWQueue<T>::Enqueue(T&& item)
 {
 	// wait until the queue has room to accept the item

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -23,8 +23,16 @@
 #include <cassert>
 
 template <typename T>
-RWQueue<T>::RWQueue(size_t queue_capacity) : capacity(queue_capacity)
+RWQueue<T>::RWQueue(size_t queue_capacity)
 {
+	Resize(queue_capacity);
+}
+
+template <typename T>
+void RWQueue<T>::Resize(size_t queue_capacity)
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	capacity = queue_capacity;
 	assert(capacity > 0);
 }
 
@@ -39,6 +47,14 @@ template <typename T>
 size_t RWQueue<T>::MaxCapacity() const
 {
 	return capacity;
+}
+
+template <typename T>
+float RWQueue<T>::GetPercentFull()
+{
+	const auto cur_level = static_cast<float>(Size());
+	const auto max_level = static_cast<float>(capacity);
+	return (100.0f * cur_level) / max_level;
 }
 
 template <typename T>

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -197,7 +197,10 @@ void RWQueue<T>::BulkDequeue(std::vector<T>& into_target, const size_t num_reque
 template class RWQueue<int>;
 template class RWQueue<std::vector<int16_t>>;
 
-// FluidSynth and MT-32
+// FluidSynth
+template class RWQueue<std::vector<float>>;
+
+// MT-32
 #include "audio_frame.h"
 template class RWQueue<AudioFrame>;
 

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -197,10 +197,7 @@ void RWQueue<T>::BulkDequeue(std::vector<T>& into_target, const size_t num_reque
 template class RWQueue<int>;
 template class RWQueue<std::vector<int16_t>>;
 
-// FluidSynth
-template class RWQueue<std::vector<float>>;
-
-// MT-32
+// FluidSynth and MT-32
 #include "audio_frame.h"
 template class RWQueue<AudioFrame>;
 

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -101,3 +101,7 @@ template class RWQueue<std::vector<int16_t>>;
 
 // MT-32 and FluidSynth
 template class RWQueue<std::vector<float>>;
+
+
+#include "midi.h"
+template class RWQueue<MidiWork>;

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -197,9 +197,9 @@ void RWQueue<T>::BulkDequeue(std::vector<T>& into_target, const size_t num_reque
 template class RWQueue<int>;
 template class RWQueue<std::vector<int16_t>>;
 
-// MT-32 and FluidSynth
-template class RWQueue<std::vector<float>>;
-
+// FluidSynth and MT-32
+#include "audio_frame.h"
+template class RWQueue<AudioFrame>;
 
 #include "midi.h"
 template class RWQueue<MidiWork>;

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -45,7 +45,7 @@ template <typename T>
 bool RWQueue<T>::IsEmpty()
 {
 	std::lock_guard<std::mutex> lock(mutex);
-	return !queue.size();
+	return queue.empty();
 }
 
 template <typename T>
@@ -81,8 +81,9 @@ T RWQueue<T>::Dequeue()
 {
 	// wait until the queue has an item that we can get
 	std::unique_lock<std::mutex> lock(mutex);
-	while (!queue.size())
+	while (queue.empty()) {
 		has_items.wait(lock);
+	}
 
 	// get it, and notify the first waiting thread that the queue has room
 	T item = std::move(queue.front());

--- a/tests/rwqueue_tests.cpp
+++ b/tests/rwqueue_tests.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2021  The DOSBox Staging Team
+ *  Copyright (C) 2021-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,7 +23,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+
 #include <thread>
+#include <tuple>
 #include <vector>
 
 namespace {
@@ -123,6 +125,197 @@ TEST(RWQueue, TrivialMoveAsync)
 	EXPECT_EQ(q.Size(), 0);
 }
 
+void bulk_enqueue(RWQueue<int>& q, const size_t total_to_enqueue,
+                  const size_t num_per_bulk_enqueue)
+{
+	// Make the index and values match, for easy testing
+	auto i               = 0;
+
+	assert(total_to_enqueue >= num_per_bulk_enqueue);
+	auto remaining_items = total_to_enqueue;
+	auto num_to_enqueue  = num_per_bulk_enqueue;
+
+	std::vector<int> items = {};
+
+	while (remaining_items > 0) {
+		items.push_back(i);
+		--remaining_items;
+
+		if (items.size() == num_to_enqueue) {
+			q.BulkEnqueue(items, num_to_enqueue);
+			EXPECT_TRUE(items.empty());
+
+			num_to_enqueue = std::min(remaining_items,
+			                          num_per_bulk_enqueue);
+		}
+		++i;
+	}
+}
+
+void bulk_dequeue(RWQueue<int>& q, const size_t total_to_dequeue,
+                  const size_t num_per_bulk_dequeue)
+{
+	auto expected_front_val = 0;
+
+	assert(total_to_dequeue >= num_per_bulk_dequeue);
+	auto remaining_items = total_to_dequeue;
+	auto num_to_dequeue  = num_per_bulk_dequeue;
+
+	std::vector<int> items = {};
+
+	while (remaining_items > 0) {
+		num_to_dequeue = std::min(remaining_items, num_per_bulk_dequeue);
+
+		q.BulkDequeue(items, num_to_dequeue);
+		remaining_items -= num_to_dequeue;
+
+		EXPECT_EQ(items.size(), num_to_dequeue);
+
+		EXPECT_EQ(static_cast<int>(items.front()), expected_front_val);
+
+		const auto expected_back_val = expected_front_val +
+		                               (static_cast<int>(num_to_dequeue) - 1);
+		EXPECT_EQ(static_cast<int>(items.back()), expected_back_val);
+
+		expected_front_val = expected_back_val + 1;
+	}
+}
+
+void run_bulk_async_test(const size_t queue_capacity,
+                         const size_t num_per_bulk_enqueue,
+                         const size_t num_per_bulk_dequeue, size_t total_to_queue)
+{
+	assert(total_to_queue >= num_per_bulk_enqueue);
+	assert(total_to_queue >= num_per_bulk_dequeue);
+
+	RWQueue<int> q(queue_capacity);
+
+	std::thread writer(bulk_enqueue, std::ref(q), total_to_queue, num_per_bulk_enqueue);
+	std::thread reader(bulk_dequeue, std::ref(q), total_to_queue, num_per_bulk_dequeue);
+
+	writer.join();
+	reader.join();
+
+	// Make sure we've consumed all produced items and the queue is empty
+	EXPECT_EQ(static_cast<int>(q.Size()), 0);
+}
+
+using bulk_params_t = typename std::tuple<size_t, size_t, size_t, size_t>;
+
+TEST(RWQueue, AsyncBulkIOSingles)
+{
+	for (const auto& [queue_capacity,
+	                  num_per_bulk_enqueue,
+	                  num_per_bulk_dequeue,
+	                  total_to_queue] : {
+
+	             // queue matches total
+	             bulk_params_t{1, 1, 1, 1},
+	             bulk_params_t{50, 1, 1, 50},
+
+	             // queue is smaller than total
+	             bulk_params_t{1, 1, 1, 50},
+	             bulk_params_t{50, 1, 1, 242},
+
+	             // queue exceeds total
+	             bulk_params_t{50, 1, 1, 1},
+	             bulk_params_t{242, 1, 1, 50},
+
+	     }) {
+		run_bulk_async_test(queue_capacity,
+		                    num_per_bulk_enqueue,
+		                    num_per_bulk_dequeue,
+		                    total_to_queue);
+	}
+}
+
+TEST(RWQueue, AsyncBulkIOEqualSizes)
+{
+	for (const auto& [queue_capacity,
+	                  num_per_bulk_enqueue,
+	                  num_per_bulk_dequeue,
+	                  total_to_queue] : {
+
+	             bulk_params_t{50, 10, 10, 10},
+	             bulk_params_t{10, 50, 50, 50},
+	             bulk_params_t{10, 10, 10, 50},
+
+	     }) {
+		run_bulk_async_test(queue_capacity,
+		                    num_per_bulk_enqueue,
+		                    num_per_bulk_dequeue,
+		                    total_to_queue);
+	}
+}
+
+TEST(RWQueue, AsyncBulkIODequeueLargerThanEnqueue)
+{
+	for (const auto& [queue_capacity,
+	                  num_per_bulk_enqueue,
+	                  num_per_bulk_dequeue,
+	                  total_to_queue] : {
+
+	             bulk_params_t{50, 1, 2, 10},
+	             bulk_params_t{10, 2, 5, 50},
+	             bulk_params_t{10, 3, 10, 50},
+
+	     }) {
+		run_bulk_async_test(queue_capacity,
+		                    num_per_bulk_enqueue,
+		                    num_per_bulk_dequeue,
+		                    total_to_queue);
+	}
+}
+
+TEST(RWQueue, AsyncBulkIOSEnqueueLargerThanDequeue)
+{
+	for (const auto& [queue_capacity,
+	                  num_per_bulk_enqueue,
+	                  num_per_bulk_dequeue,
+	                  total_to_queue] : {
+
+	             bulk_params_t{50, 2, 1, 10},
+	             bulk_params_t{10, 5, 2, 50},
+	             bulk_params_t{10, 10, 3, 50},
+
+	     }) {
+		run_bulk_async_test(queue_capacity,
+		                    num_per_bulk_enqueue,
+		                    num_per_bulk_dequeue,
+		                    total_to_queue);
+	}
+}
+
+TEST(RWQueue, AsyncBulkIOSOverSized)
+{
+	for (const auto& [queue_capacity,
+	                  num_per_bulk_enqueue,
+	                  num_per_bulk_dequeue,
+	                  total_to_queue] : {
+
+	             bulk_params_t{1, 20, 1, 20},
+	             bulk_params_t{7, 50, 2, 50},
+	             bulk_params_t{3, 100, 3, 100},
+
+	             bulk_params_t{1, 20, 1, 130},
+	             bulk_params_t{7, 50, 2, 57},
+	             bulk_params_t{3, 100, 3, 340},
+
+	             bulk_params_t{1, 2, 100, 100},
+	             bulk_params_t{9, 5, 20, 20},
+	             bulk_params_t{4, 10, 30, 30},
+
+	             bulk_params_t{1, 2, 100, 130},
+	             bulk_params_t{9, 5, 20, 53},
+	             bulk_params_t{4, 10, 30, 97},
+
+	     }) {
+		run_bulk_async_test(queue_capacity,
+		                    num_per_bulk_enqueue,
+		                    num_per_bulk_dequeue,
+		                    total_to_queue);
+	}
+}
 
 using container_t = std::vector<int16_t>;
 

--- a/tests/rwqueue_tests.cpp
+++ b/tests/rwqueue_tests.cpp
@@ -79,6 +79,7 @@ void rw_consume_trivial(RWQueue<int> *q, const size_t *max_depth)
 	}
 }
 
+/* Copying is disabled
 void rw_produce_copy_trivial(RWQueue<int> *q, const size_t *max_depth)
 {
 	for (int i = 0; i != iterations; ++i) {
@@ -86,6 +87,7 @@ void rw_produce_copy_trivial(RWQueue<int> *q, const size_t *max_depth)
 		EXPECT_TRUE(q->Size() <= *max_depth);
 	}
 }
+ */
 
 void rw_produce_move_trivial(RWQueue<int> *q, const size_t *max_depth)
 {
@@ -95,6 +97,7 @@ void rw_produce_move_trivial(RWQueue<int> *q, const size_t *max_depth)
 	}
 }
 
+/* Copying is disabled
 TEST(RWQueue, TrivialCopyAsync)
 {
 	const size_t max_depth = 8;
@@ -109,6 +112,7 @@ TEST(RWQueue, TrivialCopyAsync)
 	// Make sure we've consumed all produced items and the queue is empty
 	EXPECT_EQ(q.Size(), 0);
 }
+ */
 
 TEST(RWQueue, TrivialMoveAsync)
 {
@@ -331,8 +335,8 @@ TEST(RWQueue,ContainerSerial)
 
 		container_t v(iteration + 1); 
 		v[iteration] = iteration;
-		q.Enqueue(v);
-		EXPECT_EQ(v.size(), iteration + 1); // check copy
+		q.Enqueue(std::move(v));
+		EXPECT_EQ(v.size(), 0); // check move
 
 		EXPECT_EQ(q.MaxCapacity(), 65);
 		EXPECT_EQ(q.Size(), 1);
@@ -379,6 +383,7 @@ void rw_consume_container(RWQueue<container_t> *q, const size_t *max_depth)
 	}
 }
 
+/* Copying is disabled
 void rw_produce_copy_container(RWQueue<container_t> *q, const size_t *max_depth)
 {
 	for (int i = 0; i != iterations; ++i) {
@@ -389,6 +394,7 @@ void rw_produce_copy_container(RWQueue<container_t> *q, const size_t *max_depth)
 		EXPECT_TRUE(q->Size() <= *max_depth);
 	}
 }
+ */
 
 void rw_produce_move_container(RWQueue<container_t> *q, const size_t *max_depth)
 {
@@ -401,6 +407,7 @@ void rw_produce_move_container(RWQueue<container_t> *q, const size_t *max_depth)
 	}
 }
 
+/* Copying is disabled
 TEST(RWQueue,ContainerCopyAsync)
 {
 	const size_t max_depth = 8;
@@ -415,6 +422,7 @@ TEST(RWQueue,ContainerCopyAsync)
 	// Make sure we've consumed all produced items and the queue is empty
 	EXPECT_EQ(q.Size(), 0);
 }
+ */
 
 TEST(RWQueue,ContainerMoveAsync)
 {

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -728,6 +728,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\ansi_code_markup.h" />
+    <ClInclude Include="..\include\audio_frame.h" />
     <ClInclude Include="..\include\bios.h" />
     <ClInclude Include="..\include\bios_disk.h" />
     <ClInclude Include="..\include\bitops.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -789,6 +789,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\include\audio_frame.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\bios.h">
       <Filter>include</Filter>
     </ClInclude>


### PR DESCRIPTION
Up till now, the multi-threaded aspects of our FluidSynth and MT-32 handling code has been structurally quite different than the other audio devices. It operated on large batches of frames, and calculated the passage of time using the number of frames passed to the mixer callback, which is updated once every millisecond.

This PR refactors them to bring them in line with the other audio devices, with the benefit that the threading aspect is maintained.

Context: MIDI operates on a flow of control messages, separated by time, into the player. The player in turn generates audio output,  influenced by the control messages. 

When an external player is used (QT-FluidSynth / Munt / hardware dongle / et..), the process or device itself generates the audio stream in near-realtime. 

However, inside DOSBox when we access these libraries (libmt32emu and libfluidsynth) the task is for us to "draw out" the frames across time. 

This new approach queues the MIDI control messages received as "work" for processing.  Each MIDI work element contains the number of frames to render prior to the message, the message itself, and the type of MIDI message (Channel or Sysex).

A thread processes the queue of work and places the resulting audio frames in a queue, similar to the other audio device code.

Finally, the channel callback pulls frames off the queue. 

With the MIDI work separated in time, by measure of pending frames, any audible effects of the prior control message(s) are rendered at a per-frame granularity.

For example, Space Quest 4's MT-32 channel changes can have very tight timing between messages. Notice the log messages show the same millisecond value, but we see some number of frames between each (with each prior message effecting that change in the audio frames):

![2022-12-29_14-56](https://user-images.githubusercontent.com/1557255/210019290-64d32bf5-53ef-4507-ac3b-b1f59e9c315c.png)

This "queue of work" approach can be applied to other audio devices (letting us thread them too).

Suggest reviewing commit-by-commit. 
