### PR TITLE
Don't block r/w file opens on r/o FAT images

### DIFF
--- a/include/drives.h
+++ b/include/drives.h
@@ -200,6 +200,7 @@ public:
 	uint32_t getFirstFreeClust(void);
 	bool directoryBrowse(uint32_t dirClustNumber, direntry *useEntry, int32_t entNum, int32_t start=0);
 	bool directoryChange(uint32_t dirClustNumber, direntry *useEntry, int32_t entNum);
+	bool isReadOnly() const { return readonly; }
 	std::shared_ptr<imageDisk> loadedDisk;
 	bool created_successfully;
 	uint32_t partSectOff;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -106,7 +106,8 @@ fatFile::fatFile(const char* /*name*/,
 }
 
 bool fatFile::Read(uint8_t * data, uint16_t *size) {
-	if ((this->flags & 0xf) == OPEN_WRITE) {	// check if file opened in write-only mode
+	// check if file opened in write-only mode
+	if ((this->flags & 0xf) == OPEN_WRITE) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
@@ -159,7 +160,8 @@ bool fatFile::Read(uint8_t * data, uint16_t *size) {
 }
 
 bool fatFile::Write(uint8_t * data, uint16_t *size) {
-	if ((this->flags & 0xf) == OPEN_READ) {	// check if file opened in read-only mode
+	// check if file opened in read-only mode
+	if ((this->flags & 0xf) == OPEN_READ || myDrive->isReadOnly()) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
@@ -288,7 +290,7 @@ bool fatFile::Seek(uint32_t *pos, uint32_t type) {
 }
 
 bool fatFile::Close() {
-	if ((flags & 0xf) != OPEN_READ) {
+	if ((flags & 0xf) != OPEN_READ && !myDrive->isReadOnly()) {
 		if (newtime) {
 			direntry tmpentry;
 			myDrive->directoryBrowse(dirCluster, &tmpentry, dirIndex);
@@ -1089,7 +1091,7 @@ bool fatDrive::FileOpen(DOS_File **file, char *name, uint32_t flags) {
 		return false;
 	}
 
-	bool is_readonly = (readonly || (fileEntry.attrib & DOS_ATTR_READ_ONLY));
+	bool is_readonly = (fileEntry.attrib & DOS_ATTR_READ_ONLY);
 	bool open_for_readonly = ((flags & 0xf) == OPEN_READ);
 	if (is_readonly && !open_for_readonly) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);


### PR DESCRIPTION
Hotfix for https://github.com/dosbox-staging/dosbox-staging/pull/2278. Turns out even installers may open source files in r/w mode for no reason. Developers developers developers developers...