### PR TITLE
Improve the online help of the MORE command

### DIFF
--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -226,11 +226,11 @@ void MORE::AddMessages()
 	MSG_Add("PROGRAM_MORE_NEW_DEVICE",
 	        "[reset][color=light-yellow]--- device %s ---[reset]");
 	MSG_Add("PROGRAM_MORE_PROMPT_SINGLE",
-	        "[reset][color=light-yellow]--- press SPACE or ENTER for more ---[reset]");
+	        "[reset][color=light-yellow]--- press SPACE for next page, ENTER for next line, Q to quit ---[reset]");
 	MSG_Add("PROGRAM_MORE_PROMPT_PERCENT",
-	        "[reset][color=light-yellow]--- (%d%%) press SPACE or ENTER for more ---[reset]");
+	        "[reset][color=light-yellow]--- (%d%%) press SPACE for next page, ENTER for next line, Q to quit ---[reset]");
 	MSG_Add("PROGRAM_MORE_PROMPT_MULTI",
-	        "[reset][color=light-yellow]--- press SPACE or ENTER for more, N for next file ---[reset]");
+	        "[reset][color=light-yellow]--- press SPACE or ENTER for more, N for next file, Q to quit ---[reset]");
 	MSG_Add("PROGRAM_MORE_PROMPT_LINE",
 	        "[reset][color=light-yellow]--- line %u ---[reset]");
 	MSG_Add("PROGRAM_MORE_OPEN_ERROR",


### PR DESCRIPTION
# Description

This is a minor usability enhancement for the online help text of the `MORE` command. I personally use Vim keys when I use Unix `more` and `less`, so I'm constantly confused about what `Space` and `Enter` do. Other people who are new to the `MORE` command might face similar issues. Also, if they open a long text file by mistake, they might not know how to quit the program with the `Q` key.


# Manual testing

Tested displaying a single file with `MORE`, multiple files, and built-in commands with long help texts

![image1876470530-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/4cbbb3c1-2f90-4e43-926d-faf8b876c44c)

![image1876470529](https://github.com/dosbox-staging/dosbox-staging/assets/698770/8eeddab0-882c-479b-a05d-eb29a4e51be3)



# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

