### PR TITLE
Improve wildcard handling for `imgmount` file arguments

### DIFF
--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -1164,19 +1164,19 @@ Auflistung nicht unterstützt
 Gerät nicht konfiguriert
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-lokales Verzeichnis
+Lokales Verzeichnis
 .
 :MOUNT_TYPE_CDROM
 CD-ROM Laufwerk
 .
 :MOUNT_TYPE_FAT
-FAT Laufwerk
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO Laufwerk
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-virtuelles internes Laufwerk
+Virtuelles internes Laufwerk
 .
 :MOUNT_TYPE_UNKNOWN
 unbekanntes Laufwerk
@@ -1345,7 +1345,7 @@ Image-Name
 Wechsel-Image
 .
 :PROGRAM_MOUNT_STATUS_2
-Laufwerk %c ist eingebunden als %s
+%s ist eingebunden als Laufwerk %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3136,4 +3136,7 @@ und gemappte Mäuse erhalten immer direkte Eingabe-Daten.
 .
 :SHELL_CMD_MIXER_CHANNEL_REVERSE
 Umgekehrt
+.
+:CONJUNCTION_AND
+und
 .

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -1095,19 +1095,19 @@ listing not supported
 device not configured
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-local directory
+Local directory
 .
 :MOUNT_TYPE_CDROM
 CD-ROM drive
 .
 :MOUNT_TYPE_FAT
-FAT drive
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO drive
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-internal virtual drive
+Internal virtual drive
 .
 :MOUNT_TYPE_UNKNOWN
 unknown drive
@@ -1313,7 +1313,7 @@ Image name
 Swap slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Drive %c is mounted as %s
+%s mounted as %c drive
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3014,4 +3014,7 @@ Miscellaneous Commands
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Unknown Command
+.
+:CONJUNCTION_AND
+and
 .

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -961,7 +961,7 @@ Tipo
 Etiqueta
 .
 :PROGRAM_MOUNT_STATUS_2
-La unidad %c está montada como %s
+%s montada como unidad %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -2639,20 +2639,23 @@ Miscellaneous Commands
 Unknown Command
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-local directory
+Local directory
 .
 :MOUNT_TYPE_CDROM
 CD-ROM drive
 .
 :MOUNT_TYPE_FAT
-FAT drive
+FAT imagen
 .
 :MOUNT_TYPE_ISO
-ISO drive
+ISO imagen
 .
 :MOUNT_TYPE_VIRTUAL
-internal virtual drive
+Internal virtual drive
 .
 :MOUNT_TYPE_UNKNOWN
 unknown drive
+.
+:CONJUNCTION_AND
+y
 .

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -958,7 +958,7 @@ Type
 Nom de volume
 .
 :PROGRAM_MOUNT_STATUS_2
-Lecteur %c monté en tant que %s
+%s monté en tant que lecteur %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -2543,20 +2543,23 @@ Miscellaneous Commands
 Unknown Command
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-local directory
+Local directory
 .
 :MOUNT_TYPE_CDROM
 CD-ROM drive
 .
 :MOUNT_TYPE_FAT
-FAT drive
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO drive
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-internal virtual drive
+Internal virtual drive
 .
 :MOUNT_TYPE_UNKNOWN
 unknown drive
+.
+:CONJUNCTION_AND
+et
 .

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -1203,19 +1203,19 @@ elenco non supportato
 dispositivo non configurato
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-directory locale
+Directory locale
 .
 :MOUNT_TYPE_CDROM
-unità CD-ROM
+Unità CD-ROM
 .
 :MOUNT_TYPE_FAT
-unità FAT
+Immagine FAT
 .
 :MOUNT_TYPE_ISO
-unità ISO
+Immagine ISO
 .
 :MOUNT_TYPE_VIRTUAL
-unità virtuale interna
+Unità virtuale interna
 .
 :MOUNT_TYPE_UNKNOWN
 unità sconosciuta
@@ -1426,7 +1426,7 @@ Nome immagine
 Scambia slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Unità %c montata come %s
