### PR TITLE
Port keymapper to SDL renderer

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -60,15 +60,11 @@ constexpr Rgb888 marginal_color(255, 103, 0); // Amber for marginal conditions
 constexpr Rgb888 on_color(0, 1, 0);           // Green for on/ready/in-use
 constexpr Rgb888 off_color(0, 0, 0);          // Black for off/stopped/not-in-use
 
-enum {
-	CLR_BLACK=0,
-	CLR_GREY=1,
-	CLR_WHITE=2,
-	CLR_RED=3,
-	CLR_BLUE=4,
-	CLR_GREEN=5,
-	CLR_LAST=6
-};
+constexpr Rgb888 color_black(0, 0, 0);
+constexpr Rgb888 color_grey(127, 127, 127);
+constexpr Rgb888 color_white(255, 255, 255);
+constexpr Rgb888 color_red(255, 0, 0);
+constexpr Rgb888 color_green(0, 255, 0);
 
 enum BB_Types {
 	BB_Next,BB_Add,BB_Del,
@@ -1383,10 +1379,8 @@ private:
 
 static struct CMapper {
 	SDL_Window *window = nullptr;
-	SDL_Rect draw_rect = {0, 0, 0, 0};
-	SDL_Surface *draw_surface_nonpaletted = nullptr; // Needed for SDL_BlitScaled
-	SDL_Surface *surface = nullptr;
-	SDL_Surface *draw_surface = nullptr;
+	SDL_Renderer* renderer  = nullptr;
+	SDL_Texture* font_atlas = nullptr;
 	bool exit = false;
 	CEvent *aevent = nullptr;  // Active Event
 	CBind *abind = nullptr;    // Active Bind
@@ -1425,33 +1419,28 @@ void CBindGroup::DeactivateBindList(CBindList * list,bool ev_trigger) {
 	}
 }
 
-static void DrawText(Bitu x,Bitu y,const char * text,uint8_t color) {
-	uint8_t * draw = ((uint8_t *)mapper.draw_surface->pixels) + (y * mapper.draw_surface->w) + x;
+static void DrawText(int32_t x, int32_t y, const char* text, const Rgb888& color)
+{
+	SDL_Rect character_rect = {0, 0, 8, 14};
+	SDL_Rect dest_rect      = {x, y, 8, 14};
+	SDL_SetTextureColorMod(mapper.font_atlas, color.red, color.green, color.blue);
 	while (*text) {
-		uint8_t * font=&int10_font_14[(*text)*14];
-		Bitu i,j;uint8_t * draw_line=draw;
-		for (i=0;i<14;i++) {
-			uint8_t map=*font++;
-			for (j=0;j<8;j++) {
-				if (map & 0x80) *(draw_line+j)=color;
-				else *(draw_line+j)=CLR_BLACK;
-				map<<=1;
-			}
-			draw_line += mapper.draw_surface->w;
-		}
-		text++;draw+=8;
+		character_rect.y = *text * character_rect.h;
+		SDL_RenderCopy(mapper.renderer,
+		               mapper.font_atlas,
+		               &character_rect,
+		               &dest_rect);
+		text++;
+		dest_rect.x += character_rect.w;
 	}
 }
 
 class CButton {
 public:
-	CButton(Bitu p_x, Bitu p_y, Bitu p_dx, Bitu p_dy)
-		: x(p_x),
-		  y(p_y),
-		  dx(p_dx),
-		  dy(p_dy),
-		  color(CLR_WHITE),
-		  enabled(true)
+	CButton(int32_t p_x, int32_t p_y, int32_t p_dx, int32_t p_dy)
+	        : rect{p_x, p_y, p_dx, p_dy},
+	          color(color_white),
+	          enabled(true)
 	{
 		buttons.push_back(this);
 	}
@@ -1461,19 +1450,20 @@ public:
 	virtual void Draw() {
 		if (!enabled)
 			return;
-		uint8_t * point = ((uint8_t *)mapper.draw_surface->pixels) + (y * mapper.draw_surface->w) + x;
-		for (Bitu lines=0;lines<dy;lines++)  {
-			if (lines==0 || lines==(dy-1)) {
-				for (Bitu cols=0;cols<dx;cols++) *(point+cols)=color;
-			} else {
-				*point=color;*(point+dx-1)=color;
-			}
-			point += mapper.draw_surface->w;
-		}
+		SDL_SetRenderDrawColor(mapper.renderer,
+		                       color.red,
+		                       color.green,
+		                       color.blue,
+		                       SDL_ALPHA_OPAQUE);
+		SDL_RenderDrawRect(mapper.renderer, &rect);
 	}
-	virtual bool OnTop(Bitu _x,Bitu _y) {
-		return ( enabled && (_x>=x) && (_x<x+dx) && (_y>=y) && (_y<y+dy));
+
+	virtual bool OnTop(int32_t _x, int32_t _y)
+	{
+		return (enabled && (_x >= rect.x) && (_x < rect.x + rect.w) &&
+		        (_y >= rect.y) && (_y < rect.y + rect.h));
 	}
+
 	virtual void BindColor() {}
 	virtual void Click() {}
 
@@ -1483,10 +1473,14 @@ public:
 		mapper.redraw = true;
 	}
 
-	void SetColor(uint8_t _col) { color=_col; }
+	void SetColor(const Rgb888& _col)
+	{
+		color = _col;
+	}
+
 protected:
-	Bitu x,y,dx,dy;
-	uint8_t color;
+	SDL_Rect rect;
+	Rgb888 color;
 	bool enabled;
 };
 
@@ -1494,9 +1488,9 @@ protected:
 //+V773:SUPPRESS, class:CTextButton
 class CTextButton : public CButton {
 public:
-	CTextButton(Bitu  x, Bitu y, Bitu dx, Bitu dy, const char *txt)
-		: CButton(x, y, dx, dy),
-		  text(txt)
+	CTextButton(int32_t x, int32_t y, int32_t dx, int32_t dy, const char* txt)
+	        : CButton(x, y, dx, dy),
+	          text(txt)
 	{}
 
 	CTextButton(const CTextButton&) = delete; // prevent copy
@@ -1507,7 +1501,7 @@ public:
 		if (!enabled)
 			return;
 		CButton::Draw();
-		DrawText(x + 2, y + 2, text.c_str(), color);
+		DrawText(rect.x + 2, rect.y + 2, text.c_str(), color);
 	}
 
 	void SetText(const std::string &txt) { text = txt; }
@@ -1518,13 +1512,14 @@ protected:
 
 class CClickableTextButton : public CTextButton {
 public:
-	CClickableTextButton(Bitu _x, Bitu _y, Bitu _dx, Bitu _dy, const char * _text)
-		: CTextButton(_x, _y, _dx, _dy, _text)
+	CClickableTextButton(int32_t _x, int32_t _y, int32_t _dx, int32_t _dy,
+	                     const char* _text)
+	        : CTextButton(_x, _y, _dx, _dy, _text)
 	{}
 
 	void BindColor() override
 	{
-		this->SetColor(CLR_WHITE);
+		this->SetColor(color_white);
 	}
 };
 
@@ -1533,20 +1528,23 @@ static CEventButton * last_clicked = nullptr;
 
 class CEventButton final : public CClickableTextButton {
 public:
-	CEventButton(Bitu x, Bitu y, Bitu dx, Bitu dy, const char *text, CEvent *ev)
-		: CClickableTextButton(x, y, dx, dy, text),
-		  event(ev)
+	CEventButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
+	             const char* text, CEvent* ev)
+	        : CClickableTextButton(x, y, dx, dy, text),
+	          event(ev)
 	{}
 
 	CEventButton(const CEventButton&) = delete; // prevent copy
 	CEventButton& operator=(const CEventButton&) = delete; // prevent assignment
 
 	void BindColor() override {
-		this->SetColor(event->bindlist.begin()==event->bindlist.end() ? CLR_GREY : CLR_WHITE);
+		this->SetColor(event->bindlist.begin() == event->bindlist.end()
+		                       ? color_grey
+		                       : color_white);
 	}
 	void Click() override {
 		if (last_clicked) last_clicked->BindColor();
-		this->SetColor(CLR_GREEN);
+		this->SetColor(color_green);
 		SetActiveEvent(event);
 		last_clicked=this;
 	}
@@ -1556,14 +1554,16 @@ protected:
 
 class CCaptionButton final : public CButton {
 public:
-	CCaptionButton(Bitu _x,Bitu _y,Bitu _dx,Bitu _dy) : CButton(_x,_y,_dx,_dy){
+	CCaptionButton(int32_t _x, int32_t _y, int32_t _dx, int32_t _dy)
+	        : CButton(_x, _y, _dx, _dy)
+	{
 		caption[0]=0;
 	}
 	void Change(const char * format,...) GCC_ATTRIBUTE(__format__(__printf__,2,3));
 
 	void Draw() override {
 		if (!enabled) return;
-		DrawText(x+2,y+2,caption,color);
+		DrawText(rect.x + 2, rect.y + 2, caption, color);
 	}
 protected:
 	char caption[128] = {};
@@ -1577,15 +1577,16 @@ void CCaptionButton::Change(const char * format,...) {
 	mapper.redraw=true;
 }
 
-static void change_action_text(const char* text,uint8_t col);
+static void change_action_text(const char* text, const Rgb888& col);
 
 static void MAPPER_SaveBinds();
 
 class CBindButton final : public CClickableTextButton {
 public:
-	CBindButton(Bitu _x, Bitu _y, Bitu _dx, Bitu _dy, const char * _text, BB_Types _type)
-		: CClickableTextButton(_x, _y, _dx, _dy, _text),
-		  type(_type)
+	CBindButton(int32_t _x, int32_t _y, int32_t _dx, int32_t _dy,
+	            const char* _text, BB_Types _type)
+	        : CClickableTextButton(_x, _y, _dx, _dy, _text),
+	          type(_type)
 	{}
 
 	void Click() override {
@@ -1593,7 +1594,8 @@ public:
 		case BB_Add:
 			mapper.addbind=true;
 			SetActiveBind(nullptr);
-			change_action_text("Press a key/joystick button or move the joystick.",CLR_RED);
+			change_action_text("Press a key/joystick button or move the joystick.",
+			                   color_red);
 			break;
 		case BB_Del:
 			if (mapper.abindit != mapper.aevent->bindlist.end()) {
@@ -1628,9 +1630,10 @@ protected:
 
 class CCheckButton final : public CClickableTextButton {
 public:
-	CCheckButton(Bitu x, Bitu y, Bitu dx, Bitu dy, const char *text, BC_Types t)
-		: CClickableTextButton(x, y, dx, dy, text),
-		  type(t)
+	CCheckButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
+	             const char* text, BC_Types t)
+	        : CClickableTextButton(x, y, dx, dy, text),
+	          type(t)
 	{}
 
 	void Draw() override {
@@ -1651,11 +1654,16 @@ public:
 			break;
 		}
 		if (checked) {
-			uint8_t * point=((uint8_t *)mapper.draw_surface->pixels)+((y+2)*mapper.draw_surface->w)+x+dx-dy+2;
-			for (Bitu lines=0;lines<(dy-4);lines++)  {
-				memset(point,color,dy-4);
-				point+=mapper.draw_surface->w;
-			}
+			const SDL_Rect checkbox_rect = {rect.x + rect.w - rect.h + 2,
+			                                rect.y + 2,
+			                                rect.h - 4,
+			                                rect.h - 4};
+			SDL_SetRenderDrawColor(mapper.renderer,
+			                       color.red,
+			                       color.green,
+			                       color.blue,
+			                       SDL_ALPHA_OPAQUE);
+			SDL_RenderFillRect(mapper.renderer, &checkbox_rect);
 		}
 		CClickableTextButton::Draw();
 	}
@@ -1838,8 +1846,8 @@ static struct {
 	CCheckButton * mod1,* mod2,* mod3,* hold;
 } bind_but;
 
-
-static void change_action_text(const char* text,uint8_t col) {
+static void change_action_text(const char* text, const Rgb888& col)
+{
 	bind_but.action->Change(text,"");
 	bind_but.action->SetColor(col);
 }
@@ -1948,7 +1956,7 @@ static void update_active_bind_ui()
 	                            (mods & BMOD_Mod3 ? mod_3_desc.c_str() : ""),
 	                            mapper.abind->GetBindName().c_str());
 
-	bind_but.bind_title->SetColor(CLR_GREEN);
+	bind_but.bind_title->SetColor(color_green);
 	bind_but.bind_title->Enable(true);
 	bind_but.del->Enable(true);
 	bind_but.next->Enable(active_event_binds_num > 1);
@@ -1967,12 +1975,12 @@ static void SetActiveEvent(CEvent * event) {
 	mapper.addbind=false;
 	bind_but.event_title->Change("   Event: %s", event ? event->GetName() : "none");
 	if (!event) {
-		change_action_text("Select an event to change.",CLR_WHITE);
+		change_action_text("Select an event to change.", color_white);
 		bind_but.add->Enable(false);
 		SetActiveBind(nullptr);
 	} else {
 		change_action_text("Modify the bindings for this event or select a different event.",
-		                   CLR_WHITE);
+		                   color_white);
 		mapper.abindit=event->bindlist.begin();
 		if (mapper.abindit!=event->bindlist.end()) {
 			SetActiveBind(*(mapper.abindit));
@@ -1981,25 +1989,24 @@ static void SetActiveEvent(CEvent * event) {
 	}
 }
 
-extern SDL_Window* GFX_SetSDLSurfaceWindow(uint16_t width, uint16_t height,
-                                           bool allow_highdpi = true);
-extern SDL_Rect GFX_GetSDLSurfaceSubwindowDims(uint16_t width, uint16_t height);
+extern SDL_Window* GFX_GetWindow();
 extern void GFX_UpdateDisplayDimensions(int width, int height);
 
 static void DrawButtons() {
-	SDL_FillRect(mapper.draw_surface,nullptr,CLR_BLACK);
+	SDL_SetRenderDrawColor(mapper.renderer,
+	                       color_black.red,
+	                       color_black.green,
+	                       color_black.blue,
+	                       SDL_ALPHA_OPAQUE);
+	SDL_RenderClear(mapper.renderer);
 	for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 		(*but_it)->Draw();
 	}
-	// We can't just use SDL_BlitScaled (say for Android) in one step
-	SDL_BlitSurface(mapper.draw_surface, nullptr, mapper.draw_surface_nonpaletted, nullptr);
-	SDL_BlitScaled(mapper.draw_surface_nonpaletted, nullptr, mapper.surface, &mapper.draw_rect);
-	//SDL_BlitSurface(mapper.draw_surface, NULL, mapper.surface, NULL);
-	SDL_UpdateWindowSurface(mapper.window);
+	SDL_RenderPresent(mapper.renderer);
 }
 
-static CKeyEvent* AddKeyButtonEvent(Bitu x, Bitu y, Bitu dx, Bitu dy,
-                                    const char* const title,
+static CKeyEvent* AddKeyButtonEvent(int32_t x, int32_t y, int32_t dx,
+                                    int32_t dy, const char* const title,
                                     const char* const entry, KBD_KEYS key)
 {
 	char buf[64];
@@ -2010,7 +2017,7 @@ static CKeyEvent* AddKeyButtonEvent(Bitu x, Bitu y, Bitu dx, Bitu dy,
 	return event;
 }
 
-static CJAxisEvent* AddJAxisButton(Bitu x, Bitu y, Bitu dx, Bitu dy,
+static CJAxisEvent* AddJAxisButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
                                    const char* const title, Bitu stick, Bitu axis,
                                    bool positive, CJAxisEvent* opposite_axis)
 {
@@ -2032,7 +2039,7 @@ static CJAxisEvent * AddJAxisButton_hidden(Bitu stick,Bitu axis,bool positive,CJ
 	return new CJAxisEvent(buf,stick,axis,positive,opposite_axis);
 }
 
-static void AddJButtonButton(Bitu x, Bitu y, Bitu dx, Bitu dy,
+static void AddJButtonButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
                              const char* const title, Bitu stick, Bitu button)
 {
 	char buf[64];
@@ -2050,8 +2057,8 @@ static void AddJButtonButton_hidden(Bitu stick,Bitu button) {
 	new CJButtonEvent(buf,stick,button);
 }
 
-static void AddJHatButton(Bitu x, Bitu y, Bitu dx, Bitu dy, const char* const title,
-                          Bitu _stick, Bitu _hat, Bitu _dir)
+static void AddJHatButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
+                          const char* const title, Bitu _stick, Bitu _hat, Bitu _dir)
 {
 	char buf[64];
 	sprintf(buf, "jhat_%d_%d_%d",
@@ -2062,7 +2069,7 @@ static void AddJHatButton(Bitu x, Bitu y, Bitu dx, Bitu dy, const char* const ti
 	new CEventButton(x,y,dx,dy,title,event);
 }
 
-static void AddModButton(Bitu x, Bitu y, Bitu dx, Bitu dy,
+static void AddModButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
                          const char* const title, int mod)
 {
 	char buf[64];
@@ -2311,12 +2318,12 @@ static void CreateLayout() {
 		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Joystick 1");
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Joystick 2");
 		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
-		btn->SetColor(CLR_GREY);
+		btn->SetColor(color_grey);
 	} else if(joytype ==JOY_4AXIS || joytype == JOY_4AXIS_2) {
 		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
 		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
-		btn->SetColor(CLR_GREY);
+		btn->SetColor(color_grey);
 	} else if(joytype == JOY_CH) {
 		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
@@ -2327,11 +2334,11 @@ static void CreateLayout() {
 		new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Hat/D-pad");
 	} else if (joytype == JOY_DISABLED) {
 		btn=new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Disabled");
-		btn->SetColor(CLR_GREY);
+		btn->SetColor(color_grey);
 		btn=new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Disabled");
-		btn->SetColor(CLR_GREY);
+		btn->SetColor(color_grey);
 		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
-		btn->SetColor(CLR_GREY);
+		btn->SetColor(color_grey);
 	}
 
 	/* The modifier buttons */
@@ -2374,15 +2381,6 @@ static void CreateLayout() {
 
 	bind_but.bind_title->Change("Bind Title");
 }
-
-static SDL_Color map_pal[CLR_LAST]={
-	{0x00,0x00,0x00,0x00},			//0=black
-	{0x7f,0x7f,0x7f,0x00},			//1=grey
-	{0xff,0xff,0xff,0x00},			//2=white
-	{0xff,0x00,0x00,0x00},			//3=red
-	{0x10,0x30,0xff,0x00},			//4=blue
-	{0x00,0xff,0x20,0x00}			//5=green
-};
 
 static void CreateStringBind(char * line) {
 	line=trim(line);
@@ -2644,7 +2642,7 @@ static void MAPPER_SaveBinds() {
 		fprintf(savefile,"\n");
 	}
 	fclose(savefile);
-	change_action_text("Mapper file saved.",CLR_WHITE);
+	change_action_text("Mapper file saved.", color_white);
 	LOG_MSG("MAPPER: Wrote key bindings to %s", filename);
 }
 
@@ -2706,14 +2704,8 @@ void BIND_MappingEvents() {
 		case SDL_MOUSEMOTION:
 			if (!isButtonPressed)
 				break;
-			/* Normalize position in case a scaled sub-window is used (say on Android) */
-			event.button.x = (event.button.x - mapper.draw_rect.x) * mapper.draw_surface->w / mapper.draw_rect.w;
-			if ((event.button.x < 0) || (event.button.x >= mapper.draw_surface->w))
-				break;
-			event.button.y = (event.button.y - mapper.draw_rect.y) * mapper.draw_surface->h / mapper.draw_rect.h;
-			if ((event.button.y < 0) || (event.button.y >= mapper.draw_surface->h))
-				break;
-			/* Maybe we have been pointing at a specific button for a little while  */
+			/* Maybe we have been pointing at a specific button for
+			 * a little while  */
 			if (lastHoveredButton) {
 				/* Check if there's any change */
 				if (lastHoveredButton->OnTop(event.button.x,event.button.y))
@@ -2729,8 +2721,8 @@ void BIND_MappingEvents() {
 			/* Check which button are we currently pointing at */
 			for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 				if (dynamic_cast<CClickableTextButton *>(*but_it) && (*but_it)->OnTop(event.button.x,event.button.y)) {
-					(*but_it)->SetColor(CLR_RED);
-					mapper.redraw = true;
+					(*but_it)->SetColor(color_red);
+					mapper.redraw     = true;
 					lastHoveredButton = *but_it;
 					break;
 				}
@@ -2744,13 +2736,6 @@ void BIND_MappingEvents() {
 				mapper.redraw = true;
 				lastHoveredButton = nullptr;
 			}
-			/* Normalize position in case a scaled sub-window is used (say on Android) */
-			event.button.x = (event.button.x - mapper.draw_rect.x) * mapper.draw_surface->w / mapper.draw_rect.w;
-			if ((event.button.x < 0) || (event.button.x>=mapper.draw_surface->w))
-				break;
-			event.button.y = (event.button.y - mapper.draw_rect.y) * mapper.draw_surface->h / mapper.draw_rect.h;
-			if ((event.button.y < 0) || (event.button.y>=mapper.draw_surface->h))
-				break;
 			/* Check the press */
 			for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 				if (dynamic_cast<CClickableTextButton *>(*but_it) && (*but_it)->OnTop(event.button.x,event.button.y)) {
@@ -2766,13 +2751,11 @@ void BIND_MappingEvents() {
 			 * toggled, at least on X11. Furthermore, the restore
 			 * event should be handled on Android.
 			 */
-			if ((event.window.event == SDL_WINDOWEVENT_RESIZED)
-			    || (event.window.event == SDL_WINDOWEVENT_RESTORED)) {
-				mapper.surface = SDL_GetWindowSurface(mapper.window);
-				if (mapper.surface == nullptr)
-					E_Exit("Couldn't refresh mapper window surface after resize or restoration: %s", SDL_GetError());
-				GFX_UpdateDisplayDimensions(event.window.data1, event.window.data2);
-				mapper.draw_rect = GFX_GetSDLSurfaceSubwindowDims(640, 480);
+			if ((event.window.event == SDL_WINDOWEVENT_RESIZED) ||
+			    (event.window.event == SDL_WINDOWEVENT_RESTORED)) {
+				GFX_UpdateDisplayDimensions(event.window.data1,
+				                            event.window.data2);
+				SDL_RenderSetLogicalSize(mapper.renderer, 640, 480);
 				DrawButtons();
 			}
 			break;
@@ -2995,22 +2978,51 @@ void MAPPER_DisplayUI() {
 
 	// Be sure that there is no update in progress
 	GFX_EndUpdate( nullptr );
-	mapper.window = GFX_SetSDLSurfaceWindow(640, 480, false);
-	if (mapper.window == nullptr)
+	mapper.window = GFX_GetWindow();
+	if (mapper.window == nullptr) {
 		E_Exit("Could not initialize video mode for mapper: %s", SDL_GetError());
-	mapper.surface = SDL_GetWindowSurface(mapper.window);
-	if (mapper.surface == nullptr)
-		E_Exit("Could not retrieve window surface for mapper: %s", SDL_GetError());
+	}
+	mapper.renderer = SDL_GetRenderer(mapper.window);
+#if C_OPENGL
+	SDL_GLContext context = nullptr;
+	if (!mapper.renderer) {
+		context         = SDL_GL_GetCurrentContext();
+		mapper.renderer = SDL_CreateRenderer(mapper.window, -1, 0);
+	}
+#endif
+	if (mapper.renderer == nullptr) {
+		E_Exit("Could not retrieve window renderer for mapper: %s",
+		       SDL_GetError());
+	}
 
-	/* Set some palette entries */
-	mapper.draw_surface=SDL_CreateRGBSurface(0,640,480,8,0,0,0,0);
-	// Needed for SDL_BlitScaled
-	mapper.draw_surface_nonpaletted=SDL_CreateRGBSurface(0,640,480,32,0x0000ff00,0x00ff0000,0xff000000,0);
-	mapper.draw_rect=GFX_GetSDLSurfaceSubwindowDims(640,480);
-	// Sorry, but SDL_SetSurfacePalette requires a full palette.
-	SDL_Palette *sdl2_map_pal_ptr = SDL_AllocPalette(256);
-	SDL_SetPaletteColors(sdl2_map_pal_ptr, map_pal, 0, CLR_LAST);
-	SDL_SetSurfacePalette(mapper.draw_surface, sdl2_map_pal_ptr);
+	SDL_RenderSetLogicalSize(mapper.renderer, 640, 480);
+
+	// Create font atlas surface
+	SDL_Surface* atlas_surface = SDL_CreateRGBSurfaceFrom(
+	        int10_font_14, 8, 256 * 14, 1, 1, 0, 0, 0, 0);
+	if (atlas_surface == nullptr) {
+		E_Exit("Failed to create atlas surface for mapper: %s",
+		       SDL_GetError());
+	}
+
+	// Invert default surface palette
+	const SDL_Color atlas_colors[2] = {{0x00, 0x00, 0x00, 0x00},
+	                                   {0xff, 0xff, 0xff, 0xff}};
+	if (SDL_SetPaletteColors(atlas_surface->format->palette, atlas_colors, 0, 2) <
+	    0) {
+		LOG_WARNING("Failed to set colors in font atlas: %s",
+		            SDL_GetError());
+	}
+
+	// Convert surface to texture for accelerated SDL renderer
+	mapper.font_atlas = SDL_CreateTextureFromSurface(mapper.renderer,
+	                                                 atlas_surface);
+	SDL_FreeSurface(atlas_surface);
+	atlas_surface = nullptr;
+	if (mapper.font_atlas == nullptr) {
+		E_Exit("Failed to create font texture atlas: %s", SDL_GetError());
+	}
+
 	if (last_clicked) {
 		last_clicked->BindColor();
 		last_clicked=nullptr;
@@ -3026,17 +3038,25 @@ void MAPPER_DisplayUI() {
 		if (mapper.redraw) {
 			mapper.redraw = false;
 			DrawButtons();
-		} else {
-			SDL_UpdateWindowSurface(mapper.window);
 		}
 		BIND_MappingEvents();
 		Delay(1);
 	}
 	/* ONE SHOULD NOT FORGET TO DO THIS!
 	Unless a memory leak is desired... */
-	SDL_FreeSurface(mapper.draw_surface);
-	SDL_FreeSurface(mapper.draw_surface_nonpaletted);
-	SDL_FreePalette(sdl2_map_pal_ptr);
+	SDL_DestroyTexture(mapper.font_atlas);
+	SDL_RenderSetLogicalSize(mapper.renderer, 0, 0);
+	SDL_SetRenderDrawColor(mapper.renderer,
+	                       color_black.red,
+	                       color_black.green,
+	                       color_black.blue,
+	                       SDL_ALPHA_OPAQUE);
+#if C_OPENGL
+	if (context) {
+		SDL_DestroyRenderer(mapper.renderer);
+		SDL_GL_MakeCurrent(mapper.window, context);
+	}
+#endif
 #if defined (REDUCE_JOYSTICK_POLLING)
 	SDL_JoystickEventState(SDL_DISABLE);
 #endif

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2138,99 +2138,107 @@ static CKeyEvent * caps_lock_event=nullptr;
 static CKeyEvent * num_lock_event=nullptr;
 
 static void CreateLayout() {
-	Bitu i;
+	int32_t i;
 	/* Create the buttons for the Keyboard */
-#define BW 28
-#define BH 20
-#define DX 5
-#define PX(_X_) ((_X_)*BW + DX)
-#define PY(_Y_) (10+(_Y_)*BH)
-	AddKeyButtonEvent(PX(0),PY(0),BW,BH,"ESC","esc",KBD_esc);
-	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(0),BW,BH,combo_f[i].title,combo_f[i].entry,combo_f[i].key);
-	for (i=0;i<14;i++) AddKeyButtonEvent(PX(  i),PY(1),BW,BH,combo_1[i].title,combo_1[i].entry,combo_1[i].key);
-
-	AddKeyButtonEvent(PX(0),PY(2),BW*2,BH,"TAB","tab",KBD_tab);
-	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(2),BW,BH,combo_2[i].title,combo_2[i].entry,combo_2[i].key);
-
-	AddKeyButtonEvent(PX(14),PY(2),BW*2,BH*2,"ENTER","enter",KBD_enter);
-
-	caps_lock_event=AddKeyButtonEvent(PX(0),PY(3),BW*2,BH,"CLCK","capslock",KBD_capslock);
-	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(3),BW,BH,combo_3[i].title,combo_3[i].entry,combo_3[i].key);
-
-	AddKeyButtonEvent(PX(0),PY(4),BW*2,BH,"SHIFT","lshift",KBD_leftshift);
+	constexpr int32_t button_width  = 28;
+	constexpr int32_t button_height = 20;
+	constexpr int32_t margin        = 5;
+	constexpr auto pos_x = [](int32_t x) { return x * button_width + margin; };
+	constexpr auto pos_y = [](int32_t y) { return 10 + y * button_height; };
+	AddKeyButtonEvent(pos_x(0), pos_y(0), button_width, button_height, "ESC", "esc", KBD_esc);
 	for (i = 0; i < 12; i++) {
-		AddKeyButtonEvent(PX(2 + i),
-		                  PY(4),
-		                  BW,
-		                  BH,
+		AddKeyButtonEvent(pos_x(2 + i), pos_y(0), button_width, button_height, combo_f[i].title, combo_f[i].entry, combo_f[i].key);
+	}
+	for (i = 0; i < 14; i++) {
+		AddKeyButtonEvent(pos_x(i), pos_y(1), button_width, button_height, combo_1[i].title, combo_1[i].entry, combo_1[i].key);
+	}
+
+	AddKeyButtonEvent(pos_x(0), pos_y(2), button_width * 2, button_height, "TAB", "tab", KBD_tab);
+	for (i = 0; i < 12; i++) {
+		AddKeyButtonEvent(pos_x(2 + i), pos_y(2), button_width, button_height, combo_2[i].title, combo_2[i].entry, combo_2[i].key);
+	}
+
+	AddKeyButtonEvent(pos_x(14), pos_y(2), button_width * 2, button_height * 2, "ENTER", "enter", KBD_enter);
+
+	caps_lock_event = AddKeyButtonEvent(pos_x(0), pos_y(3), button_width * 2, button_height, "CLCK", "capslock", KBD_capslock);
+	for (i = 0; i < 12; i++) {
+		AddKeyButtonEvent(pos_x(2 + i), pos_y(3), button_width, button_height, combo_3[i].title, combo_3[i].entry, combo_3[i].key);
+	}
+
+	AddKeyButtonEvent(pos_x(0), pos_y(4), button_width * 2, button_height, "SHIFT", "lshift", KBD_leftshift);
+	for (i = 0; i < 12; i++) {
+		AddKeyButtonEvent(pos_x(2 + i),
+		                  pos_y(4),
+		                  button_width,
+		                  button_height,
 		                  combo_4[i].title,
 		                  combo_4[i].entry,
 		                  combo_4[i].key);
 	}
-	AddKeyButtonEvent(PX(14), PY(4), BW * 3, BH, "SHIFT", "rshift", KBD_rightshift);
+	AddKeyButtonEvent(pos_x(14), pos_y(4), button_width * 3, button_height, "SHIFT", "rshift", KBD_rightshift);
 
 	/* Bottom Row */
-	AddKeyButtonEvent(PX(0), PY(5), BW * 2, BH, MMOD1_NAME, "lctrl", KBD_leftctrl);
+	AddKeyButtonEvent(pos_x(0), pos_y(5), button_width * 2, button_height, MMOD1_NAME, "lctrl", KBD_leftctrl);
 
 #if !defined(MACOSX)
-	AddKeyButtonEvent(PX(2), PY(5), BW * 2, BH, MMOD3_NAME, "lgui", KBD_leftgui);
-	AddKeyButtonEvent(PX(4), PY(5), BW * 2, BH, MMOD2_NAME, "lalt", KBD_leftalt);
+	AddKeyButtonEvent(pos_x(2), pos_y(5), button_width * 2, button_height, MMOD3_NAME, "lgui", KBD_leftgui);
+	AddKeyButtonEvent(pos_x(4), pos_y(5), button_width * 2, button_height, MMOD2_NAME, "lalt", KBD_leftalt);
 #else
-	AddKeyButtonEvent(PX(2), PY(5), BW * 2, BH, MMOD2_NAME, "lalt", KBD_leftalt);
-	AddKeyButtonEvent(PX(4), PY(5), BW * 2, BH, MMOD3_NAME, "lgui", KBD_leftgui);
+	AddKeyButtonEvent(pos_x(2), pos_y(5), button_width * 2, button_height, MMOD2_NAME, "lalt", KBD_leftalt);
+	AddKeyButtonEvent(pos_x(4), pos_y(5), button_width * 2, button_height, MMOD3_NAME, "lgui", KBD_leftgui);
 #endif
 
-	AddKeyButtonEvent(PX(6), PY(5), BW * 4, BH, "SPACE", "space", KBD_space);
+	AddKeyButtonEvent(pos_x(6), pos_y(5), button_width * 4, button_height, "SPACE", "space", KBD_space);
 
 #if !defined(MACOSX)
-	AddKeyButtonEvent(PX(10), PY(5), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
-	AddKeyButtonEvent(PX(12), PY(5), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
+	AddKeyButtonEvent(pos_x(10), pos_y(5), button_width * 2, button_height, MMOD2_NAME, "ralt", KBD_rightalt);
+	AddKeyButtonEvent(pos_x(12), pos_y(5), button_width * 2, button_height, MMOD3_NAME, "rgui", KBD_rightgui);
 #else
-	AddKeyButtonEvent(PX(10), PY(5), BW * 2, BH, MMOD3_NAME, "rgui", KBD_rightgui);
-	AddKeyButtonEvent(PX(12), PY(5), BW * 2, BH, MMOD2_NAME, "ralt", KBD_rightalt);
+	AddKeyButtonEvent(pos_x(10), pos_y(5), button_width * 2, button_height, MMOD3_NAME, "rgui", KBD_rightgui);
+	AddKeyButtonEvent(pos_x(12), pos_y(5), button_width * 2, button_height, MMOD2_NAME, "ralt", KBD_rightalt);
 #endif
 
-	AddKeyButtonEvent(PX(14), PY(5), BW * 2, BH, MMOD1_NAME, "rctrl", KBD_rightctrl);
+	AddKeyButtonEvent(pos_x(14), pos_y(5), button_width * 2, button_height, MMOD1_NAME, "rctrl", KBD_rightctrl);
 
 	/* Arrow Keys */
 #define XO 17
 #define YO 0
 
-	AddKeyButtonEvent(PX(XO+0),PY(YO),BW,BH,"PRT","printscreen",KBD_printscreen);
-	AddKeyButtonEvent(PX(XO+1),PY(YO),BW,BH,"SCL","scrolllock",KBD_scrolllock);
-	AddKeyButtonEvent(PX(XO+2),PY(YO),BW,BH,"PAU","pause",KBD_pause);
-	AddKeyButtonEvent(PX(XO+0),PY(YO+1),BW,BH,"INS","insert",KBD_insert);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+1),BW,BH,"HOM","home",KBD_home);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+1),BW,BH,"PUP","pageup",KBD_pageup);
-	AddKeyButtonEvent(PX(XO+0),PY(YO+2),BW,BH,"DEL","delete",KBD_delete);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+2),BW,BH,"END","end",KBD_end);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+2),BW,BH,"PDN","pagedown",KBD_pagedown);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+4),BW,BH,"\x18","up",KBD_up);
-	AddKeyButtonEvent(PX(XO+0),PY(YO+5),BW,BH,"\x1B","left",KBD_left);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+5),BW,BH,"\x19","down",KBD_down);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+5),BW,BH,"\x1A","right",KBD_right);
+	AddKeyButtonEvent(pos_x(XO + 0), pos_y(YO), button_width, button_height, "PRT", "printscreen", KBD_printscreen);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO), button_width, button_height, "SCL", "scrolllock", KBD_scrolllock);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO), button_width, button_height, "PAU", "pause", KBD_pause);
+	AddKeyButtonEvent(pos_x(XO + 0), pos_y(YO + 1), button_width, button_height, "INS", "insert", KBD_insert);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 1), button_width, button_height, "HOM", "home", KBD_home);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 1), button_width, button_height, "PUP", "pageup", KBD_pageup);
+	AddKeyButtonEvent(pos_x(XO + 0), pos_y(YO + 2), button_width, button_height, "DEL", "delete", KBD_delete);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 2), button_width, button_height, "END", "end", KBD_end);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 2), button_width, button_height, "PDN", "pagedown", KBD_pagedown);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 4), button_width, button_height, "\x18", "up", KBD_up);
+	AddKeyButtonEvent(pos_x(XO + 0), pos_y(YO + 5), button_width, button_height, "\x1B", "left", KBD_left);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 5), button_width, button_height, "\x19", "down", KBD_down);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 5), button_width, button_height, "\x1A", "right", KBD_right);
 #undef XO
 #undef YO
 #define XO 0
 #define YO 7
 	/* Numeric KeyPad */
