### PR TITLE
Debug/trace logging improvements

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -91,13 +91,13 @@ void GFX_ShowMsg(const char* format, ...)
 #endif // C_DEBUG
 
 #ifdef NDEBUG
-// DEBUG_LOG_MSG exists only for messages useful during development, and not to
+// LOG_DEBUG exists only for messages useful during development, and not to
 // be redirected into internal DOSBox debugger for DOS programs (C_DEBUG feature).
-#define DEBUG_LOG_MSG(...)
+#define LOG_DEBUG(...)
 #else
 
 template <typename... Args>
-void DEBUG_LOG_MSG(const std::string& format, const Args&... args) noexcept
+void LOG_DEBUG(const std::string& format, const Args&... args) noexcept
 {
 	const auto format_green = std::string(loguru::terminal_green()) +
 	                          loguru::terminal_bold() + format +

--- a/include/logging.h
+++ b/include/logging.h
@@ -106,6 +106,17 @@ void LOG_DEBUG(const std::string& format, const Args&... args) noexcept
 	DLOG_F(INFO, format_green.c_str(), args...);
 }
 
+template <typename... Args>
+void LOG_TRACE(const std::string& format, const Args&... args) noexcept
+{
+	const auto format_purple = std::string(loguru::terminal_purple()) +
+	                           loguru::terminal_bold() + format +
+	                           loguru::terminal_reset();
+
+	DLOG_F(INFO, format_purple.c_str(), args...);
+}
+
+
 #endif // NDEBUG
 
 #endif

--- a/include/logging.h
+++ b/include/logging.h
@@ -20,6 +20,7 @@
 #define DOSBOX_LOGGING_H
 
 #include <cstdio>
+#include <string>
 
 #include "compiler.h"
 
@@ -56,11 +57,12 @@ public:
 		d_type(type),
 		d_severity(severity)
 		{}
-	void operator() (char const* buf, ...) GCC_ATTRIBUTE(__format__(__printf__, 2, 3));  //../src/debug/debug_gui.cpp
-
+	        void operator()(const char* buf, ...)
+	                GCC_ATTRIBUTE(__format__(__printf__, 2, 3)); //../src/debug/debug_gui.cpp
 };
 
-void DEBUG_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
+void DEBUG_ShowMsg(const char* format, ...)
+        GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
 #define LOG_MSG DEBUG_ShowMsg
 
 #define LOG_INFO(...)    LOG(LOG_ALL, LOG_NORMAL)(__VA_ARGS__)
@@ -72,11 +74,12 @@ void DEBUG_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 
 struct LOG
 {
 	inline LOG(LOG_TYPES, LOG_SEVERITIES){ }
-	inline void operator()(char const* , ...){ }
+	inline void operator()(const char*, ...) {}
 }; //add missing operators to here
 
 	//try to avoid anything smaller than bit32...
-void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
+void GFX_ShowMsg(const char* format, ...)
+        GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
 
 // Keep for compatibility
 #define LOG_MSG(...)	LOG_F(INFO, __VA_ARGS__)
@@ -92,7 +95,17 @@ void GFX_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1,
 // be redirected into internal DOSBox debugger for DOS programs (C_DEBUG feature).
 #define DEBUG_LOG_MSG(...)
 #else
-#define DEBUG_LOG_MSG(...) DLOG_F(INFO, __VA_ARGS__)
+
+template <typename... Args>
+void DEBUG_LOG_MSG(const std::string& format, const Args&... args) noexcept
+{
+	const auto format_green = std::string(loguru::terminal_green()) +
+	                          loguru::terminal_bold() + format +
+	                          loguru::terminal_reset();
+
+	DLOG_F(INFO, format_green.c_str(), args...);
+}
+
 #endif // NDEBUG
 
 #endif

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -394,14 +394,6 @@ std::optional<float> parse_prefixed_percentage(const char prefix,
 // returns value only if succeeded
 std::optional<int> to_int(const std::string& value);
 
-#if defined(__GNUC__) || defined(__clang__)
-// Disable generic "format string is not a string literal (potentially
-// insecure)" warning on GCC/Clang. Of course, it's not a security issue for
-// us; we know what we're doing.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
-#endif
-
 template <typename... Args>
 std::string format_string(const std::string& format, const Args&... args) noexcept
 {
@@ -429,9 +421,5 @@ std::string format_string(const std::string& format, const Args&... args) noexce
 	result.pop_back();
 	return result;
 }
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ extra_flags = [
 
 warnings = []
 
+# Enable additional warnings
 foreach flag : [
     '-Walloca',
     '-Wctor-dtor-privacy',
@@ -104,6 +105,15 @@ foreach flag : [
     '-Wstrict-null-sentinel',
     '-Wsuggest-override',
     '-Wzero-as-null-pointer-constant',
+]
+    if cxx.has_argument(flag)
+       warnings += flag
+    endif
+endforeach
+
+# Ignore some warnings enabled by default
+foreach flag : [
+    '-Wno-format-security'
 ]
     if cxx.has_argument(flag)
        warnings += flag

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -711,7 +711,7 @@ static void cache_closeblock()
 	                            (block->cache.next->cache.start > limit));
 #endif
 	if (cache_is_full) {
-		// DEBUG_LOG_MSG("Cache full; restarting");
+		// LOG_DEBUG("Cache full; restarting");
 		cache.block.active=cache.block.first;
 	} else {
 		cache.block.active=block->cache.next;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -194,8 +194,8 @@ void DOS_PSP::SetFileHandle(uint16_t index, uint8_t handle)
 		const PhysPt files = RealToPhysical(SGET_DWORD(sPSP, file_table));
 		mem_writeb(files + index, handle);
 	} else {
-		DEBUG_LOG_MSG("DOS: Prevented buffer overflow on write to PSP file_table[%u]",
-		              index);
+		LOG_DEBUG("DOS: Prevented buffer overflow on write to PSP file_table[%u]",
+		          index);
 	}
 }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -233,8 +233,8 @@ bool localDrive::GetSystemFilename(char* sysName, const char* const dosName)
 // Attempt to delete the file name from our local drive mount
 bool localDrive::FileUnlink(char * name) {
 	if (!FileExists(name)) {
-		DEBUG_LOG_MSG("FS: Skipping removal of %s because it doesn't exist",
-		              name);
+		LOG_DEBUG("FS: Skipping removal of '%s' because it doesn't exist",
+		          name);
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
 		return false;
 	}
@@ -268,7 +268,7 @@ bool localDrive::FileUnlink(char * name) {
 			return true;
 		}
 	}
-	DEBUG_LOG_MSG("FS: Unable to remove file %s", fullname);
+	LOG_DEBUG("FS: Unable to remove file '%s'", fullname);
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
@@ -626,7 +626,7 @@ bool localFile::ftell_and_check()
 	if (stream_pos >= 0)
 		return true;
 
-	DEBUG_LOG_MSG("FS: Failed obtaining position in file %s", name.c_str());
+	LOG_DEBUG("FS: Failed obtaining position in file '%s'", name.c_str());
 	return false;
 }
 
@@ -640,7 +640,9 @@ bool localFile::fseek_to_and_check(long pos, int whence)
 		stream_pos = pos;
 		return true;
 	}
