### PR TITLE
Refill the SB audio channel when DMA reaches terminal count (#233)

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -588,8 +588,12 @@ static void DSP_FlushData()
 static double last_dma_callback = 0.0;
 
 static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
-	if (chan!=sb.dma.chan || event==DMA_REACHED_TC) return;
-	else if (event==DMA_MASKED) {
+	assert(chan && chan == sb.dma.chan);
+
+	if (event == DMA_REACHED_TC) {
+		assert(sb.mode == MODE_DMA);
+		sb.chan->FillUp();
+	} else if (event == DMA_MASKED) {
 		if (sb.mode==MODE_DMA) {
 			//Catch up to current time, but don't generate an IRQ!
 			//Fixes problems with later sci games.


### PR DESCRIPTION
When the active DMA channel signals its reached terminal count, there is a balance of now transferred (from the game into the memory location) samples waiting to be consumed, but that haven't been read yet by the SB.

This commit asks the audio channel to get caught up to the current time: that is, to the same state when the DMA transfer completed. This fill up step will read a balance of remaining DMA samples, and queue them for playback.

In 'Worms', logging shows the pending tail of DMA data is anywhere from 4 to 30 bytes. Filling up the channel to the current time draws in enough DMA samples to complete the transfer on the SB side.

- Fixes https://github.com/dosbox-staging/dosbox-staging/issues/233