### PR TITLE
Don't sign extend 16-bit immediates to 32-bit in ppc64le dynrec, fixes #2846

### DIFF
--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -155,7 +155,12 @@ static void gen_mov_regs(HostReg reg_dst, HostReg reg_src)
 // the upper 16bit of the destination register may be destroyed
 static void gen_mov_word_to_reg_imm(HostReg dest_reg, uint16_t imm)
 {
-	IMM_OP(14, dest_reg, 0, imm); // li dest,imm
+	if (imm & 0x8000) { // watch out for sign extension
+		IMM_OP(14, dest_reg, 0, 0); // li dest,0
+		IMM_OP(24, dest_reg, dest_reg, imm); // ori dest,dest,imm
+	} else {
+		IMM_OP(14, dest_reg, 0, imm); // li dest,imm
+	}
 }
 
 DRC_PTR_SIZE_IM block_ptr;


### PR DESCRIPTION
# Description

Previous versions of the ppc32 and ppc64 dynrecs loaded 16-bit immediates without regard for sign extension (the upper 32 bits would be cleared regardless on ppc64). Most things don't care, but apparently the XGA code does, manifesting in broken fonts in Windows 3.11 emulation. This corrects the dynrec to clear the upper bits with a manual load and immediate-OR if it gets a negative `uint16_t` (positive values can still go through the old fast path, so any performance impact should be minimal).

Makes no changes other than the ppc64le dynrec, no regression risk on other platforms.

# Manual testing

Verified functioning on Fedora 38 ppc64le with test pack in #2846 . No regressions noted in SVGA games.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [X] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [X] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

