### PR TITLE
Normalise config descriptions and add default values to most of them

### DIFF
--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -278,13 +278,13 @@ void LOG_StartUp(void) {
 	/* Register the log section */
 	Section_prop * sect=control->AddSection_prop("log",LOG_Init);
 	Prop_string* Pstring = sect->Add_string("logfile",Property::Changeable::Always,"");
-	Pstring->Set_help("file where the log messages will be saved to");
+	Pstring->Set_help("File where the log messages will be saved to");
 	char buf[64];
 	for (Bitu i = LOG_ALL + 1;i < LOG_MAX;i++) {
 		safe_strcpy(buf, loggrp[i].front);
 		lowcase(buf);
 		Prop_bool* Pbool = sect->Add_bool(buf,Property::Changeable::Always,true);
-		Pbool->Set_help("Enable/Disable logging of this type.");
+		Pbool->Set_help("Enable/disable logging of this type.");
 	}
 //	MSG_Add("LOG_CONFIGFILE_HELP","Logging related options for the debugger.\n");
 }

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -431,7 +431,7 @@ void MOUNT::AddMessages() {
 	        "  [color=white]DRIVE[reset]     the drive letter where the directory will be mounted: A, C, D, ...\n"
 	        "  [color=cyan]DIRECTORY[reset] is the directory on the host OS to be mounted\n"
 	        "  TYPE      type of the directory to mount: dir, floppy, cdrom, or overlay\n"
-	        "  SIZE      free space for the virtual drive (KiB for floppies, MiB otherwise)\n"
+	        "  SIZE      free space for the virtual drive (KB for floppies, MB otherwise)\n"
 	        "  LABEL     drive label name to be used\n"
 	        "\n"
 	        "Notes:\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -444,18 +444,18 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("dosbox", &DOSBOX_RealInit);
 	pstring = secprop->Add_string("language", always, "");
 	pstring->Set_help(
-	        "Select a language to use: de, en, es, fr, it, nl, pl, and ru\n"
+	        "Select a language to use: de, en, es, fr, it, nl, pl, and ru (unset by default)\n"
 	        "Notes: This setting will override the 'LANG' environment, if set.\n"
 	        "       The 'resources/translations' directory bundled with the executable holds\n"
 	        "       these files. Please keep it along-side the executable to support this\n"
 	        "       feature.");
 	pstring = secprop->Add_string("machine", only_at_start, "svga_s3");
 	pstring->Set_values(machines);
-	pstring->Set_help("The type of machine DOSBox tries to emulate.");
+	pstring->Set_help("The type of machine DOSBox tries to emulate ('svga_s3' by default).");
 
 	pstring = secprop->Add_path("captures", always, "capture");
 	pstring->Set_help(
-	        "Directory where things like wave, midi, screenshot get captured.");
+	        "Directory where things like wave, midi, screenshot get captured ('capture' by default).");
 
 #if C_DEBUG
 	LOG_StartUp();
@@ -468,7 +468,7 @@ void DOSBOX_Init()
 	pint = secprop->Add_int("memsize", when_idle, 16);
 	pint->SetMinMax(1, 63);
 	pint->Set_help(
-	        "Amount of memory DOSBox has in megabytes.\n"
+	        "Amount of memory DOSBox has in megabytes (16 by default).\n"
 	        "This value is best left at its default to avoid problems with some games,\n"
 	        "though few games might require a higher value.\n"
 	        "There is generally no speed advantage when raising this value.");
@@ -504,14 +504,14 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("vmemsize", only_at_start, "auto");
 	pstring->Set_values(vmemsize_choices);
 	pstring->Set_help("Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per\n"
-	                  "video adapter.");
+	                  "video adapter ('auto' by default).");
 
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(
 	        "Customize the emulated video mode's frame rate, in Hz:\n"
-	        "default:  The DOS video mode determines the rate (recommended).\n"
-	        "host:     Match the DOS rate to the host rate (see 'host_rate' setting).\n"
-	        "<value>:  Sets the rate to an exact value, between 24.000 and 1000.000 (Hz).\n"
+	        "  default:  The DOS video mode determines the rate (recommended; this is the default).\n"
+	        "  host:     Match the DOS rate to the host rate (see 'host_rate' setting).\n"
+	        "  <value>:  Sets the rate to an exact value, between 24.000 and 1000.000 (Hz).\n"
 	        "We recommend the 'default' rate; otherwise test and set on a per-game basis.");
 
 	const char *vesa_modes_choices[] = {"compatible", "all", "halfline", 0};
@@ -519,17 +519,17 @@ void DOSBOX_Init()
 	Pstring->Set_values(vesa_modes_choices);
 	Pstring->Set_help(
 	        "Controls the selection of VESA 1.2 and 2.0 modes offered:\n"
-	        "  compatible   A tailored selection that maximizes game compatibility.\n"
-	        "               This is recommended along with 4 or 8 MB of video memory.\n"
-	        "  halfline     Supports the low-resolution halfline VESA 2.0 mode used by\n"
+	        "  compatible:  A tailored selection that maximizes game compatibility.\n"
+	        "               This is recommended along with 4 or 8 MB of video memory (default).\n"
+	        "  halfline:    Supports the low-resolution halfline VESA 2.0 mode used by\n"
 	        "               Extreme Assault. Use only if needed, as it's not S3 compatible.\n"
-	        "  all          Offers all modes for a given video memory size, however\n"
+	        "  all:         Offers all modes for a given video memory size, however\n"
 	        "               some games may not use them properly (flickering) or may need\n"
 	        "               more system memory (mem = ) to use them.");
 
 	Pbool = secprop->Add_bool("speed_mods", only_at_start, true);
 	Pbool->Set_help(
-	        "Permit changes known to improve performance. Currently no games are known\n"
+	        "Permit changes known to improve performance (enabled by default). Currently no games are known\n"
 	        "to be affected by this. Please file a bug with the project if you find a\n"
 	        "game that fails when this is set to true so we will list them here.");
 
@@ -548,13 +548,13 @@ void DOSBOX_Init()
 	Pstring->Set_values(autoexec_section_choices);
 	Pstring->Set_help(
 	        "How autoexec sections are handled from multiple config files.\n"
-	        "join      : combines them into one big section (legacy behavior).\n"
-	        "overwrite : use the last one encountered, like other conf settings.");
+	        "  join:      Combine them into one big section (legacy behavior; default).\n"
+	        "  overwrite: Use the last one encountered, like other config settings.");
 
 	Pbool = secprop->Add_bool("automount", only_at_start, true);
 	Pbool->Set_help(
-	        "Mounts 'drives/[c]' directories as drives on startup, where [c] is\n"
-	        "a lower-case drive letter from a to y.  The 'drives' folder can be\n"
+	        "Mount 'drives/[c]' directories as drives on startup, where [c] is\n"
+	        "a lower-case drive letter from a to y (enabled by default). The 'drives' folder can be\n"
 	        "provided relative to the current directory or via built-in resources.\n"
 	        "Mount settings can be optionally provided using a [c].conf file along-\n"
 	        "-side the drive's directory, with content as follows:\n"
@@ -571,12 +571,12 @@ void DOSBOX_Init()
 	Pstring = secprop->Add_string("startup_verbosity", only_at_start, "auto");
 	Pstring->Set_values(verbosity_choices);
 	Pstring->Set_help(
-	        "Controls verbosity prior to displaying the program:\n"
-	        "Verbosity   | Welcome | Early stdout\n"
-	        "high        |   yes   |    yes\n"
-	        "low         |   no    |    yes\n"
-	        "quiet       |   no    |    no\n"
-	        "auto        | 'low' if exec or dir is passed, otherwise 'high'");
+	        "Controls verbosity prior to displaying the program ('auto' by default):\n"
+	        "  Verbosity   | Welcome | Early stdout\n"
+	        "  high        |   yes   |    yes\n"
+	        "  low         |   no    |    yes\n"
+	        "  quiet       |   no    |    no\n"
+	        "  auto        | 'low' if exec or dir is passed, otherwise 'high'");
 
 	secprop = control->AddSection_prop("render", &RENDER_Init, true);
 	secprop->AddEarlyInitFunction(&RENDER_InitShaderSource, true);
@@ -585,15 +585,15 @@ void DOSBOX_Init()
 	pint->Set_help("Consider capping frame-rates using the '[sdl] host_rate' setting.");
 
 	Pbool = secprop->Add_bool("aspect", always, true);
