### PR TITLE
Sync enet with upstream version 2.3.6

### DIFF
--- a/src/libs/enet/LICENSE
+++ b/src/libs/enet/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2002-2016 Lee Salzman
-Copyright (c) 2017-2021 Vladyslav Hrytsenko, Dominik Madarász
+Copyright (c) 2017-2022 Vladyslav Hrytsenko, Dominik Madarász
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Description
Not too many changes here.  I grabbed the latest release 2.3.6 from 7/30/2022.  I assume we want to be grabbing stable releases rather than from tip of tree.  However, in this case there's only been 8 commits since this release so let me know if I should be syncing with their master branch instead.

This may revert some changes that @kcgen made.  I was going to just make a comment on the issue thread but figured might as well put a PR in so that we can view the difference in the GitHub UI and be sure it passes CI.

## Related issues
#2998

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

