### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,41 @@
+# Description
+
+_Describe a summary of your changes clearly and concisely, including motivation and context._
+_Breaking changes need extra explanation on backward compatibility considerations._
+
+_Feel free to include additional details, but please respect the reviewer's time and keep it brief._
+
+
+## Related issues
+
+_Related issues can be listed here (remove the section if not applicable.)_
+
+
+# Manual testing
+
+_Please describe the tests that you ran to verify your changes._
+
+_Provide clear instructions so the reviewers can reproduce and verify your results._
+
+_Include relevant details for your test configuration, operating system, etc._
+
+_Ideally, you would also test your changes with a [sanitizer build](https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#make-a-sanitizer-build) and confirm no issues were found._
+
+
+# Checklist
+
+_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._
+
+I have:
+
+- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
+- [ ] performed a self-review of my code.
+- [ ] commented on the particularly hard-to-understand areas of my code.
+- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
+- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
+- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
+- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
+- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
+- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
+- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
+

--- a/scripts/verify-markdown.sh
+++ b/scripts/verify-markdown.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 list_markdown_files () {
 	git ls-files -- \
 	  '*.md' \
+	  ':!:.github/**/*.md' \
 	  ':!:src/libs/*.md' \
 	  ':!:src/hardware/reelmagic/docs/*.md' \
 	  ':!:contrib/resources/*.md'


### PR DESCRIPTION
I think it's time to start using a PR template for both internal and external contributions.

On one hand, this sets clear expectations and doesn't make the contributor feel we're "picking on them" when asking for changes, additional testing details, or perhaps a complete re-work. One way to look at the template is "contributor training"—it might take a long time to work your way through the template and the checklist for the _first time_, but then on it should be easy sailing. Core members are already doing the majority of these things anyway, so this should not add significantly to their "workload".

Filling out the template correctly should also free up valuable time on the reviewers' side; having to ask for the same things over and over in PRs gets tiresome and time-consuming (this has become increasingly a problem for me lately).

Requiring proof of manual testing and reproducible test cases are important as not all reviewers are familiar with all parts of the codebase and every little quirky DOSBox feature. I dare to say most of us are quite familiar with one or two major areas, but not so much with the rest (certainly the case for me). Therefore, including these test cases is a necessity so anybody from the team can verify the PRs to some degree before merging.

Lastly, the checklist will help ensure consistent quality and that nothing important gets forgotten. I'm personally guilty of missing a few actions from that checklist from time to time—well, I won't be able to make any excuses going forward 😅 

My hope is that with this template in place, we'll be able to focus more on the fun parts of DOSBox development and reduce "review-related stress"—both on the contributors' and the reviewers' part. Plus asking for reproducible test cases should help reduce the likelihood of functional regressions.

The next comment shows what the template looks like in action.