### PR TITLE
Omit blank lines from command history

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -445,14 +445,19 @@ void DOS_Shell::SyntaxError()
 
 static std::string get_shell_history_path()
 {
-	const auto section = static_cast<Section_prop *>(control->GetSection("dos"));
+	const auto section = static_cast<Section_prop*>(control->GetSection("dos"));
 	if (section) {
 		const auto path = section->Get_path("shell_history_file");
 		if (path) {
-			// Workaround: If shell_history_file is not in the user's config, path->SetValue function never gets called which sets realpath.
-			// Append the config dir here to prevent this from getting written to current working directory in that case.
-			if (!path->realpath.empty() && path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
-				return (get_platform_config_dir() / path->realpath).string();
+			// Workaround: If shell_history_file is not in the
+			// user's config, path->SetValue function never gets
+			// called which sets realpath. Append the config dir
+			// here to prevent this from getting written to current
+			// working directory in that case.
+			if (!path->realpath.empty() &&
+			    path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
+				return (get_platform_config_dir() / path->realpath)
+				        .string();
 			}
 			return path->realpath;
 		}

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -77,7 +77,10 @@ void DOS_Shell::ShowPrompt()
 void DOS_Shell::InputCommand(char* line)
 {
 	std::string command = ReadCommand();
-	history.emplace_back(command);
+	trim(command);
+	if (!command.empty()) {
+		history.emplace_back(command);
+	}
 
 	const auto* const dos_section = dynamic_cast<Section_prop*>(
 	        control->GetSection("dos"));


### PR DESCRIPTION
Should be self-explanatory. Type `dir` in the current version, then press Enter a couple of times, then execute say `mixer`. You can't just press up-arrow twice to get back to the `dir` command in the history; you need to go through _every single blank line_ as well...

That's quite bad; none of the normal shells work like that!
