### PR TITLE
Move dynamic FPU synchronization inside preprocessor defines

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -45,74 +45,72 @@ void FPU_ESC6_EA(Bitu func,PhysPt ea);
 void FPU_ESC7_Normal(Bitu rm);
 void FPU_ESC7_EA(Bitu func,PhysPt ea);
 
-
-typedef union {
-    double d;
+union FPU_Reg {
+	double d = 0.0;
+	struct {
 #ifndef WORDS_BIGENDIAN
-    struct {
-        uint32_t lower;
-        int32_t upper;
-    } l;
+		uint32_t lower;
+		int32_t upper;
 #else
-    struct {
-        int32_t upper;
-        uint32_t lower;
-    } l;
+		int32_t upper;
+		uint32_t lower;
 #endif
-    int64_t ll;
-} FPU_Reg;
+	} l;
+	int64_t ll;
+};
 
-typedef struct {
-    uint32_t m1;
-    uint32_t m2;
-    uint16_t m3;
+struct FPU_P_Reg {
+	uint32_t m1 = 0;
+	uint32_t m2 = 0;
+	uint16_t m3 = 0;
 
-    uint16_t d1;
-    uint32_t d2;
-} FPU_P_Reg;
+	uint16_t d1 = 0;
+	uint32_t d2 = 0;
+};
 
