### PR TITLE
Fix for DOS error code being wrongly set on creating files

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -457,10 +457,10 @@ bool localDrive::GetFileAttr(char* name, FatAttributeFlags* attr)
 	CROSS_FILENAME(newname);
 	dirCache.ExpandNameAndNormaliseCase(newname);
 
-	const auto result = local_drive_get_attributes(newname, *attr);
-	if (result != DOSERR_NONE) {
+	if (local_drive_get_attributes(newname, *attr) != DOSERR_NONE) {
+		// The caller is responsible to act accordingly, possibly
+		// it should set DOS error code (setting it here is not allowed)
 		*attr = 0;
-		DOS_SetError(result);
 		return false;
 	}
 


### PR DESCRIPTION
# Description

Due to mistake in file attribute implementation, the DOS error code was being incorrectly set when creating (not overriding!) a new file.

Note to reviewers: I agree that having `localDrive::SetFileAttr` which required to set the DOS error code in case of failure while `localDrive::GetFileAttr` is not allowed to set it, is VERY misleading - but it was like that before our attribute work has started, and I don't want to change the design now.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2978


# Manual testing

Run the _Terminator: SkyNET_ game - it should start correctly now.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

