### PR TITLE
Minor string fixes in 'MIXER' command

### DIFF
--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -808,7 +808,7 @@ void MIXER::AddMessages()
 	        "                 volumes of stereo channels separately (e.g. [color=white]10:20[reset], [color=white]150:d6[reset])\n"
 	        "    Stereo mode: [color=white]stereo[reset], or [color=white]reverse[reset] (stereo channels only)\n"
 	        "    Crossfeed:   [color=white]x0[reset] to [color=white]x100[reset], sets crossfeed strength (stereo channels only)\n"
-	        "    Reverb:      [color=white]r0[reset] to [color=white]r100[reset]. sets reverb level\n"
+	        "    Reverb:      [color=white]r0[reset] to [color=white]r100[reset], sets reverb level\n"
 	        "    Chorus:      [color=white]c0[reset] to [color=white]c100[reset], sets chorus level\n"
 	        "\n"
 	        "Notes:\n"
@@ -857,15 +857,15 @@ void MIXER::AddMessages()
 	        "[color=white]%s[reset]\n(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_CROSSFEED_STRENGTH",
-	        "Missing crossfeed strength after [color=white]X[reset] for the "
+	        "Missing crossfeed strength after [color=white]x[reset] for the "
 	        "[color=light-cyan]%s[reset] channel\n(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_CHORUS_LEVEL",
-	        "Missing chorus level after [color=white]C[reset] for the "
+	        "Missing chorus level after [color=white]c[reset] for the "
 	        "[color=light-cyan]%s[reset] channel\n(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_REVERB_LEVEL",
-	        "Missing reverb level after [color=white]R[reset] for the "
+	        "Missing reverb level after [color=white]r[reset] for the "
 	        "[color=light-cyan]%s[reset] channel\n(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_INVALID_GLOBAL_CROSSFEED_STRENGTH",
@@ -881,15 +881,15 @@ void MIXER::AddMessages()
 	        "(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_GLOBAL_CROSSFEED_STRENGTH",
-	        "Missing global crossfeed strength after [color=white]X[reset] "
+	        "Missing global crossfeed strength after [color=white]x[reset] "
 	        "(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_GLOBAL_CHORUS_LEVEL",
-	        "Missing global chorus level after [color=white]C[reset] "
+	        "Missing global chorus level after [color=white]c[reset] "
 	        "(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_GLOBAL_REVERB_LEVEL",
-	        "Missing global reverb level after [color=white]R[reset] "
+	        "Missing global reverb level after [color=white]r[reset] "
 	        "(must be between 0 and 100)");
 
 	MSG_Add("SHELL_CMD_MIXER_MISSING_CHANNEL_COMMAND",


### PR DESCRIPTION
# Description

Fixes of two minor string issues I noticed during translation:
- there was a full stop instead of comma in one place
- if the help message uses 'x', 'c', and 'r' (lowercase), error messages should use the same capitalization


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