-	Pbool->Set_help("Scales the vertical resolution to produce a 4:3 display aspect\n"
+	Pbool->Set_help("Scale the vertical resolution to produce a 4:3 display aspect\n"
 	                "ratio, matching that of the original standard-definition monitors\n"
-	                "for which the majority of DOS games were designed. This setting\n"
+	                "for which the majority of DOS games were designed (enabled by default). This setting\n"
 	                "only affects video modes that use non-square pixels, such as\n"
-	                "320x200 or 640x400; where as square-pixel modes, such as 640x480\n"
+	                "320x200 or 640x400; whereas square-pixel modes, such as 640x480\n"
 	                "and 800x600, will be displayed as-is.");
 
 	pstring = secprop->Add_string("monochrome_palette", always, "white");
-	pstring->Set_help("Select default palette for monochrome display.\n"
+	pstring->Set_help("Select default palette for monochrome display ('white' by default).\n"
 	                  "Works only when emulating hercules or cga_mono.\n"
 	                  "You can also cycle through available colours using F11.");
 	const char *mono_pal[] = {"white", "paperwhite", "green", "amber", 0};
@@ -601,17 +601,17 @@ void DOSBOX_Init()
 
 	pstring = secprop->Add_string("cga_colors", only_at_start, "default");
 	pstring->Set_help(
-	        "Sets the interpretation of CGA RGBI colors. Affects all machine types capable\n"
+	        "Set the interpretation of CGA RGBI colors. Affects all machine types capable\n"
 	        "of displaying CGA or better graphics. Built-in presets:\n"
 	        "  default:       The canonical CGA palette, as emulated by VGA adapters\n"
 	        "                 (default).\n"
-	        "  tandy [BL]:    Emulation of an idealised Tandy monitor with adjustable\n"
+	        "  tandy <bl>:    Emulation of an idealised Tandy monitor with adjustable\n"
 	        "                 brown level. The brown level can be provided as an optional\n"
 	        "                 second parameter (0 - red, 50 - brown, 100 - dark yellow;\n"
 	        "                 defaults to 50). E.g. tandy 100\n"
 	        "  tandy-warm:    Emulation of the actual color output of an unknown Tandy\n"
 	        "                 monitor.\n"
-	        "  ibm5153 [C]:   Emulation of the actual color output of an IBM 5153 monitor\n"
+	        "  ibm5153 <c>:   Emulation of the actual color output of an IBM 5153 monitor\n"
 	        "                 with a unique contrast control that dims non-bright colors\n"
 	        "                 only. The contrast can be optionally provided as a second\n"
 	        "                 parameter (0 to 100; defaults to 100), e.g. ibm5153 60\n"
@@ -662,28 +662,27 @@ void DOSBOX_Init()
 		"normal", "simple",0 };
 	Pstring = secprop->Add_string("core", when_idle, "auto");
 	Pstring->Set_values(cores);
-	Pstring->Set_help("CPU Core used in emulation. auto will switch to dynamic if available and\n"
+	Pstring->Set_help("CPU core used in emulation ('auto' by default). 'auto' will switch to dynamic if available and\n"
 		"appropriate.");
 
 	const char* cputype_values[] = { "auto", "386", "386_slow", "486_slow", "pentium_slow", "386_prefetch", 0};
 	Pstring = secprop->Add_string("cputype", always, "auto");
 	Pstring->Set_values(cputype_values);
-	Pstring->Set_help("CPU Type used in emulation. auto is the fastest choice.");
+	Pstring->Set_help("CPU type used in emulation ('auto' by default). 'auto' is the fastest choice.");
 
 
 	pmulti_remain = secprop->AddMultiValRemain("cycles", always, " ");
 	pmulti_remain->Set_help(
-		"Number of instructions DOSBox tries to emulate each millisecond.\n"
+		"Number of instructions DOSBox tries to emulate each millisecond ('auto' by default).\n"
 		"Setting this value too high results in sound dropouts and lags.\n"
 		"Cycles can be set in 3 ways:\n"
-		"  'auto'          tries to guess what a game needs.\n"
+		"  auto:           Try to guess what a game needs.\n"
 		"                  It usually works, but can fail for certain games.\n"
-		"  'fixed #number' will set a fixed number of cycles. This is what you usually\n"
-		"                  need if 'auto' fails (Example: fixed 4000).\n"
-		"  'max'           will allocate as much cycles as your computer is able to\n"
-		"                  handle.");
+		"  fixed <number>: Set a fixed number of cycles. This is what you usually\n"
+		"                  need if 'auto' fails (example: fixed 4000).\n"
+		"  max'            Allocate as much cycles as your computer is able to handle.");
 
-	const char* cyclest[] = { "auto","fixed","max","%u",0 };
+	const char* cyclest[] = { "auto", "fixed", "max", "%u", 0 };
 	Pstring = pmulti_remain->GetSection()->Add_string("type", always, "auto");
 	pmulti_remain->SetValue("auto");
 	Pstring->Set_values(cyclest);
@@ -691,13 +690,13 @@ void DOSBOX_Init()
 	pmulti_remain->GetSection()->Add_string("parameters", always, "");
 
 	Pint = secprop->Add_int("cycleup", always, 10);
-	Pint->SetMinMax(1,1000000);
-	Pint->Set_help("Number of cycles added or subtracted with speed control hotkeys.\n"
+	Pint->SetMinMax(1, 1000000);
+	Pint->Set_help("Number of cycles added or subtracted with speed control hotkeys (10 by default).\n"
 	               "Run INTRO and see Special Keys for list of hotkeys.");
 
 	Pint = secprop->Add_int("cycledown", always, 20);
-	Pint->SetMinMax(1,1000000);
-	Pint->Set_help("Setting it lower than 100 will be a percentage.");
+	Pint->SetMinMax(1, 1000000);
+	Pint->Set_help("Setting it lower than 100 will be a percentage (20 by default).");
 
 #if C_FPU
 	secprop->AddInitFunction(&FPU_Init);
@@ -749,24 +748,24 @@ void DOSBOX_Init()
 
 	pstring->Set_values(midi_devices);
 	pstring->Set_help(
-	        "Device that will receive the MIDI data (from the emulated MIDI\n"
-	        "interface - MPU-401). Choose one of the following:\n"
+	        "Device that will receive the MIDI data from the emulated MPU-401 MIDI\n"
+	        "interface ('auto' by default):\n"
 #if C_FLUIDSYNTH
-	        "'fluidsynth', to use the built-in MIDI synthesizer. See the\n"
-	        "       [fluidsynth] section for detailed configuration.\n"
+	        "  fluidsynth:  The built-in MIDI synthesizer. See the\n"
+	        "               [fluidsynth] section for detailed configuration.\n"
 #endif
 #if C_MT32EMU
-	        "'mt32', to use the built-in Roland MT-32 synthesizer.\n"
-	        "       See the [mt32] section for detailed configuration.\n"
+	        "  mt32:        The built-in Roland MT-32 synthesizer.\n"
+	        "               See the [mt32] section for detailed configuration.\n"
 #endif
-	        "'auto', to use the first working external MIDI player. This\n"
-	        "       might be a software synthesizer or physical device.");
+	        "  auto:        The first working external MIDI player. This\n"
+	        "               might be a software synthesizer or physical device.");
 
 	pstring = secprop->Add_string("midiconfig", when_idle, "");
 	pstring->Set_help(
-	        "Configuration options for the selected MIDI interface.\n"
-	        "This is usually the id or name of the MIDI synthesizer you want\n"
-	        "to use (find the id/name with DOS command 'mixer /listmidi').\n"
+	        "Configuration options for the selected MIDI interface (unset by default).\n"
+	        "This is usually the ID or name of the MIDI synthesizer you want\n"
+	        "to use (find the ID/name with DOS command 'mixer /listmidi').\n"
 #if (C_FLUIDSYNTH == 1 || C_MT32EMU == 1)
 	        "- This option has no effect when using the built-in synthesizers\n"
 	        "  (mididevice = fluidsynth or mt32).\n"
@@ -788,7 +787,7 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("mpu401", when_idle, "intelligent");
 	const char *mputypes[] = {"intelligent", "uart", "none", 0};
 	pstring->Set_values(mputypes);
-	pstring->Set_help("Type of MPU-401 to emulate.");
+	pstring->Set_help("MPU-401 mode to emulate ('intelligent' by default).");
 
 #if C_FLUIDSYNTH
 	FLUID_AddConfigSection(control);
@@ -799,7 +798,7 @@ void DOSBOX_Init()
 #endif
 
 #if C_DEBUG
-	secprop=control->AddSection_prop("debug",&DEBUG_Init);
+	secprop = control->AddSection_prop("debug",&DEBUG_Init);
 #endif
 
 	secprop = control->AddSection_prop("sblaster", &SBLASTER_Init, true);
@@ -807,33 +806,33 @@ void DOSBOX_Init()
 	const char* sbtypes[] = {"sb1", "sb2", "sbpro1", "sbpro2", "sb16", "gb", "none", 0};
 	Pstring = secprop->Add_string("sbtype", when_idle, "sb16");
 	Pstring->Set_values(sbtypes);
-	Pstring->Set_help("Type of Sound Blaster to emulate. 'gb' is Game Blaster.");
+	Pstring->Set_help("Type of Sound Blaster to emulate ('sb16' by default). 'gb' is Game Blaster.");
 
 	const char *ios[] = {"220", "240", "260", "280", "2a0", "2c0", "2e0", "300", 0};
 	Phex = secprop->Add_hex("sbbase", when_idle, 0x220);
 	Phex->Set_values(ios);
-	Phex->Set_help("The IO address of the Sound Blaster.");
+	Phex->Set_help("The IO address of the Sound Blaster (220 by default).");
 
-	const char *irqssb[] = {"7", "5", "3", "9", "10", "11", "12", 0};
+	const char *irqssb[] = {"3", "5", "7", "9", "10", "11", "12", 0};
 	Pint = secprop->Add_int("irq", when_idle, 7);
 	Pint->Set_values(irqssb);
-	Pint->Set_help("The IRQ number of the Sound Blaster.");
+	Pint->Set_help("The IRQ number of the Sound Blaster (7 by default).");
 
-	const char *dmassb[] = {"1", "5", "0", "3", "6", "7", 0};
+	const char *dmassb[] = {"0", "1", "3", "5", "6", "7", 0};
 	Pint = secprop->Add_int("dma", when_idle, 1);
 	Pint->Set_values(dmassb);
-	Pint->Set_help("The DMA number of the Sound Blaster.");
+	Pint->Set_help("The DMA number of the Sound Blaster (1 by default).");
 
 	Pint = secprop->Add_int("hdma", when_idle, 5);
 	Pint->Set_values(dmassb);
-	Pint->Set_help("The High DMA number of the Sound Blaster.");
+	Pint->Set_help("The High DMA number of the Sound Blaster (5 by default).");
 
 	Pbool = secprop->Add_bool("sbmixer", when_idle, true);
-	Pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer.");
+	Pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer (enabled by default).");
 
 	pint = secprop->Add_int("sbwarmup", when_idle, 100);
 	pint->Set_help(
-	        "Silence initial DMA audio after card power-on, in milliseconds.\n"
+	        "Silence initial DMA audio after card power-on, in milliseconds (100 by default).\n"
 	        "This mitigates pops heard when starting many SB-based games.\n"
 	        "Reduce this if you notice intial playback is missing audio.");
 	pint->SetMinMax(0, 100);
@@ -844,7 +843,7 @@ void DOSBOX_Init()
 	const char* oplmodes[] = {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", 0};
 	Pstring = secprop->Add_string("oplmode", when_idle, "auto");
 	Pstring->Set_values(oplmodes);
-	Pstring->Set_help("Type of OPL emulation. On 'auto' the mode is determined by 'sbtype'.\n"
+	Pstring->Set_help("Type of OPL emulation ('auto' by default). On 'auto' the mode is determined by 'sbtype'.\n"
 	                  "All OPL modes are AdLib-compatible, except for 'cms'.");
 
 	Pstring = secprop->Add_string("oplemu", deprecated, "");
@@ -870,7 +869,7 @@ void DOSBOX_Init()
 
 	Pbool = secprop->Add_bool("sb_filter_always_on", when_idle, false);
 	Pbool->Set_help("Force the Sound Blaster filter to be always on\n"
-					"(disallow programs from turning the filter off).");
+					"(disallow programs from turning the filter off; disabled by default).");
 
 	Pstring = secprop->Add_string("opl_filter", when_idle, "auto");
 	Pstring->Set_help(
@@ -928,7 +927,7 @@ void DOSBOX_Init()
 	Pstring = secprop->Add_string("tandy", when_idle, "auto");
 	Pstring->Set_values(tandys);
 	Pstring->Set_help(
-	        "Enable Tandy Sound System emulation.\n"
+	        "Enable Tandy Sound System emulation ('auto' by default).\n"
 	        "For 'auto', emulation is present only if machine is set to 'tandy'.");
 
 	Pstring = secprop->Add_string("tandy_filter", when_idle, "on");
@@ -971,7 +970,7 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&PS1AUDIO_Init, true);
 
 	Pbool = secprop->Add_bool("ps1audio", when_idle, false);
-	Pbool->Set_help("Enable IBM PS/1 Audio emulation.");
+	Pbool->Set_help("Enable IBM PS/1 Audio emulation (disabled by default).");
 
 	Pstring = secprop->Add_string("ps1audio_filter", when_idle, "on");
 	Pstring->Set_help(
@@ -991,24 +990,24 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("reelmagic", when_idle, "off");
 	pstring->Set_help(
 	        "ReelMagic (aka REALmagic) MPEG playback support.\n"
-	        "  off:      Disable support (default).\n"
-	        "  cardonly: Initialize the card without loading the FMPDRV.EXE driver.\n"
-	        "  on:       Initialize the card and load the FMPDRV.EXE on start-up.");
+	        "  off:       Disable support (default).\n"
+	        "  cardonly:  Initialize the card without loading the FMPDRV.EXE driver.\n"
+	        "  on:        Initialize the card and load the FMPDRV.EXE on start-up.");
 
 	pstring = secprop->Add_string("reelmagic_key", when_idle, "auto");
 	pstring->Set_help(
 	        "Set the 32-bit magic key used to decode the game's videos.\n"
-	        "  auto:     Use the built-in routines to determine the key (default).\n"
-	        "  common:   Use the most commonly found key, which is 0x40044041.\n"
-	        "  thehorde: Use The Horde's key, which is 0xC39D7088.\n"
-	        "  <custom>: Set a custom key in hex format (e.g., 0x12345678).");
+	        "  auto:      Use the built-in routines to determine the key (default).\n"
+	        "  common:    Use the most commonly found key, which is 0x40044041.\n"
+	        "  thehorde:  Use The Horde's key, which is 0xC39D7088.\n"
+	        "  <custom>:  Set a custom key in hex format (e.g., 0x12345678).");
 
 	pint = secprop->Add_int("reelmagic_fcode", when_idle, 0);
 	pint->Set_help(
 	        "Override the frame rate code used during video playback.\n"
-	        "  0:        No override: attempt automatic rate discovery (default).\n"
-	        "  1 to 7:   Override the frame rate to one the following (use 1 through 7):\n"
-	        "            1=23.976, 2=24, 3=25, 4=29.97, 5=30, 6=50, or 7=59.94 FPS.");
+	        "  0:       No override: attempt automatic rate discovery (default).\n"
+	        "  1 to 7:  Override the frame rate to one the following (use 1 through 7):\n"
+	        "           1=23.976, 2=24, 3=25, 4=29.97, 5=30, 6=50, or 7=59.94 FPS.");
 
 	// Joystick emulation
 	secprop=control->AddSection_prop("joystick",&BIOS_Init,false);//done
@@ -1021,43 +1020,43 @@ void DOSBOX_Init()
 	Pstring = secprop->Add_string("joysticktype", when_idle, "auto");
 	Pstring->Set_values(joytypes);
 	Pstring->Set_help(
-	        "Type of joystick to emulate: auto (default),\n"
-	        "auto     : Detect and use any joystick(s), if possible.,\n"
-	        "2axis    : Support up to two joysticks, each with 2 axis\n"
-	        "4axis    : Support the first joystick only, as a 4-axis type.\n"
-	        "4axis_2  : Support the second joystick only, as a 4-axis type.\n"
-	        "fcs      : Emulate joystick as an original Thrustmaster FCS.\n"
-	        "ch       : Emulate joystick as an original CH Flightstick.\n"
-	        "hidden   : Prevent DOS from seeing the joystick(s), but enable them for\n"
-	        "           mapping.\n"
-	        "disabled : Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
-	        "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
+	        "Type of joystick to emulate:\n"
+	        "  auto:      Detect and use any joystick(s), if possible (default).\n"
+	        "  2axis:     Support up to two joysticks, each with 2 axis\n"
+	        "  4axis:     Support the first joystick only, as a 4-axis type.\n"
+	        "  4axis_2:   Support the second joystick only, as a 4-axis type.\n"
+	        "  fcs:       Emulate joystick as an original Thrustmaster FCS.\n"
+	        "  ch:        Emulate joystick as an original CH Flightstick.\n"
+	        "  hidden:    Prevent DOS from seeing the joystick(s), but enable them for\n"
+	        "             mapping.\n"
+	        "  disabled:  Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
+	          "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
 
 	Pbool = secprop->Add_bool("timed", when_idle, true);
-	Pbool->Set_help("enable timed intervals for axis. Experiment with this option, if your\n"
-	                "joystick drifts (away).");
+	Pbool->Set_help("Enable timed intervals for axis (disabled by default). Experiment with this option, if your\n"
+	                "joystick drifts away.");
 
 	Pbool = secprop->Add_bool("autofire", when_idle, false);
-	Pbool->Set_help("continuously fires as long as you keep the button pressed.");
+	Pbool->Set_help("Continuously fires as long as you keep the button pressed (disabled by default).");
 
 	Pbool = secprop->Add_bool("swap34", when_idle, false);
-	Pbool->Set_help("swap the 3rd and the 4th axis. Can be useful for certain joysticks.");
+	Pbool->Set_help("Swap the 3rd and the 4th axis (disabled by default). Can be useful for certain joysticks.");
 
 	Pbool = secprop->Add_bool("buttonwrap", when_idle, false);
-	Pbool->Set_help("enable button wrapping at the number of emulated buttons.");
+	Pbool->Set_help("Enable button wrapping at the number of emulated buttons (disabled by default).");
 
 	Pbool = secprop->Add_bool("circularinput", when_idle, false);
 	Pbool->Set_help(
-	        "enable translation of circular input to square output.\n"
+	        "Enable translation of circular input to square output (disabled by default).\n"
 	        "Try enabling this if your left analog stick can only move in a circle.");
 
 	Pint = secprop->Add_int("deadzone", when_idle, 10);
 	Pint->SetMinMax(0, 100);
-	Pint->Set_help("the percentage of motion to ignore. 100 turns the stick into a digital one.");
+	Pint->Set_help("The percentage of motion to ignore (10 by default). 100 turns the stick into a digital one.");
 
 	Pbool = secprop->Add_bool("use_joy_calibration_hotkeys", when_idle, false);
 	Pbool->Set_help(
-	        "Activates hotkeys to allow realtime calibration of the joystick's x and y axis.\n"
+	        "Enable hotkeys to allow realtime calibration of the joystick's x and y axis (disabled by default).\n"
 	        "Only consider this if in-game calibration fails and other settings have been\n"
 	        "tried.\n"
 	        " - Ctrl/Cmd+Arrow-keys adjusts the axis' scalar value:\n"
@@ -1073,11 +1072,11 @@ void DOSBOX_Init()
 
 	pstring = secprop->Add_string("joy_x_calibration", when_idle, "auto");
 	pstring->Set_help(
-	        "Apply x-axis calibration parameters from the hotkeys. Default is 'auto'.");
+	        "Apply x-axis calibration parameters from the hotkeys ('auto' by default).");
 
 	pstring = secprop->Add_string("joy_y_calibration", when_idle, "auto");
 	pstring->Set_help(
-	        "Apply Y-axis calibration parameters from the hotkeys. Default is 'auto'.");
+	        "Apply Y-axis calibration parameters from the hotkeys ('auto' by default).");
 
 	secprop = control->AddSection_prop("serial", &SERIAL_Init, true);
 	const char* serials[] = {
@@ -1089,16 +1088,16 @@ void DOSBOX_Init()
 	Pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	pmulti_remain->Set_help(
-	        "set type of device connected to com port.\n"
-	        "Can be disabled, dummy, mouse, modem, nullmodem, direct.\n"
+	        "Set type of device connected to COM port.\n"
+	        "Can be disabled, dummy, mouse, modem, nullmodem, direct ('dummy' by default).\n"
 	        "Additional parameters must be on the same line in the form of\n"
 	        "parameter:value. Parameter for all types is irq (optional).\n"
-	        "for mouse:\n"
-	        "   model, overrides setting from [mouse] section\n"
-	        "for direct: realport (required), rxdelay (optional).\n"
-	        "   (realport:COM1 realport:ttyS0).\n"
-	        "for modem: listenport, sock, baudrate (all optional).\n"
-	        "for nullmodem: server, rxdelay, txdelay, telnet, usedtr,\n"
+	        "- for mouse:\n"
+	        "    model, overrides setting from [mouse] section\n"
+	        "- for direct: realport (required), rxdelay (optional).\n"
+	        "    (realport:COM1 realport:ttyS0).\n"
+	        "- for modem: listenport, sock, baudrate (all optional).\n"
+	        "- for nullmodem: server, rxdelay, txdelay, telnet, usedtr,\n"
 	        "   transparent, port, inhsocket, sock (all optional).\n"
 	        "SOCK parameter specifies the protocol to be used by both sides\n"
 	        "of the conection. 0 for TCP and 1 for ENet reliable UDP.\n"
@@ -1109,64 +1108,64 @@ void DOSBOX_Init()
 	pmulti_remain->SetValue("dummy");
 	Pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
-	pmulti_remain->Set_help("see serial1");
+	pmulti_remain->Set_help("See 'serial1'");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial3", when_idle, " ");
 	Pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	pmulti_remain->SetValue("disabled");
 	Pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
-	pmulti_remain->Set_help("see serial1");
+	pmulti_remain->Set_help("See 'serial1'");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial4", when_idle, " ");
 	Pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	pmulti_remain->SetValue("disabled");
 	Pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
-	pmulti_remain->Set_help("see serial1");
+	pmulti_remain->Set_help("See 'serial1'");
 
 	pstring = secprop->Add_path("phonebookfile", only_at_start, "phonebook.txt");
-	pstring->Set_help("File used to map fake phone numbers to addresses.");
+	pstring->Set_help("File used to map fake phone numbers to addresses ('phonebook.txt' by default).");
 
 	/* All the DOS Related stuff, which will eventually
 	 * start up in the shell */
 	secprop = control->AddSection_prop("dos", &DOS_Init, false); // done
 	secprop->AddInitFunction(&XMS_Init, true);                   // done
 	Pbool = secprop->Add_bool("xms", when_idle, true);
-	Pbool->Set_help("Enable XMS support.");
+	Pbool->Set_help("Enable XMS support (enabled by default).");
 
 	secprop->AddInitFunction(&EMS_Init, true); // done
 	const char* ems_settings[] = {"true", "emsboard", "emm386", "false", 0};
 	Pstring = secprop->Add_string("ems", when_idle, "true");
 	Pstring->Set_values(ems_settings);
 	Pstring->Set_help(
-	        "Enable EMS support. The default (=true) provides the best\n"
+	        "Enable EMS support (enabled by default). Enabled provides the best\n"
 	        "compatibility but certain applications may run better with\n"
-	        "other choices, or require EMS support to be disabled (=false)\n"
+	        "other choices, or require EMS support to be disabled\n"
 	        "to work at all.");
 
 	Pbool = secprop->Add_bool("umb", when_idle, true);
-	Pbool->Set_help("Enable UMB support.");
+	Pbool->Set_help("Enable UMB support (enabled by default).");
 
 	pstring = secprop->Add_string("ver", when_idle, "5.0");
-	pstring->Set_help("Set DOS version (5.0 by default). Specify as major.minor format.\n"
+	pstring->Set_help("Set DOS version (5.0 by default). Specify in major.minor format.\n"
 	                  "A single number is treated as the major version.\n"
 	                  "Common settings are 3.3, 5.0, 6.22, and 7.1.");
 
 	pint = secprop->Add_int("country", when_idle, 0);
 	pint->Set_help("Set DOS country code which will affect country-specific\n"
-	               "information such as date, time, and decimal formats.\n"
+	               "information such as date, time, and decimal formats (0 by default).\n"
 	               "If set to 0, the country code corresponding to the\n"
 	               "selected keyboard layout will be used.");
 
 	Pbool = secprop->Add_bool("expand_shell_variable", when_idle, false);
 	Pbool->Set_help("Enable expanding environment variables such as %PATH%\n"
-	                "while in the DOS command shell. FreeDOS and MS-DOS 7/8\n"
-	                "COMMAND.COM supports this behavior.");
+	                "while in the DOS command shell (disabled by default).\n"
+	                "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
 
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init, true);
 	Pstring = secprop->Add_string("keyboardlayout", when_idle, "auto");
-	Pstring->Set_help("Language code of the keyboard layout (or none).");
+	Pstring->Set_help("Language code of the keyboard layout, or auto ('auto' by default).");
 
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
@@ -1175,7 +1174,7 @@ void DOSBOX_Init()
 #if C_IPX
 	secprop = control->AddSection_prop("ipx", &IPX_Init, true);
 	Pbool   = secprop->Add_bool("ipx", when_idle, false);
-	Pbool->Set_help("Enable ipx over UDP/IP emulation.");
+	Pbool->Set_help("Enable IPX over UDP/IP emulation (enabled by default).");
 #endif
 
 #if C_SLIRP
@@ -1184,11 +1183,11 @@ void DOSBOX_Init()
 	Pbool = secprop->Add_bool("ne2000", when_idle,  true);
 	Pbool->Set_help(
 	        "Enable emulation of a Novell NE2000 network card on a software-based\n"
-	        "network (using libslirp) with properties as follows:\n"
-	        " - 255.255.255.0 : Subnet mask of the 10.0.2.0 virtual LAN.\n"
-	        " - 10.0.2.2      : IP of the gateway and DHCP service.\n"
-	        " - 10.0.2.3      : IP of the virtual DNS server.\n"
-	        " - 10.0.2.15     : First IP provided by DHCP, your IP!\n"
+	        "network (using libslirp) with properties as follows (enabled by default):\n"
+	        " - 255.255.255.0:  Subnet mask of the 10.0.2.0 virtual LAN.\n"
+	        " - 10.0.2.2:       IP of the gateway and DHCP service.\n"
+	        " - 10.0.2.3:       IP of the virtual DNS server.\n"
+	        " - 10.0.2.15:      First IP provided by DHCP, your IP!\n"
 	        "Note: Inside DOS, setting this up requires an NE2000 packet driver,\n"
 	        "      DHCP client, and TCP/IP stack. You might need port-forwarding\n"
 	        "      from the host into the DOS guest, and from your router to your\n"
@@ -1199,7 +1198,7 @@ void DOSBOX_Init()
 	Phex = secprop->Add_hex("nicbase", when_idle, 0x300);
 	Phex->Set_values(nic_addresses);
 	Phex->Set_help(
-	        "The base address of the NE2000 card.\n"
+	        "The base address of the NE2000 card (300 by default).\n"
 	        "Note: Addresses 220 and 240 might not be available as they're assigned\n"
 	        "      to the Sound Blaster and Gravis UltraSound by default.");
 
@@ -1207,15 +1206,15 @@ void DOSBOX_Init()
 	                          "11", "12", "14", "15", 0};
 	Pint = secprop->Add_int("nicirq", when_idle, 3);
 	Pint->Set_values(nic_irqs);
-	Pint->Set_help("The interrupt used by the NE2000 card.\n"
+	Pint->Set_help("The interrupt used by the NE2000 card (3 by default).\n"
 	               "Note: IRQs 3 and 5 might not be available as they're assigned\n"
 	               "      to 'serial2' and the Gravis UltraSound by default.");
 
 	Pstring = secprop->Add_string("macaddr", when_idle, "AC:DE:48:88:99:AA");
-	Pstring->Set_help("The MAC address of the NE2000 card.");
+	Pstring->Set_help("The MAC address of the NE2000 card ('AC:DE:48:88:99:AA' by default).");
 
 	Pstring = secprop->Add_string("tcp_port_forwards", when_idle, "");
-	Pstring->Set_help("Forwards one or more TCP ports from the host into the DOS guest.\n"
+	Pstring->Set_help("Forwards one or more TCP ports from the host into the DOS guest (unset by default).\n"
 	                  "The format is:\n"
 	                  "  port1  port2  port3 ... (e.g., 21 80 443)\n"
 	                  "  This will forward FTP, HTTP, and HTTPS into the DOS guest.\n"
@@ -1235,7 +1234,7 @@ void DOSBOX_Init()
 	                  "  - If conflicting guest ports are given, the latter rule takes precedent.");
 
 	Pstring = secprop->Add_string("udp_port_forwards", when_idle, "");
-	Pstring->Set_help("Forwards one or more UDP ports from the host into the DOS guest.\n"
+	Pstring->Set_help("Forwards one or more UDP ports from the host into the DOS guest (unset by default).\n"
 	                  "The format is the same as for TCP port forwards.");
 #endif
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -451,11 +451,12 @@ void DOSBOX_Init()
 	        "       feature.");
 	pstring = secprop->Add_string("machine", only_at_start, "svga_s3");
 	pstring->Set_values(machines);
-	pstring->Set_help("The type of machine DOSBox tries to emulate ('svga_s3' by default).");
+	pstring->Set_help(
+	        "The type of machine DOSBox tries to emulate ('svga_s3' by default).");
 
 	pstring = secprop->Add_path("captures", always, "capture");
-	pstring->Set_help(
-	        "Directory where things like wave, midi, screenshot get captured ('capture' by default).");
+	pstring->Set_help("Directory where audio, video, MIDI, and screenshot captures get saved\n"
+	                  "('capture' by default).");
 
 #if C_DEBUG
 	LOG_StartUp();
@@ -468,9 +469,9 @@ void DOSBOX_Init()
 	pint = secprop->Add_int("memsize", when_idle, 16);
 	pint->SetMinMax(1, 63);
 	pint->Set_help(
-	        "Amount of memory DOSBox has in megabytes (16 by default).\n"
-	        "This value is best left at its default to avoid problems with some games,\n"
-	        "though few games might require a higher value.\n"
+	        "Amount of memory of the emulated machine has in MiB (16 by default).\n"
+	        "Best leave at the default setting to avoid problems with some games,\n"
+	        "though a few games might require a higher value.\n"
 	        "There is generally no speed advantage when raising this value.");
 
 	const char *mcb_fault_strategies[] = {"deny", "repair", "report", "allow", nullptr};
@@ -483,8 +484,8 @@ void DOSBOX_Init()
 	        "  repair:  Repair (and report) faults using adjacent chain blocks.\n"
 	        "  report:  Report faults but otherwise proceed as-is.\n"
 	        "  allow:   Allow faults to go unreported (hardware behavior).\n"
-	        "The default (deny) is recommended unless a game is failing with MCB corruption\n"
-	        "errors.");
+	        "The default ('deny') is recommended unless a game is failing with MCB\n"
+	        "corruption errors.");
 	pstring->Set_values(mcb_fault_strategies);
 
 	const char *vmemsize_choices[] = {
@@ -509,7 +510,7 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(
 	        "Customize the emulated video mode's frame rate, in Hz:\n"
-	        "  default:  The DOS video mode determines the rate (recommended; this is the default).\n"
+	        "  default:  The DOS video mode determines the rate (recommended; default).\n"
 	        "  host:     Match the DOS rate to the host rate (see 'host_rate' setting).\n"
 	        "  <value>:  Sets the rate to an exact value, between 24.000 and 1000.000 (Hz).\n"
 	        "We recommend the 'default' rate; otherwise test and set on a per-game basis.");
@@ -520,18 +521,20 @@ void DOSBOX_Init()
 	Pstring->Set_help(
 	        "Controls the selection of VESA 1.2 and 2.0 modes offered:\n"
 	        "  compatible:  A tailored selection that maximizes game compatibility.\n"
-	        "               This is recommended along with 4 or 8 MB of video memory (default).\n"
+	        "               This is recommended along with 4 or 8 MB of video memory\n"
+	        "               (default).\n"
 	        "  halfline:    Supports the low-resolution halfline VESA 2.0 mode used by\n"
 	        "               Extreme Assault. Use only if needed, as it's not S3 compatible.\n"
 	        "  all:         Offers all modes for a given video memory size, however\n"
 	        "               some games may not use them properly (flickering) or may need\n"
-	        "               more system memory (mem = ) to use them.");
+	        "               more system memory to use them.");
 
 	Pbool = secprop->Add_bool("speed_mods", only_at_start, true);
 	Pbool->Set_help(
-	        "Permit changes known to improve performance (enabled by default). Currently no games are known\n"
-	        "to be affected by this. Please file a bug with the project if you find a\n"
-	        "game that fails when this is set to true so we will list them here.");
+	        "Permit changes known to improve performance (enabled by default).\n"
+	        "Currently, no games are known to be negatively affected by this.\n"
+	        "Please file a bug with the project if you find a game that fails\n"
+	        "when this is enabled so we will list them here.");
 
 	secprop->AddInitFunction(&CALLBACK_Init);
 	secprop->AddInitFunction(&PIC_Init);//done
@@ -547,17 +550,17 @@ void DOSBOX_Init()
 	Pstring = secprop->Add_string("autoexec_section", only_at_start, "join");
 	Pstring->Set_values(autoexec_section_choices);
 	Pstring->Set_help(
-	        "How autoexec sections are handled from multiple config files.\n"
-	        "  join:      Combine them into one big section (legacy behavior; default).\n"
-	        "  overwrite: Use the last one encountered, like other config settings.");
+	        "How autoexec sections are handled from multiple config files:\n"
+	        "  join:       Combine them into one big section (legacy behavior; default).\n"
+	        "  overwrite:  Use the last one encountered, like other config settings.");
 
 	Pbool = secprop->Add_bool("automount", only_at_start, true);
 	Pbool->Set_help(
-	        "Mount 'drives/[c]' directories as drives on startup, where [c] is\n"
-	        "a lower-case drive letter from a to y (enabled by default). The 'drives' folder can be\n"
+	        "Mount 'drives/[c]' directories as drives on startup, where [c] is a lower-case\n"
+	        "drive letter from 'a' to 'y' (enabled by default). The 'drives' folder can be\n"
 	        "provided relative to the current directory or via built-in resources.\n"
-	        "Mount settings can be optionally provided using a [c].conf file along-\n"
-	        "-side the drive's directory, with content as follows:\n"
+	        "Mount settings can be optionally provided using a [c].conf file along-side\n"
+	        "the drive's directory, with content as follows:\n"
 	        "  [drive]\n"
 	        "  type    = dir, overlay, floppy, or cdrom\n"
 	        "  label   = custom_label\n"
@@ -585,68 +588,72 @@ void DOSBOX_Init()
 	pint->Set_help("Consider capping frame-rates using the '[sdl] host_rate' setting.");
 
 	Pbool = secprop->Add_bool("aspect", always, true);
-	Pbool->Set_help("Scale the vertical resolution to produce a 4:3 display aspect\n"
-	                "ratio, matching that of the original standard-definition monitors\n"
-	                "for which the majority of DOS games were designed (enabled by default). This setting\n"
-	                "only affects video modes that use non-square pixels, such as\n"
-	                "320x200 or 640x400; whereas square-pixel modes, such as 640x480\n"
-	                "and 800x600, will be displayed as-is.");
+	Pbool->Set_help(
+	        "Scale the vertical resolution to produce a 4:3 display aspect ratio, matching\n"
+	        "that of the original monitors the majority of DOS games were designed for\n"
+	        "(enabled by default).\n"
+	        "This setting only affects video modes that use non-square pixels, such as\n"
+	        "320x200 or 640x400; whereas square-pixel modes, such as 640x480\n"
+	        "and 800x600, are displayed as-is.");
 
 	pstring = secprop->Add_string("monochrome_palette", always, "white");
-	pstring->Set_help("Select default palette for monochrome display ('white' by default).\n"
-	                  "Works only when emulating hercules or cga_mono.\n"
-	                  "You can also cycle through available colours using F11.");
-	const char *mono_pal[] = {"white", "paperwhite", "green", "amber", 0};
+	pstring->Set_help(
+	        "Select default palette for monochrome display ('white' by default).\n"
+	        "Works only when emulating 'hercules' or 'cga_mono'.\n"
+	        "You can also cycle through available colours using F11.");
+	const char* mono_pal[] = {"white", "paperwhite", "green", "amber", 0};
 	pstring->Set_values(mono_pal);
 
 	pstring = secprop->Add_string("cga_colors", only_at_start, "default");
 	pstring->Set_help(
-	        "Set the interpretation of CGA RGBI colors. Affects all machine types capable\n"
+	        "Set the interpretation of CGA RGBI colours. Affects all machine types capable\n"
 	        "of displaying CGA or better graphics. Built-in presets:\n"
 	        "  default:       The canonical CGA palette, as emulated by VGA adapters\n"
 	        "                 (default).\n"
-	        "  tandy <bl>:    Emulation of an idealised Tandy monitor with adjustable\n"
-	        "                 brown level. The brown level can be provided as an optional\n"
-	        "                 second parameter (0 - red, 50 - brown, 100 - dark yellow;\n"
+	        "  tandy <bl>:    Emulation of an idealised Tandy monitor with adjustable brown\n"
+	        "                 level. The brown level can be provided as an optional second\n"
+	        "                 parameter (0 - red, 50 - brown, 100 - dark yellow;\n"
 	        "                 defaults to 50). E.g. tandy 100\n"
-	        "  tandy-warm:    Emulation of the actual color output of an unknown Tandy\n"
+	        "  tandy-warm:    Emulation of the actual colour output of an unknown Tandy\n"
 	        "                 monitor.\n"
-	        "  ibm5153 <c>:   Emulation of the actual color output of an IBM 5153 monitor\n"
-	        "                 with a unique contrast control that dims non-bright colors\n"
+	        "  ibm5153 <c>:   Emulation of the actual colour output of an IBM 5153 monitor\n"
+	        "                 with a unique contrast control that dims non-bright colours\n"
 	        "                 only. The contrast can be optionally provided as a second\n"
 	        "                 parameter (0 to 100; defaults to 100), e.g. ibm5153 60\n"
 	        "  agi-amiga-v1, agi-amiga-v2, agi-amiga-v3:\n"
-	        "                 Palettes used by the Amiga ports of Sierra AGI games\n"
-	        "                 (see the manual for further details).\n"
-	        "  agi-amigaish:  A mix of EGA and Amiga colors used by the Sarien\n"
+	        "                 Palettes used by the Amiga ports of Sierra AGI games.\n"
+	        "  agi-amigaish:  A mix of EGA and Amiga colours used by the Sarien\n"
 	        "                 AGI-interpreter.\n"
 	        "  scumm-amiga:   Palette used by the Amiga ports of LucasArts EGA games.\n"
-	        "  colodore:      Commodore 64 inspired colors based on the Colodore palette.\n"
+	        "  colodore:      Commodore 64 inspired colours based on the Colodore palette.\n"
 	        "  colodore-sat:  Colodore palette with 20% more saturation.\n"
 	        "  dga16:         A modern take on the canonical CGA palette with dialed back\n"
 	        "                 contrast.\n"
-	        "You can also set custom colors by specifying 16 space or comma separated color\n"
-	        "values, either as 3 or 6-digit hex codes (e.g. #f00 or #ff0000 for full red),\n"
-	        "or decimal RGB triplets (e.g. (255, 0, 255) for magenta). The 16 colors are\n"
+	        "You can also set custom colours by specifying 16 space or comma separated\n"
+	        "colour values, either as 3 or 6-digit hex codes (e.g. #f00 or #ff0000 for full red),\n"
+	        "or decimal RGB triplets (e.g. (255, 0, 255) for magenta). The 16 colours are\n"
 	        "ordered as follows:\n"
-	        "black, blue, green, cyan, red, magenta, brown, light-grey, dark-grey,\n"
-	        "light-blue, light-green, light-cyan, light-red, light-magenta, yellow,\n"
-	        "and white.\n"
+	        "  black, blue, green, cyan, red, magenta, brown, light-grey, dark-grey,\n"
+	        "  light-blue, light-green, light-cyan, light-red, light-magenta, yellow, white.\n"
 	        "Their default values, shown here in 6-digit hex code format, are:\n"
-	        "#000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555\n"
-	        "#5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 and #ffffff, respectively.");
+	        "  #000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa\n"
+	        "  #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff");
 
 	pstring = secprop->Add_string("scaler", deprecated, "none");
 	pstring->Set_help(
 	        "Software scalers are deprecated in favour of hardware-accelerated options:\n"
-	        " - If you used the normal2x/3x scalers, set a desired 'windowresolution' instead.\n"
-	        " - If you used an advanced scaler, consider one of the 'glshader' options instead.");
+	        "  - If you used the normal2x/3x scalers, set a desired 'windowresolution'\n"
+	        "    instead.\n"
+	        "  - If you used an advanced scaler, consider one of the 'glshader'\n"
+	        "    options instead.");
 
 #if C_OPENGL
 	pstring = secprop->Add_path("glshader", always, "default");
 	pstring->Set_help(
-	        "Options include 'default', 'none', a shader listed using the --list-glshaders\n"
+	        "Set the GLSL shader to use in OpenGL output modes.\n"
+			"Options include 'default', 'none', a shader listed using the --list-glshaders\n"
 	        "command-line argument, or an absolute or relative path to a file.\n"
+			"'default' sets the `interpolation/sharp.glsl` shader.\n"
 	        "In all cases, you may omit the shader's '.glsl' file extension.");
 #endif
 
@@ -654,16 +661,19 @@ void DOSBOX_Init()
 	assert(control);
 	VGA_AddCompositeSettings(*control);
 
-	secprop=control->AddSection_prop("cpu",&CPU_Init,true);//done
-	const char* cores[] = { "auto",
+	secprop = control->AddSection_prop("cpu", &CPU_Init, true); // done
+	const char* cores[] =
+	{ "auto",
 #if (C_DYNAMIC_X86) || (C_DYNREC)
-		"dynamic",
+	  "dynamic",
 #endif
-		"normal", "simple",0 };
+	  "normal",
+	  "simple",
+	  0 };
 	Pstring = secprop->Add_string("core", when_idle, "auto");
 	Pstring->Set_values(cores);
-	Pstring->Set_help("CPU core used in emulation ('auto' by default). 'auto' will switch to dynamic if available and\n"
-		"appropriate.");
+	Pstring->Set_help("CPU core used in emulation ('auto' by default). 'auto' will switch to dynamic\n"
+	                  "if available and appropriate.");
 
 	const char* cputype_values[] = { "auto", "386", "386_slow", "486_slow", "pentium_slow", "386_prefetch", 0};
 	Pstring = secprop->Add_string("cputype", always, "auto");
@@ -673,14 +683,15 @@ void DOSBOX_Init()
 
 	pmulti_remain = secprop->AddMultiValRemain("cycles", always, " ");
 	pmulti_remain->Set_help(
-		"Number of instructions DOSBox tries to emulate each millisecond ('auto' by default).\n"
-		"Setting this value too high results in sound dropouts and lags.\n"
-		"Cycles can be set in 3 ways:\n"
-		"  auto:           Try to guess what a game needs.\n"
-		"                  It usually works, but can fail for certain games.\n"
-		"  fixed <number>: Set a fixed number of cycles. This is what you usually\n"
-		"                  need if 'auto' fails (example: fixed 4000).\n"
-		"  max'            Allocate as much cycles as your computer is able to handle.");
+	        "Number of instructions DOSBox tries to emulate per millisecond\n"
+	        "('auto' by default). Setting this value too high may result in sound drop-outs\n"
+			"and lags.\n"
+	        "Possible settings:\n"
+	        "  auto:            Try to guess what a game needs. It usually works, but can\n"
+	        "                   fail with certain games.\n"
+	        "  fixed <number>:  Set a fixed number of cycles. This is what you usually\n"
+	        "                   need if 'auto' fails (e.g. 'fixed 4000').\n"
+	        "  max:             Allocate as much cycles as your computer is able to handle.");
 
 	const char* cyclest[] = { "auto", "fixed", "max", "%u", 0 };
 	Pstring = pmulti_remain->GetSection()->Add_string("type", always, "auto");
