### PR TITLE
Implement MOVE shell command

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -41,6 +41,10 @@
 
 #define LFN_NAMELENGTH 255
 
+constexpr auto CurrentDirectory = ".";
+constexpr auto ParentDirectory  = "..";
+constexpr auto DosSeparator     = '\\';
+
 // obsolete - TODO: remove
 enum FatAttributeFlagsValues : uint8_t { // 7-bit
 	DOS_ATTR_READ_ONLY = 0b000'0001,

--- a/include/shell.h
+++ b/include/shell.h
@@ -178,6 +178,7 @@ public:
 	void CMD_VER(char* args);
 	void CMD_LS(char* args);
 	void CMD_VOL(char* args);
+	void CMD_MOVE(char* args);
 
 	/* The shell's variables */
 	uint16_t input_handle         = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -647,6 +647,8 @@ void SHELL_Init() {
 	MSG_Add("SHELL_FILE_NOT_FOUND", "File not found - '%s'\n");
 	MSG_Add("SHELL_FILE_EXISTS", "File '%s' already exists.\n");
 	MSG_Add("SHELL_DIRECTORY_NOT_FOUND", "Directory not found - '%s'\n");
+	MSG_Add("SHELL_READ_ERROR", "Error reading file - '%s'\n");
+	MSG_Add("SHELL_WRITE_ERROR", "Error writing file - '%s'\n");
 
 	// Command specific messages
 	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type [color=yellow]help /all[reset] .\nA short list of the most often used commands:\n");
@@ -1258,6 +1260,31 @@ void SHELL_Init() {
 	        " Volume in drive %c is %s\n"
 	        " Volume Serial Number is %04X-%04X\n"
 	        "\n");
+	MSG_Add("SHELL_CMD_MOVE_HELP",
+	        "Moves files and renames files and directories.\n");
+	MSG_Add("SHELL_CMD_MOVE_HELP_LONG",
+	        "Usage:\n"
+	        "  [color=green]move[reset] [color=white]FILENAME1[,FILENAME2,...][reset] [color=cyan]DESTINATION[reset]\n"
+	        "  [color=green]move[reset] [color=white]DIRECTORY1[reset] [color=cyan]DIRECTORY2[reset]\n"
+	        "\n"
+	        "Where:\n"
+	        "  [color=white]FILENAME[reset]    Can be either an exact filename or an inexact filename with\n"
+	        "              wildcards, which are the asterisk (*) and the question mark (?).\n"
+	        "              Multiple, comma-seperated, filenames can be provided.\n"
+	        "  [color=white]DIRECTORY[reset]   An exact directory name, not containing any wildcards.\n"
+	        "  [color=cyan]DESTINATION[reset] An exact filename or directory, not containing any wildcards.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  If multiple source files are specified, destination must be a directory.\n"
+	        "  If not, one will be created for you.\n"
+	        "\n"
+	        "  If a single source file is specified, it will overwrite destination.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=green]move[reset] [color=white]source.bat[reset] [color=cyan]new.bat[reset]\n"
+	        "  [color=green]move[reset] [color=white]file1.txt,file2.txt[reset] [color=cyan]mydir[reset]\n");
+	MSG_Add("SHELL_CMD_MOVE_MULTIPLE_TO_SINGLE",
+	        "Cannot move multiple files to a single file.\n");
 
 	/* Ensure help categories are loaded into the message vector */
 	HELP_AddMessages();

--- a/tests/cmd_move_tests.cpp
+++ b/tests/cmd_move_tests.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+struct cmd_move_arguments {
+	std::vector<std::string> sources = {};
+	std::string destination          = {};
+	const char* error                = nullptr;
+};
+
+cmd_move_arguments cmd_move_parse_arguments(const char* args);
+
+TEST(cmd_move_parse_arguments, multiple_sources)
+{
+	cmd_move_arguments ret = cmd_move_parse_arguments(
+	        "   a.bat   ,   b.bat        ,c.bat,d.bat  destdir");
+	EXPECT_EQ(ret.error, nullptr);
+	EXPECT_EQ(ret.destination, "destdir");
+	ASSERT_EQ(ret.sources.size(), 4);
+	EXPECT_EQ(ret.sources[0], "a.bat");
+	EXPECT_EQ(ret.sources[1], "b.bat");
+	EXPECT_EQ(ret.sources[2], "c.bat");
+	EXPECT_EQ(ret.sources[3], "d.bat");
+}
+
+TEST(cmd_move_parse_arguments, too_few_arguments)
+{
+	cmd_move_arguments ret = cmd_move_parse_arguments("a");
+	ASSERT_NE(ret.error, nullptr);
+	EXPECT_EQ(strcmp(ret.error, "SHELL_MISSING_PARAMETER"), 0);
+}
+
+TEST(cmd_move_parse_arguments, too_many_arguments)
+{
+	cmd_move_arguments ret = cmd_move_parse_arguments("a b c");
+	ASSERT_NE(ret.error, nullptr);
+	EXPECT_EQ(strcmp(ret.error, "SHELL_TOO_MANY_PARAMETERS"), 0);
+}
+
+TEST(cmd_move_parse_arguments, weird_quotes)
+{
+	// This actually works in MS-DOS 6.22
+	cmd_move_arguments ret = cmd_move_parse_arguments(
+	        "\"a.bat,\"  b.\"ba\"t  \",\"  c.bat   d\"estdi\"r");
+	EXPECT_EQ(ret.error, nullptr);
+	EXPECT_EQ(ret.destination, "destdir");
+	ASSERT_EQ(ret.sources.size(), 3);
+	EXPECT_EQ(ret.sources[0], "a.bat");
+	EXPECT_EQ(ret.sources[1], "b.bat");
+	EXPECT_EQ(ret.sources[2], "c.bat");
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -70,6 +70,7 @@ unit_tests = [
     {'name': 'batch_file', 'deps': [libmisc_stubs_dep, libshell_dep]},
     {'name': 'bit_view', 'deps': []},
     {'name': 'bitops', 'deps': []},
+    {'name': 'cmd_move', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'dos_files', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'drives', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'fraction', 'deps': []},


### PR DESCRIPTION
Fixes #2539

I'm sure there's some stuff in here that needs cleaning up so feel free to be critical.  It's not the prettiest function (neither is CMD_COPY).  I've tested though and, as far as I can tell, it works identically to MS-DOS 6.22.

Error messages are an exception.  That can maybe get cleaned up.  MS-DOS does like `source => dest [error message]` and right now I'm just throwing errors as soon as they come up without formatting like that.