### PR TITLE
Fix read checks in shell file reader

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -23,7 +23,7 @@ jobs:
             max_warnings: 17
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 875
+            max_warnings: 882
 
     steps:
       - name: Checkout repository

--- a/src/shell/file_reader.cpp
+++ b/src/shell/file_reader.cpp
@@ -38,9 +38,9 @@ std::optional<uint8_t> FileReader::Read()
 {
 	std::uint8_t data        = 0;
 	std::uint16_t bytes_read = 1;
-	DOS_ReadFile(handle, &data, &bytes_read);
 
-	if (bytes_read == 0) {
+	bool result = DOS_ReadFile(handle, &data, &bytes_read);
+	if (!result || bytes_read == 0) {
 		return std::nullopt;
 	}
 


### PR DESCRIPTION
# Description

This fixes a problem in `FileReader::Read` where it was not properly checking if `DOS_ReadFile` has succeeded or not which, in some cases, caused batch script parser to get stuck in infinite loop.
Sample batch script inside archive: [d2_19pat.zip](https://github.com/dosbox-staging/dosbox-staging/files/13220961/d2_19pat.zip)


# Manual testing

Ran PATCH.BAT from the attached sample. Dosbox hanged at the end of the script without the fix and worked fine with the fix.
Tested benchmark pack from Phil's Computer Lab: https://www.philscomputerlab.com/dos-benchmark-pack.html
Tested RUN.BAT from Bubble Bobble from eXo's pack.
Tested these cases:
1. Create a .BAT file that's empty (zero-bytes).
2. Create a .BAT file that contains a single 0 or null characters.
3. Create a .BAT that contains valid lines, but ends with a 0 or null instead of a carriage return.
4. Create a .BAT that contains valid lines but that doesn't end with a null or a CR LF (It just ends at the last valid character).
5. Create a .BAT that ends with CR LF.

No issues noticed.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

