### PR TITLE
PVS Studio fixes

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 155
+          MAX_BUGS: 141
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 156
+          MAX_BUGS: 155
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -46,7 +46,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 
 	// Create the two SAA1099 devices
 	for (auto &d : devices) {
-		d = std::make_unique<saa1099_device>(machine_config(), "", nullptr, chip_clock, render_divisor);
+		d = std::make_unique<saa1099_device>("", nullptr, chip_clock, render_divisor);
 		d->device_start();
 	}
 

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -45,7 +45,6 @@ typedef uint8_t u8;
 typedef uint32_t u32;
 
 class device_t;
-struct machine_config;
 
 #define NAME( _ASDF_ ) 0
 #define BIT( _INPUT_, _BIT_ ) ( ( _INPUT_) >> (_BIT_)) & 1
@@ -56,24 +55,13 @@ struct machine_config;
 #define READ8_MEMBER(name)              u8     name( int, int)
 #define WRITE8_MEMBER(name)				void   name([[maybe_unused]] int offset, [[maybe_unused]] int space, [[maybe_unused]] u8 data)
 
-#define DECLARE_DEVICE_TYPE(Type, Class) \
-		extern const device_type Type; \
-		class Class;
-
-#define DEFINE_DEVICE_TYPE(Type, Class, ShortName, FullName)		\
-	const device_type Type = 0;
-
 class device_sound_interface {
 public:
 	struct sound_stream {
 		void update() {}
 	};
 
-	sound_stream temp;
-
-	device_sound_interface(const machine_config & /* mconfig */, [[maybe_unused]] device_t &_device)
-	        : temp()
-	{}
+	sound_stream temp = {};
 
 	virtual ~device_sound_interface() = default;
 
@@ -94,9 +82,6 @@ struct attotime {
 	static attotime from_hz([[maybe_unused]] int hz) {
 		return attotime();
 	}
-};
-
-struct machine_config {
 };
 
 typedef int device_type;
@@ -142,9 +127,7 @@ public:
 	void save_item(int, [[maybe_unused]] int blah= 0) {
 	}
 
-	device_t(const machine_config & /* mconfig */,
-	         [[maybe_unused]] device_type type,
-	         const char *short_name,
+	device_t(const char *short_name,
 	         [[maybe_unused]] device_t *owner,
 	         u32 _clock)
 	        : clockRate(_clock),

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -171,10 +171,10 @@ constexpr uint8_t envelope[8][64] = {
 
 #define FILL_ARRAY( _FILL_ ) memset( _FILL_, 0, sizeof( _FILL_ ) )
 
-saa1099_device::saa1099_device(const machine_config &mconfig, const char *tag, device_t *owner,
+saa1099_device::saa1099_device(const char *tag, device_t *owner,
                                const uint32_t clock, const int rate_divisor)
-        : device_t(mconfig, SAA1099, tag, owner, clock),
-          device_sound_interface(mconfig, *this),
+        : device_t(tag, owner, clock),
+          device_sound_interface(),
           m_stream(nullptr),
           m_noise_freqs{2 * clock / 256.0, 2 * clock / 512.0, 2 * clock / 1024.0},
 

--- a/src/hardware/mame/saa1099.h
+++ b/src/hardware/mame/saa1099.h
@@ -29,7 +29,7 @@
 
 class saa1099_device final : public device_t, public device_sound_interface {
 public:
-	saa1099_device(const machine_config &mconfig, const char *tag, device_t *owner,
+	saa1099_device(const char *tag, device_t *owner,
 	               const uint32_t clock, const int rate_divisor);
 
 	saa1099_device(const saa1099_device &) = delete; // prevent copying
@@ -94,7 +94,5 @@ private:
 	double m_sample_rate;
 	int m_chip_clock;
 };
-
-DECLARE_DEVICE_TYPE(SAA1099, saa1099_device)
 
 #endif // MAME_SOUND_SAA1099_H

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -147,9 +147,7 @@
 //When you go over this create sample
 #define RATE_MAX (1 << 10)
 
-sn76496_base_device::sn76496_base_device(const machine_config &mconfig,
-                                         device_type type,
-                                         const char *tag,
+sn76496_base_device::sn76496_base_device(const char *tag,
                                          int feedbackmask,
                                          int noisetap1,
                                          int noisetap2,
@@ -160,8 +158,8 @@ sn76496_base_device::sn76496_base_device(const machine_config &mconfig,
                                          bool sega,
                                          device_t *owner,
                                          uint32_t clock)
-        : device_t(mconfig, type, tag, owner, clock),
-          device_sound_interface(mconfig, *this),
+        : device_t(tag, owner, clock),
+          device_sound_interface(),
           m_ready_state(false),
           m_feedback_mask(feedbackmask),
           m_whitenoise_tap1(noisetap1),
@@ -181,58 +179,58 @@ sn76496_base_device::sn76496_base_device(const machine_config &mconfig,
           rate_counter(0)
 {}
 
-sn76496_device::sn76496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, SN76496, tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)
+sn76496_device::sn76496_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)
 {
 }
 
-u8106_device::u8106_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, U8106, tag, 0x4000, 0x01, 0x02, true, false, 8, false, true, owner, clock)
+u8106_device::u8106_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x4000, 0x01, 0x02, true, false, 8, false, true, owner, clock)
 {
 }
 
-y2404_device::y2404_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, Y2404, tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)
+y2404_device::y2404_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)
 {
 }
 
-sn76489_device::sn76489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, SN76489, tag, 0x4000, 0x01, 0x02, true, false, 8, false, true, owner, clock)
+sn76489_device::sn76489_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x4000, 0x01, 0x02, true, false, 8, false, true, owner, clock)
 {
 }
 
