### PR TITLE
Refactor Property->Get_string to return a std::string

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -107,7 +107,7 @@ public:
 	operator Hex() const;
 	operator int() const;
 	operator double() const;
-	operator const char*() const;
+	operator std::string() const;
 
 	bool SetValue(const std::string& in, Etype _type = V_CURRENT);
 
@@ -399,7 +399,7 @@ public:
 
 	int Get_int(const std::string& _propname) const;
 
-	const char* Get_string(const std::string& _propname) const;
+	std::string Get_string(const std::string& _propname) const;
 
 	Prop_string* GetStringProp(const std::string& propname) const;
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -203,6 +203,7 @@ bool is_hex_digits(const std::string_view s) noexcept;
 bool is_digits(const std::string_view s) noexcept;
 
 void strreplace(char* str, char o, char n);
+void ltrim(std::string& str);
 char* ltrim(char* str);
 char* rtrim(char* str);
 char* trim(char* str);
@@ -246,7 +247,8 @@ constexpr bool iequals(T1&& a, T2&& b)
 // - ("abc123", "abc123=") -> true, simply because the first is shorter.
 bool natural_compare(const std::string& a, const std::string& b);
 
-char* strip_word(char*& cmd);
+char* strip_word(char*& line);
+std::string strip_word(std::string& line);
 
 std::string replace(const std::string& str, char old_char, char new_char) noexcept;
 void trim(std::string& str, const char trim_chars[] = " \r\t\f\n");

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -225,8 +225,8 @@ static void LOG_Destroy(Section*) {
 
 static void LOG_Init(Section * sec) {
 	Section_prop * sect = static_cast<Section_prop *>(sec);
-	const char * blah = sect->Get_string("logfile");
-	if(blah && blah[0] && (debuglog = fopen(blah,"wt+"))){
+	std::string blah = sect->Get_string("logfile");
+	if(!blah.empty() && (debuglog = fopen(blah.c_str(),"wt+"))){
 		;
 	} else {
 		debuglog = nullptr;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1610,9 +1610,13 @@ public:
 		dos.internal_output=false;
 
 		const Section_prop* section = static_cast<Section_prop*>(configuration);
-		char *args = const_cast<char *>(section->Get_string("ver"));
-		const char* word = strip_word(args);
-		const auto new_version = DOS_ParseVersion(word, args);
+		std::string args = section->Get_string("ver");
+
+		// TODO: Write a version of strip_word that operates on a std::string
+		// And remove this const_cast
+		char* args_cstr = const_cast<char *>(args.c_str());
+		const char* word = strip_word(args_cstr);
+		const auto new_version = DOS_ParseVersion(word, args_cstr);
 		if (new_version.major || new_version.minor) {
 			dos.version.major = new_version.major;
 			dos.version.minor = new_version.minor;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1611,12 +1611,8 @@ public:
 
 		const Section_prop* section = static_cast<Section_prop*>(configuration);
 		std::string args = section->Get_string("ver");
-
-		// TODO: Write a version of strip_word that operates on a std::string
-		// And remove this const_cast
-		char* args_cstr = const_cast<char *>(args.c_str());
-		const char* word = strip_word(args_cstr);
-		const auto new_version = DOS_ParseVersion(word, args_cstr);
+		std::string word = strip_word(args);
+		const auto new_version = DOS_ParseVersion(word.c_str(), args.c_str());
 		if (new_version.major || new_version.minor) {
 			dos.version.major = new_version.major;
 			dos.version.minor = new_version.minor;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1677,28 +1677,28 @@ public:
 
 		loaded_layout = std::make_unique<KeyboardLayout>();
 
-		const char * layoutname=section->Get_string("keyboardlayout");
+		std::string layoutname = section->Get_string("keyboardlayout");
 
 		// If the use only provided a single value (language), then try using it
 		const auto layout_is_one_value = sv(layoutname).find(' ') == std::string::npos;
 		if (layout_is_one_value) {
-			if (!DOS_LoadKeyboardLayoutFromLanguage(layoutname)) {
+			if (!DOS_LoadKeyboardLayoutFromLanguage(layoutname.c_str())) {
 				return; // success
 			}
 		}
 		// Otherwise use the layout to get the codepage
-		const auto req_codepage = loaded_layout->ExtractCodePage(layoutname);
+		const auto req_codepage = loaded_layout->ExtractCodePage(layoutname.c_str());
 		loaded_layout->ReadCodePageFile("auto", req_codepage);
 
-		if (loaded_layout->ReadKeyboardFile(layoutname, dos.loaded_codepage)) {
-			if (strncmp(layoutname, "auto", 4)) {
+		if (loaded_layout->ReadKeyboardFile(layoutname.c_str(), dos.loaded_codepage)) {
+			if (strncmp(layoutname.c_str(), "auto", 4)) {
 				LOG_ERR("LAYOUT: Failed to load keyboard layout %s",
-				        layoutname);
+				        layoutname.c_str());
 			}
 		} else {
 			const char *lcode = loaded_layout->GetMainLanguageCode();
 			if (lcode) {
-				LOG_MSG("LAYOUT: DOS keyboard layout loaded with main language code %s for layout %s",lcode,layoutname);
+				LOG_MSG("LAYOUT: DOS keyboard layout loaded with main language code %s for layout %s",lcode,layoutname.c_str());
 			}
 		}
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -361,7 +361,7 @@ static void DOSBOX_RealInit(Section * sec) {
 		                         arguments->machine);
 	}
 
-	std::string mtype(section->Get_string("machine"));
+	std::string mtype = section->Get_string("machine");
 	svgaCard = SVGA_None;
 	machine = MCH_VGA;
 	int10.vesa_nolfb = false;
@@ -397,10 +397,10 @@ static void DOSBOX_RealInit(Section * sec) {
 	       (machine != MCH_VGA && svgaCard == SVGA_None));
 
 	// Set the user's prefered MCB fault handling strategy
-	DOS_SetMcbFaultStrategy(section->Get_string("mcb_fault_strategy"));
+	DOS_SetMcbFaultStrategy(section->Get_string("mcb_fault_strategy").c_str());
 
 	// Convert the users video memory in either MB or KB to bytes
-	const auto vmemsize_string = std::string(section->Get_string("vmemsize"));
+	const std::string vmemsize_string = section->Get_string("vmemsize");
 
 	// If auto, then default to 0 and let the adapter's setup rountine set
 	// the size
@@ -410,7 +410,8 @@ static void DOSBOX_RealInit(Section * sec) {
 	vmemsize *= (vmemsize <= 8) ? 1024 * 1024 : 1024;
 	vga.vmemsize = check_cast<uint32_t>(vmemsize);
 
-	if (const auto pref = std::string_view(section->Get_string("vesa_modes")); pref == "compatible") {
+	const std::string pref = section->Get_string("vesa_modes");
+	if (pref == "compatible") {
 		int10.vesa_mode_preference = VesaModePref::Compatible;
 	} else if (pref == "halfline") {
 		int10.vesa_mode_preference = VesaModePref::Halfline;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -936,7 +936,7 @@ void RENDER_Init(Section* sec)
 	VGA_ForceSquarePixels(force_square_pixels);
 
 	const auto mono_palette = to_monochrome_palette_enum(
-	        section->Get_string("monochrome_palette"));
+	        section->Get_string("monochrome_palette").c_str());
 	VGA_SetMonochromePalette(mono_palette);
 
 	// Only use the default 1x rendering scaler

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3247,7 +3247,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 
 	setup_viewport_resolution_from_conf(section->Get_string("viewport_resolution"));
 
-	setup_window_sizes_from_conf(section->Get_string("windowresolution"),
+	setup_window_sizes_from_conf(section->Get_string("windowresolution").c_str(),
 	                             sdl.interpolation_mode,
 	                             wants_aspect_ratio_correction);
 
@@ -3455,22 +3455,19 @@ static void GUI_StartUp(Section *sec)
 	                         sdl.pause_when_inactive;
 
 	ApplyActiveSettings(); // Assume focus on startup
-	sdl.desktop.full.fixed=false;
-	const char* fullresolution=section->Get_string("fullresolution");
+	sdl.desktop.full.fixed = false;
+	std::string fullresolution = section->Get_string("fullresolution");
 	sdl.desktop.full.width  = 0;
 	sdl.desktop.full.height = 0;
-	if(fullresolution && *fullresolution) {
-		char res[100];
-		safe_strcpy(res, fullresolution);
-		fullresolution = lowcase (res);//so x and X are allowed
-		if (strcmp(fullresolution,"original")) {
+	if(!fullresolution.empty()) {
+		lowcase(fullresolution); //so x and X are allowed
+		if (fullresolution != "original") {
 			sdl.desktop.full.fixed = true;
-			if (strcmp(fullresolution,"desktop")) { // desktop uses 0x0, below sets a custom WxH
-				char* height = const_cast<char*>(strchr(fullresolution,'x'));
-				if (height && * height) {
-					*height = 0;
-					sdl.desktop.full.height = atoi(height + 1);
-					sdl.desktop.full.width  = atoi(res);
+			if (fullresolution != "desktop") { // desktop uses 0x0, below sets a custom WxH
+				std::vector<std::string> dimensions = split(fullresolution, 'x');
+				if (dimensions.size() == 2) {
+					sdl.desktop.full.width = to_int(dimensions[0]).value_or(0);
+					sdl.desktop.full.height = to_int(dimensions[1]).value_or(0);
 					maybe_limit_requested_resolution(
 					        sdl.desktop.full.width,
 					        sdl.desktop.full.height,

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1650,12 +1650,12 @@ static void gus_init(Section *sec)
 	                       MIN_IRQ_ADDRESS,
 	                       MAX_IRQ_ADDRESS);
 
-	const auto ultradir = conf->Get_string("ultradir");
+	const std::string ultradir = conf->Get_string("ultradir");
 
 	const std::string filter_prefs = conf->Get_string("gus_filter");
 
 	// Instantiate the GUS with the settings
-	gus = std::make_unique<Gus>(port, dma, irq, ultradir, filter_prefs);
+	gus = std::make_unique<Gus>(port, dma, irq, ultradir.c_str(), filter_prefs);
 
 	constexpr auto changeable_at_runtime = true;
 	sec->AddDestroyFunction(&gus_destroy, changeable_at_runtime);

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13391,7 +13391,7 @@ static void imfc_init(Section* sec)
 	// The filter parameters have been tweaked by analysing real hardware
 	// recordings. The results are virtually indistinguishable from the
 	// real thing by ear only.
-	const std::string_view filter_choice = conf->Get_string("imfc_filter");
+	const std::string filter_choice = conf->Get_string("imfc_filter");
 	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
 
 	if (filter_choice_has_bool && *filter_choice_has_bool == true) {

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -392,7 +392,7 @@ void JOYSTICK_ParseConfiguredType()
 {
 	const auto conf = control->GetSection("joystick");
 	const auto section = static_cast<Section_prop *>(conf);
-	const auto type = std::string(section->Get_string("joysticktype"));
+	const auto type = section->Get_string("joysticktype");
 
 	if (type == "disabled")
 		joytype = JOY_DISABLED;

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -155,7 +155,7 @@ void LPT_DAC_Init(Section *section)
 	assert(section);
 	const auto prop = static_cast<Section_prop *>(section);
 
-	const std::string_view dac_choice = prop->Get_string("lpt_dac");
+	const std::string dac_choice = prop->Get_string("lpt_dac");
 
 	if (dac_choice == "disney")
 		lpt_dac = std::make_unique<Disney>();
@@ -174,7 +174,7 @@ void LPT_DAC_Init(Section *section)
 	}
 
 	// Let the DAC apply its own filter type
-	const std::string_view filter_choice = prop->Get_string("lpt_dac_filter");
+	const std::string filter_choice = prop->Get_string("lpt_dac_filter");
 	assert(lpt_dac);
 	if (!lpt_dac->TryParseAndSetCustomFilter(filter_choice)) {
 		auto filter_state = FilterState::Off;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -261,7 +261,7 @@ static void set_global_crossfeed(mixer_channel_t channel)
 	// Global crossfeed
 	auto crossfeed = 0.0f;
 
-	const std::string_view crossfeed_pref = sect->Get_string("crossfeed");
+	const std::string crossfeed_pref = sect->Get_string("crossfeed");
 	const auto crossfeed_pref_has_bool = parse_bool_setting(crossfeed_pref);
 
 	if (crossfeed_pref_has_bool) {

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -793,7 +793,7 @@ public:
 			return;
 		}
 
-		const std::string_view mpu_choice = section->Get_string("mpu401");
+		const std::string mpu_choice = section->Get_string("mpu401");
 
 		if (const auto has_bool = parse_bool_setting(mpu_choice);
 		    has_bool && *has_bool == false) {

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1482,10 +1482,10 @@ public:
         LOG_MSG("NE2000: Initialised on port %xh and IRQ %u", base, irq);
 
 		// mac address
-		const char* macstring=section->Get_string("macaddr");
+		std::string macstring = section->Get_string("macaddr");
 		unsigned int macint[6];
 		uint8_t mac[6];
-		if(sscanf(macstring,"%02x:%02x:%02x:%02x:%02x:%02x",
+		if(sscanf(macstring.c_str(),"%02x:%02x:%02x:%02x:%02x:%02x",
 			&macint[0],&macint[1],&macint[2],&macint[3],&macint[4],&macint[5]) != 6) {
 			mac[0]=0xac;mac[1]=0xde;mac[2]=0x48;
 			mac[3]=0x88;mac[4]=0xbb;mac[5]=0xaa;

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -41,7 +41,7 @@ void PCSPEAKER_Init(Section *section)
 	const auto prop = static_cast<Section_prop *>(section);
 
 	// Get the user's PC Speaker model choice
-	const auto model_choice = std::string_view(prop->Get_string("pcspeaker"));
+	const std::string model_choice = prop->Get_string("pcspeaker");
 
 	const auto model_choice_has_bool = parse_bool_setting(model_choice);
 
@@ -58,7 +58,7 @@ void PCSPEAKER_Init(Section *section)
 	}
 
 	// Get the user's filering choice
-	const std::string_view filter_choice = prop->Get_string("pcspeaker_filter");
+	const std::string filter_choice = prop->Get_string("pcspeaker_filter");
 
 	assert(pc_speaker);
 

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -1396,8 +1396,7 @@ void ReelMagic_Init(Section* sec)
 	const auto section = static_cast<Section_prop*>(sec);
 
 	// Does the user want ReelMagic emulation?
-	const auto reelmagic_choice = std::string_view(
-	        section->Get_string("reelmagic"));
+	const auto reelmagic_choice = section->Get_string("reelmagic");
 
 	const auto wants_card_only = (reelmagic_choice == "cardonly");
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2054,7 +2054,7 @@ SB_TYPES find_sbtype()
 	const auto sect = static_cast<Section_prop *>(control->GetSection("sblaster"));
 	assert(sect);
 
-	const std::string_view pref = sect->Get_string("sbtype");
+	const std::string pref = sect->Get_string("sbtype");
 
 	// Default
 	auto sbtype = SB_TYPES::SBT_NONE;
@@ -2081,7 +2081,7 @@ OplMode find_oplmode()
 	const auto sect = static_cast<Section_prop *>(control->GetSection("sblaster"));
 	assert(sect);
 
-	const std::string_view pref = sect->Get_string("oplmode");
+	const std::string pref = sect->Get_string("oplmode");
 
 	// Default
 	auto opl_mode = OplMode::None;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -653,7 +653,7 @@ void TANDYSOUND_Init(Section *section)
 {
 	assert(section);
 	const auto prop = static_cast<Section_prop*>(section);
-	const auto pref = std::string_view(prop->Get_string("tandy"));
+	const auto pref = prop->Get_string("tandy");
 	if (has_false(pref) || (!IS_TANDY_ARCH && pref == "auto")) {
 		set_tandy_sound_flag_in_bios(false);
 		return;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1421,7 +1421,7 @@ static void composite_init(Section *sec)
 	assert(sec);
 	const auto conf = static_cast<Section_prop *>(sec);
 	assert(conf);
-	const std::string_view state = conf->Get_string("composite");
+	const std::string state = conf->Get_string("composite");
 
 	if (state == "auto") {
 		cga_comp = COMPOSITE_STATE::AUTO;
@@ -1437,7 +1437,7 @@ static void composite_init(Section *sec)
 		}
 	}
 
-	const auto era_choice = std::string(conf->Get_string("era"));
+	const std::string era_choice = conf->Get_string("era");
 	is_composite_new_era = era_choice == "new" ||
 	                       (machine == MCH_PCJR && era_choice == "auto");
 

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1372,7 +1372,7 @@ static Bitu INT4B_Handler() {
 
 Bitu GetEMSType(Section_prop * section) {
 	Bitu rtype = 0;
-	const std::string_view ems_pref = section->Get_string("ems");
+	const std::string ems_pref = section->Get_string("ems");
 
 	const auto ems_pref_has_bool = parse_bool_setting(ems_pref);
 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -594,7 +594,7 @@ public:
 	{
 		Section_prop* section = static_cast<Section_prop*>(configuration);
 
-		const std::string_view device_choice = section->Get_string("mididevice");
+		const std::string device_choice = section->Get_string("mididevice");
 
 		midi = Midi{};
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -346,7 +346,7 @@ static std::deque<std_fs::path> get_selected_dirs()
 	return rom_dirs;
 }
 
-static const char *get_selected_model()
+static std::string get_selected_model()
 {
 	const auto section = static_cast<Section_prop *>(control->GetSection("mt32"));
 	assert(section);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -74,10 +74,10 @@ Value::operator double() const
 	return _double;
 }
 
-Value::operator const char*() const
+Value::operator std::string() const
 {
 	assert(type == V_STRING);
-	return _string.c_str();
+	return _string;
 }
 
 bool Value::operator==(const Value& other) const
@@ -863,7 +863,7 @@ Property* Section_prop::Get_prop(int index)
 	return nullptr;
 }
 
-const char* Section_prop::Get_string(const std::string& _propname) const
+std::string Section_prop::Get_string(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if ((*tel)->propname == _propname) {

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -52,6 +52,10 @@ void strreplace(char *str, char o, char n)
 	}
 }
 
+void ltrim(std::string &str) {
+    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) {return !isspace(c);}));
+}
+
 char *ltrim(char *str)
 {
 	while (*str && isspace(*reinterpret_cast<unsigned char *>(str)))
@@ -237,7 +241,6 @@ bool natural_compare(const std::string& a_str, const std::string& b_str)
 	return a == a_end && b != b_end;
 }
 
-// TODO: Write a version of this that operates on a std::string
 char* strip_word(char*& line)
 {
 	char *scan = line;
@@ -259,6 +262,30 @@ char* strip_word(char*& line)
 	}
 	line = scan;
 	return begin;
+}
+
+std::string strip_word(std::string& line)
+{
+	ltrim(line);
+	if (line.empty()) {
+		return "";
+	}
+	if (line[0] == '"') {
+		size_t end_quote = line.find('"', 1);
+		if (end_quote != std::string::npos) {
+			std::string word = line.substr(1, end_quote - 1);
+			line.erase(0, end_quote + 1);
+			ltrim(line);
+			return word;
+		}
+	}
+	auto end_word = std::find_if(line.begin(), line.end(), [](int c) {return isspace(c);});
+	std::string word(line.begin(), end_word);
+	if (end_word != line.end()) {
+		++end_word;
+	}
+	line.erase(line.begin(), end_word);
+	return word;
 }
 
 void strip_punctuation(std::string &str)

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -237,6 +237,7 @@ bool natural_compare(const std::string& a_str, const std::string& b_str)
 	return a == a_end && b != b_end;
 }
 
+// TODO: Write a version of this that operates on a std::string
 char* strip_word(char*& line)
 {
 	char *scan = line;

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -262,7 +262,7 @@ AutoExecModule::AutoExecModule(Section* configuration)
 	const bool has_option_no_autoexec = arguments->noautoexec;
 
 	// Should autoexec sections be joined or overwritten?
-	const std::string_view section_pref = sec->Get_string("autoexec_section");
+	const std::string section_pref = sec->Get_string("autoexec_section");
 	const bool should_join_autoexecs = (section_pref == "join");
 
 	// Check to see for extra command line options to be added

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -570,7 +570,7 @@ std::tuple<std::string, std::string, std::string> parse_drive_conf(
 	const auto settings = static_cast<Section_prop *>(conf->GetSection("drive"));
 
 	// Construct the mount arguments
-	const auto override_drive = std::string(settings->Get_string("override_drive"));
+	const std::string override_drive = settings->Get_string("override_drive");
 	if (override_drive.length() == 1 && override_drive[0] >= 'a' && override_drive[0] <= 'y')
 		drive_letter = override_drive;
 	else if (override_drive.length()) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -89,7 +89,7 @@ void DOS_Shell::InputCommand(char* line)
 		return;
 	}
 
-	const std::string_view expand_shell_variable_pref = dos_section->Get_string(
+	const std::string expand_shell_variable_pref = dos_section->Get_string(
 	        "expand_shell_variable");
 
 	const auto expand_shell_pref_has_bool = parse_bool_setting(


### PR DESCRIPTION
# Description
This was previously returning a const char* pointer to a std::string.c_str()
This has been a source of bugs in the past if the backing std::string goes out of scope or the caller tries to modify it.

Many of the callers of this function were constructing a `std::string` or doing a C style `strcpy` anyway.  In one case, the caller was `const_cast`'ing the returned `const char*` and modifying it in place (yikes).

I just think returning a pointer to a `std::string` object outside of API bounds is a bad idea.  Performance really shouldn't matter here.  The strings are short and it's all initialization code.  I highly doubt this would even show up in a profiler.

# Manual testing
I started DosBox up and changed a few of the config settings (particularly the resolution as I removed some C-style string manipulation).  Did not notice any regressions.  Behavior should not change as this is a pretty straight forward refactoring.

I will note that Clang caught some bugs that GCC did not.  There were a few places with something like `std::string_view foo = prop->Get_string("bar")` which were fine when it returned a `char*`.  With a `std::string`, it creates a temporary object that gets immediately destroyed, leaving behind a dangling `std::string_view` pointing to an invalid object.

Clang caught this citing `-Wdangling-gsl` (which was already enabled by our build system somewhere, maybe part of `-Wall` or something).  Could not find a way to make GCC report this warning.  This may make me switch to Clang as my preferred compiler.

I also did a `git grep Get_string` to manually check everywhere this was called.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

