### PR TITLE
Implement SCAS and CMPS opcodes for dynrec

### DIFF
--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -396,6 +396,10 @@ restart_prefix:
 		case 0xa4:dyn_string(R_MOVSB);break;
 		case 0xa5:dyn_string(decode.big_op ? R_MOVSD : R_MOVSW);break;
 
+		// cmpsb/w/d
+		case 0xa6: dyn_string(R_CMPSB); break;
+		case 0xa7: dyn_string(decode.big_op ? R_CMPSD : R_CMPSW); break;
+
 		// stosb/w/d
 		case 0xaa:dyn_string(R_STOSB);break;
 		case 0xab:dyn_string(decode.big_op ? R_STOSD : R_STOSW);break;
@@ -404,6 +408,9 @@ restart_prefix:
 		case 0xac:dyn_string(R_LODSB);break;
 		case 0xad:dyn_string(decode.big_op ? R_LODSD : R_LODSW);break;
 
+		// scasb/w/d
+		case 0xae: dyn_string(R_SCASB); break;
+		case 0xaf: dyn_string(decode.big_op ? R_SCASD : R_SCASW); break;
 
 		// 'test reg8/16/32,imm8/16/32'
 		case 0xa8:dyn_dop_byte_imm(DOP_TEST,DRC_REG_EAX,0);break;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -559,7 +559,21 @@ static inline const uint8_t* gen_call_function_mm(void * func,Bitu op1,Bitu op2)
 	return gen_call_function_setup(func, 4, true);
 }
 
+static inline const uint8_t* gen_call_function_Im(void* func, Bitu op1, Bitu op2)
+{
+	gen_load_param_mem(op2, 3);
+	gen_load_param_imm(op1, 2);
+	return gen_call_function_setup(func, 4, true);
+}
 
