### PR TITLE
Remove the SSE 4.2 instruction set from the hardware requirements (`80.x` release branch PR)

### DIFF
--- a/website/docs/downloads/linux.md
+++ b/website/docs/downloads/linux.md
@@ -110,7 +110,7 @@ You can easily configure your DOS games on
 
 ## Hardware requirements
 
-For x86 CPUs the SSE 4.2 instruction set is required.
+From the x86 family of processors, all x86-64 processors are supported.
 
 ## Development snapshot builds
 

--- a/website/docs/downloads/macos.md
+++ b/website/docs/downloads/macos.md
@@ -13,7 +13,7 @@ sha256: 46a256645255e8345981ea357f1416b8<wbr>ce4bc60a2aba9a86b5122d5075aa7fa9
 </small>
 
 This package is compatible with macOS 10.15 (Catalina) or newer and supports both
-Intel and M1 Macs.
+Intel and Apple silicon Macs.
 
 Check out the [0.80.1 release notes](release-notes/0.80.1.md) to learn about
 the changes and improvements introduced by this release.
@@ -52,10 +52,8 @@ to reproduce some issues).
 
 ## Hardware requirements
 
-For x86 CPUs the SSE 4.2 instruction set is required. For Intel Mac models
-that don't support it, you can try using the partial SSE4.2 emulator
-[MouSSE](https://forums.macrumors.com/threads/mp3-1-others-sse-4-2-emulation-to-enable-amd-metal-driver.2206682/).
-
+This package is compatible with macOS 10.15 (Catalina) or newer and supports
+both 64-bit Intel and Apple silicon Macs.
 
 ## Development snapshot builds
 

--- a/website/docs/downloads/windows.md
+++ b/website/docs/downloads/windows.md
@@ -54,7 +54,7 @@ for further details.
 
 ## Hardware requirements
 
-SSE 4.2 instruction set is required for version 0.75.1 or newer.
+From the x86 family of processors, all x86-64 processors are supported.
 
 ## Development snapshot builds
 


### PR DESCRIPTION
# Description

Remove the SSE 4.2 instruction set from the 80.1-release documentation's hardware requirements.

## Related issues

Fixes #2955 

# Manual testing

![2023-09-24_07-54](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/03b0f79f-ac14-4602-9b95-12afc2dd9fe0)

![2023-09-24_07-53_1](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/1ce7bb01-d038-4567-a286-60a52c275524)

![2023-09-24_07-53](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/6ebf2aef-b5f6-4886-ad68-a86f04c52895)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

