### PR TITLE
Fix deactivation of queued joystick axis movement

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -197,19 +197,16 @@ public:
 			if (!GetActivityCount()) Active(true);
 		}
 	}
-	void DeActivateEvent(bool ev_trigger) override {
-		if (ev_trigger) {
-			if (activity>0) activity--;
-			if (activity==0) {
-				/* test if still some trigger-activity is present,
-				   adjust the state in this case accordingly */
-				if (GetActivityCount()) RepostActivity();
-				else Active(false);
-			}
-		} else {
-			if (!GetActivityCount()) Active(false);
+	void DeActivateEvent(const bool ev_trigger) override
+	{
+		if (ev_trigger || GetActivityCount() == 0) {
+			// Zero-out this event's pending activity if triggered
+			// or we have no opposite-direction events
+			activity = 0;
+			Active(false);
 		}
 	}
+
 	virtual Bitu GetActivityCount() {
 		return activity;
 	}


### PR DESCRIPTION
When mapping a host keyboard button to a virtual joystick axis, the prior logic would allow a queue of the same event (ie: holding a given direction) to ignore deactivation of the event (ie: release of the direction).

This change now zeroes the queued action and deactivates when requested.

[joytest.zip](https://github.com/dosbox-staging/dosbox-staging/files/12235225/joytest.zip) was used with:
 - Host analog stick driving the axes (native control)
 - Host D-pad mapped to the analog axes
 - Keypad up/down/left/right mapped to the analog axes


