### PR TITLE
Implement SETVER.EXE command

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -393,6 +393,20 @@ public:
 	void SetStack(RealPt stackpt) { SSET_DWORD(sPSP, stack, stackpt); }
 	RealPt GetStack() const { return SGET_DWORD(sPSP, stack); }
 
+	void SetVersion(const uint8_t major, const uint8_t minor)
+	{
+		SSET_BYTE(sPSP, dos_version_major, major);
+		SSET_BYTE(sPSP, dos_version_minor, minor);
+	}
+	uint8_t GetVersionMajor() const
+	{
+		return SGET_BYTE(sPSP, dos_version_major);
+	}
+	uint8_t GetVersionMinor() const
+	{
+		return SGET_BYTE(sPSP, dos_version_minor);
+	}
+
 	bool SetNumFiles(uint16_t file_num);
 	void SetFCB1(RealPt src);
 	void SetFCB2(RealPt src);
@@ -403,31 +417,32 @@ private:
 	#pragma pack(1)
 	#endif
 	struct sPSP {
-		uint8_t   exit[2];     /* CP/M-like exit poimt */
-		uint16_t  next_seg;    /* Segment of first byte beyond memory allocated or program */
-		uint8_t   fill_1;      /* single char fill */
-		uint8_t   far_call;    /* far call opcode */
-		RealPt  cpm_entry;   /* CPM Service Request address*/
-		RealPt  int_22;      /* Terminate Address */
-		RealPt  int_23;      /* Break Address */
-		RealPt  int_24;      /* Critical Error Address */
-		uint16_t  psp_parent;  /* Parent PSP Segment */
-		uint8_t   files[20];   /* File Table - 0xff is unused */
-		uint16_t  environment; /* Segment of evironment table */
-		RealPt  stack;       /* SS:SP Save point for int 0x21 calls */
-		uint16_t  max_files;   /* Maximum open files */
-		RealPt  file_table;  /* Pointer to File Table PSP:0x18 */
-		RealPt  prev_psp;    /* Pointer to previous PSP */
-		uint8_t   interim_flag;
-		uint8_t   truename_flag;
-		uint16_t  nn_flags;
-		uint16_t  dos_version;
-		uint8_t   fill_2[14];  /* Lot's of unused stuff i can't care aboue */
-		uint8_t   service[3];  /* INT 0x21 Service call int 0x21;retf; */
-		uint8_t   fill_3[9];   /* This has some blocks with FCB info */
-		uint8_t   fcb1[16];    /* first FCB */
-		uint8_t   fcb2[16];    /* second FCB */
-		uint8_t   fill_4[4];   /* unused */
+		uint8_t  exit[2];     /* CP/M-like exit poimt */
+		uint16_t next_seg;    /* Segment of first byte beyond memory allocated or program */
+		uint8_t  fill_1;      /* single char fill */
+		uint8_t  far_call;    /* far call opcode */
+		RealPt   cpm_entry;   /* CPM Service Request address*/
+		RealPt   int_22;      /* Terminate Address */
+		RealPt   int_23;      /* Break Address */
+		RealPt   int_24;      /* Critical Error Address */
+		uint16_t psp_parent;  /* Parent PSP Segment */
+		uint8_t  files[20];   /* File Table - 0xff is unused */
+		uint16_t environment; /* Segment of evironment table */
+		RealPt   stack;       /* SS:SP Save point for int 0x21 calls */
+		uint16_t max_files;   /* Maximum open files */
+		RealPt   file_table;  /* Pointer to File Table PSP:0x18 */
+		RealPt   prev_psp;    /* Pointer to previous PSP */
+		uint8_t  interim_flag;
+		uint8_t  truename_flag;
+		uint16_t nn_flags;
+		uint8_t  dos_version_major;
+		uint8_t  dos_version_minor;
+		uint8_t  fill_2[14]; /* Lot's of unused stuff i can't care aboue */
+		uint8_t  service[3]; /* INT 0x21 Service call int 0x21;retf; */
+		uint8_t  fill_3[9];  /* This has some blocks with FCB info */
+		uint8_t  fcb1[16];   /* first FCB */
+		uint8_t  fcb2[16];   /* second FCB */
+		uint8_t  fill_4[4];  /* unused */
 		CommandTail cmdtail;
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -161,7 +161,8 @@ void DOS_PSP::MakeNew(uint16_t mem_size)
 	/* psp and psp-parent */
 	SSET_WORD(sPSP, psp_parent, dos.psp());
 	SSET_DWORD(sPSP, prev_psp, uint32_t(0xffffffff));
-	SSET_WORD(sPSP, dos_version, uint16_t(0x0005));
+	SSET_BYTE(sPSP, dos_version_major, dos.version.major);
+	SSET_BYTE(sPSP, dos_version_minor, dos.version.minor);
 	/* terminate 22,break 23,crititcal error 24 address stored */
 	SaveVectors();
 

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -22,11 +22,12 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "cpu.h"
 #include "callback.h"
+#include "cpu.h"
 #include "debug.h"
 #include "dos_inc.h"
 #include "mem.h"
+#include "program_setver.h"
 #include "programs.h"
 #include "regs.h"
 #include "string_utils.h"
@@ -437,6 +438,8 @@ bool DOS_Execute(char * name,PhysPt block_pt,uint8_t flags) {
 		newpsp.SetFCB2(block.exec.fcb2);
 		/* Save the SS:SP on the PSP of new program */
 		newpsp.SetStack(RealMakeSeg(ss,reg_sp));
+		/* If needed, override reported DOS version */
+		SETVER::OverrideVersion(name, newpsp);
 
 		/* Setup bx, contains a 0xff in bl and bh if the drive in the fcb is not valid */
 		DOS_FCB fcb1(RealSegment(block.exec.fcb1),RealOffset(block.exec.fcb1));

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -40,6 +40,7 @@
 #include "program_placeholder.h"
 #include "program_rescan.h"
 #include "program_serial.h"
+#include "program_setver.h"
 #include "program_tree.h"
 
 #if C_DEBUG
@@ -89,6 +90,7 @@ void Add_VFiles(const bool add_autoexec)
 	PROGRAMS_MakeFile("MIXER.COM", MIXER_ProgramCreate);
 	PROGRAMS_MakeFile("CONFIG.COM", CONFIG_ProgramCreate);
 	PROGRAMS_MakeFile("SERIAL.COM", ProgramCreate<SERIAL>);
+	PROGRAMS_MakeFile("SETVER.EXE", ProgramCreate<SETVER>);
 	PROGRAMS_MakeFile("TREE.COM", ProgramCreate<TREE>);
 	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramCreate);
 

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -42,6 +42,7 @@ libdos_sources = files(
     'program_placeholder.cpp',
     'program_rescan.cpp',
     'program_serial.cpp',
+    'program_setver.cpp',
     'program_tree.cpp',
 )
 

--- a/src/dos/program_setver.cpp
+++ b/src/dos/program_setver.cpp
@@ -1,0 +1,755 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "program_setver.h"
+
+#include "program_more_output.h"
+
+#include "checks.h"
+#include "config.h"
+#include "control.h"
+#include "setup.h"
+#include "std_filesystem.h"
+#include "string_utils.h"
+
+#include <fstream>
+#include <iostream>
+#include <regex>
+
+CHECK_NARROWING();
+
+using NameVersionTable = SETVER::NameVersionTable;
+
+static struct {
+	SETVER::FakeVersion version_global = {};
+	bool is_global_version_set         = false;
+
+	NameVersionTable by_file_name = {
+	        // Since MS-DOS 6.22 has some default version table,
+	        // we can provide some sane defaults too
+	        {"WIN100.BIN", {3, 40}}, // fixes Microsoft Windows 1.x
+	        {"WIN200.BIN", {3, 40}}, // fixes Microsoft Windows 2.x
+	};
+
+	NameVersionTable by_file_path = {};
+
+} setver_table;
+
+void SETVER::Run()
+{
+	if (HelpRequested()) {
+		MoreOutputStrings output(*this);
+		output.AddString(MSG_Get("PROGRAM_SETVER_HELP_LONG"));
+		output.Display();
+		return;
+	}
+
+	// Retrieve all the switches
+	constexpr bool remove_if_found = true;
+	const bool has_arg_delete = cmd->FindExist("/d", remove_if_found) ||
+	                            cmd->FindExist("/delete", remove_if_found);
+	const bool has_arg_quiet = cmd->FindExist("/q", remove_if_found) ||
+	                           cmd->FindExist("/quiet", remove_if_found);
+	// DR-DOS extensions
+	const bool has_arg_batch  = cmd->FindExist("/b", remove_if_found);
+	const bool has_arg_global = cmd->FindExist("/g", remove_if_found);
+	const bool has_arg_paged  = cmd->FindExist("/p", remove_if_found);
+	// DOSBox Staging extensions
+	const bool has_arg_all = cmd->FindExist("/all", remove_if_found);
+
+	// TODO: DR-DOS also provides /x switch to deal with BDOS versions - for
+	// now this is not implemented, it is unclear to me what it exactly does
+
+	// Make sure no other switches are supplied
+	std::string tmp_str;
+	if (cmd->FindStringBegin("/", tmp_str)) {
+		tmp_str = std::string("/") + tmp_str;
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), tmp_str.c_str());
+		return;
+	}
+
+	std::vector<std::string> params;
+	cmd->FillVector(params);
+
+	// Handle first parameter being a path to SETVER.EXE database
+	const bool is_database_candidate = !params.empty() &&
+	                                   IsNameWithPath(params[0]);
+	if (is_database_candidate && PreprocessName(params[0])) {
+		if (params[0].back() == '\\') {
+			if (params[0] != "Z:\\") {
+				WriteOut(MSG_Get("PROGRAM_SETVER_WRONG_TABLE"));
+				return;
+			}
+			params.erase(params.begin());
+		}
+	}
+
+	// Helper lambda for file name preprocessing
+	auto preprocess_name = [&](std::string& name,
+	                           const bool allow_non_existing_files = false) {
+		if (!PreprocessName(name, allow_non_existing_files)) {
+			if (IsNameWithPath(name)) {
+				WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
+			} else {
+				WriteOut(MSG_Get("SHELL_ILLEGAL_FILE_NAME"));
+			}
+			return false;
+		}
+		return true;
+	};
+
+	// Preprocess first parameter if name/path is expected
+	if (!params.empty() && !has_arg_global) {
+		// When removing file from the list, it is possible the disk it
+		// was located does not currently exist
+		const bool allow_non_existing_files = has_arg_delete;
+		if (!preprocess_name(params[0], allow_non_existing_files)) {
+			return;
+		}
+		// It shouldn't be a directory
+		if (!params[0].empty() && params[0].back() == '\\') {
+			WriteOut(MSG_Get("SHELL_EXPECTED_FILE_NOT_DIR"));
+			return;
+		}
+	}
+
+	// Detect illegal switch combinations
+	if ((has_arg_batch || has_arg_paged) && (has_arg_delete || has_arg_global)) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH_COMBO"));
+		return;
+	}
+	if (has_arg_all && !has_arg_delete) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH_COMBO"));
+		return;
+	}
+
+	// Handle cases with no file parameters
+	if (params.empty()) {
+		if (has_arg_delete && has_arg_global) {
+			CommandDeleteGlobalOnly(has_arg_quiet);
+		} else if (has_arg_delete && has_arg_all) {
+			CommandDeleteAll(has_arg_quiet);
+		} else if (has_arg_global || has_arg_delete) {
+			WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
+		} else {
+			CommandPrintAll(has_arg_batch, has_arg_paged);
+		}
+		return;
+	}
+
+	// From now on at least 1 parameter is guaranteed to exist
+
+	// Detect illegal switch combinations
+	if (has_arg_delete && has_arg_global) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH_COMBO"));
+		return;
+	}
+
+	// Hande entry deletion
+	if (has_arg_delete) {
+		if (params.size() > 1) {
+			WriteOut(MSG_Get("SHELL_TOO_MANY_PARAMETERS"));
+		} else {
+			CommandDeletePerFile(params[0], has_arg_quiet);
+		}
+		return;
+	}
+
+	// Hande global version set
+	if (has_arg_global) {
+		if (params.size() > 1) {
+			WriteOut(MSG_Get("SHELL_TOO_MANY_PARAMETERS"));
+		} else {
+			CommandSet({}, params[0], has_arg_quiet);
+		}
+		return;
+	}
+
+	// Handle per-file version set
+	if (has_arg_batch || has_arg_paged) {
+		WriteOut(MSG_Get("SHELL_WRONG_SYNTAX"));
+	} else if (params.size() > 2) {
+		WriteOut(MSG_Get("SHELL_TOO_MANY_PARAMETERS"));
+	} else {
+		CommandSet(params[0], params[1], has_arg_quiet);
+	}
+}
+
+bool SETVER::ParseVersion(const std::string& version_str, FakeVersion& version)
+{
+	version.major = 0;
+	version.minor = 0;
+
+	const std::regex expression("^([0-9])(\\.([0-9]{0,2}))?$");
+	std::smatch match = {};
+
+	std::regex_match(version_str, match, expression);
+
+	if (match.size() != 4) {
+		return false;
+	}
+
+	const auto& major_str = match[1].str();
+	const auto& minor_str = match[3].str();
+
+	const auto major = to_int(major_str);
+	if (!major) {
+		// It would be enough to assert, but PVS-Studio was unhappy
+		assert(false);
+		return false;
+	}
+
+	version.major = static_cast<uint8_t>(*major);
+
+	if (minor_str.empty()) {
+		return true;
+	}
+
+	const auto minor = to_int(minor_str);
+	if (!minor) {
+		// It would be enough to assert, but PVS-Studio was unhappy
+		assert(false);
+		return false;
+	}
+
+	if (minor_str.size() == 1) {
+		version.minor = static_cast<uint8_t>(*minor * 10);
+	} else {
+		version.minor = static_cast<uint8_t>(*minor);
+	}
+
+	return true;
+}
+
+bool SETVER::PreprocessName(std::string& name, const bool allow_non_existing_files)
+{
+	// Preprocess file names and relative paths
+	trim(name);
+	if (IsNameWithPath(name)) {
+		char buffer[DOS_PATHLENGTH];
+		if (!DOS_Canonicalize(name.c_str(), buffer)) {
+			return allow_non_existing_files;
+		}
+		name = buffer;
+		return true;
+	}
+
+	if (name.size() > LFN_NAMELENGTH) {
+		return false;
+	}
+	upcase(name);
+	return true;
+}
+
+bool SETVER::IsNameWithPath(const std::string& name)
+{
+	// TODO: Use 'contains' after migration to C++20
+	return (name.find(':') != std::string::npos) ||
+	       (name.find('\\') != std::string::npos);
+}
+
+void SETVER::CommandDeletePerFile(const std::string& name, const bool has_arg_quiet)
+{
+	auto try_delete = [](const std::string& name, NameVersionTable& table) {
+		const auto key = FindKeyCaseInsensitive(name, table);
+		if (key.empty()) {
+			return false;
+		}
+		table.erase(key);
+		return true;
+	};
+
+	if (!try_delete(name, setver_table.by_file_name) &&
+	    !try_delete(name, setver_table.by_file_path)) {
+		if (!has_arg_quiet) {
+			WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_ENTRY_NOT_FOUND"));
+		}
+		return;
+	}
+
+	SaveTableToFile();
+	if (!has_arg_quiet) {
+		WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_ENTRY_REMOVED"));
+	}
+}
+
+void SETVER::CommandDeleteGlobalOnly(const bool has_arg_quiet)
+{
+	if (!setver_table.is_global_version_set) {
+		if (!has_arg_quiet) {
+			WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_ENTRY_NOT_FOUND"));
+		}
+		return;
+	}
+
+	setver_table.is_global_version_set = false;
+
+	SaveTableToFile();
+	if (!has_arg_quiet) {
+		WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_ENTRY_REMOVED"));
+	}
+}
+
+void SETVER::CommandDeleteAll(const bool has_arg_quiet)
+{
+	if (IsTableEmpty()) {
+		if (!has_arg_quiet) {
+			WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_ALREADY_EMPTY"));
+		}
+		return;
+	}
+
+	setver_table.is_global_version_set = false;
+	setver_table.by_file_name.clear();
+	setver_table.by_file_path.clear();
+
+	SaveTableToFile();
+	if (!has_arg_quiet) {
+		WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_CLEARED"));
+	}
+}
+
+void SETVER::CommandSet(const std::string& name, const std::string& version_str,
+                        const bool has_arg_quiet)
+{
+	FakeVersion version = {};
+	if (!ParseVersion(version_str, version)) {
+		WriteOut(MSG_Get("PROGRAM_SETVER_INVALID_VERSION"));
+		return;
+	}
+
+	AddToTable(name, version);
+
+	SaveTableToFile();
+	if (!has_arg_quiet) {
+		WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_UPDATED"));
+	}
+}
+
+void SETVER::CommandPrintAll(const bool has_arg_batch, const bool has_arg_paged)
+{
+	// Nothing to print out if table is empty
+	if (IsTableEmpty()) {
+		if (!has_arg_batch) {
+			WriteOut(MSG_Get("PROGRAM_SETVER_TABLE_EMPTY"));
+		}
+		return;
+	}
+
+	const std::string setver_command = "@Z:\\SETVER.EXE ";
+
+	// Calculate indentation sizes
+	size_t indent_size_1 = 0;
+	size_t indent_size_2 = 0;
+	if (setver_table.is_global_version_set) {
+		indent_size_1 = strlen(MSG_Get("PROGRAM_SETVER_GLOBAL"));
+	}
+	for (const auto& [name, version] : setver_table.by_file_name) {
+		indent_size_1 = std::max(indent_size_1, name.length());
+	}
+	for (const auto& [name, version] : setver_table.by_file_path) {
+		indent_size_2 = std::max(indent_size_2, name.length());
+	}
+	const size_t min_space = 4; // min space between file name and version
+	indent_size_1 += min_space;
+	indent_size_2 = std::max(indent_size_1, indent_size_2 + min_space);
+	if (indent_size_1 + min_space >= indent_size_2) {
+		indent_size_1 = indent_size_2;
+	}
+
+	// Helper lambda to prepare string with indentation
+	auto indent = [](const std::string& in_str, const size_t target_size) {
+		assert(target_size > in_str.length());
+		std::string indent_str = {};
+		indent_str.resize(target_size - in_str.length(), ' ');
+		return in_str + indent_str;
+	};
+
+	// Prepare display
+	MoreOutputStrings output(*this);
+	output.SetOptionNoPaging(!has_arg_paged);
+
+	bool is_empty_line_needed = false;
+
+	// Print global version override
+	if (setver_table.is_global_version_set) {
+		if (has_arg_batch) {
+			output.AddString(":: %s\n",
+			                 MSG_Get("PROGRAM_SETVER_BATCH_GLOBAL"));
+			output.AddString("%s%d.%02d /g /q\n",
+			                 setver_command.c_str(),
+			                 setver_table.version_global.major,
+			                 setver_table.version_global.minor);
+		} else {
+			const auto tmp_str = indent(MSG_Get("PROGRAM_SETVER_GLOBAL"),
+			                            indent_size_1);
+			output.AddString("%s%d.%02d\n",
+			                 tmp_str.c_str(),
+			                 setver_table.version_global.major,
+			                 setver_table.version_global.minor);
+		}
+
+		is_empty_line_needed = true;
+	}
+
+	// Print version override by file name / by file path
+
+	auto print = [&](const NameVersionTable& table,
+	                 const size_t indent_size,
+	                 const char* batch_comment) {
+		if (table.empty()) {
+			return;
+		}
+
+		if (has_arg_batch) {
+			output.AddString(":: %s\n", batch_comment);
+		} else if (is_empty_line_needed) {
+			output.AddString("\n");
+		}
+
+		for (const auto& [name, version] : table) {
+			if (has_arg_batch) {
+				output.AddString("%s\"%s\" %d.%02d /q\n",
+				                 setver_command.c_str(),
+				                 name.c_str(),
+				                 version.major,
+				                 version.minor);
+			} else {
+				const auto tmp_str = indent(name, indent_size);
+				output.AddString("%s%d.%02d\n",
+				                 tmp_str.c_str(),
+				                 version.major,
+				                 version.minor);
+			}
+		}
+
+		is_empty_line_needed = !table.empty();
+	};
+
+	print(setver_table.by_file_name,
+	      indent_size_1,
+	      MSG_Get("PROGRAM_SETVER_BATCH_BY_FILE_NAME"));
+	print(setver_table.by_file_path,
+	      indent_size_2,
+	      MSG_Get("PROGRAM_SETVER_BATCH_BY_FILE_PATH"));
+
+	// Display the final result
+
+	if (is_empty_line_needed) {
+		output.AddString("\n");
+	}
+
+	output.Display();
+}
+
+void SETVER::AddToTable(const std::string& name, const FakeVersion& version)
+{
+	if (name.empty()) {
+		setver_table.version_global        = version;
+		setver_table.is_global_version_set = true;
+		return;
+	}
+
+	if (IsNameWithPath(name)) {
+		setver_table.by_file_path[name] = version;
+	} else {
+		setver_table.by_file_name[name] = version;
+	}
+}
+
+std::string SETVER::FindKeyCaseInsensitive(const std::string& key,
+                                           const NameVersionTable& table)
+{
+	for (const auto& [name, version] : table) {
+		if (iequals(name, key)) {
+			return name;
+		}
+	}
+
+	return {};
+}
+
+bool SETVER::IsTableEmpty()
+{
+	return !setver_table.is_global_version_set &&
+	       setver_table.by_file_name.empty() &&
+	       setver_table.by_file_path.empty();
+}
+
+void SETVER::OverrideVersion(const char* name, DOS_PSP& psp)
+{
+	assert(name);
+
+	// Check for global version override
+
+	if (setver_table.is_global_version_set) {
+		const auto& version = setver_table.version_global;
+		psp.SetVersion(version.major, version.minor);
+	}
+
+	// Get canonical file name
+
+	char buffer[DOS_PATHLENGTH];
+	if (!DOS_Canonicalize(name, buffer)) {
+		assert(false);
+		return;
+	}
+	std::string name_str = buffer;
+
+	// Check for version override - first by name with path
+
+	auto try_override = [&](const std::string& name_str,
+	                        const NameVersionTable& table) {
+		const auto key = FindKeyCaseInsensitive(name_str, table);
+		if (key.empty()) {
+			return false;
+		}
+		const auto& version = table.at(key);
+		psp.SetVersion(version.major, version.minor);
+		return true;
+	};
+
+	if (try_override(name_str, setver_table.by_file_path)) {
+		return;
+	}
+
+	// Check for version override by bare name, without path
+
+	if (setver_table.by_file_name.empty()) {
+		return;
+	}
+
+	const auto position = name_str.rfind('\\');
+	if (position + 1 >= name_str.size()) {
+		assert(false);
+		return;
+	}
+	name_str = name_str.substr(position + 1);
+	try_override(name_str, setver_table.by_file_name);
+}
+
+std::string SETVER::GetTableFilePath()
+{
+	// Original SETVER.EXE stores the version table in its own executable;
+	// this is not feasible in DOSBox, therefore we are using external file
+
+	const auto section = static_cast<Section_prop*>(control->GetSection("dos"));
+	if (!section) {
+		return {};
+	}
+
+	const Prop_path* file_path = section->Get_path("setver_table_file");
+	if (!file_path) {
+		return {};
+	}
+
+	return file_path->realpath;
+}
+
+static std::ostream& operator<<(std::ostream& stream, const SETVER::FakeVersion& version)
+{
+	assert(version.major <= 9);
+	assert(version.minor <= 99);
+
+	stream << static_cast<int>(version.major) << ".";
+	if (version.minor > 9) {
+		stream << static_cast<int>(version.minor);
+	} else {
+		stream << "0" << static_cast<int>(version.minor);
+	}
+
+	return stream;
+}
+
+void SETVER::LoadTableFromFile()
+{
+	// Do nothing if no file name specified in the configuration
+	const auto file_path = GetTableFilePath();
+	if (file_path.empty()) {
+		return;
+	}
+
+	// Helper warning lambdas
+
+	bool already_warned_format  = false;
+	bool already_warned_version = false;
+	bool already_warned_name    = false;
+
+	auto warn_file_format = [&]() {
+		if (already_warned_format) {
+			return;
+		}
+		LOG_WARNING("DOS: SETVER - table file seems to be of extended format, ignoring extra data");
+		already_warned_format = true;
+	};
+
+	auto warn_version_parse = [&]() {
+		if (already_warned_version) {
+			return;
+		}
+		LOG_WARNING("DOS: SETVER - problem parsing DOS version");
+		already_warned_version = true;
+	};
+
+	auto warn_file_name = [&]() {
+		if (already_warned_name) {
+			return;
+		}
+		LOG_WARNING("DOS: SETVER - problem parsing file name");
+		already_warned_name = true;
+	};
+
+	// If the file does not exists, save default settings there
+	if (!std_fs::exists(file_path)) {
+		SaveTableToFile();
+		return;
+	}
+
+	// Clear the table - but store previous as a backup
+	const auto backup_table            = setver_table;
+	setver_table.is_global_version_set = false;
+	setver_table.by_file_name.clear();
+	setver_table.by_file_path.clear();
+
+	// Read table from the file
+	std::ifstream file(file_path.c_str());
+	std::string line = {};
+	while (std::getline(file, line)) {
+		// Parse line
+		auto tokens = split(line, '\t');
+		// Skip empty lines
+		if (tokens.empty()) {
+			continue;
+		}
+		// Skip lines with only a single token, we are not currently
+		// using such lines
+		if (tokens.size() == 1) {
+			warn_file_format();
+			continue;
+		}
+		// Only consider first 2 tokens - ignore the remaining ones,
+		// might be needed for some extensions in the future
+		if (tokens.size() > 2) {
+			warn_file_format();
+			tokens.resize(2);
+		}
+		// First token should be a file name - it is quite likely the
+		// disk is not mounted yet, so allow non-existing files
+		constexpr bool allow_non_existing_files = true;
+		if (!tokens[0].empty() &&
+		    !PreprocessName(tokens[0], allow_non_existing_files)) {
+			warn_file_name();
+			continue;
+		}
+		// Second token should be a DOS version
+		FakeVersion version = {};
+		if (!ParseVersion(tokens[1], version)) {
+			warn_version_parse();
+			continue;
+		}
+		// Import row to the table
+		AddToTable(tokens[0], version);
+	}
+	if (file.bad()) {
+		setver_table = backup_table;
+		LOG_WARNING("DOS: SETVER - error reading table file");
+	}
+	file.close();
+}
+
+void SETVER::SaveTableToFile()
+{
+	// Do nothing if no file name specified in the configuration
+	const auto file_path = GetTableFilePath();
+	if (file_path.empty()) {
+		return;
+	}
+
+	// Write table into the file
+	std::ofstream file(file_path.c_str(), std::ios::trunc);
+	if (setver_table.is_global_version_set) {
+		file << "\t" << setver_table.version_global << '\n';
+	}
+	for (const auto& [name, version] : setver_table.by_file_name) {
+		file << name << "\t" << version << '\n';
+	}
+	for (const auto& [name, version] : setver_table.by_file_path) {
+		file << name << "\t" << version << '\n';
+	}
+	if (!file.good()) {
+		LOG_WARNING("DOS: SETVER - error saving table file");
+	}
+	file.close();
+}
+
+void SETVER::AddMessages()
+{
+	MSG_Add("PROGRAM_SETVER_HELP_LONG",
+	        "View or set the DOS version reported to applications.\n"
+	        "\n"
+	        "Usage:\n"
+	        "  [color=green]setver[reset] \\[/b] [/p]\n"
+	        "  [color=green]setver[reset] [color=cyan]FILE[reset] [color=cyan]VERSION[reset] [/q]\n"
+	        "  [color=green]setver[reset] [color=cyan]FILE[reset] /d [/q]\n"
+	        "  [color=green]setver[reset] [color=cyan]VERSION[reset] /g [/q]\n"
+	        "  [color=green]setver[reset] /d /g [/q]\n"
+	        "  [color=green]setver[reset] /d /all [/q]\n"
+	        "\n"
+	        "Where:\n"
+	        "  [color=cyan]FILE[reset]     is a file (optionally with path) to apply the settings to.\n"
+	        "  [color=cyan]VERSION[reset]  is a DOS version, in [color=white]n[reset].[color=white]nn[reset], [color=white]n[reset].[color=white]n[reset] or [color=white]n[reset] format.\n"
+	        "  /g       global setting, applied to all executables.\n"
+	        "  /d       delete entry from version table.\n"
+	        "  /all     together with /d clears the whole version table.\n"
+	        "  /b       display the list in a batch file format.\n"
+	        "  /p       display one page a time.\n"
+	        "  /q       quiet, skip confirmation messages.\n"
+	        "  /delete and /quiet have same meaning as /d and /q, respectively.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  For persistent version table, specify storage in the configuration file under\n"
+	        "  the [dos] section, using the 'setver_table_file = [color=cyan]STORAGE[reset]' setting.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=green]setver[reset] /b              ; displays settings as a batch file\n"
+	        "  [color=green]setver[reset] [color=cyan]RETRO.COM[reset] [color=white]6[reset].[color=white]22[reset]  ; reports DOS version 6.22 for every RETRO.COM file\n"
+	        "  [color=green]setver[reset] [color=cyan]RETRO.COM[reset] /d    ; stop overriding DOS version reported\n");
+
+	MSG_Add("PROGRAM_SETVER_WRONG_TABLE",
+	        "Only version table in Z:\\ directory is supported.");
+	MSG_Add("PROGRAM_SETVER_INVALID_VERSION", "Invalid DOS version.");
+
+	MSG_Add("PROGRAM_SETVER_TABLE_UPDATED", "Version table updated.");
+	MSG_Add("PROGRAM_SETVER_TABLE_CLEARED", "Version table cleared.");
+	MSG_Add("PROGRAM_SETVER_TABLE_ALREADY_EMPTY", "Version table already empty.");
+	MSG_Add("PROGRAM_SETVER_TABLE_ENTRY_REMOVED",
+	        "Entry removed from version table.");
+	MSG_Add("PROGRAM_SETVER_TABLE_ENTRY_NOT_FOUND",
+	        "Entry not found in version table.");
+
+	MSG_Add("PROGRAM_SETVER_TABLE_EMPTY", "Version table is empty.");
+	MSG_Add("PROGRAM_SETVER_GLOBAL", "Global reported version");
+
+	MSG_Add("PROGRAM_SETVER_BATCH_GLOBAL", "rule for every executable");
+	MSG_Add("PROGRAM_SETVER_BATCH_BY_FILE_NAME",
+	        "rules for matching by file name only");
+	MSG_Add("PROGRAM_SETVER_BATCH_BY_FILE_PATH",
+	        "rules for matching by file name with path");
+}

