### PR TITLE
Fix VESA 256 / 8-bit in Windows 3.1

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -651,7 +651,7 @@ static uint8_t * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 }
 
 static const uint8_t* VGA_Text_Memwrap(Bitu vidstart) {
-	vidstart &= vga.draw.linear_mask;
+	vidstart = vidstart & vga.draw.linear_mask;
 	Bitu line_end = 2 * vga.draw.blocks;
 	if (GCC_UNLIKELY((vidstart + line_end) > vga.draw.linear_mask)) {
 		// wrapping in this line

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -352,7 +352,8 @@ static uint8_t * VGA_Draw_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 	return ret;
 }
 
-static uint8_t* draw_unwrapped_line_from_dac_palette(Bitu vidstart, Bitu)
+static uint8_t* draw_unwrapped_line_from_dac_palette(Bitu vidstart,
+                                                     [[maybe_unused]] const Bitu line = 0)
 {
 	// Quick references
 	static constexpr auto palette_map        = vga.dac.palette_map;


### PR DESCRIPTION
The move the `vgaonly` broke Windows 3.1 in 256 colour-mode; screenshots of the damage, courtesy @johnnovak :

#### Windows 3.11 desktop

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/de3e111b-f144-437c-8cfa-ba29a436644b)

#### Myst

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/a5c8a17d-6ea5-47ab-9ca1-74fe91ad0a8c)

The `vgamode` transition included lookup of RGB666 (18-bit) palette values for VESA 256-colour modes, however drawing the hardware cursor was still done using the original non-palette lookup routine. This adapts the current HW cursor draw routine to use palette as well.
