### PR TITLE
Fix compilation failures on *BSD and colour rendering on big-endian platforms

### DIFF
--- a/.muon.ini
+++ b/.muon.ini
@@ -1,4 +1,3 @@
-max_line_len=80
 indent_by='    '
 space_array=false
 wide_colon=false

--- a/include/bgrx8888.h
+++ b/include/bgrx8888.h
@@ -1,0 +1,81 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_BGRX8888_H
+#define DOSBOX_BGRX8888_H
+
+#include <cstdint>
+
+// A class that holds the colour channels as an array of four 8-bit values
+// in byte order (also known as memory order), regardless of host
+// endianness. The bytes in memory are always Blue, Green, Red, and finally
+// a placeholder.
+//
+class Bgrx8888 {
+public:
+	constexpr Bgrx8888() = default;
+
+	Bgrx8888(const uint8_t b8, const uint8_t g8, const uint8_t r8)
+	{
+		Set(b8, g8, r8);
+	}
+
+	void Set(const uint8_t b8, const uint8_t g8, const uint8_t r8)
+	{
+		colour.components = {b8, g8, r8, 0};
+	}
+
+	constexpr uint8_t Blue8() const
+	{
+		return colour.components.b8;
+	}
+
+	constexpr uint8_t Green8() const
+	{
+		return colour.components.g8;
+	}
+
+	constexpr uint8_t Red8() const
+	{
+		return colour.components.r8;
+	}
+
+	// Cast operator to read-only uint32_t
+	constexpr operator uint32_t() const
+	{
+		return colour.bgrx8888;
+	}
+
+private:
+	union {
+		struct {
+			// byte order
+			uint8_t b8 = 0;
+			uint8_t g8 = 0;
+			uint8_t r8 = 0;
+			uint8_t x8 = 0;
+		} components;
+		uint32_t bgrx8888 = 0;
+	} colour = {};
+};
+
+static_assert(sizeof(Bgrx8888) == sizeof(uint32_t));
+
+#endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 
+#include "bgrx8888.h"
 #include "bit_view.h"
 #include "control.h"
 #include "fraction.h"
