### PR TITLE
Modify deploy website workflow to deploy to the GitHub Pages org repo

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -6,10 +6,21 @@ jobs:
   build_and_deploy_website:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repository
+      - name: Check out MkDocs sources
         uses: actions/checkout@v3
         with:
+          ref: main
           submodules: false
+          path: dosbox-staging
+
+      - name: Check out organisation GitHub Pages repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ACCESS_TOKEN_REPO }}
+          repository: dosbox-staging/dosbox-staging.github.io
+          ref: master
+          submodules: false
+          path: dosbox-staging.github.io
 
       - name: Install mkdocs
         run: |
@@ -18,6 +29,8 @@ jobs:
 
       - name: Build & deploy website
         run: |
-          cd website
-          mkdocs gh-deploy --force
+          cd dosbox-staging.github.io
+          mkdocs gh-deploy \
+              --config-file ../dosbox-staging/website/mkdocs.yml \
+              --remote-branch master --force
 


### PR DESCRIPTION
With this change the workflow running in this repo will push the generated output to the `master` branch of our GitHub Pages organisation repo that publishes to https://dosbox-staging.github.io

We need an access token to be generated for this to work (I think only you can do that @kcgen). The token needs to be stored as a secret in this repository under the name `ACCESS_TOKEN_REPO`.

Either of the below two methods would work, I've tested both of them on forked repos.

## Fine-grained access token

A fine-grained access token only for the `dosbox-staging.github.io` GitHub Pages org repo with **Contents** repository permissions (I recommend setting the expiration to at least a year from now):

<img width="916" alt="image" src="https://user-images.githubusercontent.com/698770/211181851-aac882e3-ddf6-4a0d-ac8e-48068d0f324b.png">

## Classic access token

Or a classic access token with **repo** access (with no expiration, or an expiration of at least a year from now):

<img width="629" alt="image" src="https://user-images.githubusercontent.com/698770/211182020-b8441d4c-f40b-43ca-a0a4-a5ce1fb3afa3.png">

