### PR TITLE
Rework shader loading

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -180,6 +180,7 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
                                   [[maybe_unused]] const uint16_t canvas_height,
                                   [[maybe_unused]] const VideoMode& video_mode,
                                   [[maybe_unused]] const bool reinit_render);
+const std::string RENDER_GetShaderSource();
 
 void RENDER_NotifyEgaModeWithVgaPalette();
 

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -173,11 +173,9 @@ struct SDL_Block {
 		int pitch = 0;
 		void* framebuf = nullptr;
 		GLuint texture;
-		GLuint displaylist;
 		GLint max_texsize;
 		bool bilinear;
 		bool npot_textures_supported = false;
-		bool use_shader;
 		bool framebuffer_is_srgb_encoded;
 		GLuint program_object;
 

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -177,17 +177,7 @@ struct SDL_Block {
 		bool bilinear;
 		bool npot_textures_supported = false;
 		bool framebuffer_is_srgb_encoded;
-		GLuint program_object;
 
-		ShaderInfo shader_info    = {};
-		std::string shader_source = {};
-
-		struct {
-			GLint texture_size;
-			GLint input_size;
-			GLint output_size;
-			GLint frame_count;
-		} ruby = {};
 		GLuint actual_frame_count;
 		GLfloat vertex_data[2*3];
 	} opengl = {};

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -171,13 +171,11 @@ struct SDL_Block {
 	struct {
 		SDL_GLContext context;
 		int pitch = 0;
-		void *framebuf = nullptr;
-		GLuint buffer;
+		void* framebuf = nullptr;
 		GLuint texture;
 		GLuint displaylist;
 		GLint max_texsize;
 		bool bilinear;
-		bool pixel_buffer_object = false;
 		bool npot_textures_supported = false;
 		bool use_shader;
 		bool framebuffer_is_srgb_encoded;

--- a/include/video.h
+++ b/include/video.h
@@ -302,7 +302,7 @@ uint32_t GFX_GetRGB(const uint8_t red, const uint8_t green, const uint8_t blue);
 
 struct ShaderInfo;
 
-void GFX_SetShader(const ShaderInfo& shader_info, const std::string& shader_source);
+bool GFX_SetShader(const ShaderInfo& shader_info);
 
 void GFX_SetIntegerScalingMode(const IntegerScalingMode mode);
 IntegerScalingMode GFX_GetIntegerScalingMode();

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -422,8 +422,7 @@ static void render_reset(void)
 	}
 
 	if (GFX_GetRenderingBackend() == RenderingBackend::OpenGl) {
-		GFX_SetShader(get_shader_manager().GetCurrentShaderInfo(),
-		              get_shader_manager().GetCurrentShaderSource());
+		GFX_SetShader(get_shader_manager().GetCurrentShaderInfo());
 	}
 
 	const auto render_pixel_aspect_ratio = render.src.pixel_aspect_ratio;
@@ -624,6 +623,11 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
 		}
 	}
 	return changed_shader;
+}
+
+const std::string RENDER_GetShaderSource()
+{
+	return get_shader_manager().GetCurrentShaderSource();
 }
 
 void RENDER_NotifyEgaModeWithVgaPalette()

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1761,11 +1761,11 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		const std::string gl_vendor = safe_gl_get_string(GL_VENDOR,
 		                                                 "unknown vendor");
-#	if WIN32
+#if WIN32
 		const auto is_vendors_srgb_unreliable = (gl_vendor == "Intel");
-#	else
+#else
 		constexpr auto is_vendors_srgb_unreliable = false;
