### PR TITLE
Cleanup formatting of a couple markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ support today's systems.
 
 ### For developers
 
-| **Feature**                    | **Status**
-|-                               |-
-| **Version control**            | Git
-| **Language**                   | C++17
-| **SDL**                        | >= 2.0.5
-| **Logging**                    | Loguru for C++<sup>[5]</sup>
-| **Buildsystem**                | Meson or Visual Studio 2022
-| **CI**                         | Yes
-| **Static analysis**            | Yes<sup>[1],[3],[4]</sup>
-| **Dynamic analysis**           | Yes
-| **clang-format**               | Yes
-| **[Development builds]**       | Yes
-| **Unit tests**                 | Yes<sup>[6]</sup>
-| **Automated regression tests** | WIP
+| **Feature**                    | **Status**                   |
+|--------------------------------|------------------------------|
+| **Version control**            | Git                          |
+| **Language**                   | C++17                        |
+| **SDL**                        | >= 2.0.5                     |
+| **Logging**                    | Loguru for C++<sup>[5]</sup> |
+| **Buildsystem**                | Meson or Visual Studio 2022  |
+| **CI**                         | Yes                          |
+| **Static analysis**            | Yes<sup>[1],[3],[4]</sup>    |
+| **Dynamic analysis**           | Yes                          |
+| **clang-format**               | Yes                          |
+| **[Development builds]**       | Yes                          |
+| **Unit tests**                 | Yes<sup>[6]</sup>            |
+| **Automated regression tests** | WIP                          |
 
 [1]: https://github.com/dosbox-staging/dosbox-staging/actions?query=workflow%3A%22Code+analysis%22
 [2]: https://lgtm.com/projects/g/dosbox-staging/dosbox-staging/

--- a/README.md
+++ b/README.md
@@ -48,39 +48,39 @@ support today's systems.
 
 ### For users
 
