### PR TITLE
Use C++11 `std::nearbyint()` for nearest FPU round

### DIFF
--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -101,23 +101,11 @@ static void FPU_FPOP(void){
 
 static double FROUND(double in){
 	switch(fpu.round){
-	case ROUND_Nearest:	
-		if (in-floor(in)>0.5) return (floor(in)+1);
-		else if (in-floor(in)<0.5) return (floor(in));
-		else return (((static_cast<int64_t>(floor(in)))&1)!=0)?(floor(in)+1):(floor(in));
-		break;
-	case ROUND_Down:
-		return (floor(in));
-		break;
-	case ROUND_Up:
-		return (ceil(in));
-		break;
-	case ROUND_Chop:
-		return in; //the cast afterwards will do it right maybe cast here
-		break;
-	default:
-		return in;
-		break;
+	case ROUND_Nearest: return std::nearbyint(in);
+	case ROUND_Down: return (floor(in));
+	case ROUND_Up: return (ceil(in));
+	case ROUND_Chop: [[fallthrough]]; // cast by the caller chops
+	default: return in;
 	}
 }
 


### PR DESCRIPTION
Also de-dupe the chop and default cases.

No regressions on x86, and picks up a couple more passes on ARM (branch is right-hand-side):

![2023-02-22_14-05](https://user-images.githubusercontent.com/1557255/220770610-c12b4e93-d780-4e5c-87ad-72be2a6e43d1.png)
