### PR TITLE
Upgrade MkDocs & remove all warnings

### DIFF
--- a/contrib/documentation/mkdocs-package-requirements.txt
+++ b/contrib/documentation/mkdocs-package-requirements.txt
@@ -1,6 +1,6 @@
-mkdocs-material == 9.1.18
-mkdocs-minify-plugin == 0.6.4
-mkdocs-redirects == 1.2.0
+mkdocs-material == 9.4.6
+mkdocs-minify-plugin == 0.7.1
+mkdocs-redirects == 1.2.1
 mkdocs-glightbox == 0.3.4
-mdx-gh-links == 0.3
+mdx-gh-links == 0.3.1
 

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -204,7 +204,7 @@ dependencies installed via your package manager.
 Windows executables in snapshot packages are not signed, therefore Windows 10
 might prevent the program from starting.
 
-See [this guide](../windows/#microsoft-defender-smartscreen) to learn how to deal with this.
+See [this guide](windows.md#microsoft-defender-smartscreen) to learn how to deal with this.
 
 
 ### macOS
@@ -212,5 +212,5 @@ See [this guide](../windows/#microsoft-defender-smartscreen) to learn how to dea
 macOS app bundles are not notarized; Apple Gatekeeper will try to prevent
 the program from running.
 
-See [this guide](../macos/#apple-gatekeeper) to learn how to deal with
+See [this guide](macos.md#apple-gatekeeper) to learn how to deal with
 this.

--- a/website/docs/downloads/release-notes/0.75.0-rc1.md
+++ b/website/docs/downloads/release-notes/0.75.0-rc1.md
@@ -8,9 +8,9 @@
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/#old-builds) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/#old-builds)
-- [macOS](/downloads/macos/#old-builds)
+- [Linux](../linux.md#old-builds) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md#old-builds)
+- [macOS](../macos.md#old-builds)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.75.0.md
+++ b/website/docs/downloads/release-notes/0.75.0.md
@@ -16,9 +16,9 @@ late in the release cycle or after the release.
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.75.1.md
+++ b/website/docs/downloads/release-notes/0.75.1.md
@@ -15,9 +15,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 
@@ -27,7 +27,7 @@ dropped.
 
 
 Brave souls interested in the latest features can test our work-in-progress
-[0.76.x&nbsp;alpha builds](/downloads/development-builds/) :smile:. Please report any issues in
+[0.76.x&nbsp;alpha builds](../development-builds.md) :smile:. Please report any issues in
 our [bugtracker](https://github.com/dosbox-staging/dosbox-staging/issues).
 
 Also, check out our growing [Wiki](https://github.com/dosbox-staging/dosbox-staging/wiki).

--- a/website/docs/downloads/release-notes/0.75.2.md
+++ b/website/docs/downloads/release-notes/0.75.2.md
@@ -13,9 +13,9 @@ This is a maintenance release from the 0.75.x stable branch.
 
 Download and launch the latest version:
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.76.0.md
+++ b/website/docs/downloads/release-notes/0.76.0.md
@@ -8,9 +8,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 
@@ -507,7 +507,7 @@ When emulating monochrome displays (Hercules or CGA/monochrome), the default
 colour palette can now be selected in the configuration file.
 
 *This feature was backported to 0.75.2 release;
-[read more](../0.75.2/#select-monochrome-palette-colour).*
+[read more](0.75.2.md#select-monochrome-palette-colour).*
 
 
 ### Raw mouse input setting
@@ -516,7 +516,7 @@ User can now bypass the operating system's mouse acceleration and sensitivity
 settings. This works in fullscreen or when the mouse is captured in window mode.
 
 *This feature was backported to 0.75.2 release;
-[read more](../0.75.2/#raw-mouse-input).*
+[read more](0.75.2.md#raw-mouse-input).*
 
 
 ### 10-axis controller support
@@ -525,7 +525,7 @@ Old joysticks compatible with DOS games can be emulated using modern 10-axis
 controllers (like DualShock or Xbox controllers).
 
 *This feature was backported to 0.75.1 release;
-[read more](../0.75.1/#add-support-for-binding-more-controller-axes).*
+[read more](0.75.1.md#add-support-for-binding-more-controller-axes).*
 
 
 ### Log memory base address
@@ -534,7 +534,7 @@ The base memory address of DOS's emulated memory region is now logged to the
 console to help some users of external software, such as **Cheat Engine**.
 
 *This feature was backported to 0.75.1 release;
-[read more](../0.75.1/#log-base-address-of-emulated-memory).*
+[read more](0.75.1.md#log-base-address-of-emulated-memory).*
 
 
 ## Bugfixes

--- a/website/docs/downloads/release-notes/0.77.0.md
+++ b/website/docs/downloads/release-notes/0.77.0.md
@@ -8,9 +8,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.77.1.md
+++ b/website/docs/downloads/release-notes/0.77.1.md
@@ -8,9 +8,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.78.0.md
+++ b/website/docs/downloads/release-notes/0.78.0.md
@@ -9,9 +9,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.78.1.md
+++ b/website/docs/downloads/release-notes/0.78.1.md
@@ -8,9 +8,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.79.0.md
+++ b/website/docs/downloads/release-notes/0.79.0.md
@@ -8,9 +8,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.79.1.md
+++ b/website/docs/downloads/release-notes/0.79.1.md
@@ -20,9 +20,9 @@ Download and launch the latest version:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/) (or [Steam on Linux](/downloads/linux#steam))
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.80.0.md
+++ b/website/docs/downloads/release-notes/0.80.0.md
@@ -31,9 +31,9 @@ file:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/)
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md)
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/downloads/release-notes/0.80.1.md
+++ b/website/docs/downloads/release-notes/0.80.1.md
@@ -24,9 +24,9 @@ file:
 
 <div class="compact" markdown>
 
-- [Linux](/downloads/linux/)
-- [Windows](/downloads/windows/)
-- [macOS](/downloads/macos/)
+- [Linux](../linux.md) (or [Steam on Linux](../linux.md#steam))
+- [Windows](../windows.md)
+- [macOS](../macos.md)
 
 </div>
 

--- a/website/docs/getting-started/beneath-a-steel-sky.md
+++ b/website/docs/getting-started/beneath-a-steel-sky.md
@@ -319,7 +319,7 @@ make the total audio output too quiet. Worse yet, the setting doesn't get
 saved, so you'd need to do this every single time when starting up the game.
 
 As we've [learned
-before](../passport-to-adventure/#sound-blaster-adlib-sound), games with Sound
+before](passport-to-adventure.md/#sound-blaster-adlib-sound), games with Sound
 Blaster support tend to use the sound card's OPL synthesiser for the music and
 its digital audio capabilities for the speech. As the OPL synth and the
 digital audio have their dedicated mixer channels, their volumes can be
@@ -798,7 +798,7 @@ appear vertically stretched on-screen. In fact, they appear exactly 20% taller
 than they should, which means the artwork was scanned using square pixels,
 then the stretching happens because of the 1:1.2 pixel aspect ratio of the
 320&times;200 VGA screen mode (you might want to revisit the
-[detailed explanation](../enhancing-prince-of-persia/#custom-viewport-resolution) to
+[detailed explanation](enhancing-prince-of-persia.md#custom-viewport-resolution) to
 refresh your memory).
 
 <figure markdown>

--- a/website/docs/getting-started/dark-forces.md
+++ b/website/docs/getting-started/dark-forces.md
@@ -223,7 +223,7 @@ be fast enough to reach the 70 FPS maximum the game supports.
 
 The game prints out the familiar message of the DOS/4GW DOS extender at
 startup, which means this is a
-[protected mode game](../beneath-a-steel-sky/#real-and-protected-mode):
+[protected mode game](beneath-a-steel-sky.md#real-and-protected-mode):
 
 ``` { . .dos-prompt }
 DOS/4GW Protected Mode Run-Time  Version 1.95
@@ -256,7 +256,7 @@ you're using a VRR monitor or a fixed 70 Hz refresh rate, it will never become
 completely smooth). Somewhere around 50&thinsp;000 cycles seems to do the
 trick, which roughly corresponds to a Pentium 90 based on our [table of
 common
-processors](../beneath-a-steel-sky/#finding-the-correct-speed-for-a-game).
+processors](beneath-a-steel-sky.md#finding-the-correct-speed-for-a-game).
 
 So we'll go with that setting. You might need to increase this if later levels
 are more demanding on the CPU, but this is a good starting point:

--- a/website/docs/getting-started/introduction.md
+++ b/website/docs/getting-started/introduction.md
@@ -43,25 +43,25 @@ your machine first, then proceed with the DOSBox Staging installation steps.
 <h3>Windows</h3>
 
 Download the latest installer from our [Windows
-downloads](../../downloads/windows) page, then proceed with the installation.
+downloads](../downloads/windows.md) page, then proceed with the installation.
 Just accept the default options, don't change anything.
 
-Make sure to read the section about dealing with [Microsoft Defender SmartScreen](../../downloads/windows/#microsoft-defender-smartscreen).
+Make sure to read the section about dealing with [Microsoft Defender SmartScreen](../downloads/windows.md#microsoft-defender-smartscreen).
 
 <h3>macOS</h3>
 
 Download the latest universal binary from our [macOS
-downloads](../../downloads/macos/) page, then simply drag the DOSBox Staging
+downloads](../downloads/macos.md) page, then simply drag the DOSBox Staging
 icon into your Applications folder. Both Intel and M1 Macs are supported.
 
 Don't delete the `.dmg` installer disk image just yet---we'll need it later.
 
-Make sure to read the section about dealing with [Apple Gatekeeper](../../downloads/macos/#apple-gatekeeper).
+Make sure to read the section about dealing with [Apple Gatekeeper](../downloads/macos.md#apple-gatekeeper).
 
 
 <h3>Linux</h3>
 
-Please check out our [Linux downloads](../../downloads/linux/) page and use
+Please check out our [Linux downloads](../downloads/linux.md) page and use
 the option that best suits your situation and needs.
 
 

--- a/website/docs/getting-started/passport-to-adventure.md
+++ b/website/docs/getting-started/passport-to-adventure.md
@@ -459,7 +459,7 @@ Later VGA cards and monitors "dropped" this filter and were just displaying
 the "raw pixels" without any such effects.
 This perceptual difference is because of the line-doubling peculiarity of VGA
 adapters in all low-resolution screen modes, as [explained
-previously](../enhancing-prince-of-persia/#true-vga-emulation).
+previously](enhancing-prince-of-persia.md#true-vga-emulation).
 
 VGA-style line-doubling changes the feel of EGA graphics, and many prefer the
 original EGA look. After all, this is what the artists saw on their screens
@@ -468,7 +468,7 @@ example, you can easily emulate the "true EGA" look with shaders if that's
 your preference.
 
 It's also worth restricting the image size to mimic that of a period-correct
-14" or 15" monitor (see the detailed explanation [here](../enhancing-prince-of-persia/#custom-viewport-resolution)).
+14" or 15" monitor (see the detailed explanation [here](enhancing-prince-of-persia.md#custom-viewport-resolution)).
 
 ```ini
 [render]
@@ -602,7 +602,7 @@ C:\>
 ```
 
 We will discuss the CPU speed settings in more detail
-[in the next chapter](../beneath-a-steel-sky/#adjusting-the-emulated-cpu-speed),
+[in the next chapter](beneath-a-steel-sky.md#adjusting-the-emulated-cpu-speed),
 but it was worth mentioning this interesting quirk here.
 
 

--- a/website/docs/getting-started/prince-of-persia.md
+++ b/website/docs/getting-started/prince-of-persia.md
@@ -109,7 +109,7 @@ accomplished slightly differently on each platform:
 
     After installing DOSBox Staging, it's highly recommended to open it once
     using the Start Menu shortcut of the desktop icon [as described
-    here](../../downloads/windows/#microsoft-defender-smartscreen), otherwise
+    here](../downloads/windows.md#microsoft-defender-smartscreen), otherwise
     the below instructions might not work.
 
 If you have used the installer with the default options to set up DOSBox
@@ -126,7 +126,7 @@ area inside it, then select *Open with DOSBox Staging* in the context menu.
 
     After installing DOSBox Staging, you *must* open it first using its
     application icon [as described
-    here](../../downloads/macos/#apple-gatekeeper), otherwise the below
+    here](../downloads/macos.md#apple-gatekeeper), otherwise the below
     instructions won't work.
 
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -42,8 +42,8 @@ markdown_extensions:
       user: dosbox-staging
       repo: dosbox-staging
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji 
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.keys
@@ -106,3 +106,6 @@ nav:
 
   - Wiki: https://github.com/dosbox-staging/dosbox-staging/wiki
 
+not_in_nav: |
+  # To silence the warning about the custom `index.md` front page
+  /index.md


### PR DESCRIPTION
# Description

Some non-controversial doco changes:

- Upgrade MkDocs deps to latest
- Get rid of all MkDocs warnings (they made the validation strict by default)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

