### PR TITLE
Add IBM Model F function keys F13 to F24

### DIFF
--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -21,7 +21,7 @@
 #define DOSBOX_KEYBOARD_H
 
 enum KBD_KEYS {
-// clang-format off
+	// clang-format off
 	KBD_NONE,
 
 	KBD_1, KBD_2, KBD_3, KBD_4, KBD_5, KBD_6, KBD_7, KBD_8, KBD_9, KBD_0,
@@ -31,6 +31,9 @@ enum KBD_KEYS {
 
 	KBD_f1,  KBD_f2,  KBD_f3,  KBD_f4,  KBD_f5,  KBD_f6,
 	KBD_f7,  KBD_f8,  KBD_f9,  KBD_f10, KBD_f11, KBD_f12,
+
+	KBD_f13, KBD_f14, KBD_f15, KBD_f16, KBD_f17, KBD_f18,
+	KBD_f19, KBD_f20, KBD_f21, KBD_f22, KBD_f23, KBD_f24,
 
 	KBD_esc, KBD_tab, KBD_backspace, KBD_enter, KBD_space,
 
@@ -58,7 +61,7 @@ enum KBD_KEYS {
 	KBD_kpenter, KBD_kpperiod,
 
 	KBD_LAST,
-// clang-format on
+	// clang-format on
 };
 
 void KEYBOARD_ClrBuffer(void);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2075,11 +2075,34 @@ struct KeyBlock {
 	const char * entry;
 	KBD_KEYS key;
 };
-static KeyBlock combo_f[12]={
-	{"F1","f1",KBD_f1},		{"F2","f2",KBD_f2},		{"F3","f3",KBD_f3},
-	{"F4","f4",KBD_f4},		{"F5","f5",KBD_f5},		{"F6","f6",KBD_f6},
-	{"F7","f7",KBD_f7},		{"F8","f8",KBD_f8},		{"F9","f9",KBD_f9},
-	{"F10","f10",KBD_f10},	{"F11","f11",KBD_f11},	{"F12","f12",KBD_f12},
+static KeyBlock f1_to_f12[] = {
+        {"F1", "f1", KBD_f1},
+        {"F2", "f2", KBD_f2},
+        {"F3", "f3", KBD_f3},
+        {"F4", "f4", KBD_f4},
+        {"F5", "f5", KBD_f5},
+        {"F6", "f6", KBD_f6},
+        {"F7", "f7", KBD_f7},
+        {"F8", "f8", KBD_f8},
+        {"F9", "f9", KBD_f9},
+        {"F10", "f10", KBD_f10},
+        {"F11", "f11", KBD_f11},
+        {"F12", "f12", KBD_f12},
+};
+
+static KeyBlock f13_to_f24[] = {
+        {"F13", "f13", KBD_f13},
+        {"F14", "f14", KBD_f14},
+        {"F15", "f15", KBD_f15},
+        {"F16", "f16", KBD_f16},
+        {"F17", "f17", KBD_f17},
+        {"F18", "f18", KBD_f18},
+        {"F19", "f19", KBD_f19},
+        {"F20", "f20", KBD_f20},
+        {"F21", "f21", KBD_f21},
+        {"F22", "f22", KBD_f22},
+        {"F23", "f23", KBD_f23},
+        {"F24", "f24", KBD_f24},
 };
 
 static KeyBlock combo_1[14]={
@@ -2137,55 +2160,94 @@ static void CreateLayout() {
 #define DX 5
 #define PX(_X_) ((_X_)*BW + DX)
 #define PY(_Y_) (10+(_Y_)*BH)
-	AddKeyButtonEvent(PX(0),PY(0),BW,BH,"ESC","esc",KBD_esc);
-	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(0),BW,BH,combo_f[i].title,combo_f[i].entry,combo_f[i].key);
-	for (i=0;i<14;i++) AddKeyButtonEvent(PX(  i),PY(1),BW,BH,combo_1[i].title,combo_1[i].entry,combo_1[i].key);
 
-	AddKeyButtonEvent(PX(0),PY(2),BW*2,BH,"TAB","tab",KBD_tab);
-	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(2),BW,BH,combo_2[i].title,combo_2[i].entry,combo_2[i].key);
+	AddKeyButtonEvent(PX(0), PY(1), BW, BH, "ESC", "esc", KBD_esc);
 
-	AddKeyButtonEvent(PX(14),PY(2),BW*2,BH*2,"ENTER","enter",KBD_enter);
+	i = 0;
+	for (const auto& f_key : f13_to_f24) {
+		AddKeyButtonEvent(
+		        PX(2 + i++), PY(0), BW, BH, f_key.title, f_key.entry, f_key.key);
+	}
 
-	caps_lock_event=AddKeyButtonEvent(PX(0),PY(3),BW*2,BH,"CLCK","capslock",KBD_capslock);
-	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(3),BW,BH,combo_3[i].title,combo_3[i].entry,combo_3[i].key);
+	i = 0;
+	for (const auto& f_key : f1_to_f12) {
+		AddKeyButtonEvent(
+		        PX(2 + i++), PY(1), BW, BH, f_key.title, f_key.entry, f_key.key);
+	}
 
-	AddKeyButtonEvent(PX(0),PY(4),BW*2,BH,"SHIFT","lshift",KBD_leftshift);
+	for (i = 0; i < 14; i++) {
+		AddKeyButtonEvent(PX(i),
+		                  PY(3),
+		                  BW,
+		                  BH,
+		                  combo_1[i].title,
+		                  combo_1[i].entry,
+		                  combo_1[i].key);
+	}
+
+	AddKeyButtonEvent(PX(0),PY(4),BW*2,BH,"TAB","tab",KBD_tab);
+
 	for (i = 0; i < 12; i++) {
 		AddKeyButtonEvent(PX(2 + i),
 		                  PY(4),
+		                  BW,
+		                  BH,
+		                  combo_2[i].title,
+		                  combo_2[i].entry,
+		                  combo_2[i].key);
+	}
+
+	AddKeyButtonEvent(PX(14), PY(4), BW * 2, BH * 2, "ENTER", "enter", KBD_enter);
+
+	caps_lock_event = AddKeyButtonEvent(
+	        PX(0), PY(5), BW * 2, BH, "CLCK", "capslock", KBD_capslock);
+	for (i = 0; i < 12; i++) {
+		AddKeyButtonEvent(PX(2 + i),
+		                  PY(5),
+		                  BW,
+		                  BH,
+		                  combo_3[i].title,
+		                  combo_3[i].entry,
+		                  combo_3[i].key);
+	}
+
+	AddKeyButtonEvent(PX(0), PY(6), BW * 2, BH, "SHIFT", "lshift", KBD_leftshift);
+	for (i = 0; i < 12; i++) {
+		AddKeyButtonEvent(PX(2 + i),
+		                  PY(6),
 		                  BW,
 		                  BH,
 		                  combo_4[i].title,
 		                  combo_4[i].entry,
 		                  combo_4[i].key);
 	}
-	AddKeyButtonEvent(PX(14), PY(4), BW * 3, BH, "SHIFT", "rshift", KBD_rightshift);
+	AddKeyButtonEvent(PX(14), PY(6), BW * 3, BH, "SHIFT", "rshift", KBD_rightshift);
 
 	/* Bottom Row */
-	AddKeyButtonEvent(PX(0), PY(5), BW * 2, BH, MMOD1_NAME, "lctrl", KBD_leftctrl);
+	AddKeyButtonEvent(PX(0), PY(7), BW * 2, BH, MMOD1_NAME, "lctrl", KBD_leftctrl);
 
 #if !defined(MACOSX)
-	AddKeyButtonEvent(PX(2), PY(5), BW * 2, BH, MMOD3_NAME, "lgui", KBD_leftgui);
-	AddKeyButtonEvent(PX(4), PY(5), BW * 2, BH, MMOD2_NAME, "lalt", KBD_leftalt);
+	AddKeyButtonEvent(PX(2), PY(7), BW * 2, BH, MMOD3_NAME, "lgui", KBD_leftgui);
+	AddKeyButtonEvent(PX(4), PY(7), BW * 2, BH, MMOD2_NAME, "lalt", KBD_leftalt);
 #else
-	AddKeyButtonEvent(PX(2), PY(5), BW * 2, BH, MMOD2_NAME, "lalt", KBD_leftalt);
-	AddKeyButtonEvent(PX(4), PY(5), BW * 2, BH, MMOD3_NAME, "lgui", KBD_leftgui);
+	AddKeyButtonEvent(PX(2), PY(7), BW * 2, BH, MMOD2_NAME, "lalt", KBD_leftalt);
+	AddKeyButtonEvent(PX(4), PY(7), BW * 2, BH, MMOD3_NAME, "lgui", KBD_leftgui);
 #endif
 
-	AddKeyButtonEvent(PX(6), PY(5), BW * 4, BH, "SPACE", "space", KBD_space);
+	AddKeyButtonEvent(PX(6), PY(7), BW * 4, BH, "SPACE", "space", KBD_space);
 
 #if !defined(MACOSX)
-	AddKeyButtonEvent(PX(10), PY(5), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
-	AddKeyButtonEvent(PX(12), PY(5), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
-	AddKeyButtonEvent(PX(14), PY(5), BW * 2, BH, MMOD1_NAME, "rctrl", KBD_rightctrl);
+	AddKeyButtonEvent(PX(10), PY(7), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
+	AddKeyButtonEvent(PX(12), PY(7), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
+	AddKeyButtonEvent(PX(14), PY(7), BW * 2, BH, MMOD1_NAME, "rctrl", KBD_rightctrl);
 #else
-	AddKeyButtonEvent(PX(10), PY(5), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
-	AddKeyButtonEvent(PX(12), PY(5), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
+	AddKeyButtonEvent(PX(10), PY(7), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
+	AddKeyButtonEvent(PX(12), PY(7), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
 #endif
 
 	/* Arrow Keys */
 #define XO 17
-#define YO 0
+#define YO 2
 
 	AddKeyButtonEvent(PX(XO+0),PY(YO),BW,BH,"PRT","printscreen",KBD_printscreen);
 	AddKeyButtonEvent(PX(XO+1),PY(YO),BW,BH,"SCL","scrolllock",KBD_scrolllock);
@@ -2203,7 +2265,7 @@ static void CreateLayout() {
 #undef XO
 #undef YO
 #define XO 0
-#define YO 7
+#define YO 9
 	/* Numeric KeyPad */
 	num_lock_event=AddKeyButtonEvent(PX(XO),PY(YO),BW,BH,"NUM","numlock",KBD_numlock);
 	AddKeyButtonEvent(PX(XO+1),PY(YO),BW,BH,"/","kp_divide",KBD_kpdivide);
@@ -2227,7 +2289,7 @@ static void CreateLayout() {
 #undef YO
 
 #define XO 10
-#define YO 8
+#define YO 10
 	/* Joystick Buttons/Texts */
 	/* Buttons 1+2 of 1st Joystick */
 	AddJButtonButton(PX(XO),PY(YO),BW,BH,"1" ,0,0);
@@ -2423,6 +2485,19 @@ static struct {
                    {"f10", SDL_SCANCODE_F10},
                    {"f11", SDL_SCANCODE_F11},
                    {"f12", SDL_SCANCODE_F12},
+
+                   {"f13", SDL_SCANCODE_F13},
+                   {"f14", SDL_SCANCODE_F14},
+                   {"f15", SDL_SCANCODE_F15},
+                   {"f16", SDL_SCANCODE_F16},
+                   {"f17", SDL_SCANCODE_F17},
+                   {"f18", SDL_SCANCODE_F18},
+                   {"f19", SDL_SCANCODE_F19},
+                   {"f20", SDL_SCANCODE_F20},
+                   {"f21", SDL_SCANCODE_F21},
+                   {"f22", SDL_SCANCODE_F22},
+                   {"f23", SDL_SCANCODE_F23},
+                   {"f24", SDL_SCANCODE_F24},
 
                    {"1", SDL_SCANCODE_1},
                    {"2", SDL_SCANCODE_2},

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -416,7 +416,21 @@ void KEYBOARD_AddKey(KBD_KEYS keytype,bool pressed) {
 	case KBD_f11:ret=87;break;
 	case KBD_f12:ret=88;break;
 
-	//The Extended keys
+	case KBD_f13: ret = 91; break;
+	case KBD_f14: ret = 92; break;
+	case KBD_f15: ret = 93; break;
+
+	case KBD_f16: ret = 99; break;
+	case KBD_f17: ret = 100; break;
+	case KBD_f18: ret = 101; break;
+	case KBD_f19: ret = 102; break;
+	case KBD_f20: ret = 103; break;
+	case KBD_f21: ret = 104; break;
+	case KBD_f22: ret = 105; break;
+	case KBD_f23: ret = 106; break;
+	case KBD_f24: ret = 107; break;
+
+	// The Extended keys
 	case KBD_kpenter:extend=true;ret=28;break;
 	case KBD_rightctrl:extend=true;ret=29;break;
 	case KBD_kpdivide:extend=true;ret=53;break;

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -137,23 +137,28 @@ static const KeyCodes& get_key_codes_for(const uint8_t scan_code)
 		/*  88 */ { 0x8600, 0x8800, 0x8a00, 0x8c00 }, /* F12 */
 		/*  89 */ { /* placeholder */ },
 		/*  90 */ { /* placeholder */ },
-		/*  91 */ {   none,   none,   none,   none }, /* Win Left */
-		/*  92 */ {   none,   none,   none,   none }, /* Win Right */
-		/*  93 */ { /* placeholder */ }, /* Win Menu */
+		/*  91 */ { 0x6800, 0x6900, 0x6A00, 0x6b00 }, /* F13 | Win Left */
+		/*  92 */ { 0x6c00, 0x6d00, 0x6e00, 0x6f00 }, /* F14 | Win Right */
+		/*  93 */ { 0x7000, 0x7100, 0x7200, 0x7300 }, /* F15 | Win Menu */
 		/*  94 */ { /* placeholder */ },
 		/*  95 */ { /* placeholder */ },
 		/*  96 */ { /* placeholder */ },
 		/*  97 */ { /* placeholder */ },
 		/*  98 */ { /* placeholder */ },
-		/*  99 */ { /* placeholder */ }, /* F16 */
-		/* 100 */ { /* placeholder */ }, /* F17 */
-		/* 101 */ { /* placeholder */ }, /* F18 */
-		/* 102 */ { /* placeholder */ }, /* F19 */
-		/* 103 */ { /* placeholder */ }, /* F20 */
-		/* 104 */ { /* placeholder */ }, /* F21 */
-		/* 105 */ { /* placeholder */ }, /* F22 */
-		/* 106 */ { /* placeholder */ }, /* F23 */
-		/* 107 */ { /* placeholder */ }, /* F24 */
+		/*  99 */ { 0x7400, 0x7500, 0x7600, 0x7700 }, /* F16 */
+		/* 100 */ { 0x7800, 0x7900, 0x7a00, 0x7b00 }, /* F17 */
+		/* 101 */ { 0x7c00, 0x7d00, 0x7e00, 0x7f00 }, /* F18 */
+		/* 102 */ { 0x8000, 0x8100, 0x8200, 0x8300 }, /* F19 */
+		/* 103 */ { 0x8400, 0x8500, 0x8600, 0x8700 }, /* F20 */
+		/* 104 */ { 0x8800, 0x8900, 0x8a00, 0x8b00 }, /* F21 */
+		/* 105 */ { 0x8c00, 0x8d00, 0x8e00, 0x8f00 }, /* F22 */
+		/* 106 */ { 0x9000, 0x9100, 0x9200, 0x9300 }, /* F23 */
+		/* 107 */ { 0x9400, 0x9500, 0x9600, 0x9700 }, /* F24 */
+
+		// Ref: the IBM Technical Reference for the Enhanced Keyboard
+		// (Publication number S84G-7499-04), which describes the scan codes for
+		// the original IBM Enhanced Keyboard, including F13 through F24.
+
 		/* 108 */ { /* placeholder */ },
 		/* 109 */ { /* placeholder */ },
 		/* 110 */ { /* placeholder */ },


### PR DESCRIPTION
Some rare games (flight simulators?) and software could make use of these extended F-keys, so this PR lets them be mapped to modern keys.

Draft for now to testing.  Once it's confirmed the scancodes are actually correct and being recognized, I'll move it out of draft so we can carry on code-reviewing it.