### PR TITLE
Increase maximum memory size to 384 MB (256 MB+128 MB)

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -136,6 +136,14 @@ int8_t clamp_to_int8(const T val)
 }
 
 template <typename T>
+uint8_t clamp_to_uint8(const T val)
+{
+	constexpr auto min_val = static_cast<T>(0);
+	constexpr auto max_val = static_cast<T>(UINT8_MAX);
+	return static_cast<uint8_t>(std::clamp(val, min_val, max_val));
+}
+
+template <typename T>
 int16_t clamp_to_int16(const T val)
 {
 	constexpr auto min_val = static_cast<T>(std::is_signed<T>{} ? INT16_MIN : 0);
@@ -144,11 +152,27 @@ int16_t clamp_to_int16(const T val)
 }
 
 template <typename T>
+uint16_t clamp_to_uint16(const T val)
+{
+	constexpr auto min_val = static_cast<T>(0);
+	constexpr auto max_val = static_cast<T>(UINT16_MAX);
+	return static_cast<uint16_t>(std::clamp(val, min_val, max_val));
+}
+
+template <typename T>
 int32_t clamp_to_int32(const T val)
 {
 	constexpr auto min_val = static_cast<T>(std::is_signed<T>{} ? INT32_MIN : 0);
 	constexpr auto max_val = static_cast<T>(INT32_MAX);
 	return static_cast<int32_t>(std::clamp(val, min_val, max_val));
+}
+
+template <typename T>
+uint32_t clamp_to_uint32(const T val)
+{
+	constexpr auto min_val = static_cast<T>(0);
+	constexpr auto max_val = static_cast<T>(UINT32_MAX);
+	return static_cast<uint32_t>(std::clamp(val, min_val, max_val));
 }
 
 inline float decibel_to_gain(const float decibel)

