### PR TITLE
Change drive macros to return boolean values

### DIFF
--- a/include/drives.h
+++ b/include/drives.h
@@ -367,9 +367,9 @@ struct isoDirEntry {
 #define ISO_MAX_FILENAME_LENGTH 37
 #define ISO_MAXPATHNAME		256
 #define ISO_FIRST_VD		16
-#define IS_ASSOC(fileFlags)	(fileFlags & ISO_ASSOCIATED)
-#define IS_DIR(fileFlags)	(fileFlags & ISO_DIRECTORY)
-#define IS_HIDDEN(fileFlags)	(fileFlags & ISO_HIDDEN)
+#define IS_ASSOC(fileFlags)	(!!(fileFlags & ISO_ASSOCIATED))
+#define IS_DIR(fileFlags)	(!!(fileFlags & ISO_DIRECTORY))
+#define IS_HIDDEN(fileFlags)	(!!(fileFlags & ISO_HIDDEN))
 #define ISO_MAX_HASH_TABLE_SIZE 	100
 
 class isoDrive final : public DOS_Drive {


### PR DESCRIPTION
# Description
Regression from the refactor to use `bit_view`.  Root problem is that the `bit_view` with `view_width` of 1 (so single bit) was being initialized with values other than 0 or 1.

Trying to repro the problem in a debug build resulted in an assert failure which allowed me to quickly track down the problem.

This PR changes the macros to always return a 0 or 1 using `!!`.  I checked the usage code and they are always being used as "true or false" checks.

https://github.com/dosbox-staging/dosbox-staging/blob/de35268dead39032c5560288d14b8a231e40b8e3/src/dos/drive_iso.cpp#L308-L310

https://github.com/dosbox-staging/dosbox-staging/blob/de35268dead39032c5560288d14b8a231e40b8e3/include/bit_view.h#L136

## Related issues
Fixes #3018
Fixes #3019

# Manual testing
In a debug build, the issue is reproducible by the following:

```
imgmount d disk.iso -t cdrom
d:
dir
```

In a release build, asserts are not compiled in.  I was able to reproduce the "file not found" issue in Dark Forces and confirmed this fixes the problem.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

