### PR TITLE
Sync dh fpu and normal fpu

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -115,12 +115,23 @@ static inline void FPU_SetTag(uint16_t tag){
 		fpu.tags[i] = static_cast<FPU_Tag>((tag >>(2*i))&3);
 }
 
+static inline uint16_t FPU_GetCW(void){
+    return fpu.cw;
+}
+
 static inline void FPU_SetCW(Bitu word){
 	fpu.cw = (uint16_t)word;
 	fpu.cw_mask_all = (uint16_t)(word | 0x3f);
 	fpu.round = (FPU_Round)((word >> 10) & 3);
 }
 
+static inline uint16_t FPU_GetSW(void){
+    return fpu.sw;
+}
+
+static inline void FPU_SetSW(Bitu word){
+    fpu.sw = (uint16_t)word;
+}
 
 static inline Bitu FPU_GET_TOP(void) {
 	return (fpu.sw & 0x3800)>>11;
@@ -131,6 +142,8 @@ static inline void FPU_SET_TOP(Bitu val){
 	fpu.sw |= (val&7)<<11;
 }
 
+void FPU_Load_P_Regs(const uint8_t* buffer);
+void FPU_Save_P_Regs(uint8_t* buffer);
 
 static inline void FPU_SET_C0(Bitu C){
 	fpu.sw &= ~0x0100;

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -116,7 +116,7 @@ static inline void FPU_SetTag(uint16_t tag){
 }
 
 static inline uint16_t FPU_GetCW(void){
-    return fpu.cw;
+	return fpu.cw;
 }
 
 static inline void FPU_SetCW(Bitu word){
@@ -126,11 +126,11 @@ static inline void FPU_SetCW(Bitu word){
 }
 
 static inline uint16_t FPU_GetSW(void){
-    return fpu.sw;
+	return fpu.sw;
 }
 
 static inline void FPU_SetSW(Bitu word){
-    fpu.sw = (uint16_t)word;
+	fpu.sw = (uint16_t)word;
 }
 
 static inline Bitu FPU_GET_TOP(void) {

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -142,8 +142,8 @@ static inline void FPU_SET_TOP(Bitu val){
 	fpu.sw |= (val&7)<<11;
 }
 
-void FPU_Load_P_Regs(const uint8_t* buffer);
-void FPU_Save_P_Regs(uint8_t* buffer);
+void FPU_LoadPRegs(const uint8_t* buffer);
+void FPU_SavePRegs(uint8_t* buffer);
 
 static inline void FPU_SET_C0(Bitu C){
 	fpu.sw &= ~0x0100;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -268,26 +268,19 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 		auto_fpu_sync () {
 			FPU_SetTag(dyn_dh_fpu.state.tag);
 			FPU_SetCW(dyn_dh_fpu.state.cw);
-			fpu.sw = dyn_dh_fpu.state.sw;
+			FPU_SetSW(dyn_dh_fpu.state.sw);
 			TOP = FPU_GET_TOP();
-			for(Bitu i = 0;i < 8;i++){
-				fpu.p_regs[STV(i)].m1 = *((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+0));
-				fpu.p_regs[STV(i)].m2 = *((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+4));
-				fpu.p_regs[STV(i)].m3 = *((uint16_t*)(dyn_dh_fpu.state.st_reg[i]+8));
-			}
+            FPU_Load_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
 		}
 		~auto_fpu_sync () {
 			FPU_SET_TOP(TOP);
+			dyn_dh_fpu.state.sw = FPU_GetSW();
+			dyn_dh_fpu.state.cw = FPU_GetCW();
 			dyn_dh_fpu.state.tag = FPU_GetTag();
-			dyn_dh_fpu.state.cw = fpu.cw;
-			dyn_dh_fpu.state.sw = fpu.sw;
-			for(Bitu i = 0;i < 8;i++){
-				*((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+0)) = fpu.p_regs[STV(i)].m1;
-				*((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+4)) = fpu.p_regs[STV(i)].m2;
-				*((uint16_t*)(dyn_dh_fpu.state.st_reg[i]+8)) = fpu.p_regs[STV(i)].m3;
-			}
+            FPU_Save_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
 		}
 	};
+
 	/* Determine the linear address of CS:EIP */
 restart_core:
 	PhysPt ip_point=SegPhys(cs)+reg_eip;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -270,14 +270,14 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			FPU_SetCW(dyn_dh_fpu.state.cw);
 			FPU_SetSW(dyn_dh_fpu.state.sw);
 			TOP = FPU_GET_TOP();
-			FPU_Load_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
+			FPU_LoadPRegs(&dyn_dh_fpu.state.st_reg[0][0]);
 		}
 		~auto_fpu_sync () {
 			FPU_SET_TOP(TOP);
 			dyn_dh_fpu.state.sw = FPU_GetSW();
 			dyn_dh_fpu.state.cw = FPU_GetCW();
 			dyn_dh_fpu.state.tag = FPU_GetTag();
-			FPU_Save_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
+			FPU_SavePRegs(&dyn_dh_fpu.state.st_reg[0][0]);
 		}
 	};
 

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -322,9 +322,9 @@ restart_core:
 			// get weird failures such as "FPU stack overflow", guest app
 			// deadlock or guest app crash.
 			Bits nc_retcode = [] {
-                auto_fpu_sync sync_fpu;
-                return CPU_Core_Normal_Run();
-            }();
+				auto_fpu_sync sync_fpu;
+				return CPU_Core_Normal_Run();
+			}();
 			if (!nc_retcode) {
 				CPU_Cycles=old_cycles-1;
 				goto restart_core;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -270,14 +270,14 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			FPU_SetCW(dyn_dh_fpu.state.cw);
 			FPU_SetSW(dyn_dh_fpu.state.sw);
 			TOP = FPU_GET_TOP();
-            FPU_Load_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
+			FPU_Load_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
 		}
 		~auto_fpu_sync () {
 			FPU_SET_TOP(TOP);
 			dyn_dh_fpu.state.sw = FPU_GetSW();
 			dyn_dh_fpu.state.cw = FPU_GetCW();
 			dyn_dh_fpu.state.tag = FPU_GetTag();
-            FPU_Save_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
+			FPU_Save_P_Regs(&dyn_dh_fpu.state.st_reg[0][0]);
 		}
 	};
 

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -321,8 +321,10 @@ restart_core:
 			// `dyn_dh_fpu`. If we do not sync between the 2 FPU states, we may
 			// get weird failures such as "FPU stack overflow", guest app
 			// deadlock or guest app crash.