+%s montata come unità %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3202,4 +3202,7 @@ Comandi Vari
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Comando Sconosciuto
+.
+:CONJUNCTION_AND
+e
 .

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -1112,19 +1112,19 @@ lijst wordt niet ondersteund
 apparaat niet geconfigureerd
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-lokale map
+Lokale map
 .
 :MOUNT_TYPE_CDROM
 CD-ROM station
 .
 :MOUNT_TYPE_FAT
-FAT schijf
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO schijf
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-interne virtuele schijf
+Interne virtuele schijf
 .
 :MOUNT_TYPE_UNKNOWN
 onbekende schijf
@@ -1332,7 +1332,7 @@ Imagenaam
 Wissel slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Schijf %c is gekoppeld als %s
+%s gekoppeld als %c schijf
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3080,4 +3080,7 @@ Diverse opdrachten
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Onbekende opdracht
+.
+:CONJUNCTION_AND
+en
 .

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -1127,19 +1127,19 @@ ReelMagic Full Motion Player (wbudowany sterownik) %hhu.%hhu
 
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-katalog lokalny
+Katalog lokalny
 .
 :MOUNT_TYPE_CDROM
 CD-ROM
 .
 :MOUNT_TYPE_FAT
-obraz FAT
+Obraz FAT
 .
 :MOUNT_TYPE_ISO
-obraz ISO
+Obraz ISO
 .
 :MOUNT_TYPE_VIRTUAL
-wewnętrzny dysk wirtualny
+Wewnętrzny dysk wirtualny
 .
 :MOUNT_TYPE_UNKNOWN
 nieznany typ
@@ -1303,7 +1303,7 @@ Obraz
 Slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Dysk %c jest zamontowany jako '%s'.
+%s zamontowany jako dysk %c.
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3018,4 +3018,7 @@ Inne polecenia
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Pozostałe, bez kategorii
+.
+:CONJUNCTION_AND
+i
 .

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -1114,7 +1114,7 @@ DOSBox был запущен со следующими параметрами к
 Метка
 .
 :PROGRAM_MOUNT_STATUS_2
-Диск %c смонтирован как %s
+%s смонтирован как диск %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -2724,19 +2724,19 @@ https://github.com/dosbox-staging/dosbox-staging/wiki
 устройство не настроено
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-локальный каталог
+Локальный каталог
 .
 :MOUNT_TYPE_CDROM
-привод CD-ROM
+Привод CD-ROM
 .
 :MOUNT_TYPE_FAT
-привод FAT
+Образ FAT
 .
 :MOUNT_TYPE_ISO
-привод ISO
+Образ ISO
 .
 :MOUNT_TYPE_VIRTUAL
-внутренний виртуальный привод
+Внутренний виртуальный привод
 .
 :MOUNT_TYPE_UNKNOWN
 неизвестный привод
@@ -3041,4 +3041,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki
 .
 :SHELL_CMD_MIXER_CHANNEL_REVERSE
 Реверс
+.
+:CONJUNCTION_AND
+и
 .

--- a/contrib/resources/translations/utf-8/de.txt
+++ b/contrib/resources/translations/utf-8/de.txt
@@ -1164,19 +1164,19 @@ Auflistung nicht unterstützt
 Gerät nicht konfiguriert
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-lokales Verzeichnis
+Lokales Verzeichnis
 .
 :MOUNT_TYPE_CDROM
 CD-ROM Laufwerk
 .
 :MOUNT_TYPE_FAT
-FAT Laufwerk
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO Laufwerk
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-virtuelles internes Laufwerk
+Virtuelles internes Laufwerk
 .
 :MOUNT_TYPE_UNKNOWN
 unbekanntes Laufwerk
@@ -1345,7 +1345,7 @@ Image-Name
 Wechsel-Image
 .
 :PROGRAM_MOUNT_STATUS_2
-Laufwerk %c ist eingebunden als %s
+%s ist eingebunden als Laufwerk %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3136,4 +3136,7 @@ und gemappte Mäuse erhalten immer direkte Eingabe-Daten.
 .
 :SHELL_CMD_MIXER_CHANNEL_REVERSE
 Umgekehrt
