### PR TITLE
Fix a Coverity warning in SDL Sound

### DIFF
--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -570,6 +570,11 @@ void Sound_FreeSample(Sound_Sample *sample)
     /* update the sample_list... */
     if (internal->prev != NULL)
     {
+        // We're not removing from the head.
+        // Assert that we're not touching sample_list (which should be the head of the linked list).
+        // This assert fixes a Coverity warning.
+        assert(sample_list != sample);
+
         Sound_SampleInternal *prevInternal;
         prevInternal = (Sound_SampleInternal *) internal->prev->opaque;
         prevInternal->next = internal->next;

--- a/src/libs/decoders/SDL_sound_internal.h
+++ b/src/libs/decoders/SDL_sound_internal.h
@@ -47,9 +47,7 @@
 #define SNDDBG(x)
 #endif
 
-#if HAVE_ASSERT_H
-#  include <assert.h>
-#endif
+#include <assert.h>
 
 #ifdef _WIN32_WCE
     extern char *strrchr(const char *s, int c);


### PR DESCRIPTION
# Description

First commit fixes the assert macro.  The downside of how we're copy + pasting third party libraries into our tree is that we're not using the build system it was written for.  `HAVE_ASSERT_H` is something SDL's build system would have defined.  I just removed that macro and always do a `#include assert.h` since we rely on that header in our other code regardless.

Second commit adds an assert that hopefully Coverity is smart enough to follow.  It thinks there is a use after free bug if we're removing from the middle of the linked list in `Sound_Quit` but that never happens.  It's freeing the entire list always removing from the head.

## Related issues

#2996


# Manual testing

Tested with ripped .ogg files of the Quake sound track.  Added the assert and confirmed it does not trigger on quit.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

