### PR TITLE
Fix state handling of the BIOS's Tandy DAC callbacks

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -21,6 +21,8 @@
 
 #include "dosbox.h"
 
+#include <optional>
+
 #define BIOS_BASE_ADDRESS_COM1          0x400
 #define BIOS_BASE_ADDRESS_COM2          0x402
 #define BIOS_BASE_ADDRESS_COM3          0x404
@@ -138,6 +140,6 @@ void INT10_ReloadRomFonts();
 
 void BIOS_SetComPorts (uint16_t baseaddr[]);
 
-void BIOS_SetupTandySbDacCallbacks();
+void BIOS_ConfigureTandyDacCallbacks(const std::optional<bool> maybe_request_dac = {});
 
 #endif

--- a/include/bios.h
+++ b/include/bios.h
@@ -140,6 +140,6 @@ void INT10_ReloadRomFonts();
 
 void BIOS_SetComPorts (uint16_t baseaddr[]);
 
-void BIOS_ConfigureTandyDacCallbacks(const std::optional<bool> maybe_request_dac = {});
+bool BIOS_ConfigureTandyDacCallbacks(const std::optional<bool> maybe_request_dac = {});
 
 #endif

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2238,10 +2238,10 @@ public:
 		sb.hw.dma8 = has_dac ? static_cast<uint8_t>(section->Get_int("dma"))
 		                     : 0;
 
-		// Setup BIOS DAC callbacks as soon as the card's access ports (
+		// Configure the BIOS DAC callbacks as soon as the card's access ports (
 		// port, IRQ, and potential 8-bit DMA address) are defined.
 		//
-		BIOS_SetupTandySbDacCallbacks();
+		BIOS_ConfigureTandyDacCallbacks();
 
 		if (!has_dac) {
 			return;
@@ -2338,6 +2338,12 @@ public:
 			        sb.hw.irq,
 			        sb.hw.dma8);
 		}
+
+		// If a Tandy Sound card is present, the following reconfigures
+		// the BIOS to direct the Tandy DAC interrupt callbacks to the
+		// Sound Blaster for handling.
+		//
+		BIOS_ConfigureTandyDacCallbacks();
 	}
 
 	~SBLASTER()

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2241,7 +2241,14 @@ public:
 		// Configure the BIOS DAC callbacks as soon as the card's access ports (
 		// port, IRQ, and potential 8-bit DMA address) are defined.
 		//
-		BIOS_ConfigureTandyDacCallbacks();
+		if (BIOS_ConfigureTandyDacCallbacks()) {
+			// Disable the hot warmup when the SB is being used as
+			// the Tandy's DAC because the BIOS toggles the SB's
+			// speaker on and off rapidly per-audio-sequence,
+			// resulting in "edge-to-edge" samples.
+			//
+			sb.dsp.hot_warmup_ms = 0;
+		}
 
 		if (!has_dac) {
 			return;
@@ -2338,12 +2345,6 @@ public:
 			        sb.hw.irq,
 			        sb.hw.dma8);
 		}
-
-		// If a Tandy Sound card is present, the following reconfigures
-		// the BIOS to direct the Tandy DAC interrupt callbacks to the
-		// Sound Blaster for handling.
-		//
-		BIOS_ConfigureTandyDacCallbacks();
 	}
 
 	~SBLASTER()

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1078,7 +1078,9 @@ static void shutdown_tandy_sb_dac_callbacks()
 // The BIOS callbacks are shutdown when the backing device is shutdown to avoid
 // advertizing the DAC's presence when none exists.
 //
-void BIOS_ConfigureTandyDacCallbacks(const std::optional<bool> maybe_request_dac)
+// Returns true if a DAC was actually setup.
+//
+bool BIOS_ConfigureTandyDacCallbacks(const std::optional<bool> maybe_request_dac)
 {
 	shutdown_tandy_sb_dac_callbacks();
 
@@ -1146,10 +1148,12 @@ void BIOS_ConfigureTandyDacCallbacks(const std::optional<bool> maybe_request_dac
 			for (auto i = 0; i < 0x10; i++) {
 				phys_writeb(PhysicalMake(0xf000, 0xa084 + i), 0x80);
 			}
-		} else {
-			real_writeb(0x40, 0xd4, 0x00);
+			return true;
 		}
 	}
+	// Indicate that the Tandy DAC callbacks are unavailable
+	real_writeb(0x40, 0xd4, 0x00);
+	return false;
 }
 
 void BIOS_SetupKeyboard(void);


### PR DESCRIPTION
# Description

Since making the BIOS's Tandy DAC callback state configurable at runtime, it had a bug where it could only be shutdown once after which it stayed off until the Tandy card was re-initialized.

The state of the BIOS's Tandy DAC callbacks is now logged, so it's clearer what it's using or if the callbacks have been shutdown:

When the BIOS interrupt calls the actual Tandy DAC:
```
TANDYDAC: Operating at 48000 Hz without resampling
TANDYDAC: Highpass filter enabled (18 dB/oct at 120 Hz)
TANDYDAC: Lowpass filter enabled (12 dB/oct at 4800 Hz)
BIOS: Tandy DAC interrupt linked to Tandy Sound on IRQ 7
```

When the BIOS interrupt calls the Sound Blaster:
```
SBPRO2: Sound Blaster Pro 2 OPL output filter enabled
OPL: Lowpass filter enabled (6 dB/oct at 8000 Hz)
BIOS: Tandy DAC interrupt linked to Sound Blaster on IRQ 7
```

Also makes a couple small self-contained tweaks:
- Eliminates the logical Tandy DAC low sample rate (now that the resampler is in place, this isn't critical)
- Eliminates the SB hot warm up timeframe when the SB is being used as the Tandy DAC because the BIOS toggles the speaker on and off for every DAC sequence.


# Manual testing

- `tandy on` (BIOS DAC linked to Tandy) -> `sbtype sbpro2` (Tandy DAC shutdown, BIOS DAC linked to SB) -> `tandy on` (SB shutdown, BIOS DAC linked back to Tandy)

- `tandy off` (BIOS DAC doesn't exist) -> `sbtype sbpro2` (BIOS DAC doesn't exist)  -> `tandy psg` (BIOS DAC linked to SB)

- `tandy off` & `sbtype off` (BIOS DAC doesn't exist) -> `tandy psg` (BIOS Tandy requested, but neither DAC exists) -> `sbtype sbpro2` (BIOS DAC linked to SB) -> `sbtype off` (BIOS DAC shutdown because neither DAC exists, but BIOS Tandy requested) -> `tandy on` (BIOS DAC linked to Tandy)

Reproduce and tested with: 
[OutRun.zip](https://github.com/dosbox-staging/dosbox-staging/files/13447527/OutRun.zip)

DAC is used for intro voice, engine rumble, and crash effects:

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/bc912d15-a4b0-46e4-abfd-7b35149ed181

Also tested sanitizer builds.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

