### PR TITLE
Remove scan and pixel doubling config settings

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -661,29 +661,6 @@ void DOSBOX_Init()
 	        "  vertical:    Constrain the vertical scaling factor to integer values\n"
 	        "               within the viewport.");
 
-	pbool = secprop->Add_bool("force_vga_single_scan", when_idle, false);
-	pbool->Set_help(
-	        "Force single scanning of double-scanned VGA modes, typically sub-400 line modes\n"
-	        "(disabled by default).\n"
-	        "This is useful to achieve a single-scanned look when using CRT shaders, or to\n"
-	        "increase performance on low-powered devices.\n"
-	        "Notes: The default 'interpolation/sharp.glsl' shader and the 'texturenb' and\n"
-	        "       'openglnb' output modes force single-scanning implicitly. With\n"
-	        "       'integer_scaling' enabled, this results in finer scaling steps with the\n"
-	        "       output remaining identical.");
-
-	pbool = secprop->Add_bool("force_no_pixel_doubling", when_idle, false);
-	pbool->Set_help(
-	        "Don't pixel double any video modes (disabled by default).\n"
-	        "Pixel-doubling is performed by default for most sub-640 pixel video modes\n"
-	        "to allow for more realistic PC CRT monitor emulation via shaders. You might\n"
-	        "want to disable this when emulating a low-resolution consumer monitor or TV,\n"
-	        "or to increase performance on low-powered devices.\n"
-	        "Notes: The default 'interpolation/sharp.glsl' shader and the 'texturenb' and\n"
-	        "       'openglnb' output modes force no pixel-doubling implicitly. With\n"
-	        "       'integer_scaling' enabled, this results in finer scaling steps with the\n"
-	        "       output remaining identical.");
-
 	pstring = secprop->Add_string("monochrome_palette", always, "white");
 	pstring->Set_help(
 	        "Select default palette for monochrome display ('white' by default).\n"

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -786,7 +786,7 @@ static void ReloadShader(const bool pressed)
 	assert(glshader_prop);
 	const auto shader_path = std::string(glshader_prop->GetValue());
 	if (shader_path.empty()) {
-		LOG_WARNING("RENDER: Failed gettina path for 'glshader' setting; not reloading");
+		LOG_WARNING("RENDER: Failed getting path for 'glshader' setting; not reloading");
 		return;
 	}
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -803,28 +803,23 @@ static bool force_no_pixel_doubling = false;
 
 // We double-scan VGA modes and pixel-double all video modes by default unless:
 //
-//  1) Single-scanning or no pixel-doubling is forced in the
-//     configuration
-//  2) Single-scanning or no pixel-doubling is forced by the OpenGL
-//     shader
-//  3) If the interpolation mode is nearest-neighbour
+//  1) Single-scanning or no pixel-doubling is forced by the OpenGL shader.
+//  2) The interpolation mode is nearest-neighbour.
 //
-// About point 2: The default `interpolation/sharp.glsl` shader forces both
-// because it scales pixels as flat adjacent rectangles. This not only produces
-// identical output versus double-scanning and pixel-doubling, but provides
-// finer integer multiplication steps (especially important for sub-4K screens)
-// and also reduces load on slow systems like the Raspberry Pi.
+// About the first point: the default `interpolation/sharp.glsl` shader forces
+// both because it scales pixels as flat adjacent rectangles. This not only
+// produces identical output versus double-scanning and pixel-doubling, but
+// also provides finer integer scaling steps (especially important on sub-4K
+// screens) and improves performance on low-end systems like the Raspberry Pi.
 //
-static void setup_scan_and_pixel_doubling(Section_prop* section)
+static void setup_scan_and_pixel_doubling([[maybe_unused]] Section_prop* section)
 {
 	const auto nearest_neighbour_enabled = (GFX_GetInterpolationMode() ==
 	                                        InterpolationMode::NearestNeighbour);
 
-	force_vga_single_scan = section->Get_bool("force_vga_single_scan") ||
-	                        nearest_neighbour_enabled;
+	force_vga_single_scan = nearest_neighbour_enabled;
+	force_no_pixel_doubling = nearest_neighbour_enabled;
 
-	force_no_pixel_doubling = section->Get_bool("force_no_pixel_doubling") ||
-	                          nearest_neighbour_enabled;
 #if C_OPENGL
 	force_vga_single_scan |= render.shader.force_single_scan;
 	force_no_pixel_doubling |= render.shader.force_no_pixel_doubling;


### PR DESCRIPTION
...with FIRE! 🔥🔥🔥🔥 😎 (unfortunately, there is no welding safety glasses emoji available 😆)

Before anyone would start accusing me of indiscriminately removing features added by other people, now one of my own creations meets the chopping board! 🪓 🔪  I've spent quite some time making sure these config settings work correctly at runtime, but given they will be unnecessary in light of what's coming (to be announced later), these features need to go to simplify and streamline the user experience!

---

Okay, so this PR removes the `force_vga_single_scan` and `force_no_pixel_doubling` settings. _Only_ the config settings; the shaders can still set these flags via the  `force_single_scan` and `force_no_pixel_doubling` pragmas.

These flags are set automatically when no OpenGL shader is in use (they're on for nearest-neighbour interpolation for optimisation purposes, and off for bilinear to achieve better image quality), and shaders have full control over these flags via the two similarly named pragmas. Conceptually, these are rendering concerns and belong to the shaders, so having yet another mechanism to override the behaviour via config settings is an unnecessary complication.

If someone wishes to force single-scanning in VGA games, that can be accomplished by creating a custom "15kHz monitor" or "arcade monitor" shader that forces single-scanning via the pragma (and possibly disable pixel doubling too to emulate a low-TVL-count display).

We are actually going to bundle such a special shader with the next release.
