### PR TITLE
Pause fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,8 +34,11 @@ Standard: c++17
 # int& var; // 'var' is a reference-to-int
 # const int& var; // 'var' is a constant-reference-to-int
 PointerAlignment: Left
-ReferenceAlignment: Left
-QualifierAlignment: Left
+# Commenting out for now as VisualStudio 2019 doesn't recognise it
+#ReferenceAlignment: Left
+
+# Commenting out for now as VisualStudio 2019 doesn't recognise it
+#QualifierAlignment: Left
 
 # The extra indent or outdent of class access modifiers, e.g. public:
 #
@@ -189,7 +192,8 @@ AlwaysBreakTemplateDeclarations: Yes
 #      --i;                                      --i;
 #    while (i);
 #
-InsertBraces: true
+# Commenting out for now as VisualStudio 2019 doesn't recognise it
+#InsertBraces: true
 
 # Attach braces to surrounding context except break before braces on function
 # definitions (also known as K&R indentation style). This is C-derived style,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3637,8 +3637,10 @@ static void GUI_StartUp(Section *sec)
 	SetPriorityLevels(priority_conf->Get_string("active"),
 	                  priority_conf->Get_string("inactive"));
 
-	sdl.mute_when_inactive  = section->Get_bool("mute_when_inactive");
 	sdl.pause_when_inactive = section->Get_bool("pause_when_inactive");
+
+	sdl.mute_when_inactive = section->Get_bool("mute_when_inactive") ||
+	                         sdl.pause_when_inactive;
 
 	// Adjust the fallback resolution based on the user's aspect-correction
 	const auto should_stretch_pixels = wants_stretched_pixels();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -571,9 +571,7 @@ void GFX_RequestExit(const bool pressed)
 			}
 			break;
 		case SDL_KEYDOWN: // Must use Pause/Break Key to resume.
-		case SDL_KEYUP:
-			if (event.key.keysym.sym == SDLK_PAUSE ||
-			    event.key.keysym.sym == SDLK_ESCAPE) {
+			if (event.key.keysym.sym == SDLK_PAUSE) {
 				const uint16_t outkeymod = event.key.keysym.mod;
 				if (inkeymod != outkeymod) {
 					KEYBOARD_ClrBuffer();


### PR DESCRIPTION
Pause is quite broken in main, at least on my Win 10 box. If I pause with Alt-Pause, DOSBox will automatically unpause itself in about a second, without exception, after which the _next_ Alt-Pause doesn't event get registered, only the _second next_! So this is effectively unusable...

This PR fixes that, and also removes support for using the Esc key to exit pause mode (the reason being that when I use Esc to unpause, the next Alt-Pause keypress always gets ignored; only the _second one_ does actually pause DOSBox again...)

This is a disgusting mess, along with the whole mapper, and I simply refuse to do serious work on it until we do a complete rewrite. At least, this makes the pause functionality usable (but you can't remap it, that never worked... arrrrgh...)

Would be good to test it on Linux, and perhaps someone could check it on macOS too... someone who has a keyboard with an F16 button, which acts as the pause button (Fn-F16 or something... thanks Apple 🤦🏻‍♂️)

There's a second fix too for the scenario when `pause_when_inactive` is enabled, but `mute_when_inactive` is left disabled. Well, mute is implicit when DOSBox is paused, but I needed to make that a bit more explicit in the code to handle external MIDI devices properly. Just try some game using an external MIDI synth and pause/unpause a few times (e.g. Space Quest V intro), and it should be obvious why the fix is needed.