-	DEBUG_LOG_MSG("FS: Failed seeking to byte %ld in file %s", stream_pos, name.c_str());
+	LOG_DEBUG("FS: Failed seeking to byte %ld in file '%s'",
+	          stream_pos,
+	          name.c_str());
 	return false;
 }
 
@@ -670,10 +672,10 @@ bool localFile::Read(uint8_t *data, uint16_t *size)
 	*size = actual; // always save the actual
 
 	if (actual != requested) {
-		//DEBUG_LOG_MSG("FS: Only read %u of %u requested bytes from file %s",
-		//              actual,
-		//              requested,
-		//              name.c_str());
+		// LOG_DEBUG("FS: Only read %u of %u requested bytes from file '%s'",
+		//           actual,
+		//           requested,
+		//           name.c_str());
 
 		// Check for host read error
 		if (ferror(fhandle)) {
@@ -712,14 +714,15 @@ bool localFile::Write(uint8_t *data, uint16_t *size)
 	if (*size == 0) {
 		const auto file = cross_fileno(fhandle);
 		if (file == -1) {
-			DEBUG_LOG_MSG("FS: Could not resolve file number for %s", name.c_str());
+			LOG_DEBUG("FS: Could not resolve file number for '%s'",
+			          name.c_str());
 			return false;
 		}
 		if (!ftell_and_check()) {
 			return false;
 		}
 		if (ftruncate(file, stream_pos) != 0) {
-			DEBUG_LOG_MSG("FS: Failed truncating file %s", name.c_str());
+			LOG_DEBUG("FS: Failed truncating file '%s'", name.c_str());
 			return false;
 		}
 		// Truncation succeeded if we made it here
@@ -730,8 +733,10 @@ bool localFile::Write(uint8_t *data, uint16_t *size)
 	const auto requested = *size;
 	const auto actual = static_cast<uint16_t>(fwrite(data, 1, requested, fhandle));
 	if (actual != requested) {
-		DEBUG_LOG_MSG("FS: Only wrote %u of %u requested bytes to file %s",
-		              actual, requested, name.c_str());
+		LOG_DEBUG("FS: Only wrote %u of %u requested bytes to file '%s'",
+		          actual,
+		          requested,
+		          name.c_str());
 
 		// Check for host write error
 		if (ferror(fhandle)) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -376,7 +376,10 @@ public:
 			return "abnt1"; // called "ABNT_C1" at kbdlayout.info
 		}
 
-		DEBUG_LOG_MSG("MAPPER: Please report unnamed SDL scancode %d (%xh)", key, key);
+		LOG_DEBUG("MAPPER: Please report unnamed SDL scancode %d (%xh)",
+		          key,
+		          key);
+
 		return sdl_scancode_name;
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -564,7 +564,7 @@ void GFX_RequestExit(const bool pressed)
 {
 	shutdown_requested = pressed;
 	if (shutdown_requested) {
-		DEBUG_LOG_MSG("SDL: Exit requested");
+		LOG_DEBUG("SDL: Exit requested");
 	}
 }
 
@@ -3793,14 +3793,14 @@ bool GFX_Events()
 		case SDL_WINDOWEVENT:
 			switch (event.window.event) {
 			case SDL_WINDOWEVENT_RESTORED:
-				// DEBUG_LOG_MSG("SDL: Window has been restored");
+				// LOG_DEBUG("SDL: Window has been restored");
 				/* We may need to re-create a texture
 				 * and more on Android. Another case:
 				 * Update surface while using X11.
 				 */
 				GFX_ResetScreen();
 #if C_OPENGL && defined(MACOSX)
-				// DEBUG_LOG_MSG("SDL: Reset macOS's GL viewport
+				// LOG_DEBUG("SDL: Reset macOS's GL viewport
 				// after window-restore");
 				if (sdl.desktop.type == SCREEN_OPENGL) {
 					glViewport(sdl.clip.x,
@@ -3813,7 +3813,7 @@ bool GFX_Events()
 				continue;
 
 			case SDL_WINDOWEVENT_RESIZED:
-				// DEBUG_LOG_MSG("SDL: Window has been resized to %dx%d",
+				// LOG_DEBUG("SDL: Window has been resized to %dx%d",
 				//               event.window.data1,
 				//               event.window.data2);
 				//
@@ -3830,7 +3830,7 @@ bool GFX_Events()
 				ApplyActiveSettings();
 				[[fallthrough]];
 			case SDL_WINDOWEVENT_EXPOSED:
-				// DEBUG_LOG_MSG("SDL: Window has been exposed "
+				// LOG_DEBUG("SDL: Window has been exposed "
 				//               "and should be redrawn");
 
 				/* TODO: below is not consistently true :(
@@ -3844,7 +3844,7 @@ bool GFX_Events()
 				 * FOCUS_GAINED event to catch window startup
 				 * and size toggles.
 				 */
-				// DEBUG_LOG_MSG("SDL: Window has gained
+				// LOG_DEBUG("SDL: Window has gained
 				// keyboard focus");
 				if (sdl.draw.callback)
 					sdl.draw.callback(GFX_CallBackRedraw);
@@ -3852,7 +3852,7 @@ bool GFX_Events()
 				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_LOST:
-				// DEBUG_LOG_MSG("SDL: Window has lost keyboard focus");
+				// LOG_DEBUG("SDL: Window has lost keyboard focus");
 #ifdef WIN32
 				if (sdl.desktop.fullscreen) {
 					VGA_KillDrawing();
@@ -3865,25 +3865,25 @@ bool GFX_Events()
 				break;
 
 			case SDL_WINDOWEVENT_ENTER:
-				// DEBUG_LOG_MSG("SDL: Window has gained mouse focus");
+				// LOG_DEBUG("SDL: Window has gained mouse focus");
 				continue;
 
 			case SDL_WINDOWEVENT_LEAVE:
-				// DEBUG_LOG_MSG("SDL: Window has lost mouse focus");
+				// LOG_DEBUG("SDL: Window has lost mouse focus");
 				continue;
 
 			case SDL_WINDOWEVENT_SHOWN:
-				// DEBUG_LOG_MSG("SDL: Window has been shown");
+				// LOG_DEBUG("SDL: Window has been shown");
 				maybe_auto_switch_shader();
 				continue;
 
 			case SDL_WINDOWEVENT_HIDDEN:
-				// DEBUG_LOG_MSG("SDL: Window has been hidden");
+				// LOG_DEBUG("SDL: Window has been hidden");
 				continue;
 
 #if C_OPENGL && defined(MACOSX)
 			case SDL_WINDOWEVENT_MOVED:
-				// DEBUG_LOG_MSG("SDL: Window has been moved to %d, %d",
+				// LOG_DEBUG("SDL: Window has been moved to %d, %d",
 				//               event.window.data1,
 				//               event.window.data2);
 				if (sdl.desktop.type == SCREEN_OPENGL) {
@@ -3933,7 +3933,7 @@ bool GFX_Events()
 #endif
 
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
-				// DEBUG_LOG_MSG("SDL: The window size has changed");
+				// LOG_DEBUG("SDL: The window size has changed");
 
 				// The window size has changed either as a
 				// result of an API call or through the system
@@ -3944,16 +3944,16 @@ bool GFX_Events()
 				continue;
 
 			case SDL_WINDOWEVENT_MINIMIZED:
-				// DEBUG_LOG_MSG("SDL: Window has been minimized");
+				// LOG_DEBUG("SDL: Window has been minimized");
 				ApplyInactiveSettings();
 				break;
 
 			case SDL_WINDOWEVENT_MAXIMIZED:
-				// DEBUG_LOG_MSG("SDL: Window has been maximized");
+				// LOG_DEBUG("SDL: Window has been maximized");
 				continue;
 
 			case SDL_WINDOWEVENT_CLOSE:
-				// DEBUG_LOG_MSG("SDL: The window manager "
+				// LOG_DEBUG("SDL: The window manager "
 				//               "requests that the window be "
 				//               "closed");
 				GFX_RequestExit(true);
@@ -3965,7 +3965,7 @@ bool GFX_Events()
 				continue;
 
 			case SDL_WINDOWEVENT_HIT_TEST:
-				// DEBUG_LOG_MSG("SDL: Window had a hit test that "
+				// LOG_DEBUG("SDL: Window had a hit test that "
 				//               "wasn't SDL_HITTEST_NORMAL");
 				continue;
 

--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -57,9 +57,9 @@ void SurroundProcessor::ControlWrite(const uint8_t val)
 
 	// Change register data at the falling edge of 'a0' word clock
 	if (control_state.a0 && !reg.a0) {
-		//		DEBUG_LOG_MSG("ADLIBGOLD: Surround: Write
-		// control register %d, data: %d",
-		// control_state.addr, control_state.data);
+		// LOG_DEBUG("ADLIBGOLD: Surround: Write control register %d, data: %d",
+		//           control_state.addr,
+		//           control_state.data);
 
 		YM7128B_ChipIdeal_Write(&chip, control_state.addr, control_state.data);
 	} else {
@@ -179,17 +179,19 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 	case StereoProcessorControlReg::VolumeLeft: {
 		const auto value = data & volume_control_mask;
 		gain.left        = calc_volume_gain(value);
-		DEBUG_LOG_MSG("ADLIBGOLD: Stereo: Final left volume set to %.2fdB (value %d)",
-		              gain.left,
-		              value);
+
+		LOG_DEBUG("ADLIBGOLD: Stereo: Final left volume set to %.2fdB (value %d)",
+		          gain.left,
+		          value);
 	} break;
 
 	case StereoProcessorControlReg::VolumeRight: {
 		const auto value = data & volume_control_mask;
 		gain.right       = calc_volume_gain(value);
-		DEBUG_LOG_MSG("ADLIBGOLD: Stereo: Final right volume set to %.2fdB (value %d)",
-		              gain.right,
-		              value);
+
+		LOG_DEBUG("ADLIBGOLD: Stereo: Final right volume set to %.2fdB (value %d)",
+		          gain.right,
+		          value);
 	} break;
 
 	case StereoProcessorControlReg::Bass: {
@@ -197,9 +199,9 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		const auto gain_db = calc_filter_gain_db(value);
 		SetLowShelfGain(gain_db);
 
-		DEBUG_LOG_MSG("ADLIBGOLD: Stereo: Bass gain set to %.2fdB (value %d)",
-		              gain_db,
-		              value);
+		LOG_DEBUG("ADLIBGOLD: Stereo: Bass gain set to %.2fdB (value %d)",
+		          gain_db,
+		          value);
 	} break;
 
 	case StereoProcessorControlReg::Treble: {
@@ -210,9 +212,9 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		const auto gain_db = calc_filter_gain_db(value + extra_treble);
 		SetHighShelfGain(gain_db);
 
-		DEBUG_LOG_MSG("ADLIBGOLD: Stereo: Treble gain set to %.2fdB (value %d)",
-		              gain_db,
-		              value);
+		LOG_DEBUG("ADLIBGOLD: Stereo: Treble gain set to %.2fdB (value %d)",
+		          gain_db,
+		          value);
 	} break;
 
 	case StereoProcessorControlReg::SwitchFunctions: {
@@ -223,9 +225,9 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		stereo_mode = StereoProcessorStereoMode(
 		        static_cast<uint8_t>(sf.stereo_mode));
 
-		DEBUG_LOG_MSG("ADLIBGOLD: Stereo: Source selector set to %d, stereo mode set to %d",
-		              static_cast<int>(source_selector),
-		              static_cast<int>(stereo_mode));
+		LOG_DEBUG("ADLIBGOLD: Stereo: Source selector set to %d, stereo mode set to %d",
+		          static_cast<int>(source_selector),
+		          static_cast<int>(stereo_mode));
 	} break;
 	}
 }

--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -25,6 +25,8 @@
 
 CHECK_NARROWING();
 
+//#define DEBUG_ADLIB_GOLD
+
 // Yamaha YM7128B Surround Processor emulation
 // -------------------------------------------
 
@@ -57,9 +59,11 @@ void SurroundProcessor::ControlWrite(const uint8_t val)
 
 	// Change register data at the falling edge of 'a0' word clock
 	if (control_state.a0 && !reg.a0) {
-		// LOG_DEBUG("ADLIBGOLD: Surround: Write control register %d, data: %d",
-		//           control_state.addr,
-		//           control_state.data);
+#ifdef DEBUG_ADLIB_GOLD
+		LOG_DEBUG("ADLIBGOLD: Surround: Write control register %d, data: %d",
+		          control_state.addr,
+		          control_state.data);
+#endif
 
 		YM7128B_ChipIdeal_Write(&chip, control_state.addr, control_state.data);
 	} else {
@@ -180,18 +184,22 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		const auto value = data & volume_control_mask;
 		gain.left        = calc_volume_gain(value);
 
+#ifdef DEBUG_ADLIB_GOLD
 		LOG_DEBUG("ADLIBGOLD: Stereo: Final left volume set to %.2fdB (value %d)",
 		          gain.left,
 		          value);
+#endif
 	} break;
 
 	case StereoProcessorControlReg::VolumeRight: {
 		const auto value = data & volume_control_mask;
 		gain.right       = calc_volume_gain(value);
 
+#ifdef DEBUG_ADLIB_GOLD
 		LOG_DEBUG("ADLIBGOLD: Stereo: Final right volume set to %.2fdB (value %d)",
 		          gain.right,
 		          value);
+#endif
 	} break;
 
 	case StereoProcessorControlReg::Bass: {
@@ -199,9 +207,11 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		const auto gain_db = calc_filter_gain_db(value);
 		SetLowShelfGain(gain_db);
 
+#ifdef DEBUG_ADLIB_GOLD
 		LOG_DEBUG("ADLIBGOLD: Stereo: Bass gain set to %.2fdB (value %d)",
 		          gain_db,
 		          value);
+#endif
 	} break;
 
 	case StereoProcessorControlReg::Treble: {
@@ -212,9 +222,11 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		const auto gain_db = calc_filter_gain_db(value + extra_treble);
 		SetHighShelfGain(gain_db);
 
+#ifdef DEBUG_ADLIB_GOLD
 		LOG_DEBUG("ADLIBGOLD: Stereo: Treble gain set to %.2fdB (value %d)",
 		          gain_db,
 		          value);
+#endif
 	} break;
 
 	case StereoProcessorControlReg::SwitchFunctions: {
@@ -225,9 +237,11 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 		stereo_mode = StereoProcessorStereoMode(
 		        static_cast<uint8_t>(sf.stereo_mode));
 
+#ifdef DEBUG_ADLIB_GOLD
 		LOG_DEBUG("ADLIBGOLD: Stereo: Source selector set to %d, stereo mode set to %d",
 		          static_cast<int>(source_selector),
 		          static_cast<int>(stereo_mode));
+#endif
 	} break;
 	}
 }

--- a/src/hardware/envelope.cpp
+++ b/src/hardware/envelope.cpp
@@ -60,12 +60,12 @@ void Envelope::Update(const int frame_rate, const int peak_amplitude,
 	edge_increment = static_cast<float>(ceil_sdivide(peak_amplitude, expansion_phase_frames));
 
 #if 0
-	DEBUG_LOG_MSG("ENVELOPE: %s grows by %-3f to %-5f across %-3u frames (%u ms)",
-	              channel_name.c_str(),
-	              edge_increment,
-	              edge_limit,
-	              expansion_phase_frames,
-	              expansion_phase_ms);
+	LOG_DEBUG("ENVELOPE: %s grows by %-3f to %-5f across %-3u frames (%u ms)",
+	          channel_name.c_str(),
+	          edge_increment,
+	          edge_limit,
+	          expansion_phase_frames,
+	          expansion_phase_ms);
 #endif
 }
 
@@ -102,10 +102,10 @@ void Envelope::Apply(const bool is_stereo, AudioFrame &frame)
 	if (++frames_done > expire_after_frames || edge >= edge_limit) {
 		process = &Envelope::Skip;
 		(void)channel_name; // [[maybe_unused]] in release builds
-		DEBUG_LOG_MSG("ENVELOPE: %s done after %u frames, peak sample was %.4f",
-		              channel_name.c_str(),
-		              frames_done,
-		              edge);
+		LOG_DEBUG("ENVELOPE: %s done after %u frames, peak sample was %.4f",
+		          channel_name.c_str(),
+		          frames_done,
+		          edge);
 	}
 }
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1053,9 +1053,11 @@ void Gus::PopulatePanScalars() noexcept
 		pan_scalar->right = static_cast<float>(sin(angle));
 		++pan_scalar;
 		++i;
-		// DEBUG_LOG_MSG("GUS: pan_scalar[%u] = %f | %f", i,
-		//               pan_scalar->left,
-		//               pan_scalar->right);
+
+		// LOG_DEBUG("GUS: pan_scalar[%u] = %f | %f",
+		//          i,
+		//          pan_scalar->left,
+		//          pan_scalar->right);
 	}
 }
 

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -389,16 +389,18 @@ public:
 		for (uint8_t i = 0; i < io_widths; ++i) {
 			const auto readers = io_read_handlers[i].size();
 			const auto writers = io_write_handlers[i].size();
-			DEBUG_LOG_MSG("IOBUS: Releasing %d read and %d write %d-bit port handlers",
-			              static_cast<int>(readers), static_cast<int>(writers), 8 << i);
+			LOG_DEBUG("IOBUS: Releasing %d read and %d write %d-bit port handlers",
+			          static_cast<int>(readers),
+			          static_cast<int>(writers),
+			          8 << i);
 
 			total_bytes += readers * sizeof(io_read_f) + sizeof(io_read_handlers[i]);
 			total_bytes += writers * sizeof(io_write_f) + sizeof(io_write_handlers[i]);
 			io_read_handlers[i].clear();
 			io_write_handlers[i].clear();
 		}
-		DEBUG_LOG_MSG("IOBUS: Handlers consumed %d total bytes",
-		              static_cast<int>(total_bytes));
+		LOG_DEBUG("IOBUS: Handlers consumed %d total bytes",
+		          static_cast<int>(total_bytes));
 	}
 };
 

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -538,8 +538,7 @@ static void pingAck(IPaddress retAddr) {
 	const int result = SDLNet_UDP_Send(ipxClientSocket, regPacket.channel,
 	                                   &regPacket);
 	if (!result) {
-		DEBUG_LOG_MSG("IPX: Failed to acknowledge send: %s",
-		              SDLNet_GetError());
+		LOG_DEBUG("IPX: Failed to acknowledge send: %s", SDLNet_GetError());
 	}
 }
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -73,6 +73,8 @@
 
 CHECK_NARROWING();
 
