### PR TITLE
Rework and improve `LS.COM` command

### DIFF
--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -2592,14 +2592,6 @@ Esempi:
 :PROGRAM_TREE_DIRECTORY
  Struttura delle directory per il volume %s
 .
-:PROGRAM_TREE_NO_SUBDIRS
-Nessuna sottodirectory da visualizzare.
-
-.
-:PROGRAM_TREE_NO_FILES_SUBDIRS
-Nessun file o sottodirectory da visualizzare.
-
-.
 :PROGRAM_TREE_TOO_MANY_FILES_SUBDIRS
 Troppi file o sottodirectory.
 
@@ -2704,6 +2696,14 @@ Il file '%s' esiste già.
 .
 :SHELL_DIRECTORY_NOT_FOUND
 Directory non trovata - '%s'
+
+.
+:SHELL_NO_SUBDIRS_TO_DISPLAY
+Nessuna sottodirectory da visualizzare.
+
+.
+:SHELL_NO_FILES_SUBDIRS_TO_DISPLAY
+Nessun file o sottodirectory da visualizzare.
 
 .
 :SHELL_READ_ERROR

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -2446,14 +2446,6 @@ Voorbeelden:
 :PROGRAM_TREE_DIRECTORY
  Directorystructuur voor volume %s
 .
-:PROGRAM_TREE_NO_SUBDIRS
-Geen submappen om weer te geven.
-
-.
-:PROGRAM_TREE_NO_FILES_SUBDIRS
-Geen bestanden of submappen om weer te geven.
-
-.
 :PROGRAM_TREE_TOO_MANY_FILES_SUBDIRS
 Te veel bestanden of submappen.
 
@@ -2558,6 +2550,14 @@ Bestand '%s' bestaat al.
 .
 :SHELL_DIRECTORY_NOT_FOUND
 Map niet gevonden - '%s'
+
+.
+:SHELL_NO_SUBDIRS_TO_DISPLAY
+Geen submappen om weer te geven.
+
+.
+:SHELL_NO_FILES_SUBDIRS_TO_DISPLAY
+Geen bestanden of submappen om weer te geven.
 
 .
 :SHELL_READ_ERROR

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -2454,14 +2454,6 @@ Przykłady:
 :PROGRAM_TREE_DIRECTORY
  Drzewo katalogów dla dysku %s
 .
-:PROGRAM_TREE_NO_SUBDIRS
-Brak podkatalogów do wyświetlenia.
-
-.
-:PROGRAM_TREE_NO_FILES_SUBDIRS
-Brak plików lub podkatalogów do wyświetlenia.
-
-.
 :PROGRAM_TREE_TOO_MANY_FILES_SUBDIRS
 Zbyt wiele plików lub podkatalogów.
 
@@ -2526,6 +2518,14 @@ Plik '%s' już istnieje.
 .
 :SHELL_DIRECTORY_NOT_FOUND
 Nie odnaleziono katalogu - '%s'.
+
+.
+:SHELL_NO_SUBDIRS_TO_DISPLAY
+Brak podkatalogów do wyświetlenia.
+
+.
+:SHELL_NO_FILES_SUBDIRS_TO_DISPLAY
+Brak plików lub podkatalogów do wyświetlenia.
 
 .
 :SHELL_READ_ERROR

--- a/include/shell.h
+++ b/include/shell.h
@@ -191,6 +191,8 @@ public:
 std::tuple<std::string, std::string, std::string, bool> parse_drive_conf(
         std::string drive_letter, const std_fs::path& conf_path);
 
+std::string to_search_pattern(const char* arg);
+
 // Localized output
 
 char* format_date(const uint16_t year, const uint8_t month, const uint8_t day);

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,14 +22,270 @@
 
 #include <string>
 
+#include "ansi_code_markup.h"
+#include "checks.h"
+#include "program_more_output.h"
 #include "shell.h"
 #include "string_utils.h"
