### PR TITLE
Improve handling of deprecated settings and other setting related improvements

### DIFF
--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -21,6 +21,7 @@
 #include "program_mixer.h"
 
 #include <cctype>
+#include <optional>
 
 #include "ansi_code_markup.h"
 #include "audio_frame.h"
@@ -148,9 +149,9 @@ void Executor::operator()(const SetChorusLevel cmd)
 	}
 }
 
-std::optional<float> parse_percentage(const std::string& s,
-                                      const float min_percent = 0.0f,
-                                      const float max_percent = 100.0f)
+static std::optional<float> parse_percentage(const std::string& s,
+                                             const float min_percent = 0.0f,
+                                             const float max_percent = 100.0f)
 {
 	if (const auto p = parse_float(s); p) {
 		if (*p >= min_percent && *p <= max_percent) {

--- a/src/dos/program_mixer.h
+++ b/src/dos/program_mixer.h
@@ -25,7 +25,6 @@
 
 #include <map>
 #include <memory>
-#include <optional>
 #include <queue>
 #include <set>
 #include <string>

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -851,7 +851,7 @@ static void init_render_settings(Section_prop& secprop)
 	        "    options instead.");
 
 #if C_OPENGL
-	string_prop = secprop.Add_path("glshader", always, "crt-auto");
+	string_prop = secprop.Add_string("glshader", always, "crt-auto");
 	string_prop->Set_help(
 	        "Set an adaptive CRT monitor emulation shader or a regular GLSL shader in OpenGL \n"
 	        "output modes.\n"
@@ -912,14 +912,16 @@ static bool handle_shader_changes()
 
 	auto& shader_manager = get_shader_manager();
 
+	constexpr auto glshader_setting_name = "glshader";
+
 	if (GFX_GetRenderingBackend() == RenderingBackend::OpenGl) {
 		const auto section     = get_render_section();
 		const auto shader_name = shader_manager.MapShaderName(
-		        section->Get_string("glshader"));
+		        section->Get_string(glshader_setting_name));
 
 		shader_manager.NotifyGlshaderSettingChanged(shader_name);
 
-		const auto string_prop = section->GetStringProp("glshader");
+		const auto string_prop = section->GetStringProp(glshader_setting_name);
 		string_prop->SetValue(shader_name);
 	}
 	const auto new_shader_name = shader_manager.GetCurrentShaderInfo().name;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -759,7 +759,7 @@ static void init_render_settings(Section_prop& secprop)
 
 	auto* int_prop = secprop.Add_int("frameskip", deprecated, 0);
 	int_prop->Set_help(
-	        "Consider capping frame-rates using the '[sdl] host_rate' setting.");
+	        "Consider capping frame rates using the 'host_rate' setting.");
 
 	auto* bool_prop = secprop.Add_bool("aspect", always, true);
 	bool_prop->Set_help(

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4189,8 +4189,11 @@ static void config_add_sdl() {
 	Pint->Set_help("Set the transparency of the DOSBox Staging screen (0 by default).\n"
 	               "From 0 (no transparency) to 90 (high transparency).");
 
-	pstring = sdl_sec->Add_string("max_resolution", deprecated, "");
-	pstring->Set_help("This setting has been renamed to viewport_resolution.");
+	pstring = sdl_sec->Add_path("max_resolution", deprecated, "");
+	pstring->Set_help("Renamed to 'viewport_resolution'.");
+
+	pstring = sdl_sec->Add_path("viewport_resolution", deprecated, "");
+	pstring->Set_help("Moved to [render] section.");
 
 	pstring = sdl_sec->Add_string("host_rate", on_start, "auto");
 	pstring->Set_help(
@@ -4270,13 +4273,13 @@ static void config_add_sdl() {
 	pstring->Set_values(get_sdl_texture_renderers());
 
 	Pmulti = sdl_sec->AddMultiVal("capture_mouse", deprecated, ",");
-	Pmulti->Set_help("Moved to [mouse] section.");
+	Pmulti->Set_help("Moved to [mouse] section and renamed to 'mouse_capture'.");
 
 	Pmulti = sdl_sec->AddMultiVal("sensitivity", deprecated, ",");
-	Pmulti->Set_help("Moved to [mouse] section.");
+	Pmulti->Set_help("Moved to [mouse] section and renamed to 'mouse_sensitivity'.");
 
 	pbool = sdl_sec->Add_bool("raw_mouse_input", deprecated, false);
-	pbool->Set_help("Moved to [mouse] section.");
+	pbool->Set_help("Moved to [mouse] section and renamed to 'mouse_raw_input'.");
 
 	Pbool = sdl_sec->Add_bool("waitonerror", always, true);
 	Pbool->Set_help("Keep the console open if an error has occurred (enabled by default).");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4189,7 +4189,7 @@ static void config_add_sdl() {
 	Pint->Set_help("Set the transparency of the DOSBox Staging screen (0 by default).\n"
 	               "From 0 (no transparency) to 90 (high transparency).");
 
-	pstring = sdl_sec->Add_path("max_resolution", deprecated, "");
+	pstring = sdl_sec->Add_string("max_resolution", deprecated, "");
 	pstring->Set_help("This setting has been renamed to viewport_resolution.");
 
 	pstring = sdl_sec->Add_string("host_rate", on_start, "auto");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -550,6 +550,9 @@ void CONFIG::Run(void)
 					if (p == nullptr) {
 						break;
 					}
+					if (p->IsDeprecated()) {
+						continue;
+					}
 					WriteOut("  - %s\n", p->propname.c_str());
 				}
 			} else {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -452,7 +452,8 @@ void CONFIG::Run(void)
 				// write config to startup directory
 				WriteConfig(pvars[0]);
 			} else {
-				// -wc without parameter: write dosbox.conf to startup directory
+				// -wc without parameter: write dosbox.conf to
+				// startup directory
 				if (control->configfiles.size()) {
 					WriteConfig("dosbox.conf");
 				} else {
@@ -586,7 +587,8 @@ void CONFIG::Run(void)
 								oss << pint->GetMin();
 								oss << "..";
 								oss << pint->GetMax();
-								possible_values += oss.str();
+								possible_values +=
+								        oss.str();
 							}
 						}
 						for (Bitu k = 0; k < pv.size(); k++) {
@@ -594,7 +596,8 @@ void CONFIG::Run(void)
 								possible_values += MSG_Get(
 								        "PROGRAM_CONFIG_HLP_POSINT");
 							} else {
-								possible_values += pv[k].ToString();
+								possible_values +=
+								        pv[k].ToString();
 							}
 							if ((k + 1) < pv.size()) {
 								possible_values += ", ";
@@ -606,19 +609,23 @@ void CONFIG::Run(void)
 						         sec->GetName(),
 						         p->GetHelp());
 
-						if (!possible_values.empty()) {
-							WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_POSSIBLE_VALUES"),
-									 possible_values.c_str());
+						if (!p->IsDeprecated()) {
+							if (!possible_values.empty()) {
+								WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_POSSIBLE_VALUES"),
+								         possible_values
+								                 .c_str());
+							}
+
+							WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_DEFAULT_VALUE"),
+							         p->GetDefaultValue()
+							                 .ToString()
+							                 .c_str());
+
+							WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE"),
+							         p->GetValue()
+							                 .ToString()
+							                 .c_str());
 						}
-
-						WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_DEFAULT_VALUE"),
-						         p->GetDefaultValue()
-						                 .ToString()
-						                 .c_str());
-
-						WriteOut(
-						        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE"),
-						        p->GetValue().ToString().c_str());
 
 						// print 'changability'
 						if (p->GetChange() ==

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -563,13 +563,13 @@ void CONFIG::Run(void)
 					                pvars[1].c_str())) {
 						// found it; make the list of
 						// possible values
-						std::string propvalues;
+						std::string possible_values;
 						std::vector<Value> pv = p->GetValues();
 
 						if (p->Get_type() == Value::V_BOOL) {
 							// possible values for
 							// boolean are true, false
-							propvalues += "true, false";
+							possible_values += "true, false";
 						} else if (p->Get_type() ==
 						           Value::V_INT) {
 							// print min, max for
@@ -586,31 +586,40 @@ void CONFIG::Run(void)
 								oss << pint->GetMin();
 								oss << "..";
 								oss << pint->GetMax();
-								propvalues += oss.str();
+								possible_values += oss.str();
 							}
 						}
 						for (Bitu k = 0; k < pv.size(); k++) {
 							if (pv[k].ToString() == "%u") {
-								propvalues += MSG_Get(
+								possible_values += MSG_Get(
 								        "PROGRAM_CONFIG_HLP_POSINT");
 							} else {
-								propvalues += pv[k].ToString();
+								possible_values += pv[k].ToString();
 							}
 							if ((k + 1) < pv.size()) {
-								propvalues += ", ";
+								possible_values += ", ";
 							}
 						}
 
+						WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
+						         p->propname.c_str(),
+						         sec->GetName(),
+						         p->GetHelp());
+
+						if (!possible_values.empty()) {
+							WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_POSSIBLE_VALUES"),
+									 possible_values.c_str());
+						}
+
+						WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_DEFAULT_VALUE"),
+						         p->GetDefaultValue()
+						                 .ToString()
+						                 .c_str());
+
 						WriteOut(
-						        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
-						        p->propname.c_str(),
-						        sec->GetName(),
-						        p->GetHelp(),
-						        propvalues.c_str(),
-						        p->GetDefaultValue()
-						                .ToString()
-						                .c_str(),
+						        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE"),
 						        p->GetValue().ToString().c_str());
