### PR TITLE
Implement creating file with attributes in local FS

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -161,4 +161,13 @@ bool get_expanded_files(const std::string &path,
 
 std::string get_language_from_os();
 
+#ifndef WIN32
+#define XATTR_FATTR_NAME "user.dosbox_fattr"
+#define XATTR_FATTR_LEN 9 // 8 bits + null terminator
+
+uint16_t get_fat_attribs_from_xattr(const char *path);
+int set_xattr_from_fat_attribs(const char* path, uint16_t fattr);
+int set_xattr_from_fat_attribs(int fd, uint16_t fattr);
+#endif
+
 #endif

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1075,8 +1075,7 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, uint16_t attributes) {
                                     fileEntry.loFirstClust,
                                     fileEntry.entrysize,
                                     this);
-	bool is_readonly     = fileEntry.attrib & DOS_ATTR_READ_ONLY;
-	fat_file->flags      = is_readonly ? OPEN_READ : OPEN_READWRITE;
+	fat_file->flags      = OPEN_READWRITE;
 	fat_file->dirCluster = dirClust;
 	fat_file->dirIndex   = subEntry;
 	fat_file->time       = fileEntry.modTime;


### PR DESCRIPTION
This implements creating files with specific attributes in local FS. Known to be used by some games (e.g. Lemmings, floppy version, creates a hidden file named RUSSELL.DAT). I had to move away from fopen towards platform-specific functions.
I've admittedly not tested Unix version because I don't have the required environment so I'd appreciate if someone could take PR Linux/Mac build and see if it works.