--- a/src/dos/program_setver.h
+++ b/src/dos/program_setver.h
@@ -1,0 +1,75 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PROGRAM_SETVER_H
+#define DOSBOX_PROGRAM_SETVER_H
+
+#include "programs.h"
+
+#include <map>
+
+class SETVER final : public Program {
+public:
+	SETVER()
+	{
+		AddMessages();
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::Misc,
+		               HELP_CmdType::Program,
+		               "SETVER"};
+	}
+	void Run();
+
+	static void LoadTableFromFile();
+	static void SaveTableToFile();
+
+	static void OverrideVersion(const char* name, DOS_PSP& psp);
+
+	struct FakeVersion {
+		uint8_t major = 0;
+		uint8_t minor = 0;
+	};
+
+	using NameVersionTable = std::map<std::string, SETVER::FakeVersion>;
+
+private:
+	static bool ParseVersion(const std::string& version_str, FakeVersion& version);
+	static bool PreprocessName(std::string& name,
+	                           const bool allow_non_existing_files = false);
+	static bool IsNameWithPath(const std::string& name);
+
+	void CommandDeletePerFile(const std::string& name, const bool has_arg_quiet);
+	void CommandDeleteGlobalOnly(const bool has_arg_quiet);
+	void CommandDeleteAll(const bool has_arg_quiet);
+	void CommandSet(const std::string& name, const std::string& version_str,
+	                const bool has_arg_quiet);
+	void CommandPrintAll(const bool has_arg_batch, const bool has_arg_paged);
+
+	static void AddToTable(const std::string& name, const FakeVersion& version);
+	static std::string FindKeyCaseInsensitive(const std::string& key,
+	                                          const NameVersionTable& table);
+	static bool IsTableEmpty();
+
+	static std::string GetTableFilePath();
+
+	void AddMessages();
+};
+
+#endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1169,6 +1169,12 @@ void DOSBOX_Init()
 	pstring->Set_help(
 	        "Language code of the keyboard layout, or 'auto' ('auto' by default).");
 