@@ -941,7 +942,7 @@ using cga_colors_t = std::array<Rgb666, NumCgaColors>;
 
 struct VgaDac {
 	Rgb666 rgb[NumVgaColors]           = {};
-	uint32_t palette_map[NumVgaColors] = {};
+	Bgrx8888 palette_map[NumVgaColors] = {};
 
 	uint8_t combine[16] = {};
 

--- a/include/video.h
+++ b/include/video.h
@@ -144,7 +144,6 @@ struct VideoMode {
 
 std::string to_string(const VideoMode& video_mode);
 
-
 enum class PixelFormat : uint8_t {
 	// Up to 256 colours, paletted;
 	// stored as packed uint8 data
@@ -177,9 +176,9 @@ enum class PixelFormat : uint8_t {
 	RGB565_Packed16 = 16,
 
 	// 16.7M (24-bit) true colour, 8 bits per red/blue/green component;
-	// stored as packed 24-bit data
+	// stored as a sequence of three packed uint8_t values in BGR byte
+	// order, also known as memory order. This format is endian-agnostic.
 	//
-	// Stored as array of uint8_t in BGR memory order (endian agnostic)
 	// Example:
 	// uint8_t *pixels = image.image_data;
 	// pixels[0] = blue; pixels[1] = green; pixels[2] = red;
@@ -188,18 +187,18 @@ enum class PixelFormat : uint8_t {
 	// FFmpeg Equivalent: AV_PIX_FMT_BGR24
 	BGR24_ByteArray = 24,
 
-	// 16.7M (32-bit) true colour; 8 bits per red/blue/green component;
-	// stored as packed uint32 data with highest 8 bits unused
+	// Same as BGR24_ByteArray but padded to 32-bits. 16.7M true colour,
+	// 8 bits per red/blue/green/empty component; stored as a sequence of
+	// four packed uint8_t values in BGRX byte order, also known as
+	// memory order. This format is endian-agnostic.
 	//
-	// Stored as array of uint32_t in host native endianess.
-	// Each uint32_t is layed out as follows:
-	// (msb)8X 8R 8G 8B(lsb)
 	// Example:
-	// uint32_t pixel = (unused << 24) | (red << 16) | (green << 8) | (blue << 0)
+	// uint8_t *pixels = image.image_data;
+	// pixels[0] = blue; pixels[1] = green; pixels[2] = red; pixels[3] = empty;
 	//
-	// SDL Equivalent: SDL_PIXELFORMAT_XRGB8888
-	// FFmpeg Equivalent: AV_PIX_FMT_0RGB32
-	XRGB8888_Packed32 = 32
+	// SDL has has no equivalent.
+	// FFmpeg Equivalent: BGRX32_ByteArray
+	BGRX32_ByteArray = 32,
 };
 
 const char* to_string(const PixelFormat pf);

--- a/meson.build
+++ b/meson.build
@@ -357,7 +357,7 @@ if cc.has_member('struct dirent', 'd_type', prefix: '#include <dirent.h>')
     conf_data.set10('HAVE_STRUCT_DIRENT_D_TYPE', true)
 endif
 
-foreach header : ['pwd.h', 'strings.h', 'netinet/in.h']
+foreach header : ['libgen.h', 'pwd.h', 'strings.h', 'sys/xattr.h', 'netinet/in.h']
     if cc.has_header(header)
         conf_data.set10('HAVE_' + header.underscorify().to_upper(), true)
     endif

--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -69,12 +69,9 @@ static ZMBV_FORMAT to_zmbv_format(const PixelFormat format)
 	case PixelFormat::RGB555_Packed16: return ZMBV_FORMAT::BPP_15;
 	case PixelFormat::RGB565_Packed16: return ZMBV_FORMAT::BPP_16;
 
-	// ZMBV is "the DOSBox capture format" supported by external tools such
-	// as VLC, MPV, and ffmpeg. Because DOSBox originally didn't have 24-bit
-	// colour, the format itself doesn't support it and treats 4-byte
-	// formats as byte-ordered BGR colour values.
-	//
-	case PixelFormat::BGR24_ByteArray: return ZMBV_FORMAT::BPP_32;
+	// ZMBV internally maps from 24-bit to 32-bit (let ZMBV manage itself).
+	case PixelFormat::BGR24_ByteArray: return ZMBV_FORMAT::BPP_24;
+
 	case PixelFormat::BGRX32_ByteArray: return ZMBV_FORMAT::BPP_32;
 	default: assertm(false, "Invalid pixel_format value"); break;
 	}

--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -347,7 +347,7 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 	// it. I this case we tell ZMBV the data is 32-bit and let the
 	// rgb24's int() cast operator up-convert.
 	case PixelFormat::BGR24_ByteArray: format = ZMBV_FORMAT::BPP_32; break;
-	case PixelFormat::XRGB8888_Packed32: format = ZMBV_FORMAT::BPP_32; break;
+	case PixelFormat::BGRX32_ByteArray: format = ZMBV_FORMAT::BPP_32; break;
 	default: assertm(false, "Invalid pixel_format value"); return;
 	}
 
@@ -413,7 +413,7 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 				}
 				break;
 
-			case PixelFormat::XRGB8888_Packed32:
+			case PixelFormat::BGRX32_ByteArray:
 				for (auto x = 0; x < src.width; ++x) {
 					const auto pixel = ((uint32_t*)src_row)[x];
 

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -106,7 +106,7 @@ private:
 
 		switch (image.params.pixel_format) {
 		case PixelFormat::RGB555_Packed16: {
-			const auto p = read_unaligned_uint16(pos);
+			const auto p = host_readw(pos);
 			pixel = Rgb555(p).ToRgb888();
 		} break;
 

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -111,7 +111,7 @@ private:
 		} break;
 
 		case PixelFormat::RGB565_Packed16: {
-			const auto p = read_unaligned_uint16(pos);
+			const auto p = host_readw(pos);
 			pixel = Rgb565(p).ToRgb888();
 		} break;
 

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -82,7 +82,7 @@ private:
 		case PixelFormat::RGB555_Packed16:
 		case PixelFormat::RGB565_Packed16: pos += 2; break;
 		case PixelFormat::BGR24_ByteArray: pos += 3; break;
-		case PixelFormat::XRGB8888_Packed32: pos += 4; break;
+		case PixelFormat::BGRX32_ByteArray: pos += 4; break;
 		default: assertm(false, "Invalid pixel_format value");
 		}
 	}
@@ -115,19 +115,11 @@ private:
 			pixel = Rgb565(p).ToRgb888();
 		} break;
 
