### PR TITLE
Sync flatpak metadata up to `0.81.0-alpha`

### DIFF
--- a/contrib/linux/dosbox-staging.metainfo.xml
+++ b/contrib/linux/dosbox-staging.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2020-2022  The DOSBox Staging Team -->
+<!-- Copyright (C) 2020-2023  The DOSBox Staging Team -->
 <component type="desktop">
   <id>io.github.dosbox-staging</id>
   <metadata_license>CC0-1.0</metadata_license>
@@ -58,6 +58,9 @@
     <category>Emulator</category>
   </categories>
   <releases>
+    <release version="0.81.0-alpha" date="2023-12-20"/>
+    <release version="0.80.1" date="2023-01-06"/>
+    <release version="0.80.0" date="2022-12-20"/>
     <release version="0.79.1" date="2022-09-30"/>
     <release version="0.79.0" date="2022-09-19"/>
     <release version="0.78.1" date="2022-01-07"/>


### PR DESCRIPTION
Thanks to @rderooy for flagging this.

---

Notes for those who might create their own flatpak builds: 

The main branch should only be used for testing or personal builds.

The release tags (vMAJOR.MINOR.BUGFIX) held on release branches (release/MAJOR.MINOR.x) should only be used for public releases.

 * branch release/0.80.x - tag v0.80.1 - tag v0.80.0

 * branch release/0.79.x
    - tag v0.79.1
    - tag v0.79.0

 * branch release/0.78.x - tag v0.78.1 - tag v0.78.0

 ...