### PR TITLE
Add support for disabling screen via the clocking mode register, fixes #2838

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -427,6 +427,13 @@ static uint8_t* draw_linear_line_from_dac_palette(Bitu vidstart, Bitu /*line*/)
 	auto pixels_remaining = check_cast<uint16_t>(vga.draw.line_length /
 	                                             bytes_per_pixel);
 
+	// If the screen is disabled, just paint black. This fixes screen
+	// fades in titles like Alien Carnage.
+	if (GCC_UNLIKELY(vga.seq.clocking_mode.is_screen_disabled)) {
+		memset(line_addr, 0, vga.draw.line_length);
+		return TempLine;
+	}
+
 	// see VGA_Draw_Linear_Line
 	if (GCC_UNLIKELY((vga.draw.line_length + offset) & ~vga.draw.linear_mask)) {
 		// Note: To exercise these wrapped scenarios, run:


### PR DESCRIPTION
Fixes #2838 by painting black for screen lines when the screen disable bit is set in the clocking mode register. This wasn't ever checked before.

Fixes: Alien Carnage (a/k/a Halloween Harry)

Regression tested against: Descent (shareware), Dark Forces (full), Ultimate Doom, Quake, Blake Stone AoG, MDK, Pinball Illusions, CyberMage Dark Awakening, Epic Pinball, Extreme Pinball (yes, I mostly play pinball and shooters), Death Rally, GeoWorks Ensemble 2.0