### PR TITLE
Offload ZMBV video encoder to worker thread

### DIFF
--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -70,7 +70,10 @@ public:
 	// non-blocking call
 	size_t Size();
 
-	// non-blocking calls
+	// non-blocking call
+	void Start();
+
+	// non-blocking call
 	void Stop();
 
 	// non-blocking call

--- a/src/capture/capture_video.h
+++ b/src/capture/capture_video.h
@@ -24,6 +24,11 @@
 
 #include "render.h"
 
+struct ZmbvWorkUnit {
+	std::vector<int16_t> audio = {};
+	RenderedImage image        = {};
+};
+
 void capture_video_add_frame(const RenderedImage& image,
                              const float frames_per_second);
 

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -46,6 +46,21 @@ size_t RWQueue<T>::Size()
 }
 
 template <typename T>
+void RWQueue<T>::Start()
+{
+	if (is_running) {
+		return;
+	}
+	mutex.lock();
+	is_running = true;
+	mutex.unlock();
+
+	// notify the conditions
+	has_items.notify_all();
+	has_room.notify_all();
+}
+
+template <typename T>
 void RWQueue<T>::Stop()
 {
 	if (!is_running) {
@@ -254,3 +269,7 @@ template class RWQueue<MidiWork>;
 
 #include "render.h"
 template class RWQueue<SaveImageTask>;
+
+// ZMBV Video Encoder
+#include "../capture/capture_video.h"
+template class RWQueue<ZmbvWorkUnit>;


### PR DESCRIPTION
Not ready for merge or review.  I banged this out in like an hour and a half and just wanted to post this as a starting point.

The threading logic is fine I think but it is just a band-aid for poor encoder performance and DOSBox reacts violently when you rip the band-aid off.

On my machine it goes like this.  Start Doom, start recording.  If you stand still, everything is good.  In single-threaded, this was a laggy mess so it's kind of better.

If you start moving around a lot, the queue quickly reaches max capacity at which point the main thread stalls while it waits for the worker thread to clear out the queue.  This is a stall for a few seconds.  Not good :sob: 

Sometimes if the main thread gets stalled for long enough,  it doesn't recover.  I think something weird may be happening in the OPL sound code because when I turn OPL off, the main thread recovers fine after the stall.

So, like I thought might happen.  Pretty straight forward to offload to a worker thread but it doesn't solve the real problem.