+
 						// print 'changability'
 						if (p->GetChange() ==
 						    Property::Changeable::OnlyAtStart) {
@@ -932,14 +941,20 @@ void PROGRAMS_Init(Section* sec)
 
 	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP",
 	        "[color=white]Purpose of property [color=light-green]'%s'[color=white] "
-			"(contained in section [color=light-cyan][%s][color=white]):[reset]\n\n%s\n\n"
-	        "[color=white]Possible values:[reset]  %s\n"
-	        "[color=white]Default value:[reset]    %s\n"
+	        "(contained in section [color=light-cyan][%s][color=white]):[reset]\n\n%s\n\n");
+
+	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP_POSSIBLE_VALUES",
+	        "[color=white]Possible values:[reset]  %s\n");
+
+	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP_DEFAULT_VALUE",
+	        "[color=white]Default value:[reset]    %s\n");
+
+	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE",
 	        "[color=white]Current value:[reset]    %s\n");
 
 	MSG_Add("PROGRAM_CONFIG_HLP_LINEHLP",
 	        "[color=white]Purpose of section [%s]:[reset]\n"
-			"%s\n[color=white]Current value:[reset]\n%s\n");
+	        "%s\n[color=white]Current value:[reset]\n%s\n");
 
 	MSG_Add("PROGRAM_CONFIG_HLP_NOCHANGE",
 	        "This property cannot be changed at runtime.\n");


### PR DESCRIPTION
# Description

What the title says 😎 Just some minor enhancements. See commit messages and the manual tests for additional details.

# Manual testing

Empty "Possible values: " lines are not printed now as it's confusing and makes no sense. For example:

<img width="1037" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/916f4c48-4ba6-4c95-9873-a6788cf87592">

---
The whole values section is omitted for deprecated settings:

<img width="978" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/7e3c5803-4c84-441b-8472-39db49f48c2e">

---
"Possible values" are still printed for settings where there is a well-defined range/set of values:

<img width="1005" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/ff055076-1603-4e04-baa0-700871642020">


<img width="975" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/9a5ef81f-2dff-420d-906b-9eb6b670a31d">


<img width="982" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/cdf48f1e-e863-452c-9c31-0fc2208f2570">

---

Deprecated properties are now omitted when listing section properties (the `[sdl]` section contains a bunch of deprecated mouse related settings not shown in the listing):

<img width="897" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/e655bdf3-6b45-450d-a25e-e29b84c3f7de">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

