### PR TITLE
Fix rounding when very close to an integer

### DIFF
--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -104,7 +104,20 @@ static double FROUND(double in){
 	case ROUND_Nearest: return std::nearbyint(in);
 	case ROUND_Down: return (floor(in));
 	case ROUND_Up: return (ceil(in));
-	case ROUND_Chop: [[fallthrough]]; // cast by the caller chops
+	case ROUND_Chop: 
+	{	
+		constexpr double tolerance = 1e-15;
+		const auto lower = std::floor(in);
+		const auto upper = std::ceil(in);
+
+		// Check if the value is within tolerance of the lower or upper integer
+		if ((in - lower) < tolerance) {
+			return lower;
+		} else if ((upper - in) < tolerance) {
+			return upper;
+		} 
+		return in;
+	}
 	default: return in;
 	}
 }

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -107,6 +107,9 @@ static double FROUND(double in){
 	case ROUND_Up: return std::ceil(in);
 	case ROUND_Chop: 
 	{
+		// Most x32/x64 builds use fpu_instructions_x86.h.
+		// If we are here on x64, we don't need this fix.
+#if !defined(__x86_64__) && !defined(_M_X64)
 		// This is a fix for rounding to a close integer in
 		// extended precision mode, e.g. 7.999999999999994; an example
 		// can be seen in the Quake options screen size slider.
@@ -124,6 +127,7 @@ static double FROUND(double in){
 				return upper;
 			}
 		}
+#endif
 		return std::trunc(in);
 	}
 	default: return in;

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -102,8 +102,8 @@ static void FPU_FPOP(void){
 static double FROUND(double in){
 	switch(fpu.round){
 	case ROUND_Nearest: return std::nearbyint(in);
-	case ROUND_Down: return (floor(in));
-	case ROUND_Up: return (ceil(in));
+	case ROUND_Down: return std::floor(in);
+	case ROUND_Up: return std::ceil(in);
 	case ROUND_Chop: 
 	{	
 		constexpr double tolerance = 1e-15;
@@ -116,7 +116,7 @@ static double FROUND(double in){
 		} else if ((upper - in) < tolerance) {
 			return upper;
 		} 
-		return in;
+		return std::trunc(in);
 	}
 	default: return in;
 	}
@@ -432,13 +432,12 @@ static void FPU_FUCOM(Bitu st, Bitu other){
 }
 
 static void FPU_FRNDINT(void){
-	int64_t temp  = static_cast<int64_t>(FROUND(fpu.regs[TOP].d));
-	double tempd = static_cast<double>(temp);
+	const auto rounded  = FROUND(fpu.regs[TOP].d);
 	if (fpu.cw&0x20) { //As we don't generate exceptions; only do it when masked
-		if (tempd != fpu.regs[TOP].d)
+		if (rounded != fpu.regs[TOP].d)
 			fpu.sw |= 0x20; //Set Precision Exception
 	}
-	fpu.regs[TOP].d = tempd;
+	fpu.regs[TOP].d = rounded;
 }
 
 static void FPU_FPREM(void){

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -106,7 +106,7 @@ static double FROUND(double in){
 	case ROUND_Up: return std::ceil(in);
 	case ROUND_Chop: 
 	{	
-		constexpr double tolerance = 1e-15;
+		constexpr double tolerance = 1e-14;
 		const auto lower = std::floor(in);
 		const auto upper = std::ceil(in);
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -116,7 +116,7 @@ static double FROUND(double in){
 		// In this case, what is almost certainly wanted is 8.0,
 		// so return the closer integer within the tolerance instead
 		// of chopping to the lower value.
-		if (fpu.cw & ExtendedPrecisionModeMask) {
+		if ((fpu.cw & ExtendedPrecisionModeMask) == ExtendedPrecisionModeMask) {
 			constexpr double tolerance = 1e-14;
 
 			if (const auto lower = std::floor(in);


### PR DESCRIPTION
# Description

This is an experimental hack for #2404. When in `ROUND_Chop` mode on non-x64 platforms, if the input number is very close to, but less than, a whole integer, it gets chopped to the value below, e.g. 7.9999999994 will chop to 7 when it should be 8.

This is only done when the FPU is set to extended precision mode, the assumption being that the number to chop, if that close to an integer, is inaccurate and would likely be the integer under full 80-bit precision.

# Manual testing

Tested the options sliders with Quake SW 1.06, and also tested QTD for performance regressions (none noted).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

