### PR TITLE
Add a toggle to deactivate DPI awareness

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -146,6 +146,8 @@ struct SDL_Block {
 
 		uint8_t bpp = 0;
 		double dpi_scale = 1.0;
+		bool want_dpi_handling = true;
+
 		bool fullscreen = false;
 
 		// This flag indicates, that we are in the process of switching

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -58,6 +58,9 @@ List of common options:
   --working-dir <path> Set working directory to <path>. DOSBox will act as if
                        started from this directory.
 
+  --ignore-dpi         Ignore display DPI (dots per inch) settings.
+                       May result in a small window on high DPI displays.
+
   -fullscreen          Start in fullscreen mode.
 
   -lang <langfile>     Start with the language specified in <langfile>.


### PR DESCRIPTION
This PR adds a CLI argument to ignore the host's DPI settings. When set, it keeps "dpi_scale" at 1.0 and disables SDL flags.

A conf-file setting is not included: because this would extensive refactoring and this feature is primarily for multi-DOSBox integrators who need consistent window sizing using one set of resolution values across all their DOSBox builds.