### PR TITLE
Reload shader fixes

### DIFF
--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -37,7 +37,8 @@ struct ReelMagic_VideoMixerMPEGProvider {
 	virtual const ReelMagic_PlayerAttributes& GetAttrs() const     = 0;
 };
 
-void ReelMagic_RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t blue);
+void ReelMagic_RENDER_SetPalette(const uint8_t entry, const uint8_t red,
+                                 const uint8_t green, const uint8_t blue);
 
 void ReelMagic_RENDER_SetSize(const uint16_t width, const uint16_t height,
                               const bool double_width, const bool double_height,

--- a/include/render.h
+++ b/include/render.h
@@ -239,7 +239,7 @@ void RENDER_SetSize(const uint16_t width, const uint16_t height,
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
 
-void RENDER_InitShaderSource([[maybe_unused]] Section* sec);
+void RENDER_InitShader([[maybe_unused]] Section* sec);
 
 void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                        const uint8_t green, const uint8_t blue);

--- a/include/render.h
+++ b/include/render.h
@@ -125,12 +125,15 @@ struct Render_t {
 
 #if C_OPENGL
 	struct {
-		std::string filename         = {};
-		std::string source           = {};
-		bool use_srgb_texture        = false;
-		bool use_srgb_framebuffer    = false;
-		bool force_single_scan       = false;
-		bool force_no_pixel_doubling = false;
+		std::string filename = {};
+		std::string source   = {};
+
+		struct {
+			bool use_srgb_texture        = false;
+			bool use_srgb_framebuffer    = false;
+			bool force_single_scan       = false;
+			bool force_no_pixel_doubling = false;
+		} settings = {};
 	} shader = {};
 #endif
 

--- a/include/render.h
+++ b/include/render.h
@@ -238,8 +238,11 @@ void RENDER_SetSize(const uint16_t width, const uint16_t height,
 
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);
+
 void RENDER_InitShaderSource([[maybe_unused]] Section* sec);
-void RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t blue);
+
+void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
+                       const uint8_t green, const uint8_t blue);
 
 #if C_OPENGL
 bool RENDER_UseSrgbTexture();

--- a/include/setup.h
+++ b/include/setup.h
@@ -319,10 +319,9 @@ private:
 		{}
 	};
 
-	std::deque<Function_wrapper> early_init_functions = {};
-	std::deque<Function_wrapper> init_functions       = {};
-	std::deque<Function_wrapper> destroyfunctions     = {};
-	std::string sectionname                           = {};
+	std::deque<Function_wrapper> init_functions   = {};
+	std::deque<Function_wrapper> destroyfunctions = {};
+	std::string sectionname                       = {};
 
 public:
 	Section() = default;
@@ -335,15 +334,11 @@ public:
 	// Children must call executedestroy!
 	virtual ~Section() = default;
 
-	void AddEarlyInitFunction(SectionFunction func,
-	                          bool changeable_at_runtime = false);
-
 	void AddInitFunction(SectionFunction func, bool changeable_at_runtime = false);
 
 	void AddDestroyFunction(SectionFunction func,
 	                        bool changeable_at_runtime = false);
 
-	void ExecuteEarlyInit(bool initall = true);
 	void ExecuteInit(bool initall = true);
 	void ExecuteDestroy(bool destroyall = true);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -633,7 +633,7 @@ void DOSBOX_Init()
 		"write-operations for these write-protected files.");
 
 	secprop = control->AddSection_prop("render", &RENDER_Init, changeable_at_runtime);
-	secprop->AddEarlyInitFunction(&RENDER_InitShaderSource, changeable_at_runtime);
+	secprop->AddEarlyInitFunction(&RENDER_InitShader, changeable_at_runtime);
 
 	pint = secprop->Add_int("frameskip", deprecated, 0);
 	pint->Set_help("Consider capping frame-rates using the '[sdl] host_rate' setting.");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -633,7 +633,6 @@ void DOSBOX_Init()
 		"write-operations for these write-protected files.");
 
 	secprop = control->AddSection_prop("render", &RENDER_Init, changeable_at_runtime);
-	secprop->AddEarlyInitFunction(&RENDER_InitShader, changeable_at_runtime);
 
 	pint = secprop->Add_int("frameskip", deprecated, 0);
 	pint->Set_help("Consider capping frame-rates using the '[sdl] host_rate' setting.");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -645,7 +645,7 @@ static bool read_shader_source(const std::string& shader_path, std::string& sour
 	return true;
 }
 
