### PR TITLE
Rework the MT-32/CM-32L ROM lookup and `MIXER /LISTMIDI` improvements

### DIFF
--- a/include/ansi_code_markup.h
+++ b/include/ansi_code_markup.h
@@ -37,6 +37,6 @@ std::string convert_ansi_markup(const char* str);
  * \param str 
  * \return std::string 
  */
-std::string convert_ansi_markup(std::string &str);
+std::string convert_ansi_markup(const std::string &str);
 
 #endif // DOSBOX_ANSI_CODE_MARKUP_H

--- a/include/mpu401.h
+++ b/include/mpu401.h
@@ -1,0 +1,30 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_MPU401_H
+#define DOSBOX_MPU401_H
+
+class Section;
+
+void MPU401_Init(Section* sec);
+
+void MPU401_Destroy(Section* sec);
+
+#endif // DOSBOX_MPU401_H

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -76,8 +76,8 @@ uint8_t MIDI_message_len_by_status[256] = {
 #include "midi_mt32.h"
 
 #if defined(MACOSX)
-#	include "midi_coremidi.h"
-#	include "midi_coreaudio.h"
+#include "midi_coreaudio.h"
+#include "midi_coremidi.h"
 
 #elif defined(WIN32)
 #include "midi_win32.h"
@@ -98,7 +98,7 @@ static void deregister_handlers()
 static void register_handlers()
 {
 	deregister_handlers();
-	
+
 #if C_FLUIDSYNTH
 	handlers.emplace_back(std::make_unique<MidiHandlerFluidsynth>());
 #endif
@@ -131,7 +131,6 @@ MidiHandler* get_handler(const std::string_view name)
 	}
 	return nullptr;
 }
-
 
 struct Midi {
 	uint8_t status = 0;
@@ -470,8 +469,9 @@ void MIDI_RawOutByte(uint8_t data)
 			midi_state.UpdateState(midi.message.msg);
 
 			// 2. Sanitise the MIDI stream unless raw output is
-			// enabled. Currently, this can result in the emission of extra
-			// MIDI Note Off events only, and updating the MIDI state.
+			// enabled. Currently, this can result in the emission
+			// of extra MIDI Note Off events only, and updating the
+			// MIDI state.
 			//
 			// `sanitise_midi_stream` also captures these extra
 			// events if MIDI capture is enabled and sends them to
@@ -726,12 +726,12 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	const char* midi_devices[] =
 	{ "auto",
 #if defined(MACOSX)
-#	if C_COREMIDI
+#if C_COREMIDI
 	  "coremidi",
-#	endif
-#	if C_COREAUDIO
+#endif
+#if C_COREAUDIO
 	  "coreaudio",
-#	endif
+#endif
 #elif defined(WIN32)
 	  "win32",
 #else
@@ -754,13 +754,13 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	        "Set where MIDI data from the emulated MPU-401 MIDI interface is sent\n"
 	        "('auto' by default):\n"
 #if defined(MACOSX)
-#	if C_COREMIDI
+#if C_COREMIDI
 	        "  coremidi:    Any device that has been configured in the macOS\n"
 	        "               Audio MIDI Setup.\n"
-#	endif
-#	if C_COREAUDIO
+#endif
+#if C_COREAUDIO
 	        "  coreaudio:   Use the built-in macOS MIDI synthesiser.\n"
-#	endif
+#endif
 #elif defined(WIN32)
 	        "  win32:       Use the Win32 MIDI playback interface.\n"
 #else

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -36,6 +36,7 @@
 #include "cross.h"
 #include "mapper.h"
 #include "midi_handler.h"
+#include "mpu401.h"
 #include "pic.h"
 #include "programs.h"
 #include "setup.h"
@@ -823,8 +824,6 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	        "the raw, unaltered MIDI output of a program, e.g. when working with music\n"
 	        "applications, or when debugging MIDI issues.");
 }
