### PR TITLE
Add docker image and CI job for ppc64le architecture

### DIFF
--- a/.github/workflows/debian-docker-build.yml
+++ b/.github/workflows/debian-docker-build.yml
@@ -7,7 +7,6 @@ on:
       - 'packages/debian-10-docker-apt.txt'
       - 'packages/debian-11-docker-apt.txt'
       - '.github/workflows/debian-docker-build.yml'
-    tags:
   pull_request:
     paths:
       - 'packages/Dockerfile*'
@@ -111,6 +110,9 @@ jobs:
             vers: 11
           - name: Debian 11 cross ARM 32
             arch: armhf
+            vers: 11
+          - name: Debian 11 cross PowerPC 64 LE
+            arch: ppc64el
             vers: 11
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -133,6 +133,16 @@ jobs:
             deb_vers: 11
             needs_min_deps: false
 
+          - name: GCC, Debian 11, ppc64le
+            os: ubuntu-20.04
+            build_flags: -Dbuildtype=debug --cross-file dosbox-cross
+            max_warnings: 0
+            run_tests: true
+            cross: true
+            arch: ppc64el
+            deb_vers: 11
+            needs_min_deps: false
+
           - name: GCC 9, minimum build
             os: ubuntu-20.04
             packages: g++-9

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -136,7 +136,7 @@ jobs:
           - name: GCC, Debian 11, ppc64le
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
-            max_warnings: 0
+            max_warnings: 21
             run_tests: true
             cross: true
             arch: ppc64el

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,16 +103,6 @@ jobs:
             deb_vers: 10
             needs_min_deps: false
 
-          - name: GCC, Debian 10, aarch64
-            os: ubuntu-20.04
-            build_flags: -Dbuildtype=debug --cross-file dosbox-cross
-            max_warnings: 21
-            run_tests: true
-            cross: true
-            arch: arm64
-            deb_vers: 10
-            needs_min_deps: false
-
           - name: GCC, Debian 11, ARMv7
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross

--- a/meson.build
+++ b/meson.build
@@ -386,7 +386,7 @@ endif
 
 # 64-bit Power ISA can run with either 4K or 64K page size.
 # (32-bit Power ISA and PowerPC are always 4K.)
-if host_machine.cpu_family() in ['ppc64', 'ppc64le']
+if host_machine.cpu_family() in ['ppc64', 'ppc64le', 'powerpc64le']
     pagesize_cmd = run_command('getconf', 'PAGESIZE', check: true)
     if pagesize_cmd.returncode() != 0
         error('''error executing getconf: unable to determine host architecture page size for ppc64 dynamic core''')

--- a/packages/Dockerfile.debian
+++ b/packages/Dockerfile.debian
@@ -27,8 +27,9 @@ RUN apt-get update &&  apt-get -y install --no-install-recommends \
 RUN pip3 install meson
 
 RUN export DPKG_TRIPLET=$(dpkg-architecture -A ${DPKG_ARCH} -q DEB_TARGET_MULTIARCH); \
+    export QEMU_TRIPLET=$(echo $DPKG_TRIPLET | sed s/powerpc/ppc/g); \
     # Fixup meson cross file for qemu-user-static and ccache
-    sed -i "2i exe_wrapper = '/usr/bin/qemu-${DPKG_TRIPLET%%-*}-static'" ${MESON_CROSS_FILE} \
+    sed -i "2i exe_wrapper = '/usr/bin/qemu-${QEMU_TRIPLET%%-*}-static'" ${MESON_CROSS_FILE} \
     && sed -i -r 's@(c|cpp) = '\'"(/usr/bin/[^']+)'@"'\1'" = ['ccache', '"'\2'"']@g" ${MESON_CROSS_FILE} \
     # Fix opusfile pkgconfig
     && sed 's@libdir=\${exec_prefix}/lib@libdir=\${prefix}/lib/'"${DPKG_TRIPLET}@g" \