@@ -691,8 +702,8 @@ void DOSBOX_Init()
 
 	Pint = secprop->Add_int("cycleup", always, 10);
 	Pint->SetMinMax(1, 1000000);
-	Pint->Set_help("Number of cycles added or subtracted with speed control hotkeys (10 by default).\n"
-	               "Run INTRO and see Special Keys for list of hotkeys.");
+	Pint->Set_help("Number of cycles added or subtracted with speed control hotkeys\n"
+	               "(10 by default).");
 
 	Pint = secprop->Add_int("cycledown", always, 20);
 	Pint->SetMinMax(1, 1000000);
@@ -720,72 +731,90 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&MPU401_Init, true);
 
 	pstring = secprop->Add_string("mididevice", when_idle, "auto");
-	const char *midi_devices[] = {
-		"auto",
+	const char* midi_devices[] =
+	{ "auto",
 #if defined(MACOSX)
-#if C_COREMIDI
-		"coremidi",
-#endif
-#if C_COREAUDIO
-		"coreaudio",
-#endif
+#	if C_COREMIDI
+	  "coremidi",
+#	endif
+#	if C_COREAUDIO
+	  "coreaudio",
+#	endif
 #elif defined(WIN32)
-		"win32",
+	  "win32",
 #else
-		"oss",
+	  "oss",
 #endif
 #if C_ALSA
-		"alsa",
+	  "alsa",
 #endif
 #if C_FLUIDSYNTH
-		"fluidsynth",
+	  "fluidsynth",
 #endif
 #if C_MT32EMU
-		"mt32",
+	  "mt32",
 #endif
-		"none",
-		0 };
+	  "none",
+	  0 };
 
 	pstring->Set_values(midi_devices);
 	pstring->Set_help(
-	        "Device that will receive the MIDI data from the emulated MPU-401 MIDI\n"
-	        "interface ('auto' by default):\n"
+	        "Set where MIDI data from the emulated MPU-401 MIDI interface is sent\n"
+	        "('auto' by default):\n"
+#if defined(MACOSX)
+#	if C_COREMIDI
+	        "  coremidi:    Any device that has been configured in the macOS\n"
+	        "               Audio MIDI Setup.\n"
+#	endif
+#	if C_COREAUDIO
+	        "  coreaudio:   Use the built-in macOS MIDI synthesiser.\n"
+#	endif
+#elif defined(WIN32)
+	        "  win32:       Use the Win32 MIDI playback interface.\n"
+#else
+	        "  oss:         Use the Linux OSS MIDI playback interface.\n"
+#endif
+#if C_ALSA
+	        "  alsa:        Use the Linux ALSA MIDI playback interface.\n"
+#endif
 #if C_FLUIDSYNTH
-	        "  fluidsynth:  The built-in MIDI synthesizer. See the\n"
-	        "               [fluidsynth] section for detailed configuration.\n"
+	        "  fluidsynth:  The built-in FluidSynth MIDI synthesizer (SoundFont player).\n"
+	        "               See the [fluidsynth] section for detailed configuration.\n"
 #endif
 #if C_MT32EMU
 	        "  mt32:        The built-in Roland MT-32 synthesizer.\n"
 	        "               See the [mt32] section for detailed configuration.\n"
 #endif
-	        "  auto:        The first working external MIDI player. This\n"
-	        "               might be a software synthesizer or physical device.");
+	        "  auto:        Either one of the built-in MIDI synthesisers (if `midiconfig` is\n"
+	        "               set to 'fluidsynth' or 'mt32'), or a MIDI device external to\n"
+	        "               DOSBox (any other 'midiconfig' value). This might be a software\n"
+	        "               synthesizer or physical device. This is the default behaviour.\n"
+	        "  none:        Disable MIDI output.");
 
 	pstring = secprop->Add_string("midiconfig", when_idle, "");
 	pstring->Set_help(
 	        "Configuration options for the selected MIDI interface (unset by default).\n"
 	        "This is usually the ID or name of the MIDI synthesizer you want\n"
-	        "to use (find the ID/name with DOS command 'mixer /listmidi').\n"
+	        "to use (find the ID/name with the DOS command 'MIXER /LISTMIDI').\n"
 #if (C_FLUIDSYNTH == 1 || C_MT32EMU == 1)
-	        "- This option has no effect when using the built-in synthesizers\n"
-	        "  (mididevice = fluidsynth or mt32).\n"
+	        "Notes: - This option has no effect when using the built-in synthesizers\n"
+	        "         ('mididevice = fluidsynth' or 'mididevice = mt32').\n"
 #endif
 #if C_COREAUDIO
-	        "- When using CoreAudio, you can specify a soundfont here.\n"
+	        "       - When using 'coreaudio', you can specify a SoundFont here.\n"
 #endif
 #if C_ALSA
-	        "- When using ALSA, use Linux command 'aconnect -l' to list open\n"
-	        "  MIDI ports, and select one (for example 'midiconfig=14:0'\n"
-	        "  for sequencer client 14, port 0).\n"
+	        "       - When using ALSA, use the Linux command 'aconnect -l' to list all open\n"
+	        "         MIDI ports and select one (e.g. 'midiconfig = 14:0' for sequencer\n"
+	        "         client 14, port 0).\n"
 #endif
-	        "- If you're using a physical Roland MT-32 with revision 0 PCB,\n"
-	        "  the hardware may require a delay in order to prevent its\n"
-	        "  buffer from overflowing. In that case, add 'delaysysex',\n"
-	        "  for example: 'midiconfig=2 delaysysex'.\n"
-	        "See the README/Manual for more details.");
+	        "       - If you're using a physical Roland MT-32 with revision 0 PCB, the\n"
+	        "         hardware may require a delay in order to prevent its buffer from\n"
+	        "         overflowing. In that case, add 'delaysysex', e.g:\n"
+	        "         'midiconfig = 2 delaysysex'.");
 
 	pstring = secprop->Add_string("mpu401", when_idle, "intelligent");