+//#define DEBUG_MIXER
+
 constexpr auto MixerFrameSize = 4;
 
 constexpr auto FreqShift = 14;
@@ -752,8 +754,10 @@ void MixerChannel::ConfigureResampler()
 		do_resample = (channel_rate != mixer_rate);
 		if (do_resample) {
 			InitLerpUpsamplerState();
+#ifdef DEBUG_MIXER
 			LOG_DEBUG("%s: Linear interpolation resampler is on",
 			          name.c_str());
+#endif
 		}
 		break;
 
@@ -761,9 +765,11 @@ void MixerChannel::ConfigureResampler()
 		do_zoh_upsample = (channel_rate < zoh_upsampler.target_freq);
 		if (do_zoh_upsample) {
 			InitZohUpsamplerState();
+#ifdef DEBUG_MIXER
 			LOG_DEBUG("%s: Zero-order-hold upsampler is on, target rate: %d Hz ",
 			          name.c_str(),
 			          zoh_upsampler.target_freq);
+#endif
 		}
 		[[fallthrough]];
 
@@ -788,10 +794,12 @@ void MixerChannel::ConfigureResampler()
 		}
 		speex_resampler_set_rate(speex_resampler.state, in_rate, out_rate);
 
+#ifdef DEBUG_MIXER
 		LOG_DEBUG("%s: Speex resampler is on, input rate: %d Hz, output rate: %d Hz)",
 		          name.c_str(),
 		          in_rate,
 		          out_rate);
