### PR TITLE
Always let MacOS homebrew overwrite conflicting junk files

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install C++ compiler and libraries
         if:   matrix.conf.needs_deps
         run: |
-          arch -arch=${{ matrix.conf.arch }} brew install \
+          arch -arch=${{ matrix.conf.arch }} brew install --overwrite \
             ${{ matrix.conf.packages }} \
             $(cat packages/macos-12-brew.txt)
 
@@ -200,7 +200,7 @@ jobs:
       - name: Install C++ compiler and libraries
         if:   matrix.runner.needs_deps
         run: >-
-          arch -arch=${{ matrix.runner.arch }} brew install librsvg tree
+          arch -arch=${{ matrix.runner.arch }} brew install --overwrite librsvg tree
           ccache libpng meson opusfile sdl2 sdl2_net speexdsp
 
       - uses:  actions/cache@v3.3.1
@@ -273,7 +273,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Install brew depedencies
-        run: brew install librsvg
+        run: brew install --overwrite librsvg
 
       - name: Download binaries
         uses: actions/download-artifact@v3
@@ -303,7 +303,7 @@ jobs:
         id:    prep-clamdb
         shell: bash
         run: |
-          brew install clamav
+          brew install --overwrite clamav
           export CLAMDB_DIR="/usr/local/Cellar/clamav"
           clamscan --heuristic-scan-precedence=yes --recursive --infected dist || true
 


### PR DESCRIPTION
Thanks @weirddan455:

> Looks like the Mac builds are having a fit now (unrelated to this PR):

```text
 ==> Pouring openssl@3--3.1.2.ventura.bottle.tar.gz
Error: Could not symlink bin/openssl
Target /usr/local/bin/openssl
is a symlink belonging to openssl@1.1. You can unlink it:
  brew unlink openssl@1.1

To force the link and overwrite all conflicting files:
  brew link --overwrite openssl@3

To list all files that would be deleted:
  brew link --overwrite --dry-run openssl@3
Error: Process completed with exit code 1.
```

> OpenSSL 3.1.2 was just released yesterday. These CI machines constantly updating packages and breaking is getting annoying...

This should fix it once and for all.  Will merge when passing.