### PR TITLE
Set the icon on window regeneration

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -316,9 +316,9 @@ void GFX_SetTitle(const int32_t new_num_cycles, const bool is_paused = false)
 	char title_buf[200] = {0};
 
 #if !defined(NDEBUG)
-	#define APP_NAME_STR "DOSBox Staging (debug build)"
+	#define APP_NAME_STR DOSBOX_NAME " (debug build)"
 #else
-	#define APP_NAME_STR "DOSBox Staging"
+	#define APP_NAME_STR DOSBOX_NAME
 #endif
 
 	auto &num_cycles      = sdl.title_bar.num_cycles;
@@ -3403,7 +3403,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	const auto transparency = clamp(section->Get_int("transparency"), 0, 90);
 	const auto alpha = static_cast<float>(100 - transparency) / 100.0f;
 	SDL_SetWindowOpacity(sdl.window, alpha);
-	SDL_SetWindowTitle(sdl.window, "DOSBox Staging");
+	SDL_SetWindowTitle(sdl.window, APP_NAME_STR);
 	SetIcon();
 
 	RENDER_Reinit();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3403,6 +3403,8 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	const auto transparency = clamp(section->Get_int("transparency"), 0, 90);
 	const auto alpha = static_cast<float>(100 - transparency) / 100.0f;
 	SDL_SetWindowOpacity(sdl.window, alpha);
+	SDL_SetWindowTitle(sdl.window, "DOSBox Staging");
+	SetIcon();
 
 	RENDER_Reinit();
 }
@@ -3553,9 +3555,6 @@ static void GUI_StartUp(Section *sec)
 	}
 
 	set_output(section, RENDER_IsAspectRatioCorrectionEnabled());
-
-	SDL_SetWindowTitle(sdl.window, "DOSBox Staging");
-	SetIcon();
 
 	/* Get some Event handlers */
 	MAPPER_AddHandler(GFX_RequestExit, SDL_SCANCODE_F9, PRIMARY_MOD,


### PR DESCRIPTION
# Description
The icon currently gets lost when the window is regenerated.  To reproduce:

1. Type `fullscreen=true` into Dosbox (doesn't work but it still regenerates the window, changing any other setting in the [sdl] group should also suffice).
2. Icon goes missing in both the top left of the window and at the bottom where the open windows are shown.  On KDE, it gets replaced by a default Xorg icon.

Note, this is probably not reproducible on Mac or MSVC builds as those don't  have an empty `SetIcon` function:

https://github.com/dosbox-staging/dosbox-staging/blob/e91cae410d1d279dfad2cde2b49314c55e42aebe/src/gui/sdlmain.cpp#L534-L544

The fix is to move the `SetIcon()` call into the `set_output` function.  This gets called in both the inital startup and when the window gets regenerated.  Also moved setting the window title in there for good measure (this gets re-set later anyway to show cycles/ms so it probably doesn't matter much).

# Manual testing
Confirmed icon and window title are getting set properly and stay set after a window regeneration.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