+#endif
 		break;
 	}
 }
@@ -818,9 +826,11 @@ void MixerChannel::ClearResampler()
 			speex_resampler_reset_mem(speex_resampler.state);
 			speex_resampler_skip_zeros(speex_resampler.state);
 
+#ifdef DEBUG_MIXER
 			LOG_DEBUG("%s: Speex resampler cleared and primed %d-frame input queue",
 			          name.c_str(),
 			          speex_resampler_get_input_latency(speex_resampler.state));
+#endif
 		}
 		break;
 	}
@@ -838,10 +848,12 @@ void MixerChannel::SetSampleRate(const uint16_t rate)
 		return;
 	}
 
+#ifdef DEBUG_MIXER
 	LOG_DEBUG("%s: Changing rate from %d to %d Hz",
 	          name.c_str(),
 	          sample_rate,
 	          target_rate);
+#endif
 
 	sample_rate = target_rate;
 
@@ -1191,7 +1203,9 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	do_crossfeed = (HasFeature(ChannelFeature::Stereo) && strength > 0.0f);
 
 	if (!do_crossfeed) {
+#ifdef DEBUG_MIXER
 		LOG_DEBUG("%s: Crossfeed is off", name.c_str());
+#endif
 		crossfeed.strength = 0.0f;
 		return;
 	}
@@ -1204,9 +1218,11 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	crossfeed.pan_left    = center - p;
 	crossfeed.pan_right   = center + p;
 
