### PR TITLE
Don't throttle emulation speed when window becomes unfocused

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -61,7 +61,6 @@ extern int32_t CPU_CyclePercUsed;
 extern int32_t CPU_CycleLimit;
 extern int64_t CPU_IODelayRemoved;
 extern bool CPU_CycleAutoAdjust;
-extern bool CPU_SkipCycleAutoAdjust;
 extern Bitu CPU_AutoDetermineMode;
 
 extern ArchitectureType CPU_ArchitectureType;
@@ -90,8 +89,6 @@ Bits CPU_Core_Dynrec_Trap_Run() noexcept;
 Bits CPU_Core_Prefetch_Run() noexcept;
 Bits CPU_Core_Prefetch_Trap_Run() noexcept;
 
-void CPU_Enable_SkipAutoAdjust(void);
-void CPU_Disable_SkipAutoAdjust(void);
 void CPU_Reset_AutoAdjust(void);
 
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -60,7 +60,6 @@ int32_t CPU_CycleDown = 0;
 int64_t CPU_IODelayRemoved = 0;
 CPU_Decoder * cpudecoder;
 bool CPU_CycleAutoAdjust = false;
-bool CPU_SkipCycleAutoAdjust = false;
 Bitu CPU_AutoDetermineMode = 0;
 
 ArchitectureType CPU_ArchitectureType = ArchitectureType::Mixed;
@@ -2163,20 +2162,6 @@ static void CPU_CycleDecrease(bool pressed) {
 	}
 }
 
-void CPU_Enable_SkipAutoAdjust(void) {
-	if (CPU_CycleAutoAdjust) {
-		CPU_CycleMax /= 2;
-		if (CPU_CycleMax < CPU_CYCLES_LOWER_LIMIT)
-			CPU_CycleMax = CPU_CYCLES_LOWER_LIMIT;
-	}
-	CPU_SkipCycleAutoAdjust=true;
-}
-
-void CPU_Disable_SkipAutoAdjust(void) {
-	CPU_SkipCycleAutoAdjust=false;
-}
-
-
 extern int64_t ticksDone;
 extern int64_t ticksScheduled;
 
@@ -2260,7 +2245,6 @@ public:
 		CPU_AutoDetermineMode=CPU_AUTODETERMINE_NONE;
 		//CPU_CycleLeft=0;//needed ?
 		CPU_Cycles=0;
-		CPU_SkipCycleAutoAdjust=false;
 
 		// Sets the value if the string in within the min and max values
 		auto set_if_in_range = [](const std::string &str, int &value,

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -222,7 +222,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	ticksAdded = ticksRemain;
 
 	// Is the system in auto cycle mode guessing ? If not just exit. (It can be temporary disabled)
-	if (!CPU_CycleAutoAdjust || CPU_SkipCycleAutoAdjust) return;
+	if (!CPU_CycleAutoAdjust) return;
 
 	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2225,9 +2225,6 @@ void GFX_SetMouseVisibility(const bool requested_visible)
 
 static void FocusInput()
 {
-	// Ensure auto-cycles are enabled
-	CPU_Disable_SkipAutoAdjust();
-
 #if defined(WIN32)
 	sdl.focus_ticks = GetTicks();
 #endif
@@ -3857,7 +3854,6 @@ bool GFX_Events()
 #endif
 				ApplyInactiveSettings();
 				GFX_LosingFocus();
-				CPU_Enable_SkipAutoAdjust();
 				break;
 
 			case SDL_WINDOWEVENT_ENTER:
@@ -4006,7 +4002,6 @@ bool GFX_Events()
 										paused = false;
 										ApplyActiveSettings();
 									}
-									CPU_Disable_SkipAutoAdjust();
 								}
 
 								/* Now poke a "release ALT" command into the keyboard buffer


### PR DESCRIPTION
# Description
This solves an issue I've been having where I get bad audio skips when the Dosbox window is unfocused.  It turns out we're silently halving the CPU cycles....

Does anyone find this feature useful?  I propose getting rid of it.  I will often be multi-talking, start a game, and do something while it's loading to be met with jarring audio skips when the intro music starts playing.  Or I just want to listen to a game's music while I do something else.  Or I'm testing ffmpeg recording and want that to run at full speed while I'm looking at code.

# Manual testing
Duke3D with FluidSynth music is the game I've found easiest to reproduce the audio skips as it needs all the cycles it can get.  It also sometimes stops playing video frames all together when cycles get halved.

I've also noticed audio skips in Space Quest 3 with MT32 sound.

I confirmed this change has resolved these issues.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

