### PR TITLE
Use int64_t consistently for tick durations

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -119,33 +119,30 @@ static inline int64_t GetTicksUs()
 	        .count();
 }
 
-static inline int GetTicksDiff(const int64_t new_ticks, const int64_t old_ticks)
+static inline int64_t GetTicksDiff(const int64_t new_ticks, const int64_t old_ticks)
 {
 	assert(new_ticks >= old_ticks);
-	assert((new_ticks - old_ticks) <= std::numeric_limits<int>::max());
-	return static_cast<int>(new_ticks - old_ticks);
+	return new_ticks - old_ticks;
 }
 
-static inline int GetTicksSince(const int64_t old_ticks)
+static inline int64_t GetTicksSince(const int64_t old_ticks)
 {
 	const auto now = GetTicks();
-	assert((now - old_ticks) <= std::numeric_limits<int>::max());
 	return GetTicksDiff(now, old_ticks);
 }
 
-static inline int GetTicksUsSince(const int64_t old_ticks)
+static inline int64_t GetTicksUsSince(const int64_t old_ticks)
 {
 	const auto now = GetTicksUs();
-	assert((now - old_ticks) <= std::numeric_limits<int>::max());
 	return GetTicksDiff(now, old_ticks);
 }
 
-static inline void Delay(const int milliseconds)
+static inline void Delay(const int64_t milliseconds)
 {
 	std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }
 
-static inline void DelayUs(const int microseconds)
+static inline void DelayUs(const int64_t microseconds)
 {
 	std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
 }

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2177,8 +2177,8 @@ void CPU_Disable_SkipAutoAdjust(void) {
 }
 
 
-extern int ticksDone;
-extern int ticksScheduled;
+extern int64_t ticksDone;
+extern int64_t ticksScheduled;
 
 void CPU_Reset_AutoAdjust(void) {
 	CPU_IODelayRemoved = 0;

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -19,6 +19,7 @@
 #include "drives.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <vector>
 #include <string>
 #include <stdio.h>
@@ -214,8 +215,9 @@ public:
 			const auto a = logoverlay ? GetTicks() : 0;
 			bool r = create_copy();
 			const auto b = logoverlay ? GetTicksSince(a) : 0;
-			if (b > 2)
-				LOG_MSG("OPTIMISE: switching took %d", b);
+			if (b > 2) {
+				LOG_MSG("OPTIMISE: switching took %" PRId64, b);
+			}
 			if (!r) return false;
 			overlay_active = true;
 			
@@ -787,8 +789,9 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 
 		}
 	}
-	if (logoverlay)
-		LOG_MSG("OPTIMISE: update cache took %d", GetTicksSince(a));
+	if (logoverlay) {
+		LOG_MSG("OPTIMISE: update cache took %" PRId64, GetTicksSince(a));
+	}
 }
 
 bool Overlay_Drive::FindNext(DOS_DTA & dta) {
@@ -981,8 +984,9 @@ bool Overlay_Drive::FileUnlink(char * name) {
 		dirCache.DeleteEntry(basename);
 
 		update_cache(false);
-		if (logoverlay)
-			LOG_MSG("OPTIMISE: unlink took %d", GetTicksSince(a));
+		if (logoverlay) {
+			LOG_MSG("OPTIMISE: unlink took %" PRId64, GetTicksSince(a));
+		}
 		return true;
 	}
 }
@@ -1244,9 +1248,10 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		//Mark old file as deleted
 		add_deleted_file(oldname,true);
 		result = true; //success
-		if (logoverlay)
-			LOG_MSG("OPTIMISE: update rename with copy took %d",
+		if (logoverlay) {
+			LOG_MSG("OPTIMISE: update rename with copy took %" PRId64,
 			        GetTicksSince(aa));
+		}
 	}
 	if (result) {
 		//handle the drive_cache (a bit better)
@@ -1254,8 +1259,9 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		if (is_deleted_file(newname)) remove_deleted_file(newname,true);
 		dirCache.EmptyCache();
 		update_cache(true);
-		if (logoverlay)
-			LOG_MSG("OPTIMISE: rename took %d", GetTicksSince(a));
+		if (logoverlay) {
+			LOG_MSG("OPTIMISE: rename took %" PRId64, GetTicksSince(a));
+		}
 	}
 	return result;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -131,11 +131,11 @@ void INT10_Init(Section*);
 
 static LoopHandler * loop;
 
-static int ticksRemain;
+static int64_t ticksRemain;
 static int64_t ticksLast;
-static int ticksAdded;
-int ticksDone;
-int ticksScheduled;
+static int64_t ticksAdded;
+int64_t ticksDone;
+int64_t ticksScheduled;
 bool ticksLocked;
 void increaseticks();
 
@@ -223,7 +223,10 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero
 		/* ratio we are aiming for is around 90% usage*/
