### PR TITLE
[WIP] Add new `aspect` and `viewport_resolution` modes to support advanced use cases

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -157,7 +157,8 @@ void RENDER_Reinit();
 
 void RENDER_AddConfigSection(const config_ptr_t& conf);
 
-bool RENDER_IsAspectRatioCorrectionEnabled();
+AspectRatioCorrectionMode RENDER_GetAspectRatioCorrectionMode();
+
 const std::string RENDER_GetCgaColorsSetting();
 
 void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette);

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -21,6 +21,7 @@
 #ifndef DOSBOX_SDLMAIN_H
 #define DOSBOX_SDLMAIN_H
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <string.h>
@@ -229,9 +230,8 @@ struct SDL_Block {
 	SDL_Rect updateRects[1024] = {};
 
 	bool use_exact_window_resolution = false;
-	bool use_viewport_limits = false;
 
-	SDL_Point viewport_resolution = {-1, -1};
+	std::optional<SDL_Point> viewport_resolution = {};
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
 	int64_t focus_ticks = 0;

--- a/include/video.h
+++ b/include/video.h
@@ -48,6 +48,8 @@ enum class IntegerScalingMode {
 	Vertical,
 };
 
+enum class AspectRatioCorrectionMode { On, Off, Viewport };
+
 // Graphics standards ordered by time of introduction (and roughly by
 // their capabilities)
 enum class GraphicsStandard { Hercules, Cga, Pcjr, Tga, Ega, Vga, Svga, Vesa };

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -21,6 +21,7 @@
 #include "program_mixer.h"
 
 #include <cctype>
+#include <optional>
 
 #include "ansi_code_markup.h"
 #include "audio_frame.h"
@@ -148,9 +149,9 @@ void Executor::operator()(const SetChorusLevel cmd)
 	}
 }
 
-std::optional<float> parse_percentage(const std::string& s,
-                                      const float min_percent = 0.0f,
-                                      const float max_percent = 100.0f)
+static std::optional<float> parse_percentage(const std::string& s,
+                                             const float min_percent = 0.0f,
+                                             const float max_percent = 100.0f)
 {
 	if (const auto p = parse_float(s); p) {
 		if (*p >= min_percent && *p <= max_percent) {

--- a/src/dos/program_mixer.h
+++ b/src/dos/program_mixer.h
@@ -25,7 +25,6 @@
 
 #include <map>
 #include <memory>
-#include <optional>
 #include <queue>
 #include <set>
 #include <string>

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -765,9 +765,9 @@ static IntegerScalingMode get_integer_scaling_mode_setting()
 		return IntegerScalingMode::Vertical;
 
 	} else {
-		LOG_WARNING("RENDER: Unknown integer scaling mode '%s', defaulting to 'off'",
+		LOG_WARNING("RENDER: Unknown integer scaling mode '%s', defaulting to 'auto'",
 		            mode.c_str());
-		return IntegerScalingMode::Off;
+		return IntegerScalingMode::Auto;
 	}
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1401,14 +1401,14 @@ RenderingBackend GFX_GetRenderingBackend()
 
 static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
 {
-	return sdl.use_viewport_limits
-	             ? SDL_Point{std::min(iround(sdl.viewport_resolution.x *
-	                                         sdl.desktop.dpi_scale),
-	                                  w),
-	                         std::min(iround(sdl.viewport_resolution.y *
-	                                         sdl.desktop.dpi_scale),
-	                                  h)}
-	             : SDL_Point{w, h};
+	if (sdl.viewport_resolution) {
+		return {std::min(iround(sdl.viewport_resolution->x * sdl.desktop.dpi_scale),
+		                 w),
+		        std::min(iround(sdl.viewport_resolution->y * sdl.desktop.dpi_scale),
+		                 h)};
+	} else {
+		return {w, h};
+	}
 }
 
 static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
@@ -2850,8 +2850,7 @@ static SDL_Point clamp_to_minimum_window_dimensions(SDL_Point size)
 
 static void setup_viewport_resolution_from_conf(const std::string &viewport_resolution_val)
 {
-	sdl.use_viewport_limits = false;
-	sdl.viewport_resolution = {-1, -1};
+	sdl.viewport_resolution = {};
 
 	constexpr auto default_val = "fit";
 	if (viewport_resolution_val == default_val)
@@ -2878,22 +2877,28 @@ static void setup_viewport_resolution_from_conf(const std::string &viewport_reso
 		LOG_WARNING("DISPLAY: Requested viewport_resolution of '%s' is outside"
 		            " the desktop '%dx%d' bounds or the 1-100%% range, "
 		            " using the default setting ('%s') instead",
-		            viewport_resolution_val.c_str(), desktop.w,
-		            desktop.h, default_val);
+		            viewport_resolution_val.c_str(),
+		            desktop.w,
+		            desktop.h,
+		            default_val);
 		return;
 	}
 
-	sdl.use_viewport_limits = true;
 	if (p > 0.0f) {
-		sdl.viewport_resolution.x = iround(desktop.w * static_cast<double>(p) / 100.0);
-		sdl.viewport_resolution.y = iround(desktop.h * static_cast<double>(p) / 100.0);
+		sdl.viewport_resolution =
+		        {iround(desktop.w * static_cast<double>(p) / 100.0),
+		         iround(desktop.h * static_cast<double>(p) / 100.0)};
+
 		LOG_MSG("DISPLAY: Limiting viewport resolution to %2.4g%% (%dx%d) of the desktop",
-		        static_cast<double>(p), sdl.viewport_resolution.x, sdl.viewport_resolution.y);
+		        static_cast<double>(p),
+		        sdl.viewport_resolution->x,
+		        sdl.viewport_resolution->y);
 
 	} else {
 		sdl.viewport_resolution = {w, h};
 		LOG_MSG("DISPLAY: Limiting viewport resolution to %dx%d",
-		        sdl.viewport_resolution.x, sdl.viewport_resolution.y);
+		        sdl.viewport_resolution->x,
+		        sdl.viewport_resolution->y);
 	}
 }
 


