### PR TITLE
Minor voodoo performance tweaks

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -753,7 +753,7 @@ void DOSBOX_Init()
 	pstring->Set_values(voodootypes);
 	pstring->Set_help("RAM amount of emulated Vodooo 3dfx card.");
 
-	pint = secprop->Add_int("voodoo_perf", only_at_start, 1);
+	pint = secprop->Add_int("voodoo_perf", only_at_start, 0);
 	pint->SetMinMax(0, 4);
 	pint->Set_help("Toggle performance optimizations for Vodooo 3dfx emulation (0 = none, 1 = use multi-threading, 2 = disable bilinear filter, 3 = both).");
 #endif

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -74,6 +74,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <thread>
 
 #include <SDL.h>
 #include <SDL_cpuinfo.h> // for proper SSE defines for MSVC
@@ -4285,6 +4286,7 @@ static void triangle_worker_shutdown(triangle_worker& tworker)
 	for (size_t i = 0; i != TRIANGLE_THREADS; i++) tworker.done[i] = false;
 	for (size_t i = 0; i != TRIANGLE_THREADS; i++) SDL_SemPost(tworker.sembegin[i]);
 	recheckdone:
+	std::this_thread::yield();
 	for (size_t i = 0; i != TRIANGLE_THREADS; i++) if (!tworker.done[i]) goto recheckdone;
 	for (size_t i = 0; i != TRIANGLE_THREADS; i++) SDL_DestroySemaphore(tworker.sembegin[i]);
 }
@@ -4343,6 +4345,7 @@ static void triangle_worker_run(triangle_worker& tworker)
 	for (size_t i = 0; i != TRIANGLE_THREADS; i++) SDL_SemPost(tworker.sembegin[i]);
 	triangle_worker_work(tworker, TRIANGLE_THREADS, TRIANGLE_WORKERS);
 	recheckdone:
+	std::this_thread::yield();
 	for (size_t i = 0; i != TRIANGLE_THREADS; i++) if (!tworker.done[i]) goto recheckdone;
 }
 


### PR DESCRIPTION
The main `triangle_worker_run` loop is using a busy-wait `goto` that pegs the CPU. Using `std::this_thread::yield` allows smoother background threading, with varying performance improvement depending on the number of cores and host CPU scheduler.

A comparison of the number of times the `done` checking goto loops:

before:
```log
2023-04-28 07:55:56.580 | busy wait goto count: 48484
2023-04-28 07:55:56.580 | busy wait goto count: 54421
2023-04-28 07:55:56.580 | busy wait goto count: 85345
2023-04-28 07:55:56.580 | busy wait goto count: 121084
2023-04-28 07:55:56.580 | busy wait goto count: 100482
2023-04-28 07:55:56.580 | busy wait goto count: 102246
```

after:
```log
2023-04-28 07:56:35.748 | busy wait goto count: 1
2023-04-28 07:56:35.748 | busy wait goto count: 30
2023-04-28 07:56:35.748 | busy wait goto count: 46
2023-04-28 07:56:35.748 | busy wait goto count: 19
2023-04-28 07:56:35.748 | busy wait goto count: 23
2023-04-28 07:56:35.748 | busy wait goto count: 39
```