--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -41,7 +41,7 @@ template <class T> T clamp(const T& n, const T& lower, const T& upper) {
 
   All credit to Charles Bailey, https://stackoverflow.com/a/707426
 */
-constexpr int wrap(int val, int const lower_bound, int const upper_bound)
+constexpr int wrap(int val, const int lower_bound, const int upper_bound)
 {
 	const auto range_size = upper_bound - lower_bound + 1;
 	if (val < lower_bound)
@@ -128,48 +128,78 @@ constexpr T1 left_shift_signed(T1 value, T2 amount)
 }
 
 template <typename T>
-int8_t clamp_to_int8(const T val)
+constexpr int8_t clamp_to_int8(const T val)
 {
-	constexpr auto min_val = static_cast<T>(std::is_signed<T>{} ? INT8_MIN : 0);
+	static_assert(!std::is_same_v<T, int8_t>,
+	              "clamping unnecessary: val is already an int8_t");
+
+	constexpr auto min_val = static_cast<T>(std::is_signed_v<T> ? INT8_MIN : 0);
 	constexpr auto max_val = static_cast<T>(INT8_MAX);
 	return static_cast<int8_t>(std::clamp(val, min_val, max_val));
 }
 
 template <typename T>
-uint8_t clamp_to_uint8(const T val)
+constexpr uint8_t clamp_to_uint8(const T val)
 {
+	static_assert(!std::is_same_v<T, uint8_t>,
+	              "clamping unnecessary: val is already an uint8_t");
+
 	constexpr auto min_val = static_cast<T>(0);
 	constexpr auto max_val = static_cast<T>(UINT8_MAX);
 	return static_cast<uint8_t>(std::clamp(val, min_val, max_val));
 }
 
 template <typename T>
-int16_t clamp_to_int16(const T val)
+constexpr int16_t clamp_to_int16(const T val)
 {
-	constexpr auto min_val = static_cast<T>(std::is_signed<T>{} ? INT16_MIN : 0);
+	static_assert(!std::is_same_v<T, int16_t>,
+	              "clamping unnecessary: val is already an int16_t");
+
+	static_assert(sizeof(T) >= sizeof(int16_t),
+	              "clamping unnecessary: val type fits within int16_t");
+
+	constexpr auto min_val = static_cast<T>(std::is_signed_v<T> ? INT16_MIN : 0);
 	constexpr auto max_val = static_cast<T>(INT16_MAX);
 	return static_cast<int16_t>(std::clamp(val, min_val, max_val));
 }
 
 template <typename T>
-uint16_t clamp_to_uint16(const T val)
+constexpr uint16_t clamp_to_uint16(const T val)
 {
+	static_assert(!std::is_same_v<T, uint16_t>,
+	              "clamping unnecessary: val is already an uint16_t");
+
+	static_assert(std::is_signed_v<T> || sizeof(T) > sizeof(uint16_t),
+	              "clamping unnecessary: val type fits within uint16_t");
+
 	constexpr auto min_val = static_cast<T>(0);
 	constexpr auto max_val = static_cast<T>(UINT16_MAX);
 	return static_cast<uint16_t>(std::clamp(val, min_val, max_val));
 }
 
 template <typename T>
-int32_t clamp_to_int32(const T val)
+constexpr int32_t clamp_to_int32(const T val)
 {
-	constexpr auto min_val = static_cast<T>(std::is_signed<T>{} ? INT32_MIN : 0);
+	static_assert(!std::is_same_v<T, int32_t>,
+	              "clamping unnecessary: val is already an int32_t");
+
+	static_assert(sizeof(T) >= sizeof(int32_t),
+	              "clamping unnecessary: val type fits within int32_t");
+
+	constexpr auto min_val = static_cast<T>(std::is_signed_v<T> ? INT32_MIN : 0);
 	constexpr auto max_val = static_cast<T>(INT32_MAX);
 	return static_cast<int32_t>(std::clamp(val, min_val, max_val));
 }
 
 template <typename T>
-uint32_t clamp_to_uint32(const T val)
+constexpr uint32_t clamp_to_uint32(const T val)
 {
+	static_assert(!std::is_same_v<T, uint32_t>,
+	              "clamping unnecessary: val is already an uint32_t");
+
+	static_assert(std::is_signed_v<T> || sizeof(T) > sizeof(uint32_t),
+	              "clamping unnecessary: val type fits within uint32_t");
+
 	constexpr auto min_val = static_cast<T>(0);
 	constexpr auto max_val = static_cast<T>(UINT32_MAX);
 	return static_cast<uint32_t>(std::clamp(val, min_val, max_val));

--- a/include/mem.h
+++ b/include/mem.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2019-2022  The DOSBox Staging Team
+ *  Copyright (C) 2019-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -41,10 +41,10 @@ void MEM_A20_Enable(bool enable);
 
 /* Memory management / EMS mapping */
 HostPt MEM_GetBlockPage();
-Bitu MEM_FreeTotal();                      // Free 4 KiB pages
-Bitu MEM_FreeLargest();                    // Largest free 4 KiB pages block
-Bitu MEM_TotalPages();                     // Total amount of 4 KiB pages
-Bitu MEM_AllocatedPages(MemHandle handle); // amount of allocated pages of handle
+Bitu MEM_FreeTotal();                          // free 4 KiB pages
+Bitu MEM_FreeLargest();                        // largest free 4 KiB pages block
+uint32_t MEM_TotalPages();                     // total amount of 4 KiB pages
+uint32_t MEM_AllocatedPages(MemHandle handle); // amount of allocated pages of handle
 MemHandle MEM_AllocatePages(Bitu pages, bool sequence);
 MemHandle MEM_GetNextFreePage();
 PhysPt MEM_AllocatePage();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -467,7 +467,7 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&MEM_Init);//done
 	secprop->AddInitFunction(&HARDWARE_Init);//done
 	pint = secprop->Add_int("memsize", when_idle, 16);
-	pint->SetMinMax(1, 63);
+	pint->SetMinMax(1, 384);
 	pint->Set_help(
 	        "Amount of memory of the emulated machine has in MB (16 by default).\n"
 	        "Best leave at the default setting to avoid problems with some games,\n"

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -220,8 +220,9 @@ void MEM_StrCopy(PhysPt pt,char * data,Bitu size) {
 	*data=0;
 }
 
-Bitu MEM_TotalPages(void) {
-	return memory.pages.size();
+uint32_t MEM_TotalPages(void)
+{
+	return check_cast<uint32_t>(memory.pages.size());
 }
 
 Bitu MEM_FreeLargest(void) {
@@ -250,12 +251,13 @@ Bitu MEM_FreeTotal(void) {
 	return free;
 }
 
-Bitu MEM_AllocatedPages(MemHandle handle) 
+uint32_t MEM_AllocatedPages(MemHandle handle) 
 {
-	Bitu pages = 0;
-	while (handle>0) {
-		pages++;
-		handle=memory.mhandles[handle];
+	uint32_t pages = 0;
+	while (handle > 0) {
+		++pages;
+		assert(pages != 0);
+		handle = memory.mhandles[handle];
 	}
 	return pages;
 }

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -29,7 +30,7 @@
 
 #define PAGES_IN_BLOCK	((1024*1024)/MEM_PAGE_SIZE)
 #define SAFE_MEMORY	32
-#define MAX_MEMORY	64
+#define MAX_MEMORY	385
 #define MAX_PAGE_ENTRIES (MAX_MEMORY*1024*1024/4096)
 #define LFB_PAGES	512
 #define MAX_LINKS	((MAX_MEMORY*1024/4)+4096)		//Hopefully enough

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1131,7 +1131,7 @@ static Bitu INT15_Handler(void) {
 			reg_eax = 0; // extended memory between 1MB and 16MB, in 1KB blocks
 			reg_ebx = 0; // extended memory above 16MB, in 64KB blocks
 			{
-				const auto mem_in_kb = MEM_TotalPages() * 4;
+				const auto mem_in_kb = static_cast<int64_t>(MEM_TotalPages() * 4);
 				if (mem_in_kb > 1024) {
 					reg_eax = std::min(static_cast<uint32_t>(mem_in_kb - 1024),
 					                   static_cast<uint32_t>(15 * 1024));

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1131,13 +1131,13 @@ static Bitu INT15_Handler(void) {
 			reg_eax = 0; // extended memory between 1MB and 16MB, in 1KB blocks
 			reg_ebx = 0; // extended memory above 16MB, in 64KB blocks
 			{
-				const auto mem_in_kb = static_cast<int64_t>(MEM_TotalPages() * 4);
+				const auto mem_in_kb = MEM_TotalPages() * 4;
 				if (mem_in_kb > 1024) {
 					reg_eax = std::min(static_cast<uint32_t>(mem_in_kb - 1024),
 					                   static_cast<uint32_t>(15 * 1024));
 				}
 				if (mem_in_kb > 16 * 1024) {
-					reg_ebx = clamp_to_uint32((mem_in_kb - 16 * 1024) / 64);
+					reg_ebx = check_cast<uint32_t>((mem_in_kb - 16 * 1024) / 64);
 				}
 			}
 			reg_ecx = reg_eax; // configured memory between 1MB and 16MB, in 1KB blocks

--- a/tests/math_utils_tests.cpp
+++ b/tests/math_utils_tests.cpp
@@ -177,8 +177,8 @@ TEST(clamp_to_int16, signed_negatives)
 TEST(clamp_to_int32, signed_negatives)
 {
 	EXPECT_EQ(clamp_to_int32(INT64_MIN), INT32_MIN);
-	EXPECT_EQ(clamp_to_int32(INT32_MIN - 0), INT32_MIN);
-	EXPECT_EQ(clamp_to_int32(INT32_MIN + 1), INT32_MIN + 1);
+	EXPECT_EQ(clamp_to_int32(static_cast<int64_t>(INT32_MIN - 0)), INT32_MIN);
+	EXPECT_EQ(clamp_to_int32(static_cast<int64_t>(INT32_MIN + 1)), INT32_MIN + 1);
 }
 
 TEST(clamp_to_int8, signed_positives)
@@ -198,8 +198,8 @@ TEST(clamp_to_int16, signed_positives)
 TEST(clamp_to_int32, signed_positives)
 {
 	EXPECT_EQ(clamp_to_int32(INT64_MAX), INT32_MAX);
-	EXPECT_EQ(clamp_to_int32(INT32_MAX - 0), INT32_MAX);
-	EXPECT_EQ(clamp_to_int32(INT64_MAX - 1), INT32_MAX);
+	EXPECT_EQ(clamp_to_int32(INT64_MAX - static_cast<int64_t>(0)), INT32_MAX);
+	EXPECT_EQ(clamp_to_int32(INT64_MAX - static_cast<int64_t>(1)), INT32_MAX);
 }
 
 TEST(clamp_to_int8, signed_literals)
@@ -229,14 +229,15 @@ TEST(clamp_to_int16, signed_literals)
 TEST(clamp_to_int32, signed_literals)
 {
 	EXPECT_EQ(clamp_to_int32(-10'000'000'000), INT32_MIN);
-	EXPECT_EQ(clamp_to_int32(-1'000'000'000), -1'000'000'000);
-	EXPECT_EQ(clamp_to_int32(-1'000'000), -1'000'000);
-	EXPECT_EQ(clamp_to_int32(-100), -100);
-	EXPECT_EQ(clamp_to_int32(0), 0);
-	EXPECT_EQ(clamp_to_int32(100), 100);
-	EXPECT_EQ(clamp_to_int32(1'000'000), 1'000'000);
-	EXPECT_EQ(clamp_to_int32(1'000'000'000), 1'000'000'000);
-	EXPECT_EQ(clamp_to_int32(10'000'000'000), INT32_MAX);
+	EXPECT_EQ(clamp_to_int32(static_cast<int64_t>(-1'000'000'000)),
+	          -1'000'000'000);
+	EXPECT_EQ(clamp_to_int32(static_cast<int64_t>(-1'000'000)), -1'000'000);
+	EXPECT_EQ(clamp_to_int32(static_cast<int64_t>(-100)), -100);
+	EXPECT_EQ(clamp_to_int32(0u), 0);
+	EXPECT_EQ(clamp_to_int32(100u), 100);
+	EXPECT_EQ(clamp_to_int32(1'000'000u), 1'000'000);
+	EXPECT_EQ(clamp_to_int32(1'000'000'000u), 1'000'000'000);
+	EXPECT_EQ(clamp_to_int32(10'000'000'000u), INT32_MAX);
 }
 
 #ifndef UINT8_MIN


### PR DESCRIPTION
Increased allowed memory size. Required some BIOS extensions to be implemented - they are documented in Ralf Braun Interrupt List:

- INT 15, AX=E801 - http://www.ctyme.com/intr/rb-1739.htm
- INT 15, AX=E881 - http://www.ctyme.com/intr/rb-1742.htm
- INT 15, AX=E820 - http://www.ctyme.com/intr/rb-1741.htm

Tested with Windows 95. The E820 routine (memory map) was taken from DOSBox-X (with cleanups by me), which inherited it from DOSBox Daum.

Maximum memory size can probably be increased even further, but starting from around 480 MB Windows 95 starts causing problems (see https://en.wikipedia.org/wiki/Windows_95#System_requirements), and 384 MB is already a lot.