### PR TITLE
core_dyn_x86: Initialise rettype to avoid compiler warning

### DIFF
--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1072,7 +1072,7 @@ static void gen_call_function(void * func,const char* ops,...) {
 	Bitu paramcount=0;
 	va_list params;
 	DynReg *dynret=NULL;
-	char rettype;
+	char rettype='\0';
 
 	/* Save the flags */
 	if (GCC_LIKELY(!skip_flags)) gen_protectflags();


### PR DESCRIPTION
tl;dr: A quick warning fix with gcc 13 I found while looking at the OPL stuff.

gcc 13 warns when uninitialised data could be read, and picks up the following in risc_x64.h:
```
In file included from ../src/cpu/core_dyn_x86.cpp:199:
../src/cpu/core_dyn_x86/risc_x64.h: In function ‘void gen_call_function(void*, const char*, ...)’:
../src/cpu/core_dyn_x86/risc_x64.h:1127:25: warning: ‘rettype’ may be used uninitialized [-Wmaybe-uninitialized]
 1127 |                         switch (rettype) {
      |                         ^~~~~~
../src/cpu/core_dyn_x86/risc_x64.h:1075:14: note: ‘rettype’ was declared here
 1075 |         char rettype;
      |              ^~~~~~~
```

While this isn't actually a problem (rettype is only read if dynret is non-NULL, and dynret is only set when rettype is), it's probably worth initialising rettype just to keep the build warning-free.