### PR TITLE
Revert increaseticks sleep to 1ms

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -184,7 +184,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 
 		static int64_t cumulativeTimeSlept = 0;
 
-		constexpr auto sleepDuration = std::chrono::microseconds(100);
+		constexpr auto sleepDuration = std::chrono::microseconds(1000);
 		std::this_thread::sleep_for(sleepDuration);
 
 		const auto timeslept = GetTicksUsSince(ticksNewUs);


### PR DESCRIPTION
This reverts the aggressive 100us sleep time in `increaseticks()` from #2655. There was no real measurable benefit from it, so let's go back to the old reliable 1ms, but keep the new fractional `ticksDone` logic.

Fixes #2790