### PR TITLE
Add extra hotkey button row in the mapper

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2304,7 +2304,7 @@ static void CreateLayout() {
 #undef YO
 
 #define XO 10
-#define YO 8
+#define YO 7
 	/* Joystick Buttons/Texts */
 	/* Buttons 1+2 of 1st Joystick */
 	AddJButtonButton(pos_x(XO), pos_y(YO), button_width, button_height, "1", 0, 0);
@@ -2415,14 +2415,15 @@ static void CreateLayout() {
 	AddModButton(pos_x(4), pos_y(14), 50, 20, "Mod3", 3);
 
 	/* Create Handler buttons */
-	int32_t xpos = 3;
-	int32_t ypos = 11;
+	int32_t xpos = 0;
+	int32_t ypos = 10;
+	constexpr auto bw = button_width + 5;
 	for (const auto &handler_event : handlergroup) {
-		new CEventButton(pos_x(xpos * 3), pos_y(ypos), button_width * 3, button_height,
+		new CEventButton(200 + xpos * 3 * bw, pos_y(ypos), bw * 3, button_height,
 		                 handler_event->button_name.c_str(), handler_event);
 		xpos++;
-		if (xpos>6) {
-			xpos = 3;
+		if (xpos>3) {
+			xpos = 0;
 			ypos++;
 		}
 	}


### PR DESCRIPTION

# Description

Prior to this change, the 6th mapper row was overlapped by the key binding instructions. This dirty hackery fixes that and buys us some time before nuking & rebuilding this good thing... 😅 

**_Now with 100% more dog pics!!!_**

# Manual testing

## Before

Start with `machine = hercules` and behold the mapper:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/f365cfba-a399-417f-bf74-517ee2487ea9)

So far so good. Now click on "Swap Image".

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/15352389-878d-4fb5-8b2d-8cb74e4cb89f)

Ooops! 

<img width="248" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/2b0e3994-1cfb-47f9-86bd-71fac64423f9">


## After

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/c4469f3b-f3b5-433e-b1c5-3a8e2abc7fb8)

<img width="239" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/9af6b37b-29d8-475e-ae2e-b04fbd2e4412">





# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

