### PR TITLE
Fix file creation regression on case sensitive file systems

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -232,9 +232,9 @@ public:
 	bool  OpenDir              (const char* path, uint16_t& id);
 	bool  ReadDir              (uint16_t id, char* &result);
 
-	void  ExpandName           (char* path);
-	char* GetExpandName        (const char* path);
-	bool  GetShortName         (const char* fullname, char* shortname);
+	void ExpandNameAndNormaliseCase(char* path);
+	char* GetExpandNameAndNormaliseCase(const char* path);
+	bool GetShortName(const char* fullname, char* shortname);
 
 	bool  FindFirst            (char* path, uint16_t& id);
 	bool  FindNext             (uint16_t id, char* &result);

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -174,11 +174,13 @@ void DOS_Drive_Cache::SetBaseDir(const char *baseDir)
 #endif
 }
 
-void DOS_Drive_Cache::ExpandName(char* path) {
-	safe_strncpy(path, GetExpandName(path), CROSS_LEN);
+void DOS_Drive_Cache::ExpandNameAndNormaliseCase(char* path)
+{
+	safe_strncpy(path, GetExpandNameAndNormaliseCase(path), CROSS_LEN);
 }
 
-char* DOS_Drive_Cache::GetExpandName(const char* path) {
+char* DOS_Drive_Cache::GetExpandNameAndNormaliseCase(const char* path)
+{
 	static char work [CROSS_LEN] = { 0 };
 	char dir [CROSS_LEN];
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -62,11 +62,16 @@ bool localDrive::FileCreate(DOS_File** file, char* name, FatAttributeFlags attri
 	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 
+	// GetExpandName returns a pointer to a static local string.
+	// Make a copy to ensure it doesn't get overwritten by future calls.
+	char expanded_name[CROSS_LEN];
+	safe_strcpy(expanded_name, dirCache.GetExpandName(newname));
+
 	attributes.archive = true;
-	FILE* file_pointer = local_drive_create_file(newname, attributes);
+	FILE* file_pointer = local_drive_create_file(expanded_name, attributes);
 
 	if (!file_pointer) {
-		LOG_MSG("Warning: file creation failed: %s",newname);
+		LOG_MSG("Warning: file creation failed: %s", expanded_name);
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
@@ -76,7 +81,7 @@ bool localDrive::FileCreate(DOS_File** file, char* name, FatAttributeFlags attri
 	}
 
 	// Make the 16 bit device information
-	*file = new localFile(name, newname, file_pointer, basedir);
+	*file = new localFile(name, expanded_name, file_pointer, basedir);
 
 	(*file)->flags = OPEN_READWRITE;
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2021,7 +2021,7 @@ void DOS_Shell::CMD_SUBST (char * args) {
 		safe_strcpy(newname, ldp->GetBasedir());
 		strcat(newname,fulldir);
 		CROSS_FILENAME(newname);
-		ldp->dirCache.ExpandName(newname);
+		ldp->dirCache.ExpandNameAndNormaliseCase(newname);
 		strcat(mountstring,"\"");
 		strcat(mountstring, newname);
 		strcat(mountstring,"\"");


### PR DESCRIPTION
# Description

This is a regression from https://github.com/dosbox-staging/dosbox-staging/commit/144783113f8f44a5c449ae7737b6ebb625104d84

The above commit removed a call to `dirCache.GetExpandName`

That function does a lot of stuff I didn't fully follow but one of those things is getting the real casing of the directory as the OS sees it.  This is important for case sensitive file systems like Linux typically uses, otherwise the file creation fails.

## Related issues

Fixes #2965


# Manual testing

- Installed Civilization into C:\MPS\CIV
- Try saving game, it works
- In Linux, rename the real directory from MPS to MpS
- Try saving game, it fails
- Make this change
- Saving the game now works regardless of casing


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

