### PR TITLE
Minor shell cleanup

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -351,17 +352,34 @@ public:
 	MemStruct(uint16_t seg, uint16_t off) : pt(PhysicalMake(seg, off)) {}
 	MemStruct(RealPt addr) : pt(RealToPhysical(addr)) {}
 
-	void SetPt(uint16_t seg) { pt = PhysicalMake(seg, 0); }
+	void SetPt(uint16_t seg)
+	{
+		pt = PhysicalMake(seg, 0);
+	}
 
 protected:
-	PhysPt pt = 0;
+	PhysPt pt    = 0;
+	~MemStruct() = default;
+};
+
+class Environment {
+public:
+	virtual std::optional<std::string> GetEnvStr(std::string_view entry) const = 0;
+
+	virtual ~Environment() = default;
+
+protected:
+	Environment()                              = default;
+	Environment(const Environment&)            = default;
+	Environment& operator=(const Environment&) = default;
+	Environment(Environment&&)                 = default;
+	Environment& operator=(Environment&&)      = default;
 };
 
 /* Program Segment Prefix */
-
-class DOS_PSP final : public MemStruct {
+class DOS_PSP final : public MemStruct, public Environment {
 public:
-	DOS_PSP(uint16_t segment) : seg(segment) { SetPt(seg); }
+	DOS_PSP(uint16_t segment) : seg(segment) { SetPt(seg); }	
 
 	void MakeNew(uint16_t mem_size);
 
@@ -413,6 +431,10 @@ public:
 	void SetFCB1(RealPt src);
 	void SetFCB2(RealPt src);
 	void SetCommandTail(RealPt src);
+
+	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
+	std::vector<std::string> GetAllEnvVars() const;
+	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 private:
 	#ifdef _MSC_VER

--- a/include/shell.h
+++ b/include/shell.h
@@ -53,21 +53,9 @@ public:
 	virtual ~ByteReader()                    = default;
 };
 
-class HostShell {
-public:
-	virtual std::optional<std::string> GetEnvStr(std::string_view entry) const = 0;
-
-	HostShell()                            = default;
-	HostShell(const HostShell&)            = delete;
-	HostShell& operator=(const HostShell&) = delete;
-	HostShell(HostShell&&)                 = delete;
-	HostShell& operator=(HostShell&&)      = delete;
-	virtual ~HostShell()                   = default;
-};
-
 class BatchFile {
 public:
-	BatchFile(const HostShell& host, std::unique_ptr<ByteReader> input_reader,
+	BatchFile(const Environment& host, std::unique_ptr<ByteReader> input_reader,
 	          std::string_view entered_name, std::string_view cmd_line,
 	          bool echo_on);
 	BatchFile(const BatchFile&)            = delete;
@@ -86,7 +74,7 @@ private:
 	[[nodiscard]] std::string ExpandedBatchLine(std::string_view line) const;
 	[[nodiscard]] std::string GetLine();
 
-	const HostShell& shell;
+	const Environment& shell;
 	CommandLine cmd;
 	std::unique_ptr<ByteReader> reader;
 	bool echo;
@@ -122,7 +110,7 @@ private:
 	bool secure_mode;
 };
 
-class DOS_Shell : public Program, public HostShell {
+class DOS_Shell : public Program {
 private:
 	void PrintHelpForCommands(MoreOutputStrings& output, HELP_Filter req_filter);
 	void AddShellCmdsToHelpList();
@@ -162,7 +150,7 @@ public:
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
-	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
+	std::optional<std::string> GetEnvStr(std::string_view entry) const;
 	std::vector<std::string> GetAllEnvVars() const;
 	bool SetEnv(std::string_view entry, std::string_view new_string);
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -55,7 +55,7 @@ public:
 
 class HostShell {
 public:
-	virtual bool GetEnvStr(const char* entry, std::string& result) const = 0;
+	virtual std::optional<std::string> GetEnvStr(std::string_view entry) const = 0;
 
 	HostShell()                            = default;
 	HostShell(const HostShell&)            = delete;
@@ -162,7 +162,7 @@ public:
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
-	bool GetEnvStr(const char* entry, std::string& result) const override;
+	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
 	bool GetEnvNum(Bitu num, std::string& result) const;
 	[[nodiscard]] Bitu GetEnvCount() const;
 	bool SetEnv(std::string_view entry, std::string_view new_string);

--- a/include/shell.h
+++ b/include/shell.h
@@ -163,8 +163,7 @@ public:
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
 	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
-	bool GetEnvNum(Bitu num, std::string& result) const;
-	[[nodiscard]] Bitu GetEnvCount() const;
+	std::vector<std::string> GetAllEnvVars() const;
 	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 	/* Commands */

--- a/include/shell.h
+++ b/include/shell.h
@@ -165,7 +165,7 @@ public:
 	bool GetEnvStr(const char* entry, std::string& result) const override;
 	bool GetEnvNum(Bitu num, std::string& result) const;
 	[[nodiscard]] Bitu GetEnvCount() const;
-	bool SetEnv(const char* entry, const char* new_string);
+	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 	/* Commands */
 	void CMD_HELP(char* args);

--- a/include/shell.h
+++ b/include/shell.h
@@ -150,8 +150,8 @@ public:
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
-	std::optional<std::string> GetEnvStr(std::string_view entry) const;
-	std::vector<std::string> GetAllEnvVars() const;
+	// HACK: Don't use in new code
+	// TODO: Remove the call to this function from autoexec
 	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 	/* Commands */

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -59,7 +59,8 @@ void MOUNT::Move_Z(char new_z)
 		/* Update environment */
 		std::string line = "";
 		std::string tempenv = {new_drive_z, ':', '\\'};
-		if (first_shell->GetEnvStr("PATH",line)) {
+		if (const auto result = first_shell->GetEnvStr("PATH")) {
+			line = *result;
 			std::string::size_type idx = line.find('=');
 			std::string value = line.substr(idx +1 , std::string::npos);
 			while ( (idx = value.find("Z:\\")) != std::string::npos ||

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -69,9 +69,15 @@ void MOUNT::Move_Z(char new_z)
 		} else {
 			value = tempenv;
 		}
-		first_shell->SetEnv("PATH", value);
+
 		tempenv += "COMMAND.COM";
-		first_shell->SetEnv("COMSPEC", tempenv);
+
+		auto psp_copy = DOS_PSP(psp->GetSegment());
+		while (psp_copy.GetSegment() != DOS_PSP::rootpsp) {
+			psp_copy = DOS_PSP(psp_copy.GetParent());
+			psp_copy.SetEnv("PATH", value);
+			psp_copy.SetEnv("COMSPEC", tempenv);
+		}
 
 		/* Change the active drive */
 		if (DOS_GetDefaultDrive() == 25)

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -59,7 +59,7 @@ void MOUNT::Move_Z(char new_z)
 		/* Update environment */
 		std::string value   = "";
 		std::string tempenv = {new_drive_z, ':', '\\'};
-		if (const auto result = first_shell->GetEnvStr("PATH")) {
+		if (const auto result = psp->GetEnvStr("PATH")) {
 			value = *result;
 			std::string::size_type idx;
 			while ((idx = value.find("Z:\\")) != std::string::npos ||

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -57,21 +57,21 @@ void MOUNT::Move_Z(char new_z)
 		Drives[25]      = nullptr;
 		if (!first_shell) return; //Should not be possible
 		/* Update environment */
-		std::string line = "";
+		std::string value   = "";
 		std::string tempenv = {new_drive_z, ':', '\\'};
 		if (const auto result = first_shell->GetEnvStr("PATH")) {
-			line = *result;
-			std::string::size_type idx = line.find('=');
-			std::string value = line.substr(idx +1 , std::string::npos);
-			while ( (idx = value.find("Z:\\")) != std::string::npos ||
-				(idx = value.find("z:\\")) != std::string::npos  )
-				value.replace(idx,3,tempenv);
-			line = std::move(value);
+			value = *result;
+			std::string::size_type idx;
+			while ((idx = value.find("Z:\\")) != std::string::npos ||
+			       (idx = value.find("z:\\")) != std::string::npos) {
+				value.replace(idx, 3, tempenv);
+			}
+		} else {
+			value = tempenv;
 		}
-		if (!line.size()) line = tempenv;
-		first_shell->SetEnv("PATH",line.c_str());
+		first_shell->SetEnv("PATH", value);
 		tempenv += "COMMAND.COM";
-		first_shell->SetEnv("COMSPEC",tempenv.c_str());
+		first_shell->SetEnv("COMSPEC", tempenv);
 
 		/* Change the active drive */
 		if (DOS_GetDefaultDrive() == 25)

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -736,7 +736,7 @@ void CONFIG::Run(void)
 					std::string val = sec->GetPropValue(
 					        pvars[0].c_str());
 					WriteOut("%s", val.c_str());
-					first_shell->SetEnv("CONFIG", val.c_str());
+					DOS_PSP(psp->GetParent()).SetEnv("CONFIG", val.c_str());
 				}
 				break;
 			}
@@ -758,7 +758,7 @@ void CONFIG::Run(void)
 					return;
 				}
 				WriteOut("%s\n", val.c_str());
-				first_shell->SetEnv("CONFIG", val.c_str());
+				DOS_PSP(psp->GetParent()).SetEnv("CONFIG", val.c_str());
 				break;
 			}
 			default:

--- a/src/shell/meson.build
+++ b/src/shell/meson.build
@@ -5,6 +5,7 @@ libshell_sources = files(
     'shell.cpp',
     'shell_batch.cpp',
     'shell_cmds.cpp',
+    'shell_history.cpp',
     'shell_misc.cpp',
 )
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -281,13 +281,10 @@ void DOS_Shell::ParseLine(char *line)
 			             "pipe%d.tmp",
 			             get_tick_random_number());
 		} else {
-			const auto idx   = env_temp_path.find('=');
-			std::string temp = env_temp_path.substr(idx + 1,
-			                                        std::string::npos);
-			if (DOS_GetFileAttr(temp.c_str(), &fattr) &&
+			if (DOS_GetFileAttr(env_temp_path.c_str(), &fattr) &&
 			    fattr & DOS_ATTR_DIRECTORY)
 				safe_sprintf(pipe_tempfile, "%s\\pipe%d.tmp",
-				             temp.c_str(),
+				             env_temp_path.c_str(),
 				             get_tick_random_number());
 			else
 				safe_sprintf(pipe_tempfile, "pipe%d.tmp",

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -268,9 +268,15 @@ void DOS_Shell::ParseLine(char *line)
 	char pipe_tempfile[270]; // Piping requires the use of a temporary file
 	uint16_t fattr;
 	if (pipe_file.length()) {
+		auto result = GetEnvStr("TEMP");
+		if (!result) {
+			result = GetEnvStr("TMP");
+		}
 		std::string env_temp_path = {};
-		if (!GetEnvStr("TEMP", env_temp_path) &&
-		    !GetEnvStr("TMP", env_temp_path)) {
+		if (result) {
+			env_temp_path = *result;
+		}
+		if (env_temp_path.empty()) {
 			safe_sprintf(pipe_tempfile,
 			             "pipe%d.tmp",
 			             get_tick_random_number());

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -268,9 +268,9 @@ void DOS_Shell::ParseLine(char *line)
 	char pipe_tempfile[270]; // Piping requires the use of a temporary file
 	uint16_t fattr;
 	if (pipe_file.length()) {
-		auto result = GetEnvStr("TEMP");
+		auto result = psp->GetEnvStr("TEMP");
 		if (!result) {
-			result = GetEnvStr("TMP");
+			result = psp->GetEnvStr("TMP");
 		}
 		std::string env_temp_path = {};
 		if (result) {

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -122,13 +122,10 @@ std::string BatchFile::ExpandedBatchLine(std::string_view line) const
 			if (closing_percent == std::string::npos) {
 				break;
 			}
-			std::string env_key(line.substr(0, closing_percent));
 
-			// Get the key's corresponding value from the environment
-			if (const auto env_val = shell.GetEnvStr(env_key)) {
-				// append just the trailing value portion
-				expanded += env_val->substr(env_key.length() +
-				                            sizeof('='));
+			if (const auto env_val = shell.GetEnvStr(
+			            line.substr(0, closing_percent))) {
+				expanded += *env_val;
 			}
 			line = line.substr(closing_percent);
 		}

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -29,7 +29,7 @@ constexpr char UnitSeparator = 31;
 
 [[nodiscard]] static bool found_label(std::string_view line, std::string_view label);
 
-BatchFile::BatchFile(const HostShell& host, std::unique_ptr<ByteReader> input_reader,
+BatchFile::BatchFile(const Environment& host, std::unique_ptr<ByteReader> input_reader,
                      const std::string_view entered_name,
                      const std::string_view cmd_line, const bool echo_on)
         : shell(host),

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -125,11 +125,10 @@ std::string BatchFile::ExpandedBatchLine(std::string_view line) const
 			std::string env_key(line.substr(0, closing_percent));
 
 			// Get the key's corresponding value from the environment
-			if (std::string env_val = {};
-			    shell.GetEnvStr(env_key.c_str(), env_val)) {
+			if (const auto env_val = shell.GetEnvStr(env_key)) {
 				// append just the trailing value portion
-				expanded += env_val.substr(env_key.length() +
-				                           sizeof('='));
+				expanded += env_val->substr(env_key.length() +
+				                            sizeof('='));
 			}
 			line = line.substr(closing_percent);
 		}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1560,9 +1560,8 @@ void DOS_Shell::CMD_SET(char * args) {
 	std::string line;
 	if (!*args) {
 		/* No command line show all environment lines */
-		Bitu count=GetEnvCount();
-		for (Bitu a=0;a<count;a++) {
-			if (GetEnvNum(a,line)) WriteOut("%s\n",line.c_str());
+		for (const auto& entry : GetAllEnvVars()) {
+			WriteOut("%s\n", entry.c_str());
 		}
 		return;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -833,8 +833,8 @@ void DOS_Shell::CMD_DIR(char* args)
 {
 	HELP("DIR");
 
-	std::string line;
-	if (GetEnvStr("DIRCMD",line)){
+	if (const auto envvar = GetEnvStr("DIRCMD")){
+		auto line = *envvar;
 		std::string::size_type idx = line.find('=');
 		std::string value=line.substr(idx +1 , std::string::npos);
 		line = std::string(args) + " " + value;
@@ -1574,7 +1574,7 @@ void DOS_Shell::CMD_SET(char * args) {
 
 	char * p=strpbrk(args, "=");
 	if (!p) {
-		if (!GetEnvStr(args,line)) WriteOut(MSG_Get("SHELL_CMD_SET_NOT_SET"),args);
+		if (!GetEnvStr(args)) WriteOut(MSG_Get("SHELL_CMD_SET_NOT_SET"),args);
 		WriteOut("%s\n",line.c_str());
 	} else {
 		*p++=0;
@@ -1589,8 +1589,8 @@ void DOS_Shell::CMD_SET(char * args) {
 				char * second = strchr(++p,'%');
 				if (!second) continue;
 				*second++ = 0;
-				std::string temp;
-				if (GetEnvStr(p,temp)) {
+				if (const auto envvar = GetEnvStr(p)) {
+					const auto& temp = *envvar;
 					std::string::size_type equals = temp.find('=');
 					if (equals == std::string::npos)
 						continue;
@@ -2181,9 +2181,8 @@ void DOS_Shell::CMD_PATH(char *args){
 		this->ParseLine(set_path);
 		return;
 	} else {
-		std::string line;
-		if (GetEnvStr("PATH", line))
-			WriteOut("%s\n", line.c_str());
+		if (const auto envvar = GetEnvStr("PATH"))
+			WriteOut("%s\n", envvar->c_str());
 		else
 			WriteOut("PATH=(null)\n");
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -833,10 +833,9 @@ void DOS_Shell::CMD_DIR(char* args)
 {
 	HELP("DIR");
 
+	auto line = std::string();
 	if (const auto envvar = GetEnvStr("DIRCMD")){
-		auto line = *envvar;
-		std::string::size_type idx = line.find('=');
-		std::string value=line.substr(idx +1 , std::string::npos);
+		const auto& value = *envvar;
 		line = std::string(args) + " " + value;
 		args=const_cast<char*>(line.c_str());
 	}
@@ -1591,14 +1590,11 @@ void DOS_Shell::CMD_SET(char * args) {
 				*second++ = 0;
 				if (const auto envvar = GetEnvStr(p)) {
 					const auto& temp = *envvar;
-					std::string::size_type equals = temp.find('=');
-					if (equals == std::string::npos)
-						continue;
 					const uintptr_t remaining_len = std::min(
 					        sizeof(parsed) - static_cast<uintptr_t>(p_parsed - parsed),
 					        sizeof(parsed));
 					safe_strncpy(p_parsed,
-					             temp.substr(equals + 1).c_str(),
+					             temp.c_str(),
 					             remaining_len);
 					p_parsed += strlen(p_parsed);
 				}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -834,7 +834,7 @@ void DOS_Shell::CMD_DIR(char* args)
 	HELP("DIR");
 
 	auto line = std::string();
-	if (const auto envvar = GetEnvStr("DIRCMD")){
+	if (const auto envvar = psp->GetEnvStr("DIRCMD")){
 		const auto& value = *envvar;
 		line = std::string(args) + " " + value;
 		args=const_cast<char*>(line.c_str());
@@ -1560,7 +1560,7 @@ void DOS_Shell::CMD_SET(char * args) {
 	std::string line;
 	if (!*args) {
 		/* No command line show all environment lines */
-		for (const auto& entry : GetAllEnvVars()) {
+		for (const auto& entry : psp->GetAllEnvVars()) {
 			WriteOut("%s\n", entry.c_str());
 		}
 		return;
@@ -1572,7 +1572,7 @@ void DOS_Shell::CMD_SET(char * args) {
 
 	char * p=strpbrk(args, "=");
 	if (!p) {
-		if (!GetEnvStr(args)) WriteOut(MSG_Get("SHELL_CMD_SET_NOT_SET"),args);
+		if (!psp->GetEnvStr(args)) WriteOut(MSG_Get("SHELL_CMD_SET_NOT_SET"),args);
 		WriteOut("%s\n",line.c_str());
 	} else {
 		*p++=0;
@@ -1587,7 +1587,8 @@ void DOS_Shell::CMD_SET(char * args) {
 				char * second = strchr(++p,'%');
 				if (!second) continue;
 				*second++ = 0;
-				if (const auto envvar = GetEnvStr(p)) {
+
+				if (const auto envvar = psp->GetEnvStr(p)) {
 					const auto& temp = *envvar;
 					const uintptr_t remaining_len = std::min(
 					        sizeof(parsed) - static_cast<uintptr_t>(p_parsed - parsed),
@@ -2176,7 +2177,7 @@ void DOS_Shell::CMD_PATH(char *args){
 		this->ParseLine(set_path);
 		return;
 	} else {
-		if (const auto envvar = GetEnvStr("PATH"))
+		if (const auto envvar = psp->GetEnvStr("PATH"))
 			WriteOut("%s\n", envvar->c_str());
 		else
 			WriteOut("PATH=(null)\n");

--- a/src/shell/shell_history.cpp
+++ b/src/shell/shell_history.cpp
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "shell.h"
+
+#include <fstream>
+
+#include "checks.h"
+#include "control.h"
+#include "dosbox.h"
+#include "fs_utils.h"
+#include "string_utils.h"
+
+CHECK_NARROWING();
+
+static constexpr int HistoryMaxLineSize = 256;
+static constexpr int HistoryMaxNumLines = 500;
+
+static std_fs::path get_shell_history_path();
+
+ShellHistory& ShellHistory::Instance()
+{
+	static auto history = ShellHistory();
+	return history;
+}
+
+void ShellHistory::Append(std::string command)
+{
+	trim(command);
+	if (!iequals(command, "exit")) {
+		commands.emplace_back(std::move(command));
+	}
+}
+
+const std::vector<std::string>& ShellHistory::GetCommands() const
+{
+	return commands;
+}
+
+ShellHistory::ShellHistory()
+        : path(get_shell_history_path()),
+          secure_mode(control->SecureMode())
+{
+	if (secure_mode) {
+		return;
+	}
+	if (path.empty()) {
+		return;
+	}
+	auto history_file = std::ifstream(path);
+	if (!history_file) {
+		return;
+	}
+
+	std::string line;
+	while (getline(history_file, line)) {
+		trim(line);
+		auto len = line.length();
+		if (len > 0 && len <= HistoryMaxLineSize) {
+			commands.emplace_back(std::move(line));
+		}
+	}
+}
+
+ShellHistory::~ShellHistory()
+{
+	if (secure_mode) {
+		return;
+	}
+	if (path.empty()) {
+		return;
+	}
+	auto history_file = std::ofstream(path);
+	if (!history_file) {
+		LOG_WARNING("SHELL: Unable to update history file: '%s'",
+		            path.string().c_str());
+		return;
+	}
+
+	if (commands.size() > HistoryMaxNumLines) {
+		commands.erase(commands.begin(), commands.end() - HistoryMaxNumLines);
+	}
+
+	for (const auto& command : commands) {
+		history_file << command << '\n';
+	}
+}
+
+static std_fs::path get_shell_history_path()
+{
+	const auto* section = dynamic_cast<Section_prop*>(control->GetSection("dos"));
+	if (section != nullptr) {
+		const auto* path = section->Get_path("shell_history_file");
+		if (path != nullptr) {
+			return path->realpath;
+		}
+	}
+	return {};
+}

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -355,8 +355,8 @@ std::string DOS_Shell::SubstituteEnvironmentVariables(std::string_view command)
 		}
 		closing_percent += 1;
 
-		if (const auto env_val =
-		            GetEnvStr(command.substr(1, closing_percent - 1))) {
+		if (const auto env_val = psp->GetEnvStr(
+		            command.substr(1, closing_percent - 1))) {
 			expanded += *env_val;
 
 			command = command.substr(closing_percent + 1);
@@ -495,7 +495,7 @@ std::string DOS_Shell::Which(const std::string_view name) const
 
 	std::vector<std::string> prefixes = {""};
 
-	if (const auto path = GetEnvStr("PATH")) {
+	if (const auto path = psp->GetEnvStr("PATH")) {
 		auto path_directories = split(*path, ';');
 
 		remove_empties(path_directories);
@@ -609,16 +609,6 @@ static void run_binary_executable(const std::string_view fullname,
 
 	/* Restore CS:IP and the stack */
 	reg_sp += 0x200;
-}
-
-std::optional<std::string> DOS_Shell::GetEnvStr(const std::string_view entry) const
-{
-	return psp->GetEnvStr(entry);
-}
-
-std::vector<std::string> DOS_Shell::GetAllEnvVars() const
-{
-	return psp->GetAllEnvVars();
 }
 
 bool DOS_Shell::SetEnv(std::string_view entry, std::string_view new_string)

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -644,36 +644,20 @@ std::optional<std::string> DOS_Shell::GetEnvStr(const std::string_view entry) co
 	}
 }
 
-bool DOS_Shell::GetEnvNum(Bitu num, std::string& result) const
+std::vector<std::string> DOS_Shell::GetAllEnvVars() const
 {
+	auto all_env_vars = std::vector<std::string>{};
+
 	char env_string[1024 + 1];
 	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-	do {
+	while(true) {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {
-			break;
+			return all_env_vars;
 		}
-		if (!num) {
-			result = env_string;
-			return true;
-		}
+		all_env_vars.emplace_back(env_string);
 		env_read += (PhysPt)(safe_strlen(env_string) + 1);
-		num--;
-	} while (1);
-	return false;
-}
-
-Bitu DOS_Shell::GetEnvCount() const
-{
-	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-	Bitu num        = 0;
-	while (mem_readb(env_read) != 0) {
-		for (; mem_readb(env_read); env_read++) {
-		};
-		env_read++;
-		num++;
 	}
-	return num;
 }
 
 bool DOS_Shell::SetEnv(std::string_view entry, std::string_view new_string)

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -79,7 +79,7 @@ void DOS_Shell::InputCommand(char* line)
 	std::string command = ReadCommand();
 	trim(command);
 	if (!command.empty()) {
-		history.emplace_back(command);
+		history.Append(command);
 	}
 
 	const auto* const dos_section = dynamic_cast<Section_prop*>(
@@ -106,7 +106,7 @@ void DOS_Shell::InputCommand(char* line)
 
 std::string DOS_Shell::ReadCommand()
 {
-	std::vector<std::string> history_clone = history;
+	std::vector<std::string> history_clone = history.GetCommands();
 	history_clone.emplace_back("");
 	auto history_index = history_clone.size() - 1;
 
@@ -150,11 +150,12 @@ std::string DOS_Shell::ReadCommand()
 			DOS_ReadFile(input_handle, &data, &byte_count);
 			switch (static_cast<ScanCode>(data)) {
 			case ScanCode::F3: {
-				if (history.empty()) {
+				if (history.GetCommands().empty()) {
 					break;
 				}
 
-				std::string_view last_command = history.back();
+				std::string_view last_command =
+				        history.GetCommands().back();
 				if (last_command.size() <= command.size()) {
 					break;
 				}
@@ -693,7 +694,7 @@ bool DOS_Shell::SetEnv(const char* entry, const char* new_string)
 	PhysPt env_write          = env_read;
 	PhysPt env_write_start    = env_read;
 	char env_string[1024 + 1] = {0};
-	const auto entry_length = strlen(entry);
+	const auto entry_length   = strlen(entry);
 	do {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -53,7 +53,7 @@ private:
 	decltype(contents)::size_type index = 0;
 };
 
-class MockShell final : public HostShell {
+class MockShell final : public Environment {
 public:
 	std::optional<std::string> GetEnvStr(std::string_view entry) const override
 	{

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -55,13 +55,13 @@ private:
 
 class MockShell final : public HostShell {
 public:
-	bool GetEnvStr(const char* entry, std::string& result) const override
+	std::optional<std::string> GetEnvStr(std::string_view entry) const override
 	{
-		if (env.find(entry) == std::end(env)) {
-			return false;
+		auto key = std::string(entry);
+		if (env.find(key) == std::end(env)) {
+			return {};
 		}
-		result = std::string(entry) + '=' + env.at(entry);
-		return true;
+		return key + '=' + env.at(key);
 	}
 
 	explicit MockShell(std::unordered_map<std::string, std::string>&& map)

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -57,11 +57,11 @@ class MockShell final : public HostShell {
 public:
 	std::optional<std::string> GetEnvStr(std::string_view entry) const override
 	{
-		auto key = std::string(entry);
-		if (env.find(key) == std::end(env)) {
+		auto environment_variable = env.find(std::string(entry));
+		if (environment_variable == std::end(env)) {
 			return {};
 		}
-		return key + '=' + env.at(key);
+		return environment_variable->second;
 	}
 
 	explicit MockShell(std::unordered_map<std::string, std::string>&& map)

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -739,6 +739,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\shell\shell.cpp" />
     <ClCompile Include="..\src\shell\shell_batch.cpp" />
     <ClCompile Include="..\src\shell\shell_cmds.cpp" />
+    <ClCompile Include="..\src\shell\shell_history.cpp" />
     <ClCompile Include="..\src\shell\shell_misc.cpp" />
     <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp" />
     <ClCompile Include="..\src\libs\loguru\loguru.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -520,6 +520,9 @@
     <ClCompile Include="..\src\shell\shell_cmds.cpp">
       <Filter>src\shell</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\shell\shell_history.cpp">
+      <Filter>src\shell</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\shell\shell_misc.cpp">
       <Filter>src\shell</Filter>
     </ClCompile>


### PR DESCRIPTION
These changes broadly deal with 2 things: shell history and the environment functions.

I moved the shell history setup functions to its own class. At first this meant that it would be called upon construction of every shell, including the ones made as a part of the registration of COMMAND.COM. Looking at the original PR it seems that this was the reason for having them in function in the first place. However making the class a singleton avoids this problem entirely, since it will now all be referring to the same instance. Note that this slightly changes behavior by recording the commands from all sub-shells instead of only the first.

Most of the changes have to do with the environment functions. I changed the result of an access to be the return values instead of out-parameters. I also made it so that when accessing an environment variable, it just gives back the value instead of the full string, which had necessitated each caller to manually parse the string to extract the value themselves. In addition I replaced the function that returned the number of variables, and the one that returned the variable at an "index". It's now a single function that just returns the strings for all of the variables. 

I also moved the functions to the program segment prefix since they're functions that operate on the PSP. In the process, I changed the programs which interact with the environment to set their environment variables to their parent's PSP instead of always the first_shell.

I originally wanted to get rid of the global first_shell instance altogether, but there are a couple of places that still use the first_shell environment in ways they probably shouldn't, but that would require some more work to change. These are in the autoexec code and the render code.