### PR TITLE
Re-initialize the BIOS DAC callbacks on SB and Tandy changes

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -138,4 +138,6 @@ void INT10_ReloadRomFonts();
 
 void BIOS_SetComPorts (uint16_t baseaddr[]);
 
+void BIOS_SetupTandySbDacCallbacks();
+
 #endif

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -82,6 +82,7 @@ centerline.
 #include <queue>
 #include <string_view>
 
+#include "bios.h"
 #include "channel_names.h"
 #include "dma.h"
 #include "hardware.h"
@@ -634,6 +635,7 @@ bool TS_Get_Address(Bitu &tsaddr, Bitu &tsirq, Bitu &tsdma)
 static void set_tandy_sound_flag_in_bios(const bool is_enabled)
 {
 	real_writeb(0x40, 0xd4, is_enabled ? 0xff : 0x00);
+	BIOS_SetupTandySbDacCallbacks();
 }
 
 static void shutdown_dac(Section*)

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1034,7 +1034,7 @@ void BIOS_ZeroExtendedSize(bool in) {
 
 static void shutdown_tandy_sb_dac_callbacks()
 {
-	/* abort DAC playing */
+	// Abort DAC playing
 	if (tandy_sb.port) {
 		IO_Write(tandy_sb.port + 0xc, 0xd3);
 		IO_Write(tandy_sb.port + 0xc, 0xd0);
@@ -1043,7 +1043,7 @@ static void shutdown_tandy_sb_dac_callbacks()
 	if (tandy_DAC_callback[0]) {
 		uint32_t orig_vector = real_readd(0x40, 0xd6);
 		if (orig_vector == tandy_DAC_callback[0]->Get_RealPointer()) {
-			/* set IRQ vector to old value */
+			// Set IRQ vector to old value
 			uint8_t tandy_irq = 7;
 			if (tandy_sb.port) {
 				tandy_irq = tandy_sb.irq;
@@ -1065,20 +1065,19 @@ static void shutdown_tandy_sb_dac_callbacks()
 		tandy_DAC_callback[0] = nullptr;
 		tandy_DAC_callback[1] = nullptr;
 	}
-}
-
-void setup_tandy_sb_dac_callbacks()
-{
 	tandy_sb.port  = 0;
 	tandy_dac.port = 0;
+}
 
-	/* tandy DAC can be requested in tandy_sound.cpp by initializing this
-	 * field */
-	const bool use_tandyDAC = (real_readb(0x40, 0xd4) == 0xff);
+void BIOS_SetupTandySbDacCallbacks()
+{
+	// Tandy DAC can be requested in tandy_sound.cpp by initializing this field
+	const bool use_tandy_dac = (real_readb(0x40, 0xd4) == 0xff);
 
-	if (use_tandyDAC) {
-		/* tandy DAC sound requested, see if soundblaster device is
-		 * available */
+	shutdown_tandy_sb_dac_callbacks();
+
+	if (use_tandy_dac) {
+		// Tandy DAC sound requested, see if soundblaster device is available
 		Bitu tandy_dac_type = 0;
 		if (Tandy_InitializeSB()) {
 			tandy_dac_type = 1;
@@ -1088,9 +1087,9 @@ void setup_tandy_sb_dac_callbacks()
 		if (tandy_dac_type) {
 			real_writew(0x40, 0xd0, 0x0000);
 			real_writew(0x40, 0xd2, 0x0000);
-			real_writeb(0x40, 0xd4, 0xff); /* tandy DAC init value */
+			real_writeb(0x40, 0xd4, 0xff); // Tandy DAC init value
 			real_writed(0x40, 0xd6, 0x00000000);
-			/* install the DAC callback handler */
+			// Install the DAC callback handler
 			tandy_DAC_callback[0] = new CALLBACK_HandlerObject();
 			tandy_DAC_callback[1] = new CALLBACK_HandlerObject();
 			tandy_DAC_callback[0]->Install(&IRQ_TandyDAC,
@@ -1286,7 +1285,7 @@ public:
 		const uint8_t machine_signature = (machine == MCH_TANDY) ? 0xff : 0x55;
 		phys_writeb(machine_signature_location, machine_signature);
 
-		setup_tandy_sb_dac_callbacks();
+		BIOS_SetupTandySbDacCallbacks();
 
 		/* Setup some stuff in 0x40 bios segment */
 		


### PR DESCRIPTION
# Description

When changing the Sound Blaster or Tandy DAC settings, re-initialize the BIOS DAC callbacks to match the new configuration.

## Related issues

Reported by **Tazman** on the eXoDOS Discord channel:

> _"When I was in my teens, I had a Tandy 1000 TL/2 computer and it supported 3 voice sound. I'm trying to get SQ3 in dosbox to duplicate the sound effects using tandy sound. It plays the music right, but not the sound effects like when Roger comes out of sleeping chamber. You hear the glass shroud slide back and Roger actually says "Where am I?".  I know I can just use any of the other sound drivers like soundblaster and such in exodos. Which is really awesome to have so much flexibility playing SQ3, but for my nostalgia fix, I would like to reproduce what I once played."_

# Manual testing

Confirmed that `tandy on` can be set on-the-fly, and the DAC effects (described above) in Space Quest 3 play as expected (skip to 3:20):

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/a3da8ae4-04c5-4413-a809-13b33749e837

Testing pack: [sq3.zip](https://github.com/dosbox-staging/dosbox-staging/files/13406530/sq3.zip)

Regression tested a handful of Sound Blaster and Tandy games using on-the-fly changes and confirmed they all still play as expected.

Another excuse to post Ron Hubbard's ripping tunes :metal:

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/231e493d-0371-44b4-b546-871487ce653e

Sanitizer build is also passing without issues.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

