### PR TITLE
Make the RWQueue more usable for complex types

### DIFF
--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -40,6 +40,7 @@
 #include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 template <typename T>
@@ -96,8 +97,9 @@ public:
 	// in the queue to dequeue.
 
 	// If queuing has stopped, this will continue to return item(s) until
-	// none remain in the queue, at which point it immediately returns T{}.
-	T Dequeue();
+	// none remain in the queue, at which point it returns empty results
+	// as indicated by the <optional> wrapper evaluating as "false".
+	std::optional<T> Dequeue();
 
 	// Bulk operations move multiple items from/to the given vector, which
 	// signficantly reduces the number of mutex lock state changes. It also

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -36,7 +36,7 @@
 
 class MidiHandlerFluidsynth final : public MidiHandler {
 public:
-	MidiHandlerFluidsynth();
+	MidiHandlerFluidsynth() = default;
 	~MidiHandlerFluidsynth() override;
 	void PrintStats();
 
@@ -84,8 +84,6 @@ private:
 	// versus the current MIDI Sysex or Msg event.
 	double last_rendered_ms = 0.0;
 	double ms_per_audio_frame = 0.0;
-
-	std::atomic_bool keep_rendering = {};
 
 	bool had_underruns = false;
 	bool is_open       = false;

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -52,7 +52,7 @@ class MidiHandler_mt32 final : public MidiHandler {
 public:
 	using service_t = std::unique_ptr<MT32Emu::Service>;
 
-	MidiHandler_mt32();
+	MidiHandler_mt32() = default;
 	~MidiHandler_mt32() override;
 	void Close() override;
 
@@ -95,8 +95,6 @@ private:
 	// versus the current MIDI Sysex or Msg event.
 	double last_rendered_ms = 0.0;
 	double ms_per_audio_frame = 0.0;
-
-	std::atomic_bool keep_rendering = {};
 
 	bool had_underruns = false;
 	bool is_open       = false;


### PR DESCRIPTION
To support the upcoming overhauled capturing PR, this adds to `RWQueue`:
 - `Stop()`, as a way to stop and the queue from accepting more items and freeing the need for these controls on the user-side.
 - `IsRunning()`, to check if the queue is still accepting new items.
 - `IsRunning() || !IsEmpty()`, can be used tell when no remaining items are left in the queue
 - `<optional>` return value from `Dequeue()`, to allow the using-side to test if the value is available.
