### PR TITLE
docs: Mention HiDPI support for Linux on front page

### DIFF
--- a/website/overrides/home.html
+++ b/website/overrides/home.html
@@ -125,7 +125,7 @@
             Host integration
           </h2>
           <ul>
-            <li><a href="https://dosbox-staging.github.io/downloads/release-notes/0.79.0/#high-dpi-on-macos">High DPI support on Windows and macOS</a></li>
+            <li><a href="https://dosbox-staging.github.io/downloads/release-notes/0.79.0/#high-dpi-on-macos">High DPI support on Windows, macOS, and Linux (Wayland)</a></li>
             <li>Vertical sync (vsync) support</li>
             <li><a href="https://dosbox-staging.github.io/downloads/release-notes/0.79.0/#frame-presentation-modes">Advanced frame pacing options for high and variable refresh rate (VRR) monitors</a></li>
             <li><a href="https://dosbox-staging.github.io/downloads/release-notes/0.75.0/#resizable-window">Resizable window support</a></li>


### PR DESCRIPTION
I have verified that it works in Plasma Wayland session, Hyprland, and Sway. Other wlroots-based compositors also should Just Work™, and GNOME likely also works.

Should this be sneak-ported back into the current version of the site?
