### PR TITLE
Import select FPU improvements (non-MMX/SSE) from DOSBox-X 

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -41,11 +41,17 @@
 
 
 #define CPU_ARCHTYPE_MIXED			0xff
+#define CPU_ARCHTYPE_8086           0x05
 #define CPU_ARCHTYPE_386SLOW		0x30
 #define CPU_ARCHTYPE_386FAST		0x35
 #define CPU_ARCHTYPE_486OLDSLOW		0x40
 #define CPU_ARCHTYPE_486NEWSLOW		0x45
 #define CPU_ARCHTYPE_PENTIUMSLOW	0x50
+
+#define FPU_ARCHTYPE_8087                       0x07
+#define FPU_ARCHTYPE_287                        0x27
+#define FPU_ARCHTYPE_387                        0x37
+#define FPU_ARCHTYPE_BEST                       0xfe
 
 /* CPU Cycle Timing */
 extern int32_t CPU_Cycles;
@@ -60,6 +66,7 @@ extern bool CPU_SkipCycleAutoAdjust;
 extern Bitu CPU_AutoDetermineMode;
 
 extern Bitu CPU_ArchitectureType;
+extern uint8_t FPU_ArchitectureType;
 
 extern Bitu CPU_PrefetchQueueSize;
 

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -262,24 +262,29 @@ static inline void FPU_SetSW(const uint16_t word)
 void FPU_SetPRegsFrom(const uint8_t dyn_regs[8][10]);
 void FPU_GetPRegsTo(uint8_t dyn_regs[8][10]);
 
