### PR TITLE
Fix FROUND Issues

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -104,6 +104,20 @@ inline int ifloor(const float x)
 	return static_cast<int>(floorf(x));
 }
 
+// Determine if two numbers are equal "enough" based on an epsilon value.
+// Uses a dynamic adjustment based on the magnitude of the numbers.
+// Based on ideas from Bruce Dawson's blog post:
+// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+inline bool are_almost_equal_relative(
+        const double a, const double b,
+        const double epsilon = std::numeric_limits<double>::epsilon())
+{
+	const auto diff    = std::fabs(a - b);
+	const auto largest = std::max(std::fabs(a), std::fabs(b));
+
+	return diff <= largest * epsilon;
+}
+
 // Left-shifts a signed value by a given amount, with overflow detection
 template <typename T1, typename T2>
 constexpr T1 left_shift_signed(T1 value, T2 amount)

--- a/tests/math_utils_tests.cpp
+++ b/tests/math_utils_tests.cpp
@@ -160,6 +160,14 @@ TEST(iroundf, invalid)
 	EXPECT_DEBUG_DEATH({ iroundf(-80000000000.0f); }, "");
 }
 
+TEST(are_almost_equal_relative, QuakeValues)
+{
+	// Numbers taken from Quake startup
+	EXPECT_TRUE(are_almost_equal_relative(239.999999999999972, 240.0));
+	EXPECT_TRUE(are_almost_equal_relative(23.999999999999996, 24.0));
+	EXPECT_TRUE(are_almost_equal_relative(7.999999999999999, 8.0));
+}
+
 TEST(clamp_to_int8, signed_negatives)
 {
 	EXPECT_EQ(clamp_to_int8(INT16_MIN), INT8_MIN);


### PR DESCRIPTION
# Description

After some further investigation of Quake, I noticed some values that didn't look right. At startup, there appear to be some scaling variables initialized:

```log
2023-11-29 15:39:48.919 | FROUND: rounding 2400.000000000000000 to 2400.000000000000000 (lower)
2023-11-29 15:39:48.919 | FROUND: chopping 239.999999999999972 to 239.000000000000000
2023-11-29 15:39:48.919 | FROUND: chopping 23.899999999999999 to 23.000000000000000
2023-11-29 15:39:48.919 | FROUND: chopping 2.300000000000000 to 2.000000000000000
2023-11-29 15:39:48.919 | FROUND: chopping 0.200000000000000 to 0.000000000000000
```

These clearly intend to be 2400, 240, 24, 2.4, and 0.2(4).

Switching over to a relative epsilon value accounts for a wide range of values, since larger integer parts of a double will result in fewer digits of precision after the decimal.

```log
2023-11-29 15:40:39.651 | FROUND: rounding 2400.000000000000000 to 2400.000000000000000 (lower)
2023-11-29 15:40:39.651 | FROUND: rounding 239.999999999999972 to 240.000000000000000 (upper)
2023-11-29 15:40:39.651 | FROUND: rounding 23.999999999999996 to 24.000000000000000 (upper)
2023-11-29 15:40:39.651 | FROUND: chopping 2.400000000000000 to 2.000000000000000
2023-11-29 15:40:39.651 | FROUND: chopping 0.200000000000000 to 0.000000000000000
```

This also includes a correction for FROUND in single precision mode by casting to a `float` before performing the truncation, which handles the same scenario as above, but the cast does everything automatically.

# Manual testing

Tested Quake normal play and QTD.

MCPDIAG results remain the same.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

