### PR TITLE
Fix extended ASCII codes not being rendered in batch files

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -42,8 +42,8 @@ extern DOS_Shell* first_shell;
 
 class ByteReader {
 public:
-	virtual void Reset()               = 0;
-	virtual std::optional<char> Read() = 0;
+	virtual void Reset()                  = 0;
+	virtual std::optional<uint8_t> Read() = 0;
 
 	ByteReader()                             = default;
 	ByteReader(const ByteReader&)            = delete;

--- a/src/shell/file_reader.cpp
+++ b/src/shell/file_reader.cpp
@@ -34,7 +34,7 @@ FileReader::FileReader(std::string_view file, [[maybe_unused]] PrivateOnly key)
           valid(DOS_OpenFile(filename.c_str(), (DOS_NOT_INHERIT | OPEN_READ), &handle))
 {}
 
-std::optional<char> FileReader::Read()
+std::optional<uint8_t> FileReader::Read()
 {
 	std::uint8_t data        = 0;
 	std::uint16_t bytes_read = 1;
@@ -44,7 +44,7 @@ std::optional<char> FileReader::Read()
 		return std::nullopt;
 	}
 
-	return static_cast<char>(data);
+	return data;
 }
 
 void FileReader::Reset()

--- a/src/shell/file_reader.h
+++ b/src/shell/file_reader.h
@@ -39,7 +39,7 @@ public:
 	        std::string_view file);
 
 	void Reset() final;
-	[[nodiscard]] std::optional<char> Read() final;
+	[[nodiscard]] std::optional<uint8_t> Read() final;
 
 	FileReader(std::string_view filename, PrivateOnly key);
 	~FileReader() final;

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -24,8 +24,8 @@
 #include "string_utils.h"
 
 // Permitted ASCII control characters in batch files
-constexpr char Esc           = 27;
-constexpr char UnitSeparator = 31;
+constexpr uint8_t Esc           = 27;
+constexpr uint8_t UnitSeparator = 31;
 
 [[nodiscard]] static bool found_label(std::string_view line, std::string_view label);
 
@@ -66,7 +66,7 @@ bool BatchFile::ReadLine(char* lineout)
 
 std::string BatchFile::GetLine()
 {
-	char data        = 0;
+	uint8_t data     = 0;
 	std::string line = {};
 
 	while (data != '\n') {

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -29,7 +29,7 @@ public:
 	{
 		index = 0;
 	}
-	std::optional<char> Read() override
+	std::optional<uint8_t> Read() override
 	{
 		if (index >= contents.size()) {
 			return std::nullopt;


### PR DESCRIPTION
# Description
Regression from https://github.com/dosbox-staging/dosbox-staging/commit/039532b95b04da2538a9ff806d9bef7193c1c14f

It was doing a `static_cast<char>` plus a signed comparison of characters.  Technically this is implementation defined and `char` can be unsigned but at least on my machine (Linux x86_64), it is signed.

This resulted in the extended ASCII codes (greater than 127) being cast to negative numbers and failing the inclusion check.

The fix is very simple:

![meme](https://github.com/dosbox-staging/dosbox-staging/assets/8128047/c304cf47-d79f-47d7-af53-1c6204483fff)


## Related issues
#3027

This fix does not help with the non-UTF-8 .conf files.  Those still render incorrectly.  However, copying the contents of autoexec in those same problematic .conf files to a .bat file now does render correctly.

# Manual testing
- Copied the .conf file from above issue to .bat.
- Removed everything except the echo commands.
- Execute the .bat
- It now renders correctly.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

