### PR TITLE
Restore sane `max N%` cycles behaviour where 100% means 100%

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2114,7 +2114,7 @@ static void CPU_CycleIncrease(bool pressed) {
 	if (!pressed) return;
 	if (CPU_CycleAutoAdjust) {
 		CPU_CyclePercUsed+=5;
-		if (CPU_CyclePercUsed>105) CPU_CyclePercUsed=105;
+		if (CPU_CyclePercUsed>100) CPU_CyclePercUsed=100;
 		LOG_MSG("CPU speed: max %d percent.",CPU_CyclePercUsed);
 		GFX_SetTitle(CPU_CyclePercUsed);
 	} else {
@@ -2265,7 +2265,7 @@ public:
 		CommandLine cmd("", p->GetSection()->Get_string("parameters"));
 
 		constexpr auto min_percent = 0;
-		constexpr auto max_percent = 105;
+		constexpr auto max_percent = 100;
 
 		if (type == "max") {
 			CPU_CycleMax = 0;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -226,9 +226,9 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
 
 	if (ticksScheduled >= 250 || ticksDone >= 250 || (ticksAdded > 15 && ticksScheduled >= 5) ) {
 		if(ticksDone < 1) ticksDone = 1; // Protect against div by zero
-		/* ratio we are aiming for is around 90% usage*/
+		// Ratio we are aiming for is 100% usage
 		int32_t ratio = static_cast<int32_t>(
-		        (ticksScheduled * (CPU_CyclePercUsed * 90 * 1024 / 100 / 100)) /
+		        (ticksScheduled * (CPU_CyclePercUsed * 100 * 1024 / 100 / 100)) /
 		        ticksDone);
 
 		int32_t new_cmax = CPU_CycleMax;


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/1913

Previously,  `cycles = max` or `cycles = max 100%` really meant 90% CPU core utilisation, and the rather hacky `cycles = max 105%` corresponded to about 95% actual utilisation. You could not go higher than that! This perhaps made _some_ sense in the early 2000s when single-core CPUs were the norm to protect inexperienced users, but as since about 2010 onwards at least dual-cores became common, this is nothing more than some confusing legacy cruft. Even the quite old and underpowered Raspberry Pi 3B released in 2016 has a 64-bit quad-core ARM Cortex...

Having said that, people are always free to use `max 90%`, `max 50%`, or whatever. I wanted to get this in for the 0.81.0 testing cycle so we can give `cycles = max` a good workout, but I expect no issues.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/1913

# Manual testing

Tried a few extremely demanding late 90s demos that use the VESA 512x384 24-bit true colour mode for CPU-based 3D rendering ([kkowboy](https://www.pouet.net/prod.php?which=87) and [moralhardcandy](https://www.pouet.net/prod.php?which=11)). They worked perfectly fine with `cycles = max`; 100% smooth 70 FPS rendering, zero sound glitches, and I was using Discord and a couple of browsers and tons of other stuff in the background on my 10-core M1 Mac.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

