### PR TITLE
Fix batch file 'goto' for previous labels

### DIFF
--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -175,6 +175,7 @@ std::string BatchFile::ExpandedBatchLine(std::string_view line) const
 bool BatchFile::Goto(const std::string_view label)
 {
 	std::string line = " ";
+	this->location = 0;
 
 	while (!line.empty()) {
 		line = GetLine();


### PR DESCRIPTION
Commit 7a4ee80935c54a441cf8a4887fc4ded82269d26a prevented the goto logic from finding a label earlier in the file. This commit just resets the file location to 0 at the beginning of the goto logic so it scans the entire file.

Test file (can't attach a .BAT):

```bat
@echo off
:start
echo "Hello"
goto DOIT
echo "Should not see this"
:DOIT
PAUSE
goto start

```
