### PR TITLE
Improve auto-cycle convergence rate with small adjustment

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -58,6 +58,7 @@ extern int32_t CPU_CycleLeft;
 extern int32_t CPU_CycleMax;
 extern int32_t CPU_OldCycleMax;
 extern int32_t CPU_CyclePercUsed;
+constexpr int32_t CPU_CycleProtectedModeDefault = 50000;
 extern int32_t CPU_CycleLimit;
 extern int64_t CPU_IODelayRemoved;
 extern bool CPU_CycleAutoAdjust;

--- a/meson.build
+++ b/meson.build
@@ -161,6 +161,16 @@ if get_option('buildtype') in ['release', 'minsize']
         '-fdata-sections',
     ]
     extra_link_flags += ['-Wl,--gc-sections']
+
+    # Apply Apple silicon-specific CPU tunings
+    if (os_family_name == 'MACOSX'
+        and host_machine.cpu_family() == 'aarch64')
+        extra_flags += [
+            '-mcpu=native',
+            '-mtune=native',
+        ]
+    endif
+
 endif
 
 # Let sanitizer builds recover and continue

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1583,6 +1583,8 @@ void CPU_SET_CRX(Bitu cr,Bitu value) {
 				CPU_CycleLeft       = 0;
 				CPU_Cycles          = 0;
 				CPU_OldCycleMax     = CPU_CycleMax;
+				CPU_CycleMax        = std::max(CPU_CycleMax,
+				                               CPU_CycleProtectedModeDefault);
 
 				GFX_SetTitle(CPU_CyclePercUsed);
 				if (!printed_cycles_auto_info) {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1562,52 +1562,58 @@ Bitu CPU_SIDT_limit(void) {
 static bool printed_cycles_auto_info = false;
 void CPU_SET_CRX(Bitu cr,Bitu value) {
 	switch (cr) {
-	case 0:
-		{
-			value|=CR0_FPUPRESENT;
-			Bitu changed=cpu.cr0 ^ value;
-			if (!changed) return;
-			cpu.cr0=value;
-			if (value & CR0_PROTECTION) {
-				cpu.pmode=true;
-				LOG(LOG_CPU,LOG_NORMAL)("Protected mode");
-				PAGING_Enable((value & CR0_PAGING)>0);
-
-				if (!(CPU_AutoDetermineMode&CPU_AUTODETERMINE_MASK)) break;
-
-				if (CPU_AutoDetermineMode&CPU_AUTODETERMINE_CYCLES) {
-					CPU_CycleAutoAdjust=true;
-					CPU_CycleLeft=0;
-					CPU_Cycles=0;
-					CPU_OldCycleMax=CPU_CycleMax;
-				        GFX_SetTitle(CPU_CyclePercUsed);
-				        if(!printed_cycles_auto_info) {
-						printed_cycles_auto_info = true;
-						LOG_MSG("DOSBox has switched to max cycles, because of the setting: cycles=auto.\nIf the game runs too fast, try a fixed cycles amount in DOSBox's options.");
-					}
-				} else {
-				        GFX_RefreshTitle();
-			        }
-#if (C_DYNAMIC_X86)
-				if (CPU_AutoDetermineMode&CPU_AUTODETERMINE_CORE) {
-					CPU_Core_Dyn_X86_Cache_Init(true);
-					cpudecoder=&CPU_Core_Dyn_X86_Run;
-				}
-#elif (C_DYNREC)
-				if (CPU_AutoDetermineMode&CPU_AUTODETERMINE_CORE) {
-					CPU_Core_Dynrec_Cache_Init(true);
-					cpudecoder=&CPU_Core_Dynrec_Run;
-				}
-#endif
-				CPU_AutoDetermineMode<<=CPU_AUTODETERMINE_SHIFT;
-			} else {
-				cpu.pmode=false;
-				if (value & CR0_PAGING) LOG_MSG("Paging requested without PE=1");
-				PAGING_Enable(false);
-				LOG(LOG_CPU,LOG_NORMAL)("Real mode");
-			}
-			break;
+	case 0: {
+		value |= CR0_FPUPRESENT;
+		Bitu changed = cpu.cr0 ^ value;
+		if (!changed) {
+			return;
 		}
+		cpu.cr0 = value;
+		if (value & CR0_PROTECTION) {
+			cpu.pmode = true;
+			LOG(LOG_CPU, LOG_NORMAL)("Protected mode");
+			PAGING_Enable((value & CR0_PAGING) > 0);
+
+			if (!(CPU_AutoDetermineMode & CPU_AUTODETERMINE_MASK)) {
+				break;
+			}
+
+			if (CPU_AutoDetermineMode & CPU_AUTODETERMINE_CYCLES) {
+				CPU_CycleAutoAdjust = true;
+				CPU_CycleLeft       = 0;
+				CPU_Cycles          = 0;
+				CPU_OldCycleMax     = CPU_CycleMax;
+
+				GFX_SetTitle(CPU_CyclePercUsed);
+				if (!printed_cycles_auto_info) {
+					printed_cycles_auto_info = true;
+					LOG_MSG("DOSBox has switched to max cycles, because of the setting: cycles=auto.\nIf the game runs too fast, try a fixed cycles amount in DOSBox's options.");
+				}
+			} else {
+				GFX_RefreshTitle();
+			}
+#if (C_DYNAMIC_X86)
+			if (CPU_AutoDetermineMode & CPU_AUTODETERMINE_CORE) {
+				CPU_Core_Dyn_X86_Cache_Init(true);
+				cpudecoder = &CPU_Core_Dyn_X86_Run;
+			}
+#elif (C_DYNREC)
+			if (CPU_AutoDetermineMode & CPU_AUTODETERMINE_CORE) {
+				CPU_Core_Dynrec_Cache_Init(true);
+				cpudecoder = &CPU_Core_Dynrec_Run;
+			}
+#endif
+			CPU_AutoDetermineMode <<= CPU_AUTODETERMINE_SHIFT;
+		} else {
+			cpu.pmode = false;
+			if (value & CR0_PAGING) {
+				LOG_MSG("Paging requested without PE=1");
+			}
+			PAGING_Enable(false);
+			LOG(LOG_CPU, LOG_NORMAL)("Real mode");
+		}
+		break;
+	}
 	case 2:
 		paging.cr2=value;
 		break;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1584,7 +1584,7 @@ void CPU_SET_CRX(Bitu cr,Bitu value) {
 				CPU_Cycles          = 0;
 				CPU_OldCycleMax     = CPU_CycleMax;
 				CPU_CycleMax        = std::max(CPU_CycleMax,
-				                               CPU_CycleProtectedModeDefault);
+                                                        CPU_CycleProtectedModeDefault);
 
 				GFX_SetTitle(CPU_CyclePercUsed);
 				if (!printed_cycles_auto_info) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -414,6 +414,17 @@ static void DOSBOX_RealInit(Section* sec)
 	ticksRemain = 0;
 	ticksLast   = GetTicks();
 	ticksLocked = false;
+
+	// Our assumption is that the auto cycle adjustment will not cause
+	// regressions, however if it is suspected, users can disable speed_mods
+	// and see if it helps. The speed_mods description asks user to report
+	// cases to the team for further assessment. Like prior speed_mods,
+	// after a extended period without negative reports, the feature will be
+	// made permanent.
+	//
+	auto_cycle_adjusted_scalar = adjust_auto_cycle_scalar(
+	        section->Get_bool("speed_mods"));
+
 	DOSBOX_SetLoop(&Normal_Loop);
 
 	MAPPER_AddHandler(DOSBOX_UnlockSpeed, SDL_SCANCODE_F12, MMOD2, "speedlock", "Speedlock");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -143,17 +143,16 @@ static constexpr int8_t AutoCycleRatioBoost = 24;
 // Either the auto-cycle ratio scalar or with added boost
 static int16_t auto_cycle_adjusted_scalar = AutoCycleRatioScalar;
 
-static constexpr int16_t AutoCycleMaxTicksScheduled = 250;
-static constexpr int8_t AutoCycleMinTicksScheduled  = 5;
-
-static constexpr int16_t AutoCycleMaxTicksDone = AutoCycleMaxTicksScheduled;
+static constexpr int8_t AutoCycleMinTicksScheduled = 5;
 static constexpr int8_t AutoCycleMinTicksDone  = 2 * AutoCycleMinTicksScheduled;
-
 static constexpr int8_t AutoCycleMinTicksAdded = 3 * AutoCycleMinTicksScheduled;
+
+static constexpr int16_t AutoCycleMaxTicksScheduled = 50 * AutoCycleMinTicksScheduled;
+static constexpr int16_t AutoCycleMaxTicksDone = AutoCycleMaxTicksScheduled;
 
 // General CPU tick constants
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~
-static constexpr int8_t MaxScheduledTicks = 20;
+static constexpr int8_t MaxScheduledTicks = 4 * AutoCycleMinTicksScheduled;
 static int64_t ticksRemain;
 static int64_t ticksLast;
 static int64_t ticksAdded;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -129,6 +129,14 @@ static LoopHandler * loop;
 // transformed into an adjustment to the current cycle count.
 //
 static constexpr int16_t AutoCycleRatioScalar = 1 << 10;
+
+// The adjustment helps the auto cycle logic converge faster on the specified
+// target (i.e.: "cycles=max", "max 75%", etc), while still being conservative
+// enough to avoid whipsawing cycles too high or low. This value has been tuned
+// on a Rasberry Pi 400, 800 Mhz x86-64, 4 Ghz 86-64, and Apple M1 system.
+//
+static constexpr int8_t AutoCycleRatioBoost = 24;
+
 static int16_t auto_cycle_adjusted_scalar = AutoCycleRatioScalar;
 
 static int64_t ticksRemain;
@@ -168,6 +176,11 @@ static Bitu Normal_Loop() {
 			} else {increaseticks();return 0;}
 		}
 	}
+}
+
+static int16_t adjust_auto_cycle_scalar(const bool wants_adjusted)
+{
+	return AutoCycleRatioScalar + (wants_adjusted ? AutoCycleRatioBoost : 0);
 }
 
 void increaseticks() { //Make it return ticksRemain and set it in the function above to remove the global variable.

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -271,9 +271,13 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 				if (ticksScheduled >= 250 && ticksDone < 10 && ratio > 5120 && CPU_CycleMax > 50000)
 					ratio = 5120;
 
+				constexpr int16_t min_ratio = 800;
 				// When downscaling multiple times in a row, ensure a minimum amount of downscaling
-				if (ticksAdded > 15 && ticksScheduled >= 5 && ticksScheduled <= MaxScheduledTicks && ratio > 800)
-					ratio = 800;
+				if (ticksAdded > 15 && ticksScheduled >= 5 &&
+				    ticksScheduled <= MaxScheduledTicks &&
+				    ratio > min_ratio) {
+					ratio = min_ratio;
+				}
 
 				if (ratio <= AutoCycleRatioScalar) {
 					// ratio_not_removed = 1.0; //enabling this restores the old formula

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -143,11 +143,12 @@ static constexpr int8_t AutoCycleRatioBoost = 24;
 // Either the auto-cycle ratio scalar or with added boost
 static int16_t auto_cycle_adjusted_scalar = AutoCycleRatioScalar;
 
+// The minimum ticks scheduled controls the rate of auto-cycle assessement
 static constexpr int8_t AutoCycleMinTicksScheduled = 5;
 static constexpr int8_t AutoCycleMinTicksDone  = 2 * AutoCycleMinTicksScheduled;
 static constexpr int8_t AutoCycleMinTicksAdded = 3 * AutoCycleMinTicksScheduled;
 
-static constexpr int16_t AutoCycleMaxTicksScheduled = 50 * AutoCycleMinTicksScheduled;
+static constexpr int16_t AutoCycleMaxTicksScheduled = 30 * AutoCycleMinTicksScheduled;
 static constexpr int16_t AutoCycleMaxTicksDone = AutoCycleMaxTicksScheduled;
 
 // General CPU tick constants

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -289,7 +289,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 		if (new_cmax < CPU_CYCLES_LOWER_LIMIT)
 			new_cmax = CPU_CYCLES_LOWER_LIMIT;
 		/*
-		LOG_INFO("cyclelog: current %06d   cmax %06d   ratio  %05d  done %03d   sched %03d Add %d rr %4.2f",
+		LOG_INFO("cyclelog: current %06d   cmax %06d   ratio  %05d  done %03" PRId64 "   sched %03" PRId64 " Add %" PRId64 " rr %4.2f",
 			CPU_CycleMax,
 			new_cmax,
 			ratio,

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -232,9 +232,8 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 
 	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero
-		/* ratio we are aiming for is around 90% usage*/
 		int32_t ratio = static_cast<int32_t>(
-		        (ticksScheduled * (CPU_CyclePercUsed * 90 * AutoCycleRatioScalar / 100 / 100)) /
+		        (ticksScheduled * (CPU_CyclePercUsed * AutoCycleRatioScalar / 100)) /
 		        ticksDone);
 
 		int32_t new_cmax = CPU_CycleMax;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -267,9 +267,13 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 				if (ticksScheduled >= 250 && ticksDone < 10 && ratio > 16384)
 					ratio = 16384;
 
-				// Limit the ratio even more when the cycles are already way above the realmode default.
-				if (ticksScheduled >= 250 && ticksDone < 10 && ratio > 5120 && CPU_CycleMax > 50000)
+				// Limit the ratio even more when the cycles are
+				// already about the protected mode default
+				if (ticksScheduled >= 250 && ticksDone < 10 &&
+				    ratio > 5120 &&
+				    CPU_CycleMax > CPU_CycleProtectedModeDefault) {
 					ratio = 5120;
+				}
 
 				constexpr int16_t min_ratio = 800;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -139,6 +139,7 @@ static constexpr int8_t AutoCycleRatioBoost = 24;
 
 static int16_t auto_cycle_adjusted_scalar = AutoCycleRatioScalar;
 
+static constexpr int8_t MaxScheduledTicks = 20;
 static int64_t ticksRemain;
 static int64_t ticksLast;
 static int64_t ticksAdded;
@@ -235,9 +236,9 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	ticksRemain = GetTicksDiff(ticksNew, ticksLast);
 	ticksLast = ticksNew;
 	ticksDone += ticksRemain;
-	if ( ticksRemain > 20 ) {
+	if ( ticksRemain > MaxScheduledTicks ) {
 //		LOG(LOG_MISC,LOG_ERROR)("large remain %d",ticksRemain);
-		ticksRemain = 20;
+		ticksRemain = MaxScheduledTicks;
 	}
 	ticksAdded = ticksRemain;
 
@@ -271,7 +272,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 					ratio = 5120;
 
 				// When downscaling multiple times in a row, ensure a minimum amount of downscaling
-				if (ticksAdded > 15 && ticksScheduled >= 5 && ticksScheduled <= 20 && ratio > 800)
+				if (ticksAdded > 15 && ticksScheduled >= 5 && ticksScheduled <= MaxScheduledTicks && ratio > 800)
 					ratio = 800;
 
 				if (ratio <= AutoCycleRatioScalar) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -129,6 +129,7 @@ static LoopHandler * loop;
 // transformed into an adjustment to the current cycle count.
 //
 static constexpr int16_t AutoCycleRatioScalar = 1 << 10;
+static int16_t auto_cycle_adjusted_scalar = AutoCycleRatioScalar;
 
 static int64_t ticksRemain;
 static int64_t ticksLast;
@@ -233,7 +234,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero
 		int32_t ratio = static_cast<int32_t>(
-		        (ticksScheduled * (CPU_CyclePercUsed * AutoCycleRatioScalar / 100)) /
+		        (ticksScheduled * (CPU_CyclePercUsed * auto_cycle_adjusted_scalar / 100)) /
 		        ticksDone);
 
 		int32_t new_cmax = CPU_CycleMax;
@@ -265,7 +266,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 					double r = (1.0 + ratio_not_removed) /(ratio_not_removed + AutoCycleRatioScalar / (static_cast<double>(ratio)));
 					new_cmax = 1 + static_cast<int32_t>(CPU_CycleMax * r);
 				} else {
-					int64_t ratio_with_removed = (int64_t) ((((double)ratio - AutoCycleRatioScalar) * ratio_not_removed) + AutoCycleRatioScalar);
+					int64_t ratio_with_removed = (int64_t) ((((double)ratio - AutoCycleRatioScalar) * ratio_not_removed) + auto_cycle_adjusted_scalar);
 					int64_t cmax_scaled = (int64_t)CPU_CycleMax * ratio_with_removed;
 					new_cmax = (int32_t)(1 + (CPU_CycleMax >> 1) + cmax_scaled / (AutoCycleRatioScalar << 1));
 				}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -272,11 +272,18 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 					ratio = 5120;
 
 				constexpr int16_t min_ratio = 800;
-				// When downscaling multiple times in a row, ensure a minimum amount of downscaling
+
+				// When downscaling multiple times in a row,
+				// do so in proportion to the tick overage
+				// (ticksAdded) amount.
+				//
 				if (ticksAdded > 15 && ticksScheduled >= 5 &&
 				    ticksScheduled <= MaxScheduledTicks &&
 				    ratio > min_ratio) {
-					ratio = min_ratio;
+					ratio = min_ratio +
+					        AutoCycleRatioBoost *
+					                (MaxScheduledTicks -
+					                 static_cast<int32_t>(ticksAdded));
 				}
 
 				if (ratio < min_ratio) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -149,6 +149,8 @@ static constexpr int8_t AutoCycleMinTicksScheduled  = 5;
 static constexpr int16_t AutoCycleMaxTicksDone = AutoCycleMaxTicksScheduled;
 static constexpr int8_t AutoCycleMinTicksDone  = 2 * AutoCycleMinTicksScheduled;
 
+static constexpr int8_t AutoCycleMinTicksAdded = 3 * AutoCycleMinTicksScheduled;
+
 // General CPU tick constants
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~
 static constexpr int8_t MaxScheduledTicks = 20;
@@ -259,12 +261,14 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 
 	if (ticksScheduled >= AutoCycleMaxTicksScheduled ||
 	    ticksDone >= AutoCycleMaxTicksDone ||
-	    (ticksAdded > 15 && ticksScheduled >= AutoCycleMinTicksScheduled)) {
+	    (ticksAdded > AutoCycleMinTicksAdded &&
+	     ticksScheduled >= AutoCycleMinTicksScheduled)) {
 		if (ticksDone < 1) {
 			ticksDone = 1; // Protect against div by zero
 		}
 		int32_t ratio = static_cast<int32_t>(
-		        (ticksScheduled * (CPU_CyclePercUsed * auto_cycle_adjusted_scalar / 100)) /
+		        (ticksScheduled *
+		         (CPU_CyclePercUsed * auto_cycle_adjusted_scalar / 100)) /
 		        ticksDone);
 
 		int32_t new_cmax = CPU_CycleMax;
@@ -300,7 +304,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 				// do so in proportion to the tick overage
 				// (ticksAdded) amount.
 				//
-				if (ticksAdded > 15 &&
+				if (ticksAdded > AutoCycleMinTicksAdded &&
 				    ticksScheduled >= AutoCycleMinTicksScheduled &&
 				    ticksScheduled <= MaxScheduledTicks &&
 				    ratio > min_ratio) {
@@ -357,15 +361,14 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 		CPU_IODelayRemoved = 0;
 		ticksDone = 0;
 		ticksScheduled = 0;
-	} else if (ticksAdded > 15) {
+	} else if (ticksAdded > AutoCycleMinTicksAdded) {
 		/* ticksAdded > 15 but ticksScheduled < 5, lower the cycles
 		   but do not reset the scheduled/done ticks to take them into
 		   account during the next auto cycle adjustment */
 		CPU_CycleMax /= 3;
 		if (CPU_CycleMax < CPU_CYCLES_LOWER_LIMIT)
 			CPU_CycleMax = CPU_CYCLES_LOWER_LIMIT;
-	} // if (ticksScheduled >= AutoCycleMaxTicksScheduled || ticksDone >=
-	  // 250 || (ticksAdded > 15 && ticksScheduled >= 5) )
+	}
 }
 
 void DOSBOX_SetLoop(LoopHandler * handler) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -279,6 +279,10 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 					ratio = min_ratio;
 				}
 
+				if (ratio < min_ratio) {
+					ratio = min_ratio;
+				}
+
 				if (ratio <= AutoCycleRatioScalar) {
 					// ratio_not_removed = 1.0; //enabling this restores the old formula
 					double r = (1.0 + ratio_not_removed) /(ratio_not_removed + AutoCycleRatioScalar / (static_cast<double>(ratio)));


### PR DESCRIPTION
# Description

Since the transition to SDL2, we've had a hard time matching upstream's `cycles = max` performance.  This PR makes a very small (3%) change in the auto-cycle metrics to improve the rate as which the auto-cycle behavior converges on the requested rate.

This only affects the automatic behavior (such as `cycles = max`) as opposed to fixed-cycle behavior (such as `cycles = 30000`).

Although I've tested it extensively, because we're close to the 0.81 release I decided to put it behind the existing `speed_mods` feature (default-enabled), which is used for performance-sensitive features that we still want to let users disable if in doubt. 

Note to reviewers: this isn't a cleanup or refactoring of the auto-cycle chunk of code, so all the existing types/casting/names/formatting is left as-is. I only wanted to touch the value itself without further changes.

This also doesn't improve the way that macOS and DOSBox interact, so there's still some time needed to quiesce prior to starting a benchmark. This seems OK though, because it's just a nuance of launching straight into a benchmark from cold-start, where as where as actual gaming sessions are unaffected.

## Related issues

Fixes #3122 

# Manual testing

Tested on:
- Raspberry Pi 400,
- x86-64 Linux at 800 MHz
- x86-64 Linux at4 GHz
- Apple M1 (Big Sur)

Specifically confirmed that this doesn't worsen auto cycle overshooting and undershooting versus the baseline behavior.

Please test with these two packs, especially if you're on macOS:

1. [:file_folder: **`perfdos.zip`**](https://github.com/dosbox-staging/dosbox-staging/files/13398108/perfdos.zip)

    - extract, `cd perfdos`, launch: `/path/to/pr/dosbox --noprimaryconf`

2. [:file_folder: **`quakes.zip`**](https://github.com/dosbox-staging/dosbox-staging/files/13398103/quakes.zip)

    - extract, `cd quakes`, launch: `/path/to/pr/dosbox --noprimaryconf`

These test packs deliberately use a small window, `outputnb`, and the `sharp` shader to minimize GL overhead and reveal the peak performance just for testing purposes.

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/fa78bd47-5a1c-47f4-8211-a05cee78e86f

For those on a Pi + RetroPie, as usual, the console framebuffer performs best when limited to 720p (this is a defect in Pi400 and below; maybe Pi5 has fixed it):

`/boo/config.txt`
```
hdmi_group=1
hdmi_mode=4
```

And because the framebuffer is vsync bound, set this in your primary conf:

```ini
[sdl]
fullscreen = true
fullresolution = original
vsync = on
```

---

@GranMinigun, @weirddan455, @FeralChild64 : curious how the above goes on your Linux systems. I've only been able to test on Ubuntu 23.04 and RetroPie.

@shermp , @kklobe, @Kappa971 : curious if you can test on any of your Windows machines.

@Grounded0 , @kklobe , @Burrito78 , @johnnovak : curious if you can test on your various Apple x86-64 and M1/M2 machines.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

