### PR TITLE
Add missing mutex lock to RWQueue

### DIFF
--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -51,7 +51,9 @@ void RWQueue<T>::Stop()
 	if (!is_running) {
 		return;
 	}
+	mutex.lock();
 	is_running = false;
+	mutex.unlock();
 
 	// notify the conditions
 	has_items.notify_one();


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/thread/condition_variable

>  Even if the shared variable is atomic, it must be modified while owning the mutex to correctly publish the modification to the waiting thread. 