### PR TITLE
Mark all core run functions with `noexcept`

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -73,17 +73,17 @@ constexpr bool CPU_ReuseCodepages = true;
 constexpr bool CPU_UseRwxMemProtect = true;
 #endif
 
-Bits CPU_Core_Normal_Run(void);
-Bits CPU_Core_Normal_Trap_Run(void);
-Bits CPU_Core_Simple_Run(void);
-Bits CPU_Core_Simple_Trap_Run(void);
-Bits CPU_Core_Full_Run(void);
-Bits CPU_Core_Dyn_X86_Run(void);
-Bits CPU_Core_Dyn_X86_Trap_Run(void);
-Bits CPU_Core_Dynrec_Run(void);
-Bits CPU_Core_Dynrec_Trap_Run(void);
-Bits CPU_Core_Prefetch_Run(void);
-Bits CPU_Core_Prefetch_Trap_Run(void);
+Bits CPU_Core_Normal_Run() noexcept;
+Bits CPU_Core_Normal_Trap_Run() noexcept;
+Bits CPU_Core_Simple_Run() noexcept;
+Bits CPU_Core_Simple_Trap_Run() noexcept;
+Bits CPU_Core_Full_Run() noexcept;
+Bits CPU_Core_Dyn_X86_Run() noexcept;
+Bits CPU_Core_Dyn_X86_Trap_Run() noexcept;
+Bits CPU_Core_Dynrec_Run() noexcept;
+Bits CPU_Core_Dynrec_Trap_Run() noexcept;
+Bits CPU_Core_Prefetch_Run() noexcept;
+Bits CPU_Core_Prefetch_Trap_Run() noexcept;
 
 void CPU_Enable_SkipAutoAdjust(void);
 void CPU_Disable_SkipAutoAdjust(void);

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -248,7 +248,8 @@ static void dyn_restoreregister(DynReg * src_reg, DynReg * dst_reg) {
 
 #include "core_dyn_x86/decoder.h"
 
-Bits CPU_Core_Dyn_X86_Run(void) {
+Bits CPU_Core_Dyn_X86_Run() noexcept
+{
 	ZoneScoped;
 	// helper class to auto-save DH_FPU state on function exit
 	class auto_dh_fpu {
@@ -365,7 +366,8 @@ run_block:
 	return CBRET_NONE;
 }
 
-Bits CPU_Core_Dyn_X86_Trap_Run(void) {
+Bits CPU_Core_Dyn_X86_Trap_Run() noexcept
+{
 	int32_t oldCycles = CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -208,7 +208,8 @@ CacheBlock *LinkBlocks(BlockReturn ret)
 	execution process, or returning from the core etc.
 */
 
-Bits CPU_Core_Dynrec_Run(void) {
+Bits CPU_Core_Dynrec_Run() noexcept
+{
 	ZoneScoped;
 	for (;;) {
 		// Determine the linear address of CS:EIP
@@ -333,7 +334,8 @@ run_block:
 	return CBRET_NONE;
 }
 
-Bits CPU_Core_Dynrec_Trap_Run(void) {
+Bits CPU_Core_Dynrec_Trap_Run() noexcept
+{
 	Bits oldCycles = CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -61,7 +61,8 @@ typedef PhysPt EAPoint;
 		continue;											\
 	}
 
-Bits CPU_Core_Full_Run(void) {
+Bits CPU_Core_Full_Run() noexcept
+{
 	ZoneScoped;
 	FullData inst{};
 	while (CPU_Cycles-->0) {
@@ -93,7 +94,6 @@ illegalopcode:
 	FillFlags();
 	return CBRET_NONE;
 }
-
 
 void CPU_Core_Full_Init(void) {
 

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -137,7 +137,8 @@ static inline uint32_t Fetchd() {
 
 #define EALookupTable (core.ea_table)
 
-Bits CPU_Core_Normal_Run(void) {
+Bits CPU_Core_Normal_Run() noexcept
+{
 	ZoneScoped;
 	while (CPU_Cycles-->0) {
 		LOADIP;
@@ -190,7 +191,8 @@ decode_end:
 	return CBRET_NONE;
 }
 
-Bits CPU_Core_Normal_Trap_Run(void) {
+Bits CPU_Core_Normal_Trap_Run() noexcept
+{
 	Bits oldCycles = CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;
@@ -202,8 +204,6 @@ Bits CPU_Core_Normal_Trap_Run(void) {
 
 	return ret;
 }
-
-
 
 void CPU_Core_Normal_Init(void) {
 

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -208,7 +208,8 @@ static uint32_t Fetchd() {
 
 #define EALookupTable (core.ea_table)
 
-Bits CPU_Core_Prefetch_Run(void) {
+Bits CPU_Core_Prefetch_Run() noexcept
+{
 	bool invalidate_pq=false;
 	while (CPU_Cycles-->0) {
 		if (invalidate_pq) {
@@ -308,7 +309,8 @@ decode_end:
 	return CBRET_NONE;
 }
 
-Bits CPU_Core_Prefetch_Trap_Run(void) {
+Bits CPU_Core_Prefetch_Trap_Run() noexcept
+{
 	Bits oldCycles = CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;
@@ -320,8 +322,6 @@ Bits CPU_Core_Prefetch_Trap_Run(void) {
 
 	return ret;
 }
-
-
 
 void CPU_Core_Prefetch_Init(void) {
 

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -133,7 +133,8 @@ static inline uint32_t Fetchd() {
 
 #define EALookupTable (core.ea_table)
 
-Bits CPU_Core_Simple_Run(void) {
+Bits CPU_Core_Simple_Run() noexcept
+{
 	ZoneScoped;
 	while (CPU_Cycles-->0) {
 		LOADIP;
@@ -195,7 +196,8 @@ decode_end:
 	return CBRET_NONE;
 }
 
-Bits CPU_Core_Simple_Trap_Run(void) {
+Bits CPU_Core_Simple_Trap_Run() noexcept
+{
 	Bits oldCycles = CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;
@@ -207,8 +209,6 @@ Bits CPU_Core_Simple_Trap_Run(void) {
 
 	return ret;
 }
-
-
 
 void CPU_Core_Simple_Init(void) {
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2436,7 +2436,7 @@ void CPU_ShutDown([[maybe_unused]] Section* sec) {
 }
 
 void CPU_Init(Section* sec) {
-	test = new CPU(sec);
+	test = new (std::nothrow) CPU(sec);
 	sec->AddDestroyFunction(&CPU_ShutDown,true);
 }
 //initialize static members

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -917,8 +917,11 @@ static void cache_init(bool enable) {
 		cache.used_pages=nullptr;
 		// setup the code pages
 		for (int i=0;i<CACHE_PAGES;i++) {
-			CodePageHandler *newpage = new CodePageHandler();
-			newpage->next=cache.free_pages;
+			auto newpage = new (std::nothrow) CodePageHandler();
+			if (GCC_UNLIKELY(!newpage)) {
+				E_Exit("DYN_CACHE: Failed to allocate code-page handler");
+			}
+			newpage->next = cache.free_pages;
 			cache.free_pages=newpage;
 		}
 	}


### PR DESCRIPTION
The cores do not use, handle, or throw exceptions.

There were only a couple uses of the `new` operator inside the entire `src/cpu` tree (`new` itself can throw if it fails to allocate, so this commit moves those to their no-throwing variant).

The cores themselves only use return codes for signal handling and control flow (both good and bad).  If things go off the rails, they quit immediately with `E_Exit()`.

This simply labels them as such (programmatically) as it's
how they were designed.
