### PR TITLE
Prevent duplicate SDL Window creation when using OpenGL

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1363,6 +1363,7 @@ finish:
 	// latency (and not the rendering pipeline).
 	render_pacer->Reset();
 
+	sdl.desktop.type = screen_type;
 	return sdl.window;
 }
 
@@ -1769,7 +1770,6 @@ uint8_t GFX_SetSize(const int width, const int height,
 		sdl.frame.update = update_frame_texture;
 		sdl.frame.present = present_frame_texture;
 
-		sdl.desktop.type = SCREEN_TEXTURE;
 		break; // SCREEN_TEXTURE
 	}
 #if C_OPENGL
@@ -2097,7 +2097,6 @@ uint8_t GFX_SetSize(const int width, const int height,
 		}
 		// Both update mechanisms use the same presentation call
 		sdl.frame.present = present_frame_gl;
-		sdl.desktop.type  = SCREEN_OPENGL;
 		break; // SCREEN_OPENGL
 	}
 #endif // C_OPENGL


### PR DESCRIPTION
This is a regression caused by commit d90fa8ee042ef459f4976b0f872d403009f6fc6d

After that commit, the window gets created once in GUI_StartUp and then a second time in GFX_SetSize when using OpenGL.  Using texture is not affected.  This causes a noticeable window flash on start-up and also causes the DOSBox icon to be replaced with a generic X.Org icon.

The problem appears to be due to not setting sdl.desktop.type to OpenGL the frist time around so it thinks the window must be re-created (texture is default so this just happens to not cause problems there).

To find this bug, I set a break point in GDB when the window gets created and looked at the stack trace.  Here you can see the duplicate window creations (both happen in the span of about 1 second upon initially launching DOSBox).

Initial creation from `GUI_StartIp`

```
Thread 1 "dosbox" hit Breakpoint 1, SetWindowMode (screen_type=SCREEN_OPENGL, width=1067, height=800, fullscreen=false)
    at ../../src/gui/sdlmain.cpp:1272
1272                    sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
(gdb) bt
#0  SetWindowMode(SCREEN_TYPES, int, int, bool) (screen_type=SCREEN_OPENGL, width=1067, height=800, fullscreen=false)
    at ../../src/gui/sdlmain.cpp:1272
#1  0x0000555555edfdfa in SetDefaultWindowMode() () at ../../src/gui/sdlmain.cpp:2758
#2  0x0000555555ee2071 in set_output(Section*, bool) (sec=0x55555896fb30, wants_aspect_ratio_correction=true)
    at ../../src/gui/sdlmain.cpp:3289
#3  0x0000555555ee3ab8 in GUI_StartUp(Section*) (sec=0x55555896fb30) at ../../src/gui/sdlmain.cpp:3566
#4  0x0000555555ba9869 in Section::ExecuteInit(bool) (this=0x55555896fb30, init_all=true) at ../../src/misc/setup.cpp:1223
#5  0x0000555555ba967e in Config::Init() const (this=0x55555896cda0) at ../../src/misc/setup.cpp:1195
#6  0x0000555555ee997d in sdl_main(int, char**) (argc=1, argv=0x7fffffffe568) at ../../src/gui/sdlmain.cpp:4714
#7  0x0000555555b82cb6 in main(int, char**) (argc=1, argv=0x7fffffffe568) at ../../src/main.cpp:30
```

Redundant Creation in `GFX_SetSize`

