### PR TITLE
Fix spelling mistakes in 'voodoo_*' config descriptions

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -704,7 +704,7 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "12");
 	pstring->Set_values(voodootypes);
 	pstring->Set_help(
-	        "Memory size (in MB) of the 3dfx Vodooo card (12 MB as default).");
+	        "Memory size (in MB) of the 3dfx Voodoo card (12 MB as default).");
 
 	pint = secprop->Add_int("voodoo_perf", only_at_start, 1);
 	pint->SetMinMax(0, 3);
@@ -713,7 +713,7 @@ void DOSBOX_Init()
 	               "   1:  Multi-threading (default).\n"
 	               "   2:  Disable bilinear filtering.\n"
 	               "   3:  All optimizations (both 1 and 2).\n"
-	               "Note: Voodo emulation is software-based and does not use host-level\n"
+	               "Note: Voodoo emulation is software-based and does not use host-level\n"
 	               "      OpenGL calls.");
 
 	// Configure capture


### PR DESCRIPTION
# Description

Fixed two spelling mistakes in `[voodoo]` section config descriptions.

# Manual testing

Type `config -wcd`, check that that the config file contains just properly written _Voodoo_ name - not _Vodooo_ or _Voodo_.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

