### PR TITLE
Website - detailing Windows, macOS support

### DIFF
--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -79,6 +79,11 @@ you build a binary optimized for gaming.
    ``` shell
    meson setup build/release-clang --native-file=.github/meson/native-clang.ini
    ```
+   
+   If building for Vista use instead:
+   ``` shell
+   meson setup -Duse_fluidsynth=false -Duse_slirp=false build/release-clang --native-file=.github/meson/native-clang.ini
+   ```   
 
 9. Compile:
 

--- a/website/docs/about/index.md
+++ b/website/docs/about/index.md
@@ -50,7 +50,7 @@ backlog](https://github.com/dosbox-staging/dosbox-staging/projects/3).
 
 ## Non-goals
 
-- Support old operating systems (Windows 9x/Me, OS/2, and Mac OS X 10.4)
+- Support old operating systems (Windows 9x/Me/XP, OS/2, and Mac OS X 10.4)
   and limited CPU/memory hardware, which are constraints
   [DOSBox](https://www.dosbox.com/) continues to support.
 

--- a/website/docs/about/index.md
+++ b/website/docs/about/index.md
@@ -50,7 +50,7 @@ backlog](https://github.com/dosbox-staging/dosbox-staging/projects/3).
 
 ## Non-goals
 
-- Support old operating systems (Windows 9x/Me/XP, OS/2, and Mac OS X 10.4)
+- Support old operating systems (Windows 9x/Me/XP, OS/2, and Mac OS X 10.5)
   and limited CPU/memory hardware, which are constraints
   [DOSBox](https://www.dosbox.com/) continues to support.
 

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -92,8 +92,8 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 document.addEventListener("DOMContentLoaded", () => {
     set_ci_status("linux.yml", "linux", "Linux");
     set_ci_status("macos.yml", "macos", "macOS");
-    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds (64-bit ZIP, 64-bit Installer with MSYS2 and MSVC)");
-    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds (32-bit ZIP, 64-bit ZIP)");
+    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds");
+    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds");
 });
 
 </script>
@@ -160,6 +160,8 @@ document.addEventListener("DOMContentLoaded", () => {
 </table>
 </div>
 
+Windows MSYS2 builds include 64-bit ZIP and Installer with both 64-bit MSYS2 (default) and 64-bit MSVC (optional).<br>
+Windows MSVC builds include 32-bit ZIP and 64-bit ZIP.
 
 ## Installation notes
 

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -115,46 +115,46 @@ document.addEventListener("DOMContentLoaded", () => {
   </tr>
   <tr>
     <td id="linux-build-link">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="linux-build-version">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="linux-build-date">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
   </tr>
   <tr>
     <td id="macos-build-link">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="macos-build-version">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="macos-build-date">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
   </tr>
   <tr>
     <td id="msys2-build-link">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="msys2-build-version">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="msys2-build-date">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
   </tr>
   <tr>
     <td id="windows-build-link">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="windows-build-version">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="windows-build-date">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg" />
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
   </tr>
 </table>

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -92,8 +92,8 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 document.addEventListener("DOMContentLoaded", () => {
     set_ci_status("linux.yml", "linux", "Linux");
     set_ci_status("macos.yml", "macos", "macOS");
-    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds");
-    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds");
+    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds (64-bit ZIP, 64-bit Installer with MSYS2 and MSVC)");
+    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds (32-bit ZIP, 64-bit ZIP)");
 });
 
 </script>

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -92,8 +92,8 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 document.addEventListener("DOMContentLoaded", () => {
     set_ci_status("linux.yml", "linux", "Linux");
     set_ci_status("macos.yml", "macos", "macOS");
-    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds");
-    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds");
+    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds ¹");
+    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds ²");
 });
 
 </script>
@@ -160,8 +160,10 @@ document.addEventListener("DOMContentLoaded", () => {
 </table>
 </div>
 
-Windows MSYS2 builds include 64-bit ZIP and Installer with both 64-bit MSYS2 (default) and 64-bit MSVC (optional).<br>
-Windows MSVC builds include 32-bit ZIP and 64-bit ZIP.
+¹ Windows MSYS2 builds include 64-bit ZIP and Installer with both 64-bit MSYS2
+(default) and 64-bit MSVC (optional).
+
+² Windows MSVC builds include 32-bit ZIP and 64-bit ZIP.
 
 ## Installation notes
 

--- a/website/docs/downloads/linux.md
+++ b/website/docs/downloads/linux.md
@@ -94,6 +94,10 @@ You can easily configure your DOS games on
 [RetroPie-Setup](https://github.com/RetroPie/RetroPie-Setup) (select
 **Optional Packages** --> **DOSBox Staging**).
 
+## Harware requirements
+
+For x86 CPUs the SSE 4.2 instruction set is required.
+
 ## Development snapshot builds
 
 You can always see what's cooking on the main branch! :sunglasses: :beer:

--- a/website/docs/downloads/macos.md
+++ b/website/docs/downloads/macos.md
@@ -39,7 +39,7 @@ compatible with macOS 10.14 (Mojave) or newer. Learn how to setup Homebrew
 ## MacPorts
 
 The [MacPorts package](https://ports.macports.org/port/dosbox-staging/)
-should build on systems as old as macOS 10.7 (Lion, circa 2011) or newer.
+should build on systems as old as macOS 10.6 (Snow Leopard, circa 2009) or newer.
 Learn how to setup MacPorts [here](https://guide.macports.org/).
 
     sudo port selfupdate

--- a/website/docs/downloads/macos.md
+++ b/website/docs/downloads/macos.md
@@ -85,43 +85,43 @@ payments and therefore ask users to bypass Apple's Gatekeeper manually.
 
 ## Older builds
 
-- [DOSBox Staging 0.80.0 Universal binary (dmg)][0_80_0]
+- [DOSBox Staging 0.80.0 Universal binary (dmg)][0_80_0] (macOS 10.15 or newer)
   <br>
   <small>
   sha256: 53f12aa63cf9d2a33a46149fb394947c<wbr>6b12d5ab9b7ba41ee2d7eab1a990fa7a
   </small>
 
-- [DOSBox Staging 0.79.1 Universal binary (dmg)][0_79_1]
+- [DOSBox Staging 0.79.1 Universal binary (dmg)][0_79_1] (macOS 10.15 or newer)
   <br>
   <small>
   sha256: 52547692be29949747bb8d3b59bf31dd<wbr>22b4f49178316417cc8f1f468eeab387
   </small>
 
-- [DOSBox Staging 0.79.0 Universal binary (dmg)][0_79_0]
+- [DOSBox Staging 0.79.0 Universal binary (dmg)][0_79_0] (macOS 10.15 or newer)
   <br>
   <small>
   sha256: 1678f7458acabecdaf2b49e0d95a20d0<wbr>57734898b70c29d4e845f52a1aa26d46
   </small>
 
-- [DOSBox Staging 0.78.1 Universal binary (dmg)][0_78_1_UB]
+- [DOSBox Staging 0.78.1 Universal binary (dmg)][0_78_1_UB] (macOS 10.15 or newer)
   <br>
   <small>
   sha256: b9ddff89e9fc283493580d5fc021b050<wbr>21a13d90305ae44e2867499b22e359c9
   </small>
 
-- [DOSBox Staging 0.78.0 Universal binary (dmg)][0_78_0_UB]
+- [DOSBox Staging 0.78.0 Universal binary (dmg)][0_78_0_UB] (macOS 10.15 or newer)
   <br>
   <small>
   sha256: 3997546560af542b7f3b55b1bc890ae4<wbr>342144a72c21af9880449adf579db88b
   </small>
 
-- [DOSBox Staging 0.77.1 x86-64 (dmg)][0_77_1_x64]
+- [DOSBox Staging 0.77.1 x86-64 (dmg)][0_77_1_x64] (macOS 10.15 or newer)
   <br>
   <small>
   sha256: 29964d79f0a85d593f8bafd30da854c7<wbr>26594c12474528f46758fc95c05f0c97
   </small>
 
-- [DOSBox Staging 0.77.1 ARM64 (dmg)][0_77_1_arm64]
+- [DOSBox Staging 0.77.1 ARM64 (dmg)][0_77_1_arm64] (macOS 11 or newer)
   <br>
   <small>
   sha256: 74a1c84bdda0db25091f749ba7a2e5e9<wbr>3f7849baf130817ea1bc182039bd3698

--- a/website/docs/downloads/macos.md
+++ b/website/docs/downloads/macos.md
@@ -25,6 +25,9 @@ the changes and improvements introduced by this release.
 
     [1]:https://github.com/dosbox-staging/dosbox-staging
 
+## Harware requirements
+
+For x86 CPUs the SSE 4.2 instruction set is required. For Intel Mac models that don't support it you can try using the parital SSE4.2 emulator [MouSSE](https://forums.macrumors.com/threads/mp3-1-others-sse-4-2-emulation-to-enable-amd-metal-driver.2206682/).
 
 ## Homebrew
 

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -39,7 +39,7 @@ For 64-bit Windows 7, use the 64-bit MSVC build. It can be optionally selected
 in the [installer](0_80_1_x64_INSTALLER) and is also available as a [portable
 ZIP archive](0_80_1_x64_ZIP).
 
-For 32-bit Windows 7, use the [portable 32-bit MSVC build](0_80_1_x32_ZIP)
+For 32-bit Windows 7, use the 32-bit MSVC build [portable ZIP archive](0_80_1_x32_ZIP)
 
 ## Windows Vista
 

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -26,7 +26,7 @@ the changes and improvements introduced by this release.
     Microsoft Defender SmartScreen, see the [section below](#microsoft-defender-smartscreen).
 
 For 32-bit Windows 7 and newer, and for 64-bit Windows 7 hosts use the respective MSVC builds:
-- The 32-bit MSVC build [Download DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
+- The 32-bit MSVC build [DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
 - The 64-bit MSVC build on Windows 7 or newer can be optionally selected in the installer.
 
 Windows Vista hosts are supported out-of-the-box up to release 0.78.1.

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -5,6 +5,8 @@ hide:
 
 # Windows builds
 
+## Windows 8.x or newer
+
 [Download DOSBox Staging 0.80.1 64-bit (Installer)][0_80_1_x64_INSTALLER]
 <br>
 <small>
@@ -17,6 +19,12 @@ sha256: 94b961f397f3b70a13daf3b573857b52<wbr>62515e75d490bfc19f019479fe1694f8
 sha256: 3680cbdf7a91467877b51c95e468ef45<wbr>b186b42518c3163fab85c727923ee659
 </small>
 
+[Download DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
+<br>
+<small>
+sha256: 
+</small>
+
 Check out the [0.80.1 release notes](release-notes/0.80.1.md) to learn about
 the changes and improvements introduced by this release.
 
@@ -25,16 +33,26 @@ the changes and improvements introduced by this release.
     If Windows 8.x or Windows 10 prevents you from running DOSBox Staging via
     Microsoft Defender SmartScreen, see the [section below](#microsoft-defender-smartscreen).
 
-The installer uses by default the MSYS2 build, which works on 64-bit Windows 8.x or newer.<br>
+## Windows 7
 
-For 64-bit Windows 7 use the 64-bit MSVC build. It can be optionally selected via the installer and is also available as ZIP.<br>
-For 32-bit Windows 7, 8.x and 10 use the 32-bit MSVC build [DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
+For 64-bit Windows 7, use the 64-bit MSVC build. It can be optionally selected
+in the [installer](0_80_1_x64_INSTALLER) and is also available as a [portable
+ZIP archive](0_80_1_x64_ZIP).
 
-Windows Vista is supported out-of-the-box up to release 0.78.1.
-<br>
-Subsequent releases can be built from source by excluding FluidSynth and Slirp. Please see the [Windows MSYS2 build instructions][5] for further details.
+For 32-bit Windows 7, use the [portable 32-bit MSVC build](0_80_1_x32_ZIP)
 
-[5]:https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2 
+## Windows Vista
+
+The official distribution packages only support Windows Vista up to version
+0.78.1.
+
+More recent releases can be built from the source by excluding FluidSynth and
+Slirp support. Please see the [Windows MSYS2 build instructions][win-build]
+for further details.
+
+[win-build]: https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2
+
+## Harware requirements
 
 CPUs without SSE4.2 are supported up to release 0.75.0. 
 
@@ -97,13 +115,13 @@ command-line install parameters, please see [Inno's documentation page](https://
 ## Older builds
 
 - [DOSBox Staging 0.80.0 64-bit (Installer)][0_80_0_x64_INSTALLER] (Windows 7 or newer)
-  <br/>
+  <br>
   <small>
   sha256: 84445c869e58f6b4591484f6178c7b5b<wbr>3c8f284bf9460e9afc4502ba842ab039
   </small>
 
 - [DOSBox Staging 0.80.0 64-bit (zip)][0_80_0_x64_ZIP] (Windows 7 or newer)
-  <br/>
+  <br>
   <small>
   sha256: 075be379ed4475615e0e86953eb21f02<wbr>4c74b4cafd6914e9cf5ef40e3d9e26cd
   </small>

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -25,17 +25,13 @@ the changes and improvements introduced by this release.
     If Windows 8.x or Windows 10 prevents you from running DOSBox Staging via
     Microsoft Defender SmartScreen, see the [section below](#microsoft-defender-smartscreen).
 
-For 32-bit Windows 7 and newer, and for 64-bit Windows 7 hosts use the respective MSVC builds:
+For 32-bit Windows 7 and newer, and for 64-bit Windows 7 use the respective MSVC builds:
 - The 32-bit MSVC build [DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
 - The 64-bit MSVC build on Windows 7 or newer can be optionally selected in the installer.
 
 Windows Vista hosts are supported out-of-the-box up to release 0.78.1.
 <br>
-Subsequent releases can be [build from source][5] by excluding FluidSynth (MIDI) and Slirp (NE2000) via:
-
-!!! MSYS2 Clang build with step 8 command 
-
-    meson setup -Duse_fluidsynth=false -Duse_slirp=false build/release-clang --native-file=.github/meson/native-clang.ini
+Subsequent releases can be built from source by excluding FluidSynth (MIDI) and Slirp (NE2000). Please see the [Windows MSYS2 build instructions][5] for further details.
 
 [5]:https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2 
 

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -54,7 +54,7 @@ for further details.
 
 ## Harware requirements
 
-CPUs without SSE4.2 are supported up to release 0.75.0. 
+SSE 4.2 instruction set is required for version 0.75.1 or newer.
 
 ## Development snapshot builds
 

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -25,13 +25,14 @@ the changes and improvements introduced by this release.
     If Windows 8.x or Windows 10 prevents you from running DOSBox Staging via
     Microsoft Defender SmartScreen, see the [section below](#microsoft-defender-smartscreen).
 
-For 32-bit Windows 7 and newer, and for 64-bit Windows 7 use the respective MSVC builds:
-- The 32-bit MSVC build [DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
-- The 64-bit MSVC build on Windows 7 or newer can be optionally selected in the installer.
+The installer uses by default the MSYS2 build, which works on 64-bit Windows 8.x or newer.<br>
 
-Windows Vista hosts are supported out-of-the-box up to release 0.78.1.
+For 64-bit Windows 7 use the 64-bit MSVC build. It can be optionally selected via the installer and is also available as ZIP.<br>
+For 32-bit Windows 7, 8.x and 10 use the 32-bit MSVC build [DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
+
+Windows Vista is supported out-of-the-box up to release 0.78.1.
 <br>
-Subsequent releases can be built from source by excluding FluidSynth (MIDI) and Slirp (NE2000). Please see the [Windows MSYS2 build instructions][5] for further details.
+Subsequent releases can be built from source by excluding FluidSynth and Slirp. Please see the [Windows MSYS2 build instructions][5] for further details.
 
 [5]:https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2 
 

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -22,7 +22,7 @@ sha256: 3680cbdf7a91467877b51c95e468ef45<wbr>b186b42518c3163fab85c727923ee659
 [Download DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
 <br>
 <small>
-sha256: 
+sha256: cd73b86699e9732bcee9fe33d4bc05e19262d0b1cc64478b18be9853fe28f083
 </small>
 
 Check out the [0.80.1 release notes](release-notes/0.80.1.md) to learn about

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -25,6 +25,21 @@ the changes and improvements introduced by this release.
     If Windows 8.x or Windows 10 prevents you from running DOSBox Staging via
     Microsoft Defender SmartScreen, see the [section below](#microsoft-defender-smartscreen).
 
+For 32-bit Windows 7 and newer, and for 64-bit Windows 7 hosts use the respective MSVC builds:
+- The 32-bit MSVC build [Download DOSBox Staging 0.80.1 32-bit (zip)][0_80_1_x32_ZIP]
+- The 64-bit MSVC build on Windows 7 or newer can be optionally selected in the installer.
+
+Windows Vista hosts are supported out-of-the-box up to release 0.78.1.
+<br>
+Subsequent releases can be [build from source][5] by excluding FluidSynth (MIDI) and Slirp (NE2000) via:
+
+!!! MSYS2 Clang build with step 8 command 
+
+    meson setup -Duse_fluidsynth=false -Duse_slirp=false build/release-clang --native-file=.github/meson/native-clang.ini
+
+[5]:https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2 
+
+CPUs without SSE4.2 are supported up to release 0.75.0. 
 
 ## Development snapshot builds
 
@@ -84,127 +99,127 @@ command-line install parameters, please see [Inno's documentation page](https://
 
 ## Older builds
 
-- [DOSBox Staging 0.80.0 64-bit (Installer)][0_80_0_x64_INSTALLER]
+- [DOSBox Staging 0.80.0 64-bit (Installer)][0_80_0_x64_INSTALLER] (Windows 7 or newer)
   <br/>
   <small>
   sha256: 84445c869e58f6b4591484f6178c7b5b<wbr>3c8f284bf9460e9afc4502ba842ab039
   </small>
 
-- [DOSBox Staging 0.80.0 64-bit (zip)][0_80_0_x64_ZIP]
+- [DOSBox Staging 0.80.0 64-bit (zip)][0_80_0_x64_ZIP] (Windows 7 or newer)
   <br/>
   <small>
   sha256: 075be379ed4475615e0e86953eb21f02<wbr>4c74b4cafd6914e9cf5ef40e3d9e26cd
   </small>
 
-- [DOSBox Staging 0.79.1 64-bit (installer)][0_79_1_x64_INSTALLER]
+- [DOSBox Staging 0.79.1 64-bit (installer)][0_79_1_x64_INSTALLER] (Windows 7 or newer)
   <br>
   <small>
   sha256: 0045ac995ada0af955681983ae86c969<wbr>a05030c25173618f8b1547a267046a27
   </small>
 
-- [DOSBox Staging 0.79.1 64-bit (zip)][0_79_1_x64_ZIP]
+- [DOSBox Staging 0.79.1 64-bit (zip)][0_79_1_x64_ZIP] (Windows 7 or newer)
   <br>
   <small>
   sha256: 8c7045dfea6dc20bb985cff516d2faee<wbr>51d2ecaf054db60632857b6941d3d648
   </small>
 
-- [DOSBox Staging 0.79.0 64-bit (installer)][0_79_0_x64_INSTALLER]
+- [DOSBox Staging 0.79.0 64-bit (installer)][0_79_0_x64_INSTALLER] (Windows 7 or newer)
   <br>
   <small>
   sha256: 154c663f76d0ca46d1d23d8c2bcea2d8<wbr>3717f1ba9103067a6a6f5ce814cf0cb2
   </small>
 
-- [DOSBox Staging 0.79.0 64-bit (zip)][0_79_0_x64_ZIP]
+- [DOSBox Staging 0.79.0 64-bit (zip)][0_79_0_x64_ZIP] (Windows 7 or newer)
   <br>
   <small>
   sha256: b3633d425489fbb5f6f9b3de75e4c2c6<wbr>dd0713c3aec504e42cac948cc1550bbe
   </small>
 
-- [DOSBox Staging 0.78.1 64-bit (zip)][0_78_1_x64_MSYS2]
+- [DOSBox Staging 0.78.1 64-bit (zip)][0_78_1_x64_MSYS2] (Windows Vista or newer)
   <br>
   <small>
   sha256: 3c2f408125351154a37e93de8a4bd05d<wbr>0c722bbf53e1f583909e4ca6c3eb9204
   </small>
 
-- [DOSBox Staging with built-in debugger 0.78.1 64-bit (zip)][0_78_1_x64_MSVC]
+- [DOSBox Staging with built-in debugger 0.78.1 64-bit (zip)][0_78_1_x64_MSVC] (Windows Vista or newer)
   <br>
   <small>
   sha256: b99f3c354f831ed2b0ed04d215170f69<wbr>6b6fc18285b0c7192c0abab62c41bbc8
   </small>
 
-- [DOSBox Staging 0.78.0 64-bit (zip)][0_78_0_x64]
+- [DOSBox Staging 0.78.0 64-bit (zip)][0_78_0_x64] (Windows Vista or newer)
   <br>
   <small>
   sha256: f13cba664259fdb0db5e32826e13dcde<wbr>d4270557963f6e823a4731129f23a8a3
   </small>
 
-- [DOSBox Staging 0.78.0 32-bit (zip)][0_78_0_x86]
+- [DOSBox Staging 0.78.0 32-bit (zip)][0_78_0_x86] (Windows Vista or newer)
   <br>
   <small>
   sha256: 0ca9201cdf3f3a1576b97b0de0e87280<wbr>b75c633976f0b179ba33a68d44f5ba56
   </small>
 
-- [DOSBox Staging 0.77.1 64-bit (zip)][0_77_1_x64]
+- [DOSBox Staging 0.77.1 64-bit (zip)][0_77_1_x64] (Windows Vista or newer)
   <br>
   <small>
   sha256: 11ba992ece6d3e4ef2046fcdb6d842da<wbr>364b69720a921d61fdcc793eb52e7051
   </small>
 
-- [DOSBox Staging 0.77.1 32-bit (zip)][0_77_1_x86]
+- [DOSBox Staging 0.77.1 32-bit (zip)][0_77_1_x86] (Windows Vista or newer)
   <br>
   <small>
   sha256: a34883101486ce2af071a29c6390f203<wbr>8889fc519e042101284f2a6999d9f0ef
   </small>
 
-- [DOSBox Staging 0.77.0 64-bit (zip)][0_77_0_x64]
+- [DOSBox Staging 0.77.0 64-bit (zip)][0_77_0_x64] (Windows Vista or newer)
   <br>
   <small>
   sha256: cacdac418642fd8c7faf1e5955110c35<wbr>d0c207392ae20835707fd2a1e1114b82
   </small>
 
-- [DOSBox Staging 0.77.0 32-bit (zip)][0_77_0_x86]
+- [DOSBox Staging 0.77.0 32-bit (zip)][0_77_0_x86] (Windows Vista or newer)
   <br>
   <small>
   sha256: f718d07bab69e3e1be0b28207039cea2<wbr>746c7e45b8ba7a19b625011f477e609a
   </small>
 
-- [DOSBox Staging 0.76.0 32-bit (zip)][0_76_0_x86]
+- [DOSBox Staging 0.76.0 32-bit (zip)][0_76_0_x86] (Windows Vista or newer)
   <br>
   <small>
   sha256: 646d2f3fa8189e411589fedcb8148a29<wbr>5361693a6ce95d08e06f4a70e5a36b16
   </small>
 
-- [DOSBox Staging 0.75.2 64-bit (zip)][0_75_2_x64]
+- [DOSBox Staging 0.75.2 64-bit (zip)][0_75_2_x64] (Windows Vista or newer)
   <br>
   <small>
   sha256: 09f0ca911813a64b8814880eb6e49ad4<wbr>dcdac9a5bb9263c4887ad82b71fad292
   </small>
 
-- [DOSBox Staging 0.75.2 32-bit (zip)][0_75_2_x86]
+- [DOSBox Staging 0.75.2 32-bit (zip)][0_75_2_x86] (Windows Vista or newer)
   <br>
   <small>
   sha256: 51dc171ff52ea395c6a22f09ebb98a93<wbr>974a95c701ca81008368c22a66deced2
   </small>
 
-- [DOSBox Staging 0.75.1 64-bit (zip)][0_75_1_x64]
+- [DOSBox Staging 0.75.1 64-bit (zip)][0_75_1_x64] (Windows Vista or newer)
   <br>
   <small>
   sha256: 80c60c4377ff2882649f113b3cb3bcd4<wbr>07c17acaac344c49fa1fc4229813f012
   </small>
 
-- [DOSBox Staging 0.75.1 32-bit (zip)][0_75_1_x86]
+- [DOSBox Staging 0.75.1 32-bit (zip)][0_75_1_x86] (Windows Vista or newer)
   <br>
   <small>
   sha256: 843c742a348f575862e152e02cf174be<wbr>0ea1c52bdb6e4bffd65f34af88b566b7
   </small>
 
-- [DOSBox Staging 0.75.0 32-bit (zip)][0_75_0_x86]
+- [DOSBox Staging 0.75.0 32-bit (zip)][0_75_0_x86] (Windows Vista or newer, supports CPUs without SSE4.2)
   <br>
   <small>
   sha256: 69046adcef2ef9920fbba8d40fc9e51f<wbr>3dd144ba4549787e1816cf1c2ae87d71
   </small>
 
-- [DOSBox Staging 0.75.0-rc1 32-bit (zip)][0_75_0_rc1_x86]
+- [DOSBox Staging 0.75.0-rc1 32-bit (zip)][0_75_0_rc1_x86] (Windows Vista or newer, supports CPUs without SSE4.2)
   <br>
   <small>
   sha256: 738d2ae2101384f2eeaf1895de64cf1b<wbr>4c76eaf7873de7e15b7f52145dfed7e7
@@ -213,6 +228,7 @@ command-line install parameters, please see [Inno's documentation page](https://
 
 [0_80_1_x64_INSTALLER]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.1/dosbox-staging-v0.80.1-setup.exe
 [0_80_1_x64_ZIP]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.1/dosbox-staging-windows-x86_64-v0.80.1.zip
+[0_80_1_x32_ZIP]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.1/dosbox-staging-windows-x86_32-v0.80.1.zip
 [0_80_0_x64_INSTALLER]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-v0.80.0-setup.exe
 [0_80_0_x64_ZIP]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-windows-msys2-x86_64-v0.80.0.zip
 [0_79_1_x64_INSTALLER]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-v0.79.1-setup.exe


### PR DESCRIPTION
Per #2258 and dosbox-staging/dosbox-staging.github.io/pull/28
Per [0.75.1 release notes](https://dosbox-staging.github.io/downloads/release-notes/0.75.1/#provide-windows-x64-builds)
> Both Windows builds now require SSE 4.2 instruction set, which is now on par with the Linux and macOS builds that have required SSE 4.2 support since the 0.75.0 release.