-		case PixelFormat::BGR24_ByteArray: {
+		case PixelFormat::BGR24_ByteArray:
+		case PixelFormat::BGRX32_ByteArray: {
 			const auto b = *(pos + 0);
 			const auto g = *(pos + 1);
 			const auto r = *(pos + 2);
-
-			pixel = {r, g, b};
-		} break;
-
-		case PixelFormat::XRGB8888_Packed32: {
-			const auto p = read_unaligned_uint32(pos);
-			const uint8_t r = (p >> 16) & 0XFF;
-			const uint8_t g = (p >> 8) & 0xFF;
-			const uint8_t b = p & 0xFF;
 
 			pixel = {r, g, b};
 		} break;

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -219,12 +219,14 @@
  * Checks for non-POSIX headers and POSIX headers not supported on Windows.
  */
 
+#mesondefine HAVE_LIBGEN_H
 #mesondefine HAVE_NETINET_IN_H
 #mesondefine HAVE_PWD_H
 #define HAVE_STDLIB_H 1
 #mesondefine HAVE_STRINGS_H
 #mesondefine HAVE_SYS_SOCKET_H
 #define HAVE_SYS_TYPES_H 1
+#mesondefine HAVE_SYS_XATTR_H
 
 /* Hardware-related defines
  */

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -54,7 +54,7 @@ const char* to_string(const PixelFormat pf)
 	case PixelFormat::RGB555_Packed16: return "RGB555_Packed16";
 	case PixelFormat::RGB565_Packed16: return "RGB565_Packed16";
 	case PixelFormat::BGR24_ByteArray: return "BGR24_ByteArray";
-	case PixelFormat::XRGB8888_Packed32: return "XRGB8888_Packed32";
+	case PixelFormat::BGRX32_ByteArray: return "BGRX32_ByteArray";
 	default: assertm(false, "Invalid pixel format"); return {};
 	}
 }
@@ -397,7 +397,7 @@ static void render_reset(void)
 		render.src_start = (render.src.width * 3) / src_pixel_bytes;
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
-	case PixelFormat::XRGB8888_Packed32:
+	case PixelFormat::BGRX32_ByteArray:
 		render.src_start = (render.src.width * 4) / src_pixel_bytes;
 		gfx_flags        = (gfx_flags & ~GFX_CAN_8);
 		break;
@@ -474,7 +474,7 @@ static void render_reset(void)
 		render.scale.inMode         = scalerMode32;
 		render.scale.cachePitch     = render.src.width * 3;
 		break;
-	case PixelFormat::XRGB8888_Packed32:
+	case PixelFormat::BGRX32_ByteArray:
 		render.scale.lineHandler = (*lineBlock)[4][render.scale.outMode];
 		render.scale.linePalHandler = nullptr;
 		render.scale.inMode         = scalerMode32;

--- a/src/hardware/reelmagic/video_mixer.cpp
+++ b/src/hardware/reelmagic/video_mixer.cpp
@@ -212,7 +212,7 @@ static uint32_t _mpegPictureWidth  = 0;
 static uint32_t _mpegPictureHeight = 0;
 
 // video mixer is exclusively 32bpp on the RENDER... VGA color palette mapping is re-done here...
-static const auto VideoMixerPixelFormat = PixelFormat::XRGB8888_Packed32;
+static const auto VideoMixerPixelFormat = PixelFormat::BGRX32_ByteArray;
 
 // current RENDER state
 static void RMR_DrawLine_Passthrough(const void* src);
@@ -340,17 +340,33 @@ static void RMR_DrawLine_MixerError([[maybe_unused]] const void* src)
 	{ \
 		if (VGA_OVER) \
 			switch (VGA_PF) { \
-			case PixelFormat::Indexed8: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO8; break; \
-			case PixelFormat::RGB565_Packed16: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO16; break; \
-			case PixelFormat::XRGB8888_Packed32: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO32; break; \
-			default: ReelMagic_RENDER_DrawLine = &RMR_DrawLine_MixerError; break; \
+			case PixelFormat::Indexed8: \
+				ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO8; \
+				break; \
+			case PixelFormat::RGB565_Packed16: \
+				ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO16; \
+				break; \
+			case PixelFormat::BGRX32_ByteArray: \
+				ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAO32; \
+				break; \
+			default: \
+				ReelMagic_RENDER_DrawLine = &RMR_DrawLine_MixerError; \
+				break; \
 			} \
 		else \
 			switch (VGA_PF) { \
-			case PixelFormat::Indexed8: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU8; break; \
-			case PixelFormat::RGB565_Packed16: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU16; break; \
-			case PixelFormat::XRGB8888_Packed32: ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU32; break; \
-			default: ReelMagic_RENDER_DrawLine = &RMR_DrawLine_MixerError; break; \
+			case PixelFormat::Indexed8: \
+				ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU8; \
+				break; \
+			case PixelFormat::RGB565_Packed16: \
+				ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU16; \
+				break; \
+			case PixelFormat::BGRX32_ByteArray: \
+				ReelMagic_RENDER_DrawLine = &DRAWLINE_FUNC_NAME##_VGAU32; \
+				break; \
+			default: \
+				ReelMagic_RENDER_DrawLine = &RMR_DrawLine_MixerError; \
+				break; \
 			} \
 	}
 

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -87,8 +87,7 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 	}
 
 	// Map the source color into palette's requested index
