### PR TITLE
Fix regression in Build Engine games (3Dfx mode)

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -24,11 +24,11 @@ jobs:
             reconfigure_build: false
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 898
+            max_warnings: 902
             reconfigure_build: false
           - name: MSVC, +voodoo
             arch: x64
-            max_warnings: 910
+            max_warnings: 914
             reconfigure_build: true
 
     steps:

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -4140,11 +4140,16 @@ static void prepare_tmu(tmu_state *t)
 	t->lodbasetemp = (-lodbase + (12 << 8)) / 2;
 }
 
-static inline INT32 round_coordinate(float value)
+static inline int32_t round_coordinate(float value)
 {
-	return (value > 0 ? (INT32)(value + .4999999f) : (INT32)(value - .5f));
-	//INT32 result = (INT32)floor(value);
-	//return result + (value - (float)result > 0.5f);
+	// This is not proper rounding algorithm akin to std::lround (it works
+	// incorrectly for values < 0.0); be extremely careful while adjusting
+	// it.  Make sure that changes do not result in regression in
+	// Build Engine games (Blood, Shadow Warrior).
+
+	const auto rounded = static_cast<int32_t>(value); // round towards 0
+	const auto rem     = static_cast<int32_t>((value - rounded) > 0.5f);
+	return rounded + rem;
 }
 
 /*************************************


### PR DESCRIPTION
Fixes this issue: https://github.com/dosbox-staging/dosbox-staging/pull/2410#issuecomment-1521827139 /  https://www.youtube.com/watch?v=Wug_1j9gmsw

Turns out the regression was caused by performance improvement (avoiding slow `std::floor` function).

This is the first attempt at fixing it; it seems to work (tested so far in Blood, Shadow Warrior, TR1, Pył), but more testing is needed. The current rounding algorithm is not mathematically correct (gives wrong results below 0), but it seems like it makes no difference to the game visuals (and we don't know what was the actual behaviour on real Voodoo card).

An idea for mid-term future improvement: this function is always called twice, on x and y floats; it would be beneficial to change it into a function accepting 2 floats and utilising SIMD to round both integers at once.

Shoutout to @schellingb for finding the root cause of regression!