### PR TITLE
Add legacy codepage to UTF-8 script

### DIFF
--- a/contrib/scripts/codepage_to_utf8.py
+++ b/contrib/scripts/codepage_to_utf8.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2023 rderooy <rderooy@users.noreply.github.com>
+
+"""
+Convert file from legacy codepage to Unicode UTF-8
+
+For example to convert a legacy GOG dosbox config file such that menus are correctly drawn.
+"""
+import argparse
+import os
+import sys
+
+parser = argparse.ArgumentParser(
+    description="Convert file from legacy codepage to Unicode UTF-8",
+    formatter_class=argparse.RawTextHelpFormatter,
+)
+parser.add_argument("filename", type=str, help="filename to convert")
+parser.add_argument(
+    "--cp", type=int, default=437, help="codepage to convert from (default: 437)"
+)
+parser.add_argument(
+    "-o", "--output", type=str, help="output filename (default: overwrite input file)"
+)
+args = parser.parse_args()
+
+if not args.output:
+    args.output = args.filename
+
+try:
+    with open(
+        os.path.expanduser(args.filename), "r", encoding="cp" + str(args.cp)
+    ) as input_file:
+        lines = input_file.read()
+except FileNotFoundError:
+    print("Error: could not locate the input file")
+    sys.exit(1)
+except LookupError:
+    print(f"Error: Unknown encoding '{args.cp}'")
+    sys.exit(1)
+except UnicodeDecodeError:
+    print("Error: input file does not appear to be a text file")
+    sys.exit(1)
+except PermissionError:
+    print("Error: permission denied trying to read the file")
+    sys.exit(1)
+
+try:
+    with open(os.path.expanduser(args.output), "w", encoding="utf-8") as output_file:
+        output_file.write(lines)
+except PermissionError:
+    print("Error: permission denied trying to write to the file")
+    sys.exit(1)
+
+print(f"File '{args.filename}' converted to UTF-8")


### PR DESCRIPTION
# Description

As requested in #3028, the simple script I created to convert files in legacy codepage format to UTF-8.

## Related issues

#3028

# Manual testing

- Converted cp437 input file to UTF-8
- Attempted to convert binary file to UTF-8
- Attempted to convert file with incorrect codepage

# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

