### PR TITLE
Refactor Prop_path to use std_fs::path

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -277,15 +277,16 @@ public:
 class Prop_path final : public Prop_string {
 public:
 	Prop_path(const std::string& name, Changeable::Value when, const char* val)
-	        : Prop_string(name, when, val),
-	          realpath(val)
-	{}
+	        : Prop_string(name, when, val)
+	{
+		SetValue(val);
+	}
 
 	~Prop_path() override = default;
 
 	bool SetValue(const std::string& in) override;
 
-	std::string realpath;
+	std_fs::path realpath = {};
 };
 
 class Prop_hex final : public Property {

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -580,7 +580,7 @@ static void capture_init(Section* sec)
 
 	// We can safely change the capture output path even if capturing of any
 	// type is in progress.
-	capture.path = std_fs::path(capture_path->realpath);
+	capture.path = capture_path->realpath;
 	if (capture.path.empty()) {
 		LOG_WARNING("CAPTURE: No value specified for `capture_dir`; defaulting to 'capture' "
 		            "in the current working directory");

--- a/src/dos/program_setver.cpp
+++ b/src/dos/program_setver.cpp
@@ -545,7 +545,7 @@ void SETVER::OverrideVersion(const char* name, DOS_PSP& psp)
 	try_override(name_str, setver_table.by_file_name);
 }
 
-std::string SETVER::GetTableFilePath()
+std_fs::path SETVER::GetTableFilePath()
 {
 	// Original SETVER.EXE stores the version table in its own executable;
 	// this is not feasible in DOSBox, therefore we are using external file

--- a/src/dos/program_setver.h
+++ b/src/dos/program_setver.h
@@ -67,7 +67,7 @@ private:
 	                                          const NameVersionTable& table);
 	static bool IsTableEmpty();
 
-	static std::string GetTableFilePath();
+	static std_fs::path GetTableFilePath();
 
 	void AddMessages();
 };

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -709,7 +709,7 @@ void RENDER_InitShaderSource([[maybe_unused]] Section *sec)
 	log_warning_if_legacy_shader_name(filename);
 
 	std::string source = {};
