### PR TITLE
Cleanup in cross.cpp

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -1,4 +1,7 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -107,13 +110,19 @@ void CROSS_DetermineConfigPaths();
 
 std_fs::path get_platform_config_dir();
 
+std_fs::path resolve_home(const std::string &str) noexcept;
+
+[[deprecated]]
 std::string CROSS_ResolveHome(const std::string &str);
 
 class Cross {
 public:
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
+
+	[[deprecated]]
 	static void ResolveHomedir(std::string & temp_line);
+
 	static bool IsPathAbsolute(std::string const& in);
 };
 

--- a/include/cross.h
+++ b/include/cross.h
@@ -112,17 +112,10 @@ std_fs::path get_platform_config_dir();
 
 std_fs::path resolve_home(const std::string &str) noexcept;
 
-[[deprecated]]
-std::string CROSS_ResolveHome(const std::string &str);
-
 class Cross {
 public:
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
-
-	[[deprecated]]
-	static void ResolveHomedir(std::string & temp_line);
-
 	static bool IsPathAbsolute(std::string const& in);
 };
 

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -94,6 +94,16 @@ std::time_t to_time_t(const std_fs::file_time_type &fs_time);
 
 #if !defined(WIN32)
 
+/* Get directory for storing user configuration files.
+ *
+ * User can change this directory by overriding XDG_CONFIG_HOME, otherwise it
+ * defaults to "$HOME/.config/".
+ *
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+
+std_fs::path get_xdg_config_home() noexcept;
+
 /* Get directory for storing user-specific data files.
  *
  * User can change this directory by overriding XDG_DATA_HOME, otherwise it

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -92,7 +92,7 @@ int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags = 0x0) no
 // Convert a filesystem time to a raw time_t value
 std::time_t to_time_t(const std_fs::file_time_type &fs_time);
 
-#if !defined(WIN32)
+#if !defined(WIN32) && !defined(MACOSX)
 
 /* Get directory for storing user configuration files.
  *

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -91,4 +91,18 @@ int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags = 0x0) no
 // Convert a filesystem time to a raw time_t value
 std::time_t to_time_t(const std_fs::file_time_type &fs_time);
 
+#if !defined(WIN32)
+
+/* Get directory for storing user-specific data files.
+ *
+ * User can change this directory by overriding XDG_DATA_HOME, otherwise it
+ * defaults to "$HOME/.local/share/".
+ *
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+
+std_fs::path get_xdg_data_home() noexcept;
+
+#endif
+
 #endif

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -25,6 +25,7 @@
 
 #include <cinttypes>
 #include <ctime>
+#include <deque>
 #include <optional>
 #include <string>
 #include <vector>
@@ -102,6 +103,19 @@ std::time_t to_time_t(const std_fs::file_time_type &fs_time);
  */
 
 std_fs::path get_xdg_data_home() noexcept;
