### PR TITLE
Prefer evdev mouse API over xinput on Linux

### DIFF
--- a/src/libs/manymouse/manymouse.c
+++ b/src/libs/manymouse/manymouse.c
@@ -5,6 +5,8 @@
  * Please see the file LICENSE.txt in the source's root directory.
  *
  *  This file written by Ryan C. Gordon.
+ *  Altered to:
+ *   - prefer modern evdev API over xinput on Linux, by Roman Standzikowski.
  */
 
 #include <stdlib.h>
@@ -31,8 +33,8 @@ extern const ManyMouseDriver *ManyMouseDriver_xinput2;
  */
 static const ManyMouseDriver **mice_drivers[] =
 {
-    &ManyMouseDriver_xinput2,
     &ManyMouseDriver_evdev,
+    &ManyMouseDriver_xinput2,
     &ManyMouseDriver_windows,
     &ManyMouseDriver_hidmanager,
     &ManyMouseDriver_hidutilities,


### PR DESCRIPTION
Changed ManyMouse default API on Linux to `evdev`. It is a more modern approach, the `xinput` is more like legacy today - moreover, in my test `evdev` driver is better at identifying which logical USB device is actually a mouse and which, is not -  for example in case of keyboard advertising it's configuration interface as a device.