### PR TITLE
Implement persistent command line history

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -111,6 +111,8 @@ public:
 	bool CheckConfig(char* cmd_in,char*line);
 	/* Internal utilities for testing */
 	virtual bool execute_shell_cmd(char *name, char *arguments);
+	void ReadCommandHistory();
+	void WriteCommandHistory();
 
 	/* Commands */
 	void CMD_HELP(char * args);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1222,6 +1222,10 @@ void DOSBOX_Init()
 	        "tab-separated format, used by SETVER.EXE as a persistent storage\n"
 	        "(empty by default).");
 
+	pstring = secprop->Add_path("command_history_file", only_at_start, "cmd_history.txt");
+	pstring->Set_help(
+		"File containing persistent command line history ('cmd_history.txt' by default).");
+
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
 	secprop->AddInitFunction(&DRIVES_Init);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -463,6 +463,9 @@ static std_fs::path get_cmd_history_path()
 
 void DOS_Shell::ReadCommandHistory()
 {
+	if (control->SecureMode()) {
+		return;
+	}
 	std::ifstream history_file(get_cmd_history_path());
 	if (history_file) {
 		std::string line;
@@ -478,6 +481,9 @@ void DOS_Shell::ReadCommandHistory()
 
 void DOS_Shell::WriteCommandHistory()
 {
+	if (control->SecureMode()) {
+		return;
+	}
 	std_fs::path history_path = get_cmd_history_path();
 	std::ofstream history_file(history_path);
 	if (!history_file) {


### PR DESCRIPTION
Fixes #2559 

I mimicked the behavior of what I observed from bash_history on my system.  I set a cap of 500 lines on the history file so it won't grow endlessly (same as what bash appears to use).  The shell simply reads from the file on startup and writes back out to it on close.

I thought about adding this to constructor and destructor of the DOS_Shell class but in testing I noticed that when COMMAND.COM gets created, it uses an instance of DOS_Shell and was clobbering the file so I implemented this only for `first_shell` instead, which from testing works fine.