### PR TITLE
Fix the cache's write mask grow call with a `std::vector` (#2984)

### DIFF
--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -183,19 +183,25 @@ static inline void decode_increase_wmapmask(Bitu size) {
 		activecb->cache.maskstart = decode.page.index;
 	} else {
 		mapidx = decode.page.index - activecb->cache.maskstart;
-		if (GCC_UNLIKELY(mapidx + size >= activecb->cache.masklen)) {
-			size_t new_mask_len = activecb->cache.masklen * 4;
+		assert(activecb->cache.wmapmask);
+		if (GCC_UNLIKELY(mapidx + size >= activecb->cache.wmapmask->size())) {
+			size_t new_mask_len = activecb->cache.wmapmask->size() * 4;
 			if (new_mask_len < mapidx + size) {
 				new_mask_len = ((mapidx + size) & ~3) * 2;
 			}
 			activecb->GrowWriteMask(check_cast<uint16_t>(new_mask_len));
 		}
 	}
+	// The mask is expected to exist and handle the index at this point
+	assert(activecb->cache.wmapmask);
+	assert(mapidx < activecb->cache.wmapmask->size());
+
 	// update mask entries
+	const auto mask_data = activecb->cache.wmapmask->data();
 	switch (size) {
-	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: add_to_unaligned_uint16(&activecb->cache.wmapmask[mapidx], 0x0101); break;
-	case 4: add_to_unaligned_uint32(&activecb->cache.wmapmask[mapidx], 0x01010101); break;
+	case 1: mask_data[mapidx] += 0x01; break;
+	case 2: add_to_unaligned_uint16(mask_data + mapidx, 0x0101); break;
+	case 4: add_to_unaligned_uint32(mask_data + mapidx, 0x01010101); break;
 	}
 }
 

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -259,19 +259,25 @@ static void inline decode_increase_wmapmask(Bitu size) {
 		activecb->cache.maskstart = decode.page.index;
 	} else {
 		mapidx = decode.page.index - activecb->cache.maskstart;
-		if (GCC_UNLIKELY(mapidx + size >= activecb->cache.masklen)) {
-			size_t new_mask_len = activecb->cache.masklen * 4;
+		assert(activecb->cache.wmapmask);
+		if (GCC_UNLIKELY(mapidx + size >= activecb->cache.wmapmask->size())) {
+			size_t new_mask_len = activecb->cache.wmapmask->size() * 4;
 			if (new_mask_len < mapidx + size) {
 				new_mask_len = ((mapidx + size) & ~3) * 2;
 			}
-			activecb->GrowWriteMask(new_mask_len);
+			activecb->GrowWriteMask(check_cast<uint16_t>(new_mask_len));
 		}
 	}
+	// The mask is expected to exist and handle the index at this point
+	assert(activecb->cache.wmapmask);
+	assert(mapidx < activecb->cache.wmapmask->size());
+
 	// update mask entries
+	const auto mask_data = activecb->cache.wmapmask->data();
 	switch (size) {
-	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: add_to_unaligned_uint16(&activecb->cache.wmapmask[mapidx], 0x0101); break;
-	case 4: add_to_unaligned_uint32(&activecb->cache.wmapmask[mapidx], 0x01010101); break;
+	case 1: mask_data[mapidx] += 0x01; break;
+	case 2: add_to_unaligned_uint16(mask_data + mapidx, 0x0101); break;
+	case 4: add_to_unaligned_uint32(mask_data + mapidx, 0x01010101); break;
 	}
 }
 


### PR DESCRIPTION
# Description

Fix the regression in #2984 using a `std::vector` instead of manually managing of the cache's mask (which has a buggy grow implementation), which also eliminates the need for the mask's length member variable.

## Related issues

#2984

# Manual testing

Tested Alone in the Dark using on x86-64 with the dynamic core using sanitizer builds:

```ini
[cpu]
core = dynamic
cycles = 10000

[autoexec]
mount c .
c:
autotype enter , esc , down up down
TATOU.COM
```
# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

