### PR TITLE
Rendering related refactorings

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -87,6 +87,22 @@ inline int iroundf(const float x)
 	return static_cast<int>(roundf(x));
 }
 
+inline int ifloor(double x)
+{
+	assert(std::isfinite(x));
+	assert(x >= (std::numeric_limits<int>::min)());
+	assert(x <= (std::numeric_limits<int>::max)());
+	return static_cast<int>(floor(x));
+}
+
+inline int ifloor(const float x)
+{
+	assert(std::isfinite(x));
+	assert(x >= static_cast<float>((std::numeric_limits<int>::min)()));
+	assert(x <= static_cast<float>((std::numeric_limits<int>::max)()));
+	return static_cast<int>(floorf(x));
+}
+
 // Left-shifts a signed value by a given amount, with overflow detection
 template <typename T1, typename T2>
 constexpr T1 left_shift_signed(T1 value, T2 amount)

--- a/include/render.h
+++ b/include/render.h
@@ -46,12 +46,6 @@ struct RenderPal_t {
 	uint32_t last         = 0;
 };
 
-struct VideoMode {
-	uint16_t width              = 0;
-	uint16_t height             = 0;
-	Fraction pixel_aspect_ratio = {};
-};
-
 enum class PixelFormat : uint8_t {
 	// Up to 256 colours, paletted;
 	// stored as packed uint8 data

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -25,9 +25,12 @@
 #include <string_view>
 #include <string.h>
 #include "SDL.h"
+
 #if C_OPENGL
 #include <SDL_opengl.h>
 #endif
+
+#include "fraction.h"
 #include "render.h"
 #include "video.h"
 
@@ -106,8 +109,7 @@ struct SDL_Block {
 	struct {
 		int width = 0;
 		int height = 0;
-		double scalex = 1.0;
-		double scaley = 1.0;
+		Fraction render_pixel_aspect_ratio = {1};
 
 		uint16_t previous_mode = 0;
 		bool has_changed = false;

--- a/include/vga.h
+++ b/include/vga.h
@@ -21,6 +21,7 @@
 
 #include "dosbox.h"
 
+#include <string>
 #include <utility>
 
 #include "bit_view.h"
@@ -114,11 +115,51 @@ enum VGAModes {
 	M_ERROR = 1 << 31,
 };
 
+// Graphics standards ordered by time of introduction (and roughly by
+// their capabilities)
+enum class GraphicsStandard { Hercules, Cga, Pcjr, Tga, Ega, Vga, Svga, Vesa };
+
+const char* to_string(const GraphicsStandard g);
+
+enum class ColorDepth {
+	Monochrome,
+	Composite,
+	IndexedColor2,
+	IndexedColor4,
+	IndexedColor16,
+	IndexedColor256,
+	HighColor15Bit,
+	HighColor16Bit,
+	TrueColor24Bit
+};
+
+const char* to_string(const ColorDepth c);
+
 struct VideoMode {
+	// Only reliable for non-custom BIOS modes; for custom modes, it's the
+	// mode used as a starting point to set up the tweaked mode, so it can
+	// be literally anything.
+	uint16_t bios_mode_number = 0;
+
+	bool is_graphics_mode = false;
+
+	// True for tweaked non-standard modes (e.g., Mode X on VGA).
+	bool is_custom_mode = false;
+
 	uint16_t width              = 0;
 	uint16_t height             = 0;
 	Fraction pixel_aspect_ratio = {};
+
+	// - For graphics modes, the first graphics standard the mode was
+	//   introduced in, unless there is ambiguity, in which case the emulated
+	//   graphics adapter (e.g. in the case of PCjr and Tandy modes).
+	// - For text modes, the graphics adapter in use.
+	GraphicsStandard graphics_standard = {};
+
+	ColorDepth color_depth = {};
 };
+
+std::string to_string(const VideoMode& video_mode);
 
 constexpr auto M_TEXT_MODES = M_TEXT | M_HERC_TEXT | M_TANDY_TEXT | M_CGA_TEXT_COMPOSITE;
 
@@ -928,7 +969,7 @@ void VGA_SetMonoPalette(const char *colour);
 void VGA_SetMode(VGAModes mode);
 void VGA_DetermineMode(void);
 void VGA_SetupHandlers(void);
-std::string VGA_ModeToString(const VGAModes mode);
+const char* to_string(const VGAModes mode);
 
 void VGA_StartResize();
 void VGA_StartResizeAfter(const uint16_t delay_ms);

--- a/include/vga.h
+++ b/include/vga.h
@@ -114,6 +114,12 @@ enum VGAModes {
 	M_ERROR = 1 << 31,
 };
 
+struct VideoMode {
+	uint16_t width              = 0;
+	uint16_t height             = 0;
+	Fraction pixel_aspect_ratio = {};
+};
+
 constexpr auto M_TEXT_MODES = M_TEXT | M_HERC_TEXT | M_TANDY_TEXT | M_CGA_TEXT_COMPOSITE;
 
 constexpr auto vesa_2_0_modes_start = 0x120;

--- a/include/video.h
+++ b/include/video.h
@@ -68,9 +68,10 @@ IntegerScalingMode GFX_GetIntegerScalingMode();
 InterpolationMode GFX_GetInterpolationMode();
 
 struct VideoMode;
+class Fraction;
 
-Bitu GFX_SetSize(const int width, const int height, const Bitu flags,
-                 const double scalex, const double scaley,
+Bitu GFX_SetSize(const int width, const int height,
+                 const Fraction& render_pixel_aspect_ratio, const Bitu flags,
                  const VideoMode& video_mode, GFX_CallBack_t callback);
 
 void GFX_ResetScreen(void);
@@ -112,6 +113,6 @@ struct SDL_Rect;
 
 SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
                           const int draw_width, const int draw_height,
-                          const double draw_scalex, const double draw_scaley);
+                          const Fraction& render_pixel_aspect_ratio);
 
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -108,4 +108,10 @@ bool GFX_HaveDesktopEnvironment();
 void MAPPER_UpdateJoysticks(void);
 #endif
 
+struct SDL_Rect;
+
+SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
+                          const int draw_width, const int draw_height,
+                          const double draw_scalex, const double draw_scaley);
+
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -80,7 +80,6 @@ void GFX_Stop(void);
 void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
 void GFX_EndUpdate( const uint16_t *changedLines );
-void GFX_GetSize(int &width, int &height, bool &fullscreen);
 void GFX_LosingFocus();
 void GFX_RegenerateWindow(Section *sec);
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -341,22 +341,8 @@ static void render_reset(void)
 	bool double_width  = render.src.double_width;
 	bool double_height = render.src.double_height;
 
-	double gfx_scalew;
-	double gfx_scaleh;
-
 	Bitu gfx_flags, xscale, yscale;
 	ScalerSimpleBlock_t* simpleBlock = &ScaleNormal1x;
-
-	const auto one_per_pixel_aspect =
-	        render.src.pixel_aspect_ratio.Inverse().ToDouble();
-
-	if (one_per_pixel_aspect > 1.0) {
-		gfx_scalew = 1;
-		gfx_scaleh = one_per_pixel_aspect;
-	} else {
-		gfx_scalew = render.src.pixel_aspect_ratio.ToDouble();
-		gfx_scaleh = 1;
-	}
 
 	// Don't do software scaler sizes larger than 4k
 	Bitu maxsize_current_input = SCALER_MAXWIDTH / width;
@@ -428,11 +414,12 @@ static void render_reset(void)
 	GFX_SetShader(render.shader.source);
 #endif
 
+	const auto render_pixel_aspect_ratio = render.src.pixel_aspect_ratio;
+
 	gfx_flags = GFX_SetSize(width,
 	                        height,
+	                        render_pixel_aspect_ratio,
 	                        gfx_flags,
-	                        gfx_scalew,
-	                        gfx_scaleh,
 	                        render.video_mode,
 	                        &render_callback);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3358,9 +3358,9 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	        sdl.display_number);
 }
 
