### PR TITLE
Fixing missing header file for select() syscall when building on MacO…

### DIFF
--- a/src/libs/manymouse/x11_xinput2.c
+++ b/src/libs/manymouse/x11_xinput2.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <dlfcn.h>
 #include <X11/extensions/XInput2.h>
+#include <sys/select.h>
 
 #if defined(BSD)
 #include <sys/time.h>


### PR DESCRIPTION
…SX Sonoma.

# Description

MacOSX builds started to fail lately after upgrade to MacOSX 14 Sonoma and introduction of Xcode 15. All details are in the referenced issue.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/2967

# Manual testing

Did a short test with:
```
meson setup build/release
meson compile -C build/release
```
and started a resulting binary to check if it runs, both went successfully.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

