### PR TITLE
Always log OpenGL shader and program info logs if they're non-empty

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -925,7 +925,7 @@ static void set_vsync(const VsyncState state)
 									: "0";
 	if (SDL_SetHint(SDL_HINT_RENDER_VSYNC, hint_str) == SDL_TRUE)
 		return;
-	LOG_WARNING("SDL: Failed setting SDL's vsync state to to %s (%s): %s",
+	LOG_WARNING("SDL: Failed setting vsync state to to %s (%s): %s",
 				vsync_state_as_string(state), hint_str, SDL_GetError());
 }
 
@@ -1325,7 +1325,10 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 		displayMode.h = height;
 
 		if (SDL_SetWindowDisplayMode(sdl.window, &displayMode) != 0) {
-			LOG_WARNING("SDL: Failed setting fullscreen mode to %dx%d at %d Hz", displayMode.w, displayMode.h, displayMode.refresh_rate);
+			LOG_WARNING("SDL: Failed setting fullscreen mode to %dx%d at %d Hz",
+			            displayMode.w,
+			            displayMode.h,
+			            displayMode.refresh_rate);
 		}
 		SDL_SetWindowFullscreen(sdl.window,
 		                        sdl.desktop.full.display_res
@@ -1664,7 +1667,7 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		if (!SetupWindowScaled(RenderingBackend::Texture)) {
 			LOG_ERR("DISPLAY: Can't initialise 'texture' window");
-			E_Exit("SDL: Creating window failed");
+			E_Exit("SDL: Failed to create window");
 		}
 
 		/* Use renderer's default format */
@@ -2811,13 +2814,20 @@ static void maybe_limit_requested_resolution(int &w, int &h, const char *size_de
 		w = desktop.w;
 		h = desktop.h;
 		was_limited = true;
-		LOG_WARNING("DISPLAY: Limitting %s resolution to '%dx%d' to avoid kmsdrm issues",
-		            size_description, w, h);
+		LOG_WARNING("DISPLAY: Limiting %s resolution to '%dx%d' to avoid kmsdrm issues",
+		            size_description,
+		            w,
+		            h);
 	}
 
 	if (!was_limited)
-		LOG_INFO("DISPLAY: Accepted %s resolution %dx%d despite exceeding the %dx%d display",
-		         size_description, w, h, desktop.w, desktop.h);
+		LOG_INFO("DISPLAY: Accepted %s resolution %dx%d despite exceeding "
+		         "the %dx%d display",
+		         size_description,
+		         w,
+		         h,
+		         desktop.w,
+		         desktop.h);
 }
 
 static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
@@ -2834,8 +2844,10 @@ static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
 		return {w, h};
 	}
 
