### PR TITLE
Close file descriptor in cdrom ioctl class

### DIFF
--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -42,6 +42,9 @@ CDROM_Interface_Ioctl::~CDROM_Interface_Ioctl()
 	if (mixer_channel) {
 		MIXER_DeregisterChannel(mixer_channel);
 	}
+	if (IsOpen()) {
+		close(cdrom_fd);
+	}
 }
 
 bool CDROM_Interface_Ioctl::IsOpen() const


### PR DESCRIPTION
I forgot to clean up after myself and leaked a file descriptor.  Just need to add a `close` in the destructor.