-	vga.dac.palette_map[palette_idx] = static_cast<uint32_t>((r8 << 16) |
-	                                                         (g8 << 8) | b8);
+	vga.dac.palette_map[palette_idx].Set(b8, g8, r8);
 
 	ReelMagic_RENDER_SetPalette(palette_idx, r8, g8, b8);
 }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -977,7 +977,8 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 			while (i < line_length) {
 				write_unaligned_uint16_at(TempLine, i++, background_color);
 			}
-		} else if (vga.draw.render.pixel_format == PixelFormat::XRGB8888_Packed32) {
+		} else if (vga.draw.render.pixel_format ==
+		           PixelFormat::BGRX32_ByteArray) {
 			const auto background_color = vga.dac.palette_map[bg_color_index];
 			const auto line_length = templine_buffer.size() / sizeof(uint32_t);
 			size_t i = 0;
@@ -1375,7 +1376,7 @@ PixelFormat VGA_ActivateHardwareCursor()
 
 	switch (vga.mode) {
 	case M_LIN32: // 32-bit true-colour VESA
-		pixel_format = PixelFormat::XRGB8888_Packed32;
+		pixel_format = PixelFormat::BGRX32_ByteArray;
 
 		VGA_DrawLine = use_hw_cursor ? VGA_Draw_LIN32_Line_HWMouse
 		                             : VGA_Draw_Linear_Line;
@@ -1404,7 +1405,7 @@ PixelFormat VGA_ActivateHardwareCursor()
 		break;
 	case M_LIN8: // 8-bit and below
 	default:
-		pixel_format = PixelFormat::XRGB8888_Packed32;
+		pixel_format = PixelFormat::BGRX32_ByteArray;
 
 		// Use routines that treats the 8-bit pixel values as
 		// indexes into the DAC's palette LUT. The palette LUT
@@ -1977,7 +1978,9 @@ ImageInfo setup_drawing()
 	case M_LIN32:
 	case M_CGA2_COMPOSITE:
 	case M_CGA4_COMPOSITE:
-	case M_CGA_TEXT_COMPOSITE: pixel_format = PixelFormat::XRGB8888_Packed32; break;
+	case M_CGA_TEXT_COMPOSITE:
+		pixel_format = PixelFormat::BGRX32_ByteArray;
+		break;
 	default: pixel_format = PixelFormat::Indexed8; break;
 	}
 
@@ -2171,7 +2174,7 @@ ImageInfo setup_drawing()
 			// The ReelMagic video mixer expects linear VGA drawing
 			// (i.e.: Return to Zork's house intro), so limit the use
 			// of 18-bit palettized LUT routine to non-mixed output.
-			pixel_format = PixelFormat::XRGB8888_Packed32;
+			pixel_format = PixelFormat::BGRX32_ByteArray;
 
 			VGA_DrawLine = draw_linear_line_from_dac_palette;
 		} else {
@@ -2260,7 +2263,7 @@ ImageInfo setup_drawing()
 		}
 
 		if (IS_VGA_ARCH) {
-			pixel_format = PixelFormat::XRGB8888_Packed32;
+			pixel_format = PixelFormat::BGRX32_ByteArray;
 
 			VGA_DrawLine = draw_linear_line_from_dac_palette;
 		} else {
@@ -2576,7 +2579,7 @@ ImageInfo setup_drawing()
 			vga.draw.pixels_per_character = vga.seq.clocking_mode.is_eight_dot_mode
 			                                      ? PixelsPerChar::Eight
 			                                      : PixelsPerChar::Nine;
-			pixel_format = PixelFormat::XRGB8888_Packed32;
+			pixel_format = PixelFormat::BGRX32_ByteArray;
 
 			VGA_DrawLine = draw_text_line_from_dac_palette;
 

--- a/src/libs/loguru/meson.build
+++ b/src/libs/loguru/meson.build
@@ -1,21 +1,29 @@
 # Enable Loguru stack traces if supported
 stacktrace_headers = ['cxxabi.h', 'dlfcn.h', 'execinfo.h']
 
-all_stacktrace_headers_found = true
+has_stacktrace_headers = true
 
 foreach header : stacktrace_headers
     if not cxx.has_header(header)
-        all_stacktrace_headers_found = false
+        has_stacktrace_headers = false
     endif
 endforeach
 
-if all_stacktrace_headers_found
+# Some platforms might have the headers but not all of the
+# functions needed for Loguru's stacktracing (like FreeBSD).
+#
+has_stacktrace_functions = cc.has_function(
+    'backtrace',
+    prefix: '#include <execinfo.h>'
+)
+
+if has_stacktrace_headers and has_stacktrace_functions
     add_project_arguments('-DLOGURU_STACKTRACES=1', language: 'cpp')
     add_project_link_arguments('-rdynamic', language: 'cpp')
 endif
 
 # Prevent loguru from parsing command-line arguments with
-# the hosts's locale-applied, because this can foul up
+# the host's locale-applied, because this can foul up
 # ncurses. (DOSBox also doesn't have foreign-language arguments).
 add_project_arguments('-DLOGURU_USE_LOCALE=0', language: 'cpp')
 

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -136,4 +136,6 @@ public:
 	void Output_UpsideDown_24(uint8_t *output);
 };
 
