### PR TITLE
Boolean config param handling improvements & cleanup

### DIFF
--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -1131,7 +1131,7 @@ Abschnitt "%s" existiert nicht.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" ist kein gültiger Wert für die Eigenschaft %s.
+"%s" ist kein gültiger Wert für die Eigenschaft "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -1016,7 +1016,7 @@ Du kannst deine MOUNT-Zeilen hier einfügen.
 # Zeilen, die mit einem "#" Zeichen beginnen, sind Kommentare.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Mögliche Werte
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -1063,7 +1063,7 @@ Section "%s" doesn't exist.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" is not a valid value for property %s.
+"%s" is not a valid value for property "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -948,7 +948,7 @@ You can put your MOUNT lines here.
 # Lines starting with a '#' character are comments.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Possible values
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -918,7 +918,7 @@ La sección "%s" no existe.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" no es un valor válido para la propiedad %s.
+"%s" no es un valor válido para la propiedad "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -803,7 +803,7 @@ Puedes colocar tus líneas MOUNT aquí.
 # Las líneas que comienzan con el caracter '#' son comentarios.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Valores posibles
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -927,7 +927,7 @@ La section "%s" n'existe pas.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" n'est pas une valeur correcte pour la propriété %s.
+"%s" n'est pas une valeur correcte pour la propriété "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -812,7 +812,7 @@ Vous pouvez mettre vos commandes MOUNT ici.
 # Les lignes commençant avec un '#' sont des commentaires.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Valeurs possibles
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -1077,7 +1077,7 @@ Puoi inserire i tuoi comandi MOUNT qui.
 # Le righe che iniziano con il carattere '#' sono commenti.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Valori possibili
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -1193,7 +1193,7 @@ La sezione "%s" non esiste.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" non è un valore valido per la proprietà %s.
+"%s" non è un valore valido per la proprietà "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -1080,7 +1080,7 @@ Sectie "%s" bestaat niet.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" is geen geldige waarde voor eigenschap %s.
+"%s" is geen geldige waarde voor eigenschap "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -965,7 +965,7 @@ U kunt hier uw MOUNT-lijnen plaatsen.
 # Regels die beginnen met een '#'-teken zijn opmerkingen.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Mogelijke waarden
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -964,7 +964,7 @@ Jest to dobre miejsce na umieszczenie poleceń MOUNT.
 # Linie zaczynające się od # są komentarzami.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Możliwe wartości
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -971,7 +971,7 @@ MAC-адрес карты NE2000.
 # Строки, начинающиеся со знака '#' - это комментарии.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Возможные значения
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/de.txt
+++ b/contrib/resources/translations/utf-8/de.txt
@@ -1131,7 +1131,7 @@ Abschnitt "%s" existiert nicht.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" ist kein gültiger Wert für die Eigenschaft %s.
+"%s" ist kein gültiger Wert für die Eigenschaft "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/utf-8/de.txt
+++ b/contrib/resources/translations/utf-8/de.txt
@@ -1016,7 +1016,7 @@ Du kannst deine MOUNT-Zeilen hier einfügen.
 # Zeilen, die mit einem "#" Zeichen beginnen, sind Kommentare.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Mögliche Werte
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/en.txt
+++ b/contrib/resources/translations/utf-8/en.txt
@@ -1063,7 +1063,7 @@ Section "%s" doesn't exist.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" is not a valid value for property %s.
+"%s" is not a valid value for property "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/utf-8/en.txt
+++ b/contrib/resources/translations/utf-8/en.txt
@@ -948,7 +948,7 @@ You can put your MOUNT lines here.
 # Lines starting with a '#' character are comments.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Possible values
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/es.txt
+++ b/contrib/resources/translations/utf-8/es.txt
@@ -913,7 +913,7 @@ Puedes colocar tus líneas MOUNT aquí.
 # Las líneas que comienzan con el caracter '#' son comentarios.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Valores posibles
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/es.txt
+++ b/contrib/resources/translations/utf-8/es.txt
@@ -1028,7 +1028,7 @@ La sección "%s" no existe.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" no es un valor válido para la propiedad %s.
+"%s" no es un valor válido para la propiedad "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/utf-8/fr.txt
+++ b/contrib/resources/translations/utf-8/fr.txt
@@ -922,7 +922,7 @@ Vous pouvez mettre vos commandes MOUNT ici.
 # Les lignes commençant avec un '#' sont des commentaires.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Valeurs possibles
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/fr.txt
+++ b/contrib/resources/translations/utf-8/fr.txt
@@ -1037,7 +1037,7 @@ La section "%s" n'existe pas.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" n'est pas une valeur correcte pour la propriété %s.
+"%s" n'est pas une valeur correcte pour la propriété "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -1077,7 +1077,7 @@ Puoi inserire i tuoi comandi MOUNT qui.
 # Le righe che iniziano con il carattere '#' sono commenti.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Valori possibili
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/it.txt
+++ b/contrib/resources/translations/utf-8/it.txt
@@ -1193,7 +1193,7 @@ La sezione "%s" non esiste.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" non è un valore valido per la proprietà %s.
+"%s" non è un valore valido per la proprietà "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/utf-8/nl.txt
+++ b/contrib/resources/translations/utf-8/nl.txt
@@ -1080,7 +1080,7 @@ Sectie "%s" bestaat niet.
 
 .
 :PROGRAM_CONFIG_VALUE_ERROR
-"%s" is geen geldige waarde voor eigenschap %s.
+"%s" is geen geldige waarde voor eigenschap "%s".
 
 .
 :PROGRAM_CONFIG_GET_SYNTAX

--- a/contrib/resources/translations/utf-8/nl.txt
+++ b/contrib/resources/translations/utf-8/nl.txt
@@ -965,7 +965,7 @@ U kunt hier uw MOUNT-lijnen plaatsen.
 # Regels die beginnen met een '#'-teken zijn opmerkingen.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Mogelijke waarden
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/pl.txt
+++ b/contrib/resources/translations/utf-8/pl.txt
@@ -964,7 +964,7 @@ Jest to dobre miejsce na umieszczenie poleceń MOUNT.
 # Linie zaczynające się od # są komentarzami.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Możliwe wartości
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/contrib/resources/translations/utf-8/ru.txt
+++ b/contrib/resources/translations/utf-8/ru.txt
@@ -971,7 +971,7 @@ MAC-адрес карты NE2000.
 # Строки, начинающиеся со знака '#' - это комментарии.
 
 .
-:CONFIG_SUGGESTED_VALUES
+:CONFIG_VALID_VALUES
 Возможные значения
 .
 :PROGRAM_CONFIG_PROPERTY_ERROR

--- a/include/setup.h
+++ b/include/setup.h
@@ -226,9 +226,7 @@ public:
 	}
 
 protected:
-	// Set interval value to in or default if in is invalid.
-	// Can be overridden to set a different value if invalid.
-	virtual bool SetVal(const Value& in)
+	virtual bool ValidateValue(const Value& in)
 	{
 		if (IsValidValue(in)) {
 			value = in;
@@ -276,13 +274,10 @@ public:
 	}
 
 	bool SetValue(const std::string& in) override;
-
 	bool IsValidValue(const Value& in) override;
 
 protected:
-	// Override SetVal, so it takes min,max in account when there are no
-	// valid values
-	bool SetVal(const Value& in) override;
+	bool ValidateValue(const Value& in) override;
 
 private:
 	Value min_value;
@@ -323,7 +318,6 @@ public:
 	~Prop_string() override = default;
 
 	bool SetValue(const std::string& in) override;
-
 	bool IsValidValue(const Value& in) override;
 };
 

--- a/include/setup.h
+++ b/include/setup.h
@@ -170,7 +170,7 @@ public:
 	// CheckValue returns true, if value is in suggested_values;
 	// Type specific properties are encouraged to override this and check
 	// for type specific features.
-	virtual bool CheckValue(const Value &in, bool warn);
+	virtual bool CheckValue(const Value &in);
 
 	Changeable::Value GetChange() const { return change; }
 	bool IsDeprecated() const { return (change == Changeable::Value::Deprecated); }
