### PR TITLE
Let `DriveManager` own all filesystem and image mount objects

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 350
+          MAX_BUGS: 341
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -44,7 +44,7 @@ jobs:
             arch: x86_64
             sys: CLANG64
             cc: clang
-            max_warnings: 1
+            max_warnings: 0
             build_flags: -Denable_debugger=normal
 
           - name: Clang x86_64 +tests

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -84,8 +84,10 @@ void incrementFDD(void);
 
 #define MAX_DISK_IMAGES (2 + MAX_HDD_IMAGES)
 
-extern std::array<std::shared_ptr<imageDisk>, MAX_DISK_IMAGES> imageDiskList;
-extern std::array<std::shared_ptr<imageDisk>, MAX_SWAPPABLE_DISKS> diskSwap;
+// Merely pointers. The actual raw image objects backing these
+// arrays are owned are managed by the drive manager class.
+extern std::array<imageDisk*, MAX_DISK_IMAGES> imageDiskList;
+extern std::array<imageDisk*, MAX_SWAPPABLE_DISKS> diskSwap;
 
 extern uint16_t imgDTASeg; /* Real memory location of temporary DTA pointer for fat image disk access */
 extern RealPt imgDTAPtr; /* Real memory location of temporary DTA pointer for fat image disk access */

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -84,8 +84,8 @@ void incrementFDD(void);
 
 #define MAX_DISK_IMAGES (2 + MAX_HDD_IMAGES)
 
-// Merely pointers. The actual raw image objects backing these
-// arrays are owned are managed by the drive manager class.
+// Merely pointers. The actual raw image objects are managed by the drive
+// manager class.
 extern std::array<imageDisk*, MAX_DISK_IMAGES> imageDiskList;
 extern std::array<imageDisk*, MAX_SWAPPABLE_DISKS> diskSwap;
 

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -25,6 +25,7 @@
 #include "dosbox.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <type_traits>
 
@@ -98,7 +99,7 @@ enum { RETURN_EXIT=0,RETURN_CTRLC=1,RETURN_ABORT=2,RETURN_TSR=3};
 /* internal Dos Tables */
 
 extern DOS_File * Files[DOS_FILES];
-extern DOS_Drive * Drives[DOS_DRIVES];
+extern std::array<DOS_Drive*, DOS_DRIVES> Drives;
 extern DOS_Device * Devices[DOS_DEVICES];
 
 extern uint8_t dos_copybuf[0x10000];

--- a/include/drives.h
+++ b/include/drives.h
@@ -48,7 +48,7 @@ public:
 	using raw_images_t        = std::vector<std::unique_ptr<imageDisk>>;
 	struct DriveInfo {
 		filesystem_images_t disks = {};
-		uint16_t currentDisk      = 0;
+		uint16_t current_disk     = 0;
 	};
 	using drive_infos_t = std::array<DriveInfo, DOS_DRIVES>;
 
@@ -65,9 +65,9 @@ public:
 
 	static void CloseNumberedImage(const imageDisk* image_ptr);
 
-	static imageDisk* RegisterRawFddImage(FILE* img_file,
-	                                      const std::string& img_name,
-	                                      const uint32_t img_size_kb);
+	static imageDisk* RegisterRawFloppyImage(FILE* img_file,
+	                                         const std::string& img_name,
+	                                         const uint32_t img_size_kb);
 	static void CloseRawFddImages();
 
 	static void InitializeDrive(int drive);
@@ -81,8 +81,8 @@ public:
 	
 private:
 	static drive_infos_t drive_infos;
-	static raw_images_t numbered_images;
-	static raw_images_t raw_fdd_images;
+	static raw_images_t indexed_images;
+	static raw_images_t raw_floppy_images;
 	static uint8_t currentDrive;
 };
 