+static inline const uint8_t* gen_call_function_Imm(void* func, Bitu op1,
+                                                   Bitu op2, Bitu op3)
+{
+	gen_load_param_mem(op3, 4);
+	gen_load_param_mem(op2, 3);
+	gen_load_param_imm(op1, 2);
+	return gen_call_function_setup(func, 5, true);
+}
 
 enum save_info_type {db_exception, cycle_check, string_break};
 

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1261,52 +1261,185 @@ static void dyn_iret(void) {
 }
 
 static void dyn_string(STRING_OP op) {
-	if (decode.rep) MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_ECX,decode.big_addr);
-	else gen_mov_dword_to_reg_imm(FC_OP1,1);
-	gen_mov_word_to_reg(FC_OP2,&cpu.direction,true);
-	uint8_t di_base_addr=decode.seg_prefix_used ? decode.seg_prefix : DRC_SEG_DS;
-	switch (op) {
-		case R_MOVSB:
-			if (decode.big_addr) gen_call_function_mm((void*)&dynrec_movsb_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			else gen_call_function_mm((void*)&dynrec_movsb_word,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			break;
-		case R_MOVSW:
-			if (decode.big_addr) gen_call_function_mm((void*)&dynrec_movsw_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			else gen_call_function_mm((void*)&dynrec_movsw_word,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			break;
-		case R_MOVSD:
-			if (decode.big_addr) gen_call_function_mm((void*)&dynrec_movsd_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			else gen_call_function_mm((void*)&dynrec_movsd_word,(Bitu)DRCD_SEG_PHYS(di_base_addr),(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			break;
-
-		case R_LODSB:
-			if (decode.big_addr) gen_call_function_m((void*)&dynrec_lodsb_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr));
-			else gen_call_function_m((void*)&dynrec_lodsb_word,(Bitu)DRCD_SEG_PHYS(di_base_addr));
-			break;
-		case R_LODSW:
-			if (decode.big_addr) gen_call_function_m((void*)&dynrec_lodsw_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr));
-			else gen_call_function_m((void*)&dynrec_lodsw_word,(Bitu)DRCD_SEG_PHYS(di_base_addr));
-			break;
-		case R_LODSD:
-			if (decode.big_addr) gen_call_function_m((void*)&dynrec_lodsd_dword,(Bitu)DRCD_SEG_PHYS(di_base_addr));
-			else gen_call_function_m((void*)&dynrec_lodsd_word,(Bitu)DRCD_SEG_PHYS(di_base_addr));
-			break;
-
-		case R_STOSB:
-			if (decode.big_addr) gen_call_function_m((void*)&dynrec_stosb_dword,(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			else gen_call_function_m((void*)&dynrec_stosb_word,(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			break;
-		case R_STOSW:
-			if (decode.big_addr) gen_call_function_m((void*)&dynrec_stosw_dword,(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			else gen_call_function_m((void*)&dynrec_stosw_word,(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			break;
-		case R_STOSD:
-			if (decode.big_addr) gen_call_function_m((void*)&dynrec_stosd_dword,(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			else gen_call_function_m((void*)&dynrec_stosd_word,(Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
-			break;
-		default: IllegalOptionDynrec("dyn_string");
+	if (decode.rep) {
+		MOV_REG_WORD_TO_HOST_REG(FC_OP1, DRC_REG_ECX, decode.big_addr);
+	} else {
+		gen_mov_dword_to_reg_imm(FC_OP1, 1);
 	}
-	if (decode.rep) MOV_REG_WORD_FROM_HOST_REG(FC_RETOP,DRC_REG_ECX,decode.big_addr);
+	gen_mov_word_to_reg(FC_OP2, &cpu.direction, true);
+	uint8_t di_base_addr = decode.seg_prefix_used ? decode.seg_prefix
+	                                              : DRC_SEG_DS;
+	switch (op) {
+	case R_MOVSB:
+		if (decode.big_addr) {
+			gen_call_function_mm((void*)&dynrec_movsb_dword,
+			                     (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_mm((void*)&dynrec_movsb_word,
+			                     (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_MOVSW:
+		if (decode.big_addr) {
+			gen_call_function_mm((void*)&dynrec_movsw_dword,
+			                     (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_mm((void*)&dynrec_movsw_word,
+			                     (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_MOVSD:
+		if (decode.big_addr) {
+			gen_call_function_mm((void*)&dynrec_movsd_dword,
+			                     (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_mm((void*)&dynrec_movsd_word,
+			                     (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+
+	case R_LODSB:
+		if (decode.big_addr) {
+			gen_call_function_m((void*)&dynrec_lodsb_dword,
+			                    (Bitu)DRCD_SEG_PHYS(di_base_addr));
+		} else {
+			gen_call_function_m((void*)&dynrec_lodsb_word,
+			                    (Bitu)DRCD_SEG_PHYS(di_base_addr));
+		}
+		break;
+	case R_LODSW:
+		if (decode.big_addr) {
+			gen_call_function_m((void*)&dynrec_lodsw_dword,
+			                    (Bitu)DRCD_SEG_PHYS(di_base_addr));
+		} else {
+			gen_call_function_m((void*)&dynrec_lodsw_word,
+			                    (Bitu)DRCD_SEG_PHYS(di_base_addr));
+		}
+		break;
+	case R_LODSD:
+		if (decode.big_addr) {
+			gen_call_function_m((void*)&dynrec_lodsd_dword,
+			                    (Bitu)DRCD_SEG_PHYS(di_base_addr));
+		} else {
+			gen_call_function_m((void*)&dynrec_lodsd_word,
+			                    (Bitu)DRCD_SEG_PHYS(di_base_addr));
+		}
+		break;
+
+	case R_CMPSB:
+		if (decode.big_addr) {
+			gen_call_function_Imm((void*)&dynrec_cmpsb_dword,
+			                      decode.rep,
+			                      (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                      (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_Imm((void*)&dynrec_cmpsb_word,
+			                      decode.rep,
+			                      (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                      (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_CMPSW:
+		if (decode.big_addr) {
+			gen_call_function_Imm((void*)&dynrec_cmpsw_dword,
+			                      decode.rep,
+			                      (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                      (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_Imm((void*)&dynrec_cmpsw_word,
+			                      decode.rep,
+			                      (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                      (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_CMPSD:
+		if (decode.big_addr) {
+			gen_call_function_Imm((void*)&dynrec_cmpsd_dword,
+			                      decode.rep,
+			                      (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                      (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_Imm((void*)&dynrec_cmpsd_word,
+			                      decode.rep,
+			                      (Bitu)DRCD_SEG_PHYS(di_base_addr),
+			                      (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+
+	case R_STOSB:
+		if (decode.big_addr) {
+			gen_call_function_m((void*)&dynrec_stosb_dword,
+			                    (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_m((void*)&dynrec_stosb_word,
+			                    (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_STOSW:
+		if (decode.big_addr) {
+			gen_call_function_m((void*)&dynrec_stosw_dword,
+			                    (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_m((void*)&dynrec_stosw_word,
+			                    (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_STOSD:
+		if (decode.big_addr) {
+			gen_call_function_m((void*)&dynrec_stosd_dword,
+			                    (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_m((void*)&dynrec_stosd_word,
+			                    (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+
+	case R_SCASB:
+		if (decode.big_addr) {
+			gen_call_function_Im((void*)&dynrec_scasb_dword,
+			                     decode.rep,
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_Im((void*)&dynrec_scasb_word,
+			                     decode.rep,
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_SCASW:
+		if (decode.big_addr) {
+			gen_call_function_Im((void*)&dynrec_scasw_dword,
+			                     decode.rep,
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_Im((void*)&dynrec_scasw_word,
+			                     decode.rep,
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+	case R_SCASD:
+		if (decode.big_addr) {
+			gen_call_function_Im((void*)&dynrec_scasd_dword,
+			                     decode.rep,
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		} else {
+			gen_call_function_Im((void*)&dynrec_scasd_word,
+			                     decode.rep,
+			                     (Bitu)DRCD_SEG_PHYS(DRC_SEG_ES));
+		}
+		break;
+
+	default: IllegalOptionDynrec("dyn_string");
+	}
+
+	if (decode.rep) {
+		MOV_REG_WORD_FROM_HOST_REG(FC_RETOP, DRC_REG_ECX, decode.big_addr);
+	}
 
 	if (op<R_SCASB) {
 		// those string operations are allowed for premature termination

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -1967,6 +1967,441 @@ static uint32_t DRC_CALL_CONV dynrec_stosd_dword(uint32_t count,int32_t add_inde
 	return count_left;
 }
 
+static uint16_t DRC_CALL_CONV dynrec_scasb_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep,
+                                                PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_scasb_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	uint8_t val = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val = mem_readb_inline(di_base + reg_di);
+
+		reg_di += add_index;
+
+		if ((decode_rep == REP_Z) != (val == reg_al)) {
+			break;
+		}
+	}
+
+	lf_var1b    = reg_al;
+	lf_var2b    = val;
+	lf_resb     = lf_var1b - lf_var2b;
+	lflags.type = t_CMPb;
+
+	return count;
+}
+
+static uint32_t DRC_CALL_CONV dynrec_scasb_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep,
+                                                 PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_scasb_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	uint8_t val = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val = mem_readb_inline(di_base + reg_edi);
+
+		reg_edi += add_index;
+
+		if ((decode_rep == REP_Z) != (val == reg_al)) {
+			break;
+		}
+	}
+
+	lf_var1b    = reg_al;
+	lf_var2b    = val;
+	lf_resb     = lf_var1b - lf_var2b;
+	lflags.type = t_CMPb;
+
+	return count;
+}
+
+static uint16_t DRC_CALL_CONV dynrec_scasw_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep,
+                                                PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_scasw_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 1);
+
+	uint16_t val = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val = mem_readw_inline(di_base + reg_di);
+
+		reg_di += add_index;
+
+		if ((decode_rep == REP_Z) != (val == reg_ax)) {
+			break;
+		}
+	}
+
+	lf_var1w    = reg_ax;
+	lf_var2w    = val;
+	lf_resw     = lf_var1w - lf_var2w;
+	lflags.type = t_CMPw;
+
+	return count;
+}
+
+static uint32_t DRC_CALL_CONV dynrec_scasw_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep,
+                                                 PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_scasw_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 1);
+
+	uint16_t val = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val = mem_readw_inline(di_base + reg_edi);
+
+		reg_edi += add_index;
+
+		if ((decode_rep == REP_Z) != (val == reg_ax)) {
+			break;
+		}
+	}
+
+	lf_var1w    = reg_ax;
+	lf_var2w    = val;
+	lf_resw     = lf_var1w - lf_var2w;
+	lflags.type = t_CMPw;
+
+	return count;
+}
+
+static uint16_t DRC_CALL_CONV dynrec_scasd_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep,
+                                                PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_scasd_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 2);
+
+	uint32_t val = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val = mem_readd_inline(di_base + reg_di);
+
+		reg_di += add_index;
+
+		if ((decode_rep == REP_Z) != (val == reg_eax)) {
+			break;
+		}
+	}
+
+	lf_var1d    = reg_eax;
+	lf_var2d    = val;
+	lf_resd     = lf_var1d - lf_var2d;
+	lflags.type = t_CMPd;
+
+	return count;
+}
+
+static uint32_t DRC_CALL_CONV dynrec_scasd_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep,
+                                                 PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_scasd_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 2);
+
+	uint32_t val = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val = mem_readd_inline(di_base + reg_edi);
+
+		reg_edi += add_index;
+
+		if ((decode_rep == REP_Z) != (val == reg_eax)) {
+			break;
+		}
+	}
+
+	lf_var1d    = reg_eax;
+	lf_var2d    = val;
+	lf_resd     = lf_var1d - lf_var2d;
+	lflags.type = t_CMPd;
+
+	return count;
+}
+
+static uint16_t DRC_CALL_CONV dynrec_cmpsb_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep, PhysPt si_base,
+                                                PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_cmpsb_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep,
+                                                PhysPt si_base, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	uint8_t val1 = 0;
+	uint8_t val2 = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val1 = mem_readb_inline(si_base + reg_si);
+		val2 = mem_readb_inline(di_base + reg_di);
+
+		reg_si += add_index;
+		reg_di += add_index;
+
+		if ((decode_rep == REP_Z) != (val1 == val2)) {
+			break;
+		}
+	}
+
+	lf_var1b    = val1;
+	lf_var2b    = val2;
+	lf_resb     = lf_var1b - lf_var2b;
+	lflags.type = t_CMPb;
+
+	return count;
+}
+
+static uint16_t DRC_CALL_CONV dynrec_cmpsb_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep, PhysPt si_base,
+                                                 PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_cmpsb_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep,
+                                                 PhysPt si_base, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	uint8_t val1 = 0;
+	uint8_t val2 = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val1 = mem_readb_inline(si_base + reg_esi);
+		val2 = mem_readb_inline(di_base + reg_edi);
+
+		reg_esi += add_index;
+		reg_edi += add_index;
+
+		if ((decode_rep == REP_Z) != (val1 == val2)) {
+			break;
+		}
+	}
+
+	lf_var1b    = val1;
+	lf_var2b    = val2;
+	lf_resb     = lf_var1b - lf_var2b;
+	lflags.type = t_CMPb;
+
+	return count;
+}
+
+static uint16_t DRC_CALL_CONV dynrec_cmpsw_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep, PhysPt si_base,
+                                                PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_cmpsw_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep,
+                                                PhysPt si_base, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 1);
+
+	uint16_t val1 = 0;
+	uint16_t val2 = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val1 = mem_readw_inline(si_base + reg_si);
+		val2 = mem_readw_inline(di_base + reg_di);
+
+		reg_si += add_index;
+		reg_di += add_index;
+
+		if ((decode_rep == REP_Z) != (val1 == val2)) {
+			break;
+		}
+	}
+
+	lf_var1w    = val1;
+	lf_var2w    = val2;
+	lf_resw     = lf_var1w - lf_var2w;
+	lflags.type = t_CMPw;
+
+	return count;
+}
+
+static uint32_t DRC_CALL_CONV dynrec_cmpsw_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep, PhysPt si_base,
+                                                 PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_cmpsw_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep,
+                                                 PhysPt si_base, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 1);
+
+	uint16_t val1 = 0;
+	uint16_t val2 = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val1 = mem_readw_inline(si_base + reg_esi);
+		val2 = mem_readw_inline(di_base + reg_edi);
+
+		reg_esi += add_index;
+		reg_edi += add_index;
+
+		if ((decode_rep == REP_Z) != (val1 == val2)) {
+			break;
+		}
+	}
+
+	lf_var1w    = val1;
+	lf_var2w    = val2;
+	lf_resw     = lf_var1w - lf_var2w;
+	lflags.type = t_CMPw;
+
+	return count;
+}
+
+static uint16_t DRC_CALL_CONV dynrec_cmpsd_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep, PhysPt si_base,
+                                                PhysPt di_base) DRC_FC;
+static uint16_t DRC_CALL_CONV dynrec_cmpsd_word(uint16_t count, int16_t add_index,
+                                                int32_t decode_rep,
+                                                PhysPt si_base, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 2);
+
+	uint32_t val1 = 0;
+	uint32_t val2 = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val1 = mem_readd_inline(si_base + reg_si);
+		val2 = mem_readd_inline(di_base + reg_di);
+
+		reg_si += add_index;
+		reg_di += add_index;
+
+		if ((decode_rep == REP_Z) != (val1 == val2)) {
+			break;
+		}
+	}
+
+	lf_var1d    = val1;
+	lf_var2d    = val2;
+	lf_resd     = lf_var1d - lf_var2d;
+	lflags.type = t_CMPd;
+
+	return count;
+}
+
+static uint32_t DRC_CALL_CONV dynrec_cmpsd_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep, PhysPt si_base,
+                                                 PhysPt di_base) DRC_FC;
+static uint32_t DRC_CALL_CONV dynrec_cmpsd_dword(uint32_t count, int32_t add_index,
+                                                 int32_t decode_rep,
+                                                 PhysPt si_base, PhysPt di_base)
+{
+	if (count == 0) {
+		return 0;
+	}
+
+	add_index = left_shift_signed(add_index, 2);
+
+	uint32_t val1 = 0;
+	uint32_t val2 = 0;
+
+	while (count > 0) {
+		--count;
+		--CPU_Cycles;
+
+		val1 = mem_readd_inline(si_base + reg_esi);
+		val2 = mem_readd_inline(di_base + reg_edi);
+
+		reg_esi += add_index;
+		reg_edi += add_index;
+
+		if ((decode_rep == REP_Z) != (val1 == val2)) {
+			break;
+		}
+	}
+
+	lf_var1d    = val1;
+	lf_var2d    = val2;
+	lf_resd     = lf_var1d - lf_var2d;
+	lflags.type = t_CMPd;
+
+	return count;
+}
 
 static void DRC_CALL_CONV dynrec_push_word(uint16_t value) DRC_FC;
 static void DRC_CALL_CONV dynrec_push_word(uint16_t value) {


### PR DESCRIPTION
# Description

This PR implements the SCASB/SCASW/SCASD and CMPSB/CMPSW/CMPSD opcodes natively in the dynamic core. These are common in many applications, especially `REPNZ SCASB`, which is often used to find the end of a null-terminated C string, and `REPZ CMPSB` to compare if two strings are equal.

Since these opcodes were not implemented in dynrec, that causes the normal core to spin up and decode, then go back to dynrec, so this should improve performance of these instructions.

# Manual testing

I have tested a handful of games, including Quake, Doom, PERFDOS, Blood, Black Cauldron, King's Quest 2, and Top Bench, forcing `core dynamic` where needed. 

I don't know that you'll visibly notice a performance improvement in most cases. There are some cases that hit it pretty hard, for example in Doom when you hit Quit and it's waiting for your input:

```log
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
2023-11-07 15:16:14.014 | dynrec_scasb_dword
```

Here is Blood, which runs at this pace (~150x per sec) continually:

```log
2023-11-07 18:21:08.314 | dynrec_cmpsb_dword
2023-11-07 18:21:08.326 | dynrec_cmpsb_dword
2023-11-07 18:21:08.354 | dynrec_scasb_dword
2023-11-07 18:21:08.354 | dynrec_scasb_dword
2023-11-07 18:21:08.354 | dynrec_scasb_dword
2023-11-07 18:21:08.354 | dynrec_scasb_dword
2023-11-07 18:21:08.355 | dynrec_cmpsb_dword
2023-11-07 18:21:08.369 | dynrec_cmpsb_dword
2023-11-07 18:21:08.369 | dynrec_cmpsb_dword
2023-11-07 18:21:08.369 | dynrec_cmpsb_dword
2023-11-07 18:21:08.369 | dynrec_cmpsb_dword
2023-11-07 18:21:08.369 | dynrec_cmpsb_dword
2023-11-07 18:21:08.397 | dynrec_scasb_dword
2023-11-07 18:21:08.397 | dynrec_scasb_dword
2023-11-07 18:21:08.397 | dynrec_scasb_dword
2023-11-07 18:21:08.398 | dynrec_scasb_dword
2023-11-07 18:21:08.398 | dynrec_cmpsb_dword
2023-11-07 18:21:08.412 | dynrec_cmpsb_dword
2023-11-07 18:21:08.442 | dynrec_scasb_dword
2023-11-07 18:21:08.442 | dynrec_scasb_dword
2023-11-07 18:21:08.442 | dynrec_scasb_dword
2023-11-07 18:21:08.442 | dynrec_scasb_dword
2023-11-07 18:21:08.442 | dynrec_cmpsb_dword
2023-11-07 18:21:08.454 | dynrec_cmpsb_dword
2023-11-07 18:21:08.482 | dynrec_scasb_dword

```

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

