### PR TITLE
Implemented VOL shell command

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -47,7 +47,8 @@ extern DOS_Shell * first_shell;
 
 class BatchFile {
 public:
-	BatchFile(DOS_Shell * host,char const* const resolved_name,char const* const entered_name, char const * const cmd_line);
+	BatchFile(DOS_Shell* host, const char* const resolved_name,
+	          const char* const entered_name, const char* const cmd_line);
 	BatchFile(const BatchFile&) = delete; // prevent copying
 	BatchFile& operator=(const BatchFile&) = delete; // prevent assignment
 	virtual ~BatchFile();
@@ -144,6 +145,7 @@ public:
 	void CMD_SHIFT(char * args);
 	void CMD_VER(char * args);
 	void CMD_LS(char *args);
+	void CMD_VOL(char* args);
 
 	/* The shell's variables */
 	uint16_t input_handle = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -638,10 +638,10 @@ static Bitu INT2E_Handler()
 	return CBRET_NONE;
 }
 
-static char const * const path_string="PATH=Z:\\";
-static char const * const comspec_string="COMSPEC=Z:\\COMMAND.COM";
-static char const * const full_name="Z:\\COMMAND.COM";
-static char const * const init_line="/INIT AUTOEXEC.BAT";
+static const char* const path_string    = "PATH=Z:\\";
+static const char* const comspec_string = "COMSPEC=Z:\\COMMAND.COM";
+static const char* const full_name      = "Z:\\COMMAND.COM";
+static const char* const init_line      = "/INIT AUTOEXEC.BAT";
 
 void SHELL_Init() {
 	// Generic messages, to be used by any command or DOS program
@@ -1250,6 +1250,26 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_VER_VER", "DOSBox Staging version %s\n"
 	                             "DOS version %d.%02d\n");
 	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
+	MSG_Add("SHELL_CMD_VOL_HELP",
+	        "Displays the disk volume and serial number, if they exist.\n");
+	MSG_Add("SHELL_CMD_VOL_HELP_LONG",
+	        "Usage:\n"
+	        "  [color=green]vol[reset] [color=cyan][DRIVE:][reset]\n"
+	        "\n"
+	        "Where:\n"
+	        "  [color=cyan]DRIVE[reset] is a drive letter followed by a colon.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  Running [color=green]vol[reset] without an argument displays uses the current drive.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=green]vol[reset]\n"
+	        "  [color=green]vol[reset] [color=cyan]c:[reset]\n");
+	MSG_Add("SHELL_CMD_VOL_OUTPUT",
+	        "\n"
+	        " Volume in drive %c is %s\n"
+	        " Volume Serial Number is %04X-%04X\n"
+	        "\n");
 
 	/* Ensure help categories are loaded into the message vector */
 	HELP_AddMessages();


### PR DESCRIPTION
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2540

I did this DOS interrupt thing since that was the only function that returns a serial number (even though it's currently hard-coded to 0x1234). I ran MS-DOS 6.22 in 86box and matched the output with that (though using DOSBox's own more helpful error messages).

Seems I'm able to create branches now so I'll delete the old PR and use this.