### PR TITLE
Present VFR duplicate frames on a tempo

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -229,6 +229,7 @@ struct SDL_Block {
 		int period_us = 0;      // same but in us, for use with chrono
 		int period_us_early = 0;
 		int period_us_late = 0;
+		int8_t vfr_dupe_countdown = 0;
 	} frame = {};
 	PPScale pp_scale = {};
 	SDL_Rect updateRects[1024] = {};


### PR DESCRIPTION
Potential fix for #2340

Adding @0mnicydle. 

Here's VFR presenting duplicates at roughly 7 Hz in an otherwise static CLI:

![2023-04-04_14-13](https://user-images.githubusercontent.com/1557255/229924008-7d2e8738-776e-4305-898b-7d0412a5fb56.png)

(the periodic jumps are the CLI application doing a redraw pass every ~15 seconds or so).