### PR TITLE
Don't save command history to current working directory

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -462,6 +462,11 @@ static std::string get_command_history_path()
 	if (section) {
 		const auto path = section->Get_path("command_history_file");
 		if (path) {
+			// Workaround: If command_history_file is not in the user's config, path->SetValue function never gets called which sets realpath.
+			// Append the config dir here to prevent this from getting written to current working directory in that case.
+			if (path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
+				return (get_platform_config_dir() / path->realpath).string();
+			}
 			return path->realpath;
 		}
 	}


### PR DESCRIPTION
Fixes #2629 

Root problem is this function doesn't get run if the user's config does not have an entry at all:

https://github.com/dosbox-staging/dosbox-staging/blob/172ba3322acf5a686e6daa1df4dbf4a0bc18a71d/src/misc/setup.cpp#L435-L462

So it seems `realpath` cannot be relied on.  I added a workaround to command history's case to append the config directory manually if it hasn't already been done (user can still specify an absolute path to store it wherever they like). 

I think maybe the `Prop_path::SetValue` function should be re-visited but I'm not sure of the best solution.  Maybe it should store a `std_fs::path` rather than a string and find the real path at construction time rather than when it finds a matching line in the config file?