### PR TITLE
Two trivial fixes

### DIFF
--- a/contrib/resources/mapping/MAIN.TXT
+++ b/contrib/resources/mapping/MAIN.TXT
@@ -953,7 +953,7 @@ CODEPAGE 1118 # Lithuanian, LST 1283 encoding
 0xf4 0x201e        #DOUBLE LOW-9 QUOTATION MARK
 0xf5 0x201c        #LEFT DOUBLE QUOTATION MARK
 0xfa 0x02d9        #DOT ABOVE
-EXTENDS CODEPAGE 8437
+EXTENDS CODEPAGE 437
 
 CODEPAGE 1119 # Lithuanian and Russian, Cyrillic, LST 1284 encoding
 # reference: https://en.wikipedia.org/wiki/Code_page_866

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4508,7 +4508,7 @@ void config_add_sdl() {
 
 	Pbool = sdl_sec->Add_bool("vsync", on_start, true);
 	Pbool->Set_help("Synchronize with display refresh rate if supported to eliminate flickering\n"
-	                "and tearing (enabled by default).\n");
+	                "and tearing (enabled by default).");
 
 	pint = sdl_sec->Add_int("vsync_skip", on_start, 7000);
 	pint->Set_help("Number of microseconds to allow rendering to block before skipping the\n"


### PR DESCRIPTION
1. Fixed mistake in code page 1118 definition, which prevents Unicode engine from using it.
2. Removed unnecessary newline character, causing a gap (empty line) in the configuration file, as on the screenshot:

![Screenshot-Bug](https://user-images.githubusercontent.com/48332137/233466831-f9c2e5a8-a72b-4335-84f3-58e7c534fdf0.png)