-| **Feature**                  | **Description**
-|-                             |-
-| **CD-DA file codecs**        | Opus, OGG/Vorbis, MP3, FLAC, and WAV
-| **Integer scaling**          | `integer_scaling = vertical` or `horizontal`; replaced "pixel-perfect" mode<sup>[7]</sup>
-| **Resizable window**         | Yes
-| **Relative window size**     | `windowresolution = small`, `medium`, or `large` config setting
-| **Window placement**         | `windowposition` config setting<sup>[16]</sup>
-| **[OPL] emulator**           |  Nuked OPL, a highly accurate (YMF262, CT1747) emulator <sup>[8]</sup>
-| **[CGA]/mono support**       | `machine = cga_mono` and `monochrome_palette` config settings<sup>[9]</sup>
-| **CGA composite modes**      | For `machine = pcjr`, `tandy`, and `cga`; toggleable via hotkeys
-| **[Wayland] support**        | Experimental: use `SDL_VIDEODRIVER=wayland`
-| **Modem phonebook file**     | `phonebookfile` config setting
-| **Raw mouse input**          | `raw_mouse_input` config setting
-| **`AUTOTYPE` command**       | Yes<sup>[10]</sup>
-| **`MORE` command**           | Yes<sup>[21]</sup>
-| **Startup verbosity**        | Yes<sup>[11]</sup>
-| **[GUS] enhancements**       | Yes<sup>[12]</sup>
-| **[FluidSynth][FS] MIDI**    | Built-in<sup>[13]</sup>; via FluidSynth 2.x (SoundFonts not included)
-| **[MT-32] emulator**         | Built-in; via libmt32emu 2.4.2 (requires user-supplied ROM files)
-| **Expanded S3 support**      | 4 and 8 MB of RAM<sup>[14]</sup>
-| **Portable & layered conf**  | By default<sup>[15]</sup>
-| **Translations handling**    | Bundled, see section 14 in README
-| **[ENet] modem transport**   | serialport `sock:1` flag or `SERIAL.COM`<sup>[17]</sup>
-| **Ethernet via [slirp]**     | See `[ethernet]` config section
-| **IDE support for CD-ROMs**  | See `-ide` flag in `IMGMOUNT.COM /help`
-| **Networking in Win3.11**    | Via local shell<sup>[18]</sup>
-| **Audio filters**            | See `*_filter` config settings
-| **Audio reverb and chorus**  | See `reverb` config setting and `MIXER.COM /help`
-| **Audio stereo crossfeed**   | See `chorus` config setting and `MIXER.COM /help`
-| **AdLib Gold emulation**     | Via `oplmode = opl3gold`; emulates the surround add-on module too<sup>[19]</sup>
-| **Master audio compressor**  | `compressor` config setting<sup>[20]</sup>
-| **Dual/multi-mouse input**   | See `[mouse]` config section
-| **ReelMagic support**        | See `[reelmagic]` config section
+| **Feature**                 | **Description**                                                                           |
+|-----------------------------|-------------------------------------------------------------------------------------------|
+| **CD-DA file codecs**       | Opus, OGG/Vorbis, MP3, FLAC, and WAV                                                      |
+| **Integer scaling**         | `integer_scaling = vertical` or `horizontal`; replaced "pixel-perfect" mode<sup>[7]</sup> |
+| **Resizable window**        | Yes                                                                                       |
+| **Relative window size**    | `windowresolution = small`, `medium`, or `large` config setting                           |
+| **Window placement**        | `windowposition` config setting<sup>[16]</sup>                                            |
+| **[OPL] emulator**          | Nuked OPL, a highly accurate (YMF262, CT1747) emulator <sup>[8]</sup>                     |
+| **[CGA]/mono support**      | `machine = cga_mono` and `monochrome_palette` config settings<sup>[9]</sup>               |
+| **CGA composite modes**     | For `machine = pcjr`, `tandy`, and `cga`; toggleable via hotkeys                          |
+| **[Wayland] support**       | Experimental: use `SDL_VIDEODRIVER=wayland`                                               |
+| **Modem phonebook file**    | `phonebookfile` config setting                                                            |
+| **Raw mouse input**         | `raw_mouse_input` config setting                                                          |
+| **`AUTOTYPE` command**      | Yes<sup>[10]</sup>                                                                        |
+| **`MORE` command**          | Yes<sup>[21]</sup>                                                                        |
+| **Startup verbosity**       | Yes<sup>[11]</sup>                                                                        |
+| **[GUS] enhancements**      | Yes<sup>[12]</sup>                                                                        |
+| **[FluidSynth][FS] MIDI**   | Built-in<sup>[13]</sup>; via FluidSynth 2.x (SoundFonts not included)                     |
+| **[MT-32] emulator**        | Built-in; via libmt32emu 2.4.2 (requires user-supplied ROM files)                         |
+| **Expanded S3 support**     | 4 and 8 MB of RAM<sup>[14]</sup>                                                          |
+| **Portable & layered conf** | By default<sup>[15]</sup>                                                                 |
+| **Translations handling**   | Bundled, see section 14 in README                                                         |
+| **[ENet] modem transport**  | serialport `sock:1` flag or `SERIAL.COM`<sup>[17]</sup>                                   |
+| **Ethernet via [slirp]**    | See `[ethernet]` config section                                                           |
+| **IDE support for CD-ROMs** | See `-ide` flag in `IMGMOUNT.COM /help`                                                   |
+| **Networking in Win3.11**   | Via local shell<sup>[18]</sup>                                                            |
+| **Audio filters**           | See `*_filter` config settings                                                            |
+| **Audio reverb and chorus** | See `reverb` config setting and `MIXER.COM /help`                                         |
+| **Audio stereo crossfeed**  | See `chorus` config setting and `MIXER.COM /help`                                         |
+| **AdLib Gold emulation**    | Via `oplmode = opl3gold`; emulates the surround add-on module too<sup>[19]</sup>          |
+| **Master audio compressor** | `compressor` config setting<sup>[20]</sup>                                                |
+| **Dual/multi-mouse input**  | See `[mouse]` config section                                                              |
+| **ReelMagic support**       | See `[reelmagic]` config section                                                          |
 
 [OPL]: https://en.wikipedia.org/wiki/Yamaha_YMF262
 [CGA]: https://en.wikipedia.org/wiki/Color_Graphics_Adapter

