### PR TITLE
Import structural FPU improvements (non-MMX/SSE) from DOSBox-X

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -41,11 +41,17 @@
 
 
 #define CPU_ARCHTYPE_MIXED			0xff
+#define CPU_ARCHTYPE_8086           0x05
 #define CPU_ARCHTYPE_386SLOW		0x30
 #define CPU_ARCHTYPE_386FAST		0x35
 #define CPU_ARCHTYPE_486OLDSLOW		0x40
 #define CPU_ARCHTYPE_486NEWSLOW		0x45
 #define CPU_ARCHTYPE_PENTIUMSLOW	0x50
+
+#define FPU_ARCHTYPE_8087                       0x07
+#define FPU_ARCHTYPE_287                        0x27
+#define FPU_ARCHTYPE_387                        0x37
+#define FPU_ARCHTYPE_BEST                       0xfe
 
 /* CPU Cycle Timing */
 extern int32_t CPU_Cycles;
@@ -60,6 +66,7 @@ extern bool CPU_SkipCycleAutoAdjust;
 extern Bitu CPU_AutoDetermineMode;
 
 extern Bitu CPU_ArchitectureType;
+extern uint8_t FPU_ArchitectureType;
 
 extern Bitu CPU_PrefetchQueueSize;
 

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -69,6 +69,7 @@ struct FPU_P_Reg {
 	uint16_t d1 = 0;
 	uint32_t d2 = 0;
 };
