### PR TITLE
Fix mouse problem with windowed mode and viewport_resolution setting

### DIFF
--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -89,11 +89,11 @@ static void update_cursor_absolute_position(const int32_t x_abs, const int32_t y
 
 		if (absolute < 0 || static_cast<uint32_t>(absolute) < clipping) {
 			// cursor is over the top or left black bar
-			state.cursor_is_outside = !state.is_fullscreen;
+			state.cursor_is_outside = !state.is_captured;
 			return 0;
 		} else if (static_cast<uint32_t>(absolute) >= resolution + clipping) {
 			// cursor is over the bottom or right black bar
-			state.cursor_is_outside = !state.is_fullscreen;
+			state.cursor_is_outside = !state.is_captured;
 			return check_cast<uint32_t>(resolution - 1);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2321 - if mouse is captured, the cursor should never be considered 'outside of drawing area'.