### PR TITLE
Fix a crash when using glshader=crt-auto-machine

### DIFF
--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -74,12 +74,13 @@ extern bool mono_cga;
 enum MachineType {
 	// In rough age-order: Hercules is the oldest and VGA is the newest
 	// (Tandy started out as a clone of the PCjr, so PCjr came first)
-	MCH_HERC  = 1 << 0,
-	MCH_CGA   = 1 << 1,
-	MCH_TANDY = 1 << 2,
-	MCH_PCJR  = 1 << 3,
-	MCH_EGA   = 1 << 4,
-	MCH_VGA   = 1 << 5,
+	MCH_INVALID = 0,
+	MCH_HERC    = 1 << 0,
+	MCH_CGA     = 1 << 1,
+	MCH_TANDY   = 1 << 2,
+	MCH_PCJR    = 1 << 3,
+	MCH_EGA     = 1 << 4,
+	MCH_VGA     = 1 << 5,
 };
 
 extern MachineType machine;

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -44,6 +44,7 @@ const char* MSG_GetRaw(const char*); // get messages (in UTF-8, without ANSI
 bool MSG_Exists(const char*);
 
 class Section;
+class Section_prop;
 
 typedef Bitu (LoopHandler)(void);
 
@@ -55,6 +56,8 @@ void DOSBOX_SetLoop(LoopHandler * handler);
 void DOSBOX_SetNormalLoop();
 
 void DOSBOX_Init(void);
+
+void DOSBOX_SetMachineTypeFromConfig(Section_prop* section);
 
 class Config;
 using config_ptr_t = std::unique_ptr<Config>;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -343,17 +343,8 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 	}
 }
 
-static void DOSBOX_RealInit(Section * sec) {
-	Section_prop * section=static_cast<Section_prop *>(sec);
-	/* Initialize some dosbox internals */
-	ticksRemain=0;
-	ticksLast=GetTicks();
-	ticksLocked = false;
-	DOSBOX_SetLoop(&Normal_Loop);
-
-	MAPPER_AddHandler(DOSBOX_UnlockSpeed, SDL_SCANCODE_F12, MMOD2,
-	                  "speedlock", "Speedlock");
-
+void DOSBOX_SetMachineTypeFromConfig(Section_prop* section)
+{
 	const auto arguments = &control->arguments;
 	if (!arguments->machine.empty()) {
 		//update value in config (else no matching against suggested values
@@ -395,6 +386,20 @@ static void DOSBOX_RealInit(Section * sec) {
 	// VGA-type machine needs an valid SVGA card and vice-versa
 	assert((machine == MCH_VGA && svgaCard != SVGA_None) ||
 	       (machine != MCH_VGA && svgaCard == SVGA_None));
+}
+
+static void DOSBOX_RealInit(Section* sec)
+{
+	Section_prop* section = static_cast<Section_prop*>(sec);
+	/* Initialize some dosbox internals */
+	ticksRemain = 0;
+	ticksLast   = GetTicks();
+	ticksLocked = false;
+	DOSBOX_SetLoop(&Normal_Loop);
+
+	MAPPER_AddHandler(DOSBOX_UnlockSpeed, SDL_SCANCODE_F12, MMOD2, "speedlock", "Speedlock");
+
+	DOSBOX_SetMachineTypeFromConfig(section);
 
 	// Set the user's prefered MCB fault handling strategy
 	DOS_SetMcbFaultStrategy(section->Get_string("mcb_fault_strategy").c_str());

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -532,6 +532,13 @@ std::string ShaderManager::FindShaderAutoMachine() const
 		return GetCompositeShader();
 	}
 
+	// DOSBOX_RealInit may have not been run yet.
+	// If not, go ahead and set the globals from the config.
+	if (machine == MCH_INVALID) {
+		DOSBOX_SetMachineTypeFromConfig(
+		        static_cast<Section_prop*>(control->GetSection("dosbox")));
+	}
+
 	switch (machine) {
 	case MCH_HERC: return GetHerculesShader();
 

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -641,6 +641,8 @@ void INT10_WriteChar(uint8_t chr, uint8_t attr, uint8_t page, uint16_t count, bo
 			case MCH_HERC:
 			case MCH_TANDY:
 				break;
+
+			default: assertm(false, "Invalid MachineType value");
 		}
 	}
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -676,6 +676,8 @@ void INT10_SetCurMode(void) {
 			}
 			if (mode_changed && CurMode->type==M_TEXT) SetTextLines();
 			break;
+
+		default: assertm(false, "Invalid MachineType value");
 		}
 
 		if (mode_changed) {
@@ -820,6 +822,8 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 		// handled in function INT10_SetVideoMode.
 		assert(false);
 		break;
+
+	default: assertm(false, "Invalid MachineType value");
 	}
 
 	//  Setup the VGA to the correct mode
@@ -979,6 +983,8 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 		// handled in function INT10_SetVideoMode.
 		assert(false);
 		break;
+
+	default: assertm(false, "Invalid MachineType value");
 	}
 
 	RealPt vparams = RealGetVec(0x1d);

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -91,6 +91,8 @@ void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val)
 	case MCH_HERC:
 	case MCH_CGA:
 		break;
