### PR TITLE
Fix slirp/ne2000 warnings

### DIFF
--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -586,19 +586,20 @@ bx_ne2k_c::page0_read(io_port_t offset, io_width_t io_len)
 void
 bx_ne2k_c::page0_write(io_port_t offset, io_val_t data, io_width_t io_len)
 {
-  auto value = check_cast<uint8_t>(data);
-  unsigned int new_value = 0;
-
   BX_DEBUG("page 0 write to port %04x, len=%u", (unsigned)offset, (unsigned)io_len);
 
   // It appears to be a common practice to use outw on page0 regs...
 
   // break up outw into two outb's
   if (io_len == io_width_t::word) {
+    const auto value = check_cast<uint16_t>(data);
     page0_write(offset, (value & 0xff), io_width_t::byte);
     page0_write(offset + 1, ((value >> 8) & 0xff), io_width_t::byte);
     return;
   }
+
+  auto value = check_cast<uint8_t>(data);
+  unsigned int new_value = 0;
 
   switch (offset) {
   case 0x1:  // PSTART

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -404,7 +404,7 @@ struct slirp_timer *SlirpEthernetConnection::TimerNew(SlirpTimerCb cb, void *cb_
 
 void SlirpEthernetConnection::TimerFree(struct slirp_timer *timer)
 {
-	std::remove(timers.begin(), timers.end(), timer);
+	timers.erase(std::remove(timers.begin(), timers.end(), timer), timers.end());
 	delete timer;
 }
 
@@ -451,7 +451,7 @@ void SlirpEthernetConnection::PollUnregister(const int fd)
 	// sentinels
 	if (fd < 0 || registered_fds.empty())
 		return;
-	std::remove(registered_fds.begin(), registered_fds.end(), fd);
+	registered_fds.erase(std::remove(registered_fds.begin(), registered_fds.end(), fd), registered_fds.end());
 }
 
 void SlirpEthernetConnection::PollsAddRegistered()

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -290,10 +290,10 @@ std::map<int, int> SlirpEthernetConnection::SetupPortForwards(const bool is_udp,
 				try {
 					const int port_num = std::stoi(port);
 					ports.push_back(port_num);
-				} catch (std::invalid_argument &e) {
+				} catch ([[maybe_unused]] std::invalid_argument &e) {
 					LOG_WARNING("SLIRP: Invalid %s port: %s", protocol, port.c_str());
 					break;
-				} catch (std::out_of_range &e) {
+				} catch ([[maybe_unused]] std::out_of_range &e) {
 					LOG_WARNING("SLIRP: Invalid %s port: %s", protocol, port.c_str());
 					break;
 				}


### PR DESCRIPTION
I have been playing with getting libslirp working with MSVC, and MSVC threw up some new warnings in the code.

This PR fixes some warnings found in the SLIRP and NE2000 code.

Some of these seem to be actual bugs.