### PR TITLE
Fix problem with some software (like MSD.EXE) displaying garbage mouse driver info

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -205,6 +205,16 @@ constexpr uint32_t clamp_to_uint32(const T val)
 	return static_cast<uint32_t>(std::clamp(val, min_val, max_val));
 }
 
+constexpr uint8_t read_low_nibble(const uint8_t byte)
+{
+	return static_cast<uint8_t>(byte & 0x0f);
+}
+
+constexpr uint8_t read_high_nibble(const uint8_t byte)
+{
+	return static_cast<uint8_t>(byte >> 4);
+}
+
 inline float decibel_to_gain(const float decibel)
 {
 	return powf(10.0f, decibel / 20.0f);


### PR DESCRIPTION
Implements 3 functions returning mouse driver information - prevents some software from displaying garbage, like _Path to MOUSE.INI_ on screenshot below:

![msd_000](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/f9bbfdc7-283e-4cdf-b9cc-752d743cb340)
