### PR TITLE
Update Catmull-Rom shader

### DIFF
--- a/contrib/resources/glshaders/interpolation/catmull-rom.glsl
+++ b/contrib/resources/glshaders/interpolation/catmull-rom.glsl
@@ -10,6 +10,11 @@
 	See http://vec3.ca/bicubic-filtering-in-fewer-taps/ for more details
 */
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+#pragma force_single_scan
+#pragma force_no_pixel_doubling
+
 #if defined(VERTEX)
 
 #if __VERSION__ >= 130

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1665,7 +1665,8 @@ static bool LoadGLShaders(const std::string_view source_sv, GLuint *vertex,
 
 [[maybe_unused]] static bool is_shader_flexible()
 {
-	constexpr std::array<std::string_view, 3> flexible_shader_names{{
+	constexpr std::array<std::string_view, 4> flexible_shader_names{{
+	        "interpolation/catmull-rom",
 	        "interpolation/sharp",
 	        "none",
 	        "default",


### PR DESCRIPTION
Now it samples in the correct colour space. Also added it to the list of well-behaving shaders, so no more black halo on the edges of the output. Comparison, before and after:

![Screenshot_20230825_114850](https://github.com/dosbox-staging/dosbox-staging/assets/11149380/c9ad0840-8548-4f46-afdf-5b929ad2b54f)
![Screenshot_20230825_115128](https://github.com/dosbox-staging/dosbox-staging/assets/11149380/0a52f605-b705-44d7-bed1-de8f88925230)