-	const char *mputypes[] = {"intelligent", "uart", "none", 0};
+	const char* mputypes[] = {"intelligent", "uart", "none", 0};
 	pstring->Set_values(mputypes);
 	pstring->Set_help("MPU-401 mode to emulate ('intelligent' by default).");
 
@@ -806,7 +835,8 @@ void DOSBOX_Init()
 	const char* sbtypes[] = {"sb1", "sb2", "sbpro1", "sbpro2", "sb16", "gb", "none", 0};
 	Pstring = secprop->Add_string("sbtype", when_idle, "sb16");
 	Pstring->Set_values(sbtypes);
-	Pstring->Set_help("Type of Sound Blaster to emulate ('sb16' by default). 'gb' is Game Blaster.");
+	Pstring->Set_help("Type of Sound Blaster to emulate ('sb16' by default).\n"
+	                  "'gb' is Game Blaster.");
 
 	const char *ios[] = {"220", "240", "260", "280", "2a0", "2c0", "2e0", "300", 0};
 	Phex = secprop->Add_hex("sbbase", when_idle, 0x220);
@@ -832,18 +862,20 @@ void DOSBOX_Init()
 
 	pint = secprop->Add_int("sbwarmup", when_idle, 100);
 	pint->Set_help(
-	        "Silence initial DMA audio after card power-on, in milliseconds (100 by default).\n"
-	        "This mitigates pops heard when starting many SB-based games.\n"
+	        "Silence initial DMA audio after card power-on, in milliseconds\n"
+	        "(100 by default). This mitigates pops heard when starting many SB-based games.\n"
 	        "Reduce this if you notice intial playback is missing audio.");
 	pint->SetMinMax(0, 100);
 
 	pint = secprop->Add_int("oplrate", deprecated, false);
-	pint->Set_help("The OPL waveform is now sampled at the mixer's playback rate to avoid resampling.");
+	pint->Set_help("The OPL waveform is now sampled at the mixer's playback rate to avoid\n"
+	               "resampling.");
 
 	const char* oplmodes[] = {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", 0};
 	Pstring = secprop->Add_string("oplmode", when_idle, "auto");
 	Pstring->Set_values(oplmodes);
-	Pstring->Set_help("Type of OPL emulation ('auto' by default). On 'auto' the mode is determined by 'sbtype'.\n"
+	Pstring->Set_help("Type of OPL emulation ('auto' by default).\n"
+	                  "On 'auto' the mode is determined by 'sbtype'.\n"
 	                  "All OPL modes are AdLib-compatible, except for 'cms'.");
 
 	Pstring = secprop->Add_string("oplemu", deprecated, "");
@@ -900,12 +932,12 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("pcspeaker", when_idle, pcspeaker_models[0]);
 	pstring->Set_help(
 	        "PC speaker emulation model:\n"
-	        "  discrete: Waveform is created using discrete steps (default).\n"
-	        "            Works well for games that use RealSound-type effects.\n"
-	        "  impulse:  Waveform is created using sinc impulses.\n"
-	        "            Recommended for square-wave games, like Commander Keen.\n"
-	        "            While improving accuracy, it is more CPU intensive.\n"
-	        "  none/off: Don't use the PC Speaker.");
+	        "  discrete:  Waveform is created using discrete steps (default).\n"
+	        "             Works well for games that use RealSound-type effects.\n"
+	        "  impulse:   Waveform is created using sinc impulses.\n"
+	        "             Recommended for square-wave games, like Commander Keen.\n"
+	        "             While improving accuracy, it is more CPU intensive.\n"
+	        "  none/off:  Don't use the PC Speaker.");
 	pstring->Set_values(pcspeaker_models);
 
 	pstring = secprop->Add_string("pcspeaker_filter", when_idle, "on");
@@ -989,14 +1021,14 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("reelmagic", &ReelMagic_Init, true);
 	pstring = secprop->Add_string("reelmagic", when_idle, "off");
 	pstring->Set_help(
-	        "ReelMagic (aka REALmagic) MPEG playback support.\n"
+	        "ReelMagic (aka REALmagic) MPEG playback support:\n"
 	        "  off:       Disable support (default).\n"
 	        "  cardonly:  Initialize the card without loading the FMPDRV.EXE driver.\n"
 	        "  on:        Initialize the card and load the FMPDRV.EXE on start-up.");
 
 	pstring = secprop->Add_string("reelmagic_key", when_idle, "auto");
 	pstring->Set_help(
-	        "Set the 32-bit magic key used to decode the game's videos.\n"
+	        "Set the 32-bit magic key used to decode the game's videos:\n"
 	        "  auto:      Use the built-in routines to determine the key (default).\n"
 	        "  common:    Use the most commonly found key, which is 0x40044041.\n"
 	        "  thehorde:  Use The Horde's key, which is 0xC39D7088.\n"
@@ -1004,7 +1036,7 @@ void DOSBOX_Init()
 
 	pint = secprop->Add_int("reelmagic_fcode", when_idle, 0);
 	pint->Set_help(
-	        "Override the frame rate code used during video playback.\n"
+	        "Override the frame rate code used during video playback:\n"
 	        "  0:       No override: attempt automatic rate discovery (default).\n"
 	        "  1 to 7:  Override the frame rate to one the following (use 1 through 7):\n"
 	        "           1=23.976, 2=24, 3=25, 4=29.97, 5=30, 6=50, or 7=59.94 FPS.");
@@ -1027,20 +1059,23 @@ void DOSBOX_Init()
 	        "  4axis_2:   Support the second joystick only, as a 4-axis type.\n"
 	        "  fcs:       Emulate joystick as an original Thrustmaster FCS.\n"
 	        "  ch:        Emulate joystick as an original CH Flightstick.\n"
-	        "  hidden:    Prevent DOS from seeing the joystick(s), but enable them for\n"
-	        "             mapping.\n"
-	        "  disabled:  Fully disable joysticks: won't be polled, mapped, or visible in DOS.\n"
-	          "(Remember to reset DOSBox's mapperfile if you saved it earlier)");
+	        "  hidden:    Prevent DOS from seeing the joystick(s), but enable them\n"
+	        "             for mapping.\n"
+	        "  disabled:  Fully disable joysticks: won't be polled, mapped,\n"
+			"             or visible in DOS.\n"
+	        "Remember to reset DOSBox's mapperfile if you saved it earlier.");
 
 	Pbool = secprop->Add_bool("timed", when_idle, true);
-	Pbool->Set_help("Enable timed intervals for axis (disabled by default). Experiment with this option, if your\n"
-	                "joystick drifts away.");
+	Pbool->Set_help("Enable timed intervals for axis (disabled by default).\n"
+	                "Experiment with this option, if your joystick drifts away.");
 
 	Pbool = secprop->Add_bool("autofire", when_idle, false);
-	Pbool->Set_help("Continuously fires as long as you keep the button pressed (disabled by default).");
+	Pbool->Set_help("Fire continuously as long as the button is pressed\n"
+	                "(disabled by default).");
 
 	Pbool = secprop->Add_bool("swap34", when_idle, false);