### PR DESCRIPTION
# Description

__Ok, I got a bit carried away, but this is the LAST NEW FEATURE FROM ME for 0.81.0 I promise 😅__

---

This PR extends the `aspect` and `viewport_resolution` settings to allow for the below advanced use cases:

- **Stretch DOS content to fullscreen** to get rid of the left & right black bars on 16:9 flat panels (requested [here](https://github.com/dosbox-staging/dosbox-staging/issues/1474), by a guy on Discord who had a medical reason for this as the black bars caused him discomfort, and by a couple of people on various forums)

- **"Zoom into" the DOS content** while keeping the correct aspect ratio (requested [here](https://github.com/dosbox-staging/dosbox-staging/discussions/2958))

- **Apply arbitrary aspect ratios manually** (the "anything goes" option—might be handy in some rare situations as this effetively emulates the vsync/hsync controls on a CRT monitor; this was requested for some pinball games [here](https://github.com/dosbox-staging/dosbox-staging/issues/1578))

- **Apply arbitrary aspect ratios _and_ "zoom into" the DOS content at the same time** (the previous two features combined; on a real CRT, you could enlarge the image so much with the horiz/vert size controls that parts of the image got cut off. This is useful for Hercules games that simply reuse the 320x200 assets in the 720x348 Hercules graphics mode; these games appear overly squashed with authentic Hercules emulation and the graphics don't fill the screen horizontally either ([more info](https://www.vogons.org/viewtopic.php?p=1202709#p1202709)))

I wasn't a fan of such requests initially because I thought they would complicate things too much and it would be too hard or even impossible to make them work consistently and logically with our existing features, but I found a way to add support for them cleanly with a minimum set of extra options. These enhancements/changes are:

- 100% backward compatible
- Don't complicate the normal use cases in any way
- Work with integer scaling as one would expect (integer scaling is always aspect-preserving, period)
- Work with upscaled screenshots
- Will work with the planned [overscan/border support](https://github.com/dosbox-staging/dosbox-staging/issues/1792) feature
- Will work with any future video capture enhancements as well (because the images passed to image/video capturer will be simply just tagged with an arbitrary aspect ratio, so things should JustWork(tm))
- We'll also be able to offer "preset" macro-controls on the OSD that set the `aspect`, `viewport_resolution` and `integer_scaling` settings with a minimal amount of clicks to set up:
  - "stretch to viewport" mode,
  - "stretch to rectangle" mode,
  - "zoom in" mode,
  - and "full horiz/vert size control" mode.
- We could even implement horiz/vert size control sliders in the OSD to set the CRT-like image stretching in real-time! 😎 

## Changes

Note that the detailed explanation for these features might sound overly complicated, but in actual use they're quite intuitive as we'll see in the examples in the manual testing section. I just wanted to document the exact behaviour here, that's all.

### New `aspect` mode

In the new `aspect = viewport` mode, the aspect ratio is calculated from the extents of the viewport, overriding the pixel aspect ratio of the DOS video mode. This can be used to:

- fully stretch the DOS content to the emulation window or the whole screen in fullscreen (when `viewport_resolution` is set to `fit`),
- or to force arbitrary pixel aspect ratios (when `viewport_resolution` is set to a concrete `WxH` value or to `overflow WxH%`).

### New `viewport_resolution` modes

There are two new `viewport_resolution` modes:

- `overflow N%` – In this new mode the viewport is scaled to `N` percent of its size (relative to `fit` mode). Going _above_ the dimensions of the window/screen is allowed because of the `overflow` keyword. So, for example `overflow 150%` would "zoom into" the content by 150% while the content remains centered. The nice thing is that the same "zoom" behaviour would happen in fullscreen or any window size because the basis for the scaling is effectively the dimensions of the window or the screen in fullscreen. This is in contrast with the existing `viewport_resolution = N%` option that can only _shrink_ the viewport to a given percentage of the _desktop resolution_. The two percent scaling options serve very different purposes; this will be further clarified in the examples.

- `overflow WxH%` – This mode is useful to "zoom into" the content while also specifying a custom aspect ratio. The basis for the scaling is the _height_ of the window or the screen in fullscreen mode, so `overflow 100x100%` would result in a completely _square viewport_ fitted snugly in the middle of the window or the screen. This is rather intuitive and logical. One has to do some maths to come up with arbitrary aspect ratios and zoom factors; for example, to force stretching the content to 16:9 _and_ zoom it in by 40%:
  - To force 16:9 aspect ratio while using the maximum height of the window/screen:`H = 100` and `W = 16/9 * 100 = 177.78`
  - To additionally zoom in by 40%: `H = 100 * 1.4 = 140` and `W = 177.78 * 1.4 = 248.89`
  - So the final setting to use is `viewport_resolution = overflow 248.89x140%` combined with `aspect = viewport`

Additionally, specifying the `fit` keyword for the existing settings is allowed for extra clarity, so `viewport_resolution = fit 960x720` is same as just `960x720`, and `fit 80%` is the same as `80%`. Allowing both forms is desirable for backward compatiblity and including `fit` makes the settings more self-describing.

## Related issues

A completely full-screen or filled screen option
https://github.com/dosbox-staging/dosbox-staging/issues/1474

Can I enlarge the screen content from the centre?
https://github.com/dosbox-staging/dosbox-staging/discussions/2958

# Manual testing

## Restrict maximum viewport size

```ini
[sdl]
viewport_resolution = fit 80%

# This also works for backward compatibility reasons
#   viewport_resolution = 80%
#
# Or to specify an exact size
#   viewport_resolution = fit 960x720
#   viewport_resolution = 960x720

[render]
# default setting
aspect = on
```

## Restrict maximum viewport size and apply custom aspect ratio (new)

```ini
[sdl]
viewport_resolution = fit 960x960

[render]
aspect = viewport
```

## Stretch DOS content to fullscreen or full window without black bars (new)

```ini
[sdl]
# default setting
viewport_resolution = fit

[render]
aspect = viewport
integer_scaling = off
```

## Zoom into DOS content and keep the correct aspect ratio (new)

```ini
[sdl]
viewport_resolution = overflow 150%

[render]
# default setting
aspect = on
```

## Zoom into DOS content and apply custom aspect ratio (new)

```ini
[sdl]
viewport_resolution = overflow 150x150%

[render]
aspect = viewport
```


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

