### PR TITLE
Auto enable shell variable expansion for DOS >=7

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1125,9 +1125,11 @@ void DOSBOX_Init()
 	               "formats. If set to 0, the country code corresponding to the selected keyboard\n"
 	               "layout will be used.");
 
-	Pbool = secprop->Add_bool("expand_shell_variable", when_idle, false);
-	Pbool->Set_help("Enable expanding environment variables such as %PATH% in the DOS command shell\n"
-	                "(disabled by default).\n"
+	Pstring = secprop->Add_string("expand_shell_variable", when_idle, "auto");
+	const char *expand_shell_variable_choices[] = {"auto", "true", "false", 0};
+	Pstring->Set_values(expand_shell_variable_choices);
+	Pstring->Set_help("Enable expanding environment variables such as %PATH% in the DOS command shell\n"
+	                "(auto by default, enabled if DOS version >= 7.0).\n"
 	                "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
 
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init, changeable_at_runtime);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -420,10 +420,15 @@ void DOS_Shell::InputCommand(char * line) {
 	if (l_completion.size()) l_completion.clear();
 
 	/* DOS %variable% substitution */
-	const auto dos = static_cast<Section_prop *>(control->GetSection("dos"));
-	assert(dos);
-	if (dos->Get_bool("expand_shell_variable"))
+	const auto dos_section = static_cast<Section_prop *>(control->GetSection("dos"));
+	assert(dos_section);
+	std::string_view expand_shell_variable_pref =
+					dos_section->Get_string("expand_shell_variable");
+	if (expand_shell_variable_pref == "true") {
 		ProcessCmdLineEnvVarStitution(line);
+	} else if (expand_shell_variable_pref == "auto" && dos.version.major >= 7) {
+		ProcessCmdLineEnvVarStitution(line);
+	}
 }
 
 /* Note: Buffer pointed to by "line" must be at least CMD_MAXLINE+1 bytes long! */


### PR DESCRIPTION
Automatically enable shell variable expansion when DOS version is set to >= 7.0

closes #2279