### PR TITLE
Fix vertical bars due to FILD/FIST memcpy trick

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -83,14 +83,16 @@ enum FPU_Round : uint8_t {
 };
 
 struct FPU_rec {
-	FPU_Reg regs[9]      = {};
-	FPU_P_Reg p_regs[9]  = {};
-	FPU_Tag tags[9]      = {};
-	uint16_t cw          = 0;
-	uint16_t cw_mask_all = 0;
-	uint16_t sw          = 0;
-	uint32_t top         = 0;
-	FPU_Round round      = {};
+	FPU_Reg regs[9]         = {};
+	int64_t regs_memcpy[9]  = {}; // for FILD/FIST 64-bit memcpy fix
+	bool use_regs_memcpy[9] = {};
+	FPU_P_Reg p_regs[9]     = {};
+	FPU_Tag tags[9]         = {};
+	uint16_t cw             = 0;
+	uint16_t cw_mask_all    = 0;
+	uint16_t sw             = 0;
+	uint32_t top            = 0;
+	FPU_Round round         = {};
 };
 
 extern FPU_rec fpu;

--- a/include/mem.h
+++ b/include/mem.h
@@ -76,7 +76,12 @@ static inline void var_write(uint32_t *var, uint32_t val)
 	host_writed((HostPt)var, val);
 }
 
-static inline uint16_t var_read(uint16_t *var)
+static inline void var_write(uint64_t* var, uint64_t val)
+{
+	host_writeq((HostPt)var, val);
+}
+
+static inline uint16_t var_read(uint16_t* var)
 {
 	return host_readw((HostPt)var);
 }
@@ -86,16 +91,23 @@ static inline uint32_t var_read(uint32_t *var)
 	return host_readd((HostPt)var);
 }
 
+static inline uint64_t var_read(uint64_t* var)
+{
+	return host_readq((HostPt)var);
+}
+
 /* The Following six functions are slower but they recognize the paged memory
  * system */
 
 uint8_t mem_readb(PhysPt pt);
 uint16_t mem_readw(PhysPt pt);
 uint32_t mem_readd(PhysPt pt);
+uint64_t mem_readq(PhysPt pt);
 
 void mem_writeb(PhysPt pt, uint8_t val);
 void mem_writew(PhysPt pt, uint16_t val);
 void mem_writed(PhysPt pt, uint32_t val);
+void mem_writeq(PhysPt pt, uint64_t val);
 
 static inline void phys_writeb(PhysPt addr, uint8_t val)
 {
@@ -112,6 +124,11 @@ static inline void phys_writed(PhysPt addr, uint32_t val)
 	host_writed(MemBase + addr, val);
 }
 
+static inline void phys_writeq(PhysPt addr, uint64_t val)
+{
+	host_writeq(MemBase + addr, val);
+}
+
 static inline uint8_t phys_readb(PhysPt addr)
 {
 	return host_readb(MemBase + addr);
@@ -125,6 +142,11 @@ static inline uint16_t phys_readw(PhysPt addr)
 static inline uint32_t phys_readd(PhysPt addr)
 {
 	return host_readd(MemBase + addr);
+}
+
+static inline uint64_t phys_readq(PhysPt addr)
+{
+	return host_readq(MemBase + addr);
 }
 
 /* These don't check for alignment, better be sure it's correct */
@@ -159,6 +181,12 @@ static inline uint32_t real_readd(uint16_t seg, uint16_t off)
 	return mem_readd(base + off);
 }
 
