### PR TITLE
Let only one device reserve a DMA channel at a time

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 318
+          MAX_BUGS: 317
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/dma.h
+++ b/include/dma.h
@@ -44,15 +44,15 @@ using DMA_Callback = std::function<void(DmaChannel *chan, DMAEvent event)>;
 class DmaChannel {
 public:
 	// Defaults at the time of initialization
-	uint32_t pagebase = 0;
+	uint32_t page_base = 0;
 	uint32_t curr_addr = 0;
 
 	uint16_t base_addr = 0;
 	uint16_t base_count  = 0;
 	uint16_t curr_count  = 0;
 
-	const uint8_t channum = 0;
-	uint8_t pagenum = 0;
+	const uint8_t chan_num = 0;
+	uint8_t page_num = 0;
 	const uint8_t DMA16 = 0;
 
 	bool increment = true;

--- a/include/dma.h
+++ b/include/dma.h
@@ -39,7 +39,7 @@ class Section;
 using DMA_ReservationCallback = std::function<void(Section*)>;
 
 class DmaChannel;
-using DMA_Callback = std::function<void(DmaChannel* chan, DMAEvent event)>;
+using DMA_Callback = std::function<void(const DmaChannel* chan, DMAEvent event)>;
 
 class DmaChannel {
 public:
@@ -66,7 +66,7 @@ public:
 	DmaChannel(uint8_t num, bool dma16);
 	~DmaChannel();
 
-	void DoCallback(DMAEvent event);
+	void DoCallback(DMAEvent event) const;
 	void SetMask(bool _mask);
 	void RegisterCallback(const DMA_Callback cb);
 	void ReachedTerminalCount();

--- a/include/dma.h
+++ b/include/dma.h
@@ -122,7 +122,7 @@ public:
 	void ResetChannel(const uint8_t channel_num) const;
 };
 
-DmaChannel * GetDMAChannel(uint8_t chan);
+DmaChannel * DMA_GetChannel(uint8_t chan);
 
 void CloseSecondDMAController();
 void DMA_ResetChannel(const uint8_t channel_num);

--- a/include/dma.h
+++ b/include/dma.h
@@ -68,7 +68,7 @@ public:
 
 	void DoCallback(DMAEvent event);
 	void SetMask(bool _mask);
-	void Register_Callback(const DMA_Callback cb);
+	void RegisterCallback(const DMA_Callback cb);
 	void ReachedTC();
 	void SetPage(uint8_t val);
 	void Raise_Request();

--- a/include/dma.h
+++ b/include/dma.h
@@ -69,7 +69,7 @@ public:
 	void DoCallback(DMAEvent event);
 	void SetMask(bool _mask);
 	void RegisterCallback(const DMA_Callback cb);
-	void ReachedTC();
+	void ReachedTerminalCount();
 	void SetPage(uint8_t val);
 	void RaiseRequest();
 	void ClearRequest();

--- a/include/dma.h
+++ b/include/dma.h
@@ -47,7 +47,7 @@ public:
 	uint32_t pagebase = 0;
 	uint32_t curr_addr = 0;
 
-	uint16_t baseaddr = 0;
+	uint16_t base_addr = 0;
 	uint16_t basecnt  = 0;
 	uint16_t currcnt  = 0;
 

--- a/include/dma.h
+++ b/include/dma.h
@@ -124,10 +124,8 @@ public:
 
 DmaChannel * GetDMAChannel(uint8_t chan);
 
-void CloseSecondDMAController(void);
-bool SecondDMAControllerAvailable(void);
-
-void DMA_SetWrapping(const uint32_t wrap);
+void CloseSecondDMAController();
 void DMA_ResetChannel(const uint8_t channel_num);
+void DMA_SetWrapping(const uint32_t wrap);
 
 #endif

--- a/include/dma.h
+++ b/include/dma.h
@@ -100,8 +100,8 @@ private:
 
 	std::unique_ptr<DmaChannel> dma_channels[4] = {};
 
-	IO_ReadHandleObject DMA_ReadHandler[0x12]   = {};
-	IO_WriteHandleObject DMA_WriteHandler[0x12] = {};
+	IO_ReadHandleObject io_read_handlers[0x12]   = {};
+	IO_WriteHandleObject io_write_handlers[0x12] = {};
 
 	const uint8_t index = 0;
 

--- a/include/dma.h
+++ b/include/dma.h
@@ -53,7 +53,7 @@ public:
 
 	const uint8_t chan_num = 0;
 	uint8_t page_num = 0;
-	const uint8_t DMA16 = 0;
+	const uint8_t is_16bit = 0;
 
 	bool increment = true;
 	bool autoinit  = false;

--- a/include/dma.h
+++ b/include/dma.h
@@ -71,8 +71,8 @@ public:
 	void RegisterCallback(const DMA_Callback cb);
 	void ReachedTC();
 	void SetPage(uint8_t val);
-	void Raise_Request();
-	void Clear_Request();
+	void RaiseRequest();
+	void ClearRequest();
 	size_t Read(size_t words, uint8_t* const dest_buffer);
 	size_t Write(size_t words, uint8_t* const src_buffer);
 

--- a/include/dma.h
+++ b/include/dma.h
@@ -45,7 +45,7 @@ class DmaChannel {
 public:
 	// Defaults at the time of initialization
 	uint32_t pagebase = 0;
-	uint32_t curraddr = 0;
+	uint32_t curr_addr = 0;
 
 	uint16_t baseaddr = 0;
 	uint16_t basecnt  = 0;

--- a/include/dma.h
+++ b/include/dma.h
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/include/dma.h
+++ b/include/dma.h
@@ -55,11 +55,11 @@ public:
 	uint8_t page_num = 0;
 	const uint8_t is_16bit = 0;
 
-	bool increment = true;
-	bool autoinit  = false;
-	bool masked    = true;
-	bool tcount    = false;
-	bool request   = false;
+	bool is_incremented = true;
+	bool is_autoiniting  = false;
+	bool is_masked    = true;
+	bool has_reached_terminal_count    = false;
+	bool has_raised_request = false;
 
 	DMA_Callback callback = {};
 

--- a/include/dma.h
+++ b/include/dma.h
@@ -124,7 +124,7 @@ public:
 
 DmaChannel * DMA_GetChannel(uint8_t chan);
 
-void CloseSecondDMAController();
+void DMA_ShutdownSecondaryController();
 void DMA_ResetChannel(const uint8_t channel_num);
 void DMA_SetWrapping(const uint32_t wrap);
 

--- a/include/dma.h
+++ b/include/dma.h
@@ -49,7 +49,7 @@ public:
 
 	uint16_t base_addr = 0;
 	uint16_t base_count  = 0;
-	uint16_t currcnt  = 0;
+	uint16_t curr_count  = 0;
 
 	const uint8_t channum = 0;
 	uint8_t pagenum = 0;

--- a/include/dma.h
+++ b/include/dma.h
@@ -36,64 +36,41 @@ enum DMAEvent {
 };
 
 class DmaChannel;
-using DMA_CallBack = std::function<void(DmaChannel *chan, DMAEvent event)>;
+using DMA_Callback = std::function<void(DmaChannel *chan, DMAEvent event)>;
 
 class DmaChannel {
 public:
-	uint32_t pagebase;
-	uint16_t baseaddr;
-	uint32_t curraddr;
-	uint16_t basecnt;
-	uint16_t currcnt;
-	uint8_t channum;
-	uint8_t pagenum;
-	uint8_t DMA16;
-	bool increment;
-	bool autoinit;
-//	uint8_t trantype; //Not used at the moment
-	bool masked;
-	bool tcount;
-	bool request;
-	DMA_CallBack callback;
+	// Defaults at the time of initialization
+	uint32_t pagebase = 0;
+	uint32_t curraddr = 0;
+
+	uint16_t baseaddr = 0;
+	uint16_t basecnt  = 0;
+	uint16_t currcnt  = 0;
+
+	const uint8_t channum = 0;
+	uint8_t pagenum = 0;
+	const uint8_t DMA16 = 0;
+
+	bool increment = true;
+	bool autoinit  = false;
+	bool masked    = true;
+	bool tcount    = false;
+	bool request   = false;
+
+	DMA_Callback callback = {};
 
 	DmaChannel(uint8_t num, bool dma16);
 
-	void DoCallBack(DMAEvent event) {
-		if (callback)
-			callback(this, event);
-	}
-	void SetMask(bool _mask) {
-		masked=_mask;
-		DoCallBack(masked ? DMA_MASKED : DMA_UNMASKED);
-	}
-	void Register_Callback(DMA_CallBack _cb) { 
-		callback = _cb; 
-		SetMask(masked);
-		if (callback) Raise_Request();
-		else Clear_Request();
-	}
-	void ReachedTC(void) {
-		tcount=true;
-		DoCallBack(DMA_REACHED_TC);
-	}
-	void SetPage(uint8_t val) {
-		pagenum=val;
-		pagebase=(pagenum >> DMA16) << (16+DMA16);
-	}
-	void Raise_Request(void) {
-		request=true;
-	}
-	void Clear_Request(void) {
-		request=false;
-	}
-	size_t Read(size_t words, uint8_t *dest_buffer)
-	{
-		return ReadOrWrite(DMA_DIRECTION::READ, words, dest_buffer);
-	}
-	size_t Write(size_t words, uint8_t *src_buffer)
-	{
-		return ReadOrWrite(DMA_DIRECTION::WRITE, words, src_buffer);
-	}
+	void DoCallback(DMAEvent event);
+	void SetMask(bool _mask);
+	void Register_Callback(const DMA_Callback cb);
+	void ReachedTC();
+	void SetPage(uint8_t val);
+	void Raise_Request();
+	void Clear_Request();
+	size_t Read(size_t words, uint8_t* dest_buffer);
+	size_t Write(size_t words, uint8_t* src_buffer);
 
 private:
 	size_t ReadOrWrite(DMA_DIRECTION direction, size_t words, uint8_t *buffer);
@@ -101,38 +78,26 @@ private:
 
 class DmaController {
 private:
-	bool flipflop;
-	DmaChannel *dma_channels[4];
+	bool flipflop = false;
+
+	std::unique_ptr<DmaChannel> dma_channels[4] = {};
+
+	IO_ReadHandleObject DMA_ReadHandler[0x12]   = {};
+	IO_WriteHandleObject DMA_WriteHandler[0x12] = {};
+
+	const uint8_t index = 0;
 
 public:
-	IO_ReadHandleObject DMA_ReadHandler[0x12];
-	IO_WriteHandleObject DMA_WriteHandler[0x12];
+	DmaController(const uint8_t controller_index);
+	~DmaController();
 
-	DmaController(uint8_t ctrl) : flipflop(false)
-	{
-		assert(ctrl == 0 || ctrl == 1); // first or second DMA controller
-		constexpr auto n = ARRAY_LEN(dma_channels);
-		for (uint8_t i = 0; i < n; ++i)
-			dma_channels[i] = new DmaChannel(i + ctrl * n, ctrl == 1);
-	}
+	// prevent copy
+	DmaController(const DmaController&) = delete;
 
-	DmaController(const DmaController &) = delete; // prevent copy
-	DmaController &operator=(const DmaController &) = delete; // prevent assignment
+	// prevent assignment
+	DmaController& operator=(const DmaController&) = delete;
 
-	~DmaController()
-	{
-		for (auto *channel : dma_channels)
-			delete channel;
-	}
-
-	DmaChannel *GetChannel(uint8_t chan) const
-	{
-		constexpr auto n = ARRAY_LEN(dma_channels);
-		if (chan < n)
-			return dma_channels[chan];
-		else
-			return nullptr;
-	}
+	DmaChannel* GetChannel(const uint8_t channel_num) const;
 
 	void WriteControllerReg(io_port_t reg, io_val_t value, io_width_t width);
 	uint16_t ReadControllerReg(io_port_t reg, io_width_t width);

--- a/include/dma.h
+++ b/include/dma.h
@@ -48,7 +48,7 @@ public:
 	uint32_t curr_addr = 0;
 
 	uint16_t base_addr = 0;
-	uint16_t basecnt  = 0;
+	uint16_t base_count  = 0;
 	uint16_t currcnt  = 0;
 
 	const uint8_t channum = 0;

--- a/include/dma.h
+++ b/include/dma.h
@@ -73,8 +73,8 @@ public:
 	void SetPage(uint8_t val);
 	void Raise_Request();
 	void Clear_Request();
-	size_t Read(size_t words, uint8_t* dest_buffer);
-	size_t Write(size_t words, uint8_t* src_buffer);
+	size_t Read(size_t words, uint8_t* const dest_buffer);
+	size_t Write(size_t words, uint8_t* const src_buffer);
 
 	// Reset the channel back to defaults, without callbacks or reservations.
 	void Reset();
@@ -87,8 +87,8 @@ public:
 
 private:
 	void EvictReserver();
-	bool HasReservation();
-	size_t ReadOrWrite(DMA_DIRECTION direction, size_t words, uint8_t *buffer);
+	bool HasReservation() const;
+	size_t ReadOrWrite(DMA_DIRECTION direction, size_t words, uint8_t* const buffer);
 
 	DMA_ReservationCallback reservation_callback = {};
 	std::string_view reservation_owner = {};

--- a/include/dma.h
+++ b/include/dma.h
@@ -39,27 +39,27 @@ class Section;
 using DMA_ReservationCallback = std::function<void(Section*)>;
 
 class DmaChannel;
-using DMA_Callback = std::function<void(DmaChannel *chan, DMAEvent event)>;
+using DMA_Callback = std::function<void(DmaChannel* chan, DMAEvent event)>;
 
 class DmaChannel {
 public:
 	// Defaults at the time of initialization
-	uint32_t page_base = 0;
+	uint32_t page_base  = 0;
 	uint32_t curr_addr = 0;
 
-	uint16_t base_addr = 0;
-	uint16_t base_count  = 0;
-	uint16_t curr_count  = 0;
+	uint16_t base_addr  = 0;
+	uint16_t base_count = 0;
+	uint16_t curr_count = 0;
 
 	const uint8_t chan_num = 0;
 	uint8_t page_num = 0;
 	const uint8_t is_16bit = 0;
 
-	bool is_incremented = true;
-	bool is_autoiniting  = false;
-	bool is_masked    = true;
-	bool has_reached_terminal_count    = false;
-	bool has_raised_request = false;
+	bool is_incremented             = true;
+	bool is_autoiniting             = false;
+	bool is_masked                  = true;
+	bool has_reached_terminal_count = false;
+	bool has_raised_request         = false;
 
 	DMA_Callback callback = {};
 
@@ -88,10 +88,11 @@ public:
 private:
 	void EvictReserver();
 	bool HasReservation() const;
-	size_t ReadOrWrite(DMA_DIRECTION direction, size_t words, uint8_t* const buffer);
+	size_t ReadOrWrite(DMA_DIRECTION direction, size_t words,
+	                   uint8_t* const buffer);
 
 	DMA_ReservationCallback reservation_callback = {};
-	std::string_view reservation_owner = {};
+	std::string_view reservation_owner           = {};
 };
 
 class DmaController {
@@ -122,7 +123,7 @@ public:
 	void ResetChannel(const uint8_t channel_num) const;
 };
 
-DmaChannel * DMA_GetChannel(uint8_t chan);
+DmaChannel* DMA_GetChannel(uint8_t chan);
 
 void DMA_ShutdownSecondaryController();
 void DMA_ResetChannel(const uint8_t channel_num);

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -478,7 +478,7 @@ void BOOT::Run(void)
 
 		/* create appearance of floppy drive DMA usage (Demon's Forge) */
 		if (!IS_TANDY_ARCH && floppysize != 0)
-			DMA_GetChannel(2)->tcount = true;
+			DMA_GetChannel(2)->has_reached_terminal_count = true;
 
 		/* revector some dos-allocated interrupts */
 		real_writed(0, 0x01 * 4, 0xf000ff53);

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -478,7 +478,7 @@ void BOOT::Run(void)
 
 		/* create appearance of floppy drive DMA usage (Demon's Forge) */
 		if (!IS_TANDY_ARCH && floppysize != 0)
-			GetDMAChannel(2)->tcount = true;
+			DMA_GetChannel(2)->tcount = true;
 
 		/* revector some dos-allocated interrupts */
 		real_writed(0, 0x01 * 4, 0xf000ff53);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -953,19 +953,19 @@ void DOSBOX_Init()
 	// Tandy audio emulation
 	secprop->AddInitFunction(&TANDYSOUND_Init, changeable_at_runtime);
 
-	const char *tandys[] = {"auto", "on", "off", 0};
+	const char* tandys[] = {"auto", "on", "psg", "off", 0};
 
 	pstring = secprop->Add_string("tandy", when_idle, "auto");
 	pstring->Set_values(tandys);
 	pstring->Set_help(
 	        "Set the Tandy/PCjr 3 Voice sound emulation:\n"
-	        "  off:   Disable Tandy/PCjr sound.\n"
-	        "  on:    Enable Tandy/PCjr sound (most games also need the machine set to\n"
-	        "         'tandy' or 'pcjr' to work).\n"
 	        "  auto:  Automatically enable Tandy/PCjr sound for the 'tandy' and 'pcjr'\n"
 	        "         machine types only (default).\n"
-	        "Notes: The Tandy DAC is only emulated if Sound Blaster emulation is disabled\n"
-	        "       with 'sbtype = none' due to resource conflicts.");
+	        "  on:    Enable Tandy/PCjr sound with DAC support, when possible.\n"
+	        "         Most games also need the machine set to 'tandy' or 'pcjr' to work.\n"
+	        "  psg:   Only enable the card's three-voice programmable sound generator\n"
+	        "         without DAC to avoid conflicts with other cards using DMA 1.\n"
+	        "  off:   Disable Tandy/PCjr sound.");
 
 	pstring = secprop->Add_string("tandy_filter", when_idle, "on");
 	pstring->Set_help(

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -844,11 +844,11 @@ void DOSBOX_Init()
 	const char *dmassb[] = {"0", "1", "3", "5", "6", "7", 0};
 	pint                 = secprop->Add_int("dma", when_idle, 1);
 	pint->Set_values(dmassb);
-	pint->Set_help("The DMA number of the Sound Blaster (1 by default).");
+	pint->Set_help("The DMA channel of the Sound Blaster (1 by default).");
 
 	pint = secprop->Add_int("hdma", when_idle, 5);
 	pint->Set_values(dmassb);
-	pint->Set_help("The High DMA number of the Sound Blaster (5 by default).");
+	pint->Set_help("The High DMA channel of the Sound Blaster 16 (5 by default).");
 
 	pbool = secprop->Add_bool("sbmixer", when_idle, true);
 	pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer (enabled by default).");

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -150,7 +150,7 @@ constexpr uint8_t to_secondary_num(const uint8_t channel_num)
 	return (static_cast<uint8_t>(channel_num - SecondaryMin));
 }
 
-DmaChannel* GetDMAChannel(const uint8_t channel_num)
+DmaChannel* DMA_GetChannel(const uint8_t channel_num)
 {
 	if (is_primary(channel_num) && (primary || activate_primary())) {
 		return primary->GetChannel(channel_num);
@@ -183,7 +183,7 @@ static DmaChannel* GetChannelFromPort(const io_port_t port)
 		LOG_WARNING("DMA: Attempted to lookup DMA channel from invalid port %04x",
 		            port);
 	}
-	return GetDMAChannel(num);
+	return DMA_GetChannel(num);
 }
 
 static void DMA_Write_Port(const io_port_t port, const io_val_t value, io_width_t)

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -161,7 +161,7 @@ DmaChannel* DMA_GetChannel(const uint8_t channel_num)
 	return nullptr;
 }
 
-void CloseSecondDMAController()
+void DMA_ShutdownSecondaryController()
 {
 	secondary = {};
 }

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -374,9 +374,9 @@ void DmaChannel::RegisterCallback(const DMA_Callback _cb)
 	callback = _cb;
 	SetMask(masked);
 	if (callback) {
-		Raise_Request();
+		RaiseRequest();
 	} else {
-		Clear_Request();
+		ClearRequest();
 	}
 }
 
@@ -392,12 +392,12 @@ void DmaChannel::SetPage(const uint8_t val)
 	pagebase = (pagenum >> DMA16) << (16 + DMA16);
 }
 
