### PR TITLE
Fix no function names in Loguru stack traces on Linux

### DIFF
--- a/src/libs/loguru/meson.build
+++ b/src/libs/loguru/meson.build
@@ -11,6 +11,7 @@ endforeach
 
 if all_stacktrace_headers_found
     add_project_arguments('-DLOGURU_STACKTRACES=1', language: 'cpp')
+    add_project_link_arguments('-rdynamic', language: 'cpp')
 endif
 
 # Prevent loguru from parsing command-line arguments with


### PR DESCRIPTION
Linux doesn't provide function names in Loguru stack traces without the `-rdynamic` linker flag.

Tested on WSL, as well as verified it still works on macOS.

Fixes #2679