### PR TITLE
Draw the video frame in text row-sized chunks

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1425,7 +1425,21 @@ PixelFormat VGA_ActivateHardwareCursor()
 // A single point to set total drawn lines and update affected delay values
 static void setup_line_drawing_delays(const uint32_t total_lines)
 {
-	vga.draw.parts_total = total_lines > 480 ? 1 : total_lines;
+	if (INT10_IsTextMode(*CurMode)) {
+		// In text modes, draw the frame in row-sized chunks, but not
+		// finer. This granarlity avoids showing inter-row changes such
+		// as when the framebuffer is being scrolled or being changed at
+		// the time of vblank.
+		//
+		vga.draw.parts_total = INT10_GetTextRows();
+	} else {
+		// In graphical modes, either draw the entire frame in one-go
+		// for high resolutions, or per-line for low resolutions as
+		// games and demos using these modes were more likely to use
+		// per-line drawing tricks.
+		//
+		vga.draw.parts_total = total_lines > 480 ? 1 : total_lines;
+	}
 
 	vga.draw.delay.parts = vga.draw.delay.vdend / vga.draw.parts_total;
 


### PR DESCRIPTION
# Description

When in text video modes, we were drawing video video frames with per-line timings.  Because DOSBox's own text console rasterizer just draws to the video memory as-is without doing fancy buffer-swapping or flipping, there could be instances where the updating frame "reveals" line-level differences during the frame update.

This PR adjusts the VGA draw part size to match the number of text rows (when in text mode), which granularizes the text updates at the row level to avoid revealing inter-row differences (at the pixel-line level).

Of course - differences can still occur mid-frame, but they will be at the text-row level.

Graphical modes are unaffected.

# Manual testing

Tested rapidly running `ls`, and also tested rapid text-based demos:

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/14202968-b326-491c-80a5-786a4b360c23

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/efa7e6d1-ea68-454d-a3a2-745b7e8ee576


https://github.com/dosbox-staging/dosbox-staging/assets/1557255/af9a4413-16b8-4134-90e1-99ee8bebd0e6



https://github.com/dosbox-staging/dosbox-staging/assets/1557255/e7f53fc6-45cd-40d6-a63d-dfd99769597f


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

