### PR TITLE
Fix double-scanning & pixel-doubling handling in `openglnb` output mode

### DIFF
--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -549,30 +549,47 @@ static bool force_square_pixels     = false;
 static bool force_vga_single_scan   = false;
 static bool force_no_pixel_doubling = false;
 
-// We double-scan VGA modes and pixel-double all video modes by default unless:
+// Double-scan VGA modes and pixel-double all video modes by default unless:
 //
-//  1) Single-scanning or no pixel-doubling is forced by the OpenGL shader.
-//  2) The interpolation mode is nearest-neighbour.
+//  1) Single-scanning or no pixel-doubling is requested by the OpenGL shader.
+//  2) The interpolation mode is nearest-neighbour in texture output mode.
 //
-// About the first point: the default `interpolation/sharp.glsl` shader forces
-// both because it scales pixels as flat adjacent rectangles. This not only
-// produces identical output versus double-scanning and pixel-doubling, but
-// also provides finer integer scaling steps (especially important on sub-4K
-// screens) and improves performance on low-end systems like the Raspberry Pi.
+// The default `interpolation/sharp.glsl` shader requests both single-scanning
+// and no pixel-doubling because it scales pixels as flat adjacent rectangles.
+// This not only produces identical output versus double-scanning and
+// pixel-doubling, but also provides finer integer scaling steps (especially
+// important on sub-4K screens), plus improves performance on low-end systems
+// like the Raspberry Pi.
+//
+// The same reasoning applies to nearest-neighbour interpolation in texture
+// output mode.
 //
 static void setup_scan_and_pixel_doubling()
 {
-	const auto nearest_neighbour_enabled = (GFX_GetInterpolationMode() ==
-	                                        InterpolationMode::NearestNeighbour);
+	const auto nearest_neighbour_on = (GFX_GetInterpolationMode() ==
+	                                   InterpolationMode::NearestNeighbour);
 
-	force_vga_single_scan   = nearest_neighbour_enabled;
-	force_no_pixel_doubling = nearest_neighbour_enabled;
+	switch (GFX_GetRenderingBackend()) {
+	case RenderingBackend::Texture:
+		force_vga_single_scan   = nearest_neighbour_on;
+		force_no_pixel_doubling = nearest_neighbour_on;
+		break;
 
-	if (GFX_GetRenderingBackend() == RenderingBackend::OpenGl) {
+	case RenderingBackend::OpenGl: {
 		const auto shader_info = get_shader_manager().GetCurrentShaderInfo();
+		const auto none_shader_active = (shader_info.name == NoneShaderName);
 
-		force_vga_single_scan |= shader_info.settings.force_single_scan;
-		force_no_pixel_doubling |= shader_info.settings.force_no_pixel_doubling;
+		const auto double_scan_enabled = (nearest_neighbour_on &&
+		                                  none_shader_active);
+
+		force_vga_single_scan = (shader_info.settings.force_single_scan ||
+		                         double_scan_enabled);
+
+		force_no_pixel_doubling = (shader_info.settings.force_no_pixel_doubling ||
+		                           double_scan_enabled);
+	} break;
+
+	default: assertm(false, "Invalid RenderindBackend value");
 	}
 
 	VGA_EnableVgaDoubleScanning(!force_vga_single_scan);

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -29,7 +29,8 @@
 // forward references
 class Fraction;
 
-constexpr auto FallbackShaderName = "none";
+constexpr auto NoneShaderName     = "none";
+constexpr auto FallbackShaderName = NoneShaderName;
 constexpr auto SharpShaderName    = "interpolation/sharp";
 
 constexpr auto AutoGraphicsStandardShaderName = "crt-auto";


### PR DESCRIPTION
# Description

The adaptive CRT shader always forced single-scanning in `openglnb` output modes which was wrong (e.g., 320x200 content always appeared single-scanned). This fix corrects that. See the updated comments block for the fixed double-scanning/pixel-doubling criteria.

The issue was reported by @SmilingSpectre and mmpp0 on the eXoDOS Discord.

# Manual testing

- Commented out the debug logging at the end of `log_display_properties()` in `sdlmain.cpp` to log the actual rendered dimensions as well.
- Verified the correct double-scanning & pixel-doubling behaviour for `opengl`, `openglnb`, `texture` and `texturenb` for all VGA modes in Deluxe Paint II (both visually and by looking at the debug logs; 320x200 modes should result in 640x400 render dimensions for VGA).
- Verified that the `output = opengl` + `glshader = none` special case results in doubling for VGA modes (i.e., 640x400 render dimensions for 320x200 modes).
- Verified that the `output = openglnb` + `glshader = none` special case results in _no_ doubling for VGA modes (i.e., 320x200 render dimensions for 320x200 modes).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

