### PR TITLE
Store envelope channel_name as std::string

### DIFF
--- a/include/envelope.h
+++ b/include/envelope.h
@@ -58,7 +58,7 @@
 
 #include <cstdint>
 #include <functional>
-
+#include <string>
 
 typedef struct AudioFrame AudioFrame_;
 
@@ -88,7 +88,7 @@ private:
 	using process_f = std::function<void(Envelope &, const bool, AudioFrame &)>;
 	process_f process = &Envelope::Apply;
 
-	const char *channel_name = nullptr;
+	std::string channel_name = {};
 
 	int expire_after_frames = 0; // Stop enveloping when this many
 	                             // frames have been processed.

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -59,12 +59,14 @@ void Envelope::Update(const int frame_rate, const int peak_amplitude,
 	assert(expansion_phase_frames);
 	edge_increment = static_cast<float>(ceil_sdivide(peak_amplitude, expansion_phase_frames));
 
-//	DEBUG_LOG_MSG("ENVELOPE: %s grows by %-3f to %-5f across %-3u frames (%u ms)",
-//	              channel_name,
-//	              edge_increment,
-//	              edge_limit,
-//	              expansion_phase_frames,
-//	              expansion_phase_ms);
+#if 0
+	DEBUG_LOG_MSG("ENVELOPE: %s grows by %-3f to %-5f across %-3u frames (%u ms)",
+	              channel_name.c_str(),
+	              edge_increment,
+	              edge_limit,
+	              expansion_phase_frames,
+	              expansion_phase_ms);
+#endif
 }
 
 bool Envelope::ClampSample(float &sample, const float lip)
@@ -101,7 +103,7 @@ void Envelope::Apply(const bool is_stereo, AudioFrame &frame)
 		process = &Envelope::Skip;
 		(void)channel_name; // [[maybe_unused]] in release builds
 		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %.4f",
-		              channel_name,
+		              channel_name.c_str(),
 		              frames_done,
 		              edge);
 	}


### PR DESCRIPTION
Found a bug in this envelope class while working on cdrom stuff (almost done btw).  It doesn't do a deep copy of its name string so if it gets created with anything besides a string literal, you get random garbage printed out to the debug log.

Pretty simple change to just std::string.  It's only used for printing debug text.