### PR TITLE
Snip truism note from MIXER long help text

### DIFF
--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -817,8 +817,6 @@ void MIXER::AddMessages()
 	        "  - You may change the settings of more than one channel in a single command.\n"
 	        "  - If no channel is specified, you can set crossfeed, reverb, or chorus\n"
 	        "    of all channels globally.\n"
-	        "  - The reverb and chorus commands also enable the default reverb and chorus\n"
-	        "    presets, respectively, if those effects are not yet enabled.\n"
 	        "  - The /noshow option applies the changes without showing the mixer settings.\n"
 	        "\n"
 	        "Examples:\n"


### PR DESCRIPTION
# Description

See title. This is a follow up fix that slipped through the prior PR. 

# Manual testing

Confirmed the mixer's long help does not include the snipped text. 


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

