### PR TITLE
Enable large disk image support

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -73,7 +73,7 @@ public:
 	uint32_t sector_size;
 	uint32_t heads,cylinders,sectors;
 private:
-	off_t current_fpos;
+	cross_off_t current_fpos;
 	enum { NONE,READ,WRITE } last_action;
 };
 

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -73,7 +73,7 @@ public:
 	uint32_t sector_size;
 	uint32_t heads,cylinders,sectors;
 private:
-	uint32_t current_fpos;
+	off_t current_fpos;
 	enum { NONE,READ,WRITE } last_action;
 };
 

--- a/include/cross.h
+++ b/include/cross.h
@@ -57,6 +57,24 @@
 #define ftruncate(blah,blah2) chsize(blah,blah2)
 #endif
 
+/* Large file support */
+#if defined(_MSC_VER)
+	// MSVC doesn't support the posix fstream functions,
+	// typedef their equivalents
+	#define cross_ftello _ftelli64
+	#define cross_fseeko _fseeki64
+	#define cross_off_t __int64
+#else
+	// All other platforms should have POSIX fstream 'o' support
+	// Note: Meson automatically sets preprocessor defines for us
+
+	// Check that off_t is 64 bits
+	static_assert(sizeof(off_t) == sizeof(int64_t), "off_t not 64 bits");
+	#define cross_ftello ftello
+	#define cross_fseeko fseeko
+	#define cross_off_t off_t
+#endif
+
 // fileno is a POSIX function (not mentioned in ISO/C++), which means it might
 // be missing when when using C++11 with strict ANSI compatibility.
 // New MSVC issues "deprecation" warning when fileno is used and recommends

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -273,6 +273,21 @@ static inline uint16_t long2para(uint32_t size) {
 	else return (uint16_t)(size>>4);
 }
 
+/* Large file support */
+#if defined(_MSC_VER)
+	// MSVC doesn't support the posix fstream functions,
+	// typedef their equivalents
+	#define ftello _ftelli64
+	#define fseeko _fseeki64
+	#define off_t __int64
+#else
+	// All other platforms should have POSIX fstream 'o' support
+	// Note: Meson automatically sets preprocessor defines for us
+
+	// Check that off_t is 64 bits
+	static_assert(sizeof(off_t) == sizeof(int64_t), "off_t not 64 bits");
+#endif
+
 /* Dos Error Codes */
 #define DOSERR_NONE 0
 #define DOSERR_FUNCTION_NUMBER_INVALID 1

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -273,21 +273,6 @@ static inline uint16_t long2para(uint32_t size) {
 	else return (uint16_t)(size>>4);
 }
 
-/* Large file support */
-#if defined(_MSC_VER)
-	// MSVC doesn't support the posix fstream functions,
-	// typedef their equivalents
-	#define ftello _ftelli64
-	#define fseeko _fseeki64
-	#define off_t __int64
-#else
-	// All other platforms should have POSIX fstream 'o' support
-	// Note: Meson automatically sets preprocessor defines for us
-
-	// Check that off_t is 64 bits
-	static_assert(sizeof(off_t) == sizeof(int64_t), "off_t not 64 bits");
-#endif
-
 /* Dos Error Codes */
 #define DOSERR_NONE 0
 #define DOSERR_FUNCTION_NUMBER_INVALID 1

--- a/include/support.h
+++ b/include/support.h
@@ -230,6 +230,10 @@ using FILE_unique_ptr = std::unique_ptr<FILE, FILE_closer>;
 // itself when it goes out of scope
 FILE_unique_ptr make_fopen(const char *fname, const char *mode);
 
