### PR TITLE
Exclude COMMAND.COM's help arguments when part of sub-command (#2263)

### DIFF
--- a/include/programs.h
+++ b/include/programs.h
@@ -55,7 +55,9 @@ public:
 	bool HasDirectory() const;
 	bool HasExecutableName() const;
 	unsigned int GetCount(void);
-	void Shift(unsigned int amount=1);
+	bool ExistsPriorTo(const std::list<std::string_view>& pre_args,
+	                   const std::list<std::string_view>& post_args) const;
+	void Shift(unsigned int amount = 1);
 	uint16_t Get_arglength();
 
 private:

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -224,7 +224,25 @@ inline bool is_empty(const char *str) noexcept
 
 // case-insensitive comparisons
 bool ciequals(const char a, const char b);
-bool iequals(const std::string &a, const std::string &b);
+
+// case-insensitive comparison for combinations of
+// const char *, const std::string&, and const string_view
+template <typename T1, typename T2>
+constexpr bool iequals(T1&& a, T2&& b)
+{
+	using str_t1 = std::conditional_t<std::is_same_v<T1, const std::string&>,
+	                                  const std::string&,
+	                                  const std::string_view>;
+
+	using str_t2 = std::conditional_t<std::is_same_v<T2, const std::string&>,
+	                                  const std::string&,
+	                                  const std::string_view>;
+
+	const str_t1 str_a = std::forward<T1>(a);
+	const str_t2 str_b = std::forward<T2>(b);
+
+	return std::equal(str_a.begin(), str_a.end(), str_b.begin(), str_b.end(), ciequals);
+}
 
 char *strip_word(char *&cmd);
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1234,7 +1234,34 @@ bool CommandLine::FindExist(const char *name, bool remove)
 	return true;
 }
 
-bool CommandLine::FindInt(const char *name, int &value, bool remove)
+// Checks if any of the command line arguments are found in the pre_args *and*
+// exist prior to any of the post_args. If none of the command line arguments
+// are found in the pre_args then false is returned.
+bool CommandLine::ExistsPriorTo(const std::list<std::string_view>& pre_args,
+                                const std::list<std::string_view>& post_args) const
+{
+	auto any_of_iequals = [](const auto& haystack,
+	                         const auto& needle) {
+		return std::any_of(haystack.begin(),
+		                   haystack.end(),
+		                   [&needle](const auto& hay) {
+			                   return iequals(hay, needle);
+		                   });
+	};
+
+	for (const auto& cli_arg : cmds) {
+		// if any of the pre-args are insensitive-equal-to the CLI argument ...
+		if (any_of_iequals(pre_args, cli_arg)) {
+			return true;
+		}
+		if (any_of_iequals(post_args, cli_arg)) {
+			return false;
+		}
+	}
+	return false;
+}
+
+bool CommandLine::FindInt(const char* name, int& value, bool remove)
 {
 	cmd_it it, it_next;
 	if (!(FindEntry(name, it, true)))

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -185,11 +185,6 @@ bool ciequals(const char a, const char b)
 	return tolower(a) == tolower(b);
 }
 
-bool iequals(const std::string &a, const std::string &b)
-{
-	return std::equal(a.begin(), a.end(), b.begin(), b.end(), ciequals);
-}
-
 char *strip_word(char *&line)
 {
 	char *scan = line;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -489,14 +489,17 @@ void DOS_Shell::RunInternal()
 
 void DOS_Shell::Run()
 {
-	char input_line[CMD_MAXLINE] = {0};
-	std::string line;
-	if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+	// COMMAND.COM's /C and /INIT spawn sub-commands. When parsing help, we need
+	// to be sure the /? and -? are intended for us and not part of the
+	// sub-command.
+	if (cmd->ExistsPriorTo({"/?", "-?"}, {"/C", "/INIT"})) {
 		MoreOutputStrings output(*this);
 		output.AddString(MSG_Get("SHELL_CMD_COMMAND_HELP_LONG"));
 		output.Display();
 		return;
 	}
+	char input_line[CMD_MAXLINE] = {0};
+	std::string line = {};
 	if (cmd->FindStringRemainBegin("/C",line)) {
 		safe_strcpy(input_line, line.c_str());
 		char* sep = strpbrk(input_line,"\r\n"); //GTA installer

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -28,6 +28,58 @@
 
 namespace {
 
+TEST(CaseInsensitiveCompare, Chars)
+{
+	constexpr const char a[] = "123";
+	constexpr const char not_a[] = "321";
+
+	EXPECT_TRUE(iequals(a, a));
+	EXPECT_FALSE(iequals(a, not_a));
+}
+
+TEST(CaseInsensitiveCompare, StringViews)
+{
+	constexpr std::string_view a = "123";
+	constexpr std::string_view not_a = "321";
+
+	EXPECT_TRUE(iequals(a, a));
+	EXPECT_FALSE(iequals(a, not_a));
+}
+
+TEST(CaseInsensitiveCompare, Strings)
+{
+	const std::string a = "123";
+	const std::string not_a = "321";
+
+	EXPECT_TRUE(iequals(a, a));
+	EXPECT_FALSE(iequals(a, not_a));
+}
+
+
+TEST(CaseInsensitiveCompare, MixedTypes)
+{
+	constexpr const char a_sz[] = "123";
+
+	constexpr std::string_view a_sv = "123";
+	constexpr std::string_view not_a_sv = "321";
+
+	const std::string a_string = "123";
+	const std::string not_a_string = "321";
+
+	// char and string_view
+	EXPECT_TRUE(iequals(a_sz, a_sv));
+	EXPECT_FALSE(iequals(a_sz, not_a_sv));
+
+	// char and string
+	EXPECT_TRUE(iequals(a_sz, a_string));
+	EXPECT_FALSE(iequals(a_sz, not_a_string));
+
+	// string_view and string
+	EXPECT_TRUE(iequals(a_sv, a_string));
+	EXPECT_FALSE(iequals(a_sv, not_a_string));
+}
+
+
 TEST(StartsWith, Prefix)
 {
 	EXPECT_TRUE(starts_with("ab", "abcd"));


### PR DESCRIPTION
Fixes #2263