### PR TITLE
Add work-arounds for S3 VESA mode 0x212 (640x480 24-bit)

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -195,4 +195,20 @@ constexpr T remap(const T in_min, const T in_max, const T out_min,
 	return lerp(out_min, out_max, t);
 }
 
+// Compute the closest power of two to the given value.
+// Credit: Bit Twiddling Hacks, Sean Eron Anderson
+// Ref: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+//
+constexpr uint32_t next_power_of_2(uint32_t v)
+{
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+	v++;
+	return v;
+}
+
 #endif

--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -195,19 +195,4 @@ constexpr T remap(const T in_min, const T in_max, const T out_min,
 	return lerp(out_min, out_max, t);
 }
 
-// Explicit instantiations for lerp, invlerp, and remap
-
-template float lerp<float>(const float a, const float b, const float t);
-template double lerp<double>(const double a, const double b, const double t);
-
-template float invlerp<float>(const float a, const float b, const float v);
-template double invlerp<double>(const double a, const double b, const double v);
-
-template float remap<float>(const float in_min, const float in_max,
-                            const float out_min, const float out_max, const float v);
-
-template double remap<double>(const double in_min, const double in_max,
-                              const double out_min, const double out_max,
-                              const double v);
-							
 #endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -66,6 +66,7 @@ constexpr auto vesa_2_0_modes_start = 0x120;
 constexpr uint16_t EGA_HALF_CLOCK = 1 << 0;
 constexpr uint16_t EGA_LINE_DOUBLE = 1 << 1;
 constexpr uint16_t VGA_PIXEL_DOUBLE = 1 << 2;
+constexpr uint16_t S3_POW2_STRIDE   = 1 << 3;
 
 // Refresh rate constants
 constexpr auto REFRESH_RATE_MIN = 23;


### PR DESCRIPTION
Thanks to @joncampbell123:

VBE mode 0x212 is 640x480 24bpp packed mode but with a per scanline stride of 2048 bytes per pixel set aside for the Windows 3.1 driver and the "640x480 (1Meg) 16 million colors" setting, so that the VBE "Get Mode Info" call reflects the proper per-scanline stride instead of the ideal one.
    
This should fix complaints about VBEMP and 640x480 24-bit color mode. Given how minimal the use of the mode is by the Windows 3.1 driver, the 2048 byte mode does not permit setting scan line length or display start i.e. panning is not permitted.

