### PR TITLE
Rename PixelFormat enum members BGR555 and BGR565 to RGB555 and RGB565

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -146,19 +146,54 @@ enum class PixelFormat : uint8_t {
 
 	// 32K high colour, 5 bits per red/blue/green component;
 	// stored as packed uint16 data with highest bit unused
-	BGR555 = 15,
 	//
+	// Stored as array of uint16_t in host native endianess.
+	// Each uint16_t is layed out as follows:
+	// (msb)1X 5R 5G 5B(lsb)
+	// Example:
+	// uint16_t pixel = (red << 10) | (green << 5) | (blue << 0)
+	//
+	// SDL Equivalent: SDL_PIXELFORMAT_RGB555
+	// FFmpeg Equivalent: AV_PIX_FMT_RGB555
+	RGB555_Packed16 = 15,
+
 	// 65K high colour, 5 bits for red/blue, 6 bit for green;
 	// stored as packed uint16 data
-	BGR565 = 16,
 	//
+	// Stored as array of uint16_t in host native endianess.
+	// Each uint16_t is layed out as follows:
+	// (msb)5R 6G 5B(lsb)
+	// Example:
+	// uint16_t pixel = (red << 11) | (green << 5) | (blue << 0)
+	//
+	// SDL Equivalent: SDL_PIXELFORMAT_RGB565
+	// FFmpeg Equivalent: AV_PIX_FMT_RGB565
+	RGB565_Packed16 = 16,
+
 	// 16.7M (24-bit) true colour, 8 bits per red/blue/green component;
 	// stored as packed 24-bit data
-	BGR888 = 24,
 	//
+	// Stored as array of uint8_t in BGR memory order (endian agnostic)
+	// Example:
+	// uint8_t *pixels = image.image_data;
+	// pixels[0] = blue; pixels[1] = green; pixels[2] = red;
+	//
+	// SDL Equivalent: SDL_PIXELFORMAT_BGR24
+	// FFmpeg Equivalent: AV_PIX_FMT_BGR24
+	BGR24_ByteArray = 24,
+
 	// 16.7M (32-bit) true colour; 8 bits per red/blue/green component;
-	// stored as packed uint32 data with lowest 8 bits unused
-	BGRX8888 = 32
+	// stored as packed uint32 data with highest 8 bits unused
+	//
+	// Stored as array of uint32_t in host native endianess.
+	// Each uint32_t is layed out as follows:
+	// (msb)8X 8R 8G 8B(lsb)
+	// Example:
+	// uint32_t pixel = (unused << 24) | (red << 16) | (green << 8) | (blue << 0)
+	//
+	// SDL Equivalent: SDL_PIXELFORMAT_XRGB8888
+	// FFmpeg Equivalent: AV_PIX_FMT_0RGB32
+	XRGB8888_Packed32 = 32
 };
 
 const char* to_string(const PixelFormat pf);

--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -338,16 +338,16 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 
 	switch (src.pixel_format) {
 	case PixelFormat::Indexed8: format = ZMBV_FORMAT::BPP_8; break;
-	case PixelFormat::BGR555: format = ZMBV_FORMAT::BPP_15; break;
-	case PixelFormat::BGR565: format = ZMBV_FORMAT::BPP_16; break;
+	case PixelFormat::RGB555_Packed16: format = ZMBV_FORMAT::BPP_15; break;
+	case PixelFormat::RGB565_Packed16: format = ZMBV_FORMAT::BPP_16; break;
 
 	// ZMBV is "the DOSBox capture format" supported by external
 	// tools such as VLC, MPV, and ffmpeg. Because DOSBox originally
 	// didn't have 24-bit color, the format itself doesn't support
 	// it. I this case we tell ZMBV the data is 32-bit and let the
 	// rgb24's int() cast operator up-convert.
-	case PixelFormat::BGR888: format = ZMBV_FORMAT::BPP_32; break;
-	case PixelFormat::BGRX8888: format = ZMBV_FORMAT::BPP_32; break;
+	case PixelFormat::BGR24_ByteArray: format = ZMBV_FORMAT::BPP_32; break;
+	case PixelFormat::XRGB8888_Packed32: format = ZMBV_FORMAT::BPP_32; break;
 	default: assertm(false, "Invalid pixel_format value"); return;
 	}
 