@@ -183,7 +183,7 @@ protected:
 	//Can be overridden to set a different value if invalid.
 	virtual bool SetVal(const Value &in)
 	{
-		if (CheckValue(in, true)) {
+		if (CheckValue(in)) {
 			value = in;
 			return true;
 		} else {
@@ -221,7 +221,7 @@ public:
 
 	bool SetValue(const std::string &in) override;
 
-	bool CheckValue(const Value &in, bool warn) override;
+	bool CheckValue(const Value &in) override;
 
 protected:
 	// Override SetVal, so it takes min,max in account when there are no
@@ -268,7 +268,7 @@ public:
 
 	bool SetValue(const std::string &in) override;
 
-	bool CheckValue(const Value &in, bool warn) override;
+	bool CheckValue(const Value &in) override;
 };
 
 class Prop_path final : public Prop_string {

--- a/include/setup.h
+++ b/include/setup.h
@@ -200,15 +200,19 @@ public:
 	{
 		return default_value;
 	}
-	// CheckValue returns true, if value is in suggested_values;
-	// Type specific properties are encouraged to override this and check
-	// for type specific features.
-	virtual bool CheckValue(const Value& in);
+
+	bool IsRestrictedValue() const
+	{
+		return !valid_values.empty();
+	}
+
+	virtual bool IsValidValue(const Value& in);
 
 	Changeable::Value GetChange() const
 	{
 		return change;
 	}
+
 	bool IsDeprecated() const
 	{
 		return (change == Changeable::Value::Deprecated);
@@ -221,11 +225,11 @@ public:
 	}
 
 protected:
-	// Set interval value to in or default if in is invalid. force always sets
-	// the value. Can be overridden to set a different value if invalid.
+	// Set interval value to in or default if in is invalid.
+	// Can be overridden to set a different value if invalid.
 	virtual bool SetVal(const Value& in)
 	{
-		if (CheckValue(in)) {
+		if (IsValidValue(in)) {
 			value = in;
 			return true;
 		} else {
@@ -235,7 +239,7 @@ protected:
 	}
 
 	Value value;
-	std::vector<Value> suggested_values;
+	std::vector<Value> valid_values;
 	Value default_value;
 	const Changeable::Value change;
 
@@ -272,11 +276,11 @@ public:
 
 	bool SetValue(const std::string& in) override;
 
-	bool CheckValue(const Value& in) override;
+	bool IsValidValue(const Value& in) override;
 
 protected:
 	// Override SetVal, so it takes min,max in account when there are no
-	// suggested values
+	// valid values
 	bool SetVal(const Value& in) override;
 
 private:
@@ -319,7 +323,7 @@ public:
 
 	bool SetValue(const std::string& in) override;
 
-	bool CheckValue(const Value& in) override;
+	bool IsValidValue(const Value& in) override;
 };
 
 class Prop_path final : public Prop_string {

--- a/include/setup.h
+++ b/include/setup.h
@@ -43,23 +43,18 @@ private:
 public:
 	Hex() : value(0) {}
 	Hex(int in) : value(in) {}
+
 	bool operator==(const Hex& other) const
 	{
 		return value == other.value;
 	}
+
 	operator int() const
 	{
 		return value;
 	}
 };
 
-/*
- * Multitype storage container that is aware of the currently stored type in it.
- * Value st = "hello";
- * Value in = 1;
- * st = 12 //Exception
- * in = 12 //works
- */
 class Value {
 private:
 	Hex _hex            = 0;
@@ -69,8 +64,6 @@ private:
 	double _double      = 0;
 
 public:
-	class WrongType {}; // Conversion error class
-
 	enum Etype {
 		V_NONE,
 		V_HEX,
@@ -81,16 +74,12 @@ public:
 		V_CURRENT
 	} type = V_NONE;
 
-	/* Constructors */
-
+	// Constructors
 	Value() = default;
 
 	Value(const Hex& in) : _hex(in), type(V_HEX) {}
-
 	Value(int in) : _int(in), type(V_INT) {}
-
 	Value(bool in) : _bool(in), type(V_BOOL) {}
-
 	Value(double in) : _double(in), type(V_DOUBLE) {}
 
 	Value(const std::string& in, Etype t)
@@ -98,50 +87,9 @@ public:
 		SetValue(in, t);
 	}
 
-	Value(const std::string& in)
-	        : _string(in),
-	          type(V_STRING)
-	{}
+	Value(const std::string& in) : _string(in), type(V_STRING) {}
 
-	Value(const char* const in)
-	        : _string(in),
-	          type(V_STRING)
-	{}
-
-	Value(const Value& in)
-	{
-		plaincopy(in);
-	}
-
-	/* Assignment operators */
-	Value& operator=(Hex in)
-	{
-		return copy(Value(in));
-	}
-	Value& operator=(int in)
-	{
-		return copy(Value(in));
-	}
-	Value& operator=(bool in)
-	{
-		return copy(Value(in));
-	}
-	Value& operator=(double in)
-	{
-		return copy(Value(in));
-	}
-	Value& operator=(const std::string& in)
-	{
-		return copy(Value(in));
-	}
-	Value& operator=(const char* const in)
-	{
-		return copy(Value(in));
-	}
-	Value& operator=(const Value& in)
-	{
-		return copy(Value(in));
-	}
+	Value(const char* const in) : _string(in), type(V_STRING) {}
 
 	bool operator==(const Value& other) const;
 
@@ -156,9 +104,6 @@ public:
 	std::string ToString() const;
 
 private:
-	Value& copy(const Value& in);
-	void plaincopy(const Value& in);
-
 	bool SetHex(const std::string& in);
 	bool SetInt(const std::string& in);
 	bool SetBool(const std::string& in);
@@ -186,6 +131,7 @@ public:
 	const char* GetHelpUtf8() const;
 
 	virtual bool SetValue(const std::string& str) = 0;
+
 	const Value& GetValue() const
 	{
 		return value;
@@ -213,6 +159,7 @@ public:
 	}
 
 	virtual const std::vector<Value>& GetValues() const;
+
 	Value::Etype Get_type()
 	{
 		return default_value.type;
@@ -336,9 +283,9 @@ typedef void (*SectionFunction)(Section*);
 
 class Section {
 private:
-	/* Wrapper class around startup and shutdown functions. the variable
-	 * changeable_at_runtime indicates it can be called on configuration
-	 * changes */
+	// Wrapper class around startup and shutdown functions. the variable
+	// changeable_at_runtime indicates it can be called on configuration
+	// changes
 	struct Function_wrapper {
 		SectionFunction function;
 		bool changeable_at_runtime;
@@ -362,7 +309,8 @@ public:
 	Section(Section&& other)            = default;
 	Section& operator=(Section&& other) = default;
 
-	virtual ~Section() = default; // Children must call executedestroy!
+	// Children must call executedestroy!
+	virtual ~Section() = default;
 
 	void AddEarlyInitFunction(SectionFunction func,
 	                          bool changeable_at_runtime = false);
@@ -375,14 +323,17 @@ public:
 	void ExecuteEarlyInit(bool initall = true);
 	void ExecuteInit(bool initall = true);
 	void ExecuteDestroy(bool destroyall = true);
+
 	const char* GetName() const
 	{
 		return sectionname.c_str();
 	}
 
 	virtual std::string GetPropValue(const std::string& property) const = 0;
-	virtual bool HandleInputline(const std::string& line)               = 0;
-	virtual void PrintData(FILE* outfile) const                         = 0;
+
+	virtual bool HandleInputline(const std::string& line) = 0;
+
+	virtual void PrintData(FILE* outfile) const = 0;
 };
 
 class PropMultiVal;

--- a/include/setup.h
+++ b/include/setup.h
@@ -226,16 +226,7 @@ public:
 	}
 
 protected:
-	virtual bool ValidateValue(const Value& in)
-	{
-		if (IsValidValue(in)) {
-			value = in;
-			return true;
-		} else {
-			value = default_value;
-			return false;
-		}
-	}
+	virtual bool ValidateValue(const Value& in);
 
 	Value value;
 	std::vector<Value> valid_values;

--- a/include/setup.h
+++ b/include/setup.h
@@ -181,9 +181,9 @@ public:
 protected:
 	//Set interval value to in or default if in is invalid. force always sets the value.
 	//Can be overridden to set a different value if invalid.
-	virtual bool SetVal(const Value &in, bool forced, bool warn = true)
+	virtual bool SetVal(const Value &in)
 	{
-		if (forced || CheckValue(in, warn)) {
+		if (CheckValue(in, true)) {
 			value = in;
 			return true;
 		} else {
@@ -226,7 +226,7 @@ public:
 protected:
 	// Override SetVal, so it takes min,max in account when there are no
 	// suggested values
-	bool SetVal(const Value &in, bool forced, bool warn = true) override;
+	bool SetVal(const Value &in) override;
 
 private:
 	Value min_value;

--- a/include/setup.h
+++ b/include/setup.h
@@ -165,11 +165,12 @@ private:
 	void destroy();
 	Value& copy(const Value& in);
 	void plaincopy(const Value& in);
+
 	bool SetHex(const std::string& in);
-	bool set_int(const std::string& in);
-	bool set_bool(const std::string& in);
-	void set_string(const std::string& in);
-	bool set_double(const std::string& in);
+	bool SetInt(const std::string& in);
+	bool SetBool(const std::string& in);
+	void SetString(const std::string& in);
+	bool SetDouble(const std::string& in);
 };
 
 class Property {
@@ -387,7 +388,9 @@ public:
 
 	void AddEarlyInitFunction(SectionFunction func,
 	                          bool changeable_at_runtime = false);
+
 	void AddInitFunction(SectionFunction func, bool changeable_at_runtime = false);
+
 	void AddDestroyFunction(SectionFunction func,
 	                        bool changeable_at_runtime = false);
 
@@ -474,7 +477,8 @@ class PropMultiVal : public Property {
 protected:
 	std::unique_ptr<Section_prop> section;
 	std::string separator;
-	void make_default_value();
+
+	void MakeDefaultValue();
 
 public:
 	PropMultiVal(const std::string& name, Changeable::Value when,

--- a/include/setup.h
+++ b/include/setup.h
@@ -411,11 +411,11 @@ public:
 
 	Prop_string* Add_string(const std::string& _propname,
 	                        Property::Changeable::Value when,
-	                        const char* _value = NULL);
+	                        const char* _value = nullptr);
 
 	Prop_path* Add_path(const std::string& _propname,
 	                    Property::Changeable::Value when,
-	                    const char* _value = NULL);
+	                    const char* _value = nullptr);
 
 	Prop_bool* Add_bool(const std::string& _propname,
 	                    Property::Changeable::Value when, bool _value = false);

--- a/include/setup.h
+++ b/include/setup.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -34,7 +34,7 @@
 
 using parse_environ_result_t = std::list<std::tuple<std::string, std::string>>;
 
-parse_environ_result_t parse_environ(const char * const * envp) noexcept;
+parse_environ_result_t parse_environ(const char* const* envp) noexcept;
 
 class Hex {
 private:
@@ -43,11 +43,17 @@ private:
 public:
 	Hex() : value(0) {}
 	Hex(int in) : value(in) {}
-	bool operator==(const Hex &other) const { return value == other.value; }
-	operator int() const { return value; }
+	bool operator==(const Hex& other) const
+	{
+		return value == other.value;
+	}
+	operator int() const
+	{
+		return value;
+	}
 };
 
-/* 
+/*
  * Multitype storage container that is aware of the currently stored type in it.
  * Value st = "hello";
  * Value in = 1;
@@ -56,11 +62,11 @@ public:
  */
 class Value {
 private:
-	Hex _hex = 0;
-	bool _bool = false;
-	int _int = 0;
-	std::string *_string = nullptr;
-	double _double = 0;
+	Hex _hex             = 0;
+	bool _bool           = false;
+	int _int             = 0;
+	std::string* _string = nullptr;
+	double _double       = 0;
 
 public:
 	class WrongType {}; // Conversion error class
@@ -79,7 +85,7 @@ public:
 
 	Value() = default;
 
-	Value(const Hex &in) : _hex(in), type(V_HEX) {}
+	Value(const Hex& in) : _hex(in), type(V_HEX) {}
 
 	Value(int in) : _int(in), type(V_INT) {}
 
@@ -87,9 +93,12 @@ public:
 
 	Value(double in) : _double(in), type(V_DOUBLE) {}
 
-	Value(const std::string &in, Etype t) { SetValue(in, t); }
+	Value(const std::string& in, Etype t)
+	{
+		SetValue(in, t);
+	}
 
-	Value(const std::string &in)
+	Value(const std::string& in)
 	        : _string(new std::string(in)),
 	          type(V_STRING)
 	{}
@@ -99,24 +108,48 @@ public:
 	          type(V_STRING)
 	{}
 
-	Value(const Value &in) { plaincopy(in); }
+	Value(const Value& in)
+	{
+		plaincopy(in);
+	}
 
 	/* Destructor */
-	virtual ~Value() { destroy(); }
+	virtual ~Value()
+	{
+		destroy();
+	}
 
 	/* Assignment operators */
-	Value &operator=(Hex in) { return copy(Value(in)); }
-	Value &operator=(int in) { return copy(Value(in)); }
-	Value &operator=(bool in) { return copy(Value(in)); }
-	Value &operator=(double in) { return copy(Value(in)); }
-	Value &operator=(const std::string &in) { return copy(Value(in)); }
+	Value& operator=(Hex in)
+	{
+		return copy(Value(in));
+	}
+	Value& operator=(int in)
+	{
+		return copy(Value(in));
+	}
+	Value& operator=(bool in)
+	{
+		return copy(Value(in));
+	}
+	Value& operator=(double in)
+	{
+		return copy(Value(in));
+	}
+	Value& operator=(const std::string& in)
+	{
+		return copy(Value(in));
+	}
 	Value& operator=(const char* const in)
 	{
 		return copy(Value(in));
 	}
-	Value &operator=(const Value &in) { return copy(Value(in)); }
+	Value& operator=(const Value& in)
+	{
+		return copy(Value(in));
+	}
 
-	bool operator==(const Value &other) const;
+	bool operator==(const Value& other) const;
 
 	operator bool() const;
 	operator Hex() const;
@@ -124,19 +157,19 @@ public:
 	operator double() const;
 	operator const char*() const;
 
-	bool SetValue(const std::string &in, Etype _type = V_CURRENT);
+	bool SetValue(const std::string& in, Etype _type = V_CURRENT);
 
 	std::string ToString() const;
 
 private:
 	void destroy();
-	Value &copy(const Value &in);
-	void plaincopy(const Value &in);
-	bool SetHex(const std::string &in);
-	bool set_int(const std::string &in);
-	bool set_bool(const std::string &in);
-	void set_string(const std::string &in);
-	bool set_double(const std::string &in);
+	Value& copy(const Value& in);
+	void plaincopy(const Value& in);
+	bool SetHex(const std::string& in);
+	bool set_int(const std::string& in);
+	bool set_bool(const std::string& in);
+	void set_string(const std::string& in);
+	bool set_double(const std::string& in);
 };
 
 class Property {
@@ -147,86 +180,104 @@ public:
 
 	const std::string propname;
 
-	Property(const std::string &name, Changeable::Value when);
+	Property(const std::string& name, Changeable::Value when);
 
 	virtual ~Property() = default;
 
-	void Set_values(const char * const * in);
-	void Set_values(const std::vector<std::string> &in);
-	void Set_help(const std::string &str);
+	void Set_values(const char* const* in);
+	void Set_values(const std::vector<std::string>& in);
+	void Set_help(const std::string& str);
 
 	const char* GetHelp() const;
 	const char* GetHelpUtf8() const;
 
-	virtual bool SetValue(const std::string &str) = 0;
-	const Value &GetValue() const
+	virtual bool SetValue(const std::string& str) = 0;
+	const Value& GetValue() const
 	{
 		return value;
 	}
-	const Value &GetDefaultValue() const
+	const Value& GetDefaultValue() const
 	{
 		return default_value;
 	}
 	// CheckValue returns true, if value is in suggested_values;
 	// Type specific properties are encouraged to override this and check
 	// for type specific features.
-	virtual bool CheckValue(const Value &in);
+	virtual bool CheckValue(const Value& in);
 
-	Changeable::Value GetChange() const { return change; }
-	bool IsDeprecated() const { return (change == Changeable::Value::Deprecated); }
+	Changeable::Value GetChange() const
+	{
+		return change;
+	}
+	bool IsDeprecated() const
+	{
+		return (change == Changeable::Value::Deprecated);
+	}
 
 	virtual const std::vector<Value>& GetValues() const;
-	Value::Etype Get_type(){return default_value.type;}
+	Value::Etype Get_type()
+	{
+		return default_value.type;
+	}
 
 protected:
-	//Set interval value to in or default if in is invalid. force always sets the value.
-	//Can be overridden to set a different value if invalid.
-	virtual bool SetVal(const Value &in)
+	// Set interval value to in or default if in is invalid. force always sets
+	// the value. Can be overridden to set a different value if invalid.
+	virtual bool SetVal(const Value& in)
 	{
 		if (CheckValue(in)) {
 			value = in;
 			return true;
 		} else {
-			value = default_value; return false;
+			value = default_value;
+			return false;
 		}
 	}
+
 	Value value;
 	std::vector<Value> suggested_values;
-	typedef std::vector<Value>::const_iterator const_iter;
 	Value default_value;
 	const Changeable::Value change;
+
+	typedef std::vector<Value>::const_iterator const_iter;
 };
 
 class Prop_int final : public Property {
 public:
-	Prop_int(const std::string &name, Changeable::Value when, int val)
+	Prop_int(const std::string& name, Changeable::Value when, int val)
 	        : Property(name, when),
 	          min_value(-1),
 	          max_value(-1)
 	{
 		default_value = val;
-		value = val;
+		value         = val;
 	}
 
 	~Prop_int() override = default;
 
-	int GetMin() const { return min_value; }
-	int GetMax() const { return max_value; }
+	int GetMin() const
+	{
+		return min_value;
+	}
+	int GetMax() const
+	{
+		return max_value;
+	}
 
-	void SetMinMax(const Value &min, const Value &max)
+	void SetMinMax(const Value& min, const Value& max)
 	{
 		min_value = min;
 		max_value = max;
 	}
 
-	bool SetValue(const std::string &in) override;
+	bool SetValue(const std::string& in) override;
 
-	bool CheckValue(const Value &in) override;
+	bool CheckValue(const Value& in) override;
 
 protected:
 	// Override SetVal, so it takes min,max in account when there are no
 	// suggested values
-	bool SetVal(const Value &in) override;
+	bool SetVal(const Value& in) override;
 
 private:
 	Value min_value;
@@ -240,65 +291,65 @@ public:
 	{
 		default_value = value = _value;
 	}
-	bool SetValue(const std::string &input);
-	~Prop_double(){ }
+	bool SetValue(const std::string& input);
+	~Prop_double() {}
 };
 
 class Prop_bool final : public Property {
 public:
-	Prop_bool(const std::string &_propname, Changeable::Value when, bool _value)
+	Prop_bool(const std::string& _propname, Changeable::Value when, bool _value)
 	        : Property(_propname, when)
 	{
 		default_value = value = _value;
 	}
-	bool SetValue(const std::string &in);
-	~Prop_bool(){ }
+	bool SetValue(const std::string& in);
+	~Prop_bool() {}
 };
 
 class Prop_string : public Property {
 public:
-	Prop_string(const std::string &name, Changeable::Value when, const char *val)
+	Prop_string(const std::string& name, Changeable::Value when, const char* val)
 	        : Property(name, when)
 	{
 		default_value = val;
-		value = val;
+		value         = val;
 	}
 
 	~Prop_string() override = default;
 
-	bool SetValue(const std::string &in) override;
+	bool SetValue(const std::string& in) override;
 
-	bool CheckValue(const Value &in) override;
+	bool CheckValue(const Value& in) override;
 };
 
 class Prop_path final : public Prop_string {
 public:
-	Prop_path(const std::string &name, Changeable::Value when, const char *val)
+	Prop_path(const std::string& name, Changeable::Value when, const char* val)
 	        : Prop_string(name, when, val),
 	          realpath(val)
 	{}
 
 	~Prop_path() override = default;
 
-	bool SetValue(const std::string &in) override;
+	bool SetValue(const std::string& in) override;
 
 	std::string realpath;
 };
 
 class Prop_hex final : public Property {
 public:
-	Prop_hex(const std::string &_propname, Changeable::Value when, Hex _value)
+	Prop_hex(const std::string& _propname, Changeable::Value when, Hex _value)
 	        : Property(_propname, when)
 	{
 		default_value = value = _value;
 	}
-	bool SetValue(const std::string &in);
-	~Prop_hex(){ }
+	bool SetValue(const std::string& in);
+	~Prop_hex() {}
 };
 
 #define NO_SUCH_PROPERTY "PROP_NOT_EXIST"
 
-typedef void (*SectionFunction)(Section *);
+typedef void (*SectionFunction)(Section*);
 
 class Section {
 private:
@@ -316,13 +367,13 @@ private:
 	};
 
 	std::deque<Function_wrapper> early_init_functions = {};
-	std::deque<Function_wrapper> initfunctions = {};
-	std::deque<Function_wrapper> destroyfunctions = {};
-	std::string sectionname = {};
+	std::deque<Function_wrapper> initfunctions        = {};
+	std::deque<Function_wrapper> destroyfunctions     = {};
+	std::string sectionname                           = {};
 
 public:
 	Section() = default;
-	Section(const std::string &name) : sectionname(name) {}
+	Section(const std::string& name) : sectionname(name) {}
 
 	// Construct and assign by std::move
 	Section(Section&& other)            = default;
@@ -337,13 +388,16 @@ public:
 	                        bool changeable_at_runtime = false);
 
 	void ExecuteEarlyInit(bool initall = true);
-	void ExecuteInit(bool initall=true);
-	void ExecuteDestroy(bool destroyall=true);
-	const char* GetName() const {return sectionname.c_str();}
+	void ExecuteInit(bool initall = true);
+	void ExecuteDestroy(bool destroyall = true);
+	const char* GetName() const
+	{
+		return sectionname.c_str();
+	}
 
-	virtual std::string GetPropValue(const std::string &property) const = 0;
-	virtual bool HandleInputline(const std::string &line) = 0;
-	virtual void PrintData(FILE *outfile) const = 0;
+	virtual std::string GetPropValue(const std::string& property) const = 0;
+	virtual bool HandleInputline(const std::string& line)               = 0;
+	virtual void PrintData(FILE* outfile) const                         = 0;
 };
 
 class PropMultiVal;
@@ -351,47 +405,65 @@ class PropMultiValRemain;
 
 class Section_prop final : public Section {
 private:
-	std::deque<Property *> properties = {};
+	std::deque<Property*> properties = {};
 	typedef std::deque<Property*>::iterator it;
 	typedef std::deque<Property*>::const_iterator const_it;
 
 public:
-	Section_prop(const std::string &name) : Section(name) {}
+	Section_prop(const std::string& name) : Section(name) {}
 
 	~Section_prop() override;
 
-	Prop_int *Add_int(const std::string &_propname,
+	Prop_int* Add_int(const std::string& _propname,
 	                  Property::Changeable::Value when, int _value = 0);
-	Prop_string *Add_string(const std::string &_propname,
+
+	Prop_string* Add_string(const std::string& _propname,
 	                        Property::Changeable::Value when,
-	                        const char *_value = NULL);
-	Prop_path *Add_path(const std::string &_propname,
+	                        const char* _value = NULL);
+
+	Prop_path* Add_path(const std::string& _propname,
 	                    Property::Changeable::Value when,
-	                    const char *_value = NULL);
-	Prop_bool *Add_bool(const std::string &_propname,
+	                    const char* _value = NULL);
+
+	Prop_bool* Add_bool(const std::string& _propname,
 	                    Property::Changeable::Value when, bool _value = false);
-	Prop_hex *Add_hex(const std::string &_propname,
+
+	Prop_hex* Add_hex(const std::string& _propname,
 	                  Property::Changeable::Value when, Hex _value = 0);
+
 	//	void Add_double(const char * _propname, double _value=0.0);
-	PropMultiVal *AddMultiVal(const std::string &_propname,
-	                         Property::Changeable::Value when,
-	                         const std::string &sep);
-	PropMultiValRemain *AddMultiValRemain(const std::string &_propname,
+	//
+	PropMultiVal* AddMultiVal(const std::string& _propname,
+	                          Property::Changeable::Value when,
+	                          const std::string& sep);
+
+	PropMultiValRemain* AddMultiValRemain(const std::string& _propname,
 	                                      Property::Changeable::Value when,
-	                                      const std::string &sep);
+	                                      const std::string& sep);
 
 	Property* Get_prop(int index);
-	int Get_int(const std::string &_propname) const;
-	const char *Get_string(const std::string &_propname) const;
-	bool Get_bool(const std::string &_propname) const;
-	Hex Get_hex(const std::string &_propname) const;
-	double Get_double(const std::string &_propname) const;
-	Prop_path *Get_path(const std::string &_propname) const;
-	PropMultiVal *GetMultiVal(const std::string &_propname) const;
-	PropMultiValRemain *GetMultiValRemain(const std::string &_propname) const;
-	bool HandleInputline(const std::string &line) override;
+
+	int Get_int(const std::string& _propname) const;
+
+	const char* Get_string(const std::string& _propname) const;
+
+	bool Get_bool(const std::string& _propname) const;
+
+	Hex Get_hex(const std::string& _propname) const;
+
+	double Get_double(const std::string& _propname) const;
+
+	Prop_path* Get_path(const std::string& _propname) const;
+
+	PropMultiVal* GetMultiVal(const std::string& _propname) const;
+
+	PropMultiValRemain* GetMultiValRemain(const std::string& _propname) const;
+
+	bool HandleInputline(const std::string& line) override;
+
 	void PrintData(FILE* outfile) const override;
-	std::string GetPropValue(const std::string &property) const override;
+
+	std::string GetPropValue(const std::string& property) const override;
 };
 
 class PropMultiVal : public Property {
@@ -401,35 +473,40 @@ protected:
 	void make_default_value();
 
 public:
-	PropMultiVal(const std::string &name,
-	              Changeable::Value when,
-	              const std::string &sep)
+	PropMultiVal(const std::string& name, Changeable::Value when,
+	             const std::string& sep)
 	        : Property(name, when),
 	          section(new Section_prop("")),
 	          separator(sep)
 	{
 		default_value = "";
-		value = "";
+		value         = "";
 	}
 
-	Section_prop *GetSection() { return section.get(); }
-	const Section_prop *GetSection() const { return section.get(); }
+	Section_prop* GetSection()
+	{
+		return section.get();
+	}
+	const Section_prop* GetSection() const
+	{
+		return section.get();
+	}
 
 	// value contains total string.
 	// SetValue sets each of the sub properties.
-	bool SetValue(const std::string &input) override;
+	bool SetValue(const std::string& input) override;
 
-	const std::vector<Value> &GetValues() const override;
+	const std::vector<Value>& GetValues() const override;
 };
 
-class PropMultiValRemain final : public PropMultiVal{
+class PropMultiValRemain final : public PropMultiVal {
 public:
-	PropMultiValRemain(const std::string &_propname,
-	                     Changeable::Value when, const std::string &sep)
+	PropMultiValRemain(const std::string& _propname, Changeable::Value when,
+	                   const std::string& sep)
 	        : PropMultiVal(_propname, when, sep)
 	{}
 
-	virtual bool SetValue(const std::string &input);
+	virtual bool SetValue(const std::string& input);
 };
 
 class Section_line final : public Section {
@@ -446,9 +523,9 @@ public:
 		ExecuteDestroy(true);
 	}
 
-	std::string GetPropValue(const std::string &property) const override;
-	bool HandleInputline(const std::string &line) override;
-	void PrintData(FILE *outfile) const override;
+	std::string GetPropValue(const std::string& property) const override;
+	bool HandleInputline(const std::string& line) override;
+	void PrintData(FILE* outfile) const override;
 
 	std::string data = {};
 };
@@ -456,23 +533,26 @@ public:
 /* Base for all hardware and software "devices" */
 class Module_base {
 protected:
-	Section *m_configuration;
+	Section* m_configuration;
 
 public:
-	Module_base(Section *conf_section) : m_configuration(conf_section) {}
+	Module_base(Section* conf_section) : m_configuration(conf_section) {}
 
-	Module_base(const Module_base &) = delete; // prevent copying
-	Module_base &operator=(const Module_base &) = delete; // prevent assignment
+	Module_base(const Module_base&) = delete;            // prevent copying
+	Module_base& operator=(const Module_base&) = delete; // prevent assignment
 
 	virtual ~Module_base() = default;
 
-	virtual bool Change_Config(Section * /*newconfig*/) { return false; }
+	virtual bool Change_Config(Section* /*newconfig*/)
+	{
+		return false;
+	}
 };
 
-void SETUP_ParseConfigFiles(const std::string &config_path);
+void SETUP_ParseConfigFiles(const std::string& config_path);
 
-const std::string &SETUP_GetLanguage();
+const std::string& SETUP_GetLanguage();
 
-const char *SetProp(std::vector<std::string> &pvars);
+const char* SetProp(std::vector<std::string>& pvars);
 
 #endif

--- a/include/setup.h
+++ b/include/setup.h
@@ -62,11 +62,11 @@ public:
  */
 class Value {
 private:
-	Hex _hex             = 0;
-	bool _bool           = false;
-	int _int             = 0;
-	std::string* _string = nullptr;
-	double _double       = 0;
+	Hex _hex            = 0;
+	bool _bool          = false;
+	int _int            = 0;
+	std::string _string = {};
+	double _double      = 0;
 
 public:
 	class WrongType {}; // Conversion error class
@@ -99,24 +99,18 @@ public:
 	}
 
 	Value(const std::string& in)
-	        : _string(new std::string(in)),
+	        : _string(in),
 	          type(V_STRING)
 	{}
 
 	Value(const char* const in)
-	        : _string(new std::string(in)),
+	        : _string(in),
 	          type(V_STRING)
 	{}
 
 	Value(const Value& in)
 	{
 		plaincopy(in);
-	}
-
-	/* Destructor */
-	virtual ~Value()
-	{
-		destroy();
 	}
 
 	/* Assignment operators */
@@ -162,7 +156,6 @@ public:
 	std::string ToString() const;
 
 private:
-	void destroy();
 	Value& copy(const Value& in);
 	void plaincopy(const Value& in);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1214,7 +1214,7 @@ void DOSBOX_Init()
 	MSG_Add("CONFIGFILE_INTRO",
 	        "# This is the configuration file for " CANONICAL_PROJECT_NAME " (%s).\n"
 	        "# Lines starting with a '#' character are comments.\n");
-	MSG_Add("CONFIG_SUGGESTED_VALUES", "Possible values");
+	MSG_Add("CONFIG_VALID_VALUES", "Possible values");
 
 	// Initialize the uptime counter when launching the first shell. This
 	// ensures that slow-performing configurable tasks (like loading MIDI

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -957,9 +957,12 @@ void CONFIG::Run(void)
 				tsec->ExecuteDestroy(false);
 				bool change_success = tsec->HandleInputline(
 				        inputline.c_str());
+
 				if (!change_success) {
+					auto val = value;
+					trim(val);
 					WriteOut(MSG_Get("PROGRAM_CONFIG_VALUE_ERROR"),
-					         value.c_str(),
+					         val.c_str(),
 					         pvars[1].c_str());
 				}
 				tsec->ExecuteInit(false);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1071,7 +1071,7 @@ void PROGRAMS_Init(Section* sec)
 	        "This operation is not permitted in secure mode.\n");
 	MSG_Add("PROGRAM_CONFIG_SECTION_ERROR", "Section \"%s\" doesn't exist.\n");
 	MSG_Add("PROGRAM_CONFIG_VALUE_ERROR",
-	        "\"%s\" is not a valid value for property %s.\n");
+	        "\"%s\" is not a valid value for property \"%s\".\n");
 	MSG_Add("PROGRAM_CONFIG_GET_SYNTAX",
 	        "Correct syntax: config -get \"section property\".\n");
 	MSG_Add("PROGRAM_CONFIG_PRINT_STARTUP",

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -180,20 +180,27 @@ bool Value::set_double(const std::string &in)
 	return true;
 }
 
-bool Value::set_bool(const std::string &in)
+bool Value::set_bool(const std::string& in)
 {
 	istringstream input(in);
 	string result;
 	input >> result;
 	lowcase(result);
 	_bool = true; // TODO
-	if(!result.size()) return false;
 
-	if(result=="0" || result=="disabled" || result=="false" || result=="off") {
+	if (!result.size()) {
+		return false;
+	}
+
+	if (result == "0" || result == "disabled" || result == "false" ||
+	    result == "off") {
 		_bool = false;
-	} else if(result=="1" || result=="enabled" || result=="true" || result=="on") {
+	} else if (result == "1" || result == "enabled" || result == "true" ||
+	           result == "on") {
 		_bool = true;
-	} else return false;
+	} else {
+		return false;
+	}
 
 	return true;
 }

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -151,23 +151,23 @@ bool Value::SetValue(const std::string& in, const Etype _type)
 	assert(type == V_NONE || type == _type);
 	type = _type;
 
-	bool retval = true;
+	bool is_valid = true;
 	switch (type) {
-	case V_HEX: retval = SetHex(in); break;
-	case V_INT: retval = SetInt(in); break;
-	case V_BOOL: retval = SetBool(in); break;
+	case V_HEX: is_valid = SetHex(in); break;
+	case V_INT: is_valid = SetInt(in); break;
+	case V_BOOL: is_valid = SetBool(in); break;
 	case V_STRING: SetString(in); break;
-	case V_DOUBLE: retval = SetDouble(in); break;
+	case V_DOUBLE: is_valid = SetDouble(in); break;
 
 	case V_NONE:
 	case V_CURRENT:
 	default:
 		LOG_ERR("SETUP: Unhandled type when setting value: '%s'",
 		        in.c_str());
-		retval = false;
+		is_valid = false;
 		break;
 	}
-	return retval;
+	return is_valid;
 }
 
 bool Value::SetHex(const std::string& in)
@@ -314,7 +314,7 @@ const char* Property::GetHelpUtf8() const
 	return MSG_GetRaw(result.c_str());
 }
 
-bool Prop_int::SetVal(const Value& in)
+bool Prop_int::ValidateValue(const Value& in)
 {
 	if (IsRestrictedValue()) {
 		if (IsValidValue(in)) {
@@ -395,7 +395,7 @@ bool Prop_double::SetValue(const std::string& input)
 	if (!val.SetValue(input, Value::V_DOUBLE)) {
 		return false;
 	}
-	return SetVal(val);
+	return ValidateValue(val);
 }
 
 // void Property::SetValue(char* input){
@@ -407,8 +407,8 @@ bool Prop_int::SetValue(const std::string& input)
 	if (!val.SetValue(input, Value::V_INT)) {
 		return false;
 	}
-	bool retval = SetVal(val);
-	return retval;
+	bool is_valid = ValidateValue(val);
+	return is_valid;
 }
 
 bool Prop_string::SetValue(const std::string& input)
@@ -422,7 +422,7 @@ bool Prop_string::SetValue(const std::string& input)
 		lowcase(temp);
 	}
 	Value val(temp, Value::V_STRING);
-	return SetVal(val);
+	return ValidateValue(val);
 }
 
 bool Prop_string::IsValidValue(const Value& in)
@@ -456,7 +456,7 @@ bool Prop_path::SetValue(const std::string& input)
 	// Special version to merge realpath with it
 
 	Value val(input, Value::V_STRING);
-	bool retval = SetVal(val);
+	bool is_valid = ValidateValue(val);
 
 	if (input.empty()) {
 		realpath.clear();
@@ -478,7 +478,7 @@ bool Prop_path::SetValue(const std::string& input)
 		realpath = workcopy;
 	}
 
-	return retval;
+	return is_valid;
 }
 
 bool Prop_bool::SetValue(const std::string& input)
@@ -490,7 +490,7 @@ bool Prop_hex::SetValue(const std::string& input)
 {
 	Value val;
 	val.SetValue(input, Value::V_HEX);
-	return SetVal(val);
+	return ValidateValue(val);
 }
 
 void PropMultiVal::MakeDefaultValue()
@@ -514,13 +514,13 @@ void PropMultiVal::MakeDefaultValue()
 	}
 
 	Value val(result, Value::V_STRING);
-	SetVal(val);
+	ValidateValue(val);
 }
 
 bool PropMultiValRemain::SetValue(const std::string& input)
 {
 	Value val(input, Value::V_STRING);
-	bool retval = SetVal(val);
+	bool is_valid = ValidateValue(val);
 
 	std::string local(input);
 	int i = 0, number_of_properties = 0;
@@ -562,13 +562,13 @@ bool PropMultiValRemain::SetValue(const std::string& input)
 		}
 		p->SetValue(in);
 	}
