### PR TITLE
FAT image mounting fixes

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -123,6 +123,9 @@ bool DOS_ForceDuplicateEntry(uint16_t entry,uint16_t newentry);
 bool DOS_GetFileDate(uint16_t entry, uint16_t* otime, uint16_t* odate);
 bool DOS_SetFileDate(uint16_t entry, uint16_t ntime, uint16_t ndate);
 
+uint16_t DOS_GetBiosTimePacked();
+uint16_t DOS_GetBiosDatePacked();
+
 // Date and Time Conversion
 constexpr uint16_t DOS_PackTime(const uint16_t hour,
                                 const uint16_t min,

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -178,6 +178,22 @@ void DOS_SetCountry(uint16_t country_number)
 	dos.tables.country[DOS_DECIMAL_SEPARATOR_OFS]   = country_info.decimal_separator;
 }
 
+uint16_t DOS_GetBiosTimePacked()
+{
+	const auto ticks   = mem_readd(BIOS_TIMER);
+	const auto seconds = (ticks * 10) / 182;
+	const auto hour    = static_cast<uint16_t>(seconds / 3600);
+	const auto min     = static_cast<uint16_t>((seconds % 3600) / 60);
+	const auto sec     = static_cast<uint16_t>(seconds % 60);
+
+	return DOS_PackTime(hour, min, sec);
+}
+
+uint16_t DOS_GetBiosDatePacked()
+{
+	return DOS_PackDate(dos.date.year, dos.date.month, dos.date.day);
+}
+
 static void DOS_AddDays(Bitu days)
 {
 	dos.date.day += days;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1183,13 +1183,8 @@ uint8_t DOS_FCBWrite(uint16_t seg,uint16_t offset,uint16_t recno) {
 	fcb.GetSizeDateTime(size,date,time);
 	if (pos+towrite>size) size=pos+towrite;
 	//time doesn't keep track of endofday
-	date = DOS_PackDate(dos.date.year,dos.date.month,dos.date.day);
-	uint32_t ticks = mem_readd(BIOS_TIMER);
-	uint32_t seconds = (ticks*10)/182;
-	uint16_t hour = (uint16_t)(seconds/3600);
-	uint16_t min = (uint16_t)((seconds % 3600)/60);
-	uint16_t sec = (uint16_t)(seconds % 60);
-	time = DOS_PackTime(hour,min,sec);
+	date = DOS_GetBiosDatePacked();
+	time = DOS_GetBiosTimePacked();
 
 	assert(fhandle < DOS_FILES);
 	Files[fhandle]->time = time;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1021,12 +1021,18 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, uint16_t attributes) {
 
 	/* Check if file already exists */
 	if(getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) {
+		if (fileEntry.attrib & DOS_ATTR_READ_ONLY) {
+			DOS_SetError(DOSERR_ACCESS_DENIED);
+			return false;
+		}
+
 		/* Truncate file */
 		if (fileEntry.loFirstClust != 0) {
 			deleteClustChain(fileEntry.loFirstClust, 0);
 			fileEntry.loFirstClust = 0;
 		}
 		fileEntry.entrysize = 0;
+		fileEntry.attrib    = check_cast<uint8_t>(attributes);
 		fileEntry.modTime   = DOS_GetBiosTimePacked();
 		fileEntry.modDate   = DOS_GetBiosDatePacked();
 		directoryChange(dirClust, &fileEntry, subEntry);
@@ -1037,9 +1043,9 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, uint16_t attributes) {
 
 		/* Can we find the base directory? */
 		if(!getDirClustNum(name, &dirClust, true)) return false;
-		memset(&fileEntry, 0, sizeof(direntry));
+		fileEntry = {};
 		memcpy(&fileEntry.entryname, &pathName[0], 11);
-		fileEntry.attrib  = (uint8_t)(attributes & 0xff);
+		fileEntry.attrib  = check_cast<uint8_t>(attributes);
 		fileEntry.modTime = DOS_GetBiosTimePacked();
 		fileEntry.modDate = DOS_GetBiosDatePacked();
 		addDirectoryEntry(dirClust, fileEntry);
@@ -1049,12 +1055,12 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, uint16_t attributes) {
 	}
 
 	/* Empty file created, now lets open it */
-	/* TODO: check for read-only flag and requested write access */
 	auto fat_file        = new fatFile(name,
                                     fileEntry.loFirstClust,
                                     fileEntry.entrysize,
                                     this);
-	fat_file->flags      = OPEN_READWRITE;
+	bool is_readonly     = fileEntry.attrib & DOS_ATTR_READ_ONLY;
+	fat_file->flags      = is_readonly ? OPEN_READ : OPEN_READWRITE;
 	fat_file->dirCluster = dirClust;
 	fat_file->dirIndex   = subEntry;
 	fat_file->time       = fileEntry.modTime;
@@ -1078,8 +1084,18 @@ bool fatDrive::FileExists(const char *name) {
 bool fatDrive::FileOpen(DOS_File **file, char *name, uint32_t flags) {
 	direntry fileEntry;
 	uint32_t dirClust, subEntry;
-	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) return false;
-	/* TODO: check for read-only flag and requested write access */
+	if (!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) {
+		DOS_SetError(DOSERR_FILE_NOT_FOUND);
+		return false;
+	}
+
+	bool is_readonly = (readonly || (fileEntry.attrib & DOS_ATTR_READ_ONLY));
+	bool open_for_readonly = ((flags & 0xf) == OPEN_READ);
+	if (is_readonly && !open_for_readonly) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return false;
+	}
+
 	auto fat_file        = new fatFile(name,
                                     fileEntry.loFirstClust,
                                     fileEntry.entrysize,
@@ -1104,25 +1120,27 @@ bool fatDrive::FileUnlink(char * name) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
+
 	direntry fileEntry;
 	uint32_t dirClust, subEntry;
-
 	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) {
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
 		return false;
 	}
-/*
-	Technically correct, but maybe an unwanted obstruction, so inactive for now.
 
-	if(fileEntry.attrib & (DOS_ATTR_SYSTEM | DOS_ATTR_HIDDEN)) {
+	/* Not sure if this is correct. */
+#if 0
+	if (fileEntry.attrib & (DOS_ATTR_SYSTEM | DOS_ATTR_HIDDEN)) {
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
 		return false;
 	}
-	if(fileEntry.attrib & DOS_ATTR_READ_ONLY) {
+#endif
+
+	if (fileEntry.attrib & DOS_ATTR_READ_ONLY) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
-*/
+
 	fileEntry.entryname[0] = 0xe5;
 	directoryChange(dirClust, &fileEntry, subEntry);
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1036,9 +1036,8 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, uint16_t attributes) {
 	(*file)->flags=OPEN_READWRITE;
 	((fatFile *)(*file))->dirCluster = dirClust;
 	((fatFile *)(*file))->dirIndex = subEntry;
-	/* Maybe modTime and date should be used ? (crt matches findnext) */
-	((fatFile *)(*file))->time = fileEntry.crtTime;
-	((fatFile *)(*file))->date = fileEntry.crtDate;
+	((fatFile *)(*file))->time = fileEntry.modTime;
+	((fatFile *)(*file))->date = fileEntry.modDate;
 
 	dos.errorcode=save_errorcode;
 	return true;
@@ -1062,9 +1061,8 @@ bool fatDrive::FileOpen(DOS_File **file, char *name, uint32_t flags) {
 	(*file)->flags = flags;
 	((fatFile *)(*file))->dirCluster = dirClust;
 	((fatFile *)(*file))->dirIndex = subEntry;
-	/* Maybe modTime and date should be used ? (crt matches findnext) */
-	((fatFile *)(*file))->time = fileEntry.crtTime;
-	((fatFile *)(*file))->date = fileEntry.crtDate;
+	((fatFile *)(*file))->time = fileEntry.modTime;
+	((fatFile *)(*file))->date = fileEntry.modDate;
 	return true;
 }
 


### PR DESCRIPTION
* Change FAT images to use modify time instead of creation time as file time returned by DOS function 57h and used by COPY command. Using creation time here makes no sense since creation time in FAT wasn't even implemented until MS-DOS 7.0 (Windows 95 DOS mode) and most old floppies don't have it set.
* Implement setting file time in mounted FAT images. Right now, editing files does not update file time and new files have time set to epoch.
* Proper r/o file attribute handling in FAT images as well as better feedback when the image is mounted in r/o mode.