-			auto_fpu_sync sync_fpu;
-			Bits nc_retcode=CPU_Core_Normal_Run();
+			Bits nc_retcode = [] {
+                auto_fpu_sync sync_fpu;
+                return CPU_Core_Normal_Run();
+            }();
 			if (!nc_retcode) {
 				CPU_Cycles=old_cycles-1;
 				goto restart_core;

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -42,19 +42,19 @@ uint16_t FPU_GetTag(void){
 }
 
 void FPU_Load_P_Regs(const uint8_t* buffer) {
-    for(Bitu i = 0;i < 8; i++){
-        fpu.p_regs[STV(i)].m1 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 0));
-        fpu.p_regs[STV(i)].m2 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 4));
-        fpu.p_regs[STV(i)].m3 = *(reinterpret_cast<const uint16_t*>(buffer + i * 10 + 8));
-    }
+	for(Bitu i = 0;i < 8; i++){
+		fpu.p_regs[STV(i)].m1 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 0));
+		fpu.p_regs[STV(i)].m2 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 4));
+		fpu.p_regs[STV(i)].m3 = *(reinterpret_cast<const uint16_t*>(buffer + i * 10 + 8));
+	}
 }
 
 void FPU_Save_P_Regs(uint8_t* buffer) {
-    for(Bitu i = 0;i < 8; i++){
-        *(reinterpret_cast<uint32_t*>(buffer + i * 10 + 0)) = fpu.p_regs[STV(i)].m1;
-        *(reinterpret_cast<uint32_t*>(buffer + i * 10 + 4)) = fpu.p_regs[STV(i)].m2;
-        *(reinterpret_cast<uint16_t*>(buffer + i * 10 + 8)) = fpu.p_regs[STV(i)].m3;
-    }
+	for(Bitu i = 0;i < 8; i++){
+		*(reinterpret_cast<uint32_t*>(buffer + i * 10 + 0)) = fpu.p_regs[STV(i)].m1;
+		*(reinterpret_cast<uint32_t*>(buffer + i * 10 + 4)) = fpu.p_regs[STV(i)].m2;
+		*(reinterpret_cast<uint16_t*>(buffer + i * 10 + 8)) = fpu.p_regs[STV(i)].m3;
+	}
 }
 
 #if C_FPU_X86

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -43,13 +43,13 @@ uint16_t FPU_GetTag(void){
 
 void FPU_LoadPRegs(const uint8_t* buffer) {
 	for(Bitu i = 0; i < 8; i++){
-		memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
+		memcpy(&fpu.p_regs[i], buffer + i * 10, 10);
 	}
 }
 
 void FPU_SavePRegs(uint8_t* buffer) {
 	for(Bitu i = 0; i < 8; i++){
-		memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
+		memcpy(buffer + i * 10, &fpu.p_regs[i], 10);
 	}
 }
 

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -43,13 +43,13 @@ uint16_t FPU_GetTag(void){
 
 void FPU_LoadPRegs(const uint8_t* buffer) {
 	for(Bitu i = 0; i < 8; i++){
-		memcpy(&fpu.p_regs[i], buffer + i * 10, 10);
+		memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
 	}
 }
 
 void FPU_SavePRegs(uint8_t* buffer) {
 	for(Bitu i = 0; i < 8; i++){
-		memcpy(buffer + i * 10, &fpu.p_regs[i], 10);
+		memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
 	}
 }
 

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -43,17 +43,13 @@ uint16_t FPU_GetTag(void){
 
 void FPU_Load_P_Regs(const uint8_t* buffer) {
 	for(Bitu i = 0;i < 8; i++){
-		fpu.p_regs[STV(i)].m1 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 0));
-		fpu.p_regs[STV(i)].m2 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 4));
-		fpu.p_regs[STV(i)].m3 = *(reinterpret_cast<const uint16_t*>(buffer + i * 10 + 8));
+		memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
 	}
 }
 
 void FPU_Save_P_Regs(uint8_t* buffer) {
 	for(Bitu i = 0;i < 8; i++){
-		*(reinterpret_cast<uint32_t*>(buffer + i * 10 + 0)) = fpu.p_regs[STV(i)].m1;
-		*(reinterpret_cast<uint32_t*>(buffer + i * 10 + 4)) = fpu.p_regs[STV(i)].m2;
-		*(reinterpret_cast<uint16_t*>(buffer + i * 10 + 8)) = fpu.p_regs[STV(i)].m3;
+		memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
 	}
 }
 

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -41,15 +41,15 @@ uint16_t FPU_GetTag(void){
 	return tag;
 }
 