-	return retval;
+	return is_valid;
 }
 
 bool PropMultiVal::SetValue(const std::string& input)
 {
 	Value val(input, Value::V_STRING);
-	bool retval = SetVal(val);
+	bool is_valid = ValidateValue(val);
 
 	std::string local(input);
 	int i = 0;
@@ -635,7 +635,7 @@ bool PropMultiVal::SetValue(const std::string& input)
 		prevargument = in;
 	}
 
-	return retval;
+	return is_valid;
 }
 
 const std::vector<Value>& Property::GetValues() const

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -145,6 +145,7 @@ bool Value::operator==(const Value& other) const
 	}
 	return false;
 }
+
 bool Value::SetValue(const std::string& in, const Etype _type)
 {
 	assert(type == V_NONE || type == _type);
@@ -193,6 +194,7 @@ bool Value::SetInt(const std::string& in)
 	_int = result;
 	return true;
 }
+
 bool Value::SetDouble(const std::string& in)
 {
 	istringstream input(in);
@@ -569,12 +571,14 @@ bool PropMultiVal::SetValue(const std::string& input)
 	bool retval = SetVal(val);
 
 	std::string local(input);
-	int i       = 0;
+	int i = 0;
+
 	Property* p = section->Get_prop(0);
-	// No properties in this section. do nothing
 	if (!p) {
+		// No properties in this section; do nothing
 		return false;
 	}
+
 	Value::Etype prevtype = Value::V_NONE;
 	string prevargument   = "";
 
@@ -585,8 +589,11 @@ bool PropMultiVal::SetValue(const std::string& input)
 		if (loc != string::npos) {
 			local.erase(0, loc);
 		}
-		loc       = local.find_first_of(separator);
-		string in = "";            // default value
+
+		loc = local.find_first_of(separator);
+
+		string in = ""; // default value
+
 		if (loc != string::npos) { // separator found
 			in = local.substr(0, loc);
 			local.erase(0, loc + 1);
@@ -604,6 +611,7 @@ bool PropMultiVal::SetValue(const std::string& input)
 				return false;
 			}
 			p->SetValue(in);
+
 		} else {
 			// Non-strings can have more things, conversion alone is
 			// not enough (as invalid values as converted to 0)
@@ -622,9 +630,11 @@ bool PropMultiVal::SetValue(const std::string& input)
 				}
 			}
 		}
+
 		prevtype     = p->Get_type();
 		prevargument = in;
 	}
+
 	return retval;
 }
 
@@ -649,12 +659,6 @@ const std::vector<Value>& PropMultiVal::GetValues() const
 	}
 	return valid_values;
 }
