### PR TITLE
Implement DOS file/directory attributes support

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -25,11 +25,11 @@
 #include "dosbox.h"
 
 #include <cstdio>
-#include <string>
-#include <vector>
 #include <ctime>
+#include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <vector>
 
 #if defined (_MSC_VER)						/* MS Visual C++ */
 #include <direct.h>
@@ -116,7 +116,7 @@ class Cross {
 public:
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
-	static bool IsPathAbsolute(std::string const& in);
+	static bool IsPathAbsolute(const std::string& in);
 };
 
 #if defined (WIN32)

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -171,7 +171,8 @@ private:
 
 class localFile : public DOS_File {
 public:
-	localFile(const char* name, FILE* handle, const char* basedir);
+	localFile(const char* name, const std_fs::path& path, FILE* handle,
+	          const char* basedir);
 	localFile(const localFile&)            = delete; // prevent copying
 	localFile& operator=(const localFile&) = delete; // prevent assignment
 	bool Read(uint8_t* data, uint16_t* size) override;
@@ -189,15 +190,25 @@ public:
 	{
 		return basedir;
 	}
+	std_fs::path GetPath() const
+	{
+		return path;
+	}
 	FILE* fhandle = nullptr; // todo handle this properly
 private:
-	const char *basedir;
-	long stream_pos = 0;
+	const std_fs::path path = {};
+	const char* basedir     = nullptr;
+	long stream_pos         = 0;
+
 	bool ftell_and_check();
 	void fseek_and_check(int whence);
 	bool fseek_to_and_check(long pos, int whence);
-	bool read_only_medium;
-	enum { NONE,READ,WRITE } last_action;
+
+	bool read_only_medium     = false;
+	bool set_archive_on_close = false;
+
+	enum class LastAction : uint8_t { None, Read, Write };
+	LastAction last_action = LastAction::None;
 };
 
 /* The following variable can be lowered to free up some memory.

--- a/include/drives.h
+++ b/include/drives.h
@@ -501,7 +501,8 @@ public:
 	bool FileStat(const char* name, FileStat_Block* const stat_block) override;
 	void EmptyCache(void) override;
 
-	FILE* create_file_in_overlay(const char* dos_filename, const char* mode);
+	std::pair<FILE*, std_fs::path> create_file_in_overlay(const char* dos_filename,
+	                                                      const char* mode);
 
 	Bits UnMount(void) override;
 	bool TestDir(char* dir) override;

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -129,4 +129,18 @@ std::deque<std_fs::path> get_xdg_data_dirs() noexcept;
 
 #endif
 
+// ***************************************************************************
+// Local drive file/directory attribute handling
+// ***************************************************************************
+
+union FatAttributeFlags; // forward declaration
+
+FILE* local_drive_create_file(const std_fs::path& path,
+                              const FatAttributeFlags attributes);
+uint16_t local_drive_create_dir(const std_fs::path& path);
+uint16_t local_drive_get_attributes(const std_fs::path& path,
+                                    FatAttributeFlags& attributes);
+uint16_t local_drive_set_attributes(const std_fs::path& path,
+                                    const FatAttributeFlags attributes);
+
 #endif

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -392,7 +392,7 @@ std::optional<float> parse_prefixed_percentage(const char prefix,
 
 // tries to convert string to integer,
 // returns value only if succeeded
-std::optional<int> to_int(const std::string& value);
+std::optional<int> to_int(const std::string& value, const int base = 10);
 
 template <typename... Args>
 std::string format_string(const std::string& format, const Args&... args) noexcept

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1075,8 +1075,7 @@ bool fatDrive::FileCreate(DOS_File **file, char *name, uint16_t attributes) {
                                     fileEntry.loFirstClust,
                                     fileEntry.entrysize,
                                     this);
-	bool is_readonly     = fileEntry.attrib & DOS_ATTR_READ_ONLY;
-	fat_file->flags      = is_readonly ? OPEN_READ : OPEN_READWRITE;
+	fat_file->flags      = OPEN_READWRITE;
 	fat_file->dirCluster = dirClust;
 	fat_file->dirIndex   = subEntry;
 	fat_file->time       = fileEntry.modTime;

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -23,13 +23,12 @@
 
 #include <cerrno>
 #include <clocale>
-#include <string>
-#include <vector>
-
 #include <limits.h>
 #include <stdlib.h>
+#include <string>
 #include <sys/types.h>
 #include <unistd.h>
+#include <vector>
 
 #if C_COREFOUNDATION
 #	include <CoreFoundation/CoreFoundation.h>
@@ -44,6 +43,7 @@
 #	include <shlobj.h>
 #else
 #	include <libgen.h>
+#include <sys/xattr.h>
 #endif
 
 #if defined HAVE_PWD_H
@@ -781,6 +781,10 @@ std::string cfstr_to_string(CFStringRef source)
 	assert(lang.empty());
 	return lang;
 }
+
+// ***************************************************************************
+// Local time support
+// ***************************************************************************
 
 namespace cross {
 

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -26,6 +26,7 @@
 #include <fstream>
 
 #include "checks.h"
+#include "dos_inc.h"
 #include "dos_system.h"
 #include "std_filesystem.h"
 
@@ -142,4 +143,15 @@ std::time_t to_time_t(const std_fs::file_time_type &fs_time)
 	        fs_time - fs_datum + fs_to_sys_delta);
 
 	return system_clock::to_time_t(sys_time);
+}
+
+// ***************************************************************************
+// Local drive file/directory attribute handling
+// ***************************************************************************
+
+uint16_t local_drive_create_dir(const std_fs::path& path)
+{
+	const auto result = create_dir(path.c_str(), 0775);
+
+	return (result == 0) ? DOSERR_NONE : DOSERR_ACCESS_DENIED;
 }

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -22,14 +22,18 @@
 
 #if !defined(WIN32)
 
-#include <cerrno>
 #include <cctype>
+#include <cerrno>
+#include <fcntl.h>
 #include <glob.h>
+#include <optional>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include "cross.h"
+#include "dos_inc.h"
 #include "logging.h"
 #include "string_utils.h"
 
@@ -146,5 +150,191 @@ std::deque<std_fs::path> get_xdg_data_dirs() noexcept
 }
 
 #endif
+
+// ***************************************************************************
+// Local drive file/directory attribute handling, WINE-compatible
+// ***************************************************************************
+
+constexpr int PermissionsRO = S_IRUSR | S_IRGRP | S_IROTH;
+constexpr int PermissionsRW = S_IWUSR | S_IWGRP | S_IWOTH | PermissionsRO;
+
+// Attributes 'hidden', 'system', and 'archive' are always taken from the
+// host extended attributes.
+constexpr uint8_t XattrReadMask = 0b0010'0110; // hidden, system, archive
+// Attributes 'read-only' and 'directory' are stored in extended attributes,
+// but not used by DOSBox, for these we are always using host file system
+// attribute bits.
+constexpr uint8_t XattrWriteMask = 0b0001'0001 | XattrReadMask;
+// We are storing DOS file attributes in Unix extended attributes, using same
+// format as WINE, Samba 3, and DOSEmu 2.
+static const std::string XattrName = "user.DOSATTRIB";
+
+constexpr size_t XattrMinLength = 3;
+constexpr size_t XattrMaxLength = 4;
+
+static std::string fat_attribs_to_xattr(const FatAttributeFlags fat_attribs)
+{
+	return format_string("0x%x", fat_attribs._data & XattrWriteMask);
+}
+
+static std::optional<FatAttributeFlags> xattr_to_fat_attribs(const std::string& xattr)
+{
+	constexpr uint8_t HexBase = 16;
+
+	if (xattr.size() <= XattrMaxLength && starts_with(xattr, "0x") &&
+	    xattr.size() >= XattrMinLength) {
+		const auto value = to_int(xattr.substr(2), HexBase);
+		if (value) {
+			return *value & XattrReadMask;
+		}
+	}
+
+	return {};
+}
+
+static std::optional<FatAttributeFlags> get_xattr(const std_fs::path& path)
+{
+	char xattr[XattrMaxLength + 1];
+
+#ifdef MACOSX
+	constexpr int offset  = 0;
+	constexpr int options = 0;
+
+	const auto length = getxattr(path.c_str(),
+	                             XattrName.c_str(),
+	                             xattr,
+	                             XattrMaxLength,
+	                             offset,
+	                             options);
+#else
+	const auto length = getxattr(path.c_str(),
+	                             XattrName.c_str(),
+	                             xattr,
+	                             XattrMaxLength);
+#endif
+	if (length <= 0) {
+		// No extended attribute present
+		return {};
+	}
+
+	if (static_cast<size_t>(length) > XattrMaxLength) {
+		LOG_MSG("DOS: Incorrect '%s' extended attribute in '%s'",
+		        XattrName.c_str(), path.c_str());
+		return {};
+	}
+
+	xattr[length] = 0;
+	return xattr_to_fat_attribs(std::string(xattr));
+}
+
+static bool set_xattr(const std_fs::path& path, const FatAttributeFlags attributes)
+{
+	const auto xattr = fat_attribs_to_xattr(attributes);
+
+#ifdef MACOSX
+	constexpr int offset  = 0;
+	constexpr int options = 0;
+
+	const auto result = setxattr(path.c_str(),
+	                             XattrName.c_str(),
+	                             xattr.c_str(),
+	                             xattr.size(),
+	                             offset,
+	                             options);
+#else
+	constexpr int flags = 0;
+
+	const auto result = setxattr(path.c_str(),
+                                     XattrName.c_str(),
+                                     xattr.c_str(),
+                                     xattr.size(),
+                                     flags);
+#endif
+	return (result == 0);
+}
+
+static bool set_xattr(const int file_descriptor, const FatAttributeFlags attributes)
+{
+	const auto xattr = fat_attribs_to_xattr(attributes);
+
+#ifdef MACOSX
+	constexpr int offset  = 0;
+	constexpr int options = 0;
+
+	const auto result = fsetxattr(file_descriptor,
+	                              XattrName.c_str(),
+	                              xattr.c_str(),
+	                              xattr.size(),
+	                              offset,
+	                              options);
+#else
+	constexpr int flags = 0;
+
+	const auto result = fsetxattr(file_descriptor,
+	                              XattrName.c_str(),
+	                              xattr.c_str(),
+	                              xattr.size(),
+	                              flags);
+#endif
+	return (result == 0);
+}
+
+FILE* local_drive_create_file(const std_fs::path& path,
+                              const FatAttributeFlags attributes)
+{
+	FILE* file_pointer         = nullptr;
+	const auto file_descriptor = open(path.c_str(),
+	                                  O_CREAT | O_RDWR | O_TRUNC,
+	                                  PermissionsRW);
+	if (file_descriptor != -1) {
+		set_xattr(file_descriptor, attributes);
+		file_pointer = fdopen(file_descriptor, "wb+");
+	}
+
+	return file_pointer;
+}
+
+uint16_t local_drive_get_attributes(const std_fs::path& path,
+                                    FatAttributeFlags& attributes)
+{
+	struct stat status;
+	if (stat(path.c_str(), &status) != 0) {
+		attributes = 0;
+		return DOSERR_FILE_NOT_FOUND;
+	}
+	const bool is_directory = status.st_mode & S_IFDIR;
+	const bool is_read_only = !(status.st_mode & S_IWUSR);
+
+	const auto result = get_xattr(path);
+	if (result) {
+		attributes = *result;
+	} else {
+		attributes         = 0;
+		attributes.archive = !is_directory;
+	}
+
+	attributes.directory = is_directory;
+	attributes.read_only = is_read_only;
+
+	return DOSERR_NONE;
+}
+
+uint16_t local_drive_set_attributes(const std_fs::path& path,
+                                    const FatAttributeFlags attributes)
+{
+	if (!path_exists(path)) {
+		return DOSERR_FILE_NOT_FOUND;
+	}
+
+	bool status = make_writable(path);
+	if (status) {
+		status = set_xattr(path, attributes);
+		if (status && attributes.read_only) {
+			status = make_readonly(path);
+		}
+	}
+
+	return status ? DOSERR_NONE : DOSERR_ACCESS_DENIED;
+}
 
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -23,10 +23,13 @@
 #if defined(WIN32)
 
 #include <direct.h>
+#include <fcntl.h>
 #include <io.h>
 #include <sys/stat.h>
 
 #include "compiler.h"
+#include "dos_inc.h"
+#include "dos_system.h"
 
 bool path_exists(const char *path) noexcept
 {
@@ -52,6 +55,60 @@ int create_dir(const std_fs::path& path, [[maybe_unused]] uint32_t mode,
 			return 0;
 	}
 	return err;
+}
+
+// ***************************************************************************
+// Local drive file/directory attribute handling
+// ***************************************************************************
+
+constexpr uint8_t WindowsAttributesMask = 0x3f;
+
+FILE* local_drive_create_file(const std_fs::path& path,
+                              const FatAttributeFlags attributes)
+{
+	FILE* file_pointer          = nullptr;
+	const auto win32_attributes = (attributes._data != 0)
+	                                    ? static_cast<DWORD>(attributes._data)
+	                                    : FILE_ATTRIBUTE_NORMAL;
+	const auto win32_handle     = CreateFileW(path.c_str(),
+                                              GENERIC_READ | GENERIC_WRITE,
+                                              0,
+                                              nullptr,
+                                              CREATE_ALWAYS,
+                                              win32_attributes,
+                                              nullptr);
+
+	if (win32_handle != INVALID_HANDLE_VALUE) {
+		const int file_descriptor =
+		        _open_osfhandle(reinterpret_cast<intptr_t>(win32_handle),
+		                        _O_RDWR | _O_BINARY);
+		file_pointer = _fdopen(file_descriptor, "wb+");
+	}
+
+	return file_pointer;
+}
+
+uint16_t local_drive_get_attributes(const std_fs::path& path,
+                                    FatAttributeFlags& attributes)
+{
+	const auto win32_attributes = GetFileAttributesW(path.c_str());
+	if (win32_attributes == INVALID_FILE_ATTRIBUTES) {
+		attributes = 0;
+		return static_cast<uint16_t>(GetLastError());
+	}
+
+	attributes = win32_attributes & WindowsAttributesMask;
+	return DOSERR_NONE;
+}
+
+uint16_t local_drive_set_attributes(const std_fs::path& path,
+                                    const FatAttributeFlags attributes)
+{
+	if (!SetFileAttributesW(path.c_str(), attributes._data)) {
+		return static_cast<uint16_t>(GetLastError());
+	}
+
+	return DOSERR_NONE;
 }
 
 #endif

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -351,10 +351,13 @@ std::optional<float> parse_prefixed_percentage(const char prefix, const std::str
 	return parse_prefixed_value(prefix, s, min_percentage, max_percentage);
 }
 
-std::optional<int> to_int(const std::string& value)
+std::optional<int> to_int(const std::string& value, const int base)
 {
 	try {
-		return std::stoi(value);
+		// Do not store number of characters processed
+		constexpr std::size_t* pos = nullptr;
+
+		return std::stoi(value, pos, base);
 	} catch (...) {
 		return {};
 	}


### PR DESCRIPTION
# Description

This is a next generation version of the patch originally prepared by @NicknineTheEagle https://github.com/dosbox-staging/dosbox-staging/pull/2693

First short explanation: Archive bit in MS-DOS means _file is newly created or modified, and archivizer software should make a backup copy during next run and clean the bit afterwards_ (at least this was the idea, in reality most of the files in MS-DOS system have Archive bit set).

This PR implements the following:
- all DOS file/directory attributes are now supported (not just Read-Only, as before)
- newly created or modified files get the Archive bit set (on both local drive and FAT images), I have tried to duplicate MS-DOS behavior as closely as possible
- on Windows host attributes are stored normally in the filesystem
- on Linux / macOS hosts Read-Only is denoted by clearing write permissions (as before), moreover all the attributes are stored in _xattr_ extended attributes, in a format compatible with WINE and DOSEmu 2 (they both use Samba 3 format); lack of extended attributes is considered as Archive bit set and Hidden / System not set (as before this implementation)

Limitations:
- overlay drives (`-t overlay` option in `MOUNT` command) are partially supported; attributes can be retrieved (always), but can be only set for files in the overlay - before anyone complains: current implementation does not even allow to set file in the overlay as Read-Only (request is mostly ignored), so the situation is actually improved now :)
- interoperability with WINE does not cover Archive bit; WINE always assumes it is set for the files and does not allow to change it
- interoperability with DOSEmu 2 wasn't tested, as I am unable to set up the emulator (crashes for me instantly after startup)

## Related issues
Implements https://github.com/dosbox-staging/dosbox-staging/issues/2793

# Manual testing

1. Just play with `ATTRIB` command or other tools to change attributes; all newly created or modified files (for example using `EDIT.COM` from MS-DOS) should get the Archive attribute set. Tested on Linux and Windows (yes, despite I'm a Linux user, I have launched it, waited till it installs 6 months of updates, and did some tests!). I was unable to test under macOS, I don't have access to Mac.

2. To test interoperability with WINE, the easiest way is to symlink some directory from DOSBox local drive to WINE virtual drive, execute `wine cmd` command from console, and play with `ATTRIB` commands of both emulators; note that WINE ignores Archive attribute (always has it set for files) and does not allow to change it.

3. I wasn't sure how MS-DOS precisely handles Archive attribute (does it set it after you open file for writing? after you write to the file? when you are closing the modified file?), so I have written a test program (attached below). To try it:
- rename file to `ATEST.C`
- install OpenWatcom inside DOSBox
- execute `OWSETENV.BAT` from the compiler directory
- compile the test program using `WCL.EXE -l=dos ATEST.C` command
- run the executable; for convenience, it shows reference values - attributes in hex format, retrieved while running the program under real MS-DOS 6.22

[ATEST.C.TXT](https://github.com/dosbox-staging/dosbox-staging/files/12688978/ATEST.C.TXT)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

