### PR TITLE
Fix or simplify some descriptions

### DIFF
--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -1176,7 +1176,7 @@ Er is geen eigenschap "%s" in sectie "%s".
 
 .
 :PROGRAM_CONFIG_SET_SYNTAX
-Correcte syntaxis: [color=light-green]config [/reset]-set [color=light-cyan][SECTIE][/reset] [color=white]EIGENSCHAP[/reset][=][color=white]WAARDE[/reset]
+Correcte syntaxis: [color=light-green]config [reset]-set [color=light-cyan][SECTIE][reset] [color=white]EIGENSCHAP[reset][=][color=white]WAARDE[reset]
 
 .
 :PROGRAM_CONFIG_NOCONFIGFILE

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -1152,7 +1152,7 @@ Brak parametru '%s' w sekcji [%s]
 
 .
 :PROGRAM_CONFIG_SET_SYNTAX
-Składnia: [color=light-green]config [/reset]-set [color=light-cyan][SECTION][/reset] [color=white]PARAMETR[/reset][=][color=white]WARTOŚĆ[/reset]
+Składnia: [color=light-green]config [reset]-set [color=light-cyan][SECTION][reset] [color=white]PARAMETR[reset][=][color=white]WARTOŚĆ[reset]
 
 .
 :PROGRAM_CONFIG_NOCONFIGFILE

--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -1,5 +1,5 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
-.TH DOSBOX 1 "Oct 26, 2023"
+.TH DOSBOX 1 "Oct 27, 2023"
 .\" Please adjust this date whenever revising the manpage.
 
 .SH NAME
@@ -67,35 +67,34 @@ DOSBox Staging quits.
 
 Legacy single dash abbrevations still work for backwards compatibility.
 .LP
---conf <configfile>      Start with the options specified in <configfile>.
-                         Multiple configfiles can be specified.
+--conf <config_file>     Start with the options specified in <config_file>.
+                         Multiple configuration files can be specified.
                          Example: --conf conf1.conf --conf conf2.conf
 
---printconf              Print the location of the default configuration file.
-                         If it does not exist, create it.
+--printconf              Print the location of the primary configuration file.
 
---editconf               Open the default configuration file in a text editor.
+--editconf               Open the primary configuration file in a text editor.
 
---eraseconf              Delete the default configuration file.
+--eraseconf              Delete the primary configuration file.
 
---noprimaryconf          Don't read settings from the default configuration file
-                         located in your user folder.
+--noprimaryconf          Don't load or create the primary configuration file.
 
---nolocalconf            Don't read settings from "dosbox.conf" if present in
-                         the current working directory.
+--nolocalconf            Don't load the local 'dosbox.conf' configuration file
+                         if present in the current working directory.
 
---set <property>=<value> Set a configuration property.
-                         Example: --set mididevice=fluidsynth --set soundfont=mysoundfont.sf2
+--set <setting>=<value>  Set a configuration setting. Multiple configuration
+                         settings can be specified. Example:
+                         --set mididevice=fluidsynth --set soundfont=mysoundfont.sf2
 
 --working-dir <path>     Set working directory to <path>. DOSBox will act as if
                          started from this directory.
 
---list-glshaders         List available GLSL shaders and their directories.
-                         Results are useable in the "glshader = " config setting.
+--list-glshaders         List all available OpenGL shaders and their paths.
+                         Results are useable in the 'glshader = ' config setting.
 
 --fullscreen             Start in fullscreen mode.
 
---lang <langfile>        Start with the language specified in <langfile>.
+--lang <lang_file>       Start with the language specified in <lang_file>.
 
 --machine <type>         Emulate a specific type of machine. The machine type has
                          influence on both the emulated video and sound cards.
@@ -103,10 +102,10 @@ Legacy single dash abbrevations still work for backwards compatibility.
                          pcjr, ega, svga_s3 (default), svga_et3000, svga_et4000,
                          svga_paradise, vesa_nolfb, vesa_oldvbe.
 
--c <command>             Run the specified DOS command before running FILE.
+-c <command>             Run the specified DOS command before handling the PATH.
                          Multiple commands can be specified.
 
---noautoexec             Don't run any [autoexec] actions.
+--noautoexec             Don't run DOS commands from any [autoexec] sections.
 
 --exit                   Exit after running '-c <command>'s and [autoexec] sections.
 
