### PR TITLE
Workaround for keyboard problem in Ultima VIII: Pagan

### DIFF
--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -372,6 +372,63 @@ static uint8_t get_translated(const uint8_t byte)
 }
 
 // ***************************************************************************
+// Port disable workaround
+// ***************************************************************************
+
+// TODO: This part is a workaround for 'Ultima VIII: Pagan' problem with
+// non-working keyboard. The proper fix would require larger rework:
+// - it seems that even if keyboard is disabled, the 8042 should fire the
+//   interrupt
+// - testing with 86Box revealed that command 0xad (disable keyboard port) and
+//   0xae (enable port) are being sent by BIOS with each and every key press;
+//   our internal BIOS does not work this way
+//
+// Ignoring command 0xad totally might be risky, as Windows 3.11 for Workgroups
+// disables/reenables the keyboard port during startup and shutdown, issuing
+// controller commands in between; if something disturbs it, we might run into
+// a problem with keyboard/mouse not responding at all.
+//
+// This code re-enables the keyboard after certain time - unless there is
+// some command currently being issued to the controller.
+
+static bool kbd_disabled_timer_running = false;
+static bool kbd_disabled_timer_expired = true;
+
+// Make the delay a little longer than between two bytes of a scancode,
+// even lower values are enough
+constexpr double kbd_disabled_duration_ms = port_delay_ms * 1.5f;
+
+// Forward declaration
+static void restart_kbd_disabled_timer();
+
+static void maybe_reenable_kbd_port()
+{
+	if (is_disabled_kbd && kbd_disabled_timer_expired) {
+		is_disabled_kbd = false;
+	}
+}
+
+static void kbd_disabled_timer_handler(uint32_t /*val*/)
+{
+	kbd_disabled_timer_running = false;
+	kbd_disabled_timer_expired = true;
+
+	if (current_command != Command::None) {
+		restart_kbd_disabled_timer();
+	}
+}
+
+static void restart_kbd_disabled_timer()
+{
+	if (kbd_disabled_timer_running) {
+		PIC_RemoveEvents(kbd_disabled_timer_handler);
+	}
+	PIC_AddEvent(kbd_disabled_timer_handler, kbd_disabled_duration_ms);
+	kbd_disabled_timer_running = true;
+	kbd_disabled_timer_expired = false;
+}
+
+// ***************************************************************************
 // Controller buffer support
 // ***************************************************************************
 
@@ -713,6 +770,7 @@ static void execute_command(const Command command)
 		is_disabled_kbd      = true;
 		uses_kbd_translation = true;
 		passed_self_test     = true;
+		restart_kbd_disabled_timer();
 		flush_buffer();
 		buffer_add(0x55);
 		break;
@@ -721,6 +779,7 @@ static void execute_command(const Command command)
 		// (as with aux port test)
 		// Disables the keyboard port
 		is_disabled_kbd = true;
+		restart_kbd_disabled_timer();
 		flush_buffer();
 		buffer_add(0x00); // as with TestPortAux
 		break;
@@ -746,6 +805,7 @@ static void execute_command(const Command command)
 		// Disable keyboard port; any keyboard command
 		// reenables the port
 		is_disabled_kbd = true;
+		restart_kbd_disabled_timer();
 		break;
 	case Command::EnablePortKbd: // 0xae
 		// Enable the keyboard port
@@ -966,6 +1026,9 @@ static void write_data_port(io_port_t, io_val_t value, io_width_t) // port 0x60
 		// A controller command is waiting for a parameter
 		const auto command = current_command;
 		current_command    = Command::None;
+		if (is_disabled_kbd) {
+			restart_kbd_disabled_timer();
+		}
 
 		const bool should_notify_aux = !I8042_IsReadyForAuxFrame();
 		const bool should_notify_kbd = !I8042_IsReadyForKbdFrame();
@@ -1009,6 +1072,9 @@ static void write_command_port(io_port_t, io_val_t value, io_width_t) // port 0x
 	status_byte.was_last_write_cmd = true;
 
 	current_command = Command::None;
