### PR TITLE
Adaptive shader fixes

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -152,6 +152,7 @@ struct RenderedImage {
 extern Render_t render;
 extern ScalerLineHandler_t RENDER_DrawLine;
 
+void RENDER_Init(Section*);
 void RENDER_Reinit();
 
 void RENDER_AddConfigSection(const config_ptr_t& conf);

--- a/include/render.h
+++ b/include/render.h
@@ -152,6 +152,8 @@ struct RenderedImage {
 extern Render_t render;
 extern ScalerLineHandler_t RENDER_DrawLine;
 
+void RENDER_Reinit();
+
 void RENDER_AddConfigSection(const config_ptr_t& conf);
 
 bool RENDER_IsAspectRatioCorrectionEnabled();

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -43,13 +43,6 @@ using present_frame_f = bool();
 constexpr void update_frame_noop([[maybe_unused]] const uint16_t *) { /* no-op */ }
 static inline bool present_frame_noop() { return true; }
 
-enum SCREEN_TYPES {
-	SCREEN_TEXTURE,
-#if C_OPENGL
-	SCREEN_OPENGL
-#endif
-};
-
 enum class FrameMode {
 	Unset,
 	Cfr,          // constant frame rate, as defined by the emulated system
@@ -101,6 +94,9 @@ struct SDL_Block {
 	bool updating        = false;
 	bool resizing_window = false;
 	bool wait_on_error = false;
+
+	RenderingBackend rendering_backend      = RenderingBackend::Texture;
+	RenderingBackend want_rendering_backend = RenderingBackend::Texture;
 
 	InterpolationMode interpolation_mode    = InterpolationMode::Bilinear;
 	IntegerScalingMode integer_scaling_mode = IntegerScalingMode::Off;
@@ -156,9 +152,8 @@ struct SDL_Block {
 		bool lazy_init_window_size  = false;
 		HostRateMode host_rate_mode = HostRateMode::Auto;
 		double preferred_host_rate  = 0.0;
-		SCREEN_TYPES type           = SCREEN_TEXTURE;
-		SCREEN_TYPES want_type      = SCREEN_TEXTURE;
 	} desktop = {};
+
 	struct {
 		int num_cycles = 0;
 		std::string hint_mouse_str  = {};

--- a/include/video.h
+++ b/include/video.h
@@ -32,9 +32,7 @@
 
 enum class RenderingBackend {
 	Texture,
-#if C_OPENGL
 	OpenGl
-#endif
 };
 
 typedef enum {

--- a/include/video.h
+++ b/include/video.h
@@ -361,4 +361,6 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 
 SDL_Rect GFX_GetCanvasSize();
 
+RenderingBackend GFX_GetRenderingBackend();
+
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -30,6 +30,13 @@
 
 #define REDUCE_JOYSTICK_POLLING
 
+enum class RenderingBackend {
+	Texture,
+#if C_OPENGL
+	OpenGl
+#endif
+};
+
 typedef enum {
 	GFX_CallBackReset,
 	GFX_CallBackStop,

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -591,6 +591,10 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
                                   [[maybe_unused]] const bool reinit_render)
 {
 #if C_OPENGL
+	if (GFX_GetRenderingBackend() != RenderingBackend::OpenGl) {
+		return false;
+	}
+
 	// Currently, the init sequence is slightly different on Windows, macOS,
 	// and Linux. The first call to this function on Windows receives an
 	// uninitialised VideoMode param with width and height set to 0 which
@@ -653,20 +657,6 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 }
 
 #if C_OPENGL
-
-static bool is_using_opengl_output_mode()
-{
-	assert(control);
-
-	const auto sdl_sec = static_cast<const Section_prop*>(
-	        control->GetSection("sdl"));
-	assert(sdl_sec);
-
-	const bool using_opengl = starts_with(sdl_sec->GetPropValue("output"),
-	                                      "opengl");
-
-	return using_opengl;
-}
 
 std::deque<std::string> RENDER_GenerateShaderInventoryMessage()
 {
@@ -936,7 +926,7 @@ void RENDER_Init(Section* sec)
 	auto& shader_manager = get_shader_manager();
 
 	auto shader_changed = false;
-	if (is_using_opengl_output_mode()) {
+	if (GFX_GetRenderingBackend() == RenderingBackend::OpenGl) {
 		const auto shader_name = shader_manager.MapShaderName(
 		        section->Get_string("glshader"));
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -338,7 +338,7 @@ static Section_prop* get_render_section()
 }
 
 #if C_OPENGL
-static void render_reinit()
+void RENDER_Reinit()
 {
 	RENDER_Init(get_render_section());
 }
@@ -615,7 +615,7 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
 
 	if (changed_shader) {
 		if (reinit_render) {
-			render_reinit();
+			RENDER_Reinit();
 
 			// We can't set the new shader name here yet because
 			// then the "shader changed" reinit path wouldn't be
@@ -672,7 +672,7 @@ static void reload_shader([[maybe_unused]] const bool pressed)
 	}
 
 	render.force_reload_shader = true;
-	render_reinit();
+	RENDER_Reinit();
 
 	// The shader settings might have been changed (e.g. force_single_scan,
 	// force_no_pixel_doubling), so force re-rendering the image using the

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -41,8 +41,6 @@
 Render_t render;
 ScalerLineHandler_t RENDER_DrawLine;
 
-void RENDER_Init(Section*);
-
 #if C_OPENGL
 static ShaderManager& get_shader_manager()
 {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3114,7 +3114,8 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	}
 	case IntegerScalingMode::Auto:
 #if C_OPENGL
-		if (sdl.opengl.shader_info.is_adaptive) {
+		if (sdl.rendering_backend == RenderingBackend::OpenGl &&
+		    sdl.opengl.shader_info.is_adaptive) {
 			std::tie(view_w,
 			         view_h) = calculate_vertical_integer_scaling_dims();
 		} else {
@@ -3703,10 +3704,16 @@ static void FinalizeWindowState()
 
 static void maybe_auto_switch_shader()
 {
+#if C_OPENGL
+	if (sdl.rendering_backend != RenderingBackend::OpenGl) {
+		return;
+	}
+
 	const auto canvas = get_canvas_size(sdl.rendering_backend);
 
 	constexpr auto reinit_render = true;
 	RENDER_MaybeAutoSwitchShader(canvas.w, canvas.h, sdl.video_mode, reinit_render);
+#endif
 }
 
 bool GFX_Events()

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3380,6 +3380,8 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	const auto transparency = clamp(section->Get_int("transparency"), 0, 90);
 	const auto alpha = static_cast<float>(100 - transparency) / 100.0f;
 	SDL_SetWindowOpacity(sdl.window, alpha);
+
+	RENDER_Reinit();
 }
 
 // extern void UI_Run(bool);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1399,6 +1399,11 @@ SDL_Rect GFX_GetCanvasSize()
 	return get_canvas_size(sdl.rendering_backend);
 }
 
+RenderingBackend GFX_GetRenderingBackend()
+{
+	return sdl.rendering_backend;
+}
+
 static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
 {
 	return sdl.use_viewport_limits


### PR DESCRIPTION
# Description

This fixes two adaptive CRT shader related bugs:

- The adaptive shader-switching mechanism was erroneously also activated in non-OpenGL output modes when `glshader` was set to an adaptive shader (`crt-auto`, `crt-auto-machine`, or `crt-auto-arcade`).
- The `integer_scaling` setting in `auto` mode wasn't restricted to OpenGL output modes only. `auto` mode should effectively work as `off` (no integers scaling) in `texture` mode as no adaptive CRT shader can be active in `texture` mode.

@GranMinigun I've also done some sdlmain cleanup as I needed to extract the badly named `SCREEN_TYPES` enum, so I took the chance to refactor it while I was at it. Let me know if this conflicts too much with your sdlmain rework, then I can revert that part.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2865

Note that starting DOSBox with `output = texture` set in the config, then switching to `opengl` at runtime does _not_ work. That's broken in main too. I'll need @GranMinigun's help on this because I'm not too sure what's going on. However, if we never allowed rendering backend changes at runtime, I don't think that would be a great loss, so I don't think this is a high priority issue (but, yeah, technically buggy currently).

# Manual testing

### Test 1

1. Start Staging with `output = texture` in the config and `--noprimaryconf`. No integer scaling should be applied; the image should fill the window.
2. Resize the window to its minimum size. Then start resizing it in multiple steps until the window occupies the whole screen. You should not see any auto-shader switching related messages in the logs.
3. Switch to fullscreen and then back to windowed. You should not see any auto-shader switching related messages in the logs.
4. Enable integer scaling with `integer_scaling = vertical` — should work as expected.
5. Disable integer scaling with `integer_scaling = off` — should work as expected.

### Test 2

1. Start Staging with the defaults and no local config (`--noprimaryconf --nolocalconf`).
2. Note that the auto CRT shader and vertical integer scaling are actived (resize the window a few times to make sure).
3. Switch to `texture` mode by running `output = texture`.
4. Note that integer scaling is disabled (the image fills the window).

### Test 3 (failing)

1. Start Staging with `output = texture` in the config and `glshader = sharp`.
2. Switch to `opengl` output (`output = opengl`).
3. Switching to OpenGL will fail and you'll see the following in the logs:

```
2023-09-14 18:41:31.995 | SDL:OPENGL: No support for texture size of 1024x512, falling back to texture
2023-09-14 18:41:32.010 | DISPLAY: VGA 720x400 16-colour text mode 03h at 70.087 Hz VFR, scaled to 2205x1654 with 1:1.35 (20:27) pixel aspect ratio
2023-09-14 18:41:32.010 | Could not create OpenGL context, switching back to texture
```

@GranMinigun I need your help on this. This also happens in main, but with a slightly different error because the renderer is not even being reinitialised there as in this branch, thereforce the shader source will contain an empty string (so the thing would fail earlier). 


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

