### PR TITLE
Fix fallback shader scaling for adaptive CRT shaders

### DIFF
--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -157,8 +157,18 @@ void ShaderManager::LoadShader(const std::string& shader_name)
 	const auto settings = ParseShaderSettings(new_shader_name,
 	                                          current_shader.source);
 
-	const bool is_adaptive = (mode != ShaderMode::Single);
-	current_shader.info    = {new_shader_name, settings, is_adaptive};
+	const bool is_adaptive = [&] {
+		if (mode == ShaderMode::Single) {
+			return false;
+
+		} else {
+			// This will turn off vertical integer scaling for the
+			// 'sharp' shader in 'integer_scaling = auto' mode
+			return (new_shader_name != SharpShaderName);
+		}
+	}();
+
+	current_shader.info = {new_shader_name, settings, is_adaptive};
 }
 
 const ShaderInfo& ShaderManager::GetCurrentShaderInfo() const
@@ -358,7 +368,6 @@ void ShaderManager::MaybeAutoSwitchShader()
 			LOG_MSG("RENDER: Using shader '%s'",
 			        current_shader.info.name.c_str());
 		}
-		current_shader.info.is_adaptive = false;
 
 	} else {
 		auto shader_changed = false;
@@ -384,11 +393,6 @@ void ShaderManager::MaybeAutoSwitchShader()
 			LOG_MSG("RENDER: Auto-switched to shader '%s'",
 			        current_shader.info.name.c_str());
 		}
-
-		// This will turn off vertical integer scaling for the 'sharp'
-		// shader in 'integer_scaling = auto' mode
-		current_shader.info.is_adaptive = (current_shader.info.name !=
-		                                   SharpShaderName);
 	}
 }
 


### PR DESCRIPTION
Always disable integer scaling in `integer_scaling = auto` mode for adaptive CRT shaders when the fallback `sharp` shader is active.

This fixes a rather obscure bug that manifests when:

- An adaptive CRT shader is selected (`glshader = crt-auto-*`)
- The default `integer_scaling = auto` mode is selected
- The fallback `sharp` shader is active because the minimum vertical scaling ratio requirement hasn't been met
- When the fallback shader activation is triggered first by a screen mode change or a window resize event, the integer scaling is turned off **_— this is correct_** ✅ 
- But if you then press the "Reload Shader" shortcut, or enter/exit fullscreen, the vertical integer scaling will be activated again **_— this is a bug_** 🛑 