-	if (!RENDER_GetShader(sh->realpath, source) &&
+	if (!RENDER_GetShader(sh->realpath.string(), source) &&
 	    (sh->realpath == filename || !RENDER_GetShader(filename, source))) {
 		sh->SetValue("none");
 		source.clear();

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -3097,7 +3097,7 @@ void MAPPER_BindKeys(Section *sec)
 	const auto mapperfile_value = section->Get_string("mapperfile");
 	const auto property = section->Get_path("mapperfile");
 	assert(property && !property->realpath.empty());
-	mapper.filename = property->realpath;
+	mapper.filename = property->realpath.string();
 
 	QueryJoysticks();
 

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -67,13 +67,13 @@ static bool MODEM_IsPhoneValid(const std::string &input) {
 	return true;
 }
 
-bool MODEM_ReadPhonebook(const std_fs::path &filename) {
-	std::ifstream loadfile(filename);
+bool MODEM_ReadPhonebook(const std_fs::path &path) {
+	std::ifstream loadfile(path);
 	if (!loadfile)
 		return false;
 
-	const std::string file_string = filename.string();
-	LOG_MSG("SERIAL: Phonebook loading from %s.", file_string.c_str());
+	const auto path_string = path.string();
+	LOG_MSG("SERIAL: Phonebook loading from %s.", path_string.c_str());
 
 	std::string linein;
 	while (std::getline(loadfile, linein)) {
@@ -81,8 +81,8 @@ bool MODEM_ReadPhonebook(const std_fs::path &filename) {
 		std::string phone, address;
 
 		if (!(iss >> phone >> address)) {
-			LOG_MSG("SERIAL: Phonebook skipped a bad line in %s.",
-			        file_string.c_str());
+			LOG_MSG("SERIAL: Phonebook skipped a bad line in '%s'",
+			        path_string.c_str());
 			continue;
 		}
 

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -67,12 +67,13 @@ static bool MODEM_IsPhoneValid(const std::string &input) {
 	return true;
 }
 
-bool MODEM_ReadPhonebook(const std::string &filename) {
+bool MODEM_ReadPhonebook(const std_fs::path &filename) {
 	std::ifstream loadfile(filename);
 	if (!loadfile)
 		return false;
 
-	LOG_MSG("SERIAL: Phonebook loading from %s.", filename.c_str());
+	const std::string file_string = filename.string();
+	LOG_MSG("SERIAL: Phonebook loading from %s.", file_string.c_str());
 
 	std::string linein;
 	while (std::getline(loadfile, linein)) {
@@ -81,7 +82,7 @@ bool MODEM_ReadPhonebook(const std::string &filename) {
 
 		if (!(iss >> phone >> address)) {
 			LOG_MSG("SERIAL: Phonebook skipped a bad line in %s.",
-			        filename.c_str());
+			        file_string.c_str());
 			continue;
 		}
 

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -63,7 +63,7 @@ enum ResTypes {
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
-bool MODEM_ReadPhonebook(const std::string &filename);
+bool MODEM_ReadPhonebook(const std_fs::path &filename);
 void MODEM_ClearPhonebook();
 
 class CFifo {

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -63,7 +63,7 @@ enum ResTypes {
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
-bool MODEM_ReadPhonebook(const std_fs::path &filename);
+bool MODEM_ReadPhonebook(const std_fs::path &path);
 void MODEM_ClearPhonebook();
 
 class CFifo {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -444,17 +444,17 @@ bool Prop_path::SetValue(const std::string& input)
 		return false;
 	}
 
-	const std_fs::path workcopy = resolve_home(input);
+	const auto temp_path = resolve_home(input);
 
-	if (workcopy.is_absolute()) {
-		realpath = workcopy;
+	if (temp_path.is_absolute()) {
+		realpath = temp_path;
 		return is_valid;
 	}
 
 	if (current_config_dir.empty()) {
-		realpath = get_platform_config_dir() / workcopy;
+		realpath = get_platform_config_dir() / temp_path;
 	} else {
-		realpath = current_config_dir / workcopy;
+		realpath = current_config_dir / temp_path;
 	}
 
 	return is_valid;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -443,22 +443,12 @@ void DOS_Shell::SyntaxError()
 	WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 }
 
-static std::string get_shell_history_path()
+static std_fs::path get_shell_history_path()
 {
 	const auto section = static_cast<Section_prop*>(control->GetSection("dos"));
 	if (section) {
 		const auto path = section->Get_path("shell_history_file");
 		if (path) {
-			// Workaround: If shell_history_file is not in the
-			// user's config, path->SetValue function never gets
-			// called which sets realpath. Append the config dir
-			// here to prevent this from getting written to current
-			// working directory in that case.
-			if (!path->realpath.empty() &&
-			    path->realpath.find(CROSS_FILESPLIT) == std::string::npos) {
-				return (get_platform_config_dir() / path->realpath)
-				        .string();
-			}
 			return path->realpath;
 		}
 	}
@@ -470,7 +460,7 @@ void DOS_Shell::ReadShellHistory()
 	if (control->SecureMode()) {
 		return;
 	}
-	std::string history_path = get_shell_history_path();
+	const auto history_path = get_shell_history_path();
 	if (history_path.empty()) {
 		return;
 	}
@@ -492,14 +482,14 @@ void DOS_Shell::WriteShellHistory()
 	if (control->SecureMode()) {
 		return;
 	}
-	std::string history_path = get_shell_history_path();
+	const auto history_path = get_shell_history_path();
 	if (history_path.empty()) {
 		return;
 	}
 	std::ofstream history_file(history_path);
 	if (!history_file) {
 		LOG_WARNING("SHELL: Unable to update history file: '%s'",
-		            history_path.c_str());
+		            history_path.string().c_str());
 		return;
 	}
 	std::vector<std::string> trimmed_history;


### PR DESCRIPTION
Fixes #2695
Fixes #2636

This was a lot simpler than I thought it would be since it's not used in that many places.  I made Prop_path store a std_fs::path instead of a string.  I also made sure it gets initialized properly to an absolute path on object construction which lets me get rid of the workaround I wrote for the shell history.