+static_assert( sizeof(FPU_P_Reg) == 16, "FPU_P_Reg size error" );
 
 enum FPU_Tag : uint8_t {
 	TAG_Valid = 0,

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -262,24 +262,29 @@ static inline void FPU_SetSW(const uint16_t word)
 void FPU_SetPRegsFrom(const uint8_t dyn_regs[8][10]);
 void FPU_GetPRegsTo(uint8_t dyn_regs[8][10]);
 
-static inline void FPU_SET_C0(Bitu C){
-	fpu.sw.C0 = !!C;
+static inline void FPU_SET_C0(const uint16_t value)
+{
+	fpu.sw.C0 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_C1(Bitu C){
-	fpu.sw.C1 = !!C;
+static inline void FPU_SET_C1(const uint16_t value)
+{
+	fpu.sw.C1 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_C2(Bitu C){
-	fpu.sw.C2 = !!C;
+static inline void FPU_SET_C2(const uint16_t value)
+{
+	fpu.sw.C2 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_C3(Bitu C){
-	fpu.sw.C3 = !!C;
+static inline void FPU_SET_C3(const uint16_t value)
+{
+	fpu.sw.C3 = (value > 0) ? 0b1 : 0b0;
 }
 
-static inline void FPU_SET_D(Bitu C){
-	fpu.sw.DE = !!C;
+static inline void FPU_SET_D(const uint16_t value)
+{
+	fpu.sw.DE = (value > 0) ? 0b1 : 0b0;
 }
 
 static inline void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr_t sub)

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -283,6 +283,12 @@ static inline uint16_t FPU_GetSW()
 	return fpu.sw;
 }
 
+static inline void FPU_SetMaskedSW(const uint16_t word, 
+                                   const uint16_t mask = FPUStatusWord::conditionAndExceptionMask)
+{
+	fpu.sw = (word & mask) | (fpu.sw & FPUStatusWord::conditionUnmask);
+}
+
 static inline void FPU_SetSW(const uint16_t word)
 {
 	fpu.sw = word;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -275,7 +275,6 @@ static void maybe_sync_host_fpu_to_dh()
 static BlockReturn sync_normal_fpu_and_run_dyn_code(const uint8_t* code) noexcept
 {
 	if (last_core == CoreType::Normal) {
-		FPU_SET_TOP(TOP);
 		dyn_dh_fpu.state.tag = FPU_GetTag();
 		dyn_dh_fpu.state.cw  = FPU_GetCW();
 		dyn_dh_fpu.state.sw  = FPU_GetSW();
@@ -292,7 +291,6 @@ static Bits sync_dh_fpu_and_run_normal_core() noexcept
 		FPU_SetTag(static_cast<uint16_t>(dyn_dh_fpu.state.tag & 0xffff));
 		FPU_SetCW(static_cast<uint16_t>(dyn_dh_fpu.state.cw & 0xffff));
 		FPU_SetSW(static_cast<uint16_t>(dyn_dh_fpu.state.sw & 0xffff));
-		TOP = FPU_GET_TOP();
 		FPU_SetPRegsFrom(dyn_dh_fpu.state.st_reg);
 		last_core = CoreType::Normal;
 	}

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -306,13 +306,13 @@ static void dyn_fpu_esc1()
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04: /* FLDENV */
-			gen_call_function((void*)&FPU_FLDENV,"%Drd",DREG(EA));
+			gen_call_function((void*)&FPU_FLDENV,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x05: /* FLDCW */
 			gen_call_function((void *)&FPU_FLDCW,"%Drd",DREG(EA));
 			break;
 		case 0x06: /* FSTENV */
-			gen_call_function((void *)&FPU_FSTENV,"%Drd",DREG(EA));
+			gen_call_function((void *)&FPU_FSTENV,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x07:  /* FNSTCW*/
 			gen_call_function((void *)&FPU_FNSTCW,"%Drd",DREG(EA));
@@ -522,15 +522,13 @@ static void dyn_fpu_esc5()
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04:	/* FRSTOR */
-			gen_call_function((void*)&FPU_FRSTOR,"%Drd",DREG(EA));
+			gen_call_function((void*)&FPU_FRSTOR,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x06:	/* FSAVE */
-			gen_call_function((void*)&FPU_FSAVE,"%Drd",DREG(EA));
+			gen_call_function((void*)&FPU_FSAVE,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x07:   /*FNSTSW */
 			gen_protectflags(); 
-			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_SET_TOP,"%Dd",DREG(TMPB));
 			gen_load_host(&fpu.sw,DREG(TMPB),4); 
 			gen_call_function((void*)&mem_writew,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
@@ -618,8 +616,6 @@ static void dyn_fpu_esc7()
 		case 0x04:
 			switch(sub){
 				case 0x00:     /* FNSTSW AX*/
-					gen_load_host(&TOP,DREG(TMPB),4);
-					gen_call_function((void*)&FPU_SET_TOP,"%Drd",DREG(TMPB)); 
 					gen_mov_host(&fpu.sw,DREG(EAX),2);
 					break;
 				default:

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -54,16 +54,22 @@ static void FPU_FFREE(Bitu st) {
 
 static inline void dyn_fpu_top() {
 	gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+	gen_shr_imm(FC_OP2,11); // stack top is 3-bit value starting at bit 11
 	gen_add_imm(FC_OP2,decode.modrm.rm);
 	gen_and_imm(FC_OP2,7);
 	gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+	gen_shr_imm(FC_OP1,11); // stack top is 3-bit value starting at bit 11
+	gen_and_imm(FC_OP1,7);
 }
 
 static inline void dyn_fpu_top_swapped() {
 	gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+	gen_shr_imm(FC_OP1,11); // stack top is 3-bit value starting at bit 11
 	gen_add_imm(FC_OP1,decode.modrm.rm);
 	gen_and_imm(FC_OP1,7);
 	gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+	gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+	gen_and_imm(FC_OP2,7);
 }
 
 static void dyn_eatree() {
@@ -138,6 +144,8 @@ static void dyn_fpu_esc0(){
 		dyn_fill_ea(FC_ADDR);
 		gen_call_function_R((void*)&FPU_FLD_F32_EA,FC_ADDR); 
 		gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+		gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
+		gen_and_imm(FC_OP1,7);
 		dyn_eatree();
 	}
 }
@@ -150,11 +158,14 @@ static void dyn_fpu_esc1(){
 		switch (decode.modrm.reg){
 		case 0x00: /* FLD STi */
 			gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
 			gen_add_imm(FC_OP1,decode.modrm.rm);
 			gen_and_imm(FC_OP1,7);
 			gen_protect_reg(FC_OP1);
 			gen_call_function_raw((void*)&FPU_PREP_PUSH); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_restore_reg(FC_OP1);
 			gen_call_function_RR((void*)&FPU_FST,FC_OP1,FC_OP2);
 			break;
@@ -294,6 +305,8 @@ static void dyn_fpu_esc1(){
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1);
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_call_function_RR((void*)&FPU_FLD_F32,FC_OP1,FC_OP2);
 			break;
 		case 0x01: /* UNKNOWN */
@@ -340,9 +353,12 @@ static void dyn_fpu_esc2(){
 			switch(decode.modrm.rm){
 			case 0x01:		/* FUCOMPP */
 				gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+				gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
 				gen_add_imm(FC_OP2,1);
 				gen_and_imm(FC_OP2,7);
 				gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+				gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
+				gen_and_imm(FC_OP1,7);
 				gen_call_function_RR((void *)&FPU_FUCOM,FC_OP1,FC_OP2);
 				gen_call_function_raw((void *)&FPU_FPOP);
 				gen_call_function_raw((void *)&FPU_FPOP);
@@ -360,6 +376,8 @@ static void dyn_fpu_esc2(){
 		dyn_fill_ea(FC_ADDR);
 		gen_call_function_R((void*)&FPU_FLD_I32_EA,FC_ADDR); 
 		gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+		gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
+		gen_and_imm(FC_OP1,7);
 		dyn_eatree();
 	}
 }
@@ -402,6 +420,8 @@ static void dyn_fpu_esc3()
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_call_function_RR((void*)&FPU_FLD_I32,FC_OP1,FC_OP2);
 			break;
 		case 0x01:	/* FISTTP */
@@ -477,6 +497,8 @@ static void dyn_fpu_esc4(){
 		dyn_fill_ea(FC_ADDR);
 		gen_call_function_R((void*)&FPU_FLD_F64_EA,FC_ADDR); 
 		gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+		gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
+		gen_and_imm(FC_OP1,7);
 		dyn_eatree();
 	}
 }
@@ -517,6 +539,8 @@ static void dyn_fpu_esc5(){
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_call_function_RR((void*)&FPU_FLD_F64,FC_OP1,FC_OP2);
 			break;
 		case 0x01:  /* FISTTP longint*/
@@ -573,9 +597,12 @@ static void dyn_fpu_esc6(){
 				return;
 			}
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
 			gen_add_imm(FC_OP2,1);
 			gen_and_imm(FC_OP2,7);
 			gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP1,7);
 			gen_call_function_RR((void*)&FPU_FCOM,FC_OP1,FC_OP2);
 			gen_call_function_raw((void*)&FPU_FPOP); /* extra pop at the bottom*/
 			break;
@@ -603,6 +630,8 @@ static void dyn_fpu_esc6(){
 		dyn_fill_ea(FC_ADDR);
 		gen_call_function_R((void*)&FPU_FLD_I16_EA,FC_ADDR); 
 		gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
+		gen_shr_imm(FC_OP1,11); /* stack top is 3-bit value starting at bit 11 */
+		gen_and_imm(FC_OP1,7);
 		dyn_eatree();
 	}
 }
@@ -648,6 +677,8 @@ static void dyn_fpu_esc7(){
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_call_function_RR((void*)&FPU_FLD_I16,FC_OP1,FC_OP2);
 			break;
 		case 0x01:
@@ -666,12 +697,16 @@ static void dyn_fpu_esc7(){
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1);
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_call_function_RR((void*)&FPU_FBLD,FC_OP1,FC_OP2);
 			break;
 		case 0x05:  /* FILD int64_t */
 			gen_call_function_raw((void*)&FPU_PREP_PUSH);
 			dyn_fill_ea(FC_OP1);
 			gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);
+			gen_shr_imm(FC_OP2,11); /* stack top is 3-bit value starting at bit 11 */
+			gen_and_imm(FC_OP2,7);
 			gen_call_function_RR((void*)&FPU_FLD_I64,FC_OP1,FC_OP2);
 			break;
 		case 0x06:	/* FBSTP packed BCD */

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -310,7 +310,7 @@ static void dyn_fpu_esc1(){
 			break;
 		case 0x04: /* FLDENV */
 			dyn_fill_ea(FC_ADDR);
-			gen_call_function_R((void*)&FPU_FLDENV,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FLDENV, FC_ADDR, !decode.big_op);
 			break;
 		case 0x05: /* FLDCW */
 			dyn_fill_ea(FC_ADDR);
@@ -318,7 +318,7 @@ static void dyn_fpu_esc1(){
 			break;
 		case 0x06: /* FSTENV */
 			dyn_fill_ea(FC_ADDR);
-			gen_call_function_R((void *)&FPU_FSTENV,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FSTENV, FC_ADDR, !decode.big_op);
 			break;
 		case 0x07:  /* FNSTCW*/
 			dyn_fill_ea(FC_ADDR);
@@ -533,15 +533,13 @@ static void dyn_fpu_esc5(){
 			break;
 		case 0x04:	/* FRSTOR */
 			dyn_fill_ea(FC_ADDR); 
-			gen_call_function_R((void*)&FPU_FRSTOR,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FRSTOR, FC_ADDR, !decode.big_op);
 			break;
 		case 0x06:	/* FSAVE */
 			dyn_fill_ea(FC_ADDR); 
-			gen_call_function_R((void*)&FPU_FSAVE,FC_ADDR);
+			gen_call_function_RI((void*)&FPU_FSAVE, FC_ADDR, !decode.big_op);
 			break;
 		case 0x07:   /*FNSTSW */
-			gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
-			gen_call_function_R((void*)&FPU_SET_TOP,FC_OP1);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&fpu.sw),false);
 			gen_call_function_RR((void*)&mem_writew,FC_OP1,FC_OP2);
@@ -632,8 +630,6 @@ static void dyn_fpu_esc7(){
 		case 0x04:
 			switch(decode.modrm.rm){
 				case 0x00:     /* FNSTSW AX*/
-					gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
-					gen_call_function_R((void*)&FPU_SET_TOP,FC_OP1); 
 					gen_mov_word_to_reg(FC_OP1,(void*)(&fpu.sw),false);
 					MOV_REG_WORD16_FROM_HOST_REG(FC_OP1,DRC_REG_EAX);
 					break;

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -664,6 +664,10 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	}
 }
 
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+    cache_addd( MOV_REG_LSR_IMM(reg, reg, imm) );
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -718,6 +718,10 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	}
 }
 
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+    cache_addd( LSR_IMM(reg, reg, imm) );
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -715,6 +715,10 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	}
 }
 
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+    cache_addd( LSR_IMM(reg, reg, imm) );
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -564,6 +564,10 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	}
 }
 
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+    cache_addd( LSR_IMM(reg, reg, imm) );
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -656,6 +656,10 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	}
 }
 
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+    cache_addd( LSR64_IMM(reg, reg, imm) );
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -278,7 +278,11 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	cache_addd(imm);
 }
 
-
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+	cache_addw(0xe8c1+(reg<<8));		// shr reg,imm
+	cache_addb(imm);
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_dynrec/risc_x86.h
+++ b/src/cpu/core_dynrec/risc_x86.h
@@ -195,7 +195,11 @@ static void gen_and_imm(HostReg reg,uint32_t imm) {
 	cache_addd(imm);
 }
 
-
+// shift right a register by an 8-bit constant
+static void gen_shr_imm(HostReg reg,uint8_t imm) {
+	cache_addw(0xe8c1+(reg<<8));		// shr reg,imm
+	cache_addb(imm);
+}
 
 // move a 32bit constant value into memory
 static void gen_mov_direct_dword(void* dest,uint32_t imm) {

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -627,11 +627,11 @@ switch (inst.code.op) {
 #if C_FPU
 		switch (((inst.rm>=0xc0) << 3) | inst.code.save) {
 		case 0x00:	FPU_ESC0_EA(inst.rm,inst.rm_eaa);break;
-		case 0x01:	FPU_ESC1_EA(inst.rm,inst.rm_eaa);break;
+		case 0x01:	FPU_ESC1_EA(inst.rm,inst.rm_eaa,inst.code.extra);break;
 		case 0x02:	FPU_ESC2_EA(inst.rm,inst.rm_eaa);break;
 		case 0x03:	FPU_ESC3_EA(inst.rm,inst.rm_eaa);break;
 		case 0x04:	FPU_ESC4_EA(inst.rm,inst.rm_eaa);break;
-		case 0x05:	FPU_ESC5_EA(inst.rm,inst.rm_eaa);break;
+		case 0x05:	FPU_ESC5_EA(inst.rm,inst.rm_eaa,inst.code.extra);break;
 		case 0x06:	FPU_ESC6_EA(inst.rm,inst.rm_eaa);break;
 		case 0x07:	FPU_ESC7_EA(inst.rm,inst.rm_eaa);break;
 

--- a/src/cpu/core_full/optable.h
+++ b/src/cpu/core_full/optable.h
@@ -174,10 +174,10 @@ static OpCode OpCodeTable[1024]={
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 //TODO FPU
 /* 0xd8 - 0xdf */
-{L_MODRM	,O_FPU		,0		,0		},{L_MODRM	,O_FPU		,1		,0		},
-{L_MODRM	,O_FPU		,2		,0		},{L_MODRM	,O_FPU		,3		,0		},
-{L_MODRM	,O_FPU		,4		,0		},{L_MODRM	,O_FPU		,5		,0		},
-{L_MODRM	,O_FPU		,6		,0		},{L_MODRM	,O_FPU		,7		,0		},
+{L_MODRM	,O_FPU		,0		,true   },{L_MODRM	,O_FPU		,1		,true   },
+{L_MODRM	,O_FPU		,2		,true   },{L_MODRM	,O_FPU		,3		,true   },
+{L_MODRM	,O_FPU		,4		,true   },{L_MODRM	,O_FPU		,5		,true   },
+{L_MODRM	,O_FPU		,6		,true   },{L_MODRM	,O_FPU		,7		,true   },
 
 /* 0xe0 - 0xe7 */
 {L_Ibx		,O_LOOPNZ	,S_AIPw	,0		},{L_Ibx	,O_LOOPZ	,S_AIPw	,0		},
@@ -529,10 +529,10 @@ static OpCode OpCodeTable[1024]={
 {L_Ib		,O_AAM		,0		,0		},{L_Ib		,O_AAD		,0		,0		},
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 /* 0x2d8 - 0x2df */
-{L_MODRM	,O_FPU		,0		,0		},{L_MODRM	,O_FPU		,1		,0		},
-{L_MODRM	,O_FPU		,2		,0		},{L_MODRM	,O_FPU		,3		,0		},
-{L_MODRM	,O_FPU		,4		,0		},{L_MODRM	,O_FPU		,5		,0		},
-{L_MODRM	,O_FPU		,6		,0		},{L_MODRM	,O_FPU		,7		,0		},
+{L_MODRM	,O_FPU		,0		,false  },{L_MODRM	,O_FPU		,1		,false  },
+{L_MODRM	,O_FPU		,2		,false  },{L_MODRM	,O_FPU		,3		,false  },
+{L_MODRM	,O_FPU		,4		,false  },{L_MODRM	,O_FPU		,5		,false  },
+{L_MODRM	,O_FPU		,6		,false  },{L_MODRM	,O_FPU		,7		,false  },
 
 /* 0x2e0 - 0x2e7 */
 {L_Ibx		,O_LOOPNZ	,S_AIPd	,0		},{L_Ibx	,O_LOOPZ	,S_AIPd	,0		},

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -141,6 +141,15 @@
 	}																		\
 }
 
+#define FPU_ESC_SIZE(code, op16) {														\
+	uint8_t rm=Fetchb();														\
+	if (rm >= 0xc0) {															\
+		FPU_ESC ## code ## _Normal(rm);										\
+	} else {																\
+		GetEAa;FPU_ESC ## code ## _EA(rm,eaa,op16);								\
+	}																		\
+}
+
 #define CASE_W(_WHICH)							\
 	case (OPCODE_NONE+_WHICH):
 

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -583,17 +583,19 @@
 	CASE_0F_B(0xc0)												/* XADD Gb,Eb */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrb;uint8_t oldrmrb=*rmrb;
-			if (rm >= 0xc0 ) {GetEArb;*rmrb=*earb;*earb+=oldrmrb;}
-			else {GetEAa;*rmrb=LoadMb(eaa);SaveMb(eaa,LoadMb(eaa)+oldrmrb);}
+			GetRMrb;auto oldrmrb=lf_var2b=*rmrb;
+			if (rm >= 0xc0 ) {GetEArb;lf_var1b=*rmrb=*earb;*earb+=oldrmrb;lf_resb=*earb;}
+			else {GetEAa;lf_var1b=*rmrb=LoadMb(eaa);SaveMb(eaa,lf_resb=*rmrb+oldrmrb);}
+			lflags.type=t_ADDb;
 			break;
 		}
 	CASE_0F_W(0xc1)												/* XADD Gw,Ew */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrw;uint16_t oldrmrw=*rmrw;
-			if (rm >= 0xc0 ) {GetEArw;*rmrw=*earw;*earw+=oldrmrw;}
-			else {GetEAa;*rmrw=LoadMw(eaa);SaveMw(eaa,LoadMw(eaa)+oldrmrw);}
+			GetRMrw;auto oldrmrw=lf_var2w=*rmrw;
+			if (rm >= 0xc0 ) {GetEArw;lf_var1w=*rmrw=*earw;*earw+=oldrmrw;lf_resw=*earw;}
+			else {GetEAa;lf_var1w=*rmrw=LoadMw(eaa);SaveMw(eaa,lf_resw=*rmrw+oldrmrw);}
+			lflags.type=t_ADDw;
 			break;
 		}
 	CASE_0F_W(0xc8)												/* BSWAP AX */

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -436,9 +436,10 @@
 	CASE_0F_D(0xc1)												/* XADD Gd,Ed */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLDSLOW) goto illegal_opcode;
-			GetRMrd;uint32_t oldrmrd=*rmrd;
-			if (rm >= 0xc0 ) {GetEArd;*rmrd=*eard;*eard+=oldrmrd;}
-			else {GetEAa;*rmrd=LoadMd(eaa);SaveMd(eaa,LoadMd(eaa)+oldrmrd);}
+			GetRMrd;auto oldrmrd=lf_var2d=*rmrd;
+			if (rm >= 0xc0 ) {GetEArd;lf_var1d=*rmrd=*eard;*eard+=oldrmrd;lf_resd=*eard;}
+			else {GetEAa;lf_var1d=*rmrd=LoadMd(eaa);SaveMd(eaa,lf_resd=*rmrd+oldrmrd);}
+			lflags.type=t_ADDd;
 			break;
 		}
 	CASE_0F_D(0xc8)												/* BSWAP EAX */

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -818,7 +818,7 @@
 	CASE_B(0xd8)												/* FPU ESC 0 */
 		 FPU_ESC(0);break;
 	CASE_B(0xd9)												/* FPU ESC 1 */
-		 FPU_ESC(1);break;
+		 FPU_ESC_SIZE(1, !(core.opcode_index&OPCODE_SIZE));break;
 	CASE_B(0xda)												/* FPU ESC 2 */
 		 FPU_ESC(2);break;
 	CASE_B(0xdb)												/* FPU ESC 3 */
@@ -826,7 +826,7 @@
 	CASE_B(0xdc)												/* FPU ESC 4 */
 		 FPU_ESC(4);break;
 	CASE_B(0xdd)												/* FPU ESC 5 */
-		 FPU_ESC(5);break;
+		 FPU_ESC_SIZE(5, !(core.opcode_index&OPCODE_SIZE));break;
 	CASE_B(0xde)												/* FPU ESC 6 */
 		 FPU_ESC(6);break;
 	CASE_B(0xdf)												/* FPU ESC 7 */

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -415,6 +415,12 @@ void FPU_ESC3_Normal(Bitu rm) {
 			E_Exit("ESC 3: ILLEGAL OPCODE group %u subfunction %u", group, sub);
 		}
 		break;
+	case 0x05:              /* FUCOMI STi */
+			FPU_FUCOMI(TOP,STV(sub));
+			break;
+	case 0x06:              /* FCOMI STi */
+			FPU_FCOMI(TOP,STV(sub));
+			break;
 	default:
 		FPU_LOG_WARN(3, false, group, sub);
 		break;
@@ -640,6 +646,14 @@ void FPU_ESC7_Normal(Bitu rm) {
 				break;
 		}
 		break;
+	case 0x05:              /* FUCOMIP STi */
+			FPU_FUCOMI(TOP,STV(sub));
+			FPU_FPOP();
+			break;
+	case 0x06:              /* FCOMIP STi */
+			FPU_FCOMI(TOP,STV(sub));
+			FPU_FPOP();
+			break;
 	default:
 		FPU_LOG_WARN(7,false,group,sub);
 		break;

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -336,6 +336,26 @@ void FPU_ESC2_Normal(Bitu rm) {
 	Bitu group=(rm >> 3) & 7;
 	Bitu sub=(rm & 7);
 	switch(group){
+	case 0x00: /* FCMOVB STi */
+		if (TFLG_B) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x01: /* FCMOVE STi */
+		if (TFLG_Z) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x02: /* FCMOVBE STi */
+		if (TFLG_BE) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x03: /* FCMOVU STi */
+		if (TFLG_P) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
 	case 0x05:
 		switch(sub){
 		case 0x01:		/* FUCOMPP */
@@ -391,6 +411,26 @@ void FPU_ESC3_Normal(Bitu rm) {
 	const auto group = static_cast<unsigned>((rm >> 3) & 7);
 	const auto sub = static_cast<unsigned>(rm & 7);
 	switch (group) {
+	case 0x00: /* FCMOVNB STi */
+		if (TFLG_NB) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x01: /* FCMOVNE STi */
+		if (TFLG_NZ) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x02: /* FCMOVNBE STi */
+		if (TFLG_NBE) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
+	case 0x03: /* FCMOVNU STi */
+		if (TFLG_NP) {
+			FPU_FCMOV(TOP, STV(sub));
+		}
+		break;
 	case 0x04:
 		switch (sub) {
 		case 0x00:				//FNENI

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -20,10 +20,11 @@
 #include "fpu.h"
 #endif
 
+static void FPU_FINIT()
+{
+	fpu.cw = {};
+	fpu.sw = {};
 
-static void FPU_FINIT(void) {
-	fpu.cw.init();
-	fpu.sw.init();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -101,15 +101,11 @@ static void FPU_FPOP(void){
 
 static double FROUND(double in){
 	switch (fpu.cw.RC){
-	case fpu::RoundMode::Nearest:
-		return std::nearbyint(in);
-	case fpu::RoundMode::Down:
-		return (floor(in));
-	case fpu::RoundMode::Up:
-		return (ceil(in));
-	case fpu::RoundMode::Chop:
-		[[fallthrough]]; // cast by the caller chops
-	default: return in;
+	case FPUControlWord::RoundMode::Nearest: return std::nearbyint(in);
+	case FPUControlWord::RoundMode::Down: return floor(in);
+	case FPUControlWord::RoundMode::Up: return ceil(in);
+	case FPUControlWord::RoundMode::Chop: [[fallthrough]]; // cast by the caller chops
+	default: return in; break;
 	}
 }
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -515,9 +515,9 @@ static void FPU_FPREM(void){
 //	Real64 res=valtop - ressaved*valdiv; 
 //      res= fmod(valtop,valdiv);
 	fpu.regs[TOP].d = valtop - ressaved*valdiv;
-	FPU_SET_C0(static_cast<Bitu>(ressaved&4));
-	FPU_SET_C3(static_cast<Bitu>(ressaved&2));
-	FPU_SET_C1(static_cast<Bitu>(ressaved&1));
+	FPU_SET_C0(static_cast<uint8_t>(ressaved & 4));
+	FPU_SET_C3(static_cast<uint8_t>(ressaved & 2));
+	FPU_SET_C1(static_cast<uint8_t>(ressaved & 1));
 	FPU_SET_C2(0);
 }
 
@@ -531,9 +531,9 @@ static void FPU_FPREM1(void){
 	else if (quot-quotf<0.5) ressaved = static_cast<int64_t>(quotf);
 	else ressaved = static_cast<int64_t>((((static_cast<int64_t>(quotf))&1)!=0)?(quotf+1):(quotf));
 	fpu.regs[TOP].d = valtop - ressaved*valdiv;
-	FPU_SET_C0(static_cast<Bitu>(ressaved&4));
-	FPU_SET_C3(static_cast<Bitu>(ressaved&2));
-	FPU_SET_C1(static_cast<Bitu>(ressaved&1));
+	FPU_SET_C0(static_cast<uint8_t>(ressaved & 4));
+	FPU_SET_C3(static_cast<uint8_t>(ressaved & 2));
+	FPU_SET_C1(static_cast<uint8_t>(ressaved & 1));
 	FPU_SET_C2(0);
 }
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -400,6 +400,10 @@ static void FPU_FST(Bitu st, Bitu other){
 	fpu.regs[other] = fpu.regs[st];
 }
 
+static inline void FPU_FCMOV(Bitu st, Bitu other) {
+        fpu.tags[st] = fpu.tags[other];
+        fpu.regs[st] = fpu.regs[other];
+}
 
 static void FPU_FCOM(Bitu st, Bitu other){
 	if (((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) ||

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1008,18 +1008,21 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         );
 #endif
 
-static void FPU_FINIT(void) {
-	fpu.cw.init();
-	fpu.sw.init();
-	fpu.tags[0]=TAG_Empty;
-	fpu.tags[1]=TAG_Empty;
-	fpu.tags[2]=TAG_Empty;
-	fpu.tags[3]=TAG_Empty;
-	fpu.tags[4]=TAG_Empty;
-	fpu.tags[5]=TAG_Empty;
-	fpu.tags[6]=TAG_Empty;
-	fpu.tags[7]=TAG_Empty;
-	fpu.tags[8]=TAG_Valid; // is only used by us
+static void FPU_FINIT()
+{
+	fpu.cw = {};
+	fpu.sw = {};
+
+	fpu.tags[0] = TAG_Empty;
+	fpu.tags[1] = TAG_Empty;
+	fpu.tags[2] = TAG_Empty;
+	fpu.tags[3] = TAG_Empty;
+	fpu.tags[4] = TAG_Empty;
+	fpu.tags[5] = TAG_Empty;
+	fpu.tags[6] = TAG_Empty;
+	fpu.tags[7] = TAG_Empty;
+
+	fpu.tags[8] = TAG_Valid; // is only used by us
 }
 
 static void FPU_FCLEX(void){

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1278,6 +1278,12 @@ static void FPU_FST(Bitu stv, Bitu other){
 	FPU_SET_C1(0);
 }
 
+static inline void FPU_FCMOV(Bitu st, Bitu other)
+{
+	fpu.p_regs[st] = fpu.p_regs[other];
+	fpu.tags[st]   = fpu.tags[other];
+}
+
 /* FPU_P_Reg holds the raw data fed to the host x86 FPU registers.
  * We can't guarantee that std::isinf() can handle that or that anything
  * in the host C++ compiler supports long double, so do it ourself */

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -60,8 +60,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fnstsw	new_sw			\
 		__asm	fstp	TBYTE PTR fpu.p_regs[ebx].m1	\
 		}								\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -79,8 +78,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	op		szI PTR fpu.p_regs[eax].m1		\
 		__asm	fnstsw	new_sw			\
 		}								\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -113,8 +111,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw   new_sw                                       \
         __asm    fldcw    save_cw                                      \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsin,fcos,f2xm1,fchs,fabs
@@ -130,8 +127,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw  new_sw                            \
         __asm    fstp    TBYTE PTR fpu.p_regs[eax].m1      \
         }                                                  \
-        fpu.sw = (new_sw & sw_mask) |                      \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fsincos
 #define FPUD_SINCOS()                                                           \
@@ -158,7 +154,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     st(0)                                                 \
         __asm    end_sincos:                                                    \
         }                                                                       \
-        fpu.sw = (new_sw & sw_mask) | (fpu.sw & ~FPUStatusWord::conditionMask); \
+        FPU_SetMaskedSW(new_sw, sw_mask); \
         if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fptan
@@ -186,8 +182,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     st(0)                             \
         __asm    end_ptan:                                  \
         }                                                   \
-        fpu.sw = (new_sw & sw_mask) |                       \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);  \
+        FPU_SetMaskedSW(new_sw, sw_mask);  \
         if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fxtract
@@ -225,8 +220,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                 \
         __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                 \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_SetMaskedSW(new_sw);             \
         FPU_PREP_PUSH();
 #endif
 
@@ -265,8 +259,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fadd,fmul,fsub,fsubr
@@ -300,8 +293,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsqrt,frndint
@@ -336,8 +328,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fstp     TBYTE PTR fpu.p_regs[eax].m1                 \
         __asm    fldcw    save_cw                                      \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fdiv,fdivr
@@ -359,8 +350,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
@@ -379,8 +369,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	fstp	TBYTE PTR fpu.p_regs[eax].m1	 \
 		__asm	fldcw	save_cw				\
 		}									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fprem,fprem1,fscale
 #define FPUD_REMAINDER(op)                                         \
@@ -404,8 +393,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
     __asm   fstp    st(0)                                          \
     __asm   fldcw   save_cw                                        \
     }                                                              \
-    fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+    FPU_SetMaskedSW(new_sw);
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)			\
@@ -421,8 +409,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	op					\
 		__asm	fnstsw	new_sw		\
 		}							\
-		fpu.sw = (new_sw & sw_mask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw, sw_mask);
 
 #define FPUD_COMPARE_EA(op)			\
 		uint16_t new_sw;				\
@@ -434,8 +421,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 		__asm	op					\
 		__asm	fnstsw	new_sw		\
 		}							\
-		fpu.sw = (new_sw & sw_mask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)                                   \
@@ -450,8 +436,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw   new_sw                           \
         __asm    fstp     st(0)                            \
         }                                                  \
-        fpu.sw = (new_sw & sw_mask) |                      \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+        FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fpatan,fyl2xp1
 #ifdef WEAK_EXCEPTIONS
@@ -488,8 +473,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw   new_sw                                       \
         __asm    fstp     TBYTE PTR fpu.p_regs[ebx].m1                 \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_SetMaskedSW(new_sw);             \
         FPU_FPOP();
 #endif
 
@@ -528,8 +512,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         __asm    fnstsw  new_sw                                        \
         __asm    fstp    TBYTE PTR fpu.p_regs[ebx].m1                  \
         }                                                              \
-        fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);             \
+        FPU_SetMaskedSW(new_sw);             \
         FPU_FPOP();
 #endif
 
@@ -580,8 +563,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (fpu.p_regs[store_to])		\
 			:	"m" (fpu.p_regs[8])			\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -602,8 +584,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"m" (fpu.p_regs[8])			\
 			:								\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 #ifdef WEAK_EXCEPTIONS
@@ -632,8 +613,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "=m" (fpu.p_regs[8])	\
 			:	"m" (fpu.p_regs[TOP]), "m" (cw_masked)			\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsin,fcos,f2xm1,fchs,fabs
@@ -647,8 +627,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			"fstpt		%1				"	\
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw = (new_sw & sw_mask) |       \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw, sw_mask);
 
 // handles fsincos
 #define FPUD_SINCOS()					\
@@ -669,8 +648,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:								\
 			:	"ax", "cc"					\
 		);									\
-		fpu.sw = (new_sw & sw_mask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask); \
+		FPU_SetMaskedSW(new_sw, sw_mask); \
 		if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fptan
@@ -692,8 +670,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:								\
 			:	"ax", "cc"					\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask); \
+		FPU_SetMaskedSW(new_sw); \
 		if (!fpu.sw.C2) FPU_PREP_PUSH();
 
 // handles fxtract
@@ -720,8 +697,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[TOP]),	\
 				"=m" (fpu.p_regs[(TOP-1)&7])			\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
+		FPU_SetMaskedSW(new_sw);             \
 		FPU_PREP_PUSH();
 #endif
 
@@ -756,8 +732,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fadd,fmul,fsub,fsubr
@@ -789,8 +764,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fsqrt,frndint
@@ -822,8 +796,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])	\
 			:	"m" (cw_masked)		\
 		);										\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 #endif
 
 // handles fdiv,fdivr
