### PR TITLE
Skip processing of hidden host files

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -37,6 +37,8 @@ std::optional<std::vector<std::string>> get_lines(const std_fs::path &text_file)
 // Is the candidate a directory or a symlink that points to one?
 bool is_directory(const std::string& candidate);
 
+bool is_hidden_by_host(const std::filesystem::path& pathname);
+
 /* Check if the given path corresponds to an existing file or directory.
  */
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -199,8 +199,8 @@ bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
 	return (fhandle != NULL);
 }
 
-FILE * localDrive::GetSystemFilePtr(char const * const name, char const * const type) {
-
+FILE* localDrive::GetSystemFilePtr(const char* const name, const char* const type)
+{
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
 	safe_strcat(newname, name);
@@ -210,8 +210,8 @@ FILE * localDrive::GetSystemFilePtr(char const * const name, char const * const 
 	return fopen_wrap(newname,type);
 }
 
-bool localDrive::GetSystemFilename(char *sysName, char const * const dosName) {
-
+bool localDrive::GetSystemFilename(char* sysName, const char* const dosName)
+{
 	strcpy(sysName, basedir);
 	strcat(sysName, dosName);
 	CROSS_FILENAME(sysName);
@@ -348,6 +348,10 @@ bool localDrive::FindNext(DOS_DTA & dta) {
 		const char* temp_name = dirCache.GetExpandName(full_name);
 		if (stat(temp_name, &stat_block) != 0) {
 			continue; // No symlinks and such
+		}
+
+		if (is_hidden_by_host(temp_name)) {
+			continue; // No host-only hidden files
 		}
 
 		if (stat_block.st_mode & S_IFDIR) {

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -45,7 +45,7 @@ bool is_directory(const std::string& candidate)
 	return std_fs::is_directory(p, ec);
 }
 
-bool is_hidden_by_host(const std::filesystem::path& pathname)
+bool is_hidden_by_host(const std_fs::path& pathname)
 {
 	assert(!pathname.empty());
 	const auto filename = pathname.filename().string();
@@ -56,11 +56,14 @@ bool is_hidden_by_host(const std::filesystem::path& pathname)
 		return false;
 	}
 
-	// If the filename starts with a dot and is longer than "8.3" or has any
-	// lower-case characters then it's definitely not a DOS filename and is
-	// meant to be hidden.
 	assert(filename[0] == '.');
-	return filename.length() > DOS_NAMELENGTH ||
+	const auto extension = pathname.extension().string();
+
+	// Consider the file hidden by the host so long as the filename starts
+	// with a dot *and* has an extension longer that DOS's three characters
+	// or uses any lower-case characters.
+
+	return extension.length() > DOS_EXTLENGTH ||
 	       std::any_of(filename.begin(), filename.end(), islower);
 }
 


### PR DESCRIPTION
Hidden host files (for local metadata and configuration records) are typically held in files (and directories) that start with a dot.

We use this pattern combined with the fact that any name longer than "8.3" or that uses lower-case characters is by definition not a DOS filename (and wasn't created by a DOS program), and therefore is highly likely meant to be  a hidden host file.

Suggest reviewing commit by commit. 

 - The "Replace `goto` with `while`" commit is meant to be white-space only (but looks more involved, because it indents the block inside the while loop). 