### PR TITLE
Release mouse if `config -set mouse_capture=nomouse` is executed

### DIFF
--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -231,6 +231,17 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 		// host OS mouse acceleration applied
 		state.is_input_raw = false;
 
+	} else if (is_config_no_mouse) { // NoMouse is configured
+
+		// Capture mouse cursor if:
+		// - we are in fullscreen mode and not in multi-display mode
+		state.is_captured = !is_window_or_multi_display;
+
+		// Drop the user capture request, otherwise runtime mouse
+		// capture configuration change (for example to OnClick) could
+		// have caused the mouse cursor to suddenly disappear
+		state.capture_was_requested = false;
+
 	} else if (state.is_window_active) { // window has focus, no GUI running
 
 		// Capture mouse cursor if any of:


### PR DESCRIPTION
# Description

Fixes a problem with `config -set mouse_capture=nomouse` command when mouse is captured, now the mouse is released (uncaptured) immediately now - I believe this is the most sane behavior.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3127


# Manual testing

- make sure DOSBox Staging is in windowed (not fullscreen) mode
- capture the mouse (depending on configuration - usually middle click inside the window works)
- execute command `config -set mouse_capture=nomouse` - mouse should be released
- execute command `config -set mouse_capture=onclick` - mouse shouldn't get auto-captured again


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

