### PR TITLE
Refactor WriteOut functions in program.cpp

### DIFF
--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -20,13 +20,13 @@
 
 #include <algorithm>
 #include <array>
-#include <sstream>
 #include <cctype>
-#include <cstdlib>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <sstream>
 #include <vector>
 
 #include "../dos/program_more_output.h"
@@ -42,7 +42,8 @@
 
 callback_number_t call_program = 0;
 
-/* This registers a file on the virtual drive and creates the correct structure for it*/
+/* This registers a file on the virtual drive and creates the correct structure
+ * for it*/
 
 constexpr std::array<uint8_t, 19> exe_block = {
         0xbc, 0x00, 0x04,       // MOV SP,0x400  Decrease stack size
@@ -75,7 +76,7 @@ static void write_to_stdout(std::string_view output)
 			out = '\r';
 			DOS_WriteFile(STDOUT, &out, &bytes_to_write);
 		}
-		out = static_cast<uint8_t>(chr);
+		out                    = static_cast<uint8_t>(chr);
 		last_written_character = out;
 		DOS_WriteFile(STDOUT, &out, &bytes_to_write);
 	}
@@ -95,7 +96,7 @@ static void truncated_chars_message(int size)
 	}
 }
 
-void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
+void PROGRAMS_MakeFile(const char* name, PROGRAMS_Creator creator)
 {
 	comdata_t comdata(exe_block.begin(), exe_block.end());
 	comdata.at(callback_pos) = static_cast<uint8_t>(call_program & 0xff);
@@ -104,7 +105,7 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
 	// the maximum callback number is only 128. So we just confirm that here.
 	static_assert(sizeof(callback_number_t) < sizeof(uint16_t));
 	constexpr uint8_t upper_8_bits_of_callback = 0;
-	comdata.at(callback_pos + 1) = upper_8_bits_of_callback;
+	comdata.at(callback_pos + 1)               = upper_8_bits_of_callback;
 
 	// Save the current program's vector index in its COM data
 	const auto index = internal_progs.size();
@@ -125,9 +126,10 @@ void PROGRAMS_MakeFile(const char *name, PROGRAMS_Creator creator)
 	creator()->AddToHelpList();
 }
 