-static inline void FPU_SET_C0(Bitu C){
-	fpu.sw.C0 = !!C;
+static inline void FPU_SET_C0(const uint16_t value)
+{
+	fpu.sw.C0 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_C1(Bitu C){
-	fpu.sw.C1 = !!C;
+static inline void FPU_SET_C1(const uint16_t value)
+{
+	fpu.sw.C1 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_C2(Bitu C){
-	fpu.sw.C2 = !!C;
+static inline void FPU_SET_C2(const uint16_t value)
+{
+	fpu.sw.C2 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_C3(Bitu C){
-	fpu.sw.C3 = !!C;
+static inline void FPU_SET_C3(const uint16_t value)
+{
+	fpu.sw.C3 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_D(Bitu C){
-	fpu.sw.DE = !!C;
+static inline void FPU_SET_D(const uint16_t value)
+{
+	fpu.sw.DE = (value > 0) ? 0b1 : 0b0;
 }
 
 static inline void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr_t sub)

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -283,6 +283,12 @@ static inline uint16_t FPU_GetSW()
 	return fpu.sw;
 }
 
+static inline void FPU_SetMaskedSW(const uint16_t word, 
+                                   const uint16_t mask = FPUStatusWord::conditionAndExceptionMask)
+{
+	fpu.sw = (word & mask) | (fpu.sw & FPUStatusWord::conditionUnmask);
+}
+
 static inline void FPU_SetSW(const uint16_t word)
 {
 	fpu.sw = word;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -275,7 +275,6 @@ static void maybe_sync_host_fpu_to_dh()
 static BlockReturn sync_normal_fpu_and_run_dyn_code(const uint8_t* code) noexcept
 {
 	if (last_core == CoreType::Normal) {
-		FPU_SET_TOP(TOP);
 		dyn_dh_fpu.state.tag = FPU_GetTag();
 		dyn_dh_fpu.state.cw  = FPU_GetCW();
 		dyn_dh_fpu.state.sw  = FPU_GetSW();
@@ -292,7 +291,6 @@ static Bits sync_dh_fpu_and_run_normal_core() noexcept
 		FPU_SetTag(static_cast<uint16_t>(dyn_dh_fpu.state.tag & 0xffff));
 		FPU_SetCW(static_cast<uint16_t>(dyn_dh_fpu.state.cw & 0xffff));
 		FPU_SetSW(static_cast<uint16_t>(dyn_dh_fpu.state.sw & 0xffff));
-		TOP = FPU_GET_TOP();
 		FPU_SetPRegsFrom(dyn_dh_fpu.state.st_reg);
 		last_core = CoreType::Normal;
 	}

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -306,13 +306,13 @@ static void dyn_fpu_esc1()
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04: /* FLDENV */
-			gen_call_function((void*)&FPU_FLDENV,"%Drd",DREG(EA));
+			gen_call_function((void*)&FPU_FLDENV,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x05: /* FLDCW */
 			gen_call_function((void *)&FPU_FLDCW,"%Drd",DREG(EA));
 			break;
 		case 0x06: /* FSTENV */
-			gen_call_function((void *)&FPU_FSTENV,"%Drd",DREG(EA));
+			gen_call_function((void *)&FPU_FSTENV,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x07:  /* FNSTCW*/
 			gen_call_function((void *)&FPU_FNSTCW,"%Drd",DREG(EA));
@@ -522,15 +522,13 @@ static void dyn_fpu_esc5()
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04:	/* FRSTOR */
-			gen_call_function((void*)&FPU_FRSTOR,"%Drd",DREG(EA));
+			gen_call_function((void*)&FPU_FRSTOR,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x06:	/* FSAVE */
-			gen_call_function((void*)&FPU_FSAVE,"%Drd",DREG(EA));
+			gen_call_function((void*)&FPU_FSAVE,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x07:   /*FNSTSW */
 			gen_protectflags(); 
-			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_SET_TOP,"%Dd",DREG(TMPB));
 			gen_load_host(&fpu.sw,DREG(TMPB),4); 
 			gen_call_function((void*)&mem_writew,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
@@ -618,8 +616,6 @@ static void dyn_fpu_esc7()
 		case 0x04:
 			switch(sub){
 				case 0x00:     /* FNSTSW AX*/
-					gen_load_host(&TOP,DREG(TMPB),4);
-					gen_call_function((void*)&FPU_SET_TOP,"%Drd",DREG(TMPB)); 
 					gen_mov_host(&fpu.sw,DREG(EAX),2);
 					break;
 				default:

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -310,7 +310,7 @@ static void dyn_fpu_esc1(){
 			break;
 		case 0x04: /* FLDENV */
 			dyn_fill_ea(FC_ADDR);
-			gen_call_function_R((void*)&FPU_FLDENV,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FLDENV, FC_ADDR, !decode.big_op);
 			break;
 		case 0x05: /* FLDCW */
 			dyn_fill_ea(FC_ADDR);
@@ -318,7 +318,7 @@ static void dyn_fpu_esc1(){
 			break;
 		case 0x06: /* FSTENV */
 			dyn_fill_ea(FC_ADDR);
-			gen_call_function_R((void *)&FPU_FSTENV,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FSTENV, FC_ADDR, !decode.big_op);
 			break;
 		case 0x07:  /* FNSTCW*/
 			dyn_fill_ea(FC_ADDR);
@@ -533,15 +533,13 @@ static void dyn_fpu_esc5(){
 			break;
 		case 0x04:	/* FRSTOR */
 			dyn_fill_ea(FC_ADDR); 
-			gen_call_function_R((void*)&FPU_FRSTOR,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FRSTOR, FC_ADDR, !decode.big_op);
 			break;
 		case 0x06:	/* FSAVE */
 			dyn_fill_ea(FC_ADDR); 
-			gen_call_function_R((void*)&FPU_FSAVE,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FSAVE, FC_ADDR, !decode.big_op);
 			break;
 		case 0x07:   /*FNSTSW */
-			gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
-			gen_call_function_R((void*)&FPU_SET_TOP,FC_OP1);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&fpu.sw),false);
 			gen_call_function_RR((void*)&mem_writew,FC_OP1,FC_OP2);
@@ -632,8 +630,6 @@ static void dyn_fpu_esc7(){
 		case 0x04:
 			switch(decode.modrm.rm){
 				case 0x00:     /* FNSTSW AX*/
-					gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
-					gen_call_function_R((void*)&FPU_SET_TOP,FC_OP1); 
 					gen_mov_word_to_reg(FC_OP1,(void*)(&fpu.sw),false);
 					MOV_REG_WORD16_FROM_HOST_REG(FC_OP1,DRC_REG_EAX);
 					break;

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -627,11 +627,11 @@ switch (inst.code.op) {
 #if C_FPU
 		switch (((inst.rm>=0xc0) << 3) | inst.code.save) {
 		case 0x00:	FPU_ESC0_EA(inst.rm,inst.rm_eaa);break;
-		case 0x01:	FPU_ESC1_EA(inst.rm,inst.rm_eaa);break;
+		case 0x01:	FPU_ESC1_EA(inst.rm,inst.rm_eaa,inst.code.extra);break;
 		case 0x02:	FPU_ESC2_EA(inst.rm,inst.rm_eaa);break;
 		case 0x03:	FPU_ESC3_EA(inst.rm,inst.rm_eaa);break;
 		case 0x04:	FPU_ESC4_EA(inst.rm,inst.rm_eaa);break;
-		case 0x05:	FPU_ESC5_EA(inst.rm,inst.rm_eaa);break;
+		case 0x05:	FPU_ESC5_EA(inst.rm,inst.rm_eaa,inst.code.extra);break;
 		case 0x06:	FPU_ESC6_EA(inst.rm,inst.rm_eaa);break;
 		case 0x07:	FPU_ESC7_EA(inst.rm,inst.rm_eaa);break;
 

--- a/src/cpu/core_full/optable.h
+++ b/src/cpu/core_full/optable.h
@@ -174,10 +174,10 @@ static OpCode OpCodeTable[1024]={
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 //TODO FPU
 /* 0xd8 - 0xdf */
-{L_MODRM	,O_FPU		,0		,0		},{L_MODRM	,O_FPU		,1		,0		},
-{L_MODRM	,O_FPU		,2		,0		},{L_MODRM	,O_FPU		,3		,0		},
-{L_MODRM	,O_FPU		,4		,0		},{L_MODRM	,O_FPU		,5		,0		},
-{L_MODRM	,O_FPU		,6		,0		},{L_MODRM	,O_FPU		,7		,0		},
+{L_MODRM	,O_FPU		,0		,true   },{L_MODRM	,O_FPU		,1		,true   },
+{L_MODRM	,O_FPU		,2		,true   },{L_MODRM	,O_FPU		,3		,true   },
+{L_MODRM	,O_FPU		,4		,true   },{L_MODRM	,O_FPU		,5		,true   },
+{L_MODRM	,O_FPU		,6		,true   },{L_MODRM	,O_FPU		,7		,true   },
 
 /* 0xe0 - 0xe7 */
 {L_Ibx		,O_LOOPNZ	,S_AIPw	,0		},{L_Ibx	,O_LOOPZ	,S_AIPw	,0		},
@@ -529,10 +529,10 @@ static OpCode OpCodeTable[1024]={
 {L_Ib		,O_AAM		,0		,0		},{L_Ib		,O_AAD		,0		,0		},
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 /* 0x2d8 - 0x2df */
-{L_MODRM	,O_FPU		,0		,0		},{L_MODRM	,O_FPU		,1		,0		},
-{L_MODRM	,O_FPU		,2		,0		},{L_MODRM	,O_FPU		,3		,0		},
-{L_MODRM	,O_FPU		,4		,0		},{L_MODRM	,O_FPU		,5		,0		},
-{L_MODRM	,O_FPU		,6		,0		},{L_MODRM	,O_FPU		,7		,0		},
+{L_MODRM	,O_FPU		,0		,false  },{L_MODRM	,O_FPU		,1		,false  },
+{L_MODRM	,O_FPU		,2		,false  },{L_MODRM	,O_FPU		,3		,false  },
+{L_MODRM	,O_FPU		,4		,false  },{L_MODRM	,O_FPU		,5		,false  },
+{L_MODRM	,O_FPU		,6		,false  },{L_MODRM	,O_FPU		,7		,false  },
 
 /* 0x2e0 - 0x2e7 */
 {L_Ibx		,O_LOOPNZ	,S_AIPd	,0		},{L_Ibx	,O_LOOPZ	,S_AIPd	,0		},

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -141,6 +141,15 @@
 	}																		\
 }
 
+#define FPU_ESC_SIZE(code, op16) {														\
+	uint8_t rm=Fetchb();														\
+	if (rm >= 0xc0) {															\
+		FPU_ESC ## code ## _Normal(rm);										\
+	} else {																\
+		GetEAa;FPU_ESC ## code ## _EA(rm,eaa,op16);								\
+	}																		\
+}
+
 #define CASE_W(_WHICH)							\
 	case (OPCODE_NONE+_WHICH):
 

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -583,17 +583,19 @@
 	CASE_0F_B(0xc0)												/* XADD Gb,Eb */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrb;uint8_t oldrmrb=*rmrb;
-			if (rm >= 0xc0 ) {GetEArb;*rmrb=*earb;*earb+=oldrmrb;}
-			else {GetEAa;*rmrb=LoadMb(eaa);SaveMb(eaa,LoadMb(eaa)+oldrmrb);}
+			GetRMrb;auto oldrmrb=lf_var2b=*rmrb;
+			if (rm >= 0xc0 ) {GetEArb;lf_var1b=*rmrb=*earb;*earb+=oldrmrb;lf_resb=*earb;}
+			else {GetEAa;lf_var1b=*rmrb=LoadMb(eaa);SaveMb(eaa,lf_resb=*rmrb+oldrmrb);}
+			lflags.type=t_ADDb;
 			break;
 		}
 	CASE_0F_W(0xc1)												/* XADD Gw,Ew */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrw;uint16_t oldrmrw=*rmrw;
-			if (rm >= 0xc0 ) {GetEArw;*rmrw=*earw;*earw+=oldrmrw;}
-			else {GetEAa;*rmrw=LoadMw(eaa);SaveMw(eaa,LoadMw(eaa)+oldrmrw);}
+			GetRMrw;auto oldrmrw=lf_var2w=*rmrw;
+			if (rm >= 0xc0 ) {GetEArw;lf_var1w=*rmrw=*earw;*earw+=oldrmrw;lf_resw=*earw;}
+			else {GetEAa;lf_var1w=*rmrw=LoadMw(eaa);SaveMw(eaa,lf_resw=*rmrw+oldrmrw);}
+			lflags.type=t_ADDw;
 			break;
 		}
 	CASE_0F_W(0xc8)												/* BSWAP AX */

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -436,9 +436,10 @@
 	CASE_0F_D(0xc1)												/* XADD Gd,Ed */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrd;uint32_t oldrmrd=*rmrd;
-			if (rm >= 0xc0 ) {GetEArd;*rmrd=*eard;*eard+=oldrmrd;}
-			else {GetEAa;*rmrd=LoadMd(eaa);SaveMd(eaa,LoadMd(eaa)+oldrmrd);}
+			GetRMrd;auto oldrmrd=lf_var2d=*rmrd;
+			if (rm >= 0xc0 ) {GetEArd;lf_var1d=*rmrd=*eard;*eard+=oldrmrd;lf_resd=*eard;}
+			else {GetEAa;lf_var1d=*rmrd=LoadMd(eaa);SaveMd(eaa,lf_resd=*rmrd+oldrmrd);}
+			lflags.type=t_ADDd;
 			break;
 		}
 	CASE_0F_D(0xc8)												/* BSWAP EAX */

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -818,7 +818,7 @@
 	CASE_B(0xd8)												/* FPU ESC 0 */
 		 FPU_ESC(0);break;
 	CASE_B(0xd9)												/* FPU ESC 1 */
-		 FPU_ESC(1);break;
+		 FPU_ESC_SIZE(1, !(core.opcode_index&OPCODE_SIZE));break;
 	CASE_B(0xda)												/* FPU ESC 2 */
 		 FPU_ESC(2);break;
 	CASE_B(0xdb)												/* FPU ESC 3 */
@@ -826,7 +826,7 @@
 	CASE_B(0xdc)												/* FPU ESC 4 */
 		 FPU_ESC(4);break;
 	CASE_B(0xdd)												/* FPU ESC 5 */
-		 FPU_ESC(5);break;
+		 FPU_ESC_SIZE(5, !(core.opcode_index&OPCODE_SIZE));break;
 	CASE_B(0xde)												/* FPU ESC 6 */
 		 FPU_ESC(6);break;
 	CASE_B(0xdf)												/* FPU ESC 7 */

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -415,6 +415,12 @@ void FPU_ESC3_Normal(Bitu rm) {
 			E_Exit("ESC 3: ILLEGAL OPCODE group %u subfunction %u", group, sub);
 		}
 		break;
+	case 0x05:              /* FUCOMI STi */
+			FPU_FUCOMI(TOP,STV(sub));
+			break;
+	case 0x06:              /* FCOMI STi */
+			FPU_FCOMI(TOP,STV(sub));
+			break;
 	default:
 		FPU_LOG_WARN(3, false, group, sub);
 		break;
@@ -640,6 +646,14 @@ void FPU_ESC7_Normal(Bitu rm) {
 				break;
 		}
 		break;
+	case 0x05:              /* FUCOMIP STi */
+			FPU_FUCOMI(TOP,STV(sub));
+			FPU_FPOP();
+			break;
+	case 0x06:              /* FCOMIP STi */
+			FPU_FCOMI(TOP,STV(sub));
+			FPU_FPOP();
+			break;
 	default:
 		FPU_LOG_WARN(7,false,group,sub);
 		break;

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -336,6 +336,26 @@ void FPU_ESC2_Normal(Bitu rm) {
 	Bitu group=(rm >> 3) & 7;
 	Bitu sub=(rm & 7);
 	switch(group){
+	case 0x00: /* FCMOVB STi */
+		if (TFLG_B) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x01: /* FCMOVE STi */
+		if (TFLG_Z) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x02: /* FCMOVBE STi */
+		if (TFLG_BE) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x03: /* FCMOVU STi */
+		if (TFLG_P) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
 	case 0x05:
 		switch(sub){
 		case 0x01:		/* FUCOMPP */
@@ -391,6 +411,26 @@ void FPU_ESC3_Normal(Bitu rm) {
 	const auto group = static_cast<unsigned>((rm >> 3) & 7);
 	const auto sub = static_cast<unsigned>(rm & 7);
 	switch (group) {
+	case 0x00: /* FCMOVNB STi */
+		if (TFLG_NB) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x01: /* FCMOVNE STi */
+		if (TFLG_NZ) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x02: /* FCMOVNBE STi */
+		if (TFLG_NBE) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x03: /* FCMOVNU STi */
+		if (TFLG_NP) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
 	case 0x04:
 		switch (sub) {
 		case 0x00:				//FNENI

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -20,10 +20,11 @@
 #include "fpu.h"
 #endif
 
+static void FPU_FINIT()
+{
+	fpu.cw = {};
+	fpu.sw = {};
 
-static void FPU_FINIT(void) {
-	fpu.cw.init();
-	fpu.sw.init();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -408,6 +408,10 @@ static void FPU_FST(Bitu st, Bitu other){
 	fpu.regs[other] = fpu.regs[st];
 }
 
+static inline void FPU_FCMOV(Bitu st, Bitu other) {
+        fpu.tags[st] = fpu.tags[other];
+        fpu.regs[st] = fpu.regs[other];
+}
 
 static void FPU_FCOM(Bitu st, Bitu other){
 	if (((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) ||

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -22,9 +22,8 @@
 
 
 static void FPU_FINIT(void) {
-	FPU_SetCW(0x37F);
-	fpu.sw = 0;
-	TOP=FPU_GET_TOP();
+	fpu.cw.init();
+	fpu.sw.init();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;
@@ -37,7 +36,7 @@ static void FPU_FINIT(void) {
 }
 
 static void FPU_FCLEX(void){
-	fpu.sw &= 0x7f00;			//should clear exceptions
+	fpu.sw.clearExceptions();
 }
 
 static void FPU_FNOP(void){
@@ -100,19 +99,19 @@ static void FPU_FPOP(void){
 }
 
 static double FROUND(double in){
-	switch(fpu.round){
-	case ROUND_Nearest:	
+	switch (fpu.cw.RC){
+	case fpu::RoundMode::Nearest:
 		if (in-floor(in)>0.5) return (floor(in)+1);
 		else if (in-floor(in)<0.5) return (floor(in));
 		else return (((static_cast<int64_t>(floor(in)))&1)!=0)?(floor(in)+1):(floor(in));
 		break;
-	case ROUND_Down:
+	case fpu::RoundMode::Down:
 		return (floor(in));
 		break;
-	case ROUND_Up:
+	case fpu::RoundMode::Up:
 		return (ceil(in));
 		break;
-	case ROUND_Chop:
+	case fpu::RoundMode::Chop:
 		return in; //the cast afterwards will do it right maybe cast here
 		break;
 	default:
@@ -518,9 +517,8 @@ static void FPU_FSCALE(void){
 	return; //2^x where x is chopped.
 }
 
-static void FPU_FSTENV(PhysPt addr){
-	FPU_SET_TOP(TOP);
-	if(!cpu.code.big) {
+static void FPU_FSTENV(PhysPt addr, bool op16){
+	if (op16) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
 		mem_writew(addr+4,static_cast<uint16_t>(FPU_GetTag()));
@@ -531,28 +529,23 @@ static void FPU_FSTENV(PhysPt addr){
 	}
 }
 
-static void FPU_FLDENV(PhysPt addr){
+static void FPU_FLDENV(PhysPt addr, bool op16){
 	uint16_t tag;
-	uint32_t tagbig;
-	Bitu cw;
-	if(!cpu.code.big) {
-		cw     = mem_readw(addr+0);
+	if (op16) {
+		fpu.cw = mem_readw(addr+0);
 		fpu.sw = mem_readw(addr+2);
 		tag    = mem_readw(addr+4);
 	} else { 
-		cw     = mem_readd(addr+0);
-		fpu.sw = (uint16_t)mem_readd(addr+4);
-		tagbig = mem_readd(addr+8);
-		tag    = static_cast<uint16_t>(tagbig);
+		fpu.cw = static_cast<uint16_t>(mem_readd(addr+0));
+		fpu.sw = static_cast<uint16_t>(mem_readd(addr+4));
+		tag    = static_cast<uint16_t>(mem_readd(addr+8));
 	}
 	FPU_SetTag(tag);
-	FPU_SetCW(cw);
-	TOP = FPU_GET_TOP();
 }
 
-static void FPU_FSAVE(PhysPt addr){
-	FPU_FSTENV(addr);
-	Bitu start = (cpu.code.big?28:14);
+static void FPU_FSAVE(PhysPt addr, bool op16){
+	FPU_FSTENV(addr, op16);
+	uint8_t start = op16 ? 14:28;
 	for(Bitu i = 0;i < 8;i++){
 		FPU_ST80(addr+start,STV(i));
 		start += 10;
@@ -560,9 +553,9 @@ static void FPU_FSAVE(PhysPt addr){
 	FPU_FINIT();
 }
 
-static void FPU_FRSTOR(PhysPt addr){
-	FPU_FLDENV(addr);
-	Bitu start = (cpu.code.big?28:14);
+static void FPU_FRSTOR(PhysPt addr, bool op16){
+	FPU_FLDENV(addr, op16);
+	uint8_t start = op16 ? 14:28;
 	for(Bitu i = 0;i < 8;i++){
 		fpu.regs[STV(i)].d = FPU_FLD80(addr+start);
 		start += 10;

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -523,9 +523,9 @@ static void FPU_FPREM(void){
 //	Real64 res=valtop - ressaved*valdiv; 
 //      res= fmod(valtop,valdiv);
 	fpu.regs[TOP].d = valtop - ressaved*valdiv;
-	FPU_SET_C0(static_cast<Bitu>(ressaved&4));
-	FPU_SET_C3(static_cast<Bitu>(ressaved&2));
-	FPU_SET_C1(static_cast<Bitu>(ressaved&1));
+	FPU_SET_C0(static_cast<uint8_t>(ressaved & 4));
+	FPU_SET_C3(static_cast<uint8_t>(ressaved & 2));
+	FPU_SET_C1(static_cast<uint8_t>(ressaved & 1));
 	FPU_SET_C2(0);
 }
 
@@ -539,9 +539,9 @@ static void FPU_FPREM1(void){
 	else if (quot-quotf<0.5) ressaved = static_cast<int64_t>(quotf);
 	else ressaved = static_cast<int64_t>((((static_cast<int64_t>(quotf))&1)!=0)?(quotf+1):(quotf));
 	fpu.regs[TOP].d = valtop - ressaved*valdiv;
-	FPU_SET_C0(static_cast<Bitu>(ressaved&4));
-	FPU_SET_C3(static_cast<Bitu>(ressaved&2));
-	FPU_SET_C1(static_cast<Bitu>(ressaved&1));
+	FPU_SET_C0(static_cast<uint8_t>(ressaved & 4));
+	FPU_SET_C3(static_cast<uint8_t>(ressaved & 2));
+	FPU_SET_C1(static_cast<uint8_t>(ressaved & 1));
 	FPU_SET_C2(0);
 }
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -410,23 +410,95 @@ static void FPU_FST(Bitu st, Bitu other){
 
 
 static void FPU_FCOM(Bitu st, Bitu other){
-	if(((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) || 
-		((fpu.tags[other] != TAG_Valid) && (fpu.tags[other] != TAG_Zero))){
-		FPU_SET_C3(1);FPU_SET_C2(1);FPU_SET_C0(1);return;
+	if (((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) ||
+	    ((fpu.tags[other] != TAG_Valid) && (fpu.tags[other] != TAG_Zero))) {
+		FPU_SET_C3(1);
+		FPU_SET_C2(1);
+		FPU_SET_C0(1);
+		return;
 	}
-	if(fpu.regs[st].d == fpu.regs[other].d){
-		FPU_SET_C3(1);FPU_SET_C2(0);FPU_SET_C0(0);return;
+
+	/* HACK: If emulating a 286 processor we want the guest to think it's
+	 * talking to a 287. For more info, read
+	 * [http://www.intel-assembler.it/portale/5/cpu-identification/asm-source-to-find-intel-cpu.asp].
+	 */
+	/* TODO: This should eventually become an option, say, a dosbox.conf
+	 * option named fputype where the user can enter "none" for no FPU, 287
+	 * or 387 for cputype=286 and cputype=386, or "auto" to match the CPU
+	 * (8086 => 8087). If the FPU type is 387 or auto, then skip this hack.
+	 * Else for 8087 and 287, use this hack. */
+	if (FPU_ArchitectureType < FPU_ARCHTYPE_387) {
+		if ((std::isinf)(fpu.regs[st].d) && (std::isinf)(fpu.regs[other].d)) {
+			/* 8087/287 consider -inf == +inf and that's what DOS
+			 * programs test for to detect 287 vs 387 */
+			FPU_SET_C3(1);
+			FPU_SET_C2(0);
+			FPU_SET_C0(0);
+			return;
+		}
 	}
-	if(fpu.regs[st].d < fpu.regs[other].d){
-		FPU_SET_C3(0);FPU_SET_C2(0);FPU_SET_C0(1);return;
+
+	if (fpu.regs[st].d == fpu.regs[other].d) {
+		FPU_SET_C3(1);
+		FPU_SET_C2(0);
+		FPU_SET_C0(0);
+		return;
+	}
+	if (fpu.regs[st].d < fpu.regs[other].d) {
+		FPU_SET_C3(0);
+		FPU_SET_C2(0);
+		FPU_SET_C0(1);
+		return;
 	}
 	// st > other
-	FPU_SET_C3(0);FPU_SET_C2(0);FPU_SET_C0(0);return;
+	FPU_SET_C3(0);
+	FPU_SET_C2(0);
+	FPU_SET_C0(0);
+	return;
 }
 
 static void FPU_FUCOM(Bitu st, Bitu other){
-	//does atm the same as fcom 
+	//does atm the same as fcom
 	FPU_FCOM(st,other);
+}
+
+uint32_t FillFlags();
+
+static void FPU_FUCOMI(Bitu st, Bitu other)
+{
+	FillFlags();
+	SETFLAGBIT(OF, false);
+
+	if (fpu.regs[st].d == fpu.regs[other].d) {
+		SETFLAGBIT(ZF, true);
+		SETFLAGBIT(PF, false);
+		SETFLAGBIT(CF, false);
+		return;
+	}
+	if (fpu.regs[st].d < fpu.regs[other].d) {
+		SETFLAGBIT(ZF, false);
+		SETFLAGBIT(PF, false);
+		SETFLAGBIT(CF, true);
+		return;
+	}
+	// st > other
+	SETFLAGBIT(ZF, false);
+	SETFLAGBIT(PF, false);
+	SETFLAGBIT(CF, false);
+	return;
+}
+
+static inline void FPU_FCOMI(Bitu st, Bitu other)
+{
+	FPU_FUCOMI(st, other);
+
+	if (((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) ||
+	    ((fpu.tags[other] != TAG_Valid) && (fpu.tags[other] != TAG_Zero))) {
+		SETFLAGBIT(ZF, true);
+		SETFLAGBIT(PF, true);
+		SETFLAGBIT(CF, true);
+		return;
+	}
 }
 
 static void FPU_FRNDINT(void){

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -101,23 +101,11 @@ static void FPU_FPOP(void){
 
 static double FROUND(double in){
 	switch (fpu.cw.RC){
-	case fpu::RoundMode::Nearest:
-		if (in-floor(in)>0.5) return (floor(in)+1);
-		else if (in-floor(in)<0.5) return (floor(in));
-		else return (((static_cast<int64_t>(floor(in)))&1)!=0)?(floor(in)+1):(floor(in));
-		break;
-	case fpu::RoundMode::Down:
-		return (floor(in));
-		break;
-	case fpu::RoundMode::Up:
-		return (ceil(in));
-		break;
-	case fpu::RoundMode::Chop:
-		return in; //the cast afterwards will do it right maybe cast here
-		break;
-	default:
-		return in;
-		break;
+	case FPUControlWord::RoundMode::Nearest: return std::nearbyint(in);
+	case FPUControlWord::RoundMode::Down: return floor(in);
+	case FPUControlWord::RoundMode::Up: return ceil(in);
+	case FPUControlWord::RoundMode::Chop: [[fallthrough]]; // cast by the caller chops
+	default: return in; break;
 	}
 }
 

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1008,18 +1008,21 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         );
 #endif
 
-static void FPU_FINIT(void) {
-	fpu.cw.init();
-	fpu.sw.init();
-	fpu.tags[0]=TAG_Empty;
-	fpu.tags[1]=TAG_Empty;
-	fpu.tags[2]=TAG_Empty;
-	fpu.tags[3]=TAG_Empty;
-	fpu.tags[4]=TAG_Empty;
-	fpu.tags[5]=TAG_Empty;
-	fpu.tags[6]=TAG_Empty;
-	fpu.tags[7]=TAG_Empty;
-	fpu.tags[8]=TAG_Valid; // is only used by us
+static void FPU_FINIT()
+{
+	fpu.cw = {};
+	fpu.sw = {};
+
+	fpu.tags[0] = TAG_Empty;
+	fpu.tags[1] = TAG_Empty;
+	fpu.tags[2] = TAG_Empty;
+	fpu.tags[3] = TAG_Empty;
+	fpu.tags[4] = TAG_Empty;
+	fpu.tags[5] = TAG_Empty;
+	fpu.tags[6] = TAG_Empty;
+	fpu.tags[7] = TAG_Empty;
+
+	fpu.tags[8] = TAG_Valid; // is only used by us
 }
 
 static void FPU_FCLEX(void){

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1278,6 +1278,12 @@ static void FPU_FST(Bitu stv, Bitu other){
 	FPU_SET_C1(0);
 }
 
+static inline void FPU_FCMOV(Bitu st, Bitu other)
+{
+	fpu.p_regs[st] = fpu.p_regs[other];
+	fpu.tags[st]   = fpu.tags[other];
+}
+
 /* FPU_P_Reg holds the raw data fed to the host x86 FPU registers.
  * We can't guarantee that std::isinf() can handle that or that anything
  * in the host C++ compiler supports long double, so do it ourself */

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -60,8 +60,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fnstsw	new_sw			\
 		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
 		}								\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -79,8 +78,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	op		szI PTR fpu.p_regs[eax].m1		\
 		__asm	fnstsw	new_sw			\
 		}								\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -113,8 +111,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw   new_sw                                       \
         __asm    fldcw    save_cw                                      \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsin,fcos,f2xm1,fchs,fabs
@@ -130,8 +127,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw  new_sw                            \
         __asm    fstp    TBYTE PTR fpu.p_regs[eax].m1      \
         }                                                  \
-        fpu.sw = (new_sw & sw_mask) |                      \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fsincos
 #define FPUD_SINCOS()                                                           \
@@ -158,7 +154,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     st(0)                                                 \
         __asm    end_sincos:                                                    \
         }                                                                       \
-        fpu.sw = (new_sw & sw_mask) | (fpu.sw & ~FPUStatusWord::conditionMask); \
+        FPU_SetMaskedSW(new_sw, sw_mask); \
         if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fptan
@@ -186,8 +182,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     st(0)                             \
         __asm    end_ptan:                                  \
         }                                                   \
-        fpu.sw = (new_sw & sw_mask) |                       \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);  \
+        FPU_SetMaskedSW(new_sw, sw_mask);  \
         if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fxtract
@@ -225,8 +220,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                 \
         __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                 \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_SetMaskedSW(new_sw);             \
         FPU_PREP_PUSH();
 #endif
 
@@ -265,8 +259,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fadd,fmul,fsub,fsubr
@@ -300,8 +293,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsqrt,frndint
@@ -336,8 +328,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                 \
         __asm    fldcw    save_cw                                      \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fdiv,fdivr
@@ -359,8 +350,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
@@ -379,8 +369,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fprem,fprem1,fscale
 #define FPUD_REMAINDER(op)                                         \
@@ -404,8 +393,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
     __asm   fstp    st(0)                                          \
     __asm   fldcw   save_cw                                        \
     }                                                              \
-    fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+    FPU_SetMaskedSW(new_sw);
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)			\
@@ -421,8 +409,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	op					\
 		__asm	fnstsw	new_sw		\
 		}							\
-		fpu.sw = (new_sw & sw_mask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw, sw_mask);
 
 #define FPUD_COMPARE_EA(op)			\
 		uint16_t new_sw;				\
@@ -434,8 +421,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	op					\
 		__asm	fnstsw	new_sw		\
 		}							\
-		fpu.sw = (new_sw & sw_mask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)                                   \
@@ -450,8 +436,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw   new_sw                           \
         __asm    fstp     st(0)                            \
         }                                                  \
-        fpu.sw = (new_sw & sw_mask) |                      \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fpatan,fyl2xp1
 #ifdef WEAK_EXCEPTIONS
@@ -488,8 +473,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw   new_sw                                       \
         __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                 \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_SetMaskedSW(new_sw);             \
         FPU_FPOP();
 #endif
 
@@ -528,8 +512,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw  new_sw                                        \
         __asm    fstp    TBYTE PTR fpu.p_regs[ebx].m1                  \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_SetMaskedSW(new_sw);             \
         FPU_FPOP();
 #endif
 
@@ -580,8 +563,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (fpu.p_regs[store_to])		\
 			:	"m" (fpu.p_regs[8])			\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -602,8 +584,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"m" (fpu.p_regs[8])			\
 			:								\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -632,8 +613,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "=m" (fpu.p_regs[8])	\
 			:	"m" (fpu.p_regs[TOP]), "m" (cw_masked)			\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsin,fcos,f2xm1,fchs,fabs
@@ -647,8 +627,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			"fstpt		%1				"	\
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw = (new_sw & sw_mask) |       \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fsincos
 #define FPUD_SINCOS()					\
@@ -669,8 +648,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:								\
 			:	"ax", "cc"					\
 		);									\
-		fpu.sw = (new_sw & sw_mask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask); \
+		FPU_SetMaskedSW(new_sw, sw_mask); \
 		if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fptan
@@ -692,8 +670,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:								\
 			:	"ax", "cc"					\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask); \
+		FPU_SetMaskedSW(new_sw); \
 		if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fxtract
@@ -720,8 +697,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP]),	\
 				"=m" (fpu.p_regs[(TOP-1)&7])			\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
+		FPU_SetMaskedSW(new_sw);             \
 		FPU_PREP_PUSH();
 #endif
 
@@ -756,8 +732,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fadd,fmul,fsub,fsubr
@@ -789,8 +764,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsqrt,frndint
@@ -822,8 +796,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])	\
 			:	"m" (cw_masked)		\
 		);										\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fdiv,fdivr
@@ -843,8 +816,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
@@ -862,8 +834,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fprem,fprem1,fscale
 #define FPUD_REMAINDER(op)                                         \
@@ -882,8 +853,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         : "=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])  \
         : "m" (fpu.p_regs[(TOP+1)&7]), "m" (cw_masked)             \
     );                                                             \
-    fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+    FPU_SetMaskedSW(new_sw);
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)					\
@@ -897,8 +867,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[op1]), "m" (fpu.p_regs[op2])	\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fcom,fucom
 #define FPUD_COMPARE_EA(op)					\
@@ -911,8 +880,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[op1])		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)					\
@@ -926,8 +894,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fpatan,fyl2xp1
 #ifdef WEAK_EXCEPTIONS
@@ -954,8 +921,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[(TOP+1)&7])		\
 			:	"m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
+		FPU_SetMaskedSW(new_sw);             \
 		FPU_FPOP();
 #endif
 
@@ -984,8 +950,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[(TOP+1)&7])		\
 			:	"m" (fpu.p_regs[TOP]) 		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
+		FPU_SetMaskedSW(new_sw);             \
 		FPU_FPOP();
 #endif
 

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -17,11 +17,19 @@
  */
 
 #ifndef DOSBOX_FPU_H
+#include "cpu.h"
 #include "fpu.h"
+#include "mem.h"
+#include "regs.h"
 #endif
 
 // #define WEAK_EXCEPTIONS
 
+#ifdef WEAK_EXCEPTIONS
+static constexpr uint16_t sw_mask = FPUStatusWord::conditionMask;
+#else
+static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
+#endif
 
 #if defined (_MSC_VER)
 
@@ -52,7 +60,8 @@
 		__asm	fnstsw	new_sw			\
 		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
 		}								\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -70,154 +79,166 @@
 		__asm	op		szI PTR fpu.p_regs[eax].m1		\
 		__asm	fnstsw	new_sw			\
 		}								\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
-#define FPUD_STORE(op,szI,szA)				\
-		uint16_t save_cw;						\
-		__asm {								\
-		__asm	fnstcw	save_cw				\
-		__asm	mov		eax, TOP			\
-		__asm	fldcw	fpu.cw_mask_all		\
-		__asm	shl		eax, 4				\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	op		szI PTR fpu.p_regs[128].m1		\
-		__asm	fldcw	save_cw				\
-		}
+#define FPUD_STORE(op,szI,szA)                          \
+        uint16_t save_cw,cw_masked=fpu.cw.allMasked();  \
+        uint32_t top = TOP;                             \
+        __asm {                                         \
+        __asm    fnstcw   save_cw                       \
+        __asm    mov      eax, top                      \
+        __asm    fldcw    cw_masked                     \
+        __asm    shl      eax, 4                        \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1  \
+        __asm    op       szI PTR fpu.p_regs[128].m1    \
+        __asm    fldcw    save_cw                       \
+        }
 #else
-#define FPUD_STORE(op,szI,szA)				\
-		uint16_t new_sw,save_cw;				\
-		__asm {								\
-		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
-		__asm	mov		eax, TOP			\
-		__asm	shl		eax, 4				\
-		__asm	mov		ebx, 8				\
-		__asm	shl		ebx, 4				\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	clx							\
-		__asm	op		szI PTR fpu.p_regs[ebx].m1		\
-		__asm	fnstsw	new_sw				\
-		__asm	fldcw	save_cw				\
-		}									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+#define FPUD_STORE(op,szI,szA)                                         \
+        uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();          \
+        uint32_t top = TOP;                                            \
+        __asm {                                                        \
+        __asm    fnstcw   save_cw                                      \
+        __asm    fldcw    cw_masked                                    \
+        __asm    mov      eax, top                                     \
+        __asm    shl      eax, 4                                       \
+        __asm    mov      ebx, 8                                       \
+        __asm    shl      ebx, 4                                       \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1                 \
+        __asm    clx                                                   \
+        __asm    op       szI PTR fpu.p_regs[ebx].m1                   \
+        __asm    fnstsw   new_sw                                       \
+        __asm    fldcw    save_cw                                      \
+        }                                                              \
+        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fsin,fcos,f2xm1,fchs,fabs
-#define FPUD_TRIG(op)				\
-		uint16_t new_sw;				\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	clx					\
-		__asm	op					\
-		__asm	fnstsw	new_sw		\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		}							\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+#define FPUD_TRIG(op)                                      \
+        uint16_t new_sw;                                   \
+        uint32_t top = TOP;                                \
+        __asm {                                            \
+        __asm    mov     eax, top                          \
+        __asm    shl     eax, 4                            \
+        __asm    fld     TBYTE PTR fpu.p_regs[eax].m1      \
+        __asm    clx                                       \
+        __asm    op                                        \
+        __asm    fnstsw  new_sw                            \
+        __asm    fstp    TBYTE PTR fpu.p_regs[eax].m1      \
+        }                                                  \
+        fpu.sw = (new_sw & sw_mask) |                      \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fsincos
-#define FPUD_SINCOS()				\
-		uint16_t new_sw;					\
-		__asm {							\
-		__asm	mov		eax, TOP		\
-		__asm	mov		ebx, eax		\
-		__asm	dec     ebx				\
-		__asm	and     ebx, 7			\
-		__asm	shl		eax, 4			\
-		__asm	shl		ebx, 4			\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	clx						\
-		__asm	fsincos					\
-		__asm	fnstsw	new_sw			\
-		__asm	mov		cx, new_sw		\
-		__asm	and		ch, 0x04 		\
-		__asm	jnz		argument_too_large1				\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	jmp		end_sincos		\
-		__asm	argument_too_large1:	\
-		__asm	fstp	st(0)			\
-		__asm	end_sincos:				\
-		}												\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
-		if ((new_sw&0x0400)==0) FPU_PREP_PUSH();
+#define FPUD_SINCOS()                                                           \
+        uint16_t new_sw;                                                        \
+        uint32_t top = TOP;                                                     \
+        __asm {                                                                 \
+        __asm    mov      eax, top                                              \
+        __asm    mov      ebx, eax                                              \
+        __asm    dec      ebx                                                   \
+        __asm    and      ebx, 7                                                \
+        __asm    shl      eax, 4                                                \
+        __asm    shl      ebx, 4                                                \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1                          \
+        __asm    clx                                                            \
+        __asm    fsincos                                                        \
+        __asm    fnstsw   new_sw                                                \
+        __asm    mov      cx, new_sw                                            \
+        __asm    and      ch, 0x04                                              \
+        __asm    jnz      argument_too_large1                                   \
+        __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                          \
+        __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                          \
+        __asm    jmp      end_sincos                                            \
+        __asm    argument_too_large1:                                           \
+        __asm    fstp     st(0)                                                 \
+        __asm    end_sincos:                                                    \
+        }                                                                       \
+        fpu.sw = (new_sw & sw_mask) | (fpu.sw & ~FPUStatusWord::conditionMask); \
+        if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fptan
-#define FPUD_PTAN()					\
-		uint16_t new_sw;					\
-		__asm {							\
-		__asm	mov		eax, TOP		\
-		__asm	mov		ebx, eax		\
-		__asm	dec     ebx				\
-		__asm	and     ebx, 7			\
-		__asm	shl		eax, 4			\
-		__asm	shl		ebx, 4			\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	clx					\
-		__asm	fptan					\
-		__asm	fnstsw	new_sw			\
-		__asm	mov		cx, new_sw		\
-		__asm	and		ch, 0x04 		\
-		__asm	jnz		argument_too_large2				\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	jmp		end_ptan		\
-		__asm	argument_too_large2:	\
-		__asm	fstp	st(0)			\
-		__asm	end_ptan:				\
-		}												\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
-		if ((new_sw&0x0400)==0) FPU_PREP_PUSH();
+#define FPUD_PTAN()                                         \
+        uint16_t new_sw;                                    \
+        uint32_t top = TOP;                                 \
+        __asm {                                             \
+        __asm    mov      eax, top                          \
+        __asm    mov      ebx, eax                          \
+        __asm    dec      ebx                               \
+        __asm    and      ebx, 7                            \
+        __asm    shl      eax, 4                            \
+        __asm    shl      ebx, 4                            \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1      \
+        __asm    clx                                        \
+        __asm    fptan                                      \
+        __asm    fnstsw   new_sw                            \
+        __asm    mov      cx, new_sw                        \
+        __asm    and      ch, 0x04                          \
+        __asm    jnz      argument_too_large2               \
+        __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1      \
+        __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1      \
+        __asm    jmp      end_ptan                          \
+        __asm    argument_too_large2:                       \
+        __asm    fstp     st(0)                             \
+        __asm    end_ptan:                                  \
+        }                                                   \
+        fpu.sw = (new_sw & sw_mask) |                       \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);  \
+        if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fxtract
 #ifdef WEAK_EXCEPTIONS
-#define FPUD_XTRACT						\
-		__asm {							\
-		__asm	mov		eax, TOP		\
-		__asm	mov		ebx, eax		\
-		__asm	dec     ebx				\
-		__asm	and     ebx, 7			\
-		__asm	shl		eax, 4			\
-		__asm	shl		ebx, 4			\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	fxtract					\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		}												\
-		FPU_PREP_PUSH();
+#define FPUD_XTRACT                                      \
+        uint32_t top = TOP;                              \
+        __asm {                                          \
+        __asm    mov      eax, top                       \
+        __asm    mov      ebx, eax                       \
+        __asm    dec      ebx                            \
+        __asm    and      ebx, 7                         \
+        __asm    shl      eax, 4                         \
+        __asm    shl      ebx, 4                         \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1   \
+        __asm    fxtract                                 \
+        __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1   \
+        __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1   \
+        }                                                \
+        FPU_PREP_PUSH();
 #else
-#define FPUD_XTRACT						\
-		uint16_t new_sw;					\
-		__asm {							\
-		__asm	mov		eax, TOP		\
-		__asm	mov		ebx, eax		\
-		__asm	dec     ebx				\
-		__asm	and     ebx, 7			\
-		__asm	shl		eax, 4			\
-		__asm	shl		ebx, 4			\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	fclex					\
-		__asm	fxtract					\
-		__asm	fnstsw	new_sw			\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		}												\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);			\
-		FPU_PREP_PUSH();
+#define FPUD_XTRACT                                                    \
+        uint16_t new_sw;                                               \
+        uint32_t top = TOP;                                            \
+        __asm {                                                        \
+        __asm    mov      eax, top                                     \
+        __asm    mov      ebx, eax                                     \
+        __asm    dec      ebx                                          \
+        __asm    and      ebx, 7                                       \
+        __asm    shl      eax, 4                                       \
+        __asm    shl      ebx, 4                                       \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1                 \
+        __asm    fclex                                                 \
+        __asm    fxtract                                               \
+        __asm    fnstsw   new_sw                                       \
+        __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                 \
+        __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                 \
+        }                                                              \
+        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_PREP_PUSH();
 #endif
 
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1(op)						\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	cw_masked           \
 		__asm	mov		ebx, op2			\
 		__asm	shl		ebx, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
@@ -228,10 +249,10 @@
 		}
 #else
 #define FPUD_ARITH1(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	cw_masked			\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
 		__asm	mov		ebx, op2			\
@@ -244,17 +265,18 @@
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1_EA(op)					\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	cw_masked    		\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
 		__asm	fxch	\
@@ -264,10 +286,10 @@
 		}
 #else
 #define FPUD_ARITH1_EA(op)					\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	cw_masked    		\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
@@ -278,48 +300,53 @@
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fsqrt,frndint
 #ifdef WEAK_EXCEPTIONS
-#define FPUD_ARITH2(op)						\
-		uint16_t save_cw;						\
-		__asm {								\
-		__asm	fnstcw	save_cw				\
-		__asm	mov		eax, TOP			\
-		__asm	fldcw	fpu.cw_mask_all		\
-		__asm	shl		eax, 4				\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	op							\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
-		__asm	fldcw	save_cw				\
-		}
+#define FPUD_ARITH2(op)                                   \
+        uint16_t save_cw,cw_masked=fpu.cw.allMasked();    \
+        uint32_t top = TOP;                               \
+        __asm {                                           \
+        __asm    fnstcw  save_cw                          \
+        __asm    mov     eax, top                         \
+        __asm    fldcw   cw_masked                        \
+        __asm    shl     eax, 4                           \
+        __asm    fld     TBYTE PTR fpu.p_regs[eax].m1     \
+        __asm    op                                       \
+        __asm    fstp    TBYTE PTR fpu.p_regs[eax].m1     \
+        __asm    fldcw   save_cw                          \
+        }
 #else
-#define FPUD_ARITH2(op)						\
-		uint16_t new_sw,save_cw;				\
-		__asm {								\
-		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
-		__asm	mov		eax, TOP			\
-		__asm	shl		eax, 4				\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	clx							\
-		__asm	op							\
-		__asm	fnstsw	new_sw				\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
-		__asm	fldcw	save_cw				\
-		}									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+
+#define FPUD_ARITH2(op)                                                \
+        uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();          \
+        uint32_t top = TOP;                                            \
+        __asm {                                                        \
+        __asm    fnstcw   save_cw                                      \
+        __asm    fldcw    cw_masked                                    \
+        __asm    mov      eax, top                                     \
+        __asm    shl      eax, 4                                       \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1                 \
+        __asm    clx                                                   \
+        __asm    op                                                    \
+        __asm    fnstsw   new_sw                                       \
+        __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                 \
+        __asm    fldcw    save_cw                                      \
+        }                                                              \
+        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1 but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	cw_masked			\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
 		__asm	mov		ebx, op2			\
@@ -332,16 +359,17 @@
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3_EA(op)					\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	cw_masked			\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
 		__asm	fxch	\
@@ -351,27 +379,33 @@
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fprem,fprem1,fscale
-#define FPUD_REMAINDER(op)			\
-		uint16_t new_sw;				\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	mov		ebx, eax	\
-		__asm	inc     ebx			\
-		__asm	and     ebx, 7		\
-		__asm	shl		ebx, 4		\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	fclex				\
-		__asm	op					\
-		__asm	fnstsw	new_sw		\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	fstp	st(0)		\
-		}							\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+#define FPUD_REMAINDER(op)                                         \
+    uint16_t new_sw, save_cw, cw_masked = fpu.cw.allMasked();      \
+    uint32_t top = TOP;                                            \
+    __asm {                                                        \
+    __asm   fnstcw  save_cw                                        \
+    __asm   fldcw   cw_masked                                      \
+    __asm   mov     eax, top                                       \
+    __asm   mov     ebx, eax                                       \
+    __asm   inc     ebx                                            \
+    __asm   and     ebx, 7                                         \
+    __asm   shl     ebx, 4                                         \
+    __asm   shl     eax, 4                                         \
+    __asm   fld     TBYTE PTR fpu.p_regs[ebx].m1                   \
+    __asm   fld     TBYTE PTR fpu.p_regs[eax].m1                   \
+    __asm   fclex                                                  \
+    __asm   op                                                     \
+    __asm   fnstsw  new_sw                                         \
+    __asm   fstp    TBYTE PTR fpu.p_regs[eax].m1                   \
+    __asm   fstp    st(0)                                          \
+    __asm   fldcw   save_cw                                        \
+    }                                                              \
+    fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)			\
@@ -387,7 +421,8 @@
 		__asm	op					\
 		__asm	fnstsw	new_sw		\
 		}							\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & sw_mask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 #define FPUD_COMPARE_EA(op)			\
 		uint16_t new_sw;				\
@@ -399,107 +434,123 @@
 		__asm	op					\
 		__asm	fnstsw	new_sw		\
 		}							\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & sw_mask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fxam,ftst
-#define FPUD_EXAMINE(op)			\
-		uint16_t new_sw;				\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	clx					\
-		__asm	op					\
-		__asm	fnstsw	new_sw		\
-		__asm	fstp	st(0)		\
-		}							\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+#define FPUD_EXAMINE(op)                                   \
+        uint16_t new_sw;                                   \
+        uint32_t top = TOP;                                \
+        __asm {                                            \
+        __asm    mov      eax, top                         \
+        __asm    shl      eax, 4                           \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1     \
+        __asm    clx                                       \
+        __asm    op                                        \
+        __asm    fnstsw   new_sw                           \
+        __asm    fstp     st(0)                            \
+        }                                                  \
+        fpu.sw = (new_sw & sw_mask) |                      \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fpatan,fyl2xp1
 #ifdef WEAK_EXCEPTIONS
-#define FPUD_WITH_POP(op)			\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	mov		ebx, eax	\
-		__asm	inc     ebx			\
-		__asm	and     ebx, 7		\
-		__asm	shl		ebx, 4		\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	op					\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		}							\
-		FPU_FPOP();
+#define FPUD_WITH_POP(op)                               \
+        uint32_t top = TOP;                             \
+        __asm {                                         \
+        __asm    mov    eax, top                        \
+        __asm    mov    ebx, eax                        \
+        __asm    inc    ebx                             \
+        __asm    and    ebx, 7                          \
+        __asm    shl    ebx, 4                          \
+        __asm    shl    eax, 4                          \
+        __asm    fld    TBYTE PTR fpu.p_regs[ebx].m1    \
+        __asm    fld    TBYTE PTR fpu.p_regs[eax].m1    \
+        __asm    op                                     \
+        __asm    fstp   TBYTE PTR fpu.p_regs[ebx].m1    \
+        }                            \
+        FPU_FPOP();
 #else
-#define FPUD_WITH_POP(op)			\
-		uint16_t new_sw;				\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	mov		ebx, eax	\
-		__asm	inc     ebx			\
-		__asm	and     ebx, 7		\
-		__asm	shl		ebx, 4		\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	fclex				\
-		__asm	op					\
-		__asm	fnstsw	new_sw		\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		}								\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);	\
-		FPU_FPOP();
+#define FPUD_WITH_POP(op)                                              \
+        uint16_t new_sw;                                               \
+        uint32_t top = TOP;                                            \
+        __asm {                                                        \
+        __asm    mov      eax, top                                     \
+        __asm    mov      ebx, eax                                     \
+        __asm    inc      ebx                                          \
+        __asm    and      ebx, 7                                       \
+        __asm    shl      ebx, 4                                       \
+        __asm    shl      eax, 4                                       \
+        __asm    fld      TBYTE PTR fpu.p_regs[ebx].m1                 \
+        __asm    fld      TBYTE PTR fpu.p_regs[eax].m1                 \
+        __asm    fclex                                                 \
+        __asm    op                                                    \
+        __asm    fnstsw   new_sw                                       \
+        __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                 \
+        }                                                              \
+        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_FPOP();
 #endif
 
 // handles fyl2x
 #ifdef WEAK_EXCEPTIONS
-#define FPUD_FYL2X(op)				\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	mov		ebx, eax	\
-		__asm	inc     ebx			\
-		__asm	and     ebx, 7		\
-		__asm	shl		ebx, 4		\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	op					\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		}								\
-		FPU_FPOP();
+#define FPUD_FYL2X(op)                                  \
+        uint32_t top = TOP;                             \
+        __asm {                                         \
+        __asm    mov    eax, top                        \
+        __asm    mov    ebx, eax                        \
+        __asm    inc    ebx                             \
+        __asm    and    ebx, 7                          \
+        __asm    shl    ebx, 4                          \
+        __asm    shl    eax, 4                          \
+        __asm    fld    TBYTE PTR fpu.p_regs[ebx].m1    \
+        __asm    fld    TBYTE PTR fpu.p_regs[eax].m1    \
+        __asm    op                                     \
+        __asm    fstp   TBYTE PTR fpu.p_regs[ebx].m1    \
+        }                                               \
+        FPU_FPOP();
 #else
-#define FPUD_FYL2X(op)				\
-		uint16_t new_sw;				\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	mov		ebx, eax	\
-		__asm	inc     ebx			\
-		__asm	and     ebx, 7		\
-		__asm	shl		ebx, 4		\
-		__asm	shl		eax, 4		\
-		__asm	fld		TBYTE PTR fpu.p_regs[ebx].m1	\
-		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
-		__asm	fclex				\
-		__asm	op					\
-		__asm	fnstsw	new_sw		\
-		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
-		}								\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);	\
-		FPU_FPOP();
+#define FPUD_FYL2X(op)                                                 \
+        uint16_t new_sw;                                               \
+        uint32_t top = TOP;                                            \
+        __asm {                                                        \
+        __asm    mov     eax, top                                      \
+        __asm    mov     ebx, eax                                      \
+        __asm    inc     ebx                                           \
+        __asm    and     ebx, 7                                        \
+        __asm    shl     ebx, 4                                        \
+        __asm    shl     eax, 4                                        \
+        __asm    fld     TBYTE PTR fpu.p_regs[ebx].m1                  \
+        __asm    fld     TBYTE PTR fpu.p_regs[eax].m1                  \
+        __asm    fclex                                                 \
+        __asm    op                                                    \
+        __asm    fnstsw  new_sw                                        \
+        __asm    fstp    TBYTE PTR fpu.p_regs[ebx].m1                  \
+        }                                                              \
+        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_FPOP();
 #endif
 
 // load math constants
-#define FPUD_LOAD_CONST(op)		\
-		FPU_PREP_PUSH();			\
-		__asm {						\
-		__asm	mov		eax, TOP	\
-		__asm	shl		eax, 4		\
-		__asm	clx					\
-		__asm	op					\
-		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	\
-		}							\
-
+#define FPUD_LOAD_CONST(op)                              \
+        FPUControlWord save_cw;                          \
+        auto cw = fpu.cw.allMasked();                    \
+        if (FPU_ArchitectureType < FPU_ARCHTYPE_387)     \
+            cw.RC = FPUControlWord::RoundMode::Nearest;  \
+        FPU_PREP_PUSH();                                 \
+        uint32_t top = TOP;                              \
+        __asm {                                          \
+        __asm    fnstcw  save_cw                         \
+        __asm    fldcw   cw                              \
+        __asm    mov     eax, top                        \
+        __asm    shl     eax, 4                          \
+        __asm    clx                                     \
+        __asm    op                                      \
+        __asm    fstp    TBYTE PTR fpu.p_regs[eax].m1    \
+        __asm    fldcw   save_cw                         \
+        }
 #else
 
 // !defined _MSC_VER
@@ -529,7 +580,8 @@
 			:	"=&am" (new_sw), "=m" (fpu.p_regs[store_to])		\
 			:	"m" (fpu.p_regs[8])			\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -550,12 +602,13 @@
 			:	"m" (fpu.p_regs[8])			\
 			:								\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_STORE(op,szI,szA)				\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%3				\n"	\
@@ -563,11 +616,11 @@
 			#op #szA "	%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "=m" (fpu.p_regs[8])	\
-			:	"m" (fpu.p_regs[TOP]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[TOP]), "m" (cw_masked)		\
 		);
 #else
 #define FPUD_STORE(op,szI,szA)				\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -577,9 +630,10 @@
 			"fnstsw		%0				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "=m" (fpu.p_regs[8])	\
-			:	"m" (fpu.p_regs[TOP]), "m" (fpu.cw_mask_all)			\
+			:	"m" (fpu.p_regs[TOP]), "m" (cw_masked)			\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fsin,fcos,f2xm1,fchs,fabs
@@ -593,7 +647,8 @@
 			"fstpt		%1				"	\
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & sw_mask) |       \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fsincos
 #define FPUD_SINCOS()					\
@@ -614,8 +669,9 @@
 			:								\
 			:	"ax", "cc"					\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
-		if ((new_sw&0x0400)==0) FPU_PREP_PUSH();
+		fpu.sw = (new_sw & sw_mask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask); \
+		if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fptan
 #define FPUD_PTAN()						\
@@ -636,8 +692,9 @@
 			:								\
 			:	"ax", "cc"					\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
-		if ((new_sw&0x0400)==0) FPU_PREP_PUSH();
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask); \
+		if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fxtract
 #ifdef WEAK_EXCEPTIONS
@@ -663,14 +720,15 @@
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP]),	\
 				"=m" (fpu.p_regs[(TOP-1)&7])			\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
 		FPU_PREP_PUSH();
 #endif
 
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1(op)						\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%3				\n"	\
@@ -680,11 +738,11 @@
 			"fstpt		%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "+m" (fpu.p_regs[op1])				\
-			:	"m" (fpu.p_regs[op2]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);
 #else
 #define FPUD_ARITH1(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -696,15 +754,16 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.p_regs[op2]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1_EA(op)					\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%2				\n"	\
@@ -713,11 +772,11 @@
 			"fstpt		%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "+m" (fpu.p_regs[op1])		\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);
 #else
 #define FPUD_ARITH1_EA(op)					\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -728,15 +787,16 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fsqrt,frndint
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH2(op)						\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%2				\n"	\
@@ -745,11 +805,11 @@
 			"fstpt		%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "+m" (fpu.p_regs[TOP])		\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);
 #else
 #define FPUD_ARITH2(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -760,15 +820,16 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])	\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);										\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 #endif
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1 but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -780,14 +841,15 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.p_regs[op2]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3_EA(op)					\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -798,25 +860,30 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);									\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fprem,fprem1,fscale
-#define FPUD_REMAINDER(op)					\
-		uint16_t new_sw;						\
-		__asm__ volatile (					\
-			"fldt		%2				\n"	\
-			"fldt		%1				\n"	\
-			"fclex						\n"	\
-			#op" 						\n"	\
-			"fnstsw		%0				\n"	\
-			"fstpt		%1				\n"	\
-			"fstp		%%st(0)			"	\
-			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP])	\
-			:	"m" (fpu.p_regs[(TOP+1)&7])				\
-		);									\
-		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
+#define FPUD_REMAINDER(op)                                         \
+    uint16_t new_sw, save_cw, cw_masked = fpu.cw.allMasked();      \
+    __asm__ volatile (                                             \
+        "fnstcw     %1              \n"                            \
+        "fldcw      %4              \n"                            \
+        "fldt       %3              \n"                            \
+        "fldt       %2              \n"                            \
+        "fclex                      \n"                            \
+        #op"                        \n"                            \
+        "fnstsw     %0              \n"                            \
+        "fstpt      %2              \n"                            \
+        "fstp       %%st(0)         \n"                            \
+        "fldcw      %1                "                            \
+        : "=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])  \
+        : "m" (fpu.p_regs[(TOP+1)&7]), "m" (cw_masked)             \
+    );                                                             \
+    fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+                 (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)					\
@@ -830,7 +897,8 @@
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[op1]), "m" (fpu.p_regs[op2])	\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fcom,fucom
 #define FPUD_COMPARE_EA(op)					\
@@ -843,7 +911,8 @@
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[op1])		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)					\
@@ -857,7 +926,8 @@
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);
 
 // handles fpatan,fyl2xp1
 #ifdef WEAK_EXCEPTIONS
