### PR TITLE
Clean up VESA_GetSVGAInformation() & get rid of warnings

### DIFF
--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -246,7 +246,7 @@ void INT10_PerformGrayScaleSumming(uint16_t start_reg,uint16_t count);
 
 
 /* Vesa Group */
-uint8_t VESA_GetSVGAInformation(uint16_t seg,uint16_t off);
+uint8_t VESA_GetSVGAInformation(const uint16_t segment, const uint16_t offset);
 uint8_t VESA_GetSVGAModeInformation(uint16_t mode,uint16_t seg,uint16_t off);
 uint8_t VESA_SetSVGAMode(uint16_t mode);
 uint8_t VESA_GetSVGAMode(uint16_t & mode);

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -98,7 +98,7 @@ uint8_t VESA_GetSVGAInformation(const uint16_t segment, const uint16_t offset)
 	const auto id = mem_readd(buffer);
 
 	const auto vbe2 = (((id == 0x56424532) || (id == 0x32454256)) &&
-	                   (!int10.vesa_oldvbe));
+	                   !int10.vesa_oldvbe);
 
 	const auto vbe_bufsize = vbe2 ? 0x200 : 0x100;
 	for (auto i = 0; i < vbe_bufsize; i++) {
@@ -451,7 +451,7 @@ uint8_t VESA_ScanLineLength(uint8_t subcall,
 	auto new_offset = static_cast<int>(vga.config.scan_len);
 	auto screen_height = CurMode->sheight;
 	auto usable_vmem_bytes = vga.vmemsize;
-	uint8_t bits_per_pixel = 8;
+	uint8_t bits_per_pixel = 0;
 	uint8_t bytes_per_offset = 8;
 	bool align_to_nearest_4th_pixel = false;
 


### PR DESCRIPTION
@FeralChild64's nice SVGA branding improvement started generating extra PVS Studio warnings once merged. Those warnings are legitimate; what is a bit perplexing is that CI was all green before I merged it 🤷🏻 

In any case, I wanted to just get rid of the warnings but then ended up cleaning up the whole function 😅 

Functionally, there's no change. The new branding still works.

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/9df3f7ca-9354-44fa-b4fc-f6d3e93bdfb4)