+.
+:CONJUNCTION_AND
+und
 .

--- a/contrib/resources/translations/utf-8/en.txt
+++ b/contrib/resources/translations/utf-8/en.txt
@@ -1095,19 +1095,19 @@ listing not supported
 device not configured
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-local directory
+Local directory
 .
 :MOUNT_TYPE_CDROM
 CD-ROM drive
 .
 :MOUNT_TYPE_FAT
-FAT drive
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO drive
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-internal virtual drive
+Internal virtual drive
 .
 :MOUNT_TYPE_UNKNOWN
 unknown drive
@@ -1313,7 +1313,7 @@ Image name
 Swap slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Drive %c is mounted as %s
+%s mounted as %c drive
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3014,4 +3014,7 @@ Miscellaneous Commands
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Unknown Command
+.
+:CONJUNCTION_AND
+and
 .

--- a/contrib/resources/translations/utf-8/es.txt
+++ b/contrib/resources/translations/utf-8/es.txt
@@ -1071,7 +1071,7 @@ Tipo
 Etiqueta
 .
 :PROGRAM_MOUNT_STATUS_2
-La unidad %c está montada como %s
+%s montada como unidad %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -2749,19 +2749,19 @@ Miscellaneous Commands
 Unknown Command
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-local directory
+Local directory
 .
 :MOUNT_TYPE_CDROM
 CD-ROM drive
 .
 :MOUNT_TYPE_FAT
-FAT drive
+FAT imagen
 .
 :MOUNT_TYPE_ISO
-ISO drive
+ISO imagen
 .
 :MOUNT_TYPE_VIRTUAL
-internal virtual drive
+Internal virtual drive
 .
 :MOUNT_TYPE_UNKNOWN
 unknown drive
@@ -2960,4 +2960,7 @@ and mapped mice always receive raw input events.
 .
 :SHELL_CMD_MIXER_CHANNEL_REVERSE
 Reverse
+.
+:CONJUNCTION_AND
+y
 .

--- a/contrib/resources/translations/utf-8/fr.txt
+++ b/contrib/resources/translations/utf-8/fr.txt
@@ -1068,7 +1068,7 @@ Type
 Nom de volume
 .
 :PROGRAM_MOUNT_STATUS_2
-Lecteur %c monté en tant que %s
+%s monté en tant que lecteur %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -2653,19 +2653,19 @@ Miscellaneous Commands
 Unknown Command
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-local directory
+Local directory
 .
 :MOUNT_TYPE_CDROM
 CD-ROM drive
 .
 :MOUNT_TYPE_FAT
-FAT drive
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO drive
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-internal virtual drive
+Internal virtual drive
 .
 :MOUNT_TYPE_UNKNOWN
 unknown drive
@@ -2864,4 +2864,7 @@ and mapped mice always receive raw input events.
 .
 :SHELL_CMD_MIXER_CHANNEL_REVERSE
 Reverse
+.
+:CONJUNCTION_AND
+et
 .

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -1203,19 +1203,19 @@ elenco non supportato
 dispositivo non configurato
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-directory locale
+Directory locale
 .
 :MOUNT_TYPE_CDROM
-unità CD-ROM
+Unità CD-ROM
 .
 :MOUNT_TYPE_FAT
-unità FAT
+Immagine FAT
 .
 :MOUNT_TYPE_ISO
-unità ISO
+Immagine ISO
 .
 :MOUNT_TYPE_VIRTUAL
-unità virtuale interna
+Unità virtuale interna
 .
 :MOUNT_TYPE_UNKNOWN
 unità sconosciuta
@@ -1426,7 +1426,7 @@ Nome immagine
 Scambia slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Unità %c montata come %s
+%s montata come unità %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3202,4 +3202,7 @@ Comandi Vari
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Comando Sconosciuto
+.
+:CONJUNCTION_AND
+e
 .

--- a/contrib/resources/translations/utf-8/nl.txt
+++ b/contrib/resources/translations/utf-8/nl.txt
@@ -1112,19 +1112,19 @@ lijst wordt niet ondersteund
 apparaat niet geconfigureerd
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-lokale map
+Lokale map
 .
 :MOUNT_TYPE_CDROM
 CD-ROM station
 .
 :MOUNT_TYPE_FAT