-	num_lock_event=AddKeyButtonEvent(PX(XO),PY(YO),BW,BH,"NUM","numlock",KBD_numlock);
-	AddKeyButtonEvent(PX(XO+1),PY(YO),BW,BH,"/","kp_divide",KBD_kpdivide);
-	AddKeyButtonEvent(PX(XO+2),PY(YO),BW,BH,"*","kp_multiply",KBD_kpmultiply);
-	AddKeyButtonEvent(PX(XO+3),PY(YO),BW,BH,"-","kp_minus",KBD_kpminus);
-	AddKeyButtonEvent(PX(XO+0),PY(YO+1),BW,BH,"7","kp_7",KBD_kp7);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+1),BW,BH,"8","kp_8",KBD_kp8);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+1),BW,BH,"9","kp_9",KBD_kp9);
-	AddKeyButtonEvent(PX(XO+3),PY(YO+1),BW,BH*2,"+","kp_plus",KBD_kpplus);
-	AddKeyButtonEvent(PX(XO),PY(YO+2),BW,BH,"4","kp_4",KBD_kp4);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+2),BW,BH,"5","kp_5",KBD_kp5);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+2),BW,BH,"6","kp_6",KBD_kp6);
-	AddKeyButtonEvent(PX(XO+0),PY(YO+3),BW,BH,"1","kp_1",KBD_kp1);
-	AddKeyButtonEvent(PX(XO+1),PY(YO+3),BW,BH,"2","kp_2",KBD_kp2);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+3),BW,BH,"3","kp_3",KBD_kp3);
-	AddKeyButtonEvent(PX(XO+3),PY(YO+3),BW,BH*2,"ENT","kp_enter",KBD_kpenter);
-	AddKeyButtonEvent(PX(XO),PY(YO+4),BW*2,BH,"0","kp_0",KBD_kp0);
-	AddKeyButtonEvent(PX(XO+2),PY(YO+4),BW,BH,".","kp_period",KBD_kpperiod);
+	num_lock_event = AddKeyButtonEvent(pos_x(XO), pos_y(YO), button_width, button_height, "NUM", "numlock", KBD_numlock);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO), button_width, button_height, "/", "kp_divide", KBD_kpdivide);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO), button_width, button_height, "*", "kp_multiply", KBD_kpmultiply);
+	AddKeyButtonEvent(pos_x(XO + 3), pos_y(YO), button_width, button_height, "-", "kp_minus", KBD_kpminus);
+	AddKeyButtonEvent(pos_x(XO + 0), pos_y(YO + 1), button_width, button_height, "7", "kp_7", KBD_kp7);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 1), button_width, button_height, "8", "kp_8", KBD_kp8);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 1), button_width, button_height, "9", "kp_9", KBD_kp9);
+	AddKeyButtonEvent(pos_x(XO + 3), pos_y(YO + 1), button_width, button_height * 2, "+", "kp_plus", KBD_kpplus);
+	AddKeyButtonEvent(pos_x(XO), pos_y(YO + 2), button_width, button_height, "4", "kp_4", KBD_kp4);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 2), button_width, button_height, "5", "kp_5", KBD_kp5);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 2), button_width, button_height, "6", "kp_6", KBD_kp6);
+	AddKeyButtonEvent(pos_x(XO + 0), pos_y(YO + 3), button_width, button_height, "1", "kp_1", KBD_kp1);
+	AddKeyButtonEvent(pos_x(XO + 1), pos_y(YO + 3), button_width, button_height, "2", "kp_2", KBD_kp2);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 3), button_width, button_height, "3", "kp_3", KBD_kp3);
+	AddKeyButtonEvent(pos_x(XO + 3), pos_y(YO + 3), button_width, button_height * 2, "ENT", "kp_enter", KBD_kpenter);
+	AddKeyButtonEvent(pos_x(XO), pos_y(YO + 4), button_width * 2, button_height, "0", "kp_0", KBD_kp0);
+	AddKeyButtonEvent(pos_x(XO + 2), pos_y(YO + 4), button_width, button_height, ".", "kp_period", KBD_kpperiod);
 
 #undef XO
 #undef YO
