### PR TITLE
Never hard-exit DOSBox when an x87 FPU stack overflow is detected

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -187,7 +187,7 @@ static inline void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr
 #define DB_FPU_STACK_CHECK_PUSH DB_FPU_STACK_CHECK_EXIT
 #else
 #define DB_FPU_STACK_CHECK_POP DB_FPU_STACK_CHECK_NONE
-#define DB_FPU_STACK_CHECK_PUSH DB_FPU_STACK_CHECK_EXIT
+#define DB_FPU_STACK_CHECK_PUSH DB_FPU_STACK_CHECK_NONE
 #endif
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2546

There's no good reason to take such a drastic measure as to hard exit DOSBox when an FPU stack overflow is detected. Real hardware does not do that; the FPU stack over/underflow just happens and sets the overflow bit that the application can optionally inspect and recover from it, etc.

This can prevent programs that cause x87 stack over/underflows but recover from them later from running. I've run into one such example, see linked ticket with repro pack.