### PR TITLE
Fix sRGB GLSL pragmas

### DIFF
--- a/contrib/resources/glshaders/none.glsl
+++ b/contrib/resources/glshaders/none.glsl
@@ -1,9 +1,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *  Copyright (C) 2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2020, jmarsh <jmarsh@vogons.org>: authored.
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@4319
  *

--- a/contrib/resources/glshaders/none.glsl
+++ b/contrib/resources/glshaders/none.glsl
@@ -22,9 +22,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#pragma use_srgb_texture
-#pragma use_srgb_framebuffer
-
 varying vec2 v_texCoord;
 #if defined(VERTEX)
 uniform vec2 rubyTextureSize;

--- a/contrib/resources/glshaders/none.glsl
+++ b/contrib/resources/glshaders/none.glsl
@@ -24,17 +24,26 @@
  */
 
 varying vec2 v_texCoord;
+
 #if defined(VERTEX)
+
 uniform vec2 rubyTextureSize;
 uniform vec2 rubyInputSize;
 attribute vec4 a_position;
-void main() {
+
+void main()
+{
 	gl_Position = a_position;
-	v_texCoord = vec2(a_position.x+1.0,1.0-a_position.y)/2.0*rubyInputSize/rubyTextureSize;
+	v_texCoord  = vec2(a_position.x + 1.0, 1.0 - a_position.y) / 2.0 *
+	             rubyInputSize / rubyTextureSize;
 }
+
 #elif defined(FRAGMENT)
+
 uniform sampler2D rubyTexture;
-void main() {
+void main()
+{
 	gl_FragColor = texture2D(rubyTexture, v_texCoord);
 }
+
 #endif

--- a/include/render.h
+++ b/include/render.h
@@ -166,8 +166,8 @@ void RENDER_InitShaderSource([[maybe_unused]] Section* sec);
 void RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t blue);
 
 #if C_OPENGL
-bool RENDER_UseSRGBTexture();
-bool RENDER_UseSRGBFramebuffer();
+bool RENDER_UseSrgbTexture();
+bool RENDER_UseSrgbFramebuffer();
 #endif
 
 #endif

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -634,12 +634,12 @@ static void parse_shader_options(const std::string &source)
 	}
 }
 
-bool RENDER_UseSRGBTexture()
+bool RENDER_UseSrgbTexture()
 {
 	return render.shader.use_srgb_texture;
 }
 
-bool RENDER_UseSRGBFramebuffer()
+bool RENDER_UseSrgbFramebuffer()
 {
 	return render.shader.use_srgb_framebuffer;
 }

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -615,7 +615,7 @@ static bool RENDER_GetShader(const std::string &shader_path, std::string &source
 static void parse_shader_options(const std::string &source)
 {
 	try {
-		const std::regex re("^\\s*#pragma\\s+(\\w+)");
+		const std::regex re("\\s*#pragma\\s+(\\w+)");
 		std::sregex_iterator next(source.begin(), source.end(), re);
 		const std::sregex_iterator end;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2184,6 +2184,13 @@ dosurface:
 		const auto texformat = RENDER_UseSrgbTexture() && sdl.opengl.framebuffer_is_srgb_encoded
 		                             ? GL_SRGB8_ALPHA8
 		                             : GL_RGB8;
+
+#if 0
+		if (texformat == GL_SRGB8_ALPHA8) {
+			LOG_MSG("OPENGL: Using sRGB texture");
+		}
+#endif
+
 		glTexImage2D(GL_TEXTURE_2D,
 		             0,
 		             texformat,
@@ -2197,6 +2204,9 @@ dosurface:
 
 		if (sdl.opengl.framebuffer_is_srgb_encoded) {
 			glEnable(GL_FRAMEBUFFER_SRGB);
+#if 0
+			LOG_MSG("OPENGL: Using sRGB framebuffer");
+#endif
 		}
 
 		glClearColor (0.0f, 0.0f, 0.0f, 1.0f);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2165,17 +2165,23 @@ dosurface:
 
 		int is_framebuffer_srgb_capable = 0;
 		if (SDL_GL_GetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
-		                        &is_framebuffer_srgb_capable))
+		                        &is_framebuffer_srgb_capable)) {
 			LOG_WARNING("OPENGL: Failed getting the framebuffer's sRGB status: %s",
 			            SDL_GetError());
+		}
 
-		sdl.opengl.framebuffer_is_srgb_encoded = RENDER_UseSRGBFramebuffer() && is_framebuffer_srgb_capable > 0;
+		sdl.opengl.framebuffer_is_srgb_encoded =
+		        RENDER_UseSrgbFramebuffer() &&
+		        (is_framebuffer_srgb_capable > 0);
 
-		if (RENDER_UseSRGBFramebuffer() && !sdl.opengl.framebuffer_is_srgb_encoded)
+		if (RENDER_UseSrgbFramebuffer() &&
+		    !sdl.opengl.framebuffer_is_srgb_encoded) {
 			LOG_WARNING("OPENGL: sRGB framebuffer not supported");
+		}
 
-		// Using GL_SRGB8_ALPHA8 because GL_SRGB8 doesn't work properly with Mesa drivers on certain integrated Intel GPUs
-		const auto texformat = RENDER_UseSRGBTexture() && sdl.opengl.framebuffer_is_srgb_encoded
+		// Using GL_SRGB8_ALPHA8 because GL_SRGB8 doesn't work properly
+		// with Mesa drivers on certain integrated Intel GPUs
+		const auto texformat = RENDER_UseSrgbTexture() && sdl.opengl.framebuffer_is_srgb_encoded
 		                             ? GL_SRGB8_ALPHA8
 		                             : GL_RGB8;
 		glTexImage2D(GL_TEXTURE_2D,


### PR DESCRIPTION
This is embarrassing... It doesn't even warrant the "regression" label because it couldn't have ever worked properly! :lolsob:

I guess I never noticed because I started using CRT shaders that do their own gamma decoding/encoding "manually" and thus interpolate in a  gamma-correct fashion.

Anyway, it should be good now, and it can be verified by uncommenting the debug logging. These two flags are enabled in the default `interpolation/sharp` shader and disabled in most CRT shaders, such as `crt/hyllian-updated`.