+#include "../ints/int10.h"
+
+CHECK_NARROWING();
 
 void LS::Run()
 {
-	std::string tmp = "";
-	cmd->GetStringRemain(tmp);
-	char args[CMD_MAXLINE];
-	safe_strcpy(args, tmp.c_str());
-	first_shell->CMD_LS(args);
+	// Handle command line
+
+	if (HelpRequested()) {
+		MoreOutputStrings output(*this);
+		output.AddString(MSG_Get("PROGRAM_LS_HELP_LONG"));
+		output.Display();
+		return;
+	}
+
+	constexpr bool remove_if_found = true;
+	const bool has_option_all = cmd->FindExist("/a", remove_if_found);
+
+	std::vector<std::string> patterns = {};
+	cmd->FillVector(patterns);
+
+	// Make sure no other switches are supplied
+
+	std::string tmp_str = {};
+	if (cmd->FindStringBegin("/", tmp_str)) {
+		tmp_str = std::string("/") + tmp_str;
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), tmp_str.c_str());
+		return;
+	}
+
+	// Check for unsupported wildcard patterns
+
+	for (const auto& pattern : patterns) {
+		const auto first_wildcard = std::min(pattern.find('*'),
+		                                     pattern.find('?'));
+		if (first_wildcard == std::string::npos) {
+			continue;
+		}
+
+		const auto last_slash     = pattern.rfind('/');
+		const auto last_backslash = pattern.rfind('\\');
+
+		if ((last_backslash != std::string::npos &&
+		     last_backslash > first_wildcard) ||
+		    (last_slash != std::string::npos &&
+		     last_slash > first_wildcard)) {
+
+		    WriteOut(MSG_Get("PROGRAM_LS_UNHANDLED_WILDCARD_PATTERN"),
+		             pattern.c_str());
+		    return;
+		}
+	}
+
+	// Prepare search parameters
+
+	FatAttributeFlags search_attr = FatAttributeFlags::NotVolume;
+	if (!has_option_all) {
+		search_attr.system = false;
+		search_attr.hidden = false;
+	}
+
+	if (patterns.empty()) {
+		patterns.push_back({});
+	}
+	for (auto& pattern : patterns) {
+		pattern = to_search_pattern(pattern.c_str());
+	}
+
+	// Search for files/directories according to pattern
+
+	std::vector<DOS_DTA::Result> dir_contents = {};
+
+	const RealPt original_dta = dos.dta();
+	dos.dta(dos.tables.tempdta);
+	DOS_DTA dta(dos.dta());
+
+	for (const auto& pattern : patterns) {
+		if (shutdown_requested) {
+			break;
+		}
+
+		if (!DOS_FindFirst(pattern.c_str(), search_attr)) {
+			continue;
+		}
+
+		do {
+			DOS_DTA::Result result = {};
+			dta.GetResult(result);
+			if (result.IsDummyDirectory()) {
+				continue;
+			}
+			dir_contents.push_back(result);
+		} while (!shutdown_requested && DOS_FindNext());
+	}
+
+	dos.dta(original_dta);
+	if (shutdown_requested) {
+		return;
+	}
+
+	if (dir_contents.empty()) {
+		WriteOut(MSG_Get("SHELL_NO_FILES_SUBDIRS_TO_DISPLAY"));
+		return;
+	}
+
+	// Sort directory contents
+
+	constexpr bool reverse_order = false;
+	DOS_Sort(dir_contents,
+	         ResultSorting::ByName,
+	         reverse_order,
+	         ResultGrouping::NonFilesFirst);
+
+	// Remove duplicates (might arise from multiple patterns)
+
+	const auto tmp = std::move(dir_contents);
+	dir_contents.clear();
+	for (const auto& entry : tmp) {
+		if (dir_contents.empty() ||
+		    dir_contents.back().IsDirectory() != entry.IsDirectory() ||
+		    dir_contents.back().name != entry.name) {
+			dir_contents.push_back(entry);
+		}
+	}
+
+	// Display search results
+
+	constexpr uint8_t separation = 2; // chars separating columns
+
+	const auto name_widths   = GetFileNameLengths(dir_contents, separation);
+	const auto column_widths = GetColumnWidths(name_widths, separation + 1);
+
+	const size_t num_columns = column_widths.size();
+
+	const auto ansi_blue  = convert_ansi_markup("[color=light-blue]");
+	const auto ansi_green = convert_ansi_markup("[color=light-green]");
+	const auto ansi_reset = convert_ansi_markup("[reset]");
+
+	auto write_color = [&](const std::string& ansi_color,
+	                       const std::string& txt,
+	                       const uint8_t width) {
+		assert(width > txt.size());
+		const auto margin_size = static_cast<int>(width - txt.size());
+		const auto output      = ansi_color + txt + ansi_reset;
+		WriteOut("%s%-*s", output.c_str(), margin_size, "");
+	};
+
+	size_t column_count = 0;
+	for (const auto& entry : dir_contents) {
+		auto name = entry.name;
+		const auto column_width = column_widths[column_count++ % num_columns];
+
+		if (entry.IsDirectory()) {
+			upcase(name);
+			write_color(ansi_blue, name, column_width);
+		} else {
+			lowcase(name);
+			if (is_executable_filename(name)) {
+				write_color(ansi_green, name, column_width);
+			} else {
+				WriteOut("%-*s", column_width, name.c_str());
+			}
+		}
+
+		if (column_count % num_columns == 0) {
+			WriteOut_NoParsing("\n");
+		}
+	}
+}
+
+std::vector<uint8_t> LS::GetFileNameLengths(const std::vector<DOS_DTA::Result>& dir_contents,
+                                            const uint8_t padding)
+{
+	std::vector<uint8_t> name_lengths = {};
+	name_lengths.reserve(dir_contents.size());
+
+	for (const auto& entry : dir_contents) {
+		const auto len = entry.name.length();
+		name_lengths.push_back(static_cast<uint8_t>(len + padding));
+	}
+
+	return name_lengths;
+}
+
+std::vector<uint8_t> LS::GetColumnWidths(const std::vector<uint8_t>& name_widths,
+                                         const uint8_t min_column_width)
+{
+	assert(min_column_width > 0);
+
+	// Actual terminal width (number of text columns) using current text
+	// mode; in practice it's either 40, 80, or 132.
+	const auto screen_width = INT10_GetTextColumns();
+
+	// Use screen_width-1 because we never want to print line up to the
+	// actual limit; this would cause unnecessary line wrapping
+	const auto max_columns = static_cast<size_t>((screen_width - 1) / min_column_width);
+	std::vector<uint8_t> column_widths(max_columns);
+
+	// This function returns true when column number is too high to fit
+	// words into a terminal width.  If it returns false, then the first
+	// column_count integers in column_widths vector describe the column
+	// widths.
+	auto too_many_columns = [&](const size_t column_count) -> bool {
+		std::fill(column_widths.begin(), column_widths.end(), 0);
+		if (column_count <= 1) {
+			return false;
+		}
+
+		uint8_t max_line_width = 0; // tally of the longest line
+		size_t current_column  = 0; // current column
+
+		for (const auto width : name_widths) {
+			const uint8_t old_width = column_widths[current_column];
+			const uint8_t new_width = std::max(old_width, width);
+
+			column_widths[current_column] = new_width;
+			max_line_width = check_cast<uint8_t>(max_line_width +
+			                                     new_width - old_width);
+
+			if (max_line_width >= screen_width) {
+				return true;
+			}
+
+			current_column = (current_column + 1) % column_count;
+		}
+		return false;
+	};
+
+	size_t column_count = max_columns;
+	while (too_many_columns(column_count)) {
+		column_count--;
+		column_widths.pop_back();
+	}
+
+	return column_widths;
+}
+
+void LS::AddMessages()
+{
+	MSG_Add("PROGRAM_LS_UNHANDLED_WILDCARD_PATTERN",
+	        "Unhandled wildcard pattern - '%s'\n");
+
+	MSG_Add("PROGRAM_LS_HELP_LONG",
+	        "Displays directory contents in wide list format.\n"
+	        "\n"
+	        "Usage:\n"
+	        "  [color=light-green]ls[reset] [[color=light-cyan]PATTERN[reset] [[color=light-cyan]PATTERN[reset], ...]] [[color=light-cyan]PATH[reset] [[color=light-cyan]PATH[reset], ...]] [/a]\n"
+	        "\n"
+	        "Where:\n"
+	        "  [color=light-cyan]PATTERN[reset] can be either an exact filename or an inexact filename with\n"
+	        "          wildcards, which are the asterisk (*) and the question mark (?).\n"
+	        "  [color=light-cyan]PATH[reset]    is an exact path in a mounted DOS drive to list contents.\n"
+	        "  /a      lists all files and directories, including hidden and system.\n"
+	        "\n"
+	        "Notes:\n"
+	        "  The command will list directories in [color=light-blue]blue[reset], executable DOS programs\n"
+	        "   (*.com, *.exe, *.bat) in [color=light-green]green[reset], and other files in the normal color.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=light-green]ls[reset] [color=light-cyan]file.txt[reset]\n"
+	        "  [color=light-green]ls[reset] [color=light-cyan]c*.ba?[reset]\n");
 }

