### PR TITLE
Refactor command line arguments

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,6 +85,9 @@ jobs:
         if:   matrix.conf.needs_deps
         run: |
           arch -arch=${{ matrix.conf.arch }} brew unlink openssl@1.1 || true
+          rm -f /usr/local/bin/openssl || true
+          arch -arch=${{ matrix.conf.arch }} brew install --overwrite openssl@3 || \
+          arch -arch=${{ matrix.conf.arch }} brew link --overwrite openssl@3
           arch -arch=${{ matrix.conf.arch }} brew install --overwrite \
             ${{ matrix.conf.packages }} \
             $(cat packages/macos-12-brew.txt)

--- a/include/control.h
+++ b/include/control.h
@@ -40,15 +40,44 @@ enum class Verbosity : int8_t {
 	High,          //   yes   |    yes       |
 };
 
+struct CommandLineArguments {
+	bool printconf;
+	bool noprimaryconf;
+	bool nolocalconf;
+	bool fullscreen;
+	bool list_glshaders;
+	bool version;
+	bool help;
+	bool eraseconf;
+	bool erasemapper;
+	bool noconsole;
+	bool startmapper;
+	bool exit;
+	bool securemode;
+	bool noautoexec;
+	std::string opencaptures;
+	std::string working_dir;
+	std::string lang;
+	std::string machine;
+	std::vector<std::string> conf;
+	std::vector<std::string> set;
+	std::optional<std::vector<std::string>> editconf;
+	std::optional<int> socket;
+};
+
 class Config {
 public:
 	CommandLine * cmdline = nullptr;
+	CommandLineArguments arguments = {};
+
 private:
 	std::deque<Section*> sectionlist = {};
 	Section_line overwritten_autoexec_section = {};
 	std::string overwritten_autoexec_conf = {};
 	void (*_start_function)(void) = nullptr;
 	bool secure_mode = false; // Sandbox mode
+	void ParseArguments();
+
 public:
 	std::vector<std::string> startup_params = {};
 	std::vector<std::string> configfiles = {};
@@ -61,6 +90,7 @@ public:
 		assert(cmdline);
 		startup_params.push_back(cmdline->GetFileName());
 		cmdline->FillVector(startup_params);
+		ParseArguments();
 	}
 
 	Config() = default;

--- a/include/programs.h
+++ b/include/programs.h
@@ -22,11 +22,12 @@
 
 #include "dosbox.h"
 
+#include "std_filesystem.h"
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <string>
-#include "std_filesystem.h"
 
 #include "dos_inc.h"
 #include "help_util.h"
@@ -36,20 +37,23 @@
 
 class CommandLine {
 public:
-	CommandLine(int argc, char const *const argv[]);
+	CommandLine(int argc, const char* const argv[]);
 	CommandLine(std::string_view name, std::string_view cmdline);
 
 	const char *GetFileName() const { return file_name.c_str(); }
 
-	bool FindExist(char const * const name,bool remove=false);
-	bool FindInt(char const * const name,int & value,bool remove=false);
-	bool FindString(char const * const name,std::string & value,bool remove=false);
-	bool FindCommand(unsigned int which,std::string & value) const;
-	bool FindStringBegin(char const * const begin,std::string & value, bool remove=false);
-	bool FindStringRemain(char const * const name,std::string & value);
-	bool FindStringRemainBegin(char const *const name, std::string &value);
-	bool GetStringRemain(std::string & value);
-	int GetParameterFromList(const char* const params[], std::vector<std::string> & output);
+	bool FindExist(const char* const name, bool remove = false);
+	bool FindInt(const char* const name, int& value, bool remove = false);
+	bool FindString(const char* const name, std::string& value,
+	                bool remove = false);
+	bool FindCommand(unsigned int which, std::string& value) const;
+	bool FindStringBegin(const char* const begin, std::string& value,
+	                     bool remove = false);
+	bool FindStringRemain(const char* const name, std::string& value);
+	bool FindStringRemainBegin(const char* const name, std::string& value);
+	bool GetStringRemain(std::string& value);
+	int GetParameterFromList(const char* const params[],
+	                         std::vector<std::string>& output);
 	void FillVector(std::vector<std::string> & vector);
 	bool HasDirectory() const;
 	bool HasExecutableName() const;
@@ -58,6 +62,12 @@ public:
 	                   const std::list<std::string_view>& post_args) const;
 	void Shift(unsigned int amount = 1);
 	uint16_t Get_arglength();
