### PR TITLE
Handle OEM102 and ABNT1 keyboard scancodes

### DIFF
--- a/contrib/sdl_key_logger/README.md
+++ b/contrib/sdl_key_logger/README.md
@@ -11,13 +11,67 @@ keyboard keys and SDL's enumerated scancodes and sdlk values.
 
 ## Build
 
-``` shell
+```shell
 meson setup build
 meson compile -C build
 ```
 
 ## Run
 
-``` shell
+```shell
   ./build/logger
 ```
+
+## Add handling for a new key
+
+Pre-requisite: the physical keyboard with the (currently)
+unhandled key
+
+1. Compile and run the logger. Press the unhandled key and get
+   the SDL scancode number for the key (get the decimal value, not
+   the hex value).
+
+2. Using the key's SDL scancode number, open SDL's
+   `SDL_scancode.h` header and find the corresponding enum key
+   name.
+
+3. In `sdl_mapper.cpp`:
+
+   - Confirm the SDL enum name doesn't exist (yet) in this
+     file.
+
+   - Add the SDL enum and a corresponding new shorthand string
+     to the DefaultKeys[] array.
+
+   - add the key's default symbol and your new shorthand name
+     to the best KeyBlock array, along with a new KBD\_<name> for
+     the key
+
+   - if the logger didn't report a text scancode name for the
+     key, then add your new shorthand name for it in
+     GetBindName(), similar to 'oem102' and 'abnt1', for which
+     SDL also doesn't have SDL scancode names.
+
+4. In keyboard.h and .cpp:
+
+   - Using http://kbdlayout.info using the correct arrangement,
+     look up the key's (non-SDL) scancode hex value.
+
+   - Convert that (non-SDL) hex scancode to decimal value.
+
+   - Add your new KBD_shortname enum name KEYBOARD_AddKey()
+     switch statement, with the ret=<value> being the (non-SDL)
+     scancode decimal value.
+
+5. In bios_keyboard.cpp's get_key_codes_for() function:
+
+   - Find (or add) the decimal index entry matching the ret=
+     (non-SDL) scancode decimal value.
+
+   - Add four codes for the key, matching the same pattern (or
+     use existing code). For example, the codes usually start
+     with the high-byte being the hex value of the (non-SDL)
+     scancode number.
+
+For a graphical layout of this process, see the image attached
+in PR: https://github.com/dosbox-staging/dosbox-staging/pull/2209

--- a/include/bios.h
+++ b/include/bios.h
@@ -112,8 +112,11 @@
 #define BIOS_DEFAULT_IRQ2_LOCATION		(RealMake(0xf000,0xff55))
 #define BIOS_DEFAULT_RESET_LOCATION		(RealMake(0xf000,(machine==MCH_PCJR)?0x0043:0xe05b))
 
