### PR TITLE
Fix spurious directory separators in `mixer /listmidi` output

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -107,16 +107,10 @@ void CROSS_DetermineConfigPaths();
 
 std_fs::path get_platform_config_dir();
 
-[[deprecated("Use get_platform_config_dir() instead.")]]
-std::string CROSS_GetPlatformConfigDir();
-
 std::string CROSS_ResolveHome(const std::string &str);
 
 class Cross {
 public:
-	[[deprecated("Use get_platform_config_dir() instead.")]]
-	static void GetPlatformConfigDir(std::string& in);
-
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
 	static void ResolveHomedir(std::string & temp_line);

--- a/include/cross.h
+++ b/include/cross.h
@@ -38,6 +38,8 @@
 #define LONGTYPE(a) a##LL
 #endif
 
+#include "std_filesystem.h"
+
 #define CROSS_LEN 512						/* Maximum filename size */
 
 
@@ -102,12 +104,19 @@ constexpr auto localtime_r = ::localtime_r;
 } // namespace cross
 
 void CROSS_DetermineConfigPaths();
+
+std_fs::path get_platform_config_dir();
+
+[[deprecated("Use get_platform_config_dir() instead.")]]
 std::string CROSS_GetPlatformConfigDir();
+
 std::string CROSS_ResolveHome(const std::string &str);
 
 class Cross {
 public:
+	[[deprecated("Use get_platform_config_dir() instead.")]]
 	static void GetPlatformConfigDir(std::string& in);
+
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
 	static void ResolveHomedir(std::string & temp_line);

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -86,7 +86,7 @@ std_fs::path simplify_path(const std_fs::path &path) noexcept;
 
 constexpr uint32_t OK_IF_EXISTS = 0x1;
 
-int create_dir(const char *path, uint32_t mode, uint32_t flags = 0x0) noexcept;
+int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags = 0x0) noexcept;
 
 // Convert a filesystem time to a raw time_t value
 std::time_t to_time_t(const std_fs::file_time_type &fs_time);

--- a/include/setup.h
+++ b/include/setup.h
@@ -32,6 +32,8 @@
 #include <tuple>
 #include <vector>
 
+#include "std_filesystem.h"
+
 using parse_environ_result_t = std::list<std::tuple<std::string, std::string>>;
 
 parse_environ_result_t parse_environ(const char* const* envp) noexcept;
@@ -486,7 +488,7 @@ public:
 	}
 };
 
-void SETUP_ParseConfigFiles(const std::string& config_path);
+void SETUP_ParseConfigFiles(const std_fs::path& config_path);
 
 const std::string& SETUP_GetLanguage();
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4702,10 +4702,9 @@ static void ListGlShaders()
 
 static int PrintConfigLocation()
 {
-	std_fs::path path = get_platform_config_dir();
 	std::string file;
 	Cross::GetPlatformConfigName(file);
-	path.append(file);
+	const auto path = (get_platform_config_dir() / file).string();
 
 	FILE *f = fopen(path.c_str(), "r");
 	if (!f && !control->PrintConfig(path)) {
@@ -4724,10 +4723,9 @@ static void eraseconfigfile() {
 		fclose(f);
 		LOG_WARNING("Warning: dosbox.conf exists in current working directory.\nThis will override the configuration file at runtime.\n");
 	}
-	auto path = get_platform_config_dir();
 	std::string file;
 	Cross::GetPlatformConfigName(file);
-	path.append(file);
+	const auto path = (get_platform_config_dir() / file).string();
 	f = fopen(path.c_str(),"r");
 	if(!f) exit(0);
 	fclose(f);
@@ -4743,7 +4741,7 @@ static void erasemapperfile() {
 		             "Please reset configuration as well and delete the dosbox.conf.\n");
 	}
 
-	const auto path = get_platform_config_dir() / MAPPERFILE;
+	const auto path = (get_platform_config_dir() / MAPPERFILE).string();
 	FILE* f = fopen(path.c_str(),"r");
 	if(!f) exit(0);
 	fclose(f);
@@ -4938,19 +4936,19 @@ int sdl_main(int argc, char *argv[])
 	}
 
 #if C_OPENGL