+#ifdef DEBUG_MIXER
 	LOG_DEBUG("%s: Crossfeed is on (strength: %.3f)",
 	          name.c_str(),
 	          static_cast<double>(crossfeed.strength));
+#endif
 }
 
 float MixerChannel::GetCrossfeedStrength()
@@ -1227,7 +1243,9 @@ void MixerChannel::SetReverbLevel(const float level)
 	do_reverb_send = (HasFeature(ChannelFeature::ReverbSend) && level > level_min);
 
 	if (!do_reverb_send) {
+#ifdef DEBUG_MIXER
 		LOG_DEBUG("%s: Reverb send is off", name.c_str());
+#endif
 		reverb.level     = level_min;
 		reverb.send_gain = level_min_db;
 		return;
@@ -1239,11 +1257,13 @@ void MixerChannel::SetReverbLevel(const float level)
 
 	reverb.send_gain = static_cast<float>(decibel_to_gain(level_db));
 
+#ifdef DEBUG_MIXER
 	LOG_DEBUG("%s: SetReverbLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
 	          name.c_str(),
 	          level,
 	          level_db,
 	          reverb.send_gain);
+#endif
 }
 
 float MixerChannel::GetReverbLevel()
@@ -1264,7 +1284,9 @@ void MixerChannel::SetChorusLevel(const float level)
 	do_chorus_send = (HasFeature(ChannelFeature::ChorusSend) && level > level_min);
 
 	if (!do_chorus_send) {
+#ifdef DEBUG_MIXER
 		LOG_DEBUG("%s: Chorus send is off", name.c_str());
+#endif
 		chorus.level     = level_min;
 		chorus.send_gain = level_min_db;
 		return;
@@ -1276,11 +1298,13 @@ void MixerChannel::SetChorusLevel(const float level)
 
 	chorus.send_gain = static_cast<float>(decibel_to_gain(level_db));
 
+#ifdef DEBUG_MIXER
 	LOG_DEBUG("%s: SetChorusLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
 	          name.c_str(),
 	          level,
 	          level_db,
 	          chorus.send_gain);
+#endif
 }
 
 float MixerChannel::GetChorusLevel()
@@ -1620,6 +1644,7 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type* data)
 
 				s.pos += s.step;
 
+#ifdef DEBUG_MIXER
 				LOG_DEBUG("%s: AddSamples last %.1f:%.1f curr %.1f:%.1f"
 				          " -> out %.1f:%.1f, pos=%.2f, step=%.2f",
 				          name.c_str(),
@@ -1631,6 +1656,7 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type* data)
 				          out_right,
 				          s.pos,
 				          s.step);
+#endif
 
 				if (s.pos > 1.0f) {
 					s.pos -= 1.0f;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -752,8 +752,8 @@ void MixerChannel::ConfigureResampler()
 		do_resample = (channel_rate != mixer_rate);
 		if (do_resample) {
 			InitLerpUpsamplerState();
-			// LOG_DEBUG("%s: Linear interpolation resampler is on",
-			//           name.c_str());
+			LOG_DEBUG("%s: Linear interpolation resampler is on",
+			          name.c_str());
 		}
 		break;
 
@@ -761,9 +761,9 @@ void MixerChannel::ConfigureResampler()
 		do_zoh_upsample = (channel_rate < zoh_upsampler.target_freq);
 		if (do_zoh_upsample) {
 			InitZohUpsamplerState();
-			// LOG_DEBUG("%s: Zero-order-hold upsampler is on, target rate: %d Hz ",
-			//           name.c_str(),
-			//           zoh_upsampler.target_freq);
+			LOG_DEBUG("%s: Zero-order-hold upsampler is on, target rate: %d Hz ",
+			          name.c_str(),
+			          zoh_upsampler.target_freq);
 		}
 		[[fallthrough]];
 
@@ -788,10 +788,10 @@ void MixerChannel::ConfigureResampler()
 		}
 		speex_resampler_set_rate(speex_resampler.state, in_rate, out_rate);
 
-		// LOG_DEBUG("%s: Speex resampler is on, input rate: %d Hz, output rate: %d Hz)",
-		//           name.c_str(),
-		//           in_rate,
-		//           out_rate);
+		LOG_DEBUG("%s: Speex resampler is on, input rate: %d Hz, output rate: %d Hz)",
+		          name.c_str(),
+		          in_rate,
+		          out_rate);
 		break;
 	}
 }
@@ -818,10 +818,9 @@ void MixerChannel::ClearResampler()
 			speex_resampler_reset_mem(speex_resampler.state);
 			speex_resampler_skip_zeros(speex_resampler.state);
 
-			// LOG_DEBUG("%s: Speex resampler cleared and primed %d-frame input queue",
-			//           name.c_str(),
-			//           speex_resampler_get_input_latency(
-			//           speex_resampler.state));
+			LOG_DEBUG("%s: Speex resampler cleared and primed %d-frame input queue",
+			          name.c_str(),
+			          speex_resampler_get_input_latency(speex_resampler.state));
 		}
 		break;
 	}
@@ -839,10 +838,11 @@ void MixerChannel::SetSampleRate(const uint16_t rate)
 		return;
 	}
 
-	// LOG_DEBUG("%s: Changing rate from %d to %d Hz",
-	//           name.c_str(),
-	//           sample_rate,
-	//           target_rate);
+	LOG_DEBUG("%s: Changing rate from %d to %d Hz",
+	          name.c_str(),
+	          sample_rate,
+	          target_rate);
+
 	sample_rate = target_rate;
 
 	freq_add = (sample_rate << FreqShift) / mixer.sample_rate;
@@ -1191,7 +1191,7 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	do_crossfeed = (HasFeature(ChannelFeature::Stereo) && strength > 0.0f);
 
 	if (!do_crossfeed) {
-		// LOG_DEBUG("%s: Crossfeed is off", name.c_str());
+		LOG_DEBUG("%s: Crossfeed is off", name.c_str());
 		crossfeed.strength = 0.0f;
 		return;
 	}
@@ -1204,9 +1204,9 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	crossfeed.pan_left    = center - p;
 	crossfeed.pan_right   = center + p;
 
-	// LOG_DEBUG("%s: Crossfeed is on (strength: %.3f)",
-	//           name.c_str(),
-	//           static_cast<double>(crossfeed.strength));
+	LOG_DEBUG("%s: Crossfeed is on (strength: %.3f)",
+	          name.c_str(),
+	          static_cast<double>(crossfeed.strength));
 }
 
 float MixerChannel::GetCrossfeedStrength()
@@ -1227,7 +1227,7 @@ void MixerChannel::SetReverbLevel(const float level)
 	do_reverb_send = (HasFeature(ChannelFeature::ReverbSend) && level > level_min);
 
 	if (!do_reverb_send) {
-		// LOG_DEBUG("%s: Reverb send is off", name.c_str());
+		LOG_DEBUG("%s: Reverb send is off", name.c_str());
 		reverb.level     = level_min;
 		reverb.send_gain = level_min_db;
 		return;
@@ -1239,11 +1239,11 @@ void MixerChannel::SetReverbLevel(const float level)
 
 	reverb.send_gain = static_cast<float>(decibel_to_gain(level_db));
 
-	// LOG_DEBUG("%s: SetReverbLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
-	//           name.c_str(),
-	//           level,
-	//           level_db,
-	//           reverb.send_gain);
+	LOG_DEBUG("%s: SetReverbLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
+	          name.c_str(),
+	          level,
+	          level_db,
+	          reverb.send_gain);
 }
 
 float MixerChannel::GetReverbLevel()
