### PR TITLE
Update RPM spec file

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ example, the **debug** and **release** configurations can reside in
 `build/debug` and `build/release`, respectively.
 
 We recommend setting the following Ccache environment variables to maximize
-the use of storage and benefit from precompiled headers:
+the use of storage and benefit from pre-compiled headers:
 
 ```shell
 CCACHE_COMPRESS=true
@@ -91,12 +91,12 @@ meson compile -C build/release-tracy
 
 If using Visual Studio, select the `Tracy` build configuration.
 
-We have instrumented a very small core of subsystem functions for baseline 
+We have instrumented a very small core of subsystem functions for baseline
 demonstration purposes. You can add additional profiling macros to your functions
 of interest.
 
 The resulting binary requires the Tracy profiler server to view profiling
-data. If using Meson on a *nix system, switch to 
+data. If using Meson on a *nix system, switch to
 `subprojects/tracy.x.x.x.x/profiler/build/unix` and run `make`
 
 If using Windows, binaries are available from the [releases](https://github.com/wolfpld/tracy/releases)
@@ -106,7 +106,7 @@ page, or you can build it locally with Visual Studio using the solution at
 Start the instrumented Staging binary, then start the server. You should see
 Staging as an available client for Connect.
 
-You can also run the server on a different machine on the network, even on a 
+You can also run the server on a different machine on the network, even on a
 different platform, profiling Linux from Windows or vice versa, for example.
 
 Please refer to the Tracy documentation for further information.
@@ -115,13 +115,13 @@ Please refer to the Tracy documentation for further information.
 
 By default, the Meson build system will lookup shared (or dynamic)
 libraries using PATH-provided pkg-config or cmake.  If they're not
-avaiable or usable, Meson's wrap system will will build local static
+available or usable, Meson's wrap system will will build local static
 libraries to meet this need.
 
 If your environment requires all dependencies be provided by the system,
 then you can disable the wrap system using Meson's setup flag:
 `-Dwrap_mode=nofallback`.  However, this will require the operating
-system satify all of DOSBox Staging's library dependencies.
+system satisfy all of DOSBox Staging's library dependencies.
 
 Detailed documentation: [Meson: Core options][meson-core]
 
@@ -155,7 +155,7 @@ meson configure build
 ```
 
 Options can be passed to the `meson setup` command using `-Doption=value`
-notation or using comma-separated notation (ie: `-Doption=value1,value2,value3`)
+notation or using comma-separated notation (i.e.: `-Doption=value1,value2,value3`)
 when the option supports multiple values.
 
 ### If your build fails
@@ -170,7 +170,7 @@ when the option supports multiple values.
 3. If the build fails with errors from the compiler (gcc/clang/msvc)
    or linker, then please open a new issue.
 
-4. If Meson reports a problem with a subpackage, try resetting it
+4. If Meson reports a problem with a sub-package, try resetting it
    with `meson subprojects update --reset name-of-subpackage`. For example,
    to reset FluidSynth: `meson subprojects update --reset fluidsynth`.
 
@@ -291,7 +291,7 @@ meson compile -C build/debug scan-build
 Recent compilers can add runtime checks for various classes of issues.
 Compared to a debug build, sanitizer builds take longer to compile
 and run slower, so are often reserved to exercise new features or
-perform a periodic whole-program checkup.
+perform a periodic whole-program check-up.
 
 - **Linux users:**:  We recommend using Clang's latest
 stable version. If you're using a Debian or Ubuntu-based distro,
@@ -317,6 +317,5 @@ The directory `build/sanitizer` will contain the compiled files, which
 will leave your normal `build/` files untouched.
 
 Run the sanitizer binary as you normally would, then exit and look for
-sanitizer mesasge in the log output.  If none exist, then your program
+sanitizer messages in the log output.  If none exist, then your program
 is running clean.
-

--- a/contrib/fedora/RPMBUILD.md
+++ b/contrib/fedora/RPMBUILD.md
@@ -18,12 +18,17 @@ Do some verification:
     $ rpmlint ~/rpmbuild/RPMS/x86_64/dosbox-staging-*
     $ rpmlint ~/rpmbuild/SRPMS/dosbox-staging-*
 
+Validate build using mock:
+  mock will do a build in a clean chroot environment. This is useful to check
+  if all all the necessary BuildRequires are specified to do a clean build:
+    $ mock -r default ~/rpmbuild/SRPMS/dosbox-staging-0.80.1-1.src.rpm
+
 Fedora build (via Koji buildsystem):
 
     $ sudo dnf install -y fedora-packager
     $ echo "<user>" > ~/.fedora.upn
     $ kinit <user>@FEDORAPROJECT.ORG
-    $ koji build --scratch rawhide ~/rpmbuild/SRPMS/dosbox-staging-0.77.0-*
+    $ koji build --scratch rawhide ~/rpmbuild/SRPMS/dosbox-staging-0.80.1-*
 
 Koji will print build status and URL (Task info).
 

