### PR TITLE
Improve MIDI buffer underrun logging

### DIFF
--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -76,7 +76,9 @@ private:
 	double ms_per_audio_frame = 0.0;
 
 	std::atomic_bool keep_rendering = {};
-	bool is_open = false;
+
+	bool had_underruns = false;
+	bool is_open       = false;
 };
 
 #endif // C_FLUIDSYNTH

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -85,7 +85,9 @@ private:
 	double ms_per_audio_frame = 0.0;
 
 	std::atomic_bool keep_rendering = {};
-	bool is_open = false;
+
+	bool had_underruns = false;
+	bool is_open       = false;
 };
 
 #endif // C_MT32EMU


### PR DESCRIPTION
Click to open (screenshots to show color and context)

### MT-32

![2023-01-17_19-13_1](https://user-images.githubusercontent.com/1557255/213075264-9e366fae-6b9e-49ad-a797-e42cdff8ba94.png)

### FluidSynth

![2023-01-17_19-13](https://user-images.githubusercontent.com/1557255/213075266-37be03bc-02be-4ea8-a823-193369e73b0f.png)
