### PR TITLE
Re-add the SDL Sound assert (third time's a charm?)

### DIFF
--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -570,6 +570,11 @@ void Sound_FreeSample(Sound_Sample *sample)
     /* update the sample_list... */
     if (internal->prev != NULL)
     {
+        // We're not removing from the head.
+        // Assert that we're not touching sample_list (which should be the head of the linked list).
+        // This assert fixes a Coverity warning.
+        assert(sample_list != sample);
+
         Sound_SampleInternal *prevInternal;
         prevInternal = (Sound_SampleInternal *) internal->prev->opaque;
         prevInternal->next = internal->next;


### PR DESCRIPTION
# Description
Coverity is still trying to take the branch where there is a previous node (should never happen).

I think I was too hasty reverting the assert commit.  Maybe with the assert + my pervious commit it'll work.  Sorry this is getting a bit messy.  Hard to iterate on these things with no way to test locally.

![coverity2](https://github.com/dosbox-staging/dosbox-staging/assets/8128047/13ff8fee-39aa-484a-a0aa-ce61062af55d)

## Related issues
#2996

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

