### PR TITLE
Re-write CLS command to not change screen mode

### DIFF
--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -2723,8 +2723,8 @@ Where:
   This command has no parameters.
 
 Notes:
-  Running [color=light-green]cls[reset] clears all texts on the DOS screen, except for the command
-  prompt (e.g. [color=white]Z:\>[reset] or [color=white]C:\GAMES>[reset]) on the top-left corner of the screen.
+  Running [color=light-green]cls[reset] clears all text on the DOS screen, except for the command
+  prompt (e.g., [color=white]Z:\>[reset] or [color=white]C:\GAMES>[reset]) on the top-left corner of the screen.
 
 Examples:
   [color=light-green]cls[reset]

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -2219,8 +2219,8 @@ Where:
   This command has no parameters.
 
 Notes:
-  Running [color=light-green]cls[reset] clears all texts on the DOS screen, except for the command
-  prompt (e.g. [color=white]Z:\>[reset] or [color=white]C:\GAMES>[reset]) on the top-left corner of the screen.
+  Running [color=light-green]cls[reset] clears all text on the DOS screen, except for the command
+  prompt (e.g., [color=white]Z:\>[reset] or [color=white]C:\GAMES>[reset]) on the top-left corner of the screen.
 
 Examples:
   [color=light-green]cls[reset]

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -847,8 +847,8 @@ void SHELL_Init() {
 	        "  This command has no parameters.\n"
 	        "\n"
 	        "Notes:\n"
-	        "  Running [color=light-green]cls[reset] clears all texts on the DOS screen, except for the command\n"
-	        "  prompt (e.g. [color=white]Z:\\>[reset] or [color=white]C:\\GAMES>[reset]) on the top-left corner of the screen.\n"
+	        "  Running [color=light-green]cls[reset] clears all text on the DOS screen, except for the command\n"
+	        "  prompt (e.g., [color=white]Z:\\>[reset] or [color=white]C:\\GAMES>[reset]) on the top-left corner of the screen.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  [color=light-green]cls[reset]\n");


### PR DESCRIPTION
# Description
Changes the CLS command to scroll the window rather than reset the video mode.

I looked at the FreeDOS source and used logic from there (simplified a bit to fit our purposes):

https://github.com/FDOS/freecom/blob/master/cmd/cls.c

## Related issues
Fixes #2598


# Manual testing

- Confirmed the bug with DOS Navigator mentioned on #2598 is fixed
- Tested with various machine types to confirm it works on different modes
- Tested with machine=hercules, ega, cga, tandy, pcjr, cga_mono, svga_s3

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

