### PR TITLE
Turn down loguru verbosity when started with following arugments

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4808,6 +4808,12 @@ int sdl_main(int argc, char *argv[])
 	loguru::g_preamble_verbose = false; // The verbosity field
 	loguru::g_preamble_pipe    = true; // The pipe symbol right before the message
 
+	if (arguments->printconf || arguments->editconf ||
+	    arguments->eraseconf || arguments->list_glshaders ||
+	    arguments->erasemapper || !arguments->opencaptures.empty()) {
+		loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
+	}
+
 	loguru::init(argc, argv);
 
 	LOG_MSG("%s version %s", CANONICAL_PROJECT_NAME, DOSBOX_GetDetailedVersion());


### PR DESCRIPTION
Fixes #2714

These arguments do fairly trival tasks and then end the program. Many also print information to the console.
Turn down log verbosity so the user can more easily see the output.

--printconf --editconf --eraseconf --list-glshaders --erasemapper --opencaptures

It turns out these arguments require some of the initialization functions to be run first.  They also use Loguru macros to log warnings and errors if something goes wrong.  So I couldn't just move them to the top of `sdlmain` like I was originally thinking.

However, it's pretty easy to turn down the verbosity of Loguru and silence the noise.