### PR TITLE
Make the DOS module depend on SDL2 net

### DIFF
--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -50,6 +50,7 @@ libdos = static_library(
     include_directories: incdir,
     dependencies: [
         sdl2_dep,
+        sdl2_net_dep,
         libdecoders_dep,
         ghc_dep,
         libiir_dep,


### PR DESCRIPTION
The DOS serial port CLI tool includes
misc_utils.h, which depends on SDL2 net
structures.

Thanks to @ThomasEricB for flagging this, and for NixOS's separate per-package include directories revealing this (the DOS module already depends on SDL but not on SDL2_net; we just 'got lucky' on existing platforms because the SDL2 net headers are often placed inside the same directory as the SDL2 headers). 