-static void parse_shader_options(const std::string& source)
+static void set_shader_settings(const std::string& source)
 {
 	try {
 		const std::regex re("\\s*#pragma\\s+(\\w+)");
@@ -657,13 +657,13 @@ static void parse_shader_options(const std::string& source)
 
 			auto pragma = match[1].str();
 			if (pragma == "use_srgb_texture") {
-				render.shader.use_srgb_texture = true;
+				render.shader.settings.use_srgb_texture = true;
 			} else if (pragma == "use_srgb_framebuffer") {
-				render.shader.use_srgb_framebuffer = true;
+				render.shader.settings.use_srgb_framebuffer = true;
 			} else if (pragma == "force_single_scan") {
-				render.shader.force_single_scan = true;
+				render.shader.settings.force_single_scan = true;
 			} else if (pragma == "force_no_pixel_doubling") {
-				render.shader.force_no_pixel_doubling = true;
+				render.shader.settings.force_no_pixel_doubling = true;
 			}
 			++next;
 		}
@@ -675,12 +675,12 @@ static void parse_shader_options(const std::string& source)
 
 bool RENDER_UseSrgbTexture()
 {
-	return render.shader.use_srgb_texture;
+	return render.shader.settings.use_srgb_texture;
 }
 
 bool RENDER_UseSrgbFramebuffer()
 {
-	return render.shader.use_srgb_framebuffer;
+	return render.shader.settings.use_srgb_framebuffer;
 }
 
 #endif
@@ -771,11 +771,11 @@ static bool init_shader([[maybe_unused]] Section* sec)
 	}
 
 	// Reset shader settings to defaults
-	render.shader = {};
+	render.shader.settings = {};
 
 	if (using_opengl && source.length() && render.shader.filename != filename) {
 		LOG_MSG("RENDER: Using GLSL shader '%s'", filename.c_str());
-		parse_shader_options(source);
+		set_shader_settings(source);
 
 		// Move the temporary filename and source into the memebers
 		render.shader.filename = std::move(filename);
@@ -856,8 +856,8 @@ static void setup_scan_and_pixel_doubling([[maybe_unused]] Section_prop* section
 	force_no_pixel_doubling = nearest_neighbour_enabled;
 
 #if C_OPENGL
-	force_vga_single_scan |= render.shader.force_single_scan;
-	force_no_pixel_doubling |= render.shader.force_no_pixel_doubling;
+	force_vga_single_scan |= render.shader.settings.force_single_scan;
+	force_no_pixel_doubling |= render.shader.settings.force_no_pixel_doubling;
 #endif
 
 	VGA_EnableVgaDoubleScanning(!force_vga_single_scan);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -722,6 +722,8 @@ void log_warning_if_legacy_shader_name(const std::string& name)
 }
 #endif
 
+// Returns true if the shader has been changed, or if a shader has been loaded
+// for the first time since launch
 static bool init_shader([[maybe_unused]] Section* sec)
 {
 #if C_OPENGL
@@ -744,6 +746,10 @@ static bool init_shader([[maybe_unused]] Section* sec)
 		filename = fallback_shader;
 	} else if (filename == "default") {
 		filename = "interpolation/sharp";
+	}
+
+	if (render.shader.filename == filename) {
+		return false;
 	}
 
 	log_warning_if_legacy_shader_name(filename);
@@ -892,8 +898,7 @@ void RENDER_Init(Section* sec)
 	GFX_SetIntegerScalingMode(section->Get_string("integer_scaling"));
 
 #if C_OPENGL
-	const auto previous_shader_filename = render.shader.filename;
-	init_shader(section);
+	const auto shader_changed = init_shader(section);
 #endif
 
 	setup_scan_and_pixel_doubling(section);
@@ -903,7 +908,7 @@ void RENDER_Init(Section* sec)
 	         (render.scale.size != prev_scale_size) ||
 	         (GFX_GetIntegerScalingMode() != prev_integer_scaling_mode)
 #if C_OPENGL
-	         || (previous_shader_filename != render.shader.filename)
+	         || shader_changed
 #endif
 	         || (prev_force_vga_single_scan != force_vga_single_scan) ||
 	         (prev_force_no_pixel_doubling != force_no_pixel_doubling));

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -863,21 +863,19 @@ void RENDER_Init(Section* sec)
 
 	setup_scan_and_pixel_doubling(section);
 
