### PR TITLE
Always write the default config if the primary config file is missing

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4558,13 +4558,11 @@ int sdl_main(int argc, char* argv[])
 		// Register DOSBox's (and all modules) messages and conf sections
 		DOSBOX_Init();
 
-		// After DOSBOX_Init() is done, all the conf sections have been
-		// registered, so we're ready to parse the conf files.
-		//
-		ParseConfigFiles(GetConfigDir());
-
-		// Write the default primary config if it doesn't exist when:
+		// Before loading any configs, write the default primary config if it
+		// doesn't exist when:
 		// - secure mode is NOT enabled with the '--securemode' option,
+		// - AND we're not in portable mode (portable mode is enabled when
+		//   'dosbox-staging.conf' exists in the executable directory)
 		// - AND the primary config is NOT disabled with the
 		//   '--noprimaryconf' option.
 		if (!arguments->securemode && !arguments->noprimaryconf) {
@@ -4583,6 +4581,11 @@ int sdl_main(int argc, char* argv[])
 				}
 			}
 		}
+
+		// After DOSBOX_Init() is done, all the conf sections have been
+		// registered, so we're ready to parse the conf files.
+		//
+		ParseConfigFiles(GetConfigDir());
 
 		// Handle command line options that don't start the emulator but only
 		// perform some actions and print the results to the console.


### PR DESCRIPTION
# Description

Fixes #3116

Prior to this change, if the primary config file was missing, it was created, but instead of the defaults, the current config settings were written. This included the local `dosbox.conf` if it existed and any extra configs loaded with the `--conf` CLI option on top of the actual defaults.

This change ensures that if we create the primary config on startup, it always contains the defaults and nothing else.

# Manual testing

### If the primary config does NOT exist in the user folder

#### Test 1

- Started Staging in a directory that has a local config that set cycles to 6666.
- Confirmed the primary config was created with the defaults
- Confirmed "Created primary config file" comes before "Loaded local config file 'dosbox.conf'" in the logs.

#### Test 2

- Started Staging in the same directory with `--nolocalconf --conf dosbox.conf`.
- Confirmed the primary config was created with the defaults.
- Confirmed "Created primary config file" comes before "Loaded custom config file 'dosbox.conf'" in the logs.

#### Test 3

- Started Staging with `--machine hercules --set cycles=6666`.
- Confirmed the primary config was created with the defaults.

#### Test 4

- Confirmed the primary config is not created when the `--noprimaryconf` option is present, regardless of the presence of the local config or any other CLI options.

#### Test 5

- Confirmed the primary config is not created when launching Staging in portable mode (`dosbox-staging.conf` exists in the executable directory).

### If the primary config DOES exist in the user folder

Confirmed that it never gets recreated or overwritten in any of the above test cases.



# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

