### PR TITLE
Fix a couple Coverity warnings involved unchecked return values

### DIFF
--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -464,10 +464,12 @@ void IMGMOUNT::Run(void)
 			const bool should_notify = std::next(it) == fat_pointers.end();
 			DriveManager::CycleDisks(drive_index(drive), should_notify);
 			char root[7] = {drive, ':', '\\', '*', '.', '*', 0};
-			DOS_FindFirst(root, DOS_ATTR_VOLUME); // force obtaining
-			                                      // the label and
-			                                      // saving it in
-			                                      // dirCache
+
+			// Obtain the drive label, saving it in the dirCache
+			if (!DOS_FindFirst(root, DOS_ATTR_VOLUME)) {
+				LOG_WARNING("DRIVE: Unable to find %c drive's volume label",
+				            drive);
+			}
 		}
 		dos.dta(save_dta);
 

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -246,8 +246,8 @@ void IMGMOUNT::Run(void)
 		}
 		drive = int_to_char(i_drive);
 	} else if (fstype == "none") {
-		cmd->FindCommand(1, temp_line);
-		if ((temp_line.size() > 1) || (!isdigit(temp_line[0]))) {
+		if (!cmd->FindCommand(1, temp_line) || temp_line.size() > 1 ||
+		    !isdigit(temp_line[0])) {
 			WriteOut_NoParsing(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY2"));
 			return;
 		}

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -395,8 +395,13 @@ int VideoCodec::FinishCompressFrame()
 	zstream.next_out  = compress.writeBuf + compress.writeDone;
 	zstream.avail_out = compress.writeSize - compress.writeDone;
 	zstream.total_out = 0;
-	deflate(&zstream, Z_SYNC_FLUSH);
-	const auto bytes_processed = static_cast<int>(compress.writeDone + zstream.total_out);
+
+	int bytes_processed = 0;
+
+	// Only tally bytes if the stream was OK
+	if (deflate(&zstream, Z_SYNC_FLUSH) >= Z_OK) {
+		bytes_processed = static_cast<int>(compress.writeDone + zstream.total_out);
+	}
 	return bytes_processed;
 }
 


### PR DESCRIPTION
(Review commit-by-commit; they are each stand-alone)
