### PR TITLE
Fixes and cleanup of PCI BIOS

### DIFF
--- a/include/inout.h
+++ b/include/inout.h
@@ -128,6 +128,10 @@ constexpr io_port_t port_num_i8255_2 = 0x62u;
 // PS/2 control port, mainly for fast A20
 constexpr io_port_t port_num_fast_a20 = 0x92u;
 
+// PCI bus registers
+constexpr io_port_t port_num_pci_config_address = 0xcf8u;
+constexpr io_port_t port_num_pci_config_data    = 0xcfcu;
+
 // VMware communication interface
 constexpr io_port_t port_num_vmware    = 0x5658u;
 constexpr io_port_t port_num_vmware_hb = 0x5659u; // high bandwidth

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -268,12 +268,20 @@ public:
 	// set up port handlers and configuration data
 	void InitializePCI(void) {
 		// install PCI-addressing ports
-		PCI_WriteHandler[0].Install(0xcf8, write_pci_addr, io_width_t::dword);
-		PCI_ReadHandler[0].Install(0xcf8, read_pci_addr, io_width_t::dword);
+		PCI_WriteHandler[0].Install(port_num_pci_config_address,
+		                            write_pci_addr,
+		                            io_width_t::dword);
+		PCI_ReadHandler[0].Install(port_num_pci_config_address,
+		                           read_pci_addr,
+		                           io_width_t::dword);
 		// install PCI-register read/write handlers
 		for (uint8_t ct = 0; ct < 4; ++ct) {
-			PCI_WriteHandler[1 + ct].Install(0xcfc + ct, write_pci, io_width_t::byte);
-			PCI_ReadHandler[1 + ct].Install(0xcfc + ct, read_pci, io_width_t::byte);
+			PCI_WriteHandler[1 + ct].Install(port_num_pci_config_data + ct,
+			                                 write_pci,
+			                                 io_width_t::byte);
+			PCI_ReadHandler[1 + ct].Install(port_num_pci_config_data + ct,
+			                                read_pci,
+			                                io_width_t::byte);
 		}
 
 		for (Bitu dev=0; dev<PCI_MAX_PCIDEVICES; dev++)

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -22,15 +22,12 @@
 #include "callback.h"
 #include "cpu.h"
 #include "dosbox.h"
-#include "inout.h"
-#include "math_utils.h"
-#include "pic.h"
 #include "hardware.h"
 #include "inout.h"
 #include "joystick.h"
+#include "math_utils.h"
 #include "mem.h"
 #include "mouse.h"
-#include "pci_bus.h"
 #include "pic.h"
 #include "regs.h"
 #include "serialport.h"
@@ -47,6 +44,8 @@
 // - Ralf Brown's Interrupt List
 // - https://www.stanislavs.org/helppc/idx_interrupt.html
 // - http://www2.ift.ulaval.ca/~marchand/ift17583/dosints.pdf
+
+void INT1AB1_Handler(); // PCI BIOS calls
 
 /* if mem_systems 0 then size_extended is reported as the real size else
  * zero is reported. ems and xms can increase or decrease the other_memsystems
@@ -369,120 +368,8 @@ static Bitu INT1A_Handler(void) {
 	case 0x85:	/* Tandy sound system reset */
 		TandyDAC_Handler(reg_ah);
 		break;
-	case 0xb1:		/* PCI Bios Calls */
-		LOG(LOG_BIOS,LOG_WARN)("INT1A:PCI bios call %2X",reg_al);
-		switch (reg_al) {
-		case 0x01: // installation check
-			if (PCI_IsInitialized()) {
-				reg_ah = 0x00;
-				reg_al = 0x01; // cfg space mechanism 1 supported
-				reg_bx = 0x0210; // ver 2.10
-				reg_cx = 0x0000; // only one PCI bus
-				reg_edx = 0x20494350;
-				reg_edi = PCI_GetPModeInterface();
-				CALLBACK_SCF(false);
-			} else {
-				CALLBACK_SCF(true);
-			}
-			break;
-		case 0x02: { // find device
-			uint32_t devnr = 0;
-			constexpr uint32_t count = 0x100;
-			const uint32_t devicetag = (reg_cx << 16) | reg_dx;
-			int found = -1;
-			for (uint32_t i = 0; i <= count; ++i) {
-				// query unique device/subdevice entries
-				IO_WriteD(0xcf8, 0x80000000 | (i << 8));
-				if (IO_ReadD(0xcfc) == devicetag) {
-					if (devnr == reg_si) {
-						found = static_cast<int>(i);
-						break;
-					} else {
-						// device found, but not the
-						// SIth device
-						devnr++;
-					}
-				}
-			}
-			if (found >= 0) {
-				reg_ah = 0x00;
-				reg_bh = 0x00; // bus 0
-				reg_bl = (uint8_t)(found & 0xff);
-				CALLBACK_SCF(false);
-			} else {
-				reg_ah = 0x86; // device not found
-				CALLBACK_SCF(true);
-			}
-				}
-				break;
-			case 0x03: {	// find device by class code
-				uint32_t devnr = 0;
-				constexpr uint32_t count = 0x100;
-				const uint32_t classtag  = reg_ecx & 0xffffff;
-				int found = -1;
-				for (uint32_t i = 0; i <= count; ++i) {
-					// query unique device/subdevice entries
-					IO_WriteD(0xcf8, 0x80000000 | (i << 8));
-					if (IO_ReadD(0xcfc)!=0xffffffff) {
-						IO_WriteD(0xcf8,0x80000000|(i<<8)|0x08);
-						if ((IO_ReadD(0xcfc)>>8)==classtag) {
-							if (devnr==reg_si) {
-								found = static_cast<int>(i);
-								break;
-							} else {
-								// device found, but not the SIth device
-								devnr++;
-							}
-						}
-					}
-				}
-				if (found>=0) {
-					reg_ah=0x00;
-					reg_bh=0x00;	// bus 0
-					reg_bl=(uint8_t)(found&0xff);
-					CALLBACK_SCF(false);
-				} else {
-					reg_ah=0x86;	// device not found
-					CALLBACK_SCF(true);
-				}
-				}
-				break;
-			case 0x08:	// read configuration byte
-				IO_WriteD(0xcf8,0x80000000|(reg_bx<<8)|(reg_di&0xfc));
-				reg_cl=IO_ReadB(0xcfc+(reg_di&3));
-				CALLBACK_SCF(false);
-				break;
-			case 0x09:	// read configuration word
-				IO_WriteD(0xcf8,0x80000000|(reg_bx<<8)|(reg_di&0xfc));
-				reg_cx=IO_ReadW(0xcfc+(reg_di&2));
-				CALLBACK_SCF(false);
-				break;
-			case 0x0a:	// read configuration dword
-				IO_WriteD(0xcf8,0x80000000|(reg_bx<<8)|(reg_di&0xfc));
-				reg_ecx=IO_ReadD(0xcfc+(reg_di&3));
-				CALLBACK_SCF(false);
-				break;
-			case 0x0b:	// write configuration byte
-				IO_WriteD(0xcf8,0x80000000|(reg_bx<<8)|(reg_di&0xfc));
-				IO_WriteB(0xcfc+(reg_di&3),reg_cl);
-				CALLBACK_SCF(false);
-				break;
-			case 0x0c:	// write configuration word
-				IO_WriteD(0xcf8,0x80000000|(reg_bx<<8)|(reg_di&0xfc));
-				IO_WriteW(0xcfc+(reg_di&2),reg_cx);
-				CALLBACK_SCF(false);
-				break;
-			case 0x0d:	// write configuration dword
-				IO_WriteD(0xcf8,0x80000000|(reg_bx<<8)|(reg_di&0xfc));
-				IO_WriteD(0xcfc+(reg_di&3),reg_ecx);
-				CALLBACK_SCF(false);
-				break;
-			default:
-				LOG(LOG_BIOS,LOG_ERROR)("INT1A:PCI BIOS: unknown function %x (%x %x %x)",
-					reg_ax,reg_bx,reg_cx,reg_dx);
-				CALLBACK_SCF(true);
-				break;
-		        }
+	case 0xb1: // PCI_FUNCTION_ID - PCI BIOS calls
+		INT1AB1_Handler();
 		break;
 	default:
 		LOG(LOG_BIOS,LOG_ERROR)("INT1A:Undefined call %2X",reg_ah);

--- a/src/ints/bios_pci.cpp
+++ b/src/ints/bios_pci.cpp
@@ -1,0 +1,266 @@
+/*
+ *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "bios.h"
+
+#include "callback.h"
+#include "checks.h"
+#include "dosbox.h"
+#include "inout.h"
+#include "pci_bus.h"
+#include "regs.h"
+#include "support.h"
+
+CHECK_NARROWING();
+
+// Reference:
+// - PCI BIOS Specification, revision 2.1
+
+// TODO (not sure if needed by anything):
+// - interrupt routing is not implemented
+// - special cycles are not implemented
+// - BIOS32 interface is not implemented
+// - 0x000ffe6e entry point is not implemented
+
+constexpr uint16_t max_device_index = 0x100;
+constexpr uint32_t enable_bit       = static_cast<uint32_t>(1 << 31);
+
+enum class ReturnCode : uint8_t {
+	Successful        = 0x00,
+	FuncNotSupported  = 0x81,
+	BadVendorId       = 0x83,
+	DeviceNotFound    = 0x86,
+	BadRegisterNumber = 0x87,
+	SetFailed         = 0x88,
+	BufferTooSmall    = 0x89,
+};
+
+static void warn_unknown_function(const uint8_t function)
+{
+	static bool already_warned[UINT8_MAX + 1];
+	if (!already_warned[function]) {
+		LOG_WARNING("INT1A: Unknown PCI function 0xb1%02x", function);
+		already_warned[function] = true;
+	}
+}
+
+static void warn_no_pci_present()
+{
+	static bool already_warned = false;
+	if (!already_warned) {
+		LOG_WARNING("INT1A: PCI function called despite no PCI present");
+		already_warned = true;
+	}
+}
+
+void INT1AB1_Handler()
+{
+	auto set_return_code = [](const ReturnCode code) {
+		reg_ah = enum_val(code);
+		CALLBACK_SCF(code != ReturnCode::Successful);
+	};
+
+	auto select_read_write_address = []() {
+		const auto address = enable_bit |
+	                             static_cast<uint32_t>(reg_bx << 8) |
+	                             static_cast<uint32_t>(reg_di & 0xfc);
+		IO_WriteD(port_num_pci_config_address,
+		          static_cast<uint32_t>(address));
+	};
+
+	if (!PCI_IsInitialized()) {
+		// No PCI subsystem
+
+		if (reg_al != 0x01) {
+			warn_no_pci_present();
+		}
+
+		set_return_code(ReturnCode::FuncNotSupported);
+		return;
+	}
+
+	switch (reg_al) {
+	case 0x01: // PCI BIOS Present
+		reg_bx  = 0x0210;     // version 2.10
+		reg_cx  = 0x0000;     // only one PCI bus
+		reg_edx = 0x20494350; // "PCI "
+		reg_edi = PCI_GetPModeInterface();
+		// AL informs which mechanisms are supported:
+		// bit 0: configuration mechanism #1
+		// bit 1: configuration mechanism #2
+		// (either bit 1 or 2 needs to be set)
+		// bit 4: special cycle generation mechanism #1
+		// bit 5: special cycle generation mechanism #2
+		// (either bit 4 or 5 can be set, must match the supported
+		// configuration mechanism)
+		reg_al = 0x01;
+		set_return_code(ReturnCode::Successful);
+		return;
+	case 0x02: // Find PCI Device
+	{
+		// Check if vendor ID is valid
+		if (reg_dx == 0xffff) {
+			set_return_code(ReturnCode::BadVendorId);
+			return;
+		}
+
+		const auto tag_value = (reg_cx << 16) | reg_dx;
+		const uint32_t device_tag = static_cast<uint32_t>(tag_value);
+
+		// Try to find requested device
+		uint32_t device_number = 0;
+		for (uint16_t i = 0; i <= max_device_index; ++i) {
+			// Query unique device/subdevice entries
+			const auto i_shifted = static_cast<uint32_t>(i << 8);
+			IO_WriteD(port_num_pci_config_address,
+			          static_cast<uint32_t>(enable_bit | i_shifted));
+			if (IO_ReadD(0xcfc) != device_tag) {
+				continue; // Tag does not match
+			}
+
+			if (device_number == reg_si) {
+				// Found!
+				reg_bl = static_cast<uint8_t>(i & 0xff);
+				reg_bh = 0x00; // bus 0
+				set_return_code(ReturnCode::Successful);
+				return;
+			}
+
+			// Matches, but is not the SIth device
+			++device_number;
+		}
+
+		// Device not found
+		set_return_code(ReturnCode::DeviceNotFound);
+		return;
+	}
+	case 0x03: { // Find PCI Class Code
+		const auto tag_value = reg_ecx & 0xffffff;
+		const uint32_t class_tag = static_cast<uint32_t>(tag_value);
+
+		// Try to find requested device
+		uint32_t device_number = 0;
+		for (uint16_t i = 0; i <= max_device_index; ++i) {
+			// Query unique device/subdevice entries
+			const auto i_shifted = static_cast<uint32_t>(i << 8);
+			IO_WriteD(port_num_pci_config_address,
+			          static_cast<uint32_t>(enable_bit | i_shifted));
+			if (IO_ReadD(port_num_pci_config_data) == UINT32_MAX) {
+				continue;
+			}
+			IO_WriteD(port_num_pci_config_address,
+			          static_cast<uint32_t>(enable_bit | i_shifted | 0x08));
+			if ((IO_ReadD(port_num_pci_config_data) >> 8) != class_tag) {
+				continue; // Tag does not match
+			}
+
+			if (device_number == reg_si) {
+				// Found!
+				reg_bl = static_cast<uint8_t>(i & 0xff);
+				reg_bh = 0x00; // bus 0
+				set_return_code(ReturnCode::Successful);
+				return;
+			}
+
+			// Matches, but is not the SIth device
+			++device_number;
+		}
+
+		// Device not found
+		set_return_code(ReturnCode::DeviceNotFound);
+		return;
+	}
+	case 0x08: // Read Configuration Byte
+	{
+		select_read_write_address();
+		const auto port = port_num_pci_config_data + (reg_di & 3);
+		reg_cl = IO_ReadB(static_cast<io_port_t>(port));
+		set_return_code(ReturnCode::Successful);
+		return;
+	}
+	case 0x09: // Read Configuration Word
+	{
+		if ((reg_di % 2) != 0) {
+			// Not a multiple of 2
+			set_return_code(ReturnCode::BadRegisterNumber);
+			return;
+		}
+		select_read_write_address();
+		const auto port = port_num_pci_config_data + (reg_di & 2);
+		reg_cx = IO_ReadW(static_cast<io_port_t>(port));
+		set_return_code(ReturnCode::Successful);
+		return;
+	}
+	case 0x0a: // Read Configuration Dword
+	{
+		if ((reg_di % 4) != 0) {
+			// Not a multiple of 4
+			set_return_code(ReturnCode::BadRegisterNumber);
+			return;
+		}
+		select_read_write_address();
+		const auto port = port_num_pci_config_data + (reg_di & 3);
+		reg_ecx = IO_ReadD(static_cast<io_port_t>(port));
+		set_return_code(ReturnCode::Successful);
+		return;
+	}
+	case 0x0b: // Write Configuration Byte
+	{
+		select_read_write_address();
+		const auto port = port_num_pci_config_data + (reg_di & 3);
+		IO_WriteB(static_cast<io_port_t>(port), reg_cl);
+		set_return_code(ReturnCode::Successful);
+		return;
+	}
+	case 0x0c: // Write Configuration Word
+	{
+		if ((reg_di % 2) != 0) {
+			// Not a multiple of 2
+			set_return_code(ReturnCode::BadRegisterNumber);
+			return;
+		}
+		select_read_write_address();
+		const auto port = port_num_pci_config_data + (reg_di & 2);
+		IO_WriteW(static_cast<io_port_t>(port), reg_cx);
+		set_return_code(ReturnCode::Successful);
+		return;
+	}
+	case 0x0d: // Write Configuration Dword
+	{
+		if ((reg_di % 4) != 0) {
+			// Not a multiple of 4
+			set_return_code(ReturnCode::BadRegisterNumber);
+			return;
+		}
+		select_read_write_address();
+		const auto port = port_num_pci_config_data + (reg_di & 3);
+		IO_WriteD(static_cast<io_port_t>(port), reg_ecx);
+		set_return_code(ReturnCode::Successful);
+		return;
+	}
+	case 0x06: // Generate Special Cycle
+	case 0x0e: // Get PCI Interrupt Routing Options
+	case 0x0f: // Set PCI Hardware Interrupt
+		set_return_code(ReturnCode::FuncNotSupported);
+		return;
+	default:
+		warn_unknown_function(reg_al);
+		set_return_code(ReturnCode::FuncNotSupported);
+	}
+}

--- a/src/ints/meson.build
+++ b/src/ints/meson.build
@@ -2,6 +2,7 @@ libints_sources = files(
     'bios.cpp',
     'bios_disk.cpp',
     'bios_keyboard.cpp',
+    'bios_pci.cpp',
     'ems.cpp',
     'int10.cpp',
     'int10_char.cpp',

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -659,6 +659,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\ints\bios.cpp" />
     <ClCompile Include="..\src\ints\bios_disk.cpp" />
     <ClCompile Include="..\src\ints\bios_keyboard.cpp" />
+    <ClCompile Include="..\src\ints\bios_pci.cpp" />
     <ClCompile Include="..\src\ints\ems.cpp" />
     <ClCompile Include="..\src\ints\int10.cpp" />
     <ClCompile Include="..\src\ints\int10_char.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -379,6 +379,9 @@
     <ClCompile Include="..\src\ints\bios_keyboard.cpp">
       <Filter>src\ints</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\ints\bios_pci.cpp">
+      <Filter>src\ints</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\ints\ems.cpp">
       <Filter>src\ints</Filter>
     </ClCompile>


### PR DESCRIPTION
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2727

- general cleanup of PCI BIOS code
- functions `0x08`, `0x09`, `0x0a`, `0x0b`, `0x0c`, and `0x0d` now put return value to AH
- functions `0x09`, `0x0a`, `0x0c`, and `0x0d` now check if input register number is valid
- function `0x02` now checks for invalid vendor ID input parameter

For PCI BIOS specification see https://github.com/dosbox-staging/dosbox-staging/files/12264271/pci_bios_21.pdf