-void DmaChannel::Raise_Request()
+void DmaChannel::RaiseRequest()
 {
 	request = true;
 }
 
-void DmaChannel::Clear_Request()
+void DmaChannel::ClearRequest()
 {
 	request = false;
 }

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -374,7 +374,7 @@ DmaChannel::DmaChannel(const uint8_t num, const bool is_dma_16bit)
 	assert(is_incremented);
 }
 
-void DmaChannel::DoCallback(const DMAEvent event)
+void DmaChannel::DoCallback(const DMAEvent event) const
 {
 	if (callback) {
 		callback(this, event);

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -245,10 +245,10 @@ void DmaController::WriteControllerReg(const io_port_t reg, const io_val_t value
 		chan=GetChannel((uint8_t)(reg >> 1));
 		flipflop=!flipflop;
 		if (flipflop) {
-			chan->basecnt=(chan->basecnt&0xff00)|val;
+			chan->base_count=(chan->base_count&0xff00)|val;
 			chan->currcnt=(chan->currcnt&0xff00)|val;
 		} else {
-			chan->basecnt=(chan->basecnt&0x00ff)|(val << 8);
+			chan->base_count=(chan->base_count&0x00ff)|(val << 8);
 			chan->currcnt=(chan->currcnt&0x00ff)|(val << 8);
 		}
 		break;
@@ -434,7 +434,7 @@ again:
 		done += left;
 		ReachedTerminalCount();
 		if (autoinit) {
-			currcnt = basecnt;
+			currcnt = base_count;
 			curr_addr = base_addr;
 			if (want)
 				goto again;
@@ -491,7 +491,7 @@ void DmaChannel::Reset()
 	curr_addr = 0;
 
 	base_addr = 0;
-	basecnt  = 0;
+	base_count  = 0;
 	currcnt  = 0;
 
 	pagenum = 0;

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -369,7 +369,7 @@ void DmaChannel::SetMask(const bool _mask)
 	DoCallback(masked ? DMA_MASKED : DMA_UNMASKED);
 }
 
-void DmaChannel::Register_Callback(const DMA_Callback _cb)
+void DmaChannel::RegisterCallback(const DMA_Callback _cb)
 {
 	callback = _cb;
 	SetMask(masked);

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -380,7 +380,7 @@ void DmaChannel::RegisterCallback(const DMA_Callback _cb)
 	}
 }
 
-void DmaChannel::ReachedTC()
+void DmaChannel::ReachedTerminalCount()
 {
 	tcount = true;
 	DoCallback(DMA_REACHED_TC);
@@ -432,7 +432,7 @@ again:
 		curr_buffer += left << DMA16;
 		want -= left;
 		done += left;
-		ReachedTC();
+		ReachedTerminalCount();
 		if (autoinit) {
 			currcnt = basecnt;
 			curraddr = baseaddr;

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -216,7 +216,7 @@ static uint16_t DMA_Read_Port(const io_port_t port, const io_width_t width)
 	} else {
 		const auto channel = GetChannelFromPort(port);
 		if (channel)
-			return channel->pagenum;
+			return channel->page_num;
 	}
 	return 0;
 }
@@ -346,7 +346,7 @@ uint16_t DmaController::ReadControllerReg(const io_port_t reg, io_width_t)
 }
 
 DmaChannel::DmaChannel(const uint8_t num, const bool is_dma_16bit)
-        : channum(num),
+        : chan_num(num),
           DMA16(is_dma_16bit ? 0x1 : 0x0)
 {
 	if (num == 4) {
@@ -388,8 +388,8 @@ void DmaChannel::ReachedTerminalCount()
 
 void DmaChannel::SetPage(const uint8_t val)
 {
-	pagenum  = val;
-	pagebase = (pagenum >> DMA16) << (16 + DMA16);
+	page_num  = val;
+	page_base = (page_num >> DMA16) << (16 + DMA16);
 }
 
 void DmaChannel::RaiseRequest()
@@ -423,12 +423,12 @@ size_t DmaChannel::ReadOrWrite(const DMA_DIRECTION direction, const size_t words
 again:
 	Bitu left = (curr_count + 1);
 	if (want < left) {
-		perform_dma_io(direction, pagebase, curr_addr, curr_buffer, want, DMA16);
+		perform_dma_io(direction, page_base, curr_addr, curr_buffer, want, DMA16);
 		done += want;
 		curr_addr += want;
 		curr_count -= want;
 	} else {
-		perform_dma_io(direction, pagebase, curr_addr, curr_buffer, left, DMA16);
+		perform_dma_io(direction, page_base, curr_addr, curr_buffer, left, DMA16);
 		curr_buffer += left << DMA16;
 		want -= left;
 		done += left;
@@ -476,7 +476,7 @@ void DmaChannel::ReserveFor(const std::string_view new_owner,
 		        new_owner.data(),
 		        reservation_owner.data(),
 		        DMA16 == 1 ? 16 : 8,
-		        channum);
+		        chan_num);
 		EvictReserver();
 	}
 	Reset();
@@ -487,14 +487,14 @@ void DmaChannel::ReserveFor(const std::string_view new_owner,
 void DmaChannel::Reset()
 {
 	// Defaults at the time of initialization
-	pagebase = 0;
+	page_base = 0;
 	curr_addr = 0;
 
 	base_addr = 0;
 	base_count  = 0;
 	curr_count  = 0;
 
-	pagenum = 0;
+	page_num = 0;
 
 	increment = true;
 	autoinit  = false;
@@ -513,7 +513,7 @@ DmaChannel::~DmaChannel()
 		LOG_MSG("DMA: Shutting down %s on %d-bit DMA channel %d",
 		        reservation_owner.data(),
 		        DMA16 == 1 ? 16 : 8,
-		        channum);
+		        chan_num);
 		EvictReserver();
 	}
 }

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -538,31 +538,31 @@ DmaController::DmaController(const uint8_t controller_index)
 
 		// Install handler for primary DMA controller ports
 		if (index == 0) {
-			DMA_WriteHandler[i].Install(i, DMA_Write_Port, width);
-			DMA_ReadHandler[i].Install(i, DMA_Read_Port, width);
+			io_write_handlers[i].Install(i, DMA_Write_Port, width);
+			io_read_handlers[i].Install(i, DMA_Read_Port, width);
 		}
 		// Install handler for secondary DMA controller ports
 		else if (IS_EGAVGA_ARCH) {
 			assert(index == 1);
 			const auto dma_port = static_cast<io_port_t>(0xc0 + i * 2);
-			DMA_WriteHandler[i].Install(dma_port, DMA_Write_Port, width);
-			DMA_ReadHandler[i].Install(dma_port, DMA_Read_Port, width);
+			io_write_handlers[i].Install(dma_port, DMA_Write_Port, width);
+			io_read_handlers[i].Install(dma_port, DMA_Read_Port, width);
 		}
 	}
 	// Install handlers for ports 0x81-0x83,0x87 (on the primary)
 	if (index == 0) {
-		DMA_WriteHandler[0x10].Install(0x81, DMA_Write_Port, io_width_t::byte, 3);
-		DMA_ReadHandler[0x10].Install(0x81, DMA_Read_Port, io_width_t::byte, 3);
-		DMA_WriteHandler[0x11].Install(0x87, DMA_Write_Port, io_width_t::byte, 1);
-		DMA_ReadHandler[0x11].Install(0x87, DMA_Read_Port, io_width_t::byte, 1);
+		io_write_handlers[0x10].Install(0x81, DMA_Write_Port, io_width_t::byte, 3);
+		io_read_handlers[0x10].Install(0x81, DMA_Read_Port, io_width_t::byte, 3);
+		io_write_handlers[0x11].Install(0x87, DMA_Write_Port, io_width_t::byte, 1);
+		io_read_handlers[0x11].Install(0x87, DMA_Read_Port, io_width_t::byte, 1);
 	}
 	// Install handlers for ports 0x89-0x8b,0x8f (on the secondary)
 	else if (IS_EGAVGA_ARCH) {
 		assert(index == 1);
-		DMA_WriteHandler[0x10].Install(0x89, DMA_Write_Port, io_width_t::byte, 3);
-		DMA_ReadHandler[0x10].Install(0x89, DMA_Read_Port, io_width_t::byte, 3);
-		DMA_WriteHandler[0x11].Install(0x8f, DMA_Write_Port, io_width_t::byte, 1);
-		DMA_ReadHandler[0x11].Install(0x8f, DMA_Read_Port, io_width_t::byte, 1);
+		io_write_handlers[0x10].Install(0x89, DMA_Write_Port, io_width_t::byte, 3);
+		io_read_handlers[0x10].Install(0x89, DMA_Read_Port, io_width_t::byte, 3);
+		io_write_handlers[0x11].Install(0x8f, DMA_Write_Port, io_width_t::byte, 1);
+		io_read_handlers[0x11].Install(0x8f, DMA_Read_Port, io_width_t::byte, 1);
 	}
 
 	LOG_MSG("DMA: Initialized %s controller",
@@ -575,10 +575,10 @@ DmaController::~DmaController()
 	        (index == 0 ? "primary" : "secondary"));
 
 	// Deregister the controller's IO handlers
-	for (auto& rh : DMA_ReadHandler) {
+	for (auto& rh : io_read_handlers) {
 		rh.Uninstall();
 	}
-	for (auto& wh : DMA_WriteHandler) {
+	for (auto& wh : io_write_handlers) {
 		wh.Uninstall();
 	}
 

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -166,11 +166,6 @@ void CloseSecondDMAController()
 	secondary = {};
 }
 
-/* check availability of second DMA controller, needed for SB16 */
-bool SecondDMAControllerAvailable(void) {
-	return (secondary != nullptr);
-}
-
 static DmaChannel* GetChannelFromPort(const io_port_t port)
 {
 	uint8_t num = UINT8_MAX;

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -232,10 +232,10 @@ void DmaController::WriteControllerReg(const io_port_t reg, const io_val_t value
 		chan=GetChannel((uint8_t)(reg >> 1));
 		flipflop=!flipflop;
 		if (flipflop) {
-			chan->baseaddr=(chan->baseaddr&0xff00)|val;
+			chan->base_addr=(chan->base_addr&0xff00)|val;
 			chan->curr_addr=(chan->curr_addr&0xff00)|val;
 		} else {
-			chan->baseaddr=(chan->baseaddr&0x00ff)|(val << 8);
+			chan->base_addr=(chan->base_addr&0x00ff)|(val << 8);
 			chan->curr_addr=(chan->curr_addr&0x00ff)|(val << 8);
 		}
 		break;
@@ -435,7 +435,7 @@ again:
 		ReachedTerminalCount();
 		if (autoinit) {
 			currcnt = basecnt;
-			curr_addr = baseaddr;
+			curr_addr = base_addr;
 			if (want)
 				goto again;
 			UpdateEMSMapping();
@@ -490,7 +490,7 @@ void DmaChannel::Reset()
 	pagebase = 0;
 	curr_addr = 0;
 
-	baseaddr = 0;
+	base_addr = 0;
 	basecnt  = 0;
 	currcnt  = 0;
 

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2022-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1296,7 +1296,7 @@ void Gus::UpdateDmaAddress(const uint8_t new_address)
 
 	// Update the address, channel, and callback
 	dma1 = new_address;
-	dma_channel = GetDMAChannel(dma1);
+	dma_channel = DMA_GetChannel(dma1);
 	assert(dma_channel);
 	dma_channel->ReserveFor("GUS", gus_destroy);
 	dma_channel->RegisterCallback(std::bind(&Gus::DmaCallback, this, _1, _2));

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -237,7 +237,7 @@ private:
 	void CheckVoiceIrq();
 	uint32_t GetDmaOffset() noexcept;
 	void UpdateDmaAddr(uint32_t offset) noexcept;
-	void DmaCallback(DmaChannel *chan, DMAEvent event);
+	void DmaCallback(const DmaChannel* chan, DMAEvent event);
 	void StartDmaTransfers();
 	bool IsDmaPcm16Bit() noexcept;
 	bool IsDmaXfer16Bit() noexcept;
@@ -923,7 +923,7 @@ void Gus::StartDmaTransfers()
 	PIC_AddEvent(GUS_DMA_Event, MS_PER_DMA_XFER);
 }
 
-void Gus::DmaCallback(DmaChannel *, DMAEvent event)
+void Gus::DmaCallback(const DmaChannel*, DMAEvent event)
 {
 	if (event == DMA_UNMASKED)
 		StartDmaTransfers();

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -835,12 +835,14 @@ void Gus::UpdateDmaAddr(uint32_t offset) noexcept
 
 bool Gus::PerformDmaTransfer()
 {
-	if (dma_channel->masked || !(dma_ctrl & 0x01))
+	if (dma_channel->is_masked || !(dma_ctrl & 0x01)) {
 		return false;
+	}
 
 #if LOG_GUS
 	LOG_MSG("GUS DMA event: max %u bytes. DMA: tc=%u mask=0 cnt=%u",
-	        BYTES_PER_DMA_XFER, dma_channel->tcount ? 1 : 0,
+	        BYTES_PER_DMA_XFER,
+	        dma_channel->has_reached_terminal_count ? 1 : 0,
 	        dma_channel->curr_count + 1);
 #endif
 
@@ -887,7 +889,7 @@ bool Gus::PerformDmaTransfer()
 		dma_ctrl |= DMA_TC_STATUS_BITMASK;
 		irq_status |= 0x80;
 		CheckIrq();
-		assert(dma_channel->tcount); // hit terminal count, we're done
+		assert(dma_channel->has_reached_terminal_count);
 		return false;
 	}
 	return true;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1299,7 +1299,7 @@ void Gus::UpdateDmaAddress(const uint8_t new_address)
 	dma_channel = GetDMAChannel(dma1);
 	assert(dma_channel);
 	dma_channel->ReserveFor("GUS", gus_destroy);
-	dma_channel->Register_Callback(std::bind(&Gus::DmaCallback, this, _1, _2));
+	dma_channel->RegisterCallback(std::bind(&Gus::DmaCallback, this, _1, _2));
 #if LOG_GUS
 	LOG_MSG("GUS: Assigned DMA1 address to %u", dma1);
 #endif

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -863,7 +863,7 @@ bool Gus::PerformDmaTransfer()
 	assert(transfered == desired);
 
 	// scale the transfer by the DMA channel's bit-depth
-	const auto bytes_transfered = transfered * (dma_channel->DMA16 + 1u);
+	const auto bytes_transfered = transfered * (dma_channel->is_16bit + 1u);
 
 	// Update the GUS's DMA address with the current position
 	UpdateDmaAddr(check_cast<uint32_t>(offset + bytes_transfered));

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -841,14 +841,14 @@ bool Gus::PerformDmaTransfer()
 #if LOG_GUS
 	LOG_MSG("GUS DMA event: max %u bytes. DMA: tc=%u mask=0 cnt=%u",
 	        BYTES_PER_DMA_XFER, dma_channel->tcount ? 1 : 0,
-	        dma_channel->currcnt + 1);
+	        dma_channel->curr_count + 1);
 #endif
 
 	// Get the current DMA offset relative to the block of GUS memory
 	const auto offset = GetDmaOffset();
 
 	// Get the pending DMA count from channel
-	const uint16_t desired = dma_channel->currcnt + 1;
+	const uint16_t desired = dma_channel->curr_count + 1;
 
 	// Will the maximum transfer stay within the GUS RAM's size?
 	assert(static_cast<size_t>(offset) + desired <= ram.size());

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1205,7 +1205,7 @@ static void DSP_Reset() {
 	sb.dma.autoinit=false;
 	sb.dma.mode=DSP_DMA_NONE;
 	sb.dma.remain_size=0;
-	if (sb.dma.chan) sb.dma.chan->Clear_Request();
+	if (sb.dma.chan) sb.dma.chan->ClearRequest();
 
 	sb.adpcm = {};
 	sb.freq = default_playback_rate_hz;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -623,7 +623,7 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 			FlushRemainingDMATransfer();
 			LOG(LOG_SB, LOG_NORMAL)
 			("DMA unmasked,starting output, auto %d block %d",
-			 static_cast<int>(chan->autoinit),
+			 static_cast<int>(chan->is_autoiniting),
 			 chan->base_count);
 		}
 	}

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1116,7 +1116,7 @@ static void DSP_DoDMATransfer(const DMA_MODES mode, uint32_t freq, bool autoinit
 	PIC_RemoveEvents(ProcessDMATransfer);
 	//Set to be masked, the dma call can change this again.
 	sb.mode = MODE_DMA_MASKED;
-	sb.dma.chan->Register_Callback(DSP_DMA_CallBack);
+	sb.dma.chan->RegisterCallback(DSP_DMA_CallBack);
 
 #if (C_DEBUG)
 	LOG(LOG_SB, LOG_NORMAL)
@@ -1242,7 +1242,7 @@ static void DSP_E2_DMA_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 	if (event==DMA_UNMASKED) {
 		uint8_t val=(uint8_t)(sb.e2.value&0xff);
 		DmaChannel * chan=GetDMAChannel(sb.hw.dma8);
-		chan->Register_Callback(0);
+		chan->RegisterCallback(0);
 		chan->Write(1,&val);
 	}
 }
@@ -1255,7 +1255,7 @@ static void DSP_ADC_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 		ch->Write(1,&val);
 	}
 	SB_RaiseIRQ(SB_IRQ_8);
-	ch->Register_Callback(0);
+	ch->RegisterCallback(0);
 }
 
 static void DSP_ChangeRate(uint32_t freq)
@@ -1339,7 +1339,7 @@ static void DSP_DoCommand() {
 		sb.dma.left = 1 + sb.dsp.in.data[0] + (sb.dsp.in.data[1] << 8);
 		sb.dma.sign=false;
 		LOG(LOG_SB,LOG_ERROR)("DSP:Faked ADC for %u bytes",sb.dma.left);
-		GetDMAChannel(sb.hw.dma8)->Register_Callback(DSP_ADC_CallBack);
+		GetDMAChannel(sb.hw.dma8)->RegisterCallback(DSP_ADC_CallBack);
 		break;
 	case 0x14:	/* Singe Cycle 8-Bit DMA DAC */
 	case 0x15:	/* Wari hack. Waru uses this one instead of 0x14, but some weird stuff going on there anyway */
@@ -1449,7 +1449,7 @@ static void DSP_DoCommand() {
 		LOG(LOG_SB, LOG_NORMAL)("Continue DMA command");
 		if (sb.mode==MODE_DMA_PAUSE) {
 			sb.mode=MODE_DMA_MASKED;
-			if (sb.dma.chan!=NULL) sb.dma.chan->Register_Callback(DSP_DMA_CallBack);
+			if (sb.dma.chan!=NULL) sb.dma.chan->RegisterCallback(DSP_DMA_CallBack);
 		}
 		break;
 	case 0xd9:  /* Exit Autoinitialize 16-bit */
@@ -1489,7 +1489,7 @@ static void DSP_DoCommand() {
 				        sb.e2.value += E2_incr_table[sb.e2.count % 4][i];
 		        sb.e2.value += E2_incr_table[sb.e2.count % 4][8];
 		        sb.e2.count++;
-		        GetDMAChannel(sb.hw.dma8)->Register_Callback(DSP_E2_DMA_CallBack);
+		        GetDMAChannel(sb.hw.dma8)->RegisterCallback(DSP_E2_DMA_CallBack);
 		}
 		break;
 	case 0xe3: /* DSP Copyright */

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -624,7 +624,7 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 			LOG(LOG_SB, LOG_NORMAL)
 			("DMA unmasked,starting output, auto %d block %d",
 			 static_cast<int>(chan->autoinit),
-			 chan->basecnt);
+			 chan->base_count);
 		}
 	}
 	else {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -587,7 +587,8 @@ static void DSP_FlushData()
 
 static double last_dma_callback = 0.0;
 
-static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
+static void DSP_DMA_CallBack(const DmaChannel* chan, DMAEvent event)
+{
 	if (chan!=sb.dma.chan || event==DMA_REACHED_TC) return;
 	else if (event==DMA_MASKED) {
 		if (sb.mode==MODE_DMA) {
@@ -1238,7 +1239,8 @@ static void DSP_DoReset(uint8_t val) {
 	}
 }
 
-static void DSP_E2_DMA_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
+static void DSP_E2_DMA_CallBack(const DmaChannel* /*chan*/, DMAEvent event)
+{
 	if (event==DMA_UNMASKED) {
 		uint8_t val=(uint8_t)(sb.e2.value&0xff);
 		DmaChannel * chan=DMA_GetChannel(sb.hw.dma8);
@@ -1247,7 +1249,8 @@ static void DSP_E2_DMA_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
 	}
 }
 
-static void DSP_ADC_CallBack(DmaChannel * /*chan*/, DMAEvent event) {
+static void DSP_ADC_CallBack(const DmaChannel* /*chan*/, DMAEvent event)
+{
 	if (event!=DMA_UNMASKED) return;
 	uint8_t val=128;
 	DmaChannel * ch=DMA_GetChannel(sb.hw.dma8);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -614,7 +614,7 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
 			}
 			sb.mode = MODE_DMA_MASKED;
 //			DSP_ChangeMode(MODE_DMA_MASKED);
-			LOG(LOG_SB,LOG_NORMAL)("DMA masked,stopping output, left %d",chan->currcnt);
+			LOG(LOG_SB,LOG_NORMAL)("DMA masked,stopping output, left %d",chan->curr_count);
 		}
 	} else if (event==DMA_UNMASKED) {
 		if (sb.mode==MODE_DMA_MASKED && sb.dma.mode!=DSP_DMA_NONE) {

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -669,7 +669,7 @@ void TANDYSOUND_Init(Section *section)
 	// ports 0xc0. Closing the controller itself means that all the high DMA
 	// ports (4 through 7) get automatically shutdown as well.
 	//
-	CloseSecondDMAController();
+	DMA_ShutdownSecondaryController();
 
 	const auto wants_dac = has_true(pref) || (IS_TANDY_ARCH && pref == "auto");
 	if (wants_dac) {

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -108,7 +108,10 @@ enum class ConfigProfile {
 	SoundCardRemoved,
 };
 
+static void shutdown_dac(Section*);
+
 class TandyDAC {
+public:
 	struct IOConfig {
 		uint16_t base = 0;
 		uint8_t irq = 0;
@@ -127,7 +130,9 @@ class TandyDAC {
 		bool irq_activated = false;
 	};
 
-public:
+	// There's only one Tandy sound's IO configuration, so make it permanent
+	static constexpr IOConfig io = {0xc4, 7, 1};
+
 	TandyDAC(const ConfigProfile config_profile,
 	         const std::string_view filter_choice);
 	~TandyDAC();
@@ -135,10 +140,6 @@ public:
 	bool IsEnabled() const
 	{
 		return is_enabled;
-	}
-	const IOConfig& GetIOConfig() const
-	{
-		return io;
 	}
 
 private:
@@ -150,7 +151,6 @@ private:
 	TandyDAC() = delete;
 
 	DMA dma = {};
-	const IOConfig io = {0xc4, 7, 1};
 
 	// Managed objects
 	mixer_channel_t channel = nullptr;
@@ -266,6 +266,11 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 		write_handlers[1].Install(io.base + card_base_offset, writer,
 		                          io_width_t::byte, 4);
 
+	// Reserve the DMA channel
+	if (dma.channel = GetDMAChannel(io.dma); dma.channel) {
+		dma.channel->ReserveFor("Tandy DAC", shutdown_dac);
+	}
+
 	is_enabled = true;
 }
 
@@ -288,6 +293,11 @@ TandyDAC::~TandyDAC()
 	// Deregister the mixer channel, after which it's cleaned up
 	assert(channel);
 	MIXER_DeregisterChannel(channel);
+
+	// Reset the DMA channel as the mixer is no longer reading samples
+	if (dma.channel) {
+		dma.channel->Reset();
+	}
 }
 
 void TandyDAC::DmaCallback([[maybe_unused]] DmaChannel*, DMAEvent event)
@@ -504,8 +514,7 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 
 	LOG_MSG("TANDY: Initialized audio card with a TI %s PSG %s",
 	        base_device->shortName,
-	        is_dac_enabled ? "and 8-bit DAC"
-	                       : "but no DAC, because a Sound Blaster is present");
+	        is_dac_enabled ? "and 8-bit DAC" : "but without DAC");
 }
 
 TandyPSG::~TandyPSG()
@@ -610,19 +619,10 @@ bool TS_Get_Address(Bitu &tsaddr, Bitu &tsirq, Bitu &tsdma)
 	}
 
 	assert(tandy_dac && tandy_dac->IsEnabled());
-	const auto io = tandy_dac->GetIOConfig();
-	tsaddr = io.base;
-	tsirq = io.irq;
-	tsdma = io.dma;
+	tsaddr = TandyDAC::io.base;
+	tsirq  = TandyDAC::io.irq;
+	tsdma  = TandyDAC::io.dma;
 	return true;
-}
-
-static bool is_sound_blaster_absent()
-{
-	uint16_t sbport;
-	uint8_t sbirq;
-	uint8_t sbdma;
-	return (SB_Get_Address(sbport, sbirq, sbdma) == false);
 }
 
 static void set_tandy_sound_flag_in_bios(const bool is_enabled)
@@ -630,12 +630,22 @@ static void set_tandy_sound_flag_in_bios(const bool is_enabled)
 	real_writeb(0x40, 0xd4, is_enabled ? 0xff : 0x00);
 }
 
