### PR TITLE
Cleanup handling of host GUI keyboard buttons

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2133,8 +2133,7 @@ static void CreateLayout() {
 	AddKeyButtonEvent(PX(12), PY(5), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
 	AddKeyButtonEvent(PX(14), PY(5), BW * 2, BH, MMOD1_NAME, "rctrl", KBD_rightctrl);
 #else
-	AddKeyButtonEvent(PX(10), PY(5), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
-	AddKeyButtonEvent(PX(12), PY(5), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
+	AddKeyButtonEvent(PX(10), PY(5), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
 #endif
 
 	/* Arrow Keys */
@@ -2439,9 +2438,9 @@ static struct {
                    {"lctrl", SDL_SCANCODE_LCTRL},
 #if !defined(MACOSX)
                    {"rctrl", SDL_SCANCODE_RCTRL},
+                   {"rgui", SDL_SCANCODE_RGUI},
 #endif
                    {"lgui", SDL_SCANCODE_LGUI},
-                   {"rgui", SDL_SCANCODE_RGUI},
                    {"comma", SDL_SCANCODE_COMMA},
                    {"period", SDL_SCANCODE_PERIOD},
                    {"slash", SDL_SCANCODE_SLASH},
@@ -2516,8 +2515,10 @@ static void CreateDefaultBinds() {
 	CreateStringBind(buffer);
 	sprintf(buffer, "mod_2 \"key %d\"", SDL_SCANCODE_LALT);
 	CreateStringBind(buffer);
+#if !defined(MACOSX)
 	sprintf(buffer, "mod_3 \"key %d\"", SDL_SCANCODE_RGUI);
 	CreateStringBind(buffer);
+#endif
 	sprintf(buffer, "mod_3 \"key %d\"", SDL_SCANCODE_LGUI);
 	CreateStringBind(buffer);
 	for (const auto &handler_event : handlergroup) {

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -434,9 +434,13 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_pagedown:extend=true;ret=81;break;
 	case KBD_insert:extend=true;ret=82;break;
 	case KBD_delete:extend=true;ret=83;break;
-	case KBD_leftgui:extend=true;ret=90;break;
-	case KBD_rightgui:extend=true;ret=89;break;
-	
+
+	 // The IBM PC XT and AT keyboard layouts lack GUI keys, so we don't
+	 // generate event codes for them. For reference, see the IBM Model F XT
+	 // (1981) and M AT (1986) layouts.
+	case KBD_leftgui:
+	case KBD_rightgui: break;
+
 	case KBD_pause:
 		KEYBOARD_AddBuffer(0xe1);
 		KEYBOARD_AddBuffer(29|(pressed?0:0x80));


### PR DESCRIPTION
 - The right-GUI button [doesn't exist on macOS layouts](https://support.apple.com/en-ca/guide/imac/apd0e7983e19/2021/mac/11.3) (so this PR snips it out from the mapper for macOS).

 - The IBM PC XT and AT keyboard layouts lack GUI keys, (so this PR  avoids generating event codes into DOS). 

> _"The IBM Model F XT Keyboard (1981) had 83 keys including 10 function keys down the left-hand side."_
> ![IBM_Model_F_XT_kbd](https://user-images.githubusercontent.com/1557255/211173324-1fc3aac8-491c-4f75-b733-2ee6c2b9cd06.jpg)


> _"The AT keyboard design was updated in 1986 with the introduction of the IBM "Model M" keyboard, a design which remains relatively unchanged even today. The function keys were moved to the top and F11 and F12 added, and depending on your country's layout had anywhere from 101 to 106 keys. The UK keyboard layout got 102 keys."_
> ![IBM_Model_M](https://user-images.githubusercontent.com/1557255/211173308-630eb4d8-688f-4b12-8e46-68b4e3c8b0aa.png)

Credit: http://dosdays.co.uk/topics/xt_vs_at_keyboards.php
