### PR TITLE
Fix `format-commit.sh`, Stop reformatting `#include`s

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,10 @@
 # This file uses configuration options available in clang-format 15.0.
 #
 # More detailed description of all options:
-# https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 #
 # Note that version of clang-format provided by your distribution might be
-# newer and provide additional options, that won't work in 8.x.
+# newer and provide additional options, that won't work in 15.x.
 #
 # This style definition should only be understood as a hint
 # for writing new code. The rules are still work-in-progress and do
@@ -25,8 +25,6 @@ ColumnLimit: 80
 # C/C++ Language specifics
 #
 Language: Cpp
-# in clang-format 9.x "Cpp11" covers formatting for C++11 and C++14
-# in clang-format 10.x: switch to "c++14"
 Standard: c++17
 
 # Align qualifiers with the type instead of the variable name
@@ -111,7 +109,7 @@ AlignOperands:  AlignAfterOperator
 #   #endif
 #   #endif
 #
-IndentPPDirectives: AfterHash
+IndentPPDirectives: None
 
 # Always place function bodies on their own lines because
 # it makes a mess when some are on the same line and others are

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -7,7 +7,7 @@ set -eu
 # Copyright (C) 2020-2023  Patryk Obara <patryk.obara@gmail.com>
 
 SCRIPT=$(basename "$0")
-VERSION="1.0.1"
+VERSION="1.0.2"
 readonly SCRIPT VERSION
 
 print_usage () {
@@ -71,10 +71,10 @@ assign_gnu_sed () {
 	# No, so help the user install it and then quit.
 	else
 		echo "'sed' is not GNU and 'gsed' is not available."
-		if [[ "${OSTYPE:-}" == "darwin"* ]]; then
+		if [[ "$(uname)" == "Darwin"* ]]; then
 			echo "Install GNU sed with: brew install gnu-sed"
 		else
-			echo "Install GNU sed with your $OSTYPE package manager."
+			echo "Install GNU sed with your package manager."
 		fi
 		exit 1
 	fi

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -4,10 +4,11 @@ set -eu
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# Copyright (C) 2020-2021  Patryk Obara <patryk.obara@gmail.com>
+# Copyright (C) 2020-2023  Patryk Obara <patryk.obara@gmail.com>
 
 SCRIPT=$(basename "$0")
-readonly SCRIPT
+VERSION="1.0.0"
+readonly SCRIPT VERSION
 
 print_usage () {
 	echo "usage: $SCRIPT [-V|--verify|-d|--diff|-a|--amend] [<commit>]"
@@ -45,6 +46,7 @@ print_usage () {
 main () {
 	case ${1:-} in
 		-h|-help|--help) print_usage ;;
+		-v|--version)    echo "$SCRIPT version $VERSION" ;;
 		-d|--diff)       handle_dependencies ; shift ; format "$@" ; assert_empty_diff ;;
 		-V|--verify)     handle_dependencies ; shift ; format "$@" ; assert_empty_diff ;;
 		-a|--amend)      handle_dependencies ; shift ; format "$@" ; amend ;;

--- a/src/midi/midi_lasynth_model.h
+++ b/src/midi/midi_lasynth_model.h
@@ -28,10 +28,10 @@
 #include <memory>
 #include <string>
 
-#	include "std_filesystem.h"
+#include "std_filesystem.h"
 
-#	define MT32EMU_API_TYPE 3
-#	include <mt32emu/mt32emu.h>
+#define MT32EMU_API_TYPE 3
+#include <mt32emu/mt32emu.h>
 
 // An LA Synth Model consists of PCM and Control ROMs either in full or partial
 // form.

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -39,7 +39,7 @@
 
 #include "mixer.h"
 #include "rwqueue.h"
-#	include "std_filesystem.h"
+#include "std_filesystem.h"
 
 class LASynthModel;
 using model_and_dir_t = std::pair<const LASynthModel*, std_fs::path>;


### PR DESCRIPTION
I noticed I left a bug in the format-commit script years ago:

    Fix reformatting code when manually specifying commits
    
    The code was written in a way to process files touched by commits since
    specified commit, but then relied on "HEAD~1" string when detecting
    ranges of modified lines. In result:
    
        ./format-commit.sh HEAD~3
    
    Was re-formatting the newest commit and not detecting any changes in
    older commits.

New formatting rules introduced in clang-format 15 break formatting of `#include` statements in some cases - I think it makes sense to disable this formatting rule:

    Disable indenting preprocessor directives
    
    In many cases we rely on ifdef statements to enable/disable a piece of
    code for specific feature - thuse sometimes we have whole cpp files
    guarded by feature check (because it's easiet to do it this way than
    making buildsystem more complicated). In such cases clang-format decides
    to push preprocessor directives (all includes (!)) by tab to right.
    
    Disable this rule, let's keep existing style.