-void FPU_Load_P_Regs(const uint8_t* buffer) {
-	for(Bitu i = 0;i < 8; i++){
-		memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
+void FPU_LoadPRegs(const uint8_t* buffer) {
+	for(Bitu i = 0; i < 8; i++){
+		memcpy(&fpu.p_regs[i], buffer + i * 10, 10);
 	}
 }
 
-void FPU_Save_P_Regs(uint8_t* buffer) {
-	for(Bitu i = 0;i < 8; i++){
-		memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
+void FPU_SavePRegs(uint8_t* buffer) {
+	for(Bitu i = 0; i < 8; i++){
+		memcpy(buffer + i * 10, &fpu.p_regs[i], 10);
 	}
 }
 

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -41,6 +41,22 @@ uint16_t FPU_GetTag(void){
 	return tag;
 }
 
+void FPU_Load_P_Regs(const uint8_t* buffer) {
+    for(Bitu i = 0;i < 8; i++){
+        fpu.p_regs[STV(i)].m1 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 0));
+        fpu.p_regs[STV(i)].m2 = *(reinterpret_cast<const uint32_t*>(buffer + i * 10 + 4));
+        fpu.p_regs[STV(i)].m3 = *(reinterpret_cast<const uint16_t*>(buffer + i * 10 + 8));
+    }
+}
+
+void FPU_Save_P_Regs(uint8_t* buffer) {
+    for(Bitu i = 0;i < 8; i++){
+        *(reinterpret_cast<uint32_t*>(buffer + i * 10 + 0)) = fpu.p_regs[STV(i)].m1;
+        *(reinterpret_cast<uint32_t*>(buffer + i * 10 + 4)) = fpu.p_regs[STV(i)].m2;
+        *(reinterpret_cast<uint16_t*>(buffer + i * 10 + 8)) = fpu.p_regs[STV(i)].m3;
+    }
+}
+
 #if C_FPU_X86
 #include "fpu_instructions_x86.h"
 #else


### PR DESCRIPTION
When the dynamic core uses normal core to run instructions, we need to
1. Copy the dh fpu state to normal fpu before entering the normal core
2. After returning from normal core, copy the normal fpu state to dh fpu

This addresses https://github.com/dosbox-staging/dosbox-staging/issues/2247