### PR TITLE
Switch back to `std::deque` in setup but with indexed access

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -25,6 +25,7 @@
 #include "dosbox.h"
 
 #include <cstdio>
+#include <deque>
 #include <list>
 #include <map>
 #include <memory>
@@ -296,8 +297,8 @@ private:
 	// changeable_at_runtime indicates it can be called on configuration
 	// changes
 	struct Function_wrapper {
-		SectionFunction function   = nullptr;
-		bool changeable_at_runtime = false;
+		SectionFunction function;
+		bool changeable_at_runtime;
 
 		Function_wrapper(const SectionFunction fn, bool ch)
 		        : function(fn),
@@ -305,10 +306,10 @@ private:
 		{}
 	};
 
-	std::list<Function_wrapper> early_init_functions = {};
-	std::list<Function_wrapper> initfunctions        = {};
-	std::list<Function_wrapper> destroyfunctions     = {};
-	std::string sectionname                          = {};
+	std::deque<Function_wrapper> early_init_functions = {};
+	std::deque<Function_wrapper> initfunctions        = {};
+	std::deque<Function_wrapper> destroyfunctions     = {};
+	std::string sectionname                           = {};
 
 public:
 	Section() = default;
@@ -350,9 +351,9 @@ class PropMultiValRemain;
 
 class Section_prop final : public Section {
 private:
-	std::list<Property*> properties = {};
-	typedef std::list<Property*>::iterator it;
-	typedef std::list<Property*>::const_iterator const_it;
+	std::deque<Property*> properties = {};
+	typedef std::deque<Property*>::iterator it;
+	typedef std::deque<Property*>::const_iterator const_it;
 
 public:
 	Section_prop(const std::string& name) : Section(name) {}

--- a/include/setup.h
+++ b/include/setup.h
@@ -292,13 +292,13 @@ public:
 typedef void (*SectionFunction)(Section*);
 
 class Section {
-private:
+public:
 	// Wrapper class around startup and shutdown functions. the variable
 	// changeable_at_runtime indicates it can be called on configuration
 	// changes
 	struct Function_wrapper {
-		SectionFunction function;
-		bool changeable_at_runtime;
+		SectionFunction function   = nullptr;
+		bool changeable_at_runtime = false;
 
 		Function_wrapper(const SectionFunction fn, bool ch)
 		        : function(fn),
@@ -306,10 +306,14 @@ private:
 		{}
 	};
 
+private:
 	std::deque<Function_wrapper> early_init_functions = {};
-	std::deque<Function_wrapper> initfunctions        = {};
-	std::deque<Function_wrapper> destroyfunctions     = {};
-	std::string sectionname                           = {};
+	std::deque<Function_wrapper> init_functions         = {};
+	std::deque<Function_wrapper> pending_init_functions = {};
+	std::deque<Function_wrapper> destroyfunctions       = {};
+	std::string sectionname                             = {};
+
+	bool is_executing_init_functions = false;
 
 public:
 	Section() = default;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -3151,11 +3151,6 @@ void MAPPER_StartUp(Section* sec)
 	assert(sec);
 	Section_prop* section = static_cast<Section_prop*>(sec);
 
-	// Runs after this function ends and for subsequent `config -set "sdl
-	// mapperfile=file.map"` commands
-	constexpr auto changeable_at_runtime = true;
-	section->AddInitFunction(&MAPPER_BindKeys, changeable_at_runtime);
-
 	// Runs one-time on shutdown
 	section->AddDestroyFunction(&MAPPER_Destroy);
 	MAPPER_AddHandler(&MAPPER_Run, SDL_SCANCODE_F1, PRIMARY_MOD, "mapper", "Mapper");

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1226,7 +1226,7 @@ void Section::ExecuteInit(bool initall)
 
 void Section::ExecuteDestroy(bool destroyall)
 {
-	typedef std::list<Function_wrapper>::iterator func_it;
+	typedef std::deque<Function_wrapper>::iterator func_it;
 
 	for (func_it tel = destroyfunctions.begin(); tel != destroyfunctions.end();) {
 		if (destroyall || (*tel).changeable_at_runtime) {


### PR DESCRIPTION
The stronger STL checks added in commit cb7c21e reported that a deque iterator was not increment-able.

`"Error: attempt to increment a singular iterator."`

This commit PR switches to indexed lookups.