### PR TITLE
Rename command_history to shell_history, for consistency

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -111,8 +111,8 @@ public:
 	bool CheckConfig(char* cmd_in,char*line);
 	/* Internal utilities for testing */
 	virtual bool execute_shell_cmd(char *name, char *arguments);
-	void ReadCommandHistory();
-	void WriteCommandHistory();
+	void ReadShellHistory();
+	void WriteShellHistory();
 
 	/* Commands */
 	void CMD_HELP(char * args);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1218,9 +1218,10 @@ void DOSBOX_Init()
 	        "(auto by default, enabled if DOS version >= 7.0).\n"
 	        "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
 
-	pstring = secprop->Add_path("command_history_file", only_at_start, "cmd_history.txt");
+	pstring = secprop->Add_path("shell_history_file", only_at_start, "shell_history.txt");
 	pstring->Set_help(
-		"File containing persistent command line history ('cmd_history.txt' by default).");
+		"File containing persistent command line history ('shell_history.txt'\n"
+		"by default).");
 
 	// Misc DOS command settings
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -456,13 +456,13 @@ void DOS_Shell::SyntaxError()
 	WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 }
 
-static std::string get_command_history_path()
+static std::string get_shell_history_path()
 {
 	const auto section = static_cast<Section_prop *>(control->GetSection("dos"));
 	if (section) {
-		const auto path = section->Get_path("command_history_file");
+		const auto path = section->Get_path("shell_history_file");
 		if (path) {
-			// Workaround: If command_history_file is not in the user's config, path->SetValue function never gets called which sets realpath.
+			// Workaround: If shell_history_file is not in the user's config, path->SetValue function never gets called which sets realpath.
 			// Append the config dir here to prevent this from getting written to current working directory in that case.
 			if (!path->realpath.empty() && path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
 				return (get_platform_config_dir() / path->realpath).string();
@@ -473,12 +473,12 @@ static std::string get_command_history_path()
 	return {};
 }
 
-void DOS_Shell::ReadCommandHistory()
+void DOS_Shell::ReadShellHistory()
 {
 	if (control->SecureMode()) {
 		return;
 	}
-	std::string history_path = get_command_history_path();
+	std::string history_path = get_shell_history_path();
 	if (history_path.empty()) {
 		return;
 	}
@@ -495,18 +495,19 @@ void DOS_Shell::ReadCommandHistory()
 	}
 }
 
-void DOS_Shell::WriteCommandHistory()
+void DOS_Shell::WriteShellHistory()
 {
 	if (control->SecureMode()) {
 		return;
 	}
-	std::string history_path = get_command_history_path();
+	std::string history_path = get_shell_history_path();
 	if (history_path.empty()) {
 		return;
 	}
 	std::ofstream history_file(history_path);
 	if (!history_file) {
-		LOG_WARNING("SHELL: Unable to write command history to file: '%s'", history_path.c_str());
+		LOG_WARNING("SHELL: Unable to update history file: '%s'",
+		            history_path.c_str());
 		return;
 	}
 	std::vector<std::string> trimmed_history;
@@ -1349,9 +1350,9 @@ void SHELL_Init() {
 	// first_shell is only setup here, so may as well invoke
 	// it's constructor directly
 	first_shell = new DOS_Shell;
-	first_shell->ReadCommandHistory();
+	first_shell->ReadShellHistory();
 	first_shell->Run();
-	first_shell->WriteCommandHistory();
+	first_shell->WriteShellHistory();
 	delete first_shell;
 	first_shell = nullptr; // Make clear that it shouldn't be used anymore
 }


### PR DESCRIPTION
Rename `command_history_file` to `shell_history_file`, for consistency with `expand_shell_variable` option. Also renamed the default history file to `shell_history.txt`.