### PR TITLE
Ignore extensions when finding highest capture index

### DIFF
--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -187,7 +187,6 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 	std::string filename_start = capture_type_to_basename(type);
 	lowcase(filename_start);
 
-	const auto ext        = capture_type_to_extension(type);
 	int32_t highest_index = 0;
 	std::error_code ec    = {};
 
@@ -198,7 +197,7 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 			            ec.message().c_str());
 			return {};
 		}
-		if (!entry.is_regular_file(ec) || entry.path().extension() != ext) {
+		if (!entry.is_regular_file(ec)) {
 			continue;
 		}
 		auto stem = entry.path().stem().string();

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -205,7 +205,9 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 		lowcase(stem);
 		if (starts_with(stem, filename_start)) {
 			const auto index = to_int(strip_prefix(stem, filename_start));
-			highest_index = std::max(highest_index, *index);
+			if (index) {
+				highest_index = std::max(highest_index, *index);
+			}
 		}
 	}
 	return highest_index;


### PR DESCRIPTION
# Description

First commit is a simple bug fix.  `to_int` returns a `std::optional`.  Using it with the * operator without first checking the boolean value results in undefined behavior so avoid doing that.

Second commit ignores the extension when searching the capture directory.  Currently the check does not accomplish much because any given basename (image, audio, midi, etc) has a unique extension (.png, .wav, .mid).

For video this is about to change and you could have video0001.avi + video0001.mp4 + video0001.mkv.  I believe this could lead to confusion, especially on Windows where file extensions are sometimes hidden by default.

Instead, maintain a single counter for any given basename.

# Manual testing

I have tested with the image capturer and did not find any regressions.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

