### PR TITLE
Restore authentic text mode pixel aspect ratio calculation

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1986,7 +1986,8 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		vga.draw.blocks = width;
 		doublewidth = vga.seq.clocking_mode.is_pixel_doubling;
 		width *= vga.draw.pixels_per_character;
-		aspect_ratio = width * 3.0 * (doublewidth ? 2 : 1) / (height * 4.0);
+		aspect_ratio *= vga.draw.pixels_per_character /
+		                static_cast<double>(PixelsPerChar::Eight);
 		break;
 	case M_HERC_GFX:
 		vga.draw.blocks=width*2;


### PR DESCRIPTION
This restores the previous authentic (or more authentic 😏) pixel aspect ratio calculation for text modes. Text modes are not just simply stretched to the 4:3 CRT screen; some of them actually appear "widescreen" when I tested them on my CRT with my S3 card, for example, mode 10Ah (120x43 VESA text mode) that is shown in the below example.

Previously, DOSBox actually quite faithfully replicated these strange PARs, so I'm restoring that behaviour. A nice side effect of these "widescreen" 120-column text modes with the previous PAR is that when you go fullscreen, they quite nicely fill a modern widescreen display! So I think in this case the authentic behaviour is quite useful and preferable in a modern context 😎 🤘🏻

### Current main

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/ebc98374-cbe1-4e88-9850-d87e1ca6bf09)

### With restored aspect ratio

(Just showcasing how it appears letterboxed on a 4:3 CRT screen. The window has 4:3 aspect ratio. But when you go fullscreen, this fits a widescreen display almost perfectly!)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/3ee6d8c6-8731-4919-a036-1e7775fa1cb4)