@@ -1264,7 +1264,7 @@ void MixerChannel::SetChorusLevel(const float level)
 	do_chorus_send = (HasFeature(ChannelFeature::ChorusSend) && level > level_min);
 
 	if (!do_chorus_send) {
-		// LOG_DEBUG("%s: Chorus send is off", name.c_str());
+		LOG_DEBUG("%s: Chorus send is off", name.c_str());
 		chorus.level     = level_min;
 		chorus.send_gain = level_min_db;
 		return;
@@ -1276,11 +1276,11 @@ void MixerChannel::SetChorusLevel(const float level)
 
 	chorus.send_gain = static_cast<float>(decibel_to_gain(level_db));
 
-	// LOG_DEBUG("%s: SetChorusLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
-	//           name.c_str(),
-	//           level,
-	//           level_db,
-	//           chorus.send_gain);
+	LOG_DEBUG("%s: SetChorusLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
+	          name.c_str(),
+	          level,
+	          level_db,
+	          chorus.send_gain);
 }
 
 float MixerChannel::GetChorusLevel()
@@ -1620,17 +1620,17 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type* data)
 
 				s.pos += s.step;
 
-				// LOG_DEBUG("%s: AddSamples last %.1f:%.1f curr %.1f:%.1f"
-				//           " -> out %.1f:%.1f, pos=%.2f, step=%.2f",
-				//           name.c_str(),
-				//           s.last_frame.left,
-				//           s.last_frame.right,
-				//           curr_frame.left,
-				//           curr_frame.right,
-				//           out_left,
-				//           out_right,
-				//           s.pos,
-				//           s.step);
+				LOG_DEBUG("%s: AddSamples last %.1f:%.1f curr %.1f:%.1f"
+				          " -> out %.1f:%.1f, pos=%.2f, step=%.2f",
+				          name.c_str(),
+				          s.last_frame.left,
+				          s.last_frame.right,
+				          curr_frame.left,
+				          curr_frame.right,
+				          out_left,
+				          out_right,
+				          s.pos,
+				          s.step);
 
 				if (s.pos > 1.0f) {
 					s.pos -= 1.0f;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -752,9 +752,8 @@ void MixerChannel::ConfigureResampler()
 		do_resample = (channel_rate != mixer_rate);
 		if (do_resample) {
 			InitLerpUpsamplerState();
-			// DEBUG_LOG_MSG("%s: Linear interpolation resampler is
-			// on",
-			//               name.c_str());
+			// LOG_DEBUG("%s: Linear interpolation resampler is on",
+			//           name.c_str());
 		}
 		break;
 
@@ -762,10 +761,9 @@ void MixerChannel::ConfigureResampler()
 		do_zoh_upsample = (channel_rate < zoh_upsampler.target_freq);
 		if (do_zoh_upsample) {
 			InitZohUpsamplerState();
-			// DEBUG_LOG_MSG("%s: Zero-order-hold upsampler is on,
-			// target rate: %d Hz ",
-			//               name.c_str(),
-			//               zoh_upsampler.target_freq);
+			// LOG_DEBUG("%s: Zero-order-hold upsampler is on, target rate: %d Hz ",
+			//           name.c_str(),
+			//           zoh_upsampler.target_freq);
 		}
 		[[fallthrough]];
 
@@ -790,11 +788,10 @@ void MixerChannel::ConfigureResampler()
 		}
 		speex_resampler_set_rate(speex_resampler.state, in_rate, out_rate);
 
-		// DEBUG_LOG_MSG("%s: Speex resampler is on, input rate: %d Hz,
-		// output rate: %d Hz)",
-		//               name.c_str(),
-		//               in_rate,
-		//               out_rate);
+		// LOG_DEBUG("%s: Speex resampler is on, input rate: %d Hz, output rate: %d Hz)",
+		//           name.c_str(),
+		//           in_rate,
+		//           out_rate);
 		break;
 	}
 }
@@ -821,11 +818,10 @@ void MixerChannel::ClearResampler()
 			speex_resampler_reset_mem(speex_resampler.state);
 			speex_resampler_skip_zeros(speex_resampler.state);
 
-			// DEBUG_LOG_MSG("%s: Speex resampler cleared and primed
-			// %d-frame input queue",
-			//               name.c_str(),
-			//               speex_resampler_get_input_latency(
-			//                       speex_resampler.state));
+			// LOG_DEBUG("%s: Speex resampler cleared and primed %d-frame input queue",
+			//           name.c_str(),
+			//           speex_resampler_get_input_latency(
+			//           speex_resampler.state));
 		}
 		break;
 	}
@@ -843,10 +839,10 @@ void MixerChannel::SetSampleRate(const uint16_t rate)
 		return;
 	}
 
-	// DEBUG_LOG_MSG("%s: Changing rate from %d to %d Hz",
-	//              name.c_str(),
-	//              sample_rate,
-	//              target_rate);
+	// LOG_DEBUG("%s: Changing rate from %d to %d Hz",
+	//           name.c_str(),
+	//           sample_rate,
+	//           target_rate);
 	sample_rate = target_rate;
 
 	freq_add = (sample_rate << FreqShift) / mixer.sample_rate;
@@ -1195,7 +1191,7 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	do_crossfeed = (HasFeature(ChannelFeature::Stereo) && strength > 0.0f);
 
 	if (!do_crossfeed) {
-		// DEBUG_LOG_MSG("%s: Crossfeed is off", name.c_str());
+		// LOG_DEBUG("%s: Crossfeed is off", name.c_str());
 		crossfeed.strength = 0.0f;
 		return;
 	}
@@ -1208,9 +1204,9 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 	crossfeed.pan_left    = center - p;
 	crossfeed.pan_right   = center + p;
 
-	// DEBUG_LOG_MSG("%s: Crossfeed is on (strength: %.3f)",
-	//               name.c_str(),
-	//               static_cast<double>(crossfeed.strength));
+	// LOG_DEBUG("%s: Crossfeed is on (strength: %.3f)",
+	//           name.c_str(),
+	//           static_cast<double>(crossfeed.strength));
 }
 
 float MixerChannel::GetCrossfeedStrength()
@@ -1231,7 +1227,7 @@ void MixerChannel::SetReverbLevel(const float level)
 	do_reverb_send = (HasFeature(ChannelFeature::ReverbSend) && level > level_min);
 
 	if (!do_reverb_send) {
-		// DEBUG_LOG_MSG("%s: Reverb send is off", name.c_str());
+		// LOG_DEBUG("%s: Reverb send is off", name.c_str());
 		reverb.level     = level_min;
 		reverb.send_gain = level_min_db;
 		return;
@@ -1243,12 +1239,11 @@ void MixerChannel::SetReverbLevel(const float level)
 
 	reverb.send_gain = static_cast<float>(decibel_to_gain(level_db));
 
-	// DEBUG_LOG_MSG("%s: SetReverbLevel: level: %4.2f, level_db: %6.2f,
-	// gain: %4.2f",
-	//               name.c_str(),
-	//               level,
-	//               level_db,
-	//               reverb.send_gain);
+	// LOG_DEBUG("%s: SetReverbLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
+	//           name.c_str(),
+	//           level,
+	//           level_db,
+	//           reverb.send_gain);
 }
 
 float MixerChannel::GetReverbLevel()
