### PR TITLE
Suppress excessively verbose `sprintf` warnings on macos + clang

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             needs_deps: true
             build_flags: -Denable_debugger=normal
             brew_path: /usr/local/homebrew
-            max_warnings: 109
+            max_warnings: 0
 
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]

--- a/meson.build
+++ b/meson.build
@@ -104,8 +104,14 @@ if get_option('asm')
     extra_flags += ['--save-temps', '/FAs']
 endif
 
+# Don't flood us with hundreds of suggestions to use Microsoft-specific calls
 if host_machine.system() == 'windows'
     extra_flags += '-Wno-pedantic-ms-format'
+endif
+
+# Don't flood us with hundreds of suggestions to use snprintf on Apple + Clang
+if host_machine.system() == 'darwin' and  cxx.get_id() == 'clang'
+    extra_flags += '-Wno-deprecated-declarations'
 endif
 
 if prefers_static_libs


### PR DESCRIPTION
Currently these warnings flood macos clang maintainers with visual clutter, preventing them from picking out useful other messages.

Doesn't disabling warnings hurt the code?

Fortunately not in this case. We've already replace over 400 prior calls with Staging's template-ized safe_<equivalent> C formatting wrappers, while the remaining calls (that X-code complains about) operate on flexibly-sized  buffers and therefore do not have a drop-in replacement to get the original array size (which is required by the `vn/sn*` variants).

Also, the current code-base passes all static and runtime UBSAN analysis involving string operations.

Is there a long-term solution?

The solution involves refactoring these areas to use more `std::string`, `std:string_view`, and non-C-based formatting techniques to eliminate the use of these C calls entirely.

If any readers take issue with this commit and would prefer that the maintenance team continue to be burdened with this flood of warnings: then those readers can jump in and help by submitting PRs. Once they're all fixed, we can re-activate this warning.