@@ -884,7 +954,8 @@
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[(TOP+1)&7])		\
 			:	"m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
 		FPU_FPOP();
 #endif
 
@@ -913,32 +984,33 @@
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[(TOP+1)&7])		\
 			:	"m" (fpu.p_regs[TOP]) 		\
 		);									\
-		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);		\
+		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
+		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
 		FPU_FPOP();
 #endif
 
 // load math constants
-#define FPUD_LOAD_CONST(op)				\
-		FPU_PREP_PUSH();					\
-		__asm__ volatile (					\
-			clx" 						\n"	\
-			#op" 						\n"	\
-			"fstpt		%0				\n"	\
-			:	"=m" (fpu.p_regs[TOP])		\
-		);
-
-#endif
-
-#ifdef WEAK_EXCEPTIONS
-const uint16_t exc_mask=0x7f00;
-#else
-const uint16_t exc_mask=0xffbf;
+#define FPUD_LOAD_CONST(op)                             \
+        FPUControlWord save_cw;                         \
+        auto cw = fpu.cw.allMasked();                   \
+        if (FPU_ArchitectureType < FPU_ARCHTYPE_387)    \
+            cw.RC = FPUControlWord::RoundMode::Nearest; \
+        FPU_PREP_PUSH();                                \
+        __asm__ volatile (                              \
+            "fnstcw     %1                          \n" \
+            "fldcw      %2                          \n" \
+            clx"                                    \n" \
+            #op"                                    \n" \
+            "fstpt      %0                          \n" \
+            "fldcw      %1                          \n" \
+            : "=m" (fpu.p_regs[TOP]), "+m" (save_cw)    \
+            : "m" (cw)                                  \
+        );
 #endif
 
 static void FPU_FINIT(void) {
-	FPU_SetCW(0x37F);
-	fpu.sw=0;
-	TOP=FPU_GET_TOP();
+	fpu.cw.init();
+	fpu.sw.init();
 	fpu.tags[0]=TAG_Empty;
 	fpu.tags[1]=TAG_Empty;
 	fpu.tags[2]=TAG_Empty;
@@ -951,7 +1023,7 @@ static void FPU_FINIT(void) {
 }
 
 static void FPU_FCLEX(void){
-	fpu.sw&=0x7f00;				//should clear exceptions
+	fpu.sw.clearExceptions();
 }
 
 static void FPU_FNOP(void){
@@ -1206,16 +1278,42 @@ static void FPU_FST(Bitu stv, Bitu other){
 	FPU_SET_C1(0);
 }
 
+/* FPU_P_Reg holds the raw data fed to the host x86 FPU registers.
+ * We can't guarantee that std::isinf() can handle that or that anything
+ * in the host C++ compiler supports long double, so do it ourself */
+static inline bool fpu_p_inf(const FPU_P_Reg &r) {
+       /* Infinity is exponent == 0x7FFF and mantissa bits [63:61] == 100b (4) */
+       return (r.m3 & 0x7FFFu) == 0x7FFFu && (r.m2 & 0xE0000000u) == 0x80000000u;
+}
+
+static inline bool FPUD_286_FCOM_INF(Bitu op1, Bitu op2) {
+       /* HACK: If emulating a 286 processor we want the guest to think it's talking to a 287.
+        *       For more info, read [http://www.intel-assembler.it/portale/5/cpu-identification/asm-source-to-find-intel-cpu.asp]. */
+       /* TODO: This should eventually become an option, say, a dosbox.conf option named fputype where the user can enter
+        *       "none" for no FPU, 287 or 387 for cputype=286 and cputype=386, or "auto" to match the CPU (8086 => 8087).
+        *       If the FPU type is 387 or auto, then skip this hack. Else for 8087 and 287, use this hack. */
+       if (CPU_ArchitectureType<=CPU_ARCHTYPE_386FAST) {
+               if (fpu_p_inf(fpu.p_regs[op1]) && fpu_p_inf(fpu.p_regs[op2])) {
+                       /* 8087/287 consider -inf == +inf and that's what DOS programs test for to detect 287 vs 387 */
+                       FPU_SET_C3(1);FPU_SET_C2(0);FPU_SET_C0(0);return true;
+               }
+       }
+
+       return false;
+}
 
 static void FPU_FCOM(Bitu op1, Bitu op2){
+	if (FPUD_286_FCOM_INF(op1,op2)) return;
 	FPUD_COMPARE(fcompp)
 }
 
 static void FPU_FCOM_EA(Bitu op1){
+	if (FPUD_286_FCOM_INF(op1,TOP)) return;
 	FPUD_COMPARE_EA(fcompp)
 }
 
 static void FPU_FUCOM(Bitu op1, Bitu op2){
+	if (FPUD_286_FCOM_INF(op1,op2)) return;
 	FPUD_COMPARE(fucompp)
 }
 
@@ -1257,9 +1355,8 @@ static void FPU_FSCALE(void){
 }
 
 
-static void FPU_FSTENV(PhysPt addr){
-	FPU_SET_TOP(TOP);
-	if(!cpu.code.big) {
+static void FPU_FSTENV(PhysPt addr, bool op16){
+	if (op16) {
 		mem_writew(addr+0,fpu.cw);
 		mem_writew(addr+2,fpu.sw);
 		mem_writew(addr+4,FPU_GetTag());
@@ -1270,29 +1367,24 @@ static void FPU_FSTENV(PhysPt addr){
 	}
 }
 
-static void FPU_FLDENV(PhysPt addr){
+static void FPU_FLDENV(PhysPt addr, bool op16){
 	uint16_t tag;
-	uint32_t tagbig;
-	Bitu cw;
-	if(!cpu.code.big) {
-		cw     = mem_readw(addr+0);
+	if (op16) {
+		fpu.cw = mem_readw(addr+0);
 		fpu.sw = mem_readw(addr+2);
 		tag    = mem_readw(addr+4);
 	} else { 
-		cw     = mem_readd(addr+0);
-		fpu.sw = (uint16_t)mem_readd(addr+4);
-		tagbig = mem_readd(addr+8);
-		tag    = static_cast<uint16_t>(tagbig);
+		fpu.cw = static_cast<uint16_t>(mem_readd(addr+0));
+		fpu.sw = static_cast<uint16_t>(mem_readd(addr+4));
+		tag    = static_cast<uint16_t>(mem_readd(addr+8));
 	}
 	FPU_SetTag(tag);
-	FPU_SetCW(cw);
-	TOP=FPU_GET_TOP();
 }
 
-static void FPU_FSAVE(PhysPt addr){
-	FPU_FSTENV(addr);
-	Bitu start=(cpu.code.big?28:14);
-	for(Bitu i=0;i<8;i++){
+static void FPU_FSAVE(PhysPt addr, bool op16){
+	FPU_FSTENV(addr, op16);
+	PhysPt start = op16 ? 14:28;
+	for(unsigned i=0;i<8;i++){
 		mem_writed(addr+start,fpu.p_regs[STV(i)].m1);
 		mem_writed(addr+start+4,fpu.p_regs[STV(i)].m2);
 		mem_writew(addr+start+8,fpu.p_regs[STV(i)].m3);
@@ -1301,10 +1393,10 @@ static void FPU_FSAVE(PhysPt addr){
 	FPU_FINIT();
 }
 
-static void FPU_FRSTOR(PhysPt addr){
-	FPU_FLDENV(addr);
-	Bitu start=(cpu.code.big?28:14);
-	for(Bitu i=0;i<8;i++){
+static void FPU_FRSTOR(PhysPt addr, bool op16){
+	FPU_FLDENV(addr, op16);
+	PhysPt start = op16 ? 14:28;
+	for(unsigned i=0;i<8;i++){
 		fpu.p_regs[STV(i)].m1 = mem_readd(addr+start);
 		fpu.p_regs[STV(i)].m2 = mem_readd(addr+start+4);
 		fpu.p_regs[STV(i)].m3 = mem_readw(addr+start+8);


### PR DESCRIPTION
This PR imports select FPU improvements by @TomCat, @ern0, @cimarronm, and @joncampbell123 with all changes brought in verbatim (formatting, style, and naming all as-is).

With the X team continuing to improve the FPU, such as the move to bit-level control and status word registers, the goal of this PR is to sync these aspects of the FPU to allow for easier code portability to and from Staging and X.

https://archive.org/details/MDIAG_ZIP

![mcpdiag_001](https://user-images.githubusercontent.com/1557255/220465734-408c99e6-0d45-4ed3-9342-113d0f9f9e52.png)

It will also allow for adjusting the FPU type to along with the current machine type (for example, pcjr, tandy, and <= 286 CPUs). This isn't included in this PR, but this is now possible:

https://archive.org/details/msdos_MCPDIAG_shareware

https://user-images.githubusercontent.com/1557255/220465815-9d4346a0-ad75-4eb9-ad8f-19f2986a5a16.mp4