@@ -843,8 +816,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
@@ -862,8 +834,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
 			:	"m" (cw_masked)		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fprem,fprem1,fscale
 #define FPUD_REMAINDER(op)                                         \
@@ -882,8 +853,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
         : "=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])  \
         : "m" (fpu.p_regs[(TOP+1)&7]), "m" (cw_masked)             \
     );                                                             \
-    fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-                 (fpu.sw & ~FPUStatusWord::conditionMask);
+    FPU_SetMaskedSW(new_sw);
 
 // handles fcom,fucom
 #define FPUD_COMPARE(op)					\
@@ -897,8 +867,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[op1]), "m" (fpu.p_regs[op2])	\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fcom,fucom
 #define FPUD_COMPARE_EA(op)					\
@@ -911,8 +880,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[op1])		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fxam,ftst
 #define FPUD_EXAMINE(op)					\
@@ -926,8 +894,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw)				\
 			:	"m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);
+		FPU_SetMaskedSW(new_sw);
 
 // handles fpatan,fyl2xp1
 #ifdef WEAK_EXCEPTIONS
@@ -954,8 +921,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[(TOP+1)&7])		\
 			:	"m" (fpu.p_regs[TOP])		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
+		FPU_SetMaskedSW(new_sw);             \
 		FPU_FPOP();
 #endif
 
