### PR TITLE
Zero initalize memory allocation in GrowWriteMask in dyn_cache

### DIFF
--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -574,21 +574,20 @@ void CacheBlock::DeleteWriteMask() {
 
 void CacheBlock::GrowWriteMask(const uint16_t new_mask_len) {
 	// This function is only called to increase the mask
-	auto& curr_mask_len = cache.masklen;
-	assert(new_mask_len > curr_mask_len);
+	assert(new_mask_len > cache.masklen);
 
 	// Allocate the new mask
 	auto new_mask = new uint8_t[new_mask_len];
+	memset(new_mask, 0, new_mask_len);
 
 	// Copy the current into the new
-	auto& curr_mask = cache.wmapmask;
-	std::copy(curr_mask, curr_mask + curr_mask_len, new_mask);
+	std::copy(cache.wmapmask, cache.wmapmask + cache.masklen, new_mask);
 
 	// Update the current
-	delete[] curr_mask;
-	curr_mask = new_mask;
+	delete[] cache.wmapmask;
+	cache.wmapmask = new_mask;
 
-	curr_mask_len = new_mask_len;
+	cache.masklen = new_mask_len;
 }
 
 void CacheBlock::Clear()


### PR DESCRIPTION
Fixes a text rendering bug regression in Alone in the Dark Fixes #2984

# Description

This fixes a regression from https://github.com/dosbox-staging/dosbox-staging/commit/fa4c535efe99e60a004c1053e6b1be4c75549f55

Previously we were using `std::make_unique` to allocate memory which default initializes the memory (clears to zero in the case of `uint8_t[]`.  Now we're just calling `new` which does not guarantee any initialization.

Call `memset` to clear the memory to zero.  Also remove some temporary variables that I felt were making the code harder to read.

## Related issues

Fixes #2984

# Manual testing

- Followed the repro instructions on #2984 
- Performed a git bisect finding https://github.com/dosbox-staging/dosbox-staging/commit/fa4c535efe99e60a004c1053e6b1be4c75549f55 as the first bad commit
- Made this change on main and confirmed it fixed the bug.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