-void TANDYSOUND_ShutDown([[maybe_unused]] Section *section)
+static void shutdown_dac(Section*)
 {
-	LOG_MSG("TANDY: Shutting down Tandy sound card");
-	set_tandy_sound_flag_in_bios(false);
-	tandy_dac.reset();
-	tandy_psg.reset();
+	if (tandy_dac) {
+		LOG_MSG("TANDY: Shutting down DAC");
+		tandy_dac.reset();
+	}
+}
+
+void TANDYSOUND_ShutDown(Section*)
+{
+	if (tandy_psg || tandy_dac) {
+		LOG_MSG("TANDY: Shutting down");
+		set_tandy_sound_flag_in_bios(false);
+		tandy_dac.reset();
+		tandy_psg.reset();
+	}
 }
 
 void TANDYSOUND_Init(Section *section)
@@ -643,12 +653,7 @@ void TANDYSOUND_Init(Section *section)
 	assert(section);
 	const auto prop = static_cast<Section_prop*>(section);
 	const auto pref = std::string_view(prop->Get_string("tandy"));
-
-	const auto pref_has_bool = parse_bool_setting(pref);
-
-	const auto wants_tandy_sound = (pref_has_bool && *pref_has_bool == true) ||
-	                               (IS_TANDY_ARCH && pref == "auto");
-	if (!wants_tandy_sound) {
+	if (has_false(pref) || (!IS_TANDY_ARCH && pref == "auto")) {
 		set_tandy_sound_flag_in_bios(false);
 		return;
 	}
@@ -660,17 +665,19 @@ void TANDYSOUND_Init(Section *section)
 	default: cfg = ConfigProfile::SoundCardOnly; break;
 	}
 
