### PR TITLE
Minor cleanups in mouse and keyboard emulation code

### DIFF
--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2022-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,121 +21,49 @@
 #define DOSBOX_KEYBOARD_H
 
 enum KBD_KEYS {
+// clang-format off
 	KBD_NONE,
-	KBD_1,
-	KBD_2,
-	KBD_3,
-	KBD_4,
-	KBD_5,
-	KBD_6,
-	KBD_7,
-	KBD_8,
-	KBD_9,
-	KBD_0,
-	KBD_q,
-	KBD_w,
-	KBD_e,
-	KBD_r,
-	KBD_t,
-	KBD_y,
-	KBD_u,
-	KBD_i,
-	KBD_o,
-	KBD_p,
-	KBD_a,
-	KBD_s,
-	KBD_d,
-	KBD_f,
-	KBD_g,
-	KBD_h,
-	KBD_j,
-	KBD_k,
-	KBD_l,
-	KBD_z,
-	KBD_x,
-	KBD_c,
-	KBD_v,
-	KBD_b,
-	KBD_n,
-	KBD_m,
-	KBD_f1,
-	KBD_f2,
-	KBD_f3,
-	KBD_f4,
-	KBD_f5,
-	KBD_f6,
-	KBD_f7,
-	KBD_f8,
-	KBD_f9,
-	KBD_f10,
-	KBD_f11,
-	KBD_f12,
 
-	/*Now the weirder keys */
+	KBD_1, KBD_2, KBD_3, KBD_4, KBD_5, KBD_6, KBD_7, KBD_8, KBD_9, KBD_0,
+	KBD_q, KBD_w, KBD_e, KBD_r, KBD_t, KBD_y, KBD_u, KBD_i, KBD_o, KBD_p,
+	KBD_a, KBD_s, KBD_d, KBD_f, KBD_g, KBD_h, KBD_j, KBD_k, KBD_l,
+	KBD_z, KBD_x, KBD_c, KBD_v, KBD_b, KBD_n, KBD_m,
 
-	KBD_esc,
-	KBD_tab,
-	KBD_backspace,
-	KBD_enter,
-	KBD_space,
-	KBD_leftalt,
-	KBD_rightalt,
-	KBD_leftctrl,
-	KBD_rightctrl,
-	KBD_leftgui,
-	KBD_rightgui,
-	KBD_leftshift,
-	KBD_rightshift,
-	KBD_capslock,
-	KBD_scrolllock,
-	KBD_numlock,
+	KBD_f1,  KBD_f2,  KBD_f3,  KBD_f4,  KBD_f5,  KBD_f6,
+	KBD_f7,  KBD_f8,  KBD_f9,  KBD_f10, KBD_f11, KBD_f12,
 
-	KBD_grave,
-	KBD_minus,
-	KBD_equals,
-	KBD_backslash,
-	KBD_leftbracket,
-	KBD_rightbracket,
-	KBD_semicolon,
-	KBD_quote,
-	KBD_period,
-	KBD_comma,
-	KBD_slash,
+	// Now the weirder keys
+
+	KBD_esc, KBD_tab, KBD_backspace, KBD_enter, KBD_space,
+
+	KBD_leftalt,   KBD_rightalt,
+	KBD_leftctrl,  KBD_rightctrl,
+	KBD_leftgui,   KBD_rightgui, // 'windows' keys
+	KBD_leftshift, KBD_rightshift,
+	
+	KBD_capslock, KBD_scrolllock, KBD_numlock,
+
+	KBD_grave, KBD_minus, KBD_equals, KBD_backslash,
+	KBD_leftbracket, KBD_rightbracket,
+	KBD_semicolon, KBD_quote,
+	KBD_period, KBD_comma, KBD_slash,
 	KBD_extra_lt_gt,
 
-	KBD_printscreen,
-	KBD_pause,
-	KBD_insert,
-	KBD_home,
-	KBD_pageup,
-	KBD_delete,
-	KBD_end,
-	KBD_pagedown,
-	KBD_left,
-	KBD_up,
-	KBD_down,
-	KBD_right,
+	KBD_printscreen, KBD_pause,
 
-	KBD_kp1,
-	KBD_kp2,
-	KBD_kp3,
-	KBD_kp4,
-	KBD_kp5,
-	KBD_kp6,
-	KBD_kp7,
-	KBD_kp8,
-	KBD_kp9,
-	KBD_kp0,
-	KBD_kpdivide,
-	KBD_kpmultiply,
-	KBD_kpminus,
-	KBD_kpplus,
-	KBD_kpenter,
-	KBD_kpperiod,
+	KBD_insert, KBD_home, KBD_pageup,
+	KBD_delete, KBD_end,  KBD_pagedown,
+	
+	KBD_left, KBD_up, KBD_down, KBD_right,
+
+	KBD_kp1, KBD_kp2, KBD_kp3, KBD_kp4, KBD_kp5, KBD_kp6, KBD_kp7, KBD_kp8, KBD_kp9, KBD_kp0,
+	KBD_kpdivide, KBD_kpmultiply, KBD_kpminus, KBD_kpplus,
+	KBD_kpenter, KBD_kpperiod,
 
 	KBD_intl1,
 
-	KBD_LAST
+	KBD_LAST,
+// clang-format on
 };
 
 void KEYBOARD_ClrBuffer(void);

--- a/src/hardware/mouse/mouseif_dos_driver.cpp
+++ b/src/hardware/mouse/mouseif_dos_driver.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *  Copyright (C) 2022-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -241,18 +241,22 @@ static uint16_t mickey_counter_to_reg16(const float x)
 // Data - default cursor/mask
 // ***************************************************************************
 
-static constexpr uint16_t default_text_and_mask = 0x77FF;
+static constexpr uint16_t default_text_and_mask = 0x77ff;
 static constexpr uint16_t default_text_xor_mask = 0x7700;
 
+// clang-format off
+
 static uint16_t default_screen_mask[cursor_size_y] = {
-	0x3FFF, 0x1FFF, 0x0FFF, 0x07FF, 0x03FF, 0x01FF, 0x00FF, 0x007F,
-        0x003F, 0x001F, 0x01FF, 0x00FF, 0x30FF, 0xF87F, 0xF87F, 0xFCFF
+	0x3fff, 0x1fff, 0x0fff, 0x07ff, 0x03ff, 0x01ff, 0x00ff, 0x007f,
+	0x003f, 0x001f, 0x01ff, 0x00ff, 0x30ff, 0xf87f, 0xf87f, 0xfcff
 };
 
 static uint16_t default_cursor_mask[cursor_size_y] = {
-	0x0000, 0x4000, 0x6000, 0x7000, 0x7800, 0x7C00, 0x7E00, 0x7F00,
-        0x7F80, 0x7C00, 0x6C00, 0x4600, 0x0600, 0x0300, 0x0300, 0x0000
+	0x0000, 0x4000, 0x6000, 0x7000, 0x7800, 0x7c00, 0x7e00, 0x7f00,
+	0x7f80, 0x7c00, 0x6c00, 0x4600, 0x0600, 0x0300, 0x0300, 0x0000
 };
+
+// clang-format on
 
 // ***************************************************************************
 // Text mode cursor


### PR DESCRIPTION
Minor cleanups, just to improve code readability and make clang formatter happy. No changes in code behavior.

This is a backport from my development to reduce the size of the upcoming (hopefully) pull request(s).