### PR TITLE
Try again to fix Coverity warning in SDL Sound

### DIFF
--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -570,11 +570,6 @@ void Sound_FreeSample(Sound_Sample *sample)
     /* update the sample_list... */
     if (internal->prev != NULL)
     {
-        // We're not removing from the head.
-        // Assert that we're not touching sample_list (which should be the head of the linked list).
-        // This assert fixes a Coverity warning.
-        assert(sample_list != sample);
-
         Sound_SampleInternal *prevInternal;
         prevInternal = (Sound_SampleInternal *) internal->prev->opaque;
         prevInternal->next = internal->next;

--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -148,12 +148,12 @@ int Sound_Quit(void)
 
     BAIL_IF_MACRO(!initialized, ERR_NOT_INITIALIZED, 0);
 
-    while (((volatile Sound_Sample *) sample_list) != NULL)
+    SDL_LockMutex(samplelist_mutex);
+    while (sample_list != NULL)
     {
-        Sound_Sample *sample = sample_list;
-        Sound_FreeSample(sample); /* Updates sample_list. */
-        sample = NULL;
+        Sound_FreeSample(sample_list); /* Updates sample_list. */
     }
+    SDL_UnlockMutex(samplelist_mutex);
 
     initialized = 0;
 


### PR DESCRIPTION
# Description
The previous PR did not solve the issue.  Coverity saw my assert and still thinks it's freeing from the middle of the list.

![coverity](https://github.com/dosbox-staging/dosbox-staging/assets/8128047/7acbf485-b640-4593-bcb4-383a19ff94f1)

It's possible it is seeing a data race.  I've removed the use of the volatile keyword and used a mutex lock around the entire loop.  `Sound_FreeSample` also takes a lock but SDL's mutex is recursive so this should be fine.

This also removes a temporary variable that was maybe confusing Coverity.  Now `Sound_FreeSample` is explicitly being called with `sample_list` (head of the linked list).

## Related issues

#2996

# Manual testing

Started Quake with ripped .ogg sound files.  Closed Dosbox and confirmed there was no crashes or deadlocks.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