+	pstring = secprop->Add_path("setver_table_file", only_at_start, "");
+	pstring->Set_help(
+	        "File containing the list of applications and assigned DOS versions, in a\n"
+	        "tab-separated format, used by SETVER.EXE as a persistent storage\n"
+	        "(empty by default).");
+
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
 	secprop->AddInitFunction(&DRIVES_Init);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include "../dos/program_more_output.h"
+#include "../dos/program_setver.h"
 #include "autoexec.h"
 #include "callback.h"
 #include "control.h"
@@ -568,9 +569,12 @@ static char const * const init_line="/INIT AUTOEXEC.BAT";
 void SHELL_Init() {
 	// Generic messages, to be used by any command or DOS program
 	MSG_Add("SHELL_ILLEGAL_PATH", "Illegal path.\n");
+	MSG_Add("SHELL_ILLEGAL_FILE_NAME", "Illegal file name.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH", "Illegal switch: %s.\n");
+	MSG_Add("SHELL_ILLEGAL_SWITCH_COMBO", "Illegal switch combination.\n");
 	MSG_Add("SHELL_MISSING_PARAMETER", "Required parameter missing.\n");
 	MSG_Add("SHELL_TOO_MANY_PARAMETERS", "Too many parameters.\n");
+	MSG_Add("SHELL_EXPECTED_FILE_NOT_DIR", "Expected a file, not a directory.\n");
 	MSG_Add("SHELL_SYNTAX_ERROR", "Incorrect command syntax.\n");
 	MSG_Add("SHELL_ACCESS_DENIED", "Access denied - '%s'\n");
 	MSG_Add("SHELL_FILE_CREATE_ERROR", "File creation error - '%s'\n");
@@ -1153,23 +1157,19 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]path[reset]\n"
 	        "  [color=green]path[reset] [color=cyan]Z:\\;C:\\DOS[reset]\n");