--- a/contrib/fedora/dosbox-staging.spec
+++ b/contrib/fedora/dosbox-staging.spec
@@ -1,44 +1,38 @@
 Name:    dosbox-staging
-Version: 0.79.0
-Release: 2%{?dist}
+Version: 0.80.1
+Release: 1%{?dist}
 Summary: DOS/x86 emulator focusing on ease of use
 License: GPLv2+
 URL:     https://dosbox-staging.github.io/
 
 Source0: https://github.com/dosbox-staging/dosbox-staging/archive/v%{version}/%{name}-%{version}.tar.gz
-Source1: https://github.com/munt/munt/archive/libmt32emu_2_5_3.tar.gz
-# Downloaded from: https://wrapdb.mesonbuild.com/v2/mt32emu_2.5.3-1/get_patch
-Source2: mt32emu_2.5.3-1_patch.zip
-
-# https://github.com/dosbox-staging/dosbox-staging/commit/5d25187760e595f7e6efa6b639c3945fb4804db1
-Patch1: 0001-Add-0.77.0-release-to-metainfo.xml.patch
 
 # This package is a drop-in replacement for dosbox
 Provides:  dosbox = %{version}-%{release}
 Obsoletes: dosbox < 0.74.4
 
-Provides: bundled(mt32emu) = 2.5.3
-
 BuildRequires: alsa-lib-devel
 BuildRequires: desktop-file-utils
+BuildRequires: ffmpeg-free-devel
 BuildRequires: fluidsynth-devel >= 2.2.3
 BuildRequires: gcc
 BuildRequires: gcc-c++
 BuildRequires: git
+BuildRequires: gmock-devel
 BuildRequires: gtest-devel
+BuildRequires: iir1-devel
 BuildRequires: libappstream-glib
 BuildRequires: libatomic
 BuildRequires: libpng-devel
-BuildRequires: libslirp >= 4.6.1
+BuildRequires: libslirp-devel >= 4.6.1
 BuildRequires: make
 BuildRequires: meson >= 0.54.2
+BuildRequires: mt32emu-devel >= 2.5.3
 BuildRequires: opusfile-devel
 BuildRequires: SDL2-devel >= 2.0.5
 BuildRequires: SDL2_image-devel
 BuildRequires: SDL2_net-devel
 BuildRequires: speexdsp-devel > 1.1.9
-# mt32emu dependencies:
-BuildRequires: cmake
 
 Requires: hicolor-icon-theme
 Requires: fluid-soundfont-gm
@@ -62,14 +56,10 @@ any old DOS game using modern hardware.
 
 %prep
 %autosetup -p1
-# mt32emu is not packaged yet; provide sources for Meson wrap dependency:
-mkdir -p %{_vpath_srcdir}/subprojects/packagecache/
-cp %{SOURCE1} %{_vpath_srcdir}/subprojects/packagecache/
-cp %{SOURCE2} %{_vpath_srcdir}/subprojects/packagecache/
 
 
 %build
-%meson -Ddefault_library=static
+%meson
 %meson_build
 
 
@@ -89,11 +79,25 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.xml
 %{_mandir}/man1/*
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/*/apps/dosbox-staging.*
+%{_datadir}/%{name}/translations/*
+%{_datadir}/%{name}/drives/*
+%{_datadir}/%{name}/freedos-cpi/*
+%{_datadir}/%{name}/freedos-keyboard/*
+%{_datadir}/%{name}/glshaders/*
+%{_datadir}/%{name}/mapperfiles/*
+%{_datadir}/%{name}/mapping-freedos.org/*
+%{_datadir}/%{name}/mapping-unicode.org/*
+%{_datadir}/%{name}/mapping-wikipedia.org/*
+%{_datadir}/%{name}/mapping/*
 %{_metainfodir}/*
 
 
 %changelog
-* Fri 24 Dec 2021 kcgen <kcgen@users.noreply.github.com>
+* Sat Jan 07 2023 rderooy <rderooy@users.noreply.github.com> - 0.80.1-1
+- Update to 0.80.1
+- Remove included mt32emu as it is now available in the distro repos
+
+* Fri Dec 24 2021 kcgen <kcgen@users.noreply.github.com>
 - 0.78.0-1
 - Update to 0.78.0
 - Raise minimum Meson version to 0.54.2


### PR DESCRIPTION
The RPM spec file was rather out of date, so I updated it to 0.80.1.

Being able to build the RPM package from a SPEC file with `rpmbuild` however does not guarantee that you can build it on other systems. As it uses your local environment and installed packages. 

As such, I also did a `mock` build (chroot environment, like copr uses) to ensure all the `BuildRequires` statements are actually pulling in everything that is needed to do a full build.

Lastly, I spotted a few typos in BUILD.md