### PR TITLE
Fix a couple issues from the `vgaonly` PR

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -170,11 +170,10 @@ public:
 protected:
 	virtual bool ValidateValue(const Value& in);
 
-	Value value;
-	std::vector<Value> valid_values;
-	Value default_value;
-	const Changeable::Value change;
-
+	Value value                                            = {};
+	std::vector<Value> valid_values                        = {};
+	Value default_value                                    = {};
+	const Changeable::Value change                         = {};
 	typedef std::vector<Value>::const_iterator const_iter;
 };
 

--- a/include/setup.h
+++ b/include/setup.h
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <deque>
 #include <list>
+#include <map>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -94,6 +95,7 @@ public:
 	Value(const char* const in) : _string(in), type(V_STRING) {}
 
 	bool operator==(const Value& other) const;
+	bool operator<(const Value& other) const;
 
 	operator bool() const;
 	operator Hex() const;
@@ -127,6 +129,9 @@ public:
 
 	void Set_values(const char* const* in);
 	void Set_values(const std::vector<std::string>& in);
+	void SetDeprecatedWithAlternateValue(const char* deprecated_value,
+	                                     const char* alternate_value);
+
 	void Set_help(const std::string& str);
 
 	const char* GetHelp() const;
@@ -149,6 +154,7 @@ public:
 	}
 
 	virtual bool IsValidValue(const Value& in);
+	virtual bool IsValueDeprecated(const Value& value) const;
 
 	Changeable::Value GetChange() const
 	{
@@ -161,6 +167,8 @@ public:
 	}
 
 	virtual const std::vector<Value>& GetValues() const;
