### PR TITLE
Revert use of pinned vcpkg versions

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -11,24 +11,6 @@ env:
   VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
 jobs:
-  check_vcpkg_manifest:
-    name: Check vcpkg manifest
-    runs-on: windows-2022
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          submodules: false
-      - name: Check vcpkg manifest for outdated dependencies
-        shell: bash
-        run: |
-          git -C "${{ env.VCPKG_ROOT }}" checkout master -f
-          git -C "${{ env.VCPKG_ROOT }}" pull &> /dev/null
-          git fetch --prune --unshallow --tags &> /dev/null
-          python scripts/generate-vcpkg-manifest.py -p "${{ env.VCPKG_ROOT }}" > vcpkg.json
-          git diff vcpkg.json
-          git diff -G'version' --ignore-all-space --quiet vcpkg.json
-
   build_windows_vs:
     name: ${{ matrix.conf.name }}
     runs-on: windows-2022
@@ -53,7 +35,6 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ env.VCPKG_ROOT }}"
-          git checkout master -f && git pull &> /dev/null
           ./bootstrap-vcpkg.sh -disableMetrics
           nuget=$(./vcpkg.exe fetch nuget | tail -n 1)
           owner="${GITHUB_REPOSITORY%/*}"
@@ -136,7 +117,6 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ env.VCPKG_ROOT }}"
-          git checkout master -f && git pull &> /dev/null
           ./bootstrap-vcpkg.sh -disableMetrics
           nuget=$(./vcpkg.exe fetch nuget | tail -n 1)
           owner="${GITHUB_REPOSITORY%/*}"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,55 +1,20 @@
 {
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "dosbox-staging",
+    "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
     "version": "0.81.0-alpha",
     "dependencies": [
-        {
-            "name": "fluidsynth",
-            "version>=": "2.2.8"
-        },
-        {
-            "name": "gtest",
-            "version>=": "1.12.1"
-        },
-        {
-            "name": "iir1",
-            "version>=": "1.9.1"
-        },
-        {
-            "name": "libmt32emu",
-            "version>=": "2.7.0"
-        },
-        {
-            "name": "libpng",
-            "version>=": "1.6.39"
-        },
-        {
-            "name": "opusfile",
-            "version>=": "0.12#1"
-        },
-        {
-            "name": "sdl2",
-            "version>=": "2.26.2"
-        },
-        {
-            "name": "sdl2-image",
-            "version>=": "2.6.2#1"
-        },
-        {
-            "name": "sdl2-net",
-            "version>=": "2.2.0#1"
-        },
-        {
-            "name": "speexdsp",
-            "version>=": "1.2.1"
-        },
-        {
-            "name": "tracy",
-            "version>=": "0.9.0#1"
-        },
-        {
-            "name": "zlib",
-            "version>=": "1.2.13"
-        }
-    ],
-    "builtin-baseline": "c30de8e1369e03f4a569f8f224eed418dd0949bb"
+        "fluidsynth",
+        "gtest",
+        "iir1",
+        "libmt32emu",
+        "libpng",
+        "opusfile",
+        "sdl2",
+        "sdl2-image",
+        "sdl2-net",
+        "speexdsp",
+        "tracy",
+        "zlib"
+    ]
 }

--- a/vcpkg.json.release_only
+++ b/vcpkg.json.release_only
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "dosbox-staging",
+    "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
+    "version": "0.81.0-alpha",
+    "builtin-baseline": "19fafcdb3557f8a029ee1a4eb203600ff638448e",
+    "dependencies": [
+        {"name": "libpng", "version>=": "1.6.37#17"}, 
+        {"name": "iir1", "version>=": "1.9.0"}, 
+        {"name": "sdl2", "version>=": "2.0.22#1"},
+        {"name": "sdl2-net", "version>=": "2.0.1#9"},
+        {"name": "libmt32emu", "version>=": "2.6.2"},
+        {"name": "opusfile", "version>=": "0.12#1"},
+        {"name": "fluidsynth", "version>=": "2.2.6#2"},
+        {"name": "gtest", "version>=": "1.11.0#5"},
+        {"name": "speexdsp", "version>=": "1.2.0#7"}
+    ]
+}


### PR DESCRIPTION
Pinned VCPKG dependencies were working [as of yesterday](https://github.com/dosbox-staging/dosbox-staging/actions?query=branch%3Akc%2Fpinned-deps-1):

![2023-01-13_11-10](https://user-images.githubusercontent.com/1557255/212399810-6d3fcf8c-6088-4b54-9ac2-4f517f213503.png)

Ref: 

Within a day, [they broke](https://github.com/dosbox-staging/dosbox-staging/actions/runs/3913857629/jobs/6690249358):

![2023-01-13_11-12](https://user-images.githubusercontent.com/1557255/212399992-05bef0b8-312b-428c-bdfb-518c816d862d.png)

Not a big deal; maybe there were some package changes.
I updated our manifest's baseline to the latest:

![2023-01-13_11-02](https://user-images.githubusercontent.com/1557255/212400155-ce6235e7-dc53-4b44-8d7a-69092e676c44.png)

However, this didn't help.

The root cause is due VCPKG's ["minimum-version" policy](https://vcpkg.readthedocs.io/en/latest/specifications/versioning/) conflicting with repository maintainers desire to keep the "maximally-fixed-repo" versions and drop the "least-fixed-repo" versions, for a given major.minor.bugfix series.

For example: vcpkg determined that libtool-2.4.6-9 is the least version that can satisfy the requirement, but the repo maintainers have rolled off libtool-2.4.6-9 and kept >= libtool-2.4.6-10:

![2023-01-13_11-31](https://user-images.githubusercontent.com/1557255/212403094-ef897374-6ab4-4c2a-adc0-247c9c110a82.png)

We can see how it plays out here:

![2023-01-13_10-47](https://user-images.githubusercontent.com/1557255/212400554-a2a936e8-8b0d-47eb-98ae-c3473d561450.png)

Why did our non-pinned builds work but the pinned builds failed?

Because this minimum-version policy is only applied when using versioned manifests.  

.. within 24 hours, we've already been shown a real-world example of how quickly the pinned version tree gets in trouble and produced a configuration that's no longer available to download or build... and we were using the latest possible dependency versions available.

So for now, I'm reverting the VCPKG pinned approach. But keeping the Meson bracketing.

Because VCPKG cannot force repo hosts to keep the oldest, buggiest versions to satisfy VCPKG's minimum-version-policy, the only viable route is for them to offer bounded versions.