@@ -1269,7 +1264,7 @@ void MixerChannel::SetChorusLevel(const float level)
 	do_chorus_send = (HasFeature(ChannelFeature::ChorusSend) && level > level_min);
 
 	if (!do_chorus_send) {
-		// DEBUG_LOG_MSG("%s: Chorus send is off", name.c_str());
+		// LOG_DEBUG("%s: Chorus send is off", name.c_str());
 		chorus.level     = level_min;
 		chorus.send_gain = level_min_db;
 		return;
@@ -1281,12 +1276,11 @@ void MixerChannel::SetChorusLevel(const float level)
 
 	chorus.send_gain = static_cast<float>(decibel_to_gain(level_db));
 
-	// DEBUG_LOG_MSG("%s: SetChorusLevel: level: %4.2f, level_db: %6.2f,
-	// gain: %4.2f",
-	//               name.c_str(),
-	//               level,
-	//               level_db,
-	//               chorus.send_gain);
+	// LOG_DEBUG("%s: SetChorusLevel: level: %4.2f, level_db: %6.2f, gain: %4.2f",
+	//           name.c_str(),
+	//           level,
+	//           level_db,
+	//           chorus.send_gain);
 }
 
 float MixerChannel::GetChorusLevel()
@@ -1626,18 +1620,17 @@ void MixerChannel::AddSamples(const uint16_t frames, const Type* data)
 
 				s.pos += s.step;
 