+uint8_t ZMBV_ToBytesPerPixel(const ZMBV_FORMAT format);
+
 #endif

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -42,8 +42,12 @@
 #	endif
 #	include <shlobj.h>
 #else // other than Windows
-#	include <libgen.h>
-#include <sys/xattr.h>
+#	if defined(HAVE_LIBGEN_H)
+#		include <libgen.h>
+#	endif
+#	if defined(HAVE_SYS_XATTR_H)
+#		include <sys/xattr.h>
+#	endif
 #endif
 
 #if defined(HAVE_PWD_H)

--- a/src/shell/command_line_stubs.cpp
+++ b/src/shell/command_line_stubs.cpp
@@ -1,0 +1,67 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+// This is a stubbed out implementation replacement for the actual CommandLine
+// class used by the unit test system for two reasons:
+//
+//  1. To avoid pulling in the DOS shell dependencies, which in turn
+//     depend on the greater DOS system.
+//
+//  2. Unit tests that aren't testing the CommandLine class itself
+//     don't need command line parsing functionality as their inputs
+//     are defined in the unit test function bodies.
+
+#include "programs.h"
+
+bool CommandLine::HasDirectory() const
+{
+	return false;
+}
+
+bool CommandLine::HasExecutableName() const
+{
+	return false;
+}
+
+bool CommandLine::FindRemoveBoolArgument(const std::string&, char)
+{
+	return false;
+}
+
+std::string CommandLine::FindRemoveStringArgument(const std::string&)
+{
+	return {};
+}
+
+std::optional<int> CommandLine::FindRemoveIntArgument(const std::string&)
+{
+	return {};
+}
+
+std::vector<std::string> CommandLine::FindRemoveVectorArgument(const std::string&)
+{
+	return {};
+}
+
+std::optional<std::vector<std::string>> CommandLine::FindRemoveOptionalArgument(
+        const std::string&)
+{
+	return {};
+}