-
-/*
-void Section_prop::Add_double(const char * _propname, double _value) {
-        Property* test=new Prop_double(_propname,_value);
-        properties.push_back(test);
-}*/
 
 void Property::Set_values(const char* const* in)
 {
@@ -886,7 +890,7 @@ bool Section_prop::HandleInputline(const std::string& line)
 
 void Section_prop::PrintData(FILE* outfile) const
 {
-	/* Now print out the individual section entries */
+	// Now print out the individual section entries
 
 	// Determine maximum length of the props in this section
 	int len = 0;
@@ -947,12 +951,12 @@ bool Config::PrintConfig(const std::string& filename) const
 		return false;
 	}
 
-	/* Print start of configfile and add a return to improve readibility. */
+	// Print start of config file and add a return to improve readibility
 	fprintf(outfile, MSG_GetRaw("CONFIGFILE_INTRO"), VERSION);
 	fprintf(outfile, "\n");
 
 	for (auto tel = sectionlist.cbegin(); tel != sectionlist.cend(); ++tel) {
-		/* Print out the Section header */
+		// Print section header
 		safe_strcpy(temp, (*tel)->GetName());
 		lowcase(temp);
 		fprintf(outfile, "[%s]\n", temp);
@@ -1052,7 +1056,9 @@ bool Config::PrintConfig(const std::string& filename) const
 
 		fprintf(outfile, "\n");
 		(*tel)->PrintData(outfile);
-		fprintf(outfile, "\n"); /* Always an empty line between sections */
+
+		// Always add empty line between sections
+		fprintf(outfile, "\n");
 	}
 
 	fclose(outfile);
@@ -1086,7 +1092,7 @@ Section_prop::~Section_prop()
 	// destroyed properties
 	ExecuteDestroy(true);
 
-	/* Delete properties themself (properties stores the pointer of a prop */
+	// Delete properties themself (properties stores the pointer of a prop
 	for (it prop = properties.begin(); prop != properties.end(); ++prop) {
 		delete (*prop);
 	}
@@ -1193,9 +1199,8 @@ void Section::ExecuteDestroy(bool destroyall)
 	for (func_it tel = destroyfunctions.begin(); tel != destroyfunctions.end();) {
 		if (destroyall || (*tel).changeable_at_runtime) {
 			(*tel).function(this);
-			tel = destroyfunctions.erase(tel); // Remove
-			                                   // destroyfunction
-			                                   // once used
+			// Remove destroyfunctions once used
+			tel = destroyfunctions.erase(tel);
 		} else {
 			++tel;
 		}
@@ -1282,7 +1287,7 @@ bool Config::ParseConfigFile(const std::string& type, const std::string& configf
 	Section* currentsection = nullptr;
 
 	while (getline(in, line)) {
-		/* strip leading/trailing whitespace */
+		// Strip leading/trailing whitespace
 		trim(line);
 		if (line.empty()) {
 			continue;
@@ -1587,11 +1592,10 @@ bool CommandLine::FindStringRemain(const char* name, std::string& value)
 	return true;
 }
 
-/* Only used for parsing command.com /C
- * Allowing /C dir and /Cdir
- * Restoring quotes back into the commands so command /C mount d "/tmp/a b"
- * works as intended
- */
+// Only used for parsing command.com /C
+// Allowing /C dir and /Cdir
+// Restoring quotes back into the commands so command /C mount d "/tmp/a b"
+// works as intended
 bool CommandLine::FindStringRemainBegin(const char* name, std::string& value)
 {
 	cmd_it it;
@@ -1759,7 +1763,7 @@ CommandLine::CommandLine(const char* name, const char* cmdline)
 		file_name = name;
 	}
 
-	/* Parse the cmds and put them in the list */
+	// Parse the commands and put them in the list
 	bool inword, inquote;
 	char c;
 	inword  = false;
@@ -1818,7 +1822,7 @@ const std::string& SETUP_GetLanguage()
 		return lang;
 	}
 
-	// Did the user provide a language on the command line?
+	// Has the user provided a language on the command line?
 	(void)control->cmdline->FindString("-lang", lang, true);
 
 	// Is a language provided in the conf file?
@@ -1849,7 +1853,7 @@ const std::string& SETUP_GetLanguage()
 		lang = lang.substr(0, 2);
 	}
 
-	// return it as lowercase
+	// Return it as lowercase
 	lowcase(lang);
 
 	lang_is_cached = true;
@@ -1956,7 +1960,6 @@ const char* SetProp(std::vector<std::string>& pvars)
 		Section* sec = control->GetSection(pvars[0].c_str());
 		if (!sec) {
 			// not a section: little duplicate from above
-			//
 			Section* sec = control->GetSectionFromProperty(
 			        pvars[0].c_str());
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -46,19 +46,11 @@ std::unique_ptr<Config> control = {};
 
 // Set by parseconfigfile so Prop_path can use it to construct the realpath
 static std::string current_config_dir;
-void Value::destroy()
-{
-	if (type == V_STRING) {
-		delete _string;
-		_string = nullptr;
-	}
-}
 
 Value& Value::copy(const Value& in)
 {
 	assert(this != &in);
 	assert(type == V_NONE || type == in.type);
-	destroy();
 	plaincopy(in);
 	return *this;
 }
@@ -71,7 +63,7 @@ void Value::plaincopy(const Value& in)
 	_bool   = in._bool;
 	_hex    = in._hex;
 	if (type == V_STRING) {
-		_string = new string(*in._string);
+		_string = in._string;
 	}
 }
 
@@ -102,7 +94,7 @@ Value::operator double() const
 Value::operator const char*() const
 {
 	assert(type == V_STRING);
-	return _string->c_str();
+	return _string.c_str();
 }
 
 bool Value::operator==(const Value& other) const
@@ -118,7 +110,7 @@ bool Value::operator==(const Value& other) const
 	case V_INT: return _int == other._int;
 	case V_HEX: return _hex == other._hex;
 	case V_DOUBLE: return _double == other._double;
-	case V_STRING: return *_string == *other._string;
+	case V_STRING: return _string == other._string;
 	default:
 		LOG_ERR("SETUP: Comparing stuff that doesn't make sense");
 		break;
@@ -214,10 +206,7 @@ bool Value::SetBool(const std::string& in)
 
 void Value::SetString(const std::string& in)
 {
-	if (!_string) {
-		_string = new string();
-	}
-	_string->assign(in);
+	_string = in;
 }
 
 string Value::ToString() const
@@ -230,7 +219,7 @@ string Value::ToString() const
 		break;
 	case V_INT: oss << _int; break;
 	case V_BOOL: oss << boolalpha << _bool; break;
-	case V_STRING: oss << *_string; break;
+	case V_STRING: oss << _string; break;
 	case V_DOUBLE:
 		oss.precision(2);
 		oss << fixed << _double;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -800,11 +800,11 @@ Prop_path* Section_prop::Get_path(const std::string& _propname) const
 			if (val) {
 				return val;
 			} else {
-				return NULL;
+				return nullptr;
 			}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 PropMultiVal* Section_prop::GetMultiVal(const std::string& _propname) const
@@ -815,11 +815,11 @@ PropMultiVal* Section_prop::GetMultiVal(const std::string& _propname) const
 			if (val) {
 				return val;
 			} else {
-				return NULL;
+				return nullptr;
 			}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 PropMultiValRemain* Section_prop::GetMultiValRemain(const std::string& _propname) const
@@ -831,11 +831,11 @@ PropMultiValRemain* Section_prop::GetMultiValRemain(const std::string& _propname
 			if (val) {
 				return val;
 			} else {
-				return NULL;
+				return nullptr;
 			}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 Property* Section_prop::Get_prop(int index)
@@ -845,7 +845,7 @@ Property* Section_prop::Get_prop(int index)
 			return (*tel);
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 const char* Section_prop::Get_string(const std::string& _propname) const
@@ -968,7 +968,7 @@ bool Config::PrintConfig(const std::string& filename) const
 	char helpline[256];
 
 	FILE* outfile = fopen(filename.c_str(), "w+t");
-	if (outfile == NULL) {
+	if (outfile == nullptr) {
 		return false;
 	}
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -293,6 +293,18 @@ bool Property::IsValidValue(const Value& in)
 	return false;
 }
 
+
+bool Property::ValidateValue(const Value& in)
+{
+	if (IsValidValue(in)) {
+		value = in;
+		return true;
+	} else {
+		value = default_value;
+		return false;
+	}
+}
+
 void Property::Set_help(const std::string& in)
 {
 	string result = string("CONFIG_") + propname;
@@ -483,7 +495,16 @@ bool Prop_path::SetValue(const std::string& input)
 
 bool Prop_bool::SetValue(const std::string& input)
 {
-	return value.SetValue(input, Value::V_BOOL);
+	auto is_valid = value.SetValue(input, Value::V_BOOL);
+	if (!is_valid) {
+		SetValue(default_value.ToString());
+
+		LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
+		            input.c_str(),
+		            propname.c_str(),
+		            default_value.ToString().c_str());
+	}
+	return is_valid;
 }
 
 bool Prop_hex::SetValue(const std::string& input)

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -739,19 +739,18 @@ Hex Section_prop::Get_hex(const std::string &_propname) const
 	return 0;
 }
 
-bool Section_prop::HandleInputline(const std::string& gegevens)
+bool Section_prop::HandleInputline(const std::string& line)
 {
-	string str1           = gegevens;
-	string::size_type loc = str1.find('=');
+	string::size_type loc = line.find('=');
 
 	if (loc == string::npos) {
 		return false;
 	}
 
-	string name = str1.substr(0, loc);
-	string val  = str1.substr(loc + 1);
+	string name = line.substr(0, loc);
+	string val  = line.substr(loc + 1);
 
-	/* Remove quotes around value */
+	// Strip quotes around the value
 	trim(val);
 	string::size_type length = val.length();
 	if (length > 1 && ((val[0] == '\"' && val[length - 1] == '\"') ||
@@ -759,7 +758,7 @@ bool Section_prop::HandleInputline(const std::string& gegevens)
 		val = val.substr(1, length - 2);
 	}
 
-	/* trim the results incase there were spaces somewhere */
+	// Trim the result in case there were spaces somewhere
 	trim(name);
 	trim(val);
 
@@ -1113,36 +1112,36 @@ bool Config::ParseConfigFile(const std::string& type, const std::string& configf
 	// Get directory from configfilename, used with relative paths.
 	current_config_dir = canonical_path.parent_path().string();
 
-	string gegevens;
+	string line;
 	Section* currentsection = nullptr;
 
-	while (getline(in, gegevens)) {
+	while (getline(in, line)) {
 		/* strip leading/trailing whitespace */
-		trim(gegevens);
-		if (gegevens.empty()) {
+		trim(line);
+		if (line.empty()) {
 			continue;
 		}
 
-		switch (gegevens[0]) {
+		switch (line[0]) {
 		case '%':
 		case '\0':
 		case '#':
 		case ' ':
 		case '\n': continue; break;
 		case '[': {
-			const auto bracket_pos = gegevens.find(']');
+			const auto bracket_pos = line.find(']');
 			if (bracket_pos == string::npos) {
 				continue;
 			}
-			gegevens.erase(bracket_pos);
-			const auto section_name = gegevens.substr(1);
+			line.erase(bracket_pos);
+			const auto section_name = line.substr(1);
 			if (const auto sec = GetSection(section_name); sec) {
 				currentsection = sec;
 			}
 		} break;
 		default:
 			if (currentsection) {
-				currentsection->HandleInputline(gegevens);
+				currentsection->HandleInputline(line);
 
 				// If this is an autoexec section, the above
 				// takes care of the joining while this handles
@@ -1152,7 +1151,7 @@ bool Config::ParseConfigFile(const std::string& type, const std::string& configf
 				// very last configuration file is processed.
 				if (std::string_view(currentsection->GetName()) ==
 				    "autoexec") {
-					OverwriteAutoexec(configfilename, gegevens);
+					OverwriteAutoexec(configfilename, line);
 				}
 			}
 			break;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -252,7 +252,7 @@ Property::Property(const std::string &name, Changeable::Value when)
 	        "Only letters, digits, and underscores are allowed in property names");
 }
 
-bool Property::CheckValue(const Value &in, bool warn)
+bool Property::CheckValue(const Value &in)
 {
 	if (suggested_values.empty())
 		return true;
@@ -262,12 +262,12 @@ bool Property::CheckValue(const Value &in, bool warn)
 			return true;
 		}
 	}
-	if (warn) {
-		LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-		            in.ToString().c_str(),
-		            propname.c_str(),
-		            default_value.ToString().c_str());
-	}
+
+	LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
+				in.ToString().c_str(),
+				propname.c_str(),
+				default_value.ToString().c_str());
+
 	return false;
 }
 
@@ -295,7 +295,7 @@ const char * Property::GetHelpUtf8() const
 bool Prop_int::SetVal(const Value &in)
 {
 	if (!suggested_values.empty()) {
-		if (CheckValue(in, true) ) {
+		if (CheckValue(in) ) {
 			value = in;
 			return true;
 		} else {
@@ -328,12 +328,12 @@ bool Prop_int::SetVal(const Value &in)
 		return true;
 	}
 }
-bool Prop_int::CheckValue(const Value &in, bool warn)
+bool Prop_int::CheckValue(const Value &in)
 {
 	//	if(!suggested_values.empty() && Property::CheckValue(in,warn))
 	// return true;
 	if (!suggested_values.empty())
-		return Property::CheckValue(in, warn);
+		return Property::CheckValue(in);
 	// LOG_MSG("still used ?");
 	// No >= and <= in Value type and == is ambigious
 	const int mi = min_value;
@@ -342,14 +342,13 @@ bool Prop_int::CheckValue(const Value &in, bool warn)
 	if (mi == -1 && ma == -1) return true;
 	if (va >= mi && va <= ma) return true;
 
-	if (warn) {
-		LOG_WARNING("CONFIG: %s lies outside the range %s-%s for config '%s', using the default value %s",
-		            in.ToString().c_str(),
-		            min_value.ToString().c_str(),
-		            max_value.ToString().c_str(),
-		            propname.c_str(),
-		            default_value.ToString().c_str());
-	}
+	LOG_WARNING("CONFIG: %s lies outside the range %s-%s for config '%s', using the default value %s",
+				in.ToString().c_str(),
+				min_value.ToString().c_str(),
+				max_value.ToString().c_str(),
+				propname.c_str(),
+				default_value.ToString().c_str());
+
 	return false;
 }
 
@@ -381,7 +380,7 @@ bool Prop_string::SetValue(const std::string &input)
 	Value val(temp,Value::V_STRING);
 	return SetVal(val);
 }
-bool Prop_string::CheckValue(const Value &in, bool warn)
+bool Prop_string::CheckValue(const Value &in)
 {
 	if (suggested_values.empty())
 		return true;
@@ -396,12 +395,12 @@ bool Prop_string::CheckValue(const Value &in, bool warn)
 			}
 		}
 	}
-	if (warn) {
-		LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-		            in.ToString().c_str(),
-		            propname.c_str(),
-		            default_value.ToString().c_str());
-	}
+
+	LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
+				in.ToString().c_str(),
+				propname.c_str(),
+				default_value.ToString().c_str());
+
 	return false;
 }
 
@@ -487,7 +486,7 @@ bool PropMultiValRemain::SetValue(const std::string &input)
 		}
 		//Test Value. If it fails set default
 		Value valtest (in,p->Get_type());
-		if (!p->CheckValue(valtest,true)) {
+		if (!p->CheckValue(valtest)) {
 			make_default_value();
 			return false;
 		}
@@ -529,7 +528,7 @@ bool PropMultiVal::SetValue(const std::string &input)
 			//Strings are only checked against the suggested values list.
 			//Test Value. If it fails set default
 			Value valtest (in,p->Get_type());
-			if (!p->CheckValue(valtest,true)) {
+			if (!p->CheckValue(valtest)) {
 				make_default_value();
 				return false;
 			}

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2021  The DOSBox Team
+ *  Copyright (C) 2002-2023  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -34,9 +34,9 @@
 #include "support.h"
 
 #if defined(_MSC_VER) || (defined(__MINGW32__) && defined(__clang__))
-_CRTIMP extern char **_environ;
+_CRTIMP extern char** _environ;
 #else
-extern char **environ;
+extern char** environ;
 #endif
 
 using namespace std;
@@ -54,7 +54,7 @@ void Value::destroy()
 	}
 }
 
-Value &Value::copy(const Value &in)
+Value& Value::copy(const Value& in)
 {
 	assert(this != &in);
 	assert(type == V_NONE || type == in.type);
@@ -63,32 +63,38 @@ Value &Value::copy(const Value &in)
 	return *this;
 }
 
-void Value::plaincopy(const Value &in)
+void Value::plaincopy(const Value& in)
 {
 	type    = in.type;
 	_int    = in._int;
 	_double = in._double;
-	_bool = in._bool;
-	_hex = in._hex;
-	if(type == V_STRING) _string = new string(*in._string);
+	_bool   = in._bool;
+	_hex    = in._hex;
+	if (type == V_STRING) {
+		_string = new string(*in._string);
+	}
 }
 
