### PR TITLE
`sdlmain` improvements

### DIFF
--- a/include/rect.h
+++ b/include/rect.h
@@ -1,0 +1,67 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_RECTANGLE_H
+#define DOSBOX_RECTANGLE_H
+
+#include "math_utils.h"
+
+namespace DosBox {
+
+// Struct to represent rectangles.
+struct Rect {
+	constexpr Rect() = default;
+
+	constexpr Rect(const float _w, const float _h)
+	        : x(0.0f),
+	          y(0.0f),
+	          w(_w),
+	          h(_h)
+	{}
+
+	constexpr Rect(const int _w, const int _h)
+	        : x(static_cast<float>(0.0f)),
+	          y(static_cast<float>(0.0f)),
+	          w(static_cast<float>(_w)),
+	          h(static_cast<float>(_h))
+	{}
+	constexpr Rect(const float _x, const float _y, const float _w, const float _h)
+	        : x(_x),
+	          y(_y),
+	          w(_w),
+	          h(_h)
+	{}
+
+	constexpr Rect(const int _x, const int _y, const int _w, const int _h)
+	        : x(static_cast<float>(_x)),
+	          y(static_cast<float>(_y)),
+	          w(static_cast<float>(_w)),
+	          h(static_cast<float>(_h))
+	{}
+
+	float x = 0;
+	float y = 0;
+	float w = 0;
+	float h = 0;
+};
+
+} // namespace DosBox
+
+#endif

--- a/include/render.h
+++ b/include/render.h
@@ -176,8 +176,8 @@ void RENDER_EndUpdate(bool abort);
 void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                        const uint8_t green, const uint8_t blue);
 
-bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
-                                  [[maybe_unused]] const uint16_t canvas_height,
+bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width_px,
+                                  [[maybe_unused]] const uint16_t canvas_height_px,
                                   [[maybe_unused]] const VideoMode& video_mode,
                                   [[maybe_unused]] const bool reinit_render);
 

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -203,7 +203,7 @@ struct SDL_Block {
 	bool mute_when_inactive  = false;
 	bool pause_when_inactive = false;
 
-	SDL_Rect clip = {0, 0, 0, 0};
+	SDL_Rect clip_px = {0, 0, 0, 0};
 	SDL_Window *window = nullptr;
 	SDL_Renderer *renderer = nullptr;
 	std::string render_driver = "";

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -103,8 +103,8 @@ struct SDL_Block {
 	IntegerScalingMode integer_scaling_mode = IntegerScalingMode::Off;
 
 	struct {
-		int width = 0;
-		int height = 0;
+		int width_px = 0;
+		int height_px = 0;
 		Fraction render_pixel_aspect_ratio = {1};
 
 		bool has_changed = false;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -21,6 +21,7 @@
 #ifndef DOSBOX_SDLMAIN_H
 #define DOSBOX_SDLMAIN_H
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <string.h>
@@ -229,9 +230,8 @@ struct SDL_Block {
 	SDL_Rect updateRects[1024] = {};
 
 	bool use_exact_window_resolution = false;
-	bool use_viewport_limits = false;
 
-	SDL_Point viewport_resolution = {-1, -1};
+	std::optional<SDL_Point> viewport_resolution = {};
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
 	int64_t focus_ticks = 0;

--- a/include/video.h
+++ b/include/video.h
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "fraction.h"
+#include "rect.h"
 #include "setup.h"
 #include "types.h"
 
@@ -351,14 +352,13 @@ bool GFX_HaveDesktopEnvironment();
 void MAPPER_UpdateJoysticks(void);
 #endif
 
-struct SDL_Rect;
+DosBox::Rect GFX_CalcViewportInPixels(const int canvas_width_px,
+                                      const int canvas_height_px,
+                                      const int draw_width_px,
+                                      const int draw_height_px,
+                                      const Fraction& render_pixel_aspect_ratio);
 
-SDL_Rect GFX_CalcViewportInPixels(const int canvas_width_px,
-                                  const int canvas_height_px,
-                                  const int draw_width_px, const int draw_height_px,
-                                  const Fraction& render_pixel_aspect_ratio);
-
-SDL_Rect GFX_GetCanvasSizeInPixels();
+DosBox::Rect GFX_GetCanvasSizeInPixels();
 
 RenderingBackend GFX_GetRenderingBackend();
 

--- a/include/video.h
+++ b/include/video.h
@@ -353,11 +353,12 @@ void MAPPER_UpdateJoysticks(void);
 
 struct SDL_Rect;
 
-SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
-                          const int draw_width, const int draw_height,
-                          const Fraction& render_pixel_aspect_ratio);
+SDL_Rect GFX_CalcViewportInPixels(const int canvas_width_px,
+                                  const int canvas_height_px,
+                                  const int draw_width, const int draw_height,
+                                  const Fraction& render_pixel_aspect_ratio);
 
-SDL_Rect GFX_GetCanvasSize();
+SDL_Rect GFX_GetCanvasSizeInPixels();
 
 RenderingBackend GFX_GetRenderingBackend();
 

--- a/include/video.h
+++ b/include/video.h
@@ -312,7 +312,7 @@ InterpolationMode GFX_GetInterpolationMode();
 struct VideoMode;
 class Fraction;
 
-uint8_t GFX_SetSize(const int width, const int height,
+uint8_t GFX_SetSize(const int width_px, const int height_px,
                     const Fraction& render_pixel_aspect_ratio, const uint8_t flags,
                     const VideoMode& video_mode, GFX_CallBack_t callback);
 
@@ -355,7 +355,7 @@ struct SDL_Rect;
 
 SDL_Rect GFX_CalcViewportInPixels(const int canvas_width_px,
                                   const int canvas_height_px,
-                                  const int draw_width, const int draw_height,
+                                  const int draw_width_px, const int draw_height_px,
                                   const Fraction& render_pixel_aspect_ratio);
 
 SDL_Rect GFX_GetCanvasSizeInPixels();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -380,7 +380,7 @@ void DOSBOX_SetMachineTypeFromConfig(Section_prop* section)
 	} else if (mtype == "svga_paradise") {
 		svgaCard = SVGA_ParadisePVGA1A;
 	} else {
-		E_Exit("DOSBOX:Unknown machine type %s", mtype.c_str());
+		E_Exit("DOSBOX: Invalid machine type '%s'", mtype.c_str());
 	}
 
 	// VGA-type machine needs an valid SVGA card and vice-versa

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -659,8 +659,8 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 		const auto canvas_px = GFX_GetCanvasSizeInPixels();
 
 		constexpr auto reinit_render = true;
-		RENDER_MaybeAutoSwitchShader(canvas_px.w,
-		                             canvas_px.h,
+		RENDER_MaybeAutoSwitchShader(iroundf(canvas_px.w),
+		                             iroundf(canvas_px.h),
 		                             video_mode,
 		                             reinit_render);
 	}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -656,10 +656,13 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 		video_mode.has_vga_colors = true;
 
 		// We are potentially auto-switching to a VGA shader now.
-		const auto canvas = GFX_GetCanvasSize();
+		const auto canvas_px = GFX_GetCanvasSizeInPixels();
 
 		constexpr auto reinit_render = true;
-		RENDER_MaybeAutoSwitchShader(canvas.w, canvas.h, video_mode, reinit_render);
+		RENDER_MaybeAutoSwitchShader(canvas_px.w,
+		                             canvas_px.h,
+		                             video_mode,
+		                             reinit_render);
 	}
 }
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -596,8 +596,8 @@ static void setup_scan_and_pixel_doubling()
 	VGA_EnablePixelDoubling(!force_no_pixel_doubling);
 }
 
-bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
-                                  [[maybe_unused]] const uint16_t canvas_height,
+bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width_px,
+                                  [[maybe_unused]] const uint16_t canvas_height_px,
                                   [[maybe_unused]] const VideoMode& video_mode,
                                   [[maybe_unused]] const bool reinit_render)
 {
@@ -610,13 +610,13 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width,
 	// uninitialised VideoMode param with width and height set to 0 which
 	// results in a crash. The proper fix is to make the init sequence 100%
 	// identical on all platforms, but in the interim this workaround will do.
-	if (canvas_width == 0 || canvas_height == 0 || video_mode.width == 0 ||
-	    video_mode.height == 0) {
+	if (canvas_width_px == 0 || canvas_height_px == 0 ||
+	    video_mode.width == 0 || video_mode.height == 0) {
 		return false;
 	}
 
-	get_shader_manager().NotifyRenderParametersChanged(canvas_width,
-	                                                   canvas_height,
+	get_shader_manager().NotifyRenderParametersChanged(canvas_width_px,
+	                                                   canvas_height_px,
 	                                                   video_mode);
 
 	const auto new_shader_name = get_shader_manager().GetCurrentShaderInfo().name;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -740,9 +740,9 @@ static IntegerScalingMode get_integer_scaling_mode_setting()
 	} else if (mode == "vertical") {
 		return IntegerScalingMode::Vertical;
 	} else {
-		LOG_WARNING("RENDER: Unknown integer scaling mode '%s', defaulting to 'off'",
+		LOG_WARNING("RENDER: Invalid integer scaling mode '%s', using 'auto'",
 		            mode.c_str());
-		return IntegerScalingMode::Off;
+		return IntegerScalingMode::Auto;
 	}
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -693,7 +693,7 @@ static void log_display_properties(const int width_px, const int height_px,
 {
 	// Get the viewport dimensions, with consideration for possible override
 	// values
-	auto get_viewport_size = [&]() -> std::pair<int, int> {
+	auto get_viewport_size_in_pixels = [&]() -> std::pair<int, int> {
 		if (viewport_size_override_px) {
 			const auto vp = calc_viewport_in_pixels(
 			        viewport_size_override_px->w,
@@ -706,14 +706,14 @@ static void log_display_properties(const int width_px, const int height_px,
 		return {vp.w, vp.h};
 	};
 
-	const auto [viewport_w, viewport_h] = get_viewport_size();
+	const auto [viewport_w_px, viewport_h_px] = get_viewport_size_in_pixels();
 
 	// Check expectations
 	assert(width_px > 0 && height_px > 0);
-	assert(viewport_w > 0 && viewport_h > 0);
+	assert(viewport_w_px > 0 && viewport_h_px > 0);
 
-	const auto scale_x = static_cast<double>(viewport_w) / width_px;
-	const auto scale_y = static_cast<double>(viewport_h) / height_px;
+	const auto scale_x = static_cast<double>(viewport_w_px) / width_px;
+	const auto scale_y = static_cast<double>(viewport_h_px) / height_px;
 
 	[[maybe_unused]] const auto one_per_render_pixel_aspect = scale_y / scale_x;
 
@@ -735,8 +735,8 @@ static void log_display_properties(const int width_px, const int height_px,
 	        video_mode_desc.c_str(),
 	        refresh_rate,
 	        frame_mode,
-	        viewport_w,
-	        viewport_h,
+	        viewport_w_px,
+	        viewport_h_px,
 	        video_mode.pixel_aspect_ratio.Inverse().ToDouble(),
 	        static_cast<int32_t>(video_mode.pixel_aspect_ratio.Num()),
 	        static_cast<int32_t>(video_mode.pixel_aspect_ratio.Denom()));

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3131,6 +3131,23 @@ SDL_Rect GFX_CalcViewportInPixels(const int canvas_width_px,
 		}
 	};
 
+	auto calc_horiz_integer_scaling_dims_in_pixels = [&]() -> std::pair<int, int> {
+		auto integer_scale_factor = std::min(
+		        bounds_w_px / draw_width,
+		        ifloor(bounds_h_px / (draw_width / image_aspect_ratio)));
+
+		if (integer_scale_factor < 1) {
+			// Revert to fit to viewport
+			return calc_bounded_dims_in_pixels();
+		} else {
+			const auto w = draw_width * integer_scale_factor;
+			const auto h = iround(draw_width * integer_scale_factor /
+			                      image_aspect_ratio);
+
+			return {w, h};
+		}
+	};
+
 	auto calc_vert_integer_scaling_dims_in_pixels = [&]() -> std::pair<int, int> {
 		auto integer_scale_factor = std::min(
 		        bounds_h_px / draw_height,
@@ -3172,23 +3189,8 @@ SDL_Rect GFX_CalcViewportInPixels(const int canvas_width_px,
 		break;
 
 	case IntegerScalingMode::Horizontal: {
-		// Calculate scaling multiplier that will allow to fit the whole
-		// image into the window or viewport bounds.
-		const auto pixel_aspect = round(draw_height * draw_scale_y) /
-		                          draw_height;
-		auto integer_scale_factor = std::min(
-		        bounds_w_px / draw_width,
-		        ifloor(bounds_h_px / (draw_height * pixel_aspect)));
-
-		if (integer_scale_factor < 1) {
-			// Revert to fit to viewport
-			std::tie(view_w_px, view_h_px) = calc_bounded_dims_in_pixels();
-		} else {
-			// Calculate the final viewport.
-			view_w_px = draw_width * integer_scale_factor;
-			view_h_px = iround(draw_height * integer_scale_factor *
-			                   pixel_aspect);
-		}
+		std::tie(view_w_px,
+		         view_h_px) = calc_horiz_integer_scaling_dims_in_pixels();
 		break;
 	}
 	case IntegerScalingMode::Vertical:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1396,7 +1396,7 @@ static SDL_Rect get_canvas_size([[maybe_unused]] const RenderingBackend renderin
 	return canvas;
 }
 
-SDL_Rect GFX_GetCanvasSize()
+SDL_Rect GFX_GetCanvasSizeInPixels()
 {
 	return get_canvas_size(sdl.rendering_backend);
 }
@@ -3081,15 +3081,16 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	        sdl.display_number);
 }
 
-SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
-                          const int draw_width, const int draw_height,
-                          const Fraction& render_pixel_aspect_ratio)
+SDL_Rect GFX_CalcViewportInPixels(const int canvas_width_px,
+                                  const int canvas_height_px,
+                                  const int draw_width, const int draw_height,
+                                  const Fraction& render_pixel_aspect_ratio)
 {
 	assert(draw_width > 0);
 	assert(draw_height > 0);
 
 	const auto [draw_scale_x, draw_scale_y] = get_scale_factors_from_pixel_aspect_ratio(
-	        render_pixel_aspect_ratio);
+			render_pixel_aspect_ratio);
 
 	assert(draw_scale_x > 0.0);
 	assert(draw_scale_y > 0.0);
@@ -3097,8 +3098,8 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	assert(std::isfinite(draw_scale_y));
 
 	// Limit the window to the user's desired viewport, if configured
-	const auto restricted_dims = restrict_to_viewport_resolution(canvas_width,
-	                                                             canvas_height);
+	const auto restricted_dims = restrict_to_viewport_resolution(canvas_width_px,
+	                                                             canvas_height_px);
 
 	const auto bounds_w = restricted_dims.x;
 	const auto bounds_h = restricted_dims.y;
@@ -3193,19 +3194,19 @@ SDL_Rect GFX_CalcViewport(const int canvas_width, const int canvas_height,
 	}
 
 	// Calculate centered viewport position.
-	const int view_x = (canvas_width - view_w) / 2;
-	const int view_y = (canvas_height - view_h) / 2;
+	const int view_x = (canvas_width_px - view_w) / 2;
+	const int view_y = (canvas_height_px - view_h) / 2;
 
 	return {view_x, view_y, view_w, view_h};
 }
 
 static SDL_Rect calc_viewport(const int canvas_width, const int canvas_height)
 {
-	return GFX_CalcViewport(canvas_width,
-	                        canvas_height,
-	                        sdl.draw.width,
-	                        sdl.draw.height,
-	                        sdl.draw.render_pixel_aspect_ratio);
+	return GFX_CalcViewportInPixels(canvas_width,
+	                                canvas_height,
+	                                sdl.draw.width,
+	                                sdl.draw.height,
+	                                sdl.draw.render_pixel_aspect_ratio);
 }
 
 IntegerScalingMode GFX_GetIntegerScalingMode()

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2790,19 +2790,24 @@ static SDL_Point refine_window_size(const SDL_Point size,
 	return FallbackWindowSize;
 }
 
-static SDL_Rect get_desktop_resolution()
+static SDL_Rect get_desktop_size()
 {
 	SDL_Rect desktop;
 	assert(sdl.display_number >= 0);
 	SDL_GetDisplayBounds(sdl.display_number, &desktop);
 
 	// Deduct the border decorations from the desktop size
-	int top = 0;
-	int left = 0;
+	int top    = 0;
+	int left   = 0;
 	int bottom = 0;
-	int right = 0;
+	int right  = 0;
+
 	(void)SDL_GetWindowBordersSize(SDL_GetWindowFromID(sdl.display_number),
-	                               &top, &left, &bottom, &right);
+	                               &top,
+	                               &left,
+	                               &bottom,
+	                               &right);
+
 	// If SDL_GetWindowBordersSize fails, it populates the values with 0.
 	desktop.w -= (left + right);
 	desktop.h -= (top + bottom);
@@ -2814,7 +2819,7 @@ static SDL_Rect get_desktop_resolution()
 
 static void maybe_limit_requested_resolution(int &w, int &h, const char *size_description)
 {
-	const auto desktop = get_desktop_resolution();
+	const auto desktop = get_desktop_size();
 	if (w <= desktop.w && h <= desktop.h)
 		return;
 
@@ -2934,7 +2939,7 @@ static void setup_viewport_resolution_from_conf(const std::string& viewport_reso
 		return;
 	}
 
-	const auto desktop = get_desktop_resolution();
+	const auto desktop = get_desktop_size();
 
 	const bool is_out_of_bounds = (w <= 0 || w > desktop.w || h <= 0 ||
 	                               h > desktop.h) &&
@@ -2987,7 +2992,7 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 		return;
 	}
 
-	const auto desktop = get_desktop_resolution();
+	const auto desktop = get_desktop_size();
 
 	const bool is_out_of_bounds = x < 0 || x > desktop.w || y < 0 ||
 	                              y > desktop.h;
@@ -3052,7 +3057,7 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	if (sdl.use_exact_window_resolution) {
 		coarse_size = parse_window_resolution_from_conf(pref);
 	} else {
-		const auto desktop = get_desktop_resolution();
+		const auto desktop = get_desktop_size();
 
 		coarse_size = window_bounds_from_label(pref, desktop);
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1129,8 +1129,8 @@ static void setup_presentation_mode(FrameMode &previous_mode)
 
 static void NewMouseScreenParams()
 {
-	if (sdl.clip.w <= 0 || sdl.clip.h <= 0 ||
-	    sdl.clip.x < 0  || sdl.clip.y < 0) {
+	if (sdl.clip_px.w <= 0 || sdl.clip_px.h <= 0 ||
+	    sdl.clip_px.x < 0  || sdl.clip_px.y < 0) {
 		// Filter out unusual parameters, which can be the result
 		// of window minimized due to ALT+TAB, for example
 		return;
@@ -1144,10 +1144,10 @@ static void NewMouseScreenParams()
 		return lround(value / sdl.desktop.dpi_scale);
 	};
 
-	params.clip_x = check_cast<uint32_t>(adapt(sdl.clip.x));
-	params.clip_y = check_cast<uint32_t>(adapt(sdl.clip.y));
-	params.res_x  = check_cast<uint32_t>(adapt(sdl.clip.w));
-	params.res_y  = check_cast<uint32_t>(adapt(sdl.clip.h));
+	params.clip_x = check_cast<uint32_t>(adapt(sdl.clip_px.x));
+	params.clip_y = check_cast<uint32_t>(adapt(sdl.clip_px.y));
+	params.res_x  = check_cast<uint32_t>(adapt(sdl.clip_px.w));
+	params.res_y  = check_cast<uint32_t>(adapt(sdl.clip_px.h));
 
 	int abs_x = 0;
 	int abs_y = 0;
@@ -1749,8 +1749,8 @@ uint8_t GFX_SetSize(const int width, const int height,
 		//         (canvas.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-		sdl.clip = calc_viewport(canvas.w, canvas.h);
-		if (SDL_RenderSetViewport(sdl.renderer, &sdl.clip) != 0)
+		sdl.clip_px = calc_viewport(canvas.w, canvas.h);
+		if (SDL_RenderSetViewport(sdl.renderer, &sdl.clip_px) != 0)
 			LOG_ERR("SDL: Failed to set viewport: %s", SDL_GetError());
 
 		sdl.frame.update = update_frame_texture;
@@ -1961,8 +1961,8 @@ uint8_t GFX_SetSize(const int width, const int height,
 		//         (canvas.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-		sdl.clip = calc_viewport(canvas.w, canvas.h);
-		glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
+		sdl.clip_px = calc_viewport(canvas.w, canvas.h);
+		glViewport(sdl.clip_px.x, sdl.clip_px.y, sdl.clip_px.w, sdl.clip_px.h);
 
 		if (sdl.opengl.texture > 0) {
 			glDeleteTextures(1,&sdl.opengl.texture);
@@ -2058,7 +2058,7 @@ uint8_t GFX_SetSize(const int width, const int height,
 			glUniform2f(sdl.opengl.ruby.input_size,
 			            (GLfloat)width,
 			            (GLfloat)height);
-			glUniform2f(sdl.opengl.ruby.output_size, (GLfloat)sdl.clip.w, (GLfloat)sdl.clip.h);
+			glUniform2f(sdl.opengl.ruby.output_size, (GLfloat)sdl.clip_px.w, (GLfloat)sdl.clip_px.h);
 			// The following uniform is *not* set right now
 			sdl.opengl.actual_frame_count = 0;
 		} else {
@@ -2411,8 +2411,8 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 	RenderedImage image = {};
 
 	auto allocate_image = [&]() {
-		image.params.width              = sdl.clip.w;
-		image.params.height             = sdl.clip.h;
+		image.params.width              = sdl.clip_px.w;
+		image.params.height             = sdl.clip_px.h;
 		image.params.double_width       = false;
 		image.params.double_height      = false;
 		image.params.pixel_aspect_ratio = {1};
@@ -2445,8 +2445,8 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 
 		allocate_image();
 
-		glReadPixels(sdl.clip.x,
-		             sdl.clip.y,
+		glReadPixels(sdl.clip_px.x,
+		             sdl.clip_px.y,
 		             image.params.width,
 		             image.params.height,
 		             GL_BGR,
@@ -2485,7 +2485,7 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 	// More info: https://afrantzis.com/pixel-format-guide/sdl2.html
 	//
 	if (SDL_RenderReadPixels(renderer,
-	                         &sdl.clip,
+	                         &sdl.clip_px,
 	                         SDL_PIXELFORMAT_BGR24,
 	                         image.image_data,
 	                         image.pitch) != 0) {
@@ -3665,17 +3665,17 @@ static void handle_video_resize(int width, int height)
 
 	const auto canvas = get_canvas_size(sdl.rendering_backend);
 
-	sdl.clip = calc_viewport(canvas.w, canvas.h);
+	sdl.clip_px = calc_viewport(canvas.w, canvas.h);
 
 	if (sdl.rendering_backend == RenderingBackend::Texture) {
-		SDL_RenderSetViewport(sdl.renderer, &sdl.clip);
+		SDL_RenderSetViewport(sdl.renderer, &sdl.clip_px);
 	}
 #if C_OPENGL
 	if (sdl.rendering_backend == RenderingBackend::OpenGl) {
-		glViewport(sdl.clip.x, sdl.clip.y, sdl.clip.w, sdl.clip.h);
+		glViewport(sdl.clip_px.x, sdl.clip_px.y, sdl.clip_px.w, sdl.clip_px.h);
 		glUniform2f(sdl.opengl.ruby.output_size,
-		            (GLfloat)sdl.clip.w,
-		            (GLfloat)sdl.clip.h);
+		            (GLfloat)sdl.clip_px.w,
+		            (GLfloat)sdl.clip_px.h);
 	}
 #endif // C_OPENGL
 
@@ -3806,10 +3806,10 @@ bool GFX_Events()
 				// LOG_DEBUG("SDL: Reset macOS's GL viewport
 				// after window-restore");
 				if (sdl.rendering_backend == RenderingBackend::OpenGl) {
-					glViewport(sdl.clip.x,
-					           sdl.clip.y,
-					           sdl.clip.w,
-					           sdl.clip.h);
+					glViewport(sdl.clip_px.x,
+					           sdl.clip_px.y,
+					           sdl.clip_px.w,
+					           sdl.clip_px.h);
 				}
 #endif
 				focus_input();
@@ -3889,10 +3889,10 @@ bool GFX_Events()
 				//               event.window.data1,
 				//               event.window.data2);
 				if (sdl.rendering_backend == RenderingBackend::OpenGl) {
-					glViewport(sdl.clip.x,
-					           sdl.clip.y,
-					           sdl.clip.w,
-					           sdl.clip.h);
+					glViewport(sdl.clip_px.x,
+					           sdl.clip_px.y,
+					           sdl.clip_px.w,
+					           sdl.clip_px.h);
 				}
 				continue;
 #endif
@@ -3914,17 +3914,17 @@ bool GFX_Events()
 				sdl.display_number = event.window.data1;
 
 				const auto canvas = get_canvas_size(sdl.rendering_backend);
-				sdl.clip = calc_viewport(canvas.w, canvas.h);
+				sdl.clip_px = calc_viewport(canvas.w, canvas.h);
 				if (sdl.rendering_backend == RenderingBackend::Texture) {
 					SDL_RenderSetViewport(sdl.renderer,
-					                      &sdl.clip);
+					                      &sdl.clip_px);
 				}
 #	if C_OPENGL
 				if (sdl.rendering_backend == RenderingBackend::OpenGl) {
-					glViewport(sdl.clip.x,
-					           sdl.clip.y,
-					           sdl.clip.w,
-					           sdl.clip.h);
+					glViewport(sdl.clip_px.x,
+					           sdl.clip_px.y,
+					           sdl.clip_px.w,
+					           sdl.clip_px.h);
 				}
 
 				maybe_auto_switch_shader();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2850,7 +2850,7 @@ static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
 		return {w, h};
 	}
 
-	LOG_WARNING("DISPLAY: Requested windowresolution '%s' is not valid, "
+	LOG_WARNING("DISPLAY: Requested window resolution '%s' is not valid, "
 	            "falling back to '%dx%d' instead",
 	            pref.c_str(),
 	            FALLBACK_WINDOW_DIMENSIONS.x,
@@ -2877,7 +2877,7 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 		} else if (pref == "desktop") {
 			return 100;
 		} else {
-			LOG_WARNING("DISPLAY: Requested windowresolution '%s' is invalid, "
+			LOG_WARNING("DISPLAY: Requested window resolution '%s' is invalid, "
 			            "using 'default' instead",
 			            pref.c_str());
 			return MediumPercent;
@@ -2920,7 +2920,7 @@ static void setup_viewport_resolution_from_conf(const std::string& viewport_reso
 	        sscanf(viewport_resolution_val.c_str(), "%f%%", &p) == 1;
 
 	if (!was_parsed) {
-		LOG_WARNING("DISPLAY: Requested viewport_resolution '%s' was not in WxH"
+		LOG_WARNING("DISPLAY: Requested viewport resolution '%s' was not in WxH"
 		            " or N%% format, using the default setting ('%s') instead",
 		            viewport_resolution_val.c_str(),
 		            default_val);
@@ -2933,9 +2933,9 @@ static void setup_viewport_resolution_from_conf(const std::string& viewport_reso
 	                               h > desktop.h) &&
 	                              (p <= 0.0f || p > 100.0f);
 	if (is_out_of_bounds) {
-		LOG_WARNING("DISPLAY: Requested viewport_resolution of '%s' is outside"
-		            " the desktop '%dx%d' bounds or the 1-100%% range, "
-		            " using the default setting ('%s') instead",
+		LOG_WARNING("DISPLAY: Requested viewport resolution of '%s' is outside "
+		            "the desktop '%dx%d' bounds or the 1-100%% range, "
+		            "using the default setting ('%s') instead",
 		            viewport_resolution_val.c_str(),
 		            desktop.w,
 		            desktop.h,
@@ -2974,7 +2974,7 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 	const auto was_parsed = (sscanf(window_position_val.c_str(), "%d,%d", &x, &y) ==
 	                         2);
 	if (!was_parsed) {
-		LOG_WARNING("DISPLAY: Requested window_position '%s' was not in X,Y format; "
+		LOG_WARNING("DISPLAY: Requested window position '%s' was not in X,Y format, "
 		            "using 'auto' instead",
 		            window_position_val.c_str());
 		return;
@@ -2985,8 +2985,8 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 	const bool is_out_of_bounds = x < 0 || x > desktop.w || y < 0 ||
 	                              y > desktop.h;
 	if (is_out_of_bounds) {
-		LOG_WARNING("DISPLAY: Requested window_position '%d,%d' is outside "
-		            "the bounds of the desktop '%dx%d', "
+		LOG_WARNING("DISPLAY: Requested window position '%d,%d' is outside the "
+		            "bounds of the desktop '%dx%d', "
 		            "using 'auto' instead",
 		            x,
 		            y,
@@ -3448,8 +3448,8 @@ static void set_priority_levels(const std::string& active_pref,
 		if (pref == "highest") {
 			return PRIORITY_LEVEL_HIGHEST;
 		}
-
-		LOG_WARNING("Invalid priority level: %s, using 'auto'", pref.data());
+		LOG_WARNING("SDL: Invalid priority level: '%s', using 'auto'",
+		            pref.data());
 
 		return PRIORITY_LEVEL_AUTO;
 	};

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -105,11 +105,11 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 		const auto draw_height = video_mode.height *
 		                         (video_mode.is_double_scanned_mode ? 2 : 1);
 
-		const auto viewport = GFX_CalcViewport(canvas_width_px,
-		                                       canvas_height_px,
-		                                       draw_width,
-		                                       draw_height,
-		                                       video_mode.pixel_aspect_ratio);
+		const auto viewport = GFX_CalcViewportInPixels(canvas_width_px,
+		                                               canvas_height_px,
+		                                               draw_width,
+		                                               draw_height,
+		                                               video_mode.pixel_aspect_ratio);
 
 		return static_cast<double>(viewport.h) / draw_height;
 	}();
@@ -120,11 +120,11 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 		const auto draw_width  = video_mode.width;
 		const auto draw_height = video_mode.height;
 
-		const auto viewport = GFX_CalcViewport(canvas_width_px,
-		                                       canvas_height_px,
-		                                       draw_width,
-		                                       draw_height,
-		                                       video_mode.pixel_aspect_ratio);
+		const auto viewport = GFX_CalcViewportInPixels(canvas_width_px,
+		                                               canvas_height_px,
+		                                               draw_width,
+		                                               draw_height,
+		                                               video_mode.pixel_aspect_ratio);
 
 		scale_y_force_single_scan = static_cast<double>(viewport.h) /
 		                            draw_height;

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -79,8 +79,8 @@ void ShaderManager::NotifyGlshaderSettingChanged(const std::string& shader_name)
 	MaybeAutoSwitchShader();
 }
 
-void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width,
-                                                  const uint16_t canvas_height,
+void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px,
+                                                  const uint16_t canvas_height_px,
                                                   const VideoMode& video_mode)
 {
 	// We need to calculate the scale factors for two eventualities: 1)
@@ -105,8 +105,8 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width,
 		const auto draw_height = video_mode.height *
 		                         (video_mode.is_double_scanned_mode ? 2 : 1);
 
-		const auto viewport = GFX_CalcViewport(canvas_width,
-		                                       canvas_height,
+		const auto viewport = GFX_CalcViewport(canvas_width_px,
+		                                       canvas_height_px,
 		                                       draw_width,
 		                                       draw_height,
 		                                       video_mode.pixel_aspect_ratio);
@@ -120,8 +120,8 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width,
 		const auto draw_width  = video_mode.width;
 		const auto draw_height = video_mode.height;
 
-		const auto viewport = GFX_CalcViewport(canvas_width,
-		                                       canvas_height,
+		const auto viewport = GFX_CalcViewport(canvas_width_px,
+		                                       canvas_height_px,
 		                                       draw_width,
 		                                       draw_height,
 		                                       video_mode.pixel_aspect_ratio);

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -139,8 +139,8 @@ public:
 
 	void NotifyGlshaderSettingChanged(const std::string& shader_name);
 
-	void NotifyRenderParametersChanged(const uint16_t canvas_width,
-	                                   const uint16_t canvas_height,
+	void NotifyRenderParametersChanged(const uint16_t canvas_width_px,
+	                                   const uint16_t canvas_height_px,
 	                                   const VideoMode& video_mode);
 
 	const ShaderInfo& GetCurrentShaderInfo() const;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2816,11 +2816,11 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	    vga.draw.render != render || fps_changed) {
 		VGA_KillDrawing();
 
-		const auto canvas = GFX_GetCanvasSize();
+		const auto canvas_px = GFX_GetCanvasSizeInPixels();
 
 		constexpr auto reinit_render = false;
 		const auto shader_changed    = RENDER_MaybeAutoSwitchShader(
-                        canvas.w, canvas.h, render.video_mode, reinit_render);
+                        canvas_px.w, canvas_px.h, render.video_mode, reinit_render);
 
 		if (shader_changed) {
 			render = setup_drawing();

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -27,8 +27,6 @@
 #include <cstring>
 #include <utility>
 
-#include <SDL.h>
-
 #include "../gui/render_scalers.h"
 #include "../ints/int10.h"
 #include "bitops.h"
@@ -2819,8 +2817,12 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		const auto canvas_px = GFX_GetCanvasSizeInPixels();
 
 		constexpr auto reinit_render = false;
-		const auto shader_changed    = RENDER_MaybeAutoSwitchShader(
-                        canvas_px.w, canvas_px.h, render.video_mode, reinit_render);
+
+		const auto shader_changed =
+		        RENDER_MaybeAutoSwitchShader(iroundf(canvas_px.w),
+		                                     iroundf(canvas_px.h),
+		                                     render.video_mode,
+		                                     reinit_render);
 
 		if (shader_changed) {
 			render = setup_drawing();


### PR DESCRIPTION
# Description

A bunch of mostly non-functional changes separated out of my upcoming viewport resolution/ aspect ratio enhancement PR.

Definitely review by commit.

Main changes:

- `SDL_Rect` is not leaking into the core emulation layers anymore; I've introduced a custom `Rectangle` type for this purpose.
- In 99% of cases there was no differentation between _logical coordinates_ (device independent coordinates) and _physical coordinates_ (device coordinates, physical pixels) in SDL main. This is very bad because you can never be sure what you're dealing with just by looking at the variable/function names, and it was making me quite upset after hacking sdlmain for a while... I've clarified the namings in the areas of sdlmain that I'm touching in my other PR directly or indirectly. About 80% of the code is still a mess, but it's a start...

For people who are not experienced with logical/physical coordinates, here's a quick rundown:

Using logical coordinates is the way forward for most use cases now that high DPI displays are increasingly the norm, especially for general GUI development and scalable vector graphics. You just use logical coordinates and things work fine on high DPI displays (if your framework is good), no need to think about it (that's what I'm doing in my other GLFW + OpenGL based programs that feature scalable vector graphics, and I can confirm, ThingsJustWork(tm)).

But when you're dealing with bitmap graphics and OpenGL, you _need_ to deal with physical pixels _as well_. Also, understanding how things to map to physical pixels is important because of the OpenGL shaders, for instance. So the code will be naturally a _mixture_ of logical and physical units, therefore we _must_ encode the units in the variable and function names, otherwise you can only guess things when reading the code.

Should I multiply this quantity by the DPI scale factor?
Should I not? 😕 
Should I divide it by the DPI factor? 🤔 

It's anyone's guess if the var is just called something like `sdl.clip.w`! 🥶 

That is bad, very bad, and it results in copious amounts of trace logging and intense hair loss during a compressed duration of time. Now, you don't wish that on your fellow devs, do you? 😎 

So the system I started adopting is as follows:

- In sdlmain we're dealing with a mixture of logical and physical coords. That's normal and it's never gonna change. As using logical coords is the preferred and recommended default these days (for the best possible reasons), names like `width` and `get_width` mean _logical coordinates_, while `width_px`, and `get_width_in_pixels` means—I'm sure you can figure that out 😎 SDL has also started adding the `*InPixels` postfix to function names in its API (although I'm not sure how consistent they are with that).
- In _all other parts of the emulation code_, we should not deal with logical units _at all_, this being a computer emulator that deals with emulated framebuffers, raw pixel arrays, and so on. So in other parts, there is no need for the `_px` and `_in_pixels` postfixes; it's implicit that `width`, `height`, etc. are always in pixels in the core layers. I stress it again: only sdlmain should deal with logical pixels! (Well, and the upcoming OSD layer as well, because it will draw the UI as scaleable vector graphics, but that's for later and it's another special case 😎)
- Another special case is passing windowing system related parameters, so for example canvas and viewport dimensions and similar quantities into the core emulation layer (e.g., the shader manager needs to know of the canvas dimensions in physical pixels to select the appropriate shader). So in order to avoid ambiguity, we still use the `_px` postfix for function arguments that have anything to do with window sizes, canvas sizes, viewport dimensions, etc. Can be a little bit redundant in some cases, but I'd rather be a little redundant than a little confusing 😄 
 
I'm hoping this is all not much controversial 😄 I don't think this is wasted effort because we don't know when we'll migrate to SDL3, plus clarifying the current sdlmain mess would help the transition effort too (I'm sure some of the current code could be (will be?) even lifted into the SDL3 branch).

# Manual testing

Tried the shaders and the various integer scaling and viewport resolution modes, fullscreen / windowed, etc., and there are no regressions.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