-	// the second DMA controller conflicts with the tandy sound's ports 0xc0
+	// The second DMA controller conflicts with the tandy sound's base IO
+	// ports 0xc0. Closing the controller itself means that all the high DMA
+	// ports (4 through 7) get automatically shutdown as well.
+	//
 	CloseSecondDMAController();
 
-	const auto can_use_tandy_dac = is_sound_blaster_absent();
-	if (can_use_tandy_dac) {
+	const auto wants_dac = has_true(pref) || (IS_TANDY_ARCH && pref == "auto");
+	if (wants_dac) {
 		tandy_dac = std::make_unique<TandyDAC>(
 		        cfg, prop->Get_string("tandy_dac_filter"));
 	}
-
 	tandy_psg = std::make_unique<TandyPSG>(cfg,
-	                                       can_use_tandy_dac,
+	                                       wants_dac,
 	                                       prop->Get_string("tandy_filter"));
 
 	set_tandy_sound_flag_in_bios(true);

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -339,7 +339,7 @@ void TandyDAC::ChangeMode()
 					const auto callback =
 					        std::bind(&TandyDAC::DmaCallback,
 					                  this, _1, _2);
-					dma.channel->Register_Callback(callback);
+					dma.channel->RegisterCallback(callback);
 					channel->Enable(true);
 					// LOG_MSG("TANDYDAC: playback started with freqency %f, volume %f", freq, vol);
 				}

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -630,7 +630,7 @@ static void set_tandy_sound_flag_in_bios(const bool is_enabled)
 	real_writeb(0x40, 0xd4, is_enabled ? 0xff : 0x00);
 }
 
