### PR TITLE
Fix mounting directory with space in its name, passed as an argument

### DIFF
--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -318,7 +318,7 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		}
 
 		if (is_directory) {
-			drive_c_directory = argument;
+			drive_c_directory = quote + argument + quote;
 			continue;
 		}
 


### PR DESCRIPTION
Fix the following problem, reported by user Jow on Discord:
- prepare directory with space in it's name
- pass it as an argument to DOSBox executable (`dosbox "/path/to/directory with space/"` on Linux)
- DOSBox fails to mount the directory as drive C:

Reason: lack of quotation marks in the `MOUNT` command in generated `Z:\AUTOEXEC.BAT` file.