-	// If something changed that needs a re-init.
-	// Only re-init when there is a src.bpp (fixes crashes on startup and
-	// directly changing the scaler without a screen specified yet).
-	if (running && render.src.bpp &&
-	    ((force_square_pixels != prev_force_square_pixels) ||
-	     (render.scale.size != prev_scale_size) ||
-	     (GFX_GetIntegerScalingMode() != prev_integer_scaling_mode)
+	const auto needs_reinit =
+	        ((force_square_pixels != prev_force_square_pixels) ||
+	         (render.scale.size != prev_scale_size) ||
+	         (GFX_GetIntegerScalingMode() != prev_integer_scaling_mode)
 #if C_OPENGL
-	     || (previous_shader_filename != render.shader.filename)
+	         || (previous_shader_filename != render.shader.filename)
 #endif
-	     || (prev_force_vga_single_scan != force_vga_single_scan) ||
-	     (prev_force_no_pixel_doubling != force_no_pixel_doubling))) {
+	         || (prev_force_vga_single_scan != force_vga_single_scan) ||
+	         (prev_force_no_pixel_doubling != force_no_pixel_doubling));
+
+	if (running && needs_reinit) {
 		RENDER_CallBack(GFX_CallBackReset);
 	}
-
 	if (!running) {
 		render.updating = true;
 	}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -722,7 +722,7 @@ void log_warning_if_legacy_shader_name(const std::string& name)
 }
 #endif
 
-void RENDER_InitShaderSource([[maybe_unused]] Section* sec)
+void RENDER_InitShader([[maybe_unused]] Section* sec)
 {
 #if C_OPENGL
 	assert(control);
@@ -886,7 +886,7 @@ void RENDER_Init(Section* sec)
 
 #if C_OPENGL
 	const auto previous_shader_filename = render.shader.filename;
-	RENDER_InitShaderSource(section);
+	RENDER_InitShader(section);
 #endif
 
 	setup_scan_and_pixel_doubling(section);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2019-2023  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -54,7 +55,7 @@ static void render_callback(GFX_CallBackFunctions_t function);
 
 static void check_palette(void)
 {
-	/* Clean up any previous changed palette data */
+	// Clean up any previous changed palette data
 	if (render.pal.changed) {
 		memset(render.pal.modified, 0, sizeof(render.pal.modified));
 		render.pal.changed = false;
@@ -96,7 +97,8 @@ static void check_palette(void)
 		}
 		break;
 	}
-	/* Setup pal index to startup values */
+
+	// Setup pal index to startup values
 	render.pal.first = 256;
 	render.pal.last  = 0;
 }
@@ -195,10 +197,12 @@ bool RENDER_StartUpdate(void)
 	render.scale.outPitch   = 0;
 	Scaler_ChangedLines[0]  = 0;
 	Scaler_ChangedLineIndex = 0;
