### PR TITLE
Only process MT-32 debug messages in debug builds

### DIFF
--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -527,11 +527,17 @@ static mt32emu_report_handler_i get_report_handler_interface()
 		}
 
 		static void printDebug([[maybe_unused]] void* instance_data,
-		                       const char* fmt, va_list list)
+		                       [[maybe_unused]] const char* fmt,
+		                       [[maybe_unused]] va_list list)
 		{
-			char msg[1024];
-			safe_sprintf(msg, fmt, list);
-			LOG_DEBUG("MT32: %s", msg);
+#if !defined(NDEBUG)
+			// Skip processing MT-32 debug output in release builds
+			// because it can be bursty
+			char msg[1024] = "MT32: ";
+			assert(fmt);
+			safe_strcat(msg, fmt);
+			LOG_DEBUG(msg, list);
+#endif
 		}
 
 		static void onErrorControlROM(void*)


### PR DESCRIPTION
# Description

Skips processing MT-32 debug messages in release builds because it can be excessive:

![2023-11-06_20-23](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/8f0303a8-69a0-435d-8858-e3ee28694f61)

Also changes the logic slight to let Loguru process the variable list directly, which fixes #3096.

## Related issues

Fixes #3096, both in release and debug builds.

# Manual testing

Tested MT-32 in release, debug, and sanitizer builds.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

