### PR TITLE
Cleanup new CI warnings due to host-side updates

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,7 +67,7 @@ jobs:
           BREW_DIR="$(brew --cache)"
           DISCARD_DIR="${{ github.workspace }}/discard"
           mkdir -p "$DISCARD_DIR"
-          mv -f "$BREW_DIR"/* "$DISCARD_DIR"
+          mv -f "$BREW_DIR"/* "$DISCARD_DIR" || true
           mkdir -p "$CCACHE_DIR"
           echo "brew_dir=$BREW_DIR"     >> $GITHUB_OUTPUT
           echo "ccache_dir=$CCACHE_DIR" >> $GITHUB_OUTPUT

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -86,11 +86,11 @@ jobs:
         run: |
           arch -arch=${{ matrix.conf.arch }} brew unlink openssl@1.1 || true
           rm -f /usr/local/bin/openssl || true
-          arch -arch=${{ matrix.conf.arch }} brew install --overwrite openssl@3 || \
-          arch -arch=${{ matrix.conf.arch }} brew link --overwrite openssl@3
+          arch -arch=${{ matrix.conf.arch }} brew install --overwrite openssl@3 || true
+          arch -arch=${{ matrix.conf.arch }} brew link --overwrite openssl@3 || true
           arch -arch=${{ matrix.conf.arch }} brew install --overwrite \
             ${{ matrix.conf.packages }} \
-            $(cat packages/macos-12-brew.txt)
+            $(cat packages/macos-12-brew.txt) || true
 
       - uses:  actions/cache@v3.3.1
         if:    matrix.conf.needs_deps

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -60,7 +60,7 @@ warnings.
 Once the linter is happy, it's time to raise your PR. Separate commits may
 help in some cases, but don't go overboard with them (we're not going to
 "bisect" the documentation, after all). Prefix your documentation related
-commits with `docs:` and website related commits with `website: ` , e.g.:
+commits with `docs:` and website related commits with `website:` , e.g.:
 
 ```
 docs: Fix Sound Blaster Pro 1 default settings

--- a/src/libs/sdlcd/macosx/AudioFileReaderThread.c
+++ b/src/libs/sdlcd/macosx/AudioFileReaderThread.c
@@ -343,7 +343,7 @@ void delete_FileReaderThread(FileReaderThread *frt)
     }
 }
 
-FileReaderThread *new_FileReaderThread ()
+static FileReaderThread *new_FileReaderThread (void)
 {
     FileReaderThread *frt = (FileReaderThread *) SDL_malloc(sizeof (FileReaderThread));
     if (frt == NULL)

--- a/src/libs/sdlcd/macosx/CDPlayer.c
+++ b/src/libs/sdlcd/macosx/CDPlayer.c
@@ -78,14 +78,14 @@ static SDL_CD* theCDROM                      = NULL;
 
 #pragma mark -- Prototypes --
 
-static OSStatus CheckInit ();
+static OSStatus CheckInit (void);
 
 static void     FilePlayNotificationHandler (void* inRefCon, OSStatus inStatus);
 
 static int      RunCallBackThread (void* inRefCon);
 
 
-void Lock()
+void Lock(void)
 {
 	if (!apiMutex) {
 		apiMutex = SDL_CreateMutex();
@@ -93,7 +93,7 @@ void Lock()
 	SDL_mutexP(apiMutex);
 }
 
-void Unlock()
+void Unlock(void)
 {
 	SDL_mutexV(apiMutex);
 }
@@ -496,7 +496,7 @@ bail:
 	return error;
 }
 
-int ReleaseFile()
+int ReleaseFile(void)
 {
 	int error = -1;
 
@@ -522,7 +522,7 @@ int ReleaseFile()
 	return error;
 }
 
-int PlayFile()
+int PlayFile(void)
 {
 	OSStatus result = -1;
 
@@ -550,7 +550,7 @@ bail:
 	return result;
 }
 
-int PauseFile()
+int PauseFile(void)
 {
 	OSStatus result = -1;
 
@@ -585,7 +585,7 @@ void SetCompletionProc(CDPlayerCompletionProc proc, SDL_CD* cdrom)
 	thePlayer->SetNotifier(thePlayer, FilePlayNotificationHandler, cdrom);
 }
 
-int GetCurrentFrame()
+int GetCurrentFrame(void)
 {
 	int frame;
 
@@ -600,7 +600,7 @@ int GetCurrentFrame()
 
 #	pragma mark-- Private Functions --
 
-static OSStatus CheckInit()
+static OSStatus CheckInit(void)
 {
 	if (playBackWasInit) {
 		return 0;

--- a/src/libs/sdlcd/macosx/CDPlayer.h
+++ b/src/libs/sdlcd/macosx/CDPlayer.h
@@ -40,17 +40,17 @@ extern "C" {
 
 typedef void (*CDPlayerCompletionProc)(SDL_CD *cdrom) ;
 
-void     Lock ();
+void     Lock (void);
 
-void     Unlock();
+void     Unlock(void);
 
 int      LoadFile (const FSRef *ref, int startFrame, int endFrame); /* pass -1 to do nothing */
 
-int      ReleaseFile ();
+int      ReleaseFile (void);
 
-int      PlayFile  ();
+int      PlayFile  (void);
 
-int      PauseFile ();
+int      PauseFile (void);
 
 void     SetCompletionProc (CDPlayerCompletionProc proc, SDL_CD *cdrom);
 
@@ -60,7 +60,7 @@ int      ListTrackFiles (FSVolumeRefNum theVolume, FSRef *trackFiles, int numTra
 
 int      DetectAudioCDVolumes (FSVolumeRefNum *volumes, int numVolumes);
 
-int      GetCurrentFrame ();
+int      GetCurrentFrame (void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes:

#### markdown linter warning (whitespace-only)

```text
 DOCUMENTATION.md:63: MD038 Spaces inside code span elements

Further documentation is available for these failures:
 - MD038: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md038---spaces-inside-code-span-elements
Error: Process completed with exit code 123.
```

#### macOS cache cleanup

```text
mv: rename /Users/runner/Library/Caches/Homebrew/* to /Users/runner/work/dosbox-staging/dosbox-staging/discard/*: No such file or directory
```

#### macOS brew install warnings

```text
Error: openssl@3 3.1.2 is already installed
To install 3.1.1_1, first run:
  brew unlink openssl@3

Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake
```

#### macOS clang 14.x C-function declaration warnings

```text

../src/libs/sdlcd/macosx/AudioFileReaderThread.c:346:40: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:499:16: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:525:13: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:553:14: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:588:20: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:603:26: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:81:27: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:88:10: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.c:96:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.h:43:15: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.h:45:16: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.h:49:22: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.h:51:20: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.h:53:20: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
../src/libs/sdlcd/macosx/CDPlayer.h:63:26: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
```