### PR TITLE
Include low width resolution in VGA scanning citeria

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1412,6 +1412,11 @@ static bool is_high_resolution(const video_mode_block_iterator_t mode_block)
 	return is_high_resolution(mode_block->swidth, mode_block->sheight);
 }
 
+static bool is_width_low_resolution(const uint16_t width)
+{
+	return width <= 320 || vga.seq.clocking_mode.is_pixel_doubling;
+}
+
 // A single point to set total draw lines and update affected parameters
 static void set_total_lines_to_draw(const uint32_t total_lines)
 {
@@ -1793,7 +1798,9 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	switch (vga.mode) {
 	case M_VGA:
 		width<<=2;
-		if (CurMode->sheight < 350) {
+		// Consider double or single-scanning if the mode itself is
+		// sub-350 line or the set width is assessed as a low resolution.
+		if (CurMode->sheight < 350 || is_width_low_resolution(width)) {
 			// Always round up odd number of lines
 			const auto height_is_odd = (height % 2 != 0);
 			if (height_is_odd) {


### PR DESCRIPTION
- Fixes #2577

Dyna Blaster uses mode `12h`, which is a 640x480 resolution and thus fails to meet the previous `CurMode->sheight < 350` criteria for single and double scanning, despite the game tweaking the timings to actually draw only 256x232.

This commit now includes low width resolutions (<=320) or indication via the Sequence Clocking Mode Register (Index 01h) Dot Clock Rate (DCR) bit.

When the DCR bit is set to 1, the master clock will be divided by 2 to generate the dot clock. All other timings are affected because they are derived from the dot clock. The dot clock divided by 2 is used for 320 and 360 horizontal PEL modes.

Ref:
  Hardware Level VGA and SVGA Video Programming Information Page
  http://www.osdever.net/FreeVGA/vga/seqreg.htm

---

### Double scanned (default)

![2023-06-07_23-40](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/c80b90b5-8334-4b89-aa9e-27532e49ccd5)

### Single scanned (`force_vga_single_scan = true`)

`DISPLAY: VGA 256x232 256-colour (mode 12h) at 59.94 Hz`

For those professional bomberman players curious about single-scan mode: yes, the bomb sizing still meet e-sports tournament regulations using the edge-to-edge method.

![2023-06-07_23-58](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/819ba4e7-7afb-4f01-9623-406002b5fac9)


https://compete.playstation.com/en-ca/all/articles/super-bomberman-r-online-esports-tournaments-competitions-events :wink: 