### PR TITLE
Add game mode support for macOS Sonoma or newer

### DIFF
--- a/contrib/macos/Info.plist.template
+++ b/contrib/macos/Info.plist.template
@@ -44,6 +44,9 @@
 	<key>CGDisableCoalescedUpdates</key>
 	<true/>
 
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
+
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 	<key>x86_64</key>

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -479,6 +479,9 @@ static void initialize_vsync_settings()
 	if (has_true(user_pref)) {
 		sdl.vsync.when_windowed.requested   = VsyncState::On;
 		sdl.vsync.when_fullscreen.requested = VsyncState::On;
+	} else if (user_pref == "adaptive") {
+		sdl.vsync.when_windowed.requested   = VsyncState::Adaptive;
+		sdl.vsync.when_fullscreen.requested = VsyncState::Adaptive;
 	} else if (has_false(user_pref)) {
 		sdl.vsync.when_windowed.requested   = VsyncState::Off;
 		sdl.vsync.when_fullscreen.requested = VsyncState::Off;
@@ -4183,7 +4186,7 @@ static void config_add_sdl() {
 	        "  <custom>:  Specify a custom rate as an integer or decimal Hz value\n"
 	        "             (23.000 is the allowed minimum).");
 
-	const char* vsync_prefs[] = {"auto", "on", "off", "yield", nullptr};
+	const char* vsync_prefs[] = {"auto", "on", "adaptive", "off", "yield", nullptr};
 	pstring = sdl_sec->Add_string("vsync", always, "auto");
 
 	pstring->Set_help(
@@ -4193,6 +4196,10 @@ static void config_add_sdl() {
 	        "  on:        Enable vsync. This can prevent tearing in some games but will\n"
 	        "             impact performance or drop frames when the DOS rate exceeds the\n"
 	        "             host rate (e.g. 70 Hz DOS rate vs 60 Hz host rate).\n"
+	        "  adaptive:  Enables vsync when the frame rate is higher than the host rate,\n"
+	        "             but disables it when the frame rate drops below the host rate.\n"
+	        "             This is a reasonable alternative on macOS instead of 'on'.\n"
+	        "             Note: only valid in OpenGL output modes; otherwise treated as 'on'.\n"
 	        "  off:       Attempt to disable vsync to allow quicker frame presentation at\n"
 	        "             the risk of tearing in some games.\n"
 	        "  yield:     Let the host's video driver control video synchronization.");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1069,6 +1069,24 @@ static void setup_presentation_mode(FrameMode &previous_mode)
 		const auto display_might_be_interpolating = (host_rate >=
 		                                             InterpolatingVrrMinRateHz);
 
+		const auto conditions_demand_constant_host_rate = (
+#if defined(MACOSX)
+		        // Normally OpenGL drivers with a swap-interval of 1
+		        // only block for the gap in time after the application
+		        // requests a buffer swap through to presentation of the
+		        // current frame.
+		        //
+		        // However, circa-2023 macOS OpenGL drivers impose
+		        // additional per-frame block penalities if frames
+		        // /aren't/ presented. Therefore, this condition demands
+		        // we present at a constant host rate.
+		        //
+		        sdl.rendering_backend == RenderingBackend::OpenGl &&
+		        get_vsync_settings().requested == VsyncState::On);
+#else
+		        false);
+#endif
+
 		// If we're fullscreen, vsynced, and using a VRR display that
 		// performs frame interpolation, then we prefer to use a
 		// constant rate.
@@ -1087,15 +1105,22 @@ static void setup_presentation_mode(FrameMode &previous_mode)
 		        supported_rate >= dos_rate
 		                ? "Host can handle the full DOS rate"
 		                : "Host cannot handle the DOS rate");
-		LOG_MSG("SDL:   - %s",
-		        conditions_prefer_constant_rate
-		                ? "CFR selected because we're fullscreen, "
-		                  "vsync'd, and display is 140+Hz"
-		                : "VFR selected because we're not "
-		                  "fullscreen, nor vsync'd, nor < 140Hz");
+		if (conditions_demand_constant_host_rate) {
+			LOG_MSG("SDL:   - CFR selected because we're on macOS using"
+			        " OpenGL with vsync on");
+		} else {
+			LOG_MSG("SDL:   - %s",
+					conditions_prefer_constant_rate
+							? "CFR selected because we're fullscreen, "
+							"vsync'd, and display is 140+Hz"
+							: "VFR selected because we're not "
+							"fullscreen, nor vsync'd, nor < 140Hz");
+		}
 #endif
-
-		if (supported_rate >= dos_rate) {
+		if (conditions_demand_constant_host_rate) {
+			mode = FrameMode::Cfr;
+			save_rate_to_frame_period(host_rate);
+		} else if (supported_rate >= dos_rate) {
 			mode = conditions_prefer_constant_rate ? FrameMode::Cfr
 			                                       : FrameMode::Vfr;
 			save_rate_to_frame_period(dos_rate);
@@ -4198,7 +4223,6 @@ static void config_add_sdl() {
 	        "             host rate (e.g. 70 Hz DOS rate vs 60 Hz host rate).\n"
 	        "  adaptive:  Enables vsync when the frame rate is higher than the host rate,\n"
 	        "             but disables it when the frame rate drops below the host rate.\n"
-	        "             This is a reasonable alternative on macOS instead of 'on'.\n"
 	        "             Note: only valid in OpenGL output modes; otherwise treated as 'on'.\n"
 	        "  off:       Attempt to disable vsync to allow quicker frame presentation at\n"
 	        "             the risk of tearing in some games.\n"


### PR DESCRIPTION
# Description

Add a field in the macOS package manifest to let macOS Sonoma users enable Game-Mode when running full screen.

## Related issues

Fixes #3014

# Manual testing

I'm unable to test it because I'm not running Sonoma.

@Burrito78 - can you check?
1. Ensure you're running macOS Sonoma on Apple silicon.
1. Move your pointer over the green button in the upper-left corner of the game window.
2. Choose Enter Full Screen from the menu that appears.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

