### PR TITLE
Fix a window size regression on macOS

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 341
+          MAX_BUGS: 338
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -160,7 +160,6 @@ struct SDL_Block {
 		HOST_RATE_MODE host_rate_mode = HOST_RATE_MODE::AUTO;
 		double preferred_host_rate = 0.0;
 		bool want_resizable_window = false;
-		SDL_WindowEventID last_size_event = {};
 		SCREEN_TYPES type = SCREEN_SURFACE;
 		SCREEN_TYPES want_type = SCREEN_SURFACE;
 	} desktop = {};

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3856,8 +3856,6 @@ static void HandleVideoResize(int width, int height)
 #endif // C_OPENGL
 
 		if (!sdl.desktop.fullscreen) {
-			save_window_size(width, height);
-
 			// If the window was resized, it might have been triggered
 			// by the OS setting DPI scale, so recalculate that.
 			sdl.desktop.dpi_scale = static_cast<double>(canvas.w) / width;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1338,25 +1338,9 @@ static SDL_Window *SetWindowMode(SCREEN_TYPES screen_type,
 		                        sdl.desktop.full.display_res
 		                                ? SDL_WINDOW_FULLSCREEN_DESKTOP
 		                                : SDL_WINDOW_FULLSCREEN);
-	} else { // Windowd mode
-
-		// Does our window still need sizing?
-		int current_w, current_h;
-		SDL_GetWindowSize(sdl.window, &current_w, &current_h);
-
-		const bool window_is_too_small = (current_w < width ||
-		                                  current_h < height);
-
-		const bool window_dimensions_not_exact = (current_w != width ||
-		                                          current_h != height);
-
-		// Adjust the window dimensions if our window isn't sized yet or
-		// we're in PP mode
-		if (window_is_too_small || (sdl.scaling_mode == SCALING_MODE::PERFECT &&
-		                            window_dimensions_not_exact)) {
-			safe_set_window_size(width, height);
-		}
-		// If we're switching down from fullscreen, then it will use the set window size
+	} else {
+		// we're switching down from fullscreen, so let SDL use the
+		// previously-set window size
 		if (sdl.desktop.switching_fullscreen) {
 			SDL_SetWindowFullscreen(sdl.window, 0);
 		}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -697,7 +697,7 @@ static uint32_t opengl_driver_crash_workaround(SCREEN_TYPES type)
 	return (default_driver_is_opengl ? SDL_WINDOW_OPENGL : 0);
 }
 
-static SDL_Point refine_window_size(const SDL_Point &size,
+static SDL_Point refine_window_size(const SDL_Point size,
                                     const SCALING_MODE scaling_mode,
                                     const bool should_stretch_pixels);
 
@@ -1670,14 +1670,14 @@ static PPScale calc_pp_scale(const int avw, const int avh)
 	               is_draw_size_doubled(), avw, avh);
 }
 
-bool operator!=(const SDL_Point& lhs, const SDL_Point& rhs)
+bool operator!=(const SDL_Point lhs, const SDL_Point rhs)
 {
 	return lhs.x != rhs.x || lhs.y != rhs.y;
 }
 
 static void initialize_sdl_window_size(SDL_Window* sdl_window,
-                                       const SDL_Point& requested_min_size,
-                                       const SDL_Point& requested_size)
+                                       const SDL_Point requested_min_size,
+                                       const SDL_Point requested_size)
 {
 	assert(sdl_window);
 
@@ -2792,12 +2792,12 @@ static bool wants_stretched_pixels()
 	return render_section->Get_bool("aspect");
 }
 
-static SDL_Point remove_stretched_aspect(const SDL_Point &size)
+static SDL_Point remove_stretched_aspect(const SDL_Point size)
 {
 	return {size.x, ceil_sdivide(size.y * 5, 6)};
 }
 
