### PR TITLE
Copy only the available command line chars

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -40,7 +40,8 @@
 #endif
 struct CommandTail{
 	uint8_t count = 0;     /* number of bytes returned */
-	char buffer[127] = {}; /* the buffer itself */
+	static constexpr size_t MaxCmdtailBufferSize = 126;
+	char buffer[MaxCmdtailBufferSize + 1] = {}; /* the buffer itself */
 } GCC_ATTRIBUTE(packed);
 #ifdef _MSC_VER
 #pragma pack ()

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -533,14 +533,10 @@ static void run_binary_executable(const std::string_view fullname,
 	full_arguments.assign(args);
 
 	/* Fill the command line */
-	CommandTail cmdtail                    = {};
-	constexpr auto max_cmdtail_buffer_size = 126;
-	std::copy_n(args.begin(), max_cmdtail_buffer_size, cmdtail.buffer);
-
-	cmdtail.count = args.size() > max_cmdtail_buffer_size
-	                      ? max_cmdtail_buffer_size
-	                      : static_cast<uint8_t>(args.size());
-
+	CommandTail cmdtail = {};
+	cmdtail.count       = static_cast<uint8_t>(
+                std::min(args.size(), CommandTail::MaxCmdtailBufferSize));
+	std::copy_n(args.begin(), cmdtail.count, cmdtail.buffer);
 	cmdtail.buffer[cmdtail.count] = '\r';
 
 	/* Copy command line in stack block too */


### PR DESCRIPTION
Prevent buffer overflow or MSVC STL assert on overflow