### PR TITLE
Avoid checked-STL false positives in Coverity build

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -78,7 +78,8 @@ jobs:
         run: |
           set -xeu
           CC="clang" CXX="clang++" meson setup \
-          -Dbuildtype=debug \
+          -Dbuildtype=minsize \
+          -Db_ndebug=false \
           -Dunit_tests=disabled \
           -Duse_alsa=false \
           -Duse_fluidsynth=false \


### PR DESCRIPTION
The recent checked-STL GCC and Clang Linux build flags have generated 30+ false-positives in Coverity.  For example (in this case, the header is part of the STL):

![2023-05-30_17-22](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/370aa95a-83d9-467f-bb50-f177248d6f02)