-	MSG_Add("SHELL_CMD_VER_HELP", "View or set the reported DOS version.\n");
-	MSG_Add("SHELL_CMD_VER_HELP_LONG", "Usage:\n"
+	MSG_Add("SHELL_CMD_VER_HELP", "View the DOS version.\n");
+	MSG_Add("SHELL_CMD_VER_HELP_LONG",
+	        "Usage:\n"
 	        "  [color=green]ver[reset]\n"
-	        "  [color=green]ver[reset] [color=white]set[reset] [color=cyan]VERSION[reset]\n"
-	        "\n"
-	        "Where:\n"
-	        "  [color=cyan]VERSION[reset] can be a whole number, such as [color=cyan]5[reset], or include a two-digit decimal\n"
-	        "          value, such as: [color=cyan]6.22[reset], [color=cyan]7.01[reset], or [color=cyan]7.10[reset]. The decimal can alternatively be\n"
-	        "          space-separated, such as: [color=cyan]6 22[reset], [color=cyan]7 01[reset], or [color=cyan]7 10[reset].\n"
 	        "\n"
 	        "Notes:\n"
-	        "  The DOS version can also be set in the configuration file under the [dos]\n"
-	        "  section using the \"ver = [color=cyan]VERSION[reset]\" setting.\n"
+	        "  The DOS version can be set in the configuration file under the [dos] section,\n"
+	        "  using the 'ver = [color=cyan]VERSION[reset]' setting.\n"
+	        "  The DOS version reported to applications can be changed using [color=green]setver[reset] command.\n"
+	        "  Old '[color=green]ver[reset] [color=white]set[reset] [color=cyan]VERSION[reset]' syntax to change DOS version is deprecated.\n"
 	        "\n"
 	        "Examples:\n"
-	        "  [color=green]ver[reset] [color=white]set[reset] [color=cyan]6.22[reset]\n"
-	        "  [color=green]ver[reset] [color=white]set[reset] [color=cyan]7 10[reset]\n");
+	        "  [color=green]ver[reset]\n");
 	MSG_Add("SHELL_CMD_VER_VER", "DOSBox Staging version %s\n"
 	                             "DOS version %d.%02d\n");
 	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
