### PR TITLE
Create and update joy binds even when physical joysticks aren't present

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -627,6 +627,7 @@ public:
 		set_joystick_led(sdl_joystick, on_color);
 		if (sdl_joystick==NULL) {
 			button_wrap=emulated_buttons;
+			axes=MAXAXIS;
 			return;
 		}
 
@@ -2821,7 +2822,6 @@ static void QueryJoysticks()
 	if (num_joysticks < 0) {
 		LOG_WARNING("MAPPER: SDL_NumJoysticks() failed: %s", SDL_GetError());
 		LOG_WARNING("MAPPER: Skipping further joystick checks");
-		joytype = JOY_NONE_FOUND;
 		return;
 	}
 
@@ -2830,7 +2830,6 @@ static void QueryJoysticks()
 	mapper.sticks.num = static_cast<unsigned int>(num_joysticks);
 	if (num_joysticks == 0) {
 		LOG_MSG("MAPPER: no joysticks found");
-		joytype = JOY_NONE_FOUND;
 		return;
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3949,14 +3949,12 @@ bool GFX_Events()
 
 	SDL_Event event;
 #if defined (REDUCE_JOYSTICK_POLLING)
-	if (MAPPER_IsUsingJoysticks()) {
-		static auto last_check_joystick = GetTicks();
-		auto current_check_joystick = GetTicks();
-		if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
-			last_check_joystick = current_check_joystick;
-			SDL_JoystickUpdate();
-			MAPPER_UpdateJoysticks();
-		}
+	static auto last_check_joystick = GetTicks();
+	auto current_check_joystick = GetTicks();
+	if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
+		last_check_joystick = current_check_joystick;
+		if (MAPPER_IsUsingJoysticks()) SDL_JoystickUpdate();
+		MAPPER_UpdateJoysticks();
 	}
 #endif
 	while (SDL_PollEvent(&event)) {


### PR DESCRIPTION
This has been broken since my change (#154) in 2019.

Emulated joysticks are still sticky when key-repeat occurs, but this is a separate issue (was not caused by my 2019 PR).

Resolves issue #2474