+	std::vector<Value> GetDeprecatedValues() const;
+	const Value& GetAlternateForDeprecatedValue(const Value& value) const;
 
 	Value::Etype Get_type()
 	{
@@ -172,6 +180,7 @@ protected:
 
 	Value value                                            = {};
 	std::vector<Value> valid_values                        = {};
+	std::map<Value, Value> deprecated_and_alternate_values = {};
 	Value default_value                                    = {};
 	const Changeable::Value change                         = {};
 	typedef std::vector<Value>::const_iterator const_iter;

--- a/include/vga.h
+++ b/include/vga.h
@@ -363,7 +363,11 @@ union ClockingModeRegister {
 struct VGA_Seq {
 	uint8_t index = 0;
 	uint8_t reset = 0;
+
 	ClockingModeRegister clocking_mode = {};
+	// Let the user force the clocking mode's 8/9-dot-mode bit high
+	bool wants_vga_8dot_font = false;
+
 	uint8_t map_mask = 0;
 	uint8_t character_map_select = 0;
 	uint8_t memory_mode = 0;

--- a/include/vga.h
+++ b/include/vga.h
@@ -157,7 +157,7 @@ enum PixelsPerChar : int8_t {
 	Nine  = 9,
 };
 
-enum class Vga200LineHandling : int8_t { Duplicate, Draw };
+enum class Vga200LineHandling : int8_t { SingleScan, DoubleScan };
 
 struct VGA_Draw {
 	bool resizing = false;
@@ -598,7 +598,7 @@ void VGA_LogInitialization(const char *adapter_name,
                            const size_t num_modes);
 
 void VGA_SetVga200LineHandling(const Vga200LineHandling vga_200_line_handling);
-bool VGA_IsDrawingDoubleScanLinesIn200LineMode();
+bool VGA_IsDoubleScanning200LineModes();
 
 extern VGA_Type vga;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -540,6 +540,9 @@ void DOSBOX_Init()
 	        "               some games may not use them properly (flickering) or may need\n"
 	        "               more system memory to use them.");
 
+	Pbool = secprop->Add_bool("vga_8dot_font", only_at_start, false);
+	Pbool->Set_help("Use 8-pixel-wide fonts for VGA machine types");
+
 	Pbool = secprop->Add_bool("speed_mods", only_at_start, true);
 	Pbool->Set_help(
 	        "Permit changes known to improve performance (enabled by default).\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -419,14 +419,12 @@ double DOSBOX_GetUptime()
 
 void DOSBOX_Init()
 {
-	Section_prop *secprop;
-	Prop_int *Pint;
-	Prop_int *pint = nullptr;
-	Prop_hex* Phex;
-	Prop_string* Pstring; // use pstring when touching properties
-	Prop_string *pstring;
-	Prop_bool* Pbool;
-	PropMultiValRemain* pmulti_remain;
+	Section_prop* secprop             = nullptr;
+	Prop_bool* pbool                  = nullptr;
+	Prop_int* pint                    = nullptr;
+	Prop_hex* phex                    = nullptr;
+	Prop_string* pstring              = nullptr;
+	PropMultiValRemain* pmulti_remain = nullptr;
 
 	// Specifies if and when a setting can be changed
 	constexpr auto always = Property::Changeable::Always;
@@ -527,9 +525,9 @@ void DOSBOX_Init()
 	        "We recommend the 'default' rate; otherwise test and set on a per-game basis.");
 
 	const char *vesa_modes_choices[] = {"compatible", "all", "halfline", 0};
-	Pstring = secprop->Add_string("vesa_modes", only_at_start, "compatible");
-	Pstring->Set_values(vesa_modes_choices);
-	Pstring->Set_help(
+	pstring = secprop->Add_string("vesa_modes", only_at_start, "compatible");
+	pstring->Set_values(vesa_modes_choices);
+	pstring->Set_help(
 	        "Controls the selection of VESA 1.2 and 2.0 modes offered:\n"
 	        "  compatible:  A tailored selection that maximizes game compatibility.\n"
 	        "               This is recommended along with 4 or 8 MB of video memory\n"
@@ -540,11 +538,11 @@ void DOSBOX_Init()
 	        "               some games may not use them properly (flickering) or may need\n"
 	        "               more system memory to use them.");
 
-	Pbool = secprop->Add_bool("vga_8dot_font", only_at_start, false);
-	Pbool->Set_help("Use 8-pixel-wide fonts for VGA machine types");
+	pbool = secprop->Add_bool("vga_8dot_font", only_at_start, false);
+	pbool->Set_help("Use 8-pixel-wide fonts for VGA machine types");
 
-	Pbool = secprop->Add_bool("speed_mods", only_at_start, true);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("speed_mods", only_at_start, true);
+	pbool->Set_help(
 	        "Permit changes known to improve performance (enabled by default).\n"
 	        "Currently, no games are known to be negatively affected by this.\n"
 	        "Please file a bug with the project if you find a game that fails\n"
@@ -561,15 +559,15 @@ void DOSBOX_Init()
 	        "overwrite",
 	        0,
 	};
-	Pstring = secprop->Add_string("autoexec_section", only_at_start, "join");
-	Pstring->Set_values(autoexec_section_choices);
-	Pstring->Set_help(
+	pstring = secprop->Add_string("autoexec_section", only_at_start, "join");
+	pstring->Set_values(autoexec_section_choices);
+	pstring->Set_help(
 	        "How autoexec sections are handled from multiple config files:\n"
 	        "  join:       Combine them into one big section (legacy behavior; default).\n"
 	        "  overwrite:  Use the last one encountered, like other config settings.");
 
-	Pbool = secprop->Add_bool("automount", only_at_start, true);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("automount", only_at_start, true);
+	pbool->Set_help(
 	        "Mount 'drives/[c]' directories as drives on startup, where [c] is a lower-case\n"
 	        "drive letter from 'a' to 'y' (enabled by default). The 'drives' folder can be\n"
 	        "provided relative to the current directory or via built-in resources.\n"
@@ -585,9 +583,9 @@ void DOSBOX_Init()
 	const char *verbosity_choices[] = {
 	        "auto", "high", "low", "quiet", 0,
 	};
-	Pstring = secprop->Add_string("startup_verbosity", only_at_start, "auto");
-	Pstring->Set_values(verbosity_choices);
-	Pstring->Set_help(
+	pstring = secprop->Add_string("startup_verbosity", only_at_start, "auto");
+	pstring->Set_values(verbosity_choices);
+	pstring->Set_help(
 	        "Controls verbosity prior to displaying the program ('auto' by default):\n"
 	        "  Verbosity   | Welcome | Early stdout\n"
 	        "  high        |   yes   |    yes\n"
@@ -595,8 +593,8 @@ void DOSBOX_Init()
 	        "  quiet       |   no    |    no\n"
 	        "  auto        | 'low' if exec or dir is passed, otherwise 'high'");
 
-	Pbool = secprop->Add_bool("allow_write_protected_files", only_at_start, true);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("allow_write_protected_files", only_at_start, true);
+	pbool->Set_help(
 	        "Many games open all their files with writable permissions; even files that they\n"
 	        "never modify. This setting lets you write-protect those files while still\n"
 	        "allowing the game to read them. A second use-case: if you're using a copy-on-write\n"
@@ -609,8 +607,8 @@ void DOSBOX_Init()
 	pint = secprop->Add_int("frameskip", deprecated, 0);
 	pint->Set_help("Consider capping frame-rates using the '[sdl] host_rate' setting.");
 
-	Pbool = secprop->Add_bool("aspect", always, true);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("aspect", always, true);
+	pbool->Set_help(
 	        "Scale the vertical resolution to produce a 4:3 display aspect ratio, matching\n"
 	        "that of the original monitors the majority of DOS games were designed for\n"
 	        "(enabled by default).\n"
@@ -692,16 +690,16 @@ void DOSBOX_Init()
 	  "normal",
 	  "simple",
 	  0 };
-	Pstring = secprop->Add_string("core", when_idle, "auto");
-	Pstring->Set_values(cores);
-	Pstring->Set_help("CPU core used in emulation ('auto' by default). 'auto' will switch to dynamic\n"
+	pstring = secprop->Add_string("core", when_idle, "auto");
+	pstring->Set_values(cores);
+	pstring->Set_help("CPU core used in emulation ('auto' by default). 'auto' will switch to dynamic\n"
 	                  "if available and appropriate.");
 
 	const char* cputype_values[] = { "auto", "386", "386_slow", "486_slow", "pentium_slow", "386_prefetch", 0};
-	Pstring = secprop->Add_string("cputype", always, "auto");
-	Pstring->Set_values(cputype_values);
-	Pstring->Set_help("CPU type used in emulation ('auto' by default). 'auto' is the fastest choice.");
-
+	pstring = secprop->Add_string("cputype", always, "auto");
+	pstring->Set_values(cputype_values);
+	pstring->Set_help(
+	        "CPU type used in emulation ('auto' by default). 'auto' is the fastest choice.");
 
 	pmulti_remain = secprop->AddMultiValRemain("cycles", always, " ");
 	pmulti_remain->Set_help(
@@ -716,20 +714,20 @@ void DOSBOX_Init()
 	        "  max:             Allocate as much cycles as your computer is able to handle.");
 
 	const char* cyclest[] = { "auto", "fixed", "max", "%u", 0 };
-	Pstring = pmulti_remain->GetSection()->Add_string("type", always, "auto");
+	pstring = pmulti_remain->GetSection()->Add_string("type", always, "auto");
 	pmulti_remain->SetValue("auto");
-	Pstring->Set_values(cyclest);
+	pstring->Set_values(cyclest);
 
 	pmulti_remain->GetSection()->Add_string("parameters", always, "");
 
-	Pint = secprop->Add_int("cycleup", always, 10);
-	Pint->SetMinMax(1, 1000000);
-	Pint->Set_help("Number of cycles added or subtracted with speed control hotkeys\n"
+	pint = secprop->Add_int("cycleup", always, 10);
+	pint->SetMinMax(1, 1000000);
+	pint->Set_help("Number of cycles added or subtracted with speed control hotkeys\n"
 	               "(10 by default).");
 
-	Pint = secprop->Add_int("cycledown", always, 20);
-	Pint->SetMinMax(1, 1000000);
-	Pint->Set_help("Setting it lower than 100 will be a percentage (20 by default).");
+	pint = secprop->Add_int("cycledown", always, 20);
+	pint->SetMinMax(1, 1000000);
+	pint->Set_help("Setting it lower than 100 will be a percentage (20 by default).");
 
 #if C_FPU
 	secprop->AddInitFunction(&FPU_Init);
@@ -769,32 +767,32 @@ void DOSBOX_Init()
 	                                   changeable_at_runtime);
 
 	const char* sbtypes[] = {"sb1", "sb2", "sbpro1", "sbpro2", "sb16", "gb", "none", 0};
-	Pstring = secprop->Add_string("sbtype", when_idle, "sb16");
-	Pstring->Set_values(sbtypes);
-	Pstring->Set_help("Type of Sound Blaster to emulate ('sb16' by default).\n"
+	pstring = secprop->Add_string("sbtype", when_idle, "sb16");
+	pstring->Set_values(sbtypes);
+	pstring->Set_help("Type of Sound Blaster to emulate ('sb16' by default).\n"
 	                  "'gb' is Game Blaster.");
 
 	const char *ios[] = {"220", "240", "260", "280", "2a0", "2c0", "2e0", "300", 0};
-	Phex = secprop->Add_hex("sbbase", when_idle, 0x220);
-	Phex->Set_values(ios);
-	Phex->Set_help("The IO address of the Sound Blaster (220 by default).");
+	phex              = secprop->Add_hex("sbbase", when_idle, 0x220);
+	phex->Set_values(ios);
+	phex->Set_help("The IO address of the Sound Blaster (220 by default).");
 
 	const char *irqssb[] = {"3", "5", "7", "9", "10", "11", "12", 0};
-	Pint = secprop->Add_int("irq", when_idle, 7);
-	Pint->Set_values(irqssb);
-	Pint->Set_help("The IRQ number of the Sound Blaster (7 by default).");
+	pint                 = secprop->Add_int("irq", when_idle, 7);
+	pint->Set_values(irqssb);
+	pint->Set_help("The IRQ number of the Sound Blaster (7 by default).");
 
 	const char *dmassb[] = {"0", "1", "3", "5", "6", "7", 0};
-	Pint = secprop->Add_int("dma", when_idle, 1);
-	Pint->Set_values(dmassb);
-	Pint->Set_help("The DMA number of the Sound Blaster (1 by default).");
+	pint                 = secprop->Add_int("dma", when_idle, 1);
+	pint->Set_values(dmassb);
+	pint->Set_help("The DMA number of the Sound Blaster (1 by default).");
 
-	Pint = secprop->Add_int("hdma", when_idle, 5);
-	Pint->Set_values(dmassb);
-	Pint->Set_help("The High DMA number of the Sound Blaster (5 by default).");
+	pint = secprop->Add_int("hdma", when_idle, 5);
+	pint->Set_values(dmassb);
+	pint->Set_help("The High DMA number of the Sound Blaster (5 by default).");
 
-	Pbool = secprop->Add_bool("sbmixer", when_idle, true);
-	Pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer (enabled by default).");
+	pbool = secprop->Add_bool("sbmixer", when_idle, true);
+	pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer (enabled by default).");
 
 	pint = secprop->Add_int("sbwarmup", when_idle, 100);
 	pint->Set_help(
@@ -808,17 +806,17 @@ void DOSBOX_Init()
 	               "resampling.");
 
 	const char* oplmodes[] = {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", 0};
-	Pstring = secprop->Add_string("oplmode", when_idle, "auto");
-	Pstring->Set_values(oplmodes);
-	Pstring->Set_help("Type of OPL emulation ('auto' by default).\n"
+	pstring = secprop->Add_string("oplmode", when_idle, "auto");
+	pstring->Set_values(oplmodes);
+	pstring->Set_help("Type of OPL emulation ('auto' by default).\n"
 	                  "On 'auto' the mode is determined by 'sbtype'.\n"
 	                  "All OPL modes are AdLib-compatible, except for 'cms'.");
 
-	Pstring = secprop->Add_string("oplemu", deprecated, "");
-	Pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
+	pstring = secprop->Add_string("oplemu", deprecated, "");
+	pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
 
-	Pstring = secprop->Add_string("sb_filter", when_idle, "modern");
-	Pstring->Set_help(
+	pstring = secprop->Add_string("sb_filter", when_idle, "modern");
+	pstring->Set_help(
 	        "Type of filter to emulate for the Sound Blaster digital sound output:\n"
 	        "  auto:      Use the appropriate filter determined by 'sbtype'.\n"
 	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
@@ -835,12 +833,13 @@ void DOSBOX_Init()
 	        "                lpf 2 12000\n"
 	        "                hpf 3 120 lfp 1 6500");
 
-	Pbool = secprop->Add_bool("sb_filter_always_on", when_idle, false);
-	Pbool->Set_help("Force the Sound Blaster filter to be always on\n"
-					"(disallow programs from turning the filter off; disabled by default).");
+	pbool = secprop->Add_bool("sb_filter_always_on", when_idle, false);
+	pbool->Set_help(
+	        "Force the Sound Blaster filter to be always on\n"
+	        "(disallow programs from turning the filter off; disabled by default).");
 
-	Pstring = secprop->Add_string("opl_filter", when_idle, "auto");
-	Pstring->Set_help(
+	pstring = secprop->Add_string("opl_filter", when_idle, "auto");
+	pstring->Set_help(
 	        "Type of filter to emulate for the Sound Blaster OPL output:\n"
 	        "  auto:      Use the appropriate filter determined by 'sbtype' (default).\n"
 	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
@@ -897,21 +896,21 @@ void DOSBOX_Init()
 
 	const char *tandys[] = {"auto", "on", "off", 0};
 
-	Pstring = secprop->Add_string("tandy", when_idle, "auto");
-	Pstring->Set_values(tandys);
-	Pstring->Set_help(
+	pstring = secprop->Add_string("tandy", when_idle, "auto");
+	pstring->Set_values(tandys);
+	pstring->Set_help(
 	        "Enable Tandy Sound System emulation ('auto' by default).\n"
 	        "For 'auto', emulation is present only if machine is set to 'tandy'.");
 
-	Pstring = secprop->Add_string("tandy_filter", when_idle, "on");
-	Pstring->Set_help(
+	pstring = secprop->Add_string("tandy_filter", when_idle, "on");
+	pstring->Set_help(
 	        "Filter for the Tandy synth output:\n"
 	        "  on:        Filter the output (default).\n"
 	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 
-	Pstring = secprop->Add_string("tandy_dac_filter", when_idle, "on");
-	Pstring->Set_help(
+	pstring = secprop->Add_string("tandy_dac_filter", when_idle, "on");
+	pstring->Set_help(
 	        "Filter for the Tandy DAC output:\n"
 	        "  on:        Filter the output (default).\n"
 	        "  off:       Don't filter the output.\n"
@@ -936,27 +935,28 @@ void DOSBOX_Init()
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 
 	// Deprecate the overloaded Disney setting
-	Pbool = secprop->Add_bool("disney", deprecated, false);
-	Pbool->Set_help("Use 'lpt_dac=disney' to enable the Disney Sound Source.");
+	pbool = secprop->Add_bool("disney", deprecated, false);
+	pbool->Set_help("Use 'lpt_dac=disney' to enable the Disney Sound Source.");
 
 	// IBM PS/1 Audio emulation
 	secprop->AddInitFunction(&PS1AUDIO_Init, changeable_at_runtime);
 
-	Pbool = secprop->Add_bool("ps1audio", when_idle, false);
-	Pbool->Set_help("Enable IBM PS/1 Audio emulation (disabled by default).");
+	pbool = secprop->Add_bool("ps1audio", when_idle, false);
+	pbool->Set_help("Enable IBM PS/1 Audio emulation (disabled by default).");
 
-	Pstring = secprop->Add_string("ps1audio_filter", when_idle, "on");
-	Pstring->Set_help(
+	pstring = secprop->Add_string("ps1audio_filter", when_idle, "on");
+	pstring->Set_help(
 	        "Filter for the PS/1 Audio synth output:\n"
 	        "  on:        Filter the output (default).\n"
 	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 
-	Pstring = secprop->Add_string("ps1audio_dac_filter", when_idle, "on");
-	Pstring->Set_help("Filter for the PS/1 Audio DAC output:\n"
-	                  "  on:        Filter the output (default).\n"
-	                  "  off:       Don't filter the output.\n"
-	                  "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
+	pstring = secprop->Add_string("ps1audio_dac_filter", when_idle, "on");
+	pstring->Set_help(
+	        "Filter for the PS/1 Audio DAC output:\n"
+	        "  on:        Filter the output (default).\n"
+	        "  off:       Don't filter the output.\n"
+	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 
 	// ReelMagic Emulator
 	secprop = control->AddSection_prop("reelmagic",
@@ -993,9 +993,9 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&JOYSTICK_Init, changeable_at_runtime);
 	const char *joytypes[] = {"auto", "2axis", "4axis",    "4axis_2", "fcs",
 	                          "ch",   "hidden",  "disabled", 0};
-	Pstring = secprop->Add_string("joysticktype", when_idle, "auto");
-	Pstring->Set_values(joytypes);
-	Pstring->Set_help(
+	pstring = secprop->Add_string("joysticktype", when_idle, "auto");
+	pstring->Set_values(joytypes);
+	pstring->Set_help(
 	        "Type of joystick to emulate:\n"
 	        "  auto:      Detect and use any joystick(s), if possible (default).\n"
 	        "  2axis:     Support up to two joysticks, each with 2 axis\n"
@@ -1006,36 +1006,36 @@ void DOSBOX_Init()
 	        "  hidden:    Prevent DOS from seeing the joystick(s), but enable them\n"
 	        "             for mapping.\n"
 	        "  disabled:  Fully disable joysticks: won't be polled, mapped,\n"
-			"             or visible in DOS.\n"
+	        "             or visible in DOS.\n"
 	        "Remember to reset DOSBox's mapperfile if you saved it earlier.");
 
-	Pbool = secprop->Add_bool("timed", when_idle, true);
-	Pbool->Set_help("Enable timed intervals for axis (disabled by default).\n"
+	pbool = secprop->Add_bool("timed", when_idle, true);
+	pbool->Set_help("Enable timed intervals for axis (disabled by default).\n"
 	                "Experiment with this option, if your joystick drifts away.");
 
-	Pbool = secprop->Add_bool("autofire", when_idle, false);
-	Pbool->Set_help("Fire continuously as long as the button is pressed\n"
+	pbool = secprop->Add_bool("autofire", when_idle, false);
+	pbool->Set_help("Fire continuously as long as the button is pressed\n"
 	                "(disabled by default).");
 
-	Pbool = secprop->Add_bool("swap34", when_idle, false);
-	Pbool->Set_help("Swap the 3rd and the 4th axis (disabled by default).\n"
+	pbool = secprop->Add_bool("swap34", when_idle, false);
+	pbool->Set_help("Swap the 3rd and the 4th axis (disabled by default).\n"
 	                "Can be useful for certain joysticks.");
 
-	Pbool = secprop->Add_bool("buttonwrap", when_idle, false);
-	Pbool->Set_help("Enable button wrapping at the number of emulated buttons (disabled by default).");
+	pbool = secprop->Add_bool("buttonwrap", when_idle, false);
+	pbool->Set_help("Enable button wrapping at the number of emulated buttons (disabled by default).");
 
-	Pbool = secprop->Add_bool("circularinput", when_idle, false);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("circularinput", when_idle, false);
+	pbool->Set_help(
 	        "Enable translation of circular input to square output (disabled by default).\n"
 	        "Try enabling this if your left analog stick can only move in a circle.");
 
-	Pint = secprop->Add_int("deadzone", when_idle, 10);
-	Pint->SetMinMax(0, 100);
-	Pint->Set_help("Percentage of motion to ignore (10 by default).\n"
+	pint = secprop->Add_int("deadzone", when_idle, 10);
+	pint->SetMinMax(0, 100);
+	pint->Set_help("Percentage of motion to ignore (10 by default).\n"
 	               "100 turns the stick into a digital one.");
 
-	Pbool = secprop->Add_bool("use_joy_calibration_hotkeys", when_idle, false);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("use_joy_calibration_hotkeys", when_idle, false);
+	pbool->Set_help(
 	        "Enable hotkeys to allow realtime calibration of the joystick's x and y axis\n"
 	        "(disabled by default). Only consider this if in-game calibration fails and\n"
 	        "other settings have been tried.\n"
@@ -1046,7 +1046,7 @@ void DOSBOX_Init()
 	        "      - left and right shift x-axis offset in the given direction.\n"
 	        "      - down and up shift the y-axis offset in the given direction.\n"
 	        "  - Reset the X and Y calibration using Ctrl+Delete and Ctrl+Home,\n"
-			"    respectively.\n"
+	        "    respectively.\n"
 	        "Each tap will report X or Y calibration values you can set below. When you find\n"
 	        "parameters that work, quit the game, switch this setting back to false, and\n"
 	        "populate the reported calibration parameters.");
@@ -1064,9 +1064,9 @@ void DOSBOX_Init()
 	        "dummy", "disabled", "mouse", "modem", "nullmodem", "direct", 0};
 
 	pmulti_remain = secprop->AddMultiValRemain("serial1", when_idle, " ");
-	Pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
+	pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
 	pmulti_remain->SetValue("dummy");
-	Pstring->Set_values(serials);
+	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	pmulti_remain->Set_help(
 	        "Set type of device connected to COM port.\n"
@@ -1084,23 +1084,23 @@ void DOSBOX_Init()
 	        "Example: serial1=modem listenport:5000 sock:1");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial2", when_idle, " ");
-	Pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
+	pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "dummy");
 	pmulti_remain->SetValue("dummy");
-	Pstring->Set_values(serials);
+	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	pmulti_remain->Set_help("See 'serial1'");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial3", when_idle, " ");
-	Pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
+	pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	pmulti_remain->SetValue("disabled");
-	Pstring->Set_values(serials);
+	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	pmulti_remain->Set_help("See 'serial1'");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial4", when_idle, " ");
-	Pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
+	pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	pmulti_remain->SetValue("disabled");
-	Pstring->Set_values(serials);
+	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	pmulti_remain->Set_help("See 'serial1'");
 
@@ -1112,20 +1112,20 @@ void DOSBOX_Init()
 	 * start up in the shell */
 	secprop = control->AddSection_prop("dos", &DOS_Init);
 	secprop->AddInitFunction(&XMS_Init, changeable_at_runtime);
-	Pbool = secprop->Add_bool("xms", when_idle, true);
-	Pbool->Set_help("Enable XMS support (enabled by default).");
+	pbool = secprop->Add_bool("xms", when_idle, true);
+	pbool->Set_help("Enable XMS support (enabled by default).");
 
 	secprop->AddInitFunction(&EMS_Init, changeable_at_runtime);
 	const char* ems_settings[] = {"true", "emsboard", "emm386", "false", 0};
-	Pstring = secprop->Add_string("ems", when_idle, "true");
-	Pstring->Set_values(ems_settings);
-	Pstring->Set_help(
+	pstring = secprop->Add_string("ems", when_idle, "true");
+	pstring->Set_values(ems_settings);
+	pstring->Set_help(
 	        "Enable EMS support (enabled by default). Enabled provides the best\n"
 	        "compatibility but certain applications may run better with other choices,\n"
 	        "or require EMS support to be disabled to work at all.");
 
-	Pbool = secprop->Add_bool("umb", when_idle, true);
-	Pbool->Set_help("Enable UMB support (enabled by default).");
+	pbool = secprop->Add_bool("umb", when_idle, true);
+	pbool->Set_help("Enable UMB support (enabled by default).");
 
 	pstring = secprop->Add_string("ver", when_idle, "5.0");
 	pstring->Set_help("Set DOS version (5.0 by default). Specify in major.minor format.\n"
@@ -1138,16 +1138,18 @@ void DOSBOX_Init()
 	               "formats. If set to 0, the country code corresponding to the selected keyboard\n"
 	               "layout will be used.");
 
-	Pstring = secprop->Add_string("expand_shell_variable", when_idle, "auto");
+	pstring = secprop->Add_string("expand_shell_variable", when_idle, "auto");
 	const char *expand_shell_variable_choices[] = {"auto", "true", "false", 0};
-	Pstring->Set_values(expand_shell_variable_choices);
-	Pstring->Set_help("Enable expanding environment variables such as %PATH% in the DOS command shell\n"
-	                "(auto by default, enabled if DOS version >= 7.0).\n"
-	                "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
+	pstring->Set_values(expand_shell_variable_choices);
+	pstring->Set_help(
+	        "Enable expanding environment variables such as %PATH% in the DOS command shell\n"
+	        "(auto by default, enabled if DOS version >= 7.0).\n"
+	        "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
 
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init, changeable_at_runtime);
-	Pstring = secprop->Add_string("keyboardlayout", when_idle, "auto");
-	Pstring->Set_help("Language code of the keyboard layout, or 'auto' ('auto' by default).");
+	pstring = secprop->Add_string("keyboardlayout", when_idle, "auto");
+	pstring->Set_help(
+	        "Language code of the keyboard layout, or 'auto' ('auto' by default).");
 
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
@@ -1155,15 +1157,15 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&CDROM_Image_Init);
 #if C_IPX
 	secprop = control->AddSection_prop("ipx", &IPX_Init, changeable_at_runtime);
-	Pbool   = secprop->Add_bool("ipx", when_idle, false);
-	Pbool->Set_help("Enable IPX over UDP/IP emulation (enabled by default).");
+	pbool = secprop->Add_bool("ipx", when_idle, false);
+	pbool->Set_help("Enable IPX over UDP/IP emulation (enabled by default).");
 #endif
 
 #if C_SLIRP
 	secprop = control->AddSection_prop("ethernet", &NE2K_Init, changeable_at_runtime);
 
-	Pbool = secprop->Add_bool("ne2000", when_idle,  true);
-	Pbool->Set_help(
+	pbool = secprop->Add_bool("ne2000", when_idle, true);
+	pbool->Set_help(
 	        "Enable emulation of a Novell NE2000 network card on a software-based\n"
 	        "network (using libslirp) with properties as follows (enabled by default):\n"
 	        "  - 255.255.255.0:  Subnet mask of the 10.0.2.0 virtual LAN.\n"
@@ -1177,28 +1179,28 @@ void DOSBOX_Init()
 
 	const char *nic_addresses[] = {"200", "220", "240", "260", "280", "2c0",
 	                               "300", "320", "340", "360", 0};
-	Phex = secprop->Add_hex("nicbase", when_idle, 0x300);
-	Phex->Set_values(nic_addresses);
-	Phex->Set_help(
-	        "Base address of the NE2000 card (300 by default).\n"
-	        "Notes: Addresses 220 and 240 might not be available as they're assigned to the\n"
-	        "       Sound Blaster and Gravis UltraSound by default.");
+	phex = secprop->Add_hex("nicbase", when_idle, 0x300);
+	phex->Set_values(nic_addresses);
+	phex->Set_help("Base address of the NE2000 card (300 by default).\n"
+	               "Notes: Addresses 220 and 240 might not be available as they're assigned to the\n"
+	               "       Sound Blaster and Gravis UltraSound by default.");
 
 	const char *nic_irqs[] = {"3",  "4",  "5",  "9",  "10",
 	                          "11", "12", "14", "15", 0};
-	Pint = secprop->Add_int("nicirq", when_idle, 3);
-	Pint->Set_values(nic_irqs);
-	Pint->Set_help("The interrupt used by the NE2000 card (3 by default).\n"
+	pint                   = secprop->Add_int("nicirq", when_idle, 3);
+	pint->Set_values(nic_irqs);
+	pint->Set_help("The interrupt used by the NE2000 card (3 by default).\n"
 	               "Notes: IRQs 3 and 5 might not be available as they're assigned to\n"
 	               "       'serial2' and the Gravis UltraSound by default.");
 
-	Pstring = secprop->Add_string("macaddr", when_idle, "AC:DE:48:88:99:AA");
-	Pstring->Set_help("The MAC address of the NE2000 card ('AC:DE:48:88:99:AA' by default).");
+	pstring = secprop->Add_string("macaddr", when_idle, "AC:DE:48:88:99:AA");
+	pstring->Set_help(
+	        "The MAC address of the NE2000 card ('AC:DE:48:88:99:AA' by default).");
 
-	Pstring = secprop->Add_string("tcp_port_forwards", when_idle, "");
-	Pstring->Set_help(
+	pstring = secprop->Add_string("tcp_port_forwards", when_idle, "");
+	pstring->Set_help(
 	        "Forward one or more TCP ports from the host into the DOS guest\n"
-			"(unset by default).\n"
+	        "(unset by default).\n"
 	        "The format is:\n"
 	        "  port1  port2  port3 ... (e.g., 21 80 443)\n"
 	        "  This will forward FTP, HTTP, and HTTPS into the DOS guest.\n"
@@ -1215,9 +1217,10 @@ void DOSBOX_Init()
 	        "       If conflicting host ports are given, only the first one is setup.\n"
 	        "       If conflicting guest ports are given, the latter rule takes precedent.");
 
-	Pstring = secprop->Add_string("udp_port_forwards", when_idle, "");
-	Pstring->Set_help("Forward one or more UDP ports from the host into the DOS guest\n"
-	                  "(unset by default). The format is the same as for TCP port forwards.");
+	pstring = secprop->Add_string("udp_port_forwards", when_idle, "");
+	pstring->Set_help(
+	        "Forward one or more UDP ports from the host into the DOS guest\n"
+	        "(unset by default). The format is the same as for TCP port forwards.");
 #endif
 
 	//	secprop->AddInitFunction(&CREDITS_Init);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -376,10 +376,6 @@ static void DOSBOX_RealInit(Section * sec) {
 		svgaCard = SVGA_TsengET3K;
 	} else if (mtype == "svga_paradise") {
 		svgaCard = SVGA_ParadisePVGA1A;
-	} else if (mtype == "vgaonly") {
-		svgaCard = SVGA_ParadisePVGA1A;
-		LOG_WARNING("CONFIG: 'machine = vgaonly' is deprecated. Consider using "
-		            "defaults or 'machine = svga_paradise' if basic (S)VGA is critical.");
 	} else {
 		E_Exit("DOSBOX:Unknown machine type %s", mtype.c_str());
 	}
@@ -465,6 +461,7 @@ void DOSBOX_Init()
 	        "       feature.");
 	pstring = secprop->Add_string("machine", only_at_start, "svga_s3");
 	pstring->Set_values(machines);
+	pstring->SetDeprecatedWithAlternateValue("vgaonly", "svga_paradise");
 	pstring->Set_help(
 	        "The type of machine DOSBox tries to emulate ('svga_s3' by default).");
 
@@ -1232,6 +1229,7 @@ void DOSBOX_Init()
 	        "# This is the configuration file for " CANONICAL_PROJECT_NAME " (%s).\n"
 	        "# Lines starting with a '#' character are comments.\n");
 	MSG_Add("CONFIG_VALID_VALUES", "Possible values");
+	MSG_Add("CONFIG_DEPRECATED_VALUES", "Deprecated values");
 
 	// Initialize the uptime counter when launching the first shell. This
 	// ensures that slow-performing configurable tasks (like loading MIDI

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -230,10 +230,10 @@ double VGA_GetPreferredRate()
 // Are we using a VGA card, in a 200-line mode, and asked to draw the
 // double-scanned lines? (This is a helper function to avoid repeating this
 // logic in the VGA drawing and CRTC areas).
-bool VGA_IsDrawingDoubleScanLinesIn200LineMode()
+bool VGA_IsDoubleScanning200LineModes()
 {
 	return IS_VGA_ARCH &&
-	       vga.draw.vga_200_line_handling == Vga200LineHandling::Draw &&
+	       vga.draw.vga_200_line_handling == Vga200LineHandling::DoubleScan &&
 	       (vga.mode == M_EGA || vga.mode == M_VGA);
 
 	// TODO: Non-composite CGA modes should be included here too, as VGA

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -145,7 +145,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		if (IS_VGA_ARCH)
 			vga.config.line_compare=(vga.config.line_compare & 0x5ff)|(val&0x40)<<3;
 
-		if (VGA_IsDrawingDoubleScanLinesIn200LineMode()) {
+		if (VGA_IsDoubleScanning200LineModes()) {
 			if ((vga.crtc.maximum_scan_line ^ val) & 0x20) {
 				crtc(maximum_scan_line)=val;
 				VGA_StartResize();

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1433,7 +1433,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			const auto is_scan_doubled = bit::is(vga.crtc.maximum_scan_line,
 			                                     bit::literals::b7);
 
-			if (VGA_IsDrawingDoubleScanLinesIn200LineMode()) {
+			if (VGA_IsDoubleScanning200LineModes()) {
 				// Set the low resolution modes to have as many
 				// lines as are scanned - Quite a few demos
 				// change the max_scanline register at display
@@ -1909,7 +1909,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	}
 	vga.draw.vblank_skip = vblank_skip;
 
-	if (!VGA_IsDrawingDoubleScanLinesIn200LineMode()) {
+	if (!VGA_IsDoubleScanning200LineModes()) {
 		// Only check for extra double height in vga modes (line
 		// multiplying by address_line_total)
 

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -111,14 +111,15 @@ void INT10_ReloadFont(void) {
 		INT10_LoadFont(RealToPhysical(int10.rom.font_8_first),false,256,0,map,8);
 		break;
 	case 14:
-		if (IS_VGA_ARCH && CurMode->mode == 7) {
+		if (IS_VGA_ARCH && CurMode->mode == 7 &&
+		    !vga.seq.clocking_mode.is_eight_dot_mode) {
 			map = 0x80;
 		}
 		INT10_LoadFont(RealToPhysical(int10.rom.font_14), false, 256, 0, map, 14);
 		break;
 	case 16:
 	default:
-		if (IS_VGA_ARCH) {
+		if (IS_VGA_ARCH && !vga.seq.clocking_mode.is_eight_dot_mode) {
 			map = 0x80;
 		}
 		INT10_LoadFont(RealToPhysical(int10.rom.font_16), false, 256, 0, map, 16);


### PR DESCRIPTION
Fixes up a couple issues from the vgaonly PR:

1. Allows config values to be deprecated with alternatives (that can be different than the default). For example:

    ```ini
    [dosbox]
    #   machine: The type of machine DOSBox tries to emulate ('svga_s3' by default).
    #   Possible values: hercules, cga, cga_mono, tandy, pcjr, ega, ...
    #   Deprecated values: vgaonly.
    ```

    Using a deprecated option warns:

    ```
    CONFIG: 'machine = vgaonly' is deprecated, falling back to the alternate: 'machine = svga_paradise'
    ```

    So now `vgaonly` is actually handled. Thanks @NicknineTheEagle for reporting this.

2. Now draws all 400-lines (low resolution double-scanned) whenever it translates to a visible difference on the output side (code-comment has a more thorough explanation). Thanks @NicknineTheEagle for reporting this.

3. Lets the user force 8-pixel-wide fonts for VGA machine types. Thanks @FeralChild64 for requesting this.
