### PR TITLE
Use safe_strcpy and safe_strcat

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1309,7 +1309,7 @@ void DOS_Shell::CMD_COPY(char* args)
 
 			if (!search_result.IsDirectory()) {
 				safe_strcpy(nameSource, pathSource);
-				strcat(nameSource, search_result.name.c_str());
+				safe_strcat(nameSource, search_result.name.c_str());
 				// Open Source
 				if (DOS_OpenFile(nameSource,0,&sourceHandle)) {
 					// Create Target or open it if in concat mode
@@ -1506,8 +1506,7 @@ static bool attrib_recursive(DOS_Shell *shell,
 					                       std::string(1, '\\') +
 					                       get_filename(args);
 					found_dirs.push_back(fullname);
-					strcpy(path, fullname.c_str());
-					*(path + len) = 0;
+					safe_strcpy(path, fullname.c_str());
 				}
 			} while (DOS_FindNext());
 			all_dirs.insert(all_dirs.begin() + 1,


### PR DESCRIPTION
# Description
Fixes two string overflow warnings found by Coverity


## Related issues
#2996


# Manual testing
It builds.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

