### PR TITLE
 Adapt to setup function additions

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -307,7 +307,7 @@ private:
 	};
 
 	std::deque<Function_wrapper> early_init_functions = {};
-	std::deque<Function_wrapper> initfunctions        = {};
+	std::deque<Function_wrapper> init_functions       = {};
 	std::deque<Function_wrapper> destroyfunctions     = {};
 	std::string sectionname                           = {};
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -3154,7 +3154,7 @@ void MAPPER_StartUp(Section* sec)
 	// Runs after this function ends and for subsequent `config -set "sdl
 	// mapperfile=file.map"` commands
 	constexpr auto changeable_at_runtime = true;
-	section->AddEarlyInitFunction(&MAPPER_BindKeys, changeable_at_runtime);
+	section->AddInitFunction(&MAPPER_BindKeys, changeable_at_runtime);
 
 	// Runs one-time on shutdown
 	section->AddDestroyFunction(&MAPPER_Destroy);


### PR DESCRIPTION
The addition of the checked STL flags (on Linux) caused crashes inside the Setup class' `ExecuteInit()`. 

The crash happens because the container that ExecuteInit is looping over gets modified (appended to) mid-iteration, which invalidates the loop iterator.

A prior attempt to avoid this moved the appended chunk to a separate container (EarlyInit), however this broke the startup sequence for the mapper.

A prior attempt to solve this also failed:
- #2557

This PR is now a third attempt to handle the modified container (and avoid crashing with the checked STL) while also keeping the original mapper placement so the startup sequence/functionality is retained.