### PR TITLE
Fix for spelling mistake on NixOS.txt

### DIFF
--- a/packages/NixOS.txt
+++ b/packages/NixOS.txt
@@ -1,4 +1,4 @@
 meson ninja gcc_multi cmake ccache SDL2 SDL2_image SDL2_net gtest 
 fluidsynth glib libGL libGLU libjack2 libmt32emu libogg libpng libpulseaudio 
 libslirp libsndfile opusfile libselinux speexdsp stdenv alsa-lib xorg.libXi 
-irr1 pkg-config
+iir1 pkg-config


### PR DESCRIPTION
It's iir1! 
