### PR TITLE
DOS mouse driver fixes

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -134,7 +134,7 @@ bool MOUSEPS2_SendPacket();
 // ***************************************************************************
 
 void MOUSEDOS_BeforeNewVideoMode();
-void MOUSEDOS_AfterNewVideoMode(const bool setmode);
+void MOUSEDOS_AfterNewVideoMode(const bool is_mode_changing);
 
 // ***************************************************************************
 // MOUSECTL.COM / GUI configurator interface


### PR DESCRIPTION
- small code cleanups
- fix problem with mouse cursor in text modes being limited to 80 columns - for both VESA (which fixes https://github.com/dosbox-staging/dosbox-staging/issues/2599) and non-VESA modes (fixes modes like 94x30)
- set proper screen parameters on DOS mouse driver reset / video mode set hook (partially based on DOSBox-X code)

-----

The easiest way to test mouse driver behavior in various text modes is to use _Necromancer's DOS Navigator_ - open the _burger_ menu in the top-left screen corner, go to _Video modes_.