@@ -984,8 +950,7 @@ static constexpr uint16_t sw_mask = FPUStatusWord::conditionAndExceptionMask;
 			:	"=&am" (new_sw), "+m" (fpu.p_regs[(TOP+1)&7])		\
 			:	"m" (fpu.p_regs[TOP]) 		\
 		);									\
-		fpu.sw = (new_sw & FPUStatusWord::conditionAndExceptionMask) | \
-		         (fpu.sw & ~FPUStatusWord::conditionMask);             \
+		FPU_SetMaskedSW(new_sw);             \
 		FPU_FPOP();
 #endif
 


### PR DESCRIPTION
This PR imports the structural FPU improvements in the DOSBox-X FPU by @TomCat, @ern0, @cimarronm, and @joncampbell123 with all changes brought in verbatim (formatting, style, and naming all as-is).

With the X team continuing to improve the FPU, such as the move to bit-level control of the status word registers, the goal of this PR is to sync these aspects of the FPU to allow for easier code portability between Staging and X.

https://archive.org/details/MDIAG_ZIP

![mcpdiag_001](https://user-images.githubusercontent.com/1557255/220465734-408c99e6-0d45-4ed3-9342-113d0f9f9e52.png)

It will also allow for adjusting the FPU type to along with the current machine type (for example, pcjr, tandy, and <= 286 CPUs). This isn't included in this PR, but this is now possible:

https://archive.org/details/msdos_MCPDIAG_shareware

---

This is re-opened from https://github.com/dosbox-staging/dosbox-staging/pull/2294 plus @joncampbell123's fixes added, which now pass on the ARM M1  without regressions versus the `main` branch (using both the normal and dynamic cores).