### PR TITLE
Implement Voodoo usability fixes

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -274,6 +274,12 @@ struct VgaDraw {
 
 	double host_refresh_hz    = RefreshRateHostDefault;
 	double dos_refresh_hz     = RefreshRateDosDefault;
+
+	// The override rate corresponds to the override VGA mode where another
+	// device can take over video output in place of the VGA card, such as
+	// Voodoo.
+	double override_refresh_hz = RefreshRateDosDefault;
+
 	double custom_refresh_hz  = RefreshRateDosDefault;
 	VgaRateMode dos_rate_mode = VgaRateMode::Default;
 
@@ -1120,7 +1126,7 @@ void VGA_SetCGA4Table(uint8_t val0, uint8_t val1, uint8_t val2, uint8_t val3);
 PixelFormat VGA_ActivateHardwareCursor();
 void VGA_KillDrawing(void);
 
-void VGA_SetOverride(bool vga_override);
+void VGA_SetOverride(const bool vga_override, const double override_refresh_hz = 0);
 void VGA_LogInitialization(const char* adapter_name, const char* ram_type,
                            const size_t num_modes);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -704,23 +704,32 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&KEYBOARD_Init);
 	secprop->AddInitFunction(&PCI_Init); // PCI bus
 
-	secprop = control->AddSection_prop("voodoo", &VOODOO_Init, false);
+	secprop = control->AddSection_prop("voodoo", &VOODOO_Init);
 
-	const char* voodootypes[] = {"disabled", "4", "12", nullptr};
-	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "12");
-	pstring->Set_values(voodootypes);
+	pbool = secprop->Add_bool("voodoo", when_idle, true);
+	pbool->Set_help("Enable 3dfx Voodoo emulation (enabled by default).");
+
+	const char* voodoo_memsizes[] = {"4", "12", nullptr};
+
+	pstring = secprop->Add_string("voodoo_memsize",
+	                              only_at_start,
+	                              voodoo_memsizes[0]);
+	pstring->Set_values(voodoo_memsizes);
 	pstring->Set_help(
-	        "Memory size (in MB) of the 3dfx Voodoo card (12 MB as default).");
+	        "Set the amount of video memory for 3dfx Voodoo graphics, either 4 or 12 megabytes.\n"
+	        "The memory is used by the Frame Buffer Interface (FBI) and Texture Mapping Unit (TMU)\n"
+	        "as follows:\n"
+	        "   4: 2 MB for the FBI and one TMU with 2 MB (default)\n"
+	        "  12: 4 MB for the FBI and two TMUs, each with 4 MB.");
 
-	pint = secprop->Add_int("voodoo_perf", only_at_start, 1);
-	pint->SetMinMax(0, 3);
-	pint->Set_help("Performance optimisations to use when emulating the 3dfx Voodoo card:\n"
-	               "   0:  No optimizations.\n"
-	               "   1:  Multi-threading (default).\n"
-	               "   2:  Disable bilinear filtering.\n"
-	               "   3:  All optimizations (both 1 and 2).\n"
-	               "Note: Voodoo emulation is software-based and does not use host-level\n"
-	               "      OpenGL calls.");
+	pbool = secprop->Add_bool("voodoo_multithreading", only_at_start, true);
+	pbool->Set_help("Use threads to improve 3dfx Voodoo performance (enabled by default).");
+
+	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, false);
+	pbool->Set_help(
+	        "Use bilinear filtering to emulate the 3dfx Voodoo's texture\n"
+	        "smoothing effect. Only suggested if you have a fast desktop-class\n"
+	        "CPU, as it can impact frame rates on slower systems (disabled by default).");
 
 	// Configure capture
 	CAPTURE_AddConfigSection(control);

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -262,7 +262,9 @@ double VGA_GetPreferredRate()
 {
 	switch (vga.draw.dos_rate_mode) {
 	case VgaRateMode::Default:
-		return vga.draw.dos_refresh_hz;
+		// If another device is overriding our VGA card, then use its rate
+		return vga.draw.vga_override ? vga.draw.override_refresh_hz
+		                             : vga.draw.dos_refresh_hz;
 	case VgaRateMode::Host:
 		assert(vga.draw.host_refresh_hz > RefreshRateMin);
 		return vga.draw.host_refresh_hz;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2877,12 +2877,13 @@ void VGA_KillDrawing(void) {
 	if (!vga.draw.vga_override) RENDER_EndUpdate(true);
 }
 
-void VGA_SetOverride(bool vga_override) {
-	if (vga.draw.vga_override!=vga_override) {
-
+void VGA_SetOverride(const bool vga_override, const double override_refresh_hz)
+{
+	if (vga.draw.vga_override != vga_override) {
 		if (vga_override) {
 			VGA_KillDrawing();
 			vga.draw.vga_override=true;
+			vga.draw.override_refresh_hz = override_refresh_hz;
 		} else {
 			vga.draw.vga_override=false;
 			vga.draw.render.width=0; // change it so the output window gets updated

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7087,7 +7087,7 @@ static void voodoo_init() {
 	}
 	// Sanity-check sizes
 	assert(fbmemsize > 0);
-	assert(tmumem0 > 0 && tmumem1 > 0);
+	assert(tmumem0 > 0);
 
 	if (tmumem1 != 0) {
 		v->tmu_config |= 0xc0;	// two TMUs


### PR DESCRIPTION
# Description

1. Standardizes the conf settings (defaults shown):

    ```ini
    [voodoo]
    voodoo                    = on
    voodoo_memsize            = 4
    voodoo_multithreading     = true
    voodoo_bilinear_filtering = false
    ```

3. Handles the Voodoo's default 60 Hz refresh rate.
4. Honors any custom `dos_rate` refresh rate while Voodoo is active.
5. ~~Includes the known-compatible `glide2x.ovl` in the Y: resources.~~


## Related issues

Fixes #2803


# Manual testing

- Tested all conf settings: valid and invalid.
- Confirmed Voodoo's 60 Hz refresh rate is used when the voodoo is overriding the VGA card's output.
- Confirmed custom `dos_rate` are honored by the Voodoo output
- Confirmed the bundled OVL is working as expected and being picked up by games, without any interaction on behalf of the user.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

