### PR TITLE
Fix null pointer de-reference in dyncache on Windows

### DIFF
--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -939,18 +939,16 @@ static void cache_init(bool enable) {
 			if (cache_code_start_ptr == MAP_FAILED) {
 				E_Exit("DYNCACHE: Failed memory-mapping cache memory because: %s", strerror(errno));
 			}
-			// aligned by definition
-			cache_code = reinterpret_cast<uint8_t *>(cache_code_start_ptr);
 #else
 			cache_code_start_ptr=static_cast<uint8_t *>(malloc(cache_code_size));
 			if (!cache_code_start_ptr) {
 				E_Exit("DYNCACHE: Failed allocating cache memory because: %s", strerror(errno));
 			}
+#endif
 			// align the cache at a page boundary
 			cache_code = reinterpret_cast<uint8_t *>(
 			    (reinterpret_cast<uintptr_t>(cache_code_start_ptr) +
 			    host_pagesize - 1) & ~(host_pagesize - 1));
-#endif
 
 			cache_code_link_blocks=cache_code;
 			cache_code=cache_code+host_pagesize;

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -948,7 +948,7 @@ static void cache_init(bool enable) {
 			// align the cache at a page boundary
 			cache_code = reinterpret_cast<uint8_t *>(
 			    (reinterpret_cast<uintptr_t>(cache_code_start_ptr) +
-			    host_pagesize - 1) & ~(host_pagesize - 1));
+			    static_cast<size_t>(host_pagesize) - 1) & ~(static_cast<size_t>(host_pagesize) - 1));
 
 			cache_code_link_blocks=cache_code;
 			cache_code=cache_code+host_pagesize;


### PR DESCRIPTION
# Description
Reverts part of commit 765bcc2

This is the only part of that commit that should affect non PPC processors.  The `#endif` got moved so that the Windows build never sets the `cache_code` variable leading to a null pointer de-reference.

I also removed the "aligned by definition" on mmap part.  I don't see the purpose of this change.  I believe VirtualAlloc on Windows which we're using a couple lines above is also "aligned by definition" to page size boundary.

In any case, if the memory is already aligned, the alignment check doesn't do anything (you still get the same address back out as far as I can tell).  Doesn't make sense as a micro-optimization either as the heap allocation is far more expensive than an add and a couple bitwise instructions.

Better to just set this back to the way it was so this variable gets set in the same way in all paths IMO.

Sidenote:  This is also why I dislike lots of inline `#ifdefs`.  Makes it very easy to introduce bugs like this.  I'd prefer to see it separated out into an `allocate_cache` function or something that has multiple implementations.  But this is legacy code and I don't feel like touching it 😄 


## Related issues
Fixes #2861


# Manual testing
I tested in MSVC and doesn't crash anymore.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

