### PR TITLE
Improve caching of subpackages

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -77,11 +77,20 @@ jobs:
           restore-keys: |
             ccache-static-clang-${{ steps.prep-ccache.outputs.yesterday }}
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Log environment
         run:  ./scripts/log-env.sh
@@ -162,11 +171,6 @@ jobs:
           sudo apt-get install $(cat packages/ubuntu-20.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
-      # Workaround frequent HTTPS-based connectivity issues
-      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
-      - name:  Fetch the libffi subproject for Glib
-        run: ./scripts/fetch-libffi-subproject.sh
-
       - name:  Prepare compiler cache
         id:    prep-ccache
         shell: bash
@@ -183,11 +187,20 @@ jobs:
           key:          ccache-sanitizers-${{ steps.prep-ccache.outputs.today }}
           restore-keys: ccache-sanitizers-${{ steps.prep-ccache.outputs.yesterday }}
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Log environment
         run:  ./scripts/log-env.sh

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -104,10 +104,20 @@ jobs:
         run: |
           brew install $(cat packages/macos-12-brew.txt)
 
-      # Workaround frequent HTTPS-based connectivity issues
-      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
-      - name:  Fetch the libffi subproject for Glib
-        run: ./scripts/fetch-libffi-subproject.sh
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
+        with:
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
         if:    matrix.system.name == 'Windows'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -43,6 +43,21 @@ jobs:
           sudo apt-get install curl zstd clang $(cat packages/ubuntu-20.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
+        with:
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
+
       - name: Prepare the Coverity package cache
         uses: actions/cache@v3.2.4
         id: cache-coverity

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,10 +34,38 @@ env:
     ghcr.io/dosbox-staging/debian-cross
 
 jobs:
+  cache_subprojects:
+    name: Cache subprojects
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+
+      - name: Install Meson
+        run:  |
+          sudo apt-get update
+          sudo apt-get install -y meson
+
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
+        with:
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
   build_ubuntu:
     name: ${{ matrix.conf.name }}
     runs-on: ${{ matrix.conf.os }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    needs: cache_subprojects
     strategy:
       matrix:
         conf:
@@ -200,12 +228,6 @@ jobs:
           restore-keys: |
             ccache-${{ matrix.conf.os }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}-1
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
-        with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}
-
       - name: Log environment
         run:  ./scripts/log-env.sh
 
@@ -227,6 +249,17 @@ jobs:
             echo "MESON_BIN=${{env.DOCKER_RUN}}:${vers} meson" >> $GITHUB_OUTPUT
             echo "CCACHE_BIN=${{env.DOCKER_RUN}}:${vers} ccache" >> $GITHUB_OUTPUT
           fi
+
+      - name: Restore subprojects cache
+        id:   cache-subprojects
+        uses: actions/cache@v3
+        with:
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Meson setup
         run:  |
@@ -254,6 +287,7 @@ jobs:
     name: Release build
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    needs: cache_subprojects
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -268,10 +302,16 @@ jobs:
             $(cat packages/ubuntu-18.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
-      # Workaround frequent HTTPS-based connectivity issues
-      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
-      - name:  Fetch the libffi subproject for Glib
-        run: ./scripts/fetch-libffi-subproject.sh
+      - name: Restore subprojects cache
+        id:   cache-subprojects
+        uses: actions/cache@v3
+        with:
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -289,12 +329,6 @@ jobs:
           key:  ccache-linux-release-${{ steps.prep-ccache.outputs.today }}-1
           restore-keys: |
             ccache-linux-release-${{ steps.prep-ccache.outputs.yesterday }}-1
-
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
-        with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-1
 
       - name: Log environment
         run:  ./scripts/log-env.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -97,11 +97,20 @@ jobs:
             ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-
             ccache-macos-debug-
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-2
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Setup and build
         run: |
@@ -193,11 +202,6 @@ jobs:
           arch -arch=${{ matrix.runner.arch }} brew install librsvg tree
           ccache libpng meson opusfile sdl2 sdl2_image sdl2_net speexdsp
 
-      # Workaround frequent HTTPS-based connectivity issues
-      # https://gitlab.freedesktop.org/freedesktop/freedesktop/-/issues/407
-      - name:  Fetch the libffi subproject for Glib
-        run: ./scripts/fetch-libffi-subproject.sh
-
       - uses:  actions/cache@v3.2.4
         if:    matrix.runner.needs_deps
         with:
@@ -205,11 +209,20 @@ jobs:
           key:  ccache-macos-release-${{ matrix.runner.arch }}-${{ steps.prep-caches.outputs.today }}-2
           restore-keys: ccache-macos-release-${{ matrix.runner.arch }}-
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id: cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-2
+          path: subprojects.tar
+          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Log environment
         run:  arch -arch=${{ matrix.runner.arch }} ./scripts/log-env.sh

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -46,11 +46,20 @@ jobs:
           sudo dpkg -i "pvs-package/pvs.deb"
           pvs-studio-analyzer credentials "${{ secrets.PvsStudioName }}" "${{ secrets.PvsStudioKey }}"
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Build
         run: |

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -113,11 +113,20 @@ jobs:
           restore-keys: |
             ccache-msys2-${{ matrix.conf.sys }}-${{ steps.prep-ccache.outputs.name_hash }}-${{ steps.prep-ccache.outputs.yesterday }}-3
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-3
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Log environment
         run:  ./scripts/log-env.sh
@@ -224,11 +233,20 @@ jobs:
           restore-keys: |
             ccache-msys2-${{matrix.conf.sys}}-release-${{ steps.prep-ccache.outputs.yesterday }}-3
 
-      - name:  Cache subprojects
-        uses:  actions/cache@v3.2.4
+      - name: Cache subprojects
+        id:   cache-subprojects
+        uses: actions/cache@v3
         with:
-          path: subprojects/packagecache
-          key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-3
+          path: subprojects.tar
+          key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-4
+          enableCrossOsArchive: true
+
+      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
+        name: Generate subprojects cache
+        run:  scripts/fetch-and-tar-subprojects.sh
+
+      - name: Extract subprojects cache
+        run:  scripts/extract-subprojects-tar.sh
 
       - name: Log environment
         run:  ./scripts/log-env.sh

--- a/packages/macos-12-brew.txt
+++ b/packages/macos-12-brew.txt
@@ -3,6 +3,7 @@ cmake
 curl
 fluid-synth
 git
+gnu-tar
 libpng
 libslirp
 meson
@@ -17,3 +18,4 @@ sdl2_image
 sdl2_net
 speexdsp
 wget
+

--- a/packages/macos-latest-brew.txt
+++ b/packages/macos-latest-brew.txt
@@ -3,6 +3,7 @@ cmake
 curl
 fluid-synth
 git
+gnu-tar
 libpng
 libslirp
 meson

--- a/scripts/extract-subprojects-tar.sh
+++ b/scripts/extract-subprojects-tar.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2023-2023  kcgen <kcgen@users.noreply.github.com>
+#
+# A trivial script that extracts previously fetched and tarred
+# subproject content.
+
+set -euo pipefail
+
+usage()
+{
+    printf "%s\n" "\
+    Usage: $0 [TARFILE]
+
+    The tar executable can be optionally overridden by setting
+    the TAR environment variables, such as: TAR=gtar"
+}
+
+setup_tar()
+{
+	if [[ -z "${TAR:-}" ]]; then
+		if tar --version | grep -q GNU; then
+			TAR=tar
+		else
+			# Fallback to gtar; if that's not found the user
+			# will get a verbose command-not-found error.
+			TAR=gtar
+		fi
+	else
+		echo "Using TAR=$TAR"
+	fi
+
+	if [[ "${OSTYPE:-}" == "msys" ]]; then
+		# If not set, tar fails when extracting symlinks
+		export MSYS=winsymlinks:lnk
+	fi
+}
+
+main()
+{
+	if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+		usage
+		exit 0
+	fi
+
+	if [[ -z "${1:-}" ]]; then
+		local tarfile="subprojects.tar"
+	else
+		local tarfile="$1"
+	fi
+
+	setup_tar
+
+	"$TAR" -xf "$tarfile"
+}
+
+>&2 main "$@"

--- a/scripts/fetch-and-tar-subprojects.sh
+++ b/scripts/fetch-and-tar-subprojects.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2023-2023  kcgen <kcgen@users.noreply.github.com>
+#
+# A simple script that fetches all non-repository subproject
+# content and tars it to a given target directory and tar file.
+#
+# The resulting tar file can be used for all build types and
+# platform types as the content is pre-setup just source.
+#
+# Compression is not used because it's compressed by zstd during
+# CI's caching process (and double-zipping is slower).
+#
+
+set -euo pipefail
+
+usage()
+{
+    printf "%s\n" "\
+    Usage: $0 [TARFILE]
+
+    The tar, git, and meson executables can be optionally
+    overridden with upper-case environment variables, such as:
+      TAR=gtar
+      GIT=/usr/local/bin/git
+      MESON=/usr/cross-arm64/bin/meson"
+}
+
+create_dirs_for()
+{
+	mkdir -p "$(dirname "$1")"
+}
+
+list_non_repo_subprojects_dirs()
+{
+	"$GIT" status --ignored --porcelain \
+	| cut -d' ' -f2 \
+	| grep subprojects/
+}
+
+tar_non_repo_subprojects_dirs()
+{
+	local tarfile="$1"
+
+	[[ ! -f "$tarfile" ]]
+
+	list_non_repo_subprojects_dirs \
+	| "$TAR" -cf "$tarfile" --ignore-failed-read --files-from -
+
+	test -f "$tarfile"
+}
+
+fetch_subprojects()
+{
+	test -d subprojects
+
+	"$MESON" subprojects download
+	"$MESON" subprojects update --reset
+	"$MESON" subprojects foreach meson subprojects download
+
+	while read -r dir; do
+		(
+			set -eu
+			cd "$(dirname "$dir")"
+			"$MESON" subprojects download
+		)
+	done < <(find . -type d -name subprojects)
+}
+
+setup_binaries()
+{
+	if [[ -z "${GIT:-}" ]]; then
+		GIT=git
+	else
+		echo "Using GIT=$GIT"
+	fi
+
+
+	if [[ -z "${TAR:-}" ]]; then
+		if tar --version | grep -q GNU; then
+			TAR=tar
+		else
+			TAR=gtar
+		fi
+	else
+		echo "Using TAR=$TAR"
+	fi
+
+
+	if [[ -z "${MESON:-}" ]]; then
+		MESON=meson
+	else
+		echo "Using MESON=$MESON"
+	fi
+}
+
+main()
+{
+	if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+		usage
+		exit 0
+	fi
+
+	if [[ -z "${1:-}" ]]; then
+		local tarfile="subprojects.tar"
+	else
+		local tarfile="$1"
+	fi
+
+	create_dirs_for "$tarfile"
+
+	setup_binaries
+
+	fetch_subprojects
+
+	tar_non_repo_subprojects_dirs "$tarfile"
+}
+
+>&2 main "$@"


### PR DESCRIPTION
### Context

When Meson's `setup` phase determines the host can't satisfy a dependency, it checks the local `subprojects/*.wrap` to see if it can build the desired dependency from source.

If so, it downloads the source from tarball / git repo /other repo (like SVN or Hg), and saves the result in the `subprojects/packagecache` directory.

### Current CI state

Our platform workflows each save their `packagecache` directory to GitHub's cache, so we can avoid re-downloading them for future runs.

We take a checksum of all our `.wrap` files, and only when that checksum changes do we invalidate the cache and re-download.

### PR's CI change

It turns out, there is more caching we can do (background: https://gitlab.gnome.org/GNOME/glib/-/issues/2906)

Inside our cached `glib-2.74.4.tar.gz` are glib's own wraps, and those are only exercised if 1) the host doesn't have glib and 2) the host doesn't have any of glib's own dependencies, like pcre2, libffi, gvdb, and others.

So this PR replaces the current single-level `packagecache` approach with a generic recursive Meson downloader that fetches all subprojects and their subprojects (and so on).

Those are all tarred up and cached with GitHub. Additionally, because this tar holds every possible wraps' source, we now flag it for reuse cross-platform (because it can satisfy any CI workflow), which furthers its  efficiency.