-	Pbool->Set_help("Swap the 3rd and the 4th axis (disabled by default). Can be useful for certain joysticks.");
+	Pbool->Set_help("Swap the 3rd and the 4th axis (disabled by default).\n"
+	                "Can be useful for certain joysticks.");
 
 	Pbool = secprop->Add_bool("buttonwrap", when_idle, false);
 	Pbool->Set_help("Enable button wrapping at the number of emulated buttons (disabled by default).");
@@ -1052,20 +1087,22 @@ void DOSBOX_Init()
 
 	Pint = secprop->Add_int("deadzone", when_idle, 10);
 	Pint->SetMinMax(0, 100);
-	Pint->Set_help("The percentage of motion to ignore (10 by default). 100 turns the stick into a digital one.");
+	Pint->Set_help("Percentage of motion to ignore (10 by default).\n"
+	               "100 turns the stick into a digital one.");
 
 	Pbool = secprop->Add_bool("use_joy_calibration_hotkeys", when_idle, false);
 	Pbool->Set_help(
-	        "Enable hotkeys to allow realtime calibration of the joystick's x and y axis (disabled by default).\n"
-	        "Only consider this if in-game calibration fails and other settings have been\n"
-	        "tried.\n"
-	        " - Ctrl/Cmd+Arrow-keys adjusts the axis' scalar value:\n"
-	        "     - left and right diminish or magnify the x-axis scalar, respectively.\n"
-	        "     - down and up diminish or magnify the y-axis scalar, respectively.\n"
-	        " - Alt+Arrow-keys adjusts the axis' offset position:\n"
-	        "     - left and right shift x-axis offset in the given direction.\n"
-	        "     - down and up shift the y-axis offset in the given direction.\n"
-	        " - Reset the X and Y calibration using Ctrl+Delete and Ctrl+Home, respectively.\n"
+	        "Enable hotkeys to allow realtime calibration of the joystick's x and y axis\n"
+	        "(disabled by default). Only consider this if in-game calibration fails and\n"
+	        "other settings have been tried.\n"
+	        "  - Ctrl/Cmd+Arrow-keys adjusts the axis' scalar value:\n"
+	        "      - left and right diminish or magnify the x-axis scalar, respectively.\n"
+	        "      - down and up diminish or magnify the y-axis scalar, respectively.\n"
+	        "  - Alt+Arrow-keys adjusts the axis' offset position:\n"
+	        "      - left and right shift x-axis offset in the given direction.\n"
+	        "      - down and up shift the y-axis offset in the given direction.\n"
+	        "  - Reset the X and Y calibration using Ctrl+Delete and Ctrl+Home,\n"
+			"    respectively.\n"
 	        "Each tap will report X or Y calibration values you can set below. When you find\n"
 	        "parameters that work, quit the game, switch this setting back to false, and\n"
 	        "populate the reported calibration parameters.");
@@ -1092,13 +1129,12 @@ void DOSBOX_Init()
 	        "Can be disabled, dummy, mouse, modem, nullmodem, direct ('dummy' by default).\n"
 	        "Additional parameters must be on the same line in the form of\n"
 	        "parameter:value. Parameter for all types is irq (optional).\n"
-	        "- for mouse:\n"
-	        "    model, overrides setting from [mouse] section\n"
-	        "- for direct: realport (required), rxdelay (optional).\n"
-	        "    (realport:COM1 realport:ttyS0).\n"
-	        "- for modem: listenport, sock, baudrate (all optional).\n"
-	        "- for nullmodem: server, rxdelay, txdelay, telnet, usedtr,\n"
-	        "   transparent, port, inhsocket, sock (all optional).\n"
+	        "  - for 'mouse':      model, overrides setting from [mouse] section\n"
+	        "  - for 'direct':     realport (required), rxdelay (optional).\n"
+	        "                      (realport:COM1 realport:ttyS0).\n"
+	        "  - for 'modem':      listenport, sock, baudrate (all optional).\n"
+	        "  - for 'nullmodem':  server, rxdelay, txdelay, telnet, usedtr,\n"
+	        "                      transparent, port, inhsocket, sock (all optional).\n"
 	        "SOCK parameter specifies the protocol to be used by both sides\n"
 	        "of the conection. 0 for TCP and 1 for ENet reliable UDP.\n"
 	        "Example: serial1=modem listenport:5000 sock:1");
@@ -1125,7 +1161,8 @@ void DOSBOX_Init()
 	pmulti_remain->Set_help("See 'serial1'");
 
 	pstring = secprop->Add_path("phonebookfile", only_at_start, "phonebook.txt");
-	pstring->Set_help("File used to map fake phone numbers to addresses ('phonebook.txt' by default).");
+	pstring->Set_help("File used to map fake phone numbers to addresses\n"
+	                  "('phonebook.txt' by default).");
 
 	/* All the DOS Related stuff, which will eventually
 	 * start up in the shell */
@@ -1140,9 +1177,8 @@ void DOSBOX_Init()
 	Pstring->Set_values(ems_settings);
 	Pstring->Set_help(
 	        "Enable EMS support (enabled by default). Enabled provides the best\n"
-	        "compatibility but certain applications may run better with\n"
-	        "other choices, or require EMS support to be disabled\n"
-	        "to work at all.");
+	        "compatibility but certain applications may run better with other choices,\n"
+	        "or require EMS support to be disabled to work at all.");
 
 	Pbool = secprop->Add_bool("umb", when_idle, true);
 	Pbool->Set_help("Enable UMB support (enabled by default).");
@@ -1153,19 +1189,19 @@ void DOSBOX_Init()
 	                  "Common settings are 3.3, 5.0, 6.22, and 7.1.");
 
 	pint = secprop->Add_int("country", when_idle, 0);
-	pint->Set_help("Set DOS country code which will affect country-specific\n"
-	               "information such as date, time, and decimal formats (0 by default).\n"
-	               "If set to 0, the country code corresponding to the\n"
-	               "selected keyboard layout will be used.");
+	pint->Set_help("Set DOS country code (0 by default).\n"
+	               "This affects country-specific information such as date, time, and decimal\n"
+	               "formats. If set to 0, the country code corresponding to the selected keyboard\n"
+	               "layout will be used.");
 
 	Pbool = secprop->Add_bool("expand_shell_variable", when_idle, false);
-	Pbool->Set_help("Enable expanding environment variables such as %PATH%\n"
-	                "while in the DOS command shell (disabled by default).\n"
+	Pbool->Set_help("Enable expanding environment variables such as %PATH% in the DOS command shell\n"
+	                "(disabled by default).\n"
 	                "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
 
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init, true);
 	Pstring = secprop->Add_string("keyboardlayout", when_idle, "auto");
-	Pstring->Set_help("Language code of the keyboard layout, or auto ('auto' by default).");
+	Pstring->Set_help("Language code of the keyboard layout, or 'auto' ('auto' by default).");
 
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
@@ -1184,58 +1220,58 @@ void DOSBOX_Init()
 	Pbool->Set_help(
 	        "Enable emulation of a Novell NE2000 network card on a software-based\n"
 	        "network (using libslirp) with properties as follows (enabled by default):\n"
-	        " - 255.255.255.0:  Subnet mask of the 10.0.2.0 virtual LAN.\n"
-	        " - 10.0.2.2:       IP of the gateway and DHCP service.\n"
-	        " - 10.0.2.3:       IP of the virtual DNS server.\n"
-	        " - 10.0.2.15:      First IP provided by DHCP, your IP!\n"
-	        "Note: Inside DOS, setting this up requires an NE2000 packet driver,\n"
-	        "      DHCP client, and TCP/IP stack. You might need port-forwarding\n"
-	        "      from the host into the DOS guest, and from your router to your\n"
-	        "      host when acting as the server for multiplayer games.");
+	        "  - 255.255.255.0:  Subnet mask of the 10.0.2.0 virtual LAN.\n"
+	        "  - 10.0.2.2:       IP of the gateway and DHCP service.\n"
+	        "  - 10.0.2.3:       IP of the virtual DNS server.\n"
+	        "  - 10.0.2.15:      First IP provided by DHCP, your IP!\n"
+	        "Notes: Inside DOS, setting this up requires an NE2000 packet driver, DHCP\n"
+	        "       client, and TCP/IP stack. You might need port-forwarding from the host\n"
+	        "       into the DOS guest, and from your router to your host when acting as the\n"
+	        "       server for multiplayer games.");
 
 	const char *nic_addresses[] = {"200", "220", "240", "260", "280", "2c0",
 	                               "300", "320", "340", "360", 0};
 	Phex = secprop->Add_hex("nicbase", when_idle, 0x300);
 	Phex->Set_values(nic_addresses);
 	Phex->Set_help(
-	        "The base address of the NE2000 card (300 by default).\n"
-	        "Note: Addresses 220 and 240 might not be available as they're assigned\n"
-	        "      to the Sound Blaster and Gravis UltraSound by default.");
+	        "Base address of the NE2000 card (300 by default).\n"
+	        "Notes: Addresses 220 and 240 might not be available as they're assigned to the\n"
+	        "       Sound Blaster and Gravis UltraSound by default.");
 
 	const char *nic_irqs[] = {"3",  "4",  "5",  "9",  "10",
 	                          "11", "12", "14", "15", 0};
 	Pint = secprop->Add_int("nicirq", when_idle, 3);
 	Pint->Set_values(nic_irqs);
 	Pint->Set_help("The interrupt used by the NE2000 card (3 by default).\n"
-	               "Note: IRQs 3 and 5 might not be available as they're assigned\n"
-	               "      to 'serial2' and the Gravis UltraSound by default.");
+	               "Notes: IRQs 3 and 5 might not be available as they're assigned to\n"
+	               "       'serial2' and the Gravis UltraSound by default.");
 
 	Pstring = secprop->Add_string("macaddr", when_idle, "AC:DE:48:88:99:AA");
 	Pstring->Set_help("The MAC address of the NE2000 card ('AC:DE:48:88:99:AA' by default).");
 
 	Pstring = secprop->Add_string("tcp_port_forwards", when_idle, "");
-	Pstring->Set_help("Forwards one or more TCP ports from the host into the DOS guest (unset by default).\n"
-	                  "The format is:\n"
-	                  "  port1  port2  port3 ... (e.g., 21 80 443)\n"
-	                  "  This will forward FTP, HTTP, and HTTPS into the DOS guest.\n"
-	                  "If the ports are privileged on the host, a mapping can be used\n"
-	                  "  host:guest  ..., (e.g., 8021:21 8080:80)\n"
-	                  "  This will forward ports 8021 and 8080 to FTP and HTTP in the guest\n"
-	                  "A range of adjacent ports can be abbreviated with a dash:\n"
-	                  "  start-end ... (e.g., 27910-27960)\n"
-	                  "  This will forward ports 27910 to 27960 into the DOS guest.\n"
-	                  "Mappings and ranges can be combined, too:\n"
-	                  "  hstart-hend:gstart-gend ..., (e.g, 8040-8080:20-60)\n"
-	                  "  This forwards ports 8040 to 8080 into 20 to 60 in the guest\n"
-	                  ""
-	                  "Notes:\n"
-	                  "  - If mapped ranges differ, the shorter range is extended to fit.\n"
-	                  "  - If conflicting host ports are given, only the first one is setup.\n"
-	                  "  - If conflicting guest ports are given, the latter rule takes precedent.");
+	Pstring->Set_help(
+	        "Forward one or more TCP ports from the host into the DOS guest\n"
+			"(unset by default).\n"
+	        "The format is:\n"
+	        "  port1  port2  port3 ... (e.g., 21 80 443)\n"
+	        "  This will forward FTP, HTTP, and HTTPS into the DOS guest.\n"
+	        "If the ports are privileged on the host, a mapping can be used\n"
+	        "  host:guest  ..., (e.g., 8021:21 8080:80)\n"
+	        "  This will forward ports 8021 and 8080 to FTP and HTTP in the guest\n"
+	        "A range of adjacent ports can be abbreviated with a dash:\n"
+	        "  start-end ... (e.g., 27910-27960)\n"
+	        "  This will forward ports 27910 to 27960 into the DOS guest.\n"
+	        "Mappings and ranges can be combined, too:\n"
+	        "  hstart-hend:gstart-gend ..., (e.g, 8040-8080:20-60)\n"
+	        "  This forwards ports 8040 to 8080 into 20 to 60 in the guest\n"
+	        "Notes: If mapped ranges differ, the shorter range is extended to fit.\n"
+	        "       If conflicting host ports are given, only the first one is setup.\n"
+	        "       If conflicting guest ports are given, the latter rule takes precedent.");
 
 	Pstring = secprop->Add_string("udp_port_forwards", when_idle, "");
-	Pstring->Set_help("Forwards one or more UDP ports from the host into the DOS guest (unset by default).\n"
-	                  "The format is the same as for TCP port forwards.");
+	Pstring->Set_help("Forward one or more UDP ports from the host into the DOS guest\n"
+	                  "(unset by default). The format is the same as for TCP port forwards.");
 #endif
 
 	//	secprop->AddInitFunction(&CREDITS_Init);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -385,7 +385,7 @@ static void DOSBOX_RealInit(Section * sec) {
 	// Set the user's prefered MCB fault handling strategy
 	DOS_SetMcbFaultStrategy(section->Get_string("mcb_fault_strategy"));
 
-	// Convert the users video memory in either MB or KiB to bytes
+	// Convert the users video memory in either MB or KB to bytes
 	const auto vmemsize_string = std::string(section->Get_string("vmemsize"));
 
 	// If auto, then default to 0 and let the adapter's setup rountine set
@@ -469,7 +469,7 @@ void DOSBOX_Init()
 	pint = secprop->Add_int("memsize", when_idle, 16);
 	pint->SetMinMax(1, 63);
 	pint->Set_help(
-	        "Amount of memory of the emulated machine has in MiB (16 by default).\n"
+	        "Amount of memory of the emulated machine has in MB (16 by default).\n"
 	        "Best leave at the default setting to avoid problems with some games,\n"
 	        "though a few games might require a higher value.\n"
 	        "There is generally no speed advantage when raising this value.");
@@ -493,18 +493,18 @@ void DOSBOX_Init()
 	        "1",
 	        "2",
 	        "4",
-	        "8", // MiB
+	        "8", // MB
 	        "256",
 	        "512",
 	        "1024",
 	        "2048",
 	        "4096",
 	        "8192",
-	        0, // KiB
+	        0, // KB
 	};
 	pstring = secprop->Add_string("vmemsize", only_at_start, "auto");
 	pstring->Set_values(vmemsize_choices);