--- a/src/shell/meson.build
+++ b/src/shell/meson.build
@@ -22,4 +22,12 @@ libshell = static_library(
 
 libshell_dep = declare_dependency(link_with: libshell)
 
+libshell_stubs = static_library(
+    'shell_stubs',
+    ['command_line.cpp'],
+    include_directories: incdir,
+)
+
+libshell_stubs_dep = declare_dependency(link_with: libshell_stubs)
+
 internal_deps += libshell_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -43,7 +43,7 @@ endforeach
 example = executable(
     'example',
     ['example_tests.cpp', 'stubs.cpp'],
-    dependencies: [gmock_dep, libmisc_stubs_dep, ghc_dep, libloguru_dep],
+    dependencies: [gmock_dep, libmisc_stubs_dep, libshell_stubs_dep, ghc_dep, libloguru_dep],
     include_directories: incdir,
     cpp_args: cpp_args,
 )
@@ -52,7 +52,7 @@ test('gtest example', example, should_fail: true)
 fs_utils = executable(
     'fs_utils',
     ['fs_utils_tests.cpp', 'stubs.cpp'],
-    dependencies: [gmock_dep, libmisc_stubs_dep, ghc_dep, libloguru_dep],
+    dependencies: [gmock_dep, libmisc_stubs_dep, libshell_stubs_dep, ghc_dep, libloguru_dep],
     include_directories: incdir,
     cpp_args: cpp_args,
 )
@@ -80,8 +80,8 @@ test(
 # other unit tests
 
 unit_tests = [
-    {'name': 'ansi_code_markup', 'deps': [libmisc_stubs_dep]},
-    {'name': 'batch_file', 'deps': [libmisc_stubs_dep, libshell_dep]},
+    {'name': 'ansi_code_markup', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
+    {'name': 'batch_file', 'deps': [dosbox_dep]},
     {'name': 'bit_view', 'deps': []},
     {'name': 'bitops', 'deps': []},
     {'name': 'cmd_move', 'deps': [dosbox_dep], 'extra_cpp': []},
@@ -89,17 +89,17 @@ unit_tests = [
     {'name': 'drives', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'fraction', 'deps': []},
     {'name': 'int10_modes', 'deps': [dosbox_dep], 'extra_cpp': []},
-    {'name': 'iohandler_containers', 'deps': [libmisc_stubs_dep]},
-    {'name': 'math_utils', 'deps': [libmisc_stubs_dep]},
+    {'name': 'iohandler_containers', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
+    {'name': 'math_utils', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
     {'name': 'mixer', 'deps': [dosbox_dep, libiir_dep], 'extra_cpp': []},
     {'name': 'rgb', 'deps': []},
-    {'name': 'rwqueue', 'deps': [libmisc_stubs_dep]},
-    {'name': 'semaphore', 'deps': [libmisc_stubs_dep]},
-    {'name': 'setup', 'deps': [libmisc_stubs_dep, libshell_dep]},
+    {'name': 'rwqueue', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
+    {'name': 'semaphore', 'deps': [dosbox_dep]},
+    {'name': 'setup', 'deps': [dosbox_dep]},
     {'name': 'shell_cmds', 'deps': [dosbox_dep], 'extra_cpp': []},
     {'name': 'shell_redirection', 'deps': [dosbox_dep], 'extra_cpp': []},
-    {'name': 'string_utils', 'deps': [libmisc_stubs_dep]},
-    {'name': 'support', 'deps': [libmisc_stubs_dep]},
+    {'name': 'string_utils', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
+    {'name': 'support', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
 ]
 
 extra_link_flags = []

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -25,13 +25,13 @@
 
 // During testing we never want to log to stdout/stderr, as it could
 // negatively affect test harness.
-void GFX_ShowMsg(const char *, ...) {}
+
 void DEBUG_ShowMsg(const char *, ...) {}
 
 void DEBUG_HeavyWriteLogInstruction() {}
 
 #if C_DEBUG
-void LOG::operator()([[maybe_unused]] char const *buf, ...)
+void LOG::operator()([[maybe_unused]] const char* buf, ...)
 {
 	(void)d_type;     // Deliberately unused.
 	(void)d_severity; // Deliberately unused.


### PR DESCRIPTION
# Description

- Fix binary compilation failures on FreeBSD.

- Fix unit test compilation and link errors on FreeBSD.

- Fix non-palette colour channel rendering and image capture on big-endian systems.

Unfortunately I've only been able to test `output=texture` combined with `texturerenderer=software` because FreeBSD's PPC big-endian AMD OpenGL drivers aren't compatible with my chipset; so need more checks to verify the OpenGL code paths.

## Related issues

Fixes #3144

# Manual testing

![2023-11-27-085638_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/3a2de4ee-c10c-44d2-a2fb-2ac15a66c7e2)

![2023-11-27-085502_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/e302c166-6be8-4ace-9a18-0ff53ab835ca)

![2023-11-27-085403_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/1b2f6d4e-7949-4132-9c4a-954b8bc662ce)

![2023-11-27-085350_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/9bbd937f-2600-489f-b7a8-f4c37df46d87)

![2023-11-27-085255_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/c6f99c73-030e-4fef-a8d2-1cf65be04598)

![2023-11-27-085230_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/f85355cb-1cc6-4638-a5f9-77313e0fb91b)

![2023-11-27-085204_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/b2d33e50-e32b-4837-a863-951147ab59c3)

![2023-11-27-085137_1280x854_scrot](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/3663f716-3b4a-4fbd-854c-b4257094b7cb)


# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