+
+	default: assertm(false, "Invalid MachineType value");
 	}
 }
 
@@ -115,6 +117,8 @@ void INT10_SetOverscanBorderColor(uint8_t val)
 	case MCH_HERC:
 	case MCH_CGA:
 		break;
+
+	default: assertm(false, "Invalid MachineType value");
 	}
 }
 
@@ -151,6 +155,8 @@ void INT10_SetAllPaletteRegisters(PhysPt data)
 	case MCH_HERC:
 	case MCH_CGA:
 		break;
+
+	default: assertm(false, "Invalid MachineType value");
 	}
 }
 
@@ -395,6 +401,8 @@ void INT10_SetBackgroundBorder(uint8_t val)
 
 	case MCH_HERC:
 		break;
+
+	default: assertm(false, "Invalid MachineType value");
 	}
 }
 


### PR DESCRIPTION
# Description
This was a weird one.  I got an assert failure in the shader code because the machine global was invalid.  Removing the assert gave the same divide by 0 crash that @FeralChild64 got so I assume he was just running a Release build.

My solution is admittedly kind of a hack.  I'm just reading the machine type from the config (extracted code from DOSBOX_RealInit into a separate function) because the shader code gets run before Dosbox get initialized.

As @johnnovak mentioned in the issue thread, init ordering is kind of a mess although in this case I am not seeing anything platform specific.  I haven't tested on Windows but I would wager a guess that at least the assertion failure happens there as well.

I had to bust out gdb to figure out what was really going on here.  If you're interested in the details, read on.  The first time the shader code gets run, it's from this stack trace:

```
Thread 1 "dosbox" hit Breakpoint 1, ShaderManager::FindShaderAutoMachine[abi:cxx11]() const (
    this=0x555557c68680 <get_shader_manager()::shader_manager>) at ../../src/gui/shader_manager.cpp:531
531             if (video_mode.color_depth == ColorDepth::Composite) {
(gdb) bt
#0  ShaderManager::FindShaderAutoMachine[abi:cxx11]() const (this=0x555557c68680 <get_shader_manager()::shader_manager>)
    at ../../src/gui/shader_manager.cpp:531
#1  0x0000555555f6189d in ShaderManager::MaybeAutoSwitchShader (this=0x555557c68680 <get_shader_manager()::shader_manager>)
    at ../../src/gui/shader_manager.cpp:380
#2  0x0000555555f5f66e in ShaderManager::NotifyGlshaderSettingChanged (
    this=0x555557c68680 <get_shader_manager()::shader_manager>, shader_name="crt-auto-machine")
    at ../../src/gui/shader_manager.cpp:72
#3  0x0000555555f164d2 in handle_shader_changes () at ../../src/gui/render.cpp:898
#4  0x0000555555f16905 in RENDER_Init (sec=0x555558a270c0) at ../../src/gui/render.cpp:947
#5  0x0000555555f14550 in RENDER_Reinit () at ../../src/gui/render.cpp:338
#6  0x0000555555f5504b in set_output (sec=0x555558a18de0, wants_aspect_ratio_correction=true)
    at ../../src/gui/sdlmain.cpp:3407
#7  0x0000555555f56046 in GUI_StartUp (sec=0x555558a18de0) at ../../src/gui/sdlmain.cpp:3555
#8  0x0000555555bfcf43 in Section::ExecuteInit (this=0x555558a18de0, init_all=true) at ../../src/misc/setup.cpp:1234
#9  0x0000555555bfcd58 in Config::Init (this=0x555558a14950) at ../../src/misc/setup.cpp:1206
#10 0x0000555555f5bda2 in sdl_main (argc=1, argv=0x7fffffffe4f8) at ../../src/gui/sdlmain.cpp:4858
#11 0x0000555555bd1ce6 in main (argc=1, argv=0x7fffffffe4f8) at ../../src/main.cpp:30
```