-static void TANDYSOUND_ShutDown([[maybe_unused]] Section *section)
+void TANDYSOUND_ShutDown([[maybe_unused]] Section *section)
 {
 	LOG_MSG("TANDY: Shutting down Tandy sound card");
 	set_tandy_sound_flag_in_bios(false);

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -144,7 +144,7 @@ public:
 
 private:
 	void ChangeMode();
-	void DmaCallback(DmaChannel *chan, DMAEvent event);
+	void DmaCallback(const DmaChannel* chan, DMAEvent event);
 	uint8_t ReadFromPort(io_port_t port, io_width_t);
 	void WriteToPort(io_port_t port, io_val_t value, io_width_t);
 	void AudioCallback(uint16_t requested);
@@ -300,7 +300,7 @@ TandyDAC::~TandyDAC()
 	}
 }
 
-void TandyDAC::DmaCallback([[maybe_unused]] DmaChannel*, DMAEvent event)
+void TandyDAC::DmaCallback([[maybe_unused]] const DmaChannel*, DMAEvent event)
 {
 	// LOG_MSG("TANDYDAC: DMA event %d", event);
 	if (event != DMA_REACHED_TC)

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -267,7 +267,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 		                          io_width_t::byte, 4);
 
 	// Reserve the DMA channel
-	if (dma.channel = GetDMAChannel(io.dma); dma.channel) {
+	if (dma.channel = DMA_GetChannel(io.dma); dma.channel) {
 		dma.channel->ReserveFor("Tandy DAC", shutdown_dac);
 	}
 
@@ -334,7 +334,7 @@ void TandyDAC::ChangeMode()
 			channel->SetAppVolume(vol, vol);
 			if ((regs.mode & 0x0c) == 0x0c) {
 				dma.is_done = false;
-				dma.channel = GetDMAChannel(io.dma);
+				dma.channel = DMA_GetChannel(io.dma);
 				if (dma.channel) {
 					const auto callback =
 					        std::bind(&TandyDAC::DmaCallback,


### PR DESCRIPTION
Previously we could have three active audio devices all thinking they had access to DMA channel 1. For example:

```ini
[dosbox]
machine = tandy

[sblaster]
sbtype = sb1
dma = 1

[gus]
gus = on
gusdma = 1

[speaker]
tandy = on (the DAC runs on DMA 1)
```

Unfortunately only one device will be functional and the others will be alive, but in a broken unrecoverable zombie state.

This PR adds the ability to reserve a DMA channel: the reservation consists of an owner and a callback. Only one reservation can be held, so if the user wants to start a subsequent (conflicting) audio device, then the prior device is gracefully shut down (through and eviction callback).

The PR then updates the three DMA-capable devices (Sound Blaster, Tandy, and GUS) to request DMA channel reservation.

- Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2544


