### PR TITLE
Fix flicker in some games due to mouse driver breaking double buffering

### DIFF
--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -863,16 +863,14 @@ void MOUSEDOS_BeforeNewVideoMode()
 
 void MOUSEDOS_AfterNewVideoMode(const bool is_mode_changing)
 {
+	constexpr uint8_t last_non_svga_mode = 0x13;
+
 	// Gather screen mode information
 
-	INT10_SetCurMode();
 	const uint8_t bios_screen_mode = mem_readb(BIOS_VIDEO_MODE);
-
-	constexpr uint8_t last_non_svga_mode = 0x13;
 
 	const bool is_svga_mode = IS_VGA_ARCH &&
 	                          (bios_screen_mode > last_non_svga_mode);
-
 	const bool is_svga_text = is_svga_mode && INT10_IsTextMode(*CurMode);
 
 	// Perform common actions - clear pending mouse events, etc.


### PR DESCRIPTION
# Description

Removed `INT10_SetCurMode()` call from within `MOUSEDOS_AfterNewVideoMode`.
It was added as a part of >80 column screen mode fix (commit https://github.com/dosbox-staging/dosbox-staging/commit/31a0c4d6f80a3506341666dffbf4a74e656bbcc7 - before it wasn't possible to move mouse cursor over 80th column) to ensure the BIOS variables are up to date - this was clearly a mistake, as this breaks double-bufferring at least in some versions of _Microsoft Flight Simulator_.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2864

# Manual testing

Checked that _Microsoft Flight Simulator 5.1_ no longer produces flicker.
Checked that mouse driver still seems to be functioning correctly (allows to move cursor over 80th column) in many screen modes offered by _Necromancer's DOS Navigator_.
Checked mouse functionality in several randomly choosen games (including _Civilization_, _Settlers II_, _Polanie_, _Warcraft II_, ...)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

