### PR TITLE
Fix single-precision FPU rounding

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -104,6 +104,20 @@ inline int ifloor(const float x)
 	return static_cast<int>(floorf(x));
 }
 
+// Determine if two numbers are equal "enough" based on an epsilon value.
+// Uses a dynamic adjustment based on the magnitude of the numbers.
+// Based on ideas from Bruce Dawson's blog post:
+// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+inline bool are_almost_equal_relative(
+        const double a, const double b,
+        const double epsilon = std::numeric_limits<double>::epsilon())
+{
+	const auto diff    = std::fabs(a - b);
+	const auto largest = std::max(std::fabs(a), std::fabs(b));
+
+	return diff <= largest * epsilon;
+}
+
 // Left-shifts a signed value by a given amount, with overflow detection
 template <typename T1, typename T2>
 constexpr T1 left_shift_signed(T1 value, T2 amount)

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -109,18 +109,22 @@ void MOUSE_NotifyWindowActive(const bool is_active);
 void MOUSE_NotifyTakeOver(const bool gui_has_taken_over);
 
 struct MouseScreenParams {
-	// size of the black bars around screen area
+	// Size of the black bars around screen area in logical units
 	uint32_t clip_x = 0;
 	uint32_t clip_y = 0;
-	// size of drawing area (in hot OS pixels)
+
+	// Size of drawing area in logical units
 	uint32_t res_x = 0;
 	uint32_t res_y = 0;
-	// new absolute mouse cursor position
+
+	// New absolute mouse cursor position in logical units
 	int32_t x_abs = 0;
 	int32_t y_abs = 0;
-	// whether the new mode is fullscreen or windowed
+
+	// Whether the new mode is fullscreen or windowed
 	bool is_fullscreen = false;
-	// whether more than one display was detected
+
+	// Whether more than one display was detected
 	bool is_multi_display = false;
 };
 

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -110,8 +110,8 @@ void MOUSE_NotifyTakeOver(const bool gui_has_taken_over);
 
 struct MouseScreenParams {
 	// Size of the black bars around screen area in logical units
-	uint32_t clip_x = 0;
-	uint32_t clip_y = 0;
+	int32_t clip_x = 0;
+	int32_t clip_y = 0;
 
 	// Size of drawing area in logical units
 	uint32_t res_x = 0;

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "rect.h"
+
 // ***************************************************************************
 // Initialization, configuration
 // ***************************************************************************
@@ -109,13 +111,11 @@ void MOUSE_NotifyWindowActive(const bool is_active);
 void MOUSE_NotifyTakeOver(const bool gui_has_taken_over);
 
 struct MouseScreenParams {
-	// Size of the black bars around screen area in logical units
-	int32_t clip_x = 0;
-	int32_t clip_y = 0;
-
-	// Size of drawing area in logical units
-	uint32_t res_x = 0;
-	uint32_t res_y = 0;
+	// The draw rectangle in logical units. Note the (x1,y1) upper-left
+	// coordinates can be negative if we're "zooming into" the DOS content
+	// (e.g., in 'relative' viewport mode), in which case the draw rect
+	// extends beyond the dimensions of the screen/window.
+	DosBox::Rect draw_rect = {};
 
 	// New absolute mouse cursor position in logical units
 	int32_t x_abs = 0;

--- a/include/rect.h
+++ b/include/rect.h
@@ -21,40 +21,185 @@
 #ifndef DOSBOX_RECTANGLE_H
 #define DOSBOX_RECTANGLE_H
 
-#include "math_utils.h"
+#include <algorithm>
+#include <cassert>
 
 namespace DosBox {
 
-// Struct to represent rectangles.
+// Struct to represent rectangles and sizes.
+//
+// As a general practice, it should be encoded in the variable/argument name
+// what we're dealing with (e.g. `viewport_rect`, `desktop_size`).
+//
 struct Rect {
 	constexpr Rect() = default;
 
-	constexpr Rect(const float _w, const float _h)
-	        : x(0.0f),
-	          y(0.0f),
-	          w(_w),
-	          h(_h)
+	constexpr Rect(const float x_pos, const float y_pos, const float width,
+	               const float height)
+	        : x(x_pos),
+	          y(y_pos),
+	          w(width),
+	          h(height)
+	{
+		assert(w >= 0.0f);
+		assert(h >= 0.0f);
+	}
+
+	constexpr Rect(const float width, const float height)
+	        : Rect(0.0f, 0.0f, width, height)
 	{}
 
-	constexpr Rect(const int _w, const int _h)
-	        : x(static_cast<float>(0.0f)),
-	          y(static_cast<float>(0.0f)),
-	          w(static_cast<float>(_w)),
-	          h(static_cast<float>(_h))
-	{}
-	constexpr Rect(const float _x, const float _y, const float _w, const float _h)
-	        : x(_x),
-	          y(_y),
-	          w(_w),
-	          h(_h)
+	constexpr Rect(const int x_pos, const int y_pos, const int width,
+	               const int height)
+	        : Rect(static_cast<float>(x_pos), static_cast<float>(y_pos),
+	               static_cast<float>(width), static_cast<float>(height))
 	{}
 
-	constexpr Rect(const int _x, const int _y, const int _w, const int _h)
-	        : x(static_cast<float>(_x)),
-	          y(static_cast<float>(_y)),
-	          w(static_cast<float>(_w)),
-	          h(static_cast<float>(_h))
+	constexpr Rect(const int width, const int height)
+	        : Rect(0, 0, width, height)
 	{}
+
+	constexpr bool operator==(const Rect& that) const
+	{
+		return (x == that.x && y == that.y && w == that.w && h == that.h);
+	}
+
+	constexpr bool operator!=(const Rect& that) const
+	{
+		return !operator==(that);
+	}
+
+	constexpr float x1() const
+	{
+		return x;
+	}
+
+	constexpr float y1() const
+	{
+		return y;
+	}
+
+	constexpr float x2() const
+	{
+		return x + w;
+	}
+
+	constexpr float y2() const
+	{
+		return y + h;
+	}
+
+	constexpr float cx() const
+	{
+		return x + w / 2;
+	}
+
+	constexpr float cy() const
+	{
+		return y + h / 2;
+	}
+
+	Rect Copy() const
+	{
+		return *this;
+	}
+
+	Rect& Scale(const float s)
+	{
+		x *= s;
+		y *= s;
+		w *= s;
+		h *= s;
+		return *this;
+	}
+
+	Rect& ScaleSize(const float s)
+	{
+		w *= s;
+		h *= s;
+		return *this;
+	}
+
+	Rect& ScaleWidth(const float s)
+	{
+		w *= s;
+		return *this;
+	}
+
+	Rect& ScaleHeight(const float s)
+	{
+		h *= s;
+		return *this;
+	}
+
+	Rect& Translate(const float dx, const float dy)
+	{
+		x += dx; 
+		y += dy;
+		return *this;
+	}
+
+	Rect& CenterTo(const float cx, const float cy)
+	{
+		x = cx - (w / 2);
+		y = cy - (h / 2);
+		return *this;
+	}
+
+	constexpr bool Contains(const Rect& r) const
+	{
+		return (r.x1() >= x1() && r.x2() <= x2()) &&
+		       (r.y1() >= y1() && r.y2() <= y2());
+	}
+
+	constexpr bool Overlaps(const Rect& r) const
+	{
+		const auto ix1 = std::max(x1(), r.x1());
+		const auto ix2 = std::min(x2(), r.x2());
+
+		if (ix1 < ix2) {
+			const auto iy1 = std::max(y1(), r.y1());
+			const auto iy2 = std::min(y2(), r.y2());
+
+			if (iy1 < iy2) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	Rect& Intersect(const Rect& r)
+	{
+		const auto ix1 = std::max(x1(), r.x1());
+		const auto ix2 = std::min(x2(), r.x2());
+
+		if (ix1 < ix2) {
+			const auto iy1 = std::max(y1(), r.y1());
+			const auto iy2 = std::min(y2(), r.y2());
+
+			if (iy1 < iy2) {
+				x = ix1;
+				y = iy1;
+				w = ix2 - ix1;
+				h = iy2 - iy1;
+
+				return *this;
+			}
+		}
+
+		// No intersection
+		w = 0.0f;
+		h = 0.0f;
+
+		return *this;
+	}
+
+	Rect& ScaleSizeToFit(const Rect& dest)
+	{
+		const auto s = std::min(dest.w / w, dest.h / h);
+		return ScaleSize(s);
+	}
 
 	float x = 0;
 	float y = 0;

--- a/include/render.h
+++ b/include/render.h
@@ -212,8 +212,7 @@ void RENDER_EndUpdate(bool abort);
 void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                        const uint8_t green, const uint8_t blue);
 
-bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width_px,
-                                  [[maybe_unused]] const uint16_t canvas_height_px,
+bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const DosBox::Rect canvas_size_px,
                                   [[maybe_unused]] const VideoMode& video_mode,
                                   [[maybe_unused]] const bool reinit_render);
 

--- a/include/render.h
+++ b/include/render.h
@@ -157,7 +157,8 @@ void RENDER_Reinit();
 
 void RENDER_AddConfigSection(const config_ptr_t& conf);
 
-bool RENDER_IsAspectRatioCorrectionEnabled();
+AspectRatioCorrectionMode RENDER_GetAspectRatioCorrectionMode();
+
 const std::string RENDER_GetCgaColorsSetting();
 
 void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette);

--- a/include/render.h
+++ b/include/render.h
@@ -21,11 +21,44 @@
 
 #include <cstring>
 #include <deque>
+#include <optional>
 #include <string>
 
 #include "../src/gui/render_scalers.h"
 #include "fraction.h"
+#include "rect.h"
 #include "vga.h"
+
+enum class ViewportMode { Fit, Relative };
+
+struct ViewportSettings {
+	ViewportMode mode = {};
+
+	// Either parameter can be set in Fit mode (but not both at the
+	// same time), or none
+	struct {
+		std::optional<DosBox::Rect> limit_size = {};
+		std::optional<float> desktop_scale     = {};
+	} fit = {};
+
+	struct {
+		float height_scale = 1.0f;
+		float width_scale  = 1.0f;
+	} relative = {};
+
+	constexpr bool operator==(const ViewportSettings& that) const
+	{
+		return (mode == that.mode && fit.limit_size == that.fit.limit_size &&
+		        fit.desktop_scale == that.fit.desktop_scale &&
+		        relative.height_scale == that.relative.height_scale &&
+		        relative.width_scale == that.relative.width_scale);
+	}
+
+	constexpr bool operator!=(const ViewportSettings& that) const
+	{
+		return !operator==(that);
+	}
+};
 
 struct RenderPal_t {
 	struct {
@@ -158,6 +191,8 @@ void RENDER_Reinit();
 void RENDER_AddConfigSection(const config_ptr_t& conf);
 
 AspectRatioCorrectionMode RENDER_GetAspectRatioCorrectionMode();
+
+DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canvas_px);
 
 const std::string RENDER_GetCgaColorsSetting();
 

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -43,11 +43,13 @@
 // in these various stages and to apply them consistently. To understand
 // the difference between logical units and pixels, please see `video.h`.
 //
-// Video mode dimensions:
+// Video mode dimensions
+// ---------------------
 //   The dimensions of the DOS video mode in raw pixels as stored on disk or
 //   in the emulated video card's framebuffer (e.g., 320x200 = 64000 pixels).
 //
-// Rendered image size:
+// Rendered image size
+// -------------------
 //   Size of the final rendered image in pixels *after* width and height
 //   doubling has been applied (e.g. 320x200 VGA is width and height doubled
 //   (scan-doubled) to 640x400; 320x200 CGA composite output is quadrupled in
@@ -55,26 +57,41 @@
 //   analogous to the actual video signal the CRT monitor "sees" (e.g., a
 //   monitor cannot differentiate between 320x200 double-scanned to 640x400,
 //   or an actual 640x400 video mode, as they're identical at the analog VGA
-//   signal level). In OpenGL output mode, this is the size of the input image
-//   in pixels sent to GLSL shaders.
+//   signal level). In OpenGL mode, this is the size of the input image in
+//   pixels sent to GLSL shaders.
 //
-// Canvas size:
+// Canvas size
+// -----------
 //   The unrestricted total available drawing area of the emulator window or
 //   the screen in fullscreen. This is reported by SDL as logical units.
 //
-// Viewport size:
+// Viewport rectangle
+// ------------------
 //   The maximum area we can *potentially* draw into in logical units.
 //   Normally, it's smaller than the canvas, but it can also be larger in
 //   certain viewport modes where we "zoom into" the image, or when we
 //   simulate the horiz/vert stretch controls of CRT monitors. In these cases,
-//   the canvas effectively acts as our "window" into the oversized viewport.
+//   the canvas effectively acts as our "window" into the oversized viewport,
+//   and one or both coordinates of the viewport rectangle's start point are
+//   negative.
 //
-// Draw size:
-//   The actual draw size in pixels after applying all rendering constraints
-//   such as integer scaling. The draw size is always equal to or smaller than
-//   the extents of the viewport. In OpenGL output mode, this is the size of
-//   the final output image coming out of the shaders, which is the image that
-//   is displayed on the host monitor with 1:1 physical pixel mapping.
+//   IMPORTANT: Note that this viewport concept is different to what SDL &
+//   OpenGL calls the "viewport". Technically, we set the SDL/OpenGL viewport
+//   to the draw rectangle described below.
+//
+// Draw rectangle
+// --------------
+//   The actual draw rectangle in pixels after applying all rendering
+//   constraints such as integer scaling. It's always 100% filled with the
+//   final output image, so its ratio is equal to the output display aspect
+//   ratio. The draw rectangle is always equal to or is contained within the
+//   viewport rectangle.
+//
+//   We set the SDL/OpenGL viewport (which is different to our *our* viewport
+//   concept) to the draw rectangle without any further transforms. In OpenGL
+//   mode, this is the size of the final output image coming out of the
+//   shaders, which is the image that is displayed on the host monitor with
+//   1:1 physical pixel mapping.
 //
 
 #define SDL_NOFRAME 0x00000020
@@ -271,7 +288,7 @@ struct SDL_Block {
 	bool mute_when_inactive  = false;
 	bool pause_when_inactive = false;
 
-	SDL_Rect clip_px          = {0, 0, 0, 0};
+	SDL_Rect draw_rect_px     = {};
 	SDL_Window* window        = nullptr;
 	SDL_Renderer* renderer    = nullptr;
 	std::string render_driver = "";

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -149,22 +149,6 @@ enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_HIGHEST
 };
 
-struct ViewportSettings {
-	ViewportMode mode = {};
-
-	// Either parameter can be set in Fit mode (but not both at the
-	// same time), or none
-	struct {
-		std::optional<DosBox::Rect> limit_size = {};
-		std::optional<float> desktop_scale     = {};
-	} fit = {};
-
-	struct {
-		float height_scale = 1.0f;
-		float width_scale  = 1.0f;
-	} relative = {};
-};
-
 struct SDL_Block {
 	bool initialized     = false;
 	bool active          = false; // If this isn't set don't draw
@@ -316,8 +300,6 @@ struct SDL_Block {
 	} frame = {};
 
 	bool use_exact_window_resolution = false;
-
-	ViewportSettings viewport = {};
 
 #if defined(WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -37,6 +37,46 @@
 #include "shader_manager.h"
 #include "video.h"
 
+// The image rendered in the emulated computer's raw framebuffer as raw pixels
+// goes through a number of transformations until it gets shown on the host
+// display. It is important to use a common vocabulary for the terms involved
+// in these various stages and to apply them consistently. To understand
+// the difference between logical units and pixels, please see `video.h`.
+//
+// Video mode dimensions:
+//   The dimensions of the DOS video mode in raw pixels as stored on disk or
+//   in the emulated video card's framebuffer (e.g., 320x200 = 64000 pixels).
+//
+// Rendered image size:
+//   Size of the final rendered image in pixels *after* width and height
+//   doubling has been applied (e.g. 320x200 VGA is width and height doubled
+//   (scan-doubled) to 640x400; 320x200 CGA composite output is quadrupled in
+//   width to 1280x200, etc.). The rendered image size is more or less
+//   analogous to the actual video signal the CRT monitor "sees" (e.g., a
+//   monitor cannot differentiate between 320x200 double-scanned to 640x400,
+//   or an actual 640x400 video mode, as they're identical at the analog VGA
+//   signal level). In OpenGL output mode, this is the size of the input image
+//   in pixels sent to GLSL shaders.
+//
+// Canvas size:
+//   The unrestricted total available drawing area of the emulator window or
+//   the screen in fullscreen. This is reported by SDL as logical units.
+//
+// Viewport size:
+//   The maximum area we can *potentially* draw into in logical units.
+//   Normally, it's smaller than the canvas, but it can also be larger in
+//   certain viewport modes where we "zoom into" the image, or when we
+//   simulate the horiz/vert stretch controls of CRT monitors. In these cases,
+//   the canvas effectively acts as our "window" into the oversized viewport.
+//
+// Draw size:
+//   The actual draw size in pixels after applying all rendering constraints
+//   such as integer scaling. The draw size is always equal to or smaller than
+//   the extents of the viewport. In OpenGL output mode, this is the size of
+//   the final output image coming out of the shaders, which is the image that
+//   is displayed on the host monitor with 1:1 physical pixel mapping.
+//
+
 #define SDL_NOFRAME 0x00000020
 
 // Texture buffer and presentation functions and type-defines

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -144,8 +144,8 @@ struct SDL_Block {
 	IntegerScalingMode integer_scaling_mode = IntegerScalingMode::Off;
 
 	struct {
-		int width_px = 0;
-		int height_px = 0;
+		int render_width_px = 0;
+		int render_height_px = 0;
 		Fraction render_pixel_aspect_ratio = {1};
 
 		bool has_changed = false;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -21,11 +21,11 @@
 #ifndef DOSBOX_SDLMAIN_H
 #define DOSBOX_SDLMAIN_H
 
+#include "SDL.h"
 #include <optional>
+#include <string.h>
 #include <string>
 #include <string_view>
-#include <string.h>
-#include "SDL.h"
 
 #if C_OPENGL
 #include <SDL_opengl.h>
@@ -80,22 +80,41 @@
 #define SDL_NOFRAME 0x00000020
 
 // Texture buffer and presentation functions and type-defines
-using update_frame_buffer_f = void(const uint16_t *);
-using present_frame_f = bool();
-constexpr void update_frame_noop([[maybe_unused]] const uint16_t *) { /* no-op */ }
-static inline bool present_frame_noop() { return true; }
+using update_frame_buffer_f = void(const uint16_t*);
+using present_frame_f       = bool();
+
+constexpr void update_frame_noop([[maybe_unused]] const uint16_t*)
+{
+	// no-op
+}
+
+static inline bool present_frame_noop()
+{
+	return true;
+}
 
 enum class FrameMode {
 	Unset,
-	Cfr,          // constant frame rate, as defined by the emulated system
-	Vfr,          // variable frame rate, as defined by the emulated system
-	ThrottledVfr, // variable frame rate, throttled to the display's rate
+
+	// Constant frame rate, as defined by the emulated system
+	Cfr,
+
+	// Variable frame rate, as defined by the emulated system
+	Vfr,
+
+	// Variable frame rate, throttled to the display's rate
+	ThrottledVfr,
 };
 
 enum class HostRateMode {
 	Auto,
-	Sdi, // serial digital interface
-	Vrr, // variable refresh rate
+
+	// Serial digital interface
+	Sdi,
+
+	// Variable refresh rate
+	Vrr,
+
 	Custom,
 };
 
@@ -141,13 +160,12 @@ struct ViewportSettings {
 	} fit = {};
 };
 
-
 struct SDL_Block {
-	bool initialized = false;
-	bool active = false; // If this isn't set don't draw
+	bool initialized     = false;
+	bool active          = false; // If this isn't set don't draw
 	bool updating        = false;
 	bool resizing_window = false;
-	bool wait_on_error = false;
+	bool wait_on_error   = false;
 
 	RenderingBackend rendering_backend      = RenderingBackend::Texture;
 	RenderingBackend want_rendering_backend = RenderingBackend::Texture;
@@ -156,13 +174,13 @@ struct SDL_Block {
 	IntegerScalingMode integer_scaling_mode = IntegerScalingMode::Off;
 
 	struct {
-		int render_width_px = 0;
-		int render_height_px = 0;
+		int render_width_px                = 0;
+		int render_height_px               = 0;
 		Fraction render_pixel_aspect_ratio = {1};
 
-		bool has_changed = false;
+		bool has_changed        = false;
 		GFX_CallBack_t callback = nullptr;
-		bool width_was_doubled = false;
+		bool width_was_doubled  = false;
 		bool height_was_doubled = false;
 	} draw = {};
 
@@ -170,46 +188,52 @@ struct SDL_Block {
 
 	struct {
 		struct {
-			int width = 0;
-			int height = 0;
-			bool fixed = false;
+			int width        = 0;
+			int height       = 0;
+			bool fixed       = false;
 			bool display_res = false;
 		} full = {};
+
 		struct {
-			// user-configured window size
-			int width = 0;
-			int height = 0;
-			bool show_decorations = true;
+			// User-configured window size
+			int width                  = 0;
+			int height                 = 0;
+			bool show_decorations      = true;
 			bool adjusted_initial_size = false;
-			int initial_x_pos = -1;
-			int initial_y_pos = -1;
-			// instantaneous canvas size of the window
+			int initial_x_pos          = -1;
+			int initial_y_pos          = -1;
+
+			// Instantaneous canvas size of the window
 			SDL_Rect canvas_size = {};
 		} window = {};
+
 		struct {
-			int width = 0;
+			int width  = 0;
 			int height = 0;
 		} requested_window_bounds = {};
 
 		PixelFormat pixel_format = {};
+
 		double dpi_scale = 1.0;
-		bool fullscreen = false;
+		bool fullscreen  = false;
 
 		// This flag indicates, that we are in the process of switching
 		// between fullscreen or window (as oppososed to changing
 		// rendering size due to rotating screen, emulation state, or
 		// user resizing the window).
 		bool switching_fullscreen = false;
+
 		// Lazy window size init triggers updating window size and
 		// position when leaving fullscreen for the first time.
 		// See FinalizeWindowState function for details.
-		bool lazy_init_window_size  = false;
+		bool lazy_init_window_size = false;
+
 		HostRateMode host_rate_mode = HostRateMode::Auto;
 		double preferred_host_rate  = 0.0;
 	} desktop = {};
 
 	struct {
-		int num_cycles = 0;
+		int num_cycles              = 0;
 		std::string hint_mouse_str  = {};
 		std::string hint_paused_str = {};
 		std::string cycles_ms_str   = {};
@@ -224,7 +248,7 @@ struct SDL_Block {
 #if C_OPENGL
 	struct {
 		SDL_GLContext context;
-		int pitch = 0;
+		int pitch      = 0;
 		void* framebuf = nullptr;
 		GLuint texture;
 		GLuint displaylist;
@@ -244,10 +268,12 @@ struct SDL_Block {
 			GLint output_size;
 			GLint frame_count;
 		} ruby = {};
+
 		GLuint actual_frame_count;
-		GLfloat vertex_data[2*3];
+		GLfloat vertex_data[2 * 3];
 	} opengl = {};
 #endif // C_OPENGL
+
 	struct {
 		PRIORITY_LEVELS active   = PRIORITY_LEVEL_AUTO;
 		PRIORITY_LEVELS inactive = PRIORITY_LEVEL_AUTO;
@@ -256,16 +282,16 @@ struct SDL_Block {
 	bool mute_when_inactive  = false;
 	bool pause_when_inactive = false;
 
-	SDL_Rect clip_px = {0, 0, 0, 0};
-	SDL_Window *window = nullptr;
-	SDL_Renderer *renderer = nullptr;
+	SDL_Rect clip_px          = {0, 0, 0, 0};
+	SDL_Window* window        = nullptr;
+	SDL_Renderer* renderer    = nullptr;
 	std::string render_driver = "";
-	int display_number = 0;
+	int display_number        = 0;
 
 	struct {
-		SDL_Surface *input_surface = nullptr;
-		SDL_Texture *texture = nullptr;
-		SDL_PixelFormat *pixelFormat = nullptr;
+		SDL_Surface* input_surface   = nullptr;
+		SDL_Texture* texture         = nullptr;
+		SDL_PixelFormat* pixelFormat = nullptr;
 	} texture = {};
 
 	struct {
@@ -273,21 +299,26 @@ struct SDL_Block {
 		update_frame_buffer_f* update = update_frame_noop;
 		FrameMode desired_mode        = FrameMode::Unset;
 		FrameMode mode                = FrameMode::Unset;
-		double period_ms    = 0.0; // in ms, for use with PIC timers
+
+		// in ms, for use with PIC timers
+		double period_ms      = 0.0;
 		float max_dupe_frames = 0.0f;
-		int period_us       = 0; // same but in us, for use with chrono
+
+		// same but in us, for use with chrono
+		int period_us       = 0;
 		int period_us_early = 0;
-		int period_us_late    = 0;
+		int period_us_late  = 0;
 	} frame = {};
 
 	bool use_exact_window_resolution = false;
 
 	ViewportSettings viewport = {};
 
-#if defined (WIN32)
+#if defined(WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
 	int64_t focus_ticks = 0;
 #endif
+
 	// State of Alt keys for certain special handlings
 	SDL_EventType laltstate = SDL_KEYUP;
 	SDL_EventType raltstate = SDL_KEYUP;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -227,8 +227,6 @@ struct SDL_Block {
 		int period_us_late    = 0;
 	} frame = {};
 
-	SDL_Rect updateRects[1024] = {};
-
 	bool use_exact_window_resolution = false;
 
 	std::optional<SDL_Point> viewport_resolution = {};

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -130,6 +130,18 @@ enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_HIGHEST
 };
 
+struct ViewportSettings {
+	ViewportMode mode = {};
+
+	// Either parameter can be set in Fit mode (but not both at the
+	// same time), or none
+	struct {
+		std::optional<DosBox::Rect> limit_size = {};
+		std::optional<float> desktop_scale     = {};
+	} fit = {};
+};
+
+
 struct SDL_Block {
 	bool initialized = false;
 	bool active = false; // If this isn't set don't draw
@@ -270,7 +282,8 @@ struct SDL_Block {
 
 	bool use_exact_window_resolution = false;
 
-	std::optional<SDL_Point> viewport_resolution = {};
+	ViewportSettings viewport = {};
+
 #if defined (WIN32)
 	// Time when sdl regains focus (Alt+Tab) in windowed mode
 	int64_t focus_ticks = 0;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -203,7 +203,7 @@ struct SDL_Block {
 
 		PixelFormat pixel_format = {};
 
-		double dpi_scale = 1.0;
+		float dpi_scale = 1.0;
 		bool fullscreen  = false;
 
 		// This flag indicates, that we are in the process of switching

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -158,6 +158,11 @@ struct ViewportSettings {
 		std::optional<DosBox::Rect> limit_size = {};
 		std::optional<float> desktop_scale     = {};
 	} fit = {};
+
+	struct {
+		float height_scale = 1.0f;
+		float width_scale  = 1.0f;
+	} relative = {};
 };
 
 struct SDL_Block {

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -32,6 +32,7 @@
 #endif
 
 #include "fraction.h"
+#include "rect.h"
 #include "render.h"
 #include "shader_manager.h"
 #include "video.h"

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -358,6 +358,10 @@ std::optional<float> parse_float(const std::string& s);
 //
 std::optional<int> parse_int(const std::string& s, const int base = 10);
 
+// Returned percentage values are unscaled.
+std::optional<float> parse_percentage_with_percent_sign(const std::string_view s);
+std::optional<float> parse_percentage_with_optional_percent_sign(const std::string_view s);
+
 template <typename... Args>
 std::string format_string(const std::string& format, const Args&... args) noexcept
 {

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -358,8 +358,6 @@ std::optional<float> parse_float(const std::string& s);
 //
 std::optional<int> parse_int(const std::string& s, const int base = 10);
 
-std::optional<float> parse_percentage(const std::string& s);
-
 template <typename... Args>
 std::string format_string(const std::string& format, const Args&... args) noexcept
 {

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -95,8 +95,11 @@ bool starts_with(const std::string_view str, const std::string_view prefix) noex
 
 bool ends_with(const std::string_view str, const std::string_view suffix) noexcept;
 
-std::string strip_prefix(const std::string& str, const std::string& prefix) noexcept;
-std::string strip_suffix(const std::string& str, const std::string& suffix) noexcept;
+std::string strip_prefix(const std::string_view str,
+                         const std::string_view prefix) noexcept;
+
+std::string strip_suffix(const std::string_view str,
+                         const std::string_view suffix) noexcept;
 
 bool find_in_case_insensitive(const std::string& needle, const std::string& haystack);
 

--- a/include/vga.h
+++ b/include/vga.h
@@ -283,7 +283,6 @@ struct VgaDraw {
 	double custom_refresh_hz  = RefreshRateDosDefault;
 	VgaRateMode dos_rate_mode = VgaRateMode::Default;
 
-	bool force_square_pixels     = false;
 	bool double_scanning_enabled = false;
 	bool pixel_doubling_enabled  = false;
 

--- a/include/video.h
+++ b/include/video.h
@@ -91,6 +91,9 @@ enum class IntegerScalingMode {
 
 enum class AspectRatioCorrectionMode { On, Off, Stretch };
 
+//enum class ViewportMode { Fit, Relative };
+enum class ViewportMode { Fit };
+
 // Graphics standards ordered by time of introduction (and roughly by
 // their capabilities)
 enum class GraphicsStandard { Hercules, Cga, Pcjr, Tga, Ega, Vga, Svga, Vesa };

--- a/include/video.h
+++ b/include/video.h
@@ -94,7 +94,7 @@ enum class AspectRatioCorrectionMode {
 	// from heuristics & hardcoded values on all other adapters.
 	Auto,
 
-	// Always force square pixel aspect ratio.
+	// Always force square pixels (1:1 pixel aspect ratio).
 	SquarePixels,
 
 	// Use a 4:3 display aspect ratio viewport as the starting point, then

--- a/include/video.h
+++ b/include/video.h
@@ -407,7 +407,7 @@ bool GFX_HaveDesktopEnvironment();
 void MAPPER_UpdateJoysticks(void);
 #endif
 
-DosBox::Rect GFX_CalcDrawSizeInPixels(const DosBox::Rect& canvas_size_px,
+DosBox::Rect GFX_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
                                       const DosBox::Rect& render_size_px,
                                       const Fraction& render_pixel_aspect_ratio);
 

--- a/include/video.h
+++ b/include/video.h
@@ -89,7 +89,20 @@ enum class IntegerScalingMode {
 	Vertical,
 };
 
-enum class AspectRatioCorrectionMode { Auto, SquarePixels, Stretch };
+enum class AspectRatioCorrectionMode {
+	// Calculate the pixel aspect ratio from the display timings on VGA, and
+	// from heuristics & hardcoded values on all other adapters.
+	Auto,
+
+	// Always force square pixel aspect ratio.
+	SquarePixels,
+
+	// Use a 4:3 display aspect ratio viewport as the starting point, then
+	// apply user-defined horizontal and vertical scale factors to it. Stretch
+	// all video modes into the resulting viewport and derive the pixel aspect
+	// ratios from that.
+	Stretch
+};
 
 enum class ViewportMode { Fit, Relative };
 

--- a/include/video.h
+++ b/include/video.h
@@ -355,7 +355,7 @@ InterpolationMode GFX_GetInterpolationMode();
 struct VideoMode;
 class Fraction;
 
-uint8_t GFX_SetSize(const int width_px, const int height_px,
+uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
                     const Fraction& render_pixel_aspect_ratio, const uint8_t flags,
                     const VideoMode& video_mode, GFX_CallBack_t callback);
 

--- a/include/video.h
+++ b/include/video.h
@@ -104,8 +104,6 @@ enum class AspectRatioCorrectionMode {
 	Stretch
 };
 
-enum class ViewportMode { Fit, Relative };
-
 // Graphics standards ordered by time of introduction (and roughly by
 // their capabilities)
 enum class GraphicsStandard { Hercules, Cga, Pcjr, Tga, Ega, Vga, Svga, Vesa };
@@ -415,6 +413,9 @@ DosBox::Rect GFX_CalcDrawSizeInPixels(const DosBox::Rect& canvas_size_px,
 
 DosBox::Rect GFX_GetCanvasSizeInPixels();
 DosBox::Rect GFX_GetViewportSizeInPixels();
+DosBox::Rect GFX_GetDesktopSize();
+
+double GFX_GetDpiScaleFactor();
 
 RenderingBackend GFX_GetRenderingBackend();
 

--- a/include/video.h
+++ b/include/video.h
@@ -29,6 +29,46 @@
 #include "setup.h"
 #include "types.h"
 
+// Pixels and logical units
+// ========================
+//
+// As high-DPI displays are becoming increasingly the norm, understanding the
+// difference between screen dimensions expressed as *logical units* versus
+// *pixels* is essential. We fully support high-DPI in DOSBox Staging, so a
+// good grasp of this topic essential when dealing with anything rendering
+// related.
+// 
+// The idea behind logical units is that a rectangle of say 200x300 *logical
+// units* in size should have the same physical dimensions when measured with
+// a ruler on a 1080p, a 4k, and an 8k screen (assuming that the physical
+// dimensions of the three screens are the same). When mapping these 200x300
+// logic units actual physical pixels the monitor is capable of displaying,
+// we'll get 200x300, 400x600, and 800x1200 pixel dimensions on 1080p, 4k, and
+// 8k screens, respectively. The *logical size* of the rectangle hasn't
+// changed, only its *resolution* expressed in raw native pixels has.
+//
+// OSes and frameworks like SDL usually report windowing system related
+// coordinates and dimensions in logical units (e.g., window sizes, total
+// desktop size, mouse position, etc.). But OpenGL only deals with pixels,
+// never logical units, and in the core emulation layers we're only dealing
+// with "raw emulated pixels" too. Consequently, in `sdlmain.cpp` we'll always
+// be dealing with a mixture of logical units and pixels, so it's essential to
+// make the distinction between them clear:
+//
+// - In `sdlmain.cpp`, we postfix every variable that holds a pixel dimension
+//   with `_px` (e.g., `render_size_px`, `width_px`). Logical units get no
+//   postfix (e.g., `window_size`, `mouse_pos`).
+//
+// - Functions and methods that return pixel dimensions are postfixed with
+//   `_in_pixels` and `InPixels`, respectively (e.g., `GFX_GetViewportSizeInPixels()`).
+//
+// - We're always dealing with pixels in the core emulation layers (e.g., VGA
+//   code), so pixel postfixes are not necessary there in general. The exception
+//   is when a core layer interfaces with the top host-side rendering layers,
+//   e.g., by calling `GFX_*` methods that interact with SDL -- the use of pixel
+//   postfixes is highly recommended in such cases to remove ambiguity.
+//
+
 #define REDUCE_JOYSTICK_POLLING
 
 enum class RenderingBackend {
@@ -354,8 +394,8 @@ bool GFX_HaveDesktopEnvironment();
 void MAPPER_UpdateJoysticks(void);
 #endif
 
-DosBox::Rect GFX_CalcViewportInPixels(const DosBox::Rect& canvas_px,
-                                      const DosBox::Rect& draw_area_px,
+DosBox::Rect GFX_CalcDrawSizeInPixels(const DosBox::Rect& canvas_size_px,
+                                      const DosBox::Rect& render_size_px,
                                       const Fraction& render_pixel_aspect_ratio);
 
 DosBox::Rect GFX_GetCanvasSizeInPixels();

--- a/include/video.h
+++ b/include/video.h
@@ -89,7 +89,7 @@ enum class IntegerScalingMode {
 	Vertical,
 };
 
-enum class AspectRatioCorrectionMode { On, Off, Stretch };
+enum class AspectRatioCorrectionMode { Auto, SquarePixels, Stretch };
 
 enum class ViewportMode { Fit, Relative };
 

--- a/include/video.h
+++ b/include/video.h
@@ -415,7 +415,7 @@ DosBox::Rect GFX_GetCanvasSizeInPixels();
 DosBox::Rect GFX_GetViewportSizeInPixels();
 DosBox::Rect GFX_GetDesktopSize();
 
-double GFX_GetDpiScaleFactor();
+float GFX_GetDpiScaleFactor();
 
 RenderingBackend GFX_GetRenderingBackend();
 

--- a/include/video.h
+++ b/include/video.h
@@ -49,6 +49,8 @@ enum class IntegerScalingMode {
 	Vertical,
 };
 
+enum class AspectRatioCorrectionMode { On, Off, Stretch };
+
 // Graphics standards ordered by time of introduction (and roughly by
 // their capabilities)
 enum class GraphicsStandard { Hercules, Cga, Pcjr, Tga, Ega, Vga, Svga, Vesa };

--- a/include/video.h
+++ b/include/video.h
@@ -91,8 +91,7 @@ enum class IntegerScalingMode {
 
 enum class AspectRatioCorrectionMode { On, Off, Stretch };
 
-//enum class ViewportMode { Fit, Relative };
-enum class ViewportMode { Fit };
+enum class ViewportMode { Fit, Relative };
 
 // Graphics standards ordered by time of introduction (and roughly by
 // their capabilities)

--- a/include/video.h
+++ b/include/video.h
@@ -354,10 +354,8 @@ bool GFX_HaveDesktopEnvironment();
 void MAPPER_UpdateJoysticks(void);
 #endif
 
-DosBox::Rect GFX_CalcViewportInPixels(const int canvas_width_px,
-                                      const int canvas_height_px,
-                                      const int draw_width_px,
-                                      const int draw_height_px,
+DosBox::Rect GFX_CalcViewportInPixels(const DosBox::Rect& canvas_px,
+                                      const DosBox::Rect& draw_area_px,
                                       const Fraction& render_pixel_aspect_ratio);
 
 DosBox::Rect GFX_GetCanvasSizeInPixels();

--- a/include/video.h
+++ b/include/video.h
@@ -359,6 +359,7 @@ DosBox::Rect GFX_CalcViewportInPixels(const int canvas_width_px,
                                       const Fraction& render_pixel_aspect_ratio);
 
 DosBox::Rect GFX_GetCanvasSizeInPixels();
+DosBox::Rect GFX_GetViewportSizeInPixels();
 
 RenderingBackend GFX_GetRenderingBackend();
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -20,6 +20,8 @@
 #include "fpu.h"
 #endif
 
+#include "math_utils.h"
+
 static constexpr uint16_t ExtendedPrecisionModeMask = 0x0300;
 
 static void FPU_FINIT(void) {
@@ -100,8 +102,9 @@ static void FPU_FPOP(void){
 	return;
 }
 
-static double FROUND(double in){
-	switch(fpu.round){
+static double FROUND(double in)
+{
+	switch (fpu.round) {
 	case ROUND_Nearest: return std::nearbyint(in);
 	case ROUND_Down: return std::floor(in);
 	case ROUND_Up: return std::ceil(in);
@@ -110,20 +113,17 @@ static double FROUND(double in){
 		// Most x32/x64 builds use fpu_instructions_x86.h.
 		// If we are here on x64, we don't need this fix.
 #if !defined(__x86_64__) && !defined(_M_X64)
-		// This is a fix for rounding to a close integer in
-		// extended precision mode, e.g. 7.999999999999994; an example
-		// can be seen in the Quake options screen size slider.
-		// In this case, what is almost certainly wanted is 8.0,
-		// so return the closer integer within the tolerance instead
-		// of chopping to the lower value.
+		// This is a fix for rounding to a close integer in extended
+		// precision mode, e.g. 7.999999999999994; an example can be
+		// seen in the Quake options screen size slider. In this case,
+		// what is almost certainly wanted is 8.0, so return the closer
+		// integer instead of chopping to the lower value.
 		if ((fpu.cw & ExtendedPrecisionModeMask) == ExtendedPrecisionModeMask) {
-			constexpr double tolerance = 1e-14;
-
 			if (const auto lower = std::floor(in);
-			    (in - lower) < tolerance) {
+			    are_almost_equal_relative(in, lower)) {
 				return lower;
 			} else if (const auto upper = std::ceil(in);
-			           (upper - in) < tolerance) {
+			           are_almost_equal_relative(upper, in)) {
 				return upper;
 			}
 		}

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -22,7 +22,11 @@
 
 #include "math_utils.h"
 
-static constexpr uint16_t ExtendedPrecisionModeMask = 0x0300;
+static constexpr uint16_t PrecisionModeMask = 0x0300;
+
+static constexpr uint16_t SinglePrecisionMode   = 0x0000;
+static constexpr uint16_t DoublePrecisionMode   = 0x0200;
+static constexpr uint16_t ExtendedPrecisionMode = 0x0300;
 
 static void FPU_FINIT(void) {
 	FPU_SetCW(0x37F);
@@ -110,6 +114,14 @@ static double FROUND(double in)
 	case ROUND_Up: return std::ceil(in);
 	case ROUND_Chop: 
 	{
+		switch (fpu.cw & PrecisionModeMask) {
+		// This case properly handles "in" values beyond the precision
+		// of a float, e.g. 5.99999999367, by correctly rounding to 6.0
+		// via the cast, then performing the truncation, instead of
+		// returning 5.0. Quake, for example, does many calculations in
+		// single precision mode.
+		case SinglePrecisionMode:
+			return std::trunc(static_cast<float>(in));
 		// Most x32/x64 builds use fpu_instructions_x86.h.
 		// If we are here on x64, we don't need this fix.
 #if !defined(__x86_64__) && !defined(_M_X64)
@@ -118,7 +130,7 @@ static double FROUND(double in)
 		// seen in the Quake options screen size slider. In this case,
 		// what is almost certainly wanted is 8.0, so return the closer
 		// integer instead of chopping to the lower value.
-		if ((fpu.cw & ExtendedPrecisionModeMask) == ExtendedPrecisionModeMask) {
+		case ExtendedPrecisionMode: {
 			if (const auto lower = std::floor(in);
 			    are_almost_equal_relative(in, lower)) {
 				return lower;
@@ -128,6 +140,8 @@ static double FROUND(double in)
 			}
 		}
 #endif
+		default: break;
+		}
 		return std::trunc(in);
 	}
 	default: return in;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -734,10 +734,10 @@ static AspectRatioCorrectionMode get_aspect_ratio_correction_mode_setting()
 	const std::string mode = get_render_section()->Get_string("aspect");
 
 	if (has_false(mode)) {
-		return AspectRatioCorrectionMode::Off;
+		return AspectRatioCorrectionMode::SquarePixels;
 
 	} else if (has_true(mode)) {
-		return AspectRatioCorrectionMode::On;
+		return AspectRatioCorrectionMode::Auto;
 
 	} else if (mode == "stretch") {
 		return AspectRatioCorrectionMode::Stretch;
@@ -745,7 +745,7 @@ static AspectRatioCorrectionMode get_aspect_ratio_correction_mode_setting()
 	} else {
 		LOG_WARNING("RENDER: Invalid 'aspect' setting '%s', using 'on'",
 		            mode.c_str());
-		return AspectRatioCorrectionMode::On;
+		return AspectRatioCorrectionMode::Auto;
 	}
 }
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1103,7 +1103,13 @@ static void init_render_settings(Section_prop& secprop)
 	        "                   beyond the window/screen. Useful to force arbitrary display\n"
 	        "                   aspect ratios with 'aspect = stretch' and to zoom into the\n"
 	        "                   image. This effectively emulates the horizontal and vertical\n"
-	        "                   stretch controls of CRT monitors.");
+	        "                   stretch controls of CRT monitors.\n"
+	        "\n"
+	        "Notes:\n"
+	        " - Using 'relative' mode with 'integer_scaling' enabled could lead to\n"
+	        "   surprising (but correct) results.\n"
+	        " - You can use the 'Strech Axis', 'Inc Stretch', and 'Dec Stretch' hotkey\n"
+	        "   actions to set the stretch in 'relative' mode in real-time.");
 
 	string_prop = secprop.Add_string("monochrome_palette",
 	                                 always,

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -352,15 +352,15 @@ static void render_reset(void)
 	// driver operating in a different thread or process.
 	std::lock_guard<std::mutex> guard(render_reset_mutex);
 
-	uint16_t width     = render.src.width;
-	bool double_width  = render.src.double_width;
-	bool double_height = render.src.double_height;
+	uint16_t render_width_px = render.src.width;
+	bool double_width        = render.src.double_width;
+	bool double_height       = render.src.double_height;
 
 	uint8_t gfx_flags, xscale, yscale;
 	ScalerSimpleBlock_t* simpleBlock = &ScaleNormal1x;
 
 	// Don't do software scaler sizes larger than 4k
-	uint16_t maxsize_current_input = SCALER_MAXWIDTH / width;
+	uint16_t maxsize_current_input = SCALER_MAXWIDTH / render_width_px;
 	if (render.scale.size > maxsize_current_input) {
 		render.scale.size = maxsize_current_input;
 	}
@@ -375,7 +375,7 @@ static void render_reset(void)
 		simpleBlock = &ScaleNormal1x;
 	}
 
-	if ((width * simpleBlock->xscale > SCALER_MAXWIDTH) ||
+	if ((render_width_px * simpleBlock->xscale > SCALER_MAXWIDTH) ||
 	    (render.src.height * simpleBlock->yscale > SCALER_MAXHEIGHT)) {
 		simpleBlock = &ScaleNormal1x;
 	}
@@ -411,8 +411,10 @@ static void render_reset(void)
 			E_Exit("Failed to create a rendering output");
 		}
 	}
-	width *= xscale;
-	const auto height = make_aspect_table(render.src.height, yscale, yscale);
+	render_width_px *= xscale;
+	const auto render_height_px = make_aspect_table(render.src.height,
+	                                                yscale,
+	                                                yscale);
 
 	// Set up scaler variables
 	if (double_height) {
@@ -429,8 +431,8 @@ static void render_reset(void)
 
 	const auto render_pixel_aspect_ratio = render.src.pixel_aspect_ratio;
 
-	gfx_flags = GFX_SetSize(width,
-	                        height,
+	gfx_flags = GFX_SetSize(render_width_px,
+	                        render_height_px,
 	                        render_pixel_aspect_ratio,
 	                        gfx_flags,
 	                        render.src.video_mode,

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -733,17 +733,17 @@ static AspectRatioCorrectionMode get_aspect_ratio_correction_mode_setting()
 {
 	const std::string mode = get_render_section()->Get_string("aspect");
 
-	if (has_false(mode)) {
-		return AspectRatioCorrectionMode::SquarePixels;
-
-	} else if (has_true(mode)) {
+	if (has_true(mode) || mode == "auto") {
 		return AspectRatioCorrectionMode::Auto;
+
+	} else if (has_false(mode) || mode == "square-pixels") {
+		return AspectRatioCorrectionMode::SquarePixels;
 
 	} else if (mode == "stretch") {
 		return AspectRatioCorrectionMode::Stretch;
 
 	} else {
-		LOG_WARNING("RENDER: Invalid 'aspect' setting '%s', using 'on'",
+		LOG_WARNING("RENDER: Invalid 'aspect' setting '%s', using 'auto'",
 		            mode.c_str());
 		return AspectRatioCorrectionMode::Auto;
 	}
@@ -1035,26 +1035,30 @@ static void init_render_settings(Section_prop& secprop)
 	int_prop->Set_help(
 	        "Consider capping frame rates using the 'host_rate' setting.");
 
-	auto* string_prop = secprop.Add_string("aspect", always, "on");
+	auto* string_prop = secprop.Add_string("aspect", always, "auto");
 	string_prop->Set_help(
-	        "Set the aspect ratio correction mode (enabled by default).\n"
-	        "  on:       Apply aspect ratio correction for modern square-pixel flat-screen\n"
-	        "            displays, so DOS video modes with non-square pixels appear as they\n"
-	        "            would on a 4:3 display aspect ratio CRT monitor the majority of DOS\n"
-	        "            games were designed for. This setting only affects video modes that\n"
-	        "            use non-square pixels, such as 320x200 or 640x400; square-pixel\n"
-	        "            modes (e.g., 320x240, 640x480, and 800x600), are displayed as-is.\n"
-	        "  off:      Don't apply aspect ratio correction; all DOS video modes will be\n"
-	        "            displayed with square pixels. Most 320x200 games will appear\n"
-	        "            squashed, but a minority of titles (e.g., DOS ports of PAL Amiga\n"
-	        "            games) need square pixels to appear as the artists intended.\n"
-	        "  stretch:  Calculate the aspect ratio from the viewport's dimensions.\n"
-	        "            Combined with 'viewport', this mode is useful to force arbitrary\n"
-	        "            aspect ratios (e.g., stretching DOS games to fullscreen on 16:9\n"
-	        "            displays) and to emulate the horizontal and vertical stretch\n"
-	        "            controls of CRT monitors.\n");
+            "Set the aspect ratio correction mode (enabled by default):\n"
+            "  auto, on:            Apply aspect ratio correction for modern square-pixel\n"
+            "                       flat-screen displays, so DOS video modes with non-square\n"
+            "                       pixels appear as they would on a 4:3 display aspect\n"
+            "                       ratio CRT monitor the majority of DOS games were\n"
+            "                       designed for. This setting only affects video modes that\n"
+            "                       use non-square pixels, such as 320x200 or 640x400;.\n"
+            "                       square-pixelmodes (e.g., 320x240, 640x480, and 800x600),\n"
+            "                       are displayed as-is.\n"
+            "  square-pixels, off:  Don't apply aspect ratio correction; all DOS video modes\n"
+            "                       are displayed with square pixels. Most 320x200 games\n"
+            "                       will appear squashed, but a minority of titles (e.g.,\n"
+            "                       DOS ports of PAL Amiga games) need square pixels to\n"
+            "                       appear as the artists intended.\n"
+            "  stretch:             Calculate the aspect ratio from the viewport's\n"
+            "                       dimensions. Combined with 'viewport', this mode is\n"
+            "                       useful to force arbitrary aspect ratios (e.g.,\n"
+            "                       stretching DOS games to fullscreen on 16:9 displays) and\n"
+            "                       to emulate the horizontal and vertical stretch controls\n"
+            "                       of CRT monitors.");
 
-	const char* aspect_values[] = {"on", "off", "stretch", nullptr};
+	const char* aspect_values[] = {"auto", "on", "square-pixels", "off", "stretch", nullptr};
 	string_prop->Set_values(aspect_values);
 
 	string_prop = secprop.Add_string("integer_scaling", always, "auto");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -816,21 +816,20 @@ static void init_render_settings(Section_prop& secprop)
 
 	string_prop = secprop.Add_string("integer_scaling", always, "auto");
 	string_prop->Set_help(
-	        "Constrain the horizontal or vertical scaling factor to integer values.\n"
-	        "The correct aspect ratio is always maintained according to the 'aspect'\n"
-	        "setting, which may result in a non-integer scaling factor in the other\n"
-	        "direction. If the image is larger than the viewport, the integer scaling\n"
-	        "constraint is auto-disabled (same as 'off'). Possible values:\n"
-	        "  auto:        'vertical' mode auto-enabled for adaptive CRT shaders only,\n"
-	        "               otherwise 'off' (default).\n"
-	        "  vertical:    Constrain the vertical scaling factor to integer values within\n"
-	        "               the viewport. This is the recommended setting when using CRT\n"
-	        "               shaders to avoid uneven scanlines and unwanted interference\n"
-	        "               artifacts.\n"
-	        "  horizontal:  Constrain the horizontal scaling factor to integer values within\n"
-	        "               the viewport.\n"
+	        "Constrain the horizontal or vertical scaling factor to the largest integer\n"
+	        "value so the image still fits into the viewport. The configured aspect ratio is\n"
+	        "always maintained according to the 'aspect' and 'viewport_resolution' settings,\n"
+	        "which may result in a non-integer scaling factor in the other dimension.\n"
+	        "If the image is larger than the viewport, the integer scaling constraint is\n"
+	        "auto-disabled (same as 'off'). Possible values:\n"
+	        "  auto:        'vertical' mode auto-enabled for adaptive CRT shaders only\n"
+	        "               (see 'glshader'), otherwise 'off' (default).\n"
+	        "  vertical:    Constrain the vertical scaling factor to integer values.\n"
+	        "               This is the recommended setting for CRT shaders to avoid uneven\n"
+	        "               scanlines and interference artifacts.\n"
+	        "  horizontal:  Constrain the horizontal scaling factor to integer values.\n"
 	        "  off:         No integer scaling constraint is applied; the image fills the\n"
-	        "               viewport according to the 'aspect' setting.");
+	        "               viewport while maintaining the configured aspect ratio.");
 
 	const char* integer_scaling_values[] = {
 	        "auto", "vertical", "horizontal", "off", nullptr};

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -973,33 +973,32 @@ static ViewportSettings get_default_viewport_settings()
 
 DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canvas_size_px)
 {
-	const auto& viewport = viewport_settings;
 	const auto dpi_scale = GFX_GetDpiScaleFactor();
 
-	switch (viewport.mode) {
+	switch (viewport_settings.mode) {
 	case ViewportMode::Fit: {
-		auto viewport_px = [&] {
-			if (viewport.fit.limit_size) {
-				return viewport.fit.limit_size->Copy().ScaleSize(
+		auto viewport_size_px = [&] {
+			if (viewport_settings.fit.limit_size) {
+				return viewport_settings.fit.limit_size->Copy().ScaleSize(
 				        dpi_scale);
 
-			} else if (viewport.fit.desktop_scale) {
+			} else if (viewport_settings.fit.desktop_scale) {
 				auto desktop_px = GFX_GetDesktopSize().ScaleSize(
 				        dpi_scale);
 
-				return desktop_px.ScaleSize(*viewport.fit.desktop_scale);
-
+				return desktop_px.ScaleSize(
+				        *viewport_settings.fit.desktop_scale);
 			} else {
-				// The viewport equals the canvas size in
-				// Fit mode without parameters
+				// The viewport_settings equals the canvas size
+				// in Fit mode without parameters
 				return canvas_size_px;
 			}
 		}();
 
-		if (canvas_size_px.Contains(viewport_px)) {
-			return viewport_px;
+		if (canvas_size_px.Contains(viewport_size_px)) {
+			return viewport_size_px;
 		} else {
-			return viewport_px.Intersect(canvas_size_px);
+			return viewport_size_px.Intersect(canvas_size_px);
 		}
 	}
 
@@ -1008,8 +1007,8 @@ DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canva
 		        canvas_size_px);
 
 		return restricted_canvas_px.Copy()
-		        .ScaleWidth(viewport.relative.width_scale)
-		        .ScaleHeight(viewport.relative.height_scale);
+		        .ScaleWidth(viewport_settings.relative.width_scale)
+		        .ScaleHeight(viewport_settings.relative.height_scale);
 	}
 
 	default: assertm(false, "Invalid ViewportMode value"); return {};

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -29,6 +29,7 @@
 #include "control.h"
 #include "fraction.h"
 #include "mapper.h"
+#include "math_utils.h"
 #include "render.h"
 #include "setup.h"
 #include "shader_manager.h"

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -777,6 +777,249 @@ static IntegerScalingMode get_integer_scaling_mode_setting()
 	}
 }
 
+static void set_default_viewport_setting()
+{
+	const auto string_prop = get_render_section()->GetStringProp(
+	        "viewport");
+	string_prop->SetValue("fit");
+}
+
+static void log_invalid_viewport_setting_warning(
+        const std::string& pref,
+        const std::optional<const std::string> extra_info = {})
+{
+	LOG_WARNING("DISPLAY: Invalid 'viewport' setting: '%s'"
+	            "%s%s, using 'fit'",
+	            pref.c_str(),
+	            (extra_info ? ". " : ""),
+	            (extra_info ? extra_info->c_str() : ""));
+}
+
+std::optional<std::pair<int, int>> parse_int_dimensions(const std::string_view s)
+{
+	const auto parts = split(s, "x");
+	if (parts.size() == 2) {
+
+		const auto w = parse_int(parts[0]);
+		const auto h = parse_int(parts[1]);
+		if (w && h) {
+			return {{*w, *h}};
+		}
+	}
+	return {};
+}
+
+static std::optional<ViewportSettings> parse_fit_viewport_modes(const std::string& pref)
+{
+	if (pref == "fit") {
+		ViewportSettings viewport = {};
+		viewport.mode             = ViewportMode::Fit;
+		return viewport;
+
+	} else if (const auto width_and_height = parse_int_dimensions(pref)) {
+		const auto [w, h] = *width_and_height;
+
+		const auto desktop = GFX_GetDesktopSize();
+
+		const bool is_out_of_bounds = (w <= 0 || w > desktop.w ||
+		                               h <= 0 || h > desktop.h);
+		if (is_out_of_bounds) {
+			const auto extra_info = format_string(
+			        "Viewport size is outside of the %dx%d desktop bounds",
+			        iroundf(desktop.w),
+			        iroundf(desktop.h));
+
+			log_invalid_viewport_setting_warning(pref, extra_info);
+			return {};
+		}
+
+		ViewportSettings viewport = {};
+		viewport.mode             = ViewportMode::Fit;
+
+		const DosBox::Rect limit = {w, h};
+		viewport.fit.limit_size  = limit;
+
+		const auto limit_px = limit.Copy().ScaleSize(GFX_GetDpiScaleFactor());
+
+		LOG_MSG("DISPLAY: Limiting viewport size to %dx%d logical units "
+		        "(%dx%d pixels)",
+		        iroundf(limit.w),
+		        iroundf(limit.h),
+		        iroundf(limit_px.w),
+		        iroundf(limit_px.h));
+
+		return viewport;
+
+	} else if (const auto percentage = parse_percentage_with_optional_percent_sign(
+	                   pref)) {
+		const auto desktop = GFX_GetDesktopSize();
+		const auto p       = *percentage;
+
+		const bool is_out_of_bounds = (p < 1.0f || p > 100.0f);
+		if (is_out_of_bounds) {
+			const auto extra_info = "Desktop percentage is outside of the 1-100%% range";
+
+			log_invalid_viewport_setting_warning(pref, extra_info);
+			return {};
+		}
+
+		ViewportSettings viewport  = {};
+		viewport.mode              = ViewportMode::Fit;
+		viewport.fit.desktop_scale = p / 100.0f;
+
+		const auto limit = desktop.Copy().ScaleSize(*viewport.fit.desktop_scale);
+		const auto limit_px = limit.Copy().ScaleSize(GFX_GetDpiScaleFactor());
+
+		LOG_MSG("DISPLAY: Limiting viewport size to %2.4g%% of the "
+		        "desktop (%dx%d logical units, %dx%d pixels)",
+		        p,
+		        iroundf(limit.w),
+		        iroundf(limit.h),
+		        iroundf(limit_px.w),
+		        iroundf(limit_px.h));
+
+		return viewport;
+
+	} else {
+		log_invalid_viewport_setting_warning(pref);
+		return {};
+	}
+}
+
+static constexpr auto MinRelativeScaleFactor = 20.0f;
+static constexpr auto MaxRelativeScaleFactor = 300.0f;
+
+static std::optional<ViewportSettings> parse_relative_viewport_modes(const std::string& pref)
+{
+	const auto parts = split(pref);
+
+	if (parts.size() == 3 && parts[0] == "relative") {
+		const auto width_scale_opt = parse_percentage_with_optional_percent_sign(
+		        parts[1]);
+
+		const auto height_scale_opt = parse_percentage_with_optional_percent_sign(
+		        parts[2]);
+
+		if (!width_scale_opt) {
+			const auto extra_info = "Invalid horizontal scale";
+			log_invalid_viewport_setting_warning(pref, extra_info);
+			return {};
+		}
+		if (!height_scale_opt) {
+			const auto extra_info = "Invalid vertical scale";
+			log_invalid_viewport_setting_warning(pref, extra_info);
+			return {};
+		}
+
+		const auto width_scale  = *width_scale_opt;
+		const auto height_scale = *height_scale_opt;
+
+		auto is_within_bounds = [&](const float scale) {
+			return (scale >= MinRelativeScaleFactor ||
+			        scale <= MaxRelativeScaleFactor);
+		};
+
+		if (!is_within_bounds(width_scale)) {
+			const auto extra_info = format_string(
+			        "Horizontal scale must be within the %.1f-%1.f%% range",
+			        MinRelativeScaleFactor,
+			        MaxRelativeScaleFactor);
+
+			log_invalid_viewport_setting_warning(pref, extra_info);
+			return {};
+		}
+		if (!is_within_bounds(height_scale)) {
+			const auto extra_info = format_string(
+			        "Vertical scale must be within the %.1f-%1.f%% range",
+			        MinRelativeScaleFactor,
+			        MaxRelativeScaleFactor);
+
+			log_invalid_viewport_setting_warning(pref, extra_info);
+			return {};
+		}
+
+		ViewportSettings viewport      = {};
+		viewport.mode                  = ViewportMode::Relative;
+		viewport.relative.width_scale  = width_scale / 100.f;
+		viewport.relative.height_scale = height_scale / 100.f;
+
+		LOG_MSG("DISPLAY: Scaling viewport by %2.4g%% horizontally and %2.4g%% vertically ",
+		        width_scale,
+		        height_scale);
+
+		return viewport;
+
+	} else {
+		log_invalid_viewport_setting_warning(pref);
+		return {};
+	}
+}
+
+static std::optional<ViewportSettings> parse_viewport_settings(const std::string& pref)
+{
+	if (starts_with(pref, "relative")) {
+		return parse_relative_viewport_modes(pref);
+	} else {
+		return parse_fit_viewport_modes(pref);
+	}
+}
+
+static ViewportSettings viewport_settings = {};
+
+static ViewportSettings get_default_viewport_settings()
+{
+	ViewportSettings viewport = {};
+
+	viewport      = {};
+	viewport.mode = ViewportMode::Fit;
+
+	return viewport;
+}
+
+DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canvas_px)
+{
+	const auto& viewport = viewport_settings;
+	const auto dpi_scale = GFX_GetDpiScaleFactor();
+
+	switch (viewport.mode) {
+	case ViewportMode::Fit: {
+		auto viewport_px = [&] {
+			if (viewport.fit.limit_size) {
+				return viewport.fit.limit_size->Copy().ScaleSize(
+				        dpi_scale);
+
+			} else if (viewport.fit.desktop_scale) {
+				auto desktop_px = GFX_GetDesktopSize().ScaleSize(dpi_scale);
+
+				return desktop_px.ScaleSize(*viewport.fit.desktop_scale);
+
+			} else {
+				// The viewport equals the canvas size in
+				// Fit mode without parameters
+				return canvas_px;
+			}
+		}();
+
+		if (canvas_px.Contains(viewport_px)) {
+			return viewport_px;
+		} else {
+			return viewport_px.Intersect(canvas_px);
+		}
+	}
+
+	case ViewportMode::Relative: {
+		const auto restricted_canvas_px = DosBox::Rect{4, 3}.ScaleSizeToFit(
+		        canvas_px);
+
+		return restricted_canvas_px.Copy()
+		        .ScaleWidth(viewport.relative.width_scale)
+		        .ScaleHeight(viewport.relative.height_scale);
+	}
+
+	default: assertm(false, "Invalid ViewportMode value"); return {};
+	}
+}
+
 const std::string RENDER_GetCgaColorsSetting()
 {
 	return get_render_section()->Get_string("cga_colors");
@@ -805,8 +1048,8 @@ static void init_render_settings(Section_prop& secprop)
 	        "            displayed with square pixels. Most 320x200 games will appear\n"
 	        "            squashed, but a minority of titles (e.g., DOS ports of PAL Amiga\n"
 	        "            games) need square pixels to appear as the artists intended.\n"
-	        "  stretch:  Calculate the aspect ratio from the viewport's dimensions. Combined\n"
-	        "            with 'viewport_resolution', this mode is useful to force arbitrary\n"
+	        "  stretch:  Calculate the aspect ratio from the viewport's dimensions.\n"
+	        "            Combined with 'viewport', this mode is useful to force arbitrary\n"
 	        "            aspect ratios (e.g., stretching DOS games to fullscreen on 16:9\n"
 	        "            displays) and to emulate the horizontal and vertical stretch\n"
 	        "            controls of CRT monitors.\n");
@@ -818,10 +1061,10 @@ static void init_render_settings(Section_prop& secprop)
 	string_prop->Set_help(
 	        "Constrain the horizontal or vertical scaling factor to the largest integer\n"
 	        "value so the image still fits into the viewport. The configured aspect ratio is\n"
-	        "always maintained according to the 'aspect' and 'viewport_resolution' settings,\n"
-	        "which may result in a non-integer scaling factor in the other dimension.\n"
-	        "If the image is larger than the viewport, the integer scaling constraint is\n"
-	        "auto-disabled (same as 'off'). Possible values:\n"
+	        "always maintained according to the 'aspect' and 'viewport' settings, which may\n"
+	        "result in a non-integer scaling factor in the other dimension. If the image is\n"
+	        "larger than the viewport, the integer scaling constraint is auto-disabled (same\n"
+	        "as 'off'). Possible values:\n"
 	        "  auto:        'vertical' mode auto-enabled for adaptive CRT shaders only\n"
 	        "               (see 'glshader'), otherwise 'off' (default).\n"
 	        "  vertical:    Constrain the vertical scaling factor to integer values.\n"
@@ -834,6 +1077,29 @@ static void init_render_settings(Section_prop& secprop)
 	const char* integer_scaling_values[] = {
 	        "auto", "vertical", "horizontal", "off", nullptr};
 	string_prop->Set_values(integer_scaling_values);
+
+	string_prop = secprop.Add_path("viewport", always, "fit");
+	string_prop->Set_help(
+	        "Set the viewport size (maximum drawable area). The video output is always\n"
+	        "contained within the viewport while taking the configured aspect ratio into\n"
+	        "account (see 'aspect'). Possible values:\n"
+	        "  fit:             Fit the viewport into the available window/screen (default).\n"
+	        "                   There might be padding (black areas) around the image with\n"
+	        "                   'integer_scaling' enabled.\n"
+	        "  WxH:             Set a fixed viewport size in WxH format in logical units\n"
+	        "                   (e.g., 960x720). The specified size must not be larger than\n"
+	        "                   the desktop. If it's larger than the window size, it's\n"
+	        "                   scaled to fit within the window.\n"
+	        "  N%:              Similar to 'WxH' but the size is specified as a percentage\n"
+	        "                   of the desktop size.\n"
+	        "  relative H% V%:  The viewport is set to a 4:3 aspect ratio rectangle fit into\n"
+	        "                   the available window/screen, then it's scaled by the H and V\n"
+	        "                   horizontal and vertical scaling factors (valid range is from\n"
+	        "                   20% to 300%). The resulting viewport is allowed to extend\n"
+	        "                   beyond the window/screen. Useful to force arbitrary display\n"
+	        "                   aspect ratios with 'aspect = stretch' and to zoom into the\n"
+	        "                   image. This effectively emulates the horizontal and vertical\n"
+	        "                   stretch controls of CRT monitors.");
 
 	string_prop = secprop.Add_string("monochrome_palette",
 	                                 always,
@@ -889,7 +1155,7 @@ static void init_render_settings(Section_prop& secprop)
 	string_prop->Set_help(
 	        "Software scalers are deprecated in favour of hardware-accelerated options:\n"
 	        "  - If you used the normal2x/3x scalers, set the desired 'windowresolution'\n"
-	        "    or 'viewport_resolution' instead, or consider using 'integer_scaling'.\n"
+	        "    or 'viewport' instead, or consider using 'integer_scaling'.\n"
 	        "  - If you used an advanced scaler, consider one of the 'glshader'\n"
 	        "    options instead.");
 
@@ -902,7 +1168,7 @@ static void init_render_settings(Section_prop& secprop)
 	        "                          people experienced the game at the time of release\n"
 	        "                          (default). The appropriate shader variant is\n"
 	        "                          automatically selected based the graphics standard of\n"
-	        "                          the current video mode and the viewport resolution,\n"
+	        "                          the current video mode and the viewport size,\n"
 	        "                          irrespective of the 'machine' setting. This means that\n"
 	        "                          even on an emulated VGA card you'll get authentic\n"
 	        "                          single-scanned EGA monitor emulation with visible\n"
@@ -994,6 +1260,7 @@ void RENDER_Init(Section* sec)
 	const auto prev_force_vga_single_scan   = force_vga_single_scan;
 	const auto prev_force_no_pixel_doubling = force_no_pixel_doubling;
 	const auto prev_integer_scaling_mode    = GFX_GetIntegerScalingMode();
+	const auto prev_viewport_settings       = viewport_settings;
 	const auto prev_aspect_ratio_correction_mode = aspect_ratio_correction_mode;
 
 	render.pal.first = 256;
@@ -1001,6 +1268,15 @@ void RENDER_Init(Section* sec)
 
 	// Get aspect ratio correction mode & force square pixels if requested
 	aspect_ratio_correction_mode = get_aspect_ratio_correction_mode_setting();
+
+	if (const auto& settings = parse_viewport_settings(
+	            section->Get_string("viewport").c_str());
+	    settings) {
+		viewport_settings = *settings;
+	} else {
+		viewport_settings = get_default_viewport_settings();
+		set_default_viewport_setting();
+	}
 
 	// Set monochrome palette
 	const auto mono_palette = to_monochrome_palette_enum(
@@ -1018,6 +1294,7 @@ void RENDER_Init(Section* sec)
 
 	const auto needs_reinit =
 	        ((aspect_ratio_correction_mode != prev_aspect_ratio_correction_mode) ||
+	         (viewport_settings != prev_viewport_settings) ||
 	         (render.scale.size != prev_scale_size) ||
 	         (GFX_GetIntegerScalingMode() != prev_integer_scaling_mode) ||
 	         shader_changed ||

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -598,8 +598,7 @@ static void setup_scan_and_pixel_doubling()
 	VGA_EnablePixelDoubling(!force_no_pixel_doubling);
 }
 
-bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width_px,
-                                  [[maybe_unused]] const uint16_t canvas_height_px,
+bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const DosBox::Rect canvas_size_px,
                                   [[maybe_unused]] const VideoMode& video_mode,
                                   [[maybe_unused]] const bool reinit_render)
 {
@@ -612,14 +611,12 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const uint16_t canvas_width_p
 	// uninitialised VideoMode param with width and height set to 0 which
 	// results in a crash. The proper fix is to make the init sequence 100%
 	// identical on all platforms, but in the interim this workaround will do.
-	if (canvas_width_px == 0 || canvas_height_px == 0 ||
+	if (canvas_size_px.w == 0 || canvas_size_px.h == 0 ||
 	    video_mode.width == 0 || video_mode.height == 0) {
 		return false;
 	}
 
-	get_shader_manager().NotifyRenderParametersChanged(canvas_width_px,
-	                                                   canvas_height_px,
-	                                                   video_mode);
+	get_shader_manager().NotifyRenderParametersChanged(canvas_size_px, video_mode);
 
 	const auto new_shader_name = get_shader_manager().GetCurrentShaderInfo().name;
 
@@ -658,11 +655,9 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 		video_mode.has_vga_colors = true;
 
 		// We are potentially auto-switching to a VGA shader now.
-		const auto canvas_size_px = GFX_GetCanvasSizeInPixels();
-
 		constexpr auto reinit_render = true;
-		RENDER_MaybeAutoSwitchShader(iroundf(canvas_size_px.w),
-		                             iroundf(canvas_size_px.h),
+
+		RENDER_MaybeAutoSwitchShader(GFX_GetCanvasSizeInPixels(),
 		                             video_mode,
 		                             reinit_render);
 	}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -658,11 +658,11 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 		video_mode.has_vga_colors = true;
 
 		// We are potentially auto-switching to a VGA shader now.
-		const auto canvas_px = GFX_GetCanvasSizeInPixels();
+		const auto canvas_size_px = GFX_GetCanvasSizeInPixels();
 
 		constexpr auto reinit_render = true;
-		RENDER_MaybeAutoSwitchShader(iroundf(canvas_px.w),
-		                             iroundf(canvas_px.h),
+		RENDER_MaybeAutoSwitchShader(iroundf(canvas_size_px.w),
+		                             iroundf(canvas_size_px.h),
 		                             video_mode,
 		                             reinit_render);
 	}
@@ -976,7 +976,7 @@ static ViewportSettings get_default_viewport_settings()
 	return viewport;
 }
 
-DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canvas_px)
+DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canvas_size_px)
 {
 	const auto& viewport = viewport_settings;
 	const auto dpi_scale = GFX_GetDpiScaleFactor();
@@ -989,27 +989,28 @@ DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canva
 				        dpi_scale);
 
 			} else if (viewport.fit.desktop_scale) {
-				auto desktop_px = GFX_GetDesktopSize().ScaleSize(dpi_scale);
+				auto desktop_px = GFX_GetDesktopSize().ScaleSize(
+				        dpi_scale);
 
 				return desktop_px.ScaleSize(*viewport.fit.desktop_scale);
 
 			} else {
 				// The viewport equals the canvas size in
 				// Fit mode without parameters
-				return canvas_px;
+				return canvas_size_px;
 			}
 		}();
 
-		if (canvas_px.Contains(viewport_px)) {
+		if (canvas_size_px.Contains(viewport_px)) {
 			return viewport_px;
 		} else {
-			return viewport_px.Intersect(canvas_px);
+			return viewport_px.Intersect(canvas_size_px);
 		}
 	}
 
 	case ViewportMode::Relative: {
 		const auto restricted_canvas_px = DosBox::Rect{4, 3}.ScaleSizeToFit(
-		        canvas_px);
+		        canvas_size_px);
 
 		return restricted_canvas_px.Copy()
 		        .ScaleWidth(viewport.relative.width_scale)

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -857,8 +857,7 @@ static void init_render_settings(Section_prop& secprop)
 	string_prop = secprop.Add_string("glshader", always, "crt-auto");
 	string_prop->Set_help(
 	        "Set an adaptive CRT monitor emulation shader or a regular GLSL shader in OpenGL \n"
-	        "output modes.\n"
-	        "Adaptive CRT shader options:\n"
+	        "output modes. Adaptive CRT shader options:\n"
 	        "  crt-auto:               A CRT shader that prioritises developer intent and how\n"
 	        "                          people experienced the game at the time of release\n"
 	        "                          (default). The appropriate shader variant is\n"

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -546,7 +546,6 @@ void RENDER_SetSize(const uint16_t width, const uint16_t height,
 	render_reset();
 }
 
-static bool force_square_pixels     = false;
 static bool force_vga_single_scan   = false;
 static bool force_no_pixel_doubling = false;
 
@@ -726,23 +725,49 @@ static const char* to_string(const enum MonochromePalette palette)
 	}
 }
 
-bool RENDER_IsAspectRatioCorrectionEnabled()
+static AspectRatioCorrectionMode aspect_ratio_correction_mode = {};
+
+static AspectRatioCorrectionMode get_aspect_ratio_correction_mode_setting()
 {
-	return get_render_section()->Get_bool("aspect");
+	const std::string mode = get_render_section()->Get_string("aspect");
+
+	if (has_false(mode)) {
+		return AspectRatioCorrectionMode::Off;
+
+	} else if (has_true(mode)) {
+		return AspectRatioCorrectionMode::On;
+
+	} else if (mode == "stretch") {
+		return AspectRatioCorrectionMode::Stretch;
+
+	} else {
+		LOG_WARNING("RENDER: Invalid 'aspect' setting '%s', using 'on'",
+		            mode.c_str());
+		return AspectRatioCorrectionMode::On;
+	}
+}
+
+AspectRatioCorrectionMode RENDER_GetAspectRatioCorrectionMode()
+{
+	return aspect_ratio_correction_mode;
 }
 
 static IntegerScalingMode get_integer_scaling_mode_setting()
 {
 	const std::string mode = get_render_section()->Get_string("integer_scaling");
 
-	if (mode == "off") {
+	if (has_false(mode)) {
 		return IntegerScalingMode::Off;
+
 	} else if (mode == "auto") {
 		return IntegerScalingMode::Auto;
+
 	} else if (mode == "horizontal") {
 		return IntegerScalingMode::Horizontal;
+
 	} else if (mode == "vertical") {
 		return IntegerScalingMode::Vertical;
+
 	} else {
 		LOG_WARNING("RENDER: Invalid 'integer_scaling' setting: '%s', using 'auto'",
 		            mode.c_str());
@@ -765,16 +790,29 @@ static void init_render_settings(Section_prop& secprop)
 	int_prop->Set_help(
 	        "Consider capping frame rates using the 'host_rate' setting.");
 
-	auto* bool_prop = secprop.Add_bool("aspect", always, true);
-	bool_prop->Set_help(
-	        "Apply aspect ratio correction for modern square-pixel flat-screen displays,\n"
-	        "so DOS resolutions with non-square pixels appear as they would on a 4:3 display\n"
-	        "aspect ratio CRT monitor the majority of DOS games were designed for (enabled\n"
-	        "by default). This setting only affects video modes that use non-square pixels,\n"
-	        "such as 320x200 or 640x400; square-pixel modes, such as 320x240, 640x480, and\n"
-	        "800x600 are displayed as-is.");
+	auto* string_prop = secprop.Add_string("aspect", always, "on");
+	string_prop->Set_help(
+	        "Set the aspect ratio correction mode (enabled by default).\n"
+	        "  on:       Apply aspect ratio correction for modern square-pixel flat-screen\n"
+	        "            displays, so DOS video modes with non-square pixels appear as they\n"
+	        "            would on a 4:3 display aspect ratio CRT monitor the majority of DOS\n"
+	        "            games were designed for. This setting only affects video modes that\n"
+	        "            use non-square pixels, such as 320x200 or 640x400; square-pixel\n"
+	        "            modes (e.g., 320x240, 640x480, and 800x600), are displayed as-is.\n"
+	        "  off:      Don't apply aspect ratio correction; all DOS video modes will be\n"
+	        "            displayed with square pixels. Most 320x200 games will appear\n"
+	        "            squashed, but a minority of titles (e.g., DOS ports of PAL Amiga\n"
+	        "            games) need square pixels to appear as the artists intended.\n"
+	        "  stretch:  Calculate the aspect ratio from the viewport's dimensions. Combined\n"
+	        "            with 'viewport_resolution', this mode is useful to force arbitrary\n"
+	        "            aspect ratios (e.g., stretching DOS games to fullscreen on 16:9\n"
+	        "            displays) and to emulate the horizontal and vertical stretch\n"
+	        "            controls of CRT monitors.\n");
 
-	auto* string_prop = secprop.Add_string("integer_scaling", always, "auto");
+	const char* aspect_values[] = {"on", "off", "stretch", nullptr};
+	string_prop->Set_values(aspect_values);
+
+	string_prop = secprop.Add_string("integer_scaling", always, "auto");
 	string_prop->Set_help(
 	        "Constrain the horizontal or vertical scaling factor to integer values.\n"
 	        "The correct aspect ratio is always maintained according to the 'aspect'\n"
@@ -950,18 +988,20 @@ void RENDER_Init(Section* sec)
 	// For restarting the renderer
 	static auto running = false;
 
+	// Store previous values of settings that should trigger a reinit
 	const auto prev_scale_size              = render.scale.size;
-	const auto prev_force_square_pixels     = force_square_pixels;
 	const auto prev_force_vga_single_scan   = force_vga_single_scan;
 	const auto prev_force_no_pixel_doubling = force_no_pixel_doubling;
 	const auto prev_integer_scaling_mode    = GFX_GetIntegerScalingMode();
+	const auto prev_aspect_ratio_correction_mode = aspect_ratio_correction_mode;
 
 	render.pal.first = 256;
 	render.pal.last  = 0;
 
-	force_square_pixels = !section->Get_bool("aspect");
-	VGA_ForceSquarePixels(force_square_pixels);
+	// Get aspect ratio correction mode & force square pixels if requested
+	aspect_ratio_correction_mode = get_aspect_ratio_correction_mode_setting();
 
+	// Set monochrome palette
 	const auto mono_palette = to_monochrome_palette_enum(
 	        section->Get_string("monochrome_palette").c_str());
 	VGA_SetMonochromePalette(mono_palette);
@@ -976,7 +1016,7 @@ void RENDER_Init(Section* sec)
 	setup_scan_and_pixel_doubling();
 
 	const auto needs_reinit =
-	        ((force_square_pixels != prev_force_square_pixels) ||
+	        ((aspect_ratio_correction_mode != prev_aspect_ratio_correction_mode) ||
 	         (render.scale.size != prev_scale_size) ||
 	         (GFX_GetIntegerScalingMode() != prev_integer_scaling_mode) ||
 	         shader_changed ||

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1226,14 +1226,10 @@ static void notify_new_mouse_screen_params()
 
 	MouseScreenParams params = {};
 
-	auto to_logical_units = [](const int value) {
-		return check_cast<int32_t>(lround(value / sdl.desktop.dpi_scale));
-	};
-
-	params.clip_x = to_logical_units(sdl.draw_rect_px.x);
-	params.clip_y = to_logical_units(sdl.draw_rect_px.y);
-	params.res_x  = to_logical_units(sdl.draw_rect_px.w);
-	params.res_y  = to_logical_units(sdl.draw_rect_px.h);
+	// It is important to scale not just the size of the rectangle but also
+	// its starting point by the inverse of the DPI scale factor.
+	params.draw_rect =
+	        to_rect(sdl.draw_rect_px).Copy().Scale(1.0f / sdl.desktop.dpi_scale);
 
 	int abs_x = 0;
 	int abs_y = 0;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1224,16 +1224,14 @@ static void NewMouseScreenParams()
 
 	MouseScreenParams params = {};
 
-	// When DPI scaling is enabled, mouse coordinates are reported on
-	// "client points" grid, not physical pixels.
-	auto adapt = [](const int value) {
-		return lround(value / sdl.desktop.dpi_scale);
+	auto to_logical_units = [](const int value) {
+		return check_cast<uint32_t>(lround(value / sdl.desktop.dpi_scale));
 	};
 
-	params.clip_x = check_cast<uint32_t>(adapt(sdl.clip_px.x));
-	params.clip_y = check_cast<uint32_t>(adapt(sdl.clip_px.y));
-	params.res_x  = check_cast<uint32_t>(adapt(sdl.clip_px.w));
-	params.res_y  = check_cast<uint32_t>(adapt(sdl.clip_px.h));
+	params.clip_x = to_logical_units(sdl.clip_px.x);
+	params.clip_y = to_logical_units(sdl.clip_px.y);
+	params.res_x  = to_logical_units(sdl.clip_px.w);
+	params.res_y  = to_logical_units(sdl.clip_px.h);
 
 	int abs_x = 0;
 	int abs_y = 0;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1232,13 +1232,20 @@ static void NewMouseScreenParams()
 	MOUSE_NewScreenParams(params);
 }
 
+static bool is_aspect_ratio_correction_enabled()
+{
+	return (RENDER_GetAspectRatioCorrectionMode() ==
+	        AspectRatioCorrectionMode::On);
+}
+
 static void update_fallback_dimensions(const double dpi_scale)
 {
 	// TODO This only works for 320x200 games. We cannot make hardcoded
 	// assumptions about aspect ratios in general, e.g. the pixel aspect ratio
 	// is 1:1 for 640x480 games both with 'aspect = on` and 'aspect = off'.
-	const auto fallback_height =
-	        (RENDER_IsAspectRatioCorrectionEnabled() ? 480 : 400) / dpi_scale;
+	const auto fallback_height = (is_aspect_ratio_correction_enabled() ? 480
+	                                                                   : 400) /
+	                             dpi_scale;
 
 	assert(dpi_scale > 0);
 	const auto fallback_width = 640 / dpi_scale;
@@ -3634,7 +3641,7 @@ static void GUI_StartUp(Section* sec)
 		GFX_ObtainDisplayDimensions();
 	}
 
-	set_output(section, RENDER_IsAspectRatioCorrectionEnabled());
+	set_output(section, is_aspect_ratio_correction_enabled());
 
 	/* Get some Event handlers */
 	MAPPER_AddHandler(GFX_RequestExit, SDL_SCANCODE_F9, PRIMARY_MOD,
@@ -3720,7 +3727,7 @@ void GFX_RegenerateWindow(Section *sec) {
 		return;
 	}
 	remove_window();
-	set_output(sec, RENDER_IsAspectRatioCorrectionEnabled());
+	set_output(sec, is_aspect_ratio_correction_enabled());
 	GFX_ResetScreen();
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4326,13 +4326,14 @@ static void config_add_sdl() {
 
 	pstring = sdl_sec->Add_string("windowresolution", on_start, "default");
 	pstring->Set_help(
-	        "Set window size when running in windowed mode:\n"
-	        "  default:   Select the best option based on your environment and\n"
-	        "             other settings.\n"
+	        "Set intial window size for windowed mode. You can still resize the window\n"
+	        "after startup.\n"
+	        "  default:   Select the best option based on your environment and other\n"
+	        "             settings (such as whether aspect ratio correction is enabled).\n"
 	        "  small, medium, large (s, m, l):\n"
 	        "             Size the window relative to the desktop.\n"
-	        "  <custom>:  Scale the window to the given dimensions in WxH format.\n"
-	        "             For example: 1024x768.");
+	        "  WxH:       Specify window size in WxH format in logical units\n"
+	        "             (e.g., 1024x768).");
 
 	pstring = sdl_sec->Add_path("viewport_resolution", always, "fit");
 	pstring->Set_help(
@@ -4343,9 +4344,9 @@ static void config_add_sdl() {
 
 	pstring = sdl_sec->Add_string("window_position", always, "auto");
 	pstring->Set_help(
-	        "Set initial window position when running in windowed mode:\n"
+	        "Set initial window position for windowed mode:\n"
 	        "  auto:      Let the window manager decide the position (default).\n"
-	        "  <custom>:  Set window position in X,Y format. For example: 250,100\n"
+	        "  X,Y:       Set window position in X,Y format (e.g., 250,100).\n"
 	        "             0,0 is the top-left corner of the screen.");
 
 	Pbool = sdl_sec->Add_bool("window_decorations", always, true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -717,7 +717,8 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 
 static DosBox::Rect calc_draw_size_in_pixels(const DosBox::Rect& canvas_size_px)
 {
-	const DosBox::Rect render_size_px = {sdl.draw.width_px, sdl.draw.height_px};
+	const DosBox::Rect render_size_px = {sdl.draw.render_width_px,
+	                                     sdl.draw.render_height_px};
 
 	const auto r = GFX_CalcDrawSizeInPixels(canvas_size_px,
 	                                        render_size_px,
@@ -1516,8 +1517,8 @@ static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
 	        sdl.draw.render_pixel_aspect_ratio);
 
 	if (window_width == 0 && window_height == 0) {
-		window_width  = iround(sdl.draw.width_px * draw_scale_x);
-		window_height = iround(sdl.draw.height_px * draw_scale_y);
+		window_width  = iround(sdl.draw.render_width_px * draw_scale_x);
+		window_height = iround(sdl.draw.render_height_px * draw_scale_y);
 	}
 
 	sdl.window = SetWindowMode(rendering_backend,
@@ -1687,7 +1688,7 @@ static void initialize_sdl_window_size(SDL_Window* sdl_window,
 	}
 }
 
-uint8_t GFX_SetSize(const int width_px, const int height_px,
+uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
                     const Fraction& render_pixel_aspect_ratio, const uint8_t flags,
                     const VideoMode& video_mode, GFX_CallBack_t callback)
 {
@@ -1703,15 +1704,15 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 	const bool double_height = flags & GFX_DBL_H;
 
 	sdl.draw.has_changed = (sdl.video_mode != video_mode ||
-	                        sdl.draw.width_px != width_px ||
-	                        sdl.draw.height_px != height_px ||
+	                        sdl.draw.render_width_px != render_width_px ||
+	                        sdl.draw.render_height_px != render_height_px ||
 	                        sdl.draw.width_was_doubled != double_width ||
 	                        sdl.draw.height_was_doubled != double_height ||
 	                        sdl.draw.render_pixel_aspect_ratio !=
 	                                render_pixel_aspect_ratio);
 
-	sdl.draw.width_px                  = width_px;
-	sdl.draw.height_px                 = height_px;
+	sdl.draw.render_width_px           = render_width_px;
+	sdl.draw.render_height_px          = render_height_px;
 	sdl.draw.width_was_doubled         = double_width;
 	sdl.draw.height_was_doubled        = double_height;
 	sdl.draw.render_pixel_aspect_ratio = render_pixel_aspect_ratio;
@@ -1746,8 +1747,8 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 		sdl.texture.texture = SDL_CreateTexture(sdl.renderer,
 		                                        texture_format,
 		                                        SDL_TEXTUREACCESS_STREAMING,
-		                                        width_px,
-		                                        height_px);
+		                                        render_width_px,
+		                                        render_height_px);
 
 		if (!sdl.texture.texture) {
 			SDL_DestroyRenderer(sdl.renderer);
@@ -1763,7 +1764,7 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 		}
 		assert(texture_input_surface == nullptr); // ensure we don't leak
 		texture_input_surface = SDL_CreateRGBSurfaceWithFormat(
-		        0, width_px, height_px, 32, texture_format);
+		        0, render_width_px, render_height_px, 32, texture_format);
 		if (!texture_input_surface) {
 			E_Exit("SDL: Error while preparing texture input");
 		}
@@ -1849,11 +1850,11 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 #endif
 
 		if (use_npot_texture) {
-			texsize_w_px = width_px;
-			texsize_h_px = height_px;
+			texsize_w_px = render_width_px;
+			texsize_h_px = render_height_px;
 		} else {
-			texsize_w_px = 2 << int_log2(width_px);
-			texsize_h_px = 2 << int_log2(height_px);
+			texsize_w_px = 2 << int_log2(render_width_px);
+			texsize_h_px = 2 << int_log2(render_height_px);
 		}
 
 		if (texsize_w_px > sdl.opengl.max_texsize ||
@@ -2011,10 +2012,10 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 		}
 
 		/* Create the texture and display list */
-		const auto framebuffer_bytes = static_cast<size_t>(width_px) *
-		                               height_px * MAX_BYTES_PER_PIXEL;
+		const auto framebuffer_bytes = static_cast<size_t>(render_width_px) *
+		                               render_height_px * MAX_BYTES_PER_PIXEL;
 		sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
-		sdl.opengl.pitch = width_px * 4;
+		sdl.opengl.pitch = render_width_px * 4;
 
 		// One-time initialize the window size
 		if (!sdl.desktop.window.adjusted_initial_size) {
@@ -2128,14 +2129,14 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 			glUniform2f(sdl.opengl.ruby.texture_size,
 			            (GLfloat)texsize_w_px, (GLfloat)texsize_h_px);
 			glUniform2f(sdl.opengl.ruby.input_size,
-			            (GLfloat)width_px,
-			            (GLfloat)height_px);
+			            (GLfloat)render_width_px,
+			            (GLfloat)render_height_px);
 			glUniform2f(sdl.opengl.ruby.output_size, (GLfloat)sdl.clip_px.w, (GLfloat)sdl.clip_px.h);
 			// The following uniform is *not* set right now
 			sdl.opengl.actual_frame_count = 0;
 		} else {
-			GLfloat tex_width = ((GLfloat)width_px / (GLfloat)texsize_w_px);
-			GLfloat tex_height = ((GLfloat)height_px / (GLfloat)texsize_h_px);
+			GLfloat tex_width = ((GLfloat)render_width_px / (GLfloat)texsize_w_px);
+			GLfloat tex_height = ((GLfloat)render_height_px / (GLfloat)texsize_h_px);
 
 			glShadeModel(GL_FLAT);
 			glMatrixMode(GL_MODELVIEW);
@@ -2173,8 +2174,8 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 	update_vsync_state();
 
 	if (sdl.draw.has_changed) {
-		log_display_properties(sdl.draw.width_px,
-		                       sdl.draw.height_px,
+		log_display_properties(sdl.draw.render_width_px,
+		                       sdl.draw.render_height_px,
 		                       sdl.video_mode,
 		                       {},
 		                       sdl.rendering_backend);
@@ -2371,8 +2372,8 @@ void GFX_SwitchFullScreen()
 	                  ? to_sdl_rect(get_canvas_size_in_pixels(sdl.rendering_backend))
 	                  : canvas_px;
 
-	log_display_properties(sdl.draw.width_px,
-	                       sdl.draw.height_px,
+	log_display_properties(sdl.draw.render_width_px,
+	                       sdl.draw.render_height_px,
 	                       sdl.video_mode,
 	                       canvas_px,
 	                       sdl.rendering_backend);
@@ -2620,14 +2621,14 @@ static void update_frame_gl(const uint16_t* changedLines)
 		const auto pitch = sdl.opengl.pitch;
 		int y = 0;
 		size_t index = 0;
-		while (y < sdl.draw.height_px) {
+		while (y < sdl.draw.render_height_px) {
 			if (!(index & 1)) {
 				y += changedLines[index];
 			} else {
 				const uint8_t *pixels = framebuf + y * pitch;
 				const int height_px = changedLines[index];
 				glTexSubImage2D(GL_TEXTURE_2D, 0, 0, y,
-				                sdl.draw.width_px, height_px, GL_BGRA_EXT,
+				                sdl.draw.render_width_px, height_px, GL_BGRA_EXT,
 				                GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
 				y += height_px;
 			}
@@ -2822,9 +2823,10 @@ static SDL_Window* set_default_window_mode()
 		return sdl.window;
 	}
 
-	// TODO: this cannot be correct; needs conversion to pixels
-	sdl.draw.width_px  = FallbackWindowSize.x;
-	sdl.draw.height_px = FallbackWindowSize.y;
+	// TODO: this cannot be correct; at least it would need conversion to
+	// pixels, and we can't correlate render and window dimensions like this
+	sdl.draw.render_width_px  = FallbackWindowSize.x;
+	sdl.draw.render_height_px = FallbackWindowSize.y;
 
 	if (sdl.desktop.fullscreen) {
 		sdl.desktop.lazy_init_window_size = true;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1218,8 +1218,7 @@ static void setup_presentation_mode(FrameMode &previous_mode)
 
 static void notify_new_mouse_screen_params()
 {
-	if (sdl.draw_rect_px.w <= 0 || sdl.draw_rect_px.h <= 0 ||
-	    sdl.draw_rect_px.x < 0 || sdl.draw_rect_px.y < 0) {
+	if (sdl.draw_rect_px.w <= 0 || sdl.draw_rect_px.h <= 0) {
 		// Filter out unusual parameters, which can be the result
 		// of window minimized due to ALT+TAB, for example
 		return;
@@ -1228,7 +1227,7 @@ static void notify_new_mouse_screen_params()
 	MouseScreenParams params = {};
 
 	auto to_logical_units = [](const int value) {
-		return check_cast<uint32_t>(lround(value / sdl.desktop.dpi_scale));
+		return check_cast<int32_t>(lround(value / sdl.desktop.dpi_scale));
 	};
 
 	params.clip_x = to_logical_units(sdl.draw_rect_px.x);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -715,10 +715,12 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 	return (default_driver_is_opengl ? SDL_WINDOW_OPENGL : 0);
 }
 
-static DosBox::Rect calc_viewport_in_pixels(const DosBox::Rect& canvas_px)
+static DosBox::Rect calc_draw_size_in_pixels(const DosBox::Rect& canvas_size_px)
 {
-	const auto r = GFX_CalcViewportInPixels(canvas_px,
-	                                        {sdl.draw.width_px, sdl.draw.height_px},
+	const DosBox::Rect render_size_px = {sdl.draw.width_px, sdl.draw.height_px};
+
+	const auto r = GFX_CalcDrawSizeInPixels(canvas_size_px,
+	                                        render_size_px,
 	                                        sdl.draw.render_pixel_aspect_ratio);
 
 	return {iroundf(r.x), iroundf(r.y), iroundf(r.w), iroundf(r.h)};
@@ -758,34 +760,30 @@ static DosBox::Rect get_canvas_size_in_pixels(
 // Logs the source and target resolution including describing scaling method
 // and pixel aspect ratio. Note that this function deliberately doesn't use
 // any global structs to disentangle it from the existing sdl-main design.
-static void log_display_properties(const int width_px, const int height_px,
+static void log_display_properties(const int render_width_px,
+                                   const int render_height_px,
                                    const VideoMode& video_mode,
-                                   const std::optional<SDL_Rect>& viewport_size_override_px,
+                                   const std::optional<SDL_Rect>& canvas_size_override_px,
                                    const RenderingBackend rendering_backend)
 {
-	// Get the viewport dimensions, with consideration for possible override
-	// values
-	auto get_viewport_size_in_pixels = [&]() -> std::pair<int, int> {
-		if (viewport_size_override_px) {
-			const auto vp = calc_viewport_in_pixels(
-			        {viewport_size_override_px->w,
-			         viewport_size_override_px->h});
+	const auto draw_size_px = [&]() -> DosBox::Rect {
+		if (canvas_size_override_px) {
+			return calc_draw_size_in_pixels(
+			        {canvas_size_override_px->w,
+			         canvas_size_override_px->h});
+		} else {
+			const auto canvas_px = get_canvas_size_in_pixels(
+			        rendering_backend);
 
-			return {vp.w, vp.h};
+			return calc_draw_size_in_pixels(canvas_px);
 		}
-		const auto canvas_px = get_canvas_size_in_pixels(rendering_backend);
-		const auto vp = calc_viewport_in_pixels(canvas_px);
-		return {vp.w, vp.h};
-	};
+	}();
 
-	const auto [viewport_w_px, viewport_h_px] = get_viewport_size_in_pixels();
+	assert(render_width_px > 0 && render_height_px > 0);
+	assert(draw_size_px.w > 0.0f && draw_size_px.h > 0.0f);
 
-	// Check expectations
-	assert(width_px > 0 && height_px > 0);
-	assert(viewport_w_px > 0 && viewport_h_px > 0);
-
-	const auto scale_x = static_cast<double>(viewport_w_px) / width_px;
-	const auto scale_y = static_cast<double>(viewport_h_px) / height_px;
+	const auto scale_x = static_cast<double>(draw_size_px.w) / render_width_px;
+	const auto scale_y = static_cast<double>(draw_size_px.h) / render_height_px;
 
 	[[maybe_unused]] const auto one_per_render_pixel_aspect = scale_y / scale_x;
 
@@ -807,17 +805,17 @@ static void log_display_properties(const int width_px, const int height_px,
 	        video_mode_desc.c_str(),
 	        refresh_rate,
 	        frame_mode,
-	        viewport_w_px,
-	        viewport_h_px,
+	        iroundf(draw_size_px.w),
+	        iroundf(draw_size_px.h),
 	        video_mode.pixel_aspect_ratio.Inverse().ToDouble(),
 	        static_cast<int32_t>(video_mode.pixel_aspect_ratio.Num()),
 	        static_cast<int32_t>(video_mode.pixel_aspect_ratio.Denom()));
 
 #if 0
-	LOG_MSG("DISPLAY: render width_px: %d, render height_px: %d, "
+	LOG_MSG("DISPLAY: render_width_px: %d, render_height_px: %d, "
 	        "render pixel aspect ratio: 1:%1.3g",
-	        width_px,
-	        height_px,
+	        render_width_px,
+	        render_height_px,
 	        one_per_render_pixel_aspect);
 #endif
 }
@@ -1820,7 +1818,7 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 		//         (canvas.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-		sdl.clip_px = to_sdl_rect(calc_viewport_in_pixels(canvas_px));
+		sdl.clip_px = to_sdl_rect(calc_draw_size_in_pixels(canvas_px));
 
 		if (SDL_RenderSetViewport(sdl.renderer, &sdl.clip_px) != 0)
 			LOG_ERR("SDL: Failed to set viewport: %s", SDL_GetError());
@@ -2035,7 +2033,7 @@ uint8_t GFX_SetSize(const int width_px, const int height_px,
 		//         (canvas_px.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-		sdl.clip_px = to_sdl_rect(calc_viewport_in_pixels(canvas_px));
+		sdl.clip_px = to_sdl_rect(calc_draw_size_in_pixels(canvas_px));
 		glViewport(sdl.clip_px.x, sdl.clip_px.y, sdl.clip_px.w, sdl.clip_px.h);
 
 		if (sdl.opengl.texture > 0) {
@@ -3176,12 +3174,12 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	        sdl.display_number);
 }
 
-DosBox::Rect GFX_CalcViewportInPixels(const DosBox::Rect& canvas_px,
-                                      const DosBox::Rect& draw_area_px,
+DosBox::Rect GFX_CalcDrawSizeInPixels(const DosBox::Rect& canvas_size_px,
+                                      const DosBox::Rect& render_size_px,
                                       const Fraction& render_pixel_aspect_ratio)
 {
-	assert(draw_area_px.w > 0.0f);
-	assert(draw_area_px.h > 0.0f);
+	assert(render_size_px.w > 0.0f);
+	assert(render_size_px.h > 0.0f);
 
 	const auto [draw_scale_x, draw_scale_y] = get_scale_factors_from_pixel_aspect_ratio(
 	        render_pixel_aspect_ratio);
@@ -3192,44 +3190,46 @@ DosBox::Rect GFX_CalcViewportInPixels(const DosBox::Rect& canvas_px,
 	assert(std::isfinite(draw_scale_y));
 
 	// Limit the window to the user's desired viewport, if configured
-	const auto bounds_px = calc_restricted_viewport_size_in_pixels(canvas_px);
+	const auto viewport_px = calc_restricted_viewport_size_in_pixels(canvas_size_px);
 
 	// It is important to calculate the image aspect ratio like this because
 	// the aspect ratio of the *image* itself it not always 4:3, in which
 	// case it would appear letter and/or pillarboxed on a real 4:3 display
 	// aspect ratio CRT monitor.
-	const auto image_aspect_ratio = (draw_area_px.w * draw_scale_x) /
-	                                (draw_area_px.h * draw_scale_y);
+	const auto image_aspect_ratio = (render_size_px.w * draw_scale_x) /
+	                                (render_size_px.h * draw_scale_y);
 
 	auto calc_bounded_dims_in_pixels = [&]() -> std::pair<int, int> {
 		// Calculate the viewport contingent on the aspect ratio of the
 		// viewport bounds versus display mode.
-		const auto bounds_aspect = static_cast<double>(bounds_px.w) /
-		                           bounds_px.h;
+		const auto bounds_aspect = static_cast<double>(viewport_px.w) /
+		                           viewport_px.h;
 
 		// TODO
 		if (bounds_aspect > image_aspect_ratio) {
-			const auto w = iround(bounds_px.h * image_aspect_ratio);
-			const auto h = bounds_px.h;
+			const auto w = iround(viewport_px.h * image_aspect_ratio);
+			const auto h = viewport_px.h;
 			return {w, h};
 		} else {
-			const auto w = bounds_px.w;
-			const auto h = iround(bounds_px.w / image_aspect_ratio);
+			const auto w = viewport_px.w;
+			const auto h = iround(viewport_px.w / image_aspect_ratio);
 			return {w, h};
 		}
 	};
 
 	auto calc_horiz_integer_scaling_dims_in_pixels = [&]() -> std::pair<int, int> {
 		auto integer_scale_factor = std::min(
-		        ifloor(bounds_px.w / draw_area_px.w),
-		        ifloor(bounds_px.h / (draw_area_px.w / image_aspect_ratio)));
+		        ifloor(viewport_px.w / render_size_px.w),
+		        ifloor(viewport_px.h /
+		               (render_size_px.w / image_aspect_ratio)));
 
 		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
 			return calc_bounded_dims_in_pixels();
 		} else {
-			const auto w = draw_area_px.w * integer_scale_factor;
-			const auto h = iround(draw_area_px.w * integer_scale_factor /
+			const auto w = render_size_px.w * integer_scale_factor;
+			const auto h = iround(render_size_px.w *
+			                      integer_scale_factor /
 			                      image_aspect_ratio);
 
 			return {w, h};
@@ -3237,63 +3237,64 @@ DosBox::Rect GFX_CalcViewportInPixels(const DosBox::Rect& canvas_px,
 	};
 
 	auto calc_vert_integer_scaling_dims_in_pixels = [&]() -> std::pair<int, int> {
-		auto integer_scale_factor = std::min(
-		        ifloor(bounds_px.h / draw_area_px.h),
-		        ifloor(bounds_px.w / (draw_area_px.h * image_aspect_ratio)));
+		auto integer_scale_factor =
+		        std::min(ifloor(viewport_px.h / render_size_px.h),
+		                 ifloor(viewport_px.w /
+		                        (render_size_px.h * image_aspect_ratio)));
 
 		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
 			return calc_bounded_dims_in_pixels();
 		} else {
-			const auto w = iround(draw_area_px.h * integer_scale_factor *
+			const auto w = iround(render_size_px.h * integer_scale_factor *
 			                      image_aspect_ratio);
-			const auto h = draw_area_px.h * integer_scale_factor;
+			const auto h = render_size_px.h * integer_scale_factor;
 
 			return {w, h};
 		}
 	};
 
-	int view_w_px = 0;
-	int view_h_px = 0;
+	int draw_w_px = 0;
+	int draw_h_px = 0;
 
 	switch (sdl.integer_scaling_mode) {
 	case IntegerScalingMode::Off: {
-		std::tie(view_w_px, view_h_px) = calc_bounded_dims_in_pixels();
+		std::tie(draw_w_px, draw_h_px) = calc_bounded_dims_in_pixels();
 		break;
 	}
 	case IntegerScalingMode::Auto:
 #if C_OPENGL
 		if (sdl.rendering_backend == RenderingBackend::OpenGl &&
 		    sdl.opengl.shader_info.is_adaptive) {
-			std::tie(view_w_px, view_h_px) =
+			std::tie(draw_w_px, draw_h_px) =
 			        calc_vert_integer_scaling_dims_in_pixels();
 		} else {
-			std::tie(view_w_px,
-			         view_h_px) = calc_bounded_dims_in_pixels();
+			std::tie(draw_w_px,
+			         draw_h_px) = calc_bounded_dims_in_pixels();
 		}
 #else
-		std::tie(view_w_px, view_h_px) = calc_bounded_dims_in_pixels();
+		std::tie(draw_w_x, draw_h_x) = calc_bounded_dims_in_pixels();
 #endif
 		break;
 
 	case IntegerScalingMode::Horizontal: {
-		std::tie(view_w_px,
-		         view_h_px) = calc_horiz_integer_scaling_dims_in_pixels();
+		std::tie(draw_w_px,
+		         draw_h_px) = calc_horiz_integer_scaling_dims_in_pixels();
 		break;
 	}
 	case IntegerScalingMode::Vertical:
-		std::tie(view_w_px,
-		         view_h_px) = calc_vert_integer_scaling_dims_in_pixels();
+		std::tie(draw_w_px,
+		         draw_h_px) = calc_vert_integer_scaling_dims_in_pixels();
 		break;
 
 	default: assertm(false, "Invalid IntegerScalingMode value");
 	}
 
 	// Calculate centered viewport position.
-	const int view_x_px = iroundf((canvas_px.w - view_w_px) / 2);
-	const int view_y_px = iroundf((canvas_px.h - view_h_px) / 2);
+	const int draw_x_px = iroundf((canvas_size_px.w - draw_w_px) / 2);
+	const int draw_y_px = iroundf((canvas_size_px.h - draw_h_px) / 2);
 
-	return {view_x_px, view_y_px, view_w_px, view_h_px};
+	return {draw_x_px, draw_y_px, draw_w_px, draw_h_px};
 }
 
 IntegerScalingMode GFX_GetIntegerScalingMode()
@@ -3758,7 +3759,7 @@ static void handle_video_resize(int width, int height)
 
 	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
 
-	sdl.clip_px = to_sdl_rect(calc_viewport_in_pixels(canvas_px));
+	sdl.clip_px = to_sdl_rect(calc_draw_size_in_pixels(canvas_px));
 
 	if (sdl.rendering_backend == RenderingBackend::Texture) {
 		SDL_RenderSetViewport(sdl.renderer, &sdl.clip_px);
@@ -4016,7 +4017,7 @@ bool GFX_Events()
 				        sdl.rendering_backend);
 
 				sdl.clip_px = to_sdl_rect(
-				        calc_viewport_in_pixels(canvas_px));
+				        calc_draw_size_in_pixels(canvas_px));
 
 				if (sdl.rendering_backend == RenderingBackend::Texture) {
 					SDL_RenderSetViewport(sdl.renderer,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -470,6 +470,16 @@ static double get_host_refresh_rate()
 	return rate;
 }
 
+static Section_prop* get_sdl_section()
+{
+	assert(control);
+
+	auto sdl_section = static_cast<Section_prop*>(control->GetSection("sdl"));
+	assert(sdl_section);
+
+	return sdl_section;
+}
+
 // Reset and populate the vsync settings from the user's conf setting. This is
 // called on-demand after startup and on output-mode changes (ie: switching from
 // an SDL-based drawing context to an OpenGL-based context).
@@ -478,7 +488,7 @@ static void initialize_vsync_settings()
 {
 	sdl.vsync = {};
 
-	const auto section = dynamic_cast<Section_prop*>(control->GetSection("sdl"));
+	const auto section = get_sdl_section();
 	const std::string user_pref = (section ? section->Get_string("vsync") : "auto");
 
 	if (has_true(user_pref)) {
@@ -3331,6 +3341,15 @@ InterpolationMode GFX_GetInterpolationMode()
 	return sdl.interpolation_mode;
 }
 
+static void set_default_viewport_resolution_settings()
+{
+	sdl.viewport      = {};
+	sdl.viewport.mode = ViewportMode::Fit;
+
+	const auto string_prop = get_sdl_section()->GetStringProp("viewport_resolution");
+	string_prop->SetValue("fit");
+}
+
 static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 {
 	// Apply the user's mouse settings
@@ -3397,8 +3416,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	            section->Get_string("viewport_resolution"))) {
 		sdl.viewport = *settings;
 	} else {
-		sdl.viewport      = {};
-		sdl.viewport.mode = ViewportMode::Fit;
+		set_default_viewport_resolution_settings();
 	}
 
 	setup_window_sizes_from_conf(section->Get_string("windowresolution").c_str(),
@@ -5007,8 +5025,7 @@ int sdl_main(int argc, char* argv[])
 		control->Init();
 
 		// Some extra SDL Functions
-		Section_prop* sdl_sec = static_cast<Section_prop*>(
-		        control->GetSection("sdl"));
+		Section_prop* sdl_sec = get_sdl_section();
 
 		// All subsystems' hotkeys need to be registered at this point
 		// to ensure their hotkeys appear in the graphical mapper.

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -294,6 +294,19 @@ extern bool CPU_CycleAutoAdjust;
 bool startup_state_numlock=false;
 bool startup_state_capslock=false;
 
+std::optional<std::pair<int, int>> parse_int_dimensions(const std::string_view s)
+{
+	const auto parts = split(s, "x");
+	if (parts.size() == 2) {
+		const auto w = parse_int(parts[0]);
+		const auto h = parse_int(parts[1]);
+		if (w && h) {
+			return {{*w, *h}};
+		}
+	}
+	return {};
+}
+
 void GFX_SetTitle(const int32_t new_num_cycles, const bool is_paused = false)
 {
 	char title_buf[200] = {0};
@@ -3016,69 +3029,98 @@ static SDL_Point clamp_to_minimum_window_dimensions(SDL_Point size)
 	return {w, h};
 }
 
-static ViewportSettings parse_viewport_settings(const std::string& viewport_resolution_pref)
+static void log_invalid_viewport_resolution_warning(
+        const std::string& pref,
+        const std::optional<const std::string> extra_info = {})
 {
-	ViewportSettings viewport = {};
+	LOG_WARNING("DISPLAY: Invalid 'viewport_resolution' setting: '%s'"
+	            "%s%s, using 'fit'",
+	            pref.c_str(),
+	            (extra_info ? ". " : ""),
+	            (extra_info ? extra_info->c_str() : ""));
+}
 
-	viewport.mode = ViewportMode::Fit;
-
-	constexpr auto default_value = "fit";
-	if (viewport_resolution_pref == default_value) {
+static std::optional<ViewportSettings> parse_fit_viewport_modes(const std::string& pref)
+{
+	if (pref == "fit") {
+		ViewportSettings viewport = {};
+		viewport.mode             = ViewportMode::Fit;
 		return viewport;
-	}
 
-	int w   = 0;
-	int h   = 0;
-	float p = 0.0f;
-	const auto was_parsed =
-	        sscanf(viewport_resolution_pref.c_str(), "%dx%d", &w, &h) == 2 ||
-	        sscanf(viewport_resolution_pref.c_str(), "%f%%", &p) == 1;
+	} else if (const auto width_and_height = parse_int_dimensions(pref)) {
+		const auto [w, h] = *width_and_height;
 
-	if (!was_parsed) {
-		LOG_WARNING("DISPLAY: Requested viewport resolution '%s' was not in WxH"
-		            " or N%% format, using the default setting ('%s') instead",
-		            viewport_resolution_pref.c_str(),
-		            default_value);
+		const auto desktop = to_rect(get_desktop_size());
+
+		const bool is_out_of_bounds = (w <= 0 || w > desktop.w ||
+		                               h <= 0 || h > desktop.h);
+		if (is_out_of_bounds) {
+			const auto extra_info = format_string(
+			        "Viewport size is outside of the %dx%d desktop bounds",
+			        iroundf(desktop.w),
+			        iroundf(desktop.h));
+
+			log_invalid_viewport_resolution_warning(pref, extra_info);
+			return {};
+		}
+
+		ViewportSettings viewport = {};
+		viewport.mode             = ViewportMode::Fit;
+
+		const DosBox::Rect limit = {w, h};
+		viewport.fit.limit_size  = limit;
+
+		const auto limit_px = limit.Copy().ScaleSize(sdl.desktop.dpi_scale);
+
+		LOG_MSG("DISPLAY: Limiting viewport size to %dx%d logical units "
+		        "(%dx%d pixels)",
+		        iroundf(limit.w),
+		        iroundf(limit.h),
+		        iroundf(limit_px.w),
+		        iroundf(limit_px.h));
+
 		return viewport;
-	}
 
-	const auto desktop = get_desktop_size();
+	} else if (const auto percentage = parse_percentage_with_optional_percent_sign(
+	                   pref)) {
+		const auto desktop = to_rect(get_desktop_size());
+		const auto p       = *percentage;
 
-	const bool is_out_of_bounds = (w <= 0 || w > desktop.w || h <= 0 ||
-	                               h > desktop.h) &&
-	                              (p <= 0.0f || p > 100.0f);
-	if (is_out_of_bounds) {
-		LOG_WARNING("DISPLAY: Requested viewport resolution of '%s' is outside "
-		            "the desktop '%dx%d' bounds or the 1-100%% range, "
-		            "using the default setting ('%s') instead",
-		            viewport_resolution_pref.c_str(),
-		            desktop.w,
-		            desktop.h,
-		            default_value);
+		const bool is_out_of_bounds = (p < 1.0f || p > 100.0f);
+		if (is_out_of_bounds) {
+			const auto extra_info = "Desktop percentage is outside of the 1-100%% range";
 
-		return viewport;
-	}
+			log_invalid_viewport_resolution_warning(pref, extra_info);
+			return {};
+		}
 
-	if (p > 0.0f) {
+		ViewportSettings viewport  = {};
+		viewport.mode              = ViewportMode::Fit;
 		viewport.fit.desktop_scale = p / 100.0f;
 
-		const auto limit_w = iround(desktop.w * *viewport.fit.desktop_scale);
-		const auto limit_h = iround(desktop.h * *viewport.fit.desktop_scale);
+		const auto limit = desktop.Copy().ScaleSize(*viewport.fit.desktop_scale);
+		const auto limit_px = limit.Copy().ScaleSize(sdl.desktop.dpi_scale);
 
-		LOG_MSG("DISPLAY: Limiting viewport resolution to %2.4g%% of the desktop (%dx%d)",
-		        static_cast<double>(p),
-		        limit_w,
-		        limit_h);
+		LOG_MSG("DISPLAY: Limiting viewport size to %2.4g%% of the "
+		        "desktop (%dx%d logical units, %dx%d pixels)",
+		        p,
+		        iroundf(limit.w),
+		        iroundf(limit.h),
+		        iroundf(limit_px.w),
+		        iroundf(limit_px.h));
 
 		return viewport;
 
 	} else {
-		viewport.fit.limit_size = {w, h};
-
-		LOG_MSG("DISPLAY: Limiting viewport resolution to %dx%d", w, h);
-
-		return viewport;
+		log_invalid_viewport_resolution_warning(pref);
+		return {};
 	}
+}
+
+static std::optional<ViewportSettings> parse_viewport_settings(
+        const std::string& pref)
+{
+	return parse_fit_viewport_modes(pref);
 }
 
 static void setup_initial_window_position_from_conf(const std::string& window_position_val)
@@ -3351,8 +3393,13 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	setup_initial_window_position_from_conf(
 	        section->Get_string("window_position"));
 
-	sdl.viewport = parse_viewport_settings(
-	        section->Get_string("viewport_resolution"));
+	if (const auto settings = parse_viewport_settings(
+	            section->Get_string("viewport_resolution"))) {
+		sdl.viewport = *settings;
+	} else {
+		sdl.viewport      = {};
+		sdl.viewport.mode = ViewportMode::Fit;
+	}
 
 	setup_window_sizes_from_conf(section->Get_string("windowresolution").c_str(),
 	                             sdl.interpolation_mode,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1455,26 +1455,30 @@ RenderingBackend GFX_GetRenderingBackend()
 	return sdl.rendering_backend;
 }
 
-static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
+static DosBox::Rect calc_restricted_viewport_size_in_pixels(const DosBox::Rect canvas_px)
 {
 	if (sdl.viewport_resolution) {
-		return {std::min(iround(sdl.viewport_resolution->x * sdl.desktop.dpi_scale),
-		                 w),
-		        std::min(iround(sdl.viewport_resolution->y * sdl.desktop.dpi_scale),
-		                 h)};
+		DosBox::Rect viewport_px = {sdl.viewport_resolution->x,
+		                            sdl.viewport_resolution->y};
+
+		viewport_px.ScaleSize(sdl.desktop.dpi_scale);
+
+		if (canvas_px.Contains(viewport_px)) {
+			return viewport_px;
+		} else {
+			return viewport_px.Intersect(canvas_px);
+		}
 	} else {
-		return {w, h};
+		return canvas_px;
 	}
 }
 
 DosBox::Rect GFX_GetViewportSizeInPixels()
 {
-	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
+	const auto canvas_px = to_rect(
+	        get_canvas_size_in_pixels(sdl.rendering_backend));
 
-	const auto restricted_dims_px =
-	        restrict_to_viewport_resolution(canvas_px.w, canvas_px.h);
-
-	return {restricted_dims_px.x, restricted_dims_px.y};
+	return calc_restricted_viewport_size_in_pixels(canvas_px);
 }
 
 static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
@@ -3183,11 +3187,11 @@ DosBox::Rect GFX_CalcViewportInPixels(const int canvas_width_px,
 	assert(std::isfinite(draw_scale_y));
 
 	// Limit the window to the user's desired viewport, if configured
-	const auto restricted_dims_px =
-	        restrict_to_viewport_resolution(canvas_width_px, canvas_height_px);
+	const auto restricted_dims_px = calc_restricted_viewport_size_in_pixels(
+	        {canvas_width_px, canvas_height_px});
 
-	const auto bounds_w_px = restricted_dims_px.x;
-	const auto bounds_h_px = restricted_dims_px.y;
+	const auto bounds_w_px = iroundf(restricted_dims_px.w);
+	const auto bounds_h_px = iroundf(restricted_dims_px.h);
 
 	// It is important to calculate the image aspect ratio like this because
 	// the aspect ratio of the *image* itself it not always 4:3, in which

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1309,8 +1309,7 @@ static void check_and_handle_dpi_change(SDL_Window* sdl_window,
 	const auto canvas_px = get_canvas_size_in_pixels(rendering_backend);
 
 	assert(width_in_logical_units > 0);
-	const auto new_dpi_scale = static_cast<double>(canvas_px.w) /
-	                           width_in_logical_units;
+	const auto new_dpi_scale = canvas_px.w / width_in_logical_units;
 
 	if (std::abs(new_dpi_scale - sdl.desktop.dpi_scale) < DBL_EPSILON) {
 		// LOG_MSG("SDL: DPI scale hasn't changed (still %f)",
@@ -1513,7 +1512,7 @@ DosBox::Rect GFX_GetViewportSizeInPixels()
 	return RENDER_CalcRestrictedViewportSizeInPixels(canvas_px);
 }
 
-double GFX_GetDpiScaleFactor()
+float GFX_GetDpiScaleFactor()
 {
 	return sdl.desktop.dpi_scale;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4358,9 +4358,6 @@ static void config_add_sdl() {
 	pstring = sdl_sec->Add_path("max_resolution", deprecated, "");
 	pstring->Set_help("Renamed to 'viewport_resolution'.");
 
-	pstring = sdl_sec->Add_path("viewport_resolution", deprecated, "");
-	pstring->Set_help("Moved to [render] section.");
-
 	pstring = sdl_sec->Add_string("host_rate", on_start, "auto");
 	pstring->Set_help(
 	        "Set the host's refresh rate:\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4361,14 +4361,14 @@ static void config_add_sdl() {
 	pstring = sdl_sec->Add_string("host_rate", on_start, "auto");
 	pstring->Set_help(
 	        "Set the host's refresh rate:\n"
-	        "  auto:      Use SDI rates, or VRR rates when fullscreen on a high-refresh\n"
-	        "             display (default).\n"
+	        "  auto:      Use SDI rates, or VRR rates when in fullscreen on a high-refresh\n"
+	        "             rate display (default).\n"
 	        "  sdi:       Use serial device interface (SDI) rates, without further\n"
 	        "             adjustment.\n"
 	        "  vrr:       Deduct 3 Hz from the reported rate (best practice for VRR\n"
 	        "             displays).\n"
-	        "  <custom>:  Specify a custom rate as an integer or decimal Hz value\n"
-	        "             (23.000 is the allowed minimum).");
+	        "  N:         Specify custom refresh rate in Hz (decimal values are allowed;\n"
+	        "             23.000 is the allowed minimum).");
 
 	const char* vsync_prefs[] = {"auto", "on", "adaptive", "off", "yield", nullptr};
 	pstring = sdl_sec->Add_string("vsync", always, "auto");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1265,7 +1265,7 @@ static void NewMouseScreenParams()
 static bool is_aspect_ratio_correction_enabled()
 {
 	return (RENDER_GetAspectRatioCorrectionMode() ==
-	        AspectRatioCorrectionMode::On);
+	        AspectRatioCorrectionMode::Auto);
 }
 
 static void update_fallback_dimensions(const double dpi_scale)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1216,7 +1216,7 @@ static void setup_presentation_mode(FrameMode &previous_mode)
 	previous_mode = mode;
 }
 
-static void NewMouseScreenParams()
+static void notify_new_mouse_screen_params()
 {
 	if (sdl.draw_rect_px.w <= 0 || sdl.draw_rect_px.h <= 0 ||
 	    sdl.draw_rect_px.x < 0 || sdl.draw_rect_px.y < 0) {
@@ -2219,7 +2219,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 #endif // C_OPENGL
 	}
 	// Ensure mouse emulation knows the current parameters
-	NewMouseScreenParams();
+	notify_new_mouse_screen_params();
 	update_vsync_state();
 
 	if (sdl.draw.has_changed) {
@@ -3699,7 +3699,7 @@ static void handle_video_resize(int width, int height)
 	}
 
 	// Ensure mouse emulation knows the current parameters
-	NewMouseScreenParams();
+	notify_new_mouse_screen_params();
 }
 
 /* TODO: Properly set window parameters and remove this routine.
@@ -3802,7 +3802,7 @@ bool GFX_Events()
 			// Events added in SDL 2.0.14
 			case SDL_DISPLAYEVENT_CONNECTED:
 			case SDL_DISPLAYEVENT_DISCONNECTED:
-				NewMouseScreenParams();
+				notify_new_mouse_screen_params();
 				break;
 #endif
 			default:
@@ -3950,7 +3950,7 @@ bool GFX_Events()
 
 				maybe_auto_switch_shader();
 #	endif
-				NewMouseScreenParams();
+				notify_new_mouse_screen_params();
 				continue;
 			}
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3755,8 +3755,7 @@ static bool maybe_auto_switch_shader()
 	const auto canvas_size_px = get_canvas_size_in_pixels(sdl.rendering_backend);
 	constexpr auto reinit_render = true;
 
-	return RENDER_MaybeAutoSwitchShader(iroundf(canvas_size_px.w),
-	                                    iroundf(canvas_size_px.h),
+	return RENDER_MaybeAutoSwitchShader(canvas_size_px,
 	                                    sdl.video_mode,
 	                                    reinit_render);
 #else

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1460,6 +1460,16 @@ static SDL_Point restrict_to_viewport_resolution(const int w, const int h)
 	}
 }
 
+DosBox::Rect GFX_GetViewportSizeInPixels()
+{
+	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
+
+	const auto restricted_dims_px =
+	        restrict_to_viewport_resolution(canvas_px.w, canvas_px.h);
+
+	return {restricted_dims_px.x, restricted_dims_px.y};
+}
+
 static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
         const Fraction& pixel_aspect_ratio)
 {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -802,7 +802,7 @@ static void log_display_properties(const int render_width_px,
 	const auto refresh_rate = VGA_GetPreferredRate();
 
 	LOG_MSG("DISPLAY: %s at %2.5g Hz %s, "
-	        "scaled to %dx%d with 1:%1.6g (%d:%d) pixel aspect ratio",
+	        "scaled to %dx%d pixels with 1:%1.6g (%d:%d) pixel aspect ratio",
 	        video_mode_desc.c_str(),
 	        refresh_rate,
 	        frame_mode,
@@ -1258,6 +1258,7 @@ static void update_fallback_dimensions(const double dpi_scale)
 
 	FallbackWindowSize = {iround(fallback_width), iround(fallback_height)};
 
+	// TODO pixels or logical unit?
 	// LOG_INFO("SDL: Updated fallback dimensions to %dx%d",
 	//          FallbackWindowSize.x,
 	//          FallbackWindowSize.y);
@@ -1274,6 +1275,7 @@ static void update_fallback_dimensions(const double dpi_scale)
 	                         FallbackWindowSize.x,
 	                         FallbackWindowSize.y);
 
+	// TODO pixels or logical unit?
 	// LOG_INFO("SDL: Updated window minimum size to %dx%d", width, height);
 }
 
@@ -1407,6 +1409,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 		displayMode.w = width;
 		displayMode.h = height;
 
+		// TODO pixels or logical unit?
 		if (SDL_SetWindowDisplayMode(sdl.window, &displayMode) != 0) {
 			LOG_WARNING("SDL: Failed setting fullscreen mode to %dx%d at %d Hz",
 			            displayMode.w,
@@ -1726,6 +1729,7 @@ static void initialize_sdl_window_size(SDL_Window* sdl_window,
 	                          std::max(requested_size.y, requested_min_size.y)};
 	if (current_size != bounded_size) {
 		safe_set_window_size(bounded_size.x, bounded_size.y);
+		// TODO pixels or logical unit?
 		// LOG_MSG("SDL: Initialized the window size to %dx%d",
 		//         bounded_size.x,
 		//         bounded_size.y);
@@ -1903,7 +1907,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 		if (texsize_w_px > sdl.opengl.max_texsize ||
 		    texsize_h_px > sdl.opengl.max_texsize) {
-			LOG_WARNING("OPENGL: No support for texture size of %dx%d, "
+			LOG_WARNING("OPENGL: No support for texture size of %dx%d pixels, "
 			            "falling back to texture",
 			            texsize_w_px,
 			            texsize_h_px);
@@ -2935,14 +2939,16 @@ static void maybe_limit_requested_resolution(int &w, int &h, const char *size_de
 		w = desktop.w;
 		h = desktop.h;
 		was_limited = true;
-		LOG_WARNING("DISPLAY: Limiting %s resolution to '%dx%d' to avoid kmsdrm issues",
+		LOG_WARNING("DISPLAY: Limiting '%s' resolution to %dx%d to avoid kmsdrm issues",
 		            size_description,
 		            w,
 		            h);
 	}
 
 	if (!was_limited)
-		LOG_INFO("DISPLAY: Accepted %s resolution %dx%d despite exceeding "
+		// TODO shouldn't we log the display resolution in physical pixels
+		// instead?
+		LOG_INFO("DISPLAY: Accepted '%s' resolution %dx%d despite exceeding "
 		         "the %dx%d display",
 		         size_description,
 		         w,
@@ -3187,6 +3193,7 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	};
 
 	// Let the user know the resulting window properties
+	// TODO pixels or logical unit?
 	LOG_MSG("DISPLAY: Initialised %dx%d windowed mode using %s scaling on display-%d",
 	        refined_size.x,
 	        refined_size.y,
@@ -3887,6 +3894,7 @@ bool GFX_Events()
 				continue;
 
 			case SDL_WINDOWEVENT_RESIZED:
+				// TODO pixels or logical unit?
 				// LOG_DEBUG("SDL: Window has been resized to %dx%d",
 				//               event.window.data1,
 				//               event.window.data2);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -743,29 +743,32 @@ static DosBox::Rect calc_draw_rect_in_pixels(const DosBox::Rect& canvas_size_px)
 static DosBox::Rect get_canvas_size_in_pixels(
         [[maybe_unused]] const RenderingBackend rendering_backend)
 {
-	SDL_Rect canvas_px = {};
+	SDL_Rect canvas_size_px = {};
 #if SDL_VERSION_ATLEAST(2, 26, 0)
-	SDL_GetWindowSizeInPixels(sdl.window, &canvas_px.w, &canvas_px.h);
+	SDL_GetWindowSizeInPixels(sdl.window, &canvas_size_px.w, &canvas_size_px.h);
 #else
 	switch (rendering_backend) {
 	case RenderingBackend::Texture:
 		if (SDL_GetRendererOutputSize(sdl.renderer,
-		                              &canvas_px.w,
-		                              &canvas_px.h) != 0) {
+		                              &canvas_size_px.w,
+		                              &canvas_size_px.h) != 0) {
 			LOG_ERR("SDL: Failed to retrieve output size: %s",
 			        SDL_GetError());
 		}
 		break;
 #if C_OPENGL
 	case RenderingBackend::OpenGl:
-		SDL_GL_GetDrawableSize(sdl.window, &canvas_px.w, &canvas_px.h);
+		SDL_GL_GetDrawableSize(sdl.window,
+		                       &canvas_size_px.w,
+		                       &canvas_size_px.h);
 		break;
 #endif
-	default: SDL_GetWindowSize(sdl.window, &canvas_px.w, &canvas_px.h);
+	default:
+		SDL_GetWindowSize(sdl.window, &canvas_size_px.w, &canvas_size_px.h);
 	}
 #endif
-	assert(canvas_px.w > 0 && canvas_px.h > 0);
-	return to_rect(canvas_px);
+	assert(canvas_size_px.w > 0 && canvas_size_px.h > 0);
+	return to_rect(canvas_size_px);
 }
 
 // Logs the source and target resolution including describing scaling method
@@ -783,10 +786,10 @@ static void log_display_properties(const int render_width_px,
 			        {canvas_size_override_px->w,
 			         canvas_size_override_px->h});
 		} else {
-			const auto canvas_px = get_canvas_size_in_pixels(
+			const auto canvas_size_px = get_canvas_size_in_pixels(
 			        rendering_backend);
 
-			return calc_draw_rect_in_pixels(canvas_px);
+			return calc_draw_rect_in_pixels(canvas_size_px);
 		}
 	}();
 
@@ -1304,10 +1307,10 @@ static void check_and_handle_dpi_change(SDL_Window* sdl_window,
 		SDL_GetWindowSize(sdl_window, &width_in_logical_units, nullptr);
 	}
 
-	const auto canvas_px = get_canvas_size_in_pixels(rendering_backend);
+	const auto canvas_size_px = get_canvas_size_in_pixels(rendering_backend);
 
 	assert(width_in_logical_units > 0);
-	const auto new_dpi_scale = canvas_px.w / width_in_logical_units;
+	const auto new_dpi_scale = canvas_size_px.w / width_in_logical_units;
 
 	if (std::abs(new_dpi_scale - sdl.desktop.dpi_scale) < DBL_EPSILON) {
 		// LOG_MSG("SDL: DPI scale hasn't changed (still %f)",
@@ -1505,9 +1508,9 @@ DosBox::Rect GFX_GetDesktopSize()
 
 DosBox::Rect GFX_GetViewportSizeInPixels()
 {
-	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
+	const auto canvas_size_px = get_canvas_size_in_pixels(sdl.rendering_backend);
 
-	return RENDER_CalcRestrictedViewportSizeInPixels(canvas_px);
+	return RENDER_CalcRestrictedViewportSizeInPixels(canvas_size_px);
 }
 
 float GFX_GetDpiScaleFactor()
@@ -1844,13 +1847,15 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 			sdl.desktop.window.adjusted_initial_size = true;
 		}
-		const auto canvas_px = get_canvas_size_in_pixels(sdl.want_rendering_backend);
+		const auto canvas_size_px = get_canvas_size_in_pixels(
+		        sdl.want_rendering_backend);
 		// LOG_MSG("Attempting to fix the centering to %d %d %d %d",
 		//         (canvas.w - sdl.clip.w) / 2,
 		//         (canvas.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-		sdl.draw_rect_px = to_sdl_rect(calc_draw_rect_in_pixels(canvas_px));
+		sdl.draw_rect_px = to_sdl_rect(
+		        calc_draw_rect_in_pixels(canvas_size_px));
 
 		if (SDL_RenderSetViewport(sdl.renderer, &sdl.draw_rect_px) != 0) {
 			LOG_ERR("SDL: Failed to set viewport: %s", SDL_GetError());
@@ -2059,14 +2064,17 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			sdl.desktop.window.adjusted_initial_size = true;
 		}
 
-		const auto canvas_px = get_canvas_size_in_pixels(
+		const auto canvas_size_px = get_canvas_size_in_pixels(
 		        sdl.want_rendering_backend);
+
 		// LOG_MSG("Attempting to fix the centering to %d %d %d %d",
-		//         (canvas_px.w - sdl.clip.w) / 2,
-		//         (canvas_px.h - sdl.clip.h) / 2,
+		//         (canvas_size_px.w - sdl.clip.w) / 2,
+		//         (canvas_size_px.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-		sdl.draw_rect_px = to_sdl_rect(calc_draw_rect_in_pixels(canvas_px));
+	
+		sdl.draw_rect_px = to_sdl_rect(
+		        calc_draw_rect_in_pixels(canvas_size_px));
 
 		glViewport(sdl.draw_rect_px.x,
 		           sdl.draw_rect_px.y,
@@ -2304,10 +2312,10 @@ void GFX_CenterMouse()
 	int height = 0;
 
 #if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 28, 1)
-	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
+	const auto canvas_size_px = get_canvas_size_in_pixels(sdl.rendering_backend);
 
-	width  = canvas_px.w;
-	height = canvas_px.h;
+	width  = canvas_size_px.w;
+	height = canvas_size_px.h;
 #else
 	SDL_GetWindowSize(sdl.window, &width, &height);
 #endif
@@ -2389,9 +2397,9 @@ void GFX_SwitchFullScreen()
 	sdl.desktop.switching_fullscreen = true;
 
 	// Record the window's current canvas size if we're departing window-mode
-	auto& canvas_px = sdl.desktop.window.canvas_size;
+	auto& canvas_size_px = sdl.desktop.window.canvas_size;
 	if (!sdl.desktop.fullscreen) {
-		canvas_px = to_sdl_rect(
+		canvas_size_px = to_sdl_rect(
 		        get_canvas_size_in_pixels(sdl.rendering_backend));
 	}
 
@@ -2409,14 +2417,15 @@ void GFX_SwitchFullScreen()
 
 	// After switching modes, get the current canvas size, which might be
 	// the windowed size or full screen size.
-	canvas_px = sdl.desktop.fullscreen
-	                  ? to_sdl_rect(get_canvas_size_in_pixels(sdl.rendering_backend))
-	                  : canvas_px;
+	canvas_size_px = sdl.desktop.fullscreen
+	                       ? to_sdl_rect(get_canvas_size_in_pixels(
+	                                 sdl.rendering_backend))
+	                       : canvas_size_px;
 
 	log_display_properties(sdl.draw.render_width_px,
 	                       sdl.draw.render_height_px,
 	                       sdl.video_mode,
-	                       canvas_px,
+	                       canvas_size_px,
 	                       sdl.rendering_backend);
 
 	sdl.desktop.switching_fullscreen = false;
@@ -3662,9 +3671,9 @@ static void handle_video_resize(int width, int height)
 		sdl.desktop.full.height = height;
 	}
 
-	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
+	const auto canvas_size_px = get_canvas_size_in_pixels(sdl.rendering_backend);
 
-	sdl.draw_rect_px = to_sdl_rect(calc_draw_rect_in_pixels(canvas_px));
+	sdl.draw_rect_px = to_sdl_rect(calc_draw_rect_in_pixels(canvas_size_px));
 
 	if (sdl.rendering_backend == RenderingBackend::Texture) {
 		SDL_RenderSetViewport(sdl.renderer, &sdl.draw_rect_px);
@@ -3743,12 +3752,11 @@ static bool maybe_auto_switch_shader()
 		return false;
 	}
 
-	const auto canvas_px = get_canvas_size_in_pixels(sdl.rendering_backend);
-
+	const auto canvas_size_px = get_canvas_size_in_pixels(sdl.rendering_backend);
 	constexpr auto reinit_render = true;
 
-	return RENDER_MaybeAutoSwitchShader(iroundf(canvas_px.w),
-	                                    iroundf(canvas_px.h),
+	return RENDER_MaybeAutoSwitchShader(iroundf(canvas_size_px.w),
+	                                    iroundf(canvas_size_px.h),
 	                                    sdl.video_mode,
 	                                    reinit_render);
 #else
@@ -3923,11 +3931,11 @@ bool GFX_Events()
 
 				sdl.display_number = event.window.data1;
 
-				const auto canvas_px = get_canvas_size_in_pixels(
+				const auto canvas_size_px = get_canvas_size_in_pixels(
 				        sdl.rendering_backend);
 
 				sdl.draw_rect_px = to_sdl_rect(
-				        calc_draw_rect_in_pixels(canvas_px));
+				        calc_draw_rect_in_pixels(canvas_size_px));
 
 				if (sdl.rendering_backend == RenderingBackend::Texture) {
 					SDL_RenderSetViewport(sdl.renderer,

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -79,8 +79,7 @@ void ShaderManager::NotifyGlshaderSettingChanged(const std::string& shader_name)
 	MaybeAutoSwitchShader();
 }
 
-void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px,
-                                                  const uint16_t canvas_height_px,
+void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size_px,
                                                   const VideoMode& video_mode)
 {
 	// We need to calculate the scale factors for two eventualities: 1)
@@ -99,8 +98,6 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 	// 1) Calculate vertical scale factor for the standard output resolution
 	// (i.e., always double-scanning on VGA).
 	//
-	const DosBox::Rect canvas_size_px = {canvas_width_px, canvas_height_px};
-
 	scale_y = [&] {
 		const auto double_scan = video_mode.is_double_scanned_mode ? 2 : 1;
 

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -99,33 +99,32 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 	// 1) Calculate vertical scale factor for the standard output resolution
 	// (i.e., always double-scanning on VGA).
 	scale_y = [&] {
-		const auto draw_width_px = video_mode.width *
-		                           (video_mode.is_double_scanned_mode ? 2 : 1);
+		const auto double_scan = video_mode.is_double_scanned_mode ? 2 : 1;
 
-		const auto draw_height_px = video_mode.height *
-		                            (video_mode.is_double_scanned_mode ? 2 : 1);
+		const DosBox::Rect render_size_px = {video_mode.width * double_scan,
+		                                     video_mode.height * double_scan};
 
-		const auto viewport_px = GFX_CalcViewportInPixels(
+		const auto draw_size_px = GFX_CalcDrawSizeInPixels(
 		        {canvas_width_px, canvas_height_px},
-		        {draw_width_px, draw_height_px},
+		        render_size_px,
 		        video_mode.pixel_aspect_ratio);
 
-		return static_cast<double>(viewport_px.h) / draw_height_px;
+		return static_cast<double>(draw_size_px.h) / render_size_px.h;
 	}();
 
 	// 2) Calculate vertical scale factor for forced single-scanning on VGA
 	// for double-scanned modes.
 	if (video_mode.is_double_scanned_mode) {
-		const auto draw_width_px  = video_mode.width;
-		const auto draw_height_px = video_mode.height;
+		const DosBox::Rect render_size_px = {video_mode.width,
+		                                     video_mode.height};
 
-		const auto viewport_px = GFX_CalcViewportInPixels(
+		const auto draw_size_px = GFX_CalcDrawSizeInPixels(
 		        {canvas_width_px, canvas_height_px},
-		        {draw_width_px, draw_height_px},
+		        render_size_px,
 		        video_mode.pixel_aspect_ratio);
 
-		scale_y_force_single_scan = static_cast<double>(viewport_px.h) /
-		                            draw_height_px;
+		scale_y_force_single_scan = static_cast<double>(draw_size_px.h) /
+		                            render_size_px.h;
 	} else {
 		scale_y_force_single_scan = scale_y;
 	}

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -99,35 +99,33 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 	// 1) Calculate vertical scale factor for the standard output resolution
 	// (i.e., always double-scanning on VGA).
 	scale_y = [&] {
-		const auto draw_width = video_mode.width *
-		                        (video_mode.is_double_scanned_mode ? 2 : 1);
+		const auto draw_width_px = video_mode.width *
+		                           (video_mode.is_double_scanned_mode ? 2 : 1);
 
-		const auto draw_height = video_mode.height *
-		                         (video_mode.is_double_scanned_mode ? 2 : 1);
+		const auto draw_height_px = video_mode.height *
+		                            (video_mode.is_double_scanned_mode ? 2 : 1);
 
-		const auto viewport = GFX_CalcViewportInPixels(canvas_width_px,
-		                                               canvas_height_px,
-		                                               draw_width,
-		                                               draw_height,
-		                                               video_mode.pixel_aspect_ratio);
+		const auto viewport_px = GFX_CalcViewportInPixels(
+		        {canvas_width_px, canvas_height_px},
+		        {draw_width_px, draw_height_px},
+		        video_mode.pixel_aspect_ratio);
 
-		return static_cast<double>(viewport.h) / draw_height;
+		return static_cast<double>(viewport_px.h) / draw_height_px;
 	}();
 
 	// 2) Calculate vertical scale factor for forced single-scanning on VGA
 	// for double-scanned modes.
 	if (video_mode.is_double_scanned_mode) {
-		const auto draw_width  = video_mode.width;
-		const auto draw_height = video_mode.height;
+		const auto draw_width_px  = video_mode.width;
+		const auto draw_height_px = video_mode.height;
 
-		const auto viewport = GFX_CalcViewportInPixels(canvas_width_px,
-		                                               canvas_height_px,
-		                                               draw_width,
-		                                               draw_height,
-		                                               video_mode.pixel_aspect_ratio);
+		const auto viewport_px = GFX_CalcViewportInPixels(
+		        {canvas_width_px, canvas_height_px},
+		        {draw_width_px, draw_height_px},
+		        video_mode.pixel_aspect_ratio);
 
-		scale_y_force_single_scan = static_cast<double>(viewport.h) /
-		                            draw_height;
+		scale_y_force_single_scan = static_cast<double>(viewport_px.h) /
+		                            draw_height_px;
 	} else {
 		scale_y_force_single_scan = scale_y;
 	}

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -98,18 +98,21 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 
 	// 1) Calculate vertical scale factor for the standard output resolution
 	// (i.e., always double-scanning on VGA).
+	//
+	const DosBox::Rect canvas_size_px = {canvas_width_px, canvas_height_px};
+
 	scale_y = [&] {
 		const auto double_scan = video_mode.is_double_scanned_mode ? 2 : 1;
 
 		const DosBox::Rect render_size_px = {video_mode.width * double_scan,
 		                                     video_mode.height * double_scan};
 
-		const auto draw_size_px = GFX_CalcDrawSizeInPixels(
-		        {canvas_width_px, canvas_height_px},
+		const auto draw_rect_px = GFX_CalcDrawRectInPixels(
+		        canvas_size_px,
 		        render_size_px,
 		        video_mode.pixel_aspect_ratio);
 
-		return static_cast<double>(draw_size_px.h) / render_size_px.h;
+		return static_cast<double>(draw_rect_px.h) / render_size_px.h;
 	}();
 
 	// 2) Calculate vertical scale factor for forced single-scanning on VGA
@@ -118,12 +121,12 @@ void ShaderManager::NotifyRenderParametersChanged(const uint16_t canvas_width_px
 		const DosBox::Rect render_size_px = {video_mode.width,
 		                                     video_mode.height};
 
-		const auto draw_size_px = GFX_CalcDrawSizeInPixels(
-		        {canvas_width_px, canvas_height_px},
+		const auto draw_rect_px = GFX_CalcDrawRectInPixels(
+		        canvas_size_px,
 		        render_size_px,
 		        video_mode.pixel_aspect_ratio);
 
-		scale_y_force_single_scan = static_cast<double>(draw_size_px.h) /
+		scale_y_force_single_scan = static_cast<double>(draw_rect_px.h) /
 		                            render_size_px.h;
 	} else {
 		scale_y_force_single_scan = scale_y;

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+#include "rect.h"
 #include "vga.h"
 
 // forward references
@@ -139,8 +140,7 @@ public:
 
 	void NotifyGlshaderSettingChanged(const std::string& shader_name);
 
-	void NotifyRenderParametersChanged(const uint16_t canvas_width_px,
-	                                   const uint16_t canvas_height_px,
+	void NotifyRenderParametersChanged(const DosBox::Rect canvas_size_px,
 	                                   const VideoMode& video_mode);
 
 	const ShaderInfo& GetCurrentShaderInfo() const;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1673,7 +1673,7 @@ void init_gus_dosbox_settings(Section_prop &secprop)
 	        "The default settings of base address 240, IRQ 5, and DMA 3 have been chosen\n"
 	        "so the GUS can coexist with a Sound Blaster card. This works fine for the\n"
 	        "majority of programs, but some games and demos expect the GUS factory\n"
-	        "defaults of base address 220, IRQ 11, DMA 1.");
+	        "defaults of base address 220, IRQ 11, and DMA 1.");
 
 	auto *hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -294,7 +294,7 @@ static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 	const char* sid_clocks[] = {"default", "c64ntsc", "c64pal", "hardsid", nullptr};
 	str_prop->Set_values(sid_clocks);
 	str_prop->Set_help(
-	        "The SID chip's clock frequency, which is jumperable on reproduction cards.\n"
+	        "The SID chip's clock frequency, which is jumperable on reproduction cards:\n"
 	        "  default:  0.895 MHz, per the original SSI-2001 card (default).\n"
 	        "  c64ntsc:  1.023 MHz, per NTSC Commodore PCs and the DuoSID.\n"
 	        "  c64pal:   0.985 MHz, per PAL Commodore PCs and the DuoSID.\n"
@@ -311,13 +311,13 @@ static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 	auto* int_prop = sec_prop.Add_int("6581filter", when_idle, 50);
 	int_prop->SetMinMax(0, 100);
 	int_prop->Set_help(
-	        "Adjusts the 6581's filtering strength as a percent from 0 to 100\n"
+	        "Adjusts the 6581's filtering strength as a percentage from 0 to 100\n"
 	        "(50 by default). The SID's analog filtering meant that each chip was\n"
 	        "physically unique.");
 
 	int_prop = sec_prop.Add_int("8580filter", when_idle, 50);
 	int_prop->SetMinMax(0, 100);
-	int_prop->Set_help("Adjusts the 8580's filtering strength as a percent from 0 to 100\n"
+	int_prop->Set_help("Adjusts the 8580's filtering strength as a percentage from 0 to 100\n"
 	                   "(50 by default).");
 
 	str_prop = sec_prop.Add_string("innovation_filter", when_idle, "off");

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -469,9 +469,11 @@ Bitu int74_ret_handler()
 
 void MOUSE_NewScreenParams(const MouseScreenParams &params)
 {
-	// clip_x, clip_y = black border (one side), in pixels
-	// res_x, res_y   = used display area, in pixels
-	// res_x + 2 * clip_x, res_y + 2 * clip_y = screen resolution or window size
+	// clip_x, clip_y = black border (one side), in logical units
+	// res_x, res_y   = used display area, in logical units
+	//
+	// res_x + 2 * clip_x, res_y + 2 * clip_y = screen resolution or window
+	// size, in logical units
 
 	assert(params.clip_x <= INT32_MAX);
 	assert(params.clip_y <= INT32_MAX);

--- a/src/hardware/input/mouse_common.h
+++ b/src/hardware/input/mouse_common.h
@@ -47,9 +47,10 @@ public:
 
 	bool started = false;
 
-	// Screen size
-	uint32_t resolution_x = 640; // resolution to which guest image is scaled,
-	uint32_t resolution_y = 400; // excluding black borders
+	// Resolution (screen size) in logical units to which guest image is
+	// scaled, excluding black borders.
+	uint32_t resolution_x = 640;
+	uint32_t resolution_y = 400;
 };
 
 class MouseInfo {

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -277,7 +277,7 @@ static void config_read(Section *section)
 	if (mouse_shared.ready_config) {
 
 		if (mouse_config.capture == MouseCapture::NoMouse) {
-			// If NoMouse got configured in runtime,
+			// If NoMouse got configured at runtime,
 			// immediately clear all the mapping
 			MouseControlAPI mouse_config_api;
 			mouse_config_api.UnMap(MouseControlAPI::ListIDs());
@@ -350,12 +350,12 @@ static void config_init(Section_prop &secprop)
 	        "For touch-screen control, use 'seamless'.");
 
 	prop_bool = secprop.Add_bool("mouse_middle_release", always, true);
-	prop_bool->Set_help("If enabled, middle-click will release the captured mouse, and also capture\n"
-	                    "when seamless (enabled by default).");
+	prop_bool->Set_help("Release the captured mouse by middle-clicking, and also capture it in\n"
+	                    "seamless mode (enabled by default).");
 
 	prop_bool = secprop.Add_bool("mouse_multi_display_aware", always, true);
-	prop_bool->Set_help("Allows mouse seamless behavior and mouse pointer release to work in fullscreen\n"
-	                    "mode for systems with more than one display. (enabled by default).\n"
+	prop_bool->Set_help("Allows seamless mouse behavior and mouse pointer release to work in fullscreen\n"
+	                    "mode on systems with more than one display (enabled by default).\n"
 	                    "Note: You should disable this if it incorrectly detects multiple displays\n"
 	                    "      when only one should actually be used. This might happen if you are\n"
 	                    "      using mirrored display mode or using an AV receiver's HDMI input for\n"
@@ -374,7 +374,7 @@ static void config_init(Section_prop &secprop)
 	prop_bool->Set_help(
 	        "Enable to bypass your operating system's mouse acceleration and sensitivity\n"
 	        "settings (enabled by default). Works in fullscreen or when the mouse is\n"
-	        "captured in window mode.");
+	        "captured in windowed mode.");
 
 	// DOS driver configuration
 

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -960,7 +960,7 @@ void MOUSEDOS_AfterNewVideoMode(const bool is_mode_changing)
 	case 0x09: // 320x200, 16 colors    (PCjr)
 	case 0x0a: // 640x200, 4 colors     (PCjr)
 	case 0x0e: // 640x200, 16 colors    (EGA, VGA)
-		// Note: Setting true horixontal resolution for <640 modes
+		// Note: Setting true horizontal resolution for <640 modes
 		// can break some games, like 'Life & Death' - be careful here!
 		state.maxpos_x = 639;
 		state.maxpos_y = 199;

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -365,11 +365,6 @@ void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3) {
 	}	
 }
 
-void VGA_ForceSquarePixels(const bool enable)
-{
-	vga.draw.force_square_pixels = enable;
-}
-
 void VGA_EnableVgaDoubleScanning(const bool enable)
 {
 	if (machine != MCH_VGA) {

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2846,15 +2846,10 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 	    vga.draw.render != render || fps_changed) {
 		VGA_KillDrawing();
 
-		const auto canvas_px = GFX_GetCanvasSizeInPixels();
-
 		constexpr auto reinit_render = false;
 
-		const auto shader_changed =
-		        RENDER_MaybeAutoSwitchShader(iroundf(canvas_px.w),
-		                                     iroundf(canvas_px.h),
-		                                     render.video_mode,
-		                                     reinit_render);
+		const auto shader_changed = RENDER_MaybeAutoSwitchShader(
+		        GFX_GetCanvasSizeInPixels(), render.video_mode, reinit_render);
 
 		if (shader_changed) {
 			render = setup_drawing();

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2707,13 +2707,13 @@ ImageInfo setup_drawing()
 	                 final_render_height / video_mode.height);
 
 	switch (RENDER_GetAspectRatioCorrectionMode()) {
-	case AspectRatioCorrectionMode::On:
+	case AspectRatioCorrectionMode::Auto:
 		// Derive video mode pixel aspect ratio from the render PAR
 		video_mode.pixel_aspect_ratio = render_pixel_aspect_ratio *
 		                                render_per_video_mode_scale;
 		break;
 
-	case AspectRatioCorrectionMode::Off:
+	case AspectRatioCorrectionMode::SquarePixels:
 		// Override PARs if square pixels are forced in aspect ratio
 		// correction disabled mode
 		render_pixel_aspect_ratio = render_per_video_mode_scale.Inverse();

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -229,9 +229,9 @@ bool Property::IsValidValue(const Value& in)
 		}
 	}
 
-	LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-	            in.ToString().c_str(),
+	LOG_WARNING("CONFIG: Invalid '%s' setting: '%s', using '%s'",
 	            propname.c_str(),
+	            in.ToString().c_str(),
 	            default_value.ToString().c_str());
 
 	return false;
@@ -241,7 +241,7 @@ bool Property::IsValueDeprecated(const Value& val) const
 {
 	const auto is_deprecated = contains(deprecated_and_alternate_values, val);
 	if (is_deprecated) {
-		LOG_WARNING("CONFIG: '%s = %s' is deprecated, "
+		LOG_WARNING("CONFIG: Setting '%s = %s' is deprecated, "
 		            "falling back to the alternate: '%s = %s'",
 		            propname.c_str(),
 		            val.ToString().c_str(),
@@ -325,11 +325,12 @@ bool Prop_int::ValidateValue(const Value& in)
 		va = mi;
 	}
 
-	LOG_WARNING("CONFIG: %s lies outside the range %s-%s for config '%s', limiting it to %d",
+	LOG_WARNING("CONFIG: Invalid '%s' setting: '%s'. "
+	            "Value outside of the valid range %s-%s, using '%d'",
+	            propname.c_str(),
 	            in.ToString().c_str(),
 	            min_value.ToString().c_str(),
 	            max_value.ToString().c_str(),
-	            propname.c_str(),
 	            va);
 
 	value = va;
@@ -354,11 +355,12 @@ bool Prop_int::IsValidValue(const Value& in)
 		return true;
 	}
 
-	LOG_WARNING("CONFIG: %s lies outside the range %s-%s for config '%s', using the default value %s",
+	LOG_WARNING("CONFIG: Invalid '%s' setting: '%s'. "
+	            "Value outside of the valid %s-%s range, using '%s'",
+	            propname.c_str(),
 	            in.ToString().c_str(),
 	            min_value.ToString().c_str(),
 	            max_value.ToString().c_str(),
-	            propname.c_str(),
 	            default_value.ToString().c_str());
 
 	return false;
@@ -425,9 +427,9 @@ bool Prop_string::IsValidValue(const Value& in)
 		}
 	}
 
-	LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-	            in.ToString().c_str(),
+	LOG_WARNING("CONFIG: Invalid '%s' setting: '%s', using '%s'",
 	            propname.c_str(),
+	            in.ToString().c_str(),
 	            default_value.ToString().c_str());
 
 	return false;
@@ -467,9 +469,9 @@ bool Prop_bool::SetValue(const std::string& input)
 	if (!is_valid) {
 		SetValue(default_value.ToString());
 
-		LOG_WARNING("CONFIG: '%s' is an invalid value for '%s', using the default: '%s'",
-		            input.c_str(),
+		LOG_WARNING("CONFIG: Invalid '%s' setting: '%s', using '%s'",
 		            propname.c_str(),
+		            input.c_str(),
 		            default_value.ToString().c_str());
 	}
 	return is_valid;
@@ -941,7 +943,7 @@ bool Section_prop::HandleInputline(const std::string& line)
 		return p->SetValue(val);
 	}
 
-	LOG_WARNING("CONFIG: Unknown option '%s'", name.c_str());
+	LOG_WARNING("CONFIG: Invalid option '%s'", name.c_str());
 	return false;
 }
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1554,7 +1554,7 @@ Verbosity Config::GetStartupVerbosity() const
 		             : Verbosity::High;
 	}
 
-	LOG_WARNING("SETUP: Unknown verbosity mode '%s', defaulting to 'high'",
+	LOG_WARNING("SETUP: Invalid 'startup_verbosity' setting: '%s', using 'high'",
 	            user_choice.c_str());
 	return Verbosity::High;
 }

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -378,3 +378,27 @@ std::optional<int> parse_int(const std::string& s, const int base)
 	}
 	return {};
 }
+
+std::optional<float> parse_percentage(const std::string_view s,
+                                      const bool is_percent_sign_optional)
+{
+	if (!is_percent_sign_optional) {
+		if (!ends_with(s, "%")) {
+			return {};
+		}
+	}
+	return {parse_float(strip_suffix(s, "%"))};
+}
+
+std::optional<float> parse_percentage_with_percent_sign(const std::string_view s)
+{
+	const auto is_percent_sign_optional = false;
+	return parse_percentage(s, is_percent_sign_optional);
+}
+
+std::optional<float> parse_percentage_with_optional_percent_sign(const std::string_view s)
+{
+	const auto is_percent_sign_optional = true;
+	return parse_percentage(s, is_percent_sign_optional);
+}
+

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -314,20 +314,20 @@ bool ends_with(const std::string_view str, const std::string_view suffix) noexce
 	return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
 }
 
-std::string strip_prefix(const std::string& str, const std::string& prefix) noexcept
+std::string strip_prefix(const std::string_view str, const std::string_view prefix) noexcept
 {
 	if (starts_with(str, prefix)) {
-		return str.substr(prefix.size());
+		return std::string(str.substr(prefix.size()));
 	}
-	return str;
+	return std::string(str);
 }
 
-std::string strip_suffix(const std::string& str, const std::string& suffix) noexcept
+std::string strip_suffix(const std::string_view str, const std::string_view suffix) noexcept
 {
 	if (ends_with(str, suffix)) {
-		return str.substr(0, str.size() - suffix.size());
+		return std::string(str.substr(0, str.size() - suffix.size()));
 	}
-	return str;
+	return std::string(str);
 }
 
 void clear_language_if_default(std::string &l)

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -378,15 +378,3 @@ std::optional<int> parse_int(const std::string& s, const int base)
 	}
 	return {};
 }
-
-std::optional<float> parse_percentage(const std::string& s)
-{
-	constexpr auto min_percentage = 0.0f;
-	constexpr auto max_percentage = 100.0f;
-	if (const auto p = parse_float(s); p) {
-		if (*p >= min_percentage && *p <= max_percentage) {
-			return p;
-		}
-	}
-	return {};
-}

--- a/tests/math_utils_tests.cpp
+++ b/tests/math_utils_tests.cpp
@@ -160,6 +160,14 @@ TEST(iroundf, invalid)
 	EXPECT_DEBUG_DEATH({ iroundf(-80000000000.0f); }, "");
 }
 
+TEST(are_almost_equal_relative, QuakeValues)
+{
+	// Numbers taken from Quake startup
+	EXPECT_TRUE(are_almost_equal_relative(239.999999999999972, 240.0));
+	EXPECT_TRUE(are_almost_equal_relative(23.999999999999996, 24.0));
+	EXPECT_TRUE(are_almost_equal_relative(7.999999999999999, 8.0));
+}
+
 TEST(clamp_to_int8, signed_negatives)
 {
 	EXPECT_EQ(clamp_to_int8(INT16_MIN), INT8_MIN);

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -411,32 +411,6 @@ TEST(ParseInt, Invalid)
 	EXPECT_EQ(parse_int(" "), empty);
 }
 
-TEST(ParsePercentage, Valid)
-{
-	EXPECT_EQ(parse_percentage("0"), 0.0f);
-	EXPECT_EQ(parse_percentage("0.0"), 0.0f);
-	EXPECT_EQ(parse_percentage("-0.0"), 0.0f);
-	EXPECT_EQ(parse_percentage("1"), 1.0f);
-	EXPECT_EQ(parse_percentage("5.0"), 5.0f);
-	EXPECT_EQ(parse_percentage("0.00001"), 0.00001f);
-	EXPECT_EQ(parse_percentage("99.9999"), 99.9999f);
-	EXPECT_EQ(parse_percentage("100"), 100.0f);
-}
-
-TEST(ParsePercentage, Invalid)
-{
-	std::optional<int> empty = {};
-	EXPECT_EQ(parse_percentage("-1"), empty);
-	EXPECT_EQ(parse_percentage("-5.0"), empty);
-	EXPECT_EQ(parse_percentage("-0.00001"), empty);
-	EXPECT_EQ(parse_percentage("100.0001"), empty);
-	EXPECT_EQ(parse_percentage("105"), empty);
-	EXPECT_EQ(parse_percentage("asdf"), empty);
-	EXPECT_EQ(parse_percentage("5a"), empty);
-	EXPECT_EQ(parse_percentage(""), empty);
-	EXPECT_EQ(parse_percentage(" "), empty);
-}
-
 TEST(FormatString, Valid)
 {
 	EXPECT_EQ(format_string(""), "");

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -411,6 +411,60 @@ TEST(ParseInt, Invalid)
 	EXPECT_EQ(parse_int(" "), empty);
 }
 
+TEST(ParsePercentageWithOptionalPercentSign, Valid)
+{
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("1%"), 1.0f);
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("1"), 1.0f);
+
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("100%"), 100.0f);
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("100"), 100.0f);
+
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("150%"), 150.0f);
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("150"), 150.0f);
+
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("-5%"), -5.0f);
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("-5"), -5.0f);
+
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("0%"), 0.0f);
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("0"), 0.0f);
+
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("-110.5%"), -110.5f);
+	EXPECT_EQ(*parse_percentage_with_optional_percent_sign("-110.5"), -110.5f);
+}
+
+TEST(ParsePercentageWithPercentSign, Valid)
+{
+	EXPECT_EQ(*parse_percentage_with_percent_sign("1%"), 1.0f);
+	EXPECT_EQ(*parse_percentage_with_percent_sign("100%"), 100.0f);
+	EXPECT_EQ(*parse_percentage_with_percent_sign("150%"), 150.0f);
+	EXPECT_EQ(*parse_percentage_with_percent_sign("-5%"), -5.0f);
+	EXPECT_EQ(*parse_percentage_with_percent_sign("0%"), 0.0f);
+	EXPECT_EQ(*parse_percentage_with_percent_sign("-110.5%"), -110.5f);
+}
+
+TEST(ParsePercentageWithPercentSign, Invalid)
+{
+	std::optional<float> empty = {};
+
+	EXPECT_EQ(parse_percentage_with_percent_sign("100"), empty);
+	EXPECT_EQ(parse_percentage_with_percent_sign("0"), empty);
+	EXPECT_EQ(parse_percentage_with_percent_sign("-1"), empty);
+	EXPECT_EQ(parse_percentage_with_percent_sign("100a"), empty);
+	EXPECT_EQ(parse_percentage_with_percent_sign("sfafsd"), empty);
+	EXPECT_EQ(parse_percentage_with_percent_sign(""), empty);
+	EXPECT_EQ(parse_percentage_with_percent_sign(" "), empty);
+}
+
+TEST(ParsePercentageWithOptionalPercentSign, Invalid)
+{
+	std::optional<float> empty = {};
+
+	EXPECT_EQ(parse_percentage_with_optional_percent_sign("100a"), empty);
+	EXPECT_EQ(parse_percentage_with_optional_percent_sign("sfafsd"), empty);
+	EXPECT_EQ(parse_percentage_with_optional_percent_sign(""), empty);
+	EXPECT_EQ(parse_percentage_with_optional_percent_sign(" "), empty);
+}
+
 TEST(FormatString, Valid)
 {
 	EXPECT_EQ(format_string(""), "");


### PR DESCRIPTION
# Description

Quake does many floating point operations in single precision mode. This was causing issues in the `FROUND` FPU emulation function, since the `double in` parameter could easily exceed the precision of a `float`. After logging this function, I saw Quake often pass values like 5.9999999967 to be chopped in single precision mode, so was getting a value of 5.0 back. By casting to a `float` prior to the `trunc`, these cases get automatically handled correctly.

On my M1 MacBook Pro system, at least, this has the nice side effect of boosting QTD by 5-7%.

# Manual testing

Tested Quake extensively. I also tried a handful of other games/demos, but couldn't find anything else that flipped over to single precision mode.

MCPDIAG results have not changed.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