-static SDL_Rect calc_viewport(const int canvas_width, const int canvas_height,
-                              const int draw_width, const int draw_height,
-                              const double draw_scalex, const double draw_scaley)
+SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
+                          const int draw_width, const int draw_height,
+                          const double draw_scalex, const double draw_scaley)
 {
 	assert(draw_width > 0);
 	assert(draw_height > 0);
@@ -3446,12 +3446,12 @@ static SDL_Rect calc_viewport(const int canvas_width, const int canvas_height,
 
 static SDL_Rect calc_viewport(const int canvas_width, const int canvas_height)
 {
-	return calc_viewport(canvas_width,
-	                     canvas_height,
-	                     sdl.draw.width,
-	                     sdl.draw.height,
-	                     sdl.draw.scalex,
-	                     sdl.draw.scaley);
+	return GFX_CalcViewport(canvas_width,
+	                        canvas_height,
+	                        sdl.draw.width,
+	                        sdl.draw.height,
+	                        sdl.draw.scalex,
+	                        sdl.draw.scaley);
 }
 
 void GFX_SetIntegerScalingMode(const std::string& new_mode)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -466,7 +466,7 @@ static double get_host_refresh_rate()
 
 	// Log if changed
 	static auto last_int_rate = 0;
-	const auto int_rate = static_cast<int>(rate);
+	const auto int_rate = ifloor(rate);
 	if (last_int_rate != int_rate) {
 		last_int_rate = int_rate;
 		LOG_MSG("SDL: Using %s display refresh rate of %2.5g Hz",
@@ -900,10 +900,10 @@ static void save_rate_to_frame_period(const double rate_hz)
 	// backoff by one-onethousandth to avoid hitting the vsync edge
 	sdl.frame.period_ms = 1'001.0 / rate_hz;
 	const auto period_us = sdl.frame.period_ms * 1'000;
-	sdl.frame.period_us = static_cast<int>(period_us);
+	sdl.frame.period_us = ifloor(period_us);
 	// Permit the frame period to be off by up to 90% before "out of sync"
-	sdl.frame.period_us_early = static_cast<int>(55 * period_us / 100);
-	sdl.frame.period_us_late = static_cast<int>(145 * period_us / 100);
+	sdl.frame.period_us_early = ifloor(55 * period_us / 100);
+	sdl.frame.period_us_late = ifloor(145 * period_us / 100);
 }
 
 static std::unique_ptr<Pacer> render_pacer = {};
@@ -3415,9 +3415,9 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 		// image into the window or viewport bounds.
 		const auto pixel_aspect = round(draw_height * draw_scale_y) /
 		                          draw_height;
-		auto integer_scale_factor = std::min(
-		        bounds_w / draw_width,
-		        static_cast<int>(bounds_h / (draw_height * pixel_aspect)));
+		auto integer_scale_factor =
+		        std::min(bounds_w / draw_width,
+		                 ifloor(bounds_h / (draw_height * pixel_aspect)));
 
 		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
@@ -3433,8 +3433,8 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	case IntegerScalingMode::Vertical: {
 		auto integer_scale_factor = std::min(
 		        bounds_h / draw_height,
-		        static_cast<int>(bounds_w /
-		                         (draw_height * image_aspect_ratio)));
+		        ifloor(bounds_w / (draw_height * image_aspect_ratio)));
+
 		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
 			std::tie(view_w, view_h) = calculate_bounded_dims();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -797,10 +797,7 @@ static void log_display_properties(const int width, const int height,
 
 	[[maybe_unused]] const auto one_per_render_pixel_aspect = scale_y / scale_x;
 
-	const auto [mode_block, mode_type] = VGA_GetCurrentMode();
-
-	const auto [mode_type_desc, colours_desc, is_custom_mode] = VGA_DescribeMode(
-	        machine, mode_block, mode_type, video_mode.width, video_mode.height);
+	const auto video_mode_desc = to_string(video_mode);
 
 	const char* frame_mode = nullptr;
 	switch (sdl.frame.mode) {
@@ -808,26 +805,14 @@ static void log_display_properties(const int width, const int height,
 	case FrameMode::Vfr: frame_mode = "VFR"; break;
 	case FrameMode::ThrottledVfr: frame_mode = "throttled VFR"; break;
 	case FrameMode::Unset: frame_mode = "Unset frame mode"; break;
+	default: assertm(false, "Invalid FrameMode");
 	}
 
 	const auto refresh_rate = VGA_GetPreferredRate();
 
-	const auto mode_desc = is_custom_mode ? ""
-	                                      : format_string(" (mode %02Xh)",
-	                                                      mode_block.mode);
-
-	// Double check all the char* string variables
-	assert(mode_type_desc);
-	assert(colours_desc);
-	assert(frame_mode);
-
-	LOG_MSG("DISPLAY: %s %dx%d %s%s at %2.5g Hz %s, "
+	LOG_MSG("DISPLAY: %s at %2.5g Hz %s, "
 	        "scaled to %dx%d with 1:%1.6g (%d:%d) pixel aspect ratio",
-	        mode_type_desc,
-	        video_mode.width,
-	        video_mode.height,
-	        colours_desc,
-	        mode_desc.c_str(),
+	        video_mode_desc.c_str(),
 	        refresh_rate,
 	        frame_mode,
 	        viewport_w,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4786,13 +4786,6 @@ void OverrideWMClass()
 #endif
 }
 
-void GFX_GetSize(int &width, int &height, bool &fullscreen)
-{
-	width = sdl.draw.width;
-	height = sdl.draw.height;
-	fullscreen = sdl.desktop.fullscreen;
-}
-
 extern "C" int SDL_CDROMInit(void);
 int sdl_main(int argc, char *argv[])
 {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1530,6 +1530,22 @@ static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
 	             : SDL_Point{w, h};
 }
 
+static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
+        const Fraction& pixel_aspect_ratio)
+{
+       const auto one_per_pixel_aspect = pixel_aspect_ratio.Inverse().ToDouble();
+
+       if (one_per_pixel_aspect > 1.0) {
+               const auto scale_x = 1;
+               const auto scale_y = one_per_pixel_aspect;
+               return {scale_x, scale_y};
+       } else {
+               const auto scale_x = pixel_aspect_ratio.ToDouble();
+               const auto scale_y = 1;
+               return {scale_x, scale_y};
+       }
+}
+
 static SDL_Window *SetupWindowScaled(SCREEN_TYPES screen_type, bool resizable)
 {
 	int window_width;
@@ -1542,9 +1558,12 @@ static SDL_Window *SetupWindowScaled(SCREEN_TYPES screen_type, bool resizable)
 		window_height = sdl.desktop.window.height;
 	}
 
+	const auto [draw_scale_x, draw_scale_y] = get_scale_factors_from_pixel_aspect_ratio(
+	        sdl.draw.render_pixel_aspect_ratio);
+
 	if (window_width == 0 && window_height == 0) {
-		window_width  = iround(sdl.draw.width * sdl.draw.scalex);
-		window_height = iround(sdl.draw.height * sdl.draw.scaley);
+		window_width  = iround(sdl.draw.width * draw_scale_x);
+		window_height = iround(sdl.draw.height * draw_scale_y);
 	}
 
 	sdl.window = SetWindowMode(screen_type,
@@ -1730,8 +1749,8 @@ static void initialize_sdl_window_size(SDL_Window* sdl_window,
 	}
 }
 
-Bitu GFX_SetSize(const int width, const int height, const Bitu flags,
-                 const double scalex, const double scaley,
+Bitu GFX_SetSize(const int width, const int height,
+                 const Fraction& render_pixel_aspect_ratio, const Bitu flags,
                  const VideoMode& video_mode, GFX_CallBack_t callback)
 {
 	Bitu retFlags = 0;
@@ -1746,20 +1765,17 @@ Bitu GFX_SetSize(const int width, const int height, const Bitu flags,
 	const bool double_height = flags & GFX_DBL_H;
 	const auto [_, mode_type] = VGA_GetCurrentMode();
 
-	sdl.draw.has_changed = (sdl.draw.width != width ||
-	                        sdl.draw.height != height ||
+	sdl.draw.has_changed = (sdl.draw.width != width || sdl.draw.height != height ||
 	                        sdl.draw.width_was_doubled != double_width ||
 	                        sdl.draw.height_was_doubled != double_height ||
-	                        sdl.draw.scalex != scalex ||
-	                        sdl.draw.scaley != scaley ||
+	                        sdl.draw.render_pixel_aspect_ratio != render_pixel_aspect_ratio ||
 	                        sdl.draw.previous_mode != mode_type);
 
-	sdl.draw.width              = width;
-	sdl.draw.height             = height;
-	sdl.draw.width_was_doubled  = double_width;
-	sdl.draw.height_was_doubled = double_height;
-	sdl.draw.scalex             = scalex;
-	sdl.draw.scaley             = scaley;
+	sdl.draw.width                     = width;
+	sdl.draw.height                    = height;
+	sdl.draw.width_was_doubled         = double_width;
+	sdl.draw.height_was_doubled        = double_height;
+	sdl.draw.render_pixel_aspect_ratio = render_pixel_aspect_ratio;
 
 	sdl.video_mode = video_mode;
 
@@ -3360,14 +3376,18 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 
 SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
                           const int draw_width, const int draw_height,
-                          const double draw_scalex, const double draw_scaley)
+                          const Fraction& render_pixel_aspect_ratio)
 {
 	assert(draw_width > 0);
 	assert(draw_height > 0);
-	assert(draw_scalex > 0.0);
-	assert(draw_scaley > 0.0);
-	assert(std::isfinite(draw_scalex));
-	assert(std::isfinite(draw_scaley));
+
+	const auto [draw_scale_x, draw_scale_y] = get_scale_factors_from_pixel_aspect_ratio(
+	        render_pixel_aspect_ratio);
+
+	assert(draw_scale_x > 0.0);
+	assert(draw_scale_y > 0.0);
+	assert(std::isfinite(draw_scale_x));
+	assert(std::isfinite(draw_scale_y));
 
 	// Limit the window to the user's desired viewport, if configured
 	const auto restricted_dims = restrict_to_viewport_resolution(canvas_width,
@@ -3375,21 +3395,25 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	const auto bounds_w = restricted_dims.x;
 	const auto bounds_h = restricted_dims.y;
 
-	// Calculate the aspect ratio of the emulated display mode.
-	const auto output_aspect = (draw_width * draw_scalex) /
-	                           (draw_height * draw_scaley);
+	// It is important to calculate the image aspect ratio like this because
+	// the aspect ratio of the *image* itself it not always 4:3, in which
+	// case it would appear letter and/or pillarboxed on a real 4:3 display
+	// aspect ratio CRT monitor.
+	const auto image_aspect_ratio = (draw_width * draw_scale_x) /
+	                                (draw_height * draw_scale_y);
 
 	auto calculate_bounded_dims = [&]() -> std::pair<int, int> {
 		// Calculate the viewport contingent on the aspect ratio of the
 		// viewport bounds versus display mode.
 		const auto bounds_aspect = static_cast<double>(bounds_w) / bounds_h;
-		if (bounds_aspect > output_aspect) {
-			const auto w = iround(bounds_h * output_aspect);
+
+		if (bounds_aspect > image_aspect_ratio) {
+			const auto w = iround(bounds_h * image_aspect_ratio);
 			const auto h = bounds_h;
 			return {w, h};
 		} else {
 			const auto w = bounds_w;
-			const auto h = iround(bounds_w / output_aspect);
+			const auto h = iround(bounds_w / image_aspect_ratio);
 			return {w, h};
 		}
 	};
@@ -3404,7 +3428,7 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	case IntegerScalingMode::Horizontal: {
 		// Calculate scaling multiplier that will allow to fit the whole
 		// image into the window or viewport bounds.
-		const auto pixel_aspect = round(draw_height * draw_scaley) /
+		const auto pixel_aspect = round(draw_height * draw_scale_y) /
 		                          draw_height;
 		auto integer_scale_factor = std::min(
 		        bounds_w / draw_width,
@@ -3424,13 +3448,14 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	case IntegerScalingMode::Vertical: {
 		auto integer_scale_factor = std::min(
 		        bounds_h / draw_height,
-		        static_cast<int>(bounds_w / (draw_height * output_aspect)));
+		        static_cast<int>(bounds_w /
+		                         (draw_height * image_aspect_ratio)));
 		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
 			std::tie(view_w, view_h) = calculate_bounded_dims();
 		} else {
 			view_w = iround(draw_height * integer_scale_factor *
-			                output_aspect);
+			                image_aspect_ratio);
 			view_h = draw_height * integer_scale_factor;
 		}
 		break;
@@ -3450,8 +3475,7 @@ static SDL_Rect calc_viewport(const int canvas_width, const int canvas_height)
 	                        canvas_height,
 	                        sdl.draw.width,
 	                        sdl.draw.height,
-	                        sdl.draw.scalex,
-	                        sdl.draw.scaley);
+	                        sdl.draw.render_pixel_aspect_ratio);
 }
 
 void GFX_SetIntegerScalingMode(const std::string& new_mode)

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -141,10 +141,10 @@ void VGA_LogInitialization(const char *adapter_name,
                            const char *ram_type,
                            const size_t num_modes)
 {
-	const auto mem_in_kib = vga.vmemsize / 1024;
+	const auto mem_in_kb = vga.vmemsize / 1024;
 	LOG_INFO("VIDEO: Initialised %s with %d %s of %s supporting %d modes",
-	         adapter_name, mem_in_kib < 1024 ? mem_in_kib : mem_in_kib / 1024,
-	         mem_in_kib < 1024 ? "KB" : "MB", ram_type,
+	         adapter_name, mem_in_kb < 1024 ? mem_in_kb : mem_in_kb / 1024,
+	         mem_in_kb < 1024 ? "KB" : "MB", ram_type,
 	         check_cast<int16_t>(num_modes));
 }
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1879,8 +1879,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	const auto vga_timings = calculate_vga_timings();
 
-	if (is_vga_scan_doubling() &&
-	    !(vga.mode == M_CGA2 || vga.mode == M_CGA4)) {
+	if (is_vga_scan_doubling() && !(vga.mode == M_CGA2 || vga.mode == M_CGA4)) {
 		vga.draw.address_line_total *= 2;
 	}
 
@@ -1968,12 +1967,29 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	}
 
 #if 0
-	LOG_MSG("VGA: vga.mode: %s", VGA_ModeToString(vga.mode).c_str());
+	LOG_MSG("VGA: vga.mode: %s", to_string(vga.mode));
 	LOG_MSG("VGA: graphics_enabled: %d, scan_doubling: %d, max_scan_line: %d",
 	        static_cast<uint8_t>(vga.attr.mode_control.is_graphics_enabled),
 	        static_cast<uint8_t>(vga.crtc.maximum_scan_line.is_scan_doubling_enabled),
 	        static_cast<uint8_t>(vga.crtc.maximum_scan_line.maximum_scan_line));
 #endif
+
+	const auto bios_mode_number = CurMode->mode;
+
+	video_mode.bios_mode_number = bios_mode_number;
+
+	auto pcjr_or_tga = [=]() {
+		return (machine == MCH_PCJR) ? GraphicsStandard::Pcjr
+		                             : GraphicsStandard::Tga;
+	};
+
+	auto cga_pcjr_or_tga = [=]() {
+		constexpr auto first_non_cga_mode = 0x08;
+		if (bios_mode_number < first_non_cga_mode) {
+			return GraphicsStandard::Cga;
+		}
+		return pcjr_or_tga();
+	};
 
 	switch (vga.mode) {
 	case M_LIN4:
@@ -1985,9 +2001,16 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		// SVGA & VESA modes
 		const auto is_pixel_doubling = vga.crtc.mode_control.div_memory_address_clock_by_2;
 
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = VESA_IsVesaMode(bios_mode_number)
+		                                     ? GraphicsStandard::Vesa
+		                                     : GraphicsStandard::Svga;
+
 		switch (vga.mode) {
 		case M_LIN8:
 			// 256-colour SVGA & VESA modes (other than mode 13h)
+			video_mode.color_depth = ColorDepth::IndexedColor256;
+
 			if (is_pixel_doubling ||
 			    (svgaCard == SVGA_S3Trio && !(vga.s3.reg_3a & 0x10))) {
 				video_mode.width = horiz_end * 4;
@@ -1999,18 +2022,24 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			// 24-bit true colour (16.7M-colour) VESA modes
 		case M_LIN32:
 			// 32-bit true colour (16.7M-colour) VESA modes
-			video_mode.width = horiz_end * 8;
+			video_mode.color_depth = ColorDepth::TrueColor24Bit;
+			video_mode.width       = horiz_end * 8;
 			break;
 		case M_LIN15:
 			// 15-bit high colour (32K-colour) VESA modes
+			video_mode.color_depth = ColorDepth::HighColor15Bit;
+			video_mode.width       = horiz_end * 4;
+			break;
 		case M_LIN16:
 			// 16-bit high colour (65K-colour) VESA modes
-			video_mode.width = horiz_end * 4;
+			video_mode.color_depth = ColorDepth::HighColor16Bit;
+			video_mode.width       = horiz_end * 4;
 			break;
 		case M_LIN4:
 			// 16-colour SVGA & VESA modes
-			vga.draw.blocks  = horiz_end;
-			video_mode.width = horiz_end * 8;
+			vga.draw.blocks        = horiz_end;
+			video_mode.width       = horiz_end * 8;
+			video_mode.color_depth = ColorDepth::IndexedColor16;
 			break;
 		default: assert(false);
 		}
@@ -2056,6 +2085,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		// modes; the 640x480 / 16-color 12h mode is tagged with M_EGA
 		// (because it's planar like all EGA modes), and all other VGA
 		// modes with M_LIN4, M_LIN8, etc.
+
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = GraphicsStandard::Vga;
+		video_mode.color_depth       = ColorDepth::IndexedColor256;
 
 		const auto is_double_scanning =
 		        (vga.crtc.maximum_scan_line.maximum_scan_line > 0);
@@ -2113,8 +2146,36 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	} break;
 
 	case M_EGA:
-		// 640x480 monochrome EGA mode
+		// 640x480 2-colour VGA mode
 		// All 16-colour EGA and VGA modes
+
+		video_mode.is_graphics_mode = true;
+
+		// Modes 11h and 12h were supported by high-end EGA cards and
+		// because of that operate internally more like EGA modes (so
+		// DOSBox uses the EGA type for them), however they were
+		// classified as VGA from a standards perspective, so we report
+		// them as such.
+		//
+		// References:
+		// [1] IBM VGA Technical Reference, Mode of Operation, pp 2-12,
+		// 19 March, 1992. [2] "IBM PC Family- BIOS Video Modes",
+		// http://minuszerodegrees.net/video/bios_video_modes.htm
+		//
+		switch (bios_mode_number) {
+		case 0x011: // 640x480 2-colour VGA mode
+			video_mode.graphics_standard = GraphicsStandard::Vga;
+			video_mode.color_depth = ColorDepth::IndexedColor2;
+			break;
+		case 0x012: // 640x480 16-colour VGA mode
+			video_mode.graphics_standard = GraphicsStandard::Vga;
+			video_mode.color_depth = ColorDepth::IndexedColor16;
+			break;
+		default: // EGA modes
+			video_mode.graphics_standard = GraphicsStandard::Ega;
+			video_mode.color_depth = ColorDepth::IndexedColor16;
+		}
+
 		vga.draw.blocks = horiz_end;
 
 		video_mode.width = horiz_end * 8;
@@ -2172,6 +2233,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		// 160x200 and 320x200 16-colour modes on Tandy & PCjr
 		vga.draw.blocks = horiz_end * 2;
 
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::IndexedColor16;
+
 		if (vga.tandy.mode.is_high_bandwidth) {
 			if (machine == MCH_TANDY &&
 			    vga.tandy.mode.is_tandy_640_dot_graphics) {
@@ -2203,6 +2268,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	case M_TANDY4:
 		// 320x200 4-colour CGA mode on CGA, Tandy & PCjr
 		// 640x200 4-colour mode on Tandy & PCjr
+
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = cga_pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::IndexedColor4;
+
 		vga.draw.blocks = horiz_end * 2;
 
 		video_mode.width  = horiz_end * 8;
@@ -2248,6 +2318,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_TANDY2:
 		// 640x200 monochrome CGA mode on CGA, Tandy & PCjr
+
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = cga_pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::IndexedColor2;
+
 		if (machine == MCH_PCJR) {
 			vga.draw.blocks = horiz_end * (vga.tandy.mode_control.is_pcjr_640x200_2_color_graphics
 			                                       ? 8
@@ -2279,9 +2354,19 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		break;
 
 	case M_CGA2:
-		// 640x200 monochrome CGA mode on EGA & VGA
+		// 640x200 2-colour CGA mode on EGA & VGA
+		// (2-colour and not monochrome because the background is always
+		// black, but the foreground colour can be changed to any of the
+		// 16 CGA colours)
 	case M_CGA4:
 		// 320x200 4-colour CGA mode on EGA & VGA
+
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = GraphicsStandard::Cga;
+		video_mode.color_depth       = (vga.mode == M_CGA2)
+		                                     ? ColorDepth::IndexedColor2
+		                                     : ColorDepth::IndexedColor4;
+
 		vga.draw.blocks = horiz_end * 2;
 
 		video_mode.width = horiz_end * 8;
@@ -2324,6 +2409,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_CGA16:
 		// Composite output in 320x200 4-colour CGA mode on PCjr only
+
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = GraphicsStandard::Pcjr;
+		video_mode.color_depth       = ColorDepth::Composite;
+
 		vga.draw.blocks = horiz_end * 2;
 
 		video_mode.width  = horiz_end * 8;
@@ -2344,6 +2434,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	case M_CGA4_COMPOSITE:
 		// Composite output in 320x200 & 640x200 4-colour modes on CGA &
 		// Tandy
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = cga_pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::Composite;
+
 		vga.draw.blocks = horiz_end * 2;
 
 		video_mode.width  = horiz_end * 8;
@@ -2362,6 +2456,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	case M_CGA2_COMPOSITE:
 		// Composite output in 640x200 monochrome CGA mode on CGA, Tandy
 		// & PCjr
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = cga_pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::Composite;
+
 		vga.draw.blocks = horiz_end * 2;
 
 		video_mode.width  = horiz_end * 16;
@@ -2378,6 +2476,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_HERC_GFX:
 		// Hercules graphics mode
+		video_mode.is_graphics_mode  = true;
+		video_mode.graphics_standard = GraphicsStandard::Hercules;
+		video_mode.color_depth       = ColorDepth::Monochrome;
+
 		vga.draw.blocks = horiz_end * 2;
 
 		video_mode.width  = horiz_end * 16;
@@ -2394,6 +2496,28 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_TEXT:
 		// All EGA, VGA, SVGA & VESA text modes
+		video_mode.is_graphics_mode = false;
+
+		switch (machine) {
+		case MCH_EGA:
+			video_mode.graphics_standard = GraphicsStandard::Ega;
+			break;
+		case MCH_VGA: {
+			constexpr auto max_vga_text_mode_number = 0x07;
+			if (bios_mode_number <= max_vga_text_mode_number) {
+				video_mode.graphics_standard = GraphicsStandard::Vga;
+			} else {
+				video_mode.graphics_standard =
+				        VESA_IsVesaMode(bios_mode_number)
+				                ? GraphicsStandard::Vesa
+				                : GraphicsStandard::Svga;
+			}
+		} break;
+		default: assert(false);
+		}
+
+		video_mode.color_depth = ColorDepth::IndexedColor16;
+
 		vga.draw.blocks = horiz_end;
 
 		if (IS_VGA_ARCH) {
@@ -2437,6 +2561,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_TANDY_TEXT:
 		// CGA, Tandy & PCjr text modes
+		video_mode.is_graphics_mode  = false;
+		video_mode.graphics_standard = cga_pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::IndexedColor16;
+
 		vga.draw.blocks = horiz_end;
 
 		video_mode.width  = horiz_end * 8;
@@ -2456,6 +2584,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_CGA_TEXT_COMPOSITE:
 		// Composite output in text modes on CGA, Tandy & PCjr
+		video_mode.is_graphics_mode  = false;
+		video_mode.graphics_standard = cga_pcjr_or_tga();
+		video_mode.color_depth       = ColorDepth::Composite;
+
 		vga.draw.blocks = horiz_end;
 
 		video_mode.width = horiz_end *
@@ -2474,6 +2606,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 	case M_HERC_TEXT:
 		// Hercules text mode
+		video_mode.is_graphics_mode  = false;
+		video_mode.graphics_standard = GraphicsStandard::Hercules;
+		video_mode.color_depth       = ColorDepth::Monochrome;
+
 		vga.draw.blocks = horiz_end;
 
 		video_mode.width  = horiz_end * 8;
@@ -2523,6 +2659,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		render_pixel_aspect_ratio = render_per_video_mode_scale.Inverse();
 		video_mode.pixel_aspect_ratio = {1};
 	}
+
+	// Try to determine if this is a custom mode
+	video_mode.is_custom_mode = (CurMode->swidth != video_mode.width ||
+	                             CurMode->sheight != video_mode.height);
 
 	vga.draw.vblank_skip = vblank_skip;
 	setup_line_drawing_delays(render_height);

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7365,11 +7365,17 @@ static void Voodoo_UpdateScreen()
 
 			constexpr Fraction render_pixel_aspect_ratio = {1};
 
-			const auto frames_per_second  = 1000.0f / v->draw.vfreq;
+			VideoMode video_mode        = {};
+			video_mode.bios_mode_number = 0;
+			video_mode.width  = check_cast<uint16_t>(width);
+			video_mode.height = check_cast<uint16_t>(height);
+			video_mode.pixel_aspect_ratio = render_pixel_aspect_ratio;
+			video_mode.graphics_standard  = GraphicsStandard::Svga;
+			video_mode.color_depth        = ColorDepth::HighColor16Bit;
+			video_mode.is_custom_mode     = false;
+			video_mode.is_graphics_mode   = true;
 
-			const VideoMode video_mode = {check_cast<uint16_t>(width),
-			                              check_cast<uint16_t>(height),
-			                              render_pixel_aspect_ratio};
+			const auto frames_per_second  = 1000.0f / v->draw.vfreq;
 
 			RENDER_SetSize(width,
 			               height,

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -48,8 +48,8 @@
 #define BIOSMEM_CRTCPU_PAGE   0x8A
 #define BIOSMEM_VS_POINTER    0xA8
 
-constexpr uint16_t MinVesaMode = 0x100;
-constexpr uint16_t MaxVesaMode = 0x7ff;
+constexpr uint16_t MinVesaBiosModeNumber = 0x100;
+constexpr uint16_t MaxVesaBiosModeNumber = 0x7ff;
 
 /*
  *
@@ -255,7 +255,7 @@ void INT10_PerformGrayScaleSumming(uint16_t start_reg,uint16_t count);
 
 /* Vesa Group */
 uint8_t VESA_GetSVGAInformation(const uint16_t segment, const uint16_t offset);
-bool VESA_IsVesaMode(const uint16_t mode);
+bool VESA_IsVesaMode(const uint16_t bios_mode_number);
 uint8_t VESA_GetSVGAModeInformation(uint16_t mode,uint16_t seg,uint16_t off);
 uint8_t VESA_SetSVGAMode(uint16_t mode);
 uint8_t VESA_GetSVGAMode(uint16_t & mode);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1005,7 +1005,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 	const auto UseLinearFramebuffer    = is(mode, b14);
 	const auto DoNotClearDisplayMemory = is(mode, b15);
 
-	if (mode >= MinVesaMode) {
+	if (mode >= MinVesaBiosModeNumber) {
 		if (UseLinearFramebuffer && int10.vesa_nolfb) {
 			return false;
 		}
@@ -1014,7 +1014,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 		}
 		mode &= 0xfff;
 	}
-	if ((mode <= MinVesaMode) && (mode & 0x80)) {
+	if ((mode <= MinVesaBiosModeNumber) && (mode & 0x80)) {
 		clearmem = false;
 		mode -= 0x80;
 	}
@@ -1427,7 +1427,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 
 	if (svgaCard == SVGA_S3Trio) {
 		//  Setup the correct clock
-		if (CurMode->mode >= MinVesaMode) {
+		if (CurMode->mode >= MinVesaBiosModeNumber) {
 			if (CurMode->vdispend>480)
 				misc_output|=0xc0;	//480-line sync
 			misc_output|=0x0c;		//Select clock 3

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -166,9 +166,10 @@ uint8_t VESA_GetSVGAInformation(const uint16_t segment, const uint16_t offset)
 //
 // "2.7 (09-Apr-96) Accepted all VESA modes in range 0x100 to 0x7ff, because some
 // cards use very strange mode numbers.'
-bool VESA_IsVesaMode(const uint16_t mode)
+bool VESA_IsVesaMode(const uint16_t bios_mode_number)
 {
-	return (mode >= MinVesaMode && mode <= MaxVesaMode);
+	return (bios_mode_number >= MinVesaBiosModeNumber &&
+	        bios_mode_number <= MaxVesaBiosModeNumber);
 }
 
 // Build-engine games have problem timing some non-standard,
@@ -200,7 +201,7 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode,uint16_t seg,uint16_t off) {
 	uint8_t modeAttributes;
 
 	mode&=0x3fff;	// vbe2 compatible, ignore lfb and keep screen content bits
-	if (mode < MinVesaMode) {
+	if (mode < MinVesaBiosModeNumber) {
 		return 0x01;
 	}
 	if (svga.accepts_mode) {
@@ -698,7 +699,7 @@ void INT10_SetupVESA(void) {
 		else {
 			if (svga.accepts_mode(ModeList_VGA[i].mode)) canuse_mode=true;
 		}
-		if (ModeList_VGA[i].mode >= MinVesaMode && canuse_mode) {
+		if (ModeList_VGA[i].mode >= MinVesaBiosModeNumber && canuse_mode) {
 			if (!int10.vesa_oldvbe || ModeList_VGA[i].mode < 0x120) {
 				phys_writew(PhysicalMake(0xc000, int10.rom.used), ModeList_VGA[i].mode);
 				int10.rom.used += 2;


### PR DESCRIPTION
A couple of tactical chess moves so I can fit in the shader auto-switching stuff in a clean way. I thought I'd raise these separately as they stand on their own and improve the code in general.

The logging of the current video mode has also been improved, now we have stuff like these:

- "CGA 640x200 16-colour text mode 03h"
- "EGA 640x350 16-colour graphics mode 10h"
- "VGA 720x400 16-colour text mode 03h"
- "VGA 320x200 256-colour graphics mode 13h"
- "VGA 360x240 256-colour graphics mode"
- "VESA 800x600 256-colour graphics mode 103h"

No functional changes apart from that. Definitely review by commit.

