### PR TITLE
Simplify double-scan criteria and let users `'force_vga_single_scan'` w/ conf option

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -157,7 +157,11 @@ enum PixelsPerChar : int8_t {
 	Nine  = 9,
 };
 
-enum class Vga200LineHandling : int8_t { SingleScan, DoubleScan };
+enum class VgaSub350LineHandling : int8_t {
+	DoubleScan,
+	SingleScan,
+	ForceSingleScan,
+};
 
 struct VGA_Draw {
 	bool resizing = false;
@@ -208,7 +212,7 @@ struct VGA_Draw {
 	bool double_scan = false;
 	bool doublewidth = false;
 	bool doubleheight = false;
-	Vga200LineHandling vga_200_line_handling = {};
+	VgaSub350LineHandling vga_sub_350_line_handling = {};
 	uint8_t font[64 * 1024] = {};
 	uint8_t *font_tables[2] = {nullptr, nullptr};
 	Bitu blinking = 0;
@@ -597,8 +601,8 @@ void VGA_LogInitialization(const char *adapter_name,
                            const char *ram_type,
                            const size_t num_modes);
 
-void VGA_SetVga200LineHandling(const Vga200LineHandling vga_200_line_handling);
-bool VGA_IsDoubleScanning200LineModes();
+void VGA_SetVgaSub350LineHandling(const VgaSub350LineHandling vga_sub_350_line_handling);
+bool VGA_IsDoubleScanningSub350LineModes();
 
 extern VGA_Type vga;
 

--- a/include/vga.h
+++ b/include/vga.h
@@ -70,9 +70,7 @@ constexpr uint16_t VGA_PIXEL_DOUBLE = 1 << 2;
 
 // Refresh rate constants
 constexpr auto REFRESH_RATE_MIN = 23;
-constexpr auto REFRESH_RATE_DOS_DOUBLED_MAX = 35;
 constexpr auto REFRESH_RATE_HOST_VRR_LFC = 48;
-constexpr auto REFRESH_RATE_HOST_TV_MAX = 50;
 constexpr auto REFRESH_RATE_HOST_DEFAULT = 60;
 constexpr auto REFRESH_RATE_DOS_DEFAULT = 70;
 constexpr auto REFRESH_RATE_HOST_VRR_MIN = 75;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -516,6 +516,9 @@ void DOSBOX_Init()
 	pstring->Set_help("Video memory in MB (1-8) or KB (256 to 8192). 'auto' uses the default per\n"
 	                  "video adapter ('auto' by default).");
 
+	pbool = secprop->Add_bool("force_vga_single_scan", when_idle, false);
+	pbool->Set_help("Always single-scan sub-350 line modes for VGA machine types");
+
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(
 	        "Customize the emulated video mode's frame rate, in Hz:\n"

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -227,13 +227,14 @@ double VGA_GetPreferredRate()
 	return vga.draw.dos_refresh_hz;
 }
 
-// Are we using a VGA card, in a 200-line mode, and asked to draw the
+// Are we using a VGA card, in a sub-350 line mode, and asked to draw the
 // double-scanned lines? (This is a helper function to avoid repeating this
 // logic in the VGA drawing and CRTC areas).
-bool VGA_IsDoubleScanning200LineModes()
+bool VGA_IsDoubleScanningSub350LineModes()
 {
 	return IS_VGA_ARCH &&
-	       vga.draw.vga_200_line_handling == Vga200LineHandling::DoubleScan &&
+	       vga.draw.vga_sub_350_line_handling ==
+	               VgaSub350LineHandling::DoubleScan &&
 	       (vga.mode == M_EGA || vga.mode == M_VGA);
 
 	// TODO: Non-composite CGA modes should be included here too, as VGA
@@ -330,14 +331,33 @@ void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3) {
 	}	
 }
 
-void VGA_SetVga200LineHandling(const Vga200LineHandling vga_200_line_handling)
+void VGA_SetVgaSub350LineHandling(const VgaSub350LineHandling vga_sub_350_line_handling)
 {
-	vga.draw.vga_200_line_handling = vga_200_line_handling;
+	if (vga.draw.vga_sub_350_line_handling ==
+	    VgaSub350LineHandling::ForceSingleScan) {
+		return;
+	}
+	vga.draw.vga_sub_350_line_handling = vga_sub_350_line_handling;
 }
 
-void VGA_Init(Section* sec) {
-//	Section_prop * section=static_cast<Section_prop *>(sec);
-	vga.draw.resizing=false;
+static void set_vga_single_scanning_pref()
+{
+	const auto conf    = control->GetSection("dosbox");
+	const auto section = dynamic_cast<Section_prop*>(conf);
+
+	if (section && section->Get_bool("force_vga_single_scan")) {
+		vga.draw.vga_sub_350_line_handling = VgaSub350LineHandling::ForceSingleScan;
+		LOG_MSG("VIDEO: Single-scanning sub-350 line modes for VGA machine types");
+	} else {
+		vga.draw.vga_sub_350_line_handling = {};
+	}
+}
+
+void VGA_Init(Section* sec)
+{
+	set_vga_single_scanning_pref();
+
+	vga.draw.resizing = false;
 	vga.mode=M_ERROR;			//For first init
 	SVGA_Setup_Driver();
 	VGA_SetupMemory(sec);

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -358,7 +358,7 @@ void VGA_Init(Section* sec)
 	set_vga_single_scanning_pref();
 
 	vga.draw.resizing = false;
-	vga.mode=M_ERROR;			//For first init
+	vga.mode          = M_ERROR; // For first init
 	SVGA_Setup_Driver();
 	VGA_SetupMemory(sec);
 	VGA_SetupMisc();

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -145,7 +145,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		if (IS_VGA_ARCH)
 			vga.config.line_compare=(vga.config.line_compare & 0x5ff)|(val&0x40)<<3;
 
-		if (VGA_IsDoubleScanning200LineModes()) {
+		if (VGA_IsDoubleScanningSub350LineModes()) {
 			if ((vga.crtc.maximum_scan_line ^ val) & 0x20) {
 				crtc(maximum_scan_line)=val;
 				VGA_StartResize();

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -19,9 +19,9 @@
 #include "dosbox.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
-#include <vector>
 
 #include "../gui/render_scalers.h"
 #include "../ints/int10.h"
@@ -42,10 +42,16 @@ typedef uint8_t * (* VGA_Line_Handler)(Bitu vidstart, Bitu line);
 
 static VGA_Line_Handler VGA_DrawLine;
 
-constexpr auto max_pixel_bytes = sizeof(uint32_t);
-constexpr auto max_line_bytes = SCALER_MAXWIDTH * SCALER_MAX_MUL_WIDTH * max_pixel_bytes;
+// Confirm the maximum dimensions accomodate VGA's sub-350 line scan doubling
+constexpr auto max_scan_doubled_width  = 400;
+constexpr auto max_scan_doubled_height = 350 - 1;
+static_assert(SCALER_MAXHEIGHT >= SCALER_MAX_MUL_HEIGHT * max_scan_doubled_height);
+static_assert(SCALER_MAXWIDTH >= SCALER_MAX_MUL_WIDTH * max_scan_doubled_width);
 
-static std::vector<uint8_t> templine_buffer(max_line_bytes);
+constexpr auto max_pixel_bytes = sizeof(uint32_t);
+constexpr auto max_line_bytes  = SCALER_MAXWIDTH * max_pixel_bytes;
+
+static std::array<uint8_t, max_line_bytes> templine_buffer;
 static auto TempLine = templine_buffer.data();
 
 static uint8_t * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1422,7 +1422,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			// When bit 7 is set to 1, 200-scan-line video data is
 			// converted to 400-scan-line output. To do this, the
 			// clock in the row scan counter is divided by 2, which
-			// allows the 200-line modes to be displayed as 400
+			// allows the sub-350 line modes to be displayed as 400
 			// lines on the display (this is called double scanning;
 			// each line is displayed twice). When this bit is set
 			// to 0, the clock to the row scan counter is equal to
@@ -1433,7 +1433,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			const auto is_scan_doubled = bit::is(vga.crtc.maximum_scan_line,
 			                                     bit::literals::b7);
 
-			if (VGA_IsDoubleScanning200LineModes()) {
+			if (VGA_IsDoubleScanningSub350LineModes()) {
 				// Set the low resolution modes to have as many
 				// lines as are scanned - Quite a few demos
 				// change the max_scanline register at display
@@ -1909,7 +1909,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	}
 	vga.draw.vblank_skip = vblank_skip;
 
-	if (!VGA_IsDoubleScanning200LineModes()) {
+	if (!VGA_IsDoubleScanningSub350LineModes()) {
 		// Only check for extra double height in vga modes (line
 		// multiplying by address_line_total)
 


### PR DESCRIPTION
Single scanning is now *only* used when sharp-scaling flat (non-shaded) pixels. The benefits of the smaller canvas are:
 - better fitment into sub-4k screen resolutions 
 - reduced load on slow systems like the Raspberry Pi

Just to be explicit, the reverse of the above means that double scanning is used when:
- OpenGL is using any shader, or
- any output mode is bi-linear scaling, and
- even `"output = surface"` is double-scanned!

The new `'force_vga_single_scan'` option trumps all of this though and guarantees single scanning: if a user needs it to get an acceptable frame rate at the cost of some visual accuracy, then so be it!
