### PR TITLE
Add support for hardware OPL2/3 chips

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -203,6 +203,7 @@ conf_data.set10('C_MT32EMU', get_option('use_mt32emu'))
 conf_data.set10('C_SSHOT', get_option('use_png'))
 conf_data.set10('C_SDL_IMAGE', get_option('use_sdl2_image'))
 conf_data.set10('C_TRACY', get_option('tracy'))
+conf_data.set10('C_OPLHW', get_option('use_oplhw'))
 conf_data.set10('C_FPU', true)
 conf_data.set10('C_FPU_X86', host_machine.cpu_family() in ['x86', 'x86_64'])
 
@@ -620,6 +621,17 @@ if get_option('tracy')
     add_project_arguments('-fno-omit-frame-pointer', language: ['c', 'cpp'])
 endif
 
+# OPLHW
+oplhw_dep = optional_dep
+if (get_option('use_oplhw'))
+    oplhw_dep = dependency(
+        'oplhw',
+        static: ('oplhw' in static_libs_list or prefers_static_libs),
+        not_found_message: msg.format('use_oplhw'),
+    )
+endif
+summary('OPLHW support', oplhw_dep.found())
+
 # macOS-only dependencies
 coreaudio_dep = optional_dep
 coremidi_dep = optional_dep
@@ -844,6 +856,7 @@ third_party_deps = [
     tracy_dep,
     libwhereami_dep,
     libtalchorus_dep,
+    oplhw_dep,
 ]
 
 if conf_data.get('C_MANYMOUSE') != 0

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,6 +21,13 @@ option(
 )
 
 option(
+    'use_oplhw',
+    type : 'boolean',
+    value : false,
+    description : 'Enable support for real OPL2/3 soundcards via liboplhw'
+)
+
+option(
     'use_fluidsynth',
     type: 'boolean',
     value: true,

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -157,6 +157,9 @@
 // Define to 1 to enable ALSA MIDI support
 #mesondefine C_ALSA
 
+// Define to 1 to enable OPL hardware support via liboplhw
+#mesondefine C_OPLHW
+
 /* Compiler features and extensions
  *
  * These are defines for compiler features we can't reliably verify during

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -805,6 +805,10 @@ void DOSBOX_Init()
 	Pstring = secprop->Add_string("oplemu", deprecated, "");
 	Pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
 
+	Pstring = secprop->Add_string("oplhw", when_idle, "");
+	Pstring->Set_help("Path to a real OPL2/3 hardware device.\n"
+			  "For example, \"alsa:\", \"opl2lpt:parport0\", or \"retrowave:/dev/ttyACM0\"");
+
 	Pstring = secprop->Add_string("sb_filter", when_idle, "modern");
 	Pstring->Set_help(
 	        "Type of filter to emulate for the Sound Blaster digital sound output:\n"

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -33,6 +33,9 @@
 #include "hardware.h"
 
 #include "../libs/nuked/opl3.h"
+#ifdef C_OPLHW
+#include "oplhw.h"
+#endif
 
 class Timer {
 public:
@@ -109,6 +112,10 @@ private:
 
 	opl3_chip oplchip = {};
 	uint8_t newm      = 0;
+
+#ifdef C_OPLHW
+	oplhw_device *oplhw_dev = nullptr;
+#endif
 
 	std::unique_ptr<AdlibGold> adlib_gold = {};
 


### PR DESCRIPTION
Following on from the discussion in #1723, this is a proof-of-concept implementation of support for real OPL2 and OPL3 hardware synths, using my oplhw[1] library[2]. It provides direct access to the hardware (bypassing the OPL3 emulation and DOSBox mixer), allowing games with Adlib or SoundBlaster FM-synth music to be played directly on such hardware.

The supported hardware includes:
- Any AdLib-compatible soundcard (via direct-port-io)
- Any OPL2/3-compatible soundcard with Linux ALSA drivers
- The OPL{2,3}LPT parallel-port soundcard
- The RetroWave OPL3 USB soundcard

These can be configured by setting the "oplhw" option to an oplhw device path, for example:
- ``ioport:388`` or ``ioport:c050`` for Adlib-compatible cards and OPL2/3-containing PCI and PCIe cards.
- ``alsa:`` or ``alsa:hw:0,0`` for any ALSA-compatible OPL2/3 card.
- ``opl2lpt:/dev/parport0`` for OPL2LPT on the first parallel port.
- ``retrowave:/dev/ttyACM0`` for a Retrowave OPL3 on USB/serial ttyACM0

Note that this is currently just a proof-of-concept patch: the details of the implementation definitely need some tidying up, both in making the code less hacky, and to resolve the issues below:

Building it currently requires liboplhw to be installed: we can investigate bundling it (ideally when it's a bit more mature) if that makes sense. Install it separately and pass ``-Duse_oplhw=true`` to meson to enable it for now.

Note that, as-is, I've only really tested liboplhw on Linux, though the latest builds of it are at least architecture independent. I imagine that at least the Retrowave and OPL2LPT backends should work with no or minimal changes on any Unix-like system, and should port comfortably to windows as well. The "ioport" backend is x86-specific, and will probably require some kernel-level support on Windows / Linux. The "alsa" backend is obviously Linux-only.

Thus far, though, this has worked fine with every game I've thrown at it, but I've definitely not tried everything.

[1]: https://davidgow.net/hacks/oplhw.html
[2]: https://github.com/sulix/liboplhw