### PR TITLE
Fix unneeded empty lines in 'TREE | MORE' display

### DIFF
--- a/src/dos/program_more_output.cpp
+++ b/src/dos/program_more_output.cpp
@@ -139,7 +139,7 @@ MoreOutputBase::UserDecision MoreOutputBase::DisplaySingleStream()
 	std::string ansi_code  = {};
 	bool is_state_ansi     = false;
 	bool is_state_ansi_end = false;
-	bool is_state_new_line = false;
+	bool is_state_new_line = true;
 
 	bool skipped_already_notified = false;
 	bool should_squish_new_line   = false;


### PR DESCRIPTION
# Description

Fixes bug when `TREE | MORE` command displays unnecessary empty lines:

![bug](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/6a9ad884-9842-437e-b8d9-eafad82af73c)

Reason: the TREE command implementation calls `MoreOutputStrings::DisplayPartial()` after submitting part of the content (so that displaying the output can start early even if reading whole directory structure is slow, for example in case of physical CD-ROM drive). Unfortunately, if the chunk of data to display was empty AND the output got redirected, the MORE engine was wrongfully putting an unnecessary newline. This was fixed by changing the initial _we are after new line_ state to `true`.

# Manual testing

1. Go to a drive with some non-trivial directory structure and execute `TREE | MORE` command
2. Create an empty file and try to display it using `MORE empty.txt` command - the output should be reasonable.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

