### PR TITLE
Fix website development build download page

### DIFF
--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -65,7 +65,7 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 
                 // If result not found, query the next page
                 if (status == undefined) {
-                    set_ci_status(workflow_file, os_name, page + 1);
+                    set_ci_status(workflow_file, os_name, description, page + 1);
                     return;
                 }
 


### PR DESCRIPTION
# Description
It broke when there is no build from the "main" branch on the first page of builds. Function call was missing an argument so it kept requesting page 1 over and over again. Use the correct number of arguments to resolve this issue.

# Manual testing
Downloaded the "Web Page Complete" in Firefox and made this change locally.  Confirmed it fixed the issue with the download links for development builds not being loaded in.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

