### PR TITLE
Fix OpenGL symbol type mismatch warning at link time

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -103,12 +103,23 @@ typedef GLvoid* (APIENTRYP PFNGLMAPBUFFERARBPROC) (GLenum target, GLenum access)
 typedef GLboolean (APIENTRYP PFNGLUNMAPBUFFERARBPROC) (GLenum target);
 #endif
 
-PFNGLGENBUFFERSARBPROC glGenBuffersARB = nullptr;
-PFNGLBINDBUFFERARBPROC glBindBufferARB = nullptr;
+// Create function pointer variables inside a namespace to avoid clobbering
+// extenally defined function names with the same names. This fixes symbol type
+// mismatch warnings at link time.
+namespace gl1 {
+PFNGLGENBUFFERSARBPROC glGenBuffersARB       = nullptr;
+PFNGLBINDBUFFERARBPROC glBindBufferARB       = nullptr;
 PFNGLDELETEBUFFERSARBPROC glDeleteBuffersARB = nullptr;
-PFNGLBUFFERDATAARBPROC glBufferDataARB = nullptr;
-PFNGLMAPBUFFERARBPROC glMapBufferARB = nullptr;
-PFNGLUNMAPBUFFERARBPROC glUnmapBufferARB = nullptr;
+PFNGLBUFFERDATAARBPROC glBufferDataARB       = nullptr;
+PFNGLMAPBUFFERARBPROC glMapBufferARB         = nullptr;
+PFNGLUNMAPBUFFERARBPROC glUnmapBufferARB     = nullptr;
+} // namespace gl1
+#define glGenBuffersARB    gl1::glGenBuffersARB
+#define glBindBufferARB    gl1::glBindBufferARB
+#define glDeleteBuffersARB gl1::glDeleteBuffersARB
+#define glBufferDataARB    gl1::glBufferDataARB
+#define glMapBufferARB     gl1::glMapBufferARB
+#define glUnmapBufferARB   gl1::glUnmapBufferARB
 
 /* Don't guard these with GL_VERSION_2_0 - Apple defines it but not these typedefs.
  * If they're already defined they should match these definitions, so no conflicts.


### PR DESCRIPTION
# Description

Fixes the following symbol type mismatch issues flagged by the [_**mold**_](https://github.com/rui314/mold) linker:

```text
mold: warning: symbol type mismatch: glGenBuffersARB
>>> defined in src/gui/libgui.a(src/gui/libgui.a.p/sdlmain.cpp.o) as STT_OBJECT
>>> defined in /usr/lib/x86_64-linux-gnu/libGL.so as STT_FUNC
mold: warning: symbol type mismatch: glBufferDataARB
>>> defined in src/gui/libgui.a(src/gui/libgui.a.p/sdlmain.cpp.o) as STT_OBJECT
>>> defined in /usr/lib/x86_64-linux-gnu/libGL.so as STT_FUNC
mold: warning: symbol type mismatch: glDeleteBuffersARB
>>> defined in src/gui/libgui.a(src/gui/libgui.a.p/sdlmain.cpp.o) as STT_OBJECT
>>> defined in /usr/lib/x86_64-linux-gnu/libGL.so as STT_FUNC
mold: warning: symbol type mismatch: glUnmapBufferARB
>>> defined in src/gui/libgui.a(src/gui/libgui.a.p/sdlmain.cpp.o) as STT_OBJECT
>>> defined in /usr/lib/x86_64-linux-gnu/libGL.so as STT_FUNC
mold: warning: symbol type mismatch: glMapBufferARB
>>> defined in src/gui/libgui.a(src/gui/libgui.a.p/sdlmain.cpp.o) as STT_OBJECT
>>> defined in /usr/lib/x86_64-linux-gnu/libGL.so as STT_FUNC
mold: warning: symbol type mismatch: glBindBufferARB
>>> defined in src/gui/libgui.a(src/gui/libgui.a.p/sdlmain.cpp.o) as STT_OBJECT
>>> defined in /usr/lib/x86_64-linux-gnu/libGL.so as STT_FUNC
```

## Related issues

None.

# Manual testing

Tested OpenGL to confirm it's still working.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

