### PR TITLE
Fix comment describing BGRX8888 PixelFormat

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -64,7 +64,7 @@ enum class PixelFormat : uint8_t {
 	BGR888 = 24,
 	//
 	// 16.7M (32-bit) true colour; 8 bits per red/blue/green component;
-	// stored as packed uint32 data with highest 8 bits unused
+	// stored as packed uint32 data with lowest 8 bits unused
 	BGRX8888 = 32
 };
 


### PR DESCRIPTION
This briefly tripped me up working on ffmpeg stuff.  I had to map this format to what ffmpeg calls `AV_PIX_FMT_BGR0`, implying that it's the low bits that are unused, not the high bits.  I had tried `AV_PIX_FMT_0BGR` first and the colors were all wrong.

It's also what the enum name suggests.  If it were really the high bits that were unused, I would expect it to be called `XBGR8888` instead.