-FAT schijf
+FAT image
 .
 :MOUNT_TYPE_ISO
-ISO schijf
+ISO image
 .
 :MOUNT_TYPE_VIRTUAL
-interne virtuele schijf
+Interne virtuele schijf
 .
 :MOUNT_TYPE_UNKNOWN
 onbekende schijf
@@ -1332,7 +1332,7 @@ Imagenaam
 Wissel slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Schijf %c is gekoppeld als %s
+%s gekoppeld als %c schijf
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3080,4 +3080,7 @@ Diverse opdrachten
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Onbekende opdracht
+.
+:CONJUNCTION_AND
+en
 .

--- a/contrib/resources/translations/utf-8/pl.txt
+++ b/contrib/resources/translations/utf-8/pl.txt
@@ -1127,19 +1127,19 @@ ReelMagic Full Motion Player (wbudowany sterownik) %hhu.%hhu
 
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-katalog lokalny
+Katalog lokalny
 .
 :MOUNT_TYPE_CDROM
 CD-ROM
 .
 :MOUNT_TYPE_FAT
-obraz FAT
+Obraz FAT
 .
 :MOUNT_TYPE_ISO
-obraz ISO
+Obraz ISO
 .
 :MOUNT_TYPE_VIRTUAL
-wewnętrzny dysk wirtualny
+Wewnętrzny dysk wirtualny
 .
 :MOUNT_TYPE_UNKNOWN
 nieznany typ
@@ -1303,7 +1303,7 @@ Obraz
 Slot
 .
 :PROGRAM_MOUNT_STATUS_2
-Dysk %c jest zamontowany jako '%s'.
+%s zamontowany jako dysk %c.
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -3018,4 +3018,7 @@ Inne polecenia
 .
 :HELP_UTIL_CATEGORY_UNKNOWN
 Pozostałe, bez kategorii
+.
+:CONJUNCTION_AND
+i
 .

--- a/contrib/resources/translations/utf-8/ru.txt
+++ b/contrib/resources/translations/utf-8/ru.txt
@@ -1114,7 +1114,7 @@ DOSBox был запущен со следующими параметрами к
 Метка
 .
 :PROGRAM_MOUNT_STATUS_2
-Диск %c смонтирован как %s
+%s смонтирован как диск %c
 
 .
 :PROGRAM_MOUNT_STATUS_1
@@ -2724,19 +2724,19 @@ https://github.com/dosbox-staging/dosbox-staging/wiki
 устройство не настроено
 .
 :MOUNT_TYPE_LOCAL_DIRECTORY
-локальный каталог
+Локальный каталог
 .
 :MOUNT_TYPE_CDROM
-привод CD-ROM
+Привод CD-ROM
 .
 :MOUNT_TYPE_FAT
-привод FAT
+Образ FAT
 .
 :MOUNT_TYPE_ISO
-привод ISO
+Образ ISO
 .
 :MOUNT_TYPE_VIRTUAL
-внутренний виртуальный привод
+Внутренний виртуальный привод
 .
 :MOUNT_TYPE_UNKNOWN
 неизвестный привод
@@ -3041,4 +3041,7 @@ https://github.com/dosbox-staging/dosbox-staging/wiki
 .
 :SHELL_CMD_MIXER_CHANNEL_REVERSE
 Реверс
+.
+:CONJUNCTION_AND
+и
 .

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -286,6 +286,8 @@ std::vector<std::string> split(const std::string &seq, const char delim);
 //   split(" ") returns {}
 std::vector<std::string> split(const std::string &seq);
 
