### PR TITLE
Add package download URL to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -93,6 +93,16 @@ body:
     validations:
       required: false
   - type: textarea
+    id: package_url
+    attributes:
+      label: Download URL of affected game or software
+      description: |
+        If a single game or program is affected, provide a download link to ensure we're using binary-exact files and version(s).
+        This is required unless the issue broadly applies.
+      placeholder: "example: https://archive.org/details/StarWarsX-wingDemo"
+    validations:
+      required: false
+  - type: textarea
     id: config_file
     attributes:
       label: Your configuration


### PR DESCRIPTION
### The issue being addressed

Many issues have been raised where the maintenance team was unable to reproduce the issue because the software being tested differed slightly from that used by the user reporting the issue.

### What this PR changes

If the issue affects a single game or program, the user is asked to input a download URL to the binary-exact package to ensure we are working with the same files and version(s).

Archive.org is given as the default example host, and given it's cleared to host all DOS preservation suites, there should be no reason why this cannot be provided.

If a user does not provide a download link for a game-specific issue, then maintainers should simply close out the ticket straight away.