### PR TITLE
Do not assert if mapperfile parameter is empty

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -3173,7 +3173,7 @@ void MAPPER_BindKeys(Section *sec)
 	const auto section = static_cast<const Section_prop *>(sec);
 	const auto mapperfile_value = section->Get_string("mapperfile");
 	const auto property = section->Get_path("mapperfile");
-	assert(property && !property->realpath.empty());
+	assert(property);
 	mapper.filename = property->realpath.string();
 
 	QueryJoysticks();


### PR DESCRIPTION
# Description

If mapper file parameter is empty, as in example:

```ini
[sdl]
mapperfile =
```

the debug build asserts. This is caused by too strict assertion in the `MAPPER_BindKeys` function:

```C++
static bool load_binds_from_file(const std::string_view mapperfile_path,
                                 const std::string_view mapperfile_name)
{
	// If the filename is empty the user wants defaults
	if (mapperfile_name == "")
		return false;
	// ...
}

void MAPPER_BindKeys(Section *sec)
{
	// ...
	assert(property && !property->realpath.empty());      // <-- this assertion is too strict
	mapper.filename = property->realpath.string();
	// ...
	if (!load_binds_from_file(mapper.filename, mapperfile_value))
		CreateDefaultBinds();
	// ...
}
```

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2977


# Manual testing

I was using configuration with an empty `mapperfile` for a while and I didn't notice any problems.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

