### PR TITLE
Further debloat of paging arrays

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -162,8 +162,8 @@ struct PagingBlock {
 	} base = {};
 #if defined(USE_FULL_TLB)
 	struct {
-		HostPt read[TLB_SIZE]  = {};
-		HostPt write[TLB_SIZE] = {};
+		std::vector<HostPt> read = std::vector<HostPt>(TLB_SIZE);
+		std::vector<HostPt> write = std::vector<HostPt>(TLB_SIZE);
 
 		std::vector<PageHandler*> readhandler  = std::vector<PageHandler*>(TLB_SIZE);
 		std::vector<PageHandler*> writehandler = std::vector<PageHandler*>(TLB_SIZE);


### PR DESCRIPTION
Following on #2101, @kcgen was there a performance or compatibility reason `read` and `write` weren't `std::vector`-ized?