-
-void MPU401_Init(Section*);
 
 void MIDI_AddConfigSection(const config_ptr_t& conf)
 {

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -30,8 +30,8 @@
 
 #include <SDL.h>
 
-#include "ansi_code_markup.h"
 #include "../capture/capture.h"
+#include "ansi_code_markup.h"
 #include "control.h"
 #include "cross.h"
 #include "mapper.h"
@@ -674,9 +674,10 @@ void MIDI_ListAll(Program* caller)
 	constexpr auto msg_indent = "  ";
 
 	for (const auto& handler : handlers) {
-		std::string name_format = msg_indent;
-		name_format.append(convert_ansi_markup("[color=white]%s:[reset]\n"));
-		caller->WriteOut(name_format.c_str(), handler->GetName().data());
+		const auto device_name = convert_ansi_markup(
+		        "[color=white]%s:[reset]\n");
+
+		caller->WriteOut(device_name.c_str(), handler->GetName().data());
 
 		const auto err = handler->ListAll(caller);
 		if (err == MIDI_RC::ERR_DEVICE_NOT_CONFIGURED) {
@@ -696,8 +697,8 @@ void MIDI_ListAll(Program* caller)
 
 static void register_midi_text_messages()
 {
-	MSG_Add("MIDI_DEVICE_LIST_NOT_SUPPORTED", "listing not supported");
-	MSG_Add("MIDI_DEVICE_NOT_CONFIGURED", "device not configured");
+	MSG_Add("MIDI_DEVICE_LIST_NOT_SUPPORTED", "Listing not supported");
+	MSG_Add("MIDI_DEVICE_NOT_CONFIGURED", "Device not configured");
 }
 
 static MIDI* test;

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -30,6 +30,7 @@
 #include <tuple>
 
 #include "../ints/int10.h"
+#include "ansi_code_markup.h"
 #include "control.h"
 #include "cross.h"
 #include "fs_utils.h"
@@ -860,10 +861,16 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program* caller)
 	const size_t term_width = INT10_GetTextColumns();
 
 	auto write_line = [caller](bool do_highlight, const std::string& line) {
-		const char color[]   = "\033[32;1m";
-		const char nocolor[] = "\033[0m";
+		constexpr auto green = "[color=light-green]";
+		constexpr auto reset = "[reset]";
+
 		if (do_highlight) {
-			caller->WriteOut("* %s%s%s\n", color, line.c_str(), nocolor);
+			const auto output = format_string("%s* %s%s\n",
+			                                  green,
+			                                  line.c_str(),
+			                                  reset);
+
+			caller->WriteOut(convert_ansi_markup(output).c_str());
 		} else {
 			caller->WriteOut("  %s\n", line.c_str());
 		}

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -230,9 +230,9 @@ const LASynthModel mt32_old_model = {"mt32_old", // "mt32_old" is 1.07
                                      &mt32_ctrl_107_b};
 
 // In order that "model = auto" will load
-const LASynthModel* all_models[] = {&cm32ln_100_model,
-                                    &cm32l_102_model,
+const LASynthModel* all_models[] = {&cm32l_102_model,
                                     &cm32l_100_model,
+                                    &cm32ln_100_model,
                                     &mt32_old_model,
                                     &mt32_107_model,
                                     &mt32_106_model,
@@ -252,9 +252,9 @@ static void init_mt32_dosbox_settings(Section_prop& sec_prop)
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	const char* models[] = {"auto",
-	                        cm32ln_100_model.GetName(),
 	                        cm32l_102_model.GetName(),
 	                        cm32l_100_model.GetName(),
+	                        cm32ln_100_model.GetName(),
 	                        mt32_old_model.GetName(),
 	                        mt32_107_model.GetName(),
 	                        mt32_106_model.GetName(),

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -47,31 +47,39 @@
 // ----------------
 
 // Analogue circuit modes: DIGITAL_ONLY, COARSE, ACCURATE, OVERSAMPLED
-constexpr auto ANALOG_MODE = MT32Emu::AnalogOutputMode_ACCURATE;
+constexpr auto AnalogMode = MT32Emu::AnalogOutputMode_ACCURATE;
 
 // DAC Emulation modes: NICE, PURE, GENERATION1, and GENERATION2
-constexpr auto DAC_MODE = MT32Emu::DACInputMode_NICE;
+//
+// Produce samples at double the volume, without tricks.
+// Nicer overdrive characteristics than the DAC hacks (it simply clips samples
+// within range) Higher quality than the real devices
+constexpr auto DacEmulationMode = MT32Emu::DACInputMode_NICE;
 
 // Analog rendering types: int16_t, FLOAT
-constexpr auto RENDERING_TYPE = MT32Emu::RendererType_FLOAT;
+// Use float samples in the renderer and simplified wave generator model.
+// Maximum output quality and minimum noise.
+constexpr auto RenderingType = MT32Emu::RendererType_FLOAT;
 
 // Sample rate conversion quality: FASTEST, FAST, GOOD, BEST
-constexpr auto RATE_CONVERSION_QUALITY = MT32Emu::SamplerateConversionQuality_BEST;
+constexpr auto ResamplingQuality = MT32Emu::SamplerateConversionQuality_BEST;
 
-// Prefer higher ramp resolution over the coarser volume steps used by the hardware
-constexpr bool USE_NICE_RAMP = true;
+// Prefer amp ramp interpolation to avoid clicks (the hardware doesn't
+// always interpolate).
+constexpr bool UseNiceRamp = true;
 
-// Prefer higher panning resolution over the coarser positions used by the hardware
-constexpr bool USE_NICE_PANNING = true;
+// Prefer higher panning resolution over the coarser positions used by the
+// hardware (this allos for "true center" pan positions which is not
+// possible on the real hardwre).
+constexpr bool UseNicePanning = true;
 
-// Prefer the rich sound offered by the hardware's existing partial mixer
-constexpr bool USE_NICE_PARTIAL_MIXING = false;
+// Prefer not forcing always in-phase partial mixing (this is more authentic
+// sounding).
+constexpr bool UseNicePartialMixing = false;
 
 using Rom = LASynthModel::Rom;
 
-const Rom mt32_pcm_100_f  = {"pcm_mt32", LASynthModel::ROM_TYPE::PCM};
-const Rom mt32_pcm_100_l  = {"pcm_mt32_l", LASynthModel::ROM_TYPE::PCM};
-const Rom mt32_pcm_100_h  = {"pcm_mt32_h", LASynthModel::ROM_TYPE::PCM};
+// MT-32
 const Rom mt32_ctrl_104_f = {"ctrl_mt32_1_04", LASynthModel::ROM_TYPE::CONTROL};
 const Rom mt32_ctrl_104_a = {"ctrl_mt32_1_04_a", LASynthModel::ROM_TYPE::CONTROL};
 const Rom mt32_ctrl_104_b = {"ctrl_mt32_1_04_b", LASynthModel::ROM_TYPE::CONTROL};
@@ -91,43 +99,55 @@ const Rom mt32_ctrl_203_f = {"ctrl_mt32_2_03", LASynthModel::ROM_TYPE::CONTROL};
 const Rom mt32_ctrl_204_f = {"ctrl_mt32_2_04", LASynthModel::ROM_TYPE::CONTROL};
 const Rom mt32_ctrl_206_f = {"ctrl_mt32_2_06", LASynthModel::ROM_TYPE::CONTROL};
 const Rom mt32_ctrl_207_f = {"ctrl_mt32_2_07", LASynthModel::ROM_TYPE::CONTROL};
+
+const Rom mt32_pcm_100_f = {"pcm_mt32", LASynthModel::ROM_TYPE::PCM};
+const Rom mt32_pcm_100_l = {"pcm_mt32_l", LASynthModel::ROM_TYPE::PCM};
+const Rom mt32_pcm_100_h = {"pcm_mt32_h", LASynthModel::ROM_TYPE::PCM};
+
+// CM-32L & CM-32LN
 const Rom cm32l_ctrl_100_f = {"ctrl_cm32l_1_00", LASynthModel::ROM_TYPE::CONTROL};
 const Rom cm32l_ctrl_102_f = {"ctrl_cm32l_1_02", LASynthModel::ROM_TYPE::CONTROL};
 const Rom cm32ln_ctrl_100_f = {"ctrl_cm32ln_1_00", LASynthModel::ROM_TYPE::CONTROL};
+
 const Rom cm32l_pcm_100_f = {"pcm_cm32l", LASynthModel::ROM_TYPE::PCM};
-const Rom cm32l_pcm_100_h  = {"pcm_cm32l_h", LASynthModel::ROM_TYPE::PCM};
-const Rom& cm32l_pcm_100_l = mt32_pcm_100_f; // Lower half of samples comes from
-                                             // MT-32
+const Rom cm32l_pcm_100_h = {"pcm_cm32l_h", LASynthModel::ROM_TYPE::PCM};
+
+// Lower half of samples comes from MT-32
+const Rom& cm32l_pcm_100_l = mt32_pcm_100_f;
 
 // Roland LA Models (composed of ROMs)
-const LASynthModel mt32_104_model   = {"mt32_104",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_104_f,
-                                       &mt32_ctrl_104_a,
-                                       &mt32_ctrl_104_b};
-const LASynthModel mt32_105_model   = {"mt32_105",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_105_f,
-                                       &mt32_ctrl_105_a,
-                                       &mt32_ctrl_105_b};
-const LASynthModel mt32_106_model   = {"mt32_106",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_106_f,
-                                       &mt32_ctrl_106_a,
-                                       &mt32_ctrl_106_b};
-const LASynthModel mt32_107_model   = {"mt32_107",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_107_f,
-                                       &mt32_ctrl_107_a,
-                                       &mt32_ctrl_107_b};
+const LASynthModel mt32_104_model = {"mt32_104",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_104_f,
+                                     &mt32_ctrl_104_a,
+                                     &mt32_ctrl_104_b};
+
+const LASynthModel mt32_105_model = {"mt32_105",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_105_f,
+                                     &mt32_ctrl_105_a,
+                                     &mt32_ctrl_105_b};
+
+const LASynthModel mt32_106_model = {"mt32_106",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_106_f,
+                                     &mt32_ctrl_106_a,
+                                     &mt32_ctrl_106_b};
+
+const LASynthModel mt32_107_model = {"mt32_107",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_107_f,
+                                     &mt32_ctrl_107_a,
+                                     &mt32_ctrl_107_b};
+
 const LASynthModel mt32_bluer_model = {"mt32_bluer",
                                        &mt32_pcm_100_f,
                                        &mt32_pcm_100_l,
@@ -135,44 +155,55 @@ const LASynthModel mt32_bluer_model = {"mt32_bluer",
                                        &mt32_ctrl_bluer_f,
                                        &mt32_ctrl_bluer_a,
                                        &mt32_ctrl_bluer_b};
-const LASynthModel mt32_203_model   = {"mt32_203",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_203_f,
-                                       nullptr,
-                                       nullptr};
-const LASynthModel mt32_204_model   = {"mt32_204",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_204_f,
-                                       nullptr,
-                                       nullptr};
-const LASynthModel mt32_206_model   = {"mt32_206",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_206_f,
-                                       nullptr,
-                                       nullptr};
-const LASynthModel mt32_207_model   = {"mt32_207",
-                                       &mt32_pcm_100_f,
-                                       &mt32_pcm_100_l,
-                                       &mt32_pcm_100_h,
-                                       &mt32_ctrl_207_f,
-                                       nullptr,
-                                       nullptr};
-const LASynthModel cm32l_100_model  = {"cm32l_100",
-                                       &cm32l_pcm_100_f,
-                                       &cm32l_pcm_100_l,
-                                       &cm32l_pcm_100_h,
-                                       &cm32l_ctrl_100_f,
-                                       nullptr,
-                                       nullptr};
-const LASynthModel cm32l_102_model = {
-        "cm32l_102",       &cm32l_pcm_100_f, &cm32l_pcm_100_l, &cm32l_pcm_100_h,
-        &cm32l_ctrl_102_f, nullptr, nullptr};
+
+const LASynthModel mt32_203_model = {"mt32_203",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_203_f,
+                                     nullptr,
+                                     nullptr};
+
+const LASynthModel mt32_204_model = {"mt32_204",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_204_f,
+                                     nullptr,
+                                     nullptr};
+
+const LASynthModel mt32_206_model = {"mt32_206",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_206_f,
+                                     nullptr,
+                                     nullptr};
+
+const LASynthModel mt32_207_model = {"mt32_207",
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_207_f,
+                                     nullptr,
+                                     nullptr};
+
+const LASynthModel cm32l_100_model = {"cm32l_100",
+                                      &cm32l_pcm_100_f,
+                                      &cm32l_pcm_100_l,
+                                      &cm32l_pcm_100_h,
+                                      &cm32l_ctrl_100_f,
+                                      nullptr,
+                                      nullptr};
+
+const LASynthModel cm32l_102_model = {"cm32l_102",
+                                      &cm32l_pcm_100_f,
+                                      &cm32l_pcm_100_l,
+                                      &cm32l_pcm_100_h,
+                                      &cm32l_ctrl_102_f,
+                                      nullptr,
+                                      nullptr};
+
 const LASynthModel cm32ln_100_model = {"cm32ln_100",
                                        &cm32l_pcm_100_f,
                                        &cm32l_pcm_100_l,
@@ -182,11 +213,15 @@ const LASynthModel cm32ln_100_model = {"cm32ln_100",
                                        nullptr};
 
 // Aliased models
-const LASynthModel mt32_new_model = {"mt32_new", // new is 2.04
-                                     &mt32_pcm_100_f, &mt32_pcm_100_l,
-                                     &mt32_pcm_100_h, &mt32_ctrl_204_f,
-                                     nullptr,         nullptr};
-const LASynthModel mt32_old_model = {"mt32_old", // old is 1.07
+const LASynthModel mt32_new_model = {"mt32_new", // "mt32_new" is 2.04
+                                     &mt32_pcm_100_f,
+                                     &mt32_pcm_100_l,
+                                     &mt32_pcm_100_h,
+                                     &mt32_ctrl_204_f,
+                                     nullptr,
+                                     nullptr};
+
+const LASynthModel mt32_old_model = {"mt32_old", // "mt32_old" is 1.07
                                      &mt32_pcm_100_f,
                                      &mt32_pcm_100_l,
                                      &mt32_pcm_100_h,
@@ -212,7 +247,7 @@ const LASynthModel* all_models[] = {&cm32ln_100_model,
 
 MidiHandler_mt32 mt32_instance;
 
-static void init_mt32_dosbox_settings(Section_prop &sec_prop)
+static void init_mt32_dosbox_settings(Section_prop& sec_prop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
@@ -232,7 +267,8 @@ static void init_mt32_dosbox_settings(Section_prop &sec_prop)
 	                        mt32_206_model.GetName(),
 	                        mt32_203_model.GetName(),
 	                        nullptr};
-	auto *str_prop       = sec_prop.Add_string("model", when_idle, "auto");
+
+	auto* str_prop = sec_prop.Add_string("model", when_idle, "auto");
 	str_prop->Set_values(models);
 	str_prop->Set_help(
 	        "MT-32 model to use:\n"
@@ -275,7 +311,7 @@ static void register_mt32_text_messages()
 	MSG_Add("MT32_SOURCE_DIR_LABEL", "Loaded From : ");
 }
 
-#	if defined(WIN32)
+#if defined(WIN32)
 
 static std::deque<std_fs::path> get_rom_dirs()
 {
@@ -324,8 +360,7 @@ static std::deque<std_fs::path> get_rom_dirs()
 
 static std::deque<std_fs::path> get_selected_dirs()
 {
-	const auto section = static_cast<Section_prop *>(
-	        control->GetSection("mt32"));
+	const auto section = static_cast<Section_prop*>(control->GetSection("mt32"));
 	assert(section);
 
 	// Get potential ROM directories from the environment and/or system
@@ -348,7 +383,7 @@ static std::deque<std_fs::path> get_selected_dirs()
 
 static std::string get_selected_model()
 {
-	const auto section = static_cast<Section_prop *>(control->GetSection("mt32"));
+	const auto section = static_cast<Section_prop*>(control->GetSection("mt32"));
 	assert(section);
 	return section->Get_string("model");
 }
@@ -356,10 +391,12 @@ static std::string get_selected_model()
 static std::set<const LASynthModel*> has_models(const MidiHandler_mt32::service_t& service,
                                                 const std_fs::path& dir)
 {
-	std::set<const LASynthModel *> models = {};
-	for (const auto &model : all_models)
-		if (model->InDir(service, dir))
+	std::set<const LASynthModel*> models = {};
+	for (const auto& model : all_models) {
+		if (model->InDir(service, dir)) {
 			models.insert(model);
+		}
+	}
 	return models;
 }
 
@@ -368,11 +405,15 @@ static std::optional<model_and_dir_t> load_model(
         const std::string& selected_model, const std::deque<std_fs::path>& rom_dirs)
 {
 	const bool is_auto = (selected_model == "auto");
-	for (const auto &model : all_models)
-		if (is_auto || model->Matches(selected_model))
-			for (const auto &dir : rom_dirs)
-				if (model->Load(service, dir))
+	for (const auto& model : all_models) {
+		if (is_auto || model->Matches(selected_model)) {
+			for (const auto& dir : rom_dirs) {
+				if (model->Load(service, dir)) {
 					return {{model, simplify_path(dir)}};
+				}
+			}
+		}
+	}
 	return {};
 }
 
@@ -385,26 +426,25 @@ static mt32emu_report_handler_i get_report_handler_interface()
 			return MT32EMU_REPORT_HANDLER_VERSION_0;
 		}
 
-		static void printDebug([[maybe_unused]] void *instance_data,
-		                       const char *fmt,
-		                       va_list list)
+		static void printDebug([[maybe_unused]] void* instance_data,
+		                       const char* fmt, va_list list)
 		{
 			char msg[1024];
 			safe_sprintf(msg, fmt, list);
 			LOG_DEBUG("MT32: %s", msg);
 		}
 
-		static void onErrorControlROM(void *)
+		static void onErrorControlROM(void*)
 		{
 			LOG_WARNING("MT32: Couldn't open Control ROM file");
 		}
 
-		static void onErrorPCMROM(void *)
+		static void onErrorPCMROM(void*)
 		{
 			LOG_WARNING("MT32: Couldn't open PCM ROM file");
 		}
 
-		static void showLCDMessage(void *, const char *message)
+		static void showLCDMessage(void*, const char* message)
 		{
 			LOG_MSG("MT32: LCD-Message: %s", message);
 		}
@@ -438,8 +478,9 @@ MidiHandler_mt32::service_t MidiHandler_mt32::GetService()
 	const std::lock_guard<std::mutex> lock(service_mutex);
 	service_t mt32_service = std::make_unique<MT32Emu::Service>();
 	// Has libmt32emu already created a context?
-	if (!mt32_service->getContext())
+	if (!mt32_service->getContext()) {
 		mt32_service->createContext(get_report_handler_interface(), this);
+	}
 	return mt32_service;
 }
 
@@ -450,12 +491,16 @@ static size_t get_max_dir_width(const LASynthModel* (&models_without_aliases)[12
                                 const char* indent, const char* column_delim)
 {
 	const size_t column_delim_width = strlen(column_delim);
+
 	size_t header_width = strlen(indent);
-	for (const auto &model : models_without_aliases)
+
+	for (const auto& model : models_without_aliases) {
 		header_width += strlen(model->GetVersion()) + column_delim_width;
+	}
 
 	const size_t term_width = INT10_GetTextColumns() - column_delim_width;
 	assert(term_width > header_width);
+
 	const auto max_dir_width = term_width - header_width;
 	return max_dir_width;
 }
@@ -468,7 +513,8 @@ using dirs_with_models_t = std::map<std_fs::path, std::set<const LASynthModel*>>
 static std::set<const LASynthModel*> populate_available_models(
         const MidiHandler_mt32::service_t& service, dirs_with_models_t& dirs_with_models)
 {
-	std::set<const LASynthModel *> available_models;
+	std::set<const LASynthModel*> available_models;
+
 	for (const auto& dir : get_selected_dirs()) {
 		const auto models = has_models(service, dir);
 		if (!models.empty()) {
@@ -483,12 +529,13 @@ static std::set<const LASynthModel*> populate_available_models(
 // across the first row and directories are printed down the left column.
 // Long directories are truncated and model versions are used to avoid text
 // wrapping.
-MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
+MIDI_RC MidiHandler_mt32::ListAll(Program* caller)
 {
 	// Table layout constants
-	constexpr char column_delim[] = " ";
-	constexpr char indent[] = "  ";
+	constexpr char column_delim[]  = " ";
+	constexpr char indent[]        = "  ";
 	constexpr char trailing_dots[] = "..";
+
 	const auto delim_width = strlen(column_delim);
 
 	const LASynthModel* models_without_aliases[] = {&cm32ln_100_model,
@@ -505,7 +552,9 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 	                                                &mt32_203_model};
 
 	const size_t max_dir_width = get_max_dir_width(models_without_aliases,
-	                                               indent, column_delim);
+	                                               indent,
+	                                               column_delim);
+
 	const size_t truncated_dir_width = max_dir_width - strlen(trailing_dots);
 	assert(truncated_dir_width < max_dir_width);
 
@@ -513,6 +562,7 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 	dirs_with_models_t dirs_with_models;
 	const auto available_models = populate_available_models(GetService(),
 	                                                        dirs_with_models);
+
 	if (available_models.empty()) {
 		caller->WriteOut("%s%s\n", indent, MSG_Get("MT32_NO_SUPPORTED_MODELS"));
 		return MIDI_RC::OK;
@@ -529,22 +579,26 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 	// Print the header row of all models
 	const std::string dirs_padding(max_dir_width, ' ');
 	caller->WriteOut("%s%s", indent, dirs_padding.c_str());
-	for (const auto &model : models_without_aliases) {
-		const bool is_missing = (available_models.find(model) == available_models.end());
+
+	for (const auto& model : models_without_aliases) {
+		const bool is_missing = (available_models.find(model) ==
+		                         available_models.end());
+
 		const auto color = get_highlight(is_missing);
-		caller->WriteOut("%s%s%s%s", color, model->GetVersion(),
-		                 nocolor, column_delim);
+
+		caller->WriteOut("%s%s%s%s", color, model->GetVersion(), nocolor, column_delim);
 	}
 	caller->WriteOut("\n");
 
 	// Get the single-character inventory presence indicators
 	const std::string_view missing_indicator = MSG_Get(
 	        "MT32_INVENTORY_TABLE_MISSING_LETTER");
+
 	const std::string_view available_indicator = MSG_Get(
 	        "MT32_INVENTORY_TABLE_AVAILABLE_LETTER");
 
 	// Iterate over the found directories and models
-	for (const auto &dir_and_models : dirs_with_models) {
+	for (const auto& dir_and_models : dirs_with_models) {
 		const auto dir = simplify_path(dir_and_models.first).string();
 
 		const auto& dir_models = dir_and_models.second;
@@ -552,19 +606,26 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 		// Print the directory, and truncate it if it's too long
 		if (dir.size() > max_dir_width) {
 			const auto truncated_dir = dir.substr(0, truncated_dir_width);
-			caller->WriteOut("%s%s%s", indent, truncated_dir.c_str(), trailing_dots);
+			caller->WriteOut("%s%s%s",
+			                 indent,
+			                 truncated_dir.c_str(),
+			                 trailing_dots);
 		}
 		// Otherwise print the directory with padding
 		else {
-			const auto pad_width = max_dir_width - dir.size();
+			const auto pad_width   = max_dir_width - dir.size();
 			const auto dir_padding = std::string(pad_width, ' ');
-			caller->WriteOut("%s%s%s", indent, dir.c_str(), dir_padding.c_str());
+			caller->WriteOut("%s%s%s",
+			                 indent,
+			                 dir.c_str(),
+			                 dir_padding.c_str());
 		}
 		// Print an indicator if the directory has the model
-		for (const auto &model : models_without_aliases) {
+		for (const auto& model : models_without_aliases) {
 			const auto column_width = strlen(model->GetVersion());
 			std::string textbox(column_width + delim_width, ' ');
 			assert(textbox.size() > 2);
+
 			const size_t text_center = (textbox.size() / 2) - 1;
 
 			const bool is_missing = (dir_models.find(model) ==
@@ -588,6 +649,7 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 
 	if (model_and_dir && service) {
 		// Print the loaded ROM version
+
 		mt32emu_rom_info rom_info = {};
 		{
 			// Request exclusive access prior to getting ROM info
@@ -619,25 +681,27 @@ MIDI_RC MidiHandler_mt32::ListAll(Program *caller)
 	return MIDI_RC::OK;
 }
 
-bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
+bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 {
 	Close();
 
-	service_t mt32_service = GetService();
+	service_t mt32_service           = GetService();
 	const std::string selected_model = get_selected_model();
-	const auto rom_dirs = get_selected_dirs();
+	const auto rom_dirs              = get_selected_dirs();
 
 	// Load the selected model and print info about it
 	auto loaded_model_and_dir = load_model(mt32_service, selected_model, rom_dirs);
 	if (!loaded_model_and_dir) {
 		LOG_WARNING("MT32: Failed to find ROMs for model %s in:",
-		        selected_model.c_str());
+		            selected_model.c_str());
+
 		for (const auto& dir : rom_dirs) {
 			const char div = (dir != rom_dirs.back() ? '|' : '`');
 			LOG_MSG("MT32:  %c- %s", div, dir.string().c_str());
 		}
 		return false;
 	}
+
 	mt32emu_rom_info rom_info;
 	mt32_service->getROMInfo(&rom_info);
 
@@ -646,17 +710,18 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	        rom_info.control_rom_description,
 	        loaded_model_and_dir->second.string().c_str());
 
-	const auto audio_frame_rate_hz = MIXER_GetSampleRate();
-	ms_per_audio_frame             = millis_in_second / audio_frame_rate_hz;
+	const auto sample_rate_hz = MIXER_GetSampleRate();
 
-	mt32_service->setAnalogOutputMode(ANALOG_MODE);
-	mt32_service->selectRendererType(RENDERING_TYPE);
-	mt32_service->setStereoOutputSampleRate(audio_frame_rate_hz);
-	mt32_service->setSamplerateConversionQuality(RATE_CONVERSION_QUALITY);
-	mt32_service->setDACInputMode(DAC_MODE);
-	mt32_service->setNiceAmpRampEnabled(USE_NICE_RAMP);
-	mt32_service->setNicePanningEnabled(USE_NICE_PANNING);
-	mt32_service->setNicePartialMixingEnabled(USE_NICE_PARTIAL_MIXING);
+	ms_per_audio_frame = millis_in_second / sample_rate_hz;
+
+	mt32_service->setAnalogOutputMode(AnalogMode);
+	mt32_service->selectRendererType(RenderingType);
+	mt32_service->setStereoOutputSampleRate(sample_rate_hz);
+	mt32_service->setSamplerateConversionQuality(ResamplingQuality);
+	mt32_service->setDACInputMode(DacEmulationMode);
+	mt32_service->setNiceAmpRampEnabled(UseNiceRamp);
+	mt32_service->setNicePanningEnabled(UseNicePanning);
+	mt32_service->setNicePartialMixingEnabled(UseNicePartialMixing);
 
 	const auto rc = mt32_service->openSynth();
 	if (rc != MT32EMU_RC_OK) {
@@ -669,7 +734,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	                                      std::placeholders::_1);
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                      audio_frame_rate_hz,
+	                                      sample_rate_hz,
 	                                      "MT32",
 	                                      {ChannelFeature::Sleep,
 	                                       ChannelFeature::Stereo,
@@ -679,15 +744,16 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	// ask the channel to scale all the samples up to its 0db level.
 	mixer_channel->Set0dbScalar(Max16BitSampleValue);
 
-	const auto section = static_cast<Section_prop *>(control->GetSection("mt32"));
+	const auto section = static_cast<Section_prop*>(control->GetSection("mt32"));
 	assert(section);
 
 	const std::string filter_prefs = section->Get_string("mt32_filter");
-	//
+
 	if (!mixer_channel->TryParseAndSetCustomFilter(filter_prefs)) {
-		if (filter_prefs != "off")
+		if (filter_prefs != "off") {
 			LOG_WARNING("MT32: Invalid 'mt32_filter' value: '%s', using 'off'",
 			            filter_prefs.c_str());
+		}
 
 		mixer_channel->SetHighPassFilter(FilterState::Off);
 		mixer_channel->SetLowPassFilter(FilterState::Off);
@@ -700,8 +766,8 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 	const auto render_ahead_ms = MIXER_GetPreBufferMs() * 2;
 
 	// Size the out-bound audio frame FIFO
-	assert(audio_frame_rate_hz > 8000); // sane lower-bound of 8 KHz
-	const auto audio_frames_per_ms = iround(audio_frame_rate_hz / millis_in_second);
+	assert(sample_rate_hz > 8000); // sane lower-bound of 8 KHz
+	const auto audio_frames_per_ms = iround(sample_rate_hz / millis_in_second);
 	audio_frame_fifo.Resize(
 	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));
 
@@ -722,13 +788,13 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char *conf)
 
 	// If we haven't failed yet, then we're ready to begin so move the local
 	// objects into the member variables.
-	service = std::move(mt32_service);
-	channel = std::move(mixer_channel);
+	service       = std::move(mt32_service);
+	channel       = std::move(mixer_channel);
 	model_and_dir = std::move(loaded_model_and_dir);
 
 	// Start rendering audio
 	const auto render = std::bind(&MidiHandler_mt32::Render, this);
-	renderer = std::thread(render);
+	renderer          = std::thread(render);
 	set_thread_name(renderer, "dosbox:mt32");
 
 	is_open = true;
@@ -742,8 +808,9 @@ MidiHandler_mt32::~MidiHandler_mt32()
 
 void MidiHandler_mt32::Close()
 {
-	if (!is_open)
+	if (!is_open) {
 		return;
+	}
 
 	LOG_MSG("MT32: Shutting down");
 
@@ -754,16 +821,18 @@ void MidiHandler_mt32::Close()
 	}
 
 	// Stop playback
-	if (channel)
+	if (channel) {
 		channel->Enable(false);
+	}
 
 	// Stop queueing new MIDI work and audio frames
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
 
 	// Wait for the rendering thread to finish
-	if (renderer.joinable())
+	if (renderer.joinable()) {
 		renderer.join();
+	}
 
 	// Stop the synthesizer
 	if (service) {
@@ -780,10 +849,10 @@ void MidiHandler_mt32::Close()
 	// Reset the members
 	service.reset();
 
-	last_rendered_ms = 0.0;
+	last_rendered_ms   = 0.0;
 	ms_per_audio_frame = 0.0;
 
-	is_open          = false;
+	is_open = false;
 }
 
 uint16_t MidiHandler_mt32::GetNumPendingAudioFrames()
@@ -819,7 +888,7 @@ void MidiHandler_mt32::PlayMsg(const MidiMessage& msg)
 }
 
 // The request to play the sysex message is placed in the MIDI work FIFO
-void MidiHandler_mt32::PlaySysex(uint8_t *sysex, size_t len)
+void MidiHandler_mt32::PlaySysex(uint8_t* sysex, size_t len)
 {
 	std::vector<uint8_t> message(sysex, sysex + len);
 	MidiWork work{std::move(message), GetNumPendingAudioFrames(), MessageType::SysEx};
@@ -834,6 +903,7 @@ void MidiHandler_mt32::MixerCallBack(const uint16_t requested_audio_frames)
 
 	// Report buffer underruns
 	constexpr auto warning_percent = 5.0f;
+
 	if (const auto percent_full = audio_frame_fifo.GetPercentFull();
 	    percent_full < warning_percent) {
 		static auto iteration = 0;
@@ -852,6 +922,7 @@ void MidiHandler_mt32::MixerCallBack(const uint16_t requested_audio_frames)
 		assert(audio_frames.size() == requested_audio_frames);
 		channel->AddSamples_sfloat(requested_audio_frames,
 		                           &audio_frames[0][0]);
+
 		last_rendered_ms = PIC_FullIndex();
 	} else {
 		assert(!audio_frame_fifo.IsRunning());
@@ -862,6 +933,7 @@ void MidiHandler_mt32::MixerCallBack(const uint16_t requested_audio_frames)
 void MidiHandler_mt32::RenderAudioFramesToFifo(const uint16_t num_frames)
 {
 	static std::vector<AudioFrame> audio_frames = {};
+
 	// Maybe expand the vector
 	if (audio_frames.size() < num_frames) {
 		audio_frames.resize(num_frames);
@@ -901,11 +973,14 @@ void MidiHandler_mt32::ProcessWorkFromFifo()
 
 	if (work->message_type == MessageType::Channel) {
 		assert(work->message.size() >= MaxMidiMessageLen);
+
 		const auto& data   = work->message.data();
 		const uint32_t msg = data[0] + (data[1] << 8) + (data[2] << 16);
+
 		service->playMsg(msg);
 	} else {
 		assert(work->message_type == MessageType::SysEx);
+
 		service->playSysex(work->message.data(),
 		                   static_cast<uint32_t>(work->message.size()));
 	}
@@ -920,13 +995,12 @@ void MidiHandler_mt32::Render()
 	}
 }
 
-static void mt32_init([[maybe_unused]] Section *sec)
-{}
+static void mt32_init([[maybe_unused]] Section* sec) {}
 
-void MT32_AddConfigSection(const config_ptr_t &conf)
+void MT32_AddConfigSection(const config_ptr_t& conf)
 {
 	assert(conf);
-	Section_prop *sec_prop = conf->AddSection_prop("mt32", &mt32_init);
+	Section_prop* sec_prop = conf->AddSection_prop("mt32", &mt32_init);
 
 	assert(sec_prop);
 	init_mt32_dosbox_settings(*sec_prop);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -37,6 +37,7 @@
 #include "fs_utils.h"
 #include "math_utils.h"
 #include "midi.h"
+#include "mpu401.h"
 #include "midi_lasynth_model.h"
 #include "mixer.h"
 #include "pic.h"

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -44,7 +44,7 @@
 // forward declaration
 class LASynthModel;
 
-using model_and_dir_t = std::pair<const LASynthModel*, std_fs::path>;
+using ModelAndDir = std::pair<const LASynthModel*, std_fs::path>;
 
 static_assert(MT32EMU_VERSION_MAJOR > 2 ||
                       (MT32EMU_VERSION_MAJOR == 2 && MT32EMU_VERSION_MINOR >= 5),
@@ -92,7 +92,7 @@ private:
 	service_t service        = {};
 	std::thread renderer     = {};
 
-	std::optional<model_and_dir_t> model_and_dir = {};
+	std::optional<ModelAndDir> model_and_dir = {};
 
 	// Used to track the balance of time between the last mixer callback
 	// versus the current MIDI Sysex or Msg event.

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -68,10 +68,10 @@ public:
 		return MidiDeviceType::BuiltIn;
 	}
 
-	MIDI_RC ListAll(Program *caller) override;
-	bool Open(const char *conf) override;
+	MIDI_RC ListAll(Program* caller) override;
+	bool Open(const char* conf) override;
 	void PlayMsg(const MidiMessage& msg) override;
-	void PlaySysex(uint8_t *sysex, size_t len) override;
+	void PlaySysex(uint8_t* sysex, size_t len) override;
 	void PrintStats();
 
 private:
@@ -89,13 +89,14 @@ private:
 	RWQueue<MidiWork> work_fifo{1};
 
 	std::mutex service_mutex = {};
-	service_t service = {};
-	std::thread renderer = {};
+	service_t service        = {};
+	std::thread renderer     = {};
+
 	std::optional<model_and_dir_t> model_and_dir = {};
 
 	// Used to track the balance of time between the last mixer callback
 	// versus the current MIDI Sysex or Msg event.
-	double last_rendered_ms = 0.0;
+	double last_rendered_ms   = 0.0;
 	double ms_per_audio_frame = 0.0;
 
 	bool had_underruns = false;

--- a/src/misc/ansi_code_markup.cpp
+++ b/src/misc/ansi_code_markup.cpp
@@ -309,7 +309,7 @@ static const char *get_ansi_code(const Tag &tag)
 	return ansi_code;
 }
 
-std::string convert_ansi_markup(std::string &str)
+std::string convert_ansi_markup(const std::string &str)
 {
 	return convert_ansi_markup(str.c_str());
 }


### PR DESCRIPTION
# Description

Now that we have moved from filename-based MT-32/CM-32L ROM lookup to [hash-based](https://github.com/dosbox-staging/dosbox-staging/pull/2591), the unversioned vs versioned ROM differentiation doesn't make much sense.

`mt32_old` and `mt32_new` linking to specific v1.x and v2.x MT-32 versions, respectively, was also a pretty arbitrary decision and was in conflict with how the `auto` model worked.

This change makes the lookup behaviour of "symbolic" models uniform and consistent (`auto`, `mt32`, `cm32l`, `mt32_old`, and `mt32_new`). The lookup mechanism of models that specify the version number (e.g., `mt32_107`, `cm32l_102`) is unchanged.

The output of `MIXER /LISTMIDI` is also improved.

## Previous behaviour

- **Unversioned ROMs** were expected to exist with the `MT32_CONTROL.ROM` & `MT32_PCM.ROM` filenames for MT-32, and `MT-32 CM32L_CONTROL.ROM` & `CM32L_PCM.ROM` for the CM-32L.
- **Versioned ROMs** were expected to be named according to the MAME MT-32/CM-32L file naming convention.
- `model = auto` loaded the first existing ROM in priority order as specified in the config description of `model`.
- `model = mt32` attempted to load the **unversioned** MT-32 ROM and fail the ROM file did not exist.
- `model = cm32l` attempted to load the **unversioned** CM-32L ROM and fail the ROM file did not exist.
- `model = mt32_new` attempted to load the **versioned** v2.04 MT-32 ROM and fail if that exact ROM file did not exist.
- `model = mt32_old` attempted to load the **versioned** v1.07 MT-32 ROM and fail if that exact ROM file did not exist.

## New revised behaviour

- We drop the concept of **versioned** and **unversioned** ROMs completely. Valid MT-32/CM-32L ROMs are identified by their checksums (hashes) at startup, the filenames do not matter. Every identified ROM file is tied to a concrete version number, naturally—it can't work any other way.
- `model = auto` loads the first existing ROM in priority order as specified in the config description of `model`. **This is the same behaviour as before.**
- `model = mt32` loads the first MT-32 ROM using the same priority order (it fails if only CM-32L ROMs are present or no ROMs at all). 
- `model = cm32l` loads the first CM-32L ROM in priority order (it fails if only MT-32 ROMs are present or no ROMs at all). 
- `model = mt32_new` loads the first v2.x MT-32 ROM in priority order (it fails only if no v2.x MT-32 ROMs are present).  
- `model = mt32_old` loads the first v1.x MT-32 ROM in priority order (it fails only if no v1.x MT-32 ROMs are present).   

## New `model` setting description

Basically, a succinct version of the above:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/3b4e46d7-c926-4308-8c3b-edbc13508eb7)

## Backward compatibility

In some weird edge cases (point 3), the behaviour _can_ be different than before (meaning a different ROM model might be picked up while the contents of the `romdir` is _exactly_ the same and the user's config is _exactly_ the same too). However, I think this is a complete non-issue as most people would fall into the sane 1) and 2) use cases. People doing weird shit as described in 3) will need to fix up their configs 😎 

1. `romdir` has the "unversioned" ROM files _only_. In this legacy use case, `model = mt32` will pick the MT-32 ROM and `model = cm32l` the CM-32L ROM. Easy!

2. `romdir` has all versioned ROM files (recommended setup). In this case, everything works as expected, even a. bit better (e.g., for `mt32_new` we'll still pick the "best" available "new" MT-32 ROM, even if v2.04 is missing).

3. Mixed case when `romdir` contains _both_ versioned and unversioned ROM files, *and* the person uses `mt32` or `cm32l` which were previously referring to the "unversioned" files—well, depending on what version the "unversioned" ROMs are, and what "versioned" ROMs the person has, the behaviour can be... pretty much anything 😄 However, this use case was always a bit of a clusterfuck and normally people who still use "legacy unversioned ROMs" fall into the first category. The behaviour with mixed versioned and unversioned ROMs was pretty confusing previously and it wasn't a good idea to do that anyway.

## Related issues

Fixes:

- https://github.com/dosbox-staging/dosbox-staging/issues/2969 (except for actually changing the MT-32 when setting a different `model` value)
- https://github.com/dosbox-staging/dosbox-staging/issues/2484
- https://github.com/dosbox-staging/dosbox-staging/issues/2617

# Manual testing

Tested for regressions when using exact model versions and the symbolic models. The symbolic model resolution is more interesting, so here's the test evidence for that:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/d7f8d1f3-2b3b-41ef-80b3-618e974d36ff)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/2d95e014-22df-446d-b470-f7cb10b59356)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/e621fd0f-b4f9-40fa-9413-e544bd995130)

### Hercules output

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/74fb6b80-6b33-49a9-aa4d-4b601aaae502)



# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