-Value::operator bool () const {
+Value::operator bool() const
+{
 	assert(type == V_BOOL);
 	return _bool;
 }
 
-Value::operator Hex () const {
+Value::operator Hex() const
+{
 	assert(type == V_HEX);
 	return _hex;
 }
 
-Value::operator int () const {
+Value::operator int() const
+{
 	assert(type == V_INT);
 	return _int;
 }
 
-Value::operator double () const {
+Value::operator double() const
+{
 	assert(type == V_DOUBLE);
 	return _double;
 }
@@ -99,35 +105,47 @@ Value::operator const char*() const
 	return _string->c_str();
 }
 
-bool Value::operator==(const Value &other) const
+bool Value::operator==(const Value& other) const
 {
-	if (this == &other)
+	if (this == &other) {
 		return true;
-	if (type != other.type)
+	}
+	if (type != other.type) {
 		return false;
-	switch(type){
-		case V_BOOL:
-			if(_bool == other._bool) return true;
-			break;
-		case V_INT:
-			if(_int == other._int) return true;
-			break;
-		case V_HEX:
-			if(_hex == other._hex) return true;
-			break;
-		case V_DOUBLE:
-			if(_double == other._double) return true;
-			break;
-		case V_STRING:
-			if((*_string) == (*other._string)) return true;
-			break;
-		default:
-		        LOG_ERR("SETUP: Comparing stuff that doesn't make sense");
-		        break;
+	}
+	switch (type) {
+	case V_BOOL:
+		if (_bool == other._bool) {
+			return true;
+		}
+		break;
+	case V_INT:
+		if (_int == other._int) {
+			return true;
+		}
+		break;
+	case V_HEX:
+		if (_hex == other._hex) {
+			return true;
+		}
+		break;
+	case V_DOUBLE:
+		if (_double == other._double) {
+			return true;
+		}
+		break;
+	case V_STRING:
+		if ((*_string) == (*other._string)) {
+			return true;
+		}
+		break;
+	default:
+		LOG_ERR("SETUP: Comparing stuff that doesn't make sense");
+		break;
 	}
 	return false;
 }
-bool Value::SetValue(const std::string &in, const Etype _type)
+bool Value::SetValue(const std::string& in, const Etype _type)
 {
 	assert(type == V_NONE || type == _type);
 	type = _type;
@@ -143,39 +161,46 @@ bool Value::SetValue(const std::string &in, const Etype _type)
 	case V_NONE:
 	case V_CURRENT:
 	default:
-		LOG_ERR("SETUP: Unhandled type when setting value: '%s'", in.c_str());
+		LOG_ERR("SETUP: Unhandled type when setting value: '%s'",
+		        in.c_str());
 		retval = false;
 		break;
 	}
 	return retval;
 }
 
-bool Value::SetHex(const std::string &in)
+bool Value::SetHex(const std::string& in)
 {
 	istringstream input(in);
 	input.flags(ios::hex);
 	int result = INT_MIN;
 	input >> result;
-	if(result == INT_MIN) return false;
+	if (result == INT_MIN) {
+		return false;
+	}
 	_hex = result;
 	return true;
 }
 
-bool Value::set_int(const std::string &in)
+bool Value::set_int(const std::string& in)
 {
 	istringstream input(in);
 	int result = INT_MIN;
 	input >> result;
-	if(result == INT_MIN) return false;
+	if (result == INT_MIN) {
+		return false;
+	}
 	_int = result;
 	return true;
 }
-bool Value::set_double(const std::string &in)
+bool Value::set_double(const std::string& in)
 {
 	istringstream input(in);
 	double result = std::numeric_limits<double>::infinity();
 	input >> result;
-	if(result == std::numeric_limits<double>::infinity()) return false;
+	if (result == std::numeric_limits<double>::infinity()) {
+		return false;
+	}
 	_double = result;
 	return true;
 }
@@ -205,43 +230,37 @@ bool Value::set_bool(const std::string& in)
 	return true;
 }
 
-void Value::set_string(const std::string &in)
+void Value::set_string(const std::string& in)
 {
-	if (!_string)
+	if (!_string) {
 		_string = new string();
+	}
 	_string->assign(in);
 }
 
-string Value::ToString() const {
+string Value::ToString() const
+{
 	ostringstream oss;
-	switch(type) {
-		case V_HEX:
-			oss.flags(ios::hex);
-			oss << _hex;
-			break;
-		case V_INT:
-			oss << _int;
-			break;
-		case V_BOOL:
-			oss << boolalpha << _bool;
-			break;
-		case V_STRING:
-			oss << *_string;
-			break;
-		case V_DOUBLE:
-			oss.precision(2);
-			oss << fixed << _double;
-			break;
-		case V_NONE:
-		case V_CURRENT:
-		default:
-			E_Exit("ToString messed up ?");
-			break;
+	switch (type) {
+	case V_HEX:
+		oss.flags(ios::hex);
+		oss << _hex;
+		break;
+	case V_INT: oss << _int; break;
+	case V_BOOL: oss << boolalpha << _bool; break;
+	case V_STRING: oss << *_string; break;
+	case V_DOUBLE:
+		oss.precision(2);
+		oss << fixed << _double;
+		break;
+	case V_NONE:
+	case V_CURRENT:
+	default: E_Exit("ToString messed up ?"); break;
 	}
 	return oss.str();
 }
 
-Property::Property(const std::string &name, Changeable::Value when)
+Property::Property(const std::string& name, Changeable::Value when)
         : propname(name),
           value(),
           suggested_values{},
@@ -252,50 +271,51 @@ Property::Property(const std::string &name, Changeable::Value when)
 	        "Only letters, digits, and underscores are allowed in property names");
 }
 
-bool Property::CheckValue(const Value &in)
+bool Property::CheckValue(const Value& in)
 {
-	if (suggested_values.empty())
+	if (suggested_values.empty()) {
 		return true;
+	}
 	for (const_iter it = suggested_values.begin(); it != suggested_values.end();
 	     ++it) {
-		if ( (*it) == in) { //Match!
+		if ((*it) == in) { // Match!
 			return true;
 		}
 	}
 
 	LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-				in.ToString().c_str(),
-				propname.c_str(),
-				default_value.ToString().c_str());
+	            in.ToString().c_str(),
+	            propname.c_str(),
+	            default_value.ToString().c_str());
 
 	return false;
 }
 
-void Property::Set_help(const std::string &in)
+void Property::Set_help(const std::string& in)
 {
 	string result = string("CONFIG_") + propname;
 	upcase(result);
-	MSG_Add(result.c_str(),in.c_str());
+	MSG_Add(result.c_str(), in.c_str());
 }
 
-const char * Property::GetHelp() const
+const char* Property::GetHelp() const
 {
 	std::string result = "CONFIG_" + propname;
 	upcase(result);
 	return MSG_Get(result.c_str());
 }
 
-const char * Property::GetHelpUtf8() const
+const char* Property::GetHelpUtf8() const
 {
 	std::string result = "CONFIG_" + propname;
 	upcase(result);
 	return MSG_GetRaw(result.c_str());
 }
 
-bool Prop_int::SetVal(const Value &in)
+bool Prop_int::SetVal(const Value& in)
 {
 	if (!suggested_values.empty()) {
-		if (CheckValue(in) ) {
+		if (CheckValue(in)) {
 			value = in;
 			return true;
 		} else {
@@ -306,85 +326,107 @@ bool Prop_int::SetVal(const Value &in)
 		// Handle ranges if specified
 		const int mi = min_value;
 		const int ma = max_value;
-		int va = static_cast<int>(Value(in));
+		int va       = static_cast<int>(Value(in));
 
-		//No ranges
-		if (mi == -1 && ma == -1) { value = in; return true;}
+		// No ranges
+		if (mi == -1 && ma == -1) {
+			value = in;
+			return true;
+		}
 
-		//Inside range
-		if (va >= mi && va <= ma) { value = in; return true;}
+		// Inside range
+		if (va >= mi && va <= ma) {
+			value = in;
+			return true;
+		}
 
-		//Outside range, set it to the closest boundary
-		if (va > ma ) va = ma; else va = mi;
+		// Outside range, set it to the closest boundary
+		if (va > ma) {
+			va = ma;
+		} else {
+			va = mi;
+		}
 
 		LOG_WARNING("CONFIG: %s lies outside the range %s-%s for config '%s', limiting it to %d",
-					in.ToString().c_str(),
-					min_value.ToString().c_str(),
-					max_value.ToString().c_str(),
-					propname.c_str(),
-					va);
+		            in.ToString().c_str(),
+		            min_value.ToString().c_str(),
+		            max_value.ToString().c_str(),
+		            propname.c_str(),
+		            va);
 
 		value = va;
 		return true;
 	}
 }
-bool Prop_int::CheckValue(const Value &in)
+bool Prop_int::CheckValue(const Value& in)
 {
 	//	if(!suggested_values.empty() && Property::CheckValue(in,warn))
 	// return true;
-	if (!suggested_values.empty())
+	if (!suggested_values.empty()) {
 		return Property::CheckValue(in);
+	}
 	// LOG_MSG("still used ?");
 	// No >= and <= in Value type and == is ambigious
 	const int mi = min_value;
 	const int ma = max_value;
-	int va = static_cast<int>(Value(in));
-	if (mi == -1 && ma == -1) return true;
-	if (va >= mi && va <= ma) return true;
+	int va       = static_cast<int>(Value(in));
+	if (mi == -1 && ma == -1) {
+		return true;
+	}
+	if (va >= mi && va <= ma) {
+		return true;
+	}
 
 	LOG_WARNING("CONFIG: %s lies outside the range %s-%s for config '%s', using the default value %s",
-				in.ToString().c_str(),
-				min_value.ToString().c_str(),
-				max_value.ToString().c_str(),
-				propname.c_str(),
-				default_value.ToString().c_str());
+	            in.ToString().c_str(),
+	            min_value.ToString().c_str(),
+	            max_value.ToString().c_str(),
+	            propname.c_str(),
+	            default_value.ToString().c_str());
 
 	return false;
 }
 
-bool Prop_double::SetValue(const std::string &input)
+bool Prop_double::SetValue(const std::string& input)
 {
 	Value val;
-	if(!val.SetValue(input,Value::V_DOUBLE)) return false;
+	if (!val.SetValue(input, Value::V_DOUBLE)) {
+		return false;
+	}
 	return SetVal(val);
 }
 
-//void Property::SetValue(char* input){
+// void Property::SetValue(char* input){
 //	value.SetValue(input, Value::V_CURRENT);
-//}
-bool Prop_int::SetValue(const std::string &input)
+// }
+bool Prop_int::SetValue(const std::string& input)
 {
 	Value val;
-	if (!val.SetValue(input,Value::V_INT)) return false;
+	if (!val.SetValue(input, Value::V_INT)) {
+		return false;
+	}
 	bool retval = SetVal(val);
 	return retval;
 }
 
-bool Prop_string::SetValue(const std::string &input)
+bool Prop_string::SetValue(const std::string& input)
 {
 	// Special version for lowcase stuff
 	std::string temp(input);
-	//suggested values always case insensitive.
-	//If there are none then it can be paths and such which are case sensitive
-	if (!suggested_values.empty()) lowcase(temp);
-	Value val(temp,Value::V_STRING);
+	// suggested values always case insensitive.
+	// If there are none then it can be paths and such which are case sensitive
+	if (!suggested_values.empty()) {
+		lowcase(temp);
+	}
+	Value val(temp, Value::V_STRING);
 	return SetVal(val);
 }
-bool Prop_string::CheckValue(const Value &in)
+bool Prop_string::CheckValue(const Value& in)
 {
-	if (suggested_values.empty())
+	if (suggested_values.empty()) {
 		return true;
-	for (const auto &val : suggested_values) {
+	}
+	for (const auto& val : suggested_values) {
 		if (val == in) { // Match!
 			return true;
 		}
@@ -397,95 +439,119 @@ bool Prop_string::CheckValue(const Value &in)
 	}
 
 	LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-				in.ToString().c_str(),
-				propname.c_str(),
-				default_value.ToString().c_str());
+	            in.ToString().c_str(),
+	            propname.c_str(),
+	            default_value.ToString().c_str());
 
 	return false;
 }
 
-bool Prop_path::SetValue(const std::string &input)
+bool Prop_path::SetValue(const std::string& input)
 {
 	// Special version to merge realpath with it
 
-	Value val(input,Value::V_STRING);
+	Value val(input, Value::V_STRING);
 	bool retval = SetVal(val);
 
 	if (input.empty()) {
 		realpath.clear();
 		return false;
 	}
+
 	std::string workcopy(input);
-	Cross::ResolveHomedir(workcopy); //Parse ~ and friends
-	//Prepend config directory in it exists. Check for absolute paths later
-	if ( current_config_dir.empty()) realpath = workcopy;
-	else realpath = current_config_dir + CROSS_FILESPLIT + workcopy;
-	//Absolute paths
-	if (Cross::IsPathAbsolute(workcopy)) realpath = workcopy;
+	Cross::ResolveHomedir(workcopy); // Parse ~ and friends
+	                                 //
+	// Prepend config directory in it exists. Check for absolute paths later
+	if (current_config_dir.empty()) {
+		realpath = workcopy;
+	} else {
+		realpath = current_config_dir + CROSS_FILESPLIT + workcopy;
+	}
+
+	// Absolute paths
+	if (Cross::IsPathAbsolute(workcopy)) {
+		realpath = workcopy;
+	}
+
 	return retval;
 }
 
-bool Prop_bool::SetValue(const std::string &input)
+bool Prop_bool::SetValue(const std::string& input)
 {
 	return value.SetValue(input, Value::V_BOOL);
 }
 
