### PR TITLE
Revert dynamic core changes

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -52,8 +52,7 @@
 #endif
 
 #ifdef PAGESIZE
-// Some platforms like ppc64 have page sizes of 64K, so uint16_t isn't enough.
-constexpr uint32_t host_pagesize = { PAGESIZE };
+constexpr uint16_t host_pagesize = { PAGESIZE };
 #else
 constexpr uint16_t host_pagesize = 4096;
 #endif

--- a/meson.build
+++ b/meson.build
@@ -277,9 +277,6 @@ conf_data.set10('C_TRACY', get_option('tracy'))
 conf_data.set10('C_FPU', true)
 conf_data.set10('C_FPU_X86', host_machine.cpu_family() in ['x86', 'x86_64'])
 
-# Default page size is 4K, but not on all platforms.
-pagesize = 4096
-
 if get_option('enable_debugger') != 'none'
     conf_data.set10('C_DEBUG', true)
 endif
@@ -384,24 +381,12 @@ if host_machine.endian() == 'big'
     conf_data.set10('WORDS_BIGENDIAN', true)
 endif
 
-# 64-bit Power ISA can run with either 4K or 64K page size.
-# (32-bit Power ISA and PowerPC are always 4K.)
-if host_machine.cpu_family() in ['ppc64', 'ppc64le']
-    pagesize_cmd = run_command('getconf', 'PAGESIZE', check: true)
-    if pagesize_cmd.returncode() != 0
-        error('''error executing getconf: unable to determine host architecture page size for ppc64 dynamic core''')
-    else
-        pagesize = pagesize_cmd.stdout().strip().to_int()
-        if pagesize < 4096
-            # unexpected; did getconf return an empty or bogus string?
-            error('''need at least 4096-byte pages, getconf PAGESIZE returned '''+pagesize_cmd.stdout())
-        else
-            if pagesize != 4096
-                conf_data.set('PAGESIZE', pagesize)
-            endif
-        endif
-    endif
-endif
+# Non-4K memory page size is supported only for ppc64 at the moment.
+# TODO re-enable ppc dynrec while working on W^X stuff
+#      disabled because SVN r4424 broke compilation of ppc backends
+#if host_machine.cpu_family() in ['ppc64', 'ppc64le']
+#  conf_data.set('PAGESIZE', 65536)
+#endif
 
 set_prio_code = '''
 #include <sys/resource.h>
@@ -869,10 +854,6 @@ if host_machine.system() in ['windows', 'cygwin']
     winmm_dep = cxx.find_library('winmm', required: true)
     summary('Windows Multimedia support', winmm_dep.found())
 endif
-
-# Display page size in use (and to alert the user this may be salient).
-summary('Host page size (bytes)', pagesize.to_string())
-
 
 # Setup include directories
 incdir = [

--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -155,12 +155,7 @@ static void gen_mov_regs(HostReg reg_dst, HostReg reg_src)
 // the upper 16bit of the destination register may be destroyed
 static void gen_mov_word_to_reg_imm(HostReg dest_reg, uint16_t imm)
 {
-	if (imm & 0x8000) { // watch out for sign extension
-		IMM_OP(14, dest_reg, 0, 0); // li dest,0
-		IMM_OP(24, dest_reg, dest_reg, imm); // ori dest,dest,imm
-	} else {
-		IMM_OP(14, dest_reg, 0, imm); // li dest,imm
-	}
+	IMM_OP(14, dest_reg, 0, imm); // li dest,imm
 }
 
 DRC_PTR_SIZE_IM block_ptr;

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -795,31 +795,12 @@ constexpr bool is_64bit_platform = sizeof(void *) == 8;
 
 static inline void dyn_mem_adjust(void *&ptr, size_t &size)
 {
-#if (PAGESIZE == 65536)
-	// Use different code on 64K page systems (currently just ppc64le).
-	// The other code will sometimes underrun our pointer into unmapped
-	// memory and mprotect() will then fail.
-	const uintptr_t p = reinterpret_cast<uintptr_t>(ptr);
-	const auto align_adjust = p % host_pagesize;
-	const auto p_aligned = p - align_adjust;
-	assert((p_aligned % host_pagesize) == 0);
-
-	const auto new_size = size + align_adjust;
-	const auto new_size_adjust = new_size % host_pagesize;
-	if (new_size <= host_pagesize) {
-		size = host_pagesize;
-	} else if (new_size_adjust) {
-		size = (new_size - new_size_adjust) + host_pagesize;
-		assert((size % host_pagesize) == 0);
-	}
-#else
 	// Align to page boundary and adjust size. The -1/+1 voodoo
 	// is required to avoid segfaults on 32-bit builds.
 	const auto p = reinterpret_cast<uintptr_t>(ptr) - 1;
 	const auto align_adjust = p % host_pagesize;
 	const auto p_aligned = p - align_adjust;
 	size += align_adjust + 1;
-#endif
 	ptr = reinterpret_cast<void *>(p_aligned);
 }
 
@@ -939,18 +920,16 @@ static void cache_init(bool enable) {
 			if (cache_code_start_ptr == MAP_FAILED) {
 				E_Exit("DYNCACHE: Failed memory-mapping cache memory because: %s", strerror(errno));
 			}
-			// aligned by definition
-			cache_code = reinterpret_cast<uint8_t *>(cache_code_start_ptr);
 #else
 			cache_code_start_ptr=static_cast<uint8_t *>(malloc(cache_code_size));
 			if (!cache_code_start_ptr) {
 				E_Exit("DYNCACHE: Failed allocating cache memory because: %s", strerror(errno));
 			}
+#endif
 			// align the cache at a page boundary
 			cache_code = reinterpret_cast<uint8_t *>(
 			    (reinterpret_cast<uintptr_t>(cache_code_start_ptr) +
 			    host_pagesize - 1) & ~(host_pagesize - 1));
-#endif
 
 			cache_code_link_blocks=cache_code;
 			cache_code=cache_code+host_pagesize;


### PR DESCRIPTION
This reverts @classilla's dynamic core related changes as it wasn't sufficiently regression tested and it turns out it breaks the dynamic core on Windows (at least).

We're not against these improvements, but any changes related to such fundamental parts of DOSBox should be thoroughly regression tested before merging on all supported platforms, so macOS, Windows, and Linux.

See related discussion:
https://github.com/dosbox-staging/dosbox-staging/issues/2861