-/* maximum of scancodes handled by keyboard bios routines */
-#define MAX_SCAN_CODE 0x59
+// The maximum "normal key" scancode value handled by keyboard bios routines.
+// This should match the maximum return value set in KEYBOARD_AddKey()'s switch
+// statement. The scan code is read from an 8-bit register (reg_al) and
+// therefore limited to handling 255 keys.
+constexpr uint8_t MAX_SCAN_CODE = 115;
 
 /* The Section handling Bios Disk Access */
 //#define BIOS_MAX_DISK 10

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -32,22 +32,19 @@ enum KBD_KEYS {
 	KBD_f1,  KBD_f2,  KBD_f3,  KBD_f4,  KBD_f5,  KBD_f6,
 	KBD_f7,  KBD_f8,  KBD_f9,  KBD_f10, KBD_f11, KBD_f12,
 
-	// Now the weirder keys
-
 	KBD_esc, KBD_tab, KBD_backspace, KBD_enter, KBD_space,
 
 	KBD_leftalt,   KBD_rightalt,
 	KBD_leftctrl,  KBD_rightctrl,
 	KBD_leftgui,   KBD_rightgui, // 'windows' keys
 	KBD_leftshift, KBD_rightshift,
-	
+
 	KBD_capslock, KBD_scrolllock, KBD_numlock,
 
 	KBD_grave, KBD_minus, KBD_equals, KBD_backslash,
 	KBD_leftbracket, KBD_rightbracket,
 	KBD_semicolon, KBD_quote,
-	KBD_period, KBD_comma, KBD_slash,
-	KBD_extra_lt_gt,
+	KBD_oem102, KBD_period, KBD_comma, KBD_slash, KBD_abnt1,
 
 	KBD_printscreen, KBD_pause,
 
@@ -59,8 +56,6 @@ enum KBD_KEYS {
 	KBD_kp1, KBD_kp2, KBD_kp3, KBD_kp4, KBD_kp5, KBD_kp6, KBD_kp7, KBD_kp8, KBD_kp9, KBD_kp0,
 	KBD_kpdivide, KBD_kpmultiply, KBD_kpminus, KBD_kpplus,
 	KBD_kpenter, KBD_kpperiod,
-
-	KBD_intl1,
 
 	KBD_LAST,
 // clang-format on

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -19,13 +19,14 @@
 #include "dosbox.h"
 #include "keyboard.h"
 
+#include "bios.h"
 #include "bitops.h"
 #include "inout.h"
-#include "pic.h"
 #include "mem.h"
 #include "mixer.h"
-#include "timer.h"
+#include "pic.h"
 #include "support.h"
+#include "timer.h"
 
 #define KEYBUFSIZE 32
 #define KEYDELAY   0.300 // Considering 20-30 khz serial clock and 11 bits/char
@@ -365,6 +366,7 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_grave:ret=41;break;
 	case KBD_leftshift:ret=42;break;
 	case KBD_backslash:ret=43;break;
+	case KBD_oem102: ret = 86; break;
 	case KBD_z:ret=44;break;
 	case KBD_x:ret=45;break;
 	case KBD_c:ret=46;break;
@@ -376,6 +378,7 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_comma:ret=51;break;
 	case KBD_period:ret=52;break;
 	case KBD_slash:ret=53;break;
+	case KBD_abnt1: ret = 115; break;
 	case KBD_rightshift:ret=54;break;
 	case KBD_kpmultiply:ret=55;break;
 	case KBD_leftalt:ret=56;break;
@@ -410,16 +413,10 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_kp0:ret=82;break;
 	case KBD_kpperiod:ret=83;break;
 
-	case KBD_extra_lt_gt:ret=86;break;
 	case KBD_f11:ret=87;break;
 	case KBD_f12:ret=88;break;
 
-	// International keys
-
-	case KBD_intl1:ret=89;break;
-
 	//The Extended keys
-
 	case KBD_kpenter:extend=true;ret=28;break;
 	case KBD_rightctrl:extend=true;ret=29;break;
 	case KBD_kpdivide:extend=true;ret=53;break;
@@ -434,8 +431,8 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_pagedown:extend=true;ret=81;break;
 	case KBD_insert:extend=true;ret=82;break;
 	case KBD_delete:extend=true;ret=83;break;
-	case KBD_leftgui:extend=true;ret=90;break;
-	case KBD_rightgui:extend=true;ret=89;break;
+	case KBD_leftgui:extend=true;ret=91;break;
+	case KBD_rightgui:extend=true;ret=92;break;
 	
 	case KBD_pause:
 		KEYBOARD_AddBuffer(0xe1);
@@ -452,6 +449,8 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 		E_Exit("Unsupported key press");
 		break;
 	}
+	assert(ret <= MAX_SCAN_CODE);
+
 	/* Add the actual key in the keyboard queue */
 	if (pressed) {
 		if (keyb.repeat.key == keytype) keyb.repeat.wait = keyb.repeat.rate;


### PR DESCRIPTION
The mapper, keyboard, and BIOS tables are expanded to handle the `oem102` and `abnt1` keys (found on Brazilian ABNT2 keyboards).

The left and right windows keys are given their correct scancodes (91 and 92).

Ref: http://www.quadibloc.com/comp/scan.htm, thanks to @FeralChild64 for this.

Non-functional changes:
 - The BIOS table of keys is moved inside an accessor function where the lookup index is validated.

 - Each key in the BIOS table of keys is prefixed with its index as a comment. This can be used as a debugging aid, for example: you can directly lookup the key being used by printing the index.

 - Type narrowing is fixed and checked (as a separate commit)

Fixes #2199 