### PR TITLE
Make MOVE and SUBST external commands

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -42,6 +42,7 @@
 #include "program_rescan.h"
 #include "program_serial.h"
 #include "program_setver.h"
+#include "program_subst.h"
 #include "program_tree.h"
 
 #if C_DEBUG
@@ -94,6 +95,7 @@ void Add_VFiles(const bool add_autoexec)
 	PROGRAMS_MakeFile("SETVER.EXE", ProgramCreate<SETVER>);
 	PROGRAMS_MakeFile("TREE.COM", ProgramCreate<TREE>);
 	PROGRAMS_MakeFile("MOVE.EXE", ProgramCreate<MOVE>);
+	PROGRAMS_MakeFile("SUBST.EXE", ProgramCreate<SUBST>);
 	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramCreate);
 
 	if (add_autoexec) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -37,6 +37,7 @@
 #include "program_more.h"
 #include "program_mount.h"
 #include "program_mousectl.h"
+#include "program_move.h"
 #include "program_placeholder.h"
 #include "program_rescan.h"
 #include "program_serial.h"
@@ -92,6 +93,7 @@ void Add_VFiles(const bool add_autoexec)
 	PROGRAMS_MakeFile("SERIAL.COM", ProgramCreate<SERIAL>);
 	PROGRAMS_MakeFile("SETVER.EXE", ProgramCreate<SETVER>);
 	PROGRAMS_MakeFile("TREE.COM", ProgramCreate<TREE>);
