### PR TITLE
Add wrap for SDL2 to support static macos builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ project(
         'glib:warning_level=0',
         'glib:xattr=false',
         'gtest:warning_level=0',
+        'libjpeg-turbo:b_staticpic=true',
+        'libpng:b_staticpic=true',
+        'sdl2_image:b_staticpic=true',
     ],
 )
 
@@ -508,7 +511,8 @@ if get_option('use_sdl2_image')
     sdl2_image_dep = dependency(
         'SDL2_image',
         version: ['>= 2.0.0', '< 3'],
-        static: ('sdl2_image' in static_libs_list),
+        default_options: default_wrap_options,
+        static: ('sdl2_image' in static_libs_list or prefers_static_libs),
         not_found_message: msg.format('use_sdl2_image'),
     )
 endif

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -12,6 +12,7 @@ libgui = static_library(
     include_directories: incdir,
     dependencies: [
         sdl2_dep,
+        sdl2_image_dep,
         opengl_dep,
         ghc_dep,
         libiir_dep,

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -9,8 +9,8 @@ munt-libmt32emu*
 packagecache
 pcre*
 proxy-libintl*
+SDL2_image-*
 speexdsp-*
 tracy-*
 zlib*
 gvdb*
-

--- a/subprojects/libjpeg-turbo.wrap
+++ b/subprojects/libjpeg-turbo.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = libjpeg-turbo-2.1.4
+source_url = https://sourceforge.net/projects/libjpeg-turbo/files/2.1.4/libjpeg-turbo-2.1.4.tar.gz
+source_filename = libjpeg-turbo-2.1.4.tar.gz
+source_hash = d3ed26a1131a13686dfca4935e520eb7c90ae76fbc45d98bb50a8dc86230342b
+patch_filename = libjpeg-turbo_2.1.4-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_2.1.4-1/get_patch
+patch_hash = 5ac2378c090a3456f4dd34e80b12bbaf17e40eba67de1eeb366b3cbf5eb03269
+wrapdb_version = 2.1.4-1
+
+[provide]
+dependency_names = libjpeg

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = libpng-1.6.39
+source_url = https://github.com/glennrp/libpng/archive/v1.6.39.tar.gz
+source_filename = libpng-1.6.39.tar.gz
+source_hash = a00e9d2f2f664186e4202db9299397f851aea71b36a35e74910b8820e380d441
+patch_filename = libpng_1.6.39-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.39-2/get_patch
+patch_hash = 8bcf8f69f50233f3a35e3718ab3c91b0c51b4c1a08a84c87be0b1f4813adf17f
+wrapdb_version = 1.6.39-2
+
+[provide]
+libpng = libpng_dep

--- a/subprojects/sdl2_image.wrap
+++ b/subprojects/sdl2_image.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = SDL2_image-2.6.2
+source_url = https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.6.2.tar.gz
+source_filename = SDL2_image-2.6.2.tar.gz
+source_hash = 48355fb4d8d00bac639cd1c4f4a7661c4afef2c212af60b340e06b7059814777
+patch_filename = sdl2_image_2.6.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_image_2.6.2-1/get_patch
+patch_hash = 07592dc80753ba0d0855753a7fa09f76718cb6b744305d85fb8e3738ac77b285
+wrapdb_version = 2.6.2-1
+
+[provide]
+sdl2_image = sdl2_image_dep


### PR DESCRIPTION
Homebrew's latest SDL2 image package no longer is a stand-alone library, but depends on other shared brew libraries (below), which breaks our self-contained macos release builds:

```
/usr/local/homebrew/opt/highway/lib/libhwy.1.dylib (compatibility version 1.0.0, current version 1.0.3)
/usr/local/homebrew/opt/brotli/lib/libbrotlidec.1.dylib (compatibility version 1.0.0, current version 1.0.9)
/usr/local/homebrew/opt/libavif/lib/libavif.15.dylib (compatibility version 15.0.0, current version 15.0.1)
```

This PR adds the sdl2-image wrap to let us build our own local and static sdl2-image instead of depending on brew.