### PR TITLE
Fix joysticks breaking after a config -set

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2802,10 +2802,11 @@ void BIND_MappingEvents() {
 // results. If no joysticks are valid then joytype is set to JOY_NONE_FOUND.
 // This also resets mapper.sticks.num_groups to 0 and mapper.sticks.num to the
 // number of found SDL joysticks.
+
+// 7-21-2023: No longer resetting mapper.sticks.num_groups due to https://github.com/dosbox-staging/dosbox-staging/issues/2687
 static void QueryJoysticks()
 {
 	// Reset our joystick status
-	mapper.sticks.num_groups = 0;
 	mapper.sticks.num = 0;
 
 	JOYSTICK_ParseConfiguredType();


### PR DESCRIPTION
Fixes #2687

`MAPPER_BindKeys` gets called when an SDL config entry gets changed.  This resets this global `num_groups` variable.  On first run, `CreateBindGroups()` gets called which increments this variable.  On subsequent runs, the bindgroups do not get re-created and resetting this variables makes it think there are no joysticks connected.

This whole file is kind of hard to follow... globals and raw pointers everywhere.  This fixes the problem as far as I can tell though.