### PR TITLE
Fix invalid default config value for voodoo_memsize

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -781,7 +781,7 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("voodoo", &VOODOO_Init, false);
 
 	const char* voodootypes[] = {"disabled", "4", "12", nullptr};
-	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "12mb");
+	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "12");
 	pstring->Set_values(voodootypes);
 	pstring->Set_help(
 	        "Memory size (in MB) of the 3dfx Vodooo card (12 MB as default).");


### PR DESCRIPTION
The default value was "12mb" but valid values do not include "mb"

This fixes a warning: CONFIG: '12mb' is an invalid value for
'voodoo_memsize', using the default: '12mb'

Changed default from "12mb" to "12" to correct this.