+static inline uint64_t real_readq(uint16_t seg, uint16_t off)
+{
+	const auto base = static_cast<uint32_t>(seg << 4);
+	return mem_readq(base + off);
+}
+
 static inline void real_writeb(uint16_t seg, uint16_t off, uint8_t val)
 {
 	const auto base = static_cast<uint32_t>(seg << 4);
@@ -175,6 +203,12 @@ static inline void real_writed(uint16_t seg, uint16_t off, uint32_t val)
 {
 	const auto base = static_cast<uint32_t>(seg << 4);
 	mem_writed(base + off, val);
+}
+
+static inline void real_writeq(uint16_t seg, uint16_t off, uint64_t val)
+{
+	const auto base = static_cast<uint32_t>(seg << 4);
+	mem_writeq(base + off, val);
 }
 
 static inline uint16_t RealSegment(RealPt pt)

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -149,8 +149,7 @@ static Real64 FPU_FLD80(PhysPt addr) {
 		FPU_Reg eind  = {};
 	} test = {};
 
-	test.eind.l.lower = mem_readd(addr);
-	test.eind.l.upper = mem_readd(addr+4);
+	test.eind.ll = mem_readq(addr);
 	test.begin = mem_readw(addr+8);
    
 	int64_t exp64 = (((test.begin&0x7fff) - BIAS80));
@@ -191,8 +190,7 @@ static void FPU_ST80(PhysPt addr,Bitu reg) {
 	}
 	test.begin = (static_cast<int16_t>(sign80)<<15)| static_cast<int16_t>(exp80final);
 	test.eind.ll = mant80final;
-	mem_writed(addr,test.eind.l.lower);
-	mem_writed(addr+4,test.eind.l.upper);
+	mem_writeq(addr, test.eind.ll);
 	mem_writew(addr+8,test.begin);
 }
 
