### PR TITLE
Limit consecutive duplicate frames in VFR presentation mode

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -222,10 +222,10 @@ struct SDL_Block {
 		FrameMode desired_mode        = FrameMode::Unset;
 		FrameMode mode                = FrameMode::Unset;
 		double period_ms    = 0.0; // in ms, for use with PIC timers
+		float max_dupe_frames = 0.0f;
 		int period_us       = 0; // same but in us, for use with chrono
 		int period_us_early = 0;
-		int period_us_late  = 0;
-		int8_t vfr_dupe_countdown = 0;
+		int period_us_late    = 0;
 	} frame = {};
 
 	SDL_Rect updateRects[1024] = {};


### PR DESCRIPTION
# Description

VFR mode could previously have a presentation rate of 0 fps leading
to a blank screen across fullscreen-window mode switches.

This commit ensures a lower-bound of 10 fps (at all DOS rates),
even if all frames are duplicates.

Thanks to:
- @GranMinigun for explaining the root cause is due to tearing down and re-instanting the rendering stack across FS and window-mode switches.
- @johnnovak for the suggestion to re-instate a minimum configurable rate for the VFR presentation modes

## Related issues

Fixes #2993

# Manual testing

Tested with Falcon AT, static CLI screens, and ran benchmarks, along with a  a range of allowable `dos_rate` values from 30 to 1000 Hz.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

