### PR TITLE
Increase max memory size to 3072 MB, minor cleanup

### DIFF
--- a/include/mem.h
+++ b/include/mem.h
@@ -36,6 +36,9 @@ typedef int32_t MemHandle;
 extern HostPt MemBase;
 HostPt GetMemBase();
 
+uint16_t MEM_GetMinMegabytes();
+uint16_t MEM_GetMaxMegabytes();
+
 bool MEM_A20_Enabled();
 void MEM_A20_Enable(bool enable);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -40,6 +40,7 @@
 #include "inout.h"
 #include "ints/int10.h"
 #include "mapper.h"
+#include "memory.h"
 #include "midi.h"
 #include "mixer.h"
 #include "mouse.h"
@@ -468,7 +469,7 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&MEM_Init);
 	secprop->AddInitFunction(&HARDWARE_Init);
 	pint = secprop->Add_int("memsize", when_idle, 16);
-	pint->SetMinMax(1, 384);
+	pint->SetMinMax(MEM_GetMinMegabytes(), MEM_GetMaxMegabytes());
 	pint->Set_help(
 	        "Amount of memory of the emulated machine has in MB (16 by default).\n"
 	        "Best leave at the default setting to avoid problems with some games,\n"


### PR DESCRIPTION
- further increased maximum memory size - to the point where emulated S3 linear framebuffer starts
- cleaned up the memory code a little
- additional warning is printed if selected memory size is above what Windows 95 supports
- tested that PATCHMEM by Rudolph R. Loew allows to use full 3072 MB RAM, at least with Windows 95
