### PR TITLE
Update Tracy to 0.10

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -669,7 +669,7 @@ tracy_dep = optional_dep
 if get_option('tracy')
     tracy_dep = dependency(
         'tracy',
-        # version: ['>= 0.9', '< 1'],
+        version: ['>= 0.10', '< 1'],
         default_options: default_wrap_options,
         static: ('tracy' in static_libs_list or prefers_static_libs),
         not_found_message: msg.format('tracy'),

--- a/subprojects/tracy.wrap
+++ b/subprojects/tracy.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = tracy-0.9.1
-source_url = https://github.com/wolfpld/tracy/archive/refs/tags/v0.9.1.tar.gz
-source_filename = tracy-0.9.1.tar.gz
-source_hash = c2de9f35ab2a516a9689ff18f5b62a55b73b93b66514bd09ba013d7957993cd7
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/tracy_0.9.1-1/tracy-0.9.1.tar.gz
-wrapdb_version = 0.9.1-1
+directory = tracy-0.10
+source_url = https://github.com/wolfpld/tracy/archive/refs/tags/v0.10.tar.gz
+source_filename = tracy-0.10.tar.gz
+source_hash = a76017d928f3f2727540fb950edd3b736caa97b12dbb4e5edce66542cbea6600
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/tracy_0.10-1/tracy-0.10.tar.gz
+wrapdb_version = 0.10-1
 
 [provide]
 tracy = tracy_dep


### PR DESCRIPTION
# Description

Update Tracy to [0.10](https://github.com/wolfpld/tracy/releases/tag/v0.10) 

# Manual testing

Made a build with

```shell
meson setup -Dtracy=true build/release-tracy
meson compile -C build/release-tracy
```

Verified binary was discoverable:
![CleanShot 2023-10-17 at 07 25 52@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/11f61acf-28af-4fa7-9fef-e4be76e42809)

Verified binary reported statistics for instrumented `increaseticks()`:
![CleanShot 2023-10-17 at 07 26 29@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/bd31b4e1-0419-4536-afa6-ca8a7df9b10a)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

