### PR TITLE
Move environment functions to psp (+ other small changes)

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -55,7 +55,7 @@ public:
 
 class HostShell {
 public:
-	virtual bool GetEnvStr(const char* entry, std::string& result) const = 0;
+	virtual std::optional<std::string> GetEnvStr(std::string_view entry) const = 0;
 
 	HostShell()                            = default;
 	HostShell(const HostShell&)            = delete;
@@ -162,7 +162,7 @@ public:
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
-	bool GetEnvStr(const char* entry, std::string& result) const override;
+	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
 	bool GetEnvNum(Bitu num, std::string& result) const;
 	[[nodiscard]] Bitu GetEnvCount() const;
 	bool SetEnv(std::string_view entry, std::string_view new_string);

--- a/include/shell.h
+++ b/include/shell.h
@@ -163,8 +163,7 @@ public:
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
 	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
-	bool GetEnvNum(Bitu num, std::string& result) const;
-	[[nodiscard]] Bitu GetEnvCount() const;
+	std::vector<std::string> GetAllEnvVars() const;
 	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 	/* Commands */

--- a/include/shell.h
+++ b/include/shell.h
@@ -165,7 +165,7 @@ public:
 	bool GetEnvStr(const char* entry, std::string& result) const override;
 	bool GetEnvNum(Bitu num, std::string& result) const;
 	[[nodiscard]] Bitu GetEnvCount() const;
-	bool SetEnv(const char* entry, const char* new_string);
+	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 	/* Commands */
 	void CMD_HELP(char* args);

--- a/include/shell.h
+++ b/include/shell.h
@@ -150,8 +150,8 @@ public:
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
-	std::optional<std::string> GetEnvStr(std::string_view entry) const;
-	std::vector<std::string> GetAllEnvVars() const;
+	// HACK: Don't use in new code
+	// TODO: Remove the call to this function from autoexec
 	bool SetEnv(std::string_view entry, std::string_view new_string);
 
 	/* Commands */

--- a/include/shell.h
+++ b/include/shell.h
@@ -103,6 +103,25 @@ struct SHELL_Cmd {
 	HELP_Category category = HELP_Category::Misc;
 };
 
+class ShellHistory {
+public:
+	std::vector<std::string> GetCommands(uint16_t code_page) const;
+	void Append(std::string command, uint16_t code_page);
+
+	ShellHistory();
+	~ShellHistory();
+	ShellHistory(const ShellHistory&)            = delete;
+	ShellHistory& operator=(const ShellHistory&) = delete;
+	ShellHistory(ShellHistory&&)                 = delete;
+	ShellHistory& operator=(ShellHistory&&)      = delete;
+
+private:
+	std::vector<std::string> commands{};
+	std_fs::path path;
+};
+
+extern std::unique_ptr<ShellHistory> global_shell_history;
+
 class DOS_Shell : public Program, public HostShell {
 private:
 	void PrintHelpForCommands(MoreOutputStrings& output, HELP_Filter req_filter);
@@ -113,15 +132,17 @@ private:
 	[[nodiscard]] std::string Which(std::string_view name) const;
 
 	friend class AutoexecEditor;
-	std::vector<std::string> utf8_history{};
-	std::stack<BatchFile> batchfiles{};
 
+	ShellHistory& history                  = *global_shell_history;
+	std::stack<BatchFile> batchfiles       = {};
+	uint16_t input_handle                  = STDIN;
+	bool call                              = false;
 	bool exit_cmd_called                   = false;
 	static inline bool help_list_populated = false;
 
 public:
 	DOS_Shell();
-	~DOS_Shell() override = default;
+	~DOS_Shell() override                  = default;
 	DOS_Shell(const DOS_Shell&)            = delete; // prevent copy
 	DOS_Shell& operator=(const DOS_Shell&) = delete; // prevent assignment
 	void Run() override;
@@ -140,9 +161,6 @@ public:
 	virtual bool ExecuteShellCommand(const char* const name, char* arguments);
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
-
-	void ReadShellHistory();
-	void WriteShellHistory();
 
 	bool GetEnvStr(const char* entry, std::string& result) const override;
 	bool GetEnvNum(Bitu num, std::string& result) const;
@@ -183,10 +201,7 @@ public:
 	void CMD_VOL(char* args);
 	void CMD_MOVE(char* args);
 
-	/* The shell's variables */
-	uint16_t input_handle         = 0;
-	bool echo                     = false;
-	bool call                     = false;
+	bool echo = true;
 };
 
 std::tuple<std::string, std::string, std::string, bool> parse_drive_conf(

--- a/include/shell.h
+++ b/include/shell.h
@@ -53,21 +53,9 @@ public:
 	virtual ~ByteReader()                    = default;
 };
 
-class HostShell {
-public:
-	virtual std::optional<std::string> GetEnvStr(std::string_view entry) const = 0;
-
-	HostShell()                            = default;
-	HostShell(const HostShell&)            = delete;
-	HostShell& operator=(const HostShell&) = delete;
-	HostShell(HostShell&&)                 = delete;
-	HostShell& operator=(HostShell&&)      = delete;
-	virtual ~HostShell()                   = default;
-};
-
 class BatchFile {
 public:
-	BatchFile(const HostShell& host, std::unique_ptr<ByteReader> input_reader,
+	BatchFile(const Environment& host, std::unique_ptr<ByteReader> input_reader,
 	          std::string_view entered_name, std::string_view cmd_line,
 	          bool echo_on);
 	BatchFile(const BatchFile&)            = delete;
@@ -86,7 +74,7 @@ private:
 	[[nodiscard]] std::string ExpandedBatchLine(std::string_view line) const;
 	[[nodiscard]] std::string GetLine();
 
-	const HostShell& shell;
+	const Environment& shell;
 	CommandLine cmd;
 	std::unique_ptr<ByteReader> reader;
 	bool echo;
@@ -122,7 +110,7 @@ private:
 
 extern std::unique_ptr<ShellHistory> global_shell_history;
 
-class DOS_Shell : public Program, public HostShell {
+class DOS_Shell : public Program {
 private:
 	void PrintHelpForCommands(MoreOutputStrings& output, HELP_Filter req_filter);
 	void AddShellCmdsToHelpList();
@@ -162,7 +150,7 @@ public:
 	bool ExecuteProgram(std::string_view name, std::string_view args);
 	bool ExecuteConfigChange(const char* const cmd_in, const char* const line);
 
-	std::optional<std::string> GetEnvStr(std::string_view entry) const override;
+	std::optional<std::string> GetEnvStr(std::string_view entry) const;
 	std::vector<std::string> GetAllEnvVars() const;
 	bool SetEnv(std::string_view entry, std::string_view new_string);
 

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #include "mem.h"
+#include "string_utils.h"
 #include "support.h"
 
 static void dos_memset(PhysPt addr, uint8_t val, size_t n)
@@ -305,6 +306,119 @@ bool DOS_PSP::SetNumFiles(uint16_t file_num)
 		SSET_DWORD(sPSP, file_table, data);
 	}
 	SSET_WORD(sPSP, max_files, file_num);
+	return true;
+}
+
+static constexpr auto bytes_to_read = 1024;
+
+std::optional<std::string> DOS_PSP::GetEnvironmentValue(const std::string_view variable) const
+{
+	/* Walk through the internal environment and see for a match */
+	PhysPt env_read = PhysicalMake(GetEnvironment(), 0);
+
+	char env_string[bytes_to_read + 1];
+	if (variable.empty()) {
+		return {};
+	}
+
+	for (;;) {
+		MEM_StrCopy(env_read, env_string, bytes_to_read);
+		if (!env_string[0]) {
+			return {};
+		}
+		env_read += (PhysPt)(safe_strlen(env_string) + 1);
+		char* equal = strchr(env_string, '=');
+		if (!equal) {
+			continue;
+		}
+		/* replace the = with \0 to get the length */
+		*equal = '\0';
+		if (strlen(env_string) != variable.size()) {
+			continue;
+		}
+		if (!iequals(variable, env_string)) {
+			continue;
+		}
+
+		return env_string + variable.size() + sizeof('=');
+	}
+}
+
+std::vector<std::string> DOS_PSP::GetAllRawEnvironmentStrings() const
+{
+	std::vector<std::string> all_env_vars = {};
+
+	char env_string[bytes_to_read + 1];
+	PhysPt env_read = PhysicalMake(GetEnvironment(), 0);
+	for (;;) {
+		MEM_StrCopy(env_read, env_string, bytes_to_read);
+		if (!env_string[0]) {
+			return all_env_vars;
+		}
+		all_env_vars.emplace_back(env_string);
+		env_read += (PhysPt)(safe_strlen(env_string) + 1);
+	}
+}
+
+bool DOS_PSP::SetEnvironmentValue(std::string_view variable, std::string_view new_string)
+{
+	PhysPt env_read = PhysicalMake(GetEnvironment(), 0);
+
+	// Get size of environment.
+	DOS_MCB mcb(GetEnvironment() - 1);
+	uint16_t envsize = mcb.GetSize() * 16;
+
+	PhysPt env_write                   = env_read;
+	PhysPt env_write_start             = env_read;
+	char env_string[bytes_to_read + 1] = {0};
+	const auto entry_length            = variable.size();
+	do {
+		MEM_StrCopy(env_read, env_string, bytes_to_read);
+		if (!env_string[0]) {
+			break;
+		}
+		env_read += (PhysPt)(safe_strlen(env_string) + 1);
+		if (!strchr(env_string, '=')) {
+			continue; /* Remove corrupt entry? */
+		}
+		if (iequals(variable,
+		            std::string_view(env_string).substr(0, entry_length)) &&
+		    env_string[entry_length] == '=') {
+			continue;
+		}
+		MEM_BlockWrite(env_write,
+		               env_string,
+		               (Bitu)(safe_strlen(env_string) + 1));
+		env_write += (PhysPt)(safe_strlen(env_string) + 1);
+	} while (true);
+	/* TODO Maybe save the program name sometime. not really needed though */
+	/* Save the new entry */
+
+	// ensure room
+	if (envsize <= (env_write - env_write_start) + variable.size() + 1 +
+	                       new_string.size() + 2) {
+		return false;
+	}
+
+	if (!new_string.empty()) {
+		std::string bigentry(variable);
+		for (std::string::iterator it = bigentry.begin();
+		     it != bigentry.end();
+		     ++it) {
+			*it = toupper(*it);
+		}
+		snprintf(env_string,
+		         bytes_to_read + 1,
+		         "%s=%s",
+		         bigentry.c_str(),
+		         std::string(new_string).c_str());
+		MEM_BlockWrite(env_write,
+		               env_string,
+		               (Bitu)(safe_strlen(env_string) + 1));
+		env_write += (PhysPt)(safe_strlen(env_string) + 1);
+	}
+	/* Clear out the final piece of the environment */
+	mem_writeb(env_write, 0);
 	return true;
 }
 

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -59,7 +59,8 @@ void MOUNT::Move_Z(char new_z)
 		/* Update environment */
 		std::string line = "";
 		std::string tempenv = {new_drive_z, ':', '\\'};
-		if (first_shell->GetEnvStr("PATH",line)) {
+		if (const auto result = first_shell->GetEnvStr("PATH")) {
+			line = *result;
 			std::string::size_type idx = line.find('=');
 			std::string value = line.substr(idx +1 , std::string::npos);
 			while ( (idx = value.find("Z:\\")) != std::string::npos ||

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -61,8 +61,8 @@ void MOUNT::Move_Z(char new_z)
 		/* Update environment */
 		std::string value   = {};
 		std::string tempenv = {new_drive_z, ':', '\\'};
-		if (const auto result = first_shell->GetEnvStr("PATH")) {
-			value                      = *result;
+		if (const auto result = psp->GetEnvironmentValue("PATH")) {
+			value = *result;
 			std::string::size_type idx = {};
 			while ((idx = value.find("Z:\\")) != std::string::npos ||
 			       (idx = value.find("z:\\")) != std::string::npos) {

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -55,23 +55,25 @@ void MOUNT::Move_Z(char new_z)
 		/* remap drives */
 		Drives[new_idx] = Drives[25];
 		Drives[25]      = nullptr;
-		if (!first_shell) return; //Should not be possible
+		if (!first_shell) {
+			return; // Should not be possible
+		}
 		/* Update environment */
-		std::string line = "";
+		std::string value   = {};
 		std::string tempenv = {new_drive_z, ':', '\\'};
 		if (const auto result = first_shell->GetEnvStr("PATH")) {
-			line = *result;
-			std::string::size_type idx = line.find('=');
-			std::string value = line.substr(idx +1 , std::string::npos);
-			while ( (idx = value.find("Z:\\")) != std::string::npos ||
-				(idx = value.find("z:\\")) != std::string::npos  )
-				value.replace(idx,3,tempenv);
-			line = std::move(value);
+			value                      = *result;
+			std::string::size_type idx = {};
+			while ((idx = value.find("Z:\\")) != std::string::npos ||
+			       (idx = value.find("z:\\")) != std::string::npos) {
+				value.replace(idx, 3, tempenv);
+			}
+		} else {
+			value = tempenv;
 		}
-		if (!line.size()) line = tempenv;
-		first_shell->SetEnv("PATH",line.c_str());
+		first_shell->SetEnv("PATH", value);
 		tempenv += "COMMAND.COM";
-		first_shell->SetEnv("COMSPEC",tempenv.c_str());
+		first_shell->SetEnv("COMSPEC", tempenv);
 
 		/* Change the active drive */
 		if (DOS_GetDefaultDrive() == 25)

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -71,9 +71,15 @@ void MOUNT::Move_Z(char new_z)
 		} else {
 			value = tempenv;
 		}
-		first_shell->SetEnv("PATH", value);
+
 		tempenv += "COMMAND.COM";
-		first_shell->SetEnv("COMSPEC", tempenv);
+
+		auto psp_copy = DOS_PSP(psp->GetSegment());
+		while (psp_copy.GetSegment() != DOS_PSP::rootpsp) {
+			psp_copy = DOS_PSP(psp_copy.GetParent());
+			psp_copy.SetEnvironmentValue("PATH", value);
+			psp_copy.SetEnvironmentValue("COMSPEC", tempenv);
+		}
 
 		/* Change the active drive */
 		if (DOS_GetDefaultDrive() == 25)

--- a/src/dos/program_setver.cpp
+++ b/src/dos/program_setver.cpp
@@ -183,9 +183,11 @@ void SETVER::Run()
 
 	// Handle per-file version set
 	if (has_arg_batch || has_arg_paged) {
-		WriteOut(MSG_Get("SHELL_WRONG_SYNTAX"));
+		WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 	} else if (params.size() > 2) {
 		WriteOut(MSG_Get("SHELL_TOO_MANY_PARAMETERS"));
+	} else if (params.size() < 2) {
+		WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 	} else {
 		CommandSet(params[0], params[1], has_arg_quiet);
 	}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1217,6 +1217,8 @@ void DOSBOX_Init()
 	pstring = secprop->Add_path("shell_history_file",
 	                            only_at_start,
 	                            "shell_history.txt");
+	global_shell_history = std::make_unique<ShellHistory>();
+
 	pstring->Set_help(
 	        "File containing persistent command line history ('shell_history.txt'\n"
 	        "by default). Setting it to empty disables persistent shell history.");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -752,7 +752,9 @@ void CONFIG::Run(void)
 					std::string val = sec->GetPropValue(
 					        pvars[0].c_str());
 					WriteOut("%s", val.c_str());
-					first_shell->SetEnv("CONFIG", val.c_str());
+					DOS_PSP(psp->GetParent())
+					        .SetEnvironmentValue("CONFIG",
+					                             val.c_str());
 				}
 				break;
 			}
@@ -774,7 +776,8 @@ void CONFIG::Run(void)
 					return;
 				}
 				WriteOut("%s\n", val.c_str());
-				first_shell->SetEnv("CONFIG", val.c_str());
+				DOS_PSP(psp->GetParent())
+				        .SetEnvironmentValue("CONFIG", val.c_str());
 				break;
 			}
 			default:

--- a/src/shell/file_reader.h
+++ b/src/shell/file_reader.h
@@ -27,32 +27,23 @@
 #include "shell.h"
 
 class FileReader final : public ByteReader {
-private:
-	// Exists to effectively make the FileReader constructor private
-	// It still needs to be public for internal use with std::make_unique
-	struct PrivateOnly {
-		explicit PrivateOnly() = default;
-	};
-
 public:
-	[[nodiscard]] static std::optional<std::unique_ptr<FileReader>> GetFileReader(
-	        std::string_view file);
+	static std::optional<FileReader> GetFileReader(const std::string& file);
 
 	void Reset() final;
-	[[nodiscard]] std::optional<uint8_t> Read() final;
+	std::optional<uint8_t> Read() final;
 
-	FileReader(std::string_view filename, PrivateOnly key);
 	~FileReader() final;
 
 	FileReader(const FileReader&)            = delete;
 	FileReader& operator=(const FileReader&) = delete;
-	FileReader(FileReader&&)                 = delete;
-	FileReader& operator=(FileReader&&)      = delete;
+
+	FileReader(FileReader&& other) noexcept;
+	FileReader& operator=(FileReader&& other) noexcept;
 
 private:
-	std::string filename = {};
-	uint16_t handle      = 0;
-	bool valid;
+	explicit FileReader(uint16_t file_handle);
+	std::optional<uint16_t> handle;
 };
 
 #endif

--- a/src/shell/meson.build
+++ b/src/shell/meson.build
@@ -5,6 +5,7 @@ libshell_sources = files(
     'shell.cpp',
     'shell_batch.cpp',
     'shell_cmds.cpp',
+    'shell_history.cpp',
     'shell_misc.cpp',
 )
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -279,9 +279,15 @@ void DOS_Shell::ParseLine(char *line)
 	char pipe_tempfile[270]; // Piping requires the use of a temporary file
 	FatAttributeFlags fattr = {};
 	if (pipe_file.length()) {
+		auto result = GetEnvStr("TEMP");
+		if (!result) {
+			result = GetEnvStr("TMP");
+		}
 		std::string env_temp_path = {};
-		if (!GetEnvStr("TEMP", env_temp_path) &&
-		    !GetEnvStr("TMP", env_temp_path)) {
+		if (result) {
+			env_temp_path = *result;
+		}
+		if (env_temp_path.empty()) {
 			safe_sprintf(pipe_tempfile,
 			             "pipe%d.tmp",
 			             get_tick_random_number());

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -38,13 +38,11 @@
 #include "support.h"
 #include "timer.h"
 
-constexpr int HistoryMaxLineSize = 256;
-constexpr int HistoryMaxNumLines = 500;
-
 callback_number_t call_shellstop = 0;
 /* Larger scope so shell_del autoexec can use it to
  * remove things from the environment */
 DOS_Shell *first_shell = nullptr;
+std::unique_ptr<ShellHistory> global_shell_history;
 
 static Bitu shellstop_handler()
 {
@@ -56,10 +54,6 @@ std::unique_ptr<Program> SHELL_ProgramCreate() {
 }
 
 DOS_Shell::DOS_Shell()
-        : Program(),
-          input_handle(STDIN),
-          echo(true),
-          call(false)
 {
 	AddShellCmdsToHelpList();
 	help_detail = {HELP_Filter::All,
@@ -454,73 +448,6 @@ void DOS_Shell::Run()
 void DOS_Shell::SyntaxError()
 {
 	WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
-}
-
-static std_fs::path get_shell_history_path()
-{
-	const auto section = static_cast<Section_prop*>(control->GetSection("dos"));
-	if (section) {
-		const auto path = section->Get_path("shell_history_file");
-		if (path) {
-			return path->realpath;
-		}
-	}
-	return {};
-}
-
-void DOS_Shell::ReadShellHistory()
-{
-	const auto history_path = get_shell_history_path();
-	if (history_path.empty()) {
-		return;
-	}
-	std::ifstream history_file(history_path);
-	if (history_file) {
-		std::string line;
-		while (getline(history_file, line)) {
-			trim(line);
-			auto len = line.length();
-			if (len > 0 && len <= HistoryMaxLineSize) {
-				utf8_history.emplace_back(std::move(line));
-			}
-		}
-	}
-}
-
-void DOS_Shell::WriteShellHistory()
-{
-	const auto history_path = get_shell_history_path();
-	if (history_path.empty()) {
-		return;
-	}
-	std::ofstream history_file(history_path);
-	if (!history_file) {
-		LOG_WARNING("SHELL: Unable to update history file: '%s'",
-		            history_path.string().c_str());
-		return;
-	}
-	std::vector<std::string> trimmed_history;
-	trimmed_history.reserve(utf8_history.size());
-	for (std::string str : utf8_history) {
-		trim(str);
-		auto len = str.length();
-		if (len > 0 && len <= HistoryMaxLineSize) {
-			trimmed_history.emplace_back(std::move(str));
-		}
-	}
-	// Remove "exit" from the history if it is the last command entered
-	if (!trimmed_history.empty()) {
-		std::string last = trimmed_history.back();
-		lowcase(last);
-		if (last == "exit") {
-			trimmed_history.pop_back();
-		}
-	}
-	int size = static_cast<int>(trimmed_history.size());
-	int start = std::max(0, size - HistoryMaxNumLines);
-	for (int i = start; i < size; ++i) {
-		history_file << trimmed_history[i] << std::endl;
-	}
 }
 
 extern int64_t ticks_at_program_launch;
@@ -1444,19 +1371,9 @@ void SHELL_Init() {
 	// first_shell is only setup here, so may as well invoke
 	// it's constructor directly
 	first_shell = new DOS_Shell;
-
-	// Must check arguments directly as control->SwitchToSecureMode()
-	// will not be called until the first shell is run
-	if (!control->arguments.securemode) {
-		first_shell->ReadShellHistory();
-	}
 	first_shell->Run();
-
-	// Secure mode can be enabled from the shell during runtime.
-	// On exit, we must check this value instead.
-	if (!control->SecureMode()) {
-		first_shell->WriteShellHistory();
-	}
 	delete first_shell;
 	first_shell = nullptr; // Make clear that it shouldn't be used anymore
+	
+	global_shell_history.reset();
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -292,15 +292,13 @@ void DOS_Shell::ParseLine(char *line)
 			             "pipe%d.tmp",
 			             get_tick_random_number());
 		} else {
-			const auto idx   = env_temp_path.find('=');
-			std::string temp = env_temp_path.substr(idx + 1,
-			                                        std::string::npos);
-			if (DOS_GetFileAttr(temp.c_str(), &fattr) && fattr.directory) {
+			if (DOS_GetFileAttr(env_temp_path.c_str(), &fattr) &&
+			    fattr.directory) {
 				safe_sprintf(pipe_tempfile,
 				             "%s\\pipe%d.tmp",
-				             temp.c_str(),
+				             env_temp_path.c_str(),
 				             get_tick_random_number());
-			} else
+		        } else
 				safe_sprintf(pipe_tempfile, "pipe%d.tmp",
 				             get_tick_random_number());
 		}

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -122,13 +122,10 @@ std::string BatchFile::ExpandedBatchLine(std::string_view line) const
 			if (closing_percent == std::string::npos) {
 				break;
 			}
-			std::string env_key(line.substr(0, closing_percent));
 
-			// Get the key's corresponding value from the environment
-			if (const auto env_val = shell.GetEnvStr(env_key)) {
-				// append just the trailing value portion
-				expanded += env_val->substr(env_key.length() +
-				                            sizeof('='));
+			if (const auto env_val = shell.GetEnvStr(
+			            line.substr(0, closing_percent))) {
+				expanded += *env_val;
 			}
 			line = line.substr(closing_percent);
 		}

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -125,11 +125,10 @@ std::string BatchFile::ExpandedBatchLine(std::string_view line) const
 			std::string env_key(line.substr(0, closing_percent));
 
 			// Get the key's corresponding value from the environment
-			if (std::string env_val = {};
-			    shell.GetEnvStr(env_key.c_str(), env_val)) {
+			if (const auto env_val = shell.GetEnvStr(env_key)) {
 				// append just the trailing value portion
-				expanded += env_val.substr(env_key.length() +
-				                           sizeof('='));
+				expanded += env_val->substr(env_key.length() +
+				                            sizeof('='));
 			}
 			line = line.substr(closing_percent);
 		}

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -29,7 +29,7 @@ constexpr uint8_t UnitSeparator = 31;
 
 [[nodiscard]] static bool found_label(std::string_view line, std::string_view label);
 
-BatchFile::BatchFile(const HostShell& host, std::unique_ptr<ByteReader> input_reader,
+BatchFile::BatchFile(const Environment& host, std::unique_ptr<ByteReader> input_reader,
                      const std::string_view entered_name,
                      const std::string_view cmd_line, const bool echo_on)
         : shell(host),
@@ -123,7 +123,7 @@ std::string BatchFile::ExpandedBatchLine(std::string_view line) const
 				break;
 			}
 
-			if (const auto env_val = shell.GetEnvStr(
+			if (const auto env_val = shell.GetEnvironmentValue(
 			            line.substr(0, closing_percent))) {
 				expanded += *env_val;
 			}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1460,9 +1460,8 @@ void DOS_Shell::CMD_SET(char * args) {
 	std::string line;
 	if (!*args) {
 		/* No command line show all environment lines */
-		Bitu count=GetEnvCount();
-		for (Bitu a=0;a<count;a++) {
-			if (GetEnvNum(a,line)) WriteOut("%s\n",line.c_str());
+		for (const auto& entry : GetAllEnvVars()) {
+			WriteOut("%s\n", entry.c_str());
 		}
 		return;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -778,11 +778,9 @@ void DOS_Shell::CMD_DIR(char* args)
 {
 	HELP("DIR");
 
+	std::string line = {};
 	if (const auto envvar = GetEnvStr("DIRCMD")){
-		auto line = *envvar;
-		std::string::size_type idx = line.find('=');
-		std::string value=line.substr(idx +1 , std::string::npos);
-		line = std::string(args) + " " + value;
+		line = std::string(args) + " " + *envvar;
 		args=const_cast<char*>(line.c_str());
 	}
 
@@ -1477,8 +1475,13 @@ void DOS_Shell::CMD_SET(char * args) {
 
 	char* p = strpbrk(args, "=");
 	if (!p) {
+		auto variable = std::string(args);
+		for (auto& c : variable) {
+			c = std::toupper(c);
+		}
 		if (const auto value = GetEnvStr(args)) {
-			WriteOut("%s\n", value->c_str());
+			WriteOut("%s\n",
+			         std::string(variable + '=' + *value).c_str());
 		} else {
 			WriteOut(MSG_Get("SHELL_CMD_SET_NOT_SET"), args);
 		}
@@ -1498,14 +1501,11 @@ void DOS_Shell::CMD_SET(char * args) {
 				*second++ = 0;
 				if (const auto envvar = GetEnvStr(p)) {
 					const auto& temp = *envvar;
-					std::string::size_type equals = temp.find('=');
-					if (equals == std::string::npos)
-						continue;
 					const uintptr_t remaining_len = std::min(
 					        sizeof(parsed) - static_cast<uintptr_t>(p_parsed - parsed),
 					        sizeof(parsed));
 					safe_strncpy(p_parsed,
-					             temp.substr(equals + 1).c_str(),
+					             temp.c_str(),
 					             remaining_len);
 					p_parsed += strlen(p_parsed);
 				}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -779,7 +779,7 @@ void DOS_Shell::CMD_DIR(char* args)
 	HELP("DIR");
 
 	std::string line = {};
-	if (const auto envvar = GetEnvStr("DIRCMD")){
+	if (const auto envvar = psp->GetEnvironmentValue("DIRCMD")){
 		line = std::string(args) + " " + *envvar;
 		args=const_cast<char*>(line.c_str());
 	}
@@ -1460,7 +1460,7 @@ void DOS_Shell::CMD_SET(char * args) {
 	std::string line;
 	if (!*args) {
 		/* No command line show all environment lines */
-		for (const auto& entry : GetAllEnvVars()) {
+		for (const auto& entry : psp->GetAllRawEnvironmentStrings()) {
 			WriteOut("%s\n", entry.c_str());
 		}
 		return;
@@ -1478,7 +1478,7 @@ void DOS_Shell::CMD_SET(char * args) {
 		for (auto& c : variable) {
 			c = std::toupper(c);
 		}
-		if (const auto value = GetEnvStr(args)) {
+		if (const auto value = psp->GetEnvironmentValue(args)) {
 			WriteOut("%s\n",
 			         std::string(variable + '=' + *value).c_str());
 		} else {
@@ -1498,7 +1498,8 @@ void DOS_Shell::CMD_SET(char * args) {
 				char * second = strchr(++p,'%');
 				if (!second) continue;
 				*second++ = 0;
-				if (const auto envvar = GetEnvStr(p)) {
+
+				if (const auto envvar = psp->GetEnvironmentValue(p)) {
 					const auto& temp = *envvar;
 					const uintptr_t remaining_len = std::min(
 					        sizeof(parsed) - static_cast<uintptr_t>(p_parsed - parsed),
@@ -2088,7 +2089,7 @@ void DOS_Shell::CMD_PATH(char *args){
 		this->ParseLine(set_path);
 		return;
 	} else {
-		if (const auto envvar = GetEnvStr("PATH"))
+		if (const auto envvar = psp->GetEnvironmentValue("PATH"))
 			WriteOut("%s\n", envvar->c_str());
 		else
 			WriteOut("PATH=(null)\n");

--- a/src/shell/shell_history.cpp
+++ b/src/shell/shell_history.cpp
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "shell.h"
+
+#include <fstream>
+
+#include "checks.h"
+#include "control.h"
+#include "dosbox.h"
+#include "fs_utils.h"
+#include "string_utils.h"
+
+CHECK_NARROWING();
+
+static constexpr int HistoryMaxLineLength = 256;
+static constexpr int HistoryMaxNumLines = 500;
+
+static std_fs::path get_shell_history_path();
+static bool command_is_exit(std::string_view command);
+
+void ShellHistory::Append(std::string command, uint16_t code_page)
+{
+	auto to_utf8_str = [code_page](const std::string& dos_str) {
+		std::string utf8_str = {};
+		dos_to_utf8(dos_str, utf8_str, code_page);
+		return utf8_str;
+	};
+	
+	trim(command);
+	
+	auto utf8_command = to_utf8_str(command);
+
+	if (!command_is_exit(command) && !command.empty() &&
+	    (commands.empty() || commands.back() != utf8_command)) {
+		commands.emplace_back(std::move(utf8_command));
+	}
+}
+
+std::vector<std::string> ShellHistory::GetCommands(uint16_t code_page) const
+{
+	auto to_dos_str = [code_page](const std::string& utf8_str) {
+		std::string dos_str = {};
+		utf8_to_dos(utf8_str, dos_str, UnicodeFallback::Simple, code_page);
+		return dos_str;
+	};
+
+	std::vector<std::string> dos_encoded_commands{};
+	std::transform(commands.begin(),
+	               commands.end(),
+	               std::back_inserter(dos_encoded_commands),
+	               to_dos_str);
+
+	return dos_encoded_commands;
+}
+
+ShellHistory::ShellHistory() : path(get_shell_history_path())
+{
+	// Must check arguments directly as control->SwitchToSecureMode()
+	// will not be called until the first shell is run
+	if (control->arguments.securemode) {
+		return;
+	}
+	if (path.empty()) {
+		return;
+	}
+	auto history_file = std::ifstream(path);
+	if (!history_file) {
+		path.clear();
+		return;
+	}
+
+	std::string line;
+	while (getline(history_file, line)) {
+		trim(line);
+		auto len = line.length();
+		if (len > 0 && len <= HistoryMaxLineLength) {
+			commands.emplace_back(line);
+		}
+	}
+}
+
+ShellHistory::~ShellHistory()
+{
+	// Secure mode can be enabled from the shell during runtime.
+	// On exit, we must check this value instead.
+	if (control->SecureMode()) {
+		return;
+	}
+	if (path.empty()) {
+		return;
+	}
+	auto history_file = std::ofstream(path);
+	if (!history_file) {
+		LOG_WARNING("SHELL: Unable to update history file: '%s'",
+		            path.string().c_str());
+		return;
+	}
+
+	if (commands.size() > HistoryMaxNumLines) {
+		commands.erase(commands.begin(), commands.end() - HistoryMaxNumLines);
+	}
+
+	for (const auto& command : commands) {
+		history_file << command << '\n';
+	}
+}
+
+static std_fs::path get_shell_history_path()
+{
+	const auto* section = dynamic_cast<Section_prop*>(control->GetSection("dos"));
+	assert(section);
+
+	const auto* path = section->Get_path("shell_history_file");
+	if (path == nullptr) {
+		return {};
+	}
+
+	return path->realpath;
+}
+
+static bool command_is_exit(std::string_view command)
+{
+	static constexpr auto Delimiters = std::string_view(",;= \t");
+	static constexpr auto Exit       = std::string_view("exit");
+
+	auto command_start = command.find_first_not_of(Delimiters);
+	if (command_start > command.size() ||
+	    !ciequals(command[command_start], Exit.front())) {
+		return false;
+	}
+	command = command.substr(command_start);
+
+	auto command_end = command.find_first_of(Delimiters);
+	if (command_end <= command.size()) {
+		command = command.substr(0, command_end);
+	}
+
+	return iequals(Exit, command);
+}

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -644,36 +644,20 @@ std::optional<std::string> DOS_Shell::GetEnvStr(const std::string_view entry) co
 	}
 }
 
-bool DOS_Shell::GetEnvNum(Bitu num, std::string& result) const
+std::vector<std::string> DOS_Shell::GetAllEnvVars() const
 {
+	auto all_env_vars = std::vector<std::string>{};
+
 	char env_string[1024 + 1];
 	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-	do {
+	while(true) {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {
-			break;
+			return all_env_vars;
 		}
-		if (!num) {
-			result = env_string;
-			return true;
-		}
+		all_env_vars.emplace_back(env_string);
 		env_read += (PhysPt)(safe_strlen(env_string) + 1);
-		num--;
-	} while (1);
-	return false;
-}
-
-Bitu DOS_Shell::GetEnvCount() const
-{
-	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-	Bitu num        = 0;
-	while (mem_readb(env_read) != 0) {
-		for (; mem_readb(env_read); env_read++) {
-		};
-		env_read++;
-		num++;
 	}
-	return num;
 }
 
 bool DOS_Shell::SetEnv(std::string_view entry, std::string_view new_string)

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -355,9 +355,9 @@ std::string DOS_Shell::SubstituteEnvironmentVariables(std::string_view command)
 		}
 		closing_percent += 1;
 
-		const std::string env_key(command.substr(1, closing_percent - 1));
-		if (const auto env_val = GetEnvStr(env_key)) {
-			expanded += env_val->substr(env_key.length() + sizeof('='));
+		if (const auto env_val =
+		            GetEnvStr(command.substr(1, closing_percent - 1))) {
+			expanded += *env_val;
 
 			command = command.substr(closing_percent + 1);
 		} else {
@@ -494,12 +494,9 @@ std::string DOS_Shell::Which(const std::string_view name) const
 	static constexpr auto extensions = {"", ".COM", ".EXE", ".BAT"};
 
 	std::vector<std::string> prefixes = {""};
-	auto path_environment             = GetEnvStr("PATH").value_or("");
-	const auto path_equals            = path_environment.find_first_of('=');
 
-	if (path_equals != std::string::npos) {
-		path_environment = path_environment.substr(path_equals + 1);
-		auto path_directories = split_with_empties(path_environment, ';');
+	if (const auto path = GetEnvStr("PATH")) {
+		auto path_directories = split_with_empties(*path, ';');
 
 		remove_empties(path_directories);
 
@@ -614,7 +611,7 @@ static void run_binary_executable(const std::string_view fullname,
 	reg_sp += 0x200;
 }
 
-std::optional<std::string> DOS_Shell::GetEnvStr(std::string_view entry) const
+std::optional<std::string> DOS_Shell::GetEnvStr(const std::string_view entry) const
 {
 	/* Walk through the internal environment and see for a match */
 	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
@@ -624,7 +621,7 @@ std::optional<std::string> DOS_Shell::GetEnvStr(std::string_view entry) const
 		return {};
 	}
 
-	do {
+	while (true) {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {
 			return {};
@@ -635,18 +632,16 @@ std::optional<std::string> DOS_Shell::GetEnvStr(std::string_view entry) const
 			continue;
 		}
 		/* replace the = with \0 to get the length */
-		*equal = 0;
+		*equal = '\0';
 		if (strlen(env_string) != entry.size()) {
 			continue;
 		}
 		if (!iequals(entry, env_string)) {
 			continue;
 		}
-		/* restore the = to get the original result */
-		*equal = '=';
-		return env_string;
-	} while (1);
-	return {};
+
+		return env_string + entry.size() + sizeof('=');
+	}
 }
 
 bool DOS_Shell::GetEnvNum(Bitu num, std::string& result) const

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -355,8 +355,8 @@ std::string DOS_Shell::SubstituteEnvironmentVariables(std::string_view command)
 		}
 		closing_percent += 1;
 
-		if (const auto env_val =
-		            GetEnvStr(command.substr(1, closing_percent - 1))) {
+		if (const auto env_val = psp->GetEnvironmentValue(
+		            command.substr(1, closing_percent - 1))) {
 			expanded += *env_val;
 
 			command = command.substr(closing_percent + 1);
@@ -495,7 +495,7 @@ std::string DOS_Shell::Which(const std::string_view name) const
 
 	std::vector<std::string> prefixes = {""};
 
-	if (const auto path = GetEnvStr("PATH")) {
+	if (const auto path = psp->GetEnvironmentValue("PATH")) {
 		auto path_directories = split_with_empties(*path, ';');
 
 		remove_empties(path_directories);
@@ -609,16 +609,6 @@ static void run_binary_executable(const std::string_view fullname,
 
 	/* Restore CS:IP and the stack */
 	reg_sp += 0x200;
-}
-
-std::optional<std::string> DOS_Shell::GetEnvStr(const std::string_view entry) const
-{
-	return psp->GetEnvironmentValue(entry);
-}
-
-std::vector<std::string> DOS_Shell::GetAllEnvVars() const
-{
-	return psp->GetAllRawEnvironmentStrings();
 }
 
 bool DOS_Shell::SetEnv(std::string_view entry, std::string_view new_string)

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -473,7 +473,7 @@ bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 
 		auto reader = FileReader::GetFileReader(fullname);
 		if (reader) {
-			batchfiles.emplace(*this, std::move(*reader), name, args, echo);
+			batchfiles.emplace(*psp, std::move(*reader), name, args, echo);
 		} else {
 			WriteOut("Could not open %s", fullname.c_str());
 		}
@@ -613,111 +613,15 @@ static void run_binary_executable(const std::string_view fullname,
 
 std::optional<std::string> DOS_Shell::GetEnvStr(const std::string_view entry) const
 {
-	/* Walk through the internal environment and see for a match */
-	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-
-	char env_string[1024 + 1];
-	if (entry.empty()) {
-		return {};
-	}
-
-	while (true) {
-		MEM_StrCopy(env_read, env_string, 1024);
-		if (!env_string[0]) {
-			return {};
-		}
-		env_read += (PhysPt)(safe_strlen(env_string) + 1);
-		char* equal = strchr(env_string, '=');
-		if (!equal) {
-			continue;
-		}
-		/* replace the = with \0 to get the length */
-		*equal = '\0';
-		if (strlen(env_string) != entry.size()) {
-			continue;
-		}
-		if (!iequals(entry, env_string)) {
-			continue;
-		}
-
-		return env_string + entry.size() + sizeof('=');
-	}
+	return psp->GetEnvironmentValue(entry);
 }
 
 std::vector<std::string> DOS_Shell::GetAllEnvVars() const
 {
-	auto all_env_vars = std::vector<std::string>{};
-
-	char env_string[1024 + 1];
-	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-	while(true) {
-		MEM_StrCopy(env_read, env_string, 1024);
-		if (!env_string[0]) {
-			return all_env_vars;
-		}
-		all_env_vars.emplace_back(env_string);
-		env_read += (PhysPt)(safe_strlen(env_string) + 1);
-	}
+	return psp->GetAllRawEnvironmentStrings();
 }
 
 bool DOS_Shell::SetEnv(std::string_view entry, std::string_view new_string)
 {
-	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
-
-	// Get size of environment.
-	DOS_MCB mcb(psp->GetEnvironment() - 1);
-	uint16_t envsize = mcb.GetSize() * 16;
-
-	PhysPt env_write          = env_read;
-	PhysPt env_write_start    = env_read;
-	char env_string[1024 + 1] = {0};
-	const auto entry_length   = entry.size();
-	do {
-		MEM_StrCopy(env_read, env_string, 1024);
-		if (!env_string[0]) {
-			break;
-		}
-		env_read += (PhysPt)(safe_strlen(env_string) + 1);
-		if (!strchr(env_string, '=')) {
-			continue; /* Remove corrupt entry? */
-		}
-		if (iequals(entry,
-		            std::string_view(env_string).substr(0, entry_length)) &&
-		    env_string[entry_length] == '=') {
-			continue;
-		}
-		MEM_BlockWrite(env_write,
-		               env_string,
-		               (Bitu)(safe_strlen(env_string) + 1));
-		env_write += (PhysPt)(safe_strlen(env_string) + 1);
-	} while (1);
-	/* TODO Maybe save the program name sometime. not really needed though */
-	/* Save the new entry */
-
-	// ensure room
-	if (envsize <= (env_write - env_write_start) + entry.size() + 1 +
-	                       new_string.size() + 2) {
-		return false;
-	}
-
-	if (!new_string.empty()) {
-		std::string bigentry(entry);
-		for (std::string::iterator it = bigentry.begin();
-		     it != bigentry.end();
-		     ++it) {
-			*it = toupper(*it);
-		}
-		snprintf(env_string,
-		         1024 + 1,
-		         "%s=%s",
-		         bigentry.c_str(),
-		         std::string(new_string).c_str());
-		MEM_BlockWrite(env_write,
-		               env_string,
-		               (Bitu)(safe_strlen(env_string) + 1));
-		env_write += (PhysPt)(safe_strlen(env_string) + 1);
-	}
-	/* Clear out the final piece of the environment */
-	mem_writeb(env_write, 0);
-	return true;
+	return psp->SetEnvironmentValue(entry, new_string);
 }

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -356,8 +356,8 @@ std::string DOS_Shell::SubstituteEnvironmentVariables(std::string_view command)
 		closing_percent += 1;
 
 		const std::string env_key(command.substr(1, closing_percent - 1));
-		if (std::string env_val = {}; GetEnvStr(env_key.c_str(), env_val)) {
-			expanded += env_val.substr(env_key.length() + sizeof('='));
+		if (const auto env_val = GetEnvStr(env_key)) {
+			expanded += env_val->substr(env_key.length() + sizeof('='));
 
 			command = command.substr(closing_percent + 1);
 		} else {
@@ -494,11 +494,10 @@ std::string DOS_Shell::Which(const std::string_view name) const
 	static constexpr auto extensions = {"", ".COM", ".EXE", ".BAT"};
 
 	std::vector<std::string> prefixes = {""};
-	std::string path_environment;
-	const auto have_path_env = GetEnvStr("PATH", path_environment);
-	const auto path_equals   = path_environment.find_first_of('=');
+	auto path_environment             = GetEnvStr("PATH").value_or("");
+	const auto path_equals            = path_environment.find_first_of('=');
 
-	if (have_path_env && path_equals != std::string::npos) {
+	if (path_equals != std::string::npos) {
 		path_environment = path_environment.substr(path_equals + 1);
 		auto path_directories = split_with_empties(path_environment, ';');
 
@@ -615,21 +614,20 @@ static void run_binary_executable(const std::string_view fullname,
 	reg_sp += 0x200;
 }
 
-bool DOS_Shell::GetEnvStr(const char* entry, std::string& result) const
+std::optional<std::string> DOS_Shell::GetEnvStr(std::string_view entry) const
 {
 	/* Walk through the internal environment and see for a match */
 	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
 
 	char env_string[1024 + 1];
-	result.erase();
-	if (!entry[0]) {
-		return false;
+	if (entry.empty()) {
+		return {};
 	}
-	const auto entry_length = strlen(entry);
+
 	do {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {
-			return false;
+			return {};
 		}
 		env_read += (PhysPt)(safe_strlen(env_string) + 1);
 		char* equal = strchr(env_string, '=');
@@ -638,18 +636,17 @@ bool DOS_Shell::GetEnvStr(const char* entry, std::string& result) const
 		}
 		/* replace the = with \0 to get the length */
 		*equal = 0;
-		if (strlen(env_string) != entry_length) {
+		if (strlen(env_string) != entry.size()) {
 			continue;
 		}
-		if (strcasecmp(entry, env_string) != 0) {
+		if (!iequals(entry, env_string)) {
 			continue;
 		}
 		/* restore the = to get the original result */
 		*equal = '=';
-		result = env_string;
-		return true;
+		return env_string;
 	} while (1);
-	return false;
+	return {};
 }
 
 bool DOS_Shell::GetEnvNum(Bitu num, std::string& result) const

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -473,7 +473,12 @@ bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 
 		auto reader = FileReader::GetFileReader(fullname);
 		if (reader) {
-			batchfiles.emplace(*psp, std::move(*reader), name, args, echo);
+			batchfiles.emplace(*psp,
+			                   std::make_unique<FileReader>(
+			                           std::move(*reader)),
+			                   name,
+			                   args,
+			                   echo);
 		} else {
 			WriteOut("Could not open %s", fullname.c_str());
 		}

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -684,7 +684,7 @@ Bitu DOS_Shell::GetEnvCount() const
 	return num;
 }
 
-bool DOS_Shell::SetEnv(const char* entry, const char* new_string)
+bool DOS_Shell::SetEnv(std::string_view entry, std::string_view new_string)
 {
 	PhysPt env_read = PhysicalMake(psp->GetEnvironment(), 0);
 
@@ -695,7 +695,7 @@ bool DOS_Shell::SetEnv(const char* entry, const char* new_string)
 	PhysPt env_write          = env_read;
 	PhysPt env_write_start    = env_read;
 	char env_string[1024 + 1] = {0};
-	const auto entry_length   = strlen(entry);
+	const auto entry_length   = entry.size();
 	do {
 		MEM_StrCopy(env_read, env_string, 1024);
 		if (!env_string[0]) {
@@ -705,7 +705,8 @@ bool DOS_Shell::SetEnv(const char* entry, const char* new_string)
 		if (!strchr(env_string, '=')) {
 			continue; /* Remove corrupt entry? */
 		}
-		if ((strncasecmp(entry, env_string, entry_length) == 0) &&
+		if (iequals(entry,
+		            std::string_view(env_string).substr(0, entry_length)) &&
 		    env_string[entry_length] == '=') {
 			continue;
 		}
@@ -718,19 +719,23 @@ bool DOS_Shell::SetEnv(const char* entry, const char* new_string)
 	/* Save the new entry */
 
 	// ensure room
-	if (envsize <= (env_write - env_write_start) + strlen(entry) + 1 +
-	                       strlen(new_string) + 2) {
+	if (envsize <= (env_write - env_write_start) + entry.size() + 1 +
+	                       new_string.size() + 2) {
 		return false;
 	}
 
-	if (new_string[0]) {
+	if (!new_string.empty()) {
 		std::string bigentry(entry);
 		for (std::string::iterator it = bigentry.begin();
 		     it != bigentry.end();
 		     ++it) {
 			*it = toupper(*it);
 		}
-		snprintf(env_string, 1024 + 1, "%s=%s", bigentry.c_str(), new_string);
+		snprintf(env_string,
+		         1024 + 1,
+		         "%s=%s",
+		         bigentry.c_str(),
+		         std::string(new_string).c_str());
 		MEM_BlockWrite(env_write,
 		               env_string,
 		               (Bitu)(safe_strlen(env_string) + 1));

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -55,13 +55,13 @@ private:
 
 class MockShell final : public HostShell {
 public:
-	bool GetEnvStr(const char* entry, std::string& result) const override
+	std::optional<std::string> GetEnvStr(std::string_view entry) const override
 	{
-		if (env.find(entry) == std::end(env)) {
-			return false;
+		auto key = std::string(entry);
+		if (env.find(key) == std::end(env)) {
+			return {};
 		}
-		result = std::string(entry) + '=' + env.at(entry);
-		return true;
+		return key + '=' + env.at(key);
 	}
 
 	explicit MockShell(std::unordered_map<std::string, std::string>&& map)

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -57,11 +57,11 @@ class MockShell final : public HostShell {
 public:
 	std::optional<std::string> GetEnvStr(std::string_view entry) const override
 	{
-		auto key = std::string(entry);
-		if (env.find(key) == std::end(env)) {
+		auto environment_variable = env.find(std::string(entry));
+		if (environment_variable == std::end(env)) {
 			return {};
 		}
-		return key + '=' + env.at(key);
+		return environment_variable->second;
 	}
 
 	explicit MockShell(std::unordered_map<std::string, std::string>&& map)

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -53,9 +53,9 @@ private:
 	decltype(contents)::size_type index = 0;
 };
 
-class MockShell final : public HostShell {
+class MockShell final : public Environment {
 public:
-	std::optional<std::string> GetEnvStr(std::string_view entry) const override
+	std::optional<std::string> GetEnvironmentValue(std::string_view entry) const override
 	{
 		auto environment_variable = env.find(std::string(entry));
 		if (environment_variable == std::end(env)) {

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -727,6 +727,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClCompile Include="..\src\shell\shell.cpp" />
     <ClCompile Include="..\src\shell\shell_batch.cpp" />
     <ClCompile Include="..\src\shell\shell_cmds.cpp" />
+    <ClCompile Include="..\src\shell\shell_history.cpp" />
     <ClCompile Include="..\src\shell\shell_misc.cpp" />
     <ClCompile Include="..\src\libs\ghc\fs_std_impl.cpp" />
     <ClCompile Include="..\src\libs\loguru\loguru.cpp" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -520,6 +520,9 @@
     <ClCompile Include="..\src\shell\shell_cmds.cpp">
       <Filter>src\shell</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\shell\shell_history.cpp">
+      <Filter>src\shell</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\shell\shell_misc.cpp">
       <Filter>src\shell</Filter>
     </ClCompile>


### PR DESCRIPTION
# Description

Most of the changes involve moving the functions querying and commanding the environment out of the shell class and into the psp class. These function only operate on the shell's psp anyways so it makes no sense to have them outside the psp. This also means that programs that query the environment no longer have to go through the hacky global `first_shell`. Removing `first_shell` was the primary motivation for these commits, though after these changes it is still being used in autoexec.

There are also a few single-commit changes in here:

Moved shell_history out of individual functions and into its own class.

Fixed a crash in the setver program when too few args are present.

Vastly improved the semantics of the FileReader class (the interface remains unchanged).

More details in a comment below.

# Manual testing

Ensure that read, write, and list environment functions work as expected with the `SET` command.

- `SET PATH`
- `SET VAR=VAL`
- `SET`

`MOUNT -Z` changes the letter of the Z drive. Note that you can't run this more than once per session. From what I can tell, this was a hack for WINE, since there was a conflict with the WINE Z drive. In addition to the environment interface change, I made the change propagate across subshells, whereas it would break your path before.

 - Run `MOUNT -Z E`. Ensure that your PATH variable has changed to include E: instead of Z:. Go into a subshell and ensure that the change is visible there too.
 - Restart and run the command again, this time from a subshell. Ensure the changes are reflected in the parent shell.

ParseLine is functionally unchanged. Only the name resolution for temp files was touched. Launch from terminal so you can see logging ouptut. Input any command with the vertical bar pipe. It can be a garbage command like `a | a`. In the logging output, you should see `Redirecting output to pipeXXXX.tmp`. Now try again while setting a `TMP` or `TEMP` environment variable to a directory. If you pipe again, the file will be prefixed by the chosen directory.

Environment variable resolution is functionally unchanged. Create a batch file with the line `ECHO %PATH%`, and ensure that your path is printed. Do the same directly on the DOS command line when the settings to get shell expansion there are set to on.

Executable resolution is functionally unchanged. Ensure all directories in your `PATH` work.

The `PATH` command is functionally unchanged. Ensure it matches the output of `SET PATH`.

The `DIR` command is functionally unchanged. Ensure that it works without the `DIRCMD` environment variable being set. Also ensure that it applies the expected switches when `DIRCMD` is set. For example, `SET DIRCMD=/b` should apply the `/b` switch automatically when using `DIR`.

The `CONFIG` command is functionally unchanged. The writes to the `CONFIG` environment variable should be the same as before.

- `CONFIG -GET VER` echoes current does version, and sets the `CONFIG` environment variable to that value
- `CONFIG -GET DOS VER` does the same

## Shell History Tests
Make sure the config file can be read from and written to.

When the sum of lines in the history file and the new commands are over 500 (or whatever the specified constant in the class is), ensure that the file contains only the most recent 500 lines upon exit.

Ensure that exit never written to the file.

Remove read permissions and ensure that dosbox doesn't explode. Then do that again, but make the file write-only.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