+
+/* Get directories for searching for data files in addition to the XDG_DATA_HOME
+ * directory.
+ *
+ * The directories are ordered according to user preference.
+ *
+ * User can change this list by overriding XDG_DATA_DIRS, otherwise it defaults
+ * to "/usr/local/share/:/usr/share/".
+ *
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+
+std::deque<std_fs::path> get_xdg_data_dirs() noexcept;
 
 #endif
 

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -95,8 +95,7 @@ FILE* BOOT::getFSFile(const char* filename, uint32_t* ksize, uint32_t* bsize,
 	if (tmpfile)
 		return tmpfile;
 	// File not found on mounted filesystem. Try regular filesystem
-	std::string filename_s(filename);
-	Cross::ResolveHomedir(filename_s);
+	const auto filename_s = resolve_home(filename).string();
 	tmpfile = fopen_wrap(filename_s.c_str(), "rb+");
 	if (!tmpfile) {
 		if ((tmpfile = fopen_wrap(filename_s.c_str(), "rb"))) {

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -278,8 +278,7 @@ void IMGMOUNT::Run(void)
 				        temp_line.c_str());
 			}
 		} else {
-			std::string home_resolve = temp_line;
-			Cross::ResolveHomedir(home_resolve);
+			const auto home_resolve = resolve_home(temp_line).string();
 			if (home_resolve == real_path) {
 				LOG_MSG("IMGMOUNT: Path '%s' found",
 				        temp_line.c_str());
@@ -295,8 +294,7 @@ void IMGMOUNT::Run(void)
 		struct stat test;
 		if (stat(temp_line.c_str(), &test)) {
 			// See if it works if the ~ are written out
-			std::string homedir(temp_line);
-			Cross::ResolveHomedir(homedir);
+			const auto homedir = resolve_home(temp_line).string();
 			if (!stat(homedir.c_str(), &test)) {
 				temp_line = std::move(homedir);
 			} else {

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -290,8 +290,7 @@ void MOUNT::Run(void) {
 		if (real_path.empty()) {
 			LOG_MSG("MOUNT: Path '%s' not found", temp_line.c_str());
 		} else {
-			std::string home_resolve = temp_line;
-			Cross::ResolveHomedir(home_resolve);
+			const auto home_resolve = resolve_home(temp_line).string();
 			if (home_resolve == real_path) {
 				LOG_MSG("MOUNT: Path '%s' found",
 						temp_line.c_str());

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -159,10 +159,8 @@ static std::deque<std_fs::path> get_data_dirs()
 
 static std::deque<std_fs::path> get_data_dirs()
 {
-	// First priority is $XDG_DATA_HOME
-	const char *xdg_data_home_env = getenv("XDG_DATA_HOME");
-	const std_fs::path xdg_data_home = CROSS_ResolveHome(
-	        xdg_data_home_env ? xdg_data_home_env : "~/.local/share");
+	// First priority is user-specific data location
+	const auto xdg_data_home = get_xdg_data_home();
 
 	std::deque<std_fs::path> dirs = {
 	        xdg_data_home / "dosbox/soundfonts",

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -151,7 +151,7 @@ static std::deque<std_fs::path> get_data_dirs()
 {
 	return {
 	        get_platform_config_dir() / "soundfonts",
-	        std_fs::path(CROSS_ResolveHome("~/Library/Audio/Sounds/Banks")),
+	        resolve_home("~/Library/Audio/Sounds/Banks"),
 	};
 }
 
@@ -184,7 +184,7 @@ static std::deque<std_fs::path> get_data_dirs()
 
 static std::string find_sf_file(const std::string &name)
 {
-	const std_fs::path sf_path = CROSS_ResolveHome(name);
+	const std_fs::path sf_path = resolve_home(name);
 	if (path_exists(sf_path))
 		return sf_path.string();
 	for (const auto &dir : get_data_dirs()) {
@@ -757,7 +757,7 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program *caller)
 
 	// If selected soundfont exists in the current working directory,
 	// then print it.
-	const std_fs::path sf_path = CROSS_ResolveHome(sf_name);
+	const std_fs::path sf_path = resolve_home(sf_name);
 	if (path_exists(sf_path)) {
 		write_line((sf_path == selected_font),
 		           format_sf2_line(term_width - 2, sf_name));

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -169,18 +169,9 @@ static std::deque<std_fs::path> get_data_dirs()
 	};
 
 	// Second priority are the $XDG_DATA_DIRS
-	const char *xdg_data_dirs_env = getenv("XDG_DATA_DIRS");
-	if (!xdg_data_dirs_env)
-		xdg_data_dirs_env = "/usr/local/share:/usr/share";
-
-	for (auto xdg_data_dir : split(xdg_data_dirs_env, ':')) {
-		trim(xdg_data_dir);
-		if (xdg_data_dir.empty()) {
-			continue;
-		}
-		const std_fs::path resolved_dir = CROSS_ResolveHome(xdg_data_dir);
-		dirs.emplace_back(resolved_dir / "soundfonts");
-		dirs.emplace_back(resolved_dir / "sounds/sf2");
+	for (const auto& data_dir : get_xdg_data_dirs()) {
+		dirs.emplace_back(data_dir / "soundfonts");
+		dirs.emplace_back(data_dir / "sounds/sf2");
 	}
 
 	// Third priority is $XDG_CONF_HOME, for convenience

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -241,10 +241,8 @@ static std::deque<std_fs::path> get_rom_dirs()
 
 static std::deque<std_fs::path> get_rom_dirs()
 {
-	// First priority is $XDG_DATA_HOME
-	const char *xdg_data_home_env = getenv("XDG_DATA_HOME");
-	const auto xdg_data_home      = std_fs::path(CROSS_ResolveHome(
-                xdg_data_home_env ? xdg_data_home_env : "~/.local/share"));
+	// First priority is user-specific data location
+	const auto xdg_data_home = get_xdg_data_home();
 
 	std::deque<std_fs::path> dirs = {
 	        xdg_data_home / "dosbox/mt32-roms",

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -231,7 +231,7 @@ static std::deque<std_fs::path> get_rom_dirs()
 {
 	return {
 	        get_platform_config_dir() / "mt32-roms",
-	        CROSS_ResolveHome("~/Library/Audio/Sounds/MT32-Roms/"),
+	        resolve_home("~/Library/Audio/Sounds/MT32-Roms/"),
 	        "/usr/local/share/mt32-rom-data/",
 	        "/usr/share/mt32-rom-data/",
 	};
@@ -279,7 +279,7 @@ static std::deque<std_fs::path> get_selected_dirs()
 		selected_romdir += CROSS_FILESPLIT;
 
 	// Make sure we search the user's configured directory first
-	rom_dirs.emplace_front(CROSS_ResolveHome((selected_romdir)));
+	rom_dirs.emplace_front(resolve_home(selected_romdir));
 	return rom_dirs;
 }
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -250,18 +250,8 @@ static std::deque<std_fs::path> get_rom_dirs()
 	};
 
 	// Second priority are the $XDG_DATA_DIRS
-	const char *xdg_data_dirs_env = getenv("XDG_DATA_DIRS");
-	if (!xdg_data_dirs_env)
-		xdg_data_dirs_env = "/usr/local/share:/usr/share";
-
-	for (auto xdg_data_dir : split(xdg_data_dirs_env, ':')) {
-		trim(xdg_data_dir);
-		if (xdg_data_dir.empty()) {
-			continue;
-		}
-		const auto resolved_dir = std_fs::path(
-		        CROSS_ResolveHome(xdg_data_dir));
-		dirs.emplace_back(resolved_dir / "mt32-rom-data");
+	for (const auto& data_dir : get_xdg_data_dirs()) {
+		dirs.emplace_back(data_dir / "mt32-rom-data");
 	}
 
 	// Third priority is $XDG_CONF_HOME, for convenience

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -68,9 +68,9 @@ std::string cached_conf_path;
 
 static std::string DetermineConfigPath()
 {
-	const std::string conf_path = CROSS_ResolveHome("~/Library/Preferences/DOSBox");
-	mkdir(conf_path.c_str(), 0700);
-	return conf_path;
+	const auto conf_path = resolve_home("~/Library/Preferences/DOSBox");
+	create_dir(conf_path, 0700);
+	return conf_path.string();
 }
 
 #else
@@ -85,7 +85,7 @@ static std::string DetermineConfigPath()
 	}
 
 	auto fallback_to_deprecated = []() {
-		const std::string old_conf_path = CROSS_ResolveHome("~/.dosbox");
+		const std::string old_conf_path = resolve_home("~/.dosbox").string();
 		if (path_exists(old_conf_path + "/" + GetConfigName())) {
 			LOG_WARNING("CONFIG: Falling back to deprecated path (~/.dosbox) due to errors");
 			LOG_WARNING("CONFIG: Please investigate the problems and try again");

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -208,11 +208,6 @@ void Cross::GetPlatformConfigName(std::string &in)
 	in = GetConfigName();
 }
 
-void Cross::ResolveHomedir(std::string &in)
-{
-	in = CROSS_ResolveHome(in);
-}
-
 void Cross::CreatePlatformConfigDir(std::string &in)
 {
 #ifdef WIN32
@@ -229,11 +224,6 @@ void Cross::CreatePlatformConfigDir(std::string &in)
 		LOG_MSG("ERROR: Creation of config directory '%s' failed: %s",
 		        in.c_str(), safe_strerror(errno).c_str());
 	}
-}
-
-std::string CROSS_ResolveHome(const std::string &str)
-{
-	return resolve_home(str).string();
 }
 
 std_fs::path resolve_home(const std::string &str) noexcept

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -233,6 +233,11 @@ void Cross::CreatePlatformConfigDir(std::string &in)
 
 std::string CROSS_ResolveHome(const std::string &str)
 {
+	return resolve_home(str).string();
+}
+
+std_fs::path resolve_home(const std::string &str) noexcept
+{
 	if (!str.size() || str[0] != '~') // No ~
 		return str;
 

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -77,11 +77,10 @@ static std::string DetermineConfigPath()
 
 static std::string DetermineConfigPath()
 {
-	const char *xdg_conf_home = getenv("XDG_CONFIG_HOME");
-	const std::string conf_home = xdg_conf_home ? xdg_conf_home : "~/.config";
-	const std::string conf_path = CROSS_ResolveHome(conf_home + "/dosbox");
+	const auto conf_path = get_xdg_config_home() / "dosbox";
+	std::error_code ec = {};
 
-	if (path_exists(conf_path + "/" + GetConfigName())) {
+	if (std_fs::exists(conf_path / GetConfigName())) {
 		return conf_path;
 	}
 
@@ -93,8 +92,6 @@ static std::string DetermineConfigPath()
 		}
 		return old_conf_path;
 	};
-
-	std::error_code ec = {};
 
 	if (!std_fs::exists(conf_path, ec)) {
 		if (std_fs::create_directories(conf_path, ec)) {

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "cross.h"
 #include "logging.h"
 #include "string_utils.h"
 
@@ -109,5 +110,16 @@ int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags) noexcept
 	}
 	return err;
 }
+
+#if !defined(MACOSX)
+
+std_fs::path get_xdg_data_home() noexcept
+{
+	const char* var       = getenv("XDG_DATA_HOME");
+	const char* data_home = ((var && var[0]) ? var : "~/.local/share");
+	return std_fs::path(CROSS_ResolveHome(data_home));
+}
+
+#endif
 
 #endif

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -117,14 +117,14 @@ std_fs::path get_xdg_config_home() noexcept
 {
 	const char* var       = getenv("XDG_CONFIG_HOME");
 	const char* conf_home = ((var && var[0]) ? var : "~/.config");
-	return std_fs::path(CROSS_ResolveHome(conf_home));
+	return resolve_home(conf_home);
 }
 
 std_fs::path get_xdg_data_home() noexcept
 {
 	const char* var       = getenv("XDG_DATA_HOME");
 	const char* data_home = ((var && var[0]) ? var : "~/.local/share");
-	return std_fs::path(CROSS_ResolveHome(data_home));
+	return resolve_home(data_home);
 }
 
 std::deque<std_fs::path> get_xdg_data_dirs() noexcept
@@ -136,7 +136,7 @@ std::deque<std_fs::path> get_xdg_data_dirs() noexcept
 	for (auto& dir : split(data_dirs, ':')) {
 		trim(dir);
 		if (!dir.empty()) {
-			paths.emplace_back(CROSS_ResolveHome(dir));
+			paths.emplace_back(resolve_home(dir));
 		}
 	}
 	return paths;

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -120,6 +120,21 @@ std_fs::path get_xdg_data_home() noexcept
 	return std_fs::path(CROSS_ResolveHome(data_home));
 }
 
+std::deque<std_fs::path> get_xdg_data_dirs() noexcept
+{
+	const char* var       = getenv("XDG_DATA_DIRS");
+	const char* data_dirs = ((var && var[0]) ? var : "/usr/local/share:/usr/share");
+
+	std::deque<std_fs::path> paths{};
+	for (auto& dir : split(data_dirs, ':')) {
+		trim(dir);
+		if (!dir.empty()) {
+			paths.emplace_back(CROSS_ResolveHome(dir));
+		}
+	}
+	return paths;
+}
+
 #endif
 
 #endif

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -113,6 +113,13 @@ int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags) noexcept
 
 #if !defined(MACOSX)
 
+std_fs::path get_xdg_config_home() noexcept
+{
+	const char* var       = getenv("XDG_CONFIG_HOME");
+	const char* conf_home = ((var && var[0]) ? var : "~/.config");
+	return std_fs::path(CROSS_ResolveHome(conf_home));
+}
+
 std_fs::path get_xdg_data_home() noexcept
 {
 	const char* var       = getenv("XDG_DATA_HOME");

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -447,8 +447,7 @@ bool Prop_path::SetValue(const std::string& input)
 		return false;
 	}
 
-	std::string workcopy(input);
-	Cross::ResolveHomedir(workcopy);
+	const std::string workcopy = resolve_home(input).string();
 
 	// Prepend config directory in it exists. Check for absolute paths later
 	if (current_config_dir.empty()) {

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -292,15 +292,16 @@ static const std::deque<std_fs::path> &GetResourceParentPaths()
 	// compile time.
 	add_if_exists(std_fs::path(CUSTOM_DATADIR) / CANONICAL_PROJECT_NAME);
 
-	// Fourth priority is the user's XDG data specification
+	// Fourth priority is the user and system XDG data specification
+#if !defined(WIN32) && !defined(MACOSX)
 	add_if_exists(get_xdg_data_home() / CANONICAL_PROJECT_NAME);
 
-	// Fifth priority is the system's XDG data specification
 	for (const auto& data_dir : get_xdg_data_dirs()) {
 		add_if_exists(data_dir / CANONICAL_PROJECT_NAME);
 	}
+#endif
 
-	// Sixth priority is a best-effort fallback for --prefix installations
+	// Fifth priority is a best-effort fallback for --prefix installations
 	// into paths not pointed to by the system's XDG_DATA_ variables. Note
 	// that This lookup is deliberately relative to the executable to permit
 	// portability of the install tree (do not replace this with --prefix,

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -296,29 +296,8 @@ static const std::deque<std_fs::path> &GetResourceParentPaths()
 	add_if_exists(get_xdg_data_home() / CANONICAL_PROJECT_NAME);
 
 	// Fifth priority is the system's XDG data specification
-	//
-	//  $XDG_DATA_DIRS defines the preference-ordered set of base
-	//  directories to search for data files in addition to the
-	//  $XDG_DATA_HOME base directory. The directories in $XDG_DATA_DIRS
-	//  should be seperated with a colon ':'.
-	//
-	// If $XDG_DATA_DIRS is either not set or empty, a value equal to
-	// /usr/local/share/:/usr/share/ should be used.
-	// Ref:https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-	//
-	const char *xdg_data_dirs_env = getenv("XDG_DATA_DIRS");
-
-	// If XDG_DATA_DIRS is undefined, use the default:
-	if (!xdg_data_dirs_env)
-		xdg_data_dirs_env = "/usr/local/share:/usr/share";
-
-	for (auto& xdg_data_dir : split(xdg_data_dirs_env, ':')) {
-		trim(xdg_data_dir);
-		if (!xdg_data_dir.empty()) {
-			const std_fs::path resolved_dir = CROSS_ResolveHome(
-			        xdg_data_dir);
-			add_if_exists(resolved_dir / CANONICAL_PROJECT_NAME);
-		}
+	for (const auto& data_dir : get_xdg_data_dirs()) {
+		add_if_exists(data_dir / CANONICAL_PROJECT_NAME);
 	}
 
 	// Sixth priority is a best-effort fallback for --prefix installations

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -293,19 +293,7 @@ static const std::deque<std_fs::path> &GetResourceParentPaths()
 	add_if_exists(std_fs::path(CUSTOM_DATADIR) / CANONICAL_PROJECT_NAME);
 
 	// Fourth priority is the user's XDG data specification
-	//
-	// $XDG_DATA_HOME defines the base directory relative to which
-	// user-specific data files should be stored. If $XDG_DATA_HOME is
-	// either not set or empty, a default equal to $HOME/.local/share should
-	// be used.
-	// Ref:https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-	//
-	const char *xdg_data_home_env = getenv("XDG_DATA_HOME");
-	if (!xdg_data_home_env)
-		xdg_data_home_env = "~/.local/share";
-
-	const std_fs::path xdg_data_home = CROSS_ResolveHome(xdg_data_home_env);
-	add_if_exists(xdg_data_home / CANONICAL_PROJECT_NAME);
+	add_if_exists(get_xdg_data_home() / CANONICAL_PROJECT_NAME);
 
 	// Fifth priority is the system's XDG data specification
 	//


### PR DESCRIPTION
In #2383 we started cleaning up `cross.cpp` by replacing old `CROSS_GetPlatformConfigDir` and  `Cross::GetPlatformConfigDir` with `std::filesystem` returning `get_platform_config_dir`. This is the continuation of this work.