### PR TITLE
Simplify and improve `presentation_mode` handling

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -72,17 +72,17 @@ enum class VsyncState {
 };
 
 // The vsync settings consists of three parts:
-//  - What the user asked for,
-//  - What the measured state is after setting the requested. The video driver
-//    may honor the requested vsync state, ignore it, change it, or be outright
-//    buggy.
+//  - What the user asked for.
+//  - What the measured state is after setting the requested vsync state.
+//    The video driver may honor the requested vsync state, ignore it, change
+//    it, or be outright buggy.
 //  - The benchmarked rate is the actual frame rate after setting the requested
 //    stated, and is used to determined the measured state.
 //
 struct VsyncSettings {
 	VsyncState requested = VsyncState::Unset;
 	VsyncState measured  = VsyncState::Unset;
-	int benchmarked_rate  = 0;
+	int benchmarked_rate = 0;
 };
 
 enum PRIORITY_LEVELS {
@@ -163,12 +163,14 @@ struct SDL_Block {
 		std::string hint_paused_str = {};
 		std::string cycles_ms_str   = {};
 	} title_bar = {};
+
 	struct {
-		VsyncSettings when_windowed = {};
+		VsyncSettings when_windowed   = {};
 		VsyncSettings when_fullscreen = {};
-		VsyncState current = VsyncState::On;
-		int skip_us = 0;
+		VsyncState current            = VsyncState::On;
+		int skip_us                   = 0;
 	} vsync = {};
+
 #if C_OPENGL
 	struct {
 		SDL_GLContext context;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -54,11 +54,11 @@ enum class FrameMode {
 	ThrottledVfr, // variable frame rate, throttled to the display's rate
 };
 
-enum class HOST_RATE_MODE {
-	AUTO,
-	SDI, // serial digital interface
-	VRR, // variable refresh rate
-	CUSTOM,
+enum class HostRateMode {
+	Auto,
+	Sdi, // serial digital interface
+	Vrr, // variable refresh rate
+	Custom,
 };
 
 enum class InterpolationMode { Bilinear, NearestNeighbour };
@@ -153,7 +153,7 @@ struct SDL_Block {
 		// position when leaving fullscreen for the first time.
 		// See FinalizeWindowState function for details.
 		bool lazy_init_window_size = false;
-		HOST_RATE_MODE host_rate_mode = HOST_RATE_MODE::AUTO;
+		HostRateMode host_rate_mode = HostRateMode::Auto;
 		double preferred_host_rate = 0.0;
 		bool want_resizable_window = false;
 		SCREEN_TYPES type = SCREEN_SURFACE;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -51,7 +51,6 @@ enum class FRAME_MODE {
 	UNSET,
 	CFR,        // constant frame rate, as defined by the emulated system
 	VFR,        // variable frame rate, as defined by the emulated system
-	SYNCED_CFR, // constant frame rate, synced with the display's refresh rate
 	THROTTLED_VFR, // variable frame rate, throttled to the display's rate
 };
 
@@ -64,22 +63,26 @@ enum class HOST_RATE_MODE {
 
 enum class SCALING_MODE { NONE, NEAREST };
 
-enum class VSYNC_STATE {
-	UNSET = -2,
-	ADAPTIVE = -1,
-	OFF = 0,
-	ON = 1,
+enum class VsyncState {
+	Unset    = -2,
+	Adaptive = -1,
+	Off      = 0,
+	On       = 1,
+	Yield    = 2,
 };
 
-// A vsync preference consists of three parts:
-//  - What the user asked for
-//  - What the host reports vsync as after setting it
-//  - What the actual resulting state is after setting it
-struct VsyncPreference {
-	VSYNC_STATE requested = VSYNC_STATE::UNSET;
-	VSYNC_STATE reported = VSYNC_STATE::UNSET;
-	VSYNC_STATE resultant = VSYNC_STATE::UNSET;
-	int benchmarked_rate = 0;
+// The vsync settings consists of three parts:
+//  - What the user asked for,
+//  - What the measured state is after setting the requested. The video driver
+//    may honor the requested vsync state, ignore it, change it, or be outright
+//    buggy.
+//  - The benchmarked rate is the actual frame rate after setting the requested
+//    stated, and is used to determined the measured state.
+//
+struct VsyncSettings {
+	VsyncState requested = VsyncState::Unset;
+	VsyncState measured  = VsyncState::Unset;
+	int benchmarked_rate  = 0;
 };
 
 enum PRIORITY_LEVELS {
@@ -161,9 +164,9 @@ struct SDL_Block {
 		std::string cycles_ms_str   = {};
 	} title_bar = {};
 	struct {
-		VsyncPreference when_windowed = {};
-		VsyncPreference when_fullscreen = {};
-		VSYNC_STATE current = VSYNC_STATE::ON;
+		VsyncSettings when_windowed = {};
+		VsyncSettings when_fullscreen = {};
+		VsyncState current = VsyncState::On;
 		int skip_us = 0;
 	} vsync = {};
 #if C_OPENGL

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -47,11 +47,11 @@ enum SCREEN_TYPES	{
 #endif
 };
 
-enum class FRAME_MODE {
-	UNSET,
-	CFR,        // constant frame rate, as defined by the emulated system
-	VFR,        // variable frame rate, as defined by the emulated system
-	THROTTLED_VFR, // variable frame rate, throttled to the display's rate
+enum class FrameMode {
+	Unset,
+	Cfr,          // constant frame rate, as defined by the emulated system
+	Vfr,          // variable frame rate, as defined by the emulated system
+	ThrottledVfr, // variable frame rate, throttled to the display's rate
 };
 
 enum class HOST_RATE_MODE {
@@ -210,25 +210,30 @@ struct SDL_Block {
 	SDL_Renderer *renderer = nullptr;
 	std::string render_driver = "";
 	int display_number = 0;
+
 	struct {
 		SDL_Surface *input_surface = nullptr;
 		SDL_Texture *texture = nullptr;
 		SDL_PixelFormat *pixelFormat = nullptr;
 	} texture = {};
+
 	struct {
-		present_frame_f *present = present_frame_noop;
-		update_frame_buffer_f *update = update_frame_noop;
-		FRAME_MODE desired_mode = FRAME_MODE::UNSET;
-		FRAME_MODE mode = FRAME_MODE::UNSET;
-		double period_ms = 0.0; // in ms, for use with PIC timers
-		int period_us = 0;      // same but in us, for use with chrono
+		present_frame_f* present      = present_frame_noop;
+		update_frame_buffer_f* update = update_frame_noop;
+		FrameMode desired_mode        = FrameMode::Unset;
+		FrameMode mode                = FrameMode::Unset;
+		double period_ms    = 0.0; // in ms, for use with PIC timers
+		int period_us       = 0; // same but in us, for use with chrono
 		int period_us_early = 0;
-		int period_us_late = 0;
+		int period_us_late  = 0;
 		int8_t vfr_dupe_countdown = 0;
 	} frame = {};
+
 	SDL_Rect updateRects[1024] = {};
+
 	bool use_exact_window_resolution = false;
 	bool use_viewport_limits = false;
+
 	SDL_Point viewport_resolution = {-1, -1};
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -61,7 +61,7 @@ enum class HOST_RATE_MODE {
 	CUSTOM,
 };
 
-enum class SCALING_MODE { NONE, NEAREST };
+enum class InterpolationMode { Bilinear, NearestNeighbour };
 
 enum class VsyncState {
 	Unset    = -2,
@@ -101,8 +101,10 @@ struct SDL_Block {
 	bool update_display_contents = true;
 	bool resizing_window = false;
 	bool wait_on_error = false;
-	SCALING_MODE scaling_mode = SCALING_MODE::NONE;
+
+	InterpolationMode interpolation_mode    = InterpolationMode::Bilinear;
 	IntegerScalingMode integer_scaling_mode = IntegerScalingMode::Off;
+
 	struct {
 		int width = 0;
 		int height = 0;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -167,7 +167,6 @@ struct SDL_Block {
 	struct {
 		VsyncSettings when_windowed   = {};
 		VsyncSettings when_fullscreen = {};
-		VsyncState current            = VsyncState::On;
 		int skip_us                   = 0;
 	} vsync = {};
 

--- a/include/vga.h
+++ b/include/vga.h
@@ -70,12 +70,12 @@ constexpr uint16_t EGA_LINE_DOUBLE = 1 << 1;
 constexpr uint16_t VGA_PIXEL_DOUBLE = 1 << 2;
 
 // Refresh rate constants
-constexpr auto REFRESH_RATE_MIN = 23;
-constexpr auto REFRESH_RATE_HOST_VRR_LFC = 48;
-constexpr auto REFRESH_RATE_HOST_DEFAULT = 60;
-constexpr auto REFRESH_RATE_DOS_DEFAULT = 70;
+constexpr auto RefreshRateMin            = 23;
+constexpr auto RefreshRateHostVrrLfc     = 48;
+constexpr auto RefreshRateHostDefault    = 60;
+constexpr auto RefreshRateDosDefault     = 70;
 constexpr auto InterpolatingVrrMinRateHz = 140;
-constexpr auto REFRESH_RATE_MAX = 1000;
+constexpr auto RefreshRateMax            = 1000;
 
 #define CLK_25 25175
 #define CLK_28 28322
@@ -149,7 +149,7 @@ struct VGA_Config {
 
 enum Drawmode { PART, DRAWLINE, EGALINE };
 
-enum class VGA_RATE_MODE { DEFAULT, HOST, CUSTOM };
+enum class VgaRateMode { Default, Host, Custom };
 
 enum PixelsPerChar : int8_t {
 	Eight = 8,
@@ -227,10 +227,10 @@ struct VGA_Draw {
 	// clang-format on
 	Bitu bpp = 0;
 
-	double host_refresh_hz = REFRESH_RATE_HOST_DEFAULT;
-	double dos_refresh_hz = REFRESH_RATE_DOS_DEFAULT;
-	double custom_refresh_hz = REFRESH_RATE_DOS_DEFAULT;
-	VGA_RATE_MODE dos_rate_mode = VGA_RATE_MODE::DEFAULT;
+	double host_refresh_hz = RefreshRateHostDefault;
+	double dos_refresh_hz = RefreshRateDosDefault;
+	double custom_refresh_hz = RefreshRateDosDefault;
+	VgaRateMode dos_rate_mode = VgaRateMode::Default;
 	Fraction pixel_aspect_ratio = {};
 	bool double_scan = false;
 	bool doublewidth = false;

--- a/include/vga.h
+++ b/include/vga.h
@@ -74,7 +74,7 @@ constexpr auto REFRESH_RATE_MIN = 23;
 constexpr auto REFRESH_RATE_HOST_VRR_LFC = 48;
 constexpr auto REFRESH_RATE_HOST_DEFAULT = 60;
 constexpr auto REFRESH_RATE_DOS_DEFAULT = 70;
-constexpr auto REFRESH_RATE_HOST_VRR_MIN = 75;
+constexpr auto InterpolatingVrrMinRateHz = 140;
 constexpr auto REFRESH_RATE_MAX = 1000;
 
 #define CLK_25 25175

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -242,7 +242,7 @@ static void update_frame_gl_fb(const uint16_t *changedLines);
 static bool present_frame_gl();
 #endif
 
-static const char *vsync_state_as_string(const VsyncState state)
+static const char* vsync_state_as_string(const VsyncState state)
 {
 	switch (state) {
 	case VsyncState::Unset: return "unset";
@@ -495,15 +495,15 @@ static void populate_requested_vsync_settings()
 		sdl.vsync.when_fullscreen.requested = VsyncState::Yield;
 	} else {
 		assert(user_pref == "auto");
-		// In window-mode, assume the window manager has exclusive
+		// In windowed-mode, assume the window manager has exclusive
 		// access to the GPU so leave vsync off
 		sdl.vsync.when_windowed.requested = VsyncState::Off;
 
 		// For fullscreen mode, VRR displays that perform
-		// frame-interpolation need vsync enabled to lock onto the
-		// content. So we select vsync-on whenever a display is
-		// /potentially/ this type.  This has little downside because at
-		// > 140+ Hz, all DOS refresh rates are going to be presented.
+		// frame interpolation need vsync enabled to lock onto the
+		// content. So we select "vsync on" whenever a display is
+		// /potentially/ this type. This has little downside because at
+		// >140+ Hz, all DOS refresh rates are going to be presented.
 		//
 		const bool prefers_vsync_when_fullscreen =
 		        (get_host_refresh_rate() >= InterpolatingVrrMinRateHz);
@@ -517,10 +517,10 @@ static void populate_requested_vsync_settings()
 		//
 		// 2) is "less worse" when the *unique* DOS frame rate actually
 		//    exceeds the host rate. Why? When disabled, frames might
-		//    tear, but there is no slow down or full frames dropped.
+		//    tear, but there is no slowdown or full frames dropped.
 		//    When enabled, entire frames will either be dropped or
 		//    the host will jam up with a rendering stall, drain the
-		//    audio buffer and possible stutter or pop.
+		//    audio buffer, and possible stutter or pop.
 		//
 		// 'auto' lets us make a judgement call for average user, so
 		// we accept the risk of tearing with the guarantee of no
@@ -887,7 +887,7 @@ static VsyncSettings& get_vsync_settings()
 }
 
 // Benchmarks are run in each vsync'd mode as part of the vsync detection
-// process. This routine returns the vsync-mode's current benchmark rate
+// process. This routine returns the vsync mode's current benchmark rate
 // if available.
 static std::optional<int> get_benchmarked_vsync_rate()
 {
@@ -1136,7 +1136,7 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 	VGA_SetHostRate(host_rate);
 	const auto dos_rate = VGA_GetPreferredRate();
 
-	// Update the VFR duplicate cowndown based on the DOS rate to produce a
+	// Update the VFR duplicate countdown based on the DOS rate to produce a
 	// fixed lower-bound dupe refresh rate.
 	set_vfr_dupe_countdown_from_rate(dos_rate);
 
@@ -1174,14 +1174,13 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 			return vsync_is_on ? std::min(bench_rate, host_rate)
 			                   : std::max(bench_rate, host_rate);
 		};
-
 		const auto supported_rate = get_supported_rate();
 
 		const auto display_might_be_interpolating = (host_rate >=
 		                                             InterpolatingVrrMinRateHz);
 
 		// If we're fullscreen, vsynced, and using a VRR display that
-		// performs frame-interpolation, then we prefer to use a
+		// performs frame interpolation, then we prefer to use a
 		// constant rate.
 		const auto conditions_prefer_constant_rate =
 		        (sdl.desktop.fullscreen && vsync_is_on &&

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4464,38 +4464,38 @@ void config_add_sdl() {
 	        "             display (default).\n"
 	        "  sdi:       Use serial device interface (SDI) rates, without further\n"
 	        "             adjustment.\n"
-	        "  vrr:       Deduct 3 Hz from the reported rate (best-practice for VRR\n"
+	        "  vrr:       Deduct 3 Hz from the reported rate (best practice for VRR\n"
 	        "             displays).\n"
-	        "  <custom>:  Specify a custom rate as a whole or decimal value greater than\n"
-	        "             23.000.");
+	        "  <custom>:  Specify a custom rate as an integer or decimal Hz value\n"
+	        "             (23.000 is the allowed minimum).");
 
 	const char* vsync_prefs[] = {"auto", "on", "off", "yield", 0};
 	pstring = sdl_sec->Add_string("vsync", always, "auto");
 
 	pstring->Set_help(
-	        "Set the host video drivers synchronization mode:\n"
-	        "  auto:      Limit the synchronization to beneficial cases, such as when\n"
-	        "             using an interpolating VRR display in fullscreen (default).\n"
-	        "  on:        Enable synchronization. This can prevent tearing in some games\n"
-	        "             but will impact performance or drop frames when the DOS rate\n"
-	        "             exceeds the host rate (e.g., 70 Hz vs. 60 Hz).\n"
-	        "  off:       Attempt to disable video synchronization to allow quicker\n"
-	        "             frame presentation at the risk of tearing in some games.\n"
+	        "Set the host video driver's vertical synchronization (vsync) mode:\n"
+	        "  auto:      Limit vsync to beneficial cases, such as when using an\n"
+	        "             interpolating VRR display in fullscreen (default).\n"
+	        "  on:        Enable vsync. This can prevent tearing in some games but will\n"
+	        "             impact performance or drop frames when the DOS rate exceeds the\n"
+	        "             host rate (e.g. 70 Hz DOS rate vs 60 Hz host rate).\n"
+	        "  off:       Attempt to disable vsync to allow quicker frame presentation at\n"
+	        "             the risk of tearing in some games.\n"
 	        "  yield:     Let the host's video driver control video synchronization.");
 	pstring->Set_values(vsync_prefs);
 
 	pint = sdl_sec->Add_int("vsync_skip", on_start, 0);
 	pint->Set_help("Number of microseconds to allow rendering to block before skipping the\n"
-	               "next frame. For example, a value of 7000 is roughly half the frame time at 70 Hz.\n"
-				   "0 disables this and will always render (default).");
+	               "next frame. For example, a value of 7000 is roughly half the frame time\n"
+	               "at 70 Hz. 0 disables this and will always render (default).");
 	pint->SetMinMax(0, 14000);
 
 	const char *presentation_modes[] = {"auto", "cfr", "vfr", 0};
 	pstring = sdl_sec->Add_string("presentation_mode", always, "auto");
 	pstring->Set_help(
 	        "Select the frame presentation mode:\n"
-	        "  auto:  Intelligently time and drop frames to prevent emulation\n"
-	        "         stalls, based on host and DOS frame rates (default).\n"
+	        "  auto:  Intelligently time and drop frames to prevent emulation stalls,\n"
+	        "         based on host and DOS frame rates (default).\n"
 	        "  cfr:   Always present DOS frames at a constant frame rate.\n"
 	        "  vfr:   Always present changed DOS frames at a variable frame rate.");
 	pstring->Set_values(presentation_modes);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -438,7 +438,7 @@ static double get_host_refresh_rate()
 	const char *rate_description = ""; // description of the refresh rate
 
 	switch (sdl.desktop.host_rate_mode) {
-	case HOST_RATE_MODE::AUTO:
+	case HostRateMode::Auto:
 		if (const auto sdl_rate = get_sdl_rate();
 		    sdl.desktop.fullscreen && sdl_rate >= InterpolatingVrrMinRateHz) {
 			rate = get_vrr_rate(sdl_rate);
@@ -448,15 +448,15 @@ static double get_host_refresh_rate()
 			rate_description = "standard SDI (auto)";
 		}
 		break;
-	case HOST_RATE_MODE::SDI:
+	case HostRateMode::Sdi:
 		rate = get_sdi_rate(get_sdl_rate());
 		rate_description = "standard SDI";
 		break;
-	case HOST_RATE_MODE::VRR:
+	case HostRateMode::Vrr:
 		rate = get_vrr_rate(get_sdl_rate());
 		rate_description = "VRR-adjusted";
 		break;
-	case HOST_RATE_MODE::CUSTOM:
+	case HostRateMode::Custom:
 		assert(sdl.desktop.preferred_host_rate >= REFRESH_RATE_MIN);
 		rate = sdl.desktop.preferred_host_rate;
 		rate_description = "custom";
@@ -3763,21 +3763,21 @@ static void GUI_StartUp(Section *sec)
 	}
 
 	const std::string host_rate_pref = section->Get_string("host_rate");
-	if (host_rate_pref == "auto")
-		sdl.desktop.host_rate_mode = HOST_RATE_MODE::AUTO;
-	else if (host_rate_pref == "sdi")
-		sdl.desktop.host_rate_mode = HOST_RATE_MODE::SDI;
-	else if (host_rate_pref == "vrr")
-		sdl.desktop.host_rate_mode = HOST_RATE_MODE::VRR;
-	else {
+	if (host_rate_pref == "auto") {
+		sdl.desktop.host_rate_mode = HostRateMode::Auto;
+	} else if (host_rate_pref == "sdi") {
+		sdl.desktop.host_rate_mode = HostRateMode::Sdi;
+	} else if (host_rate_pref == "vrr") {
+		sdl.desktop.host_rate_mode = HostRateMode::Vrr;
+	} else {
 		const auto rate = to_finite<double>(host_rate_pref);
 		if (std::isfinite(rate) && rate >= REFRESH_RATE_MIN) {
-			sdl.desktop.host_rate_mode = HOST_RATE_MODE::CUSTOM;
+			sdl.desktop.host_rate_mode      = HostRateMode::Custom;
 			sdl.desktop.preferred_host_rate = rate;
 		} else {
 			LOG_WARNING("SDL: Invalid 'host_rate' value: '%s', using 'auto'",
 			            host_rate_pref.c_str());
-			sdl.desktop.host_rate_mode = HOST_RATE_MODE::AUTO;
+			sdl.desktop.host_rate_mode = HostRateMode::Auto;
 		}
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -403,19 +403,19 @@ static double get_host_refresh_rate()
 		if (display_in_use < 0) {
 			LOG_ERR("SDL: Could not get the current window index: %s",
 			        SDL_GetError());
-			return REFRESH_RATE_HOST_DEFAULT;
+			return RefreshRateHostDefault;
 		}
 		if (SDL_GetCurrentDisplayMode(display_in_use, &mode) != 0) {
 			LOG_ERR("SDL: Could not get the current display mode: %s",
 			        SDL_GetError());
-			return REFRESH_RATE_HOST_DEFAULT;
+			return RefreshRateHostDefault;
 		}
-		if (sdl_rate < REFRESH_RATE_MIN) {
+		if (sdl_rate < RefreshRateMin) {
 			LOG_WARNING("SDL: Got a strange refresh rate of %d Hz",
 			            sdl_rate);
-			return REFRESH_RATE_HOST_DEFAULT;
+			return RefreshRateHostDefault;
 		}
-		assert(sdl_rate >= REFRESH_RATE_MIN);
+		assert(sdl_rate >= RefreshRateMin);
 		return sdl_rate;
 	};
 
@@ -457,12 +457,12 @@ static double get_host_refresh_rate()
 		rate_description = "VRR-adjusted";
 		break;
 	case HostRateMode::Custom:
-		assert(sdl.desktop.preferred_host_rate >= REFRESH_RATE_MIN);
+		assert(sdl.desktop.preferred_host_rate >= RefreshRateMin);
 		rate = sdl.desktop.preferred_host_rate;
 		rate_description = "custom";
 		break;
 	}
-	assert(rate >= REFRESH_RATE_MIN);
+	assert(rate >= RefreshRateMin);
 
 	// Log if changed
 	static auto last_int_rate = 0;
@@ -900,7 +900,7 @@ static void set_vfr_dupe_countdown_from_rate(const double dos_rate_hz)
 	constexpr auto max_dupe_rate_hz = 10.0;
 
 	assert(dos_rate_hz >= max_dupe_rate_hz);
-	assert(dos_rate_hz <= REFRESH_RATE_MAX);
+	assert(dos_rate_hz <= RefreshRateMax);
 	const auto dos_to_dupe_frames = iround(dos_rate_hz / max_dupe_rate_hz);
 
 	sdl.frame.vfr_dupe_countdown = check_cast<int8_t>(dos_to_dupe_frames);
@@ -3771,7 +3771,7 @@ static void GUI_StartUp(Section *sec)
 		sdl.desktop.host_rate_mode = HostRateMode::Vrr;
 	} else {
 		const auto rate = to_finite<double>(host_rate_pref);
-		if (std::isfinite(rate) && rate >= REFRESH_RATE_MIN) {
+		if (std::isfinite(rate) && rate >= RefreshRateMin) {
 			sdl.desktop.host_rate_mode      = HostRateMode::Custom;
 			sdl.desktop.preferred_host_rate = rate;
 		} else {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1142,9 +1142,7 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 
 	// Consider any vsync state that isn't explicitly off as having some
 	// level of vsync enforcement as "on"
-	const auto vsync_is_on = (sdl.vsync.current == VsyncState::On ||
-	                          get_vsync_settings().requested !=
-	                                  VsyncState::Off);
+	const auto vsync_is_on = (get_vsync_settings().requested != VsyncState::Off);
 
 	// to be set below
 	auto mode = FRAME_MODE::UNSET;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -905,8 +905,10 @@ static void set_vfr_dupe_countdown_from_rate(const double dos_rate_hz)
 
 	sdl.frame.vfr_dupe_countdown = check_cast<int8_t>(dos_to_dupe_frames);
 
-	// LOG_MSG("SDL: Setting VFR duplicate countdown to %d "
-	//         "from a DOS rate of %.1f Hz ", dos_to_dupe_frames, dos_rate_hz);
+#if 0
+	LOG_MSG("SDL: Setting VFR duplicate countdown to %d "
+	        "from a DOS rate of %.1f Hz ", dos_to_dupe_frames, dos_rate_hz);
+#endif
 }
 
 static void save_rate_to_frame_period(const double rate_hz)
@@ -1162,8 +1164,9 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 	}
 	// Automatic CFR or VFR modes
 	else {
+		const auto has_bench_rate = get_benchmarked_vsync_rate();
+
 		auto get_supported_rate = [=]() -> double {
-			const auto has_bench_rate = get_benchmarked_vsync_rate();
 			if (!has_bench_rate) {
 				return host_rate;
 			}
@@ -1184,24 +1187,24 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 		        (sdl.desktop.fullscreen && vsync_is_on &&
 		         display_might_be_interpolating);
 
-		/*
-		LOG_MSG("Auto presentation mode conditions:");
-		LOG_MSG("  - DOS rate is %2.5g Hz", dos_rate);
+#if 0	
+		LOG_MSG("SDL: Auto presentation mode conditions:");
+		LOG_MSG("SDL:   - DOS rate is %2.5g Hz", dos_rate);
 		if (has_bench_rate) {
-		        LOG_MSG("  - Host renders at %d FPS", *has_bench_rate);
+		        LOG_MSG("SDL:   - Host renders at %d FPS", *has_bench_rate);
 		}
-		LOG_MSG("  - Display refresh rate is %.3f Hz", host_rate);
-		LOG_MSG("  - %s",
+		LOG_MSG("SDL:   - Display refresh rate is %.3f Hz", host_rate);
+		LOG_MSG("SDL:   - %s",
 		        supported_rate >= dos_rate
 		                ? "Host can handle the full DOS rate"
 		                : "Host cannot handle the DOS rate");
-		LOG_MSG("  - %s",
+		LOG_MSG("SDL:   - %s",
 		        conditions_prefer_constant_rate
 		                ? "CFR selected because we're fullscreen, "
 		                  "vsync'd, and display is 140+Hz"
 		                : "VFR selected because we're not "
 		                  "fullscreen, nor vsync'd, nor < 140Hz");
-		*/
+#endif
 
 		if (supported_rate >= dos_rate) {
 			mode = conditions_prefer_constant_rate ? FRAME_MODE::CFR

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -800,12 +800,12 @@ static void log_display_properties(int source_w, int source_h,
 	const auto [mode_desc, colours_desc] =
 	        VGA_DescribeMode(mode_type, mode_id, source_w, source_h);
 
-	const char *frame_mode = nullptr;
+	const char* frame_mode = nullptr;
 	switch (sdl.frame.mode) {
-	case FRAME_MODE::CFR: frame_mode = "CFR"; break;
-	case FRAME_MODE::VFR: frame_mode = "VFR"; break;
-	case FRAME_MODE::THROTTLED_VFR: frame_mode = "throttled VFR"; break;
-	case FRAME_MODE::UNSET: frame_mode = "Unset frame_mode"; break;
+	case FrameMode::Cfr: frame_mode = "CFR"; break;
+	case FrameMode::Vfr: frame_mode = "VFR"; break;
+	case FrameMode::ThrottledVfr: frame_mode = "throttled VFR"; break;
+	case FrameMode::Unset: frame_mode = "Unset frame_mode"; break;
 	}
 
 	auto refresh_rate = VGA_GetPreferredRate();
@@ -1129,7 +1129,7 @@ static void maybe_present_synced(const bool present_if_last_skipped)
 	last_sync_time = should_present ? GetTicksUs() : now;
 }
 
-static void setup_presentation_mode(FRAME_MODE &previous_mode)
+static void setup_presentation_mode(FrameMode &previous_mode)
 {
 	// Always get the reported refresh rate and hint the VGA side with it.
 	// This ensures the VGA side always has the host's rate to prior to its
@@ -1147,11 +1147,11 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 	const auto vsync_is_on = (get_vsync_settings().requested != VsyncState::Off);
 
 	// to be set below
-	auto mode = FRAME_MODE::UNSET;
+	auto mode = FrameMode::Unset;
 
 	// Manual CFR or VFR modes
-	if (sdl.frame.desired_mode == FRAME_MODE::CFR ||
-	    sdl.frame.desired_mode == FRAME_MODE::VFR) {
+	if (sdl.frame.desired_mode == FrameMode::Cfr ||
+	    sdl.frame.desired_mode == FrameMode::Vfr) {
 		mode = sdl.frame.desired_mode;
 
 		// Frames will be presented at the DOS rate.
@@ -1207,11 +1207,11 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 #endif
 
 		if (supported_rate >= dos_rate) {
-			mode = conditions_prefer_constant_rate ? FRAME_MODE::CFR
-			                                       : FRAME_MODE::VFR;
+			mode = conditions_prefer_constant_rate ? FrameMode::Cfr
+			                                       : FrameMode::Vfr;
 			save_rate_to_frame_period(dos_rate);
 		} else {
-			mode =FRAME_MODE::THROTTLED_VFR;
+			mode = FrameMode::ThrottledVfr;
 			save_rate_to_frame_period(nearest_common_rate(supported_rate));
 		}
 		// In auto-mode, the presentation rate doesn't exceed supported
@@ -1220,7 +1220,7 @@ static void setup_presentation_mode(FRAME_MODE &previous_mode)
 	}
 
 	// If the mode is unchanged, do nothing
-	assert(mode != FRAME_MODE::UNSET);
+	assert(mode != FrameMode::Unset);
 	if (previous_mode == mode)
 		return;
 	previous_mode = mode;
@@ -2562,14 +2562,14 @@ void GFX_EndUpdate(const uint16_t *changedLines)
 		const auto frame_is_new = sdl.update_display_contents && sdl.updating;
 
 		switch (sdl.frame.mode) {
-		case FRAME_MODE::CFR:
+		case FrameMode::Cfr:
 			maybe_present_synced(frame_is_new);
 			break;
-		case FRAME_MODE::VFR: present_new_or_maybe_dupe(frame_is_new); break;
-		case FRAME_MODE::THROTTLED_VFR:
+		case FrameMode::Vfr: present_new_or_maybe_dupe(frame_is_new); break;
+		case FrameMode::ThrottledVfr:
 			maybe_present_throttled_or_dupe(frame_is_new);
 			break;
-		case FRAME_MODE::UNSET:
+		case FrameMode::Unset:
 			break;
 		}
 	}
@@ -3790,13 +3790,13 @@ static void GUI_StartUp(Section *sec)
 	const std::string presentation_mode_pref = section->Get_string(
 	        "presentation_mode");
 	if (presentation_mode_pref == "auto")
-		sdl.frame.desired_mode = FRAME_MODE::UNSET;
+		sdl.frame.desired_mode = FrameMode::Unset;
 	else if (presentation_mode_pref == "cfr")
-		sdl.frame.desired_mode = FRAME_MODE::CFR;
+		sdl.frame.desired_mode = FrameMode::Cfr;
 	else if (presentation_mode_pref == "vfr")
-		sdl.frame.desired_mode = FRAME_MODE::VFR;
+		sdl.frame.desired_mode = FrameMode::Vfr;
 	else {
-		sdl.frame.desired_mode = FRAME_MODE::UNSET;
+		sdl.frame.desired_mode = FrameMode::Unset;
 		LOG_WARNING("SDL: Invalid 'presentation_mode' value: '%s'",
 		            presentation_mode_pref.c_str());
 	}

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -221,31 +221,31 @@ void VGA_StartResizeAfter(const uint16_t delay_ms)
 void VGA_SetHostRate(const double refresh_hz)
 {
 	// may come from user content, so always clamp it
-	constexpr auto min_rate = static_cast<double>(REFRESH_RATE_MIN);
-	constexpr auto max_rate = static_cast<double>(REFRESH_RATE_MAX);
+	constexpr auto min_rate = static_cast<double>(RefreshRateMin);
+	constexpr auto max_rate = static_cast<double>(RefreshRateMax);
 	vga.draw.host_refresh_hz = clamp(refresh_hz,min_rate, max_rate);
 }
 
 void VGA_SetRatePreference(const std::string &pref)
 {
 	if (pref == "default") {
-		vga.draw.dos_rate_mode = VGA_RATE_MODE::DEFAULT;
+		vga.draw.dos_rate_mode = VgaRateMode::Default;
 		LOG_MSG("VIDEO: Using the DOS video mode's frame rate");
 
 	} else if (pref == "host") {
-		vga.draw.dos_rate_mode = VGA_RATE_MODE::HOST;
+		vga.draw.dos_rate_mode = VgaRateMode::Host;
 		LOG_MSG("VIDEO: Matching the DOS graphical frame rate to the host");
 
 	} else if (const auto rate = to_finite<double>(pref); std::isfinite(rate)) {
-		vga.draw.dos_rate_mode = VGA_RATE_MODE::CUSTOM;
-		constexpr auto min_rate = static_cast<double>(REFRESH_RATE_MIN);
-		constexpr auto max_rate = static_cast<double>(REFRESH_RATE_MAX);
+		vga.draw.dos_rate_mode = VgaRateMode::Custom;
+		constexpr auto min_rate = static_cast<double>(RefreshRateMin);
+		constexpr auto max_rate = static_cast<double>(RefreshRateMax);
 		vga.draw.custom_refresh_hz = clamp(rate, min_rate, max_rate);
 		LOG_MSG("VIDEO: Using a custom DOS graphical frame rate of %.3g Hz",
 		        vga.draw.custom_refresh_hz);
 
 	} else {
-		vga.draw.dos_rate_mode = VGA_RATE_MODE::DEFAULT;
+		vga.draw.dos_rate_mode = VgaRateMode::Default;
 		LOG_WARNING("VIDEO: Unknown frame rate setting: %s, using default",
 		            pref.c_str());
 	}
@@ -254,14 +254,14 @@ void VGA_SetRatePreference(const std::string &pref)
 double VGA_GetPreferredRate()
 {
 	switch (vga.draw.dos_rate_mode) {
-	case VGA_RATE_MODE::DEFAULT:
+	case VgaRateMode::Default:
 		return vga.draw.dos_refresh_hz;
-	case VGA_RATE_MODE::HOST:
-		assert(vga.draw.host_refresh_hz > REFRESH_RATE_MIN);
+	case VgaRateMode::Host:
+		assert(vga.draw.host_refresh_hz > RefreshRateMin);
 		return vga.draw.host_refresh_hz;
-	case VGA_RATE_MODE::CUSTOM:
-		assert(vga.draw.custom_refresh_hz >= REFRESH_RATE_MIN);
-		assert(vga.draw.custom_refresh_hz <= REFRESH_RATE_MAX);
+	case VgaRateMode::Custom:
+		assert(vga.draw.custom_refresh_hz >= RefreshRateMin);
+		assert(vga.draw.custom_refresh_hz <= RefreshRateMax);
 		return vga.draw.custom_refresh_hz;
 	}
 	return vga.draw.dos_refresh_hz;

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -253,12 +253,6 @@ void VGA_SetRatePreference(const std::string &pref)
 
 double VGA_GetPreferredRate()
 {
-	// If we're in a text-mode, always use the as-indicated DOS rate because
-	// the vblank rate is often used for timing.
-	if (CurMode->type & M_TEXT_MODES)
-		return vga.draw.dos_refresh_hz;
-
-	// In we're in a graphical mode, then we can use preferred rates
 	switch (vga.draw.dos_rate_mode) {
 	case VGA_RATE_MODE::DEFAULT:
 		return vga.draw.dos_refresh_hz;


### PR DESCRIPTION
kcgen basically finished the work on this and @0mnicydle and myself have tested and verified it. I think kcgen still wanted to do some minor cleanup and perhaps split it into separate commits, but frankly, it works fine and it can go in as it is. I've been using this for the past few days with good results.

I've added some very minor cleanup/improvements on top of it in separate commits.

- This is the original PR (please read the description): https://github.com/dosbox-staging/dosbox-staging/pull/2552
Confirmation of functionality by me and @0mnicydle can be found around the end of that extremely long discussion thread.

- And this is the original issue it fixes: https://github.com/dosbox-staging/dosbox-staging/issues/2551

---

More context:

The TL;DR is that this is a long-standing issue going back about a year. It manifests under specific conditions, but when it does, it makes programs that don't continuously refresh the screen quite hard and confusing to use (e.g. applications that don't feature a blinking cursor but only static screens that get updated sporadically on user interactions; this includes some game setup utilities as well). First kcgen and I thought this had something to do with text modes, but that was a red herring. As we went deeper, it turned out something was fundamentally wrong with the frame presentation mechanism and this is the fix for that.

We need this in as there are some fixes in current main to the "red herring text-mode problem" which actually made the whole thing overall worse... So we either revert those or merge this in. I much prefer the latter as it works fine, as I said, and it's a big improvement over the v0.80.0 behaviour for application programs.

It's a complete feature enhancement, and kcgen or whoever else can improve on it later. But we really should include it in v0.81.0, which is close to the release candidate stage.


