### PR TITLE
Fix the aspect ratio of 40-column 00h and 01h BIOS text modes

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -40,14 +40,14 @@
 #include "vga.h"
 #include "video.h"
 
-//#define DEBUG_VGA_DRAW
+// #define DEBUG_VGA_DRAW
 
-typedef uint8_t * (* VGA_Line_Handler)(Bitu vidstart, Bitu line);
+typedef uint8_t* (*VGA_Line_Handler)(Bitu vidstart, Bitu line);
 
 static VGA_Line_Handler VGA_DrawLine;
 
 // Confirm the maximum dimensions accomodate VGA's pixel and scan doubling
-constexpr auto max_pixel_doubled_width  = 512;
+constexpr auto max_pixel_doubled_width = 512;
 constexpr auto max_scan_doubled_height = 400;
 static_assert(SCALER_MAXWIDTH >= SCALER_MAX_MUL_WIDTH * max_pixel_doubled_width);
 static_assert(SCALER_MAXHEIGHT >= SCALER_MAX_MUL_HEIGHT * max_scan_doubled_height);
@@ -2608,9 +2608,6 @@ ImageInfo setup_drawing()
 		render_pixel_aspect_ratio *= {PixelsPerChar::Eight,
 		                              vga.draw.pixels_per_character};
 
-		if (double_width) {
-			render_pixel_aspect_ratio /= 2;
-		}
 		break;
 
 	case M_TANDY_TEXT:


### PR DESCRIPTION
# Description

The aspect ratio was incorrectly calculated for the 40-column 00h and 01h BIOS text modes on all emulated graphics adapters. This PR fixes that.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2849

# Manual testing

- Tested the inventory screen of Space Quest I and Gold Rush with `machine = cga`, `tandy`, `ega`, and `svga_s3`.
- Regression tested 80-column text modes and 132-colum VESA text modes.
- Verified that the `raw` and `upscaled` screenshots are in the correct aspect ratio as well.
- Also updated the [Video emulation tests](https://github.com/dosbox-staging/dosbox-staging/wiki/Video-emulation-tests) wiki page with relevant info (search for "mode 01h").

Space Quest I inventory screen `rendered` screenshots:

## `machine = cga` (320x200)

![sq1-cga](https://github.com/dosbox-staging/dosbox-staging/assets/698770/461b21a5-5416-4eaf-8add-31e4c1e51025)

## `machine = ega` (320x350)

![sq1-ega](https://github.com/dosbox-staging/dosbox-staging/assets/698770/92ba47fb-b9bb-47d1-88d1-7ae2106efae1)

## `machine = svga_s3` (360x400)

![sq1-vga](https://github.com/dosbox-staging/dosbox-staging/assets/698770/4cf2abb5-655b-40d2-a75a-50d499255e2b)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

