### PR TITLE
Make shell configuration shortcuts optional/configurable

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -136,7 +136,7 @@ public:
 	void DoCommand(char* cmd);
 	bool Execute(std::string_view name, std::string_view args);
 	/* Checks if it matches a hardware-property */
-	bool CheckConfig(char* cmd_in, char* line);
+	bool CheckConfig(const char* const cmd_in, const char* const line);
 	/* Internal utilities for testing */
 	virtual bool execute_shell_cmd(char* name, char* arguments);
 	void ReadShellHistory();

--- a/include/shell.h
+++ b/include/shell.h
@@ -134,11 +134,13 @@ public:
 	void InputCommand(char* line);
 	void ShowPrompt();
 	void DoCommand(char* cmd);
-	bool Execute(std::string_view name, std::string_view args);
-	/* Checks if it matches a hardware-property */
-	bool CheckConfig(const char* const cmd_in, const char* const line);
-	/* Internal utilities for testing */
-	virtual bool execute_shell_cmd(char* name, char* arguments);
+
+	// Execute external shell command / program / configuration change
+	// 'virtual' needed for unit tests
+	virtual bool ExecuteShellCommand(const char* const name, char* arguments);
+	bool ExecuteProgram(std::string_view name, std::string_view args);
+	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
+
 	void ReadShellHistory();
 	void WriteShellHistory();
 

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2215,7 +2215,7 @@ public:
 
 		// Start shell
 		DOS_Shell shell;
-		if (!shell.Execute(filename, args))
+		if (!shell.ExecuteProgram(filename, args))
 			WriteOut(MSG_Get("PROGRAM_EXECUTABLE_MISSING"), filename);
 
 		// set old reg values

--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -76,7 +76,7 @@ void LOADFIX::Run(void)
 			}
 			// Use shell to start program
 			DOS_Shell shell;
-			shell.Execute(filename,args);
+			shell.ExecuteProgram(filename, args);
 			DOS_FreeMemory(segment);
 			WriteOut(MSG_Get("PROGRAM_LOADFIX_DEALLOC"),kb);
 		}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1135,6 +1135,11 @@ void DOSBOX_Init()
 	        "(auto by default, enabled if DOS version >= 7.0).\n"
 	        "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
 
+	pbool = secprop->Add_bool("shell_config_shortcuts", when_idle, true);
+	pbool->Set_help("Allow shortcuts for direct configuration management (enabled by default), i.e.\n"
+	                "instead of 'config -set sbtype sb16' it is enough to execute 'sbtype sb16', \n"
+	                "and instead of 'config -get sbtype' it is enough to execute 'sbtype' command.\n");
+
 	pstring = secprop->Add_path("shell_history_file", only_at_start, "shell_history.txt");
 	pstring->Set_help(
 		"File containing persistent command line history ('shell_history.txt'\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -631,6 +631,11 @@ void DOSBOX_Init()
 		"copy-on-write or network-based filesystem, this setting avoids triggering\n"
 		"write-operations for these write-protected files.");
 
+	pbool = secprop->Add_bool("shell_config_shortcuts", when_idle, true);
+	pbool->Set_help("Allow shortcuts for direct configuration management (enabled by default), i.e.\n"
+	                "instead of 'config -set sbtype sb16' it is enough to execute 'sbtype sb16', \n"
+	                "and instead of 'config -get sbtype' it is enough to execute 'sbtype' command.");
+
 	// Configure render settings
 	RENDER_AddConfigSection(control);
 
@@ -1134,11 +1139,6 @@ void DOSBOX_Init()
 	        "Enable expanding environment variables such as %PATH% in the DOS command shell\n"
 	        "(auto by default, enabled if DOS version >= 7.0).\n"
 	        "FreeDOS and MS-DOS 7/8 COMMAND.COM supports this behavior.");
-
-	pbool = secprop->Add_bool("shell_config_shortcuts", when_idle, true);
-	pbool->Set_help("Allow shortcuts for direct configuration management (enabled by default), i.e.\n"
-	                "instead of 'config -set sbtype sb16' it is enough to execute 'sbtype sb16', \n"
-	                "and instead of 'config -get sbtype' it is enough to execute 'sbtype' command.\n");
 
 	pstring = secprop->Add_path("shell_history_file", only_at_start, "shell_history.txt");
 	pstring->Set_help(

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -129,21 +129,34 @@ bool lookup_shell_cmd(std::string name, SHELL_Cmd &shell_cmd)
 	return true;
 }
 