-	pstring->Set_help("Video memory in MiB (1-8) or KiB (256 to 8192). 'auto' uses the default per\n"
+	pstring->Set_help("Video memory in MB (1-8) or KB (256 to 8192). 'auto' uses the default per\n"
 	                  "video adapter ('auto' by default).");
 
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4310,12 +4310,12 @@ void config_add_sdl() {
 	pstring = sdl_sec->Add_string("windowresolution", on_start, "default");
 	pstring->Set_help(
 	        "Set window size when running in windowed mode:\n"
-	        "  default:   Select the best option based on your\n"
-	        "             environment and other settings.\n"
-	        "  small, medium, or large (or s, m, l):\n"
+	        "  default:   Select the best option based on your environment and\n"
+	        "             other settings.\n"
+	        "  small, medium, large (s, m, l):\n"
 	        "             Size the window relative to the desktop.\n"
-	        "  <custom>:  Scale the window to the given dimensions in\n"
-	        "             WxH format. For example: 1024x768.\n"
+	        "  <custom>:  Scale the window to the given dimensions in WxH format.\n"
+	        "             For example: 1024x768.\n"
 	        "             Scaling is not performed for output=surface.");
 
 	pstring = sdl_sec->Add_path("viewport_resolution", always, "fit");
@@ -4333,7 +4333,7 @@ void config_add_sdl() {
 	        "             0,0 is the top-left corner of the screen.");
 
 	Pbool = sdl_sec->Add_bool("window_decorations", always, true);
-	Pbool->Set_help("Controls whether to display window decorations in windowed mode.");
+	Pbool->Set_help("Enable window decorations in windowed mode.");
 
 	Pint = sdl_sec->Add_int("transparency", always, 0);
 	Pint->Set_help("Set the transparency of the DOSBox Staging screen.\n"
@@ -4356,18 +4356,18 @@ void config_add_sdl() {
 
 	Pbool = sdl_sec->Add_bool("vsync", on_start, false);
 	Pbool->Set_help(
-	        "Synchronize with display refresh rate if supported. This can\n"
-	        "reduce flickering and tearing, but may also impact performance.");
+	        "Synchronize with display refresh rate if supported.\n"
+	        "This can reduce flickering and tearing, but may also impact performance.");
 
 	pint = sdl_sec->Add_int("vsync_skip", on_start, 7000);
-	pint->Set_help("Number of microseconds to allow rendering to block before skipping the next\n"
-	               "frame. 0 disables this and will always render.");
+	pint->Set_help("Number of microseconds to allow rendering to block before skipping the\n"
+	               "next frame. 0 disables this and will always render.");
 	pint->SetMinMax(0, 14000);
 
 	const char *presentation_modes[] = {"auto", "cfr", "vfr", 0};
 	pstring = sdl_sec->Add_string("presentation_mode", always, "auto");
 	pstring->Set_help(
-	        "Optionally select the frame presentation mode:\n"
+	        "Select the frame presentation mode:\n"
 	        "  auto:  Intelligently time and drop frames to prevent\n"
 	        "         emulation stalls, based on host and DOS frame rates.\n"
 	        "  cfr:   Always present DOS frames at a constant frame rate.\n"
@@ -4391,12 +4391,12 @@ void config_add_sdl() {
 #else
 	Pstring = sdl_sec->Add_string("output", always, "texture");
 #endif
-	Pstring->Set_help("What video system to use for output.");
+	Pstring->Set_help("Video system to use for output.");
 	Pstring->Set_values(outputs);
 
 	pstring = sdl_sec->Add_string("texture_renderer", always, "auto");
-	pstring->Set_help("Choose a renderer driver when using a texture output mode.\n"
-	                  "Use texture_renderer=auto for an automatic choice.");
+	pstring->Set_help("Render driver to use in 'texture' output mode.\n"
+	                  "Use 'texture_renderer = auto' for an automatic choice.");
 	pstring->Set_values(Get_SDL_TextureRenderers());
 
 	Pmulti = sdl_sec->AddMultiVal("capture_mouse", deprecated, ",");
@@ -4411,9 +4411,9 @@ void config_add_sdl() {
 
 	Pmulti = sdl_sec->AddMultiVal("priority", always, " ");
 	Pmulti->SetValue("auto auto");
-	Pmulti->Set_help("Priority levels to apply when active and inactive, respectively. \n"
-	                 "   auto:  Let the host operating system manage the priority (valid for both).\n"
-	                 "Default is: 'auto auto'");
+	Pmulti->Set_help("Priority levels to apply when active and inactive, respectively.\n"
+	                 "('auto auto' by default)\n"
+	                 "'auto' lets the host operating system manage the priority.");
 
 	const char *priority_level_choices[] = {
 	        "auto",
@@ -4441,13 +4441,13 @@ void config_add_sdl() {
 	        "File used to load/save the key/event mappings.\n"
 	        "Pre-configured maps are bundled in the 'resources/mapperfiles' directory.\n"
 	        "They can be loaded by name, for example: mapperfile = xbox/xenon2.map\n"
-	        "Note: the -resetmapper commandline flag only deletes the default mapperfile.");
+	        "Notes: The -resetmapper commandline flag only deletes the default mapperfile.");
 
 	pstring = sdl_sec->Add_string("screensaver", on_start, "auto");
 	pstring->Set_help(
-	        "Use 'allow' or 'block' to override the SDL_VIDEO_ALLOW_SCREENSAVER\n"
-	        "environment variable (which usually blocks the OS screensaver\n"
-	        "while the emulator is running).");
+	        "Use 'allow' or 'block' to override the SDL_VIDEO_ALLOW_SCREENSAVER environment\n"
+	        "variable (which usually blocks the OS screensaver while the emulator is\n"
+	        "running).");
 	const char *ssopts[] = {"auto", "allow", "block", 0};
 	pstring->Set_values(ssopts);
 }

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1657,12 +1657,12 @@ void init_gus_dosbox_settings(Section_prop &secprop)
 	int_prop->Set_values(dmas);
 	int_prop->Set_help("The DMA channel of the Gravis UltraSound (3 by default).");
 
-	auto *str_prop = secprop.Add_string("ultradir", when_idle, "C:\\ULTRASND");
+	auto* str_prop = secprop.Add_string("ultradir", when_idle, "C:\\ULTRASND");
 	assert(str_prop);
-	str_prop->Set_help("Path to UltraSound directory ('C:\\ULTRASND' by default). In this directory\n"
-	                   "there should be a MIDI directory that contains\n"
-	                   "the patch files for GUS playback. Patch sets used\n"
-	                   "with Timidity should work fine.");
+	str_prop->Set_help(
+	        "Path to UltraSound directory ('C:\\ULTRASND' by default).\n"
+	        "In this directory there should be a MIDI directory that contains the patch\n"
+	        "files for GUS playback. Patch sets used with Timidity should work fine.");
 
 	str_prop = secprop.Add_string("gus_filter", when_idle, "off");
 	assert(str_prop);

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1635,31 +1635,31 @@ void init_gus_dosbox_settings(Section_prop &secprop)
 
 	auto *bool_prop = secprop.Add_bool("gus", when_idle, false);
 	assert(bool_prop);
-	bool_prop->Set_help("Enable Gravis UltraSound emulation.");
+	bool_prop->Set_help("Enable Gravis UltraSound emulation (disabled by default).");
 
 	auto *hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);
 	const char *const bases[] = {"240", "220", "260", "280",  "2a0",
 	                             "2c0", "2e0", "300", nullptr};
 	hex_prop->Set_values(bases);
-	hex_prop->Set_help("The IO base address of the Gravis UltraSound.");
+	hex_prop->Set_help("The IO base address of the Gravis UltraSound (240 by default).");
 
 	auto *int_prop = secprop.Add_int("gusirq", when_idle, 5);
 	assert(int_prop);
-	const char *const irqs[] = {"5",  "3",  "7",  "9",
+	const char *const irqs[] = {"3",  "5",  "7",  "9",
 	                            "10", "11", "12", nullptr};
 	int_prop->Set_values(irqs);
-	int_prop->Set_help("The IRQ number of the Gravis UltraSound.");
+	int_prop->Set_help("The IRQ number of the Gravis UltraSound (5 by default).");
 
 	int_prop = secprop.Add_int("gusdma", when_idle, 3);
 	assert(int_prop);
-	const char *const dmas[] = {"3", "0", "1", "5", "6", "7", nullptr};
+	const char *const dmas[] = {"0", "1", "3", "5", "6", "7", nullptr};
 	int_prop->Set_values(dmas);
-	int_prop->Set_help("The DMA channel of the Gravis UltraSound.");
+	int_prop->Set_help("The DMA channel of the Gravis UltraSound (3 by default).");
 
 	auto *str_prop = secprop.Add_string("ultradir", when_idle, "C:\\ULTRASND");
 	assert(str_prop);
-	str_prop->Set_help("Path to UltraSound directory. In this directory\n"
+	str_prop->Set_help("Path to UltraSound directory ('C:\\ULTRASND' by default). In this directory\n"
 	                   "there should be a MIDI directory that contains\n"
 	                   "the patch files for GUS playback. Patch sets used\n"
 	                   "with Timidity should work fine.");

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -54,8 +54,8 @@ const auto ultradir_env_name = "ULTRADIR";
 constexpr uint32_t RAM_SIZE = 1024 * 1024; // 1 MiB
 
 // DMA transfer size and rate constants
-constexpr uint32_t BYTES_PER_DMA_XFER = 8 * 1024;         // 8 KiB per transfer
-constexpr uint32_t ISA_BUS_THROUGHPUT = 32 * 1024 * 1024; // 32 MiB/s
+constexpr uint32_t BYTES_PER_DMA_XFER = 8 * 1024;         // 8 KB per transfer
+constexpr uint32_t ISA_BUS_THROUGHPUT = 32 * 1024 * 1024; // 32 MB/s
 constexpr uint16_t DMA_TRANSFERS_PER_S = ISA_BUS_THROUGHPUT / BYTES_PER_DMA_XFER;
 constexpr double MS_PER_DMA_XFER = millis_in_second / DMA_TRANSFERS_PER_S;
 

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -273,12 +273,12 @@ static void init_innovation_dosbox_settings(Section_prop &sec_prop)
 	str_prop->Set_values(sid_models);
 	str_prop->Set_help(
 	        "Model of chip to emulate in the Innovation SSI-2001 card:\n"
-	        " - auto:  Selects the 6581 chip.\n"
-	        " - 6581:  The original chip, known for its bassy and rich character.\n"
-	        " - 8580:  A later revision that more closely matched the SID specification.\n"
-	        "          It fixed the 6581's DC bias and is less prone to distortion.\n"
-	        "          The 8580 is an option on reproduction cards, like the DuoSID.\n"
-	        " - none:  Disables the card.");
+	        "  auto:  Use the 6581 chip.\n"
+	        "  6581:  The original chip, known for its bassy and rich character.\n"
+	        "  8580:  A later revision that more closely matched the SID specification.\n"
+	        "         It fixed the 6581's DC bias and is less prone to distortion.\n"
+	        "         The 8580 is an option on reproduction cards, like the DuoSID.\n"
+	        "  none:  Disable the card (default).");
 
 	// Chip clock frequency
 	str_prop = sec_prop.Add_string("sidclock", when_idle, "default");
@@ -286,28 +286,28 @@ static void init_innovation_dosbox_settings(Section_prop &sec_prop)
 	str_prop->Set_values(sid_clocks);
 	str_prop->Set_help(
 	        "The SID chip's clock frequency, which is jumperable on reproduction cards.\n"
-	        " - default: uses 0.895 MHz, per the original SSI-2001 card.\n"
-	        " - c64ntsc: uses 1.023 MHz, per NTSC Commodore PCs and the DuoSID.\n"
-	        " - c64pal:  uses 0.985 MHz, per PAL Commodore PCs and the DuoSID.\n"
-	        " - hardsid: uses 1.000 MHz, available on the DuoSID.");
+	        "  default:  0.895 MHz, per the original SSI-2001 card (default).\n"
+	        "  c64ntsc:  1.023 MHz, per NTSC Commodore PCs and the DuoSID.\n"
+	        "  c64pal:   0.985 MHz, per PAL Commodore PCs and the DuoSID.\n"
+	        "  hardsid:  1.000 MHz, available on the DuoSID.");
 
 	// IO Address
 	auto *hex_prop = sec_prop.Add_hex("sidport", when_idle, 0x280);
 	const char *sid_ports[] = {"240", "260", "280", "2a0", "2c0", 0};
 	hex_prop->Set_values(sid_ports);
-	hex_prop->Set_help("The IO port address of the Innovation SSI-2001.");
+	hex_prop->Set_help("The IO port address of the Innovation SSI-2001 (280 by default).");
 
 	// Filter strengths
 	auto *int_prop = sec_prop.Add_int("6581filter", when_idle, 50);
 	int_prop->SetMinMax(0, 100);
 	int_prop->Set_help(
-	        "The SID's analog filtering meant that each chip was physically unique.\n"
-	        "Adjusts the 6581's filtering strength as a percent from 0 to 100.");
+	        "Adjusts the 6581's filtering strength as a percent from 0 to 100 (50 by default).\n"
+	        "The SID's analog filtering meant that each chip was physically unique.");
 
 	int_prop = sec_prop.Add_int("8580filter", when_idle, 50);
 	int_prop->SetMinMax(0, 100);
 	int_prop->Set_help(
-	        "Adjusts the 8580's filtering strength as a percent from 0 to 100.");
+	        "Adjusts the 8580's filtering strength as a percent from 0 to 100 (50 by default).");
 
 	str_prop = sec_prop.Add_string("innovation_filter", when_idle, "off");
 	assert(str_prop);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -263,13 +263,13 @@ static void innovation_init(Section *sec)
 	sec->AddDestroyFunction(&innovation_destroy, true);
 }
 
-static void init_innovation_dosbox_settings(Section_prop &sec_prop)
+static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	// Chip type
-	auto *str_prop = sec_prop.Add_string("sidmodel", when_idle, "none");
-	const char *sid_models[] = {"auto", "6581", "8580", "none", 0};
+	auto* str_prop = sec_prop.Add_string("sidmodel", when_idle, "none");
+	const char* sid_models[] = {"auto", "6581", "8580", "none", 0};
 	str_prop->Set_values(sid_models);
 	str_prop->Set_help(
 	        "Model of chip to emulate in the Innovation SSI-2001 card:\n"
@@ -282,7 +282,7 @@ static void init_innovation_dosbox_settings(Section_prop &sec_prop)
 
 	// Chip clock frequency
 	str_prop = sec_prop.Add_string("sidclock", when_idle, "default");
-	const char *sid_clocks[] = {"default", "c64ntsc", "c64pal", "hardsid", 0};
+	const char* sid_clocks[] = {"default", "c64ntsc", "c64pal", "hardsid", 0};
 	str_prop->Set_values(sid_clocks);
 	str_prop->Set_help(
 	        "The SID chip's clock frequency, which is jumperable on reproduction cards.\n"
@@ -292,22 +292,24 @@ static void init_innovation_dosbox_settings(Section_prop &sec_prop)
 	        "  hardsid:  1.000 MHz, available on the DuoSID.");
 
 	// IO Address
-	auto *hex_prop = sec_prop.Add_hex("sidport", when_idle, 0x280);
-	const char *sid_ports[] = {"240", "260", "280", "2a0", "2c0", 0};
+	auto* hex_prop          = sec_prop.Add_hex("sidport", when_idle, 0x280);
+	const char* sid_ports[] = {"240", "260", "280", "2a0", "2c0", 0};
 	hex_prop->Set_values(sid_ports);
-	hex_prop->Set_help("The IO port address of the Innovation SSI-2001 (280 by default).");
+	hex_prop->Set_help(
+	        "The IO port address of the Innovation SSI-2001 (280 by default).");
 
 	// Filter strengths
-	auto *int_prop = sec_prop.Add_int("6581filter", when_idle, 50);
+	auto* int_prop = sec_prop.Add_int("6581filter", when_idle, 50);
 	int_prop->SetMinMax(0, 100);
 	int_prop->Set_help(
-	        "Adjusts the 6581's filtering strength as a percent from 0 to 100 (50 by default).\n"
-	        "The SID's analog filtering meant that each chip was physically unique.");
+	        "Adjusts the 6581's filtering strength as a percent from 0 to 100\n"
+	        "(50 by default). The SID's analog filtering meant that each chip was\n"
+	        "physically unique.");
 
 	int_prop = sec_prop.Add_int("8580filter", when_idle, 50);
 	int_prop->SetMinMax(0, 100);
-	int_prop->Set_help(
-	        "Adjusts the 8580's filtering strength as a percent from 0 to 100 (50 by default).");
+	int_prop->Set_help("Adjusts the 8580's filtering strength as a percent from 0 to 100\n"
+	                   "(50 by default).");
 
 	str_prop = sec_prop.Add_string("innovation_filter", when_idle, "off");
 	assert(str_prop);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2380,7 +2380,6 @@ private:
 		        "               use [color=white]L:R[reset] to set the left and right side separately (e.g. [color=white]10:20[reset])\n"
 		        "    Lineout:   [color=white]stereo[reset], [color=white]reverse[reset] (for stereo channels only)\n"
 		        "    Crossfeed: [color=white]x0[reset] to [color=white]x100[reset]    Reverb: [color=white]r0[reset] to [color=white]r100[reset]    Chorus: [color=white]c0[reset] to [color=white]c100[reset]\n"
-		        "\n"
 		        "Notes:\n"
 		        "  Running [color=green]mixer[reset] without an argument shows the current mixer settings.\n"
 		        "  You may change the settings of more than one channel in a single command.\n"
@@ -2790,7 +2789,9 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 
 	auto bool_prop = sec_prop.Add_bool("nosound", always, false);
 	assert(bool_prop);
-	bool_prop->Set_help("Enable silent mode, sound is still emulated though (disabled by default).");
+	bool_prop->Set_help(
+	        "Enable silent mode (disabled by default).\n"
+	        "Sound is still fullhy emulated in silent mode, but DOSBox outputs silence.");
 
 	auto int_prop = sec_prop.Add_int("rate", only_at_start, default_rate);
 	assert(int_prop);
@@ -2812,9 +2813,7 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "How many milliseconds of sound to render on top of the blocksize; larger values\n"
 	        "might help with sound stuttering but sound will also be more lagged.");
 
