### PR TITLE
Add mouse button mapping community patch

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -65,6 +65,21 @@ enum class MouseMapStatus : uint8_t {
 	Disabled
 };
 
+// Each mouse button has a corresponding fixed identifying value, similar to
+// keyboard scan codes.
+enum class MouseButtonId : uint8_t {
+	Left   = 0,
+	Right  = 1,
+	Middle = 2,
+	Extra1 = 3,
+	Extra2 = 4,
+
+	// Aliases
+	First = Left,
+	Last  = Extra2,
+	None  = UINT8_MAX,
+};
+
 // ***************************************************************************
 // Notifications from external subsystems - all should go via these methods
 // ***************************************************************************
@@ -74,8 +89,8 @@ void MOUSE_EventMoved(const float x_rel, const float y_rel,
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
                       const MouseInterfaceId device_id);
 
-void MOUSE_EventButton(const uint8_t idx, const bool pressed);
-void MOUSE_EventButton(const uint8_t idx, const bool pressed,
+void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed);
+void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed,
                        const MouseInterfaceId device_id);
 
 void MOUSE_EventWheel(const int16_t w_rel);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1704,7 +1704,21 @@ public:
 
 	KBD_KEYS key;
 };
-
+/*
+class CMouseButtonEvent : public CTriggeredEvent {
+public:
+	CMouseButtonEvent(char const * const _entry,Bit8u _button) : CTriggeredEvent(_entry) {
+		button=_button;
+	}
+	void Active(bool yesno) {
+		if (yesno)
+			Mouse_ButtonPressed(button);
+		else
+			Mouse_ButtonReleased(button);
+	}
+	Bit8u button;
+};
+*/
 class CJAxisEvent final : public CContinuousEvent {
 public:
 	CJAxisEvent(const char* const entry, Bitu s, Bitu a, bool p,
@@ -2019,7 +2033,16 @@ static CKeyEvent* AddKeyButtonEvent(int32_t x, int32_t y, int32_t dx,
 	new CEventButton(x,y,dx,dy,title,event);
 	return event;
 }
-
+/*
+static CMouseButtonEvent * AddMouseButtonEvent(Bitu x,Bitu y,Bitu dx,Bitu dy,char const * const title,char const * const entry,Bit8u button) {
+	char buf[64];
+	strcpy(buf,"mouse_");
+	strcat(buf,entry);
+	CMouseButtonEvent * event=new CMouseButtonEvent(buf,button);
+	new CEventButton(x,y,dx,dy,title,event);
+	return event;
+}
+*/
 static CJAxisEvent* AddJAxisButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
                                    const char* const title, Bitu stick, Bitu axis,
                                    bool positive, CJAxisEvent* opposite_axis)
@@ -2245,6 +2268,18 @@ static void CreateLayout() {
 
 #undef XO
 #undef YO
+
+#if 0
+#define XO 5
+#define YO 8
+	/* Mouse Buttons */
+	new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Mouse");
+	AddMouseButtonEvent(PX(XO+0),PY(YO),BW,BH,"L","left",0);
+	AddMouseButtonEvent(PX(XO+1),PY(YO),BW,BH,"M","middle",2);
+	AddMouseButtonEvent(PX(XO+2),PY(YO),BW,BH,"R","right",1);
+#undef XO
+#undef YO
+#endif
 
 #define XO 10
 #define YO 8

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1704,21 +1704,25 @@ public:
 
 	KBD_KEYS key;
 };
-/*
-class CMouseButtonEvent : public CTriggeredEvent {
+
+class CMouseButtonEvent final : public CTriggeredEvent {
 public:
-	CMouseButtonEvent(char const * const _entry,Bit8u _button) : CTriggeredEvent(_entry) {
-		button=_button;
+	CMouseButtonEvent() = delete;
+
+	CMouseButtonEvent(const char* const entry, const MouseButtonId id)
+	        : CTriggeredEvent(entry),
+	          button_id(id)
+	{}
+
+	void Active(const bool pressed) override
+	{
+		MOUSE_EventButton(button_id, pressed);
 	}
-	void Active(bool yesno) {
-		if (yesno)
-			Mouse_ButtonPressed(button);
-		else
-			Mouse_ButtonReleased(button);
-	}
-	Bit8u button;
+
+private:
+	const MouseButtonId button_id = MouseButtonId::None;
 };
-*/
+
 class CJAxisEvent final : public CContinuousEvent {
 public:
 	CJAxisEvent(const char* const entry, Bitu s, Bitu a, bool p,
@@ -2033,16 +2037,18 @@ static CKeyEvent* AddKeyButtonEvent(int32_t x, int32_t y, int32_t dx,
 	new CEventButton(x,y,dx,dy,title,event);
 	return event;
 }
-/*
-static CMouseButtonEvent * AddMouseButtonEvent(Bitu x,Bitu y,Bitu dx,Bitu dy,char const * const title,char const * const entry,Bit8u button) {
-	char buf[64];
-	strcpy(buf,"mouse_");
-	strcat(buf,entry);
-	CMouseButtonEvent * event=new CMouseButtonEvent(buf,button);
-	new CEventButton(x,y,dx,dy,title,event);
+
+static CMouseButtonEvent* AddMouseButtonEvent(const int32_t x, const int32_t y,
+                                              const int32_t dx, const int32_t dy,
+                                              const char* const title,
+                                              const char* const entry,
+                                              const MouseButtonId button_id)
+{
+	auto event = new CMouseButtonEvent(entry, button_id);
+	new CEventButton(x, y, dx, dy, title, event);
 	return event;
 }
-*/
+
 static CJAxisEvent* AddJAxisButton(int32_t x, int32_t y, int32_t dx, int32_t dy,
                                    const char* const title, Bitu stick, Bitu axis,
                                    bool positive, CJAxisEvent* opposite_axis)
@@ -2269,17 +2275,36 @@ static void CreateLayout() {
 #undef XO
 #undef YO
 
-#if 0
 #define XO 5
 #define YO 8
 	/* Mouse Buttons */
-	new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Mouse");
-	AddMouseButtonEvent(PX(XO+0),PY(YO),BW,BH,"L","left",0);
-	AddMouseButtonEvent(PX(XO+1),PY(YO),BW,BH,"M","middle",2);
-	AddMouseButtonEvent(PX(XO+2),PY(YO),BW,BH,"R","right",1);
+	new CTextButton(pos_x(XO + 0), pos_y(YO - 1), 3 * button_width, 20, "Mouse");
+
+	AddMouseButtonEvent(pos_x(XO + 0),
+	                    pos_y(YO),
+	                    button_width,
+	                    button_height,
+	                    "L",
+	                    "mouse_left",
+	                    MouseButtonId::Left);
+
+	AddMouseButtonEvent(pos_x(XO + 1),
+	                    pos_y(YO),
+	                    button_width,
+	                    button_height,
+	                    "M",
+	                    "mouse_middle",
+	                    MouseButtonId::Middle);
+
+	AddMouseButtonEvent(pos_x(XO + 2),
+	                    pos_y(YO),
+	                    button_width,
+	                    button_height,
+	                    "R",
+	                    "mouse_right",
+	                    MouseButtonId::Right);
 #undef XO
 #undef YO
-#endif
 
 #define XO 10
 #define YO 8

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3605,15 +3605,17 @@ static void HandleMouseWheel(SDL_MouseWheelEvent *wheel)
 static void HandleMouseButton(SDL_MouseButtonEvent * button)
 {
 	auto notify_button = [](const uint8_t button, const bool pressed) {
+		// clang-format off
 		switch (button) {
-		case SDL_BUTTON_LEFT:   MOUSE_EventButton(0, pressed); break;
-		case SDL_BUTTON_RIGHT:  MOUSE_EventButton(1, pressed); break;
-		case SDL_BUTTON_MIDDLE: MOUSE_EventButton(2, pressed); break;
-		case SDL_BUTTON_X1:     MOUSE_EventButton(3, pressed); break;
-		case SDL_BUTTON_X2:     MOUSE_EventButton(4, pressed); break;
+		case SDL_BUTTON_LEFT:   MOUSE_EventButton(MouseButtonId::Left,   pressed); break;
+		case SDL_BUTTON_RIGHT:  MOUSE_EventButton(MouseButtonId::Right,  pressed); break;
+		case SDL_BUTTON_MIDDLE: MOUSE_EventButton(MouseButtonId::Middle, pressed); break;
+		case SDL_BUTTON_X1:     MOUSE_EventButton(MouseButtonId::Extra1, pressed); break;
+		case SDL_BUTTON_X2:     MOUSE_EventButton(MouseButtonId::Extra2, pressed); break;
 		}
+		// clang-format on
 	};
-
+	assert(button);
 	notify_button(button->button, button->state == SDL_PRESSED);
 }
 

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -561,7 +561,7 @@ void MOUSE_EventMoved(const float x_rel, const float y_rel,
 	}
 }
 
-void MOUSE_EventButton(const uint8_t idx, const bool pressed)
+void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed)
 {
 	// Event from GFX
 
@@ -576,14 +576,15 @@ void MOUSE_EventButton(const uint8_t idx, const bool pressed)
 			return;
 		}
 
+		const auto is_middle = (button_id == MouseButtonId::Middle);
+
 		// Handle mouse capture toggle by middle click
-		constexpr uint8_t idx_middle = 2;
-		if (idx == idx_middle && state.should_capture_on_middle) {
+		if (is_middle && state.should_capture_on_middle) {
 			state.capture_was_requested = true;
 			MOUSE_UpdateGFX();
 			return;
 		}
-		if (idx == idx_middle && state.should_release_on_middle) {
+		if (is_middle && state.should_release_on_middle) {
 			state.capture_was_requested = false;
 			MOUSE_UpdateGFX();
 			return;
@@ -598,10 +599,10 @@ void MOUSE_EventButton(const uint8_t idx, const bool pressed)
 	// Notify mouse interfaces
 	for (auto &interface : mouse_interfaces)
 		if (interface->IsUsingHostPointer())
-			interface->NotifyButton(idx, pressed);
+			interface->NotifyButton(button_id, pressed);
 }
 
-void MOUSE_EventButton(const uint8_t idx, const bool pressed,
+void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed,
                        const MouseInterfaceId interface_id)
 {
 	// Event from ManyMouse
@@ -616,7 +617,7 @@ void MOUSE_EventButton(const uint8_t idx, const bool pressed,
 	// Notify mouse interface
 	auto interface = MouseInterface::Get(interface_id);
 	if (interface && interface->IsUsingEvents()) {
-		interface->NotifyButton(idx, pressed);
+		interface->NotifyButton(button_id, pressed);
 	}
 }
 

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -152,7 +152,7 @@ public:
 
 	void NotifyMoved(const float x_rel, const float y_rel,
 	                 const uint32_t x_abs, const uint32_t y_abs) override;
-	void NotifyButton(const uint8_t idx, const bool pressed) override;
+	void NotifyButton(const MouseButtonId id, const bool pressed) override;
 	void NotifyWheel(const int16_t w_rel) override;
 	void NotifyBooting() override;
 
@@ -177,7 +177,7 @@ public:
 
 	void NotifyMoved(const float x_rel, const float y_rel,
 	                 const uint32_t x_abs, const uint32_t y_abs) override;
-	void NotifyButton(const uint8_t idx, const bool pressed) override;
+	void NotifyButton(const MouseButtonId id, const bool pressed) override;
 	void NotifyWheel(const int16_t w_rel) override;
 	void NotifyBooting() override;
 
@@ -205,7 +205,7 @@ public:
 
 	void NotifyMoved(const float x_rel, const float y_rel,
 	                 const uint32_t x_abs, const uint32_t y_abs) override;
-	void NotifyButton(const uint8_t idx, const bool pressed) override;
+	void NotifyButton(const MouseButtonId id, const bool pressed) override;
 	void NotifyWheel(const int16_t w_rel) override;
 
 	void UpdateRate() override;
@@ -564,29 +564,21 @@ void MouseInterface::UpdateRate()
 	rate_hz = MOUSE_ClampRateHz(std::max(interface_rate_hz, min_rate_hz));
 }
 
-void MouseInterface::UpdateButtons(const uint8_t idx, const bool pressed)
+void MouseInterface::UpdateButtons(const MouseButtonId button_id, const bool pressed)
 {
 	old_buttons_12  = buttons_12;
 	old_buttons_345 = buttons_345;
 
-	switch (idx) {
-	case 0: // left button
-		buttons_12.left = pressed ? 1 : 0;
-		break;
-	case 1: // right button
-		buttons_12.right = pressed ? 1 : 0;
-		break;
-	case 2: // middle button
-		buttons_345.middle = pressed ? 1 : 0;
-		break;
-	case 3: // extra button #1
-		buttons_345.extra_1 = pressed ? 1 : 0;
-		break;
-	case 4: // extra button #2
-		buttons_345.extra_2 = pressed ? 1 : 0;
-		break;
-	default: // button not supported
-		return;
+	// clang-format off
+	switch (button_id) {
+	case MouseButtonId::Left:   buttons_12.left     = pressed; break;
+	case MouseButtonId::Right:  buttons_12.right    = pressed; break;
+	case MouseButtonId::Middle: buttons_345.middle  = pressed; break;
+	case MouseButtonId::Extra1: buttons_345.extra_1 = pressed; break;
+	case MouseButtonId::Extra2: buttons_345.extra_2 = pressed; break;
+	case MouseButtonId::None: // button not supported
+	// clang-format on
+	default: return;
 	}
 }
 
@@ -660,9 +652,9 @@ void InterfaceDos::NotifyMoved(const float x_rel, const float y_rel,
 	                     y_abs);
 }
 
-void InterfaceDos::NotifyButton(const uint8_t idx, const bool pressed)
+void InterfaceDos::NotifyButton(const MouseButtonId button_id, const bool pressed)
 {
-	UpdateButtons(idx, pressed);
+	UpdateButtons(button_id, pressed);
 	if (GCC_UNLIKELY(!ChangedButtonsSquished())) {
 		return;
 	}
@@ -729,9 +721,9 @@ void InterfacePS2::NotifyMoved(const float x_rel, const float y_rel,
 	MOUSEPS2_NotifyMoved(x_rel * sensitivity_coeff_x, y_rel * sensitivity_coeff_y);
 }
 
-void InterfacePS2::NotifyButton(const uint8_t idx, const bool pressed)
+void InterfacePS2::NotifyButton(const MouseButtonId button_id, const bool pressed)
 {
-	UpdateButtons(idx, pressed);
+	UpdateButtons(button_id, pressed);
 	if (GCC_UNLIKELY(!ChangedButtonsJoined())) {
 		return;
 	}
@@ -792,16 +784,16 @@ void InterfaceCOM::NotifyMoved(const float x_rel, const float y_rel,
 	                      y_rel * sensitivity_coeff_y);
 }
 
-void InterfaceCOM::NotifyButton(const uint8_t idx, const bool pressed)
+void InterfaceCOM::NotifyButton(const MouseButtonId button_id, const bool pressed)
 {
 	assert(listener);
 
-	UpdateButtons(idx, pressed);
+	UpdateButtons(button_id, pressed);
 	if (GCC_UNLIKELY(!ChangedButtonsSquished())) {
 		return;
 	}
 
-	listener->NotifyButton(GetButtonsSquished()._data, idx);
+	listener->NotifyButton(GetButtonsSquished()._data, button_id);
 }
 
 void InterfaceCOM::NotifyWheel(const int16_t w_rel)

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -127,7 +127,7 @@ public:
 
 	virtual void NotifyMoved(const float x_rel, const float y_rel,
 	                         const uint32_t x_abs, const uint32_t y_abs) = 0;
-	virtual void NotifyButton(const uint8_t idx, const bool pressed) = 0;
+	virtual void NotifyButton(const MouseButtonId id, const bool pressed) = 0;
 	virtual void NotifyWheel(const int16_t w_rel) = 0;
 
 	void NotifyInterfaceRate(const uint16_t rate_hz);
@@ -182,7 +182,7 @@ protected:
 	virtual void UpdateSensitivity();
 	virtual void UpdateMinRate();
 	virtual void UpdateRate();
-	void UpdateButtons(const uint8_t idx, const bool pressed);
+	void UpdateButtons(const MouseButtonId id, const bool pressed);
 	void ResetButtons();
 
 	bool ChangedButtonsJoined() const;

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -28,6 +28,7 @@
 #include "string_utils.h"
 
 #include <algorithm>
+#include <initializer_list>
 
 CHECK_NARROWING();
 
@@ -408,13 +409,14 @@ void ManyMouseGlue::HandleEvent(const ManyMouseEvent &event, const bool critical
 		// LOG_INFO("MANYMOUSE #%u BUTTON %u %s", event.device,
 		// event.item, event.value ? "press" : "release");
 		if (no_interface || (critical_only && !event.value) ||
-		    (event.item >= max_buttons))
+		    (event.item > static_cast<uint8_t>(manymouse_max_button_id))) {
 			// TODO: Consider supporting extra mouse buttons
 			// in the future. On Linux event items 3-7 are for
 			// scroll wheel(s), 8 is for SDL button X1, 9 is
 			// for X2, etc. - but I don't know yet if this
 			// is consistent across various platforms
 			break;
+		}
 		MOUSE_EventButton(static_cast<MouseButtonId>(event.item),
 		                  event.value,
 		                  interface_id);
@@ -432,8 +434,9 @@ void ManyMouseGlue::HandleEvent(const ManyMouseEvent &event, const bool critical
 		// LOG_INFO("MANYMOUSE #%u DISCONNECT", event.device);
 		physical_devices[event.device].disconnected = true;
 
-		for (uint8_t button = 0; button < max_buttons; ++button) {
-			const auto button_id = static_cast<MouseButtonId>(button);
+		for (const auto button_id : {MouseButtonId::Left,
+		                             MouseButtonId::Right,
+		                             MouseButtonId::Middle}) {
 			MOUSE_EventButton(button_id, false, interface_id);
 		}
 		MOUSE_NotifyDisconnect(interface_id);

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -415,7 +415,7 @@ void ManyMouseGlue::HandleEvent(const ManyMouseEvent &event, const bool critical
 			// for X2, etc. - but I don't know yet if this
 			// is consistent across various platforms
 			break;
-		MOUSE_EventButton(static_cast<uint8_t>(event.item),
+		MOUSE_EventButton(static_cast<MouseButtonId>(event.item),
 		                  event.value,
 		                  interface_id);
 		break;
@@ -431,8 +431,11 @@ void ManyMouseGlue::HandleEvent(const ManyMouseEvent &event, const bool critical
 	case MANYMOUSE_EVENT_DISCONNECT:
 		// LOG_INFO("MANYMOUSE #%u DISCONNECT", event.device);
 		physical_devices[event.device].disconnected = true;
-		for (uint8_t button = 0; button < max_buttons; button++)
-			MOUSE_EventButton(button, false, interface_id);
+
+		for (uint8_t button = 0; button < max_buttons; ++button) {
+			const auto button_id = static_cast<MouseButtonId>(button);
+			MOUSE_EventButton(button_id, false, interface_id);
+		}
 		MOUSE_NotifyDisconnect(interface_id);
 		break;
 

--- a/src/hardware/input/mouse_manymouse.h
+++ b/src/hardware/input/mouse_manymouse.h
@@ -103,7 +103,9 @@ private:
 	std::vector<int> rel_x = {}; // not yet reported accumulated movements
 	std::vector<int> rel_y = {};
 
-	static constexpr uint8_t max_buttons  = 3;
+	static constexpr uint8_t max_buttons = 3;
+	static_assert(max_buttons <= static_cast<uint8_t>(MouseButtonId::Last));
+
 	static constexpr uint8_t max_mice     = UINT8_MAX - 1;
 	static constexpr double tick_interval = 5.0;
 

--- a/src/hardware/input/mouse_manymouse.h
+++ b/src/hardware/input/mouse_manymouse.h
@@ -103,8 +103,9 @@ private:
 	std::vector<int> rel_x = {}; // not yet reported accumulated movements
 	std::vector<int> rel_y = {};
 
-	static constexpr uint8_t max_buttons = 3;
-	static_assert(max_buttons <= static_cast<uint8_t>(MouseButtonId::Last));
+	// Limit our handling to what Settlers 1 and 2 can use, which is the
+	// only known DOS game that support multiple mice.
+	static constexpr auto manymouse_max_button_id = MouseButtonId::Middle;
 
 	static constexpr uint8_t max_mice     = UINT8_MAX - 1;
 	static constexpr double tick_interval = 5.0;

--- a/src/hardware/serialport/serialmouse.cpp
+++ b/src/hardware/serialport/serialmouse.cpp
@@ -259,17 +259,21 @@ void CSerialMouse::NotifyMoved(const float x_rel, const float y_rel)
 		got_another_move = true;
 }
 
-void CSerialMouse::NotifyButton(const uint8_t new_buttons, const uint8_t idx)
+void CSerialMouse::NotifyButton(const uint8_t new_buttons, const MouseButtonId button_id)
 {
-	if (!has_3rd_button && idx > 1)
+	const auto is_middle_or_greater = (button_id >= MouseButtonId::Middle);
+
+	if (!has_3rd_button && is_middle_or_greater) {
 		return;
+	}
 
 	buttons = new_buttons;
 
-	if (xmit_idx >= packet_len)
-		StartPacketData(idx > 1);
-	else
+	if (xmit_idx >= packet_len) {
+		StartPacketData(is_middle_or_greater);
+	} else {
 		got_another_button = true;
+	}
 }
 
 void CSerialMouse::NotifyWheel(const int16_t w_rel)

--- a/src/hardware/serialport/serialmouse.h
+++ b/src/hardware/serialport/serialmouse.h
@@ -31,7 +31,7 @@ public:
 
 	void NotifyMoved(const float x_rel, const float y_rel);
 	void NotifyButton(const uint8_t new_buttons,
-	                  const uint8_t idx); // changed button, staring from 0
+	                  const MouseButtonId id); // changed button
 	void NotifyWheel(const int16_t w_rel);
 
 	void BoostRate(const uint16_t rate_hz); // 0 = standard rate


### PR DESCRIPTION
# Description

Adds the mouse buttons to the mapper using @legoscia's community patch. Thanks @legoscia!


This let's users map host-side keyboard and joystick events to create DOS-side mouse-button click, hold, and release events.

It's handy for users on mono-click touch-pads or using mono-button mice , like the ChesterMouse: 

![](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/d86e687a-eade-4327-a164-5bb7434bd1b7)

This is the last of the features to be integrated from DOSBox ECE's patch set.

## Notes to reviewers

Suggest reviewing commit-by-commit.

The first commit replaces our literal integer mouse buttons with a named enum as a prerequisite, because I didn't want to use the patch's magic literals. @FeralChild64 : hoping you can review this commit, specifically.

As for the patch itself: it's just a couple tiny additions to the mapper and follows the existing mapper structure perfectly. 

## Related issues

Fixes #3073

# Manual testing

Tested the baseline PS/2 and serial mouse types.

Tested mapping host keyboard events to mouse buttons.

Tested in games and windows 3.1.

Tested:
 1. short click and release (with a keyboard button)
 2. long click and release (with a keyboard button)
 3. click, hold, and release
 5. click, hold, drag (moving the mouse), and release

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

