### PR TITLE
Handle host code pages when running `dosbox.exe --help` on Windows

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 162
+          MAX_BUGS: 161
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/contrib/resources/mapping/MAIN.TXT
+++ b/contrib/resources/mapping/MAIN.TXT
@@ -1,4 +1,10 @@
 #
+# Note: when adding new code pages, avoid conflicts with currently supported
+# Microsoft code pages, the list can be found here:
+# - https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+# Otherwise please adapt 'utf8_to_host_console' function accordingly.
+#
+#
 # Fully supported code pages (92 code pages):
 #
 # 113   - Yugoslavian, Latin

--- a/contrib/resources/mapping/MAIN.TXT
+++ b/contrib/resources/mapping/MAIN.TXT
@@ -2,7 +2,6 @@
 # Note: when adding new code pages, avoid conflicts with currently supported
 # Microsoft code pages, the list can be found here:
 # - https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
-# Otherwise please adapt 'utf8_to_host_console' function accordingly.
 #
 #
 # Fully supported code pages (92 code pages):

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -323,10 +323,6 @@ void dos_to_utf8(const std::string& in_str, std::string& out_str);
 void dos_to_utf8(const std::string& in_str, std::string& out_str,
                  const uint16_t code_page);
 
-// As above, but converts to encoding used by (or at least compatible to) host
-// OS command line console.
-bool utf8_to_host_console(const std::string& in_str, std::string& out_str);
-
 // Convert DOS code page string to lower/upper case; converters are aware of all
 // the national characters. Functions without 'code_page' parameter use current
 // DOS code page.

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -323,6 +323,10 @@ void dos_to_utf8(const std::string& in_str, std::string& out_str);
 void dos_to_utf8(const std::string& in_str, std::string& out_str,
                  const uint16_t code_page);
 
+// As above, but converts to encoding used by (or at least compatible to) host
+// OS command line console.
+bool utf8_to_host_console(const std::string& in_str, std::string& out_str);
+
 // Convert DOS code page string to lower/upper case; converters are aware of all
 // the national characters. Functions without 'code_page' parameter use current
 // DOS code page.

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -40,6 +40,7 @@
 #ifdef WIN32
 #include <process.h>
 #include <signal.h>
+#include <windows.h>
 #endif
 
 #include <SDL.h>
@@ -4680,9 +4681,18 @@ int sdl_main(int argc, char* argv[])
 			const auto program_name = argv[0];
 			const auto help_utf8 = format_string(MSG_GetRaw("DOSBOX_HELP"),
 			                                     program_name);
-			std::string help_str = {};
-			utf8_to_host_console(help_utf8, help_str);
-			printf(help_str.c_str());
+#ifdef WIN32
+			const auto old_code_page = GetConsoleOutputCP();
+
+			constexpr uint16_t CodePageUtf8 = 65001;
+			SetConsoleOutputCP(CodePageUtf8);
+			printf(help_utf8.c_str());
+			SetConsoleOutputCP(old_code_page);
+#else
+			// Assume any OS without special support uses UTF-8 as
+			// console encoding
+			printf(help_utf8.c_str());
+#endif
 			return 0;
 		}
 		if (arguments->editconf) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4678,7 +4678,11 @@ int sdl_main(int argc, char* argv[])
 		if (arguments->help) {
 			assert(argv && argv[0]);
 			const auto program_name = argv[0];
-			printf(MSG_GetRaw("DOSBOX_HELP"), program_name);
+			const auto help_utf8 = format_string(MSG_GetRaw("DOSBOX_HELP"),
+			                                     program_name);
+			std::string help_str = {};
+			utf8_to_host_console(help_utf8, help_str);
+			printf(help_str.c_str());
 			return 0;
 		}
 		if (arguments->editconf) {

--- a/src/misc/unicode.cpp
+++ b/src/misc/unicode.cpp
@@ -31,10 +31,6 @@
 #include "dos_inc.h"
 #include "string_utils.h"
 
-#if defined(WIN32)
-#include "windows.h"
-#endif
-
 CHECK_NARROWING();
 
 // ***************************************************************************
@@ -2054,30 +2050,6 @@ void dos_to_utf8(const std::string& in_str, std::string& out_str,
                  const uint16_t code_page)
 {
 	dos_to_utf8_common(in_str, out_str, get_custom_code_page(code_page));
-}
-
-bool utf8_to_host_console(const std::string& in_str, std::string& out_str)
-{
-#if defined(WIN32)
-	// Reference:
-	// - https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
-	constexpr uint16_t CodePageUtf8 = 65001;
-
-	const auto console_code_page = static_cast<uint16_t>(GetConsoleOutputCP());
-	if (console_code_page == CodePageUtf8) {
-		out_str = in_str;
-		return true;
-	}
-
-	// TODO: Once UTF-16 (or any other Unicode encoding) is supported,
-	// add special handling here
-
-	return utf8_to_dos(in_str, out_str, UnicodeFallback::Simple, console_code_page);
-#else
-	// Assume any OS without special support uses UTF-8 as console encoding
-	out_str = in_str;
-	return true;
-#endif
 }
 
 static void lowercase_dos_common(std::string& in_str, const uint16_t code_page)


### PR DESCRIPTION
# Description

This is my follow-up of the PR https://github.com/dosbox-staging/dosbox-staging/pull/3052

1. On Windows the 'dosbox.exe --help' command will ask the host OS about the console code page and (if it's not UTF-8) will try to render the help text as nicely as possible using internal Unicode engine.
**[edit]** Changed implementation to temporarily switch the console to UTF-8.

3. Default (fallback) code page is no longer 437, instead we are using a 7-bit ASCII. Code page 437 was a sane choice when not many code pages were supported; with current selection it is better to assume that unknown codepage is something completely exotic.

4. I have no idea who fixed one PVS Studio warning, but I have decremented the allowance.

Some screenshots - default console settings, before my changes:

![Screenshot-Before-Changes](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/fa098342-5d6f-4b15-bed6-7dbf3dfe0363)

Same settings, after my changes:

![Screenshot-After-Changes](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/bbf65d30-3f9d-4ab1-a604-25b9a33cebcd)

And here is how the text is rendered when console is UTF-8:

![Screenshot-UTF-8](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/1a1b3541-c954-4372-9ff9-8ce283c337e5)



## Related issues

Improves https://github.com/dosbox-staging/dosbox-staging/issues/3051


# Manual testing

Test file: [fc.lng.gz](https://github.com/dosbox-staging/dosbox-staging/files/13192332/fc.lng.gz)

0. Use the Microsoft Windows build

1. Set DOSBox to use dummy language provided above (decompress the file, put it into resources/translations) by setting

```ini
[dosbox]
language = fc
```

3. From the Windows console (`cmd.exe`) execute `dosbox --help` and enjoy the selection of multi-language song lyrics :D 

4. Repeat previous with different code pages set in the console - you can switch between them using `chcp <codepage>` command, where `<codepage>` is one from https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers

Notes:
- not all the code pages are supported - unsupported ones will cause DOSBox to drop all the national accents
- https://github.com/dosbox-staging/dosbox-staging/blob/main/contrib/resources/mapping/MAIN.TXT - contains a list of code pages currently supported by our Unicode engine (not all of them are supported by Windows 11)
- UTF-8 console (`chcp 65001`) is supported too


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

