### PR TITLE
Fix const issue writing a png with png12

### DIFF
--- a/src/capture/image/png_writer.cpp
+++ b/src/capture/image/png_writer.cpp
@@ -242,7 +242,7 @@ void PngWriter::WritePngInfo(const uint16_t width, const uint16_t height,
 void PngWriter::WriteRow(std::vector<uint8_t>::const_iterator row)
 {
 	assert(png_ptr);
-	png_write_row(png_ptr, &*row);
+	png_write_row(png_ptr, const_cast<png_bytep>(&*row));
 }
 
 void PngWriter::FinalisePng()


### PR DESCRIPTION
When building against libpng v1.2 (png12), compilation fails due to png_write_row accepting a 'png_bytep' (unsigned char*), where we provide data from a const_iterator:
```
../src/capture/image/png_writer.cpp: In member function ‘void PngWriter::WriteRow(std::vector<unsigned char>::const_iterator)’:
../src/capture/image/png_writer.cpp:245:32: error: invalid conversion from ‘const unsigned char*’ to ‘png_bytep’ {aka ‘unsigned char*’} [-fpermissive]
  245 |         png_write_row(png_ptr, &*row);
      |                                ^~~~~
      |                                |
      |                                const unsigned char*
In file included from /usr/include/zlib.h:34,
                 from /usr/include/libpng12/png.h:317,
                 from ../src/capture/image/png_writer.h:33,
                 from ../src/capture/image/png_writer.cpp:24:
/usr/include/libpng12/png.h:1646:39: note:   initializing argument 2 of ‘void png_write_row(png_structp, png_bytep)’
 1646 | extern PNG_EXPORT(void,png_write_row) PNGARG((png_structp png_ptr,
      |                                       ^~~~~~
```

It's safe to cast away the const issue, as png_write_row() doesn't write to the row pointer passed in.

Even though png12 is quite old, it's used by default if installed (at least on openSUSE), so failing to support it is breaking the default build.