-	LOG_WARNING("DISPLAY: Requested windowresolution '%s' is not valid, falling back to '%dx%d' instead",
-	            pref.c_str(), FALLBACK_WINDOW_DIMENSIONS.x,
+	LOG_WARNING("DISPLAY: Requested windowresolution '%s' is not valid, "
+	            "falling back to '%dx%d' instead",
+	            pref.c_str(),
+	            FALLBACK_WINDOW_DIMENSIONS.x,
 	            FALLBACK_WINDOW_DIMENSIONS.y);
 
 	return FALLBACK_WINDOW_DIMENSIONS;
@@ -2946,7 +2958,8 @@ static void setup_initial_window_position_from_conf(const std::string &window_po
 	int x, y;
 	const auto was_parsed = sscanf(window_position_val.c_str(), "%d,%d", &x, &y) == 2;
 	if (!was_parsed) {
-		LOG_WARNING("DISPLAY: Requested window_position '%s' was not in X,Y format, using 'auto' instead",
+		LOG_WARNING("DISPLAY: Requested window_position '%s' was not in X,Y format; "
+		            "using 'auto' instead",
 		            window_position_val.c_str());
 		return;
 	}
@@ -2955,9 +2968,13 @@ static void setup_initial_window_position_from_conf(const std::string &window_po
 	const bool is_out_of_bounds = x < 0 || x > desktop.w || y < 0 ||
 	                              y > desktop.h;
 	if (is_out_of_bounds) {
-		LOG_WARNING("DISPLAY: Requested window_position '%d,%d' is outside the bounds of the desktop '%dx%d', "
+		LOG_WARNING("DISPLAY: Requested window_position '%d,%d' is outside "
+		            "the bounds of the desktop '%dx%d', "
 		            "using 'auto' instead",
-		            x, y, desktop.w, desktop.h);
+		            x,
+		            y,
+		            desktop.w,
+		            desktop.h);
 		return;
 	}
 
@@ -3224,7 +3241,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 #endif
 
 	} else {
-		LOG_WARNING("SDL: Unsupported output device %s, switching back to texture",
+		LOG_WARNING("SDL: Unsupported output device '%s', using 'texture' output mode",
 		            output.c_str());
 		sdl.want_rendering_backend = RenderingBackend::Texture;
 	}
@@ -3240,7 +3257,8 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	if (sdl.render_driver != "auto") {
 		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER,
 		                sdl.render_driver.c_str()) == SDL_FALSE) {
-			LOG_WARNING("SDL: Failed to set '%s' texture renderer driver; falling back to automatic selection",
+			LOG_WARNING("SDL: Failed to set '%s' texture renderer driver; "
+			            "falling back to automatic selection",
 			            sdl.render_driver.c_str());
 		}
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1664,7 +1664,7 @@ uint8_t GFX_SetSize(const int width, const int height,
 
 		if (!SetupWindowScaled(RenderingBackend::Texture)) {
 			LOG_ERR("DISPLAY: Can't initialise 'texture' window");
-			E_Exit("Creating window failed");
+			E_Exit("SDL: Creating window failed");
 		}
 
 		/* Use renderer's default format */
@@ -3356,7 +3356,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 #endif    // OPENGL
 
 	if (!SetDefaultWindowMode())
-		E_Exit("Could not initialize video: %s", SDL_GetError());
+		E_Exit("SDL: Could not initialize video: %s", SDL_GetError());
 
 	const auto transparency = clamp(section->Get_int("transparency"), 0, 90);
 	const auto alpha = static_cast<float>(100 - transparency) / 100.0f;
@@ -4720,10 +4720,10 @@ int sdl_main(int argc, char* argv[])
 		}
 
 		if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO) < 0) {
-			E_Exit("Can't init SDL %s", SDL_GetError());
+			E_Exit("SDL: Can't init SDL %s", SDL_GetError());
 		}
 		if (SDL_CDROMInit() < 0) {
-			LOG_WARNING("Failed to init CD-ROM support");
+			LOG_WARNING("SDL: Failed to init CD-ROM support");
 		}
 
 		sdl.initialized = true;
@@ -4754,7 +4754,7 @@ int sdl_main(int argc, char* argv[])
 			const char* result = SetProp(pvars);
 
 			if (strlen(result)) {
-				LOG_WARNING("%s", result);
+				LOG_WARNING("CONFIG: %s", result);
 			} else {
 				Section* tsec = control->GetSection(pvars[0]);
 				std::string value(pvars[2]);
@@ -4776,7 +4776,7 @@ int sdl_main(int argc, char* argv[])
 				        inputline.c_str());
 
 				if (!change_success && !value.empty()) {
-					LOG_WARNING("Cannot set \"%s\"\n",
+					LOG_WARNING("CONFIG: Cannot set '%s'",
 					            inputline.c_str());
 				}
 			}


### PR DESCRIPTION
# Description

After compiling an OpenGL shader and linking a shader program, the vendor-specific OpenGL info logs might contain warnings and helpful informational messages even if the compilation/linking status was successful, so we'll always log them if they're non-empty.

This might or might not help diagnose shader issues (like this one https://github.com/dosbox-staging/dosbox-staging/issues/3114), but it's good practice to do it anyway.

For the record, these info logs stay empty with all the new adaptive CRT shaders on my MacBook M1 Pro with an integrated GPU.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3114

# Manual testing

Started up Staging with the adaptive CRT shaders. Nothing extra got logged and the shaders were working fine with various window sizes and in fullscreen.

Trace logged that the info log sizes are zero, so the no extra logging checks out.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