--- a/website/docs/downloads/release-notes/0.76.0.md
+++ b/website/docs/downloads/release-notes/0.76.0.md
@@ -37,10 +37,10 @@ Sample from [Rise of the Triad][rott] (1995). For other comparisons see [link].
 
 Using headphones is highly recommended!
 
-GUS emulator | Sample (FLAC)
---- | ---
-Old implementation | <audio controls src="https://archive.org/download/dosbox-staging-v0.76.0-gravis-ultrasound-improvements/rott-before.flac"> Your browser does not support the <code>audio</code> element.</audio>
-New implementation (with improvements) | <audio controls src="https://archive.org/download/dosbox-staging-v0.76.0-gravis-ultrasound-improvements/rott-after.flac"> Your browser does not support the <code>audio</code> element.</audio>
+| GUS emulator                           | Sample (FLAC)                                                                                                                                                                                    |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Old implementation                     | <audio controls src="https://archive.org/download/dosbox-staging-v0.76.0-gravis-ultrasound-improvements/rott-before.flac"> Your browser does not support the <code>audio</code> element.</audio> |
+| New implementation (with improvements) | <audio controls src="https://archive.org/download/dosbox-staging-v0.76.0-gravis-ultrasound-improvements/rott-after.flac"> Your browser does not support the <code>audio</code> element.</audio>  |
 
 Several changes have been made to the GUS emulation resulting in (sometimes)
 audible differences, as follows:

--- a/website/docs/getting-started/dark-forces.md
+++ b/website/docs/getting-started/dark-forces.md
@@ -132,12 +132,12 @@ the slight judder resulting from the 60/70 Hz mismatch.
 
 For reference, these are the refresh rates of all emulated graphics cards:
 
-| Graphics adapter      | Refresh rate
-| ----------------------| -------------
-| SVGA and VESA         | 70 Hz or higher --- 640&times;480 or higher extended and VESA modes
-| VGA                   | 60 Hz --- 640&times;480 standard mode only<br>70 Hz --- all other standard modes
-| CGA, PCjr, Tandy, EGA | 60 Hz
-| Hercules              | 50 Hz
+| Graphics adapter      | Refresh rate                                                                     |
+|-----------------------|----------------------------------------------------------------------------------|
+| SVGA and VESA         | 70 Hz or higher --- 640&times;480 or higher extended and VESA modes              |
+| VGA                   | 60 Hz --- 640&times;480 standard mode only<br>70 Hz --- all other standard modes |
+| CGA, PCjr, Tandy, EGA | 60 Hz                                                                            |
+| Hercules              | 50 Hz                                                                            |
 
 !!! tip "Creating custom 60 and 70 Hz screen modes"
 


### PR DESCRIPTION
# Description

Cleanup table formatting (white-space / table tokens) in a couple markdown files using an auto-formatter.  No content changes.

## Related issues

The latest update of the markdown linter catches MD055 and MD057, which are flagged:

