### PR TITLE
Don't emulate CDROM lag for stationary calls

### DIFF
--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -80,7 +80,6 @@ bool CDROM_Interface_SDL::GetAudioTracks(uint8_t &stTrack, uint8_t &end, TMSF &l
 		stTrack = 1;
 		end = cd->numtracks;
 		leadOut = frames_to_msf(cd->track[cd->numtracks].offset);
-		LagDriveResponse();
 	}
 	return CD_INDRIVE(SDL_CDStatus(cd));
 }
@@ -94,7 +93,6 @@ bool CDROM_Interface_SDL::GetAudioTrackInfo(uint8_t track,
 		attr = cd->track[track - 1].type << 4; // sdl uses 0 for audio
 		                                       // and 4 for data. instead
 		                                       // of 0x00 and 0x40
-		LagDriveResponse();
 	}
 	return CD_INDRIVE(SDL_CDStatus(cd));
 }
@@ -121,7 +119,6 @@ bool CDROM_Interface_SDL::GetAudioStatus(bool &playing, bool &pause)
 	if (CD_INDRIVE(SDL_CDStatus(cd))) {
 		playing = (cd->status == CD_PLAYING);
 		pause = (cd->status == CD_PAUSED);
-		LagDriveResponse();
 	}
 	return CD_INDRIVE(SDL_CDStatus(cd));
 }
@@ -137,7 +134,6 @@ bool CDROM_Interface_SDL::GetMediaTrayStatus(bool &mediaPresent,
 	oldLeadOut = cd->track[cd->numtracks].offset;
 	if (mediaChanged) {
 		SDL_CDStatus(cd);
-		LagDriveResponse();
 	}
 	return true;
 }
@@ -152,7 +148,6 @@ bool CDROM_Interface_SDL::PlayAudioSector(const uint32_t start, uint32_t len)
 
 bool CDROM_Interface_SDL::PauseAudio(bool resume)
 {
-	LagDriveResponse();
 	if (resume)
 		return (SDL_CDResume(cd) == 0);
 	else
@@ -165,13 +160,11 @@ bool CDROM_Interface_SDL::StopAudio()
 	SDL_CDClose(cd);
 	cd = SDL_CDOpen(driveID);
 
-	LagDriveResponse();
 	return (SDL_CDStop(cd) == 0);
 }
 
 bool CDROM_Interface_SDL::LoadUnloadMedia([[maybe_unused]] bool unload)
 {
-	LagDriveResponse();
 	return (SDL_CDEject(cd) == 0);
 }
 
@@ -219,7 +212,6 @@ bool CDROM_Interface_Fake::GetAudioTracks(uint8_t& stTrack, uint8_t& end, TMSF& 
 	leadOut.min	= 60;
 	leadOut.sec = leadOut.fr = 0;
 
-	LagDriveResponse();
 	return true;
 }
 
@@ -229,7 +221,6 @@ bool CDROM_Interface_Fake::GetAudioTrackInfo(uint8_t track, TMSF& start, unsigne
 	start.sec = 2;
 	attr	  = 0x60; // data / permitted
 
-	LagDriveResponse();
 	return true;
 }
 
@@ -245,8 +236,6 @@ bool CDROM_Interface_Fake :: GetAudioSub(unsigned char& attr, unsigned char& tra
 
 bool CDROM_Interface_Fake :: GetAudioStatus(bool& playing, bool& pause) {
 	playing = pause = false;
-
-	LagDriveResponse();
 	return true;
 }
 
@@ -254,8 +243,6 @@ bool CDROM_Interface_Fake :: GetMediaTrayStatus(bool& mediaPresent, bool& mediaC
 	mediaPresent = true;
 	mediaChanged = false;
 	trayOpen     = false;
-
-	LagDriveResponse();
 	return true;
 }
 

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -580,7 +580,6 @@ bool CDROM_Interface_Image::GetAudioTracks(uint8_t& start_track_num,
 	        lead_out_msf.sec,
 	        lead_out_msf.fr);
 #endif
-	LagDriveResponse();
 	return true;
 }
 
@@ -614,7 +613,6 @@ bool CDROM_Interface_Image::GetAudioTrackInfo(uint8_t requested_track_num,
 	        start_msf.fr,
 	        msf_to_frames(start_msf));
 #endif
-	LagDriveResponse();
 	return true;
 }
 
@@ -686,7 +684,6 @@ bool CDROM_Interface_Image::GetAudioStatus(bool& playing, bool& pause)
 	        playing ? "is playing" : "stopped",
 	        pause ? "paused" : "not paused");
 #endif
-	LagDriveResponse();
 	return true;
 }
 
@@ -701,7 +698,6 @@ bool CDROM_Interface_Image::GetMediaTrayStatus(bool& mediaPresent, bool& mediaCh
 	        mediaChanged ? "was changed" : "hasn't been changed",
 	        trayOpen ? "open" : "closed");
 #endif
-	LagDriveResponse();
 	return true;
 }
 
@@ -814,7 +810,6 @@ bool CDROM_Interface_Image::PauseAudio(bool resume)
 	player.isPaused = !resume;
 	if (player.channel) {
 		player.channel->Enable(resume);
-		LagDriveResponse();
 	}
 #ifdef DEBUG
 	LOG_MSG("CDROM: PauseAudio => audio is now %s",
@@ -829,7 +824,6 @@ bool CDROM_Interface_Image::StopAudio(void)
 	player.isPaused = false;
 	if (player.channel) {
 		player.channel->Enable(false);
-		LagDriveResponse();
 	}
 #ifdef DEBUG
 	LOG_MSG("CDROM: StopAudio => stopped playback and halted the mixer");
@@ -955,7 +949,6 @@ track_iter CDROM_Interface_Image::GetTrack(const uint32_t sector)
 		}
 	}
 #endif
-	LagDriveResponse();
 	return track;
 }
 


### PR DESCRIPTION
These are calls where time is not being measured or changing.

The remaining calls (left unchanged) involve the passage of time, such as getting the current playback position as relative and absolute MSF objects.

Thanks to @0mnicydle for quickly flagging this as a regression in Dark Seek II's intro FMV sequence.