--- a/packages/Dockerfile.debian-base
+++ b/packages/Dockerfile.debian-base
@@ -4,8 +4,9 @@ FROM debian:${DEB_VERS}-slim
 # Enable architectures
 RUN dpkg --add-architecture amd64 && \
     dpkg --add-architecture arm64 && \
-    dpkg --add-architecture i386 &&  \
-    dpkg --add-architecture armhf
+    dpkg --add-architecture i386  &&  \
+    dpkg --add-architecture armhf && \
+    dpkg --add-architecture ppc64el
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -14,19 +14,19 @@ conf_data.set10('C_PER_PAGE_W_OR_X', per_page_w_or_x_pref.auto() or per_page_w_o
 
 # Platform-specific
 core_selection = [
-    # cpu_family selected_core        dynrec_define    target     unaligned  per-page
-    #                                                             mem        W^X
-    [ 'x86_64',  ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64',  1,         1 ],
-    [ 'x86',     ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86',     1,         1 ],
-    [ 'x86_64',  ['dynrec'],          'C_DYNREC',      'X86_64',  1,         1 ],
-    [ 'x86',     ['dynrec'],          'C_DYNREC',      'X86',     1,         1 ],
-    [ 'aarch64', ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1,         1 ], # ARMv8+ (64-bit)
-    [ 'arm',     ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1,         1 ], # ARMv7+
-    [ 'armv6',   ['auto', 'dynrec'],  'C_DYNREC',      'ARMV4LE', 0,         0 ], # ARMv6 or older
-    [ 'ppc64',   ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors
-    [ 'ppc64le', ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors (little-endian)
-    [ 'ppc',     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         0 ], # 32 bit PPC processors (big-endian)
-    [ 'mips',    ['auto', 'dynrec'],  'C_DYNREC',      'MIPSEL',  0,         0 ], # 32 bit MIPS processor
+    # cpu_family                  selected_core        dynrec_define    target     unaligned  per-page
+    #                                                                              mem        W^X
+    [ ['x86_64'],                 ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64',  1,         1 ],
+    [ ['x86'],                    ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86',     1,         1 ],
+    [ ['x86_64'],                 ['dynrec'],          'C_DYNREC',      'X86_64',  1,         1 ],
+    [ ['x86'],                    ['dynrec'],          'C_DYNREC',      'X86',     1,         1 ],
+    [ ['aarch64'],                ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1,         1 ], # ARMv8+ (64-bit)
+    [ ['arm'],                    ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1,         1 ], # ARMv7+
+    [ ['armv6'],                  ['auto', 'dynrec'],  'C_DYNREC',      'ARMV4LE', 0,         0 ], # ARMv6 or older
+    [ ['ppc64',   'powerpc64'],   ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors
+    [ ['ppc64le', 'powerpc64le'], ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors (little-endian)
+    [ ['ppc',     'powerpc'],     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         0 ], # 32 bit PPC processors (big-endian)
+    [ ['mips'],                   ['auto', 'dynrec'],  'C_DYNREC',      'MIPSEL',  0,         0 ], # 32 bit MIPS processor
 ]
 
 selected_core = get_option('dynamic_core')
@@ -39,7 +39,7 @@ foreach line : core_selection
     unaligned_mem = line[4]
     per_page_w_or_x = line[5]
     if (
-        (host_machine.cpu_family() == cpu_family)
+        cpu_family.contains(host_machine.cpu_family())
         and opts_for_arch.contains(selected_core)
     )
         conf_data.set('C_TARGETCPU', target_cpu)


### PR DESCRIPTION
As mentioned in #2789 this PR adds a ppc64le docker image and adds it to the build matrix for linux CI.

I had to jump through a few hoops, because for some reason Debian decided to use `powerpc` instead of `ppc` everywhere. And for the cherry on top, the architecture name is `ppc64el`. No, that's not a typo.

This exposed some warnings in the ppc64le dynamic recompiler, so I've increased `max_warnings` to 21. @classilla if you are interested in fixing these, please feel free to after this PR is merged.