### PR TITLE
Add a memory read breakpoint feature to the builtin debugger

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -33,7 +33,7 @@ Bitu DEBUG_EnableDebugger(void);
 extern Bitu cycle_count;
 extern Bitu debugCallback;
 
-#ifdef C_HEAVY_DEBUG
+#if C_HEAVY_DEBUG
 bool DEBUG_HeavyIsBreakpoint(void);
 void DEBUG_HeavyWriteLogInstruction(void);
 #endif

--- a/include/mem.h
+++ b/include/mem.h
@@ -89,9 +89,19 @@ static inline uint32_t var_read(uint32_t *var)
 /* The Following six functions are slower but they recognize the paged memory
  * system */
 
-uint8_t mem_readb(PhysPt pt);
-uint16_t mem_readw(PhysPt pt);
-uint32_t mem_readd(PhysPt pt);
+enum class MemOpMode {
+	WithBreakpoints,
+	SkipBreakpoints,
+};
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint8_t mem_readb(const PhysPt pt);
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint16_t mem_readw(const PhysPt pt);
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint32_t mem_readd(const PhysPt pt);
 
 void mem_writeb(PhysPt pt, uint8_t val);
 void mem_writew(PhysPt pt, uint16_t val);

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1051,9 +1051,15 @@ static void dyn_pop(DynReg * dynreg,bool checked=true) {
 		gen_mov_host(&core_dyn.readdata,dynreg,decode.big_op?4:2);
 	} else {
 		if (decode.big_op) {
-			gen_call_function((void *)&mem_readd,"%Rd%Drd",dynreg,DREG(STACK));
+			gen_call_function((void*)&mem_readd<MemOpMode::WithBreakpoints>,
+			                  "%Rd%Drd",
+			                  dynreg,
+			                  DREG(STACK));
 		} else {
-			gen_call_function((void *)&mem_readw,"%Rw%Drd",dynreg,DREG(STACK));
+			gen_call_function((void*)&mem_readw<MemOpMode::WithBreakpoints>,
+			                  "%Rw%Drd",
+			                  dynreg,
+			                  DREG(STACK));
 		}
 	}
 	if (dynreg!=DREG(ESP)) {

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -290,7 +290,15 @@ static std::vector<CDebugVar *> varList = {};
 
 bool skipFirstInstruction = false;
 
-enum EBreakpoint { BKPNT_UNKNOWN, BKPNT_PHYSICAL, BKPNT_INTERRUPT, BKPNT_MEMORY, BKPNT_MEMORY_PROT, BKPNT_MEMORY_LINEAR };
+enum EBreakpoint {
+	BKPNT_UNKNOWN,
+	BKPNT_PHYSICAL,
+	BKPNT_INTERRUPT,
+	BKPNT_MEMORY,
+	BKPNT_MEMORY_READ,
+	BKPNT_MEMORY_PROT,
+	BKPNT_MEMORY_LINEAR
+};
 
 #define BPINT_ALL 0x100
 
@@ -318,6 +326,22 @@ public:
 	uint8_t GetIntNr() const noexcept { return intNr; }
 	uint16_t GetValue() const noexcept { return ahValue; }
 	uint16_t GetOther() const noexcept { return alValue; }
+#if C_HEAVY_DEBUG
+	void FlagMemoryAsRead()
+	{
+		memory_was_read = true;
+	}
+
+	void FlagMemoryAsUnread()
+	{
+		memory_was_read = false;
+	}
+
+	bool WasMemoryRead() const
+	{
+		return memory_was_read;
+	}
+#endif
 
 	// statics
 	static CBreakpoint*		AddBreakpoint		(uint16_t seg, uint32_t off, bool once);
@@ -352,8 +376,9 @@ private:
 	// Shared
 	bool active = 0;
 	bool once   = 0;
+#if C_HEAVY_DEBUG
+	bool memory_was_read = false;
 
-#	if C_HEAVY_DEBUG
 	friend bool DEBUG_HeavyIsBreakpoint(void);
 #	endif
 };
@@ -406,6 +431,34 @@ void CBreakpoint::Activate(bool _active)
 
 // Statics
 static std::list<CBreakpoint *> BPoints = {};