@@ -2239,126 +2247,128 @@ static void CreateLayout() {
 #define YO 8
 	/* Joystick Buttons/Texts */
 	/* Buttons 1+2 of 1st Joystick */
-	AddJButtonButton(PX(XO),PY(YO),BW,BH,"1" ,0,0);
-	AddJButtonButton(PX(XO+2),PY(YO),BW,BH,"2" ,0,1);
+	AddJButtonButton(pos_x(XO), pos_y(YO), button_width, button_height, "1", 0, 0);
+	AddJButtonButton(pos_x(XO + 2), pos_y(YO), button_width, button_height, "2", 0, 1);
 	/* Axes 1+2 (X+Y) of 1st Joystick */
-	CJAxisEvent * cjaxis=AddJAxisButton(PX(XO+1),PY(YO),BW,BH,"Y-",0,1,false,nullptr);
-	AddJAxisButton  (PX(XO+1),PY(YO+1),BW,BH,"Y+",0,1,true,cjaxis);
-	cjaxis=AddJAxisButton  (PX(XO),PY(YO+1),BW,BH,"X-",0,0,false,nullptr);
-	AddJAxisButton  (PX(XO+2),PY(YO+1),BW,BH,"X+",0,0,true,cjaxis);
+	CJAxisEvent* cjaxis = AddJAxisButton(pos_x(XO + 1), pos_y(YO), button_width, button_height, "Y-", 0, 1, false, nullptr);
+	AddJAxisButton(pos_x(XO + 1), pos_y(YO + 1), button_width, button_height, "Y+", 0, 1, true, cjaxis);
+	cjaxis = AddJAxisButton(pos_x(XO), pos_y(YO + 1), button_width, button_height, "X-", 0, 0, false, nullptr);
+	AddJAxisButton(pos_x(XO + 2), pos_y(YO + 1), button_width, button_height, "X+", 0, 0, true, cjaxis);
 
 	CJAxisEvent * tmp_ptr;
 
 	assert(joytype != JOY_UNSET);
 	if (joytype == JOY_2AXIS) {
 		/* Buttons 1+2 of 2nd Joystick */
-		AddJButtonButton(PX(XO+4),PY(YO),BW,BH,"1" ,1,0);
-		AddJButtonButton(PX(XO+4+2),PY(YO),BW,BH,"2" ,1,1);
+		AddJButtonButton(pos_x(XO + 4), pos_y(YO), button_width, button_height, "1", 1, 0);
+		AddJButtonButton(pos_x(XO + 4 + 2), pos_y(YO), button_width, button_height, "2", 1, 1);
 		/* Buttons 3+4 of 1st Joystick, not accessible */
 		AddJButtonButton_hidden(0,2);
 		AddJButtonButton_hidden(0,3);
 
 		/* Axes 1+2 (X+Y) of 2nd Joystick */
-		cjaxis  = AddJAxisButton(PX(XO+4),PY(YO+1),BW,BH,"X-",1,0,false,nullptr);
-		tmp_ptr = AddJAxisButton(PX(XO+4+2),PY(YO+1),BW,BH,"X+",1,0,true,cjaxis);
+		cjaxis  = AddJAxisButton(pos_x(XO + 4), pos_y(YO + 1), button_width, button_height, "X-", 1, 0, false, nullptr);
+		tmp_ptr = AddJAxisButton(pos_x(XO + 4 + 2), pos_y(YO + 1), button_width, button_height, "X+", 1, 0, true, cjaxis);
 		(void)tmp_ptr;
-		cjaxis  = AddJAxisButton(PX(XO+4+1),PY(YO+0),BW,BH,"Y-",1,1,false,nullptr);
-		tmp_ptr = AddJAxisButton(PX(XO+4+1),PY(YO+1),BW,BH,"Y+",1,1,true,cjaxis);
+		cjaxis  = AddJAxisButton(pos_x(XO + 4 + 1), pos_y(YO + 0), button_width, button_height, "Y-", 1, 1, false, nullptr);
+		tmp_ptr = AddJAxisButton(pos_x(XO + 4 + 1), pos_y(YO + 1), button_width, button_height, "Y+", 1, 1, true, cjaxis);
 		(void)tmp_ptr;
 		/* Axes 3+4 (X+Y) of 1st Joystick, not accessible */
-		cjaxis  = AddJAxisButton_hidden(0,2,false,nullptr);
-		tmp_ptr = AddJAxisButton_hidden(0,2,true,cjaxis);
+		cjaxis  = AddJAxisButton_hidden(0, 2, false, nullptr);
+		tmp_ptr = AddJAxisButton_hidden(0, 2, true, cjaxis);
 		(void)tmp_ptr;
-		cjaxis  = AddJAxisButton_hidden(0,3,false,nullptr);
-		tmp_ptr = AddJAxisButton_hidden(0,3,true,cjaxis);
+		cjaxis  = AddJAxisButton_hidden(0, 3, false, nullptr);
+		tmp_ptr = AddJAxisButton_hidden(0, 3, true, cjaxis);
 		(void)tmp_ptr;
 	} else {
 		/* Buttons 3+4 of 1st Joystick */
-		AddJButtonButton(PX(XO+4),PY(YO),BW,BH,"3" ,0,2);
-		AddJButtonButton(PX(XO+4+2),PY(YO),BW,BH,"4" ,0,3);
+		AddJButtonButton(pos_x(XO + 4), pos_y(YO), button_width, button_height, "3", 0, 2);
+		AddJButtonButton(pos_x(XO + 4 + 2), pos_y(YO), button_width, button_height, "4", 0, 3);
 		/* Buttons 1+2 of 2nd Joystick, not accessible */
-		AddJButtonButton_hidden(1,0);
-		AddJButtonButton_hidden(1,1);
+		AddJButtonButton_hidden(1, 0);
+		AddJButtonButton_hidden(1, 1);
 
 		/* Axes 3+4 (X+Y) of 1st Joystick */
-		cjaxis  = AddJAxisButton(PX(XO+4),PY(YO+1),BW,BH,"X-",0,2,false,nullptr);
-		tmp_ptr = AddJAxisButton(PX(XO+4+2),PY(YO+1),BW,BH,"X+",0,2,true,cjaxis);
+		cjaxis  = AddJAxisButton(pos_x(XO + 4), pos_y(YO + 1), button_width, button_height, "X-", 0, 2, false, nullptr);
+		tmp_ptr = AddJAxisButton(pos_x(XO + 4 + 2), pos_y(YO + 1), button_width, button_height, "X+", 0, 2, true, cjaxis);
 		(void)tmp_ptr;
-		cjaxis  = AddJAxisButton(PX(XO+4+1),PY(YO+0),BW,BH,"Y-",0,3,false,nullptr);
-		tmp_ptr = AddJAxisButton(PX(XO+4+1),PY(YO+1),BW,BH,"Y+",0,3,true,cjaxis);
+		cjaxis  = AddJAxisButton(pos_x(XO + 4 + 1), pos_y(YO + 0), button_width, button_height, "Y-", 0, 3, false, nullptr);
+		tmp_ptr = AddJAxisButton(pos_x(XO + 4 + 1), pos_y(YO + 1), button_width, button_height, "Y+", 0, 3, true, cjaxis);
 		(void)tmp_ptr;
 		/* Axes 1+2 (X+Y) of 2nd Joystick , not accessible*/
-		cjaxis  = AddJAxisButton_hidden(1,0,false,nullptr);
-		tmp_ptr = AddJAxisButton_hidden(1,0,true,cjaxis);
+		cjaxis  = AddJAxisButton_hidden(1, 0, false, nullptr);
+		tmp_ptr = AddJAxisButton_hidden(1, 0, true, cjaxis);
 		(void)tmp_ptr;
-		cjaxis  = AddJAxisButton_hidden(1,1,false,nullptr);
-		tmp_ptr = AddJAxisButton_hidden(1,1,true,cjaxis);
+		cjaxis  = AddJAxisButton_hidden(1, 1, false, nullptr);
+		tmp_ptr = AddJAxisButton_hidden(1, 1, true, cjaxis);
 		(void)tmp_ptr;
 	}
 
-	if (joytype==JOY_CH) {
+	if (joytype == JOY_CH) {
 		/* Buttons 5+6 of 1st Joystick */
-		AddJButtonButton(PX(XO+8),PY(YO),BW,BH,"5" ,0,4);
-		AddJButtonButton(PX(XO+8+2),PY(YO),BW,BH,"6" ,0,5);
+		AddJButtonButton(pos_x(XO + 8), pos_y(YO), button_width, button_height, "5", 0, 4);
+		AddJButtonButton(pos_x(XO + 8 + 2), pos_y(YO), button_width, button_height, "6", 0, 5);
 	} else {
 		/* Buttons 5+6 of 1st Joystick, not accessible */
-		AddJButtonButton_hidden(0,4);
-		AddJButtonButton_hidden(0,5);
+		AddJButtonButton_hidden(0, 4);
+		AddJButtonButton_hidden(0, 5);
 	}
 
 	/* Hat directions up, left, down, right */
-	AddJHatButton(PX(XO+8+1),PY(YO),BW,BH,"UP",0,0,0);
-	AddJHatButton(PX(XO+8+0),PY(YO+1),BW,BH,"LFT",0,0,3);
-	AddJHatButton(PX(XO+8+1),PY(YO+1),BW,BH,"DWN",0,0,2);
-	AddJHatButton(PX(XO+8+2),PY(YO+1),BW,BH,"RGT",0,0,1);
+	AddJHatButton(pos_x(XO + 8 + 1), pos_y(YO), button_width, button_height, "UP", 0, 0, 0);
+	AddJHatButton(pos_x(XO + 8 + 0), pos_y(YO + 1), button_width, button_height, "LFT", 0, 0, 3);
+	AddJHatButton(pos_x(XO + 8 + 1), pos_y(YO + 1), button_width, button_height, "DWN", 0, 0, 2);
+	AddJHatButton(pos_x(XO + 8 + 2), pos_y(YO + 1), button_width, button_height, "RGT", 0, 0, 1);
 
 	/* Labels for the joystick */
 	CTextButton * btn;
-	if (joytype ==JOY_2AXIS) {
-		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Joystick 1");
-		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Joystick 2");
-		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
+	if (joytype == JOY_2AXIS) {
+		new CTextButton(pos_x(XO + 0), pos_y(YO - 1), 3 * button_width, 20, "Joystick 1");
+		new CTextButton(pos_x(XO + 4), pos_y(YO - 1), 3 * button_width, 20, "Joystick 2");
+		btn = new CTextButton(pos_x(XO + 8), pos_y(YO - 1), 3 * button_width, 20, "Disabled");
 		btn->SetColor(color_grey);
-	} else if(joytype ==JOY_4AXIS || joytype == JOY_4AXIS_2) {
-		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
-		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
-		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
+	} else if(joytype == JOY_4AXIS || joytype == JOY_4AXIS_2) {
+		new CTextButton(pos_x(XO + 0), pos_y(YO - 1), 3 * button_width, 20, "Axis 1/2");
+		new CTextButton(pos_x(XO + 4), pos_y(YO - 1), 3 * button_width, 20, "Axis 3/4");
+		btn = new CTextButton(pos_x(XO + 8), pos_y(YO - 1), 3 * button_width, 20, "Disabled");
 		btn->SetColor(color_grey);
 	} else if(joytype == JOY_CH) {
-		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
-		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
-		new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Hat/D-pad");
-	} else if ( joytype==JOY_FCS) {
-		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
-		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3");
-		new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Hat/D-pad");
+		new CTextButton(pos_x(XO + 0), pos_y(YO - 1), 3 * button_width, 20, "Axis 1/2");
+		new CTextButton(pos_x(XO + 4), pos_y(YO - 1), 3 * button_width, 20, "Axis 3/4");
+		new CTextButton(pos_x(XO + 8), pos_y(YO - 1), 3 * button_width, 20, "Hat/D-pad");
+	} else if ( joytype == JOY_FCS) {
+		new CTextButton(pos_x(XO + 0), pos_y(YO - 1), 3 * button_width, 20, "Axis 1/2");
+		new CTextButton(pos_x(XO + 4), pos_y(YO - 1), 3 * button_width, 20, "Axis 3");
+		new CTextButton(pos_x(XO + 8), pos_y(YO - 1), 3 * button_width, 20, "Hat/D-pad");
 	} else if (joytype == JOY_DISABLED) {
-		btn=new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Disabled");
+		btn = new CTextButton(pos_x(XO + 0), pos_y(YO - 1), 3 * button_width, 20, "Disabled");
 		btn->SetColor(color_grey);
-		btn=new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Disabled");
+		btn = new CTextButton(pos_x(XO + 4), pos_y(YO - 1), 3 * button_width, 20, "Disabled");
 		btn->SetColor(color_grey);
-		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
+		btn = new CTextButton(pos_x(XO + 8), pos_y(YO - 1), 3 * button_width, 20, "Disabled");
 		btn->SetColor(color_grey);
 	}
 
 	/* The modifier buttons */
-	AddModButton(PX(0),PY(14),50,20,"Mod1",1);
-	AddModButton(PX(2),PY(14),50,20,"Mod2",2);
-	AddModButton(PX(4),PY(14),50,20,"Mod3",3);
+	AddModButton(pos_x(0), pos_y(14), 50, 20, "Mod1", 1);
+	AddModButton(pos_x(2), pos_y(14), 50, 20, "Mod2", 2);
+	AddModButton(pos_x(4), pos_y(14), 50, 20, "Mod3", 3);
 
 	/* Create Handler buttons */
-	Bitu xpos=3;Bitu ypos=11;
+	int32_t xpos = 3;
+	int32_t ypos = 11;
 	for (const auto &handler_event : handlergroup) {
-		new CEventButton(PX(xpos * 3), PY(ypos), BW * 3, BH,
+		new CEventButton(pos_x(xpos * 3), pos_y(ypos), button_width * 3, button_height,
 		                 handler_event->button_name.c_str(), handler_event);
 		xpos++;
 		if (xpos>6) {
-			xpos=3;ypos++;
+			xpos = 3;
+			ypos++;
 		}
 	}
 	/* Create some text buttons */
-//	new CTextButton(PX(6),0,124,20,"Keyboard Layout");
-//	new CTextButton(PX(17),0,124,20,"Joystick Layout");
+//	new CTextButton(pos_x(6), 0, 124, 20, "Keyboard Layout");
+//	new CTextButton(pos_x(17), 0, 124, 20, "Joystick Layout");
 
 	bind_but.action = new CCaptionButton(0, 335, 0, 0);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1453,13 +1453,10 @@ finish:
 	return sdl.window;
 }
 
-// Used for the mapper UI and more: Creates a fullscreen window with desktop res
-// on Android, and a non-fullscreen window with the input dimensions otherwise.
-SDL_Window* GFX_SetSDLSurfaceWindow(uint16_t width, uint16_t height,
-                                    bool allow_highdpi = true)
+// Returns the current window; used for mapper UI.
+SDL_Window* GFX_GetWindow()
 {
-	constexpr bool fullscreen = false;
-	return SetWindowMode(SCREEN_SURFACE, width, height, fullscreen, FIXED_SIZE, allow_highdpi);
+	return sdl.window;
 }
 
 // Returns the rectangle in the current window to be used for scaling a

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -34,32 +34,32 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -27,7 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <VCProjectVersion>16.0</VCProjectVersion>
+    <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{10F658E8-8DB0-4F7A-9B61-6272BB309144}</ProjectGuid>
     <RootNamespace>testsinvs</RootNamespace>
@@ -37,37 +37,37 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -169,6 +169,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AssemblerOutput>NoListing</AssemblerOutput>
+      <AdditionalOptions>/Zc:lambda %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -213,6 +214,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AssemblerOutput>NoListing</AssemblerOutput>
+      <AdditionalOptions>/Zc:lambda %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -260,6 +262,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <AdditionalOptions>/Zc:lambda %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -315,6 +318,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <AdditionalOptions>/Zc:lambda %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -372,6 +376,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <AdditionalOptions>/Zc:lambda %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
@@ -428,6 +433,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <AdditionalOptions>/Zc:lambda %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -35,39 +35,39 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Does what it says: moves mapper from software surface to SDL's rendering API. The emulator window is now reused instead of creating a new one.

If you're not happy with the mapper's pseudo-lambdas and how they're formatted, you're welcome to steal this branch. These changes would go far beyond the scope of the PR though, and the whole thing will be eventually rewritten anyway, hence why I'm leaving it as is.

While it seems to work with the surface output, this is not intentional, and it will be removed in a subsequent PR anyway. (Damn, that sounds broken...)

Extracted from - and is a prerequisite to - #2450.
