### PR TITLE
  Use extended ASCII check in MORE command 

### DIFF
--- a/src/dos/program_more_output.cpp
+++ b/src/dos/program_more_output.cpp
@@ -275,12 +275,7 @@ MoreOutputBase::UserDecision MoreOutputBase::DisplaySingleStream()
 			}
 		}
 		if (!is_state_ansi && (current_column == previous_column) &&
-#if (CHAR_MIN == 0) // 'char' is unsigned
-		    (code >= ' ') &&
-#else // 'char' is signed
-		    (code >= ' ' || code < 0) &&
-#endif
-		    (code != code_del)) {
+		    is_extended_printable_ascii(code)) {
 			// Alphanumeric character outside of ANSI sequence
 			// always changes the current column - if not, the
 			// output must have been redirected


### PR DESCRIPTION
@FeralChild64 , the new ARM builders are hitting this warning on the 0.80.x branch:

```
../src/dos/program_more_output.cpp:197:50: warning:
comparison is always false due to limited range of
data type [-Wtype-limits]
```

Because `char` is unsigned on ARM.  I put together this commit to address it - but then saw you already included a work-around for it in `main`, as part of the larger MORE enhancements.

If you think this is an improvement (I'm thinking we can leverage these ASCII checkers more broadly now, too), then I can backport it.