### PR TITLE
Add a fade-to-sleep-after-last-port-write feature to the mixer

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -796,6 +796,19 @@ void DOSBOX_Init()
 	                  "On 'auto' the mode is determined by 'sbtype'.\n"
 	                  "All OPL modes are AdLib-compatible, except for 'cms'.");
 
+	pstring = secprop->Add_string("opl_fadeout", when_idle, "off");
+	pstring->Set_help(
+	        "Fade out the OPL synth output after the last IO port write:\n"
+	        "  off:       Don't fade out; residual output will play forever (default).\n"
+	        "  on:        Wait 0.5s before fading out over a 0.5s period.\n"
+	        "  <custom>:  A custom fade-out definition in the following format:\n"
+	        "               WAIT FADE\n"
+	        "             Where WAIT is how long after the last IO port write fading begins,\n"
+	        "             ranging between 100 and 5000 milliseconds; and FADE is the fade-out\n"
+	        "             period, ranging between 10 and 3000 milliseconds. Examples:\n"
+	        "                300 200 (Wait 300ms before fading out over a 200ms period)\n"
+	        "                1000 3000 (Wait 1s before fading out over a 3s period)");
+
 	pstring = secprop->Add_string("oplemu", deprecated, "");
 	pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -905,6 +905,13 @@ void DOSBOX_Init()
 	        "         without DAC to avoid conflicts with other cards using DMA 1.\n"
 	        "  off:   Disable Tandy/PCjr sound.");
 
+	pstring = secprop->Add_string("tandy_fadeout", when_idle, "off");
+	pstring->Set_help(
+	        "Fade out the Tandy synth output after the last IO port write:\n"
+	        "  off:       Don't fade out; residual output will play forever (default).\n"
+	        "  on:        Wait 0.5s before fading out over a 0.5s period.\n"
+	        "  <custom>:  Custom fade out definition; see 'opl_fadeout' for details.");
+
 	pstring = secprop->Add_string("tandy_filter", when_idle, "on");
 	pstring->Set_help(
 	        "Filter for the Tandy synth output:\n"

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -531,6 +531,7 @@ void OPL::RenderUpToNow()
 	const auto now = PIC_FullIndex();
 
 	// Wake up the channel and update the last rendered time datum.
+	assert(channel);
 	if (channel->WakeUp()) {
 		last_rendered_ms = now;
 		return;
@@ -888,6 +889,7 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 	ctrl.mixer = section->Get_bool("sbmixer");
 
 	std::set channel_features = {ChannelFeature::Sleep,
+	                             ChannelFeature::FadeOut,
 	                             ChannelFeature::ReverbSend,
 	                             ChannelFeature::ChorusSend,
 	                             ChannelFeature::Synthesizer};
@@ -917,6 +919,9 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 	// existence.
 	constexpr auto opl_volume_scale_factor = 1.5f;
 	channel->Set0dbScalar(opl_volume_scale_factor);
+
+	// Setup fadeout
+	channel->ConfigureFadeOut(section->Get_string("opl_fadeout"));
 
 	Init(check_cast<uint16_t>(channel->GetSampleRate()));
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -168,6 +168,7 @@ private:
 class TandyPSG {
 public:
 	TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled,
+	         const std::string_view fadeout_choice,
 	         const std::string_view filter_choice);
 	~TandyPSG();
 
@@ -450,6 +451,7 @@ void TandyDAC::AudioCallback(uint16_t requested)
 }
 
 TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled,
+                   const std::string_view fadeout_choice,
                    const std::string_view filter_choice)
 {
 	assert(config_profile != ConfigProfile::SoundCardRemoved);
@@ -479,9 +481,13 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 	                           use_mixer_rate,
 	                           ChannelName::TandyPsg,
 	                           {ChannelFeature::Sleep,
+	                            ChannelFeature::FadeOut,
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::ChorusSend,
 	                            ChannelFeature::Synthesizer});
+
+	// Setup fadeout
+	channel->ConfigureFadeOut(fadeout_choice);
 
 	// Setup filters
 	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
