### PR TITLE
Improve `mouse_sensitivity` behavior

### DIFF
--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -544,10 +544,12 @@ void MOUSECTL::AddMessages()
 	        "  -s -sx -sy     sets sensitivity / for x axis / for y axis, from -999 to +999\n"
 	        "  -r             sets minimum mouse sampling rate\n"
 	        "  -on -off       enables or disables mouse on the given interface\n"
-	        "  -reset         restores all mouse settings from the configuration file\n"
+	        "  -reset         restores default mouse settings\n"
 	        "\n"
 	        "Notes:\n"
 	        "  If sensitivity or rate is omitted, it is reset to default value.\n"
+	        "  Mouse sensitivity set in the configuration file acts as global scale factor,\n"
+	        "  per-interface sensitivity set by this commands works on top of that.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  [color=light-green]mousectl[reset] [color=white]DOS[reset] [color=white]COM1[reset] -map    ; asks user to select mice for a two player game");

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -570,11 +570,16 @@ void MOUSE_EventMoved(const float x_rel, const float y_rel,
 	// so it needs data in both formats.
 
 	// Notify mouse interfaces
-	for (auto &interface : mouse_interfaces)
-		if (interface->IsUsingHostPointer())
-			interface->NotifyMoved(x_rel, y_rel,
+	const float x_scaled = x_rel * mouse_config.sensitivity_coeff_x;
+	const float y_scaled = y_rel * mouse_config.sensitivity_coeff_y;
+	for (auto& interface : mouse_interfaces) {
+		if (interface->IsUsingHostPointer()) {
+			interface->NotifyMoved(x_scaled,
+			                       y_scaled,
 			                       state.cursor_x_abs,
 			                       state.cursor_y_abs);
+		}
+	}
 }
 
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
@@ -590,7 +595,9 @@ void MOUSE_EventMoved(const float x_rel, const float y_rel,
 	// Notify mouse interface
 	auto interface = MouseInterface::Get(interface_id);
 	if (interface && interface->IsUsingEvents()) {
-		interface->NotifyMoved(x_rel, y_rel, 0, 0);
+		const float x_scaled = x_rel * mouse_config.sensitivity_coeff_x;
+		const float y_scaled = y_rel * mouse_config.sensitivity_coeff_y;
+		interface->NotifyMoved(x_scaled, y_scaled, 0, 0);
 	}
 }
 
@@ -630,9 +637,11 @@ void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed)
 	}
 
 	// Notify mouse interfaces
-	for (auto &interface : mouse_interfaces)
-		if (interface->IsUsingHostPointer())
+	for (auto& interface : mouse_interfaces) {
+		if (interface->IsUsingHostPointer()) {
 			interface->NotifyButton(button_id, pressed);
+		}
+	}
 }
 
 void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed,
@@ -664,9 +673,11 @@ void MOUSE_EventWheel(const int16_t w_rel)
 	}
 
 	// Notify mouse interfaces
-	for (auto &interface : mouse_interfaces)
-		if (interface->IsUsingHostPointer())
+	for (auto& interface : mouse_interfaces) {
+		if (interface->IsUsingHostPointer()) {
 			interface->NotifyWheel(w_rel);
+		}
+	}
 }
 
 void MOUSE_EventWheel(const int16_t w_rel, const MouseInterfaceId interface_id)

--- a/src/hardware/input/mouse_common.h
+++ b/src/hardware/input/mouse_common.h
@@ -65,6 +65,8 @@ extern MouseShared mouse_shared; // shared internal information
 // Common helper calculations
 // ***************************************************************************
 
+float MOUSE_SensitivityCoefficient(const int16_t user_setting);
+
 float MOUSE_GetBallisticsCoeff(const float speed);
 uint8_t MOUSE_GetDelayFromRateHz(const uint16_t rate_hz);
 

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -105,78 +105,151 @@ static const std::vector<uint16_t> list_rates = {
         // issues.
 };
 
-bool MouseConfig::ParseCaptureType(const std::string_view capture_str,
-                                   MouseCapture& capture)
+const std::vector<uint16_t>& MouseConfig::GetValidMinRateList()
 {
-	if (capture_str == capture_type_seamless_str)
-		capture = MouseCapture::Seamless;
-	else if (capture_str == capture_type_onclick_str)
-		capture = MouseCapture::OnClick;
-	else if (capture_str == capture_type_onstart_str)
-		capture = MouseCapture::OnStart;
-	else if (capture_str == capture_type_nomouse_str)
-		capture = MouseCapture::NoMouse;
-	else
-		return false;
-	return true;
+	return list_rates;
 }
 
