### PR TITLE
Add FOR Command

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -159,6 +159,7 @@ public:
 	void CMD_DELETE(char* args);
 	void CMD_ECHO(char* args);
 	void CMD_EXIT(char* args);
+	void CMD_FOR(char* args);
 	void CMD_MKDIR(char* args);
 	void CMD_CHDIR(char* args);
 	void CMD_RMDIR(char* args);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -262,7 +262,8 @@ void strip_punctuation(std::string& str);
 //   split("::", ':') returns {"", "", ""}
 std::vector<std::string> split(std::string_view seq, char delim);
 
-// Split a string on whitespace, where whitespace can be any of the following:
+// Split a string on any character found in delim.
+// Delim defaults to all whitespace characters:
 // ' '    (0x20)  space (SPC)
 // '\t'   (0x09)  horizontal tab (TAB)
 // '\n'   (0x0a)  newline (LF)
@@ -276,7 +277,8 @@ std::vector<std::string> split(std::string_view seq, char delim);
 //   split("a\tb\nc\vd e\rf") returns {"a", "b", "c", "d", "e", "f"}
 //   split("  ") returns {}
 //   split(" ") returns {}
-std::vector<std::string> split(std::string_view seq);
+std::vector<std::string> split(std::string_view seq,
+                               std::string_view delims = " \f\n\r\t\v");
 
 std::string join_with_commas(const std::vector<std::string>& items,
                              const std::string_view and_conjunction = "and",

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -148,30 +148,29 @@ std::vector<std::string> split(const std::string_view seq, const char delim)
 	return words;
 }
 
-std::vector<std::string> split(const std::string_view seq)
+std::vector<std::string> split(const std::string_view seq, const std::string_view delims)
 {
 	std::vector<std::string> words;
-	if (seq.empty())
+	if (seq.empty()) {
 		return words;
-
-	constexpr auto whitespace = " \f\n\r\t\v";
+	}
 
 	// count words to reserve space in our vector
 	size_t n  = 0;
-	auto head = seq.find_first_not_of(whitespace, 0);
+	auto head = seq.find_first_not_of(delims, 0);
 	while (head != std::string::npos) {
-		const auto tail = seq.find_first_of(whitespace, head);
-		head            = seq.find_first_not_of(whitespace, tail);
+		const auto tail = seq.find_first_of(delims, head);
+		head            = seq.find_first_not_of(delims, tail);
 		++n;
 	}
 	words.reserve(n);
 
 	// populate the vector with the words
-	head = seq.find_first_not_of(whitespace, 0);
+	head = seq.find_first_not_of(delims, 0);
 	while (head != std::string::npos) {
-		const auto tail = seq.find_first_of(whitespace, head);
+		const auto tail = seq.find_first_of(delims, head);
 		words.emplace_back(seq.substr(head, tail - head));
-		head = seq.find_first_not_of(whitespace, tail);
+		head = seq.find_first_not_of(delims, tail);
 	}
 
 	// did we reserve the exact space needed?

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -627,6 +627,9 @@ static const char* const full_name      = "Z:\\COMMAND.COM";
 static const char* const init_line      = "/INIT AUTOEXEC.BAT";
 
 void SHELL_Init() {
+	
+	//clang-format off
+	
 	// Generic messages, to be used by any command or DOS program
 	MSG_Add("SHELL_ILLEGAL_PATH", "Illegal path.\n");
 	MSG_Add("SHELL_ILLEGAL_FILE_NAME", "Illegal file name.\n");
@@ -1328,6 +1331,25 @@ void SHELL_Init() {
 	        "  [color=green]move[reset] [color=white]file1.txt,file2.txt[reset] [color=cyan]mydir[reset]\n");
 	MSG_Add("SHELL_CMD_MOVE_MULTIPLE_TO_SINGLE",
 	        "Cannot move multiple files to a single file.\n");
+	MSG_Add("SHELL_CMD_FOR_HELP",
+	        "Runs a parametrized command on every element of a parameter list.\n");
+	MSG_Add("SHELL_CMD_FOR_HELP_LONG",
+		"Usage:\n"
+		"  [color=green]FOR[reset] [color=white]%VAR[reset] [color=cyan]IN[reset] [color=white](PARAMS)[reset] [color=cyan]DO[reset] COMMAND\n"
+		"Where:\n"
+		"  [color=white]%VAR[reset]     A single character variable prefixed by '%'.\n"
+		"  [color=white](PARAMS)[reset] Parameters replacing [color=white]%VAR[reset] instances in COMMAND.\n"
+		"  COMMAND  Any valid command. Use [color=white]%VAR[reset] to parametrize the command.\n"
+		"Notes:\n"
+		"  In batch files, [color=white]%VAR[reset] must be written as [color=white]%%VAR[reset].\n"
+		"  Parameters in [color=white](PARAMS)[reset] can be separated by any valid DOS separator.\n"
+		"  Wildcards in [color=white](PARAMS)[reset] add matching files to the list.\n"
+		"Examples:\n"
+		"  [color=green]FOR[reset] [color=white]%C[reset] [color=cyan]IN[reset] [color=white](HI HELLO)[reset] [color=cyan]DO[reset] ECHO %C\n"
+		"  [color=green]FOR[reset] [color=white]%D[reset] [color=cyan]IN[reset] [color=white](*.TXT)[reset] [color=cyan]DO[reset] DEL %D\n"
+	);
+
+	//clang-format on
 
 	/* Ensure help categories are loaded into the message vector */
 	HELP_AddMessages();


### PR DESCRIPTION
# Description

Added the FOR Command.

To the best of my knowledge, this behaves exactly like the FOR command on DOS.

Resolves #448

Also added a string_view delimiters parameter to the split function, allowing splitting on multiple characters of the caller's choosing.

# Manual testing
TODO


# Checklist

TODO

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