+	bool FindRemoveBoolArgument(const std::string& name, char short_letter = 0);
+	std::string FindRemoveStringArgument(const std::string& name);
+	std::vector<std::string> FindRemoveVectorArgument(const std::string& name);
+	std::optional<std::vector<std::string>> FindRemoveOptionalArgument(
+	        const std::string& name);
+	std::optional<int> FindRemoveIntArgument(const std::string& name);
 
 private:
 	using cmd_it = std::list<std::string>::iterator;
@@ -65,7 +75,10 @@ private:
 	std::list<std::string> cmds = {};
 	std::string file_name = "";
 
-	bool FindEntry(char const * const name,cmd_it & it,bool neednext=false);
+	bool FindEntry(const char* const name, cmd_it& it, bool neednext = false);
+	std::string FindRemoveSingleString(const char* name);
+	bool FindBoolArgument(const std::string& name, bool remove,
+	                      char short_letter = 0);
 };
 
 class Program {
@@ -104,7 +117,7 @@ protected:
 
 using PROGRAMS_Creator = std::function<std::unique_ptr<Program>()>;
 void PROGRAMS_Destroy([[maybe_unused]] Section* sec);
-void PROGRAMS_MakeFile(char const * const name, PROGRAMS_Creator creator);
+void PROGRAMS_MakeFile(const char* const name, PROGRAMS_Creator creator);
 
 template<class P>
 std::unique_ptr<Program> ProgramCreate() {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -353,10 +353,11 @@ static void DOSBOX_RealInit(Section * sec) {
 	MAPPER_AddHandler(DOSBOX_UnlockSpeed, SDL_SCANCODE_F12, MMOD2,
 	                  "speedlock", "Speedlock");
 
-	std::string cmd_machine;
-	if (control->cmdline->FindString("-machine",cmd_machine,true)){
+	const auto arguments = &control->arguments;
+	if (!arguments->machine.empty()) {
 		//update value in config (else no matching against suggested values
-		section->HandleInputline(std::string("machine=") + cmd_machine);
+		section->HandleInputline(std::string("machine=") +
+		                         arguments->machine);
 	}
 
 	std::string mtype(section->Get_string("machine"));

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -35,50 +35,69 @@ There is NO WARRANTY, to the extent permitted by law.
 constexpr char help_msg[] =
         R"(Usage: dosbox [OPTION]... [FILE]
 
-List of common options:
+List of available options:
 
-  --printconf          Print the location of the default configuration file.
+  --conf <configfile>      Start with the options specified in <configfile>.
+                           Multiple configfiles can be specified.
+                           Example: --conf conf1.conf --conf conf2.conf
 
-  --editconf           Open the default configuration file in a text editor.
+  --printconf              Print the location of the default configuration file.
+                           If it does not exist, create it.
 
-  -c <command>         Run the specified DOS command before running FILE.
-                       Multiple commands can be specified.
+  --editconf               Open the default configuration file in a text editor.
 
-  -noautoexec          Don't perform any [autoexec] actions.
+  --eraseconf              Delete the default configuration file.
 
-  -noprimaryconf       Don't read settings from the primary configuration file
-                       located in your user folder.
+  --noprimaryconf          Don't read settings from the default configuration file
+                           located in your user folder.
 
-  -nolocalconf         Don't read settings from "dosbox.conf" if present in
-                       the current working directory.
+  --nolocalconf            Don't read settings from "dosbox.conf" if present in
+                           the current working directory.
 
-  -conf <configfile>   Start with the options specified in <configfile>.
-                       Multiple configfiles can be specified.
+  --set <property>=<value> Set a configuration property.
+                           Example: --set mididevice=fluidsynth --set soundfont=mysoundfont.sf2
 
-  --working-dir <path> Set working directory to <path>. DOSBox will act as if
-                       started from this directory.
+  --working-dir <path>     Set working directory to <path>. DOSBox will act as if
+                           started from this directory.
 
-  -fullscreen          Start in fullscreen mode.
+  --list-glshaders         List available GLSL shaders and their directories.
+                           Results are useable in the "glshader = " config setting.
 
-  -lang <langfile>     Start with the language specified in <langfile>.
+  --fullscreen             Start in fullscreen mode.
 
-  --list-glshaders     List available GLSL shaders and their directories.
-                       Results are useable in the "glshader = " config setting.
+  --lang <langfile>        Start with the language specified in <langfile>.
 
-  -machine <type>      Emulate a specific type of machine. The machine type has
-                       influence on both the emulated video and sound cards.
-                       Valid choices are: hercules, cga, cga_mono, tandy,
-                       pcjr, ega, svga_s3 (default), svga_et3000, svga_et4000,
-                       svga_paradise, vesa_nolfb, vesa_oldvbe.
+  --machine <type>         Emulate a specific type of machine. The machine type has
+                           influence on both the emulated video and sound cards.
+                           Valid choices are: hercules, cga, cga_mono, tandy,
+                           pcjr, ega, svga_s3 (default), svga_et3000, svga_et4000,
+                           svga_paradise, vesa_nolfb, vesa_oldvbe.
 
-  -exit                Exit after the DOS program specified by FILE has ended.
+  -c <command>             Run the specified DOS command before running FILE.
+                           Multiple commands can be specified.
 
-  -h, --help           Print this help message and exit.
+  --noautoexec             Don't execute any [autoexec] actions.
 
-  -v, --version        Print version information and exit.
+  --exit                   Exit after the DOS program specified by FILE has ended.
+                           If no FILE has been specified, execute [autoexcec] and
+                           terminate.
 
-You can find full list of options in the man page: dosbox(1)
-And in the file: /usr/share/doc/dosbox-staging/README
+  --startmapper            Run the mapper GUI.
+
+  --erasemapper            Delete the default mapper file.
+
+  --securemode             Enable secure mode. The [config] and [autoexec] sections
+                           of the loaded configuration file will be skipped,
+                           and commands such as MOUNT and IMGMOUNT are disabled.
+
+  --socket <num>           Run nullmodem on the specified socket number.
+
+  --opencaptures           Call program with as first parameter the location of the
+                           captures folder.
+
+  -h, --help               Print this help message and exit.
+
+  -v, --version            Print version information and exit.
 )";
 
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3729,7 +3729,8 @@ static void GUI_StartUp(Section *sec)
 	sdl.resizing_window = false;
 	sdl.wait_on_error = section->Get_bool("waitonerror");
 
-	sdl.desktop.fullscreen = control->cmdline->FindExist("-fullscreen", true) || section->Get_bool("fullscreen");
+	sdl.desktop.fullscreen = control->arguments.fullscreen ||
+	                         section->Get_bool("fullscreen");
 
 	auto priority_conf = section->GetMultiVal("priority")->GetSection();
 	SetPriorityLevels(priority_conf->Get_string("active"),
@@ -4613,14 +4614,13 @@ static int LaunchEditor()
 		execlp(prog.c_str(), prog.c_str(), path.c_str(), (char *)nullptr);
 	};
 
-	std::string editor;
-	constexpr bool remove_arg = true;
 	// Loop until one succeeds
-	while (control->cmdline->FindString("--editconf", editor, remove_arg))
-		replace_with_process(editor);
-
-	while (control->cmdline->FindString("-editconf", editor, remove_arg))
-		replace_with_process(editor);
+	const auto arguments = &control->arguments;
+	if (arguments->editconf) {
+		for (const auto& editor : *arguments->editconf) {
+			replace_with_process(editor);
+		}
+	}
 
 	const char *env_editor = getenv("EDITOR");
 	if (env_editor)
@@ -4785,17 +4785,14 @@ int sdl_main(int argc, char *argv[])
 {
 	CommandLine com_line(argc, argv);
 	control = std::make_unique<Config>(&com_line);
+	const auto arguments = &control->arguments;
 
-	if (control->cmdline->FindExist("--version") ||
-	    control->cmdline->FindExist("-version") ||
-	    control->cmdline->FindExist("-v")) {
+	if (arguments->version) {
 		printf(version_msg, CANONICAL_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 		return 0;
 	}
 
-	if (control->cmdline->FindExist("--help") ||
-	    control->cmdline->FindExist("-help") ||
-	    control->cmdline->FindExist("-h")) {
+	if (arguments->help) {
 		printf(help_msg); // -V618
 		return 0;
 	}
@@ -4819,15 +4816,12 @@ int sdl_main(int argc, char *argv[])
 
 	int rcode = 0; // assume good until proven otherwise
 	try {
-		std::string working_dir;
-		constexpr bool remove_arg = true;
-		if (control->cmdline->FindString("--working-dir", working_dir, remove_arg) ||
-		    control->cmdline->FindString("-working-dir", working_dir, remove_arg)) {
+		if (!arguments->working_dir.empty()) {
 			std::error_code ec;
-			std_fs::current_path(working_dir, ec);
+			std_fs::current_path(arguments->working_dir, ec);
 			if (ec) {
 				LOG_ERR("Cannot set working directory to %s",
-				        working_dir.c_str());
+				        arguments->working_dir.c_str());
 			}
 		}
 
@@ -4840,22 +4834,24 @@ int sdl_main(int argc, char *argv[])
 		config_add_sdl();
 		DOSBOX_Init();
 
-		if (control->cmdline->FindExist("--editconf") ||
-		    control->cmdline->FindExist("-editconf")) {
+		if (arguments->editconf) {
 			const int err = LaunchEditor();
 			return err;
 		}
 
-		std::string editor;
-		if(control->cmdline->FindString("-opencaptures",editor,true)) launchcaptures(editor);
-		if(control->cmdline->FindExist("-eraseconf")) eraseconfigfile();
-		if(control->cmdline->FindExist("-resetconf")) eraseconfigfile();
-		if(control->cmdline->FindExist("-erasemapper")) erasemapperfile();
-		if(control->cmdline->FindExist("-resetmapper")) erasemapperfile();
+		if (!arguments->opencaptures.empty()) {
+			launchcaptures(arguments->opencaptures);
+		}
+		if (arguments->eraseconf) {
+			eraseconfigfile();
+		}
+		if (arguments->erasemapper) {
+			erasemapperfile();
+		}
 
 		/* Can't disable the console with debugger enabled */
 #if defined(WIN32) && !(C_DEBUG)
-		if (control->cmdline->FindExist("-noconsole")) {
+		if (arguments->noconsole) {
 			FreeConsole();
 			/* Redirect standard input and standard output */
 			if(freopen(STDOUT_FILE, "w", stdout) == NULL)
@@ -4876,14 +4872,12 @@ int sdl_main(int argc, char *argv[])
 		}
 #endif  //defined(WIN32) && !(C_DEBUG)
 
-		if (control->cmdline->FindExist("--printconf") ||
-		    control->cmdline->FindExist("-printconf")) {
+		if (arguments->printconf) {
 			const int err = PrintConfigLocation();
 			return err;
 		}
 
-		if (control->cmdline->FindExist("--list-glshaders") ||
-		    control->cmdline->FindExist("-list-glshaders")) {
+		if (arguments->list_glshaders) {
 			ListGlShaders();
 			return 0;
 		}
@@ -4926,8 +4920,7 @@ int sdl_main(int argc, char *argv[])
 		"Usage: [color=green]config [/reset]-set [color=cyan][SECTION][/reset] "
 		"[color=white]PROPERTY[/reset][=][color=white]VALUE[/reset]\n");
 
-	std::string line;
-	while (control->cmdline->FindString("-set", line, true)) {
+	for (auto line : arguments->set) {
 		trim(line);
 		if (line.empty()
 		    || line[0] == '%' || line[0] == '\0'
@@ -4988,13 +4981,13 @@ int sdl_main(int argc, char *argv[])
 		// All subsystems' hotkeys need to be registered at this point
 		// to ensure their hotkeys appear in the graphical mapper.
 		MAPPER_BindKeys(sdl_sec);
-		if (control->cmdline->FindExist("-startmapper"))
-			MAPPER_DisplayUI();
+		if (arguments->startmapper) {
+		MAPPER_DisplayUI();
+		}
 
 		control->StartUp(); // Run the machine until shutdown
 		control.reset();  // Shutdown and release
-
-	} catch (char *error) {
+	} catch (char* error) {
 		rcode = 1;
 		GFX_ShowMsg("Exit to error: %s",error);
 		fflush(nullptr);
@@ -5008,7 +5001,7 @@ int sdl_main(int argc, char *argv[])
 			Sleep(5000);
 #endif
 		}
-	} catch (const std::exception &e) {
+	} catch (const std::exception& e) {
 		// catch all exceptions that derive from the standard library
 		LOG_ERR("EXCEPTION: Standard library exception: %s", e.what());
 		rcode = 1;

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -89,9 +89,10 @@ CNullModem::CNullModem(const uint8_t port_idx, CommandLine *cmd)
 	if (getUintFromString("inhsocket:", bool_temp, cmd)) {
 #ifdef NATIVESOCKETS
 		if (bool_temp == 1) {
-			int sock;
-			if (control->cmdline->FindInt("-socket", sock, true)) {
-				dtrrespect = false;
+			const auto arguments = &control->arguments;
+			if (arguments->socket) {
+				int sock    = *arguments->socket;
+				dtrrespect  = false;
 				transparent = true;
 				LOG_MSG("SERIAL: Port %" PRIu8 " inheritance "
 				        "socket handle: %d",

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -255,10 +255,11 @@ AutoExecModule::AutoExecModule(Section* configuration)
 	// Check -securemode switch to disable mount/imgmount/boot after
 	// running autoexec.bat
 	const auto cmdline = control->cmdline; // short-lived copy
-	const bool has_option_securemode = cmdline->FindExist("-securemode", true);
+	const auto arguments = &control->arguments;
+	const bool has_option_securemode = arguments->securemode;
 
 	// Are autoexec sections permitted?
-	const bool has_option_no_autoexec = cmdline->FindExist("-noautoexec", true);
+	const bool has_option_no_autoexec = arguments->noautoexec;
 
 	// Should autoexec sections be joined or overwritten?
 	const std::string_view section_pref = sec->Get_string("autoexec_section");
@@ -291,7 +292,7 @@ AutoExecModule::AutoExecModule(Section* configuration)
 	}
 
 	// Check for the -exit switch, which indicates they want to quit
-	const bool exit_arg_exists = cmdline->FindExist("-exit", true);
+	const bool exit_arg_exists = arguments->exit;
 
 	// Check if instant-launch is active
 	const bool using_instant_launch_with_executable =

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -428,7 +428,7 @@ void DOS_Shell::CMD_EXIT(char *args)
 {
 	HELP("EXIT");
 
-	const bool wants_force_exit = control->cmdline->FindExist("-exit");
+	const bool wants_force_exit = control->arguments.exit;
 	const bool is_normal_launch = control->GetStartupVerbosity() !=
 	                              Verbosity::InstantLaunch;
 


### PR DESCRIPTION
Fixes #2121

I didn't end up using `getopt`.  It seemed more trouble than it was worth and didn't fit in well with our existing `CommandLine` class.  It also has some oddities like behaving differently if certain environment variables are set such as `POSIXLY_CORRECT` and it mutates the `argv` argument that it takes in.  There's also the possibility that it behaves differently on different platforms.

Anyway, I think I've cleaned the mess up quite a bit.  All the argument get parsed into a struct in the global Config class on program start.  Then, whenever someone wants to check if an argument is set, they can just directly read the already parsed value.  That way we're not doing parsing stuff all over the code and it should be more maintainable.  If someone wants to add a new argument, it's just adding a variable to the struct and then add a single line to the `ParseArguments()` function.

This mostly removes all the `control->cmdline` calls.  The one place I left that in was Autoexec.  There's a bunch of custom parsing logic in there that I didn't want to touch.