### PR TITLE
Cleanup two ASAN initialization order issues

### DIFF
--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -643,16 +643,20 @@ static std::vector<MouseInterface *> get_relevant_interfaces(
 {
 	std::vector<MouseInterface *> list_tmp = {};
 
-	if (list_ids.empty())
+	if (list_ids.empty()) {
 		// If command does not specify interfaces,
 		// assume we are interested in all of them
-		list_tmp = mouse_interfaces;
-	else
-		for (const auto &interface_id : list_ids) {
-			auto interface = MouseInterface::Get(interface_id);
-			if (interface)
-				list_tmp.push_back(interface);
+		for (const auto& interface : mouse_interfaces) {
+			list_tmp.push_back(interface.get());
 		}
+	} else {
+		for (const auto& id : list_ids) {
+			if (const auto interface = MouseInterface::Get(id);
+			    interface) {
+				list_tmp.push_back(interface);
+			}
+		}
+	}
 
 	// Filter out not emulated ones
 	std::vector<MouseInterface *> list_out = {};

--- a/src/hardware/input/mouse_common.cpp
+++ b/src/hardware/input/mouse_common.cpp
@@ -29,8 +29,8 @@ CHECK_NARROWING();
 // Common variables
 // ***************************************************************************
 
-MouseInfo   mouse_info;
-MouseShared mouse_shared;
+MouseInfo mouse_info     = {};
+MouseShared mouse_shared = {};
 
 // ***************************************************************************
 // Common helper calculations

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -119,6 +119,7 @@ public:
 	MouseInterface()                                 = delete;
 	MouseInterface(const MouseInterface&)            = delete;
 	MouseInterface& operator=(const MouseInterface&) = delete;
+	virtual ~MouseInterface()                        = default;
 
 	static void InitAllInstances();
 	static MouseInterface* Get(const MouseInterfaceId interface_id);
@@ -173,7 +174,6 @@ protected:
 
 	MouseInterface(const MouseInterfaceId interface_id,
 	               const float sensitivity_predefined);
-	virtual ~MouseInterface() = default;
 	virtual void Init();
 
 	uint8_t GetInterfaceIdx() const;
@@ -221,6 +221,6 @@ private:
 	float sensitivity_predefined = 1.0f; // hardcoded for the given interface
 };
 
-extern std::vector<MouseInterface*> mouse_interfaces;
+extern std::vector<std::unique_ptr<MouseInterface>> mouse_interfaces;
 
 #endif // DOSBOX_MOUSE_INTERFACES_H


### PR DESCRIPTION
### Render pacer

Previously the pacer was a global object initialized on startup, however it accessed timer values even before they had a chance to initialize:

![2023-03-11_19-38](https://user-images.githubusercontent.com/1557255/224526265-94648493-8eb0-45a6-85e1-6d2c8048e64b.png)

The first commit moves the pacer's construction to when its conf setting is parsed.

### Mouse interface objects

Similar to the pacer, previously the mouse interfaces were initialized on startup, however they accessed members of the two mouse state variables (`mouse_info` and `mouse_shared`) even before they had a chance to initialize:

![2023-03-11_19-39](https://user-images.githubusercontent.com/1557255/224526263-6a630ef1-ba9d-4815-b94e-72ee031f5b4c.png)

The second commit moves the interface construction into the mouse interface initialization function. 

In both commits, the objects are now managed using `std::unique_ptr`s.