### PR TITLE
Add short prompts for MORE commands for 40 column screen modes

### DIFF
--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -231,6 +231,10 @@ void MORE::AddMessages()
 	        "[reset][color=light-yellow]--- (%d%%) press SPACE for next page, ENTER for next line, Q to quit ---[reset]");
 	MSG_Add("PROGRAM_MORE_PROMPT_MULTI",
 	        "[reset][color=light-yellow]--- press SPACE or ENTER for more, N for next file, Q to quit ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_SHORT",
+	        "[reset][color=light-yellow]--- more ---[reset]");
+	MSG_Add("PROGRAM_MORE_PROMPT_SHORT_PERCENT",
+	        "[reset][color=light-yellow]--- (%d%%) more ---[reset]");
 	MSG_Add("PROGRAM_MORE_PROMPT_LINE",
 	        "[reset][color=light-yellow]--- line %u ---[reset]");
 	MSG_Add("PROGRAM_MORE_OPEN_ERROR",

--- a/src/dos/program_more_output.cpp
+++ b/src/dos/program_more_output.cpp
@@ -345,18 +345,29 @@ MoreOutputBase::UserDecision MoreOutputBase::PromptUser()
 	bool prompt_type_line_num = false;
 
 	auto display_prompt = [this, &line_num](const bool prompt_type_line_num) {
+		// If using 40-column screen mode (or any custom one with less
+		// columns than standard 80), use short prompts to avoid display
+		// corruption
+		const bool use_short_prompt = max_columns < 80;
 		if (prompt_type_line_num) {
 			WriteOut(MSG_Get("PROGRAM_MORE_PROMPT_LINE"), line_num);
 		} else if (has_multiple_files) {
-			WriteOut(MSG_Get("PROGRAM_MORE_PROMPT_MULTI"));
+			WriteOut(MSG_Get(use_short_prompt
+			                         ? "PROGRAM_MORE_PROMPT_SHORT"
+			                         : "PROGRAM_MORE_PROMPT_MULTI"));
 		} else {
 			if (lines_in_stream) {
 				const auto tmp = static_cast<float>(line_num) /
 			                     static_cast<float>(lines_in_stream);
-				WriteOut(MSG_Get("PROGRAM_MORE_PROMPT_PERCENT"),
+				WriteOut(MSG_Get(use_short_prompt
+				                         ? "PROGRAM_MORE_PROMPT_SHORT_PERCENT"
+				                         : "PROGRAM_MORE_PROMPT_PERCENT"),
 				         std::min(static_cast<int>(tmp * 100), 100));
 			} else {
-				WriteOut(MSG_Get("PROGRAM_MORE_PROMPT_SINGLE"));
+				WriteOut(MSG_Get(
+				        use_short_prompt
+				                ? "PROGRAM_MORE_PROMPT_SHORT"
+				                : "PROGRAM_MORE_PROMPT_SINGLE"));
 			}
 		}
 	};


### PR DESCRIPTION
# Description

I would still prefer `MORE` command not to break on 40 column screen modes, thus I have added short prompts, which do not contain ANY tips/hints for the user; this way they will remain short for every translation imaginable.

I agree that no one uses them on purpose, but sometimes we end up in one when the program malfunctions and terminates - the change is to give a small aid to the user, who might want to do some recovery actions or post-mortem analysis.

# Manual testing

I have only tested this by manually changing `use_short_prompt` condition in the code, to trigger displaying short prompts.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

