### PR TITLE
Differentiate CLI arguments from markup tags with escapes

### DIFF
--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -2336,7 +2336,7 @@ Zeigt eine Liste der Dateien und Unterverzeichnisse an.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Verwendung:
-  [color=green]dir[reset] [color=cyan][SUCHMUSTER][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]REIHENFOLGE[reset]]
+  [color=green]dir[reset] [color=cyan][SUCHMUSTER][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]REIHENFOLGE[reset]]
 
 Wobei:
   [color=cyan]SUCHMUSTER[reset] ist entweder ein exakter Dateiname oder ein ungenauer Dateiname

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -2452,7 +2452,7 @@ Displays a list of files and subdirectories in a directory.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Usage:
-  [color=green]dir[reset] [color=cyan][PATTERN][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]ORDER[reset]]
+  [color=green]dir[reset] [color=cyan][PATTERN][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]ORDER[reset]]
 
 Where:
   [color=cyan]PATTERN[reset] is either an exact filename or an inexact filename with wildcards,

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -2006,7 +2006,7 @@ Muestra una lista de archivos y subdirectorios de un directorio.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Uso:
-  [32;1mdir[0m [36;1m[PATRÓN][0m [/w] [/b] [/p] [ad] [a-d] [/o[37;1mORDEN[0m]
+  [32;1mdir[0m [36;1m[PATRÓN][0m [/w] \[/b] [/p] [ad] [a-d] [/o[37;1mORDEN[0m]
 
 Dónde:
   [36;1mPATRÓN[0m es un nombre de archivo exacto o un nombre de archivo inexacto con comodines,
@@ -2460,7 +2460,7 @@ Espera a que se presione una tecla y establece un valor ERRORLEVEL.
 :SHELL_CMD_CHOICE_HELP_LONG
 Uso:
   [32;1mchoice[0m [36;1m[TEXTO][0m
-  [32;1mchoice[0m /c[:][37;1mOPCIONES[0m [/n] [/s] [36;1m[TEXTO][0m
+  [32;1mchoice[0m /c[:][37;1mOPCIONES[0m [/n] \[/s] [36;1m[TEXTO][0m
 
 Dónde:
   [36;1mTEXTO[0m         es el texto a mostrar como un aviso, o vacío.

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -2654,7 +2654,7 @@ Visualizza un elenco di file e sottodirectory in una directory.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Utilizzo:
-  [color=green]dir[reset] [color=cyan][MODELLO][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]ORDINAM[reset]]
+  [color=green]dir[reset] [color=cyan][MODELLO][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]ORDINAM[reset]]
 
 Dove:
   [color=cyan]MODELLO[reset] è un nome file specifico o con caratteri jolly, cioè asterisco (*)

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -2512,7 +2512,7 @@ Toont een lijst met bestanden en submappen in een map.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Gebruik:
-  [color=green]dir[reset] [color=cyan][PATROON][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]VOLGORDE[reset]]
+  [color=green]dir[reset] [color=cyan][PATROON][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]VOLGORDE[reset]]
 
 Waar:
   [color=cyan]PATROON[reset]    is ofwel een exacte bestandsnaam of een onnauwkeurige

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -2500,7 +2500,7 @@ Wyświetla listę plików i podkatalogów.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Składnia:
-  [color=green]dir[reset] [color=cyan][WZORZEC][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]PORZĄDEK[reset]]
+  [color=green]dir[reset] [color=cyan][WZORZEC][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]PORZĄDEK[reset]]
 
 Gdzie:
   [color=cyan]WZORZEC[reset]       dokładna nazwa lub nazwa z symbolami wieloznaczności (maskami),

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -1853,7 +1853,7 @@ GOTO: Метка %s не найдена.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Использование:
-  [color=green]dir[reset] [color=cyan][ШАБЛОН][reset] [/w] [/b] [/p] [/ad] [/a-d] [/o[color=white]ПОРЯДОК[reset]]
+  [color=green]dir[reset] [color=cyan][ШАБЛОН][reset] [/w] \[/b] [/p] [/ad] [/a-d] [/o[color=white]ПОРЯДОК[reset]]
 
 Где:
   [color=cyan]ШАБЛОН[reset]    - точное имя файла либо имя файла с символами подстановки:

--- a/contrib/resources/translations/utf-8/de.txt
+++ b/contrib/resources/translations/utf-8/de.txt
@@ -2336,7 +2336,7 @@ Zeigt eine Liste der Dateien und Unterverzeichnisse an.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Verwendung:
-  [color=green]dir[reset] [color=cyan][SUCHMUSTER][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]REIHENFOLGE[reset]]
+  [color=green]dir[reset] [color=cyan][SUCHMUSTER][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]REIHENFOLGE[reset]]
 
 Wobei:
   [color=cyan]SUCHMUSTER[reset] ist entweder ein exakter Dateiname oder ein ungenauer Dateiname

--- a/contrib/resources/translations/utf-8/en.txt
+++ b/contrib/resources/translations/utf-8/en.txt
@@ -2452,7 +2452,7 @@ Displays a list of files and subdirectories in a directory.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Usage:
-  [color=green]dir[reset] [color=cyan][PATTERN][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]ORDER[reset]]
+  [color=green]dir[reset] [color=cyan][PATTERN][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]ORDER[reset]]
 
 Where:
   [color=cyan]PATTERN[reset] is either an exact filename or an inexact filename with wildcards,

--- a/contrib/resources/translations/utf-8/es.txt
+++ b/contrib/resources/translations/utf-8/es.txt
@@ -2116,7 +2116,7 @@ Muestra una lista de archivos y subdirectorios de un directorio.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Uso:
-  [32;1mdir[0m [36;1m[PATRÓN][0m [/w] [/b] [/p] [ad] [a-d] [/o[37;1mORDEN[0m]
+  [32;1mdir[0m [36;1m[PATRÓN][0m [/w] \[/b] [/p] [ad] [a-d] [/o[37;1mORDEN[0m]
 
 Dónde:
   [36;1mPATRÓN[0m es un nombre de archivo exacto o un nombre de archivo inexacto con comodines,
@@ -2570,7 +2570,7 @@ Espera a que se presione una tecla y establece un valor ERRORLEVEL.
 :SHELL_CMD_CHOICE_HELP_LONG
 Uso:
   [32;1mchoice[0m [36;1m[TEXTO][0m
-  [32;1mchoice[0m /c[:][37;1mOPCIONES[0m [/n] [/s] [36;1m[TEXTO][0m
+  [32;1mchoice[0m /c[:][37;1mOPCIONES[0m [/n] \[/s] [36;1m[TEXTO][0m
 
 Dónde:
   [36;1mTEXTO[0m         es el texto a mostrar como un aviso, o vacío.

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -2654,7 +2654,7 @@ Visualizza un elenco di file e sottodirectory in una directory.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Utilizzo:
-  [color=green]dir[reset] [color=cyan][MODELLO][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]ORDINAM[reset]]
+  [color=green]dir[reset] [color=cyan][MODELLO][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]ORDINAM[reset]]
 
 Dove:
   [color=cyan]MODELLO[reset] è un nome file specifico o con caratteri jolly, cioè asterisco (*)

--- a/contrib/resources/translations/utf-8/nl.txt
+++ b/contrib/resources/translations/utf-8/nl.txt
@@ -2512,7 +2512,7 @@ Toont een lijst met bestanden en submappen in een map.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Gebruik:
-  [color=green]dir[reset] [color=cyan][PATROON][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]VOLGORDE[reset]]
+  [color=green]dir[reset] [color=cyan][PATROON][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]VOLGORDE[reset]]
 
 Waar:
   [color=cyan]PATROON[reset]    is ofwel een exacte bestandsnaam of een onnauwkeurige

--- a/contrib/resources/translations/utf-8/pl.txt
+++ b/contrib/resources/translations/utf-8/pl.txt
@@ -2500,7 +2500,7 @@ Wyświetla listę plików i podkatalogów.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Składnia:
-  [color=green]dir[reset] [color=cyan][WZORZEC][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]PORZĄDEK[reset]]
+  [color=green]dir[reset] [color=cyan][WZORZEC][reset] [/w] \[/b] [/p] [ad] [a-d] [/o[color=white]PORZĄDEK[reset]]
 
 Gdzie:
   [color=cyan]WZORZEC[reset]       dokładna nazwa lub nazwa z symbolami wieloznaczności (maskami),

--- a/contrib/resources/translations/utf-8/ru.txt
+++ b/contrib/resources/translations/utf-8/ru.txt
@@ -1853,7 +1853,7 @@ GOTO: Метка %s не найдена.
 .
 :SHELL_CMD_DIR_HELP_LONG
 Использование:
-  [color=green]dir[reset] [color=cyan][ШАБЛОН][reset] [/w] [/b] [/p] [/ad] [/a-d] [/o[color=white]ПОРЯДОК[reset]]
+  [color=green]dir[reset] [color=cyan][ШАБЛОН][reset] [/w] \[/b] [/p] [/ad] [/a-d] [/o[color=white]ПОРЯДОК[reset]]
 
 Где:
   [color=cyan]ШАБЛОН[reset]    - точное имя файла либо имя файла с символами подстановки:

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1132,7 +1132,7 @@ void SHELL_Init() {
 	        "Displays a list of files and subdirectories in a directory.\n");
 	MSG_Add("SHELL_CMD_DIR_HELP_LONG",
 	        "Usage:\n"
-	        "  [color=green]dir[reset] [color=cyan][PATTERN][reset] [/w] [/b] [/p] [ad] [a-d] [/o[color=white]ORDER[reset]]\n"
+	        "  [color=green]dir[reset] [color=cyan][PATTERN][reset] [/w] \\[/b] [/p] [ad] [a-d] [/o[color=white]ORDER[reset]]\n"
 	        "\n"
 	        "Where:\n"
 	        "  [color=cyan]PATTERN[reset] is either an exact filename or an inexact filename with wildcards,\n"


### PR DESCRIPTION
Fixes #2345

Good catch, @FeralChild64 and excellent forsight @shermp to include escapes.