-	const auto glshaders_dir = config_path / "glshaders";
+	const auto glshaders_dir = (config_path / "glshaders").string();
 	if (create_dir(glshaders_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
 			    glshaders_dir.c_str(), safe_strerror(errno).c_str());
 #endif // C_OPENGL
 #if C_FLUIDSYNTH
-	const auto soundfonts_dir = config_path / "soundfonts";
+	const auto soundfonts_dir = (config_path / "soundfonts").string();
 	if (create_dir(soundfonts_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
 			    soundfonts_dir.c_str(), safe_strerror(errno).c_str());
 #endif // C_FLUIDSYNTH
 #if C_MT32EMU
-	const auto mt32_rom_dir = config_path / "mt32-roms";
+	const auto mt32_rom_dir = (config_path / "mt32-roms").string();
 	if (create_dir(mt32_rom_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
 			    mt32_rom_dir.c_str(), safe_strerror(errno).c_str());

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4677,7 +4677,7 @@ static void launchcaptures(const std::string& edit)
 	Cross::CreatePlatformConfigDir(path);
 	path += file;
 
-	if (create_dir(path.c_str(), 0700, OK_IF_EXISTS) != 0) {
+	if (create_dir(path, 0700, OK_IF_EXISTS) != 0) {
 		fprintf(stderr, "Can't access capture dir '%s': %s\n",
 		        path.c_str(), safe_strerror(errno).c_str());
 		exit(1);
@@ -4936,22 +4936,25 @@ int sdl_main(int argc, char *argv[])
 	}
 
 #if C_OPENGL
-	const auto glshaders_dir = (config_path / "glshaders").string();
-	if (create_dir(glshaders_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
+	const auto glshaders_dir = config_path / "glshaders";
+	if (create_dir(glshaders_dir, 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
-			    glshaders_dir.c_str(), safe_strerror(errno).c_str());
+			    glshaders_dir.string().c_str(),
+			    safe_strerror(errno).c_str());
 #endif // C_OPENGL
 #if C_FLUIDSYNTH
-	const auto soundfonts_dir = (config_path / "soundfonts").string();
-	if (create_dir(soundfonts_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
+	const auto soundfonts_dir = config_path / "soundfonts";
+	if (create_dir(soundfonts_dir, 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
-			    soundfonts_dir.c_str(), safe_strerror(errno).c_str());
+			    soundfonts_dir.string().c_str(),
+			    safe_strerror(errno).c_str());
 #endif // C_FLUIDSYNTH
 #if C_MT32EMU
-	const auto mt32_rom_dir = (config_path / "mt32-roms").string();
-	if (create_dir(mt32_rom_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
+	const auto mt32_rom_dir = config_path / "mt32-roms";
+	if (create_dir(mt32_rom_dir, 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
-			    mt32_rom_dir.c_str(), safe_strerror(errno).c_str());
+			    mt32_rom_dir.string().c_str(),
+			    safe_strerror(errno).c_str());
 #endif // C_MT32EMU
 
 		control->ParseEnv();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4702,10 +4702,10 @@ static void ListGlShaders()
 
 static int PrintConfigLocation()
 {
-	std::string path, file;
-	Cross::CreatePlatformConfigDir(path);
+	std_fs::path path = get_platform_config_dir();
+	std::string file;
 	Cross::GetPlatformConfigName(file);
-	path += file;
+	path.append(file);
 
 	FILE *f = fopen(path.c_str(), "r");
 	if (!f && !control->PrintConfig(path)) {
@@ -4724,10 +4724,10 @@ static void eraseconfigfile() {
 		fclose(f);
 		LOG_WARNING("Warning: dosbox.conf exists in current working directory.\nThis will override the configuration file at runtime.\n");
 	}
-	std::string path,file;
-	Cross::GetPlatformConfigDir(path);
+	auto path = get_platform_config_dir();
+	std::string file;
 	Cross::GetPlatformConfigName(file);
-	path += file;
+	path.append(file);
 	f = fopen(path.c_str(),"r");
 	if(!f) exit(0);
 	fclose(f);
@@ -4743,9 +4743,7 @@ static void erasemapperfile() {
 		             "Please reset configuration as well and delete the dosbox.conf.\n");
 	}
 
-	std::string path,file=MAPPERFILE;
-	Cross::GetPlatformConfigDir(path);
-	path += file;
+	const auto path = get_platform_config_dir() / MAPPERFILE;
 	FILE* f = fopen(path.c_str(),"r");
 	if(!f) exit(0);
 	fclose(f);
@@ -4902,7 +4900,7 @@ int sdl_main(int argc, char *argv[])
 		SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL,
 		SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
 
-	const auto config_path = CROSS_GetPlatformConfigDir();
+	const auto config_path = get_platform_config_dir().string();
 	SETUP_ParseConfigFiles(config_path);
 
 	MSG_Add("PROGRAM_CONFIG_PROPERTY_ERROR", "No such section or property: %s\n");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4900,7 +4900,7 @@ int sdl_main(int argc, char *argv[])
 		SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL,
 		SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
 
-	const auto config_path = get_platform_config_dir().string();
+	const auto config_path = get_platform_config_dir();
 	SETUP_ParseConfigFiles(config_path);
 
 	MSG_Add("PROGRAM_CONFIG_PROPERTY_ERROR", "No such section or property: %s\n");
@@ -4938,19 +4938,19 @@ int sdl_main(int argc, char *argv[])
 	}
 
 #if C_OPENGL
-	const std::string glshaders_dir = config_path + "glshaders";
+	const auto glshaders_dir = config_path / "glshaders";
 	if (create_dir(glshaders_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
 			    glshaders_dir.c_str(), safe_strerror(errno).c_str());
 #endif // C_OPENGL
 #if C_FLUIDSYNTH
-	const std::string soundfonts_dir = config_path + "soundfonts";
+	const auto soundfonts_dir = config_path / "soundfonts";
 	if (create_dir(soundfonts_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
 			    soundfonts_dir.c_str(), safe_strerror(errno).c_str());
 #endif // C_FLUIDSYNTH
 #if C_MT32EMU
-	const std::string mt32_rom_dir = config_path + "mt32-roms";
+	const auto mt32_rom_dir = config_path / "mt32-roms";
 	if (create_dir(mt32_rom_dir.c_str(), 0700, OK_IF_EXISTS) != 0)
 		LOG_WARNING("CONFIG: Can't create dir '%s': %s",
 			    mt32_rom_dir.c_str(), safe_strerror(errno).c_str());

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -105,7 +105,7 @@ std::string CAPTURE_GetScreenshotFilename(const char *type, const char *ext)
 	dir = open_directory(capturedir.c_str());
 	if (!dir) {
 		// Try creating it first
-		if (create_dir(capturedir.c_str(), 0700, OK_IF_EXISTS) != 0) {
+		if (create_dir(capturedir, 0700, OK_IF_EXISTS) != 0) {
 			LOG_WARNING("Can't create dir '%s' for capturing: %s",
 			            capturedir.c_str(),
 			            safe_strerror(errno).c_str());

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -138,6 +138,9 @@ static std::deque<std_fs::path> get_data_dirs()
 {
 	return {
 	        get_platform_config_dir() / "soundfonts",
+
+	        // C:\soundfonts is the default place where FluidSynth places default.sf2
+	        // https://www.fluidsynth.org/api/fluidsettings.xml#synth.default-soundfont
 	        "C:\\soundfonts\\",
 	};
 }
@@ -149,8 +152,6 @@ static std::deque<std_fs::path> get_data_dirs()
 	return {
 	        get_platform_config_dir() / "soundfonts",
 	        std_fs::path(CROSS_ResolveHome("~/Library/Audio/Sounds/Banks")),
-	        // TODO: check /usr/local/share/soundfonts
-	        // TODO: check /usr/share/soundfonts
 	};
 }
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -194,7 +194,7 @@ static std::deque<std_fs::path> get_data_dirs()
 
 static std::string find_sf_file(const std::string &name)
 {
-	const std::string sf_path = CROSS_ResolveHome(name);
+	const std_fs::path sf_path = CROSS_ResolveHome(name);
 	if (path_exists(sf_path))
 		return sf_path.string();
 	for (const auto &dir : get_data_dirs()) {
@@ -767,9 +767,10 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program *caller)
 
 	// If selected soundfont exists in the current working directory,
 	// then print it.
-	const std::string sf_path = CROSS_ResolveHome(sf_name);
+	const std_fs::path sf_path = CROSS_ResolveHome(sf_name);
 	if (path_exists(sf_path)) {
-		write_line((sf_path == selected_font), sf_name);
+		write_line((sf_path == selected_font),
+		           format_sf2_line(term_width - 2, sf_name));
 	}
 
 	// Go through all soundfont directories and list all .sf2 files.

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -137,7 +137,7 @@ std::tuple<std::string, int> parse_sf_pref(const std::string &line,
 static std::deque<std_fs::path> get_data_dirs()
 {
 	return {
-	        std_fs::path(CROSS_GetPlatformConfigDir()) / "soundfonts",
+	        get_platform_config_dir() / "soundfonts",
 	        "C:\\soundfonts\\",
 	};
 }
@@ -147,7 +147,7 @@ static std::deque<std_fs::path> get_data_dirs()
 static std::deque<std_fs::path> get_data_dirs()
 {
 	return {
-	        std_fs::path(CROSS_GetPlatformConfigDir()) / "soundfonts",
+	        get_platform_config_dir() / "soundfonts",
 	        std_fs::path(CROSS_ResolveHome("~/Library/Audio/Sounds/Banks")),
 	        // TODO: check /usr/local/share/soundfonts
 	        // TODO: check /usr/share/soundfonts
@@ -185,7 +185,7 @@ static std::deque<std_fs::path> get_data_dirs()
 	}
 
 	// Third priority is $XDG_CONF_HOME, for convenience
-	dirs.emplace_back(std_fs::path(CROSS_GetPlatformConfigDir()) / "soundfonts");
+	dirs.emplace_back(get_platform_config_dir() / "soundfonts");
 
 	return dirs;
 }

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -576,7 +576,8 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	if (!loaded_model_and_dir) {
 		LOG_WARNING("MT32: Failed to find ROMs for model %s in:",
 		        selected_model.c_str());
-		for (const auto &dir : rom_dirs) {
+		for (const auto &dir_path : rom_dirs) {
+			const auto dir = dir_path.string();
 			const char div = (dir != rom_dirs.back() ? '|' : '`');
 			LOG_MSG("MT32:  %c- %s", div, dir.c_str());
 		}

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -175,7 +175,7 @@ static void W32_ConfDir(std::string& in,bool create) {
 }
 #endif
 
-std::string CROSS_GetPlatformConfigDir()
+static std::string get_platform_config_dir()
 {
 	// Cache the result, as this doesn't change
 	static std::string conf_dir = {};
@@ -207,6 +207,13 @@ std::string CROSS_GetPlatformConfigDir()
 		conf_dir += CROSS_FILESPLIT;
 #endif
 	return conf_dir;
+}
+
+std::string CROSS_GetPlatformConfigDir()
+{
+	const auto dir = get_platform_config_dir();
+	assert(dir.back() == CROSS_FILESPLIT);
+	return dir;
 }
 
 void Cross::GetPlatformConfigDir(std::string &in)

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -205,18 +205,6 @@ std_fs::path get_platform_config_dir()
 	return conf_dir;
 }
 
-std::string CROSS_GetPlatformConfigDir()
-{
-	const auto dir = get_platform_config_dir().string();
-	assert(dir.back() != CROSS_FILESPLIT);
-	return dir + CROSS_FILESPLIT;
-}
-
-void Cross::GetPlatformConfigDir(std::string &in)
-{
-	in = CROSS_GetPlatformConfigDir();
-}
-
 void Cross::GetPlatformConfigName(std::string &in)
 {
 	in = GetConfigName();

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -228,7 +228,7 @@ void Cross::CreatePlatformConfigDir(std::string &in)
 	if (in.back() != CROSS_FILESPLIT)
 		in += CROSS_FILESPLIT;
 
-	if (create_dir(in.c_str(), 0700, OK_IF_EXISTS) != 0) {
+	if (create_dir(in, 0700, OK_IF_EXISTS) != 0) {
 		LOG_MSG("ERROR: Creation of config directory '%s' failed: %s",
 		        in.c_str(), safe_strerror(errno).c_str());
 	}

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -188,8 +188,9 @@ std_fs::path get_platform_config_dir()
 	std::error_code ec = {};
 	if (std_fs::is_regular_file(portable_conf_path, ec)) {
 		conf_dir = portable_conf_path.parent_path();
+		const auto conf_str = conf_dir.string();
 		LOG_MSG("CONFIG: Using portable configuration layout in %s",
-		        conf_dir.c_str());
+		        conf_str.c_str());
 		return conf_dir;
 	}
 

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -98,13 +98,13 @@ std::string to_native_path(const std::string &path) noexcept
 	return ret;
 }
 
-int create_dir(const char *path, uint32_t mode, uint32_t flags) noexcept
+int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags) noexcept
 {
 	static_assert(sizeof(uint32_t) >= sizeof(mode_t), "");
-	const int err = mkdir(path, mode);
+	const int err = mkdir(path.c_str(), mode);
 	if ((errno == EEXIST) && (flags & OK_IF_EXISTS)) {
 		struct stat pstat;
-		if ((stat(path, &pstat) == 0) && S_ISDIR(pstat.st_mode))
+		if ((stat(path.c_str(), &pstat) == 0) && S_ISDIR(pstat.st_mode))
 			return 0;
 	}
 	return err;

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -40,12 +40,14 @@ std::string to_native_path(const std::string &path) noexcept
 	return "";
 }
 
-int create_dir(const char *path, [[maybe_unused]] uint32_t mode, uint32_t flags) noexcept
+int create_dir(const std_fs::path& path, [[maybe_unused]] uint32_t mode,
+               uint32_t flags) noexcept
 {
-	const int err = mkdir(path);
+	const auto path_str = path.string();
+	const int err       = mkdir(path_str.c_str());
 	if ((errno == EEXIST) && (flags & OK_IF_EXISTS)) {
 		struct _stat pstat;
-		if ((_stat(path, &pstat) == 0) &&
+		if ((_stat(path_str.c_str(), &pstat) == 0) &&
 		    ((pstat.st_mode & _S_IFMT) == _S_IFDIR))
 			return 0;
 	}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -435,9 +435,8 @@ private:
 	{
 		if (configdir) {
 			// write file to the default config directory
-			std::string config_path;
-			Cross::GetPlatformConfigDir(config_path);
-			name = config_path + name;
+			const auto config_path = get_platform_config_dir() / name;
+			name = config_path.string();
 		}
 		WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_WHICH"), name.c_str());
 		if (!control->PrintConfig(name)) {
@@ -524,8 +523,7 @@ void CONFIG::Run(void)
 
 		case P_LISTCONF: {
 			Bitu size = control->configfiles.size();
-			std::string config_path;
-			Cross::GetPlatformConfigDir(config_path);
+			const std_fs::path config_path = get_platform_config_dir();
 			WriteOut(MSG_Get("PROGRAM_CONFIG_CONFDIR"),
 			         VERSION,
 			         config_path.c_str());

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1836,7 +1836,7 @@ const std::string& SETUP_GetLanguage()
 // Parse the user's configuration files starting with the primary, then custom
 // -conf's, and finally the local dosbox.conf
 void MSG_Init(Section_prop*);
-void SETUP_ParseConfigFiles(const std::string& config_path)
+void SETUP_ParseConfigFiles(const std_fs::path& config_dir)
 {
 	std::string config_file;
 
@@ -1845,8 +1845,8 @@ void SETUP_ParseConfigFiles(const std::string& config_path)
 	                                                             true);
 	if (wants_primary_conf) {
 		Cross::GetPlatformConfigName(config_file);
-		const std::string config_combined = config_path + config_file;
-		control->ParseConfigFile("primary", config_combined);
+		const auto cfg = config_dir / config_file;
+		control->ParseConfigFile("primary", cfg.string());
 	}
 
 	// Second: parse the local 'dosbox.conf', if present
@@ -1860,8 +1860,8 @@ void SETUP_ParseConfigFiles(const std::string& config_path)
 	while (control->cmdline->FindString("-conf", config_file, true)) {
 		if (!control->ParseConfigFile("custom", config_file)) {
 			// Try to load it from the user directory
-			if (!control->ParseConfigFile("custom",
-			                              config_path + config_file)) {
+			const auto cfg = config_dir / config_file;
+			if (!control->ParseConfigFile("custom", cfg.string())) {
 				LOG_WARNING("CONFIG: Can't open custom config file '%s'",
 				            config_file.c_str());
 			}
@@ -1878,7 +1878,7 @@ void SETUP_ParseConfigFiles(const std::string& config_path)
 
 	// Create a new primary if permitted and no other conf was loaded
 	if (wants_primary_conf && !control->configfiles.size()) {
-		std::string new_config_path = config_path;
+		std::string new_config_path = config_dir.string();
 
 		Cross::CreatePlatformConfigDir(new_config_path);
 		Cross::GetPlatformConfigName(config_file);

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -342,7 +342,7 @@ static const std::deque<std_fs::path> &GetResourceParentPaths()
 	add_if_exists(GetExecutablePath() / "../share" / CANONICAL_PROJECT_NAME);
 
 	// Last priority is the user's configuration directory
-	add_if_exists(std_fs::path(CROSS_GetPlatformConfigDir()));
+	add_if_exists(get_platform_config_dir());
 
 	return paths;
 }

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -27,7 +27,7 @@ public:
 		// pre-requisite that's asserted during the Init process.
 		//
 		CROSS_DetermineConfigPaths();
-		const auto config_path = CROSS_GetPlatformConfigDir();
+		const auto config_path = get_platform_config_dir();
 		SETUP_ParseConfigFiles(config_path);
 
 		Section *_sec;


### PR DESCRIPTION
Quote from commit message:

Command 'mixer /listmidi' depends on OS env variables and user settings
to look for .sf2 installed on the system. This means that in some cases
we had a problem, e.g. when running:

    XDG_DATA_DIRS=/usr/share dosbox

command was printing (correctly):

    * default.sf2 - /usr/share/soundfonts/default.sf2

but for:

    XDG_DATA_DIRS=/usr/share/ dosbox

command was printing spurious directory separators:

    * default.sf2 - /usr/share//soundfonts/default.sf2

This is annoying, because to support accidental lack of separator
implemenation was sometimes adding spurious separators already, so the
problem was *always* visible when system-wide soundfont was installed.

Use std::filesystem ability to join path elements in cross-platform way
to prevent this problem and avoid various edge-cases.