### PR TITLE
Fix incorrect pixel aspect ratio calculation for all text modes

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2151,8 +2151,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	vga.changes.frame = 0;
 	vga.changes.writeMask = 1;
 #endif
-	// Cheap hack to make all > 640x480 modes have square pixels
-	if (is_high_resolution(width, height)) {
+	// Cheap hack to make all > 640x480 modes have square pixels.
+	// Leave text modes alone because more than 480 line text modes all
+	// feature non-square pixels.
+	const auto is_text_mode = CurMode->type & M_TEXT_MODES;
+	if (!is_text_mode && is_high_resolution(width, height)) {
 		aspect_ratio = 1.0;
 	}
 //	LOG_MSG("ht %d vt %d ratio %f", htotal, vtotal, aspect_ratio );


### PR DESCRIPTION
The pixel aspect ratio (PAR) calculation logic employs a simple "high resolution hack" to set the PAR of all high-res modes starting from 640x480 to 1:1 (square pixels). The problem is that some text modes that use 480 lines or more need non-square pixels to appear correct.

I've tested some of these modes on my S3 card on a CRT and yes, they get stretched to fullscreen.

This change excludes all text modes from the "high-res square pixels hack" which fixes the PAR for the following text modes:

```
VGA
   720x688  80x43 (mode 019h)
   640x480  80x60 (mode 043h)
  1056x480 132x60 (mode 064h)

VESA
   640x480  80x60 (mode 108h)
  1056x688 132x43 (mode 10Ah)
  1056x480 132x60 (mode 10Ch)

Tseng
  1056x688 132x44 (mode 018h)
  1056x688 132x44 (mode 022h)

Paradise
  1056x688 132x43 (mode 054h)
  1056x688 132x43 (mode 056h)
```

## Example (VESA 132x60, mode 10Ch)

### Incorrect (square pixels)

![image0049](https://github.com/dosbox-staging/dosbox-staging/assets/698770/39327ea9-e068-439d-ab74-320d68dbb804)

### Correct (1:1.58 PAR)

```
DISPLAY: Text 1056x480 16-colour (mode 10Ch) at 69.968 Hz VFR, scaled to 2206x1586 with 1:1.58 pixel aspect ratio
```
![image0048](https://github.com/dosbox-staging/dosbox-staging/assets/698770/b8bb99c7-c35d-4797-b015-6b84c3718746)



