### PR TITLE
Suppress ALSA API macros PVS Studio warnings

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 177
+          MAX_BUGS: 170
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -23,7 +23,7 @@ jobs:
             max_warnings: 20
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 886
+            max_warnings: 893
 
     steps:
       - name: Checkout repository

--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -2,6 +2,62 @@
     "version": 2,
     "warnings": [
         {
+            "CodeCurrent": 3531902440,
+            "CodeNext": 664109,
+            "CodePrev": 1751171634,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
+            "CodeCurrent": 3315748765,
+            "CodeNext": 664105,
+            "CodePrev": 2822630980,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
+            "CodeCurrent": 1928789835,
+            "CodeNext": 664109,
+            "CodePrev": 2700121506,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
+            "CodeCurrent": 602552363,
+            "CodeNext": 664109,
+            "CodePrev": 290488018,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
+            "CodeCurrent": 2199812853,
+            "CodeNext": 664109,
+            "CodePrev": 580975878,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
+            "CodeCurrent": 3867534273,
+            "CodeNext": 664109,
+            "CodePrev": 2822640836,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
+            "CodeCurrent": 551702431,
+            "CodeNext": 664105,
+            "CodePrev": 2700674978,
+            "ErrorCode": "V684",
+            "FileName": "midi_alsa.cpp",
+            "Message": "A value of the variable '(& ev)->flags' is not modified. Consider inspecting the expression. It is possible that '_' should be present instead of '_'."
+        },
+        {
             "CodeCurrent": 88293181,
             "CodeNext": 6447,
             "CodePrev": 2507819856,


### PR DESCRIPTION
The last PR of my PVS Studio crusade - at least for now :)

This time I would like to suppress some warnings, shown on the screenshot below. These are all originating from ALSA headers - the `snd_*` are macros, which PVS Studio does not like. I believe there is nothing sane we can do about them (we probably don't want to alter ALSA headers after all), other than ignoring these.

![PVS](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/606af52e-ed95-4853-a20d-577eef74ddc1)