```
Thread 1 "dosbox" hit Breakpoint 1, SetWindowMode (screen_type=SCREEN_OPENGL, width=1067, height=800, fullscreen=false)
    at ../../src/gui/sdlmain.cpp:1272
1272                    sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
(gdb) bt
#0  SetWindowMode(SCREEN_TYPES, int, int, bool) (screen_type=SCREEN_OPENGL, width=1067, height=800, fullscreen=false)
    at ../../src/gui/sdlmain.cpp:1272
#1  0x0000555555edbc75 in SetupWindowScaled(SCREEN_TYPES) (screen_type=SCREEN_OPENGL) at ../../src/gui/sdlmain.cpp:1456
#2  0x0000555555edd3cd in GFX_SetSize(int, int, Fraction const&, unsigned char, VideoMode const&, void (*)(GFX_CallBackFunctions_t))
    (width=720, height=400, render_pixel_aspect_ratio=..., flags=8 '\b', video_mode=..., callback=0x555555ea2175 <render_callback(GFX_CallBackFunctions_t)>) at ../../src/gui/sdlmain.cpp:1840
#3  0x0000555555ea1d15 in render_reset() () at ../../src/gui/render.cpp:431
#4  0x0000555555ea22dc in RENDER_SetSize(unsigned short, unsigned short, bool, bool, Fraction const&, PixelFormat, double, VideoMode const&)
    (width=720, height=400, double_width=false, double_height=false, render_pixel_aspect_ratio=..., pixel_format=PixelFormat::BGRX8888, frames_per_second=70.086592427616921, video_mode=...) at ../../src/gui/render.cpp:545
#5  0x0000555556013a74 in SetupVideoMixer(bool) (updateRenderMode=true) at ../../src/hardware/reelmagic/video_mixer.cpp:535
#6  0x0000555556014831 in ReelMagic_RENDER_SetSize(unsigned short, unsigned short, bool, bool, Fraction const&, PixelFormat, double, VideoMode const&)
    (width=720, height=400, double_width=false, double_height=false, render_pixel_aspect_ratio=..., pixel_format=PixelFormat::BGRX8888, frames_per_second=70.086592427616921, video_mode=...) at ../../src/hardware/reelmagic/video_mixer.cpp:723
#7  0x0000555556043b27 in VGA_SetupDrawing(unsigned int) () at ../../src/hardware/vga_draw.cpp:2847
#8  0x0000555555fefb12 in PIC_RunQueue() () at ../../src/hardware/pic.cpp:538
#9  0x0000555555b82e49 in Normal_Loop() () at ../../src/dosbox.cpp:144
#10 0x0000555555b83593 in DOSBOX_RunMachine() () at ../../src/dosbox.cpp:321
#11 0x0000555555cadbca in CALLBACK_RunRealInt(unsigned char) (intnum=22 '\026') at ../../src/cpu/callback.cpp:114
#12 0x0000555555d7996a in device_CON::Read(unsigned char*, unsigned short*)
    (this=0x555559090bc0, data=0x7fffffffcc49 "", size=0x7fffffffcc12) at ../../src/dos/dev_con.h:87
#13 0x0000555555d7b62d in DOS_Device::Read(unsigned char*, unsigned short*)
    (this=0x5555591dd640, data=0x7fffffffcc49 "", size=0x7fffffffcc12) at ../../src/dos/dos_devices.cpp:331
#14 0x0000555555d8111f in DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)
    (entry=0, data=0x7fffffffcc49 "", amount=0x7fffffffcc4e, fcb=false) at ../../src/dos/dos_files.cpp:470
#15 0x000055555614af74 in DOS_Shell::ReadCommand[abi:cxx11]() (this=0x555559110ae0) at ../../src/shell/shell_misc.cpp:134
#16 0x000055555614a941 in DOS_Shell::InputCommand(char*) (this=0x555559110ae0, line=0x7fffffffd020 "AUTOEXEC.BAT")
    at ../../src/shell/shell_misc.cpp:79
#17 0x00005555561213f7 in DOS_Shell::Run() (this=0x555559110ae0) at ../../src/shell/shell.cpp:435
#18 0x0000555556124332 in SHELL_Init() () at ../../src/shell/shell.cpp:1431
#19 0x0000555555bab283 in Config::StartUp() (this=0x55555896cda0) at ../../src/misc/setup.cpp:1520
#20 0x0000555555ee9a31 in sdl_main(int, char**) (argc=1, argv=0x7fffffffe568) at ../../src/gui/sdlmain.cpp:4725
#21 0x0000555555b82cb6 in main(int, char**) (argc=1, argv=0x7fffffffe568) at ../../src/main.cpp:30
```