### PR TITLE
Encapsulate the Cache's write mask functions as members

### DIFF
--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -184,8 +184,8 @@ static bool decode_fetchb_imm(Bitu & val) {
 			if (tlb_addr) {
 				val=(Bitu)(tlb_addr+decode.code);
 				decode.active_block->cache.AddByteToWriteMaskAt(decode.page.index);
-				decode.code++;
-				decode.page.index++;
+				++decode.code;
+				++decode.page.index;
 				return true;
 			}
 		}

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -130,7 +130,7 @@ static uint8_t decode_fetchb(void) {
         /* Advance to the next page */
 		decode.active_block->page.end=4095;
 		/* trigger possible page fault here */
-		decode.page.first++;
+		++decode.page.first;
 		Bitu fetchaddr=decode.page.first << 12;
 		mem_readb(fetchaddr);
 		MakeCodePage(fetchaddr,decode.page.code);
@@ -145,8 +145,8 @@ static uint8_t decode_fetchb(void) {
 		decode.page.index=0;
 	}
 	decode.page.wmap[decode.page.index]+=0x01;
-	decode.page.index++;
-	decode.code+=1;
+	++decode.page.index;
+	++decode.code;
 	return mem_readb(decode.code-1);
 }
 static uint16_t decode_fetchw(void) {
@@ -243,7 +243,9 @@ static bool decode_fetchd_imm(Bitu & val) {
 
 static void dyn_reduce_cycles(void) {
 	gen_protectflags();
-	if (!decode.cycles) decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	gen_dop_word_imm(DOP_SUB,true,DREG(CYCLES),decode.cycles);
 }
 
@@ -328,24 +330,28 @@ static void dyn_check_bool_exception(DynReg * check) {
 	gen_dop_byte(DOP_TEST,check,0,check,0);
 	save_info[used_save_info].branch_pos=gen_create_branch_long(BR_NZ);
 	dyn_savestate(&save_info[used_save_info].state);
-	if (!decode.cycles) decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	save_info[used_save_info].cycles=decode.cycles;
 	save_info[used_save_info].eip_change=decode.op_start-decode.code_start;
 	if (!cpu.code.big) save_info[used_save_info].eip_change&=0xffff;
 	save_info[used_save_info].type=db_exception;
-	used_save_info++;
+	++used_save_info;
 }
 
 static void dyn_check_bool_exception_al(void) {
 	cache_addw(0xC084);     // test al,al
 	save_info[used_save_info].branch_pos=gen_create_branch_long(BR_NZ);
 	dyn_savestate(&save_info[used_save_info].state);
-	if (!decode.cycles) decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	save_info[used_save_info].cycles=decode.cycles;
 	save_info[used_save_info].eip_change=decode.op_start-decode.code_start;
 	if (!cpu.code.big) save_info[used_save_info].eip_change&=0xffff;
 	save_info[used_save_info].type=db_exception;
-	used_save_info++;
+	++used_save_info;
 }
 
 #include "pic.h"
@@ -356,12 +362,14 @@ static void dyn_check_irqrequest(void) {
 	save_info[used_save_info].branch_pos=gen_create_branch_long(BR_NZ);
 	gen_releasereg(DREG(TMPB));
 	dyn_savestate(&save_info[used_save_info].state);
-	if (!decode.cycles) decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	save_info[used_save_info].cycles=decode.cycles;
 	save_info[used_save_info].eip_change=decode.code-decode.code_start;
 	if (!cpu.code.big) save_info[used_save_info].eip_change&=0xffff;
 	save_info[used_save_info].type=normal;
-	used_save_info++;
+	++used_save_info;
 }
 
 static void dyn_fill_blocks(void) {
@@ -472,14 +480,15 @@ static void dyn_write_word_release(DynReg * addr,DynReg * val,bool dword) {
 static void dyn_check_bool_exception_ne(void) {
 	save_info[used_save_info].branch_pos = gen_create_branch_long(BR_Z);
 	dyn_savestate(&save_info[used_save_info].state);
-	if (!decode.cycles)
-		decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	save_info[used_save_info].cycles = decode.cycles;
 	save_info[used_save_info].eip_change = decode.op_start - decode.code_start;
 	if (!cpu.code.big)
 		save_info[used_save_info].eip_change &= 0xffff;
 	save_info[used_save_info].type = db_exception;
-	used_save_info++;
+	++used_save_info;
 }
 
 static void dyn_read_intro(DynReg * addr,bool release_addr=true) {
@@ -2168,7 +2177,7 @@ static void dyn_larlsl(bool islar) {
 	dyn_savestate(&save_info[used_save_info].state);	\
 	save_info[used_save_info].return_pos=cache.pos;		\
 	save_info[used_save_info].type=fpu_restore;			\
-	used_save_info++;									\
+	++used_save_info;									\
 }
 #endif
 #include "dyn_fpu.h"
@@ -2203,7 +2212,7 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 	gen_dop_word(DOP_TEST,true,DREG(CYCLES),DREG(CYCLES));
 	save_info[used_save_info].branch_pos=gen_create_branch_long(BR_LE);
 	save_info[used_save_info].type=cycle_check;
-	used_save_info++;
+	++used_save_info;
 	gen_releasereg(DREG(CYCLES));
 	decode.cycles=0;
 #ifdef X86_DYNFPU_DH_ENABLED
@@ -2215,7 +2224,7 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 		decode.big_op=cpu.code.big;
 		decode.segprefix=nullptr;
 		decode.rep=REP_NONE;
-		decode.cycles++;
+		++decode.cycles;
 		decode.op_start=decode.code;
 restart_prefix:
 		Bitu opcode;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -179,7 +179,7 @@ static inline void decode_increase_wmapmask(Bitu size) {
 	size_t mapidx        = 0;
 	CacheBlock* activecb = decode.active_block;
 	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
-		activecb->GrowWriteMask(START_WMMEM);
+		activecb->cache.GrowWriteMask(START_WMMEM);
 		activecb->cache.maskstart = decode.page.index;
 	} else {
 		mapidx = decode.page.index - activecb->cache.maskstart;
@@ -188,7 +188,7 @@ static inline void decode_increase_wmapmask(Bitu size) {
 			if (new_mask_len < mapidx + size) {
 				new_mask_len = ((mapidx + size) & ~3) * 2;
 			}
-			activecb->GrowWriteMask(check_cast<uint16_t>(new_mask_len));
+			activecb->cache.GrowWriteMask(check_cast<uint16_t>(new_mask_len));
 		}
 	}
 	// update mask entries

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -173,32 +173,6 @@ static uint32_t decode_fetchd(void) {
 	return mem_readd(decode.code-4);
 }
 
-#define START_WMMEM 64
-
-static inline void decode_increase_wmapmask(Bitu size) {
-	size_t mapidx        = 0;
-	CacheBlock* activecb = decode.active_block;
-	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
-		activecb->cache.GrowWriteMask(START_WMMEM);
-		activecb->cache.maskstart = decode.page.index;
-	} else {
-		mapidx = decode.page.index - activecb->cache.maskstart;
-		if (GCC_UNLIKELY(mapidx + size >= activecb->cache.masklen)) {
-			size_t new_mask_len = activecb->cache.masklen * 4;
-			if (new_mask_len < mapidx + size) {
-				new_mask_len = ((mapidx + size) & ~3) * 2;
-			}
-			activecb->cache.GrowWriteMask(check_cast<uint16_t>(new_mask_len));
-		}
-	}
-	// update mask entries
-	switch (size) {
-	case 1: activecb->cache.wmapmask[mapidx] += 0x01; break;
-	case 2: add_to_unaligned_uint16(&activecb->cache.wmapmask[mapidx], 0x0101); break;
-	case 4: add_to_unaligned_uint32(&activecb->cache.wmapmask[mapidx], 0x01010101); break;
-	}
-}
-
 static bool decode_fetchb_imm(Bitu & val) {
 	if (decode.page.index<4096) {
 		if (decode.page.invmap != nullptr) {
@@ -209,7 +183,7 @@ static bool decode_fetchb_imm(Bitu & val) {
 			HostPt tlb_addr=get_tlb_read(decode.code);
 			if (tlb_addr) {
 				val=(Bitu)(tlb_addr+decode.code);
-				decode_increase_wmapmask(1);
+				decode.active_block->cache.AddByteToWriteMaskAt(decode.page.index);
 				decode.code++;
 				decode.page.index++;
 				return true;
@@ -231,9 +205,9 @@ static bool decode_fetchw_imm(Bitu & val) {
 			HostPt tlb_addr=get_tlb_read(decode.code);
 			if (tlb_addr) {
 				val=(Bitu)(tlb_addr+decode.code);
-				decode_increase_wmapmask(2);
-				decode.code+=2;
-				decode.page.index+=2;
+				decode.active_block->cache.AddWordToWriteMaskAt(decode.page.index);
+				decode.code += 2;
+				decode.page.index += 2;
 				return true;
 			}
 		}
@@ -255,9 +229,9 @@ static bool decode_fetchd_imm(Bitu & val) {
 			HostPt tlb_addr=get_tlb_read(decode.code);
 			if (tlb_addr) {
 				val=(Bitu)(tlb_addr+decode.code);
-				decode_increase_wmapmask(4);
-				decode.code+=4;
-				decode.page.index+=4;
+				decode.active_block->cache.AddDwordToWriteMaskAt(decode.page.index);
+				decode.code += 4;
+				decode.page.index += 4;
 				return true;
 			}
 		}

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -196,7 +196,7 @@ static void decode_advancepage(void) {
 	// Advance to the next page
 	decode.active_block->page.end=4095;
 	// trigger possible page fault here
-	decode.page.first++;
+	++decode.page.first;
 	Bitu faddr=decode.page.first << 12;
 	mem_readb(faddr);
 	MakeCodePage(faddr,decode.page.code);
@@ -217,8 +217,8 @@ static uint8_t decode_fetchb(void) {
 		decode_advancepage();
 	}
 	decode.page.wmap[decode.page.index]+=0x01;
-	decode.page.index++;
-	decode.code+=1;
+	++decode.page.index;
+	++decode.code;
 	return mem_readb(decode.code-1);
 }
 // fetch the next word of the instruction stream
@@ -428,7 +428,9 @@ static void inline dyn_get_modrm(void) {
 
 // adjust CPU_Cycles value
 static void dyn_reduce_cycles(void) {
-	if (!decode.cycles) decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	gen_sub_direct_word(&CPU_Cycles,decode.cycles,true);
 }
 
@@ -637,13 +639,15 @@ static void dyn_closeblock(void) {
 // add a check that can branch to the exception handling
 static void dyn_check_exception(HostReg reg) {
 	save_info_dynrec[used_save_info_dynrec].branch_pos=gen_create_branch_long_nonzero(reg,false);
-	if (!decode.cycles) decode.cycles++;
+	if (!decode.cycles) {
+		++decode.cycles;
+	}
 	save_info_dynrec[used_save_info_dynrec].cycles=decode.cycles;
 	// in case of an exception eip will point to the start of the current instruction
 	save_info_dynrec[used_save_info_dynrec].eip_change=decode.op_start-decode.code_start;
 	if (!cpu.code.big) save_info_dynrec[used_save_info_dynrec].eip_change&=0xffff;
 	save_info_dynrec[used_save_info_dynrec].type=db_exception;
-	used_save_info_dynrec++;
+	++used_save_info_dynrec;
 }
 
 bool DRC_CALL_CONV mem_readb_checked_drc(PhysPt address) DRC_FC;
@@ -1190,7 +1194,7 @@ static void InvalidateFlagsPartially(void* current_simple_function,Bitu flags_ty
 	mf_functions[mf_functions_num].pos=cache.pos;
 	mf_functions[mf_functions_num].fct_ptr=current_simple_function;
 	mf_functions[mf_functions_num].ftype=flags_type;
-	mf_functions_num++;
+	++mf_functions_num;
 #endif
 }
 
@@ -1202,7 +1206,7 @@ static void InvalidateFlagsPartially(void* current_simple_function,const uint8_t
 	mf_functions[mf_functions_num].pos=cpos;
 	mf_functions[mf_functions_num].fct_ptr=current_simple_function;
 	mf_functions[mf_functions_num].ftype=flags_type;
-	mf_functions_num++;
+	++mf_functions_num;
 #endif
 }
 

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -255,7 +255,7 @@ static void inline decode_increase_wmapmask(Bitu size) {
 	size_t mapidx        = 0;
 	CacheBlock* activecb = decode.active_block;
 	if (GCC_UNLIKELY(!activecb->cache.wmapmask)) {
-		activecb->GrowWriteMask(START_WMMEM);
+		activecb->cache.GrowWriteMask(START_WMMEM);
 		activecb->cache.maskstart = decode.page.index;
 	} else {
 		mapidx = decode.page.index - activecb->cache.maskstart;
@@ -264,7 +264,7 @@ static void inline decode_increase_wmapmask(Bitu size) {
 			if (new_mask_len < mapidx + size) {
 				new_mask_len = ((mapidx + size) & ~3) * 2;
 			}
-			activecb->GrowWriteMask(new_mask_len);
+			activecb->cache.GrowWriteMask(new_mask_len);
 		}
 	}
 	// update mask entries

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -265,8 +265,8 @@ static bool decode_fetchb_imm(Bitu & val) {
 		if (tlb_addr) {
 			val=(Bitu)(tlb_addr+decode.code);
 			decode.active_block->cache.AddByteToWriteMaskAt(decode.page.index);
-			decode.code++;
-			decode.page.index++;
+			++decode.code;
+			++decode.page.index;
 			return true;
 		}
 	}


### PR DESCRIPTION
# Description

This PR is a small refactoring that encapsulates the `Cache`'s write-map mask functionality as member functions, which simplifies their code but also reduces pointer dereferences (as they're not drilling into two levels of structs).

Additionally, this eliminates the duplicate `decode_increase_wmapmask` functions.

Suggest reviewing commit-by-commit.

@weirddan455 , this re-purposes the de-referencing cleanup done in the `std::vector` write map branch, but now on top of the current `main` code. I've tossed that vector branch  :-)

# Manual testing

Tested release and sanitizer builds of the benchmarks, Alone in the Dark, Windows 3.1 applications, as well as builds with the dynamic-core disabled (`-Ddynamic_core=none`) and `-Ddynamic_core=dynrec`.

Performance is unaffected and the branch's release-build dynrec ASM files are just a bit smaller (`693064` bytes for main, `692828` for the branch; that said.. the PR's goal is just to de-dupe and move a bit of this mask functionality closer to the variables they operates on).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