+std::string join_with_commas(const std::vector<std::string>& items,
+                             const char* end_punctuation);
 
 // Clear the language if it's set to the POSIX default
 void clear_language_if_default(std::string &language);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -287,7 +287,8 @@ std::vector<std::string> split(const std::string &seq, const char delim);
 std::vector<std::string> split(const std::string &seq);
 
 std::string join_with_commas(const std::vector<std::string>& items,
-                             const char* end_punctuation);
+                             const std::string_view and_conjunction = "and",
+                             const std::string_view end_punctuation = ".");
 
 // Clear the language if it's set to the POSIX default
 void clear_language_if_default(std::string &language);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -244,7 +244,17 @@ constexpr bool iequals(T1&& a, T2&& b)
 	return std::equal(str_a.begin(), str_a.end(), str_b.begin(), str_b.end(), ciequals);
 }
 
-char *strip_word(char *&cmd);
+// Performs a "natural" comparison between A and B, which is case-insensitive
+// and treats number sequenences as whole numbers. Returns true if A < B. This
+// function can be used with higher order sort rountines, like std::sort.
+//
+// Examples:
+// - ("abc_2", "ABC_10") -> true, because abc_ matches and 2 < 10.
+// - ("xyz_2", "ABC_10") -> false, because 'x' > 'a'.
+// - ("abc123", "abc123=") -> true, simply because the first is shorter.
+bool natural_compare(const std::string& a, const std::string& b);
+
+char* strip_word(char*& cmd);
 
 std::string replace(const std::string &str, char old_char, char new_char) noexcept;
 void trim(std::string &str, const char trim_chars[] = " \r\t\f\n");

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -23,8 +23,8 @@
 #include <string.h>
 #include <time.h>
 
-#include "bios_disk.h"
 #include "bios.h"
+#include "bios_disk.h"
 #include "cross.h"
 #include "dos_inc.h"
 #include "string_utils.h"
@@ -754,6 +754,7 @@ fatDrive::fatDrive(const char *sysFilename,
 		imgDTAPtr = RealMake(imgDTASeg, 0);
 		imgDTA    = new DOS_DTA(imgDTAPtr);
 	}
+	assert(sysFilename);
 	diskfile = fopen_wrap_ro_fallback(sysFilename, readonly);
 	created_successfully = (diskfile != nullptr);
 	if (!created_successfully)
@@ -905,15 +906,21 @@ fatDrive::fatDrive(const char *sysFilename,
 	firstDataSector = (bootbuffer.reservedsectors + (bootbuffer.fatcopies * bootbuffer.sectorsperfat) + RootDirSectors) + partSectOff;
 	firstRootDirSect = bootbuffer.reservedsectors + (bootbuffer.fatcopies * bootbuffer.sectorsperfat) + partSectOff;
 
-	if(CountOfClusters < 4085) {
+	if (CountOfClusters < 4085) {
 		/* Volume is FAT12 */
-		LOG_MSG("Mounted FAT volume is FAT12 with %d clusters", CountOfClusters);
+		LOG_MSG("FAT: Mounted %s as FAT12 volume with %d clusters",
+		        sysFilename,
+		        CountOfClusters);
 		fattype = FAT12;
 	} else if (CountOfClusters < 65525) {
-		LOG_MSG("Mounted FAT volume is FAT16 with %d clusters", CountOfClusters);
+		LOG_MSG("FAT: Mounted %s as FAT16 volume with %d clusters",
+		        sysFilename,
+		        CountOfClusters);
 		fattype = FAT16;
 	} else {
-		LOG_MSG("Mounted FAT volume is FAT32 with %d clusters", CountOfClusters);
+		LOG_MSG("FAT: Mounted %s as FAT32 volume with %d clusters",
+		        sysFilename,
+		        CountOfClusters);
 		fattype = FAT32;
 	}
 

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -458,11 +458,11 @@ void IMGMOUNT::Run(void)
 		}
 		dos.dta(save_dta);
 
-		std::string tmp(paths[0]);
-		for (i = 1; i < paths.size(); i++) {
-			tmp += "; " + paths[i];
-		}
-		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
+		constexpr auto end_punctuation = ".";
+		const auto joined_paths = join_with_commas(paths, end_punctuation);
+		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
+		         drive,
+		         joined_paths.c_str());
 
 		auto newdrive = static_cast<fatDrive*>(imgDisks[0]);
 		assert(newdrive);
