### PR TITLE
Fix lockup involving specific mount order

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -23,7 +23,7 @@ jobs:
             max_warnings: 20
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 910
+            max_warnings: 904
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -380,6 +380,16 @@ void DOS_AddDevice(DOS_Device * adddev);
 /* DelDevice destroys the device that is pointed to. */
 void DOS_DelDevice(DOS_Device * dev);
 
+// Get, append, and query the DOS device header linked list
+RealPt DOS_GetNextDevice(const RealPt rp);
+RealPt DOS_GetLastDevice();
+void DOS_AppendDevice(const uint16_t segment, const uint16_t offset = 0);
+bool DOS_IsLastDevice(const RealPt rp);
+bool DOS_DeviceHasName(const RealPt rp, const std::string_view req_name);
+bool DOS_DeviceHasAttributes(const RealPt rp, const uint16_t attributes);
+uint16_t DOS_GetDeviceStrategy(const RealPt rp);
+uint16_t DOS_GetDeviceInterrupt(const RealPt rp);
+
 void VFILE_Register(const char *name,
                     const uint8_t *data,
                     const uint32_t size,

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -351,15 +351,7 @@ int CMscdex::AddDrive(uint16_t _drive, char* physicalPath, uint8_t& subUnit)
 		devHeader.SetName				("MSCD001 ");
 
 		//Link it in the device chain
-		uint32_t start = dos_infoblock.GetDeviceChain();
-		uint16_t segm  = (uint16_t)(start>>16);
-		uint16_t offm  = (uint16_t)(start&0xFFFF);
-		while(start != 0xFFFFFFFF) {
-			segm  = (uint16_t)(start>>16);
-			offm  = (uint16_t)(start&0xFFFF);
-			start = real_readd(segm,offm);
-		}
-		real_writed(segm,offm,seg<<16);
+		DOS_AppendDevice(seg);
 
 		// Create Callback Strategy
 		uint16_t off = sizeof(DOS_DeviceHeader::sDeviceHeader);


### PR DESCRIPTION
Fixes #2304, which reports that Staging locks up when a floppy image is mounted before a CDROM image, followed by accessing the mounted floppy drive.

This lockup is caused by the device scanning routine added in 598de87, which enters and endless loop. 

This PR adds some basic routines to walk and query the DOS device linked list, and uses them in function to replace the one that locks up.

To prove that we can trust the replacement function, an intermediate commit compares its results against the original function'd results using asserts (which indeed pass in all of the tests I've thrown at it, including scanning the win 3.11 device drivers). 

Finally the PR pivots to use the replacement function, along with making use of the new functions in the MSCDEX code.

Thanks to @distantvale for catching this.