-bool MouseConfig::ParseCOMModel(const std::string_view model_str,
+bool MouseConfig::ParseComModel(const std::string_view model_str,
                                 MouseModelCOM& model, bool& auto_msm)
 {
 	if (model_str == model_com_2button_str) {
 		model    = MouseModelCOM::Microsoft;
 		auto_msm = false;
-		return true;
 	} else if (model_str == model_com_3button_str) {
 		model    = MouseModelCOM::Logitech;
 		auto_msm = false;
-		return true;
 	} else if (model_str == model_com_wheel_str) {
 		model    = MouseModelCOM::Wheel;
 		auto_msm = false;
-		return true;
 	} else if (model_str == model_com_msm_str) {
 		model    = MouseModelCOM::MouseSystems;
 		auto_msm = false;
-		return true;
 	} else if (model_str == model_com_2button_msm_str) {
 		model    = MouseModelCOM::Microsoft;
 		auto_msm = true;
-		return true;
 	} else if (model_str == model_com_3button_msm_str) {
 		model    = MouseModelCOM::Logitech;
 		auto_msm = true;
-		return true;
 	} else if (model_str == model_com_wheel_msm_str) {
 		model    = MouseModelCOM::Wheel;
 		auto_msm = true;
-		return true;
-	}
-
-	return false;
-}
-
-bool MouseConfig::ParsePS2Model(const std::string_view model_str, MouseModelPS2& model)
-{
-	if (model_str == model_ps2_standard_str) {
-		model = MouseModelPS2::Standard;
-	} else if (model_str == model_ps2_intellimouse_str) {
-		model = MouseModelPS2::IntelliMouse;
-	} else if (model_str == model_ps2_explorer_str) {
-		model = MouseModelPS2::Explorer;
-	} else if (auto as_bool = parse_bool_setting(model_str);
-	           as_bool && *as_bool == false) {
-		model = MouseModelPS2::NoMouse;
 	} else {
 		return false;
 	}
+
 	return true;
 }
 
-const std::vector<uint16_t> &MouseConfig::GetValidMinRateList()
+static void SetCaptureType(const std::string_view capture_str)
 {
-	return list_rates;
+	if (capture_str == capture_type_seamless_str) {
+		mouse_config.capture = MouseCapture::Seamless;
+	} else if (capture_str == capture_type_onclick_str) {
+		mouse_config.capture = MouseCapture::OnClick;
+	} else if (capture_str == capture_type_onstart_str) {
+		mouse_config.capture = MouseCapture::OnStart;
+	} else if (capture_str == capture_type_nomouse_str) {
+		mouse_config.capture = MouseCapture::NoMouse;
+	} else {
+		assert(false);
+	}
+}
+
+static void SetPs2Model(const std::string_view model_str)
+{
+	if (model_str == model_ps2_standard_str) {
+		mouse_config.model_ps2 = MouseModelPS2::Standard;
+	} else if (model_str == model_ps2_intellimouse_str) {
+		mouse_config.model_ps2 = MouseModelPS2::IntelliMouse;
+	} else if (model_str == model_ps2_explorer_str) {
+		mouse_config.model_ps2 = MouseModelPS2::Explorer;
+	} else if (model_str == model_ps2_nomouse_str) {
+		mouse_config.model_ps2 = MouseModelPS2::NoMouse;
+	} else {
+		assert(false);
+	}
+}
+
+static void SetComModel(const std::string_view model_str)
+{
+	[[maybe_unused]] const auto result = MouseConfig::ParseComModel(
+	        model_str, mouse_config.model_com, mouse_config.model_com_auto_msm);
+	assert(result);
+}
+
+static void SetSensitivity(const std::string_view sensitivity_str)
+{
+	// Coefficient to convert percentage in integer to float
+	constexpr float coeff = 0.01f;
+
+	// Default sensitivity value
+	const auto& user_default = mouse_predefined.sensitivity_user_default;
+	const auto default_value = coeff * user_default;
+
+	// Split input string into values
+	auto values_str = split(sensitivity_str, " \t,;");
+	if (values_str.size() > 2) {
+		LOG_WARNING("MOUSE: Too many values in 'mouse_sensitivity', using '%d'",
+		            user_default);
+		mouse_config.sensitivity_coeff_x = default_value;
+		mouse_config.sensitivity_coeff_y = default_value;
+		return;
+	}
+
+	// If no values given, use defaults
+	if (values_str.empty()) {
+		mouse_config.sensitivity_coeff_x = default_value;
+		mouse_config.sensitivity_coeff_y = default_value;
+		return;
+	}
+
+	// Convert values to integers
+	std::vector<int> values_int = {};
+
+	bool out_of_range   = false;
+	const int value_min = -mouse_predefined.sensitivity_user_max;
+	const int value_max = mouse_predefined.sensitivity_user_max;
+	for (auto& value_str : values_str) {
+		// Remove trailing '%' signs, if present
+		if (ends_with(value_str, "%")) {
+			value_str.pop_back();
+		}
+
+		const auto value = parse_int(value_str);
+		if (!value) {
+			LOG_WARNING("MOUSE: Invalid 'mouse_sensitivity' setting: '%s', using '%d'",
+			            value_str.c_str(), user_default);
+			mouse_config.sensitivity_coeff_x = default_value;
+			mouse_config.sensitivity_coeff_y = default_value;
+			return;
+		}
+
+		const auto value_clamped = clamp(*value, value_min, value_max);
+		if (value_clamped != *value) {
+			out_of_range = true;
+		}
+		values_int.push_back(value_clamped);
+	}
+
+	if (out_of_range) {
+		LOG_WARNING("MOUSE: 'mouse_sensitivity' adjusted to range %+d - %+d",
+		            value_min,
+		            value_max);
+	}
+
+	// Set the actual values
+	assert(values_int.size() == 1 || values_int.size() == 2);
+	const auto value_float_0 = static_cast<float>(values_int[0]);
+	mouse_config.sensitivity_coeff_x = coeff * value_float_0;
+	if (values_int.size() == 2) {
+		const auto value_float_1 = static_cast<float>(values_int[1]);
+		mouse_config.sensitivity_coeff_y = coeff * value_float_1;
+	} else {
+		mouse_config.sensitivity_coeff_y = mouse_config.sensitivity_coeff_x;
+	}
+
+	return;
 }
 
 static void config_read(Section *section)
@@ -189,8 +262,8 @@ static void config_read(Section *section)
 
 	// Settings changeable during runtime
 
-	std::string prop_str = conf->Get_string("mouse_capture");
-	MouseConfig::ParseCaptureType(prop_str, mouse_config.capture);
+	SetCaptureType(conf->Get_string("mouse_capture"));
+	SetSensitivity(conf->Get_string("mouse_sensitivity"));
 
 	mouse_config.multi_display_aware =
 		conf->Get_bool("mouse_multi_display_aware");
@@ -198,12 +271,6 @@ static void config_read(Section *section)
 	mouse_config.middle_release = conf->Get_bool("mouse_middle_release");
 	mouse_config.raw_input      = conf->Get_bool("mouse_raw_input");
 	mouse_config.dos_immediate  = conf->Get_bool("dos_mouse_immediate");
-
-	PropMultiVal* prop_multi = conf->GetMultiVal("mouse_sensitivity");
-	mouse_config.sensitivity_coeff_x =
-	        0.01f * static_cast<float>(prop_multi->GetSection()->Get_int("xsens"));
-	mouse_config.sensitivity_coeff_y =
-	        0.01f * static_cast<float>(prop_multi->GetSection()->Get_int("ysens"));
 
 	// Settings below should be read only once
 
@@ -226,15 +293,11 @@ static void config_read(Section *section)
 
 	// PS/2 AUX port mouse configuration
 
-	prop_str = conf->Get_string("ps2_mouse_model");
-	MouseConfig::ParsePS2Model(prop_str, mouse_config.model_ps2);
+	SetPs2Model(conf->Get_string("ps2_mouse_model"));
 
 	// COM port mouse configuration
 
-	prop_str = conf->Get_string("com_mouse_model");
-	MouseConfig::ParseCOMModel(prop_str,
-	                           mouse_config.model_com,
-	                           mouse_config.model_com_auto_msm);
+	SetComModel(conf->Get_string("com_mouse_model"));
 
 	// VMM PCI interfaces
 
@@ -264,10 +327,8 @@ static void config_init(Section_prop &secprop)
 	constexpr auto always        = Property::Changeable::Always;
 	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
 
-	Prop_bool    *prop_bool  = nullptr;
-	Prop_int     *prop_int   = nullptr;
-	Prop_string  *prop_str   = nullptr;
-	PropMultiVal *prop_multi = nullptr;
+	Prop_bool* prop_bool  = nullptr;
+	Prop_string* prop_str = nullptr;
 
 	// General configuration
 
@@ -300,21 +361,14 @@ static void config_init(Section_prop &secprop)
 	                    "      using mirrored display mode or using an AV receiver's HDMI input for\n"
 	                    "      audio-only listening.");
 