-enum FPU_Tag {
+enum FPU_Tag : uint8_t {
 	TAG_Valid = 0,
 	TAG_Zero  = 1,
 	TAG_Weird = 2,
 	TAG_Empty = 3
 };
 
-enum FPU_Round {
-	ROUND_Nearest = 0,		
+enum FPU_Round : uint8_t {
+	ROUND_Nearest = 0,
 	ROUND_Down    = 1,
-	ROUND_Up      = 2,	
+	ROUND_Up      = 2,
 	ROUND_Chop    = 3
 };
 
-typedef struct FPU_rec {
-	FPU_Reg		regs[9];
-	FPU_P_Reg	p_regs[9];
-	FPU_Tag		tags[9];
-	uint16_t		cw,cw_mask_all;
-	uint16_t		sw;
-	uint32_t		top;
-	FPU_Round	round;
-} FPU_rec;
+struct FPU_rec {
+	FPU_Reg regs[9]      = {};
+	FPU_P_Reg p_regs[9]  = {};
+	FPU_Tag tags[9]      = {};
+	uint16_t cw          = 0;
+	uint16_t cw_mask_all = 0;
+	uint16_t sw          = 0;
+	uint32_t top         = 0;
+	FPU_Round round      = {};
+};
 
-#define L2E		1.4426950408889634
-#define L2T		3.3219280948873623
-#define LN2		0.69314718055994531
-#define LG2		0.3010299956639812
-
+constexpr auto L2E = 1.4426950408889634;
+constexpr auto L2T = 3.3219280948873623;
+constexpr auto LN2 = 0.69314718055994531;
+constexpr auto LG2 = 0.3010299956639812;
 
 extern FPU_rec fpu;
 
 #define TOP fpu.top
 #define STV(i)  ( (fpu.top+ (i) ) & 7 )
 
-
-uint16_t FPU_GetTag(void);
+uint16_t FPU_GetTag();
 void FPU_FLDCW(PhysPt addr);
 
-static inline void FPU_SetTag(uint16_t tag){
-	for(Bitu i=0;i<8;i++)
-		fpu.tags[i] = static_cast<FPU_Tag>((tag >>(2*i))&3);
+static inline void FPU_SetTag(const uint16_t tag)
+{
+	for (uint8_t i = 0; i < 8; ++i) {
+		fpu.tags[i] = static_cast<FPU_Tag>((tag >> (2 * i)) & 3);
+	}
 }
 
 static inline uint16_t FPU_GetCW()
@@ -120,11 +118,11 @@ static inline uint16_t FPU_GetCW()
 	return fpu.cw;
 }
 
-static inline void FPU_SetCW(Bitu word)
+static inline void FPU_SetCW(const uint16_t word)
 {
-	fpu.cw = (uint16_t)word;
-	fpu.cw_mask_all = (uint16_t)(word | 0x3f);
-	fpu.round = (FPU_Round)((word >> 10) & 3);
+	fpu.cw          = word;
+	fpu.cw_mask_all = word | 0x3f;
+	fpu.round       = static_cast<FPU_Round>((word >> 10) & 3);
 }
 
 static inline uint16_t FPU_GetSW()
@@ -132,18 +130,20 @@ static inline uint16_t FPU_GetSW()
 	return fpu.sw;
 }
 
-static inline void FPU_SetSW(Bitu word)
+static inline void FPU_SetSW(const uint16_t word)
 {
-	fpu.sw = (uint16_t)word;
+	fpu.sw = word;
 }
 
-static inline Bitu FPU_GET_TOP(void) {
-	return (fpu.sw & 0x3800)>>11;
+static inline uint8_t FPU_GET_TOP()
+{
+	return static_cast<uint8_t>((fpu.sw & 0x3800) >> 11);
 }
 
-static inline void FPU_SET_TOP(Bitu val){
+static inline void FPU_SET_TOP(const uint32_t val)
+{
 	fpu.sw &= ~0x3800;
-	fpu.sw |= (val&7)<<11;
+	fpu.sw |= static_cast<uint16_t>((val & 7) << 11);
 }
 
 void FPU_LoadPRegs(const uint8_t* buffer);

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -146,8 +146,8 @@ static inline void FPU_SET_TOP(const uint32_t val)
 	fpu.sw |= static_cast<uint16_t>((val & 7) << 11);
 }
 
-void FPU_LoadPRegs(const uint8_t* buffer);
-void FPU_SavePRegs(uint8_t* buffer);
+void FPU_SetPRegsFrom(const uint8_t dyn_regs[8][10]);
+void FPU_GetPRegsTo(uint8_t dyn_regs[8][10]);
 
 static inline void FPU_SET_C0(Bitu C){
 	fpu.sw &= ~0x0100;

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -93,11 +93,6 @@ struct FPU_rec {
 	FPU_Round round      = {};
 };
 
-constexpr auto L2E = 1.4426950408889634;
-constexpr auto L2T = 3.3219280948873623;
-constexpr auto LN2 = 0.69314718055994531;
-constexpr auto LG2 = 0.3010299956639812;
-
 extern FPU_rec fpu;
 
 #define TOP fpu.top
@@ -135,14 +130,16 @@ static inline void FPU_SetSW(const uint16_t word)
 	fpu.sw = word;
 }
 
+constexpr uint16_t fpu_top_register_bits = 0x3800;
+
 static inline uint8_t FPU_GET_TOP()
 {
-	return static_cast<uint8_t>((fpu.sw & 0x3800) >> 11);
+	return static_cast<uint8_t>((fpu.sw & fpu_top_register_bits) >> 11);
 }
 
 static inline void FPU_SET_TOP(const uint32_t val)
 {
-	fpu.sw &= ~0x3800;
+	fpu.sw &= ~fpu_top_register_bits;
 	fpu.sw |= static_cast<uint16_t>((val & 7) << 11);
 }
 

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -163,37 +163,46 @@ static struct {
 	uint32_t readdata;
 } core_dyn;
 
-#if defined(X86_DYNFPU_DH_ENABLED)
-static struct dyn_dh_fpu {
-	uint16_t		cw,host_cw;
-	bool		state_used;
+#	if defined(X86_DYNFPU_DH_ENABLED)
+
+struct dyn_dh_fpu {
+	uint16_t cw                 = 0x37f;
+	uint16_t host_cw            = 0;
+	bool state_used             = false;
+
+
 	// some fields expanded here for alignment purposes
 	struct {
-		uint32_t cw;
-		uint32_t sw;
-		uint32_t tag;
-		uint32_t ip;
-		uint32_t cs;
-		uint32_t ea;
-		uint32_t ds;
-		uint8_t st_reg[8][10];
-	} state;
-	FPU_P_Reg	temp,temp2;
-	uint32_t		dh_fpu_enabled;
-	uint8_t		temp_state[128];
-} dyn_dh_fpu;
-#endif
+		uint32_t cw  = 0x37f;
+		uint32_t sw  = 0;
+		uint32_t tag = 0xffff;
+		uint32_t ip  = 0;
+		uint32_t cs  = 0;
+		uint32_t ea  = 0;
+		uint32_t ds  = 0;
 
-#define X86         0x01
-#define X86_64      0x02
+		uint8_t st_reg[8][10] = {};
+	} state = {};
 
-#if C_TARGETCPU == X86_64
-#include "core_dyn_x86/risc_x64.h"
-#elif C_TARGETCPU == X86
-#include "core_dyn_x86/risc_x86.h"
-#else
-#error DYN_X86 core not supported for this CPU target.
-#endif
+	FPU_P_Reg temp  = {};
+	FPU_P_Reg temp2 = {};
+
+	uint32_t dh_fpu_enabled = true;
+	uint8_t temp_state[128] = {};
+} dyn_dh_fpu = {};
+
+#	endif
+
+#	define X86    0x01
+#	define X86_64 0x02
+
+#	if C_TARGETCPU == X86_64
+#		include "core_dyn_x86/risc_x64.h"
+#	elif C_TARGETCPU == X86
+#		include "core_dyn_x86/risc_x86.h"
+#	else
+#		error DYN_X86 core not supported for this CPU target.
+#	endif
 
 struct DynState {
 	DynReg regs[G_MAX];
@@ -494,16 +503,8 @@ void CPU_Core_Dyn_X86_Init(void) {
 
 #if defined(X86_DYNFPU_DH_ENABLED)
 	/* Init the fpu state */
-	dyn_dh_fpu.dh_fpu_enabled=true;
-	dyn_dh_fpu.state_used=false;
-	dyn_dh_fpu.cw=0x37f;
-	// FINIT
-	memset(&dyn_dh_fpu.state, 0, sizeof(dyn_dh_fpu.state));
-	dyn_dh_fpu.state.cw = 0x37F;
-	dyn_dh_fpu.state.tag = 0xFFFF;
-#endif
-
-	return;
+	dyn_dh_fpu = {};
+#	endif
 }
 
 void CPU_Core_Dyn_X86_Cache_Init(bool enable_cache) {

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -263,7 +263,7 @@ static void copy_dh_fpu_to_normal()
 	FPU_SetCW(dyn_dh_fpu.state.cw);
 	FPU_SetSW(dyn_dh_fpu.state.sw);
 	TOP = FPU_GET_TOP();
-	FPU_LoadPRegs(&dyn_dh_fpu.state.st_reg[0][0]);
+	FPU_SetPRegsFrom(dyn_dh_fpu.state.st_reg);
 }
 
 static void copy_normal_fpu_to_dh()
@@ -272,7 +272,7 @@ static void copy_normal_fpu_to_dh()
 	dyn_dh_fpu.state.sw  = FPU_GetSW();
 	dyn_dh_fpu.state.cw  = FPU_GetCW();
 	dyn_dh_fpu.state.tag = FPU_GetTag();
-	FPU_SavePRegs(&dyn_dh_fpu.state.st_reg[0][0]);
+	FPU_GetPRegsTo(dyn_dh_fpu.state.st_reg);
 }
 
 Bits CPU_Core_Dyn_X86_Run() noexcept

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -86,7 +86,7 @@
 // sub dst, src, #imm		@	0 <= imm <= 7
 #define SUB_IMM3(dst, src, imm) (0x1e00 + (dst) + ((src) << 3) + ((imm) << 6) )
 // sub dst, #imm		@	0 <= imm <= 255
-#define SUB_IMM8(dst, imm) (0x3800 + ((dst) << 8) + (imm) )
+#define SUB_IMM8(dst, imm) (fpu_top_register_bits + ((dst) << 8) + (imm) )
 // neg dst, src
 #define NEG(dst, src) (0x4240 + (dst) + ((src) << 3) )
 // cmp dst, #imm		@	0 <= imm <= 255

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -83,7 +83,7 @@
 // sub dst, src, #imm		@	0 <= imm <= 7
 #define SUB_IMM3(dst, src, imm) (0x1e00 + (dst) + ((src) << 3) + ((imm) << 6) )
 // sub dst, #imm		@	0 <= imm <= 255
-#define SUB_IMM8(dst, imm) (0x3800 + ((dst) << 8) + (imm) )
+#define SUB_IMM8(dst, imm) (fpu_top_register_bits + ((dst) << 8) + (imm) )
 // neg dst, src
 #define NEG(dst, src) (0x4240 + (dst) + ((src) << 3) )
 // cmp dst, #imm		@	0 <= imm <= 255

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -83,7 +83,7 @@
 // sub dst, src, #imm		@	0 <= imm <= 7
 #define SUB_IMM3(dst, src, imm) (0x1e00 + (dst) + ((src) << 3) + ((imm) << 6) )
 // sub dst, #imm		@	0 <= imm <= 255
-#define SUB_IMM8(dst, imm) (0x3800 + ((dst) << 8) + (imm) )
+#define SUB_IMM8(dst, imm) (fpu_top_register_bits + ((dst) << 8) + (imm) )
 // neg dst, src
 #define NEG(dst, src) (0x4240 + (dst) + ((src) << 3) )
 // cmp dst, #imm		@	0 <= imm <= 255

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -27,17 +27,19 @@
 #include "fpu.h"
 #include "cpu.h"
 
-FPU_rec fpu;
+FPU_rec fpu = {};
 
 void FPU_FLDCW(PhysPt addr){
 	uint16_t temp = mem_readw(addr);
 	FPU_SetCW(temp);
 }
 
-uint16_t FPU_GetTag(void){
-	uint16_t tag=0;
-	for(Bitu i=0;i<8;i++)
-		tag |= ( (fpu.tags[i]&3) <<(2*i));
+uint16_t FPU_GetTag()
+{
+	uint16_t tag = 0;
+	for (Bitu i = 0; i < 8; i++) {
+		tag |= ((fpu.tags[i] & 3) << (2 * i));
+	}
 	return tag;
 }
 

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -43,17 +43,27 @@ uint16_t FPU_GetTag()
 	return tag;
 }
 
-void FPU_LoadPRegs(const uint8_t* buffer)
+void FPU_SetPRegsFrom(const uint8_t dyn_regs[8][10])
 {
-	for (Bitu i = 0; i < 8; i++) {
-		memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
+	for (uint8_t i = 0; i < 8; ++i) {
+		auto& norm_p_reg        = fpu.p_regs[STV(i)];
+		const auto dyn_reg_addr = dyn_regs[i];
+
+		norm_p_reg.m1 = read_unaligned_uint32_at(dyn_reg_addr, 0);
+		norm_p_reg.m2 = read_unaligned_uint32_at(dyn_reg_addr, 1);
+		norm_p_reg.m3 = read_unaligned_uint16_at(dyn_reg_addr, 4);
 	}
 }
 
-void FPU_SavePRegs(uint8_t* buffer)
+void FPU_GetPRegsTo(uint8_t dyn_regs[8][10])
 {
-	for (Bitu i = 0; i < 8; i++) {
-		memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
+	for (uint8_t i = 0; i < 8; ++i) {
+		auto dyn_reg_addr      = dyn_regs[i];
+		const auto& norm_p_reg = fpu.p_regs[STV(i)];
+
+		write_unaligned_uint32_at(dyn_reg_addr, 0, norm_p_reg.m1);
+		write_unaligned_uint32_at(dyn_reg_addr, 1, norm_p_reg.m2);
+		write_unaligned_uint16_at(dyn_reg_addr, 4, norm_p_reg.m3);
 	}
 }
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -126,9 +126,10 @@ static double FROUND(double in){
 
 static Real64 FPU_FLD80(PhysPt addr) {
 	struct {
-		int16_t begin;
-		FPU_Reg eind;
-	} test;
+		int16_t begin = 0;
+		FPU_Reg eind  = {};
+	} test = {};
+
 	test.eind.l.lower = mem_readd(addr);
 	test.eind.l.upper = mem_readd(addr+4);
 	test.begin = mem_readw(addr+8);
@@ -154,12 +155,13 @@ static Real64 FPU_FLD80(PhysPt addr) {
 
 static void FPU_ST80(PhysPt addr,Bitu reg) {
 	struct {
-		int16_t begin;
-		FPU_Reg eind;
-	} test;
-	int64_t sign80 = (fpu.regs[reg].ll&LONGTYPE(0x8000000000000000))?1:0;
-	int64_t exp80 =  fpu.regs[reg].ll&LONGTYPE(0x7ff0000000000000);
-	int64_t exp80final = (exp80>>52);
+		int16_t begin = 0;
+		FPU_Reg eind  = {};
+	} test = {};
+
+	int64_t sign80 = (fpu.regs[reg].ll & LONGTYPE(0x8000000000000000)) ? 1 : 0;
+	int64_t exp80       = fpu.regs[reg].ll & LONGTYPE(0x7ff0000000000000);
+	int64_t exp80final  = (exp80 >> 52);
 	int64_t mant80 = fpu.regs[reg].ll&LONGTYPE(0x000fffffffffffff);
 	int64_t mant80final = (mant80 << 11);
 	if(fpu.regs[reg].d != 0){ //Zero is a special case

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -601,13 +601,14 @@ static void FPU_FLD1(void){
 }
 
 static void FPU_FLDL2T(void){
+	constexpr auto L2T = M_LN10 / M_LN2;
 	FPU_PREP_PUSH();
 	fpu.regs[TOP].d = L2T;
 }
 
 static void FPU_FLDL2E(void){
 	FPU_PREP_PUSH();
-	fpu.regs[TOP].d = L2E;
+	fpu.regs[TOP].d = M_LOG2E;
 }
 
 static void FPU_FLDPI(void){
@@ -616,13 +617,14 @@ static void FPU_FLDPI(void){
 }
 
 static void FPU_FLDLG2(void){
+	constexpr auto LG2 = M_LOG10E / M_LOG2E;
 	FPU_PREP_PUSH();
 	fpu.regs[TOP].d = LG2;
 }
 
 static void FPU_FLDLN2(void){
 	FPU_PREP_PUSH();
-	fpu.regs[TOP].d = LN2;
+	fpu.regs[TOP].d = M_LN2;
 }
 
 static void FPU_FLDZ(void){

--- a/tests/files/fpu_test.asm
+++ b/tests/files/fpu_test.asm
@@ -1,0 +1,89 @@
+; Authored by finalpatch (GitHub)
+;   Source: https://gist.github.com/finalpatch/91ae4449875c3cf217327bfdcbeab0c5
+;   Tests: https://github.com/dosbox-staging/dosbox-staging/issues/2247
+;
+; tasm fpu_test
+; tlink fpu_test
+
+.model small
+.stack 100h
+
+.data
+fval dd 123.1, 223.1, 323.1, 423.1, 523.1, 623.1, 723.1, 823.1
+fdst dd 8 dup(0.0)
+sok  db "ok$"
+sbad db "bad$"
+
+.code
+modcode proc near
+   ; rewrite the instruction at l2
+   lea bp, l2
+   ; starting from +1
+   ; skipping the fwait added by assembler
+   ; first overwrite with NOPs
+   ; then rewrite to original instruction
+   mov byte ptr es:[bp+1], 90h
+   mov byte ptr es:[bp+2], 90h
+   mov byte ptr es:[bp+3], 20h
+   mov byte ptr es:[bp+4], 90h
+   mov byte ptr es:[bp+1], 0d9h ;fstp fdst[bx]
+   mov byte ptr es:[bp+2], 9fh
+   mov byte ptr es:[bp+3], 20h
+   mov byte ptr es:[bp+4], 00h
+   ret
+modcode endp
+
+main proc near
+   mov ax, @data
+   mov ds, ax
+   ; point es to code seg
+   ; so we can modify code va es
+   mov ax, cs
+   mov es, ax
+
+   ; reset fpu
+   finit
+
+   ; fill ST0-ST7
+   mov cx, 8
+   mov bx, 0
+l1:
+   fld fval[bx]
+   add bx, 4
+   loop l1
+
+   ; store ST7-ST0
+   mov cx, 8
+   mov bx, 28
+l2:
+   fstp dword ptr fdst[bx]
+   ; invalidate the previous instruciton
+   ; force it to run on normal core
+   call modcode
+   sub bx, 4
+   loop l2
+
+   ; compare 32 bytes at fval and fdst
+   lea si, fval
+   lea di, fdst
+   mov ax, @data
+   mov es, ax
+   cld
+   mov cx, 32
+   repe cmpsb
+   je good
+bad:
+   lea dx, sbad
+   jmp print
+good:
+   lea dx, sok
+print:
+   mov ah, 09h
+   int 21h
+
+   ; reset fpu and quit
+   fninit
+   mov ah,4ch
+   int 21h
+main endp
+end main


### PR DESCRIPTION
This is a follow-up adjustment mentioned by @finalpatch; thanks!
 
This PR also:
- Makes non-functional adjustments to the previously-touched FPU additions (uses more const and auto arguments, replaces C casts with C++ casts, uses default initializes, and uses C++ struct definition style ("struct Type {... }", just like classes).
- Fixes a couple dangling memset/memcpy warnings by using the unaligned accessor functions.
- Uses the Get and Set verbs in the PReg function names (to make the match the others).
- The last two commits are functional changes (deliberately independent and the last in this set) to be easy bisection points if either cause problems down the road.

Hoping you can test this with your Turbo C debugger @finalpatch (and anything else you can throw at it like large and tiny values / overflow / div-by-zero / NaN / etc).

Suggest reviewing commit-by-commit.

DOS Navigator is still OK, as are UBSAN builds.