### PR TITLE
Improve the help and output of the `CONFIG` command

### DIFF
--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -608,7 +608,7 @@ void IMGMOUNT::AddMessages()
 {
 	AddCommonMountMessages();
 	MSG_Add("PROGRAM_IMGMOUNT_HELP_LONG",
-	        "Mount a CD-ROM, floppy, or disk image to a drive letter.\n"
+	        "Mounts a CD-ROM, floppy, or disk image to a drive letter.\n"
 	        "\n"
 	        "Usage:\n"
 	        "  [color=green]imgmount[reset] [color=white]DRIVE[reset] [color=cyan]CDROM-SET[reset] [-fs iso] [-ide] -t cdrom|iso\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4895,9 +4895,11 @@ int sdl_main(int argc, char *argv[])
 
 	MSG_Add("PROGRAM_CONFIG_PROPERTY_ERROR", "No such section or property: %s\n");
 	MSG_Add("PROGRAM_CONFIG_NO_PROPERTY",
-		"There is no property \"%s\" in section \"%s\".\n");
+		"There is no property '%s' in section [%s]\n");
 	MSG_Add("PROGRAM_CONFIG_SET_SYNTAX",
-		"Correct syntax: config -set \"[section] property=value\".\n");
+		"Usage: [color=green]config [/reset]-set [color=cyan][SECTION][/reset] "
+		"[color=white]PROPERTY[/reset][=][color=white]VALUE[/reset]\n");
+
 	std::string line;
 	while (control->cmdline->FindString("-set", line, true)) {
 		trim(line);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2377,7 +2377,7 @@ private:
 	void AddMessages()
 	{
 		MSG_Add("SHELL_CMD_MIXER_HELP_LONG",
-		        "Displays or changes the sound mixer settings.\n"
+		        "\nDisplays or changes the sound mixer settings.\n"
 		        "\n"
 		        "Usage:\n"
 		        "  [color=green]mixer[reset] [color=cyan][CHANNEL][reset] [color=white]COMMANDS[reset] [/noshow]\n"

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2377,7 +2377,7 @@ private:
 	void AddMessages()
 	{
 		MSG_Add("SHELL_CMD_MIXER_HELP_LONG",
-		        "\nDisplays or changes the sound mixer settings.\n"
+		        "Displays or changes the sound mixer settings.\n"
 		        "\n"
 		        "Usage:\n"
 		        "  [color=green]mixer[reset] [color=cyan][CHANNEL][reset] [color=white]COMMANDS[reset] [/noshow]\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -388,7 +388,7 @@ void DOS_Shell::Run()
 	std::string line = {};
 	if (cmd->FindStringRemainBegin("/C",line)) {
 		safe_strcpy(input_line, line.c_str());
-		char* sep = strpbrk(input_line,"\r\n"); //GTA installer
+		char* sep = strpbrk(input_line, "\r\n"); //GTA installer
 		if (sep) *sep = 0;
 		DOS_Shell temp;
 		temp.echo = echo;
@@ -613,7 +613,7 @@ static Bitu INT2E_Handler()
 	MEM_BlockRead(PhysicalMake(dos.psp(),128),&tail,128);
 	if (tail.count<127) tail.buffer[tail.count]=0;
 	else tail.buffer[126]=0;
-	char* crlf=strpbrk(tail.buffer,"\r\n");
+	char* crlf=strpbrk(tail.buffer, "\r\n");
 	if (crlf) *crlf=0;
 
 	/* Execute command */
@@ -640,7 +640,7 @@ void SHELL_Init() {
 	// Generic messages, to be used by any command or DOS program
 	MSG_Add("SHELL_ILLEGAL_PATH", "Illegal path.\n");
 	MSG_Add("SHELL_ILLEGAL_FILE_NAME", "Illegal file name.\n");
-	MSG_Add("SHELL_ILLEGAL_SWITCH", "Illegal switch: %s.\n");
+	MSG_Add("SHELL_ILLEGAL_SWITCH", "Illegal switch: %s\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH_COMBO", "Illegal switch combination.\n");
 	MSG_Add("SHELL_MISSING_PARAMETER", "Required parameter missing.\n");
 	MSG_Add("SHELL_TOO_MANY_PARAMETERS", "Too many parameters.\n");
@@ -656,7 +656,8 @@ void SHELL_Init() {
 	MSG_Add("SHELL_WRITE_ERROR", "Error writing file - '%s'\n");
 
 	// Command specific messages
-	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type [color=yellow]help /all[reset] .\nA short list of the most often used commands:\n");
+	MSG_Add("SHELL_CMD_HELP", "If you want a list of all supported commands, run [color=yellow]help /all[reset]\n"
+			"A short list of the most often used commands:\n");
 	MSG_Add("SHELL_CMD_COMMAND_HELP_LONG",
 	        "Starts the DOSBox Staging command shell.\n"
 	        "Usage:\n"
@@ -677,17 +678,24 @@ void SHELL_Init() {
 	        "  [color=green]command[reset]\n"
 	        "  [color=green]command[reset] /c [color=cyan]echo[reset] [color=white]Hello world![reset]\n"
 	        "  [color=green]command[reset] /init [color=cyan]dir[reset]\n");
-	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
-	MSG_Add("SHELL_CMD_ECHO_OFF", "ECHO is off.\n");
-	MSG_Add("SHELL_CMD_CHDIR_ERROR","Unable to change to: %s.\n");
-	MSG_Add("SHELL_CMD_CHDIR_HINT","Hint: To change to different drive type [color=light-red]%c:[reset]\n");
-	MSG_Add("SHELL_CMD_CHDIR_HINT_2","directoryname is longer than 8 characters and/or contains spaces.\nTry [color=light-red]cd %s[reset]\n");
-	MSG_Add("SHELL_CMD_CHDIR_HINT_3","You are still on drive Z:, change to a mounted drive with [color=light-red]C:[reset].\n");
+
+	MSG_Add("SHELL_CMD_ECHO_ON", "Echo is on.\n");
+	MSG_Add("SHELL_CMD_ECHO_OFF", "Echo is off.\n");
+
+	MSG_Add("SHELL_CMD_CHDIR_ERROR", "Unable to change to: %s\n");
+	MSG_Add("SHELL_CMD_CHDIR_HINT", "Hint: To change to a different drive, run [color=yellow]%c:[reset]\n");
+
+	MSG_Add("SHELL_CMD_CHDIR_HINT_2",
+	        "Directory name is longer than 8 characters and/or contains spaces.\n"
+	        "Try [color=yellow]cd %s[reset]\n");
+	MSG_Add("SHELL_CMD_CHDIR_HINT_3", "You are still on drive Z:; change to a mounted drive with [color=yellow]C:[reset].\n");
+
 	MSG_Add("SHELL_CMD_DATE_HELP", "Displays or changes the internal date.\n");
 	MSG_Add("SHELL_CMD_DATE_ERROR", "The specified date is not correct.\n");
 	MSG_Add("SHELL_CMD_DATE_DAYS", "3SunMonTueWedThuFriSat"); // "2SoMoDiMiDoFrSa"
 	MSG_Add("SHELL_CMD_DATE_NOW", "Current date: ");
-	MSG_Add("SHELL_CMD_DATE_SETHLP", "Type 'date %s' to change.\n");
+	MSG_Add("SHELL_CMD_DATE_SETHLP", "Run [color=yellow]date %s[reset] to change the current date.\n");
+
 	MSG_Add("SHELL_CMD_DATE_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]date[reset] [/t]\n"
@@ -706,10 +714,11 @@ void SHELL_Init() {
 	        "  [color=green]date[reset]\n"
 	        "  [color=green]date[reset] /h\n"
 	        "  [color=green]date[reset] [color=cyan]%s[reset]\n");
+
 	MSG_Add("SHELL_CMD_TIME_HELP", "Displays or changes the internal time.\n");
 	MSG_Add("SHELL_CMD_TIME_ERROR", "The specified time is not correct.\n");
 	MSG_Add("SHELL_CMD_TIME_NOW", "Current time: ");
-	MSG_Add("SHELL_CMD_TIME_SETHLP", "Type 'time %s' to change.\n");
+	MSG_Add("SHELL_CMD_TIME_SETHLP", "Run [color=yellow]time %s[reset] to change the current time.\n");
 	MSG_Add("SHELL_CMD_TIME_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]time[reset] [/t]\n"
@@ -728,26 +737,38 @@ void SHELL_Init() {
 	        "  [color=green]time[reset]\n"
 	        "  [color=green]time[reset] /h\n"
 	        "  [color=green]time[reset] [color=cyan]%s[reset]\n");
-	MSG_Add("SHELL_CMD_MKDIR_ERROR","Unable to make: %s.\n");
-	MSG_Add("SHELL_CMD_RMDIR_ERROR","Unable to remove: %s.\n");
-	MSG_Add("SHELL_CMD_DEL_ERROR","Unable to delete: %s.\n");
-	MSG_Add("SHELL_CMD_SET_NOT_SET","Environment variable %s not defined.\n");
-	MSG_Add("SHELL_CMD_SET_OUT_OF_SPACE","Not enough environment space left.\n");
-	MSG_Add("SHELL_CMD_IF_EXIST_MISSING_FILENAME","IF EXIST: Missing filename.\n");
-	MSG_Add("SHELL_CMD_IF_ERRORLEVEL_MISSING_NUMBER","IF ERRORLEVEL: Missing number.\n");
-	MSG_Add("SHELL_CMD_IF_ERRORLEVEL_INVALID_NUMBER","IF ERRORLEVEL: Invalid number.\n");
-	MSG_Add("SHELL_CMD_GOTO_MISSING_LABEL","No label supplied to GOTO command.\n");
-	MSG_Add("SHELL_CMD_GOTO_LABEL_NOT_FOUND","GOTO: Label %s not found.\n");
-	MSG_Add("SHELL_CMD_DUPLICATE_REDIRECTION", "Duplicate redirection - %s\n");
+
+	MSG_Add("SHELL_CMD_MKDIR_ERROR", "Unable to make: %s.\n");
+	MSG_Add("SHELL_CMD_RMDIR_ERROR", "Unable to remove: %s.\n");
+
+	MSG_Add("SHELL_CMD_DEL_ERROR", "Unable to delete: %s.\n");
+
+	MSG_Add("SHELL_CMD_SET_NOT_SET", "Environment variable '%s' not defined.\n");
+	MSG_Add("SHELL_CMD_SET_OUT_OF_SPACE", "Not enough environment space left.\n");
+
+	MSG_Add("SHELL_CMD_IF_EXIST_MISSING_FILENAME", "IF EXIST: Missing filename.\n");
+	MSG_Add("SHELL_CMD_IF_ERRORLEVEL_MISSING_NUMBER", "IF ERRORLEVEL: Missing number.\n");
+	MSG_Add("SHELL_CMD_IF_ERRORLEVEL_INVALID_NUMBER", "IF ERRORLEVEL: Invalid number.\n");
+
+	MSG_Add("SHELL_CMD_GOTO_MISSING_LABEL", "No label supplied to GOTO command.\n");
+	MSG_Add("SHELL_CMD_GOTO_LABEL_NOT_FOUND", "GOTO: Label '%s' not found.\n");
+
+	MSG_Add("SHELL_CMD_DUPLICATE_REDIRECTION", "Duplicate redirection: %s\n");
+
 	MSG_Add("SHELL_CMD_FAILED_PIPE", "\nFailed to create/open a temporary file for piping. Check the %%TEMP%% variable.\n");
-	MSG_Add("SHELL_CMD_DIR_VOLUME"," Volume in drive %c is %s\n");
-	MSG_Add("SHELL_CMD_DIR_INTRO"," Directory of %s\n");
-	MSG_Add("SHELL_CMD_DIR_BYTES_USED","%17d file(s) %21s bytes\n");
-	MSG_Add("SHELL_CMD_DIR_BYTES_FREE","%17d dir(s)  %21s bytes free\n");
-	MSG_Add("SHELL_EXECUTE_DRIVE_NOT_FOUND","Drive %c does not exist!\nYou must [color=light-red]mount[reset] it first. Type [color=yellow]intro[reset] or [color=yellow]intro mount[reset] for more information.\n");
-	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND","Illegal command: %s.\n");
-	MSG_Add("SHELL_CMD_PAUSE", "Press a key to continue...");
+
+	MSG_Add("SHELL_CMD_DIR_VOLUME", " Volume in drive %c is %s\n");
+	MSG_Add("SHELL_CMD_DIR_INTRO", " Directory of %s\n");
+	MSG_Add("SHELL_CMD_DIR_BYTES_USED", "%17d file(s) %21s bytes\n");
+	MSG_Add("SHELL_CMD_DIR_BYTES_FREE", "%17d dir(s)  %21s bytes free\n");
+
+	MSG_Add("SHELL_EXECUTE_DRIVE_NOT_FOUND", "Drive %c does not exist!\nYou must [color=yellow]mount[reset] it first. "
+			"Run [color=yellow]intro[reset] or [color=yellow]intro mount[reset] for more information.\n");
+
+	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND", "Illegal command: %s\n");
+	MSG_Add("SHELL_CMD_PAUSE", "Press any key to continue...");
 	MSG_Add("SHELL_CMD_PAUSE_HELP", "Waits for a keystroke to continue.\n");
+
 	MSG_Add("SHELL_CMD_PAUSE_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]pause[reset]\n"
@@ -762,10 +783,11 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]pause[reset]\n");
-	MSG_Add("SHELL_CMD_COPY_FAILURE","Copy failure : %s.\n");
-	MSG_Add("SHELL_CMD_COPY_SUCCESS","   %d File(s) copied.\n");
-	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");
-	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST failed. You either made an error in your commandline or the target drive is already used.\nIt's only possible to use SUBST on Local drives");
+
+	MSG_Add("SHELL_CMD_COPY_FAILURE", "Copy failure : %s.\n");
+	MSG_Add("SHELL_CMD_COPY_SUCCESS", "   %d File(s) copied.\n");
+	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE", "Unable to remove, drive not in use.\n");
+	MSG_Add("SHELL_CMD_SUBST_FAILURE", "SUBST failed, the target drive may already exist.\nNote it is only possible to use SUBST on local drives.");
 
 	MSG_Add("SHELL_STARTUP_BEGIN",
 	        "[bgcolor=blue][color=white]╔════════════════════════════════════════════════════════════════════╗\n"
@@ -797,8 +819,9 @@ void SHELL_Init() {
 	        "╚════════════════════════════════════════════════════════════════════╝[reset]\n"
 	        "\n");
 
-	MSG_Add("SHELL_STARTUP_SUB","[color=green]" CANONICAL_PROJECT_NAME " %s[reset]\n");
-	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays or changes the current directory.\n");
+	MSG_Add("SHELL_STARTUP_SUB", "[color=green]" CANONICAL_PROJECT_NAME " %s[reset]\n");
+
+	MSG_Add("SHELL_CMD_CHDIR_HELP", "Displays or changes the current directory.\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]cd[reset] [color=cyan]DIRECTORY[reset]\n"
@@ -814,6 +837,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]cd[reset]\n"
 	        "  [color=green]cd[reset] [color=cyan]mydir[reset]\n");
+
 	MSG_Add("SHELL_CMD_CLS_HELP", "Clears the DOS screen.\n");
 	MSG_Add("SHELL_CMD_CLS_HELP_LONG",
 	        "Usage:\n"
@@ -828,6 +852,7 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]cls[reset]\n");
+
 	MSG_Add("SHELL_CMD_DIR_HELP",
 	        "Displays a list of files and subdirectories in a directory.\n");
 	MSG_Add("SHELL_CMD_DIR_HELP_LONG",
@@ -853,6 +878,7 @@ void SHELL_Init() {
 	        "  [color=green]dir[reset] [color=cyan][reset]\n"
 	        "  [color=green]dir[reset] [color=cyan]games.*[reset] /p\n"
 	        "  [color=green]dir[reset] [color=cyan]c:\\games\\*.exe[reset] /b /o[color=white]-d[reset]\n");
+
 	MSG_Add("SHELL_CMD_ECHO_HELP",
 	        "Displays messages and enables/disables command echoing.\n");
 	MSG_Add("SHELL_CMD_ECHO_HELP_LONG",
@@ -871,6 +897,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]echo[reset] [color=cyan]off[reset]\n"
 	        "  [color=green]echo[reset] [color=cyan]Hello world![reset]\n");
+
 	MSG_Add("SHELL_CMD_EXIT_HELP", "Exits from the DOS shell.\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP_LONG",
 	        "Usage:\n"
@@ -886,6 +913,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]exit[reset]\n");
 	MSG_Add("SHELL_CMD_EXIT_TOO_SOON", "Preventing an early 'exit' call from terminating.\n");
+
 	MSG_Add("SHELL_CMD_HELP_HELP",
 	        "Displays help information for DOS commands.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP_LONG",
@@ -905,6 +933,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]help[reset] [color=cyan]dir[reset]\n"
 	        "  [color=green]help[reset] /all\n");
+
 	MSG_Add("SHELL_CMD_MKDIR_HELP", "Creates a directory.\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP_LONG",
 	        "Usage:\n"
@@ -921,6 +950,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]md[reset] [color=cyan]newdir[reset]\n"
 	        "  [color=green]md[reset] [color=cyan]c:\\games\\dir[reset]\n");
+
 	MSG_Add("SHELL_CMD_RMDIR_HELP", "Removes a directory.\n");
 	MSG_Add("SHELL_CMD_RMDIR_HELP_LONG",
 	        "Usage:\n"
@@ -935,6 +965,7 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]rd[reset] [color=cyan]emptydir[reset]\n");
+
 	MSG_Add("SHELL_CMD_SET_HELP", "Displays or changes environment variables.\n");
 	MSG_Add("SHELL_CMD_SET_HELP_LONG",
 	        "Usage:\n"
@@ -952,6 +983,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]set[reset]\n"
 	        "  [color=green]set[reset] [color=white]name[reset]=[color=cyan]value[reset]\n");
+
 	MSG_Add("SHELL_CMD_IF_HELP",
 	        "Performs conditional processing in batch programs.\n");
 	MSG_Add("SHELL_CMD_IF_HELP_LONG",
@@ -976,6 +1008,7 @@ void SHELL_Init() {
 	        "  [color=green]if[reset] [color=cyan]errorlevel[reset] [color=white]2[reset] dir\n"
 	        "  [color=green]if[reset] [color=white]\"%%myvar%%\"==\"mystring\"[reset] echo Hello world!\n"
 	        "  [color=green]if[reset] [color=magenta]not[reset] [color=cyan]exist[reset] [color=white]file.txt[reset] exit\n");
+
 	MSG_Add("SHELL_CMD_GOTO_HELP",
 	        "Jumps to a labeled line in a batch program.\n");
 	MSG_Add("SHELL_CMD_GOTO_HELP_LONG",
@@ -991,7 +1024,8 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]goto[reset] [color=cyan]mylabel[reset]\n");
-	MSG_Add("SHELL_CMD_SHIFT_HELP","Left-shifts command-line parameters in a batch program.\n");
+
+	MSG_Add("SHELL_CMD_SHIFT_HELP", "Left-shifts command-line parameters in a batch program.\n");
 	MSG_Add("SHELL_CMD_SHIFT_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]shift[reset]\n"
@@ -1005,7 +1039,8 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]shift[reset]\n");
-	MSG_Add("SHELL_CMD_TYPE_HELP", "Display the contents of a text file.\n");
+
+	MSG_Add("SHELL_CMD_TYPE_HELP", "Displays the contents of a text file.\n");
 	MSG_Add("SHELL_CMD_TYPE_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]type[reset] [color=cyan]FILE[reset]\n"
@@ -1020,6 +1055,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]type[reset] [color=cyan]text.txt[reset]\n"
 	        "  [color=green]type[reset] [color=cyan]c:\\dos\\readme.txt[reset]\n");
+
 	MSG_Add("SHELL_CMD_REM_HELP", "Adds comments in a batch program.\n");
 	MSG_Add("SHELL_CMD_REM_HELP_LONG",
 	        "Usage:\n"
@@ -1034,7 +1070,9 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]rem[reset] [color=cyan]This is my test batch program.[reset]\n");
-	MSG_Add("SHELL_CMD_NO_WILD","This is a simple version of the command, no wildcards allowed!\n");
+
+	MSG_Add("SHELL_CMD_NO_WILD", "This is a simple version of the command, no wildcards allowed!\n");
+
 	MSG_Add("SHELL_CMD_RENAME_HELP", "Renames one or more files.\n");
 	MSG_Add("SHELL_CMD_RENAME_HELP_LONG",
 	        "Usage:\n"
@@ -1052,7 +1090,8 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]ren[reset] [color=white]oldname[reset] [color=cyan]newname[reset]\n"
 	        "  [color=green]ren[reset] [color=white]c:\\dos\\file.txt[reset] [color=cyan]f.txt[reset]\n");
-	MSG_Add("SHELL_CMD_DELETE_HELP","Removes one or more files.\n");
+
+	MSG_Add("SHELL_CMD_DELETE_HELP", "Removes one or more files.\n");
 	MSG_Add("SHELL_CMD_DELETE_HELP_LONG", "Usage:\n"
 	        "  [color=green]del[reset] [color=cyan]PATTERN[reset]\n"
 	        "  [color=green]erase[reset] [color=cyan]PATTERN[reset]\n"
@@ -1071,6 +1110,7 @@ void SHELL_Init() {
 	        "  [color=green]del[reset] [color=cyan]test.bat[reset]\n"
 	        "  [color=green]del[reset] [color=cyan]c*.*[reset]\n"
 	        "  [color=green]del[reset] [color=cyan]a?b.c*[reset]\n");
+
 	MSG_Add("SHELL_CMD_COPY_HELP", "Copies one or more files.\n");
 	MSG_Add("SHELL_CMD_COPY_HELP_LONG",
 	        "Usage:\n"
@@ -1090,6 +1130,7 @@ void SHELL_Init() {
 	        "  [color=green]copy[reset] [color=white]source.bat[reset] [color=cyan]new.bat[reset]\n"
 	        "  [color=green]copy[reset] [color=white]file1.txt+file2.txt[reset] [color=cyan]file3.txt[reset]\n"
 	        "  [color=green]copy[reset] [color=white]..\\c*.*[reset]\n");
+
 	MSG_Add("SHELL_CMD_CALL_HELP",
 	        "Starts a batch program from within another batch program.\n");
 	MSG_Add("SHELL_CMD_CALL_HELP_LONG",
@@ -1107,7 +1148,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]call[reset] [color=white]mybatch.bat[reset]\n"
 	        "  [color=green]call[reset] [color=white]file.bat[reset] [color=cyan]Hello world![reset]\n");
-	MSG_Add("SHELL_CMD_SUBST_HELP", "Assign an internal directory to a drive.\n");
+	MSG_Add("SHELL_CMD_SUBST_HELP", "Assigns an internal directory to a drive.\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]subst[reset] [color=white]DRIVE[reset] [color=cyan]PATH[reset]\n"
@@ -1124,6 +1165,7 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]subst[reset] [color=white]d:[reset] [color=cyan]c:\\games[reset]\n"
 	        "  [color=green]subst[reset] [color=white]e:[reset] [color=cyan]/d[reset]\n");
+
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP", "Loads a DOS program into upper memory.\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP_LONG",
 	        "Usage:\n"
@@ -1141,8 +1183,9 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=green]lh[reset] [color=cyan]tsrapp[reset] [color=white]args[reset]\n");
+
 	MSG_Add("SHELL_CMD_LS_HELP",
-	        "Displays directory contents in the wide list format.\n");
+	        "Displays directory contents in wide list format.\n");
 	MSG_Add("SHELL_CMD_LS_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]ls[reset] [color=cyan]PATTERN[reset]\n"
@@ -1186,6 +1229,7 @@ void SHELL_Init() {
 	        "  [color=green]attrib[reset] [color=white]+R[reset] [color=white]-A[reset] [color=cyan]*.txt[reset]\n");
 	MSG_Add("SHELL_CMD_ATTRIB_GET_ERROR", "Unable to get attributes: %s\n");
 	MSG_Add("SHELL_CMD_ATTRIB_SET_ERROR", "Unable to set attributes: %s\n");
+
 	MSG_Add("SHELL_CMD_CHOICE_HELP",
 	        "Waits for a keypress and sets an ERRORLEVEL value.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG",
@@ -1211,6 +1255,7 @@ void SHELL_Init() {
 	        "  [color=green]choice[reset] /c:[color=white]abc[reset] /s [color=cyan]Type the letter a, b, or c[reset]\n");
 	MSG_Add("SHELL_CMD_CHOICE_EOF", "\n[color=red]Choice failed[reset]: the input stream ended without a valid choice.\n");
 	MSG_Add("SHELL_CMD_CHOICE_ABORTED", "\n[color=yellow]Choice aborted.[reset]\n");
+
 	MSG_Add("SHELL_CMD_PATH_HELP",
 	        "Displays or sets a search path for executable files.\n");
 	MSG_Add("SHELL_CMD_PATH_HELP_LONG",
@@ -1229,7 +1274,8 @@ void SHELL_Init() {
 	        "Examples:\n"
 	        "  [color=green]path[reset]\n"
 	        "  [color=green]path[reset] [color=cyan]Z:\\;C:\\DOS[reset]\n");
-	MSG_Add("SHELL_CMD_VER_HELP", "View the DOS version.\n");
+
+	MSG_Add("SHELL_CMD_VER_HELP", "Shows the DOS version.\n");
 	MSG_Add("SHELL_CMD_VER_HELP_LONG",
 	        "Usage:\n"
 	        "  [color=green]ver[reset]\n"
@@ -1245,6 +1291,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_VER_VER", "DOSBox Staging version %s\n"
 	                             "DOS version %d.%02d\n");
 	MSG_Add("SHELL_CMD_VER_INVALID", "The specified DOS version is not correct.\n");
+
 	MSG_Add("SHELL_CMD_VOL_HELP",
 	        "Displays the disk volume and serial number, if they exist.\n");
 	MSG_Add("SHELL_CMD_VOL_HELP_LONG",
@@ -1265,6 +1312,7 @@ void SHELL_Init() {
 	        " Volume in drive %c is %s\n"
 	        " Volume Serial Number is %04X-%04X\n"
 	        "\n");
+
 	MSG_Add("SHELL_CMD_MOVE_HELP",
 	        "Moves files and renames files and directories.\n");
 	MSG_Add("SHELL_CMD_MOVE_HELP_LONG",
@@ -1301,7 +1349,7 @@ void SHELL_Init() {
 	SegSet16(cs,RealSegment(newcsip));
 	reg_ip=RealOffset(newcsip);
 
-	CALLBACK_Setup(call_shellstop,shellstop_handler,CB_IRET,"shell stop");
+	CALLBACK_Setup(call_shellstop,shellstop_handler,CB_IRET, "shell stop");
 	PROGRAMS_MakeFile("COMMAND.COM",SHELL_ProgramCreate);
 
 	/* Now call up the shell for the first time */
@@ -1322,7 +1370,7 @@ void SHELL_Init() {
 	/* Set up int 2e handler */
 	Bitu call_int2e=CALLBACK_Allocate();
 	RealPt addr_int2e=RealMake(psp_seg+16+1,8);
-	CALLBACK_Setup(call_int2e,&INT2E_Handler,CB_IRET_STI,RealToPhysical(addr_int2e),"Shell Int 2e");
+	CALLBACK_Setup(call_int2e,&INT2E_Handler,CB_IRET_STI,RealToPhysical(addr_int2e), "Shell Int 2e");
 	RealSetVec(0x2e,addr_int2e);
 
 	/* Setup MCBs */


### PR DESCRIPTION
Addresses my complaints raised in https://github.com/dosbox-staging/dosbox-staging/issues/2669 plus gives the output of the `CONFIG` command some much needed love.

This is how it looks like now:

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/d73bb72b-5f91-4bc1-8f60-86f48b9886d5">
<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/b8fbd410-3b8b-4b82-88a2-7d1a3b30b94f">

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/6b2b3871-8688-4c03-90e2-8efb4fbb6189">

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/f5ea2f2f-513a-4bea-9062-a55b26465029">