--- a/src/dos/program_ls.h
+++ b/src/dos/program_ls.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2023  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 #ifndef DOSBOX_PROGRAM_LS_H
 #define DOSBOX_PROGRAM_LS_H
 
+#include "dos_inc.h"
 #include "programs.h"
 
 #include <string>
@@ -29,12 +30,23 @@ class LS final : public Program {
 public:
 	LS()
 	{
+		AddMessages();
 		help_detail = {HELP_Filter::All,
 		               HELP_Category::File,
 		               HELP_CmdType::Program,
 		               "LS"};
 	}
 	void Run() override;
+
+private:
+	// Map a vector of dir contents to a vector of word widths
+	static std::vector<uint8_t> GetFileNameLengths(
+	        const std::vector<DOS_DTA::Result>& dir_contents,
+	        const uint8_t padding = 0);
+	static std::vector<uint8_t> GetColumnWidths(const std::vector<uint8_t>& name_widths,
+	        const uint8_t min_column_width);
+
+	static void AddMessages();
 };
 
 #endif

--- a/src/dos/program_tree.cpp
+++ b/src/dos/program_tree.cpp
@@ -397,8 +397,8 @@ bool TREE::DisplayTree(MoreOutputStrings& output, const std::string& path,
 	if (is_first_entry && !depth) {
 		output.AddString("\n");
 		output.AddString(MSG_Get(has_option_files
-		                                 ? "PROGRAM_TREE_NO_FILES_SUBDIRS"
-		                                 : "PROGRAM_TREE_NO_SUBDIRS"));
+		                                 ? "SHELL_NO_FILES_SUBDIRS_TO_DISPLAY"
+		                                 : "SHELL_NO_SUBDIRS_TO_DISPLAY"));
 	} else if (has_option_files) {
 		// If listing files, separate directories with empty lines
 		display_empty();
@@ -441,9 +441,6 @@ void TREE::AddMessages()
 
 	MSG_Add("PROGRAM_TREE_DIRECTORY", " Directory tree for volume %s");
 
-	MSG_Add("PROGRAM_TREE_NO_SUBDIRS", "No subdirectories to display.\n");
-	MSG_Add("PROGRAM_TREE_NO_FILES_SUBDIRS",
-	        "No files or subdirectories to display.\n");
 	MSG_Add("PROGRAM_TREE_TOO_MANY_FILES_SUBDIRS",
 	        "Too many files or subdirectories.\n");
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -655,6 +655,8 @@ void SHELL_Init() {
 	MSG_Add("SHELL_FILE_NOT_FOUND", "File not found - '%s'\n");
 	MSG_Add("SHELL_FILE_EXISTS", "File '%s' already exists.\n");
 	MSG_Add("SHELL_DIRECTORY_NOT_FOUND", "Directory not found - '%s'\n");
+	MSG_Add("SHELL_NO_SUBDIRS_TO_DISPLAY", "No subdirectories to display.\n");
+	MSG_Add("SHELL_NO_FILES_SUBDIRS_TO_DISPLAY", "No files or subdirectories to display.\n");
 	MSG_Add("SHELL_READ_ERROR", "Error reading file - '%s'\n");
 	MSG_Add("SHELL_WRITE_ERROR", "Error writing file - '%s'\n");
 
@@ -1186,28 +1188,6 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=light-green]lh[reset] [color=light-cyan]tsrapp[reset] [color=white]args[reset]\n");
-
-	MSG_Add("SHELL_CMD_LS_HELP",
-	        "Displays directory contents in wide list format.\n");
-	MSG_Add("SHELL_CMD_LS_HELP_LONG",
-	        "Usage:\n"
-	        "  [color=light-green]ls[reset] [color=light-cyan]PATTERN[reset]\n"
-	        "  [color=light-green]ls[reset] [color=light-cyan]PATH[reset]\n"
-	        "\n"
-	        "Where:\n"
-	        "  [color=light-cyan]PATTERN[reset] can be either an exact filename or an inexact filename with\n"
-	        "          wildcards, which are the asterisk (*) and the question mark (?).\n"
-	        "  [color=light-cyan]PATH[reset]    is an exact path in a mounted DOS drive to list contents.\n"
-	        "\n"
-	        "Notes:\n"
-	        "  The command will list directories in [color=light-blue]blue[reset], executable DOS programs\n"
-	        "   (*.com, *.exe, *.bat) in [color=light-green]green[reset], and other files in the normal color.\n"
-	        "\n"
-	        "Examples:\n"
-	        "  [color=light-green]ls[reset] [color=light-cyan]file.txt[reset]\n"
-	        "  [color=light-green]ls[reset] [color=light-cyan]c*.ba?[reset]\n");
-	MSG_Add("SHELL_CMD_LS_PATH_ERR",
-	        "ls: cannot access '%s': No such file or directory\n");
 
 	MSG_Add("SHELL_CMD_ATTRIB_HELP",
 			"Displays or changes file attributes.\n");


### PR DESCRIPTION
# Description

- Moved `LS.COM` command implementation to `program_ls.cpp` file, cleaned up the code a little.
- Added support for multiple directories / patterns in the command line.
- Command does not display files and directories with Hidden or System attributes anymore, unless `/a` switch is given. 
Rationale: GNU implementation also skips hidden files by default; there are no system files on Unix, and DOS commands which skips hidden files typically skip system files too.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/2956 (partial fix only)


# Manual testing

Played with the command in  various directories, also containing hidden/system files. Sanitizer build did not reveal any issues.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

