### PR TITLE
Fix bug where DTA can be modified by DELETE command

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -226,9 +226,6 @@ void DOS_Shell::CMD_CLS(char *args)
 
 void DOS_Shell::CMD_DELETE(char * args) {
 	HELP("DELETE");
-	/* Command uses dta so set it to our internal dta */
-	const RealPt save_dta = dos.dta();
-	dos.dta(dos.tables.tempdta);
 
 	char * rem=ScanCMDRemain(args);
 	if (rem) {
@@ -242,6 +239,11 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	args = ExpandDot(args,buffer, CROSS_LEN);
 	StripSpaces(args);
 	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));return; }
+
+	/* Command uses dta so set it to our internal dta */
+	const RealPt save_dta = dos.dta();
+	dos.dta(dos.tables.tempdta);
+
 //TODO Maybe support confirmation for *.* like dos does.
 	bool res=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME);
 	if (!res) {


### PR DESCRIPTION
I was looking at code for these shell commands and I believe I found a bug here.  There's two error checking + early returns where the DTA can be modified and not restored.  In other commands, it gets restored on all paths.

DTA is not actually needed until `DOS_FindFirst` gets run so I moved the saving/modifying code until after the error checking is done.