-	/* Clearing the cache will first process the line to make sure it's
-	 * never the same */
+
+	// Clearing the cache will first process the line to make sure it's
+	// never the same
 	if (GCC_UNLIKELY(render.scale.clearCache)) {
-		//		LOG_MSG("Clearing cache");
+		// LOG_MSG("Clearing cache");
+
 		// Will always have to update the screen with this one anyway,
 		// so let's update already
 		if (GCC_UNLIKELY(!GFX_StartUpdate(render.scale.outWrite,
@@ -210,8 +214,8 @@ bool RENDER_StartUpdate(void)
 		RENDER_DrawLine         = clear_cache_handler;
 	} else {
 		if (render.pal.changed) {
-			/* Assume pal changes always do a full screen update
-			 * anyway */
+			// Assume pal changes always do a full screen update
+			// anyway
 			if (GCC_UNLIKELY(!GFX_StartUpdate(render.scale.outWrite,
 			                                  render.scale.outPitch))) {
 				return false;
@@ -338,7 +342,7 @@ static void render_reset(void)
 		gfx_scaleh = 1;
 	}
 
-	/* Don't do software scaler sizes larger than 4k */
+	// Don't do software scaler sizes larger than 4k
 	Bitu maxsize_current_input = SCALER_MAXWIDTH / width;
 	if (render.scale.size > maxsize_current_input) {
 		render.scale.size = maxsize_current_input;
@@ -391,7 +395,7 @@ static void render_reset(void)
 	width *= xscale;
 	const auto height = make_aspect_table(render.src.height, yscale, yscale);
 
-	// Setup the scaler variables
+	// Set up scaler variables
 	if (double_height) {
 		gfx_flags |= GFX_DBL_H;
 	}
@@ -461,15 +465,18 @@ static void render_reset(void)
 	render.scale.blocks    = render.src.width / SCALER_BLOCKSIZE;
 	render.scale.lastBlock = render.src.width % SCALER_BLOCKSIZE;
 	render.scale.inHeight  = render.src.height;
-	/* Reset the palette change detection to it's initial value */
+
+	// Reset the palette change detection to it's initial value
 	render.pal.first   = 0;
 	render.pal.last    = 255;
 	render.pal.changed = false;
 	memset(render.pal.modified, 0, sizeof(render.pal.modified));
+
 	// Finish this frame using a copy only handler
 	RENDER_DrawLine       = finish_line_handler;
 	render.scale.outWrite = nullptr;
-	/* Signal the next frame to first reinit the cache */
+
+	// Signal the next frame to first reinit the cache
 	render.scale.clearCache = true;
 	render.active           = true;
 }
@@ -617,7 +624,7 @@ static bool read_shader_source(const std::string& shader_path, std::string& sour
 			}
 		}
 		if (pre_defs.length()) {
-			// if "#version" occurs it must be before anything
+			// If "#version" occurs, it must be before anything,
 			// except comments and whitespace
 			auto pos = s.find("#version ");
 
@@ -753,6 +760,7 @@ void RENDER_InitShaderSource([[maybe_unused]] Section* sec)
 		for (const auto& line : RENDER_InventoryShaders()) {
 			LOG_WARNING("RENDER: %s", line.c_str());
 		}
+
 		// Fallback to the 'none' shader and otherwise fail
 		if (read_shader_source(fallback_shader, source)) {
 			filename = fallback_shader;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -59,8 +59,9 @@ static void check_palette(void)
 		memset(render.pal.modified, 0, sizeof(render.pal.modified));
 		render.pal.changed = false;
 	}
-	if (render.pal.first > render.pal.last)
+	if (render.pal.first > render.pal.last) {
 		return;
+	}
 	Bitu i;
 	switch (render.scale.outMode) {
 	case scalerMode8: break;
@@ -115,15 +116,15 @@ void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
 	}
 }
 
-static void empty_line_handler(const void *) {}
+static void empty_line_handler(const void*) {}
 
-static void start_line_handler(const void *s)
+static void start_line_handler(const void* s)
 {
 	if (s) {
-		const Bitu *src = (Bitu *)s;
-		Bitu *cache     = (Bitu *)(render.scale.cacheRead);
+		const Bitu* src = (Bitu*)s;
+		Bitu* cache     = (Bitu*)(render.scale.cacheRead);
 		for (Bits x = render.src.start; x > 0;) {
-			const auto src_ptr = reinterpret_cast<const uint8_t *>(src);
+			const auto src_ptr = reinterpret_cast<const uint8_t*>(src);
 			const auto src_val = read_unaligned_size_t(src_ptr);
 			if (GCC_UNLIKELY(src_val != cache[0])) {
 				if (!GFX_StartUpdate(render.scale.outWrite,
@@ -148,11 +149,11 @@ static void start_line_handler(const void *s)
 	render.scale.outLine++;
 }
 
-static void finish_line_handler(const void *s)
+static void finish_line_handler(const void* s)
 {
 	if (s) {
-		const Bitu *src = (Bitu *)s;
-		Bitu *cache     = (Bitu *)(render.scale.cacheRead);
+		const Bitu* src = (Bitu*)s;
+		Bitu* cache     = (Bitu*)(render.scale.cacheRead);
 		for (Bits x = render.src.start; x > 0;) {
 			cache[0] = src[0];
 			x--;
@@ -163,30 +164,33 @@ static void finish_line_handler(const void *s)
 	render.scale.cacheRead += render.scale.cachePitch;
 }
 
-static void clear_cache_handler(const void *src)
+static void clear_cache_handler(const void* src)
 {
 	Bitu x, width;
 	uint32_t *srcLine, *cacheLine;
-	srcLine   = (uint32_t *)src;
-	cacheLine = (uint32_t *)render.scale.cacheRead;
+	srcLine   = (uint32_t*)src;
+	cacheLine = (uint32_t*)render.scale.cacheRead;
 	width     = render.scale.cachePitch / 4;
-	for (x = 0; x < width; x++)
+	for (x = 0; x < width; x++) {
 		cacheLine[x] = ~srcLine[x];
+	}
 	render.scale.lineHandler(src);
 }
 
 bool RENDER_StartUpdate(void)
 {
-	if (GCC_UNLIKELY(render.updating))
+	if (GCC_UNLIKELY(render.updating)) {
 		return false;
-	if (GCC_UNLIKELY(!render.active))
+	}
+	if (GCC_UNLIKELY(!render.active)) {
 		return false;
+	}
 	if (render.scale.inMode == scalerMode8) {
 		check_palette();
 	}
 	render.scale.inLine     = 0;
 	render.scale.outLine    = 0;
-	render.scale.cacheRead  = (uint8_t *)&scalerSourceCache;
+	render.scale.cacheRead  = (uint8_t*)&scalerSourceCache;
 	render.scale.outWrite   = nullptr;
 	render.scale.outPitch   = 0;
 	Scaler_ChangedLines[0]  = 0;
@@ -198,8 +202,9 @@ bool RENDER_StartUpdate(void)
 		// Will always have to update the screen with this one anyway,
 		// so let's update already
 		if (GCC_UNLIKELY(!GFX_StartUpdate(render.scale.outWrite,
-		                                  render.scale.outPitch)))
+		                                  render.scale.outPitch))) {
 			return false;
+		}
 		render.fullFrame        = true;
 		render.scale.clearCache = false;
 		RENDER_DrawLine         = clear_cache_handler;
@@ -208,8 +213,9 @@ bool RENDER_StartUpdate(void)
 			/* Assume pal changes always do a full screen update
 			 * anyway */
 			if (GCC_UNLIKELY(!GFX_StartUpdate(render.scale.outWrite,
-			                                  render.scale.outPitch)))
+			                                  render.scale.outPitch))) {
 				return false;
+			}
 			RENDER_DrawLine  = render.scale.linePalHandler;
 			render.fullFrame = true;
 		} else {
@@ -311,7 +317,7 @@ static void render_reset(void)
 	// driver operating in a different thread or process.
 	std::lock_guard<std::mutex> guard(render_reset_mutex);
 
-	Bitu width  = render.src.width;
+	Bitu width         = render.src.width;
 	bool double_width  = render.src.double_width;
 	bool double_height = render.src.double_height;
 
@@ -322,7 +328,7 @@ static void render_reset(void)
 	ScalerSimpleBlock_t* simpleBlock = &ScaleNormal1x;
 
 	const auto one_per_pixel_aspect =
-			render.src.pixel_aspect_ratio.Inverse().ToDouble();
+	        render.src.pixel_aspect_ratio.Inverse().ToDouble();
 
 	if (one_per_pixel_aspect > 1.0) {
 		gfx_scalew = 1;
@@ -334,8 +340,9 @@ static void render_reset(void)
 
 	/* Don't do software scaler sizes larger than 4k */
 	Bitu maxsize_current_input = SCALER_MAXWIDTH / width;
-	if (render.scale.size > maxsize_current_input)
+	if (render.scale.size > maxsize_current_input) {
 		render.scale.size = maxsize_current_input;
+	}
 
 	if (double_height && double_width) {
 		simpleBlock = &ScaleNormal2x;
@@ -344,7 +351,7 @@ static void render_reset(void)
 	} else if (double_height) {
 		simpleBlock = &ScaleNormalDh;
 	} else {
-		simpleBlock  = &ScaleNormal1x;
+		simpleBlock = &ScaleNormal1x;
 	}
 
 	if ((width * simpleBlock->xscale > SCALER_MAXWIDTH) ||
@@ -360,19 +367,19 @@ static void render_reset(void)
 	case 8: render.src.start = (render.src.width * 1) / sizeof(Bitu); break;
 	case 15:
 		render.src.start = (render.src.width * 2) / sizeof(Bitu);
-		gfx_flags = (gfx_flags & ~GFX_CAN_8);
+		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
 	case 16:
 		render.src.start = (render.src.width * 2) / sizeof(Bitu);
-		gfx_flags = (gfx_flags & ~GFX_CAN_8);
+		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
 	case 24:
 		render.src.start = (render.src.width * 3) / sizeof(Bitu);
-		gfx_flags = (gfx_flags & ~GFX_CAN_8);
+		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
 	case 32:
 		render.src.start = (render.src.width * 4) / sizeof(Bitu);
-		gfx_flags = (gfx_flags & ~GFX_CAN_8);
+		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
 	}
 	gfx_flags = GFX_GetBestMode(gfx_flags);
@@ -404,16 +411,17 @@ static void render_reset(void)
 	                        render.video_mode,
 	                        &render_callback);
 
-	if (gfx_flags & GFX_CAN_8)
+	if (gfx_flags & GFX_CAN_8) {
 		render.scale.outMode = scalerMode8;
-	else if (gfx_flags & GFX_CAN_15)
+	} else if (gfx_flags & GFX_CAN_15) {
 		render.scale.outMode = scalerMode15;
-	else if (gfx_flags & GFX_CAN_16)
+	} else if (gfx_flags & GFX_CAN_16) {
 		render.scale.outMode = scalerMode16;
-	else if (gfx_flags & GFX_CAN_32)
+	} else if (gfx_flags & GFX_CAN_32) {
 		render.scale.outMode = scalerMode32;
-	else
+	} else {
 		E_Exit("Failed to create a rendering output");
+	}
 
 	const auto lineBlock = gfx_flags & GFX_CAN_RANDOM ? &simpleBlock->Random
 	                                                  : &simpleBlock->Linear;
@@ -421,8 +429,8 @@ static void render_reset(void)
 	case 8:
 		render.scale.lineHandler = (*lineBlock)[0][render.scale.outMode];
 		render.scale.linePalHandler = (*lineBlock)[5][render.scale.outMode];
-		render.scale.inMode         = scalerMode8;
-		render.scale.cachePitch     = render.src.width * 1;
+		render.scale.inMode     = scalerMode8;
+		render.scale.cachePitch = render.src.width * 1;
 		break;
 	case 15:
 		render.scale.lineHandler = (*lineBlock)[1][render.scale.outMode];
@@ -511,17 +519,19 @@ void RENDER_SetSize(const uint16_t width, const uint16_t height,
 #if C_OPENGL
 
 // Reads the given shader path into the string
-static bool read_shader(const std_fs::path &shader_path, std::string &shader_str)
+static bool read_shader(const std_fs::path& shader_path, std::string& shader_str)
 {
 	std::ifstream fshader(shader_path, std::ios_base::binary);
-	if (!fshader.is_open())
+	if (!fshader.is_open()) {
 		return false;
+	}
 
 	std::stringstream buf;
 	buf << fshader.rdbuf();
 	fshader.close();
-	if (buf.str().empty())
+	if (buf.str().empty()) {
 		return false;
+	}
 
 	shader_str = buf.str();
 	shader_str += '\n';
@@ -539,7 +549,7 @@ std::deque<std::string> RENDER_InventoryShaders()
 	const std::string file_prefix = "        ";
 
 	std::error_code ec = {};
-	for (auto &[dir, shaders] : GetFilesInResource("glshaders", ".glsl")) {
+	for (auto& [dir, shaders] : GetFilesInResource("glshaders", ".glsl")) {
 		const auto dir_exists      = std_fs::is_directory(dir, ec);
 		auto shader                = shaders.begin();
 		const auto dir_has_shaders = shader != shaders.end();
@@ -578,9 +588,11 @@ static bool read_shader_source(const std::string& shader_path, std::string& sour
 	                                              shader_path + ".glsl")};
 
 	std::string s; // to be populated with the shader source
-	for (const auto &p : candidate_paths)
-		if (read_shader(p, s))
+	for (const auto& p : candidate_paths) {
+		if (read_shader(p, s)) {
 			break;
+		}
+	}
 
 	if (s.empty()) {
 		source.clear();
@@ -592,12 +604,14 @@ static bool read_shader_source(const std::string& shader_path, std::string& sour
 		const size_t count = first_shell->GetEnvCount();
 		for (size_t i = 0; i < count; ++i) {
 			std::string env;
-			if (!first_shell->GetEnvNum(i, env))
+			if (!first_shell->GetEnvNum(i, env)) {
 				continue;
+			}
 			if (env.compare(0, 9, "GLSHADER_") == 0) {
 				const auto brk = env.find('=');
-				if (brk == std::string::npos)
+				if (brk == std::string::npos) {
 					continue;
+				}
 				env[brk] = ' ';
 				pre_defs += "#define " + env.substr(9) + '\n';
 			}
@@ -607,8 +621,9 @@ static bool read_shader_source(const std::string& shader_path, std::string& sour
 			// except comments and whitespace
 			auto pos = s.find("#version ");
 
-			if (pos != std::string::npos)
+			if (pos != std::string::npos) {
 				pos = s.find('\n', pos + 9);
+			}
 
 			s.insert(pos, pre_defs);
 		}
@@ -664,7 +679,7 @@ bool RENDER_UseSrgbFramebuffer()
 #endif
 
 #if C_OPENGL
-void log_warning_if_legacy_shader_name(const std::string &name)
+void log_warning_if_legacy_shader_name(const std::string& name)
 {
 	static const std::map<std::string, std::string> legacy_name_mappings = {
 	        {"advinterp2x", "scaler/advinterp2x"},
@@ -682,7 +697,7 @@ void log_warning_if_legacy_shader_name(const std::string &name)
 	        {"tv3x", "scaler/tv3x"}};
 
 	std_fs::path shader_path = name;
-	std_fs::path ext  = shader_path.extension();
+	std_fs::path ext         = shader_path.extension();
 
 	if (!(ext == "" || ext == ".glsl")) {
 		return;
@@ -694,23 +709,23 @@ void log_warning_if_legacy_shader_name(const std::string &name)
 	if (it != legacy_name_mappings.end()) {
 		const auto new_name = it->second;
 		LOG_WARNING("RENDER: Built-in shader '%s' has been renamed; please use '%s' instead.",
-					name.c_str(),
-					new_name.c_str());
+		            name.c_str(),
+		            new_name.c_str());
 	}
 }
 #endif
 
-void RENDER_InitShaderSource([[maybe_unused]] Section *sec)
+void RENDER_InitShaderSource([[maybe_unused]] Section* sec)
 {
 #if C_OPENGL
 	assert(control);
-	const Section *sdl_sec = control->GetSection("sdl");
+	const Section* sdl_sec = control->GetSection("sdl");
 	assert(sdl_sec);
 
 	const bool using_opengl = starts_with(sdl_sec->GetPropValue("output"),
 	                                      "opengl");
 
-	const auto render_sec = static_cast<const Section_prop *>(
+	const auto render_sec = static_cast<const Section_prop*>(
 	        control->GetSection("render"));
 
 	assert(render_sec);
@@ -735,7 +750,7 @@ void RENDER_InitShaderSource([[maybe_unused]] Section *sec)
 
 		// List all the existing shaders for the user
 		LOG_ERR("RENDER: Shader file '%s' not found", filename.c_str());
-		for (const auto &line : RENDER_InventoryShaders()) {
+		for (const auto& line : RENDER_InventoryShaders()) {
 			LOG_WARNING("RENDER: %s", line.c_str());
 		}
 		// Fallback to the 'none' shader and otherwise fail
@@ -764,7 +779,7 @@ void RENDER_InitShaderSource([[maybe_unused]] Section *sec)
 #endif
 }
 
-void RENDER_Init(Section *sec);
+void RENDER_Init(Section* sec);
 
 static void reload_shader(const bool pressed)
 {
@@ -772,8 +787,9 @@ static void reload_shader(const bool pressed)
 	// tweaking shader presets. Ultimately, this code will go away once the
 	// new shading system has been introduced, so massaging the current code
 	// to make this "nicer" would be largely a wasted effort...
-	if (!pressed)
+	if (!pressed) {
 		return;
+	}
 
 	assert(control);
 	auto render_section = control->GetSection("render");
@@ -821,7 +837,7 @@ static void setup_scan_and_pixel_doubling([[maybe_unused]] Section_prop* section
 	const auto nearest_neighbour_enabled = (GFX_GetInterpolationMode() ==
 	                                        InterpolationMode::NearestNeighbour);
 
-	force_vga_single_scan = nearest_neighbour_enabled;
+	force_vga_single_scan   = nearest_neighbour_enabled;
 	force_no_pixel_doubling = nearest_neighbour_enabled;
 
 #if C_OPENGL

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -722,7 +722,7 @@ void log_warning_if_legacy_shader_name(const std::string& name)
 }
 #endif
 
-void RENDER_InitShader([[maybe_unused]] Section* sec)
+static bool init_shader([[maybe_unused]] Section* sec)
 {
 #if C_OPENGL
 	assert(control);
@@ -784,7 +784,14 @@ void RENDER_InitShader([[maybe_unused]] Section* sec)
 		// Pass the shader source up to the GFX engine
 		GFX_SetShader(render.shader.source);
 	}
+
+	return true;
 #endif
+}
+
+void RENDER_InitShader(Section* sec)
+{
+	init_shader(sec);
 }
 
 void RENDER_Init(Section* sec);
@@ -886,7 +893,7 @@ void RENDER_Init(Section* sec)
 
 #if C_OPENGL
 	const auto previous_shader_filename = render.shader.filename;
-	RENDER_InitShader(section);
+	init_shader(section);
 #endif
 
 	setup_scan_and_pixel_doubling(section);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -100,15 +100,19 @@ static void check_palette(void)
 	render.pal.last  = 0;
 }
 
-void RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t blue)
+void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
+                       const uint8_t green, const uint8_t blue)
 {
 	render.pal.rgb[entry].red   = red;
 	render.pal.rgb[entry].green = green;
 	render.pal.rgb[entry].blue  = blue;
-	if (render.pal.first > entry)
+
+	if (render.pal.first > entry) {
 		render.pal.first = entry;
-	if (render.pal.last < entry)
+	}
+	if (render.pal.last < entry) {
 		render.pal.last = entry;
+	}
 }
 
 static void empty_line_handler(const void *) {}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2202,9 +2202,11 @@ dosurface:
 #if 0
 			LOG_MSG("OPENGL: Using sRGB framebuffer");
 #endif
+		} else {
+			glDisable(GL_FRAMEBUFFER_SRGB);
 		}
 
-		glClearColor (0.0f, 0.0f, 0.0f, 1.0f);
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
 		glClear(GL_COLOR_BUFFER_BIT);
 		SDL_GL_SwapWindow(sdl.window);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3485,7 +3485,7 @@ static void set_output(Section* sec, bool should_stretch_pixels)
 
 #if C_OPENGL
 	} else if (starts_with(output, "opengl")) {
-		RENDER_InitShaderSource(sec);
+		RENDER_InitShader(sec);
 		if (output == "opengl") {
 			sdl.desktop.want_type  = SCREEN_OPENGL;
 			sdl.interpolation_mode = InterpolationMode::Bilinear;

--- a/src/hardware/reelmagic/video_mixer.cpp
+++ b/src/hardware/reelmagic/video_mixer.cpp
@@ -695,7 +695,8 @@ static void SetupVideoMixer(const bool updateRenderMode)
 //
 // The RENDER_*() interceptors begin here...
 //
-void ReelMagic_RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t blue)
+void ReelMagic_RENDER_SetPalette(const uint8_t entry, const uint8_t red,
+                                 const uint8_t green, const uint8_t blue)
 {
 	VGA32bppPixel& p = VGAPalettePixel::_vgaPalette32bpp[entry];
 	p.red            = red;
@@ -705,7 +706,7 @@ void ReelMagic_RENDER_SetPal(uint8_t entry, uint8_t red, uint8_t green, uint8_t 
 
 	VGAPalettePixel::_vgaPalette16bpp[entry].FromRgb888(red, green, blue);
 
-	RENDER_SetPal(entry, red, green, blue);
+	RENDER_SetPalette(entry, red, green, blue);
 }
 
 void ReelMagic_RENDER_SetSize(const uint16_t width, const uint16_t height,

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -68,7 +68,7 @@ static void VGA_DAC_SendColor(uint8_t index, uint8_t src)
 	vga.dac.palette_map[index] = static_cast<uint32_t>((r8 << 16) |
 	                                                   (g8 << 8) | b8);
 
-	ReelMagic_RENDER_SetPal(index, r8, g8, b8);
+	ReelMagic_RENDER_SetPalette(index, r8, g8, b8);
 }
 
 static void VGA_DAC_UpdateColor(uint16_t index)

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -582,7 +582,7 @@ static void update_cga16_color_pcjr()
 			const auto b = to_linear_rgb(-0.0272f * R - 0.0401f * G + 1.1677f * B);
 
 			const uint8_t index = bits | ((x & 1) == 0 ? 0x30 : 0x80) | ((x & 2) == 0 ? 0x40 : 0);
-			ReelMagic_RENDER_SetPal(index, r, g, b);
+			ReelMagic_RENDER_SetPalette(index, r, g, b);
 		}
 	}
 }

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1105,15 +1105,6 @@ bool Config::PrintConfig(const std::string& filename) const
 	return true;
 }
 
-Section_prop* Config::AddEarlySectionProp(const char* name, SectionFunction func,
-                                          bool changeable_at_runtime)
-{
-	Section_prop* s = new Section_prop(name);
-	s->AddEarlyInitFunction(func, changeable_at_runtime);
-	sectionlist.push_back(s);
-	return s;
-}
-
 Section_prop* Config::AddSection_prop(const char* section_name, SectionFunction func,
                                       bool changeable_at_runtime)
 {
@@ -1191,18 +1182,7 @@ Config::Config(Config&& source) noexcept
 void Config::Init() const
 {
 	for (const auto& sec : sectionlist) {
-		sec->ExecuteEarlyInit();
-	}
-
-	for (const auto& sec : sectionlist) {
 		sec->ExecuteInit();
-	}
-}
-
-void Section::AddEarlyInitFunction(SectionFunction func, bool changeable_at_runtime)
-{
-	if (func) {
-		early_init_functions.emplace_back(func, changeable_at_runtime);
 	}
 }
 
@@ -1216,16 +1196,6 @@ void Section::AddInitFunction(SectionFunction func, bool changeable_at_runtime)
 void Section::AddDestroyFunction(SectionFunction func, bool changeable_at_runtime)
 {
 	destroyfunctions.emplace_front(func, changeable_at_runtime);
-}
-
-void Section::ExecuteEarlyInit(bool init_all)
-{
-	for (const auto& fn : early_init_functions) {
-		if (init_all || fn.changeable_at_runtime) {
-			assert(fn.function);
-			fn.function(this);
-		}
-	}
 }
 
 void Section::ExecuteInit(const bool init_all)

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -36,14 +36,6 @@ public:
 
 		for (auto section_name : sections) {
 			_sec = control->GetSection(section_name);
-			// NOTE: Some of the sections will return null pointers,
-			// if you add a section below, make sure to test for
-			// nullptr before executing early init.
-			_sec->ExecuteEarlyInit();
-		}
-
-		for (auto section_name : sections) {
-			_sec = control->GetSection(section_name);
 			_sec->ExecuteInit();
 		}
 	}


### PR DESCRIPTION
In current main, reloading/changing shaders at runtime is plagued with several serious problems. Sometimes you get a black screen, the sRGB framebuffer cannot be disabled via pragmas once enabled, and there are memory leaks that will invariably result in a hard crash after a certain number of shader changes or reloads.

This PR fixes all that 😎 You can switch shaders and/or reload them as many times as you want—it just works 🤘🏻 Passed the UBSAN tests too.

It should be easy to follow what I've done commit by commit; otherwise not so much 😅 