-static SDL_Point refine_window_size(const SDL_Point &size,
+static SDL_Point refine_window_size(const SDL_Point size,
                                     const SCALING_MODE scaling_mode,
                                     const bool should_stretch_pixels)
 {
@@ -2942,8 +2942,8 @@ static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
 	return FALLBACK_WINDOW_DIMENSIONS;
 }
 
-static SDL_Point window_bounds_from_label(const std::string &pref,
-                                          const SDL_Rect &desktop)
+static SDL_Point window_bounds_from_label(const std::string& pref,
+                                          const SDL_Rect desktop)
 {
 	int percent = DEFAULT_WINDOW_PERCENT;
 	if (starts_with("s", pref))

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1882,8 +1882,7 @@ dosurface:
 		const bool desired_size_is_valid = (desired_w > 0 && desired_h > 0);
 
 		// Adjust the window size if needed and permitted
-		if (sdl.scaling_mode != SCALING_MODE::PERFECT &&
-		    window_doesnt_match_desired && desired_size_is_valid &&
+		if (window_doesnt_match_desired && desired_size_is_valid &&
 		    !sdl.desktop.window.adjusted_initial_size) {
 			sdl.desktop.window.adjusted_initial_size = true;
 			safe_set_window_size(desired_w, desired_h);
@@ -2071,8 +2070,7 @@ dosurface:
 		const bool desired_size_is_valid = (desired_w > 0 && desired_h > 0);
 
 		// Adjust the window size if needed and permitted
-		if (sdl.scaling_mode != SCALING_MODE::PERFECT &&
-		    window_doesnt_match_desired && desired_size_is_valid &&
+		if (window_doesnt_match_desired && desired_size_is_valid &&
 		    !sdl.desktop.window.adjusted_initial_size) {
 			sdl.desktop.window.adjusted_initial_size = true;
 			safe_set_window_size(desired_w, desired_h);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1246,6 +1246,19 @@ static void update_fallback_dimensions(const double dpi_scale)
 	// LOG_INFO("SDL: Updated fallback dimensions to %dx%d",
 	//          FALLBACK_WINDOW_DIMENSIONS.x,
 	//          FALLBACK_WINDOW_DIMENSIONS.y);
+
+	// Keep the SDL minimum allowed window size in lock-step with the
+	// fallback dimensions. If these aren't linked, the window can obscure
+	// the content (or vice-versa).
+	if (!sdl.window) {
+		return;
+		// LOG_WARNING("SDL: Tried setting window minimum size,"
+		//             " but the SDL window is not available yet");
+	}
+	SDL_SetWindowMinimumSize(sdl.window,
+	                         FALLBACK_WINDOW_DIMENSIONS.x,
+	                         FALLBACK_WINDOW_DIMENSIONS.y);
+	// LOG_INFO("SDL: Updated window minimum size to %dx%d", width, height);
 }
 
 // This is a collection point for things affected by DPI changes, instead of

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1945,6 +1945,13 @@ dosurface:
 			retFlags |= GFX_CAN_RANDOM;
 		}
 
+		// Re-apply the minimum bounds prior to clipping the
+		// texture-based window because SDL invalidates the prior bounds
+		// in the above changes.
+		SDL_SetWindowMinimumSize(sdl.window,
+		                         FALLBACK_WINDOW_DIMENSIONS.x,
+		                         FALLBACK_WINDOW_DIMENSIONS.y);
+
 		// One-time intialize the window size
 		if (!sdl.desktop.window.adjusted_initial_size) {
 			initialize_sdl_window_size(sdl.window,
@@ -2013,6 +2020,13 @@ dosurface:
 			LOG_ERR("SDL:OPENGL: Failed requesting an sRGB framebuffer: %s",
 			        SDL_GetError());
 		}
+
+		// Re-apply the minimum bounds prior to clipping the OpenGL
+		// window because SDL invalidates the prior bounds in the above
+		// window changes.
+		SDL_SetWindowMinimumSize(sdl.window,
+		                         FALLBACK_WINDOW_DIMENSIONS.x,
+		                         FALLBACK_WINDOW_DIMENSIONS.y);
 
 		SetupWindowScaled(SCREEN_OPENGL, sdl.desktop.want_resizable_window);
 
@@ -2260,14 +2274,6 @@ dosurface:
 	}
 #endif // C_OPENGL
 	}
-
-	// Always re-apply the minimum size to the updated window instead of
-	// checking GetWindowMinumSize, as SDL invalidates the prior set
-	// minimums when switching from fullscreen back to windowed.
-	SDL_SetWindowMinimumSize(sdl.window,
-	                         FALLBACK_WINDOW_DIMENSIONS.x,
-	                         FALLBACK_WINDOW_DIMENSIONS.y);
-
 	// Ensure mouse emulation knows the current parameters
 	NewMouseScreenParams();
 	update_vsync_state();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3977,8 +3977,15 @@ bool GFX_Events()
 				// DEBUG_LOG_MSG("SDL: Window has been resized to %dx%d",
 				//               event.window.data1,
 				//               event.window.data2);
-				HandleVideoResize(event.window.data1,
-				                  event.window.data2);
+
+				// When going from an initial fullscreen to
+				// windowed state, this event will be called
+				// moments before SDL's windowed mode is
+				// engaged, so simply ensure the window size has
+				// already been established:
+				assert(sdl.desktop.window.width > 0 &&
+				       sdl.desktop.window.height > 0);
+
 				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_GAINED:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1223,6 +1223,40 @@ static void NewMouseScreenParams()
 	        sdl.desktop.fullscreen);
 }
 
+static bool wants_stretched_pixels()
+{
+	const auto render_section = static_cast<Section_prop*>(
+	        control->GetSection("render"));
+	assert(render_section);
+
+	return render_section->Get_bool("aspect");
+}
+
+static void update_fallback_dimensions(const double dpi_scale)
+{
+	const auto should_stretch_pixels = wants_stretched_pixels();
+	const auto fallback_height = (should_stretch_pixels ? 480 : 400) / dpi_scale;
+
+	assert(dpi_scale > 0);
+	const auto fallback_width = 640 / dpi_scale;
+
+	FALLBACK_WINDOW_DIMENSIONS = {iround(fallback_width),
+	                              iround(fallback_height)};
+
+	// LOG_INFO("SDL: Updated fallback dimensions to %dx%d",
+	//          FALLBACK_WINDOW_DIMENSIONS.x,
+	//          FALLBACK_WINDOW_DIMENSIONS.y);
+}
+
+// This is a collection point for things affected by DPI changes, instead of
+// duplicating these calls at every point in the code where we save a new DPI
+static void apply_new_dpi_scale(const double dpi_scale)
+{
+	update_fallback_dimensions(dpi_scale);
+
+	// add more functions here
+}
+
 static void check_and_handle_dpi_change(SDL_Window* sdl_window,
                                         const SCREEN_TYPES screen_type,
                                         int width_in_logical_units = 0)
@@ -1246,9 +1280,9 @@ static void check_and_handle_dpi_change(SDL_Window* sdl_window,
 	// LOG_MSG("SDL: DPI scale updated from %f to %f",
 	//         sdl.desktop.dpi_scale,
 	//         new_dpi_scale);
+
+	apply_new_dpi_scale(new_dpi_scale);
 }
-
-
 
 static SDL_Window* SetWindowMode(SCREEN_TYPES screen_type, int width,
                                  int height, bool fullscreen, bool resizable)
@@ -2803,15 +2837,6 @@ static bool detect_resizable_window()
 	return true;
 }
 
