### PR TITLE
website: Remove 0.79.0 release from downloads as the files are missing

### DIFF
--- a/website/docs/downloads/linux.md
+++ b/website/docs/downloads/linux.md
@@ -132,12 +132,6 @@ are designed with developers and testers in mind.
   sha256: aebf8619bb44934f18d0e219d50c4e2c<wbr>03b179c37daa67a9b800e7bd3aefc262
   </small>
 
-- [DOSBox Staging 0.79.0 (tar.xz)][0_79_0]
-  <br>
-  <small>
-  sha256: 804adb294096ab651490b1664570203f<wbr>24e460048d7e6e2e388d210a8380016a
-  </small>
-
 - [DOSBox Staging 0.78.1 (tar.xz)][0_78_1]
   <br>
   <small>
@@ -195,7 +189,6 @@ are designed with developers and testers in mind.
 [0_80_1]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.1/dosbox-staging-linux-v0.80.1.tar.xz
 [0_80_0]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-linux-v0.80.0.tar.xz
 [0_79_1]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-linux-v0.79.1.tar.xz
-[0_79_0]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-linux-v0.79.0.tar.xz
 [0_78_1]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-linux-v0.78.1.tar.xz
 [0_78_0]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-linux-v0.78.0.tar.xz
 [0_77_1]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.1/dosbox-staging-linux-v0.77.1.tar.xz

--- a/website/docs/downloads/macos.md
+++ b/website/docs/downloads/macos.md
@@ -104,12 +104,6 @@ payments and therefore ask users to bypass Apple's Gatekeeper manually.
   sha256: 52547692be29949747bb8d3b59bf31dd<wbr>22b4f49178316417cc8f1f468eeab387
   </small>
 
-- [DOSBox Staging 0.79.0 Universal binary (dmg)][0_79_0] (macOS 10.15 or newer)
-  <br>
-  <small>
-  sha256: 1678f7458acabecdaf2b49e0d95a20d0<wbr>57734898b70c29d4e845f52a1aa26d46
-  </small>
-
 - [DOSBox Staging 0.78.1 Universal binary (dmg)][0_78_1_UB] (macOS 10.15 or newer)
   <br>
   <small>
@@ -185,7 +179,6 @@ payments and therefore ask users to bypass Apple's Gatekeeper manually.
 [0_80_1]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.1/dosbox-staging-macOS-v0.80.1.dmg
 [0_80_0]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-macOS-v0.80.0.dmg
 [0_79_1]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-macOS-v0.79.1.dmg
-[0_79_0]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-macOS-v0.79.0.dmg
 [0_78_1_UB]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-macOS-v0.78.1.dmg
 [0_78_0_UB]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-macOS-v0.78.0.dmg
 [0_77_1_x64]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.1/dosbox-staging-macOS-v0.77.1.dmg

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -138,18 +138,6 @@ command-line install parameters, please see [Inno's documentation page](https://
   sha256: 8c7045dfea6dc20bb985cff516d2faee<wbr>51d2ecaf054db60632857b6941d3d648
   </small>
 
-- [DOSBox Staging 0.79.0 64-bit (installer)][0_79_0_x64_INSTALLER] (Windows 7 or newer)
-  <br>
-  <small>
-  sha256: 154c663f76d0ca46d1d23d8c2bcea2d8<wbr>3717f1ba9103067a6a6f5ce814cf0cb2
-  </small>
-
-- [DOSBox Staging 0.79.0 64-bit (zip)][0_79_0_x64_ZIP] (Windows 7 or newer)
-  <br>
-  <small>
-  sha256: b3633d425489fbb5f6f9b3de75e4c2c6<wbr>dd0713c3aec504e42cac948cc1550bbe
-  </small>
-
 - [DOSBox Staging 0.78.1 64-bit (zip)][0_78_1_x64_MSYS2] (Windows Vista or newer)
   <br>
   <small>
@@ -248,8 +236,6 @@ command-line install parameters, please see [Inno's documentation page](https://
 [0_80_0_x64_ZIP]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-windows-msys2-x86_64-v0.80.0.zip
 [0_79_1_x64_INSTALLER]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-v0.79.1-setup.exe
 [0_79_1_x64_ZIP]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-windows-x86_64-v0.79.1.zip
-[0_79_0_x64_INSTALLER]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-v0.79.0-setup.exe
-[0_79_0_x64_ZIP]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-windows-x86_64-v0.79.0.zip
 [0_78_1_x64_MSYS2]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-x86_64-v0.78.1.zip
 [0_78_1_x64_MSVC]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-x64-v0.78.1.zip
 [0_78_0_x64]: https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-windows-msys2-x86_64-v0.78.0.zip


### PR DESCRIPTION
I just noticed that kcgen had apparently removed the 0.79.0 release binaries from the GitHub releases with this comment:

> Instead of 0.79.0, we recommend downloading the 0.79.1 maintenance release because it fixes several issues.
> 
> (The 0.79.0 release can always be compiled from source or via the v079.0 commit tag)

See here: https://github.com/dosbox-staging/dosbox-staging/releases/tag/v0.79.0

I don't quite like this; I think we shouldn't remove `.0` releases retrospectively from the downloads section just because we released a patch point release later. We _want_ all of our published releases archived for easier regression testing at the very least! (e.g. I can't rebuild any commit before about 2022 May here on macOS; I'm getting linker errors... surely fixable, but time-consuming)

Anyway, I'm not aware of an easy way to rebuild the missing artifacts, so I'm removing the broken links instead as that reeks of amateur hour... I'd prefer to rebuild those artifacts and restore the download links, so if anyone knows how to do that instead, I'm all ears!