-		int32_t ratio = (ticksScheduled * (CPU_CyclePercUsed*90*1024/100/100)) / ticksDone;
+		int32_t ratio = static_cast<int32_t>(
+		        (ticksScheduled * (CPU_CyclePercUsed * 90 * 1024 / 100 / 100)) /
+		        ticksDone);
+
 		int32_t new_cmax = CPU_CycleMax;
 		int64_t cproc = (int64_t)CPU_CycleMax * (int64_t)ticksScheduled;
 		double ratioremoved = 0.0; //increase scope for logging

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -882,8 +882,8 @@ static int benchmark_presentation_rate()
 		sdl.frame.update(nullptr);
 		sdl.frame.present();
 	}
-	const auto elapsed_us = std::max(1, GetTicksUsSince(start_us));
-	return (bench_frames * 1'000'000) / elapsed_us;
+	const auto elapsed_us = std::max(static_cast<int64_t>(1L), GetTicksUsSince(start_us));
+	return static_cast<int>((bench_frames * 1'000'000) / elapsed_us);
 }
 
 static VSYNC_STATE get_reported_vsync()

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -23,9 +23,10 @@
 
 #include <SDL_net.h>
 
-#include <string.h>
-#include <time.h>
-#include <stdio.h>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 
 #include "cross.h"
 #include "string_utils.h"
@@ -802,11 +803,10 @@ bool ConnectToServer(const char* strAddr)
 			} else {
 				// Wait for return packet from server.
 				// This will contain our IPX address and port num
-				uint32_t elapsed;
 				const auto ticks = GetTicks();
 
 				while(true) {
-					elapsed = GetTicksSince(ticks);
+					const auto elapsed = GetTicksSince(ticks);
 					if(elapsed > 5000) {
 						LOG_MSG("Timeout connecting to server at %s", strAddr);
 						SDLNet_UDP_Close(ipxClientSocket);
@@ -1053,7 +1053,7 @@ public:
 					CALLBACK_Idle();
 					if(pingCheck(&pingHead)) {
 						WriteOut(
-						        "Response from %d.%d.%d.%d, port %d time=%dms\n",
+						        "Response from %d.%d.%d.%d, port %d time=ms\n",
 						        CONVIP(pingHead.src.addr.byIP.host),
 						        SDLNet_Read16(&pingHead.src.addr.byIP.port),
 						        GetTicksSince(ticks));

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -149,7 +149,7 @@ struct Midi {
 		uint8_t buf[MIDI_SYSEX_SIZE] = {};
 
 		size_t pos       = 0;
-		int delay_ms     = 0;
+		int64_t delay_ms = 0;
 		int64_t start_ms = 0;
 	} sysex = {};
 

--- a/src/misc/pacer.cpp
+++ b/src/misc/pacer.cpp
@@ -21,6 +21,8 @@
 
 #include "pacer.h"
 
+#include <cinttypes>
+
 Pacer::Pacer(const std::string &name, const int timeout, const LogLevel level)
         : pacer_name(name),
           iteration_start(GetTicksUs())
@@ -49,7 +51,7 @@ void Pacer::Checkpoint()
 	// Pacer is reset
 	if (was_reset) {
 		if (log_level == LogLevel::CHECKPOINTS)
-			LOG_MSG("PACER: %s reset ignored %dus of latency",
+			LOG_MSG("PACER: %s reset ignored %" PRId64 "us of latency",
 			        pacer_name.c_str(),
 			        GetTicksUsSince(iteration_start));
 		was_reset = false;
@@ -63,10 +65,10 @@ void Pacer::Checkpoint()
 
 		if (log_level != LogLevel::NOTHING) {
 			if (!can_run) {
-				LOG_WARNING("PACER: %s took %dus, skipping next",
+				LOG_WARNING("PACER: %s took %" PRId64 "us, skipping next",
 				            pacer_name.c_str(), iteration_took);
 			} else if (log_level == LogLevel::CHECKPOINTS) {
-				LOG_MSG("PACER: %s took %dus, can run next",
+				LOG_MSG("PACER: %s took %" PRId64 "us, can run next",
 				        pacer_name.c_str(), iteration_took);
 			}
 		}


### PR DESCRIPTION
I left DOSBox running for a few hours in the afternoon in the background, then when I brought it to the foreground, it crashed with the following:

```
Assertion failed: ((new_ticks - old_ticks) <= std::numeric_limits<int>::max()), function GetTicksDiff, file timer.h, line 125.
```

Turns out the results of the tick difference calculation was truncated to half the 32-bit integer range, effectively, and for no good reason. This fixes that, plus cleans up the tick variable types in a few places (changing from `int` to `int64_t`).

Technically, it would be better to use `uint64_t`, but job for another day 😄 