### PR TITLE
Fix register-level PS/2 mouse access when DOS mouse driver is disabled

### DIFF
--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -536,7 +536,9 @@ static void cmd_reset(bool is_startup = false)
 	set_protocol(MouseModelPS2::Standard);
 	frame.clear();
 
-	if (!is_startup) {
+	if (is_startup) {
+		PIC_SetIRQMask(mouse_predefined.IRQ_PS2, false);
+	} else {
 		I8042_AddAuxByte(0xaa); // self-test passed
 		cmd_get_dev_id();
 	}


### PR DESCRIPTION
# Description

Fixes the problem with PS/2 mouse not working in Windows 3.11 for Workgroups when our internal DOS driver was disabled.
Problem reason: DOS driver sets the mouse IRQ mask to false while initialization, which seems to be expected by Windows; this did not happen when our internal DOS driver was disabled.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3095


# Manual testing

To verify changes, put the following lines in the configuration file:

```
[mouse]
dos_mouse_driver = false
ps2_mouse_model  = explorer
```

and start Windows 3.11 (or boot Windows 95) with PS/2 mouse driver. Before the change mouse doesn't work, now it does.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