-sn76489a_device::sn76489a_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, SN76489A, tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)
+sn76489a_device::sn76489a_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x10000, 0x04, 0x08, false, false, 8, false, true, owner, clock)
 {
 }
 
-sn76494_device::sn76494_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, SN76494, tag, 0x10000, 0x04, 0x08, false, false, 1, false, true, owner, clock)
+sn76494_device::sn76494_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x10000, 0x04, 0x08, false, false, 1, false, true, owner, clock)
 {
 }
 
-sn94624_device::sn94624_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, SN94624, tag, 0x4000, 0x01, 0x02, true, false, 1, false, true, owner, clock)
+sn94624_device::sn94624_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x4000, 0x01, 0x02, true, false, 1, false, true, owner, clock)
 {
 }
 
-ncr8496_device::ncr8496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, NCR8496, tag, 0x8000, 0x02, 0x20, true, false, 8, true, true, owner, clock)
+ncr8496_device::ncr8496_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x8000, 0x02, 0x20, true, false, 8, true, true, owner, clock)
 {
 }
 
-pssj3_device::pssj3_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, PSSJ3, tag, 0x8000, 0x02, 0x20, false, false, 8, true, true, owner, clock)
+pssj3_device::pssj3_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x8000, 0x02, 0x20, false, false, 8, true, true, owner, clock)
 {
 }
 
-gamegear_device::gamegear_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, GAMEGEAR, tag, 0x8000, 0x01, 0x08, true, true, 8, false, false, owner, clock)
+gamegear_device::gamegear_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x8000, 0x01, 0x08, true, true, 8, false, false, owner, clock)
 {
 }
 
-segapsg_device::segapsg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sn76496_base_device(mconfig, SEGAPSG, tag, 0x8000, 0x01, 0x08, true, false, 8, false, false, owner, clock)
+segapsg_device::segapsg_device(const char *tag, device_t *owner, uint32_t clock)
+	: sn76496_base_device(tag, 0x8000, 0x01, 0x08, true, false, 8, false, false, owner, clock)
 {
 }
 
@@ -520,16 +518,3 @@ void sn76496_base_device::register_for_save_states()
 	save_item(NAME(m_cycles_to_ready));
 //  save_item(NAME(m_sega_style_psg));
 }
-
-DEFINE_DEVICE_TYPE(SN76496,  sn76496_device,   "sn76496",      "SN76496")
-DEFINE_DEVICE_TYPE(U8106,    u8106_device,     "u8106",        "U8106")
-DEFINE_DEVICE_TYPE(Y2404,    y2404_device,     "y2404",        "Y2404")
-DEFINE_DEVICE_TYPE(SN76489,  sn76489_device,   "sn76489",      "SN76489")
-DEFINE_DEVICE_TYPE(SN76489A, sn76489a_device,  "sn76489a",     "SN76489A")
-DEFINE_DEVICE_TYPE(SN76494,  sn76494_device,   "sn76494",      "SN76494")
-DEFINE_DEVICE_TYPE(SN94624,  sn94624_device,   "sn94624",      "SN94624")
-DEFINE_DEVICE_TYPE(NCR8496,  ncr8496_device,   "ncr8496",      "NCR8496")
-DEFINE_DEVICE_TYPE(PSSJ3,    pssj3_device,     "pssj3",        "PSSJ-3")
-DEFINE_DEVICE_TYPE(GAMEGEAR, gamegear_device,  "gamegear_psg", "Game Gear PSG")
-DEFINE_DEVICE_TYPE(SEGAPSG,  segapsg_device,   "segapsg",      "Sega VDP PSG")
-

--- a/src/hardware/mame/sn76496.h
+++ b/src/hardware/mame/sn76496.h
@@ -5,18 +5,6 @@
 #ifndef MAME_SOUND_SN76496_H
 #define MAME_SOUND_SN76496_H
 
-DECLARE_DEVICE_TYPE(SN76496,  sn76496_device)
-DECLARE_DEVICE_TYPE(U8106,    u8106_device)
-DECLARE_DEVICE_TYPE(Y2404,    y2404_device)
-DECLARE_DEVICE_TYPE(SN76489,  sn76489_device)
-DECLARE_DEVICE_TYPE(SN76489A, sn76489a_device)
-DECLARE_DEVICE_TYPE(SN76494,  sn76494_device)
-DECLARE_DEVICE_TYPE(SN94624,  sn94624_device)
-DECLARE_DEVICE_TYPE(NCR8496,  ncr8496_device)
-DECLARE_DEVICE_TYPE(PSSJ3,    pssj3_device)
-DECLARE_DEVICE_TYPE(GAMEGEAR, gamegear_device)
-DECLARE_DEVICE_TYPE(SEGAPSG,  segapsg_device)
-
 #if 0
 
 