-static Bitu PROGRAMS_Handler(void) {
+static Bitu PROGRAMS_Handler(void)
+{
 	/* This sets up everything for a program start up call */
-	Bitu size=sizeof(uint8_t);
+	Bitu size = sizeof(uint8_t);
 	uint8_t index;
 
 	// Sanity check the exec_block size before down-casting
@@ -137,66 +139,77 @@ static Bitu PROGRAMS_Handler(void) {
 	/* Read the index from program code in memory */
 	PhysPt reader = PhysMake(dos.psp(),
 	                         256 + static_cast<uint16_t>(exec_block_size));
-	HostPt writer=(HostPt)&index;
-	for (;size>0;size--) *writer++=mem_readb(reader++);
+	HostPt writer = (HostPt)&index;
+	for (; size > 0; size--) {
+		*writer++ = mem_readb(reader++);
+	}
 	const PROGRAMS_Creator& creator = internal_progs.at(index);
-	const auto new_program = creator();
+	const auto new_program          = creator();
 	new_program->Run();
 	return CBRET_NONE;
 }
 
-
 /* Main functions used in all program */
 
-
-Program::Program() {
+Program::Program()
+{
 	/* Find the command line and setup the PSP */
 	psp = new DOS_PSP(dos.psp());
 	/* Scan environment for filename */
-	PhysPt envscan=PhysMake(psp->GetEnvironment(),0);
-	while (mem_readb(envscan)) envscan+=mem_strlen(envscan)+1;
-	envscan+=3;
+	PhysPt envscan = PhysMake(psp->GetEnvironment(), 0);
+	while (mem_readb(envscan)) {
+		envscan += mem_strlen(envscan) + 1;
+	}
+	envscan += 3;
 	CommandTail tail;
-	MEM_BlockRead(PhysMake(dos.psp(),128),&tail,128);
-	if (tail.count<127) tail.buffer[tail.count]=0;
-	else tail.buffer[126]=0;
-	char filename[256+1];
-	MEM_StrCopy(envscan,filename,256);
-	cmd = new CommandLine(filename,tail.buffer);
+	MEM_BlockRead(PhysMake(dos.psp(), 128), &tail, 128);
+	if (tail.count < 127) {
+		tail.buffer[tail.count] = 0;
+	} else {
+		tail.buffer[126] = 0;
+	}
+	char filename[256 + 1];
+	MEM_StrCopy(envscan, filename, 256);
+	cmd = new CommandLine(filename, tail.buffer);
 }
 
 extern std::string full_arguments;
 
-void Program::ChangeToLongCmd() {
+void Program::ChangeToLongCmd()
+{
 	/*
 	 * Get arguments directly from the shell instead of the psp.
-	 * this is done in securemode: (as then the arguments to mount and friends
-	 * can only be given on the shell ( so no int 21 4b)
-	 * Securemode part is disabled as each of the internal command has already
-	 * protection for it. (and it breaks games like cdman)
-	 * it is also done for long arguments to as it is convient (as the total commandline can be longer then 127 characters.
-	 * imgmount with lot's of parameters
-	 * Length of arguments can be ~120. but switch when above 100 to be sure
+	 * this is done in securemode: (as then the arguments to mount and
+	 * friends can only be given on the shell ( so no int 21 4b) Securemode
+	 * part is disabled as each of the internal command has already protection
+	 * for it. (and it breaks games like cdman) it is also done for long
+	 * arguments to as it is convient (as the total commandline can be
+	 * longer then 127 characters. imgmount with lot's of parameters Length
+	 * of arguments can be ~120. but switch when above 100 to be sure
 	 */
 
 	if (/*control->SecureMode() ||*/ cmd->Get_arglength() > 100) {
-		CommandLine* temp = new CommandLine(cmd->GetFileName(),full_arguments.c_str());
+		CommandLine* temp = new CommandLine(cmd->GetFileName(),
+		                                    full_arguments.c_str());
 		delete cmd;
 		cmd = temp;
 	}
-	full_arguments.assign(""); //Clear so it gets even more save
+	full_arguments.assign(""); // Clear so it gets even more save
 }
 
-bool Program::SuppressWriteOut(const char *format)
+bool Program::SuppressWriteOut(const char* format)
 {
 	// Have we encountered an executable thus far?
 	static bool encountered_executable = false;
-	if (encountered_executable)
+	if (encountered_executable) {
 		return false;
-	if (control->GetStartupVerbosity() >= Verbosity::Low)
+	}
+	if (control->GetStartupVerbosity() >= Verbosity::Low) {
 		return false;
-	if (!control->cmdline->HasExecutableName())
+	}
+	if (!control->cmdline->HasExecutableName()) {
 		return false;
+	}
 
 	// Keep suppressing output until after we hit the first executable.
 	encountered_executable = is_executable_filename(format);
@@ -234,7 +247,6 @@ void Program::WriteOut(const char* format, const char* arguments)
 
 	write_to_stdout(buf);
 	truncated_chars_message(size);
-
 }
 
 void Program::WriteOut_NoParsing(const char* str)
@@ -253,35 +265,46 @@ void Program::ResetLastWrittenChar(char c)
 
 void Program::InjectMissingNewline()
 {
-	if (last_written_character == '\n')
+	if (last_written_character == '\n') {
 		return;
+	}
 
-	uint16_t n = 2;
-	uint8_t dos_nl[] = "\r\n";
+	uint16_t n          = 2;
+	uint8_t dos_nl[]    = "\r\n";
 	dos.internal_output = true;
 	DOS_WriteFile(STDOUT, dos_nl, &n);
-	dos.internal_output = false;
+	dos.internal_output    = false;
 	last_written_character = '\n';
 }
 
-bool Program::GetEnvStr(const char *entry, std::string &result) const
+bool Program::GetEnvStr(const char* entry, std::string& result) const
 {
 	/* Walk through the internal environment and see for a match */
-	PhysPt env_read=PhysMake(psp->GetEnvironment(),0);
+	PhysPt env_read = PhysMake(psp->GetEnvironment(), 0);
 
-	char env_string[1024+1];
+	char env_string[1024 + 1];
 	result.erase();
-	if (!entry[0]) return false;
-	do 	{
-		MEM_StrCopy(env_read,env_string,1024);
-		if (!env_string[0]) return false;
-		env_read += (PhysPt)(safe_strlen(env_string)+1);
-		char* equal = strchr(env_string,'=');
-		if (!equal) continue;
+	if (!entry[0]) {
+		return false;
+	}
+	do {
+		MEM_StrCopy(env_read, env_string, 1024);
+		if (!env_string[0]) {
+			return false;
+		}
+		env_read += (PhysPt)(safe_strlen(env_string) + 1);
+		char* equal = strchr(env_string, '=');
+		if (!equal) {
+			continue;
+		}
 		/* replace the = with \0 to get the length */
 		*equal = 0;
-		if (strlen(env_string) != strlen(entry)) continue;
-		if (strcasecmp(entry,env_string)!=0) continue;
+		if (strlen(env_string) != strlen(entry)) {
+			continue;
+		}
+		if (strcasecmp(entry, env_string) != 0) {
+			continue;
+		}
 		/* restore the = to get the original result */
 		*equal = '=';
 		result = env_string;
@@ -290,15 +313,20 @@ bool Program::GetEnvStr(const char *entry, std::string &result) const
 	return false;
 }
 
-bool Program::GetEnvNum(Bitu num, std::string &result) const
+bool Program::GetEnvNum(Bitu num, std::string& result) const
 {
-	char env_string[1024+1];
-	PhysPt env_read=PhysMake(psp->GetEnvironment(),0);
-	do 	{
-		MEM_StrCopy(env_read,env_string,1024);
-		if (!env_string[0]) break;
-		if (!num) { result=env_string;return true;}
-		env_read += (PhysPt)(safe_strlen(env_string)+1);
+	char env_string[1024 + 1];
+	PhysPt env_read = PhysMake(psp->GetEnvironment(), 0);
+	do {
+		MEM_StrCopy(env_read, env_string, 1024);
+		if (!env_string[0]) {
+			break;
+		}
+		if (!num) {
+			result = env_string;
+			return true;
+		}
+		env_read += (PhysPt)(safe_strlen(env_string) + 1);
 		num--;
 	} while (1);
 	return false;
@@ -306,67 +334,88 @@ bool Program::GetEnvNum(Bitu num, std::string &result) const
 
 Bitu Program::GetEnvCount() const
 {
-	PhysPt env_read=PhysMake(psp->GetEnvironment(),0);
-	Bitu num=0;
-	while (mem_readb(env_read)!=0) {
-		for (;mem_readb(env_read);env_read++) {};
+	PhysPt env_read = PhysMake(psp->GetEnvironment(), 0);
+	Bitu num        = 0;
+	while (mem_readb(env_read) != 0) {
+		for (; mem_readb(env_read); env_read++) {
+		};
 		env_read++;
 		num++;
 	}
 	return num;
 }
 
-bool Program::SetEnv(const char * entry,const char * new_string) {
-	PhysPt env_read = PhysMake(psp->GetEnvironment(),0);
+bool Program::SetEnv(const char* entry, const char* new_string)
+{
+	PhysPt env_read = PhysMake(psp->GetEnvironment(), 0);
 
-	//Get size of environment.
+	// Get size of environment.
 	DOS_MCB mcb(psp->GetEnvironment() - 1);
-	uint16_t envsize = mcb.GetSize()*16;
+	uint16_t envsize = mcb.GetSize() * 16;
 
-
-	PhysPt env_write = env_read;
-	PhysPt env_write_start = env_read;
-	char env_string[1024+1] = { 0 };
-	do 	{
-		MEM_StrCopy(env_read,env_string,1024);
-		if (!env_string[0]) break;
-		env_read += (PhysPt)(safe_strlen(env_string)+1);
-		if (!strchr(env_string,'=')) continue;		/* Remove corrupt entry? */
-		if ((strncasecmp(entry,env_string,strlen(entry))==0) &&
-			env_string[strlen(entry)]=='=') continue;
-		MEM_BlockWrite(env_write,env_string,(Bitu)(safe_strlen(env_string)+1));
-		env_write += (PhysPt)(safe_strlen(env_string)+1);
+	PhysPt env_write          = env_read;
+	PhysPt env_write_start    = env_read;
+	char env_string[1024 + 1] = {0};
+	do {
+		MEM_StrCopy(env_read, env_string, 1024);
+		if (!env_string[0]) {
+			break;
+		}
+		env_read += (PhysPt)(safe_strlen(env_string) + 1);
+		if (!strchr(env_string, '=')) {
+			continue; /* Remove corrupt entry? */
+		}
+		if ((strncasecmp(entry, env_string, strlen(entry)) == 0) &&
+		    env_string[strlen(entry)] == '=') {
+			continue;
+		}
+		MEM_BlockWrite(env_write,
+		               env_string,
+		               (Bitu)(safe_strlen(env_string) + 1));
+		env_write += (PhysPt)(safe_strlen(env_string) + 1);
 	} while (1);
-/* TODO Maybe save the program name sometime. not really needed though */
+	/* TODO Maybe save the program name sometime. not really needed though */
 	/* Save the new entry */
 
-	//ensure room
-	if (envsize <= (env_write-env_write_start) + strlen(entry) + 1 + strlen(new_string) + 2) return false;
+	// ensure room
+	if (envsize <= (env_write - env_write_start) + strlen(entry) + 1 +
+	                       strlen(new_string) + 2) {
+		return false;
+	}
 
 	if (new_string[0]) {
 		std::string bigentry(entry);
-		for (std::string::iterator it = bigentry.begin(); it != bigentry.end(); ++it) *it = toupper(*it);
-		snprintf(env_string,1024+1,"%s=%s",bigentry.c_str(),new_string);
-		MEM_BlockWrite(env_write,env_string,(Bitu)(safe_strlen(env_string)+1));
-		env_write += (PhysPt)(safe_strlen(env_string)+1);
+		for (std::string::iterator it = bigentry.begin();
+		     it != bigentry.end();
+		     ++it) {
+			*it = toupper(*it);
+		}
+		snprintf(env_string, 1024 + 1, "%s=%s", bigentry.c_str(), new_string);
+		MEM_BlockWrite(env_write,
+		               env_string,
+		               (Bitu)(safe_strlen(env_string) + 1));
+		env_write += (PhysPt)(safe_strlen(env_string) + 1);
 	}
 	/* Clear out the final piece of the environment */
-	mem_writeb(env_write,0);
+	mem_writeb(env_write, 0);
 	return true;
 }
 
-bool Program::HelpRequested() {
+bool Program::HelpRequested()
+{
 	return cmd->FindExist("/?", false) || cmd->FindExist("-h", false) ||
 	       cmd->FindExist("--help", false);
 }
 
-void Program::AddToHelpList() {
-	if (help_detail.name.size())
+void Program::AddToHelpList()
+{
+	if (help_detail.name.size()) {
 		HELP_AddToHelpList(help_detail.name, help_detail);
+	}
 }
 
-bool MSG_Write(const char *);
-void restart_program(std::vector<std::string> & parameters);
+bool MSG_Write(const char*);
+void restart_program(std::vector<std::string>& parameters);
 
 class CONFIG final : public Program {
 public:
@@ -378,24 +427,27 @@ public:
 		               "CONFIG"};
 	}
 	void Run(void);
+
 private:
 	void restart(const char* useconfig);
 
-	void writeconf(std::string name, bool configdir) {
+	void writeconf(std::string name, bool configdir)
+	{
 		if (configdir) {
 			// write file to the default config directory
 			std::string config_path;
 			Cross::GetPlatformConfigDir(config_path);
 			name = config_path + name;
 		}
-		WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_WHICH"),name.c_str());
+		WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_WHICH"), name.c_str());
 		if (!control->PrintConfig(name)) {
 			WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"), name.c_str());
 		}
 		return;
 	}
 
-	bool securemode_check() {
+	bool securemode_check()
+	{
 		if (control->SecureMode()) {
 			WriteOut(MSG_Get("PROGRAM_CONFIG_SECURE_DISALLOW"));
 			return true;
@@ -404,25 +456,38 @@ private:
 	}
 };
 
-void CONFIG::Run(void) {
+void CONFIG::Run(void)
+{
 	static const char* const params[] = {
-		"-r", "-wcp", "-wcd", "-wc", "-writeconf", "-l", "-rmconf",
-		"-h", "-help", "-?", "-axclear", "-axadd", "-axtype",
-		"-avistart","-avistop",
-		"-startmapper",
-		"-get", "-set",
-		"-writelang", "-wl", "-securemode", "" };
+	        "-r",          "-wcp",      "-wcd",       "-wc",
+	        "-writeconf",  "-l",        "-rmconf",    "-h",
+	        "-help",       "-?",        "-axclear",   "-axadd",
+	        "-axtype",     "-avistart", "-avistop",   "-startmapper",
+	        "-get",        "-set",      "-writelang", "-wl",
+	        "-securemode", ""};
 	enum prs {
-		P_NOMATCH, P_NOPARAMS, // fixed return values for GetParameterFromList
+		P_NOMATCH,
+		P_NOPARAMS, // fixed return values for GetParameterFromList
 		P_RESTART,
-		P_WRITECONF_PORTABLE, P_WRITECONF_DEFAULT, P_WRITECONF, P_WRITECONF2,
-		P_LISTCONF,	P_KILLCONF,
-		P_HELP, P_HELP2, P_HELP3,
-		P_AUTOEXEC_CLEAR, P_AUTOEXEC_ADD, P_AUTOEXEC_TYPE,
-		P_REC_AVI_START, P_REC_AVI_STOP,
+		P_WRITECONF_PORTABLE,
+		P_WRITECONF_DEFAULT,
+		P_WRITECONF,
+		P_WRITECONF2,
+		P_LISTCONF,
+		P_KILLCONF,
+		P_HELP,
+		P_HELP2,
+		P_HELP3,
+		P_AUTOEXEC_CLEAR,
+		P_AUTOEXEC_ADD,
+		P_AUTOEXEC_TYPE,
+		P_REC_AVI_START,
+		P_REC_AVI_STOP,
 		P_START_MAPPER,
-		P_GETPROP, P_SETPROP,
-		P_WRITELANG, P_WRITELANG2,
+		P_GETPROP,
+		P_SETPROP,
+		P_WRITELANG,
+		P_WRITELANG2,
 		P_SECURE
 	} presult = P_NOMATCH;
 
@@ -437,14 +502,17 @@ void CONFIG::Run(void) {
 	// Loop through the passed parameters
 	while (presult != P_NOPARAMS) {
 		presult = (enum prs)cmd->GetParameterFromList(params, pvars);
-		switch(presult) {
-
+		switch (presult) {
 		case P_RESTART:
-			if (securemode_check()) return;
-			if (pvars.size() == 0) restart_program(control->startup_params);
-			else {
+			if (securemode_check()) {
+				return;
+			}
+			if (pvars.size() == 0) {
+				restart_program(control->startup_params);
+			} else {
 				std::vector<std::string> restart_params;
-				restart_params.push_back(control->cmdline->GetFileName());
+				restart_params.push_back(
+				        control->cmdline->GetFileName());
 				for (size_t i = 0; i < pvars.size(); i++) {
 					restart_params.push_back(pvars[i]);
 				}
@@ -458,75 +526,108 @@ void CONFIG::Run(void) {
 			Bitu size = control->configfiles.size();
 			std::string config_path;
 			Cross::GetPlatformConfigDir(config_path);
-			WriteOut(MSG_Get("PROGRAM_CONFIG_CONFDIR"), VERSION,
+			WriteOut(MSG_Get("PROGRAM_CONFIG_CONFDIR"),
+			         VERSION,
 			         config_path.c_str());
-			if (size==0) WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
-			else {
-				WriteOut(MSG_Get("PROGRAM_CONFIG_PRIMARY_CONF"),control->configfiles.front().c_str());
+			if (size == 0) {
+				WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
+			} else {
+				WriteOut(MSG_Get("PROGRAM_CONFIG_PRIMARY_CONF"),
+				         control->configfiles.front().c_str());
 				if (size > 1) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_ADDITIONAL_CONF"));
-					for (Bitu i = 1; i < size; i++)
-						WriteOut("%s\n",control->configfiles[i].c_str());
+					WriteOut(MSG_Get(
+					        "PROGRAM_CONFIG_ADDITIONAL_CONF"));
+					for (Bitu i = 1; i < size; i++) {
+						WriteOut("%s\n",
+						         control->configfiles[i].c_str());
+					}
 				}
 			}
 			if (control->startup_params.size() > 0) {
 				std::string test;
-				for (size_t k = 0; k < control->startup_params.size(); k++)
+				for (size_t k = 0;
+				     k < control->startup_params.size();
+				     k++) {
 					test += control->startup_params[k] + " ";
-				WriteOut(MSG_Get("PROGRAM_CONFIG_PRINT_STARTUP"), test.c_str());
+				}
+				WriteOut(MSG_Get("PROGRAM_CONFIG_PRINT_STARTUP"),
+				         test.c_str());
 			}
 			break;
 		}
-		case P_WRITECONF: case P_WRITECONF2:
-			if (securemode_check()) return;
-			if (pvars.size() > 1) return;
-			else if (pvars.size() == 1) {
-				// write config to specific file, except if it is an absolute path
-				writeconf(pvars[0], !Cross::IsPathAbsolute(pvars[0]));
+		case P_WRITECONF:
+		case P_WRITECONF2:
+			if (securemode_check()) {
+				return;
+			}
+			if (pvars.size() > 1) {
+				return;
+			} else if (pvars.size() == 1) {
+				// write config to specific file, except if it
+				// is an absolute path
+				writeconf(pvars[0],
+				          !Cross::IsPathAbsolute(pvars[0]));
 			} else {
 				// -wc without parameter: write primary config file
-				if (control->configfiles.size()) writeconf(control->configfiles[0], false);
-				else WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
+				if (control->configfiles.size()) {
+					writeconf(control->configfiles[0], false);
+				} else {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
+				}
 			}
 			break;
 		case P_WRITECONF_DEFAULT: {
 			// write to /userdir/dosbox0.xx.conf
-			if (securemode_check()) return;
-			if (pvars.size() > 0) return;
+			if (securemode_check()) {
+				return;
+			}
+			if (pvars.size() > 0) {
+				return;
+			}
 			std::string confname;
 			Cross::GetPlatformConfigName(confname);
 			writeconf(confname, true);
 			break;
 		}
 		case P_WRITECONF_PORTABLE:
-			if (securemode_check()) return;
-			if (pvars.size() > 1) return;
-			else if (pvars.size() == 1) {
+			if (securemode_check()) {
+				return;
+			}
+			if (pvars.size() > 1) {
+				return;
+			} else if (pvars.size() == 1) {
 				// write config to startup directory
 				writeconf(pvars[0], false);
 			} else {
-				// -wcp without parameter: write dosbox.conf to startup directory
-				if (control->configfiles.size()) writeconf(std::string("dosbox.conf"), false);
-				else WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
+				// -wcp without parameter: write dosbox.conf to
+				// startup directory
+				if (control->configfiles.size()) {
+					writeconf(std::string("dosbox.conf"), false);
+				} else {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
+				}
 			}
 			break;
 
 		case P_NOPARAMS:
-			if (!first)
+			if (!first) {
 				break;
+			}
 			[[fallthrough]];
 
 		case P_NOMATCH: display_help(); return;
 
-		case P_HELP: case P_HELP2: case P_HELP3: {
-			switch(pvars.size()) {
+		case P_HELP:
+		case P_HELP2:
+		case P_HELP3: {
+			switch (pvars.size()) {
 			case 0: display_help(); return;
 			case 1: {
-				if (!strcasecmp("sections",pvars[0].c_str())) {
+				if (!strcasecmp("sections", pvars[0].c_str())) {
 					// list the sections
 					WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_SECTLIST"));
-					for (const Section *sec : *control) {
-						WriteOut("%s\n",sec->GetName());
+					for (const Section* sec : *control) {
+						WriteOut("%s\n", sec->GetName());
 					}
 					return;
 				}
@@ -534,23 +635,29 @@ void CONFIG::Run(void) {
 				Section* sec = control->GetSection(pvars[0].c_str());
 				if (!sec) {
 					// could be a property
-					sec = control->GetSectionFromProperty(pvars[0].c_str());
+					sec = control->GetSectionFromProperty(
+					        pvars[0].c_str());
 					if (!sec) {
-						WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+						WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+						         pvars[0].c_str());
 						return;
 					}
-					pvars.insert(pvars.begin(),std::string(sec->GetName()));
+					pvars.insert(pvars.begin(),
+					             std::string(sec->GetName()));
 				}
 				break;
 			}
 			case 2: {
 				// sanity check
 				Section* sec = control->GetSection(pvars[0].c_str());
-				Section* sec2 = control->GetSectionFromProperty(pvars[1].c_str());
+				Section* sec2 = control->GetSectionFromProperty(
+				        pvars[1].c_str());
 				if (!sec) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+					         pvars[0].c_str());
 				} else if (!sec2 || sec != sec2) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[1].c_str());
+					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+					         pvars[1].c_str());
 				}
 				break;
 			}
@@ -559,51 +666,70 @@ void CONFIG::Run(void) {
 			// if we have one value in pvars, it's a section
 			// two values are section + property
 			Section* sec = control->GetSection(pvars[0].c_str());
-			if (sec==NULL) {
-				WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+			if (sec == NULL) {
+				WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+				         pvars[0].c_str());
 				return;
 			}
-			Section_prop* psec = dynamic_cast <Section_prop*>(sec);
-			if (psec==NULL) {
+			Section_prop* psec = dynamic_cast<Section_prop*>(sec);
+			if (psec == NULL) {
 				// failed; maybe it's the autoexec section?
-				Section_line* pline = dynamic_cast <Section_line*>(sec);
-				if (pline==NULL) E_Exit("Section dynamic cast failed.");
+				Section_line* pline = dynamic_cast<Section_line*>(sec);
+				if (pline == NULL) {
+					E_Exit("Section dynamic cast failed.");
+				}
 
 				WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_LINEHLP"),
-					pline->GetName(),
-					// this is 'unclean' but the autoexec section has no help associated
-					MSG_Get("AUTOEXEC_CONFIGFILE_HELP"),
-					pline->data.c_str() );
+				         pline->GetName(),
+				         // this is 'unclean' but the autoexec
+				         // section has no help associated
+				         MSG_Get("AUTOEXEC_CONFIGFILE_HELP"),
+				         pline->data.c_str());
 				return;
 			}
-			if (pvars.size()==1) {
+			if (pvars.size() == 1) {
 				size_t i = 0;
-				WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_SECTHLP"),pvars[0].c_str());
+				WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_SECTHLP"),
+				         pvars[0].c_str());
 				while (true) {
 					// list the properties
 					Property* p = psec->Get_prop(i++);
-					if (p==NULL) break;
+					if (p == NULL) {
+						break;
+					}
 					WriteOut("%s\n", p->propname.c_str());
 				}
 			} else {
 				// find the property by it's name
 				size_t i = 0;
 				while (true) {
-					Property *p = psec->Get_prop(i++);
-					if (p==NULL) break;
-					if (!strcasecmp(p->propname.c_str(),pvars[1].c_str())) {
-						// found it; make the list of possible values
+					Property* p = psec->Get_prop(i++);
+					if (p == NULL) {
+						break;
+					}
+					if (!strcasecmp(p->propname.c_str(),
+					                pvars[1].c_str())) {
+						// found it; make the list of
+						// possible values
 						std::string propvalues;
 						std::vector<Value> pv = p->GetValues();
 
-						if (p->Get_type()==Value::V_BOOL) {
-							// possible values for boolean are true, false
+						if (p->Get_type() == Value::V_BOOL) {
+							// possible values for
+							// boolean are true, false
 							propvalues += "true, false";
-						} else if (p->Get_type()==Value::V_INT) {
-							// print min, max for integer values if used
-							Prop_int* pint = dynamic_cast <Prop_int*>(p);
-							if (pint==NULL) E_Exit("Int property dynamic cast failed.");
-							if (pint->GetMin() != pint->GetMax()) {
+						} else if (p->Get_type() ==
+						           Value::V_INT) {
+							// print min, max for
+							// integer values if used
+							Prop_int* pint =
+							        dynamic_cast<Prop_int*>(
+							                p);
+							if (pint == NULL) {
+								E_Exit("Int property dynamic cast failed.");
+							}
+							if (pint->GetMin() !=
+							    pint->GetMax()) {
 								std::ostringstream oss;
 								oss << pint->GetMin();
 								oss << "..";
@@ -612,21 +738,32 @@ void CONFIG::Run(void) {
 							}
 						}
 						for (Bitu k = 0; k < pv.size(); k++) {
-							if (pv[k].ToString() =="%u")
-								propvalues += MSG_Get("PROGRAM_CONFIG_HLP_POSINT");
-							else propvalues += pv[k].ToString();
-							if ((k+1) < pv.size()) propvalues += ", ";
+							if (pv[k].ToString() == "%u") {
+								propvalues += MSG_Get(
+								        "PROGRAM_CONFIG_HLP_POSINT");
+							} else {
+								propvalues += pv[k].ToString();
+							}
+							if ((k + 1) < pv.size()) {
+								propvalues += ", ";
+							}
 						}
 
-						WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
-							p->propname.c_str(),
-							sec->GetName(),
-							p->GetHelp(), propvalues.c_str(),
-							p->GetDefaultValue().ToString().c_str(),
-							p->GetValue().ToString().c_str());
+						WriteOut(
+						        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
+						        p->propname.c_str(),
+						        sec->GetName(),
+						        p->GetHelp(),
+						        propvalues.c_str(),
+						        p->GetDefaultValue()
+						                .ToString()
+						                .c_str(),
+						        p->GetValue().ToString().c_str());
 						// print 'changability'
-						if (p->GetChange() == Property::Changeable::OnlyAtStart) {
-							WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_NOCHANGE"));
+						if (p->GetChange() ==
+						    Property::Changeable::OnlyAtStart) {
+							WriteOut(MSG_Get(
+							        "PROGRAM_CONFIG_HLP_NOCHANGE"));
 						}
 						return;
 					}
@@ -636,8 +773,8 @@ void CONFIG::Run(void) {
 			return;
 		}
 		case P_AUTOEXEC_CLEAR: {
-			Section_line* sec = dynamic_cast <Section_line*>
-				(control->GetSection(std::string("autoexec")));
+			Section_line* sec = dynamic_cast<Section_line*>(
+			        control->GetSection(std::string("autoexec")));
 			if (!sec) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_SECTION_ERROR"));
 				return;
@@ -650,8 +787,8 @@ void CONFIG::Run(void) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_MISSINGPARAM"));
 				return;
 			}
-			Section_line* sec = dynamic_cast <Section_line*>
-				(control->GetSection(std::string("autoexec")));
+			Section_line* sec = dynamic_cast<Section_line*>(
+			        control->GetSection(std::string("autoexec")));
 			if (!sec) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_SECTION_ERROR"));
 				return;
@@ -662,23 +799,21 @@ void CONFIG::Run(void) {
 			break;
 		}
 		case P_AUTOEXEC_TYPE: {
-			Section_line* sec = dynamic_cast <Section_line*>
-				(control->GetSection(std::string("autoexec")));
+			Section_line* sec = dynamic_cast<Section_line*>(
+			        control->GetSection(std::string("autoexec")));
 			if (!sec) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_SECTION_ERROR"));
 				return;
 			}
-			WriteOut("\n%s",sec->data.c_str());
+			WriteOut("\n%s", sec->data.c_str());
 			break;
 		}
-		case P_REC_AVI_START:
-			CAPTURE_VideoStart();
-			break;
-		case P_REC_AVI_STOP:
-			CAPTURE_VideoStop();
-			break;
+		case P_REC_AVI_START: CAPTURE_VideoStart(); break;
+		case P_REC_AVI_STOP: CAPTURE_VideoStop(); break;
 		case P_START_MAPPER:
-			if (securemode_check()) return;
+			if (securemode_check()) {
+				return;
+			}
 			MAPPER_Run(false);
 			break;
 		case P_GETPROP: {
@@ -686,17 +821,18 @@ void CONFIG::Run(void) {
 			// "property"
 			// "section"
 			// "section" "property"
-			if (pvars.size()==0) {
+			if (pvars.size() == 0) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_GET_SYNTAX"));
 				return;
 			}
 			std::string::size_type spcpos = pvars[0].find_first_of(' ');
 			// split on the ' '
 			if (spcpos != std::string::npos) {
-				pvars.insert(pvars.begin()+1,pvars[0].substr(spcpos+1));
+				pvars.insert(pvars.begin() + 1,
+				             pvars[0].substr(spcpos + 1));
 				pvars[0].erase(spcpos);
 			}
-			switch(pvars.size()) {
+			switch (pvars.size()) {
 			case 1: {
 				// property/section only
 				// is it a section?
@@ -704,41 +840,52 @@ void CONFIG::Run(void) {
 				if (sec) {
 					// list properties in section
 					Bitu i = 0;
-					Section_prop* psec = dynamic_cast <Section_prop*>(sec);
-					if (psec==NULL) {
+					Section_prop* psec =
+					        dynamic_cast<Section_prop*>(sec);
+					if (psec == NULL) {
 						// autoexec section
-						Section_line* pline = dynamic_cast <Section_line*>(sec);
-						if (pline==NULL) E_Exit("Section dynamic cast failed.");
+						Section_line* pline =
+						        dynamic_cast<Section_line*>(sec);
+						if (pline == NULL) {
+							E_Exit("Section dynamic cast failed.");
+						}
 
-						WriteOut("%s",pline->data.c_str());
+						WriteOut("%s", pline->data.c_str());
 						break;
 					}
 					while (true) {
 						// list the properties
 						Property* p = psec->Get_prop(i++);
-						if (p==NULL) break;
-						WriteOut("%s=%s\n", p->propname.c_str(),
-							p->GetValue().ToString().c_str());
+						if (p == NULL) {
+							break;
+						}
+						WriteOut(
+						        "%s=%s\n",
+						        p->propname.c_str(),
+						        p->GetValue().ToString().c_str());
 					}
 				} else {
 					// no: maybe it's a property?
-					sec = control->GetSectionFromProperty(pvars[0].c_str());
+					sec = control->GetSectionFromProperty(
+					        pvars[0].c_str());
 					if (!sec) {
-						WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+						WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+						         pvars[0].c_str());
 						return;
 					}
 					// it's a property name
-					std::string val = sec->GetPropValue(pvars[0].c_str());
-					WriteOut("%s",val.c_str());
-					first_shell->SetEnv("CONFIG",val.c_str());
+					std::string val = sec->GetPropValue(
+					        pvars[0].c_str());
+					WriteOut("%s", val.c_str());
+					first_shell->SetEnv("CONFIG", val.c_str());
 				}
 				break;
 			}
 			case 2: {
 				// section + property
-				const char *sec_name = pvars[0].c_str();
-				const char *prop_name = pvars[1].c_str();
-				const Section *sec = control->GetSection(sec_name);
+				const char* sec_name  = pvars[0].c_str();
+				const char* prop_name = pvars[1].c_str();
+				const Section* sec = control->GetSection(sec_name);
 				if (!sec) {
 					WriteOut(MSG_Get("PROGRAM_CONFIG_SECTION_ERROR"),
 					         sec_name);
@@ -747,7 +894,8 @@ void CONFIG::Run(void) {
 				const std::string val = sec->GetPropValue(prop_name);
 				if (val == NO_SUCH_PROPERTY) {
 					WriteOut(MSG_Get("PROGRAM_CONFIG_NO_PROPERTY"),
-					         prop_name, sec_name);
+					         prop_name,
+					         sec_name);
 					return;
 				}
 				WriteOut("%s\n", val.c_str());
@@ -760,7 +908,7 @@ void CONFIG::Run(void) {
 			}
 			return;
 		}
-		case P_SETPROP:	{
+		case P_SETPROP: {
 			// Code for the configuration changes
 			// Official format: config -set "section property=value"
 			// Accepted: with or without -set,
@@ -774,47 +922,64 @@ void CONFIG::Run(void) {
 			// "property" "value" "value" ...
 			// "property=value" "value" "value" ...
 
-			if (pvars.size()==0) {
+			if (pvars.size() == 0) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
 				return;
 			}
 
 			// add rest of command
 			std::string rest;
-			if (cmd->GetStringRemain(rest)) pvars.push_back(rest);
-			const char *result = SetProp(pvars);
-			if (strlen(result)) WriteOut(result);
-			else {
+			if (cmd->GetStringRemain(rest)) {
+				pvars.push_back(rest);
+			}
+			const char* result = SetProp(pvars);
+			if (strlen(result)) {
+				WriteOut(result);
+			} else {
 				Section* tsec = control->GetSection(pvars[0]);
-				// Input has been parsed (pvar[0]=section, [1]=property, [2]=value)
-				// now execute
+				// Input has been parsed (pvar[0]=section,
+				// [1]=property, [2]=value) now execute
 				std::string value(pvars[2]);
-				//Due to parsing there can be a = at the start of value.
-				while (value.size() && (value.at(0) ==' ' ||value.at(0) =='=') ) value.erase(0,1);
-				for (Bitu i = 3; i < pvars.size(); i++) value += (std::string(" ") + pvars[i]);
-				if (value.empty() ) {
+				// Due to parsing there can be a = at the start
+				// of value.
+				while (value.size() && (value.at(0) == ' ' ||
+				                        value.at(0) == '=')) {
+					value.erase(0, 1);
+				}
+				for (Bitu i = 3; i < pvars.size(); i++) {
+					value += (std::string(" ") + pvars[i]);
+				}
+				if (value.empty()) {
 					WriteOut(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
 					return;
 				}
 				std::string inputline = pvars[1] + "=" + value;
 				tsec->ExecuteDestroy(false);
-				bool change_success = tsec->HandleInputline(inputline.c_str());
-				if (!change_success) WriteOut(MSG_Get("PROGRAM_CONFIG_VALUE_ERROR"),
-                    value.c_str(),pvars[1].c_str());
+				bool change_success = tsec->HandleInputline(
+				        inputline.c_str());
+				if (!change_success) {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_VALUE_ERROR"),
+					         value.c_str(),
+					         pvars[1].c_str());
+				}
 				tsec->ExecuteInit(false);
 			}
 			return;
 		}
-		case P_WRITELANG: case P_WRITELANG2:
-			// In secure mode don't allow a new languagefile to be created
-			// Who knows which kind of file we would overwrite.
-			if (securemode_check()) return;
+		case P_WRITELANG:
+		case P_WRITELANG2:
+			// In secure mode don't allow a new languagefile to be
+			// created Who knows which kind of file we would overwrite.
+			if (securemode_check()) {
+				return;
+			}
 			if (pvars.size() < 1) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_MISSINGPARAM"));
 				return;
 			}
 			if (!MSG_Write(pvars[0].c_str())) {
-				WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"),pvars[0].c_str());
+				WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"),
+				         pvars[0].c_str());
 				return;
 			}
 			break;
@@ -825,42 +990,41 @@ void CONFIG::Run(void) {
 			WriteOut(MSG_Get("PROGRAM_CONFIG_SECURE_ON"));
 			return;
 
-		default:
-			E_Exit("bug");
-			break;
+		default: E_Exit("bug"); break;
 		}
 		first = false;
 	}
-
 }
 
-
-std::unique_ptr<Program> CONFIG_ProgramCreate() {
+std::unique_ptr<Program> CONFIG_ProgramCreate()
+{
 	return ProgramCreate<CONFIG>();
 }
 
-void PROGRAMS_Destroy([[maybe_unused]] Section* sec) {
+void PROGRAMS_Destroy([[maybe_unused]] Section* sec)
+{
 	internal_progs_comdata.clear();
 	internal_progs.clear();
 }
 
-void PROGRAMS_Init(Section* sec) {
+void PROGRAMS_Init(Section* sec)
+{
 	/* Setup a special callback to start virtual programs */
-	call_program=CALLBACK_Allocate();
-	CALLBACK_Setup(call_program,&PROGRAMS_Handler,CB_RETF,"internal program");
+	call_program = CALLBACK_Allocate();
+	CALLBACK_Setup(call_program, &PROGRAMS_Handler, CB_RETF, "internal program");
 
 	// Cleanup -- allows unit tests to run indefinitely & cleanly
-	sec->AddDestroyFunction(&PROGRAMS_Destroy,false);
+	sec->AddDestroyFunction(&PROGRAMS_Destroy, false);
 
 	// listconf
-	MSG_Add("PROGRAM_CONFIG_NOCONFIGFILE","No config file loaded!\n");
-	MSG_Add("PROGRAM_CONFIG_PRIMARY_CONF","Primary config file: \n%s\n");
-	MSG_Add("PROGRAM_CONFIG_ADDITIONAL_CONF","Additional config files:\n");
+	MSG_Add("PROGRAM_CONFIG_NOCONFIGFILE", "No config file loaded!\n");
+	MSG_Add("PROGRAM_CONFIG_PRIMARY_CONF", "Primary config file: \n%s\n");
+	MSG_Add("PROGRAM_CONFIG_ADDITIONAL_CONF", "Additional config files:\n");
 	MSG_Add("PROGRAM_CONFIG_CONFDIR",
 	        "DOSBox Staging %s configuration directory: \n%s\n\n");
 
 	// writeconf
-	MSG_Add("PROGRAM_CONFIG_FILE_ERROR","\nCan't open file %s\n");
+	MSG_Add("PROGRAM_CONFIG_FILE_ERROR", "\nCan't open file %s\n");
 	MSG_Add("PROGRAM_CONFIG_FILE_WHICH", "Writing config file %s\n");
 
 	// help
@@ -890,19 +1054,28 @@ void PROGRAMS_Init(Section* sec) {
 	        "-startmapper starts the keymapper.\n"
 	        "-get \"section property\" returns the value of the property.\n"
 	        "-set \"section property=value\" sets the value.\n");
-	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP","Purpose of property \"%s\" (contained in section \"%s\"):\n%s\n\nPossible Values: %s\nDefault value: %s\nCurrent value: %s\n");
-	MSG_Add("PROGRAM_CONFIG_HLP_LINEHLP","Purpose of section \"%s\":\n%s\nCurrent value:\n%s\n");
-	MSG_Add("PROGRAM_CONFIG_HLP_NOCHANGE","This property cannot be changed at runtime.\n");
-	MSG_Add("PROGRAM_CONFIG_HLP_POSINT","positive integer");
-	MSG_Add("PROGRAM_CONFIG_HLP_SECTHLP","Section %s contains the following properties:\n");
-	MSG_Add("PROGRAM_CONFIG_HLP_SECTLIST","DOSBox configuration contains the following sections:\n\n");
+	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP",
+	        "Purpose of property \"%s\" (contained in section \"%s\"):\n%s\n\nPossible Values: %s\nDefault value: %s\nCurrent value: %s\n");
+	MSG_Add("PROGRAM_CONFIG_HLP_LINEHLP",
+	        "Purpose of section \"%s\":\n%s\nCurrent value:\n%s\n");
+	MSG_Add("PROGRAM_CONFIG_HLP_NOCHANGE",
+	        "This property cannot be changed at runtime.\n");
+	MSG_Add("PROGRAM_CONFIG_HLP_POSINT", "positive integer");
+	MSG_Add("PROGRAM_CONFIG_HLP_SECTHLP",
+	        "Section %s contains the following properties:\n");
+	MSG_Add("PROGRAM_CONFIG_HLP_SECTLIST",
+	        "DOSBox configuration contains the following sections:\n\n");
 
-	MSG_Add("PROGRAM_CONFIG_SECURE_ON","Switched to secure mode.\n");
-	MSG_Add("PROGRAM_CONFIG_SECURE_DISALLOW","This operation is not permitted in secure mode.\n");
+	MSG_Add("PROGRAM_CONFIG_SECURE_ON", "Switched to secure mode.\n");
+	MSG_Add("PROGRAM_CONFIG_SECURE_DISALLOW",
+	        "This operation is not permitted in secure mode.\n");
 	MSG_Add("PROGRAM_CONFIG_SECTION_ERROR", "Section \"%s\" doesn't exist.\n");
-	MSG_Add("PROGRAM_CONFIG_VALUE_ERROR","\"%s\" is not a valid value for property %s.\n");
-	MSG_Add("PROGRAM_CONFIG_GET_SYNTAX","Correct syntax: config -get \"section property\".\n");
-	MSG_Add("PROGRAM_CONFIG_PRINT_STARTUP", "\nDOSBox was started with the following command line parameters:\n%s\n");
+	MSG_Add("PROGRAM_CONFIG_VALUE_ERROR",
+	        "\"%s\" is not a valid value for property %s.\n");
+	MSG_Add("PROGRAM_CONFIG_GET_SYNTAX",
+	        "Correct syntax: config -get \"section property\".\n");
+	MSG_Add("PROGRAM_CONFIG_PRINT_STARTUP",
+	        "\nDOSBox was started with the following command line parameters:\n%s\n");
 	MSG_Add("PROGRAM_CONFIG_MISSINGPARAM", "Missing parameter.\n");
 	MSG_Add("PROGRAM_PATH_TOO_LONG",
 	        "The path \"%s\" exceeds the DOS maximum length of %d characters\n");


### PR DESCRIPTION
Separate the printing loop from the functions into its own helper function, since it's the same in all 3 functions.

Replace sprintf with snprintf to prevent buffer overflow. With sprintf, the program would segfault when the string was too big.

Print a message when the output doesn't fit into the buffer instead of silently truncating.