### PR TITLE
[Draft] Update CONTRIBUTING.md documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,8 +129,9 @@ custom clang-format ruleset to make it crystal clear, skip to
    Using `snake_case` names for such functions is recommended.
 5. Do NOT use that convention for static functions (single file scope), class
    names, methods, enums, or other constructs.
-6. Class names and method names can use `CamelCase` or `snake_case`.
-   Be consistent, DON'T mix styles like this: `get_DefaultValue_Str` (bleh).
+6. Class names, method names, enum names and enum values may use `CamelCase` 
+   or `snake_case`. Be consistent, DON'T mix styles like this:
+   `get_DefaultValue_Str` (bleh).
 7. Using `snake_case` for variable names, parameter names, struct fields, and
    class fields is recommended.
 8. Use header guards in format: `DOSBOX_HEADERNAME_H` or
@@ -144,6 +145,11 @@ via email is also possible - contact maintainer about the details.
 
 Code submitted as raw source files (not patches), files attached to issue
 comments, forum posts, diffs in non-git format, etc will be promptly ignored.
+
+Any changes to README.md have to consider the project's latest stable release, 
+not the latest commit from the alpha version. New feature additions and removals
+related to changes from the alpha are added to the README.md as part of one of 
+the release steps, when we review all the documentation for release.
 
 #### Commit messages
 


### PR DESCRIPTION
[CONTRIBUTING.md](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md) needs to be clearer and contain more information. Right now, there are some unwritten rules that contributors are expected to follow, which creates easily preventable mistakes. Adding these rules to [CONTRIBUTING.md](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md) will prevent mistakes in the future and makes sure contributors can find all this information all in one place (as of now, contributors are required to keep up with the latest reviews from other unrelated Pull Requests to find some of this information). This is basically to prevent these types of situations (see https://github.com/dosbox-staging/dosbox-staging/pull/2456#discussion_r1186660771):

![firefox_5BpXc85UCz](https://github.com/dosbox-staging/dosbox-staging/assets/9662095/bc65e723-cb4c-4e48-8e51-a9b9297766b8)

**I'm making this a draft because:**

1. This needs to be discussed in-depth. Perhaps the entire file needs to be re-written or re-organized. 
2. I want to receive as many suggestions before nailing down a strategy for this problem and merging this into main
3. I need that frequent PR reviewers (like @johnnovak, @kcgen, @dreamer ... you know, the usual suspects) tell me what are the most frequent review topics and request-changes in the latest PRs (that are relevant to this and would benefit to being added on contributing.md)

Anyway, I hope my intent is clear from my words above. Have a nice day!