### PR TITLE
Disable FluidSynth's own unit tests under MSYS2 CI

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -29,7 +29,7 @@ jobs:
             cc: gcc
             max_warnings: 0
             run_tests: true
-            build_flags: -Dbuildtype=debug
+            build_flags: -Dbuildtype=debug -Dfluidsynth:tests=false
 
           - name: GCC (UCRT) x86_64 +debugger
             toolchain: ucrt-
@@ -54,7 +54,7 @@ jobs:
             cc: clang
             max_warnings: 0
             run_tests: true
-            build_flags: -Dbuildtype=debug
+            build_flags: -Dbuildtype=debug -Dfluidsynth:tests=false
 
     defaults:
       run:


### PR DESCRIPTION
Every week, GitHub applies stable updates and security patches to their VMs and rolls them over. This week's rollover introduced some change impacting how MSYS2's Clang LLD linker imports DLL symbols - causing all of FluidSynth's unit tests to start failing (only under MSYS2 Clang):

![2023-03-22_09-25](https://user-images.githubusercontent.com/1557255/226972572-d3d2bf35-9606-4484-ab11-34b387dc5e21.png)

Our prior branches and `main` build are fine (prior to this weekends rollover):

FluidSynth's unit tests compiled and ran on the prior `main` commit: https://github.com/dosbox-staging/dosbox-staging/actions/runs/4440895580

![2023-03-22_09-21](https://user-images.githubusercontent.com/1557255/226972712-2314c1c9-165b-42c2-942c-c766bf824ea4.png)

So this PR just disables these unit tests under MSY2 CI for now.

Let's hope the problem is causing wide-spread issues and GitHub (or MSYS2) are on top of this issue and it's fixed in the next rollover (and we can try reverting this commit in the commits weeks).