### PR TITLE
Add compile-time flag for experimental Voodoo support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -205,6 +205,7 @@ conf_data.set10('C_SDL_IMAGE', get_option('use_sdl2_image'))
 conf_data.set10('C_TRACY', get_option('tracy'))
 conf_data.set10('C_FPU', true)
 conf_data.set10('C_FPU_X86', host_machine.cpu_family() in ['x86', 'x86_64'])
+conf_data.set10('C_VOODOO', get_option('experimental_voodoo_support'))
 
 if get_option('enable_debugger') != 'none'
     conf_data.set10('C_DEBUG', true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -194,3 +194,10 @@ option(
     value: false,
     description: 'Save intermediate assembly output',
 )
+
+option(
+    'experimental_voodoo_support',
+    type: 'boolean',
+    value: false,
+    description: ''
+)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -133,6 +133,9 @@
 // Define to 1 to enable MT-32 emulator
 #mesondefine C_MT32EMU
 
+// Define to 1 to enable 3dfx Voodoo card emulation
+#mesondefine C_VOODOO
+
 // Define to 1 to enable mouse mapping support
 #mesondefine C_MANYMOUSE
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -79,6 +79,10 @@
 //Define to report opengl errors
 //#define DB_OPENGL_ERROR
 
+#if C_VOODOO
+#error "Voodoo support is not implemented yet"
+#endif
+
 #ifndef APIENTRY
 #define APIENTRY
 #endif

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -65,6 +65,9 @@
 // Define to 1 to enable MT-32 emulator
 #define C_MT32EMU 1
 
+// Define to 1 to enable 3dfx Voodoo card emulation
+#define C_VOODOO 0
+
 /* Enable the FPU module, still only for beta testing */
 #define C_FPU 1
 


### PR DESCRIPTION
No code yet, just a disabled compilation flag to be used during development.

Once 3dfx support will be complete and tested and stable, we'll remove the feature flag.