### PR TITLE
Let the VESA 8-bit mode draw lines from the DAC palette

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -595,7 +595,7 @@ void VGA_StartUpdateLFB(void);
 void VGA_SetBlinking(uint8_t enabled);
 void VGA_SetCGA2Table(uint8_t val0,uint8_t val1);
 void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3);
-void VGA_ActivateHardwareCursor(void);
+uint8_t VGA_ActivateHardwareCursor();
 void VGA_KillDrawing(void);
 
 void VGA_SetOverride(bool vga_override);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -51,7 +51,8 @@ static_assert(SCALER_MAXWIDTH >= SCALER_MAX_MUL_WIDTH * max_scan_doubled_width);
 constexpr auto max_pixel_bytes = sizeof(uint32_t);
 constexpr auto max_line_bytes  = SCALER_MAXWIDTH * max_pixel_bytes;
 
-static std::array<uint8_t, max_line_bytes> templine_buffer;
+// The line buffer can be written in units up to RGB888 pixels (32-bit) size
+alignas(uint32_t) static std::array<uint8_t, max_line_bytes> templine_buffer;
 static auto TempLine = templine_buffer.data();
 
 static uint8_t * VGA_Draw_1BPP_Line(Bitu vidstart, Bitu line) {

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1339,6 +1339,20 @@ uint8_t VGA_ActivateHardwareCursor()
 		// 8-bit palette LUT and prepares the high-colour pixels for
 		// rendering.
 		break;
+	case M_LIN8: // 8-bit VESA
+		if (should_draw_with_hw_mouse()) {
+			VGA_DrawLine = VGA_Draw_VGA_Line_HWMouse;
+		} else {
+			bit_per_line_pixel = 32;
+			VGA_DrawLine = draw_unwrapped_line_from_dac_palette;
+			//
+			// Use a routine that treats the 8-bit pixel values as
+			// indexes into the DAC's palette LUT. The palette LUT
+			// is populated with 32-bit RGB's (XRGB888) pre-scaled
+			// from 18-bit RGB666 values that have been written by
+			// the user-space software via DAC IO write registers.
+		}
+		break;
 	default:
 		VGA_DrawLine = should_draw_with_hw_mouse()
 		                     ? VGA_Draw_VGA_Line_HWMouse

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -117,7 +117,7 @@ void SVGA_S3_WriteCRTC(io_port_t reg, io_val_t value, io_width_t)
 	case 0x45:  /* Hardware cursor mode */
 		vga.s3.hgc.curmode = val;
 		// Activate hardware cursor code if needed
-		VGA_ActivateHardwareCursor();
+		(void)VGA_ActivateHardwareCursor();
 		break;
 	case 0x46:
 		vga.s3.hgc.originx = (vga.s3.hgc.originx & 0x00ff) | (val << 8);


### PR DESCRIPTION
Previously the 8-bit VESA mode's line drawing routine wasn't doing DAC palette lookups.  This adds an equivalent linear lookup routine, but adds palette lookup.

Fixes #2486 

For VGA 640x480+ modes that 8-bit VESA is typically used in, rendering is still performed in bulk at the end of the frame instead of paced out per-line because so far we haven't seen games or demos perform DAC's palette effects mid-frame in 640x480+ modes.