### PR TITLE
Sync Nuked-OPL3 with upstream

### DIFF
--- a/src/libs/nuked/opl3.c
+++ b/src/libs/nuked/opl3.c
@@ -1108,7 +1108,7 @@ static void OPL3_ProcessSlot(opl3_slot *slot)
     OPL3_SlotGenerate(slot);
 }
 
-inline void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
+void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 {
     opl3_channel *channel;
     opl3_writebuf *writebuf;

--- a/src/libs/nuked/opl3.h
+++ b/src/libs/nuked/opl3.h
@@ -101,6 +101,7 @@ struct _opl3_channel {
     uint8_t alg;
     uint8_t ksv;
     uint16_t cha, chb;
+    uint16_t chc, chd;
     uint8_t ch_num;
 };
 
@@ -128,7 +129,7 @@ struct _opl3_chip {
     uint8_t tremoloshift;
     uint32_t noise;
     int16_t zeromod;
-    int32_t mixbuff[2];
+    int32_t mixbuff[4];
     uint8_t rm_hh_bit2;
     uint8_t rm_hh_bit3;
     uint8_t rm_hh_bit7;
@@ -143,8 +144,8 @@ struct _opl3_chip {
     /* OPL3L */
     int32_t rateratio;
     int32_t samplecnt;
-    int16_t oldsamples[2];
-    int16_t samples[2];
+    int16_t oldsamples[4];
+    int16_t samples[4];
 
     uint64_t writebuf_samplecnt;
     uint32_t writebuf_cur;
@@ -159,6 +160,10 @@ void OPL3_Reset(opl3_chip *chip, uint32_t samplerate);
 void OPL3_WriteReg(opl3_chip *chip, uint16_t reg, uint8_t v);
 void OPL3_WriteRegBuffered(opl3_chip *chip, uint16_t reg, uint8_t v);
 void OPL3_GenerateStream(opl3_chip *chip, int16_t *sndptr, uint32_t numsamples);
+
+void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4);
+void OPL3_Generate4ChResampled(opl3_chip *chip, int16_t *buf4);
+void OPL3_Generate4ChStream(opl3_chip *chip, int16_t *sndptr1, int16_t *sndptr2, uint32_t numsamples);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Description
This nukes (heh) a CI fix @kcgen made but one of the upstream fixes I think may address that issue.  If CI fails, I'll do a cherry-pick to bring our custom changes back in.

## Related issues
#2998


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

