### PR TITLE
Fix memory access in VirtualBox device, enable VirtualBox mouse protocol

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -26,12 +26,6 @@
 #include <string>
 #include <vector>
 
-// In many cases the VirtualBox mouse protocol does not work correctly yet, thus
-// it is disabled for now - if you want to enable it, read the  'IMPORTANT NOTE'
-// in 'virtualbox.cpp' and uncomment line below:
-
-// #define EXPERIMENTAL_VIRTUALBOX_MOUSE
-
 // ***************************************************************************
 // Initialization, configuration
 // ***************************************************************************

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -247,6 +247,8 @@ public:
 	const std::vector<MousePhysicalInfoEntry> &GetInfoPhysical();
 
 	static bool IsNoMouseMode();
+	static bool IsMappingBlockedByDriver();
+	
 	static bool CheckInterfaces(const ListIDs &list_ids);
 	static bool PatternToRegex(const std::string &pattern, std::regex &regex);
 

--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -325,6 +325,21 @@ void MOUSECTL::FinalizeMapping()
 	WriteOut("\n\n");
 }
 
+bool MOUSECTL::CheckMappingPossible()
+{
+	if (MouseControlAPI::IsNoMouseMode()) {
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE"));
+		return false;
+	}
+
+	if (MouseControlAPI::IsMappingBlockedByDriver()) {
+		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAPPING_BLOCKED_BY_DRIVER"));
+		return false;
+	}
+
+	return true;
+}
+
 bool MOUSECTL::CmdMap(const MouseInterfaceId interface_id, const std::string &pattern)
 {
 	std::regex regex;
@@ -333,8 +348,7 @@ bool MOUSECTL::CmdMap(const MouseInterfaceId interface_id, const std::string &pa
 		return false;
 	}
 
-	if (MouseControlAPI::IsNoMouseMode()) {
-		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE"));
+	if (!CheckMappingPossible()) {
 		return false;
 	}
 
@@ -352,8 +366,7 @@ bool MOUSECTL::CmdMap()
 {
 	assert(!list_ids.empty());
 
-	if (MouseControlAPI::IsNoMouseMode()) {
-		WriteOut(MSG_Get("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE"));
+	if (!CheckMappingPossible()) {
 		return false;
 	}
 
@@ -550,6 +563,8 @@ void MOUSECTL::AddMessages()
 
 	MSG_Add("PROGRAM_MOUSECTL_MAPPING_NO_MOUSE",
 	        "Mapping not available in no-mouse mode.\n");
+	MSG_Add("PROGRAM_MOUSECTL_MAPPING_BLOCKED_BY_DRIVER",
+	        "Mapping not possible with current guest mouse driver.\n");
 	MSG_Add("PROGRAM_MOUSECTL_NO_INTERFACES",
 	        "No mouse interfaces available.\n");
 	MSG_Add("PROGRAM_MOUSECTL_MISSING_INTERFACES",

--- a/src/dos/program_mousectl.h
+++ b/src/dos/program_mousectl.h
@@ -43,6 +43,7 @@ private:
 	bool ParseSensitivity(const std::string &param, int16_t &value);
 	static bool ParseIntParam(const std::string &param, int &value);
 	bool CheckInterfaces();
+	bool CheckMappingPossible();
 	void FinalizeMapping();
 
 	static const char *GetMapStatusStr(const MouseMapStatus map_status);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -344,14 +344,22 @@ bool GFX_HaveDesktopEnvironment()
 	// https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
 	// https://askubuntu.com/questions/72549/how-to-determine-which-window-manager-and-desktop-environment-is-running
 	// https://unix.stackexchange.com/questions/116539/how-to-detect-the-desktop-environment-in-a-bash-script
-	//
-	constexpr const char* vars[] = {"XDG_CURRENT_DESKTOP",
-	                                "XDG_SESSION_DESKTOP",
-	                                "DESKTOP_SESSION",
-	                                "GDMSESSION"};
 
-	return std::any_of(std::begin(vars), std::end(vars), std::getenv);
+	static bool already_checked          = false;
+	static bool have_desktop_environment = false;
+	if (!already_checked) {
+		constexpr const char* vars[] = {"XDG_CURRENT_DESKTOP",
+		                                "XDG_SESSION_DESKTOP",
+		                                "DESKTOP_SESSION",
+		                                "GDMSESSION"};
 
+		have_desktop_environment = std::any_of(std::begin(vars),
+		                                       std::end(vars),
+		                                       std::getenv);
+		already_checked = true;
+	}
+
+	return have_desktop_environment;
 #else
 	// Assume we have a desktop environment on all other systems
 	return true;

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -239,12 +239,8 @@ static void config_read(Section *section)
 
 	// VMM PCI interfaces
 
-#ifdef EXPERIMENTAL_VIRTUALBOX_MOUSE
-
 	mouse_config.is_vmware_mouse_enabled = conf->Get_bool("vmware_mouse");
 	mouse_config.is_virtualbox_mouse_enabled = conf->Get_bool("virtualbox_mouse");
-
-#endif
 
 	// Start mouse emulation if everything is ready
 	mouse_shared.ready_config = true;
@@ -374,16 +370,12 @@ static void config_init(Section_prop &secprop)
 
 	// VMM interfaces
 
-#ifdef EXPERIMENTAL_VIRTUALBOX_MOUSE
-
 	prop_bool = secprop.Add_bool("vmware_mouse", only_at_start, true);
 	prop_bool->Set_help("VMware mouse interface (enabled by default).\n"
-	                    "Note: This requires PS/2 mouse to be enabled.\n");
+	                    "Note: This requires PS/2 mouse to be enabled.");
 	prop_bool = secprop.Add_bool("virtualbox_mouse", only_at_start, true);
 	prop_bool->Set_help("VirtualBox mouse interface (enabled by default).\n"
-	                    "Note: This requires PS/2 mouse to be enabled.\n");
-
-#endif
+	                    "Note: This requires PS/2 mouse to be enabled.");
 }
 
 void MOUSE_AddConfigSection(const config_ptr_t& conf)

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -91,13 +91,8 @@ struct MouseConfig {
 	MouseModelCOM model_com = MouseModelCOM::Wheel;
 	bool model_com_auto_msm = true;
 
-#ifdef EXPERIMENTAL_VIRTUALBOX_MOUSE
 	bool is_vmware_mouse_enabled     = false;
 	bool is_virtualbox_mouse_enabled = false;
-#else
-	bool is_vmware_mouse_enabled     = true;
-	bool is_virtualbox_mouse_enabled = false;
-#endif
 
 	// Helper functions for external modules
 


### PR DESCRIPTION
# Description

Problem reason: VirtualBox device implementation used memory access function which were paging aware, while we are supposed to use functions which ignore paging. This is now fixed, plus several other improvements were implemented - back then I didn't test the support too much when I realized it didn't work with Windows.

### Limitations

#### DOS driver

Unfortunately, the unofficial VirtualBox DOS mouse driver works reliably only when real MS-DOS is booted, with our simulated DOS it is unusable. Hopefully, this is not a serious problem, as our driver already provides seamless mouse integration.

#### Mouse mapping

If we map a physical mouse A to our virtual DOS driver, and a physical mouse B to a PS/2 driver, and guest side is using mouse driver with virtual machine integration - we have a problem.
In case of VMware driver, we cheat to the driver: we pretend the integration is OK, but in reality the driver only gets events from the selected physical mouse.
With VirtualBox protocol... the driver can tell us that it won't be drawing the cursor by itself, and we should just show the host OS cursor. And we have no good way to reject the request from the driver (especially once it is already running...), and we have absolutely no way to tell the host OS to use only the particular selected mouse and ignore all the others.
If something like this happens, we are removing all the mouse mappings to prevent problems.

#### Desktop-less environment, without host mouse cursor

Same problem might happen on some exotic environments, when the guest side driver wants us to draw host side mouse cursor, and we have no possibility to do so.
Since there is no easy way to handle this situation gracefully (unless we want to emulate part of the desktop environment and draw our own mouse cursor), VirtualBox mouse interface is disabled in such environments - it's not useful in this case anyway.

# Manual testing

Played with the drivers:

- unofficial Windows 3.x driver: https://git.javispedro.com/cgit/vbmouse.git/about/
- unofficial DOS driver: https://git.javispedro.com/cgit/vbados.git/about/

The Windows 3.x driver seems to be very stable, plus if the VirtualBox mouse protocol is disabled, it reverts to classic PS/2.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