@@ -678,6 +684,7 @@ void TANDYSOUND_Init(Section *section)
 	}
 	tandy_psg = std::make_unique<TandyPSG>(cfg,
 	                                       wants_dac,
+	                                       prop->Get_string("tandy_fadeout"),
 	                                       prop->Get_string("tandy_filter"));
 
 	set_tandy_sound_flag_in_bios(true);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -91,6 +91,7 @@ unit_tests = [
     {'name': 'int10_modes', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'iohandler_containers', 'deps': [libmisc_stubs_dep]},
     {'name': 'math_utils', 'deps': [libmisc_stubs_dep]},
+    {'name': 'mixer', 'deps': [dosbox_dep, libiir_dep], 'extra_cpp': []},
     {'name': 'rgb', 'deps': []},
     {'name': 'rwqueue', 'deps': [libmisc_stubs_dep]},
     {'name': 'semaphore', 'deps': [libmisc_stubs_dep]},

--- a/tests/mixer_tests.cpp
+++ b/tests/mixer_tests.cpp
@@ -1,0 +1,84 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "mixer.h"
+
+#include <gtest/gtest.h>
+
+static void callback(const uint16_t) {}
+
+constexpr auto ChannelName = "TEST";
+
+namespace {
+
+TEST(MixerConfigureFadeOut, Boolean)
+{
+	MixerChannel channel(callback, ChannelName, {ChannelFeature::Sleep});
+
+	ASSERT_TRUE(channel.ConfigureFadeOut("on"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("off"));
+}
+
+TEST(MixerConfigureFadeOut, ShortWait)
+{
+	MixerChannel channel(callback, ChannelName, {ChannelFeature::Sleep});
+
+	ASSERT_TRUE(channel.ConfigureFadeOut("100 10"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("100 1500"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("100 3000"));
+}
+
+TEST(MixerConfigureFadeOut, MediumWait)
+{
+	MixerChannel channel(callback, ChannelName, {ChannelFeature::Sleep});
+
+	ASSERT_TRUE(channel.ConfigureFadeOut("2500 10"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("2500 1500"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("2500 3000"));
+}
+
+TEST(MixerConfigureFadeOut, LongWait)
+{
+	MixerChannel channel(callback, ChannelName, {ChannelFeature::Sleep});
+
+	ASSERT_TRUE(channel.ConfigureFadeOut("5000 10"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("5000 1500"));
+	ASSERT_TRUE(channel.ConfigureFadeOut("5000 3000"));
+}
+
+TEST(MixerConfigureFadeOut, JunkStrings)
+{
+	MixerChannel channel(callback, ChannelName, {ChannelFeature::Sleep});
+	// Junk/invalid
+	ASSERT_FALSE(channel.ConfigureFadeOut(""));
+	ASSERT_FALSE(channel.ConfigureFadeOut("junk"));
+	ASSERT_FALSE(channel.ConfigureFadeOut("a b c"));
+}
+
+TEST(MixerConfigureFadeOut, OutOfBounds)
+{
+	MixerChannel channel(callback, ChannelName, {ChannelFeature::Sleep});
+	// Out of bounds
+	ASSERT_FALSE(channel.ConfigureFadeOut("99 9"));
+	ASSERT_FALSE(channel.ConfigureFadeOut("-1 -10000"));
+	ASSERT_FALSE(channel.ConfigureFadeOut("3001 10000"));
+}
+
+} // namespace


### PR DESCRIPTION
# Description

Adds a linear fade-to-sleep after the last port-write feature to the mixer's existing sleeper class:

![2023-11-05_17-11](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/30ab1c79-2928-4e6f-a07e-f2b724ae1057)

1. This feature is **disabled by default**. It needs to be opted-in via device-specific conf setting (`tandy_fadeout = ...` or `opl_fadeout = ...`). 

1. This is a quality of life feature for users who want protection against "phone off the hook" behavior that some games exhibit _when using tone-generating audio devices_.

1. This is not an emulation improvement or bug fix. This feature is desirable regardless if the game is buggy or coded correctly. Who knows.. maybe the developers intended to blast the user with a 10-second fixed-waveform  during the intermission!.. OK: but I don't want to hear it :-)

1. It will only be made available for **fixed-waveform generating devices** because these devices will continue to play the last-requested waveform indefinitely until requested otherwise.

1. The `WAIT`-before-fade period and the `FADE` down period are both configurable. Conservative defaults will be used, so users who turn it on don't have to worry about "cutting the music short", so to speak.

    For example, here are two inn visit sequences in Bard's Tale (Staging and 86Box):

    https://github.com/dosbox-staging/dosbox-staging/assets/1557255/5e1796b3-c7d9-4c57-81f3-6a1a9bb362b8

    https://github.com/dosbox-staging/dosbox-staging/assets/1557255/c46e65c1-1416-4367-95ba-177b140d15b2

## Related issues

None.

# Manual testing

Tested many OPL and Tandy games to checks for regressions, both with it enabled and disabled.

Tested Bard's Tale Construction Set and California games II. Confirmed their output is correctly faded down to silence after the configured WAIT and FADE durations, after their last IO port write.

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/741cd2ba-ae14-4c9a-80ad-c51ab5310827

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/c5ca9425-b5ad-47d5-a016-4b371cdfb6bc

Tested values ranges:
- `WAIT` values: too high, too low, garbage text, and missing
- `FADE` values: too high, too low, garbage text, and missing

- `WAIT` min, while `FADE` min
- `WAIT` min, while `FADE` mid
- `WAIT` min, while `FADE` max

- `WAIT` mid, while `FADE` min
- `WAIT` mid, while `FADE` mid
- `WAIT` mid, while `FADE` max

- `WAIT` max, while `FADE` min
- `WAIT` max, while `FADE` mid
- `WAIT` max, while `FADE` max

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

