### PR TITLE
Force OpenGL renderer backend for keymapper

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 207
+          MAX_BUGS: 206
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -23,7 +23,7 @@ jobs:
             max_warnings: 20
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 895
+            max_warnings: 886
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Applies only to OpenGL output. Fixes exiting from mapper on macOS.

I decided not to dig too deep into the issue and just utilize SDL's context reuse. Maybe I'll come back to that sometime later and provide feedback to the SDL crew (or maybe someone will beat me to it?).

With `output=opengl`, `texture_renderer` setting now doesn't affect mapper interface (OpenGL backend is always used). `output=texture` just reuses existing renderer, no change here. Surface output now is definitely broken in most cases, but whatever.