### PR TITLE
Gracefully quit stdin loops on program termination

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -394,6 +394,10 @@ static Bitu DOS_21Handler(void) {
 			free--;
 			for(;;) {
 				DOS_ReadFile(STDIN,&c,&n);
+				// gracefully exit potentially endless loop
+				if (shutdown_requested) {
+					break;
+				}
 				if (n == 0)				// End of file
 					E_Exit("DOS:0x0a:Redirected input reached EOF");
 				if (c == 10)			// Line feed
@@ -436,7 +440,13 @@ static Bitu DOS_21Handler(void) {
 			if (handle!=0xFF && Files[handle] && Files[handle]->IsName("CON")) {
 				uint8_t c;uint16_t n;
 				while (DOS_GetSTDINStatus()) {
-					n=1;	DOS_ReadFile(STDIN,&c,&n);
+					n=1;
+					DOS_ReadFile(STDIN,&c,&n);
+
+					// gracefully exit potentially endless loop
+					if (shutdown_requested) {
+						break;
+					}
 				}
 			}
 			switch (reg_al) {


### PR DESCRIPTION
Fixes #2347 

Check it with [OTHELLO.zip](https://github.com/dosbox-staging/dosbox-staging/files/11012521/OTHELLO.zip), run the game and press Ctrl+F9 at console input prompt.