### PR TITLE
Enable loguru stack traces

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -246,16 +246,4 @@
 // XDG_DATA_HOME or XDG_DATA_DIRS to include the --datadir.
 #mesondefine CUSTOM_DATADIR
 
-/* Loguru-related defines
- */
-
-// Prevent loguru from parsing command-line arguments with
-// with the hosts's locale-applied, because this can foul up
-// ncurses. (DOSBox also doesn't have foreign-language arguments).
-//
-#define LOGURU_USE_LOCALE 0
-
-// Redefine “assert” to call Loguru version (!NDEBUG only).
-#define LOGURU_REDEFINE_ASSERT 1
-
 #endif

--- a/src/libs/loguru/meson.build
+++ b/src/libs/loguru/meson.build
@@ -1,3 +1,23 @@
+# Enable Loguru stack traces if supported
+stacktrace_headers = ['cxxabi.h', 'dlfcn.h', 'execinfo.h']
+
+all_stacktrace_headers_found = true
+
+foreach header : stacktrace_headers
+    if not cxx.has_header(header)
+        all_stacktrace_headers_found = false
+    endif
+endforeach
+
+if all_stacktrace_headers_found
+    add_project_arguments('-DLOGURU_STACKTRACES=1', language: 'cpp')
+endif
+
+# Prevent loguru from parsing command-line arguments with
+# the hosts's locale-applied, because this can foul up
+# ncurses. (DOSBox also doesn't have foreign-language arguments).
+add_project_arguments('-DLOGURU_USE_LOCALE=0', language: 'cpp')
+
 libloguru = static_library(
     'loguru',
     'loguru.cpp',

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -122,15 +122,3 @@
 // On Windows, this path is not customizeable, so it's left blank here.
 //
 #define CUSTOM_DATADIR ""
-
-/* Loguru-related defines
- */
-
-// Prevent loguru from parsing command-line arguments with
-// with the hosts's locale-applied, because this can foul up
-// ncurses. (DOSBox also doesn't have foreign-language arguments).
-//
-#define LOGURU_USE_LOCALE 0
-
-// Redefine “assert” to call Loguru version (!NDEBUG only).
-#define LOGURU_REDEFINE_ASSERT 1


### PR DESCRIPTION
Loguru's autodetect logic for enabling stack traces is not very robust, so add logic to meson.build that checks for the headers included by `loguru.cpp` if `LOGURU_STACKTRACES=1`.

Here is the relevant snippet from `loguru.cpp`

```cpp
#if LOGURU_STACKTRACES
	#include <cxxabi.h>    // for __cxa_demangle
	#include <dlfcn.h>     // for dladdr
	#include <execinfo.h>  // for backtrace
#endif // LOGURU_STACKTRACES
```

So  I just check for those headers in `meson.build` and force the flag, since `loguru.cpp` needs to be compiled with it.

Here's an example trace from an assert:

```log
Assertion failed: (1==0), function increaseticks, file dosbox.cpp, line 186.

Loguru caught a signal: SIGABRT
Stack trace:
18         0x18d68bf28 start + 2236
17         0x1000b2624 main + 36
16         0x1003a3760 sdl_main(int, char**) + 5844
15         0x1001186bc Config::StartUp() + 28
14         0x100626408 SHELL_Init() + 3904
13         0x100623704 DOS_Shell::Run() + 1540
12         0x100647408 DOS_Shell::InputCommand(char*) + 56
11         0x100647984 DOS_Shell::ReadCommand() + 712
10         0x10025a8f0 DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool) + 292
9          0x1002551cc DOS_Device::Read(unsigned char*, unsigned short*) + 64
8          0x100252c04 device_CON::Read(unsigned char*, unsigned short*) + 340
7          0x100184a90 CALLBACK_RunRealInt(unsigned char) + 92
6          0x1000b2ecc DOSBOX_RunMachine() + 28
5          0x1000b2e90 Normal_Loop() + 264
4          0x1000b2704 increaseticks() + 196
3          0x18d8f0e44 err + 0
2          0x18d8f1ae8 abort + 180
1          0x18d9e3c28 pthread_kill + 288
0          0x18da12a24 _sigtramp + 56
2023-06-28 10:03:55.285 | Signal: SIGABRT
```