### PR TITLE
Drop Visual Studio 2019-specific accomodations in `.clang-format` 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,11 +32,8 @@ Standard: c++17
 # int& var; // 'var' is a reference-to-int
 # const int& var; // 'var' is a constant-reference-to-int
 PointerAlignment: Left
-# Commenting out for now as VisualStudio 2019 doesn't recognise it
-#ReferenceAlignment: Left
-
-# Commenting out for now as VisualStudio 2019 doesn't recognise it
-#QualifierAlignment: Left
+ReferenceAlignment: Left
+QualifierAlignment: Left
 
 # The extra indent or outdent of class access modifiers, e.g. public:
 #
@@ -190,8 +187,7 @@ AlwaysBreakTemplateDeclarations: Yes
 #      --i;                                      --i;
 #    while (i);
 #
-# Commenting out for now as VisualStudio 2019 doesn't recognise it
-#InsertBraces: true
+InsertBraces: true
 
 # Attach braces to surrounding context except break before braces on function
 # definitions (also known as K&R indentation style). This is C-derived style,


### PR DESCRIPTION
These were added to accommodate VS2019, with the cost of now missing out on automatic formatting improvements, like adding brackets around `for`, `while`, and `if/else` bodies.

Because the majority of contributors are using Linux or macOS, and that Windows users can still run the formatter from MSYS2 or us VS2022 instead of VS2019, the cost of this change (loss of very valuable formatting) outweighs the benefit to Windows VS2019 users (who are few in number and still have other options to run the formatter).