### PR TITLE
MIXER command improvements & general mixer enhancements + fixes

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -74,7 +74,7 @@ jobs:
           general_criteria="GA:1,2;64:1;OP:1,2,3;CS:1"
           stamp="$(date +'%Y-%m-%d_T%H%M')-${GITHUB_SHA:0:8}"
           reportdir="pvs-report/pvs-report-${stamp}"
-          disable_warnings="V002,V801,V802,V813,V826,V1042,V1071,V2008"
+          disable_warnings="V002,V801,V802,V813,V826,V1042,V1071,V2008,V2010"
 
           mkdir -p "${reportdir}"
 

--- a/include/audio_frame.h
+++ b/include/audio_frame.h
@@ -51,6 +51,11 @@ struct AudioFrame {
 		assert(i < 2);
 		return i == 0 ? left : right;
 	}
+
+	constexpr bool operator==(const AudioFrame& that) const
+	{
+		return (left == that.left && right == that.right);
+	}
 };
 
 #endif

--- a/include/channel_names.h
+++ b/include/channel_names.h
@@ -1,0 +1,83 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_CHANNEL_NAMES_H
+#define DOSBOX_CHANNEL_NAMES_H
+
+#include <vector>
+
+namespace ChannelName {
+
+constexpr auto CdAudio             = "CDAUDIO";
+constexpr auto Cms                 = "CMS";
+constexpr auto CovoxDac            = "COVOX";
+constexpr auto DisneySoundSource   = "DISNEY";
+constexpr auto FluidSynth          = "FSYNTH";
+constexpr auto GravisUltrasound    = "GUS";
+constexpr auto IbmMusicFeatureCard = "IMFC";
+constexpr auto InnovationSsi2001   = "INNOVATION";
+constexpr auto Master              = "MASTER";
+constexpr auto Opl                 = "OPL";
+constexpr auto PcSpeaker           = "PCSPEAKER";
+constexpr auto Ps1AudioDac         = "PS1DAC";
+constexpr auto Ps1AudioPsg         = "PS1";
+constexpr auto ReelMagic           = "REELMAGIC";
+constexpr auto RolandMt32          = "MT32";
+constexpr auto SoundBlasterDac     = "SB";
+constexpr auto StereOn1Dac         = "STON1";
+constexpr auto TandyDac            = "TANDYDAC";
+constexpr auto TandyPsg            = "TANDY";
+
+} // namespace ChannelName
+
+// A list of all possible mixer channel names (for enhancements only;
+// core functionality should still work even if this list is completely
+// empty).
+//
+// Currently, this is only used by the MIXER command to report errors more
+// accurately. The worst that can happen if a new channel is not added to the
+// list is that certain error messages will be a little less helpful. Because of
+// how this list is used, inventing a mechanism to build this list automatically
+// at startup would be overkill.
+//
+// clang-format off
+static std::vector<std::string> AllChannelNames = {
+        ChannelName::CdAudio,
+        ChannelName::Cms,
+        ChannelName::CovoxDac,
+        ChannelName::DisneySoundSource,
+        ChannelName::FluidSynth,
+        ChannelName::GravisUltrasound,
+        ChannelName::IbmMusicFeatureCard,
+        ChannelName::InnovationSsi2001,
+        ChannelName::Master,
+        ChannelName::RolandMt32,
+        ChannelName::PcSpeaker,
+        ChannelName::Ps1AudioPsg,
+        ChannelName::Ps1AudioDac,
+        ChannelName::ReelMagic,
+        ChannelName::SoundBlasterDac,
+        ChannelName::StereOn1Dac,
+        ChannelName::TandyPsg,
+        ChannelName::TandyDac,
+};
+// clang-format on
+
+#endif // DOSBOX_CHANNEL_NAMES_H

--- a/include/channel_names.h
+++ b/include/channel_names.h
@@ -25,25 +25,25 @@
 
 namespace ChannelName {
 
-constexpr auto CdAudio             = "CDAUDIO";
-constexpr auto Cms                 = "CMS";
-constexpr auto CovoxDac            = "COVOX";
-constexpr auto DisneySoundSource   = "DISNEY";
-constexpr auto FluidSynth          = "FSYNTH";
-constexpr auto GravisUltrasound    = "GUS";
-constexpr auto IbmMusicFeatureCard = "IMFC";
-constexpr auto InnovationSsi2001   = "INNOVATION";
-constexpr auto Master              = "MASTER";
-constexpr auto Opl                 = "OPL";
-constexpr auto PcSpeaker           = "PCSPEAKER";
-constexpr auto Ps1AudioDac         = "PS1DAC";
-constexpr auto Ps1AudioPsg         = "PS1";
-constexpr auto ReelMagic           = "REELMAGIC";
-constexpr auto RolandMt32          = "MT32";
-constexpr auto SoundBlasterDac     = "SB";
-constexpr auto StereOn1Dac         = "STON1";
-constexpr auto TandyDac            = "TANDYDAC";
-constexpr auto TandyPsg            = "TANDY";
+constexpr auto CdAudio              = "CDAUDIO";
+constexpr auto Cms                  = "CMS";
+constexpr auto CovoxDac             = "COVOX";
+constexpr auto DisneySoundSourceDac = "DISNEY";
+constexpr auto FluidSynth           = "FSYNTH";
+constexpr auto GravisUltrasound     = "GUS";
+constexpr auto IbmMusicFeatureCard  = "IMFC";
+constexpr auto InnovationSsi2001    = "INNOVATION";
+constexpr auto Master               = "MASTER";
+constexpr auto Opl                  = "OPL";
+constexpr auto PcSpeaker            = "PCSPEAKER";
+constexpr auto Ps1AudioCardDac      = "PS1DAC";
+constexpr auto Ps1AudioCardPsg      = "PS1";
+constexpr auto ReelMagic            = "REELMAGIC";
+constexpr auto RolandMt32           = "MT32";
+constexpr auto SoundBlasterDac      = "SB";
+constexpr auto StereoOn1Dac         = "STON1";
+constexpr auto TandyDac             = "TANDYDAC";
+constexpr auto TandyPsg             = "TANDY";
 
 } // namespace ChannelName
 
@@ -62,21 +62,21 @@ static std::vector<std::string> AllChannelNames = {
         ChannelName::CdAudio,
         ChannelName::Cms,
         ChannelName::CovoxDac,
-        ChannelName::DisneySoundSource,
+        ChannelName::DisneySoundSourceDac,
         ChannelName::FluidSynth,
         ChannelName::GravisUltrasound,
         ChannelName::IbmMusicFeatureCard,
         ChannelName::InnovationSsi2001,
         ChannelName::Master,
-        ChannelName::RolandMt32,
         ChannelName::PcSpeaker,
-        ChannelName::Ps1AudioPsg,
-        ChannelName::Ps1AudioDac,
+        ChannelName::Ps1AudioCardDac,
+        ChannelName::Ps1AudioCardPsg,
         ChannelName::ReelMagic,
+        ChannelName::RolandMt32,
         ChannelName::SoundBlasterDac,
-        ChannelName::StereOn1Dac,
-        ChannelName::TandyPsg,
+        ChannelName::StereoOn1Dac,
         ChannelName::TandyDac,
+        ChannelName::TandyPsg,
 };
 // clang-format on
 