-	bool_prop = sec_prop.Add_bool("negotiate",
-	                              only_at_start,
-	                              default_allow_negotiate);
+	bool_prop = sec_prop.Add_bool("negotiate", only_at_start, default_allow_negotiate);
 	bool_prop->Set_help("Let the system audio driver negotiate (possibly) better rate and blocksize\n"
 	                    "settings.");
 
@@ -2833,7 +2832,7 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "  <strength>:  Set crossfeed strength from 0 to 100, where 0 means no crossfeed\n"
 	        "               (off) and 100 full crossfeed (effectively turning stereo content\n"
 	        "               into mono).\n"
-	        "Note: You can set per-channel crossfeed via mixer commands.");
+	        "Notes: You can set per-channel crossfeed via mixer commands.");
 
 	const char *reverb_presets[] = {"off", "on", "tiny", "small", "medium", "large", "huge", nullptr};
 	string_prop = sec_prop.Add_string("reverb", when_idle, reverb_presets[0]);
@@ -2851,7 +2850,7 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "           channels for music and digital audio.\n"
 	        "  huge:    A stronger variant of the large hall preset; works really well\n"
 	        "           in some games with more atmospheric soundtracks.\n"
-	        "Note: You can fine-tune per-channel reverb levels via mixer commands.");
+	        "Notes: You can fine-tune per-channel reverb levels via mixer commands.");
 	string_prop->Set_values(reverb_presets);
 
 	const char *chorus_presets[] = {"off", "on", "light", "normal", "strong", nullptr};
@@ -2860,11 +2859,11 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 	        "Enable chorus globally to add a sense of stereo movement to the sound:\n"
 	        "  off:     No chorus (default).\n"
 	        "  on:      Enable chorus (normal preset).\n"
-	        "  light:   A light chorus effect (especially suited for\n"
-	        "           synth music that features lots of white noise.)\n"
+	        "  light:   A light chorus effect (especially suited for synth music that\n"
+	        "           features lots of white noise.)\n"
 	        "  normal:  Normal chorus that works well with a wide variety of games.\n"
 	        "  strong:  An obvious and upfront chorus effect.\n"
-	        "Note: You can fine-tune per-channel chorus levels via mixer commands.");
+	        "Notes: You can fine-tune per-channel chorus levels via mixer commands.");
 	string_prop->Set_values(chorus_presets);
 
 	MAPPER_AddHandler(ToggleMute, SDL_SCANCODE_F8, PRIMARY_MOD, "mute", "Mute");

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2390,7 +2390,7 @@ private:
 		        "\n"
 		        "Examples:\n"
 		        "  [color=green]mixer[reset] [color=cyan]cdda[reset] [color=white]50[reset] [color=cyan]sb[reset] [color=white]reverse[reset] /noshow\n"
-		        "  [color=green]mixer[reset] [color=white]x30[reset] [color=cyan]fm[reset] [color=white]150 r50 c30[reset] [color=cyan]sb[reset] [color=white]x10[reset]");
+		        "  [color=green]mixer[reset] [color=white]x30[reset] [color=cyan]opl[reset] [color=white]150 r50 c30[reset] [color=cyan]sb[reset] [color=white]x10[reset]");
 
 		MSG_Add("SHELL_CMD_MIXER_HEADER_LAYOUT",
 		        "%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f  %-8s %5s %7s %7s");
@@ -2790,14 +2790,14 @@ void init_mixer_dosbox_settings(Section_prop &sec_prop)
 
 	auto bool_prop = sec_prop.Add_bool("nosound", always, false);
 	assert(bool_prop);
-	bool_prop->Set_help("Enable silent mode, sound is still emulated though.");
+	bool_prop->Set_help("Enable silent mode, sound is still emulated though (disabled by default).");
 
 	auto int_prop = sec_prop.Add_int("rate", only_at_start, default_rate);
 	assert(int_prop);
 	const char *rates[] = {
 	        "8000", "11025", "16000", "22050", "32000", "44100", "48000", 0};
 	int_prop->Set_values(rates);
-	int_prop->Set_help("Mixer sample rate.");
+	int_prop->Set_help("Mixer sample rate (48000 by default).");
 
 	const char *blocksizes[] = {"128", "256", "512", "1024", "2048", "4096", "8192", 0};
 

--- a/src/hardware/mouse/mouse_config.cpp
+++ b/src/hardware/mouse/mouse_config.cpp
@@ -278,11 +278,11 @@ static void config_init(Section_prop &secprop)
 
 	prop_multi = secprop.AddMultiVal("mouse_sensitivity", only_at_start, ",");
 	prop_multi->Set_help(
-	        "Default mouse sensitivity (100,100 by default). 100 is the base value, 150 is 150% sensitivity, etc.\n"
-	        "Negative values reverse mouse direction, 0 disables the movement completely.\n"
-	        "The optional second parameter specifies vertical sensitivity (e.g. 100,200).\n"
-	        "The setting can be adjusted in runtime (also per mouse interface) using internal\n"
-	        "MOUSECTL.COM tool, available on drive Z.");
+	        "Mouse sensitivity for the horizontal and vertical axes, as a percentage\n"
+	        "(100,100 by default). Negative values invert the axis, zero disables it.\n"
+	        "Providing only one value sets sensitivity for both axes.\n"
+	        "The setting can be adjusted in runtime (also per mouse interface) using\n"
+	        "internal MOUSECTL.COM tool, available on drive Z.");
 	prop_multi->SetValue("100");
 
 	prop_int = prop_multi->GetSection()->Add_int("xsens", only_at_start, 100);

--- a/src/hardware/mouse/mouse_config.cpp
+++ b/src/hardware/mouse/mouse_config.cpp
@@ -263,26 +263,26 @@ static void config_init(Section_prop &secprop)
 	prop_str->Set_values(list_capture_types);
 	prop_str->Set_help(
 	        "Choose a mouse control method:\n"
-	        "  onclick:   Capture the mouse when clicking any button in the window.\n"
+	        "  onclick:   Capture the mouse when clicking any button in the window (default).\n"
 	        "  onstart:   Capture the mouse immediately on start. Might not work correctly\n"
 	        "             on some host operating systems.\n"
 	        "  seamless:  Let the mouse move seamlessly; captures only with middle-click or\n"
 	        "             hotkey. Seamless mouse does not work correctly with all the games,\n"
 	        "             Windows 3.1x can be made compatible with a custom mouse driver.\n"
 	        "  nomouse:   Hide the mouse and don't send input to the game.\n"
-	        "For touchscreen control use the seamless method.\n");
+	        "For touchscreen control, use 'seamless'.");
 
 	prop_bool = secprop.Add_bool("mouse_middle_release", always, true);
-	prop_bool->Set_help("If true, middle-click will release the captured mouse, and also\n"
-	                    "capture when seamless.");
+	prop_bool->Set_help("If enabled, middle-click will release the captured mouse, and also\n"
+	                    "capture when seamless (enabled by default).");
 
 	prop_multi = secprop.AddMultiVal("mouse_sensitivity", only_at_start, ",");
 	prop_multi->Set_help(
-	        "Default mouse sensitivity. 100 is a base value, 150 is 150% sensitivity, etc.\n"
+	        "Default mouse sensitivity (100,100 by default). 100 is the base value, 150 is 150% sensitivity, etc.\n"
 	        "Negative values reverse mouse direction, 0 disables the movement completely.\n"
 	        "The optional second parameter specifies vertical sensitivity (e.g. 100,200).\n"
-	        "Setting can be adjusted in runtime (also per mouse interface) using internal\n"
-	        "MOUSECTL.COM tool, available on drive Z:.");
+	        "The setting can be adjusted in runtime (also per mouse interface) using internal\n"
+	        "MOUSECTL.COM tool, available on drive Z.");
 	prop_multi->SetValue("100");
 
 	prop_int = prop_multi->GetSection()->Add_int("xsens", only_at_start, 100);
@@ -295,14 +295,14 @@ static void config_init(Section_prop &secprop)
 	prop_bool = secprop.Add_bool("mouse_raw_input", always, true);
 	prop_bool->Set_help(
 	        "Enable to bypass your operating system's mouse acceleration and sensitivity\n"
-	        "settings. Works in fullscreen or when the mouse is captured in window mode.");
+	        "settings (enabled by default). Works in fullscreen or when the mouse is captured in window mode.");
 
 	// DOS driver configuration
 
 	prop_bool = secprop.Add_bool("dos_mouse_driver", only_at_start, true);
 	assert(prop_bool);
 	prop_bool->Set_help(
-	        "Enable built-in DOS mouse driver.\n"
+	        "Enable built-in DOS mouse driver (enabled by default).\n"
 	        "Notes:\n"
 	        "   Disable if you intend to use original MOUSE.COM driver in emulated DOS.\n"
 	        "   When guest OS is booted, built-in driver gets disabled automatically.");
@@ -310,15 +310,14 @@ static void config_init(Section_prop &secprop)
 	prop_bool = secprop.Add_bool("dos_mouse_immediate", always, false);
 	assert(prop_bool);
 	prop_bool->Set_help(
-	        "Updates mouse movement counters immediately, without waiting for interrupt.\n"
-	        "May improve gameplay, especially in fast paced games (arcade, FPS, etc.) - as\n"
+	        "Updates mouse movement counters immediately, without waiting for interrupt (disabled by default).\n"
+	        "May improve gameplay, especially in fast-paced games (arcade, FPS, etc.), as\n"
 	        "for some games it effectively boosts the mouse sampling rate to 1000 Hz, without\n"
 	        "increasing interrupt overhead.\n"
 	        "Might cause compatibility issues. List of known incompatible games:\n"
 	        "   - Ultima Underworld: The Stygian Abyss\n"
 	        "   - Ultima Underworld II: Labyrinth of Worlds\n"
-	        "Please file a bug with the project if you find another game that fails when\n"
-	        "this is enabled, we will update this list.");
+	        "Please report it if you find another incompatible game so we can update this list.");
 
 	// Physical mice configuration
 
@@ -329,12 +328,12 @@ static void config_init(Section_prop &secprop)
 	prop_str->Set_help(
 	        "PS/2 AUX port mouse model:\n"
 	        // TODO - Add option "none"
-	        "   standard:       3 buttons, standard PS/2 mouse.\n"
-	        "   intellimouse:   3 buttons + wheel, Microsoft IntelliMouse.\n"
+	        "   standard:      3 buttons, standard PS/2 mouse.\n"
+	        "   intellimouse:  3 buttons + wheel, Microsoft IntelliMouse (default)."
 #ifdef ENABLE_EXPLORER_MOUSE
-	        "   explorer:       5 buttons + wheel, Microsoft IntelliMouse Explorer.\n"
+	        "\n   explorer:      5 buttons + wheel, Microsoft IntelliMouse Explorer."
 #endif
-	        "Default: intellimouse");
+	        );
 
 	prop_str = secprop.Add_string("com_mouse_model", only_at_start,
 	                              model_com_wheel_msm_str);
@@ -342,19 +341,15 @@ static void config_init(Section_prop &secprop)
 	prop_str->Set_values(list_models_com);
 	prop_str->Set_help(
 	        "COM (serial) port default mouse model:\n"
-	        "   2button:        2 buttons, Microsoft mouse.\n"
-	        "   3button:        3 buttons, Logitech mouse,\n"
-	        "                   mostly compatible with Microsoft mouse.\n"
-	        "   wheel:          3 buttons + wheel,\n"
-	        "                   mostly compatible with Microsoft mouse.\n"
-	        "   msm:            3 buttons, Mouse Systems mouse,\n"
-	        "                   NOT COMPATIBLE with Microsoft mouse.\n"
-	        "   2button+msm:    Automatic choice between 2button and msm.\n"
-	        "   3button+msm:    Automatic choice between 3button and msm.\n"
-	        "   wheel+msm:      Automatic choice between wheel and msm.\n"
-	        "Default: wheel+msm\n"
+	        "   2button:      2 buttons, Microsoft mouse.\n"
+	        "   3button:      3 buttons, Logitech mouse; mostly compatible with Microsoft mouse.\n"
+	        "   wheel:        3 buttons + wheel; mostly compatible with Microsoft mouse.\n"
+	        "   msm:          3 buttons, Mouse Systems mouse; NOT compatible with Microsoft mouse.\n"
+	        "   2button+msm:  Automatic choice between '2button' and 'msm'.\n"
+	        "   3button+msm:  Automatic choice between '3button' and 'msm'.\n"
+	        "   wheel+msm:    Automatic choice between 'wheel' and 'msm' (default).\n"
 	        "Notes:\n"
-	        "   Go to [serial] section to enable/disable COM port mice.");
+	        "   Enable/disable COM port mice in the [serial] section.");
 }
 
 void MOUSE_AddConfigSection(const config_ptr_t &conf)

--- a/src/hardware/mouse/mouse_config.cpp
+++ b/src/hardware/mouse/mouse_config.cpp
@@ -262,19 +262,21 @@ static void config_init(Section_prop &secprop)
 	assert(prop_str);
 	prop_str->Set_values(list_capture_types);
 	prop_str->Set_help(
-	        "Choose a mouse control method:\n"
-	        "  onclick:   Capture the mouse when clicking any button in the window (default).\n"
+	        "Set the mouse capture behaviour:\n"
+	        "  onclick:   Capture the mouse when clicking any mouse button in the window \n"
+	        "             (default).\n"
 	        "  onstart:   Capture the mouse immediately on start. Might not work correctly\n"
 	        "             on some host operating systems.\n"
-	        "  seamless:  Let the mouse move seamlessly; captures only with middle-click or\n"
-	        "             hotkey. Seamless mouse does not work correctly with all the games,\n"
+	        "  seamless:  Let the mouse move seamlessly between the DOSBox window and the\n"
+	        "             rest of the desktop; captures only with middle-click or hotkey.\n"
+	        "             Seamless mouse does not work correctly with all the games.\n"
 	        "             Windows 3.1x can be made compatible with a custom mouse driver.\n"
-	        "  nomouse:   Hide the mouse and don't send input to the game.\n"
-	        "For touchscreen control, use 'seamless'.");
+	        "  nomouse:   Hide the mouse and don't send mouse input to the game.\n"
+	        "For touch-screen control, use 'seamless'.");
 
 	prop_bool = secprop.Add_bool("mouse_middle_release", always, true);
-	prop_bool->Set_help("If enabled, middle-click will release the captured mouse, and also\n"
-	                    "capture when seamless (enabled by default).");
+	prop_bool->Set_help("If enabled, middle-click will release the captured mouse, and also capture\n"
+	                    "when seamless (enabled by default).");
 
 	prop_multi = secprop.AddMultiVal("mouse_sensitivity", only_at_start, ",");
 	prop_multi->Set_help(
@@ -295,7 +297,8 @@ static void config_init(Section_prop &secprop)
 	prop_bool = secprop.Add_bool("mouse_raw_input", always, true);
 	prop_bool->Set_help(
 	        "Enable to bypass your operating system's mouse acceleration and sensitivity\n"
-	        "settings (enabled by default). Works in fullscreen or when the mouse is captured in window mode.");
+	        "settings (enabled by default). Works in fullscreen or when the mouse is\n"
+	        "captured in window mode.");
 
 	// DOS driver configuration
 
@@ -303,21 +306,21 @@ static void config_init(Section_prop &secprop)
 	assert(prop_bool);
 	prop_bool->Set_help(
 	        "Enable built-in DOS mouse driver (enabled by default).\n"
-	        "Notes:\n"
-	        "   Disable if you intend to use original MOUSE.COM driver in emulated DOS.\n"
-	        "   When guest OS is booted, built-in driver gets disabled automatically.");
+	        "Notes: Disable if you intend to use original MOUSE.COM driver in emulated DOS.\n"
+	        "       When guest OS is booted, built-in driver gets disabled automatically.");
 
 	prop_bool = secprop.Add_bool("dos_mouse_immediate", always, false);
 	assert(prop_bool);
 	prop_bool->Set_help(
-	        "Updates mouse movement counters immediately, without waiting for interrupt (disabled by default).\n"
-	        "May improve gameplay, especially in fast-paced games (arcade, FPS, etc.), as\n"
-	        "for some games it effectively boosts the mouse sampling rate to 1000 Hz, without\n"
-	        "increasing interrupt overhead.\n"
+	        "Update mouse movement counters immediately, without waiting for interrupt\n"
+	        "(disabled by default). May improve gameplay, especially in fast-paced games\n"
+	        "(arcade, FPS, etc.), as for some games it effectively boosts the mouse\n"
+	        "sampling rate to 1000 Hz, without increasing interrupt overhead.\n"
 	        "Might cause compatibility issues. List of known incompatible games:\n"
-	        "   - Ultima Underworld: The Stygian Abyss\n"
-	        "   - Ultima Underworld II: Labyrinth of Worlds\n"
-	        "Please report it if you find another incompatible game so we can update this list.");
+	        "  - Ultima Underworld: The Stygian Abyss\n"
+	        "  - Ultima Underworld II: Labyrinth of Worlds\n"
+	        "Please report it if you find another incompatible game so we can update this\n"
+	        "list.");
 
 	// Physical mice configuration
 
