### PR TITLE
Fix CGA composite regression

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1960,6 +1960,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		VGA_DrawLine = VGA_Draw_CGA2_Composite_Line;
 		break;
 	case M_CGA4_COMPOSITE:
+		vga.draw.blocks = width * 2;
 		width <<= 4;
 		pixel_aspect_ratio = {height * 4 * (doubleheight ? 2 : 1), width * 3};
 		VGA_DrawLine = VGA_Draw_CGA4_Composite_Line;


### PR DESCRIPTION
Something that I accidentally introduced during my image capture related refactorings (deleted a line by accident, apparently 🤷🏻)

Config to reproduce (using the eXoDOS version):

```ini
[dosbox]
machine = cga

[cpu]
cycles = 240
core = normal

[composite]
composite = on

[autoexec]
c:
autotype -w 0.5 a space
brucelee
```

## Current main

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/ec4ae1be-ef96-4b46-99d6-ce11982771f9)

## After fix 

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/22c89396-3ff9-48d4-8296-91aa8df33b75)
