### PR TITLE
Ignore trailing colon in shell redirection (#2240)

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -107,11 +107,17 @@ void DOS_Shell::GetRedirection(char *line,
 			found = redir.find_first_of(find_chars);
 			// Get the length of the substring before the
 			// characters, or the entire string if not found
-			if (found == std::string::npos)
+			if (found == std::string::npos) {
 				temp_len = redir.size();
-			else
-				temp_len = found - // Ignore ':' character
-				           (redir[found - 1] == ':' ? 1 : 0);
+			} else {
+				temp_len = found;
+			}
+
+			// Ignore trailing ':' character
+			if (temp_len > 0 && redir[temp_len - 1] == ':') {
+				--temp_len;
+			}
+
 			// Assign substring content of length to output parameters
 			output = (character == '>'
 			                  ? &out_file

--- a/tests/shell_redirection_tests.cpp
+++ b/tests/shell_redirection_tests.cpp
@@ -106,6 +106,24 @@ TEST_F(DOS_Shell_REDIRTest, CMD_Redirection)
 	EXPECT_EQ(append, false);
 
 	in = out = pipe = "";
+	strcpy(line, "less<in.txt>NUL");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "less");
+	EXPECT_EQ(in, "in.txt");
+	EXPECT_EQ(out, "NUL");
+	EXPECT_EQ(pipe, "");
+	EXPECT_EQ(append, false);
+
+	in = out = pipe = "";
+	strcpy(line, "less<in.txt>NUL:");
+	shell.GetRedirection(line, in, out, pipe, &append);
+	EXPECT_STREQ(line, "less:");
+	EXPECT_EQ(in, "in.txt");
+	EXPECT_EQ(out, "NUL");
+	EXPECT_EQ(pipe, "");
+	EXPECT_EQ(append, false);
+
+	in = out = pipe = "";
 	strcpy(line, "more<file.txt|sort");
 	shell.GetRedirection(line, in, out, pipe, &append);
 	EXPECT_STREQ(line, "more");


### PR DESCRIPTION
Ignoring the trailing colon was part of the prior (working) instance:

https://github.com/dosbox-staging/dosbox-staging/commit/a0629955a1334ce1c3788c89c38f87917bda56b3#diff-35199a581467cbca792c14aae243d4986c3492aed47158059fe9a58aac3a7727L215

Fixes #2440
