### PR TITLE
Fix compilation error on `misc_util.h` 

### DIFF
--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -56,7 +56,7 @@
 #include <ctime>
 #endif
 
-#include <SDL_net.h>
+#include <SDL2/SDL_net.h>
 
 #include "../../libs/enet/include/enet.h"
 


### PR DESCRIPTION
Meson couldn't compile because of this.