### PR TITLE
Drop OpenGL PBO support

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -171,13 +171,11 @@ struct SDL_Block {
 	struct {
 		SDL_GLContext context;
 		int pitch = 0;
-		void *framebuf = nullptr;
-		GLuint buffer;
+		void* framebuf = nullptr;
 		GLuint texture;
 		GLuint displaylist;
 		GLint max_texsize;
 		bool bilinear;
-		bool pixel_buffer_object = false;
 		bool npot_textures_supported = false;
 		bool use_shader;
 		bool framebuffer_is_srgb_encoded;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -85,42 +85,6 @@
 #define APIENTRYP APIENTRY *
 #endif
 
-#ifndef GL_ARB_pixel_buffer_object
-#define GL_ARB_pixel_buffer_object 1
-#define GL_PIXEL_PACK_BUFFER_ARB           0x88EB
-#define GL_PIXEL_UNPACK_BUFFER_ARB         0x88EC
-#define GL_PIXEL_PACK_BUFFER_BINDING_ARB   0x88ED
-#define GL_PIXEL_UNPACK_BUFFER_BINDING_ARB 0x88EF
-#endif
-
-#ifndef GL_ARB_vertex_buffer_object
-#define GL_ARB_vertex_buffer_object 1
-typedef void (APIENTRYP PFNGLGENBUFFERSARBPROC) (GLsizei n, GLuint *buffers);
-typedef void (APIENTRYP PFNGLBINDBUFFERARBPROC) (GLenum target, GLuint buffer);
-typedef void (APIENTRYP PFNGLDELETEBUFFERSARBPROC) (GLsizei n, const GLuint *buffers);
-typedef void (APIENTRYP PFNGLBUFFERDATAARBPROC) (GLenum target, GLsizeiptr size, const GLvoid *data, GLenum usage);
-typedef GLvoid* (APIENTRYP PFNGLMAPBUFFERARBPROC) (GLenum target, GLenum access);
-typedef GLboolean (APIENTRYP PFNGLUNMAPBUFFERARBPROC) (GLenum target);
-#endif
-
-// Create function pointer variables inside a namespace to avoid clobbering
-// extenally defined function names with the same names. This fixes symbol type
-// mismatch warnings at link time.
-namespace gl1 {
-PFNGLGENBUFFERSARBPROC glGenBuffersARB       = nullptr;
-PFNGLBINDBUFFERARBPROC glBindBufferARB       = nullptr;
-PFNGLDELETEBUFFERSARBPROC glDeleteBuffersARB = nullptr;
-PFNGLBUFFERDATAARBPROC glBufferDataARB       = nullptr;
-PFNGLMAPBUFFERARBPROC glMapBufferARB         = nullptr;
-PFNGLUNMAPBUFFERARBPROC glUnmapBufferARB     = nullptr;
-} // namespace gl1
-#define glGenBuffersARB    gl1::glGenBuffersARB
-#define glBindBufferARB    gl1::glBindBufferARB
-#define glDeleteBuffersARB gl1::glDeleteBuffersARB
-#define glBufferDataARB    gl1::glBufferDataARB
-#define glMapBufferARB     gl1::glMapBufferARB
-#define glUnmapBufferARB   gl1::glUnmapBufferARB
-
 /* Don't guard these with GL_VERSION_2_0 - Apple defines it but not these typedefs.
  * If they're already defined they should match these definitions, so no conflicts.
  */
@@ -239,8 +203,7 @@ static void HandleVideoResize(int width, int height);
 static void update_frame_texture([[maybe_unused]] const uint16_t* changedLines);
 static bool present_frame_texture();
 #if C_OPENGL
-static void update_frame_gl_pbo([[maybe_unused]] const uint16_t *changedLines);
-static void update_frame_gl_fb(const uint16_t *changedLines);
+static void update_frame_gl(const uint16_t *changedLines);
 static bool present_frame_gl();
 #endif
 
@@ -1774,15 +1737,11 @@ uint8_t GFX_SetSize(const int width, const int height,
 	}
 #if C_OPENGL
 	case RenderingBackend::OpenGl: {
-		if (sdl.opengl.pixel_buffer_object) {
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-			if (sdl.opengl.buffer) glDeleteBuffersARB(1, &sdl.opengl.buffer);
-		} else {
-			free(sdl.opengl.framebuf);
-		}
-		sdl.opengl.framebuf=nullptr;
-		if (!(flags & GFX_CAN_32))
+		free(sdl.opengl.framebuf);
+		sdl.opengl.framebuf = nullptr;
+		if (!(flags & GFX_CAN_32)) {
 			goto fallback_texture;
+		}
 
 		int texsize_w, texsize_h;
 
@@ -1935,17 +1894,10 @@ uint8_t GFX_SetSize(const int width, const int height,
 		/* Create the texture and display list */
 		const auto framebuffer_bytes = static_cast<size_t>(width) *
 		                               height * MAX_BYTES_PER_PIXEL;
-		if (sdl.opengl.pixel_buffer_object) {
-			glGenBuffersARB(1, &sdl.opengl.buffer);
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
-			glBufferDataARB(GL_PIXEL_UNPACK_BUFFER_EXT, framebuffer_bytes, nullptr, GL_STREAM_DRAW_ARB);
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-		} else {
-			sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
-		}
+		sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
 		sdl.opengl.pitch = width * 4;
 
-		// One-time intialize the window size
+		// One-time initialize the window size
 		if (!sdl.desktop.window.adjusted_initial_size) {
 			initialize_sdl_window_size(sdl.window,
 			                           FALLBACK_WINDOW_DIMENSIONS,
@@ -2088,14 +2040,8 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		OPENGL_ERROR("End of setsize");
 
-		retFlags = GFX_CAN_32;
-		if (sdl.opengl.pixel_buffer_object) {
-			sdl.frame.update = update_frame_gl_pbo;
-		} else {
-			sdl.frame.update = update_frame_gl_fb;
-			retFlags |= GFX_CAN_RANDOM;
-		}
-		// Both update mechanisms use the same presentation call
+		retFlags          = GFX_CAN_32 | GFX_CAN_RANDOM;
+		sdl.frame.update  = update_frame_gl;
 		sdl.frame.present = present_frame_gl;
 		break; // RenderingBackend::OpenGl
 	}
@@ -2320,8 +2266,7 @@ static void SwitchFullScreen(bool pressed)
 // This function returns write'able buffer for user to draw upon. Successful
 // return depends on properly initialized SDL_Block structure (which generally
 // can be achieved via GFX_SetSize call), and specifically - properly
-// initialized output-specific bits (sdl.texture, sdl.opengl.framebuf, or
-// sdl.openg.pixel_buffer_object fields).
+// initialized output-specific bits (sdl.texture or sdl.opengl.framebuf fields).
 //
 // If everything is prepared correctly, this function returns true, assigns
 // 'pixels' output parameter to to a buffer (with format specified via earlier
@@ -2342,18 +2287,14 @@ bool GFX_StartUpdate(uint8_t * &pixels, int &pitch)
 		return true;
 #if C_OPENGL
 	case RenderingBackend::OpenGl:
-		if (sdl.opengl.pixel_buffer_object) {
-			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
-			pixels = static_cast<uint8_t *>(glMapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, GL_WRITE_ONLY));
-		} else {
-			pixels = static_cast<uint8_t *>(sdl.opengl.framebuf);
-		}
+		pixels = static_cast<uint8_t*>(sdl.opengl.framebuf);
 		OPENGL_ERROR("end of start update");
-		if (pixels == nullptr)
+		if (pixels == nullptr) {
 			return false;
+		}
 		static_assert(std::is_same<decltype(pitch), decltype((sdl.opengl.pitch))>::value,
 		              "Our internal pitch types should be the same.");
-		pitch = sdl.opengl.pitch;
+		pitch        = sdl.opengl.pitch;
 		sdl.updating = true;
 		return true;
 #endif
@@ -2530,23 +2471,10 @@ static bool present_frame_texture()
 	return is_presenting;
 }
 
-// OpenGL PBO-based update, frame-based update, and presentation
+// OpenGL frame-based update and presentation
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #if C_OPENGL
-static void update_frame_gl_pbo([[maybe_unused]] const uint16_t *changedLines)
-{
-	if (sdl.updating) {
-		glUnmapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, sdl.draw.width,
-		                sdl.draw.height, GL_BGRA_EXT,
-		                GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
-		glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-	} else {
-		sdl.opengl.actual_frame_count++;
-	}
-}
-
-static void update_frame_gl_fb(const uint16_t *changedLines)
+static void update_frame_gl(const uint16_t* changedLines)
 {
 	if (changedLines) {
 		const auto framebuf = static_cast<uint8_t *>(sdl.opengl.framebuf);
@@ -3345,38 +3273,14 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			         glUniform2f && glUniform1i && glUseProgram &&
 			         glVertexAttribPointer);
 
-			sdl.opengl.buffer = 0;
 			sdl.opengl.framebuf = nullptr;
 			sdl.opengl.texture = 0;
 			sdl.opengl.displaylist = 0;
 			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &sdl.opengl.max_texsize);
 
-			glGenBuffersARB = (PFNGLGENBUFFERSARBPROC)SDL_GL_GetProcAddress(
-			        "glGenBuffersARB");
-			glBindBufferARB = (PFNGLBINDBUFFERARBPROC)SDL_GL_GetProcAddress(
-			        "glBindBufferARB");
-			glDeleteBuffersARB = (PFNGLDELETEBUFFERSARBPROC)
-			        SDL_GL_GetProcAddress("glDeleteBuffersARB");
-			glBufferDataARB = (PFNGLBUFFERDATAARBPROC)SDL_GL_GetProcAddress(
-			        "glBufferDataARB");
-			glMapBufferARB = (PFNGLMAPBUFFERARBPROC)SDL_GL_GetProcAddress(
-			        "glMapBufferARB");
-			glUnmapBufferARB = (PFNGLUNMAPBUFFERARBPROC)SDL_GL_GetProcAddress(
-			        "glUnmapBufferARB");
-			const bool have_arb_buffers = glGenBuffersARB &&
-			                              glBindBufferARB &&
-			                              glDeleteBuffersARB &&
-			                              glBufferDataARB &&
-			                              glMapBufferARB &&
-			                              glUnmapBufferARB;
-
 			const auto gl_version_string = safe_gl_get_string(GL_VERSION,
 			                                                  "0.0.0");
 			const int gl_version_major = gl_version_string[0] - '0';
-
-			sdl.opengl.pixel_buffer_object =
-			        have_arb_buffers &&
-			        SDL_GL_ExtensionSupported("GL_ARB_pixel_buffer_object");
 
 			sdl.opengl.npot_textures_supported =
 			        gl_version_major >= 2 ||
@@ -3396,9 +3300,6 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			         safe_gl_get_string(GL_SHADING_LANGUAGE_VERSION,
 			                            "unknown"));
 
-			LOG_INFO("OPENGL: Pixel buffer object %s",
-			         sdl.opengl.pixel_buffer_object ? "available"
-			                                        : "missing");
 			LOG_INFO("OPENGL: NPOT textures %s",
 			         npot_support_msg.c_str());
 		}


### PR DESCRIPTION
# Description

Thanks to @GranMinigun for this commit.

The pixel buffer object (PBO) harms performance on already slow-video systems: specifically those using shared-memory / integrated graphics, like SBCs, Intel HD, and AMD APUs.

Removing the PBO will give these systems a noticeable and valuable performance increase.

Removing OpenGL PBO has been discussed, extensively benchmarked on all platforms, and agreed by the team before:  https://github.com/dosbox-staging/dosbox-staging/pull/2450#issuecomment-1703884190

## Related issues

None.

# Manual testing

Testing has been done with the same commit here:

https://github.com/dosbox-staging/dosbox-staging/pull/2450#issuecomment-1703884190

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

