### PR TITLE
Adjust ticksDone with render time

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -224,7 +224,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 	// Is the system in auto cycle mode guessing ? If not just exit. (It can be temporary disabled)
 	if (!CPU_CycleAutoAdjust) return;
 
-	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
+	if (ticksScheduled >= 100 || ticksDone >= 100 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero
 		/* ratio we are aiming for is around 90% usage*/
 		int32_t ratio = static_cast<int32_t>(
@@ -244,11 +244,11 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 
 				/* Don't allow very high ratio which can cause us to lock as we don't scale down
 				 * for very low ratios. High ratio might result because of timing resolution */
-				if (ticksScheduled >= 250 && ticksDone < 10 && ratio > 16384)
+				if (ticksScheduled >= 100 && ticksDone < 10 && ratio > 16384)
 					ratio = 16384;
 
 				// Limit the ratio even more when the cycles are already way above the realmode default.
-				if (ticksScheduled >= 250 && ticksDone < 10 && ratio > 5120 && CPU_CycleMax > 50000)
+				if (ticksScheduled >= 100 && ticksDone < 10 && ratio > 5120 && CPU_CycleMax > 50000)
 					ratio = 5120;
 
 				// When downscaling multiple times in a row, ensure a minimum amount of downscaling


### PR DESCRIPTION
# Description

Since render time can take up to several milliseconds, we adjust ticksDone downwards with the time spent, similar to how increaseticks() adjusts for time spent sleeping. This boosts FPS for cycle guessing by 15-20 FPS on QTD on a 2020 MacBook M1.

I've also increased the speed at which cycle adjusting happens, to 100 ticks instead of 250.

## Related issues

Although similar in motivation, this change is independent of, and complimentary with, #3131 


# Manual testing

I tested Quake, Doom, Blood, PERFDOS, and QTD via DOSBench. I paid close attention to audio, and did not notice any artifacts.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