As far as I can tell, the SDL section is always the first to get initialized (its init function is `GUI_StartUp`).  This in turn calls `RENDER_Init` which calls the shader code.  This all happens before the Dosbox section gets initialized so the shader manager doesn't know what to do about the machine type (triggering the assert).

Later on, the Render section gets initialized (calling for a 2nd time `RENDER_Init` and repeating this process.)

```
Thread 1 "dosbox" hit Breakpoint 1, ShaderManager::FindShaderAutoMachine[abi:cxx11]() const (
    this=0x555557c68680 <get_shader_manager()::shader_manager>) at ../../src/gui/shader_manager.cpp:531
531             if (video_mode.color_depth == ColorDepth::Composite) {
(gdb) bt
#0  ShaderManager::FindShaderAutoMachine[abi:cxx11]() const (this=0x555557c68680 <get_shader_manager()::shader_manager>)
    at ../../src/gui/shader_manager.cpp:531
#1  0x0000555555f6189d in ShaderManager::MaybeAutoSwitchShader (this=0x555557c68680 <get_shader_manager()::shader_manager>)
    at ../../src/gui/shader_manager.cpp:380
#2  0x0000555555f5f66e in ShaderManager::NotifyGlshaderSettingChanged (
    this=0x555557c68680 <get_shader_manager()::shader_manager>, shader_name="crt-auto-machine")
    at ../../src/gui/shader_manager.cpp:72
#3  0x0000555555f164d2 in handle_shader_changes () at ../../src/gui/render.cpp:898
#4  0x0000555555f16905 in RENDER_Init (sec=0x555558a270c0) at ../../src/gui/render.cpp:947
#5  0x0000555555bfcf43 in Section::ExecuteInit (this=0x555558a270c0, init_all=true) at ../../src/misc/setup.cpp:1234
#6  0x0000555555bfcd58 in Config::Init (this=0x555558a14950) at ../../src/misc/setup.cpp:1206
#7  0x0000555555f5bda2 in sdl_main (argc=1, argv=0x7fffffffe4f8) at ../../src/gui/sdlmain.cpp:4858
#8  0x0000555555bd1ce6 in main (argc=1, argv=0x7fffffffe4f8) at ../../src/main.cpp:30
```

By this point (if you're running a release build and the assert didn't trigger), the Dosbox section has been initialized and the shader manager is happy.  However, the shader manager reports that there has been a shader change (from "empty string" to something valid).  This makes the 2nd run of `RENDER_Init` take a branch to call into `VGA_SetupDrawing` which runs into a divide by 0 bug due to more uninitialized global variables.

https://github.com/dosbox-staging/dosbox-staging/blob/55a6f98e0394623d48a73a4b62e1b587faaa2e5c/src/gui/render.cpp#L947-L962

This PR kind of sidesteps that 2nd issue because now the shader manager gets it right the first time and the `needs_reinit` variable will be false.

## Related issues
Fixes #3059


# Manual testing
- Followed repo steps from #3059
- Stepped through with GDB to figure out wtf was going on
- Assertion failure no longer happens
- Divide by 0 no longer happens


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