-bool DOS_Shell::CheckConfig(char *cmd_in, char *line) {
-	Section* test = control->GetSectionFromProperty(cmd_in);
-	if (!test)
+bool DOS_Shell::CheckConfig(const char* const cmd_in, const char* const line)
+{
+	assert(control);
+	const auto section_dos = static_cast<Section_prop*>(
+	        control->GetSection("dos"));
+	assert(section_dos);
+	if (!section_dos->Get_bool("shell_config_shortcuts")) {
 		return false;
+	}
+
+	Section* test = control->GetSectionFromProperty(cmd_in);
+	if (!test) {
+		return false;
+	}
 
 	if (line && !line[0]) {
 		std::string val = test->GetPropValue(cmd_in);
-		if (val != NO_SUCH_PROPERTY)
+		if (val != NO_SUCH_PROPERTY) {
 			WriteOut("%s\n", val.c_str());
+		}
 		return true;
 	}
+
 	char newcom[1024];
 	safe_sprintf(newcom, "z:\\config -set %s %s%s", test->GetName(), cmd_in,
 	             line ? line : "");
 	DoCommand(newcom);
+
 	return true;
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -132,10 +132,10 @@ bool lookup_shell_cmd(std::string name, SHELL_Cmd &shell_cmd)
 bool DOS_Shell::ExecuteConfigChange(const char* const cmd_in, const char* const line)
 {
 	assert(control);
-	const auto section_dos = static_cast<Section_prop*>(
-	        control->GetSection("dos"));
-	assert(section_dos);
-	if (!section_dos->Get_bool("shell_config_shortcuts")) {
+	const auto section_dosbox = static_cast<Section_prop*>(
+	        control->GetSection("dosbox"));
+	assert(section_dosbox);
+	if (!section_dosbox->Get_bool("shell_config_shortcuts")) {
 		return false;
 	}
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -444,7 +444,7 @@ void CommandPrompt::SetCursor(const std::string::size_type index)
 	                   position_zero.page);
 }
 
-bool DOS_Shell::Execute(std::string_view name, std::string_view args)
+bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 {
 	if (name.size() > 1 && (std::isalpha(name[0]) != 0) &&
 	    (name.substr(1) == ":" || name.substr(1) == ":\\")) {

--- a/tests/shell_cmds_tests.cpp
+++ b/tests/shell_cmds_tests.cpp
@@ -62,13 +62,13 @@ public:
 	 * MockDOS_Shell()
 	 * {
 	 * 	// delegate call to the real object.
-	 * 	ON_CALL(*this, execute_shell_cmd)
+	 * 	ON_CALL(*this, ExecuteShellCommand)
 	 * 	        .WillByDefault([this](char *name, char *arguments) {
-	 * 		        return real_.execute_shell_cmd(name, arguments);
+	 * 		        return real_.ExecuteShellCommand(name, arguments);
 	 * 	        });
 	 * }
 	 */
-	MOCK_METHOD(bool, execute_shell_cmd, (char *name, char *arguments), (override));
+	MOCK_METHOD(bool, ExecuteShellCommand, (const char * const name, char *arguments), (override));
 	MOCK_METHOD(void,
 	            WriteOut,
 	            (const char *format, const char *arguments),
@@ -83,7 +83,7 @@ void assert_DoCommand(std::string input, std::string expected_name, std::string 
 	MockDOS_Shell shell;
 	char *input_c_str = const_cast<char *>(input.c_str());
 	EXPECT_CALL(shell,
-	            execute_shell_cmd(StrEq(expected_name), StrEq(expected_args)))
+	            ExecuteShellCommand(StrEq(expected_name), StrEq(expected_args)))
 	        .Times(1)
 	        .WillOnce(Return(true));
 	EXPECT_NO_THROW({ shell.DoCommand(input_c_str); });


### PR DESCRIPTION
Our `COMMAND.COM` replacement allows to use shortcuts for changing the configuration, for example instead of

`config -set dma=7`

it is enough to execute command `dma 7`. Some like it, some don't (see a slightly off-topic discussion in issue https://github.com/dosbox-staging/dosbox-staging/issues/2795), as the shell can go the 'configuration view/change' route in unexpected moments - like when we thing some executable in in the search `PATH`, while in reality it is not.

This PR makes this functionality configurable (but enabled by default). The small argument 'const' cleanup didn't cover the whole `DOS_Shell::Execute*` functions, as I wanted to limit the scope of the changes to a reasonable size and not introduce additional risks.