### PR TITLE
Minor Unicode definitions improvements

### DIFF
--- a/contrib/resources/mapping/ASCII.TXT
+++ b/contrib/resources/mapping/ASCII.TXT
@@ -943,6 +943,7 @@
 0x0589 :   #ARMENIAN FULL STOP
 0x058a -   #ARMENIAN HYPHEN
 0x058e NNN #LEFT-FACING ARMENIAN ETERNITY SIGN
+0x058f NNN #ARMENIAN DRAM SIGN
 
 # ****************************************************************************
 # 0x0590 - 0x05ff     Hebrew
@@ -1711,7 +1712,7 @@
 0x207f NNN #SUPERSCRIPT LATIN SMALL LETTER N
 
 # ****************************************************************************
-# 0x20a0 - 0x20cf     Currency Symbols (full coverage)
+# 0x20a0 - 0x20cf     Currency Symbols
 # ****************************************************************************
 
 0x20a0 E   #EURO-CURRENCY SIGN
@@ -1746,6 +1747,8 @@
 0x20bd P   #RUBLE SIGN
 0x20be G   #LARI SIGN
 0x20bf B   #BITCOIN SIGN
+0x20c0 c   #SOM SIGN
+
 
 # ****************************************************************************
 # 0x2100 - 0x214f     Letterlike Symbols
@@ -1981,6 +1984,7 @@
 
 # Arabic scripts cannot be mapped to 7-bit ASCII at all
 
+0xfe73 NNN #ARABIC TAIL FRAGMENT
 0xfe7d NNN #ARABIC SHADDA MEDIAL FORM
 0xfe80 NNN #ARABIC LETTER HAMZA ISOLATED FORM
 0xfe81 NNN #ARABIC LETTER ALEF WITH MADDA ABOVE ISOLATED FORM

--- a/contrib/resources/mapping/MAIN.TXT
+++ b/contrib/resources/mapping/MAIN.TXT
@@ -7,7 +7,7 @@
 # ID    - description                                            [ID usage originator]
 #
 #
-# Fully supported code pages (92 code pages):
+# Fully supported code pages (93 code pages):
 #
 # 113   - Yugoslavian, Latin                                     [AST Premium Exec DOS]
 # 437   - United States                                          [IBM, Microsoft]
@@ -33,12 +33,13 @@
 # 855   - South Slavic, Cyrillic                                 [IBM, Microsoft]
 # 856   - Hebrew-2, with EUR                                     [IBM, Microsoft; FreeDOS adds EUR sign]
 # 857   - Latin-5 (Turkish), with EUR                            [IBM, Microsoft; FreeDOS adds EUR sign]
-# 858   - Latin-1 (Western European), with EUR                   [IBM, Microsoft; FreeDOS adds EUR sign]
+# 858   - Latin-1 (Western European), with EUR                   [IBM, Microsoft]
 # 859   - Latin-9 (Western European), with EUR                   [IBM, Microsoft]
 # 860   - Portuguese                                             [IBM, Microsoft]
 # 861   - Icelandic                                              [IBM, Microsoft]
 # 862   - Hebrew-2                                               [IBM, Microsoft]
 # 863   - Canadian French                                        [IBM, Microsoft]
+# 864   - Arabic                                                 [IBM, Microsoft; IBM and FreeDOS add more characters]
 # 865   - Nordic                                                 [IBM, Microsoft]
 # 866   - Russian, Cyrillic                                      [IBM, Microsoft]
 # 867   - Czech and Slovak, Kamenicky encoding                   [NEC printers]
@@ -169,10 +170,8 @@
 # 28606 - South-Eastern European, with EUR, ISO 8859-16 encoding [Microsoft]
 #
 #
-# Code pages mostly supported (2 code pages), but with unidentified characters still left (TODO):
+# Code pages mostly supported (1 code page), but with unidentified characters still left (TODO):
 #
-# 864   - Arabic                                                 [IBM, Microsoft; FreeDOS adds more characters]
-#       - 1 character still unidentified (FreeDOS CP specific code page extension)
 # 59829 - Georgian                                               [FreeDOS]
 #       - 1 character still unidentified
 #
@@ -968,10 +967,10 @@ CODEPAGE 863 # Canadian French
 EXTENDS FILE mapping-unicode.org CP_863.TXT
 
 CODEPAGE 864 # Arabic
-# FreeDOS specific code page extensions
+# FreeDOS and IBM specific code page extensions
 0x9b 0xfef9        #ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW ISOLATED FORM
 0x9c 0xfefa        #ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW FINAL FORM
-# 0x9f TODO: unidentified character - FreeDOS specific
+0x9f 0xfe73        #ARABIC TAIL FRAGMENT
 0xa6 0xfe87        #ARABIC LETTER ALEF WITH HAMZA BELOW ISOLATED FORM
 0xa7 0xfe88        #ARABIC LETTER ALEF WITH HAMZA BELOW FINAL FORM
 EXTENDS FILE mapping-unicode.org CP_864.TXT


### PR DESCRIPTION
# Description

- add one Arabic symbol definition, code page 864 definitions are now complete (information was on Wikipedia, https://en.wikipedia.org/wiki/Code_page_864 - shame on me...)
- added Som and Dram currency definition (needed for upcoming COUNTRY rework)
- corrected few descriptions 


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/1986 (improves only, does not fully fix yet)


# Manual testing

Enter command `keyb ar462 864`, make sure there are no warning logs printed (Unicode engine checks consistency of definitions).


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

