### PR TITLE
Disable writing command line history if entry is empty

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -464,7 +464,7 @@ static std::string get_command_history_path()
 		if (path) {
 			// Workaround: If command_history_file is not in the user's config, path->SetValue function never gets called which sets realpath.
 			// Append the config dir here to prevent this from getting written to current working directory in that case.
-			if (path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
+			if (!path->realpath.empty() && path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
 				return (get_platform_config_dir() / path->realpath).string();
 			}
 			return path->realpath;


### PR DESCRIPTION
Follow up to #2629 and #2630

Command history should be disabled if the config entry is empty.  This is a regression caused by my previous PR.  Added missing empty check.

Likely this just caused an erroneous warning message as it tried to create a file with the same name as the user's config directory, which will fail.