### PR TITLE
Hopefully make MSYS2 build pass

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -104,6 +104,7 @@ jobs:
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-zlib
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-speexdsp
             mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-python-pip
+            mingw-w64-${{matrix.conf.toolchain}}${{matrix.conf.arch}}-fluidsynth
 
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -229,6 +230,7 @@ jobs:
             mingw-w64-clang-${{matrix.conf.arch}}-zlib
             mingw-w64-clang-${{matrix.conf.arch}}-speexdsp
             mingw-w64-clang-${{matrix.conf.arch}}-python-pip
+            mingw-w64-clang-${{matrix.conf.arch}}-fluidsynth
 
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -294,10 +296,10 @@ jobs:
 
       - name: Setup release build
         run: |
-          meson setup -Ddefault_library=static -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_RELEASE_DIR
+          meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_RELEASE_DIR
 
       - name: Setup debugger build
-        run: meson setup -Ddefault_library=static -Db_lto=true -Db_lto_threads=$(nproc) -Denable_debugger=normal $BUILD_DEBUGGER_DIR
+        run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) -Denable_debugger=normal $BUILD_DEBUGGER_DIR
 
       - name: Build release
         run: |


### PR DESCRIPTION
I played around with this on my Windows partition for a while.  The problem seems to be this flag in fluidsynth that tries to link statically against Glib (dependency of Fluidsynth).

However, I just could not for the life of me get Glib to statically link in MSYS2.  I even tried a "hello world" Glib program, directly calling the compiler so as to bypass Meson and everything else in our build system.  It links just fine dynamically but as soon as I add the `-static` flag, it throws up undefined symbol errors.

It assume it's a regression in MSYS2 with some package updates (since none of the commits we've made recently should have broken this) although I wasn't able to find it.  I tried the previous version of Glib and the previous version of Meson but it still fails.

Anyway, hopefully this workaround is fine.  Did I mention I hate build systems?  :roll_eyes: 