### PR TITLE
Use dynamic SDL version checking for logging

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4886,8 +4886,10 @@ int sdl_main(int argc, char *argv[])
 	// Once initialised, ensure we clean up SDL for all exit conditions
 	atexit(QuitSDL);
 
+	SDL_version sdl_version;
+	SDL_GetVersion(&sdl_version);
 	LOG_MSG("SDL: version %d.%d.%d initialised (%s video and %s audio)",
-		SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL,
+		sdl_version.major, sdl_version.minor, sdl_version.patch,
 		SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
 
 	const auto config_path = get_platform_config_dir();


### PR DESCRIPTION
This was using a compile time constant, rather than showing what the user is actually running.  Brought to my attention in #2671 and then confirmed by running the pre-compiled 0.81.0 binary from the DOSBox Staging website.  Apparently it was compiled against an ancient SDL 2.0.8 version :roll_eyes: 

There's also some sketchy checks against this compile time constant version:

https://github.com/dosbox-staging/dosbox-staging/blob/56a52cfceb1de0f5621228675789dd4b29653648/src/gui/sdlmain.cpp#L4154

https://github.com/dosbox-staging/dosbox-staging/blob/56a52cfceb1de0f5621228675789dd4b29653648/src/gui/sdlmain.cpp#L4870

I don't know enough about what the code is doing so I left it out for now.  However, I suspect the code that is inside these macros never made it out to our users since we are building with an old SDL version and this would have just gotten `#ifdef`'d out.

If we want this to be checking against what the user is actually running, we need to be using the dynamic `SDL_GetVersion()` function.