### PR TITLE
Clean up OpenGL attribute init

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -211,6 +211,8 @@ static bool present_frame_texture();
 #if C_OPENGL
 static void update_frame_gl(const uint16_t *changedLines);
 static bool present_frame_gl();
+static const char* safe_gl_get_string(const GLenum requested_name,
+                                      const char* default_result);
 #endif
 
 static const char* vsync_state_as_string(const VsyncState state)
@@ -1307,6 +1309,40 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 		if (rendering_backend == RenderingBackend::OpenGl) {
 			flags |= SDL_WINDOW_OPENGL;
 		}
+
+		// We need a context to query the vendor string.
+		const auto temp_window = SDL_CreateWindow(
+		        "", 0, 0, 200, 200, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+		if (temp_window == nullptr) {
+			LOG_ERR("SDL: Failed to create temporary window: %s",
+			        SDL_GetError());
+			return nullptr;
+		}
+		const auto temp_context = SDL_GL_CreateContext(temp_window);
+		if (temp_context == nullptr) {
+			LOG_ERR("OPENGL: Failed to create temporary context: %s",
+			        SDL_GetError());
+			return nullptr;
+		}
+
+		const std::string gl_vendor = safe_gl_get_string(GL_VENDOR,
+		                                                 "unknown vendor");
+
+		SDL_GL_DeleteContext(temp_context);
+		SDL_DestroyWindow(temp_window);
+#if WIN32
+		const auto is_vendors_srgb_unreliable = (gl_vendor == "Intel");
+#else
+		constexpr auto is_vendors_srgb_unreliable = false;
+#endif
+		if (is_vendors_srgb_unreliable) {
+			LOG_WARNING("OPENGL: Not requesting an sRGB framebuffer"
+			            " because %s's driver is unreliable",
+			            gl_vendor.data());
+		} else if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
+			LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
+			        SDL_GetError());
+		}
 #endif
 		if (!sdl.desktop.window.show_decorations) {
 			flags |= SDL_WINDOW_BORDERLESS;
@@ -1865,24 +1901,6 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			            texsize_h_px);
 			goto fallback_texture;
 		}
-		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-
-		const std::string gl_vendor = safe_gl_get_string(GL_VENDOR,
-		                                                 "unknown vendor");
-#	if WIN32
-		const auto is_vendors_srgb_unreliable = (gl_vendor == "Intel");
-#	else
-		constexpr auto is_vendors_srgb_unreliable = false;
-#	endif
-		if (is_vendors_srgb_unreliable) {
-			LOG_WARNING("OPENGL: Not requesting an sRGB framebuffer "
-			            "because %s's driver is unreliable",
-			            gl_vendor.data());
-
-		} else if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
-			LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
-			        SDL_GetError());
-		}
 
 		// Re-apply the minimum bounds prior to clipping the OpenGL
 		// window because SDL invalidates the prior bounds in the above
@@ -2070,6 +2088,17 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		assert(emptytex);
 
 		memset(emptytex, 0, texture_area_bytes);
+
+		int is_double_buffering_enabled = 0;
+		if (SDL_GL_GetAttribute(SDL_GL_DOUBLEBUFFER,
+		                        &is_double_buffering_enabled)) {
+			LOG_WARNING("OPENGL: Failed getting double buffering status: %s",
+			            SDL_GetError());
+		} else {
+			if (!is_double_buffering_enabled) {
+				LOG_WARNING("OPENGL: Double buffering not enabled");
+			}
+		}
 
 		int is_framebuffer_srgb_capable = 0;
 		if (SDL_GL_GetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,


### PR DESCRIPTION
# Description

This is a pedantic cleanup of the `SDL_GL_SetAttribute()` calls in `sdlmain.cpp`. The [SDL docs](https://wiki.libsdl.org/SDL2/SDL_GLattr) specify that these should be set prior to `SDL_CreateWindow`:

```
While you can set most OpenGL attributes normally, the attributes listed above must be 
known before SDL creates the window that will be used with the OpenGL context.
```

The `SDL_GL_FRAMEBUFFER_SRGB_CAPABLE` attribute requires a bit of hack. The driver vendor cannot be queried without a context, so I create a temporary hidden OpenGL window and context, query the driver, then destroy them.

Also, `SDL_GL_DOUBLEBUFFER` is enabled by default, so I got rid of the call to set that, but, inspired by a Discord comment from @johnnovak, I query the value and display a warning if it's not enabled.

Things seem to be working fine as-is, but given the wide range of quality of OpenGL drivers, let's do it by the book.

# Manual testing

I ran the artifact builds for macOS, Windows, and Linux (via WSL2), verifying `output = opengl` and testing Quake, Doom, King's Quest 3, Future Crew's Panic, Unreal, and Second Reality.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