-static bool wants_stretched_pixels()
-{
-	const auto render_section = static_cast<Section_prop *>(
-	        control->GetSection("render"));
-	assert(render_section);
-
-	return render_section->Get_bool("aspect");
-}
-
 static SDL_Point remove_stretched_aspect(const SDL_Point size)
 {
 	return {size.x, ceil_sdivide(size.y * 5, 6)};
@@ -3657,11 +3682,6 @@ static void GUI_StartUp(Section *sec)
 	sdl.mute_when_inactive = section->Get_bool("mute_when_inactive") ||
 	                         sdl.pause_when_inactive;
 
-	// Adjust the fallback resolution based on the user's aspect-correction
-	const auto should_stretch_pixels = wants_stretched_pixels();
-	FALLBACK_WINDOW_DIMENSIONS = should_stretch_pixels ? SDL_Point{640, 480}
-	                                                   : SDL_Point{640, 400};
-
 	ApplyActiveSettings(); // Assume focus on startup
 	sdl.desktop.full.fixed=false;
 	const char* fullresolution=section->Get_string("fullresolution");
@@ -3744,7 +3764,7 @@ static void GUI_StartUp(Section *sec)
 		GFX_ObtainDisplayDimensions();
 	}
 
-	set_output(section, should_stretch_pixels);
+	set_output(section, wants_stretched_pixels());
 
 	SDL_SetWindowTitle(sdl.window, "DOSBox Staging");
 	SetIcon();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3981,7 +3981,6 @@ bool GFX_Events()
 				//               event.window.data2);
 				HandleVideoResize(event.window.data1,
 				                  event.window.data2);
