### PR TITLE
Fix coverity sign extension warning

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1840,8 +1840,8 @@ static Fraction calc_pixel_aspect_from_dimensions(const uint16_t width,
                                                   const bool double_width,
                                                   const bool double_height)
 {
-	const auto storage_aspect_ratio = Fraction(width * (double_width ? 2 : 1),
-	                                           height * (double_height ? 2 : 1));
+	const auto storage_aspect_ratio = Fraction(static_cast<int64_t>(width) * (double_width ? 2 : 1),
+	                                           static_cast<int64_t>(height) * (double_height ? 2 : 1));
 
 	return display_aspect_ratio / storage_aspect_ratio;
 }


### PR DESCRIPTION
# Description
Again, not sure how to test that this actually fixes the warning without pushing to main but I think this one is pretty straight forward.


## Related issues
#2996

# Manual testing
It builds.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

