### PR TITLE
Website - dev builds query improvement

### DIFF
--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -32,15 +32,12 @@ function set_build_version(gh_api_artifacts, os_name) {
 }
 
 // Fetch build status using GitHub API and update HTML
-function set_ci_status(workflow_file, os_name, description, page = 1) {
+function set_ci_status(workflow_file, os_name, description) {
 
     // GitHub has strict rate-limits for anonymous users: 60 requests per hour;
-    // We request 100 results per page (max allowed); main builds are very
-    // likely to be included in the first page anyway.
-    if (page > 10) {
-        return;
-    }
+    // We are requesting only one page, with a limit of 1, with the filter query params.
 
+    let page = 1;
     let per_page = 1;
     let gh_api_url = "https://api.github.com/repos/dosbox-staging/dosbox-staging/";
 

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -31,6 +31,17 @@ function set_build_version(gh_api_artifacts, os_name) {
         });
 }
 
+function handle_error(error_message, os_name) {
+  let build_link_tr_el = document.getElementById(os_name + "-build-link");
+  build_link_tr_el.innerHTML = error_message;
+
+  let version_el = document.getElementById(os_name + "-build-version");
+  version_el.textContent = '';
+
+  let date_el = document.getElementById(os_name + "-build-date");
+  date_el.textContent = '';
+}
+
 // Fetch build status using GitHub API and update HTML
 function set_ci_status(workflow_file, os_name, description) {
 
@@ -60,6 +71,7 @@ function set_ci_status(workflow_file, os_name, description) {
             if (response.status !== 200) {
                 console.log("Looks like there was a problem." +
                             "Status Code: " + response.status);
+                handle_error(`HTTP Error Code ${response.status}`, os_name);
                 return;
             }
 
@@ -71,7 +83,9 @@ function set_ci_status(workflow_file, os_name, description) {
 
                 // If result not found, query the next page
                 if (status == undefined) {
-                    console.warn(`No records found for ${workflow_file}`);
+                    const error_message = `No builds found for ${workflow_file}`;
+                    console.warn(error_message);
+                    handle_error(error_message, os_name);
                     return;
                 }
 

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -41,12 +41,19 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
         return;
     }
 
-    let per_page = 100;
+    let per_page = 1;
     let gh_api_url = "https://api.github.com/repos/dosbox-staging/dosbox-staging/";
+
+    let filter_branch = "main";
+    let filter_event = "push";
+    let filter_status = "success";
 
     const queryParams = new URLSearchParams();
     queryParams.set("page", page);
     queryParams.set("per_page", per_page);
+    queryParams.set("branch", filter_branch);
+    queryParams.set("event", filter_event);
+    queryParams.set("status", filter_status);
 
     fetch(gh_api_url + "actions/workflows/" + workflow_file + "/runs?" +
           queryParams.toString())

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -43,8 +43,13 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 
     let per_page = 100;
     let gh_api_url = "https://api.github.com/repos/dosbox-staging/dosbox-staging/";
-    fetch(gh_api_url + "actions/workflows/" + workflow_file + "/runs" +
-          "?page=" + page + "&per_page=" + per_page)
+
+    const queryParams = new URLSearchParams();
+    queryParams.set("page", page);
+    queryParams.set("per_page", per_page);
+
+    fetch(gh_api_url + "actions/workflows/" + workflow_file + "/runs?" +
+          queryParams.toString())
         .then(response => {
 
             // Handle HTTP error

--- a/website/docs/downloads/development-builds.md
+++ b/website/docs/downloads/development-builds.md
@@ -70,14 +70,11 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 
                 console.log(data.workflow_runs);
 
-                let status = data.workflow_runs
-                    .filter(run => run.head_branch == "main")
-                    .filter(run => run.event == "push")
-                    .find(run => run.conclusion == "success");
+                const status = data.workflow_runs.length && data.workflow_runs[0];
 
                 // If result not found, query the next page
                 if (status == undefined) {
-                    set_ci_status(workflow_file, os_name, description, page + 1);
+                    console.warn(`No records found for ${workflow_file}`);
                     return;
                 }
 


### PR DESCRIPTION
# Description

The development builds page for the website currently will load 100 records per page, for up to 10 pages to find the latest dev build. This can lead to rate limiting and github API lets us be more efficient.

These changes switch to use github's query parameter filters to check for the branch of main, the event of push, and the status of success, instead of doing it with filtering on the browser side. As well, it limits it to grabbing one page and only one record, which should make loading time very fast.

This also adds error handling to display the error on the page, so that if there was a rate limiting issue or some other problem, it'll display on the screen, to make it more obvious to the user.


# Manual testing

I ran the mkdocs locally and was able to verify that the errors display when you're rate limited, and that I can see the builds when the github API succeeds. There should now only be one API call per platform, and one record returned per API call.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

