### PR TITLE
Introduce PixelFormat enum

### DIFF
--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -43,7 +43,7 @@ void ReelMagic_RENDER_SetPalette(const uint8_t entry, const uint8_t red,
 void ReelMagic_RENDER_SetSize(const uint16_t width, const uint16_t height,
                               const bool double_width, const bool double_height,
                               const Fraction& render_pixel_aspect_ratio,
-                              const uint8_t bits_per_pixel,
+                              const PixelFormat bits_per_pixel,
                               const double frames_per_second,
                               const VideoMode& video_mode);
 

--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -43,7 +43,7 @@ void ReelMagic_RENDER_SetPalette(const uint8_t entry, const uint8_t red,
 void ReelMagic_RENDER_SetSize(const uint16_t width, const uint16_t height,
                               const bool double_width, const bool double_height,
                               const Fraction& render_pixel_aspect_ratio,
-                              const PixelFormat bits_per_pixel,
+                              const PixelFormat pixel_format,
                               const double frames_per_second,
                               const VideoMode& video_mode);
 

--- a/include/render.h
+++ b/include/render.h
@@ -86,7 +86,7 @@ struct Render_t {
 		uint32_t start = 0;
 
 		// Pixel format of the image data
-		PixelFormat bpp = {};
+		PixelFormat pixel_format = {};
 
 		// Frames per second
 		double fps = 0;
@@ -177,13 +177,13 @@ struct RenderedImage {
 	Fraction pixel_aspect_ratio = {};
 
 	// Pixel format of the image data
-	PixelFormat bits_per_pixel = {};
+	PixelFormat pixel_format = {};
 
 	// Bytes per row
 	uint16_t pitch = 0;
 
 	// (width * height) number of pixels stored in the pixel format defined
-	// by bits_per_pixel
+	// by pixel_format
 	uint8_t* image_data = nullptr;
 
 	// Pointer to a (256 * 4) byte long palette data, stored as 8-bit RGB
@@ -193,7 +193,7 @@ struct RenderedImage {
 
 	inline bool is_paletted() const
 	{
-		return (bits_per_pixel == PixelFormat::Indexed8);
+		return (pixel_format == PixelFormat::Indexed8);
 	}
 
 	RenderedImage deep_copy() const
@@ -237,7 +237,7 @@ std::deque<std::string> RENDER_InventoryShaders();
 void RENDER_SetSize(const uint16_t width, const uint16_t height,
                     const bool double_width, const bool double_height,
                     const Fraction& render_pixel_aspect_ratio,
-                    const PixelFormat bits_per_pixel,
+                    const PixelFormat pixel_format,
                     const double frames_per_second, const VideoMode& video_mode);
 
 bool RENDER_StartUpdate(void);

--- a/include/render.h
+++ b/include/render.h
@@ -74,6 +74,8 @@ enum class PixelFormat : uint8_t {
 	BGRX8888 = 32
 };
 
+const char* to_string(const PixelFormat pf);
+
 struct Render_t {
 	// Details about the rendered image.
 	// E.g. for the 320x200 256-colour 13h VGA mode with double-scanning

--- a/include/render.h
+++ b/include/render.h
@@ -52,6 +52,28 @@ struct VideoMode {
 	Fraction pixel_aspect_ratio = {};
 };
 
+enum class PixelFormat : uint8_t {
+	// Up to 256 colours, paletted;
+	// stored as packed uint8 data
+	Indexed8 = 8,
+
+	// 32K high colour, 5 bits per red/blue/green component;
+	// stored as packed uint16 data with highest bit unused
+	BGR555 = 15,
+	//
+	// 65K high colour, 5 bits for red/blue, 6 bit for green;
+	// stored as packed uint16 data
+	BGR565 = 16,
+	//
+	// 16.7M (24-bit) true colour, 8 bits per red/blue/green component;
+	// stored as packed 24-bit data
+	BGR888 = 24,
+	//
+	// 16.7M (32-bit) true colour; 8 bits per red/blue/green component;
+	// stored as packed uint32 data with highest 8 bits unused
+	BGRX8888 = 32
+};
+
 struct Render_t {
 	// Details about the rendered image.
 	// E.g. for the 320x200 256-colour 13h VGA mode with double-scanning

--- a/include/render.h
+++ b/include/render.h
@@ -25,6 +25,7 @@
 
 #include "../src/gui/render_scalers.h"
 #include "fraction.h"
+#include "vga.h"
 
 struct RenderPal_t {
 	struct {
@@ -84,8 +85,8 @@ struct Render_t {
 
 		uint32_t start = 0;
 
-		// Pixel format of the image data (see `bpp` in vga.h for details)
-		uint8_t bpp = 0;
+		// Pixel format of the image data
+		PixelFormat bpp = {};
 
 		// Frames per second
 		double fps = 0;
@@ -175,8 +176,8 @@ struct RenderedImage {
 	// aspect ratio of the source video mode)
 	Fraction pixel_aspect_ratio = {};
 
-	// Pixel format of the image data (see `bpp` in vga.h for details)
-	uint8_t bits_per_pixel = 0;
+	// Pixel format of the image data
+	PixelFormat bits_per_pixel = {};
 
 	// Bytes per row
 	uint16_t pitch = 0;
@@ -192,7 +193,7 @@ struct RenderedImage {
 
 	inline bool is_paletted() const
 	{
-		return (bits_per_pixel == 8);
+		return (bits_per_pixel == PixelFormat::Indexed8);
 	}
 
 	RenderedImage deep_copy() const
@@ -236,7 +237,7 @@ std::deque<std::string> RENDER_InventoryShaders();
 void RENDER_SetSize(const uint16_t width, const uint16_t height,
                     const bool double_width, const bool double_height,
                     const Fraction& render_pixel_aspect_ratio,
-                    const uint8_t bits_per_pixel,
+                    const PixelFormat bits_per_pixel,
                     const double frames_per_second, const VideoMode& video_mode);
 
 bool RENDER_StartUpdate(void);

--- a/include/render.h
+++ b/include/render.h
@@ -76,6 +76,8 @@ enum class PixelFormat : uint8_t {
 
 const char* to_string(const PixelFormat pf);
 
+uint8_t get_bits_per_pixel(const PixelFormat pf);
+
 struct Render_t {
 	// Details about the rendered image.
 	// E.g. for the 320x200 256-colour 13h VGA mode with double-scanning

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -142,7 +142,7 @@ struct SDL_Block {
 			int height = 0;
 		} requested_window_bounds = {};
 
-		PixelFormat bpp = {};
+		PixelFormat pixel_format = {};
 		double dpi_scale = 1.0;
 		bool fullscreen = false;
 

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -142,7 +142,7 @@ struct SDL_Block {
 			int height = 0;
 		} requested_window_bounds = {};
 
-		uint8_t bpp = 0;
+		PixelFormat bpp = {};
 		double dpi_scale = 1.0;
 		bool fullscreen = false;
 

--- a/include/vga.h
+++ b/include/vga.h
@@ -224,27 +224,7 @@ enum PixelsPerChar : int8_t {
 	Nine  = 9,
 };
 
-enum class PixelFormat : uint8_t {
-	// Up to 256 colours, paletted;
-	// stored as packed uint8 data
-	Indexed8 = 8,
-
-	// 32K high colour, 5 bits per red/blue/green component;
-	// stored as packed uint16 data with highest bit unused
-	BGR555 = 15,
-	//
-	// 65K high colour, 5 bits for red/blue, 6 bit for green;
-	// stored as packed uint16 data
-	BGR565 = 16,
-	//
-	// 16.7M (24-bit) true colour, 8 bits per red/blue/green component;
-	// stored as packed 24-bit data
-	BGR888 = 24,
-	//
-	// 16.7M (32-bit) true colour; 8 bits per red/blue/green component;
-	// stored as packed uint32 data with highest 8 bits unused
-	BGRX8888 = 32
-};
+enum class PixelFormat : uint8_t;
 
 struct VGA_Draw {
 	bool resizing   = false;

--- a/include/vga.h
+++ b/include/vga.h
@@ -288,7 +288,7 @@ struct VGA_Draw {
 		double per_line_ms = 0;
 	} delay = {};
 
-	PixelFormat bpp = {};
+	PixelFormat pixel_format = {};
 
 	double host_refresh_hz = RefreshRateHostDefault;
 	double dos_refresh_hz = RefreshRateDosDefault;

--- a/include/vga.h
+++ b/include/vga.h
@@ -224,6 +224,28 @@ enum PixelsPerChar : int8_t {
 	Nine  = 9,
 };
 
+enum class PixelFormat : uint8_t {
+	// Up to 256 colours, paletted;
+	// stored as packed uint8 data
+	Indexed8 = 8,
+
+	// 32K high colour, 5 bits per red/blue/green component;
+	// stored as packed uint16 data with highest bit unused
+	BGR555 = 15,
+	//
+	// 65K high colour, 5 bits for red/blue, 6 bit for green;
+	// stored as packed uint16 data
+	BGR565 = 16,
+	//
+	// 16.7M (24-bit) true colour, 8 bits per red/blue/green component;
+	// stored as packed 24-bit data
+	BGR888 = 24,
+	//
+	// 16.7M (32-bit) true colour; 8 bits per red/blue/green component;
+	// stored as packed uint32 data with highest 8 bits unused
+	BGRX8888 = 32
+};
+
 struct VGA_Draw {
 	bool resizing   = false;
 	uint16_t width  = 0;
@@ -266,30 +288,7 @@ struct VGA_Draw {
 		double per_line_ms = 0;
 	} delay = {};
 
-	// clang-format off
-	//
-	// Non-paletted RGB image data is stored as a continuous stream of BGR
-	// pixel values in memory.
-	//
-	// Valid values are the following:
-	//
-	//  8 - Indexed8   Up to 256 colours, paletted;
-	//                 stored as packed uint8 data
-	//
-	// 15 - BGR555     32K high colour, 5 bits per red/blue/green component;
-	//                 stored as packed uint16 data with highest bit unused
-	//
-	// 16 - BGR565     65K high colour, 5 bits for red/blue, 6 bit for green;
-	//                 stored as packed uint16 data
-	//
-	// 24 - BGR888     16.7M (24-bit) true colour, 8 bits per red/blue/green component;
-	//                 stored as packed 24-bit data
-	//
-	// 32 - BGRX8888   16.7M (32-bit) true colour; 8 bits per red/blue/green component;
-	//                 stored as packed uint32 data with highest 8 bits unused
-	//
-	// clang-format on
-	uint8_t bpp = 0;
+	PixelFormat bpp = {};
 
 	double host_refresh_hz = RefreshRateHostDefault;
 	double dos_refresh_hz = RefreshRateDosDefault;
@@ -999,7 +998,7 @@ void VGA_StartUpdateLFB(void);
 void VGA_SetBlinking(uint8_t enabled);
 void VGA_SetCGA2Table(uint8_t val0,uint8_t val1);
 void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3);
-uint8_t VGA_ActivateHardwareCursor();
+PixelFormat VGA_ActivateHardwareCursor();
 void VGA_KillDrawing(void);
 
 void VGA_SetOverride(bool vga_override);

--- a/src/capture/image/image_decoder.cpp
+++ b/src/capture/image/image_decoder.cpp
@@ -29,10 +29,6 @@ void ImageDecoder::Init(const RenderedImage& image, const uint8_t row_skip_count
 	assert(image.width > 0);
 	assert(image.height > 0);
 
-	assert(image.bits_per_pixel == 8 || image.bits_per_pixel == 15 ||
-	       image.bits_per_pixel == 16 || image.bits_per_pixel == 24 ||
-	       image.bits_per_pixel == 32);
-
 	assert(image.pitch >= image.width);
 	assert(image.pixel_aspect_ratio.ToDouble() >= 0.0);
 	assert(image.image_data);

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -31,6 +31,7 @@
 #include "rgb565.h"
 #include "rgb888.h"
 #include "support.h"
+#include "vga.h"
 
 class ImageDecoder {
 public:
@@ -77,19 +78,11 @@ private:
 	inline void IncrementPos()
 	{
 		switch (image.bits_per_pixel) {
-		case 8: // Indexed8
-			++pos;
-			break;
-		case 15: // BGR555
-		case 16: // BGR565
-			pos += 2;
-			break;
-		case 24: // BGR888
-			pos += 3;
-			break;
-		case 32: // XBGR8888
-			pos += 4;
-			break;
+		case PixelFormat::Indexed8: ++pos; break;
+		case PixelFormat::BGR555:
+		case PixelFormat::BGR565: pos += 2; break;
+		case PixelFormat::BGR888: pos += 3; break;
+		case PixelFormat::BGRX8888: pos += 4; break;
 		default: assertm(false, "Invalid bits_per_pixel value");
 		}
 	}
@@ -112,20 +105,20 @@ private:
 		Rgb888 pixel = {};
 
 		switch (image.bits_per_pixel) {
-		case 15: { // BGR555
+		case PixelFormat::BGR555: {
 			const auto p = host_to_le(
 			        *reinterpret_cast<const uint16_t*>(pos));
 			pixel = Rgb555(p).ToRgb888();
 		} break;
 
-		case 16: { // BGR565
+		case PixelFormat::BGR565: {
 			const auto p = host_to_le(
 			        *reinterpret_cast<const uint16_t*>(pos));
 			pixel = Rgb565(p).ToRgb888();
 		} break;
 
-		case 24:   // BGR888
-		case 32: { // XBGR8888
+		case PixelFormat::BGR888:
+		case PixelFormat::BGRX8888: {
 			const auto b = *(pos + 0);
 			const auto g = *(pos + 1);
 			const auto r = *(pos + 2);

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -77,13 +77,13 @@ private:
 
 	inline void IncrementPos()
 	{
-		switch (image.bits_per_pixel) {
+		switch (image.pixel_format) {
 		case PixelFormat::Indexed8: ++pos; break;
 		case PixelFormat::BGR555:
 		case PixelFormat::BGR565: pos += 2; break;
 		case PixelFormat::BGR888: pos += 3; break;
 		case PixelFormat::BGRX8888: pos += 4; break;
-		default: assertm(false, "Invalid bits_per_pixel value");
+		default: assertm(false, "Invalid pixel_format value");
 		}
 	}
 
@@ -104,7 +104,7 @@ private:
 	{
 		Rgb888 pixel = {};
 
-		switch (image.bits_per_pixel) {
+		switch (image.pixel_format) {
 		case PixelFormat::BGR555: {
 			const auto p = host_to_le(
 			        *reinterpret_cast<const uint16_t*>(pos));
@@ -125,7 +125,7 @@ private:
 
 			pixel = {r, g, b};
 		} break;
-		default: assertm(false, "Invalid bits_per_pixel value");
+		default: assertm(false, "Invalid pixel_format value");
 		}
 
 		IncrementPos();

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -131,7 +131,7 @@ static void write_upscaled_png(FILE* outfile, PngWriter& png_writer,
                                const uint8_t* palette_data)
 {
 	switch (image_scaler.GetOutputPixelFormat()) {
-	case PixelFormat::Indexed8:
+	case OutputPixelFormat::Indexed8:
 		if (!png_writer.InitIndexed8(outfile,
 		                             width,
 		                             height,
@@ -141,7 +141,7 @@ static void write_upscaled_png(FILE* outfile, PngWriter& png_writer,
 			return;
 		}
 		break;
-	case PixelFormat::Rgb888:
+	case OutputPixelFormat::Rgb888:
 		if (!png_writer.InitRgb888(
 		            outfile, width, height, pixel_aspect_ratio, video_mode)) {
 			return;

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -162,7 +162,7 @@ void ImageScaler::LogParams()
 	        "    input.double_width:         %10s\n"
 	        "    input.double_height:        %10s\n"
 	        "    input.PAR:                  1:%1.6f (%d:%d)\n"
-	        "    input.bits_per_pixel:       %10d\n"
+	        "    input.pixel_format:         %10d\n"
 	        "    input.pitch:                %10d\n"
 	        "    --------------------------------------\n"
 	        "    video_mode.width:           %10d\n"
@@ -183,7 +183,7 @@ void ImageScaler::LogParams()
 	        input.pixel_aspect_ratio.Inverse().ToDouble(),
 	        static_cast<int32_t>(input.pixel_aspect_ratio.Num()),
 	        static_cast<int32_t>(input.pixel_aspect_ratio.Denom()),
-	        enum_val(input.bits_per_pixel),
+	        enum_val(input.pixel_format),
 	        input.pitch,
 
 	        video_mode.width,

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -162,7 +162,7 @@ void ImageScaler::LogParams()
 	        "    input.double_width:         %10s\n"
 	        "    input.double_height:        %10s\n"
 	        "    input.PAR:                  1:%1.6f (%d:%d)\n"
-	        "    input.pixel_format:         %10d\n"
+	        "    input.pixel_format:         %10s\n"
 	        "    input.pitch:                %10d\n"
 	        "    --------------------------------------\n"
 	        "    video_mode.width:           %10d\n"
@@ -183,7 +183,7 @@ void ImageScaler::LogParams()
 	        input.pixel_aspect_ratio.Inverse().ToDouble(),
 	        static_cast<int32_t>(input.pixel_aspect_ratio.Num()),
 	        static_cast<int32_t>(input.pixel_aspect_ratio.Denom()),
-	        enum_val(input.pixel_format),
+	        to_string(input.pixel_format),
 	        input.pitch,
 
 	        video_mode.width,

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -70,8 +70,8 @@ void ImageScaler::UpdateOutputParamsUpscale()
 
 	output.vert_scaling_mode = PerAxisScaling::Integer;
 
-	// Adjusting for a few special modes where the rendered width is twice the
-	// video mode width:
+	// Adjusting for a few special modes where the rendered width is twice
+	// the video mode width:
 	// - The Tandy/PCjr 160x200 is rendered as 320x200
 	// - The Tandy 640x200 4-colour composite mode is rendered as 1280x200
 	assert(input.width % video_mode.width == 0);
@@ -129,9 +129,9 @@ void ImageScaler::UpdateOutputParamsUpscale()
 	         (output.vert_scaling_mode == PerAxisScaling::Integer));
 
 	if (only_integer_scaling && input.is_paletted()) {
-		output.pixel_format = PixelFormat::Indexed8;
+		output.pixel_format = OutputPixelFormat::Indexed8;
 	} else {
-		output.pixel_format = PixelFormat::Rgb888;
+		output.pixel_format = OutputPixelFormat::Rgb888;
 	}
 
 	output.curr_row   = 0;
@@ -140,10 +140,10 @@ void ImageScaler::UpdateOutputParamsUpscale()
 
 void ImageScaler::LogParams()
 {
-	auto pixel_format_to_string = [](const PixelFormat pf) -> std::string {
+	auto pixel_format_to_string = [](const OutputPixelFormat pf) -> std::string {
 		switch (pf) {
-		case PixelFormat::Indexed8: return "Indexed8";
-		case PixelFormat::Rgb888: return "RGB888";
+		case OutputPixelFormat::Indexed8: return "Indexed8";
+		case OutputPixelFormat::Rgb888: return "RGB888";
 		default: assert(false); return {};
 		}
 	};
@@ -183,7 +183,7 @@ void ImageScaler::LogParams()
 	        input.pixel_aspect_ratio.Inverse().ToDouble(),
 	        static_cast<int32_t>(input.pixel_aspect_ratio.Num()),
 	        static_cast<int32_t>(input.pixel_aspect_ratio.Denom()),
-	        input.bits_per_pixel,
+	        enum_val(input.bits_per_pixel),
 	        input.pitch,
 
 	        video_mode.width,
@@ -205,8 +205,8 @@ void ImageScaler::AllocateBuffers()
 {
 	uint8_t bytes_per_pixel = {};
 	switch (output.pixel_format) {
-	case PixelFormat::Indexed8: bytes_per_pixel = 8; break;
-	case PixelFormat::Rgb888: bytes_per_pixel = 24; break;
+	case OutputPixelFormat::Indexed8: bytes_per_pixel = 8; break;
+	case OutputPixelFormat::Rgb888: bytes_per_pixel = 24; break;
 	default: assert(false);
 	}
 
@@ -229,7 +229,7 @@ uint16_t ImageScaler::GetOutputHeight() const
 	return output.height;
 }
 
-PixelFormat ImageScaler::GetOutputPixelFormat() const
+OutputPixelFormat ImageScaler::GetOutputPixelFormat() const
 {
 	return output.pixel_format;
 }

--- a/src/capture/image/image_scaler.h
+++ b/src/capture/image/image_scaler.h
@@ -28,7 +28,7 @@
 #include "render.h"
 #include "rgb888.h"
 
-enum class PixelFormat { Indexed8, Rgb888 };
+enum class OutputPixelFormat { Indexed8, Rgb888 };
 
 enum class PerAxisScaling { Integer, Fractional };
 
@@ -87,7 +87,7 @@ public:
 
 	uint16_t GetOutputWidth() const;
 	uint16_t GetOutputHeight() const;
-	PixelFormat GetOutputPixelFormat() const;
+	OutputPixelFormat GetOutputPixelFormat() const;
 
 	// prevent copying
 	ImageScaler(const ImageScaler&) = delete;
@@ -125,7 +125,7 @@ private:
 		PerAxisScaling horiz_scaling_mode = {};
 		PerAxisScaling vert_scaling_mode  = {};
 
-		PixelFormat pixel_format = {};
+		OutputPixelFormat pixel_format = {};
 
 		uint16_t curr_row  = 0;
 		uint8_t row_repeat = 0;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -51,6 +51,18 @@
 Render_t render;
 ScalerLineHandler_t RENDER_DrawLine;
 
+const char* to_string(const PixelFormat pf)
+{
+	switch (pf) {
+	case PixelFormat::Indexed8: return "Indexed8";
+	case PixelFormat::BGR555: return "BGR555";
+	case PixelFormat::BGR565: return "BGR565";
+	case PixelFormat::BGR888: return "BGR888";
+	case PixelFormat::BGRX8888: return "BGRX8888";
+	default: assertm(false, "Invalid pixel format"); return {};
+	}
+}
+
 static void render_callback(GFX_CallBackFunctions_t function);
 
 static void check_palette(void)

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -63,6 +63,10 @@ const char* to_string(const PixelFormat pf)
 	}
 }
 
+uint8_t get_bits_per_pixel(const PixelFormat pf) {
+	return enum_val(pf);
+}
+
 static void render_callback(GFX_CallBackFunctions_t function);
 
 static void check_palette(void)
@@ -479,7 +483,7 @@ static void render_reset(void)
 		break;
 	default:
 		E_Exit("RENDER: Invalid pixel_format %u",
-		       enum_val(render.src.pixel_format));
+		       static_cast<uint8_t>(render.src.pixel_format));
 	}
 
 	render.scale.blocks    = render.src.width / SCALER_BLOCKSIZE;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -368,20 +368,20 @@ static void render_reset(void)
 	yscale    = simpleBlock->yscale;
 	//		LOG_MSG("Scaler:%s",simpleBlock->name);
 	switch (render.src.bpp) {
-	case 8: render.src.start = (render.src.width * 1) / sizeof(Bitu); break;
-	case 15:
+	case PixelFormat::Indexed8: render.src.start = (render.src.width * 1) / sizeof(Bitu); break;
+	case PixelFormat::BGR555:
 		render.src.start = (render.src.width * 2) / sizeof(Bitu);
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
-	case 16:
+	case PixelFormat::BGR565:
 		render.src.start = (render.src.width * 2) / sizeof(Bitu);
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
-	case 24:
+	case PixelFormat::BGR888:
 		render.src.start = (render.src.width * 3) / sizeof(Bitu);
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
-	case 32:
+	case PixelFormat::BGRX8888:
 		render.src.start = (render.src.width * 4) / sizeof(Bitu);
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
@@ -430,37 +430,37 @@ static void render_reset(void)
 	const auto lineBlock = gfx_flags & GFX_CAN_RANDOM ? &simpleBlock->Random
 	                                                  : &simpleBlock->Linear;
 	switch (render.src.bpp) {
-	case 8:
+	case PixelFormat::Indexed8:
 		render.scale.lineHandler = (*lineBlock)[0][render.scale.outMode];
 		render.scale.linePalHandler = (*lineBlock)[5][render.scale.outMode];
 		render.scale.inMode     = scalerMode8;
 		render.scale.cachePitch = render.src.width * 1;
 		break;
-	case 15:
+	case PixelFormat::BGR555:
 		render.scale.lineHandler = (*lineBlock)[1][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode15;
 		render.scale.cachePitch     = render.src.width * 2;
 		break;
-	case 16:
+	case PixelFormat::BGR565:
 		render.scale.lineHandler = (*lineBlock)[2][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode16;
 		render.scale.cachePitch     = render.src.width * 2;
 		break;
-	case 24:
+	case PixelFormat::BGR888:
 		render.scale.lineHandler = (*lineBlock)[3][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode32;
 		render.scale.cachePitch     = render.src.width * 3;
 		break;
-	case 32:
+	case PixelFormat::BGRX8888:
 		render.scale.lineHandler = (*lineBlock)[4][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode32;
 		render.scale.cachePitch     = render.src.width * 4;
 		break;
-	default: E_Exit("RENDER:Wrong source bpp %u", render.src.bpp);
+	default: E_Exit("RENDER:Wrong source bpp %u", enum_val(render.src.bpp));
 	}
 	render.scale.blocks    = render.src.width / SCALER_BLOCKSIZE;
 	render.scale.lastBlock = render.src.width % SCALER_BLOCKSIZE;
@@ -500,7 +500,7 @@ static void render_callback(GFX_CallBackFunctions_t function)
 void RENDER_SetSize(const uint16_t width, const uint16_t height,
                     const bool double_width, const bool double_height,
                     const Fraction& render_pixel_aspect_ratio,
-                    const uint8_t bits_per_pixel,
+                    const PixelFormat bits_per_pixel,
                     const double frames_per_second, const VideoMode& video_mode)
 {
 	halt_render();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -662,7 +662,7 @@ Bitu GFX_GetBestMode(Bitu flags)
 	switch (sdl.desktop.want_type) {
 	case SCREEN_SURFACE:
 	check_surface:
-		switch (sdl.desktop.bpp) {
+		switch (sdl.desktop.pixel_format) {
 		case PixelFormat::Indexed8:
 			if (flags & GFX_CAN_8) flags&=~(GFX_CAN_15|GFX_CAN_16|GFX_CAN_32);
 			break;
@@ -1784,7 +1784,7 @@ dosurface:
 				                           FIXED_SIZE);
 				if (sdl.window == nullptr) {
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
-					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.bpp),
+					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.pixel_format),
 					       SDL_GetError());
 				}
 
@@ -1804,7 +1804,7 @@ dosurface:
 				                           FIXED_SIZE);
 				if (sdl.window == nullptr) {
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
-					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.bpp),
+					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.pixel_format),
 					       SDL_GetError());
 				}
 			}
@@ -1819,7 +1819,7 @@ dosurface:
 			                           FIXED_SIZE);
 			if (sdl.window == nullptr) {
 				E_Exit("Could not set windowed video mode %ix%i-%i: %s",
-				       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.bpp),
+				       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.pixel_format),
 				       SDL_GetError());
 			}
 		}
@@ -2596,8 +2596,8 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 		image.double_height         = false;
 		image.is_flipped_vertically = false;
 		image.pixel_aspect_ratio    = {1};
-		image.bits_per_pixel        = PixelFormat::BGR888;
-		image.pitch        = image.width * (enum_val(image.bits_per_pixel) / 8);
+		image.pixel_format          = PixelFormat::BGR888;
+		image.pitch = image.width * (enum_val(image.pixel_format) / 8);
 		image.palette_data = nullptr;
 
 		const auto image_size_bytes = check_cast<uint32_t>(image.height *

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -663,17 +663,17 @@ Bitu GFX_GetBestMode(Bitu flags)
 	case SCREEN_SURFACE:
 	check_surface:
 		switch (sdl.desktop.bpp) {
-		case 8:
+		case PixelFormat::Indexed8:
 			if (flags & GFX_CAN_8) flags&=~(GFX_CAN_15|GFX_CAN_16|GFX_CAN_32);
 			break;
-		case 15:
+		case PixelFormat::BGR555:
 			if (flags & GFX_CAN_15) flags&=~(GFX_CAN_8|GFX_CAN_16|GFX_CAN_32);
 			break;
-		case 16:
+		case PixelFormat::BGR565:
 			if (flags & GFX_CAN_16) flags&=~(GFX_CAN_8|GFX_CAN_15|GFX_CAN_32);
 			break;
-		case 24:
-		case 32:
+		case PixelFormat::BGR888:
+		case PixelFormat::BGRX8888:
 			if (flags & GFX_CAN_32) flags&=~(GFX_CAN_8|GFX_CAN_15|GFX_CAN_16);
 			break;
 		}
@@ -1784,7 +1784,7 @@ dosurface:
 				                           FIXED_SIZE);
 				if (sdl.window == nullptr) {
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
-					       sdl.clip.w, sdl.clip.h, sdl.desktop.bpp,
+					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.bpp),
 					       SDL_GetError());
 				}
 
@@ -1804,7 +1804,7 @@ dosurface:
 				                           FIXED_SIZE);
 				if (sdl.window == nullptr) {
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
-					       sdl.clip.w, sdl.clip.h, sdl.desktop.bpp,
+					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.bpp),
 					       SDL_GetError());
 				}
 			}
@@ -1819,7 +1819,7 @@ dosurface:
 			                           FIXED_SIZE);
 			if (sdl.window == nullptr) {
 				E_Exit("Could not set windowed video mode %ix%i-%i: %s",
-				       sdl.clip.w, sdl.clip.h, sdl.desktop.bpp,
+				       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.bpp),
 				       SDL_GetError());
 			}
 		}
@@ -2596,8 +2596,8 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 		image.double_height         = false;
 		image.is_flipped_vertically = false;
 		image.pixel_aspect_ratio    = {1};
-		image.bits_per_pixel        = 24;
-		image.pitch        = image.width * (image.bits_per_pixel / 8);
+		image.bits_per_pixel        = PixelFormat::BGR888;
+		image.pitch        = image.width * (enum_val(image.bits_per_pixel) / 8);
 		image.palette_data = nullptr;
 
 		const auto image_size_bytes = check_cast<uint32_t>(image.height *

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1784,7 +1784,9 @@ dosurface:
 				                           FIXED_SIZE);
 				if (sdl.window == nullptr) {
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
-					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.pixel_format),
+					       sdl.clip.w,
+					       sdl.clip.h,
+					       get_bits_per_pixel(sdl.desktop.pixel_format),
 					       SDL_GetError());
 				}
 
@@ -1804,7 +1806,9 @@ dosurface:
 				                           FIXED_SIZE);
 				if (sdl.window == nullptr) {
 					E_Exit("Could not set fullscreen video mode %ix%i-%i: %s",
-					       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.pixel_format),
+					       sdl.clip.w,
+					       sdl.clip.h,
+					       get_bits_per_pixel(sdl.desktop.pixel_format),
 					       SDL_GetError());
 				}
 			}
@@ -1819,7 +1823,9 @@ dosurface:
 			                           FIXED_SIZE);
 			if (sdl.window == nullptr) {
 				E_Exit("Could not set windowed video mode %ix%i-%i: %s",
-				       sdl.clip.w, sdl.clip.h, enum_val(sdl.desktop.pixel_format),
+				       sdl.clip.w,
+				       sdl.clip.h,
+				       get_bits_per_pixel(sdl.desktop.pixel_format),
 				       SDL_GetError());
 			}
 		}
@@ -2597,7 +2603,10 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 		image.is_flipped_vertically = false;
 		image.pixel_aspect_ratio    = {1};
 		image.pixel_format          = PixelFormat::BGR888;
-		image.pitch = image.width * (enum_val(image.pixel_format) / 8);
+
+		image.pitch = image.width *
+		              (get_bits_per_pixel(image.pixel_format) / 8);
+
 		image.palette_data = nullptr;
 
 		const auto image_size_bytes = check_cast<uint32_t>(image.height *

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2526,7 +2526,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	vga.draw.vblank_skip = vblank_skip;
 	setup_line_drawing_delays(render_height);
-	vga.draw.line_length = render_width * ((enum_val(pixel_format) + 1) / 8);
+
+	vga.draw.line_length = render_width *
+	                       ((get_bits_per_pixel(pixel_format) + 1) / 8);
+
 #ifdef VGA_KEEP_CHANGES
 	vga.changes.active    = false;
 	vga.changes.frame     = 0;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -956,11 +956,11 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 			bg_color_index = 0;
 			break;
 		}
-		if (vga.draw.bpp == PixelFormat::Indexed8) {
+		if (vga.draw.pixel_format == PixelFormat::Indexed8) {
 			std::fill(templine_buffer.begin(),
 			          templine_buffer.end(),
 			          bg_color_index);
-		} else if (vga.draw.bpp == PixelFormat::BGR565) {
+		} else if (vga.draw.pixel_format == PixelFormat::BGR565) {
 			const auto background_color = from_rgb_888_to_565(
 			        vga.dac.palette_map[bg_color_index]);
 			const auto line_length = templine_buffer.size() / sizeof(uint16_t);
@@ -968,7 +968,7 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 			while (i < line_length) {
 				write_unaligned_uint16_at(TempLine, i++, background_color);
 			}
-		} else if (vga.draw.bpp == PixelFormat::BGRX8888) {
+		} else if (vga.draw.pixel_format == PixelFormat::BGRX8888) {
 			const auto background_color = vga.dac.palette_map[bg_color_index];
 			const auto line_length = templine_buffer.size() / sizeof(uint32_t);
 			size_t i = 0;
@@ -1943,16 +1943,16 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	Fraction render_pixel_aspect_ratio = {1};
 
-	PixelFormat bpp;
+	PixelFormat pixel_format;
 	switch (vga.mode) {
-	case M_LIN15: bpp = PixelFormat::BGR555; break;
-	case M_LIN16: bpp = PixelFormat::BGR565; break;
-	case M_LIN24: bpp = PixelFormat::BGR888; break;
+	case M_LIN15: pixel_format = PixelFormat::BGR555; break;
+	case M_LIN16: pixel_format = PixelFormat::BGR565; break;
+	case M_LIN24: pixel_format = PixelFormat::BGR888; break;
 	case M_LIN32:
 	case M_CGA2_COMPOSITE:
 	case M_CGA4_COMPOSITE:
-	case M_CGA_TEXT_COMPOSITE: bpp = PixelFormat::BGRX8888; break;
-	default: bpp = PixelFormat::Indexed8; break;
+	case M_CGA_TEXT_COMPOSITE: pixel_format = PixelFormat::BGRX8888; break;
+	default: pixel_format = PixelFormat::Indexed8; break;
 	}
 
 	switch (vga.mode) {
@@ -2045,7 +2045,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			VGA_DrawLine = VGA_Draw_Linear_Line;
 		} else {
 			// Use HW mouse cursor drawer if enabled
-			bpp = VGA_ActivateHardwareCursor();
+			pixel_format = VGA_ActivateHardwareCursor();
 		}
 	} break;
 
@@ -2104,7 +2104,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			// The ReelMagic video mixer expects linear VGA drawing
 			// (i.e.: Return to Zork's house intro), so limit the use
 			// of 18-bit palettized LUT routine to non-mixed output.
-			bpp = PixelFormat::BGRX8888;
+			pixel_format = PixelFormat::BGRX8888;
 
 			VGA_DrawLine = draw_linear_line_from_dac_palette;
 		} else {
@@ -2160,7 +2160,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		}
 
 		if (IS_VGA_ARCH) {
-			bpp = PixelFormat::BGRX8888;
+			pixel_format = PixelFormat::BGRX8888;
 
 			VGA_DrawLine = draw_linear_line_from_dac_palette;
 		} else {
@@ -2400,7 +2400,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			vga.draw.pixels_per_character = vga.seq.clocking_mode.is_eight_dot_mode
 			                                      ? PixelsPerChar::Eight
 			                                      : PixelsPerChar::Nine;
-			bpp = PixelFormat::BGRX8888;
+			pixel_format = PixelFormat::BGRX8888;
 
 			VGA_DrawLine = draw_text_line_from_dac_palette;
 
@@ -2526,7 +2526,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	vga.draw.vblank_skip = vblank_skip;
 	setup_line_drawing_delays(render_height);
-	vga.draw.line_length = render_width * ((enum_val(bpp) + 1) / 8);
+	vga.draw.line_length = render_width * ((enum_val(pixel_format) + 1) / 8);
 #ifdef VGA_KEEP_CHANGES
 	vga.changes.active    = false;
 	vga.changes.frame     = 0;
@@ -2600,7 +2600,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	    (vga.draw.doublewidth != double_width) ||
 	    (vga.draw.doubleheight != double_height) ||
 	    (vga.draw.pixel_aspect_ratio != render_pixel_aspect_ratio) ||
-	    (vga.draw.bpp != bpp) || fps_changed) {
+	    (vga.draw.pixel_format != pixel_format) || fps_changed) {
 		VGA_KillDrawing();
 
 		if (render_width > SCALER_MAXWIDTH ||
@@ -2621,7 +2621,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		vga.draw.doublewidth        = double_width;
 		vga.draw.doubleheight       = double_height;
 		vga.draw.pixel_aspect_ratio = render_pixel_aspect_ratio;
-		vga.draw.bpp                = bpp;
+		vga.draw.pixel_format       = pixel_format;
 
 		if (double_height) {
 			vga.draw.lines_scaled = 2;
@@ -2635,7 +2635,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			                         double_width,
 			                         double_height,
 			                         render_pixel_aspect_ratio,
-			                         bpp,
+			                         pixel_format,
 			                         fps,
 			                         video_mode);
 		}

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7365,7 +7365,6 @@ static void Voodoo_UpdateScreen()
 
 			constexpr Fraction render_pixel_aspect_ratio = {1};
 
-			constexpr uint8_t bits_per_pixel = 16;
 			const auto frames_per_second  = 1000.0f / v->draw.vfreq;
 
 			const VideoMode video_mode = {check_cast<uint16_t>(width),
@@ -7377,7 +7376,7 @@ static void Voodoo_UpdateScreen()
 			               double_width,
 			               double_height,
 			               render_pixel_aspect_ratio,
-			               bits_per_pixel,
+			               PixelFormat::BGR565,
 			               frames_per_second,
 			               video_mode);
 		}


### PR DESCRIPTION
Ok, so learning from my recent experience with clinically obese PRs 😅, from now on I'm trying to raise multiple smaller ones for refactoring jobs that can be well-separated.

The `bpp` (bits per pixel) thing has been bothering me for quite some time now — it really should be an enum, and it should be a pixel format descriptor rather than just a number. Well, now it is 😎 

Tested with a few games (CGA/EGA/VGA/Tandy), demos, and Return to Zork (to make sure I did not break ReelMagic that had some weird `bpp == 0` init hack that luckily wasn't doing anything useful, apparently), plus checked the image & video capture features for regressions. Everything is hunky-dory 😄 (except for https://github.com/dosbox-staging/dosbox-staging/issues/2734, but I broke that one a while ago; that's unrelated to this change).