@@ -545,11 +545,12 @@ void IMGMOUNT::Run(void)
 
 		// Print status message (success)
 		WriteOut(MSG_Get("MSCDEX_SUCCESS"));
-		std::string tmp(paths[0]);
-		for (i = 1; i < paths.size(); i++) {
-			tmp += "; " + paths[i];
-		}
-		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
+
+		constexpr auto end_punctuation = ".";
+		const auto joined_paths = join_with_commas(paths, end_punctuation);
+		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
+		         drive,
+		         joined_paths.c_str());
 
 	} else if (fstype == "none") {
 		FILE* newDisk = fopen_wrap_ro_fallback(temp_line, roflag);

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -363,6 +363,23 @@ void IMGMOUNT::Run(void)
 		temp_line = paths[0];
 	}
 
+	auto write_out_mount_status = [this](const char* image_type,
+	                                     const std::vector<std::string>& images,
+	                                     const char drive_letter) {
+		constexpr auto end_punctuation = "";
+
+		const auto images_str = join_with_commas(images,
+		                                         MSG_Get("CONJUNCTION_AND"),
+		                                         end_punctuation);
+
+		const std::string type_and_images_str = image_type +
+		                                        std::string(" ") + images_str;
+
+		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
+		         type_and_images_str.c_str(),
+		         drive_letter);
+	};
+
 	if (fstype == "fat") {
 		if (imgsizedetect) {
 			FILE* diskfile = fopen_wrap_ro_fallback(temp_line, roflag);
@@ -458,12 +475,7 @@ void IMGMOUNT::Run(void)
 		}
 		dos.dta(save_dta);
 
-		constexpr auto end_punctuation = ".";
-		const auto joined_paths = join_with_commas(paths, end_punctuation);
-		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
-		         drive,
-		         joined_paths.c_str());
-
+		write_out_mount_status(MSG_Get("MOUNT_TYPE_FAT"), paths, drive);
 		auto newdrive = static_cast<fatDrive*>(imgDisks[0]);
 		assert(newdrive);
 		if (('A' <= drive && drive <= 'B' &&
@@ -546,11 +558,7 @@ void IMGMOUNT::Run(void)
 		// Print status message (success)
 		WriteOut(MSG_Get("MSCDEX_SUCCESS"));
 
-		constexpr auto end_punctuation = ".";
-		const auto joined_paths = join_with_commas(paths, end_punctuation);
-		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
-		         drive,
-		         joined_paths.c_str());
+		write_out_mount_status(MSG_Get("MOUNT_TYPE_ISO"), paths, drive);
 
 	} else if (fstype == "none") {
 		FILE* newDisk = fopen_wrap_ro_fallback(temp_line, roflag);

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -387,8 +387,8 @@ void MOUNT::Run(void) {
 				newdrive->GetMediaByte());
 	if (type != "overlay")
 		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
-		         drive,
-		         newdrive->GetInfoString().c_str());
+		         newdrive->GetInfoString().c_str(),
+		         drive);
 	else
 		WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_STATUS"),
 		         temp_line.c_str(),

