### PR TITLE
Harmonize ManyMouse support message in the build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -815,7 +815,7 @@ endif
 
 # Determine if system is capable of using ManyMouse library
 conf_data.set10('C_MANYMOUSE', true)
-manymouse_summary_msg = 'Enabled'
+manymouse_summary_msg = 'True'
 
 # ManyMouse optionally supports the X Input 2.0 protocol (regardless of OS)
 xinput2_dep = optional_dep


### PR DESCRIPTION
# Description

I don't really like that ManyMouse support message during build time is different than others (_Enabled_ vs _True_). I would like to harmonize this.

![screenshot](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/21f484c3-24ba-423d-b946-2d74bb53340f)


# Manual testing

N/A


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

