### PR TITLE
De-SDL voodoo threading

### DIFF
--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -1,0 +1,66 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <condition_variable>
+#include <mutex>
+
+/*
+ * A Semaphore class for synchronizing threads.
+ *
+ * This Semaphore implementation uses a count to represent the number of 
+ * available resources, along with a mutex and a condition variable to 
+ * handle synchronization between threads.
+ */
+class Semaphore {
+public:
+    /**
+     * Constructs a new Semaphore.
+     *
+     * @param count The initial count. Defaults to 0.
+     */
+    Semaphore(int count = 0) : count(count) {}
+
+    /**
+     * Decrements (acquires) the semaphore. If the count is 0, this will block
+     * until another thread calls notify().
+     */
+    void wait() {
+        std::unique_lock lock(mtx);
+        while (count == 0) {
+            cv.wait(lock);
+        }
+        --count;
+    }
+
+    /**
+     * Increments (releases) the semaphore, potentially unblocking a thread
+     * currently waiting on wait().
+     */
+    void notify() {
+        std::unique_lock lock(mtx);
+        ++count;
+        cv.notify_one();
+    }
+
+private:
+    std::mutex mtx             = {};    // Mutex to protect count.
+    std::condition_variable cv = {};    // Condition variable for the count.
+    int count                  = 0;     // Current count.
+};

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -75,6 +75,7 @@ unit_tests = [
     {'name': 'iohandler_containers', 'deps': [libmisc_stubs_dep]},
     {'name': 'math_utils', 'deps': [libmisc_stubs_dep]},
     {'name': 'rwqueue', 'deps': [libmisc_stubs_dep]},
+    {'name': 'semaphore', 'deps': [libmisc_stubs_dep]},
     {'name': 'setup', 'deps': [libmisc_stubs_dep]},
     {'name': 'shell_cmds', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'shell_redirection', 'deps': [dosbox_dep], 'extra_cpp': []},

--- a/tests/semaphore_tests.cpp
+++ b/tests/semaphore_tests.cpp
@@ -1,0 +1,44 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <gtest/gtest.h>
+#include <thread>
+#include "semaphore.h"  // assuming the semaphore class is defined in this header
+
+class SemaphoreTest : public ::testing::Test {
+protected:
+    Semaphore semaphore{0};
+    bool done = false;
+};
+
+TEST_F(SemaphoreTest, TestNotify) {
+    std::thread worker([&]() {
+        semaphore.wait();
+        // At this point, the semaphore should have been notified by the main thread.
+        done = true;
+    });
+
+    // The worker thread should be waiting on the semaphore at this point.
+    semaphore.notify();
+
+    worker.join();
+
+    EXPECT_TRUE(done);
+}


### PR DESCRIPTION
Migrate all Voodoo SDL threading-related code to C++17. Add a simple semaphore implementation to replace SDL's semaphore. 

Mostly this is just an excuse for me to get a bit more experience with C++ threading; I didn't notice any tangible performance benefits.