### PR TITLE
Improve window-size determination

### DIFF
--- a/contrib/window_tshirt_sizes/README.md
+++ b/contrib/window_tshirt_sizes/README.md
@@ -1,0 +1,18 @@
+# T-Shirt Sizes
+
+See how different percentages for the small, medium,
+and large t-shirt sizes generate different window
+resolutions for the various screen sizes.
+
+## Build
+
+``` shell
+meson setup build
+meson compile -C build
+```
+
+## Run
+
+``` shell
+  ./build/sizes
+```

--- a/contrib/window_tshirt_sizes/meson.build
+++ b/contrib/window_tshirt_sizes/meson.build
@@ -1,0 +1,10 @@
+project(
+    'tshirt-sizes',
+    'cpp',
+    default_options: [ 'cpp_std=c++17' ]
+)
+
+executable(
+    'sizes',
+    'src/sizes.cpp',
+)

--- a/contrib/window_tshirt_sizes/src/sizes.cpp
+++ b/contrib/window_tshirt_sizes/src/sizes.cpp
@@ -1,0 +1,139 @@
+
+#include <cassert>
+#include <stdio.h>
+
+class SDL_Point {
+public:
+	int x            = 0;
+	int y            = 0;
+	const char* name = nullptr;
+	constexpr SDL_Point(const int _x, const int _y, const char* _name = nullptr)
+	        : x(_x),
+	          y(_y),
+	          name(_name){};
+};
+
+constexpr SDL_Point eight_by_five_ratio = {8, 5, "widescreen"};
+constexpr SDL_Point four_by_three_ratio = {4, 3, "standard"};
+
+constexpr SDL_Point list_of_aspect_ratios[] = {eight_by_five_ratio,
+                                               four_by_three_ratio};
+
+constexpr int small_percent  = 33;
+constexpr int medium_percent = 50;
+constexpr int large_percent  = 75;
+constexpr int full_percent   = 100;
+
+constexpr int list_of_percent_scalers[] = {small_percent,
+                                           medium_percent,
+                                           large_percent,
+                                           full_percent};
+
+// https://en.wikipedia.org/wiki/Display_resolution
+constexpr SDL_Point list_of_screen_dimensions[] = {
+        {640, 480, "VGA"},
+        {720, 480, "480p NTSC"},
+        {726, 576, "480p PAL"},
+        {800, 600, "SVGA"},
+        {1024, 768, "XGA"},
+        {1280, 720, "720p"},
+        {1280, 800, "WXGA"},
+        {1280, 1024, "Super-eXtended Graphics Array (SXGA)"},
+        {1360, 768, "High Definition (HD)"},
+        {1366, 768, "High Definition (HD)"},
+        {1440, 900, "WXGA+"},
+        {1536, 864, "N/A"},
+        {1600, 900, "High Definition Plus (HD+)"},
+        {1680, 1050, "WSXGA+"},
+        {1600, 1200, "High Definition Plus (HD+)"},
+        {1920, 1080, "Full High Definition (FHD)"},
+        {1920, 1200, "Wide Ultra Extended Graphics Array (WUXGA)"},
+        {2048, 872, "Cinemascope"},
+        {2048, 1152, "QWXGA 16:9"},
+        {2048, 1536, "QXGA 4:3"},
+        {2048, 1556, "Film (full-aperture)"},
+        {2560, 1080, "UWFHD roughly 21:9"},
+        {2560, 1440, "Quad High Definition (QHD)"},
+        {2560, 1600, "WQXGA 16:10"},
+        {3440, 1440, "Wide Quad High Definition (WQHD)"},
+        {3840, 2160, "4K or Ultra High Definition (UHD)"},
+        {4096, 3072, "4K reference resolution"},
+        {7680, 4320, "8K"},
+};
+
+SDL_Point calc_nearest_aspect_corrected_dimensions(const SDL_Point& source_dimensions,
+                                                   const SDL_Point& aspect_ratios,
+                                                   const int in_multiples_of = 20)
+{
+	auto to_nearest_multiple = [](const int source_dimension,
+	                              const int aspect_ratio,
+	                              const int in_multiples_of) {
+		assert(aspect_ratio > 0);
+		assert(in_multiples_of > 0);
+		const auto aspect_multiple = aspect_ratio * in_multiples_of;
+		assert(source_dimension > aspect_multiple);
+		return (source_dimension / aspect_multiple) * aspect_multiple;
+	};
+
+	auto width = to_nearest_multiple(source_dimensions.x,
+	                                 aspect_ratios.x,
+	                                 in_multiples_of);
+
+	auto height = to_nearest_multiple(source_dimensions.y,
+	                                  aspect_ratios.y,
+	                                  in_multiples_of);
+
+	const auto width_with_ratio  = width * aspect_ratios.y;
+	const auto height_with_ratio = height * aspect_ratios.x;
+
+	// screen is landscape, so bound the width using the height
+	if (width_with_ratio > height_with_ratio) {
+		width = height_with_ratio / aspect_ratios.y;
+	}
+	// screen is portrait, so bound the height using the width
+	else if (height_with_ratio > width_with_ratio) {
+		height = width_with_ratio / aspect_ratios.x;
+	}
+
+	return {width, height};
+}
+
+int main()
+{
+	auto print_dimensions = [](const SDL_Point& dimensions) {
+		printf("%4dx%4d ", dimensions.x, dimensions.y);
+	};
+
+	for (const auto& aspect_ratio : list_of_aspect_ratios) {
+		printf("Sizes for %s aspect ratio %d:%d\n",
+		       aspect_ratio.name,
+		       aspect_ratio.x,
+		       aspect_ratio.y);
+		printf("   Screen     Small    Medium     Large      Full  Description\n");
+
+		for (const auto& screen_dimensions : list_of_screen_dimensions) {
+			print_dimensions(screen_dimensions);
+
+			for (const int percentage_scaler : list_of_percent_scalers) {
+				auto scale_by = [](const int dim, const int scaler) {
+					return dim * scaler / 100;
+				};
+				const SDL_Point reduced_dimensions = {
+				        scale_by(screen_dimensions.x, percentage_scaler),
+				        scale_by(screen_dimensions.y,
+				                 percentage_scaler)};
+
+				const auto nearest_dimensions =
+				        calc_nearest_aspect_corrected_dimensions(
+				                reduced_dimensions, aspect_ratio);
+
+				print_dimensions(nearest_dimensions);
+			}
+			printf(" %s\n", screen_dimensions.name);
+		}
+
+		printf("\n");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Some users have reported huge default windows out-of-the-box on Windows:

![image](https://user-images.githubusercontent.com/1557255/213963119-15d6b24e-22ab-49b4-8d3c-324da0e820da.png)

This is due to the window-size calculation being too aggressive in using vertical space combined with the "magnification" feature on Windows. 

One of the benefits of the previous look-up-table approach was that it picked decent small, medium, and large dimensions for a range of screen sizes (from 720p up to 4k).

This PR replaces the screen size lookup table with a step-wise calculation, and slightly more conservative presets, with the goal of still picking decent sizes.

Small is ~33%, medium is 50%, and large is 75%.


## 4:3-aspect preset sizes

```
   Screen     Small    Medium     Large      Full  Description
 640x 480  160x 120  320x 240  480x 360  640x 480  VGA
 720x 480  160x 120  320x 240  480x 360  640x 480  480p NTSC
 726x 576  160x 120  320x 240  480x 360  720x 540  480p PAL
 800x 600  240x 180  400x 300  560x 420  800x 600  SVGA
1024x 768  320x 240  480x 360  720x 540  960x 720  XGA
1280x 720  240x 180  480x 360  720x 540  960x 720  720p
1280x 800  320x 240  480x 360  800x 600 1040x 780  WXGA
1280x1024  400x 300  640x 480  960x 720 1280x 960  Super-eXtended Graphics Array (SXGA)
1360x 768  320x 240  480x 360  720x 540  960x 720  High Definition (HD)
1366x 768  320x 240  480x 360  720x 540  960x 720  High Definition (HD)
1440x 900  320x 240  560x 420  880x 660 1200x 900  WXGA+
1536x 864  320x 240  560x 420  800x 600 1120x 840  N/A
1600x 900  320x 240  560x 420  880x 660 1200x 900  High Definition Plus (HD+)
1680x1050  400x 300  640x 480 1040x 780 1360x1020  WSXGA+
1600x1200  480x 360  800x 600 1200x 900 1600x1200  High Definition Plus (HD+)
1920x1080  400x 300  720x 540 1040x 780 1440x1080  Full High Definition (FHD)
1920x1200  480x 360  800x 600 1200x 900 1600x1200  Wide Ultra Extended Graphics Array (WUXGA)
2048x 872  320x 240  560x 420  800x 600 1120x 840  Cinemascope
2048x1152  480x 360  720x 540 1120x 840 1520x1140  QWXGA 16:9
2048x1536  640x 480  960x 720 1520x1140 2000x1500  QXGA 4:3
2048x1556  640x 480  960x 720 1520x1140 2000x1500  Film (full-aperture)
2560x1080  400x 300  720x 540 1040x 780 1440x1080  UWFHD roughly 21:9
2560x1440  560x 420  960x 720 1440x1080 1920x1440  Quad High Definition (QHD)
2560x1600  640x 480 1040x 780 1600x1200 2080x1560  WQXGA 16:10
3440x1440  560x 420  960x 720 1440x1080 1920x1440  Wide Quad High Definition (WQHD)
3840x2160  880x 660 1440x1080 2160x1620 2880x2160  4K or Ultra High Definition (UHD)
4096x3072 1280x 960 2000x1500 3040x2280 4080x3060  4K reference resolution
7680x4320 1840x1380 2880x2160 4320x3240 5760x4320  8K
```

## 8:5-aspect preset sizes

```
   Screen     Small    Medium     Large      Full  Description
 640x 480  160x 100  320x 200  480x 300  640x 400  VGA
 720x 480  160x 100  320x 200  480x 300  640x 400  480p NTSC
 726x 576  160x 100  320x 200  480x 300  640x 400  480p PAL
 800x 600  160x 100  320x 200  480x 300  800x 500  SVGA
1024x 768  320x 200  480x 300  640x 400  960x 600  XGA
1280x 720  320x 200  480x 300  800x 500 1120x 700  720p
1280x 800  320x 200  640x 400  960x 600 1280x 800  WXGA
1280x1024  320x 200  640x 400  960x 600 1280x 800  Super-eXtended Graphics Array (SXGA)
1360x 768  320x 200  480x 300  800x 500 1120x 700  High Definition (HD)
1366x 768  320x 200  480x 300  800x 500 1120x 700  High Definition (HD)
1440x 900  320x 200  640x 400  960x 600 1440x 900  WXGA+
1536x 864  320x 200  640x 400  960x 600 1280x 800  N/A
1600x 900  320x 200  640x 400  960x 600 1440x 900  High Definition Plus (HD+)
1680x1050  480x 300  800x 500 1120x 700 1600x1000  WSXGA+
1600x1200  480x 300  800x 500 1120x 700 1600x1000  High Definition Plus (HD+)
1920x1080  480x 300  800x 500 1280x 800 1600x1000  Full High Definition (FHD)
1920x1200  480x 300  960x 600 1440x 900 1920x1200  Wide Ultra Extended Graphics Array (WUXGA)
2048x 872  320x 200  640x 400  960x 600 1280x 800  Cinemascope
2048x1152  480x 300  800x 500 1280x 800 1760x1100  QWXGA 16:9
2048x1536  640x 400  960x 600 1440x 900 1920x1200  QXGA 4:3
2048x1556  640x 400  960x 600 1440x 900 1920x1200  Film (full-aperture)
2560x1080  480x 300  800x 500 1280x 800 1600x1000  UWFHD roughly 21:9
2560x1440  640x 400 1120x 700 1600x1000 2240x1400  Quad High Definition (QHD)
2560x1600  800x 500 1280x 800 1920x1200 2560x1600  WQXGA 16:10
3440x1440  640x 400 1120x 700 1600x1000 2240x1400  Wide Quad High Definition (WQHD)
3840x2160 1120x 700 1600x1000 2560x1600 3360x2100  4K or Ultra High Definition (UHD)
4096x3072 1280x 800 1920x1200 3040x1900 4000x2500  4K reference resolution
7680x4320 2240x1400 3360x2100 5120x3200 6880x4300  8K
```