### PR TITLE
Add multi-monitor awareness mode for mouse capture

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -93,15 +93,24 @@ void MOUSE_NotifyWindowActive(const bool is_active);
 // visible while a GUI is running)
 void MOUSE_NotifyTakeOver(const bool gui_has_taken_over);
 
+struct MouseScreenParams {
+	// size of the black bars around screen area
+	uint32_t clip_x = 0;
+	uint32_t clip_y = 0;
+	// size of drawing area (in hot OS pixels)
+	uint32_t res_x = 0;
+	uint32_t res_y = 0;
+	// new absolute mouse cursor position
+	int32_t x_abs = 0;
+	int32_t y_abs = 0;
+	// whether the new mode is fullscreen or windowed
+	bool is_fullscreen = false;
+	// whether more than one display was detected
+	bool is_multi_display = false;
+};
+
 // To be called when screen mode changes, emulator window gets resized, etc.
-// clip_x / clip_y - size of the black bars around screen area
-// res_x / res_y   - size of drawing area (in hot OS pixels)
-// x_abs / y_abs   - new absolute mouse cursor position
-// is_fullscreen   - whether the new mode is fullscreen or windowed
-void MOUSE_NewScreenParams(const uint32_t clip_x, const uint32_t clip_y,
-                           const uint32_t res_x, const uint32_t res_y,
-                           const int32_t x_abs, const int32_t y_abs,
-                           const bool is_fullscreen);
+void MOUSE_NewScreenParams(const MouseScreenParams &params);
 
 // Notification that user pressed/released the hotkey combination
 // to capture/release the mouse

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -45,9 +45,11 @@ static ManyMouseGlue &manymouse = ManyMouseGlue::GetInstance();
 // ***************************************************************************
 
 static struct {
-	bool is_fullscreen = false; // if full screen mode is active
-	uint32_t clip_x    = 0;     // clipping = size of black border (one side)
-	uint32_t clip_y    = 0;
+	bool is_fullscreen    = false; // if full screen mode is active
+	bool is_multi_display = false; // if host system has more than 1 display
+
+	uint32_t clip_x = 0; // clipping = size of black border (one side)
+	uint32_t clip_y = 0;
 
 	uint32_t cursor_x_abs  = 0;     // absolute position from start of drawing area
 	uint32_t cursor_y_abs  = 0;
@@ -141,8 +143,9 @@ static void update_cursor_visibility()
 	}
 
 	// Apply calculated settings if changed or if this is the first run
-	if (first_time || old_is_visible != state.is_visible)
+	if (first_time || old_is_visible != state.is_visible) {
 		GFX_SetMouseVisibility(state.is_visible);
+	}
 
 	// And take a note that this is no longer the first run
 	first_time = false;
@@ -151,28 +154,34 @@ static void update_cursor_visibility()
 static void update_state() // updates whole 'state' structure, except cursor visibility
 {
 	// If mouse subsystem not started yet, do nothing
-	if (!mouse_shared.started)
+	if (!mouse_shared.started) {
 		return;
+	}
 
 	const bool is_config_on_start = (mouse_config.capture == MouseCapture::OnStart);
 	const bool is_config_on_click = (mouse_config.capture == MouseCapture::OnClick);
 	const bool is_config_no_mouse = (mouse_config.capture == MouseCapture::NoMouse);
 
+	// Only consider multi-display mode if enabled in the configuration!
+	const bool is_window_or_multi_display = !state.is_fullscreen ||
+		(state.is_multi_display && mouse_config.multi_display_aware);
+
 	// If running for the first time, capture the mouse if this was configured
 	static bool first_time = true;
-	if (first_time && is_config_on_start)
+	if (first_time && is_config_on_start) {
 		state.capture_was_requested = true;
+	}
 
 	// We are running in seamless mode:
 	// - we have a desktop environment, and
-	// - we are not in windowed mode, and
+	// - we are in windowed or multi-display mode, and
 	// - NoMouse is not configured, and
 	// - seamless driver is running or Seamless capture is configured
 	const bool is_seamless_config = (mouse_config.capture == MouseCapture::Seamless);
 	const bool is_seamless_driver = mouse_shared.active_vmm;
 
 	state.is_seamless = state.have_desktop_environment &&
-	                    !state.is_fullscreen &&
+	                    is_window_or_multi_display &&
 	                    !is_config_no_mouse &&
 	                    (is_seamless_driver || is_seamless_config);
 
@@ -208,18 +217,17 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 
 		// Capture mouse cursor if any of:
 		// - we lack a desktop environment,
-		// - we are in fullscreen mode
+		// - we are in fullscreen mode and not in multi-display mode
 		// - user asked to capture the mouse
 		state.is_captured = !state.have_desktop_environment ||
-		                    state.is_fullscreen ||
+		                    !is_window_or_multi_display ||
 		                    state.capture_was_requested;
 	}
 
 	// Drop mouse events (except for button release) if any of:
 	// - GUI has taken over the mouse
 	// - capture type is NoMouse
