### PR TITLE
Change sdl.opengl.shader_source from std::string_view to std::string

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -191,7 +191,7 @@ struct SDL_Block {
 		bool use_shader;
 		bool framebuffer_is_srgb_encoded;
 		GLuint program_object;
-		std::string_view shader_source_sv = {};
+		std::string shader_source = {};
 		struct {
 			GLint texture_size;
 			GLint input_size;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2294,8 +2294,7 @@ dosurface:
 void GFX_SetShader([[maybe_unused]] const std::string &source)
 {
 #if C_OPENGL
-	if (sdl.opengl.shader_source != source)
-		sdl.opengl.shader_source = source;
+	sdl.opengl.shader_source = source;
 
 	if (!sdl.opengl.use_shader)
 		return;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2039,7 +2039,7 @@ dosurface:
 				if (sdl.opengl.program_object == 0) {
 					GLuint vertexShader, fragmentShader;
 
-					if (!LoadGLShaders(sdl.opengl.shader_source_sv,
+					if (!LoadGLShaders(sdl.opengl.shader_source,
 					                   &vertexShader,
 					                   &fragmentShader)) {
 						LOG_ERR("SDL:OPENGL: Failed to compile shader!");
@@ -2294,8 +2294,8 @@ dosurface:
 void GFX_SetShader([[maybe_unused]] const std::string &source)
 {
 #if C_OPENGL
-	if (sdl.opengl.shader_source_sv != source)
-		sdl.opengl.shader_source_sv = source;
+	if (sdl.opengl.shader_source != source)
+		sdl.opengl.shader_source = source;
 
 	if (!sdl.opengl.use_shader)
 		return;


### PR DESCRIPTION
Fixes a potential use after free bug if the source string becomes invalidated.

@johnnovak I was unable to reproduce the crash on Linux.  Tried with `-Db_sanitize=address,undefined` on both Clang and GCC on your "Do not review" branch.  However, based on the stack trace you provided, I believe this is the root cause. 

We were storing a `std::string_view` in this SDL struct which causes undefined behavior if the backing string becomes invalidated.  I think this should really just be a `std::string`.

It doesn't matter much to me if you want to do the `std::move` stuff or not but this is liable to cause problems down the road regardless.  Quote from https://en.cppreference.com/w/cpp/string/basic_string_view

>  It is the programmer's responsibility to ensure that std::string_view does not outlive the pointed-to character array: 

Note how it says "character array" rather than "string".  I believe this can cause problems even with a copy instead of a move.  If the copy causes a heap reallocation to a different place in memory, that would also invalidate the character array.

I'd be interested to know if this fixes the crash for you.