### PR TITLE
Disable framebuffer acceleration for debugger

### DIFF
--- a/src/libs/PDCurses/sdl2_queue/pdcscrn.cpp
+++ b/src/libs/PDCurses/sdl2_queue/pdcscrn.cpp
@@ -277,6 +277,9 @@ int PDC_scr_open(void)
         env = getenv("PDC_COLS");
         pdc_swidth = (env ? atoi(env) : 80) * pdc_fwidth;
 
+        /* Workaround to not disrupt OpenGL context state in other windows. */
+        SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "0");
+
         constexpr uint32_t flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
 
         pdc_window = SDL_CreateWindow("PDCurses",


### PR DESCRIPTION
Single-line change, some details in the commit message. Only affects outputs that directly access window surface (so surface output, mapper, and debugger).

Closes #1824.