### PR TITLE
Skip compiler if error instead of aborting in compile_commits.sh

### DIFF
--- a/scripts/compile_commits.sh
+++ b/scripts/compile_commits.sh
@@ -164,7 +164,8 @@ meson_setup_for_compiler() {
 	if ! run "$meson_setup"; then
 		echo "Reproduce with:"
 		echo "$meson_setup"
-		exit 1
+		echo ""
+		return 1
 	fi
 	return 0
 }


### PR DESCRIPTION
# Description

When the `compile_commits.sh` script runs, if there's an error setting up a compiler, the entire script aborts. This change allows it to return and continue looking for other compilers.

I have GCC 13 installed on my Mac, but there's a bug in Meson when trying to discover it:

```log
---
The Meson build system
Version: 1.2.3
Source dir: /Users/kklobe/src/dosbox-staging
Build dir: /Users/kklobe/src/dosbox-staging/build/gcc
Build type: native build
Project name: dosbox-staging
Project version: 0.81.0-alpha

meson.build:1:0: ERROR: Unable to detect linker for compiler `gcc-13 -Wl,--version`
stdout: 
stderr: collect2 version 13.2.0
/usr/bin/ld -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/ -dynamic -arch arm64 -platform_version macos 14.0.0 0.0 -o a.out -L/opt/homebrew/Cellar/gcc/13.2.0/bin/../lib/gcc/current/gcc/aarch64-apple-darwin22/13 -L/opt/homebrew/Cellar/gcc/13.2.0/bin/../lib/gcc/current/gcc -L/opt/homebrew/Cellar/gcc/13.2.0/bin/../lib/gcc/current/gcc/aarch64-apple-darwin22/13/../../.. --version -lemutls_w -lgcc -lSystem -lgcc -no_compact_unwind -rpath @loader_path -rpath /opt/homebrew/Cellar/gcc/13.2.0/lib/gcc/current/gcc/aarch64-apple-darwin22/13 -rpath /opt/homebrew/Cellar/gcc/13.2.0/lib/gcc/current/gcc -rpath /opt/homebrew/Cellar/gcc/13.2.0/lib/gcc/current
ld: unknown options: --version 
collect2: error: ld returned 1 exit status


A full log can be found at /Users/kklobe/src/dosbox-staging/build/gcc/meson-logs/meson-log.txt
---
```

I also have clang, which works just fine, but the script bails on the GCC error and never gets to clang.

# Manual testing

I ran the script successfully against this very branch.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

