### PR TITLE
Restore pause on macOS & pause indicator in the window's title bar

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -32,8 +32,8 @@
 #include "lazyflags.h"
 #include "support.h"
 
-extern void GFX_RefreshTitle();
-extern void GFX_SetTitle(const int32_t cycles, const bool paused = false);
+extern void GFX_RefreshTitle(const bool is_paused = false);
+extern void GFX_SetTitle(const int32_t cycles, const bool is_paused = false);
 
 #if 1
 #undef LOG

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -66,8 +66,8 @@ struct EXE_Header {
 #define OVERLAY 3
 
 
-extern void GFX_RefreshTitle();
-extern void GFX_SetTitle(const int32_t cycles, const bool paused = false);
+extern void GFX_RefreshTitle(const bool is_paused = false);
+extern void GFX_SetTitle(const int32_t cycles, const bool is_paused = false);
 
 void DOS_UpdatePSPName(void) {
 	DOS_MCB mcb(dos.psp()-1);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -568,8 +568,9 @@ static bool is_command_pressed(const SDL_Event event)
 
 [[maybe_unused]] static void pause_emulation(bool pressed)
 {
-	if (!pressed)
+	if (!pressed) {
 		return;
+	}
 	const auto inkeymod = static_cast<uint16_t>(SDL_GetModState());
 
 	bool is_paused = true;
@@ -577,13 +578,17 @@ static bool is_command_pressed(const SDL_Event event)
 
 	Delay(500);
 	SDL_Event event;
+
 	while (SDL_PollEvent(&event)) {
 		// flush event queue.
 	}
-	/* NOTE: This is one of the few places where we use SDL key codes
-	with SDL 2.0, rather than scan codes. Is that the correct behavior? */
+
+	// NOTE: This is one of the few places where we use SDL key codes with
+	// SDL 2.0, rather than scan codes. Is that the correct behavior?
 	while (is_paused && !shutdown_requested) {
-		SDL_WaitEvent(&event);    // since we're not polling, cpu usage drops to 0.
+		// since we're not polling, CPU usage drops to 0.
+		SDL_WaitEvent(&event);
+
 		switch (event.type) {
 		case SDL_QUIT: GFX_RequestExit(true); break;
 
@@ -595,29 +600,36 @@ static bool is_command_pressed(const SDL_Event event)
 			break;
 
 		case SDL_KEYDOWN:
-#if defined (MACOSX)
+#if defined(MACOSX)
 			// Pause/unpause is hardcoded to Command+P on macOS
-			if (is_command_pressed(event) && event.key.keysym.sym == SDLK_p) {
+			if (is_command_pressed(event) &&
+			    event.key.keysym.sym == SDLK_p) {
 #else
-			// Pause/unpause is hardcoded to Alt+Pause on Window & Linux
+			// Pause/unpause is hardcoded to Alt+Pause on Window &
+			// Linux
 			if (event.key.keysym.sym == SDLK_PAUSE) {
 #endif
 				const uint16_t outkeymod = event.key.keysym.mod;
 				if (inkeymod != outkeymod) {
 					KEYBOARD_ClrBuffer();
 					MAPPER_LosingFocus();
-					//Not perfect if the pressed alt key is switched, but then we have to
-					//insert the keys into the mapper or create/rewrite the event and push it.
-					//Which is tricky due to possible use of scancodes.
+					// Not perfect if the pressed Alt key is
+					// switched, but then we have to insert
+					// the keys into the mapper or
+					// create/rewrite the event and push it.
+					// Which is tricky due to possible use
+					// of scancodes.
 				}
 				is_paused = false;
 				GFX_RefreshTitle(is_paused);
 				break;
 			}
 
-#if defined (MACOSX)
-			if (is_command_pressed(event) && event.key.keysym.sym == SDLK_q) {
-				/* On macs, all aps exit when pressing cmd-q */
+#if defined(MACOSX)
+			if (is_command_pressed(event) &&
+			    event.key.keysym.sym == SDLK_q) {
+				// On macOS, Command+Q is the default key to close an
+				// application
 				GFX_RequestExit(true);
 				break;
 			}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -566,7 +566,7 @@ static bool is_command_pressed(const SDL_Event event)
 }
 #endif
 
-[[maybe_unused]] static void PauseDOSBox(bool pressed)
+[[maybe_unused]] static void pause_emulation(bool pressed)
 {
 	if (!pressed)
 		return;
@@ -3618,11 +3618,11 @@ static void GUI_StartUp(Section* sec)
 /* Pause binds with activate-debugger */
 #elif defined(MACOSX)
 	// Pause/unpause is hardcoded to Command+P on macOS
-	MAPPER_AddHandler(&PauseDOSBox, SDL_SCANCODE_P, PRIMARY_MOD,
+	MAPPER_AddHandler(&pause_emulation, SDL_SCANCODE_P, PRIMARY_MOD,
 	                  "pause", "Pause Emu.");
 #else
 	// Pause/unpause is hardcoded to Alt+Pause on Window & Linux
-	MAPPER_AddHandler(&PauseDOSBox, SDL_SCANCODE_PAUSE, MMOD2,
+	MAPPER_AddHandler(&pause_emulation, SDL_SCANCODE_PAUSE, MMOD2,
 	                  "pause", "Pause Emu.");
 #endif
 	/* Get Keyboard state of numlock and capslock */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -324,10 +324,10 @@ void GFX_SetTitle(const int32_t new_num_cycles, const bool is_paused = false)
 	SDL_SetWindowTitle(sdl.window, title_buf);
 }
 
-void GFX_RefreshTitle()
+void GFX_RefreshTitle(const bool is_paused = false)
 {
 	constexpr int8_t refresh_cycle_count = -1;
-	GFX_SetTitle(refresh_cycle_count);
+	GFX_SetTitle(refresh_cycle_count, is_paused);
 }
 
 // Detects if we're running within a desktop environment (or window manager).
@@ -572,8 +572,9 @@ static bool is_command_pressed(const SDL_Event event)
 		return;
 	const auto inkeymod = static_cast<uint16_t>(SDL_GetModState());
 
-	GFX_RefreshTitle();
-	bool paused = true;
+	bool is_paused = true;
+	GFX_RefreshTitle(is_paused);
+
 	Delay(500);
 	SDL_Event event;
 	while (SDL_PollEvent(&event)) {
@@ -581,7 +582,7 @@ static bool is_command_pressed(const SDL_Event event)
 	}
 	/* NOTE: This is one of the few places where we use SDL key codes
 	with SDL 2.0, rather than scan codes. Is that the correct behavior? */
-	while (paused && !shutdown_requested) {
+	while (is_paused && !shutdown_requested) {
 		SDL_WaitEvent(&event);    // since we're not polling, cpu usage drops to 0.
 		switch (event.type) {
 		case SDL_QUIT: GFX_RequestExit(true); break;
@@ -609,8 +610,8 @@ static bool is_command_pressed(const SDL_Event event)
 					//insert the keys into the mapper or create/rewrite the event and push it.
 					//Which is tricky due to possible use of scancodes.
 				}
-				paused = false;
-				GFX_RefreshTitle();
+				is_paused = false;
+				GFX_RefreshTitle(is_paused);
 				break;
 			}
 


### PR DESCRIPTION
# Description

Due to popular demand from @Grounded0 😄 , this restores the pause function on macOS (fixes https://github.com/dosbox-staging/dosbox-staging/issues/1865). The hotkey is hardcoded: Cmd+P pauses, then Cmd+P again unpauses.

It also restores the pause indicator in the window's title bar on all platforms, so at least in windowed mode you'll know DOSBox is not responding because it's paused:

<img width="660" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/602a73ab-f995-4825-8efd-eff74cc6236f">

---

To recap:

- Pause/unpause is hardcoded to Alt+Pause on Windows & Linux.
- Using Esc to unpause caused issues, so that has been removed.
- If you remap the "Pause Emu." hotkey in the mapper, you'll get all sorts of erratic behaviour—don't do it. Remapping the pause key is currently not supported.
- User input is effectively stopped in Pause mode as it's a hack. So you cannot use any other hotkeys like creating a screenshot while the game is paused, or enter/exit fullscreen, or anything else. All you can do is exit pause mode. More info: https://github.com/dosbox-staging/dosbox-staging/pull/2323#issuecomment-1462349376

The pause feature will be rebuilt and properly implemented when we get to reimplementing the mapper from the ground up, but most likely not until then as the current implementation is a royal mess...


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/1865

https://github.com/dosbox-staging/dosbox-staging/pull/1970

# Manual testing

- Pause/unpause works in windowed mode and you can see the "PAUSED" indicator in the window's title bar
- Pause/unpause works in fullscreen mode
- Cmd+Q or clicking on the red close window titlebar widget exists DOSBox while in pause mode
- Minimising the paused window then restoring it works
- If `pause_when_inactive` is enabled, manual pause overrides the auto-unpause (so if you've paused with Cmd+P, deactivating and activating the window again won't unpause—I think this is fine and logical)
 
# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

