### PR TITLE
Normalise warnings messages

### DIFF
--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -55,14 +55,14 @@ void ImageCapturer::ConfigureGroupedMode(const std::string& prefs)
 
 	const auto formats = split_with_empties(prefs, ' ');
 	if (formats.size() == 0) {
-		LOG_WARNING("CAPTURE: 'default_image_capture_formats' not specified; "
-		            "defaulting to 'upscaled'");
+		LOG_WARNING("CAPTURE: 'default_image_capture_formats' not specified, "
+		            "using 'upscaled'");
 		set_defaults();
 		return;
 	}
 	if (formats.size() > 3) {
 		LOG_WARNING("CAPTURE: Invalid 'default_image_capture_formats' setting: '%s'. "
-		            "Must not contain more than 3 formats; defaulting to 'upscaled'.",
+		            "Must not contain more than 3 formats, using 'upscaled'.",
 		            prefs.c_str());
 		set_defaults();
 		return;
@@ -76,10 +76,9 @@ void ImageCapturer::ConfigureGroupedMode(const std::string& prefs)
 		} else if (format == "rendered") {
 			grouped_mode.wants_rendered = true;
 		} else {
-			LOG_WARNING("CAPTURE: Invalid image capture format specified for "
-			            "'default_image_capture_formats': '%s'. "
+			LOG_WARNING("CAPTURE: Invalid 'default_image_capture_formats' setting: '%s'. "
 			            "Valid formats are 'raw', 'upscaled', and 'rendered'; "
-			            "defaulting to 'upscaled'.",
+			            "using 'upscaled'.",
 			            format.c_str());
 			set_defaults();
 			return;

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -71,7 +71,7 @@ void ImageSaver::QueueImage(const RenderedImage& image, const CapturedImageType 
                             const std::optional<std_fs::path>& path)
 {
 	if (!image_fifo.IsRunning()) {
-		LOG_WARNING("CAPTURE: Cannot create screenshots while image capturer"
+		LOG_WARNING("CAPTURE: Cannot capture image while image capturer "
 		            "is shutting down");
 		return;
 	}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -743,7 +743,7 @@ static IntegerScalingMode get_integer_scaling_mode_setting()
 	} else if (mode == "vertical") {
 		return IntegerScalingMode::Vertical;
 	} else {
-		LOG_WARNING("RENDER: Invalid integer scaling mode '%s', using 'auto'",
+		LOG_WARNING("RENDER: Invalid 'integer_scaling' setting: '%s', using 'auto'",
 		            mode.c_str());
 		return IntegerScalingMode::Auto;
 	}

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2747,7 +2747,7 @@ static bool load_binds_from_file(const std::string_view mapperfile_path,
 	// Only report load failures for customized mapperfiles because by
 	// default, the mapperfile is not provided
 	if (!was_loaded && mapperfile_name != MAPPERFILE)
-		LOG_WARNING("MAPPER: Failed loading mapperfile '%s' directly and from resources",
+		LOG_WARNING("MAPPER: Failed loading mapperfile '%s' directly or from resources",
 		            mapperfile_name.data());
 
 	return was_loaded;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2225,7 +2225,7 @@ void GFX_SetMouseRawInput(const bool requested_raw_input)
 	if (SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP,
 	                            requested_raw_input ? "0" : "1",
 	                            SDL_HINT_OVERRIDE) != SDL_TRUE)
-		LOG_WARNING("SDL: Mouse raw input %s failed",
+		LOG_WARNING("SDL: Failed to %s raw mouse input",
 		            requested_raw_input ? "enable" : "disable");
 }
 
@@ -2877,11 +2877,9 @@ static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
 		return {w, h};
 	}
 
-	LOG_WARNING("DISPLAY: Requested window resolution '%s' is not valid, "
-	            "falling back to '%dx%d' instead",
-	            pref.c_str(),
-	            FallbackWindowSize.x,
-	            FallbackWindowSize.y);
+	LOG_WARNING("DISPLAY: Invalid 'windowresolution' setting: '%s', "
+	            "using 'default'",
+	            pref.c_str());
 
 	return FallbackWindowSize;
 }
@@ -2904,8 +2902,8 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 		} else if (pref == "desktop") {
 			return 100;
 		} else {
-			LOG_WARNING("DISPLAY: Requested window resolution '%s' is invalid, "
-			            "using 'default' instead",
+			LOG_WARNING("DISPLAY: Invalid 'windowresolution' setting: '%s', "
+			            "using 'default'",
 			            pref.c_str());
 			return MediumPercent;
 		}
@@ -3001,8 +2999,8 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 	const auto was_parsed = (sscanf(window_position_val.c_str(), "%d,%d", &x, &y) ==
 	                         2);
 	if (!was_parsed) {
-		LOG_WARNING("DISPLAY: Requested window position '%s' was not in X,Y format, "
-		            "using 'auto' instead",
+		LOG_WARNING("DISPLAY: Invalid 'window_position' setting: '%s'. "
+		            "Must be in X,Y format, using 'auto'.",
 		            window_position_val.c_str());
 		return;
 	}
@@ -3012,11 +3010,10 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 	const bool is_out_of_bounds = x < 0 || x > desktop.w || y < 0 ||
 	                              y > desktop.h;
 	if (is_out_of_bounds) {
-		LOG_WARNING("DISPLAY: Requested window position '%d,%d' is outside the "
-		            "bounds of the desktop '%dx%d', "
-		            "using 'auto' instead",
-		            x,
-		            y,
+		LOG_WARNING("DISPLAY: Invalid 'window_position' setting: '%s'. "
+		            "Requested position is outside the bounds of the %dx%d "
+		            "desktop, using 'auto'.",
+		            window_position_val.c_str(),
 		            desktop.w,
 		            desktop.h);
 		return;
@@ -3473,7 +3470,7 @@ static void set_priority_levels(const std::string& active_pref,
 		if (pref == "highest") {
 			return PRIORITY_LEVEL_HIGHEST;
 		}
-		LOG_WARNING("SDL: Invalid priority level: '%s', using 'auto'",
+		LOG_WARNING("SDL: Invalid 'priority' setting: '%s', using 'auto'",
 		            pref.data());
 
 		return PRIORITY_LEVEL_AUTO;
@@ -3545,7 +3542,7 @@ static void GUI_StartUp(Section* sec)
 			sdl.desktop.host_rate_mode      = HostRateMode::Custom;
 			sdl.desktop.preferred_host_rate = rate;
 		} else {
-			LOG_WARNING("SDL: Invalid 'host_rate' value: '%s', using 'auto'",
+			LOG_WARNING("SDL: Invalid 'host_rate' setting: '%s', using 'auto'",
 			            host_rate_pref.c_str());
 			sdl.desktop.host_rate_mode = HostRateMode::Auto;
 		}
@@ -3575,7 +3572,7 @@ static void GUI_StartUp(Section* sec)
 		sdl.frame.desired_mode = FrameMode::Vfr;
 	else {
 		sdl.frame.desired_mode = FrameMode::Unset;
-		LOG_WARNING("SDL: Invalid 'presentation_mode' value: '%s'",
+		LOG_WARNING("SDL: Invalid 'presentation_mode' setting: '%s', using 'auto'",
 		            presentation_mode_pref.c_str());
 	}
 
@@ -4803,7 +4800,7 @@ int sdl_main(int argc, char* argv[])
 			E_Exit("SDL: Can't init SDL %s", SDL_GetError());
 		}
 		if (SDL_CDROMInit() < 0) {
-			LOG_WARNING("SDL: Failed to init CD-ROM support");
+			LOG_WARNING("SDL: Failed to initialise CD-ROM support");
 		}
 
 		sdl.initialized = true;

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -104,7 +104,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
-			LOG_WARNING("CMS: Invalid 'cms_filter' value: '%s', using 'off'",
+			LOG_WARNING("CMS: Invalid 'cms_filter' setting: '%s', using 'off'",
 			            filter_choice.c_str());
 		}
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -637,7 +637,7 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 
 	if (!audio_channel->TryParseAndSetCustomFilter(filter_prefs)) {
 		if (filter_prefs != "off")
-			LOG_WARNING("GUS: Invalid 'gus_filter' value: '%s', using 'off'",
+			LOG_WARNING("GUS: Invalid 'gus_filter' setting: '%s', using 'off'",
 			            filter_prefs.c_str());
 
 		audio_channel->SetHighPassFilter(FilterState::Off);

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13410,7 +13410,7 @@ static void imfc_init(Section* sec)
 
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
-			LOG_WARNING("IMFC: Invalid 'imfc_filter' value: '%s', using 'off'",
+			LOG_WARNING("IMFC: Invalid 'imfc_filter' setting: '%s', using 'off'",
 			            filter_choice.data());
 		}
 

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -95,7 +95,7 @@ void Innovation::Open(const std::string_view model_choice,
 		        channel_filter_choice);
 
 		if (!filter_choice_has_bool) {
-			LOG_WARNING("INNOVATION: Invalid 'innovation_filter' value: '%s', using 'off'",
+			LOG_WARNING("INNOVATION: Invalid 'innovation_filter' setting: '%s', using 'off'",
 			            channel_filter_choice.data());
 		}
 

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -534,8 +534,8 @@ static void configure_calibration(const Section_prop &settings)
 			return parsed_rates;
 		}
 		if (pref != "auto" && pref.length() != 0)
-			LOG_WARNING("JOYSTICK: Invalid %c_calibration parameters: %s."
-			            " Must be auto or number,number.",
+			LOG_WARNING("JOYSTICK: Invalid '%c_calibration' setting: '%s', "
+			            "using 'auto'",
 			            default_rates.axis,
 			            pref.data());
 		return default_rates;

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -167,7 +167,7 @@ void LPT_DAC_Init(Section *section)
 		// The remaining setting is to turn the LPT DAC off
 		const auto dac_choice_has_bool = parse_bool_setting(dac_choice);
 		if (!dac_choice_has_bool || *dac_choice_has_bool != false) {
-			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac' choice: '%s', using 'none'",
+			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac' setting: '%s', using 'none'",
 			            dac_choice.data());
 		}
 		return;
@@ -184,7 +184,7 @@ void LPT_DAC_Init(Section *section)
 			filter_state = *filter_choice_has_bool ? FilterState::On
 			                                       : FilterState::Off;
 		} else {
-			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac_filter' value: '%s', using 'off'",
+			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac_filter' setting: '%s', using 'off'",
 			            filter_choice.data());
 			assert(filter_state == FilterState::Off);
 		}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -348,7 +348,7 @@ static CrossfeedPreset crossfeed_pref_to_preset(const std::string_view pref)
 
 	// the conf system programmatically guarantees only the above prefs are
 	// used
-	LOG_WARNING("MIXER: Invalid crossfeed preset name: '%s'; crossfeed disabled",
+	LOG_WARNING("MIXER: Invalid 'crossfeed' setting: '%s', using 'off'",
 	            pref.data());
 	return CrossfeedPreset::None;
 }
@@ -435,7 +435,7 @@ static ReverbPreset reverb_pref_to_preset(const std::string_view pref)
 
 	// the conf system programmatically guarantees only the above prefs are
 	// used
-	LOG_WARNING("MIXER: Invalid reverb preset name: '%s'; reverb disabled",
+	LOG_WARNING("MIXER: Invalid 'reverb' setting: '%s', using 'off'",
 	            pref.data());
 	return ReverbPreset::None;
 }
@@ -527,7 +527,7 @@ static ChorusPreset chorus_pref_to_preset(const std::string_view pref)
 
 	// the conf system programmatically guarantees only the above prefs are
 	// used
-	LOG_WARNING("MIXER: Invalid chorus preset name: '%s'; chorus disabled",
+	LOG_WARNING("MIXER: Invalid 'chorus' setting: '%s', using ' off'",
 	            pref.data());
 	return ChorusPreset::None;
 }

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -376,7 +376,7 @@ bx_ne2k_c::asic_read(io_port_t offset, io_width_t io_len)
     // have been initialised.
     //
     if (!s.remote_bytes) {
-	    LOG_WARNING("Empty ASIC read from port=0x%02x of length %u and %u remote_bytes",
+	    LOG_WARNING("NE2000: Empty ASIC read from port=0x%02x of length %u and %u remote_bytes",
 			offset, enum_val(io_len), s.remote_bytes);
 	    break;
     }

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -69,7 +69,7 @@ void PCSPEAKER_Init(Section *section)
 				pc_speaker->SetFilterState(FilterState::On);
 			}
 		} else {
-			LOG_WARNING("PCSPEAKER: Invalid 'pcspeaker_filter' value: '%s', using 'off'",
+			LOG_WARNING("PCSPEAKER: Invalid 'pcspeaker_filter' setting: '%s', using 'off'",
 			            filter_choice.data());
 			pc_speaker->SetFilterState(FilterState::Off);
 		}

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -207,7 +207,7 @@ void PcSpeakerDiscrete::ForwardPIT(const float newindex)
 	case PitMode::HardwareStrobe:
 	case PitMode::Inactive:
 	default:
-		LOG_WARNING("PCSPEAKER: Unhandled PIT mode %s", pit_mode_to_string(pit_mode));
+		LOG_WARNING("PCSPEAKER: Unhandled PIT mode: '%s'", pit_mode_to_string(pit_mode));
 		break;
 	}
 }
@@ -279,7 +279,7 @@ void PcSpeakerDiscrete::SetCounter(int count, const PitMode mode)
 		break;
 	default:
 #if C_DEBUG
-		LOG_WARNING("PCSPEAKER: Unhandled speaker PIT mode: %s", pit_mode_to_string(pit_mode));
+		LOG_WARNING("PCSPEAKER: Unhandled speaker PIT mode: '%s'", pit_mode_to_string(pit_mode));
 #endif
 		return;
 	}

--- a/src/hardware/pcspeaker_impulse.cpp
+++ b/src/hardware/pcspeaker_impulse.cpp
@@ -290,7 +290,7 @@ void PcSpeakerImpulse::SetCounter(const int cntr, const PitMode pit_mode)
 
 	default:
 #ifdef SPKR_DEBUGGING
-		LOG_WARNING("Unhandled speaker PIT mode: %s at %f", pit_mode_to_string(pit_mode), PIC_FullIndex());
+		LOG_WARNING("PCSPEAKER: Unhandled speaker PIT mode: '%s' at %f", pit_mode_to_string(pit_mode), PIC_FullIndex());
 #endif
 		return;
 	}

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -146,7 +146,7 @@ Ps1Dac::Ps1Dac(const std::string_view filter_choice)
 
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
-			LOG_WARNING("PS1DAC: Invalid 'ps1audio_dac_filter' value: '%s', using 'off'",
+			LOG_WARNING("PS1DAC: Invalid 'ps1audio_dac_filter' setting: '%s', using 'off'",
 			            filter_choice.data());
 		}
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -470,7 +470,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 	const auto filter_type = determine_filter_type(filter_choice, sb_type);
 
 	if (!filter_type) {
-		LOG_WARNING("%s: Invalid 'sb_filter' value: '%s', using 'off'",
+		LOG_WARNING("%s: Invalid 'sb_filter' setting: '%s', using 'off'",
 		            CardType(),
 		            filter_choice.c_str());
 
@@ -544,7 +544,7 @@ static void configure_opl_filter(mixer_channel_t channel,
 
 	if (!filter_type) {
 		if (filter_choice != "off")
-			LOG_WARNING("%s: Invalid 'opl_filter' value: '%s', using 'off'",
+			LOG_WARNING("%s: Invalid 'opl_filter' setting: '%s', using 'off'",
 			            CardType(),
 			            filter_choice.c_str());
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -250,7 +250,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
-			LOG_WARNING("TANDYDAC: Invalid 'tandy_dac_filter' value: '%s', using 'off'",
+			LOG_WARNING("TANDYDAC: Invalid 'tandy_dac_filter' setting: '%s', using 'off'",
 			            filter_choice.data());
 		}
 

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -253,7 +253,7 @@ void VGA_SetRatePreference(const std::string &pref)
 
 	} else {
 		vga.draw.dos_rate_mode = VgaRateMode::Default;
-		LOG_WARNING("VIDEO: Unknown frame rate setting: %s, using default",
+		LOG_WARNING("VIDEO: Unknown frame rate setting: '%s', using 'default'",
 		            pref.c_str());
 	}
 }

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -19,7 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include <stdlib.h>
 #include "dosbox.h"
 #include "inout.h"

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -19,7 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
 #include "inout.h"
 #include "vga.h"

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -19,7 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
 #include "inout.h"
 #include "pic.h"

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1431,7 +1431,7 @@ static void composite_init(Section *sec)
 			cga_comp = *state_has_bool ? COMPOSITE_STATE::ON
 			                           : COMPOSITE_STATE::OFF;
 		} else {
-			LOG_WARNING("COMPOSITE: Invalid 'composite' value: '%s', using 'off'",
+			LOG_WARNING("COMPOSITE: Invalid 'composite' setting: '%s', using 'off'",
 			            state.data());
 			cga_comp = COMPOSITE_STATE::OFF;
 		}

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -19,7 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
 #include "setup.h"
 #include "vga.h"

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -19,7 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
 
 #include <algorithm>

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -19,7 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
 #include "inout.h"
 #include "vga.h"

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -19,8 +19,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-
 #include "dosbox.h"
 
 #include <cstdlib>

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1204,7 +1204,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 		if (width == io_width_t::byte)
 			vga_write_p3d4(0, val, io_width_t::byte);
 		else if (width == io_width_t::word) {
-			LOG_WARNING("XGA 16-bit write to vga_write_p3d4, vga_write_p3d5");
+			LOG_WARNING("XGA: 16-bit write to vga_write_p3d4, vga_write_p3d5");
 			vga_write_p3d4(0, val & 0xff, io_width_t::byte);
 			vga_write_p3d5(0, val >> 8, io_width_t::byte);
 		} else


### PR DESCRIPTION
# Description

I've just done a warning message normalisations sweep for consistency. I like consistency, as you can tell 😎 

I left the `viewport_resolution` related warnings intentionally alone as I'm addressing those in my upcoming PR.


# Manual testing

DOSBox still compiles & starts up 😄 (no functional changes)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

