### PR TITLE
Updated modem CONNECT response behavior

### DIFF
--- a/include/serialport.h
+++ b/include/serialport.h
@@ -49,6 +49,9 @@
 #include "hardware.h"
 #endif
 
+constexpr uint32_t SerialMinBaudRate = 300u;
+constexpr uint32_t SerialMaxBaudRate = 115200u;
+
 // Serial port interface
 #define SERIAL_IO_HANDLERS 8
 #define SERIAL_MAX_FIFO_SIZE 256

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -291,6 +291,8 @@ public:
 	bool Getchar(uint8_t *data, uint8_t *lsr, bool wait_dsr, uint32_t timeout);
 	uint8_t GetPortNumber() const { return port_index + 1; }
 
+	uint32_t GetPortBaudRate() const;
+
 	// What type of port is this?
 	SERIAL_PORT_TYPE serialType = SERIAL_PORT_TYPE::DISABLED;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1061,7 +1061,7 @@ void DOSBOX_Init()
 	        "  - for 'mouse':      model, overrides setting from [mouse] section\n"
 	        "  - for 'direct':     realport (required), rxdelay (optional).\n"
 	        "                      (realport:COM1 realport:ttyS0).\n"
-	        "  - for 'modem':      listenport, sock, baudrate (all optional).\n"
+	        "  - for 'modem':      listenport, sock, bps (all optional).\n"
 	        "  - for 'nullmodem':  server, rxdelay, txdelay, telnet, usedtr,\n"
 	        "                      transparent, port, inhsocket, sock (all optional).\n"
 	        "SOCK parameter specifies the protocol to be used by both sides\n"

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -247,7 +247,7 @@ bool CDirectSerial::doReceive() {
 
 // updatePortConfig is called when emulated app changes the serial port
 // parameters baudrate, stopbits, number of databits, parity.
-void CDirectSerial::updatePortConfig(uint16_t divider, uint8_t lcr)
+void CDirectSerial::updatePortConfig(uint16_t, uint8_t lcr)
 {
 	uint8_t parity = 0;
 
@@ -262,7 +262,7 @@ void CDirectSerial::updatePortConfig(uint16_t divider, uint8_t lcr)
 	uint8_t bytelength = (lcr & 0x3) + 5;
 
 	// baudrate
-	const uint32_t baudrate = divider ? 115200 / divider : 115200;
+	const uint32_t baudrate = GetPortBaudRate();
 
 	// stopbits
 	uint8_t stopbits;

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1289,6 +1289,14 @@ bool CSerial::Putchar(uint8_t data, bool wait_dsr, bool wait_cts, uint32_t timeo
 	return true;
 }
 
+uint32_t CSerial::GetPortBaudRate() const {
+	if (baud_divider == 0) {
+		return 115200;
+	}
+
+	return 115200 / baud_divider;
+}
+
 class SERIALPORTS final : public Module_base {
 public:
 	SERIALPORTS (Section * configuration):Module_base (configuration) {

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1018,10 +1018,9 @@ static constexpr std::tuple<uint8_t, uint8_t> baud_to_regs(uint32_t baud_rate)
 	// Cap the lower-bound to 300 baud. Although the first 1950s modem
 	// offered 110 baud, by the time DOS was available 8-bit ISA modems
 	// offered at least 300 and even 1200 baud.
-	baud_rate = std::max(300u, baud_rate);
+	baud_rate = std::max(SerialMinBaudRate, baud_rate);
 
-	constexpr auto max_baud = 115200u;
-	const auto delay_ratio = static_cast<uint16_t>(max_baud / baud_rate);
+	const auto delay_ratio = static_cast<uint16_t>(SerialMaxBaudRate / baud_rate);
 
 	const uint8_t transmit_reg = delay_ratio & 0xff;  // bottom byte
 	const uint8_t interrupt_reg = delay_ratio >> 8;   // top byte
@@ -1291,10 +1290,10 @@ bool CSerial::Putchar(uint8_t data, bool wait_dsr, bool wait_cts, uint32_t timeo
 
 uint32_t CSerial::GetPortBaudRate() const {
 	if (baud_divider == 0) {
-		return 115200;
+		return SerialMaxBaudRate;
 	}
 
-	return 115200 / baud_divider;
+	return SerialMaxBaudRate / baud_divider;
 }
 
 class SERIALPORTS final : public Module_base {

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -360,13 +360,12 @@ void CSerialModem::SetModemSpeed(const uint32_t cfg_val) {
 }
 
 void CSerialModem::UpdateConnectString() {
-	constexpr auto min_bps     = 300u;
-	constexpr auto max_bps     = 115200u;
 	const uint32_t connect_val = clamp(modem_bps_config,
-	                                   min_bps,
+	                                   SerialMinBaudRate,
 	                                   GetPortBaudRate());
 
-	assert(connect_val >= min_bps && connect_val <= max_bps);
+	assert(connect_val >= SerialMinBaudRate &&
+	       connect_val <= SerialMaxBaudRate);
 	safe_sprintf(connect_string, "CONNECT %d", connect_val);
 }
 

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -153,19 +153,21 @@ CSerialModem::CSerialModem(const uint8_t port_idx, CommandLine *cmd)
 	}
 
 	// Get the connect speed to report
-	constexpr auto min_baudrate = 300u;
-	constexpr auto max_baudrate = 57600u;
-	if (getUintFromString("baudrate:", val, cmd)) {
-		val = clamp(val, min_baudrate, max_baudrate);
+	constexpr auto min_bps = 300u;
+	constexpr auto max_bps = 57600u;
+	if (getUintFromString("bps:", val, cmd)) {
+		val = clamp(val, min_bps, max_bps);
 	} else {
-		val = max_baudrate;
+		val = max_bps;
 	}
 
-	assert(val >= min_baudrate && val <= max_baudrate);
+	assert(val >= min_bps && val <= max_bps);
 	safe_sprintf(connect_string, "CONNECT %d", val);
 
-	LOG_MSG("SERIAL: Port %" PRIu8 " will report baud rate %d",
-			GetPortNumber(), val);
+	LOG_MSG("SERIAL: Port %" PRIu8 " modem will report connection speed"
+	        "of %d bits per second",
+	        GetPortNumber(),
+	        val);
 
 	InstallationSuccessful=true;
 }

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -29,7 +29,6 @@
 #include "serialport.h"
 #include "misc_util.h"
 
-#define MODEMSPD 57600
 #define SREGS 100
 
 //If it's too high you overflow terminal clients buffers i think
@@ -191,6 +190,7 @@ public:
 	void AcceptIncomingCall();
 	uint32_t ScanNumber(char *&scan) const;
 	char GetChar(char * & scan) const;
+	uint32_t UpdateConnectString();
 
 	void DoCommand();
 
@@ -249,6 +249,7 @@ protected:
 	uint16_t listenport = 23; // 23 is the default telnet TCP/IP port
 	uint8_t reg[SREGS] = {0};
 	SocketType socketType = SocketType::Tcp;
+	uint32_t modem_bps_config = 0;
 	std::unique_ptr<NETServerSocket> serversocket = nullptr;
 	std::unique_ptr<NETClientSocket> clientsocket = nullptr;
 	std::unique_ptr<NETClientSocket> waitingclientsocket = nullptr;

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -190,7 +190,8 @@ public:
 	void AcceptIncomingCall();
 	uint32_t ScanNumber(char *&scan) const;
 	char GetChar(char * & scan) const;
-	uint32_t UpdateConnectString();
+	void SetModemSpeed(const uint32_t cfg_val);
+	void UpdateConnectString();
 
 	void DoCommand();
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -542,7 +542,8 @@ static Bitu INT14_Handler(void) {
 		default: assert(false); return CBRET_NONE;
 		}
 
-		const auto baudresult = static_cast<uint16_t>(115200 / baudrate);
+		const auto baudresult = static_cast<uint16_t>(
+		        SerialMaxBaudRate / baudrate);
 
 		IO_WriteB(port+3, 0x80);	// enable divider access
 		IO_WriteB(port, (uint8_t)baudresult&0xff);


### PR DESCRIPTION
# Description

- Renamed modem "baudrate" parameter to "bps" (bits per second). This is done because CONNECT response reports established connection's _speed_ not baud rate. Modem speed and modem baud rate are two different things as described here: https://www.linuxjournal.com/files/linuxjournal.com/linuxjournal/articles/010/1097/1097s2.html
- Reported modem speed now matches port baud rate by default. According to this article, later modems would usually synchronize their speed to port baud rate: https://tldp.org/HOWTO/Remote-Serial-Console-HOWTO/preparation-setspeed.html This should make things easier for the user in cases like Doom 1.2 which mandates modem speed to be 9600.
- You can now use AT+BPS command to change reported modem speed at runtime.


# Manual testing

Tested with Doom 1.2 and Doom 1.9. Doom 1.2 sets port baud rate to 9600 so modem returns CONNECT 9600 response. Doom 1.9 sets port baud rate to 14400 by default to modem returns CONNECT 14400 response.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

