### PR TITLE
Fix MSCDEX regression in game "Fascination (1991)"

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -586,6 +586,27 @@ public:
  * Some documents refer to it also as Data Transfer Address or Disk Transfer Area.
  */
 
+#ifdef _MSC_VER
+#pragma pack(1)
+#endif
+struct sDTA {
+	uint8_t sdrive;						/* The Drive the search is taking place */
+	uint8_t sname[8];						/* The Search pattern for the filename */
+	uint8_t sext[3];						/* The Search pattern for the extension */
+	uint8_t sattr;						/* The Attributes that need to be found */
+	uint16_t dirID;						/* custom: dir-search ID for multiple searches at the same time */
+	uint16_t dirCluster;					/* custom (drive_fat only): cluster number for multiple searches at the same time */
+	uint8_t fill[4];
+	uint8_t attr;
+	uint16_t time;
+	uint16_t date;
+	uint32_t size;
+	char name[DOS_NAMELENGTH_ASCII];
+} GCC_ATTRIBUTE(packed);
+#ifdef _MSC_VER
+#pragma pack()
+#endif
+
 class DOS_DTA final : public MemStruct {
 public:
 	DOS_DTA(RealPt addr) : MemStruct(addr) {}
@@ -641,28 +662,6 @@ public:
 
 	void SetDirIDCluster(uint16_t cl) { SSET_WORD(sDTA, dirCluster, cl); }
 	uint16_t GetDirIDCluster() const { return SGET_WORD(sDTA, dirCluster); }
-
-private:
-	#ifdef _MSC_VER
-	#pragma pack(1)
-	#endif
-	struct sDTA {
-		uint8_t sdrive;						/* The Drive the search is taking place */
-		uint8_t sname[8];						/* The Search pattern for the filename */
-		uint8_t sext[3];						/* The Search pattern for the extension */
-		uint8_t sattr;						/* The Attributes that need to be found */
-		uint16_t dirID;						/* custom: dir-search ID for multiple searches at the same time */
-		uint16_t dirCluster;					/* custom (drive_fat only): cluster number for multiple searches at the same time */
-		uint8_t fill[4];
-		uint8_t attr;
-		uint16_t time;
-		uint16_t date;
-		uint32_t size;
-		char name[DOS_NAMELENGTH_ASCII];
-	} GCC_ATTRIBUTE(packed);
-	#ifdef _MSC_VER
-	#pragma pack()
-	#endif
 };
 
 enum class ResultGrouping {

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -437,7 +437,7 @@ void DOS_DelDevice(DOS_Device * dev);
 RealPt DOS_GetNextDevice(const RealPt rp);
 RealPt DOS_GetLastDevice();
 void DOS_AppendDevice(const uint16_t segment, const uint16_t offset = 0);
-bool DOS_IsLastDevice(const RealPt rp);
+bool DOS_IsEndPointer(const RealPt rp);
 bool DOS_DeviceHasName(const RealPt rp, const std::string_view req_name);
 bool DOS_DeviceHasAttributes(const RealPt rp, const uint16_t attributes);
 uint16_t DOS_GetDeviceStrategy(const RealPt rp);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -764,6 +764,16 @@ bool fatDrive::allocateCluster(uint32_t useCluster, uint32_t prevCluster) {
 	return true;
 }
 
+constexpr uint16_t dta_pages()
+{
+	constexpr auto BytesPerPage = 16;
+	uint16_t pages = sizeof(struct sDTA) / BytesPerPage;
+	if ((sizeof(struct sDTA) % BytesPerPage) != 0) {
+		++pages;
+	}
+	return pages;
+}
+
 fatDrive::fatDrive(const char *sysFilename,
                    uint32_t bytesector,
                    uint32_t cylsector,
@@ -791,7 +801,7 @@ fatDrive::fatDrive(const char *sysFilename,
 	struct partTable mbrData;
 	
 	if(imgDTASeg == 0) {
-		imgDTASeg = DOS_GetMemory(2);
+		imgDTASeg = DOS_GetMemory(dta_pages());
 		imgDTAPtr = RealMake(imgDTASeg, 0);
 		imgDTA    = new DOS_DTA(imgDTAPtr);
 	}


### PR DESCRIPTION
# Description
Regression from commit c4a6c7db9abe3ebf84953744794b4b82266732e9

Fixed a bug when traversing the DOS device linked list. The last valid device is one before the end pointer.

~~Do not merge yet.  This does fix #3162 but re-introduces bug #2304  All this DOS memory stuff is making my head hurt so this as far as I've got tonight.  Wanted to post this in case anyone has any suggestions.  I suspect someone is clobbering the linked list somewhere.~~

Turns out DTA wasn't being allocated enough pages and was the culprit stomping on this list.  Fixed that underlying bug and everything looks good now.

## Related issues
#2304 
#2310
#3162

# Manual testing
Reproduced bug #3162 on main.  This PR fixes the bug by correctly appending to the linked list.

Reproduced #2304 one commit before the #2310 PR.  Confirmed this bug does not occur on main.  ~~This PR makes this bug re-appear~~   Root cause of this bug is now fixed in the first commit of this PR (not enough pages allocated by DTA).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