-	state.should_drop_events = state.gui_has_taken_over ||
-                               is_config_no_mouse;
+	state.should_drop_events = state.gui_has_taken_over || is_config_no_mouse;
 	if (!state.is_seamless) {
 
 		// If not Seamless mode, also drop events if any of:
@@ -232,22 +240,22 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 
 	// Use a hotkey to toggle mouse capture if:
 	// - we have a desktop environment, and
-	// - are in windowed mode, and
+	// - we are in windowed or multi-display mode, and
 	// - capture type is different than NoMouse
 	state.should_toggle_on_hotkey = state.have_desktop_environment &&
-	                                !state.is_fullscreen &&
+	                                is_window_or_multi_display &&
 	                                !is_config_no_mouse;
 
 	// Use any mouse click to capture the mouse if:
 	// - we have a desktop environment, and
-	// - windowed mode, and
+	// - we are in windowed or multi-display mode, and
 	// - mouse is not captured, and
 	// - we are not in seamless mode, and
 	// - no GUI has taken over the mouse, and
 	// - capture type is different than NoMouse, and
 	// - capture on start/click was configured or mapping is in effect
 	state.should_capture_on_click = state.have_desktop_environment &&
-	                                !state.is_fullscreen &&
+	                                is_window_or_multi_display &&
 	                                !state.is_captured &&
 	                                !state.is_seamless &&
 	                                !state.gui_has_taken_over &&
@@ -256,14 +264,14 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 
 	// Use a middle click to capture the mouse if:
 	// - we have a desktop environment, and
-	// - windowed mode, and
+	// - we are in windowed or multi-display mode, and
 	// - mouse is not captured, and
 	// - no GUI has taken over the mouse, and
 	// - capture type is different than NoMouse, and
 	// - seamless mode is in effect, and
 	// - middle release was configured
 	state.should_capture_on_middle = state.have_desktop_environment &&
-	                                 !state.is_fullscreen &&
+	                                 is_window_or_multi_display &&
 	                                 !state.is_captured &&
 	                                 !state.gui_has_taken_over &&
 	                                 !is_config_no_mouse &&
@@ -272,11 +280,11 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 
 	// Use a middle click to release the mouse if:
 	// - we have a desktop environment, and
-	// - windowed mode, and
+	// - we are in windowed or multi-display mode, and
 	// - mouse is captured, and
 	// - release by middle button was configured
 	state.should_release_on_middle = state.have_desktop_environment &&
-	                                 !state.is_fullscreen &&
+	                                 is_window_or_multi_display &&
 	                                 state.is_captured &&
 	                                 mouse_config.middle_release;
 
@@ -287,7 +295,7 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 	// TODO: if SDL gets expanded to include ManyMouse, change the behavior!
 
 	// Select hint to be displayed on a title bar
-	if (!state.have_desktop_environment || state.is_fullscreen ||
+	if (!state.have_desktop_environment || !is_window_or_multi_display ||
 	    state.gui_has_taken_over || !state.is_window_active) {
 		state.hint_id = MouseHint::None;
 	} else if (is_config_no_mouse) {
@@ -419,37 +427,36 @@ Bitu int74_ret_handler()
 // External notifications
 // ***************************************************************************
 
-void MOUSE_NewScreenParams(const uint32_t clip_x, const uint32_t clip_y,
-                           const uint32_t res_x, const uint32_t res_y,
-                           const int32_t x_abs, const int32_t y_abs,
-                           const bool is_fullscreen)
+void MOUSE_NewScreenParams(const MouseScreenParams &params)
 {
 	// clip_x, clip_y = black border (one side), in pixels
 	// res_x, res_y   = used display area, in pixels
 	// res_x + 2 * clip_x, res_y + 2 * clip_y = screen resolution or window size
 
-	assert(clip_x <= INT32_MAX);
-	assert(clip_y <= INT32_MAX);
-	assert(res_x <= INT32_MAX);
-	assert(res_y <= INT32_MAX);
+	assert(params.clip_x <= INT32_MAX);
+	assert(params.clip_y <= INT32_MAX);
+	assert(params.res_x <= INT32_MAX);
+	assert(params.res_y <= INT32_MAX);
 
-	state.clip_x = clip_x;
-	state.clip_y = clip_y;
+	state.clip_x = params.clip_x;
+	state.clip_y = params.clip_y;
 
 	// Protection against strange window sizes,
 	// to prevent division by 0 in some places
 	constexpr uint32_t min = 2;
-	mouse_shared.resolution_x = std::max(res_x, min);
-	mouse_shared.resolution_y = std::max(res_y, min);
+	mouse_shared.resolution_x = std::max(params.res_x, min);
+	mouse_shared.resolution_y = std::max(params.res_y, min);
 
 	// If we are switching back from fullscreen,
 	// clear the user capture request
-	if (state.is_fullscreen && !is_fullscreen)
+	if (state.is_fullscreen && !params.is_fullscreen) {
 		state.capture_was_requested = false;
+	}
 
-	state.is_fullscreen = is_fullscreen;
+	state.is_fullscreen    = params.is_fullscreen;
+	state.is_multi_display = params.is_multi_display;
 
-	update_cursor_absolute_position(x_abs, y_abs);
+	update_cursor_absolute_position(params.x_abs, params.y_abs);
 
 	MOUSE_UpdateGFX();
 	MOUSEVMM_NewScreenParams(state.cursor_x_abs, state.cursor_y_abs);

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -189,6 +189,9 @@ static void config_read(Section *section)
 	std::string prop_str = conf->Get_string("mouse_capture");
 	MouseConfig::ParseCaptureType(prop_str, mouse_config.capture);
 
+	mouse_config.multi_display_aware =
+		conf->Get_bool("mouse_multi_display_aware");
+
 	mouse_config.middle_release = conf->Get_bool("mouse_middle_release");
 	mouse_config.raw_input      = conf->Get_bool("mouse_raw_input");
 	mouse_config.dos_immediate  = conf->Get_bool("dos_mouse_immediate");
@@ -269,6 +272,14 @@ static void config_init(Section_prop &secprop)
 	prop_bool = secprop.Add_bool("mouse_middle_release", always, true);
 	prop_bool->Set_help("If enabled, middle-click will release the captured mouse, and also capture\n"
 	                    "when seamless (enabled by default).");
+
+	prop_bool = secprop.Add_bool("mouse_multi_display_aware", always, true);
+	prop_bool->Set_help("Allows mouse seamless behavior and mouse pointer release to work in fullscreen\n"
+	                    "mode for systems with more than one display. (enabled by default).\n"
+	                    "Notes: You should set this to false if it incorrectly detects multiple displays\n"
+	                    "       when only one should actually be used. This might happen if you are\n"
+	                    "       using mirrored display mode or using an AV receiver's HDMI input for\n"
+	                    "       audio-only listening.");
 
 	prop_multi = secprop.AddMultiVal("mouse_sensitivity", only_at_start, ",");
 	prop_multi->Set_help(

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *  Copyright (C) 2022-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -78,9 +78,10 @@ struct MouseConfig {
 	MouseCapture capture = MouseCapture::OnStart;
 	bool middle_release  = true;
 
-	int16_t sensitivity_x = 50; // default sensitivity values
-	int16_t sensitivity_y = 50;
-	bool raw_input        = false; // true = relative input is raw data
+	int16_t sensitivity_x    = 50; // default sensitivity values
+	int16_t sensitivity_y    = 50;
+	bool raw_input           = false; // true = relative input is raw data
+	bool multi_display_aware = false;
 
 	bool dos_driver    = false; // whether DOS virtual mouse driver should be enabled
 	bool dos_immediate = false;


### PR DESCRIPTION
Add multi-monitor awareness mode for mouse emulation. If mode is enabled in the configuration file AND the SDL library reports that multiple monitors are detected:

- switching to fullscreen does not automatically capture the mouse
- in fullscreen mode  it is possible to release (un-capture) the mouse
- seamless capture works also in fullscreen mode; you can freely move the mouse between the monitors

Use case: I want to have the DOSBox fullscreen on one monitor, and the logs and browsable source code on another one :) Currently switching to fullscreen captures the mouse and does not allow it to be released (= not useful at all).