--- a/include/channel_names.h
+++ b/include/channel_names.h
@@ -68,6 +68,7 @@ static std::vector<std::string> AllChannelNames = {
         ChannelName::IbmMusicFeatureCard,
         ChannelName::InnovationSsi2001,
         ChannelName::Master,
+        ChannelName::Opl,
         ChannelName::PcSpeaker,
         ChannelName::Ps1AudioCardDac,
         ChannelName::Ps1AudioCardPsg,

--- a/include/control.h
+++ b/include/control.h
@@ -91,8 +91,10 @@ public:
 	          overwritten_autoexec_section("overwritten-autoexec")
 	{
 		assert(cmdline);
-		startup_params.push_back(cmdline->GetFileName());
-		cmdline->FillVector(startup_params);
+		startup_params = cmdline->GetArguments();
+		startup_params.insert(startup_params.begin(),
+		                      cmdline->GetFileName());
+
 		ParseArguments();
 	}
 

--- a/include/logging.h
+++ b/include/logging.h
@@ -94,6 +94,7 @@ void GFX_ShowMsg(const char* format, ...)
 // LOG_DEBUG exists only for messages useful during development, and not to
 // be redirected into internal DOSBox debugger for DOS programs (C_DEBUG feature).
 #define LOG_DEBUG(...)
+#define LOG_TRACE(...)
 #else
 
 template <typename... Args>

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 
 #include "../src/hardware/compressor.h"
 #include "audio_frame.h"
@@ -169,6 +170,7 @@ public:
 	~MixerChannel();
 
 	bool HasFeature(ChannelFeature feature) const;
+	std::set<ChannelFeature> GetFeatures() const;
 	const std::string& GetName() const;
 	uint16_t GetSampleRate() const;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -256,7 +256,7 @@ private:
 	void InitZohUpsamplerState();
 	void InitLerpUpsamplerState();
 
-	AudioFrame ApplyCrossfeed(const AudioFrame& frame) const;
+	AudioFrame ApplyCrossfeed(const AudioFrame frame) const;
 
 	std::string name = {};
 	Envelope envelope;
@@ -385,7 +385,7 @@ private:
 	public:
 		Sleeper() = delete;
 		Sleeper(MixerChannel& c);
-		void Listen(const AudioFrame& frame);
+		void Listen(const AudioFrame frame);
 		void MaybeSleep();
 		bool WakeUp();
 
@@ -414,8 +414,8 @@ void MIXER_AddConfigSection(const config_ptr_t& conf);
 uint16_t MIXER_GetSampleRate();
 uint16_t MIXER_GetPreBufferMs();
 
-const AudioFrame& MIXER_GetMasterVolume();
-void MIXER_SetMasterVolume(const AudioFrame& volume);
+const AudioFrame MIXER_GetMasterVolume();
+void MIXER_SetMasterVolume(const AudioFrame volume);
 
 void MIXER_Mute();
 void MIXER_Unmute();

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -167,7 +167,6 @@ public:
 	void ChangeChannelMap(const LineIndex left, const LineIndex right);
 	bool ChangeLineoutMap(std::string choice);
 	std::string DescribeLineout() const;
-	void ReactivateEnvelope();
 	void SetSampleRate(const uint16_t _freq);
 	void SetPeakAmplitude(const int peak);
 	void Mix(const uint16_t frames_requested);
@@ -222,8 +221,6 @@ public:
 
 	// Pass-through to the sleeper
 	bool WakeUp();
-
-	void FlushSamples();
 
 	// Timing on how many sample frames have been done by the mixer
 	std::atomic<int> frames_done = 0;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -406,7 +406,6 @@ mixer_channel_t MIXER_AddChannel(MIXER_Handler handler, const uint16_t freq,
 mixer_channel_t MIXER_FindChannel(const char* name);
 std::map<std::string, mixer_channel_t>& MIXER_GetChannels();
 
-void MIXER_DeregisterChannel(const std::string& name);
 void MIXER_DeregisterChannel(mixer_channel_t& channel);
 
 // Mixer configuration and initialization

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -119,7 +119,6 @@ enum class ChannelFeature {
 	Stereo,
 	Synthesizer,
 };
-using channel_features_t = std::set<ChannelFeature>;
 
 enum class FilterState { Off, On, ForcedOn };
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -101,6 +101,16 @@ enum LineIndex : uint8_t {
 	// would go here.
 };
 
+struct StereoLine {
+	LineIndex left  = Left;
+	LineIndex right = Right;
+
+	bool operator==(const StereoLine other) const;
+};
+
+static constexpr StereoLine Stereo  = {Left, Right};
+static constexpr StereoLine Reverse = {Right, Left};
+
 enum class ChannelFeature {
 	ChorusSend,
 	DigitalAudio,
@@ -164,8 +174,8 @@ public:
 	void SetAppVolume(const float f);
 	void SetAppVolume(const float left, const float right);
 
-	void ChangeChannelMap(const LineIndex left, const LineIndex right);
-	bool ChangeLineoutMap(std::string choice);
+	void SetChannelMap(const StereoLine map);
+	void SetLineoutMap(const StereoLine map);
 	std::string DescribeLineout() const;
 	void SetSampleRate(const uint16_t _freq);
 	void SetPeakAmplitude(const int peak);
@@ -304,15 +314,6 @@ private:
 	// peak, like the PCSpeaker, should update it with: SetPeakAmplitude()
 	//
 	int peak_amplitude = Max16BitSampleValue;
-
-	struct StereoLine {
-		LineIndex left  = Left;
-		LineIndex right = Right;
-		bool operator==(const StereoLine other) const;
-	};
-
-	static constexpr StereoLine Stereo  = {Left, Right};
-	static constexpr StereoLine Reverse = {Right, Left};
 
 	// User-configurable that defines how the channel's Stereo line maps
 	// into the mixer.

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -123,6 +123,15 @@ using channel_features_t = std::set<ChannelFeature>;
 
 enum class FilterState { Off, On, ForcedOn };
 
+struct MixerChannelSettings {
+	bool is_enabled          = {};
+	AudioFrame user_volume   = {};
+	StereoLine lineout_map   = {};
+	float crossfeed_strength = {};
+	float reverb_level       = {};
+	float chorus_level       = {};
+};
+
 enum class ResampleMethod {
 	// Use simple linear interpolation to resample from the channel sample
 	// rate to the mixer rate. This is the legacy behaviour, and it acts as a
@@ -183,6 +192,9 @@ public:
 	void SetPeakAmplitude(const int peak);
 	void Mix(const uint16_t frames_requested);
 
+	MixerChannelSettings GetSettings() const;
+	void SetSettings(const MixerChannelSettings& s);
+
 	// Fill up until needed
 	void AddSilence();
 
@@ -196,13 +208,13 @@ public:
 	void SetZeroOrderHoldUpsamplerTargetFreq(const uint16_t target_freq);
 
 	void SetCrossfeedStrength(const float strength);
-	float GetCrossfeedStrength();
+	float GetCrossfeedStrength() const;
 
 	void SetReverbLevel(const float level);
-	float GetReverbLevel();
+	float GetReverbLevel() const;
 
 	void SetChorusLevel(const float level);
-	float GetChorusLevel();
+	float GetChorusLevel() const;
 
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
 	void AddSamples(const uint16_t len, const Type* data);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -167,12 +167,11 @@ public:
 	void Set0dbScalar(const float f);
 	void RecalcCombinedVolume();
 
-	const AudioFrame& GetUserVolume() const;
-	void SetUserVolume(const float left, const float right);
+	const AudioFrame GetUserVolume() const;
+	void SetUserVolume(const AudioFrame volume);
 
-	const AudioFrame& GetAppVolume() const;
-	void SetAppVolume(const float f);
-	void SetAppVolume(const float left, const float right);
+	const AudioFrame GetAppVolume() const;
+	void SetAppVolume(const AudioFrame volume);
 
 	void SetChannelMap(const StereoLine map);
 	void SetLineoutMap(const StereoLine map);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -174,7 +174,10 @@ public:
 	void SetAppVolume(const AudioFrame volume);
 
 	void SetChannelMap(const StereoLine map);
+
 	void SetLineoutMap(const StereoLine map);
+	StereoLine GetLineoutMap() const;
+
 	std::string DescribeLineout() const;
 	void SetSampleRate(const uint16_t _freq);
 	void SetPeakAmplitude(const int peak);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -95,7 +95,7 @@ constexpr T Mixer_GetSilentDOSSample()
 }
 
 // A simple enum to describe the array index associated with a given audio line
-enum LineIndex : uint8_t {
+enum LineIndex {
 	Left  = 0,
 	Right = 1,
 	// DOS games didn't support surround sound, but if surround sound
@@ -151,6 +151,10 @@ enum class ResampleMethod {
 	// (everything below half the channel's sample rate is cut).
 	Resample
 };
+
+enum class CrossfeedPreset { None, Light, Normal, Strong };
+
+constexpr auto DefaultCrossfeedPreset = CrossfeedPreset::Normal;
 
 enum class ReverbPreset { None, Tiny, Small, Medium, Large, Huge };
 
@@ -257,8 +261,6 @@ private:
 	// prevent default construction, copying, and assignment
 	MixerChannel()                    = delete;
 	MixerChannel(const MixerChannel&) = delete;
-
-	MixerChannel& operator=(const MixerChannel&) = delete;
 
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
 	AudioFrame ConvertNextFrame(const Type* data, const work_index_t pos);
@@ -436,14 +438,15 @@ void MIXER_SetMasterVolume(const AudioFrame volume);
 void MIXER_Mute();
 void MIXER_Unmute();
 
-void MIXER_UpdateAllChannelVolumes();
-
 void MIXER_LockAudioDevice();
 void MIXER_UnlockAudioDevice();
 
 // Return true if the mixer was explicitly muted by the user (as opposed to
 // auto-muted when `mute_when_inactive` is enabled)
 bool MIXER_IsManuallyMuted();
+
+CrossfeedPreset MIXER_GetCrossfeedPreset();
+void MIXER_SetCrossfeedPreset(const CrossfeedPreset new_preset);
 
 ReverbPreset MIXER_GetReverbPreset();
 void MIXER_SetReverbPreset(const ReverbPreset new_preset);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -32,6 +32,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "../src/hardware/compressor.h"
 #include "audio_frame.h"

--- a/include/programs.h
+++ b/include/programs.h
@@ -32,7 +32,8 @@
 #include "dos_inc.h"
 #include "help_util.h"
 
-#define WIKI_URL                   "https://github.com/dosbox-staging/dosbox-staging/wiki"
+#define WIKI_URL "https://github.com/dosbox-staging/dosbox-staging/wiki"
+
 #define WIKI_ADD_UTILITIES_ARTICLE WIKI_URL "/Add-Utilities"
 
 class CommandLine {
@@ -40,43 +41,65 @@ public:
 	CommandLine(int argc, const char* const argv[]);
 	CommandLine(std::string_view name, std::string_view cmdline);
 
-	const char *GetFileName() const { return file_name.c_str(); }
+	const char* GetFileName() const
+	{
+		return file_name.c_str();
+	}
 
 	bool FindExist(const char* const name, bool remove = false);
 	bool FindInt(const char* const name, int& value, bool remove = false);
+
 	bool FindString(const char* const name, std::string& value,
 	                bool remove = false);
+
 	bool FindCommand(unsigned int which, std::string& value) const;
+
 	bool FindStringBegin(const char* const begin, std::string& value,
 	                     bool remove = false);
+
 	bool FindStringRemain(const char* const name, std::string& value);
+
 	bool FindStringRemainBegin(const char* const name, std::string& value);
+
 	bool GetStringRemain(std::string& value);
+
 	int GetParameterFromList(const char* const params[],
 	                         std::vector<std::string>& output);
+
 	std::vector<std::string> GetArguments();
+
 	bool HasDirectory() const;
 	bool HasExecutableName() const;
+
 	unsigned int GetCount(void);
+
 	bool ExistsPriorTo(const std::list<std::string_view>& pre_args,
 	                   const std::list<std::string_view>& post_args) const;
+
 	void Shift(unsigned int amount = 1);
 	uint16_t Get_arglength();
+
 	bool FindRemoveBoolArgument(const std::string& name, char short_letter = 0);
+
 	std::string FindRemoveStringArgument(const std::string& name);
+
 	std::vector<std::string> FindRemoveVectorArgument(const std::string& name);
+
 	std::optional<std::vector<std::string>> FindRemoveOptionalArgument(
 	        const std::string& name);
+
 	std::optional<int> FindRemoveIntArgument(const std::string& name);
 
 private:
 	using cmd_it = std::list<std::string>::iterator;
 
 	std::list<std::string> cmds = {};
-	std::string file_name = "";
+	std::string file_name       = "";
 
 	bool FindEntry(const char* const name, cmd_it& it, bool neednext = false);
+
 	std::string FindRemoveSingleString(const char* name);
+
 	bool FindBoolArgument(const std::string& name, bool remove,
 	                      char short_letter = 0);
 };
@@ -85,8 +108,8 @@ class Program {
 public:
 	Program();
 
-	Program(const Program &) = delete;            // prevent copy
-	Program &operator=(const Program &) = delete; // prevent assignment
+	Program(const Program&)            = delete; // prevent copy
+	Program& operator=(const Program&) = delete; // prevent assignment
 
 	virtual ~Program()
 	{
@@ -95,14 +118,21 @@ public:
 	}
 
 	std::string temp_line = "";
-	CommandLine *cmd = nullptr;
-	DOS_PSP *psp = nullptr;
+	CommandLine* cmd      = nullptr;
+	DOS_PSP* psp          = nullptr;
 
-	virtual void Run(void)=0;
-	virtual void WriteOut(const char *format, const char * arguments);
-	virtual void WriteOut(const char *format, ...);	// printf to DOS stdout
-	void WriteOut_NoParsing(const char *str); // write string to DOS stdout
-	bool SuppressWriteOut(const char *format); // prevent writing to DOS stdout
+	virtual void Run(void) = 0;
+	virtual void WriteOut(const char* format, const char* arguments);
+
+	// printf to DOS stdout
+	virtual void WriteOut(const char* format, ...);
+
+	// Write string to DOS stdout
+	void WriteOut_NoParsing(const char* str);
+
+	// Prevent writing to DOS stdout
+	bool SuppressWriteOut(const char* format);
+
 	void InjectMissingNewline();
 	void ChangeToLongCmd();
 	bool HelpRequested();
@@ -112,16 +142,18 @@ public:
 	void AddToHelpList();
 
 protected:
-	HELP_Detail help_detail {};
+	HELP_Detail help_detail{};
 };
 
 using PROGRAMS_Creator = std::function<std::unique_ptr<Program>()>;
+
 void PROGRAMS_Destroy([[maybe_unused]] Section* sec);
 void PROGRAMS_MakeFile(const char* const name, PROGRAMS_Creator creator);
 
-template<class P>
-std::unique_ptr<Program> ProgramCreate() {
-	// ensure that P is derived from Program
+template <class P>
+std::unique_ptr<Program> ProgramCreate()
+{
+	// Ensure that P is derived from Program
 	static_assert(std::is_base_of_v<Program, P>, "class not derived from Program");
 	return std::make_unique<P>();
 }

--- a/include/programs.h
+++ b/include/programs.h
@@ -54,7 +54,7 @@ public:
 	bool GetStringRemain(std::string& value);
 	int GetParameterFromList(const char* const params[],
 	                         std::vector<std::string>& output);
-	void FillVector(std::vector<std::string> & vector);
+	std::vector<std::string> GetArguments();
 	bool HasDirectory() const;
 	bool HasExecutableName() const;
 	unsigned int GetCount(void);

--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -61,7 +61,6 @@ void ReelMagic_ClearVideoMixerMPEGProvider();
 void ReelMagic_InitVideoMixer(Section* /*sec*/);
 
 // audio mixer related
-constexpr auto reelmagic_channel_name = "REELMAGIC";
 void ReelMagic_EnableAudioChannel(const bool should_enable);
 
 //

--- a/include/setup.h
+++ b/include/setup.h
@@ -401,6 +401,7 @@ public:
 
 	std::string Get_string(const std::string& _propname) const;
 
+	Prop_bool* GetBoolProp(const std::string& propname) const;
 	Prop_string* GetStringProp(const std::string& propname) const;
 
 	bool Get_bool(const std::string& _propname) const;

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -331,70 +331,29 @@ void lowercase_dos(std::string& in_str, const uint16_t code_page);
 void uppercase_dos(std::string& in_str);
 void uppercase_dos(std::string& in_str, const uint16_t code_page);
 
-// Parse a value from the string, clamp the result within the given min and max
-// values, and return it as a float. This API should give us enough numerical
-// range and accuracy for any text-based inputs.
+// Parse the string as an integer or decimal value and return it as a float.
+// This API should give us enough numerical range and accuracy for any
+// text-based inputs.
 //
 // For example:
-//  - parse_value("101", 0, 100) return 100.0f.
-//  - parse_value("x10", 0, 100) return empty.
-//  - parse_value("txt", 0, 100) return empty.
-//  - parse_value("", 0, 100) return empty.
+//  - parse_value("100")  returns 100.0f
+//  - parse_value("100a") returns empty
+//  - parse_value("x10")  returns empty
+//  - parse_value("txt")  returns empty
 //
-// To use it, check if the result then access it:
-//   const auto val = parse_value(s, ...);
-//   if (val)
-//       do_something(*val)
-//   else
-//       log_warning("%s was invalid", s.c_str());
-//
-// Alternatively, scope the value inside the if/else
-//   if (const auto v = parse_value(s, ...); v)
-//       do_something(*v)
-//   else
-//       log_warning("%s was invalid", s.c_str());
-//
-std::optional<float> parse_value(const std::string_view s,
-                                 const float min_value, const float max_value);
+std::optional<float> parse_float(const std::string& s);
 
-// parse_value clamped between 0 and 100
-std::optional<float> parse_percentage(const std::string_view s);
-
-// Parse a value from a character-prefixed string, clamp the result within the
-// given min and max values, and return it as a float. This API should give us
-// enough numerical range and accuracy for any text-based inputs.
+// Parse the string as an integer and return it as a integer.
 //
 // For example:
-//  - parse_prefixed_value('x', "x101", 0, 100) return 100.0f.
-//  - parse_prefixed_value('X', "x101", 0, 100) return 100.0f.
-//  - parse_prefixed_value('y', "x101", 0, 100) return empty.
-//  - parse_prefixed_value('y', "1000", 0, 100) return empty.
-//  - parse_prefixed_value('y', "text", 0, 100) return empty.
+//  - parse_value("100")  returns 100
+//  - parse_value("100a") returns empty
+//  - parse_value("x10")  returns empty
+//  - parse_value("txt")  returns empty
 //
-// To use it, check if the result then access it:
-//   const auto val = parse_prefixed_value(...);
-//   if (val)
-//       do_something(*val);
-//   else
-//       log_warning("%s was invalid", s.c_str());
-//
-// Alternatively, scope the value inside the if/else
-//   if (const auto v = parse_prefixed_value(...); v)
-//       do_something(*v)
-//   else
-//       log_warning("%s was invalid", s.c_str());
-//
-std::optional<float> parse_prefixed_value(const char prefix, const std::string& s,
-                                          const float min_value,
-                                          const float max_value);
+std::optional<int> parse_int(const std::string& s, const int base = 10);
 
-// parse_prefixed_value clamped between 0 and 100
-std::optional<float> parse_prefixed_percentage(const char prefix,
-                                               const std::string& s);
-
-// tries to convert string to integer,
-// returns value only if succeeded
-std::optional<int> to_int(const std::string& value, const int base = 10);
+std::optional<float> parse_percentage(const std::string& s);
 
 template <typename... Args>
 std::string format_string(const std::string& format, const Args&... args) noexcept

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -203,7 +203,7 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 		auto stem = entry.path().stem().string();
 		lowcase(stem);
 		if (starts_with(stem, filename_start)) {
-			const auto index = to_int(strip_prefix(stem, filename_start));
+			const auto index = parse_int(strip_prefix(stem, filename_start));
 			if (index) {
 				highest_index = std::max(highest_index, *index);
 			}

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -202,8 +202,16 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 		}
 		auto stem = entry.path().stem().string();
 		lowcase(stem);
+
 		if (starts_with(stem, filename_start)) {
-			const auto index = parse_int(strip_prefix(stem, filename_start));
+			auto index_str = strip_prefix(stem, filename_start);
+
+			// Strip "-raw" or "-rendered" postfix if it's there
+			if (const auto dash_pos = index_str.find('-');
+			    dash_pos != std::string::npos) {
+				index_str = index_str.substr(0, dash_pos);
+			}
+			const auto index = parse_int(index_str);
 			if (index) {
 				highest_index = std::max(highest_index, *index);
 			}

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -842,7 +842,7 @@ void CDROM_Interface_Image::ChannelControl(TCtrl ctrl)
 		return;
 	}
 	// Adjust the volume of our mixer channel as defined by the application
-	player.channel->SetAppVolume(ctrl.vol[0] / 255.0f, ctrl.vol[1] / 255.0f);
+	player.channel->SetAppVolume({ctrl.vol[0] / 255.0f, ctrl.vol[1] / 255.0f});
 
 	// Map the audio channels in our mixer channel as defined by the application
 	const auto left_mapped = static_cast<LineIndex>(ctrl.out[0]);

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -847,7 +847,7 @@ void CDROM_Interface_Image::ChannelControl(TCtrl ctrl)
 	// Map the audio channels in our mixer channel as defined by the application
 	const auto left_mapped = static_cast<LineIndex>(ctrl.out[0]);
 	const auto right_mapped = static_cast<LineIndex>(ctrl.out[1]);
-	player.channel->ChangeChannelMap(left_mapped, right_mapped);
+	player.channel->SetChannelMap({left_mapped, right_mapped});
 
 #ifdef DEBUG
 	LOG_MSG("CDROM: ChannelControl => volumes %d/255 and %d/255, "

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -41,11 +41,12 @@
 #include <cstring>
 #endif
 
+#include "channel_names.h"
 #include "drives.h"
 #include "fs_utils.h"
+#include "math_utils.h"
 #include "setup.h"
 #include "string_utils.h"
-#include "math_utils.h"
 
 using namespace std;
 
@@ -497,14 +498,14 @@ CDROM_Interface_Image::CDROM_Interface_Image(uint8_t sub_unit)
 
 			player.channel = MIXER_AddChannel(mixer_callback,
 			                                  use_mixer_rate,
-			                                  "CDAUDIO",
+			                                  ChannelName::CdAudio,
 			                                  {ChannelFeature::Stereo,
 			                                   ChannelFeature::DigitalAudio});
 
 			player.channel->Enable(false); // only enabled during playback periods
 		}
 #ifdef DEBUG
-		LOG_MSG("CDROM: Initialised the CDAUDIO audio channel");
+		LOG_MSG("CDROM: Initialised the %s audio channel", ChannelName::CdAudio);
 #endif
 	}
 	refCount++;

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -461,7 +461,8 @@ void CDROM_Interface_Ioctl::ChannelControl(TCtrl ctrl)
 
 	constexpr float MaxVolume = 255.0f;
 	// Adjust the volume of our mixer channel as defined by the application
-	mixer_channel->SetAppVolume(ctrl.vol[0] / MaxVolume, ctrl.vol[1] / MaxVolume);
+	mixer_channel->SetAppVolume(
+	        {ctrl.vol[0] / MaxVolume, ctrl.vol[1] / MaxVolume});
 
 	// Map the audio channels in our mixer channel as defined by the
 	// application

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -467,7 +467,7 @@ void CDROM_Interface_Ioctl::ChannelControl(TCtrl ctrl)
 	// application
 	const auto left_mapped  = static_cast<LineIndex>(ctrl.out[0]);
 	const auto right_mapped = static_cast<LineIndex>(ctrl.out[1]);
-	mixer_channel->ChangeChannelMap(left_mapped, right_mapped);
+	mixer_channel->SetChannelMap({left_mapped, right_mapped});
 #ifdef DEBUG_IOCTL
 	LOG_INFO("CDROM_IOCTL: ChannelControl => volumes %d/255 and %d/255, "
 	         "and left-right map %d, %d",

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <string.h>
+
 #include "cdrom.h"
 #include "support.h"
 
@@ -30,7 +31,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-constexpr auto MixerChannelNamePrefix = "CDAUDIO_";
 // ioctl cannot be read more than 75 redbook frames at a time (one second of audio)
 constexpr int InputBufferMaxRedbookFrames = 25;
 constexpr size_t PcmSamplesPerRedbookFrame = BYTES_PER_RAW_REDBOOK_FRAME / REDBOOK_BPS;
@@ -340,7 +340,7 @@ void CDROM_Interface_Ioctl::InitAudio(const int device_number)
 		return;
 	}
 
-	std::string name = std::string(MixerChannelNamePrefix) +
+	std::string name = std::string(ChannelName::CdAudio) + "_" +
 	                   std::to_string(device_number);
 
 	// Input buffer is used as a C-style buffer passed to an ioctl.

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "cdrom.h"
+#include "channel_names.h"
 #include "support.h"
 
 #if defined(LINUX)

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -153,8 +153,8 @@ void AUTOTYPE::Run()
 	const auto pace_ms = static_cast<uint32_t>(pace_s * 1000);
 
 	// Get the button sequence
-	std::vector<std::string> sequence;
-	cmd->FillVector(sequence);
+	auto sequence = cmd->GetArguments();
+
 	if (sequence.empty()) {
 		WriteOut_NoParsing("AUTOTYPE: button sequence is empty\n");
 		return;

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -45,8 +45,7 @@ void LS::Run()
 	constexpr bool remove_if_found = true;
 	const bool has_option_all = cmd->FindExist("/a", remove_if_found);
 
-	std::vector<std::string> patterns = {};
-	cmd->FillVector(patterns);
+	auto patterns = cmd->GetArguments();
 
 	// Make sure no other switches are supplied
 

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -104,8 +104,7 @@ void MIXER::Run()
 
 	auto showStatus = !cmd->FindExist("/NOSHOW", true);
 
-	std::vector<std::string> args = {};
-	cmd->FillVector(args);
+	auto args = cmd->GetArguments();
 
 	auto set_reverb_level = [&](const float level,
 	                            const channels_set_t& selected_channels) {

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -311,7 +311,7 @@ void MIXER::ShowMixerStatus()
 	column_layout.append({'\n'});
 
 	auto show_channel = [&](const std::string& name,
-	                        const AudioFrame& volume,
+	                        const AudioFrame volume,
 	                        const std::string& mode,
 	                        const std::string& xfeed,
 	                        const std::string& reverb,

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -54,7 +54,7 @@ static std::optional<AudioFrame> parse_volume(const std::string& s)
 		constexpr auto min_percent = 0.0f;
 		constexpr auto max_percent = 9999.0f;
 
-		if (const auto p = parse_value(s, min_percent, max_percent); p) {
+		if (const auto p = parse_float(s); p) {
 			return percentage_to_gain(*p);
 		}
 
@@ -63,10 +63,10 @@ static std::optional<AudioFrame> parse_volume(const std::string& s)
 		constexpr auto max_db         = 39.999f;
 		constexpr auto decibel_prefix = 'd';
 
-		if (const auto d = parse_prefixed_value(decibel_prefix, s, min_db, max_db);
+/*		if (const auto d = parse_prefixed_value(decibel_prefix, s, min_db, max_db);
 		    d) {
 			return decibel_to_gain(*d);
-		}
+		} */
 
 		return {};
 	};
@@ -191,7 +191,7 @@ void MIXER::Run()
 
 		if (global_command) {
 			// Global commands apply to all non-master channels
-			if (auto p = parse_prefixed_percentage(crossfeed_command, arg);
+/*			if (auto p = parse_prefixed_percentage(crossfeed_command, arg);
 			    p) {
 				for (auto& it : MIXER_GetChannels()) {
 					const auto strength = percentage_to_gain(*p);
@@ -210,7 +210,7 @@ void MIXER::Run()
 				const auto level = percentage_to_gain(*p);
 				set_chorus_level(level, set_of_channels());
 				continue;
-			}
+			} */
 
 		} else if (is_master) {
 			// Only setting the volume is allowed for the
@@ -221,7 +221,7 @@ void MIXER::Run()
 
 		} else if (channel) {
 			// Adjust settings of a regular non-master channel
-			if (auto p = parse_prefixed_percentage(crossfeed_command, arg);
+/*			if (auto p = parse_prefixed_percentage(crossfeed_command, arg);
 			    p) {
 				const auto strength = percentage_to_gain(*p);
 				channel->SetCrossfeedStrength(strength);
@@ -239,7 +239,7 @@ void MIXER::Run()
 				set_chorus_level(level, {channel});
 
 				continue;
-			}
+			} */
 
 			if (auto mode = parse_stereo_mode(arg); mode) {
 				channel->SetLineoutMap(*mode);

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -149,6 +149,17 @@ void MIXER::Run()
 		}
 	};
 
+	auto parse_stereo_mode =
+	        [&](const std::string& arg) -> std::optional<StereoLine> {
+		if (arg == "STEREO") {
+			return Stereo;
+		}
+		if (arg == "REVERSE") {
+			return Reverse;
+		}
+		return {};
+	};
+
 	auto is_master = false;
 
 	mixer_channel_t channel = {};
@@ -231,7 +242,8 @@ void MIXER::Run()
 				continue;
 			}
 
-			if (channel->ChangeLineoutMap(arg)) {
+			if (auto mode = parse_stereo_mode(arg); mode) {
+				channel->SetLineoutMap(*mode);
 				continue;
 			}
 

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -248,7 +248,7 @@ void MIXER::Run()
 			}
 
 			if (const auto v = parse_volume(arg); v) {
-				channel->SetUserVolume(v->left, v->right);
+				channel->SetUserVolume({v->left, v->right});
 			}
 		}
 	}
@@ -311,7 +311,7 @@ void MIXER::ShowMixerStatus()
 	column_layout.append({'\n'});
 
 	auto show_channel = [&](const std::string& name,
-	                        const AudioFrame volume,
+	                        const AudioFrame& volume,
 	                        const std::string& mode,
 	                        const std::string& xfeed,
 	                        const std::string& reverb,

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -734,7 +734,9 @@ bool ChannelInfos::HasFeature(const std::string& channel_name,
 void MIXER::Run()
 {
 	if (HelpRequested()) {
-		WriteOut(MSG_Get("SHELL_CMD_MIXER_HELP_LONG"));
+		MoreOutputStrings output(*this);
+		output.AddString(MSG_Get("SHELL_CMD_MIXER_HELP_LONG"));
+		output.Display();
 		return;
 	}
 	if (cmd->FindExist("/LISTMIDI")) {

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -20,74 +20,715 @@
 
 #include "program_mixer.h"
 
-#include <optional>
-#include <string>
-#include <vector>
+#include <cctype>
 
 #include "ansi_code_markup.h"
 #include "audio_frame.h"
+#include "channel_names.h"
 #include "checks.h"
 #include "math_utils.h"
 #include "midi.h"
-#include "mixer.h"
+#include "program_more_output.h"
 #include "string_utils.h"
 
 CHECK_NARROWING();
 
-using channels_set_t = std::set<mixer_channel_t>;
+namespace MixerCommand {
 
-static channels_set_t set_of_channels()
+bool SelectChannel::operator==(const SelectChannel that) const
 {
-	channels_set_t channels = {};
-	for (const auto& it : MIXER_GetChannels()) {
-		channels.emplace(it.second);
-	}
-	return channels;
+	return channel_name == that.channel_name;
 }
 
-// Parse the volume in string form, either in stereo or mono format,
-// and possibly in decibel format, which is prefixed with a 'd'.
-static std::optional<AudioFrame> parse_volume(const std::string& s)
+bool SetVolume::operator==(const SetVolume that) const
 {
-	auto to_volume = [](const std::string& s) -> std::optional<float> {
-		// Try parsing the volume from a percent value
-		constexpr auto min_percent = 0.0f;
-		constexpr auto max_percent = 9999.0f;
+	return volume == that.volume;
+}
 
-		if (const auto p = parse_float(s); p) {
+bool SetStereoMode::operator==(const SetStereoMode that) const
+{
+	return lineout_map == that.lineout_map;
+}
+
+bool SetCrossfeedStrength::operator==(const SetCrossfeedStrength that) const
+{
+	return strength == that.strength;
+}
+
+bool SetReverbLevel::operator==(const SetReverbLevel that) const
+{
+	return level == that.level;
+}
+
+bool SetChorusLevel::operator==(const SetChorusLevel that) const
+{
+	return level == that.level;
+}
+
+void Executor::operator()(const SelectChannel cmd)
+{
+	global_command = false;
+	master_channel = false;
+	channel        = nullptr;
+
+	if (cmd.channel_name == GlobalVirtualChannelName) {
+		global_command = true;
+	} else if (cmd.channel_name == ChannelName::Master) {
+		master_channel = true;
+	} else {
+		channel = MIXER_FindChannel(cmd.channel_name.c_str());
+		assert(channel);
+	}
+}
+
+void Executor::operator()(const SetVolume cmd)
+{
+	if (master_channel) {
+		MIXER_SetMasterVolume(cmd.volume);
+	} else {
+		assert(channel);
+		channel->SetUserVolume({cmd.volume.left, cmd.volume.right});
+	}
+}
+
+void Executor::operator()(const SetStereoMode cmd)
+{
+	assert(channel);
+	channel->SetLineoutMap(cmd.lineout_map);
+}
+
+void Executor::operator()(const SetCrossfeedStrength cmd)
+{
+	// Enable crossfeed if it's disabled
+	if (MIXER_GetCrossfeedPreset() == CrossfeedPreset::None) {
+		MIXER_SetCrossfeedPreset(DefaultCrossfeedPreset);
+	}
+
+	if (global_command) {
+		for (const auto& [_, channel] : MIXER_GetChannels()) {
+			channel->SetCrossfeedStrength(cmd.strength);
+		}
+	} else {
+		assert(channel);
+		channel->SetCrossfeedStrength(cmd.strength);
+	}
+}
+
+void Executor::operator()(const SetReverbLevel cmd)
+{
+	// Enable reverb if it's disabled
+	if (MIXER_GetReverbPreset() == ReverbPreset::None) {
+		MIXER_SetReverbPreset(DefaultReverbPreset);
+	}
+
+	if (global_command) {
+		for (const auto& [_, channel] : MIXER_GetChannels()) {
+			channel->SetReverbLevel(cmd.level);
+		}
+	} else {
+		assert(channel);
+		channel->SetReverbLevel(cmd.level);
+	}
+}
+
+void Executor::operator()(const SetChorusLevel cmd)
+{
+	// Enable chorus if it's disabled
+	if (MIXER_GetChorusPreset() == ChorusPreset::None) {
+		MIXER_SetChorusPreset(DefaultChorusPreset);
+	}
+
+	if (global_command) {
+		for (const auto& [_, channel] : MIXER_GetChannels()) {
+			channel->SetChorusLevel(cmd.level);
+		}
+	} else {
+		assert(channel);
+		channel->SetChorusLevel(cmd.level);
+	}
+}
+
+std::optional<float> parse_percentage(const std::string& s,
+                                      const float min_percent = 0.0f,
+                                      const float max_percent = 100.0f)
+{
+	if (const auto p = parse_float(s); p) {
+		if (*p >= min_percent && *p <= max_percent) {
 			return percentage_to_gain(*p);
 		}
+	}
+	return {};
+}
 
-		// Try parsing the volume from a decibel value
-		constexpr auto min_db         = -40.00f;
-		constexpr auto max_db         = 39.999f;
-		constexpr auto decibel_prefix = 'd';
+static bool is_start_of_number(const char c)
+{
+	return (c == '-' || c == '+' || std::isdigit(c));
+}
 
-/*		if (const auto d = parse_prefixed_value(decibel_prefix, s, min_db, max_db);
-		    d) {
-			return decibel_to_gain(*d);
-		} */
+constexpr auto CrossfeedCommandPrefix = 'X';
+constexpr auto ReverbCommandPrefix    = 'R';
+constexpr auto ChorusCommandPrefix    = 'C';
 
+static bool is_global_channel(const std::string& channel_name)
+{
+	return channel_name == GlobalVirtualChannelName;
+}
+
+static bool is_master_channel(const std::string& channel_name)
+{
+	return channel_name == ChannelName::Master;
+}
+
+static Error error(const ErrorType type, const std::string& message)
+{
+	const Error error = {type, message};
+	return error;
+}
+
+constexpr auto DecibelVolumeCommandPrefix = 'D';
+
+static bool is_volume_command(const std::string& s)
+{
+	if (s.size() < 1) {
+		return false;
+	}
+	auto is_percent_volume_command = [&]() {
+		return is_start_of_number(s[0]);
+	};
+	auto is_decibel_volume_command = [&]() {
+		return (s[0] == DecibelVolumeCommandPrefix);
+	};
+	return is_percent_volume_command() || is_decibel_volume_command();
+}
+
+static std::variant<Error, Command> parse_volume_command(const std::string& s,
+                                                         const std::string& channel_name)
+{
+	if (is_global_channel(channel_name)) {
+		const auto message = format_string(
+		        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_COMMAND"),
+		        s.c_str());
+
+		return error(ErrorType::InvalidGlobalCommand, message);
+	}
+
+	constexpr auto MinDb = -96.00f;
+	constexpr auto MaxDb = 40.000f;
+
+	static const auto MinPercent = decibel_to_gain(MinDb);
+
+	// Almost 40 dB, just a *tiny* bit below to ensure that the mixer
+	// columns don't get too wide.
+	constexpr auto MaxPercent = 9999.0f;
+
+	static const auto MinGain = MinPercent / 100.0f;
+	static const auto MaxGain = MaxPercent / 100.0f;
+
+	auto parse_percent_volume = [&](const std::string& s) -> std::optional<float> {
+		// Allow setting the volume to absolute silence (-inf dB) when
+		// specifying percentage volumes
+		if (const auto p = parse_percentage(s, 0.0f, MaxPercent); p) {
+			return *p;
+		}
 		return {};
+	};
+
+	auto parse_decibel_volume = [&](const std::string& s) -> std::optional<float> {
+		if (s[0] != DecibelVolumeCommandPrefix) {
+			return {};
+		};
+		if (const auto d = parse_float(s.substr(1));
+		    d && (*d >= MinDb && *d <= MaxDb)) {
+			return std::clamp(decibel_to_gain(*d), MinGain, MaxGain);
+		}
+		return {};
+	};
+
+	auto parse_volume = [&](const std::string& s) -> std::optional<float> {
+		if (s.size() < 1) {
+			return {};
+		}
+		auto v = parse_percent_volume(s);
+		if (!v) {
+			v = parse_decibel_volume(s);
+		}
+		if (!v) {
+			return {};
+		}
+
+		// Allow setting the volume to absolute silence (-inf dB) if a
+		// percentage volume of '0' was specified...
+		if (*v == 0.0f) {
+			return *v;
+		}
+		// ...but clamp to the [-96dB, 40dB] range otherwise (40dB would
+		// be a 10000 percentage value, but we clamp to 9999 instead
+		// because the tabular mixer output looks better that way).
+		return std::clamp(*v, MinPercent, MaxPercent);
 	};
 
 	auto parts = split(s, ':');
 
 	if (parts.size() == 1) {
-		// Single volume value
-		if (const auto v = to_volume(parts[0]); v) {
-			return AudioFrame(*v, *v);
+		// Single volume value for both channels (e.g. 10)
+		if (const auto v = parse_volume(parts[0]); v) {
+			const SetVolume cmd = {AudioFrame(*v, *v)};
+			return cmd;
+		} else {
+			const Error error = {ErrorType::InvalidVolumeCommand,
+			                     format_string(MSG_Get("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND"),
+			                                   channel_name.c_str(),
+			                                   s.c_str())};
+			return error;
 		}
+
 	} else if (parts.size() == 2) {
-		// Stereo volume value
-		const auto l = to_volume(parts[0]);
-		const auto r = to_volume(parts[1]);
+		// Colon-separated stereo volume value (e.g. 10:20)
+		const auto l = parse_volume(parts[0]);
+		const auto r = parse_volume(parts[1]);
 		if (l && r) {
-			return AudioFrame(*l, *r);
+			const SetVolume cmd = {AudioFrame(*l, *r)};
+			return cmd;
+		} else {
+			const Error error = {ErrorType::InvalidVolumeCommand,
+			                     format_string(MSG_Get("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND"),
+			                                   channel_name.c_str(),
+			                                   s.c_str())};
+			return error;
+		}
+	} else { // more than 2 parts
+		const Error error = {ErrorType::InvalidVolumeCommand,
+		                     format_string(MSG_Get("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND"),
+		                                   channel_name.c_str(),
+		                                   s.c_str())};
+		return error;
+	}
+}
+
+static std::optional<StereoLine> parse_stereo_mode(const std::string& s)
+{
+	if (s == "STEREO") {
+		return Stereo;
+	}
+	if (s == "REVERSE") {
+		return Reverse;
+	}
+	return {};
+}
+
+static bool is_command_with_prefix(const std::string& s, const char prefix)
+{
+	if (s.size() < 1) {
+		return false;
+	}
+	const auto command_prefix = s[0];
+	if (s.size() == 1) {
+		return (command_prefix == prefix);
+	} else {
+		return (command_prefix == prefix && is_start_of_number(s[1]));
+	}
+}
+
+static Error make_invalid_master_channel_command_error(const std::string& command)
+{
+	const auto message = format_string(MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
+	                                   ChannelName::Master,
+	                                   command.c_str());
+
+	return error(ErrorType::InvalidMasterChannelCommand, message);
+}
+
+static std::variant<Error, Command> parse_crossfeed_command(
+        const std::string& s, const std::string& channel_name,
+        const ChannelInfos& channel_infos)
+{
+	assert(s.size() >= 1);
+
+	const auto is_channel_mono = !channel_infos.HasFeature(channel_name,
+	                                                       ChannelFeature::Stereo);
+	if (is_channel_mono) {
+		const auto message = format_string(
+		        MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
+		        channel_name.c_str(),
+		        s.c_str());
+
+		return error(ErrorType::InvalidChannelCommand, message);
+	}
+
+	if (is_master_channel(channel_name)) {
+		return make_invalid_master_channel_command_error(s);
+	}
+
+	if (s.size() == 1) {
+		const auto msg_id =
+		        (is_global_channel(channel_name)
+		                 ? "SHELL_CMD_MIXER_MISSING_GLOBAL_CROSSFEED_STRENGTH"
+		                 : "SHELL_CMD_MIXER_MISSING_CROSSFEED_STRENGTH");
+
+		const auto message = format_string(MSG_Get(msg_id),
+		                                   channel_name.c_str());
+
+		return error(ErrorType::MissingCrossfeedStrength, message);
+	}
+
+	if (const auto strength = parse_percentage(s.substr(1)); strength) {
+		const SetCrossfeedStrength cmd = {*strength};
+		return cmd;
+	} else {
+		if (is_global_channel(channel_name)) {
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_CROSSFEED_STRENGTH"),
+			        s.c_str());
+			return error(ErrorType::InvalidGlobalCrossfeedStrength,
+			             message);
+		} else {
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INVALID_CROSSFEED_STRENGTH"),
+			        channel_name.c_str(),
+			        s.c_str());
+			return error(ErrorType::InvalidCrossfeedStrength, message);
+		}
+	}
+}
+
+static std::variant<Error, Command> parse_reverb_command(const std::string& s,
+                                                         const std::string& channel_name,
+                                                         const ChannelInfos& channel_infos)
+{
+	assert(s.size() >= 1);
+
+	if (is_master_channel(channel_name)) {
+		return make_invalid_master_channel_command_error(s);
+	}
+
+	if (!channel_infos.HasFeature(channel_name, ChannelFeature::ReverbSend)) {
+		const auto message = format_string(
+		        MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
+		        channel_name.c_str(),
+		        s.c_str());
+
+		return error(ErrorType::InvalidChannelCommand, message);
+	}
+
+	if (s.size() == 1) {
+		const auto msg_id = (is_global_channel(channel_name)
+		                             ? "SHELL_CMD_MIXER_MISSING_GLOBAL_REVERB_LEVEL"
+		                             : "SHELL_CMD_MIXER_MISSING_REVERB_LEVEL");
+
+		const auto message = format_string(MSG_Get(msg_id),
+		                                   channel_name.c_str());
+
+		return error(ErrorType::MissingReverbLevel, message);
+	}
+
+	if (const auto level = parse_percentage(s.substr(1)); level) {
+		const SetReverbLevel cmd = {*level};
+		return cmd;
+	} else {
+		if (is_global_channel(channel_name)) {
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_REVERB_LEVEL"),
+			        s.c_str());
+
+			return error(ErrorType::InvalidGlobalReverbLevel, message);
+		} else {
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INVALID_REVERB_LEVEL"),
+			        channel_name.c_str(),
+			        s.c_str());
+
+			return error(ErrorType::InvalidReverbLevel, message);
+		}
+	}
+}
+
+static std::variant<Error, Command> parse_chorus_command(const std::string& s,
+                                                         const std::string& channel_name,
+                                                         const ChannelInfos& channel_infos)
+{
+	assert(s.size() >= 1);
+
+	if (is_master_channel(channel_name)) {
+		return make_invalid_master_channel_command_error(s);
+	}
+
+	if (!channel_infos.HasFeature(channel_name, ChannelFeature::ChorusSend)) {
+		const auto message = format_string(
+		        MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
+		        channel_name.c_str(),
+		        s.c_str());
+
+		return error(ErrorType::InvalidChannelCommand, message);
+	}
+
+	if (s.size() == 1) {
+		const auto msg_id = (is_global_channel(channel_name)
+		                             ? "SHELL_CMD_MIXER_MISSING_GLOBAL_CHORUS_LEVEL"
+		                             : "SHELL_CMD_MIXER_MISSING_CHORUS_LEVEL");
+
+		const auto message = format_string(MSG_Get(msg_id),
+		                                   channel_name.c_str());
+
+		return error(ErrorType::MissingChorusLevel, message);
+	}
+
+	if (const auto level = parse_percentage(s.substr(1)); level) {
+		const SetChorusLevel cmd = {*level};
+		return cmd;
+	} else {
+		if (is_global_channel(channel_name)) {
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_CHORUS_LEVEL"),
+			        s.c_str());
+
+			return error(ErrorType::InvalidGlobalChorusLevel, message);
+		} else {
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INVALID_CHORUS_LEVEL"),
+			        channel_name.c_str(),
+			        s.c_str());
+
+			return error(ErrorType::InvalidChorusLevel, message);
+		}
+	}
+}
+
+std::variant<Error, std::queue<Command>> ParseCommands(
+        const std::vector<std::string>& args, const ChannelInfos& channel_infos,
+        const std::vector<std::string>& all_channel_names)
+{
+	std::string curr_channel_name   = GlobalVirtualChannelName;
+	auto curr_channel_command_count = 0;
+
+	std::queue<Command> commands = {};
+
+	// We always implicitly select the "global virtual channel" at the start
+	const SelectChannel cmd = {GlobalVirtualChannelName};
+	commands.emplace(cmd);
+
+	auto parse_select_channel_command =
+	        [&](const std::string& channel_name) -> std::optional<SelectChannel> {
+		if (channel_infos.HasChannel(channel_name)) {
+			const SelectChannel cmd = {channel_name};
+			return cmd;
+		}
+		return {};
+	};
+
+	auto is_valid_channel_name = [&](const std::string& channel_name) {
+		for (const auto& name : all_channel_names) {
+			if (name == channel_name) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	for (const auto& argument : args) {
+		auto arg = argument;
+		upcase(arg);
+
+		// The order of checking for the various error conditions
+		// matters. Things will still work if the order is altered, but
+		// the error messages will become slightly less meaningful.
+
+		if (is_volume_command(arg)) {
+			// Set volume command
+
+			const auto result = parse_volume_command(arg, curr_channel_name);
+
+			if (auto cmd = std::get_if<Command>(&result); cmd) {
+				commands.emplace(*cmd);
+				++curr_channel_command_count;
+			} else {
+				return std::get<Error>(result);
+			}
+
+		} else if (const auto mode = parse_stereo_mode(arg); mode) {
+			// Set stereo mode command
+
+			if (is_global_channel(curr_channel_name)) {
+				const auto message = format_string(
+				        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_COMMAND"),
+				        arg.c_str());
+
+				return error(ErrorType::InvalidGlobalCommand, message);
+			}
+
+			const auto is_channel_mono = !channel_infos.HasFeature(
+			        curr_channel_name, ChannelFeature::Stereo);
+
+			if (is_master_channel(curr_channel_name) || is_channel_mono) {
+				const auto message = format_string(
+				        MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
+				        curr_channel_name.c_str(),
+				        arg.c_str());
+
+				return error(ErrorType::InvalidChannelCommand,
+				             message);
+			}
+
+			const SetStereoMode cmd = {*mode};
+			commands.emplace(cmd);
+			++curr_channel_command_count;
+
+		} else if (is_command_with_prefix(arg, CrossfeedCommandPrefix)) {
+			// Set crossfeed strength command
+
+			const auto result = parse_crossfeed_command(arg,
+			                                            curr_channel_name,
+			                                            channel_infos);
+
+			if (auto cmd = std::get_if<Command>(&result); cmd) {
+				commands.emplace(*cmd);
+				++curr_channel_command_count;
+			} else {
+				return std::get<Error>(result);
+			}
+
+		} else if (is_command_with_prefix(arg, ReverbCommandPrefix)) {
+			// Set reverb level command
+
+			const auto result = parse_reverb_command(arg,
+			                                         curr_channel_name,
+			                                         channel_infos);
+
+			if (auto cmd = std::get_if<Command>(&result); cmd) {
+				commands.emplace(*cmd);
+				++curr_channel_command_count;
+			} else {
+				return std::get<Error>(result);
+			}
+
+		} else if (is_command_with_prefix(arg, ChorusCommandPrefix)) {
+			// Set chorus level command
+
+			const auto result = parse_chorus_command(arg,
+			                                         curr_channel_name,
+			                                         channel_infos);
+
+			if (auto cmd = std::get_if<Command>(&result); cmd) {
+				commands.emplace(*cmd);
+				++curr_channel_command_count;
+			} else {
+				return std::get<Error>(result);
+			}
+
+		} else if (const auto command = parse_select_channel_command(arg);
+		           command) {
+			// First try to find the channel in the list of channel
+			// infos which is generated from the currently active
+			// channels.
+
+			if (!is_global_channel(curr_channel_name) &&
+			    curr_channel_command_count == 0) {
+				const auto message = format_string(
+				        MSG_Get("SHELL_CMD_MIXER_MISSING_CHANNEL_COMMAND"),
+				        curr_channel_name.c_str());
+
+				return error(ErrorType::MissingChannelCommand,
+				             message);
+			}
+
+			curr_channel_name = command->channel_name;
+			commands.emplace(*command);
+			curr_channel_command_count = 0;
+
+		} else if (is_valid_channel_name(arg)) {
+			// At this point we know the channel is not currently
+			// active. So if the channel name itself is active,
+			// raise an error.
+
+			const auto message = format_string(
+			        MSG_Get("SHELL_CMD_MIXER_INACTIVE_CHANNEL"),
+			        arg.c_str());
+
+			return error(ErrorType::InactiveChannel, message);
+
+		} else {
+			// Unknown command
+
+			if (is_global_channel(curr_channel_name)) {
+				const auto message = format_string(
+				        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_COMMAND"),
+				        arg.c_str());
+
+				return error(ErrorType::InvalidGlobalCommand, message);
+			} else {
+				const auto message = format_string(
+				        MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
+				        curr_channel_name.c_str(),
+				        arg.c_str());
+
+				const auto error_type =
+				        (is_master_channel(curr_channel_name)
+				                 ? ErrorType::InvalidMasterChannelCommand
+				                 : ErrorType::InvalidChannelCommand);
+
+				return error(error_type, message);
+			}
 		}
 	}
 
-	return {};
+	if (curr_channel_command_count == 0) {
+		const auto message = format_string(
+		        MSG_Get("SHELL_CMD_MIXER_MISSING_CHANNEL_COMMAND"),
+		        curr_channel_name.c_str());
+
+		return error(ErrorType::MissingChannelCommand, message);
+	}
+
+	return commands;
+}
+
+void ExecuteCommands(Executor& executor, std::queue<Command>& commands)
+{
+	while (!commands.empty()) {
+		std::visit(executor, commands.front());
+		commands.pop();
+	}
+}
+
+} // namespace MixerCommand
+
+static ChannelInfos create_channel_infos()
+{
+	ChannelInfosMap infos = {};
+
+	for (const auto& [name, channel] : MIXER_GetChannels()) {
+		infos[name] = channel->GetFeatures();
+	}
+
+	return ChannelInfos(infos);
+}
+
+ChannelInfos::ChannelInfos(const ChannelInfosMap& channel_infos)
+{
+	features_by_channel_name[GlobalVirtualChannelName] = {
+	        ChannelFeature::Stereo,
+	        ChannelFeature::ReverbSend,
+	        ChannelFeature::ChorusSend};
+
+	features_by_channel_name[ChannelName::Master] = {ChannelFeature::Stereo};
+
+	features_by_channel_name.insert(channel_infos.begin(), channel_infos.end());
+}
+
+bool ChannelInfos::HasChannel(const std::string& channel_name) const
+{
+	return features_by_channel_name.find(channel_name) !=
+	       features_by_channel_name.end();
+}
+
+bool ChannelInfos::HasFeature(const std::string& channel_name,
+                              const ChannelFeature feature) const
+{
+	if (auto it = features_by_channel_name.find(channel_name);
+	    it != features_by_channel_name.end()) {
+		const auto [_, features] = *it;
+		return (features.find(feature) != features.end());
+	}
+	return false;
 }
 
 void MIXER::Run()
@@ -96,169 +737,56 @@ void MIXER::Run()
 		WriteOut(MSG_Get("SHELL_CMD_MIXER_HELP_LONG"));
 		return;
 	}
-
 	if (cmd->FindExist("/LISTMIDI")) {
 		MIDI_ListAll(this);
 		return;
 	}
 
-	auto showStatus = !cmd->FindExist("/NOSHOW", true);
+	constexpr auto remove = true;
+	auto show_status      = !cmd->FindExist("/NOSHOW", remove);
 
-	auto args = cmd->GetArguments();
-
-	auto set_reverb_level = [&](const float level,
-	                            const channels_set_t& selected_channels) {
-		const auto should_zero_other_channels = (MIXER_GetReverbPreset() ==
-		                                         ReverbPreset::None);
-
-		// Do we need to start the reverb engine?
-		if (MIXER_GetReverbPreset() == ReverbPreset::None) {
-			MIXER_SetReverbPreset(DefaultReverbPreset);
+	if (cmd->GetCount() == 0) {
+		if (show_status) {
+			ShowMixerStatus();
 		}
+		return;
+	}
 
-		for ([[maybe_unused]] const auto& [_, channel] :
-		     MIXER_GetChannels()) {
-			if (selected_channels.find(channel) !=
-			    selected_channels.end()) {
-				channel->SetReverbLevel(level);
-			} else if (should_zero_other_channels) {
-				channel->SetReverbLevel(0);
-			}
-		}
-	};
-
-	auto set_chorus_level = [&](const float level,
-	                            const channels_set_t& selected_channels) {
-		const auto should_zero_other_channels = (MIXER_GetChorusPreset() ==
-		                                         ChorusPreset::None);
-
-		// Do we need to start the chorus engine?
-		if (MIXER_GetChorusPreset() == ChorusPreset::None) {
-			MIXER_SetChorusPreset(DefaultChorusPreset);
-		}
-
-		for ([[maybe_unused]] const auto& [_, channel] :
-		     MIXER_GetChannels()) {
-			if (selected_channels.find(channel) !=
-			    selected_channels.end()) {
-				channel->SetChorusLevel(level);
-			} else if (should_zero_other_channels) {
-				channel->SetChorusLevel(0);
-			}
-		}
-	};
-
-	auto parse_stereo_mode =
-	        [&](const std::string& arg) -> std::optional<StereoLine> {
-		if (arg == "STEREO") {
-			return Stereo;
-		}
-		if (arg == "REVERSE") {
-			return Reverse;
-		}
-		return {};
-	};
-
-	auto is_master = false;
-
-	mixer_channel_t channel = {};
+	const auto args = cmd->GetArguments();
 
 	MIXER_LockAudioDevice();
 
-	for (auto& arg : args) {
-		// Does this argument set the target channel of
-		// subsequent commands?
-		upcase(arg);
+	auto result = MixerCommand::ParseCommands(args,
+	                                          create_channel_infos(),
+	                                          AllChannelNames);
 
-		if (arg == "MASTER") {
-			channel   = nullptr;
-			is_master = true;
-			continue;
-		} else {
-			auto chan = MIXER_FindChannel(arg.c_str());
-			if (chan) {
-				channel   = chan;
-				is_master = false;
-				continue;
-			}
+	if (auto commands = std::get_if<std::queue<MixerCommand::Command>>(&result);
+	    commands) {
+		// Success (all mixer commands executed successfully)
+		MixerCommand::Executor executor = {};
+		MixerCommand::ExecuteCommands(executor, *commands);
+
+		if (show_status) {
+			ShowMixerStatus();
 		}
 
-		const auto global_command = !is_master && !channel;
-
-		constexpr auto crossfeed_command = 'X';
-		constexpr auto reverb_command    = 'R';
-		constexpr auto chorus_command    = 'C';
-
-		if (global_command) {
-			// Global commands apply to all non-master channels
-/*			if (auto p = parse_prefixed_percentage(crossfeed_command, arg);
-			    p) {
-				for (auto& it : MIXER_GetChannels()) {
-					const auto strength = percentage_to_gain(*p);
-					it.second->SetCrossfeedStrength(strength);
-				}
-				continue;
-
-			} else if (p = parse_prefixed_percentage(reverb_command, arg);
-			           p) {
-				const auto level = percentage_to_gain(*p);
-				set_reverb_level(level, set_of_channels());
-				continue;
-
-			} else if (p = parse_prefixed_percentage(chorus_command, arg);
-			           p) {
-				const auto level = percentage_to_gain(*p);
-				set_chorus_level(level, set_of_channels());
-				continue;
-			} */
-
-		} else if (is_master) {
-			// Only setting the volume is allowed for the
-			// master channel
-			if (const auto v = parse_volume(arg); v) {
-				MIXER_SetMasterVolume(*v);
-			}
-
-		} else if (channel) {
-			// Adjust settings of a regular non-master channel
-/*			if (auto p = parse_prefixed_percentage(crossfeed_command, arg);
-			    p) {
-				const auto strength = percentage_to_gain(*p);
-				channel->SetCrossfeedStrength(strength);
-				continue;
-
-			} else if (p = parse_prefixed_percentage(reverb_command, arg);
-			           p) {
-				const auto level = percentage_to_gain(*p);
-				set_reverb_level(level, {channel});
-				continue;
-
-			} else if (p = parse_prefixed_percentage(chorus_command, arg);
-			           p) {
-				const auto level = percentage_to_gain(*p);
-				set_chorus_level(level, {channel});
-
-				continue;
-			} */
-
-			if (auto mode = parse_stereo_mode(arg); mode) {
-				channel->SetLineoutMap(*mode);
-				continue;
-			}
-
-			if (const auto v = parse_volume(arg); v) {
-				channel->SetUserVolume({v->left, v->right});
-			}
+	} else {
+		// Error (no mixer command was executed)
+		if (show_status) {
+			ShowMixerStatus();
+			WriteOut("\n");
 		}
+		auto error = std::get<MixerCommand::Error>(result);
+		const auto error_message = error.message.c_str();
+		WriteOut("%s\n", error_message);
+
+		// To give people a hint if their [autoexec] contains invalid
+		// MIXER commands.
+		LOG_WARNING("MIXER: Incorrect MIXER command invocation; "
+		            "run MIXER /? for help");
 	}
 
 	MIXER_UnlockAudioDevice();
-
-	MIXER_UpdateAllChannelVolumes();
-
-	if (showStatus) {
-		ShowMixerStatus();
-	}
 }
 
 void MIXER::AddMessages()
@@ -271,23 +799,29 @@ void MIXER::AddMessages()
 	        "  [color=light-green]mixer[reset] [/listmidi]\n"
 	        "\n"
 	        "Where:\n"
-	        "  [color=light-cyan]CHANNEL[reset]  is the sound channel to change the settings of.\n"
+	        "  [color=light-cyan]CHANNEL[reset]  is the mixer channel to change the settings of.\n"
 	        "  [color=white]COMMANDS[reset] is one or more of the following commands:\n"
-	        "    Volume:    [color=white]0[reset] to [color=white]100[reset], or decibel value prefixed with [color=white]d[reset] (e.g. [color=white]d-7.5[reset])\n"
-	        "               use [color=white]L:R[reset] to set the left and right side separately (e.g. [color=white]10:20[reset])\n"
-	        "    Lineout:   [color=white]stereo[reset], [color=white]reverse[reset] (for stereo channels only)\n"
-	        "    Crossfeed: [color=white]x0[reset] to [color=white]x100[reset]    Reverb: [color=white]r0[reset] to [color=white]r100[reset]    Chorus: [color=white]c0[reset] to [color=white]c100[reset]\n"
+	        "    Volume:      Percentage volume of [color=white]0[reset] to [color=white]9999[reset], or decibel volume prefixed\n"
+	        "                 with [color=white]d[reset] (e.g. [color=white]d-7.5[reset]). Use [color=white]L:R[reset] to set the left and right\n"
+	        "                 volumes of stereo channels separately (e.g. [color=white]10:20[reset], [color=white]150:d6[reset])\n"
+	        "    Stereo mode: [color=white]stereo[reset], or [color=white]reverse[reset] (stereo channels only)\n"
+	        "    Crossfeed:   [color=white]x0[reset] to [color=white]x100[reset], sets crossfeed strength (stereo channels only)\n"
+	        "    Reverb:      [color=white]r0[reset] to [color=white]r100[reset]. sets reverb level\n"
+	        "    Chorus:      [color=white]c0[reset] to [color=white]c100[reset], sets chorus level\n"
+	        "\n"
 	        "Notes:\n"
 	        "  - Run [color=light-green]mixer[reset] without arguments to view the current settings.\n"
-	        "  - You may change the settings of more than one channel in a single command.\n"
-	        "  - If channel is unspecified, you can set crossfeed, reverb, or chorus\n"
-	        "    globally for all channels.\n"
 	        "  - Run [color=light-green]mixer[reset] /listmidi to list all available MIDI devices.\n"
+	        "  - You may change the settings of more than one channel in a single command.\n"
+	        "  - If no channel is specified, you can set crossfeed, reverb, or chorus\n"
+	        "    of all channels globally.\n"
+	        "  - The reverb and chorus commands also enable the default reverb and chorus\n"
+	        "    presets, respectively, if those effects are not yet enabled.\n"
 	        "  - The /noshow option applies the changes without showing the mixer settings.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  [color=light-green]mixer[reset] [color=light-cyan]cdaudio[reset] [color=white]50[reset] [color=light-cyan]sb[reset] [color=white]reverse[reset] /noshow\n"
-	        "  [color=light-green]mixer[reset] [color=white]x30[reset] [color=light-cyan]opl[reset] [color=white]150 r50 c30[reset] [color=light-cyan]sb[reset] [color=white]x10[reset]");
+	        "  [color=light-green]mixer[reset] [color=white]x30[reset] [color=light-cyan]master[reset] [color=white]40[reset] [color=light-cyan]opl[reset] [color=white]150 r50 c30[reset] [color=light-cyan]sb[reset] [color=white]x10[reset]");
 
 	MSG_Add("SHELL_CMD_MIXER_HEADER_LAYOUT",
 	        "%-22s %4.0f:%-4.0f %+6.2f:%-+6.2f  %-8s %5s %7s %7s");
@@ -296,12 +830,74 @@ void MIXER::AddMessages()
 	        "[color=white]Channel      Volume    Volume (dB)   Mode     Xfeed  Reverb  Chorus[reset]");
 
 	MSG_Add("SHELL_CMD_MIXER_CHANNEL_OFF", "off");
-
 	MSG_Add("SHELL_CMD_MIXER_CHANNEL_STEREO", "Stereo");
-
 	MSG_Add("SHELL_CMD_MIXER_CHANNEL_REVERSE", "Reverse");
-
 	MSG_Add("SHELL_CMD_MIXER_CHANNEL_MONO", "Mono");
+
+	MSG_Add("SHELL_CMD_MIXER_INACTIVE_CHANNEL",
+	        "Channel [color=light-cyan]%s[reset] is not active");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_GLOBAL_COMMAND",
+	        "Invalid global command: [color=white]%s[reset]");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND",
+	        "Invalid volume for the [color=light-cyan]%s[reset] channel: "
+	        "[color=white]%s[reset] (run MIXER /? for help)");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_CROSSFEED_STRENGTH",
+	        "Invalid crossfeed strength for the [color=light-cyan]%s[reset] channel: "
+	        "[color=white]%s[reset]\n(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_CHORUS_LEVEL",
+	        "Invalid chorus level for the [color=light-cyan]%s[reset] channel: "
+	        "[color=white]%s[reset]\n(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_REVERB_LEVEL",
+	        "Invalid reverb level for the [color=light-cyan]%s[reset] channel: "
+	        "[color=white]%s[reset]\n(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_CROSSFEED_STRENGTH",
+	        "Missing crossfeed strength after [color=white]X[reset] for the "
+	        "[color=light-cyan]%s[reset] channel\n(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_CHORUS_LEVEL",
+	        "Missing chorus level after [color=white]C[reset] for the "
+	        "[color=light-cyan]%s[reset] channel\n(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_REVERB_LEVEL",
+	        "Missing reverb level after [color=white]R[reset] for the "
+	        "[color=light-cyan]%s[reset] channel\n(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_GLOBAL_CROSSFEED_STRENGTH",
+	        "Invalid global crossfeed strength [color=white]%s[reset] "
+	        "(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_GLOBAL_CHORUS_LEVEL",
+	        "Invalid global chorus level [color=white]%s[reset] "
+	        "(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_GLOBAL_REVERB_LEVEL",
+	        "Invalid global reverb level [color=white]%s[reset] "
+	        "(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_GLOBAL_CROSSFEED_STRENGTH",
+	        "Missing global crossfeed strength after [color=white]X[reset] "
+	        "(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_GLOBAL_CHORUS_LEVEL",
+	        "Missing global chorus level after [color=white]C[reset] "
+	        "(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_GLOBAL_REVERB_LEVEL",
+	        "Missing global reverb level after [color=white]R[reset] "
+	        "(must be between 0 and 100)");
+
+	MSG_Add("SHELL_CMD_MIXER_MISSING_CHANNEL_COMMAND",
+	        "Missing command for the [color=light-cyan]%s[reset] channel");
+
+	MSG_Add("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND",
+	        "Invalid command for the [color=light-cyan]%s[reset] channel: "
+	        "[color=white]%s[reset]");
 }
 
 void MIXER::ShowMixerStatus()
@@ -317,8 +913,8 @@ void MIXER::ShowMixerStatus()
 	                        const std::string& chorus) {
 		WriteOut(column_layout.c_str(),
 		         name.c_str(),
-		         static_cast<double>(volume.left * 100.0f),
-		         static_cast<double>(volume.right * 100.0f),
+		         static_cast<double>(gain_to_percentage(volume.left)),
+		         static_cast<double>(gain_to_percentage(volume.right)),
 		         static_cast<double>(gain_to_decibel(volume.left)),
 		         static_cast<double>(gain_to_decibel(volume.right)),
 		         mode.c_str(),
@@ -347,8 +943,9 @@ void MIXER::ShowMixerStatus()
 		std::string xfeed = none_value;
 		if (chan->HasFeature(ChannelFeature::Stereo)) {
 			if (chan->GetCrossfeedStrength() > 0.0f) {
-				xfeed = std::to_string(static_cast<uint8_t>(round(
-				        chan->GetCrossfeedStrength() * 100.0f)));
+				xfeed = std::to_string(static_cast<uint8_t>(
+				        round(gain_to_percentage(
+				                chan->GetCrossfeedStrength()))));
 			} else {
 				xfeed = off_value;
 			}
@@ -357,8 +954,8 @@ void MIXER::ShowMixerStatus()
 		std::string reverb = none_value;
 		if (chan->HasFeature(ChannelFeature::ReverbSend)) {
 			if (chan->GetReverbLevel() > 0.0f) {
-				reverb = std::to_string(static_cast<uint8_t>(
-				        round(chan->GetReverbLevel() * 100.0f)));
+				reverb = std::to_string(static_cast<uint8_t>(round(
+				        gain_to_percentage(chan->GetReverbLevel()))));
 			} else {
 				reverb = off_value;
 			}
@@ -367,8 +964,8 @@ void MIXER::ShowMixerStatus()
 		std::string chorus = none_value;
 		if (chan->HasFeature(ChannelFeature::ChorusSend)) {
 			if (chan->GetChorusLevel() > 0.0f) {
-				chorus = std::to_string(static_cast<uint8_t>(
-				        round(chan->GetChorusLevel() * 100.0f)));
+				chorus = std::to_string(static_cast<uint8_t>(round(
+				        gain_to_percentage(chan->GetChorusLevel()))));
 			} else {
 				chorus = off_value;
 			}

--- a/src/dos/program_mixer.h
+++ b/src/dos/program_mixer.h
@@ -23,6 +23,124 @@
 
 #include "programs.h"
 
+#include <map>
+#include <memory>
+#include <optional>
+#include <queue>
+#include <set>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "audio_frame.h"
+#include "mixer.h"
+
+constexpr auto GlobalVirtualChannelName = "*";
+
+using ChannelInfosMap = std::map<std::string, std::set<ChannelFeature>>;
+
+class ChannelInfos {
+public:
+	ChannelInfos(const ChannelInfosMap& channel_infos);
+
+	bool HasChannel(const std::string& channel_name) const;
+
+	bool HasFeature(const std::string& channel_name,
+	                const ChannelFeature feature) const;
+
+private:
+	ChannelInfosMap features_by_channel_name = {};
+};
+
+namespace MixerCommand {
+
+struct SelectChannel {
+	std::string channel_name = {};
+	bool operator==(const SelectChannel that) const;
+};
+
+struct SetVolume {
+	AudioFrame volume = {};
+	bool operator==(const SetVolume that) const;
+};
+
+struct SetStereoMode {
+	StereoLine lineout_map = {};
+	bool operator==(const SetStereoMode that) const;
+};
+
+struct SetCrossfeedStrength {
+	float strength = {};
+	bool operator==(const SetCrossfeedStrength that) const;
+};
+
+struct SetReverbLevel {
+	float level = {};
+	bool operator==(const SetReverbLevel that) const;
+};
+
+struct SetChorusLevel {
+	float level = {};
+	bool operator==(const SetChorusLevel that) const;
+};
+
+using Command = std::variant<SelectChannel, SetVolume, SetStereoMode,
+                             SetCrossfeedStrength, SetReverbLevel, SetChorusLevel>;
+
+enum class ErrorType {
+	InactiveChannel,
+
+	InvalidGlobalCommand,
+	InvalidMasterChannelCommand,
+	InvalidChannelCommand,
+	MissingChannelCommand,
+
+	InvalidGlobalCrossfeedStrength,
+	InvalidGlobalReverbLevel,
+	InvalidGlobalChorusLevel,
+
+	InvalidCrossfeedStrength,
+	InvalidReverbLevel,
+	InvalidChorusLevel,
+
+	MissingCrossfeedStrength,
+	MissingReverbLevel,
+	MissingChorusLevel,
+
+	InvalidVolumeCommand,
+};
+
+struct Error {
+	MixerCommand::ErrorType type = {};
+	std::string message          = {};
+};
+
+struct Executor {
+	void operator()(const SelectChannel cmd);
+	void operator()(const SetVolume cmd);
+	void operator()(const SetStereoMode cmd);
+	void operator()(const SetCrossfeedStrength cmd);
+	void operator()(const SetReverbLevel cmd);
+	void operator()(const SetChorusLevel cmd);
+
+private:
+	bool global_command = false;
+
+	// If 'master_channel' is true, then the MASTER channel is selected,
+	// otherwise 'channel' points to the selected non-master channel.
+	bool master_channel = false;
+
+	std::shared_ptr<MixerChannel> channel = {};
+};
+
+std::variant<Error, std::queue<Command>> ParseCommands(
+        const std::vector<std::string>& args, const ChannelInfos& channel_infos,
+        const std::vector<std::string>& all_channel_names);
+
+void ExecuteCommands(Executor& executor, std::queue<Command>& commands);
+
+} // namespace MixerCommand
+
 class MIXER final : public Program {
 public:
 	MIXER()

--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -71,7 +71,7 @@ bool MORE::ParseCommandLine(MoreOutputFiles &output)
 
 	// Check if specified tabulation size
 	if (cmd->FindStringBegin("/t", tmp_str, true)) {
-		const auto value = to_int(tmp_str);
+		const auto value = parse_int(tmp_str);
 		if (!value || *value < 1 || *value > 9) {
 			std::string full_switch = std::string("/t") + tmp_str;
 			result_errorcode = DOSERR_FUNCTION_NUMBER_INVALID;
@@ -84,7 +84,7 @@ bool MORE::ParseCommandLine(MoreOutputFiles &output)
 
 	// Check if specified start line
 	if (cmd->FindStringBegin("+", tmp_str, true)) {
-		const auto value = to_int(tmp_str);
+		const auto value = parse_int(tmp_str);
 		if (!value || *value < 0) {
 			std::string full_switch = std::string("+") + tmp_str;
 			result_errorcode = DOSERR_FUNCTION_NUMBER_INVALID;

--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -108,9 +108,7 @@ bool MORE::ParseCommandLine(MoreOutputFiles &output)
 
 bool MORE::FindInputFiles(MoreOutputFiles &output)
 {
-	// Put all the remaining parameters into vector
-	std::vector<std::string> params;
-	cmd->FillVector(params);
+	const auto params = cmd->GetArguments();
 	if (params.empty()) {
 		return true;
 	}

--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -44,9 +44,7 @@ void MOUSECTL::Run()
 
 bool MOUSECTL::ParseAndRun()
 {
-	// Put all the parameters into vector
-	std::vector<std::string> params;
-	cmd->FillVector(params);
+	auto params = cmd->GetArguments();
 
 	// Extract the list of interfaces from the vector
 	list_ids.clear();

--- a/src/dos/program_setver.cpp
+++ b/src/dos/program_setver.cpp
@@ -85,8 +85,7 @@ void SETVER::Run()
 		return;
 	}
 
-	std::vector<std::string> params;
-	cmd->FillVector(params);
+	auto params = cmd->GetArguments();
 
 	// Handle first parameter being a path to SETVER.EXE database
 	const bool is_database_candidate = !params.empty() &&

--- a/src/dos/program_setver.cpp
+++ b/src/dos/program_setver.cpp
@@ -208,7 +208,7 @@ bool SETVER::ParseVersion(const std::string& version_str, FakeVersion& version)
 	const auto& major_str = match[1].str();
 	const auto& minor_str = match[3].str();
 
-	const auto major = to_int(major_str);
+	const auto major = parse_int(major_str);
 	if (!major) {
 		// It would be enough to assert, but PVS-Studio was unhappy
 		assert(false);
@@ -221,7 +221,7 @@ bool SETVER::ParseVersion(const std::string& version_str, FakeVersion& version)
 		return true;
 	}
 
-	const auto minor = to_int(minor_str);
+	const auto minor = parse_int(minor_str);
 	if (!minor) {
 		// It would be enough to assert, but PVS-Studio was unhappy
 		assert(false);

--- a/src/dos/program_tree.cpp
+++ b/src/dos/program_tree.cpp
@@ -108,8 +108,7 @@ void TREE::Run()
 	}
 
 	// Check if directory is provided
-	std::vector<std::string> params;
-	cmd->FillVector(params);
+	const auto params = cmd->GetArguments();
 	if (params.size() > 1) {
 		WriteOut(MSG_Get("SHELL_TOO_MANY_PARAMETERS"));
 		return;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3488,8 +3488,8 @@ static void GUI_StartUp(Section *sec)
 			if (fullresolution != "desktop") { // desktop uses 0x0, below sets a custom WxH
 				std::vector<std::string> dimensions = split(fullresolution, 'x');
 				if (dimensions.size() == 2) {
-					sdl.desktop.full.width = to_int(dimensions[0]).value_or(0);
-					sdl.desktop.full.height = to_int(dimensions[1]).value_or(0);
+					sdl.desktop.full.width = parse_int(dimensions[0]).value_or(0);
+					sdl.desktop.full.height = parse_int(dimensions[1]).value_or(0);
 					maybe_limit_requested_resolution(
 					        sdl.desktop.full.width,
 					        sdl.desktop.full.height,

--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -25,7 +25,7 @@
 
 CHECK_NARROWING();
 
-//#define DEBUG_ADLIB_GOLD
+// #define DEBUG_ADLIB_GOLD
 
 // Yamaha YM7128B Surround Processor emulation
 // -------------------------------------------
@@ -72,16 +72,17 @@ void SurroundProcessor::ControlWrite(const uint8_t val)
 		// the rising edge of 'sci'.
 		if (!control_state.sci && reg.sci) {
 			// The 'a0' word clock determines the type of the data.
-			if (reg.a0)
+			if (reg.a0) {
 				// Data cycle
 				control_state.data = static_cast<uint8_t>(
 				                             control_state.data << 1) |
 				                     reg.din;
-			else
+			} else {
 				// Address cycle
 				control_state.addr = static_cast<uint8_t>(
 				                             control_state.addr << 1) |
 				                     reg.din;
+			}
 		}
 	}
 
@@ -119,16 +120,18 @@ void StereoProcessor::SetLowShelfGain(const double gain_db)
 {
 	constexpr auto cutoff_freq = 400.0;
 	constexpr auto slope       = 0.5;
-	for (auto &f : lowshelf)
+	for (auto& f : lowshelf) {
 		f.setup(sample_rate, cutoff_freq, gain_db, slope);
+	}
 }
 
 void StereoProcessor::SetHighShelfGain(const double gain_db)
 {
 	constexpr auto cutoff_freq = 2500.0;
 	constexpr auto slope       = 0.5;
-	for (auto &f : highshelf)
+	for (auto& f : highshelf) {
 		f.setup(sample_rate, cutoff_freq, gain_db, slope);
+	}
 }
 
 StereoProcessor::~StereoProcessor() = default;
@@ -344,7 +347,7 @@ void AdlibGold::SurroundControlWrite(const uint8_t val)
 	surround_processor->ControlWrite(val);
 }
 
-void AdlibGold::Process(const int16_t *in, const uint32_t frames, float *out)
+void AdlibGold::Process(const int16_t* in, const uint32_t frames, float* out)
 {
 	auto frames_remaining = frames;
 

--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -90,7 +90,7 @@ void SurroundProcessor::ControlWrite(const uint8_t val)
 	control_state.a0  = reg.a0;
 }
 
-AudioFrame SurroundProcessor::Process(const AudioFrame &frame)
+AudioFrame SurroundProcessor::Process(const AudioFrame frame)
 {
 	YM7128B_ChipIdeal_Process_Data data = {};
 
@@ -249,7 +249,7 @@ void StereoProcessor::ControlWrite(const StereoProcessorControlReg reg,
 	}
 }
 
-AudioFrame StereoProcessor::ProcessSourceSelection(const AudioFrame &frame)
+AudioFrame StereoProcessor::ProcessSourceSelection(const AudioFrame frame)
 {
 	switch (source_selector) {
 	case StereoProcessorSourceSelector::SoundA1:
@@ -269,7 +269,7 @@ AudioFrame StereoProcessor::ProcessSourceSelection(const AudioFrame &frame)
 	}
 }
 
-AudioFrame StereoProcessor::ProcessShelvingFilters(const AudioFrame &frame)
+AudioFrame StereoProcessor::ProcessShelvingFilters(const AudioFrame frame)
 {
 	AudioFrame out_frame = {};
 
@@ -280,7 +280,7 @@ AudioFrame StereoProcessor::ProcessShelvingFilters(const AudioFrame &frame)
 	return out_frame;
 }
 
-AudioFrame StereoProcessor::ProcessStereoProcessing(const AudioFrame &frame)
+AudioFrame StereoProcessor::ProcessStereoProcessing(const AudioFrame frame)
 {
 	AudioFrame out_frame = {};
 
@@ -311,7 +311,7 @@ AudioFrame StereoProcessor::ProcessStereoProcessing(const AudioFrame &frame)
 	return out_frame;
 }
 
-AudioFrame StereoProcessor::Process(const AudioFrame &frame)
+AudioFrame StereoProcessor::Process(const AudioFrame frame)
 {
 	auto out_frame = ProcessSourceSelection(frame);
 	out_frame      = ProcessShelvingFilters(out_frame);

--- a/src/hardware/adlib_gold.h
+++ b/src/hardware/adlib_gold.h
@@ -37,9 +37,9 @@ public:
 	AudioFrame Process(const AudioFrame &frame);
 
 	// prevent copying
-	SurroundProcessor(const SurroundProcessor &) = delete;
+	SurroundProcessor(const SurroundProcessor&) = delete;
 	// prevent assignment
-	SurroundProcessor &operator=(const SurroundProcessor &) = delete;
+	SurroundProcessor& operator=(const SurroundProcessor&) = delete;
 
 private:
 	YM7128B_ChipIdeal chip = {};
@@ -97,9 +97,9 @@ public:
 	void SetHighShelfGain(const double gain_db);
 
 	// prevent copying
-	StereoProcessor(const StereoProcessor &) = delete;
+	StereoProcessor(const StereoProcessor&) = delete;
 	// prevent assignment
-	StereoProcessor &operator=(const StereoProcessor &) = delete;
+	StereoProcessor& operator=(const StereoProcessor&) = delete;
 
 private:
 	uint16_t sample_rate = 0;
@@ -130,7 +130,7 @@ public:
 	void StereoControlWrite(const StereoProcessorControlReg reg,
 	                        const uint8_t data);
 
-	void Process(const int16_t *in, const uint32_t frames, float *out);
+	void Process(const int16_t* in, const uint32_t frames, float* out);
 
 private:
 	std::unique_ptr<SurroundProcessor> surround_processor = {};

--- a/src/hardware/adlib_gold.h
+++ b/src/hardware/adlib_gold.h
@@ -34,7 +34,7 @@ public:
 	~SurroundProcessor();
 
 	void ControlWrite(const uint8_t val);
-	AudioFrame Process(const AudioFrame &frame);
+	AudioFrame Process(const AudioFrame frame);
 
 	// prevent copying
 	SurroundProcessor(const SurroundProcessor&) = delete;
@@ -91,7 +91,7 @@ public:
 
 	void Reset();
 	void ControlWrite(const StereoProcessorControlReg, const uint8_t data);
-	AudioFrame Process(const AudioFrame &frame);
+	AudioFrame Process(const AudioFrame frame);
 
 	void SetLowShelfGain(const double gain_db);
 	void SetHighShelfGain(const double gain_db);
@@ -116,9 +116,9 @@ private:
 	// All-pass filter for pseudo-stereo processing
 	Iir::RBJ::AllPass allpass = {};
 
-	AudioFrame ProcessSourceSelection(const AudioFrame &frame);
-	AudioFrame ProcessShelvingFilters(const AudioFrame &frame);
-	AudioFrame ProcessStereoProcessing(const AudioFrame &frame);
+	AudioFrame ProcessSourceSelection(const AudioFrame frame);
+	AudioFrame ProcessShelvingFilters(const AudioFrame frame);
+	AudioFrame ProcessStereoProcessing(const AudioFrame frame);
 };
 
 class AdlibGold {

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -73,7 +73,7 @@ void Compressor::Reset()
 	max_over_db     = 0.0f;
 }
 
-AudioFrame Compressor::Process(const AudioFrame &in)
+AudioFrame Compressor::Process(const AudioFrame in)
 {
 	const float left  = in.left  * scale_in;
 	const float right = in.right * scale_in;

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -85,7 +85,7 @@ public:
 	               const float release_time_ms, const float rms_window_ms);
 	void Reset();
 
-	AudioFrame Process(const AudioFrame &in);
+	AudioFrame Process(const AudioFrame in);
 
 	// prevent copying
 	Compressor(const Compressor &) = delete;

--- a/src/hardware/covox.h
+++ b/src/hardware/covox.h
@@ -21,13 +21,14 @@
 
 #include "dosbox.h"
 
+#include "channel_names.h"
 #include "inout.h"
 #include "lpt_dac.h"
 #include "mixer.h"
 
 class Covox final : public LptDac {
 public:
-	Covox() : LptDac("COVOX", use_mixer_rate) {}
+	Covox() : LptDac(ChannelName::CovoxDac, use_mixer_rate) {}
 	void BindToPort(const io_port_t lpt_port) final;
 	void ConfigureFilters(const FilterState state) final;
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -21,11 +21,12 @@
 
 #include <cassert>
 
+#include "channel_names.h"
 #include "checks.h"
 
 CHECK_NARROWING();
 
-Disney::Disney() : LptDac("DISNEY", use_mixer_rate)
+Disney::Disney() : LptDac(ChannelName::DisneySoundSourceDac, use_mixer_rate)
 {
 	// Prime the FIFO with a single silent sample
 	fifo.emplace(data_reg);

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -21,8 +21,9 @@
 
 #include "gameblaster.h"
 
-#include "setup.h"
+#include "channel_names.h"
 #include "pic.h"
+#include "setup.h"
 
 // The Game Blaster is nothing else than a rebranding of Creative's first PC
 // sound card, the Creative Music System (C/MS).
@@ -84,7 +85,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 
 	channel = MIXER_AddChannel(audio_callback,
 	                           use_mixer_rate,
-	                           "CMS",
+	                           ChannelName::Cms,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::Stereo,
 	                            ChannelFeature::ReverbSend,

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "autoexec.h"
+#include "channel_names.h"
 #include "control.h"
 #include "dma.h"
 #include "hardware.h"
@@ -620,7 +621,7 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 
 	audio_channel = MIXER_AddChannel(mixer_callback,
 	                                 use_mixer_rate,
-	                                 "GUS",
+	                                 ChannelName::GravisUltrasound,
 	                                 {ChannelFeature::Sleep,
 	                                  ChannelFeature::Stereo,
 	                                  ChannelFeature::ReverbSend,
@@ -1333,7 +1334,7 @@ void Gus::UpdateDmaAddress(const uint8_t new_address)
 	dma1 = new_address;
 	dma_channel = DMA_GetChannel(dma1);
 	assert(dma_channel);
-	dma_channel->ReserveFor("GUS", gus_destroy);
+	dma_channel->ReserveFor(ChannelName::GravisUltrasound, gus_destroy);
 	dma_channel->RegisterCallback(std::bind(&Gus::DmaCallback, this, _1, _2));
 #if LOG_GUS
 	LOG_MSG("GUS: Assigned DMA1 address to %u", dma1);

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -65,6 +65,7 @@
 #include <thread>
 #include <utility>
 
+#include "channel_names.h"
 #include "control.h"
 #include "dma.h"
 #include "inout.h"
@@ -89,7 +90,7 @@ constexpr uint8_t MaxIrqAddress = 7;
 #if IMFC_VERBOSE_LOGGING
 SDL_mutex* m_loggerMutex = nullptr;
 template <typename... Args>
-void IMF_LOG(std::string format, Args const&... args)
+void IMF_LOG(std::string format, const Args&... args)
 {
 	SDL_LockMutex(m_loggerMutex);
 	printf((format + "\n").c_str(), args...);
@@ -5367,7 +5368,7 @@ private:
 
 	template <typename... Args>
 	void log_debug([[maybe_unused]] std::string format,
-	               [[maybe_unused]] Args const&... args)
+	               [[maybe_unused]] const Args&... args)
 	{
 		// IMF_LOG(("[%s] [DEBUG] " + format).c_str(),
 		// getCurrentThreadName().c_str(), args...);
@@ -5375,7 +5376,7 @@ private:
 
 	template <typename... Args>
 	void log_info([[maybe_unused]] std::string format,
-	              [[maybe_unused]] Args const&... args)
+	              [[maybe_unused]] const Args&... args)
 	{
 		// IMF_LOG(("[%s] [INFO] " + format).c_str(),
 		// getCurrentThreadName().c_str(), args...);
@@ -5383,7 +5384,7 @@ private:
 
 	template <typename... Args>
 	void log_error([[maybe_unused]] const char* format,
-	               [[maybe_unused]] Args const&... args)
+	               [[maybe_unused]] const Args&... args)
 	{
 #if IMFC_VERBOSE_LOGGING
 		static std::string message = {};
@@ -5788,7 +5789,7 @@ private:
 			if (readResult.status == ReadStatus::Success) {
 				send_midi_byte_to_System_in_THRU_mode(readResult.data);
 			}
-			SystemReadResult const systemReadResult =
+			const SystemReadResult systemReadResult =
 			        system_read9BitMidiDataByte();
 			if (systemReadResult.status == SystemDataAvailable) {
 				processIncomingMusicCardMessageByte(
@@ -6009,7 +6010,7 @@ private:
 					        m_actualMidiFlowPath.System_To_MidiOut);
 					return {ReadStatus::Error, 0xF7};
 				case MidiDataAvailable:
-					SystemReadResult const systemReadResult =
+					const SystemReadResult systemReadResult =
 					        system_read9BitMidiDataByte();
 					// log_debug("readMidiDataWithTimeout()
 					// - case MidiDataAvailable (0x%02X)",
@@ -6192,7 +6193,7 @@ private:
 			const ReadResult readResult = readMidiData();
 			if (readResult.status == ReadStatus::Error) {
 				log_debug("MUSIC_MODE_LOOP_read_System_And_Dispatch - system_read9BitMidiDataByte()");
-				SystemReadResult const systemReadResult =
+				const SystemReadResult systemReadResult =
 				        system_read9BitMidiDataByte();
 				if (systemReadResult.status == SystemDataAvailable) {
 					log_debug("PC->IMFC: Found system data [1%02X] in queue",
@@ -13382,7 +13383,7 @@ static void imfc_init(Section* sec)
 	// Register the Audio channel
 	auto channel = MIXER_AddChannel(IMFC_Mixer_Callback,
 	                                imfc_sampling_rate_hz,
-	                                "IMFC",
+	                                ChannelName::IbmMusicFeatureCard,
 	                                {ChannelFeature::Stereo,
 	                                 ChannelFeature::ReverbSend,
 	                                 ChannelFeature::ChorusSend,

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -21,6 +21,7 @@
 
 #include "innovation.h"
 
+#include "channel_names.h"
 #include "checks.h"
 #include "control.h"
 #include "pic.h"
@@ -83,7 +84,7 @@ void Innovation::Open(const std::string_view model_choice,
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,
 	                                      use_mixer_rate,
-	                                      "INNOVATION",
+	                                      ChannelName::InnovationSsi2001,
 	                                      {ChannelFeature::Sleep,
 	                                       ChannelFeature::ReverbSend,
 	                                       ChannelFeature::ChorusSend,

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -32,17 +32,17 @@
 #include "ston1_dac.h"
 
 LptDac::LptDac(const std::string_view name, const uint16_t channel_rate_hz,
-               channel_features_t extra_features)
+               std::set<ChannelFeature> extra_features)
         : dac_name(name)
 {
 	assert(!dac_name.empty());
 	using namespace std::placeholders;
 	const auto audio_callback = std::bind(&LptDac::AudioCallback, this, _1);
 
-	auto features = channel_features_t{ChannelFeature::Sleep,
-	                                   ChannelFeature::ReverbSend,
-	                                   ChannelFeature::ChorusSend,
-	                                   ChannelFeature::DigitalAudio};
+	std::set<ChannelFeature> features = {ChannelFeature::Sleep,
+	                                     ChannelFeature::ReverbSend,
+	                                     ChannelFeature::ChorusSend,
+	                                     ChannelFeature::DigitalAudio};
 
 	features.insert(extra_features.begin(), extra_features.end());
 

--- a/src/hardware/lpt_dac.h
+++ b/src/hardware/lpt_dac.h
@@ -24,6 +24,7 @@
 #include "dosbox.h"
 
 #include <queue>
+#include <set>
 #include <string_view>
 
 #include "inout.h"
@@ -34,7 +35,7 @@
 class LptDac {
 public:
 	LptDac(const std::string_view name, const uint16_t channel_rate_hz,
-	       channel_features_t extra_features = {});
+	       std::set<ChannelFeature> extra_features = {});
 	virtual ~LptDac();
 
 	// public interfaces

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -475,7 +475,7 @@ void MIXER_SetChorusPreset(const ChorusPreset new_preset)
 	}
 }
 
-static void configure_crossfeed(const std::string_view crossfeed_pref)
+static void configure_crossfeed(const std::string& crossfeed_pref)
 {
 	const auto crossfeed_pref_has_bool = parse_bool_setting(crossfeed_pref);
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1263,7 +1263,7 @@ void MixerChannel::SetCrossfeedStrength(const float strength)
 #endif
 }
 
-float MixerChannel::GetCrossfeedStrength()
+float MixerChannel::GetCrossfeedStrength() const
 {
 	return crossfeed.strength;
 }
@@ -1304,7 +1304,7 @@ void MixerChannel::SetReverbLevel(const float level)
 #endif
 }
 
-float MixerChannel::GetReverbLevel()
+float MixerChannel::GetReverbLevel() const
 {
 	return reverb.level;
 }
@@ -1345,7 +1345,7 @@ void MixerChannel::SetChorusLevel(const float level)
 #endif
 }
 
-float MixerChannel::GetChorusLevel()
+float MixerChannel::GetChorusLevel() const
 {
 	return chorus.level;
 }
@@ -1966,6 +1966,30 @@ std::string MixerChannel::DescribeLineout() const
 	// data), so we can assert.
 	assertm(false, "Unknown lineout mode");
 	return "unknown";
+}
+
+MixerChannelSettings MixerChannel::GetSettings() const
+{
+	MixerChannelSettings s = {};
+
+	s.is_enabled         = is_enabled;
+	s.user_volume        = GetUserVolume();
+	s.lineout_map        = GetLineoutMap();
+	s.crossfeed_strength = GetCrossfeedStrength();
+	s.reverb_level       = GetReverbLevel();
+	s.chorus_level       = GetChorusLevel();
+
+	return s;
+}
+
+void MixerChannel::SetSettings(const MixerChannelSettings& s)
+{
+	is_enabled = s.is_enabled;
+	SetUserVolume(s.user_volume);
+	SetLineoutMap(s.lineout_map);
+	SetCrossfeedStrength(s.crossfeed_strength);
+	SetReverbLevel(s.reverb_level);
+	SetChorusLevel(s.chorus_level);
 }
 
 MixerChannel::~MixerChannel()

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -683,12 +683,12 @@ void MixerChannel::SetAppVolume(const float v)
 	SetAppVolume(v, v);
 }
 
-const AudioFrame& MIXER_GetMasterVolume()
+const AudioFrame MIXER_GetMasterVolume()
 {
 	return mixer.master_volume;
 }
 
-void MIXER_SetMasterVolume(const AudioFrame& volume)
+void MIXER_SetMasterVolume(const AudioFrame volume)
 {
 	mixer.master_volume = volume;
 }
@@ -1576,7 +1576,7 @@ spx_uint32_t estimate_max_out_frames(SpeexResamplerState* resampler_state,
 	return ceil_udivide(in_frames * ratio_den, ratio_num);
 }
 
-AudioFrame MixerChannel::ApplyCrossfeed(const AudioFrame& frame) const
+AudioFrame MixerChannel::ApplyCrossfeed(const AudioFrame frame) const
 {
 	// Pan mono sample using -6dB linear pan law in the stereo field
 	// pan: 0.0 = left, 0.5 = center, 1.0 = right
@@ -1592,7 +1592,7 @@ MixerChannel::Sleeper::Sleeper(MixerChannel& c) : channel(c) {}
 
 // Records if samples had a magnitude great than 1. This is a one-way street;
 // once "had_noise" is tripped, it can only be reset after waking up.
-void MixerChannel::Sleeper::Listen(const AudioFrame& frame)
+void MixerChannel::Sleeper::Listen(const AudioFrame frame)
 {
 	if (had_noise) {
 		return;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2699,18 +2699,23 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 
 	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_blocksize);
 	int_prop->Set_values(blocksizes);
-	int_prop->Set_help("Mixer block size; larger values might help with sound stuttering but sound will\n"
-	                   "also be more lagged.");
+	int_prop->Set_help(format_string(
+	        "Mixer block size in sample frames (%d by default). Larger values might help\n"
+	        "with sound stuttering but the sound will also be more lagged.",
+	        default_blocksize));
 
 	int_prop = sec_prop.Add_int("prebuffer", only_at_start, default_prebuffer_ms);
 	int_prop->SetMinMax(0, MaxPrebufferMs);
-	int_prop->Set_help(
-	        "How many milliseconds of sound to render on top of the blocksize; larger values\n"
-	        "might help with sound stuttering but sound will also be more lagged.");
+	int_prop->Set_help(format_string("How many milliseconds of sound to render on top of the blocksize\n"
+	                                 "(%d by default). Larger values might help with sound stuttering but the sound\n"
+	                                 "will also be more lagged.",
+	                                 default_prebuffer_ms));
 
 	bool_prop = sec_prop.Add_bool("negotiate", only_at_start, default_allow_negotiate);
-	bool_prop->Set_help("Let the system audio driver negotiate (possibly) better rate and blocksize\n"
-	                    "settings.");
+	bool_prop->Set_help(
+	        format_string("Let the system audio driver negotiate possibly better sample rate and blocksize\n"
+	                      "settings (%s by default).",
+	                      default_allow_negotiate ? "enabled" : "disabled"));
 
 	const auto default_on = true;
 	bool_prop = sec_prop.Add_bool("compressor", when_idle, default_on);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -908,11 +908,6 @@ uint16_t MixerChannel::GetSampleRate() const
 	return check_cast<uint16_t>(sample_rate);
 }
 
-void MixerChannel::ReactivateEnvelope()
-{
-	envelope.Reactivate();
-}
-
 void MixerChannel::SetPeakAmplitude(const int peak)
 {
 	peak_amplitude = peak;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -263,6 +263,11 @@ bool MixerChannel::HasFeature(const ChannelFeature feature) const
 	return features.find(feature) != features.end();
 }
 
+std::set<ChannelFeature> MixerChannel::GetFeatures() const
+{
+	return features;
+}
+
 bool StereoLine::operator==(const StereoLine other) const
 {
 	return left == other.left && right == other.right;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -206,6 +206,11 @@ void MixerChannel::SetLineoutMap(const StereoLine map)
 	output_map = map;
 }
 
+StereoLine MixerChannel::GetLineoutMap() const
+{
+	return output_map;
+}
+
 // TODO Once the mixer code is thorougly refactored, revisit whether this is
 // still necessary (i.e., we might be able to be more precise with our
 // 'frames_needed' calculation so we never under or overshoot).

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -507,20 +507,6 @@ static void configure_compressor(const bool compressor_enabled)
 	LOG_MSG("MIXER: Master compressor enabled");
 }
 
-// Remove a channel by name from the mixer's map of channels.
-void MIXER_DeregisterChannel(const std::string& name_to_remove)
-{
-	MIXER_LockAudioDevice();
-
-	auto it = mixer.channels.find(name_to_remove);
-	if (it != mixer.channels.end()) {
-		mixer.channels.erase(it);
-	}
-
-	MIXER_UnlockAudioDevice();
-}
-
-// Remove a channel using the shared pointer variable.
 void MIXER_DeregisterChannel(mixer_channel_t& channel_to_remove)
 {
 	if (!channel_to_remove) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -35,6 +35,7 @@
 #include <speex/speex_resampler.h>
 
 #include "../capture/capture.h"
+#include "channel_names.h"
 #include "checks.h"
 #include "control.h"
 #include "cross.h"
@@ -622,13 +623,13 @@ mixer_channel_t MIXER_FindChannel(const char* name)
 		if (std::string_view(name) == "SPKR") {
 			LOG_WARNING("MIXER: 'SPKR' is deprecated due to inconsistent "
 			            "naming, please use 'PCSPEAKER' instead");
-			it = mixer.channels.find("PCSPEAKER");
+			it = mixer.channels.find(ChannelName::PcSpeaker);
 
 			// Deprecated alias FM to OPL
 		} else if (std::string_view(name) == "FM") {
 			LOG_WARNING("MIXER: 'FM' is deprecated due to inconsistent "
-			            "naming, please use 'OPL' instead");
-			it = mixer.channels.find("OPL");
+			            "naming, please use '%s' instead", ChannelName::Opl);
+			it = mixer.channels.find(ChannelName::Opl);
 		}
 	}
 

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -634,8 +634,8 @@ void OPL::AdlibGoldControlWrite(const uint8_t val)
 			// Dune CD version uses 32 volume steps in an apparent
 			// mistake, should be 128
 			channel->SetAppVolume(
-			        static_cast<float>(ctrl.lvol & 0x1f) / 31.0f,
-			        static_cast<float>(ctrl.rvol & 0x1f) / 31.0f);
+			        {static_cast<float>(ctrl.lvol & 0x1f) / 31.0f,
+			         static_cast<float>(ctrl.rvol & 0x1f) / 31.0f});
 		}
 		break;
 

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 
 #include "../capture/capture.h"
+#include "channel_names.h"
 #include "cpu.h"
 #include "mapper.h"
 #include "mem.h"
@@ -900,8 +901,11 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 	                                      this,
 	                                      std::placeholders::_1);
 
-	// Register the Audio channel
-	channel = MIXER_AddChannel(mixer_callback, use_mixer_rate, "OPL", channel_features);
+	// Register the audio channel
+	channel = MIXER_AddChannel(mixer_callback,
+	                           use_mixer_rate,
+	                           ChannelName::Opl,
+	                           channel_features);
 
 	// Used to be 2.0, which was measured to be too high. Exact value
 	// depends on card/clone.

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -23,6 +23,7 @@
 #include <queue>
 #include <string>
 
+#include "channel_names.h"
 #include "mixer.h"
 #include "pic.h"
 #include "setup.h"
@@ -38,7 +39,7 @@ public:
 	bool TryParseAndSetCustomFilter(const std::string_view filter_choice) final;
 	void SetCounter(const int cntr, const PitMode m) final;
 	void SetPITControl(const PitMode) final {}
-	void SetType(const PpiPortB &b) final;
+	void SetType(const PpiPortB& b) final;
 
 private:
 	void ChannelCallback(const uint16_t len);
@@ -49,11 +50,11 @@ private:
 	float NeutralLastPitOr(const float fallback) const;
 
 	// Constants
-	static constexpr char device_name[] = "PCSPEAKER";
-	static constexpr char model_name[]  = "discrete";
+	static constexpr auto device_name = ChannelName::PcSpeaker;
+	static constexpr auto model_name  = "discrete";
 
-	// The discrete PWM scalar was manually adjusted to roughly match voltage
-	// levels recorded from a hardware PC Speaker 
+	// The discrete PWM scalar was manually adjusted to roughly match
+	// voltage levels recorded from a hardware PC Speaker
 	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
 	static constexpr float pwm_scalar = 0.75f;
 	static constexpr float sqw_scalar = pwm_scalar / 2.0f;

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -24,10 +24,11 @@
 #include <deque>
 #include <string>
 
+#include "channel_names.h"
 #include "inout.h"
+#include "pic.h"
 #include "setup.h"
 #include "support.h"
-#include "pic.h"
 
 class PcSpeakerImpulse final : public PcSpeaker {
 public:
@@ -38,7 +39,7 @@ public:
 	bool TryParseAndSetCustomFilter(const std::string_view filter_choice) final;
 	void SetCounter(const int cntr, const PitMode pit_mode) final;
 	void SetPITControl(const PitMode pit_mode) final;
-	void SetType(const PpiPortB &port_b) final;
+	void SetType(const PpiPortB& port_b) final;
 
 private:
 	void AddImpulse(float index, const int16_t amplitude);
@@ -49,13 +50,13 @@ private:
 	void InitializeImpulseLUT();
 
 	// Constants
-	static constexpr char device_name[] = "PCSPEAKER";
-	static constexpr char model_name[]  = "impulse";
+	static constexpr auto device_name = ChannelName::PcSpeaker;
+	static constexpr auto model_name  = "impulse";
 
 	// Amplitude constants
 
 	// The impulse PWM scalar was manually adjusted to roughly match voltage
-	// levels recorded from a hardware PC Speaker 
+	// levels recorded from a hardware PC Speaker
 	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
 	static constexpr float pwm_scalar = 0.5f;
 
@@ -85,7 +86,7 @@ private:
 
 	static constexpr float max_possible_pit_ms = 1320000.0f / PIT_TICK_RATE;
 
-	// Compound types and containers	
+	// Compound types and containers
 	struct PitState {
 		// PIT starts in mode 3 (SquareWave) at ~903 Hz (pit_max) with
 		// positive amplitude

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -27,6 +27,7 @@
 #include <queue>
 #include <string.h>
 
+#include "channel_names.h"
 #include "control.h"
 #include "dma.h"
 #include "inout.h"
@@ -127,7 +128,7 @@ Ps1Dac::Ps1Dac(const std::string_view filter_choice)
 
 	channel = MIXER_AddChannel(callback,
 	                           use_mixer_rate,
-	                           "PS1DAC",
+	                           ChannelName::Ps1AudioCardDac,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::ChorusSend,
@@ -416,7 +417,7 @@ Ps1Synth::Ps1Synth(const std::string_view filter_choice)
 
 	channel = MIXER_AddChannel(callback,
 	                           use_mixer_rate,
-	                           "PS1",
+	                           ChannelName::Ps1AudioCardPsg,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::ChorusSend,

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -1173,7 +1173,7 @@ static void SetMixerVolume(const char* const channelName, const uint16_t percent
 
 	AudioFrame vol_gain     = chan->GetAppVolume();
 	vol_gain[right ? 1 : 0] = percentage_to_gain(percentage);
-	chan->SetAppVolume(vol_gain.left, vol_gain.right);
+	chan->SetAppVolume({vol_gain.left, vol_gain.right});
 }
 
 static bool RMDEV_SYS_int2fHandler()

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -36,6 +36,7 @@
 
 #include "../../dos/program_more_output.h"
 #include "callback.h"
+#include "channel_names.h"
 #include "dos_inc.h"
 #include "dos_system.h"
 #include "mapper.h"
@@ -1232,28 +1233,28 @@ static bool RMDEV_SYS_int2fHandler()
 			reg_ax = 100; // can't touch this
 			return true;
 		case 0x0012: // query MPEG left volume
-			reg_ax = GetMixerVolume(reelmagic_channel_name, false);
+			reg_ax = GetMixerVolume(ChannelName::ReelMagic, false);
 			return true;
 		case 0x0013: // query MPEG right volume
-			reg_ax = GetMixerVolume(reelmagic_channel_name, true);
+			reg_ax = GetMixerVolume(ChannelName::ReelMagic, true);
 			return true;
 		case 0x0014: // query SYNT left volume
-			reg_ax = GetMixerVolume("OPL", false);
+			reg_ax = GetMixerVolume(ChannelName::Opl, false);
 			return true;
 		case 0x0015: // query SYNT right volume
-			reg_ax = GetMixerVolume("OPL", true);
+			reg_ax = GetMixerVolume(ChannelName::Opl, true);
 			return true;
 		case 0x0016: // query PCM left volume
-			reg_ax = GetMixerVolume("SB", false);
+			reg_ax = GetMixerVolume(ChannelName::SoundBlasterDac, false);
 			return true;
 		case 0x0017: // query PCM right volume
-			reg_ax = GetMixerVolume("SB", true);
+			reg_ax = GetMixerVolume(ChannelName::SoundBlasterDac, true);
 			return true;
 		case 0x001C: // query CD left volume
-			reg_ax = GetMixerVolume("CDAUDIO", false);
+			reg_ax = GetMixerVolume(ChannelName::CdAudio, false);
 			return true;
 		case 0x001D: // query CD right volume
-			reg_ax = GetMixerVolume("CDAUDIO", true);
+			reg_ax = GetMixerVolume(ChannelName::CdAudio, true);
 			return true;
 		}
 		break;
@@ -1266,28 +1267,28 @@ static bool RMDEV_SYS_int2fHandler()
 			LOG(LOG_REELMAGIC, LOG_ERROR)("RMDEV.SYS: Can't update MAIN Right Volume");
 			return true;
 		case 0x0012: // set MPEG left volume
-			SetMixerVolume(reelmagic_channel_name, reg_dx, false);
+			SetMixerVolume(ChannelName::ReelMagic, reg_dx, false);
 			return true;
 		case 0x0013: // set MPEG right volume
-			SetMixerVolume(reelmagic_channel_name, reg_dx, true);
+			SetMixerVolume(ChannelName::ReelMagic, reg_dx, true);
 			return true;
 		case 0x0014: // set SYNT left volume
-			SetMixerVolume("OPL", reg_dx, false);
+			SetMixerVolume(ChannelName::Opl, reg_dx, false);
 			return true;
 		case 0x0015: // set SYNT right volume
-			SetMixerVolume("OPL", reg_dx, true);
+			SetMixerVolume(ChannelName::Opl, reg_dx, true);
 			return true;
 		case 0x0016: // set PCM left volume
-			SetMixerVolume("SB", reg_dx, false);
+			SetMixerVolume(ChannelName::SoundBlasterDac, reg_dx, false);
 			return true;
 		case 0x0017: // set PCM right volume
-			SetMixerVolume("SB", reg_dx, true);
+			SetMixerVolume(ChannelName::SoundBlasterDac, reg_dx, true);
 			return true;
 		case 0x001C: // set CD left volume
-			SetMixerVolume("CDAUDIO", reg_dx, false);
+			SetMixerVolume(ChannelName::CdAudio, reg_dx, false);
 			return true;
 		case 0x001D: // set CD right volume
-			SetMixerVolume("CDAUDIO", reg_dx, true);
+			SetMixerVolume(ChannelName::CdAudio, reg_dx, true);
 			return true;
 		}
 		break;

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 
+#include "channel_names.h"
 #include "dos_system.h"
 #include "logging.h"
 #include "mixer.h"
@@ -788,7 +789,7 @@ void ReelMagic_EnableAudioChannel(const bool should_enable)
 
 	mixer_channel = MIXER_AddChannel(&RMMixerChannelCallback,
 	                                 use_mixer_rate,
-	                                 reelmagic_channel_name,
+	                                 ChannelName::ReelMagic,
 	                                 {// ChannelFeature::Sleep,
 	                                  ChannelFeature::Stereo,
 	                                  // ChannelFeature::ReverbSend,

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1649,18 +1649,18 @@ static void CTMIXER_UpdateVolumes() {
 	float m1 = calc_vol(sb.mixer.master[1]);
 	auto chan = MIXER_FindChannel("SB");
 	if (chan) {
-		chan->SetAppVolume(m0 * calc_vol(sb.mixer.dac[0]),
-		                   m1 * calc_vol(sb.mixer.dac[1]));
+		chan->SetAppVolume({m0 * calc_vol(sb.mixer.dac[0]),
+		                    m1 * calc_vol(sb.mixer.dac[1])});
 	}
 	chan = MIXER_FindChannel("OPL");
 	if (chan) {
-		chan->SetAppVolume(m0 * calc_vol(sb.mixer.fm[0]),
-		                   m1 * calc_vol(sb.mixer.fm[1]));
+		chan->SetAppVolume({m0 * calc_vol(sb.mixer.fm[0]),
+		                    m1 * calc_vol(sb.mixer.fm[1])});
 	}
 	chan = MIXER_FindChannel("CDAUDIO");
 	if (chan) {
-		chan->SetAppVolume(m0 * calc_vol(sb.mixer.cda[0]),
-		                   m1 * calc_vol(sb.mixer.cda[1]));
+		chan->SetAppVolume({m0 * calc_vol(sb.mixer.cda[0]),
+		                    m1 * calc_vol(sb.mixer.cda[1])});
 	}
 }
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -27,6 +27,7 @@
 #include <tuple>
 
 #include "autoexec.h"
+#include "channel_names.h"
 #include "control.h"
 #include "dma.h"
 #include "hardware.h"
@@ -550,7 +551,7 @@ static void configure_opl_filter(mixer_channel_t channel,
 	case FilterType::SBPro2: enable_lpf(1, 8000); break;
 	}
 
-	log_filter_config("OPL", *filter_type);
+	log_filter_config(ChannelName::Opl, *filter_type);
 	set_filter(channel, config);
 }
 
@@ -1647,17 +1648,17 @@ static void CTMIXER_UpdateVolumes() {
 
 	float m0 = calc_vol(sb.mixer.master[0]);
 	float m1 = calc_vol(sb.mixer.master[1]);
-	auto chan = MIXER_FindChannel("SB");
+	auto chan = MIXER_FindChannel(ChannelName::SoundBlasterDac);
 	if (chan) {
 		chan->SetAppVolume({m0 * calc_vol(sb.mixer.dac[0]),
 		                    m1 * calc_vol(sb.mixer.dac[1])});
 	}
-	chan = MIXER_FindChannel("OPL");
+	chan = MIXER_FindChannel(ChannelName::Opl);
 	if (chan) {
 		chan->SetAppVolume({m0 * calc_vol(sb.mixer.fm[0]),
 		                    m1 * calc_vol(sb.mixer.fm[1])});
 	}
-	chan = MIXER_FindChannel("CDAUDIO");
+	chan = MIXER_FindChannel(ChannelName::CdAudio);
 	if (chan) {
 		chan->SetAppVolume({m0 * calc_vol(sb.mixer.cda[0]),
 		                    m1 * calc_vol(sb.mixer.cda[1])});
@@ -2206,7 +2207,7 @@ public:
 		case OplMode::Opl3:
 		case OplMode::Opl3Gold: {
 			OPL_Init(section, oplmode);
-			auto opl_channel = MIXER_FindChannel("OPL");
+			auto opl_channel = MIXER_FindChannel(ChannelName::Opl);
 			assert(opl_channel);
 
 			const std::string opl_filter_prefs = section->Get_string(
@@ -2245,7 +2246,7 @@ public:
 
 		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack,
 		                           default_playback_rate_hz,
-		                           "SB",
+		                           ChannelName::SoundBlasterDac,
 		                           channel_features);
 
 		const std::string sb_filter_prefs = section->Get_string("sb_filter");

--- a/src/hardware/ston1_dac.h
+++ b/src/hardware/ston1_dac.h
@@ -21,13 +21,18 @@
 
 #include "dosbox.h"
 
+#include "channel_names.h"
 #include "inout.h"
 #include "lpt_dac.h"
 #include "mixer.h"
 
 class StereoOn1 final : public LptDac {
 public:
-	StereoOn1() : LptDac("STON1", ston1_max_30_khz, {ChannelFeature::Stereo}){}
+	StereoOn1()
+	        : LptDac(ChannelName::StereoOn1Dac, ston1_max_30_khz,
+	                 {ChannelFeature::Stereo})
+	{}
+
 	void BindToPort(const io_port_t lpt_port) final;
 	void ConfigureFilters(const FilterState state) final;
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -332,7 +332,7 @@ void TandyDAC::ChangeMode()
 			channel->FillUp(); // using the prior frequency
 			channel->SetSampleRate(freq);
 			const auto vol = static_cast<float>(regs.amplitude) / 7.0f;
-			channel->SetAppVolume(vol, vol);
+			channel->SetAppVolume({vol, vol});
 			if ((regs.mode & 0x0c) == 0x0c) {
 				dma.is_done = false;
 				dma.channel = DMA_GetChannel(io.dma);

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -82,11 +82,12 @@ centerline.
 #include <queue>
 #include <string_view>
 
+#include "channel_names.h"
 #include "dma.h"
 #include "hardware.h"
 #include "inout.h"
-#include "mem.h"
 #include "math_utils.h"
+#include "mem.h"
 #include "mixer.h"
 #include "pic.h"
 #include "setup.h"
@@ -225,7 +226,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 
 	channel = MIXER_AddChannel(callback,
 	                           use_mixer_rate,
-	                           "TANDYDAC",
+	                           ChannelName::TandyDac,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ChorusSend,
 	                            ChannelFeature::ReverbSend,
@@ -478,7 +479,7 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 
 	channel = MIXER_AddChannel(callback,
 	                           use_mixer_rate,
-	                           "TANDY",
+	                           ChannelName::TandyPsg,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::ChorusSend,

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -31,6 +31,7 @@
 
 #include "../ints/int10.h"
 #include "ansi_code_markup.h"
+#include "channel_names.h"
 #include "control.h"
 #include "cross.h"
 #include "fs_utils.h"
@@ -496,7 +497,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,
 	                                      audio_frame_rate_hz,
-	                                      "FSYNTH",
+	                                      ChannelName::FluidSynth,
 	                                      {ChannelFeature::Sleep,
 	                                       ChannelFeature::Stereo,
 	                                       ChannelFeature::ReverbSend,

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -34,6 +34,7 @@
 
 #include "../ints/int10.h"
 #include "ansi_code_markup.h"
+#include "channel_names.h"
 #include "control.h"
 #include "cross.h"
 #include "fs_utils.h"
@@ -793,7 +794,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,
 	                                      sample_rate_hz,
-	                                      "MT32",
+	                                      ChannelName::RolandMt32,
 	                                      {ChannelFeature::Sleep,
 	                                       ChannelFeature::Stereo,
 	                                       ChannelFeature::Synthesizer});

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -183,7 +183,7 @@ static std::optional<FatAttributeFlags> xattr_to_fat_attribs(const std::string& 
 
 	if (xattr.size() <= XattrMaxLength && starts_with(xattr, "0x") &&
 	    xattr.size() >= XattrMinLength) {
-		const auto value = to_int(xattr.substr(2), HexBase);
+		const auto value = parse_int(xattr.substr(2), HexBase);
 		if (value) {
 			return *value & XattrReadMask;
 		}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -386,8 +386,11 @@ void CONFIG::Run(void)
 				for (size_t i = 0; i < pvars.size(); i++) {
 					restart_params.push_back(pvars[i]);
 				}
-				// the rest on the commandline, too
-				cmd->FillVector(restart_params);
+				const auto remaining_args = cmd->GetArguments();
+				restart_params.insert(restart_params.end(),
+				                      remaining_args.begin(),
+				                      remaining_args.end());
+
 				restart_program(restart_params);
 			}
 			return;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -873,6 +873,17 @@ std::string Section_prop::Get_string(const std::string& _propname) const
 	return "";
 }
 
+Prop_bool* Section_prop::GetBoolProp(const std::string& propname) const
+{
+	for (const auto property : properties) {
+		if (property->propname == propname) {
+			return dynamic_cast<Prop_bool*>(property);
+		}
+	}
+	return nullptr;
+}
+
+
 Prop_string* Section_prop::GetStringProp(const std::string& propname) const
 {
 	for (const auto property : properties) {

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -28,8 +28,9 @@
 bool is_hex_digits(const std::string_view s) noexcept
 {
 	for (const auto ch : s) {
-		if (!isxdigit(ch))
+		if (!isxdigit(ch)) {
 			return false;
+		}
 	}
 	return true;
 }
@@ -338,55 +339,55 @@ void clear_language_if_default(std::string &l)
 	}
 }
 
-std::optional<float> parse_value(const std::string_view s,
-                                 const float min_value, const float max_value)
+std::optional<float> parse_float(const std::string& s)
 {
-	// parse_value can check if a string holds a number (or not), so we expect
-	// exceptions and return an empty result to indicate conversion status.
+	// parse_float can check if a string holds a number (or not), so we
+	// expect exceptions and return an empty result to indicate conversion
+	// status.
 	try {
 		if (!s.empty()) {
-			return std::clamp(std::stof(s.data()), min_value, max_value);
+			size_t num_chars_processed = 0;
+			const auto number = std::stof(s, &num_chars_processed);
+			if (s.size() == num_chars_processed) {
+				return number;
+			}
 		}
 		// Note: stof can throw invalid_argument and out_of_range
-	} catch (const std::invalid_argument &) {
+	} catch (const std::invalid_argument&) {
 		// do nothing, we expect these
-	} catch (const std::out_of_range &) {
+	} catch (const std::out_of_range&) {
 		// do nothing, we expect these
 	}
-	return {}; // empty
+	return {};
 }
 
-std::optional<float> parse_percentage(const std::string_view s)
-{
-	constexpr auto min_percentage = 0.0f;
-	constexpr auto max_percentage = 100.0f;
-	return parse_value(s, min_percentage, max_percentage);
-}
-
-std::optional<float> parse_prefixed_value(const char prefix, const std::string &s,
-                                          const float min_value, const float max_value)
-{
-	if (s.size() <= 1 || !ciequals(s[0], prefix))
-		return {};
-
-	return parse_value(s.substr(1), min_value, max_value);
-}
-
-std::optional<float> parse_prefixed_percentage(const char prefix, const std::string &s)
-{
-	constexpr auto min_percentage = 0.0f;
-	constexpr auto max_percentage = 100.0f;
-	return parse_prefixed_value(prefix, s, min_percentage, max_percentage);
-}
-
-std::optional<int> to_int(const std::string& value, const int base)
+std::optional<int> parse_int(const std::string& s, const int base)
 {
 	try {
-		// Do not store number of characters processed
-		constexpr std::size_t* pos = nullptr;
-
-		return std::stoi(value, pos, base);
-	} catch (...) {
-		return {};
+		if (!s.empty()) {
+			size_t num_chars_processed = 0;
+			const auto number = std::stoi(s, &num_chars_processed, base);
+			if (s.size() == num_chars_processed) {
+				return number;
+			}
+		}
+		// Note: stof can throw invalid_argument and out_of_range
+	} catch (const std::invalid_argument&) {
+		// do nothing, we expect these
+	} catch (const std::out_of_range&) {
+		// do nothing, we expect these
 	}
+	return {};
+}
+
+std::optional<float> parse_percentage(const std::string& s)
+{
+	constexpr auto min_percentage = 0.0f;
+	constexpr auto max_percentage = 100.0f;
+	if (const auto p = parse_float(s); p) {
+		if (*p >= min_percentage && *p <= max_percentage) {
+			return p;
+		}
+	}
+	return {};
 }

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -242,19 +242,21 @@ unsigned int CommandLine::GetCount(void)
 	return (unsigned int)cmds.size();
 }
 
-void CommandLine::FillVector(std::vector<std::string>& vector)
+std::vector<std::string> CommandLine::GetArguments()
 {
-	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
-		vector.push_back((*it));
+	std::vector<std::string> args;
+	for (const auto& cmd : cmds) {
+		args.emplace_back(cmd);
 	}
 #ifdef WIN32
 	// Add back the \" if the parameter contained a space
-	for (Bitu i = 0; i < vector.size(); i++) {
-		if (vector[i].find(' ') != std::string::npos) {
-			vector[i] = "\"" + vector[i] + "\"";
+	for (auto& arg : args) {
+		if (arg.find(' ') != std::string::npos) {
+			arg = "\"" + arg + "\"";
 		}
 	}
 #endif
+	return args;
 }
 
 int CommandLine::GetParameterFromList(const char* const params[],

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -453,5 +453,5 @@ std::optional<std::vector<std::string>> CommandLine::FindRemoveOptionalArgument(
 
 std::optional<int> CommandLine::FindRemoveIntArgument(const std::string& name)
 {
-	return to_int(FindRemoveStringArgument(name));
+	return parse_int(FindRemoveStringArgument(name));
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -63,6 +63,20 @@ test(
     is_parallel: false,
 )
 
+program_mixer = executable(
+    'program_mixer',
+    ['program_mixer_tests.cpp'],
+    dependencies: [gmock_dep, dosbox_dep, libiir_dep],
+    include_directories: incdir,
+    cpp_args: cpp_args,
+)
+test(
+    'gtest program_mixer',
+    program_mixer,
+    workdir: project_source_root,
+    is_parallel: false,
+)
+
 # other unit tests
 
 unit_tests = [

--- a/tests/program_mixer_tests.cpp
+++ b/tests/program_mixer_tests.cpp
@@ -1,0 +1,648 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "../src/dos/program_mixer.h"
+#include "channel_names.h"
+
+#include <gtest/gtest.h>
+
+using namespace MixerCommand;
+
+const auto Minus6Db = powf(10.0f, -6.0f / 20.0f); // ≈ 0.5012 ≈ 0.5
+const auto Plus12Db = powf(10.0f, 12.0f / 20.0f); // ≈ 3.9811 ≈ 2.0
+
+static ChannelInfos create_channel_infos()
+{
+	ChannelInfosMap infos = {};
+
+	infos["SB"] = {ChannelFeature::Stereo,
+	               ChannelFeature::ReverbSend,
+	               ChannelFeature::ChorusSend};
+
+	// Mono channel
+	infos["OPL"] = {ChannelFeature::ReverbSend, ChannelFeature::ChorusSend};
+
+	// Mono channel
+	infos["PCSPEAKER"] = {ChannelFeature::ReverbSend, ChannelFeature::ChorusSend};
+
+	// Stereo channel with no reverb & chorus support
+	infos["MT32"] = {ChannelFeature::Stereo};
+
+	return ChannelInfos(infos);
+}
+
+static ChannelInfos channel_infos = create_channel_infos();
+
+static void assert_success(const std::vector<std::string>& args,
+                           const std::queue<Command>& expected)
+{
+	const auto result = ParseCommands(args, channel_infos, AllChannelNames);
+
+	if (auto error = std::get_if<Error>(&result); error) {
+		printf("*** TEST FAILED: ");
+		printf(error->message.c_str());
+		printf("\n");
+		FAIL();
+	} else {
+		auto actual = std::get<std::queue<MixerCommand::Command>>(result);
+		EXPECT_EQ(actual, expected);
+	}
+}
+
+static void assert_failure(const std::vector<std::string>& args,
+                           const ErrorType expected_error_type)
+{
+	const auto result = ParseCommands(args, channel_infos, AllChannelNames);
+
+	if (auto error = std::get_if<Error>(&result); error) {
+		LOG_WARNING(error->message.c_str());
+		EXPECT_EQ(error->type, expected_error_type);
+	} else {
+		printf("*** TEST FAILED: No error reported");
+		FAIL();
+	}
+}
+
+static std::queue<Command> select_sb_channel()
+{
+	std::queue<Command> cmd = {};
+	cmd.emplace(SelectChannel{GlobalVirtualChannelName});
+	cmd.emplace(SelectChannel{"SB"});
+	return cmd;
+}
+
+static std::queue<Command> select_pcspeaker_channel()
+{
+	std::queue<Command> cmd = {};
+	cmd.emplace(SelectChannel{GlobalVirtualChannelName});
+	cmd.emplace(SelectChannel{"PCSPEAKER"});
+	return cmd;
+}
+
+// ************************************************************************
+// SUCCESS CASES
+// ************************************************************************
+//
+// Global
+TEST(ProgramMixer, Global_SetReverbLevel)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SetReverbLevel{0.2f});
+
+	assert_success({"r20"}, expected);
+}
+
+TEST(ProgramMixer, Global_SetChorusLevel)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SetChorusLevel{0.2f});
+
+	assert_success({"c20"}, expected);
+}
+
+TEST(ProgramMixer, Global_SetCrossfeedStrength_StereoChannel)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SetCrossfeedStrength{0.2f});
+
+	assert_success({"x20"}, expected);
+}
+
+TEST(ProgramMixer, Global_SetAllValid)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SetReverbLevel{0.2f});
+	expected.emplace(SetChorusLevel{0.1f});
+	expected.emplace(SetCrossfeedStrength{0.3f});
+
+	assert_success({"r20", "c10", "x30"}, expected);
+}
+
+TEST(ProgramMixer, Global_SetAllValidMultiple)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SetCrossfeedStrength{0.07f});
+	expected.emplace(SetReverbLevel{0.08f});
+	expected.emplace(SetCrossfeedStrength{0.30f});
+	expected.emplace(SetChorusLevel{0.09f});
+	expected.emplace(SetReverbLevel{0.20f});
+	expected.emplace(SetCrossfeedStrength{0.10f});
+
+	assert_success({"x7", "r8", "x30", "c9", "r20", "x10"}, expected);
+}
+
+// Master
+TEST(ProgramMixer, Master_SetVolume)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SelectChannel{ChannelName::Master});
+	expected.emplace(SetVolume{AudioFrame(0.2f, 0.2f)});
+
+	assert_success({"master", "20"}, expected);
+}
+
+TEST(ProgramMixer, Master_SetVolumeMultiple)
+{
+	std::queue<Command> expected = {};
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SelectChannel{ChannelName::Master});
+	expected.emplace(SetVolume{AudioFrame(0.1f, 0.1f)});
+	expected.emplace(SetVolume{AudioFrame(0.2f, 0.2f)});
+
+	assert_success({"master", "10", "20"}, expected);
+}
+
+// Channel
+TEST(ProgramMixer, Channel_SetVolumePercentMinLimit)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(0.0f, 0.0f)});
+
+	assert_success({"sb", "0"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumePercentMaxLimit)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(99.99f, 99.99f)});
+
+	assert_success({"sb", "9999"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumePercentSingle)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(0.2f, 0.2f)});
+
+	assert_success({"sb", "20"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumePercentSinglePlus)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(0.2f, 0.2f)});
+
+	assert_success({"sb", "+20"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumePercentStereo)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(0.2f, 1.5f)});
+
+	assert_success({"sb", "20:150"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumeDecibelMinLimit)
+{
+	const auto Minus96Db = powf(10.0f, -96.0f / 20.0f); // ≈ 0.0
+
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(Minus96Db, Minus96Db)});
+
+	assert_success({"sb", "d-96"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumeDecibelMaxLimit)
+{
+	const auto Plus40Db = 99.99f;
+
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(Plus40Db, Plus40Db)});
+
+	assert_success({"sb", "d40"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumeDecibelSingle)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(Minus6Db, Minus6Db)});
+
+	assert_success({"sb", "d-6"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumeDecibelSinglePlus)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(Plus12Db, Plus12Db)});
+
+	assert_success({"sb", "d+12"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumeDecibelStereo)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(Minus6Db, Plus12Db)});
+
+	assert_success({"sb", "d-6:d12"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumeDecibelPercentStereo)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(Minus6Db, 1.23f)});
+
+	assert_success({"sb", "d-6:123"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetVolumePercentDecibelStereo)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetVolume{AudioFrame(0.4f, Plus12Db)});
+
+	assert_success({"sb", "40:d12"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetStereoModeStereo)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetStereoMode{Stereo});
+
+	assert_success({"sb", "stereo"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetStereoModeReverse)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetStereoMode{Reverse});
+
+	assert_success({"sb", "reverse"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetCrossfeedStrength)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetCrossfeedStrength{0.1f});
+
+	assert_success({"sb", "x10"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetCrossfeedStrengthLimits)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetCrossfeedStrength{0.0f});
+	expected.emplace(SetCrossfeedStrength{1.0f});
+
+	assert_success({"sb", "x0", "x100"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetReverbLevel_StereoChannel)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetReverbLevel{0.2f});
+
+	assert_success({"sb", "r20"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetReverbLevel_MonoChannel)
+{
+	auto expected = select_pcspeaker_channel();
+	expected.emplace(SetReverbLevel{0.2f});
+
+	assert_success({"pcspeaker", "r20"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetReverbLevelLimits)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetReverbLevel{0.0f});
+	expected.emplace(SetReverbLevel{1.0f});
+
+	assert_success({"sb", "r0", "r100"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetChorusLevel_StereoChannel)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetChorusLevel{0.2f});
+
+	assert_success({"sb", "c20"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetChorusLevel_MonoChannel)
+{
+	auto expected = select_pcspeaker_channel();
+	expected.emplace(SetChorusLevel{0.2f});
+
+	assert_success({"pcspeaker", "c20"}, expected);
+}
+
+TEST(ProgramMixer, Channel_SetChorusLevelLimits)
+{
+	auto expected = select_sb_channel();
+	expected.emplace(SetChorusLevel{0.0f});
+	expected.emplace(SetChorusLevel{1.0f});
+
+	assert_success({"sb", "c0", "c100"}, expected);
+}
+
+TEST(ProgramMixer, AllCommands)
+{
+	std::queue<Command> expected = {};
+	// Global
+	expected.emplace(SelectChannel{GlobalVirtualChannelName});
+	expected.emplace(SetCrossfeedStrength{0.07f});
+	expected.emplace(SetReverbLevel{0.08f});
+	expected.emplace(SetChorusLevel{0.30f});
+	// MASTER
+	expected.emplace(SelectChannel{ChannelName::Master});
+	expected.emplace(SetVolume{AudioFrame(0.1f, Minus6Db)});
+	// SB
+	expected.emplace(SelectChannel{"SB"});
+	expected.emplace(SetChorusLevel{0.09f});
+	expected.emplace(SetReverbLevel{0.20f});
+	expected.emplace(SetStereoMode{Reverse});
+	expected.emplace(SetCrossfeedStrength{0.10f});
+	expected.emplace(SetVolume{AudioFrame(0.20f, 0.20f)});
+
+	assert_success({"x7", "r8", "c30", "master", "10:d-6", "sb", "c9", "r20", "reverse", "x10", "20"},
+	               expected);
+}
+
+// ************************************************************************
+// FAILURE CASES
+// ************************************************************************
+//
+// Global commands
+TEST(ProgramMixer, Global_InvalidSetVolumeCommand)
+{
+	assert_failure({"10"}, ErrorType::InvalidGlobalCommand);
+}
+
+TEST(ProgramMixer, Global_InvalidSetStereoModeCommand)
+{
+	assert_failure({"stereo"}, ErrorType::InvalidGlobalCommand);
+}
+
+TEST(ProgramMixer, Global_InvalidCommand)
+{
+	assert_failure({"asdf"}, ErrorType::InvalidGlobalCommand);
+}
+
+TEST(ProgramMixer, Global_InactiveChannel)
+{
+	assert_failure({"gus"}, ErrorType::InactiveChannel);
+}
+
+// Master commands
+TEST(ProgramMixer, Master_MissingCommand)
+{
+	assert_failure({"master"}, ErrorType::MissingChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InvalidSetStereoModeCommand)
+{
+	assert_failure({"master", "stereo"}, ErrorType::InvalidChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InvalidSetReverbCommand)
+{
+	assert_failure({"master", "r20"}, ErrorType::InvalidMasterChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InvalidSetChorusLevelCommand)
+{
+	assert_failure({"master", "c20"}, ErrorType::InvalidMasterChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InvalidSetCrossfeedStrengthCommand)
+{
+	assert_failure({"master", "x20"}, ErrorType::InvalidMasterChannelCommand);
+}
+
+TEST(ProgramMixer, Master_MissingCommandBeforeChannelCommand)
+{
+	// "gus" is a valid channel name
+	assert_failure({"master", "opl"}, ErrorType::MissingChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InvalidCommand)
+{
+	// "asdf" is not valid channel name
+	assert_failure({"master", "asdf"}, ErrorType::InvalidMasterChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InvalidSingleLetterCommand)
+{
+	// valid command prefixes
+	assert_failure({"master", "x"}, ErrorType::InvalidMasterChannelCommand);
+	assert_failure({"master", "r"}, ErrorType::InvalidMasterChannelCommand);
+	assert_failure({"master", "c"}, ErrorType::InvalidMasterChannelCommand);
+
+	assert_failure({"master", "."}, ErrorType::InvalidMasterChannelCommand);
+	assert_failure({"master", "$"}, ErrorType::InvalidMasterChannelCommand);
+	assert_failure({"master", "w"}, ErrorType::InvalidMasterChannelCommand);
+}
+
+TEST(ProgramMixer, Master_InactiveChannel)
+{
+	assert_failure({"master", "10", "gus"}, ErrorType::InactiveChannel);
+}
+
+// Channel commands
+TEST(ProgramMixer, Channel_InactiveChannel)
+{
+	assert_failure({"sb", "10", "gus"}, ErrorType::InactiveChannel);
+}
+
+// Set stereo mode
+TEST(ProgramMixer, SetStereoModeReverse_InvalidForMonoChannel)
+{
+	assert_failure({"pcspeaker", "reverse"}, ErrorType::InvalidChannelCommand);
+}
+
+// Set volume
+TEST(ProgramMixer, SetVolume_InvalidPercentVolume_Over)
+{
+	assert_failure({"sb", "10000"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidPercentVolume_Negative)
+{
+	assert_failure({"sb", "-1"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidPercentVolume_ExtraLetters)
+{
+	assert_failure({"sb", "50ab"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidDecibelVolume_Over)
+{
+	assert_failure({"sb", "d40.1"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidDecibelVolume_Under)
+{
+	assert_failure({"sb", "d-96.1"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidDecibelVolume_ExtraLetters)
+{
+	assert_failure({"sb", "d6ab"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidStereoVolume_RightMissing)
+{
+	assert_failure({"sb", "10:"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidStereoVolume_LeftMissing)
+{
+	assert_failure({"sb", ":10"}, ErrorType::InvalidChannelCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidStereoVolume_LeftInvalid)
+{
+	assert_failure({"sb", "10a:20"}, ErrorType::InvalidVolumeCommand);
+}
+
+TEST(ProgramMixer, SetVolume_InvalidStereoVolume_RightInvalid)
+{
+	assert_failure({"sb", "10:20a"}, ErrorType::InvalidVolumeCommand);
+}
+
+// Set crossfeed strength
+//
+TEST(ProgramMixer, SetCrossfeedStrength_MissingStrength_Channel)
+{
+	assert_failure({"sb", "x"}, ErrorType::MissingCrossfeedStrength);
+}
+
+TEST(ProgramMixer, SetCrossfeedStrength_MissingStrength_Global)
+{
+	assert_failure({"x"}, ErrorType::MissingCrossfeedStrength);
+}
+
+TEST(ProgramMixer, SetCrossfeedStrength_InvalidStrength_Over)
+{
+	assert_failure({"sb", "x101"}, ErrorType::InvalidCrossfeedStrength);
+}
+
+TEST(ProgramMixer, SetCrossfeedStrength_InvalidStrength_Under)
+{
+	assert_failure({"sb", "x-1"}, ErrorType::InvalidCrossfeedStrength);
+}
+
+TEST(ProgramMixer, SetCrossfeedStrength_InvalidStrength_Global)
+{
+	assert_failure({"x-1"}, ErrorType::InvalidGlobalCrossfeedStrength);
+}
+
+TEST(ProgramMixer, SetCrossfeedStrength_InvalidStrength_ExtraLetters)
+{
+	assert_failure({"sb", "x50f"}, ErrorType::InvalidCrossfeedStrength);
+}
+
+TEST(ProgramMixer, SetCrossfeedStrength_InvalidForMonoChannel)
+{
+	assert_failure({"pcspeaker", "x30"}, ErrorType::InvalidChannelCommand);
+}
+
+// Set chorus level
+//
+TEST(ProgramMixer, SetChorusLevel_ChorusNotSupported_MissingLevel)
+{
+	assert_failure({"mt32", "c"}, ErrorType::InvalidChannelCommand);
+}
+
+TEST(ProgramMixer, SetChorusLevel_ChorusNotSupported)
+{
+	assert_failure({"mt32", "c20"}, ErrorType::InvalidChannelCommand);
+}
+
+TEST(ProgramMixer, SetChorusLevel_MissingLevel_Channel)
+{
+	assert_failure({"sb", "c"}, ErrorType::MissingChorusLevel);
+}
+
+TEST(ProgramMixer, SetChorusLevel_MissingLevel_Global)
+{
+	assert_failure({"c"}, ErrorType::MissingChorusLevel);
+}
+
+TEST(ProgramMixer, SetChorusLevel_InvalidLevel_Over)
+{
+	assert_failure({"sb", "c101"}, ErrorType::InvalidChorusLevel);
+}
+
+TEST(ProgramMixer, SetChorusLevel_InvalidLevel_Under)
+{
+	assert_failure({"sb", "c-1"}, ErrorType::InvalidChorusLevel);
+}
+
+TEST(ProgramMixer, SetChorusLevel_InvalidLevel_Global)
+{
+	assert_failure({"c-1"}, ErrorType::InvalidGlobalChorusLevel);
+}
+
+TEST(ProgramMixer, SetChorusLevel_InvalidLevel_ExtraLetters)
+{
+	assert_failure({"sb", "c50f"}, ErrorType::InvalidChorusLevel);
+}
+
+// Set reverb level
+//
+TEST(ProgramMixer, SetReverbLevel_ReverbNotSupported_MissingLevel)
+{
+	assert_failure({"mt32", "r"}, ErrorType::InvalidChannelCommand);
+}
+
+TEST(ProgramMixer, SetReverbLevel_ReverbNotSupported)
+{
+	assert_failure({"mt32", "r20"}, ErrorType::InvalidChannelCommand);
+}
+
+TEST(ProgramMixer, SetReverbLevel_MissingLevel_Channel)
+{
+	assert_failure({"sb", "r"}, ErrorType::MissingReverbLevel);
+}
+
+TEST(ProgramMixer, SetReverbLevel_MissingLevel_Global)
+{
+	assert_failure({"r"}, ErrorType::MissingReverbLevel);
+}
+
+TEST(ProgramMixer, SetReverbLevel_InvalidLevel_Over)
+{
+	assert_failure({"sb", "r101"}, ErrorType::InvalidReverbLevel);
+}
+
+TEST(ProgramMixer, SetReverbLevel_InvalidLevel_Under)
+{
+	assert_failure({"sb", "r-1"}, ErrorType::InvalidReverbLevel);
+}
+
+TEST(ProgramMixer, SetReverbLevel_InvalidLevel_Global)
+{
+	assert_failure({"r-1"}, ErrorType::InvalidGlobalReverbLevel);
+}
+
+TEST(ProgramMixer, SetReverbLevel_InvalidLevel_ExtraLetters)
+{
+	assert_failure({"sb", "r50f"}, ErrorType::InvalidReverbLevel);
+}
+

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -363,78 +363,78 @@ TEST(Split, Empty)
 	EXPECT_EQ(split("   "), empty);
 }
 
-TEST(ParseValue, Valid)
+TEST(ParseFloat, Valid)
 {
 	// negatives
-	EXPECT_EQ(*parse_value("-10000", -11000, 0), -10000.0f);
-	EXPECT_EQ(*parse_value("-0.1", -1, 0), -0.1f);
-	EXPECT_EQ(*parse_value("-0.0001", -1, 0), -0.0001f);
-	EXPECT_EQ(*parse_value("-0.0", -1, 1), -0.0f);
-	EXPECT_EQ(*parse_value("0", -1, 1), 0.0f);
+	EXPECT_EQ(*parse_float("-10000"), -10000.0f);
+	EXPECT_EQ(*parse_float("-0.1"), -0.1f);
+	EXPECT_EQ(*parse_float("-0.0001"), -0.0001f);
+	EXPECT_EQ(*parse_float("-0.0"), 0.0f);
+	EXPECT_EQ(*parse_float("-0"), 0.0f);
 
 	// positives
-	EXPECT_EQ(*parse_value("0.0", -1, 1), 0.0f);
-	EXPECT_EQ(*parse_value("0.0001", -1, 1), 0.0001f);
-	EXPECT_EQ(*parse_value("0.1", -1, 1), 0.1f);
-	EXPECT_EQ(*parse_value("10000", 0, 11000), 10000.0f);
+	EXPECT_EQ(*parse_float("10000"), 10000.0f);
+	EXPECT_EQ(*parse_float("0.1"), 0.1f);
+	EXPECT_EQ(*parse_float("0.0001"), 0.0001f);
+	EXPECT_EQ(*parse_float("0.0"), 0.0f);
+	EXPECT_EQ(*parse_float("0"), 0.0f);
+}
+
+TEST(ParseFloat, Invalid)
+{
+	std::optional<float> empty = {};
+	EXPECT_EQ(parse_float("100a"), empty);
+	EXPECT_EQ(parse_float("sfafsd"), empty);
+	EXPECT_EQ(parse_float(""), empty);
+	EXPECT_EQ(parse_float(" "), empty);
+}
+
+TEST(ParseInt, Valid)
+{
+	// negatives
+	EXPECT_EQ(*parse_float("-10000"), -10000);
+	EXPECT_EQ(*parse_float("-0"), 0);
+	EXPECT_EQ(*parse_float("-1"), -1);
+
+	// positives
+	EXPECT_EQ(*parse_int("10000"), 10000);
+	EXPECT_EQ(*parse_int("0"), 0);
+	EXPECT_EQ(*parse_int("1"), 1);
+}
+
+TEST(ParseInt, Invalid)
+{
+	std::optional<int> empty = {};
+	EXPECT_EQ(parse_int("100a"), empty);
+	EXPECT_EQ(parse_int("sfafsd"), empty);
+	EXPECT_EQ(parse_int(""), empty);
+	EXPECT_EQ(parse_int(" "), empty);
 }
 
 TEST(ParsePercentage, Valid)
 {
-	EXPECT_EQ(*parse_percentage("-100"), 0.0f);
-	EXPECT_EQ(*parse_percentage("0"), 0.0f);
-	EXPECT_EQ(*parse_percentage("1"), 1.0f);
-	EXPECT_EQ(*parse_percentage("50"), 50.0f);
-	EXPECT_EQ(*parse_percentage("100"), 100.0f);
-	EXPECT_EQ(*parse_percentage("1000"), 100.0f);
+	EXPECT_EQ(parse_percentage("0"), 0.0f);
+	EXPECT_EQ(parse_percentage("0.0"), 0.0f);
+	EXPECT_EQ(parse_percentage("-0.0"), 0.0f);
+	EXPECT_EQ(parse_percentage("1"), 1.0f);
+	EXPECT_EQ(parse_percentage("5.0"), 5.0f);
+	EXPECT_EQ(parse_percentage("0.00001"), 0.00001f);
+	EXPECT_EQ(parse_percentage("99.9999"), 99.9999f);
+	EXPECT_EQ(parse_percentage("100"), 100.0f);
 }
 
-TEST(ParseBoth, Invalid)
+TEST(ParsePercentage, Invalid)
 {
-	std::optional<float> empty = {};
-	EXPECT_EQ(parse_value("sfafsd", 0, 1), empty);
-	EXPECT_EQ(parse_value("", 0, 1), empty);
-	EXPECT_EQ(parse_percentage("dfsfsdf"), empty);
+	std::optional<int> empty = {};
+	EXPECT_EQ(parse_percentage("-1"), empty);
+	EXPECT_EQ(parse_percentage("-5.0"), empty);
+	EXPECT_EQ(parse_percentage("-0.00001"), empty);
+	EXPECT_EQ(parse_percentage("100.0001"), empty);
+	EXPECT_EQ(parse_percentage("105"), empty);
+	EXPECT_EQ(parse_percentage("asdf"), empty);
+	EXPECT_EQ(parse_percentage("5a"), empty);
 	EXPECT_EQ(parse_percentage(""), empty);
-}
-
-TEST(ParsePrefixedValue, Valid)
-{
-	// negatives
-	EXPECT_EQ(*parse_prefixed_value('a', "a-10000", -10000, 0), -10000.0f);
-	EXPECT_EQ(*parse_prefixed_value('b', "b-0.1", -1, 1), -0.1f);
-	EXPECT_EQ(*parse_prefixed_value('c', "c-0.0001", -1, 1), -0.0001f);
-	EXPECT_EQ(*parse_prefixed_value('d', "d-0.0", -1, 1), -0.0f);
-	EXPECT_EQ(*parse_prefixed_value('e', "e0", 0, 1), 0.0f);
-
-	// positives
-	EXPECT_EQ(*parse_prefixed_value('f', "f0.0", 0, 1), 0.0f);
-	EXPECT_EQ(*parse_prefixed_value('g', "g0.0001", 0, 1), 0.0001f);
-	EXPECT_EQ(*parse_prefixed_value('h', "h0.1", 0, 1), 0.1f);
-	EXPECT_EQ(*parse_prefixed_value('i', "i10000", 0, 11000), 10000.0f);
-}
-
-TEST(ParsePrefixedPercentage, Valid)
-{
-	EXPECT_EQ(*parse_prefixed_percentage('u', "u-100"), 0.0f);
-	EXPECT_EQ(*parse_prefixed_percentage('v', "v0"), 0.0f);
-	EXPECT_EQ(*parse_prefixed_percentage('w', "w1"), 1.0f);
-	EXPECT_EQ(*parse_prefixed_percentage('x', "x50"), 50.0f);
-	EXPECT_EQ(*parse_prefixed_percentage('y', "y100"), 100.0f);
-	EXPECT_EQ(*parse_prefixed_percentage('z', "z1000"), 100.0f);
-}
-
-TEST(ParsePrefixedBoth, Invalid)
-{
-	std::optional<float> empty = {};
-	EXPECT_EQ(parse_prefixed_value('a', "b-10000", 0, 1), empty);
-	EXPECT_EQ(parse_prefixed_percentage('z', "y1000"), empty);
-	EXPECT_EQ(parse_prefixed_value('a', "-10000", 0, 1), empty);
-	EXPECT_EQ(parse_prefixed_percentage('z', "1000"), empty);
-	EXPECT_EQ(parse_prefixed_value('a', "", 0, 1), empty);
-	EXPECT_EQ(parse_prefixed_percentage('z', ""), empty);
-	EXPECT_EQ(parse_prefixed_value(' ', "----", 0, 1), empty);
-	EXPECT_EQ(parse_prefixed_percentage(' ', ""), empty);
+	EXPECT_EQ(parse_percentage(" "), empty);
 }
 
 TEST(FormatString, Valid)


### PR DESCRIPTION
# Description

This is a significant rework of the command parsing, error reporting, and state handling of the `MIXER` command. The following bug fixes and improvements have been made:

- Mixer channel settings now "survive" deleting then later re-creating the channel instead of simply getting the default settings when the channel is recreated. For example, if you customise the settings of the `SB` and `OPL` channels, then change `sbtype` to something else, the `SB` and `OPL` channels will retain their settings. Similar situation for the `FSYNTH` channel when setting `mididevice` to something else then back to `fluidsynth`.

- The `MIXER` command no longer accepts slightly incorrect input; command parsing is now strict and we're displaying error messages for invalid commands. These messages also try to guide the user to correct their mistakes.

- This _might_ cause backward compatibility issues if people had slightly (or very!) incorrect `MIXER` command invocations in their configs, so we're also logging a warning when the MIXER command fails. That should give people a chance to correct these mistakes. Examples of invalid input that is no longer accepted:
    - `MIXER ASDF R1` – Previously, the `ASDF` param was ignored because there is no channel with that name, so the scope stayed at "global scope" (all channels), then a global reverb setting of 1 was applied to all channels, which is super confusing.
    - `MIXER SB 10 GUS` – This set the `SB` volume to 10; now it fails because every channel name must be followed by one or more commands to remove ambiguity, and there's nothing after `GUS`.
    - `MIXER SB 10 BLAH 4` – This set the `SB` channel's volume to 10 and ignored the non-existing `BLAH` channel; now an error is raised that `BLAH` is an invalid command.
    - `MIXER SB ASDF` – This just printed the mixer status but did not raise any errors; now it does.
    - `MIXER SB R150` – This silently clamped the reverb level to 100 and set it for the `SB` channel; now we raise an error.
    -  `MIXER GUS 50` – If the GUS was not enabled, this just displayed the current mixer settings; now it prints and error saying that the `GUS` channel is not active.
    - There are millions of other cases that were confusing, wrong, or "technically correct" (according to the weird and overly relaxed parsing rules) but plain counterintuitive. Strict parsing and error reporting take care of all that. See the unit tests for further details and test cases.
   
- `MIXER` command handling is now "transactional"—if there is a single error in a list of multiple commands, no command will be executed but an error for the first problem will be raised. This is just common sense and leads to less confusing behaviour overall.

- The `crossfeed` config setting has been revised; now it works the same way as the `chorus` setting (it has `light`, `normal` and `strong` presets, and `on` defaults to `normal`). The previous behaviour where you could set a global crossfeed value (e.g., `crossfeed = 30`) was unsupportable even with a lot of special casing. It was simply impossible to make that behaviour consistent with the `reverb` and `chorus` settings—I literally rewrote it in 4-5 different ways before I settled on this solution. It just can't be done.


## Other bundled changes

The number parsing string util functions have been revised to make them more generic, and the parsing is now strict. Previously, non-digit characters after digits were silently ignored; this now results in a parse error. Strict parsing is desirable as lenient parsing is a fertile breeding ground for subtle bugs and surprising behaviour (if affected the mixer commands, for example).

The flow-on effect is that the argument parsing of the `MORE` command is now stricter: `MORE /t4x fname` worked before (it set the tab size to 4 chars), but now that generates an "illegal switch" error (`/t4` is the correct invocation). Other DOS commands implemented by us might be affected too.

## Technical notes

I started using the `std::visit` and `std::variant` std lib features which are ideally suited for command line parsers and any kind of scenario when dealing with polymorphic command execution. I'm very cautious when adopting new C++ features, but these are so ideally suited to the task that I found them irresistible 😎  They're quite sane and low overhead, both mentally and syntax-wise.

`std::variant` is quite nice even in isolation; it can be used to return an "Either" or "Result" type common in functional languages that encapsulates either a "success" or an "error" result. IMO, this is the preferred alternative to the hacky old C/C++ way of providing "out" pointer arguments to return "secondary" results, such as errors.

A few nice introductory articles about using `std::visit` and `std::variant` together to implement command parsers & executors:

- https://cpp-corner.com/visit-them-all-with-stdvariant/
- https://www.cppstories.com/2020/04/variant-virtual-polymorphism.html/
- https://trussel.ch/cpp/design%20patterns/2020/10/18/command-pattern.html

If everybody hates them, we can discuss finding an alternative way, but it would be a lot more complex and there would be a lot of boilerplate involved, so I'm strongly in favour of using `std::visit` and `std::variant` judiciously going forward (at least in non-performance intensive code).

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2468
List of various issues fixed: https://github.com/dosbox-staging/dosbox-staging/issues/2468#issuecomment-1596526490


# Manual testing

Proof of manual testing. These are end-to-end tests that exercise the whole stack; it would be difficult to create an automated test fixture/harness that wires up )just enough components_ to make this possible and would yield the same level of confidence.

These are _highest-value tests_, the absolutely highest value there is. Therefore, I'd like to keep them around by all means, preferably in an automated form. They are invaluable for regression testing when anyone touches the mixer the next time (some situations are complex and subtle; most people wouldn't even know what regressions to look out for... that includes me 6 months from now :sunglasses:).

Btw, one of the reasons why this PR was dragging on for so long was that redoing all this testing manually takes like 20 minutes (in a relaxed manner) and I was getting sick of it after re-doing it for the 10th time...

My low-cost solution is to write a batch file containing these commands that pipes the results to a file, then have an `expected.txt` that contains the expected outcome with the ANSI colour codes stripped. Then write a bash script that takes the actual output, strips the ANSI stuff out, then diffs it against `expected.txt`. Would do the job, but better ideas are welcome (hint: suggesting to write an actual end-to-end test harness that would take days or weeks is _not_ a better idea :sunglasses:)


## Error messages

![error-messages-1](https://github.com/dosbox-staging/dosbox-staging/assets/698770/39257981-efdd-4802-bafe-33842c4bc910)

![error-messages-2](https://github.com/dosbox-staging/dosbox-staging/assets/698770/c23dd1b3-dced-4a9f-b98e-bc0a8922c1ba)

![error-messages-3](https://github.com/dosbox-staging/dosbox-staging/assets/698770/5699510d-9b66-4937-8390-38e1cfa79515)

![error-messages-4](https://github.com/dosbox-staging/dosbox-staging/assets/698770/5ee25dc4-ba2e-40b7-a1a6-585bb76efafe)

## Setting persistence

![setting-persistence-1](https://github.com/dosbox-staging/dosbox-staging/assets/698770/ba3dfd9a-26c0-4b6f-96f3-fd749a399b53)

![setting-persistence-2](https://github.com/dosbox-staging/dosbox-staging/assets/698770/500fb9f4-b4e2-4cc0-9222-9d1d5b0ac55f)

![setting-persistence-3](https://github.com/dosbox-staging/dosbox-staging/assets/698770/b33efded-8030-4c7c-95e5-83cb9cc27b86)

## MIDI stuff

![midi-1](https://github.com/dosbox-staging/dosbox-staging/assets/698770/4e04d2f6-025d-4267-a40c-1e2d63b393d0)

![midi-2](https://github.com/dosbox-staging/dosbox-staging/assets/698770/b8e67054-ffe9-4b31-9ce0-63b188b04f4b)

![midi-3](https://github.com/dosbox-staging/dosbox-staging/assets/698770/b992ba1d-f4ef-4980-88d3-8d507ecaf3be)

![midi-4](https://github.com/dosbox-staging/dosbox-staging/assets/698770/e84c1537-c81c-4536-9141-41ac6a0b67c5)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

