### PR TITLE
Re-add "mt32" and "cm32l" alias models

### DIFF
--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -217,6 +217,8 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	const char* models[] = {"auto",
+	                        "mt32",
+	                        "cm32l",
 	                        cm32ln_100_model.GetName(),
 	                        cm32l_102_model.GetName(),
 	                        cm32l_100_model.GetName(),


### PR DESCRIPTION
# Description
Regression from PR #2591. The logic for these still works. It's a simple reverse string search. They were just accidentally removed from the list of valid config values.

## Related issues
#2969


# Manual testing
Tested model=mt32 and model=cm32l and confirmed they work.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