@@ -333,23 +336,26 @@ static void config_init(Section_prop &secprop)
 #ifdef ENABLE_EXPLORER_MOUSE
 	        "\n   explorer:      5 buttons + wheel, Microsoft IntelliMouse Explorer."
 #endif
-	        );
+	);
 
-	prop_str = secprop.Add_string("com_mouse_model", only_at_start,
+	prop_str = secprop.Add_string("com_mouse_model",
+	                              only_at_start,
 	                              model_com_wheel_msm_str);
 	assert(prop_str);
 	prop_str->Set_values(list_models_com);
 	prop_str->Set_help(
 	        "COM (serial) port default mouse model:\n"
 	        "   2button:      2 buttons, Microsoft mouse.\n"
-	        "   3button:      3 buttons, Logitech mouse; mostly compatible with Microsoft mouse.\n"
-	        "   wheel:        3 buttons + wheel; mostly compatible with Microsoft mouse.\n"
-	        "   msm:          3 buttons, Mouse Systems mouse; NOT compatible with Microsoft mouse.\n"
+	        "   3button:      3 buttons, Logitech mouse;\n"
+	        "                 mostly compatible with Microsoft mouse.\n"
+	        "   wheel:        3 buttons + wheel;\n"
+	        "                 mostly compatible with Microsoft mouse.\n"
+	        "   msm:          3 buttons, Mouse Systems mouse;\n"
+	        "                 NOT compatible with Microsoft mouse.\n"
 	        "   2button+msm:  Automatic choice between '2button' and 'msm'.\n"
 	        "   3button+msm:  Automatic choice between '3button' and 'msm'.\n"
 	        "   wheel+msm:    Automatic choice between 'wheel' and 'msm' (default).\n"
-	        "Notes:\n"
-	        "   Enable/disable COM port mice in the [serial] section.");
+	        "Notes: Enable COM port mice in the [serial] section.");
 }
 
 void MOUSE_AddConfigSection(const config_ptr_t &conf)

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1501,22 +1501,24 @@ static void composite_settings(Section_prop &secprop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
-	const char *states[] = {"auto", "on", "off", 0};
+	const char* states[] = {"auto", "on", "off", 0};
 	auto str_prop = secprop.Add_string("composite", when_idle, "auto");
 	str_prop->Set_values(states);
-	str_prop->Set_help("Enable composite mode on start ('auto' by default). 'auto' lets the program decide.\n"
-	                   "Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.\n"
-	                   "      Then read the new settings from your console and enter them here.");
-
-	const char *eras[] = {"auto", "old", "new", 0};
-	str_prop = secprop.Add_string("era", when_idle, "auto");
-	str_prop->Set_values(eras);
 	str_prop->Set_help(
-	        "Era of composite technology ('auto' by default). When 'auto', PCjr uses new and CGA/Tandy use old.");
+	        "Enable composite mode on start ('auto' by default).\n"
+	        "'auto' lets the program decide.\n"
+	        "Notes: Fine-tune the settings below (i.e., hue) using the composite hotkeys,\n"
+	        "       then read the new settings from your console and enter them here.");
+
+	const char* eras[] = {"auto", "old", "new", 0};
+	str_prop           = secprop.Add_string("era", when_idle, "auto");
+	str_prop->Set_values(eras);
+	str_prop->Set_help("Era of composite technology ('auto' by default).\n"
+	                   "When 'auto', PCjr uses 'new', and CGA/Tandy use 'old'.");
 
 	auto int_prop = secprop.Add_int("hue", when_idle, hue.get_default());
 	int_prop->SetMinMax(hue.get_min(), hue.get_max());
-	int_prop->Set_help("Appearance of RGB palette. For example, adjust until sky is blue.");
+	int_prop->Set_help("Appearance of RGB palette. For example, adjust until the sky is blue.");
 
 	int_prop = secprop.Add_int("saturation", when_idle, saturation.get_default());
 	int_prop->SetMinMax(saturation.get_min(), saturation.get_max());

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1504,7 +1504,7 @@ static void composite_settings(Section_prop &secprop)
 	const char *states[] = {"auto", "on", "off", 0};
 	auto str_prop = secprop.Add_string("composite", when_idle, "auto");
 	str_prop->Set_values(states);
-	str_prop->Set_help("Enable composite mode on start. 'auto' lets the program decide.\n"
+	str_prop->Set_help("Enable composite mode on start ('auto' by default). 'auto' lets the program decide.\n"
 	                   "Note: Fine-tune the settings below (ie: hue) using the composite hotkeys.\n"
 	                   "      Then read the new settings from your console and enter them here.");
 
@@ -1512,7 +1512,7 @@ static void composite_settings(Section_prop &secprop)
 	str_prop = secprop.Add_string("era", when_idle, "auto");
 	str_prop->Set_values(eras);
 	str_prop->Set_help(
-	        "Era of composite technology. When 'auto', PCjr uses new and CGA/Tandy use old.");
+	        "Era of composite technology ('auto' by default). When 'auto', PCjr uses new and CGA/Tandy use old.");
 
 	auto int_prop = secprop.Add_int("hue", when_idle, hue.get_default());
 	int_prop->SetMinMax(hue.get_min(), hue.get_max());

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -814,7 +814,7 @@ void SVGA_Setup_TsengET3K(void) {
 	IO_RegisterReadHandler(0x3cd, read_p3cd_et3k, io_width_t::byte);
 	IO_RegisterWriteHandler(0x3cd, write_p3cd_et3k, io_width_t::byte);
 
-	// The ET3000AX/BX had a fixed 512 KiB of DRAM
+	// The ET3000AX/BX had a fixed 512 KB of DRAM
 	vga.vmemsize = 512*1024;
 
 	const auto num_modes = ModeList_VGA_Tseng.size();

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -684,7 +684,7 @@ static void FinishSetMode(bool clearmem) {
 		case M_HERC_TEXT:
 		case M_TANDY_TEXT:
 		case M_TEXT: {
-			// TODO Hercules had 32KiB compared to CGA/MDA 16KiB,
+			// TODO Hercules had 32KB compared to CGA/MDA 16 KB,
 			// but does it matter in here?
 			uint16_t seg = (CurMode->mode==7)?0xb000:0xb800;
 			for (uint16_t ct=0;ct<16*1024;ct++) real_writew(seg,ct*2,0x0720);

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -430,7 +430,7 @@ uint8_t VESA_ScanLineLength(uint8_t subcall,
 
 	switch (CurMode->type) {
 	case M_TEXT:
-		// In text mode we only have a 32 KiB window to operate on
+		// In text mode we only have a 32 KB window to operate on
 		usable_vmem_bytes = 32 * 1024;
 		screen_height = CurMode->theight;
 		bytes_per_offset = 4;   // 2 characters + 2 attributes

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -330,7 +330,7 @@ Bitu XMS_Handler(void) {
 		SET_RESULT(XMS_GetHandleInformation(reg_dx,reg_bh,reg_bl,reg_dx),false);
 		break;
 	case XMS_RESIZE_ANY_EXTENDED_MEMORY_BLOCK:					/* 0x8f */
-		if(reg_ebx > reg_bx) LOG_MSG("64MB memory limit!");
+		if(reg_ebx > reg_bx) LOG_MSG("64 MB memory limit!");
 		[[fallthrough]];
 	case XMS_RESIZE_EXTENDED_MEMORY_BLOCK:						/* 0f */
 		SET_RESULT(XMS_ResizeMemory(reg_dx, reg_bx));

--- a/src/libs/decoders/mp3_seek_table.cpp
+++ b/src/libs/decoders/mp3_seek_table.cpp
@@ -165,7 +165,7 @@ uint64_t calculate_stream_hash(struct SDL_RWops* const context) {
     auto hash_state = XXH_OK;
     vector<char> buffer(1024, 0);
 
-    // Seek prior to the last 32 KiB (or less) in the file, which is what we'll hash
+    // Seek prior to the last 32 KB (or less) in the file, which is what we'll hash
     const auto bytes_to_hash = std::min(static_cast<size_t>(32768u), stream_size);
     const auto pos_to_hash_from = static_cast<Sint64>(stream_size - bytes_to_hash);
     SDL_RWseek(context, pos_to_hash_from, RW_SEEK_SET);

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -51,7 +51,7 @@ static void init_fluid_dosbox_settings(Section_prop &secprop)
 	// in the OS. Usually it's Fluid_R3.
 	auto *str_prop = secprop.Add_string("soundfont", when_idle, "default.sf2");
 	str_prop->Set_help(
-	        "Path to a SoundFont file in .sf2 format. You can use an\n"
+	        "Path to a SoundFont file in .sf2 format ('default.sf2' by default). You can use an\n"
 	        "absolute or relative path, or the name of an .sf2 inside\n"
 	        "the 'soundfonts' directory within your DOSBox configuration\n"
 	        "directory.\n"
@@ -62,7 +62,7 @@ static void init_fluid_dosbox_settings(Section_prop &secprop)
 
 	str_prop = secprop.Add_string("fsynth_chorus", when_idle, "auto");
 	str_prop->Set_help(
-	        "Chorus effect: 'auto', 'on', 'off', or custom values.\n"
+	        "Chorus effect: 'auto (default)', 'on', 'off', or custom values.\n"
 	        "When using custom values:\n"
 	        "  All five must be provided in-order and space-separated.\n"
 	        "  They are: voice-count level speed depth modulation-wave, where:\n"
@@ -80,7 +80,7 @@ static void init_fluid_dosbox_settings(Section_prop &secprop)
 
 	str_prop = secprop.Add_string("fsynth_reverb", when_idle, "auto");
 	str_prop->Set_help(
-	        "Reverb effect: 'auto', 'on', 'off', or custom values.\n"
+	        "Reverb effect: 'auto' (default), 'on', 'off', or custom values.\n"
 	        "When using custom values:\n"
 	        "  All four must be provided in-order and space-separated.\n"
 	        "  They are: room-size damping width level, where:\n"

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -51,32 +51,29 @@ static void init_fluid_dosbox_settings(Section_prop &secprop)
 	// in the OS. Usually it's Fluid_R3.
 	auto *str_prop = secprop.Add_string("soundfont", when_idle, "default.sf2");
 	str_prop->Set_help(
-	        "Path to a SoundFont file in .sf2 format ('default.sf2' by default). You can use an\n"
-	        "absolute or relative path, or the name of an .sf2 inside\n"
-	        "the 'soundfonts' directory within your DOSBox configuration\n"
-	        "directory.\n"
-	        "Note: The optional volume scaling percentage after the filename\n"
-	        "has been deprecated. Please use a mixer command instead to\n"
-	        "change the FluidSynth audio channel's volume, e.g.:\n"
-	        "  MIXER FSYNTH 200");
+	        "Path to a SoundFont file in .sf2 format ('default.sf2' by default).\n"
+	        "You can use an absolute or relative path, or the name of an .sf2 inside the\n"
+	        "'soundfonts' directory within your DOSBox configuration directory.\n"
+	        "Notes: The optional volume scaling percentage after the filename has been\n"
+	        "       deprecated. Please use a mixer command instead to change the FluidSynth\n"
+	        "       audio channel's volume, e.g. 'MIXER FSYNTH 200'");
 
 	str_prop = secprop.Add_string("fsynth_chorus", when_idle, "auto");
 	str_prop->Set_help(
-	        "Chorus effect: 'auto (default)', 'on', 'off', or custom values.\n"
+	        "Chorus effect: 'auto' (default), 'on', 'off', or custom values.\n"
 	        "When using custom values:\n"
 	        "  All five must be provided in-order and space-separated.\n"
 	        "  They are: voice-count level speed depth modulation-wave, where:\n"
-	        "  - voice-count is an integer from 0 to 99.\n"
-	        "  - level is a decimal from 0.0 to 10.0\n"
-	        "  - speed is a decimal, measured in Hz, from 0.1 to 5.0\n"
-	        "  - depth is a decimal from 0.0 to 21.0\n"
-	        "  - modulation-wave is either 'sine' or 'triangle'\n"
+	        "    - voice-count is an integer from 0 to 99.\n"
+	        "    - level is a decimal from 0.0 to 10.0\n"
+	        "    - speed is a decimal, measured in Hz, from 0.1 to 5.0\n"
+	        "    - depth is a decimal from 0.0 to 21.0\n"
+	        "    - modulation-wave is either 'sine' or 'triangle'\n"
 	        "  For example: chorus = 3 1.2 0.3 8.0 sine\n"
-	        "Note: You can disable the FluidSynth chorus and enable the\n"
-	        "mixer-level chorus on the FluidSynth channel instead, or\n"
-	        "enable both chorus effects at the same time. Whether this\n"
-	        "sounds good depends on the SoundFont and the chorus settings\n"
-	        "being used.");
+	        "Notes: You can disable the FluidSynth chorus and enable the mixer-level chorus\n"
+	        "       on the FluidSynth channel instead, or enable both chorus effects at the\n"
+	        "       same time. Whether this sounds good depends on the SoundFont and the\n"
+	        "       chorus settings being used.");
 
 	str_prop = secprop.Add_string("fsynth_reverb", when_idle, "auto");
 	str_prop->Set_help(
@@ -84,16 +81,15 @@ static void init_fluid_dosbox_settings(Section_prop &secprop)
 	        "When using custom values:\n"
 	        "  All four must be provided in-order and space-separated.\n"
 	        "  They are: room-size damping width level, where:\n"
-	        "  - room-size is a decimal from 0.0 to 1.0\n"
-	        "  - damping is a decimal from 0.0 to 1.0\n"
-	        "  - width is a decimal from 0.0 to 100.0\n"
-	        "  - level is a decimal from 0.0 to 1.0\n"
+	        "    - room-size is a decimal from 0.0 to 1.0\n"
+	        "    - damping is a decimal from 0.0 to 1.0\n"
+	        "    - width is a decimal from 0.0 to 100.0\n"
+	        "    - level is a decimal from 0.0 to 1.0\n"
 	        "  For example: reverb = 0.61 0.23 0.76 0.56\n"
-	        "Note: You can disable the FluidSynth reverb and enable the\n"
-	        "mixer-level reverb on the FluidSynth channel instead, or\n"
-	        "enable both reverb effects at the same time. Whether this\n"
-	        "sounds good depends on the SoundFont and the reverb settings\n"
-	        "being used.");
+	        "Notes: You can disable the FluidSynth reverb and enable the mixer-level reverb\n"
+	        "       on the FluidSynth channel instead, or enable both reverb effects at the\n"
+	        "       same time. Whether this sounds good depends on the SoundFont and the\n"
+	        "       reverb settings being used.");
 
 	str_prop = secprop.Add_string("fsynth_filter", when_idle, "off");
 	assert(str_prop);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -180,10 +180,12 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	auto *str_prop       = sec_prop.Add_string("model", when_idle, "auto");
 	str_prop->Set_values(models);
 	str_prop->Set_help(
-	        "Model of synthesizer to use.\n"
-	        "'auto' picks the first model with available ROMs, in order as listed.\n"
-	        "'cm32l' and 'mt32' pick the first model of their type, in the order listed.\n"
-	        "'mt32_old' and 'mt32_new' are aliases for 1.07 and 2.04, respectively.");
+	        "MT-32 model to use:\n"
+	        "  auto:      Pick the first available model, in order as listed.\n"
+	        "  mt32:      Pick the first available MT-32 model, in order as listed.\n"
+	        "  cm32l:     Pick the first available CM-32L model, in order as listed.\n"
+	        "  mt32_old:  Alias for MT-32 v1.07.\n"
+	        "  mt32_new:  Alias for MT-32 v2.04.");
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");
 	str_prop->Set_help(


### PR DESCRIPTION
The big improvement here is listing the default values for most config settings. Some of the more elaborate ones need the `sprintf` treatment; I left those for another pass. Anyway, this takes care of the low-hanging fruit, which is about 90% of all config settings.

Almost started re-wrapping the descriptions because some lines got longer after adding the defaults, but quickly realised it's pointless because in the end it's gonna be all over the place anyway (because of the varying levels of indentation, depending on the length of the param names).