--- a/src/dos/program_mount_common.cpp
+++ b/src/dos/program_mount_common.cpp
@@ -82,15 +82,15 @@ void AddCommonMountMessages() {
 	MSG_Add("PROGRAM_MOUNT_STATUS_LABEL", "Label");
 	MSG_Add("PROGRAM_MOUNT_STATUS_NAME", "Image name");
 	MSG_Add("PROGRAM_MOUNT_STATUS_SLOT", "Swap slot");
-	MSG_Add("PROGRAM_MOUNT_STATUS_2","Drive %c is mounted as %s\n");
+	MSG_Add("PROGRAM_MOUNT_STATUS_2", "%s mounted as %c drive\n");
 	MSG_Add("PROGRAM_MOUNT_STATUS_1", "The currently mounted drives are:\n");
 }
 
 void AddMountTypeMessages() {
-	MSG_Add("MOUNT_TYPE_LOCAL_DIRECTORY", "local directory");
+	MSG_Add("MOUNT_TYPE_LOCAL_DIRECTORY", "Local directory");
 	MSG_Add("MOUNT_TYPE_CDROM", "CD-ROM drive");
-	MSG_Add("MOUNT_TYPE_FAT", "FAT drive");
-	MSG_Add("MOUNT_TYPE_ISO", "ISO drive");
-	MSG_Add("MOUNT_TYPE_VIRTUAL", "internal virtual drive");
+	MSG_Add("MOUNT_TYPE_FAT", "FAT image");
+	MSG_Add("MOUNT_TYPE_ISO", "ISO image");
+	MSG_Add("MOUNT_TYPE_VIRTUAL", "Internal virtual drive");
 	MSG_Add("MOUNT_TYPE_UNKNOWN", "unknown drive");
 }

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -902,4 +902,5 @@ void PROGRAMS_Init(Section* sec) {
 	MSG_Add("PROGRAM_PATH_TOO_LONG",
 	        "The path \"%s\" exceeds the DOS maximum length of %d characters\n");
 	MSG_Add("PROGRAM_EXECUTABLE_MISSING", "Executable file not found: %s\n");
+	MSG_Add("CONJUNCTION_AND", "and");
 }

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -185,7 +185,35 @@ bool ciequals(const char a, const char b)
 	return tolower(a) == tolower(b);
 }
 
-char *strip_word(char *&line)
+bool natural_compare(const std::string& a_str, const std::string& b_str)
+{
+	auto parse_num = [](auto& it, const auto it_end) {
+		int num = 0;
+		while (it != it_end && isdigit(*it)) {
+			num = num * 10 + (*it - '0');
+			++it;
+		}
+		return num;
+	};
+	auto a = a_str.begin();
+	auto b = b_str.begin();
+
+	const auto a_end = a_str.end();
+	const auto b_end = b_str.end();
+
+	while (a != a_end && b != b_end) {
+		const auto found_nums = isdigit(*a) && isdigit(*b);
+		const auto a_val = found_nums ? parse_num(a, a_end) : tolower(*a++);
+		const auto b_val = found_nums ? parse_num(b, b_end) : tolower(*b++);
+		if (a_val != b_val) {
+			return a_val < b_val;
+		}
+	}
+	// the overlapping strings match, so finally check if A is shorter
+	return a == a_end && b != b_end;
+}
+
+char* strip_word(char*& line)
 {
 	char *scan = line;
 	scan       = ltrim(scan);

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -181,19 +181,24 @@ std::vector<std::string> split(const std::string &seq)
 }
 
 std::string join_with_commas(const std::vector<std::string>& items,
-                             const char* end_punctuation)
+                             const std::string_view and_conjunction,
+                             const std::string_view end_punctuation)
 {
 	const auto num_items = items.size();
 
 	std::string result = {};
-	std::string_view separator = (num_items == 2) ? " and " : ", ";
 
-	auto item_num = 1;
+	const auto and_pair = std::string(" ") + and_conjunction.data() + " ";
+	const auto and_multi = std::string(", ") + and_conjunction.data() + " ";
+
+	std::string separator = (num_items == 2u) ? and_pair : ", ";
+
+	size_t item_num = 1;
 	for (const auto& item : items) {
 		assert(!item.empty());
 		result += item;
 		result += (item_num == num_items) ? end_punctuation : separator;
-		separator = (item_num + 2 == num_items) ? ", and " : separator;
+		separator = (item_num + 2u == num_items) ? and_multi : separator;
 		++item_num;
 	}
 	return result;

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -180,6 +180,25 @@ std::vector<std::string> split(const std::string &seq)
 	return words;
 }
 
+std::string join_with_commas(const std::vector<std::string>& items,
+                             const char* end_punctuation)
+{
+	const auto num_items = items.size();
+
+	std::string result = {};
+	std::string_view separator = (num_items == 2) ? " and " : ", ";
+
+	auto item_num = 1;
+	for (const auto& item : items) {
+		assert(!item.empty());
+		result += item;
+		result += (item_num == num_items) ? end_punctuation : separator;
+		separator = (item_num + 2 == num_items) ? ", and " : separator;
+		++item_num;
+	}
+	return result;
+}
+
 bool ciequals(const char a, const char b)
 {
 	return tolower(a) == tolower(b);

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -80,6 +80,53 @@ TEST(CaseInsensitiveCompare, MixedTypes)
 }
 
 
