### PR TITLE
Bump the fluidsynth, glib, gtest, libjpeg-turbo, and mt32emu wraps

### DIFF
--- a/subprojects/fluidsynth.wrap
+++ b/subprojects/fluidsynth.wrap
@@ -3,11 +3,11 @@ directory = fluidsynth-2.3.3
 source_url = https://github.com/FluidSynth/fluidsynth/archive/v2.3.3.tar.gz
 source_filename = fluidsynth-2.3.3.tar.gz
 source_hash = 321f7d3f72206b2522f30a1cb8ad1936fd4533ffc4d29dd335b1953c9fb371e6
-patch_filename = fluidsynth_2.3.3-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/fluidsynth_2.3.3-1/get_patch
-patch_hash = 788bf5c2d25947c3f532961b64f08bb05386a942b30dbf295e13416c67a63613
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fluidsynth_2.3.3-1/fluidsynth-2.3.3.tar.gz
-wrapdb_version = 2.3.3-1
+patch_filename = fluidsynth_2.3.3-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fluidsynth_2.3.3-2/get_patch
+patch_hash = adfafa9f2b4d7af8f7b2218916fff9d70942a9e50bb69d4642b8e8f5cbb22ae3
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fluidsynth_2.3.3-2/fluidsynth-2.3.3.tar.gz
+wrapdb_version = 2.3.3-2
 
 [provide]
 fluidsynth = fluidsynth_dep

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = glib-2.76.4
-source_url = https://download.gnome.org/sources/glib/2.76/glib-2.76.4.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/glib_2.76.4-1/glib-2.76.4.tar.xz
-source_filename = glib-2.76.4.tar.xz
-source_hash = 5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda
-wrapdb_version = 2.76.4-1
+directory = glib-2.78.0
+source_url = https://download.gnome.org/sources/glib/2.78/glib-2.78.0.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/glib_2.78.0-1/glib-2.78.0.tar.xz
+source_filename = glib-2.78.0.tar.xz
+source_hash = 44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30
+wrapdb_version = 2.78.0-1
 
 [provide]
 dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = googletest-1.13.0
-source_url = https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
-source_filename = gtest-1.13.0.tar.gz
-source_hash = ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363
-patch_filename = gtest_1.13.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.13.0-1/get_patch
-patch_hash = 6d82a02c3a45071cea989983bf6becde801cbbfd29196ba30dada0215393b082
-wrapdb_version = 1.13.0-1
+directory = googletest-1.14.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+source_filename = gtest-1.14.0.tar.gz
+source_hash = 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+patch_filename = gtest_1.14.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.14.0-1/get_patch
+patch_hash = 2e693c7d3f9370a7aa6dac802bada0874d3198ad4cfdf75647b818f691182b50
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.14.0-1/gtest-1.14.0.tar.gz
+wrapdb_version = 1.14.0-1
 
 [provide]
 gtest = gtest_dep

--- a/subprojects/libjpeg-turbo.wrap
+++ b/subprojects/libjpeg-turbo.wrap
@@ -3,11 +3,11 @@ directory = libjpeg-turbo-3.0.0
 source_url = https://sourceforge.net/projects/libjpeg-turbo/files/3.0.0/libjpeg-turbo-3.0.0.tar.gz
 source_filename = libjpeg-turbo-3.0.0.tar.gz
 source_hash = c77c65fcce3d33417b2e90432e7a0eb05f59a7fff884022a9d931775d583bfaa
-patch_filename = libjpeg-turbo_3.0.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.0.0-1/get_patch
-patch_hash = 8e1de0730d26ccc7f35c8bff9474621084ccc4634e7deb1a7ab2d0fac491b39d
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libjpeg-turbo_3.0.0-1/libjpeg-turbo-3.0.0.tar.gz
-wrapdb_version = 3.0.0-1
+patch_filename = libjpeg-turbo_3.0.0-5_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.0.0-5/get_patch
+patch_hash = 32391e47d23690674f824b7e485cb212d85d32177ae87f22f82f8d7be2993ec3
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libjpeg-turbo_3.0.0-5/libjpeg-turbo-3.0.0.tar.gz
+wrapdb_version = 3.0.0-5
 
 [provide]
-dependency_names = libjpeg
+dependency_names = libjpeg, libturbojpeg

--- a/subprojects/mt32emu.wrap
+++ b/subprojects/mt32emu.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = munt-libmt32emu_2_7_0
-source_url = https://github.com/munt/munt/archive/libmt32emu_2_7_0.tar.gz
-source_filename = libmt32emu_2_7_0.tar.gz
-source_hash = 5ede7c3d28a3bb0d9e637935b8b96484fadb409c9e5952a9e5432b3e05e5dbc1
-patch_filename = mt32emu_2.7.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/mt32emu_2.7.0-1/get_patch
-patch_hash = 58a3c7a74a7ef91ba60544a4ec4c3688474f7f6cb1a8b8a0ea81459f9eb92e01
-wrapdb_version = 2.7.0-1
+directory = munt-libmt32emu_2_7_1
+source_url = https://github.com/munt/munt/archive/libmt32emu_2_7_1.tar.gz
+source_filename = libmt32emu_2_7_1.tar.gz
+source_hash = e4524d52d6799a4e32a961a2e92074f14adcb2f110a4e7a06bede77050cfdaf4
+patch_filename = mt32emu_2.7.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/mt32emu_2.7.1-1/get_patch
+patch_hash = 2477830f61767670e90819457b65f9fc4e1dd915ebfddaf0d9607ebf260d67c0
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/mt32emu_2.7.1-1/libmt32emu_2_7_1.tar.gz
+wrapdb_version = 2.7.1-1
 
 [provide]
 mt32emu = mt32emu_dep

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = zlib-1.2.13
-source_url = http://zlib.net/fossils/zlib-1.2.13.tar.gz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.2.13-4/zlib-1.2.13.tar.gz
-source_filename = zlib-1.2.13.tar.gz
-source_hash = b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
-patch_filename = zlib_1.2.13-4_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.2.13-4/get_patch
-patch_hash = 19636b7807e679b92240bc7a99aed85d1be908a45430b12c7687a825cb499d5e
-wrapdb_version = 1.2.13-4
+directory = zlib-1.3
+source_url = http://zlib.net/fossils/zlib-1.3.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3-3/zlib-1.3.tar.gz
+source_filename = zlib-1.3.tar.gz
+source_hash = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
+patch_filename = zlib_1.3-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3-3/get_patch
+patch_hash = dcb86003e945761dc47aed34b6179003c5e68ddbca4cf71ebc5875ae57b76b8e
+wrapdb_version = 1.3-3
 
 [provide]
 zlib = zlib_dep


### PR DESCRIPTION
# Description

Update a handful of wraps to get in sync with latest revs.

# Manual testing

Tested release and debug builds forcing the use of the **gtest**, **fluidsynth**, and **mt32emu** wraps. 

@johnnovak, hopefully this fixes #2985.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