@@ -207,8 +205,7 @@ static void FPU_FLD_F32(PhysPt addr,Bitu store_to) {
 }
 
 static void FPU_FLD_F64(PhysPt addr,Bitu store_to) {
-	fpu.regs[store_to].l.lower = mem_readd(addr);
-	fpu.regs[store_to].l.upper = mem_readd(addr+4);
+	fpu.regs[store_to].ll = mem_readq(addr);
 }
 
 static void FPU_FLD_F80(PhysPt addr) {
@@ -230,8 +227,7 @@ static void FPU_FLD_I64(PhysPt addr,Bitu store_to) {
 	constexpr int64_t int53_max = (1LL << 53) - 1;
 
 	FPU_Reg temp_reg;
-	temp_reg.l.lower = mem_readd(addr);
-	temp_reg.l.upper = mem_readd(addr + 4);
+	temp_reg.ll = mem_readq(addr);
 
 	fpu.regs[store_to].d = static_cast<Real64>(temp_reg.ll);
 	// This is a fix for vertical bars that appear in some games that
@@ -295,8 +291,7 @@ static void FPU_FST_F32(PhysPt addr) {
 }
 
 static void FPU_FST_F64(PhysPt addr) {
-	mem_writed(addr,fpu.regs[TOP].l.lower);
-	mem_writed(addr+4,fpu.regs[TOP].l.upper);
+	mem_writeq(addr, fpu.regs[TOP].ll);
 }
 
 static void FPU_FST_F80(PhysPt addr) {
@@ -321,15 +316,14 @@ static void FPU_FST_I64(PhysPt addr)
 	if (fpu.use_regs_memcpy[TOP]) {
 		temp_reg.ll = fpu.regs_memcpy[TOP];
 	} else {
-		double val = FROUND(fpu.regs[TOP].d);
+		double val  = FROUND(fpu.regs[TOP].d);
 		temp_reg.ll = (val <= static_cast<double>(INT64_MAX) &&
 		               val >= static_cast<double>(INT64_MIN))
 		                    ? static_cast<int64_t>(val)
 		                    : LONGTYPE(0x8000000000000000);
 	}
 
-	mem_writed(addr, temp_reg.l.lower);
-	mem_writed(addr + 4, temp_reg.l.upper);
+	mem_writeq(addr, temp_reg.ll);
 }
 
 static void FPU_FBST(PhysPt addr) {

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -496,6 +496,15 @@ uint32_t mem_unalignedreadd(PhysPt address) {
 	return ret;
 }
 
+uint64_t mem_unalignedreadq(PhysPt address)
+{
+	uint64_t ret = 0;
+	for (int i = 0; i < 8; ++i) {
+		ret |= static_cast<uint64_t>(mem_readb_inline(address + i))
+		    << (i * 8);
+	}
+	return ret;
+}
 
 void mem_unalignedwritew(PhysPt address,uint16_t val) {
 	mem_writeb_inline(address,(uint8_t)val);val>>=8;
@@ -509,6 +518,13 @@ void mem_unalignedwrited(PhysPt address,uint32_t val) {
 	mem_writeb_inline(address+3,(uint8_t)val);
 }
 
+void mem_unalignedwriteq(PhysPt address, uint64_t val)
+{
+	for (int i = 0; i < 8; ++i) {
+		mem_writeb_inline(address + i, static_cast<uint8_t>(val));
+		val >>= 8;
+	}
+}
 
 bool mem_unalignedreadw_checked(PhysPt address, uint16_t * val) {
 	uint8_t rval1;
@@ -543,8 +559,27 @@ bool mem_unalignedreadd_checked(PhysPt address, uint32_t * val) {
 	return false;
 }
 
-bool mem_unalignedwritew_checked(PhysPt address, uint16_t val) {
-	if (mem_writeb_checked(address+0, (uint8_t)(val & 0xff))) return true;
+bool mem_unalignedreadq_checked(PhysPt address, uint64_t* val)
+{
+	uint8_t rval[8];
+	for (int i = 0; i < 8; ++i) {
+		if (mem_readb_checked(address + i, &rval[i])) {
+			return true;
+		}
+	}
+
+	*val = 0;
+	for (int i = 0; i < 8; ++i) {
+		*val |= static_cast<uint64_t>(rval[i]) << (i * 8);
+	}
+	return false;
+}
+
+bool mem_unalignedwritew_checked(PhysPt address, uint16_t val)
+{
+	if (mem_writeb_checked(address + 0, (uint8_t)(val & 0xff))) {
+		return true;
+	}
 	val >>= 8;
 	if (mem_writeb_checked(address+1, (uint8_t)(val & 0xff))) return true;
 	return false;
@@ -561,7 +596,20 @@ bool mem_unalignedwrited_checked(PhysPt address, uint32_t val) {
 	return false;
 }
 
-uint8_t mem_readb(PhysPt address) {
+bool mem_unalignedwriteq_checked(PhysPt address, uint64_t val)
+{
+	for (int i = 0; i < 8; ++i) {
+		if (mem_writeb_checked(address + i,
+		                       static_cast<uint8_t>(val & 0xff))) {
+			return true;
+		}
+		val >>= 8;
+	}
+	return false;
+}
+
+uint8_t mem_readb(PhysPt address)
+{
 	return mem_readb_inline(address);
 }
 
@@ -573,8 +621,14 @@ uint32_t mem_readd(PhysPt address) {
 	return mem_readd_inline(address);
 }
 
-void mem_writeb(PhysPt address,uint8_t val) {
-	mem_writeb_inline(address,val);
+uint64_t mem_readq(PhysPt address)
+{
+	return mem_readq_inline(address);
+}
+
+void mem_writeb(PhysPt address, uint8_t val)
+{
+	mem_writeb_inline(address, val);
 }
 
 void mem_writew(PhysPt address,uint16_t val) {
@@ -583,6 +637,11 @@ void mem_writew(PhysPt address,uint16_t val) {
 
 void mem_writed(PhysPt address,uint32_t val) {
 	mem_writed_inline(address,val);
+}
+
+void mem_writeq(PhysPt address, uint64_t val)
+{
+	mem_writeq_inline(address, val);
 }
 
 static void write_p92(io_port_t, io_val_t value, io_width_t)


### PR DESCRIPTION
# Description

This is a fix for the vertical bars video corruption seen on a few games (Carmageddon, Motor Mash) and demos (Sunflower, Multikolor), due to a trick they use with FILD/FIST FPU instructions to do a fast memcpy, specifically with 64-bit integer values.

Obviously this needs a lot of testing - throw everything you can at it.

## Related issues

Several games and demos are mentioned in #1231 and #3125.

Ideas for this fix were inspired by https://github.com/joncampbell123/dosbox-x/issues/119.

# Manual testing

I tested the following:

- Intel Math CoProcessor Advanced Diagnostics to verify no new floating point issues were introduced.
- Quake SW 1.06 to verify non-memcpy-trick usage of FILD/FIST still works
- Carmageddon
- Motor Mash
- Sunflower
- Multikolor

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