+
+#if C_HEAVY_DEBUG
+template <typename T>
+void DEBUG_UpdateMemoryReadBreakpoints(const PhysPt addr)
+{
+	static_assert(std::is_unsigned_v<T>);
+	static_assert(std::is_integral_v<T>);
+
+	for (CBreakpoint* bp : BPoints) {
+		if (bp->GetType() == BKPNT_MEMORY_READ) {
+			const PhysPt location_begin = bp->GetLocation();
+			const PhysPt location_end = location_begin + sizeof(T);
+			if ((addr >= location_begin) && (addr < location_end)) {
+				DEBUG_ShowMsg("bpmr hit: %04X:%04X, cs:ip = %04X:%04X",
+				              bp->GetSegment(),
+				              bp->GetOffset(),
+				              SegValue(cs),
+				              reg_eip);
+				bp->FlagMemoryAsRead();
+			}
+		}
+	}
+}
+// Explicit instantiations
+template void DEBUG_UpdateMemoryReadBreakpoints<uint8_t>(const PhysPt addr);
+template void DEBUG_UpdateMemoryReadBreakpoints<uint16_t>(const PhysPt addr);
+template void DEBUG_UpdateMemoryReadBreakpoints<uint32_t>(const PhysPt addr);
+#endif
 
 CBreakpoint* CBreakpoint::AddBreakpoint(uint16_t seg, uint32_t off, bool once)
 {
@@ -514,6 +567,15 @@ bool CBreakpoint::CheckBreakpoint(Bitu seg, Bitu off)
 					// Yup, memory value changed
 					DEBUG_ShowMsg("DEBUG: Memory breakpoint %s: %04X:%04X - %02X -> %02X\n",(bp->GetType()==BKPNT_MEMORY_PROT)?"(Prot)":"",bp->GetSegment(),bp->GetOffset(),bp->GetValue(),value);
 					bp->SetValue(value);
+					return true;
+				}
+			} else if (bp->GetType() == BKPNT_MEMORY_READ) {
+				if (bp->WasMemoryRead()) {
+					// Yup, memory value was read
+					DEBUG_ShowMsg("DEBUG: Memory read breakpoint: %04X:%04X\n",
+					              bp->GetSegment(),
+					              bp->GetOffset());
+					bp->FlagMemoryAsUnread();
 					return true;
 				}
 			}
@@ -1125,6 +1187,19 @@ bool ParseCommand(char* str) {
 		return true;
 	}
 