@@ -114,7 +113,8 @@ Legacy single dash abbrevations still work for backwards compatibility.
 
 --erasemapper            Delete the default mapper file.
 
---securemode             Enable secure mode by disabling the MOUNT and IMGMOUNT commands.
+--securemode             Enable secure mode by disabling the MOUNT and IMGMOUNT
+                         commands.
 
 --socket <num>           Run nullmodem on the specified socket number.
 

--- a/include/midi.h
+++ b/include/midi.h
@@ -142,7 +142,7 @@ constexpr uint8_t SystemReset   = 0xff;
 constexpr uint8_t SystemExclusive = 0xf0;
 } // namespace MidiStatus
 
-// Channel Mode Messages are Control Change Messages that use the the reserved
+// Channel Mode Messages are Control Change Messages that use the reserved
 // 120-127 controller number range to set the Channel Mode.
 namespace MidiChannelMode {
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4165,7 +4165,7 @@ static void messages_add_sdl()
 	        "                           pcjr, ega, svga_s3 (default), svga_et3000, svga_et4000,\n"
 	        "                           svga_paradise, vesa_nolfb, vesa_oldvbe.\n"
 	        "\n"
-	        "  -c <command>             Run the specified DOS command before running FILE.\n"
+	        "  -c <command>             Run the specified DOS command before handling the PATH.\n"
 	        "                           Multiple commands can be specified.\n"
 	        "\n"
 	        "  --noautoexec             Don't run DOS commands from any [autoexec] sections.\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4183,7 +4183,7 @@ static void messages_add_sdl()
 	        "\n"
 	        "  -h, -?, --help           Print help message and exit.\n"
 	        "\n"
-	        "  -v, --version            Print version information and exit.\n");
+	        "  -V, --version            Print version information and exit.\n");
 
 	MSG_Add("PROGRAM_CONFIG_PROPERTY_ERROR", "No such section or property: %s\n");
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4191,8 +4191,8 @@ static void messages_add_sdl()
 	        "There is no property '%s' in section [%s]\n");
 
 	MSG_Add("PROGRAM_CONFIG_SET_SYNTAX",
-	        "Usage: [color=light-green]config [/reset]-set [color=light-cyan][SECTION][/reset] "
-	        "[color=white]PROPERTY[/reset][=][color=white]VALUE[/reset]\n");
+	        "Usage: [color=light-green]config [reset]-set [color=light-cyan][SECTION][reset] "
+	        "[color=white]PROPERTY[reset][=][color=white]VALUE[reset]\n");
 
 	MSG_Add("TITLEBAR_CYCLES_MS",    "cycles/ms");
 	MSG_Add("TITLEBAR_HINT_PAUSED",  "(PAUSED)");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4140,7 +4140,7 @@ static void messages_add_sdl()
 	        "\n"
 	        "  --eraseconf              Delete the primary configuration file.\n"
 	        "\n"
-	        "  --noprimaryconf          Don't load or create the the primary configuration file.\n"
+	        "  --noprimaryconf          Don't load or create the primary configuration file.\n"
 	        "\n"
 	        "  --nolocalconf            Don't load the local 'dosbox.conf' configuration file\n"
 	        "                           if present in the current working directory.\n"

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -839,7 +839,7 @@ uint32_t Gus::GetDmaOffset() noexcept
 	return check_cast<uint32_t>(adjusted << 4) + dma_addr_nibble;
 }
 
