### PR TITLE
Fix logging of some pre-EGA modes

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -510,8 +510,14 @@ void VGA_SetupXGA(void);
 void VGA_AddCompositeSettings(Config &conf);
 
 /* Some support functions */
-std::pair<std::string, std::string> VGA_DescribeType(const VGAModes type,
-                                                     const uint16_t mode);
+
+// Get the current video mode's type and numeric ID
+std::pair<VGAModes, uint16_t> VGA_GetCurrentMode();
+
+// Describes the given video mode's type and ID, ie: "VGA, "256 color"
+std::pair<const char*, const char*> VGA_DescribeMode(const VGAModes video_mode_type,
+                                                     const uint16_t video_mode_id);
+
 void VGA_SetClock(Bitu which, uint32_t target);
 
 // Save, get, and limit refresh and clock functions

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -750,8 +750,8 @@ static void log_display_properties(int source_w, int source_h,
 	const auto scale_y = static_cast<double>(target_h) / source_h;
 	const auto out_par = scale_y / scale_x;
 
-	const auto [type_name, type_colours] = VGA_DescribeType(CurMode->type,
-	                                                        CurMode->mode);
+	const auto [mode_type, mode_id] = VGA_GetCurrentMode();
+	const auto [mode_desc, colours_desc] = VGA_DescribeMode(mode_type, mode_id);
 
 	const char *frame_mode = nullptr;
 	switch (sdl.frame.mode) {
@@ -759,9 +759,8 @@ static void log_display_properties(int source_w, int source_h,
 	case FRAME_MODE::VFR: frame_mode = "VFR"; break;
 	case FRAME_MODE::SYNCED_CFR: frame_mode = "synced CFR"; break;
 	case FRAME_MODE::THROTTLED_VFR: frame_mode = "throttled VFR"; break;
-	case FRAME_MODE::UNSET: break;
+	case FRAME_MODE::UNSET: frame_mode = "Unset frame_mode"; break;
 	}
-	assert(frame_mode);
 
 	// Some DOS FPS rates are double-scanned in hardware, so multiply them
 	// up to avoid confusion (ie: 30 Hz should actually be shown at 60Hz)
@@ -770,15 +769,19 @@ static void log_display_properties(int source_w, int source_h,
 	                                      ? "double-scanned "
 	                                      : "";
 
-	const auto colours = (type_colours == "") ? "" : " " + type_colours;
+	// Double check all the char* string variables
+	assert(mode_desc);
+	assert(colours_desc);
+	assert(double_scanned_str);
+	assert(frame_mode);
 
-	LOG_MSG("DISPLAY: %s %dx%d%s (mode %02Xh) at %s%2.5g Hz %s, scaled"
+	LOG_MSG("DISPLAY: %s %dx%d %s (mode %02Xh) at %s%2.5g Hz %s, scaled"
 	        " to %dx%d with %.4g pixel aspect ratio",
-	        type_name.c_str(),
+	        mode_desc,
 	        source_w,
 	        source_h,
-	        colours.c_str(),
-	        CurMode->mode,
+	        colours_desc,
+	        mode_id,
 	        double_scanned_str,
 	        refresh_rate,
 	        frame_mode,

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -42,38 +42,53 @@ uint32_t ExpandTable[256];
 uint32_t Expand16Table[4][16];
 uint32_t FillTable[16];
 
-std::pair<std::string, std::string> VGA_DescribeType(const VGAModes type, uint16_t mode)
+// Get the current video mode's type and numeric ID
+std::pair<VGAModes, uint16_t> VGA_GetCurrentMode()
+{
+	assert(CurMode != ModeList_VGA.end());
+	return {vga.mode, CurMode->mode};
+}
+
+// Describes the given video mode's type and ID, ie: "VGA, "256 color"
+std::pair<const char*, const char*> VGA_DescribeMode(const VGAModes video_mode_type,
+                                                     const uint16_t video_mode_id)
 {
 	// clang-format off
-	switch (type) {
+	switch (video_mode_type) {
+	case M_HERC_TEXT:          return {"Text",     "monochrome"};
+	case M_HERC_GFX:           return {"Hercules", "monochrome"};
 	case M_TEXT:
-	case M_HERC_TEXT:
 	case M_TANDY_TEXT:
-	case M_CGA_TEXT_COMPOSITE: return std::pair("Text", "");
-	case M_HERC_GFX:           return std::pair("Hercules", "monochrome");
+	case M_CGA_TEXT_COMPOSITE: return {"Text",  "16 color"};
 	case M_CGA2_COMPOSITE:
-	case M_CGA4_COMPOSITE:     return std::pair("CGA",   "composite");
-	case M_CGA2:               return std::pair("CGA",   "2 color");
-	case M_CGA4:               return std::pair("CGA",   "4 color");
-	case M_CGA16:              return std::pair("CGA",   "16 color");
-	case M_TANDY2:             return std::pair("Tandy", "2 color");
-	case M_TANDY4:             return std::pair("Tandy", "4 color");
-	case M_TANDY16:            return std::pair("Tandy", "16 color");
+	case M_CGA4_COMPOSITE:     return {"CGA",   "composite"};
+	case M_CGA2:               return {"CGA",   "2 color"};
+	case M_CGA4:               return {"CGA",   "4 color"};
+	case M_CGA16:              return {"CGA",   "16 color"};
+	case M_TANDY2:             return {"Tandy", "2 color"};
+	case M_TANDY4:             return {"Tandy", "4 color"};
+	case M_TANDY16:            return {"Tandy", "16 color"};
 	case M_EGA: // see comment below
-	    switch (mode) {
-	    case 0x011:            return std::pair("VGA",   "monochrome");
-	    case 0x012:            return std::pair("VGA",   "16 color");
-	    default:               return std::pair("EGA",   "16 color");
+	    switch (video_mode_id) {
+	    case 0x011:            return {"VGA",   "monochrome"};
+	    case 0x012:            return {"VGA",   "16 color"};
+	    default:               return {"EGA",   "16 color"};
 	    }
-	case M_VGA:                return std::pair("VGA",   "8-bit");
-	case M_LIN4:               return std::pair("VESA",  "16 color");
-	case M_LIN8:               return std::pair("VESA",  "8-bit");
-	case M_LIN15:              return std::pair("VESA",  "15-bit");
-	case M_LIN16:              return std::pair("VESA",  "16-bit");
-	case M_LIN24:              return std::pair("VESA",  "24-bit");
-	case M_LIN32:              return std::pair("VESA",  "32-bit");
+	case M_VGA:                return {"VGA",   "8-bit"};
+	case M_LIN4:               return {"VESA",  "16 color"};
+	case M_LIN8:               return {"VESA",  "8-bit"};
+	case M_LIN15:              return {"VESA",  "15-bit"};
+	case M_LIN16:              return {"VESA",  "16-bit"};
+	case M_LIN24:              return {"VESA",  "24-bit"};
+	case M_LIN32:              return {"VESA",  "32-bit"};
+
 	case M_ERROR:
-	default: return std::pair("Unknown", "");
+	default:
+		// Should not occur; log the values and inform the user 
+		LOG_ERR("VIDEO: Unknown mode: %u with ID: %u",
+		        static_cast<uint32_t>(video_mode_type),
+		        video_mode_id);
+		return {"Unknown mode", "nknown color-depth"};
 	}
 	// clang-format on
 


### PR DESCRIPTION
Noticed some modes are not logged correctly, for example:

![2023-01-02_19-50](https://user-images.githubusercontent.com/1557255/210298136-d747f969-df8e-48c9-b6d9-71b238eba455.png)

Now:

![2023-01-02_19-26](https://user-images.githubusercontent.com/1557255/210298175-860a9431-a081-4317-91c3-5070ea43c8ab.png)