+TEST(NaturalCompare, AtStartChar)
+{
+	EXPECT_FALSE(natural_compare("", ""));
+
+	EXPECT_TRUE(natural_compare(" ", "  "));
+	EXPECT_TRUE(natural_compare("a", "Aa"));
+	EXPECT_TRUE(natural_compare("aA", "Ba"));
+	EXPECT_TRUE(natural_compare("Aa", "ba"));
+}
+TEST(NaturalCompare, AtStartNum)
+{
+
+	EXPECT_TRUE(natural_compare("1", "1a"));
+	EXPECT_TRUE(natural_compare("1", "2a"));
+	EXPECT_TRUE(natural_compare("999", "1000a"));
+}
+
+TEST(NaturalCompare, InMiddleChar)
+{
+	EXPECT_TRUE(natural_compare("aac", "ABC"));
+	EXPECT_TRUE(natural_compare("aAc", "aBc"));
+	EXPECT_TRUE(natural_compare("AAC", "abc"));
+}
+TEST(NaturalCompare, InMiddleNum)
+{
+
+	EXPECT_TRUE(natural_compare("a1a", "a1aa"));
+	EXPECT_TRUE(natural_compare("A1A", "a2a"));
+	EXPECT_TRUE(natural_compare("A999b", "a1000a"));
+}
+TEST(NaturalCompare, AtEndChar)
+{
+	EXPECT_TRUE(natural_compare("abc", "ABCd"));
+	EXPECT_TRUE(natural_compare("abcD", "abcE"));
+	EXPECT_TRUE(natural_compare("ABCD", "abce"));
+
+}
+TEST(NaturalCompare, AtEndNum)
+{
+
+	EXPECT_TRUE(natural_compare("a1", "a1 "));
+	EXPECT_TRUE(natural_compare("A10", "b2"));
+	EXPECT_TRUE(natural_compare("A10", "a20"));
+	EXPECT_TRUE(natural_compare("Ab999", "aB1000"));
+}
+
+
 TEST(StartsWith, Prefix)
 {
 	EXPECT_TRUE(starts_with("ab", "abcd"));


### PR DESCRIPTION
Previously, alpha-numeric sorting was used when mounting disk images with wildcards.

This works fine when disk image numbers are zero-padded up to the largest, for example in an 11 disk set: `disk01.img`, `disk02.img`, ..., `disk11.img`.

However, sometimes disks aren't zero-padded resulting in unwanted ordering:

![2023-02-08_17-49](https://user-images.githubusercontent.com/1557255/217696398-261c167c-c6c5-4486-8398-dbeb35da30b9.png)


This PR adds natural sorting:

![2023-02-08_17-51_1](https://user-images.githubusercontent.com/1557255/217696482-02781779-0a16-4506-a10b-ec1470098918.png)

And nicer logging of the result.

- Singles: ![2023-02-08_17-50_1](https://user-images.githubusercontent.com/1557255/217696614-d306d08b-b37c-4f12-971e-878ff4bf4b68.png)

- Pairs: ![2023-02-08_17-50_2](https://user-images.githubusercontent.com/1557255/217696693-0c89e13f-7ace-487e-b5cf-35e2041b4ce8.png)

- Three or more: ![2023-02-08_17-51](https://user-images.githubusercontent.com/1557255/217696760-4b52c146-b13e-4470-bd30-d8f70de12140.png)


It also adds filename to the console log messages, which can help when reporting issues or when parsing with a script:

```
2023-02-08 | FAT: Mounted disk1.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk2.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk3.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk4.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk5.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk6.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk7.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk8.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk9.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk10.img as FAT12 volume with 2847 clusters
2023-02-08 | FAT: Mounted disk11.img as FAT12 volume with 2847 clusters
```

Thanks to @Eulisker from the eXoDOS project for catching this bug :+1: !