-#	endif
+#endif
 		if (is_vendors_srgb_unreliable) {
 			LOG_WARNING("SDL:OPENGL: Not requesting an sRGB framebuffer"
 			            " because %s's driver is unreliable",
@@ -1786,99 +1786,123 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		/* We may simply use SDL_BYTESPERPIXEL
 		here rather than SDL_BITSPERPIXEL   */
-		if (!sdl.window || SDL_BYTESPERPIXEL(SDL_GetWindowPixelFormat(sdl.window))<2) {
+		if (!sdl.window ||
+		    SDL_BYTESPERPIXEL(SDL_GetWindowPixelFormat(sdl.window)) < 2) {
 			LOG_WARNING("SDL:OPENGL: Can't open drawing window, are you running in 16bpp (or higher) mode?");
 			goto fallback_texture;
 		}
 
-		if (sdl.opengl.use_shader) {
-			GLuint prog=0;
-			// reset error
-			glGetError();
-			glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&prog);
-			// if there was an error this context doesn't support shaders
-			if (glGetError()==GL_NO_ERROR && (sdl.opengl.program_object==0 || prog!=sdl.opengl.program_object)) {
-				// check if existing program is valid
-				if (sdl.opengl.program_object) {
-					glUseProgram(sdl.opengl.program_object);
-					if (glGetError() != GL_NO_ERROR) {
-						// program is not usable (probably new context), purge it
-						glDeleteProgram(sdl.opengl.program_object);
-						sdl.opengl.program_object = 0;
-					}
+		GLuint prog = 0;
+		// reset error
+		glGetError();
+		glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&prog);
+		// if there was an error this context doesn't support shaders
+		if (glGetError() == GL_NO_ERROR &&
+		    (sdl.opengl.program_object == 0 ||
+		     prog != sdl.opengl.program_object)) {
+			// check if existing program is valid
+			if (sdl.opengl.program_object) {
+				glUseProgram(sdl.opengl.program_object);
+				if (glGetError() != GL_NO_ERROR) {
+					// program is not usable (probably new
+					// context), purge it
+					glDeleteProgram(sdl.opengl.program_object);
+					sdl.opengl.program_object = 0;
+				}
+			}
+
+			// does program need to be rebuilt?
+			if (sdl.opengl.program_object == 0) {
+				GLuint vertexShader, fragmentShader;
+
+				if (!LoadGLShaders(sdl.opengl.shader_source,
+				                   &vertexShader,
+				                   &fragmentShader)) {
+					LOG_ERR("SDL:OPENGL: Failed to compile shader!");
+					goto fallback_texture;
 				}
 
-				// does program need to be rebuilt?
-				if (sdl.opengl.program_object == 0) {
-					GLuint vertexShader, fragmentShader;
-
-					if (!LoadGLShaders(sdl.opengl.shader_source,
-					                   &vertexShader,
-					                   &fragmentShader)) {
-						LOG_ERR("SDL:OPENGL: Failed to compile shader!");
-						goto fallback_texture;
-					}
-
-					sdl.opengl.program_object = glCreateProgram();
-					if (!sdl.opengl.program_object) {
-						glDeleteShader(vertexShader);
-						glDeleteShader(fragmentShader);
-						LOG_WARNING("SDL:OPENGL: Can't create program object, falling back to texture");
-						goto fallback_texture;
-					}
-					glAttachShader(sdl.opengl.program_object, vertexShader);
-					glAttachShader(sdl.opengl.program_object, fragmentShader);
-					// Link the program
-					glLinkProgram(sdl.opengl.program_object);
-					// Even if we *are* successful, we may delete the shader objects
+				sdl.opengl.program_object = glCreateProgram();
+				if (!sdl.opengl.program_object) {
 					glDeleteShader(vertexShader);
 					glDeleteShader(fragmentShader);
-
-					// Check the link status
-					GLint isProgramLinked;
-					glGetProgramiv(sdl.opengl.program_object, GL_LINK_STATUS, &isProgramLinked);
-					if (!isProgramLinked) {
-						GLint info_len = 0;
-						glGetProgramiv(sdl.opengl.program_object, GL_INFO_LOG_LENGTH, &info_len);
-
-						if (info_len > 1) {
-							std::vector<GLchar> info_log(info_len);
-							glGetProgramInfoLog(sdl.opengl.program_object, info_len, nullptr, info_log.data());
-							LOG_ERR("SDL:OPENGL: Error link program:\n %s", info_log.data());
-						}
-						glDeleteProgram(sdl.opengl.program_object);
-						sdl.opengl.program_object = 0;
-						goto fallback_texture;
-					}
-
-					glUseProgram(sdl.opengl.program_object);
-
-					GLint u = glGetAttribLocation(sdl.opengl.program_object, "a_position");
-					// upper left
-					sdl.opengl.vertex_data[0] = -1.0f;
-					sdl.opengl.vertex_data[1] = 1.0f;
-					// lower left
-					sdl.opengl.vertex_data[2] = -1.0f;
-					sdl.opengl.vertex_data[3] = -3.0f;
-					// upper right
-					sdl.opengl.vertex_data[4] = 3.0f;
-					sdl.opengl.vertex_data[5] = 1.0f;
-					// Load the vertex positions
-					glVertexAttribPointer(u, 2, GL_FLOAT, GL_FALSE, 0, sdl.opengl.vertex_data);
-					glEnableVertexAttribArray(u);
-
-					u = glGetUniformLocation(sdl.opengl.program_object, "rubyTexture");
-					glUniform1i(u, 0);
-
-					sdl.opengl.ruby.texture_size = glGetUniformLocation(sdl.opengl.program_object, "rubyTextureSize");
-					sdl.opengl.ruby.input_size = glGetUniformLocation(sdl.opengl.program_object, "rubyInputSize");
-					sdl.opengl.ruby.output_size = glGetUniformLocation(sdl.opengl.program_object, "rubyOutputSize");
-					sdl.opengl.ruby.frame_count = glGetUniformLocation(sdl.opengl.program_object, "rubyFrameCount");
+					LOG_WARNING("SDL:OPENGL: Can't create program object, falling back to texture");
+					goto fallback_texture;
 				}
+				glAttachShader(sdl.opengl.program_object,
+				               vertexShader);
+				glAttachShader(sdl.opengl.program_object,
+				               fragmentShader);
+				// Link the program
+				glLinkProgram(sdl.opengl.program_object);
+				// Even if we *are* successful, we may delete
+				// the shader objects
+				glDeleteShader(vertexShader);
+				glDeleteShader(fragmentShader);
+
+				// Check the link status
+				GLint isProgramLinked;
+				glGetProgramiv(sdl.opengl.program_object,
+				               GL_LINK_STATUS,
+				               &isProgramLinked);
+				if (!isProgramLinked) {
+					GLint info_len = 0;
+					glGetProgramiv(sdl.opengl.program_object,
+					               GL_INFO_LOG_LENGTH,
+					               &info_len);
+
+					if (info_len > 1) {
+						std::vector<GLchar> info_log(info_len);
+						glGetProgramInfoLog(sdl.opengl.program_object,
+						                    info_len,
+						                    nullptr,
+						                    info_log.data());
+						LOG_ERR("SDL:OPENGL: Error link program:\n %s",
+						        info_log.data());
+					}
+					glDeleteProgram(sdl.opengl.program_object);
+					sdl.opengl.program_object = 0;
+					goto fallback_texture;
+				}
+
+				glUseProgram(sdl.opengl.program_object);
+
+				GLint u = glGetAttribLocation(sdl.opengl.program_object,
+				                              "a_position");
+				// upper left
+				sdl.opengl.vertex_data[0] = -1.0f;
+				sdl.opengl.vertex_data[1] = 1.0f;
+				// lower left
+				sdl.opengl.vertex_data[2] = -1.0f;
+				sdl.opengl.vertex_data[3] = -3.0f;
+				// upper right
+				sdl.opengl.vertex_data[4] = 3.0f;
+				sdl.opengl.vertex_data[5] = 1.0f;
+				// Load the vertex positions
+				glVertexAttribPointer(u,
+				                      2,
+				                      GL_FLOAT,
+				                      GL_FALSE,
+				                      0,
+				                      sdl.opengl.vertex_data);
+				glEnableVertexAttribArray(u);
+
+				u = glGetUniformLocation(sdl.opengl.program_object,
+				                         "rubyTexture");
+				glUniform1i(u, 0);
+
+				sdl.opengl.ruby.texture_size = glGetUniformLocation(
+				        sdl.opengl.program_object, "rubyTextureSize");
+				sdl.opengl.ruby.input_size = glGetUniformLocation(
+				        sdl.opengl.program_object, "rubyInputSize");
+				sdl.opengl.ruby.output_size = glGetUniformLocation(
+				        sdl.opengl.program_object, "rubyOutputSize");
+				sdl.opengl.ruby.frame_count = glGetUniformLocation(
+				        sdl.opengl.program_object, "rubyFrameCount");
 			}
 		}
 
-		/* Create the texture and display list */
+		/* Create the texture */
 		const auto framebuffer_bytes = static_cast<size_t>(width) *
 		                               height * MAX_BYTES_PER_PIXEL;
 		sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
@@ -1903,10 +1927,10 @@ uint8_t GFX_SetSize(const int width, const int height,
 		glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
 
 		if (sdl.opengl.texture > 0) {
-			glDeleteTextures(1,&sdl.opengl.texture);
+			glDeleteTextures(1, &sdl.opengl.texture);
 		}
 		glGenTextures(1, &sdl.opengl.texture);
-		glBindTexture(GL_TEXTURE_2D,sdl.opengl.texture);
+		glBindTexture(GL_TEXTURE_2D, sdl.opengl.texture);
 
 		// No borders
 		const auto wrap_parameter = use_npot_texture ? GL_CLAMP_TO_EDGE
@@ -1924,7 +1948,7 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		const auto texture_area_bytes = static_cast<size_t>(texsize_w) *
 		                                texsize_h * MAX_BYTES_PER_PIXEL;
-		uint8_t *emptytex = new uint8_t[texture_area_bytes];
+		uint8_t* emptytex = new uint8_t[texture_area_bytes];
 		assert(emptytex);
 
 		memset(emptytex, 0, texture_area_bytes);
@@ -1989,41 +2013,16 @@ uint8_t GFX_SetSize(const int width, const int height,
 		glDisable(GL_CULL_FACE);
 		glEnable(GL_TEXTURE_2D);
 
-		if (sdl.opengl.program_object) {
-			// Set shader variables
-			glUniform2f(sdl.opengl.ruby.texture_size,
-			            (GLfloat)texsize_w, (GLfloat)texsize_h);
-			glUniform2f(sdl.opengl.ruby.input_size,
-			            (GLfloat)width,
-			            (GLfloat)height);
-			glUniform2f(sdl.opengl.ruby.output_size, (GLfloat)sdl.clip.w, (GLfloat)sdl.clip.h);
-			// The following uniform is *not* set right now
-			sdl.opengl.actual_frame_count = 0;
-		} else {
-			GLfloat tex_width = ((GLfloat)width / (GLfloat)texsize_w);
-			GLfloat tex_height = ((GLfloat)height / (GLfloat)texsize_h);
-
-			glShadeModel(GL_FLAT);
-			glMatrixMode(GL_MODELVIEW);
-			glLoadIdentity();
-
-			if (glIsList(sdl.opengl.displaylist)) glDeleteLists(sdl.opengl.displaylist, 1);
-			sdl.opengl.displaylist = glGenLists(1);
-			glNewList(sdl.opengl.displaylist, GL_COMPILE);
-
-			//Create one huge triangle and only display a portion.
-			//When using a quad, there was scaling bug (certain resolutions on Nvidia chipsets) in the seam
-			glBegin(GL_TRIANGLES);
-			// upper left
-			glTexCoord2f(0,0); glVertex2f(-1.0f, 1.0f);
-			// lower left
-			glTexCoord2f(0,tex_height*2); glVertex2f(-1.0f,-3.0f);
-			// upper right
-			glTexCoord2f(tex_width*2,0); glVertex2f(3.0f, 1.0f);
-			glEnd();
-
-			glEndList();
-		}
+		// Set shader variables
+		glUniform2f(sdl.opengl.ruby.texture_size,
+		            (GLfloat)texsize_w,
+		            (GLfloat)texsize_h);
+		glUniform2f(sdl.opengl.ruby.input_size, (GLfloat)width, (GLfloat)height);
+		glUniform2f(sdl.opengl.ruby.output_size,
+		            (GLfloat)sdl.clip.w,
+		            (GLfloat)sdl.clip.h);
+		// The following uniform is *not* set right now
+		sdl.opengl.actual_frame_count = 0;
 
 		OPENGL_ERROR("End of setsize");
 
@@ -2059,9 +2058,6 @@ void GFX_SetShader([[maybe_unused]] const ShaderInfo& shader_info,
 	sdl.opengl.shader_info   = shader_info;
 	sdl.opengl.shader_source = shader_source;
 
-	if (!sdl.opengl.use_shader) {
-		return;
-	}
 	if (sdl.opengl.program_object) {
 		glDeleteProgram(sdl.opengl.program_object);
 		sdl.opengl.program_object = 0;
@@ -2484,13 +2480,9 @@ static bool present_frame_gl()
 	const auto is_presenting = render_pacer->CanRun();
 	if (is_presenting) {
 		glClear(GL_COLOR_BUFFER_BIT);
-		if (sdl.opengl.program_object) {
-			glUniform1i(sdl.opengl.ruby.frame_count,
-			            sdl.opengl.actual_frame_count++);
-			glDrawArrays(GL_TRIANGLES, 0, 3);
-		} else {
-			glCallList(sdl.opengl.displaylist);
-		}
+		glUniform1i(sdl.opengl.ruby.frame_count,
+		            ++sdl.opengl.actual_frame_count);
+		glDrawArrays(GL_TRIANGLES, 0, 3);
 
 		if (CAPTURE_IsCapturingPostRenderImage()) {
 			// glReadPixels() implicitly blocks until all pipelined rendering
@@ -3242,20 +3234,22 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			        "glUseProgram");
 			glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)
 			        SDL_GL_GetProcAddress("glVertexAttribPointer");
-			sdl.opengl.use_shader =
-			        (glAttachShader && glCompileShader &&
-			         glCreateProgram && glDeleteProgram &&
-			         glDeleteShader && glEnableVertexAttribArray &&
-			         glGetAttribLocation && glGetProgramiv &&
-			         glGetProgramInfoLog && glGetShaderiv &&
-			         glGetShaderInfoLog && glGetUniformLocation &&
-			         glLinkProgram && glShaderSource &&
-			         glUniform2f && glUniform1i && glUseProgram &&
-			         glVertexAttribPointer);
+			if (!(glAttachShader && glCompileShader &&
+			      glCreateProgram && glDeleteProgram && glDeleteShader &&
+			      glEnableVertexAttribArray && glGetAttribLocation &&
+			      glGetProgramiv && glGetProgramInfoLog &&
+			      glGetShaderiv && glGetShaderInfoLog &&
+			      glGetUniformLocation && glLinkProgram &&
+			      glShaderSource && glUniform2f && glUniform1i &&
+			      glUseProgram && glVertexAttribPointer)) {
+				LOG_WARNING("OPENGL: No shaders support present, falling back to texture");
+				sdl.want_rendering_backend = RenderingBackend::Texture;
+			}
+		}
 
+		if (sdl.want_rendering_backend == RenderingBackend::OpenGl) {
 			sdl.opengl.framebuf = nullptr;
-			sdl.opengl.texture = 0;
-			sdl.opengl.displaylist = 0;
+			sdl.opengl.texture  = 0;
 			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &sdl.opengl.max_texsize);
 
 			const auto gl_version_string = safe_gl_get_string(GL_VERSION,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -84,31 +84,6 @@
 #define APIENTRYP APIENTRY *
 #endif
 
-#ifndef GL_ARB_pixel_buffer_object
-#define GL_ARB_pixel_buffer_object 1
-#define GL_PIXEL_PACK_BUFFER_ARB           0x88EB
-#define GL_PIXEL_UNPACK_BUFFER_ARB         0x88EC
-#define GL_PIXEL_PACK_BUFFER_BINDING_ARB   0x88ED
-#define GL_PIXEL_UNPACK_BUFFER_BINDING_ARB 0x88EF
-#endif
-
-#ifndef GL_ARB_vertex_buffer_object
-#define GL_ARB_vertex_buffer_object 1
-typedef void (APIENTRYP PFNGLGENBUFFERSARBPROC) (GLsizei n, GLuint *buffers);
-typedef void (APIENTRYP PFNGLBINDBUFFERARBPROC) (GLenum target, GLuint buffer);
-typedef void (APIENTRYP PFNGLDELETEBUFFERSARBPROC) (GLsizei n, const GLuint *buffers);
-typedef void (APIENTRYP PFNGLBUFFERDATAARBPROC) (GLenum target, GLsizeiptr size, const GLvoid *data, GLenum usage);
-typedef GLvoid* (APIENTRYP PFNGLMAPBUFFERARBPROC) (GLenum target, GLenum access);
-typedef GLboolean (APIENTRYP PFNGLUNMAPBUFFERARBPROC) (GLenum target);
-#endif
-
-PFNGLGENBUFFERSARBPROC glGenBuffersARB = nullptr;
-PFNGLBINDBUFFERARBPROC glBindBufferARB = nullptr;
-PFNGLDELETEBUFFERSARBPROC glDeleteBuffersARB = nullptr;
-PFNGLBUFFERDATAARBPROC glBufferDataARB = nullptr;
-PFNGLMAPBUFFERARBPROC glMapBufferARB = nullptr;
-PFNGLUNMAPBUFFERARBPROC glUnmapBufferARB = nullptr;
-
 /* Don't guard these with GL_VERSION_2_0 - Apple defines it but not these typedefs.
  * If they're already defined they should match these definitions, so no conflicts.
  */
@@ -227,8 +202,7 @@ static void HandleVideoResize(int width, int height);
 static void update_frame_texture([[maybe_unused]] const uint16_t* changedLines);
 static bool present_frame_texture();
 #if C_OPENGL
-static void update_frame_gl_pbo([[maybe_unused]] const uint16_t *changedLines);
-static void update_frame_gl_fb(const uint16_t *changedLines);
+static void update_frame_gl(const uint16_t *changedLines);
 static bool present_frame_gl();
 #endif
 
@@ -1750,15 +1724,11 @@ uint8_t GFX_SetSize(const int width, const int height,
 	}
 #if C_OPENGL
 	case RenderingBackend::OpenGl: {
-		if (sdl.opengl.pixel_buffer_object) {
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-			if (sdl.opengl.buffer) glDeleteBuffersARB(1, &sdl.opengl.buffer);
-		} else {
-			free(sdl.opengl.framebuf);
-		}
-		sdl.opengl.framebuf=nullptr;
-		if (!(flags & GFX_CAN_32))
+		free(sdl.opengl.framebuf);
+		sdl.opengl.framebuf = nullptr;
+		if (!(flags & GFX_CAN_32)) {
 			goto fallback_texture;
+		}
 
 		int texsize_w, texsize_h;
 
@@ -1911,17 +1881,10 @@ uint8_t GFX_SetSize(const int width, const int height,
 		/* Create the texture and display list */
 		const auto framebuffer_bytes = static_cast<size_t>(width) *
 		                               height * MAX_BYTES_PER_PIXEL;
-		if (sdl.opengl.pixel_buffer_object) {
-			glGenBuffersARB(1, &sdl.opengl.buffer);
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
-			glBufferDataARB(GL_PIXEL_UNPACK_BUFFER_EXT, framebuffer_bytes, nullptr, GL_STREAM_DRAW_ARB);
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-		} else {
-			sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
-		}
+		sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
 		sdl.opengl.pitch = width * 4;
 
-		// One-time intialize the window size
+		// One-time initialize the window size
 		if (!sdl.desktop.window.adjusted_initial_size) {
 			initialize_sdl_window_size(sdl.window,
 			                           FALLBACK_WINDOW_DIMENSIONS,
@@ -2064,14 +2027,8 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		OPENGL_ERROR("End of setsize");
 
-		retFlags = GFX_CAN_32;
-		if (sdl.opengl.pixel_buffer_object) {
-			sdl.frame.update = update_frame_gl_pbo;
-		} else {
-			sdl.frame.update = update_frame_gl_fb;
-			retFlags |= GFX_CAN_RANDOM;
-		}
-		// Both update mechanisms use the same presentation call
+		retFlags          = GFX_CAN_32 | GFX_CAN_RANDOM;
+		sdl.frame.update  = update_frame_gl;
 		sdl.frame.present = present_frame_gl;
 		break; // RenderingBackend::OpenGl
 	}
@@ -2299,8 +2256,7 @@ static void SwitchFullScreen(bool pressed)
 // This function returns write'able buffer for user to draw upon. Successful
 // return depends on properly initialized SDL_Block structure (which generally
 // can be achieved via GFX_SetSize call), and specifically - properly
-// initialized output-specific bits (sdl.texture, sdl.opengl.framebuf, or
-// sdl.openg.pixel_buffer_object fields).
+// initialized output-specific bits (sdl.texture or sdl.opengl.framebuf fields).
 //
 // If everything is prepared correctly, this function returns true, assigns
 // 'pixels' output parameter to to a buffer (with format specified via earlier
@@ -2321,18 +2277,14 @@ bool GFX_StartUpdate(uint8_t * &pixels, int &pitch)
 		return true;
 #if C_OPENGL
 	case RenderingBackend::OpenGl:
-		if (sdl.opengl.pixel_buffer_object) {
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
-			pixels = static_cast<uint8_t *>(glMapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, GL_WRITE_ONLY));
-		} else {
-			pixels = static_cast<uint8_t *>(sdl.opengl.framebuf);
-		}
+		pixels = static_cast<uint8_t*>(sdl.opengl.framebuf);
 		OPENGL_ERROR("end of start update");
-		if (pixels == nullptr)
+		if (pixels == nullptr) {
 			return false;
+		}
 		static_assert(std::is_same<decltype(pitch), decltype((sdl.opengl.pitch))>::value,
 		              "Our internal pitch types should be the same.");
-		pitch = sdl.opengl.pitch;
+		pitch        = sdl.opengl.pitch;
 		sdl.updating = true;
 		return true;
 #endif
@@ -2499,23 +2451,10 @@ static bool present_frame_texture()
 	return is_presenting;
 }
 
-// OpenGL PBO-based update, frame-based update, and presentation
+// OpenGL frame-based update and presentation
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #if C_OPENGL
-static void update_frame_gl_pbo([[maybe_unused]] const uint16_t *changedLines)
-{
-	if (sdl.updating) {
-		glUnmapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, sdl.draw.width,
-		                sdl.draw.height, GL_BGRA_EXT,
-		                GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
-		glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-	} else {
-		sdl.opengl.actual_frame_count++;
-	}
-}
-
-static void update_frame_gl_fb(const uint16_t *changedLines)
+static void update_frame_gl(const uint16_t* changedLines)
 {
 	if (changedLines) {
 		const auto framebuf = static_cast<uint8_t *>(sdl.opengl.framebuf);
@@ -3314,38 +3253,14 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			         glUniform2f && glUniform1i && glUseProgram &&
 			         glVertexAttribPointer);
 
-			sdl.opengl.buffer = 0;
 			sdl.opengl.framebuf = nullptr;
 			sdl.opengl.texture = 0;
 			sdl.opengl.displaylist = 0;
 			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &sdl.opengl.max_texsize);
 
-			glGenBuffersARB = (PFNGLGENBUFFERSARBPROC)SDL_GL_GetProcAddress(
-			        "glGenBuffersARB");
-			glBindBufferARB = (PFNGLBINDBUFFERARBPROC)SDL_GL_GetProcAddress(
-			        "glBindBufferARB");
-			glDeleteBuffersARB = (PFNGLDELETEBUFFERSARBPROC)
-			        SDL_GL_GetProcAddress("glDeleteBuffersARB");
-			glBufferDataARB = (PFNGLBUFFERDATAARBPROC)SDL_GL_GetProcAddress(
-			        "glBufferDataARB");
-			glMapBufferARB = (PFNGLMAPBUFFERARBPROC)SDL_GL_GetProcAddress(
-			        "glMapBufferARB");
-			glUnmapBufferARB = (PFNGLUNMAPBUFFERARBPROC)SDL_GL_GetProcAddress(
-			        "glUnmapBufferARB");
-			const bool have_arb_buffers = glGenBuffersARB &&
-			                              glBindBufferARB &&
-			                              glDeleteBuffersARB &&
-			                              glBufferDataARB &&
-			                              glMapBufferARB &&
-			                              glUnmapBufferARB;
-
 			const auto gl_version_string = safe_gl_get_string(GL_VERSION,
 			                                                  "0.0.0");
 			const int gl_version_major = gl_version_string[0] - '0';
-
-			sdl.opengl.pixel_buffer_object =
-			        have_arb_buffers &&
-			        SDL_GL_ExtensionSupported("GL_ARB_pixel_buffer_object");
 
 			sdl.opengl.npot_textures_supported =
 			        gl_version_major >= 2 ||
@@ -3365,9 +3280,6 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			         safe_gl_get_string(GL_SHADING_LANGUAGE_VERSION,
 			                            "unknown"));
 
-			LOG_INFO("OPENGL: Pixel buffer object %s",
-			         sdl.opengl.pixel_buffer_object ? "available"
-			                                        : "missing");
 			LOG_INFO("OPENGL: NPOT textures %s",
 			         npot_support_msg.c_str());
 		}


### PR DESCRIPTION
# Description

This PR changes the way shader programs and related settings are stored. Instead of keeping just one shader program and recompiling it each time a shader change is requested, every shader is now loaded and compiled once on demand, then stored in a `std::map`. This allows for much quicker transitions between shaders in `crt-auto` sets, and shader loading process in general was reworked a bit to be slightly more sane.

Partially extracted from #2450. The first two commits are self-explanatory high-precision chainsaw surgery, mostly unrelated.

Unfortunately, the work is unfinished (see the next section), and I don't really have a feeling for where it should move. The real reason behind the changes was to have some sane way of loading shaders outside of OpenGL rendering initialization in #2450, and initially the changes were meant to be a part of that PR. The entanglement of `sdlmain.cpp`, `render.cpp`, and `shader_manager.cpp` did me. Couldn't sit on it, so pushing as is. It's up for grabs, if anyone wants it. Sorry.


# Manual testing

- Running with any shader set in the configuration - works;
- Triggering automatic shader switch by resizing the window - works, the storage is populated as expected, but there's still a noticeable hiccup whenever the target shader changes pixel doubling setting;
- Triggering manual shader reload (Ctrl+F2) - fails, not implemented;
- Attempting to load a non-existing shader source file - works, shader manager catches that and instead passes a fallback source (note that it will still attempt to load other sources from the auto set and will retain integer scaling setting when automatic switch is triggered);
- Attempting to load a malformed shader source - fails, either keeps the last successfully compiled shader or outputs nothing.


# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
