### PR TITLE
Consistently cast and wrap the mixer's position

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -62,6 +62,7 @@ enum class MixerState {
 
 #define MIXER_BUFSIZE (16 * 1024)
 #define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
+
 extern uint8_t MixTemp[MIXER_BUFSIZE];
 extern int16_t lut_u8to16[UINT8_MAX + 1];
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -60,10 +60,12 @@ enum class MixerState {
 	Muted
 };
 
-#define MIXER_BUFSIZE (16 * 1024)
-#define MIXER_BUFMASK (MIXER_BUFSIZE - 1)
+using work_index_t = uint16_t;
 
-extern uint8_t MixTemp[MIXER_BUFSIZE];
+static constexpr work_index_t MixerBufferLength = {16 * 1024};
+static constexpr work_index_t MixerBufferMask   = {MixerBufferLength - 1};
+
+extern uint8_t MixTemp[MixerBufferLength];
 extern int16_t lut_u8to16[UINT8_MAX + 1];
 
 #define MAX_AUDIO ((1<<(16-1))-1)
@@ -138,8 +140,6 @@ enum class ResampleMethod {
 	// (everything below half the channel's sample rate is cut).
 	Resample
 };
-
-using work_index_t = uint16_t;
 
 // forward declarations
 struct SpeexResamplerState_;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -369,7 +369,7 @@ private:
 		uint32_t                 totalTrackFrames   = 0;
 		uint32_t                 startSector        = 0;
 		uint32_t                 totalRedbookFrames = 0;
-		int16_t                  buffer[MIXER_BUFSIZE * REDBOOK_CHANNELS] = {0};
+		int16_t buffer[MixerBufferLength * REDBOOK_CHANNELS] = {0};
 		bool                     isPlaying          = false;
 		bool                     isPaused           = false;
 	} player;


### PR DESCRIPTION
Applies the same ring-buffer wrapping in all places in the mixer, consistently. Possibly fixes #2704.

