### PR TITLE
Link mt32emu statically in the MSYS2 CI release

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -296,10 +296,10 @@ jobs:
 
       - name: Setup release build
         run: |
-          meson setup -Db_lto=true -Db_lto_threads=$(nproc) $BUILD_RELEASE_DIR
+          meson setup -Db_lto=true -Db_lto_threads=$(nproc) -Dtry_static_libs=mt32emu $BUILD_RELEASE_DIR
 
       - name: Setup debugger build
-        run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) -Denable_debugger=normal $BUILD_DEBUGGER_DIR
+        run: meson setup -Db_lto=true -Db_lto_threads=$(nproc) -Denable_debugger=normal -Dtry_static_libs=mt32emu $BUILD_DEBUGGER_DIR
 
       - name: Build release
         run: |


### PR DESCRIPTION
Fixes the following missing DLL startup error:

![2023-08-01_14-11](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/327df8d6-e7a8-44cb-b7a3-8a49a2582845)