-	prop_multi = secprop.AddMultiVal("mouse_sensitivity", always, ",");
-	prop_multi->Set_help(
+	prop_str = secprop.Add_string("mouse_sensitivity", always, "100");
+	prop_str->Set_help(
 	        "Global mouse sensitivity for the horizontal and vertical axes, as a percentage\n"
-	        "(100,100 by default). Negative values invert the axis, zero disables it.\n"
+	        "(100 by default). Values can be separated by spaces, commas, or semicolons\n"
+	        "(i.e. 100,150). Negative values invert the axis, zero disables it.\n"
 	        "Providing only one value sets sensitivity for both axes.\n"
 	        "Sensitivity can be further fine-tuned per mouse interface using the internal\n"
 	        "MOUSECTL.COM tool available on the Z drive.");
-	prop_multi->SetValue("100");
-
-	prop_int = prop_multi->GetSection()->Add_int("xsens", only_at_start, 100);
-	prop_int->SetMinMax(-mouse_predefined.sensitivity_user_max,
-	                    mouse_predefined.sensitivity_user_max);
-	prop_int = prop_multi->GetSection()->Add_int("ysens", only_at_start, 100);
-	prop_int->SetMinMax(-mouse_predefined.sensitivity_user_max,
-	                    mouse_predefined.sensitivity_user_max);
 
 	prop_bool = secprop.Add_bool("mouse_raw_input", always, true);
 	prop_bool->Set_help(

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -199,6 +199,12 @@ static void config_read(Section *section)
 	mouse_config.raw_input      = conf->Get_bool("mouse_raw_input");
 	mouse_config.dos_immediate  = conf->Get_bool("dos_mouse_immediate");
 
+	PropMultiVal* prop_multi = conf->GetMultiVal("mouse_sensitivity");
+	mouse_config.sensitivity_coeff_x =
+	        0.01f * static_cast<float>(prop_multi->GetSection()->Get_int("xsens"));
+	mouse_config.sensitivity_coeff_y =
+	        0.01f * static_cast<float>(prop_multi->GetSection()->Get_int("ysens"));
+
 	// Settings below should be read only once
 
 	if (mouse_shared.ready_config) {
@@ -213,14 +219,6 @@ static void config_read(Section *section)
 		MOUSE_UpdateGFX();
 		return;
 	}
-
-	// Default mouse sensitivity
-
-	PropMultiVal *prop_multi = conf->GetMultiVal("mouse_sensitivity");
-	mouse_config.sensitivity_x = static_cast<int16_t>(
-	        prop_multi->GetSection()->Get_int("xsens"));
-	mouse_config.sensitivity_y = static_cast<int16_t>(
-	        prop_multi->GetSection()->Get_int("ysens"));
 
 	// DOS driver configuration
 
@@ -302,13 +300,13 @@ static void config_init(Section_prop &secprop)
 	                    "      using mirrored display mode or using an AV receiver's HDMI input for\n"
 	                    "      audio-only listening.");
 
-	prop_multi = secprop.AddMultiVal("mouse_sensitivity", only_at_start, ",");
+	prop_multi = secprop.AddMultiVal("mouse_sensitivity", always, ",");
 	prop_multi->Set_help(
-	        "Mouse sensitivity for the horizontal and vertical axes, as a percentage\n"
+	        "Global mouse sensitivity for the horizontal and vertical axes, as a percentage\n"
 	        "(100,100 by default). Negative values invert the axis, zero disables it.\n"
 	        "Providing only one value sets sensitivity for both axes.\n"
-	        "The setting can be adjusted in runtime (also per mouse interface) using\n"
-	        "internal MOUSECTL.COM tool, available on drive Z.");
+	        "Sensitivity can be further fine-tuned per mouse interface using the internal\n"
+	        "MOUSECTL.COM tool available on the Z drive.");
 	prop_multi->SetValue("100");
 
 	prop_int = prop_multi->GetSection()->Add_int("xsens", only_at_start, 100);

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -42,8 +42,9 @@ struct MousePredefined {
 	// Larger values = higher mouse acceleration
 	const float acceleration_vmm = 1.0f;
 
-	// Maximum allowed user sensitivity value
-	const int16_t sensitivity_user_max = 999;
+	// Default and maximum allowed user sensitivity value
+	const int16_t sensitivity_user_default = 100;
+	const int16_t sensitivity_user_max     = 999;
 
 	// IRQ used by PS/2 mouse - do not change unless you really know
 	// what you are doing!
@@ -78,8 +79,9 @@ struct MouseConfig {
 	MouseCapture capture = MouseCapture::OnStart;
 	bool middle_release  = true;
 
-	int16_t sensitivity_x    = 50; // default sensitivity values
-	int16_t sensitivity_y    = 50;
+	float sensitivity_coeff_x = 1.0f;
+	float sensitivity_coeff_y = 1.0f;
+
 	bool raw_input           = false; // true = relative input is raw data
 	bool multi_display_aware = false;
 

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -98,13 +98,9 @@ struct MouseConfig {
 
 	// Helper functions for external modules
 
-	static const std::vector<uint16_t> &GetValidMinRateList();
-	static bool ParseCaptureType(const std::string_view capture_str,
-	                             MouseCapture& capture);
-	static bool ParseCOMModel(const std::string_view model_str,
+	static const std::vector<uint16_t>& GetValidMinRateList();
+	static bool ParseComModel(const std::string_view model_str,
 	                          MouseModelCOM& model, bool& auto_msm);
-	static bool ParsePS2Model(const std::string_view model_str,
-	                          MouseModelPS2& model);
 };
 
 extern MouseConfig mouse_config;

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -497,17 +497,18 @@ void MouseInterface::ConfigSetSensitivityY(const int16_t value)
 
 void MouseInterface::ConfigResetSensitivity()
 {
-	ConfigSetSensitivity(mouse_config.sensitivity_x, mouse_config.sensitivity_y);
+	ConfigSetSensitivity(mouse_predefined.sensitivity_user_default,
+	                     mouse_predefined.sensitivity_user_default);
 }
 
 void MouseInterface::ConfigResetSensitivityX()
 {
-	ConfigSetSensitivityX(mouse_config.sensitivity_x);
+	ConfigSetSensitivityX(mouse_predefined.sensitivity_user_default);
 }
 
 void MouseInterface::ConfigResetSensitivityY()
 {
-	ConfigSetSensitivityY(mouse_config.sensitivity_y);
+	ConfigSetSensitivityY(mouse_predefined.sensitivity_user_default);
 }
 
 void MouseInterface::ConfigSetMinRate(const uint16_t value_hz)

--- a/src/hardware/serialport/serialmouse.cpp
+++ b/src/hardware/serialport/serialmouse.cpp
@@ -62,7 +62,7 @@ CSerialMouse::CSerialMouse(const uint8_t id, CommandLine *cmd)
 
 	std::string model_string;
 	if (cmd->FindStringBegin("model:", model_string, false) &&
-	    !MouseConfig::ParseCOMModel(model_string, param_model, param_auto_msm)) {
+	    !MouseConfig::ParseComModel(model_string, param_model, param_auto_msm)) {
 		LOG_ERR("MOUSE (COM%d): Invalid model '%s'",
 		        port_num,
 		        model_string.c_str());


### PR DESCRIPTION
# Description

Implemented changes requested by @johnnovak:
- `mouse_sensitivity` can now be changed at runtime; to achieve this, sensitivity settings from `mousectl` tool (which can be set differently per mouse interface) now work independently, as a second layer of scaling
- improved `mouse_sensitivity` argument parsing for better error detection


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3133


# Manual testing

- test that `mousectl -s <value>` command and `mouse_sensitivity` setting still work
- try different legal and illegal values of `mouse_sensitivity` in config file; values out of range should be cropped, any other error should cause the defaults to be applied; all errors should be logged


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

