### PR TITLE
Re-write DOS_Shell::CMD_RENAME

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -184,8 +184,9 @@ bool DOS_UnlinkFile(const char* const name);
 bool DOS_FindFirst(const char* search, FatAttributeFlags attr,
                    bool fcb_findfirst = false);
 bool DOS_FindNext(void);
-bool DOS_Canonicalize(const char* const name, char* const big);
-bool DOS_CreateTempFile(char * const name,uint16_t * entry);
+bool DOS_Canonicalize(const char* const name, char* const canonicalized);
+std::string DOS_Canonicalize(const char* const name);
+bool DOS_CreateTempFile(char* const name, uint16_t* entry);
 bool DOS_FileExists(const char* const name);
 
 /* Helper Functions */

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -93,6 +93,11 @@ struct FileStat_Block {
 
 class DOS_DTA;
 
+struct DosFilename {
+	std::string name = {};
+	std::string ext  = {};
+};
+
 class DOS_File {
 public:
 	DOS_File() = default;


### PR DESCRIPTION
# Description
Re-wrote the Rename command.  It now supports wildcards and uses C++ style string manipulation.


## Related issues
Fixes #2212


# Manual testing
Confirmed the bug in #2212 is fixed.  Also manually compared some edge cases to real MS-DOS 6.22 (running in 86box) and it mostly behaves the same.  This could probably use some unit tests.  I'm not sure if we have the ability to test shell commands in a "fake" filesystem.  I can look at that tomorrow or something (getting a bit tired of programming for the day :sleeping: and wanted to go ahead and get this up for review.)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