-				sdl.desktop.last_size_event = SDL_WINDOWEVENT_RESIZED;
 				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
@@ -4093,9 +4092,6 @@ bool GFX_Events()
 
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
 				// DEBUG_LOG_MSG("SDL: The window size has changed");
-
-				// differentiate this size change versus resizing.
-				sdl.desktop.last_size_event = SDL_WINDOWEVENT_SIZE_CHANGED;
 
 				// The window size has changed either as a
 				// result of an API call or through the system

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3959,6 +3959,16 @@ bool GFX_Events()
 				 * Update surface while using X11.
 				 */
 				GFX_ResetScreen();
+#if C_OPENGL && defined(MACOSX)
+				// DEBUG_LOG_MSG("SDL: Reset macOS's GL viewport
+				// after window-restore");
+				if (sdl.desktop.type == SCREEN_OPENGL) {
+					glViewport(sdl.clip.x,
+					           sdl.clip.y,
+					           sdl.clip.w,
+					           sdl.clip.h);
+				}
+#endif
 				FocusInput();
 				continue;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2188,6 +2188,13 @@ dosurface:
 #endif // C_OPENGL
 	}
 
+	// Always re-apply the minimum size to the updated window instead of
+	// checking GetWindowMinumSize, as SDL invalidates the prior set
+	// minimums when switching from fullscreen back to windowed.
+	SDL_SetWindowMinimumSize(sdl.window,
+	                         FALLBACK_WINDOW_DIMENSIONS.x,
+	                         FALLBACK_WINDOW_DIMENSIONS.y);
+
 	// Ensure mouse emulation knows the current parameters
 	NewMouseScreenParams();
 	update_vsync_state();


### PR DESCRIPTION
Tentatively fixes #2335 

Suggest testing all eight permutations of:

```ini
[SDL]
fullscreen = on / off
output = texture / opengl / texturepp / openglpp
windowresolution = 960x720
```

For each permutation:
1. Alt+Enter to toggle between full and window-mode
2. Resizing and drag the window.
3. Toggle back in and out of full screen
4. Confirm your prior window size and position is retained. 

Other things to look for:
- Toggling should be as fast or faster than baseline
- Toggling should have the same or less flickering or visual 'activity' between the transitions. This is because there is now only one call to SDL making the window change instead of 3 or more (depending on platform).

Ideally we can test all these permutations on Windows, Linux(es), and macOS(es).

I've done a fair bit of testing on Linux (Ubuntu 22.10) and macOS 11.x, but the more the better. 
