### PR TITLE
Notify all when RWQueue stops

### DIFF
--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -56,8 +56,8 @@ void RWQueue<T>::Stop()
 	mutex.unlock();
 
 	// notify the conditions
-	has_items.notify_one();
-	has_room.notify_one();
+	has_items.notify_all();
+	has_room.notify_all();
 }
 
 template <typename T>


### PR DESCRIPTION
Found another bug in RWQueue.  We need to notify all threads when the queue stops or we can have a deadlock.

I'm pretty sure I'll need to add a couple more methods to this class as well once I get FFmpeg threading sorted out but  that'll go in my big PR alongside the use case.  At a minimum, I think I'll need a `Drain` method and a `Start` method so that I can `Stop` the queue, `Drain` all remaining elements from it in a non-blocking manner, and then `Start` it back up again.

For now though, I'm just pushing these bug fixes in small PRs as I see them since this could cause a stall in existing code.