### PR TITLE
Use presence of desktop environment in mouse capture states

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -88,7 +88,10 @@ void GFX_SetMouseCapture(const bool requested_capture);
 void GFX_SetMouseVisibility(const bool requested_visible);
 void GFX_SetMouseRawInput(const bool requested_raw_input);
 
-#if defined (REDUCE_JOYSTICK_POLLING)
+// Detects the presence of a desktop environment or window manager
+bool GFX_HaveDesktopEnvironment();
+
+#if defined(REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);
 #endif
 


### PR DESCRIPTION
It's possible to run without a desktop environment on Linux and BSD, which is a common usecase on single-board-computers (SBCs). In these configurations, there is nowhere for the mouse to go if its uncaptured (and doing so can cause it to be "lost" or flicker in front o the display), therefore, we want to always keep it captured (similar to fullscreen mode).

This commit checks if we have a desktop environment and use its presence (or lack of) into the mouse state controls.

---

PR Marked as `Bug` + `Raspberry Pi`, because the new default `mouse_capture = onclick` results in a buggy default for these users. This PR fixes it so they start up in a captured stated.

Tested on RetroPie as well as Linux both with and without a desktop environment.