-				// DEBUG_LOG_MSG("%s: AddSamples last %.1f:%.1f
-				// curr %.1f:%.1f"
-				//               " -> out %.1f:%.1f, pos=%.2f,
-				//               step=%.2f", name.c_str(),
-				//               s.last_frame.left,
-				//               s.last_frame.right,
-				//               curr_frame.left,
-				//               curr_frame.right,
-				//               out_left,
-				//               out_right,
-				//               s.pos,
-				//               s.step);
+				// LOG_DEBUG("%s: AddSamples last %.1f:%.1f curr %.1f:%.1f"
+				//           " -> out %.1f:%.1f, pos=%.2f, step=%.2f",
+				//           name.c_str(),
+				//           s.last_frame.left,
+				//           s.last_frame.right,
+				//           curr_frame.left,
+				//           curr_frame.right,
+				//           out_left,
+				//           out_right,
+				//           s.pos,
+				//           s.step);
 
 				if (s.pos > 1.0f) {
 					s.pos -= 1.0f;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -423,7 +423,7 @@ void TandyDAC::WriteToPort(io_port_t port, io_val_t value, io_width_t)
 void TandyDAC::AudioCallback(uint16_t requested)
 {
 	if (!channel || !dma.channel) {
-		DEBUG_LOG_MSG("TANDY: Skipping update until the DAC is initialized");
+		LOG_DEBUG("TANDY: Skipping update until the DAC is initialized");
 		return;
 	}
 	const bool should_read = is_enabled && (regs.mode & 0x0c) == 0x0c &&

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -40,9 +40,7 @@
 #include "vga.h"
 #include "video.h"
 
-//#undef C_DEBUG
-//#define C_DEBUG 1
-//#define LOG(X,Y) LOG_MSG
+//#define DEBUG_VGA_DRAW
 
 typedef uint8_t * (* VGA_Line_Handler)(Bitu vidstart, Bitu line);
 
@@ -1986,12 +1984,12 @@ ImageInfo setup_drawing()
 		break;
 	}
 
-#if 0
-	LOG_MSG("VGA: vga.mode: %s", to_string(vga.mode));
-	LOG_MSG("VGA: graphics_enabled: %d, scan_doubling: %d, max_scan_line: %d",
-	        static_cast<uint8_t>(vga.attr.mode_control.is_graphics_enabled),
-	        static_cast<uint8_t>(vga.crtc.maximum_scan_line.is_scan_doubling_enabled),
-	        static_cast<uint8_t>(vga.crtc.maximum_scan_line.maximum_scan_line));
+#ifdef DEBUG_VGA_DRAW
+	LOG_DEBUG("VGA: vga.mode: %s, graphics_enabled: %d, scan_doubling: %d, max_scan_line: %d",
+	          to_string(vga.mode),
+	          static_cast<uint8_t>(vga.attr.mode_control.is_graphics_enabled),
+	          static_cast<uint8_t>(vga.crtc.maximum_scan_line.is_scan_doubling_enabled),
+	          static_cast<uint8_t>(vga.crtc.maximum_scan_line.maximum_scan_line));
 #endif
 
 	const auto bios_mode_number = CurMode->mode;
@@ -2720,46 +2718,42 @@ ImageInfo setup_drawing()
 	vga.changes.writeMask = 1;
 #endif
 
-#if 0
-	LOG_MSG("VGA: horiz.total: %d, vert.total: %d",
-	        vga_timings.horiz.total,
-	        vga_timings.vert.total);
-#endif
+#ifdef DEBUG_VGA_DRAW
+	LOG_DEBUG("VGA: horiz.total: %d, vert.total: %d",
+	          vga_timings.horiz.total,
+	          vga_timings.vert.total);
 
-#if 0
-	LOG_MSG("VGA: RENDER: width: %d, height: %d, dblw: %d, dblh: %d, PAR: %lld:%lld (1:%g)",
-	        render_width,
-	        render_height,
-	        double_width,
-	        double_height,
-	        render_pixel_aspect_ratio.Num(),
-	        render_pixel_aspect_ratio.Denom(),
-	        render_pixel_aspect_ratio.Inverse().ToDouble());
+	LOG_DEBUG("VGA: RENDER: width: %d, height: %d, dblw: %d, dblh: %d, PAR: %lld:%lld (1:%g)",
+	          render_width,
+	          render_height,
+	          double_width,
+	          double_height,
+	          render_pixel_aspect_ratio.Num(),
+	          render_pixel_aspect_ratio.Denom(),
+	          render_pixel_aspect_ratio.Inverse().ToDouble());
 
-	LOG_MSG("VGA: VIDEO_MODE: width: %d, height: %d, PAR: %lld:%lld (1:%g)",
-	        video_mode.width,
-	        video_mode.height,
-	        video_mode.pixel_aspect_ratio.Num(),
-	        video_mode.pixel_aspect_ratio.Denom(),
-	        video_mode.pixel_aspect_ratio.Inverse().ToDouble());
-#endif
+	LOG_DEBUG("VGA: VIDEO_MODE: width: %d, height: %d, PAR: %lld:%lld (1:%g)",
+	          video_mode.width,
+	          video_mode.height,
+	          video_mode.pixel_aspect_ratio.Num(),
+	          video_mode.pixel_aspect_ratio.Denom(),
+	          video_mode.pixel_aspect_ratio.Inverse().ToDouble());
 
-#if 0
-	LOG_MSG("h total %2.5f (%3.2fkHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
-	        vga.draw.delay.htotal,
-	        (1.0 / vga.draw.delay.htotal),
-	        vga.draw.delay.hblkstart,
-	        vga.draw.delay.hblkend,
-	        vga.draw.delay.hrstart,
-	        vga.draw.delay.hrend);
+	LOG_DEBUG("VGA: h total %2.5f (%3.2fkHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
+	          vga.draw.delay.htotal,
+	          (1.0 / vga.draw.delay.htotal),
+	          vga.draw.delay.hblkstart,
+	          vga.draw.delay.hblkend,
+	          vga.draw.delay.hrstart,
+	          vga.draw.delay.hrend);
 
-	LOG_MSG("v total %2.5f (%3.2fHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
-	        vga.draw.delay.vtotal,
-	        (1000.0 / vga.draw.delay.vtotal),
-	        vga.draw.delay.vblkstart,
-	        vga.draw.delay.vblkend,
-	        vga.draw.delay.vrstart,
-	        vga.draw.delay.vrend);
+	LOG_DEBUG("VGA: v total %2.5f (%3.2fHz) blank(%02.5f/%02.5f) retrace(%02.5f/%02.5f)",
+	          vga.draw.delay.vtotal,
+	          (1000.0 / vga.draw.delay.vtotal),
+	          vga.draw.delay.vblkstart,
+	          vga.draw.delay.vblkend,
+	          vga.draw.delay.vrstart,
+	          vga.draw.delay.vrend);
 #endif
 
 	ImageInfo render = {};

--- a/src/midi/midi_alsa.cpp
+++ b/src/midi/midi_alsa.cpp
@@ -266,7 +266,7 @@ bool MidiHandler_alsa::Open(const char *conf)
 	assert(conf != nullptr);
 	seq = {-1, -1};
 
-	DEBUG_LOG_MSG("MIDI:ALSA: Attempting connection to: '%s'", conf);
+	LOG_DEBUG("MIDI:ALSA: Attempting connection to: '%s'", conf);
 
 	// Try to use port specified in config; if port is not configured,
 	// then attempt to connect to the newest capable port.

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -388,7 +388,7 @@ static mt32emu_report_handler_i get_report_handler_interface()
 		{
 			char msg[1024];
 			safe_sprintf(msg, fmt, list);
-			DEBUG_LOG_MSG("MT32: %s", msg);
+			LOG_DEBUG("MT32: %s", msg);
 		}
 
 		static void onErrorControlROM(void *)

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -759,7 +759,7 @@ std::string cfstr_to_string(CFStringRef source)
 #if C_COREFOUNDATION
 	lang = get_lang_from_macos();
 	if (!lang.empty()) {
-		DEBUG_LOG_MSG("LANG: Got language '%s' from macOS locale", lang.c_str());
+		LOG_DEBUG("LANG: Got language '%s' from macOS locale", lang.c_str());
 		return lang;
 	}
 #endif
@@ -767,14 +767,14 @@ std::string cfstr_to_string(CFStringRef source)
 #if defined(WIN32)
 	lang = get_lang_from_windows();
 	if (!lang.empty()) {
-		DEBUG_LOG_MSG("LANG: Got language '%s' from Windows locale", lang.c_str());
+		LOG_DEBUG("LANG: Got language '%s' from Windows locale", lang.c_str());
 		return lang;
 	}
 #endif
 
 	lang = get_lang_from_posix();
 	if (!lang.empty()) {
-		DEBUG_LOG_MSG("LANG: Got language '%s' from POSIX locale", lang.c_str());
+		LOG_DEBUG("LANG: Got language '%s' from POSIX locale", lang.c_str());
 		return lang;
 	}
 

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -83,16 +83,19 @@ std::string to_native_path(const std::string &path) noexcept
 		return "";
 	}
 	if (err != 0) {
-		DEBUG_LOG_MSG("FS: glob error (%d) while searching for '%s'",
-		              err, path.c_str());
+		LOG_DEBUG("FS: glob error (%d) while searching for '%s'",
+		          err,
+		          path.c_str());
 		globfree(&pglob);
 		return "";
 	}
 	if (pglob.gl_pathc > 1) {
-		DEBUG_LOG_MSG("FS: Searching for path '%s' gives ambiguous results:",
-		              path.c_str());
-		for (size_t i = 0; i < pglob.gl_pathc; i++)
-			DEBUG_LOG_MSG("%s", pglob.gl_pathv[i]);
+		LOG_DEBUG("FS: Searching for path '%s' gives ambiguous results:",
+		          path.c_str());
+
+		for (size_t i = 0; i < pglob.gl_pathc; i++) {
+			LOG_DEBUG("%s", pglob.gl_pathv[i]);
+		}
 	}
 	const std::string ret = pglob.gl_pathv[0];
 	globfree(&pglob);

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -469,9 +469,9 @@ std::vector<uint8_t> LoadResourceBlob(const std_fs::path &name,
 
 	// non-const to allow movement out of the function
 	std::vector<uint8_t> buffer(std::istreambuf_iterator<char>{file}, {});
-	// DEBUG_LOG_MSG("RESOURCE: Loaded resource '%s' [%d bytes]",
-	//               resource_path.string().c_str(),
-	//               check_cast<int>(buffer.size()));
+	// LOG_DEBUG("RESOURCE: Loaded resource '%s' [%d bytes]",
+	//           resource_path.string().c_str(),
+	//           check_cast<int>(buffer.size()));
 	return buffer;
 }
 

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -86,9 +86,9 @@ std::string BatchFile::GetLine()
 		 */
 		if (data <= UnitSeparator && data != '\t' && data != '\b' &&
 		    data != Esc && data != '\n' && data != '\r') {
-			DEBUG_LOG_MSG("Encountered non-standard character: Dec %03u and Hex %#04x",
-			              data,
-			              data);
+			LOG_DEBUG("Encountered non-standard character: Dec %03u and Hex %#04x",
+			          data,
+			          data);
 		} else {
 			line += data;
 		}


### PR DESCRIPTION
When it comes to debugging, I'm very much an old-school `printf` trace logger type of person (_Who needs 'em stinkin' debuggers? Not this guy!_ 😎)

So I've been prefixing my `LOG_MSG` statements with stuff like to `>>>>>>>>` and `!!!!!!!!!` and `*******` to make them stand out from the rest, then started repurposing `LOG_ERR` and `LOG_WARNING` because the coloured output makes my debug/trace messages stand out even more.

Then today it dawned on me: I can actually make `LOG_DEBUG` output stuff in a different colour with loguru! I've also seen the light and realised that @weirddan455 was right all along—module-specific `DEBUG_MODULNAME` `ifdef`s are the way to go. So I started converting a few modules to that convention as well.

Here's how it looks in action with `mixer.cpp` and `vga_draw.cpp` debug logging enabled. As you can see, my VGA and mixer debug crap doesn't get drowned in the rest of the crap anymore. Crap stands out, loud and clear—it doesn't get better than that! 😎 🤘🏻 

...except when it does! 😆 I've also added `LOG_TRACE` for good measure which uses a nice purple colour .

<img width="1321" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/7ffedc71-3dd2-41e5-8221-f77614b86a57">