-bool Prop_hex::SetValue(const std::string &input)
+bool Prop_hex::SetValue(const std::string& input)
 {
 	Value val;
-	val.SetValue(input,Value::V_HEX);
+	val.SetValue(input, Value::V_HEX);
 	return SetVal(val);
 }
 
 void PropMultiVal::make_default_value()
 {
-	Property *p = section->Get_prop(0);
-	if (!p) return;
+	Property* p = section->Get_prop(0);
+	if (!p) {
+		return;
+	}
 
 	int i = 1;
+
 	std::string result = p->GetDefaultValue().ToString();
-	while( (p = section->Get_prop(i++)) ) {
+
+	while ((p = section->Get_prop(i++))) {
 		std::string props = p->GetDefaultValue().ToString();
-		if (props.empty()) continue;
-		result += separator; result += props;
+		if (props.empty()) {
+			continue;
+		}
+		result += separator;
+		result += props;
 	}
-	Value val(result,Value::V_STRING);
+
+	Value val(result, Value::V_STRING);
 	SetVal(val);
 }
 
-//TODO checkvalue stuff
-bool PropMultiValRemain::SetValue(const std::string &input)
+// TODO checkvalue stuff
+bool PropMultiValRemain::SetValue(const std::string& input)
 {
 	Value val(input, Value::V_STRING);
 	bool retval = SetVal(val);
 
 	std::string local(input);
-	int i = 0,number_of_properties = 0;
-	Property *p = section->Get_prop(0);
-	//No properties in this section. do nothing
-	if (!p) return false;
+	int i = 0, number_of_properties = 0;
+	Property* p = section->Get_prop(0);
+	// No properties in this section. do nothing
+	if (!p) {
+		return false;
+	}
 
-	while( (section->Get_prop(number_of_properties)) )
+	while ((section->Get_prop(number_of_properties))) {
 		number_of_properties++;
+	}
 
 	string::size_type loc = string::npos;
-	while( (p = section->Get_prop(i++)) ) {
-		//trim leading separators
+
+	while ((p = section->Get_prop(i++))) {
+		// trim leading separators
 		loc = local.find_first_not_of(separator);
-		if (loc != string::npos) local.erase(0,loc);
-		loc = local.find_first_of(separator);
-		string in = "";//default value
-		/* when i == number_of_properties add the total line. (makes more then
-		 * one string argument possible for parameters of cpu) */
-		if (loc != string::npos && i < number_of_properties) { //separator found
-			in = local.substr(0,loc);
-			local.erase(0,loc+1);
-		} else if (local.size()) { //last argument or last property
+		if (loc != string::npos) {
+			local.erase(0, loc);
+		}
+		loc       = local.find_first_of(separator);
+		string in = ""; // default value
+		/* when i == number_of_properties add the total line. (makes more
+		 * then one string argument possible for parameters of cpu) */
+		if (loc != string::npos && i < number_of_properties) { // separator
+			                                               // found
+			in = local.substr(0, loc);
+			local.erase(0, loc + 1);
+		} else if (local.size()) { // last argument or last property
 			in = local;
 			local.clear();
 		}
-		//Test Value. If it fails set default
-		Value valtest (in,p->Get_type());
+		// Test Value. If it fails set default
+		Value valtest(in, p->Get_type());
 		if (!p->CheckValue(valtest)) {
 			make_default_value();
 			return false;
@@ -495,76 +561,90 @@ bool PropMultiValRemain::SetValue(const std::string &input)
 	return retval;
 }
 
-//TODO checkvalue stuff
-bool PropMultiVal::SetValue(const std::string &input)
+// TODO checkvalue stuff
+bool PropMultiVal::SetValue(const std::string& input)
 {
 	Value val(input, Value::V_STRING);
 	bool retval = SetVal(val);
 
 	std::string local(input);
-	int i = 0;
-	Property *p = section->Get_prop(0);
-	//No properties in this section. do nothing
-	if (!p) return false;
+	int i       = 0;
+	Property* p = section->Get_prop(0);
+	// No properties in this section. do nothing
+	if (!p) {
+		return false;
+	}
 	Value::Etype prevtype = Value::V_NONE;
-	string prevargument = "";
+	string prevargument   = "";
 
 	string::size_type loc = string::npos;
-	while( (p = section->Get_prop(i++)) ) {
-		//trim leading separators
+	while ((p = section->Get_prop(i++))) {
+		// trim leading separators
 		loc = local.find_first_not_of(separator);
-		if (loc != string::npos) local.erase(0,loc);
-		loc = local.find_first_of(separator);
-		string in = "";//default value
-		if (loc != string::npos) { //separator found
-			in = local.substr(0,loc);
-			local.erase(0,loc+1);
-		} else if (local.size()) { //last argument
+		if (loc != string::npos) {
+			local.erase(0, loc);
+		}
+		loc       = local.find_first_of(separator);
+		string in = "";            // default value
+		if (loc != string::npos) { // separator found
+			in = local.substr(0, loc);
+			local.erase(0, loc + 1);
+		} else if (local.size()) { // last argument
 			in = local;
 			local.clear();
 		}
 
 		if (p->Get_type() == Value::V_STRING) {
-			//Strings are only checked against the suggested values list.
-			//Test Value. If it fails set default
-			Value valtest (in,p->Get_type());
+			// Strings are only checked against the suggested values
+			// list. Test Value. If it fails set default
+			Value valtest(in, p->Get_type());
 			if (!p->CheckValue(valtest)) {
 				make_default_value();
 				return false;
 			}
 			p->SetValue(in);
 		} else {
-			//Non-strings can have more things, conversion alone is not enough (as invalid values as converted to 0)
+			// Non-strings can have more things, conversion alone is
+			// not enough (as invalid values as converted to 0)
 			bool r = p->SetValue(in);
 			if (!r) {
-				if (in.empty() && p->Get_type() == prevtype ) {
-					//Nothing there, but same type of variable, so repeat it (sensitivity)
+				if (in.empty() && p->Get_type() == prevtype) {
+					// Nothing there, but same type of
+					// variable, so repeat it (sensitivity)
 					in = prevargument;
 					p->SetValue(in);
 				} else {
-					//Something was there to be parsed or not the same type. Invalidate entire property.
+					// Something was there to be parsed or
+					// not the same type. Invalidate entire
+					// property.
 					make_default_value();
 				}
 			}
 		}
-		prevtype = p->Get_type();
+		prevtype     = p->Get_type();
 		prevargument = in;
-
 	}
 	return retval;
 }
 
-const std::vector<Value>& Property::GetValues() const {
+const std::vector<Value>& Property::GetValues() const
+{
 	return suggested_values;
 }
-const std::vector<Value>& PropMultiVal::GetValues() const {
-	Property *p = section->Get_prop(0);
-	//No properties in this section. do nothing
-	if (!p) return suggested_values;
-	int i =0;
-	while( (p = section->Get_prop(i++)) ) {
+
+const std::vector<Value>& PropMultiVal::GetValues() const
+{
+	Property* p = section->Get_prop(0);
+	// No properties in this section. do nothing
+	if (!p) {
+		return suggested_values;
+	}
+	int i = 0;
+	while ((p = section->Get_prop(i++))) {
 		std::vector<Value> v = p->GetValues();
-		if(!v.empty()) return p->GetValues();
+		if (!v.empty()) {
+			return p->GetValues();
+		}
 	}
 	return suggested_values;
 }
@@ -575,84 +655,88 @@ void Section_prop::Add_double(const char * _propname, double _value) {
         properties.push_back(test);
 }*/
 
-void Property::Set_values(const char * const *in) {
+void Property::Set_values(const char* const* in)
+{
 	Value::Etype type = default_value.type;
+
 	int i = 0;
+
 	while (in[i]) {
-		Value val(in[i],type);
+		Value val(in[i], type);
 		suggested_values.push_back(val);
 		i++;
 	}
 }
 
-void Property::Set_values(const std::vector<std::string> & in) {
+void Property::Set_values(const std::vector<std::string>& in)
+{
 	Value::Etype type = default_value.type;
-	for (auto &str : in) {
+	for (auto& str : in) {
 		Value val(str, type);
 		suggested_values.push_back(val);
 	}
 }
 
-Prop_int *Section_prop::Add_int(const std::string &_propname,
+Prop_int* Section_prop::Add_int(const std::string& _propname,
                                 Property::Changeable::Value when, int _value)
 {
-	Prop_int *test = new Prop_int(_propname, when, _value);
+	Prop_int* test = new Prop_int(_propname, when, _value);
 	properties.push_back(test);
 	return test;
 }
 
-Prop_string *Section_prop::Add_string(const std::string &_propname,
+Prop_string* Section_prop::Add_string(const std::string& _propname,
                                       Property::Changeable::Value when,
-                                      const char *_value)
+                                      const char* _value)
 {
-	Prop_string *test = new Prop_string(_propname, when, _value);
+	Prop_string* test = new Prop_string(_propname, when, _value);
 	properties.push_back(test);
 	return test;
 }
 
-Prop_path *Section_prop::Add_path(const std::string &_propname,
-                                  Property::Changeable::Value when, const char *_value)
+Prop_path* Section_prop::Add_path(const std::string& _propname,
+                                  Property::Changeable::Value when, const char* _value)
 {
-	Prop_path *test = new Prop_path(_propname, when, _value);
+	Prop_path* test = new Prop_path(_propname, when, _value);
 	properties.push_back(test);
 	return test;
 }
 
-Prop_bool *Section_prop::Add_bool(const std::string &_propname,
+Prop_bool* Section_prop::Add_bool(const std::string& _propname,
                                   Property::Changeable::Value when, bool _value)
 {
-	Prop_bool *test = new Prop_bool(_propname, when, _value);
+	Prop_bool* test = new Prop_bool(_propname, when, _value);
 	properties.push_back(test);
 	return test;
 }
 
-Prop_hex *Section_prop::Add_hex(const std::string &_propname,
+Prop_hex* Section_prop::Add_hex(const std::string& _propname,
                                 Property::Changeable::Value when, Hex _value)
 {
-	Prop_hex *test = new Prop_hex(_propname, when, _value);
+	Prop_hex* test = new Prop_hex(_propname, when, _value);
 	properties.push_back(test);
 	return test;
 }
 
-PropMultiVal *Section_prop::AddMultiVal(const std::string &_propname,
-                                       Property::Changeable::Value when,
-                                       const std::string &sep)
+PropMultiVal* Section_prop::AddMultiVal(const std::string& _propname,
+                                        Property::Changeable::Value when,
+                                        const std::string& sep)
 {
-	PropMultiVal *test = new PropMultiVal(_propname, when, sep);
+	PropMultiVal* test = new PropMultiVal(_propname, when, sep);
 	properties.push_back(test);
 	return test;
 }
 
-PropMultiValRemain *Section_prop::AddMultiValRemain(const std::string &_propname,
+PropMultiValRemain* Section_prop::AddMultiValRemain(const std::string& _propname,
                                                     Property::Changeable::Value when,
-                                                    const std::string &sep)
+                                                    const std::string& sep)
 {
-	PropMultiValRemain *test = new PropMultiValRemain(_propname, when, sep);
+	PropMultiValRemain* test = new PropMultiValRemain(_propname, when, sep);
 	properties.push_back(test);
 	return test;
 }
 
-int Section_prop::Get_int(const std::string &_propname) const
+int Section_prop::Get_int(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); tel++) {
 		if ((*tel)->propname == _propname) {
@@ -662,7 +746,7 @@ int Section_prop::Get_int(const std::string &_propname) const
 	return 0;
 }
 
-bool Section_prop::Get_bool(const std::string &_propname) const
+bool Section_prop::Get_bool(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
@@ -672,7 +756,7 @@ bool Section_prop::Get_bool(const std::string &_propname) const
 	return false;
 }
 
-double Section_prop::Get_double(const std::string &_propname) const
+double Section_prop::Get_double(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
@@ -682,46 +766,62 @@ double Section_prop::Get_double(const std::string &_propname) const
 	return 0.0;
 }
 
-Prop_path *Section_prop::Get_path(const std::string &_propname) const
+Prop_path* Section_prop::Get_path(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
 			Prop_path* val = dynamic_cast<Prop_path*>((*tel));
-			if (val) return val; else return NULL;
+			if (val) {
+				return val;
+			} else {
+				return NULL;
+			}
 		}
 	}
 	return NULL;
 }
 
-PropMultiVal *Section_prop::GetMultiVal(const std::string &_propname) const
+PropMultiVal* Section_prop::GetMultiVal(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
 			PropMultiVal* val = dynamic_cast<PropMultiVal*>((*tel));
-			if(val) return val; else return NULL;
+			if (val) {
+				return val;
+			} else {
+				return NULL;
+			}
 		}
 	}
 	return NULL;
 }
 
-PropMultiValRemain *Section_prop::GetMultiValRemain(const std::string &_propname) const
+PropMultiValRemain* Section_prop::GetMultiValRemain(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
-			PropMultiValRemain* val = dynamic_cast<PropMultiValRemain*>((*tel));
-			if (val) return val; else return NULL;
+			PropMultiValRemain* val = dynamic_cast<PropMultiValRemain*>(
+			        (*tel));
+			if (val) {
+				return val;
+			} else {
+				return NULL;
+			}
 		}
 	}
 	return NULL;
 }
-Property* Section_prop::Get_prop(int index){
-	for(it tel = properties.begin();tel != properties.end();++tel){
-		if (!index--) return (*tel);
+Property* Section_prop::Get_prop(int index)
+{
+	for (it tel = properties.begin(); tel != properties.end(); ++tel) {
+		if (!index--) {
+			return (*tel);
+		}
 	}
 	return NULL;
 }
 
-const char *Section_prop::Get_string(const std::string &_propname) const
+const char* Section_prop::Get_string(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
@@ -730,7 +830,7 @@ const char *Section_prop::Get_string(const std::string &_propname) const
 	}
 	return "";
 }
-Hex Section_prop::Get_hex(const std::string &_propname) const
+Hex Section_prop::Get_hex(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {
@@ -781,29 +881,31 @@ bool Section_prop::HandleInputline(const std::string& line)
 	return false;
 }
 
-void Section_prop::PrintData(FILE* outfile) const {
+void Section_prop::PrintData(FILE* outfile) const
+{
 	/* Now print out the individual section entries */
 
 	// Determine maximum length of the props in this section
 	int len = 0;
-	for (const auto &tel : properties) {
+	for (const auto& tel : properties) {
 		const auto prop_length = check_cast<int>(tel->propname.length());
 		len = std::max<int>(len, prop_length);
 	}
 
-	for (const auto &tel : properties) {
-
-		if (tel->IsDeprecated())
+	for (const auto& tel : properties) {
+		if (tel->IsDeprecated()) {
 			continue;
+		}
 
-		fprintf(outfile, "%-*s = %s\n",
+		fprintf(outfile,
+		        "%-*s = %s\n",
 		        std::min<int>(40, len),
 		        tel->propname.c_str(),
 		        tel->GetValue().ToString().c_str());
 	}
 }
 
-string Section_prop::GetPropValue(const std::string &_property) const
+string Section_prop::GetPropValue(const std::string& _property) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if (!strcasecmp((*tel)->propname.c_str(), _property.c_str())) {
@@ -813,29 +915,34 @@ string Section_prop::GetPropValue(const std::string &_property) const
 	return NO_SUCH_PROPERTY;
 }
 
-bool Section_line::HandleInputline(const std::string &line)
+bool Section_line::HandleInputline(const std::string& line)
 {
-	if (!data.empty()) data += "\n"; //Add return to previous line in buffer
+	if (!data.empty()) {
+		data += "\n"; // Add return to previous line in buffer
+	}
 	data += line;
 	return true;
 }
 
-void Section_line::PrintData(FILE *outfile) const
+void Section_line::PrintData(FILE* outfile) const
 {
 	fprintf(outfile, "%s", data.c_str());
 }
 
-std::string Section_line::GetPropValue(const std::string &) const
+std::string Section_line::GetPropValue(const std::string&) const
 {
 	return NO_SUCH_PROPERTY;
 }
 
-bool Config::PrintConfig(const std::string &filename) const
+bool Config::PrintConfig(const std::string& filename) const
 {
 	char temp[50];
 	char helpline[256];
-	FILE *outfile = fopen(filename.c_str(), "w+t");
-	if (outfile == NULL) return false;
+
+	FILE* outfile = fopen(filename.c_str(), "w+t");
+	if (outfile == NULL) {
+		return false;
+	}
 
 	/* Print start of configfile and add a return to improve readibility. */
 	fprintf(outfile, MSG_GetRaw("CONFIGFILE_INTRO"), VERSION);
@@ -845,59 +952,93 @@ bool Config::PrintConfig(const std::string &filename) const
 		/* Print out the Section header */
 		safe_strcpy(temp, (*tel)->GetName());
 		lowcase(temp);
-		fprintf(outfile,"[%s]\n",temp);
+		fprintf(outfile, "[%s]\n", temp);
 
-		Section_prop *sec = dynamic_cast<Section_prop *>(*tel);
+		Section_prop* sec = dynamic_cast<Section_prop*>(*tel);
 		if (sec) {
-			Property *p;
-			int i = 0;
+			Property* p;
+			int i           = 0;
 			size_t maxwidth = 0;
+
 			while ((p = sec->Get_prop(i++))) {
 				maxwidth = std::max(maxwidth, p->propname.length());
 			}
-			i=0;
+
+			i = 0;
+
 			char prefix[80];
 			int intmaxwidth = std::min<int>(60, check_cast<int>(maxwidth));
 			safe_sprintf(prefix, "\n# %*s  ", intmaxwidth, "");
-			while ((p = sec->Get_prop(i++))) {
 
-				if (p->IsDeprecated())
+			while ((p = sec->Get_prop(i++))) {
+				if (p->IsDeprecated()) {
 					continue;
+				}
 
 				std::string help = p->GetHelpUtf8();
+
 				std::string::size_type pos = std::string::npos;
-				while ((pos = help.find('\n', pos+1)) != std::string::npos) {
+
+				while ((pos = help.find('\n', pos + 1)) !=
+				       std::string::npos) {
 					help.replace(pos, 1, prefix);
 				}
 
-				fprintf(outfile, "# %*s: %s", intmaxwidth, p->propname.c_str(), help.c_str());
+				fprintf(outfile,
+				        "# %*s: %s",
+				        intmaxwidth,
+				        p->propname.c_str(),
+				        help.c_str());
 
 				std::vector<Value> values = p->GetValues();
+
 				if (!values.empty()) {
-					fprintf(outfile, "%s%s:", prefix, MSG_GetRaw("CONFIG_SUGGESTED_VALUES"));
-					std::vector<Value>::const_iterator it = values.begin();
+					fprintf(outfile,
+					        "%s%s:",
+					        prefix,
+					        MSG_GetRaw("CONFIG_SUGGESTED_VALUES"));
+
+					std::vector<Value>::const_iterator it =
+					        values.begin();
+
 					while (it != values.end()) {
-						if((*it).ToString() != "%u") { //Hack hack hack. else we need to modify GetValues, but that one is const...
-							if (it != values.begin()) fputs(",", outfile);
-							fprintf(outfile, " %s", (*it).ToString().c_str());
+						if ((*it).ToString() !=
+						    "%u") { // Hack hack hack.
+							    // else we need to
+							    // modify GetValues,
+							    // but that one is
+							    // const...
+							if (it != values.begin()) {
+								fputs(",", outfile);
+							}
+
+							fprintf(outfile,
+							        " %s",
+							        (*it).ToString().c_str());
 						}
 						++it;
 					}
-					fprintf(outfile,".");
+					fprintf(outfile, ".");
 				}
-			fprintf(outfile, "\n");
+				fprintf(outfile, "\n");
 			}
 		} else {
 			upcase(temp);
-			strcat(temp,"_CONFIGFILE_HELP");
-			const char * helpstr = MSG_GetRaw(temp);
-			const char * linestart = helpstr;
-			char * helpwrite = helpline;
-			while (*helpstr && static_cast<size_t>(helpstr - linestart) < sizeof(helpline)) {
+			strcat(temp, "_CONFIGFILE_HELP");
+
+			const char* helpstr   = MSG_GetRaw(temp);
+			const char* linestart = helpstr;
+			char* helpwrite       = helpline;
+
+			while (*helpstr && static_cast<size_t>(helpstr - linestart) <
+			                           sizeof(helpline)) {
 				*helpwrite++ = *helpstr;
+
 				if (*helpstr == '\n') {
 					*helpwrite = 0;
+
 					fprintf(outfile, "# %s", helpline);
+
 					helpwrite = helpline;
 					linestart = ++helpstr;
 				} else {
@@ -906,31 +1047,31 @@ bool Config::PrintConfig(const std::string &filename) const
 			}
 		}
 
-		fprintf(outfile,"\n");
+		fprintf(outfile, "\n");
 		(*tel)->PrintData(outfile);
-		fprintf(outfile,"\n");		/* Always an empty line between sections */
+		fprintf(outfile, "\n"); /* Always an empty line between sections */
 	}
+
 	fclose(outfile);
 	return true;
 }
 
-Section_prop *Config::AddEarlySectionProp(const char *name,
-                                          SectionFunction func,
+Section_prop* Config::AddEarlySectionProp(const char* name, SectionFunction func,
                                           bool changeable_at_runtime)
 {
-	Section_prop *s = new Section_prop(name);
+	Section_prop* s = new Section_prop(name);
 	s->AddEarlyInitFunction(func, changeable_at_runtime);
 	sectionlist.push_back(s);
 	return s;
 }
 
-Section_prop *Config::AddSection_prop(const char *section_name,
-                                      SectionFunction func,
+Section_prop* Config::AddSection_prop(const char* section_name, SectionFunction func,
                                       bool changeable_at_runtime)
 {
 	assertm(std::regex_match(section_name, std::regex{"[a-zA-Z0-9]+"}),
 	        "Only letters and digits are allowed in section name");
-	Section_prop *s = new Section_prop(section_name);
+
+	Section_prop* s = new Section_prop(section_name);
 	s->AddInitFunction(func, changeable_at_runtime);
 	sectionlist.push_back(s);
 	return s;
@@ -938,39 +1079,46 @@ Section_prop *Config::AddSection_prop(const char *section_name,
 
 Section_prop::~Section_prop()
 {
-	//ExecuteDestroy should be here else the destroy functions use destroyed properties
+	// ExecuteDestroy should be here else the destroy functions use
+	// destroyed properties
 	ExecuteDestroy(true);
+
 	/* Delete properties themself (properties stores the pointer of a prop */
-	for(it prop = properties.begin(); prop != properties.end(); ++prop)
+	for (it prop = properties.begin(); prop != properties.end(); ++prop) {
 		delete (*prop);
+	}
 }
 
-Section_line *Config::AddSection_line(const char *section_name, SectionFunction func)
+Section_line* Config::AddSection_line(const char* section_name, SectionFunction func)
 {
 	assertm(std::regex_match(section_name, std::regex{"[a-zA-Z0-9]+"}),
 	        "Only letters and digits are allowed in section name");
-	Section_line *blah = new Section_line(section_name);
+
+	Section_line* blah = new Section_line(section_name);
 	blah->AddInitFunction(func);
 	sectionlist.push_back(blah);
+
 	return blah;
 }
 
 // Move assignment operator
-Config &Config::operator=(Config &&source) noexcept
+Config& Config::operator=(Config&& source) noexcept
 {
-	if (this == &source)
+	if (this == &source) {
 		return *this;
+	}
 
 	// Move each member
-	cmdline                      = std::move(source.cmdline);
-	sectionlist                  = std::move(source.sectionlist);
-	_start_function              = std::move(source._start_function);
-	secure_mode                  = std::move(source.secure_mode);
-	startup_params               = std::move(source.startup_params);
-	configfiles                  = std::move(source.configfiles);
-	configFilesCanonical         = std::move(source.configFilesCanonical);
+	cmdline              = std::move(source.cmdline);
+	sectionlist          = std::move(source.sectionlist);
+	_start_function      = std::move(source._start_function);
+	secure_mode          = std::move(source.secure_mode);
+	startup_params       = std::move(source.startup_params);
+	configfiles          = std::move(source.configfiles);
+	configFilesCanonical = std::move(source.configFilesCanonical);
+
 	overwritten_autoexec_section = std::move(source.overwritten_autoexec_section);
-	overwritten_autoexec_conf    = std::move(source.overwritten_autoexec_conf);
+	overwritten_autoexec_conf = std::move(source.overwritten_autoexec_conf);
 
 	// Hollow-out the source
 	source.cmdline                      = {};
@@ -986,18 +1134,20 @@ Config &Config::operator=(Config &&source) noexcept
 }
 
 // Move constructor, leverages move by assignment
-Config::Config(Config &&source) noexcept
+Config::Config(Config&& source) noexcept
 {
 	*this = std::move(source);
 }
 
 void Config::Init() const
 {
-	for (const auto &sec : sectionlist)
+	for (const auto& sec : sectionlist) {
 		sec->ExecuteEarlyInit();
+	}
 
-	for (const auto &sec : sectionlist)
+	for (const auto& sec : sectionlist) {
 		sec->ExecuteInit();
+	}
 }
 
 void Section::AddEarlyInitFunction(SectionFunction func, bool changeable_at_runtime)
@@ -1017,54 +1167,66 @@ void Section::AddDestroyFunction(SectionFunction func, bool changeable_at_runtim
 
 void Section::ExecuteEarlyInit(bool init_all)
 {
-	for (const auto &fn : early_init_functions)
-		if (init_all || fn.changeable_at_runtime)
+	for (const auto& fn : early_init_functions) {
+		if (init_all || fn.changeable_at_runtime) {
 			fn.function(this);
+		}
+	}
 }
 
 void Section::ExecuteInit(bool initall)
 {
-	for (const auto &fn : initfunctions)
-		if (initall || fn.changeable_at_runtime)
+	for (const auto& fn : initfunctions) {
+		if (initall || fn.changeable_at_runtime) {
 			fn.function(this);
+		}
+	}
 }
 
-void Section::ExecuteDestroy(bool destroyall) {
+void Section::ExecuteDestroy(bool destroyall)
+{
 	typedef std::deque<Function_wrapper>::iterator func_it;
-	for (func_it tel = destroyfunctions.begin(); tel != destroyfunctions.end(); ) {
+
+	for (func_it tel = destroyfunctions.begin(); tel != destroyfunctions.end();) {
 		if (destroyall || (*tel).changeable_at_runtime) {
 			(*tel).function(this);
-			tel = destroyfunctions.erase(tel); //Remove destroyfunction once used
-		} else
+			tel = destroyfunctions.erase(tel); // Remove
+			                                   // destroyfunction
+			                                   // once used
+		} else {
 			++tel;
+		}
 	}
 }
 
 Config::~Config()
 {
-	for (auto cnt = sectionlist.rbegin(); cnt != sectionlist.rend(); ++cnt)
+	for (auto cnt = sectionlist.rbegin(); cnt != sectionlist.rend(); ++cnt) {
 		delete (*cnt);
+	}
 }
 
-Section *Config::GetSection(const std::string &section_name) const
+Section* Config::GetSection(const std::string& section_name) const
 {
-	for (auto *el : sectionlist) {
-		if (!strcasecmp(el->GetName(), section_name.c_str()))
+	for (auto* el : sectionlist) {
+		if (!strcasecmp(el->GetName(), section_name.c_str())) {
 			return el;
+		}
 	}
 	return nullptr;
 }
 
-Section *Config::GetSectionFromProperty(const char *prop) const
+Section* Config::GetSectionFromProperty(const char* prop) const
 {
-	for (auto *el : sectionlist) {
-		if (el->GetPropValue(prop) != NO_SUCH_PROPERTY)
+	for (auto* el : sectionlist) {
+		if (el->GetPropValue(prop) != NO_SUCH_PROPERTY) {
 			return el;
+		}
 	}
 	return nullptr;
 }
 
-void Config::OverwriteAutoexec(const std::string &conf, const std::string &line)
+void Config::OverwriteAutoexec(const std::string& conf, const std::string& line)
 {
 	// If we're in a new config file, then record that filename and reset
 	// the section
@@ -1075,12 +1237,12 @@ void Config::OverwriteAutoexec(const std::string &conf, const std::string &line)
 	overwritten_autoexec_section.HandleInputline(line);
 }
 
-const std::string &Config::GetOverwrittenAutoexecConf() const
+const std::string& Config::GetOverwrittenAutoexecConf() const
 {
 	return overwritten_autoexec_conf;
 }
 
-const Section_line &Config::GetOverwrittenAutoexecSection() const
+const Section_line& Config::GetOverwrittenAutoexecSection() const
 {
 	return overwritten_autoexec_section;
 }
@@ -1147,9 +1309,10 @@ bool Config::ParseConfigFile(const std::string& type, const std::string& configf
 				// If this is an autoexec section, the above
 				// takes care of the joining while this handles
 				// the overwrriten mode. We need to be prepared
-				// for either scenario to play out because we won't
-				// know the users final preferance until the
-				// very last configuration file is processed.
+				// for either scenario to play out because we
+				// won't know the users final preferance until
+				// the very last configuration file is
+				// processed.
 				if (std::string_view(currentsection->GetName()) ==
 				    "autoexec") {
 					OverwriteAutoexec(configfilename, line);
@@ -1168,7 +1331,7 @@ bool Config::ParseConfigFile(const std::string& type, const std::string& configf
 	return true;
 }
 
-parse_environ_result_t parse_environ(const char * const * envp) noexcept
+parse_environ_result_t parse_environ(const char* const* envp) noexcept
 {
 	assert(envp);
 
@@ -1176,22 +1339,31 @@ parse_environ_result_t parse_environ(const char * const * envp) noexcept
 	// DOSBOX_SECTIONNAME_PROPNAME=VALUE (prefix, section, and property
 	// names are case-insensitive).
 	std::list<std::tuple<std::string, std::string>> props_to_set;
-	for (const char * const *str = envp; *str; str++) {
-		const char *env_var = *str;
-		if (strncasecmp(env_var, "DOSBOX_", 7) != 0)
+
+	for (const char* const* str = envp; *str; str++) {
+		const char* env_var = *str;
+		if (strncasecmp(env_var, "DOSBOX_", 7) != 0) {
 			continue;
-		const std::string rest = (env_var + 7);
+		}
+
+		const std::string rest       = (env_var + 7);
 		const auto section_delimiter = rest.find('_');
-		if (section_delimiter == string::npos)
+		if (section_delimiter == string::npos) {
 			continue;
+		}
+
 		const auto section_name = rest.substr(0, section_delimiter);
-		if (section_name.empty())
+		if (section_name.empty()) {
 			continue;
+		}
+
 		const auto prop_name_and_value = rest.substr(section_delimiter + 1);
-		if (prop_name_and_value.empty() || !isalpha(prop_name_and_value[0]))
+		if (prop_name_and_value.empty() || !isalpha(prop_name_and_value[0])) {
 			continue;
-		props_to_set.emplace_back(std::make_tuple(section_name,
-		                                          prop_name_and_value));
+		}
+
+		props_to_set.emplace_back(
+		        std::make_tuple(section_name, prop_name_and_value));
 	}
 
 	return props_to_set;
@@ -1200,25 +1372,31 @@ parse_environ_result_t parse_environ(const char * const * envp) noexcept
 void Config::ParseEnv()
 {
 #if defined(_MSC_VER) || (defined(__MINGW32__) && defined(__clang__))
-	const char *const *envp = _environ;
+	const char* const* envp = _environ;
 #else
-	const char *const *envp = environ;
+	const char* const* envp = environ;
 #endif
-	if (envp == nullptr)
+	if (envp == nullptr) {
 		return;
+	}
 
-	for (const auto &set_prop_desc : parse_environ(envp)) {
+	for (const auto& set_prop_desc : parse_environ(envp)) {
 		const auto section_name = std::get<0>(set_prop_desc);
-		Section *sec = GetSection(section_name);
-		if (!sec)
+
+		Section* sec = GetSection(section_name);
+
+		if (!sec) {
 			continue;
+		}
+
 		const auto prop_name_and_value = std::get<1>(set_prop_desc);
 		sec->HandleInputline(prop_name_and_value);
 	}
 }
 
-void Config::SetStartUp(void (*_function)(void)) {
-	_start_function=_function;
+void Config::SetStartUp(void (*_function)(void))
+{
+	_start_function = _function;
 }
 
 void Config::StartUp()
@@ -1232,27 +1410,35 @@ Verbosity Config::GetStartupVerbosity() const
 	assert(s);
 	const std::string user_choice = s->GetPropValue("startup_verbosity");
 
-	if (user_choice == "high")
+	if (user_choice == "high") {
 		return Verbosity::High;
-	if (user_choice == "low")
+	}
+	if (user_choice == "low") {
 		return Verbosity::Low;
-	if (user_choice == "quiet")
+	}
+	if (user_choice == "quiet") {
 		return Verbosity::Quiet;
-	if (user_choice == "auto")
+	}
+	if (user_choice == "auto") {
 		return (cmdline->HasDirectory() || cmdline->HasExecutableName())
-		               ? Verbosity::InstantLaunch
-		               : Verbosity::High;
+		             ? Verbosity::InstantLaunch
+		             : Verbosity::High;
+	}
 
 	LOG_WARNING("SETUP: Unknown verbosity mode '%s', defaulting to 'high'",
 	            user_choice.c_str());
 	return Verbosity::High;
 }
 
-bool CommandLine::FindExist(const char *name, bool remove)
+bool CommandLine::FindExist(const char* name, bool remove)
 {
 	cmd_it it;
-	if (!(FindEntry(name,it,false))) return false;
-	if (remove) cmds.erase(it);
+	if (!(FindEntry(name, it, false))) {
+		return false;
+	}
+	if (remove) {
+		cmds.erase(it);
+	}
 	return true;
 }
 
@@ -1262,8 +1448,7 @@ bool CommandLine::FindExist(const char *name, bool remove)
 bool CommandLine::ExistsPriorTo(const std::list<std::string_view>& pre_args,
                                 const std::list<std::string_view>& post_args) const
 {
-	auto any_of_iequals = [](const auto& haystack,
-	                         const auto& needle) {
+	auto any_of_iequals = [](const auto& haystack, const auto& needle) {
 		return std::any_of(haystack.begin(),
 		                   haystack.end(),
 		                   [&needle](const auto& hay) {
@@ -1272,7 +1457,8 @@ bool CommandLine::ExistsPriorTo(const std::list<std::string_view>& pre_args,
 	};
 
 	for (const auto& cli_arg : cmds) {
-		// if any of the pre-args are insensitive-equal-to the CLI argument ...
+		// if any of the pre-args are insensitive-equal-to the CLI
+		// argument ...
 		if (any_of_iequals(pre_args, cli_arg)) {
 			return true;
 		}
@@ -1286,31 +1472,52 @@ bool CommandLine::ExistsPriorTo(const std::list<std::string_view>& pre_args,
 bool CommandLine::FindInt(const char* name, int& value, bool remove)
 {
 	cmd_it it, it_next;
-	if (!(FindEntry(name, it, true)))
+
+	if (!(FindEntry(name, it, true))) {
 		return false;
-	it_next=it;++it_next;
-	value=atoi((*it_next).c_str());
-	if (remove) cmds.erase(it,++it_next);
+	}
+
+	it_next = it;
+	++it_next;
+	value = atoi((*it_next).c_str());
+
+	if (remove) {
+		cmds.erase(it, ++it_next);
+	}
 	return true;
 }
 
-bool CommandLine::FindString(const char *name, std::string &value, bool remove)
+bool CommandLine::FindString(const char* name, std::string& value, bool remove)
 {
 	cmd_it it, it_next;
-	if (!(FindEntry(name, it, true)))
+
+	if (!(FindEntry(name, it, true))) {
 		return false;
-	it_next=it;++it_next;
-	value=*it_next;
-	if (remove) cmds.erase(it,++it_next);
+	}
+
+	it_next = it;
+	++it_next;
+	value = *it_next;
+
+	if (remove) {
+		cmds.erase(it, ++it_next);
+	}
 	return true;
 }
 
-bool CommandLine::FindCommand(unsigned int which,std::string & value) {
-	if (which<1) return false;
-	if (which>cmds.size()) return false;
-	cmd_it it=cmds.begin();
-	for (;which>1;which--) it++;
-	value=(*it);
+bool CommandLine::FindCommand(unsigned int which, std::string& value)
+{
+	if (which < 1) {
+		return false;
+	}
+	if (which > cmds.size()) {
+		return false;
+	}
+	cmd_it it = cmds.begin();
+	for (; which > 1; which--) {
+		it++;
+	}
+	value = (*it);
 	return true;
 }
 
@@ -1323,18 +1530,23 @@ bool CommandLine::HasDirectory() const
 // Was an executable filename provided on the command line?
 bool CommandLine::HasExecutableName() const
 {
-	for (const auto& arg : cmds)
-		if (is_executable_filename(arg))
+	for (const auto& arg : cmds) {
+		if (is_executable_filename(arg)) {
 			return true;
+		}
+	}
 	return false;
 }
 
-bool CommandLine::FindEntry(const char *name, cmd_it &it, bool neednext)
+bool CommandLine::FindEntry(const char* name, cmd_it& it, bool neednext)
 {
 	for (it = cmds.begin(); it != cmds.end(); ++it) {
-		if (!strcasecmp((*it).c_str(),name)) {
-			cmd_it itnext=it;++itnext;
-			if (neednext && (itnext==cmds.end())) return false;
+		if (!strcasecmp((*it).c_str(), name)) {
+			cmd_it itnext = it;
+			++itnext;
+			if (neednext && (itnext == cmds.end())) {
+				return false;
+			}
 			return true;
 		}
 	}
@@ -1345,24 +1557,27 @@ bool CommandLine::FindStringBegin(const char* const begin, std::string& value,
                                   bool remove)
 {
 	size_t len = strlen(begin);
-	for (cmd_it it = cmds.begin(); it != cmds.end();++it) {
-		if (strncmp(begin,(*it).c_str(),len)==0) {
-			value=((*it).c_str() + len);
-			if (remove) cmds.erase(it);
+	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
+		if (strncmp(begin, (*it).c_str(), len) == 0) {
+			value = ((*it).c_str() + len);
+			if (remove) {
+				cmds.erase(it);
+			}
 			return true;
 		}
 	}
 	return false;
 }
 
-bool CommandLine::FindStringRemain(const char *name, std::string &value)
+bool CommandLine::FindStringRemain(const char* name, std::string& value)
 {
 	cmd_it it;
 	value.clear();
-	if (!FindEntry(name, it))
+	if (!FindEntry(name, it)) {
 		return false;
+	}
 	++it;
-	for (;it != cmds.end();++it) {
+	for (; it != cmds.end(); ++it) {
 		value += " ";
 		value += (*it);
 	}
@@ -1371,111 +1586,132 @@ bool CommandLine::FindStringRemain(const char *name, std::string &value)
 
 /* Only used for parsing command.com /C
  * Allowing /C dir and /Cdir
- * Restoring quotes back into the commands so command /C mount d "/tmp/a b" works as intended
+ * Restoring quotes back into the commands so command /C mount d "/tmp/a b"
+ * works as intended
  */
-bool CommandLine::FindStringRemainBegin(const char *name, std::string &value)
+bool CommandLine::FindStringRemainBegin(const char* name, std::string& value)
 {
 	cmd_it it;
 	value.clear();
+
 	if (!FindEntry(name, it)) {
 		size_t len = strlen(name);
-			for (it = cmds.begin();it != cmds.end();++it) {
-				if (strncasecmp(name,(*it).c_str(),len)==0) {
-					std::string temp = ((*it).c_str() + len);
-					//Restore quotes for correct parsing in later stages
-					if(temp.find(' ') != std::string::npos)
-						value = std::string("\"") + temp + std::string("\"");
-					else
-						value = temp;
-					break;
+
+		for (it = cmds.begin(); it != cmds.end(); ++it) {
+			if (strncasecmp(name, (*it).c_str(), len) == 0) {
+				std::string temp = ((*it).c_str() + len);
+				// Restore quotes for correct parsing in later
+				// stages
+				if (temp.find(' ') != std::string::npos) {
+					value = std::string("\"") + temp +
+					        std::string("\"");
+				} else {
+					value = temp;
 				}
+				break;
 			}
-		if (it == cmds.end()) return false;
+		}
+		if (it == cmds.end()) {
+			return false;
+		}
 	}
+
 	++it;
-	for (;it != cmds.end();++it) {
+
+	for (; it != cmds.end(); ++it) {
 		value += " ";
 		std::string temp = (*it);
-		if(temp.find(' ') != std::string::npos)
+		if (temp.find(' ') != std::string::npos) {
 			value += std::string("\"") + temp + std::string("\"");
-		else
+		} else {
 			value += temp;
+		}
 	}
 	return true;
 }
 
-bool CommandLine::GetStringRemain(std::string & value) {
-	if (!cmds.size()) return false;
+bool CommandLine::GetStringRemain(std::string& value)
+{
+	if (!cmds.size()) {
+		return false;
+	}
 
-	cmd_it it = cmds.begin();value = (*it++);
-	for(;it != cmds.end();++it) {
+	cmd_it it = cmds.begin();
+	value     = (*it++);
+
+	for (; it != cmds.end(); ++it) {
 		value += " ";
 		value += (*it);
 	}
 	return true;
 }
 
-
-unsigned int CommandLine::GetCount(void) {
+unsigned int CommandLine::GetCount(void)
+{
 	return (unsigned int)cmds.size();
 }
 
-void CommandLine::FillVector(std::vector<std::string> & vector) {
-	for(cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
+void CommandLine::FillVector(std::vector<std::string>& vector)
+{
+	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
 		vector.push_back((*it));
 	}
 #ifdef WIN32
 	// add back the \" if the parameter contained a space
-	for(Bitu i = 0; i < vector.size(); i++) {
-		if(vector[i].find(' ') != std::string::npos) {
-			vector[i] = "\""+vector[i]+"\"";
+	for (Bitu i = 0; i < vector.size(); i++) {
+		if (vector[i].find(' ') != std::string::npos) {
+			vector[i] = "\"" + vector[i] + "\"";
 		}
 	}
 #endif
 }
 
-int CommandLine::GetParameterFromList(const char* const params[], std::vector<std::string> & output) {
+int CommandLine::GetParameterFromList(const char* const params[],
+                                      std::vector<std::string>& output)
+{
 	// return values: 0 = P_NOMATCH, 1 = P_NOPARAMS
 	// TODO return nomoreparams
 	int retval = 1;
 	output.clear();
-	enum {
-		P_START, P_FIRSTNOMATCH, P_FIRSTMATCH
-	} parsestate = P_START;
+
+	enum { P_START, P_FIRSTNOMATCH, P_FIRSTMATCH } parsestate = P_START;
+
 	cmd_it it = cmds.begin();
-	while(it != cmds.end()) {
+
+	while (it != cmds.end()) {
 		bool found = false;
+
 		for (int i = 0; *params[i] != 0; ++i) {
-			if (!strcasecmp((*it).c_str(),params[i])) {
+			if (!strcasecmp((*it).c_str(), params[i])) {
 				// found a parameter
 				found = true;
-				switch(parsestate) {
+				switch (parsestate) {
 				case P_START:
-					retval = i+2;
+					retval     = i + 2;
 					parsestate = P_FIRSTMATCH;
 					break;
 				case P_FIRSTMATCH:
-				case P_FIRSTNOMATCH:
-					return retval;
+				case P_FIRSTNOMATCH: return retval;
 				}
 			}
 		}
-		if(!found)
-			switch(parsestate) {
+
+		if (!found) {
+			switch (parsestate) {
 			case P_START:
-				retval = 0; // no match
+				retval     = 0; // no match
 				parsestate = P_FIRSTNOMATCH;
 				output.push_back(*it);
 				break;
 			case P_FIRSTMATCH:
-			case P_FIRSTNOMATCH:
-				output.push_back(*it);
-				break;
+			case P_FIRSTNOMATCH: output.push_back(*it); break;
 			}
+		}
+
 		cmd_it itold = it;
 		++it;
-		cmds.erase(itold);
 
+		cmds.erase(itold);
 	}
 
 	return retval;
@@ -1483,11 +1719,13 @@ int CommandLine::GetParameterFromList(const char* const params[], std::vector<st
 
 CommandLine::CommandLine(int argc, const char* const argv[])
 {
-	if (argc>0) {
-		file_name=argv[0];
+	if (argc > 0) {
+		file_name = argv[0];
 	}
-	int i=1;
-	while (i<argc) {
+
+	int i = 1;
+
+	while (i < argc) {
 		cmds.push_back(argv[i]);
 		i++;
 	}
@@ -1495,64 +1733,87 @@ CommandLine::CommandLine(int argc, const char* const argv[])
 
 uint16_t CommandLine::Get_arglength()
 {
-	if (cmds.empty())
+	if (cmds.empty()) {
 		return 0;
+	}
 
 	size_t total_length = 0;
-	for (const auto &cmd : cmds)
+	for (const auto& cmd : cmds) {
 		total_length += cmd.size() + 1;
+	}
 
 	if (total_length > UINT16_MAX) {
 		LOG_WARNING("SETUP: Command line length too long, truncating");
 		total_length = UINT16_MAX;
 	}
+
 	return static_cast<uint16_t>(total_length);
 }
 
-CommandLine::CommandLine(const char *name, const char *cmdline)
+CommandLine::CommandLine(const char* name, const char* cmdline)
 {
-	if (name) file_name=name;
+	if (name) {
+		file_name = name;
+	}
+
 	/* Parse the cmds and put them in the list */
-	bool inword,inquote;char c;
-	inword=false;inquote=false;
+	bool inword, inquote;
+	char c;
+	inword  = false;
+	inquote = false;
 	std::string str;
-	const char * c_cmdline=cmdline;
-	while ((c=*c_cmdline)!=0) {
+
+	const char* c_cmdline = cmdline;
+
+	while ((c = *c_cmdline) != 0) {
 		if (inquote) {
-			if (c!='"') str+=c;
-			else {
-				inquote=false;
+			if (c != '"') {
+				str += c;
+			} else {
+				inquote = false;
 				cmds.push_back(str);
 				str.erase();
 			}
 		} else if (inword) {
-			if (c!=' ') str+=c;
-			else {
-				inword=false;
+			if (c != ' ') {
+				str += c;
+			} else {
+				inword = false;
 				cmds.push_back(str);
 				str.erase();
 			}
+		} else if (c == '\"') {
+			inquote = true;
+		} else if (c != ' ') {
+			str += c;
+			inword = true;
 		}
-		else if (c=='\"') { inquote=true;}
-		else if (c!=' ') { str+=c;inword=true;}
 		c_cmdline++;
 	}
-	if (inword || inquote) cmds.push_back(str);
-}
 
-void CommandLine::Shift(unsigned int amount) {
-	while(amount--) {
-		file_name = cmds.size()?(*(cmds.begin())):"";
-		if(cmds.size()) cmds.erase(cmds.begin());
+	if (inword || inquote) {
+		cmds.push_back(str);
 	}
 }
 
-const std::string &SETUP_GetLanguage()
+void CommandLine::Shift(unsigned int amount)
+{
+	while (amount--) {
+		file_name = cmds.size() ? (*(cmds.begin())) : "";
+		if (cmds.size()) {
+			cmds.erase(cmds.begin());
+		}
+	}
+}
+
+const std::string& SETUP_GetLanguage()
 {
 	static bool lang_is_cached = false;
-	static std::string lang = {};
-	if (lang_is_cached)
+	static std::string lang    = {};
+
+	if (lang_is_cached) {
 		return lang;
+	}
 
 	// Did the user provide a language on the command line?
 	(void)control->cmdline->FindString("-lang", lang, true);
@@ -1561,17 +1822,18 @@ const std::string &SETUP_GetLanguage()
 	if (lang.empty()) {
 		const auto section = control->GetSection("dosbox");
 		assert(section);
-		lang = static_cast<const Section_prop *>(section)->Get_string(
-		        "language");
+		lang = static_cast<const Section_prop*>(section)->Get_string("language");
 	}
+
 	// Check the LANG environment variable
 	if (lang.empty()) {
-		const char *envlang = getenv("LANG");
+		const char* envlang = getenv("LANG");
 		if (envlang) {
 			lang = envlang;
 			clear_language_if_default(lang);
 		}
 	}
+
 	// Query the OS using OS-specific calls
 	if (lang.empty()) {
 		lang = get_language_from_os();
@@ -1593,13 +1855,14 @@ const std::string &SETUP_GetLanguage()
 
 // Parse the user's configuration files starting with the primary, then custom
 // -conf's, and finally the local dosbox.conf
-void MSG_Init(Section_prop *);
-void SETUP_ParseConfigFiles(const std::string &config_path)
+void MSG_Init(Section_prop*);
+void SETUP_ParseConfigFiles(const std::string& config_path)
 {
 	std::string config_file;
 
 	// First: parse the user's primary config file
-	const bool wants_primary_conf = !control->cmdline->FindExist("-noprimaryconf", true);
+	const bool wants_primary_conf = !control->cmdline->FindExist("-noprimaryconf",
+	                                                             true);
 	if (wants_primary_conf) {
 		Cross::GetPlatformConfigName(config_file);
 		const std::string config_combined = config_path + config_file;
@@ -1607,7 +1870,8 @@ void SETUP_ParseConfigFiles(const std::string &config_path)
 	}
 
 	// Second: parse the local 'dosbox.conf', if present
-	const bool wants_local_conf = !control->cmdline->FindExist("-nolocalconf", true);
+	const bool wants_local_conf = !control->cmdline->FindExist("-nolocalconf",
+	                                                           true);
 	if (wants_local_conf) {
 		control->ParseConfigFile("local", "dosbox.conf");
 	}
@@ -1628,104 +1892,137 @@ void SETUP_ParseConfigFiles(const std::string &config_path)
 	// to discover the user's desired language. At this point, we can now
 	// initialize the messaging system which honors the language and loads
 	// those messages.
-	if (const auto sec = control->GetSection("dosbox"); sec)
-		MSG_Init(static_cast<Section_prop *>(sec));
+	if (const auto sec = control->GetSection("dosbox"); sec) {
+		MSG_Init(static_cast<Section_prop*>(sec));
+	}
 
 	// Create a new primary if permitted and no other conf was loaded
 	if (wants_primary_conf && !control->configfiles.size()) {
 		std::string new_config_path = config_path;
+
 		Cross::CreatePlatformConfigDir(new_config_path);
 		Cross::GetPlatformConfigName(config_file);
+
 		const std::string config_combined = new_config_path + config_file;
+
 		if (control->PrintConfig(config_combined)) {
-			LOG_MSG("CONFIG: Wrote new primary config file '%s'", config_combined.c_str());
+			LOG_MSG("CONFIG: Wrote new primary config file '%s'",
+			        config_combined.c_str());
 			control->ParseConfigFile("new primary", config_combined);
 		} else {
 			LOG_WARNING("CONFIG: Unable to write a new primary config file '%s'",
-						config_combined.c_str());
+			            config_combined.c_str());
 		}
 	}
 }
 
 static char return_msg[200];
-const char *SetProp(std::vector<std::string> &pvars) {
+const char* SetProp(std::vector<std::string>& pvars)
+{
 	*return_msg = 0;
 	// attempt to split off the first word
 	std::string::size_type spcpos = pvars[0].find_first_of(' ');
 	std::string::size_type equpos = pvars[0].find_first_of('=');
 
 	if ((equpos != std::string::npos) &&
-		((spcpos == std::string::npos) || (equpos < spcpos))) {
+	    ((spcpos == std::string::npos) || (equpos < spcpos))) {
 		// If we have a '=' possibly before a ' ' split on the =
-		pvars.insert(pvars.begin()+1,pvars[0].substr(equpos+1));
+		pvars.insert(pvars.begin() + 1, pvars[0].substr(equpos + 1));
 		pvars[0].erase(equpos);
+
 		// As we had a = the first thing must be a property now
-		Section* sec=control->GetSectionFromProperty(pvars[0].c_str());
-		if (sec) pvars.insert(pvars.begin(),std::string(sec->GetName()));
-		else {
-			safe_sprintf(return_msg, MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+		Section* sec = control->GetSectionFromProperty(pvars[0].c_str());
+
+		if (sec) {
+			pvars.insert(pvars.begin(), std::string(sec->GetName()));
+		} else {
+			safe_sprintf(return_msg,
+			             MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+			             pvars[0].c_str());
 			return return_msg;
 		}
 		// order in the vector should be ok now
 	} else {
 		if ((spcpos != std::string::npos) &&
-			((equpos == std::string::npos) || (spcpos < equpos))) {
+		    ((equpos == std::string::npos) || (spcpos < equpos))) {
 			// ' ' before a possible '=', split on the ' '
-			pvars.insert(pvars.begin()+1,pvars[0].substr(spcpos+1));
+			pvars.insert(pvars.begin() + 1, pvars[0].substr(spcpos + 1));
 			pvars[0].erase(spcpos);
 		}
 		// check if the first parameter is a section or property
 		Section* sec = control->GetSection(pvars[0].c_str());
 		if (!sec) {
 			// not a section: little duplicate from above
-			Section* sec=control->GetSectionFromProperty(pvars[0].c_str());
-			if (sec) pvars.insert(pvars.begin(),std::string(sec->GetName()));
-			else {
-				safe_sprintf(return_msg, MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+			//
+			Section* sec = control->GetSectionFromProperty(
+			        pvars[0].c_str());
+
+			if (sec) {
+				pvars.insert(pvars.begin(),
+				             std::string(sec->GetName()));
+			} else {
+				safe_sprintf(return_msg,
+				             MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),
+				             pvars[0].c_str());
 				return return_msg;
 			}
 		} else {
-			// first of pvars is most likely a section, but could still be gus
-			// have a look at the second parameter
+			// first of pvars is most likely a section, but could
+			// still be gus have a look at the second parameter
 			if (pvars.size() < 2) {
-				safe_strcpy(return_msg, MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
+				safe_strcpy(return_msg,
+				            MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
 				return return_msg;
 			}
+
 			std::string::size_type spcpos2 = pvars[1].find_first_of(' ');
 			std::string::size_type equpos2 = pvars[1].find_first_of('=');
+
 			if ((equpos2 != std::string::npos) &&
-				((spcpos2 == std::string::npos) || (equpos2 < spcpos2))) {
+			    ((spcpos2 == std::string::npos) || (equpos2 < spcpos2))) {
 				// split on the =
-				pvars.insert(pvars.begin()+2,pvars[1].substr(equpos2+1));
+				pvars.insert(pvars.begin() + 2,
+				             pvars[1].substr(equpos2 + 1));
 				pvars[1].erase(equpos2);
 			} else if ((spcpos2 != std::string::npos) &&
-				((equpos2 == std::string::npos) || (spcpos2 < equpos2))) {
+			           ((equpos2 == std::string::npos) ||
+			            (spcpos2 < equpos2))) {
 				// split on the ' '
-				pvars.insert(pvars.begin()+2,pvars[1].substr(spcpos2+1));
+				pvars.insert(pvars.begin() + 2,
+				             pvars[1].substr(spcpos2 + 1));
 				pvars[1].erase(spcpos2);
 			}
+
 			// is this a property?
-			Section* sec2 = control->GetSectionFromProperty(pvars[1].c_str());
+			Section* sec2 = control->GetSectionFromProperty(
+			        pvars[1].c_str());
+
 			if (!sec2) {
 				// not a property,
-				Section* sec3 = control->GetSectionFromProperty(pvars[0].c_str());
+				Section* sec3 = control->GetSectionFromProperty(
+				        pvars[0].c_str());
 				if (sec3) {
 					// section and property name are identical
-					pvars.insert(pvars.begin(),pvars[0]);
+					pvars.insert(pvars.begin(), pvars[0]);
 				} // else has been checked above already
 			}
 		}
 	}
+
 	if (pvars.size() < 3) {
 		safe_strcpy(return_msg, MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
 		return return_msg;
 	}
+
 	// check if the property actually exists in the section
 	Section* sec2 = control->GetSectionFromProperty(pvars[1].c_str());
 	if (!sec2) {
-		safe_sprintf(return_msg, MSG_Get("PROGRAM_CONFIG_NO_PROPERTY"),
-			pvars[1].c_str(),pvars[0].c_str());
+		safe_sprintf(return_msg,
+		             MSG_Get("PROGRAM_CONFIG_NO_PROPERTY"),
+		             pvars[1].c_str(),
+		             pvars[0].c_str());
 		return return_msg;
 	}
+
 	return return_msg;
 }

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -47,26 +47,6 @@ std::unique_ptr<Config> control = {};
 // Set by parseconfigfile so Prop_path can use it to construct the realpath
 static std::string current_config_dir;
 
-Value& Value::copy(const Value& in)
-{
-	assert(this != &in);
-	assert(type == V_NONE || type == in.type);
-	plaincopy(in);
-	return *this;
-}
-
-void Value::plaincopy(const Value& in)
-{
-	type    = in.type;
-	_int    = in._int;
-	_double = in._double;
-	_bool   = in._bool;
-	_hex    = in._hex;
-	if (type == V_STRING) {
-		_string = in._string;
-	}
-}
-
 Value::operator bool() const
 {
 	assert(type == V_BOOL);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -153,10 +153,10 @@ bool Value::SetValue(const std::string& in, const Etype _type)
 	bool retval = true;
 	switch (type) {
 	case V_HEX: retval = SetHex(in); break;
-	case V_INT: retval = set_int(in); break;
-	case V_BOOL: retval = set_bool(in); break;
-	case V_STRING: set_string(in); break;
-	case V_DOUBLE: retval = set_double(in); break;
+	case V_INT: retval = SetInt(in); break;
+	case V_BOOL: retval = SetBool(in); break;
+	case V_STRING: SetString(in); break;
+	case V_DOUBLE: retval = SetDouble(in); break;
 
 	case V_NONE:
 	case V_CURRENT:
@@ -182,7 +182,7 @@ bool Value::SetHex(const std::string& in)
 	return true;
 }
 
-bool Value::set_int(const std::string& in)
+bool Value::SetInt(const std::string& in)
 {
 	istringstream input(in);
 	int result = INT_MIN;
@@ -193,7 +193,7 @@ bool Value::set_int(const std::string& in)
 	_int = result;
 	return true;
 }
-bool Value::set_double(const std::string& in)
+bool Value::SetDouble(const std::string& in)
 {
 	istringstream input(in);
 	double result = std::numeric_limits<double>::infinity();
@@ -205,7 +205,7 @@ bool Value::set_double(const std::string& in)
 	return true;
 }
 
-bool Value::set_bool(const std::string& in)
+bool Value::SetBool(const std::string& in)
 {
 	istringstream input(in);
 	string result;
@@ -230,7 +230,7 @@ bool Value::set_bool(const std::string& in)
 	return true;
 }
 
-void Value::set_string(const std::string& in)
+void Value::SetString(const std::string& in)
 {
 	if (!_string) {
 		_string = new string();
@@ -491,7 +491,7 @@ bool Prop_hex::SetValue(const std::string& input)
 	return SetVal(val);
 }
 
-void PropMultiVal::make_default_value()
+void PropMultiVal::MakeDefaultValue()
 {
 	Property* p = section->Get_prop(0);
 	if (!p) {
@@ -555,7 +555,7 @@ bool PropMultiValRemain::SetValue(const std::string& input)
 		// Test Value. If it fails set default
 		Value valtest(in, p->Get_type());
 		if (!p->IsValidValue(valtest)) {
-			make_default_value();
+			MakeDefaultValue();
 			return false;
 		}
 		p->SetValue(in);
@@ -600,7 +600,7 @@ bool PropMultiVal::SetValue(const std::string& input)
 			// list. Test Value. If it fails set default
 			Value valtest(in, p->Get_type());
 			if (!p->IsValidValue(valtest)) {
-				make_default_value();
+				MakeDefaultValue();
 				return false;
 			}
 			p->SetValue(in);
@@ -618,7 +618,7 @@ bool PropMultiVal::SetValue(const std::string& input)
 					// Something was there to be parsed or
 					// not the same type. Invalidate entire
 					// property.
-					make_default_value();
+					MakeDefaultValue();
 				}
 			}
 		}


### PR DESCRIPTION
In current `main`, if you provide an invalid value to a bool config param, an error will be printed to the DOSBox output, but there's no warning for it in the logs (a problem when your config contains invalid bool values). Additionally, _the config param will always be set to true_ (!), regardless of what its default value is. Wut?!?!

Proof:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/698770/226829316-f2f0dc78-f034-4945-8424-e939e4da455e.png">

This is clearly not great and user-friendly, _especially_ not newbie friendly when they make a typo in the config, and suddenly all sorts of things will be silently enabled...

With this change, invalid boolean values will generate **warnings in the logs**, and the params will be **set to their default values**. E.g.

```
2023-03-22 17:16:56.850 | CONFIG: 'asdf' is an invalid value for 'fullscreen', using the default: 'false'
```

Additionally, I've added "yes" and "no" to the list of accepted boolean values—it allows for making the config more readable in some cases.

There's also some cosmetic fixes and removal of unnecessary cruft from the code, plus some cleanup attempt of the setup stuff... I wouldn't say I was overly successful, but I think it sucks less. That's something 😅

This is another area infested by spaghetti OOP; the validation/error handling is next to impossible to follow (and untangle; it's super weird and very badly structured), so if it was me, I'd write unit tests around it, then rewrite it from scratch in a much saner way... At least the clang reformat highlighted how insane the nesting in some functions is.

Review commit by commit, by all means; there's lots of cleanup & clang reformat going on.
