### PR TITLE
Filesystem fixes

### DIFF
--- a/include/drives.h
+++ b/include/drives.h
@@ -63,7 +63,10 @@ private:
 
 class localDrive : public DOS_Drive {
 public:
-	localDrive(const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid);
+	localDrive(const char* startdir, uint16_t _bytes_sector,
+	           uint8_t _sectors_cluster, uint16_t _total_clusters,
+	           uint16_t _free_clusters, uint8_t _mediaid,
+	           bool _always_open_ro_files = false);
 	virtual bool FileOpen(DOS_File * * file,char * name,uint32_t flags);
 	virtual FILE* GetSystemFilePtr(const char* const name, const char* const type);
 	virtual bool GetSystemFilename(char* sysName, const char* const dosName);
@@ -94,6 +97,7 @@ protected:
 
 private:
 	bool IsFirstEncounter(const std::string& filename);
+	bool always_open_ro_files;
 	std::unordered_set<std::string> write_protected_files;
 	struct {
 		uint16_t bytes_sector;

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -142,11 +142,10 @@ void DOS_Drive_Cache::SetBaseDir(const char *baseDir)
 		return;
 
 	// Guard if source and destination are the same
-	if (basePath == baseDir) {
-		return;
+	if (basePath != baseDir) {
+		safe_strcpy(basePath, baseDir);
 	}
 
-	safe_strcpy(basePath, baseDir);
 	static uint16_t id = 0;
 	if (OpenDir(baseDir,id)) {
 		char* result = 0;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -154,9 +154,15 @@ bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
 		// If yes, check if the file can be opened with Read-only access:
 		fhandle = fopen_wrap(newname, "rb");
 		if (fhandle) {
+			if (!always_open_ro_files)
+				fhandle = nullptr;
 
 #ifdef DEBUG
-			open_msg = "wanted writes but opened read-only";
+			if (always_open_ro_files) {
+				open_msg = "wanted writes but opened read-only";
+			} else {
+				open_msg = "wanted writes but file is read-only";
+			}
 #else
 			// Inform the user that the file is being protected against modification.
 			// If the DOS program /really/ needs to write to the file, it will
@@ -180,7 +186,9 @@ bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
 	}
 
 #ifdef DEBUG
-	else {
+	else if (!fhandle) {
+		open_msg = "failed with desired flags";
+	} else {
 		open_msg = "succeeded with desired flags";
 	}
 	LOG_MSG("FILESYSTEM: flags=%2s, %-12s %s",
@@ -189,14 +197,15 @@ bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
 	        open_msg.c_str());
 #endif
 
-	if (fhandle) {
-		*file = new localFile(name, fhandle, basedir);
-		(*file)->flags = flags;  // for the inheritance flag and maybe check for others.
-	} else {
-		// Otherwise we really can't open the file.
+	if (!fhandle) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
+		return false;
 	}
-	return (fhandle != NULL);
+
+	*file = new localFile(name, fhandle, basedir);
+	(*file)->flags = flags;  // for the inheritance flag and maybe check for others.
+
+	return true;
 }
 
 FILE* localDrive::GetSystemFilePtr(const char* const name, const char* const type)
@@ -588,18 +597,13 @@ Bits localDrive::UnMount(void) {
 	return 0; 
 }
 
-localDrive::localDrive(const char * startdir,
-                       uint16_t _bytes_sector,
-                       uint8_t _sectors_cluster,
-                       uint16_t _total_clusters,
-                       uint16_t _free_clusters,
-                       uint8_t _mediaid)
-	: write_protected_files{},
-	  allocation{_bytes_sector,
-	             _sectors_cluster,
-	             _total_clusters,
-	             _free_clusters,
-	             _mediaid}
+localDrive::localDrive(const char* startdir, uint16_t _bytes_sector,
+                       uint8_t _sectors_cluster, uint16_t _total_clusters,
+                       uint16_t _free_clusters, uint8_t _mediaid,
+                       bool _always_open_ro_files)
+        : always_open_ro_files(_always_open_ro_files),
+          write_protected_files{},
+          allocation{_bytes_sector, _sectors_cluster, _total_clusters, _free_clusters, _mediaid}
 {
 	type = DosDriveType::Local;
 	safe_strcpy(basedir, startdir);

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -174,6 +174,10 @@ void MOUNT::Run(void) {
 		return;
 	}
 
+	const Section_prop* section = static_cast<Section_prop*>(
+	        control->GetSection("dosbox"));
+	assert(section);
+
 	std::string type="dir";
 	cmd->FindString("-t",type,true);
 	bool iscdrom = (type =="cdrom"); //Used for mscdex bug cdrom label name emulation
@@ -374,7 +378,14 @@ void MOUNT::Run(void) {
 				delete Drives[drive_index(drive)];
 				Drives[drive_index(drive)] = nullptr;
 			} else {
-				newdrive = new localDrive(temp_line.c_str(),sizes[0],int8_tize,sizes[2],sizes[3],mediaid);
+				newdrive = new localDrive(
+				        temp_line.c_str(),
+				        sizes[0],
+				        int8_tize,
+				        sizes[2],
+				        sizes[3],
+				        mediaid,
+				        section->Get_bool("allow_write_protected_files"));
 			}
 		}
 	} else {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -581,6 +581,14 @@ void DOSBOX_Init()
 	        "  quiet       |   no    |    no\n"
 	        "  auto        | 'low' if exec or dir is passed, otherwise 'high'");
 
+	Pbool = secprop->Add_bool("allow_write_protected_files", only_at_start, true);
+	Pbool->Set_help(
+	        "Many games open all their files with writable permissions; even files that they\n"
+	        "never modify. This setting lets you write-protect those files while still\n"
+	        "allowing the game to read them. A second use-case: if you're using a copy-on-write\n"
+	        "or network-based filesystem, this setting avoids triggering write-operations for\n"
+	        "these write-protected files.");
+
 	secprop = control->AddSection_prop("render", &RENDER_Init, true);
 	secprop->AddEarlyInitFunction(&RENDER_InitShaderSource, true);
 


### PR DESCRIPTION
* Fix floppy mount label not updating on rescan. Was broken by an optimization.
* Return error in local FS on file write failure. Local FS currently returns success even on complete write failure.
* Added a setting to config that allows user to allow/disallow r/w opens of write-protected files in local FS. This makes behavior added in https://github.com/dosbox-staging/dosbox-staging/pull/143 optional - while it's more user-friendly it's also inaccurate to real DOS so it should be possible to turn it off.