### PR TITLE
Use the PNG native row type in png-specific write functions

### DIFF
--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -149,9 +149,9 @@ static void write_upscaled_png(FILE* outfile, PngWriter& png_writer,
 		break;
 	};
 
-	auto rows_to_write = image_scaler.GetOutputHeight();
-	while (rows_to_write--) {
-		auto row = image_scaler.GetNextOutputRow();
+	// Write the rows
+	png_bytep row = {};
+	while ((row = image_scaler.GetNextOutputRow())) {
 		png_writer.WriteRow(row);
 	}
 }
@@ -215,7 +215,7 @@ void ImageSaver::SaveRawImage(const RenderedImage& image, const VideoMode& video
 				*out++ = pixel.blue;
 			}
 		}
-		png_writer.WriteRow(row_buf.begin());
+		png_writer.WriteRow(row_buf.data());
 		image_decoder.AdvanceRow();
 	}
 }
@@ -277,7 +277,7 @@ void ImageSaver::SaveRenderedImage(const RenderedImage& image,
 			*out++ = pixel.green;
 			*out++ = pixel.blue;
 		}
-		png_writer.WriteRow(row_buf.begin());
+		png_writer.WriteRow(row_buf.data());
 		image_decoder.AdvanceRow();
 	}
 }

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -328,10 +328,10 @@ void ImageScaler::GenerateNextSharpUpscaledOutputRow()
 	SetRowRepeat();
 }
 
-std::vector<uint8_t>::const_iterator ImageScaler::GetNextOutputRow()
+uint8_t* ImageScaler::GetNextOutputRow()
 {
 	if (output.curr_row >= output.height) {
-		return output.row_buf.end();
+		return nullptr;
 	}
 
 	if (output.row_repeat == 0) {
@@ -348,5 +348,5 @@ std::vector<uint8_t>::const_iterator ImageScaler::GetNextOutputRow()
 
 	++output.curr_row;
 
-	return output.row_buf.begin();
+	return output.row_buf.data();
 }

--- a/src/capture/image/image_scaler.h
+++ b/src/capture/image/image_scaler.h
@@ -71,7 +71,7 @@ enum class PerAxisScaling { Integer, Fractional };
 //   to query the output parameters decided by the upscaler.
 //
 // - Call `GetNextOutputRow()` repeatedly to get the upscaled output until the
-//   end of the iterator is reached.
+//   end is reached, indicated by a nullptr return value.
 //
 // - Call `Init()` again to process another image (no need to destruct &
 //   re-create).
@@ -83,7 +83,7 @@ public:
 
 	void Init(const RenderedImage& image, const VideoMode& video_mode);
 
-	std::vector<uint8_t>::const_iterator GetNextOutputRow();
+	uint8_t* GetNextOutputRow();
 
 	uint16_t GetOutputWidth() const;
 	uint16_t GetOutputHeight() const;

--- a/src/capture/image/png_writer.cpp
+++ b/src/capture/image/png_writer.cpp
@@ -239,10 +239,11 @@ void PngWriter::WritePngInfo(const uint16_t width, const uint16_t height,
 	png_write_info(png_ptr, png_info_ptr);
 }
 
-void PngWriter::WriteRow(std::vector<uint8_t>::const_iterator row)
+void PngWriter::WriteRow(png_bytep row)
 {
 	assert(png_ptr);
-	png_write_row(png_ptr, &*row);
+	assert(row);
+	png_write_row(png_ptr, row);
 }
 
 void PngWriter::FinalisePng()

--- a/src/capture/image/png_writer.h
+++ b/src/capture/image/png_writer.h
@@ -48,7 +48,7 @@ public:
 	                  const Fraction& pixel_aspect_ratio,
 	                  const VideoMode& video_mode, const uint8_t* palette_data);
 
-	void WriteRow(std::vector<uint8_t>::const_iterator row);
+	void WriteRow(png_bytep row);
 
 	// prevent copying
 	PngWriter(const PngWriter&) = delete;


### PR DESCRIPTION
This PR lets the `PngWriter` row-write function takes in PNG's row type directly ([`png_bytep`](https://refspecs.linuxbase.org/LSB_3.1.0/LSB-Desktop-generic/LSB-Desktop-generic/libpng12.png.write.row.1.html)), which avoids dereferencing and casting from iterators as @sulix [reported](https://github.com/dosbox-staging/dosbox-staging/pull/2740).

The `PngWriter`'s job is to interface w/ the PNG library, and using PNG's API-defined `png_bytep` type puts PNG in charge of the type we need accept (making the interface directly compliant with whatever the PNG header needs).

From the looks of it, `png_bytep` can be a `const uint8_t*` or non-const, both of which are supported by vector's `.data()` output.

It adjusts `ImageScaler::GetNextOutputRow`'s interface to use a pointer to the vector's contiguous data (and vector's `.data()` interface), without having to inject any PNG-specific details into the scaler.

---

It would be nice if there was a C++ binding and we could use iterators more naturally with PNG, but one draw back is iterators aren't guaranteed to be contiguous (just in general) - where as memory blocks are.  So this is probably a better natural fit in the future too if we eventually add another lossless format, say, JPEG-XL (if/when it's widely supported).