### PR TITLE
Regenerate primary config file if it is empty

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -140,6 +140,9 @@ public:
 	                     const std::string& config_file_name);
 
 	void ParseEnv();
+	void ParseConfigFiles(const std_fs::path& config_path);
+	const std::string& GetLanguage();
+	const char* SetProp(std::vector<std::string>& pvars);
 
 	bool SecureMode() const
 	{

--- a/include/cross.h
+++ b/include/cross.h
@@ -113,6 +113,7 @@ void InitConfigDir();
 
 std_fs::path GetConfigDir();
 std::string GetPrimaryConfigName();
+std_fs::path GetPrimaryConfigPath();
 
 std_fs::path resolve_home(const std::string &str) noexcept;
 

--- a/include/setup.h
+++ b/include/setup.h
@@ -507,13 +507,6 @@ public:
 	}
 };
 
-std_fs::path GetPrimaryConfigPath();
-void ParseConfigFiles(const std_fs::path& config_path);
-
-const std::string& GetLanguage();
-
-const char* SetProp(std::vector<std::string>& pvars);
-
-bool ConfigFileIsValid(const std_fs::path& path);
+bool config_file_is_valid(const std_fs::path& path);
 
 #endif

--- a/include/setup.h
+++ b/include/setup.h
@@ -514,4 +514,6 @@ const std::string& GetLanguage();
 
 const char* SetProp(std::vector<std::string>& pvars);
 
+bool ConfigFileIsValid(const std_fs::path& path);
+
 #endif

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1639,7 +1639,7 @@ KeyboardErrorCode DOS_LoadKeyboardLayoutFromLanguage(const char * language_pref)
 	// If a specific language wasn't provided, get it from setup
 	std::string language = language_pref;
 	if (language == "auto")
-		language = GetLanguage();
+		language = control->GetLanguage();
 
 	// Does the language have a country associate with it?
 	auto country       = default_country;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4692,7 +4692,7 @@ int sdl_main(int argc, char* argv[])
 		if (!arguments->securemode && !arguments->noprimaryconf) {
 			const auto primary_config_path = GetPrimaryConfigPath();
 
-			if (!path_exists(primary_config_path)) {
+			if (!ConfigFileIsValid(primary_config_path)) {
 				// No config is loaded at this point, so we're
 				// writing the default settings to the primary
 				// config.

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4692,7 +4692,7 @@ int sdl_main(int argc, char* argv[])
 		if (!arguments->securemode && !arguments->noprimaryconf) {
 			const auto primary_config_path = GetPrimaryConfigPath();
 
-			if (!ConfigFileIsValid(primary_config_path)) {
+			if (!config_file_is_valid(primary_config_path)) {
 				// No config is loaded at this point, so we're
 				// writing the default settings to the primary
 				// config.
@@ -4709,7 +4709,7 @@ int sdl_main(int argc, char* argv[])
 		// After DOSBOX_Init() is done, all the conf sections have been
 		// registered, so we're ready to parse the conf files.
 		//
-		ParseConfigFiles(GetConfigDir());
+		control->ParseConfigFiles(GetConfigDir());
 
 		// Handle command line options that don't start the emulator but only
 		// perform some actions and print the results to the console.
@@ -4831,7 +4831,7 @@ int sdl_main(int argc, char* argv[])
 
 			std::vector<std::string> pvars(1, std::move(line));
 
-			const char* result = SetProp(pvars);
+			const char* result = control->SetProp(pvars);
 
 			if (strlen(result)) {
 				LOG_WARNING("CONFIG: %s", result);

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -60,6 +60,11 @@ std::string GetPrimaryConfigName()
 	return CANONICAL_PROJECT_NAME ".conf";
 }
 
+std_fs::path GetPrimaryConfigPath()
+{
+	return GetConfigDir() / GetPrimaryConfigName();
+}
+
 #if defined(MACOSX)
 
 static std_fs::path get_or_create_config_dir()

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -253,7 +253,7 @@ void MSG_Init([[maybe_unused]] Section_prop *section)
 	static const std_fs::path subdir   = "translations";
 	static const std::string extension = ".lng";
 
-	const auto lang = GetLanguage();
+	const auto lang = control->GetLanguage();
 
 	// If the language is english, then use the internal message
 	if (lang.empty() || starts_with(lang, "en")) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -794,7 +794,7 @@ void CONFIG::Run(void)
 			if (cmd->GetStringRemain(rest)) {
 				pvars.push_back(rest);
 			}
-			const char* result = SetProp(pvars);
+			const char* result = control->SetProp(pvars);
 			if (strlen(result)) {
 				WriteOut(result);
 			} else {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1804,3 +1804,28 @@ void Config::ParseArguments()
 
 	arguments.editconf = cmdline->FindRemoveOptionalArgument("editconf");
 }
+
+// Only checks if config file exists and is not empty
+bool ConfigFileIsValid(const std_fs::path& path)
+{
+	FILE* file = fopen(path.string().c_str(), "r");
+	if (!file) {
+		return false;
+	}
+
+	constexpr size_t BufferSize = 4096;
+	char buffer[BufferSize];
+	size_t bytes_read;
+	do {
+		bytes_read = fread(buffer, 1, BufferSize, file);
+		for (size_t i = 0; i < bytes_read; ++i) {
+			if (!isspace(buffer[i])) {
+				fclose(file);
+				return true;
+			}
+		}
+	} while (bytes_read == BufferSize);
+
+	fclose(file);
+	return false;
+}

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -28,7 +28,7 @@ public:
 		//
 		InitConfigDir();
 		const auto config_path = GetConfigDir();
-		ParseConfigFiles(config_path);
+		control->ParseConfigFiles(config_path);
 
 		Section *_sec;
 		// This will register all the init functions, but won't run them


### PR DESCRIPTION
# Description
This PR simply checks if the found config file is empty (or contains only whitespace).  If so, re-create the config file as if it were not there.

There was some discussion about how best to enable portable mode that happened on a closed PR #2966

Flagging everyone involved in that discussion as a reviewer.

@Torinde it would not let me add you as a reviewer for some reason but feel free to comment here.

## Related issues
#2966

# Manual testing
Portable mode can be enabled simply by `touch /path/to/dosbox/dosbox-staging.conf` (or similarly creating an empty file with Notepad or something).  This worked before but left  the user with an empty config file.  Now, the config file gets regenerated with default settings.

Tested that no behavior changes on finding a non-empty config file or non-existent config file (configfile if created if it doesn't exist and left alone if it is non-empty).  Tested various whitespace characters and confirmed an all white-space containing file is treated as empty.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