@@ -1266,6 +1266,8 @@ void SHELL_Init() {
 	dos.dta(RealMake(psp_seg,0x80));
 	dos.psp(psp_seg);
 
+	// Load SETVER fake version table from external file
+	SETVER::LoadTableFromFile();
 
 	// first_shell is only setup here, so may as well invoke
 	// it's constructor directly

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2146,8 +2146,15 @@ void DOS_Shell::CMD_VER(char *args)
 	HELP("VER");
 	if (args && strlen(args)) {
 		char *word = strip_word(args);
-		if (strcasecmp(word, "set"))
+		if (strcasecmp(word, "set")) {
+			WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 			return;
+		}
+
+		// Despite declared as deprecated, we should probably never
+		// remove it, for compatibility with original DOSBox
+		LOG_WARNING("SHELL: Command 'ver set VERSION' is deprecated");
+
 		word = strip_word(args);
 		const auto new_version = DOS_ParseVersion(word, args);
 		if (new_version.major || new_version.minor) {

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -565,6 +565,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\dos\program_placeholder.cpp" />
     <ClCompile Include="..\src\dos\program_rescan.cpp" />
     <ClCompile Include="..\src\dos\program_serial.cpp" />
+    <ClCompile Include="..\src\dos\program_setver.cpp" />
     <ClCompile Include="..\src\dos\program_tree.cpp" />
     <ClCompile Include="..\src\fpu\fpu.cpp" />
     <ClCompile Include="..\src\gui\render.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -631,6 +631,9 @@
     <ClCompile Include="..\src\dos\program_serial.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_setver.cpp">
+      <Filter>src\dos</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\dos\program_tree.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>


### PR DESCRIPTION
This PR implements a `SETVER.EXE` utility, with nearly all extensions found in DR-DOS (this is the only extended version known to me; Microsoft has ditched this tool in modern Windows, so no more extensions should be expected from them).

The `ver set VERSION` command is "deprecated", but still mentioned in the documentation, I do not plan to remove it, ever. Unfortunately, this `ver` extended syntax isn't similar to other DOS commands at all, and it goes against the overall DOS design - but I guess we have to live with it - for sake of compatibility.

Technical reading regarding DOS version reporting and SETVER utility:
[https://www.geoffchappell.com/notes/dos/interrupts/21h/30h/index.htm](https://www.geoffchappell.com/notes/dos/interrupts/21h/30h/index.htm) 