### PR TITLE
Convert SDLOSXCAGuard files to UTF-8

### DIFF
--- a/src/libs/sdlcd/macosx/SDLOSXCAGuard.c
+++ b/src/libs/sdlcd/macosx/SDLOSXCAGuard.c
@@ -30,7 +30,7 @@
 /*  
     Note: This file hasn't been modified so technically we have to keep the disclaimer :-(
     
-    Copyright:  © Copyright 2002 Apple Computer, Inc. All rights reserved.
+    Copyright:  Â© Copyright 2002 Apple Computer, Inc. All rights reserved.
 
     Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple Computer, Inc.
             ("Apple") in consideration of your agreement to the following terms, and your
@@ -39,7 +39,7 @@
             please do not use, install, modify or redistribute this Apple software.
 
             In consideration of your agreement to abide by the following terms, and subject
-            to these terms, Apple grants you a personal, non-exclusive license, under AppleÕs
+            to these terms, Apple grants you a personal, non-exclusive license, under Appleâ€™s
             copyrights in this original Apple software (the "Apple Software"), to use,
             reproduce, modify and redistribute the Apple Software, with or without
             modifications, in source and/or binary forms; provided that if you redistribute

--- a/src/libs/sdlcd/macosx/SDLOSXCAGuard.h
+++ b/src/libs/sdlcd/macosx/SDLOSXCAGuard.h
@@ -25,7 +25,7 @@
     Note: This file hasn't been modified so technically we have to keep the disclaimer :-(
 
 
-    Copyright:  © Copyright 2002 Apple Computer, Inc. All rights reserved.
+    Copyright:  Â© Copyright 2002 Apple Computer, Inc. All rights reserved.
 
     Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple Computer, Inc.
             ("Apple") in consideration of your agreement to the following terms, and your
@@ -34,7 +34,7 @@
             please do not use, install, modify or redistribute this Apple software.
 
             In consideration of your agreement to abide by the following terms, and subject
-            to these terms, Apple grants you a personal, non-exclusive license, under AppleÕs
+            to these terms, Apple grants you a personal, non-exclusive license, under Appleâ€™s
             copyrights in this original Apple software (the "Apple Software"), to use,
             reproduce, modify and redistribute the Apple Software, with or without
             modifications, in source and/or binary forms; provided that if you redistribute


### PR DESCRIPTION
# Description

This simply coverts the files `SDLOSXCAGuard.c` and `SDLOSXCAGuard.h` from Mac OS Roman to UTF-8, quieting an issue with Clang about "invalid UTF-8 in comment."

# Manual testing

I don't perceive this having any impact to any actual code, but might make the Apple license in those files more readable.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

