### PR TITLE
Don't auto-disable OpenGL for debugger-enabled builds on Linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -549,29 +549,10 @@ summary('SDL_image 2.0 support', sdl2_image_dep.found())
 
 # OpenGL
 opengl_dep = optional_dep
-opengl_summary_msg = 'Disabled'
-if get_option('use_opengl') != 'false'
+if get_option('use_opengl')
     opengl_dep = dependency('gl', not_found_message: msg.format('use_opengl'))
 endif
-if (
-    opengl_dep.found()
-    and host_machine.system() == 'linux'
-    and get_option('use_opengl') == 'auto'
-    and get_option('enable_debugger') != 'none'
-)
-
-    warning(
-        '''OpenGL is disabled because it's not compatible with the debugger.
-            To use OpenGL with the debugger, force it with "-Duse_opengl=true"''',
-    )
-
-    conf_data.set10('C_OPENGL', false)
-    opengl_summary_msg = 'Found, but disabled due to conflict with debugger'
-else
-    conf_data.set10('C_OPENGL', opengl_dep.found())
-    opengl_summary_msg = opengl_dep.found()
-endif
-summary('OpenGL support', opengl_summary_msg)
+conf_data.set10('C_OPENGL', opengl_dep.found())
 
 # FluidSynth (depends on glib)
 fluid_dep = optional_dep

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,9 +14,8 @@ option(
 
 option(
     'use_opengl',
-    type: 'combo',
-    choices: ['auto', 'true', 'false'],
-    value: 'auto',
+    type: 'boolean',
+    value: true,
     description: 'Enable OpenGL support',
 )
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -201,15 +201,15 @@ SDL_Block sdl;
 
 // Masks to be passed when creating SDL_Surface.
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-constexpr uint32_t RMASK = 0xff000000;
-constexpr uint32_t GMASK = 0x00ff0000;
-constexpr uint32_t BMASK = 0x0000ff00;
-constexpr uint32_t AMASK = 0x000000ff;
+[[maybe_unused]] constexpr uint32_t RMASK = 0xff000000;
+[[maybe_unused]] constexpr uint32_t GMASK = 0x00ff0000;
+[[maybe_unused]] constexpr uint32_t BMASK = 0x0000ff00;
+[[maybe_unused]] constexpr uint32_t AMASK = 0x000000ff;
 #else
-constexpr uint32_t RMASK = 0x000000ff;
-constexpr uint32_t GMASK = 0x0000ff00;
-constexpr uint32_t BMASK = 0x00ff0000;
-constexpr uint32_t AMASK = 0xff000000;
+[[maybe_unused]] constexpr uint32_t RMASK = 0x000000ff;
+[[maybe_unused]] constexpr uint32_t GMASK = 0x0000ff00;
+[[maybe_unused]] constexpr uint32_t BMASK = 0x00ff0000;
+[[maybe_unused]] constexpr uint32_t AMASK = 0xff000000;
 #endif
 
 // Size and ratio constants

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -990,23 +990,18 @@ static void set_vsync(const VSYNC_STATE state)
 		return;
 	}
 #endif
-	if (sdl.desktop.type == SCREEN_TEXTURE || sdl.desktop.type == SCREEN_SURFACE) {
-		// https://wiki.libsdl.org/SDL_HINT_RENDER_VSYNC - can only be
-		// set to "1", "0", adapative is currently not supported, so we
-		// also treat it as "1"
-		const auto hint_str = (state == VSYNC_STATE::ON ||
-		                       state == VSYNC_STATE::ADAPTIVE)
-		                              ? "1"
-		                              : "0";
-		if (SDL_SetHint(SDL_HINT_RENDER_VSYNC, hint_str) == SDL_TRUE)
-			return;
-		LOG_WARNING("SDL: Failed setting SDL's vsync state to to %s (%s): %s",
-		            vsync_state_as_string(state), hint_str, SDL_GetError());
+	assert (sdl.desktop.type == SCREEN_TEXTURE || sdl.desktop.type == SCREEN_SURFACE);
+	// https://wiki.libsdl.org/SDL_HINT_RENDER_VSYNC - can only be
+	// set to "1", "0", adapative is currently not supported, so we
+	// also treat it as "1"
+	const auto hint_str = (state == VSYNC_STATE::ON ||
+							state == VSYNC_STATE::ADAPTIVE)
+									? "1"
+									: "0";
+	if (SDL_SetHint(SDL_HINT_RENDER_VSYNC, hint_str) == SDL_TRUE)
 		return;
-	}
-	// Unhandled screen type
-	LOG_WARNING("SDL: Failed setting the vsync state to %s: unsupported screen type",
-	            vsync_state_as_string(state));
+	LOG_WARNING("SDL: Failed setting SDL's vsync state to to %s (%s): %s",
+				vsync_state_as_string(state), hint_str, SDL_GetError());
 }
 
 static void update_vsync_state()

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -923,21 +923,20 @@ static VSYNC_STATE get_reported_vsync()
 			            retval);
 			break;
 		}