-// Update the current 16-bit DMA position from the the given 20-bit RAM offset
+// Update the current 16-bit DMA position from the given 20-bit RAM offset
 void Gus::UpdateDmaAddr(uint32_t offset) noexcept
 {
 	uint32_t adjusted;

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -268,7 +268,7 @@ static void write_p201(io_port_t, io_val_t, io_width_t)
 }
 static void write_p201_timed(io_port_t, io_val_t, io_width_t)
 {
-	// Convert the the joystick's instantaneous position to activation duration in ticks
+	// Convert the joystick's instantaneous position to activation duration in ticks
 
 	/*
 	// Original calculation

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -654,7 +654,7 @@ public:
 		// Size the actual memory pages
 		memory.pages.resize(num_pages);
 
-		// The MemBase is address of the the first page's first byte
+		// The MemBase is address of the first page's first byte
 		MemBase = &(memory.pages[0].bytes[0]);
 
 		LOG_MSG("MEMORY: Using %d DOS memory pages (%u MB) at address: %p",

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2246,7 +2246,7 @@ static void mix_samples(const int frames_requested)
 		                     reinterpret_cast<int16_t*>(out));
 	}
 
-	// Reset the the tick_add for constant speed
+	// Reset the tick_add for constant speed
 	if (is_mixer_irq_important()) {
 		mixer.tick_add = calc_tickadd(mixer.sample_rate);
 	}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2857,10 +2857,7 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "  light:   Light crossfeed (strength 15).\n"
 	        "  normal:  Normal crossfeed (strength 40).\n"
 	        "  strong:  Strong crossfeed (strength 65).\n"
-	        "Notes:\n"
-			"  - The crossfeed strength of subsequently activated mixer channels will be\n"
-			"    set to the preset defaults.\n"
-			"  - You can fine-tune per-channel crossfeed strengths via mixer commands.");
+	        "Note: You can fine-tune each channel's crossfeed strength using the MIXER.");
 	string_prop->Set_values(crossfeed_presets);
 
 	const char* reverb_presets[] = {
@@ -2880,10 +2877,7 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "           channels for music and digital audio.\n"
 	        "  huge:    A stronger variant of the large hall preset; works really well\n"
 	        "           in some games with more atmospheric soundtracks.\n"
-	        "Notes:\n"
-			"  - Reverb levels of subsequently activated mixer channels will be set to the\n"
-			"    preset defaults.\n"
-			"  - You can fine-tune per-channel reverb levels via mixer commands.");
+	        "Note: You can fine-tune each channel's reverb level using the MIXER.");
 	string_prop->Set_values(reverb_presets);
 
 	const char* chorus_presets[] = {"off", "on", "light", "normal", "strong", nullptr};
@@ -2896,10 +2890,7 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "           features lots of white noise.)\n"
 	        "  normal:  Normal chorus that works well with a wide variety of games.\n"
 	        "  strong:  An obvious and upfront chorus effect.\n"
-	        "Notes:\n"
-			"  - Chorus levels of subsequently activated mixer channels will be set to the\n"
-			"    preset defaults.\n"
-			"  - You can fine-tune per-channel chorus levels via mixer commands.");
+	        "Note: You can fine-tune each channel's chorus level using the MIXER.");
 	string_prop->Set_values(chorus_presets);
 
 	MAPPER_AddHandler(handle_toggle_mute, SDL_SCANCODE_F8, PRIMARY_MOD, "mute", "Mute");

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -162,7 +162,7 @@ public:
 			// if ( passed > 0 ) LOG_MSG( "Delay %d", passed ) ;
 
 			// If we passed more than 30 seconds since the last
-			// command, we'll restart the the capture
+			// command, we'll restart the capture
 			if (passed > 30000) {
 				CloseFile();
 				goto skipWrite;

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -739,7 +739,7 @@ void INT10_Init(Section* /*sec*/) {
 	call_10=CALLBACK_Allocate();	
 	CALLBACK_Setup(call_10,&INT10_Handler,CB_IRET,"Int 10 video");
 	RealSetVec(0x10,CALLBACK_RealPointer(call_10));
-	//Init the 0x40 segment and init the datastructures in the the video rom area
+	//Init the 0x40 segment and init the datastructures in the video rom area
 	INT10_SetupRomMemory();
 	INT10_Seg40Init();
 	INT10_SetVideoMode(0x3);

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -113,7 +113,7 @@
 // https://github.com/dosbox-staging/dosbox-staging/issues/1314)
 //
 // Because the recommendations in these warnings will not be acted
-// upon given the planned direction of the the project, they
+// upon given the planned direction of the project, they
 // therefore provide no value and are being silenced.
 
 #ifndef _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
# Description


Fixes or simplifies some descriptions.

## Related issues

Fixes #3061 

# Manual testing

Tested:
 - printing the updated CLI `--help` hows updated text
 - printing man page shows updated text
 - writing a new conf files has updated text
 - passing `-V` prints the version
 - printing `config /help` handles the `[reset]` tag:

    ![2023-10-27_11-03](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/14e8c96a-e591-4293-a391-b2c403bd9568)



# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