+	PROGRAMS_MakeFile("MOVE.EXE", ProgramCreate<MOVE>);
 	PROGRAMS_MakeFile("COMMAND.COM", SHELL_ProgramCreate);
 
 	if (add_autoexec) {

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -44,6 +44,7 @@ libdos_sources = files(
     'program_rescan.cpp',
     'program_serial.cpp',
     'program_setver.cpp',
+    'program_subst.cpp',
     'program_tree.cpp',
 )
 

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -39,6 +39,7 @@ libdos_sources = files(
     'program_mount.cpp',
     'program_mount_common.cpp',
     'program_mousectl.cpp',
+    'program_move.cpp',
     'program_placeholder.cpp',
     'program_rescan.cpp',
     'program_serial.cpp',

--- a/src/dos/program_move.cpp
+++ b/src/dos/program_move.cpp
@@ -1,0 +1,35 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "program_move.h"
+
+#include <string>
+
+#include "shell.h"
+#include "string_utils.h"
+
+void MOVE::Run()
+{
+	std::string tmp = "";
+	cmd->GetStringRemain(tmp);
+	char args[CMD_MAXLINE];
+	safe_strcpy(args, tmp.c_str());
+	first_shell->CMD_MOVE(args);
+}

--- a/src/dos/program_move.h
+++ b/src/dos/program_move.h
@@ -1,0 +1,40 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PROGRAM_MOVE_H
+#define DOSBOX_PROGRAM_MOVE_H
+
+#include "programs.h"
+
+#include <string>
+
+class MOVE final : public Program {
+public:
+	MOVE()
+	{
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::File,
+		               HELP_CmdType::Program,
+		               "MOVE"};
+	}
+	void Run();
+};
+
+#endif

--- a/src/dos/program_subst.cpp
+++ b/src/dos/program_subst.cpp
@@ -1,0 +1,35 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "program_subst.h"
+
+#include <string>
+
+#include "shell.h"
+#include "string_utils.h"
+
+void SUBST::Run()
+{
+	std::string tmp = "";
+	cmd->GetStringRemain(tmp);
+	char args[CMD_MAXLINE];
+	safe_strcpy(args, tmp.c_str());
+	first_shell->CMD_SUBST(args);
+}

--- a/src/dos/program_subst.h
+++ b/src/dos/program_subst.h
@@ -1,0 +1,40 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_PROGRAM_SUBST_H
+#define DOSBOX_PROGRAM_SUBST_H
+
+#include "programs.h"
+
+#include <string>
+
+class SUBST final : public Program {
+public:
+	SUBST()
+	{
+		help_detail = {HELP_Filter::All,
+		               HELP_Category::File,
+		               HELP_CmdType::Program,
+		               "SUBST"};
+	}
+	void Run();
+};
+
+#endif

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -77,7 +77,6 @@ static const std::map<std::string, SHELL_Cmd> shell_cmds = {
 	{ "RMDIR",    {&DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Filter::All,    HELP_Category::File } },
 	{ "SET",      {&DOS_Shell::CMD_SET,      "SET",      HELP_Filter::All,    HELP_Category::Misc} },
 	{ "SHIFT",    {&DOS_Shell::CMD_SHIFT,    "SHIFT",    HELP_Filter::All,    HELP_Category::Batch } },
-	{ "SUBST",    {&DOS_Shell::CMD_SUBST,    "SUBST",    HELP_Filter::All,    HELP_Category::File} },
 	{ "TIME",     {&DOS_Shell::CMD_TIME,     "TIME",     HELP_Filter::All,    HELP_Category::Misc } },
 	{ "TYPE",     {&DOS_Shell::CMD_TYPE,     "TYPE",     HELP_Filter::Common, HELP_Category::Misc } },
 	{ "VER",      {&DOS_Shell::CMD_VER,      "VER",      HELP_Filter::All,    HELP_Category::Misc } },

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -68,7 +68,6 @@ static const std::map<std::string, SHELL_Cmd> shell_cmds = {
 	{ "LOADHIGH", {&DOS_Shell::CMD_LOADHIGH, "LOADHIGH", HELP_Filter::All,    HELP_Category::Misc } },
 	{ "MD",       {&DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Filter::Common, HELP_Category::File } },
 	{ "MKDIR",    {&DOS_Shell::CMD_MKDIR,    "MKDIR",    HELP_Filter::All,    HELP_Category::File } },
-	{ "MOVE",     {&DOS_Shell::CMD_MOVE,     "MOVE",     HELP_Filter::All,    HELP_Category::File } },
 	{ "PATH",     {&DOS_Shell::CMD_PATH,     "PATH",     HELP_Filter::All,    HELP_Category::Misc} },
 	{ "PAUSE",    {&DOS_Shell::CMD_PAUSE,    "PAUSE",    HELP_Filter::All,    HELP_Category::Batch } },
 	{ "RD",       {&DOS_Shell::CMD_RMDIR,    "RMDIR",    HELP_Filter::Common, HELP_Category::File } },

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -576,6 +576,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\dos\program_rescan.cpp" />
     <ClCompile Include="..\src\dos\program_serial.cpp" />
     <ClCompile Include="..\src\dos\program_setver.cpp" />
+    <ClCompile Include="..\src\dos\program_subst.cpp" />
     <ClCompile Include="..\src\dos\program_tree.cpp" />
     <ClCompile Include="..\src\fpu\fpu.cpp" />
     <ClCompile Include="..\src\gui\render.cpp" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -571,6 +571,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\dos\program_mount_common.cpp" />
     <ClCompile Include="..\src\dos\program_mount.cpp" />
     <ClCompile Include="..\src\dos\program_mousectl.cpp" />
+    <ClCompile Include="..\src\dos\program_move.cpp" />
     <ClCompile Include="..\src\dos\program_placeholder.cpp" />
     <ClCompile Include="..\src\dos\program_rescan.cpp" />
     <ClCompile Include="..\src\dos\program_serial.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -541,6 +541,9 @@
     <ClCompile Include="..\src\dos\program_ls.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_move.cpp">
+      <Filter>src\dos</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\dos\program_placeholder.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -547,6 +547,9 @@
     <ClCompile Include="..\src\dos\program_placeholder.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\dos\program_subst.cpp">
+      <Filter>src\dos</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\misc\fs_utils.cpp">
       <Filter>src\misc</Filter>
     </ClCompile>


### PR DESCRIPTION
Fixes #2666 #2667

As discussed, this is just re-using the existing code from `shell_cmds.cpp`