+int64_t stdio_size_bytes(FILE* f);
+int64_t stdio_size_kb(FILE* f);
+int64_t stdio_num_sectors(FILE* f);
+
 const std_fs::path &GetExecutablePath();
 std_fs::path GetResourcePath(const std_fs::path &name);
 std_fs::path GetResourcePath(const std_fs::path &subdir, const std_fs::path &name);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -775,8 +775,8 @@ fatDrive::fatDrive(const char *sysFilename,
 	created_successfully = (diskfile != nullptr);
 	if (!created_successfully)
 		return;
-	fseeko(diskfile, 0L, SEEK_END);
-	filesize = (uint32_t)ftello(diskfile) / 1024L;
+	cross_fseeko(diskfile, 0L, SEEK_END);
+	filesize = (uint32_t)cross_ftello(diskfile) / 1024L;
 	is_hdd = (filesize > 2880);
 
 	/* Load disk image */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -775,8 +775,12 @@ fatDrive::fatDrive(const char *sysFilename,
 	created_successfully = (diskfile != nullptr);
 	if (!created_successfully)
 		return;
-	cross_fseeko(diskfile, 0L, SEEK_END);
-	filesize = (uint32_t)cross_ftello(diskfile) / 1024L;
+	const auto sz = stdio_size_kb(diskfile);
+	if (sz < 0) {
+		fclose(diskfile);
+		return;
+	}
+	filesize = check_cast<uint32_t>(sz);
 	is_hdd = (filesize > 2880);
 
 	/* Load disk image */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -775,8 +775,8 @@ fatDrive::fatDrive(const char *sysFilename,
 	created_successfully = (diskfile != nullptr);
 	if (!created_successfully)
 		return;
-	fseek(diskfile, 0L, SEEK_END);
-	filesize = (uint32_t)ftell(diskfile) / 1024L;
+	fseeko(diskfile, 0L, SEEK_END);
+	filesize = (uint32_t)ftello(diskfile) / 1024L;
 	is_hdd = (filesize > 2880);
 
 	/* Load disk image */

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -388,7 +388,7 @@ void IMGMOUNT::Run(void)
 				return;
 			}
 			fseeko(diskfile, 0L, SEEK_END);
-			uint32_t fcsize = (uint32_t)(ftello(diskfile) / 512L);
+			uint32_t fcsize = static_cast<uint32_t>(ftello(diskfile) / 512L);
 			uint8_t buf[512];
 			fseeko(diskfile, 0L, SEEK_SET);
 			if (fread(buf, sizeof(uint8_t), 512, diskfile) < 512) {
@@ -567,7 +567,7 @@ void IMGMOUNT::Run(void)
 			return;
 		}
 		fseeko(newDisk, 0L, SEEK_END);
-		uint32_t imagesize = (ftello(newDisk) / 1024);
+		uint32_t imagesize = static_cast<uint32_t>(ftello(newDisk) / 1024);
 		const bool hdd     = (imagesize > 2880);
 		// Seems to make sense to require a valid geometry..
 		if (hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -387,11 +387,16 @@ void IMGMOUNT::Run(void)
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 				return;
 			}
-			cross_fseeko(diskfile, 0L, SEEK_END);
-			uint32_t fcsize = static_cast<uint32_t>(cross_ftello(diskfile) / 512L);
+			const auto sz = stdio_num_sectors(diskfile);
+			if (sz < 0) {
+				fclose(diskfile);
+				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
+				return;
+			}
+			uint32_t fcsize = check_cast<uint32_t>(sz);
 			uint8_t buf[512];
-			cross_fseeko(diskfile, 0L, SEEK_SET);
-			if (fread(buf, sizeof(uint8_t), 512, diskfile) < 512) {
+			if (cross_fseeko(diskfile, 0L, SEEK_SET) != 0 || 
+				fread(buf, sizeof(uint8_t), 512, diskfile) < 512) {
 				fclose(diskfile);
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 				return;
@@ -566,8 +571,13 @@ void IMGMOUNT::Run(void)
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 			return;
 		}
-		cross_fseeko(newDisk, 0L, SEEK_END);
-		uint32_t imagesize = static_cast<uint32_t>(cross_ftello(newDisk) / 1024);
+		const auto sz = stdio_size_kb(newDisk);
+		if (sz < 0) {
+			fclose(newDisk);
+			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
+			return;
+		}
+		uint32_t imagesize = check_cast<uint32_t>(sz);
 		const bool hdd     = (imagesize > 2880);
 		// Seems to make sense to require a valid geometry..
 		if (hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -387,10 +387,10 @@ void IMGMOUNT::Run(void)
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 				return;
 			}
-			fseeko(diskfile, 0L, SEEK_END);
-			uint32_t fcsize = static_cast<uint32_t>(ftello(diskfile) / 512L);
+			cross_fseeko(diskfile, 0L, SEEK_END);
+			uint32_t fcsize = static_cast<uint32_t>(cross_ftello(diskfile) / 512L);
 			uint8_t buf[512];
-			fseeko(diskfile, 0L, SEEK_SET);
+			cross_fseeko(diskfile, 0L, SEEK_SET);
 			if (fread(buf, sizeof(uint8_t), 512, diskfile) < 512) {
 				fclose(diskfile);
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
@@ -566,8 +566,8 @@ void IMGMOUNT::Run(void)
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 			return;
 		}
-		fseeko(newDisk, 0L, SEEK_END);
-		uint32_t imagesize = static_cast<uint32_t>(ftello(newDisk) / 1024);
+		cross_fseeko(newDisk, 0L, SEEK_END);
+		uint32_t imagesize = static_cast<uint32_t>(cross_ftello(newDisk) / 1024);
 		const bool hdd     = (imagesize > 2880);
 		// Seems to make sense to require a valid geometry..
 		if (hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -387,10 +387,10 @@ void IMGMOUNT::Run(void)
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 				return;
 			}
-			fseek(diskfile, 0L, SEEK_END);
-			uint32_t fcsize = (uint32_t)(ftell(diskfile) / 512L);
+			fseeko(diskfile, 0L, SEEK_END);
+			uint32_t fcsize = (uint32_t)(ftello(diskfile) / 512L);
 			uint8_t buf[512];
-			fseek(diskfile, 0L, SEEK_SET);
+			fseeko(diskfile, 0L, SEEK_SET);
 			if (fread(buf, sizeof(uint8_t), 512, diskfile) < 512) {
 				fclose(diskfile);
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
@@ -566,8 +566,8 @@ void IMGMOUNT::Run(void)
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 			return;
 		}
-		fseek(newDisk, 0L, SEEK_END);
-		uint32_t imagesize = (ftell(newDisk) / 1024);
+		fseeko(newDisk, 0L, SEEK_END);
+		uint32_t imagesize = (ftello(newDisk) / 1024);
 		const bool hdd     = (imagesize > 2880);
 		// Seems to make sense to require a valid geometry..
 		if (hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -164,7 +164,7 @@ uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,v
 
 uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void *data)
 {
-	const cross_off_t bytenum = static_cast<cross_off_t>(sectnum) * sector_size;
+	const auto bytenum = check_cast<cross_off_t>(sectnum) * sector_size;
 
 	if (last_action == WRITE || bytenum != current_fpos) {
 		if (cross_fseeko(diskimg, bytenum, SEEK_SET) != 0) {
@@ -190,7 +190,7 @@ uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,
 
 
 uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void *data) {
-	cross_off_t bytenum = static_cast<cross_off_t>(sectnum) * sector_size;
+	const auto bytenum = check_cast<cross_off_t>(sectnum) * sector_size;
 
 	//LOG_MSG("Writing sectors to %ld at bytenum %d", sectnum, bytenum);
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -164,10 +164,10 @@ uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,v
 
 uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void *data)
 {
-	const uint32_t bytenum = sectnum * sector_size;
+	const off_t bytenum = static_cast<off_t>(sectnum) * sector_size;
 
 	if (last_action == WRITE || bytenum != current_fpos) {
-		if (fseek(diskimg, bytenum, SEEK_SET) != 0) {
+		if (fseeko(diskimg, bytenum, SEEK_SET) != 0) {
 			LOG_ERR("BIOSDISK: Could not seek to sector %u in file '%s': %s",
 			        sectnum, diskname, strerror(errno));
 			return 0xff;
@@ -190,16 +190,14 @@ uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,
 
 
 uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void *data) {
-	uint32_t bytenum;
-
-	bytenum = sectnum * sector_size;
+	off_t bytenum = static_cast<off_t>(sectnum) * sector_size;
 
 	//LOG_MSG("Writing sectors to %ld at bytenum %d", sectnum, bytenum);
 
 	if (last_action == READ || bytenum != current_fpos) {
-		if (fseek(diskimg, bytenum, SEEK_SET) != 0) {
-			LOG_ERR("BIOSDISK: Could not seek to byte %u in file '%s': %s",
-			        bytenum, diskname, strerror(errno));
+		if (fseeko(diskimg, bytenum, SEEK_SET) != 0) {
+			LOG_ERR("BIOSDISK: Could not seek to byte %lld in file '%s': %s",
+			        static_cast<long long int>(bytenum), diskname, strerror(errno));
 			return 0xff;
 		}
 	}

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -164,10 +164,10 @@ uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,v
 
 uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void *data)
 {
-	const off_t bytenum = static_cast<off_t>(sectnum) * sector_size;
+	const cross_off_t bytenum = static_cast<cross_off_t>(sectnum) * sector_size;
 
 	if (last_action == WRITE || bytenum != current_fpos) {
-		if (fseeko(diskimg, bytenum, SEEK_SET) != 0) {
+		if (cross_fseeko(diskimg, bytenum, SEEK_SET) != 0) {
 			LOG_ERR("BIOSDISK: Could not seek to sector %u in file '%s': %s",
 			        sectnum, diskname, strerror(errno));
 			return 0xff;
@@ -190,12 +190,12 @@ uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,
 
 
 uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void *data) {
-	off_t bytenum = static_cast<off_t>(sectnum) * sector_size;
+	cross_off_t bytenum = static_cast<cross_off_t>(sectnum) * sector_size;
 
 	//LOG_MSG("Writing sectors to %ld at bytenum %d", sectnum, bytenum);
 
 	if (last_action == READ || bytenum != current_fpos) {
-		if (fseeko(diskimg, bytenum, SEEK_SET) != 0) {
+		if (cross_fseeko(diskimg, bytenum, SEEK_SET) != 0) {
 			LOG_ERR("BIOSDISK: Could not seek to byte %lld in file '%s': %s",
 			        static_cast<long long int>(bytenum), diskname, strerror(errno));
 			return 0xff;


### PR DESCRIPTION
This PR enables large HDD disk images to be used with Dosbox-staging. It is similar to the large disk support in the fat32 testing branches, but I have taken a slightly different approach.

This PR does not implement IDE support for hard disks, nor does it enable FAT 32 support. It is sufficient to mount and boot large disk images using the `-fs none` option in `imgmount`.

@ThomasEricB you might be interested in testing this.