### PR TITLE
Update development-builds.md - mention platforms.yml

### DIFF
--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -90,10 +90,11 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-    set_ci_status("linux.yml", "linux", "Linux");
-    set_ci_status("macos.yml", "macos", "macOS");
-    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds ¹");
-    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds ²");
+    set_ci_status("linux.yml", "linux", "Linux x86-64");
+    set_ci_status("platforms.yml", "platforms", "Linux non-x86 ¹");
+    set_ci_status("macos.yml", "macos", "macOS x86-64 and ARM64");
+    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds ²");
+    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds ³");
 });
 
 </script>
@@ -121,6 +122,17 @@ document.addEventListener("DOMContentLoaded", () => {
       <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
     <td id="linux-build-date">
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
+    </td>
+  </tr>
+  <tr>
+    <td id="platforms-build-link">
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
+    </td>
+    <td id="platforms-build-version">
+      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
+    </td>
+    <td id="platforms-build-date">
       <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
   </tr>
@@ -160,10 +172,12 @@ document.addEventListener("DOMContentLoaded", () => {
 </table>
 </div>
 
-¹ Windows MSYS2 builds include 64-bit ZIP and Installer with both 64-bit MSYS2
+¹ Linux non-x86 builds include 32-bit ARMv6 and ARMv7; 64-bit ARM, Power and IBM z
+
+² Windows MSYS2 builds include 64-bit ZIP and Installer with both 64-bit MSYS2
 (default) and 64-bit MSVC (optional).
 
-² Windows MSVC builds include 32-bit ZIP and 64-bit ZIP.
+³ Windows MSVC builds include 32-bit ZIP and 64-bit ZIP.
 
 ## Installation notes
 


### PR DESCRIPTION
At
https://github.com/dosbox-staging/dosbox-staging/actions/runs/6000987478 are listed
> ARM64, ARMv6, ARMv7, ppc64le, s390x

At https://dosbox-staging.github.io/downloads/release-notes/0.75.0/ are listed
> Linux x86_64, ARMv6, ARMv7, IBM LinuxONE, and IBM POWER8 platforms

At https://github.com/dosbox-staging/dosbox-staging/commit/ef86642de390839afc77b2b591a6ea9ac43909b3 are mentioned
> Fortunately I have
a working MacBook G4 now, so can help again.
Note: the PPC 64-bit backends haven't been updated (because I don't have such a system)

Thus few questions:
- is POWER8 a minimum requirement? Or the ppc64le build will work on other 64-bit Power ISA CPUs that support Little endian mode? Later seems to be the case per https://en.wikipedia.org/wiki/Ppc64
- is there a 32-bit PowerPC G4 build?
- is there a 64-bit Big endian build (ppc64)?