### PR TITLE
Tune the IBM Music Feature card's 0-dB level and default filter 

### DIFF
--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13393,15 +13393,17 @@ static void imfc_init(Section* sec)
 	constexpr auto volume_scalar = 2.1f;
 	channel->Set0dbScalar(volume_scalar);
 
-	// The filter parameters have been tweaked by analysing real hardware
-	// recordings. The results are virtually indistinguishable from the
-	// real thing by ear only.
+	// The filter parameters have been tweaked by analysing hardware
+	// line-out recordings by Pierre: Ref:
+	// https://www.youtube.com/watch?v=WHVWDi15AIw. The results are
+	// virtually indistinguishable from the real thing by ear and spectrum
+	// analysis.
 	const std::string filter_choice = conf->Get_string("imfc_filter");
 	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
 
 	if (filter_choice_has_bool && *filter_choice_has_bool == true) {
-		constexpr auto order       = 1;
-		constexpr auto cutoff_freq = 8000;
+		constexpr auto order       = 2;
+		constexpr auto cutoff_freq = 3500;
 		channel->ConfigureLowPassFilter(order, cutoff_freq);
 		channel->SetLowPassFilter(FilterState::On);
 

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13450,7 +13450,7 @@ void init_imfc_dosbox_settings(Section_prop& secprop)
 	int_prop->Set_help(
 	        "The IRQ number of the IBM Music Feature Card (3 by default).");
 
-	const auto str_prop = secprop.Add_string("imfc_filter", when_idle, "off");
+	const auto str_prop = secprop.Add_string("imfc_filter", when_idle, "on");
 	assert(str_prop);
 	str_prop->Set_help(
 	        "Filter for the IBM Music Feature Card output:\n"

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13375,9 +13375,13 @@ static void imfc_init(Section* sec)
 	m_loggerMutex = SDL_CreateMutex();
 #endif
 
+	// The emulation requires playback at 44.1 KHz to match the pitch of
+	// original hardware.
+	constexpr uint16_t imfc_sampling_rate_hz = 44100;
+
 	// Register the Audio channel
 	auto channel = MIXER_AddChannel(IMFC_Mixer_Callback,
-	                                use_mixer_rate,
+	                                imfc_sampling_rate_hz,
 	                                "IMFC",
 	                                {ChannelFeature::Stereo,
 	                                 ChannelFeature::ReverbSend,

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13384,8 +13384,9 @@ static void imfc_init(Section* sec)
 	                                 ChannelFeature::ChorusSend,
 	                                 ChannelFeature::Synthesizer});
 
-	// Bring up the volume to get it on-par with line recordings
-	constexpr auto volume_scalar = 4.0f;
+	// Default volume scalar adjusted to match hardware line-out levels
+	// recorded by Pierre: Ref: https://www.youtube.com/watch?v=WHVWDi15AIw
+	constexpr auto volume_scalar = 2.1f;
 	channel->Set0dbScalar(volume_scalar);
 
 	// The filter parameters have been tweaked by analysing real hardware


### PR DESCRIPTION
# Description

@Python-Exoproject found a nice set of IMFC/FB01 line-out recordings. 

Comparing them against our existing IMFC settings showed we're delivering a little under 3 dB too much default volume and that our default low-pass filter is twice as permissive as it should be (both in dB order and the pass frequency).

This PR tunes these defaults to match the recordings.

## Testing: King's Quest I SCI (1990)

**Line-out recording:**

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/8e9487b4-a86f-43ce-be24-478b88208383

Source: Pierre, YouTube https://www.youtube.com/watch?v=WHVWDi15AIw

**PR:**

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/caa55b17-d4c1-4251-b18c-af157e7da4e5

```ini
[dosbox]
machine = ega
memsize = 1

[cpu]
cycles = 3000

[imfc]
imfc = on
imfc_filter = on

[dos]
xms = false
ems = false
umb = false

[autoexec]
@mount c .
c:
copy iesource.cfg resource.cfg
sierra
exit
```

**Waveform and spectrum comparison:**

Line-out is first, PR is second. Both roll off at 3.5 KHz and taper down to `-85 dB` just under 16 KHz.

![2023-10-23_11-25](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/7892efc0-7e7e-4222-b020-4568dea47520)

## Testing: Laura Bow 1 - The Colonel's Bequest (1989)

**Line-out recording:**

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/ea374a99-9490-4c21-9ce3-7f738c8637b7

Source: Pierre, Youtube https://www.youtube.com/watch?v=VZs3VZm61Z8

**PR:**

Similar to the original recording, a chorus value of 80 `mixer imfc c80` is applied to the IMFC output in the `[autoexec]` section. 


https://github.com/dosbox-staging/dosbox-staging/assets/1557255/6d7d0cc5-4f82-4796-85c5-c82f782c06cc


```ini
[dosbox]
machine = ega
memsize = 1

[cpu]
cycles = 3000

[imfc]
imfc = on
imfc_filter = on

[dos]
xms = false
ems = false
umb = false

[autoexec]
@mount c .
c:
copy iesource.cfg resource.cfg
mixer imfc c80
sierra
exit
```

**Waveform and spectrum comparison:**

Line-out is first, PR is second. Both roll off at 3.5 KHz and taper down to `-85 dB` just under 9 KHz.

![2023-10-23_11-37](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/4e4d1e85-a2df-4137-a6a0-d747f6dc3a08)

If you inspect the low frequency side, the IMFC recordings have more amplitude retained going down from 50 Hz and below, which makes sense because we have our 50 Hz high-pass filter in place to scrub off mostly inaudible ultra low frequencies.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

