### PR TITLE
Fix compatibility problems with VBADOS (VBMOUSE.EXE) mouse driver

### DIFF
--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -419,6 +419,7 @@ static Bitu int74_handler()
 
 Bitu int74_ret_handler()
 {
+	MOUSEBIOS_FinalizeInterrupt();
 	MOUSEDOS_FinalizeInterrupt();
 	return CBRET_NONE;
 }

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -81,6 +81,7 @@ void MOUSEPS2_NotifyWheel(const int16_t w_rel);
 
 bool MOUSEBIOS_CheckCallback();
 void MOUSEBIOS_DoCallback();
+void MOUSEBIOS_FinalizeInterrupt();
 
 // ***************************************************************************
 // VMware protocol extension for PS/2 mouse

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -1775,13 +1775,16 @@ static Bitu int33_handler()
 		SegSet16(es, info_segment);
 		reg_di = info_offset_version;
 		break;
-	case 0x70: // Mouse Systems - installation check
-	case 0x72: // Mouse Systems 7.01+, Genius Mouse 9.06+ - unknown
-	case 0x73: // Mouse Systems 7.01+ - get button assignments
-		LOG_WARNING("MOUSE (DOS): Mouse Sytems extensions not implemented");
-		break;
-	case 0x53C1: // Logitech CyberMan
-		LOG_WARNING("MOUSE (DOS): Logitech CyberMan function 0x53c1 not implemented");
+	case 0x70:   // Mouse Systems       - installation check
+	case 0x72:   // Mouse Systems 7.01+ - unknown functionality
+	             // Genius Mouse 9.06+  - unknown functionality
+	case 0x73:   // Mouse Systems 7.01+ - get button assignments
+	             // VBADOS              - get driver info
+	case 0x53c1: // Logitech CyberMan   - unknown functionality
+		// Do not print out any warnings for known 3rd party oem driver
+		// extensions - every software (except the one bound to the
+		// particular driver) should continue working correctly even if
+		// we completely ignore the call
 		break;
 	default:
 		LOG_WARNING("MOUSE (DOS): Function 0x%04x not implemented", reg_ax);

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -119,6 +119,8 @@ static uint8_t unlock_idx_xp = 0;
 static std::vector<uint8_t> frame = {};
 // if enough movement or other mouse state changes for a new frame
 static bool has_data_for_frame = false;
+// if virtual machine mouse interface needs us to issue dummy event
+static bool vmm_needs_dummy_event = false;
 
 static uint8_t rate_hz = 0; // maximum rate at which the mouse state is updated
 static bool scaling_21 = false;
@@ -677,14 +679,17 @@ void MOUSEPS2_NotifyMoved(const float x_rel, const float y_rel)
 	constexpr float threshold = 0.5f;
 
 	has_data_for_frame |= (std::fabs(delta_x) >= threshold) ||
-	                      (std::fabs(delta_y) >= threshold);
+	                      (std::fabs(delta_y) >= threshold) ||
+	                      vmm_needs_dummy_event;
 	maybe_transfer_frame();
