### PR TITLE
Remove opencaptures

### DIFF
--- a/README
+++ b/README
@@ -395,8 +395,6 @@ dosbox -eraseconf
 
 dosbox -erasemapper
 
-dosbox -opencaptures program
-
 
   NAME
         If "NAME" is a directory it will mount that as the C: drive.
@@ -519,10 +517,6 @@ dosbox -opencaptures program
         Open the default configuration file in a text editor. If no editor name
         is given, then use the program from EDITOR environment variable,
         otherwise DOSBox will try to guess the name.
-
-  -opencaptures program
-        calls program with as first parameter the location of the captures
-        folder.
 
   --printconf
         Print the location of the default configuration file.

--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -42,8 +42,6 @@ dosbox \- DOSBox Staging, x86/DOS emulator, a modern continuation of DOSBox
 .B dosbox \-\-list\-glshaders
 .LP
 .B dosbox \-\-erasemapper
-.LP
-.B dosbox \-\-opencaptures
 
 .SH DESCRIPTION
 
@@ -118,9 +116,6 @@ Legacy single dash abbrevations still work for backwards compatibility.
                          and commands such as MOUNT and IMGMOUNT are disabled.
 
 --socket <num>           Run nullmodem on the specified socket number.
-
---opencaptures           Call program with as first parameter the location of the
-                         captures folder.
 
 --help                   Print help message and exit.
 

--- a/scripts/captures.bat
+++ b/scripts/captures.bat
@@ -1,1 +1,0 @@
-DOSBox.exe -opencaptures explorer.exe


### PR DESCRIPTION
# Description

As part of #2966 the `--opencaptures program` parameter was removed. This PR removes mentions of it in the man page and README. Also deletes a file `captures.bat`, which seems as some kind of usage example?

What was the usecase for that parameter? The commit of the batch file is from 2010 (so it's a later addition) stating "Installer improvements"... maybe somebody can trace if there were some related changes in 2010 to go along with that batch file?

If somebody can explain the purpose of that -and- it's decided not needed anymore, then it can be removed. But if nobody knows why it's there - maybe better to keep it for "backwards compatibility"? Or remove it and wait to get explanation of the usecase from whoever gets affected and comes to ask about it?

# Manual testing

None

# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.