--- a/include/drives.h
+++ b/include/drives.h
@@ -44,8 +44,13 @@ class imageDisk; // forward declare
 
 class DriveManager {
 public:
-	using raw_images_t        = std::vector<std::unique_ptr<imageDisk>>;
 	using filesystem_images_t = std::vector<std::unique_ptr<DOS_Drive>>;
+	using raw_images_t        = std::vector<std::unique_ptr<imageDisk>>;
+	struct DriveInfo {
+		filesystem_images_t disks = {};
+		uint16_t currentDisk      = 0;
+	};
+	using drive_infos_t = std::array<DriveInfo, DOS_DRIVES>;
 
 	static std::vector<DOS_Drive*> AppendFilesystemImages(
 	        const int drive, filesystem_images_t& filesystem_images);
@@ -75,10 +80,7 @@ public:
 	static void Init(Section* sec);
 	
 private:
-	static struct DriveInfo {
-		filesystem_images_t disks = {};
-		uint16_t currentDisk = 0;
-	} driveInfos[DOS_DRIVES];
+	static drive_infos_t drive_infos;
 	static raw_images_t numbered_images;
 	static raw_images_t raw_fdd_images;
 	static uint8_t currentDrive;

--- a/include/drives.h
+++ b/include/drives.h
@@ -40,9 +40,31 @@ void VFILE_Register(const char *name,
                     const uint32_t size,
                     const char *dir);
 
+class imageDisk; // forward declare
+
 class DriveManager {
 public:
-	static void AppendDisk(int drive, DOS_Drive* disk);
+	using raw_images_t        = std::vector<std::unique_ptr<imageDisk>>;
+	using filesystem_images_t = std::vector<std::unique_ptr<DOS_Drive>>;
+
+	static std::vector<DOS_Drive*> AppendFilesystemImages(
+	        const int drive, filesystem_images_t& filesystem_images);
+
+	static DOS_Drive* RegisterFilesystemImage(
+	        const int drive, std::unique_ptr<DOS_Drive>&& filesystem_image);
+
+	static imageDisk* RegisterNumberedImage(FILE* img_file,
+	                                        const std::string& img_name,
+	                                        const uint32_t img_size_kb,
+	                                        const bool is_hdd);
+
+	static void CloseNumberedImage(const imageDisk* image_ptr);
+
+	static imageDisk* RegisterRawFddImage(FILE* img_file,
+	                                      const std::string& img_name,
+	                                      const uint32_t img_size_kb);
+	static void CloseRawFddImages();
+
 	static void InitializeDrive(int drive);
 	static int UnmountDrive(int drive);
 //	static void CycleDrive(bool pressed);
@@ -54,11 +76,12 @@ public:
 	
 private:
 	static struct DriveInfo {
-		std::vector<DOS_Drive*> disks = {};
-		int currentDisk = 0;
+		filesystem_images_t disks = {};
+		uint16_t currentDisk = 0;
 	} driveInfos[DOS_DRIVES];
-	
-	static int currentDrive;
+	static raw_images_t numbered_images;
+	static raw_images_t raw_fdd_images;
+	static uint8_t currentDrive;
 };
 
 class localDrive : public DOS_Drive {

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1063,9 +1063,9 @@ bool CDROM_Interface_Image::LoadIsoFile(char* filename)
 	tracks.clear();
 
 	// data track (track 1)
-	Track track;
-	bool error;
-	track.file = make_shared<BinaryFile>(filename, error);
+	Track track = {};
+	bool error  = false;
+	track.file  = make_shared<BinaryFile>(filename, error);
 
 	if (error) {
 		return false;
@@ -1402,7 +1402,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 		return false;
 	}
 
-	localDrive *ldp = dynamic_cast<localDrive*>(Drives[drive]);
+	const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
 	if (ldp) {
 		ldp->GetSystemFilename(tmp, fullname);
 		if (path_exists(tmp)) {

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1402,7 +1402,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 		return false;
 	}
 
-	const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
+	const auto ldp = dynamic_cast<localDrive*>(Drives.at(drive));
 	if (ldp) {
 		ldp->GetSystemFilename(tmp, fullname);
 		if (path_exists(tmp)) {

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1379,7 +1379,7 @@ static Bitu DOS_27Handler(void) {
 
 static uint16_t DOS_SectorAccess(const bool read)
 {
-	const auto drive = dynamic_cast<fatDrive*>(Drives[reg_al]);
+	const auto drive = dynamic_cast<fatDrive*>(Drives.at(reg_al));
 	assert(drive);
 
 	auto bufferSeg = SegValue(ds);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -365,13 +365,7 @@ static Bitu DOS_21Handler(void) {
 			break;
 		};
 		break;
-	case 0x07:		/* Character Input, without echo */
-		{
-				uint8_t c;uint16_t n=1;
-				DOS_ReadFile (STDIN,&c,&n);
-				reg_al=c;
-				break;
-		};
+	case 0x07:              /* Character Input, without echo */
 	case 0x08:		/* Direct Character Input, without echo (checks for breaks officially :)*/
 		{
 				uint8_t c;uint16_t n=1;
@@ -1020,9 +1014,7 @@ static Bitu DOS_21Handler(void) {
 	case 0x50:					/* Set current PSP */
 		dos.psp(reg_bx);
 		break;
-	case 0x51:					/* Get current PSP */
-		reg_bx=dos.psp();
-		break;
+	// case 0x51: Get current PSP, co-located with case 0x62
 	case 0x52: {				/* Get list of lists */
 		uint8_t count=2; // floppy drives always counted
 		while (count<DOS_DRIVES && Drives[count] && !Drives[count]->isRemovable()) count++;
@@ -1195,7 +1187,9 @@ static Bitu DOS_21Handler(void) {
 			CALLBACK_SCF(true);
 		}
 		break;
-	case 0x62:					/* Get Current PSP Address */
+
+	case 0x51: /* Get Current PSP */
+	case 0x62: /* Get Current PSP Address */
 		reg_bx=dos.psp();
 		break;
 	case 0x63:					/* DOUBLE BYTE CHARACTER SET */
@@ -1385,7 +1379,9 @@ static Bitu DOS_27Handler(void) {
 
 static uint16_t DOS_SectorAccess(const bool read)
 {
-	auto drive = static_cast<fatDrive *>(Drives[reg_al]);
+	const auto drive = dynamic_cast<fatDrive*>(Drives[reg_al]);
+	assert(drive);
+
 	auto bufferSeg = SegValue(ds);
 	auto bufferOff = reg_bx;
 	auto sectorCnt = reg_cx;
@@ -1587,7 +1583,10 @@ public:
 		}
 	}
 	~DOS(){
-		for (uint16_t i = 0; i < DOS_DRIVES; i++)	delete Drives[i];
+		// Clear the driver pointers. The actual objects are managed by
+		// the drive manager class.
+		Drives.fill(nullptr);
+
 		// de-init devices, this allows DOSBox to cleanly re-initialize
 		// without throwing an inevitable `DOS: Too many devices added`
 		// exception

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -359,7 +359,7 @@ uint8_t DOS_FindDevice(const char* name)
 	if(name_part) {
 		*name_part++ = 0;
 		// Check validity of leading directory.
-		//  if(!Drives[drive]->TestDir(fullname))
+		//  if(!Drives.at(drive)->TestDir(fullname))
 		//      return DOS_DEVICES; //can be invalid
 	} else
 		name_part = fullname;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -45,8 +45,8 @@
 
 DOS_File* Files[DOS_FILES] = {};
 
-// Merely pointers. The actual filesystem and raw image objects backing these
-// drives are owned are managed by the drive manager class.
+// Merely pointers. The actual filesystem and raw image objects are managed by
+// the drive manager class.
 std::array<DOS_Drive*, DOS_DRIVES> Drives = {};
 
 uint8_t DOS_GetDefaultDrive(void) {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -61,7 +61,8 @@ void DOS_SetDefaultDrive(uint8_t drive) {
 	if (drive<DOS_DRIVES && ((drive<2) || Drives[drive])) {dos.current_drive = drive; DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(drive);}
 }
 
-bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive) {
+bool DOS_MakeName(const char* const name, char* const fullname, uint8_t* drive)
+{
 	if(!name || *name == 0 || *name == ' ') {
 		/* Both \0 and space are seperators and
 		 * empty filenames report file not found */
@@ -203,7 +204,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive)
 		}
 		tempdir[w++]=upname[r++];
 	}
-	return true;	
+	return true;
 }
 
 bool DOS_GetCurrentDir(uint8_t drive,char * const buffer) {
@@ -218,18 +219,21 @@ bool DOS_GetCurrentDir(uint8_t drive,char * const buffer) {
 }
 static bool PathExists(const char *name);
 
-bool DOS_ChangeDir(char const * const dir) {
+bool DOS_ChangeDir(const char* const dir)
+{
 	uint8_t drive;
 	char fulldir[DOS_PATHLENGTH];
 	const auto exists_and_set = DOS_MakeName(dir, fulldir, &drive) &&
-	                            Drives[drive]->TestDir(fulldir) &&
-	                            safe_strcpy(Drives[drive]->curdir, fulldir);
-	if (!exists_and_set)
+	                            Drives.at(drive)->TestDir(fulldir) &&
+	                            safe_strcpy(Drives.at(drive)->curdir, fulldir);
+	if (!exists_and_set) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
+	}
 	return exists_and_set;
 }
 
-bool DOS_MakeDir(char const * const dir) {
+bool DOS_MakeDir(const char* const dir)
+{
 	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	size_t len = strlen(dir);
 	if(!len || dir[len-1] == '\\') {
@@ -237,25 +241,28 @@ bool DOS_MakeDir(char const * const dir) {
 		return false;
 	}
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
-	if(Drives[drive]->MakeDir(fulldir)) return true;
+	if (Drives.at(drive)->MakeDir(fulldir)) {
+		return true;
+	}
 
 	/* Determine reason for failing */
-	if(Drives[drive]->TestDir(fulldir)) 
+	if (Drives.at(drive)->TestDir(fulldir)) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
-	else
+	} else
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 	return false;
 }
 
-bool DOS_RemoveDir(char const * const dir) {
-/* We need to do the test before the removal as can not rely on
- * the host to forbid removal of the current directory.
- * We never change directory. Everything happens in the drives.
- */
+bool DOS_RemoveDir(const char* const dir)
+{
+	/* We need to do the test before the removal as can not rely on
+	 * the host to forbid removal of the current directory.
+	 * We never change directory. Everything happens in the drives.
+	 */
 	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
 	/* Check if exists */
-	if(!Drives[drive]->TestDir(fulldir)) {
+	if (!Drives.at(drive)->TestDir(fulldir)) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}
@@ -267,7 +274,9 @@ bool DOS_RemoveDir(char const * const dir) {
 		return false;
 	}
 
-	if(Drives[drive]->RemoveDir(fulldir)) return true;
+	if (Drives.at(drive)->RemoveDir(fulldir)) {
+		return true;
+	}
 
 	/* Failed. We know it exists and it's not the current dir */
 	/* Assume non empty */
@@ -275,7 +284,8 @@ bool DOS_RemoveDir(char const * const dir) {
 	return false;
 }
 
-static bool PathExists(char const * const name) {
+static bool PathExists(const char* const name)
+{
 	const char* leading = strrchr(name,'\\');
 	if(!leading) return true;
 	char temp[CROSS_LEN];
@@ -285,11 +295,14 @@ static bool PathExists(char const * const name) {
 	*lead = 0;
 	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	if (!DOS_MakeName(temp,fulldir,&drive)) return false;
-	if(!Drives[drive]->TestDir(fulldir)) return false;
+	if (!Drives.at(drive)->TestDir(fulldir)) {
+		return false;
+	}
 	return true;
 }
 
-bool DOS_Rename(char const * const oldname,char const * const newname) {
+bool DOS_Rename(const char* const oldname, const char* const newname)
+{
 	uint8_t driveold;char fullold[DOS_PATHLENGTH];
 	uint8_t drivenew;char fullnew[DOS_PATHLENGTH];
 	if (!DOS_MakeName(oldname,fullold,&driveold)) return false;
@@ -307,18 +320,20 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 	}
 	/*Test if target exists => no access */
 	uint16_t attr;
-	if(Drives[drivenew]->GetFileAttr(fullnew,&attr)) {
+	if (Drives.at(drivenew)->GetFileAttr(fullnew, &attr)) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
 	/* Source must exist */
-	if (!Drives[driveold]->GetFileAttr( fullold, &attr ) ) {
+	if (!Drives.at(driveold)->GetFileAttr(fullold, &attr)) {
 		if (!PathExists(oldname)) DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		else DOS_SetError(DOSERR_FILE_NOT_FOUND);
 		return false;
 	}
 
-	if (Drives[drivenew]->Rename(fullold,fullnew)) return true;
+	if (Drives.at(drivenew)->Rename(fullold, fullnew)) {
+		return true;
+	}
 	/* Rename failed despite checks => no access */
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
@@ -367,9 +382,11 @@ bool DOS_FindFirst(const char *search, uint16_t attr, bool fcb_findfirst)
 		LOG(LOG_DOSMISC,LOG_WARN)("finding device %s",pattern);
 		return true;
 	}
-   
-	if (Drives[drive]->FindFirst(dir,dta,fcb_findfirst)) return true;
-	
+
+	if (Drives.at(drive)->FindFirst(dir, dta, fcb_findfirst)) {
+		return true;
+	}
+
 	return false;
 }
 
@@ -485,7 +502,8 @@ bool DOS_FlushFile(uint16_t entry) {
 	return true;
 }
 
-bool DOS_CreateFile(char const * name,uint16_t attributes,uint16_t * entry,bool fcb) {
+bool DOS_CreateFile(const char* name, uint16_t attributes, uint16_t* entry, bool fcb)
+{
 	// Creation of a device is the same as opening it
 	// Tc201 installer
 	if (DOS_FindDevice(name) != DOS_DEVICES)
@@ -524,7 +542,7 @@ bool DOS_CreateFile(char const * name,uint16_t attributes,uint16_t * entry,bool 
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
-	bool foundit=Drives[drive]->FileCreate(&Files[handle],fullname,attributes);
+	bool foundit = Drives.at(drive)->FileCreate(&Files[handle], fullname, attributes);
 	if (foundit) { 
 		Files[handle]->SetDrive(drive);
 		Files[handle]->AddRef();
@@ -537,7 +555,8 @@ bool DOS_CreateFile(char const * name,uint16_t attributes,uint16_t * entry,bool 
 	}
 }
 
-bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
+bool DOS_OpenFile(const char* name, uint8_t flags, uint16_t* entry, bool fcb)
+{
 	/* First check for devices */
 	if (flags>2) LOG(LOG_FILES,LOG_ERROR)("Special file open command %X file %s",flags,name);
 	else LOG(LOG_FILES,LOG_NORMAL)("file open command %X file %s",flags,name);
@@ -586,7 +605,7 @@ bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 	} else {
 		const auto old_errorcode = dos.errorcode;
 		dos.errorcode = 0;
-		exists = Drives[drive]->FileOpen(&Files[handle], fullname, flags);
+		exists = Drives.at(drive)->FileOpen(&Files[handle], fullname, flags);
 		if (exists)
 			Files[handle]->SetDrive(drive);
 		if (dos.errorcode == DOSERR_ACCESS_CODE_INVALID)
@@ -599,9 +618,10 @@ bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 		return true;
 	} else {
 		//Test if file exists, but opened in read-write mode (and writeprotected)
-		if(((flags&3) != OPEN_READ) && Drives[drive]->FileExists(fullname))
+		if (((flags & 3) != OPEN_READ) &&
+		    Drives.at(drive)->FileExists(fullname)) {
 			DOS_SetError(DOSERR_ACCESS_DENIED);
-		else {
+		} else {
 			if(!PathExists(name)) DOS_SetError(DOSERR_PATH_NOT_FOUND); 
 			else DOS_SetError(DOSERR_FILE_NOT_FOUND);
 		}
@@ -609,8 +629,10 @@ bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 	}
 }
 
-bool DOS_OpenFileExtended(char const * name, uint16_t flags, uint16_t createAttr, uint16_t action, uint16_t *entry, uint16_t* status) {
-// FIXME: Not yet supported : Bit 13 of flags (int 0x24 on critical error)
+bool DOS_OpenFileExtended(const char* name, uint16_t flags, uint16_t createAttr,
+                          uint16_t action, uint16_t* entry, uint16_t* status)
+{
+	// FIXME: Not yet supported : Bit 13 of flags (int 0x24 on critical error)
 	uint16_t result = 0;
 	if (action==0) {
 		// always fail setting
@@ -660,7 +682,8 @@ bool DOS_OpenFileExtended(char const * name, uint16_t flags, uint16_t createAttr
 	return true;
 }
 
-bool DOS_UnlinkFile(char const * const name) {
+bool DOS_UnlinkFile(const char* const name)
+{
 	char fullname[DOS_PATHLENGTH];
 	uint8_t drive;
 
@@ -676,16 +699,16 @@ bool DOS_UnlinkFile(char const * const name) {
 		return false;
 	}
 
-	return Drives[drive]->FileUnlink(fullname);
+	return Drives.at(drive)->FileUnlink(fullname);
 }
 
-bool DOS_GetFileAttr(char const *const name, uint16_t *attr)
+bool DOS_GetFileAttr(const char* const name, uint16_t* attr)
 {
 	char fullname[DOS_PATHLENGTH];
 	uint8_t drive;
 	if (!DOS_MakeName(name, fullname, &drive))
 		return false;
-	if (Drives[drive]->GetFileAttr(fullname, attr)) {
+	if (Drives.at(drive)->GetFileAttr(fullname, attr)) {
 		return true;
 	} else {
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
@@ -693,7 +716,7 @@ bool DOS_GetFileAttr(char const *const name, uint16_t *attr)
 	}
 }
 
-bool DOS_SetFileAttr(char const *const name, uint16_t attr)
+bool DOS_SetFileAttr(const char* const name, uint16_t attr)
 {
 	char fullname[DOS_PATHLENGTH];
 	uint8_t drive;
@@ -706,7 +729,7 @@ bool DOS_SetFileAttr(char const *const name, uint16_t attr)
 	}
 
 	uint16_t old_attr;
-	if (!Drives[drive]->GetFileAttr(fullname, &old_attr)) {
+	if (!Drives.at(drive)->GetFileAttr(fullname, &old_attr)) {
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
 		return false;
 	}
@@ -722,11 +745,13 @@ bool DOS_SetFileAttr(char const *const name, uint16_t attr)
 	/* define what cannot be changed */
 	const uint16_t attr_mask = (DOS_ATTR_VOLUME | DOS_ATTR_DIRECTORY);
 	attr = (attr & ~attr_mask) | (old_attr & attr_mask);
-	return Drives[drive]->SetFileAttr(fullname, attr);
+	return Drives.at(drive)->SetFileAttr(fullname, attr);
 }
 
-bool DOS_Canonicalize(char const * const name,char * const big) {
-//TODO Add Better support for devices and shit but will it be needed i doubt it :) 
+bool DOS_Canonicalize(const char* const name, char* const big)
+{
+	// TODO Add Better support for devices and shit but will it be needed i
+	// doubt it :) 
 	uint8_t drive;
 	char fullname[DOS_PATHLENGTH];
 	if (!DOS_MakeName(name,fullname,&drive)) return false;
@@ -1367,11 +1392,11 @@ void DOS_FCBSetRandomRecord(uint16_t seg, uint16_t offset) {
 	fcb.SetRandom(block*128+rec);
 }
 
-
-bool DOS_FileExists(char const * const name) {
+bool DOS_FileExists(const char* const name)
+{
 	char fullname[DOS_PATHLENGTH];uint8_t drive;
 	if (!DOS_MakeName(name,fullname,&drive)) return false;
-	return Drives[drive]->FileExists(fullname);
+	return Drives.at(drive)->FileExists(fullname);
 }
 
 bool DOS_GetAllocationInfo(uint8_t drive,uint16_t * _bytes_sector,uint8_t * _sectors_cluster,uint16_t * _total_clusters) {
@@ -1389,7 +1414,7 @@ bool DOS_GetAllocationInfo(uint8_t drive,uint16_t * _bytes_sector,uint8_t * _sec
 }
 
 bool DOS_SetDrive(uint8_t drive) {
-	if (Drives[drive]) {
+	if (Drives.at(drive)) {
 		DOS_SetDefaultDrive(drive);
 		return true;
 	} else {
@@ -1444,6 +1469,6 @@ void DOS_SetupFiles()
 
 	const auto z_drive_index = drive_index('Z');
 
-	Drives[z_drive_index] = DriveManager::RegisterFilesystemImage(
+	Drives.at(z_drive_index) = DriveManager::RegisterFilesystemImage(
 	        z_drive_index, std::make_unique<Virtual_Drive>());
 }

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -52,7 +52,7 @@ static FILE_unique_ptr open_layout_file(const char *name, const char *resource_d
 	char fullname[DOS_PATHLENGTH] = {};
 	if (DOS_MakeName(name, fullname, &drive)) try {
 		// try to open file on mounted drive first
-		const auto ldp = dynamic_cast<localDrive *>(Drives[drive]);
+		const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
 		if (ldp) {
 			if (const auto fp = ldp->GetSystemFilePtr(fullname, file_perms); fp) {
 				return FILE_unique_ptr(fp);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -452,7 +452,10 @@ bool fatDrive::getEntryName(char *fullname, char *entname) {
 	return true;
 }
 
-bool fatDrive::getFileDirEntry(char const * const filename, direntry * useEntry, uint32_t * dirClust, uint32_t * subEntry, const bool dir_ok) {
+bool fatDrive::getFileDirEntry(const char* const filename, direntry* useEntry,
+                               uint32_t* dirClust, uint32_t* subEntry,
+                               const bool dir_ok)
+{
 	size_t len = strnlen(filename, DOS_PATHLENGTH);
 	char dirtoken[DOS_PATHLENGTH];
 	uint32_t currentClust = 0;
@@ -781,7 +784,7 @@ fatDrive::fatDrive(const char *sysFilename,
 		return;
 	}
 	filesize = check_cast<uint32_t>(sz);
-	is_hdd = (filesize > 2880);
+	is_hdd   = (filesize > 2880);
 
 	/* Load disk image */
 	loadedDisk.reset(new imageDisk(diskfile, sysFilename, filesize, is_hdd));
@@ -1003,8 +1006,8 @@ uint32_t fatDrive::getFirstFreeClust(void) {
 bool fatDrive::isRemote(void) {	return false; }
 bool fatDrive::isRemovable(void) { return false; }
 
-Bits fatDrive::UnMount(void) {
-	delete this;
+Bits fatDrive::UnMount()
+{
 	return 0;
 }
 

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -390,12 +390,9 @@ bool isoDrive::isRemovable(void) {
 	return true;
 }
 
-Bits isoDrive::UnMount(void) {
-	if(MSCDEX_RemoveDrive(driveLetter)) {
-		delete this;
-		return 0;
-	}
-	return 2;
+Bits isoDrive::UnMount()
+{
+	return MSCDEX_RemoveDrive(driveLetter) ? 0 : 2;
 }
 
 int isoDrive::GetDirIterator(const isoDirEntry* de) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -594,9 +594,9 @@ bool localDrive::isRemovable(void) {
 	return false;
 }
 
-Bits localDrive::UnMount(void) { 
-	delete this;
-	return 0; 
+Bits localDrive::UnMount()
+{
+	return 0;
 }
 
 localDrive::localDrive(const char* startdir, uint16_t _bytes_sector,
@@ -986,7 +986,6 @@ bool cdromDrive::isRemovable(void) {
 
 Bits cdromDrive::UnMount(void) {
 	if (MSCDEX_RemoveDrive(driveLetter)) {
-		delete this;
 		return 0;
 	}
 	return 2;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -282,10 +282,13 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	if (allocation.mediaid==0xF0) {
 		EmptyCache(); //rescan floppie-content on each findfirst
 	}
-    
-	char end[2]={CROSS_FILESPLIT,0};
-	if (tempDir[strlen(tempDir) - 1] != CROSS_FILESPLIT)
+
+	// End the temp directory with a slash
+	const auto temp_dir_len = strlen(tempDir);
+	if (temp_dir_len < 1 || tempDir[temp_dir_len - 1] != CROSS_FILESPLIT) {
+		constexpr char end[] = {CROSS_FILESPLIT, '\0'};
 		safe_strcat(tempDir, end);
+	}
 
 	uint16_t id;
 	if (!dirCache.FindFirst(tempDir,id)) {

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -230,7 +230,7 @@ public:
 //Create leading directories of a file being overlayed if they exist in the original (localDrive).
 //This function is used to create copies of existing files, so all leading directories exist in the original.
 
-FILE *Overlay_Drive::create_file_in_overlay(const char *dos_filename, char const *mode)
+FILE* Overlay_Drive::create_file_in_overlay(const char* dos_filename, const char* mode)
 {
 	if (logoverlay) LOG_MSG("create_file_in_overlay called %s %s",dos_filename,mode);
 	char newname[CROSS_LEN];

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -298,7 +298,7 @@ bool OverlayFile::create_copy() {
 	FILE* newhandle = NULL;
 	uint8_t drive_set = GetDrive();
 	if (drive_set != 0xff && drive_set < DOS_DRIVES && Drives[drive_set]){
-		Overlay_Drive* od = dynamic_cast<Overlay_Drive*>(Drives[drive_set]);
+		const auto od = dynamic_cast<Overlay_Drive*>(Drives[drive_set]);
 		if (od) {
 			newhandle = od->create_file_in_overlay(GetName(),"wb+"); //todo check wb+
 		}
@@ -685,15 +685,24 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 #endif
 
 			std::string backupi(*i);
+
+			auto maybe_add_path = [&]() {
+				if ((safe_strlen(dir_name) > prefix_lengh + 5) &&
+				    strncmp(dir_name,
+				            special_prefix.c_str(),
+				            prefix_lengh) == 0) {
+					specials.emplace_back(string(dirpush) + dir_name);
+				} else if (is_directory) {
+					dirnames.emplace_back(string(dirpush) + dir_name);
+				} else {
+					filenames.emplace_back(string(dirpush) + dir_name);
+				}
+			};
 			// Read complete directory
 			if (read_directory_first(dirp, dir_name, is_directory)) {
-				if ((safe_strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(string(dirpush)+dir_name);
-				else if (is_directory) dirnames.push_back(string(dirpush)+dir_name);
-				else filenames.push_back(string(dirpush)+dir_name);
+				maybe_add_path();
 				while (read_directory_next(dirp, dir_name, is_directory)) {
-					if ((safe_strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(string(dirpush)+dir_name);
-					else if (is_directory) dirnames.push_back(string(dirpush)+dir_name);
-					else filenames.push_back(string(dirpush)+dir_name);
+					maybe_add_path();
 				}
 			}
 			close_directory(dirp);
@@ -1287,10 +1296,11 @@ bool Overlay_Drive::FileStat(const char* name, FileStat_Block * const stat_block
 	return true;
 }
 
-Bits Overlay_Drive::UnMount(void) { 
-	delete this;
-	return 0; 
+Bits Overlay_Drive::UnMount()
+{
+	return 0;
 }
+
 void Overlay_Drive::EmptyCache(void){
 	localDrive::EmptyCache();
 	update_cache(true);//lets rebuild it.

--- a/src/dos/program_biostest.cpp
+++ b/src/dos/program_biostest.cpp
@@ -44,7 +44,7 @@ void BIOSTEST::Run(void) {
 
 	try {
 		// try to read ROM file into buffer
-		ldp = dynamic_cast<localDrive *>(Drives[drive]);
+		ldp = dynamic_cast<localDrive*>(Drives.at(drive));
 		if (!ldp)
 			return;
 

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -50,7 +50,7 @@ FILE* BOOT::getFSFile_mounted(const char* filename, uint32_t* ksize,
 		return NULL;
 
 	try {
-		const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
+		const auto ldp = dynamic_cast<localDrive*>(Drives.at(drive));
 		if (!ldp)
 			return NULL;
 
@@ -259,14 +259,14 @@ void BOOT::Run(void)
 
 	swapInDisks(0);
 
-	if (!imageDiskList[drive_index(drive)]) {
+	if (!imageDiskList.at(drive_index(drive))) {
 		WriteOut(MSG_Get("PROGRAM_BOOT_UNABLE"), drive);
 		return;
 	}
 
 	bootSector bootarea;
-	imageDiskList[drive_index(drive)]->Read_Sector(
-	        0, 0, 1, reinterpret_cast<uint8_t *>(&bootarea));
+	imageDiskList.at(drive_index(drive))
+	        ->Read_Sector(0, 0, 1, reinterpret_cast<uint8_t*>(&bootarea));
 	if ((bootarea.rawdata[0] == 0x50) && (bootarea.rawdata[1] == 0x43) &&
 	    (bootarea.rawdata[2] == 0x6a) && (bootarea.rawdata[3] == 0x72)) {
 		if (machine != MCH_PCJR) {

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -240,7 +240,8 @@ void BOOT::Run(void)
 			FILE *usefile = getFSFile(temp_line.c_str(),
 			                          &floppysize, &rombytesize);
 			if (usefile != NULL) {
-				diskSwap[i] = DriveManager::RegisterRawFddImage(usefile, temp_line, floppysize);
+				diskSwap[i] = DriveManager::RegisterRawFloppyImage(
+				        usefile, temp_line, floppysize);
 				if (usefile_1 == NULL) {
 					usefile_1 = usefile;
 					rombytesize_1 = rombytesize;

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -125,6 +125,7 @@ static bool add_wildcard_paths(const std::string& path_arg,
 	return true;
 }
 
+// This function desparately needs to be refactored into type-specific mounters
 void IMGMOUNT::Run(void)
 {
 	// Hack To allow long commandlines
@@ -184,9 +185,9 @@ void IMGMOUNT::Run(void)
 
 	uint16_t sizes[4]  = {0};
 	bool imgsizedetect = false;
+	const uint8_t mediaid = (type == "floppy") ? 0xF0 : 0xF8; // all others
 
 	std::string str_size = "";
-	uint8_t mediaid      = 0xF8;
 
 	// Possibly used to hold the IDE channel and drive slot for CDROM types
 	std::string ide_value     = {};
@@ -195,14 +196,10 @@ void IMGMOUNT::Run(void)
 	const bool wants_ide      = cmd->FindString("-ide", ide_value, true) ||
 	                       cmd->FindExist("-ide", true);
 
-	if (type == "floppy") {
-		mediaid = 0xF0;
-	} else if (type == "iso") {
+	if (type == "iso") {
 		// str_size="2048,1,65535,0";	// ignored, see drive_iso.cpp
 		// (AllocationInfo)
-		mediaid = 0xF8;
-		fstype  = "iso";
-
+		fstype = "iso";
 		if (wants_ide) {
 			IDE_Get_Next_Cable_Slot(ide_index, is_second_cable_slot);
 		}
@@ -319,9 +316,8 @@ void IMGMOUNT::Run(void)
 					return;
 				}
 
-				localDrive* ldp = dynamic_cast<localDrive*>(
-				        Drives[dummy]);
-				if (ldp == NULL) {
+				const auto ldp = dynamic_cast<localDrive*>(Drives[dummy]);
+				if (ldp == nullptr) {
 					WriteOut(MSG_Get(
 					        "PROGRAM_IMGMOUNT_FILE_NOT_FOUND"));
 					return;
@@ -428,37 +424,31 @@ void IMGMOUNT::Run(void)
 			return;
 		}
 
-		std::vector<DOS_Drive*> imgDisks;
-		std::vector<std::string>::size_type i;
-		std::vector<DOS_Drive*>::size_type ct;
+		DriveManager::filesystem_images_t fat_images = {};
 
-		for (i = 0; i < paths.size(); i++) {
-			std::unique_ptr<fatDrive> newDrive(
-			        new fatDrive(paths[i].c_str(),
-			                     sizes[0],
-			                     sizes[1],
-			                     sizes[2],
-			                     sizes[3],
-			                     0,
-			                     roflag));
-
-			if (newDrive->created_successfully) {
-				imgDisks.push_back(static_cast<DOS_Drive*>(
-				        newDrive.release()));
+		for (const auto& fat_path : paths) {
+			auto fat_image = std::make_unique<fatDrive>(fat_path.c_str(),
+			                                            sizes[0],
+			                                            sizes[1],
+			                                            sizes[2],
+			                                            sizes[3],
+			                                            0,
+			                                            roflag);
+			if (fat_image->created_successfully) {
+				fat_images.emplace_back(std::move(fat_image));
 			} else {
-				// Tear-down all prior drives when we hit a problem
 				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE"));
-				for (auto pImgDisk : imgDisks) {
-					delete pImgDisk;
-				}
 				return;
 			}
 		}
+		if (fat_images.empty()) {
+			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE"));
+			return;
+		}
 
 		// Update DriveManager
-		for (ct = 0; ct < imgDisks.size(); ct++) {
-			DriveManager::AppendDisk(drive_index(drive), imgDisks[ct]);
-		}
+		const auto fat_pointers = DriveManager::AppendFilesystemImages(
+		        drive_index(drive), fat_images);
 		DriveManager::InitializeDrive(drive_index(drive));
 
 		// Set the correct media byte in the table
@@ -469,9 +459,9 @@ void IMGMOUNT::Run(void)
 		RealPt save_dta = dos.dta();
 		dos.dta(dos.tables.tempdta);
 
-		for (ct = 0; ct < imgDisks.size(); ct++) {
-			const bool notify = (ct == (imgDisks.size() - 1));
-			DriveManager::CycleDisks(drive_index(drive), notify);
+		for (auto it = fat_pointers.begin(); it != fat_pointers.end(); ++it) {
+			const bool should_notify = std::next(it) == fat_pointers.end();
+			DriveManager::CycleDisks(drive_index(drive), should_notify);
 			char root[7] = {drive, ':', '\\', '*', '.', '*', 0};
 			DOS_FindFirst(root, DOS_ATTR_VOLUME); // force obtaining
 			                                      // the label and
@@ -481,13 +471,16 @@ void IMGMOUNT::Run(void)
 		dos.dta(save_dta);
 
 		write_out_mount_status(MSG_Get("MOUNT_TYPE_FAT"), paths, drive);
-		auto newdrive = static_cast<fatDrive*>(imgDisks[0]);
-		assert(newdrive);
-		if (('A' <= drive && drive <= 'B' &&
-		     !(newdrive->loadedDisk->hardDrive)) ||
-		    ('C' <= drive && drive <= 'D' && newdrive->loadedDisk->hardDrive)) {
-			const size_t idx   = drive_index(drive);
-			imageDiskList[idx] = newdrive->loadedDisk;
+
+		const auto fat_image = dynamic_cast<fatDrive*>(fat_pointers.front());
+		assert(fat_image);
+		const auto has_hdd = fat_image->loadedDisk &&
+		                     fat_image->loadedDisk->hardDrive;
+
+		const auto is_floppy = (drive == 'A' || drive == 'B') && !has_hdd;
+		const auto is_hdd = (drive == 'C' || drive == 'D') && has_hdd;
+		if (is_floppy || is_hdd) {
+			imageDiskList[drive_index(drive)] = fat_image->loadedDisk.get();
 			updateDPT();
 		}
 	} else if (fstype == "iso") {
@@ -498,16 +491,14 @@ void IMGMOUNT::Run(void)
 
 		MSCDEX_SetCDInterface(CDROM_USE_SDL, -1);
 		// create new drives for all images
-		std::vector<DOS_Drive*> isoDisks;
-		std::vector<std::string>::size_type i;
-		std::vector<DOS_Drive*>::size_type ct;
-		for (i = 0; i < paths.size(); i++) {
-			int error           = -1;
-			DOS_Drive* newDrive = new isoDrive(drive,
-			                                   paths[i].c_str(),
-			                                   mediaid,
-			                                   error);
-			isoDisks.push_back(newDrive);
+		DriveManager::filesystem_images_t iso_images = {};
+		for (const auto& iso_path : paths) {
+			int error = -1;
+
+			auto iso_image = std::make_unique<isoDrive>(
+			        drive, iso_path.c_str(), mediaid, error);
+
+			iso_images.emplace_back(std::move(iso_image));
 			switch (error) {
 			case 0: break;
 			case 1:
@@ -532,16 +523,13 @@ void IMGMOUNT::Run(void)
 			}
 			// error: clean up and leave
 			if (error) {
-				for (ct = 0; ct < isoDisks.size(); ct++) {
-					delete isoDisks[ct];
-				}
+				WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE"));
 				return;
 			}
 		}
 		// Update DriveManager
-		for (ct = 0; ct < isoDisks.size(); ct++) {
-			DriveManager::AppendDisk(drive_index(drive), isoDisks[ct]);
-		}
+		(void)DriveManager::AppendFilesystemImages(drive_index(drive),
+		                                           iso_images);
 		DriveManager::InitializeDrive(drive_index(drive));
 
 		// Set the correct media byte in the table
@@ -578,31 +566,33 @@ void IMGMOUNT::Run(void)
 			return;
 		}
 		uint32_t imagesize = check_cast<uint32_t>(sz);
-		const bool hdd     = (imagesize > 2880);
+		const bool is_hdd  = (imagesize > 2880);
 		// Seems to make sense to require a valid geometry..
-		if (hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&
+		if (is_hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&
 		    sizes[3] == 0) {
 			fclose(newDisk);
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_GEOMETRY"));
 			return;
 		}
 
-		imageDisk* newImage = new imageDisk(newDisk,
-		                                    temp_line.c_str(),
-		                                    imagesize,
-		                                    hdd);
+		const auto drive_index = drive - '0';
 
-		if (hdd) {
-			newImage->Set_Geometry(sizes[2], sizes[3], sizes[1], sizes[0]);
+		imageDiskList[drive_index] = DriveManager::RegisterNumberedImage(
+		        newDisk, temp_line, imagesize, is_hdd);
+
+		if (is_hdd) {
+			imageDiskList[drive_index]->Set_Geometry(sizes[2],
+			                                         sizes[3],
+			                                         sizes[1],
+			                                         sizes[0]);
 		}
-		imageDiskList[drive - '0'].reset(newImage);
 
-		if ((drive == '2' || drive == '3') && hdd) {
+		if ((drive == '2' || drive == '3') && is_hdd) {
 			updateDPT();
 		}
 
 		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"),
-		         drive - '0',
+		         drive_index,
 		         temp_line.c_str());
 	}
 

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -557,14 +557,14 @@ void IMGMOUNT::Run(void)
 		write_out_mount_status(MSG_Get("MOUNT_TYPE_ISO"), paths, drive);
 
 	} else if (fstype == "none") {
-		FILE* newDisk = fopen_wrap_ro_fallback(temp_line, roflag);
-		if (!newDisk) {
+		FILE* new_disk = fopen_wrap_ro_fallback(temp_line, roflag);
+		if (!new_disk) {
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 			return;
 		}
-		const auto sz = stdio_size_kb(newDisk);
+		const auto sz = stdio_size_kb(new_disk);
 		if (sz < 0) {
-			fclose(newDisk);
+			fclose(new_disk);
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_IMAGE"));
 			return;
 		}
@@ -573,7 +573,7 @@ void IMGMOUNT::Run(void)
 		// Seems to make sense to require a valid geometry..
 		if (is_hdd && sizes[0] == 0 && sizes[1] == 0 && sizes[2] == 0 &&
 		    sizes[3] == 0) {
-			fclose(newDisk);
+			fclose(new_disk);
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_GEOMETRY"));
 			return;
 		}
@@ -581,7 +581,7 @@ void IMGMOUNT::Run(void)
 		const auto drive_index = drive - '0';
 
 		imageDiskList.at(drive_index) = DriveManager::RegisterNumberedImage(
-		        newDisk, temp_line, imagesize, is_hdd);
+		        new_disk, temp_line, imagesize, is_hdd);
 
 		if (is_hdd) {
 			imageDiskList.at(drive_index)

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -310,13 +310,15 @@ void IMGMOUNT::Run(void)
 					        "PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE"));
 					return;
 				}
-				if (Drives[dummy]->GetType() != DosDriveType::Local) {
+				if (Drives.at(dummy)->GetType() !=
+				    DosDriveType::Local) {
 					WriteOut(MSG_Get(
 					        "PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE"));
 					return;
 				}
 
-				const auto ldp = dynamic_cast<localDrive*>(Drives[dummy]);
+				const auto ldp = dynamic_cast<localDrive*>(
+				        Drives.at(dummy));
 				if (ldp == nullptr) {
 					WriteOut(MSG_Get(
 					        "PROGRAM_IMGMOUNT_FILE_NOT_FOUND"));
@@ -419,7 +421,7 @@ void IMGMOUNT::Run(void)
 			        sizes[3]);
 		}
 
-		if (Drives[drive_index(drive)]) {
+		if (Drives.at(drive_index(drive))) {
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_ALREADY_MOUNTED"));
 			return;
 		}
@@ -480,11 +482,12 @@ void IMGMOUNT::Run(void)
 		const auto is_floppy = (drive == 'A' || drive == 'B') && !has_hdd;
 		const auto is_hdd = (drive == 'C' || drive == 'D') && has_hdd;
 		if (is_floppy || is_hdd) {
-			imageDiskList[drive_index(drive)] = fat_image->loadedDisk.get();
+			imageDiskList.at(
+			        drive_index(drive)) = fat_image->loadedDisk.get();
 			updateDPT();
 		}
 	} else if (fstype == "iso") {
-		if (Drives[drive_index(drive)]) {
+		if (Drives.at(drive_index(drive))) {
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_ALREADY_MOUNTED"));
 			return;
 		}
@@ -577,14 +580,12 @@ void IMGMOUNT::Run(void)
 
 		const auto drive_index = drive - '0';
 
-		imageDiskList[drive_index] = DriveManager::RegisterNumberedImage(
+		imageDiskList.at(drive_index) = DriveManager::RegisterNumberedImage(
 		        newDisk, temp_line, imagesize, is_hdd);
 
 		if (is_hdd) {
-			imageDiskList[drive_index]->Set_Geometry(sizes[2],
-			                                         sizes[3],
-			                                         sizes[1],
-			                                         sizes[0]);
+			imageDiskList.at(drive_index)
+			        ->Set_Geometry(sizes[2], sizes[3], sizes[1], sizes[0]);
 		}
 
 		if ((drive == '2' || drive == '3') && is_hdd) {

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -42,13 +42,14 @@ void LOADROM::Run(void) {
     }
     uint8_t drive;
     char fullname[DOS_PATHLENGTH];
-    localDrive* ldp=0;
     if (!DOS_MakeName((char *)temp_line.c_str(),fullname,&drive)) return;
 
     try {
         /* try to read ROM file into buffer */
-        ldp=dynamic_cast<localDrive*>(Drives[drive]);
-        if (!ldp) return;
+		const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
+		if (!ldp) {
+			return;
+		}
 
         FILE *tmpfile = ldp->GetSystemFilePtr(fullname, "rb");
         if (tmpfile == NULL) {

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -46,9 +46,9 @@ void LOADROM::Run(void) {
 
     try {
         /* try to read ROM file into buffer */
-		const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
-		if (!ldp) {
-			return;
+	const auto ldp = dynamic_cast<localDrive*>(Drives.at(drive));
+	if (!ldp) {
+		return;
 		}
 
         FILE *tmpfile = ldp->GetSystemFilePtr(fullname, "rb");

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -249,14 +249,14 @@ void MOUNT::Run(void) {
 		drive = int_to_char(i_drive);
 		if (type == "overlay") {
 			//Ensure that the base drive exists:
-			if (!Drives[drive_index(drive)]) {
+			if (!Drives.at(drive_index(drive))) {
 				WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_NO_BASE"));
 				return;
 			}
-		} else if (Drives[drive_index(drive)]) {
+		} else if (Drives.at(drive_index(drive))) {
 			WriteOut(MSG_Get("PROGRAM_MOUNT_ALREADY_MOUNTED"),
 			         drive,
-			         Drives[drive_index(drive)]->GetInfoString().c_str());
+			         Drives.at(drive_index(drive))->GetInfoString().c_str());
 			return;
 		}
 
@@ -390,7 +390,7 @@ void MOUNT::Run(void) {
 					safe_strcpy(newdrive->curdir,
 								ldp->curdir);
 				}
-				Drives[drive_index(drive)] = nullptr;
+				Drives.at(drive_index(drive)) = nullptr;
 			} else {
 				newdrive = std::make_unique<localDrive>(
 				        temp_line.c_str(),
@@ -410,7 +410,7 @@ void MOUNT::Run(void) {
 
 	drive_pointer = DriveManager::RegisterFilesystemImage(drive_index(drive),
 	                                                      std::move(newdrive));
-	Drives[drive_index(drive)] = drive_pointer;
+	Drives.at(drive_index(drive)) = drive_pointer;
 
 	/* Set the correct media byte in the table */
 	mem_writeb(Real2Phys(dos.tables.mediaid) + (drive_index(drive)) * 9,

--- a/src/dos/program_mount_common.cpp
+++ b/src/dos/program_mount_common.cpp
@@ -39,18 +39,20 @@ const char *UnmountHelper(char umount)
 	                                           : drive_index(drive_id);
 	assert(i_drive < DOS_DRIVES);
 
-	if (i_drive < MAX_DISK_IMAGES && Drives[i_drive] == NULL && !imageDiskList[i_drive])
+	if (i_drive < MAX_DISK_IMAGES && !Drives[i_drive] && !imageDiskList[i_drive]) {
 		return MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED");
+	}
 
-	if (i_drive >= MAX_DISK_IMAGES && Drives[i_drive] == NULL)
+	if (i_drive >= MAX_DISK_IMAGES && !Drives[i_drive]) {
 		return MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED");
+	}
 
 	if (Drives[i_drive]) {
 		switch (DriveManager::UnmountDrive(i_drive)) {
 			case 1: return MSG_Get("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL");
 			case 2: return MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS");
 		}
-		Drives[i_drive] = 0;
+		Drives[i_drive] = nullptr;
 		mem_writeb(Real2Phys(dos.tables.mediaid)+i_drive*9,0);
 		if (i_drive == DOS_GetDefaultDrive()) {
 			DOS_SetDrive(ZDRIVE_NUM);
@@ -59,7 +61,8 @@ const char *UnmountHelper(char umount)
 	}
 
 	if (i_drive < MAX_DISK_IMAGES && imageDiskList[i_drive]) {
-		imageDiskList[i_drive].reset();
+		imageDiskList[i_drive] = nullptr;
+		DriveManager::CloseNumberedImage(imageDiskList[i_drive]);
 	}
 
 	return MSG_Get("PROGRAM_MOUNT_UMOUNT_SUCCESS");

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -169,7 +169,7 @@ public:
 	std::string id_model = "DOSBox IDE disk";
 	uint8_t bios_disk_index;
 
-	std::shared_ptr<imageDisk> getBIOSdisk();
+	imageDisk* getBIOSdisk();
 
 	void update_from_biosdisk();
 	virtual uint32_t data_read(io_width_t width);          /* read from 1F0h data port from IDE device */
@@ -2129,7 +2129,7 @@ IDEATADevice::IDEATADevice(IDEController *c, uint8_t disk_index)
 IDEATADevice::~IDEATADevice()
 {}
 
-std::shared_ptr<imageDisk> IDEATADevice::getBIOSdisk()
+imageDisk* IDEATADevice::getBIOSdisk()
 {
 	if (bios_disk_index >= (2 + MAX_HDD_IMAGES))
 		return nullptr;
@@ -2157,7 +2157,7 @@ void IDEATAPICDROMDevice::update_from_cdrom()
 
 void IDEATADevice::update_from_biosdisk()
 {
-	std::shared_ptr<imageDisk> dsk = getBIOSdisk();
+	const auto dsk = getBIOSdisk();
 	if (dsk == nullptr) {
 		LOG_WARNING("IDE: IDE update from BIOS disk failed, disk not available");
 		return;
@@ -2697,7 +2697,7 @@ void IDE_EmuINT13DiskReadByBIOS(uint8_t disk, uint32_t cyl, uint32_t head, unsig
 				bool vm86 = IDE_CPU_Is_Vm86();
 
 				if ((ata->bios_disk_index - 2) == (disk - 0x80)) {
-					std::shared_ptr<imageDisk> dsk = ata->getBIOSdisk();
+					const auto dsk = ata->getBIOSdisk();
 
 					/* print warning if INT 13h is being called after the OS changed
 					 * logical geometry */
@@ -2944,7 +2944,7 @@ static void IDE_DelayedCommand(uint32_t idx /*which IDE controller*/)
 		IDEATADevice *ata = (IDEATADevice *)dev;
 		uint32_t sectorn = 0; /* TBD: expand to uint64_t when adding LBA48 emulation */
 		uint32_t sectcount;
-		std::shared_ptr<imageDisk> disk;
+		imageDisk* disk = nullptr;
 		//      int i;
 
 		switch (dev->command) {

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2397,7 +2397,7 @@ void IDE_Hard_Disk_Attach(int8_t index,
 		return;
 	}
 
-	if (!imageDiskList[bios_disk_index]) {
+	if (!imageDiskList.at(bios_disk_index)) {
 		LOG_WARNING("IDE: Asked to attach bios disk that does not exist");
 		return;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1939,7 +1939,10 @@ void DOS_Shell::CMD_SUBST (char * args) {
    		uint8_t drive;char fulldir[DOS_PATHLENGTH];
 		if (!DOS_MakeName(const_cast<char*>(arg.c_str()),fulldir,&drive)) throw 0;
 
-		if ( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
+		ldp = dynamic_cast<localDrive*>(Drives[drive]);
+		if (!ldp) {
+			throw 0;
+		}
 		char newname[CROSS_LEN];
 		safe_strcpy(newname, ldp->GetBasedir());
 		strcat(newname,fulldir);

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -66,10 +66,8 @@ void assert_DTAExtendName(const std::string_view input_fullname,
 	EXPECT_EQ(output_ext, expected_ext);
 }
 
-void assert_DOS_MakeName(char const *const input,
-                         bool exp_result,
-                         std::string exp_fullname = "",
-                         int exp_drive = 0)
+void assert_DOS_MakeName(const char* const input, bool exp_result,
+                         std::string exp_fullname = "", int exp_drive = 0)
 {
 	uint8_t drive_result;
 	char fullname_result[DOS_PATHLENGTH];
@@ -126,7 +124,7 @@ TEST_F(DOS_FilesTest, DOS_MakeName_Uppercase)
 	// lower case
 	assert_DOS_MakeName("z:\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
 	// current dir isn't uppercased if it's not already
-	safe_strcpy(Drives[25]->curdir, "Windows\\Folder");
+	safe_strcpy(Drives.at(25)->curdir, "Windows\\Folder");
 	assert_DOS_MakeName("autoexec.bat", true,
 	                    "Windows\\Folder\\AUTOEXEC.BAT", 25);
 }
@@ -163,28 +161,28 @@ TEST_F(DOS_FilesTest, DOS_MakeName_Assumes_Current_Drive_And_Dir)
 	// when passed only a filename, assume default drive and current dir
 	assert_DOS_MakeName("AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
 	// artificially change directory
-	safe_strcpy(Drives[25]->curdir, "CODE");
+	safe_strcpy(Drives.at(25)->curdir, "CODE");
 	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\AUTOEXEC.BAT", 25);
 	// artificially change directory
-	safe_strcpy(Drives[25]->curdir, "CODE\\BIN");
+	safe_strcpy(Drives.at(25)->curdir, "CODE\\BIN");
 	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\BIN\\AUTOEXEC.BAT", 25);
 	// ignores current dir and goes to root
 	assert_DOS_MakeName("\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
-	safe_strcpy(Drives[25]->curdir, "");
+	safe_strcpy(Drives.at(25)->curdir, "");
 	assert_DOS_MakeName("Z:\\CODE\\BIN", true, "CODE\\BIN", 25);
 	assert_DOS_MakeName("Z:", true, "", 25);
 	assert_DOS_MakeName("Z:\\", true, "", 25);
 	// This is a bug but we need to capture this functionality
-	safe_strcpy(Drives[25]->curdir, "CODE\\BIN\\");
+	safe_strcpy(Drives.at(25)->curdir, "CODE\\BIN\\");
 	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\BIN\\\\AUTOEXEC.BAT", 25);
-	safe_strcpy(Drives[25]->curdir, "CODE\\BIN\\\\");
+	safe_strcpy(Drives.at(25)->curdir, "CODE\\BIN\\\\");
 	assert_DOS_MakeName("AUTOEXEC.BAT", true, "CODE\\BIN\\\\\\AUTOEXEC.BAT", 25);
 }
 
 // This tests that illegal char matching happens AFTER 8.3 trimming
 TEST_F(DOS_FilesTest, DOS_MakeName_Illegal_Chars_After_8_3)
 {
-	safe_strcpy(Drives[25]->curdir, "BIN");
+	safe_strcpy(Drives.at(25)->curdir, "BIN");
 	assert_DOS_MakeName("\n2345678AAAAABBB.BAT", false);
 	assert_DOS_MakeName("12345678.\n23BBBBBAAA", false);
 	assert_DOS_MakeName("12345678AAAAABB\n.BAT", true, "BIN\\12345678.BAT", 25);
@@ -194,7 +192,7 @@ TEST_F(DOS_FilesTest, DOS_MakeName_Illegal_Chars_After_8_3)
 TEST_F(DOS_FilesTest, DOS_MakeName_DOS_PATHLENGTH_checks)
 {
 	// Right on the line ...
-	safe_strcpy(Drives[25]->curdir,
+	safe_strcpy(Drives.at(25)->curdir,
 	            "aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\"
 	            "aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaa\\aaaaaaaaaa");
 	assert_DOS_MakeName("BBBBB.BB", true,
@@ -209,14 +207,14 @@ TEST_F(DOS_FilesTest, DOS_MakeName_DOS_PATHLENGTH_checks)
 
 TEST_F(DOS_FilesTest, DOS_MakeName_Enforce_8_3)
 {
-	safe_strcpy(Drives[25]->curdir, "BIN");
+	safe_strcpy(Drives.at(25)->curdir, "BIN");
 	assert_DOS_MakeName("12345678AAAAABBBB.BAT", true, "BIN\\12345678.BAT", 25);
 	assert_DOS_MakeName("12345678.123BBBBBAAAA", true, "BIN\\12345678.123", 25);
 }
 
 TEST_F(DOS_FilesTest, DOS_MakeName_Dot_Handling)
 {
-	safe_strcpy(Drives[25]->curdir, "WINDOWS\\CONFIG");
+	safe_strcpy(Drives.at(25)->curdir, "WINDOWS\\CONFIG");
 	assert_DOS_MakeName(".", true, "WINDOWS\\CONFIG", 25);
 	assert_DOS_MakeName("..", true, "WINDOWS", 25);
 	assert_DOS_MakeName("...", true, "", 25);
@@ -224,10 +222,10 @@ TEST_F(DOS_FilesTest, DOS_MakeName_Dot_Handling)
 	                    "WINDOWS\\CONFIG\\AUTOEXEC.BAT", 25);
 	assert_DOS_MakeName("..\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
 	assert_DOS_MakeName("...\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
-	safe_strcpy(Drives[25]->curdir, "WINDOWS\\CONFIG\\FOLDER");
+	safe_strcpy(Drives.at(25)->curdir, "WINDOWS\\CONFIG\\FOLDER");
 	assert_DOS_MakeName("...\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
 	assert_DOS_MakeName("....\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
-	safe_strcpy(Drives[25]->curdir, "WINDOWS\\CONFIG\\FOLDER\\DEEP");
+	safe_strcpy(Drives.at(25)->curdir, "WINDOWS\\CONFIG\\FOLDER\\DEEP");
 	assert_DOS_MakeName("....\\AUTOEXEC.BAT", true, "WINDOWS\\AUTOEXEC.BAT", 25);
 	assert_DOS_MakeName(".....\\AUTOEXEC.BAT", true, "AUTOEXEC.BAT", 25);
 	// make sure we can exceed the depth


### PR DESCRIPTION
Previously, management of the mountable filesystems (CDROM ISOs, HDD FAT16, Floppy FAT12) and raw images (numbered HDD images and bootable floppy images) was spread across a handful of literal arrays:

- `imageDiskList[]` array
- `diskSwap[]` array
- `Drives[]` array

This made it difficult to properly destruct and replace objects without double-free situations.

This commit moves all ownership inside the `DriveManager` class where they are all held as `std::unique_ptr` objects to guarantee that only one instance exists.

The other three literal arrays (`imageDiskList`, `diskSwap`, and `Drives` hold simple pointers into the drive manager's `unique_ptr->get()` content.  This removes all management responsibility from the arrays.

Unfortunately this is a large commit because it's essentially all-or-nothing, as once the data types are switched, all the affected code needs to be switched, too.