+		return state;
 	}
 #endif
-	if (sdl.desktop.type == SCREEN_TEXTURE || sdl.desktop.type == SCREEN_SURFACE) {
-		const std::string_view retstr = SDL_GetHint(SDL_HINT_RENDER_VSYNC);
-		if (retstr == "1")
-			state = VSYNC_STATE::ON;
-		else if (retstr == "0")
-			state = VSYNC_STATE::OFF;
-		else if (retstr == "-1")
-			state = VSYNC_STATE::ADAPTIVE;
-		else
-			LOG_WARNING("SDL: Reported an unknown vsync state: %s",
-			            retstr.data());
-	}
-	assert(state != VSYNC_STATE::UNSET);
+	assert (sdl.desktop.type == SCREEN_TEXTURE || sdl.desktop.type == SCREEN_SURFACE);
+	const std::string_view retstr = SDL_GetHint(SDL_HINT_RENDER_VSYNC);
+	if (retstr == "1")
+		state = VSYNC_STATE::ON;
+	else if (retstr == "0")
+		state = VSYNC_STATE::OFF;
+	else if (retstr == "-1")
+		state = VSYNC_STATE::ADAPTIVE;
+	else
+		LOG_WARNING("SDL: Reported an unknown vsync state: %s",
+					retstr.data());
 	return state;
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3578,7 +3578,6 @@ std::optional<SDL_Surface *> SDLMAIN_GetRenderedSurface()
 {
 	// Variables common to all screen-modes
 	const auto renderer = SDL_GetRenderer(sdl.window);
-	const auto canvas   = get_canvas_size(sdl.desktop.type);
 
 #if C_OPENGL
 	// Get the OpenGL-renderer surface
@@ -3667,16 +3666,12 @@ std::optional<SDL_Surface *> SDLMAIN_GetRenderedSurface()
 
 	// We're already in surface-mode, how convenient ;)
 	// -----------------------------------------------
-	else if (sdl.desktop.type == SCREEN_SURFACE) {
-		assert(sdl.surface);
-		// Simply return a copy
-		return SDL_ConvertSurfaceFormat(sdl.surface,
-		                                sdl.surface->format->format,
-		                                0);
-	}
-
-	LOG_WARNING("SDL: unhandled screen-type (bug)");
-	return {};
+	assert(sdl.desktop.type == SCREEN_SURFACE);
+	assert(sdl.surface);
+	// Simply return a copy
+	return SDL_ConvertSurfaceFormat(sdl.surface,
+	                                sdl.surface->format->format,
+	                                0);
 }
 
 // extern void UI_Run(bool);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3589,6 +3589,7 @@ std::optional<SDL_Surface *> SDLMAIN_GetRenderedSurface()
 		constexpr int gl_bits_per_pixel = gl_channels * 8; // 8-bpp
 
 		// Allocate a 24-bit surface to be populated
+		const auto canvas = get_canvas_size(sdl.desktop.type);
 		const auto surface = SDL_CreateRGBSurface(SDL_SWSURFACE,
 		                                          canvas.w,
 		                                          canvas.h,
@@ -3642,6 +3643,7 @@ std::optional<SDL_Surface *> SDLMAIN_GetRenderedSurface()
 		const auto pixel_format = rinfo.texture_formats[0];
 
 		// Create a 32-bit surface with colour format matching the renderer
+		const auto canvas = get_canvas_size(sdl.desktop.type);
 		const auto surface = SDL_CreateRGBSurfaceWithFormat(
 		        SDL_SWSURFACE, canvas.w, canvas.h, 32, pixel_format);
 		if (!surface || !renderer) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4647,8 +4647,10 @@ void restart_program(std::vector<std::string> & parameters) {
 	// parameter 0 is the executable path
 	// contents of the vector follow
 	// last one is NULL
-	for(Bitu i = 0; i < parameters.size(); i++) newargs[i] = (char*)parameters[i].c_str();
-	newargs[parameters.size()] = NULL;
+	for (size_t i = 0; i < parameters.size(); i++) {
+		newargs[i] = parameters[i].data();
+	}
+	newargs[parameters.size()] = nullptr;
 	MIXER_CloseAudioDevice();
 	Delay(50);
 	QuitSDL();


### PR DESCRIPTION
Now that @GranMinigun has fixed OpenGL when used with the debugger, this PR reverts the exclusion of OpenGL in debugger builds.