+	if (command == "BPMR") { // Add new breakpoint
+		uint16_t seg = (uint16_t)GetHexValue(found, found);
+		found++; // skip ":"
+		uint32_t ofs    = GetHexValue(found, found);
+		CBreakpoint* bp = CBreakpoint::AddMemBreakpoint(seg, ofs);
+		bp->SetType(BKPNT_MEMORY_READ);
+		bp->FlagMemoryAsUnread();
+		DEBUG_ShowMsg("DEBUG: Set memory read breakpoint at %04X:%04X\n",
+		              seg,
+		              ofs);
+		return true;
+	}
+
 	if (command == "BPPM") { // Add new breakpoint
 		uint16_t seg = (uint16_t)GetHexValue(found,found);found++; // skip ":"
 		uint32_t ofs = GetHexValue(found,found);
@@ -1345,6 +1420,7 @@ bool ParseCommand(char* str) {
 		DEBUG_ShowMsg("BPINT  [intNr] [ah] [al]  - Set interrupt breakpoint with ah and al.\n");
 #if C_HEAVY_DEBUG
 		DEBUG_ShowMsg("BPM    [segment]:[offset] - Set memory breakpoint (memory change).\n");
+		DEBUG_ShowMsg("BPMR   [segment]:[offset] - Set memory breakpoint (memory read).\n");
 		DEBUG_ShowMsg("BPPM   [selector]:[offset]- Set pmode-memory breakpoint (memory change).\n");
 		DEBUG_ShowMsg("BPLM   [linear address]   - Set linear memory breakpoint (memory change).\n");
 #endif
@@ -1450,19 +1526,25 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 
 			if (cpu.pmode) outmask[6] = '8';
 				switch (DasmLastOperandSize()) {
-				case 8 : {	uint8_t val = mem_readb(address);
-							outmask[12] = '2';
-							sprintf(result,outmask,prefix,adr,val);
-						}	break;
-				case 16: {	uint16_t val = mem_readw(address);
-							outmask[12] = '4';
-							sprintf(result,outmask,prefix,adr,val);
-						}	break;
-				case 32: {	uint32_t val = mem_readd(address);
-							outmask[12] = '8';
-							sprintf(result,outmask,prefix,adr,val);
-						}	break;
-			}
+			        case 8: {
+				        uint8_t val = mem_readb<MemOpMode::SkipBreakpoints>(
+				                address);
+				        outmask[12] = '2';
+				        sprintf(result, outmask, prefix, adr, val);
+			        } break;
+			        case 16: {
+				        uint16_t val = mem_readw<MemOpMode::SkipBreakpoints>(
+				                address);
+				        outmask[12] = '4';
+				        sprintf(result, outmask, prefix, adr, val);
+			        } break;
+			        case 32: {
+				        uint32_t val = mem_readd<MemOpMode::SkipBreakpoints>(
+				                address);
+				        outmask[12] = '8';
+				        sprintf(result, outmask, prefix, adr, val);
+			        } break;
+			        }
 		} else {
 			sprintf(result,"[illegal]");
 		}

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -468,8 +468,9 @@ static char *addr_to_hex(UINT32 addr, int splitup) {
 static PhysPt getbyte_mac;
 static PhysPt startPtr;
 
-static UINT8 getbyte(void) {
-	return mem_readb(getbyte_mac++);
+static UINT8 getbyte()
+{
+	return mem_readb<MemOpMode::SkipBreakpoints>(getbyte_mac++);
 }
 
 /*

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -561,19 +561,36 @@ bool mem_unalignedwrited_checked(PhysPt address, uint32_t val) {
 	return false;
 }
 
-uint8_t mem_readb(PhysPt address) {
-	return mem_readb_inline(address);
+template <MemOpMode op_mode>
+uint8_t mem_readb(const PhysPt address)
+{
+	return mem_readb_inline<op_mode>(address);
 }
 
-uint16_t mem_readw(PhysPt address) {
-	return mem_readw_inline(address);
+template <MemOpMode op_mode>
+uint16_t mem_readw(const PhysPt address)
+{
+	return mem_readw_inline<op_mode>(address);
 }
 
-uint32_t mem_readd(PhysPt address) {
-	return mem_readd_inline(address);
+template <MemOpMode op_mode>
+uint32_t mem_readd(const PhysPt address)
+{
+	return mem_readd_inline<op_mode>(address);
 }
 
-void mem_writeb(PhysPt address,uint8_t val) {
+// Explicit instantiations for mem_readb, mem_readw, and mem_readd
+template uint8_t mem_readb<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint8_t mem_readb<MemOpMode::SkipBreakpoints>(const PhysPt address);
+
+template uint16_t mem_readw<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint16_t mem_readw<MemOpMode::SkipBreakpoints>(const PhysPt address);
+
+template uint32_t mem_readd<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint32_t mem_readd<MemOpMode::SkipBreakpoints>(const PhysPt address);
+
+void mem_writeb(PhysPt address, uint8_t val)
+{
 	mem_writeb_inline(address,val);
 }
 


### PR DESCRIPTION
# Description

adds a C_HEAVY_DEBUG feature for breaking on memory reads - memory write breakpoints were already available in dosbox svn long time

* will break on read of the memory using F5-run or just show accessing code point on F10 single-step
* only working so far for non-protected realmode, and as most of the debug features only reliable when using core=normal (or as i was told on vogons years ago)

![bpmr](https://github.com/dosbox-staging/dosbox-staging/assets/580819/ce7e54ba-c7c4-48b5-b44d-7ac86673ab85)

use in debugger with: BPMR seg:ofs

# Manual testing

tested the feature with a simple nasm DOS COM executable aka clean environment

assemble with recent nasm using `nasm -f bin bpmr.asm -o bpmr.com`

```
; nasm -f bin bpmr.asm -o bpmr.com
org 100h

mov si,test1
lodsb
lodsb
lodsb

mov byte [test2],'z'

mov al,byte [test1]

mov cx,3
mov si,test1
rep lodsb

mov si,test1
mov di,test2
movsb
movsb
movsb

mov cx,3 
mov si,test1
mov di,test2
rep movsb

mov ax,4C00h
int 21h

test1 db 'ABC'
test2 db 'abc'
```

# Checklist

I have:
 
* [x]  followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
* [x]  performed a self-review of my code.
* [ ]  commented on the particularly hard-to-understand areas of my code.
* [x]  split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
* [x]  applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
* [x]  [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
* [ ]  confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
* [ ]  added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
* [ ]  made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
* [ ]  [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
