### PR TITLE
Update Readme.md to add pkgconfig for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ sudo apt install meson
 ``` shell
 # Arch, Manjaro
 sudo pacman -S ccache gcc meson alsa-lib libpng sdl2 sdl2_image sdl2_net \
-               opusfile fluidsynth libslirp speexdsp libxi
+               opusfile fluidsynth libslirp speexdsp libxi pkgconf
 ```
 
 ``` shell


### PR DESCRIPTION
This is required by Meson to build at the last step.

https://archlinux.org/packages/core/x86_64/pkgconf/

@kcgen 