### PR TITLE
Country codes cleanup, fix incorrect country set in some cases

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -886,74 +886,120 @@ static inline uint8_t RealHandle(uint16_t handle) {
 #define DOS_THOUSANDS_SEPARATOR_OFS 7
 #define DOS_DECIMAL_SEPARATOR_OFS   9
 
+// Sources of the country numbers:
+// - MS-DOS 6.22, COUNTRY.TXT file
+// - PC-DOS 2000, HELP COUNTRY command, information table
+// - DR-DOS 7.03, HELP, Table 9-2: Country Codes and Code Pages
+// - FreeDOS 1.3, country.asm (source code)
+// - Paragon PTS DOS 2000 Pro manual
+// - https://en.wikipedia.org/wiki/List_of_country_calling_codes
+//   (used for remaining countries, especially where we have keyboard layout)
 enum class Country : uint16_t {
-	United_States  = 1,
-	Candian_French = 2,
-	Latin_America  = 3,
-	Russia         = 7,
-	Greece         = 30,
-	Netherlands    = 31,
-	Belgium        = 32,
-	France         = 33,
-	Spain          = 34,
-	Hungary        = 36,
-	Yugoslavia     = 38,
-	Italy          = 39,
-	Romania        = 40,
-	Switzerland    = 41,
-	Czech_Slovak   = 42,
-	Austria        = 43,
-	United_Kingdom = 44,
-	Denmark        = 45,
-	Sweden         = 46,
-	Norway         = 47,
-	Poland         = 48,
-	Germany        = 49,
-	Argentina      = 54,
-	Brazil         = 55,
-	Malaysia       = 60,
-	Australia      = 61,
-	Philippines    = 63,
-	Singapore      = 65,
-	Kazakhstan     = 77,
-	Japan          = 81,
-	South_Korea    = 82,
-	Vietnam        = 84,
-	China          = 86,
-	Turkey         = 90,
-	India          = 91,
-	Niger          = 227,
-	Benin          = 229,
-	Nigeria        = 234,
-	Faeroe_Islands = 298,
-	Portugal       = 351,
-	Iceland        = 354,
-	Albania        = 355,
-	Malta          = 356,
-	Finland        = 358,
-	Bulgaria       = 359,
-	Lithuania      = 370,
-	Latvia         = 371,
-	Estonia        = 372,
-	Armenia        = 374,
-	Belarus        = 375,
-	Ukraine        = 380,
-	Serbia         = 381,
-	Montenegro     = 382,
-	Croatia        = 384,
-	Slovenia       = 386,
-	Bosnia         = 387,
-	Macedonia      = 389,
-	Taiwan         = 886,
-	Arabic         = 785,
-	Israel         = 972,
-	Mongolia       = 976,
-	Tadjikistan    = 992,
-	Turkmenistan   = 993,
-	Azerbaijan     = 994,
-	Georgia        = 995,
-	Kyrgyzstan     = 996,
-	Uzbekistan     = 998,
+	United_States      = 1,   // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Canada_French      = 2,   // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Latin_America      = 3,   // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Canada_English     = 4,   // MS-DOS
+	Russia             = 7,   // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	South_Africa       = 27,  // MS-DOS
+	Greece             = 30,  // MS-DOS, PC-DOS,         FreeDOS
+	Netherlands        = 31,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Belgium            = 32,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	France             = 33,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Spain              = 34,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Hungary            = 36,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS
+	Yugoslavia         = 38,  // MS-DOS, PC-DOS,         FreeDOS
+	Italy              = 39,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Romania            = 40,  // MS-DOS, PC-DOS,         FreeDOS
+	Switzerland        = 41,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Czechia            = 42,  // MS-DOS                                   (*)
+	Austria            = 43,  // MS-DOS                  FreeDOS
+	United_Kingdom     = 44,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Denmark            = 45,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Sweden             = 46,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Norway             = 47,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Poland             = 48,  // MS-DOS, PC-DOS,         FreeDOS
+	Germany            = 49,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Mexico             = 52,  // MS-DOS
+	Argentina          = 54,  // MS-DOS,                 FreeDOS
+	Brazil             = 55,  // MS-DOS, PC-DOS,         FreeDOS
+	Chile              = 56,  // MS-DOS
+	Colombia           = 57,  // MS-DOS
+	Venezuela          = 58,  // MS-DOS
+	Malaysia           = 60,  // MS-DOS,                 FreeDOS
+	Australia          = 61,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS          (*)
+	Philippines        = 63,
+	New_Zealand        = 64,  // MS-DOS
+	Singapore          = 65,  // MS-DOS,                 FreeDOS
+	Kazakhstan         = 77,
+	Japan              = 81,  // MS-DOS, PC-DOS,         FreeDOS, Paragon
+	Korea              = 82,  // MS-DOS,                 FreeDOS, Paragon (*)
+	Vietnam            = 84,
+	China              = 86,  // MS-DOS,                 FreeDOS, Paragon
+	Turkey             = 90,  // MS-DOS, PC-DOS, DR-DOS, FreeDOS
+	India              = 91,  // MS-DOS,                 FreeDOS
+	Niger              = 227,
+	Benin              = 229,
+	Nigeria            = 234,
+	Faroe_Islands      = 298,
+	Portugal           = 351, // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Ireland            = 353, // MS-DOS
+	Iceland            = 354, // MS-DOS, PC-DOS
+	Albania            = 355, // MS-DOS, PC-DOS
+	Malta              = 356,
+	Finland            = 358, // MS-DOS, PC-DOS, DR-DOS, FreeDOS, Paragon
+	Bulgaria           = 359, // MS-DOS, PC-DOS,         FreeDOS
+	Lithuania          = 370,
+	Latvia             = 371,
+	Estonia            = 372,
+	Armenia            = 374,
+	Belarus            = 375, //                         FreeDOS
+	Ukraine            = 380, //                         FreeDOS
+	Serbia             = 381, // MS-DOS, PC-DOS,         FreeDOS          (*)
+	Montenegro         = 382,
+	Croatia            = 384, // MS-DOS,                 FreeDOS          (*)
+	Slovenia           = 386, // MS-DOS, PC-DOS,         FreeDOS
+	Bosnia_Herzegovina = 387, //         PC-DOS,         FreeDOS
+	Macedonia          = 389, // MS-DOS, PC-DOS,         FreeDOS
+	Slovakia           = 421, // MS-DOS                                   (*)
+	Ecuador            = 593, // MS-DOS
+	Arabic             = 785, // MS-DOS,                 FreeDOS, Paragon (*)
+	Hong_Kong          = 852, // MS-DOS
+	Taiwan             = 886, // MS-DOS
+	Israel             = 972, // MS-DOS,                 FreeDOS, Paragon
+	Mongolia           = 976,
+	Tadjikistan        = 992,
+	Turkmenistan       = 993,
+	Azerbaijan         = 994,
+	Georgia            = 995,
+	Kyrgyzstan         = 996,
+	Uzbekistan         = 998,
+
+	// (*) Remarks:
+	// - MS-DOS and PC-DOS use country code 381 for both Serbia and Montenegro
+	// - MS-DOS and PC-DOS use country code 61 also for International English
+	// - PC-DOS uses country code 381 also for Yugoslavia Cyrillic
+	// - PC-DOS uses country code 385 (not 386) for Croatia
+	// - PC-DOS uses country code 388 for Bosna/Herzegovina Cyrillic
+	// - PC-DOS uses country code 421 for Czechia and 422 for Slovakia
+	// - FreeDOS uses country code 042 for Czechoslovakia
+	// - FreeDOS calls country code 785 Middle-East,
+	//   MS-DOS calls it Arabic South
+	// - Paragon PTS DOS uses country code 61 only for Australia
+	// - Paragon PTS DOS uses country code 88 for Taiwan
+	// - DOSes use country code 82 for Korea, despite country calling code
+	//   82 is assigned to South Korea
+
+	// FreeDOS also supports the following, not yet handled here:
+	// - Belgium/Dutch        40032
+	// - Belgium/French       41032
+	// - Belgium/German       42032
+	// - Spain/Spanish        40034
+	// - Spain/Catalan        41034
+	// - Spain/Gallegan       42034
+	// - Spain/Basque         43034
+	// - Switzerland/German   40041
+	// - Switzerland/French   41041
+	// - Switzerland/Italian  42041
 };
 
 #endif

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -83,78 +83,89 @@ static const CountryInfo& LookupCountryInfo(const uint16_t country_number) {
 	// result as old MS-DOS systems, but should at least provide reasonably consistent user experience with
 	// certain host operating systems.
 	static constexpr CountryInfo COUNTRY_INFO[]= {
-		//                        | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
-	//	{ Country::None           , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_PERIOD }, // C
-		{ Country::United_States  , DATE_MDY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_US
-		{ Country::Candian_French , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_CA
-		{ Country::Latin_America  , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // es_419
-		{ Country::Russia         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // ru_RU
-		{ Country::Greece         , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // el_GR
-		{ Country::Netherlands    , DATE_DMY , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // nl_NL
-		{ Country::Belgium        , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_BE
-		{ Country::France         , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_FR
-		{ Country::Spain          , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_ES
-		{ Country::Hungary        , DATE_YMD , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // hu_HU
-		{ Country::Yugoslavia     , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // sr_RS/sr_ME/hr_HR/sk_SK/bs_BA/mk_MK
-		{ Country::Italy          , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // it_IT
-		{ Country::Romania        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // ro_RO
-		{ Country::Switzerland    , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_APOST  , SEP_PERIOD }, // ??_CH
-		{ Country::Czech_Slovak   , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // cs_CZ
-		{ Country::Austria        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // de_AT
-		{ Country::United_Kingdom , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_GB
-		{ Country::Denmark        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // da_DK
-		{ Country::Sweden         , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sv_SE
-		{ Country::Norway         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // nn_NO
-		{ Country::Poland         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // pl_PL
-		{ Country::Germany        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // de_DE
-		{ Country::Argentina      , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_AR
-		{ Country::Brazil         , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // pt_BR
-		//                        | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
-		{ Country::Malaysia       , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ms_MY
-		{ Country::Australia      , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_AU
-		{ Country::Philippines    , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // fil_PH
-		{ Country::Singapore      , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ms_SG
-		{ Country::Kazakhstan     , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // kk_KZ
-		{ Country::Japan          , DATE_YMD , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ja_JP
-		{ Country::South_Korea    , DATE_YMD , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ko_KR
-		{ Country::Vietnam        , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // vi_VN
-		{ Country::China          , DATE_YMD , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // zh_CN
-		{ Country::Turkey         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // tr_TR
-		{ Country::India          , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // hi_IN
-		{ Country::Niger          , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_NE
-		{ Country::Benin          , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_BJ
-		{ Country::Nigeria        , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_NG
-		{ Country::Faeroe_Islands , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // fo_FO
-		{ Country::Portugal       , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // pt_PT
-		{ Country::Iceland        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // is_IS
-		{ Country::Albania        , DATE_DMY , SEP_PERIOD , TIME_12H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sq_AL
-		{ Country::Malta          , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // mt_MT
-		{ Country::Finland        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fi_FI
-		{ Country::Bulgaria       , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // bg_BG
-		{ Country::Lithuania      , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // lt_LT
-		{ Country::Latvia         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // lv_LV
-		{ Country::Estonia        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // et_EE
-		{ Country::Armenia        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // hy_AM
-		//                        | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
-		{ Country::Belarus        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // be_BY
-		{ Country::Ukraine        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // uk_UA
-		{ Country::Serbia         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // sr_RS
-		{ Country::Montenegro     , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // sr_ME
-		{ Country::Croatia        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // hr_HR
-		{ Country::Slovenia       , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sk_SK
-		{ Country::Bosnia         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // bs_BA
-		{ Country::Macedonia      , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // mk_MK
-		{ Country::Taiwan         , DATE_YMD , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // zh_TW
-		{ Country::Arabic         , DATE_DMY , SEP_PERIOD , TIME_12H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // ar_??
-		{ Country::Israel         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // he_IL
-		{ Country::Mongolia       , DATE_YMD , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // mn_MN
-		{ Country::Tadjikistan    , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // tg_TJ
-		{ Country::Turkmenistan   , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // tk_TM
-		{ Country::Azerbaijan     , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // az_AZ
-		{ Country::Georgia        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // ka_GE
-		{ Country::Kyrgyzstan     , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // ky_KG
-		{ Country::Uzbekistan     , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // uz_UZ
-		//                        | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
+		//                            | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
+	//	{ Country::International      , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_PERIOD }, // C
+		{ Country::United_States      , DATE_MDY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_US
+		{ Country::Canada_French      , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_CA
+		{ Country::Latin_America      , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // es_419
+		{ Country::Canada_English     , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_CA
+		{ Country::Russia             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // ru_RU
+		{ Country::South_Africa       , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // af_ZA
+		{ Country::Greece             , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // el_GR
+		{ Country::Netherlands        , DATE_DMY , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // nl_NL
+		{ Country::Belgium            , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_BE
+		{ Country::France             , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_FR
+		{ Country::Spain              , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_ES
+		{ Country::Hungary            , DATE_YMD , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // hu_HU
+		{ Country::Yugoslavia         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // sr_RS/sr_ME/hr_HR/sk_SK/bs_BA/mk_MK
+		{ Country::Italy              , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // it_IT
+		{ Country::Romania            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // ro_RO
+		{ Country::Switzerland        , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_APOST  , SEP_PERIOD }, // ??_CH
+		{ Country::Czechia            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // cs_CZ
+		{ Country::Austria            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // de_AT
+		{ Country::United_Kingdom     , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_GB
+		//                            | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
+		{ Country::Denmark            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // da_DK
+		{ Country::Sweden             , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sv_SE
+		{ Country::Norway             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // nn_NO
+		{ Country::Poland             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // pl_PL
+		{ Country::Germany            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // de_DE
+		{ Country::Argentina          , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_AR
+		{ Country::Brazil             , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // pt_BR
+		{ Country::Chile              , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_CL
+		{ Country::Colombia           , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_CO
+		{ Country::Venezuela          , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_VE
+		{ Country::Malaysia           , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ms_MY
+		{ Country::Australia          , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_AU
+		{ Country::Philippines        , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // fil_PH
+		{ Country::New_Zealand        , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_NZ
+		{ Country::Singapore          , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ms_SG
+		{ Country::Kazakhstan         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // kk_KZ
+		{ Country::Japan              , DATE_YMD , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ja_JP
+		{ Country::Korea              , DATE_YMD , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // ko_KR
+		{ Country::Vietnam            , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // vi_VN
+		{ Country::China              , DATE_YMD , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // zh_CN
+		//                            | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  
+		{ Country::Turkey             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // tr_TR
+		{ Country::India              , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // hi_IN
+		{ Country::Niger              , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_NE
+		{ Country::Benin              , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fr_BJ
+		{ Country::Nigeria            , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_NG
+		{ Country::Faroe_Islands      , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // fo_FO
+		{ Country::Portugal           , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // pt_PT
+		{ Country::Ireland            , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_IE
+		{ Country::Iceland            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // is_IS
+		{ Country::Albania            , DATE_DMY , SEP_PERIOD , TIME_12H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sq_AL
+		{ Country::Malta              , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // mt_MT
+		{ Country::Finland            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // fi_FI
+		{ Country::Bulgaria           , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // bg_BG
+		{ Country::Lithuania          , DATE_YMD , SEP_DASH   , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // lt_LT
+		{ Country::Latvia             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // lv_LV
+		{ Country::Estonia            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // et_EE
+		{ Country::Armenia            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // hy_AM
+		{ Country::Belarus            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // be_BY
+		{ Country::Ukraine            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // uk_UA
+		{ Country::Serbia             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // sr_RS
+		//                            | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
+		{ Country::Montenegro         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // sr_ME
+		{ Country::Croatia            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // hr_HR
+		{ Country::Slovenia           , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sl_SI
+		{ Country::Bosnia_Herzegovina , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // bs_BA
+		{ Country::Macedonia          , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // mk_MK
+		{ Country::Slovakia           , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // sk_SK
+		{ Country::Ecuador            , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // es_EC
+		{ Country::Arabic             , DATE_DMY , SEP_PERIOD , TIME_12H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // ar_??
+		{ Country::Hong_Kong          , DATE_DMY , SEP_SLASH  , TIME_12H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // en_HK, zh_HK
+		{ Country::Taiwan             , DATE_YMD , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // zh_TW
+		{ Country::Israel             , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // he_IL
+		{ Country::Mongolia           , DATE_YMD , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_COMMA  , SEP_PERIOD }, // mn_MN
+		{ Country::Tadjikistan        , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // tg_TJ
+		{ Country::Turkmenistan       , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // tk_TM
+		{ Country::Azerbaijan         , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_PERIOD , SEP_COMMA  }, // az_AZ
+		{ Country::Georgia            , DATE_DMY , SEP_PERIOD , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // ka_GE
+		{ Country::Kyrgyzstan         , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // ky_KG
+		{ Country::Uzbekistan         , DATE_DMY , SEP_SLASH  , TIME_24H , SEP_COLON  , SEP_SPACE  , SEP_COMMA  }, // uz_UZ
+		//                            | Date fmt | Date separ | Time fmt | Time separ | 1000 separ | Dec separ  |
 	};
 
 	for (const auto& country : COUNTRY_INFO) {

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -172,6 +172,8 @@ static const CountryInfo& LookupCountryInfo(const uint16_t country_number) {
 		if (static_cast<uint16_t>(country.country_number) == country_number)
 			return country;
 	}
+
+	LOG_WARNING("DOS: No locale info for country %d", country_number);
 	return COUNTRY_INFO[0];
 }
 

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1227,126 +1227,126 @@ const char* DOS_GetLoadedLayout(void) {
 static const std::map<std::string, Country> country_code_map{
         // clang-format off
 	// reference: https://gitlab.com/FreeDOS/base/keyb_lay/-/blob/master/DOC/KEYB/LAYOUTS/LAYOUTS.TXT
-	{"ar462",  Country::Arabic         },
-	{"ar470",  Country::Arabic         },
-	{"az",     Country::Azerbaijan     },
-	{"ba",     Country::Bosnia         },
-	{"be",     Country::Belgium        },
-	{"bg",     Country::Bulgaria       }, // 101-key
-	{"bg103",  Country::Bulgaria       }, // 101-key, Phonetic
-	{"bg241",  Country::Bulgaria       }, // 102-key
-	{"bl",     Country::Belarus        },
-	{"bn",     Country::Benin          },
-	{"br",     Country::Brazil         }, // ABNT layout
-	{"br274",  Country::Brazil         }, // US layout
-	{"bx",     Country::Belgium        }, // International
-	{"by",     Country::Belarus        },
-	{"ca",     Country::Candian_French }, // Standard
-	{"ce",     Country::Russia         }, // Chechnya Standard
-	{"ce443",  Country::Russia         }, // Chechnya Typewriter
-	{"cg",     Country::Montenegro     },
-	{"cf",     Country::Candian_French }, // Standard
-	{"cf445",  Country::Candian_French }, // Dual-layer
-	{"co",     Country::United_States  }, // Colemak
-	{"cz",     Country::Czech_Slovak   }, // Czechia, QWERTY
-	{"cz243",  Country::Czech_Slovak   }, // Czechia, Standard
-	{"cz489",  Country::Czech_Slovak   }, // Czechia, Programmers
-	{"de",     Country::Germany        }, // Standard
-	{"dk",     Country::Denmark        },
-	{"dv",     Country::United_States  }, // Dvorak
-	{"ee",     Country::Estonia        },
-	{"el",     Country::Greece         }, // 319
-	{"es",     Country::Spain          },
-	{"et",     Country::Estonia        },
-	{"fi",     Country::Finland        },
-	{"fo",     Country::Faeroe_Islands },
-	{"fr",     Country::France         }, // Standard
-	{"fx",     Country::France         }, // International
-	{"gk",     Country::Greece         }, // 319
-	{"gk220",  Country::Greece         }, // 220
-	{"gk459",  Country::Greece         }, // 101-key
-	{"gr",     Country::Germany        }, // Standard
-	{"gr453",  Country::Germany        }, // Dual-layer
-	{"hr",     Country::Croatia        },
-	{"hu",     Country::Hungary        }, // 101-key
-	{"hu208",  Country::Hungary        }, // 102-key
-	{"hy",     Country::Armenia        },
-	{"il",     Country::Israel         },
-	{"is",     Country::Iceland        }, // 101-key
-	{"is161",  Country::Iceland        }, // 102-key
-	{"it",     Country::Italy          }, // Standard
-	{"it142",  Country::Italy          }, // Comma on Numeric Pad
-	{"ix",     Country::Italy          }, // International
-	{"jp",     Country::Japan          },
-	{"ka",     Country::Georgia        },
-	{"kk",     Country::Kazakhstan     },
-	{"kk476",  Country::Kazakhstan     },
-	{"kx",     Country::United_Kingdom }, // International
-	{"ky",     Country::Kyrgyzstan     },
-	{"la",     Country::Latin_America  },
-	{"lh",     Country::United_States  }, // Left-Hand Dvorak
-	{"lt",     Country::Lithuania      }, // Baltic
-	{"lt210",  Country::Lithuania      }, // 101-key, Programmers
-	{"lt211",  Country::Lithuania      }, // AZERTY
-	{"lt221",  Country::Lithuania      }, // Standard
-	{"lt456",  Country::Lithuania      }, // Dual-layout
-	{"lv",     Country::Latvia         }, // Standard
-	{"lv455",  Country::Latvia         }, // Dual-layout
-	{"ml",     Country::Malta          }, // UK-based
-	{"mk",     Country::Macedonia      },
-	{"mn",     Country::Mongolia       },
-	{"mo",     Country::Mongolia       },
-	{"mt",     Country::Malta          }, // UK-based
-	{"mt103",  Country::Malta          }, // US-based
-	{"ne",     Country::Niger          },
-	{"ng",     Country::Nigeria        },
-	{"nl",     Country::Netherlands    }, // 102-key
-	{"no",     Country::Norway         },
-	{"ph",     Country::Philippines    },
-	{"pl",     Country::Poland         }, // 101-key, Programmers
-	{"pl214",  Country::Poland         }, // 102-key
-	{"po",     Country::Portugal       },
-	{"px",     Country::Portugal       }, // International
-	{"ro",     Country::Romania        }, // Standard
-	{"ro446",  Country::Romania        }, // QWERTY
-	{"rh",     Country::United_States  }, // Right-Hand Dvorak
-	{"ru",     Country::Russia         }, // Standard
-	{"ru443",  Country::Russia         }, // Typewriter
-	{"rx",     Country::Russia         }, // Extended Standard
-	{"rx443",  Country::Russia         }, // Extended Typewriter
-	{"sd",     Country::Switzerland    }, // German
-	{"sf",     Country::Switzerland    }, // French
-	{"sg",     Country::Switzerland    }, // German
-	{"si",     Country::Slovenia       },
-	{"sk",     Country::Czech_Slovak   }, // Slovakia
-	{"sp",     Country::Spain          },
-	{"sq",     Country::Albania        }, // No-deadkeys
-	{"sq448",  Country::Albania        }, // Deadkeys
-	{"sr",     Country::Serbia         }, // Deadkey
-	{"su",     Country::Finland        },
-	{"sv",     Country::Sweden         },
-	{"sx",     Country::Spain          }, // International
-	{"tj",     Country::Tadjikistan    },
-	{"tm",     Country::Turkmenistan   },
-	{"tr",     Country::Turkey         }, // QWERTY
-	{"tr440",  Country::Turkey         }, // Non-standard
-	{"tt",     Country::Russia         }, // Tatarstan Standard
-	{"tt443",  Country::Russia         }, // Tatarstan Typewriter
-	{"ua",     Country::Ukraine        }, // 101-key
-	{"uk",     Country::United_Kingdom }, // Standard
-	{"uk168",  Country::United_Kingdom }, // Allternate
-	{"ur",     Country::Ukraine        }, // 101-key
-	{"ur465",  Country::Ukraine        }, // 101-key
-	{"ur1996", Country::Ukraine        }, // 101-key
-	{"ur2001", Country::Ukraine        }, // 102-key
-	{"ur2007", Country::Ukraine        }, // 102-key
-	{"us",     Country::United_States  }, // Standard
-	{"ux",     Country::United_States  }, // International
-	{"uz",     Country::Uzbekistan     },
-	{"vi",     Country::Vietnam        },
-	{"yc",     Country::Serbia         }, // Deadkey
-	{"yc450",  Country::Serbia         }, // No-deadkey
-	{"yu",     Country::Yugoslavia     },
+	{"ar462",  Country::Arabic             },
+	{"ar470",  Country::Arabic             },
+	{"az",     Country::Azerbaijan         },
+	{"ba",     Country::Bosnia_Herzegovina },
+	{"be",     Country::Belgium            },
+	{"bg",     Country::Bulgaria           }, // 101-key
+	{"bg103",  Country::Bulgaria           }, // 101-key, Phonetic
+	{"bg241",  Country::Bulgaria           }, // 102-key
+	{"bl",     Country::Belarus            },
+	{"bn",     Country::Benin              },
+	{"br",     Country::Brazil             }, // ABNT layout
+	{"br274",  Country::Brazil             }, // US layout
+	{"bx",     Country::Belgium            }, // International
+	{"by",     Country::Belarus            },
+	{"ca",     Country::Canada_English     }, // Standard
+	{"ce",     Country::Russia             }, // Chechnya Standard
+	{"ce443",  Country::Russia             }, // Chechnya Typewriter
+	{"cg",     Country::Montenegro         },
+	{"cf",     Country::Canada_French      }, // Standard
+	{"cf445",  Country::Canada_French      }, // Dual-layer
+	{"co",     Country::United_States      }, // Colemak
+	{"cz",     Country::Czechia            }, // QWERTY
+	{"cz243",  Country::Czechia            }, // Standard
+	{"cz489",  Country::Czechia            }, // Programmers
+	{"de",     Country::Germany            }, // Standard
+	{"dk",     Country::Denmark            },
+	{"dv",     Country::United_States      }, // Dvorak
+	{"ee",     Country::Estonia            },
+	{"el",     Country::Greece             }, // 319
+	{"es",     Country::Spain              },
+	{"et",     Country::Estonia            },
+	{"fi",     Country::Finland            },
+	{"fo",     Country::Faroe_Islands      },
+	{"fr",     Country::France             }, // Standard
+	{"fx",     Country::France             }, // International
+	{"gk",     Country::Greece             }, // 319
+	{"gk220",  Country::Greece             }, // 220
+	{"gk459",  Country::Greece             }, // 101-key
+	{"gr",     Country::Germany            }, // Standard
+	{"gr453",  Country::Germany            }, // Dual-layer
+	{"hr",     Country::Croatia            },
+	{"hu",     Country::Hungary            }, // 101-key
+	{"hu208",  Country::Hungary            }, // 102-key
+	{"hy",     Country::Armenia            },
+	{"il",     Country::Israel             },
+	{"is",     Country::Iceland            }, // 101-key
+	{"is161",  Country::Iceland            }, // 102-key
+	{"it",     Country::Italy              }, // Standard
+	{"it142",  Country::Italy              }, // Comma on Numeric Pad
+	{"ix",     Country::Italy              }, // International
+	{"jp",     Country::Japan              },
+	{"ka",     Country::Georgia            },
+	{"kk",     Country::Kazakhstan         },
+	{"kk476",  Country::Kazakhstan         },
+	{"kx",     Country::United_Kingdom     }, // International
+	{"ky",     Country::Kyrgyzstan         },
+	{"la",     Country::Latin_America      },
+	{"lh",     Country::United_States      }, // Left-Hand Dvorak
+	{"lt",     Country::Lithuania          }, // Baltic
+	{"lt210",  Country::Lithuania          }, // 101-key, Programmers
+	{"lt211",  Country::Lithuania          }, // AZERTY
+	{"lt221",  Country::Lithuania          }, // Standard
+	{"lt456",  Country::Lithuania          }, // Dual-layout
+	{"lv",     Country::Latvia             }, // Standard
+	{"lv455",  Country::Latvia             }, // Dual-layout
+	{"ml",     Country::Malta              }, // UK-based
+	{"mk",     Country::Macedonia          },
+	{"mn",     Country::Mongolia           },
+	{"mo",     Country::Mongolia           },
+	{"mt",     Country::Malta              }, // UK-based
+	{"mt103",  Country::Malta              }, // US-based
+	{"ne",     Country::Niger              },
+	{"ng",     Country::Nigeria            },
+	{"nl",     Country::Netherlands        }, // 102-key
+	{"no",     Country::Norway             },
+	{"ph",     Country::Philippines        },
+	{"pl",     Country::Poland             }, // 101-key, Programmers
+	{"pl214",  Country::Poland             }, // 102-key
+	{"po",     Country::Portugal           },
+	{"px",     Country::Portugal           }, // International
+	{"ro",     Country::Romania            }, // Standard
+	{"ro446",  Country::Romania            }, // QWERTY
+	{"rh",     Country::United_States      }, // Right-Hand Dvorak
+	{"ru",     Country::Russia             }, // Standard
+	{"ru443",  Country::Russia             }, // Typewriter
+	{"rx",     Country::Russia             }, // Extended Standard
+	{"rx443",  Country::Russia             }, // Extended Typewriter
+	{"sd",     Country::Switzerland        }, // German
+	{"sf",     Country::Switzerland        }, // French
+	{"sg",     Country::Switzerland        }, // German
+	{"si",     Country::Slovenia           },
+	{"sk",     Country::Slovakia           },
+	{"sp",     Country::Spain              },
+	{"sq",     Country::Albania            }, // No-deadkeys
+	{"sq448",  Country::Albania            }, // Deadkeys
+	{"sr",     Country::Serbia             }, // Deadkey
+	{"su",     Country::Finland            },
+	{"sv",     Country::Sweden             },
+	{"sx",     Country::Spain              }, // International
+	{"tj",     Country::Tadjikistan        },
+	{"tm",     Country::Turkmenistan       },
+	{"tr",     Country::Turkey             }, // QWERTY
+	{"tr440",  Country::Turkey             }, // Non-standard
+	{"tt",     Country::Russia             }, // Tatarstan Standard
+	{"tt443",  Country::Russia             }, // Tatarstan Typewriter
+	{"ua",     Country::Ukraine            }, // 101-key
+	{"uk",     Country::United_Kingdom     }, // Standard
+	{"uk168",  Country::United_Kingdom     }, // Allternate
+	{"ur",     Country::Ukraine            }, // 101-key
+	{"ur465",  Country::Ukraine            }, // 101-key
+	{"ur1996", Country::Ukraine            }, // 101-key
+	{"ur2001", Country::Ukraine            }, // 102-key
+	{"ur2007", Country::Ukraine            }, // 102-key
+	{"us",     Country::United_States      }, // Standard
+	{"ux",     Country::United_States      }, // International
+	{"uz",     Country::Uzbekistan         },
+	{"vi",     Country::Vietnam            },
+	{"yc",     Country::Serbia             }, // Deadkey
+	{"yc450",  Country::Serbia             }, // No-deadkey
+	{"yu",     Country::Yugoslavia         },
         // clang-format on
 };
 
@@ -1394,20 +1394,45 @@ uint16_t assert_codepage(const uint16_t codepage)
 {
 	// grouped in ascending ordered by codepage value
 	switch (country) {
+
+	case Country::Australia:
+	case Country::China:
+	case Country::Hong_Kong:
+	case Country::India:
+	case Country::Ireland:
+	case Country::Japan:
+	case Country::Korea:
+	case Country::Malaysia:
+	case Country::New_Zealand:
+	case Country::Singapore:
+	case Country::South_Africa:
+	case Country::Taiwan:
+	case Country::United_Kingdom:
+	case Country::United_States: return assert_codepage(437);
+
 	case Country::Poland: return assert_codepage(668);
 
 	case Country::Lithuania: return assert_codepage(774);
 
+	case Country::Argentina:
+	case Country::Austria:
 	case Country::Belgium:
+	case Country::Canada_English:
+	case Country::Chile:
+	case Country::Colombia:
+	case Country::Ecuador:
 	case Country::Finland:
 	case Country::France:
 	case Country::Germany:
 	case Country::Italy:
 	case Country::Latin_America:
+	case Country::Mexico:
 	case Country::Netherlands:
+	case Country::Philippines:
 	case Country::Spain:
 	case Country::Sweden:
-	case Country::Switzerland: return assert_codepage(850);
+	case Country::Switzerland:
+	case Country::Venezuela: return assert_codepage(850);
 
 	case Country::Albania:
 	case Country::Croatia:
@@ -1416,7 +1441,9 @@ uint16_t assert_codepage(const uint16_t codepage)
 	case Country::Slovenia:
 	case Country::Turkmenistan: return assert_codepage(852);
 
-	case Country::Bosnia:
+	case Country::Malta: return assert_codepage(853);
+
+	case Country::Bosnia_Herzegovina:
 	case Country::Bulgaria:
 	case Country::Macedonia:
 	case Country::Serbia:
@@ -1427,11 +1454,12 @@ uint16_t assert_codepage(const uint16_t codepage)
 	case Country::Brazil:
 	case Country::Portugal: return assert_codepage(860);
 
+	case Country::Faroe_Islands:
 	case Country::Iceland: return assert_codepage(861);
 
 	case Country::Israel: return assert_codepage(862);
 
-	case Country::Candian_French: return assert_codepage(863);
+	case Country::Canada_French: return assert_codepage(863);
 
 	case Country::Arabic: return assert_codepage(864);
 
@@ -1440,9 +1468,12 @@ uint16_t assert_codepage(const uint16_t codepage)
 
 	case Country::Russia: return assert_codepage(866);
 
-	case Country::Czech_Slovak: return assert_codepage(867);
+	case Country::Czechia:
+	case Country::Slovakia: return assert_codepage(867);
 
 	case Country::Greece: return assert_codepage(869);
+
+	case Country::Armenia: return assert_codepage(899);
 
 	case Country::Estonia: return assert_codepage(1116);
 
@@ -1454,13 +1485,29 @@ uint16_t assert_codepage(const uint16_t codepage)
 
 	case Country::Hungary: return assert_codepage(3845);
 
+	case Country::Tadjikistan: return assert_codepage(30002);
+
 	case Country::Nigeria: return assert_codepage(30005);
+
+	case Country::Vietnam: return assert_codepage(30006);
+
+	case Country::Benin: return assert_codepage(30027);
+
+	case Country::Niger: return assert_codepage(30028);
+
+	case Country::Kazakhstan:
+	case Country::Kyrgyzstan:
+	case Country::Mongolia: return assert_codepage(58152);
 
 	case Country::Azerbaijan: return assert_codepage(58210);
 
 	case Country::Georgia: return assert_codepage(59829);
 
-	default: return assert_codepage(default_cp_437);
+	case Country::Uzbekistan: return assert_codepage(62306);
+
+	default:
+		LOG_WARNING("LAYOUT: No default code page for country %d", static_cast<int>(country));
+		return assert_codepage(default_cp_437);
 	}
 }
 

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1354,14 +1354,6 @@ static const std::map<std::string, const char *> language_to_layout_exception_ma
         {"nl", "us"},
 };
 
-static bool country_number_exists(const int requested_number)
-{
-	for ([[maybe_unused]] const auto &[code, number] : country_code_map)
-		if (requested_number == static_cast<int>(number))
-			return true;
-	return false;
-}
-
 static bool lookup_country_from_code(const char *country_code, Country &country)
 {
 	if (country_code) {
@@ -1778,7 +1770,7 @@ static void set_country_from_pref(const int country_pref)
 	auto country_number = static_cast<uint16_t>(default_country);
 
 	// If the country preference is valid, use it
-	if (country_pref > 0 && country_number_exists(country_pref)) {
+	if (country_pref > 0) {
 		country_number = static_cast<uint16_t>(country_pref);
 	} else if (const auto country_code = DOS_GetLoadedLayout(); country_code) {
 		if (Country c; lookup_country_from_code(country_code, c)) {
@@ -1788,8 +1780,7 @@ static void set_country_from_pref(const int country_pref)
 			        country_code);
 		}
 	}
-	// At this point, the country number is expected to be valid
-	assert(country_number_exists(country_number));
+
 	DOS_SetCountry(country_number);
 }
 


### PR DESCRIPTION
# Description

1. Cleaned up country codes
    - added all country codes missing from different DOSes, _MS-DOS 6.22_ having the highest priority in case of conflicts/mismatches; also checked code pages supported by _PC DOS 2000_, _DR DOS 7.03_,  _FreeDOS 1.3_, _PTS DOS Pro 2000_
    - documented the origin of various country codes, documented all the deviation
    - added some missing locale information

2. Fixed a problem with wrong country code being set in some cases
The config option description claims _If set to 0, the country code corresponding to the selected keyboard layout will be used_. This was not entirely true - in fact, it was trying to guess country number from keyboard layout if there was no default keyboard layout associated with the given country. This is now fixed.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3128 (fixes the PR only partially!)


# Manual testing

You can set `country = code` in the config file (codes suggested to check in the table below). Once DOSBox is started, type command `dir` and check that time/date is printed out according to `COUNTRY_INFO` structure from `dos.cpp` file

| country name | code   |
| ------------- | ------------- |
| Canada_English | 4   |
| South_Africa   | 27  |
| Mexico         | 52  |
| Chile          | 56  |
| Colombia       | 57  |
| Venezuela      | 58  |
| New_Zealand    | 64  |
| Vietnam        | 84  |
| Niger          | 227 |
| Benin          | 229 |
| Ireland        | 353 |
| Malta          | 356 |
| Armenia        | 374 |
| Slovakia       | 421 |
| Ecuador        | 593 |
| Hong_Kong      | 852 |
| Mongolia       | 976 |
| Tadjikistan    | 992 |
| Uzbekistan     | 998 |


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