```text
README.md:26: MD055 Table row doesn't begin/end with pipes
README.md:27: MD055 Table row doesn't begin/end with pipes
README.md:28: MD055 Table row doesn't begin/end with pipes
README.md:29: MD055 Table row doesn't begin/end with pipes
README.md:30: MD055 Table row doesn't begin/end with pipes
README.md:31: MD055 Table row doesn't begin/end with pipes
README.md:32: MD055 Table row doesn't begin/end with pipes
README.md:33: MD055 Table row doesn't begin/end with pipes
README.md:34: MD055 Table row doesn't begin/end with pipes
README.md:35: MD055 Table row doesn't begin/end with pipes
README.md:36: MD055 Table row doesn't begin/end with pipes
README.md:37: MD055 Table row doesn't begin/end with pipes
README.md:38: MD055 Table row doesn't begin/end with pipes
README.md:39: MD055 Table row doesn't begin/end with pipes
README.md:51: MD055 Table row doesn't begin/end with pipes
README.md:52: MD055 Table row doesn't begin/end with pipes
README.md:53: MD055 Table row doesn't begin/end with pipes
README.md:54: MD055 Table row doesn't begin/end with pipes
README.md:55: MD055 Table row doesn't begin/end with pipes
README.md:56: MD055 Table row doesn't begin/end with pipes
README.md:57: MD055 Table row doesn't begin/end with pipes
README.md:58: MD055 Table row doesn't begin/end with pipes
README.md:59: MD055 Table row doesn't begin/end with pipes
README.md:60: MD055 Table row doesn't begin/end with pipes
README.md:61: MD055 Table row doesn't begin/end with pipes
README.md:62: MD055 Table row doesn't begin/end with pipes
README.md:63: MD055 Table row doesn't begin/end with pipes
README.md:64: MD055 Table row doesn't begin/end with pipes
README.md:65: MD055 Table row doesn't begin/end with pipes
README.md:66: MD055 Table row doesn't begin/end with pipes
README.md:67: MD055 Table row doesn't begin/end with pipes
README.md:68: MD055 Table row doesn't begin/end with pipes
README.md:69: MD055 Table row doesn't begin/end with pipes
README.md:70: MD055 Table row doesn't begin/end with pipes
README.md:71: MD055 Table row doesn't begin/end with pipes
README.md:72: MD055 Table row doesn't begin/end with pipes
README.md:73: MD055 Table row doesn't begin/end with pipes
README.md:74: MD055 Table row doesn't begin/end with pipes
README.md:75: MD055 Table row doesn't begin/end with pipes
README.md:76: MD055 Table row doesn't begin/end with pipes
README.md:77: MD055 Table row doesn't begin/end with pipes
README.md:78: MD055 Table row doesn't begin/end with pipes
README.md:79: MD055 Table row doesn't begin/end with pipes
README.md:80: MD055 Table row doesn't begin/end with pipes
README.md:81: MD055 Table row doesn't begin/end with pipes
README.md:82: MD055 Table row doesn't begin/end with pipes
README.md:83: MD055 Table row doesn't begin/end with pipes
README.md:27: MD057 Table has missing or invalid header separation (second row)
README.md:52: MD057 Table has missing or invalid header separation (second row)
website/docs/downloads/release-notes/0.76.0.md:40: MD055 Table row doesn't begin/end with pipes
website/docs/downloads/release-notes/0.76.0.md:41: MD055 Table row doesn't begin/end with pipes
website/docs/downloads/release-notes/0.76.0.md:42: MD055 Table row doesn't begin/end with pipes
website/docs/downloads/release-notes/0.76.0.md:43: MD055 Table row doesn't begin/end with pipes
website/docs/downloads/release-notes/0.76.0.md:41: MD057 Table has missing or invalid header separation (second row)
website/docs/getting-started/dark-forces.md:135: MD055 Table row doesn't begin/end with pipes
website/docs/getting-started/dark-forces.md:136: MD055 Table row doesn't begin/end with pipes
website/docs/getting-started/dark-forces.md:137: MD055 Table row doesn't begin/end with pipes
website/docs/getting-started/dark-forces.md:138: MD055 Table row doesn't begin/end with pipes
website/docs/getting-started/dark-forces.md:139: MD055 Table row doesn't begin/end with pipes
website/docs/getting-started/dark-forces.md:140: MD055 Table row doesn't begin/end with pipes
website/docs/getting-started/dark-forces.md:136: MD057 Table has missing or invalid header separation (second row)
```

# Manual testing

`mkdocs serve` shows correct table rendering:

![2023-10-03_13-59](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/d0d29eab-d591-45b3-adcc-37363e8c9cfb)

---

![2023-10-03_13-58](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/f70f4769-88dd-4801-9f52-2031a720e750)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