@@ -40,8 +28,6 @@ public:
 	void convert_samplerate(int32_t target_rate);
 protected:
 	sn76496_base_device(
-			const machine_config &mconfig,
-			device_type type,
 			const char *tag,
 			int feedbackmask,
 			int noisetap1,
@@ -104,35 +90,35 @@ private:
 class sn76496_device final : public sn76496_base_device
 {
 public:
-	sn76496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sn76496_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // U8106 not verified yet. todo: verify; (a custom marked sn76489? only used on mr. do and maybe other universal games)
 class u8106_device final : public sn76496_base_device
 {
 public:
-	u8106_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	u8106_device( const char *tag, device_t *owner, uint32_t clock);
 };
 
 // Y2404 not verified yet. todo: verify; (don't be fooled by the Y, it's a TI chip, not Yamaha)
 class y2404_device final : public sn76496_base_device
 {
 public:
-	y2404_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	y2404_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // NCR8496 whitenoise verified, phase verified; verified by ValleyBell & NewRisingSun
 class sn76489_device final : public sn76496_base_device
 {
 public:
-	sn76489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sn76489_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // PSSJ-3 whitenoise verified, phase verified; verified by ValleyBell & NewRisingSun
 class pssj3_device final : public sn76496_base_device
 {
 public:
-	pssj3_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	pssj3_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 
@@ -140,42 +126,42 @@ public:
 class sn76489a_device final : public sn76496_base_device
 {
 public:
-	sn76489a_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sn76489a_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // SN76494 not verified, (according to datasheet: same as sn76489a but without the /8 divider)
 class sn76494_device final : public sn76496_base_device
 {
 public:
-	sn76494_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sn76494_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // SN94624 whitenoise verified, phase verified, period verified; verified by PlgDavid
 class sn94624_device final : public sn76496_base_device
 {
 public:
-	sn94624_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sn94624_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // NCR8496 not verified; info from smspower wiki and vgmpf wiki
 class ncr8496_device final : public sn76496_base_device
 {
 public:
-	ncr8496_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ncr8496_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // Verified by Justin Kerk
 class gamegear_device final : public sn76496_base_device
 {
 public:
-	gamegear_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	gamegear_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 // todo: verify; from smspower wiki, assumed to have same invert as gamegear
 class segapsg_device final : public sn76496_base_device
 {
 public:
-	segapsg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	segapsg_device(const char *tag, device_t *owner, uint32_t clock);
 };
 
 #endif // MAME_SOUND_SN76496_H

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -411,7 +411,7 @@ private:
 };
 
 Ps1Synth::Ps1Synth(const std::string_view filter_choice)
-        : device(machine_config(), nullptr, nullptr, ps1_psg_clock_hz)
+        : device(nullptr, nullptr, ps1_psg_clock_hz)
 {
 	const auto callback = std::bind(&Ps1Synth::AudioCallback, this, _1);
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -457,12 +457,10 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 	// Instantiate the MAME PSG device
 	constexpr auto rounded_psg_clock = render_rate_hz * render_divisor;
 	if (config_profile == ConfigProfile::PCjrSystem)
-		device = std::make_unique<sn76496_device>(machine_config(),
-		                                          "SN76489", nullptr,
+		device = std::make_unique<sn76496_device>("SN76489", nullptr,
 		                                          rounded_psg_clock);
 	else
-		device = std::make_unique<ncr8496_device>(machine_config(),
-		                                          "NCR 8496", nullptr,
+		device = std::make_unique<ncr8496_device>("NCR 8496", nullptr,
 		                                          rounded_psg_clock);
 	// Register the write ports
 	constexpr io_port_t base_addr = 0xc0;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -624,6 +624,7 @@ bool DOS_Shell::GetEnvStr(const char* entry, std::string& result) const
 	if (!entry[0]) {
 		return false;
 	}
+	const auto entry_length = strlen(entry);
 	do {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {
@@ -636,7 +637,7 @@ bool DOS_Shell::GetEnvStr(const char* entry, std::string& result) const
 		}
 		/* replace the = with \0 to get the length */
 		*equal = 0;
-		if (strlen(env_string) != strlen(entry)) {
+		if (strlen(env_string) != entry_length) {
 			continue;
 		}
 		if (strcasecmp(entry, env_string) != 0) {


### PR DESCRIPTION
# Description

Got rid of 5 PVS Studio warnings - 14 in audio code (it was enough to remove one empty, unused structure; removed some additional unneeded elements due to old GCC complaining) and 1 in shell code (multiple call to `strlen` in a loop, for the same string).

# Manual testing

Type `set` inside the emulator - it should print out environment variables as before the change.
Tried _Civilization_ game on Tandy setting - Tandy audio works.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

