### PR TITLE
Fix incorrect version reporting in Virtualbox LOG_WARNING.

### DIFF
--- a/src/hardware/virtualbox.cpp
+++ b/src/hardware/virtualbox.cpp
@@ -287,7 +287,7 @@ static void warn_unsupported_struct_version(const RequestHeader& header)
 		LOG_WARNING("VIRTUALBOX: unimplemented request #%d structure v%d.%02d",
 		            enum_val(header.request_type),
 		            header.struct_version >> 16,
-		            header.struct_version && 0xffff);
+		            header.struct_version & 0xffff);
 		already_warned_set.insert(header.struct_version);
 	}
 }
@@ -467,7 +467,7 @@ static void handle_report_guest_info(const RequestHeader& header,
 		if (payload.interface_version != ver_1_04) {
 			LOG_WARNING("VIRTUALBOX: unimplemented protocol v%d.%02d",
 			            payload.interface_version >> 16,
-			            payload.interface_version && 0xffff);
+			            payload.interface_version & 0xffff);
 			client_disconnect();
 			break;
 		}


### PR DESCRIPTION
# Description
Found by Coverity. This is clearly wrong. It's trying to do a bitwise AND mask of the bottom 16 bits but was incorrectly using a logical and.


## Related issues
#2996


# Manual testing
It builds

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

