### PR TITLE
Implemented VOL shell command

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -144,6 +144,7 @@ public:
 	void CMD_SHIFT(char * args);
 	void CMD_VER(char * args);
 	void CMD_LS(char *args);
+	void CMD_VOL(char *args);
 
 	/* The shell's variables */
 	uint16_t input_handle = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1250,6 +1250,25 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_VER_VER", "DOSBox Staging version %s\n"
 	                             "DOS version %d.%02d\n");
 	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
+	MSG_Add("SHELL_CMD_VOL_HELP", "Displays the disk volume and serial number, if they exist.\n");
+	MSG_Add("SHELL_CMD_VOL_HELP_LONG",
+	        "Usage:\n"
+	        "  [color=green]vol[reset] [color=cyan][DRIVE:][reset]\n"
+	        "\n"
+	        "Where:\n"
+	        "  [color=cyan]DRIVE[reset] is a drive letter followed by a colon.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Running [color=green]vol[reset] without an argument displays uses the current drive.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=green]vol[reset]\n"
+	        "  [color=green]vol[reset] [color=cyan]c:[reset]\n");
+	MSG_Add("SHELL_CMD_VOL_OUTPUT",
+			"\n"
+			" Volume in drive %c is %s\n"
+			" Volume Serial Number is %04X-%04X\n"
+			"\n");
 
 	/* Ensure help categories are loaded into the message vector */
 	HELP_AddMessages();


### PR DESCRIPTION
Fixes #2540 

I did this DOS interrupt thing since that was the only function that returns a serial number (even though it's currently hard-coded to 0x1234).  I ran MS-DOS 6.22 in 86box and matched the output with that (though using DOSBox's own more helpful error messages).

@johnnovak Had issues trying to push this to a branch on the main repo so I just pushed this to my fork.

```
Enumerating objects: 15, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 4 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 2.29 KiB | 2.29 MiB/s, done.
Total 8 (delta 7), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (7/7), completed with 7 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/wd/vol.
remote: error: This branch must not contain merge commits.
To https://github.com/dosbox-staging/dosbox-staging.git
 ! [remote rejected]     wd/vol -> wd/vol (protected branch hook declined)
error: failed to push some refs to 'https://github.com/dosbox-staging/dosbox-staging.git'
```

The weird thing is it let me create a branch without the "wd/" prefix (I did so accidentally and then deleted it) so I have permissions to push where I shouldn't but not to where I should.