### PR TITLE
Fix MIDI capture

### DIFF
--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -429,6 +429,9 @@ void CAPTURE_AddAudioData(const uint32_t sample_rate, const uint32_t num_sample_
 
 void CAPTURE_AddMidiData(const bool sysex, const size_t len, const uint8_t* data)
 {
+	if (capture.state.midi == CaptureState::Pending) {
+		capture.state.midi = CaptureState::InProgress;
+	}
 	capture_midi_add_data(sysex, len, data);
 }
 


### PR DESCRIPTION
I broke it, so now I'm fixing it. Apologies for the inconvenience 😊 

(MIDI files were created with zero bytes, or even if data was written, the finalise method that updates the header with the actual length was not updated and the contents of the buffer was not flushed...)