@@ -391,8 +391,8 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 				}
 				break;
 
-			case PixelFormat::BGR555:
-			case PixelFormat::BGR565:
+			case PixelFormat::RGB555_Packed16:
+			case PixelFormat::RGB565_Packed16:
 				for (auto x = 0; x < src.width; ++x) {
 					const auto pixel = ((uint16_t*)src_row)[x];
 
@@ -401,7 +401,7 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 				}
 				break;
 
-			case PixelFormat::BGR888:
+			case PixelFormat::BGR24_ByteArray:
 				for (auto x = 0; x < src.width; ++x) {
 					const auto pixel = reinterpret_cast<const Rgb888*>(
 					        src_row)[x];
@@ -413,7 +413,7 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 				}
 				break;
 
-			case PixelFormat::BGRX8888:
+			case PixelFormat::XRGB8888_Packed32:
 				for (auto x = 0; x < src.width; ++x) {
 					const auto pixel = ((uint32_t*)src_row)[x];
 
@@ -425,7 +425,7 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 			row_pointer = row_buffer;
 
 		} else {
-			if (src.pixel_format == PixelFormat::BGR888) {
+			if (src.pixel_format == PixelFormat::BGR24_ByteArray) {
 				for (auto x = 0; x < src.width; ++x) {
 					const auto pixel = reinterpret_cast<const Rgb888*>(
 					        src_row)[x];

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -79,10 +79,10 @@ private:
 	{
 		switch (image.params.pixel_format) {
 		case PixelFormat::Indexed8: ++pos; break;
-		case PixelFormat::BGR555:
-		case PixelFormat::BGR565: pos += 2; break;
-		case PixelFormat::BGR888: pos += 3; break;
-		case PixelFormat::BGRX8888: pos += 4; break;
+		case PixelFormat::RGB555_Packed16:
+		case PixelFormat::RGB565_Packed16: pos += 2; break;
+		case PixelFormat::BGR24_ByteArray: pos += 3; break;
+		case PixelFormat::XRGB8888_Packed32: pos += 4; break;
 		default: assertm(false, "Invalid pixel_format value");
 		}
 	}
@@ -105,26 +105,27 @@ private:
 		Rgb888 pixel = {};
 
 		switch (image.params.pixel_format) {
-		case PixelFormat::BGR555: {
+		case PixelFormat::RGB555_Packed16: {
 			const auto p = host_to_le(
 			        *reinterpret_cast<const uint16_t*>(pos));
 			pixel = Rgb555(p).ToRgb888();
 		} break;
 
-		case PixelFormat::BGR565: {
+		case PixelFormat::RGB565_Packed16: {
 			const auto p = host_to_le(
 			        *reinterpret_cast<const uint16_t*>(pos));
 			pixel = Rgb565(p).ToRgb888();
 		} break;
 
-		case PixelFormat::BGR888:
-		case PixelFormat::BGRX8888: {
+		case PixelFormat::BGR24_ByteArray:
+		case PixelFormat::XRGB8888_Packed32: {
 			const auto b = *(pos + 0);
 			const auto g = *(pos + 1);
 			const auto r = *(pos + 2);
 
 			pixel = {r, g, b};
 		} break;
+
 		default: assertm(false, "Invalid pixel_format value");
 		}
 

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -106,22 +106,28 @@ private:
 
 		switch (image.params.pixel_format) {
 		case PixelFormat::RGB555_Packed16: {
-			const auto p = host_to_le(
-			        *reinterpret_cast<const uint16_t*>(pos));
+			const auto p = read_unaligned_uint16(pos);
 			pixel = Rgb555(p).ToRgb888();
 		} break;
 
 		case PixelFormat::RGB565_Packed16: {
-			const auto p = host_to_le(
-			        *reinterpret_cast<const uint16_t*>(pos));
+			const auto p = read_unaligned_uint16(pos);
 			pixel = Rgb565(p).ToRgb888();
 		} break;
 
-		case PixelFormat::BGR24_ByteArray:
-		case PixelFormat::XRGB8888_Packed32: {
+		case PixelFormat::BGR24_ByteArray: {
 			const auto b = *(pos + 0);
 			const auto g = *(pos + 1);
 			const auto r = *(pos + 2);
+
+			pixel = {r, g, b};
+		} break;
+
+		case PixelFormat::XRGB8888_Packed32: {
+			const auto p = read_unaligned_uint32(pos);
+			const uint8_t r = (p >> 16) & 0XFF;
+			const uint8_t g = (p >> 8) & 0xFF;
+			const uint8_t b = p & 0xFF;
 
 			pixel = {r, g, b};
 		} break;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -55,10 +55,10 @@ const char* to_string(const PixelFormat pf)
 {
 	switch (pf) {
 	case PixelFormat::Indexed8: return "Indexed8";
-	case PixelFormat::BGR555: return "BGR555";
-	case PixelFormat::BGR565: return "BGR565";
-	case PixelFormat::BGR888: return "BGR888";
-	case PixelFormat::BGRX8888: return "BGRX8888";
+	case PixelFormat::RGB555_Packed16: return "RGB555_Packed16";
+	case PixelFormat::RGB565_Packed16: return "RGB565_Packed16";
+	case PixelFormat::BGR24_ByteArray: return "BGR24_ByteArray";
+	case PixelFormat::XRGB8888_Packed32: return "XRGB8888_Packed32";
 	default: assertm(false, "Invalid pixel format"); return {};
 	}
 }
@@ -394,16 +394,16 @@ static void render_reset(void)
 
 	switch (render.src.pixel_format) {
 	case PixelFormat::Indexed8:
-	case PixelFormat::BGR555:
-	case PixelFormat::BGR565:
+	case PixelFormat::RGB555_Packed16:
+	case PixelFormat::RGB565_Packed16:
 		render.src_start = (render.src.width * 2) / src_pixel_bytes;
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
-	case PixelFormat::BGR888:
+	case PixelFormat::BGR24_ByteArray:
 		render.src_start = (render.src.width * 3) / src_pixel_bytes;
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
-	case PixelFormat::BGRX8888:
+	case PixelFormat::XRGB8888_Packed32:
 		render.src_start = (render.src.width * 4) / src_pixel_bytes;
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
@@ -462,25 +462,25 @@ static void render_reset(void)
 		render.scale.inMode     = scalerMode8;
 		render.scale.cachePitch = render.src.width * 1;
 		break;
-	case PixelFormat::BGR555:
+	case PixelFormat::RGB555_Packed16:
 		render.scale.lineHandler = (*lineBlock)[1][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode15;
 		render.scale.cachePitch     = render.src.width * 2;
 		break;
-	case PixelFormat::BGR565:
+	case PixelFormat::RGB565_Packed16:
 		render.scale.lineHandler = (*lineBlock)[2][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode16;
 		render.scale.cachePitch     = render.src.width * 2;
 		break;
-	case PixelFormat::BGR888:
+	case PixelFormat::BGR24_ByteArray:
 		render.scale.lineHandler = (*lineBlock)[3][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode32;
 		render.scale.cachePitch     = render.src.width * 3;
 		break;
-	case PixelFormat::BGRX8888:
+	case PixelFormat::XRGB8888_Packed32:
 		render.scale.lineHandler = (*lineBlock)[4][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode32;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2384,7 +2384,7 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 		image.params.double_width       = false;
 		image.params.double_height      = false;
 		image.params.pixel_aspect_ratio = {1};
-		image.params.pixel_format       = PixelFormat::BGR888;
+		image.params.pixel_format       = PixelFormat::BGR24_ByteArray;
 		image.params.video_mode         = sdl.video_mode;
 
 		image.is_flipped_vertically = false;

--- a/src/hardware/reelmagic/video_mixer.cpp
+++ b/src/hardware/reelmagic/video_mixer.cpp
@@ -212,7 +212,7 @@ static uint32_t _mpegPictureWidth  = 0;
 static uint32_t _mpegPictureHeight = 0;
 
 // video mixer is exclusively 32bpp on the RENDER... VGA color palette mapping is re-done here...
-static const auto VideoMixerPixelFormat = PixelFormat::BGRX8888;
+static const auto VideoMixerPixelFormat = PixelFormat::XRGB8888_Packed32;
 
 // current RENDER state
 static void RMR_DrawLine_Passthrough(const void* src);
@@ -341,15 +341,15 @@ static void RMR_DrawLine_MixerError([[maybe_unused]] const void* src)
 		if (VGA_OVER) \
 			switch (VGA_PF) { \
 			case PixelFormat::Indexed8: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO8; break; \
-			case PixelFormat::BGR565: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO16; break; \
-			case PixelFormat::BGRX8888: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO32; break; \
+			case PixelFormat::RGB565_Packed16: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO16; break; \
+			case PixelFormat::XRGB8888_Packed32: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO32; break; \
 			default: ReelMagic_RENDER_DrawLine = &RMR_DrawLine_MixerError; break; \
 			} \
 		else \
 			switch (VGA_PF) { \
 			case PixelFormat::Indexed8: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU8; break; \
-			case PixelFormat::BGR565: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU16; break; \
-			case PixelFormat::BGRX8888: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU32; break; \
+			case PixelFormat::RGB565_Packed16: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU16; break; \
+			case PixelFormat::XRGB8888_Packed32: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU32; break; \
 			default: ReelMagic_RENDER_DrawLine = &RMR_DrawLine_MixerError; break; \
 			} \
 	}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -964,7 +964,7 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 			std::fill(templine_buffer.begin(),
 			          templine_buffer.end(),
 			          bg_color_index);
-		} else if (vga.draw.render.pixel_format == PixelFormat::BGR565) {
+		} else if (vga.draw.render.pixel_format == PixelFormat::RGB565_Packed16) {
 			const auto background_color = from_rgb_888_to_565(
 			        vga.dac.palette_map[bg_color_index]);
 			const auto line_length = templine_buffer.size() / sizeof(uint16_t);
@@ -972,7 +972,7 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 			while (i < line_length) {
 				write_unaligned_uint16_at(TempLine, i++, background_color);
 			}
-		} else if (vga.draw.render.pixel_format == PixelFormat::BGRX8888) {
+		} else if (vga.draw.render.pixel_format == PixelFormat::XRGB8888_Packed32) {
 			const auto background_color = vga.dac.palette_map[bg_color_index];
 			const auto line_length = templine_buffer.size() / sizeof(uint32_t);
 			size_t i = 0;
@@ -1370,7 +1370,7 @@ PixelFormat VGA_ActivateHardwareCursor()
 
 	switch (vga.mode) {
 	case M_LIN32: // 32-bit true-colour VESA
-		pixel_format = PixelFormat::BGRX8888;
+		pixel_format = PixelFormat::XRGB8888_Packed32;
 
 		VGA_DrawLine = use_hw_cursor ? VGA_Draw_LIN32_Line_HWMouse
 		                             : VGA_Draw_Linear_Line;
@@ -1380,26 +1380,26 @@ PixelFormat VGA_ActivateHardwareCursor()
 		// rendering.
 		break;
 	case M_LIN24: // 24-bit true-colour VESA
-		pixel_format = PixelFormat::BGR888;
+		pixel_format = PixelFormat::BGR24_ByteArray;
 
 		VGA_DrawLine = use_hw_cursor ? VGA_Draw_LIN32_Line_HWMouse
 		                             : VGA_Draw_Linear_Line;
 		break;
 	case M_LIN16: // 16-bit high-colour VESA
-		pixel_format = PixelFormat::BGR565;
+		pixel_format = PixelFormat::RGB565_Packed16;
 
 		VGA_DrawLine = use_hw_cursor ? VGA_Draw_LIN16_Line_HWMouse
 		                             : VGA_Draw_Linear_Line;
 		break;
 	case M_LIN15: // 15-bit high-colour VESA
-		pixel_format = PixelFormat::BGR555;
+		pixel_format = PixelFormat::RGB555_Packed16;
 
 		VGA_DrawLine = use_hw_cursor ? VGA_Draw_LIN16_Line_HWMouse
 		                             : VGA_Draw_Linear_Line;
 		break;
 	case M_LIN8: // 8-bit and below
 	default:
-		pixel_format = PixelFormat::BGRX8888;
+		pixel_format = PixelFormat::XRGB8888_Packed32;
 
 		// Use routines that treats the 8-bit pixel values as
 		// indexes into the DAC's palette LUT. The palette LUT
@@ -1966,13 +1966,13 @@ ImageInfo setup_drawing()
 
 	PixelFormat pixel_format;
 	switch (vga.mode) {
-	case M_LIN15: pixel_format = PixelFormat::BGR555; break;
-	case M_LIN16: pixel_format = PixelFormat::BGR565; break;
-	case M_LIN24: pixel_format = PixelFormat::BGR888; break;
+	case M_LIN15: pixel_format = PixelFormat::RGB555_Packed16; break;
+	case M_LIN16: pixel_format = PixelFormat::RGB565_Packed16; break;
+	case M_LIN24: pixel_format = PixelFormat::BGR24_ByteArray; break;
 	case M_LIN32:
 	case M_CGA2_COMPOSITE:
 	case M_CGA4_COMPOSITE:
-	case M_CGA_TEXT_COMPOSITE: pixel_format = PixelFormat::BGRX8888; break;
+	case M_CGA_TEXT_COMPOSITE: pixel_format = PixelFormat::XRGB8888_Packed32; break;
 	default: pixel_format = PixelFormat::Indexed8; break;
 	}
 
@@ -2166,7 +2166,7 @@ ImageInfo setup_drawing()
 			// The ReelMagic video mixer expects linear VGA drawing
 			// (i.e.: Return to Zork's house intro), so limit the use
 			// of 18-bit palettized LUT routine to non-mixed output.
-			pixel_format = PixelFormat::BGRX8888;
+			pixel_format = PixelFormat::XRGB8888_Packed32;
 
 			VGA_DrawLine = draw_linear_line_from_dac_palette;
 		} else {
@@ -2255,7 +2255,7 @@ ImageInfo setup_drawing()
 		}
 
 		if (IS_VGA_ARCH) {
-			pixel_format = PixelFormat::BGRX8888;
+			pixel_format = PixelFormat::XRGB8888_Packed32;
 
 			VGA_DrawLine = draw_linear_line_from_dac_palette;
 		} else {
@@ -2571,7 +2571,7 @@ ImageInfo setup_drawing()
 			vga.draw.pixels_per_character = vga.seq.clocking_mode.is_eight_dot_mode
 			                                      ? PixelsPerChar::Eight
 			                                      : PixelsPerChar::Nine;
-			pixel_format = PixelFormat::BGRX8888;
+			pixel_format = PixelFormat::XRGB8888_Packed32;
 
 			VGA_DrawLine = draw_text_line_from_dac_palette;
 

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7382,7 +7382,7 @@ static void Voodoo_UpdateScreen()
 			               double_width,
 			               double_height,
 			               render_pixel_aspect_ratio,
-			               PixelFormat::BGR565,
+			               PixelFormat::RGB565_Packed16,
 			               frames_per_second,
 			               video_mode);
 		}


### PR DESCRIPTION
These were mis-named. Red is stored in the high bits and blue is stored in the low bits.

This is just a re-name.  Nothing functional changes in this PR.

I found this because colors were wrong in the demo scene stuff @johnnovak sent me.  I was mapping FFmpeg's BGR enums when really they're stored as RGB (and a simple swap to the right FFmpeg fixed it).

Also, if you look at where these are decoded for image capturing, they get mapped to RGB helpers (not BGR):

https://github.com/dosbox-staging/dosbox-staging/blob/6b7f3645ea096c9fc036a585d1b6a6c6c90fdaf9/src/capture/image/image_decoder.h#L108-L118