+	vmm_needs_dummy_event = false;
 }
 
 void MOUSEPS2_NotifyMovedDummy()
 {
-	has_data_for_frame = true;
-	maybe_transfer_frame();
+	if (should_report()) {
+		vmm_needs_dummy_event = true;
+	}
 }
 
 void MOUSEPS2_NotifyButton(const MouseButtons12S new_buttons_12S,
@@ -696,22 +701,25 @@ void MOUSEPS2_NotifyButton(const MouseButtons12S new_buttons_12S,
 	buttons_all = new_buttons_all;
 	MOUSEPS2_UpdateButtonSquish();
 
-	has_data_for_frame |= (buttons_old._data != buttons._data);
+	has_data_for_frame |= (buttons_old._data != buttons._data) ||
+	                      vmm_needs_dummy_event;
 	maybe_transfer_frame();
+	vmm_needs_dummy_event = false;
 }
 
 void MOUSEPS2_NotifyWheel(const int16_t w_rel)
 {
-	if (protocol != MouseModelPS2::IntelliMouse &&
-	    protocol != MouseModelPS2::Explorer) {
-		return;
+	// Note: VMware mouse protocol can support wheel even if the emulated
+	// PS/2 mouse does not have it - this works at least with VBADOS v0.67
+	auto old_counter_w = counter_w;
+	if (protocol == MouseModelPS2::IntelliMouse ||
+	    protocol == MouseModelPS2::Explorer) {
+		counter_w = clamp_to_int8(static_cast<int32_t>(counter_w + w_rel));
 	}
 
-	auto old_counter_w = counter_w;
-	counter_w = clamp_to_int8(static_cast<int32_t>(counter_w + w_rel));
-
-	has_data_for_frame |= (old_counter_w != counter_w);
+	has_data_for_frame |= (old_counter_w != counter_w) || vmm_needs_dummy_event;
 	maybe_transfer_frame();
+	vmm_needs_dummy_event = false;
 }
 
 void MOUSEPS2_SetDelay(const uint8_t new_delay_ms)
@@ -742,6 +750,37 @@ static RealPt ps2_callback   = 0;
 
 std::vector<uint8_t> bios_buffer = {};
 
+static bool bios_delay_running  = false;
+static bool bios_delay_finished = true;
+
+static void bios_delay_handler(uint32_t /*val*/)
+{
+	bios_delay_running  = false;
+	bios_delay_finished = true;
+
+	PIC_ActivateIRQ(mouse_predefined.IRQ_PS2);
+}
+
+static void bios_maybe_start_delay_timer()
+{
+	constexpr uint8_t timer_delay_ms = 1;
+
+	if (bios_delay_running) {
+		return;
+	}
+
+	PIC_AddEvent(bios_delay_handler, timer_delay_ms);
+	bios_delay_running  = true;
+	bios_delay_finished = false;
+}
+
+static void bios_cancel_delay_timer()
+{
+	PIC_RemoveEvents(bios_delay_handler);
+	bios_delay_running  = false;
+	bios_delay_finished = true;
+}
+
 static bool bios_enable()
 {
 	mouse_shared.active_bios = callback_init;
@@ -753,6 +792,8 @@ static bool bios_enable()
 
 static bool bios_disable()
 {
+	bios_cancel_delay_timer();
+
 	mouse_shared.active_bios = false;
 	bios_buffer.clear();
 	MOUSE_UpdateGFX();
@@ -813,7 +854,11 @@ bool MOUSEBIOS_CheckCallback()
 		return false;
 	}
 
-	const size_t max_buffer_size = static_cast<size_t>(bios_frame_size * 4);
+	// Least common multiple of supported framed sizes - to minimize chances
+	// of guest driver going out-of-sync if we are forced to remove frame
+	// from the buffer
+	constexpr size_t max_buffer_size = 3 * 4;
+
 	while (1) {
 		if (!bios_is_aux_byte_waiting()) {
 			// No more AUX data to read
@@ -840,18 +885,22 @@ bool MOUSEBIOS_CheckCallback()
 
 void MOUSEBIOS_DoCallback()
 {
-	assert(bios_frame_size == 3 || bios_frame_size == 4);
+	assert(bios_frame_size == 1 || bios_frame_size == 3 || bios_frame_size == 4);
 	assert(bios_buffer.size() >= bios_frame_size);
 
 	if (bios_frame_size == 3) {
 		CPU_Push16(bios_buffer[0]);
 		CPU_Push16(bios_buffer[1]);
 		CPU_Push16(bios_buffer[2]);
-	} else {
+	} else if (bios_frame_size == 4) {
 		const auto word_0 = bios_buffer[0] + (bios_buffer[1] << 8);
 		CPU_Push16(static_cast<uint16_t>(word_0));
 		CPU_Push16(bios_buffer[2]);
 		CPU_Push16(bios_buffer[3]);
+	} else { // bios_frame_size == 1
+		CPU_Push16(bios_buffer[0]);
+		CPU_Push16(0);
+		CPU_Push16(0);
 	}
 	CPU_Push16(0u);
 
@@ -861,6 +910,17 @@ void MOUSEBIOS_DoCallback()
 	CPU_Push16(RealOffset(ps2_callback));
 	SegSet16(cs, callback_seg);
 	reg_ip = callback_ofs;
+}
+
+void MOUSEBIOS_FinalizeInterrupt()
+{
+	// It is possible that before our interrupt got handled, another full
+	// packet arrived from the simulated PS/2 hardware
+	if (MOUSEBIOS_CheckCallback()) {
+		bios_maybe_start_delay_timer();
+	} else {
+		bios_cancel_delay_timer();
+	}
 }
 
 void MOUSEBIOS_Subfunction_C2() // INT 15h, AH = 0xc2
@@ -926,7 +986,10 @@ void MOUSEBIOS_Subfunction_C2() // INT 15h, AH = 0xc2
 		set_return_value(BiosRetVal::Success);
 		break;
 	case 0x05: // initialize
-		if (reg_bh == 3 || reg_bh == 4) {
+		if (reg_bh == 1 || reg_bh == 3 || reg_bh == 4) {
+			// NOTE: if you want to support more frame sizes, do not
+			// forget to update 'max_buffer_size' constant in
+			// 'MOUSEBIOS_CheckCallback' routine!
 			bios_frame_size = reg_bh;
 			bios_disable();
 			cmd_set_defaults();


### PR DESCRIPTION
- fixed PS/2 packet data loss problems when BIOS was receiving the next packet before the previous one was fully retrieved (due to this problem VBMOUSE.EXE was completely broken if emulated PS/2 mouse supported wheel)
- prevented unnecessary dummy mouse events in VMware mouse protocol
- added support for PS/2 mouse packet size 1 to the BIOS - VBADOS seems to prefer it
- silenced warning in our internal DOS driver, which was a result of VBADOS checking if it is already installed

Driver link: https://git.javispedro.com/cgit/vbados.git/about/ (changes are related to `VBMOUSE.EXE` DOS driver, not to the Windows driver)