### PR TITLE
Handle exiting when pause_when_inactive=true

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3989,7 +3989,7 @@ bool GFX_Events()
 						// flush event queue.
 //					}
 
-					while (paused) {
+					while (paused && !shutdown_requested) {
 						// WaitEvent waits for an event rather than polling, so CPU usage drops to zero
 						SDL_WaitEvent(&ev);
 


### PR DESCRIPTION
# Description
Quick fix for a bug I just encountered.  To reproduce:

1. In the config file under `[sdl]`, set `pause_when_inactive=true` (this setting does not properly change at runtime, must be set in config).
2. Unfocus the Dosbox window
3. Click the X to close the window
4. Dosbox will not close until the window is re-focused

This fix simply checks if shutdown has been requested and, if so, breaks out of the "pause loop".  This is the same way that the `PauseDOSBox` function handles this.  `PauseDOSBox` is the code that gets run when you press ALT+Pause on the keyboard.  `pause_when_inactive` is handled separately in the code touched by this PR.

## Related issues
No known issues filed.  Was quicker for me to just make this PR.

# Manual testing
Followed repo steps above and confirmed this fixes the issue.  Also confirmed the pausing functionality still works.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