+	if (is_disabled_kbd) {
+		restart_kbd_disabled_timer();
+	}
 	if ((byte <= 0x1f) || (byte >= 0x40 && byte <= 0x5f)) {
 		// AMI BIOS systems command aliases
 		execute_command(static_cast<Command>(byte + 0x20));
@@ -1099,6 +1165,7 @@ bool I8042_IsReadyForAuxFrame()
 
 bool I8042_IsReadyForKbdFrame()
 {
+	maybe_reenable_kbd_port();
 	return !waiting_bytes_from_kbd && !is_disabled_kbd && !is_diagnostic_dump;
 }
 

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -101,7 +101,7 @@ static uint8_t delay_ms = 5;
 // true = delay timer is in progress
 static bool delay_running = false;
 // true = delay timer expired, event can be sent immediately
-static bool delay_finished = true;
+static bool delay_expired = true;
 
 static MouseButtonsAll buttons;     // currently visible button state
 static MouseButtonsAll buttons_all; // state of all 5 buttons as on the host side
@@ -343,8 +343,8 @@ static void maybe_transfer_frame(); // forward declaration
 
 static void delay_handler(uint32_t /*val*/)
 {
-	delay_running  = false;
-	delay_finished = true;
+	delay_running = false;
+	delay_expired = true;
 
 	maybe_transfer_frame();
 }
@@ -355,8 +355,8 @@ static void maybe_start_delay_timer(const uint8_t timer_delay_ms)
 		return;
 	}
 	PIC_AddEvent(delay_handler, timer_delay_ms);
-	delay_running  = true;
-	delay_finished = false;
+	delay_running = true;
+	delay_expired = false;
 }
 
 static bool should_report()
@@ -366,7 +366,7 @@ static bool should_report()
 
 static void maybe_transfer_frame()
 {
-	if (!delay_finished) {
+	if (!delay_expired) {
 		maybe_start_delay_timer(delay_ms);
 		return;
 	}
@@ -750,13 +750,13 @@ static RealPt ps2_callback   = 0;
 
 std::vector<uint8_t> bios_buffer = {};
 
-static bool bios_delay_running  = false;
-static bool bios_delay_finished = true;
+static bool bios_delay_running = false;
+static bool bios_delay_expired = true;
 
 static void bios_delay_handler(uint32_t /*val*/)
 {
-	bios_delay_running  = false;
-	bios_delay_finished = true;
+	bios_delay_running = false;
+	bios_delay_expired = true;
 
 	PIC_ActivateIRQ(mouse_predefined.IRQ_PS2);
 }
@@ -770,15 +770,15 @@ static void bios_maybe_start_delay_timer()
 	}
 
 	PIC_AddEvent(bios_delay_handler, timer_delay_ms);
-	bios_delay_running  = true;
-	bios_delay_finished = false;
+	bios_delay_running = true;
+	bios_delay_expired = false;
 }
 
 static void bios_cancel_delay_timer()
 {
 	PIC_RemoveEvents(bios_delay_handler);
-	bios_delay_running  = false;
-	bios_delay_finished = true;
+	bios_delay_running = false;
+	bios_delay_expired = true;
 }
 
 static bool bios_enable()


### PR DESCRIPTION
# Description

This is a workaround for _Ultima VIII: Pagan_ keyboard problem; it introduces timeout for disabling the keyboard (commands to disable keyboard used to have almost no effect before the rework which introduced the regression).

A proper fix would be too risky for now, as it would involve:
- firing keyboard interrupt for a key press/release even if keyboard is disabled (easy) - this is something the new 8042 emulation missed
- improving our BIOS to work with keyboard most of the time disabled with 0xad command (risky, might easily introduce regressions if not done properly) 


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3104


# Manual testing

1. Start Ultima VIII: Pagan game, press Esc to skip intro, type player name - should work noe.
2. Start Windows 3.11 for Workgroups, quit it - keyboard should still be operable (regression test).


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

